### PR TITLE
fix(update): escape systemd update handoffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@ Docs: https://docs.openclaw.ai
 - Codex app-server: disable native Code Mode when the effective exec host is `node` and keep OpenClaw `exec`/`process` available, so `/exec host=node` routes shell commands through the selected node instead of the gateway. Fixes #85012. (#85090) Thanks @sahilsatralkar.
 - Agents: bound embedded auto-compaction session write-lock watchdogs to the compaction timeout instead of the full run timeout, so stuck compaction cannot hold the live session lock for the whole run window. (#84949) Thanks @luoyanglang.
 - Gateway/agents: return phase-aware `agent.wait` timeout attribution and only cool auth profiles on provider-started timeouts. Refs #65504. Thanks @100yenadmin.
+- Gateway/systemd: launch managed update handoff helpers in a transient user scope so systemd-supervised Update Now flows survive the gateway unit restart. Fixes #84068.
 - Gateway: defer provider auth-state prewarm until after startup readiness so early gateway tool/session requests are not blocked by provider auth discovery. (#85272) Thanks @dutifulbob.
 - Gateway/models: coalesce provider auth-state rewarms after auth-profile failures and log event-loop delay for warm/rewarm work, so provider auth bursts no longer stack full auth sweeps behind channel replies.
 - Gateway/models: stop cancelled provider auth-state prewarms from continuing full provider sweeps, so reload and auth-failure bursts no longer keep startup busy.

--- a/src/gateway/server-methods/update-managed-service-handoff.test.ts
+++ b/src/gateway/server-methods/update-managed-service-handoff.test.ts
@@ -44,8 +44,7 @@ async function runHelperWithExistingSentinel(params: {
 }) {
   const { execFile } =
     await vi.importActual<typeof import("node:child_process")>("node:child_process");
-  const { startManagedServiceUpdateHandoff } =
-    await import("./update-managed-service-handoff.js");
+  const { startManagedServiceUpdateHandoff } = await import("./update-managed-service-handoff.js");
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-handoff-helper-test-"));
   tempDirs.add(tmpDir);
 
@@ -182,6 +181,77 @@ describe("managed service update handoff", () => {
     }
     expect(options.env.OPENCLAW_UPDATE_RUN_HANDOFF).toBe("1");
     expect(options.env[CONTROL_PLANE_UPDATE_SENTINEL_META_ENV]).toMatch(/sentinel-meta\.json$/u);
+  });
+
+  it("launches systemd handoffs through a transient user scope", async () => {
+    const { startManagedServiceUpdateHandoff } =
+      await import("./update-managed-service-handoff.js");
+    const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-systemd-run-bin-"));
+    tempDirs.add(binDir);
+    const systemdRunPath = path.join(binDir, "systemd-run");
+    await fs.writeFile(systemdRunPath, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+
+    const result = await startManagedServiceUpdateHandoff({
+      root: "/tmp/openclaw",
+      timeoutMs: 1_800_000,
+      restartDelayMs: 500,
+      parentPid: 12345,
+      execPath: "/usr/local/bin/node",
+      argv1: "/opt/openclaw/openclaw.mjs",
+      handoffId: "handoff-123",
+      supervisor: "systemd",
+      env: {
+        PATH: binDir,
+        OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway.service",
+        INVOCATION_ID: "gateway-invocation",
+        KEEP_ME: "1",
+      },
+      meta: {
+        handoffId: "handoff-123",
+        sessionKey: "agent:test:webchat:dm:user-123",
+        continuationMessage: "continue after restart",
+      },
+    });
+
+    expect(result.status).toBe("started");
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [command, args, options] = spawnMock.mock.calls[0] as unknown as [
+      string,
+      string[],
+      { env: NodeJS.ProcessEnv; detached?: boolean; cwd?: string },
+    ];
+    expect(command).toBe(systemdRunPath);
+    expect(args.slice(0, 4)).toEqual([
+      "--user",
+      "--scope",
+      "--collect",
+      "--unit=openclaw-update-handoff-123.scope",
+    ]);
+    expect(args.slice(4, 7)).toEqual([
+      "/usr/local/bin/node",
+      expect.stringMatching(/handoff\.cjs$/u),
+      expect.stringMatching(/handoff\.json$/u),
+    ]);
+    tempDirs.add(path.dirname(args[5] ?? result.logPath));
+    const helperParams = JSON.parse(await fs.readFile(args[6] ?? "", "utf-8")) as {
+      commandArgv?: string[];
+      handoffId?: string;
+    };
+    expect(helperParams.commandArgv).toEqual([
+      "/usr/local/bin/node",
+      "/opt/openclaw/openclaw.mjs",
+      "update",
+      "--yes",
+      "--json",
+      "--timeout",
+      "1800",
+    ]);
+    expect(helperParams.handoffId).toBe("handoff-123");
+    expect(options.detached).toBe(true);
+    expect(options.env.OPENCLAW_SYSTEMD_UNIT).toBe("openclaw-gateway.service");
+    expect(options.env.INVOCATION_ID).toBeUndefined();
+    expect(options.env.KEEP_ME).toBe("1");
+    expect(options.env.OPENCLAW_UPDATE_RUN_HANDOFF).toBe("1");
   });
 
   it("does not overwrite a restart sentinel owned by another startup task", async () => {

--- a/src/gateway/server-methods/update-managed-service-handoff.ts
+++ b/src/gateway/server-methods/update-managed-service-handoff.ts
@@ -3,7 +3,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { resolveRestartSentinelPath } from "../../infra/restart-sentinel.js";
-import { SUPERVISOR_HINT_ENV_VARS } from "../../infra/supervisor-markers.js";
+import {
+  SUPERVISOR_HINT_ENV_VARS,
+  type RespawnSupervisor,
+} from "../../infra/supervisor-markers.js";
 import {
   CONTROL_PLANE_UPDATE_SENTINEL_META_ENV,
   type ControlPlaneUpdateSentinelMetaFile,
@@ -12,6 +15,7 @@ import { MANAGED_SERVICE_UPDATE_HANDOFF_TEMP_PREFIX } from "../../infra/update-m
 import type { UpdateRestartSentinelMeta } from "../../infra/update-restart-sentinel-payload.js";
 
 const PARENT_EXIT_GRACE_MS = 60_000;
+const SYSTEMD_RUN_CANDIDATE_PATHS = ["/usr/bin/systemd-run", "/bin/systemd-run"] as const;
 const SERVICE_IDENTITY_ENV_VARS = new Set<string>([
   "OPENCLAW_LAUNCHD_LABEL",
   "OPENCLAW_SYSTEMD_UNIT",
@@ -319,12 +323,95 @@ async function resolveManagedServiceHandoffCwd(root: string): Promise<string> {
   return root;
 }
 
+async function resolveExecutableOnPath(
+  name: string,
+  env: NodeJS.ProcessEnv,
+  fallbackPaths: readonly string[],
+): Promise<string | null> {
+  const candidates = new Set<string>();
+  const pathValue = env.PATH?.trim();
+  if (pathValue) {
+    for (const dir of pathValue.split(path.delimiter)) {
+      if (dir.trim()) {
+        candidates.add(path.join(dir, name));
+      }
+    }
+  }
+  for (const candidate of fallbackPaths) {
+    candidates.add(candidate);
+  }
+
+  for (const candidate of candidates) {
+    try {
+      await fs.access(candidate, fs.constants.X_OK);
+      return candidate;
+    } catch {
+      // Try the next candidate.
+    }
+  }
+  return null;
+}
+
+function sanitizeSystemdUnitFragment(value: string | undefined): string {
+  const normalized = value?.trim().replace(/[^A-Za-z0-9_.:@-]+/gu, "-") ?? "";
+  return normalized.replace(/^-+|-+$/gu, "").slice(0, 80);
+}
+
+function buildSystemdHandoffUnitName(handoffId: string | undefined): string {
+  const suffix =
+    sanitizeSystemdUnitFragment(handoffId) ||
+    sanitizeSystemdUnitFragment(`${process.pid}-${Date.now()}`) ||
+    "handoff";
+  return `openclaw-update-${suffix}.scope`;
+}
+
+async function resolveHandoffSpawn(params: {
+  supervisor?: RespawnSupervisor | null;
+  env: NodeJS.ProcessEnv;
+  execPath: string;
+  scriptPath: string;
+  paramsPath: string;
+  handoffId?: string;
+}): Promise<{ command: string; args: string[] }> {
+  if (params.supervisor !== "systemd") {
+    return {
+      command: params.execPath,
+      args: [params.scriptPath, params.paramsPath],
+    };
+  }
+
+  const systemdRunPath = await resolveExecutableOnPath(
+    "systemd-run",
+    params.env,
+    SYSTEMD_RUN_CANDIDATE_PATHS,
+  );
+  if (!systemdRunPath) {
+    throw new Error(
+      "systemd-run is required to start the managed update handoff outside openclaw-gateway.service",
+    );
+  }
+
+  return {
+    command: systemdRunPath,
+    args: [
+      "--user",
+      "--scope",
+      "--collect",
+      `--unit=${buildSystemdHandoffUnitName(params.handoffId)}`,
+      params.execPath,
+      params.scriptPath,
+      params.paramsPath,
+    ],
+  };
+}
+
 export async function startManagedServiceUpdateHandoff(params: {
   root: string;
   timeoutMs?: number;
   restartDelayMs?: number;
   meta: UpdateRestartSentinelMeta;
   handoffId?: string;
+  supervisor?: RespawnSupervisor | null;
   env?: NodeJS.ProcessEnv;
   execPath?: string;
   argv1?: string;
@@ -368,7 +455,15 @@ export async function startManagedServiceUpdateHandoff(params: {
     [CONTROL_PLANE_UPDATE_SENTINEL_META_ENV]: metaPath,
     OPENCLAW_UPDATE_RUN_HANDOFF: "1",
   };
-  const child = spawn(params.execPath ?? process.execPath, [scriptPath, paramsPath], {
+  const spawnTarget = await resolveHandoffSpawn({
+    supervisor: params.supervisor,
+    env,
+    execPath: params.execPath ?? process.execPath,
+    scriptPath,
+    paramsPath,
+    handoffId: params.handoffId,
+  });
+  const child = spawn(spawnTarget.command, spawnTarget.args, {
     cwd: handoffCwd,
     env,
     detached: true,

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -114,7 +114,7 @@ vi.mock("./restart-request.js", () => ({
     sessionKey: params.sessionKey,
     note: params.note,
     continuationMessage: params.continuationMessage,
-    restartDelayMs: undefined,
+    restartDelayMs: params.restartDelayMs,
   }),
 }));
 
@@ -367,6 +367,7 @@ describe("update.run restart scheduling", () => {
       expect.objectContaining({
         root: "/tmp/openclaw",
         handoffId: expect.any(String),
+        supervisor: "launchd",
         meta: expect.objectContaining({
           handoffId: expect.any(String),
         }),
@@ -412,6 +413,33 @@ describe("update.run restart scheduling", () => {
         stats: expect.objectContaining({
           reason: "managed-service-handoff-started",
         }),
+      }),
+    );
+  });
+
+  it("keeps a startup grace before restarting after systemd handoff spawn", async () => {
+    detectRespawnSupervisorMock.mockReturnValueOnce("systemd");
+    resolveUpdateInstallSurfaceMock.mockResolvedValueOnce({
+      kind: "global",
+      mode: "npm",
+      root: "/tmp/openclaw-global",
+      packageRoot: "/tmp/openclaw-global",
+    });
+
+    await invokeUpdateRun({ restartDelayMs: 0 });
+
+    expect(startManagedServiceUpdateHandoffMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        supervisor: "systemd",
+        restartDelayMs: 0,
+      }),
+    );
+    expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        delayMs: 2000,
+        reason: "update.run",
+        skipCooldown: true,
+        skipDeferral: true,
       }),
     );
   });

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -29,6 +29,8 @@ import {
 } from "./update-managed-service-handoff.js";
 import { assertValidParams } from "./validation.js";
 
+const SYSTEMD_HANDOFF_RESTART_GRACE_MS = 2000;
+
 function formatUpdateRunErrorMessage(err: unknown): string {
   if (err instanceof Error) {
     return err.message || err.name;
@@ -42,6 +44,19 @@ function tryResolveProcessCwd(): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+function resolveManagedServiceHandoffRestartDelayMs(
+  restartDelayMs: number | undefined,
+  supervisor: ReturnType<typeof detectRespawnSupervisor>,
+): number | undefined {
+  if (supervisor !== "systemd") {
+    return restartDelayMs;
+  }
+  return Math.max(
+    restartDelayMs ?? SYSTEMD_HANDOFF_RESTART_GRACE_MS,
+    SYSTEMD_HANDOFF_RESTART_GRACE_MS,
+  );
 }
 
 export const updateHandlers: GatewayRequestHandlers = {
@@ -88,6 +103,7 @@ export const updateHandlers: GatewayRequestHandlers = {
       ...(note !== undefined ? { note } : {}),
       ...(continuationMessage !== undefined ? { continuationMessage } : {}),
     };
+    let supervisor: ReturnType<typeof detectRespawnSupervisor> = null;
     try {
       const config = context.getRuntimeConfig();
       const configChannel = normalizeUpdateChannel(config.update?.channel);
@@ -105,7 +121,7 @@ export const updateHandlers: GatewayRequestHandlers = {
         cwd: root,
         argv1: process.argv[1],
       });
-      const supervisor = detectRespawnSupervisor(process.env, process.platform);
+      supervisor = detectRespawnSupervisor(process.env, process.platform);
       if (!isRestartEnabled(config) && !supervisor) {
         const beforeVersion = installSurface.root
           ? await readPackageVersion(installSurface.root)
@@ -132,6 +148,7 @@ export const updateHandlers: GatewayRequestHandlers = {
               restartDelayMs,
               meta: sentinelMeta,
               handoffId,
+              supervisor,
             });
             handoff = {
               status: "started",
@@ -230,7 +247,7 @@ export const updateHandlers: GatewayRequestHandlers = {
         ? scheduleGatewaySigusr1Restart({
             delayMs:
               handoff?.status === "started"
-                ? restartDelayMs
+                ? resolveManagedServiceHandoffRestartDelayMs(restartDelayMs, supervisor)
                 : updateWasPackageSwap
                   ? 0
                   : restartDelayMs,


### PR DESCRIPTION
## Summary

- Fixes #84068 by launching systemd-managed update handoff helpers through `systemd-run --user --scope --collect` so the helper moves out of `openclaw-gateway.service` before the gateway unit restarts.
- Keeps launchd, schtasks, and non-systemd handoffs on the existing detached Node launch path.
- Adds a systemd-only 2s restart grace even when a caller asks for `restartDelayMs: 0`, plus focused coverage for the transient scope command and restart scheduling.

## Verification

2026-05-23 update after rebasing onto `origin/main` (`32f91503be`), head `35c99588ab`:

- `node scripts/run-vitest.mjs src/gateway/server-methods/update-managed-service-handoff.test.ts src/gateway/server-methods/update.test.ts --reporter=verbose` (4 files, 50 tests passed)
- `./node_modules/.bin/oxfmt --check --threads=1 CHANGELOG.md src/gateway/server-methods/update-managed-service-handoff.ts src/gateway/server-methods/update-managed-service-handoff.test.ts src/gateway/server-methods/update.ts src/gateway/server-methods/update.test.ts`
- `./node_modules/.bin/oxlint src/gateway/server-methods/update-managed-service-handoff.ts src/gateway/server-methods/update-managed-service-handoff.test.ts src/gateway/server-methods/update.ts src/gateway/server-methods/update.test.ts`
- `git diff --check origin/main...HEAD`

Earlier verification before the rebase:

- `pnpm install`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/server-methods/update-managed-service-handoff.test.ts src/gateway/server-methods/update.test.ts src/commands/status-update-restart.test.ts -- --reporter=verbose`
- `pnpm exec oxlint --tsconfig config/tsconfig/oxlint.core.json src/gateway/server-methods/update-managed-service-handoff.ts src/gateway/server-methods/update-managed-service-handoff.test.ts src/gateway/server-methods/update.test.ts src/gateway/server-methods/update.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `git diff --check`
- `codex review --uncommitted`

Note: `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ...` was blocked in this worktree before linting changed files by an unrelated WhatsApp boundary artifact failure: missing `baileys` types in `extensions/whatsapp`. Direct focused oxlint on changed files passed.

## Real behavior proof

Behavior addressed: systemd-supervised Control UI/package update handoffs no longer leave the update helper inside `openclaw-gateway.service`, where the helper can be killed by the gateway unit restart before it writes `handoff.log` or runs `openclaw update`.

Real environment tested: WSL Ubuntu-24.04 checkout at `/root/src/openclaw-85414`, Node/Vitest via repo wrapper. Earlier proof also used a WSL2 Ubuntu 24.04 user-systemd environment with a real `systemctl --user` unit, documented in the PR comments.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/gateway/server-methods/update-managed-service-handoff.test.ts src/gateway/server-methods/update.test.ts --reporter=verbose`

Evidence after fix: The focused tests verify the production handoff path chooses `systemd-run --user --scope --collect --unit=openclaw-update-<handoff>.scope <node> <handoff.cjs> <handoff.json>` for `supervisor: "systemd"`, while preserving service identity env and stripping transient systemd invocation hints. The update scheduling test verifies the minimum 2000ms systemd restart grace when `restartDelayMs: 0` is requested.

Observed result after fix: The focused suite passed: 4 test files, 50 tests. The systemd handoff starter spawns `systemd-run` instead of a plain detached Node child, and `update.run` schedules the gateway restart with enough grace for the transient scope handoff to leave the service cgroup.

What was not tested: I did not repeat the live package-upgrade/systemd-unit E2E after this rebase; the changed behavior is covered by the production-path tests plus the earlier live WSL systemd proof in the PR discussion.
