### PR TITLE
fix(cli-runner): preserve claude-cli conversation history across session reseed

### DIFF
--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -446,8 +446,15 @@ export async function prepareCliRunContext(
     prompt: preparedPrompt,
   });
   preparedPrompt = annotateInterSessionPromptText(preparedPrompt, params.inputProvenance);
+  // A CLI session invalidated for auth/system-prompt/mcp/transcript reasons has
+  // no reusable sessionId; without a raw-transcript reseed the fresh run starts
+  // with zero history. Force reseed in that case regardless of the opt-in flag —
+  // silently losing the whole conversation must never be the default outcome of
+  // an auth-profile / auth-epoch rotation.
+  const cliSessionInvalidated =
+    !reusableCliSession.sessionId && reusableCliSession.invalidatedReason !== undefined;
   const allowRawTranscriptReseed =
-    backendResolved.config.reseedFromRawTranscriptWhenUncompacted === true;
+    backendResolved.config.reseedFromRawTranscriptWhenUncompacted === true || cliSessionInvalidated;
   const rawTranscriptReseedReason = reusableCliSession.sessionId
     ? "session-expired"
     : reusableCliSession.invalidatedReason;

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -57,7 +57,9 @@ import { buildCliAgentSystemPrompt, normalizeCliModel } from "./helpers.js";
 import { cliBackendLog } from "./log.js";
 import {
   buildCliSessionHistoryPrompt,
+  cliReseedMessagesLookThin,
   hasCliSessionTranscript,
+  loadClaudeCliReseedMessages,
   loadCliSessionHistoryMessages,
   loadCliSessionReseedMessages,
 } from "./session-history.js";
@@ -77,6 +79,9 @@ const prepareDeps = {
   // Surfaced as a dep so tests can stub the on-disk Claude CLI transcript probe
   // without touching ~/.claude/projects.
   claudeCliSessionTranscriptHasContent,
+  // Surfaced as a dep so tests can stub the Claude CLI transcript reseed
+  // fallback without touching ~/.claude/projects.
+  loadClaudeCliReseedMessages,
 };
 
 export function setCliRunnerPrepareTestDeps(overrides: Partial<typeof prepareDeps>): void {
@@ -460,17 +465,37 @@ export async function prepareCliRunContext(
     : reusableCliSession.invalidatedReason;
   const shouldPrepareOpenClawHistoryPrompt =
     !reusableCliSession.sessionId || allowRawTranscriptReseed;
+  let reseedMessages = shouldPrepareOpenClawHistoryPrompt
+    ? await loadCliSessionReseedMessages({
+        sessionId: params.sessionId,
+        sessionFile: params.sessionFile,
+        sessionKey: params.sessionKey,
+        agentId: params.agentId,
+        config: params.config,
+        allowRawTranscriptReseed,
+        rawTranscriptReseedReason,
+      })
+    : [];
+  // The OpenClaw-side transcript for a claude-cli run often holds only
+  // assistant turns plus internal runtime-event prompts. When it is missing
+  // or one-sided, fall back to the Claude CLI's own on-disk transcript — the
+  // authoritative turn-by-turn record — so the fresh run keeps real context.
+  if (
+    shouldPrepareOpenClawHistoryPrompt &&
+    isClaudeCliProvider(params.provider) &&
+    candidateClaudeCliSessionId &&
+    cliReseedMessagesLookThin(reseedMessages)
+  ) {
+    const claudeReseedMessages = prepareDeps.loadClaudeCliReseedMessages({
+      claudeCliSessionId: candidateClaudeCliSessionId,
+    });
+    if (claudeReseedMessages.length > 0) {
+      reseedMessages = claudeReseedMessages;
+    }
+  }
   const openClawHistoryPrompt = shouldPrepareOpenClawHistoryPrompt
     ? buildCliSessionHistoryPrompt({
-        messages: await loadCliSessionReseedMessages({
-          sessionId: params.sessionId,
-          sessionFile: params.sessionFile,
-          sessionKey: params.sessionKey,
-          agentId: params.agentId,
-          config: params.config,
-          allowRawTranscriptReseed,
-          rawTranscriptReseedReason,
-        }),
+        messages: reseedMessages,
         prompt: preparedPrompt,
       })
     : undefined;

--- a/src/agents/cli-runner/session-history.test.ts
+++ b/src/agents/cli-runner/session-history.test.ts
@@ -460,7 +460,7 @@ describe("loadCliSessionReseedMessages", () => {
     }
   });
 
-  it("does not raw-reseed auth-boundary invalidations even when opted in", async () => {
+  it("raw-reseeds auth-boundary invalidations so context survives an auth rotation", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-state-"));
     vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
     const sessionFile = createSessionTranscript({
@@ -470,26 +470,18 @@ describe("loadCliSessionReseedMessages", () => {
     });
 
     try {
-      await expect(
-        loadCliSessionReseedMessages({
+      for (const reason of ["auth-profile", "auth-epoch"] as const) {
+        const reseed = await loadCliSessionReseedMessages({
           sessionId: "session-auth-boundary",
           sessionFile,
           sessionKey: "agent:main:main",
           agentId: "main",
           allowRawTranscriptReseed: true,
-          rawTranscriptReseedReason: "auth-profile",
-        }),
-      ).resolves.toStrictEqual([]);
-      await expect(
-        loadCliSessionReseedMessages({
-          sessionId: "session-auth-boundary",
-          sessionFile,
-          sessionKey: "agent:main:main",
-          agentId: "main",
-          allowRawTranscriptReseed: true,
-          rawTranscriptReseedReason: "auth-epoch",
-        }),
-      ).resolves.toStrictEqual([]);
+          rawTranscriptReseedReason: reason,
+        });
+        expect(reseed).toHaveLength(1);
+        expectMessageFields(reseed[0], { role: "user", content: "previous account context" });
+      }
     } finally {
       fs.rmSync(stateDir, { recursive: true, force: true });
     }
@@ -575,15 +567,19 @@ describe("buildCliSessionHistoryPrompt", () => {
     ).toBeUndefined();
   });
 
-  it("caps rendered reseed history before adding the next user message", () => {
+  it("caps rendered reseed history and keeps the most recent turns", () => {
     const prompt = buildCliSessionHistoryPrompt({
-      messages: [{ role: "compactionSummary", summary: "x".repeat(100) }],
+      messages: [
+        { role: "user", content: `stale opening ${"x".repeat(200)}` },
+        { role: "assistant", content: [{ type: "text", text: "RECENT_ANSWER_MARKER" }] },
+      ],
       prompt: "current ask must survive",
-      maxHistoryChars: 20,
+      maxHistoryChars: 60,
     });
 
-    expect(prompt).toContain("[OpenClaw reseed history truncated]");
+    expect(prompt).toContain("[OpenClaw reseed history truncated");
+    expect(prompt).toContain("RECENT_ANSWER_MARKER");
     expect(prompt).toContain("<next_user_message>\ncurrent ask must survive\n</next_user_message>");
-    expect(prompt).not.toContain("x".repeat(80));
+    expect(prompt).not.toContain("stale opening");
   });
 });

--- a/src/agents/cli-runner/session-history.test.ts
+++ b/src/agents/cli-runner/session-history.test.ts
@@ -5,6 +5,7 @@ import { CURRENT_SESSION_VERSION } from "@earendil-works/pi-coding-agent";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildCliSessionHistoryPrompt,
+  cliReseedMessagesLookThin,
   hasCliSessionTranscript,
   loadCliSessionContextEngineMessages,
   loadCliSessionHistoryMessages,
@@ -581,5 +582,39 @@ describe("buildCliSessionHistoryPrompt", () => {
     expect(prompt).toContain("RECENT_ANSWER_MARKER");
     expect(prompt).toContain("<next_user_message>\ncurrent ask must survive\n</next_user_message>");
     expect(prompt).not.toContain("stale opening");
+  });
+});
+
+describe("cliReseedMessagesLookThin", () => {
+  it("treats an empty reseed as thin", () => {
+    expect(cliReseedMessagesLookThin([])).toBe(true);
+  });
+
+  it("treats an assistant-only transcript as thin (one-sided)", () => {
+    expect(
+      cliReseedMessagesLookThin([
+        { role: "assistant", content: "a1" },
+        { role: "assistant", content: "a2" },
+      ]),
+    ).toBe(true);
+  });
+
+  it("treats a user-only transcript as thin (one-sided)", () => {
+    expect(cliReseedMessagesLookThin([{ role: "user", content: "u1" }])).toBe(true);
+  });
+
+  it("treats a two-sided transcript as not thin", () => {
+    expect(
+      cliReseedMessagesLookThin([
+        { role: "user", content: "u1" },
+        { role: "assistant", content: "a1" },
+      ]),
+    ).toBe(false);
+  });
+
+  it("treats a compaction summary as not thin even on its own", () => {
+    expect(
+      cliReseedMessagesLookThin([{ role: "compactionSummary", summary: "prior context" }]),
+    ).toBe(false);
   });
 });

--- a/src/agents/cli-runner/session-history.ts
+++ b/src/agents/cli-runner/session-history.ts
@@ -16,7 +16,7 @@ import {
 
 export const MAX_CLI_SESSION_HISTORY_FILE_BYTES = 5 * 1024 * 1024;
 export const MAX_CLI_SESSION_HISTORY_MESSAGES = MAX_AGENT_HOOK_HISTORY_MESSAGES;
-export const MAX_CLI_SESSION_RESEED_HISTORY_CHARS = 12 * 1024;
+export const MAX_CLI_SESSION_RESEED_HISTORY_CHARS = 64 * 1024;
 
 type HistoryMessage = {
   role?: unknown;
@@ -47,6 +47,8 @@ type RawTranscriptReseedReason =
   | "session-expired";
 
 const RAW_TRANSCRIPT_RESEED_ALLOWED_REASONS = new Set<RawTranscriptReseedReason>([
+  "auth-profile",
+  "auth-epoch",
   "missing-transcript",
   "system-prompt",
   "mcp",
@@ -145,9 +147,14 @@ export function buildCliSessionHistoryPrompt(params: {
     })
     .join("\n\n")
     .trim();
+  // Keep the most recent turns when truncating: continuity needs the tail of
+  // the conversation, not its opening. Slicing from the start would drop the
+  // freshest context and preserve only stale history.
   const renderedHistory =
     renderedHistoryRaw.length > maxHistoryChars
-      ? `${renderedHistoryRaw.slice(0, maxHistoryChars).trimEnd()}\n[OpenClaw reseed history truncated]`
+      ? `[OpenClaw reseed history truncated — oldest turns dropped]\n${renderedHistoryRaw
+          .slice(renderedHistoryRaw.length - maxHistoryChars)
+          .trimStart()}`
       : renderedHistoryRaw;
 
   if (!renderedHistory) {

--- a/src/agents/cli-runner/session-history.ts
+++ b/src/agents/cli-runner/session-history.ts
@@ -7,6 +7,7 @@ import {
   resolveSessionFilePathOptions,
 } from "../../config/sessions/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { readClaudeCliFallbackSeed } from "../../gateway/cli-session-history.js";
 import { isPathInside } from "../../infra/path-guards.js";
 import { resolveSessionAgentIds } from "../agent-scope.js";
 import {
@@ -379,4 +380,63 @@ export async function loadCliSessionReseedMessages(params: {
     },
     ...limitAgentHookHistoryMessages(tailMessages, MAX_CLI_SESSION_HISTORY_MESSAGES - 1),
   ];
+}
+
+/**
+ * A reseed message set is "thin" when it cannot anchor a continued
+ * conversation: empty, or one-sided (only user OR only assistant turns).
+ * The OpenClaw session transcript for a claude-cli run frequently holds only
+ * assistant outputs plus internal runtime-event prompts, so a reseed built
+ * from it alone leaves the fresh CLI session without the real user turns.
+ */
+export function cliReseedMessagesLookThin(messages: unknown[]): boolean {
+  if (messages.length === 0) {
+    return true;
+  }
+  let hasUser = false;
+  let hasAssistant = false;
+  for (const message of messages) {
+    const role = (message as { role?: unknown } | null)?.role;
+    if (role === "compactionSummary") {
+      // A compaction summary already encodes both sides of the conversation.
+      return false;
+    }
+    if (role === "user") {
+      hasUser = true;
+    } else if (role === "assistant") {
+      hasAssistant = true;
+    }
+  }
+  return !(hasUser && hasAssistant);
+}
+
+/**
+ * Reseed history reconstructed from the Claude CLI's own on-disk transcript
+ * (`~/.claude/projects/<dir>/<cliSessionId>.jsonl`) — the authoritative
+ * turn-by-turn record. Used as a fallback when the OpenClaw-side transcript
+ * is missing or one-sided. Returns the shape `buildCliSessionHistoryPrompt`
+ * consumes, mirroring `loadCliSessionReseedMessages`.
+ */
+export function loadClaudeCliReseedMessages(params: {
+  claudeCliSessionId?: string;
+  homeDir?: string;
+}): unknown[] {
+  const cliSessionId = params.claudeCliSessionId?.trim();
+  if (!cliSessionId) {
+    return [];
+  }
+  const seed = readClaudeCliFallbackSeed({
+    cliSessionId,
+    ...(params.homeDir ? { homeDir: params.homeDir } : {}),
+  });
+  if (!seed) {
+    return [];
+  }
+  const tail = limitAgentHookHistoryMessages(
+    seed.recentTurns as unknown[],
+    seed.summaryText ? MAX_CLI_SESSION_HISTORY_MESSAGES - 1 : MAX_CLI_SESSION_HISTORY_MESSAGES,
+  );
+  return seed.summaryText
+    ? [{ role: "compactionSummary", summary: seed.summaryText }, ...tail]
+    : tail;
 }


### PR DESCRIPTION
## Summary
- **Problem:** When a `claude-cli` session is invalidated (auth-profile / auth-epoch rotation, system-prompt or MCP change), the fresh CLI run was reseeded with empty or one-sided history — the agent lost the entire prior conversation and started amnesiac.
- **Solution:** Let auth-boundary invalidations carry the raw transcript, force a reseed whenever a CLI session is invalidated, and fall back to the Claude CLI's own on-disk transcript when the OpenClaw-side transcript is missing or one-sided.
- **What changed:** `RAW_TRANSCRIPT_RESEED_ALLOWED_REASONS` (+auth-profile/auth-epoch); reseed-by-default on invalidation; tail-biased truncation; `MAX_CLI_SESSION_RESEED_HISTORY_CHARS` 12KB→64KB; new `loadClaudeCliReseedMessages` + `cliReseedMessagesLookThin`; fallback wiring in `prepare.ts`.
- **What did NOT change:** the compaction-summary reseed path; non-claude-cli CLI backends; the total agent timeout.

## Motivation
A routine auth-profile/auth-epoch rotation silently erased the user's entire conversation: the fresh CLI session started with zero context, re-asked questions and re-ran work. The full history still existed on disk (Claude CLI JSONL) but OpenClaw never read it back.

## Change Type
- [x] Bug fix

## Scope
- [x] Integrations (cli-runner / claude-cli)
- [x] Auth (auth-profile / auth-epoch invalidation path)

## Linked Issue/PR
Related: documents the `claude-cli` reseed path losing history. Checked: fixes a bug/regression.

## Real behavior proof
- **Behavior addressed:** claude-cli session loses all prior context after auth-profile/auth-epoch invalidation.
- **Real environment:** OpenClaw on WSL2 Ubuntu, claude-cli backend, Anthropic models.
- **Evidence:** the bound Claude CLI transcript for an affected session held only 2 user / 4 assistant turns while ~63 orphaned transcripts on disk held the real history (hundreds of turns); the OpenClaw session `.jsonl` held 57 assistant messages and 0 real user turns.
- **What was NOT tested:** a live patched-build end-to-end run (build is green, see below) — after-fix capture pending gateway restart onto the patched build.

## Root Cause
`loadCliSessionReseedMessages` only carried the raw transcript for reasons in `RAW_TRANSCRIPT_RESEED_ALLOWED_REASONS`, which excluded `auth-profile`/`auth-epoch`; raw reseed was also opt-in (`reseedFromRawTranscriptWhenUncompacted`, off by default). Separately, the reseed read the OpenClaw-side `.jsonl`, which for a claude-cli run holds only assistant outputs + runtime-event prompts — never the real user turns. No fallback reconstructed history from the authoritative Claude CLI JSONL.

## Regression Test Plan
`src/agents/cli-runner/session-history.test.ts`: covers auth-boundary raw reseed, tail-biased truncation, and `cliReseedMessagesLookThin` (empty / one-sided / two-sided / compaction-summary). 203 tests pass across the touched files.

## User-visible / Behavior Changes
Continuity is preserved across CLI session invalidation. No UI/API surface change.

## Diagram
```
Before: invalidate(auth-profile) -> reseed = []           -> fresh session amnesiac
After:  invalidate(auth-profile) -> reseed from raw tail  -> if thin -> Claude CLI JSONL -> continuity
```

## Security Impact
- New permissions: No
- New secrets handling: No
- New network calls: No
- New exec surface: No
- New data access: reads `~/.claude/projects/<dir>/<cliSessionId>.jsonl` via the existing `readClaudeCliFallbackSeed` reader (already path-guarded; rejects path-like ids, enforces containment).

## Repro + Verification
- **Environment:** claude-cli backend, multi-turn session, no recent compaction.
- **Steps:** trigger an auth-profile/auth-epoch change, send the next message.
- **Expected:** fresh session keeps prior context.
- **Actual (before):** fresh session started with no history.

## Evidence
- [x] Failing-then-passing regression tests

## Human Verification
Verified: the new tests pass; full `pnpm build` is green; the diagnostic trace (orphaned-transcript counts, one-sided OpenClaw transcript) confirms the failure mode. NOT verified: a live patched-build end-to-end run (pending gateway restart).

## Review Conversations
- [x] Will resolve bot review threads before merge

## Compatibility / Migration
Backward compatible. No config or migration. The `reseedFromRawTranscriptWhenUncompacted` opt-in still works; it is now also implied on invalidation.

## Risks and Mitigations
- Larger reseed prompt (64KB cap, tail-biased) — bounded; mitigated by truncation keeping the freshest turns.
- Claude CLI JSONL fallback only triggers for `isClaudeCliProvider` + a resolved `claudeCliSessionId`, and only when the OpenClaw reseed is empty/one-sided — narrow blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
