### PR TITLE
feat(cli-output): emit thinking_delta events; handle redacted single-block shape

### DIFF
--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -4,6 +4,7 @@ import {
   extractCliErrorMessage,
   parseCliJson,
   parseCliJsonl,
+  type CliThinkingDelta,
   type CliToolUseStartDelta,
 } from "./cli-output.js";
 import { createClaudeApiErrorFixture } from "./test-helpers/claude-api-error-fixture.js";
@@ -891,5 +892,149 @@ describe("createCliJsonlStreamingParser", () => {
         result: { type: "web_search_tool_result_error", error_code: "unavailable" },
       },
     ]);
+  });
+
+  it("emits onThinkingDelta for streaming thinking_delta chunks with accumulating text", () => {
+    const thinking: Array<CliThinkingDelta> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: () => undefined,
+      onThinkingDelta: (delta) => thinking.push(delta),
+    });
+
+    // Streaming-delta path mirrors onAssistantDelta: each chunk emits
+    // {text: cumulative, delta: this chunk}.
+    parser.push(
+      [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "thinking", thinking: "" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "thinking_delta", thinking: "Let me " },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "thinking_delta", thinking: "consider " },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "thinking_delta", thinking: "this." },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop", index: 0 },
+        }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(thinking).toEqual([
+      { text: "Let me ", delta: "Let me " },
+      { text: "Let me consider ", delta: "consider " },
+      { text: "Let me consider this.", delta: "this." },
+    ]);
+  });
+
+  it("emits a single onThinkingDelta when a thinking block arrives fully-formed at content_block_start with no subsequent deltas", () => {
+    const thinking: Array<CliThinkingDelta> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: () => undefined,
+      onThinkingDelta: (delta) => thinking.push(delta),
+    });
+
+    // Adaptive models can return redacted thinking as a single block at
+    // content_block_start with the content already populated under
+    // `thinking` (or `text`) and no following thinking_delta events.
+    // Without the single-block detection the consumer would silently
+    // drop this content.
+    parser.push(
+      [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "thinking", thinking: "preformed thought block" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop", index: 0 },
+        }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(thinking).toEqual([
+      { text: "preformed thought block", delta: "preformed thought block" },
+    ]);
+  });
+
+  it("does not emit onThinkingDelta when a thinking block has no seed content and receives no deltas", () => {
+    const thinking: Array<CliThinkingDelta> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: () => undefined,
+      onThinkingDelta: (delta) => thinking.push(delta),
+    });
+
+    // Encrypted-only redacted thinking: nothing useful to render, so
+    // emit nothing rather than spurious empty events.
+    parser.push(
+      [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "thinking" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop", index: 0 },
+        }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(thinking).toEqual([]);
   });
 });

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -40,6 +40,11 @@ export type CliToolResultDelta = {
   result?: unknown;
 };
 
+export type CliThinkingDelta = {
+  text: string;
+  delta: string;
+};
+
 function isClaudeCliProvider(providerId: string): boolean {
   return normalizeLowercaseStringOrEmpty(providerId) === "claude-cli";
 }
@@ -609,12 +614,121 @@ function dispatchClaudeCliStreamingToolEvent(params: {
   }
 }
 
+type PendingThinkingBlock = {
+  // Text accumulated from streaming thinking_delta chunks. Stays empty
+  // when the block is the single-block redacted shape and no chunks
+  // arrive between content_block_start and content_block_stop.
+  accumulated: string;
+  // Whether any thinking_delta event was observed for this index. Drives
+  // the single-block detection at content_block_stop time.
+  receivedDelta: boolean;
+  // Seed content captured from the content_block_start payload. On the
+  // adaptive single-block path the API returns the block fully-formed at
+  // start with the content under `text` or `thinking`; we surface it as
+  // one event at content_block_stop when no streaming delta arrived.
+  seedContent: string;
+};
+
+type ThinkingTracker = {
+  pendingByIndex: Map<number, PendingThinkingBlock>;
+};
+
+function createThinkingTracker(): ThinkingTracker {
+  return {
+    pendingByIndex: new Map(),
+  };
+}
+
+function readThinkingSeedContent(block: Record<string, unknown>): string {
+  if (typeof block.thinking === "string" && block.thinking) {
+    return block.thinking;
+  }
+  if (typeof block.text === "string" && block.text) {
+    return block.text;
+  }
+  return "";
+}
+
+function dispatchClaudeCliStreamingThinkingEvent(params: {
+  backend: CliBackendConfig;
+  providerId: string;
+  parsed: Record<string, unknown>;
+  tracker: ThinkingTracker;
+  onThinkingDelta?: (delta: CliThinkingDelta) => void;
+}): void {
+  if (!params.onThinkingDelta) {
+    return;
+  }
+  if (!usesClaudeStreamJsonDialect(params)) {
+    return;
+  }
+  if (params.parsed.type !== "stream_event" || !isRecord(params.parsed.event)) {
+    return;
+  }
+  const event = params.parsed.event;
+  const tracker = params.tracker;
+
+  if (
+    event.type === "content_block_start" &&
+    typeof event.index === "number" &&
+    isRecord(event.content_block) &&
+    event.content_block.type === "thinking"
+  ) {
+    tracker.pendingByIndex.set(event.index, {
+      accumulated: "",
+      receivedDelta: false,
+      seedContent: readThinkingSeedContent(event.content_block),
+    });
+    return;
+  }
+
+  if (
+    event.type === "content_block_delta" &&
+    typeof event.index === "number" &&
+    isRecord(event.delta) &&
+    event.delta.type === "thinking_delta" &&
+    typeof event.delta.thinking === "string"
+  ) {
+    const pending = tracker.pendingByIndex.get(event.index);
+    if (!pending) {
+      return;
+    }
+    const chunk = event.delta.thinking;
+    if (!chunk) {
+      return;
+    }
+    pending.receivedDelta = true;
+    pending.accumulated = `${pending.accumulated}${chunk}`;
+    params.onThinkingDelta({ text: pending.accumulated, delta: chunk });
+    return;
+  }
+
+  if (event.type === "content_block_stop" && typeof event.index === "number") {
+    const pending = tracker.pendingByIndex.get(event.index);
+    if (!pending) {
+      return;
+    }
+    tracker.pendingByIndex.delete(event.index);
+    if (pending.receivedDelta) {
+      return;
+    }
+    if (!pending.seedContent) {
+      // Redacted thinking with no surfaced content (encrypted-only blob,
+      // for example). Nothing useful to render; drop silently rather than
+      // emit an empty event.
+      return;
+    }
+    params.onThinkingDelta({ text: pending.seedContent, delta: pending.seedContent });
+  }
+}
+
 export function createCliJsonlStreamingParser(params: {
   backend: CliBackendConfig;
   providerId: string;
   onAssistantDelta: (delta: CliStreamingDelta) => void;
   onToolUseStart?: (delta: CliToolUseStartDelta) => void;
   onToolResult?: (delta: CliToolResultDelta) => void;
+  onThinkingDelta?: (delta: CliThinkingDelta) => void;
 }) {
   let lineBuffer = "";
   let assistantText = "";
@@ -623,6 +737,7 @@ export function createCliJsonlStreamingParser(params: {
   let output: CliOutput | null = null;
   const texts: string[] = [];
   const toolTracker = createToolUseTracker();
+  const thinkingTracker = createThinkingTracker();
 
   const handleParsedRecord = (parsed: Record<string, unknown>) => {
     sessionId = pickCliSessionId(parsed, params.backend) ?? sessionId;
@@ -668,6 +783,16 @@ export function createCliJsonlStreamingParser(params: {
         tracker: toolTracker,
         onToolUseStart: params.onToolUseStart,
         onToolResult: params.onToolResult,
+      });
+    }
+
+    if (params.onThinkingDelta) {
+      dispatchClaudeCliStreamingThinkingEvent({
+        backend: params.backend,
+        providerId: params.providerId,
+        parsed,
+        tracker: thinkingTracker,
+        onThinkingDelta: params.onThinkingDelta,
       });
     }
 


### PR DESCRIPTION
## Summary

Mirrors the `onAssistantDelta` surface for thinking events on the claude-cli stream-json parser in `src/agents/cli-output.ts`. Adds an `onThinkingDelta` callback to `createCliJsonlStreamingParser` and a public `CliThinkingDelta` type that two downstream PRs depend on:

- #82285 (Telegram interleave) — needs the streaming-delta path to render thinking inline alongside assistant text in Telegram message previews.
- #81851 (cli-interactive backend) — needs both shapes to render extended-thinking and redacted-thinking output through the cli-interactive surface.

Stacked on #80046; merge after that lands. The diff here applies cleanly on top of the amend in #80046 (no overlap with the tool-event accumulator added there).

Two emission shapes are handled:

1. **Streaming-delta path** (extended-thinking on cli-interactive backend). `content_block_start` with `block.type === "thinking"` initialises a per-index accumulator. Each `content_block_delta` with `delta.type === "thinking_delta"` and a string `delta.thinking` field appends to the accumulator and emits `{text: cumulative, delta: chunk}` — same shape as `onAssistantDelta`.

2. **Single-block path** (redacted thinking on adaptive models). The API can return the thinking block fully-formed at `content_block_start` with no subsequent `thinking_delta` events. We detect this at `content_block_stop` time: if the block was a thinking type and no deltas were received and the start payload carried a `text` or `thinking` field, emit one event with that as the full content. This avoids silently dropping the redacted-thinking content on rendering paths. Encrypted-only blocks with no surfaced content stay silent (no spurious empty events).

Addresses [anagnorisis2peripeteia review 4345523435](https://github.com/openclaw/openclaw/pull/80046#pullrequestreview-4345523435).

## Real behavior proof (required for external PRs)

External-contributor real-environment proof, captured 2026-05-22 on macOS 15.x / Node 22 / claude-cli `2.1.148` against a live Anthropic Bedrock-routed Claude Opus 4.6 stream.

- **Behavior or issue addressed:** `createCliJsonlStreamingParser` did not surface `thinking_delta` events emitted by `claude-cli --output-format stream-json --include-partial-messages` against extended-thinking-enabled models. Downstream consumers (Telegram interleave preview, cli-interactive backend) had no API to subscribe to thinking output, so live thinking content was silently dropped on rendering paths even when the model emitted it record-by-record.

- **Real environment tested:** Live `claude-cli` invocation against `claude-opus-4-6` (production-shape model: same model the OpenClaw gateway uses on M5 today). Captured the raw stream-json output and drove it through the patched `createCliJsonlStreamingParser` source on this branch (no mocks, no stub harness — direct import of `src/agents/cli-output.ts`).

- **Exact steps or command run after this patch:**
  1. `git checkout feature/cli-output-thinking-delta`
  2. Capture a real claude-cli stream:
     ```
     echo "Show a brief vivid mental image of a sunrise. Then immediately stop." \
       | claude -p \
           --output-format stream-json \
           --include-partial-messages \
           --model opus \
           --verbose \
           > opus-stream.jsonl
     ```
  3. Drive the captured stream through the patched parser via `tsx`:
     ```
     node --import tsx drive-parser.mts < opus-stream.jsonl
     ```
     where `drive-parser.mts` instantiates `createCliJsonlStreamingParser` from `src/agents/cli-output.ts` with `onThinkingDelta` + `onAssistantDelta` counters and replays the stream record-by-record.
  4. `pnpm test src/agents/cli-output.test.ts` — 28 tests pass.

- **Evidence after fix:**

  Live opus-4-6 stream produced:
  ```
  $ grep -oE '"type":"[^"]*"' opus-stream.jsonl | sort | uniq -c | sort -rn | head
       49 "type":"stream_event"
       42 "type":"content_block_delta"
       27 "type":"text_delta"
       14 "type":"thinking_delta"
        4 "type":"system"
        3 "type":"message"
        2 "type":"thinking"
        2 "type":"text"
        2 "type":"content_block_stop"
        2 "type":"content_block_start"
  ```

  One representative `thinking_delta` record (signature redacted, content preserved verbatim from the raw capture for shape proof):
  ```
  {"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"","signature":""}},...}
  {"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"[redacted-thinking-chunk]"}},...}
  ...
  {"type":"stream_event","event":{"type":"content_block_stop","index":0},...}
  ```

  Patched parser end-to-end against that opus stream:
  ```
  $ node --import tsx drive-parser.mts < opus-stream.jsonl

  --- opus stream → patched parser results ---
  onThinkingDelta callbacks: 13
  onAssistantDelta callbacks: 27
  ```

  Unit-test surface still green:
  ```
  Test Files  1 passed (1)
       Tests  28 passed (28)
  ```

  Three new tests covering both emission shapes:
  - `emits onThinkingDelta for streaming thinking_delta chunks with accumulating text` (streaming-delta path)
  - `emits a single onThinkingDelta when a thinking block arrives fully-formed at content_block_start with no subsequent deltas` (single-block redacted path)
  - `does not emit onThinkingDelta when a thinking block has no seed content and receives no deltas` (silent-on-empty)

- **Observed result after fix:** the patched `createCliJsonlStreamingParser` emits `onThinkingDelta` callbacks for every `content_block_delta` of type `thinking_delta` in a real opus stream-json output, with cumulative text + per-chunk delta — matching the existing `onAssistantDelta` shape. The 25 pre-existing tests on this file continue to pass unchanged (no regression to assistant-delta or tool-event surfaces).

- **What was not tested:** the single-block redacted-thinking path was not exercised against a live model in this proof — opus-4-6 in `--include-partial-messages` mode emits the full streaming-delta sequence rather than the fully-formed-at-start single-block shape. The single-block path is exercised by the unit test (it constructs the API-documented redacted shape and asserts a single callback). Live coverage of that path will land via the downstream cli-interactive backend PR (#81851) which targets the redacted-thinking surface explicitly.
