### PR TITLE
feat(agents): add local skill route tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Agents/skills: add a local `local_skill_route` tool so agents can shortlist matching skills before reading SKILL.md when a workspace exposes many skills.
 - Agents/subagents: limit default sub-agent bootstrap context to `AGENTS.md` and `TOOLS.md`, keeping persona, identity, user, memory, heartbeat, and setup files out of delegated workers by default. (#85283) Thanks @100yenadmin.
 - Maintainer skills: exclude plugin SDK/API boundary work from `openclaw-landable-bug-sweep` so bugbash sweeps stay focused on small paper-cut fixes.
 - Plugin SDK: add a generic channel-message poll sender so channel plugins can expose poll delivery without depending on channel-specific SDK facades.

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
@@ -483,6 +483,14 @@
       "title": "Agents",
       "detailKeys": []
     },
+    "local_skill_route": {
+      "emoji": "🧭",
+      "title": "Skill Route",
+      "detailKeys": [
+        "query",
+        "limit"
+      ]
+    },
     "memory_search": {
       "emoji": "🧠",
       "title": "Memory Search",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1233,6 +1233,7 @@
                 "group": "Skills",
                 "pages": [
                   "tools/skills",
+                  "tools/skill-routing",
                   "tools/creating-skills",
                   "tools/skills-config",
                   "tools/slash-commands",

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -21,15 +21,15 @@ group membership, provider restrictions, and configuration fields, use
 For most agents, start with the built-in tool categories, then adjust policy
 only when the agent should see fewer tools or needs explicit host access.
 
-| If you need to...                           | Use this first                                 | Then read                                                               |
-| ------------------------------------------- | ---------------------------------------------- | ----------------------------------------------------------------------- |
-| Let an agent act with existing capabilities | [Built-in tools](#built-in-tool-categories)    | [Tool categories](#built-in-tool-categories)                            |
-| Control what an agent can call              | [Tool policy](#configure-access-and-approvals) | [Tools and custom providers](/gateway/config-tools)                     |
-| Teach an agent a workflow                   | [Skills](#choose-tools-skills-or-plugins)      | [Skills](/tools/skills) and [Creating skills](/tools/creating-skills)   |
-| Add a new integration or runtime surface    | [Plugins](#extend-capabilities)                | [Plugins](/tools/plugin) and [Build plugins](/plugins/building-plugins) |
-| Run work later or in the background         | [Automation](/automation)                      | [Automation overview](/automation)                                      |
-| Coordinate multiple agents or harnesses     | [Sub-agents](/tools/subagents)                 | [ACP agents](/tools/acp-agents) and [Agent send](/tools/agent-send)     |
-| Search a large PI tool catalog              | [Tool Search](/tools/tool-search)              | [Tool Search](/tools/tool-search)                                       |
+| If you need to...                           | Use this first                                 | Then read                                                                                                     |
+| ------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Let an agent act with existing capabilities | [Built-in tools](#built-in-tool-categories)    | [Tool categories](#built-in-tool-categories)                                                                  |
+| Control what an agent can call              | [Tool policy](#configure-access-and-approvals) | [Tools and custom providers](/gateway/config-tools)                                                           |
+| Teach an agent a workflow                   | [Skills](#choose-tools-skills-or-plugins)      | [Skills](/tools/skills), [Skill routing](/tools/skill-routing), and [Creating skills](/tools/creating-skills) |
+| Add a new integration or runtime surface    | [Plugins](#extend-capabilities)                | [Plugins](/tools/plugin) and [Build plugins](/plugins/building-plugins)                                       |
+| Run work later or in the background         | [Automation](/automation)                      | [Automation overview](/automation)                                                                            |
+| Coordinate multiple agents or harnesses     | [Sub-agents](/tools/subagents)                 | [ACP agents](/tools/acp-agents) and [Agent send](/tools/agent-send)                                           |
+| Search a large PI tool catalog              | [Tool Search](/tools/tool-search)              | [Tool Search](/tools/tool-search)                                                                             |
 
 ## Choose tools, skills, or plugins
 
@@ -143,6 +143,8 @@ Choose the extension path by the job you need OpenClaw to do:
   [Build plugins](/plugins/building-plugins).
 - Add or tune reusable agent instructions with [Skills](/tools/skills) and
   [Creating skills](/tools/creating-skills).
+- Use [Skill routing](/tools/skill-routing) when a workspace exposes enough
+  skills that the agent needs a local shortlist before reading `SKILL.md`.
 - Package reusable workflow material with
   [Skill workshop](/plugins/skill-workshop) when the workflow belongs in a
   plugin-distributed skill bundle.

--- a/docs/tools/skill-routing.md
+++ b/docs/tools/skill-routing.md
@@ -1,0 +1,139 @@
+---
+summary: "How the local skill router shortlists matching SKILL.md files for an agent run"
+read_when:
+  - You want to understand how local_skill_route works
+  - You are debugging why an agent did or did not read a skill
+  - You are scaling a workspace with many skills
+title: "Skill routing"
+sidebarTitle: "Skill routing"
+---
+
+Skill routing helps an agent choose a relevant `SKILL.md` without guessing a
+path or reading several unrelated skills. OpenClaw exposes the
+`local_skill_route` runtime tool when the current run has a skill snapshot. The
+agent can call it with the user's task, receive a ranked shortlist, and then
+read exactly one matching skill when the result is clear.
+
+The router is local, read-only, and deterministic. It does not call an external
+rerank service, run another model, or replace skill allowlists. It is a compact
+foundation for large workspaces where sending every skill description directly
+to the model is increasingly expensive.
+
+## When the router appears
+
+OpenClaw registers `local_skill_route` only when the agent tool set receives a
+`skillsSnapshot` for the current run. That keeps the prompt and tool surface in
+sync:
+
+- If the tool is registered, the Skills prompt can tell the model to call
+  `local_skill_route` when skill choice is unclear.
+- If the tool is not registered, the prompt falls back to scanning the visible
+  `<available_skills>` catalog and never mentions the router.
+- If no skills are available, the router is omitted entirely.
+
+Sandboxed runs that intentionally do not carry a skill snapshot still get the
+normal visible skills prompt when OpenClaw can build one from loaded entries,
+but they do not receive `local_skill_route`.
+
+## What the tool receives
+
+The tool accepts the current task as a short query:
+
+```json
+{
+  "query": "schedule a calendar meeting tomorrow",
+  "limit": 5
+}
+```
+
+`query` is required. `limit` is optional, defaults to `5`, and is capped at
+`10`.
+
+## What the tool returns
+
+The result is JSON with one of three statuses:
+
+- `matched`: one skill is clearly strongest. The instruction tells the agent to
+  read that skill's `SKILL.md` location before using it.
+- `ambiguous`: two or more strong matches are close together. The agent should
+  ask the user to choose, or use task context to pick the most specific match.
+- `nomatch`: no candidate is strong enough. The agent should not read a skill
+  unless the user gives more specific context.
+
+Example result:
+
+```json
+{
+  "status": "matched",
+  "query": "schedule a calendar meeting tomorrow",
+  "instruction": "Read /workspace/skills/calendar/SKILL.md before using the skill.",
+  "matches": [
+    {
+      "name": "calendar",
+      "description": "Create and update calendar events and meetings",
+      "location": "/workspace/skills/calendar/SKILL.md",
+      "score": 0.72
+    }
+  ]
+}
+```
+
+The router returns skill names, descriptions, locations, and scores. It does not
+return skill body text. The agent still must use the normal read tool to load
+`SKILL.md`.
+
+## How matching works
+
+The current router uses lexical scoring:
+
+1. Normalize the query, skill name, and skill description with lowercase NFKC
+   text.
+2. Tokenize letters and numbers.
+3. Boost matches in the skill name more than matches in the description.
+4. Add a smaller score for partial token overlap.
+5. Sort by score, then by skill name for deterministic ties.
+6. Classify the result as `matched`, `ambiguous`, or `nomatch` with fixed local
+   thresholds.
+
+This makes routing stable and cheap. It also means the router is not semantic:
+if a task uses words that do not overlap a skill name or description, the tool
+may return `nomatch`. Good skill names and concise descriptions matter.
+
+## Prompt behavior
+
+When skills are present, OpenClaw still includes the normal Skills section. The
+router changes the decision path, not the read contract:
+
+1. The agent scans the visible skill catalog.
+2. If one skill clearly applies, it can read that `SKILL.md` directly.
+3. If the choice is unclear and `local_skill_route` is available, it calls the
+   router with the user's request.
+4. It reads at most one matching `SKILL.md` up front.
+5. It never invents skill paths.
+
+The current router does not remove the visible `<available_skills>` catalog
+from the system prompt. That larger prompt-size optimization needs a separate
+design because it changes model behavior for every skill-enabled run.
+
+## Debug routing
+
+If an agent does not use the expected skill:
+
+1. Confirm the skill is visible to that agent. See [Skills](/tools/skills) for
+   roots, precedence, and allowlists.
+2. Check whether `local_skill_route` is present in the run's tool list. If it is
+   missing, the run did not receive a skill snapshot.
+3. Check the skill's `name` and `description`. The router matches those fields,
+   not the full `SKILL.md` body.
+4. Try a query that includes the expected skill name or description terms.
+5. If two skills are close, expect `ambiguous` and make the skill names or
+   descriptions more specific.
+
+## Related
+
+- [Skills](/tools/skills) for load order, allowlists, and snapshots
+- [Creating skills](/tools/creating-skills) for writing clear skill names and
+  descriptions
+- [Skills config](/tools/skills-config) for configuration fields
+- [Tool Search](/tools/tool-search) for compact discovery across large PI tool
+  catalogs

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -14,6 +14,11 @@ containing a `SKILL.md` with YAML frontmatter and instructions. OpenClaw
 loads bundled skills plus optional local overrides, and filters them at
 load time based on environment, config, and binary presence.
 
+When a run has many visible skills, the agent can use
+[`local_skill_route`](/tools/skill-routing) to shortlist likely matches before
+reading a `SKILL.md`. Routing does not change skill visibility or allowlists; it
+only helps the agent choose which visible skill to read.
+
 ## Locations and precedence
 
 OpenClaw loads skills from these sources, **highest precedence first**:

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -28,6 +28,7 @@ import {
   wrapToolWithBeforeToolCallHook,
 } from "./pi-tools.before-tool-call.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
+import type { SkillSnapshot } from "./skills/types.js";
 import type { SpawnedToolContext } from "./spawned-context.js";
 import type { ToolFsPolicy } from "./tool-fs-policy.js";
 import { resolveToolLoopDetectionConfig } from "./tool-loop-detection-config.js";
@@ -49,6 +50,7 @@ import { createSessionsListTool } from "./tools/sessions-list-tool.js";
 import { createSessionsSendTool } from "./tools/sessions-send-tool.js";
 import { createSessionsSpawnTool } from "./tools/sessions-spawn-tool.js";
 import { createSessionsYieldTool } from "./tools/sessions-yield-tool.js";
+import { createSkillRouteTool } from "./tools/skill-route-tool.js";
 import { createSubagentsTool } from "./tools/subagents-tool.js";
 import { createTtsTool } from "./tools/tts-tool.js";
 import { createUpdatePlanTool } from "./tools/update-plan-tool.js";
@@ -145,6 +147,8 @@ export function createOpenClawTools(
     requesterSenderId?: string | null;
     /** Auth profiles already loaded for this run; used for prompt-time tool availability. */
     authProfileStore?: AuthProfileStore;
+    /** Skills available to this run; used by the local skill router. */
+    skillsSnapshot?: SkillSnapshot;
     /** Ephemeral session UUID — regenerated on /new and /reset. */
     sessionId?: string;
     /**
@@ -316,6 +320,7 @@ export function createOpenClawTools(
         senderIsOwner: options?.senderIsOwner,
       });
   const heartbeatTool = options?.enableHeartbeatTool ? createHeartbeatResponseTool() : null;
+  const skillRouteTool = createSkillRouteTool({ skillsSnapshot: options?.skillsSnapshot });
   options?.recordToolPrepStage?.("openclaw-tools:message-tool");
   const nodesToolBase = createNodesTool({
     agentSessionKey: options?.agentSessionKey,
@@ -389,7 +394,7 @@ export function createOpenClawTools(
           }),
         ]),
     ...(messageTool && includeMessageTool ? [messageTool] : []),
-    ...collectPresentOpenClawTools([heartbeatTool]),
+    ...collectPresentOpenClawTools([heartbeatTool, skillRouteTool]),
     createTtsTool({
       agentChannel: options?.agentChannel,
       config: resolvedConfig,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -963,6 +963,7 @@ export function createOpenClawCodingTools(options?: {
           requesterSenderId: options?.senderId,
           senderIsOwner: options?.senderIsOwner,
           authProfileStore: options?.authProfileStore,
+          skillsSnapshot: options?.skillsSnapshot,
           sessionId: options?.sessionId,
           inheritedToolAllowlist,
           inheritedToolDenylist,

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -685,6 +685,28 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("If several apply, choose the most specific.");
   });
 
+  it("mentions skill routing only when the tool is available", () => {
+    const skillsPrompt =
+      "<available_skills>\n  <skill>\n    <name>demo</name>\n  </skill>\n</available_skills>";
+    const withoutTool = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      skillsPrompt,
+    });
+    const withTool = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      skillsPrompt,
+      toolNames: ["read", "local_skill_route"],
+    });
+
+    expect(withoutTool).not.toContain("call `local_skill_route`");
+    expect(withTool).toContain(
+      "If skill choice is unclear, call `local_skill_route` with the user request before reading any SKILL.md.",
+    );
+    expect(withTool).toContain(
+      "- local_skill_route: Find likely local skills for the current task",
+    );
+  });
+
   it("appends available skills when provided", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -240,7 +240,11 @@ function buildExecApprovalPromptGuidance(params: {
   return 'If exec returns approval-pending, send the exact /approve command from "Reply with:"; do not ask for another code.';
 }
 
-function buildSkillsSection(params: { skillsPrompt?: string; readToolName: string }) {
+function buildSkillsSection(params: {
+  skillsPrompt?: string;
+  readToolName: string;
+  hasSkillRouteTool: boolean;
+}) {
   const trimmed = params.skillsPrompt?.trim();
   if (!trimmed) {
     return [];
@@ -248,12 +252,15 @@ function buildSkillsSection(params: { skillsPrompt?: string; readToolName: strin
   return [
     "## Skills",
     `Scan <available_skills>. If one clearly applies, read its SKILL.md at exact <location> with \`${params.readToolName}\`, then follow it.`,
+    params.hasSkillRouteTool
+      ? "If skill choice is unclear, call `local_skill_route` with the user request before reading any SKILL.md."
+      : "",
     "If several apply, choose the most specific. If none clearly apply, read none.",
     "One skill up front max. Never guess/fabricate skill paths.",
     "External API writes: batch when safe, avoid tight loops, respect 429/Retry-After.",
     trimmed,
     "",
-  ];
+  ].filter(Boolean);
 }
 
 function buildMemorySection(params: {
@@ -770,6 +777,7 @@ export function buildAgentSystemPrompt(params: {
       "Show a /status-equivalent status card (usage + time + Reasoning/Verbose/Elevated); use for model-use questions (📊 session_status); optional per-session model override",
     image: "Analyze an image with the configured image model",
     image_generate: "Generate images with the configured image-generation model",
+    local_skill_route: "Find likely local skills for the current task",
   };
 
   const toolOrder = [
@@ -800,6 +808,7 @@ export function buildAgentSystemPrompt(params: {
     "session_status",
     "image",
     "image_generate",
+    "local_skill_route",
   ];
 
   const rawToolNames = (params.toolNames ?? []).map((tool) => tool.trim());
@@ -934,6 +943,7 @@ export function buildAgentSystemPrompt(params: {
   const skillsSection = buildSkillsSection({
     skillsPrompt,
     readToolName,
+    hasSkillRouteTool: availableTools.has("local_skill_route"),
   });
   const memorySection = buildMemorySection({
     isMinimal,

--- a/src/agents/tool-display-config.ts
+++ b/src/agents/tool-display-config.ts
@@ -337,6 +337,11 @@ export const TOOL_DISPLAY_CONFIG: ToolDisplayConfig = {
       title: "Agents",
       detailKeys: [],
     },
+    local_skill_route: {
+      emoji: "🧭",
+      title: "Skill Route",
+      detailKeys: ["query", "limit"],
+    },
     memory_search: {
       emoji: "🧠",
       title: "Memory Search",

--- a/src/agents/tools/skill-route-tool.test.ts
+++ b/src/agents/tools/skill-route-tool.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { createOpenClawTools } from "../openclaw-tools.js";
+import { createCanonicalFixtureSkill } from "../skills.test-helpers.js";
+import type { Skill } from "../skills/skill-contract.js";
+import type { SkillSnapshot } from "../skills/types.js";
+import { createSkillRouteTool, rankSkillRoutes } from "./skill-route-tool.js";
+
+function skill(name: string, description: string): Skill {
+  return createCanonicalFixtureSkill({
+    name,
+    description,
+    filePath: `/tmp/skills/${name}/SKILL.md`,
+    baseDir: `/tmp/skills/${name}`,
+    source: "test",
+  });
+}
+
+function snapshot(skills: Skill[]): SkillSnapshot {
+  return {
+    prompt: "",
+    skills: skills.map((entry) => ({ name: entry.name })),
+    resolvedSkills: skills,
+  };
+}
+
+function detailsOf(
+  result: Awaited<ReturnType<NonNullable<ReturnType<typeof createSkillRouteTool>>["execute"]>>,
+) {
+  return result.details as {
+    status: string;
+    instruction: string;
+    matches: Array<{ name: string; score: number; location?: string }>;
+  };
+}
+
+describe("local_skill_route", () => {
+  it("ranks the skill that matches the user task", () => {
+    const matches = rankSkillRoutes({
+      query: "please schedule a calendar meeting tomorrow",
+      skills: [
+        skill("github", "Review pull requests and issues"),
+        skill("calendar", "Create and update calendar events and meetings"),
+      ],
+    });
+
+    expect(matches[0]).toMatchObject({
+      name: "calendar",
+      location: "/tmp/skills/calendar/SKILL.md",
+    });
+    expect(matches[0]?.score).toBeGreaterThan(matches[1]?.score ?? 0);
+  });
+
+  it("returns a matched instruction with the SKILL.md location", async () => {
+    const tool = createSkillRouteTool({
+      skillsSnapshot: snapshot([
+        skill("github", "Review pull requests and issues"),
+        skill("calendar", "Create and update calendar events and meetings"),
+      ]),
+    });
+
+    expect(tool).not.toBeNull();
+    const result = await tool!.execute("route", {
+      query: "create a calendar event",
+    });
+    const details = detailsOf(result);
+
+    expect(details.status).toBe("matched");
+    expect(details.matches[0]).toMatchObject({
+      name: "calendar",
+      location: "/tmp/skills/calendar/SKILL.md",
+    });
+    expect(details.instruction).toContain("/tmp/skills/calendar/SKILL.md");
+  });
+
+  it("marks close matches as ambiguous", async () => {
+    const tool = createSkillRouteTool({
+      skillsSnapshot: snapshot([
+        skill("github-pr", "Review GitHub pull requests"),
+        skill("github-issues", "Triage GitHub issues"),
+      ]),
+    });
+
+    const result = await tool!.execute("route", {
+      query: "github",
+    });
+    const details = detailsOf(result);
+
+    expect(details.status).toBe("ambiguous");
+    expect(details.matches.map((match) => match.name).toSorted()).toEqual([
+      "github-issues",
+      "github-pr",
+    ]);
+  });
+
+  it("does not recommend a skill for unrelated requests", async () => {
+    const tool = createSkillRouteTool({
+      skillsSnapshot: snapshot([skill("calendar", "Create and update calendar events")]),
+    });
+
+    const result = await tool!.execute("route", {
+      query: "resize this image and remove the background",
+    });
+    const details = detailsOf(result);
+
+    expect(details.status).toBe("nomatch");
+    expect(details.instruction).toContain("Do not read a skill");
+  });
+
+  it("is registered only when skills are available", () => {
+    const withoutSkills = createOpenClawTools({ disablePluginTools: true });
+    expect(withoutSkills.some((tool) => tool.name === "local_skill_route")).toBe(false);
+
+    const withSkills = createOpenClawTools({
+      disablePluginTools: true,
+      skillsSnapshot: snapshot([skill("calendar", "Create and update calendar events")]),
+    });
+    expect(withSkills.some((tool) => tool.name === "local_skill_route")).toBe(true);
+  });
+});

--- a/src/agents/tools/skill-route-tool.ts
+++ b/src/agents/tools/skill-route-tool.ts
@@ -1,0 +1,177 @@
+import { Type } from "typebox";
+import type { Skill } from "../skills/skill-contract.js";
+import type { SkillSnapshot } from "../skills/types.js";
+import type { AnyAgentTool } from "./common.js";
+import { asToolParamsRecord, jsonResult, readNumberParam, readStringParam } from "./common.js";
+
+const SkillRouteToolSchema = Type.Object({
+  query: Type.String({
+    description: "User request or task to match against available skills.",
+  }),
+  limit: Type.Optional(
+    Type.Number({
+      description: "Maximum matches to return. Defaults to 5.",
+    }),
+  ),
+});
+
+type RouteSkillCandidate = {
+  name: string;
+  description?: string;
+  location?: string;
+};
+
+type SkillRouteMatch = {
+  name: string;
+  score: number;
+  description?: string;
+  location?: string;
+};
+
+const DEFAULT_LIMIT = 5;
+const MAX_LIMIT = 10;
+const MATCH_THRESHOLD = 0.25;
+const AMBIGUOUS_SCORE_DELTA = 0.08;
+const WORD_RE = /[\p{L}\p{N}]+/gu;
+
+function normalizeText(value: string): string {
+  return value.toLocaleLowerCase().normalize("NFKC");
+}
+
+function tokenize(value: string): string[] {
+  return [...normalizeText(value).matchAll(WORD_RE)]
+    .map((match) => match[0])
+    .filter((token) => token.length >= 2);
+}
+
+function uniqueTokens(value: string): Set<string> {
+  return new Set(tokenize(value));
+}
+
+function resolveSkillCandidates(snapshot?: SkillSnapshot): RouteSkillCandidate[] {
+  const resolved = snapshot?.resolvedSkills ?? [];
+  if (resolved.length > 0) {
+    return resolved.map((skill) => ({
+      name: skill.name,
+      description: skill.description,
+      location: skill.filePath,
+    }));
+  }
+
+  return (snapshot?.skills ?? []).map((skill) => ({ name: skill.name }));
+}
+
+function scoreSkill(query: string, skill: RouteSkillCandidate): number {
+  const queryTokens = uniqueTokens(query);
+  if (queryTokens.size === 0) {
+    return 0;
+  }
+
+  const name = normalizeText(skill.name);
+  const description = normalizeText(skill.description ?? "");
+  const haystack = `${name} ${description}`;
+  const skillTokens = uniqueTokens(haystack);
+  let score = 0;
+  for (const token of queryTokens) {
+    if (name.includes(token)) {
+      score += 0.34;
+      continue;
+    }
+    if (skillTokens.has(token)) {
+      score += 0.2;
+      continue;
+    }
+    if (
+      [...skillTokens].some(
+        (skillToken) => skillToken.includes(token) || token.includes(skillToken),
+      )
+    ) {
+      score += 0.08;
+    }
+  }
+
+  const queryNormalized = normalizeText(query);
+  if (queryNormalized.includes(name) || name.includes(queryNormalized)) {
+    score += 0.55;
+  }
+
+  return Number(Math.min(score / Math.max(queryTokens.size, 1), 1).toFixed(3));
+}
+
+export function rankSkillRoutes(params: {
+  query: string;
+  skills: Skill[];
+  limit?: number;
+}): SkillRouteMatch[] {
+  const limit = Math.min(Math.max(Math.trunc(params.limit ?? DEFAULT_LIMIT), 1), MAX_LIMIT);
+  return params.skills
+    .map((skill) => ({
+      name: skill.name,
+      score: scoreSkill(params.query, {
+        name: skill.name,
+        description: skill.description,
+        location: skill.filePath,
+      }),
+      description: skill.description,
+      location: skill.filePath,
+    }))
+    .filter((match) => match.score > 0)
+    .toSorted((a, b) => b.score - a.score || a.name.localeCompare(b.name))
+    .slice(0, limit);
+}
+
+export function createSkillRouteTool(opts?: {
+  skillsSnapshot?: SkillSnapshot;
+}): AnyAgentTool | null {
+  const candidates = resolveSkillCandidates(opts?.skillsSnapshot);
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  return {
+    label: "Skill Route",
+    name: "local_skill_route",
+    description:
+      "Find likely local skills for the current task. Use before reading SKILL.md when skill choice is unclear or the skills list is large.",
+    parameters: SkillRouteToolSchema,
+    execute: async (_toolCallId, params) => {
+      const record = asToolParamsRecord(params);
+      const query = readStringParam(record, "query", { required: true });
+      const limit = Math.min(
+        Math.max(readNumberParam(record, "limit", { integer: true }) ?? DEFAULT_LIMIT, 1),
+        MAX_LIMIT,
+      );
+      const matches = candidates
+        .map((skill) => ({
+          name: skill.name,
+          description: skill.description,
+          location: skill.location,
+          score: scoreSkill(query, skill),
+        }))
+        .filter((match) => match.score > 0)
+        .toSorted((a, b) => b.score - a.score || a.name.localeCompare(b.name))
+        .slice(0, limit);
+      const strongMatches = matches.filter((match) => match.score >= MATCH_THRESHOLD);
+      const top = strongMatches[0];
+      const runnerUp = strongMatches[1];
+      const status = !top
+        ? "nomatch"
+        : runnerUp && top.score - runnerUp.score <= AMBIGUOUS_SCORE_DELTA
+          ? "ambiguous"
+          : "matched";
+      const instruction =
+        status === "matched" && top?.location
+          ? `Read ${top.location} before using the skill.`
+          : status === "ambiguous"
+            ? "Ask the user to choose, or read the most specific matching SKILL.md if the task context disambiguates it."
+            : "Do not read a skill unless the task gives a clearer match.";
+
+      return jsonResult({
+        status,
+        query,
+        instruction,
+        matches: status === "nomatch" ? matches.slice(0, limit) : strongMatches.slice(0, limit),
+      });
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- add `local_skill_route`, a read-only local tool that ranks available skills for the current user task and returns matched/ambiguous/nomatch guidance
- wire the tool through `createOpenClawTools` from the per-run `skillsSnapshot`, and pass that snapshot from coding tools
- gate system-prompt guidance on actual tool availability, with regression coverage for router behavior and prompt/tool sync
- add tool display metadata and refresh the shared OpenClawKit tool-display snapshot
- document how skill routing works in `docs/tools/skill-routing.md` and link it from the tools/skills docs

## Verification

- `pnpm format:check CHANGELOG.md src/agents/openclaw-tools.ts src/agents/pi-tools.ts src/agents/system-prompt.ts src/agents/system-prompt.test.ts src/agents/tools/skill-route-tool.ts src/agents/tools/skill-route-tool.test.ts`
- `pnpm tool-display:check`
- `pnpm format:docs:check docs/tools/skill-routing.md docs/tools/skills.md docs/tools/index.md`
- `pnpm check:docs`
- `pnpm docs:list | rg 'tools/skill-routing|tools/skills.md|tools/index.md'`
- `git diff --check`
- Testbox-through-Crabbox `tbx_01ks7vhrjy2j1ckczfesb2qn5p`: `pnpm test src/agents/tools/skill-route-tool.test.ts src/agents/system-prompt.test.ts` (89 tests passed)
- Testbox-through-Crabbox `tbx_01ks7w610dxwezg0x3g1prqs6p`: `pnpm check:changed`
- `$autoreview`: `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local` clean, no accepted/actionable findings after the router patch and after the display metadata fix

Behavior addressed: agents can shortlist likely local skills before reading SKILL.md when a workspace exposes many skills.
Real environment tested: Blacksmith Testbox through Crabbox against the OpenClaw CI check workflow, plus the local docs validation suite.
Exact steps or command run after this patch: `pnpm test src/agents/tools/skill-route-tool.test.ts src/agents/system-prompt.test.ts`, `pnpm tool-display:check`, `pnpm check:docs`, and `pnpm check:changed`.
Evidence after fix: focused Testbox `tbx_01ks7vhrjy2j1ckczfesb2qn5p` passed 84 system-prompt tests and 5 skill-router tests; changed gate Testbox `tbx_01ks7w610dxwezg0x3g1prqs6p` passed typecheck, lint, import-cycle, tool-display, and changed-file guards; docs checks passed with 0 broken internal links.
Observed result after fix: `local_skill_route` is present only when a skills snapshot exists, prompt guidance only mentions it when registered, the tool returns matched, ambiguous, and nomatch routing outcomes, and docs explain the lifecycle and debugging path.
What was not tested: live LLM routing behavior with a real 90+ skill deployment and external rerank/LLM-judge scoring; this PR is the local deterministic foundation only.
