### PR TITLE
fix(cli): keep logs follow on live gateway state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,7 @@ Docs: https://docs.openclaw.ai
 - OpenCode Go: strip unsupported Kimi reasoning replay fields before provider requests so repeated `kimi-k2.6` turns do not fail schema validation. Fixes #83812. Thanks @Sleeck.
 - Browser/CDP: add a WSL2 portproxy self-loop hint when Chrome DevTools endpoints accept connections but return an empty HTTP reply. Fixes #59209. Thanks @Owlock.
 - Agents/tools: add bounded tool-policy audit log entries that identify which allow/deny rule removed tools or blocked a sandboxed tool call. Fixes #55801. Thanks @justinjkline.
-- CLI/logs: read implicit local Gateway logs through the passive backend client path so `openclaw logs --follow` does not register as a paired device, and stop following stale configured-file fallbacks after live RPC failures. Fixes #83656 and #66841.
+- CLI/logs: read implicit local Gateway logs through the passive backend client path so `openclaw logs --follow` does not register as a paired device, and use the active Linux systemd journal instead of stale configured-file fallbacks when live local RPC is unavailable. Fixes #83656 and #66841.
 - Agents/OpenAI: preserve structured provider error code, type, and redacted body metadata on boundary-aware transport failures.
 - Doctor/Codex: point native Codex asset warnings at the canonical `openclaw migrate plan codex` preview command. Fixes #84948. Thanks @markoa.
 - CLI/models: make `capability model auth logout --agent` remove auth profiles from the selected non-default agent store. Fixes #85092. Thanks @islandpreneur007.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ Docs: https://docs.openclaw.ai
 - OpenCode Go: strip unsupported Kimi reasoning replay fields before provider requests so repeated `kimi-k2.6` turns do not fail schema validation. Fixes #83812. Thanks @Sleeck.
 - Browser/CDP: add a WSL2 portproxy self-loop hint when Chrome DevTools endpoints accept connections but return an empty HTTP reply. Fixes #59209. Thanks @Owlock.
 - Agents/tools: add bounded tool-policy audit log entries that identify which allow/deny rule removed tools or blocked a sandboxed tool call. Fixes #55801. Thanks @justinjkline.
+- CLI/logs: read implicit local Gateway logs through the passive backend client path so `openclaw logs --follow` does not register as a paired device, and stop following stale configured-file fallbacks after live RPC failures. Fixes #83656 and #66841.
 - Agents/OpenAI: preserve structured provider error code, type, and redacted body metadata on boundary-aware transport failures.
 - Doctor/Codex: point native Codex asset warnings at the canonical `openclaw migrate plan codex` preview command. Fixes #84948. Thanks @markoa.
 - CLI/models: make `capability model auth logout --agent` remove auth profiles from the selected non-default agent store. Fixes #85092. Thanks @islandpreneur007.

--- a/docs/cli/logs.md
+++ b/docs/cli/logs.md
@@ -57,7 +57,7 @@ openclaw logs --url ws://127.0.0.1:18789 --token "$OPENCLAW_GATEWAY_TOKEN"
 
 - Use `--local-time` to render timestamps in your local timezone.
 - If the implicit local loopback Gateway asks for pairing, closes during connect, or times out before `logs.tail` answers, `openclaw logs` falls back to the configured Gateway file log automatically. Explicit `--url` targets do not use this fallback.
-- `openclaw logs --follow` does not fall back to configured files after Gateway RPC failures, because following a stale side-by-side log can hide the active Gateway's real state.
+- `openclaw logs --follow` does not follow configured-file fallbacks after implicit local Gateway RPC failures. On Linux, it uses the active user-systemd Gateway journal by PID when available and prints the selected log source; otherwise it keeps retrying the live Gateway instead of tailing a potentially stale side-by-side file.
 - When using `--follow`, transient gateway disconnects (WebSocket close, timeout, connection drop) trigger automatic reconnection with exponential backoff (up to 8 retries, capped at 30 s between attempts). A warning is printed to stderr on each retry, and a `[logs] gateway reconnected` notice is printed once a poll succeeds. In `--json` mode both the retry warning and the reconnect transition are emitted as `{"type":"notice"}` records on stderr. Non-recoverable errors (auth failure, bad configuration) still exit immediately.
 
 ## Related

--- a/docs/cli/logs.md
+++ b/docs/cli/logs.md
@@ -57,6 +57,7 @@ openclaw logs --url ws://127.0.0.1:18789 --token "$OPENCLAW_GATEWAY_TOKEN"
 
 - Use `--local-time` to render timestamps in your local timezone.
 - If the implicit local loopback Gateway asks for pairing, closes during connect, or times out before `logs.tail` answers, `openclaw logs` falls back to the configured Gateway file log automatically. Explicit `--url` targets do not use this fallback.
+- `openclaw logs --follow` does not fall back to configured files after Gateway RPC failures, because following a stale side-by-side log can hide the active Gateway's real state.
 - When using `--follow`, transient gateway disconnects (WebSocket close, timeout, connection drop) trigger automatic reconnection with exponential backoff (up to 8 retries, capped at 30 s between attempts). A warning is printed to stderr on each retry, and a `[logs] gateway reconnected` notice is printed once a poll succeeds. In `--json` mode both the retry warning and the reconnect transition are emitted as `{"type":"notice"}` records on stderr. Non-recoverable errors (auth failure, bad configuration) still exit immediately.
 
 ## Related

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -76,7 +76,9 @@ In JSON mode, the CLI emits `type`-tagged objects:
 If the implicit local loopback Gateway asks for pairing, closes during connect,
 or times out before `logs.tail` answers, `openclaw logs` falls back to the
 configured Gateway file log automatically. Explicit `--url` targets do not use
-this fallback.
+this fallback. `openclaw logs --follow` is stricter: on Linux it uses the active
+user-systemd Gateway journal by PID when available, and otherwise keeps retrying
+the live Gateway instead of following a potentially stale side-by-side file.
 
 If the Gateway is unreachable, the CLI prints a short hint to run:
 

--- a/src/cli/logs-cli.runtime.ts
+++ b/src/cli/logs-cli.runtime.ts
@@ -1,3 +1,82 @@
+import { spawn } from "node:child_process";
+
 export { buildGatewayConnectionDetails } from "../gateway/call.js";
-export { execFileUtf8 } from "../daemon/exec-file.js";
-export { readSystemdServiceExecStart, readSystemdServiceRuntime } from "../daemon/systemd.js";
+export { resolveGatewaySystemdServiceName } from "../daemon/constants.js";
+export { readSystemdServiceRuntime } from "../daemon/systemd.js";
+
+type ExecFileTailResult = { stdout: string; stderr: string; code: number; truncated: boolean };
+
+export async function execFileUtf8Tail(
+  command: string,
+  args: string[],
+  options: { env?: NodeJS.ProcessEnv; maxBytes: number },
+): Promise<ExecFileTailResult> {
+  return await new Promise<ExecFileTailResult>((resolve) => {
+    const child = spawn(command, args, {
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let truncated = false;
+    let settled = false;
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdoutChunks.push(chunk);
+      stdoutBytes += chunk.length;
+      while (stdoutBytes > options.maxBytes && stdoutChunks.length > 0) {
+        const first = stdoutChunks[0];
+        const overflow = stdoutBytes - options.maxBytes;
+        if (first.length <= overflow) {
+          stdoutChunks.shift();
+          stdoutBytes -= first.length;
+        } else {
+          stdoutChunks[0] = first.subarray(overflow);
+          stdoutBytes -= overflow;
+        }
+        truncated = true;
+      }
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderrChunks.push(chunk);
+      stderrBytes += chunk.length;
+      while (stderrBytes > 64 * 1024 && stderrChunks.length > 0) {
+        const first = stderrChunks[0];
+        const overflow = stderrBytes - 64 * 1024;
+        if (first.length <= overflow) {
+          stderrChunks.shift();
+          stderrBytes -= first.length;
+        } else {
+          stderrChunks[0] = first.subarray(overflow);
+          stderrBytes -= overflow;
+        }
+      }
+    });
+    child.on("error", (error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve({
+        stdout: Buffer.concat(stdoutChunks).toString("utf8"),
+        stderr: error instanceof Error ? error.message : String(error),
+        code: 1,
+        truncated,
+      });
+    });
+    child.on("close", (code) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve({
+        stdout: Buffer.concat(stdoutChunks).toString("utf8"),
+        stderr: Buffer.concat(stderrChunks).toString("utf8"),
+        code: typeof code === "number" ? code : 1,
+        truncated,
+      });
+    });
+  });
+}

--- a/src/cli/logs-cli.runtime.ts
+++ b/src/cli/logs-cli.runtime.ts
@@ -1,1 +1,3 @@
 export { buildGatewayConnectionDetails } from "../gateway/call.js";
+export { execFileUtf8 } from "../daemon/exec-file.js";
+export { readSystemdServiceExecStart, readSystemdServiceRuntime } from "../daemon/systemd.js";

--- a/src/cli/logs-cli.test.ts
+++ b/src/cli/logs-cli.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GatewayTransportError } from "../gateway/call.js";
 import { runRegisteredCli } from "../test-utils/command-runner.js";
 import { formatLogTimestamp, registerLogsCli } from "./logs-cli.js";
@@ -38,6 +38,9 @@ const { MockGatewayTransportError } = vi.hoisted(() => ({
 
 const callGatewayFromCli = vi.fn();
 const readConfiguredLogTail = vi.fn();
+const readSystemdServiceRuntime = vi.fn();
+const readSystemdServiceExecStart = vi.fn();
+const execFileUtf8 = vi.fn();
 const buildGatewayConnectionDetails = vi.fn(
   (_options?: {
     configPath?: string;
@@ -63,6 +66,20 @@ vi.mock("../logging/log-tail.js", () => ({
   readConfiguredLogTail: (
     ...args: Parameters<typeof import("../logging/log-tail.js").readConfiguredLogTail>
   ) => readConfiguredLogTail(...args),
+}));
+
+vi.mock("./logs-cli.runtime.js", () => ({
+  buildGatewayConnectionDetails: (
+    ...args: Parameters<typeof import("../gateway/call.js").buildGatewayConnectionDetails>
+  ) => buildGatewayConnectionDetails(...args),
+  readSystemdServiceRuntime: (
+    ...args: Parameters<typeof import("../daemon/systemd.js").readSystemdServiceRuntime>
+  ) => readSystemdServiceRuntime(...args),
+  readSystemdServiceExecStart: (
+    ...args: Parameters<typeof import("../daemon/systemd.js").readSystemdServiceExecStart>
+  ) => readSystemdServiceExecStart(...args),
+  execFileUtf8: (...args: Parameters<typeof import("../daemon/exec-file.js").execFileUtf8>) =>
+    execFileUtf8(...args),
 }));
 
 vi.mock("../infra/backoff.js", () => ({
@@ -104,10 +121,19 @@ function captureStderrWrites() {
 }
 
 describe("logs cli", () => {
+  beforeEach(() => {
+    readSystemdServiceRuntime.mockResolvedValue({ status: "stopped" });
+    readSystemdServiceExecStart.mockResolvedValue(null);
+    execFileUtf8.mockResolvedValue({ stdout: "", stderr: "", code: 1 });
+  });
+
   afterEach(() => {
     callGatewayFromCli.mockClear();
     readConfiguredLogTail.mockClear();
     buildGatewayConnectionDetails.mockClear();
+    readSystemdServiceRuntime.mockClear();
+    readSystemdServiceExecStart.mockClear();
+    execFileUtf8.mockClear();
     vi.restoreAllMocks();
   });
 
@@ -319,6 +345,59 @@ describe("logs cli", () => {
   });
 
   describe("--follow retry behavior", () => {
+    it("uses the active systemd journal for implicit local follow failures", async () => {
+      callGatewayFromCli.mockRejectedValueOnce(
+        new GatewayTransportError({
+          kind: "closed",
+          code: 1006,
+          reason: "abnormal closure",
+          connectionDetails: {
+            url: "ws://127.0.0.1:18789",
+            urlSource: "local loopback",
+            message: "",
+          },
+          message: "gateway closed (1006 abnormal closure): abnormal closure",
+        }),
+      );
+      readSystemdServiceRuntime.mockResolvedValueOnce({ status: "running", pid: 2557 });
+      readSystemdServiceExecStart.mockResolvedValueOnce({
+        programArguments: [
+          "/usr/bin/node",
+          "/home/openclaw/openclaw-sidecar/dist/index.js",
+          "gateway",
+          "--token",
+          "secret-token",
+        ],
+      });
+      execFileUtf8.mockResolvedValueOnce({
+        stdout: ["journal line", "-- cursor: s=abc"].join("\n"),
+        stderr: "",
+        code: 0,
+      });
+
+      const stderrWrites = captureStderrWrites();
+      const stdoutWrites = captureStdoutWrites();
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+      await runLogsCli(["logs", "--follow", "--interval", "1"]);
+
+      expect(readConfiguredLogTail).not.toHaveBeenCalled();
+      expect(execFileUtf8).toHaveBeenCalledWith(
+        "journalctl",
+        expect.arrayContaining(["--user", "_PID=2557", "--output=cat", "--show-cursor"]),
+        expect.any(Object),
+      );
+      expect(stderrWrites.join("")).toContain("reading active systemd gateway journal");
+      expect(stderrWrites.join("")).not.toContain("gateway disconnected");
+      expect(stdoutWrites.join("")).toContain("Log source: journalctl --user _PID=2557");
+      expect(stdoutWrites.join("")).toContain("Service PID: 2557");
+      expect(stdoutWrites.join("")).toContain(
+        "Service ExecStart: /usr/bin/node /home/openclaw/openclaw-sidecar/dist/index.js gateway --token [redacted]",
+      );
+      expect(stdoutWrites.join("")).toContain("journal line");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
     it("retries loopback close errors in --follow mode instead of tailing fallback files", async () => {
       const closeError = new GatewayTransportError({
         kind: "closed",

--- a/src/cli/logs-cli.test.ts
+++ b/src/cli/logs-cli.test.ts
@@ -39,8 +39,7 @@ const { MockGatewayTransportError } = vi.hoisted(() => ({
 const callGatewayFromCli = vi.fn();
 const readConfiguredLogTail = vi.fn();
 const readSystemdServiceRuntime = vi.fn();
-const readSystemdServiceExecStart = vi.fn();
-const execFileUtf8 = vi.fn();
+const execFileUtf8Tail = vi.fn();
 const buildGatewayConnectionDetails = vi.fn(
   (_options?: {
     configPath?: string;
@@ -75,11 +74,12 @@ vi.mock("./logs-cli.runtime.js", () => ({
   readSystemdServiceRuntime: (
     ...args: Parameters<typeof import("../daemon/systemd.js").readSystemdServiceRuntime>
   ) => readSystemdServiceRuntime(...args),
-  readSystemdServiceExecStart: (
-    ...args: Parameters<typeof import("../daemon/systemd.js").readSystemdServiceExecStart>
-  ) => readSystemdServiceExecStart(...args),
-  execFileUtf8: (...args: Parameters<typeof import("../daemon/exec-file.js").execFileUtf8>) =>
-    execFileUtf8(...args),
+  execFileUtf8Tail: (
+    ...args: Parameters<typeof import("./logs-cli.runtime.js").execFileUtf8Tail>
+  ) => execFileUtf8Tail(...args),
+  resolveGatewaySystemdServiceName: (
+    ...args: Parameters<typeof import("../daemon/constants.js").resolveGatewaySystemdServiceName>
+  ) => "openclaw-gateway",
 }));
 
 vi.mock("../infra/backoff.js", () => ({
@@ -123,8 +123,7 @@ function captureStderrWrites() {
 describe("logs cli", () => {
   beforeEach(() => {
     readSystemdServiceRuntime.mockResolvedValue({ status: "stopped" });
-    readSystemdServiceExecStart.mockResolvedValue(null);
-    execFileUtf8.mockResolvedValue({ stdout: "", stderr: "", code: 1 });
+    execFileUtf8Tail.mockResolvedValue({ stdout: "", stderr: "", code: 1, truncated: false });
   });
 
   afterEach(() => {
@@ -132,8 +131,7 @@ describe("logs cli", () => {
     readConfiguredLogTail.mockClear();
     buildGatewayConnectionDetails.mockClear();
     readSystemdServiceRuntime.mockClear();
-    readSystemdServiceExecStart.mockClear();
-    execFileUtf8.mockClear();
+    execFileUtf8Tail.mockClear();
     vi.restoreAllMocks();
   });
 
@@ -346,34 +344,36 @@ describe("logs cli", () => {
 
   describe("--follow retry behavior", () => {
     it("uses the active systemd journal for implicit local follow failures", async () => {
-      callGatewayFromCli.mockRejectedValueOnce(
-        new GatewayTransportError({
-          kind: "closed",
-          code: 1006,
-          reason: "abnormal closure",
-          connectionDetails: {
-            url: "ws://127.0.0.1:18789",
-            urlSource: "local loopback",
-            message: "",
-          },
-          message: "gateway closed (1006 abnormal closure): abnormal closure",
-        }),
-      );
-      readSystemdServiceRuntime.mockResolvedValueOnce({ status: "running", pid: 2557 });
-      readSystemdServiceExecStart.mockResolvedValueOnce({
-        programArguments: [
-          "/usr/bin/node",
-          "/home/openclaw/openclaw-sidecar/dist/index.js",
-          "gateway",
-          "--token",
-          "secret-token",
-        ],
+      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+      const closeError = new GatewayTransportError({
+        kind: "closed",
+        code: 1006,
+        reason: "abnormal closure",
+        connectionDetails: {
+          url: "ws://127.0.0.1:18789",
+          urlSource: "local loopback",
+          message: "",
+        },
+        message: "gateway closed (1006 abnormal closure): abnormal closure",
       });
-      execFileUtf8.mockResolvedValueOnce({
-        stdout: ["journal line", "-- cursor: s=abc"].join("\n"),
-        stderr: "",
-        code: 0,
-      });
+      callGatewayFromCli.mockRejectedValueOnce(closeError).mockRejectedValueOnce(closeError);
+      readSystemdServiceRuntime.mockResolvedValue({ status: "running", pid: 2557 });
+      execFileUtf8Tail
+        .mockResolvedValueOnce({
+          stdout: [
+            "Authorization: Bearer sk-abcdefghijklmnopqrstuvwxyz",
+            "-- cursor: s=abc",
+          ].join("\n"),
+          stderr: "",
+          code: 0,
+          truncated: false,
+        })
+        .mockResolvedValueOnce({
+          stdout: ["second journal line", "-- cursor: s=def"].join("\n"),
+          stderr: "",
+          code: 0,
+          truncated: false,
+        });
 
       const stderrWrites = captureStderrWrites();
       const stdoutWrites = captureStdoutWrites();
@@ -382,19 +382,33 @@ describe("logs cli", () => {
       await runLogsCli(["logs", "--follow", "--interval", "1"]);
 
       expect(readConfiguredLogTail).not.toHaveBeenCalled();
-      expect(execFileUtf8).toHaveBeenCalledWith(
+      expect(execFileUtf8Tail).toHaveBeenCalledWith(
         "journalctl",
-        expect.arrayContaining(["--user", "_PID=2557", "--output=cat", "--show-cursor"]),
+        expect.arrayContaining([
+          "--user",
+          "--boot",
+          "--user-unit=openclaw-gateway.service",
+          "_PID=2557",
+          "--output=cat",
+          "--show-cursor",
+        ]),
+        expect.any(Object),
+      );
+      expect(execFileUtf8Tail).toHaveBeenNthCalledWith(
+        2,
+        "journalctl",
+        expect.arrayContaining(["--after-cursor=s=abc"]),
         expect.any(Object),
       );
       expect(stderrWrites.join("")).toContain("reading active systemd gateway journal");
-      expect(stderrWrites.join("")).not.toContain("gateway disconnected");
-      expect(stdoutWrites.join("")).toContain("Log source: journalctl --user _PID=2557");
-      expect(stdoutWrites.join("")).toContain("Service PID: 2557");
       expect(stdoutWrites.join("")).toContain(
-        "Service ExecStart: /usr/bin/node /home/openclaw/openclaw-sidecar/dist/index.js gateway --token [redacted]",
+        "Log source: journalctl --user --boot --user-unit=openclaw-gateway.service _PID=2557",
       );
-      expect(stdoutWrites.join("")).toContain("journal line");
+      expect(stdoutWrites.join("")).toContain("Service PID: 2557");
+      expect(stdoutWrites.join("")).toContain("Service Unit: openclaw-gateway.service");
+      expect(stdoutWrites.join("")).not.toContain("sk-abcdefghijklmnopqrstuvwxyz");
+      expect(stdoutWrites.join("")).toContain("Authorization: Bearer");
+      expect(stdoutWrites.join("")).toContain("second journal line");
       expect(exitSpy).toHaveBeenCalledWith(1);
     });
 

--- a/src/cli/logs-cli.test.ts
+++ b/src/cli/logs-cli.test.ts
@@ -132,6 +132,47 @@ describe("logs cli", () => {
     expect(stderrWrites.join("")).toContain("Log cursor reset");
   });
 
+  it("uses the passive local Gateway client for implicit loopback log reads", async () => {
+    callGatewayFromCli.mockResolvedValueOnce({
+      file: "/tmp/openclaw.log",
+      lines: ["raw line"],
+    });
+
+    captureStdoutWrites();
+
+    await runLogsCli(["logs"]);
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "logs.tail",
+      expect.any(Object),
+      { cursor: undefined, limit: 200, maxBytes: 250_000 },
+      {
+        progress: true,
+        clientName: "gateway-client",
+        mode: "backend",
+        deviceIdentity: null,
+      },
+    );
+  });
+
+  it("keeps explicit Gateway URLs on the normal CLI client identity", async () => {
+    callGatewayFromCli.mockResolvedValueOnce({
+      file: "/tmp/openclaw.log",
+      lines: ["raw line"],
+    });
+
+    captureStdoutWrites();
+
+    await runLogsCli(["logs", "--url", "ws://127.0.0.1:18789"]);
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "logs.tail",
+      expect.any(Object),
+      { cursor: undefined, limit: 200, maxBytes: 250_000 },
+      { progress: true },
+    );
+  });
+
   it("wires --local-time through CLI parsing and emits local timestamps", async () => {
     callGatewayFromCli.mockResolvedValueOnce({
       file: "/tmp/openclaw.log",
@@ -278,29 +319,21 @@ describe("logs cli", () => {
   });
 
   describe("--follow retry behavior", () => {
-    it("uses local fallback (not retry warning) for loopback close errors in --follow mode", async () => {
-      // Loopback close errors are absorbed by shouldUseLocalLogsFallback inside fetchLogs —
-      // they never reach the retry path, so no "gateway disconnected" warning is emitted.
-      callGatewayFromCli.mockRejectedValueOnce(
-        new GatewayTransportError({
-          kind: "closed",
-          code: 1006,
-          reason: "abnormal closure",
-          connectionDetails: {
-            url: "ws://127.0.0.1:18789",
-            urlSource: "local loopback",
-            message: "",
-          },
-          message: "gateway closed (1006 abnormal closure): abnormal closure",
-        }),
-      );
-      readConfiguredLogTail.mockResolvedValueOnce({
-        file: "/tmp/openclaw.log",
-        cursor: 5,
-        lines: ["local fallback line"],
-        truncated: false,
-        reset: false,
+    it("retries loopback close errors in --follow mode instead of tailing fallback files", async () => {
+      const closeError = new GatewayTransportError({
+        kind: "closed",
+        code: 1006,
+        reason: "abnormal closure",
+        connectionDetails: {
+          url: "ws://127.0.0.1:18789",
+          urlSource: "local loopback",
+          message: "",
+        },
+        message: "gateway closed (1006 abnormal closure): abnormal closure",
       });
+      for (let i = 0; i <= 8; i += 1) {
+        callGatewayFromCli.mockRejectedValueOnce(closeError);
+      }
 
       const stderrWrites = captureStderrWrites();
       const stdoutWrites = captureStdoutWrites();
@@ -308,9 +341,10 @@ describe("logs cli", () => {
 
       await runLogsCli(["logs", "--follow", "--interval", "1"]);
 
-      expect(stderrWrites.join("")).toContain("Local Gateway RPC unavailable");
-      expect(stderrWrites.join("")).not.toContain("gateway disconnected");
-      expect(stdoutWrites.join("")).toContain("local fallback line");
+      expect(readConfiguredLogTail).not.toHaveBeenCalled();
+      expect((stderrWrites.join("").match(/gateway disconnected/g) ?? []).length).toBe(8);
+      expect(stderrWrites.join("")).toContain("Gateway not reachable");
+      expect(stdoutWrites.join("")).not.toContain("local fallback line");
       expect(exitSpy).toHaveBeenCalledWith(1);
     });
 

--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -12,6 +12,7 @@ import { computeBackoff } from "../infra/backoff.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { readConfiguredLogTail } from "../logging/log-tail.js";
 import { parseLogLine } from "../logging/parse-log-line.js";
+import { redactSensitiveLines, resolveRedactOptions } from "../logging/redact.js";
 import { formatTimestamp, isValidTimeZone } from "../logging/timestamps.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
@@ -38,9 +39,9 @@ type LogsTailPayload = {
   sourceKind?: "file" | "journal";
   service?: {
     pid?: number;
-    execStart?: string;
+    unit?: string;
   };
-  cursor?: LogCursor;
+  cursor?: number | string;
   size?: number;
   lines?: string[];
   truncated?: boolean;
@@ -48,7 +49,19 @@ type LogsTailPayload = {
   localFallback?: boolean;
 };
 
-type LogCursor = number | string;
+type LogCursorState = {
+  gateway?: number;
+  journal?: string;
+  journalSince?: string;
+  forceJournal?: boolean;
+};
+
+class JournalFallbackUnavailableError extends Error {
+  constructor() {
+    super("Active systemd journal unavailable for logs follow fallback");
+    this.name = "JournalFallbackUnavailableError";
+  }
+}
 
 type LogsCliOptions = {
   limit?: string;
@@ -69,16 +82,8 @@ const LOCAL_FALLBACK_NOTICE = "Local Gateway RPC unavailable; reading configured
 const JOURNAL_FALLBACK_NOTICE =
   "Local Gateway RPC unavailable; reading active systemd gateway journal instead.";
 const JOURNAL_CURSOR_PREFIX = "-- cursor: ";
-const SENSITIVE_EXEC_ARG_NAMES = new Set([
-  "--api-key",
-  "--apikey",
-  "--auth",
-  "--client-secret",
-  "--key",
-  "--password",
-  "--secret",
-  "--token",
-]);
+const JOURNAL_MAX_LIMIT = 5000;
+const JOURNAL_MAX_BYTES = 1_000_000;
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {
   if (!value) {
@@ -90,17 +95,28 @@ function parsePositiveInt(value: string | undefined, fallback: number): number {
 
 async function fetchLogs(
   opts: LogsCliOptions,
-  cursor: LogCursor | undefined,
+  cursors: LogCursorState,
   showProgress: boolean,
 ): Promise<LogsTailPayload> {
   const limit = parsePositiveInt(opts.limit, 200);
   const maxBytes = parsePositiveInt(opts.maxBytes, 250_000);
-  const gatewayCursor = typeof cursor === "number" ? cursor : undefined;
+  if (cursors.forceJournal) {
+    const journalPayload = await readSystemdJournalFallback({
+      cursor: cursors.journal,
+      since: cursors.journalSince,
+      limit,
+      maxBytes,
+    });
+    if (journalPayload) {
+      return journalPayload;
+    }
+    throw new JournalFallbackUnavailableError();
+  }
   try {
     const payload = await callGatewayFromCli(
       "logs.tail",
       opts,
-      { cursor: gatewayCursor, limit, maxBytes },
+      { cursor: cursors.gateway, limit, maxBytes },
       buildLogsTailGatewayExtra(opts, showProgress),
     );
     if (!payload || typeof payload !== "object") {
@@ -112,7 +128,12 @@ async function fetchLogs(
       throw error;
     }
     if (opts.follow) {
-      const journalPayload = await readSystemdJournalFallback({ cursor, limit, maxBytes });
+      const journalPayload = await readSystemdJournalFallback({
+        cursor: cursors.journal,
+        since: cursors.journalSince,
+        limit,
+        maxBytes,
+      });
       if (journalPayload) {
         return journalPayload;
       }
@@ -120,7 +141,7 @@ async function fetchLogs(
     }
     // Match the Gateway logs.tail source when implicit local RPC is unavailable.
     return {
-      ...(await readConfiguredLogTail({ cursor: gatewayCursor, limit, maxBytes })),
+      ...(await readConfiguredLogTail({ cursor: cursors.gateway, limit, maxBytes })),
       sourceKind: "file",
       localFallback: true,
     };
@@ -199,7 +220,8 @@ function isPlainGatewayRequestTimeoutError(message: string): boolean {
 }
 
 async function readSystemdJournalFallback(params: {
-  cursor: LogCursor | undefined;
+  cursor: string | undefined;
+  since: string | undefined;
   limit: number;
   maxBytes: number;
 }): Promise<LogsTailPayload | null> {
@@ -211,10 +233,14 @@ async function readSystemdJournalFallback(params: {
   if (service.status !== "running" || typeof service.pid !== "number") {
     return null;
   }
-  const serviceCommand = await runtime.readSystemdServiceExecStart(process.env).catch(() => null);
-  const source = `journalctl --user _PID=${service.pid}`;
+  const limit = clampPositiveInt(params.limit, 1, JOURNAL_MAX_LIMIT);
+  const maxBytes = clampPositiveInt(params.maxBytes, 1, JOURNAL_MAX_BYTES);
+  const unitName = resolveLogsSystemdUnitName(runtime, process.env);
+  const source = `journalctl --user --boot --user-unit=${unitName} _PID=${service.pid}`;
   const args = [
     "--user",
+    "--boot",
+    `--user-unit=${unitName}`,
     `_PID=${service.pid}`,
     "--no-pager",
     "--output=cat",
@@ -222,30 +248,52 @@ async function readSystemdJournalFallback(params: {
   ];
   if (typeof params.cursor === "string" && params.cursor.trim().length > 0) {
     args.push(`--after-cursor=${params.cursor}`);
+  } else if (params.since) {
+    args.push(`--since=${params.since}`);
   } else {
-    args.push("-n", String(params.limit));
+    args.push("-n", String(limit));
   }
-  const result = await runtime.execFileUtf8("journalctl", args, {
+  const result = await runtime.execFileUtf8Tail("journalctl", args, {
     env: process.env,
-    maxBuffer: Math.max(params.maxBytes * 2, 1024 * 1024),
+    maxBytes,
   });
   if (result.code !== 0) {
     return null;
   }
-  const parsed = parseJournalctlOutput(result.stdout);
+  const boundedOutput = normalizeTailText(result.stdout, result.truncated);
+  const parsed = parseJournalctlOutput(boundedOutput.text);
+  const lines = parsed.lines.length > limit ? parsed.lines.slice(-limit) : parsed.lines;
+  const redaction = resolveRedactOptions();
   return {
     source,
     sourceKind: "journal",
     service: {
       pid: service.pid,
-      ...(serviceCommand
-        ? { execStart: formatServiceExecStart(serviceCommand.programArguments) }
-        : {}),
+      unit: unitName,
     },
     cursor: parsed.cursor ?? params.cursor,
-    lines: parsed.lines,
+    lines: redactSensitiveLines(lines, redaction),
+    truncated: boundedOutput.truncated || parsed.lines.length > limit,
     localFallback: true,
   };
+}
+
+function clampPositiveInt(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  return Math.max(min, Math.min(max, Math.floor(value)));
+}
+
+function normalizeTailText(text: string, truncated: boolean): { text: string; truncated: boolean } {
+  if (!truncated) {
+    return { text, truncated };
+  }
+  const firstNewline = text.indexOf("\n");
+  if (firstNewline < 0) {
+    return { text: "", truncated };
+  }
+  return { text: text.slice(firstNewline + 1), truncated };
 }
 
 function parseJournalctlOutput(output: string): { lines: string[]; cursor?: string } {
@@ -264,58 +312,15 @@ function parseJournalctlOutput(output: string): { lines: string[]; cursor?: stri
   return { lines, cursor };
 }
 
-function formatServiceExecStart(args: readonly string[]): string {
-  const rendered: string[] = [];
-  let redactNext = false;
-  for (const arg of args) {
-    if (redactNext) {
-      rendered.push("[redacted]");
-      redactNext = false;
-      continue;
-    }
-    const [name, value] = splitInlineArg(arg);
-    if (isSensitiveExecArgName(name)) {
-      if (value === undefined) {
-        rendered.push(name);
-        redactNext = true;
-      } else {
-        rendered.push(`${name}=[redacted]`);
-      }
-      continue;
-    }
-    rendered.push(renderShellArg(arg));
+function resolveLogsSystemdUnitName(
+  runtime: LogsCliRuntimeModule,
+  env: NodeJS.ProcessEnv,
+): string {
+  const override = env.OPENCLAW_SYSTEMD_UNIT?.trim();
+  if (override) {
+    return override.endsWith(".service") ? override : `${override}.service`;
   }
-  return rendered.join(" ");
-}
-
-function isSensitiveExecArgName(name: string): boolean {
-  if (SENSITIVE_EXEC_ARG_NAMES.has(name)) {
-    return true;
-  }
-  const normalized = normalizeLowercaseStringOrEmpty(name);
-  return (
-    normalized.includes("api-key") ||
-    normalized.includes("apikey") ||
-    normalized.includes("auth") ||
-    normalized.includes("password") ||
-    normalized.includes("secret") ||
-    normalized.includes("token")
-  );
-}
-
-function splitInlineArg(arg: string): [string, string | undefined] {
-  const index = arg.indexOf("=");
-  if (index <= 0) {
-    return [arg, undefined];
-  }
-  return [arg.slice(0, index), arg.slice(index + 1)];
-}
-
-function renderShellArg(arg: string): string {
-  if (/^[A-Za-z0-9_./:=@%+-]+$/u.test(arg)) {
-    return arg;
-  }
-  return JSON.stringify(arg);
+  return `${runtime.resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE)}.service`;
 }
 
 const MAX_FOLLOW_RETRIES = 8;
@@ -326,6 +331,9 @@ const FOLLOW_BACKOFF_POLICY = { initialMs: 1_000, maxMs: 30_000, factor: 2, jitt
 // Auth errors (4xxx), policy violations (1008), and pairing-required messages are
 // non-recoverable without user action and must not loop.
 function isTransientFollowError(error: unknown): boolean {
+  if (error instanceof JournalFallbackUnavailableError) {
+    return true;
+  }
   if (isGatewayTransportError(error)) {
     if (error.kind === "timeout") {
       return true;
@@ -493,7 +501,10 @@ export function registerLogsCli(program: Command) {
   logs.action(async (opts: LogsCliOptions) => {
     const { logLine, errorLine, emitJsonLine } = createLogWriters();
     const interval = parsePositiveInt(opts.interval, 1000);
-    let cursor: LogCursor | undefined;
+    let gatewayCursor: number | undefined;
+    let journalCursor: string | undefined;
+    let journalSince: string | undefined;
+    let forceJournal = false;
     let first = true;
     const jsonMode = Boolean(opts.json);
     const pretty = !jsonMode && process.stdout.isTTY && !opts.plain;
@@ -506,9 +517,17 @@ export function registerLogsCli(program: Command) {
       let payload: LogsTailPayload;
       // Show progress spinner only on first fetch, not during follow polling
       const showProgress = first && !opts.follow;
+      const gatewayPollStartedAt = new Date().toISOString();
       try {
-        payload = await fetchLogs(opts, cursor, showProgress);
+        payload = await fetchLogs(
+          opts,
+          { gateway: gatewayCursor, journal: journalCursor, journalSince, forceJournal },
+          showProgress,
+        );
       } catch (err) {
+        if (err instanceof JournalFallbackUnavailableError) {
+          forceJournal = false;
+        }
         if (opts.follow && followRetryAttempt < MAX_FOLLOW_RETRIES && isTransientFollowError(err)) {
           followRetryAttempt += 1;
           const backoffMs = computeBackoff(FOLLOW_BACKOFF_POLICY, followRetryAttempt);
@@ -614,10 +633,7 @@ export function registerLogsCli(program: Command) {
             ) {
               return;
             }
-            if (
-              payload.service?.execStart &&
-              !logLine(`Service ExecStart: ${payload.service.execStart}`)
-            ) {
+            if (payload.service?.unit && !logLine(`Service Unit: ${payload.service.unit}`)) {
               return;
             }
           } else if (payload.file) {
@@ -651,10 +667,19 @@ export function registerLogsCli(program: Command) {
           }
         }
       }
-      cursor =
-        typeof payload.cursor === "number" && Number.isFinite(payload.cursor)
-          ? payload.cursor
-          : cursor;
+      if (payload.sourceKind === "journal") {
+        forceJournal = true;
+        if (typeof payload.cursor === "string" && payload.cursor.trim().length > 0) {
+          journalCursor = payload.cursor;
+        }
+      } else if (typeof payload.cursor === "number" && Number.isFinite(payload.cursor)) {
+        gatewayCursor = payload.cursor;
+        if (opts.follow) {
+          journalSince = gatewayPollStartedAt;
+        }
+      } else if (typeof payload.cursor === "string" && payload.cursor.trim().length > 0) {
+        journalCursor = payload.cursor;
+      }
       first = false;
 
       if (!opts.follow) {

--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -6,6 +6,7 @@ import {
   type GatewayConnectionDetails,
 } from "../gateway/call.js";
 import { isLoopbackHost } from "../gateway/net.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../gateway/protocol/client-info.js";
 import { readConnectPairingRequiredMessage } from "../gateway/protocol/connect-error-details.js";
 import { computeBackoff } from "../infra/backoff.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -78,7 +79,7 @@ async function fetchLogs(
       "logs.tail",
       opts,
       { cursor, limit, maxBytes },
-      { progress: showProgress },
+      buildLogsTailGatewayExtra(opts, showProgress),
     );
     if (!payload || typeof payload !== "object") {
       throw new Error("Unexpected logs.tail response");
@@ -104,6 +105,9 @@ function normalizeErrorMessage(error: unknown): string {
 }
 
 function shouldUseLocalLogsFallback(opts: LogsCliOptions, error: unknown): boolean {
+  if (opts.follow) {
+    return false;
+  }
   if (!isLocalGatewayRpcUnavailableError(error)) {
     return false;
   }
@@ -114,6 +118,26 @@ function shouldUseLocalLogsFallback(opts: LogsCliOptions, error: unknown): boole
     ? error.connectionDetails
     : buildGatewayConnectionDetails();
   return isImplicitLoopbackGatewayConnection(connection);
+}
+
+function buildLogsTailGatewayExtra(opts: LogsCliOptions, showProgress: boolean) {
+  const base = { progress: showProgress };
+  if (!shouldUsePassiveLocalLogsClient(opts)) {
+    return base;
+  }
+  return {
+    ...base,
+    clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+    mode: GATEWAY_CLIENT_MODES.BACKEND,
+    deviceIdentity: null,
+  };
+}
+
+function shouldUsePassiveLocalLogsClient(opts: LogsCliOptions): boolean {
+  if (typeof opts.url === "string" && opts.url.trim().length > 0) {
+    return false;
+  }
+  return isImplicitLoopbackGatewayConnection(buildGatewayConnectionDetails());
 }
 
 function isImplicitLoopbackGatewayConnection(connection: GatewayConnectionDetails): boolean {

--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -34,13 +34,21 @@ async function loadLogsCliRuntime(): Promise<LogsCliRuntimeModule> {
 
 type LogsTailPayload = {
   file?: string;
-  cursor?: number;
+  source?: string;
+  sourceKind?: "file" | "journal";
+  service?: {
+    pid?: number;
+    execStart?: string;
+  };
+  cursor?: LogCursor;
   size?: number;
   lines?: string[];
   truncated?: boolean;
   reset?: boolean;
   localFallback?: boolean;
 };
+
+type LogCursor = number | string;
 
 type LogsCliOptions = {
   limit?: string;
@@ -58,6 +66,19 @@ type LogsCliOptions = {
 };
 
 const LOCAL_FALLBACK_NOTICE = "Local Gateway RPC unavailable; reading configured file log instead.";
+const JOURNAL_FALLBACK_NOTICE =
+  "Local Gateway RPC unavailable; reading active systemd gateway journal instead.";
+const JOURNAL_CURSOR_PREFIX = "-- cursor: ";
+const SENSITIVE_EXEC_ARG_NAMES = new Set([
+  "--api-key",
+  "--apikey",
+  "--auth",
+  "--client-secret",
+  "--key",
+  "--password",
+  "--secret",
+  "--token",
+]);
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {
   if (!value) {
@@ -69,16 +90,17 @@ function parsePositiveInt(value: string | undefined, fallback: number): number {
 
 async function fetchLogs(
   opts: LogsCliOptions,
-  cursor: number | undefined,
+  cursor: LogCursor | undefined,
   showProgress: boolean,
 ): Promise<LogsTailPayload> {
   const limit = parsePositiveInt(opts.limit, 200);
   const maxBytes = parsePositiveInt(opts.maxBytes, 250_000);
+  const gatewayCursor = typeof cursor === "number" ? cursor : undefined;
   try {
     const payload = await callGatewayFromCli(
       "logs.tail",
       opts,
-      { cursor, limit, maxBytes },
+      { cursor: gatewayCursor, limit, maxBytes },
       buildLogsTailGatewayExtra(opts, showProgress),
     );
     if (!payload || typeof payload !== "object") {
@@ -89,9 +111,17 @@ async function fetchLogs(
     if (!shouldUseLocalLogsFallback(opts, error)) {
       throw error;
     }
+    if (opts.follow) {
+      const journalPayload = await readSystemdJournalFallback({ cursor, limit, maxBytes });
+      if (journalPayload) {
+        return journalPayload;
+      }
+      throw error;
+    }
     // Match the Gateway logs.tail source when implicit local RPC is unavailable.
     return {
-      ...(await readConfiguredLogTail({ cursor, limit, maxBytes })),
+      ...(await readConfiguredLogTail({ cursor: gatewayCursor, limit, maxBytes })),
+      sourceKind: "file",
       localFallback: true,
     };
   }
@@ -105,9 +135,6 @@ function normalizeErrorMessage(error: unknown): string {
 }
 
 function shouldUseLocalLogsFallback(opts: LogsCliOptions, error: unknown): boolean {
-  if (opts.follow) {
-    return false;
-  }
   if (!isLocalGatewayRpcUnavailableError(error)) {
     return false;
   }
@@ -169,6 +196,126 @@ function isPlainGatewayRequestCloseError(message: string): boolean {
 
 function isPlainGatewayRequestTimeoutError(message: string): boolean {
   return /^gateway timeout after \d+ms\b/u.test(message);
+}
+
+async function readSystemdJournalFallback(params: {
+  cursor: LogCursor | undefined;
+  limit: number;
+  maxBytes: number;
+}): Promise<LogsTailPayload | null> {
+  if (process.platform !== "linux") {
+    return null;
+  }
+  const runtime = await loadLogsCliRuntime();
+  const service = await runtime.readSystemdServiceRuntime(process.env);
+  if (service.status !== "running" || typeof service.pid !== "number") {
+    return null;
+  }
+  const serviceCommand = await runtime.readSystemdServiceExecStart(process.env).catch(() => null);
+  const source = `journalctl --user _PID=${service.pid}`;
+  const args = [
+    "--user",
+    `_PID=${service.pid}`,
+    "--no-pager",
+    "--output=cat",
+    "--show-cursor",
+  ];
+  if (typeof params.cursor === "string" && params.cursor.trim().length > 0) {
+    args.push(`--after-cursor=${params.cursor}`);
+  } else {
+    args.push("-n", String(params.limit));
+  }
+  const result = await runtime.execFileUtf8("journalctl", args, {
+    env: process.env,
+    maxBuffer: Math.max(params.maxBytes * 2, 1024 * 1024),
+  });
+  if (result.code !== 0) {
+    return null;
+  }
+  const parsed = parseJournalctlOutput(result.stdout);
+  return {
+    source,
+    sourceKind: "journal",
+    service: {
+      pid: service.pid,
+      ...(serviceCommand
+        ? { execStart: formatServiceExecStart(serviceCommand.programArguments) }
+        : {}),
+    },
+    cursor: parsed.cursor ?? params.cursor,
+    lines: parsed.lines,
+    localFallback: true,
+  };
+}
+
+function parseJournalctlOutput(output: string): { lines: string[]; cursor?: string } {
+  const lines: string[] = [];
+  let cursor: string | undefined;
+  for (const rawLine of output.split(/\r?\n/u)) {
+    if (!rawLine) {
+      continue;
+    }
+    if (rawLine.startsWith(JOURNAL_CURSOR_PREFIX)) {
+      cursor = rawLine.slice(JOURNAL_CURSOR_PREFIX.length).trim() || cursor;
+      continue;
+    }
+    lines.push(rawLine);
+  }
+  return { lines, cursor };
+}
+
+function formatServiceExecStart(args: readonly string[]): string {
+  const rendered: string[] = [];
+  let redactNext = false;
+  for (const arg of args) {
+    if (redactNext) {
+      rendered.push("[redacted]");
+      redactNext = false;
+      continue;
+    }
+    const [name, value] = splitInlineArg(arg);
+    if (isSensitiveExecArgName(name)) {
+      if (value === undefined) {
+        rendered.push(name);
+        redactNext = true;
+      } else {
+        rendered.push(`${name}=[redacted]`);
+      }
+      continue;
+    }
+    rendered.push(renderShellArg(arg));
+  }
+  return rendered.join(" ");
+}
+
+function isSensitiveExecArgName(name: string): boolean {
+  if (SENSITIVE_EXEC_ARG_NAMES.has(name)) {
+    return true;
+  }
+  const normalized = normalizeLowercaseStringOrEmpty(name);
+  return (
+    normalized.includes("api-key") ||
+    normalized.includes("apikey") ||
+    normalized.includes("auth") ||
+    normalized.includes("password") ||
+    normalized.includes("secret") ||
+    normalized.includes("token")
+  );
+}
+
+function splitInlineArg(arg: string): [string, string | undefined] {
+  const index = arg.indexOf("=");
+  if (index <= 0) {
+    return [arg, undefined];
+  }
+  return [arg.slice(0, index), arg.slice(index + 1)];
+}
+
+function renderShellArg(arg: string): string {
+  if (/^[A-Za-z0-9_./:=@%+-]+$/u.test(arg)) {
+    return arg;
+  }
+  return JSON.stringify(arg);
 }
 
 const MAX_FOLLOW_RETRIES = 8;
@@ -346,7 +493,7 @@ export function registerLogsCli(program: Command) {
   logs.action(async (opts: LogsCliOptions) => {
     const { logLine, errorLine, emitJsonLine } = createLogWriters();
     const interval = parsePositiveInt(opts.interval, 1000);
-    let cursor: number | undefined;
+    let cursor: LogCursor | undefined;
     let first = true;
     const jsonMode = Boolean(opts.json);
     const pretty = !jsonMode && process.stdout.isTTY && !opts.plain;
@@ -405,6 +552,9 @@ export function registerLogsCli(program: Command) {
             !emitJsonLine({
               type: "meta",
               file: payload.file,
+              source: payload.source,
+              sourceKind: payload.sourceKind,
+              service: payload.service,
               cursor: payload.cursor,
               size: payload.size,
             })
@@ -445,15 +595,36 @@ export function registerLogsCli(program: Command) {
           }
         }
       } else {
-        if (first && payload.file && payload.localFallback === true) {
-          if (!errorLine(colorize(rich, theme.warn, LOCAL_FALLBACK_NOTICE))) {
+        if (first && payload.localFallback === true) {
+          const notice =
+            payload.sourceKind === "journal" ? JOURNAL_FALLBACK_NOTICE : LOCAL_FALLBACK_NOTICE;
+          if (!errorLine(colorize(rich, theme.warn, notice))) {
             return;
           }
         }
-        if (first && payload.file) {
-          const prefix = pretty ? colorize(rich, theme.muted, "Log file:") : "Log file:";
-          if (!logLine(`${prefix} ${payload.file}`)) {
-            return;
+        if (first) {
+          if (payload.sourceKind === "journal" && payload.source) {
+            const prefix = pretty ? colorize(rich, theme.muted, "Log source:") : "Log source:";
+            if (!logLine(`${prefix} ${payload.source}`)) {
+              return;
+            }
+            if (
+              payload.service?.pid !== undefined &&
+              !logLine(`Service PID: ${payload.service.pid}`)
+            ) {
+              return;
+            }
+            if (
+              payload.service?.execStart &&
+              !logLine(`Service ExecStart: ${payload.service.execStart}`)
+            ) {
+              return;
+            }
+          } else if (payload.file) {
+            const prefix = pretty ? colorize(rich, theme.muted, "Log file:") : "Log file:";
+            if (!logLine(`${prefix} ${payload.file}`)) {
+              return;
+            }
           }
         }
         for (const line of lines) {


### PR DESCRIPTION
Summary
- Use the passive backend Gateway client for implicit local `openclaw logs` reads so log viewing does not register or rewrite a paired device.
- Keep explicit `--url` targets on the existing CLI identity path.
- In `--follow`, avoid stale configured-file fallbacks; on Linux, use the active user-systemd Gateway journal by unit and PID when implicit local RPC is unavailable.
- Keep journal fallback output bounded, redacted, boot-scoped, line-limited, and on its own cursor domain.
- Update CLI/logging docs and changelog.

Verification
Behavior addressed: `openclaw logs --follow` no longer mutates paired-device state for implicit local reads and no longer follows stale configured-file fallback logs after live local RPC failures.
Real environment tested: AWS Crabbox Linux c7a.8xlarge.
Exact steps or command run after this patch: `git diff --check`; `AUTOREVIEW_AUTO_TESTS=0 AUTOREVIEW_OPENCLAW_MAINTAINER_VALIDATION=1 .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`; `node scripts/crabbox-wrapper.mjs run --no-hydrate --shell -- "pnpm test:serial src/cli/logs-cli.test.ts"`; `node scripts/crabbox-wrapper.mjs run --fresh-pr openclaw/openclaw#85380 --no-hydrate --shell -- "pnpm check:changed"`.
Evidence after fix: autoreview clean; focused AWS run `run_691721a0d6ca` / lease `cbx_9161e75595d8` passed `src/cli/logs-cli.test.ts` with 25 tests; fresh-PR AWS run `run_0121df014dbf` / lease `cbx_8f88323c0809` passed `pnpm check:changed`.
Observed result after fix: implicit local logs use the passive backend client without a device identity; follow-mode local RPC failures use the bounded/redacted active systemd journal path when available and do not tail configured files.
What was not tested: a live side-by-side cutover host with a real managed Gateway service producing systemd journal entries.

Fixes #83656
Fixes #66841
