### PR TITLE
fix(infra): allow macOS browser open over SSH env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 - CLI/update: start managed Gateway update handoff helpers from a stable existing directory and tolerate deleted cwd/package roots during macOS LaunchAgent handoff. Fixes #83808. (#83875) Thanks @jason-allen-oneal.
 - Cron: honor `cron.retry.retryOn: ["network"]` for common network error codes such as `EAI_AGAIN`, `EHOSTUNREACH`, and `ENETUNREACH`.
 - Gateway chat: broadcast returned agent-run error payloads after an agent starts so ACP/WebChat clients receive terminal idle-timeout errors. Fixes #84945.
+- Dashboard/CLI: allow macOS browser launching through `open` even when SSH environment variables are present, while preserving Linux SSH no-display protection. Fixes #67088. Thanks @theglove44.
 - Agents/OpenAI: preserve structured provider error code, type, and redacted body metadata on boundary-aware transport failures.
 - Doctor/Codex: point native Codex asset warnings at the canonical `openclaw migrate plan codex` preview command. Fixes #84948. Thanks @markoa.
 - CLI/models: make `capability model auth logout --agent` remove auth profiles from the selected non-default agent store. Fixes #85092. Thanks @islandpreneur007.

--- a/src/infra/browser-open.test.ts
+++ b/src/infra/browser-open.test.ts
@@ -1,11 +1,19 @@
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+const detectBinaryMock = vi.hoisted(() => vi.fn(async () => false));
+
+vi.mock("./detect-binary.js", () => ({
+  detectBinary: detectBinaryMock,
+}));
+
 import { resolveBrowserOpenCommand } from "./browser-open.js";
 import { resetWindowsInstallRootsForTests } from "./windows-install-roots.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
+  detectBinaryMock.mockReset().mockResolvedValue(false);
   resetWindowsInstallRootsForTests();
 });
 
@@ -43,5 +51,25 @@ describe("resolveBrowserOpenCommand", () => {
     const rundll32 = path.win32.join("D:\\Windows", "System32", "rundll32.exe");
     expect(resolved.argv).toEqual([rundll32, "url.dll,FileProtocolHandler"]);
     expect(resolved.command).toBe(rundll32);
+  });
+
+  it("resolves macOS open even when SSH environment variables are present", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    vi.stubEnv("SSH_CONNECTION", "192.0.2.1 12345 192.0.2.2 22");
+    detectBinaryMock.mockResolvedValueOnce(true);
+
+    const resolved = await resolveBrowserOpenCommand();
+
+    expect(detectBinaryMock).toHaveBeenCalledWith("open");
+    expect(resolved).toEqual({ argv: ["open"], command: "open" });
+  });
+
+  it("still refuses browser launch over Linux SSH without a display", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    vi.stubEnv("SSH_CONNECTION", "192.0.2.1 12345 192.0.2.2 22");
+
+    const resolved = await resolveBrowserOpenCommand();
+
+    expect(resolved).toEqual({ argv: null, reason: "ssh-no-display" });
   });
 });

--- a/src/infra/browser-open.ts
+++ b/src/infra/browser-open.ts
@@ -48,7 +48,7 @@ export async function resolveBrowserOpenCommand(): Promise<BrowserOpenCommand> {
     Boolean(process.env.SSH_TTY) ||
     Boolean(process.env.SSH_CONNECTION);
 
-  if (isSsh && !hasDisplay && platform !== "win32") {
+  if (isSsh && !hasDisplay && platform !== "win32" && platform !== "darwin") {
     return { argv: null, reason: "ssh-no-display" };
   }
 


### PR DESCRIPTION
Summary
- Let macOS resolve browser launching through `open` even when SSH environment variables are present.
- Preserve the Linux SSH/no-display refusal path.
- Add focused tests for both platform branches.

Verification
Behavior addressed: `openclaw dashboard`/browser launch helpers no longer misclassify macOS shells with `SSH_CONNECTION` as headless when `open` is available.
Real environment tested: local macOS source checkout with platform/env branches mocked in unit tests.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/infra/browser-open.test.ts`; `git diff --check`; `.agents/skills/autoreview/scripts/autoreview --mode local`
Evidence after fix: regression test verifies macOS + `SSH_CONNECTION` resolves `{ argv: ["open"], command: "open" }`, while Linux + SSH without display still returns `ssh-no-display`.
Observed result after fix: focused test passed, diff check passed, autoreview reported no accepted/actionable findings.
What was not tested: live browser opening from an SSH-launched macOS terminal.

Fixes #67088
