### PR TITLE
fix(tools): honor config auth for media model selection

### DIFF
--- a/src/agents/tools/image-generate-tool.actions.ts
+++ b/src/agents/tools/image-generate-tool.actions.ts
@@ -60,6 +60,7 @@ export function summarizeImageGenerationCapabilities(provider: ImageGenerationPr
 
 export function createImageGenerateListActionResult(params: {
   cfg?: OpenClawConfig;
+  workspaceDir?: string;
   agentDir?: string;
   authStore?: AuthProfileStore;
 }): ImageGenerateActionResult {
@@ -69,6 +70,7 @@ export function createImageGenerateListActionResult(params: {
     providers,
     emptyText: "No image-generation providers are registered.",
     cfg: params.cfg,
+    workspaceDir: params.workspaceDir,
     agentDir: params.agentDir,
     authStore: params.authStore,
     listModes: listSupportedImageGenerationModes,

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -202,11 +202,13 @@ const ImageGenerateToolSchema = Type.Object({
 
 export function resolveImageGenerationModelConfigForTool(params: {
   cfg?: OpenClawConfig;
+  workspaceDir?: string;
   agentDir?: string;
   authStore?: AuthProfileStore;
 }): ToolModelConfig | null {
   return resolveCapabilityModelConfigForTool({
     cfg: params.cfg,
+    workspaceDir: params.workspaceDir,
     agentDir: params.agentDir,
     authStore: params.authStore,
     modelConfig: params.cfg?.agents?.defaults?.imageGenerationModel,
@@ -799,6 +801,7 @@ export function createImageGenerateTool(options?: {
       if (action === "list") {
         return createImageGenerateListActionResult({
           cfg,
+          workspaceDir: options?.workspaceDir,
           agentDir: options?.agentDir,
           authStore: options?.authProfileStore,
         });
@@ -809,6 +812,7 @@ export function createImageGenerateTool(options?: {
 
       const imageGenerationModelConfig = resolveImageGenerationModelConfigForTool({
         cfg,
+        workspaceDir: options?.workspaceDir,
         agentDir: options?.agentDir,
         authStore: options?.authProfileStore,
       });

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -121,6 +121,41 @@ vi.mock("../auth-profiles.js", () => ({
 }));
 
 vi.mock("../model-auth.js", () => ({
+  resolveModelAuthMode: (
+    provider: string,
+    cfg?: OpenClawConfig,
+    authStore?: { profiles?: Record<string, { provider?: string; type?: string }> },
+  ) => {
+    const providerConfig = cfg?.models?.providers?.[provider];
+    if (providerConfig?.auth === "aws-sdk") {
+      return "aws-sdk";
+    }
+    if (provider === "amazon-bedrock" && providerConfig?.auth === undefined) {
+      return "aws-sdk";
+    }
+    const apiKey = providerConfig?.apiKey;
+    if (typeof apiKey === "string" && apiKey.trim().length > 0) {
+      return "api-key";
+    }
+    const profile = Object.values(authStore?.profiles ?? {}).find(
+      (entry) => entry?.provider === provider,
+    );
+    return profile?.type === "oauth" || profile?.type === "token" ? profile.type : undefined;
+  },
+  hasRuntimeAvailableProviderAuth: ({
+    provider,
+    cfg,
+  }: {
+    provider: string;
+    cfg?: OpenClawConfig;
+  }) => {
+    const providerConfig = cfg?.models?.providers?.[provider];
+    const apiKey = providerConfig?.apiKey;
+    if (typeof apiKey === "string" && apiKey.trim().length > 0) {
+      return true;
+    }
+    return false;
+  },
   resolveEnvApiKey: (provider: string) => {
     const envVarByProvider: Record<string, string[]> = {
       anthropic: ["ANTHROPIC_API_KEY", "ANTHROPIC_OAUTH_TOKEN"],
@@ -1060,6 +1095,30 @@ describe("image tool implicit imageModel config", () => {
     });
   });
 
+  it("pairs a custom provider when config declares its api key", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { model: { primary: "hatchery-qwen3.6-plus/text-1" } } },
+        models: {
+          providers: {
+            "hatchery-qwen3.6-plus": {
+              baseUrl: "https://example.com",
+              apiKey: "sk-configured", // pragma: allowlist secret
+              models: [
+                makeModelDefinition("text-1", ["text"]),
+                makeModelDefinition("qwen3.6-plus", ["text", "image"]),
+              ],
+            },
+          },
+        },
+      };
+      expect(resolveImageModelConfigForTool({ cfg, agentDir })).toEqual({
+        primary: "hatchery-qwen3.6-plus/qwen3.6-plus",
+      });
+      expect(typeof createImageTool({ config: cfg, agentDir })?.execute).toBe("function");
+    });
+  });
+
   it("does not double-prefix custom provider model IDs that already include the provider", async () => {
     await withTempAgentDir(async (agentDir) => {
       await writeAuthProfiles(agentDir, {
@@ -1107,6 +1166,8 @@ describe("image tool implicit imageModel config", () => {
           providers: {
             "amazon-bedrock": {
               baseUrl: "https://example.com",
+              auth: "api-key",
+              apiKey: "sk-configured", // pragma: allowlist secret
               models: [
                 makeModelDefinition("text-1", ["text"]),
                 makeModelDefinition("vision-1", ["text", "image"]),

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -239,6 +239,8 @@ export function resolveImageModelConfigForTool(params: {
 
   return buildToolModelConfigFromCandidates({
     explicit,
+    cfg: params.cfg,
+    workspaceDir: params.workspaceDir,
     agentDir: params.agentDir,
     authStore: params.authStore,
     candidates: [...primaryAliasCandidates, ...primaryCandidates, ...remainingAutoCandidates],

--- a/src/agents/tools/media-generate-tool-actions-shared.ts
+++ b/src/agents/tools/media-generate-tool-actions-shared.ts
@@ -45,6 +45,7 @@ export function createMediaGenerateProviderListActionResult<
   providers: TProvider[];
   emptyText: string;
   cfg?: OpenClawConfig;
+  workspaceDir?: string;
   agentDir?: string;
   authStore?: AuthProfileStore;
   listModes: (provider: TProvider) => string[];
@@ -72,6 +73,7 @@ export function createMediaGenerateProviderListActionResult<
           providers: params.providers,
           provider,
           cfg: params.cfg,
+          workspaceDir: params.workspaceDir,
           agentDir: params.agentDir,
           authStore: params.authStore,
         }),

--- a/src/agents/tools/media-tool-shared.test.ts
+++ b/src/agents/tools/media-tool-shared.test.ts
@@ -104,6 +104,28 @@ describe("resolveModelFromRegistry", () => {
 });
 
 describe("hasGenerationToolAvailability", () => {
+  it("accepts config-backed custom provider auth for generation providers", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "custom-image": {
+            baseUrl: "https://example.com/v1",
+            apiKey: "sk-configured", // pragma: allowlist secret
+            models: [],
+          },
+        },
+      },
+    };
+
+    expect(
+      hasGenerationToolAvailability({
+        providerKey: "imageGenerationProviders",
+        cfg,
+        providers: [{ id: "custom-image", defaultModel: "workflow" }],
+      }),
+    ).toBe(true);
+  });
+
   it("allows generation tools for runtime providers configured without auth", () => {
     expect(
       hasGenerationToolAvailability({

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -27,7 +27,7 @@ import {
 import {
   buildToolModelConfigFromCandidates,
   coerceToolModelConfig,
-  hasAuthForProvider,
+  hasProviderAuthForTool,
   hasToolModelConfig,
   resolveDefaultModelRef,
   type ToolModelConfig,
@@ -192,6 +192,7 @@ export function isCapabilityProviderConfigured<T extends CapabilityProvider>(par
   provider?: T;
   providerId?: string;
   cfg?: OpenClawConfig;
+  workspaceDir?: string;
   agentDir?: string;
   authStore?: AuthProfileStore;
 }): boolean {
@@ -203,8 +204,10 @@ export function isCapabilityProviderConfigured<T extends CapabilityProvider>(par
     });
   if (!provider) {
     return params.providerId
-      ? hasAuthForProvider({
+      ? hasProviderAuthForTool({
           provider: params.providerId,
+          cfg: params.cfg,
+          workspaceDir: params.workspaceDir,
           agentDir: params.agentDir,
           authStore: params.authStore,
         })
@@ -216,8 +219,10 @@ export function isCapabilityProviderConfigured<T extends CapabilityProvider>(par
       agentDir: params.agentDir,
     });
   }
-  return hasAuthForProvider({
+  return hasProviderAuthForTool({
     provider: provider.id,
+    cfg: params.cfg,
+    workspaceDir: params.workspaceDir,
     agentDir: params.agentDir,
     authStore: params.authStore,
   });
@@ -251,6 +256,7 @@ export function resolveSelectedCapabilityProvider<T extends CapabilityProvider>(
 
 function resolveCapabilityModelCandidatesForTool(params: {
   cfg?: OpenClawConfig;
+  workspaceDir?: string;
   agentDir?: string;
   authStore?: AuthProfileStore;
   providers: CapabilityProvider[];
@@ -267,6 +273,7 @@ function resolveCapabilityModelCandidatesForTool(params: {
         providers: params.providers,
         provider,
         cfg: params.cfg,
+        workspaceDir: params.workspaceDir,
         agentDir: params.agentDir,
         authStore: params.authStore,
       })
@@ -309,6 +316,7 @@ function resolveCapabilityModelCandidatesForTool(params: {
 
 export function resolveCapabilityModelConfigForTool(params: {
   cfg?: OpenClawConfig;
+  workspaceDir?: string;
   agentDir?: string;
   authStore?: AuthProfileStore;
   modelConfig?: AgentModelConfig;
@@ -326,10 +334,13 @@ export function resolveCapabilityModelConfigForTool(params: {
   };
   return buildToolModelConfigFromCandidates({
     explicit,
+    cfg: params.cfg,
+    workspaceDir: params.workspaceDir,
     agentDir: params.agentDir,
     authStore: params.authStore,
     candidates: resolveCapabilityModelCandidatesForTool({
       cfg: params.cfg,
+      workspaceDir: params.workspaceDir,
       agentDir: params.agentDir,
       authStore: params.authStore,
       providers: getProviders(),
@@ -339,6 +350,7 @@ export function resolveCapabilityModelConfigForTool(params: {
         providers: getProviders(),
         providerId,
         cfg: params.cfg,
+        workspaceDir: params.workspaceDir,
         agentDir: params.agentDir,
         authStore: params.authStore,
       }),
@@ -367,6 +379,7 @@ export function hasGenerationToolAvailability(params: {
         providers,
         provider,
         cfg: params.cfg,
+        workspaceDir: params.workspaceDir,
         agentDir: params.agentDir,
         authStore: params.authStore,
       }),
@@ -396,8 +409,10 @@ export function hasGenerationToolAvailability(params: {
     contract: params.providerKey,
     config: params.cfg,
   }).some((providerId) =>
-    hasAuthForProvider({
+    hasProviderAuthForTool({
       provider: providerId,
+      cfg: params.cfg,
+      workspaceDir: params.workspaceDir,
       agentDir: params.agentDir,
       authStore: params.authStore,
     }),

--- a/src/agents/tools/model-config.helpers.test.ts
+++ b/src/agents/tools/model-config.helpers.test.ts
@@ -139,6 +139,24 @@ describe("hasProviderAuthForTool", () => {
     });
   });
 
+  it("keeps config env API keys even when amazon-bedrock config defaults to aws-sdk", () => {
+    vi.stubEnv("BEDROCK_API_KEY", "sk-env-profile"); // pragma: allowlist secret
+    const cfg = {
+      models: {
+        providers: {
+          "amazon-bedrock": {
+            baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+            auth: "aws-sdk",
+            apiKey: { source: "env", provider: "default", id: "BEDROCK_API_KEY" },
+            models: [],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(hasProviderAuthForTool({ provider: "amazon-bedrock", cfg })).toBe(true);
+  });
+
   it("rejects providers without config, env, or profile auth", () => {
     expect(hasProviderAuthForTool({ provider: "unconfigured-provider" })).toBe(false);
   });

--- a/src/agents/tools/model-config.helpers.test.ts
+++ b/src/agents/tools/model-config.helpers.test.ts
@@ -1,6 +1,27 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import { hasProviderAuthForTool } from "./model-config.helpers.js";
+
+async function withTempAgentDir<T>(run: (agentDir: string) => Promise<T>): Promise<T> {
+  const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-tool-auth-"));
+  try {
+    return await run(agentDir);
+  } finally {
+    await fs.rm(agentDir, { recursive: true, force: true });
+  }
+}
+
+async function writeAuthProfiles(agentDir: string, profiles: unknown) {
+  await fs.mkdir(agentDir, { recursive: true });
+  await fs.writeFile(
+    path.join(agentDir, "auth-profiles.json"),
+    `${JSON.stringify(profiles, null, 2)}\n`,
+    "utf8",
+  );
+}
 
 describe("hasProviderAuthForTool", () => {
   afterEach(() => {
@@ -59,6 +80,63 @@ describe("hasProviderAuthForTool", () => {
 
   it("rejects implicit amazon-bedrock aws-sdk auth for tool preflight", () => {
     expect(hasProviderAuthForTool({ provider: "amazon-bedrock", cfg: {} })).toBe(false);
+  });
+
+  it("keeps agent-local amazon-bedrock API key profiles before implicit aws-sdk rejection", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      await writeAuthProfiles(agentDir, {
+        version: 1,
+        profiles: {
+          "amazon-bedrock:default": {
+            provider: "amazon-bedrock",
+            type: "api_key",
+            key: "sk-profile", // pragma: allowlist secret
+          },
+        },
+      });
+
+      const cfg = {
+        models: {
+          providers: {
+            "amazon-bedrock": {
+              baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+              models: [],
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      expect(hasProviderAuthForTool({ provider: "amazon-bedrock", cfg, agentDir })).toBe(true);
+    });
+  });
+
+  it("still rejects explicit amazon-bedrock aws-sdk auth for tool preflight", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      await writeAuthProfiles(agentDir, {
+        version: 1,
+        profiles: {
+          "amazon-bedrock:default": {
+            provider: "amazon-bedrock",
+            type: "api_key",
+            key: "sk-profile", // pragma: allowlist secret
+          },
+        },
+      });
+
+      const cfg = {
+        models: {
+          providers: {
+            "amazon-bedrock": {
+              baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+              auth: "aws-sdk",
+              models: [],
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      expect(hasProviderAuthForTool({ provider: "amazon-bedrock", cfg, agentDir })).toBe(false);
+    });
   });
 
   it("rejects providers without config, env, or profile auth", () => {

--- a/src/agents/tools/model-config.helpers.test.ts
+++ b/src/agents/tools/model-config.helpers.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { hasProviderAuthForTool } from "./model-config.helpers.js";
+
+describe("hasProviderAuthForTool", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("accepts config-backed custom provider auth", () => {
+    const cfg = {
+      models: {
+        providers: {
+          hatchery: {
+            baseUrl: "https://example.com/v1",
+            apiKey: "sk-configured", // pragma: allowlist secret
+            models: [],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(hasProviderAuthForTool({ provider: "hatchery", cfg })).toBe(true);
+  });
+
+  it("keeps auth-store profiles as valid tool auth", () => {
+    expect(
+      hasProviderAuthForTool({
+        provider: "hatchery",
+        authStore: {
+          version: 1,
+          profiles: {
+            "hatchery:default": {
+              provider: "hatchery",
+              type: "api_key",
+              key: "sk-profile", // pragma: allowlist secret
+            },
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects aws-sdk auth because tool execution requires an API key string", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "amazon-bedrock": {
+            baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+            auth: "aws-sdk",
+            models: [],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(hasProviderAuthForTool({ provider: "amazon-bedrock", cfg })).toBe(false);
+  });
+
+  it("rejects implicit amazon-bedrock aws-sdk auth for tool preflight", () => {
+    expect(hasProviderAuthForTool({ provider: "amazon-bedrock", cfg: {} })).toBe(false);
+  });
+
+  it("rejects providers without config, env, or profile auth", () => {
+    expect(hasProviderAuthForTool({ provider: "unconfigured-provider" })).toBe(false);
+  });
+});

--- a/src/agents/tools/model-config.helpers.test.ts
+++ b/src/agents/tools/model-config.helpers.test.ts
@@ -110,7 +110,7 @@ describe("hasProviderAuthForTool", () => {
     });
   });
 
-  it("still rejects explicit amazon-bedrock aws-sdk auth for tool preflight", async () => {
+  it("keeps agent-local API key profiles even when amazon-bedrock config defaults to aws-sdk", async () => {
     await withTempAgentDir(async (agentDir) => {
       await writeAuthProfiles(agentDir, {
         version: 1,
@@ -135,7 +135,7 @@ describe("hasProviderAuthForTool", () => {
         },
       } as OpenClawConfig;
 
-      expect(hasProviderAuthForTool({ provider: "amazon-bedrock", cfg, agentDir })).toBe(false);
+      expect(hasProviderAuthForTool({ provider: "amazon-bedrock", cfg, agentDir })).toBe(true);
     });
   });
 

--- a/src/agents/tools/model-config.helpers.test.ts
+++ b/src/agents/tools/model-config.helpers.test.ts
@@ -62,6 +62,81 @@ describe("hasProviderAuthForTool", () => {
     ).toBe(true);
   });
 
+  it("keeps bearer token profiles as valid tool auth", () => {
+    expect(
+      hasProviderAuthForTool({
+        provider: "hatchery",
+        authStore: {
+          version: 1,
+          profiles: {
+            "hatchery:default": {
+              provider: "hatchery",
+              type: "token",
+              token: "tok-profile", // pragma: allowlist secret
+            },
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects blank API-key auth-store profiles for tool preflight", () => {
+    expect(
+      hasProviderAuthForTool({
+        provider: "hatchery",
+        authStore: {
+          version: 1,
+          profiles: {
+            "hatchery:default": {
+              provider: "hatchery",
+              type: "api_key",
+              key: "   ",
+            },
+          },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects expired bearer token profiles for tool preflight", () => {
+    expect(
+      hasProviderAuthForTool({
+        provider: "hatchery",
+        authStore: {
+          version: 1,
+          profiles: {
+            "hatchery:default": {
+              provider: "hatchery",
+              type: "token",
+              token: "tok-profile", // pragma: allowlist secret
+              expires: Date.now() - 1_000,
+            },
+          },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps env-backed API-key profiles as valid tool auth", () => {
+    vi.stubEnv("HATCHERY_API_KEY", "sk-hatchery-env-profile"); // pragma: allowlist secret
+
+    expect(
+      hasProviderAuthForTool({
+        provider: "hatchery",
+        authStore: {
+          version: 1,
+          profiles: {
+            "hatchery:default": {
+              provider: "hatchery",
+              type: "api_key",
+              keyRef: { source: "env", provider: "default", id: "HATCHERY_API_KEY" },
+            },
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
   it("rejects aws-sdk auth because tool execution requires an API key string", () => {
     const cfg = {
       models: {

--- a/src/agents/tools/model-config.helpers.ts
+++ b/src/agents/tools/model-config.helpers.ts
@@ -19,6 +19,7 @@ import {
   resolveModelAuthMode,
 } from "../model-auth.js";
 import { resolveConfiguredModelRef } from "../model-selection.js";
+import { findNormalizedProviderValue } from "../provider-id.js";
 
 export type ToolModelConfig = { primary?: string; fallbacks?: string[]; timeoutMs?: number };
 
@@ -71,6 +72,22 @@ export function hasProviderAuthForTool(params: {
   agentDir?: string;
   authStore?: AuthProfileStore;
 }): boolean {
+  const providerConfig = findNormalizedProviderValue(
+    params.cfg?.models?.providers,
+    params.provider,
+  );
+  if (providerConfig?.auth === "aws-sdk") {
+    return false;
+  }
+  if (
+    hasAuthForProvider({
+      provider: params.provider,
+      agentDir: params.agentDir,
+      authStore: params.authStore,
+    })
+  ) {
+    return true;
+  }
   if (
     resolveModelAuthMode(params.provider, params.cfg, params.authStore, {
       workspaceDir: params.workspaceDir,
@@ -78,18 +95,11 @@ export function hasProviderAuthForTool(params: {
   ) {
     return false;
   }
-  return (
-    hasRuntimeAvailableProviderAuth({
-      provider: params.provider,
-      cfg: params.cfg,
-      workspaceDir: params.workspaceDir,
-    }) ||
-    hasAuthForProvider({
-      provider: params.provider,
-      agentDir: params.agentDir,
-      authStore: params.authStore,
-    })
-  );
+  return hasRuntimeAvailableProviderAuth({
+    provider: params.provider,
+    cfg: params.cfg,
+    workspaceDir: params.workspaceDir,
+  });
 }
 
 export function coerceToolModelConfig(model?: AgentToolModelConfig): ToolModelConfig {

--- a/src/agents/tools/model-config.helpers.ts
+++ b/src/agents/tools/model-config.helpers.ts
@@ -19,7 +19,6 @@ import {
   resolveModelAuthMode,
 } from "../model-auth.js";
 import { resolveConfiguredModelRef } from "../model-selection.js";
-import { findNormalizedProviderValue } from "../provider-id.js";
 
 export type ToolModelConfig = { primary?: string; fallbacks?: string[]; timeoutMs?: number };
 
@@ -72,13 +71,6 @@ export function hasProviderAuthForTool(params: {
   agentDir?: string;
   authStore?: AuthProfileStore;
 }): boolean {
-  const providerConfig = findNormalizedProviderValue(
-    params.cfg?.models?.providers,
-    params.provider,
-  );
-  if (providerConfig?.auth === "aws-sdk") {
-    return false;
-  }
   if (
     hasAuthForProvider({
       provider: params.provider,

--- a/src/agents/tools/model-config.helpers.ts
+++ b/src/agents/tools/model-config.helpers.ts
@@ -15,6 +15,7 @@ import type { AuthProfileStore } from "../auth-profiles/types.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import {
   hasRuntimeAvailableProviderAuth,
+  hasUsableCustomProviderApiKey,
   resolveEnvApiKey,
   resolveModelAuthMode,
 } from "../model-auth.js";
@@ -78,6 +79,9 @@ export function hasProviderAuthForTool(params: {
       authStore: params.authStore,
     })
   ) {
+    return true;
+  }
+  if (hasUsableCustomProviderApiKey(params.cfg, params.provider)) {
     return true;
   }
   if (

--- a/src/agents/tools/model-config.helpers.ts
+++ b/src/agents/tools/model-config.helpers.ts
@@ -13,7 +13,11 @@ import {
 } from "../auth-profiles.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
-import { resolveEnvApiKey } from "../model-auth.js";
+import {
+  hasRuntimeAvailableProviderAuth,
+  resolveEnvApiKey,
+  resolveModelAuthMode,
+} from "../model-auth.js";
 import { resolveConfiguredModelRef } from "../model-selection.js";
 
 export type ToolModelConfig = { primary?: string; fallbacks?: string[]; timeoutMs?: number };
@@ -60,6 +64,34 @@ export function hasAuthForProvider(params: {
   return listProfilesForProvider(store, params.provider).length > 0;
 }
 
+export function hasProviderAuthForTool(params: {
+  provider: string;
+  cfg?: OpenClawConfig;
+  workspaceDir?: string;
+  agentDir?: string;
+  authStore?: AuthProfileStore;
+}): boolean {
+  if (
+    resolveModelAuthMode(params.provider, params.cfg, params.authStore, {
+      workspaceDir: params.workspaceDir,
+    }) === "aws-sdk"
+  ) {
+    return false;
+  }
+  return (
+    hasRuntimeAvailableProviderAuth({
+      provider: params.provider,
+      cfg: params.cfg,
+      workspaceDir: params.workspaceDir,
+    }) ||
+    hasAuthForProvider({
+      provider: params.provider,
+      agentDir: params.agentDir,
+      authStore: params.authStore,
+    })
+  );
+}
+
 export function coerceToolModelConfig(model?: AgentToolModelConfig): ToolModelConfig {
   const primary = resolveAgentModelPrimaryValue(model);
   const fallbacks = resolveAgentModelFallbackValues(model);
@@ -73,6 +105,8 @@ export function coerceToolModelConfig(model?: AgentToolModelConfig): ToolModelCo
 
 export function buildToolModelConfigFromCandidates(params: {
   explicit: ToolModelConfig;
+  cfg?: OpenClawConfig;
+  workspaceDir?: string;
   agentDir?: string;
   authStore?: AuthProfileStore;
   candidates: Array<string | null | undefined>;
@@ -91,8 +125,10 @@ export function buildToolModelConfigFromCandidates(params: {
     const provider = trimmed.slice(0, trimmed.indexOf("/")).trim();
     const providerConfigured =
       params.isProviderConfigured?.(provider) ??
-      hasAuthForProvider({
+      hasProviderAuthForTool({
         provider,
+        cfg: params.cfg,
+        workspaceDir: params.workspaceDir,
         agentDir: params.agentDir,
         authStore: params.authStore,
       });

--- a/src/agents/tools/model-config.helpers.ts
+++ b/src/agents/tools/model-config.helpers.ts
@@ -5,13 +5,15 @@ import {
 } from "../../config/model-input.js";
 import type { AgentToolModelConfig } from "../../config/types.agents-shared.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { coerceSecretRef } from "../../config/types.secrets.js";
+import { normalizeOptionalSecretInput } from "../../utils/normalize-secret-input.js";
 import {
   externalCliDiscoveryForProviderAuth,
   ensureAuthProfileStore,
   hasAnyAuthProfileStoreSource,
   listProfilesForProvider,
 } from "../auth-profiles.js";
-import type { AuthProfileStore } from "../auth-profiles/types.js";
+import type { AuthProfileCredential, AuthProfileStore } from "../auth-profiles/types.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import {
   hasRuntimeAvailableProviderAuth,
@@ -43,6 +45,7 @@ export function resolveDefaultModelRef(cfg?: OpenClawConfig): { provider: string
 
 export function hasAuthForProvider(params: {
   provider: string;
+  cfg?: OpenClawConfig;
   agentDir?: string;
   authStore?: AuthProfileStore;
 }): boolean {
@@ -50,7 +53,11 @@ export function hasAuthForProvider(params: {
     return true;
   }
   if (params.authStore) {
-    return listProfilesForProvider(params.authStore, params.provider).length > 0;
+    return hasUsableProfileForProvider({
+      store: params.authStore,
+      provider: params.provider,
+      cfg: params.cfg,
+    });
   }
   const agentDir = params.agentDir?.trim();
   if (!agentDir) {
@@ -62,7 +69,71 @@ export function hasAuthForProvider(params: {
   const store = ensureAuthProfileStore(agentDir, {
     externalCli: externalCliDiscoveryForProviderAuth({ provider: params.provider }),
   });
-  return listProfilesForProvider(store, params.provider).length > 0;
+  return hasUsableProfileForProvider({
+    store,
+    provider: params.provider,
+    cfg: params.cfg,
+  });
+}
+
+function hasUsableProfileForProvider(params: {
+  store: AuthProfileStore;
+  provider: string;
+  cfg?: OpenClawConfig;
+}): boolean {
+  return listProfilesForProvider(params.store, params.provider).some((profileId) => {
+    const credential = params.store.profiles[profileId];
+    return Boolean(credential && hasUsableProfileCredential({ credential, cfg: params.cfg }));
+  });
+}
+
+function hasUsableProfileCredential(params: {
+  credential: AuthProfileCredential;
+  cfg?: OpenClawConfig;
+}): boolean {
+  if (params.credential.type === "api_key") {
+    return (
+      hasAvailableProfileSecretInput({
+        value: params.credential.key,
+        cfg: params.cfg,
+      }) ||
+      hasAvailableProfileSecretInput({
+        value: params.credential.keyRef,
+        cfg: params.cfg,
+      })
+    );
+  }
+  if (params.credential.type === "token") {
+    if (typeof params.credential.expires === "number" && params.credential.expires <= Date.now()) {
+      return false;
+    }
+    return (
+      hasAvailableProfileSecretInput({
+        value: params.credential.token,
+        cfg: params.cfg,
+      }) ||
+      hasAvailableProfileSecretInput({
+        value: params.credential.tokenRef,
+        cfg: params.cfg,
+      })
+    );
+  }
+  return Boolean(
+    normalizeOptionalSecretInput(params.credential.access) ||
+    normalizeOptionalSecretInput(params.credential.refresh) ||
+    normalizeOptionalSecretInput(params.credential.idToken),
+  );
+}
+
+function hasAvailableProfileSecretInput(params: { value: unknown; cfg?: OpenClawConfig }): boolean {
+  const ref = coerceSecretRef(params.value, params.cfg?.secrets?.defaults);
+  if (ref) {
+    if (ref.source === "env") {
+      return Boolean(normalizeOptionalSecretInput(process.env[ref.id]));
+    }
+    return true;
+  }
+  return Boolean(normalizeOptionalSecretInput(params.value));
 }
 
 export function hasProviderAuthForTool(params: {
@@ -75,6 +146,7 @@ export function hasProviderAuthForTool(params: {
   if (
     hasAuthForProvider({
       provider: params.provider,
+      cfg: params.cfg,
       agentDir: params.agentDir,
       authStore: params.authStore,
     })

--- a/src/agents/tools/music-generate-tool.actions.ts
+++ b/src/agents/tools/music-generate-tool.actions.ts
@@ -57,7 +57,7 @@ function summarizeMusicGenerationCapabilities(
 
 export function createMusicGenerateListActionResult(
   config?: OpenClawConfig,
-  options?: { agentDir?: string; authStore?: AuthProfileStore },
+  options?: { workspaceDir?: string; agentDir?: string; authStore?: AuthProfileStore },
 ): MusicGenerateActionResult {
   const providers = listRuntimeMusicGenerationProviders({ config });
   return createMediaGenerateProviderListActionResult({
@@ -65,6 +65,7 @@ export function createMusicGenerateListActionResult(
     providers,
     emptyText: "No music-generation providers are registered.",
     cfg: config,
+    workspaceDir: options?.workspaceDir,
     agentDir: options?.agentDir,
     authStore: options?.authStore,
     listModes: listSupportedMusicGenerationModes,

--- a/src/agents/tools/music-generate-tool.ts
+++ b/src/agents/tools/music-generate-tool.ts
@@ -137,11 +137,13 @@ const MusicGenerateToolSchema = Type.Object({
 
 function resolveMusicGenerationModelConfigForTool(params: {
   cfg?: OpenClawConfig;
+  workspaceDir?: string;
   agentDir?: string;
   authStore?: AuthProfileStore;
 }): ToolModelConfig | null {
   return resolveCapabilityModelConfigForTool({
     cfg: params.cfg,
+    workspaceDir: params.workspaceDir,
     agentDir: params.agentDir,
     authStore: params.authStore,
     modelConfig: params.cfg?.agents?.defaults?.musicGenerationModel,
@@ -607,6 +609,7 @@ export function createMusicGenerateTool(options?: {
 
       if (action === "list") {
         return createMusicGenerateListActionResult(cfg, {
+          workspaceDir: options?.workspaceDir,
           agentDir: options?.agentDir,
           authStore: options?.authProfileStore,
         });
@@ -618,6 +621,7 @@ export function createMusicGenerateTool(options?: {
 
       const musicGenerationModelConfig = resolveMusicGenerationModelConfigForTool({
         cfg,
+        workspaceDir: options?.workspaceDir,
         agentDir: options?.agentDir,
         authStore: options?.authProfileStore,
       });

--- a/src/agents/tools/pdf-tool.model-config.test.ts
+++ b/src/agents/tools/pdf-tool.model-config.test.ts
@@ -33,6 +33,26 @@ vi.mock("./model-config.helpers.js", () => ({
     }
     return false;
   },
+  hasProviderAuthForTool: ({ provider, cfg }: { provider: string; cfg?: OpenClawConfig }) => {
+    const providerConfig = cfg?.models?.providers?.[provider];
+    const apiKey = providerConfig?.apiKey;
+    if (typeof apiKey === "string" && apiKey.trim().length > 0) {
+      return true;
+    }
+    if (provider === "anthropic") {
+      return Boolean(process.env.ANTHROPIC_API_KEY || process.env.ANTHROPIC_OAUTH_TOKEN);
+    }
+    if (provider === "openai") {
+      return Boolean(process.env.OPENAI_API_KEY);
+    }
+    if (provider === "google") {
+      return Boolean(process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY);
+    }
+    if (provider === "minimax" || provider === "minimax-cn") {
+      return Boolean(process.env.MINIMAX_API_KEY);
+    }
+    return false;
+  },
   resolveDefaultModelRef: (cfg?: OpenClawConfig) => {
     const modelCfg = cfg?.agents?.defaults?.model;
     const primary =
@@ -107,6 +127,35 @@ describe("resolvePdfModelConfigForTool", () => {
     expect(resolvePdfModelConfigForTool({ cfg, agentDir: TEST_AGENT_DIR })?.primary).toBe(
       ANTHROPIC_PDF_MODEL,
     );
+  });
+
+  it("uses a config-authenticated custom provider image model as a PDF fallback", () => {
+    const cfg = {
+      ...withDefaultModel("hatchery/text-1"),
+      models: {
+        providers: {
+          hatchery: {
+            baseUrl: "https://example.com/v1",
+            apiKey: "sk-configured", // pragma: allowlist secret
+            models: [
+              {
+                id: "vision-1",
+                name: "Vision 1",
+                reasoning: false,
+                input: ["text", "image"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 32_000,
+                maxTokens: 4_096,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(resolvePdfModelConfigForTool({ cfg, agentDir: TEST_AGENT_DIR })).toEqual({
+      primary: "hatchery/vision-1",
+    });
   });
 
   it("does not add configured MiniMax chat models as automatic PDF image fallbacks", () => {

--- a/src/agents/tools/pdf-tool.model-config.ts
+++ b/src/agents/tools/pdf-tool.model-config.ts
@@ -12,7 +12,7 @@ import {
   resolveConfiguredImageModelRefs,
   resolveProviderVisionModelFromConfig,
 } from "./image-tool.helpers.js";
-import { hasAuthForProvider, resolveDefaultModelRef } from "./model-config.helpers.js";
+import { hasProviderAuthForTool, resolveDefaultModelRef } from "./model-config.helpers.js";
 import { coercePdfModelConfig } from "./pdf-tool.helpers.js";
 
 function resolveImageCandidateRefs(params: {
@@ -29,8 +29,10 @@ function resolveImageCandidateRefs(params: {
   })
     .filter((providerId) => !params.filter || params.filter(providerId))
     .filter((providerId) =>
-      hasAuthForProvider({
+      hasProviderAuthForTool({
         provider: providerId,
+        cfg: params.cfg,
+        workspaceDir: params.workspaceDir,
         agentDir: params.agentDir,
         authStore: params.authStore,
       }),
@@ -76,8 +78,10 @@ export function resolvePdfModelConfigForTool(params: {
   }
 
   const primary = resolveDefaultModelRef(params.cfg);
-  const googleOk = hasAuthForProvider({
+  const googleOk = hasProviderAuthForTool({
     provider: "google",
+    cfg: params.cfg,
+    workspaceDir: params.workspaceDir,
     agentDir: params.agentDir,
     authStore: params.authStore,
   });
@@ -92,8 +96,10 @@ export function resolvePdfModelConfigForTool(params: {
 
   let preferred: string | null = null;
 
-  const providerOk = hasAuthForProvider({
+  const providerOk = hasProviderAuthForTool({
     provider: primary.provider,
+    cfg: params.cfg,
+    workspaceDir: params.workspaceDir,
     agentDir: params.agentDir,
     authStore: params.authStore,
   });
@@ -140,8 +146,10 @@ export function resolvePdfModelConfigForTool(params: {
       if (
         !providerId ||
         isMinimaxVlmProvider(providerId) ||
-        !hasAuthForProvider({
+        !hasProviderAuthForTool({
           provider: providerId,
+          cfg: params.cfg,
+          workspaceDir: params.workspaceDir,
           agentDir: params.agentDir,
           authStore: params.authStore,
         })

--- a/src/agents/tools/video-generate-tool.actions.ts
+++ b/src/agents/tools/video-generate-tool.actions.ts
@@ -80,7 +80,7 @@ function summarizeVideoGenerationCapabilities(
 
 export function createVideoGenerateListActionResult(
   config?: OpenClawConfig,
-  options?: { agentDir?: string; authStore?: AuthProfileStore },
+  options?: { workspaceDir?: string; agentDir?: string; authStore?: AuthProfileStore },
 ): VideoGenerateActionResult {
   const providers = listRuntimeVideoGenerationProviders({ config });
   return createMediaGenerateProviderListActionResult({
@@ -88,6 +88,7 @@ export function createVideoGenerateListActionResult(
     providers,
     emptyText: "No video-generation providers are registered.",
     cfg: config,
+    workspaceDir: options?.workspaceDir,
     agentDir: options?.agentDir,
     authStore: options?.authStore,
     listModes: listSupportedVideoGenerationModes,

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -216,11 +216,13 @@ function createVideoGenerateToolSchema(params: { includeAudioReferences: boolean
 
 export function resolveVideoGenerationModelConfigForTool(params: {
   cfg?: OpenClawConfig;
+  workspaceDir?: string;
   agentDir?: string;
   authStore?: AuthProfileStore;
 }): ToolModelConfig | null {
   return resolveCapabilityModelConfigForTool({
     cfg: params.cfg,
+    workspaceDir: params.workspaceDir,
     agentDir: params.agentDir,
     authStore: params.authStore,
     modelConfig: params.cfg?.agents?.defaults?.videoGenerationModel,
@@ -951,6 +953,7 @@ export function createVideoGenerateTool(options?: {
 
       if (action === "list") {
         return createVideoGenerateListActionResult(cfg, {
+          workspaceDir: options?.workspaceDir,
           agentDir: options?.agentDir,
           authStore: options?.authProfileStore,
         });
@@ -962,6 +965,7 @@ export function createVideoGenerateTool(options?: {
 
       const videoGenerationModelConfig = resolveVideoGenerationModelConfigForTool({
         cfg,
+        workspaceDir: options?.workspaceDir,
         agentDir: options?.agentDir,
         authStore: options?.authProfileStore,
       });

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -263,6 +263,7 @@ function isVideoGenerationProviderConfigured(params: {
     }) ||
     hasAuthForProvider({
       provider: params.providerId,
+      cfg: params.cfg,
       agentDir: params.agentDir,
       authStore: params.authStore,
     })


### PR DESCRIPTION
## Summary
- Use a shared config-aware auth preflight for media tool model selection so custom providers with `models.providers.*.apiKey` can be auto-selected.
- Thread `workspaceDir` through generation tool model/list availability paths so discovery and execution use the same auth context.
- Keep `aws-sdk` auth out of API-key-only tool preflight and preserve video reference-audio capability semantics.

## Verification
- `node scripts/run-vitest.mjs src/agents/tools/model-config.helpers.test.ts src/agents/tools/media-tool-shared.test.ts src/agents/tools/image-generate-tool.test.ts src/agents/tools/music-generate-tool.test.ts src/agents/tools/image-tool.test.ts src/agents/tools/pdf-tool.model-config.test.ts` (`262 passed`)
- `ReadLints` on changed tool files
- Droid narrow review of accepted fixes: `PASS`

## Real behavior proof
Behavior addressed: Custom provider image/media tool auto-selection now recognizes config-backed API keys while avoiding aws-sdk-only providers that cannot satisfy current tool API-key execution.
Real environment tested: Local Mason worktree on Linux with focused Vitest coverage and review checks.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/tools/model-config.helpers.test.ts src/agents/tools/media-tool-shared.test.ts src/agents/tools/image-generate-tool.test.ts src/agents/tools/music-generate-tool.test.ts src/agents/tools/image-tool.test.ts src/agents/tools/pdf-tool.model-config.test.ts`
Evidence after fix: Focused suite reported `12 passed (12)` test files and `262 passed (262)` tests.
Observed result after fix: Config-backed custom provider auth is accepted for image/PDF/media model selection, aws-sdk-only tool preflight is rejected, and generation list/model availability receives workspace auth context.
What was not tested: Full repository check, live provider calls, and existing video reference-audio test failures unrelated to this diff.