### PR TITLE
fix(media): avoid eager provider startup for audio listing

### DIFF
--- a/extensions/senseaudio/openclaw.plugin.json
+++ b/extensions/senseaudio/openclaw.plugin.json
@@ -10,6 +10,17 @@
   "contracts": {
     "mediaUnderstandingProviders": ["senseaudio"]
   },
+  "mediaUnderstandingProviderMetadata": {
+    "senseaudio": {
+      "capabilities": ["audio"],
+      "defaultModels": {
+        "audio": "senseaudio-asr-pro-1.5-260319"
+      },
+      "autoPriority": {
+        "audio": 40
+      }
+    }
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -132,6 +132,7 @@ const mocks = vi.hoisted(() => ({
   ]),
   registerBuiltInMemoryEmbeddingProviders: vi.fn(),
   buildMediaUnderstandingRegistry: vi.fn(() => new Map()),
+  buildMediaUnderstandingManifestMetadataRegistry: vi.fn(() => new Map()),
   convertHeicToJpeg: vi.fn(async () => Buffer.from("jpeg-normalized")),
   isWebSearchProviderConfigured: vi.fn(() => false),
   isWebFetchProviderConfigured: vi.fn(() => false),
@@ -240,6 +241,11 @@ vi.mock("../media-understanding/runtime.js", () => ({
 vi.mock("../media-understanding/provider-registry.js", () => ({
   buildMediaUnderstandingRegistry:
     mocks.buildMediaUnderstandingRegistry as typeof import("../media-understanding/provider-registry.js").buildMediaUnderstandingRegistry,
+}));
+
+vi.mock("../media-understanding/manifest-metadata.js", () => ({
+  buildMediaUnderstandingManifestMetadataRegistry:
+    mocks.buildMediaUnderstandingManifestMetadataRegistry as typeof import("../media-understanding/manifest-metadata.js").buildMediaUnderstandingManifestMetadataRegistry,
 }));
 
 vi.mock("../media/media-services.js", async (importOriginal) => {
@@ -442,6 +448,7 @@ describe("capability cli", () => {
     mocks.setTtsProvider.mockClear();
     mocks.resolveExplicitTtsOverrides.mockClear();
     mocks.buildMediaUnderstandingRegistry.mockReset().mockReturnValue(new Map());
+    mocks.buildMediaUnderstandingManifestMetadataRegistry.mockReset().mockReturnValue(new Map());
     mocks.convertHeicToJpeg.mockClear();
     mocks.createEmbeddingProvider.mockClear();
     mocks.registerMemoryEmbeddingProvider.mockClear();
@@ -2277,7 +2284,7 @@ describe("capability cli", () => {
   it("marks env-backed audio providers as configured", async () => {
     vi.stubEnv("DEEPGRAM_API_KEY", "deepgram-test-key");
     vi.stubEnv("GROQ_API_KEY", "groq-test-key");
-    mocks.buildMediaUnderstandingRegistry.mockReturnValueOnce(
+    mocks.buildMediaUnderstandingManifestMetadataRegistry.mockReturnValueOnce(
       new Map([
         [
           "deepgram",
@@ -2321,6 +2328,7 @@ describe("capability cli", () => {
         defaultModels: { audio: "whisper-large-v3-turbo" },
       },
     ]);
+    expect(mocks.buildMediaUnderstandingRegistry).not.toHaveBeenCalled();
   });
 
   it("resolves plugin web search SecretRefs before running infer web search", async () => {

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -133,6 +133,7 @@ const mocks = vi.hoisted(() => ({
   registerBuiltInMemoryEmbeddingProviders: vi.fn(),
   buildMediaUnderstandingRegistry: vi.fn(() => new Map()),
   buildMediaUnderstandingManifestMetadataRegistry: vi.fn(() => new Map()),
+  hasAvailableMediaUnderstandingManifestMetadataGaps: vi.fn(() => false),
   convertHeicToJpeg: vi.fn(async () => Buffer.from("jpeg-normalized")),
   isWebSearchProviderConfigured: vi.fn(() => false),
   isWebFetchProviderConfigured: vi.fn(() => false),
@@ -246,6 +247,8 @@ vi.mock("../media-understanding/provider-registry.js", () => ({
 vi.mock("../media-understanding/manifest-metadata.js", () => ({
   buildMediaUnderstandingManifestMetadataRegistry:
     mocks.buildMediaUnderstandingManifestMetadataRegistry as typeof import("../media-understanding/manifest-metadata.js").buildMediaUnderstandingManifestMetadataRegistry,
+  hasAvailableMediaUnderstandingManifestMetadataGaps:
+    mocks.hasAvailableMediaUnderstandingManifestMetadataGaps as typeof import("../media-understanding/manifest-metadata.js").hasAvailableMediaUnderstandingManifestMetadataGaps,
 }));
 
 vi.mock("../media/media-services.js", async (importOriginal) => {
@@ -449,6 +452,7 @@ describe("capability cli", () => {
     mocks.resolveExplicitTtsOverrides.mockClear();
     mocks.buildMediaUnderstandingRegistry.mockReset().mockReturnValue(new Map());
     mocks.buildMediaUnderstandingManifestMetadataRegistry.mockReset().mockReturnValue(new Map());
+    mocks.hasAvailableMediaUnderstandingManifestMetadataGaps.mockReset().mockReturnValue(false);
     mocks.convertHeicToJpeg.mockClear();
     mocks.createEmbeddingProvider.mockClear();
     mocks.registerMemoryEmbeddingProvider.mockClear();

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -38,6 +38,7 @@ import type {
   ImageGenerationBackground,
   ImageGenerationOutputFormat,
 } from "../image-generation/types.js";
+import { buildMediaUnderstandingManifestMetadataRegistry } from "../media-understanding/manifest-metadata.js";
 import { buildMediaUnderstandingRegistry } from "../media-understanding/provider-registry.js";
 import type { RunMediaUnderstandingFileResult } from "../media-understanding/runtime-types.js";
 import {
@@ -2081,7 +2082,7 @@ export function registerCapabilityCli(program: Command) {
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
         const cfg = getRuntimeConfig();
-        const providers = [...buildMediaUnderstandingRegistry(undefined, cfg).values()]
+        const providers = [...buildMediaUnderstandingManifestMetadataRegistry(cfg).values()]
           .filter((provider) => provider.capabilities?.includes("audio"))
           .map((provider) => ({
             available: true,

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -38,7 +38,10 @@ import type {
   ImageGenerationBackground,
   ImageGenerationOutputFormat,
 } from "../image-generation/types.js";
-import { buildMediaUnderstandingManifestMetadataRegistry } from "../media-understanding/manifest-metadata.js";
+import {
+  buildMediaUnderstandingManifestMetadataRegistry,
+  hasAvailableMediaUnderstandingManifestMetadataGaps,
+} from "../media-understanding/manifest-metadata.js";
 import { buildMediaUnderstandingRegistry } from "../media-understanding/provider-registry.js";
 import type { RunMediaUnderstandingFileResult } from "../media-understanding/runtime-types.js";
 import {
@@ -2082,7 +2085,16 @@ export function registerCapabilityCli(program: Command) {
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
         const cfg = getRuntimeConfig();
-        const providers = [...buildMediaUnderstandingManifestMetadataRegistry(cfg).values()]
+        const metadataRegistry = buildMediaUnderstandingManifestMetadataRegistry(cfg);
+        const providerRegistry = hasAvailableMediaUnderstandingManifestMetadataGaps(cfg)
+          ? new Map([
+              ...metadataRegistry,
+              ...[...buildMediaUnderstandingRegistry(undefined, cfg)].filter(
+                ([providerId]) => !metadataRegistry.has(providerId),
+              ),
+            ])
+          : metadataRegistry;
+        const providers = [...providerRegistry.values()]
           .filter((provider) => provider.capabilities?.includes("audio"))
           .map((provider) => ({
             available: true,

--- a/src/media-understanding/defaults.test.ts
+++ b/src/media-understanding/defaults.test.ts
@@ -89,6 +89,7 @@ vi.mock("../plugins/plugin-registry.js", () => ({
 }));
 
 vi.mock("../plugins/manifest-contract-eligibility.js", () => ({
+  isManifestPluginAvailableForControlPlane: () => true,
   loadManifestMetadataSnapshot: () => ({
     index: { plugins: [] },
     plugins: mediaMetadataPlugins,

--- a/src/media-understanding/manifest-metadata.test.ts
+++ b/src/media-understanding/manifest-metadata.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const manifestMocks = vi.hoisted(() => ({
+  isAvailable: vi.fn(() => true),
+  plugins: [] as Array<{
+    id: string;
+    origin?: string;
+    contracts?: { mediaUnderstandingProviders?: string[] };
+    mediaUnderstandingProviderMetadata?: Record<string, unknown>;
+  }>,
+}));
+
+vi.mock("../plugins/manifest-contract-eligibility.js", () => ({
+  isManifestPluginAvailableForControlPlane: manifestMocks.isAvailable,
+  loadManifestMetadataSnapshot: () => ({
+    index: { plugins: [] },
+    plugins: manifestMocks.plugins,
+  }),
+}));
+
+import { buildMediaUnderstandingManifestMetadataRegistry } from "./manifest-metadata.js";
+
+describe("buildMediaUnderstandingManifestMetadataRegistry", () => {
+  beforeEach(() => {
+    manifestMocks.isAvailable.mockReset().mockReturnValue(true);
+    manifestMocks.plugins.length = 0;
+  });
+
+  it("lists declared audio provider metadata without loading provider runtime", () => {
+    manifestMocks.plugins.push({
+      id: "senseaudio",
+      origin: "bundled",
+      contracts: { mediaUnderstandingProviders: ["senseaudio"] },
+      mediaUnderstandingProviderMetadata: {
+        senseaudio: {
+          capabilities: ["audio"],
+          defaultModels: { audio: "senseaudio-asr-pro-1.5-260319" },
+          autoPriority: { audio: 40 },
+        },
+      },
+    });
+
+    expect(buildMediaUnderstandingManifestMetadataRegistry().get("senseaudio")).toEqual({
+      id: "senseaudio",
+      capabilities: ["audio"],
+      defaultModels: { audio: "senseaudio-asr-pro-1.5-260319" },
+      autoPriority: { audio: 40 },
+      nativeDocumentInputs: undefined,
+    });
+  });
+
+  it("does not report bundled providers when plugins are globally disabled", () => {
+    manifestMocks.plugins.push({
+      id: "senseaudio",
+      origin: "bundled",
+      contracts: { mediaUnderstandingProviders: ["senseaudio"] },
+      mediaUnderstandingProviderMetadata: {
+        senseaudio: {
+          capabilities: ["audio"],
+          defaultModels: { audio: "senseaudio-asr-pro-1.5-260319" },
+        },
+      },
+    });
+
+    expect(
+      buildMediaUnderstandingManifestMetadataRegistry({ plugins: { enabled: false } }),
+    ).toEqual(new Map());
+    expect(manifestMocks.isAvailable).not.toHaveBeenCalled();
+  });
+});

--- a/src/media-understanding/manifest-metadata.test.ts
+++ b/src/media-understanding/manifest-metadata.test.ts
@@ -18,7 +18,10 @@ vi.mock("../plugins/manifest-contract-eligibility.js", () => ({
   }),
 }));
 
-import { buildMediaUnderstandingManifestMetadataRegistry } from "./manifest-metadata.js";
+import {
+  buildMediaUnderstandingManifestMetadataRegistry,
+  hasAvailableMediaUnderstandingManifestMetadataGaps,
+} from "./manifest-metadata.js";
 
 describe("buildMediaUnderstandingManifestMetadataRegistry", () => {
   beforeEach(() => {
@@ -66,5 +69,78 @@ describe("buildMediaUnderstandingManifestMetadataRegistry", () => {
       buildMediaUnderstandingManifestMetadataRegistry({ plugins: { enabled: false } }),
     ).toEqual(new Map());
     expect(manifestMocks.isAvailable).not.toHaveBeenCalled();
+  });
+
+  it("does not report providers rejected by plugin activation policy", () => {
+    manifestMocks.isAvailable.mockReturnValue(false);
+    manifestMocks.plugins.push({
+      id: "senseaudio",
+      origin: "bundled",
+      contracts: { mediaUnderstandingProviders: ["senseaudio"] },
+      mediaUnderstandingProviderMetadata: {
+        senseaudio: {
+          capabilities: ["audio"],
+        },
+      },
+    });
+
+    expect(buildMediaUnderstandingManifestMetadataRegistry()).toEqual(new Map());
+  });
+
+  it("does not report bundled providers excluded by plugins.allow", () => {
+    manifestMocks.plugins.push({
+      id: "senseaudio",
+      origin: "bundled",
+      contracts: { mediaUnderstandingProviders: ["senseaudio"] },
+      mediaUnderstandingProviderMetadata: {
+        senseaudio: {
+          capabilities: ["audio"],
+        },
+      },
+    });
+
+    expect(
+      buildMediaUnderstandingManifestMetadataRegistry({ plugins: { allow: ["codex"] } }),
+    ).toEqual(new Map());
+  });
+
+  it("does not report bundled providers disabled by plugin entry config", () => {
+    manifestMocks.plugins.push({
+      id: "senseaudio",
+      origin: "bundled",
+      contracts: { mediaUnderstandingProviders: ["senseaudio"] },
+      mediaUnderstandingProviderMetadata: {
+        senseaudio: {
+          capabilities: ["audio"],
+        },
+      },
+    });
+
+    expect(
+      buildMediaUnderstandingManifestMetadataRegistry({
+        plugins: { entries: { senseaudio: { enabled: false } } },
+      }),
+    ).toEqual(new Map());
+  });
+
+  it("detects available providers that need runtime compatibility fallback", () => {
+    manifestMocks.plugins.push({
+      id: "external-audio",
+      origin: "global",
+      contracts: { mediaUnderstandingProviders: ["external-audio"] },
+    });
+
+    expect(hasAvailableMediaUnderstandingManifestMetadataGaps()).toBe(true);
+  });
+
+  it("does not trigger runtime fallback for unavailable metadata-less providers", () => {
+    manifestMocks.isAvailable.mockReturnValue(false);
+    manifestMocks.plugins.push({
+      id: "external-audio",
+      origin: "global",
+      contracts: { mediaUnderstandingProviders: ["external-audio"] },
+    });
+
+    expect(hasAvailableMediaUnderstandingManifestMetadataGaps()).toBe(false);
   });
 });

--- a/src/media-understanding/manifest-metadata.ts
+++ b/src/media-understanding/manifest-metadata.ts
@@ -1,5 +1,8 @@
 import type { OpenClawConfig } from "../config/types.js";
-import { loadManifestMetadataSnapshot } from "../plugins/manifest-contract-eligibility.js";
+import {
+  isManifestPluginAvailableForControlPlane,
+  loadManifestMetadataSnapshot,
+} from "../plugins/manifest-contract-eligibility.js";
 import { normalizeMediaProviderId } from "./provider-id.js";
 import type { MediaUnderstandingProvider } from "./types.js";
 
@@ -14,6 +17,15 @@ export function buildMediaUnderstandingManifestMetadataRegistry(
     ...(workspaceDir ? { workspaceDir } : {}),
   });
   for (const plugin of snapshot.plugins) {
+    if (
+      !isManifestPluginAvailableForControlPlane({
+        snapshot,
+        plugin,
+        config: cfg,
+      })
+    ) {
+      continue;
+    }
     const declaredProviders = new Set(
       (plugin.contracts?.mediaUnderstandingProviders ?? []).map((providerId) =>
         normalizeMediaProviderId(providerId),

--- a/src/media-understanding/manifest-metadata.ts
+++ b/src/media-understanding/manifest-metadata.ts
@@ -11,6 +11,9 @@ export function buildMediaUnderstandingManifestMetadataRegistry(
   workspaceDir?: string,
 ): Map<string, MediaUnderstandingProvider> {
   const registry = new Map<string, MediaUnderstandingProvider>();
+  if (cfg?.plugins?.enabled === false) {
+    return registry;
+  }
   const snapshot = loadManifestMetadataSnapshot({
     config: cfg,
     env: process.env,

--- a/src/media-understanding/manifest-metadata.ts
+++ b/src/media-understanding/manifest-metadata.ts
@@ -1,10 +1,26 @@
 import type { OpenClawConfig } from "../config/types.js";
+import { normalizePluginsConfig } from "../plugins/config-state.js";
 import {
   isManifestPluginAvailableForControlPlane,
   loadManifestMetadataSnapshot,
 } from "../plugins/manifest-contract-eligibility.js";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { normalizeMediaProviderId } from "./provider-id.js";
 import type { MediaUnderstandingProvider } from "./types.js";
+
+function isPluginAllowedForMediaListing(
+  plugin: Pick<PluginManifestRecord, "id" | "origin">,
+  cfg?: OpenClawConfig,
+): boolean {
+  if (plugin.origin !== "bundled") {
+    return true;
+  }
+  const plugins = normalizePluginsConfig(cfg?.plugins);
+  if (plugins.deny.includes(plugin.id) || plugins.entries[plugin.id]?.enabled === false) {
+    return false;
+  }
+  return plugins.allow.length === 0 || plugins.allow.includes(plugin.id);
+}
 
 export function buildMediaUnderstandingManifestMetadataRegistry(
   cfg?: OpenClawConfig,
@@ -29,6 +45,9 @@ export function buildMediaUnderstandingManifestMetadataRegistry(
     ) {
       continue;
     }
+    if (!isPluginAllowedForMediaListing(plugin, cfg)) {
+      continue;
+    }
     const declaredProviders = new Set(
       (plugin.contracts?.mediaUnderstandingProviders ?? []).map((providerId) =>
         normalizeMediaProviderId(providerId),
@@ -51,4 +70,44 @@ export function buildMediaUnderstandingManifestMetadataRegistry(
     }
   }
   return registry;
+}
+
+export function hasAvailableMediaUnderstandingManifestMetadataGaps(
+  cfg?: OpenClawConfig,
+  workspaceDir?: string,
+): boolean {
+  if (cfg?.plugins?.enabled === false) {
+    return false;
+  }
+  const snapshot = loadManifestMetadataSnapshot({
+    config: cfg,
+    env: process.env,
+    ...(workspaceDir ? { workspaceDir } : {}),
+  });
+  for (const plugin of snapshot.plugins) {
+    if (
+      !isManifestPluginAvailableForControlPlane({
+        snapshot,
+        plugin,
+        config: cfg,
+      })
+    ) {
+      continue;
+    }
+    if (!isPluginAllowedForMediaListing(plugin, cfg)) {
+      continue;
+    }
+    const metadataProviderIds = new Set(
+      Object.keys(plugin.mediaUnderstandingProviderMetadata ?? {}).map((providerId) =>
+        normalizeMediaProviderId(providerId),
+      ),
+    );
+    for (const providerId of plugin.contracts?.mediaUnderstandingProviders ?? []) {
+      const normalizedProviderId = normalizeMediaProviderId(providerId);
+      if (normalizedProviderId && !metadataProviderIds.has(normalizedProviderId)) {
+        return true;
+      }
+    }
+  }
+  return false;
 }

--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -719,7 +719,7 @@ describe("resolvePluginCapabilityProviders", () => {
 
     expectResolvedCapabilityProviderIds(providers, ["openai", "deepgram"]);
     expectInitialRuntimeRegistryLookup();
-    expectActiveRegistryLookup(["deepgram", "google"]);
+    expectActiveRegistryLookup(["deepgram"]);
   });
 
   it("keeps active speech providers when cfg requests an active provider alias", () => {
@@ -1302,6 +1302,68 @@ describe("resolvePluginCapabilityProviders", () => {
     expectResolvedCapabilityProviderIds(providers, ["google"]);
     expectManifestRegistryLoad(0, {});
     expectActiveRegistryLookup(["google"]);
+  });
+
+  it("loads only config-requested media-understanding providers when no active registry exists", () => {
+    const cfg = {
+      tools: {
+        media: {
+          audio: {
+            models: [{ provider: "deepgram", model: "nova-3" }],
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const compatConfig = {
+      plugins: {
+        enabled: true,
+        allow: ["deepgram"],
+        entries: { deepgram: { enabled: true } },
+      },
+    } as OpenClawConfig;
+    const loaded = createEmptyPluginRegistry();
+    loaded.mediaUnderstandingProviders.push({
+      pluginId: "deepgram",
+      pluginName: "deepgram",
+      source: "test",
+      provider: {
+        id: "deepgram",
+        capabilities: ["audio"],
+      },
+    } as never);
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "deepgram",
+          origin: "bundled",
+          contracts: { mediaUnderstandingProviders: ["deepgram"] },
+        },
+        {
+          id: "google",
+          origin: "bundled",
+          contracts: { mediaUnderstandingProviders: ["google"] },
+        },
+      ] as never,
+      diagnostics: [],
+    });
+    mocks.withBundledPluginEnablementCompat.mockReturnValue(compatConfig);
+    mocks.withBundledPluginVitestCompat.mockReturnValue(compatConfig);
+    mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
+      params === undefined ? undefined : loaded,
+    );
+
+    const providers = resolvePluginCapabilityProviders({
+      key: "mediaUnderstandingProviders",
+      cfg,
+    });
+
+    expectResolvedCapabilityProviderIds(providers, ["deepgram"]);
+    expectManifestRegistryLoad(0, cfg);
+    expectActiveRegistryLookup(["deepgram"]);
+    expect(mocks.withBundledPluginAllowlistCompat).toHaveBeenCalledWith({
+      config: cfg,
+      pluginIds: ["deepgram"],
+    });
   });
 
   it("loads fallback snapshots without startup dependency repair", () => {

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -568,7 +568,7 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
     }
   }
   let requestedProviders: Set<string> | undefined;
-  if (params.key === "speechProviders") {
+  if (params.key === "speechProviders" || params.key === "mediaUnderstandingProviders") {
     requestedProviders =
       missingRequestedProviders ??
       (activeProviders.length === 0


### PR DESCRIPTION
## Summary
- list audio transcription providers from manifest metadata instead of constructing the runtime media-understanding registry
- add missing bundled SenseAudio provider metadata so `capability audio providers` can report it without loading runtime code
- apply control-plane plugin availability filtering to media-understanding manifest metadata, including global `plugins.enabled: false`
- narrow plugin capability provider loading to config-requested media providers when no active registry exists

## Why
`openclaw capability audio providers` only needs provider metadata for status/listing output. Building the runtime registry can eagerly load provider implementations and plugin code, which is slower and can trigger work unrelated to listing configured audio providers.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `openclaw capability audio providers --json` should list manifest-declared audio providers without eager runtime startup, include bundled SenseAudio metadata, and omit bundled plugin providers when plugins are globally disabled.
- Real environment tested: Real OpenClaw checkout on Linux, Node.js v24.2.0, built CLI entrypoint from this PR branch after patching.
- Exact steps or command run after this patch:

```bash
CI=true OPENCLAW_BUILD_VERBOSE=1 NODE_OPTIONS=--max-old-space-size=8192 OPENCLAW_TSDOWN_TIMEOUT_MS=300000 node scripts/build-all.mjs cliStartup
node scripts/test-projects.mjs src/media-understanding/defaults.test.ts src/media-understanding/manifest-metadata.test.ts src/cli/capability-cli.test.ts
OPENCLAW_STATE_DIR=$(mktemp -d) HOME=$(mktemp -d) node openclaw.mjs capability audio providers --json
tmp_home=$(mktemp -d); tmp_state=$(mktemp -d); cfg=$(mktemp); printf '%s\n' '{"plugins":{"enabled":false}}' > "$cfg"; OPENCLAW_STATE_DIR="$tmp_state" HOME="$tmp_home" OPENCLAW_CONFIG_PATH="$cfg" node openclaw.mjs capability audio providers --json
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied live terminal output from the built CLI:

```json
{
  "id": "senseaudio",
  "capabilities": ["audio"],
  "defaultModels": {
    "audio": "senseaudio-asr-pro-1.5-260319"
  },
  "available": true,
  "configured": false,
  "selected": false
}
```

Disabled-plugin config copied live output:

```json
[]
```

- Observed result after fix: The real CLI provider list includes `senseaudio` with the expected audio default model, and the same command returns an empty provider list when run with `OPENCLAW_CONFIG_PATH` pointing to a config containing `{"plugins":{"enabled":false}}`. The focused test shard also passed: media-understanding 10 tests and cli capability 76 tests.
- What was not tested: I did not call the SenseAudio service or verify a live transcription; this PR only changes provider discovery/listing metadata.
- Before evidence (optional but encouraged): Review report showed SenseAudio missing from `capability audio providers` output and bundled providers still appearing when plugins were globally disabled.

## Root Cause
The CLI listing path moved to manifest metadata, but SenseAudio did not declare media-understanding provider metadata in its bundled manifest. The metadata builder also delegated availability filtering without first honoring the global plugin disable switch, so disabled plugin providers could still be listed.

## Tests
- `node scripts/test-projects.mjs src/media-understanding/defaults.test.ts src/media-understanding/manifest-metadata.test.ts src/cli/capability-cli.test.ts`
- `CI=true OPENCLAW_BUILD_VERBOSE=1 NODE_OPTIONS=--max-old-space-size=8192 OPENCLAW_TSDOWN_TIMEOUT_MS=300000 node scripts/build-all.mjs cliStartup`
- `OPENCLAW_STATE_DIR=$(mktemp -d) HOME=$(mktemp -d) node openclaw.mjs capability audio providers --json`
- disabled-plugin config CLI proof command above
- `corepack pnpm exec oxfmt --write --threads=1 extensions/senseaudio/openclaw.plugin.json src/media-understanding/manifest-metadata.ts src/media-understanding/manifest-metadata.test.ts src/media-understanding/defaults.test.ts`
- `git diff --check`

## Hygiene
- committed with GitHub noreply author email
- staged only the four intended source/test files
- checked the staged diff for obvious credential patterns before committing
