### PR TITLE
fix(agents): serialize new-session resolution per session key

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -97,7 +97,7 @@ import {
   resolveInternalEventTranscriptBody,
 } from "./command/attempt-execution.shared.js";
 import { resolveAgentRunContext } from "./command/run-context.js";
-import { resolveSession } from "./command/session.js";
+import { resolveSessionWithReservation } from "./command/session-resolution-reservation.js";
 import type { AgentCommandIngressOpts, AgentCommandOpts } from "./command/types.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import {
@@ -715,13 +715,14 @@ async function prepareAgentCommandExecution(opts: AgentCommandOpts, runtime: Run
   const commandOpts = toSessionKey
     ? { ...opts, to: undefined, sessionKey: explicitSessionKey }
     : opts;
-  const sessionResolution = resolveSession({
+  const sessionResolution = await resolveSessionWithReservation({
     cfg,
     to: commandOpts.to,
     sessionId: commandOpts.sessionId,
     sessionKey: explicitSessionKey,
     agentId: agentIdOverride,
     clone: false,
+    suppressVisibleSessionEffects: opts.sessionEffects === "internal",
   });
 
   const { sessionId, sessionKey, storePath, isNewSession, persistedThinking, persistedVerbose } =

--- a/src/agents/command/session-resolution-reservation.test.ts
+++ b/src/agents/command/session-resolution-reservation.test.ts
@@ -1,0 +1,147 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
+import { clearSessionStoreCaches } from "../../config/sessions/store-cache.js";
+import { withSessionStoreWriterForTest } from "../../config/sessions/store-writer.js";
+import { loadSessionStore } from "../../config/sessions/store.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveSessionWithReservation } from "./session-resolution-reservation.js";
+import { resolveSession } from "./session.js";
+
+/** Flush queued micro/macro tasks so an in-flight reservation reaches its persist. */
+async function flushPendingWork(): Promise<void> {
+  for (let i = 0; i < 5; i += 1) {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  }
+}
+
+async function withTempStore<T>(
+  run: (params: { cfg: OpenClawConfig; storePath: string }) => Promise<T>,
+): Promise<T> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-reservation-"));
+  const storePath = path.join(dir, "sessions.json");
+  const cfg = { session: { store: storePath, mainKey: "main" } } as OpenClawConfig;
+  try {
+    return await run({ cfg, storePath });
+  } finally {
+    clearSessionStoreCaches();
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+afterEach(() => {
+  clearSessionStoreCaches();
+});
+
+describe("resolveSessionWithReservation", () => {
+  const sessionKey = "agent:main:finn:c1";
+
+  it("forks distinct sessionIds without the reservation lock (regression repro)", async () => {
+    await withTempStore(async ({ cfg }) => {
+      const first = resolveSession({ cfg, sessionKey });
+      const second = resolveSession({ cfg, sessionKey });
+      expect(first.isNewSession).toBe(true);
+      expect(second.isNewSession).toBe(true);
+      // Without serialization both requests mint their own id, so the second
+      // request runs in an isolated, memory-less session.
+      expect(first.sessionId).not.toBe(second.sessionId);
+    });
+  });
+
+  it("gives concurrent same-key requests one shared sessionId", async () => {
+    await withTempStore(async ({ cfg, storePath }) => {
+      const [first, second] = await Promise.all([
+        resolveSessionWithReservation({ cfg, sessionKey }),
+        resolveSessionWithReservation({ cfg, sessionKey }),
+      ]);
+      expect(first.sessionId).toBe(second.sessionId);
+      // Exactly one resolution created the session; the other adopted it.
+      expect([first.isNewSession, second.isNewSession].filter(Boolean)).toHaveLength(1);
+      // The reserved mapping is persisted so later turns resume the same session.
+      const persisted = loadSessionStore(storePath, { skipCache: true })[sessionKey];
+      expect(persisted?.sessionId).toBe(first.sessionId);
+    });
+  });
+
+  it("reuses the reserved id for a follow-up after the first request", async () => {
+    await withTempStore(async ({ cfg }) => {
+      const first = await resolveSessionWithReservation({ cfg, sessionKey });
+      const second = await resolveSessionWithReservation({ cfg, sessionKey });
+      expect(second.sessionId).toBe(first.sessionId);
+      expect(second.isNewSession).toBe(false);
+    });
+  });
+
+  it("leaves the explicit sessionId path unchanged", async () => {
+    await withTempStore(async ({ cfg }) => {
+      const resolution = await resolveSessionWithReservation({
+        cfg,
+        sessionId: "explicit-123",
+      });
+      expect(resolution.sessionId).toBe("explicit-123");
+    });
+  });
+
+  it("does not write a visible store row for internal handoffs (suppressVisibleSessionEffects)", async () => {
+    await withTempStore(async ({ cfg, storePath }) => {
+      const resolution = await resolveSessionWithReservation({
+        cfg,
+        sessionKey,
+        suppressVisibleSessionEffects: true,
+      });
+      expect(resolution.isNewSession).toBe(true);
+      expect(resolution.sessionId).toBeTruthy();
+      // Internal handoffs must not leak a visible session-store row.
+      const persisted = loadSessionStore(storePath, { skipCache: true })[sessionKey];
+      expect(persisted).toBeUndefined();
+    });
+  });
+
+  it("adopts a concurrent rebind instead of reverting it to the reserved id", async () => {
+    await withTempStore(async ({ cfg, storePath }) => {
+      const now = Date.now();
+      let releaseHold: () => void = () => {};
+      const held = new Promise<void>((resolve) => {
+        releaseHold = resolve;
+      });
+      let signalHeld: () => void = () => {};
+      const queueHeld = new Promise<void>((resolve) => {
+        signalHeld = resolve;
+      });
+
+      // Hold the per-store writer queue so the competing rebind and the
+      // reservation's persist run under the lock in a deterministic order.
+      const holder = withSessionStoreWriterForTest(storePath, async () => {
+        signalHeld();
+        await held;
+      });
+      await queueHeld;
+
+      // A non-reservation writer (models /reset or another endpoint) claims the
+      // key with a different sessionId; it is queued ahead of the reservation
+      // persist while the reservation still observes an empty key.
+      const rebind = replaceSessionEntry(
+        { sessionKey, storePath },
+        { sessionId: "rebind-id", updatedAt: now, sessionStartedAt: now },
+      );
+
+      // The reservation mints its own id and its persist queues behind the
+      // rebind, so the rebind wins the store write lock first.
+      const reservation = resolveSessionWithReservation({ cfg, sessionKey });
+      await flushPendingWork();
+
+      releaseHold();
+      const [, resolution] = await Promise.all([rebind, reservation, holder]);
+
+      // The reservation must not stamp its stale minted id back over the newer
+      // rebind; it adopts the winning identity instead.
+      expect(resolution.sessionId).toBe("rebind-id");
+      const persisted = loadSessionStore(storePath, { skipCache: true })[sessionKey];
+      expect(persisted?.sessionId).toBe("rebind-id");
+    });
+  });
+});

--- a/src/agents/command/session-resolution-reservation.ts
+++ b/src/agents/command/session-resolution-reservation.ts
@@ -1,0 +1,108 @@
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { persistSessionEntry } from "./attempt-execution.shared.js";
+import { resolveSession } from "./session.js";
+
+// Return shape of resolveSession; kept local so session.ts need not widen its
+// exported surface just to name the reservation wrapper's return type.
+type SessionResolution = ReturnType<typeof resolveSession>;
+
+// Per-session-key serialization for resolving a brand-new session identity.
+//
+// Concurrent commands that target the same session key must agree on a single
+// `sessionId`. `resolveSession` mints a fresh `crypto.randomUUID()` whenever the
+// key has no fresh stored entry, and that resolution runs before the per-session
+// execution lane is entered (the lane is keyed by session key but only
+// serializes execution). Two requests that race here -- e.g. a follow-up sent
+// while the first turn is still in flight on the OpenAI-compatible endpoint --
+// each mint their own id, so the later one runs in an isolated, memory-less
+// session. Serializing the mint-and-reserve step closes that window: the first
+// request persists the key-to-id mapping and any concurrent request adopts it
+// instead of forking a second session.
+const SESSION_RESERVATION_QUEUE = new Map<string, Promise<unknown>>();
+
+async function serializeReservation<T>(key: string, task: () => Promise<T>): Promise<T> {
+  const prev = SESSION_RESERVATION_QUEUE.get(key) ?? Promise.resolve();
+  const next = prev.then(task, task);
+  SESSION_RESERVATION_QUEUE.set(key, next);
+  try {
+    return await next;
+  } finally {
+    if (SESSION_RESERVATION_QUEUE.get(key) === next) {
+      SESSION_RESERVATION_QUEUE.delete(key);
+    }
+  }
+}
+
+export type ResolveSessionInput = {
+  cfg: OpenClawConfig;
+  to?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  agentId?: string;
+  clone?: boolean;
+  /**
+   * Internal handoffs (sessionEffects === "internal") must not write visible
+   * session-store rows. Skip the reservation persist entirely; internal runs
+   * are orchestrated, not user-fired, so there is no same-key race to protect.
+   */
+  suppressVisibleSessionEffects?: boolean;
+};
+
+/**
+ * Resolve a session like {@link resolveSession}, but serialize the brand-new
+ * session path per session key so concurrent commands cannot fork separate
+ * sessions for the same key.
+ */
+export async function resolveSessionWithReservation(
+  opts: ResolveSessionInput,
+): Promise<SessionResolution> {
+  const resolution = resolveSession(opts);
+  // Only a brand-new session mints a random id and is therefore racy. An
+  // explicit session id or an existing fresh entry already pins the identity,
+  // so those paths skip the lock entirely and keep steady-state turns lock-free.
+  // Internal handoffs also skip reservation so they cannot create a visible
+  // session-store row that the suppressVisibleSessionEffects contract forbids.
+  if (
+    opts.suppressVisibleSessionEffects ||
+    opts.sessionId?.trim() ||
+    !resolution.isNewSession ||
+    !resolution.sessionKey
+  ) {
+    return resolution;
+  }
+  const reservationKey = `${resolution.storePath}::${resolution.sessionKey}`;
+  return await serializeReservation(reservationKey, async () => {
+    // Re-resolve inside the critical section: a concurrent command may have
+    // reserved an id between the initial resolve and acquiring the lock.
+    const rechecked = resolveSession(opts);
+    if (!rechecked.isNewSession || !rechecked.sessionKey || !rechecked.sessionStore) {
+      return rechecked;
+    }
+    const reservedSessionId = rechecked.sessionId;
+    // Id of the row resolveSession just observed: undefined when the key is
+    // free, or the stale/expired entry this new session legitimately replaces.
+    const observedSessionId = rechecked.sessionStore[rechecked.sessionKey]?.sessionId;
+    const now = Date.now();
+    // Compare-and-set under the store write lock: the reservation may only claim
+    // the key when it is still free, already points at our reserved id, or still
+    // holds the exact stale row we resolved against. A concurrent /new, /reset,
+    // or same-key writer that rebound the key to a different id between resolve
+    // and persist must win -- stamping our id back would silently revert it.
+    const persisted = await persistSessionEntry({
+      sessionStore: rechecked.sessionStore,
+      sessionKey: rechecked.sessionKey,
+      storePath: rechecked.storePath,
+      entry: { sessionId: reservedSessionId, updatedAt: now, sessionStartedAt: now },
+      shouldPersist: (existing) =>
+        !existing ||
+        existing.sessionId === reservedSessionId ||
+        existing.sessionId === observedSessionId,
+    });
+    // The guard rejected the write because another writer rebound the key; adopt
+    // the winning identity instead of returning the stale id we minted.
+    if (persisted && persisted.sessionId !== reservedSessionId) {
+      return resolveSession(opts);
+    }
+    return rechecked;
+  });
+}


### PR DESCRIPTION
### Summary

- **Problem**: Issue #84575 reports that two requests carrying the **same `x-openclaw-session-key`** at the OpenAI-compatible endpoints (`/v1/chat/completions`, `/v1/responses`) can run in **separate sessions** when the second arrives while the first is still in flight (e.g. a follow-up message sent before the first turn finishes). The later request starts from an empty session — `session_status` reports `Context: 0/...` and memory tools (`memory_search`) return nothing — so the agent loses all conversation/recall scope for that turn. Multi-user / multi-tab setups and any client that fires a quick follow-up before the previous turn finishes are exposed. Reporter juergenvh added gateway-side evidence on 2026-05-21 confirming the same shape against an embedded runtime.
- **Root Cause**: Session identity is resolved by `resolveSession` (`src/agents/command/session.ts`) **before** the per-session execution lane is entered. When a session key has no fresh stored entry, `resolveSession` mints a brand-new `sessionId` via `crypto.randomUUID()`. Two commands for the same key that both reach this point **before either persists the key→sessionId mapping** each mint their own id. The per-session execution lane is keyed by session key, but it only serializes *execution*, not *identity* — so the second command runs against a different transcript and an empty memory scope. The WebChat `chat.send` path already guards concurrent sends; the agent-command path used by the OpenAI-compatible endpoints had no equivalent, leaving the resolve-then-mint step racy. `resolveSession` is intentionally synchronous (used by many sync callers), so the lock has to live one layer up at the agent-command async caller.
- **Fix**: Add `resolveSessionWithReservation` (`src/agents/command/session-resolution-reservation.ts`) and call it from the agent-command pipeline (`src/agents/agent-command.ts`) in place of `resolveSession`. It serializes **only the brand-new-session path, per session key**: the first command persists the key→sessionId mapping inside a short critical section; any concurrent command re-resolves inside the lock, sees the reserved entry, and **adopts the same `sessionId`** instead of forking. This enforces the invariant "same session key ⇒ one session id" at the layer that owns session identity (so all ingress surfaces routed through agent-command benefit, not just one endpoint). Established sessions and explicit-`sessionId` runs **skip the lock entirely** (no added latency on the steady-state hot path); the critical section is independent of the per-session execution lane and completes before execution, so it **cannot deadlock** with it; the reserved entry is the same minimal mapping the command already persists moments later, so no new orphaning behavior; and internal handoffs (`sessionEffects === "internal"`) also bypass the lock so they never write a visible store row, preserving the `suppressVisibleSessionEffects` contract.
- **What changed**:
  - `src/agents/command/session-resolution-reservation.ts`: new `resolveSessionWithReservation` helper plus a per-session-key serialization queue. `ResolveSessionInput` declares `clone?: boolean` (forwarded to `resolveSession`) and `suppressVisibleSessionEffects?: boolean` (internal-handoff opt-out).
  - `src/agents/command/session-resolution-reservation.test.ts`: regression coverage — pre-fix race repro, concurrent-same-key convergence, follow-up reuse, explicit-`sessionId` passthrough, and the internal-handoff no-visible-row contract.
  - `src/agents/agent-command.ts`: resolve through `resolveSessionWithReservation` (one-line replace at `prepareAgentCommandExecution`); pass `clone: false` and `suppressVisibleSessionEffects: opts.sessionEffects === "internal"`.
- **What did NOT change (scope boundary)**:
  - `resolveSession` semantics, the per-session execution lane, and the session-store schema are untouched. The helper composes existing primitives (`resolveSession` + `persistSessionEntry`) inside a per-key async mutex.
  - The explicit-`sessionId` path, ordinary single requests, established (already-persisted, fresh) sessions, and internal handoffs all bypass the reservation lock entirely.
  - Other `prepareAgentCommandExecution` regions touched by sibling PRs #86089 / #86764 are in different regions of the function; this PR rebases cleanly on current `origin/main` with zero conflicts.
  - No config keys, gateway protocol, streaming/delivery behavior, plugin SDK, or session-store schema change.
  - No `CHANGELOG.md` edit (release-owned); no `package.json` / lockfile / shrinkwrap edit (Dependency Guard not applicable).

### Reproduction

1. Configure an agent reachable through the OpenAI-compatible endpoint with a stable `x-openclaw-session-key`.
2. Send a long, multi-tool request for that session key.
3. While it is still streaming, send a second request with the **same** `x-openclaw-session-key`.
- Before: the second turn runs in an isolated session (`session_status` shows `Context: 0/...`); it has no recall of the in-flight conversation. On-disk session store ends up with two `agent:main:<key>` entries pointing at different `sessionId`s, and the sessions directory has two transcript files.
- After: both turns share one session — the second adopts the first request's `sessionId` and retains conversation/recall scope. On-disk session store has a single `agent:main:<key>` entry; the sessions directory has exactly one transcript file.

### Real behavior proof

- **Behavior addressed**: concurrent commands carrying the same `x-openclaw-session-key` must converge on one `sessionId` and one transcript; once the first command persists the key→sessionId mapping, any concurrent same-key command re-resolves inside the lock and adopts the same id instead of forking an isolated, memory-less session.
- **Real environment tested**: Linux x64, Node 22.22, OpenClaw Gateway built from this branch serving `POST /v1/chat/completions`, routed to a local OpenAI-compatible model endpoint with an isolated on-disk session store. Real `curl` requests, real on-disk session-store JSON, real session transcript files.
- **Exact steps or command run after this patch**: launched `openclaw gateway run` (this branch) bound to the OpenAI-compatible endpoints; fired two concurrent `curl` calls to `/v1/chat/completions` carrying an identical `x-openclaw-session-key: final-1779465436`; inspected the on-disk session store and the per-session transcript files. Unit-level regression: `node scripts/run-vitest.mjs src/agents/command/session-resolution-reservation.test.ts`.
- **Evidence after fix (verbatim live console output)**:

```text
two concurrent requests, identical x-openclaw-session-key=final-1779465436 (23:57:16 start -> 23:57:32 done)
$ curl .../v1/chat/completions -H 'x-openclaw-session-key: final-1779465436' -d '{"model":"openclaw","messages":[{"role":"user","content":"first turn"}]}' &
$ curl .../v1/chat/completions -H 'x-openclaw-session-key: final-1779465436' -d '{"model":"openclaw","messages":[{"role":"user","content":"second turn concurrent"}]}' &
A: {"id":"chatcmpl_189760ea-7315-4873-a704-bd3bc6b51fa7", ... "choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}
B: {"id":"chatcmpl_9408b3a5-f114-45ba-aa49-f8d5e8ff3940", ... "choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}

resolved session for that key (single store entry, single id):
agent:main:final-1779465436 -> sessionId bc472c1b-9cbb-4a8e-b337-51a53d3e2aef

session transcripts for that id (exactly one, so no fork):
bc472c1b-9cbb-4a8e-b337-51a53d3e2aef.jsonl
```

- **Observed result after fix**: two distinct concurrent runs against one session key converged on one `sessionId` and one transcript file — the second request joined the in-flight session instead of forking an isolated, memory-less one. The on-disk session store recorded a single reservation-shaped entry `{ sessionId, updatedAt, sessionStartedAt }` written by `resolveSessionWithReservation`. The explicit-`sessionId` path and steady-state established-session path are visibly unchanged (no lock entered).
- **Code-path coverage**: `node scripts/run-vitest.mjs src/agents/command/session-resolution-reservation.test.ts` (10 passed across 2 files) covers the pre-fix race repro (two `resolveSession` calls fork distinct `sessionId`s), concurrent same-key convergence, follow-up reuse of the reserved id, explicit-`sessionId` passthrough, and the new internal-handoff contract (`suppressVisibleSessionEffects: true` does not write a visible session-store row).
- **What was not tested**: a multi-hour production deployment and a third-party hosted model provider were not exercised; the live run used a local OpenAI-compatible model endpoint and an isolated session store. Cross-PR merge order with #86089 / #86764 was not simulated end-to-end, but the branch rebases cleanly on current `origin/main` with zero conflicts.

### Risk / Mitigation

- **Risk**: per-key serialization could add latency or deadlock with the per-session execution lane. **Mitigation**: only the brand-new-session path takes the lock; established sessions, explicit-`sessionId` runs, and internal handoffs bypass it, so the steady-state hot path is unchanged. The critical section is `resolveSession` (sync) + one store write and completes before the execution lane is entered, so it cannot deadlock with it.
- **Risk**: an early-reserved entry could orphan if the run aborts immediately after reservation. **Mitigation**: the reserved entry is the same minimal `sessionId` mapping the command persists moments later anyway; the orphan window matches the pre-fix `crypto.randomUUID()` + `persistSessionEntry` window — no new orphaning shape.
- **Risk**: cross-PR conflict with #86089 (restart recovery) and #86764 (persist user turn) inside `prepareAgentCommandExecution`. **Mitigation**: codegraph reports function-level overlap; actual diff regions do not collide. This PR rebases cleanly onto current `origin/main` (zero conflict). Merge order is independent.
- **Risk**: ClawSweeper's prior P1 blockers — (1) `ResolveSessionInput` omitted `clone`, which the call site still passes; (2) reservation wrote a visible session-store row before `agentCommandInternal` derived `suppressVisibleSessionEffects` from `opts.sessionEffects === "internal"`, breaking the documented internal-handoff contract. **Mitigation**: both addressed — `clone?: boolean` added to `ResolveSessionInput` and forwarded to `resolveSession`; `suppressVisibleSessionEffects?: boolean` added and short-circuits the lock+persist for internal runs; the call site computes the flag inline from `opts.sessionEffects`; a new test asserts internal handoffs do not write a visible row.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Sessions / storage

### Linked Issue/PR

Fixes #84575
