### PR TITLE
fix: split image setup and request timeout semantics

### DIFF
--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -339,7 +339,7 @@ Configures inbound media understanding (image/audio/video):
 
     - `capabilities`: optional list (`image`, `audio`, `video`). Defaults: `openai`/`anthropic`/`minimax` → image, `google` → image+audio+video, `groq` → audio.
     - `prompt`, `maxChars`, `maxBytes`, `timeoutSeconds`, `language`: per-entry overrides.
-    - `tools.media.image.timeoutSeconds` and matching image model `timeoutSeconds` entries also apply when the agent calls the explicit `image` tool.
+    - `tools.media.image.timeoutSeconds` and matching image model `timeoutSeconds` entries also apply when the agent calls the explicit `image` tool. For image understanding, this timeout applies to the request itself and is not reduced by earlier preparation work.
     - Failures fall back to the next entry.
 
     Provider auth follows standard order: `auth-profiles.json` → env vars → `models.providers.*.apiKey`.

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -313,7 +313,9 @@ available timeout in this order:
 - For `image_generate` without a configured timeout, the 120 second
   image-generation default.
 - For the media-understanding `image` tool, `tools.media.image.timeoutSeconds`
-  converted to milliseconds, or the 60 second media default.
+  converted to milliseconds, or the 60 second media default. For image
+  understanding, this applies to the request itself and is not reduced by
+  earlier preparation work.
 - The 90 second dynamic-tool default.
 
 Dynamic tool budgets are capped at 600000 ms. On timeout, OpenClaw aborts the

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -557,8 +557,10 @@ or shortens that specific tool budget. The `image_generate` tool uses
 `agents.defaults.imageGenerationModel.timeoutMs` when the tool call does not
 provide its own timeout, or a 120 second image-generation default otherwise.
 The media-understanding `image` tool uses
-`tools.media.image.timeoutSeconds` or its 60 second media default. Dynamic tool
-budgets are capped at 600000 ms. On timeout, OpenClaw aborts the tool signal
+`tools.media.image.timeoutSeconds` or its 60 second media default. For image
+understanding, that timeout applies to the request itself and is not
+reduced by earlier preparation work. Dynamic tool budgets are
+capped at 600000 ms. On timeout, OpenClaw aborts the tool signal
 where supported and returns a failed dynamic-tool response to Codex so the turn
 can continue instead of leaving the session in `processing`.
 

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -1097,16 +1097,15 @@ describe("describeImageWithModel", () => {
     expect(options.timeoutMs).toBe(1000);
 
     const assertion = expect(result).rejects.toThrow(
-      "image description request timed out after 1000ms",
+      `image description request timed out after 1000ms (setup took ${slowSetupMs}ms before provider request started)`,
     );
     await vi.advanceTimersByTimeAsync(1000);
     await assertion;
     expect(options.signal.aborted).toBe(true);
   });
 
-  it("uses a fixed internal timeout for image runtime setup", async () => {
+  it("rejects when image runtime setup exceeds the request timeout", async () => {
     vi.useFakeTimers();
-    const setupTimeoutMs = 15_000;
     resolveModelAsyncMock.mockImplementationOnce(() => new Promise(() => {}));
 
     const result = describeImageWithModel({
@@ -1122,12 +1121,9 @@ describe("describeImageWithModel", () => {
     });
 
     const assertion = expect(result).rejects.toThrow(
-      `image description setup timed out after ${setupTimeoutMs}ms before the request started`,
+      "image description setup timed out after 25ms before provider request started",
     );
-    await vi.advanceTimersByTimeAsync(setupTimeoutMs - 1);
-    await Promise.resolve();
-    expect(completeMock).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(1);
+    await vi.advanceTimersByTimeAsync(25);
     await assertion;
     expect(completeMock).not.toHaveBeenCalled();
   });

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -1097,15 +1097,16 @@ describe("describeImageWithModel", () => {
     expect(options.timeoutMs).toBe(1000);
 
     const assertion = expect(result).rejects.toThrow(
-      `image description request timed out after 1000ms (setup took ${slowSetupMs}ms before provider request started)`,
+      "image description request timed out after 1000ms",
     );
     await vi.advanceTimersByTimeAsync(1000);
     await assertion;
     expect(options.signal.aborted).toBe(true);
   });
 
-  it("rejects when image runtime setup exceeds the request timeout", async () => {
+  it("uses a fixed internal timeout for image runtime setup", async () => {
     vi.useFakeTimers();
+    const setupTimeoutMs = 15_000;
     resolveModelAsyncMock.mockImplementationOnce(() => new Promise(() => {}));
 
     const result = describeImageWithModel({
@@ -1121,9 +1122,12 @@ describe("describeImageWithModel", () => {
     });
 
     const assertion = expect(result).rejects.toThrow(
-      "image description setup timed out after 25ms before provider request started",
+      `image description setup timed out after ${setupTimeoutMs}ms before the request started`,
     );
-    await vi.advanceTimersByTimeAsync(25);
+    await vi.advanceTimersByTimeAsync(setupTimeoutMs - 1);
+    await Promise.resolve();
+    expect(completeMock).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
     await assertion;
     expect(completeMock).not.toHaveBeenCalled();
   });

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -1029,7 +1029,9 @@ describe("describeImageWithModel", () => {
       timeoutMs: 25,
     });
 
-    const assertion = expect(result).rejects.toThrow("image description timed out after 25ms");
+    const assertion = expect(result).rejects.toThrow(
+      "image description request timed out after 25ms",
+    );
     await vi.advanceTimersByTimeAsync(25);
     await assertion;
     const firstCall = requireFirstMockCall(completeMock, "timed image completion");
@@ -1039,6 +1041,67 @@ describe("describeImageWithModel", () => {
     }
     expect(options.signal.aborted).toBe(true);
     expect(options.timeoutMs).toBe(25);
+  });
+
+  it("keeps the full configured timeout for provider requests after slow setup", async () => {
+    vi.useFakeTimers();
+    const slowSetupMs = 400;
+    discoverModelsMock.mockReturnValue({
+      find: vi.fn(() => ({
+        api: "openai-responses",
+        provider: "openai",
+        id: "gpt-5.4-mini",
+        input: ["text", "image"],
+        baseUrl: "https://api.openai.com/v1",
+      })),
+    });
+    resolveModelAsyncMock.mockImplementationOnce(
+      async (provider: string, modelId: string, agentDir?: string, cfg?: unknown) => {
+        await new Promise((resolve) => setTimeout(resolve, slowSetupMs));
+        const authStorage = {
+          setRuntimeApiKey: setRuntimeApiKeyMock,
+        };
+        const modelRegistry = discoverModelsMock(authStorage, agentDir);
+        const model = resolveModelWithRegistryMock({
+          provider,
+          modelId,
+          modelRegistry,
+          cfg,
+          agentDir,
+        });
+        return { authStorage, model, modelRegistry };
+      },
+    );
+    completeMock.mockImplementation(() => new Promise(() => {}));
+
+    const result = describeImageWithModel({
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+      provider: "openai",
+      model: "gpt-5.4-mini",
+      buffer: Buffer.from("png-bytes"),
+      fileName: "image.png",
+      mime: "image/png",
+      prompt: "Describe the image.",
+      timeoutMs: 1000,
+    });
+
+    await vi.advanceTimersByTimeAsync(slowSetupMs);
+    await Promise.resolve();
+    expect(completeMock).toHaveBeenCalledTimes(1);
+    const firstCall = requireFirstMockCall(completeMock, "slow setup image completion");
+    const [, , options] = firstCall;
+    if (!options?.signal) {
+      throw new Error("Expected image completion abort signal");
+    }
+    expect(options.timeoutMs).toBe(1000);
+
+    const assertion = expect(result).rejects.toThrow(
+      `image description request timed out after 1000ms (setup took ${slowSetupMs}ms before provider request started)`,
+    );
+    await vi.advanceTimersByTimeAsync(1000);
+    await assertion;
+    expect(options.signal.aborted).toBe(true);
   });
 
   it("rejects when image runtime setup exceeds the request timeout", async () => {
@@ -1057,7 +1120,9 @@ describe("describeImageWithModel", () => {
       timeoutMs: 25,
     });
 
-    const assertion = expect(result).rejects.toThrow("image description timed out after 25ms");
+    const assertion = expect(result).rejects.toThrow(
+      "image description setup timed out after 25ms before provider request started",
+    );
     await vi.advanceTimersByTimeAsync(25);
     await assertion;
     expect(completeMock).not.toHaveBeenCalled();

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -428,17 +428,39 @@ async function resolveMinimaxVlmFallbackRuntime(params: {
   };
 }
 
-function resolveImageDescriptionTimeoutMs(timeoutMs: number | undefined, startedAtMs: number) {
+function resolveImageDescriptionTimeoutMs(timeoutMs: number | undefined) {
   if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
     return undefined;
   }
-  return Math.max(1, Math.floor(timeoutMs - (Date.now() - startedAtMs)));
+  return Math.floor(timeoutMs);
+}
+
+function buildImageDescriptionTimeoutError(params: {
+  phase: "setup" | "request";
+  timeoutMs: number;
+  setupDurationMs?: number;
+}): Error {
+  if (params.phase === "setup") {
+    return new Error(
+      `image description setup timed out after ${params.timeoutMs}ms before provider request started`,
+    );
+  }
+  const setupDurationMs =
+    typeof params.setupDurationMs === "number" && Number.isFinite(params.setupDurationMs)
+      ? Math.max(0, Math.floor(params.setupDurationMs))
+      : 0;
+  return new Error(
+    setupDurationMs > 0
+      ? `image description request timed out after ${params.timeoutMs}ms (setup took ${setupDurationMs}ms before provider request started)`
+      : `image description request timed out after ${params.timeoutMs}ms`,
+  );
 }
 
 async function withImageDescriptionTimeout<T>(params: {
   task: Promise<T>;
   timeoutMs: number | undefined;
   controller: AbortController;
+  createTimeoutError: (timeoutMs: number) => Error;
 }): Promise<T> {
   if (params.timeoutMs === undefined) {
     return await params.task;
@@ -450,7 +472,7 @@ async function withImageDescriptionTimeout<T>(params: {
       new Promise<never>((_, reject) => {
         timeout = setTimeout(() => {
           params.controller.abort();
-          reject(new Error(`image description timed out after ${params.timeoutMs}ms`));
+          reject(params.createTimeoutError(params.timeoutMs!));
         }, params.timeoutMs);
       }),
     ]);
@@ -468,13 +490,16 @@ async function describeImagesWithModelInternal(
   const prompt = params.prompt ?? "Describe the image.";
   const startedAtMs = Date.now();
   const controller = new AbortController();
+  const configuredTimeoutMs = resolveImageDescriptionTimeoutMs(params.timeoutMs);
   let apiKey: string;
   let model: Model | undefined;
 
   try {
     const resolved = await withImageDescriptionTimeout({
       controller,
-      timeoutMs: resolveImageDescriptionTimeoutMs(params.timeoutMs, startedAtMs),
+      timeoutMs: configuredTimeoutMs,
+      createTimeoutError: (timeoutMs) =>
+        buildImageDescriptionTimeoutError({ phase: "setup", timeoutMs }),
       task: resolveImageRuntime(params),
     });
     apiKey = resolved.apiKey;
@@ -483,7 +508,13 @@ async function describeImagesWithModelInternal(
     if (!isMinimaxVlmModel(params.provider, params.model) || !isUnknownModelError(err)) {
       throw err;
     }
-    const fallback = await resolveMinimaxVlmFallbackRuntime(params);
+    const fallback = await withImageDescriptionTimeout({
+      controller,
+      timeoutMs: configuredTimeoutMs,
+      createTimeoutError: (timeoutMs) =>
+        buildImageDescriptionTimeoutError({ phase: "setup", timeoutMs }),
+      task: resolveMinimaxVlmFallbackRuntime(params),
+    });
     return await describeImagesWithMinimax({
       apiKey: fallback.apiKey,
       provider: params.provider,
@@ -494,6 +525,8 @@ async function describeImagesWithModelInternal(
       images: params.images,
     });
   }
+
+  const setupDurationMs = Date.now() - startedAtMs;
 
   if (isMinimaxVlmModel(model.provider, model.id)) {
     return await describeImagesWithMinimax({
@@ -521,7 +554,7 @@ async function describeImagesWithModelInternal(
   const maxTokens = resolveImageToolMaxTokens(model.maxTokens, params.maxTokens);
   const completeImage = async (onPayload?: ProviderStreamOptions["onPayload"]) => {
     const payloadHandler = composeImageDescriptionPayloadHandlers(onPayload, options.onPayload);
-    const timeoutMs = resolveImageDescriptionTimeoutMs(params.timeoutMs, startedAtMs);
+    const timeoutMs = configuredTimeoutMs;
     const headers = buildImageRequestHeaders(model);
     const streamOptions = {
       apiKey,
@@ -537,6 +570,12 @@ async function describeImagesWithModelInternal(
     return await withImageDescriptionTimeout({
       controller,
       timeoutMs,
+      createTimeoutError: (requestTimeoutMs) =>
+        buildImageDescriptionTimeoutError({
+          phase: "request",
+          timeoutMs: requestTimeoutMs,
+          setupDurationMs,
+        }),
       task,
     });
   };

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -31,6 +31,9 @@ import type {
   ImagesDescriptionResult,
 } from "./types.js";
 
+// Keep runtime preparation bounded without shrinking the user-configured provider request budget.
+const IMAGE_DESCRIPTION_SETUP_TIMEOUT_MS = 15_000;
+
 function resolveImageToolMaxTokens(modelMaxTokens: number | undefined, requestedMaxTokens = 4096) {
   if (
     typeof modelMaxTokens !== "number" ||
@@ -438,29 +441,19 @@ function resolveImageDescriptionTimeoutMs(timeoutMs: number | undefined) {
 function buildImageDescriptionTimeoutError(params: {
   phase: "setup" | "request";
   timeoutMs: number;
-  setupDurationMs?: number;
 }): Error {
-  if (params.phase === "setup") {
-    return new Error(
-      `image description setup timed out after ${params.timeoutMs}ms before provider request started`,
-    );
-  }
-  const setupDurationMs =
-    typeof params.setupDurationMs === "number" && Number.isFinite(params.setupDurationMs)
-      ? Math.max(0, Math.floor(params.setupDurationMs))
-      : 0;
-  return new Error(
-    setupDurationMs > 0
-      ? `image description request timed out after ${params.timeoutMs}ms (setup took ${setupDurationMs}ms before provider request started)`
-      : `image description request timed out after ${params.timeoutMs}ms`,
-  );
+  return params.phase === "setup"
+    ? new Error(
+        `image description setup timed out after ${params.timeoutMs}ms before the request started`,
+      )
+    : new Error(`image description request timed out after ${params.timeoutMs}ms`);
 }
 
 async function withImageDescriptionTimeout<T>(params: {
   task: Promise<T>;
   timeoutMs: number | undefined;
   controller: AbortController;
-  createTimeoutError: (timeoutMs: number) => Error;
+  phase: "setup" | "request";
 }): Promise<T> {
   if (params.timeoutMs === undefined) {
     return await params.task;
@@ -472,7 +465,12 @@ async function withImageDescriptionTimeout<T>(params: {
       new Promise<never>((_, reject) => {
         timeout = setTimeout(() => {
           params.controller.abort();
-          reject(params.createTimeoutError(params.timeoutMs!));
+          reject(
+            buildImageDescriptionTimeoutError({
+              phase: params.phase,
+              timeoutMs: params.timeoutMs!,
+            }),
+          );
         }, params.timeoutMs);
       }),
     ]);
@@ -488,18 +486,17 @@ async function describeImagesWithModelInternal(
   options: { onPayload?: ProviderStreamOptions["onPayload"] } = {},
 ): Promise<ImagesDescriptionResult> {
   const prompt = params.prompt ?? "Describe the image.";
-  const startedAtMs = Date.now();
   const controller = new AbortController();
   const configuredTimeoutMs = resolveImageDescriptionTimeoutMs(params.timeoutMs);
+  const setupTimeoutMs = IMAGE_DESCRIPTION_SETUP_TIMEOUT_MS;
   let apiKey: string;
   let model: Model | undefined;
 
   try {
     const resolved = await withImageDescriptionTimeout({
       controller,
-      timeoutMs: configuredTimeoutMs,
-      createTimeoutError: (timeoutMs) =>
-        buildImageDescriptionTimeoutError({ phase: "setup", timeoutMs }),
+      timeoutMs: setupTimeoutMs,
+      phase: "setup",
       task: resolveImageRuntime(params),
     });
     apiKey = resolved.apiKey;
@@ -510,9 +507,8 @@ async function describeImagesWithModelInternal(
     }
     const fallback = await withImageDescriptionTimeout({
       controller,
-      timeoutMs: configuredTimeoutMs,
-      createTimeoutError: (timeoutMs) =>
-        buildImageDescriptionTimeoutError({ phase: "setup", timeoutMs }),
+      timeoutMs: setupTimeoutMs,
+      phase: "setup",
       task: resolveMinimaxVlmFallbackRuntime(params),
     });
     return await describeImagesWithMinimax({
@@ -525,8 +521,6 @@ async function describeImagesWithModelInternal(
       images: params.images,
     });
   }
-
-  const setupDurationMs = Date.now() - startedAtMs;
 
   if (isMinimaxVlmModel(model.provider, model.id)) {
     return await describeImagesWithMinimax({
@@ -570,12 +564,7 @@ async function describeImagesWithModelInternal(
     return await withImageDescriptionTimeout({
       controller,
       timeoutMs,
-      createTimeoutError: (requestTimeoutMs) =>
-        buildImageDescriptionTimeoutError({
-          phase: "request",
-          timeoutMs: requestTimeoutMs,
-          setupDurationMs,
-        }),
+      phase: "request",
       task,
     });
   };

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -31,9 +31,6 @@ import type {
   ImagesDescriptionResult,
 } from "./types.js";
 
-// Keep runtime preparation bounded without shrinking the user-configured provider request budget.
-const IMAGE_DESCRIPTION_SETUP_TIMEOUT_MS = 15_000;
-
 function resolveImageToolMaxTokens(modelMaxTokens: number | undefined, requestedMaxTokens = 4096) {
   if (
     typeof modelMaxTokens !== "number" ||
@@ -441,19 +438,29 @@ function resolveImageDescriptionTimeoutMs(timeoutMs: number | undefined) {
 function buildImageDescriptionTimeoutError(params: {
   phase: "setup" | "request";
   timeoutMs: number;
+  setupDurationMs?: number;
 }): Error {
-  return params.phase === "setup"
-    ? new Error(
-        `image description setup timed out after ${params.timeoutMs}ms before the request started`,
-      )
-    : new Error(`image description request timed out after ${params.timeoutMs}ms`);
+  if (params.phase === "setup") {
+    return new Error(
+      `image description setup timed out after ${params.timeoutMs}ms before provider request started`,
+    );
+  }
+  const setupDurationMs =
+    typeof params.setupDurationMs === "number" && Number.isFinite(params.setupDurationMs)
+      ? Math.max(0, Math.floor(params.setupDurationMs))
+      : 0;
+  return new Error(
+    setupDurationMs > 0
+      ? `image description request timed out after ${params.timeoutMs}ms (setup took ${setupDurationMs}ms before provider request started)`
+      : `image description request timed out after ${params.timeoutMs}ms`,
+  );
 }
 
 async function withImageDescriptionTimeout<T>(params: {
   task: Promise<T>;
   timeoutMs: number | undefined;
   controller: AbortController;
-  phase: "setup" | "request";
+  createTimeoutError: (timeoutMs: number) => Error;
 }): Promise<T> {
   if (params.timeoutMs === undefined) {
     return await params.task;
@@ -465,12 +472,7 @@ async function withImageDescriptionTimeout<T>(params: {
       new Promise<never>((_, reject) => {
         timeout = setTimeout(() => {
           params.controller.abort();
-          reject(
-            buildImageDescriptionTimeoutError({
-              phase: params.phase,
-              timeoutMs: params.timeoutMs!,
-            }),
-          );
+          reject(params.createTimeoutError(params.timeoutMs!));
         }, params.timeoutMs);
       }),
     ]);
@@ -486,17 +488,18 @@ async function describeImagesWithModelInternal(
   options: { onPayload?: ProviderStreamOptions["onPayload"] } = {},
 ): Promise<ImagesDescriptionResult> {
   const prompt = params.prompt ?? "Describe the image.";
+  const startedAtMs = Date.now();
   const controller = new AbortController();
   const configuredTimeoutMs = resolveImageDescriptionTimeoutMs(params.timeoutMs);
-  const setupTimeoutMs = IMAGE_DESCRIPTION_SETUP_TIMEOUT_MS;
   let apiKey: string;
   let model: Model | undefined;
 
   try {
     const resolved = await withImageDescriptionTimeout({
       controller,
-      timeoutMs: setupTimeoutMs,
-      phase: "setup",
+      timeoutMs: configuredTimeoutMs,
+      createTimeoutError: (timeoutMs) =>
+        buildImageDescriptionTimeoutError({ phase: "setup", timeoutMs }),
       task: resolveImageRuntime(params),
     });
     apiKey = resolved.apiKey;
@@ -507,8 +510,9 @@ async function describeImagesWithModelInternal(
     }
     const fallback = await withImageDescriptionTimeout({
       controller,
-      timeoutMs: setupTimeoutMs,
-      phase: "setup",
+      timeoutMs: configuredTimeoutMs,
+      createTimeoutError: (timeoutMs) =>
+        buildImageDescriptionTimeoutError({ phase: "setup", timeoutMs }),
       task: resolveMinimaxVlmFallbackRuntime(params),
     });
     return await describeImagesWithMinimax({
@@ -521,6 +525,8 @@ async function describeImagesWithModelInternal(
       images: params.images,
     });
   }
+
+  const setupDurationMs = Date.now() - startedAtMs;
 
   if (isMinimaxVlmModel(model.provider, model.id)) {
     return await describeImagesWithMinimax({
@@ -564,7 +570,12 @@ async function describeImagesWithModelInternal(
     return await withImageDescriptionTimeout({
       controller,
       timeoutMs,
-      phase: "request",
+      createTimeoutError: (requestTimeoutMs) =>
+        buildImageDescriptionTimeoutError({
+          phase: "request",
+          timeoutMs: requestTimeoutMs,
+          setupDurationMs,
+        }),
       task,
     });
   };


### PR DESCRIPTION
## Summary
- split image-description timeout handling so setup and provider request both use the configured `tools.media.image.timeoutSeconds` budget instead of shrinking the request budget by elapsed setup time
- preserve the full configured timeout for the provider request instead of silently subtracting setup latency down to a tiny remaining budget
- add focused tests covering request timeout messaging, setup timeout messaging, and slow-setup request behavior
- keep public docs user-facing: the image timeout still applies to the request itself and is not reduced by earlier preparation work
- keep the heavier image-tool latency and runtime-loading reductions for follow-up PRs after this timeout-semantics fix

## Verification
- `git diff --check`
- `env CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 node scripts/crabbox-wrapper.mjs run --provider docker --docker-image node:22-bookworm --timing-json --shell -- "bash -lc 'corepack enable >/dev/null 2>&1 && env CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 corepack pnpm test src/media-understanding/image.test.ts'"`

## Real behavior proof
Behavior addressed: image timeout errors no longer collapse setup latency into a tiny remaining provider timeout; setup and request failures now report distinct phases.
Real environment tested: Crabbox `docker` provider with `node:22-bookworm`, synced from this worktree.
Exact steps or command run after this patch: run the targeted media-understanding Vitest file via Crabbox Docker using the command above.
Evidence after fix: `src/media-understanding/image.test.ts` passes with 25 tests; assertions cover request timeout messaging, setup timeout messaging, and a slow setup that still passes the full configured timeout through to the provider request.
Observed result after fix: the test suite passed, provider-request calls still received `timeoutMs: 1000` after a mocked `400ms` setup delay, and timeout messages now distinguish `setup` vs `request`.
What was not tested: live provider behavior and the follow-up PRs that will reduce the image runtime-loading latency itself.
