### PR TITLE
fix(agents): keep hook context past cache boundary

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -668,6 +668,18 @@ describe("composeSystemPromptWithHookContext", () => {
     ).toBe("prepend line\nsecond line\n\nbase system\n\nappend");
   });
 
+  it("keeps hook system context after the cache boundary when the base prompt is split", () => {
+    const composedSystemPrompt = composeSystemPromptWithHookContext({
+      baseSystemPrompt: `stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}dynamic suffix`,
+      prependSystemContext: "  prepended hook context  ",
+      appendSystemContext: "  appended hook context  ",
+    });
+
+    expect(composedSystemPrompt).toBe(
+      `stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}prepended hook context\n\ndynamic suffix\n\nappended hook context`,
+    );
+  });
+
   it("avoids blank separators when base system prompt is empty", () => {
     expect(
       composeSystemPromptWithHookContext({

--- a/src/agents/pi-embedded-runner/run/attempt.thread-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.thread-helpers.ts
@@ -1,6 +1,10 @@
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { joinPresentTextSegments } from "../../../shared/text/join-segments.js";
 import { normalizeStructuredPromptSection } from "../../prompt-cache-stability.js";
+import {
+  SYSTEM_PROMPT_CACHE_BOUNDARY,
+  prependSystemPromptAdditionAfterCacheBoundary,
+} from "../../system-prompt-cache-boundary.js";
 
 export const ATTEMPT_CACHE_TTL_CUSTOM_TYPE = "openclaw.cache-ttl";
 
@@ -20,7 +24,21 @@ export function composeSystemPromptWithHookContext(params: {
   if (!prependSystem && !appendSystem) {
     return undefined;
   }
-  return joinPresentTextSegments([prependSystem, params.baseSystemPrompt, appendSystem], {
+
+  const baseSystemPrompt = params.baseSystemPrompt;
+  const baseHasCacheBoundary =
+    typeof baseSystemPrompt === "string" && baseSystemPrompt.includes(SYSTEM_PROMPT_CACHE_BOUNDARY);
+  if (baseHasCacheBoundary) {
+    const promptWithPrependedContext = prependSystemPromptAdditionAfterCacheBoundary({
+      systemPrompt: baseSystemPrompt,
+      systemPromptAddition: prependSystem,
+    });
+    return joinPresentTextSegments([promptWithPrependedContext, appendSystem], {
+      trim: true,
+    });
+  }
+
+  return joinPresentTextSegments([prependSystem, baseSystemPrompt, appendSystem], {
     trim: true,
   });
 }


### PR DESCRIPTION
## Summary

- Fixes #85203 by keeping prompt-build hook system context on the dynamic side of an existing `SYSTEM_PROMPT_CACHE_BOUNDARY` instead of prepending it before the cacheable stable prefix.
- Preserves the old prepend/base/append order for prompts that do not carry a cache boundary.
- Adds focused regression coverage for the boundary-aware hook context composition path.

## Tests

- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt.test.ts`
- `node scripts/run-vitest.mjs src/agents/system-prompt-cache-boundary.test.ts src/agents/pi-embedded-runner/run/attempt.test.ts src/agents/cli-runner.helpers.test.ts`
- `node --import tsx --input-type=module <<'EOF' ... EOF` (runtime helper proof shown below)
- `git diff --check`

## Real behavior proof

Behavior addressed: Runtime prompt-build hook system context could destabilize provider prompt caching by being concatenated before an already split system prompt; the patch keeps hook context after `SYSTEM_PROMPT_CACHE_BOUNDARY` so the stable prefix bytes remain unchanged while the hook context stays in the dynamic suffix.

Real environment tested: Local macOS source checkout on this PR head, Node via repo scripts, with existing/partially installed workspace dependencies. The runtime proof imported the real TypeScript helper through `tsx` and exercised the same `composeSystemPromptWithHookContext` function used by the embedded runner and CLI runner prepare path.

Exact steps or command run after this patch:

```sh
node --import tsx --input-type=module <<'EOF'
import { composeSystemPromptWithHookContext } from './src/agents/pi-embedded-runner/run/attempt.thread-helpers.ts';
import { SYSTEM_PROMPT_CACHE_BOUNDARY } from './src/agents/system-prompt-cache-boundary.ts';
const prompt = composeSystemPromptWithHookContext({
  baseSystemPrompt: `stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}dynamic suffix`,
  prependSystemContext: 'per-turn hook prepend',
  appendSystemContext: 'per-turn hook append',
});
console.log(JSON.stringify({ prompt, stablePrefixPreserved: prompt?.startsWith(`stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}`), prependedAfterBoundary: prompt?.includes(`${SYSTEM_PROMPT_CACHE_BOUNDARY}per-turn hook prepend\n\ndynamic suffix`) }, null, 2));
EOF
```

Evidence after fix: The runtime command printed:

```json
{
  "prompt": "stable prefix\n<!-- OPENCLAW_CACHE_BOUNDARY -->\nper-turn hook prepend\n\ndynamic suffix\n\nper-turn hook append",
  "stablePrefixPreserved": true,
  "prependedAfterBoundary": true
}
```

Observed result after fix: Hook prepend and append context remain visible in the composed system prompt, but the composed prompt still starts with the original stable prefix immediately followed by `SYSTEM_PROMPT_CACHE_BOUNDARY`; the per-turn hook prepend appears after the boundary and before the original dynamic suffix.

What was not tested: Live Anthropic/OpenAI cache telemetry was not run, and the broader issue list of all possible system-prompt concat sites was not mechanically rewritten. This PR intentionally limits the change to the source-proven `composeSystemPromptWithHookContext` runtime path and focused regression tests.
