### PR TITLE
fix(cli): recover replaced device approvals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 - Doctor/Codex: point native Codex asset warnings at the canonical `openclaw migrate plan codex` preview command. Fixes #84948. Thanks @markoa.
 - CLI/models: make `capability model auth logout --agent` remove auth profiles from the selected non-default agent store. Fixes #85092. Thanks @islandpreneur007.
 - CLI/status: suppress systemd user-service setup hints when `openclaw status --deep` can already reach a running Gateway RPC service. Fixes #85094. Thanks @islandpreneur007.
+- CLI/devices: recover local approval when a same-device repair request replaces the request ID being approved.
 - CLI/agents: retry transient normal-close Gateway handshakes before falling back to embedded `openclaw agent` execution.
 - CLI/update: keep managed Gateway service stop/restart status lines out of `openclaw update --json` stdout so package-update automation can parse the JSON payload.
 - Plugins: resolve OpenClaw plugin SDK subpaths for native external plugin runtimes without mutating package installs or broadening process-wide module resolution.

--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -61,6 +61,8 @@ type PendingDevice = {
   deviceId: string;
   publicKey?: string;
   displayName?: string;
+  clientId?: string;
+  clientMode?: string;
   role?: string;
   roles?: string[];
   scopes?: string[];
@@ -84,6 +86,11 @@ type PairedDevice = {
 type DevicePairingList = {
   pending?: PendingDevice[];
   paired?: PairedDevice[];
+};
+
+type ApprovePairingGatewayContext = {
+  originalRequest: PendingDevice | null;
+  scopes?: OperatorScope[];
 };
 
 const FALLBACK_NOTICE = "Direct scope access failed; using local fallback.";
@@ -225,7 +232,7 @@ async function approvePairingWithFallback(
   opts: DevicesRpcOpts,
   requestId: string,
 ): Promise<Record<string, unknown> | null> {
-  const scopes = await resolveApprovePairingGatewayScopes(opts, requestId);
+  const { scopes, originalRequest } = await resolveApprovePairingGatewayContext(opts, requestId);
   try {
     return await callGatewayCli(
       "device.pair.approve",
@@ -248,6 +255,53 @@ async function approvePairingWithFallback(
     }
     const gatewayRequestId = normalizeOptionalString(fallback.details.requestId);
     if (gatewayRequestId && gatewayRequestId !== requestId) {
+      const local = await listDevicePairing();
+      const localList = {
+        pending: local.pending as PendingDevice[],
+        paired: local.paired.map((device) => redactLocalPairedDevice(device)),
+      };
+      const replacement = findSameDeviceReplacementRequest({
+        originalRequest,
+        originalRequestId: requestId,
+        gatewayRequestId,
+        pending: localList.pending,
+        paired: localList.paired,
+      });
+      if (replacement) {
+        const approved = await approveDevicePairing(replacement.requestId, {
+          callerScopes: ["operator.admin"],
+        });
+        if (!approved) {
+          return null;
+        }
+        if (approved.status === "forbidden") {
+          throw new Error(formatDevicePairingForbiddenMessage(approved), { cause: error });
+        }
+        if (opts.json !== true) {
+          defaultRuntime.log(
+            theme.warn(
+              `Pending request ${sanitizeForLog(requestId)} was replaced by same-device repair ${sanitizeForLog(replacement.requestId)}; approving latest compatible request.`,
+            ),
+          );
+          defaultRuntime.log(theme.warn(FALLBACK_NOTICE));
+        }
+        return {
+          requestId: replacement.requestId,
+          resolved: {
+            kind: "same-device-replacement",
+            requestedRequestId: requestId,
+            approvedRequestId: replacement.requestId,
+          },
+          device: redactLocalPairedDevice(approved.device),
+        };
+      }
+      const hasOriginalPending = Boolean(findPendingRequestById(localList.pending, requestId));
+      const hasGatewayPending = Boolean(
+        findPendingRequestById(localList.pending, gatewayRequestId),
+      );
+      if (!hasOriginalPending && !hasGatewayPending) {
+        return null;
+      }
       throw buildFallbackStateMismatchError(fallback.details);
     }
     const approved = await approveDevicePairing(requestId, {
@@ -303,6 +357,122 @@ function normalizeOperatorScopes(scopes: string[] | undefined): string[] {
   );
 }
 
+function findPendingRequestById(
+  pending: PendingDevice[] | undefined,
+  requestId: string | null | undefined,
+): PendingDevice | null {
+  const normalizedRequestId = normalizeOptionalString(requestId);
+  if (!normalizedRequestId) {
+    return null;
+  }
+  return (
+    pending?.find(
+      (request) => normalizeOptionalString(request.requestId) === normalizedRequestId,
+    ) ?? null
+  );
+}
+
+function hasExactRoleMatch(original: PendingDevice, replacement: PendingDevice): boolean {
+  const originalRoles = normalizeDeviceRoles(original);
+  const replacementRoles = normalizeDeviceRoles(replacement);
+  if (originalRoles.length !== replacementRoles.length) {
+    return false;
+  }
+  const replacementRoleSet = new Set(replacementRoles);
+  return originalRoles.every((role) => replacementRoleSet.has(role));
+}
+
+function hasCompatibleClientMetadata(original: PendingDevice, replacement: PendingDevice): boolean {
+  const originalClientId = normalizeOptionalString(original.clientId);
+  const replacementClientId = normalizeOptionalString(replacement.clientId);
+  if (originalClientId && replacementClientId && originalClientId !== replacementClientId) {
+    return false;
+  }
+  const originalClientMode = normalizeOptionalString(original.clientMode);
+  const replacementClientMode = normalizeOptionalString(replacement.clientMode);
+  return !(
+    originalClientMode &&
+    replacementClientMode &&
+    originalClientMode !== replacementClientMode
+  );
+}
+
+function resolveOriginalReplacementScopes(
+  original: PendingDevice,
+  paired: PairedDevice | undefined,
+): string[] {
+  const requestedScopes = normalizeDeviceAuthScopes(original.scopes);
+  const inferredOperatorScopes = resolvePendingOperatorApprovalScopes(original, paired);
+  return [...new Set([...requestedScopes, ...inferredOperatorScopes])];
+}
+
+function replacementScopesCoverOriginal(
+  original: PendingDevice,
+  replacement: PendingDevice,
+  paired: PairedDevice | undefined,
+): boolean {
+  const originalScopes = resolveOriginalReplacementScopes(original, paired);
+  const replacementScopes = normalizeDeviceAuthScopes(replacement.scopes);
+  const replacementScopeSet = new Set(replacementScopes);
+  if (!originalScopes.every((scope) => replacementScopeSet.has(scope))) {
+    return false;
+  }
+  // Same-device repair reconnects can supersede a stale request with a combined
+  // request that appends the pairing scope required for the repaired session to
+  // reconnect and complete approval.
+  return replacementScopes.every(
+    (scope) => originalScopes.includes(scope) || scope === PAIRING_SCOPE,
+  );
+}
+
+function findSameDeviceReplacementRequest(params: {
+  originalRequest: PendingDevice | null;
+  originalRequestId: string;
+  gatewayRequestId: string;
+  pending: PendingDevice[] | undefined;
+  paired: PairedDevice[] | undefined;
+}): PendingDevice | null {
+  const originalRequestId = normalizeOptionalString(params.originalRequestId);
+  if (!params.originalRequest || !originalRequestId) {
+    // Without the pre-approve snapshot we cannot prove that the gateway's newer
+    // request is the same-device repair contract the operator intended to approve.
+    return null;
+  }
+  if (normalizeOptionalString(params.originalRequest.requestId) !== originalRequestId) {
+    return null;
+  }
+  const replacement = findPendingRequestById(params.pending, params.gatewayRequestId);
+  if (!replacement) {
+    return null;
+  }
+  const originalDeviceId = normalizeOptionalString(params.originalRequest.deviceId);
+  const replacementDeviceId = normalizeOptionalString(replacement.deviceId);
+  if (!originalDeviceId || originalDeviceId !== replacementDeviceId) {
+    return null;
+  }
+  const originalPublicKey = normalizeOptionalString(params.originalRequest.publicKey);
+  const replacementPublicKey = normalizeOptionalString(replacement.publicKey);
+  if (!originalPublicKey || !replacementPublicKey || originalPublicKey !== replacementPublicKey) {
+    return null;
+  }
+  if (!hasExactRoleMatch(params.originalRequest, replacement)) {
+    return null;
+  }
+  if (!hasCompatibleClientMetadata(params.originalRequest, replacement)) {
+    return null;
+  }
+  const pairedByDeviceId = indexPairedDevices(params.paired);
+  const originalPaired = lookupPairedDevice(pairedByDeviceId, params.originalRequest);
+  const replacementPaired = lookupPairedDevice(pairedByDeviceId, replacement);
+  if (!replacementScopesCoverOriginal(params.originalRequest, replacement, originalPaired)) {
+    return null;
+  }
+  if (replacement.isRepair !== true && (!originalPaired || !replacementPaired)) {
+    return null;
+  }
+  return replacement;
+}
+
 function resolvePairedOperatorScopes(paired: PairedDevice | undefined): string[] {
   const operatorToken = paired?.tokens?.find((token) => {
     const role = normalizeOptionalString(token.role);
@@ -347,22 +517,25 @@ function resolveApprovePairingScopesForRequest(
   return [...out];
 }
 
-async function resolveApprovePairingGatewayScopes(
+async function resolveApprovePairingGatewayContext(
   opts: DevicesRpcOpts,
   requestId: string,
-): Promise<OperatorScope[] | undefined> {
+): Promise<ApprovePairingGatewayContext> {
   try {
     const list = await listPairingWithFallback(opts);
-    const request = list.pending?.find((pending) => pending.requestId === requestId);
+    const request = findPendingRequestById(list.pending, requestId);
     if (!request) {
-      return undefined;
+      return { originalRequest: null, scopes: undefined };
     }
-    return resolveApprovePairingScopesForRequest(
-      request,
-      lookupPairedDevice(indexPairedDevices(list.paired), request),
-    );
+    return {
+      originalRequest: request,
+      scopes: resolveApprovePairingScopesForRequest(
+        request,
+        lookupPairedDevice(indexPairedDevices(list.paired), request),
+      ),
+    };
   } catch {
-    return undefined;
+    return { originalRequest: null, scopes: undefined };
   }
 }
 
@@ -753,9 +926,14 @@ export async function runDevicesApproveCommand(
     defaultRuntime.writeJson(result);
     return;
   }
+  const resultRequestId = (result as { requestId?: unknown })?.requestId;
+  const approvedRequestId =
+    typeof resultRequestId === "string" && resultRequestId.trim().length > 0
+      ? resultRequestId
+      : resolvedRequestId;
   const deviceId = (result as { device?: { deviceId?: string } })?.device?.deviceId;
   defaultRuntime.log(
-    `${theme.success("Approved")} ${theme.command(deviceId ?? "ok")} ${theme.muted(`(${resolvedRequestId})`)}`,
+    `${theme.success("Approved")} ${theme.command(deviceId ?? "ok")} ${theme.muted(`(${approvedRequestId})`)}`,
   );
 }
 

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -252,6 +252,58 @@ describe("devices cli approve", () => {
     });
   });
 
+  it("inherits non-admin operator token scopes when a repair approval omits explicit scopes", async () => {
+    callGateway
+      .mockResolvedValueOnce({
+        pending: [
+          pendingDevice({
+            requestId: "req-read-repair",
+            scopes: [],
+          }),
+        ],
+        paired: [
+          pairedDevice({
+            tokens: [{ role: "operator", scopes: ["operator.read"] }],
+          }),
+        ],
+      })
+      .mockResolvedValueOnce({ device: { deviceId: "device-1" } });
+
+    await runDevicesApprove(["req-read-repair"]);
+
+    expectGatewayCall(1, {
+      method: "device.pair.approve",
+      params: { requestId: "req-read-repair" },
+      scopes: ["operator.pairing", "operator.read"],
+    });
+  });
+
+  it("falls back to paired scopes when a repair approval omits explicit scopes and no operator token is stored", async () => {
+    callGateway
+      .mockResolvedValueOnce({
+        pending: [
+          pendingDevice({
+            requestId: "req-read-repair-scopes",
+            scopes: [],
+          }),
+        ],
+        paired: [
+          pairedDevice({
+            scopes: ["operator.read"],
+          }),
+        ],
+      })
+      .mockResolvedValueOnce({ device: { deviceId: "device-1" } });
+
+    await runDevicesApprove(["req-read-repair-scopes"]);
+
+    expectGatewayCall(1, {
+      method: "device.pair.approve",
+      params: { requestId: "req-read-repair-scopes" },
+      scopes: ["operator.pairing", "operator.read"],
+    });
+  });
+
   it("prints selected details and exits when implicit approval is used", async () => {
     callGateway.mockResolvedValueOnce({
       pending: [
@@ -521,9 +573,8 @@ describe("devices cli tokens", () => {
     await runDevicesCommand(["rotate", "--device", " ", "--role", "main"]);
 
     expect(callGateway).not.toHaveBeenCalled();
-    expect(runtime.error).toHaveBeenCalledWith(
-      "--device and --role are required. Run openclaw devices list to choose a paired device.",
-    );
+    expect(readRuntimeErrorOutput()).toContain("--device and --role are required.");
+    expect(readRuntimeErrorOutput()).toContain("devices list");
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 });
@@ -564,6 +615,648 @@ describe("devices cli local fallback", () => {
     expect(readRuntimeOutput()).toContain("Approved");
   });
 
+  it("approves a same-device compatible replacement request during local fallback", async () => {
+    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
+    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
+    listDevicePairing.mockResolvedValueOnce({
+      pending: [
+        {
+          requestId: "req-old",
+          deviceId: "device-1",
+          publicKey: "pk",
+          role: "operator",
+          scopes: ["operator.read"],
+          clientId: "openclaw-macos",
+          clientMode: "cli",
+          isRepair: true,
+          ts: 1,
+        },
+        {
+          requestId: "req-new",
+          deviceId: "device-1",
+          publicKey: "pk",
+          role: "operator",
+          scopes: ["operator.read", "operator.pairing"],
+          clientId: "openclaw-macos",
+          clientMode: "cli",
+          isRepair: true,
+          ts: 2,
+        },
+      ],
+      paired: [],
+    });
+    listDevicePairing.mockResolvedValueOnce({
+      pending: [
+        {
+          requestId: "req-new",
+          deviceId: "device-1",
+          publicKey: "pk",
+          role: "operator",
+          scopes: ["operator.read", "operator.pairing"],
+          clientId: "openclaw-macos",
+          clientMode: "cli",
+          isRepair: true,
+          ts: 2,
+        },
+      ],
+      paired: [],
+    });
+    approveDevicePairing.mockResolvedValueOnce({
+      requestId: "req-new",
+      device: {
+        deviceId: "device-1",
+        publicKey: "pk",
+        approvedAtMs: 1,
+        createdAtMs: 1,
+      },
+    });
+    summarizeDeviceTokens.mockReturnValue(undefined);
+
+    await runDevicesApprove(["req-old"]);
+
+    expect(listDevicePairing).toHaveBeenCalledTimes(2);
+    expect(approveDevicePairing).toHaveBeenCalledWith("req-new", {
+      callerScopes: ["operator.admin"],
+    });
+    expect(readRuntimeOutput()).toContain(fallbackNotice);
+    expect(readRuntimeOutput()).toContain(
+      "Pending request req-old was replaced by same-device repair req-new; approving latest compatible request.",
+    );
+    expect(readRuntimeOutput()).toContain("(req-new)");
+  });
+
+  it("emits resolved metadata in JSON mode when local fallback approves a replacement request", async () => {
+    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
+    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
+    listDevicePairing
+      .mockResolvedValueOnce({
+        pending: [
+          {
+            requestId: "req-old",
+            deviceId: "device-1",
+            publicKey: "pk",
+            role: "operator",
+            scopes: ["operator.read"],
+            clientId: "openclaw-macos",
+            clientMode: "cli",
+            isRepair: true,
+            ts: 1,
+          },
+          {
+            requestId: "req-new",
+            deviceId: "device-1",
+            publicKey: "pk",
+            role: "operator",
+            scopes: ["operator.read", "operator.pairing"],
+            clientId: "openclaw-macos",
+            clientMode: "cli",
+            isRepair: true,
+            ts: 2,
+          },
+        ],
+        paired: [],
+      })
+      .mockResolvedValueOnce({
+        pending: [
+          {
+            requestId: "req-new",
+            deviceId: "device-1",
+            publicKey: "pk",
+            role: "operator",
+            scopes: ["operator.read", "operator.pairing"],
+            clientId: "openclaw-macos",
+            clientMode: "cli",
+            isRepair: true,
+            ts: 2,
+          },
+        ],
+        paired: [],
+      });
+    approveDevicePairing.mockResolvedValueOnce({
+      requestId: "req-new",
+      device: {
+        deviceId: "device-1",
+        publicKey: "pk",
+        approvedAtMs: 1,
+        createdAtMs: 1,
+      },
+    });
+
+    await runDevicesApprove(["req-old", "--json"]);
+
+    expect(runtime.writeJson).toHaveBeenCalledWith({
+      requestId: "req-new",
+      resolved: {
+        kind: "same-device-replacement",
+        requestedRequestId: "req-old",
+        approvedRequestId: "req-new",
+      },
+      device: {
+        deviceId: "device-1",
+        publicKey: "pk",
+        approvedAtMs: 1,
+        createdAtMs: 1,
+        tokens: undefined,
+      },
+    });
+    expect(runtime.log).not.toHaveBeenCalledWith(
+      expect.stringContaining("Pending request req-old was replaced"),
+    );
+  });
+
+  it("approves a replacement request when the original repair inherited scopes from the paired token", async () => {
+    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
+    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
+    listDevicePairing
+      .mockResolvedValueOnce({
+        pending: [
+          {
+            requestId: "req-old",
+            deviceId: "device-1",
+            publicKey: "pk",
+            role: "operator",
+            scopes: [],
+            clientId: "openclaw-macos",
+            clientMode: "cli",
+            isRepair: true,
+            ts: 1,
+          },
+          {
+            requestId: "req-new",
+            deviceId: "device-1",
+            publicKey: "pk",
+            role: "operator",
+            scopes: ["operator.read", "operator.pairing"],
+            clientId: "openclaw-macos",
+            clientMode: "cli",
+            isRepair: true,
+            ts: 2,
+          },
+        ],
+        paired: [
+          {
+            deviceId: "device-1",
+            publicKey: "pk",
+            roles: ["operator"],
+            scopes: ["operator.read"],
+            tokens: [{ role: "operator", scopes: ["operator.read"] }],
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        pending: [
+          {
+            requestId: "req-new",
+            deviceId: "device-1",
+            publicKey: "pk",
+            role: "operator",
+            scopes: ["operator.read", "operator.pairing"],
+            clientId: "openclaw-macos",
+            clientMode: "cli",
+            isRepair: true,
+            ts: 2,
+          },
+        ],
+        paired: [
+          {
+            deviceId: "device-1",
+            publicKey: "pk",
+            roles: ["operator"],
+            scopes: ["operator.read"],
+            tokens: [{ role: "operator", scopes: ["operator.read"] }],
+          },
+        ],
+      });
+    approveDevicePairing.mockResolvedValueOnce({
+      requestId: "req-new",
+      device: {
+        deviceId: "device-1",
+        publicKey: "pk",
+        approvedAtMs: 1,
+        createdAtMs: 1,
+      },
+    });
+
+    await runDevicesApprove(["req-old"]);
+
+    expect(approveDevicePairing).toHaveBeenCalledWith("req-new", {
+      callerScopes: ["operator.admin"],
+    });
+    expect(readRuntimeOutput()).toContain(
+      "Pending request req-old was replaced by same-device repair req-new; approving latest compatible request.",
+    );
+  });
+
+  it("fails closed when the original request snapshot is missing", async () => {
+    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
+    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
+    listDevicePairing
+      .mockResolvedValueOnce({
+        pending: [
+          {
+            requestId: "req-new",
+            deviceId: "device-1",
+            publicKey: "pk",
+            role: "operator",
+            scopes: ["operator.read", "operator.pairing"],
+            clientId: "openclaw-macos",
+            clientMode: "cli",
+            isRepair: true,
+            ts: 2,
+          },
+        ],
+        paired: [],
+      })
+      .mockResolvedValueOnce({
+        pending: [
+          {
+            requestId: "req-new",
+            deviceId: "device-1",
+            publicKey: "pk",
+            role: "operator",
+            scopes: ["operator.read", "operator.pairing"],
+            clientId: "openclaw-macos",
+            clientMode: "cli",
+            isRepair: true,
+            ts: 2,
+          },
+        ],
+        paired: [],
+      });
+
+    await expect(runDevicesApprove(["req-old"])).rejects.toThrow(
+      "local fallback pairing state does not contain the gateway request",
+    );
+    expect(approveDevicePairing).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the replacement request is not a compatible scope superset", async () => {
+    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
+    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
+    listDevicePairing
+      .mockResolvedValueOnce({
+        pending: [
+          {
+            requestId: "req-old",
+            deviceId: "device-1",
+            publicKey: "pk",
+            role: "operator",
+            scopes: ["operator.read", "operator.write"],
+            clientId: "openclaw-macos",
+            clientMode: "cli",
+            isRepair: true,
+            ts: 1,
+          },
+          {
+            requestId: "req-new",
+            deviceId: "device-1",
+            publicKey: "pk",
+            role: "operator",
+            scopes: ["operator.pairing"],
+            clientId: "openclaw-macos",
+            clientMode: "cli",
+            isRepair: true,
+            ts: 2,
+          },
+        ],
+        paired: [],
+      })
+      .mockResolvedValueOnce({
+        pending: [
+          {
+            requestId: "req-new",
+            deviceId: "device-1",
+            publicKey: "pk",
+            role: "operator",
+            scopes: ["operator.pairing"],
+            clientId: "openclaw-macos",
+            clientMode: "cli",
+            isRepair: true,
+            ts: 2,
+          },
+        ],
+        paired: [],
+      });
+
+    await expect(runDevicesApprove(["req-old"])).rejects.toThrow(
+      "local fallback pairing state does not contain the gateway request",
+    );
+    expect(approveDevicePairing).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the replacement request adds unrelated broader scopes", async () => {
+    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
+    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
+    listDevicePairing
+      .mockResolvedValueOnce({
+        pending: [
+          {
+            requestId: "req-old",
+            deviceId: "device-1",
+            publicKey: "pk",
+            role: "operator",
+            scopes: ["operator.read"],
+            clientId: "openclaw-macos",
+            clientMode: "cli",
+            isRepair: true,
+            ts: 1,
+          },
+          {
+            requestId: "req-new",
+            deviceId: "device-1",
+            publicKey: "pk",
+            role: "operator",
+            scopes: ["operator.read", "operator.write"],
+            clientId: "openclaw-macos",
+            clientMode: "cli",
+            isRepair: true,
+            ts: 2,
+          },
+        ],
+        paired: [],
+      })
+      .mockResolvedValueOnce({
+        pending: [
+          {
+            requestId: "req-new",
+            deviceId: "device-1",
+            publicKey: "pk",
+            role: "operator",
+            scopes: ["operator.read", "operator.write"],
+            clientId: "openclaw-macos",
+            clientMode: "cli",
+            isRepair: true,
+            ts: 2,
+          },
+        ],
+        paired: [],
+      });
+
+    await expect(runDevicesApprove(["req-old"])).rejects.toThrow(
+      "local fallback pairing state does not contain the gateway request",
+    );
+    expect(approveDevicePairing).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the replacement request belongs to a different device", async () => {
+    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
+    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
+    listDevicePairing
+      .mockResolvedValueOnce({
+        pending: [
+          {
+            requestId: "req-old",
+            deviceId: "device-1",
+            publicKey: "pk",
+            role: "operator",
+            scopes: ["operator.read"],
+            clientId: "openclaw-macos",
+            clientMode: "cli",
+            isRepair: true,
+            ts: 1,
+          },
+          {
+            requestId: "req-new",
+            deviceId: "device-2",
+            publicKey: "pk",
+            role: "operator",
+            scopes: ["operator.read", "operator.pairing"],
+            clientId: "openclaw-macos",
+            clientMode: "cli",
+            isRepair: true,
+            ts: 2,
+          },
+        ],
+        paired: [],
+      })
+      .mockResolvedValueOnce({
+        pending: [
+          {
+            requestId: "req-new",
+            deviceId: "device-2",
+            publicKey: "pk",
+            role: "operator",
+            scopes: ["operator.read", "operator.pairing"],
+            clientId: "openclaw-macos",
+            clientMode: "cli",
+            isRepair: true,
+            ts: 2,
+          },
+        ],
+        paired: [],
+      });
+
+    await expect(runDevicesApprove(["req-old"])).rejects.toThrow(
+      "local fallback pairing state does not contain the gateway request",
+    );
+    expect(approveDevicePairing).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the replacement request has a different public key", async () => {
+    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
+    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
+    listDevicePairing
+      .mockResolvedValueOnce({
+        pending: [
+          {
+            requestId: "req-old",
+            deviceId: "device-1",
+            publicKey: "pk-old",
+            role: "operator",
+            scopes: ["operator.read"],
+            clientId: "openclaw-macos",
+            clientMode: "cli",
+            isRepair: true,
+            ts: 1,
+          },
+          {
+            requestId: "req-new",
+            deviceId: "device-1",
+            publicKey: "pk-new",
+            role: "operator",
+            scopes: ["operator.read", "operator.pairing"],
+            clientId: "openclaw-macos",
+            clientMode: "cli",
+            isRepair: true,
+            ts: 2,
+          },
+        ],
+        paired: [],
+      })
+      .mockResolvedValueOnce({
+        pending: [
+          {
+            requestId: "req-new",
+            deviceId: "device-1",
+            publicKey: "pk-new",
+            role: "operator",
+            scopes: ["operator.read", "operator.pairing"],
+            clientId: "openclaw-macos",
+            clientMode: "cli",
+            isRepair: true,
+            ts: 2,
+          },
+        ],
+        paired: [],
+      });
+
+    await expect(runDevicesApprove(["req-old"])).rejects.toThrow(
+      "local fallback pairing state does not contain the gateway request",
+    );
+    expect(approveDevicePairing).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the replacement request changes the requested role set", async () => {
+    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
+    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
+    listDevicePairing
+      .mockResolvedValueOnce({
+        pending: [
+          {
+            requestId: "req-old",
+            deviceId: "device-1",
+            publicKey: "pk",
+            role: "operator",
+            scopes: ["operator.read"],
+            clientId: "openclaw-macos",
+            clientMode: "cli",
+            isRepair: true,
+            ts: 1,
+          },
+          {
+            requestId: "req-new",
+            deviceId: "device-1",
+            publicKey: "pk",
+            roles: ["operator", "different-role"],
+            scopes: ["operator.read", "operator.pairing"],
+            clientId: "openclaw-macos",
+            clientMode: "cli",
+            isRepair: true,
+            ts: 2,
+          },
+        ],
+        paired: [],
+      })
+      .mockResolvedValueOnce({
+        pending: [
+          {
+            requestId: "req-new",
+            deviceId: "device-1",
+            publicKey: "pk",
+            roles: ["operator", "different-role"],
+            scopes: ["operator.read", "operator.pairing"],
+            clientId: "openclaw-macos",
+            clientMode: "cli",
+            isRepair: true,
+            ts: 2,
+          },
+        ],
+        paired: [],
+      });
+
+    await expect(runDevicesApprove(["req-old"])).rejects.toThrow(
+      "local fallback pairing state does not contain the gateway request",
+    );
+    expect(approveDevicePairing).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the replacement request conflicts with client metadata", async () => {
+    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
+    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
+    listDevicePairing
+      .mockResolvedValueOnce({
+        pending: [
+          {
+            requestId: "req-old",
+            deviceId: "device-1",
+            publicKey: "pk",
+            role: "operator",
+            scopes: ["operator.read"],
+            clientId: "openclaw-macos",
+            clientMode: "cli",
+            isRepair: true,
+            ts: 1,
+          },
+          {
+            requestId: "req-new",
+            deviceId: "device-1",
+            publicKey: "pk",
+            role: "operator",
+            scopes: ["operator.read", "operator.pairing"],
+            clientId: "openclaw-ios",
+            clientMode: "agent",
+            isRepair: true,
+            ts: 2,
+          },
+        ],
+        paired: [],
+      })
+      .mockResolvedValueOnce({
+        pending: [
+          {
+            requestId: "req-new",
+            deviceId: "device-1",
+            publicKey: "pk",
+            role: "operator",
+            scopes: ["operator.read", "operator.pairing"],
+            clientId: "openclaw-ios",
+            clientMode: "agent",
+            isRepair: true,
+            ts: 2,
+          },
+        ],
+        paired: [],
+      });
+
+    await expect(runDevicesApprove(["req-old"])).rejects.toThrow(
+      "local fallback pairing state does not contain the gateway request",
+    );
+    expect(approveDevicePairing).not.toHaveBeenCalled();
+  });
+
+  it("keeps unknown requestId behavior when neither the original nor replacement request remains pending", async () => {
+    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
+    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
+    listDevicePairing
+      .mockResolvedValueOnce({
+        pending: [
+          {
+            requestId: "req-old",
+            deviceId: "device-1",
+            publicKey: "pk",
+            role: "operator",
+            scopes: ["operator.read"],
+            clientId: "openclaw-macos",
+            clientMode: "cli",
+            isRepair: true,
+            ts: 1,
+          },
+          {
+            requestId: "req-new",
+            deviceId: "device-1",
+            publicKey: "pk",
+            role: "operator",
+            scopes: ["operator.read", "operator.pairing"],
+            clientId: "openclaw-macos",
+            clientMode: "cli",
+            isRepair: true,
+            ts: 2,
+          },
+        ],
+        paired: [],
+      })
+      .mockResolvedValueOnce({
+        pending: [],
+        paired: [],
+      });
+
+    await runDevicesApprove(["req-old"]);
+
+    expect(runtime.error).toHaveBeenCalledWith("unknown requestId");
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(approveDevicePairing).not.toHaveBeenCalled();
+  });
+
   it("falls back to local pairing list when gateway returns a scope upgrade message on loopback", async () => {
     mockLocalPairingFallback("scope upgrade pending approval (requestId: req-1)");
 
@@ -587,7 +1280,7 @@ describe("devices cli local fallback", () => {
     expect(readRuntimeOutput()).not.toContain(fallbackNotice);
   });
 
-  it("refuses local approve fallback when the gateway request is absent locally", async () => {
+  it("keeps the mismatch error when the gateway request itself is absent locally", async () => {
     rejectGatewayForLocalFallback("device pairing required (requestId: req-profile)");
     rejectGatewayForLocalFallback("device pairing required (requestId: req-profile)");
     approveDevicePairing.mockResolvedValueOnce(undefined);
@@ -598,15 +1291,15 @@ describe("devices cli local fallback", () => {
     expect(readRuntimeOutput()).not.toContain(fallbackNotice);
   });
 
-  it("refuses local approve fallback before approving a different local request", async () => {
+  it("keeps unknown requestId behavior instead of approving a different local request", async () => {
     rejectGatewayForLocalFallback("device pairing required (requestId: req-profile)");
     rejectGatewayForLocalFallback("device pairing required (requestId: req-profile)");
 
-    await expect(runDevicesApprove(["req-default"])).rejects.toThrow(
-      "local fallback pairing state does not contain the gateway request",
-    );
+    await runDevicesApprove(["req-default"]);
+
     expect(approveDevicePairing).not.toHaveBeenCalled();
-    expect(readRuntimeOutput()).not.toContain(fallbackNotice);
+    expect(runtime.error).toHaveBeenCalledWith("unknown requestId");
+    expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 
   it("does not use local fallback when an explicit --url is provided", async () => {

--- a/src/infra/device-pairing-churn.test.ts
+++ b/src/infra/device-pairing-churn.test.ts
@@ -1,0 +1,181 @@
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { normalizeDeviceAuthScopes } from "../shared/device-auth.js";
+import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
+import {
+  approveDevicePairing,
+  getPairedDevice,
+  listDevicePairing,
+  requestDevicePairing,
+  type PairedDevice,
+} from "./device-pairing.js";
+
+const DEVICE_ID = "device-cli";
+const PUBLIC_KEY = "public-key-cli";
+const suiteRootTracker = createSuiteTempRootTracker({ prefix: "openclaw-device-pairing-churn-" });
+
+function requireValue<T>(value: T | null | undefined, message: string): T {
+  if (value == null) {
+    throw new Error(message);
+  }
+  return value;
+}
+
+function expectScopesToContain(scopes: string[] | undefined, expected: readonly string[]) {
+  expect(scopes).toEqual(expect.arrayContaining([...expected]));
+}
+
+function readOperatorTokenScopes(device: PairedDevice | null): string[] {
+  return requireValue(device, "expected paired device").tokens?.operator?.scopes ?? [];
+}
+
+async function makeDevicePairingDir(): Promise<string> {
+  return await suiteRootTracker.make("case");
+}
+
+async function approveInitialPairing(baseDir: string, scopes: string[]) {
+  const request = await requestDevicePairing(
+    {
+      deviceId: DEVICE_ID,
+      publicKey: PUBLIC_KEY,
+      role: "operator",
+      scopes,
+    },
+    baseDir,
+  );
+  await approveDevicePairing(request.request.requestId, { callerScopes: scopes }, baseDir);
+  return request;
+}
+
+describe("device pairing requestId churn", () => {
+  beforeAll(async () => {
+    await suiteRootTracker.setup();
+  });
+
+  afterAll(async () => {
+    await suiteRootTracker.cleanup();
+  });
+
+  test("supersedes a stale read repair request when a devices-first flow reconnects to approve the repair", async () => {
+    const baseDir = await makeDevicePairingDir();
+
+    await approveInitialPairing(baseDir, ["operator.pairing"]);
+
+    const pairedAfterDevices = await getPairedDevice(DEVICE_ID, baseDir);
+    expect(pairedAfterDevices?.approvedScopes).toEqual(["operator.pairing"]);
+    expect(readOperatorTokenScopes(pairedAfterDevices)).toEqual(["operator.pairing"]);
+
+    const readRepair = await requestDevicePairing(
+      {
+        deviceId: DEVICE_ID,
+        publicKey: PUBLIC_KEY,
+        role: "operator",
+        scopes: ["operator.read"],
+      },
+      baseDir,
+    );
+    expect(readRepair.request.isRepair).toBe(true);
+    expect(readRepair.request.scopes).toEqual(["operator.read"]);
+    expect((await listDevicePairing(baseDir)).pending).toHaveLength(1);
+
+    // `openclaw devices approve <requestId>` reconnects with the caller scopes
+    // needed by the gateway. That reconnect supersedes the earlier repair request.
+    const approveReconnect = await requestDevicePairing(
+      {
+        deviceId: DEVICE_ID,
+        publicKey: PUBLIC_KEY,
+        role: "operator",
+        scopes: ["operator.pairing", "operator.read"],
+      },
+      baseDir,
+    );
+
+    expect(approveReconnect.created).toBe(true);
+    expect(approveReconnect.request.requestId).not.toBe(readRepair.request.requestId);
+
+    const staleApprove = await approveDevicePairing(
+      readRepair.request.requestId,
+      { callerScopes: ["operator.pairing", "operator.read"] },
+      baseDir,
+    );
+    expect(staleApprove).toBeNull();
+
+    const pairedAfterStaleApprove = await getPairedDevice(DEVICE_ID, baseDir);
+    expect(pairedAfterStaleApprove?.approvedScopes).toEqual(["operator.pairing"]);
+    expect(readOperatorTokenScopes(pairedAfterStaleApprove)).toEqual(["operator.pairing"]);
+    expect(pairedAfterStaleApprove?.publicKey).toBe(PUBLIC_KEY);
+
+    const pairingList = await listDevicePairing(baseDir);
+    expect(pairingList.pending).toHaveLength(1);
+    const pending = requireValue(pairingList.pending[0], "expected replacement pending request");
+    expect(pending.requestId).toBe(approveReconnect.request.requestId);
+    expect(pending.deviceId).toBe(DEVICE_ID);
+    expect(pending.publicKey).toBe(PUBLIC_KEY);
+    expect(pending.role).toBe("operator");
+    expectScopesToContain(pending.scopes, ["operator.pairing", "operator.read"]);
+  });
+
+  test("supports cron-first progressive operator escalation from read to pairing to admin", async () => {
+    const baseDir = await makeDevicePairingDir();
+
+    await approveInitialPairing(baseDir, ["operator.read"]);
+
+    const pairedAfterCron = await getPairedDevice(DEVICE_ID, baseDir);
+    expect(pairedAfterCron?.approvedScopes).toEqual(["operator.read"]);
+    expect(readOperatorTokenScopes(pairedAfterCron)).toEqual(["operator.read"]);
+
+    const pairingRepair = await requestDevicePairing(
+      {
+        deviceId: DEVICE_ID,
+        publicKey: PUBLIC_KEY,
+        role: "operator",
+        scopes: ["operator.pairing"],
+      },
+      baseDir,
+    );
+
+    const pairingApproved = await approveDevicePairing(
+      pairingRepair.request.requestId,
+      { callerScopes: ["operator.read", "operator.pairing"] },
+      baseDir,
+    );
+    expect(pairingApproved?.status).toBe("approved");
+    expect((await listDevicePairing(baseDir)).pending).toHaveLength(0);
+
+    const pairedAfterPairing = await getPairedDevice(DEVICE_ID, baseDir);
+    expectScopesToContain(pairedAfterPairing?.approvedScopes, [
+      "operator.read",
+      "operator.pairing",
+    ]);
+    expect(readOperatorTokenScopes(pairedAfterPairing)).toEqual(
+      normalizeDeviceAuthScopes(["operator.read", "operator.pairing"]),
+    );
+
+    const adminRepair = await requestDevicePairing(
+      {
+        deviceId: DEVICE_ID,
+        publicKey: PUBLIC_KEY,
+        role: "operator",
+        scopes: ["operator.admin"],
+      },
+      baseDir,
+    );
+
+    const adminApproved = await approveDevicePairing(
+      adminRepair.request.requestId,
+      { callerScopes: ["operator.admin"] },
+      baseDir,
+    );
+    expect(adminApproved?.status).toBe("approved");
+    expect((await listDevicePairing(baseDir)).pending).toHaveLength(0);
+
+    const pairedAfterAdmin = await getPairedDevice(DEVICE_ID, baseDir);
+    expectScopesToContain(pairedAfterAdmin?.approvedScopes, [
+      "operator.admin",
+      "operator.pairing",
+      "operator.read",
+    ]);
+    expect(readOperatorTokenScopes(pairedAfterAdmin)).toEqual(
+      normalizeDeviceAuthScopes(["operator.admin", "operator.pairing", "operator.read"]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Recover `openclaw devices approve <requestId>` when a local same-device repair request supersedes the request being approved.
- Require the replacement to match the original device identity, role/client metadata, and a compatible scope superset before approving it via local fallback.
- Add focused infra and CLI tests for devices-first requestId churn, cron-first progressive authority, replacement approval, fail-closed cases, and JSON/interactive output.

## Verification

- `pnpm test src/cli/devices-cli.test.ts src/infra/device-pairing-churn.test.ts`
- `git diff --check origin/main..HEAD`

## Real behavior proof

Behavior addressed: `openclaw devices approve <requestId>` no longer fails with an unclear `unknown requestId` when the same local CLI repair request has been superseded by a compatible replacement during the approval reconnect.

Real environment tested: Local source checkout on Linux after rebasing onto current `origin/main`; focused Vitest shards for CLI and infra pairing behavior.

Exact steps or command run after this patch: `pnpm test src/cli/devices-cli.test.ts src/infra/device-pairing-churn.test.ts`

Evidence after fix: Test output reported `src/infra/device-pairing-churn.test.ts (2 tests)` passed and `src/cli/devices-cli.test.ts (43 tests)` passed; `git diff --check origin/main..HEAD` produced no output.

Observed result after fix: same-device compatible replacement approvals use the replacement request ID, emit resolved metadata in JSON mode, print an interactive replacement notice, and fail closed for missing snapshots, incompatible scopes, cross-device replacements, public-key changes, role changes, metadata conflicts, remote `--url`, or missing pending requests.

What was not tested: Full packaged Docker/Crabbox smoke for the final branch; previous black-box validation was used to define the focused source-level regression coverage.

Refs: https://github.com/openclaw/openclaw/issues/74484
