### PR TITLE
fix(media): resolve media:// claim-check refs in loadImageFromRef and image-tool (#74123) [AI-assisted]

### DIFF
--- a/src/agents/pi-embedded-runner/run/images.test.ts
+++ b/src/agents/pi-embedded-runner/run/images.test.ts
@@ -350,6 +350,30 @@ describe("modelSupportsImages", () => {
 });
 
 describe("loadImageFromRef", () => {
+  async function withManagedInboundPng(
+    run: (params: { stateDir: string; mediaId: string; mediaPath: string }) => Promise<void>,
+  ) {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-native-image-inbound-"));
+    const inboundDir = path.join(stateDir, "media", "inbound");
+    const mediaId = "claim-check-test.png";
+    const mediaPath = path.join(inboundDir, mediaId);
+    await fs.mkdir(inboundDir, { recursive: true });
+    await fs.writeFile(
+      mediaPath,
+      Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=",
+        "base64",
+      ),
+    );
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    try {
+      await run({ stateDir, mediaId, mediaPath });
+    } finally {
+      vi.unstubAllEnvs();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  }
+
   it("allows sandbox-validated host paths outside default media roots", async () => {
     const homeDir = os.homedir();
     await fs.mkdir(homeDir, { recursive: true });
@@ -385,6 +409,68 @@ describe("loadImageFromRef", () => {
     } finally {
       await fs.rm(sandboxParent, { recursive: true, force: true });
     }
+  });
+
+  it("resolves media:// claim-check URIs against the inbound media store", async () => {
+    // Regression: previously `loadImageFromRef` treated `media://inbound/<id>`
+    // as a plain relative path and `path.resolve(workspaceDir, ref.resolved)`
+    // mangled it into `<workspaceDir>/media:/inbound/<id>`, ENOENTing silently
+    // (upstream #74123 seam 1).
+    await withManagedInboundPng(async ({ mediaId }) => {
+      const image = await loadImageFromRef(
+        {
+          raw: `media://inbound/${mediaId}`,
+          type: "media-uri",
+          resolved: `media://inbound/${mediaId}`,
+        },
+        "/home/node/.openclaw/workspace",
+      );
+
+      expect(image?.type).toBe("image");
+      expect(image?.mimeType).toMatch(/^image\//);
+      expect(image?.data).toBeTruthy();
+    });
+  });
+
+  it("resolves media:// claim-check URIs when sandbox reads are enabled", async () => {
+    await withManagedInboundPng(async ({ mediaId }) => {
+      const sandboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-native-image-sandbox-"));
+      try {
+        const image = await loadImageFromRef(
+          {
+            raw: `media://inbound/${mediaId}`,
+            type: "media-uri",
+            resolved: `media://inbound/${mediaId}`,
+          },
+          sandboxRoot,
+          {
+            workspaceOnly: true,
+            sandbox: {
+              root: sandboxRoot,
+              bridge: createHostSandboxFsBridge(sandboxRoot),
+            },
+          },
+        );
+
+        expect(image?.type).toBe("image");
+        expect(image?.mimeType).toMatch(/^image\//);
+        expect(image?.data).toBeTruthy();
+      } finally {
+        await fs.rm(sandboxRoot, { recursive: true, force: true });
+      }
+    });
+  });
+
+  it("returns null for media:// URIs that do not match a known inbound buffer", async () => {
+    const image = await loadImageFromRef(
+      {
+        raw: "media://inbound/no-such-buffer.png",
+        type: "media-uri",
+        resolved: "media://inbound/no-such-buffer.png",
+      },
+      "/home/node/.openclaw/workspace",
+    );
+    expect(image).toBeNull();
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import type { ImageContent } from "@earendil-works/pi-ai";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import { assertNoWindowsNetworkPath, safeFileURLToPath } from "../../../infra/local-file-access.js";
+import { resolveMediaReferenceLocalPath } from "../../../media/media-reference.js";
 import type { PromptImageOrderEntry } from "../../../media/prompt-image-order.js";
 import { loadWebMedia } from "../../../media/web-media.js";
 import { normalizeLowercaseStringOrEmpty } from "../../../shared/string-coerce.js";
@@ -436,8 +437,35 @@ export async function loadImageFromRef(
   try {
     let targetPath = ref.resolved;
 
+    let mediaLocalRoots: readonly string[] | undefined;
+
     // Resolve paths relative to sandbox or workspace as needed
-    if (options?.sandbox) {
+    if (ref.type === "media-uri") {
+      // Claim-check URI written by the Gateway's inbound media offload
+      // (`media://inbound/<id>`). Resolve to the physical buffer path before
+      // sandbox validation or workspace resolution — otherwise
+      // `path.resolve(workspaceDir, "media://inbound/<id>")` mangles the URI
+      // into a non-existent workspace-rooted path (e.g.
+      // `<workspace>/media:/inbound/<id>`) and `loadWebMedia` ENOENTs. Managed
+      // inbound buffers are outside sandbox/workspace roots, so allow exactly
+      // the resolved buffer directory instead of forcing sandbox bridge reads.
+      try {
+        targetPath = await resolveMediaReferenceLocalPath(ref.resolved);
+      } catch (err) {
+        log.debug(
+          `Native image: media-uri resolution failed for ${ref.resolved}: ${formatErrorMessage(err)}`,
+        );
+        return null;
+      }
+      if (targetPath === ref.resolved) {
+        // `resolveMediaReferenceLocalPath` returns its input unchanged when the
+        // URI does not match a known inbound buffer. Bail out instead of
+        // letting downstream code try to read `media://...` as a real file.
+        log.debug(`Native image: no inbound buffer for media-uri ${ref.resolved}`);
+        return null;
+      }
+      mediaLocalRoots = [path.dirname(targetPath)];
+    } else if (options?.sandbox) {
       try {
         const resolved = await resolveSandboxedBridgeMediaPath({
           sandbox: {
@@ -459,18 +487,21 @@ export async function loadImageFromRef(
     }
 
     // loadWebMedia handles local file paths (including file:// URLs)
-    const media = options?.sandbox
-      ? await loadWebMedia(targetPath, {
-          maxBytes: options.maxBytes,
-          sandboxValidated: true,
-          readFile: createSandboxBridgeReadFile({ sandbox: options.sandbox }),
-        })
-      : await loadWebMedia(
-          targetPath,
-          options?.workspaceOnly
-            ? { maxBytes: options.maxBytes, localRoots: [workspaceDir] }
-            : options?.maxBytes,
-        );
+    const media =
+      options?.sandbox && !mediaLocalRoots
+        ? await loadWebMedia(targetPath, {
+            maxBytes: options.maxBytes,
+            sandboxValidated: true,
+            readFile: createSandboxBridgeReadFile({ sandbox: options.sandbox }),
+          })
+        : await loadWebMedia(
+            targetPath,
+            mediaLocalRoots
+              ? { maxBytes: options?.maxBytes, localRoots: mediaLocalRoots }
+              : options?.workspaceOnly
+                ? { maxBytes: options.maxBytes, localRoots: [workspaceDir] }
+                : options?.maxBytes,
+          );
 
     if (media.kind !== "image") {
       log.debug(`Native image: not an image file: ${targetPath} (got ${media.kind})`);

--- a/src/agents/sandbox-media-paths.test.ts
+++ b/src/agents/sandbox-media-paths.test.ts
@@ -42,4 +42,58 @@ describe("createSandboxBridgeReadFile", () => {
     expect(resolved).toEqual({ resolved: "/sandbox/image.png" });
     expect(stat).not.toHaveBeenCalled();
   });
+
+  it("rewrites media store refs through the inbound sandbox fallback", async () => {
+    const stat = vi.fn(async () => ({ type: "file", size: 1, mtimeMs: 1 }));
+    const resolvePath = vi.fn(({ filePath }: { filePath: string }) => ({
+      relativePath: filePath,
+      containerPath: `/sandbox/${filePath}`,
+    }));
+
+    const resolved = await resolveSandboxedBridgeMediaPath({
+      sandbox: {
+        root: "/tmp/sandbox-root",
+        bridge: { resolvePath, stat } as unknown as SandboxFsBridge,
+      },
+      mediaPath: "media://inbound/photo%20one.png",
+      inboundFallbackDir: "media/inbound",
+    });
+
+    expect(resolved).toEqual({
+      resolved: "/sandbox/media/inbound/photo one.png",
+      rewrittenFrom: "media://inbound/photo%20one.png",
+    });
+    expect(stat).toHaveBeenCalledWith({
+      filePath: "media/inbound/photo one.png",
+      cwd: "/tmp/sandbox-root",
+    });
+    expect(resolvePath).toHaveBeenCalledWith({
+      filePath: "media/inbound/photo one.png",
+      cwd: "/tmp/sandbox-root",
+    });
+  });
+
+  it("does not rewrite media store refs with nested decoded paths", async () => {
+    const stat = vi.fn(async () => ({ type: "file", size: 1, mtimeMs: 1 }));
+    const resolvePath = vi.fn(({ filePath }: { filePath: string }) => ({
+      relativePath: filePath,
+      containerPath: `/sandbox/${filePath}`,
+    }));
+
+    const resolved = await resolveSandboxedBridgeMediaPath({
+      sandbox: {
+        root: "/tmp/sandbox-root",
+        bridge: { resolvePath, stat } as unknown as SandboxFsBridge,
+      },
+      mediaPath: "media://inbound/nested%2Fsecret.png",
+      inboundFallbackDir: "media/inbound",
+    });
+
+    expect(resolved).toEqual({ resolved: "/sandbox/media://inbound/nested%2Fsecret.png" });
+    expect(stat).not.toHaveBeenCalled();
+    expect(resolvePath).toHaveBeenCalledWith({
+      filePath: "media://inbound/nested%2Fsecret.png",
+      cwd: "/tmp/sandbox-root",
+    });
+  });
 });

--- a/src/agents/sandbox-media-paths.ts
+++ b/src/agents/sandbox-media-paths.ts
@@ -26,6 +26,7 @@ export async function resolveSandboxedBridgeMediaPath(params: {
   const normalizeFileUrl = (rawPath: string) =>
     rawPath.startsWith("file://") ? rawPath.slice("file://".length) : rawPath;
   const filePath = normalizeFileUrl(params.mediaPath);
+  const mediaStoreMatch = /^media:\/\/inbound\/(.+)$/i.exec(filePath);
   const enforceWorkspaceBoundary = async (hostPath: string) => {
     if (!params.sandbox.workspaceOnly) {
       return;
@@ -42,6 +43,33 @@ export async function resolveSandboxedBridgeMediaPath(params: {
       filePath,
       cwd: params.sandbox.root,
     });
+  if (mediaStoreMatch && params.inboundFallbackDir?.trim()) {
+    try {
+      const decodedId = decodeURIComponent(mediaStoreMatch[1]);
+      if (decodedId && !decodedId.includes("/") && !decodedId.includes("\\")) {
+        const fallbackPath = path.join(params.inboundFallbackDir.trim(), decodedId);
+        const stat = await params.sandbox.bridge.stat({
+          filePath: fallbackPath,
+          cwd: params.sandbox.root,
+        });
+        if (stat) {
+          const resolvedFallback = params.sandbox.bridge.resolvePath({
+            filePath: fallbackPath,
+            cwd: params.sandbox.root,
+          });
+          if (resolvedFallback.hostPath) {
+            await enforceWorkspaceBoundary(resolvedFallback.hostPath);
+          }
+          return {
+            resolved: resolvedFallback.hostPath ?? resolvedFallback.containerPath,
+            rewrittenFrom: filePath,
+          };
+        }
+      }
+    } catch {
+      // Fall through to the existing direct/fallback error path for a clear failure.
+    }
+  }
   try {
     const resolved = resolveDirect();
     if (resolved.hostPath) {

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -1724,6 +1724,46 @@ describe("image tool implicit imageModel config", () => {
       expect((res.details as { rewrittenFrom?: string }).rewrittenFrom).toContain("photo.png");
     });
   });
+
+  it("preserves media:// refs for sandbox inbound fallback resolution", async () => {
+    await withTempSandboxState(async ({ agentDir, sandboxRoot }) => {
+      await fs.mkdir(path.join(sandboxRoot, "media", "inbound"), {
+        recursive: true,
+      });
+      await fs.writeFile(
+        path.join(sandboxRoot, "media", "inbound", "photo.png"),
+        Buffer.from(ONE_PIXEL_PNG_B64, "base64"),
+      );
+
+      const fetch = stubMinimaxOkFetch();
+      const cfg: OpenClawConfig = {
+        ...createMinimaxImageConfig(),
+        tools: { fs: { workspaceOnly: true } },
+      };
+      const sandbox = {
+        root: sandboxRoot,
+        bridge: createHostSandboxFsBridge(sandboxRoot),
+        workspaceOnly: true,
+      };
+      const tool = createRequiredImageTool({
+        config: cfg,
+        agentDir,
+        sandbox,
+        workspaceDir: sandboxRoot,
+      });
+
+      const res = await tool.execute("t1", {
+        prompt: "Describe the image.",
+        image: "media://inbound/photo.png",
+      });
+
+      expectToolText(res, "ok");
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect((res.details as { rewrittenFrom?: string }).rewrittenFrom).toBe(
+        "media://inbound/photo.png",
+      );
+    });
+  });
 });
 
 describe("image tool data URL support", () => {
@@ -1936,6 +1976,32 @@ describe("image tool managed inbound media", () => {
 
         await expectImageToolExecOk(tool, mediaPath);
         expect(fetch).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  it("resolves media://inbound refs even when workspaceDir is set", async () => {
+    // Regression: when an agent had `options.workspaceDir` set (the common
+    // case for any sessioned agent run), the IIFE that builds `resolvedImage`
+    // fell into the relative-path branch for `media://inbound/<id>` because
+    // the URI is technically non-absolute. `resolve(workspaceDir, "media://...")`
+    // mangled the URI into `<workspaceDir>/media:/inbound/<id>` and
+    // `loadWebMedia` ENOENTed before its own `resolveMediaStoreUriToPath`
+    // helper could rescue it (upstream #74123 seam 2).
+    await withManagedInboundPng(async ({ mediaId }) => {
+      installImageUnderstandingProviderStubs();
+      const fetch = stubMinimaxOkFetch();
+      await withTempAgentDir(async (agentDir) => {
+        await withTempWorkspacePng(async ({ workspaceDir }) => {
+          const tool = createRequiredImageTool({
+            config: createMinimaxImageConfig(),
+            agentDir,
+            workspaceDir,
+          });
+
+          await expectImageToolExecOk(tool, `media://inbound/${mediaId}`);
+          expect(fetch).toHaveBeenCalledTimes(1);
+        });
       });
     });
   });

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -15,6 +15,7 @@ import { buildProviderRegistry } from "../../media-understanding/runner.js";
 import {
   classifyMediaReferenceSource,
   normalizeMediaReferenceSource,
+  resolveMediaReferenceLocalPath,
 } from "../../media/media-reference.js";
 import { loadWebMedia } from "../../media/web-media.js";
 import {
@@ -625,9 +626,25 @@ export function createImageTool(options?: {
           throw new Error("Sandboxed image tool does not allow remote URLs.");
         }
 
-        const resolvedImage = (() => {
+        // Resolve `media://inbound/<id>` claim-check URIs to their physical
+        // buffer path BEFORE the non-sandbox workspace fallback. Without this
+        // short-circuit, the workspace-resolve branch below sees a non-absolute
+        // reference and calls `resolve(workspaceDir, "media://inbound/<id>")`,
+        // which produces `<workspaceDir>/media:/inbound/<id>` and ENOENTs at
+        // load time. Sandboxed runs keep the raw URI so the sandbox bridge can
+        // rewrite it through its managed inbound media fallback instead of
+        // crossing the boundary with a host state-dir path.
+        const resolvedImage = await (async () => {
           if (sandboxConfig) {
             return normalizedRef;
+          }
+          if (refInfo.isMediaStoreUrl) {
+            const localPath = await resolveMediaReferenceLocalPath(normalizedRef);
+            // `resolveMediaReferenceLocalPath` returns its input unchanged when
+            // no inbound buffer matches. Pass that through so the existing
+            // `loadWebMedia` ENOENT path still surfaces a clear error rather
+            // than masking it as a workspace miss.
+            return localPath;
           }
           if (normalizedRef.startsWith("~")) {
             return resolveUserPath(normalizedRef);


### PR DESCRIPTION
## Summary

- Problem: `media://inbound/...` claim-check image refs were detected but then treated like workspace-relative paths in two native image-loading seams.
- Why it matters: agents could not recover an inbound image once a prompt or tool call carried the claim-check URI instead of a local file path.
- What changed: `loadImageFromRef` and the `image` tool now resolve inbound `media://` refs to their local media buffer before workspace path resolution.
- What did NOT change (scope boundary): no remote URL policy changes; no changelog edit.

AI-assisted: yes. Prompt/session reference: Pi goal session `2026-05-22T13-29-51Z`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #74123
- Related #74186
- Related #74278
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: when inbound images reached the native runner as `media://inbound/...` claim-check refs, image-loading seams resolved them as paths like `<workspace>/media:/inbound/...` and failed to load them.
- Real environment tested: self-hosted OpenClaw gateway using a direct channel image message.
- Exact steps or command run after this patch: deployed the resolver wiring with the catalog fix, sent an image to the agent, then inspected the submitted provider trajectory and the visible channel reply.
- Evidence after fix (redacted copied runtime log):

```json
{
  "type": "prompt.submitted",
  "provider": "openai-codex",
  "modelId": "gpt-5.5",
  "data": {
    "imagesCount": 1,
    "msgContentTypes": ["image", "text"]
  }
}
```

Visible reply after fix:

```text
It’s a tan/cognac leather briefcase or laptop bag — structured rectangular shape, twin handles, detachable shoulder strap, zip top. The logo says “FOM” / “Freedom of Movement”.
```

- Observed result after fix: the agent could read and describe the inbound image.
- What was not tested: full channel E2E against every sandbox backend; focused sandbox bridge coverage now verifies native `media://` prompt-image loading.
- Before evidence (redacted copied runtime log):

```json
{
  "type": "prompt.submitted",
  "provider": "openai-codex",
  "modelId": "gpt-5.5",
  "data": {
    "prompt": "[media attached: media://inbound/<redacted>.jpg (image/jpeg)] ...",
    "imagesCount": 0
  }
}
```

## Root Cause (if applicable)

- Root cause: `media://inbound/...` refs were recognized as image refs, but these two consumers did not resolve the claim-check URI before generic workspace path resolution.
- Missing detection / guardrail: tests covered detection and other seams, but not native `loadImageFromRef` or `image` tool resolution of `media://` refs.
- Contributing context (if known): this complements #74186 and #74278 by wiring two additional seams from #74123.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-runner/run/images.test.ts`, `src/agents/tools/image-tool.test.ts`
- Scenario the test should lock in: `media://inbound/...` refs are resolved through the media store before workspace path fallback, including native prompt-image loading with sandbox reads enabled.
- Why this is the smallest reliable guardrail: both failures were seam-local URI resolution gaps.
- Existing test that already covers this (if any): none for these two seams.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Agents can recover inbound media claim-check image refs in native prompt image loading and the `image` tool instead of failing on a mangled workspace path.

## Diagram (if applicable)

```text
Before:
media://inbound/id.jpg -> workspace path fallback -> <workspace>/media:/inbound/id.jpg -> ENOENT

After:
media://inbound/id.jpg -> media store resolver -> local media buffer path -> image loads
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux container deployment
- Runtime/container: OpenClaw gateway
- Model/provider: `openai-codex/gpt-5.5`
- Integration/channel (if any): direct channel image message
- Relevant config (redacted): standard inbound media storage with claim-check `media://inbound/...` refs

### Steps

1. Produce an inbound image ref as `media://inbound/<id>.jpg`.
2. Let the native image loader or `image` tool consume that ref.
3. Confirm the ref resolves through the media store instead of workspace path fallback.

### Expected

- The image loader receives a local media buffer path and loads the image.

### Actual

- Before this fix, the URI was resolved as a workspace-relative path containing `media:/inbound/...` and failed to load.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: live direct-channel image turn reached the model as `imagesCount: 1`; the model replied with a correct visual description.
- Edge cases checked: native prompt image loading, native prompt image loading with sandbox reads enabled, and `image` tool path resolution each have focused regression coverage.
- What you did **not** verify: full channel E2E against every sandbox backend.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: malformed or missing `media://` refs could be mistaken for file paths.
  - Mitigation: unresolved media refs stay on the existing failure path rather than being silently treated as valid files.
