### PR TITLE
fix(cli): suppress systemd hints for live gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 - Agents/OpenAI: preserve structured provider error code, type, and redacted body metadata on boundary-aware transport failures.
 - Doctor/Codex: point native Codex asset warnings at the canonical `openclaw migrate plan codex` preview command. Fixes #84948. Thanks @markoa.
 - CLI/models: make `capability model auth logout --agent` remove auth profiles from the selected non-default agent store. Fixes #85092. Thanks @islandpreneur007.
+- CLI/status: suppress systemd user-service setup hints when `openclaw status --deep` can already reach a running Gateway RPC service. Fixes #85094. Thanks @islandpreneur007.
 - CLI/agents: retry transient normal-close Gateway handshakes before falling back to embedded `openclaw agent` execution.
 - CLI/update: keep managed Gateway service stop/restart status lines out of `openclaw update --json` stdout so package-update automation can parse the JSON payload.
 - Plugins: resolve OpenClaw plugin SDK subpaths for native external plugin runtimes without mutating package installs or broadening process-wide module resolution.

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -9,6 +9,8 @@ const runtime = vi.hoisted(() => ({
 const resolveControlUiLinksMock = vi.hoisted(() =>
   vi.fn((_opts?: unknown) => ({ httpUrl: "http://127.0.0.1:18789" })),
 );
+const isSystemdUnavailableDetailMock = vi.hoisted(() => vi.fn(() => false));
+const renderSystemdUnavailableHintsMock = vi.hoisted(() => vi.fn(() => []));
 
 vi.mock("../../runtime.js", () => ({
   defaultRuntime: runtime,
@@ -46,8 +48,8 @@ vi.mock("../../daemon/restart-logs.js", () => ({
 }));
 
 vi.mock("../../daemon/systemd-hints.js", () => ({
-  isSystemdUnavailableDetail: () => false,
-  renderSystemdUnavailableHints: () => [],
+  isSystemdUnavailableDetail: isSystemdUnavailableDetailMock,
+  renderSystemdUnavailableHints: renderSystemdUnavailableHintsMock,
 }));
 
 vi.mock("../../infra/wsl.js", () => ({
@@ -87,6 +89,8 @@ describe("printDaemonStatus", () => {
     runtime.log.mockReset();
     runtime.error.mockReset();
     resolveControlUiLinksMock.mockClear();
+    isSystemdUnavailableDetailMock.mockReset().mockReturnValue(false);
+    renderSystemdUnavailableHintsMock.mockReset().mockReturnValue([]);
   });
 
   it("prints stale gateway pid guidance when runtime does not own the listener", () => {
@@ -505,5 +509,44 @@ describe("printDaemonStatus", () => {
     expectMockLineContains(runtime.log, "Other gateway-like services detected");
     expectMockLineContains(runtime.log, "ai.openclaw.gateway.rescue");
     expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("does not print systemd user-service hints when a gateway responds", () => {
+    const platform = vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    isSystemdUnavailableDetailMock.mockReturnValue(true);
+    renderSystemdUnavailableHintsMock.mockReturnValue(["run loginctl enable-linger"]);
+
+    try {
+      printDaemonStatus(
+        {
+          service: {
+            label: "systemd user",
+            loaded: false,
+            loadedText: "not loaded",
+            notLoadedText: "not loaded",
+            runtime: { status: "unknown", detail: "systemd user services unavailable" },
+          },
+          rpc: {
+            ok: true,
+            url: "ws://127.0.0.1:18789",
+            server: { version: "2026.5.12" },
+          },
+          port: {
+            port: 18789,
+            status: "busy",
+            listeners: [],
+            hints: [],
+          },
+          extraServices: [],
+        },
+        { json: false },
+      );
+    } finally {
+      platform.mockRestore();
+    }
+
+    const errors = runtime.error.mock.calls.map(([line]) => line).join("\n");
+    expect(errors).not.toContain("systemd user services unavailable");
+    expect(errors).not.toContain("run loginctl enable-linger");
   });
 });

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -10,7 +10,7 @@ const resolveControlUiLinksMock = vi.hoisted(() =>
   vi.fn((_opts?: unknown) => ({ httpUrl: "http://127.0.0.1:18789" })),
 );
 const isSystemdUnavailableDetailMock = vi.hoisted(() => vi.fn(() => false));
-const renderSystemdUnavailableHintsMock = vi.hoisted(() => vi.fn(() => []));
+const renderSystemdUnavailableHintsMock = vi.hoisted(() => vi.fn<() => string[]>(() => []));
 
 vi.mock("../../runtime.js", () => ({
   defaultRuntime: runtime,

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -320,7 +320,9 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean })
   }
 
   const systemdUnavailable =
-    process.platform === "linux" && isSystemdUnavailableDetail(service.runtime?.detail);
+    process.platform === "linux" &&
+    rpc?.ok !== true &&
+    isSystemdUnavailableDetail(service.runtime?.detail);
   if (systemdUnavailable) {
     const container = Boolean(
       resolveDaemonContainerContext(service.command?.environment ?? process.env),


### PR DESCRIPTION
Summary
- Keep `openclaw status --deep` from printing systemd user-service setup hints when Gateway RPC is already reachable.
- Add regression coverage for a Linux status payload where the local user service probe is unavailable but a Gateway is responding.

Verification
Behavior addressed: status output no longer reports a false systemd user-service problem for externally managed/system-scoped Gateways that respond over RPC.
Real environment tested: local macOS source checkout with Linux platform mocked in the focused unit test.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/cli/daemon-cli/status.print.test.ts`; `git diff --check`; `.agents/skills/autoreview/scripts/autoreview --mode local`
Evidence after fix: regression test forces `isSystemdUnavailableDetail()` true with `rpc.ok: true` and asserts the systemd hints are not printed.
Observed result after fix: focused test passed, diff check passed, autoreview reported no accepted/actionable findings.
What was not tested: live Linux systemd system-service Gateway install.

Fixes #85094
