### PR TITLE
fix(auth-profiles): break self-reinforcing session auth override loop (#85126)

### DIFF
--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -1,6 +1,7 @@
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import { resolveAgentConfig, resolveSessionAgentId } from "../agent-scope.js";
 import {
   isConfiguredAwsSdkAuthProfileForProvider,
   isStoredCredentialCompatibleWithAuthProvider,
@@ -159,6 +160,34 @@ export async function resolveSessionAuthProfileOverride(params: {
   if (current && order.length > 0 && !order.includes(current) && source !== "user") {
     await clearSessionAuthProfileOverride({ sessionEntry, sessionStore, sessionKey, storePath });
     current = undefined;
+  }
+
+  // When the override was set automatically (via fallback) and the current
+  // run's provider differs from the agent's configured default model provider,
+  // include the default provider's auth profiles in the order list. This
+  // prevents a fallback from permanently locking the session to the fallback
+  // provider's auth profile (https://github.com/openclaw/openclaw/issues/85126).
+  if (source === "auto") {
+    const sessionAgentId = resolveSessionAgentId({ config: cfg, sessionKey });
+    const agentCfg = resolveAgentConfig(cfg, sessionAgentId);
+    const rawModel: string | { primary?: string } | undefined =
+      agentCfg?.model ?? cfg.agents?.defaults?.model;
+    const agentPrimary =
+      typeof rawModel === "string"
+        ? rawModel
+        : rawModel && typeof rawModel === "object" && "primary" in rawModel
+          ? (rawModel as { primary: string }).primary
+          : undefined;
+    if (agentPrimary) {
+      const agentProvider = agentPrimary.split("/")[0];
+      if (agentProvider && agentProvider !== provider) {
+        const agentOrder = resolveAuthProfileOrder({ cfg, store, provider: agentProvider });
+        if (agentOrder.length > 0) {
+          // Prepend default provider's order so it's preferred over the fallback's
+          order.splice(0, order.length, ...new Set([...agentOrder, ...order]));
+        }
+      }
+    }
   }
 
   if (order.length === 0) {


### PR DESCRIPTION
## Description

Fixes a self-reinforcing loop in `resolveSessionAuthProfileOverride` that permanently pins a session to the wrong auth profile after a fallback occurs.

### Root Cause

When a session falls back from its configured primary provider to a fallback (e.g., MiniMax → DeepSeek), the session entry stores the fallback provider's auth profile override (e.g., `deepseek:default`) with `source: "auto"`. On every subsequent turn, `resolveSessionAuthProfileOverride` builds the auth profile order exclusively from the **current run's provider** (the fallback, e.g., `deepseek`), never from the agent's configured **default model provider** (e.g., `minimax`). Since the fallback's auth profile is valid for the fallback provider's order, the clearing logic never fires, and the session is permanently stuck.

### Fix

When `source === "auto"` (the override was set automatically via fallback), also include the agent's configured default model provider's auth profiles in the order list by prepending them. This allows the `pickFirstAvailable` / `pickNextAvailable` logic to find and prefer the default model's auth profile when it's available, breaking the self-reinforcing loop.

### Testing

- For an agent configured with `minimax/MiniMax-M2.7` as primary and `deepseek/deepseek-v4-flash` as fallback:
  - Before: After the first fallback to DeepSeek, the session permanently pins to `deepseek:default`. Auth order is `["deepseek:default"]` → no alternative to pick.
  - After: Auth order becomes `["minimax:global", "deepseek:default"]`. On re-resolution, `pickFirstAvailable` finds `minimax:global` and switches back.

### Related

Fixes #85126 (supersedes the narrower issue description)
Related: #62412, #62710 (unmerged)
