### PR TITLE
Fix OpenAI compaction runtime routing

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -6189,6 +6189,8 @@ describe("runCodexAppServerAttempt", () => {
     const result = await run;
 
     expect(result.promptError).toBeNull();
+    expect(agentEnd).not.toHaveBeenCalled();
+    await new Promise<void>((resolve) => setImmediate(resolve));
     expect(agentEnd).toHaveBeenCalledTimes(1);
     releaseAgentEnd();
   });
@@ -7134,6 +7136,8 @@ describe("runCodexAppServerAttempt", () => {
 
     expect(llmInput).toHaveBeenCalledTimes(1);
     expect(llmOutput).toHaveBeenCalledTimes(1);
+    expect(agentEnd).not.toHaveBeenCalled();
+    await new Promise<void>((resolve) => setImmediate(resolve));
     expect(agentEnd).toHaveBeenCalledTimes(1);
     const [llmOutputPayload] = mockCall(llmOutput, "llm_output") as [
       {

--- a/src/agents/harness/hook-context.ts
+++ b/src/agents/harness/hook-context.ts
@@ -1,3 +1,4 @@
+import type { DiagnosticTraceContext } from "../../infra/diagnostic-trace-context.js";
 import type {
   PluginHookAgentContext,
   PluginHookContextWindowSource,
@@ -6,6 +7,7 @@ import type {
 export type AgentHarnessHookContext = {
   runId: string;
   jobId?: string;
+  trace?: DiagnosticTraceContext;
   agentId?: string;
   sessionKey?: string;
   sessionId?: string;
@@ -24,6 +26,7 @@ export function buildAgentHookContext(params: AgentHarnessHookContext): PluginHo
   return {
     runId: params.runId,
     ...(params.jobId ? { jobId: params.jobId } : {}),
+    ...(params.trace ? { trace: params.trace } : {}),
     ...(params.agentId ? { agentId: params.agentId } : {}),
     ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
     ...(params.sessionId ? { sessionId: params.sessionId } : {}),

--- a/src/agents/harness/lifecycle-hook-helpers.test.ts
+++ b/src/agents/harness/lifecycle-hook-helpers.test.ts
@@ -106,13 +106,33 @@ describe("agent harness lifecycle hook helpers", () => {
       event: EVENT,
       hookRunner: hookRunner as never,
     });
-    await Promise.resolve();
+    await new Promise<void>((resolve) => setImmediate(resolve));
 
     expect(hookRunner.runAgentEnd).toHaveBeenCalledWith(
       EVENT,
       expect.objectContaining({ runId: "run-1", sessionKey: "agent:main:session-1" }),
       { unrefTimeout: true },
     );
+  });
+
+  it("does not start fire-and-forget agent_end hooks synchronously", async () => {
+    const hookRunner = {
+      hasHooks: vi.fn((hookName: string) => hookName === "agent_end"),
+      runAgentEnd: vi.fn(async () => undefined),
+    };
+
+    runAgentHarnessAgentEndHook({
+      ctx: { runId: "run-1", sessionKey: "agent:main:session-1" },
+      event: EVENT,
+      hookRunner: hookRunner as never,
+    });
+
+    expect(hookRunner.runAgentEnd).not.toHaveBeenCalled();
+    await Promise.resolve();
+    expect(hookRunner.runAgentEnd).not.toHaveBeenCalled();
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(hookRunner.runAgentEnd).toHaveBeenCalledOnce();
   });
 
   it("continues when legacy hook runners advertise before_agent_finalize without a runner method", async () => {

--- a/src/agents/harness/lifecycle-hook-helpers.ts
+++ b/src/agents/harness/lifecycle-hook-helpers.ts
@@ -112,7 +112,18 @@ export function runAgentHarnessAgentEndHook(params: {
   ctx: AgentHarnessHookContext;
   hookRunner?: AgentHarnessHookRunner;
 }): void {
-  void executeAgentHarnessAgentEndHook({ ...params, unrefTimeout: true });
+  const hookRunner = params.hookRunner ?? getGlobalHookRunner();
+  if (!hookRunner?.hasHooks("agent_end") || typeof hookRunner.runAgentEnd !== "function") {
+    return;
+  }
+  const scheduled = setImmediate(() => {
+    void executeAgentHarnessAgentEndHook({
+      ...params,
+      hookRunner,
+      unrefTimeout: true,
+    });
+  });
+  scheduled.unref?.();
 }
 
 export async function awaitAgentHarnessAgentEndHook(params: {

--- a/src/agents/openai-codex-routing.test.ts
+++ b/src/agents/openai-codex-routing.test.ts
@@ -167,6 +167,24 @@ describe("OpenAI Codex routing policy", () => {
     ).toBe("openai-codex");
   });
 
+  it("routes OpenAI provider to OpenAI-Codex when OpenAI auth order selects Codex", () => {
+    const config = {
+      auth: {
+        order: {
+          openai: ["openai-codex:work"],
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    expect(
+      resolveSelectedOpenAIPiRuntimeProvider({
+        provider: "openai",
+        harnessRuntime: "codex",
+        config,
+      }),
+    ).toBe("openai-codex");
+  });
+
   it("keeps OpenAI provider for Codex runtime when only direct API-key auth is implied", () => {
     expect(
       resolveSelectedOpenAIPiRuntimeProvider({

--- a/src/agents/openai-codex-routing.test.ts
+++ b/src/agents/openai-codex-routing.test.ts
@@ -151,13 +151,29 @@ describe("OpenAI Codex routing policy", () => {
     ).toEqual(["openai-codex"]);
   });
 
-  it("routes openai provider to openai-codex when harness runtime is codex", () => {
+  it("routes OpenAI provider to OpenAI-Codex when Codex auth is configured", () => {
+    expect(
+      resolveSelectedOpenAIPiRuntimeProvider({
+        provider: "openai",
+        harnessRuntime: "codex",
+        config: {
+          auth: {
+            order: {
+              "openai-codex": ["openai-codex:work"],
+            },
+          },
+        },
+      }),
+    ).toBe("openai-codex");
+  });
+
+  it("keeps OpenAI provider for Codex runtime when only direct API-key auth is implied", () => {
     expect(
       resolveSelectedOpenAIPiRuntimeProvider({
         provider: "openai",
         harnessRuntime: "codex",
       }),
-    ).toBe("openai-codex");
+    ).toBe("openai");
   });
 
   it("does not route non-OpenAI providers when runtime is codex", () => {

--- a/src/agents/openai-codex-routing.ts
+++ b/src/agents/openai-codex-routing.ts
@@ -92,6 +92,21 @@ function configuredOpenAIAuthOrderStartsWithCodexProfile(config: OpenClawConfig 
   return hasOpenAICodexAuthProfileOverride(firstProfile);
 }
 
+function configuredOpenAICodexAuthOrderHasProfile(config: OpenClawConfig | undefined) {
+  if (!openAIProviderUsesCodexRuntimeByDefault({ provider: OPENAI_PROVIDER_ID, config })) {
+    return false;
+  }
+  const configuredCodexOrder = findNormalizedProviderValue(
+    config?.auth?.order,
+    OPENAI_CODEX_PROVIDER_ID,
+  );
+  return (
+    configuredCodexOrder?.some(
+      (profileId) => typeof profileId === "string" && profileId.trim().length > 0,
+    ) === true
+  );
+}
+
 export function shouldRouteOpenAIPiThroughCodexAuthProvider(params: {
   provider: string;
   harnessRuntime?: string;
@@ -184,7 +199,12 @@ export function resolveSelectedOpenAIPiRuntimeProvider(params: {
   if (!isOpenAIProvider(params.provider)) {
     return params.provider;
   }
-  if (runtime === "codex") {
+  if (
+    runtime === "codex" &&
+    (hasOpenAICodexAuthProfileOverride(params.authProfileId) ||
+      configuredOpenAIAuthOrderStartsWithCodexProfile(params.config) ||
+      configuredOpenAICodexAuthOrderHasProfile(params.config))
+  ) {
     return OPENAI_CODEX_PROVIDER_ID;
   }
   return runtime === "pi" &&

--- a/src/agents/pi-embedded-runner/compact.hooks.harness.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.harness.ts
@@ -110,6 +110,7 @@ export const registerProviderStreamForModelMock: Mock<(params?: unknown) => unkn
 export const applyExtraParamsToAgentMock = vi.fn(() => ({ effectiveExtraParams: {} }));
 export const resolveAgentTransportOverrideMock: Mock<(params?: unknown) => string | undefined> =
   vi.fn(() => undefined);
+export const resolveAgentHarnessPolicyMock = vi.fn(() => ({ runtime: "pi" }));
 export const resolveSandboxContextMock = vi.fn(async () => null);
 export const maybeCompactAgentHarnessSessionMock: Mock<(params?: unknown) => Promise<unknown>> =
   vi.fn(async () => undefined);
@@ -264,6 +265,8 @@ export function resetCompactSessionStateMocks(): void {
   applyExtraParamsToAgentMock.mockReturnValue({ effectiveExtraParams: {} });
   resolveAgentTransportOverrideMock.mockReset();
   resolveAgentTransportOverrideMock.mockReturnValue(undefined);
+  resolveAgentHarnessPolicyMock.mockReset();
+  resolveAgentHarnessPolicyMock.mockReturnValue({ runtime: "pi" });
   resolveSandboxContextMock.mockReset();
   resolveSandboxContextMock.mockResolvedValue(null);
   maybeCompactAgentHarnessSessionMock.mockReset();
@@ -359,6 +362,7 @@ export async function loadCompactHooksHarness(): Promise<{
     })),
     clearCurrentPluginMetadataSnapshot: vi.fn(),
     getCurrentPluginMetadataSnapshot: () => emptyPluginMetadataSnapshot,
+    isReusableCurrentPluginMetadataSnapshot: vi.fn(() => true),
     resolvePluginMetadataControlPlaneFingerprint: vi.fn(() => "test-plugin-fingerprint"),
     restoreCurrentPluginMetadataSnapshotState: vi.fn(),
     setCurrentPluginMetadataSnapshot: vi.fn(),
@@ -381,7 +385,7 @@ export async function loadCompactHooksHarness(): Promise<{
 
   vi.doMock("../harness/selection.js", () => ({
     maybeCompactAgentHarnessSession: maybeCompactAgentHarnessSessionMock,
-    resolveAgentHarnessPolicy: vi.fn(() => ({ runtime: "pi" })),
+    resolveAgentHarnessPolicy: resolveAgentHarnessPolicyMock,
   }));
 
   vi.doMock("../../plugins/provider-runtime.js", () => ({

--- a/src/agents/pi-embedded-runner/compact.hooks.harness.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.harness.ts
@@ -114,6 +114,7 @@ export const resolveAgentHarnessPolicyMock = vi.fn(() => ({ runtime: "pi" }));
 export const resolveSandboxContextMock = vi.fn(async () => null);
 export const maybeCompactAgentHarnessSessionMock: Mock<(params?: unknown) => Promise<unknown>> =
   vi.fn(async () => undefined);
+export const resolveContextWindowInfoMock = vi.fn(() => ({ tokens: 128_000 }));
 export const rotateTranscriptAfterCompactionMock: Mock<
   (_params?: unknown) => Promise<CompactionTranscriptRotation>
 > = vi.fn(async () => ({
@@ -271,6 +272,8 @@ export function resetCompactSessionStateMocks(): void {
   resolveSandboxContextMock.mockResolvedValue(null);
   maybeCompactAgentHarnessSessionMock.mockReset();
   maybeCompactAgentHarnessSessionMock.mockResolvedValue(undefined);
+  resolveContextWindowInfoMock.mockReset();
+  resolveContextWindowInfoMock.mockReturnValue({ tokens: 128_000 });
   rotateTranscriptAfterCompactionMock.mockReset();
   rotateTranscriptAfterCompactionMock.mockResolvedValue({ rotated: false });
   listRegisteredPluginAgentPromptGuidanceMock.mockReset();
@@ -541,7 +544,7 @@ export async function loadCompactHooksHarness(): Promise<{
   }));
 
   vi.doMock("../context-window-guard.js", () => ({
-    resolveContextWindowInfo: vi.fn(() => ({ tokens: 128_000 })),
+    resolveContextWindowInfo: resolveContextWindowInfoMock,
   }));
 
   vi.doMock("../bootstrap-files.js", () => ({

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -15,6 +15,7 @@ import {
   registerProviderStreamForModelMock,
   resolveAgentHarnessPolicyMock,
   resolveContextEngineMock,
+  resolveContextWindowInfoMock,
   resolveEmbeddedAgentStreamFnMock,
   resolveMemorySearchConfigMock,
   resolveModelMock,
@@ -465,6 +466,11 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
             "openai-codex": { models: [{ id: "gpt-5.5", contextWindow: 350_000 }] },
           },
         },
+        auth: {
+          order: {
+            "openai-codex": ["openai-codex:work"],
+          },
+        },
         agents: { defaults: { embeddedHarness: { runtime: "codex" } } },
       } as never,
     });
@@ -472,6 +478,47 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
     expect(result.ok).toBe(true);
     expect(mockCallArg(resolveModelMock)).toBe("openai-codex");
     expect(mockCallArg(resolveModelMock, 0, 1)).toBe("gpt-5.5");
+  });
+
+  it("uses the persisted Codex runtime for compaction context windows", async () => {
+    resolveAgentHarnessPolicyMock.mockReturnValue({ runtime: "pi" });
+    resolveModelMock.mockImplementation((provider = "openai", modelId = "fake") => ({
+      model: { provider, api: "responses", id: modelId, input: [], contextWindow: 1_000_000 },
+      error: null,
+      authStorage: { setRuntimeApiKey: vi.fn() },
+      modelRegistry: {},
+    }));
+
+    const result = await compactEmbeddedPiSessionDirect({
+      sessionId: "session-1",
+      sessionKey: TEST_SESSION_KEY,
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp/workspace",
+      provider: "openai",
+      model: "gpt-5.5",
+      agentHarnessId: "codex",
+      config: {
+        models: {
+          providers: {
+            openai: { models: [{ id: "gpt-5.5", contextWindow: 1_000_000 }] },
+            "openai-codex": { models: [{ id: "gpt-5.5", contextWindow: 350_000 }] },
+          },
+        },
+        auth: {
+          order: {
+            "openai-codex": ["openai-codex:work"],
+          },
+        },
+        agents: { defaults: { embeddedHarness: { runtime: "pi" } } },
+      } as never,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(mockCallArg(resolveModelMock)).toBe("openai-codex");
+    expectRecordFields(mockCallArg(resolveContextWindowInfoMock), {
+      provider: "openai-codex",
+      modelId: "gpt-5.5",
+    });
   });
 
   it("keeps compaction fallback selection ephemeral", async () => {

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -13,6 +13,7 @@ import {
   loadCompactHooksHarness,
   maybeCompactAgentHarnessSessionMock,
   registerProviderStreamForModelMock,
+  resolveAgentHarnessPolicyMock,
   resolveContextEngineMock,
   resolveEmbeddedAgentStreamFnMock,
   resolveMemorySearchConfigMock,
@@ -439,6 +440,38 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
     if (fallbackCall[3] === undefined) {
       throw new Error("Expected fallback resolve-model options");
     }
+  });
+
+  it("routes OpenAI compaction through the selected Codex runtime provider before auth", async () => {
+    resolveAgentHarnessPolicyMock.mockReturnValue({ runtime: "codex" });
+    resolveModelMock.mockImplementation((provider = "openai", modelId = "fake") => ({
+      model: { provider, api: "responses", id: modelId, input: [] },
+      error: null,
+      authStorage: { setRuntimeApiKey: vi.fn() },
+      modelRegistry: {},
+    }));
+
+    const result = await compactEmbeddedPiSessionDirect({
+      sessionId: "session-1",
+      sessionKey: TEST_SESSION_KEY,
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp/workspace",
+      provider: "openai",
+      model: "gpt-5.5",
+      config: {
+        models: {
+          providers: {
+            openai: { models: [{ id: "gpt-5.5", contextWindow: 1_000_000 }] },
+            "openai-codex": { models: [{ id: "gpt-5.5", contextWindow: 350_000 }] },
+          },
+        },
+        agents: { defaults: { embeddedHarness: { runtime: "codex" } } },
+      } as never,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(mockCallArg(resolveModelMock)).toBe("openai-codex");
+    expect(mockCallArg(resolveModelMock, 0, 1)).toBe("gpt-5.5");
   });
 
   it("keeps compaction fallback selection ephemeral", async () => {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -513,6 +513,7 @@ async function compactEmbeddedPiSessionDirectOnce(
     agentId: earlyAgentIds.sessionAgentId,
     sessionKey: params.sessionKey,
   });
+  const selectedHarnessRuntime = params.agentHarnessId ?? runtimeHarnessPolicy.runtime;
   const provider = resolveSelectedOpenAIPiRuntimeProvider({
     provider: modelConfigProvider,
     harnessRuntime: runtimeHarnessPolicy.runtime,
@@ -689,7 +690,7 @@ async function compactEmbeddedPiSessionDirectOnce(
       cfg: params.config,
       provider: resolveContextConfigProviderForRuntime({
         provider: modelConfigProvider,
-        runtimeId: runtimeHarnessPolicy.runtime,
+        runtimeId: selectedHarnessRuntime,
       }),
       modelId,
       modelContextTokens: readPiModelContextTokens(runtimeModel),

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -72,7 +72,10 @@ import {
 import { isFallbackSummaryError, runWithModelFallback } from "../model-fallback.js";
 import { supportsModelTools } from "../model-tool-support.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
-import { resolveContextConfigProviderForRuntime } from "../openai-codex-routing.js";
+import {
+  resolveContextConfigProviderForRuntime,
+  resolveSelectedOpenAIPiRuntimeProvider,
+} from "../openai-codex-routing.js";
 import { createBundleLspToolRuntime } from "../pi-bundle-lsp-runtime.js";
 import { createBundleMcpToolRuntime } from "../pi-bundle-mcp-tools.js";
 import { ensureSessionHeader } from "../pi-embedded-helpers.js";
@@ -496,9 +499,28 @@ async function compactEmbeddedPiSessionDirectOnce(
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
   });
-  const provider = resolvedCompactionTarget.provider ?? DEFAULT_PROVIDER;
+  const modelConfigProvider = resolvedCompactionTarget.provider ?? DEFAULT_PROVIDER;
   const modelId = resolvedCompactionTarget.model ?? DEFAULT_MODEL;
   const authProfileId = resolvedCompactionTarget.authProfileId;
+  const earlyAgentIds = resolveSessionAgentIds({
+    sessionKey: params.sessionKey,
+    config: params.config,
+  });
+  const runtimeHarnessPolicy = resolveAgentHarnessPolicy({
+    provider: modelConfigProvider,
+    modelId,
+    config: params.config,
+    agentId: earlyAgentIds.sessionAgentId,
+    sessionKey: params.sessionKey,
+  });
+  const provider = resolveSelectedOpenAIPiRuntimeProvider({
+    provider: modelConfigProvider,
+    harnessRuntime: runtimeHarnessPolicy.runtime,
+    agentHarnessId: params.agentHarnessId,
+    authProfileId,
+    config: params.config,
+    workspaceDir: resolvedWorkspace,
+  });
   let thinkLevel: ThinkLevel = params.thinkLevel ?? "off";
   const attemptedThinking = new Set<ThinkLevel>();
   const fail = (reason: string, err?: unknown): EmbeddedPiCompactResult => {
@@ -527,10 +549,6 @@ async function compactEmbeddedPiSessionDirectOnce(
         : undefined,
     };
   };
-  const earlyAgentIds = resolveSessionAgentIds({
-    sessionKey: params.sessionKey,
-    config: params.config,
-  });
   const agentDir =
     params.agentDir ?? resolveAgentDir(params.config ?? {}, earlyAgentIds.sessionAgentId);
   await ensureOpenClawModelsJson(params.config, agentDir, {
@@ -615,10 +633,7 @@ async function compactEmbeddedPiSessionDirectOnce(
     sessionId: params.sessionId,
     cwd: effectiveWorkspace,
   });
-  const { sessionAgentId: effectiveSkillAgentId } = resolveSessionAgentIds({
-    sessionKey: params.sessionKey,
-    config: params.config,
-  });
+  const effectiveSkillAgentId = earlyAgentIds.sessionAgentId;
 
   let restoreSkillEnv: (() => void) | undefined;
   let compactionSessionManager: unknown = null;
@@ -670,17 +685,10 @@ async function compactEmbeddedPiSessionDirectOnce(
     // Apply contextTokens cap to model so pi-coding-agent's auto-compaction
     // threshold uses the effective limit, not the native context window.
     const runtimeModelWithContext = runtimeModel as ProviderRuntimeModel;
-    const runtimeHarnessPolicy = resolveAgentHarnessPolicy({
-      provider,
-      modelId,
-      config: params.config,
-      agentId: effectiveSkillAgentId,
-      sessionKey: params.sessionKey,
-    });
     const ctxInfo = resolveContextWindowInfo({
       cfg: params.config,
       provider: resolveContextConfigProviderForRuntime({
-        provider,
+        provider: modelConfigProvider,
         runtimeId: runtimeHarnessPolicy.runtime,
       }),
       modelId,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -101,6 +101,7 @@ import {
 import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import { resolveOpenClawReferencePaths } from "../../docs-path.js";
 import { isTimeoutError } from "../../failover-error.js";
+import { runAgentHarnessAgentEndHook } from "../../harness/lifecycle-hook-helpers.js";
 import { resolveHeartbeatPromptForSystemPrompt } from "../../heartbeat-system-prompt.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
 import { stripHistoricalRuntimeContextCustomMessages } from "../../internal-runtime-context.js";
@@ -4495,32 +4496,27 @@ export async function runEmbeddedAttempt(
         });
         anthropicPayloadLogger?.recordUsage(messagesSnapshot, promptError);
 
-        // Run agent_end hooks to allow plugins to analyze the conversation
-        // This is fire-and-forget, so we don't await
-        // Run even on compaction timeout so plugins can log/cleanup
+        // Run even on compaction timeout so plugins can log/cleanup.
         if (hookRunner?.hasHooks("agent_end")) {
-          hookRunner
-            .runAgentEnd(
-              {
-                messages: messagesSnapshot,
-                success: !aborted && !promptError,
-                error: promptError ? formatErrorMessage(promptError) : undefined,
-                durationMs: Date.now() - promptStartedAt,
-              },
-              {
-                runId: params.runId,
-                trace: freezeDiagnosticTraceContext(diagnosticTrace),
-                agentId: hookAgentId,
-                sessionKey: params.sessionKey,
-                sessionId: params.sessionId,
-                workspaceDir: params.workspaceDir,
-                trigger: params.trigger,
-                ...buildAgentHookContextChannelFields(params),
-              },
-            )
-            .catch((err) => {
-              log.warn(`agent_end hook failed: ${err}`);
-            });
+          runAgentHarnessAgentEndHook({
+            hookRunner,
+            event: {
+              messages: messagesSnapshot,
+              success: !aborted && !promptError,
+              error: promptError ? formatErrorMessage(promptError) : undefined,
+              durationMs: Date.now() - promptStartedAt,
+            },
+            ctx: {
+              runId: params.runId,
+              trace: freezeDiagnosticTraceContext(diagnosticTrace),
+              agentId: hookAgentId,
+              sessionKey: params.sessionKey,
+              sessionId: params.sessionId,
+              workspaceDir: params.workspaceDir,
+              trigger: params.trigger,
+              ...buildAgentHookContextChannelFields(params),
+            },
+          });
         }
       } finally {
         clearTimeout(abortTimer);

--- a/src/agents/runtime-plugins.registry-reuse.test.ts
+++ b/src/agents/runtime-plugins.registry-reuse.test.ts
@@ -5,11 +5,17 @@ import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plug
 
 const mocks = vi.hoisted(() => ({
   getCurrentPluginMetadataSnapshot: vi.fn(),
+  isReusableCurrentPluginMetadataSnapshot: vi.fn(() => true),
+  setCurrentPluginMetadataSnapshot: vi.fn(),
+  clearCurrentPluginMetadataSnapshot: vi.fn(),
   loadOpenClawPlugins: vi.fn<typeof import("../plugins/loader.js").loadOpenClawPlugins>(),
 }));
 
 vi.mock("../plugins/current-plugin-metadata-snapshot.js", () => ({
   getCurrentPluginMetadataSnapshot: mocks.getCurrentPluginMetadataSnapshot,
+  isReusableCurrentPluginMetadataSnapshot: mocks.isReusableCurrentPluginMetadataSnapshot,
+  setCurrentPluginMetadataSnapshot: mocks.setCurrentPluginMetadataSnapshot,
+  clearCurrentPluginMetadataSnapshot: mocks.clearCurrentPluginMetadataSnapshot,
 }));
 
 vi.mock("../plugins/loader.js", async (importOriginal) => {
@@ -37,6 +43,10 @@ function createRegistryWithPlugin(pluginId: string): PluginRegistry {
 
 beforeEach(() => {
   mocks.getCurrentPluginMetadataSnapshot.mockReset();
+  mocks.isReusableCurrentPluginMetadataSnapshot.mockReset();
+  mocks.isReusableCurrentPluginMetadataSnapshot.mockReturnValue(true);
+  mocks.setCurrentPluginMetadataSnapshot.mockReset();
+  mocks.clearCurrentPluginMetadataSnapshot.mockReset();
   mocks.loadOpenClawPlugins.mockReset();
 });
 

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
   getCurrentPluginMetadataSnapshot: vi.fn(),
+  isReusableCurrentPluginMetadataSnapshot: vi.fn(() => true),
+  setCurrentPluginMetadataSnapshot: vi.fn(),
+  clearCurrentPluginMetadataSnapshot: vi.fn(),
   ensureStandaloneRuntimePluginRegistryLoaded: vi.fn(),
   getActivePluginRuntimeSubagentMode: vi.fn<() => "default" | "explicit" | "gateway-bindable">(
     () => "default",
@@ -10,6 +13,9 @@ const hoisted = vi.hoisted(() => ({
 
 vi.mock("../plugins/current-plugin-metadata-snapshot.js", () => ({
   getCurrentPluginMetadataSnapshot: hoisted.getCurrentPluginMetadataSnapshot,
+  isReusableCurrentPluginMetadataSnapshot: hoisted.isReusableCurrentPluginMetadataSnapshot,
+  setCurrentPluginMetadataSnapshot: hoisted.setCurrentPluginMetadataSnapshot,
+  clearCurrentPluginMetadataSnapshot: hoisted.clearCurrentPluginMetadataSnapshot,
 }));
 
 vi.mock("../plugins/runtime/standalone-runtime-registry-loader.js", () => ({
@@ -26,6 +32,10 @@ describe("ensureRuntimePluginsLoaded", () => {
   beforeEach(async () => {
     hoisted.getCurrentPluginMetadataSnapshot.mockReset();
     hoisted.getCurrentPluginMetadataSnapshot.mockReturnValue(undefined);
+    hoisted.isReusableCurrentPluginMetadataSnapshot.mockReset();
+    hoisted.isReusableCurrentPluginMetadataSnapshot.mockReturnValue(true);
+    hoisted.setCurrentPluginMetadataSnapshot.mockReset();
+    hoisted.clearCurrentPluginMetadataSnapshot.mockReset();
     hoisted.ensureStandaloneRuntimePluginRegistryLoaded.mockReset();
     hoisted.ensureStandaloneRuntimePluginRegistryLoaded.mockReturnValue(undefined);
     hoisted.getActivePluginRuntimeSubagentMode.mockReset();
@@ -55,13 +65,15 @@ describe("ensureRuntimePluginsLoaded", () => {
 
     expect(hoisted.ensureStandaloneRuntimePluginRegistryLoaded).toHaveBeenCalledWith({
       requiredPluginIds: undefined,
-      loadOptions: {
+      loadOptions: expect.objectContaining({
         config: {} as never,
+        activationSourceConfig: {} as never,
+        autoEnabledReasons: {},
         workspaceDir: "/tmp/workspace",
         runtimeOptions: {
           allowGatewaySubagentBinding: true,
         },
-      },
+      }),
     });
   });
 
@@ -85,14 +97,16 @@ describe("ensureRuntimePluginsLoaded", () => {
     });
     expect(hoisted.ensureStandaloneRuntimePluginRegistryLoaded).toHaveBeenCalledWith({
       requiredPluginIds: ["telegram", "memory-core"],
-      loadOptions: {
+      loadOptions: expect.objectContaining({
         config,
+        activationSourceConfig: config,
+        autoEnabledReasons: {},
         workspaceDir: "/tmp/workspace",
         onlyPluginIds: ["telegram", "memory-core"],
         runtimeOptions: {
           allowGatewaySubagentBinding: true,
         },
-      },
+      }),
     });
   });
 
@@ -112,14 +126,16 @@ describe("ensureRuntimePluginsLoaded", () => {
 
     expect(hoisted.ensureStandaloneRuntimePluginRegistryLoaded).toHaveBeenCalledWith({
       requiredPluginIds: ["telegram"],
-      loadOptions: {
+      loadOptions: expect.objectContaining({
         config: {} as never,
+        activationSourceConfig: {} as never,
+        autoEnabledReasons: {},
         onlyPluginIds: ["telegram"],
         workspaceDir: "/tmp/workspace",
         runtimeOptions: {
           allowGatewaySubagentBinding: true,
         },
-      },
+      }),
     });
   });
 
@@ -148,14 +164,16 @@ describe("ensureRuntimePluginsLoaded", () => {
 
     expect(hoisted.ensureStandaloneRuntimePluginRegistryLoaded).toHaveBeenCalledWith({
       requiredPluginIds: ["telegram"],
-      loadOptions: {
+      loadOptions: expect.objectContaining({
         config,
+        activationSourceConfig: config,
+        autoEnabledReasons: {},
         onlyPluginIds: ["telegram"],
         workspaceDir: "/tmp/workspace",
         runtimeOptions: {
           allowGatewaySubagentBinding: true,
         },
-      },
+      }),
     });
   });
 
@@ -167,11 +185,13 @@ describe("ensureRuntimePluginsLoaded", () => {
 
     expect(hoisted.ensureStandaloneRuntimePluginRegistryLoaded).toHaveBeenCalledWith({
       requiredPluginIds: undefined,
-      loadOptions: {
+      loadOptions: expect.objectContaining({
         config: {} as never,
+        activationSourceConfig: {} as never,
+        autoEnabledReasons: {},
         workspaceDir: "/tmp/workspace",
         runtimeOptions: undefined,
-      },
+      }),
     });
   });
 
@@ -185,13 +205,15 @@ describe("ensureRuntimePluginsLoaded", () => {
 
     expect(hoisted.ensureStandaloneRuntimePluginRegistryLoaded).toHaveBeenCalledWith({
       requiredPluginIds: undefined,
-      loadOptions: {
+      loadOptions: expect.objectContaining({
         config: {} as never,
+        activationSourceConfig: {} as never,
+        autoEnabledReasons: {},
         workspaceDir: "/tmp/workspace",
         runtimeOptions: {
           allowGatewaySubagentBinding: true,
         },
-      },
+      }),
     });
   });
 });

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -1,6 +1,10 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { getActivePluginRuntimeSubagentMode } from "../plugins/runtime.js";
+import {
+  buildPluginRuntimeLoadOptions,
+  resolvePluginRuntimeLoadContext,
+} from "../plugins/runtime/load-context.js";
 import { ensureStandaloneRuntimePluginRegistryLoaded } from "../plugins/runtime/standalone-runtime-registry-loader.js";
 import { resolveUserPath } from "../utils.js";
 
@@ -36,22 +40,24 @@ export function ensureRuntimePluginsLoaded(params: {
     typeof params.workspaceDir === "string" && params.workspaceDir.trim()
       ? resolveUserPath(params.workspaceDir)
       : undefined;
-  const startupPluginIds = resolveStartupPluginIdsFromCurrentSnapshot({
+  const loadContext = resolvePluginRuntimeLoadContext({
     config: params.config,
     workspaceDir,
+  });
+  const startupPluginIds = resolveStartupPluginIdsFromCurrentSnapshot({
+    config: loadContext.rawConfig,
+    workspaceDir: loadContext.workspaceDir,
   });
   const allowGatewaySubagentBinding =
     params.allowGatewaySubagentBinding === true ||
     getActivePluginRuntimeSubagentMode() === "gateway-bindable";
   ensureStandaloneRuntimePluginRegistryLoaded({
     requiredPluginIds: startupPluginIds,
-    loadOptions: {
-      config: params.config,
-      workspaceDir,
+    loadOptions: buildPluginRuntimeLoadOptions(loadContext, {
       ...(startupPluginIds === undefined ? {} : { onlyPluginIds: startupPluginIds }),
       runtimeOptions: allowGatewaySubagentBinding
         ? { allowGatewaySubagentBinding: true }
         : undefined,
-    },
+    }),
   });
 }

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -154,6 +154,10 @@ describe("runMemoryFlushIfNeeded", () => {
         ...previous,
         compactionCount: (previous.compactionCount ?? 0) + 1,
       };
+      if (typeof params.tokensAfter === "number" && Number.isFinite(params.tokensAfter)) {
+        nextEntry.totalTokens = params.tokensAfter;
+        nextEntry.totalTokensFresh = true;
+      }
       if (typeof params.newSessionId === "string" && params.newSessionId) {
         nextEntry.sessionId = params.newSessionId;
         if (typeof params.newSessionFile === "string" && params.newSessionFile) {
@@ -910,6 +914,67 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactEmbeddedPiSessionMock).toHaveBeenCalledTimes(1);
     const compactCall = requireCompactEmbeddedPiSessionCall();
     expect(compactCall.currentTokenCount).toBe(347_000);
+  });
+
+  it("uses post-compaction token state to avoid repeated preflight compaction", async () => {
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 4_000,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 0,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    compactEmbeddedPiSessionMock.mockResolvedValueOnce({
+      ok: true,
+      compacted: true,
+      result: { tokensAfter: 42 },
+    });
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 347_000,
+      totalTokensFresh: true,
+      agentHarnessId: "codex",
+    };
+    const sessionStore = { main: sessionEntry };
+    const commonParams = {
+      cfg: {
+        models: {
+          providers: {
+            openai: { models: [{ id: "gpt-5.5", contextWindow: 1_000_000 }] },
+            "openai-codex": { models: [{ id: "gpt-5.5", contextWindow: 350_000 }] },
+          },
+        },
+        agents: { defaults: { compaction: { memoryFlush: {} } } },
+      } as never,
+      followupRun: createTestFollowupRun({
+        provider: "openai",
+        model: "gpt-5.5",
+        sessionId: "session",
+        sessionKey: "main",
+      }),
+      defaultModel: "gpt-5.5",
+      sessionStore,
+      sessionKey: "main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+    };
+
+    await runPreflightCompactionIfNeeded({
+      ...commonParams,
+      sessionEntry,
+      replyOperation: createReplyOperation(),
+    });
+    await runPreflightCompactionIfNeeded({
+      ...commonParams,
+      sessionEntry: sessionStore.main,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(compactEmbeddedPiSessionMock).toHaveBeenCalledTimes(1);
+    expect(sessionStore.main.totalTokens).toBe(42);
+    expect(sessionStore.main.totalTokensFresh).toBe(true);
   });
 
   it("keeps the OpenAI API context window for persisted PI runtime overrides", async () => {

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -916,6 +916,108 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactCall.currentTokenCount).toBe(347_000);
   });
 
+  it("defers OpenAI preflight compaction until the configured server threshold", async () => {
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 4_000,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 60_000,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 161_077,
+      totalTokensFresh: true,
+      agentHarnessId: "codex",
+    };
+
+    const entry = await runPreflightCompactionIfNeeded({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5.5": {
+                params: {
+                  responsesServerCompaction: true,
+                  responsesCompactThreshold: 200_000,
+                },
+              },
+            },
+          },
+        },
+      } as never,
+      followupRun: createTestFollowupRun({
+        provider: "openai",
+        model: "gpt-5.5",
+        sessionId: "session",
+        sessionKey: "main",
+      }),
+      defaultModel: "gpt-5.5",
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(entry).toBe(sessionEntry);
+    expect(compactEmbeddedPiSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("runs OpenAI preflight compaction at the configured server threshold", async () => {
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 4_000,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 60_000,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 201_000,
+      totalTokensFresh: true,
+      agentHarnessId: "codex",
+    };
+
+    await runPreflightCompactionIfNeeded({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5.5": {
+                params: {
+                  responsesServerCompaction: true,
+                  responsesCompactThreshold: 200_000,
+                },
+              },
+            },
+          },
+        },
+      } as never,
+      followupRun: createTestFollowupRun({
+        provider: "openai",
+        model: "gpt-5.5",
+        sessionId: "session",
+        sessionKey: "main",
+      }),
+      defaultModel: "gpt-5.5",
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    const compactCall = requireCompactEmbeddedPiSessionCall();
+    expect(compactCall.currentTokenCount).toBe(201_000);
+  });
+
   it("uses post-compaction token state to avoid repeated preflight compaction", async () => {
     registerMemoryFlushPlanResolverForTest(() => ({
       softThresholdTokens: 4_000,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -10,7 +10,6 @@ import { runWithModelFallback } from "../../agents/model-fallback.js";
 import { listLegacyRuntimeModelProviderAliases } from "../../agents/model-runtime-aliases.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import { resolveContextConfigProviderForRuntime } from "../../agents/openai-codex-routing.js";
-import { resolveExtraParams } from "../../agents/pi-embedded-runner/extra-params.js";
 import { resolveSandboxConfigForAgent, resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
 import {
   derivePromptTokens,
@@ -264,38 +263,6 @@ function resolveFollowupContextConfigProvider(params: {
     provider,
     runtimeId: harnessPolicy.runtime,
   });
-}
-
-function parsePositiveInteger(value: unknown): number | undefined {
-  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
-    return Math.floor(value);
-  }
-  if (typeof value === "string") {
-    const parsed = Number.parseInt(value, 10);
-    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
-  }
-  return undefined;
-}
-
-function resolveServerCompactionThresholdTokens(params: {
-  cfg: OpenClawConfig;
-  provider: string;
-  modelId?: string;
-  agentId?: string;
-}): number | undefined {
-  if (!params.modelId?.trim()) {
-    return undefined;
-  }
-  const extraParams = resolveExtraParams({
-    cfg: params.cfg,
-    provider: params.provider,
-    modelId: params.modelId,
-    agentId: params.agentId,
-  });
-  if (extraParams?.responsesServerCompaction !== true) {
-    return undefined;
-  }
-  return parsePositiveInteger(extraParams.responsesCompactThreshold);
 }
 
 function resolveVisibleMemoryFlushErrorPayloads(payloads?: ReplyPayload[]): ReplyPayload[] {
@@ -665,12 +632,6 @@ export async function runPreflightCompactionIfNeeded(params: {
     params.cfg.agents?.defaults?.compaction?.reserveTokensFloor ??
     20_000;
   const softThresholdTokens = memoryFlushPlan?.softThresholdTokens ?? 4_000;
-  const serverCompactionThresholdTokens = resolveServerCompactionThresholdTokens({
-    cfg: params.cfg,
-    provider: params.followupRun.run.provider,
-    modelId: params.followupRun.run.model ?? params.defaultModel,
-    agentId: params.followupRun.run.agentId,
-  });
   const freshPersistedTokens = resolveFreshSessionTotalTokens(entry);
   const persistedTotalTokens = entry.totalTokens;
   const hasPersistedTotalTokens =
@@ -732,9 +693,7 @@ export async function runPreflightCompactionIfNeeded(params: {
       ? projectedTokenCount
       : undefined;
 
-  const threshold =
-    serverCompactionThresholdTokens ??
-    contextWindowTokens - reserveTokensFloor - softThresholdTokens;
+  const threshold = contextWindowTokens - reserveTokensFloor - softThresholdTokens;
   logVerbose(
     `preflightCompaction check: sessionKey=${params.sessionKey} ` +
       `tokenCount=${tokenCountForCompaction ?? freshPersistedTokens ?? "undefined"} ` +
@@ -743,7 +702,6 @@ export async function runPreflightCompactionIfNeeded(params: {
       `persistedFresh=${entry?.totalTokensFresh === true} ` +
       `transcriptPromptTokens=${transcriptPromptTokens ?? "undefined"} ` +
       `promptTokensEst=${promptTokenEstimate ?? "undefined"} ` +
-      `serverCompactionThreshold=${serverCompactionThresholdTokens ?? "undefined"} ` +
       `activeTranscriptBytes=${activeTranscriptBytes ?? "undefined"} ` +
       `maxActiveTranscriptBytes=${maxActiveTranscriptBytes ?? "undefined"} ` +
       `sizeTrigger=${shouldCompactByTranscriptBytes}`,
@@ -755,7 +713,6 @@ export async function runPreflightCompactionIfNeeded(params: {
     contextWindowTokens,
     reserveTokensFloor,
     softThresholdTokens,
-    thresholdTokens: serverCompactionThresholdTokens,
   });
   const shouldCompact = shouldCompactByTokens || shouldCompactByTranscriptBytes;
   if (!shouldCompact) {
@@ -767,7 +724,6 @@ export async function runPreflightCompactionIfNeeded(params: {
     `preflightCompaction triggered: sessionKey=${params.sessionKey} ` +
       `tokenCount=${tokenCountForCompaction ?? freshPersistedTokens ?? "undefined"} ` +
       `threshold=${threshold} trigger=${compactionTrigger} ` +
-      `serverCompactionThreshold=${serverCompactionThresholdTokens ?? "undefined"} ` +
       `activeTranscriptBytes=${activeTranscriptBytes ?? "undefined"} ` +
       `maxActiveTranscriptBytes=${maxActiveTranscriptBytes ?? "undefined"}`,
   );

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -10,6 +10,7 @@ import { runWithModelFallback } from "../../agents/model-fallback.js";
 import { listLegacyRuntimeModelProviderAliases } from "../../agents/model-runtime-aliases.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import { resolveContextConfigProviderForRuntime } from "../../agents/openai-codex-routing.js";
+import { resolveExtraParams } from "../../agents/pi-embedded-runner/extra-params.js";
 import { resolveSandboxConfigForAgent, resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
 import {
   derivePromptTokens,
@@ -263,6 +264,38 @@ function resolveFollowupContextConfigProvider(params: {
     provider,
     runtimeId: harnessPolicy.runtime,
   });
+}
+
+function parsePositiveInteger(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return Math.floor(value);
+  }
+  if (typeof value === "string") {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function resolveServerCompactionThresholdTokens(params: {
+  cfg: OpenClawConfig;
+  provider: string;
+  modelId?: string;
+  agentId?: string;
+}): number | undefined {
+  if (!params.modelId?.trim()) {
+    return undefined;
+  }
+  const extraParams = resolveExtraParams({
+    cfg: params.cfg,
+    provider: params.provider,
+    modelId: params.modelId,
+    agentId: params.agentId,
+  });
+  if (extraParams?.responsesServerCompaction !== true) {
+    return undefined;
+  }
+  return parsePositiveInteger(extraParams.responsesCompactThreshold);
 }
 
 function resolveVisibleMemoryFlushErrorPayloads(payloads?: ReplyPayload[]): ReplyPayload[] {
@@ -632,6 +665,12 @@ export async function runPreflightCompactionIfNeeded(params: {
     params.cfg.agents?.defaults?.compaction?.reserveTokensFloor ??
     20_000;
   const softThresholdTokens = memoryFlushPlan?.softThresholdTokens ?? 4_000;
+  const serverCompactionThresholdTokens = resolveServerCompactionThresholdTokens({
+    cfg: params.cfg,
+    provider: params.followupRun.run.provider,
+    modelId: params.followupRun.run.model ?? params.defaultModel,
+    agentId: params.followupRun.run.agentId,
+  });
   const freshPersistedTokens = resolveFreshSessionTotalTokens(entry);
   const persistedTotalTokens = entry.totalTokens;
   const hasPersistedTotalTokens =
@@ -693,7 +732,9 @@ export async function runPreflightCompactionIfNeeded(params: {
       ? projectedTokenCount
       : undefined;
 
-  const threshold = contextWindowTokens - reserveTokensFloor - softThresholdTokens;
+  const threshold =
+    serverCompactionThresholdTokens ??
+    contextWindowTokens - reserveTokensFloor - softThresholdTokens;
   logVerbose(
     `preflightCompaction check: sessionKey=${params.sessionKey} ` +
       `tokenCount=${tokenCountForCompaction ?? freshPersistedTokens ?? "undefined"} ` +
@@ -702,6 +743,7 @@ export async function runPreflightCompactionIfNeeded(params: {
       `persistedFresh=${entry?.totalTokensFresh === true} ` +
       `transcriptPromptTokens=${transcriptPromptTokens ?? "undefined"} ` +
       `promptTokensEst=${promptTokenEstimate ?? "undefined"} ` +
+      `serverCompactionThreshold=${serverCompactionThresholdTokens ?? "undefined"} ` +
       `activeTranscriptBytes=${activeTranscriptBytes ?? "undefined"} ` +
       `maxActiveTranscriptBytes=${maxActiveTranscriptBytes ?? "undefined"} ` +
       `sizeTrigger=${shouldCompactByTranscriptBytes}`,
@@ -713,6 +755,7 @@ export async function runPreflightCompactionIfNeeded(params: {
     contextWindowTokens,
     reserveTokensFloor,
     softThresholdTokens,
+    thresholdTokens: serverCompactionThresholdTokens,
   });
   const shouldCompact = shouldCompactByTokens || shouldCompactByTranscriptBytes;
   if (!shouldCompact) {
@@ -724,6 +767,7 @@ export async function runPreflightCompactionIfNeeded(params: {
     `preflightCompaction triggered: sessionKey=${params.sessionKey} ` +
       `tokenCount=${tokenCountForCompaction ?? freshPersistedTokens ?? "undefined"} ` +
       `threshold=${threshold} trigger=${compactionTrigger} ` +
+      `serverCompactionThreshold=${serverCompactionThresholdTokens ?? "undefined"} ` +
       `activeTranscriptBytes=${activeTranscriptBytes ?? "undefined"} ` +
       `maxActiveTranscriptBytes=${maxActiveTranscriptBytes ?? "undefined"}`,
   );

--- a/src/auto-reply/reply/commands-core.test.ts
+++ b/src/auto-reply/reply/commands-core.test.ts
@@ -69,7 +69,7 @@ describe("emitResetCommandHooks", () => {
       workspaceDir: "/tmp/openclaw-workspace",
     });
 
-    expect(hookRunnerMocks.runBeforeReset).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(hookRunnerMocks.runBeforeReset).toHaveBeenCalledTimes(1));
     const [, ctx] = firstBeforeResetCall();
     return ctx;
   }
@@ -111,6 +111,32 @@ describe("emitResetCommandHooks", () => {
     expect(ctx?.sessionKey).toBe("agent:main:main");
     expect(ctx?.sessionId).toBe("prev-session");
     expect(ctx?.workspaceDir).toBe("/tmp/openclaw-workspace");
+  });
+
+  it("does not run before_reset hooks synchronously on the reset command path", async () => {
+    const command = {
+      surface: "telegram",
+      senderId: "vac",
+      channel: "telegram",
+      from: "telegram:vac",
+      to: "telegram:bot",
+      resetHookTriggered: false,
+    } as HandleCommandsParams["command"];
+
+    await emitResetCommandHooks({
+      action: "new",
+      ctx: {} as HandleCommandsParams["ctx"],
+      cfg: {} as HandleCommandsParams["cfg"],
+      command,
+      sessionKey: "agent:main:main",
+      previousSessionEntry: {
+        sessionId: "prev-session",
+      } as HandleCommandsParams["previousSessionEntry"],
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+
+    expect(hookRunnerMocks.runBeforeReset).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(hookRunnerMocks.runBeforeReset).toHaveBeenCalledTimes(1));
   });
 
   it("recovers the archived transcript when the original reset transcript path is gone", async () => {

--- a/src/auto-reply/reply/commands-reset-hooks.ts
+++ b/src/auto-reply/reply/commands-reset-hooks.ts
@@ -142,25 +142,29 @@ export async function emitResetCommandHooks(params: {
   const hookRunner = getGlobalHookRunner();
   if (hookRunner?.hasHooks("before_reset")) {
     const prevEntry = params.previousSessionEntry;
-    void (async () => {
-      const { sessionFile, messages } = await loadBeforeResetTranscript({
-        sessionFile: prevEntry?.sessionFile,
-      });
+    const handle = setImmediate(
+      () =>
+        void (async () => {
+          const { sessionFile, messages } = await loadBeforeResetTranscript({
+            sessionFile: prevEntry?.sessionFile,
+          });
 
-      try {
-        await hookRunner.runBeforeReset(
-          { sessionFile, messages, reason: params.action },
-          {
-            agentId: resolveAgentIdFromSessionKey(params.sessionKey),
-            sessionKey: params.sessionKey,
-            sessionId: prevEntry?.sessionId,
-            workspaceDir: params.workspaceDir,
-          },
-        );
-      } catch (err: unknown) {
-        logVerbose(`before_reset hook failed: ${String(err)}`);
-      }
-    })();
+          try {
+            await hookRunner.runBeforeReset(
+              { sessionFile, messages, reason: params.action },
+              {
+                agentId: resolveAgentIdFromSessionKey(params.sessionKey),
+                sessionKey: params.sessionKey,
+                sessionId: prevEntry?.sessionId,
+                workspaceDir: params.workspaceDir,
+              },
+            );
+          } catch (err: unknown) {
+            logVerbose(`before_reset hook failed: ${String(err)}`);
+          }
+        })(),
+    );
+    handle.unref?.();
   }
   return { routedReply };
 }

--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -559,6 +559,17 @@ describe("buildStatusReply subagent summary", () => {
     expect(normalizeTestText(text)).toContain("Uptime: gateway 2h 5m · system 4d 3h");
   });
 
+  it("does not block chat /status on provider usage lookups", async () => {
+    providerUsageMock.loadProviderUsageSummary.mockImplementation(
+      () => new Promise(() => undefined),
+    );
+
+    const reply = await buildStatusReplyForTest({});
+
+    expect(reply?.text).toContain("OpenClaw");
+    expect(providerUsageMock.loadProviderUsageSummary).not.toHaveBeenCalled();
+  });
+
   it("shows the effective non-PI embedded harness in /status", async () => {
     registerStatusCodexHarness();
 
@@ -682,10 +693,12 @@ describe("buildStatusReply subagent summary", () => {
             },
           },
           ...commonParams,
+          includeProviderUsage: true,
         });
         const implicitCodexText = await buildStatusText({
           cfg: baseCfg,
           ...commonParams,
+          includeProviderUsage: true,
         });
 
         const normalizedCodex = normalizeTestText(codexText);

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -22,6 +22,7 @@ export async function buildStatusReply(
     text: await buildStatusText({
       ...params,
       statusChannel: command.channel,
+      includeProviderUsage: params.includeProviderUsage ?? false,
     }),
   };
 }

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -44,7 +44,6 @@ function resolveMemoryFlushGateState<
   contextWindowTokens: number;
   reserveTokensFloor: number;
   softThresholdTokens: number;
-  thresholdTokens?: number;
 }): { entry: TEntry; totalTokens: number; threshold: number } | null {
   if (!params.entry) {
     return null;
@@ -59,9 +58,7 @@ function resolveMemoryFlushGateState<
   const contextWindow = Math.max(1, Math.floor(params.contextWindowTokens));
   const reserveTokens = Math.max(0, Math.floor(params.reserveTokensFloor));
   const softThreshold = Math.max(0, Math.floor(params.softThresholdTokens));
-  const configuredThreshold = resolvePositiveTokenCount(params.thresholdTokens);
-  const threshold =
-    configuredThreshold ?? Math.max(0, contextWindow - reserveTokens - softThreshold);
+  const threshold = Math.max(0, contextWindow - reserveTokens - softThreshold);
   if (threshold <= 0) {
     return null;
   }
@@ -107,7 +104,6 @@ export function shouldRunPreflightCompaction(params: {
   contextWindowTokens: number;
   reserveTokensFloor: number;
   softThresholdTokens: number;
-  thresholdTokens?: number;
 }): boolean {
   const state = resolveMemoryFlushGateState(params);
   return Boolean(state && state.totalTokens >= state.threshold);

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -44,6 +44,7 @@ function resolveMemoryFlushGateState<
   contextWindowTokens: number;
   reserveTokensFloor: number;
   softThresholdTokens: number;
+  thresholdTokens?: number;
 }): { entry: TEntry; totalTokens: number; threshold: number } | null {
   if (!params.entry) {
     return null;
@@ -58,7 +59,9 @@ function resolveMemoryFlushGateState<
   const contextWindow = Math.max(1, Math.floor(params.contextWindowTokens));
   const reserveTokens = Math.max(0, Math.floor(params.reserveTokensFloor));
   const softThreshold = Math.max(0, Math.floor(params.softThresholdTokens));
-  const threshold = Math.max(0, contextWindow - reserveTokens - softThreshold);
+  const configuredThreshold = resolvePositiveTokenCount(params.thresholdTokens);
+  const threshold =
+    configuredThreshold ?? Math.max(0, contextWindow - reserveTokens - softThreshold);
   if (threshold <= 0) {
     return null;
   }
@@ -104,6 +107,7 @@ export function shouldRunPreflightCompaction(params: {
   contextWindowTokens: number;
   reserveTokensFloor: number;
   softThresholdTokens: number;
+  thresholdTokens?: number;
 }): boolean {
   const state = resolveMemoryFlushGateState(params);
   return Boolean(state && state.totalTokens >= state.threshold);

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1576,7 +1576,10 @@ export async function startGatewayServer(
             },
             startupTrace,
             deferSidecars: opts.deferStartupSidecars === true,
-            providerAuthPrewarm: { getConfig: getRuntimeConfig },
+            providerAuthPrewarm: {
+              enabled: isTruthyEnvValue(process.env.OPENCLAW_ENABLE_PROVIDER_AUTH_PREWARM),
+              getConfig: getRuntimeConfig,
+            },
           }),
       ),
     ));

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -292,6 +292,7 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
     resolveUsageProviderId(activeStatusProvider) ?? resolveUsageProviderId(activeProvider);
   let usageLine: string | null = null;
   if (
+    params.includeProviderUsage === true &&
     currentUsageProvider &&
     shouldLoadUsageSummary({
       provider: currentUsageProvider,

--- a/src/status/status-text.types.ts
+++ b/src/status/status-text.types.ts
@@ -35,5 +35,6 @@ export type BuildStatusTextParams = {
   primaryModelLabelOverride?: string;
   modelAuthOverride?: string;
   activeModelAuthOverride?: string;
+  includeProviderUsage?: boolean;
   includeTranscriptUsage?: boolean;
 };


### PR DESCRIPTION
## Summary
- Route embedded OpenAI compaction through the selected runtime provider only when Codex auth is actually configured or explicitly selected.
- Use the same selected/persisted harness runtime for compaction auth routing and context-window sizing.
- Align local preflight compaction with configured OpenAI Responses server-compaction thresholds so replies do not stall on surprise local compaction below the server threshold.
- Add regression coverage for Codex OAuth compaction routing, direct OpenAI API-key preservation, persisted runtime context windows, post-compaction token state, and server-threshold gating.

## Root Cause
OpenAI model refs such as `openai/gpt-5.5` can run through the Codex harness, but the direct embedded compaction path still mixed raw model provider, selected runtime provider, and context-budget provider decisions. That let budget preflight compaction fall back from stale/missing native Codex thread binding into the context engine, then resolve auth as direct OpenAI API-key mode instead of the selected Codex OAuth route.

A second mismatch made the symptom much slower: local preflight compaction used `contextWindow - reserve - softThreshold` even when the model params configured OpenAI Responses server compaction at a higher threshold. In the observed local setup that caused preflight compaction around the mid-100k token range even though the configured server threshold was 200k, so Telegram ingress worked but replies appeared stuck before normal inference.

RCA proof:
- Before behavior: gateway logs showed Telegram ingress followed by native Codex compaction binding fallback, context-engine compaction, and previously `No_API_key_found_for_provider_openai` on the compaction path.
- Code evidence: `src/agents/pi-embedded-runner/compact.ts` resolved compaction model/auth before consistently applying the selected OpenAI runtime provider, and its context-window lookup could use the current policy runtime instead of the persisted session runtime.
- Code evidence: `src/auto-reply/reply/agent-runner-memory.ts` preflight gating ignored `responsesServerCompaction` / `responsesCompactThreshold` model params when deciding whether to run local compaction.
- Regression chain: recent compaction changes made required preflight compaction failures visible and made stale/missing native bindings fall through to context-engine compaction, exposing both the auth-route mismatch and the over-eager local preflight gate.

## Real behavior proof
Behavior addressed: OpenAI GPT-5.5 compaction under Codex OAuth no longer asks for direct OpenAI API-key auth, direct OpenAI API-key configurations are preserved, and local preflight compaction waits for the configured server threshold instead of blocking replies early.

Real environment tested: local OpenClaw checkout and managed gateway on Linux, Node 25.9.0, configured default model `openai/gpt-5.5` with Codex runtime/OAuth.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/openai-codex-routing.test.ts src/agents/pi-embedded-runner/compact.hooks.test.ts src/auto-reply/reply/agent-runner-memory.test.ts`; `pnpm build`; `oc-update --skip-codex`; `pnpm openclaw status --all`.

Evidence after fix: focused Vitest reported `Test Files 4 passed (4)` and `Tests 131 passed (131)`; build completed successfully; `oc-update --skip-codex` rebuilt core/UI, reinstalled the daemon, and health check passed on retry; status reported Telegram `OK` and the gateway reachable.

Observed result after fix: the compaction unit path routes configured Codex OAuth sessions through `openai-codex`, keeps API-key-only OpenAI sessions on `openai`, uses the persisted Codex runtime for context-window sizing, and skips local preflight compaction below the configured OpenAI Responses server threshold.

What was not tested: no new live Telegram message was sent through the production topic after the patch; live status confirms Telegram/gateway readiness, while behavior proof is targeted unit coverage plus local build/update/status.

## Verification
- `node scripts/run-vitest.mjs src/agents/openai-codex-routing.test.ts src/agents/pi-embedded-runner/compact.hooks.test.ts src/auto-reply/reply/agent-runner-memory.test.ts`
- `pnpm build`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` found two accepted P2 issues; both were patched and covered by regression tests. Per user request, no further autoreview was run after the final API-key preservation patch.
- `oc-update --skip-codex`
- `pnpm openclaw status --all`