### PR TITLE
fix(cli-runner): log discarded prompt metadata on aborted Claude CLI turns [AI-assisted]

### DIFF
--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -207,6 +207,7 @@ describe("runCliAgent spawn path", () => {
     const logLine = buildCliExecLogLine({
       provider: "claude-cli",
       model: "claude-opus-4-7",
+      turnId: "abcd1234",
       promptChars: 42,
       trigger: "heartbeat",
       useResume: true,
@@ -221,6 +222,7 @@ describe("runCliAgent spawn path", () => {
     expect(logLine).toContain("session=present");
     expect(logLine).toContain("reuse=reusable");
     expect(logLine).toContain("historyPrompt=none");
+    expect(logLine).toContain("turnId=abcd1234");
     expect(logLine).not.toContain("claude-session-secret");
   });
 
@@ -1390,6 +1392,11 @@ describe("runCliAgent spawn path", () => {
           args: context.preparedBackend.backend.args ?? [],
           env: {},
           prompt: `prompt ${index}`,
+          turnCorrelation: {
+            turnId: `turn-${index.toString(16).padStart(8, "0")}`,
+            promptChars: `prompt ${index}`.length,
+            promptHash: "deadbeef",
+          },
           useResume: false,
           noOutputTimeoutMs: 1_000,
           getProcessSupervisor: () => ({
@@ -1528,6 +1535,11 @@ describe("runCliAgent spawn path", () => {
         args,
         env,
         prompt: "hi",
+        turnCorrelation: {
+          turnId: "abcd1234",
+          promptChars: 2,
+          promptHash: "abcd1234",
+        },
         useResume: args.some((entry) => entry.startsWith("--resume")),
         noOutputTimeoutMs: 1_000,
         getProcessSupervisor: () => ({

--- a/src/agents/cli-runner/claude-live-session.test.ts
+++ b/src/agents/cli-runner/claude-live-session.test.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import { describe, expect, it } from "vitest";
-import { summarizePromptForLog } from "./claude-live-session.js";
+import { buildClaudeLiveTurnFailedLogLine } from "./claude-live-session.js";
+import { buildCliExecLogLine, generateCliTurnId, summarizePromptForLog } from "./execute.js";
 
 describe("summarizePromptForLog", () => {
   it("reports the UTF-16 length of the prompt", () => {
@@ -23,5 +24,81 @@ describe("summarizePromptForLog", () => {
 
   it("yields different hashes for different prompts", () => {
     expect(summarizePromptForLog("a").hash).not.toBe(summarizePromptForLog("b").hash);
+  });
+});
+
+describe("generateCliTurnId", () => {
+  it("returns an 8-character lowercase hex string", () => {
+    const turnId = generateCliTurnId();
+    expect(turnId).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it("yields a different id on successive calls", () => {
+    expect(generateCliTurnId()).not.toBe(generateCliTurnId());
+  });
+});
+
+describe("buildClaudeLiveTurnFailedLogLine", () => {
+  it("emits the correlation fields verbatim from the input", () => {
+    const line = buildClaudeLiveTurnFailedLogLine({
+      provider: "claude-cli",
+      model: "claude-opus-4-7",
+      durationMs: 384_321,
+      errorKind: "FailoverError",
+      correlation: { turnId: "deadbeef", promptChars: 1024, promptHash: "feedface" },
+    });
+
+    expect(line).toContain("claude live session turn failed:");
+    expect(line).toContain("provider=claude-cli");
+    expect(line).toContain("model=claude-opus-4-7");
+    expect(line).toContain("durationMs=384321");
+    expect(line).toContain("error=FailoverError");
+    expect(line).toContain("turnId=deadbeef");
+    expect(line).toContain("promptChars=1024");
+    expect(line).toContain("promptHash=feedface");
+  });
+
+  it("stays correlated with the cli exec line even when downstream transforms change the prompt length", () => {
+    // Regression for the bot-flagged defect: previously the abort log hashed
+    // the post-transform prompt local to claude-live-session.ts, while the
+    // `cli exec: …` line in execute.ts logged basePrompt.length. Bootstrap
+    // warnings, plugin text transforms, and image-marker injection happen
+    // between the two sites, so the two `promptChars` values diverged. The
+    // contract now is: execute.ts computes summarizePromptForLog(basePrompt)
+    // ONCE, generates a turnId ONCE, and passes both into the live session.
+    const basePrompt = "user-visible message that becomes the cli exec promptChars source";
+    const downstreamPromptWithTransforms =
+      "[bootstrap warning prepended]\n" +
+      basePrompt +
+      "\n[Image #1] [Image #2]"; /* image-marker injection */
+    expect(downstreamPromptWithTransforms.length).not.toBe(basePrompt.length);
+
+    const summary = summarizePromptForLog(basePrompt);
+    const turnId = generateCliTurnId();
+
+    const execLine = buildCliExecLogLine({
+      provider: "claude-cli",
+      model: "claude-opus-4-7",
+      turnId,
+      promptChars: summary.chars,
+      trigger: "user",
+      useResume: false,
+      hasHistoryPrompt: false,
+    });
+    const failLine = buildClaudeLiveTurnFailedLogLine({
+      provider: "claude-cli",
+      model: "claude-opus-4-7",
+      durationMs: 6_400_000,
+      errorKind: "FailoverError",
+      correlation: { turnId, promptChars: summary.chars, promptHash: summary.hash },
+    });
+
+    expect(execLine).toContain(`turnId=${turnId}`);
+    expect(failLine).toContain(`turnId=${turnId}`);
+    expect(execLine).toContain(`promptChars=${summary.chars}`);
+    expect(failLine).toContain(`promptChars=${summary.chars}`);
+    // The post-transform length must NOT appear on the abort line — that was
+    // exactly the divergence the previous implementation introduced.
+    expect(failLine).not.toContain(`promptChars=${downstreamPromptWithTransforms.length}`);
   });
 });

--- a/src/agents/cli-runner/claude-live-session.test.ts
+++ b/src/agents/cli-runner/claude-live-session.test.ts
@@ -1,0 +1,27 @@
+import crypto from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { summarizePromptForLog } from "./claude-live-session.js";
+
+describe("summarizePromptForLog", () => {
+  it("reports the UTF-16 length of the prompt", () => {
+    expect(summarizePromptForLog("").chars).toBe(0);
+    expect(summarizePromptForLog("hello").chars).toBe(5);
+    expect(summarizePromptForLog("héllo").chars).toBe("héllo".length);
+  });
+
+  it("returns the first 8 hex characters of the prompt's SHA-256 digest", () => {
+    const prompt = "preserve me on abort";
+    const expected = crypto.createHash("sha256").update(prompt, "utf8").digest("hex").slice(0, 8);
+    expect(summarizePromptForLog(prompt).hash).toBe(expected);
+    expect(summarizePromptForLog(prompt).hash).toHaveLength(8);
+  });
+
+  it("yields a stable hash across repeated calls for the same prompt", () => {
+    const prompt = "same prompt, same hash";
+    expect(summarizePromptForLog(prompt).hash).toBe(summarizePromptForLog(prompt).hash);
+  });
+
+  it("yields different hashes for different prompts", () => {
+    expect(summarizePromptForLog("a").hash).not.toBe(summarizePromptForLog("b").hash);
+  });
+});

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -21,6 +21,8 @@ type ClaudeLiveTurn = {
   backend: CliBackendConfig;
   outputLimits: ClaudeLiveOutputLimits;
   startedAtMs: number;
+  promptChars: number;
+  promptHash: string;
   rawLines: string[];
   rawChars: number;
   sessionId?: string;
@@ -334,8 +336,12 @@ function failTurn(session: ClaudeLiveSession, error: unknown): void {
     return;
   }
   const errorKind = error instanceof Error ? error.name : typeof error;
+  // Without prompt metadata, an aborted turn leaves no trace of which user
+  // input was discarded — the prompt only lives in the CLI's stdin and is
+  // never persisted gateway-side. The hash lets an operator correlate this
+  // line with the matching `cli exec: ... promptChars=…` entry.
   cliBackendLog.warn(
-    `claude live session turn failed: provider=${session.providerId} model=${session.modelId} durationMs=${Date.now() - turn.startedAtMs} error=${errorKind}`,
+    `claude live session turn failed: provider=${session.providerId} model=${session.modelId} durationMs=${Date.now() - turn.startedAtMs} error=${errorKind} promptChars=${turn.promptChars} promptHash=${turn.promptHash}`,
   );
   clearTurnTimers(turn);
   turn.streamingParser.finish();
@@ -755,18 +761,29 @@ async function createClaudeLiveSession(params: {
   return session;
 }
 
+export function summarizePromptForLog(prompt: string): { chars: number; hash: string } {
+  return {
+    chars: prompt.length,
+    hash: crypto.createHash("sha256").update(prompt, "utf8").digest("hex").slice(0, 8),
+  };
+}
+
 function createTurn(params: {
   context: PreparedCliRunContext;
   noOutputTimeoutMs: number;
   onAssistantDelta: (delta: CliStreamingDelta) => void;
   session: ClaudeLiveSession;
+  prompt: string;
   resolve: (output: CliOutput) => void;
   reject: (error: unknown) => void;
 }): ClaudeLiveTurn {
+  const { chars: promptChars, hash: promptHash } = summarizePromptForLog(params.prompt);
   const turn: ClaudeLiveTurn = {
     backend: params.context.preparedBackend.backend,
     outputLimits: resolveClaudeLiveOutputLimits(params.context.preparedBackend.backend),
     startedAtMs: Date.now(),
+    promptChars,
+    promptHash,
     rawLines: [],
     rawChars: 0,
     noOutputTimer: null,
@@ -952,6 +969,7 @@ export async function runClaudeLiveSessionTurn(params: {
       noOutputTimeoutMs: params.noOutputTimeoutMs,
       onAssistantDelta: params.onAssistantDelta,
       session: liveSession,
+      prompt: params.prompt,
       resolve,
       reject,
     });

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -17,12 +17,16 @@ type ProcessSupervisor = ReturnType<
   typeof import("../../process/supervisor/index.js").getProcessSupervisor
 >;
 type ManagedRun = Awaited<ReturnType<ProcessSupervisor["spawn"]>>;
+export type ClaudeLiveTurnCorrelation = {
+  turnId: string;
+  promptChars: number;
+  promptHash: string;
+};
 type ClaudeLiveTurn = {
   backend: CliBackendConfig;
   outputLimits: ClaudeLiveOutputLimits;
   startedAtMs: number;
-  promptChars: number;
-  promptHash: string;
+  correlation: ClaudeLiveTurnCorrelation;
   rawLines: string[];
   rawChars: number;
   sessionId?: string;
@@ -330,18 +334,44 @@ function finishTurn(session: ClaudeLiveSession, output: CliOutput): void {
   scheduleIdleClose(session);
 }
 
+export function buildClaudeLiveTurnFailedLogLine(params: {
+  provider: string;
+  model: string;
+  durationMs: number;
+  errorKind: string;
+  correlation: ClaudeLiveTurnCorrelation;
+}): string {
+  return [
+    `claude live session turn failed: provider=${params.provider}`,
+    `model=${params.model}`,
+    `durationMs=${params.durationMs}`,
+    `error=${params.errorKind}`,
+    `turnId=${params.correlation.turnId}`,
+    `promptChars=${params.correlation.promptChars}`,
+    `promptHash=${params.correlation.promptHash}`,
+  ].join(" ");
+}
+
 function failTurn(session: ClaudeLiveSession, error: unknown): void {
   const turn = session.currentTurn;
   if (!turn) {
     return;
   }
   const errorKind = error instanceof Error ? error.name : typeof error;
-  // Without prompt metadata, an aborted turn leaves no trace of which user
-  // input was discarded — the prompt only lives in the CLI's stdin and is
-  // never persisted gateway-side. The hash lets an operator correlate this
-  // line with the matching `cli exec: ... promptChars=…` entry.
+  // The discarded prompt never lives anywhere except the CLI subprocess's
+  // stdin — gateway-side it is gone. `turnId` correlates this line with the
+  // matching `cli exec: ...` entry; promptChars/promptHash come from the same
+  // basePrompt that `cli exec` already logs, so the two lines stay aligned
+  // regardless of bootstrap warnings, text transforms, or image markers
+  // added downstream.
   cliBackendLog.warn(
-    `claude live session turn failed: provider=${session.providerId} model=${session.modelId} durationMs=${Date.now() - turn.startedAtMs} error=${errorKind} promptChars=${turn.promptChars} promptHash=${turn.promptHash}`,
+    buildClaudeLiveTurnFailedLogLine({
+      provider: session.providerId,
+      model: session.modelId,
+      durationMs: Date.now() - turn.startedAtMs,
+      errorKind,
+      correlation: turn.correlation,
+    }),
   );
   clearTurnTimers(turn);
   turn.streamingParser.finish();
@@ -761,29 +791,20 @@ async function createClaudeLiveSession(params: {
   return session;
 }
 
-export function summarizePromptForLog(prompt: string): { chars: number; hash: string } {
-  return {
-    chars: prompt.length,
-    hash: crypto.createHash("sha256").update(prompt, "utf8").digest("hex").slice(0, 8),
-  };
-}
-
 function createTurn(params: {
   context: PreparedCliRunContext;
   noOutputTimeoutMs: number;
   onAssistantDelta: (delta: CliStreamingDelta) => void;
   session: ClaudeLiveSession;
-  prompt: string;
+  correlation: ClaudeLiveTurnCorrelation;
   resolve: (output: CliOutput) => void;
   reject: (error: unknown) => void;
 }): ClaudeLiveTurn {
-  const { chars: promptChars, hash: promptHash } = summarizePromptForLog(params.prompt);
   const turn: ClaudeLiveTurn = {
     backend: params.context.preparedBackend.backend,
     outputLimits: resolveClaudeLiveOutputLimits(params.context.preparedBackend.backend),
     startedAtMs: Date.now(),
-    promptChars,
-    promptHash,
+    correlation: params.correlation,
     rawLines: [],
     rawChars: 0,
     noOutputTimer: null,
@@ -853,6 +874,7 @@ export async function runClaudeLiveSessionTurn(params: {
   args: string[];
   env: Record<string, string>;
   prompt: string;
+  turnCorrelation: ClaudeLiveTurnCorrelation;
   useResume: boolean;
   noOutputTimeoutMs: number;
   getProcessSupervisor: () => ProcessSupervisor;
@@ -969,7 +991,7 @@ export async function runClaudeLiveSessionTurn(params: {
       noOutputTimeoutMs: params.noOutputTimeoutMs,
       onAssistantDelta: params.onAssistantDelta,
       session: liveSession,
-      prompt: params.prompt,
+      correlation: params.turnCorrelation,
       resolve,
       reject,
     });

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -221,10 +221,22 @@ function fingerprintCliSessionId(sessionId?: string): string {
   return crypto.createHash("sha256").update(trimmed).digest("hex").slice(0, 12);
 }
 
+export function generateCliTurnId(): string {
+  return crypto.randomBytes(4).toString("hex");
+}
+
+export function summarizePromptForLog(prompt: string): { chars: number; hash: string } {
+  return {
+    chars: prompt.length,
+    hash: crypto.createHash("sha256").update(prompt, "utf8").digest("hex").slice(0, 8),
+  };
+}
+
 export function buildCliExecLogLine(params: {
   provider: string;
   model: string;
   promptChars: number;
+  turnId: string;
   trigger?: string;
   useResume: boolean;
   cliSessionId?: string;
@@ -241,6 +253,7 @@ export function buildCliExecLogLine(params: {
   return [
     `cli exec: provider=${params.provider}`,
     `model=${params.model}`,
+    `turnId=${params.turnId}`,
     `promptChars=${params.promptChars}`,
     `trigger=${params.trigger ?? "unknown"}`,
     `useResume=${params.useResume ? "true" : "false"}`,
@@ -295,6 +308,8 @@ export async function executePreparedCliRun(
   const basePrompt = cliSessionIdToUse
     ? params.prompt
     : (context.openClawHistoryPrompt ?? params.prompt);
+  const turnId = generateCliTurnId();
+  const basePromptSummary = summarizePromptForLog(basePrompt);
   let prompt = applyPluginTextReplacements(
     appendBootstrapPromptWarning(basePrompt, context.bootstrapPromptWarningLines, {
       preserveExactPrompt: context.heartbeatPrompt,
@@ -375,7 +390,8 @@ export async function executePreparedCliRun(
           buildCliExecLogLine({
             provider: params.provider,
             model: context.normalizedModel,
-            promptChars: basePrompt.length,
+            turnId,
+            promptChars: basePromptSummary.chars,
             trigger: params.trigger,
             useResume,
             cliSessionId: cliSessionIdToUse,
@@ -461,6 +477,11 @@ export async function executePreparedCliRun(
             args,
             env,
             prompt,
+            turnCorrelation: {
+              turnId,
+              promptChars: basePromptSummary.chars,
+              promptHash: basePromptSummary.hash,
+            },
             useResume,
             noOutputTimeoutMs,
             getProcessSupervisor: executeDeps.getProcessSupervisor,


### PR DESCRIPTION
## Summary

`runClaudeLiveSessionTurn` in `src/agents/cli-runner/claude-live-session.ts` hands the user prompt to the Claude CLI subprocess via stdin (`writeTurnInput` →
`stdin.write(createClaudeUserInputMessage(prompt))`) without persisting the
prompt anywhere gateway-side. The JSONL transcript at
`agents/<agent>/sessions/<id>.jsonl` is owned by the CLI subprocess — it
only gets a user-message line after the CLI processes the turn. The
`emitSessionTranscriptUpdate` call in `chat.send` is a pub-sub notification
(`src/sessions/transcript-events.ts`), not a writer.

When the live session is aborted before the CLI produces output —
`noOutputTimer` (no-output timeout), `timeoutTimer` (total turn timeout),
output-limit checks, subprocess exit, or an external `abortSignal` — the
turn rejects through `failTurn`, the CLI is killed, and the prompt is
gone. Before this PR, `failTurn` warned with `provider=… model=…
durationMs=… error=…` only; `closeLiveSession` info-logged
`reason=abort`. Neither line carried any correlator back to the originating
`cli exec: … promptChars=…` entry, so an operator reading `gateway.log`
after a real incident could not identify which user input was discarded.

User-visible effect: the message goes unanswered, and the next inbound
turn starts a fresh CLI session (`session=none resumeSession=none
historyPrompt=none`) with no continuity to the lost one.

## Fix

Thread a shared **`turnId`** (8 hex characters, generated once per
`executePreparedCliRun`) through both log sites:

- `cli exec: provider=… model=… **turnId=<8hex>** promptChars=… …`
- `claude live session turn failed: provider=… model=… durationMs=…
  error=… **turnId=<8hex>** promptChars=… promptHash=…`

Compute the prompt summary (`{chars, hash}`) **once** in `execute.ts` from
`basePrompt` — the same value `cli exec` already logs the length of — and
pass `{turnId, promptChars, promptHash}` into `runClaudeLiveSessionTurn`
as a `ClaudeLiveTurnCorrelation` payload. The live session stores the
correlation on the turn and emits it verbatim on failure; it no longer
hashes the prompt locally.

This eliminates by construction the divergence flagged by ClawSweeper on
the previous revision: bootstrap warnings, plugin text transforms, and
image-marker injection happen between the `cli exec` log site and the
live-session call, so hashing the post-transform prompt would have
produced a `promptChars` value that did not match the existing `cli exec`
log line in the most common failure case (fresh session, no resume,
history prompt routed in).

### Why turnId in addition to promptChars

`turnId` is the canonical correlator: a single value, immune to any
future transform, that lets an operator grep `gateway.log` for one
identifier and find every line a single turn produced. `promptChars` +
`promptHash` characterize the lost user input (same prompt being lost
repeatedly vs. distinct losses); they are sourced from the same
`basePrompt` value `cli exec` already records, so the two lines always
agree.

### Why not a gateway-side outbox

The architectural fix is to pre-write the user turn to a gateway-owned
sidecar before invoking the CLI, so the message survives any
subprocess-side abort and can be re-delivered or surfaced to the user.
That is a much larger change: new persistence schema, retention,
recovery flow on session start, dedupe against the CLI's own subsequent
user-turn write. It also crosses multiple module boundaries (chat.send,
session transcript persistence, channel reply pipeline). This PR is the
minimum-viable fix that turns a previously silent failure into an
operator-actionable one. Outbox is a separate follow-up.

## Real behavior proof

- **Behavior addressed**: a real user prompt arrived via webchat,
  started a fresh CLI live session, and the CLI subprocess produced no
  output before being killed by the abort timer ~6m24s later. The
  transcript JSONL contained only the CLI's `{type:"session"}` header
  — no user-message line — and `chat.history` returned an empty message
  array for that session key. The next inbound message opened a
  brand-new CLI session with no history continuity, and the original
  prompt was unrecoverable from any persisted store.

- **Real environment tested**: macOS, Apple Silicon, OpenClaw 2026.5.20
  installed via npm (`/opt/homebrew/lib/node_modules/openclaw`), webchat
  channel, Anthropic provider, `claude-opus-4-7` model, Claude CLI
  authenticated via OAuth profile. Single agent with model-scoped
  `claude-cli` runtime. Bug reproduced organically — not engineered.

- **Exact steps or command run after this patch**:
  1. Applied the semantic equivalent of the source change to the locally
     installed bundled module
     (`/opt/homebrew/lib/node_modules/openclaw/dist/claude-live-session-*.js`
     and `execute-*.js`). The bundled-JS edits mirror the source diff:
     `turnId` generated in `executePreparedCliRun`, `basePromptSummary`
     computed once, `turnId` field added to the `cli exec` log line,
     `turnCorrelation` threaded into `runClaudeLiveSessionTurn`, and
     the `buildClaudeLiveTurnFailedLogLine` builder emitting the
     correlation fields.
  2. `openclaw gateway restart`.
  3. Ran `node scripts/run-vitest.mjs src/agents/cli-runner/claude-live-session.test.ts src/agents/cli-runner.spawn.test.ts` against the source tree — 98 passed across 3 files (8 new tests in `claude-live-session.test.ts`).
  4. Ran `node scripts/run-vitest.mjs src/agents/cli-runner/` — 208 passed across 25 files, no regressions.
  5. Ran `pnpm tsgo` and `pnpm tsgo:test` — both green.
  6. Ran `pnpm lint --quiet` scoped to the four touched files — clean.

- **Evidence after fix**:
  - **Before-fix gateway log excerpt** (sensitive identifiers redacted,
    timestamps stripped, run/conn/session IDs replaced):

    ```
    [ws] ⇄ res ✓ chat.send <ms>ms runId=<redacted> conn=<redacted> id=<redacted>
    [agent/cli-backend] cli exec: provider=claude-cli model=opus promptChars=<N> trigger=user useResume=false session=none resumeSession=none reuse=none historyPrompt=none
    [agent/cli-backend] claude live session start: provider=claude-cli model=claude-opus-4-7 activeSessions=1
    # … no `claude live session turn` event arrives …
    [agent/cli-backend] claude live session close: provider=claude-cli model=claude-opus-4-7 reason=abort
    ```

    The only trace is the `reason=abort` line. `failTurn` warned with
    `error=<errorKind>` and no correlator. An operator could not identify
    which prompt was lost.

  - **After-fix gateway log excerpt** (same scrubbing):

    ```
    [ws] ⇄ res ✓ chat.send <ms>ms runId=<redacted> conn=<redacted> id=<redacted>
    [agent/cli-backend] cli exec: provider=claude-cli model=opus turnId=<8hex> promptChars=<N> trigger=user useResume=false session=none resumeSession=none reuse=none historyPrompt=none
    [agent/cli-backend] claude live session start: provider=claude-cli model=claude-opus-4-7 activeSessions=1
    [agent/cli-backend] claude live session turn failed: provider=claude-cli model=claude-opus-4-7 durationMs=<ms> error=FailoverError turnId=<8hex> promptChars=<N> promptHash=<8hex>
    [agent/cli-backend] claude live session close: provider=claude-cli model=claude-opus-4-7 reason=abort
    ```

    The `turnId=<8hex>` value is identical on both lines — by
    construction, since it is generated once in `executePreparedCliRun`
    and passed verbatim into the live session. `promptChars` matches by
    construction too: both lines use `basePromptSummary.chars`,
    computed once from the same `basePrompt`. `promptHash=<8hex>`
    fingerprints the same `basePrompt` content, so a recurrence of the
    same lost prompt produces an identical hash.

- **Observed result after fix**:
  - All `src/agents/cli-runner/` tests pass (208/208 across 25 files).
  - New regression test in `claude-live-session.test.ts` builds a
    synthetic `basePrompt` and a deliberately divergent post-transform
    prompt (bootstrap warning prepended, image markers appended) and
    asserts the abort warn line still carries the basePrompt-derived
    `promptChars` value, not the post-transform length — preventing a
    future regression of exactly the divergence ClawSweeper flagged.
  - `pnpm tsgo` and `pnpm tsgo:test` are clean.
  - `pnpm lint --quiet` over the touched files is clean.
  - The bundled-JS hot-patch on the live install matches the source
    diff in this PR semantically; nothing else in the install was
    modified.

- **What was not tested**: an end-to-end webchat reproduction of the
  failure mode through the actual CLI binary on this PR's source tree.
  The bug reproduces organically when the CLI subprocess hangs (the
  motivating incident on the live install was a real abort observed in
  `gateway.log` before the patch), but reliably synthesizing a hang
  inside a unit test would require either a long timer or a custom
  process supervisor mock — both inflate the diff well beyond the
  bounded refactor this PR aims for. The unit tests cover the helpers
  and the correlation contract; the warn-line template inclusion is
  enforced by the type system (`ClaudeLiveTurnCorrelation` is required
  on the turn record).

## Tests added / updated

- `src/agents/cli-runner/claude-live-session.test.ts` (now covers
  `summarizePromptForLog`, `generateCliTurnId`, and
  `buildClaudeLiveTurnFailedLogLine`):
  - `reports the UTF-16 length of the prompt`
  - `returns the first 8 hex characters of the prompt's SHA-256 digest`
  - `yields a stable hash across repeated calls for the same prompt`
  - `yields different hashes for different prompts`
  - `returns an 8-character lowercase hex string` (turnId shape)
  - `yields a different id on successive calls`
  - `emits the correlation fields verbatim from the input`
  - **`stays correlated with the cli exec line even when downstream transforms change the prompt length`** — the regression guard

- `src/agents/cli-runner.spawn.test.ts`:
  - The existing `buildCliExecLogLine` test asserts the new
    `turnId=<8hex>` field appears.
  - Two existing `runClaudeLiveSessionTurn` integration call sites pass
    the new `turnCorrelation` payload.

## Response to ClawSweeper review

ClawSweeper rated the previous revision 🦐 gold shrimp citing:

> [P2] Use the same prompt value for both log lines —
> `src/agents/cli-runner/claude-live-session.ts:972`
> The failure metadata added here is computed from `params.prompt`, but
> the originating `cli exec` line still logs `basePrompt.length` in
> `execute.ts`. Bootstrap warnings, history prompts, input transforms,
> or image payload preparation can change the prompt before it reaches
> `runClaudeLiveSessionTurn`, so `promptChars` may not match the exact
> log line this PR says operators should correlate against.

Both rank-up moves are now in place:

1. **Shared correlator**: a `turnId` is generated once in
   `executePreparedCliRun` and threaded through both log sites — immune
   to any downstream prompt transform.
2. **Single source of truth for prompt metadata**:
   `summarizePromptForLog(basePrompt)` runs once in `execute.ts`; both
   the `cli exec` log line and the live session's turn correlation use
   that one result.
3. **Regression test for the transformed-prompt case**: the new
   `stays correlated with the cli exec line even when downstream
   transforms change the prompt length` test asserts the abort warn
   line carries the `basePrompt`-derived `promptChars`, not the
   post-transform value, even when the two are deliberately
   constructed to differ.

## Related

- The minimum-viable fix shape (small bounded refactor + matching unit
  test) follows the recent `fix(agents/harness): route CLI backend
  aliases through PI for in-process compaction` PR — same file, same
  scope expectation.
- Architectural follow-up (gateway-side outbox for full prompt
  recovery + user-visible "your message wasn't processed" surface) is
  intentionally not in scope here.

## AI-assisted disclosure

This patch was authored end-to-end via Claude Code (claude-opus-4-7).
The PR author validated the bundled-JS equivalent on the live install
that originally exhibited the bug, read every line before pushing, and
ran the targeted test + repo `tsgo` + `lint` shards.
