### PR TITLE
fix(ui): move chat session search into picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1440,6 +1440,7 @@
     "deps:transitive-risk:report": "node scripts/transitive-manifest-risk-report.mjs",
     "deps:vuln:gate": "node scripts/dependency-vulnerability-gate.mjs",
     "dev": "node scripts/run-node.mjs",
+    "dev:ui:mock": "node --import tsx scripts/control-ui-mock-dev.ts",
     "docs:bin": "node scripts/build-docs-list.mjs",
     "docs:check-i18n-glossary": "node scripts/check-docs-i18n-glossary.mjs",
     "docs:check-links": "node scripts/docs-link-audit.mjs",

--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -1,0 +1,215 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createServer, type Plugin, type ViteDevServer } from "vite";
+import { CONTROL_UI_BOOTSTRAP_CONFIG_PATH } from "../src/gateway/control-ui-contract.js";
+import {
+  createControlUiMockBootstrapConfig,
+  createControlUiMockGatewayInitScript,
+  type ControlUiMockGatewayScenario,
+} from "../ui/src/test-helpers/control-ui-e2e.ts";
+
+type CliOptions = {
+  host: string;
+  port: number;
+};
+
+type SessionListOptions = {
+  hasMore: boolean;
+  nextOffset: number | null;
+  offset?: number;
+  totalCount: number;
+};
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const uiRoot = path.join(repoRoot, "ui");
+
+function parseArgs(args: string[]): CliOptions {
+  const options: CliOptions = { host: "127.0.0.1", port: 5187 };
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--host") {
+      options.host = args[++i] ?? options.host;
+    } else if (arg.startsWith("--host=")) {
+      options.host = arg.slice("--host=".length) || options.host;
+    } else if (arg === "--port") {
+      options.port = parsePort(args[++i], options.port);
+    } else if (arg.startsWith("--port=")) {
+      options.port = parsePort(arg.slice("--port=".length), options.port);
+    }
+  }
+  return options;
+}
+
+function parsePort(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 && parsed < 65_536 ? parsed : fallback;
+}
+
+function sessionRow(key: string, label: string, updatedAt: number) {
+  return {
+    contextTokens: null,
+    displayName: label,
+    hasActiveRun: false,
+    key,
+    kind: "direct",
+    label,
+    model: "gpt-5.5",
+    modelProvider: "openai",
+    status: "done",
+    totalTokens: 0,
+    updatedAt,
+  };
+}
+
+function sessionsListResponse(sessions: unknown[], options: SessionListOptions) {
+  return {
+    count: sessions.length,
+    defaults: {
+      contextTokens: null,
+      model: "gpt-5.5",
+      modelProvider: "openai",
+    },
+    hasMore: options.hasMore,
+    limitApplied: 50,
+    nextOffset: options.nextOffset,
+    offset: options.offset ?? 0,
+    path: "",
+    sessions,
+    totalCount: options.totalCount,
+    ts: Date.now(),
+  };
+}
+
+function createChatPickerScenario(): ControlUiMockGatewayScenario {
+  const baseTime = Date.parse("2026-05-22T09:00:00.000Z");
+  return {
+    assistantAgentId: "openclaw-mock",
+    assistantName: "OpenClaw mock",
+    defaultAgentId: "openclaw-mock",
+    historyMessages: [
+      {
+        content: [
+          {
+            text: 'Mock Control UI is running. Open the chat picker, search for "telegram", then use Load more.',
+            type: "text",
+          },
+        ],
+        role: "assistant",
+        timestamp: baseTime,
+      },
+    ],
+    methodResponses: {
+      "sessions.list": {
+        cases: [
+          {
+            match: { offset: 50, search: "telegram" },
+            response: sessionsListResponse(
+              [
+                sessionRow("agent:telegram-51", "Telegram archive page 51", baseTime - 180_000),
+                sessionRow("agent:telegram-52", "Telegram archive page 52", baseTime - 240_000),
+              ],
+              { hasMore: false, nextOffset: null, offset: 50, totalCount: 4 },
+            ),
+          },
+          {
+            match: { search: "telegram" },
+            response: sessionsListResponse(
+              [
+                sessionRow("agent:telegram", "Telegram follow-up", baseTime - 60_000),
+                sessionRow("agent:telegram-mobile", "Telegram mobile handoff", baseTime - 120_000),
+              ],
+              { hasMore: true, nextOffset: 50, totalCount: 4 },
+            ),
+          },
+          {
+            match: {},
+            response: sessionsListResponse(
+              [
+                sessionRow("agent:alpha", "Alpha planning", baseTime - 1_000),
+                sessionRow("agent:design", "Design review", baseTime - 30_000),
+              ],
+              { hasMore: true, nextOffset: 50, totalCount: 125 },
+            ),
+          },
+        ],
+      },
+    },
+    models: [{ id: "gpt-5.5", name: "gpt-5.5", provider: "openai" }],
+    sessionKey: "agent:alpha",
+  };
+}
+
+function escapeScriptContent(script: string): string {
+  return script.replaceAll("</script", "<\\/script");
+}
+
+function createMockGatewayPlugin(scenario: ControlUiMockGatewayScenario): Plugin {
+  const initScript = escapeScriptContent(createControlUiMockGatewayInitScript(scenario));
+  const bootstrapBody = JSON.stringify(createControlUiMockBootstrapConfig(scenario));
+  return {
+    configureServer(server) {
+      server.middlewares.use(CONTROL_UI_BOOTSTRAP_CONFIG_PATH, (_req, res) => {
+        res.statusCode = 200;
+        res.setHeader("content-type", "application/json");
+        res.end(bootstrapBody);
+      });
+    },
+    name: "openclaw-control-ui-mock-gateway",
+    transformIndexHtml(html) {
+      return html.replace(
+        "</head>",
+        `    <script data-openclaw-control-ui-mock-gateway>\n${initScript}\n    </script>\n  </head>`,
+      );
+    },
+  };
+}
+
+function hostForUrl(boundAddress: string, requestedHost: string): string {
+  const host = boundAddress === "0.0.0.0" || boundAddress === "::" ? requestedHost : boundAddress;
+  const reachableHost = host === "0.0.0.0" || host === "::" ? "127.0.0.1" : host;
+  return reachableHost.includes(":") ? `[${reachableHost}]` : reachableHost;
+}
+
+function resolveServerUrl(server: ViteDevServer, requestedHost: string): string {
+  const address = server.httpServer?.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Control UI mock server did not expose a TCP port");
+  }
+  return `http://${hostForUrl(address.address, requestedHost)}:${address.port}/chat`;
+}
+
+async function waitForShutdown(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    process.once("SIGINT", resolve);
+    process.once("SIGTERM", resolve);
+  });
+}
+
+const options = parseArgs(process.argv.slice(2));
+const scenario = createChatPickerScenario();
+const server = await createServer({
+  base: "/",
+  cacheDir: path.join(repoRoot, ".artifacts", "control-ui-mock-vite"),
+  clearScreen: false,
+  configFile: false,
+  define: {
+    OPENCLAW_CONTROL_UI_BUILD_ID: JSON.stringify("mock"),
+  },
+  logLevel: "error",
+  optimizeDeps: {
+    include: ["lit/directives/repeat.js"],
+  },
+  plugins: [createMockGatewayPlugin(scenario)],
+  publicDir: path.join(uiRoot, "public"),
+  root: uiRoot,
+  server: {
+    host: options.host,
+    port: options.port,
+    strictPort: false,
+  },
+});
+
+await server.listen();
+console.log(`[control-ui-mock] ${resolveServerUrl(server, options.host)}`);
+await waitForShutdown();
+await server.close();

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1273,14 +1273,6 @@
   max-width: none;
 }
 
-.chat-controls__session-stack {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  width: 100%;
-  min-width: 0;
-}
-
 .chat-controls__session-row {
   display: grid;
   grid-template-columns:
@@ -1316,36 +1308,101 @@
 
 .chat-controls__session-picker {
   grid-area: session;
+  position: relative;
 }
 
-.chat-controls__session-actions {
+.chat-controls__session-trigger {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 6px;
   width: 100%;
+  min-height: 36px;
+  padding: 8px 10px 8px 12px;
+  border: 1px solid var(--input);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  color: var(--text);
+  font: inherit;
+  font-size: 14px;
+  line-height: 1.2;
+  cursor: pointer;
+  min-width: 0;
+  transition:
+    background var(--duration-fast) ease-out,
+    border-color var(--duration-fast) ease-out;
+}
+
+.chat-controls__session-trigger:hover:not(:disabled),
+.chat-controls__session-trigger[aria-expanded="true"] {
+  border-color: color-mix(in srgb, var(--accent) 38%, var(--input));
+  background: color-mix(in srgb, var(--bg-elevated) 90%, var(--accent-subtle) 10%);
+}
+
+.chat-controls__session-trigger:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.chat-controls__session-trigger-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   min-width: 0;
 }
 
-.chat-controls__session-search {
-  position: relative;
-  flex: 1 1 220px;
-  min-width: 160px;
-  max-width: none;
+.chat-controls__session-trigger-icon {
+  display: inline-flex;
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+  color: var(--muted);
 }
 
-.chat-controls__session-search input {
+.chat-controls__session-trigger-icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.chat-session-picker {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  z-index: 90;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: min(520px, calc(100vw - 32px));
+  max-height: min(520px, calc(100vh - 132px));
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--card);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.34);
+  overflow: hidden;
+}
+
+.chat-session-picker__search-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 36px auto;
+  gap: 6px;
+  align-items: center;
+}
+
+.chat-session-picker__search {
+  position: relative;
+  min-width: 0;
+}
+
+.chat-session-picker__search input {
   box-sizing: border-box;
   width: 100%;
-  height: 36px;
   min-height: 36px;
   padding: 0 12px 0 34px;
-  border-color: color-mix(in srgb, var(--input) 88%, transparent);
-  border-radius: var(--radius-lg);
-  background-color: color-mix(in srgb, var(--card) 92%, var(--bg-elevated) 8%);
   font-size: 13px;
 }
 
-.chat-controls__session-search-icon {
+.chat-session-picker__search-icon {
   position: absolute;
   left: 11px;
   top: 50%;
@@ -1357,16 +1414,111 @@
   pointer-events: none;
 }
 
-.chat-controls__session-search-icon svg {
+.chat-session-picker__search-icon svg {
   width: 15px;
   height: 15px;
+}
+
+.chat-session-picker__list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.chat-session-picker__option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  min-height: 44px;
+  padding: 8px 10px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.chat-session-picker__option:hover,
+.chat-session-picker__option:focus-visible {
+  background: var(--bg-hover);
+  border-color: color-mix(in srgb, var(--border) 78%, transparent);
+}
+
+.chat-session-picker__option--selected {
+  background: color-mix(in srgb, var(--accent-subtle) 72%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 28%, transparent);
+}
+
+.chat-session-picker__option-main {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.chat-session-picker__option-label,
+.chat-session-picker__option-meta {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-session-picker__option-label {
+  color: var(--text-strong);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.chat-session-picker__option-meta {
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.chat-session-picker__option-check {
+  display: inline-flex;
+  width: 16px;
+  height: 16px;
+  color: var(--accent);
+  flex: 0 0 auto;
+}
+
+.chat-session-picker__option-check svg {
+  width: 16px;
+  height: 16px;
+}
+
+.chat-session-picker__status {
+  padding: 14px 10px;
+  color: var(--muted);
+  font-size: 13px;
+  text-align: center;
+}
+
+.chat-session-picker__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding-top: 8px;
+  border-top: 1px solid color-mix(in srgb, var(--border) 74%, transparent);
+}
+
+.chat-session-picker__count {
+  color: var(--muted);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
 }
 
 .chat-controls__agent {
   grid-area: agent;
 }
 
-.chat-controls__session-row--flash .chat-controls__session-picker select {
+.chat-controls__session-row--flash .chat-controls__session-trigger {
   animation: chat-session-switch-flash 0.2s ease-out;
 }
 
@@ -1392,7 +1544,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .chat-controls__session-row--flash .chat-controls__session-picker select {
+  .chat-controls__session-row--flash .chat-controls__session-trigger {
     animation: none;
     border-color: color-mix(in srgb, var(--accent) 70%, var(--border));
     box-shadow: var(--focus-ring);

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1383,14 +1383,13 @@
 }
 
 .chat-session-picker__search-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 36px auto;
+  display: flex;
   gap: 6px;
   align-items: center;
 }
 
 .chat-session-picker__search {
-  position: relative;
+  flex: 1 1 auto;
   min-width: 0;
 }
 
@@ -1398,25 +1397,22 @@
   box-sizing: border-box;
   width: 100%;
   min-height: 36px;
-  padding: 0 12px 0 34px;
+  padding: 0 12px;
   font-size: 13px;
 }
 
-.chat-session-picker__search-icon {
-  position: absolute;
-  left: 11px;
-  top: 50%;
-  display: inline-flex;
-  width: 15px;
-  height: 15px;
-  color: var(--muted);
-  transform: translateY(-50%);
-  pointer-events: none;
+.chat-session-picker .chat-session-picker__icon-button.btn--icon {
+  flex: 0 0 36px;
+  width: 36px;
+  min-width: 36px;
+  height: 36px;
+  padding: 0;
+  border-radius: var(--radius-md);
 }
 
-.chat-session-picker__search-icon svg {
-  width: 15px;
-  height: 15px;
+.chat-session-picker .chat-session-picker__icon-button.btn--icon svg {
+  width: 16px;
+  height: 16px;
 }
 
 .chat-session-picker__list {

--- a/ui/src/styles/chat/layout.test.ts
+++ b/ui/src/styles/chat/layout.test.ts
@@ -58,6 +58,15 @@ describe("chat layout styles", () => {
     expect(css).toContain("height: 22px;");
   });
 
+  it("keeps chat session picker search icon buttons fixed size", () => {
+    const css = readLayoutCss();
+
+    expect(css).toContain(".chat-session-picker .chat-session-picker__icon-button.btn--icon {");
+    expect(css).toContain("flex: 0 0 36px;");
+    expect(css).toContain("width: 36px;");
+    expect(css).toContain("min-width: 36px;");
+  });
+
   it("keeps composer controls labeled and large enough without shrinking mobile taps", () => {
     const css = readLayoutCss();
 

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -473,24 +473,6 @@
     width: 100%;
   }
 
-  .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__session-actions {
-    display: grid;
-    grid-auto-columns: 44px;
-    grid-auto-flow: column;
-    grid-template-columns: minmax(0, 1fr);
-    gap: 8px;
-  }
-
-  .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__session-search {
-    min-width: 0;
-    width: 100%;
-  }
-
-  .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__session-search input {
-    min-height: 44px;
-    font-size: 14px;
-  }
-
   .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__session-row--single-agent {
     grid-template-columns: minmax(0, 7fr) minmax(0, 5fr);
     grid-template-areas:
@@ -531,6 +513,29 @@
     grid-area: session;
   }
 
+  .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__session-trigger {
+    min-height: 44px;
+    padding: 10px 12px;
+    font-size: 14px;
+  }
+
+  .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-session-picker {
+    position: static;
+    width: 100%;
+    max-height: min(52vh, 420px);
+    margin-top: 8px;
+    box-shadow: none;
+  }
+
+  .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-session-picker__search-row {
+    grid-template-columns: minmax(0, 1fr) 44px auto;
+  }
+
+  .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-session-picker__search input {
+    min-height: 44px;
+    font-size: 14px;
+  }
+
   .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__model {
     grid-area: model;
   }
@@ -554,7 +559,8 @@
     max-width: none;
   }
 
-  .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__session select {
+  .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__session select,
+  .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__session-trigger {
     width: 100%;
     font-size: 14px;
     min-height: 44px;

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -527,13 +527,20 @@
     box-shadow: none;
   }
 
-  .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-session-picker__search-row {
-    grid-template-columns: minmax(0, 1fr) 44px auto;
-  }
-
   .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-session-picker__search input {
     min-height: 44px;
     font-size: 14px;
+  }
+
+  .chat-mobile-controls-wrapper
+    .chat-controls-dropdown
+    .chat-session-picker
+    .chat-session-picker__icon-button.btn--icon {
+    flex: 0 0 44px;
+    width: 44px;
+    min-width: 44px;
+    height: 44px;
+    padding: 0;
   }
 
   .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__model {

--- a/ui/src/styles/layout.mobile.test.ts
+++ b/ui/src/styles/layout.mobile.test.ts
@@ -46,6 +46,15 @@ describe("chat header responsive mobile styles", () => {
     );
     expect(css).toContain("height: 44px;");
   });
+
+  it("keeps chat session picker search icons from stretching in mobile controls", () => {
+    const css = readMobileCss();
+
+    expect(css).toContain(".chat-session-picker__icon-button.btn--icon {");
+    expect(css).toContain("flex: 0 0 44px;");
+    expect(css).toContain("width: 44px;");
+    expect(css).toContain("min-width: 44px;");
+  });
 });
 
 describe("sidebar menu trigger styles", () => {

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -23,6 +23,17 @@ export type ControlUiMockGatewayScenario = {
   sessionKey?: string;
 };
 
+export type ControlUiMockGatewayMethodResponseCase = {
+  match?: Record<string, unknown>;
+  response: unknown;
+};
+
+export type ControlUiMockGatewayMethodResponseCases = {
+  cases: ControlUiMockGatewayMethodResponseCase[];
+};
+
+type NormalizedControlUiMockGatewayScenario = Required<ControlUiMockGatewayScenario>;
+
 export type ControlUiE2eServer = {
   baseUrl: string;
   close: () => Promise<void>;
@@ -106,7 +117,7 @@ function resolveServerBaseUrl(server: ViteDevServer): string {
 
 function normalizeScenario(
   scenario: ControlUiMockGatewayScenario,
-): Required<ControlUiMockGatewayScenario> {
+): NormalizedControlUiMockGatewayScenario {
   const defaultAgentId = scenario.defaultAgentId?.trim() || "main";
   const sessionKey = scenario.sessionKey?.trim() || "main";
   return {
@@ -120,6 +131,355 @@ function normalizeScenario(
   };
 }
 
+export function createControlUiMockBootstrapConfig(scenario: ControlUiMockGatewayScenario = {}) {
+  const normalizedScenario = normalizeScenario(scenario);
+  return {
+    allowExternalEmbedUrls: false,
+    assistantAgentId: normalizedScenario.assistantAgentId,
+    assistantAvatar: "",
+    assistantName: normalizedScenario.assistantName,
+    basePath: "/",
+    embedSandbox: "scripts",
+    localMediaPreviewRoots: [],
+    serverVersion: "e2e",
+  };
+}
+
+export function createControlUiMockGatewayInitScript(
+  scenario: ControlUiMockGatewayScenario = {},
+): string {
+  const input = {
+    protocolVersion: PROTOCOL_VERSION,
+    scenario: normalizeScenario(scenario),
+  };
+  return `(() => { const __name = (target) => target; (${installControlUiMockGateway.toString()})(${JSON.stringify(input)}); })();`;
+}
+
+function installControlUiMockGateway(input: {
+  protocolVersion: number;
+  scenario: NormalizedControlUiMockGatewayScenario;
+}) {
+  type BrowserRequest = { id: string; method: string; params?: unknown };
+  type BrowserFrame = {
+    id?: unknown;
+    method?: unknown;
+    params?: unknown;
+    type?: unknown;
+  };
+  type BrowserScenario = NormalizedControlUiMockGatewayScenario;
+  type BrowserMethodResponseCase = {
+    match?: Record<string, unknown>;
+    response?: unknown;
+  };
+  type BrowserMethodResponseCases = {
+    cases?: BrowserMethodResponseCase[];
+  };
+  type ExposedGateway = {
+    emit: (event: string, payload?: unknown) => void;
+    findRequests: (method?: string) => BrowserRequest[];
+    requests: BrowserRequest[];
+  };
+  type WindowWithGateway = Window & {
+    openclawControlUiE2eGateway?: ExposedGateway;
+  };
+
+  const scenario: BrowserScenario = input.scenario;
+  const protocolVersion = input.protocolVersion;
+  const requests: BrowserRequest[] = [];
+  let seq = 0;
+
+  function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+  }
+
+  function hasOwn(record: Record<string, unknown>, key: string): boolean {
+    return Object.prototype.hasOwnProperty.call(record, key);
+  }
+
+  function valuesEqual(actual: unknown, expected: unknown): boolean {
+    if (Object.is(actual, expected)) {
+      return true;
+    }
+    if ((actual && typeof actual === "object") || (expected && typeof expected === "object")) {
+      try {
+        return JSON.stringify(actual) === JSON.stringify(expected);
+      } catch {
+        return false;
+      }
+    }
+    return false;
+  }
+
+  function paramsMatch(params: unknown, match: Record<string, unknown> | undefined): boolean {
+    if (!match) {
+      return true;
+    }
+    const entries = Object.entries(match);
+    if (entries.length === 0) {
+      return true;
+    }
+    if (!isRecord(params)) {
+      return false;
+    }
+    return entries.every(
+      ([key, expected]) => hasOwn(params, key) && valuesEqual(params[key], expected),
+    );
+  }
+
+  function responseCases(value: unknown): BrowserMethodResponseCase[] | null {
+    if (!isRecord(value)) {
+      return null;
+    }
+    const maybeCases = (value as BrowserMethodResponseCases).cases;
+    return Array.isArray(maybeCases) ? maybeCases : null;
+  }
+
+  function configuredResponse(
+    method: string,
+    params: unknown,
+  ): { found: boolean; value?: unknown } {
+    if (!hasOwn(scenario.methodResponses, method)) {
+      return { found: false };
+    }
+    const configured = scenario.methodResponses[method];
+    const cases = responseCases(configured);
+    if (!cases) {
+      return { found: true, value: configured };
+    }
+    const matchingCase = cases.find((candidate) => paramsMatch(params, candidate.match));
+    if (!matchingCase) {
+      return { found: false };
+    }
+    return { found: true, value: matchingCase.response };
+  }
+
+  function sessionRow() {
+    return {
+      contextTokens: null,
+      displayName: "Main",
+      hasActiveRun: false,
+      key: scenario.sessionKey,
+      kind: "direct",
+      label: "Main",
+      model: "gpt-5.5",
+      modelProvider: "openai",
+      status: "done",
+      totalTokens: 0,
+      updatedAt: Date.now(),
+    };
+  }
+
+  function buildResponse(method: string, params: unknown): unknown {
+    const configured = configuredResponse(method, params);
+    if (configured.found) {
+      return configured.value;
+    }
+    switch (method) {
+      case "connect":
+        return {
+          auth: {
+            deviceToken: "e2e-device-token",
+            role: "operator",
+            scopes: [
+              "operator.admin",
+              "operator.read",
+              "operator.write",
+              "operator.approvals",
+              "operator.pairing",
+            ],
+          },
+          features: { events: [], methods: [] },
+          protocol: protocolVersion,
+          server: { connId: "control-ui-e2e", version: "e2e" },
+          snapshot: {
+            sessionDefaults: {
+              defaultAgentId: scenario.defaultAgentId,
+              mainKey: "main",
+              mainSessionKey: scenario.sessionKey,
+              scope: "agent",
+            },
+          },
+          type: "hello-ok",
+        };
+      case "agent.identity.get":
+        return {
+          agentId: scenario.assistantAgentId,
+          avatar: "",
+          avatarStatus: "none",
+          name: scenario.assistantName,
+        };
+      case "agents.list":
+        return {
+          agents: [
+            {
+              id: scenario.defaultAgentId,
+              identity: { name: scenario.assistantName },
+              name: scenario.assistantName,
+            },
+          ],
+          defaultId: scenario.defaultAgentId,
+          mainKey: "main",
+          scope: "agent",
+        };
+      case "chat.history":
+        return {
+          messages: scenario.historyMessages,
+          sessionId: "control-ui-e2e-session",
+          thinkingLevel: null,
+        };
+      case "chat.send":
+        return { ok: true, queued: false, params };
+      case "commands.list":
+        return { commands: [] };
+      case "health":
+        return {
+          agents: [],
+          defaultAgentId: scenario.defaultAgentId,
+          durationMs: 0,
+          heartbeatSeconds: 0,
+          ok: true,
+          sessions: { count: 1, path: "", recent: [] },
+          ts: Date.now(),
+        };
+      case "models.list":
+        return { models: scenario.models };
+      case "sessions.list":
+        return {
+          count: 1,
+          defaults: {
+            contextTokens: null,
+            model: "gpt-5.5",
+            modelProvider: "openai",
+          },
+          path: "",
+          sessions: [sessionRow()],
+          ts: Date.now(),
+        };
+      case "sessions.subscribe":
+        return { ok: true };
+      default:
+        return {};
+    }
+  }
+
+  function parseFrame(raw: string | ArrayBufferLike | Blob | ArrayBufferView): BrowserFrame | null {
+    if (typeof raw !== "string") {
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(raw) as BrowserFrame;
+      return parsed && typeof parsed === "object" ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+
+  class MockWebSocket extends EventTarget {
+    static readonly CLOSED = 3;
+    static readonly CLOSING = 2;
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static latest: MockWebSocket | null = null;
+
+    binaryType: BinaryType = "blob";
+    readonly bufferedAmount = 0;
+    readonly extensions = "";
+    onclose: ((event: CloseEvent) => void) | null = null;
+    onerror: ((event: Event) => void) | null = null;
+    onmessage: ((event: MessageEvent) => void) | null = null;
+    onopen: ((event: Event) => void) | null = null;
+    readonly protocol = "";
+    readyState = MockWebSocket.CONNECTING;
+    readonly url: string;
+
+    constructor(url: string | URL) {
+      super();
+      this.url = String(url);
+      MockWebSocket.latest = this;
+      window.setTimeout(() => {
+        if (this.readyState !== MockWebSocket.CONNECTING) {
+          return;
+        }
+        this.readyState = MockWebSocket.OPEN;
+        this.dispatchEvent(new Event("open"));
+        this.deliver({
+          event: "connect.challenge",
+          payload: { nonce: "control-ui-e2e-nonce" },
+          type: "event",
+        });
+      }, 0);
+    }
+
+    override dispatchEvent(event: Event): boolean {
+      const dispatched = super.dispatchEvent(event);
+      if (event.type === "open") {
+        this.onopen?.(event);
+      } else if (event.type === "message") {
+        this.onmessage?.(event as MessageEvent);
+      } else if (event.type === "close") {
+        this.onclose?.(event as CloseEvent);
+      } else if (event.type === "error") {
+        this.onerror?.(event);
+      }
+      return dispatched;
+    }
+
+    close(code = 1000, reason = ""): void {
+      if (this.readyState === MockWebSocket.CLOSED) {
+        return;
+      }
+      this.readyState = MockWebSocket.CLOSED;
+      this.dispatchEvent(new CloseEvent("close", { code, reason }));
+    }
+
+    send(raw: string | ArrayBufferLike | Blob | ArrayBufferView): void {
+      const frame = parseFrame(raw);
+      if (!frame || frame.type !== "req") {
+        return;
+      }
+      const id = typeof frame.id === "string" ? frame.id : "";
+      const method = typeof frame.method === "string" ? frame.method : "";
+      if (!id || !method) {
+        return;
+      }
+      requests.push({ id, method, params: frame.params });
+      window.setTimeout(() => {
+        this.deliver({
+          id,
+          ok: true,
+          payload: buildResponse(method, frame.params),
+          type: "res",
+        });
+      }, 0);
+    }
+
+    deliver(frame: unknown): void {
+      if (this.readyState !== MockWebSocket.OPEN) {
+        return;
+      }
+      this.dispatchEvent(new MessageEvent("message", { data: JSON.stringify(frame) }));
+    }
+  }
+
+  const exposed: ExposedGateway = {
+    emit(event, payload) {
+      MockWebSocket.latest?.deliver({
+        event,
+        payload,
+        seq: ++seq,
+        type: "event",
+      });
+    },
+    findRequests(method) {
+      return method ? requests.filter((request) => request.method === method) : [...requests];
+    },
+    requests,
+  };
+
+  (window as WindowWithGateway).openclawControlUiE2eGateway = exposed;
+  window.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+}
+
 export async function installMockGateway(
   page: Page,
   scenario: ControlUiMockGatewayScenario = {},
@@ -127,273 +487,12 @@ export async function installMockGateway(
   const normalizedScenario = normalizeScenario(scenario);
   await page.route(`**${CONTROL_UI_BOOTSTRAP_CONFIG_PATH}`, (route) =>
     route.fulfill({
-      body: JSON.stringify({
-        allowExternalEmbedUrls: false,
-        assistantAgentId: normalizedScenario.assistantAgentId,
-        assistantAvatar: "",
-        assistantName: normalizedScenario.assistantName,
-        basePath: "/",
-        embedSandbox: "scripts",
-        localMediaPreviewRoots: [],
-        serverVersion: "e2e",
-      }),
+      body: JSON.stringify(createControlUiMockBootstrapConfig(normalizedScenario)),
       contentType: "application/json",
       status: 200,
     }),
   );
-  await page.addInitScript(
-    (input: { protocolVersion: number; scenario: Required<ControlUiMockGatewayScenario> }) => {
-      type BrowserRequest = { id: string; method: string; params?: unknown };
-      type BrowserFrame = {
-        id?: unknown;
-        method?: unknown;
-        params?: unknown;
-        type?: unknown;
-      };
-      type BrowserScenario = Required<ControlUiMockGatewayScenario>;
-      type ExposedGateway = {
-        emit: (event: string, payload?: unknown) => void;
-        findRequests: (method?: string) => BrowserRequest[];
-        requests: BrowserRequest[];
-      };
-      type WindowWithGateway = Window & {
-        openclawControlUiE2eGateway?: ExposedGateway;
-      };
-
-      const scenario: BrowserScenario = input.scenario;
-      const protocolVersion = input.protocolVersion;
-      const requests: BrowserRequest[] = [];
-      let seq = 0;
-
-      function sessionRow() {
-        return {
-          contextTokens: null,
-          displayName: "Main",
-          hasActiveRun: false,
-          key: scenario.sessionKey,
-          kind: "direct",
-          label: "Main",
-          model: "gpt-5.5",
-          modelProvider: "openai",
-          status: "done",
-          totalTokens: 0,
-          updatedAt: Date.now(),
-        };
-      }
-
-      function buildResponse(method: string, params: unknown): unknown {
-        if (Object.prototype.hasOwnProperty.call(scenario.methodResponses, method)) {
-          return scenario.methodResponses[method];
-        }
-        switch (method) {
-          case "connect":
-            return {
-              auth: {
-                deviceToken: "e2e-device-token",
-                role: "operator",
-                scopes: [
-                  "operator.admin",
-                  "operator.read",
-                  "operator.write",
-                  "operator.approvals",
-                  "operator.pairing",
-                ],
-              },
-              features: { events: [], methods: [] },
-              protocol: protocolVersion,
-              server: { connId: "control-ui-e2e", version: "e2e" },
-              snapshot: {
-                sessionDefaults: {
-                  defaultAgentId: scenario.defaultAgentId,
-                  mainKey: "main",
-                  mainSessionKey: scenario.sessionKey,
-                  scope: "agent",
-                },
-              },
-              type: "hello-ok",
-            };
-          case "agent.identity.get":
-            return {
-              agentId: scenario.assistantAgentId,
-              avatar: "",
-              avatarStatus: "none",
-              name: scenario.assistantName,
-            };
-          case "agents.list":
-            return {
-              agents: [
-                {
-                  id: scenario.defaultAgentId,
-                  identity: { name: scenario.assistantName },
-                  name: scenario.assistantName,
-                },
-              ],
-              defaultId: scenario.defaultAgentId,
-              mainKey: "main",
-              scope: "agent",
-            };
-          case "chat.history":
-            return {
-              messages: scenario.historyMessages,
-              sessionId: "control-ui-e2e-session",
-              thinkingLevel: null,
-            };
-          case "chat.send":
-            return { ok: true, queued: false, params };
-          case "commands.list":
-            return { commands: [] };
-          case "health":
-            return {
-              agents: [],
-              defaultAgentId: scenario.defaultAgentId,
-              durationMs: 0,
-              heartbeatSeconds: 0,
-              ok: true,
-              sessions: { count: 1, path: "", recent: [] },
-              ts: Date.now(),
-            };
-          case "models.list":
-            return { models: scenario.models };
-          case "sessions.list":
-            return {
-              count: 1,
-              defaults: {
-                contextTokens: null,
-                model: "gpt-5.5",
-                modelProvider: "openai",
-              },
-              path: "",
-              sessions: [sessionRow()],
-              ts: Date.now(),
-            };
-          case "sessions.subscribe":
-            return { ok: true };
-          default:
-            return {};
-        }
-      }
-
-      function parseFrame(
-        raw: string | ArrayBufferLike | Blob | ArrayBufferView,
-      ): BrowserFrame | null {
-        if (typeof raw !== "string") {
-          return null;
-        }
-        try {
-          const parsed = JSON.parse(raw) as BrowserFrame;
-          return parsed && typeof parsed === "object" ? parsed : null;
-        } catch {
-          return null;
-        }
-      }
-
-      class MockWebSocket extends EventTarget {
-        static readonly CLOSED = 3;
-        static readonly CLOSING = 2;
-        static readonly CONNECTING = 0;
-        static readonly OPEN = 1;
-        static latest: MockWebSocket | null = null;
-
-        binaryType: BinaryType = "blob";
-        readonly bufferedAmount = 0;
-        readonly extensions = "";
-        onclose: ((event: CloseEvent) => void) | null = null;
-        onerror: ((event: Event) => void) | null = null;
-        onmessage: ((event: MessageEvent) => void) | null = null;
-        onopen: ((event: Event) => void) | null = null;
-        readonly protocol = "";
-        readyState = MockWebSocket.CONNECTING;
-        readonly url: string;
-
-        constructor(url: string | URL) {
-          super();
-          this.url = String(url);
-          MockWebSocket.latest = this;
-          window.setTimeout(() => {
-            if (this.readyState !== MockWebSocket.CONNECTING) {
-              return;
-            }
-            this.readyState = MockWebSocket.OPEN;
-            this.dispatchEvent(new Event("open"));
-            this.deliver({
-              event: "connect.challenge",
-              payload: { nonce: "control-ui-e2e-nonce" },
-              type: "event",
-            });
-          }, 0);
-        }
-
-        override dispatchEvent(event: Event): boolean {
-          const dispatched = super.dispatchEvent(event);
-          if (event.type === "open") {
-            this.onopen?.(event);
-          } else if (event.type === "message") {
-            this.onmessage?.(event as MessageEvent);
-          } else if (event.type === "close") {
-            this.onclose?.(event as CloseEvent);
-          } else if (event.type === "error") {
-            this.onerror?.(event);
-          }
-          return dispatched;
-        }
-
-        close(code = 1000, reason = ""): void {
-          if (this.readyState === MockWebSocket.CLOSED) {
-            return;
-          }
-          this.readyState = MockWebSocket.CLOSED;
-          this.dispatchEvent(new CloseEvent("close", { code, reason }));
-        }
-
-        send(raw: string | ArrayBufferLike | Blob | ArrayBufferView): void {
-          const frame = parseFrame(raw);
-          if (!frame || frame.type !== "req") {
-            return;
-          }
-          const id = typeof frame.id === "string" ? frame.id : "";
-          const method = typeof frame.method === "string" ? frame.method : "";
-          if (!id || !method) {
-            return;
-          }
-          requests.push({ id, method, params: frame.params });
-          window.setTimeout(() => {
-            this.deliver({
-              id,
-              ok: true,
-              payload: buildResponse(method, frame.params),
-              type: "res",
-            });
-          }, 0);
-        }
-
-        deliver(frame: unknown): void {
-          if (this.readyState !== MockWebSocket.OPEN) {
-            return;
-          }
-          this.dispatchEvent(new MessageEvent("message", { data: JSON.stringify(frame) }));
-        }
-      }
-
-      const exposed: ExposedGateway = {
-        emit(event, payload) {
-          MockWebSocket.latest?.deliver({
-            event,
-            payload,
-            seq: ++seq,
-            type: "event",
-          });
-        },
-        findRequests(method) {
-          return method ? requests.filter((request) => request.method === method) : [...requests];
-        },
-        requests,
-      };
-
-      (window as WindowWithGateway).openclawControlUiE2eGateway = exposed;
-      window.WebSocket = MockWebSocket as unknown as typeof WebSocket;
-    },
-    { protocolVersion: PROTOCOL_VERSION, scenario: normalizedScenario },
-  );
+  await page.addInitScript({ content: createControlUiMockGatewayInitScript(normalizedScenario) });
   return createMockGatewayControls(page, normalizedScenario.sessionKey);
 }
 

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -70,7 +70,6 @@ export type ChatHost = ChatInputHistoryState & {
   chatModelSwitchPromises?: Record<string, Promise<boolean>>;
   chatModelsLoading: boolean;
   chatModelCatalog: ModelCatalogEntry[];
-  chatSessionSearchAppliedQuery?: string | null;
   sessionsResult?: SessionsListResult | null;
   sessionsShowArchived?: boolean;
   updateComplete?: Promise<unknown>;
@@ -96,22 +95,20 @@ export const CHAT_SESSIONS_ACTIVE_MINUTES = 0;
 export const CHAT_SESSIONS_REFRESH_LIMIT = 50;
 
 export function createChatSessionsLoadOverrides(
-  state: {
-    chatSessionSearchAppliedQuery?: string | null;
-    sessionsShowArchived?: boolean;
-  },
-  options: { offset?: number; append?: boolean } = {},
+  state: { sessionsShowArchived?: boolean },
+  options: { offset?: number; append?: boolean; search?: string | null } = {},
 ): LoadSessionsOverrides {
   const overrides: LoadSessionsOverrides = {
     activeMinutes: CHAT_SESSIONS_ACTIVE_MINUTES,
     limit: CHAT_SESSIONS_REFRESH_LIMIT,
     includeGlobal: true,
     includeUnknown: true,
+    configuredAgentsOnly: true,
   };
   if (typeof state.sessionsShowArchived === "boolean") {
     overrides.showArchived = state.sessionsShowArchived;
   }
-  const search = normalizeOptionalString(state.chatSessionSearchAppliedQuery ?? undefined);
+  const search = normalizeOptionalString(options.search ?? undefined);
   if (search) {
     overrides.search = search;
   }

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -109,7 +109,6 @@ type GatewayHost = {
   pendingUpdateExpectedVersion: string | null;
   updateStatusBanner: { tone: "danger" | "warn" | "info"; text: string } | null;
   sessionKey: string;
-  chatSessionSearchAppliedQuery: string;
   sessionsShowArchived: boolean;
   chatRunId: string | null;
   pendingAbort?: { runId?: string | null; sessionKey: string } | null;

--- a/ui/src/ui/app-render.helpers.browser.test.ts
+++ b/ui/src/ui/app-render.helpers.browser.test.ts
@@ -60,6 +60,13 @@ function createState(overrides: Partial<AppViewState> = {}) {
     chatModelCatalog: [],
     chatModelOverrides: {},
     chatModelsLoading: false,
+    chatSessionPickerOpen: false,
+    chatSessionPickerSurface: null,
+    chatSessionPickerQuery: "",
+    chatSessionPickerAppliedQuery: "",
+    chatSessionPickerLoading: false,
+    chatSessionPickerError: null,
+    chatSessionPickerResult: null,
     client: { request: vi.fn() },
     ...overrides,
   } as unknown as AppViewState;
@@ -281,14 +288,19 @@ describe("chat header controls (browser)", () => {
 
     const sessionRows = container.querySelectorAll(".chat-controls__session-row");
     expect(sessionRows).toHaveLength(1);
+    const sessionTrigger = requireButton(
+      container.querySelector<HTMLButtonElement>('button[data-chat-session-select="true"]'),
+      "session trigger",
+    );
+    expect(sessionTrigger.dataset.chatSessionSelect).toBe("true");
+
     const selectDatasets = Array.from(container.querySelectorAll("select")).map(
       (select) => select.dataset,
     );
-    expect(selectDatasets).toHaveLength(4);
+    expect(selectDatasets).toHaveLength(3);
     expect(selectDatasets[0]?.chatAgentFilter).toBe("true");
-    expect(selectDatasets[1]?.chatSessionSelect).toBe("true");
-    expect(selectDatasets[2]?.chatModelSelect).toBe("true");
-    expect(selectDatasets[3]?.chatThinkingSelect).toBe("true");
+    expect(selectDatasets[1]?.chatModelSelect).toBe("true");
+    expect(selectDatasets[2]?.chatThinkingSelect).toBe("true");
     const autoScrollToggle = requireButton(
       container.querySelector<HTMLButtonElement>('[data-chat-auto-scroll-toggle="true"]'),
       "auto-scroll toggle",

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -252,7 +252,7 @@ function renderCronFilterIcon(hiddenCount: number) {
 }
 
 export function renderChatSessionSelect(state: AppViewState) {
-  return renderChatSessionSelectBase(state, switchChatSession);
+  return renderChatSessionSelectBase(state, switchChatSession, { surface: "desktop" });
 }
 
 function chatAutoScrollLabel(mode: ChatAutoScrollMode) {
@@ -556,7 +556,7 @@ export function renderChatMobileToggle(state: AppViewState) {
         }}
       >
         <div class="chat-controls">
-          ${renderChatSessionSelectBase(state, switchChatSession)}
+          ${renderChatSessionSelectBase(state, switchChatSession, { surface: "mobile" })}
           <div class="chat-controls__thinking">
             ${renderChatAutoScrollToggle(state)}
             <button
@@ -630,7 +630,9 @@ export function renderChatMobileToggle(state: AppViewState) {
 
 export function switchChatSession(state: AppViewState, nextSessionKey: string) {
   const previousSessionKey = state.sessionKey;
-  const nextSessionRow = state.sessionsResult?.sessions.find((row) => row.key === nextSessionKey);
+  const nextSessionRow =
+    state.sessionsResult?.sessions.find((row) => row.key === nextSessionKey) ??
+    state.chatSessionPickerResult?.sessions.find((row) => row.key === nextSessionKey);
   const nextSessionLabel = resolveSessionDisplayName(nextSessionKey, nextSessionRow);
   resetChatStateForSessionSwitch(state, nextSessionKey);
   if (previousSessionKey !== nextSessionKey) {

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -114,8 +114,13 @@ export type AppViewState = {
   chatModelCatalog: ModelCatalogEntry[];
   sessionSwitchNotice: { id: number; text: string } | null;
   sessionSwitchFlashKey: string | null;
-  chatSessionSearchQuery: string;
-  chatSessionSearchAppliedQuery: string;
+  chatSessionPickerOpen: boolean;
+  chatSessionPickerSurface: "desktop" | "mobile" | null;
+  chatSessionPickerQuery: string;
+  chatSessionPickerAppliedQuery: string;
+  chatSessionPickerLoading: boolean;
+  chatSessionPickerError: string | null;
+  chatSessionPickerResult: SessionsListResult | null;
   announceSessionSwitch?: (sessionKey: string, label: string) => void;
   chatQueue: ChatQueueItem[];
   chatQueueBySession: Record<string, ChatQueueItem[]>;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -228,8 +228,13 @@ export class OpenClawApp extends LitElement {
   @state() chatModelCatalog: ModelCatalogEntry[] = [];
   @state() sessionSwitchNotice: { id: number; text: string } | null = null;
   @state() sessionSwitchFlashKey: string | null = null;
-  @state() chatSessionSearchQuery = "";
-  @state() chatSessionSearchAppliedQuery = "";
+  @state() chatSessionPickerOpen = false;
+  @state() chatSessionPickerSurface: "desktop" | "mobile" | null = null;
+  @state() chatSessionPickerQuery = "";
+  @state() chatSessionPickerAppliedQuery = "";
+  @state() chatSessionPickerLoading = false;
+  @state() chatSessionPickerError: string | null = null;
+  @state() chatSessionPickerResult: SessionsListResult | null = null;
   private sessionSwitchNoticeSeq = 0;
   private sessionSwitchNoticeTimer: number | null = null;
   private sessionSwitchFlashTimer: number | null = null;
@@ -625,18 +630,37 @@ export class OpenClawApp extends LitElement {
     }
   };
   private chatMobileControlsKeydownHandler = (e: KeyboardEvent) => {
-    if (e.key !== "Escape" || !this.chatMobileControlsOpen) {
+    if (e.key !== "Escape") {
+      return;
+    }
+    if (this.chatSessionPickerOpen) {
+      e.preventDefault();
+      this.chatSessionPickerOpen = false;
+      this.chatSessionPickerSurface = null;
+      return;
+    }
+    if (!this.chatMobileControlsOpen) {
       return;
     }
     e.preventDefault();
     this.setChatMobileControlsOpen(false, { restoreFocus: true });
   };
   private chatMobileControlsPointerdownHandler = (e: Event) => {
+    const path = e.composedPath();
+    if (this.chatSessionPickerOpen) {
+      const insidePicker = Array.from(this.querySelectorAll(".chat-controls__session-picker")).some(
+        (node) => path.includes(node),
+      );
+      if (!insidePicker) {
+        this.chatSessionPickerOpen = false;
+        this.chatSessionPickerSurface = null;
+      }
+    }
     if (!this.chatMobileControlsOpen) {
       return;
     }
     const wrapper = this.querySelector(".chat-mobile-controls-wrapper");
-    if (wrapper && e.composedPath().includes(wrapper)) {
+    if (wrapper && path.includes(wrapper)) {
       return;
     }
     this.setChatMobileControlsOpen(false);
@@ -798,6 +822,10 @@ export class OpenClawApp extends LitElement {
 
     const focusTarget = options?.restoreFocus ? this.chatMobileControlsTrigger : null;
     this.chatMobileControlsOpen = false;
+    if (this.chatSessionPickerSurface === "mobile") {
+      this.chatSessionPickerOpen = false;
+      this.chatSessionPickerSurface = null;
+    }
     this.chatMobileControlsTrigger = null;
     if (!(focusTarget instanceof HTMLElement) || !focusTarget.isConnected) {
       return;

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -1,7 +1,7 @@
 import { html } from "lit";
 import { repeat } from "lit/directives/repeat.js";
 import { t } from "../../i18n/index.ts";
-import { CHAT_SESSIONS_REFRESH_LIMIT, createChatSessionsLoadOverrides } from "../app-chat.ts";
+import { createChatSessionsLoadOverrides } from "../app-chat.ts";
 import type { AppViewState } from "../app-view-state.ts";
 import { createChatModelOverride } from "../chat-model-ref.ts";
 import {
@@ -139,22 +139,27 @@ function toggleChatSessionPicker(state: AppViewState, surface: ChatSessionSelect
 }
 
 function createChatSessionPickerRequestParams(
+  state: AppViewState,
   options: { query?: string; offset?: number } = {},
 ): Record<string, unknown> {
+  const overrides = createChatSessionsLoadOverrides(state, {
+    search: options.query,
+    offset: options.offset,
+  });
   const params: Record<string, unknown> = {
-    includeGlobal: true,
-    includeUnknown: true,
-    configuredAgentsOnly: true,
-    limit: CHAT_SESSIONS_REFRESH_LIMIT,
+    includeGlobal: overrides.includeGlobal,
+    includeUnknown: overrides.includeUnknown,
+    configuredAgentsOnly: overrides.configuredAgentsOnly,
+    limit: overrides.limit,
   };
   const offset =
-    typeof options.offset === "number" && Number.isFinite(options.offset)
-      ? Math.max(0, Math.floor(options.offset))
+    typeof overrides.offset === "number" && Number.isFinite(overrides.offset)
+      ? Math.max(0, Math.floor(overrides.offset))
       : 0;
   if (offset > 0) {
     params.offset = offset;
   }
-  const search = normalizeOptionalString(options.query ?? undefined);
+  const search = normalizeOptionalString(overrides.search ?? undefined);
   if (search) {
     params.search = search;
   }
@@ -213,7 +218,7 @@ async function loadChatSessionPickerPage(
       state,
       await state.client.request<SessionsListResult>(
         "sessions.list",
-        createChatSessionPickerRequestParams({ query, offset: options.offset }),
+        createChatSessionPickerRequestParams(state, { query, offset: options.offset }),
       ),
     );
     const previous = state.chatSessionPickerResult ?? state.sessionsResult;

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -9,7 +9,7 @@ import {
   resolveChatModelSelectState,
 } from "../chat-model-select-state.ts";
 import { refreshVisibleToolsEffectiveForCurrentSession } from "../controllers/agents.ts";
-import { isArchivedSessionRow, loadSessions } from "../controllers/sessions.ts";
+import { loadSessions } from "../controllers/sessions.ts";
 import { icons } from "../icons.ts";
 import { isMonitoredAuthProvider } from "../model-auth-helpers.ts";
 import { pathForTab } from "../navigation.ts";
@@ -168,7 +168,7 @@ function projectChatSessionPickerResult(
   if (state.sessionsShowArchived) {
     return result;
   }
-  const sessions = result.sessions.filter((row) => row.key && !isArchivedSessionRow(row));
+  const sessions = result.sessions.filter((row) => row.key && row.archived !== true);
   return {
     ...result,
     count: sessions.length,
@@ -378,7 +378,6 @@ function renderChatSessionPickerPopover(
     >
       <div class="chat-session-picker__search-row">
         <label class="field chat-session-picker__search">
-          <span class="chat-session-picker__search-icon" aria-hidden="true">${icons.search}</span>
           <input
             data-chat-session-picker-search="true"
             type="search"
@@ -398,7 +397,7 @@ function renderChatSessionPickerPopover(
           />
         </label>
         <button
-          class="btn btn--ghost btn--icon"
+          class="btn btn--ghost btn--icon chat-session-picker__icon-button"
           data-chat-session-search-submit="true"
           type="button"
           title=${t("common.search")}
@@ -410,7 +409,7 @@ function renderChatSessionPickerPopover(
         </button>
         ${hasQuery
           ? html`<button
-              class="btn btn--ghost btn--icon"
+              class="btn btn--ghost btn--icon chat-session-picker__icon-button"
               data-chat-session-search-clear="true"
               type="button"
               title=${t("chat.selectors.clearSessionSearch")}

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -1,7 +1,7 @@
 import { html } from "lit";
 import { repeat } from "lit/directives/repeat.js";
 import { t } from "../../i18n/index.ts";
-import { createChatSessionsLoadOverrides } from "../app-chat.ts";
+import { CHAT_SESSIONS_REFRESH_LIMIT, createChatSessionsLoadOverrides } from "../app-chat.ts";
 import type { AppViewState } from "../app-view-state.ts";
 import { createChatModelOverride } from "../chat-model-ref.ts";
 import {
@@ -9,7 +9,7 @@ import {
   resolveChatModelSelectState,
 } from "../chat-model-select-state.ts";
 import { refreshVisibleToolsEffectiveForCurrentSession } from "../controllers/agents.ts";
-import { loadSessions } from "../controllers/sessions.ts";
+import { isArchivedSessionRow, loadSessions } from "../controllers/sessions.ts";
 import { icons } from "../icons.ts";
 import { isMonitoredAuthProvider } from "../model-auth-helpers.ts";
 import { pathForTab } from "../navigation.ts";
@@ -36,10 +36,12 @@ import {
 import type { GatewayThinkingLevelOption, SessionsListResult } from "../types.ts";
 
 type ChatSessionSwitchHandler = (state: AppViewState, nextSessionKey: string) => void;
+type ChatSessionSelectSurface = "desktop" | "mobile";
 
 export function renderChatSessionSelect(
   state: AppViewState,
   onSwitchSession: ChatSessionSwitchHandler = () => undefined,
+  options: { surface?: ChatSessionSelectSurface } = {},
 ) {
   const sessionGroups = resolveSessionOptionGroups(state, state.sessionKey, state.sessionsResult);
   const agentOptions = resolveChatAgentFilterOptions(state);
@@ -48,10 +50,9 @@ export function renderChatSessionSelect(
   const modelSelect = renderChatModelSelect(state);
   const thinkingSelect = renderChatThinkingSelect(state);
   const quotaPill = renderChatQuotaPill(state);
-  const sessionActions = renderChatSessionSearchControls(state);
-  const selectedSessionLabel =
-    sessionGroups.flatMap((group) => group.options).find((entry) => entry.key === state.sessionKey)
-      ?.label ?? state.sessionKey;
+  const surface = options.surface ?? "desktop";
+  const selectedSessionLabel = resolveSelectedChatSessionLabel(state, sessionGroups);
+  const pickerOpen = state.chatSessionPickerOpen && state.chatSessionPickerSurface === surface;
   const flashSession = state.sessionSwitchFlashKey === state.sessionKey;
   const rowClass = [
     "chat-controls__session-row",
@@ -62,48 +63,17 @@ export function renderChatSessionSelect(
     .filter(Boolean)
     .join(" ");
   return html`
-    <div class="chat-controls__session-stack">
-      <div class=${rowClass}>
-        ${agentSelect}
-        <label class="field chat-controls__session chat-controls__session-picker">
-          <select
-            data-chat-session-select="true"
-            aria-label=${t("chat.selectors.session")}
-            .value=${state.sessionKey}
-            title=${selectedSessionLabel}
-            ?disabled=${!state.connected || sessionGroups.length === 0}
-            @change=${(e: Event) => {
-              const next = (e.target as HTMLSelectElement).value;
-              if (state.sessionKey === next) {
-                return;
-              }
-              onSwitchSession(state, next);
-            }}
-          >
-            ${repeat(
-              sessionGroups,
-              (group) => group.id,
-              (group) =>
-                html`<optgroup label=${group.label}>
-                  ${repeat(
-                    group.options,
-                    (entry) => entry.key,
-                    (entry) =>
-                      html`<option
-                        value=${entry.key}
-                        title=${entry.title}
-                        ?selected=${entry.key === state.sessionKey}
-                      >
-                        ${entry.label}
-                      </option>`,
-                  )}
-                </optgroup>`,
-            )}
-          </select>
-        </label>
-        ${modelSelect} ${thinkingSelect} ${quotaPill}
-      </div>
-      ${sessionActions}
+    <div class=${rowClass}>
+      ${agentSelect}
+      ${renderChatSessionPicker({
+        state,
+        onSwitchSession,
+        surface,
+        selectedSessionLabel,
+        pickerOpen,
+        disabled: !state.connected || !state.client,
+      })}
+      ${modelSelect} ${thinkingSelect} ${quotaPill}
     </div>
     <div class="chat-controls__session-notice" role="status" aria-live="polite">
       ${state.sessionSwitchNotice?.text ?? ""}
@@ -111,7 +81,9 @@ export function renderChatSessionSelect(
   `;
 }
 
-function resolveNextChatSessionOffset(sessions: SessionsListResult | null): number | null {
+function resolveNextChatSessionOffset(
+  sessions: SessionsListResult | null | undefined,
+): number | null {
   if (!sessions?.hasMore) {
     return null;
   }
@@ -121,100 +93,400 @@ function resolveNextChatSessionOffset(sessions: SessionsListResult | null): numb
   return sessions.sessions.length;
 }
 
-async function refreshSessionOptions(
-  state: AppViewState,
-  options: { offset?: number; append?: boolean } = {},
-) {
+async function refreshSessionOptions(state: AppViewState) {
   await loadSessions(state as unknown as Parameters<typeof loadSessions>[0], {
-    ...createChatSessionsLoadOverrides(state, options),
+    ...createChatSessionsLoadOverrides(state),
   });
 }
 
-async function applyChatSessionSearch(state: AppViewState) {
-  state.chatSessionSearchAppliedQuery = normalizeOptionalString(state.chatSessionSearchQuery) ?? "";
-  await refreshSessionOptions(state);
+function requestHostUpdate(state: AppViewState) {
+  (state as AppViewState & { requestUpdate?: () => void }).requestUpdate?.();
 }
 
-async function clearChatSessionSearch(state: AppViewState) {
-  state.chatSessionSearchQuery = "";
-  state.chatSessionSearchAppliedQuery = "";
-  await refreshSessionOptions(state);
+function focusChatSessionPickerSearch(state: AppViewState) {
+  const updateComplete = (state as AppViewState & { updateComplete?: Promise<unknown> })
+    .updateComplete;
+  const focus = () => {
+    document.querySelector<HTMLInputElement>('[data-chat-session-picker-search="true"]')?.focus();
+  };
+  if (updateComplete) {
+    void updateComplete.then(focus);
+    return;
+  }
+  setTimeout(focus, 0);
 }
 
-async function loadMoreChatSessions(state: AppViewState) {
-  const offset = resolveNextChatSessionOffset(state.sessionsResult);
+function openChatSessionPicker(state: AppViewState, surface: ChatSessionSelectSurface) {
+  state.chatSessionPickerOpen = true;
+  state.chatSessionPickerSurface = surface;
+  state.chatSessionPickerError = null;
+  requestHostUpdate(state);
+  focusChatSessionPickerSearch(state);
+}
+
+function closeChatSessionPicker(state: AppViewState) {
+  state.chatSessionPickerOpen = false;
+  state.chatSessionPickerSurface = null;
+  requestHostUpdate(state);
+}
+
+function toggleChatSessionPicker(state: AppViewState, surface: ChatSessionSelectSurface) {
+  if (state.chatSessionPickerOpen && state.chatSessionPickerSurface === surface) {
+    closeChatSessionPicker(state);
+    return;
+  }
+  openChatSessionPicker(state, surface);
+}
+
+function createChatSessionPickerRequestParams(
+  options: { query?: string; offset?: number } = {},
+): Record<string, unknown> {
+  const params: Record<string, unknown> = {
+    includeGlobal: true,
+    includeUnknown: true,
+    configuredAgentsOnly: true,
+    limit: CHAT_SESSIONS_REFRESH_LIMIT,
+  };
+  const offset =
+    typeof options.offset === "number" && Number.isFinite(options.offset)
+      ? Math.max(0, Math.floor(options.offset))
+      : 0;
+  if (offset > 0) {
+    params.offset = offset;
+  }
+  const search = normalizeOptionalString(options.query ?? undefined);
+  if (search) {
+    params.search = search;
+  }
+  return params;
+}
+
+function projectChatSessionPickerResult(
+  state: AppViewState,
+  result: SessionsListResult,
+): SessionsListResult {
+  if (state.sessionsShowArchived) {
+    return result;
+  }
+  const sessions = result.sessions.filter((row) => row.key && !isArchivedSessionRow(row));
+  return {
+    ...result,
+    count: sessions.length,
+    sessions,
+  };
+}
+
+function appendChatSessionPickerResult(
+  previous: SessionsListResult,
+  page: SessionsListResult,
+): SessionsListResult {
+  const rowsByKey = new Map(previous.sessions.map((row) => [row.key, row] as const));
+  const sessions = [...previous.sessions];
+  for (const row of page.sessions) {
+    if (rowsByKey.has(row.key)) {
+      continue;
+    }
+    rowsByKey.set(row.key, row);
+    sessions.push(row);
+  }
+  return {
+    ...page,
+    count: sessions.length,
+    sessions,
+    totalCount: page.totalCount ?? previous.totalCount,
+  };
+}
+
+async function loadChatSessionPickerPage(
+  state: AppViewState,
+  options: { query?: string; offset?: number; append?: boolean } = {},
+) {
+  if (!state.client || !state.connected) {
+    return;
+  }
+  const query = normalizeOptionalString(options.query ?? state.chatSessionPickerAppliedQuery) ?? "";
+  state.chatSessionPickerLoading = true;
+  state.chatSessionPickerError = null;
+  requestHostUpdate(state);
+  try {
+    const page = projectChatSessionPickerResult(
+      state,
+      await state.client.request<SessionsListResult>(
+        "sessions.list",
+        createChatSessionPickerRequestParams({ query, offset: options.offset }),
+      ),
+    );
+    const previous = state.chatSessionPickerResult ?? state.sessionsResult;
+    state.chatSessionPickerResult =
+      options.append === true && previous ? appendChatSessionPickerResult(previous, page) : page;
+    state.chatSessionPickerAppliedQuery = query;
+  } catch (err) {
+    state.chatSessionPickerError = String(err);
+  } finally {
+    state.chatSessionPickerLoading = false;
+    requestHostUpdate(state);
+  }
+}
+
+async function applyChatSessionPickerSearch(state: AppViewState) {
+  const query = normalizeOptionalString(state.chatSessionPickerQuery) ?? "";
+  if (!query) {
+    clearChatSessionPickerSearch(state);
+    return;
+  }
+  await loadChatSessionPickerPage(state, { query });
+}
+
+function clearChatSessionPickerSearch(state: AppViewState) {
+  state.chatSessionPickerQuery = "";
+  state.chatSessionPickerAppliedQuery = "";
+  state.chatSessionPickerError = null;
+  state.chatSessionPickerResult = null;
+  requestHostUpdate(state);
+  focusChatSessionPickerSearch(state);
+}
+
+async function loadMoreChatSessionPickerResults(state: AppViewState) {
+  const result = resolveChatSessionPickerResult(state);
+  const offset = resolveNextChatSessionOffset(result);
   if (offset === null) {
     return;
   }
-  await refreshSessionOptions(state, { offset, append: true });
+  await loadChatSessionPickerPage(state, {
+    query: state.chatSessionPickerAppliedQuery,
+    offset,
+    append: true,
+  });
 }
 
-function renderChatSessionSearchControls(state: AppViewState) {
-  const draft = state.chatSessionSearchQuery ?? "";
-  const applied = state.chatSessionSearchAppliedQuery ?? "";
-  const hasQuery = draft.trim() !== "" || applied.trim() !== "";
-  const disabled = !state.connected || !state.client || state.sessionsLoading;
-  const loadMoreOffset = resolveNextChatSessionOffset(state.sessionsResult);
+function resolveChatSessionRow(
+  state: AppViewState,
+  sessionKey: string,
+): SessionsListResult["sessions"][number] | undefined {
+  return (
+    state.sessionsResult?.sessions.find((row) => row.key === sessionKey) ??
+    state.chatSessionPickerResult?.sessions.find((row) => row.key === sessionKey)
+  );
+}
+
+function resolveChatSessionPickerResult(state: AppViewState): SessionsListResult | null {
+  if (state.chatSessionPickerResult || state.chatSessionPickerAppliedQuery) {
+    return state.chatSessionPickerResult;
+  }
+  return state.sessionsResult;
+}
+
+function resolveSelectedChatSessionLabel(
+  state: AppViewState,
+  sessionGroups: SessionOptionGroup[],
+): string {
+  const row = resolveChatSessionRow(state, state.sessionKey);
+  const displayName = resolveSessionDisplayName(state.sessionKey, row);
+  if (displayName !== state.sessionKey) {
+    return displayName;
+  }
+  return (
+    sessionGroups.flatMap((group) => group.options).find((entry) => entry.key === state.sessionKey)
+      ?.label ?? state.sessionKey
+  );
+}
+
+function formatChatSessionPickerMeta(row: SessionsListResult["sessions"][number]): string {
+  const parts = [
+    normalizeOptionalString(row.surface),
+    [normalizeOptionalString(row.modelProvider), normalizeOptionalString(row.model)]
+      .filter(Boolean)
+      .join("/"),
+  ].filter(Boolean);
+  if (typeof row.updatedAt === "number" && Number.isFinite(row.updatedAt)) {
+    parts.push(new Date(row.updatedAt).toLocaleString());
+  }
+  return parts.join(" · ");
+}
+
+function renderChatSessionPicker(params: {
+  state: AppViewState;
+  onSwitchSession: ChatSessionSwitchHandler;
+  surface: ChatSessionSelectSurface;
+  selectedSessionLabel: string;
+  pickerOpen: boolean;
+  disabled: boolean;
+}) {
+  const { state, onSwitchSession, surface, selectedSessionLabel, pickerOpen, disabled } = params;
+  const pickerId = `chat-session-picker-${surface}`;
   return html`
-    <div class="chat-controls__session-actions">
-      <label class="field chat-controls__session-search">
-        <span class="chat-controls__session-search-icon" aria-hidden="true">${icons.search}</span>
-        <input
-          data-chat-session-search="true"
-          type="search"
-          placeholder=${t("chat.selectors.sessionSearch")}
-          aria-label=${t("chat.selectors.sessionSearch")}
-          .value=${draft}
-          ?disabled=${disabled}
-          @input=${(event: Event) => {
-            state.chatSessionSearchQuery = (event.target as HTMLInputElement).value;
-          }}
-          @keydown=${(event: KeyboardEvent) => {
-            if (event.key !== "Enter") {
-              return;
-            }
-            event.preventDefault();
-            void applyChatSessionSearch(state);
-          }}
-        />
-      </label>
+    <div class="chat-controls__session chat-controls__session-picker">
       <button
-        class="btn btn--ghost btn--icon"
-        data-chat-session-search-submit="true"
+        class="chat-controls__session-trigger"
+        data-chat-session-select="true"
         type="button"
-        title=${t("common.search")}
-        aria-label=${t("common.search")}
+        title=${selectedSessionLabel}
+        aria-label=${t("chat.selectors.session")}
+        aria-haspopup="dialog"
+        aria-expanded=${pickerOpen ? "true" : "false"}
+        aria-controls=${pickerId}
         ?disabled=${disabled}
-        @click=${() => void applyChatSessionSearch(state)}
+        @click=${() => toggleChatSessionPicker(state, surface)}
+        @keydown=${(event: KeyboardEvent) => {
+          if (event.key === "ArrowDown" || event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            openChatSessionPicker(state, surface);
+          }
+        }}
       >
-        ${icons.search}
+        <span class="chat-controls__session-trigger-label">${selectedSessionLabel}</span>
+        <span class="chat-controls__session-trigger-icon" aria-hidden="true">
+          ${icons.chevronDown}
+        </span>
       </button>
-      ${hasQuery
-        ? html`<button
-            class="btn btn--ghost btn--icon"
-            data-chat-session-search-clear="true"
-            type="button"
-            title=${t("chat.selectors.clearSessionSearch")}
-            aria-label=${t("chat.selectors.clearSessionSearch")}
+      ${pickerOpen ? renderChatSessionPickerPopover(state, onSwitchSession, pickerId) : ""}
+    </div>
+  `;
+}
+
+function renderChatSessionPickerPopover(
+  state: AppViewState,
+  onSwitchSession: ChatSessionSwitchHandler,
+  pickerId: string,
+) {
+  const result = resolveChatSessionPickerResult(state);
+  const rows = result?.sessions ?? [];
+  const disabled = !state.connected || !state.client || state.chatSessionPickerLoading;
+  const hasQuery =
+    state.chatSessionPickerQuery.trim() !== "" || state.chatSessionPickerAppliedQuery.trim() !== "";
+  const loadMoreOffset = resolveNextChatSessionOffset(result);
+  const shownCount = rows.length;
+  const totalCount = result?.totalCount;
+  const countLabel =
+    typeof totalCount === "number" && Number.isFinite(totalCount)
+      ? `${shownCount} / ${totalCount}`
+      : String(shownCount);
+
+  return html`
+    <div
+      id=${pickerId}
+      class="chat-session-picker"
+      role="dialog"
+      aria-label=${t("chat.selectors.session")}
+      @keydown=${(event: KeyboardEvent) => {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          event.stopPropagation();
+          closeChatSessionPicker(state);
+        }
+      }}
+    >
+      <div class="chat-session-picker__search-row">
+        <label class="field chat-session-picker__search">
+          <span class="chat-session-picker__search-icon" aria-hidden="true">${icons.search}</span>
+          <input
+            data-chat-session-picker-search="true"
+            type="search"
+            placeholder=${t("chat.selectors.sessionSearch")}
+            aria-label=${t("chat.selectors.sessionSearch")}
+            .value=${state.chatSessionPickerQuery}
             ?disabled=${disabled}
-            @click=${() => void clearChatSessionSearch(state)}
-          >
-            ${icons.x}
-          </button>`
+            @input=${(event: Event) => {
+              state.chatSessionPickerQuery = (event.target as HTMLInputElement).value;
+            }}
+            @keydown=${(event: KeyboardEvent) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                void applyChatSessionPickerSearch(state);
+              }
+            }}
+          />
+        </label>
+        <button
+          class="btn btn--ghost btn--icon"
+          data-chat-session-search-submit="true"
+          type="button"
+          title=${t("common.search")}
+          aria-label=${t("common.search")}
+          ?disabled=${disabled}
+          @click=${() => void applyChatSessionPickerSearch(state)}
+        >
+          ${icons.search}
+        </button>
+        ${hasQuery
+          ? html`<button
+              class="btn btn--ghost btn--icon"
+              data-chat-session-search-clear="true"
+              type="button"
+              title=${t("chat.selectors.clearSessionSearch")}
+              aria-label=${t("chat.selectors.clearSessionSearch")}
+              ?disabled=${disabled}
+              @click=${() => clearChatSessionPickerSearch(state)}
+            >
+              ${icons.x}
+            </button>`
+          : ""}
+      </div>
+      ${state.chatSessionPickerError
+        ? html`<div class="chat-session-picker__status" role="alert">
+            ${state.chatSessionPickerError}
+          </div>`
         : ""}
-      ${loadMoreOffset !== null
-        ? html`<button
-            class="btn btn--ghost btn--icon"
-            data-chat-session-load-more="true"
-            type="button"
-            title=${t("chat.selectors.loadMoreSessions")}
-            aria-label=${t("chat.selectors.loadMoreSessions")}
-            ?disabled=${disabled}
-            @click=${() => void loadMoreChatSessions(state)}
-          >
-            ${icons.arrowDown}
-          </button>`
-        : ""}
+      <div class="chat-session-picker__list" role="listbox">
+        ${state.chatSessionPickerLoading && rows.length === 0
+          ? html`<div class="chat-session-picker__status">${t("common.loading")}</div>`
+          : ""}
+        ${!state.chatSessionPickerLoading && rows.length === 0
+          ? html`<div class="chat-session-picker__status">${t("sessionsView.noSessions")}</div>`
+          : ""}
+        ${repeat(
+          rows,
+          (row) => row.key,
+          (row) => {
+            const label = resolveSessionDisplayName(row.key, row);
+            const meta = formatChatSessionPickerMeta(row);
+            const selected = row.key === state.sessionKey;
+            return html`
+              <button
+                class="chat-session-picker__option ${selected
+                  ? "chat-session-picker__option--selected"
+                  : ""}"
+                data-chat-session-picker-option="true"
+                data-session-key=${row.key}
+                role="option"
+                aria-selected=${selected ? "true" : "false"}
+                title=${label}
+                type="button"
+                @click=${() => {
+                  closeChatSessionPicker(state);
+                  if (row.key !== state.sessionKey) {
+                    onSwitchSession(state, row.key);
+                  }
+                }}
+              >
+                <span class="chat-session-picker__option-main">
+                  <span class="chat-session-picker__option-label">${label}</span>
+                  ${meta ? html`<span class="chat-session-picker__option-meta">${meta}</span>` : ""}
+                </span>
+                ${selected
+                  ? html`<span class="chat-session-picker__option-check" aria-hidden="true">
+                      ${icons.check}
+                    </span>`
+                  : ""}
+              </button>
+            `;
+          },
+        )}
+      </div>
+      <div class="chat-session-picker__footer">
+        <span class="chat-session-picker__count">${countLabel}</span>
+        ${loadMoreOffset !== null
+          ? html`<button
+              class="btn btn--ghost btn--sm"
+              data-chat-session-load-more="true"
+              type="button"
+              ?disabled=${disabled}
+              @click=${() => void loadMoreChatSessionPickerResults(state)}
+            >
+              ${t("chat.selectors.loadMoreSessions")}
+            </button>`
+          : ""}
+      </div>
     </div>
   `;
 }

--- a/ui/src/ui/e2e/chat-picker-pagination.e2e.test.ts
+++ b/ui/src/ui/e2e/chat-picker-pagination.e2e.test.ts
@@ -1,0 +1,219 @@
+import { chromium, type Browser } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+  type MockGatewayControls,
+  type MockGatewayRequest,
+} from "../../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = chromium.executablePath();
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+
+let browser: Browser;
+let server: ControlUiE2eServer;
+
+function sessionRow(key: string, label: string, updatedAt: number) {
+  return {
+    contextTokens: null,
+    displayName: label,
+    hasActiveRun: false,
+    key,
+    kind: "direct",
+    label,
+    model: "gpt-5.5",
+    modelProvider: "openai",
+    status: "done",
+    totalTokens: 0,
+    updatedAt,
+  };
+}
+
+function sessionsListResponse(
+  sessions: unknown[],
+  options: { hasMore: boolean; nextOffset: number | null; offset?: number; totalCount: number },
+) {
+  return {
+    count: sessions.length,
+    defaults: {
+      contextTokens: null,
+      model: "gpt-5.5",
+      modelProvider: "openai",
+    },
+    hasMore: options.hasMore,
+    limitApplied: 50,
+    nextOffset: options.nextOffset,
+    offset: options.offset ?? 0,
+    path: "",
+    sessions,
+    totalCount: options.totalCount,
+    ts: Date.now(),
+  };
+}
+
+function requireRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Expected object value");
+  }
+  return value as Record<string, unknown>;
+}
+
+function requestParams(request: MockGatewayRequest): Record<string, unknown> {
+  return requireRecord(request.params);
+}
+
+async function waitForSessionsRequest(
+  gateway: MockGatewayControls,
+  predicate: (params: Record<string, unknown>) => boolean,
+): Promise<MockGatewayRequest> {
+  const deadline = Date.now() + 10_000;
+  let requests: MockGatewayRequest[] = [];
+  while (Date.now() < deadline) {
+    requests = await gateway.getRequests("sessions.list");
+    const match = requests.find((request) => predicate(requestParams(request)));
+    if (match) {
+      return match;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`No matching sessions.list request found: ${JSON.stringify(requests)}`);
+}
+
+describeControlUiE2e("Control UI chat picker mocked Gateway E2E", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(
+        `Playwright Chromium is not installed at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+      );
+    }
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch();
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("searches and pages chat sessions through the GUI", async () => {
+    const baseTime = Date.parse("2026-05-22T09:00:00.000Z");
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": {
+          cases: [
+            {
+              match: { offset: 50, search: "telegram" },
+              response: sessionsListResponse(
+                [
+                  sessionRow("agent:telegram-51", "Telegram archive page 51", baseTime - 180_000),
+                  sessionRow("agent:telegram-52", "Telegram archive page 52", baseTime - 240_000),
+                ],
+                { hasMore: false, nextOffset: null, offset: 50, totalCount: 4 },
+              ),
+            },
+            {
+              match: { search: "telegram" },
+              response: sessionsListResponse(
+                [
+                  sessionRow("agent:telegram", "Telegram follow-up", baseTime - 60_000),
+                  sessionRow(
+                    "agent:telegram-mobile",
+                    "Telegram mobile handoff",
+                    baseTime - 120_000,
+                  ),
+                ],
+                { hasMore: true, nextOffset: 50, totalCount: 4 },
+              ),
+            },
+            {
+              match: {},
+              response: sessionsListResponse(
+                [
+                  sessionRow("agent:alpha", "Alpha planning", baseTime - 1_000),
+                  sessionRow("agent:design", "Design review", baseTime - 30_000),
+                ],
+                { hasMore: true, nextOffset: 50, totalCount: 125 },
+              ),
+            },
+          ],
+        },
+      },
+      sessionKey: "agent:alpha",
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await page.getByRole("button", { name: "Chat session" }).click();
+
+      const searchInput = page.locator('[data-chat-session-picker-search="true"]').last();
+      await searchInput.waitFor({ state: "visible", timeout: 10_000 });
+
+      const initialRequest = await waitForSessionsRequest(
+        gateway,
+        (params) => params.limit === 50 && params.includeGlobal === true,
+      );
+      expect(requestParams(initialRequest)).toMatchObject({
+        configuredAgentsOnly: true,
+        includeGlobal: true,
+        includeUnknown: true,
+        limit: 50,
+      });
+      expect(requestParams(initialRequest)).not.toHaveProperty("search");
+      expect(requestParams(initialRequest)).not.toHaveProperty("offset");
+      await page.getByRole("option", { name: /Alpha planning/u }).waitFor({ timeout: 10_000 });
+
+      await searchInput.fill(" telegram ");
+      await page.locator('[data-chat-session-search-submit="true"]').last().click();
+
+      const searchRequest = await waitForSessionsRequest(
+        gateway,
+        (params) => params.search === "telegram" && !("offset" in params),
+      );
+      expect(requestParams(searchRequest)).toMatchObject({
+        configuredAgentsOnly: true,
+        includeGlobal: true,
+        includeUnknown: true,
+        limit: 50,
+        search: "telegram",
+      });
+      await page.getByRole("option", { name: /Telegram follow-up/u }).waitFor({
+        timeout: 10_000,
+      });
+      await page.getByText("2 / 4").waitFor({ timeout: 10_000 });
+
+      await page.getByRole("button", { name: "Load more sessions" }).click();
+
+      const nextPageRequest = await waitForSessionsRequest(
+        gateway,
+        (params) => params.search === "telegram" && params.offset === 50,
+      );
+      expect(requestParams(nextPageRequest)).toMatchObject({
+        configuredAgentsOnly: true,
+        includeGlobal: true,
+        includeUnknown: true,
+        limit: 50,
+        offset: 50,
+        search: "telegram",
+      });
+      await page.getByRole("option", { name: /Telegram archive page 51/u }).waitFor({
+        timeout: 10_000,
+      });
+      await page.getByText("4 / 4").waitFor({ timeout: 10_000 });
+      await expect
+        .poll(async () => page.getByRole("button", { name: "Load more sessions" }).count())
+        .toBe(0);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -18,7 +18,7 @@ import { buildRawSidebarContent } from "../chat/chat-sidebar-raw.ts";
 import { renderWelcomeState } from "../chat/chat-welcome.ts";
 import { renderChatSessionSelect } from "../chat/session-controls.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
-import type { ModelCatalogEntry } from "../types.ts";
+import type { GatewaySessionRow, ModelCatalogEntry, SessionsListResult } from "../types.ts";
 import type { ChatAttachment, ChatQueueItem } from "../ui-types.ts";
 import { renderChat, resetChatViewState } from "./chat.ts";
 
@@ -217,6 +217,22 @@ function renderQueue(params: {
   return container;
 }
 
+function createSessionsResultFromRows(
+  sessions: GatewaySessionRow[],
+  overrides: Partial<
+    Pick<SessionsListResult, "hasMore" | "nextOffset" | "offset" | "totalCount">
+  > = {},
+): SessionsListResult {
+  return {
+    ts: 0,
+    path: "",
+    count: sessions.length,
+    defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+    sessions,
+    ...overrides,
+  };
+}
+
 function createChatHeaderState(
   overrides: {
     model?: string | null;
@@ -231,7 +247,7 @@ function createChatHeaderState(
   let currentModelProvider = overrides.modelProvider ?? (currentModel ? "openai" : null);
   const omitSessionFromList = overrides.omitSessionFromList ?? false;
   const catalog = overrides.models ?? createModelCatalog(...DEFAULT_CHAT_MODEL_CATALOG);
-  const request = vi.fn(async (method: string, params: Record<string, unknown>) => {
+  const request = vi.fn(async (method: string, params: Record<string, unknown> = {}) => {
     if (method === "sessions.patch") {
       const nextModel = (params.model as string | null | undefined) ?? null;
       if (!nextModel) {
@@ -261,6 +277,44 @@ function createChatHeaderState(
       return { messages: [], thinkingLevel: null };
     }
     if (method === "sessions.list") {
+      const search = typeof params.search === "string" ? params.search.trim() : "";
+      const offset =
+        typeof params.offset === "number" && Number.isFinite(params.offset) ? params.offset : 0;
+      if (search === "telegram" && offset === 50) {
+        return createSessionsResultFromRows(
+          [
+            {
+              key: "agent:main:telegram-page-51",
+              kind: "direct",
+              label: "Telegram page 51",
+              updatedAt: 2,
+            },
+            {
+              key: "agent:main:telegram-page-52",
+              kind: "direct",
+              label: "Telegram page 52",
+              updatedAt: 1,
+            },
+          ],
+          { hasMore: false, nextOffset: null, offset: 50, totalCount: 4 },
+        );
+      }
+      if (search === "telegram") {
+        return createSessionsResultFromRows(
+          [
+            { key: "agent:main:telegram-one", kind: "direct", label: "Telegram one", updatedAt: 4 },
+            { key: "agent:main:telegram-two", kind: "direct", label: "Telegram two", updatedAt: 3 },
+            {
+              key: "agent:main:telegram-archived",
+              kind: "direct",
+              label: "Telegram archived",
+              updatedAt: 2,
+              archived: true,
+            },
+          ],
+          { hasMore: true, nextOffset: 50, totalCount: 4 },
+        );
+      }
       return createSessionsListResult({
         model: currentModel,
         modelProvider: currentModelProvider,
@@ -295,6 +349,13 @@ function createChatHeaderState(
     chatModelOverrides: {},
     chatModelCatalog: catalog,
     chatModelsLoading: false,
+    chatSessionPickerOpen: false,
+    chatSessionPickerSurface: null,
+    chatSessionPickerQuery: "",
+    chatSessionPickerAppliedQuery: "",
+    chatSessionPickerLoading: false,
+    chatSessionPickerError: null,
+    chatSessionPickerResult: null,
     client: { request } as unknown as GatewayBrowserClient,
     settings: {
       gatewayUrl: "",
@@ -1154,15 +1215,12 @@ describe("chat session controls", () => {
     const agentSelect = container.querySelector<HTMLSelectElement>(
       'select[data-chat-agent-filter="true"]',
     );
-    const sessionSelect = container.querySelector<HTMLSelectElement>(
-      'select[data-chat-session-select="true"]',
+    const sessionTrigger = container.querySelector<HTMLButtonElement>(
+      'button[data-chat-session-select="true"]',
     );
 
     expect(agentSelect?.value).toBe("alpha");
-    expect([...sessionSelect!.options].map((option) => option.value)).toEqual([
-      "agent:alpha:main",
-      "agent:alpha:dashboard:alpha-recent",
-    ]);
+    expect(sessionTrigger?.textContent).toContain("main");
 
     agentSelect!.value = "beta";
     agentSelect!.dispatchEvent(new Event("change", { bubbles: true }));
@@ -1177,21 +1235,25 @@ describe("chat session controls", () => {
     render(renderChatSessionSelect(state), container);
 
     expect(
+      container
+        .querySelector<HTMLButtonElement>('button[data-chat-session-select="true"]')
+        ?.getAttribute("aria-label"),
+    ).toBe(t("chat.selectors.session"));
+    expect(
       [...container.querySelectorAll("select")].map((select) => select.getAttribute("aria-label")),
-    ).toEqual([
-      t("chat.selectors.session"),
-      t("chat.selectors.model"),
-      t("chat.selectors.thinkingLevel"),
-    ]);
+    ).toEqual([t("chat.selectors.model"), t("chat.selectors.thinkingLevel")]);
   });
 
-  it("searches chat sessions through the bounded session list request", () => {
-    const { state } = createChatHeaderState();
+  it("searches chat sessions inside the picker without replacing recent sessions", async () => {
+    const { state, request } = createChatHeaderState();
+    const originalSessionsResult = state.sessionsResult;
     const container = document.createElement("div");
     render(renderChatSessionSelect(state), container);
 
+    container.querySelector<HTMLButtonElement>('button[data-chat-session-select="true"]')!.click();
+    render(renderChatSessionSelect(state), container);
     const input = container.querySelector<HTMLInputElement>(
-      'input[data-chat-session-search="true"]',
+      'input[data-chat-session-picker-search="true"]',
     );
     const submit = container.querySelector<HTMLButtonElement>(
       'button[data-chat-session-search-submit="true"]',
@@ -1200,24 +1262,95 @@ describe("chat session controls", () => {
     input!.value = " telegram ";
     input!.dispatchEvent(new Event("input", { bubbles: true }));
     submit!.click();
+    await flushTasks();
+    render(renderChatSessionSelect(state), container);
 
-    expect(state.chatSessionSearchQuery).toBe(" telegram ");
-    expect(state.chatSessionSearchAppliedQuery).toBe("telegram");
-    expect(loadSessionsMock).toHaveBeenCalledWith(
-      state,
-      expect.objectContaining({
-        limit: 50,
-        includeGlobal: true,
-        includeUnknown: true,
-        search: "telegram",
-      }),
-    );
+    expect(state.chatSessionPickerQuery).toBe(" telegram ");
+    expect(state.chatSessionPickerAppliedQuery).toBe("telegram");
+    expect(state.sessionsResult).toBe(originalSessionsResult);
+    expect(state.chatSessionPickerResult?.sessions.map((row) => row.key)).toEqual([
+      "agent:main:telegram-one",
+      "agent:main:telegram-two",
+    ]);
+    expect(request).toHaveBeenCalledWith("sessions.list", {
+      configuredAgentsOnly: true,
+      includeGlobal: true,
+      includeUnknown: true,
+      limit: 50,
+      search: "telegram",
+    });
+    expect(loadSessionsMock).not.toHaveBeenCalled();
   });
 
-  it("loads another chat session page using the server next offset", () => {
+  it("loads another chat session picker page using the server next offset", async () => {
+    const { state, request } = createChatHeaderState();
+    state.chatSessionPickerOpen = true;
+    state.chatSessionPickerSurface = "desktop";
+    state.chatSessionPickerQuery = "telegram";
+    state.chatSessionPickerAppliedQuery = "telegram";
+    state.chatSessionPickerResult = createSessionsResultFromRows(
+      [
+        { key: "agent:main:telegram-one", kind: "direct", label: "Telegram one", updatedAt: 4 },
+        { key: "agent:main:telegram-two", kind: "direct", label: "Telegram two", updatedAt: 3 },
+      ],
+      {
+        hasMore: true,
+        nextOffset: 50,
+        totalCount: 4,
+      },
+    );
+    const originalSessionsResult = state.sessionsResult;
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const loadMore = container.querySelector<HTMLButtonElement>(
+      'button[data-chat-session-load-more="true"]',
+    );
+    loadMore!.click();
+    await flushTasks();
+
+    expect(state.sessionsResult).toBe(originalSessionsResult);
+    expect(state.chatSessionPickerResult?.sessions.map((row) => row.key)).toEqual([
+      "agent:main:telegram-one",
+      "agent:main:telegram-two",
+      "agent:main:telegram-page-51",
+      "agent:main:telegram-page-52",
+    ]);
+    expect(request).toHaveBeenCalledWith("sessions.list", {
+      configuredAgentsOnly: true,
+      includeGlobal: true,
+      includeUnknown: true,
+      limit: 50,
+      offset: 50,
+      search: "telegram",
+    });
+  });
+
+  it("keeps Escape inside the chat session picker from bubbling", () => {
     const { state } = createChatHeaderState();
-    state.chatSessionSearchAppliedQuery = "telegram";
-    state.sessionsResult = {
+    state.chatSessionPickerOpen = true;
+    state.chatSessionPickerSurface = "mobile";
+    const documentKeydown = vi.fn();
+    document.addEventListener("keydown", documentKeydown);
+    try {
+      const container = document.createElement("div");
+      render(renderChatSessionSelect(state, undefined, { surface: "mobile" }), container);
+      const picker = container.querySelector<HTMLElement>(".chat-session-picker");
+
+      picker!.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+
+      expect(state.chatSessionPickerOpen).toBe(false);
+      expect(documentKeydown).not.toHaveBeenCalled();
+    } finally {
+      document.removeEventListener("keydown", documentKeydown);
+    }
+  });
+
+  it("renders picker pagination controls inside the popover", () => {
+    const { state } = createChatHeaderState();
+    state.chatSessionPickerOpen = true;
+    state.chatSessionPickerSurface = "desktop";
+    state.chatSessionPickerResult = {
       ...state.sessionsResult!,
       totalCount: 125,
       limitApplied: 50,
@@ -1227,19 +1360,12 @@ describe("chat session controls", () => {
     const container = document.createElement("div");
     render(renderChatSessionSelect(state), container);
 
-    const loadMore = container.querySelector<HTMLButtonElement>(
-      'button[data-chat-session-load-more="true"]',
+    expect(container.querySelector(".chat-session-picker")).toBeInstanceOf(HTMLElement);
+    expect(container.querySelector(".chat-session-picker__footer")?.textContent).toContain(
+      "1 / 125",
     );
-    loadMore!.click();
-
-    expect(loadSessionsMock).toHaveBeenCalledWith(
-      state,
-      expect.objectContaining({
-        limit: 50,
-        offset: 50,
-        append: true,
-        search: "telegram",
-      }),
+    expect(container.querySelector('button[data-chat-session-load-more="true"]')).toBeInstanceOf(
+      HTMLButtonElement,
     );
   });
 
@@ -1345,13 +1471,12 @@ describe("chat session controls", () => {
     const container = document.createElement("div");
     render(renderChatSessionSelect(state), container);
 
-    const sessionSelect = container.querySelector<HTMLSelectElement>(
-      'select[data-chat-session-select="true"]',
+    const sessionTrigger = container.querySelector<HTMLButtonElement>(
+      'button[data-chat-session-select="true"]',
     );
 
-    expect(sessionSelect?.value).toBe("agent:main:main");
-    expect([...sessionSelect!.options].map((option) => option.value)).toEqual(["agent:main:main"]);
-    expect(sessionSelect?.selectedOptions[0]?.textContent?.trim()).toBe("main");
+    expect(sessionTrigger?.textContent).toContain("Main Session");
+    expect(sessionTrigger?.disabled).toBe(false);
   });
 
   it("patches the current session model and refreshes active tool visibility", async () => {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1261,12 +1261,13 @@ describe("chat session controls", () => {
 
     input!.value = " telegram ";
     input!.dispatchEvent(new Event("input", { bubbles: true }));
-    submit!.click();
-    await flushTasks();
+    expect(state.chatSessionPickerQuery).toBe(" telegram ");
+    expect(submit?.disabled).toBe(false);
+    submit!.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    await vi.waitFor(() => expect(state.chatSessionPickerAppliedQuery).toBe("telegram"));
     render(renderChatSessionSelect(state), container);
 
     expect(state.chatSessionPickerQuery).toBe(" telegram ");
-    expect(state.chatSessionPickerAppliedQuery).toBe("telegram");
     expect(state.sessionsResult).toBe(originalSessionsResult);
     expect(state.chatSessionPickerResult?.sessions.map((row) => row.key)).toEqual([
       "agent:main:telegram-one",
@@ -1306,8 +1307,9 @@ describe("chat session controls", () => {
     const loadMore = container.querySelector<HTMLButtonElement>(
       'button[data-chat-session-load-more="true"]',
     );
-    loadMore!.click();
-    await flushTasks();
+    expect(loadMore?.disabled).toBe(false);
+    loadMore!.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    await vi.waitFor(() => expect(state.chatSessionPickerResult?.sessions).toHaveLength(4));
 
     expect(state.sessionsResult).toBe(originalSessionsResult);
     expect(state.chatSessionPickerResult?.sessions.map((row) => row.key)).toEqual([

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -339,6 +339,9 @@ function createChatHeaderState(
     sessionKey: "main",
     connected: true,
     sessionsHideCron: true,
+    sessionsIncludeGlobal: true,
+    sessionsIncludeUnknown: false,
+    sessionsShowArchived: false,
     sessionsResult: createSessionsListResult({
       model: currentModel,
       modelProvider: currentModelProvider,
@@ -1246,6 +1249,8 @@ describe("chat session controls", () => {
 
   it("searches chat sessions inside the picker without replacing recent sessions", async () => {
     const { state, request } = createChatHeaderState();
+    state.sessionsIncludeGlobal = false;
+    state.sessionsIncludeUnknown = false;
     const originalSessionsResult = state.sessionsResult;
     const container = document.createElement("div");
     render(renderChatSessionSelect(state), container);
@@ -1285,6 +1290,8 @@ describe("chat session controls", () => {
 
   it("loads another chat session picker page using the server next offset", async () => {
     const { state, request } = createChatHeaderState();
+    state.sessionsIncludeGlobal = false;
+    state.sessionsIncludeUnknown = false;
     state.chatSessionPickerOpen = true;
     state.chatSessionPickerSurface = "desktop";
     state.chatSessionPickerQuery = "telegram";


### PR DESCRIPTION
## Summary

- Replace the chat session select/search row with a session picker popover anchored to the session trigger.
- Keep picker search and pagination in picker-local state so recent sessions are not rewritten.
- Smooth the picker search controls to one fixed-size search icon button plus a fixed-size clear button, with desktop/mobile CSS regression coverage.

## Verification

- `node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts ui/src/ui/app-render.helpers.browser.test.ts ui/src/styles/chat/layout.test.ts ui/src/styles/layout.mobile.test.ts`
- `node scripts/run-vitest.mjs ui/src/ui/chat/chat-responsive.browser.test.ts ui/src/ui/navigation.browser.test.ts`
- `pnpm format:check -- ui/src/ui/chat/session-controls.ts ui/src/ui/views/chat.test.ts ui/src/styles/chat/layout.css ui/src/styles/layout.mobile.css ui/src/styles/chat/layout.test.ts ui/src/styles/layout.mobile.test.ts`
- `git diff --check`
- `node scripts/run-oxlint.mjs ui/src/ui/chat/session-controls.ts ui/src/ui/views/chat.test.ts ui/src/styles/chat/layout.test.ts ui/src/styles/layout.mobile.test.ts`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-ui.tsbuildinfo`
- `AUTOREVIEW_AUTO_TESTS=0 /Users/aknight/.codex/worktrees/3141/openclaw/.agents/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof

Behavior addressed: Chat session search and pagination now live inside the picker popover and no longer mutate global recent-session state; the picker search icon controls stay fixed-size.

Real environment tested: Local Control UI Vite app at `http://127.0.0.1:5187/chat` with Playwright-injected mocked session data.

Exact steps or command run after this patch: `node /private/tmp/record-chat-picker-video.mjs http://127.0.0.1:5187/chat`

Evidence after fix: Local recording at `/private/tmp/openclaw-chat-picker-video/chat-picker-search-pagination.webm`; picker-state screenshot at `/private/tmp/openclaw-chat-picker-video/chat-picker-search-pagination.png`.

Observed result after fix: The session trigger opens the picker, searching `telegram` returns picker-local results, Load more appends the next page, and the search row uses one stable search icon button with a separate clear button only when needed.

What was not tested: Live Gateway data or the packaged desktop app.
