### PR TITLE
fix(agents): preserve OpenAI reasoning token usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 - CLI/agents: retry transient normal-close Gateway handshakes before falling back to embedded `openclaw agent` execution.
 - CLI/update: keep managed Gateway service stop/restart status lines out of `openclaw update --json` stdout so package-update automation can parse the JSON payload.
 - Plugins: resolve OpenClaw plugin SDK subpaths for native external plugin runtimes without mutating package installs or broadening process-wide module resolution.
+- Agents/OpenAI: preserve Responses and Chat Completions `reasoning_tokens` usage metadata without double-counting it in aggregate output tokens. (#85319)
 - Providers/Gemini: strip fractional seconds from web-search time range filters so Gemini accepts freshness-bound search requests. (#85071) Thanks @Noerr.
 - OpenAI Codex: preserve image input support for sparse `openai-codex/gpt-5.5` catalog rows. (#85095) Thanks @sercada.
 - Plugins/discovery: strip `-plugin` package suffixes when deriving plugin id hints so package names line up with manifest ids. (#85170) Thanks @JulyanXu.

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -364,6 +364,7 @@ describe("openai transport stream", () => {
               output_tokens: 5,
               total_tokens: 7,
               input_tokens_details: { cached_tokens: 4 },
+              output_tokens_details: { reasoning_tokens: 3 },
             },
           },
         },
@@ -377,6 +378,7 @@ describe("openai transport stream", () => {
       input: 0,
       output: 5,
       cacheRead: 4,
+      reasoningTokens: 3,
       totalTokens: 9,
     });
   });
@@ -1119,7 +1121,7 @@ describe("openai transport stream", () => {
     }
   });
 
-  it("does not double-count reasoning tokens and clamps uncached prompt usage at zero", () => {
+  it("preserves reasoning tokens without double-counting them", () => {
     const model = {
       id: "gpt-5",
       name: "GPT-5",
@@ -1148,9 +1150,25 @@ describe("openai transport stream", () => {
         input: 7,
         output: 20,
         cacheRead: 3,
+        reasoningTokens: 7,
         totalTokens: 30,
       },
     );
+  });
+
+  it("clamps uncached prompt usage at zero", () => {
+    const model = {
+      id: "gpt-5",
+      name: "GPT-5",
+      api: "openai-completions",
+      provider: "openai",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 1, output: 2, cacheRead: 0.5, cacheWrite: 0 },
+      contextWindow: 200000,
+      maxTokens: 8192,
+    } satisfies Model<"openai-completions">;
 
     expectRecordFields(
       parseTransportChunkUsage(

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -204,6 +204,7 @@ type MutableAssistantOutput = {
     output: number;
     cacheRead: number;
     cacheWrite: number;
+    reasoningTokens?: number;
     totalTokens: number;
     cost: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
   };
@@ -1530,6 +1531,7 @@ async function processResponsesStream(
             output_tokens?: number;
             total_tokens?: number;
             input_tokens_details?: { cached_tokens?: number };
+            output_tokens_details?: { reasoning_tokens?: number };
             service_tier?: ResponseCreateParamsStreaming["service_tier"];
             status?: string;
           }
@@ -1538,12 +1540,16 @@ async function processResponsesStream(
         const cachedTokens = usage.input_tokens_details?.cached_tokens || 0;
         const inputTokens = usage.input_tokens || 0;
         const outputTokens = usage.output_tokens || 0;
+        const reasoningTokens = usage.output_tokens_details?.reasoning_tokens;
         const input = Math.max(0, inputTokens - cachedTokens);
         output.usage = {
           input,
           output: outputTokens,
           cacheRead: cachedTokens,
           cacheWrite: 0,
+          ...(typeof reasoningTokens === "number" && Number.isFinite(reasoningTokens)
+            ? { reasoningTokens }
+            : {}),
           totalTokens: input + outputTokens + cachedTokens,
           cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
         };
@@ -3436,11 +3442,15 @@ export function parseTransportChunkUsage(
   const promptTokens = rawUsage.prompt_tokens || 0;
   const input = Math.max(0, promptTokens - cachedTokens);
   const outputTokens = rawUsage.completion_tokens || 0;
+  const reasoningTokens = rawUsage.completion_tokens_details?.reasoning_tokens;
   const usage = {
     input,
     output: outputTokens,
     cacheRead: cachedTokens,
     cacheWrite: 0,
+    ...(typeof reasoningTokens === "number" && Number.isFinite(reasoningTokens)
+      ? { reasoningTokens }
+      : {}),
     totalTokens: input + outputTokens + cachedTokens,
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
   };

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -35,6 +35,7 @@ export type EmbeddedPiAgentMeta = {
     output?: number;
     cacheRead?: number;
     cacheWrite?: number;
+    reasoningTokens?: number;
     total?: number;
   };
   /**
@@ -49,6 +50,7 @@ export type EmbeddedPiAgentMeta = {
     output?: number;
     cacheRead?: number;
     cacheWrite?: number;
+    reasoningTokens?: number;
     total?: number;
   };
 };

--- a/src/agents/pi-embedded-runner/usage-accumulator.test.ts
+++ b/src/agents/pi-embedded-runner/usage-accumulator.test.ts
@@ -12,6 +12,7 @@ type UsageInput = NonNullable<Parameters<typeof mergeUsageIntoAccumulator>[1]>;
 const FIRST_USAGE: UsageInput = {
   input: 100,
   output: 50,
+  reasoningTokens: 12,
   cacheRead: 80_000,
   cacheWrite: 5_000,
   total: 85_150,
@@ -28,6 +29,7 @@ const SECOND_USAGE: UsageInput = {
 const FINAL_USAGE: UsageInput = {
   input: 150,
   output: 40,
+  reasoningTokens: 7,
   cacheRead: 84_000,
   cacheWrite: 0,
   total: 84_190,
@@ -53,6 +55,7 @@ describe("usage-accumulator", () => {
 
       expect(acc.input).toBe(370);
       expect(acc.output).toBe(120);
+      expect(acc.reasoningTokens).toBe(19);
       expect(acc.cacheRead).toBe(246_000);
       expect(acc.cacheWrite).toBe(5_000);
       expect(acc.total).toBe(251_490);
@@ -63,6 +66,7 @@ describe("usage-accumulator", () => {
 
       expect(acc.lastInput).toBe(150);
       expect(acc.lastOutput).toBe(40);
+      expect(acc.lastReasoningTokens).toBe(7);
       expect(acc.lastCacheRead).toBe(84_000);
       expect(acc.lastCacheWrite).toBe(0);
       expect(acc.lastTotal).toBe(84_190);
@@ -100,6 +104,7 @@ describe("usage-accumulator", () => {
       mergeUsageIntoAccumulator(acc, {
         input: 100,
         output: 50,
+        reasoningTokens: 4,
         cacheRead: 80_000,
         cacheWrite: 5_000,
       });
@@ -119,6 +124,7 @@ describe("usage-accumulator", () => {
       expect(toNormalizedUsage(acc)).toEqual({
         input: 370,
         output: 120,
+        reasoningTokens: 4,
         cacheRead: 246_000,
         cacheWrite: 5_000,
         total: 251_490,
@@ -146,6 +152,7 @@ describe("usage-accumulator", () => {
       expect(toLastCallUsage(acc)).toEqual({
         input: 150,
         output: 40,
+        reasoningTokens: 7,
         cacheRead: 84_000,
         cacheWrite: undefined,
         total: 84_190,
@@ -169,6 +176,7 @@ describe("usage-accumulator", () => {
           {
             inputTokens: 99,
             outputTokens: 12,
+            completion_tokens_details: { reasoning_tokens: 8 },
             cache_read_input_tokens: 456,
             cache_creation_input_tokens: 3,
             totalTokens: 570,
@@ -178,6 +186,7 @@ describe("usage-accumulator", () => {
       ).toEqual({
         input: 99,
         output: 12,
+        reasoningTokens: 8,
         cacheRead: 456,
         cacheWrite: 3,
         total: 570,
@@ -190,6 +199,7 @@ describe("usage-accumulator", () => {
       expect(resolveLastCallUsage(undefined, acc)).toEqual({
         input: 150,
         output: 40,
+        reasoningTokens: 7,
         cacheRead: 84_000,
         cacheWrite: undefined,
         total: 84_190,
@@ -202,6 +212,7 @@ describe("usage-accumulator", () => {
       expect(resolveLastCallUsage({ responseId: "abc" } as never, acc)).toEqual({
         input: 150,
         output: 40,
+        reasoningTokens: 7,
         cacheRead: 84_000,
         cacheWrite: undefined,
         total: 84_190,

--- a/src/agents/pi-embedded-runner/usage-accumulator.ts
+++ b/src/agents/pi-embedded-runner/usage-accumulator.ts
@@ -5,12 +5,14 @@ export type UsageAccumulator = {
   output: number;
   cacheRead: number;
   cacheWrite: number;
+  reasoningTokens: number;
   total: number;
   /** Exact usage snapshot from the most recent API call. */
   lastInput: number;
   lastOutput: number;
   lastCacheRead: number;
   lastCacheWrite: number;
+  lastReasoningTokens: number;
   lastTotal: number;
 };
 
@@ -19,11 +21,13 @@ export const createUsageAccumulator = (): UsageAccumulator => ({
   output: 0,
   cacheRead: 0,
   cacheWrite: 0,
+  reasoningTokens: 0,
   total: 0,
   lastInput: 0,
   lastOutput: 0,
   lastCacheRead: 0,
   lastCacheWrite: 0,
+  lastReasoningTokens: 0,
   lastTotal: 0,
 });
 
@@ -31,9 +35,14 @@ type MaybeUsage = NormalizedUsage | undefined;
 
 const hasUsageValues = (usage: MaybeUsage): usage is NormalizedUsage =>
   !!usage &&
-  [usage.input, usage.output, usage.cacheRead, usage.cacheWrite, usage.total].some(
-    (value) => typeof value === "number" && Number.isFinite(value) && value > 0,
-  );
+  [
+    usage.input,
+    usage.output,
+    usage.cacheRead,
+    usage.cacheWrite,
+    usage.reasoningTokens,
+    usage.total,
+  ].some((value) => typeof value === "number" && Number.isFinite(value) && value > 0);
 
 export const mergeUsageIntoAccumulator = (target: UsageAccumulator, usage: MaybeUsage) => {
   if (!hasUsageValues(usage)) {
@@ -46,11 +55,13 @@ export const mergeUsageIntoAccumulator = (target: UsageAccumulator, usage: Maybe
   target.output += usage.output ?? 0;
   target.cacheRead += usage.cacheRead ?? 0;
   target.cacheWrite += usage.cacheWrite ?? 0;
+  target.reasoningTokens += usage.reasoningTokens ?? 0;
   target.total += callTotal;
   target.lastInput = usage.input ?? 0;
   target.lastOutput = usage.output ?? 0;
   target.lastCacheRead = usage.cacheRead ?? 0;
   target.lastCacheWrite = usage.cacheWrite ?? 0;
+  target.lastReasoningTokens = usage.reasoningTokens ?? 0;
   target.lastTotal = callTotal;
 };
 
@@ -60,6 +71,7 @@ export const toNormalizedUsage = (usage: UsageAccumulator): NormalizedUsage | un
     usage.output > 0 ||
     usage.cacheRead > 0 ||
     usage.cacheWrite > 0 ||
+    usage.reasoningTokens > 0 ||
     usage.total > 0;
   if (!hasUsage) {
     return undefined;
@@ -69,6 +81,7 @@ export const toNormalizedUsage = (usage: UsageAccumulator): NormalizedUsage | un
     output: usage.output || undefined,
     cacheRead: usage.cacheRead || undefined,
     cacheWrite: usage.cacheWrite || undefined,
+    ...(usage.reasoningTokens > 0 ? { reasoningTokens: usage.reasoningTokens } : {}),
     total: usage.total || undefined,
   };
 };
@@ -79,6 +92,7 @@ export const toLastCallUsage = (usage: UsageAccumulator): NormalizedUsage | unde
     usage.lastOutput > 0 ||
     usage.lastCacheRead > 0 ||
     usage.lastCacheWrite > 0 ||
+    usage.lastReasoningTokens > 0 ||
     usage.lastTotal > 0;
   if (!hasUsage) {
     return undefined;
@@ -88,6 +102,7 @@ export const toLastCallUsage = (usage: UsageAccumulator): NormalizedUsage | unde
     output: usage.lastOutput || undefined,
     cacheRead: usage.lastCacheRead || undefined,
     cacheWrite: usage.lastCacheWrite || undefined,
+    ...(usage.lastReasoningTokens > 0 ? { reasoningTokens: usage.lastReasoningTokens } : {}),
     total: usage.lastTotal || undefined,
   };
 };

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -201,6 +201,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     output: 0,
     cacheRead: 0,
     cacheWrite: 0,
+    reasoningTokens: 0,
     total: 0,
   };
   let compactionCount = 0;
@@ -470,6 +471,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     usageTotals.output += usage.output ?? 0;
     usageTotals.cacheRead += usage.cacheRead ?? 0;
     usageTotals.cacheWrite += usage.cacheWrite ?? 0;
+    usageTotals.reasoningTokens += usage.reasoningTokens ?? 0;
     const usageTotal =
       usage.total ??
       (usage.input ?? 0) + (usage.output ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0);
@@ -492,6 +494,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       usageTotals.output > 0 ||
       usageTotals.cacheRead > 0 ||
       usageTotals.cacheWrite > 0 ||
+      usageTotals.reasoningTokens > 0 ||
       usageTotals.total > 0;
     if (!hasUsage) {
       return undefined;
@@ -503,6 +506,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       output: usageTotals.output || undefined,
       cacheRead: usageTotals.cacheRead || undefined,
       cacheWrite: usageTotals.cacheWrite || undefined,
+      ...(usageTotals.reasoningTokens > 0 ? { reasoningTokens: usageTotals.reasoningTokens } : {}),
       total: usageTotals.total || derivedTotal || undefined,
     };
   };

--- a/src/agents/usage.normalization.test.ts
+++ b/src/agents/usage.normalization.test.ts
@@ -90,6 +90,7 @@ describe("normalizeUsage", () => {
     expect(hasNonzeroUsage(null)).toBe(false);
     expect(hasNonzeroUsage({})).toBe(false);
     expect(hasNonzeroUsage({ input: 0, output: 0 })).toBe(false);
+    expect(hasNonzeroUsage({ reasoningTokens: 1 })).toBe(true);
     expect(hasNonzeroUsage({ input: 1 })).toBe(true);
     expect(hasNonzeroUsage({ total: 1 })).toBe(true);
   });

--- a/src/agents/usage.test.ts
+++ b/src/agents/usage.test.ts
@@ -96,13 +96,32 @@ describe("normalizeUsage", () => {
       output_tokens: 30,
       total_tokens: 250,
       input_tokens_details: { cached_tokens: 100 },
+      output_tokens_details: { reasoning_tokens: 17 },
     });
     expect(usage).toEqual({
       input: 20,
       output: 30,
       cacheRead: 100,
       cacheWrite: undefined,
+      reasoningTokens: 17,
       total: 250,
+    });
+  });
+
+  it("handles OpenAI Chat Completions reasoning token details", () => {
+    const usage = normalizeUsage({
+      prompt_tokens: 120,
+      completion_tokens: 30,
+      total_tokens: 150,
+      completion_tokens_details: { reasoning_tokens: 11 },
+    });
+    expect(usage).toEqual({
+      input: 120,
+      output: 30,
+      cacheRead: undefined,
+      cacheWrite: undefined,
+      reasoningTokens: 11,
+      total: 150,
     });
   });
 
@@ -178,6 +197,21 @@ describe("toOpenAiChatCompletionsUsage", () => {
       prompt_tokens: 0,
       completion_tokens: 0,
       total_tokens: 42,
+    });
+  });
+
+  it("preserves reasoning token details", () => {
+    const usage = normalizeUsage({
+      prompt_tokens: 10,
+      completion_tokens: 8,
+      completion_tokens_details: { reasoning_tokens: 6 },
+      total_tokens: 18,
+    });
+    expect(toOpenAiChatCompletionsUsage(usage)).toEqual({
+      prompt_tokens: 10,
+      completion_tokens: 8,
+      completion_tokens_details: { reasoning_tokens: 6 },
+      total_tokens: 18,
     });
   });
 

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -17,6 +17,10 @@ export type UsageLike = {
   completion_tokens?: number;
   cache_read_input_tokens?: number;
   cache_creation_input_tokens?: number;
+  reasoningTokens?: number;
+  reasoning_tokens?: number;
+  completion_tokens_details?: { reasoning_tokens?: number };
+  output_tokens_details?: { reasoning_tokens?: number };
   // Moonshot/Kimi uses cached_tokens for cache read count (explicit caching API).
   cached_tokens?: number;
   // OpenAI Responses reports cached prompt reuse here.
@@ -42,6 +46,7 @@ export type NormalizedUsage = {
   output?: number;
   cacheRead?: number;
   cacheWrite?: number;
+  reasoningTokens?: number;
   total?: number;
 };
 
@@ -81,9 +86,14 @@ export function hasNonzeroUsage(usage?: NormalizedUsage | null): usage is Normal
   if (!usage) {
     return false;
   }
-  return [usage.input, usage.output, usage.cacheRead, usage.cacheWrite, usage.total].some(
-    (v) => typeof v === "number" && Number.isFinite(v) && v > 0,
-  );
+  return [
+    usage.input,
+    usage.output,
+    usage.cacheRead,
+    usage.cacheWrite,
+    usage.reasoningTokens,
+    usage.total,
+  ].some((v) => typeof v === "number" && Number.isFinite(v) && v > 0);
 }
 
 const normalizeTokenCount = (value: unknown): number | undefined => {
@@ -148,6 +158,12 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
   const cacheWrite = normalizeTokenCount(
     raw.cacheWrite ?? raw.cache_write ?? raw.cache_creation_input_tokens,
   );
+  const reasoningTokens = normalizeTokenCount(
+    raw.reasoningTokens ??
+      raw.reasoning_tokens ??
+      raw.completion_tokens_details?.reasoning_tokens ??
+      raw.output_tokens_details?.reasoning_tokens,
+  );
   const total = normalizeTokenCount(raw.total ?? raw.totalTokens ?? raw.total_tokens);
 
   if (
@@ -155,6 +171,7 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
     output === undefined &&
     cacheRead === undefined &&
     cacheWrite === undefined &&
+    reasoningTokens === undefined &&
     total === undefined
   ) {
     return undefined;
@@ -165,6 +182,7 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
     output,
     cacheRead,
     cacheWrite,
+    ...(reasoningTokens !== undefined ? { reasoningTokens } : {}),
     total,
   };
 }
@@ -182,6 +200,7 @@ export function toOpenAiChatCompletionsUsage(usage: NormalizedUsage | undefined)
   prompt_tokens: number;
   completion_tokens: number;
   total_tokens: number;
+  completion_tokens_details?: { reasoning_tokens: number };
 } {
   const input = usage?.input ?? 0;
   const output = usage?.output ?? 0;
@@ -197,10 +216,14 @@ export function toOpenAiChatCompletionsUsage(usage: NormalizedUsage | undefined)
   const totalTokens =
     aggregateTotal !== undefined ? Math.max(componentTotal, aggregateTotal) : componentTotal;
 
+  const reasoningTokens = normalizeTokenCount(usage?.reasoningTokens);
   return {
     prompt_tokens: promptTokens,
     completion_tokens: completionTokens,
     total_tokens: totalTokens,
+    ...(reasoningTokens !== undefined
+      ? { completion_tokens_details: { reasoning_tokens: reasoningTokens } }
+      : {}),
   };
 }
 


### PR DESCRIPTION
## Summary

- Preserve OpenAI Responses `output_tokens_details.reasoning_tokens` and Chat Completions `completion_tokens_details.reasoning_tokens` as `reasoningTokens` usage metadata.
- Carry reasoning-token metadata through normalized usage, embedded-run accumulators, and OpenAI-compatible usage serialization without adding it again to aggregate output totals.
- Add regression coverage for Responses usage, Chat Completions usage, normalization, and accumulator propagation.

## Verification

- `pnpm test src/agents/openai-transport-stream.test.ts src/agents/usage.test.ts src/agents/usage.normalization.test.ts src/agents/pi-embedded-runner/usage-accumulator.test.ts`
- `git diff --check origin/main...HEAD`
- `pnpm check:changed` via Blacksmith Testbox `tbx_01ks7n7vp03ren1rs0k7qndcsy`, GitHub Actions run https://github.com/openclaw/openclaw/actions/runs/26283736862
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local` reported no accepted/actionable findings
- Live OpenAI API smoke against `gpt-5.4-mini` for Responses and Chat Completions usage payloads

## Real behavior proof

Behavior addressed: OpenAI-compatible reasoning model usage reports can include reasoning-token counters inside provider usage details. OpenClaw now preserves those counters as `reasoningTokens` and keeps aggregate token totals unchanged because reasoning tokens are already part of completion/output tokens.

Real environment tested: Live OpenAI Responses API and Chat Completions API calls against `gpt-5.4-mini`, local Vitest shards, and Blacksmith Testbox `check:changed` against the final rebased branch diff.

Exact steps or command run after this patch: Live API smoke with `gpt-5.4-mini`; `pnpm test src/agents/openai-transport-stream.test.ts src/agents/usage.test.ts src/agents/usage.normalization.test.ts src/agents/pi-embedded-runner/usage-accumulator.test.ts`; `pnpm check:changed`.

Evidence after fix: Live Responses usage returned `output_tokens_details.reasoning_tokens=23` with `input_tokens=25`, `output_tokens=30`, and `total_tokens=55`. Live Chat Completions usage returned `completion_tokens_details.reasoning_tokens=21` with `prompt_tokens=25`, `completion_tokens=31`, and `total_tokens=56`. Feeding those live usage objects through this branch produced `normalizeUsage(...).reasoningTokens=23` for Responses, `normalizeUsage(...).reasoningTokens=21` for Chat, `parseTransportChunkUsage(...).reasoningTokens=21`, and `toOpenAiChatCompletionsUsage(...)` emitted `completion_tokens_details.reasoning_tokens=21`.

Observed result after fix: Focused tests passed 230 tests across 4 files; final rebased `check:changed` completed with exit 0 on Testbox; live provider payloads and branch parser/normalizer both preserved nonzero reasoning-token metadata.

What was not tested: Full live OpenClaw agent execution was not run; the live proof covers provider payload shape plus the exact branch parser and normalization code paths for usage metadata.
