### PR TITLE
perf(cli): skip config load for default root help

### DIFF
--- a/src/cli/root-help-live-config.test.ts
+++ b/src/cli/root-help-live-config.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadRootHelpRenderOptionsForConfigSensitivePlugins } from "./root-help-live-config.js";
 
 const readConfigFileSnapshotMock = vi.hoisted(() => vi.fn());
@@ -8,8 +11,132 @@ vi.mock("../config/config.js", () => ({
 }));
 
 describe("root help live config", () => {
+  const originalEnv = {
+    HOME: process.env.HOME,
+    OPENCLAW_CONFIG_PATH: process.env.OPENCLAW_CONFIG_PATH,
+    OPENCLAW_HOME: process.env.OPENCLAW_HOME,
+    OPENCLAW_STATE_DIR: process.env.OPENCLAW_STATE_DIR,
+    OPENCLAW_BUNDLED_PLUGINS_DIR: process.env.OPENCLAW_BUNDLED_PLUGINS_DIR,
+    OPENCLAW_DISABLE_BUNDLED_PLUGINS: process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS,
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it("skips the heavy config module when no plugin-sensitive config file exists", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-root-help-"));
+    process.env.OPENCLAW_STATE_DIR = path.join(tempDir, "state");
+    process.env.OPENCLAW_CONFIG_PATH = path.join(tempDir, "missing-openclaw.json");
+    delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+    delete process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS;
+
+    await expect(
+      loadRootHelpRenderOptionsForConfigSensitivePlugins(process.env),
+    ).resolves.toBeNull();
+
+    expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("checks live config when plugin-sensitive env only exists in legacy gateway env", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-root-help-"));
+    try {
+      const cwdDir = path.join(tempDir, "cwd");
+      const gatewayEnvPath = path.join(tempDir, ".config", "openclaw", "gateway.env");
+      fs.mkdirSync(cwdDir, { recursive: true });
+      fs.mkdirSync(path.dirname(gatewayEnvPath), { recursive: true });
+      fs.writeFileSync(gatewayEnvPath, "OPENCLAW_DISABLE_BUNDLED_PLUGINS=1\n", "utf8");
+      vi.spyOn(process, "cwd").mockReturnValue(cwdDir);
+      process.env.HOME = tempDir;
+      process.env.OPENCLAW_STATE_DIR = path.join(tempDir, ".openclaw");
+      delete process.env.OPENCLAW_CONFIG_PATH;
+      delete process.env.OPENCLAW_HOME;
+      delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+      delete process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS;
+      readConfigFileSnapshotMock.mockResolvedValueOnce({
+        valid: true,
+        sourceConfig: {},
+        runtimeConfig: {},
+      });
+
+      await expect(
+        loadRootHelpRenderOptionsForConfigSensitivePlugins(process.env),
+      ).resolves.toBeNull();
+
+      expect(readConfigFileSnapshotMock).toHaveBeenCalledOnce();
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores legacy gateway env during precheck for an explicit custom state dir", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-root-help-"));
+    try {
+      const cwdDir = path.join(tempDir, "cwd");
+      const gatewayEnvPath = path.join(tempDir, ".config", "openclaw", "gateway.env");
+      fs.mkdirSync(cwdDir, { recursive: true });
+      fs.mkdirSync(path.dirname(gatewayEnvPath), { recursive: true });
+      fs.writeFileSync(gatewayEnvPath, "OPENCLAW_DISABLE_BUNDLED_PLUGINS=1\n", "utf8");
+      vi.spyOn(process, "cwd").mockReturnValue(cwdDir);
+      process.env.HOME = tempDir;
+      process.env.OPENCLAW_STATE_DIR = path.join(tempDir, "custom-state");
+      process.env.OPENCLAW_CONFIG_PATH = path.join(tempDir, "missing-openclaw.json");
+      delete process.env.OPENCLAW_HOME;
+      delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+      delete process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS;
+
+      await expect(
+        loadRootHelpRenderOptionsForConfigSensitivePlugins(process.env),
+      ).resolves.toBeNull();
+
+      expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("checks live config when plugin-sensitive env exists beside an explicit config path", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-root-help-"));
+    try {
+      const cwdDir = path.join(tempDir, "cwd");
+      const configPath = path.join(tempDir, "custom", "missing-openclaw.json");
+      const configDirEnvPath = path.join(path.dirname(configPath), ".env");
+      fs.mkdirSync(cwdDir, { recursive: true });
+      fs.mkdirSync(path.dirname(configDirEnvPath), { recursive: true });
+      fs.writeFileSync(configDirEnvPath, "OPENCLAW_DISABLE_BUNDLED_PLUGINS=1\n", "utf8");
+      vi.spyOn(process, "cwd").mockReturnValue(cwdDir);
+      process.env.HOME = tempDir;
+      process.env.OPENCLAW_CONFIG_PATH = configPath;
+      delete process.env.OPENCLAW_STATE_DIR;
+      delete process.env.OPENCLAW_HOME;
+      delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+      delete process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS;
+      readConfigFileSnapshotMock.mockResolvedValueOnce({
+        valid: true,
+        sourceConfig: {},
+        runtimeConfig: {},
+      });
+
+      await expect(
+        loadRootHelpRenderOptionsForConfigSensitivePlugins(process.env),
+      ).resolves.toBeNull();
+
+      expect(readConfigFileSnapshotMock).toHaveBeenCalledOnce();
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("uses precomputed help when plugin-sensitive config is invalid", async () => {

--- a/src/cli/root-help-live-config.ts
+++ b/src/cli/root-help-live-config.ts
@@ -1,4 +1,9 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import type { RootHelpRenderOptions } from "./program/root-help.js";
 
 function hasEntries(value: object | undefined): boolean {
@@ -32,9 +37,70 @@ export function hasPluginHelpAffectingEnv(env: NodeJS.ProcessEnv): boolean {
   );
 }
 
+function hasPotentialDotEnv(env: NodeJS.ProcessEnv): boolean {
+  try {
+    if (fs.existsSync(path.join(process.cwd(), ".env"))) {
+      return true;
+    }
+    if (fs.existsSync(path.join(resolveStateDir(env), ".env"))) {
+      return true;
+    }
+    if (hasConfigPathDotEnv(env)) {
+      return true;
+    }
+    return hasLegacyGatewayDotEnv(env);
+  } catch {
+    return true;
+  }
+}
+
+function hasConfigPathDotEnv(env: NodeJS.ProcessEnv): boolean {
+  if (!env.OPENCLAW_CONFIG_PATH?.trim()) {
+    return false;
+  }
+  return fs.existsSync(
+    path.join(path.dirname(resolveConfigPath(env, resolveStateDir(env))), ".env"),
+  );
+}
+
+function hasExplicitNonDefaultStateDir(env: NodeJS.ProcessEnv): boolean {
+  const override = env.OPENCLAW_STATE_DIR?.trim();
+  if (!override) {
+    return false;
+  }
+  const homeDir = resolveRequiredHomeDir(env, os.homedir);
+  const stateDir = resolveStateDir(env, () => homeDir);
+  const defaultStateDir = path.join(homeDir, ".openclaw");
+  return path.resolve(stateDir) !== path.resolve(defaultStateDir);
+}
+
+function hasLegacyGatewayDotEnv(env: NodeJS.ProcessEnv): boolean {
+  if (hasExplicitNonDefaultStateDir(env)) {
+    return false;
+  }
+  const homeDir = resolveRequiredHomeDir(env, os.homedir);
+  return fs.existsSync(path.join(homeDir, ".config", "openclaw", "gateway.env"));
+}
+
+function hasConfigFile(env: NodeJS.ProcessEnv): boolean {
+  try {
+    return fs.existsSync(resolveConfigPath(env, resolveStateDir(env)));
+  } catch {
+    return true;
+  }
+}
+
 export async function loadRootHelpRenderOptionsForConfigSensitivePlugins(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<RootHelpRenderOptions | null> {
+  if (
+    env === process.env &&
+    !hasPluginHelpAffectingEnv(env) &&
+    !hasPotentialDotEnv(env) &&
+    !hasConfigFile(env)
+  ) {
+    return null;
+  }
   const configModule = await import("../config/config.js");
   const snapshot = await configModule.readConfigFileSnapshot({
     observe: false,


### PR DESCRIPTION
## Summary
- avoid importing the full config/validation stack for `openclaw --help` when there is no config file, no OpenClaw dotenv file, and no plugin-help-affecting env override
- keep the existing live-config path for configured/plugin-sensitive help, invalid config handling, and injected-env tests
- include the legacy `~/.config/openclaw/gateway.env` runtime dotenv compatibility path in the fast-path precheck unless an explicit non-default `OPENCLAW_STATE_DIR` is active

## Why
The root help fast path has precomputed help text, but it still called `readConfigFileSnapshot()` first to see whether plugin config could affect help output. In a default/no-config invocation that dragged in config validation before printing static help.

## Real behavior proof
Behavior or issue addressed: default `openclaw --help` startup no longer imports the full config/validation stack when no config, dotenv, or plugin-help-affecting env can change static root help output. Plugin-sensitive help still uses the live config path, including legacy `~/.config/openclaw/gateway.env` and the `.env` file beside an explicit `OPENCLAW_CONFIG_PATH`.

Real environment tested: local OpenClaw checkout on Linux, CLI startup artifacts built with `node scripts/build-all.mjs cliStartup`, isolated temporary HOME/state directories, real CLI startup measured with `node scripts/bench-cli-startup.ts --case help`, and focused Vitest regression coverage on the pushed PR head `4b2c49f3`.

Exact steps or command run after this patch:
1. Built CLI startup artifacts: `node scripts/build-all.mjs cliStartup`.
2. Measured the previous root help path with isolated temp-home runs: `node scripts/bench-cli-startup.ts --case help --runs 3 --warmup 0 --timeout-ms 10000 --json`.
3. Measured this PR's root help path with isolated temp-home runs: `node scripts/bench-cli-startup.ts --case help --runs 5 --warmup 0 --timeout-ms 10000 --json`.
4. Added regression coverage for legacy `~/.config/openclaw/gateway.env`, explicit custom `OPENCLAW_STATE_DIR` exclusion, and explicit `OPENCLAW_CONFIG_PATH` sidecar `.env` handling.
5. Ran focused checks after the compatibility repair.

Evidence after fix:
```text
Before: node scripts/bench-cli-startup.ts --case help --runs 3 --warmup 0 --timeout-ms 10000 --json
avg duration 1116.7ms, avg RSS 264.1MB

After: node scripts/bench-cli-startup.ts --case help --runs 5 --warmup 0 --timeout-ms 10000 --json
avg duration 44.4ms, avg RSS 54.1MB

Focused regression: node scripts/test-projects.mjs src/cli/root-help-live-config.test.ts
Test Files  1 passed (1)
Tests  6 passed (6)
[test] passed 1 Vitest shard in 9.79s

Format: corepack pnpm exec oxfmt --write --threads=1 src/cli/root-help-live-config.ts src/cli/root-help-live-config.test.ts
Finished in 39ms on 2 files using 1 threads.

Diff hygiene: git diff --check -- src/cli/root-help-live-config.ts src/cli/root-help-live-config.test.ts
passed

Guard check: corepack pnpm check:no-conflict-markers && node scripts/generate-npm-shrinkwrap.mjs --all --check
npm-shrinkwrap.json is current across checked packages
```

Observed result after fix: default root help improved by 1072.3ms (-96.0%) and 209.9MB RSS (-79.5%) in the isolated real CLI startup sample. The focused regression suite now passes 6/6 and covers the legacy `gateway.env` compatibility path, custom state-dir exclusion, and explicit config-path sidecar `.env` path. The shrinkwrap guard now reports current generated files after regeneration.

What was not tested: full repository CI was not run locally. GitHub Actions is still the broad merge gate after the pushed PR head.


## Tests
- `node scripts/test-projects.mjs src/cli/root-help-live-config.test.ts` - passed, 5/5 after the legacy `gateway.env` repair
- `corepack pnpm exec oxfmt --write --threads=1 src/cli/root-help-live-config.ts src/cli/root-help-live-config.test.ts` (commit hook)
- `git diff --check HEAD~1..HEAD -- src/cli/root-help-live-config.ts src/cli/root-help-live-config.test.ts` - passed after the follow-up repair

## Hygiene
- committed with GitHub noreply author email
- staged only the two intended CLI files
- checked the staged diff for obvious credential patterns before committing

Related follow-up to #85353 and #85368; this is the startup/init overhead bucket outside media provider discovery.

