### PR TITLE
fix(plugins): stop re-adding bundled plugin paths to plugins.load.paths during channel sync

### DIFF
--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -3013,14 +3013,14 @@ describe("syncPluginsForUpdateChannel", () => {
       expectedInstallPath: appBundledPluginRoot("feishu"),
     },
     {
-      name: "repairs bundled install metadata when the load path is re-added",
+      name: "repairs bundled install metadata without re-adding current bundled load path",
       config: createBundledPathInstallConfig({
         loadPaths: [],
         installPath: "/tmp/old-feishu",
         spec: "@openclaw/feishu",
       }),
       expectedChanged: true,
-      expectedLoadPaths: [appBundledPluginRoot("feishu")],
+      expectedLoadPaths: [],
       expectedInstallPath: appBundledPluginRoot("feishu"),
     },
   ] as const)(

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -2051,9 +2051,14 @@ export async function syncPluginsForUpdateChannel(params: {
       if (!pathsEqual(record.sourcePath, bundledInfo.localPath, env)) {
         continue;
       }
-      // Keep explicit bundled installs on release channels. Replacing them with
-      // npm installs can reintroduce duplicate-id shadowing and packaging drift.
-      loadHelpers.addPath(bundledInfo.localPath);
+      // Keep explicit bundled installs on release channels, but do NOT write
+      // the current bundled directory into plugins.load.paths. Bundled plugins
+      // are auto-loaded by OpenClaw's discovery layer, and an explicit load
+      // path entry triggers a circular warning in doctor (which removes it)
+      // followed by re-addition here on the next sync, creating a cycle.
+      //
+      // The install record itself is preserved below so that channel sync
+      // tracks the intentional path install and does not overwrite it.
       const alreadyBundled =
         record.source === "path" &&
         pathsEqual(record.sourcePath, bundledInfo.localPath, env) &&


### PR DESCRIPTION
## Summary

Fix the circular `doctor --fix` warning loop where:
1. `syncPluginsForUpdateChannel` adds current bundled plugin paths to `plugins.load.paths` 
2. `openclaw doctor --fix` removes them (triggers "ignored plugins.load.paths entry" warning)
3. Next channel sync adds them back → infinite cycle

## Root Cause

In `src/plugins/update.ts:L2056`, `syncPluginsForUpdateChannel` was calling `loadHelpers.addPath(bundledInfo.localPath)` for path-installed bundled plugins. Bundled plugins are auto-discovered by the plugin layer and do not need explicit `load.paths` entries — adding one triggers a redundant-path warning in `doctor` (discovery.ts:L1260-1266), which `doctor --fix` removes, only for the next sync to add it back.

## Fix

Remove the `addPath` call. The install record itself is still preserved so that channel sync tracks the intentional path install and does not overwrite it with an npm equivalent.

## Changes

- `src/plugins/update.ts`: Remove `loadHelpers.addPath(bundledInfo.localPath)` and update comment
- `src/plugins/update.test.ts`: Update test expectation for "repairs bundled install metadata" case (loadPaths should remain `[]` instead of being populated with the bundled path)

## Tests

```
✓ src/plugins/update.test.ts — 79/79 passed
✓ src/commands/doctor/shared/bundled-plugin-load-paths.test.ts — 9/9 passed
```

Fixes #85334