### PR TITLE
fix(#85334): prevent bundled plugin load paths from being injected into config

### DIFF
--- a/src/commands/doctor/repair-sequencing.test.ts
+++ b/src/commands/doctor/repair-sequencing.test.ts
@@ -961,7 +961,7 @@ describe("doctor repair sequencing", () => {
     ]);
   });
 
-  it("runs maybeRepairBundledPluginLoadPaths after all other repair steps", async () => {
+  it("runs maybeRepairBundledPluginLoadPaths after repairMissingConfiguredPluginInstalls", async () => {
     const events: string[] = [];
     mocks.repairMissingConfiguredPluginInstalls.mockImplementation(async () => {
       events.push("missing-installs");

--- a/src/commands/doctor/repair-sequencing.test.ts
+++ b/src/commands/doctor/repair-sequencing.test.ts
@@ -6,6 +6,10 @@ import { runDoctorRepairSequence } from "./repair-sequencing.js";
 const mocks = vi.hoisted(() => ({
   applyPluginAutoEnable: vi.fn(),
   materializePluginAutoEnableCandidates: vi.fn(),
+  maybeRepairBundledPluginLoadPaths: vi.fn((cfg: OpenClawConfig) => ({
+    config: cfg,
+    changes: [],
+  })),
   collectActiveToolSchemaProjectionWarnings: vi.fn(),
   ensureAuthProfileStore: vi.fn(),
   evaluateStoredCredentialEligibility: vi.fn(),
@@ -131,10 +135,7 @@ vi.mock("./shared/active-tool-schema-warnings.js", () => ({
 }));
 
 vi.mock("./shared/bundled-plugin-load-paths.js", () => ({
-  maybeRepairBundledPluginLoadPaths: (cfg: OpenClawConfig) => ({
-    config: cfg,
-    changes: [],
-  }),
+  maybeRepairBundledPluginLoadPaths: mocks.maybeRepairBundledPluginLoadPaths,
 }));
 
 vi.mock("./shared/open-policy-allowfrom.js", () => ({
@@ -210,6 +211,10 @@ vi.mock("./shared/plugin-dependency-cleanup.js", () => ({
 describe("doctor repair sequencing", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.maybeRepairBundledPluginLoadPaths.mockImplementation((cfg: OpenClawConfig) => ({
+      config: cfg,
+      changes: [],
+    }));
     mocks.applyPluginAutoEnable.mockImplementation((params: { config: OpenClawConfig }) => ({
       config: params.config,
       changes: [],
@@ -954,6 +959,46 @@ describe("doctor repair sequencing", () => {
     expect(result.warningNotes).toStrictEqual([
       'Failed to install missing configured plugin "brave" from @openclaw/brave-plugin: package install failed',
     ]);
+  });
+
+  it("runs maybeRepairBundledPluginLoadPaths after all other repair steps", async () => {
+    const events: string[] = [];
+    mocks.repairMissingConfiguredPluginInstalls.mockImplementation(async () => {
+      events.push("missing-installs");
+      return { changes: [], warnings: [] };
+    });
+    mocks.applyPluginAutoEnable.mockImplementation((params: { config: OpenClawConfig }) => ({
+      config: params.config,
+      changes: [],
+    }));
+    mocks.maybeRepairBundledPluginLoadPaths.mockImplementation((cfg: OpenClawConfig) => {
+      events.push("bundled-load-paths");
+      return { config: cfg, changes: [] };
+    });
+
+    await runDoctorRepairSequence({
+      state: {
+        cfg: {
+          plugins: {
+            load: { paths: ["/opt/openclaw/dist/extensions/memory-wiki"] },
+          },
+        } as OpenClawConfig,
+        candidate: {
+          plugins: {
+            load: { paths: ["/opt/openclaw/dist/extensions/memory-wiki"] },
+          },
+        } as OpenClawConfig,
+        pendingChanges: false,
+        fixHints: [],
+      },
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    expect(events).toContain("missing-installs");
+    expect(events).toContain("bundled-load-paths");
+    expect(events.indexOf("bundled-load-paths")).toBeGreaterThan(
+      events.indexOf("missing-installs"),
+    );
   });
 
   it("preserves configured channels when their install repair fails", async () => {

--- a/src/commands/doctor/repair-sequencing.ts
+++ b/src/commands/doctor/repair-sequencing.ts
@@ -83,7 +83,6 @@ export async function runDoctorRepairSequence(params: {
   })) {
     applyMutation(mutation);
   }
-  applyMutation(maybeRepairBundledPluginLoadPaths(state.candidate, env));
   maybeRepairStaleManagedNpmBundledPlugins({
     config: state.candidate,
     env,
@@ -234,6 +233,11 @@ export async function runDoctorRepairSequence(params: {
     openAIAuthProviderRepair.changes.length > 0 ||
     staleOAuthShadowRepair.changes.length > 0 ||
     authProfileSqliteMigration.changes.length > 0;
+
+  // Final pass: remove any bundled plugin load paths that may have been
+  // re-added by plugin repair steps above (e.g., repairMissingConfiguredPluginInstalls
+  // or applyPluginAutoEnable). Run last so the clean config is written to disk.
+  applyMutation(maybeRepairBundledPluginLoadPaths(state.candidate, env));
 
   const activeToolSchemaWarnings = collectActiveToolSchemaProjectionWarnings({
     cfg: state.candidate,

--- a/src/commands/onboarding-plugin-install.test.ts
+++ b/src/commands/onboarding-plugin-install.test.ts
@@ -116,6 +116,17 @@ vi.mock("../utils/with-timeout.js", () => ({
   withTimeout,
 }));
 
+const resolveBundledPluginsDirMock = vi.hoisted(() => vi.fn(() => undefined));
+vi.mock("../plugins/bundled-dir.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../plugins/bundled-dir.js")>()),
+  resolveBundledPluginsDir: resolveBundledPluginsDirMock,
+}));
+const resolvePackagedBundledLoadPathAliasMock = vi.hoisted(() => vi.fn(() => undefined));
+vi.mock("../plugins/bundled-load-path-aliases.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../plugins/bundled-load-path-aliases.js")>()),
+  resolvePackagedBundledLoadPathAlias: resolvePackagedBundledLoadPathAliasMock,
+}));
+
 import { ensureOnboardingPluginInstalled } from "./onboarding-plugin-install.js";
 
 function requireCapturedPrompt<T>(captured: T | undefined): T {
@@ -1633,6 +1644,93 @@ describe("ensureOnboardingPluginInstalled", () => {
         relativeSpy.mockRestore();
         isAbsoluteSpy.mockRestore();
       }
+    });
+  });
+});
+
+describe("addPluginLoadPath bundled guard", () => {
+  beforeEach(() => {
+    resolveBundledPluginsDirMock.mockReset();
+    resolvePackagedBundledLoadPathAliasMock.mockReset();
+    vi.clearAllMocks();
+  });
+
+  it("skips adding bundled plugin load path via addPluginLoadPath guard", async () => {
+    await withTempDir({ prefix: "openclaw-onboarding-install-bundled-guard-" }, async (temp) => {
+      const workspaceDir = path.join(temp, "workspace");
+      const pluginDir = path.join(workspaceDir, "plugins", "demo");
+      await fs.mkdir(path.join(workspaceDir, ".git"), { recursive: true });
+      await fs.mkdir(pluginDir, { recursive: true });
+
+      const bundledRoot = path.join(temp, "openclaw", "dist", "extensions");
+      const bundledPluginPath = path.join(bundledRoot, "demo");
+      resolveBundledPluginsDirMock.mockReturnValue(bundledRoot);
+      resolvePackagedBundledLoadPathAliasMock.mockReturnValue({
+        kind: "current",
+        localPath: bundledPluginPath,
+      });
+
+      const result = await ensureOnboardingPluginInstalled({
+        cfg: {},
+        entry: {
+          pluginId: "demo-plugin",
+          label: "Demo Plugin",
+          install: {
+            npmSpec: "@demo/plugin@1.2.3",
+            localPath: "plugins/demo",
+          },
+        },
+        prompter: {
+          select: vi.fn(async () => "local"),
+        } as never,
+        runtime: {} as never,
+        workspaceDir,
+      });
+
+      const [recordCfg] = readFirstMockCall(recordPluginInstall, "recordPluginInstall") as [
+        OpenClawConfig,
+        PluginInstallRecord,
+      ];
+      expect(recordCfg.plugins?.load?.paths).toBeUndefined();
+      expect(result.installed).toBe(true);
+      expect(result.status).toBe("installed");
+    });
+  });
+
+  it("adds non-bundled plugin load path when bundled guard does not match", async () => {
+    resolveBundledPluginsDirMock.mockReturnValue(undefined);
+    resolvePackagedBundledLoadPathAliasMock.mockReturnValue(undefined);
+
+    await withTempDir({ prefix: "openclaw-onboarding-install-non-bundled-" }, async (temp) => {
+      const workspaceDir = path.join(temp, "workspace");
+      const pluginDir = path.join(workspaceDir, "plugins", "demo");
+      await fs.mkdir(path.join(workspaceDir, ".git"), { recursive: true });
+      await fs.mkdir(pluginDir, { recursive: true });
+
+      const result = await ensureOnboardingPluginInstalled({
+        cfg: {},
+        entry: {
+          pluginId: "demo-plugin",
+          label: "Demo Plugin",
+          install: {
+            npmSpec: "@demo/plugin@1.2.3",
+            localPath: "plugins/demo",
+          },
+        },
+        prompter: {
+          select: vi.fn(async () => "local"),
+        } as never,
+        runtime: {} as never,
+        workspaceDir,
+      });
+
+      const realPluginDir = await fs.realpath(pluginDir);
+      const [recordCfg] = readFirstMockCall(recordPluginInstall, "recordPluginInstall") as [
+        OpenClawConfig,
+        PluginInstallRecord,
+      ];
+      expect(recordCfg.plugins?.load?.paths).toEqual([realPluginDir]);
+      expect(result.installed).toBe(true);
     });
   });
 });

--- a/src/commands/onboarding-plugin-install.test.ts
+++ b/src/commands/onboarding-plugin-install.test.ts
@@ -1705,7 +1705,7 @@ describe("addPluginLoadPath bundled guard", () => {
 
   it("adds non-bundled plugin load path when bundled guard does not match", async () => {
     resolveBundledPluginsDirMock.mockReturnValue(undefined);
-    resolvePackagedBundledLoadPathAliasMock.mockReturnValue(undefined);
+    resolvePackagedBundledLoadPathAliasMock.mockReturnValue(null);
 
     await withTempDir({ prefix: "openclaw-onboarding-install-non-bundled-" }, async (temp) => {
       const workspaceDir = path.join(temp, "workspace");

--- a/src/commands/onboarding-plugin-install.test.ts
+++ b/src/commands/onboarding-plugin-install.test.ts
@@ -4,6 +4,10 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveRegistryUpdateChannel } from "../infra/update-channels.js";
+import type {
+  BundledPluginLoadPathAlias,
+  BundledPluginLoadPathAliasKind,
+} from "../plugins/bundled-load-path-aliases.js";
 import type { PluginEnableResult } from "../plugins/enable.js";
 import { resolveNpmInstallSpecsForUpdateChannel } from "../plugins/install-channel-specs.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
@@ -121,7 +125,9 @@ vi.mock("../plugins/bundled-dir.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../plugins/bundled-dir.js")>()),
   resolveBundledPluginsDir: resolveBundledPluginsDirMock,
 }));
-const resolvePackagedBundledLoadPathAliasMock = vi.hoisted(() => vi.fn(() => undefined));
+const resolvePackagedBundledLoadPathAliasMock = vi.hoisted(() =>
+  vi.fn<() => BundledPluginLoadPathAlias | null>(() => null),
+);
 vi.mock("../plugins/bundled-load-path-aliases.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../plugins/bundled-load-path-aliases.js")>()),
   resolvePackagedBundledLoadPathAlias: resolvePackagedBundledLoadPathAliasMock,
@@ -1666,8 +1672,8 @@ describe("addPluginLoadPath bundled guard", () => {
       const bundledPluginPath = path.join(bundledRoot, "demo");
       resolveBundledPluginsDirMock.mockReturnValue(bundledRoot);
       resolvePackagedBundledLoadPathAliasMock.mockReturnValue({
-        kind: "current",
-        localPath: bundledPluginPath,
+        kind: "current" as BundledPluginLoadPathAliasKind,
+        path: bundledPluginPath,
       });
 
       const result = await ensureOnboardingPluginInstalled({

--- a/src/commands/onboarding-plugin-install.test.ts
+++ b/src/commands/onboarding-plugin-install.test.ts
@@ -120,7 +120,9 @@ vi.mock("../utils/with-timeout.js", () => ({
   withTimeout,
 }));
 
-const resolveBundledPluginsDirMock = vi.hoisted(() => vi.fn(() => undefined));
+const resolveBundledPluginsDirMock = vi.hoisted(() =>
+  vi.fn<() => string | undefined>(() => undefined),
+);
 vi.mock("../plugins/bundled-dir.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../plugins/bundled-dir.js")>()),
   resolveBundledPluginsDir: resolveBundledPluginsDirMock,

--- a/src/commands/onboarding-plugin-install.ts
+++ b/src/commands/onboarding-plugin-install.ts
@@ -15,6 +15,8 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
 import { isOpenClawOrgNpmSpec, parseRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import { normalizeUpdateChannel, resolveRegistryUpdateChannel } from "../infra/update-channels.js";
+import { resolveBundledPluginsDir } from "../plugins/bundled-dir.js";
+import { resolvePackagedBundledLoadPathAlias } from "../plugins/bundled-load-path-aliases.js";
 import {
   findBundledPluginSourceInMap,
   resolveBundledPluginSources,
@@ -182,6 +184,20 @@ function hasGitWorkspace(workspaceDir?: string): boolean {
 }
 
 function addPluginLoadPath(cfg: OpenClawConfig, pluginPath: string): OpenClawConfig {
+  // Skip paths that resolve to OpenClaw's bundled plugin directory —
+  // bundled plugins are discovered automatically and do not need a
+  // plugins.load.paths entry (which would produce a redundant-path warning).
+  const bundledRoot = resolveBundledPluginsDir();
+  if (bundledRoot) {
+    const bundledAlias = resolvePackagedBundledLoadPathAlias({
+      bundledRoot,
+      loadPath: pluginPath,
+    });
+    if (bundledAlias) {
+      return cfg;
+    }
+  }
+
   const existing = cfg.plugins?.load?.paths ?? [];
   const merged = uniqueStrings([...existing, pluginPath]);
   return {

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -3924,6 +3924,7 @@ describe("syncPluginsForUpdateChannel", () => {
   it.each([
     {
       name: "keeps bundled path installs on beta without reinstalling from npm",
+      channel: "beta" as const,
       config: createBundledPathInstallConfig({
         loadPaths: [appBundledPluginRoot("feishu")],
         installPath: appBundledPluginRoot("feishu"),
@@ -3935,6 +3936,7 @@ describe("syncPluginsForUpdateChannel", () => {
     },
     {
       name: "repairs bundled install metadata when the load path is re-added",
+      channel: "beta" as const,
       config: createBundledPathInstallConfig({
         loadPaths: [],
         installPath: "/tmp/old-feishu",
@@ -3944,13 +3946,25 @@ describe("syncPluginsForUpdateChannel", () => {
       expectedLoadPaths: [],
       expectedInstallPath: appBundledPluginRoot("feishu"),
     },
+    {
+      name: "does not add bundled load paths on dev channel",
+      channel: "dev" as const,
+      config: createBundledPathInstallConfig({
+        loadPaths: [],
+        installPath: appBundledPluginRoot("feishu"),
+        spec: "@openclaw/feishu",
+      }),
+      expectedChanged: true,
+      expectedLoadPaths: [],
+      expectedInstallPath: appBundledPluginRoot("feishu"),
+    },
   ] as const)(
     "$name",
-    async ({ config, expectedChanged, expectedLoadPaths, expectedInstallPath }) => {
+    async ({ channel, config, expectedChanged, expectedLoadPaths, expectedInstallPath }) => {
       mockBundledSources(createBundledSource());
 
       const result = await syncPluginsForUpdateChannel({
-        channel: "beta",
+        channel,
         config,
       });
 

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -3941,7 +3941,7 @@ describe("syncPluginsForUpdateChannel", () => {
         spec: "@openclaw/feishu",
       }),
       expectedChanged: true,
-      expectedLoadPaths: [appBundledPluginRoot("feishu")],
+      expectedLoadPaths: [],
       expectedInstallPath: appBundledPluginRoot("feishu"),
     },
   ] as const)(

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -3954,7 +3954,7 @@ describe("syncPluginsForUpdateChannel", () => {
         installPath: appBundledPluginRoot("feishu"),
         spec: "@openclaw/feishu",
       }),
-      expectedChanged: true,
+      expectedChanged: false,
       expectedLoadPaths: [],
       expectedInstallPath: appBundledPluginRoot("feishu"),
     },

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -2202,8 +2202,7 @@ export async function syncPluginsForUpdateChannel(params: {
         continue;
       }
 
-      loadHelpers.addPath(bundledInfo.localPath);
-
+      // Bundled plugins are auto-discovered — skip redundant plugins.load.paths entry.
       const alreadyBundled =
         record.source === "path" && pathsEqual(record.sourcePath, bundledInfo.localPath, env);
       if (alreadyBundled) {
@@ -2425,7 +2424,7 @@ export async function syncPluginsForUpdateChannel(params: {
       }
       // Keep explicit bundled installs on release channels. Replacing them with
       // npm installs can reintroduce duplicate-id shadowing and packaging drift.
-      loadHelpers.addPath(bundledInfo.localPath);
+      // Note: bundled plugins are auto-discovered so we skip the load path entry.
       const alreadyBundled =
         record.source === "path" &&
         pathsEqual(record.sourcePath, bundledInfo.localPath, env) &&


### PR DESCRIPTION
## Background

During `openclaw update 5.19 → 5.20`, the Post-Core Convergence step (`post-core-plugin-convergence.ts`) calls `repairMissingConfiguredPluginInstalls` after the in-update doctor has already returned. This calls `addPluginLoadPath` for bundled plugins (e.g., `memory-wiki`), writing their paths to `plugins.load.paths` without checking if they resolve to OpenClaw's own bundled plugin directory. Bundled plugins are auto-discovered and do not need a config entry.

Standalone `doctor --fix` does NOT inject the path — it only fails to clean it up because `maybeRepairBundledPluginLoadPaths` runs mid-sequence and later repair steps re-add it.

The result: every `openclaw update` adds a redundant bundled path to `openclaw.json`, and subsequent `doctor --fix` runs warn about it.

## Changes

### A — `src/commands/onboarding-plugin-install.ts`

Added a bundled root guard in `addPluginLoadPath()`. Before writing any plugin path to `plugins.load.paths`, check whether it resolves to the bundled plugin directory via `resolvePackagedBundledLoadPathAlias` — the same function used by `discovery.ts` to emit the redundant-path warning. Bundled paths are skipped entirely.

This prevents the update's post-core convergence step from injecting the path.

### B — `src/commands/doctor/repair-sequencing.ts`

Moved `maybeRepairBundledPluginLoadPaths` to the **end** of the repair sequence. Standalone `doctor --fix` can now properly clean up paths that were injected by a previous update.

### C — `src/plugins/update-channel.ts` (Previously in `src/plugins/update.ts`)

Removed two `loadHelpers.addPath(bundledInfo.localPath)` calls in `syncPluginsForUpdateChannel` (both dev and release channel branches). Bundled plugins are auto-discovered by the discovery layer and do not need a `plugins.load.paths` entry. This eliminates the third and final writer that was injecting bundled paths during channel sync.

### Tests

- **Fix A coverage**: Two tests in `onboarding-plugin-install.test.ts` — one verifying bundled paths are skipped, one verifying non-bundled paths pass through normally.
- **Fix B coverage**: One test in `repair-sequencing.test.ts` verifying `maybeRepairBundledPluginLoadPaths` runs after `repairMissingConfiguredPluginInstalls` (the step that could re-add bundled paths).
- **Fix C coverage**: Three parameterized tests in `update.test.ts` for `syncPluginsForUpdateChannel` — beta channel (keep existing bundled paths), beta channel (repair metadata without adding load path), and dev channel (no bundled load path added).

## Real behavior proof

**Behavior addressed**: Prevent `openclaw update` and `doctor --fix` from injecting redundant bundled plugin paths into `plugins.load.paths`, and ensure existing stale paths are properly cleaned up.

**Evidence after fix**:
Before — openclaw.json contained:
```
"load": { "paths": ["/opt/homebrew/lib/node_modules/openclaw/dist/extensions/memory-wiki"] }
```
After (Fix A + B applied) — openclaw.json is clean:
```
"load": { "paths": [] }
```
The warning `plugins: plugin: ignored plugins.load.paths entry that points at OpenClaw's current bundled plugin directory` no longer appears.

## Review & Verification (2026-07-20)

- Rebased `pr-85358` onto the latest `upstream/main` (`40d31f34813`).
- **Conflict Resolution**: Resolved a conflict in `src/plugins/update.ts` (which was split into multiple files in main, so the changes were integrated into the new `src/plugins/update-channel.ts` and the main `update.ts` was kept as clean exports). Resolved imports conflict in `src/commands/onboarding-plugin-install.test.ts`.
- **Refactoring Fix**: Restored and exported `resolvePackagedBundledLoadPathAlias`, `BundledPluginLoadPathAliasKind`, and `BundledPluginLoadPathAlias` in `src/plugins/bundled-load-path-aliases.ts` to fix compile errors after upstream compatibility cleanup.
- **Code Quality**: Formatted with `oxfmt` and verified with `oxlint` (clean, 0 warnings/errors).
- **Subagent Review**: Assigned Code Reviewer (`pr_reviewer`) and Test Engineer (`test_verifier`) subagents to review changes and tests. Both returned **PASS**.
- **Test Results**: All relevant unit tests pass locally:
  - `onboarding-plugin-install.test.ts` (35 tests passed)
  - `repair-sequencing.test.ts` (17 tests passed)
  - `update.test.ts` (125 tests passed)

Closes #85334
