### PR TITLE
fix(cli): default logs to local timestamps

### DIFF
--- a/docs/cli/logs.md
+++ b/docs/cli/logs.md
@@ -24,7 +24,8 @@ Related:
 - `--json`: emit line-delimited JSON events
 - `--plain`: plain text output without styled formatting
 - `--no-color`: disable ANSI colors
-- `--local-time`: render timestamps in your local timezone
+- `--local-time`: render timestamps in your local timezone (default)
+- `--utc`: render timestamps in UTC
 
 ## Shared Gateway RPC options
 
@@ -49,13 +50,14 @@ openclaw logs --plain
 openclaw logs --no-color
 openclaw logs --limit 500
 openclaw logs --local-time
+openclaw logs --utc
 openclaw logs --follow --local-time
 openclaw logs --url ws://127.0.0.1:18789 --token "$OPENCLAW_GATEWAY_TOKEN"
 ```
 
 ## Notes
 
-- Use `--local-time` to render timestamps in your local timezone.
+- Timestamps render in your local timezone by default. Use `--utc` for UTC output.
 - If the implicit local loopback Gateway asks for pairing, closes during connect, or times out before `logs.tail` answers, `openclaw logs` falls back to the configured Gateway file log automatically. Explicit `--url` targets do not use this fallback.
 - `openclaw logs --follow` does not follow configured-file fallbacks after implicit local Gateway RPC failures. On Linux, it uses the active user-systemd Gateway journal by PID when available and prints the selected log source; otherwise it keeps retrying the live Gateway instead of tailing a potentially stale side-by-side file.
 - When using `--follow`, transient gateway disconnects (WebSocket close, timeout, connection drop) trigger automatic reconnection with exponential backoff (up to 8 retries, capped at 30 s between attempts). A warning is printed to stderr on each retry, and a `[logs] gateway reconnected` notice is printed once a poll succeeds. In `--json` mode both the retry warning and the reconnect transition are emitted as `{"type":"notice"}` records on stderr. Non-recoverable errors (auth failure, bad configuration) still exit immediately.

--- a/src/cli/logs-cli.test.ts
+++ b/src/cli/logs-cli.test.ts
@@ -120,6 +120,20 @@ function captureStderrWrites() {
   return writes;
 }
 
+async function withTimeZone<T>(timeZone: string, run: () => Promise<T> | T): Promise<T> {
+  const previous = process.env.TZ;
+  process.env.TZ = timeZone;
+  try {
+    return await run();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.TZ;
+    } else {
+      process.env.TZ = previous;
+    }
+  }
+}
+
 describe("logs cli", () => {
   beforeEach(() => {
     readSystemdServiceRuntime.mockResolvedValue({ status: "stopped" });
@@ -197,29 +211,73 @@ describe("logs cli", () => {
     );
   });
 
-  it("wires --local-time through CLI parsing and emits local timestamps", async () => {
-    callGatewayFromCli.mockResolvedValueOnce({
-      file: "/tmp/openclaw.log",
-      lines: [
-        JSON.stringify({
-          time: "2025-01-01T12:00:00.000Z",
-          _meta: { logLevelName: "INFO", name: JSON.stringify({ subsystem: "gateway" }) },
-          0: "line one",
-        }),
-      ],
+  it("emits local timestamps by default", async () => {
+    await withTimeZone("America/New_York", async () => {
+      callGatewayFromCli.mockResolvedValueOnce({
+        file: "/tmp/openclaw.log",
+        lines: [
+          JSON.stringify({
+            time: "2025-01-01T12:00:00.000Z",
+            _meta: { logLevelName: "INFO", name: JSON.stringify({ subsystem: "gateway" }) },
+            0: "line one",
+          }),
+        ],
+      });
+
+      const stdoutWrites = captureStdoutWrites();
+
+      await runLogsCli(["logs", "--plain"]);
+
+      const output = stdoutWrites.join("");
+      expect(output).toContain("line one");
+      expect(output).toContain("2025-01-01T07:00:00.000-05:00");
     });
+  });
 
-    const stdoutWrites = captureStdoutWrites();
+  it("keeps --local-time accepted as the compatibility spelling", async () => {
+    await withTimeZone("America/New_York", async () => {
+      callGatewayFromCli.mockResolvedValueOnce({
+        file: "/tmp/openclaw.log",
+        lines: [
+          JSON.stringify({
+            time: "2025-01-01T12:00:00.000Z",
+            _meta: { logLevelName: "INFO", name: JSON.stringify({ subsystem: "gateway" }) },
+            0: "line one",
+          }),
+        ],
+      });
 
-    await runLogsCli(["logs", "--local-time", "--plain"]);
+      const stdoutWrites = captureStdoutWrites();
 
-    const output = stdoutWrites.join("");
-    expect(output).toContain("line one");
-    const timestamp = output.match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z?/u)?.[0];
-    if (timestamp === undefined) {
-      throw new Error("expected local timestamp in logs output");
-    }
-    expect(timestamp.endsWith("Z")).toBe(false);
+      await runLogsCli(["logs", "--local-time", "--plain"]);
+
+      const output = stdoutWrites.join("");
+      expect(output).toContain("line one");
+      expect(output).toContain("2025-01-01T07:00:00.000-05:00");
+    });
+  });
+
+  it("wires --utc through CLI parsing and emits UTC timestamps", async () => {
+    await withTimeZone("America/New_York", async () => {
+      callGatewayFromCli.mockResolvedValueOnce({
+        file: "/tmp/openclaw.log",
+        lines: [
+          JSON.stringify({
+            time: "2025-01-01T12:00:00.000Z",
+            _meta: { logLevelName: "INFO", name: JSON.stringify({ subsystem: "gateway" }) },
+            0: "line one",
+          }),
+        ],
+      });
+
+      const stdoutWrites = captureStdoutWrites();
+
+      await runLogsCli(["logs", "--utc", "--plain"]);
+
+      const output = stdoutWrites.join("");
+      expect(output).toContain("line one");
+      expect(output).toContain("2025-01-01T12:00:00.000Z");
+    });
   });
 
   it("warns when the output pipe closes", async () => {
@@ -632,30 +690,42 @@ describe("logs cli", () => {
   });
 
   describe("formatLogTimestamp", () => {
-    it("formats UTC timestamp in plain mode by default", () => {
-      const result = formatLogTimestamp("2025-01-01T12:00:00.000Z");
+    it("formats local timestamp in plain mode by default", async () => {
+      await withTimeZone("America/New_York", () => {
+        const result = formatLogTimestamp("2025-01-01T12:00:00.000Z");
+        expect(result).toBe("2025-01-01T07:00:00.000-05:00");
+      });
+    });
+
+    it("formats local timestamp in pretty mode by default", async () => {
+      await withTimeZone("America/New_York", () => {
+        const result = formatLogTimestamp("2025-01-01T12:00:00.000Z", "pretty");
+        expect(result).toBe("07:00:00-05:00");
+      });
+    });
+
+    it("formats UTC timestamp in plain mode when localTime is false", () => {
+      const result = formatLogTimestamp("2025-01-01T12:00:00.000Z", "plain", false);
       expect(result).toBe("2025-01-01T12:00:00.000Z");
     });
 
-    it("formats UTC timestamp in pretty mode", () => {
-      const result = formatLogTimestamp("2025-01-01T12:00:00.000Z", "pretty");
+    it("formats UTC timestamp in pretty mode when localTime is false", () => {
+      const result = formatLogTimestamp("2025-01-01T12:00:00.000Z", "pretty", false);
       expect(result).toBe("12:00:00+00:00");
     });
 
-    it("formats local time in plain mode when localTime is true", () => {
-      const utcTime = "2025-01-01T12:00:00.000Z";
-      const result = formatLogTimestamp(utcTime, "plain", true);
-      // Should be local time with explicit timezone offset (not 'Z' suffix).
-      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2}$/);
-      // The exact time depends on timezone, but should be different from UTC
-      expect(result).not.toBe(utcTime);
+    it("formats local time in plain mode when localTime is true", async () => {
+      await withTimeZone("America/New_York", () => {
+        const result = formatLogTimestamp("2025-01-01T12:00:00.000Z", "plain", true);
+        expect(result).toBe("2025-01-01T07:00:00.000-05:00");
+      });
     });
 
-    it("formats local time in pretty mode when localTime is true", () => {
-      const utcTime = "2025-01-01T12:00:00.000Z";
-      const result = formatLogTimestamp(utcTime, "pretty", true);
-      // Should be HH:MM:SS±HH:MM format with timezone offset.
-      expect(result).toMatch(/^\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/);
+    it("formats local time in pretty mode when localTime is true", async () => {
+      await withTimeZone("America/New_York", () => {
+        const result = formatLogTimestamp("2025-01-01T12:00:00.000Z", "pretty", true);
+        expect(result).toBe("07:00:00-05:00");
+      });
     });
 
     it.each([

--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -13,7 +13,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { readConfiguredLogTail } from "../logging/log-tail.js";
 import { parseLogLine } from "../logging/parse-log-line.js";
 import { redactSensitiveLines, resolveRedactOptions } from "../logging/redact.js";
-import { formatTimestamp, isValidTimeZone } from "../logging/timestamps.js";
+import { formatTimestamp } from "../logging/timestamps.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { formatDocsLink } from "../terminal/links.js";
@@ -72,6 +72,7 @@ type LogsCliOptions = {
   plain?: boolean;
   color?: boolean;
   localTime?: boolean;
+  utc?: boolean;
   url?: string;
   token?: string;
   timeout?: string;
@@ -352,7 +353,7 @@ function isTransientFollowError(error: unknown): boolean {
 export function formatLogTimestamp(
   value?: string,
   mode: "pretty" | "plain" = "plain",
-  localTime = false,
+  localTime = true,
 ) {
   if (!value) {
     return "";
@@ -489,7 +490,8 @@ export function registerLogsCli(program: Command) {
     .option("--json", "Emit JSON log lines", false)
     .option("--plain", "Plain text output (no ANSI styling)", false)
     .option("--no-color", "Disable ANSI colors")
-    .option("--local-time", "Display timestamps in local timezone", false)
+    .option("--local-time", "Display timestamps in local timezone (default)", false)
+    .option("--utc", "Display timestamps in UTC", false)
     .addHelpText(
       "after",
       () =>
@@ -509,8 +511,7 @@ export function registerLogsCli(program: Command) {
     const jsonMode = Boolean(opts.json);
     const pretty = !jsonMode && process.stdout.isTTY && !opts.plain;
     const rich = isRich() && opts.color !== false;
-    const localTime =
-      Boolean(opts.localTime) || (!!process.env.TZ && isValidTimeZone(process.env.TZ));
+    const localTime = !opts.utc;
 
     let followRetryAttempt = 0;
     while (true) {


### PR DESCRIPTION
Summary
- Render `openclaw logs` text timestamps in local time by default.
- Add `--utc` for operators and scripts that need UTC output.
- Keep `--local-time` accepted as the compatibility spelling, and update focused tests/docs/changelog.

Verification
Behavior addressed: cleaned maintainer recut of the local-time logs timestamp behavior from closed dirty PR #47365.
Real environment tested: not completed; remote runners are blocked in this shell.
Exact steps or command run after this patch: `git diff --check`; `AUTOREVIEW_AUTO_TESTS=0 AUTOREVIEW_OPENCLAW_MAINTAINER_VALIDATION=1 .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`; `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --shell -- "pnpm test:serial src/cli/logs-cli.test.ts"`; `../crabbox/bin/crabbox run --provider aws --shell -- "pnpm test:serial src/cli/logs-cli.test.ts"`
Evidence after fix: diff check passed; autoreview reported no accepted/actionable findings. Blacksmith Testbox failed before execution because `blacksmith auth login` is required. AWS Crabbox failed before execution because AWS credentials / IMDS role are unavailable.
Observed result after fix: code review is clean, but no remote test command executed.
What was not tested: focused logs CLI Vitest test, changed gate, and real non-UTC gateway log-stream proof.

Refs #47365
