### PR TITLE
Fix replay-invalid session recovery

### DIFF
--- a/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
@@ -1559,6 +1559,11 @@ describe("classifyProviderRuntimeFailureKind", () => {
     expect(
       classifyProviderRuntimeFailureKind("401 input item ID does not belong to this connection"),
     ).toBe("replay_invalid");
+    expect(
+      classifyProviderRuntimeFailureKind(
+        "400 code=invalid_encrypted_content Encrypted content could not be decrypted or parsed.",
+      ),
+    ).toBe("replay_invalid");
   });
 
   it("splits ambiguous provider runtime failures instead of collapsing to unknown", () => {

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -353,7 +353,7 @@ const DNS_ERROR_RE = /\benotfound\b|\beai_again\b|\bgetaddrinfo\b|\bno such host
 const INTERRUPTED_NETWORK_ERROR_RE =
   /\beconnrefused\b|\beconnreset\b|\beconnaborted\b|\benetreset\b|\behostunreach\b|\behostdown\b|\benetunreach\b|\bepipe\b|\bsocket hang up\b|\bconnection refused\b|\bconnection reset\b|\bconnection aborted\b|\bnetwork is unreachable\b|\bhost is unreachable\b|\bfetch failed\b|\bconnection error\b|\bnetwork request failed\b/i;
 const REPLAY_INVALID_RE =
-  /\bprevious_response_id\b.*\b(?:invalid|unknown|not found|does not exist|expired|mismatch)\b|\btool_(?:use|call)\.(?:input|arguments)\b.*\b(?:missing|required)\b|\bincorrect role information\b|\broles must alternate\b|\binput item id does not belong to this connection\b/i;
+  /\bprevious_response_id\b.*\b(?:invalid|unknown|not found|does not exist|expired|mismatch)\b|\btool_(?:use|call)\.(?:input|arguments)\b.*\b(?:missing|required)\b|\bincorrect role information\b|\broles must alternate\b|\binput item id does not belong to this connection\b|\binvalid_encrypted_content\b|\bencrypted content could not be decrypted or parsed\b/i;
 const SANDBOX_BLOCKED_RE =
   /\bapproval is required\b|\bapproval timed out\b|\bapproval was denied\b|\bblocked by sandbox\b|\bsandbox\b.*\b(?:blocked|denied|forbidden|disabled|not allowed)\b|\bexec denied\s*\(/i;
 const NO_BODY_HTTP_WRAPPER_RE =

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -96,6 +96,12 @@ vi.mock("../../agents/bootstrap-budget.js", () => ({
 
 vi.mock("../../agents/embedded-agent-helpers.js", () => ({
   BILLING_ERROR_USER_MESSAGE: "billing",
+  classifyProviderRuntimeFailureKind: (message: string) =>
+    /invalid_encrypted_content|encrypted content could not be decrypted or parsed|tool_(?:use|call)\.(?:input|arguments)|input item id does not belong to this connection/i.test(
+      message,
+    )
+      ? "replay_invalid"
+      : "unclassified",
   formatRateLimitOrOverloadedErrorCopy: (message: string) => {
     if (/model\s+(?:is\s+)?at capacity/i.test(message)) {
       return "⚠️ Selected model is at capacity. Try a different model, or wait and retry.";
@@ -5473,6 +5479,50 @@ describe("runAgentTurnWithFallback", () => {
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
       expect(result.payload.text).toBe(PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE);
+    }
+  });
+
+  it("returns a session reset hint for OpenAI encrypted replay failures", async () => {
+    const resetSessionAfterReplayInvalid = vi.fn(async () => true);
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(
+      new Error(
+        "400 code=invalid_encrypted_content Encrypted content could not be decrypted or parsed.",
+      ),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "telegram",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {},
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      resetSessionAfterReplayInvalid,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(resetSessionAfterReplayInvalid).toHaveBeenCalledWith(
+      "400 code=invalid_encrypted_content Encrypted content could not be decrypted or parsed.",
+    );
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(
+        "⚠️ Session history got out of sync. Please try again, or use /new to start a fresh session.",
+      );
     }
   });
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -27,6 +27,7 @@ import {
   isOverloadedErrorMessage,
   isRateLimitErrorMessage,
   isTransientHttpError,
+  classifyProviderRuntimeFailureKind,
 } from "../../agents/embedded-agent-helpers.js";
 import { sanitizeUserFacingText } from "../../agents/embedded-agent-helpers/sanitize-user-facing-text.js";
 import { isMessagingToolSendAction } from "../../agents/embedded-agent-messaging.js";
@@ -607,6 +608,13 @@ function hasBillingAttemptSummary(err: unknown): boolean {
   );
 }
 
+const REPLAY_INVALID_SESSION_USER_MESSAGE =
+  "⚠️ Session history got out of sync. Please try again, or use /new to start a fresh session.";
+
+function isReplayInvalidRunFailureError(message: string): boolean {
+  return classifyProviderRuntimeFailureKind(message) === "replay_invalid";
+}
+
 function collapseRepeatedFailureDetail(message: string): string {
   const parts = message
     .split(/\s+\|\s+/u)
@@ -750,6 +758,12 @@ function buildExternalRunFailureReply(
   if (providerRequestError) {
     return {
       text: providerRequestError.userMessage,
+      isGenericRunnerFailure: false,
+    };
+  }
+  if (isReplayInvalidRunFailureError(normalizedMessage)) {
+    return {
+      text: REPLAY_INVALID_SESSION_USER_MESSAGE,
       isGenericRunnerFailure: false,
     };
   }
@@ -1400,6 +1414,7 @@ export async function runAgentTurnWithFallback(params: {
   shouldEmitToolOutput: () => boolean;
   pendingToolTasks: Set<Promise<void>>;
   resetSessionAfterRoleOrderingConflict: (reason: string) => Promise<boolean>;
+  resetSessionAfterReplayInvalid?: (reason: string) => Promise<boolean>;
   isHeartbeat: boolean;
   sessionKey?: string;
   runtimePolicySessionKey?: string;
@@ -2744,6 +2759,16 @@ export async function runAgentTurnWithFallback(params: {
             text: providerRequestError.userMessage,
           }),
         };
+      }
+
+      if (isReplayInvalidRunFailureError(message)) {
+        try {
+          await params.resetSessionAfterReplayInvalid?.(message);
+        } catch (resetErr) {
+          defaultRuntime.error(
+            `Failed to reset replay-invalid session ${params.sessionKey}: ${String(resetErr)}`,
+          );
+        }
       }
 
       if (isTransientHttp && !didRetryTransientHttpError) {

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -200,6 +200,7 @@ function createMinimalRun(params?: {
   return {
     typing,
     opts,
+    followupRun,
     run: async () => {
       const runReplyAgent = await getRunReplyAgent();
       return runReplyAgent({
@@ -425,6 +426,61 @@ describe("runReplyAgent pending final delivery capture", () => {
     const raw = await readFile(storePath, "utf8");
     return JSON.parse(raw).main as SessionEntry;
   }
+
+  it("rotates poisoned replay-invalid sessions before returning reset guidance", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "poisoned-session",
+      sessionFile: "/tmp/poisoned-session.jsonl",
+      updatedAt: Date.now(),
+      sessionStartedAt: Date.now() - 10_000,
+      systemSent: true,
+      status: "running",
+      contextTokens: 272_000,
+      inputTokens: 877_883,
+      outputTokens: 5_500,
+      modelProvider: "openai-codex",
+      model: "gpt-5.5",
+      cliSessionBindings: { "codex-cli": { sessionId: "codex-session" } },
+    };
+    const sessionStore = { main: sessionEntry };
+    const storePath = await createSessionStoreFile(sessionEntry);
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(
+      new Error(
+        "400 code=invalid_encrypted_content Encrypted content could not be decrypted or parsed.",
+      ),
+    );
+
+    const { followupRun, run } = createMinimalRun({
+      sessionEntry,
+      sessionStore,
+      sessionKey: "main",
+      storePath,
+      runOverrides: {
+        provider: "openai-codex",
+        model: "gpt-5.5",
+      },
+    });
+
+    const result = await run();
+    const stored = await readStoredMainSession(storePath);
+
+    expect(result).toMatchObject({
+      text: "⚠️ Session history got out of sync. Please try again, or use /new to start a fresh session.",
+    });
+    expect(stored.sessionId).not.toBe("poisoned-session");
+    expect(stored.sessionFile).toEqual(expect.any(String));
+    expect(stored.sessionFile).not.toBe("/tmp/poisoned-session.jsonl");
+    expect(followupRun.run.sessionId).toBe(stored.sessionId);
+    expect(followupRun.run.sessionFile).toBe(stored.sessionFile);
+    expect(vi.mocked(refreshQueuedFollowupSession)).toHaveBeenCalledWith({
+      key: "main",
+      previousSessionId: "poisoned-session",
+      nextSessionId: stored.sessionId,
+      nextSessionFile: stored.sessionFile,
+    });
+    expect(stored.systemSent).toBe(false);
+    expect(stored.contextTokens).toBeUndefined();
+  });
 
   it("does not persist message-tool-only final replies for heartbeat replay", async () => {
     const sessionEntry: SessionEntry = {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1460,6 +1460,13 @@ export async function runReplyAgent(params: {
           `Role ordering conflict (${reason}). Restarting session ${sessionKey} -> ${nextSessionId}.`,
         cleanupTranscripts: true,
       });
+    const resetSessionAfterReplayInvalid = async (reason: string): Promise<boolean> =>
+      resetSession({
+        failureLabel: "replay-invalid session state",
+        buildLogMessage: (nextSessionId) =>
+          `Replay-invalid session state (${reason}). Restarting session ${sessionKey} -> ${nextSessionId}.`,
+        cleanupTranscripts: true,
+      });
 
     replyOperation.setPhase("running");
     const runStartedAt = Date.now();
@@ -1482,6 +1489,7 @@ export async function runReplyAgent(params: {
         shouldEmitToolOutput,
         pendingToolTasks,
         resetSessionAfterRoleOrderingConflict,
+        resetSessionAfterReplayInvalid,
         isHeartbeat,
         sessionKey,
         runtimePolicySessionKey,


### PR DESCRIPTION
## Summary

- Classify OpenAI/Codex `invalid_encrypted_content` failures as replay-invalid session state.
- Return the specific stale-session recovery message instead of the generic runner failure copy.
- Reset/rotate the poisoned reply session with the existing `resetReplyRunSession` path before returning the recovery guidance.

This is the cleaner follow-up to #85294. It deliberately leaves current `main`'s native Codex Responses replay contract intact: safe reasoning replay remains enabled, while upstream's existing transport sanitizer/retry continues to strip unsafe encrypted content where appropriate.

## Verification

- `git diff --check`
- `node scripts/run-vitest.mjs src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts src/auto-reply/reply/agent-runner-execution.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts -t "rotates poisoned replay-invalid sessions"`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`

## Real behavior proof

Behavior addressed: A native OpenAI Codex encrypted replay failure should not leave the reply agent bound to a poisoned session that keeps failing with generic "Something went wrong" responses.

Real environment tested: Local OpenClaw checkout at PR head, using the real `resetReplyRunSession` helper against an on-disk OpenClaw session store rooted at `/tmp/openclaw-live-proof` with `OPENCLAW_STATE_DIR=/tmp/openclaw-live-proof/state`.

Exact steps or command run after this patch: Ran a local `node --import tsx --input-type=module` transcript that created a poisoned `sessions.json`, invoked `resetReplyRunSession` with the observed `invalid_encrypted_content` failure class, then inspected the persisted session store with plain `node`.

Evidence after fix: Terminal output from the local OpenClaw filesystem run:

```text
Replay-invalid session state redacted. Restarting session main -> 77af034a-01f9-44b1-8c0c-020c8abb9913.

{
  "resetApplied": true,
  "beforeSessionId": "poisoned-session",
  "afterSessionId": "77af034a-01f9-44b1-8c0c-020c8abb9913",
  "oldBindingStillActive": false,
  "staleRuntimeFieldsCleared": {
    "systemSent": false,
    "contextTokens": null,
    "modelProvider": null,
    "model": null
  },
  "sessionFile": "/tmp/openclaw-live-proof/state/agents/main/sessions/77af034a-01f9-44b1-8c0c-020c8abb9913.jsonl",
  "userFacingRecovery": "Session history got out of sync. Please try again, or use /new to start a fresh session."
}
```

Observed result after fix: The OpenClaw session store moved from `poisoned-session` to a fresh session id, the old transcript path is no longer the active binding, stale runtime fields were cleared, and the recovery copy is the stale-session guidance instead of the generic failure copy.

What was not tested: No production Telegram/OpenClaw VM turn or live OpenAI Codex backend request was run, because that would require production bot and model credentials. The PR also does not change the native Codex Responses transport replay sanitizer that is already present on `main`.
