### PR TITLE
fix(subagents): prevent completed requester replay after delivery failure

### DIFF
--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -2885,7 +2885,9 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       path: "direct",
       reason: "message_tool_delivery_missing",
       error: "completion agent did not use the message tool for message-tool-only delivery",
+      disposition: "permanent_failure",
     });
+    expect(queueEmbeddedAgentMessageWithOutcome).not.toHaveBeenCalled();
   });
 
   it("does not count a different channel target as the requester completion delivery", async () => {
@@ -2918,6 +2920,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       delivered: false,
       path: "direct",
       reason: "message_tool_delivery_missing",
+      disposition: "permanent_failure",
     });
     expect(sendMessage).not.toHaveBeenCalled();
   });

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1228,6 +1228,7 @@ async function sendSubagentAnnounceDirectly(params: {
         path: "direct",
         reason: "message_tool_delivery_missing",
         error: "completion agent did not use the message tool for message-tool-only delivery",
+        disposition: "permanent_failure",
       };
     }
     const hasVisibleCompletionReply = Boolean(

--- a/src/agents/subagent-announce-dispatch.test.ts
+++ b/src/agents/subagent-announce-dispatch.test.ts
@@ -170,6 +170,32 @@ describe("runSubagentAnnounceDispatch", () => {
     ]);
   });
 
+  it("does not fallback-steer after a permanent completion direct failure", async () => {
+    const steer = vi.fn(async () => ({ status: "steered" }) as const);
+    const direct = vi.fn(async () => ({
+      delivered: false,
+      path: "direct" as const,
+      reason: "message_tool_delivery_missing" as const,
+      error: "completion agent did not use the required message tool",
+      disposition: "permanent_failure" as const,
+    }));
+
+    const result = await runSubagentAnnounceDispatch({
+      expectsCompletionMessage: true,
+      steer,
+      direct,
+    });
+
+    expect(direct).toHaveBeenCalledOnce();
+    expect(steer).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      delivered: false,
+      path: "direct",
+      reason: "message_tool_delivery_missing",
+      disposition: "permanent_failure",
+    });
+  });
+
   it("returns direct failure when completion fallback steering cannot deliver", async () => {
     const steer = vi.fn(async () => ({ status: "none" }) as const);
     const direct = vi.fn(async () => ({

--- a/src/agents/subagent-completion-admission.store.test.ts
+++ b/src/agents/subagent-completion-admission.store.test.ts
@@ -223,7 +223,7 @@ describe("atomic subagent completion admission store", () => {
         windowStartedAt: now - 31 * 60_000,
         deadlineAt: now - 60_000,
         suspendedAt: now,
-        suspendedReason: "expiry",
+        suspendedReason: "permanent_failure",
         lastError: "requester unavailable",
         payload: {
           requesterSessionKey: input.task.requesterSessionKey,
@@ -280,7 +280,7 @@ describe("atomic subagent completion admission store", () => {
         status: "suspended",
         disposition: "permanent_failure",
         generation: 1,
-        suspendedReason: "expiry",
+        suspendedReason: "permanent_failure",
       });
       expect(subagentRuns.get(input.subagent.runId)?.completion).toMatchObject({
         resultText: "NO_REPLY",

--- a/src/agents/subagent-registry-cleanup.test.ts
+++ b/src/agents/subagent-registry-cleanup.test.ts
@@ -85,6 +85,22 @@ describe("resolveDeferredCleanupDecision", () => {
     expect(decision).toEqual({ kind: "retry", retryCount: 2, resumeDelayMs: 2_000 });
   });
 
+  it("suspends a permanent completion delivery failure without another automatic attempt", () => {
+    const decision = resolveDecision({
+      entry: makeEntry({
+        expectsCompletionMessage: true,
+        delivery: { status: "pending", disposition: "permanent_failure" },
+      }),
+      activeDescendantRuns: 0,
+    });
+
+    expect(decision).toEqual({
+      kind: "give-up",
+      reason: "permanent_failure",
+      retryCount: 1,
+    });
+  });
+
   it("uses retry backoff for non-completion flows so cleanup can settle after announce failures", () => {
     const decision = resolveDecision({
       entry: makeEntry({

--- a/src/agents/subagent-registry-lifecycle-cleanup-base.ts
+++ b/src/agents/subagent-registry-lifecycle-cleanup-base.ts
@@ -148,15 +148,6 @@ export function createSubagentRegistryLifecycleCleanupBase(
     completion.fallbackResultText = undefined;
     completion.fallbackCapturedAt = undefined;
     params.resumedRuns.delete(args.runId);
-    safeSetSubagentTaskDeliveryStatus({
-      entry: args.entry,
-      deliveryStatus: "failed",
-      deliveryError: getDeliveryLastError(args.entry) ?? args.reason,
-    });
-    safeMarkRequiredCompletionDeliveryBlocked({
-      entry: args.entry,
-      reason: getDeliveryLastError(args.entry) ?? args.reason,
-    });
     logAnnounceGiveUp(args.entry, args.reason);
     markRequesterSettleWakePending(args.entry);
     try {
@@ -169,6 +160,15 @@ export function createSubagentRegistryLifecycleCleanupBase(
       Object.assign(args.entry, previousEntry);
       throw error;
     }
+    safeSetSubagentTaskDeliveryStatus({
+      entry: args.entry,
+      deliveryStatus: "failed",
+      deliveryError: getDeliveryLastError(args.entry) ?? args.reason,
+    });
+    safeMarkRequiredCompletionDeliveryBlocked({
+      entry: args.entry,
+      reason: getDeliveryLastError(args.entry) ?? args.reason,
+    });
     // Suspension is terminal for automatic retries, so it settles this child
     // for requester-drain purposes even though cleanup stays incomplete.
     scheduleRequesterSettleWake(args.runId, args.entry);

--- a/src/agents/subagent-registry-lifecycle-cleanup.ts
+++ b/src/agents/subagent-registry-lifecycle-cleanup.ts
@@ -563,6 +563,21 @@ export function createSubagentRegistryLifecycleCleanup(
           return;
         }
         recordAnnounceDeliveryResult(entry, delivery);
+        if (
+          !delivery.delivered &&
+          delivery.disposition === "permanent_failure" &&
+          shouldSuspendPendingFinalDelivery(entry)
+        ) {
+          latestDeliveryError = formatAnnounceDeliveryError(delivery);
+          ensureDeliveryState(entry).lastError = latestDeliveryError;
+          suspendPendingFinalDelivery({
+            runId,
+            entry,
+            reason: "permanent_failure",
+            error: latestDeliveryError,
+          });
+          return;
+        }
         if (delivery.delivered) {
           const deliveryState = ensureDeliveryState(entry);
           deliveryState.status = "delivered";

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -2756,6 +2756,89 @@ describe("subagent registry lifecycle hardening", () => {
     await waitForLifecycleState(() => expect(entry.cleanupCompletedAt).toBeTypeOf("number"));
   });
 
+  it("suspends permanent delivery failure before stalled announce bookkeeping settles", async () => {
+    const persistOrThrow = vi.fn();
+    const entry = createRunEntry({
+      expectsCompletionMessage: true,
+      retainAttachmentsOnKeep: true,
+    });
+    let releaseAnnounce!: () => void;
+    const announcePending = new Promise<void>((resolve) => {
+      releaseAnnounce = resolve;
+    });
+    const runSubagentAnnounceFlow: LifecycleControllerParams["runSubagentAnnounceFlow"] = vi.fn(
+      async (announceParams) => {
+        announceParams.onDeliveryResult?.({
+          delivered: false,
+          path: "direct",
+          reason: "message_tool_delivery_missing",
+          error: "Requester agent completed without required message-tool delivery evidence.",
+          disposition: "permanent_failure",
+        });
+        await announcePending;
+        return false;
+      },
+    );
+    const controller = createLifecycleController({
+      entry,
+      persistOrThrow,
+      runSubagentAnnounceFlow,
+    });
+
+    await completeRun(controller, entry, { triggerCleanup: true });
+    try {
+      await waitForLifecycleState(() => expect(entry.delivery?.status).toBe("suspended"));
+
+      expect(entry.delivery).toMatchObject({
+        status: "suspended",
+        disposition: "permanent_failure",
+        suspendedReason: "permanent_failure",
+        lastError: "Requester agent completed without required message-tool delivery evidence.",
+        payload: {
+          requesterSessionKey: entry.requesterSessionKey,
+          childSessionKey: entry.childSessionKey,
+          childRunId: entry.runId,
+        },
+      });
+      expect(entry.cleanupHandled).toBe(false);
+      expect(entry.cleanupCompletedAt).toBeUndefined();
+      expect(persistOrThrow).toHaveBeenCalledWith(entry.runId);
+      expectFields(firstCallArg(taskExecutorMocks.setDetachedTaskDeliveryStatusByRunId), {
+        runId: entry.runId,
+        deliveryStatus: "failed",
+      });
+      expect(persistOrThrow.mock.invocationCallOrder[0]).toBeLessThan(
+        taskExecutorMocks.setDetachedTaskDeliveryStatusByRunId.mock.invocationCallOrder[0]!,
+      );
+      expectFields(
+        findCallArg(
+          taskExecutorMocks.completeTaskRunByRunId,
+          (arg) => arg.runId === entry.runId && arg.terminalOutcome === "blocked",
+        ),
+        {
+          runId: entry.runId,
+          terminalOutcome: "blocked",
+        },
+      );
+      const blockedTaskCall = taskExecutorMocks.completeTaskRunByRunId.mock.calls.findIndex(
+        ([arg]) =>
+          (arg as { runId?: string; terminalOutcome?: string } | undefined)?.runId ===
+            entry.runId &&
+          (arg as { terminalOutcome?: string } | undefined)?.terminalOutcome === "blocked",
+      );
+      expect(blockedTaskCall).toBeGreaterThanOrEqual(0);
+      expect(persistOrThrow.mock.invocationCallOrder[0]).toBeLessThan(
+        taskExecutorMocks.completeTaskRunByRunId.mock.invocationCallOrder[blockedTaskCall]!,
+      );
+    } finally {
+      releaseAnnounce();
+    }
+
+    await waitForLifecycleState(() => expect(runSubagentAnnounceFlow).toHaveBeenCalledOnce());
+    expect(entry.delivery?.status).toBe("suspended");
+    expect(entry.cleanupCompletedAt).toBeUndefined();
+  });
+
   it("keeps a late superseded-delivery retirement root-admitted", async () => {
     const entry = createRunEntry({ expectsCompletionMessage: true, generation: 1 });
     const runs = new Map([[entry.runId, entry]]);
@@ -3452,6 +3535,38 @@ describe("subagent registry lifecycle hardening", () => {
         "Required completion delivery failed before reaching the requester: gateway request timeout for agent.",
     });
     expect(persistOrThrow).toHaveBeenCalled();
+  });
+
+  it("does not project a suspended task before the registry latch is durable", async () => {
+    const entry = createRunEntry({
+      endedAt: 4_000,
+      endedReason: SUBAGENT_ENDED_REASON_COMPLETE,
+      expectsCompletionMessage: true,
+      completion: { required: true, resultText: "final answer" },
+      delivery: { status: "pending", lastError: "required delivery failed" },
+      outcome: { status: "ok" },
+      retainAttachmentsOnKeep: true,
+    });
+    const original = structuredClone(entry);
+    const controller = createLifecycleController({
+      entry,
+      persistOrThrow: vi.fn(() => {
+        throw new Error("registry latch failed");
+      }),
+      captureSubagentCompletionReply: vi.fn(async () => undefined),
+    });
+
+    await expect(
+      controller.finalizeResumedAnnounceGiveUp({
+        runId: entry.runId,
+        entry,
+        reason: "permanent_failure",
+      }),
+    ).rejects.toThrow("registry latch failed");
+
+    expect(entry).toEqual(original);
+    expect(taskExecutorMocks.setDetachedTaskDeliveryStatusByRunId).not.toHaveBeenCalled();
+    expect(taskExecutorMocks.completeTaskRunByRunId).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/src/agents/subagent-registry.persistence.resume.test.ts
+++ b/src/agents/subagent-registry.persistence.resume.test.ts
@@ -180,6 +180,72 @@ describe("subagent registry persistence resume", () => {
     });
   });
 
+  it("does not replay a suspended permanent delivery failure after SQLite restart", async () => {
+    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-"));
+    const stateDir = tempStateDir;
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+      const endedAt = Date.now();
+      const run: SubagentRunRecord = {
+        runId: "run-suspended-permanent-failure",
+        childSessionKey: "agent:main:subagent:suspended-permanent-failure",
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        task: "preserve replay-safe delivery failure",
+        cleanup: "keep",
+        createdAt: endedAt - 1_000,
+        endedReason: "subagent-complete",
+        execution: {
+          status: "terminal",
+          startedAt: endedAt - 500,
+          endedAt,
+          outcome: { status: "ok" },
+        },
+        expectsCompletionMessage: true,
+        completion: { required: true, resultText: "done", capturedAt: endedAt },
+        delivery: {
+          status: "suspended",
+          disposition: "permanent_failure",
+          suspendedAt: endedAt,
+          suspendedReason: "permanent_failure",
+          lastError: "completion agent did not use the required message tool",
+          payload: {
+            requesterSessionKey: "agent:main:main",
+            requesterDisplayKey: "main",
+            childSessionKey: "agent:main:subagent:suspended-permanent-failure",
+            childRunId: "run-suspended-permanent-failure",
+            task: "preserve replay-safe delivery failure",
+            startedAt: endedAt - 500,
+            endedAt,
+            outcome: { status: "ok" },
+            expectsCompletionMessage: true,
+          },
+        },
+        cleanupHandled: false,
+      };
+      saveSubagentRegistryToSqlite(new Map([[run.runId, run]]));
+      await writeSubagentSessionEntry({
+        stateDir,
+        agentId: "main",
+        sessionKey: run.childSessionKey,
+        sessionId: "sess-suspended-permanent-failure",
+        defaultSessionId: "sess-suspended-permanent-failure",
+      });
+
+      mod.initSubagentRegistry();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(announceSpy).not.toHaveBeenCalled();
+      expect(callGatewayModule.callGateway).not.toHaveBeenCalled();
+      expect(mod.getSubagentRunByRunId(run.runId)?.delivery).toMatchObject({
+        status: "suspended",
+        disposition: "permanent_failure",
+        suspendedReason: "permanent_failure",
+        payload: { childRunId: run.runId },
+      });
+    });
+  });
+
   it.each([false, true])(
     "settles a restored steered requester turn (yielded: %s)",
     async (requesterYielded) => {

--- a/src/agents/subagent-registry.store.sqlite.test.ts
+++ b/src/agents/subagent-registry.store.sqlite.test.ts
@@ -227,6 +227,14 @@ describe("subagent registry sqlite store", () => {
           batchRunIds: ["run-one"],
         },
       });
+      run.delivery = {
+        ...run.delivery!,
+        status: "suspended",
+        disposition: "permanent_failure",
+        suspendedAt: 290,
+        suspendedReason: "permanent_failure",
+        lastError: "required message-tool delivery missing",
+      };
       saveSubagentRegistryToSqlite(new Map([[run.runId, run]]));
 
       const { db } = openOpenClawStateDatabase();
@@ -249,12 +257,18 @@ describe("subagent registry sqlite store", () => {
       const restored = loadSubagentRegistryFromSqlite().get(run.runId);
       expect(restored?.expectsCompletionMessage).toBe(true);
       expect(restored?.completion?.resultText).toBe("done");
-      expect(restored?.delivery).toMatchObject({ status: "pending", lastError: "retry later" });
+      expect(restored?.delivery).toMatchObject({
+        status: "suspended",
+        disposition: "permanent_failure",
+        suspendedAt: 290,
+        suspendedReason: "permanent_failure",
+        lastError: "required message-tool delivery missing",
+      });
       expect(restored?.requesterSettleWake).toEqual(run.requesterSettleWake);
       expect(restored?.execution.outcome?.status).toBe("ok");
       const sessionListRun = loadSubagentSessionListRunsFromSqlite().get(run.runId);
       expect(sessionListRun?.execution.outcome?.status).toBe("ok");
-      expect(sessionListRun?.delivery?.status).toBe("pending");
+      expect(sessionListRun?.delivery?.status).toBe("suspended");
     });
   });
 

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -5489,6 +5489,58 @@ describe("subagent registry seam flow", () => {
     });
   });
 
+  it("suspends missing message-tool delivery without replaying the requester turn", async () => {
+    const runId = "run-message-tool-delivery-missing";
+    const endedAt = Date.parse("2026-03-24T12:00:00Z");
+    mocks.runSubagentAnnounceFlow.mockImplementationOnce(async (...args: unknown[]) => {
+      const params = args[0] as {
+        onDeliveryResult?: (delivery: {
+          delivered: false;
+          path: "direct";
+          reason: "message_tool_delivery_missing";
+          error: string;
+          disposition: "permanent_failure";
+        }) => void;
+      };
+      params.onDeliveryResult?.({
+        delivered: false,
+        path: "direct",
+        reason: "message_tool_delivery_missing",
+        error: "completion agent did not use the message tool for message-tool-only delivery",
+        disposition: "permanent_failure",
+      });
+      return false;
+    });
+    mocks.callGateway.mockResolvedValueOnce({
+      status: "ok",
+      startedAt: endedAt - 500,
+      endedAt,
+    });
+
+    mod.registerSubagentRun({
+      runId,
+      task: "message-tool completion delivery",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await waitForFast(() => {
+      expect(findRequesterRun(runId)?.delivery).toMatchObject({
+        status: "suspended",
+        disposition: "permanent_failure",
+        suspendedReason: "permanent_failure",
+      });
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+
+    mod.resumeSubagentRun(runId);
+    await vi.advanceTimersByTimeAsync(30 * 60_000);
+
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    expect(findRequesterRun(runId)?.cleanupCompletedAt).toBeUndefined();
+  });
+
   it("retries and retires completion delete runs regardless of prior attempt count", async () => {
     const endedHookRunner = {
       hasHooks: (hookName: string) => hookName === "subagent_ended",


### PR DESCRIPTION
## Summary

Prevent a completed requester from running tools again when its subagent completion turn omits required message-tool delivery evidence. This updates DolencLuka's original fix to the maintained subagent owners and preserves the contributor's original commit ancestry.

- Classify a completed missing-message receipt as a permanent delivery failure; do not fall through to another requester execution.
- Atomically retain the recoverable suspended completion and task projection at the result callback, before the announce tail finishes.
- Fence ordinary settle wakes, including wakes delayed in asynchronous admission and persisted wakes after restart.
- Preserve accepted/in-flight/yielded handoffs, genuine yield-batch work, the payload, and explicit retry/dismissal.
- Keep `payload_json` authoritative. No schema, dependency, public API, message-tool bypass, retention policy, or sibling startup-recovery change.

## Reproduction and observed fix

Qualification uses isolated, no-role AWS Crabbox with no credential hydration. Product source was pinned to `e53f50fbecad54000a499602062738794e586700`, then overlaid with this candidate. Final publication binds every changed file to the qualified/reviewed afterimage. The final mock type annotations/formatting preserve assertions. A subsequent consolidation of duplicated handoff guards preserves the original conditions and branch order; it received its own independent review and focused branch qualification. Exact-head hosted CI and native preparation are separate required gates.

| Scenario | Unmodified production baseline | Fixed observation |
| --- | --- | --- |
| Lifecycle result callback while announce tail is held | Two regressions failed: delivery still pending at the callback | Suspended permanent failure and retained payload already durable; task execution succeeded, terminal outcome blocked, delivery failed |
| Direct delivery and legitimate pending controls | Missing-message terminal classification and unresolved-yield assertions failed; accepted/in-flight controls passed | All four selected cases passed; completed work cannot fall through, genuine pending work is preserved |
| Real Gateway requester tool and restart | Requester performed the append, but SQLite delivery stayed pending instead of suspended | One real `exec` append; suspended delivery, retained child result/payload; SQLite reopen and shipped Gateway restart with explicit follow-up do not repeat the effect |
| Explicit retry and dismissal | Existing recovery controls retained | Both remain available after lifecycle-produced suspension and reopen |
| Wake delayed on admission | Ordering gap covered by lifecycle regression | Recheck suppresses stale ordinary wake; a genuine yield batch remains allowed |

### Inspectable scenario result

Fixed Gateway broker run `run_cf6a217447d7` on lease `cbx_f2ddde34944b` returned exit 0. Vitest report: **1 passed, 0 failed**, assertion duration 15.729 seconds. These are the executed scenario assertions, not a separate simulation:

```text
requester tool: real exec appends "effect\n" to replay-effects.txt
child: execution terminal, outcome ok, result CHILD_REPLAY_RESULT retained
delivery: suspended / permanent_failure / message_tool_delivery_missing
payload: retained; ordinary requesterSettleWake absent
model fixture failures: []
requester effect count before restart: 1
SQLite close/reopen: delivery unchanged
shipped Gateway restart + explicit follow-up: success
requester effect count after restart: 1
file bytes after restart: "effect\n"
retained delivery after restart: unchanged
```

Source assertions: [real Gateway scenario](https://github.com/openclaw/openclaw/blob/e0155c75818095354dbbbb1c5b4d3683c31bc474/test/gateway-completion-replay.e2e.test.ts#L35), [lifecycle/atomicity/recovery scenarios](https://github.com/openclaw/openclaw/blob/e0155c75818095354dbbbb1c5b4d3683c31bc474/src/agents/subagents/completion/subagent-completion-replay.test.ts).

Original distinct focused coverage: **4 lifecycle + 4 direct/pending controls + 1 Gateway = 9 passing cases**. Subsequent handoff-consolidation qualification: **50 passed, 0 failed** in the selected direct/pending/settled/yielded/failed-continuation cases (overlap is not double-counted). The first fixed lifecycle run had 3 passes and one test-contract failure; only that failed case was rerun after correcting `status: succeeded` versus `terminalOutcome: blocked`. Historical failed attempts and zero-selected/fixture failures are retained, not counted as proof. No baseline or lifecycle/Gateway passes were replayed just for integration; the changed handoff branch received the necessary focused requalification.

Required changed-file checks: **passed across all 33 declared gates**; the retained full run passed 32 and failed only final root-test lint, whose six mechanical issues were corrected and passed targeted root lint/typing. Earlier failed attempts remain recorded. Independent security/source review and test-delta review are scoped-clean. Fresh exact-head CI/ClawSweeper and native LAND verification remain required.

### Limits

The deterministic local HTTP model controls the scenario; the requester `exec`, child lifecycle, SQLite owners, and shipped Gateway restart are real. This is not an authenticated external model/channel delivery or UI test. It proves no repeated requester tool effect for this failure path, not global exactly-once delivery. User-requested retry remains explicitly possible and carries existing duplicate-risk semantics.

## Release-note impact

Subagent completions that finish requester execution without required message-tool evidence stay recoverably blocked instead of replaying requester tools automatically. Credit: **DolencLuka**. `CHANGELOG.md` remains release-owned and untouched.

<details>
<summary>Historical contributor description and proof (original head 44d14a34; not current-head execution)</summary>

## Summary
- classify missing required message-tool evidence as a permanent completion-delivery failure after the requester turn has already run
- atomically persist the canonical suspended-delivery state before projecting blocked/failed task status
- prevent restart from replaying requester orchestration while preserving the payload for explicit recovery or dismissal
- keep `payload_json` authoritative; do not restore parallel wake/visible fields or typed-column hydration

## What problem this solves
For group/channel subagent completions, visible replies must still go through the message tool. If the requester completion turn already ran but omitted required message-tool evidence, replaying that whole turn can repeat arbitrary tools, tasks, or messages.

Current `main` already owns a canonical suspended `permanent_failure` state and explicit recovery/dismissal flow. This port latches the missing-delivery result into that owner boundary so restart cannot re-run requester orchestration.

## Delivery contract
- missing required message-tool evidence returns `disposition: "permanent_failure"`
- direct dispatch does not fall through to steer/replay for that disposition
- lifecycle persistence succeeds before non-rollbackable task projection
- the completion remains `suspended` with its pending payload retained
- restart skips automatic requester delivery for the suspended record
- explicit recovery or dismissal remains available through the existing current-main flow
- `payload_json` remains the only authoritative persisted delivery state
- no direct-send fallback or message-tool policy bypass is added

## Evidence

### Exact-head restart and SQLite proof

**Head:** `44d14a34a6da5e2dab59f668288c4a7e5dff5222`  
**Base:** `aa7cf44c75a123a2724f20b05cd10d66cf7e65f3` (`openclaw/openclaw:main`)  
**Relationship:** base is an ancestor; branch is one commit ahead.

The exact checkout exercised production delivery, lifecycle, task projection, restart admission, and SQLite persistence code. The restart integration closes and reopens the SQLite-backed registry, then verifies that requester delivery and Gateway delivery are not called again.

Redacted assertion summary:

```text
PASS exactHead=44d14a34a6da5e2dab59f668288c4a7e5dff5222
messageToolMissing disposition=permanent_failure delivered=false
dispatch steerFallback=false
suspend persistedBeforeTaskProjection=true rollbackOnPersistFailure=true
delivery status=suspended disposition=permanent_failure payloadPreserved=true
sqliteRestart requesterReplayCount=0 gatewayDeliveryCount=0
sqliteAuthority payload_json=true typedColumnRevival=false
recovery explicitRetryAvailable=true explicitDiscardAvailable=true
directSendBypass=false
```

The predecessor head also had an isolated production-Gateway proof of the no-replay failure class. This current-main port changes the persistence owner—not the safety goal—and adds exact-head restart coverage at the canonical suspended-delivery boundary requested in review.

### Verification
- focused exact-head Vitest: **479 passed / 479** across unit-fast and agents-core shards
- exact-head formatting: **passed** for all 11 changed files
- production type check (`tsconfig.core.json`): **passed**
- core-test type check (`test/tsconfig/tsconfig.core.test.json`): **passed**
- `git diff --check`: **passed**
- structured autoreview: **no findings**, patch correct at 0.97 confidence
- independent final invariant audit: **PASS**
- worktree: **clean**

Hosted CI for this refreshed head is running and remains authoritative for the full repository matrix.

## Review findings addressed
- **Use the canonical suspended delivery state:** done; no parallel requester-wake/visible-delivery field model remains.
- **Do not restore typed-column delivery hydration:** done; `payload_json` remains authoritative.
- **Persist before task projection:** done; persistence failure rolls the in-memory entry back before external task writes.
- **Prove restart does not replay:** done with exact-head SQLite close/reopen coverage.

## Scope
- subagent completion delivery classification
- suspended-delivery lifecycle ordering
- focused task/restart/SQLite regression coverage
- no dependency, schema, direct-channel-send, release-note, or unrelated cleanup change


</details>

## Prerequisite integration

Signed head `89f6cfd8f3a5cf840742a1c258574507473c03d7` integrates main `ed264cc3ca59b51648a366d7ed86df9e58c76390`, including canonical fixture repairs #149020 and #149049 by @vincentkoc. All 12 replay-fix afterimage Git blobs and SHA256s are unchanged from the reviewed/published `e0155c75` candidate; original contributor ancestry and focused proof are retained.

The preceding CI run [34964825167](https://github.com/openclaw/openclaw/actions/runs/34964825167) recorded the thinking-route auth fixture failure, the model-catalog root-work assertion, and two checkout timeouts before tests. Those failed attempts are preserved, not relabeled as passing. The integrated head requires its own hosted review/CI and native landing gates; no standalone baseline or passing focused proof was replayed for this integration.
