### PR TITLE
fix(ui): localize talk transcript labels

### DIFF
--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -1,11 +1,14 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-22T09:10:20.125Z",
+  "fallbackKeys": [
+    "chat.composer.stillListening",
+    "chat.composer.talkTranscript"
+  ],
+  "generatedAt": "2026-05-22T14:49:12.133Z",
   "locale": "ar",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e6749bdaf859097428ca6bcd98bdb46915c6a8660ba50656ebd2e6be9d655821",
-  "totalKeys": 1120,
+  "sourceHash": "2e6cfef7fe4490f7f524e448706ee7bfb8441ff88e1c79f479b7521f0db6e7cb",
+  "totalKeys": 1122,
   "translatedKeys": 1120,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,11 +1,14 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-22T09:08:58.722Z",
+  "fallbackKeys": [
+    "chat.composer.stillListening",
+    "chat.composer.talkTranscript"
+  ],
+  "generatedAt": "2026-05-22T14:49:11.605Z",
   "locale": "de",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e6749bdaf859097428ca6bcd98bdb46915c6a8660ba50656ebd2e6be9d655821",
-  "totalKeys": 1120,
+  "sourceHash": "2e6cfef7fe4490f7f524e448706ee7bfb8441ff88e1c79f479b7521f0db6e7cb",
+  "totalKeys": 1122,
   "translatedKeys": 1120,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,11 +1,14 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-22T09:09:37.807Z",
+  "fallbackKeys": [
+    "chat.composer.stillListening",
+    "chat.composer.talkTranscript"
+  ],
+  "generatedAt": "2026-05-22T14:49:11.707Z",
   "locale": "es",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e6749bdaf859097428ca6bcd98bdb46915c6a8660ba50656ebd2e6be9d655821",
-  "totalKeys": 1120,
+  "sourceHash": "2e6cfef7fe4490f7f524e448706ee7bfb8441ff88e1c79f479b7521f0db6e7cb",
+  "totalKeys": 1122,
   "translatedKeys": 1120,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -1,11 +1,14 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-22T09:11:56.512Z",
+  "fallbackKeys": [
+    "chat.composer.stillListening",
+    "chat.composer.talkTranscript"
+  ],
+  "generatedAt": "2026-05-22T14:49:13.013Z",
   "locale": "fa",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e6749bdaf859097428ca6bcd98bdb46915c6a8660ba50656ebd2e6be9d655821",
-  "totalKeys": 1120,
+  "sourceHash": "2e6cfef7fe4490f7f524e448706ee7bfb8441ff88e1c79f479b7521f0db6e7cb",
+  "totalKeys": 1122,
   "translatedKeys": 1120,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,11 +1,14 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-22T09:10:10.869Z",
+  "fallbackKeys": [
+    "chat.composer.stillListening",
+    "chat.composer.talkTranscript"
+  ],
+  "generatedAt": "2026-05-22T14:49:12.022Z",
   "locale": "fr",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e6749bdaf859097428ca6bcd98bdb46915c6a8660ba50656ebd2e6be9d655821",
-  "totalKeys": 1120,
+  "sourceHash": "2e6cfef7fe4490f7f524e448706ee7bfb8441ff88e1c79f479b7521f0db6e7cb",
+  "totalKeys": 1122,
   "translatedKeys": 1120,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,11 +1,14 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-22T09:11:02.426Z",
+  "fallbackKeys": [
+    "chat.composer.stillListening",
+    "chat.composer.talkTranscript"
+  ],
+  "generatedAt": "2026-05-22T14:49:12.535Z",
   "locale": "id",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e6749bdaf859097428ca6bcd98bdb46915c6a8660ba50656ebd2e6be9d655821",
-  "totalKeys": 1120,
+  "sourceHash": "2e6cfef7fe4490f7f524e448706ee7bfb8441ff88e1c79f479b7521f0db6e7cb",
+  "totalKeys": 1122,
   "translatedKeys": 1120,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -1,11 +1,14 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-22T09:10:17.494Z",
+  "fallbackKeys": [
+    "chat.composer.stillListening",
+    "chat.composer.talkTranscript"
+  ],
+  "generatedAt": "2026-05-22T14:49:12.239Z",
   "locale": "it",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e6749bdaf859097428ca6bcd98bdb46915c6a8660ba50656ebd2e6be9d655821",
-  "totalKeys": 1120,
+  "sourceHash": "2e6cfef7fe4490f7f524e448706ee7bfb8441ff88e1c79f479b7521f0db6e7cb",
+  "totalKeys": 1122,
   "translatedKeys": 1120,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,11 +1,14 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-22T09:09:41.379Z",
+  "fallbackKeys": [
+    "chat.composer.stillListening",
+    "chat.composer.talkTranscript"
+  ],
+  "generatedAt": "2026-05-22T14:49:11.818Z",
   "locale": "ja-JP",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e6749bdaf859097428ca6bcd98bdb46915c6a8660ba50656ebd2e6be9d655821",
-  "totalKeys": 1120,
+  "sourceHash": "2e6cfef7fe4490f7f524e448706ee7bfb8441ff88e1c79f479b7521f0db6e7cb",
+  "totalKeys": 1122,
   "translatedKeys": 1120,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,11 +1,14 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-22T09:09:43.668Z",
+  "fallbackKeys": [
+    "chat.composer.stillListening",
+    "chat.composer.talkTranscript"
+  ],
+  "generatedAt": "2026-05-22T14:49:11.920Z",
   "locale": "ko",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e6749bdaf859097428ca6bcd98bdb46915c6a8660ba50656ebd2e6be9d655821",
-  "totalKeys": 1120,
+  "sourceHash": "2e6cfef7fe4490f7f524e448706ee7bfb8441ff88e1c79f479b7521f0db6e7cb",
+  "totalKeys": 1122,
   "translatedKeys": 1120,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -1,11 +1,14 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-22T09:11:44.758Z",
+  "fallbackKeys": [
+    "chat.composer.stillListening",
+    "chat.composer.talkTranscript"
+  ],
+  "generatedAt": "2026-05-22T14:49:12.916Z",
   "locale": "nl",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e6749bdaf859097428ca6bcd98bdb46915c6a8660ba50656ebd2e6be9d655821",
-  "totalKeys": 1120,
+  "sourceHash": "2e6cfef7fe4490f7f524e448706ee7bfb8441ff88e1c79f479b7521f0db6e7cb",
+  "totalKeys": 1122,
   "translatedKeys": 1120,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,11 +1,14 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-22T09:11:03.157Z",
+  "fallbackKeys": [
+    "chat.composer.stillListening",
+    "chat.composer.talkTranscript"
+  ],
+  "generatedAt": "2026-05-22T14:49:12.630Z",
   "locale": "pl",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e6749bdaf859097428ca6bcd98bdb46915c6a8660ba50656ebd2e6be9d655821",
-  "totalKeys": 1120,
+  "sourceHash": "2e6cfef7fe4490f7f524e448706ee7bfb8441ff88e1c79f479b7521f0db6e7cb",
+  "totalKeys": 1122,
   "translatedKeys": 1120,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,11 +1,14 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-22T09:08:59.594Z",
+  "fallbackKeys": [
+    "chat.composer.stillListening",
+    "chat.composer.talkTranscript"
+  ],
+  "generatedAt": "2026-05-22T14:49:11.500Z",
   "locale": "pt-BR",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e6749bdaf859097428ca6bcd98bdb46915c6a8660ba50656ebd2e6be9d655821",
-  "totalKeys": 1120,
+  "sourceHash": "2e6cfef7fe4490f7f524e448706ee7bfb8441ff88e1c79f479b7521f0db6e7cb",
+  "totalKeys": 1122,
   "translatedKeys": 1120,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,11 +1,14 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-22T09:11:26.173Z",
+  "fallbackKeys": [
+    "chat.composer.stillListening",
+    "chat.composer.talkTranscript"
+  ],
+  "generatedAt": "2026-05-22T14:49:12.724Z",
   "locale": "th",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e6749bdaf859097428ca6bcd98bdb46915c6a8660ba50656ebd2e6be9d655821",
-  "totalKeys": 1120,
+  "sourceHash": "2e6cfef7fe4490f7f524e448706ee7bfb8441ff88e1c79f479b7521f0db6e7cb",
+  "totalKeys": 1122,
   "translatedKeys": 1120,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,11 +1,14 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-22T09:10:20.710Z",
+  "fallbackKeys": [
+    "chat.composer.stillListening",
+    "chat.composer.talkTranscript"
+  ],
+  "generatedAt": "2026-05-22T14:49:12.336Z",
   "locale": "tr",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e6749bdaf859097428ca6bcd98bdb46915c6a8660ba50656ebd2e6be9d655821",
-  "totalKeys": 1120,
+  "sourceHash": "2e6cfef7fe4490f7f524e448706ee7bfb8441ff88e1c79f479b7521f0db6e7cb",
+  "totalKeys": 1122,
   "translatedKeys": 1120,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,11 +1,14 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-22T09:11:00.185Z",
+  "fallbackKeys": [
+    "chat.composer.stillListening",
+    "chat.composer.talkTranscript"
+  ],
+  "generatedAt": "2026-05-22T14:49:12.437Z",
   "locale": "uk",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e6749bdaf859097428ca6bcd98bdb46915c6a8660ba50656ebd2e6be9d655821",
-  "totalKeys": 1120,
+  "sourceHash": "2e6cfef7fe4490f7f524e448706ee7bfb8441ff88e1c79f479b7521f0db6e7cb",
+  "totalKeys": 1122,
   "translatedKeys": 1120,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -1,11 +1,14 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-22T09:11:40.422Z",
+  "fallbackKeys": [
+    "chat.composer.stillListening",
+    "chat.composer.talkTranscript"
+  ],
+  "generatedAt": "2026-05-22T14:49:12.821Z",
   "locale": "vi",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e6749bdaf859097428ca6bcd98bdb46915c6a8660ba50656ebd2e6be9d655821",
-  "totalKeys": 1120,
+  "sourceHash": "2e6cfef7fe4490f7f524e448706ee7bfb8441ff88e1c79f479b7521f0db6e7cb",
+  "totalKeys": 1122,
   "translatedKeys": 1120,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,11 +1,14 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-22T09:08:59.112Z",
+  "fallbackKeys": [
+    "chat.composer.stillListening",
+    "chat.composer.talkTranscript"
+  ],
+  "generatedAt": "2026-05-22T14:49:11.082Z",
   "locale": "zh-CN",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e6749bdaf859097428ca6bcd98bdb46915c6a8660ba50656ebd2e6be9d655821",
-  "totalKeys": 1120,
+  "sourceHash": "2e6cfef7fe4490f7f524e448706ee7bfb8441ff88e1c79f479b7521f0db6e7cb",
+  "totalKeys": 1122,
   "translatedKeys": 1120,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,11 +1,14 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-05-22T09:09:27.299Z",
+  "fallbackKeys": [
+    "chat.composer.stillListening",
+    "chat.composer.talkTranscript"
+  ],
+  "generatedAt": "2026-05-22T14:49:11.397Z",
   "locale": "zh-TW",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e6749bdaf859097428ca6bcd98bdb46915c6a8660ba50656ebd2e6be9d655821",
-  "totalKeys": 1120,
+  "sourceHash": "2e6cfef7fe4490f7f524e448706ee7bfb8441ff88e1c79f479b7521f0db6e7cb",
+  "totalKeys": 1122,
   "translatedKeys": 1120,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -1076,6 +1076,8 @@ export const ar: TranslationMap = {
       placeholderDisconnected: "Connect to the gateway to start chatting...",
       attachFile: "Attach file",
       startTalk: "Start Talk",
+      stillListening: "Still listening",
+      talkTranscript: "Talk transcript",
       stopTalk: "Stop Talk",
     },
     selectors: {

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -1100,6 +1100,8 @@ export const de: TranslationMap = {
       placeholderDisconnected: "Connect to the gateway to start chatting...",
       attachFile: "Attach file",
       startTalk: "Start Talk",
+      stillListening: "Still listening",
+      talkTranscript: "Talk transcript",
       stopTalk: "Stop Talk",
     },
     selectors: {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1082,6 +1082,8 @@ export const en: TranslationMap = {
       placeholderDisconnected: "Connect to the gateway to start chatting...",
       attachFile: "Attach file",
       startTalk: "Start Talk",
+      stillListening: "Still listening",
+      talkTranscript: "Talk transcript",
       stopTalk: "Stop Talk",
     },
     selectors: {

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -1097,6 +1097,8 @@ export const es: TranslationMap = {
       placeholderDisconnected: "Connect to the gateway to start chatting...",
       attachFile: "Attach file",
       startTalk: "Start Talk",
+      stillListening: "Still listening",
+      talkTranscript: "Talk transcript",
       stopTalk: "Stop Talk",
     },
     selectors: {

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -1093,6 +1093,8 @@ export const fa: TranslationMap = {
       placeholderDisconnected: "Connect to the gateway to start chatting...",
       attachFile: "Attach file",
       startTalk: "Start Talk",
+      stillListening: "Still listening",
+      talkTranscript: "Talk transcript",
       stopTalk: "Stop Talk",
     },
     selectors: {

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -1104,6 +1104,8 @@ export const fr: TranslationMap = {
       placeholderDisconnected: "Connect to the gateway to start chatting...",
       attachFile: "Attach file",
       startTalk: "Start Talk",
+      stillListening: "Still listening",
+      talkTranscript: "Talk transcript",
       stopTalk: "Stop Talk",
     },
     selectors: {

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -1091,6 +1091,8 @@ export const id: TranslationMap = {
       placeholderDisconnected: "Connect to the gateway to start chatting...",
       attachFile: "Attach file",
       startTalk: "Start Talk",
+      stillListening: "Still listening",
+      talkTranscript: "Talk transcript",
       stopTalk: "Stop Talk",
     },
     selectors: {

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -1098,6 +1098,8 @@ export const it: TranslationMap = {
       placeholderDisconnected: "Connect to the gateway to start chatting...",
       attachFile: "Attach file",
       startTalk: "Start Talk",
+      stillListening: "Still listening",
+      talkTranscript: "Talk transcript",
       stopTalk: "Stop Talk",
     },
     selectors: {

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -1095,6 +1095,8 @@ export const ja_JP: TranslationMap = {
       placeholderDisconnected: "Connect to the gateway to start chatting...",
       attachFile: "Attach file",
       startTalk: "Start Talk",
+      stillListening: "Still listening",
+      talkTranscript: "Talk transcript",
       stopTalk: "Stop Talk",
     },
     selectors: {

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -1084,6 +1084,8 @@ export const ko: TranslationMap = {
       placeholderDisconnected: "Connect to the gateway to start chatting...",
       attachFile: "Attach file",
       startTalk: "Start Talk",
+      stillListening: "Still listening",
+      talkTranscript: "Talk transcript",
       stopTalk: "Stop Talk",
     },
     selectors: {

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -1096,6 +1096,8 @@ export const nl: TranslationMap = {
       placeholderDisconnected: "Connect to the gateway to start chatting...",
       attachFile: "Attach file",
       startTalk: "Start Talk",
+      stillListening: "Still listening",
+      talkTranscript: "Talk transcript",
       stopTalk: "Stop Talk",
     },
     selectors: {

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -1096,6 +1096,8 @@ export const pl: TranslationMap = {
       placeholderDisconnected: "Connect to the gateway to start chatting...",
       attachFile: "Attach file",
       startTalk: "Start Talk",
+      stillListening: "Still listening",
+      talkTranscript: "Talk transcript",
       stopTalk: "Stop Talk",
     },
     selectors: {

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -1092,6 +1092,8 @@ export const pt_BR: TranslationMap = {
       placeholderDisconnected: "Connect to the gateway to start chatting...",
       attachFile: "Attach file",
       startTalk: "Start Talk",
+      stillListening: "Still listening",
+      talkTranscript: "Talk transcript",
       stopTalk: "Stop Talk",
     },
     selectors: {

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -1061,6 +1061,8 @@ export const th: TranslationMap = {
       placeholderDisconnected: "Connect to the gateway to start chatting...",
       attachFile: "Attach file",
       startTalk: "Start Talk",
+      stillListening: "Still listening",
+      talkTranscript: "Talk transcript",
       stopTalk: "Stop Talk",
     },
     selectors: {

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -1097,6 +1097,8 @@ export const tr: TranslationMap = {
       placeholderDisconnected: "Connect to the gateway to start chatting...",
       attachFile: "Attach file",
       startTalk: "Start Talk",
+      stillListening: "Still listening",
+      talkTranscript: "Talk transcript",
       stopTalk: "Stop Talk",
     },
     selectors: {

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -1094,6 +1094,8 @@ export const uk: TranslationMap = {
       placeholderDisconnected: "Connect to the gateway to start chatting...",
       attachFile: "Attach file",
       startTalk: "Start Talk",
+      stillListening: "Still listening",
+      talkTranscript: "Talk transcript",
       stopTalk: "Stop Talk",
     },
     selectors: {

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -1083,6 +1083,8 @@ export const vi: TranslationMap = {
       placeholderDisconnected: "Connect to the gateway to start chatting...",
       attachFile: "Attach file",
       startTalk: "Start Talk",
+      stillListening: "Still listening",
+      talkTranscript: "Talk transcript",
       stopTalk: "Stop Talk",
     },
     selectors: {

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -1057,6 +1057,8 @@ export const zh_CN: TranslationMap = {
       placeholderDisconnected: "连接到 Gateway 后开始聊天...",
       attachFile: "附加文件",
       startTalk: "开始 Talk",
+      stillListening: "Still listening",
+      talkTranscript: "Talk transcript",
       stopTalk: "停止 Talk",
     },
     selectors: {

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -1059,6 +1059,8 @@ export const zh_TW: TranslationMap = {
       placeholderDisconnected: "Connect to the gateway to start chatting...",
       attachFile: "Attach file",
       startTalk: "Start Talk",
+      stillListening: "Still listening",
+      talkTranscript: "Talk transcript",
       stopTalk: "Stop Talk",
     },
     selectors: {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -337,7 +337,7 @@ function renderRealtimeTalkConversation(props: ChatProps) {
     return nothing;
   }
   return html`
-    <div class="agent-chat__voice-turns" role="log" aria-label="Talk transcript">
+    <div class="agent-chat__voice-turns" role="log" aria-label=${t("chat.composer.talkTranscript")}>
       ${repeat(
         entries,
         (entry) => entry.id,
@@ -354,7 +354,7 @@ function renderRealtimeTalkConversation(props: ChatProps) {
               ${entry.isStreaming
                 ? html`<span
                     class="agent-chat__voice-turn-stream"
-                    aria-label="Still listening"
+                    aria-label=${t("chat.composer.stillListening")}
                   ></span>`
                 : nothing}
             </div>


### PR DESCRIPTION
## Summary

- Localizes the new realtime talk transcript aria labels through the Control UI i18n registry.
- Regenerates fallback locale bundles and i18n metadata for the added keys.

## Root Cause

Full Release Validation hit the normal CI `build-artifacts` lane, where `pnpm ui:i18n:check` failed because `ui/src/ui/views/chat.ts` introduced raw user-facing aria labels for `Still listening` and `Talk transcript`.

## Verification

- `node --import tsx scripts/control-ui-i18n.ts check` — passed with a temporary PATH wrapper for the script's `pnpm exec oxfmt` call in this linked Codex worktree
- `node_modules/.bin/oxfmt --check $(git diff --name-only -- '*.ts' '*.json')` — passed
- `git diff --check` — passed
- Failing upstream proof: Full Release Validation https://github.com/openclaw/openclaw/actions/runs/26294079790, child CI https://github.com/openclaw/openclaw/actions/runs/26294323242, `build-artifacts` failed on Control UI raw-copy drift

## Real behavior proof

Behavior addressed: Control UI talk transcript aria labels are now sourced from i18n instead of raw copy.
Real environment tested: Local linked OpenClaw worktree on macOS using Node 24.15.0 and shared repo `node_modules`; GitHub Full Release Validation exposed the failing CI child.
Exact steps or command run after this patch: `node --import tsx scripts/control-ui-i18n.ts check`; `node_modules/.bin/oxfmt --check $(git diff --name-only -- '*.ts' '*.json')`; `git diff --check`.
Evidence after fix: The i18n check completed cleanly for all 18 non-English locale bundles after regeneration.
Observed result after fix: Raw-copy drift no longer reports `Still listening` or `Talk transcript`.
What was not tested: PR CI is not complete yet; the original full release validation parent is still running other lanes.
