### PR TITLE
fix(gateway): bound startup sidecar fanout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/startup: bound ACP identity reconcile and stale session-lock cleanup fanout so large persisted session sets no longer monopolize the event loop during sidecar startup. Fixes #85366. Thanks @NianJiuZst.
 - Gateway: defer provider auth-state prewarm until after startup readiness so early gateway tool/session requests are not blocked by provider auth discovery. (#85272) Thanks @dutifulbob.
 - Agents/Codex: show the first plan update as a transient chat status notice without counting it as final assistant content.
 - Gateway/LaunchAgent: wait for launchd reload bootout to finish and fall back to kickstart when bootstrap races, so reload handoff does not leave the service deregistered. Fixes #84630. (#84641) Thanks @NianJiuZst.

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -14,6 +14,7 @@ import {
 } from "../../tasks/detached-task-runtime.js";
 import { resolveRequiredCompletionTerminalResult } from "../../tasks/task-completion-contract.js";
 import type { DeliveryContext } from "../../utils/delivery-context.js";
+import { runTasksWithConcurrency } from "../../utils/run-with-concurrency.js";
 import {
   AcpRuntimeError,
   formatAcpErrorChain,
@@ -93,6 +94,11 @@ const ACP_TURN_TIMEOUT_CLEANUP_GRACE_MS = 2_000;
 const ACP_TURN_TIMEOUT_REASON = "turn-timeout";
 const ACP_BACKGROUND_TASK_TEXT_MAX_LENGTH = 160;
 const ACP_BACKGROUND_TASK_PROGRESS_MAX_LENGTH = 240;
+const ACP_STARTUP_IDENTITY_RECONCILE_CONCURRENCY = 4;
+
+async function yieldToEventLoop(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
 
 function summarizeBackgroundTaskText(text: string): string {
   const normalized = normalizeText(text) ?? "ACP background task";
@@ -242,10 +248,6 @@ export class AcpSessionManager {
   async reconcilePendingSessionIdentities(params: {
     cfg: OpenClawConfig;
   }): Promise<AcpStartupIdentityReconcileResult> {
-    let checked = 0;
-    let resolved = 0;
-    let failed = 0;
-
     let acpSessions: Awaited<ReturnType<AcpSessionManagerDeps["listAcpSessions"]>>;
     try {
       acpSessions = await this.deps.listAcpSessions({
@@ -253,58 +255,76 @@ export class AcpSessionManager {
       });
     } catch (error) {
       logVerbose(`acp-manager: startup identity scan failed: ${String(error)}`);
-      return { checked, resolved, failed: failed + 1 };
+      return { checked: 0, resolved: 0, failed: 1 };
     }
 
-    for (const session of acpSessions) {
-      if (!session.acp || !session.sessionKey) {
-        continue;
-      }
-      const currentIdentity = resolveSessionIdentityFromMeta(session.acp);
-      if (
-        !isSessionIdentityPending(currentIdentity) ||
-        !identityHasStableSessionId(currentIdentity)
-      ) {
-        continue;
-      }
-
-      checked += 1;
-      try {
-        const becameResolved = await this.withSessionActor(session.sessionKey, async () => {
-          const resolution = this.resolveSession({
-            cfg: params.cfg,
-            sessionKey: session.sessionKey,
-          });
-          if (resolution.kind !== "ready") {
-            return false;
-          }
-          const { runtime, handle, meta } = await this.ensureRuntimeHandle({
-            cfg: params.cfg,
-            sessionKey: session.sessionKey,
-            meta: resolution.meta,
-          });
-          const reconciled = await this.reconcileRuntimeSessionIdentifiers({
-            cfg: params.cfg,
-            sessionKey: session.sessionKey,
-            runtime,
-            handle,
-            meta,
-            failOnStatusError: false,
-          });
-          return !isSessionIdentityPending(resolveSessionIdentityFromMeta(reconciled.meta));
-        });
-        if (becameResolved) {
-          resolved += 1;
+    const startupTasks = acpSessions.map(
+      (session) => async (): Promise<AcpStartupIdentityReconcileResult> => {
+        if (!session.acp || !session.sessionKey) {
+          return { checked: 0, resolved: 0, failed: 0 };
         }
-      } catch (error) {
-        failed += 1;
-        logVerbose(
-          `acp-manager: startup identity reconcile failed for ${session.sessionKey}: ${String(error)}`,
-        );
-      }
-    }
+        const currentIdentity = resolveSessionIdentityFromMeta(session.acp);
+        if (
+          !isSessionIdentityPending(currentIdentity) ||
+          !identityHasStableSessionId(currentIdentity)
+        ) {
+          return { checked: 0, resolved: 0, failed: 0 };
+        }
 
-    return { checked, resolved, failed };
+        // Let the gateway service other work between startup sweep items.
+        await yieldToEventLoop();
+
+        try {
+          const becameResolved = await this.withSessionActor(session.sessionKey, async () => {
+            const resolution = this.resolveSession({
+              cfg: params.cfg,
+              sessionKey: session.sessionKey,
+            });
+            if (resolution.kind !== "ready") {
+              return false;
+            }
+            const { runtime, handle, meta } = await this.ensureRuntimeHandle({
+              cfg: params.cfg,
+              sessionKey: session.sessionKey,
+              meta: resolution.meta,
+            });
+            const reconciled = await this.reconcileRuntimeSessionIdentifiers({
+              cfg: params.cfg,
+              sessionKey: session.sessionKey,
+              runtime,
+              handle,
+              meta,
+              failOnStatusError: false,
+            });
+            return !isSessionIdentityPending(resolveSessionIdentityFromMeta(reconciled.meta));
+          });
+          return {
+            checked: 1,
+            resolved: becameResolved ? 1 : 0,
+            failed: 0,
+          };
+        } catch (error) {
+          logVerbose(
+            `acp-manager: startup identity reconcile failed for ${session.sessionKey}: ${String(error)}`,
+          );
+          return { checked: 1, resolved: 0, failed: 1 };
+        }
+      },
+    );
+
+    const startup = await runTasksWithConcurrency({
+      tasks: startupTasks,
+      limit: ACP_STARTUP_IDENTITY_RECONCILE_CONCURRENCY,
+    });
+
+    return startup.results.reduce<AcpStartupIdentityReconcileResult>(
+      (totals, current) => ({
+        checked: totals.checked + (current?.checked ?? 0),
+        resolved: totals.resolved + (current?.resolved ?? 0),
+        failed: totals.failed + (current?.failed ?? 0),
+      }),
+      { checked: 0, resolved: 0, failed: 0 },
+    );
   }
 
   async initializeSession(input: AcpInitializeSessionInput): Promise<{

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -3916,6 +3916,110 @@ describe("AcpSessionManager", () => {
     expect(currentMeta.identity?.agentSessionId).toBe("agent-session-1");
   });
 
+  it("bounds startup identity reconciliation fanout while yielding to other work", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+
+    const sessionKeys = Array.from(
+      { length: 9 },
+      (_value, index) => `agent:codex:acp:session-${index + 1}`,
+    );
+    const metaBySessionKey = new Map<string, SessionAcpMeta>(
+      sessionKeys.map((sessionKey) => [
+        sessionKey,
+        {
+          ...readySessionMeta(),
+          runtimeSessionName: `runtime:${sessionKey}`,
+          identity: {
+            state: "pending",
+            source: "ensure",
+            acpxSessionId: `acpx:${sessionKey}`,
+            lastUpdatedAt: Date.now(),
+          },
+        },
+      ]),
+    );
+    hoisted.listAcpSessionEntriesMock.mockResolvedValue(
+      sessionKeys.map((sessionKey) => ({
+        cfg: baseCfg,
+        storePath: "/tmp/sessions-acp.json",
+        sessionKey,
+        storeSessionKey: sessionKey,
+        entry: {
+          sessionId: sessionKey,
+          updatedAt: Date.now(),
+          acp: metaBySessionKey.get(sessionKey),
+        },
+        acp: metaBySessionKey.get(sessionKey),
+      })),
+    );
+    hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+      const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey ?? "";
+      return {
+        sessionKey,
+        storeSessionKey: sessionKey,
+        acp: metaBySessionKey.get(sessionKey),
+      };
+    });
+    hoisted.upsertAcpSessionMetaMock.mockImplementation(async (paramsUnknown: unknown) => {
+      const params = paramsUnknown as {
+        sessionKey: string;
+        mutate: (
+          current: SessionAcpMeta | undefined,
+          entry: { acp?: SessionAcpMeta } | undefined,
+        ) => SessionAcpMeta | null | undefined;
+      };
+      const current = metaBySessionKey.get(params.sessionKey);
+      const next = params.mutate(current, current ? { acp: current } : undefined);
+      if (next) {
+        metaBySessionKey.set(params.sessionKey, next);
+      }
+      return {
+        sessionId: params.sessionKey,
+        updatedAt: Date.now(),
+        acp: next,
+      };
+    });
+
+    let inFlight = 0;
+    let maxInFlight = 0;
+    runtimeState.getStatus.mockImplementation(async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      try {
+        await sleep(5);
+        return {
+          summary: "status=alive",
+          acpxSessionId: "resolved-acpx-session",
+          agentSessionId: "resolved-agent-session",
+          details: { status: "alive" },
+        };
+      } finally {
+        inFlight -= 1;
+      }
+    });
+
+    let immediateFired = false;
+    const immediate = new Promise<void>((resolve) => {
+      setImmediate(() => {
+        immediateFired = true;
+        resolve();
+      });
+    });
+
+    const manager = new AcpSessionManager();
+    const result = await manager.reconcilePendingSessionIdentities({ cfg: baseCfg });
+    await immediate;
+
+    expect(result).toEqual({ checked: 9, resolved: 9, failed: 0 });
+    expect(immediateFired).toBe(true);
+    expect(maxInFlight).toBeGreaterThan(1);
+    expect(maxInFlight).toBeLessThanOrEqual(4);
+  });
+
   it("skips startup reconcile for pending identities without stable runtime ids", async () => {
     const runtimeState = createRuntime();
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -552,6 +552,73 @@ describe("acquireSessionWriteLock", () => {
     }
   });
 
+  it("bounds stale lock cleanup fanout while yielding to other work", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-fanout-"));
+    const sessionsDir = path.join(root, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const nowMs = Date.now();
+    const lockNames = Array.from(
+      { length: 9 },
+      (_value, index) => `${String(index).padStart(2, "0")}.jsonl.lock`,
+    );
+
+    try {
+      await Promise.all(
+        lockNames.map((lockName) =>
+          fs.writeFile(
+            path.join(sessionsDir, lockName),
+            JSON.stringify({
+              pid: process.pid,
+              createdAt: new Date(nowMs).toISOString(),
+            }),
+            "utf8",
+          ),
+        ),
+      );
+
+      const readFileOriginal = fs.readFile.bind(fs);
+      const readFileSpy = vi.spyOn(fs, "readFile");
+      try {
+        let inFlight = 0;
+        let maxInFlight = 0;
+        readFileSpy.mockImplementation(async (...args: Parameters<typeof fs.readFile>) => {
+          const filePath = args[0];
+          if (typeof filePath !== "string" || !filePath.endsWith(".jsonl.lock")) {
+            return await readFileOriginal(...args);
+          }
+          inFlight += 1;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          try {
+            await new Promise<void>((resolve) => setTimeout(resolve, 5));
+            return await readFileOriginal(...args);
+          } finally {
+            inFlight -= 1;
+          }
+        });
+        const resultPromise = cleanStaleLockFiles({
+          sessionsDir,
+          staleMs: 30_000,
+          nowMs,
+          removeStale: true,
+          readOwnerProcessArgs: () => ["python", "worker.py"],
+        });
+
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        const result = await resultPromise;
+
+        expect(result.cleaned).toHaveLength(lockNames.length);
+        expect(result.locks.map((lock) => path.basename(lock.lockPath))).toEqual(lockNames);
+        expect(maxInFlight).toBeGreaterThan(1);
+        expect(maxInFlight).toBeLessThanOrEqual(testing.SESSION_LOCK_CLEANUP_CONCURRENCY);
+      } finally {
+        readFileSpy.mockRestore();
+      }
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("cleans fresh live .jsonl lock files owned by a non-OpenClaw process", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
     const sessionsDir = path.join(root, "sessions");

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { createFileLockManager } from "../infra/file-lock-manager.js";
 import { readGatewayProcessArgsSync as readProcessArgsSync } from "../infra/gateway-processes.js";
 import { getProcessStartTime, isPidAlive } from "../shared/pid-alive.js";
+import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
 import { SessionWriteLockTimeoutError } from "./session-write-lock-error.js";
 
 type LockFilePayload = {
@@ -45,6 +46,11 @@ const DEFAULT_TIMEOUT_GRACE_MS = 2 * 60 * 1000;
 // and the owner metadata write. Keep the grace short so 10s callers recover.
 const ORPHAN_LOCK_PAYLOAD_GRACE_MS = 5_000;
 const MAX_LOCK_HOLD_MS = 2_147_000_000;
+const SESSION_LOCK_CLEANUP_CONCURRENCY = 4;
+
+async function yieldToEventLoop(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
 
 type CleanupState = {
   registered: boolean;
@@ -681,33 +687,49 @@ export async function cleanStaleLockFiles(params: {
     .filter((entry) => entry.name.endsWith(".jsonl.lock"))
     .toSorted((a, b) => a.name.localeCompare(b.name));
 
-  for (const entry of lockEntries) {
-    const lockPath = path.join(sessionsDir, entry.name);
-    const payload = await readLockPayload(lockPath);
-    const inspected = inspectLockPayloadForSession({
-      payload,
-      staleMs,
-      nowMs,
-      heldByThisProcess: false,
-      reclaimLockWithoutStarttime: false,
-      readOwnerProcessArgs: ownerProcessArgsReader,
-    });
-    const lockInfo: SessionLockInspection = {
-      lockPath,
-      ...inspected,
-      removed: false,
-    };
+  const cleanup = await runTasksWithConcurrency({
+    limit: SESSION_LOCK_CLEANUP_CONCURRENCY,
+    tasks: lockEntries.map((entry) => async (): Promise<SessionLockInspection> => {
+      await yieldToEventLoop();
+      const lockPath = path.join(sessionsDir, entry.name);
+      const payload = await readLockPayload(lockPath);
+      const inspected = inspectLockPayloadForSession({
+        payload,
+        staleMs,
+        nowMs,
+        heldByThisProcess: false,
+        reclaimLockWithoutStarttime: false,
+        readOwnerProcessArgs: ownerProcessArgsReader,
+      });
+      const lockInfo: SessionLockInspection = {
+        lockPath,
+        ...inspected,
+        removed: false,
+      };
 
-    if (lockInfo.stale && removeStale) {
-      await fs.rm(lockPath, { force: true });
-      lockInfo.removed = true;
-      cleaned.push(lockInfo);
-      params.log?.warn?.(
-        `removed stale session lock: ${lockPath} (${lockInfo.staleReasons.join(", ") || "unknown"})`,
-      );
+      if (lockInfo.stale && removeStale) {
+        await fs.rm(lockPath, { force: true });
+        lockInfo.removed = true;
+        params.log?.warn?.(
+          `removed stale session lock: ${lockPath} (${lockInfo.staleReasons.join(", ") || "unknown"})`,
+        );
+      }
+
+      return lockInfo;
+    }),
+  });
+  if (cleanup.hasError) {
+    throw cleanup.firstError;
+  }
+
+  for (const lockInfo of cleanup.results) {
+    if (!lockInfo) {
+      continue;
     }
-
     locks.push(lockInfo);
+    if (lockInfo.removed) {
+      cleaned.push(lockInfo);
+    }
   }
 
   return { locks, cleaned };
@@ -794,6 +816,7 @@ export const testing = {
   handleTerminationSignal,
   releaseAllLocksSync,
   runLockWatchdogCheck,
+  SESSION_LOCK_CLEANUP_CONCURRENCY,
   setProcessStartTimeResolverForTest(resolver: ((pid: number) => number | null) | null): void {
     resolveProcessStartTimeForLock = resolver ?? getProcessStartTime;
   },

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -27,6 +27,10 @@ const hoisted = vi.hoisted(() => {
   const refreshLatestUpdateRestartSentinel = vi.fn<
     typeof import("./server-restart-sentinel.js").refreshLatestUpdateRestartSentinel
   >(async () => null);
+  const resolveAgentSessionDirs = vi.fn(async () => [] as string[]);
+  const cleanStaleLockFiles = vi.fn(async () => ({ locks: [], cleaned: [] }));
+  const markRestartAbortedMainSessionsFromLocks = vi.fn(async () => ({ marked: 0, skipped: 0 }));
+  const scheduleRestartAbortedMainSessionRecovery = vi.fn();
   const getAcpRuntimeBackend = vi.fn<(id?: string) => unknown>(() => null);
   const reconcilePendingSessionIdentities = vi.fn(async () => ({
     checked: 0,
@@ -70,6 +74,10 @@ const hoisted = vi.hoisted(() => {
     shouldWakeFromRestartSentinel,
     scheduleRestartSentinelWake,
     refreshLatestUpdateRestartSentinel,
+    resolveAgentSessionDirs,
+    cleanStaleLockFiles,
+    markRestartAbortedMainSessionsFromLocks,
+    scheduleRestartAbortedMainSessionRecovery,
     getAcpRuntimeBackend,
     reconcilePendingSessionIdentities,
     resolveAgentModelPrimaryValue,
@@ -89,11 +97,16 @@ const hoisted = vi.hoisted(() => {
 });
 
 vi.mock("../agents/session-dirs.js", () => ({
-  resolveAgentSessionDirs: vi.fn(async () => []),
+  resolveAgentSessionDirs: hoisted.resolveAgentSessionDirs,
 }));
 
 vi.mock("../agents/session-write-lock.js", () => ({
-  cleanStaleLockFiles: vi.fn(async () => {}),
+  cleanStaleLockFiles: hoisted.cleanStaleLockFiles,
+}));
+
+vi.mock("../agents/main-session-restart-recovery.js", () => ({
+  markRestartAbortedMainSessionsFromLocks: hoisted.markRestartAbortedMainSessionsFromLocks,
+  scheduleRestartAbortedMainSessionRecovery: hoisted.scheduleRestartAbortedMainSessionRecovery,
 }));
 
 vi.mock("../agents/subagent-registry.js", () => ({
@@ -321,6 +334,13 @@ describe("startGatewayPostAttachRuntime", () => {
     hoisted.scheduleSubagentOrphanRecovery.mockClear();
     hoisted.shouldWakeFromRestartSentinel.mockReturnValue(false);
     hoisted.scheduleRestartSentinelWake.mockClear();
+    hoisted.resolveAgentSessionDirs.mockReset();
+    hoisted.resolveAgentSessionDirs.mockResolvedValue([]);
+    hoisted.cleanStaleLockFiles.mockReset();
+    hoisted.cleanStaleLockFiles.mockResolvedValue({ locks: [], cleaned: [] });
+    hoisted.markRestartAbortedMainSessionsFromLocks.mockReset();
+    hoisted.markRestartAbortedMainSessionsFromLocks.mockResolvedValue({ marked: 0, skipped: 0 });
+    hoisted.scheduleRestartAbortedMainSessionRecovery.mockClear();
     hoisted.getAcpRuntimeBackend.mockReset();
     hoisted.getAcpRuntimeBackend.mockReturnValue(null);
     hoisted.reconcilePendingSessionIdentities.mockClear();
@@ -1688,6 +1708,75 @@ describe("startGatewayPostAttachRuntime", () => {
         ["backend", "acpx"],
       ],
     });
+  });
+
+  it("bounds post-ready session lock directory cleanup fanout", async () => {
+    const sessionDirs = Array.from(
+      { length: 9 },
+      (_value, index) => `/tmp/openclaw-state/agents/agent-${index + 1}/sessions`,
+    );
+    hoisted.resolveAgentSessionDirs.mockResolvedValueOnce(sessionDirs);
+
+    let inFlight = 0;
+    let maxInFlight = 0;
+    hoisted.cleanStaleLockFiles.mockImplementation(async (paramsUnknown: unknown) => {
+      const params = paramsUnknown as { sessionsDir: string };
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      try {
+        await new Promise<void>((resolve) => setTimeout(resolve, 5));
+        return {
+          locks: [],
+          cleaned: [
+            {
+              lockPath: `${params.sessionsDir}/stale.jsonl.lock`,
+              pid: null,
+              pidAlive: false,
+              createdAt: null,
+              ageMs: null,
+              stale: true,
+              staleReasons: ["dead-pid"],
+              removed: true,
+            },
+          ],
+        };
+      } finally {
+        inFlight -= 1;
+      }
+    });
+
+    const trace = createStartupTraceRecorder();
+    await startGatewaySidecars({
+      cfg: {
+        hooks: { internal: { enabled: false } },
+      } as never,
+      pluginRegistry: createPostAttachParams().pluginRegistry,
+      defaultWorkspaceDir: "/tmp/openclaw-workspace",
+      deps: {} as never,
+      startChannels: vi.fn(async () => {}),
+      log: { warn: vi.fn() },
+      logHooks: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      logChannels: {
+        info: vi.fn(),
+        error: vi.fn(),
+      },
+      startupTrace: trace.startupTrace,
+    });
+
+    await vi.waitFor(() => {
+      expect(hoisted.cleanStaleLockFiles).toHaveBeenCalledTimes(sessionDirs.length);
+    });
+
+    expect(maxInFlight).toBeGreaterThan(1);
+    expect(maxInFlight).toBeLessThanOrEqual(testing.STARTUP_SESSION_LOCK_DIR_CONCURRENCY);
+    expect(hoisted.markRestartAbortedMainSessionsFromLocks).toHaveBeenCalledTimes(
+      sessionDirs.length,
+    );
+    expect(trace.measures).toContain("sidecars.session-locks");
   });
 
   it("passes typed gateway_start context with config, workspace dir, and a live cron getter", async () => {

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -14,6 +14,7 @@ import type { loadOpenClawPlugins } from "../plugins/loader.js";
 import { getPluginModuleLoaderStats } from "../plugins/plugin-module-loader-cache.js";
 import type { PluginRegistry } from "../plugins/registry.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
+import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
 import {
   GATEWAY_EVENT_UPDATE_AVAILABLE,
   type GatewayUpdateAvailableEventPayload,
@@ -28,6 +29,7 @@ const ACP_BACKEND_READY_POLL_MS = 50;
 const PRIMARY_MODEL_PREWARM_TIMEOUT_MS = 5_000;
 const STARTUP_PROVIDER_DISCOVERY_TIMEOUT_MS = 5_000;
 const PROVIDER_AUTH_PREWARM_START_DELAY_MS = 1_000;
+const STARTUP_SESSION_LOCK_DIR_CONCURRENCY = 4;
 const SKIP_STARTUP_MODEL_PREWARM_ENV = "OPENCLAW_SKIP_STARTUP_MODEL_PREWARM";
 const QMD_STARTUP_IDLE_DELAY_MS = 120_000;
 const RESTART_SENTINEL_FILENAME = "restart-sentinel.json";
@@ -67,6 +69,10 @@ async function measureStartup<T>(
   run: () => Awaitable<T>,
 ): Promise<T> {
   return startupTrace ? startupTrace.measure(name, run) : await run();
+}
+
+async function yieldToEventLoop(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
 }
 
 function shouldCheckRestartSentinel(env: NodeJS.ProcessEnv = process.env): boolean {
@@ -642,29 +648,39 @@ export async function startGatewaySidecars(params: {
     log: params.log,
     run: async () => {
       try {
-        const [{ resolveStateDir }, { resolveAgentSessionDirs }, { cleanStaleLockFiles }] =
-          await Promise.all([
-            import("../config/paths.js"),
-            import("../agents/session-dirs.js"),
-            import("../agents/session-write-lock.js"),
-          ]);
+        const [
+          { resolveStateDir },
+          { resolveAgentSessionDirs },
+          { cleanStaleLockFiles },
+          { markRestartAbortedMainSessionsFromLocks },
+        ] = await Promise.all([
+          import("../config/paths.js"),
+          import("../agents/session-dirs.js"),
+          import("../agents/session-write-lock.js"),
+          import("../agents/main-session-restart-recovery.js"),
+        ]);
         const stateDir = resolveStateDir(process.env);
         const sessionDirs = await resolveAgentSessionDirs(stateDir);
-        for (const sessionsDir of sessionDirs) {
-          const result = await cleanStaleLockFiles({
-            sessionsDir,
-            config: params.cfg,
-            removeStale: true,
-            log: { warn: (message) => params.log.warn(message) },
-          });
-          if (result.cleaned.length > 0) {
-            const { markRestartAbortedMainSessionsFromLocks } =
-              await import("../agents/main-session-restart-recovery.js");
-            await markRestartAbortedMainSessionsFromLocks({
+        const cleanup = await runTasksWithConcurrency({
+          limit: STARTUP_SESSION_LOCK_DIR_CONCURRENCY,
+          tasks: sessionDirs.map((sessionsDir) => async () => {
+            await yieldToEventLoop();
+            const result = await cleanStaleLockFiles({
               sessionsDir,
-              cleanedLocks: result.cleaned,
+              config: params.cfg,
+              removeStale: true,
+              log: { warn: (message) => params.log.warn(message) },
             });
-          }
+            if (result.cleaned.length > 0) {
+              await markRestartAbortedMainSessionsFromLocks({
+                sessionsDir,
+                cleanedLocks: result.cleaned,
+              });
+            }
+          }),
+        });
+        if (cleanup.hasError) {
+          throw cleanup.firstError;
         }
       } catch (err) {
         params.log.warn(`session lock cleanup failed on startup: ${String(err)}`);
@@ -1146,6 +1162,7 @@ export const testing = {
   resolveGatewayMemoryStartupPolicy,
   scheduleProviderAuthStatePrewarm,
   schedulePrimaryModelPrewarm,
+  STARTUP_SESSION_LOCK_DIR_CONCURRENCY,
   shouldSkipStartupModelPrewarm,
   stopPostReadySidecarsAfterCloseStarted,
 };


### PR DESCRIPTION
## Summary

Fixes #85366 by moving the two startup sidecar fanout paths from fully serial sweeps to bounded, yielding background work:

- ACP startup identity reconciliation now runs pending session work through `runTasksWithConcurrency` with a small concurrency cap and an event-loop yield before each checked session.
- Startup stale session-lock cleanup now scans agent session directories through a bounded fanout and preserves restart-aborted marking for cleaned locks.
- Per-directory stale lock file inspection now uses bounded concurrency, yields before each lock inspection, and still propagates cleanup errors instead of silently dropping them.

## Why

Large installs can accumulate dozens of persisted ACP sessions and many agent session directories. The old startup sidecars awaited each ACP session and session-lock directory one at a time, which matched the issue report's 450-460 second diagnostic phases and event-loop starvation warnings. This keeps existing ownership and metadata contracts intact while letting the gateway service other work during the sweep.

## Verification

- `node scripts/run-vitest.mjs src/acp/control-plane/manager.test.ts`
- `node scripts/run-vitest.mjs src/gateway/server-startup-post-attach.test.ts`
- `node scripts/run-vitest.mjs src/agents/session-write-lock.test.ts`
- `node scripts/run-oxlint.mjs src/acp/control-plane/manager.core.ts src/acp/control-plane/manager.test.ts src/agents/session-write-lock.ts src/agents/session-write-lock.test.ts src/gateway/server-startup-post-attach.ts src/gateway/server-startup-post-attach.test.ts`
- `node scripts/github/real-behavior-proof-check.mjs` with a local pull_request event containing this PR body

## Real behavior proof

Behavior addressed: Gateway startup sidecars for ACP identity reconciliation and stale session-lock cleanup no longer process large session fanout as a single serial sweep that monopolizes startup work.

Real environment tested: Local OpenClaw source checkout on macOS with Node 24.14.1, using repository startup-sidecar and session-lock code paths plus synthetic multi-session and multi-directory fanout fixtures.

Exact steps or command run after this patch: Ran `node scripts/run-vitest.mjs src/acp/control-plane/manager.test.ts`, `node scripts/run-vitest.mjs src/gateway/server-startup-post-attach.test.ts`, and `node scripts/run-vitest.mjs src/agents/session-write-lock.test.ts`; also ran `node scripts/github/real-behavior-proof-check.mjs` against this PR body via a local pull_request event file.

Evidence after fix: Terminal output from the local checkout showed `src/acp/control-plane/manager.test.ts` passed 81 tests, `src/gateway/server-startup-post-attach.test.ts` passed 38 tests, and `src/agents/session-write-lock.test.ts` passed 70 tests. The added fanout cases observed concurrent work greater than 1 and bounded by the configured cap while using `setImmediate` yields.

Observed result after fix: The ACP startup reconcile fixture resolved 9 pending sessions with peak concurrency above 1 and no more than 4; the gateway startup session-lock fixture cleaned 9 agent session directories with bounded fanout; the stale lock fixture cleaned 9 lock files in deterministic order with bounded per-directory fanout.

What was not tested: I did not recreate the reporter's exact 50-90 session production install or the original 450-second wall-clock startup log locally.
