### PR TITLE
fix(cron): classify network retry errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron: honor `cron.retry.retryOn: ["network"]` for common network error codes such as `EAI_AGAIN`, `EHOSTUNREACH`, and `ENETUNREACH`.
 - Agents/OpenAI: preserve structured provider error code, type, and redacted body metadata on boundary-aware transport failures.
 - CLI/agents: retry transient normal-close Gateway handshakes before falling back to embedded `openclaw agent` execution.
 - CLI/update: keep managed Gateway service stop/restart status lines out of `openclaw update --json` stdout so package-update automation can parse the JSON payload.

--- a/src/cron/retry-hint.test.ts
+++ b/src/cron/retry-hint.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { resolveCronExecutionRetryHint } from "./retry-hint.js";
+
+describe("resolveCronExecutionRetryHint", () => {
+  it("matches classified transient errors", () => {
+    expect(resolveCronExecutionRetryHint("HTTP 529", ["overloaded"])).toEqual({
+      retryable: true,
+      category: "overloaded",
+    });
+    expect(resolveCronExecutionRetryHint("429 rate limit exceeded", ["rate_limit"])).toEqual({
+      retryable: true,
+      category: "rate_limit",
+    });
+  });
+
+  it("treats common network error codes as network when retryOn only includes network", () => {
+    for (const code of [
+      "EAI_AGAIN",
+      "EHOSTUNREACH",
+      "EHOSTDOWN",
+      "ENETRESET",
+      "ENETUNREACH",
+      "EPIPE",
+    ]) {
+      expect(resolveCronExecutionRetryHint(`temporary DNS failure: ${code}`, ["network"])).toEqual({
+        retryable: true,
+        category: "network",
+      });
+    }
+  });
+
+  it("does not retry permanent errors", () => {
+    expect(resolveCronExecutionRetryHint("invalid API key", ["network"])).toEqual({
+      retryable: false,
+    });
+  });
+});

--- a/src/cron/retry-hint.ts
+++ b/src/cron/retry-hint.ts
@@ -1,0 +1,38 @@
+import type { CronRetryOn } from "../config/types.cron.js";
+
+export type CronRetryHint = {
+  retryable: boolean;
+  category?: CronRetryOn;
+};
+
+const TRANSIENT_PATTERNS: Record<CronRetryOn, RegExp> = {
+  rate_limit:
+    /(rate[_ ]limit|too many requests|429|resource has been exhausted|cloudflare|tokens per day)/i,
+  overloaded:
+    /\b529\b|\boverloaded(?:_error)?\b|high demand|temporar(?:ily|y) overloaded|capacity exceeded/i,
+  network:
+    /(network|fetch failed|socket|econnreset|econnrefused|eai_again|ehostunreach|ehostdown|enetreset|enetunreach|epipe)/i,
+  timeout: /(timeout|etimedout)/i,
+  server_error: /\b5\d{2}\b/,
+};
+
+export function resolveCronExecutionRetryHint(
+  error: string | undefined,
+  retryOn?: CronRetryOn[],
+  classifiedReason?: string | null,
+): CronRetryHint {
+  if (!error || typeof error !== "string") {
+    return { retryable: false };
+  }
+  const keys = retryOn?.length ? retryOn : (Object.keys(TRANSIENT_PATTERNS) as CronRetryOn[]);
+  const classified = classifiedReason ?? undefined;
+  if (classified && keys.includes(classified as CronRetryOn)) {
+    return { retryable: true, category: classified as CronRetryOn };
+  }
+  for (const key of keys) {
+    if (TRANSIENT_PATTERNS[key]?.test(error)) {
+      return { retryable: true, category: key };
+    }
+  }
+  return { retryable: false };
+}

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -2,7 +2,7 @@ import { resolveFailoverReasonFromError } from "../../agents/failover-error.js";
 import { formatEmbeddedAgentExecutionPhase } from "../../agents/pi-embedded-runner/execution-phase.js";
 import { readSessionEntry } from "../../config/sessions/store-load.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
-import type { CronConfig, CronRetryOn } from "../../config/types.cron.js";
+import type { CronConfig } from "../../config/types.cron.js";
 import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
 import {
   HEARTBEAT_SKIP_CRON_IN_PROGRESS,
@@ -25,6 +25,7 @@ import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import { clearCronJobActive, markCronJobActive } from "../active-jobs.js";
 import { resolveCronDeliveryPlan, resolveFailureDestination } from "../delivery-plan.js";
 import { resolveCronAgentSessionKey } from "../isolated-agent/session-key.js";
+import { resolveCronExecutionRetryHint } from "../retry-hint.js";
 import {
   createCronRunDiagnosticsFromError,
   normalizeCronRunDiagnostics,
@@ -560,28 +561,6 @@ function tryFinishCronTaskRun(
 /** Default max retries for one-shot jobs on transient errors (#24355). */
 const DEFAULT_MAX_TRANSIENT_RETRIES = 3;
 
-const TRANSIENT_PATTERNS: Record<string, RegExp> = {
-  rate_limit:
-    /(rate[_ ]limit|too many requests|429|resource has been exhausted|cloudflare|tokens per day)/i,
-  overloaded:
-    /\b529\b|\boverloaded(?:_error)?\b|high demand|temporar(?:ily|y) overloaded|capacity exceeded/i,
-  network: /(network|econnreset|econnrefused|fetch failed|socket)/i,
-  timeout: /(timeout|etimedout)/i,
-  server_error: /\b5\d{2}\b/,
-};
-
-function isTransientCronError(error: string | undefined, retryOn?: CronRetryOn[]): boolean {
-  if (!error || typeof error !== "string") {
-    return false;
-  }
-  const keys = retryOn?.length ? retryOn : (Object.keys(TRANSIENT_PATTERNS) as CronRetryOn[]);
-  const classified = resolveFailoverReasonFromError(error);
-  if (classified && keys.includes(classified as CronRetryOn)) {
-    return true;
-  }
-  return keys.some((k) => TRANSIENT_PATTERNS[k]?.test(error));
-}
-
 function resolveCronNextRunWithLowerBound(params: {
   state: CronServiceState;
   job: CronJob;
@@ -970,10 +949,14 @@ export function applyJobResult(
         job.state.nextRunAtMs = undefined;
       } else if (result.status === "error") {
         const retryConfig = resolveRetryConfig(state.deps.cronConfig);
-        const transient = isTransientCronError(result.error, retryConfig.retryOn);
+        const retryHint = resolveCronExecutionRetryHint(
+          result.error,
+          retryConfig.retryOn,
+          job.state.lastErrorReason,
+        );
         // consecutiveErrors is always set to ≥1 by the increment block above.
         const consecutive = job.state.consecutiveErrors;
-        if (transient && consecutive <= retryConfig.maxAttempts) {
+        if (retryHint.retryable && consecutive <= retryConfig.maxAttempts) {
           // Schedule retry with backoff (#24355).
           const backoff = errorBackoffMs(consecutive, retryConfig.backoffMs);
           job.state.nextRunAtMs = result.endedAt + backoff;
@@ -1000,7 +983,8 @@ export function applyJobResult(
               jobName: job.name,
               consecutiveErrors: consecutive,
               error: result.error,
-              reason: transient ? "max retries exhausted" : "permanent error",
+              reason: retryHint.retryable ? "max retries exhausted" : "permanent error",
+              retryCategory: retryHint.category,
             },
             "cron: disabling one-shot job after error",
           );


### PR DESCRIPTION
Summary
- Extract cron one-shot retry classification into `resolveCronExecutionRetryHint`.
- Treat common network error codes (`EAI_AGAIN`, `EHOSTUNREACH`, `EHOSTDOWN`, `ENETRESET`, `ENETUNREACH`, `EPIPE`) as `network` when `cron.retry.retryOn` is restricted to `network`.
- Add focused regression coverage and changelog entry.

Verification
- `pnpm format:check CHANGELOG.md src/cron/retry-hint.ts src/cron/retry-hint.test.ts src/cron/service/timer.ts`
- `git diff --check`
- `pnpm check:changed` via Testbox `tbx_01ks7rp7bzvzc9gx16k5q1nt9e`
- `node scripts/run-vitest.mjs src/cron/retry-hint.test.ts` via Testbox `tbx_01ks7rtr8a6a50fvpnv3b9djsh` (3 passed)
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local` (clean)

Behavior addressed: one-shot cron jobs with `cron.retry.retryOn: ["network"]` could skip retrying common network-code failures such as `EAI_AGAIN` because those codes were classified outside the small cron network regex.
Real environment tested: Blacksmith Testbox through Crabbox, provider `blacksmith-testbox`.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/cron/retry-hint.test.ts` and `pnpm check:changed`.
Evidence after fix: focused Testbox run `tbx_01ks7rtr8a6a50fvpnv3b9djsh` passed 3 retry-hint tests; changed gate `tbx_01ks7rp7bzvzc9gx16k5q1nt9e` exited 0.
Observed result after fix: network-only retry policy now marks those network-code strings retryable with category `network`.
What was not tested: no live provider outage was induced; this is deterministic cron retry classification coverage plus CI-parity changed checks.
