### PR TITLE
Make cron agent watchdogs configurable

### DIFF
--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -1047,6 +1047,17 @@ describe("cron webhook schema", () => {
     });
     expect(res.success).toBe(true);
   });
+
+  it("accepts isolated cron agent watchdog timeouts", () => {
+    const res = OpenClawSchema.safeParse({
+      cron: {
+        isolatedAgentSetupTimeoutMs: 180000,
+        isolatedAgentPreExecutionTimeoutMs: 180000,
+      },
+    });
+
+    expect(res.success).toBe(true);
+  });
 });
 
 describe("broadcast", () => {

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -130,6 +130,8 @@ const TARGET_KEYS = [
   "cron.enabled",
   "cron.store",
   "cron.maxConcurrentRuns",
+  "cron.isolatedAgentSetupTimeoutMs",
+  "cron.isolatedAgentPreExecutionTimeoutMs",
   "cron.retry",
   "cron.retry.maxAttempts",
   "cron.retry.backoffMs",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1666,6 +1666,10 @@ export const FIELD_HELP: Record<string, string> = {
     "Path to the cron job store file used to persist scheduled jobs across restarts. Set an explicit path only when you need custom storage layout, backups, or mounted volumes.",
   "cron.maxConcurrentRuns":
     "Limits how many cron jobs can execute at the same time when multiple schedules fire together, including isolated agent-turn LLM execution on the dedicated cron-nested lane. Use lower values to protect CPU/memory under heavy automation load, or raise carefully for higher throughput.",
+  "cron.isolatedAgentSetupTimeoutMs":
+    "Milliseconds an isolated cron agent turn may spend setting up before the runner reports that it started (default: 60000). Increase when startup work such as session/bootstrap loading can legitimately exceed one minute.",
+  "cron.isolatedAgentPreExecutionTimeoutMs":
+    "Milliseconds an isolated cron agent turn may spend in pre-execution phases after the runner starts but before model/tool execution begins (default: 60000). Increase for slow provider setup or heavy pre-reply hooks.",
   "cron.retry":
     "Overrides the default retry policy for one-shot jobs when they fail with transient errors (rate limit, overloaded, network, server_error). Omit to use defaults: maxAttempts 3, backoffMs [30000, 60000, 300000], retry all transient types.",
   "cron.retry.maxAttempts":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -818,6 +818,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "cron.enabled": "Cron Enabled",
   "cron.store": "Cron Store Path",
   "cron.maxConcurrentRuns": "Cron Max Concurrent Runs",
+  "cron.isolatedAgentSetupTimeoutMs": "Cron Isolated Agent Setup Timeout (ms)",
+  "cron.isolatedAgentPreExecutionTimeoutMs": "Cron Isolated Agent Pre-execution Timeout (ms)",
   "cron.retry": "Cron Retry Policy",
   "cron.retry.maxAttempts": "Cron Retry Max Attempts",
   "cron.retry.backoffMs": "Cron Retry Backoff (ms)",

--- a/src/config/types.cron.ts
+++ b/src/config/types.cron.ts
@@ -32,6 +32,16 @@ export type CronConfig = {
   enabled?: boolean;
   store?: string;
   maxConcurrentRuns?: number;
+  /**
+   * Milliseconds an isolated cron agent turn may spend setting up before the
+   * runner reports that it started. Default: 60000.
+   */
+  isolatedAgentSetupTimeoutMs?: number;
+  /**
+   * Milliseconds an isolated cron agent turn may spend in pre-execution phases
+   * after the runner starts but before model/tool execution begins. Default: 60000.
+   */
+  isolatedAgentPreExecutionTimeoutMs?: number;
   /** Override default retry policy for one-shot jobs on transient errors. */
   retry?: CronRetryConfig;
   /**

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -743,6 +743,8 @@ export const OpenClawSchema = z
         enabled: z.boolean().optional(),
         store: z.string().optional(),
         maxConcurrentRuns: z.number().int().positive().optional(),
+        isolatedAgentSetupTimeoutMs: z.number().int().positive().optional(),
+        isolatedAgentPreExecutionTimeoutMs: z.number().int().positive().optional(),
         retry: z
           .object({
             maxAttempts: z.number().int().min(0).max(10).optional(),

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -1437,6 +1437,69 @@ describe("cron service timer regressions", () => {
     }
   });
 
+  it("honors the global isolated agent setup timeout override", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = timerRegressionFixtures.makeStorePath();
+      const scheduledAt = Date.parse("2026-05-22T10:00:00.000Z");
+      const cronJob = createIsolatedRegressionJob({
+        id: "isolated-setup-timeout-configured",
+        name: "configured setup timeout",
+        scheduledAt,
+        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+        payload: { kind: "agentTurn", message: "work", timeoutSeconds: 300 },
+        state: { nextRunAtMs: scheduledAt },
+      });
+      await writeCronJobs(store.storePath, [cronJob]);
+
+      vi.setSystemTime(scheduledAt);
+      let now = scheduledAt;
+      const started = createDeferred<void>();
+      let abortObserved = false;
+      const cleanupTimedOutAgentRun = vi.fn(async () => {});
+      const state = createCronServiceState({
+        cronEnabled: true,
+        cronConfig: { isolatedAgentSetupTimeoutMs: 180_000 },
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        cleanupTimedOutAgentRun,
+        runIsolatedAgentJob: vi.fn(async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+          started.resolve();
+          abortSignal?.addEventListener(
+            "abort",
+            () => {
+              abortObserved = true;
+            },
+            { once: true },
+          );
+          return await new Promise<never>(() => {});
+        }),
+      });
+
+      const timerPromise = onTimer(state);
+      await started.promise;
+      await vi.advanceTimersByTimeAsync(60_100);
+      now += 60_100;
+      expect(abortObserved).toBe(false);
+      expect(cleanupTimedOutAgentRun).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(120_000);
+      now += 120_000;
+      await timerPromise;
+
+      const job = requireJob(state, "isolated-setup-timeout-configured");
+      expect(abortObserved).toBe(true);
+      expect(job.state.lastStatus).toBe("error");
+      expect(job.state.lastError).toContain("setup timed out before runner start");
+      expect(cleanupTimedOutAgentRun).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("times out isolated agent runs that stall before execution starts (#74803)", async () => {
     vi.useFakeTimers();
     try {
@@ -1520,6 +1583,81 @@ describe("cron service timer regressions", () => {
       const execution = requireRecord(cleanupArgs.execution);
       expect(execution.jobId).toBe("isolated-pre-model-timeout-74803");
       expect(execution.phase).toBe("context_engine");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("honors the global isolated agent pre-execution timeout override", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = timerRegressionFixtures.makeStorePath();
+      const scheduledAt = Date.parse("2026-05-22T10:05:00.000Z");
+      const cronJob = createIsolatedRegressionJob({
+        id: "isolated-pre-execution-timeout-configured",
+        name: "configured pre-execution timeout",
+        scheduledAt,
+        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+        payload: { kind: "agentTurn", message: "work", timeoutSeconds: 600 },
+        state: { nextRunAtMs: scheduledAt },
+      });
+      await writeCronJobs(store.storePath, [cronJob]);
+
+      vi.setSystemTime(scheduledAt);
+      let now = scheduledAt;
+      const started = createDeferred<void>();
+      let abortObserved = false;
+      const cleanupTimedOutAgentRun = vi.fn(async () => {});
+      const state = createCronServiceState({
+        cronEnabled: true,
+        cronConfig: { isolatedAgentPreExecutionTimeoutMs: 180_000 },
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        cleanupTimedOutAgentRun,
+        runIsolatedAgentJob: vi.fn(
+          async ({
+            abortSignal,
+            onExecutionStarted,
+          }: {
+            abortSignal?: AbortSignal;
+            onExecutionStarted?: (info?: CronAgentExecutionStarted) => void;
+          }) => {
+            onExecutionStarted?.({
+              jobId: "isolated-pre-execution-timeout-configured",
+              phase: "runner_entered",
+            });
+            started.resolve();
+            abortSignal?.addEventListener(
+              "abort",
+              () => {
+                abortObserved = true;
+              },
+              { once: true },
+            );
+            return await new Promise<never>(() => {});
+          },
+        ),
+      });
+
+      const timerPromise = onTimer(state);
+      await started.promise;
+      await vi.advanceTimersByTimeAsync(60_100);
+      now += 60_100;
+      expect(abortObserved).toBe(false);
+      expect(cleanupTimedOutAgentRun).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(120_000);
+      now += 120_000;
+      await timerPromise;
+
+      const job = requireJob(state, "isolated-pre-execution-timeout-configured");
+      expect(abortObserved).toBe(true);
+      expect(job.state.lastStatus).toBe("error");
+      expect(job.state.lastError).toContain("stalled before execution start");
+      expect(cleanupTimedOutAgentRun).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -67,8 +67,8 @@ export { DEFAULT_JOB_TIMEOUT_MS } from "./timeout-policy.js";
 
 const MAX_TIMER_DELAY_MS = 60_000;
 const CRON_TIMEOUT_CLEANUP_GUARD_MS = 20_000;
-const CRON_AGENT_SETUP_WATCHDOG_MS = 60_000;
-const CRON_AGENT_PRE_EXECUTION_WATCHDOG_MS = 60_000;
+const DEFAULT_CRON_AGENT_SETUP_WATCHDOG_MS = 60_000;
+const DEFAULT_CRON_AGENT_PRE_EXECUTION_WATCHDOG_MS = 60_000;
 const CRON_AGENT_PRE_EXECUTION_MIN_WATCHDOG_MS = 1_000;
 
 /**
@@ -186,6 +186,8 @@ export async function executeJobCoreWithTimeout(
   const watchdog = createCronAgentWatchdog({
     deferUntilRunner: deferTimeoutUntilExecutionStart,
     jobTimeoutMs,
+    setupWatchdogMs: resolveCronAgentSetupWatchdogMs(state.deps.cronConfig),
+    preExecutionWatchdogMs: resolveCronAgentPreExecutionWatchdogMs(state.deps.cronConfig),
     triggerTimeout,
   });
   const corePromise = executeJobCore(state, job, runAbortController.signal, {
@@ -224,6 +226,8 @@ export async function executeJobCoreWithTimeout(
 function createCronAgentWatchdog(params: {
   deferUntilRunner: boolean;
   jobTimeoutMs: number;
+  setupWatchdogMs: number;
+  preExecutionWatchdogMs: number;
   triggerTimeout: (reason: string) => void;
 }): CronAgentWatchdog {
   let state: CronAgentWatchdogState = params.deferUntilRunner ? "waiting_for_runner" : "executing";
@@ -265,11 +269,14 @@ function createCronAgentWatchdog(params: {
     if (preExecutionTimeoutId || state !== "waiting_for_execution") {
       return;
     }
-    preExecutionTimeoutId = setTimeout(() => {
-      if (state === "waiting_for_execution") {
-        setTimedOut(preExecutionTimeoutErrorMessage(activeExecution));
-      }
-    }, resolveCronAgentPreExecutionWatchdogMs(params.jobTimeoutMs));
+    preExecutionTimeoutId = setTimeout(
+      () => {
+        if (state === "waiting_for_execution") {
+          setTimedOut(preExecutionTimeoutErrorMessage(activeExecution));
+        }
+      },
+      clampCronAgentPreExecutionWatchdogMs(params.jobTimeoutMs, params.preExecutionWatchdogMs),
+    );
   };
   const noteExecutionProgress = (info?: CronAgentExecutionStarted) => {
     if (!info) {
@@ -300,7 +307,7 @@ function createCronAgentWatchdog(params: {
           if (state === "waiting_for_runner") {
             setTimedOut(setupTimeoutErrorMessage(activeExecution));
           }
-        }, CRON_AGENT_SETUP_WATCHDOG_MS);
+        }, params.setupWatchdogMs);
         return;
       }
       startTimeout();
@@ -398,10 +405,34 @@ function formatCronAgentExecutionPhase(execution?: CronAgentExecutionStarted): s
   return formatEmbeddedAgentExecutionPhase(execution?.phase);
 }
 
-function resolveCronAgentPreExecutionWatchdogMs(jobTimeoutMs: number): number {
+function resolvePositiveCronTimeoutMs(raw: number | undefined, fallbackMs: number): number {
+  if (typeof raw !== "number" || !Number.isFinite(raw)) {
+    return fallbackMs;
+  }
+  return Math.max(1, Math.floor(raw));
+}
+
+function resolveCronAgentSetupWatchdogMs(cronConfig?: CronConfig): number {
+  return resolvePositiveCronTimeoutMs(
+    cronConfig?.isolatedAgentSetupTimeoutMs,
+    DEFAULT_CRON_AGENT_SETUP_WATCHDOG_MS,
+  );
+}
+
+function resolveCronAgentPreExecutionWatchdogMs(cronConfig?: CronConfig): number {
+  return resolvePositiveCronTimeoutMs(
+    cronConfig?.isolatedAgentPreExecutionTimeoutMs,
+    DEFAULT_CRON_AGENT_PRE_EXECUTION_WATCHDOG_MS,
+  );
+}
+
+function clampCronAgentPreExecutionWatchdogMs(
+  jobTimeoutMs: number,
+  preExecutionWatchdogMs: number,
+): number {
   return Math.max(
     CRON_AGENT_PRE_EXECUTION_MIN_WATCHDOG_MS,
-    Math.min(CRON_AGENT_PRE_EXECUTION_WATCHDOG_MS, Math.floor(jobTimeoutMs / 2)),
+    Math.min(preExecutionWatchdogMs, Math.floor(jobTimeoutMs / 2)),
   );
 }
 


### PR DESCRIPTION
Summary
- Add global cron config for isolated agent setup and pre-execution watchdog timeouts.
- Wire those values into cron isolated agent timeout handling while preserving the existing 60s defaults.
- Add schema/help/label coverage and regression tests for the configured timeouts.

Verification
- `node scripts/run-vitest.mjs src/cron/service/timer.regression.test.ts src/config/config-misc.test.ts src/config/schema.help.quality.test.ts src/config/zod-schema.cron-retention.test.ts`
- `pnpm config:schema:check`
- `git diff --check`
- `pnpm check:changed`

Behavior addressed: isolated cron agent setup and pre-execution watchdogs are now configurable through global `cron.isolatedAgentSetupTimeoutMs` and `cron.isolatedAgentPreExecutionTimeoutMs`.
Real environment tested: local macOS source checkout with repo dependencies installed via `pnpm install`.
Exact steps or command run after this patch: targeted Vitest command above plus config schema check, diff whitespace check, and changed-file gate.
Evidence after fix: regression tests show 180000ms overrides defer abort past the old 60000ms default and then time out at the configured window.
Observed result after fix: all listed checks passed locally.
What was not tested: full repository test suite and live gateway cron execution.
