### PR TITLE
Improve context overflow failure messaging

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -352,6 +352,8 @@ describe("isContextOverflowError", () => {
       "Maximum context length",
       "prompt is too long: 208423 tokens > 200000 maximum",
       "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.",
+      "Codex ran out of room in the model’s context window. Start a new thread or clear earlier history before retrying.",
+      "Codex ran out of room in the model context window. Start a new thread or clear earlier history before retrying.",
       "Context overflow: Summarization failed",
       "413 Request Entity Too Large",
     ];

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -351,6 +351,7 @@ describe("isContextOverflowError", () => {
       "context length exceeded",
       "Maximum context length",
       "prompt is too long: 208423 tokens > 200000 maximum",
+      "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.",
       "Context overflow: Summarization failed",
       "413 Request Entity Too Large",
     ];

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -107,6 +107,7 @@ export function isContextOverflowError(errorMessage?: string): boolean {
     lower.includes("context window") ||
     lower.includes("context length") ||
     lower.includes("maximum context length");
+  const hasCodexContextRoomError = /ran out of room\b.*\bcontext window\b/iu.test(errorMessage);
   return (
     lower.includes("request_too_large") ||
     (lower.includes("invalid_argument") && lower.includes("maximum number of tokens")) ||
@@ -115,8 +116,7 @@ export function isContextOverflowError(errorMessage?: string): boolean {
     lower.includes("maximum context length") ||
     lower.includes("prompt is too long") ||
     lower.includes("prompt too long") ||
-    lower.includes("ran out of room in the model's context window") ||
-    lower.includes("ran out of room in the models context window") ||
+    hasCodexContextRoomError ||
     lower.includes("exceeds model context window") ||
     lower.includes("model token limit") ||
     (lower.includes("input exceeds") && lower.includes("maximum number of tokens")) ||

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -115,6 +115,8 @@ export function isContextOverflowError(errorMessage?: string): boolean {
     lower.includes("maximum context length") ||
     lower.includes("prompt is too long") ||
     lower.includes("prompt too long") ||
+    lower.includes("ran out of room in the model's context window") ||
+    lower.includes("ran out of room in the models context window") ||
     lower.includes("exceeds model context window") ||
     lower.includes("model token limit") ||
     (lower.includes("input exceeds") && lower.includes("maximum number of tokens")) ||

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -24,6 +24,9 @@ const state = vi.hoisted(() => ({
   runWithModelFallbackMock: vi.fn(),
   isCliProviderMock: vi.fn((_: unknown) => false),
   isInternalMessageChannelMock: vi.fn((_: unknown) => false),
+  isBillingErrorMessageMock: vi.fn((_: string | undefined) => false),
+  isLikelyContextOverflowErrorMock: vi.fn((_: string | undefined) => false),
+  isRateLimitErrorMessageMock: vi.fn((_: string | undefined) => false),
   createBlockReplyDeliveryHandlerMock: vi.fn(),
 }));
 
@@ -89,11 +92,11 @@ vi.mock("../../agents/pi-embedded-helpers.js", () => ({
   },
   isCompactionFailureError: () => false,
   isContextOverflowError: () => false,
-  isBillingErrorMessage: () => false,
-  isLikelyContextOverflowError: () => false,
+  isBillingErrorMessage: (message?: string) => state.isBillingErrorMessageMock(message),
+  isLikelyContextOverflowError: (message?: string) =>
+    state.isLikelyContextOverflowErrorMock(message),
   isOverloadedErrorMessage: (message: string) => /overloaded|capacity/i.test(message),
-  isRateLimitErrorMessage: (message: string) =>
-    /rate.limit|too many requests|429|usage limit/i.test(message),
+  isRateLimitErrorMessage: (message?: string) => state.isRateLimitErrorMessageMock(message),
   isTransientHttpError: () => false,
   sanitizeUserFacingText: (text?: string) => text ?? "",
 }));
@@ -484,6 +487,15 @@ describe("runAgentTurnWithFallback", () => {
     state.isCliProviderMock.mockReturnValue(false);
     state.isInternalMessageChannelMock.mockReset();
     state.isInternalMessageChannelMock.mockReturnValue(false);
+    state.isBillingErrorMessageMock.mockReset();
+    state.isBillingErrorMessageMock.mockReturnValue(false);
+    state.isLikelyContextOverflowErrorMock.mockReset();
+    state.isLikelyContextOverflowErrorMock.mockReturnValue(false);
+    state.isRateLimitErrorMessageMock.mockReset();
+    state.isRateLimitErrorMessageMock.mockImplementation(
+      (message?: string) =>
+        !!message && /rate.limit|too many requests|429|usage limit/i.test(message),
+    );
     state.createBlockReplyDeliveryHandlerMock.mockReset();
     state.createBlockReplyDeliveryHandlerMock.mockReturnValue(undefined);
     state.runWithModelFallbackMock.mockImplementation(async (params: FallbackRunnerParams) => ({
@@ -3410,6 +3422,72 @@ describe("runAgentTurnWithFallback", () => {
       expect(result.payload.text).not.toContain("All models failed");
       expect(result.payload.text).not.toContain("402 (billing)");
       expect(result.payload.text).not.toContain("Rate-limited");
+    }
+  });
+
+  it("surfaces context overflow when fallback exhaustion mixes primary overflow with billing", async () => {
+    state.isLikelyContextOverflowErrorMock.mockImplementation(
+      (message?: string) =>
+        !!message && /ran out of room in the model'?s context window/i.test(message),
+    );
+    state.runWithModelFallbackMock.mockRejectedValueOnce(
+      Object.assign(
+        new Error(
+          "All models failed (2): openai/gpt-5.5: Codex ran out of room in the model's context window (unknown) | anthropic/claude-sonnet-4-6: Provider anthropic has billing issue (skipping all models) (billing)",
+        ),
+        {
+          name: "FallbackSummaryError",
+          attempts: [
+            {
+              provider: "openai",
+              model: "gpt-5.5",
+              error:
+                "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.",
+              reason: "unknown",
+            },
+            {
+              provider: "anthropic",
+              model: "claude-sonnet-4-6",
+              error: "Provider anthropic has billing issue (skipping all models)",
+              reason: "billing",
+            },
+          ],
+          soonestCooldownExpiry: null,
+        },
+      ),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "telegram",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {},
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toContain("Context limit exceeded");
+      expect(result.payload.text).toContain("fallback model was also unavailable");
+      expect(result.payload.text).not.toBe(GENERIC_RUN_FAILURE_TEXT);
+      expect(result.payload.text).not.toContain("All models failed");
     }
   });
 

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -3485,9 +3485,56 @@ describe("runAgentTurnWithFallback", () => {
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
       expect(result.payload.text).toContain("Context limit exceeded");
-      expect(result.payload.text).toContain("fallback model was also unavailable");
+      expect(result.payload.text).toContain("One or more fallback models were also unavailable");
       expect(result.payload.text).not.toBe(GENERIC_RUN_FAILURE_TEXT);
       expect(result.payload.text).not.toContain("All models failed");
+    }
+  });
+
+  it("surfaces direct Codex context overflow before reply without raw provider text", async () => {
+    state.isLikelyContextOverflowErrorMock.mockImplementation(
+      (message?: string) => !!message && /ran out of room\b.*\bcontext window/i.test(message),
+    );
+    state.runWithModelFallbackMock.mockRejectedValueOnce(
+      new Error(
+        "Codex ran out of room in the model’s context window. Start a new thread or clear earlier history before retrying.",
+      ),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "telegram",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {},
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toContain("Context limit exceeded");
+      expect(result.payload.text).toContain(
+        "Start a fresh session or retry with a narrower request",
+      );
+      expect(result.payload.text).not.toBe(GENERIC_RUN_FAILURE_TEXT);
+      expect(result.payload.text).not.toContain("ran out of room");
+      expect(result.payload.text).not.toContain("/compact");
     }
   });
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -455,6 +455,36 @@ function isPureBillingSummary(err: unknown): boolean {
   );
 }
 
+function fallbackSummaryHasContextOverflowAttempt(err: unknown): boolean {
+  return (
+    isFallbackSummaryError(err) &&
+    err.attempts.some((attempt) => isLikelyContextOverflowError(formatErrorMessage(attempt.error)))
+  );
+}
+
+function fallbackSummaryHasUnavailableFallbackAttempt(err: unknown): boolean {
+  return (
+    isFallbackSummaryError(err) &&
+    err.attempts.some((attempt) => {
+      if (attempt.reason === "billing" || attempt.reason === "rate_limit") {
+        return true;
+      }
+      const message = formatErrorMessage(attempt.error);
+      return isBillingErrorMessage(message) || isRateLimitErrorMessage(message);
+    })
+  );
+}
+
+function buildContextOverflowBeforeReplyText(params?: { fallbackUnavailable?: boolean }): string {
+  return (
+    "⚠️ Context limit exceeded before I could reply. The current thread is too large for the primary model. " +
+    "Use /compact or /new, then retry with a narrower request." +
+    (params?.fallbackUnavailable
+      ? " A fallback model was also unavailable because of billing or rate-limit cooldown, so automatic recovery could not continue."
+      : "")
+  );
+}
+
 function collapseRepeatedFailureDetail(message: string): string {
   const parts = message
     .split(/\s+\|\s+/u)
@@ -630,6 +660,24 @@ export function buildKnownAgentRunFailureReplyPayload(params: {
     return markAgentRunFailureReplyPayload({
       text: resolveExternalRunFailureTextForConversation({
         text: BILLING_ERROR_USER_MESSAGE,
+        sessionCtx: params.sessionCtx,
+        isGenericRunnerFailure: false,
+        cfg: params.cfg,
+      }),
+    });
+  }
+
+  const hasFallbackContextOverflow = fallbackSummaryHasContextOverflowAttempt(params.err);
+  const isContextOverflow =
+    (isFallbackSummary && hasFallbackContextOverflow) ||
+    (!isFallbackSummary && isLikelyContextOverflowError(message));
+  if (isContextOverflow) {
+    return markAgentRunFailureReplyPayload({
+      text: resolveExternalRunFailureTextForConversation({
+        text: buildContextOverflowBeforeReplyText({
+          fallbackUnavailable:
+            isFallbackSummary && fallbackSummaryHasUnavailableFallbackAttempt(params.err),
+        }),
         sessionCtx: params.sessionCtx,
         isGenericRunnerFailure: false,
         cfg: params.cfg,
@@ -2213,10 +2261,15 @@ export async function runAgentTurnWithFallback(params: {
         continue;
       }
       const message = formatErrorMessage(err);
-      const isBilling = isFallbackSummaryError(err)
+      const isFallbackSummary = isFallbackSummaryError(err);
+      const isBilling = isFallbackSummary
         ? isPureBillingSummary(err)
         : isBillingErrorMessage(message);
-      const isContextOverflow = !isBilling && isLikelyContextOverflowError(message);
+      const hasFallbackContextOverflow = fallbackSummaryHasContextOverflowAttempt(err);
+      const isContextOverflow =
+        !isBilling &&
+        ((isFallbackSummary && hasFallbackContextOverflow) ||
+          (!isFallbackSummary && isLikelyContextOverflowError(message)));
       const isCompactionFailure = !isBilling && isCompactionFailureError(message);
       const providerRequestError =
         !isBilling && !shouldSurfaceToControlUi ? classifyProviderRequestError(err) : undefined;
@@ -2312,7 +2365,6 @@ export async function runAgentTurnWithFallback(params: {
       // underlying error. FallbackSummaryError messages embed per-attempt
       // reason labels like `(rate_limit)`, so string-matching the summary text
       // would misclassify mixed-cause exhaustion as a pure transient cooldown.
-      const isFallbackSummary = isFallbackSummaryError(err);
       const isPureTransientSummary = isFallbackSummary
         ? isPureTransientRateLimitSummary(err)
         : false;
@@ -2348,7 +2400,10 @@ export async function runAgentTurnWithFallback(params: {
           : rateLimitOrOverloadedCopy
             ? rateLimitOrOverloadedCopy
             : isContextOverflow
-              ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
+              ? buildContextOverflowBeforeReplyText({
+                  fallbackUnavailable:
+                    isFallbackSummary && fallbackSummaryHasUnavailableFallbackAttempt(err),
+                })
               : shouldSurfaceToControlUi
                 ? `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`
                 : (externalRunFailureReply?.text ?? genericFallbackText);

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -478,9 +478,9 @@ function fallbackSummaryHasUnavailableFallbackAttempt(err: unknown): boolean {
 function buildContextOverflowBeforeReplyText(params?: { fallbackUnavailable?: boolean }): string {
   return (
     "⚠️ Context limit exceeded before I could reply. The current thread is too large for the primary model. " +
-    "Use /compact or /new, then retry with a narrower request." +
+    "Start a fresh session or retry with a narrower request." +
     (params?.fallbackUnavailable
-      ? " A fallback model was also unavailable because of billing or rate-limit cooldown, so automatic recovery could not continue."
+      ? " One or more fallback models were also unavailable due to billing or rate-limit cooldown, so automatic recovery could not continue."
       : "")
   );
 }


### PR DESCRIPTION
## Summary
- classify Codex context-window room errors as context overflow
- show a specific context-limit message instead of generic Something went wrong
- clarify when fallback models are unavailable due to billing or rate-limit cooldown

## Verification
- `npx vitest run src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts src/auto-reply/reply/agent-runner-execution.test.ts --maxWorkers=1`
- `NODE_OPTIONS=--max-old-space-size=8192 npx tsc -p test/tsconfig/tsconfig.core.test.json --noEmit --pretty false`
- `npx oxfmt --check src/agents/pi-embedded-helpers/errors.ts src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts`
- `git diff --check`

## Real behavior proof
- **Behavior or issue addressed:** Codex context-window "ran out of room" failures are now classified as context overflow so agent-runner can show a specific context-limit failure message instead of a generic failure.
- **Real environment tested:** Local OpenClaw source checkout on macOS in `/Users/moon/.openclaw/plugin-sources/openclaw-core.clone` at PR head `fc8bd5a2be`.
- **Exact steps or command run after this patch:** `npx tsx -e 'import { isContextOverflowError } from "./src/agents/pi-embedded-helpers/errors.ts"; const sample = "Codex ran out of room in the model’s context window. Start a new thread or clear earlier history before retrying."; console.log(JSON.stringify({ sample, classifiedAsContextOverflow: isContextOverflowError(sample) }, null, 2));'`
- **Evidence after fix:** Terminal output from the command above:

```json
{
  "sample": "Codex ran out of room in the model’s context window. Start a new thread or clear earlier history before retrying.",
  "classifiedAsContextOverflow": true
}
```

- **Observed result after fix:** The real classifier call returns `classifiedAsContextOverflow: true` for the current Codex wording, which is the condition needed for the agent-runner context-limit UX path.
- **What was not tested:** Full live Telegram overflow reproduction was not forced because intentionally filling a production session context is disruptive; focused local tests cover the before-reply text and fallback billing/rate-limit summary path.
