### PR TITLE
refactor(agents): carry resolved model runtime through auth

### DIFF
--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -662,6 +662,26 @@ describe("ollama plugin", () => {
     });
   });
 
+  it("mints synthetic auth for a selected model with local Ollama baseUrl", () => {
+    const provider = registerProvider();
+
+    const auth = provider.resolveSyntheticAuth?.({
+      provider: "my-router",
+      modelBaseUrl: "http://localhost:11434",
+      providerConfig: {
+        baseUrl: "https://router.example.com/v1",
+        api: "openai-completions",
+        models: [],
+      },
+    } as never);
+
+    expect(auth).toEqual({
+      apiKey: "ollama-local",
+      source: "models.providers.my-router (synthetic local key)",
+      mode: "api-key",
+    });
+  });
+
   it("mints synthetic auth for non-default baseURL alias config", () => {
     const provider = registerProvider();
 

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -34,6 +34,7 @@ import {
   OLLAMA_PROVIDER_ID,
   resolveOllamaDiscoveryResult,
   shouldUseSyntheticOllamaAuth,
+  shouldUseSyntheticOllamaAuthForSelectedModel,
   type OllamaPluginConfig,
 } from "./src/discovery-shared.js";
 import {
@@ -259,8 +260,8 @@ export default definePluginEntry({
       matchesContextOverflowError: ({ errorMessage }) =>
         /\bollama\b.*(?:context length|too many tokens|context window)/i.test(errorMessage) ||
         /\btruncating input\b.*\btoo long\b/i.test(errorMessage),
-      resolveSyntheticAuth: ({ provider, providerConfig }) => {
-        if (!shouldUseSyntheticOllamaAuth(providerConfig)) {
+      resolveSyntheticAuth: ({ provider, providerConfig, modelBaseUrl }) => {
+        if (!shouldUseSyntheticOllamaAuthForSelectedModel({ providerConfig, modelBaseUrl })) {
           return undefined;
         }
         return {

--- a/extensions/ollama/provider-discovery.ts
+++ b/extensions/ollama/provider-discovery.ts
@@ -4,7 +4,7 @@ import {
   OLLAMA_DEFAULT_API_KEY,
   OLLAMA_PROVIDER_ID,
   resolveOllamaDiscoveryResult,
-  shouldUseSyntheticOllamaAuth,
+  shouldUseSyntheticOllamaAuthForSelectedModel,
   type OllamaPluginConfig,
 } from "./src/discovery-shared.js";
 import { buildOllamaProvider } from "./src/provider-models.js";
@@ -15,7 +15,11 @@ type OllamaProviderPlugin = {
   docsPath: string;
   envVars: string[];
   auth: [];
-  resolveSyntheticAuth: (ctx: { provider?: string; providerConfig?: ModelProviderConfig }) =>
+  resolveSyntheticAuth: (ctx: {
+    provider?: string;
+    providerConfig?: ModelProviderConfig;
+    modelBaseUrl?: string;
+  }) =>
     | {
         apiKey: string;
         source: string;
@@ -50,8 +54,8 @@ export const ollamaProviderDiscovery: OllamaProviderPlugin = {
   docsPath: "/providers/ollama",
   envVars: ["OLLAMA_API_KEY"],
   auth: [],
-  resolveSyntheticAuth: ({ provider, providerConfig }) => {
-    if (!shouldUseSyntheticOllamaAuth(providerConfig)) {
+  resolveSyntheticAuth: ({ provider, providerConfig, modelBaseUrl }) => {
+    if (!shouldUseSyntheticOllamaAuthForSelectedModel({ providerConfig, modelBaseUrl })) {
       return undefined;
     }
     return {

--- a/extensions/ollama/src/discovery-shared.ts
+++ b/extensions/ollama/src/discovery-shared.ts
@@ -184,6 +184,17 @@ export function shouldUseSyntheticOllamaAuth(
   return isLocalOllamaBaseUrl(readProviderBaseUrl(providerConfig));
 }
 
+export function shouldUseSyntheticOllamaAuthForSelectedModel(params: {
+  providerConfig: ModelProviderConfig | undefined;
+  modelBaseUrl?: string;
+}): boolean {
+  const modelBaseUrl = normalizeOptionalString(params.modelBaseUrl);
+  if (modelBaseUrl) {
+    return isLocalOllamaBaseUrl(modelBaseUrl);
+  }
+  return shouldUseSyntheticOllamaAuth(params.providerConfig);
+}
+
 function hasMeaningfulExplicitOllamaConfig(
   providerConfig: ModelProviderConfig | undefined,
 ): boolean {

--- a/extensions/ollama/src/stream.test.ts
+++ b/extensions/ollama/src/stream.test.ts
@@ -8,7 +8,11 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   fetchWithSsrFGuard: fetchWithSsrFGuardMock,
 }));
 
-import { buildAssistantMessage, createOllamaStreamFn } from "./stream.js";
+import {
+  buildAssistantMessage,
+  createOllamaStreamFn,
+  resolveOllamaBaseUrlForRun,
+} from "./stream.js";
 
 function makeOllamaResponse(params: {
   content?: string;
@@ -355,5 +359,16 @@ describe("createOllamaStreamFn thinking events", () => {
       name: "read",
       arguments: { path: "/path/to/file", line_start: 1, line_end: 400 },
     });
+  });
+});
+
+describe("resolveOllamaBaseUrlForRun", () => {
+  it("prefers selected model baseUrl over provider baseUrl", () => {
+    expect(
+      resolveOllamaBaseUrlForRun({
+        modelBaseUrl: "http://127.0.0.1:11434",
+        providerBaseUrl: "https://router.example/v1",
+      }),
+    ).toBe("http://127.0.0.1:11434");
   });
 });

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -103,13 +103,13 @@ export function resolveOllamaBaseUrlForRun(params: {
   modelBaseUrl?: string;
   providerBaseUrl?: string;
 }): string {
-  const providerBaseUrl = params.providerBaseUrl?.trim();
-  if (providerBaseUrl) {
-    return providerBaseUrl;
-  }
   const modelBaseUrl = params.modelBaseUrl?.trim();
   if (modelBaseUrl) {
     return modelBaseUrl;
+  }
+  const providerBaseUrl = params.providerBaseUrl?.trim();
+  if (providerBaseUrl) {
+    return providerBaseUrl;
   }
   return OLLAMA_NATIVE_BASE_URL;
 }

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -438,6 +438,7 @@ export async function loadCompactHooksHarness(): Promise<{
     })),
     clearCurrentPluginMetadataSnapshot: vi.fn(),
     getCurrentPluginMetadataSnapshot: () => emptyPluginMetadataSnapshot,
+    isReusableCurrentPluginMetadataSnapshot: vi.fn(() => true),
     resolvePluginMetadataControlPlaneFingerprint: vi.fn(() => "test-plugin-fingerprint"),
     restoreCurrentPluginMetadataSnapshotState: vi.fn(),
     setCurrentPluginMetadataSnapshot: vi.fn(),

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -146,6 +146,7 @@ import { buildEmbeddedMessageActionDiscoveryInput } from "./message-action-disco
 import { readAgentModelContextTokens } from "./model-context-tokens.js";
 import { resolveModelAsync } from "./model.js";
 import { sanitizeSessionHistory, validateReplayTurns } from "./replay-history.js";
+import { withResolvedModelRuntimeModel } from "./resolved-model-runtime.js";
 import { createEmbeddedAgentResourceLoader } from "./resource-loader.js";
 import { resolveAttemptSpawnWorkspaceDir } from "./run/attempt.thread-helpers.js";
 import { buildEmbeddedSandboxInfo } from "./sandbox-info.js";
@@ -539,7 +540,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
   await ensureOpenClawModelsJson(params.config, agentDir, {
     workspaceDir: resolvedWorkspace,
   });
-  const { model, error, authStorage, modelRegistry } = await resolveModelAsync(
+  const { model, runtime, error, authStorage, modelRegistry } = await resolveModelAsync(
     runtimeProvider,
     modelId,
     agentDir,
@@ -550,6 +551,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
     return fail(reason);
   }
   let runtimeModel = model;
+  let resolvedModelRuntime = runtime;
   let apiKeyInfo: Awaited<ReturnType<typeof getApiKeyForModel>> | null = null;
   let hasRuntimeAuthExchange = false;
   try {
@@ -559,6 +561,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
       profileId: authProfileId,
       agentDir,
       workspaceDir: resolvedWorkspace,
+      modelRuntimeAuth: resolvedModelRuntime?.auth,
     });
 
     if (!apiKeyInfo.apiKey) {
@@ -586,6 +589,9 @@ async function compactEmbeddedAgentSessionDirectOnce(
       });
       if (preparedAuth?.baseUrl) {
         runtimeModel = { ...runtimeModel, baseUrl: preparedAuth.baseUrl };
+        resolvedModelRuntime = resolvedModelRuntime
+          ? withResolvedModelRuntimeModel(resolvedModelRuntime, runtimeModel)
+          : undefined;
       }
       const runtimeApiKey = preparedAuth?.apiKey ?? apiKeyInfo.apiKey;
       hasRuntimeAuthExchange = Boolean(preparedAuth?.apiKey);
@@ -720,13 +726,16 @@ async function compactEmbeddedAgentSessionDirectOnce(
       hasRuntimeAuthExchange ? null : apiKeyInfo,
       params.config,
     );
+    resolvedModelRuntime = resolvedModelRuntime
+      ? withResolvedModelRuntimeModel(resolvedModelRuntime, effectiveModel)
+      : undefined;
     const runtimePlan =
       params.runtimePlan ??
       buildAgentRuntimePlan({
-        provider,
-        modelId,
-        model: effectiveModel,
-        modelApi: effectiveModel.api,
+        provider: resolvedModelRuntime?.ref.provider ?? provider,
+        modelId: resolvedModelRuntime?.ref.modelId ?? modelId,
+        model: resolvedModelRuntime?.model ?? effectiveModel,
+        modelApi: resolvedModelRuntime?.transport.api ?? effectiveModel.api,
         harnessId: params.agentHarnessId,
         harnessRuntime: runtimeHarnessPolicy.runtime,
         authProfileProvider: authProfileId?.split(":", 1)[0],

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -257,6 +257,16 @@ function expectResolvedModel(result: ResolveModelForTestResult) {
   return result.model;
 }
 
+function expectResolvedRuntime(result: ResolveModelForTestResult) {
+  if (result.error !== undefined) {
+    throw new Error(`expected model resolution to succeed, got error: ${result.error}`);
+  }
+  if (!result.runtime) {
+    throw new Error("expected model resolution to return runtime metadata");
+  }
+  return result.runtime;
+}
+
 function expectRecordFields(record: unknown, expected: Record<string, unknown>) {
   if (!record || typeof record !== "object") {
     throw new Error("Expected record");
@@ -911,13 +921,43 @@ describe("resolveModel", () => {
 
     const claude = resolveModelForTest("my-router", "my-router/claude", "/tmp/agent", cfg);
     const claudeModel = expectResolvedModel(claude);
+    const claudeRuntime = expectResolvedRuntime(claude);
     expect(claudeModel.api).toBe("anthropic-messages");
     expect(claudeModel.baseUrl).toBe("http://localhost:8080");
+    expect(claudeRuntime.ref).toEqual({
+      provider: "my-router",
+      modelId: "my-router/claude",
+    });
+    expect(claudeRuntime.transport).toMatchObject({
+      api: "anthropic-messages",
+      baseUrl: "http://localhost:8080",
+    });
+    expect(claudeRuntime.auth).toMatchObject({
+      providerRefs: ["my-router", "anthropic-messages"],
+      preferredProvider: "anthropic-messages",
+      modelApi: "anthropic-messages",
+      modelBaseUrl: "http://localhost:8080",
+    });
+    expect(claudeRuntime.source).toMatchObject({
+      providerConfigPath: "models.providers.my-router",
+      modelConfigPath: "models.providers.my-router.models[my-router/claude]",
+    });
 
     const gpt = resolveModelForTest("my-router", "my-router/gpt", "/tmp/agent", cfg);
     const gptModel = expectResolvedModel(gpt);
+    const gptRuntime = expectResolvedRuntime(gpt);
     expect(gptModel.api).toBe("openai-completions");
     expect(gptModel.baseUrl).toBe("http://localhost:8080/v1");
+    expect(gptRuntime.transport).toMatchObject({
+      api: "openai-completions",
+      baseUrl: "http://localhost:8080/v1",
+    });
+    expect(gptRuntime.auth).toMatchObject({
+      providerRefs: ["my-router", "openai-completions"],
+      preferredProvider: "openai-completions",
+      modelApi: "openai-completions",
+      modelBaseUrl: "http://localhost:8080/v1",
+    });
   });
 
   it("defaults baseUrl-only local custom fallback models to chat completions", () => {

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -1289,7 +1289,7 @@ function resolveModelRuntimeWithRegistry(params: {
 export function resolveModelWithRegistry(params: {
   provider: string;
   modelId: string;
-  modelRegistry: ModelRegistry;
+  modelRegistry: CoreModelRegistry;
   cfg?: OpenClawConfig;
   agentDir?: string;
   workspaceDir?: string;
@@ -1524,10 +1524,14 @@ export async function resolveModelAsync(
     const resolvedMediaInput = (modelResolution.model as ProviderRuntimeModel).mediaInput;
     const mediaInput = mergeModelMediaInput(staticMediaInput, resolvedMediaInput);
     if (mediaInput) {
+      const modelWithMediaInput: ProviderRuntimeModel = {
+        ...(modelResolution.model as ProviderRuntimeModel),
+        mediaInput,
+      };
       modelResolution = createResolvedModelRuntimeResult({
         provider: normalizedRef.provider,
         modelId: normalizedRef.model,
-        model: { ...(modelResolution.model as ProviderRuntimeModel), mediaInput },
+        model: modelWithMediaInput,
         providerConfig,
       });
     }

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -52,6 +52,11 @@ import {
   canonicalizeManifestModelCatalogProviderAlias,
   resolveBundledStaticCatalogModel,
 } from "./model.static-catalog.js";
+import {
+  createResolvedModelRuntime,
+  type ResolvedModelRuntime,
+  type ResolvedModelRuntimeSource,
+} from "./resolved-model-runtime.js";
 
 type ProviderRuntimeHooks = {
   applyProviderResolvedTransportWithPlugin?: (
@@ -71,6 +76,11 @@ type ProviderRuntimeHooks = {
     params: Parameters<typeof normalizeProviderResolvedModelWithPlugin>[0],
   ) => unknown;
   normalizeProviderTransportWithPlugin: typeof normalizeProviderTransportWithPlugin;
+};
+
+type ResolvedModelRuntimeResult = {
+  model: Model<Api>;
+  runtime: ResolvedModelRuntime;
 };
 
 const TARGET_PROVIDER_RUNTIME_HOOKS: ProviderRuntimeHooks = {
@@ -466,6 +476,59 @@ function findConfiguredProviderModel(
       modelId,
     }),
   );
+}
+
+function resolveConfiguredProviderModelSource(params: {
+  providerConfig: InlineProviderConfig | undefined;
+  provider: string;
+  modelId: string;
+}): ResolvedModelRuntimeSource {
+  if (!params.providerConfig) {
+    return { discoveredModel: true };
+  }
+  const source: ResolvedModelRuntimeSource = {
+    providerConfigPath: `models.providers.${params.provider}`,
+  };
+  const configuredIndex = params.providerConfig.models?.findIndex((candidate) =>
+    matchesProviderScopedModelId({
+      candidateId: candidate.id,
+      provider: params.provider,
+      modelId: params.modelId,
+    }),
+  );
+  if (configuredIndex !== undefined && configuredIndex >= 0) {
+    const configuredModel = params.providerConfig.models?.[configuredIndex];
+    source.modelConfigPath = configuredModel?.id
+      ? `models.providers.${params.provider}.models[${configuredModel.id}]`
+      : `models.providers.${params.provider}.models[${configuredIndex}]`;
+  } else {
+    source.discoveredModel = true;
+  }
+  return source;
+}
+
+function createResolvedModelRuntimeResult(params: {
+  provider: string;
+  modelId: string;
+  model: Model<Api>;
+  providerConfig?: InlineProviderConfig;
+  source?: ResolvedModelRuntimeSource;
+}): ResolvedModelRuntimeResult {
+  return {
+    model: params.model,
+    runtime: createResolvedModelRuntime({
+      provider: params.provider,
+      modelId: params.modelId,
+      model: params.model,
+      source:
+        params.source ??
+        resolveConfiguredProviderModelSource({
+          providerConfig: params.providerConfig,
+          provider: params.provider,
+          modelId: params.modelId,
+        }),
+    }),
+  };
 }
 
 function hasConfiguredFallbackSurface(params: {
@@ -1146,7 +1209,7 @@ function normalizeProviderModelRef(params: {
   };
 }
 
-export function resolveModelWithRegistry(params: {
+function resolveModelRuntimeWithRegistry(params: {
   provider: string;
   modelId: string;
   modelRegistry: CoreModelRegistry;
@@ -1154,7 +1217,7 @@ export function resolveModelWithRegistry(params: {
   agentDir?: string;
   workspaceDir?: string;
   runtimeHooks?: ProviderRuntimeHooks;
-}): Model | undefined {
+}): ResolvedModelRuntimeResult | undefined {
   const workspaceDir = params.workspaceDir ?? params.cfg?.agents?.defaults?.workspace;
   const normalizedRef = normalizeProviderModelRef({ ...params, workspaceDir });
   const normalizedParams = {
@@ -1167,6 +1230,7 @@ export function resolveModelWithRegistry(params: {
     ...normalizedParams,
     ...(workspaceDir !== undefined ? { workspaceDir } : {}),
   };
+  const providerConfig = resolveConfiguredProviderConfig(scopedParams.cfg, scopedParams.provider);
   const explicitModel = resolveExplicitModelWithRegistry(scopedParams);
   if (explicitModel?.kind === "suppressed") {
     return undefined;
@@ -1182,20 +1246,56 @@ export function resolveModelWithRegistry(params: {
         runtimeHooks,
       })
     ) {
-      return explicitModel.model;
+      return createResolvedModelRuntimeResult({
+        provider: scopedParams.provider,
+        modelId: scopedParams.modelId,
+        model: explicitModel.model,
+        providerConfig,
+      });
     }
     const pluginDynamicModel = resolvePluginDynamicModelWithRegistry(scopedParams);
-    return preferProviderRuntimeResolvedModel({
+    const preferredModel = preferProviderRuntimeResolvedModel({
       explicitModel: explicitModel.model,
       runtimeResolvedModel: pluginDynamicModel,
+    });
+    return createResolvedModelRuntimeResult({
+      provider: scopedParams.provider,
+      modelId: scopedParams.modelId,
+      model: preferredModel,
+      providerConfig,
     });
   }
   const pluginDynamicModel = resolvePluginDynamicModelWithRegistry(scopedParams);
   if (pluginDynamicModel) {
-    return pluginDynamicModel;
+    return createResolvedModelRuntimeResult({
+      provider: scopedParams.provider,
+      modelId: scopedParams.modelId,
+      model: pluginDynamicModel,
+      providerConfig,
+    });
   }
 
-  return resolveConfiguredFallbackModel(scopedParams);
+  const fallbackModel = resolveConfiguredFallbackModel(scopedParams);
+  return fallbackModel
+    ? createResolvedModelRuntimeResult({
+        provider: scopedParams.provider,
+        modelId: scopedParams.modelId,
+        model: fallbackModel,
+        providerConfig,
+      })
+    : undefined;
+}
+
+export function resolveModelWithRegistry(params: {
+  provider: string;
+  modelId: string;
+  modelRegistry: ModelRegistry;
+  cfg?: OpenClawConfig;
+  agentDir?: string;
+  workspaceDir?: string;
+  runtimeHooks?: ProviderRuntimeHooks;
+}): Model<Api> | undefined {
+  return resolveModelRuntimeWithRegistry(params)?.model;
 }
 
 export function resolveModel(
@@ -1211,7 +1311,8 @@ export function resolveModel(
     workspaceDir?: string;
   },
 ): {
-  model?: Model;
+  model?: Model<Api>;
+  runtime?: ResolvedModelRuntime;
   error?: string;
   authStorage: AuthStorage;
   modelRegistry: ModelRegistry;
@@ -1230,7 +1331,7 @@ export function resolveModel(
     cachedStores?.modelRegistry ??
     discoverModels(authStorage, resolvedAgentDir);
   const runtimeHooks = resolveRuntimeHooks(options);
-  const model = resolveModelWithRegistry({
+  const modelResolution = resolveModelRuntimeWithRegistry({
     provider: normalizedRef.provider,
     modelId: normalizedRef.model,
     modelRegistry,
@@ -1239,8 +1340,13 @@ export function resolveModel(
     workspaceDir,
     runtimeHooks,
   });
-  if (model) {
-    return { model, authStorage, modelRegistry };
+  if (modelResolution) {
+    return {
+      model: modelResolution.model,
+      runtime: modelResolution.runtime,
+      authStorage,
+      modelRegistry,
+    };
   }
 
   return {
@@ -1273,7 +1379,8 @@ export async function resolveModelAsync(
     workspaceDir?: string;
   },
 ): Promise<{
-  model?: Model;
+  model?: Model<Api>;
+  runtime?: ResolvedModelRuntime;
   error?: string;
   authStorage: AuthStorage;
   modelRegistry: ModelRegistry;
@@ -1339,7 +1446,7 @@ export async function resolveModelAsync(
         providerConfig,
       },
     });
-    return resolveModelWithRegistry({
+    return resolveModelRuntimeWithRegistry({
       provider: normalizedRef.provider,
       modelId: normalizedRef.model,
       modelRegistry,
@@ -1349,7 +1456,7 @@ export async function resolveModelAsync(
       runtimeHooks,
     });
   };
-  let model =
+  let modelResolution =
     explicitModel?.kind === "resolved" &&
     !shouldCompareProviderRuntimeResolvedModel({
       provider: normalizedRef.provider,
@@ -1359,15 +1466,20 @@ export async function resolveModelAsync(
       workspaceDir,
       runtimeHooks,
     })
-      ? explicitModel.model
+      ? createResolvedModelRuntimeResult({
+          provider: normalizedRef.provider,
+          modelId: normalizedRef.model,
+          model: explicitModel.model,
+          providerConfig,
+        })
       : await resolveDynamicAttempt();
-  if (!model && !explicitModel && options?.retryTransientProviderRuntimeMiss) {
+  if (!modelResolution && !explicitModel && options?.retryTransientProviderRuntimeMiss) {
     // Startup can race the first provider-runtime snapshot load on a fresh
     // gateway boot. Retry once before surfacing a user-visible "Unknown model"
     // that disappears on the next message.
-    model = await resolveDynamicAttempt();
+    modelResolution = await resolveDynamicAttempt();
   }
-  if (!model && !explicitModel && options?.allowBundledStaticCatalogFallback) {
+  if (!modelResolution && !explicitModel && options?.allowBundledStaticCatalogFallback) {
     const staticCatalogModel = resolveBundledStaticCatalogModel({
       provider: normalizedRef.provider,
       modelId: normalizedRef.model,
@@ -1385,7 +1497,7 @@ export async function resolveModelAsync(
         workspaceDir,
         preferDiscoveredModelMetadata: true,
       });
-      model = normalizeResolvedModel({
+      const model = normalizeResolvedModel({
         provider: normalizedRef.provider,
         cfg,
         agentDir: resolvedAgentDir,
@@ -1393,9 +1505,15 @@ export async function resolveModelAsync(
         model: overriddenStaticCatalogModel,
         runtimeHooks,
       });
+      modelResolution = createResolvedModelRuntimeResult({
+        provider: normalizedRef.provider,
+        modelId: normalizedRef.model,
+        model,
+        providerConfig,
+      });
     }
   }
-  if (model && options?.allowBundledStaticCatalogFallback) {
+  if (modelResolution && options?.allowBundledStaticCatalogFallback) {
     const staticCatalogModel = resolveBundledStaticCatalogModel({
       provider: normalizedRef.provider,
       modelId: normalizedRef.model,
@@ -1403,14 +1521,24 @@ export async function resolveModelAsync(
       workspaceDir,
     });
     const staticMediaInput = (staticCatalogModel as ProviderRuntimeModel | undefined)?.mediaInput;
-    const resolvedMediaInput = (model as ProviderRuntimeModel).mediaInput;
+    const resolvedMediaInput = (modelResolution.model as ProviderRuntimeModel).mediaInput;
     const mediaInput = mergeModelMediaInput(staticMediaInput, resolvedMediaInput);
     if (mediaInput) {
-      model = { ...(model as ProviderRuntimeModel), mediaInput } as typeof model;
+      modelResolution = createResolvedModelRuntimeResult({
+        provider: normalizedRef.provider,
+        modelId: normalizedRef.model,
+        model: { ...(modelResolution.model as ProviderRuntimeModel), mediaInput },
+        providerConfig,
+      });
     }
   }
-  if (model) {
-    return { model, authStorage, modelRegistry };
+  if (modelResolution) {
+    return {
+      model: modelResolution.model,
+      runtime: modelResolution.runtime,
+      authStorage,
+      modelRegistry,
+    };
   }
 
   return {

--- a/src/agents/embedded-agent-runner/resolved-model-runtime.ts
+++ b/src/agents/embedded-agent-runner/resolved-model-runtime.ts
@@ -1,4 +1,4 @@
-import type { Api, Model } from "@earendil-works/pi-ai";
+import type { Api, Model } from "../../llm/types.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 export type {
   ResolvedModelRuntime,

--- a/src/agents/embedded-agent-runner/resolved-model-runtime.ts
+++ b/src/agents/embedded-agent-runner/resolved-model-runtime.ts
@@ -1,0 +1,75 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
+export type {
+  ResolvedModelRuntime,
+  ResolvedModelRuntimeAuth,
+  ResolvedModelRuntimeRef,
+  ResolvedModelRuntimeSource,
+  ResolvedModelRuntimeTransport,
+} from "../resolved-model-runtime.types.js";
+import { normalizeProviderId } from "../model-selection.js";
+import { getModelProviderRequestTransport } from "../provider-request-config.js";
+import type {
+  ResolvedModelRuntime,
+  ResolvedModelRuntimeSource,
+} from "../resolved-model-runtime.types.js";
+import { normalizeResolvedTransportApi } from "./model.inline-provider.js";
+
+function resolveAuthProviderRefs(params: { provider: string; api?: string }): string[] {
+  const refs = [params.provider];
+  const apiRef = params.api?.trim();
+  if (apiRef && normalizeProviderId(apiRef) !== normalizeProviderId(params.provider)) {
+    refs.push(apiRef);
+  }
+  return [...new Set(refs)];
+}
+
+function resolvePreferredAuthProvider(providerRefs: readonly string[]): string | undefined {
+  return providerRefs.length > 1 ? providerRefs[providerRefs.length - 1] : providerRefs[0];
+}
+
+export function createResolvedModelRuntime(params: {
+  provider: string;
+  modelId: string;
+  model: Model<Api>;
+  source?: ResolvedModelRuntimeSource;
+}): ResolvedModelRuntime {
+  const api = normalizeResolvedTransportApi(params.model.api);
+  const providerRefs = resolveAuthProviderRefs({
+    provider: params.provider,
+    api: api ?? params.model.api,
+  });
+  const request = getModelProviderRequestTransport(params.model);
+  return {
+    ref: {
+      provider: params.provider,
+      modelId: params.modelId,
+    },
+    model: params.model as ProviderRuntimeModel,
+    transport: {
+      ...(api ? { api } : {}),
+      ...(params.model.baseUrl ? { baseUrl: params.model.baseUrl } : {}),
+      ...(params.model.headers ? { headers: params.model.headers as Record<string, string> } : {}),
+      ...(request ? { request } : {}),
+    },
+    auth: {
+      providerRefs,
+      preferredProvider: resolvePreferredAuthProvider(providerRefs),
+      ...(api ? { modelApi: api } : {}),
+      ...(params.model.baseUrl ? { modelBaseUrl: params.model.baseUrl } : {}),
+    },
+    source: params.source ?? {},
+  };
+}
+
+export function withResolvedModelRuntimeModel(
+  runtime: ResolvedModelRuntime,
+  model: Model<Api>,
+): ResolvedModelRuntime {
+  return createResolvedModelRuntime({
+    provider: runtime.ref.provider,
+    modelId: runtime.ref.modelId,
+    model,
+    source: runtime.source,
+  });
+}

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -123,6 +123,10 @@ import {
   type PostCompactionGuardObservation,
 } from "./post-compaction-loop-guard.js";
 import { createEmbeddedRunReplayState, observeReplayMetadata } from "./replay-state.js";
+import {
+  withResolvedModelRuntimeModel,
+  type ResolvedModelRuntime,
+} from "./resolved-model-runtime.js";
 import { handleAssistantFailover } from "./run/assistant-failover.js";
 import {
   createEmbeddedRunStageTracker,
@@ -750,7 +754,7 @@ export async function runEmbeddedAgent(
         });
       }
       provider = resolvedModelProvider;
-      const { model, error, authStorage, modelRegistry } = modelResolution;
+      const { model, error, authStorage, modelRegistry, runtime } = modelResolution;
       if (!model) {
         throw new FailoverError(error ?? `Unknown model: ${provider}/${modelId}`, {
           reason: "model_not_found",
@@ -761,6 +765,7 @@ export async function runEmbeddedAgent(
         });
       }
       let runtimeModel = model;
+      let resolvedModelRuntime = runtime as ResolvedModelRuntime | undefined;
 
       const resolvedRuntimeModel = resolveEffectiveRuntimeModel({
         cfg: params.config,
@@ -774,6 +779,9 @@ export async function runEmbeddedAgent(
       });
       const ctxInfo = resolvedRuntimeModel.ctxInfo;
       let effectiveModel = resolvedRuntimeModel.effectiveModel;
+      if (resolvedModelRuntime) {
+        resolvedModelRuntime = withResolvedModelRuntimeModel(resolvedModelRuntime, effectiveModel);
+      }
       startupStages.mark("model-resolution");
       notifyExecutionPhase("model_resolution", { provider, model: modelId });
 
@@ -1038,13 +1046,20 @@ export async function runEmbeddedAgent(
         allowTransientCooldownProbe: params.allowTransientCooldownProbe === true,
         getProvider: () => provider,
         getModelId: () => modelId,
+        getResolvedModelRuntime: () => resolvedModelRuntime,
         getRuntimeModel: () => runtimeModel,
         setRuntimeModel: (next) => {
           runtimeModel = next;
+          if (resolvedModelRuntime) {
+            resolvedModelRuntime = withResolvedModelRuntimeModel(resolvedModelRuntime, next);
+          }
         },
         getEffectiveModel: () => effectiveModel,
         setEffectiveModel: (next) => {
           effectiveModel = next;
+          if (resolvedModelRuntime) {
+            resolvedModelRuntime = withResolvedModelRuntimeModel(resolvedModelRuntime, next);
+          }
         },
         getApiKeyInfo: () => apiKeyInfo,
         setApiKeyInfo: (next) => {
@@ -1485,10 +1500,10 @@ export async function runEmbeddedAgent(
             startupStages.mark(EMBEDDED_RUN_ATTEMPT_DISPATCH_STAGE.prompt);
           }
           const runtimePlan = buildAgentRuntimePlan({
-            provider,
-            modelId,
-            model: effectiveModel,
-            modelApi: effectiveModel.api,
+            provider: resolvedModelRuntime?.ref.provider ?? provider,
+            modelId: resolvedModelRuntime?.ref.modelId ?? modelId,
+            model: resolvedModelRuntime?.model ?? effectiveModel,
+            modelApi: resolvedModelRuntime?.transport.api ?? effectiveModel.api,
             harnessId: agentHarness.id,
             harnessRuntime: agentHarness.id,
             allowHarnessAuthProfileForwarding: pluginHarnessOwnsTransport,

--- a/src/agents/embedded-agent-runner/run/auth-controller.test.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.test.ts
@@ -92,6 +92,12 @@ function createMutableEmbeddedRunAuthController(params: {
   setRuntimeApiKey: RuntimeApiKeySetter;
   profileCandidates?: string[];
   warn?: (message: string) => void;
+  modelRuntimeAuth?: {
+    providerRefs: string[];
+    preferredProvider?: string;
+    modelApi?: string;
+    modelBaseUrl?: string;
+  };
 }) {
   return createEmbeddedRunAuthController({
     config: undefined,
@@ -109,6 +115,16 @@ function createMutableEmbeddedRunAuthController(params: {
     allowTransientCooldownProbe: false,
     getProvider: () => "custom-openai",
     getModelId: () => "test-model",
+    getResolvedModelRuntime: () =>
+      params.modelRuntimeAuth
+        ? {
+            ref: { provider: "custom-openai", modelId: "test-model" },
+            model: params.harness.runtimeModel,
+            transport: {},
+            auth: params.modelRuntimeAuth,
+            source: {},
+          }
+        : undefined,
     getRuntimeModel: () => params.harness.runtimeModel,
     setRuntimeModel: (next) => {
       params.harness.runtimeModel = next;
@@ -196,6 +212,37 @@ describe("createEmbeddedRunAuthController", () => {
     expect(harness.runtimeAuthState?.sourceApiKey).toBe("source-api-key");
     expect(harness.runtimeAuthState?.authMode).toBe("api-key");
     expect(harness.runtimeAuthState?.profileId).toBe("default");
+  });
+
+  it("passes resolved model runtime auth facts into credential resolution", async () => {
+    const harness = createMutableAuthControllerHarness();
+    const setRuntimeApiKey = vi.fn<(provider: string, apiKey: string) => void>();
+    const modelRuntimeAuth = {
+      providerRefs: ["my-router", "anthropic-messages"],
+      preferredProvider: "anthropic-messages",
+      modelApi: "anthropic-messages",
+      modelBaseUrl: "http://router.local",
+    };
+
+    mocks.getApiKeyForModel.mockResolvedValue({
+      apiKey: "source-api-key",
+      mode: "api-key",
+      profileId: "default",
+      source: "env",
+    });
+    mocks.prepareProviderRuntimeAuth.mockResolvedValue(undefined);
+
+    const controller = createMutableEmbeddedRunAuthController({
+      harness,
+      setRuntimeApiKey,
+      modelRuntimeAuth,
+    });
+
+    await controller.initializeAuthProfile();
+
+    expect(mocks.getApiKeyForModel).toHaveBeenCalledWith(
+      expect.objectContaining({ modelRuntimeAuth }),
+    );
   });
 
   it("includes the checked credential source when an api key is missing", async () => {

--- a/src/agents/embedded-agent-runner/run/auth-controller.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.ts
@@ -24,6 +24,7 @@ import {
   sanitizeRuntimeProviderRequestOverrides,
 } from "../../provider-request-config.js";
 import { clampRuntimeAuthRefreshDelayMs } from "../../runtime-auth-refresh.js";
+import type { ResolvedModelRuntime } from "../resolved-model-runtime.js";
 import {
   RUNTIME_AUTH_REFRESH_MARGIN_MS,
   RUNTIME_AUTH_REFRESH_MIN_DELAY_MS,
@@ -58,6 +59,7 @@ export function createEmbeddedRunAuthController(params: {
   allowTransientCooldownProbe: boolean;
   getProvider(): string;
   getModelId(): string;
+  getResolvedModelRuntime?(): ResolvedModelRuntime | undefined;
   getRuntimeModel(): Model;
   setRuntimeModel(next: Model): void;
   getEffectiveModel(): Model;
@@ -359,6 +361,7 @@ export function createEmbeddedRunAuthController(params: {
       agentDir: params.agentDir,
       workspaceDir: params.workspaceDir,
       lockedProfile: candidate != null && candidate === params.lockedProfileId,
+      modelRuntimeAuth: params.getResolvedModelRuntime?.()?.auth,
     });
   };
 

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -1193,6 +1193,41 @@ describe("resolveApiKeyForProvider – synthetic local auth for custom providers
     });
   });
 
+  it("derives runtime auth from the selected model when caller has no descriptor", async () => {
+    const auth = await getApiKeyForModel({
+      model: {
+        provider: "my-router",
+        id: "local-llama",
+        name: "Local Llama",
+        api: "ollama",
+        baseUrl: "http://localhost:11434",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 8192,
+        maxTokens: 4096,
+      } as Model<"ollama">,
+      cfg: {
+        models: {
+          providers: {
+            "my-router": {
+              baseUrl: "http://router.local/v1",
+              api: "openai-completions",
+              models: [],
+            },
+          },
+        },
+      },
+      store: { version: 1, profiles: {} },
+    });
+
+    expectAuthFields(auth, {
+      apiKey: "ollama-local",
+      source: "models.providers.my-router (synthetic local key)",
+      mode: "api-key",
+    });
+  });
+
   it("accepts non-secret local markers for private LAN custom OpenAI-compatible providers", async () => {
     const auth = await resolveApiKeyForProvider({
       provider: "custom-192-168-0-222-11434",

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -74,7 +74,12 @@ vi.mock("../plugins/provider-runtime.js", async () => {
         };
       };
       modelApi?: string;
-      context: { providerConfig?: { api?: string; baseUrl?: string; models?: unknown[] } };
+      providerRefs?: string[];
+      context: {
+        providerConfig?: { api?: string; baseUrl?: string; models?: unknown[] };
+        modelApi?: string;
+        modelBaseUrl?: string;
+      };
     }) => {
       if (params.provider === "plugin-web") {
         if (
@@ -108,10 +113,14 @@ vi.mock("../plugins/provider-runtime.js", async () => {
           mode: "oauth" as const,
         };
       }
-      const effectiveApi = params.modelApi ?? params.context.providerConfig?.api;
+      const effectiveApi =
+        params.context.modelApi ?? params.modelApi ?? params.context.providerConfig?.api;
+      const effectiveBaseUrl =
+        params.context.modelBaseUrl ?? params.context.providerConfig?.baseUrl;
       if (
         effectiveApi === "ollama" &&
-        (params.context.providerConfig?.baseUrl?.startsWith("http://192.168.") ||
+        (effectiveBaseUrl?.startsWith("http://192.168.") ||
+          effectiveBaseUrl?.startsWith("http://localhost") ||
           params.modelApi === "ollama")
       ) {
         return {
@@ -1131,6 +1140,48 @@ describe("resolveApiKeyForProvider – synthetic local auth for custom providers
             },
           },
         },
+      },
+      store: { version: 1, profiles: {} },
+    });
+
+    expectAuthFields(auth, {
+      apiKey: "ollama-local",
+      source: "models.providers.my-router (synthetic local key)",
+      mode: "api-key",
+    });
+  });
+
+  it("uses resolved model runtime auth for provider auth when the selected model changes api", async () => {
+    const auth = await resolveApiKeyForProvider({
+      provider: "my-router",
+      cfg: {
+        models: {
+          providers: {
+            "my-router": {
+              baseUrl: "http://router.local/v1",
+              api: "openai-completions",
+              models: [
+                {
+                  id: "my-router/local-llama",
+                  name: "Local Llama",
+                  api: "ollama",
+                  baseUrl: "http://localhost:11434",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 8192,
+                  maxTokens: 4096,
+                },
+              ],
+            },
+          },
+        },
+      },
+      modelRuntimeAuth: {
+        providerRefs: ["my-router", "ollama"],
+        preferredProvider: "ollama",
+        modelApi: "ollama",
+        modelBaseUrl: "http://localhost:11434",
       },
       store: { version: 1, profiles: {} },
     });

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -5,7 +5,7 @@ import type { ModelProviderAuthMode, ModelProviderConfig } from "../config/types
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { coerceSecretRef } from "../config/types.secrets.js";
 import { getShellEnvAppliedKeys } from "../infra/shell-env.js";
-import type { Model } from "../llm/types.js";
+import type { Api, Model } from "../llm/types.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   buildProviderMissingAuthMessageWithPlugin,
@@ -570,6 +570,23 @@ function resolveSyntheticLocalProviderAuth(params: {
   return null;
 }
 
+function resolveModelRuntimeAuthFromModel(model: Model<Api>): ResolvedModelRuntimeAuth {
+  const provider = model.provider;
+  const modelApi = typeof model.api === "string" ? model.api : undefined;
+  const providerRefs = [provider];
+  if (modelApi && normalizeProviderId(modelApi) !== normalizeProviderId(provider)) {
+    providerRefs.push(modelApi);
+  }
+  const modelBaseUrl =
+    typeof model.baseUrl === "string" && model.baseUrl.trim() ? model.baseUrl : undefined;
+  return {
+    providerRefs,
+    preferredProvider: providerRefs.length > 1 ? providerRefs[providerRefs.length - 1] : provider,
+    ...(modelApi ? { modelApi } : {}),
+    ...(modelBaseUrl ? { modelBaseUrl } : {}),
+  };
+}
+
 function resolveEnvSourceLabel(params: {
   applied: Set<string>;
   envVars: string[];
@@ -1071,6 +1088,8 @@ export async function getApiKeyForModel(params: {
   credentialPrecedence?: ProviderCredentialPrecedence;
   modelRuntimeAuth?: ResolvedModelRuntimeAuth;
 }): Promise<ResolvedProviderAuth> {
+  const modelRuntimeAuth =
+    params.modelRuntimeAuth ?? resolveModelRuntimeAuthFromModel(params.model);
   return resolveApiKeyForProvider({
     provider: params.model.provider,
     cfg: params.cfg,
@@ -1082,7 +1101,7 @@ export async function getApiKeyForModel(params: {
     lockedProfile: params.lockedProfile,
     credentialPrecedence: params.credentialPrecedence,
     modelApi: params.model.api,
-    modelRuntimeAuth: params.modelRuntimeAuth,
+    modelRuntimeAuth,
   });
 }
 

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -48,6 +48,7 @@ import {
 } from "./model-auth-markers.js";
 import { type ResolvedProviderAuth } from "./model-auth-runtime-shared.js";
 import { normalizeProviderId } from "./model-selection.js";
+import type { ResolvedModelRuntimeAuth } from "./resolved-model-runtime.types.js";
 
 export {
   ensureAuthProfileStore,
@@ -490,6 +491,7 @@ function resolveProviderSyntheticRuntimeAuth(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;
   modelApi?: string;
+  modelRuntimeAuth?: ResolvedModelRuntimeAuth;
 }): SyntheticProviderAuthResolution {
   const resolveFromConfig = (
     config: OpenClawConfig | undefined,
@@ -503,8 +505,11 @@ function resolveProviderSyntheticRuntimeAuth(params: {
           config,
           provider: params.provider,
           providerConfig,
+          modelApi: params.modelRuntimeAuth?.modelApi ?? params.modelApi,
+          modelBaseUrl: params.modelRuntimeAuth?.modelBaseUrl,
         },
         modelApi: params.modelApi,
+        providerRefs: params.modelRuntimeAuth?.providerRefs,
       }) ?? undefined
     );
   };
@@ -536,6 +541,7 @@ function resolveSyntheticLocalProviderAuth(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;
   modelApi?: string;
+  modelRuntimeAuth?: ResolvedModelRuntimeAuth;
 }): ResolvedProviderAuth | null {
   const syntheticProviderAuth = resolveProviderSyntheticRuntimeAuth(params);
   if (syntheticProviderAuth.auth) {
@@ -614,6 +620,7 @@ function shouldDeferSyntheticProfileAuth(params: {
   provider: string;
   resolvedApiKey: string | undefined;
   modelApi?: string;
+  modelRuntimeAuth?: ResolvedModelRuntimeAuth;
 }): boolean {
   const providerConfig = resolveProviderConfig(params.cfg, params.provider);
   return (
@@ -621,11 +628,14 @@ function shouldDeferSyntheticProfileAuth(params: {
       provider: params.provider,
       config: params.cfg,
       modelApi: params.modelApi,
+      providerRefs: params.modelRuntimeAuth?.providerRefs,
       context: {
         config: params.cfg,
         provider: params.provider,
         providerConfig,
         resolvedApiKey: params.resolvedApiKey,
+        modelApi: params.modelRuntimeAuth?.modelApi ?? params.modelApi,
+        modelBaseUrl: params.modelRuntimeAuth?.modelBaseUrl,
       },
     }) === true
   );
@@ -657,6 +667,7 @@ export async function resolveApiKeyForProvider(params: {
   forceRefresh?: boolean;
   credentialPrecedence?: ProviderCredentialPrecedence;
   modelApi?: string;
+  modelRuntimeAuth?: ResolvedModelRuntimeAuth;
 }): Promise<ResolvedProviderAuth> {
   const { provider, cfg, profileId, preferredProfile } = params;
   const agentDir = params.agentDir?.trim() || (cfg ? resolveDefaultAgentDir(cfg) : undefined);
@@ -706,6 +717,7 @@ export async function resolveApiKeyForProvider(params: {
         provider,
         resolvedApiKey: resolved.apiKey,
         modelApi: params.modelApi,
+        modelRuntimeAuth: params.modelRuntimeAuth,
       })
     ) {
       return resolveApiKeyForProvider({ ...params, profileId: undefined, lockedProfile: true }) //
@@ -837,6 +849,7 @@ export async function resolveApiKeyForProvider(params: {
             provider,
             resolvedApiKey: resolved.apiKey,
             modelApi: params.modelApi,
+            modelRuntimeAuth: params.modelRuntimeAuth,
           })
         ) {
           deferredAuthProfileResult ??= result;
@@ -876,6 +889,7 @@ export async function resolveApiKeyForProvider(params: {
     cfg,
     provider,
     modelApi: params.modelApi,
+    modelRuntimeAuth: params.modelRuntimeAuth,
   });
   if (syntheticLocalAuth) {
     return syntheticLocalAuth;
@@ -1055,6 +1069,7 @@ export async function getApiKeyForModel(params: {
   workspaceDir?: string;
   lockedProfile?: boolean;
   credentialPrecedence?: ProviderCredentialPrecedence;
+  modelRuntimeAuth?: ResolvedModelRuntimeAuth;
 }): Promise<ResolvedProviderAuth> {
   return resolveApiKeyForProvider({
     provider: params.model.provider,
@@ -1067,6 +1082,7 @@ export async function getApiKeyForModel(params: {
     lockedProfile: params.lockedProfile,
     credentialPrecedence: params.credentialPrecedence,
     modelApi: params.model.api,
+    modelRuntimeAuth: params.modelRuntimeAuth,
   });
 }
 

--- a/src/agents/resolved-model-runtime.types.ts
+++ b/src/agents/resolved-model-runtime.types.ts
@@ -1,4 +1,4 @@
-import type { Api } from "@earendil-works/pi-ai";
+import type { Api } from "../llm/types.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import type { ModelProviderRequestTransportOverrides } from "./provider-request-config.js";
 

--- a/src/agents/resolved-model-runtime.types.ts
+++ b/src/agents/resolved-model-runtime.types.ts
@@ -1,0 +1,36 @@
+import type { Api } from "@earendil-works/pi-ai";
+import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
+import type { ModelProviderRequestTransportOverrides } from "./provider-request-config.js";
+
+export type ResolvedModelRuntimeRef = {
+  provider: string;
+  modelId: string;
+};
+
+export type ResolvedModelRuntimeTransport = {
+  api?: Api;
+  baseUrl?: string;
+  headers?: Record<string, string>;
+  request?: ModelProviderRequestTransportOverrides;
+};
+
+export type ResolvedModelRuntimeAuth = {
+  providerRefs: string[];
+  preferredProvider?: string;
+  modelApi?: string;
+  modelBaseUrl?: string;
+};
+
+export type ResolvedModelRuntimeSource = {
+  providerConfigPath?: string;
+  modelConfigPath?: string;
+  discoveredModel?: boolean;
+};
+
+export type ResolvedModelRuntime = {
+  ref: ResolvedModelRuntimeRef;
+  model: ProviderRuntimeModel;
+  transport: ResolvedModelRuntimeTransport;
+  auth: ResolvedModelRuntimeAuth;
+  source: ResolvedModelRuntimeSource;
+};

--- a/src/plugins/provider-external-auth.types.ts
+++ b/src/plugins/provider-external-auth.types.ts
@@ -6,6 +6,8 @@ export type ProviderResolveSyntheticAuthContext = {
   config?: OpenClawConfig;
   provider: string;
   providerConfig?: ModelProviderConfig;
+  modelApi?: string;
+  modelBaseUrl?: string;
 };
 
 export type ProviderSyntheticAuthResult = {

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -440,7 +440,7 @@ describe("provider-runtime", () => {
   });
 
   it("derives model refs from runtime hook contexts", () => {
-    const createStreamFn = vi.fn();
+    const createStreamFn = vi.fn(() => vi.fn() as never);
     resolvePluginProvidersMock.mockReturnValue([
       {
         id: "anthropic",

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -599,6 +599,47 @@ describe("provider-runtime", () => {
     expect(resolvePluginProvidersMock).not.toHaveBeenCalled();
   });
 
+  it("uses the selected model api owner for stream hooks when the configured provider differs", () => {
+    const createStreamFn = vi.fn(() => vi.fn());
+    const provider: ProviderPlugin = {
+      id: "ollama",
+      label: "Ollama",
+      auth: [],
+      createStreamFn,
+    };
+    resolvePluginProvidersMock.mockImplementation((params) => {
+      const providerRefs = (params as { providerRefs?: string[] }).providerRefs ?? [];
+      return providerRefs.includes("ollama") ? [provider] : [];
+    });
+
+    expect(
+      resolveProviderStreamFn({
+        provider: "custom-router",
+        config: {
+          models: {
+            providers: {
+              "custom-router": {
+                api: "openai-completions",
+                baseUrl: "https://router.example/v1",
+                models: [],
+              },
+            },
+          },
+        } as never,
+        context: createDemoResolvedModelContext({
+          provider: "custom-router",
+          model: {
+            ...MODEL,
+            provider: "custom-router",
+            api: "ollama",
+            baseUrl: "http://127.0.0.1:11434",
+          },
+        }),
+      }),
+    ).toBeTypeOf("function");
+    expect(createStreamFn).toHaveBeenCalledOnce();
+  });
+
   it("does not load runtime plugins for stream hooks when loading is disabled", () => {
     expect(
       resolveProviderStreamFn({

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -506,9 +506,7 @@ export function normalizeProviderToolSchemasWithPlugin(params: {
     params.allowRuntimePluginLoad === false
       ? (params.runtimeHandle?.plugin ?? resolveLoadedProviderRuntimePlugin(params))
       : ensureProviderRuntimePluginHandle(params).plugin;
-  return (
-    plugin?.normalizeToolSchemas?.(params.context) ?? undefined
-  );
+  return plugin?.normalizeToolSchemas?.(params.context) ?? undefined;
 }
 
 export function inspectProviderToolSchemasWithPlugin(params: {
@@ -524,9 +522,7 @@ export function inspectProviderToolSchemasWithPlugin(params: {
     params.allowRuntimePluginLoad === false
       ? (params.runtimeHandle?.plugin ?? resolveLoadedProviderRuntimePlugin(params))
       : ensureProviderRuntimePluginHandle(params).plugin;
-  return (
-    plugin?.inspectToolSchemas?.(params.context) ?? undefined
-  );
+  return plugin?.inspectToolSchemas?.(params.context) ?? undefined;
 }
 
 export function resolveProviderReasoningOutputModeWithPlugin(params: {

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -548,11 +548,30 @@ export function resolveProviderStreamFn(params: {
   allowRuntimePluginLoad?: boolean;
   context: ProviderCreateStreamFnContext;
 }) {
-  const plugin =
+  const resolvePlugin =
     params.allowRuntimePluginLoad === false
-      ? resolveLoadedProviderRuntimePlugin(params)
-      : resolveProviderRuntimePlugin(params);
-  return plugin?.createStreamFn?.(params.context) ?? undefined;
+      ? resolveLoadedProviderRuntimePlugin
+      : resolveProviderRuntimePlugin;
+  const plugin = resolvePlugin(params);
+  const streamFn = plugin?.createStreamFn?.(params.context);
+  if (streamFn) {
+    return streamFn;
+  }
+
+  const modelApi =
+    typeof params.context.model?.api === "string"
+      ? normalizeProviderId(params.context.model.api)
+      : "";
+  if (!modelApi || modelApi === normalizeProviderId(params.provider)) {
+    return undefined;
+  }
+
+  return (
+    resolvePlugin({
+      ...params,
+      provider: modelApi,
+    })?.createStreamFn?.(params.context) ?? undefined
+  );
 }
 
 export function resolveProviderTransportTurnStateWithPlugin(params: {

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -798,12 +798,11 @@ export function resolveProviderSyntheticAuthWithPlugin(params: {
   env?: NodeJS.ProcessEnv;
   context: ProviderResolveSyntheticAuthContext;
   modelApi?: string;
+  providerRefs?: string[];
 }) {
-  const providerRefs = resolveProviderHookRefs(
-    params.provider,
-    params.context.providerConfig,
-    params.modelApi,
-  );
+  const providerRefs =
+    params.providerRefs ??
+    resolveProviderHookRefs(params.provider, params.context.providerConfig, params.modelApi);
   const discoveryPluginIds = [
     ...new Set(
       providerRefs.flatMap(
@@ -937,12 +936,11 @@ export function shouldDeferProviderSyntheticProfileAuthWithPlugin(params: {
   env?: NodeJS.ProcessEnv;
   context: ProviderDeferSyntheticProfileAuthContext;
   modelApi?: string;
+  providerRefs?: string[];
 }) {
-  const providerRefs = resolveProviderHookRefs(
-    params.provider,
-    params.context.providerConfig,
-    params.modelApi,
-  );
+  const providerRefs =
+    params.providerRefs ??
+    resolveProviderHookRefs(params.provider, params.context.providerConfig, params.modelApi);
   for (const providerRef of providerRefs) {
     const resolved = resolveProviderRuntimePlugin({
       ...params,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1199,6 +1199,8 @@ export type ProviderDeferSyntheticProfileAuthContext = {
   provider: string;
   providerConfig?: ModelProviderConfig;
   resolvedApiKey?: string;
+  modelApi?: string;
+  modelBaseUrl?: string;
 };
 
 export type ProviderSystemPromptContributionContext = {


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (@osolmaz). Ready for maintainer review.

AI-assisted implementation requested by a maintainer.

## Summary

Carry the resolved model runtime through the embedded agent path.

This is a follow-up to #80488. That PR fixed the narrow transport-aware per-model override path; this PR handles the more general runtime/plugin-owned path by keeping the selected provider, final model API/base URL, provider refs that own auth/stream hooks, and runtime plan together after model resolution. Later auth, stream setup, compaction, and runtime planning use those resolved facts instead of deriving them again from provider/model strings.

Refs #80487. Follow-up to #80488.

## What Changed

- Added a resolved model runtime descriptor with provider/model ref, effective transport, auth provider refs, and source metadata.
- Updated sync and async model resolution to return that descriptor alongside the existing resolved model.
- Passed resolved runtime auth facts into embedded-run and compaction credential resolution, synthetic provider auth, and synthetic-profile defer hooks.
- Let shared model auth derive selected-model auth facts when a caller has only the resolved model and not an explicit descriptor.
- Let provider runtime auth hooks use explicit resolved provider refs when available.
- Built the agent runtime plan from the resolved descriptor after runtime model updates.
- Routed stream hook lookup through the selected model API owner when a custom provider's selected model changes API, and made Ollama selected-model `baseUrl` override provider `baseUrl`.

## Testing

Latest after rebasing onto current `upstream/main`:

- `node scripts/run-vitest.mjs src/plugins/provider-runtime.test.ts extensions/ollama/src/stream.test.ts extensions/ollama/index.test.ts src/agents/model-auth.test.ts src/agents/pi-embedded-runner/model.test.ts src/agents/pi-embedded-runner/run/auth-controller.test.ts src/plugins/provider-runtime.synthetic-auth-discovery.test.ts src/agents/pi-embedded-runner/compact.hooks.test.ts src/agents/pi-embedded-runner/compaction-runtime-context.test.ts` - passed, 14 files / 510 tests.
- `git diff --check` - passed.
- `node --import tsx scripts/check-import-cycles.ts` - passed, 0 runtime value cycles.

Earlier validation on the same implementation before the final rebase:

- `node scripts/run-vitest.mjs src/agents/model-auth.test.ts src/agents/pi-embedded-runner/compact.hooks.test.ts` - passed, 4 files / 200 tests after the shared-auth fallback and compaction follow-through fix.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo` - passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo` - passed.
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo` - passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo` - passed.
- `pnpm exec oxfmt --check extensions/ollama/index.test.ts extensions/ollama/index.ts extensions/ollama/provider-discovery.ts extensions/ollama/src/discovery-shared.ts extensions/ollama/src/stream.test.ts extensions/ollama/src/stream.ts src/agents/model-auth.test.ts src/agents/model-auth.ts src/agents/pi-embedded-runner/compact.hooks.harness.ts src/agents/pi-embedded-runner/compact.ts src/agents/pi-embedded-runner/model.test.ts src/agents/pi-embedded-runner/model.ts src/agents/pi-embedded-runner/resolved-model-runtime.ts src/agents/pi-embedded-runner/run.ts src/agents/pi-embedded-runner/run/auth-controller.test.ts src/agents/pi-embedded-runner/run/auth-controller.ts src/agents/resolved-model-runtime.types.ts src/plugins/provider-external-auth.types.ts src/plugins/provider-runtime.test.ts src/plugins/provider-runtime.ts src/plugins/types.ts` - passed.
- `OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_OLLAMA=1 OPENCLAW_LIVE_OLLAMA_MODEL=qwen2.5:3b OPENCLAW_LIVE_OLLAMA_WEB_SEARCH=0 node scripts/run-vitest.mjs --config test/vitest/vitest.live.config.ts extensions/ollama/ollama.live.test.ts -t "runs native chat"` - passed, 1 live test / 3 skipped by filter.
- Manual local source CLI proof with a custom provider whose provider-level API/baseUrl points at an inert router and whose selected model overrides to native local Ollama - passed.
- `codex review --base upstream/main` - passed after fixing the review finding about callers that resolve model auth without an explicit runtime descriptor.

## Real behavior proof

Behavior addressed: custom/router-backed model selections now carry the final resolved transport/auth/stream facts into auth, stream setup, compaction, and runtime planning. A provider default no longer stands in for a per-model runtime choice.

Real environment tested: local source checkout with Node 22, repo dependencies installed, and local Ollama serving `qwen2.5:3b` at `http://127.0.0.1:11434`. No external provider secrets were printed or committed.

Exact steps or command run after this patch: created a temporary `openclaw.json` where `models.providers.custom-router` had provider-level `api: "openai-completions"` and `baseUrl: "https://router.invalid/v1"`, while selected model `custom-router/qwen2.5:3b` had model-level `api: "ollama"` and `baseUrl: "http://127.0.0.1:11434"`; then ran:

```bash
OPENCLAW_STATE_DIR="$tmp/state" \
OPENCLAW_CONFIG_PATH="$tmp/openclaw.json" \
OPENCLAW_NO_RESPAWN=1 \
OPENCLAW_TEST_FAST=1 \
OPENCLAW_LIVE_TEST=1 \
OPENCLAW_LIVE_OLLAMA=1 \
OLLAMA_API_KEY= \
node scripts/run-node.mjs infer model run \
  --local \
  --model custom-router/qwen2.5:3b \
  --prompt 'Reply with exactly one word: pong' \
  --json
```

Evidence after fix:

```json
{
  "ok": true,
  "capability": "model.run",
  "transport": "local",
  "provider": "custom-router",
  "model": "qwen2.5:3b",
  "attempts": [],
  "outputs": [
    {
      "text": "pong",
      "mediaUrl": null
    }
  ]
}
```

Observed result after fix: OpenClaw kept the visible selected provider/model as `custom-router/qwen2.5:3b`, but used the selected model's native Ollama API/base URL for the actual local run. The inert provider-level router URL was not used, and the command returned `ok: true` with the local model response.

What was not tested: full remote `pnpm check:changed` proof is blocked in this environment because Blacksmith Testbox is unavailable (`blacksmith` CLI missing) and direct AWS Crabbox has no usable AWS credentials/IMDS identity. Live Anthropic, Google, and OpenAI auth-profile smokes were not run in this local pass.

## Risks

- This is an internal descriptor plumbing change, so the main risk is stale callers continuing to infer runtime facts from only provider/model strings.
- Plugin auth hook contexts receive additive optional fields only, but this is still public plugin contract surface and should get owner review before merge.
