### PR TITLE
test(perf): compare saved CLI startup benchmarks

### DIFF
--- a/scripts/bench-cli-startup.ts
+++ b/scripts/bench-cli-startup.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -53,8 +53,24 @@ type SuiteResult = {
   }>;
 };
 
+type BenchmarkReport = {
+  primary: SuiteResult;
+  secondary?: SuiteResult | null;
+};
+
+type CaseDelta = {
+  id: string;
+  name: string;
+  durationAvgDeltaMs: number;
+  durationAvgDeltaPct: number;
+  maxRssAvgDeltaMb: number | null;
+  maxRssAvgDeltaPct: number | null;
+};
+
 type CliOptions = {
   cases: CommandCase[];
+  compareBaseline?: string;
+  compareCandidate?: string;
   entryPrimary: string;
   entrySecondary?: string;
   runs: number;
@@ -722,8 +738,26 @@ function printSuite(result: SuiteResult): void {
 }
 
 function printDelta(primary: SuiteResult, secondary: SuiteResult): void {
-  const primaryById = new Map(primary.cases.map((commandCase) => [commandCase.id, commandCase]));
+  const deltas = buildCaseDeltas(primary, secondary);
   console.log("Delta (secondary - primary, avg)");
+  for (const delta of deltas) {
+    const durationDelta = delta.durationAvgDeltaMs;
+    const durationPct = delta.durationAvgDeltaPct;
+    const durationSign = durationDelta > 0 ? "+" : "";
+    let line = `${delta.name.padEnd(24)} ${durationSign}${formatMs(durationDelta)} (${durationSign}${durationPct.toFixed(1)}%)`;
+    if (delta.maxRssAvgDeltaMb != null && delta.maxRssAvgDeltaPct != null) {
+      const rssDelta = delta.maxRssAvgDeltaMb;
+      const rssPct = delta.maxRssAvgDeltaPct;
+      const rssSign = rssDelta > 0 ? "+" : "";
+      line += ` rss ${rssSign}${formatMb(rssDelta)} (${rssSign}${rssPct.toFixed(1)}%)`;
+    }
+    console.log(line);
+  }
+}
+
+function buildCaseDeltas(primary: SuiteResult, secondary: SuiteResult): CaseDelta[] {
+  const primaryById = new Map(primary.cases.map((commandCase) => [commandCase.id, commandCase]));
+  const deltas: CaseDelta[] = [];
   for (const commandCase of secondary.cases) {
     const baseline = primaryById.get(commandCase.id);
     if (!baseline) {
@@ -734,17 +768,24 @@ function printDelta(primary: SuiteResult, secondary: SuiteResult): void {
       baseline.summary.durationMs.avg > 0
         ? (durationDelta / baseline.summary.durationMs.avg) * 100
         : 0;
-    const durationSign = durationDelta > 0 ? "+" : "";
-    let line = `${commandCase.name.padEnd(24)} ${durationSign}${formatMs(durationDelta)} (${durationSign}${durationPct.toFixed(1)}%)`;
-    if (baseline.summary.maxRssMb && commandCase.summary.maxRssMb) {
-      const rssDelta = commandCase.summary.maxRssMb.avg - baseline.summary.maxRssMb.avg;
-      const rssPct =
-        baseline.summary.maxRssMb.avg > 0 ? (rssDelta / baseline.summary.maxRssMb.avg) * 100 : 0;
-      const rssSign = rssDelta > 0 ? "+" : "";
-      line += ` rss ${rssSign}${formatMb(rssDelta)} (${rssSign}${rssPct.toFixed(1)}%)`;
-    }
-    console.log(line);
+    const rssDelta =
+      baseline.summary.maxRssMb && commandCase.summary.maxRssMb
+        ? commandCase.summary.maxRssMb.avg - baseline.summary.maxRssMb.avg
+        : null;
+    const rssPct =
+      rssDelta != null && baseline.summary.maxRssMb && baseline.summary.maxRssMb.avg > 0
+        ? (rssDelta / baseline.summary.maxRssMb.avg) * 100
+        : null;
+    deltas.push({
+      id: commandCase.id,
+      name: commandCase.name,
+      durationAvgDeltaMs: durationDelta,
+      durationAvgDeltaPct: durationPct,
+      maxRssAvgDeltaMb: rssDelta,
+      maxRssAvgDeltaPct: rssPct,
+    });
   }
+  return deltas;
 }
 
 async function buildSuiteResult(params: {
@@ -793,6 +834,8 @@ function parseOptions(): CliOptions {
   });
   return {
     cases,
+    compareBaseline: parseFlagValue("--compare-baseline"),
+    compareCandidate: parseFlagValue("--compare-candidate"),
     entryPrimary: parseFlagValue("--entry-primary") ?? parseFlagValue("--entry") ?? DEFAULT_ENTRY,
     entrySecondary: parseFlagValue("--entry-secondary"),
     runs: parsePositiveInt(parseFlagValue("--runs"), DEFAULT_RUNS),
@@ -821,6 +864,8 @@ Options:
   --warmup <n>                 Warmup runs per case (default: ${DEFAULT_WARMUP})
   --timeout-ms <ms>            Per-run timeout (default: ${DEFAULT_TIMEOUT_MS})
   --output <path>              Write machine-readable JSON to a file
+  --compare-baseline <path>    Read a saved JSON report as the baseline
+  --compare-candidate <path>   Read a saved JSON report as the candidate and print deltas
   --cpu-prof-dir <dir>         Write V8 CPU profiles for each run
   --heap-prof-dir <dir>        Write V8 heap profiles for each run
   --json                       Emit machine-readable JSON
@@ -831,6 +876,10 @@ Case ids:
 `);
 }
 
+function readBenchmarkReport(filePath: string): BenchmarkReport {
+  return JSON.parse(readFileSync(filePath, "utf8")) as BenchmarkReport;
+}
+
 async function main(): Promise<void> {
   if (hasFlag("--help")) {
     printUsage();
@@ -838,6 +887,24 @@ async function main(): Promise<void> {
   }
 
   const options = parseOptions();
+  if (options.compareBaseline || options.compareCandidate) {
+    if (!options.compareBaseline || !options.compareCandidate) {
+      throw new Error("--compare-baseline and --compare-candidate must be provided together");
+    }
+    const baseline = readBenchmarkReport(options.compareBaseline);
+    const candidate = readBenchmarkReport(options.compareCandidate);
+    const comparison = {
+      baseline: options.compareBaseline,
+      candidate: options.compareCandidate,
+      deltas: buildCaseDeltas(baseline.primary, candidate.primary),
+    };
+    if (options.json) {
+      console.log(JSON.stringify(comparison, null, 2));
+      return;
+    }
+    printDelta(baseline.primary, candidate.primary);
+    return;
+  }
   const tmpDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-bench-"));
   const rssHookPath = buildRssHook(tmpDir);
   try {


### PR DESCRIPTION
## Summary
- add saved-report comparison mode to `scripts/bench-cli-startup.ts`
- emit duration and RSS deltas as either terminal text or JSON
- keep the existing entry-vs-entry comparison path for same-run experiments
- refresh shrinkwrap snapshots so `check-guards` passes under the current pnpm lockfile

## Why
The follow-up performance PRs need repeatable before/after numbers. The benchmark harness could already save JSON reports, but comparing two saved reports required ad-hoc one-off scripts. This makes the comparison reusable for future PR bodies and review proof.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: saved CLI startup benchmark reports can now be compared directly, with text output for PR proof and JSON output for downstream tooling.
- Real environment tested: Real OpenClaw checkout on Linux, Node.js v24.2.0, using saved benchmark JSON reports produced from the #85396 root-help performance test.
- Exact steps or command run after this patch:

```bash
node scripts/bench-cli-startup.ts --compare-baseline /tmp/root-help-before.json --compare-candidate /tmp/root-help-after.json
node scripts/bench-cli-startup.ts --compare-baseline /tmp/root-help-before.json --compare-candidate /tmp/root-help-after.json --json
corepack pnpm exec oxfmt --write --threads=1 scripts/bench-cli-startup.ts
node scripts/generate-npm-shrinkwrap.mjs --all --check
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied live terminal output from comparing the saved #85396 benchmark reports:

```text
--help -1072.3ms (-96.0%) rss -209.9MB (-79.5%)
```

JSON mode emitted machine-readable `deltas[]` entries containing `durationAvgDeltaMs`, `durationAvgDeltaPct`, `maxRssAvgDeltaMb`, and `maxRssAvgDeltaPct`.

- Observed result after fix: The text comparison reports the expected startup and RSS reduction from the saved before/after reports, and JSON mode exposes the same deltas as structured fields for automation.
- What was not tested: I did not rerun the original slow benchmark captures in this PR; this PR validates comparison of already-saved real benchmark reports.
- Before evidence (optional but encouraged): Before this patch, comparing two saved benchmark JSON files required ad-hoc one-off scripts instead of a reusable harness mode.

## Tests
- `corepack pnpm exec oxfmt --write --threads=1 scripts/bench-cli-startup.ts` (commit hook)
- `git diff --check -- scripts/bench-cli-startup.ts`
- `corepack pnpm check:no-conflict-markers && node scripts/generate-npm-shrinkwrap.mjs --all --check`
- manual smoke commands above

## Hygiene
- committed with GitHub noreply author email
- staged only `scripts/bench-cli-startup.ts` in the original feature commit and only generated `npm-shrinkwrap.json` files in the follow-up guard-fix commit
- checked the staged diffs for obvious credential patterns before committing

Related follow-up to #85353, #85368, and #85396; this covers the benchmark/profiling harness bucket for the performance-audit series.
