### PR TITLE
fix(opencode-go): strip Kimi reasoning replay fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Docs: https://docs.openclaw.ai
 - Gateway chat: broadcast returned agent-run error payloads after an agent starts so ACP/WebChat clients receive terminal idle-timeout errors. Fixes #84945.
 - Dashboard/CLI: allow macOS browser launching through `open` even when SSH environment variables are present, while preserving Linux SSH no-display protection. Fixes #67088. Thanks @theglove44.
 - Codex app-server: keep native web search observations out of mirrored chat transcripts while preserving tool progress telemetry. Fixes #85109. Thanks @ugitmebaby.
+- OpenCode Go: strip unsupported Kimi reasoning replay fields before provider requests so repeated `kimi-k2.6` turns do not fail schema validation. Fixes #83812. Thanks @Sleeck.
 - Agents/OpenAI: preserve structured provider error code, type, and redacted body metadata on boundary-aware transport failures.
 - Doctor/Codex: point native Codex asset warnings at the canonical `openclaw migrate plan codex` preview command. Fixes #84948. Thanks @markoa.
 - CLI/models: make `capability model auth logout --agent` remove auth profiles from the selected non-default agent store. Fixes #85092. Thanks @islandpreneur007.

--- a/extensions/opencode-go/reasoning-sanitizer.test.ts
+++ b/extensions/opencode-go/reasoning-sanitizer.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { stripOpencodeGoKimiReasoningPayload } from "./reasoning-sanitizer.js";
+
+describe("OpenCode Go Kimi reasoning payload sanitizer", () => {
+  it("strips unsupported replay reasoning fields from messages and input", () => {
+    const payload = {
+      model: "kimi-k2.6",
+      reasoning_effort: "high",
+      reasoning: { effort: "high" },
+      reasoningEffort: "high",
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "done" },
+            { type: "thinking", reasoning_details: [{ text: "private thought" }] },
+            { type: "redacted_thinking", data: "opaque" },
+          ],
+          reasoning_details: [{ text: "private thought" }],
+          reasoning_content: "private thought",
+          reasoning_text: "private thought",
+        },
+      ],
+      input: [
+        {
+          role: "assistant",
+          content: "done",
+          reasoning_details: [{ text: "private thought" }],
+        },
+        { type: "reasoning", summary: [] },
+        {
+          role: "assistant",
+          content: [{ type: "thinking", reasoning_details: [{ text: "private thought" }] }],
+        },
+      ],
+    };
+
+    stripOpencodeGoKimiReasoningPayload(payload);
+
+    expect(payload).toEqual({
+      model: "kimi-k2.6",
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "done" }],
+        },
+      ],
+      input: [
+        {
+          role: "assistant",
+          content: "done",
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "[assistant reasoning omitted]" }],
+        },
+      ],
+    });
+  });
+});

--- a/extensions/opencode-go/reasoning-sanitizer.ts
+++ b/extensions/opencode-go/reasoning-sanitizer.ts
@@ -1,0 +1,71 @@
+const REASONING_REPLAY_FIELDS = [
+  "reasoning_details",
+  "reasoning_content",
+  "reasoning",
+  "reasoning_text",
+] as const;
+
+const OMITTED_ASSISTANT_REASONING_TEXT = "[assistant reasoning omitted]";
+
+function isReasoningReplayPart(value: unknown): boolean {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const type = (value as { type?: unknown }).type;
+  return type === "thinking" || type === "redacted_thinking" || type === "reasoning";
+}
+
+function stripReasoningReplayFields(value: unknown): void {
+  if (!value || typeof value !== "object") {
+    return;
+  }
+
+  const record = value as Record<string, unknown>;
+  for (const field of REASONING_REPLAY_FIELDS) {
+    delete record[field];
+  }
+
+  const content = record.content;
+  if (Array.isArray(content)) {
+    const nextContent = [];
+    for (const part of content) {
+      if (isReasoningReplayPart(part)) {
+        continue;
+      }
+      stripReasoningReplayFields(part);
+      nextContent.push(part);
+    }
+    record.content =
+      nextContent.length > 0
+        ? nextContent
+        : [{ type: "text", text: OMITTED_ASSISTANT_REASONING_TEXT }];
+  }
+}
+
+function stripReasoningReplayFieldsFromList(value: unknown): unknown {
+  if (!Array.isArray(value)) {
+    return value;
+  }
+  const nextItems = [];
+
+  for (const item of value) {
+    if (isReasoningReplayPart(item)) {
+      continue;
+    }
+    stripReasoningReplayFields(item);
+    nextItems.push(item);
+  }
+  return nextItems;
+}
+
+export function stripOpencodeGoKimiReasoningPayload(payloadObj: Record<string, unknown>): void {
+  stripReasoningReplayFields(payloadObj);
+  delete payloadObj.reasoning_effort;
+  delete payloadObj.reasoningEffort;
+  if ("messages" in payloadObj) {
+    payloadObj.messages = stripReasoningReplayFieldsFromList(payloadObj.messages);
+  }
+  if ("input" in payloadObj) {
+    payloadObj.input = stripReasoningReplayFieldsFromList(payloadObj.input);
+  }
+}

--- a/extensions/opencode-go/stream.ts
+++ b/extensions/opencode-go/stream.ts
@@ -4,6 +4,7 @@ import {
   streamWithPayloadPatch,
 } from "openclaw/plugin-sdk/provider-stream-shared";
 import { isOpencodeGoKimiNoReasoningModelId } from "./provider-catalog.js";
+import { stripOpencodeGoKimiReasoningPayload } from "./reasoning-sanitizer.js";
 
 function isOpencodeGoDeepSeekV4ModelId(modelId: unknown): boolean {
   return modelId === "deepseek-v4-flash" || modelId === "deepseek-v4-pro";
@@ -22,9 +23,7 @@ export function createOpencodeGoDeepSeekV4Wrapper(
 }
 
 function stripReasoningParams(payloadObj: Record<string, unknown>): void {
-  delete payloadObj.reasoning;
-  delete payloadObj.reasoning_effort;
-  delete payloadObj.reasoningEffort;
+  stripOpencodeGoKimiReasoningPayload(payloadObj);
 }
 
 export function createOpencodeGoKimiNoReasoningWrapper(


### PR DESCRIPTION
Summary
- strip replay-only reasoning fields from OpenCode Go Kimi payload messages/input
- remove replay-only thinking/reasoning content parts so Kimi OpenAI-compatible requests stay schema-clean
- keep reasoning-only assistant turns non-empty with the existing omitted-reasoning text pattern

Fixes #83812.

Verification
- `/Users/steipete/.local/share/fnm/node-versions/v24.13.0/installation/bin/node ./node_modules/.bin/tsx -e "...stripOpencodeGoKimiReasoningPayload payload assertion..."`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Behavior addressed: OpenCode Go `kimi-k2.6` repeated turns no longer send unsupported reasoning replay fields or thinking/reasoning replay content parts to the provider.
Real environment tested: local OpenClaw checkout on Node 24.13.0 with the OpenCode Go sanitizer executed directly; GitHub CI will run the full repository gates.
Exact steps or command run after this patch: direct Node 24 `tsx` assertion of `stripOpencodeGoKimiReasoningPayload`, `git diff --check`, and Codex autoreview local mode.
Evidence after fix: the captured payload assertion removed `reasoning`, `reasoning_effort`, `reasoningEffort`, `reasoning_details`, `reasoning_content`, `reasoning_text`, `type: "thinking"`, `type: "redacted_thinking"`, and `type: "reasoning"` replay parts while preserving visible text.
Observed result after fix: direct assertion printed `sanitizer ok`; autoreview reported no accepted/actionable findings.
What was not tested: a live OpenCode Go request with real Kimi credentials; local Vitest prebundle did not reach test execution in this checkout, so CI remains the full automated gate.
