### PR TITLE
fix(openai-codex): preserve image input capability on configured catalog rows (AI-assisted)

### DIFF
--- a/extensions/openai/openai-codex-provider.test.ts
+++ b/extensions/openai/openai-codex-provider.test.ts
@@ -824,6 +824,93 @@ describe("openai codex provider", () => {
     });
   });
 
+  it("restores [text,image] input on stale gpt-5.5 rows that omit the input field", () => {
+    // Regression: persisted/configured catalog rows can omit the `input` field
+    // for openai-codex models. When that row wins the catalog merge,
+    // `modelSupportsInput(entry, "image")` returns false and the gateway routes
+    // inbound images down the claim-check offload path (`media://inbound/<id>`)
+    // instead of inlining them. Mirror of the Anthropic precedent set by
+    // upstream #83756.
+    const provider = buildOpenAICodexProviderPlugin();
+
+    const model = provider.normalizeResolvedModel?.({
+      provider: "openai-codex",
+      modelId: "gpt-5.5",
+      model: {
+        id: "gpt-5.5",
+        name: "gpt-5.5",
+        provider: "openai-codex",
+        api: "openai-codex-responses",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        reasoning: true,
+        // No `input` field at all — the stale persisted/configured row shape.
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1_050_000,
+        contextTokens: 272_000,
+        maxTokens: 128_000,
+      },
+    } as never);
+
+    expect(model?.input).toEqual(["text", "image"]);
+  });
+
+  it("preserves [text,image] input on rows that already declare image capability", () => {
+    const provider = buildOpenAICodexProviderPlugin();
+
+    const model = provider.normalizeResolvedModel?.({
+      provider: "openai-codex",
+      modelId: "gpt-5.5",
+      model: {
+        id: "gpt-5.5",
+        name: "gpt-5.5",
+        provider: "openai-codex",
+        api: "openai-codex-responses",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1_050_000,
+        contextTokens: 272_000,
+        maxTokens: 128_000,
+      },
+    } as never);
+
+    // Existing image capability untouched; transport is already canonical so
+    // normalizeResolvedModel may return undefined (no-op).
+    if (model) {
+      expect(model.input).toEqual(["text", "image"]);
+    }
+  });
+
+  it("leaves codex-suffix and legacy model rows text-only (not vision-capable)", () => {
+    const provider = buildOpenAICodexProviderPlugin();
+
+    const model = provider.normalizeResolvedModel?.({
+      provider: "openai-codex",
+      modelId: "gpt-5.3-codex",
+      model: {
+        id: "gpt-5.3-codex",
+        name: "gpt-5.3-codex",
+        provider: "openai-codex",
+        api: "openai-codex-responses",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        reasoning: true,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 400_000,
+        contextTokens: 272_000,
+        maxTokens: 128_000,
+      },
+    } as never);
+
+    // No image capability should be added — gpt-5.X-codex models are
+    // Codex CLI / agent-mode only and not in the documented vision list.
+    // normalizeResolvedModel may return undefined (no transport change) or a
+    // model with the existing input array; either way `image` must not appear.
+    if (model?.input) {
+      expect(model.input).not.toContain("image");
+    }
+  });
+
   it("normalizes transport metadata for stale /backend-api/v1 codex routes", () => {
     const provider = buildOpenAICodexProviderPlugin();
 

--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -141,6 +141,43 @@ function normalizeCodexTransportFields(params: {
   return { api, baseUrl };
 }
 
+function hasImageInput(input: unknown): boolean {
+  return Array.isArray(input) && input.includes("image");
+}
+
+function matchesOpenAICodexImageCapableModel(modelId: string, modelName?: string): boolean {
+  return [modelId, modelName]
+    .filter((value): value is string => typeof value === "string")
+    .some((candidate) => matchesExactOrPrefix(candidate, OPENAI_CODEX_MODERN_MODEL_IDS));
+}
+
+/**
+ * Restore native `["text", "image"]` input capability on resolved Codex rows
+ * for the known modern model IDs (gpt-5.4, gpt-5.4-mini, gpt-5.4-pro, gpt-5.5,
+ * gpt-5.5-pro). Persisted/configured model rows can omit the `input` field
+ * entirely when they were written by older OpenClaw versions. When that row wins
+ * the catalog merge, `modelSupportsInput(entry, "image")` returns false and the
+ * gateway's `chat.send` handler offloads inbound images as `media://inbound/<id>`
+ * claim-check URIs instead of inlining them.
+ *
+ * Mirrors the Anthropic precedent set by upstream #83756.
+ */
+function applyOpenAICodexImageInputCapability(params: {
+  modelId: string;
+  model: ProviderRuntimeModel;
+}): ProviderRuntimeModel | undefined {
+  if (hasImageInput(params.model.input)) {
+    return undefined;
+  }
+  if (!matchesOpenAICodexImageCapableModel(params.modelId, params.model.name)) {
+    return undefined;
+  }
+  return {
+    ...params.model,
+    input: ["text", "image"],
+  };
+}
+
 function normalizeCodexTransport(model: ProviderRuntimeModel): ProviderRuntimeModel {
   const lowerModelId = normalizeLowercaseStringOrEmpty(model.id);
   const canonicalModelId =
@@ -570,7 +607,13 @@ export function buildOpenAICodexProviderPlugin(): ProviderPlugin {
       if (normalizeProviderId(ctx.provider) !== PROVIDER_ID) {
         return undefined;
       }
-      return normalizeCodexTransport(ctx.model);
+      const transportNormalized = normalizeCodexTransport(ctx.model);
+      const imageCapable =
+        applyOpenAICodexImageInputCapability({
+          modelId: ctx.modelId,
+          model: transportNormalized,
+        }) ?? transportNormalized;
+      return imageCapable === ctx.model ? undefined : imageCapable;
     },
     normalizeTransport: ({ provider, api, baseUrl }) => {
       if (normalizeProviderId(provider) !== PROVIDER_ID) {


### PR DESCRIPTION
## Summary

- Problem: sparse configured `openai-codex` model rows can lose their `input: ["text", "image"]` capability during model resolution.
- Why it matters: the gateway then treats image-capable Codex models as text-only and offloads inbound images as claim-check refs instead of inlining them for the model.
- What changed: modern Codex OAuth rows (`gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-pro`, `gpt-5.5`, `gpt-5.5-pro`) regain image input capability when a sparse configured row is resolved.
- What did NOT change (scope boundary): no transport/auth changes; no changes to non-Codex providers; no changelog edit.

AI-assisted: yes. Prompt/session reference: Pi goal session `2026-05-22T13-29-51Z`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #83746
- Related #83756
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: inbound channel images sent to an `openai-codex/gpt-5.5` agent were not reaching the model when the configured catalog row omitted `input`.
- Real environment tested: self-hosted OpenClaw gateway using `openai-codex/gpt-5.5` on a direct channel session.
- Exact steps or command run after this patch: deployed the same catalog-normalization patch to the gateway, sent an image to the agent over the channel, then inspected the provider trajectory for the image-bearing turn.
- Evidence after fix (redacted copied runtime log):

```json
{
  "type": "prompt.submitted",
  "provider": "openai-codex",
  "modelId": "gpt-5.5",
  "modelApi": "openai-codex-responses",
  "data": {
    "imagesCount": 1,
    "msgContentTypes": ["image", "text"]
  }
}
```

- Observed result after fix: the model received the image and correctly replied that it showed a tan/cognac leather briefcase or laptop bag with a Freedom of Movement logo.
- What was not tested: every Codex model alias; this PR locks the known modern Codex rows covered by the provider resolver.
- Before evidence (redacted copied runtime log):

```json
{
  "type": "prompt.submitted",
  "provider": "openai-codex",
  "modelId": "gpt-5.5",
  "modelApi": "openai-codex-responses",
  "data": {
    "prompt": "[media attached: media://inbound/<redacted>.jpg (image/jpeg)] ...",
    "imagesCount": 0
  }
}
```

## Root Cause (if applicable)

- Root cause: configured Codex model rows written without `input` could win model resolution over the bundled image-capable catalog row.
- Missing detection / guardrail: no provider test covered sparse configured Codex rows preserving image capability.
- Contributing context (if known): mirrors the Anthropic sparse-catalog issue fixed in #83756, but on the `openai-codex` provider path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/openai/openai-codex-provider.test.ts`
- Scenario the test should lock in: resolving a sparse configured `gpt-5.5` Codex row repairs `input` to include image support.
- Why this is the smallest reliable guardrail: the bug lives in provider model resolution before the gateway image planner runs.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Inbound images continue to work for configured modern `openai-codex/gpt-5.*` model rows that omit `input`.

## Diagram (if applicable)

```text
Before:
configured Codex row without input -> resolved as text-only -> inbound image offloaded -> imagesCount 0

After:
configured Codex row without input -> image input restored -> inbound image inlined -> imagesCount 1
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux container deployment
- Runtime/container: OpenClaw gateway
- Model/provider: `openai-codex/gpt-5.5`
- Integration/channel (if any): direct channel image message
- Relevant config (redacted): configured `openai-codex/gpt-5.5` row with no `input` field before the fix

### Steps

1. Configure an `openai-codex/gpt-5.5` model row without `input`.
2. Send an image-bearing direct message to an agent using that model.
3. Inspect the submitted provider payload / trajectory.

### Expected

- The submitted provider payload includes an image block and `imagesCount` is at least `1`.

### Actual

- Before this fix, `imagesCount` was `0` and the prompt contained only a `media://inbound/...` claim-check string.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: live image-bearing direct-channel turn on `openai-codex/gpt-5.5` changed from `imagesCount: 0` before to `imagesCount: 1` after; model answered the image content correctly.
- Edge cases checked: sparse configured row keeps existing context/max token metadata while restoring image input.
- What you did **not** verify: every configured Codex alias.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a future non-image-capable model matching the modern Codex prefix could be marked image-capable.
  - Mitigation: the allow-list is limited to the known modern Codex IDs already represented as image-capable in the provider catalog/synthesis path.
