### PR TITLE
Fix heartbeat message-tool delivery policy

### DIFF
--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -288,9 +288,17 @@ beforeAll(async () => {
     },
   };
 
+  const discordPlugin = createOutboundTestPlugin({
+    id: "discord",
+    outbound: {
+      deliveryMode: "direct",
+    },
+  });
+
   testRegistry = createTestRegistry([
     { pluginId: "whatsapp", plugin: whatsappPlugin, source: "test" },
     { pluginId: "telegram", plugin: telegramPlugin, source: "test" },
+    { pluginId: "discord", plugin: discordPlugin, source: "test" },
   ]);
   setActivePluginRegistry(testRegistry);
 
@@ -519,6 +527,20 @@ describe("resolveHeartbeatDeliveryTarget", () => {
         expected: {
           channel: "telegram",
           to: "-100123",
+          chatType: "group",
+          accountId: undefined,
+          lastChannel: undefined,
+          lastAccountId: undefined,
+        },
+      },
+      {
+        name: "infer explicit discord channel target",
+        cfg: { agents: { defaults: { heartbeat: { target: "discord", to: "channel:123" } } } },
+        entry: baseEntry,
+        expected: {
+          channel: "discord",
+          to: "channel:123",
+          chatType: "channel",
           accountId: undefined,
           lastChannel: undefined,
           lastAccountId: undefined,
@@ -531,6 +553,7 @@ describe("resolveHeartbeatDeliveryTarget", () => {
         expected: {
           channel: "telegram",
           to: "5232990709",
+          chatType: "direct",
           accountId: undefined,
           lastChannel: "telegram",
           lastAccountId: undefined,
@@ -581,6 +604,7 @@ describe("resolveHeartbeatDeliveryTarget", () => {
       expected: {
         channel: "telegram",
         to: "-100123",
+        chatType: "group",
         accountId: "work",
         lastChannel: undefined,
         lastAccountId: undefined,

--- a/src/infra/heartbeat-runner.tool-response.test.ts
+++ b/src/infra/heartbeat-runner.tool-response.test.ts
@@ -33,19 +33,34 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
     tmpDir: string;
     storePath: string;
     visibleReplies?: "automatic" | "message_tool";
+    groupVisibleReplies?: "automatic" | "message_tool";
     agentRuntimeId?: string;
+    modelRuntimeId?: string;
     model?: string;
+    target?: "telegram" | "last";
   }): OpenClawConfig {
     return {
       agents: {
         defaults: {
           workspace: params.tmpDir,
-          heartbeat: { every: "5m", target: "telegram" },
+          heartbeat: { every: "5m", target: params.target ?? "telegram" },
           ...(params.model ? { model: params.model } : {}),
+          ...(params.model && params.modelRuntimeId
+            ? { models: { [params.model]: { agentRuntime: { id: params.modelRuntimeId } } } }
+            : {}),
           ...(params.agentRuntimeId ? { agentRuntime: { id: params.agentRuntimeId } } : {}),
         },
       },
-      ...(params.visibleReplies ? { messages: { visibleReplies: params.visibleReplies } } : {}),
+      ...(params.visibleReplies || params.groupVisibleReplies
+        ? {
+            messages: {
+              ...(params.visibleReplies ? { visibleReplies: params.visibleReplies } : {}),
+              ...(params.groupVisibleReplies
+                ? { groupChat: { visibleReplies: params.groupVisibleReplies } }
+                : {}),
+            },
+          }
+        : {}),
       channels: {
         telegram: {
           token: "test-token",
@@ -228,6 +243,15 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
     expectHeartbeatToolPrompt(result, ["notify=false"]);
   });
 
+  it("uses the heartbeat response tool prompt for group message-tool mode", async () => {
+    const result = await runPromptScenario({
+      config: { groupVisibleReplies: "message_tool", target: "last" },
+      session: { lastTo: "group:redacted" },
+    });
+
+    expectHeartbeatToolPrompt(result, ["notify=false"]);
+  });
+
   it("uses the heartbeat response tool prompt for Codex harness sessions by default", async () => {
     const result = await runPromptScenario({
       session: { agentHarnessId: "codex" },
@@ -314,6 +338,31 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
     });
 
     expectHeartbeatToolPrompt(result);
+  });
+
+  it("uses the heartbeat response tool prompt for model-specific Codex runtimes", async () => {
+    const result = await runPromptScenario({
+      config: {
+        model: "openai/gpt-5.5",
+        modelRuntimeId: "codex",
+      },
+    });
+
+    expectHeartbeatToolPrompt(result);
+  });
+
+  it("honors model-specific non-Codex runtimes over default Codex heartbeat mode", async () => {
+    const result = await runPromptScenario({
+      config: {
+        agentRuntimeId: "codex",
+        model: "openai/gpt-5.5",
+        modelRuntimeId: "pi",
+      },
+    });
+
+    expect(result.calledCtx.Body).toContain("HEARTBEAT_OK");
+    expect(result.calledCtx.Body).not.toContain("heartbeat_respond");
+    expect(result.calledOpts.sourceReplyDeliveryMode).toBeUndefined();
   });
 
   it("uses the heartbeat response tool prompt when the Codex runtime is env-forced", async () => {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -13,6 +13,7 @@ import {
   resolveDefaultAgentId,
 } from "../agents/agent-scope.js";
 import { appendCronStyleCurrentTimeLine } from "../agents/current-time.js";
+import { resolveAgentHarnessPolicy } from "../agents/harness/policy.js";
 import { resolveModelRefFromString, type ModelRef } from "../agents/model-selection.js";
 import { resolveEmbeddedSessionLane } from "../agents/pi-embedded-runner/lanes.js";
 import { formatReasoningMessage } from "../agents/pi-embedded-utils.js";
@@ -39,6 +40,7 @@ import { replyRunRegistry } from "../auto-reply/reply/reply-run-registry.js";
 import { resolveResponsePrefixTemplate } from "../auto-reply/reply/response-prefix-template.js";
 import { HEARTBEAT_TOKEN } from "../auto-reply/tokens.js";
 import type { ReplyPayload } from "../auto-reply/types.js";
+import { normalizeChatType, type ChatType } from "../channels/chat-type.js";
 import { sendDurableMessageBatch } from "../channels/message/runtime.js";
 import { getChannelPlugin } from "../channels/plugins/index.js";
 import type {
@@ -451,6 +453,7 @@ function usesCodexHarness(params: {
     normalizeHeartbeatRuntimeId(process.env.OPENCLAW_AGENT_RUNTIME) ||
     normalizeHeartbeatRuntimeId(agentEntry?.agentRuntime?.id) ||
     normalizeHeartbeatRuntimeId(agentEntry?.embeddedHarness?.runtime) ||
+    resolveConfiguredHeartbeatModelRuntimeId(params) ||
     normalizeHeartbeatRuntimeId(params.cfg.agents?.defaults?.agentRuntime?.id) ||
     normalizeHeartbeatRuntimeId(params.cfg.agents?.defaults?.embeddedHarness?.runtime);
   if (runtimeId === "codex") {
@@ -462,13 +465,38 @@ function usesCodexHarness(params: {
   return normalizeLowercaseStringOrEmpty(resolveHeartbeatModelRef(params).provider) === "codex";
 }
 
+function resolveConfiguredHeartbeatModelRuntimeId(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  heartbeat?: HeartbeatConfig;
+  entry?: SessionEntry;
+}): string {
+  const modelRef = resolveHeartbeatModelRef(params);
+  const policy = resolveAgentHarnessPolicy({
+    config: params.cfg,
+    provider: modelRef.provider,
+    modelId: modelRef.model,
+    agentId: params.agentId,
+  });
+  if (policy.runtimeSource === "implicit") {
+    return "";
+  }
+  const runtime = normalizeHeartbeatRuntimeId(policy.runtime);
+  return runtime === "auto" ? "" : runtime;
+}
+
 function shouldUseHeartbeatResponseToolPrompt(params: {
   cfg: OpenClawConfig;
   agentId: string;
   heartbeat?: HeartbeatConfig;
   entry?: SessionEntry;
+  chatType?: ChatType;
 }): boolean {
-  const visibleReplies = params.cfg.messages?.visibleReplies;
+  const chatType = normalizeChatType(params.chatType);
+  const visibleReplies =
+    chatType === "group" || chatType === "channel"
+      ? (params.cfg.messages?.groupChat?.visibleReplies ?? params.cfg.messages?.visibleReplies)
+      : params.cfg.messages?.visibleReplies;
   if (visibleReplies === "message_tool") {
     return true;
   }
@@ -1462,6 +1490,7 @@ export async function runHeartbeatOnce(opts: {
     agentId,
     heartbeat,
     entry,
+    chatType: delivery.chatType,
   });
   const {
     prompt,

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -34,6 +34,7 @@ export type HeartbeatTarget = OutboundChannel;
 export type OutboundTarget = {
   channel: OutboundChannel;
   to?: string;
+  chatType?: ChatType;
   reason?: string;
   accountId?: string;
   threadId?: string | number;
@@ -236,6 +237,7 @@ export function resolveHeartbeatDeliveryTarget(params: {
   return {
     channel: resolvedTarget.channel,
     to: resolved.to,
+    chatType: deliveryChatType,
     reason,
     accountId: effectiveAccountId,
     // Heartbeats normally avoid inheriting session reply-thread IDs, but some


### PR DESCRIPTION
## Summary
- Fixes #85310.
- Aligns scheduled heartbeat response-tool selection with group/channel `messages.groupChat.visibleReplies` policy.
- Includes model-specific heartbeat runtime resolution so `agents.defaults.models[model].agentRuntime.id = "codex"` activates message-tool-only heartbeat delivery.

## Root Cause
Scheduled heartbeat runs decided whether to force the heartbeat response tool before carrying forward the resolved delivery chat type or model-specific runtime policy. That meant a group/channel setup using `messages.groupChat.visibleReplies = "message_tool"`, or a model-specific Codex runtime override, could still run with the legacy `HEARTBEAT_OK` prompt and no `sourceReplyDeliveryMode` override. Downstream dispatch already suppresses text-only failed tool output when `sourceReplyDeliveryMode` is `message_tool_only`; the heartbeat path was not consistently entering that runtime-enforced mode.

## Why This Is Safe
- The change only affects heartbeat prompt/delivery mode selection for already-configured message-tool-only or Codex-runtime heartbeat cases.
- Existing automatic heartbeat behavior remains unchanged when visible replies are `automatic` and no Codex runtime policy applies.
- Model-specific non-Codex runtime config continues to override broader default Codex heartbeat mode, with regression coverage.
- The fix reuses existing runtime policy resolution and existing dispatch suppression rather than adding channel-specific string filtering.

## Security And Runtime Controls
- Existing send policy checks are unchanged.
- Existing message-tool availability/profile policy is unchanged.
- Existing dispatch-side `message_tool_only` suppression for text-only failed tool output is unchanged.
- No new channel credentials, allowlist behavior, provider auth, or tool permissions are introduced.

## Real Behavior Proof
Behavior addressed: heartbeat scheduled turns now honor group/channel `message_tool` reply policy and model-specific Codex runtime config, so failed internal tool/file-read messages stay private.

Real environment tested: local OpenClaw source checkout on this PR branch, with a temporary in-memory config that enabled only `channels.discord`. Telegram, Slack, Matrix, Signal, iMessage, MS Teams, and WhatsApp were disabled by omission. Discord token, guild ID, channel ID, and message IDs are redacted below.

After fix, OpenClaw sent a real heartbeat notification into the configured Discord channel and the proof script read the channel back through the Discord API:

Discord message URL for manual verification: https://discord.com/channels/1481298384714338398/1481298387058950239/1507377049021448192

A local browser screenshot was also captured from that URL (`discord-issue-85310-proof.png`) showing the proof message in `#general` on the `openclaw test server` Discord. The screenshot is not committed to the repo.


```json
{
  "proof": "issue-85310-real-discord-after",
  "sanitizedConfig": {
    "enabledChannels": ["discord"],
    "disabledByOmission": [
      "telegram",
      "slack",
      "matrix",
      "signal",
      "imessage",
      "msteams",
      "whatsapp"
    ],
    "guildId": "1481...8398",
    "channelId": "1481...0239",
    "token": "REDACTED",
    "messages": {
      "groupChat": {
        "visibleReplies": "message_tool"
      }
    },
    "model": {
      "primary": "openai/gpt-5.5"
    },
    "modelRuntime": {
      "id": "codex"
    },
    "discordStreamingMode": "off"
  },
  "result": {
    "status": "ran",
    "reason": null
  },
  "captured": {
    "bodyHasHeartbeatRespond": true,
    "bodyHasLegacyOk": false,
    "sourceReplyDeliveryMode": "message_tool_only",
    "enableHeartbeatTool": true,
    "forceHeartbeatTool": true
  },
  "discordReadback": {
    "sentMessageFound": true,
    "sentMessageId": "1507...8192",
    "sentMessageContent": "OpenClaw Discord proof oc85310-1779457093435-665a9c: heartbeat message-tool delivery is active.",
    "newMessageCount": 1,
    "newMessages": [
      {
        "id": "1507...8192",
        "authorBot": true,
        "content": "OpenClaw Discord proof oc85310-1779457093435-665a9c: heartbeat message-tool delivery is active."
      }
    ],
    "leakedInternalMarkerCount": 0,
    "leakedInternalMarkers": []
  }
}
```

Observed result after fix: the real Discord channel received only the expected OpenClaw heartbeat proof message. The heartbeat runner entered `message_tool_only` runtime mode, used the heartbeat response tool prompt instead of the legacy `HEARTBEAT_OK` prompt, and the Discord readback found no `print lines ... failed`, `HEARTBEAT_OK`, or `heartbeat_respond` internal markers in the new visible channel output.

## Tests
- `git diff --check`
- `node scripts/run-vitest.mjs src/infra/heartbeat-runner.tool-response.test.ts src/auto-reply/reply/dispatch-from-config.test.ts -- --reporter=verbose`
- `pnpm check:changed`
- `pnpm build`

## Out Of Scope
- No Discord-specific sanitizer or output string filtering.
- No changes to channel allowlists, credentials, send policy, or tool permission policy.
- No broad rewrite of the heartbeat runner or dispatch pipeline.

## Transparency
AI-assisted implementation; reviewed against the final diff and validated with the commands above.

