### PR TITLE
fix(agents): lock transcript-writing session events [AI-assisted]

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
@@ -961,6 +961,8 @@ describe("embedded attempt session lock lifecycle", () => {
       },
     });
 
+    await session["_processAgentEvent"]({ type: "custom_message" });
+    await session["_processAgentEvent"]({ type: "message" });
     await session["_processAgentEvent"]({ type: "message_update" });
     await session["_processAgentEvent"]({ type: "tool_execution_end" });
     await session["_processAgentEvent"]({ type: "message_end" });
@@ -968,6 +970,8 @@ describe("embedded attempt session lock lifecycle", () => {
     await session["_processAgentEvent"]({});
 
     expect(processed).toEqual([
+      "custom_message",
+      "message",
       "message_update",
       "tool_execution_end",
       "message_end",
@@ -975,9 +979,37 @@ describe("embedded attempt session lock lifecycle", () => {
       undefined,
     ]);
     expect(hasHandlers).toHaveBeenCalledWith("tool_execution_end");
-    expect(acquireSessionWriteLock).toHaveBeenCalledTimes(3);
+    expect(acquireSessionWriteLock).toHaveBeenCalledTimes(5);
     expect(acquireSessionWriteLock).toHaveBeenCalledWith(lockOptions);
-    expect(releases).toEqual(["released", "released", "released"]);
+    expect(releases).toEqual(["released", "released", "released", "released", "released"]);
+  });
+
+  it("locks the real Pi agent event handler for transcript-writing events", async () => {
+    const locked: string[] = [];
+    const handled: Array<string | undefined> = [];
+    const session = {
+      _agentEventQueue: Promise.resolve(),
+      _disconnectFromAgent: vi.fn(),
+      _reconnectToAgent: vi.fn(),
+      _handleAgentEvent(event: { type?: string }) {
+        handled.push(event.type);
+      },
+    };
+
+    installSessionEventWriteLock({
+      session,
+      withSessionWriteLock: async (run) => {
+        locked.push("lock");
+        return await run();
+      },
+    });
+
+    await Promise.resolve(session["_handleAgentEvent"]({ type: "message" }));
+    await Promise.resolve(session["_handleAgentEvent"]({ type: "custom_message" }));
+    await Promise.resolve(session["_handleAgentEvent"]({ type: "tool_execution_end" }));
+
+    expect(handled).toEqual(["message", "custom_message", "tool_execution_end"]);
+    expect(locked).toEqual(["lock", "lock"]);
   });
 
   it("makes the Pi event listener await locked session event processing", async () => {
@@ -1010,16 +1042,65 @@ describe("embedded attempt session lock lifecycle", () => {
     const result = handleAgentEvent({ type: "message_end" }) as unknown as Promise<unknown>;
 
     expect(result).toHaveProperty("then");
-    expect(events).toEqual(["disconnect", "reconnect", "handle:message_end"]);
+    expect(events).toEqual([
+      "disconnect",
+      "reconnect",
+      "disconnect",
+      "reconnect",
+      "lock",
+      "handle:message_end",
+    ]);
 
     await result;
 
     expect(events).toEqual([
       "disconnect",
       "reconnect",
-      "handle:message_end",
+      "disconnect",
+      "reconnect",
       "lock",
+      "handle:message_end",
       "process:message_end",
+    ]);
+  });
+
+  it("reconnects the Pi listener to the final locked event handler", async () => {
+    const events: string[] = [];
+    let subscribed: ((event: { type?: string }) => unknown) | undefined;
+    const session = {
+      _agentEventQueue: Promise.resolve(),
+      _disconnectFromAgent: vi.fn(() => {
+        events.push("disconnect");
+        subscribed = undefined;
+      }),
+      _reconnectToAgent: vi.fn(() => {
+        events.push("reconnect");
+        subscribed = session["_handleAgentEvent"];
+      }),
+      _handleAgentEvent(event: { type?: string }) {
+        events.push(`handle:${event.type}`);
+      },
+    };
+
+    installSessionEventWriteLock({
+      session,
+      withSessionWriteLock: async (run) => {
+        events.push("lock");
+        return await run();
+      },
+    });
+
+    const result = subscribed?.({ type: "message" });
+    expect(result).toHaveProperty("then");
+    await Promise.resolve(result);
+
+    expect(events).toEqual([
+      "disconnect",
+      "reconnect",
+      "disconnect",
+      "reconnect",
+      "lock",
+      "handle:message",
     ]);
   });
 

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
@@ -25,7 +25,10 @@ type SessionWriteLockRunOptions = {
 };
 
 type SessionEventProcessor = {
+  _handleAgentEvent?: AwaitableSessionEventHandler;
   _processAgentEvent?: (event: unknown) => Promise<void>;
+  _disconnectFromAgent?: () => void;
+  _reconnectToAgent?: () => void;
   _extensionRunner?: {
     hasHandlers?: (eventType: string) => boolean;
   };
@@ -85,7 +88,13 @@ function sessionHasExtensionHandlers(session: SessionEventProcessor, eventType: 
 
 function eventMayReachTranscriptWriters(session: SessionEventProcessor, event: unknown): boolean {
   const type = (event as { type?: unknown } | null)?.type;
-  if (type === "message_update" || type === "message_end" || type === "agent_end") {
+  if (
+    type === "message" ||
+    type === "custom_message" ||
+    type === "message_update" ||
+    type === "message_end" ||
+    type === "agent_end"
+  ) {
     return true;
   }
   if (typeof type !== "string") {
@@ -555,11 +564,39 @@ export function installSessionEventWriteLock(params: {
 }): void {
   installAwaitableSessionEventQueue(params.session);
   const session = params.session as SessionEventProcessor;
-  const original = session["_processAgentEvent"];
-  if (
-    typeof original !== "function" ||
-    session["__openclawSessionEventWriteLockInstalled"] === true
-  ) {
+  if (session["__openclawSessionEventWriteLockInstalled"] === true) {
+    return;
+  }
+
+  const originalHandleAgentEvent = session["_handleAgentEvent"];
+  if (typeof originalHandleAgentEvent === "function") {
+    const canReconnect =
+      typeof session["_disconnectFromAgent"] === "function" &&
+      typeof session["_reconnectToAgent"] === "function";
+    if (canReconnect) {
+      session["_disconnectFromAgent"]?.();
+    }
+    session["__openclawSessionEventWriteLockInstalled"] = true;
+    session["_handleAgentEvent"] = async function lockedHandleAgentEvent(
+      this: unknown,
+      event: unknown,
+      signal?: unknown,
+    ) {
+      if (!eventMayReachTranscriptWriters(session, event)) {
+        return await originalHandleAgentEvent.call(this, event, signal);
+      }
+      return await params.withSessionWriteLock(
+        async () => await originalHandleAgentEvent.call(this, event, signal),
+      );
+    };
+    if (canReconnect) {
+      session["_reconnectToAgent"]?.();
+    }
+    return;
+  }
+
+  const originalProcessAgentEvent = session["_processAgentEvent"];
+  if (typeof originalProcessAgentEvent !== "function") {
     return;
   }
   session["__openclawSessionEventWriteLockInstalled"] = true;
@@ -568,9 +605,11 @@ export function installSessionEventWriteLock(params: {
     event: unknown,
   ) {
     if (!eventMayReachTranscriptWriters(session, event)) {
-      return await original.call(this, event);
+      return await originalProcessAgentEvent.call(this, event);
     }
-    return await params.withSessionWriteLock(async () => await original.call(this, event));
+    return await params.withSessionWriteLock(
+      async () => await originalProcessAgentEvent.call(this, event),
+    );
   };
 }
 


### PR DESCRIPTION
## Summary

- Problem: embedded prompt-lock fencing can report a takeover after a successful visible reply when `message`/`custom_message` session events write transcript entries while the prompt lock is released.
- Why it matters: the user can receive the correct channel reply and then see a misleading generic failure trailer from the losing lane.
- What changed: the real Pi `_handleAgentEvent` listener path now acquires the embedded session write lock for events that can write transcript entries; `_processAgentEvent` remains a fallback seam.
- What did NOT change (scope boundary): no channel routing changes, no lane ownership changes, no changelog edit.

AI-assisted: yes. Prompt/session reference: Pi goal session `2026-05-22T13-29-51Z`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: a direct channel image turn produced the correct visible reply, then a second generic failure trailer because the embedded runner detected session file drift after the prompt lock was released.
- Real environment observed: self-hosted OpenClaw gateway using a direct WhatsApp image message.
- Evidence before fix (redacted copied runtime log):

```text
[diagnostic] lane task error: lane=main durationMs=22823 error="EmbeddedAttemptSessionTakeoverError: session file changed while embedded prompt lock was released: .../sessions/<session>.jsonl"
[diagnostic] lane task error: lane=session:agent:main:whatsapp:direct:+REDACTED durationMs=22833 error="EmbeddedAttemptSessionTakeoverError: session file changed while embedded prompt lock was released: .../sessions/<session>.jsonl"
Embedded agent failed before reply: session file changed while embedded prompt lock was released: .../sessions/<session>.jsonl
```

Visible channel behavior before fix:

```text
<correct image description reply>
⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session.
```

- Observed cause: Pi agent events can write transcript entries through `_handleAgentEvent` while the embedded prompt lock is released, but the OpenClaw write-lock wrapper did not cover the real subscribed listener for all transcript-writing event types.
- Expected result after fix: visible reply events that can write the transcript are serialized through the same session write lock, so the embedded fence does not mistake local transcript writes for an external takeover.
- After-fix live proof: a lue-kube gateway proof image carrying this patch on the production-compatible `2026.5.19-beta.1` base delivered a WhatsApp direct-channel reply successfully, with no generic failure trailer or `EmbeddedAttemptSessionTakeoverError` in the post-send gateway log window.

## After-fix Real Behavior Proof

## PR3 ISSUE-113 after-fix real behavior proof

Runtime image: `lue-and-naddy-kube.tail59faed.ts.net/openclaw-custom:2026.5.19-lue.3-issue-113-compatible-proof@sha256:b11a9e5f823b0a17273f84252ca2c8253200e72c1ec83f27a3af640124895f1e`
OpenClaw version in pod: `2026.5.19-beta.1 (8d1de78)`
Patch marker in pod: `lockedHandleAgentEvent` + `__openclawSessionEventQueueAwaitInstalled` present in `/app/dist/selection-Cd9E0tXO.js`.

Proof command window: 2026-05-22T17:49:05Z → 2026-05-22T17:49:33Z
Direct-channel target: WhatsApp `+REDACTED`
Proof token: `PR3-ISSUE-113-PROOF-194905`
Session id: `54790651-461e-4889-9dd9-9d6a10e5404a`

Command run from the gateway pod:

```bash
openclaw agent --to +REDACTED --channel whatsapp --deliver --timeout 240 --json --message "Proof check PR3-ISSUE-113-PROOF-194905: reply with exactly this sentence and nothing else: PR3 session-event lock proof delivered without failure trailer."
```

Observed result:

```json
{
  "runId": "90590ff8-187c-486b-ad6d-f651d23952e8",
  "status": "ok",
  "summary": "completed",
  "reply": "PR3 session-event lock proof delivered without failure trailer.",
  "deliveryStatus": {
    "requested": true,
    "attempted": true,
    "status": "sent",
    "succeeded": true,
    "resultCount": 1,
    "payloadOutcomes": [
      {
        "index": 0,
        "status": "sent",
        "resultCount": 1
      }
    ]
  },
  "meta": {
    "durationMs": 11984,
    "sessionId": "54790651-461e-4889-9dd9-9d6a10e5404a",
    "provider": "openai-codex",
    "model": "gpt-5.5",
    "agentHarnessId": "pi",
    "stopReason": "stop",
    "executionTrace": {
      "winnerProvider": "openai-codex",
      "winnerModel": "gpt-5.5",
      "attempts": [
        {
          "provider": "openai-codex",
          "model": "gpt-5.5",
          "result": "success",
          "stage": "assistant"
        }
      ],
      "fallbackUsed": false,
      "runner": "embedded"
    }
  }
}
```

Post-send gateway log check after waiting 35s:

```text
EmbeddedAttemptSessionTakeoverError: 0
"Something went wrong while processing your request": 0
"Embedded agent failed before reply": 0
```

Conclusion: the live direct-channel proof turn delivered the expected WhatsApp reply and no generic failure trailer/takeover error appeared in the post-send gateway log window.

## Root Cause (if applicable)

- Root cause: the embedded attempt session lock released around prompt execution, but the real Pi `_handleAgentEvent` listener could process transcript-writing events outside the OpenClaw session write lock.
- Missing detection / guardrail: existing tests covered a fabricated processing seam and did not prove the subscribed Pi listener was reconnected to the final locked handler.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts`
- Scenario the test should lock in: `custom_message` and `message` events acquire the session write lock, the real `_handleAgentEvent` seam is wrapped, and the final reconnected listener captures the locked handler rather than the pre-lock awaitable wrapper.
- Why this is the smallest reliable guardrail: the failure was caused by transcript-writing Pi event handling escaping the embedded session write lock.
- Existing test that already covers this (if any): existing predicate coverage for other transcript-writing events.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Successful direct-channel replies should no longer be followed by a misleading generic failure trailer caused by local transcript event writes racing the embedded session fence.

## Diagram (if applicable)

```text
Before:
message event -> transcript write while prompt lock released -> session fingerprint drift -> takeover error -> failure trailer

After:
message event -> session write lock -> serialized transcript write -> no false takeover from local reply event
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

Commands run locally on this branch:

```bash
LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 pnpm --dir /private/tmp/openclaw-pr3-session-event-lock build
LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 pnpm --dir /private/tmp/openclaw-pr3-session-event-lock check
LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 pnpm --dir /private/tmp/openclaw-pr3-session-event-lock exec vitest run src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 pnpm --dir /private/tmp/openclaw-pr3-session-event-lock test
```

Results:

- `pnpm build`: passed.
- `pnpm check`: passed after the corrected `_handleAgentEvent` patch.
- Focused `attempt.session-lock.test.ts`: passed, including the `message` / `custom_message` lock coverage, real `_handleAgentEvent` coverage, queue-await coverage, and captured-listener reconnect regression.
- Full `pnpm test`: patch-area suites passed; unrelated pre-existing channel-suite failures were observed in `configured-state.test.ts` channel order and `qa-channel` registry contract metadata.

Local Codex review:

```bash
codex review --base upstream/main
```

## Reviewer Notes

- The fix intentionally stays at the session event write-lock seam instead of changing lane dispatch ownership.
- Non-transcript events without extension handlers remain unlocked.

