### PR TITLE
[codex] fix gateway derived plugin metadata reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 - QA-Lab: make the commitments heartbeat-target-none scenario request an immediate heartbeat instead of waiting for the next scheduled heartbeat.
 - Gateway CLI: surface local post-challenge connect assembly failures immediately instead of waiting for the wrapper timeout. Fixes #68944. (#85253) Thanks @samzong.
 - Agents/exec: treat denied exec approvals as terminal instead of feeding them back into agent follow-up work, and recognize Chinese stop phrases in abort handling. Fixes #69386. (#85194) Thanks @samzong.
+- Gateway/plugins: reuse Gateway-owned derived plugin metadata during startup auth prewarm so stale release registries do not trigger repeated source-tree scans on `main`. Thanks @amknight.
 - CLI/agents: abort accepted Gateway-backed `openclaw agent` runs on SIGINT/SIGTERM so cron and supervisor timeouts do not leave remote agent work alive. Fixes #71710. (#84381) Thanks @Kaspre.
 - Codex app-server: retry replay-safe stdio client-close turns once using structured failure metadata, while surfacing idle `turn/completed` timeouts instead of blindly replaying active shared-server turns. Thanks @VACInc.
 - Codex app-server: reject command overrides that embed Node or package-manager arguments and point users to `appServer.args`, so Windows startup avoids shell parsing failures. (#84417) Thanks @TurboTheTurtle.

--- a/src/agents/model-provider-auth.test.ts
+++ b/src/agents/model-provider-auth.test.ts
@@ -1,9 +1,16 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
 
 const modelCatalogMocks = vi.hoisted(() => ({
-  loadModelCatalog: vi.fn<() => Promise<ModelCatalogEntry[]>>(),
+  loadModelCatalog:
+    vi.fn<
+      (params: {
+        config: OpenClawConfig;
+        metadataSnapshot?: PluginMetadataSnapshot;
+      }) => Promise<ModelCatalogEntry[]>
+    >(),
 }));
 
 const modelAuthMocks = vi.hoisted(() => ({
@@ -81,6 +88,19 @@ describe("prepared provider auth state", () => {
     clearCurrentProviderAuthState();
     await expect(hasAuthForModelProvider({ provider: "anthropic", cfg })).resolves.toBe(true);
     expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(3);
+  });
+
+  it("passes a prepared metadata snapshot to model catalog warming", async () => {
+    const cfg = {} as OpenClawConfig;
+    const metadataSnapshot = {} as PluginMetadataSnapshot;
+    modelCatalogMocks.loadModelCatalog.mockResolvedValue([]);
+
+    await warmCurrentProviderAuthState(cfg, { metadataSnapshot });
+
+    expect(modelCatalogMocks.loadModelCatalog).toHaveBeenCalledWith({
+      config: cfg,
+      metadataSnapshot,
+    });
   });
 
   it("hasAuthForModelProvider falls through to compute when the caller narrows the auth-discovery scope", async () => {

--- a/src/agents/model-provider-auth.ts
+++ b/src/agents/model-provider-auth.ts
@@ -1,5 +1,6 @@
 import { hashRuntimeConfigValue } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import {
   listAgentIds,
   resolveAgentDir,
@@ -181,12 +182,18 @@ export function createProviderAuthChecker(params: {
   };
 }
 
-export async function warmCurrentProviderAuthState(cfg: OpenClawConfig): Promise<void> {
+export async function warmCurrentProviderAuthState(
+  cfg: OpenClawConfig,
+  options: { metadataSnapshot?: PluginMetadataSnapshot } = {},
+): Promise<void> {
   // Claim a fresh generation; any concurrent warm or clear bumps this and
   // turns our published state stale.
   currentProviderAuthStateGeneration += 1;
   const ownGeneration = currentProviderAuthStateGeneration;
-  const catalog = await loadModelCatalog({ config: cfg });
+  const catalog = await loadModelCatalog({
+    config: cfg,
+    ...(options.metadataSnapshot ? { metadataSnapshot: options.metadataSnapshot } : {}),
+  });
   const providers = new Set<string>();
   for (const entry of catalog) {
     providers.add(normalizeProviderId(entry.provider));

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -11,6 +11,7 @@ import type { scheduleGatewayUpdateCheck } from "../infra/update-startup.js";
 import type { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { PluginHookGatewayCronService } from "../plugins/hook-types.js";
 import type { loadOpenClawPlugins } from "../plugins/loader.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import { getPluginModuleLoaderStats } from "../plugins/plugin-module-loader-cache.js";
 import type { PluginRegistry } from "../plugins/registry.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
@@ -831,6 +832,7 @@ export async function startGatewayPostAttachRuntime(
       debug?: (msg: string) => void;
     };
     gatewayPluginConfigAtStart: OpenClawConfig;
+    pluginMetadataSnapshot?: PluginMetadataSnapshot;
     pluginRegistry: ReturnType<typeof loadOpenClawPlugins>;
     defaultWorkspaceDir: string;
     deps: CliDeps;
@@ -1043,7 +1045,10 @@ export async function startGatewayPostAttachRuntime(
         scheduleAuthMapRewarm("auth-profile-failure");
       });
       const startMs = Date.now();
-      await warmCurrentProviderAuthState(params.cfgAtStart);
+      await warmCurrentProviderAuthState(
+        params.cfgAtStart,
+        params.pluginMetadataSnapshot ? { metadataSnapshot: params.pluginMetadataSnapshot } : {},
+      );
       params.log.info(`provider auth state pre-warmed in ${Date.now() - startMs}ms`);
     })
     .catch((err) => {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -682,6 +682,7 @@ export async function startGatewayServer(
     compatibleConfigs: [startupRuntimeConfig, cfgAtStart, gatewayPluginConfigAtStart],
     env: process.env,
     workspaceDir: defaultWorkspaceDir,
+    allowGatewayDerivedSnapshot: true,
   });
   if (pluginLookUpTable) {
     const metrics = pluginLookUpTable.metrics;
@@ -1270,6 +1271,7 @@ export async function startGatewayServer(
         config: params.nextConfig,
         env: process.env,
         workspaceDir: defaultWorkspaceDir,
+        allowGatewayDerivedSnapshot: true,
       });
       const loaded = prepareGatewayPluginLoad({
         cfg: params.nextConfig,
@@ -1505,6 +1507,7 @@ export async function startGatewayServer(
             controlUiBasePath,
             logTailscale,
             gatewayPluginConfigAtStart,
+            pluginMetadataSnapshot: pluginLookUpTable,
             pluginRegistry,
             defaultWorkspaceDir,
             deps,

--- a/src/plugins/current-plugin-metadata-snapshot.test.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.test.ts
@@ -226,6 +226,25 @@ describe("current plugin metadata snapshot", () => {
     expect(getCurrentPluginMetadataSnapshot()).toBeUndefined();
   });
 
+  it("can explicitly keep gateway-owned derived registry snapshots", () => {
+    const config = { plugins: { allow: ["demo"] } };
+    const workspaceDir = "/workspace";
+    const snapshot = createSnapshot({ config, registrySource: "derived", workspaceDir });
+    setCurrentPluginMetadataSnapshot(snapshot, {
+      config,
+      workspaceDir,
+      allowGatewayDerivedSnapshot: true,
+    });
+
+    expect(getCurrentPluginMetadataSnapshot({ config, workspaceDir })).toBe(snapshot);
+    expect(
+      getCurrentPluginMetadataSnapshot({
+        config: { plugins: { allow: ["other"] } },
+        workspaceDir,
+      }),
+    ).toBeUndefined();
+  });
+
   it("restores a captured current snapshot state", () => {
     const firstConfig = { plugins: { allow: ["first"] } };
     const secondConfig = { plugins: { allow: ["second"] } };

--- a/src/plugins/current-plugin-metadata-snapshot.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.ts
@@ -25,8 +25,9 @@ export function resolvePluginMetadataControlPlaneFingerprint(
 
 export function isReusableCurrentPluginMetadataSnapshot(
   snapshot: PluginMetadataSnapshot,
+  options: { allowGatewayDerivedSnapshot?: boolean } = {},
 ): boolean {
-  return snapshot.registrySource !== "derived";
+  return snapshot.registrySource !== "derived" || options.allowGatewayDerivedSnapshot === true;
 }
 
 // Single-slot Gateway-owned handoff. Replace or clear it at lifecycle boundaries;
@@ -38,9 +39,10 @@ export function setCurrentPluginMetadataSnapshot(
     compatibleConfigs?: readonly OpenClawConfig[];
     env?: NodeJS.ProcessEnv;
     workspaceDir?: string;
+    allowGatewayDerivedSnapshot?: boolean;
   } = {},
 ): void {
-  if (snapshot && !isReusableCurrentPluginMetadataSnapshot(snapshot)) {
+  if (snapshot && !isReusableCurrentPluginMetadataSnapshot(snapshot, options)) {
     clearCurrentPluginMetadataSnapshotState();
     return;
   }

--- a/src/plugins/plugin-registry-snapshot.test.ts
+++ b/src/plugins/plugin-registry-snapshot.test.ts
@@ -271,6 +271,73 @@ describe("loadPluginRegistrySnapshotWithMetadata", () => {
     expect(result.source).not.toBe("provided");
   });
 
+  it("reuses a gateway-owned derived current metadata snapshot with registry diagnostics", () => {
+    const env = createHermeticEnv(makeTempDir());
+    const config = {};
+    const workspaceDir = path.join(makeTempDir(), "workspace");
+    const policyHash = resolveInstalledPluginIndexPolicyHash(config);
+    const index: InstalledPluginIndex = {
+      version: 1,
+      hostContractVersion: "test",
+      compatRegistryVersion: "test",
+      migrationVersion: 1,
+      policyHash,
+      generatedAtMs: 0,
+      installRecords: {},
+      plugins: [],
+      diagnostics: [],
+    };
+    const registryDiagnostics = [
+      {
+        level: "warn",
+        code: "persisted-registry-stale-source",
+        message: "stale",
+      },
+    ] as const;
+    setCurrentPluginMetadataSnapshot(
+      {
+        policyHash,
+        configFingerprint: "",
+        registrySource: "derived",
+        workspaceDir,
+        index,
+        registryDiagnostics,
+        manifestRegistry: { plugins: [], diagnostics: [] },
+        plugins: [],
+        diagnostics: [],
+        byPluginId: new Map(),
+        normalizePluginId: (pluginId: string) => pluginId,
+        owners: {
+          channels: new Map(),
+          channelConfigs: new Map(),
+          providers: new Map(),
+          modelCatalogProviders: new Map(),
+          cliBackends: new Map(),
+          setupProviders: new Map(),
+          commandAliases: new Map(),
+          contracts: new Map(),
+        },
+        metrics: {
+          registrySnapshotMs: 0,
+          manifestRegistryMs: 0,
+          ownerMapsMs: 0,
+          totalMs: 0,
+          indexPluginCount: 0,
+          manifestPluginCount: 0,
+        },
+      },
+      { config, env, workspaceDir, allowGatewayDerivedSnapshot: true },
+    );
+
+    const result = loadPluginRegistrySnapshotWithMetadata({ config, env, workspaceDir });
+
+    expect(result).toEqual({
+      snapshot: index,
+      source: "derived",
+      diagnostics: registryDiagnostics,
+    });
+  });
+
   it("does not reuse current metadata when explicit derivation inputs are supplied", () => {
     const tempRoot = makeTempDir();
     const env = {

--- a/src/plugins/plugin-registry-snapshot.ts
+++ b/src/plugins/plugin-registry-snapshot.ts
@@ -96,12 +96,15 @@ function loadCurrentPluginRegistrySnapshotResult(
     ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
     ...(params.workspaceDir === undefined ? { allowWorkspaceScopedSnapshot: true } : {}),
   });
-  if (!current || current.registryDiagnostics.length > 0) {
+  if (!current) {
+    return undefined;
+  }
+  if (current.registryDiagnostics.length > 0 && current.registrySource !== "derived") {
     return undefined;
   }
   return {
     snapshot: current.index,
-    source: "provided",
+    source: current.registrySource === "derived" ? "derived" : "provided",
     diagnostics: current.registryDiagnostics,
   };
 }

--- a/src/plugins/runtime/load-context.test.ts
+++ b/src/plugins/runtime/load-context.test.ts
@@ -52,7 +52,8 @@ vi.mock("../current-plugin-metadata-snapshot.js", () => ({
   getCurrentPluginMetadataSnapshot: getCurrentPluginMetadataSnapshotMock,
   isReusableCurrentPluginMetadataSnapshot: (
     snapshot: typeof metadataSnapshot & { registrySource?: "derived" },
-  ) => snapshot.registrySource !== "derived",
+    options: { allowGatewayDerivedSnapshot?: boolean } = {},
+  ) => snapshot.registrySource !== "derived" || options.allowGatewayDerivedSnapshot === true,
   setCurrentPluginMetadataSnapshot: setCurrentPluginMetadataSnapshotMock,
 }));
 
@@ -154,6 +155,29 @@ describe("resolvePluginRuntimeLoadContext", () => {
 
     expect(setCurrentPluginMetadataSnapshotMock).not.toHaveBeenCalled();
     expect(clearCurrentPluginMetadataSnapshotMock).toHaveBeenCalledOnce();
+  });
+
+  it("keeps gateway-owned derived metadata from the current snapshot slot", () => {
+    const derivedSnapshot = { ...metadataSnapshot } as typeof metadataSnapshot & {
+      registrySource: "derived";
+    };
+    derivedSnapshot.registrySource = "derived";
+    getCurrentPluginMetadataSnapshotMock.mockReturnValueOnce(derivedSnapshot as never);
+
+    resolvePluginRuntimeLoadContext({
+      config: { plugins: {} },
+      env: { HOME: "/tmp/openclaw-home" } as NodeJS.ProcessEnv,
+    });
+
+    expect(loadPluginMetadataSnapshotMock).not.toHaveBeenCalled();
+    expect(clearCurrentPluginMetadataSnapshotMock).not.toHaveBeenCalled();
+    expect(setCurrentPluginMetadataSnapshotMock).toHaveBeenCalledWith(derivedSnapshot, {
+      config: { plugins: {} },
+      compatibleConfigs: [{ plugins: {} }, { plugins: {} }],
+      env: { HOME: "/tmp/openclaw-home" },
+      workspaceDir: "/resolved-workspace",
+      allowGatewayDerivedSnapshot: true,
+    });
   });
 
   it("uses the source runtime snapshot for plugin activation source config", () => {

--- a/src/plugins/runtime/load-context.ts
+++ b/src/plugins/runtime/load-context.ts
@@ -68,13 +68,16 @@ export function resolvePluginRuntimeLoadContext(
   const rawConfig = options?.config ?? getRuntimeConfig();
   const rawWorkspaceDir =
     options?.workspaceDir ?? resolveAgentWorkspaceDir(rawConfig, resolveDefaultAgentId(rawConfig));
-  const metadataSnapshot = options?.manifestRegistry
+  const currentMetadataSnapshot = options?.manifestRegistry
     ? undefined
-    : (getCurrentPluginMetadataSnapshot({
+    : getCurrentPluginMetadataSnapshot({
         config: rawConfig,
         env,
         workspaceDir: rawWorkspaceDir,
-      }) ??
+      });
+  const metadataSnapshot = options?.manifestRegistry
+    ? undefined
+    : (currentMetadataSnapshot ??
       loadPluginMetadataSnapshot({
         config: rawConfig,
         env,
@@ -97,12 +100,19 @@ export function resolvePluginRuntimeLoadContext(
   const workspaceDir =
     options?.workspaceDir ?? resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
   if (metadataSnapshot) {
-    if (isReusableCurrentPluginMetadataSnapshot(metadataSnapshot)) {
+    const allowGatewayDerivedSnapshot =
+      currentMetadataSnapshot === metadataSnapshot && metadataSnapshot.registrySource === "derived";
+    if (
+      isReusableCurrentPluginMetadataSnapshot(metadataSnapshot, {
+        allowGatewayDerivedSnapshot,
+      })
+    ) {
       setCurrentPluginMetadataSnapshot(metadataSnapshot, {
         config: rawConfig,
         compatibleConfigs: [config, activationSourceConfig],
         env,
         workspaceDir,
+        ...(allowGatewayDerivedSnapshot ? { allowGatewayDerivedSnapshot } : {}),
       });
     } else {
       clearCurrentPluginMetadataSnapshot();


### PR DESCRIPTION
## Summary

- Allows Gateway-owned derived plugin metadata snapshots to remain reusable for the Gateway process when the persisted registry is stale or missing.
- Threads the prepared metadata snapshot into provider auth prewarm model catalog loading.
- Keeps registry snapshot source semantics intact by returning derived diagnostic snapshots as `source: "derived"`, not trusted `provided`.
- Preserves the derived snapshot when runtime load-context code reuses the current Gateway-owned slot.

## Verification

- `node scripts/run-vitest.mjs src/plugins/current-plugin-metadata-snapshot.test.ts src/agents/model-provider-auth.test.ts` passed: 3 files, 27 tests.
- `node scripts/run-vitest.mjs src/plugins/current-plugin-metadata-snapshot.test.ts src/plugins/plugin-registry-snapshot.test.ts src/agents/model-provider-auth.test.ts` passed: 4 files, 42 tests.
- `node scripts/run-vitest.mjs src/plugins/plugin-registry-snapshot.test.ts` passed: 1 file, 15 tests.
- `node scripts/run-vitest.mjs src/plugins/runtime/load-context.test.ts src/plugins/current-plugin-metadata-snapshot.test.ts src/plugins/plugin-registry-snapshot.test.ts src/agents/model-provider-auth.test.ts` passed: 5 files, 48 tests.
- `pnpm check:changed --staged` passed for each staged patch segment. One lint-core attempt hit a qa-channel boundary dts prep error, then the same command passed on retry without code changes.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` passed with no accepted/actionable findings.

## Real behavior proof

Behavior addressed: Gateway startup on source `main` after a stale release plugin registry should reuse the startup-derived plugin metadata instead of repeatedly scanning plugin manifests during auth/model prewarm.
Real environment tested: Local OpenClaw source checkout on macOS with focused Vitest, staged changed checks, and Codex autoreview.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/runtime/load-context.test.ts src/plugins/current-plugin-metadata-snapshot.test.ts src/plugins/plugin-registry-snapshot.test.ts src/agents/model-provider-auth.test.ts`; `pnpm check:changed --staged`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`.
Evidence after fix: Unit coverage proves derived snapshots are rejected by default, accepted only by Gateway opt-in, reused by registry snapshot lookups without being mislabeled as provided, preserved by runtime load-context handoff, and passed into auth prewarm model catalog loading.
Observed result after fix: Focused tests passed, staged checks passed, and autoreview reported no actionable findings.
What was not tested: A full live Gateway startup repro with the patched branch was not rerun before opening this draft PR.