### PR TITLE
fix(plugin-loader): prefer native loading for compiled SDK imports

### DIFF
--- a/src/plugins/plugin-module-loader-cache.test.ts
+++ b/src/plugins/plugin-module-loader-cache.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PluginModuleLoaderFactory } from "./plugin-module-loader-cache.js";
@@ -454,6 +457,100 @@ describe("getCachedPluginModuleLoader", () => {
       sourceTransformFallbacks: 0,
       sourceTransformForced: 0,
     });
+  });
+
+  it("tries native loading before source-transforming compiled plugin-sdk imports", async () => {
+    const fromSourceTransformer = vi.fn();
+    const createJiti = vi.fn(() => fromSourceTransformer);
+    const nativeStub = vi.fn((target: string) => ({
+      ok: true as const,
+      moduleExport: { loadedFrom: target },
+    }));
+    vi.doMock("./native-module-require.js", () => ({
+      isJavaScriptModulePath: (p: string) =>
+        p.endsWith(".js") || p.endsWith(".mjs") || p.endsWith(".cjs"),
+      tryNativeRequireJavaScriptModule: nativeStub,
+    }));
+    const { getCachedPluginModuleLoader, getPluginModuleLoaderStats } = await importFreshModule<
+      typeof import("./plugin-module-loader-cache.js")
+    >(import.meta.url, "./plugin-module-loader-cache.js?scope=plugin-sdk-native-first");
+
+    const cache = new Map();
+    const loader = getCachedPluginModuleLoader({
+      cache,
+      modulePath: "/repo/dist/extensions/codex/index.js",
+      importerUrl: "file:///repo/src/plugins/loader.ts",
+      loaderFilename: "file:///repo/src/plugins/loader.ts",
+      aliasMap: {
+        "openclaw/plugin-sdk/agent-runtime": "/repo/dist/plugin-sdk/agent-runtime.js",
+      },
+      tryNative: true,
+      createLoader: asPluginModuleLoaderFactory(createJiti),
+    });
+
+    const result = loader("/repo/dist/extensions/codex/index.js") as { loadedFrom: string };
+    expect(result.loadedFrom).toBe("/repo/dist/extensions/codex/index.js");
+    expect(createJiti).not.toHaveBeenCalled();
+    expect(fromSourceTransformer).not.toHaveBeenCalled();
+    expectNativeOptions(nativeStub, "/repo/dist/extensions/codex/index.js");
+    expectStats(getPluginModuleLoaderStats(), {
+      calls: 1,
+      nativeHits: 1,
+      nativeMisses: 0,
+      sourceTransformFallbacks: 0,
+      sourceTransformForced: 0,
+    });
+  });
+
+  it("falls back to alias source transform when native loading declines plugin-sdk imports", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-loader-"));
+    const target = path.join(tempDir, "codex-plugin.js");
+    fs.writeFileSync(
+      target,
+      'import { resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";\n',
+      "utf8",
+    );
+    const fromSourceTransformer = vi.fn(() => ({ fromSourceTransform: true }));
+    const createJiti = vi.fn(() => fromSourceTransformer);
+    const nativeStub = vi.fn(() => ({ ok: false as const }));
+    vi.doMock("./native-module-require.js", () => ({
+      isJavaScriptModulePath: () => true,
+      tryNativeRequireJavaScriptModule: nativeStub,
+    }));
+    const { getCachedPluginModuleLoader, getPluginModuleLoaderStats } = await importFreshModule<
+      typeof import("./plugin-module-loader-cache.js")
+    >(import.meta.url, "./plugin-module-loader-cache.js?scope=plugin-sdk-alias-fallback");
+
+    const cache = new Map();
+    const loader = getCachedPluginModuleLoader({
+      cache,
+      modulePath: target,
+      importerUrl: "file:///repo/src/plugins/loader.ts",
+      loaderFilename: "file:///repo/src/plugins/loader.ts",
+      aliasMap: {
+        "openclaw/plugin-sdk/agent-runtime": "/repo/dist/plugin-sdk/agent-runtime.js",
+      },
+      tryNative: true,
+      createLoader: asPluginModuleLoaderFactory(createJiti),
+    });
+
+    const result = loader(target) as {
+      fromSourceTransform: boolean;
+    };
+    expect(result.fromSourceTransform).toBe(true);
+    expectNativeOptions(nativeStub, target);
+    expectJitiOptions(createJiti, 0, "file:///repo/src/plugins/loader.ts", {
+      tryNative: false,
+    });
+    expect(fromSourceTransformer).toHaveBeenCalledWith(target);
+    const stats = expectStats(getPluginModuleLoaderStats(), {
+      calls: 1,
+      nativeHits: 0,
+      nativeMisses: 1,
+      sourceTransformFallbacks: 1,
+      sourceTransformForced: 0,
+    });
+    expect(stats.topSourceTransformTargets).toEqual([{ target, count: 1 }]);
   });
 
   it("does not source-transform fallback after native loading reaches a missing dependency", async () => {

--- a/src/plugins/plugin-module-loader-cache.ts
+++ b/src/plugins/plugin-module-loader-cache.ts
@@ -277,14 +277,10 @@ function createPluginModuleLoader(params: {
   });
   return ((target: string, ...rest: unknown[]) => {
     pluginModuleLoaderStats.calls += 1;
-    if (shouldForceSourceTransformForPluginSdkAlias({ target, aliasMap: params.aliasMap })) {
-      pluginModuleLoaderStats.sourceTransformForced += 1;
-      recordSourceTransformTarget(target);
-      return (getLoadWithAliasTransform() as (t: string, ...a: unknown[]) => unknown)(
-        target,
-        ...rest,
-      );
-    }
+    const needsPluginSdkAliasTransform = shouldForceSourceTransformForPluginSdkAlias({
+      target,
+      aliasMap: params.aliasMap,
+    });
     const native = tryNativeRequireJavaScriptModule(target, {
       allowWindows: true,
       aliasMap: params.aliasMap,
@@ -294,6 +290,15 @@ function createPluginModuleLoader(params: {
     if (native.ok) {
       pluginModuleLoaderStats.nativeHits += 1;
       return native.moduleExport;
+    }
+    if (needsPluginSdkAliasTransform) {
+      pluginModuleLoaderStats.nativeMisses += 1;
+      pluginModuleLoaderStats.sourceTransformFallbacks += 1;
+      recordSourceTransformTarget(target);
+      return (getLoadWithAliasTransform() as (t: string, ...a: unknown[]) => unknown)(
+        target,
+        ...rest,
+      );
     }
     pluginModuleLoaderStats.nativeMisses += 1;
     pluginModuleLoaderStats.sourceTransformFallbacks += 1;


### PR DESCRIPTION
## Summary

This changes the plugin module loader to try native loading before forcing `jiti` source transformation for compiled JavaScript files that import `openclaw/plugin-sdk/*`.

The loader still preserves the existing safety fallback: if native loading declines and the file needs plugin-sdk alias rewriting, it falls back to the alias-aware `jiti` path.

## Why

On a 2026.5.18 install, `openclaw infer audio providers --json` spent most of its cold-start time loading the Codex plugin through `jiti` even though the plugin is already compiled JS.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: compiled JavaScript plugins that import `openclaw/plugin-sdk/*` should prefer native loading before falling back to alias-aware `jiti`, reducing real CLI/plugin discovery startup time without breaking transcription.
- Real environment tested: Real OpenClaw install/checkout on Linux, Node.js v24.2.0, patched into a throwaway copy of the installed runtime from the 2026.5.18 install.
- Exact steps or command run after this patch:

```bash
OPENCLAW_PLUGIN_LOAD_PROFILE=1 openclaw infer audio providers --json
openclaw infer audio providers --json
openclaw infer audio transcribe /tmp/openclaw-proof.ogg --provider openai --model gpt-4o-transcribe
corepack pnpm exec vitest run src/plugins/plugin-module-loader-cache.test.ts
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied live timing output from the throwaway patched runtime:

```text
Current live install: openclaw infer audio providers --json ~35-38s
OPENCLAW_PLUGIN_LOAD_PROFILE=1: Codex discovery alone ~25-30s
CPU profile: dominated by jiti loading/transformation under @openclaw/codex/dist/...
Direct native import of @openclaw/codex/dist/index.js: ~3.6s
Patched runtime: infer audio providers --json ~12.8s
Patched runtime: infer audio transcribe on the same 5.48s OGG test file ~15.5s
Actual hosted OpenAI transcription request inside that run: ~1.7-2.8s
```

- Observed result after fix: The real patched runtime kept provider listing and OpenAI transcription working while reducing the provider-listing path from roughly 35-38s to roughly 12.8s, with plugin load overhead no longer dominated by the Codex `jiti` transform path.
- What was not tested: I did not run every third-party plugin or every provider; this proof covered the compiled Codex plugin path and one real OpenAI audio transcription path.
- Before evidence (optional but encouraged): Baseline live install measurement above showed `openclaw infer audio providers --json` at roughly 35-38s, with Codex discovery alone around 25-30s under `OPENCLAW_PLUGIN_LOAD_PROFILE=1`.

## Tests

- `corepack pnpm exec vitest run src/plugins/plugin-module-loader-cache.test.ts`
