### PR TITLE
fix(ui): prefer source replies in realtime talk consult

### DIFF
--- a/ui/src/ui/chat/realtime-talk-shared.ts
+++ b/ui/src/ui/chat/realtime-talk-shared.ts
@@ -187,6 +187,12 @@ type ChatPayload = {
   message?: unknown;
 };
 
+type AgentPayload = {
+  runId?: string;
+  stream?: string;
+  data?: unknown;
+};
+
 function extractTextFromMessage(message: unknown): string {
   if (!message || typeof message !== "object") {
     return "";
@@ -206,6 +212,46 @@ function extractTextFromMessage(message: unknown): string {
     })
     .filter(Boolean);
   return parts.join("\n\n").trim();
+}
+
+function extractCanonicalSourceReplyText(value: unknown): string {
+  if (typeof value === "string") {
+    try {
+      return extractCanonicalSourceReplyText(JSON.parse(value));
+    } catch {
+      return "";
+    }
+  }
+  if (!value || typeof value !== "object") {
+    return "";
+  }
+  const record = value as Record<string, unknown>;
+  const sourceReply = record.sourceReply;
+  if (sourceReply && typeof sourceReply === "object") {
+    const sourceReplyText = extractTextFromMessage(sourceReply);
+    if (sourceReplyText) {
+      return sourceReplyText;
+    }
+  }
+  const payload = record.payload;
+  if (payload && typeof payload === "object") {
+    const payloadText = extractCanonicalSourceReplyText(payload);
+    if (payloadText) {
+      return payloadText;
+    }
+  }
+  const result = record.result;
+  if (result !== undefined) {
+    return extractCanonicalSourceReplyText(result);
+  }
+  return "";
+}
+
+function extractTalkCanonicalTextFromAgentPayload(payload: AgentPayload | undefined): string {
+  if (!payload || payload.stream !== "tool") {
+    return "";
+  }
+  return extractCanonicalSourceReplyText(payload.data);
 }
 
 function waitForChatResult(params: {
@@ -229,7 +275,19 @@ function waitForChatResult(params: {
     };
     params.signal?.addEventListener("abort", onAbort, { once: true });
     let unsubscribe: () => void = () => undefined;
+    let canonicalSourceReplyText = "";
     unsubscribe = params.client.addEventListener((evt: GatewayEventFrame) => {
+      if (evt.event === "agent") {
+        const payload = evt.payload as AgentPayload | undefined;
+        if (payload?.runId !== params.runId) {
+          return;
+        }
+        const sourceReplyText = extractTalkCanonicalTextFromAgentPayload(payload);
+        if (sourceReplyText) {
+          canonicalSourceReplyText = sourceReplyText;
+        }
+        return;
+      }
       if (evt.event !== "chat") {
         return;
       }
@@ -239,7 +297,11 @@ function waitForChatResult(params: {
       }
       if (payload.state === "final") {
         cleanup();
-        resolve(extractTextFromMessage(payload.message) || "OpenClaw finished with no text.");
+        resolve(
+          canonicalSourceReplyText ||
+            extractTextFromMessage(payload.message) ||
+            "OpenClaw finished with no text.",
+        );
       } else if (payload.state === "aborted") {
         cleanup();
         reject(

--- a/ui/src/ui/realtime-talk-consult.test.ts
+++ b/ui/src/ui/realtime-talk-consult.test.ts
@@ -58,4 +58,64 @@ describe("RealtimeTalkSession consult handoff", () => {
     expect(toolCall?.[1]?.args).toEqual({ question: "Are the basement lights off?" });
     expect(submit).toHaveBeenCalledWith("call-1", { result: "Basement lights are off." });
   });
+
+  it("speaks the internal source reply when message-tool-only delivery mirrors the visible answer", async () => {
+    let listener: ((event: { event: string; payload?: unknown }) => void) | undefined;
+    const request = vi.fn(async (method: string, _params: unknown) => {
+      if (method === "talk.client.toolCall") {
+        setImmediate(() => {
+          listener?.({
+            event: "agent",
+            payload: {
+              runId: "run-message-tool",
+              stream: "tool",
+              data: {
+                phase: "end",
+                result: {
+                  kind: "send",
+                  payload: {
+                    sourceReplyDeliveryMode: "message_tool_only",
+                    sourceReplySink: "internal-ui",
+                    sourceReply: { text: "The tool-backed status is green." },
+                  },
+                },
+              },
+            },
+          });
+          listener?.({
+            event: "chat",
+            payload: {
+              runId: "run-message-tool",
+              state: "final",
+              message: { text: "I could not get that information." },
+            },
+          });
+        });
+        return { runId: "run-message-tool" };
+      }
+      throw new Error(`unexpected request: ${method}`);
+    });
+    const addEventListener = vi.fn((callback: typeof listener) => {
+      listener = callback;
+      return () => {
+        listener = undefined;
+      };
+    });
+    const submit = vi.fn();
+
+    await submitRealtimeTalkConsult({
+      ctx: {
+        client: { request, addEventListener },
+        sessionKey: "agent:main:main",
+        callbacks: {},
+      } as never,
+      callId: "call-message-tool",
+      args: { question: "Check the status" },
+      submit,
+    });
+
+    expect(submit).toHaveBeenCalledWith("call-message-tool", {
+      result: "The tool-backed status is green.",
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Fixes #85275.
- Makes realtime talk consults capture same-run agent tool events and prefer the canonical internal `sourceReply` text when message-tool-only delivery mirrors the visible answer.
- Adds a regression test so stale/fallback final chat text is not submitted to the voice consult when the source reply contains the actual answer.

## Tests
- `node scripts/run-vitest.mjs ui/src/ui/realtime-talk-consult.test.ts`
- `git diff --check`
- `node --import tsx --input-type=module <<'EOF' ... EOF` runtime proof below

## Real behavior proof
Behavior addressed: Realtime talk consults should speak/submit the visible internal source reply produced by `sourceReplyDeliveryMode: "message_tool_only"` instead of stale final chat text.

Real environment tested: Local OpenClaw checkout on macOS with the UI realtime talk consult module executed through Node + tsx against a Gateway-browser-client-shaped runtime stub.

Exact steps or command run after this patch: Ran this after applying the patch:
```sh
node --import tsx --input-type=module <<'EOF'
globalThis.window = { setTimeout, clearTimeout };
const { submitRealtimeTalkConsult } = await import('./ui/src/ui/chat/realtime-talk-shared.ts');
let listener;
const submitted = [];
const client = {
  async request(method, params) {
    if (method !== 'talk.client.toolCall') throw new Error(`unexpected ${method}`);
    setTimeout(() => {
      listener?.({ event: 'agent', payload: { runId: 'runtime-proof-run', stream: 'tool', data: { result: { payload: { sourceReplyDeliveryMode: 'message_tool_only', sourceReplySink: 'internal-ui', sourceReply: { text: 'VISIBLE_CANONICAL_REPLY' } } } } } });
      listener?.({ event: 'chat', payload: { runId: 'runtime-proof-run', state: 'final', message: { text: 'STALE_SPOKEN_FALLBACK' } } });
    }, 0);
    return { runId: 'runtime-proof-run' };
  },
  addEventListener(callback) {
    listener = callback;
    return () => { listener = undefined; };
  },
};
await submitRealtimeTalkConsult({
  ctx: { client, sessionKey: 'agent:main:main', callbacks: {} },
  args: { question: 'proof' },
  submit: (callId, result) => submitted.push([callId, result]),
  callId: 'runtime-proof-call',
});
console.log(JSON.stringify(submitted));
if (submitted[0]?.[1]?.result !== 'VISIBLE_CANONICAL_REPLY') {
  throw new Error('Talk consult did not prefer canonical source reply');
}
EOF
```

Evidence after fix: Terminal stdout from the runtime command:
```text
[["runtime-proof-call",{"result":"VISIBLE_CANONICAL_REPLY"}]]
```

Observed result after fix: The consult submitted `VISIBLE_CANONICAL_REPLY` from the internal source reply even though the final chat message carried `STALE_SPOKEN_FALLBACK`.

What was not tested: No microphone/audio device or full browser UI session was exercised; this patch only changes the consult handoff text selection path.
