### PR TITLE
fix(codex): keep idle guard after turn started

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -3739,6 +3739,39 @@ describe("runCodexAppServerAttempt", () => {
     ).toHaveLength(2);
   });
 
+  it("interrupts when the only current-turn progress is turn/started", async () => {
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.timeoutMs = 200;
+
+    const run = runCodexAppServerAttempt(params, {
+      turnCompletionIdleTimeoutMs: 5,
+      turnAssistantCompletionIdleTimeoutMs: 1_000,
+      turnTerminalIdleTimeoutMs: 1_000,
+    });
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "turn/started",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: { id: "turn-1", status: "inProgress" },
+      },
+    });
+
+    const result = await run;
+
+    expect(result.aborted).toBe(true);
+    expect(result.timedOut).toBe(true);
+    expect(result.promptError).toBe(
+      "codex app-server turn idle timed out waiting for turn/completed",
+    );
+    expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(true);
+  });
+
   it("does not count non-turn app-server requests as turn attempt progress", async () => {
     const harness = createStartedThreadHarness();
     const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
@@ -7636,11 +7669,16 @@ describe("runCodexAppServerAttempt", () => {
       }
       if (method === "turn/start") {
         await harness.notify({
-          method: "turn/started",
+          method: "item/started",
           params: {
             threadId: "thread-1",
             turnId: "turn-1",
-            turn: { id: "turn-1", status: "inProgress" },
+            item: {
+              id: "tool-1",
+              type: "commandExecution",
+              command: "sleep 1",
+              status: "inProgress",
+            },
           },
         });
         return turnStartResult("turn-1", "inProgress");

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2090,6 +2090,7 @@ export async function runCodexAppServerAttempt(
     if (
       turnCompletionIdleWatchArmed &&
       !turnCompletionIdleWatchPinnedByTerminalError &&
+      notification.method !== "turn/started" &&
       notification.method !== "turn/completed" &&
       isCurrentTurnNotification &&
       !trackedDynamicToolCompletion &&


### PR DESCRIPTION
## Summary

- keep the Codex app-server completion-idle watchdog armed after a current-turn `turn/started` notification
- add regression coverage for the reported `turn/started`-then-silence wedge
- update the existing pre-`turn/start` progress test to use real item progress instead of bare `turn/started`

Fixes #85251

## Real behavior proof

- **Behavior or issue addressed:** A Codex app-server turn that emits only current-turn `notification:turn/started` and then goes silent now keeps the short completion-idle watchdog armed and interrupts the turn instead of waiting for the outer stuck-session recovery window.
- **Real environment tested:** Local OpenClaw checkout on Linux in `/home/chenglunhu/code/openclaw`, exact PR head `0b7dd6ade620939ff4037ada98591d3344517ac9`, Node/Vitest project runtime from this repository.
- **Exact steps or command run after this patch:** Ran the Codex app-server runtime harness against the exact PR head with `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -- --reporter=verbose`, then confirmed the new `turn/started`-only case returns the timeout path and calls `turn/interrupt`.
- **Evidence after fix:** Copied terminal output from the local run:

```text
$ node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -- --reporter=verbose

 Test Files  1 passed (1)
      Tests  205 passed (205)
   Start at  22:50:21
   Duration  32.23s (transform 10.09s, setup 305ms, import 11.90s, tests 19.93s, environment 0ms)
```

- **Observed result after fix:** The added regression exercises `runCodexAppServerAttempt` with a real app-server harness turn where the only current-turn notification is `turn/started`; the observed result is `timedOut=true`, prompt error `codex app-server turn idle timed out waiting for turn/completed`, and a `turn/interrupt` request for `thread-1` / `turn-1`.
- **What was not tested:** I did not run a live macOS Codex OAuth app-server process or a Telegram channel replay; this patch validates the source-proven app-server watchdog path directly.

## Validation

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -- --reporter=verbose`
- `git diff --check`
- `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit 2>&1 | rg "extensions/codex/src/app-server/run-attempt\.(ts|test\.ts)" || true`

## Audit

- Audit A (existing helper): existing `turnCompletionIdleWatchArmed`/`armTurnCompletionIdleWatch` path reused; no new predicate/helper introduced.
- Audit B (shared callers): `runCodexAppServerAttempt` is shared, but the change preserves the existing watchdog contract and only narrows one notification disarm case inside the local handler.
- Audit C (broader rival): #75213 is an old conflicting bot PR in the same harness area but targets unrelated shared-client traffic; #85242 has rival #85296 and was skipped. No direct active PR fixes #85251.
