### PR TITLE
fix(codex): skip native web search transcript mirroring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 - Cron: honor `cron.retry.retryOn: ["network"]` for common network error codes such as `EAI_AGAIN`, `EHOSTUNREACH`, and `ENETUNREACH`.
 - Gateway chat: broadcast returned agent-run error payloads after an agent starts so ACP/WebChat clients receive terminal idle-timeout errors. Fixes #84945.
 - Dashboard/CLI: allow macOS browser launching through `open` even when SSH environment variables are present, while preserving Linux SSH no-display protection. Fixes #67088. Thanks @theglove44.
+- Codex app-server: keep native web search observations out of mirrored chat transcripts while preserving tool progress telemetry. Fixes #85109. Thanks @ugitmebaby.
 - Agents/OpenAI: preserve structured provider error code, type, and redacted body metadata on boundary-aware transport failures.
 - Doctor/Codex: point native Codex asset warnings at the canonical `openclaw migrate plan codex` preview command. Fixes #84948. Thanks @markoa.
 - CLI/models: make `capability model auth logout --agent` remove auth profiles from the selected non-default agent store. Fixes #85092. Thanks @islandpreneur007.

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -2031,6 +2031,40 @@ describe("CodexAppServerEventProjector", () => {
     expect(toolResultContent.content).toBe("opened");
   });
 
+  it("does not mirror Codex-native web searches into transcript snapshots", async () => {
+    const projector = await createProjector();
+
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "webSearch",
+          id: "search-observed",
+          status: "completed",
+          durationMs: 5,
+        },
+      }),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(
+      result.messagesSnapshot.some((message) => {
+        const record = message as Record<string, unknown>;
+        if (record.role === "toolResult") {
+          return true;
+        }
+        const content = Array.isArray(record.content) ? record.content : [];
+        return content.some((entry) => {
+          return (
+            typeof entry === "object" &&
+            entry !== null &&
+            (entry as Record<string, unknown>).type === "toolCall"
+          );
+        });
+      }),
+    ).toBe(false);
+  });
+
   it("emits verbose summaries for transcript-recorded dynamic tool calls", async () => {
     const onAgentEvent = vi.fn();
     const onToolResult = vi.fn();

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -2049,7 +2049,7 @@ describe("CodexAppServerEventProjector", () => {
 
     expect(
       result.messagesSnapshot.some((message) => {
-        const record = message as Record<string, unknown>;
+        const record = message as unknown as Record<string, unknown>;
         if (record.role === "toolResult") {
           return true;
         }

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -1234,7 +1234,7 @@ export class CodexAppServerEventProjector {
   }
 
   private recordNativeToolTranscriptCall(item: CodexThreadItem | undefined): void {
-    if (!item || !shouldSynthesizeToolProgressForItem(item)) {
+    if (!item || !shouldRecordNativeToolTranscript(item)) {
       return;
     }
     const name = itemName(item);
@@ -1249,7 +1249,7 @@ export class CodexAppServerEventProjector {
   }
 
   private recordNativeToolTranscriptResult(item: CodexThreadItem | undefined): void {
-    if (!item || !shouldSynthesizeToolProgressForItem(item)) {
+    if (!item || !shouldRecordNativeToolTranscript(item)) {
       return;
     }
     const name = itemName(item);
@@ -1774,6 +1774,10 @@ function shouldSynthesizeToolProgressForItem(item: CodexThreadItem): boolean {
     default:
       return false;
   }
+}
+
+function shouldRecordNativeToolTranscript(item: CodexThreadItem): boolean {
+  return shouldSynthesizeToolProgressForItem(item) && item.type !== "webSearch";
 }
 
 function isMutatingNativeToolItem(item: CodexThreadItem): boolean {


### PR DESCRIPTION
Summary
- Stop recording Codex-native `webSearch` item observations as synthetic assistant/toolResult messages in mirrored transcript snapshots.
- Keep the existing native tool progress/telemetry path intact.
- Add a projector regression test for the transcript snapshot.

Verification
Behavior addressed: Codex-native web search observations no longer appear in chat/session history as empty `web_search` tool calls with stub-only results.
Real environment tested: local macOS source checkout.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.test.ts`; `git diff --check`; `.agents/skills/autoreview/scripts/autoreview --mode local`
Evidence after fix: regression test completes a native `webSearch` item and asserts the mirrored transcript snapshot contains no toolCall/toolResult messages for it.
Observed result after fix: focused test passed, diff check passed, autoreview reported no accepted/actionable findings.
What was not tested: live Codex app-server run with real web search.

Fixes #85109
