### PR TITLE
test(google): narrow web search fake timers

### DIFF
--- a/extensions/google/web-search-provider.test.ts
+++ b/extensions/google/web-search-provider.test.ts
@@ -401,7 +401,7 @@ describe("google web search provider", () => {
   });
 
   it("passes freshness to Gemini Google Search grounding as a time range", async () => {
-    vi.useFakeTimers();
+    vi.useFakeTimers({ toFake: ["Date"] });
     // Use a wall-clock-realistic moment with non-zero milliseconds; the helper
     // must strip them to avoid Gemini's "Granularity of nano is not supported".
     vi.setSystemTime(new Date("2026-04-15T12:00:00.123Z"));
@@ -434,7 +434,7 @@ describe("google web search provider", () => {
   });
 
   it("strips sub-second precision from freshness timestamps so Gemini accepts them", async () => {
-    vi.useFakeTimers();
+    vi.useFakeTimers({ toFake: ["Date"] });
     // "now" with non-zero milliseconds. Without stripping, toISOString() emits
     // "2026-04-15T12:00:00.123Z", which Gemini's google_search.time_range_filter
     // rejects with "Granularity of nano is not supported".


### PR DESCRIPTION
## Summary

- narrow the Google web search freshness tests to fake only `Date`
- keep the wall-clock timestamp assertions deterministic without replacing timer behavior the provider does not need mocked

## Verification

- `node scripts/run-vitest.mjs extensions/google/web-search-provider.test.ts`
- `node_modules/.bin/oxfmt --check extensions/google/web-search-provider.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- not run: `pnpm check:changed` locally; this is a Codex worktree, and remote Testbox/Crabbox attempts were blocked by missing Blacksmith/AWS auth

## Real behavior proof

Behavior addressed: Google web search freshness tests set deterministic wall-clock time without replacing unrelated timer behavior.

Real environment tested: local Codex worktree with the repo Node Vitest wrapper.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/google/web-search-provider.test.ts`

Evidence after fix: `extensions/google/web-search-provider.test.ts` passed 20 tests.

Observed result after fix: Gemini freshness timestamp assertions stayed deterministic and the focused provider test file passed.

What was not tested: broad `pnpm check:changed`, because local pnpm gates are avoided in Codex worktrees and remote auth was unavailable.
