### PR TITLE
fix(gateway): preserve OpenAI usage aliases in chat history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 - Skills: watch each shared skill directory once across agent workspaces instead of once per agent, preventing file-descriptor exhaustion (`EMFILE`) that disposed bundle-mcp processes and stalled sessions on multi-agent gateways. Fixes #84968. (#85130) Thanks @openperf.
 - Cron: honor `cron.retry.retryOn: ["network"]` for common network error codes such as `EAI_AGAIN`, `EHOSTUNREACH`, and `ENETUNREACH`.
 - Gateway chat: broadcast returned agent-run error payloads after an agent starts so ACP/WebChat clients receive terminal idle-timeout errors. Fixes #84945.
+- Gateway chat display: preserve OpenAI-compatible `prompt_tokens`, `completion_tokens`, and `total_tokens` usage fields in sanitized chat history so llama.cpp sessions keep context counts. Fixes #77992. Thanks @MarTT79.
 - Dashboard/CLI: allow macOS browser launching through `open` even when SSH environment variables are present, while preserving Linux SSH no-display protection. Fixes #67088. Thanks @theglove44.
 - Codex app-server: keep native web search observations out of mirrored chat transcripts while preserving tool progress telemetry. Fixes #85109. Thanks @ugitmebaby.
 - Agents/OpenAI: preserve structured provider error code, type, and redacted body metadata on boundary-aware transport failures.

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -228,13 +228,21 @@ function sanitizeUsage(raw: unknown): Record<string, number> | undefined {
   const knownFields = [
     "input",
     "output",
+    "total",
     "totalTokens",
     "inputTokens",
     "outputTokens",
+    "promptTokens",
+    "completionTokens",
     "cacheRead",
     "cacheWrite",
     "cache_read_input_tokens",
     "cache_creation_input_tokens",
+    "input_tokens",
+    "output_tokens",
+    "prompt_tokens",
+    "completion_tokens",
+    "total_tokens",
   ];
 
   for (const k of knownFields) {

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -530,6 +530,35 @@ describe("sanitizeChatHistoryMessages", () => {
     ]);
   });
 
+  it("preserves OpenAI-compatible assistant usage aliases for display context", () => {
+    const result = sanitizeChatHistoryMessages([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "done" }],
+        usage: {
+          prompt_tokens: 11,
+          completion_tokens: 1,
+          total_tokens: 12,
+          provider_payload: "discard",
+        },
+        timestamp: 1,
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "done" }],
+        usage: {
+          prompt_tokens: 11,
+          completion_tokens: 1,
+          total_tokens: 12,
+        },
+        timestamp: 1,
+      },
+    ]);
+  });
+
   it("drops commentary-only assistant entries when phase exists only in textSignature", () => {
     const result = sanitizeChatHistoryMessages([
       {


### PR DESCRIPTION
Summary
- preserve OpenAI-compatible assistant usage aliases through sanitized chat history
- add regression coverage for `prompt_tokens`, `completion_tokens`, and `total_tokens`
- keep unrelated provider payload fields stripped from the display projection

Fixes #77992.

Verification
- `/Users/steipete/.local/share/fnm/node-versions/v24.13.0/installation/bin/node ./node_modules/.bin/tsx -e "...sanitizeChatHistoryMessages usage alias assertion..."`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Behavior addressed: llama.cpp/OpenAI-compatible usage metadata no longer loses `prompt_tokens`, `completion_tokens`, and `total_tokens` before chat/session display code can compute context usage.
Real environment tested: local OpenClaw checkout on Node 24.13.0 with the gateway chat display sanitizer executed directly; GitHub CI will run the full repository gates.
Exact steps or command run after this patch: direct Node 24 `tsx` assertion for `sanitizeChatHistoryMessages`, `git diff --check`, and Codex autoreview local mode.
Evidence after fix: the direct assertion verified sanitized assistant history preserves the three OpenAI-compatible numeric usage fields and still discards an unrelated provider payload field.
Observed result after fix: direct assertion printed `usage aliases ok`; autoreview reported no accepted/actionable findings.
What was not tested: a live llama.cpp server; this patch covers the deterministic projection path that was dropping the reported usage fields.
