### PR TITLE
fix(doctor): point Codex asset warning at migrate plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/OpenAI: preserve structured provider error code, type, and redacted body metadata on boundary-aware transport failures.
+- Doctor/Codex: point native Codex asset warnings at the canonical `openclaw migrate plan codex` preview command. Fixes #84948. Thanks @markoa.
 - CLI/agents: retry transient normal-close Gateway handshakes before falling back to embedded `openclaw agent` execution.
 - CLI/update: keep managed Gateway service stop/restart status lines out of `openclaw update --json` stdout so package-update automation can parse the JSON payload.
 - Plugins: resolve OpenClaw plugin SDK subpaths for native external plugin runtimes without mutating package installs or broadening process-wide module resolution.

--- a/src/commands/doctor/shared/codex-native-assets.test.ts
+++ b/src/commands/doctor/shared/codex-native-assets.test.ts
@@ -123,7 +123,7 @@ describe("collectCodexNativeAssetWarnings", () => {
         "- Personal Codex CLI assets were found, but native Codex-mode OpenClaw agents use isolated per-agent Codex homes.",
         `- Sources: ${codexHome} and ${path.join(root, ".agents", "skills")} (1 skill, 0 plugins, 0 config files, 0 hook files).`,
         "- These assets will not be loaded by the Codex app-server child unless you intentionally promote them.",
-        "- Run `openclaw migrate codex --dry-run` to inventory them. Applying that migration copies skills into the current OpenClaw agent workspace; Codex plugins, hooks, and config stay manual-review only.",
+        "- Run `openclaw migrate plan codex` to inventory them. Applying that migration copies skills into the current OpenClaw agent workspace; Codex plugins, hooks, and config stay manual-review only.",
       ].join("\n"),
     ]);
   });

--- a/src/commands/doctor/shared/codex-native-assets.ts
+++ b/src/commands/doctor/shared/codex-native-assets.ts
@@ -201,7 +201,7 @@ export async function collectCodexNativeAssetWarnings(params: {
       "- Personal Codex CLI assets were found, but native Codex-mode OpenClaw agents use isolated per-agent Codex homes.",
       `- Sources: ${resolveCodexHome(env)} and ${resolvePersonalAgentSkillsDir(env)} (${counts.join(", ")}).`,
       "- These assets will not be loaded by the Codex app-server child unless you intentionally promote them.",
-      "- Run `openclaw migrate codex --dry-run` to inventory them. Applying that migration copies skills into the current OpenClaw agent workspace; Codex plugins, hooks, and config stay manual-review only.",
+      "- Run `openclaw migrate plan codex` to inventory them. Applying that migration copies skills into the current OpenClaw agent workspace; Codex plugins, hooks, and config stay manual-review only.",
     ].join("\n"),
   ];
 }


### PR DESCRIPTION
Summary
- Point the Codex-native asset doctor warning at `openclaw migrate plan codex`, the registered preview command for provider migrations.
- Update the focused doctor warning regression test and changelog credit.

Verification
Behavior addressed: `openclaw doctor` no longer recommends the stale/ambiguous `openclaw migrate codex --dry-run` form for Codex asset inventory.
Real environment tested: local macOS source checkout.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/commands/doctor/shared/codex-native-assets.test.ts`; `git diff --check`; `.agents/skills/autoreview/scripts/autoreview --mode local`
Evidence after fix: the Codex native asset warning test now expects the canonical `openclaw migrate plan codex` command.
Observed result after fix: focused test passed, diff check passed, autoreview reported no accepted/actionable findings.
What was not tested: live doctor run against a real Codex home.

Fixes #84948
