### PR TITLE
fix(browser): hint WSL portproxy CDP empty replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Docs: https://docs.openclaw.ai
 - Dashboard/CLI: allow macOS browser launching through `open` even when SSH environment variables are present, while preserving Linux SSH no-display protection. Fixes #67088. Thanks @theglove44.
 - Codex app-server: keep native web search observations out of mirrored chat transcripts while preserving tool progress telemetry. Fixes #85109. Thanks @ugitmebaby.
 - OpenCode Go: strip unsupported Kimi reasoning replay fields before provider requests so repeated `kimi-k2.6` turns do not fail schema validation. Fixes #83812. Thanks @Sleeck.
+- Browser/CDP: add a WSL2 portproxy self-loop hint when Chrome DevTools endpoints accept connections but return an empty HTTP reply. Fixes #59209. Thanks @Owlock.
 - Agents/OpenAI: preserve structured provider error code, type, and redacted body metadata on boundary-aware transport failures.
 - Doctor/Codex: point native Codex asset warnings at the canonical `openclaw migrate plan codex` preview command. Fixes #84948. Thanks @markoa.
 - CLI/models: make `capability model auth logout --agent` remove auth profiles from the selected non-default agent store. Fixes #85092. Thanks @islandpreneur007.

--- a/extensions/acpx/npm-shrinkwrap.json
+++ b/extensions/acpx/npm-shrinkwrap.json
@@ -903,7 +903,6 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
       "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -2239,7 +2238,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/extensions/amazon-bedrock-mantle/npm-shrinkwrap.json
+++ b/extensions/amazon-bedrock-mantle/npm-shrinkwrap.json
@@ -1314,7 +1314,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1351,7 +1350,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/extensions/amazon-bedrock/npm-shrinkwrap.json
+++ b/extensions/amazon-bedrock/npm-shrinkwrap.json
@@ -1188,7 +1188,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1225,7 +1224,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/extensions/anthropic-vertex/npm-shrinkwrap.json
+++ b/extensions/anthropic-vertex/npm-shrinkwrap.json
@@ -1321,7 +1321,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1373,7 +1372,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/extensions/browser/src/browser/chrome.diagnostics.ts
+++ b/extensions/browser/src/browser/chrome.diagnostics.ts
@@ -57,6 +57,12 @@ function elapsedSince(startedAt: number): number {
 
 export function safeChromeCdpErrorMessage(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
+  const cause = error instanceof Error ? error.cause : undefined;
+  const causeMessage =
+    cause instanceof Error ? cause.message : typeof cause === "string" ? cause : undefined;
+  if (message && causeMessage && !message.includes(causeMessage)) {
+    return redactSensitiveText(`${message}: ${causeMessage}`);
+  }
   return redactSensitiveText(message || "unknown error");
 }
 
@@ -247,7 +253,15 @@ export function formatChromeCdpDiagnostic(diagnostic: ChromeCdpDiagnostic): stri
     return `CDP diagnostic: ready after ${diagnostic.elapsedMs}ms; cdp=${redactedCdpUrl}; websocket=${redactedWsUrl}.${browser}`;
   }
   const websocket = redactedWsUrl ? `; websocket=${redactedWsUrl}` : "";
-  return `CDP diagnostic: ${diagnostic.code} after ${diagnostic.elapsedMs}ms; cdp=${redactedCdpUrl}${websocket}; ${diagnostic.message}.`;
+  const wslPortproxyHint =
+    diagnostic.code === "http_unreachable" && isLikelyEmptyHttpReply(diagnostic.message)
+      ? " In WSL2-to-Windows Chrome setups, this can be a stale netsh portproxy self-loop where svchost/iphlpsvc owns the CDP port instead of chrome.exe; verify with tasklist /svc and curl /json/version, then remove any 127.0.0.1:9222 -> 127.0.0.1:9222 portproxy rule."
+      : "";
+  return `CDP diagnostic: ${diagnostic.code} after ${diagnostic.elapsedMs}ms; cdp=${redactedCdpUrl}${websocket}; ${diagnostic.message}.${wslPortproxyHint}`;
+}
+
+function isLikelyEmptyHttpReply(message: string): boolean {
+  return /empty reply|other side closed|socket closed|terminated before response/i.test(message);
 }
 
 export async function diagnoseChromeCdp(

--- a/extensions/browser/src/browser/chrome.test.ts
+++ b/extensions/browser/src/browser/chrome.test.ts
@@ -633,6 +633,19 @@ describe("browser chrome helpers", () => {
     expect(formatted).not.toContain("supersecret123");
   });
 
+  it("adds a WSL2 portproxy hint for empty HTTP CDP replies", () => {
+    const formatted = formatChromeCdpDiagnostic({
+      ok: false,
+      code: "http_unreachable",
+      cdpUrl: "http://172.30.144.1:9222",
+      message: "fetch failed: other side closed",
+      elapsedMs: 12,
+    });
+
+    expect(formatted).toContain("svchost/iphlpsvc owns the CDP port");
+    expect(formatted).toContain("127.0.0.1:9222 -> 127.0.0.1:9222");
+  });
+
   it("probes direct ws:// CDP URLs (with /devtools/ path) via handshake instead of HTTP", async () => {
     // A direct WS endpoint like ws://host/devtools/browser/<uuid> is already
     // the handshake target — isChromeReachable must NOT hit /json/version.

--- a/extensions/codex/npm-shrinkwrap.json
+++ b/extensions/codex/npm-shrinkwrap.json
@@ -1866,7 +1866,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1918,7 +1917,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/extensions/diagnostics-otel/npm-shrinkwrap.json
+++ b/extensions/diagnostics-otel/npm-shrinkwrap.json
@@ -67,7 +67,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -581,7 +580,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },

--- a/extensions/discord/npm-shrinkwrap.json
+++ b/extensions/discord/npm-shrinkwrap.json
@@ -432,8 +432,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.1.1.tgz",
       "integrity": "sha512-mL0fZZOUnXdZ78woRXp18lApwpp0lF5tozJOD1Wut0dgrA9WuQTgSels/CSmFleaAZrJi/nci5KOVtbuxeWoQA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prism-media": {
       "version": "1.3.5",

--- a/extensions/memory-lancedb/npm-shrinkwrap.json
+++ b/extensions/memory-lancedb/npm-shrinkwrap.json
@@ -209,7 +209,6 @@
       "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-18.1.0.tgz",
       "integrity": "sha512-v/ShMp57iBnBp4lDgV8Jx3d3Q5/Hac25FWmQ98eMahUiHPXcvwIMKJD0hBIgclm/FCG+LwPkAKtkRO1O/W0YGg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.11",
         "@types/command-line-args": "^5.2.3",

--- a/extensions/twitch/npm-shrinkwrap.json
+++ b/extensions/twitch/npm-shrinkwrap.json
@@ -168,7 +168,6 @@
       "resolved": "https://registry.npmjs.org/@twurple/auth/-/auth-8.1.4.tgz",
       "integrity": "sha512-ylsJoPInCw9BwOqxKcx+1k2ce9QG3vJpKFzPdIyHh49HvM/ulQZ0CAGysydugDYXF0iO/TGryh7PluSwx5fIwA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@d-fischer/logger": "^4.2.1",
         "@d-fischer/shared-utils": "^3.6.1",
@@ -289,7 +288,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/extensions/whatsapp/npm-shrinkwrap.json
+++ b/extensions/whatsapp/npm-shrinkwrap.json
@@ -1178,7 +1178,6 @@
       "resolved": "https://registry.npmjs.org/audio-decode/-/audio-decode-2.2.3.tgz",
       "integrity": "sha512-Z0lHvMayR/Pad9+O9ddzaBJE0DrhZkQlStrC1RwcAHF3AhQAsdwKHeLGK8fYKyp2DDU6xHxzGb4CLMui12yVrg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@wasm-audio-decoders/flac": "^0.2.4",
         "@wasm-audio-decoders/ogg-vorbis": "^0.1.15",
@@ -1418,7 +1417,6 @@
       "resolved": "https://registry.npmjs.org/jimp/-/jimp-1.6.1.tgz",
       "integrity": "sha512-hNQh6rZtWfSVWSNVmvq87N5BPJsNH7k7I7qyrXf9DOma9xATQk3fsyHazCQe51nCjdkoWdTmh0vD7bjVSLoxxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jimp/core": "1.6.1",
         "@jimp/diff": "1.6.1",
@@ -1463,7 +1461,6 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1567,7 +1567,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -2814,7 +2813,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3232,7 +3230,6 @@
       "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.43.0.tgz",
       "integrity": "sha512-7dYm06A945mXuIk/5HUlSjeyIYChW8vCEiU2dkOKKqJJzwAWxTkCc91Eqbz7TgODh2rtFFKWI/fekowWHOkmjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@grammyjs/types": "3.27.3",
         "abort-controller": "^3.0.0",
@@ -3301,7 +3298,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
       "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5068,7 +5064,6 @@
       "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
       "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=22.19.0"
       }
@@ -5292,7 +5287,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
Summary
- include nested fetch causes in redacted Chrome CDP diagnostic messages
- add a WSL2 portproxy self-loop hint for empty/closed HTTP CDP replies
- keep the hint off ordinary refused/unreachable failures

Fixes #59209.

Verification
- `/Users/steipete/.local/share/fnm/node-versions/v24.13.0/installation/bin/node ./node_modules/.bin/tsx -e "...formatChromeCdpDiagnostic assertion..."`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Behavior addressed: WSL2 users whose Windows CDP port is owned by stale `netsh portproxy`/`svchost` now get a targeted empty-reply diagnostic instead of a generic unreachable message.
Real environment tested: local OpenClaw checkout on Node 24.13.0 with the browser diagnostic formatter executed directly; GitHub CI will run the full repository gates.
Exact steps or command run after this patch: direct Node 24 `tsx` assertion for `safeChromeCdpErrorMessage` and `formatChromeCdpDiagnostic`, `git diff --check`, and Codex autoreview local mode.
Evidence after fix: the direct assertion verified the WSL2 hint appears for `fetch failed: other side closed` and does not appear for `fetch failed: connect ECONNREFUSED`.
Observed result after fix: direct assertion printed `cdp hint ok`; autoreview reported no accepted/actionable findings.
What was not tested: a live WSL2 Windows Chrome portproxy setup; the change is diagnostic text only and does not alter CDP connection behavior.
