### PR TITLE
Fix Telegram DM reply delivery for overlapping turns

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3050,6 +3050,88 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliveredTexts).toContain("fresh request answer");
   });
 
+  it("keeps newer DM requests from aborting active same-session dispatch", async () => {
+    let firstStarted: (() => void) | undefined;
+    const firstStartGate = new Promise<void>((resolve) => {
+      firstStarted = resolve;
+    });
+    let releaseFirst: (() => void) | undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let secondStarted: (() => void) | undefined;
+    const secondStartGate = new Promise<void>((resolve) => {
+      secondStarted = resolve;
+    });
+    let firstAbortSignal: AbortSignal | undefined;
+    dispatchReplyWithBufferedBlockDispatcher
+      .mockImplementationOnce(async ({ dispatcherOptions, replyOptions }) => {
+        firstAbortSignal = replyOptions?.abortSignal;
+        firstStarted?.();
+        await firstGate;
+        await dispatcherOptions.deliver({ text: "earlier DM answer" }, { kind: "final" });
+        return {
+          queuedFinal: true,
+          counts: { block: 0, final: 1, tool: 0 },
+        };
+      })
+      .mockImplementationOnce(async ({ dispatcherOptions }) => {
+        secondStarted?.();
+        await dispatcherOptions.deliver({ text: "fresh DM answer" }, { kind: "final" });
+        return {
+          queuedFinal: true,
+          counts: { block: 0, final: 1, tool: 0 },
+        };
+      });
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    const createDirectContext = (messageId: number, body: string) =>
+      createContext({
+        ctxPayload: {
+          SessionKey: "agent:main:main",
+          ChatType: "direct",
+          MessageSid: String(messageId),
+          RawBody: body,
+          BodyForAgent: body,
+          CommandBody: body,
+          CommandAuthorized: true,
+        } as unknown as TelegramMessageContext["ctxPayload"],
+        msg: {
+          chat: { id: 123, type: "private" },
+          message_id: messageId,
+        } as unknown as TelegramMessageContext["msg"],
+        chatId: 123,
+        isGroup: false,
+        historyKey: "telegram:123",
+        historyLimit: 10,
+        groupHistories: new Map(),
+        threadSpec: { id: undefined, scope: "none" },
+      });
+
+    const firstPromise = dispatchWithContext({
+      context: createDirectContext(99, "first request"),
+      streamMode: "off",
+    });
+    await firstStartGate;
+    const secondPromise = dispatchWithContext({
+      context: createDirectContext(100, "second request"),
+      streamMode: "off",
+    });
+    await secondStartGate;
+
+    expect(firstAbortSignal?.aborted).toBe(false);
+    releaseFirst?.();
+    await Promise.all([firstPromise, secondPromise]);
+
+    const deliveredTexts = deliverReplies.mock.calls.flatMap((call) =>
+      ((call[0] as { replies?: Array<{ text?: string }> }).replies ?? []).map(
+        (reply) => reply.text,
+      ),
+    );
+    expect(deliveredTexts).toContain("fresh DM answer");
+    expect(deliveredTexts).toContain("earlier DM answer");
+  });
+
   it("keeps /btw side questions from aborting an active same-session dispatch", async () => {
     const historyKey = "telegram:group:-100123";
     const groupHistories = new Map([[historyKey, []]]);

--- a/extensions/telegram/src/telegram-reply-fence.test.ts
+++ b/extensions/telegram/src/telegram-reply-fence.test.ts
@@ -92,6 +92,20 @@ describe("shouldSupersedeTelegramReplyFence", () => {
         CommandAuthorized: true,
       }),
     ).toBe(false);
+    expect(
+      shouldSupersedeTelegramReplyFence({
+        ChatType: "direct",
+        CommandBody: "/plugin_command",
+        CommandAuthorized: true,
+        CommandTurn: {
+          kind: "text-slash",
+          source: "text",
+          authorized: true,
+          commandName: "plugin_command",
+          body: "/plugin_command",
+        },
+      }),
+    ).toBe(true);
   });
 });
 

--- a/extensions/telegram/src/telegram-reply-fence.test.ts
+++ b/extensions/telegram/src/telegram-reply-fence.test.ts
@@ -78,6 +78,20 @@ describe("shouldSupersedeTelegramReplyFence", () => {
         CommandAuthorized: true,
       }),
     ).toBe(true);
+    expect(
+      shouldSupersedeTelegramReplyFence({
+        ChatType: "direct",
+        CommandBody: "/diagnostics confirm abc123def456",
+        CommandAuthorized: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSupersedeTelegramReplyFence({
+        ChatType: "direct",
+        CommandBody: "/var/log error",
+        CommandAuthorized: true,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/extensions/telegram/src/telegram-reply-fence.test.ts
+++ b/extensions/telegram/src/telegram-reply-fence.test.ts
@@ -55,6 +55,23 @@ describe("shouldSupersedeTelegramReplyFence", () => {
       }),
     ).toBe(true);
   });
+
+  it("keeps normal direct turns deliverable while preserving direct aborts", () => {
+    expect(
+      shouldSupersedeTelegramReplyFence({
+        ChatType: "direct",
+        CommandBody: "answer this",
+        CommandAuthorized: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSupersedeTelegramReplyFence({
+        ChatType: "direct",
+        CommandBody: "/stop",
+        CommandAuthorized: true,
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("telegram reply fence supersede", () => {

--- a/extensions/telegram/src/telegram-reply-fence.test.ts
+++ b/extensions/telegram/src/telegram-reply-fence.test.ts
@@ -71,6 +71,13 @@ describe("shouldSupersedeTelegramReplyFence", () => {
         CommandAuthorized: true,
       }),
     ).toBe(true);
+    expect(
+      shouldSupersedeTelegramReplyFence({
+        ChatType: "direct",
+        CommandBody: "/diagnostics confirm abc123def456",
+        CommandAuthorized: true,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/extensions/telegram/src/telegram-reply-fence.ts
+++ b/extensions/telegram/src/telegram-reply-fence.ts
@@ -207,6 +207,9 @@ export function shouldSupersedeTelegramReplyFence(ctxPayload: {
   ) {
     return false;
   }
+  if (dispatchText.trimStart().startsWith("/")) {
+    return true;
+  }
   if (ctxPayload.ChatType === "direct") {
     return false;
   }

--- a/extensions/telegram/src/telegram-reply-fence.ts
+++ b/extensions/telegram/src/telegram-reply-fence.ts
@@ -1,4 +1,8 @@
 import {
+  maybeResolveTextAlias,
+  normalizeCommandBody,
+} from "openclaw/plugin-sdk/command-auth-native";
+import {
   isAbortRequestText,
   isBtwRequestText,
 } from "openclaw/plugin-sdk/command-primitives-runtime";
@@ -190,6 +194,10 @@ export function releaseTelegramReplyFenceAbortController(
   maybeDeleteTelegramReplyFenceState(key, state);
 }
 
+function isRecognizedTelegramTextCommand(rawText: string): boolean {
+  return maybeResolveTextAlias(normalizeCommandBody(rawText)) != null;
+}
+
 export function shouldSupersedeTelegramReplyFence(ctxPayload: {
   Body?: string;
   ChatType?: string;
@@ -207,10 +215,10 @@ export function shouldSupersedeTelegramReplyFence(ctxPayload: {
   ) {
     return false;
   }
-  if (dispatchText.trimStart().startsWith("/")) {
-    return true;
-  }
   if (ctxPayload.ChatType === "direct") {
+    if (ctxPayload.CommandAuthorized && isRecognizedTelegramTextCommand(dispatchText)) {
+      return true;
+    }
     return false;
   }
   return true;

--- a/extensions/telegram/src/telegram-reply-fence.ts
+++ b/extensions/telegram/src/telegram-reply-fence.ts
@@ -192,6 +192,7 @@ export function releaseTelegramReplyFenceAbortController(
 
 export function shouldSupersedeTelegramReplyFence(ctxPayload: {
   Body?: string;
+  ChatType?: string;
   RawBody?: string;
   CommandBody?: string;
   CommandAuthorized: boolean;
@@ -204,6 +205,9 @@ export function shouldSupersedeTelegramReplyFence(ctxPayload: {
     isBtwRequestText(dispatchText) ||
     isTelegramReadOnlyControlLaneText({ rawText: dispatchText })
   ) {
+    return false;
+  }
+  if (ctxPayload.ChatType === "direct") {
     return false;
   }
   return true;

--- a/extensions/telegram/src/telegram-reply-fence.ts
+++ b/extensions/telegram/src/telegram-reply-fence.ts
@@ -1,4 +1,8 @@
 import {
+  isExplicitCommandTurn,
+  type CommandTurnContext,
+} from "openclaw/plugin-sdk/channel-inbound";
+import {
   maybeResolveTextAlias,
   normalizeCommandBody,
 } from "openclaw/plugin-sdk/command-auth-native";
@@ -204,6 +208,7 @@ export function shouldSupersedeTelegramReplyFence(ctxPayload: {
   RawBody?: string;
   CommandBody?: string;
   CommandAuthorized: boolean;
+  CommandTurn?: CommandTurnContext;
 }): boolean {
   const dispatchText = ctxPayload.CommandBody ?? ctxPayload.RawBody ?? ctxPayload.Body ?? "";
   if (isAbortRequestText(dispatchText)) {
@@ -216,7 +221,11 @@ export function shouldSupersedeTelegramReplyFence(ctxPayload: {
     return false;
   }
   if (ctxPayload.ChatType === "direct") {
-    if (ctxPayload.CommandAuthorized && isRecognizedTelegramTextCommand(dispatchText)) {
+    if (
+      ctxPayload.CommandAuthorized &&
+      (isExplicitCommandTurn(ctxPayload.CommandTurn) ||
+        isRecognizedTelegramTextCommand(dispatchText))
+    ) {
       return true;
     }
     return false;


### PR DESCRIPTION
## Summary
- Fixes #85314 by keeping normal Telegram DM turns from superseding earlier same-session DM reply delivery.
- Adds a focused regression test proving overlapping direct-message turns both remain deliverable.

## Root Cause
Telegram reply fences are keyed by the effective session key, and direct chats commonly use `agent:main:main`. Before this change, every normal Telegram user request superseded the active fence for that session. When a second DM arrived before the first turn reached final delivery, the first turn's delivery path saw a newer fence generation and returned before outbound Telegram delivery.

## Fix
Normal Telegram direct-chat turns no longer supersede active same-session reply work. Authorized abort requests still supersede, `/btw` and read-only control lanes remain non-interrupting, and existing group/room-event latest-wins behavior is unchanged.

## Why This Is Safe
The change is limited to Telegram reply-fence supersede policy and only for `ChatType: "direct"` normal turns. It does not alter routing, auth, pairing, outbound target resolution, Telegram send parameters, group behavior, message-tool policy, or provider prompts. The regression test asserts both the runtime abort signal and the observable outbound replies for overlapping DM turns.

## Security / Runtime Controls Unchanged
- Telegram token handling, channel allowlists, pairing, command authorization, and owner-only command checks are unchanged.
- Authorized `/stop` remains runtime-enforced and can still interrupt active work.
- Group and room-event supersede semantics remain covered by existing tests.
- No config defaults, docs surfaces, generated config artifacts, or migration/repair paths changed.

## Real Behavior Proof
Redacted pre-patch/source proof:

```text
$ pnpm test extensions/telegram/src/bot-message-dispatch.test.ts -t "lets newer user requests abort active same-session dispatch" -- --reporter=verbose
✓ dispatchTelegramMessage draft streaming > lets newer user requests abort active same-session dispatch
Test Files  1 passed (1)
Tests  1 passed | 83 skipped (84)
```

Redacted local gateway/channel proof while preparing manual Telegram verification:

```text
Gateway: bind=loopback (127.0.0.1), port=18789
Runtime: running
Connectivity probe: ok
Telegram default: enabled, configured, running, connected, mode:polling

2026-05-22T08:53:18.799-04:00 info gateway/channels/telegram/inbound Inbound message telegram:<redacted-user> -> @<redacted-bot> (direct, 99 chars)
2026-05-22T08:53:33.732-04:00 info gateway/channels/telegram/inbound Inbound message telegram:<redacted-user> -> @<redacted-bot> (direct, 60 chars)
```

Redacted post-patch proof:
<img width="959" height="501" alt="telegram_proof" src="https://github.com/user-attachments/assets/e322be82-0c23-43bd-823c-dc04f54a9473" />

```text
$ pnpm test extensions/telegram/src/bot-message-dispatch.test.ts -t "keeps newer DM requests from aborting active same-session dispatch" -- --reporter=verbose
✓ dispatchTelegramMessage draft streaming > keeps newer DM requests from aborting active same-session dispatch
Test Files  1 passed (1)
Tests  1 passed | 84 skipped (85)
```

The manual Telegram screenshot will be attached separately after visual confirmation.

## Tests
- `git diff --check origin/main...HEAD`
- `pnpm test extensions/telegram/src/bot-message-dispatch.test.ts`
- `pnpm test extensions/telegram/src/conversation-route.base-session-key.test.ts`
- `pnpm check:changed`

## Out-of-Scope Follow-Ups
- Changing group latest-wins behavior.
- Changing visible-reply/message-tool policy.
- Changing Telegram routing/session-key policy.
- Adding model-prompt behavior guarantees for delayed natural-language instructions.

Made with [Cursor](https://cursor.com)