### PR TITLE
fix(daemon): use exit code instead of localized text for schtasks fallback

### DIFF
--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -248,6 +248,17 @@ describe("Windows startup fallback", () => {
     });
   });
 
+  it("falls back to a Startup-folder launcher when schtasks create returns localized access denied", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      addStartupFallbackMissingResponses([{ code: 1, stdout: "", stderr: "错误: 拒绝访问。" }]);
+
+      await installGatewayScheduledTask(env);
+
+      await expect(fs.access(resolveStartupEntryPath(env))).resolves.toBeUndefined();
+      expectStartupFallbackSpawn();
+    });
+  });
+
   it("falls back to a Startup-folder launcher when schtasks create hangs", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       addStartupFallbackMissingResponses([

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -38,6 +38,7 @@ function resolveTaskName(env: GatewayServiceEnv): string {
 function shouldFallbackToStartupEntry(params: { code: number; detail: string }): boolean {
   return (
     params.code === 1 ||
+    /(?:access is denied|acceso denegado)/i.test(params.detail) ||
     params.code === 124 ||
     /schtasks timed out/i.test(params.detail) ||
     /schtasks produced no output/i.test(params.detail)

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -37,7 +37,7 @@ function resolveTaskName(env: GatewayServiceEnv): string {
 
 function shouldFallbackToStartupEntry(params: { code: number; detail: string }): boolean {
   return (
-    /(?:access is denied|acceso denegado)/i.test(params.detail) ||
+    params.code === 1 ||
     params.code === 124 ||
     /schtasks timed out/i.test(params.detail) ||
     /schtasks produced no output/i.test(params.detail)


### PR DESCRIPTION
## Summary

Fixes `shouldFallbackToStartupEntry()` silently failing on non-English Windows systems by using exit code instead of localized error text matching.

## Problem

The regex only matched English/Spanish error messages (`"access is denied"` / `"acceso denegado"`), causing silent fallback failure on non-English Windows systems (Chinese, Japanese, French, German, Korean, Russian, etc.).

## Fix

- Replace `/access is denied|acceso denegado/i` regex with `params.code === 1`
- schtasks returns exit code 1 for access denied / generic failure regardless of system locale
- Locale-independent, simpler, and more reliable

## Files Changed

| File | Changes |
|------|---------|
| `src/daemon/schtasks.ts` | +1/-1 |

Fixes: #85255