### PR TITLE
fix(imessage): advance catchup cursor from live messages

### DIFF
--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -683,7 +683,7 @@ channels: {
 
 ### How it runs
 
-One pass per `monitorIMessageProvider` startup, sequenced as `imsg launch` ready → `watch.subscribe` → `performIMessageCatchup` → live dispatch loop. Catchup itself uses `chats.list` + per-chat `messages.history` against the same JSON-RPC client used by `imsg watch`. Anything that arrives during the catchup pass flows through live dispatch normally; the existing inbound-dedupe cache absorbs any overlap with replayed rows.
+One pass per `monitorIMessageProvider` startup, sequenced as `imsg launch` ready → `watch.subscribe` → `performIMessageCatchup` → live dispatch loop. Catchup itself uses `chats.list` + per-chat `messages.history` against the same JSON-RPC client used by `imsg watch`. Anything that arrives during the catchup pass flows through live dispatch normally; the existing inbound-dedupe cache absorbs any overlap with replayed rows, and live-handled rows advance the same persisted cursor once they are safely resolved.
 
 Each replayed row is fed through the live dispatch path (`evaluateIMessageInbound` + `dispatchInboundMessage`), so allowlists, group policy, debouncer, echo cache, and read receipts behave identically on replayed and live messages.
 

--- a/extensions/acpx/npm-shrinkwrap.json
+++ b/extensions/acpx/npm-shrinkwrap.json
@@ -903,7 +903,6 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
       "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -2239,7 +2238,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/extensions/amazon-bedrock-mantle/npm-shrinkwrap.json
+++ b/extensions/amazon-bedrock-mantle/npm-shrinkwrap.json
@@ -1314,7 +1314,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1351,7 +1350,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/extensions/amazon-bedrock/npm-shrinkwrap.json
+++ b/extensions/amazon-bedrock/npm-shrinkwrap.json
@@ -1188,7 +1188,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1225,7 +1224,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/extensions/anthropic-vertex/npm-shrinkwrap.json
+++ b/extensions/anthropic-vertex/npm-shrinkwrap.json
@@ -1321,7 +1321,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1373,7 +1372,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/extensions/codex/npm-shrinkwrap.json
+++ b/extensions/codex/npm-shrinkwrap.json
@@ -1866,7 +1866,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1918,7 +1917,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/extensions/diagnostics-otel/npm-shrinkwrap.json
+++ b/extensions/diagnostics-otel/npm-shrinkwrap.json
@@ -67,7 +67,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -581,7 +580,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },

--- a/extensions/discord/npm-shrinkwrap.json
+++ b/extensions/discord/npm-shrinkwrap.json
@@ -432,8 +432,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.1.1.tgz",
       "integrity": "sha512-mL0fZZOUnXdZ78woRXp18lApwpp0lF5tozJOD1Wut0dgrA9WuQTgSels/CSmFleaAZrJi/nci5KOVtbuxeWoQA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prism-media": {
       "version": "1.3.5",

--- a/extensions/imessage/src/monitor.catchup-cursor.test.ts
+++ b/extensions/imessage/src/monitor.catchup-cursor.test.ts
@@ -1,0 +1,520 @@
+import type { waitForTransportReady } from "openclaw/plugin-sdk/transport-ready-runtime";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { createIMessageRpcClient } from "./client.js";
+import { monitorIMessageProvider } from "./monitor.js";
+import type { runIMessageCatchup } from "./monitor/catchup-bridge.js";
+import type { advanceIMessageCatchupCursor } from "./monitor/catchup.js";
+import type { IMessagePayload } from "./monitor/types.js";
+
+const waitForTransportReadyMock = vi.hoisted(() =>
+  vi.fn<typeof waitForTransportReady>(async () => {}),
+);
+const createIMessageRpcClientMock = vi.hoisted(() => vi.fn<typeof createIMessageRpcClient>());
+const runIMessageCatchupMock = vi.hoisted(() => vi.fn<typeof runIMessageCatchup>());
+const advanceIMessageCatchupCursorMock = vi.hoisted(() =>
+  vi.fn<typeof advanceIMessageCatchupCursor>(async () => true),
+);
+const readChannelAllowFromStoreMock = vi.hoisted(() => vi.fn(async () => [] as string[]));
+const recordInboundSessionMock = vi.hoisted(() => vi.fn(async (_params: unknown) => {}));
+const dispatchInboundMessageMock = vi.hoisted(() =>
+  vi.fn(async () => ({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } }) as const),
+);
+
+vi.mock("openclaw/plugin-sdk/transport-ready-runtime", () => ({
+  waitForTransportReady: waitForTransportReadyMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/conversation-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/conversation-runtime")>();
+  return {
+    ...actual,
+    readChannelAllowFromStore: readChannelAllowFromStoreMock,
+    recordInboundSession: recordInboundSessionMock,
+    upsertChannelPairingRequest: vi.fn(),
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/reply-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/reply-runtime")>();
+  return {
+    ...actual,
+    dispatchInboundMessage: dispatchInboundMessageMock,
+  };
+});
+
+vi.mock("./client.js", () => ({
+  createIMessageRpcClient: createIMessageRpcClientMock,
+}));
+
+vi.mock("./monitor/abort-handler.js", () => ({
+  attachIMessageMonitorAbortHandler: vi.fn(() => () => {}),
+}));
+
+vi.mock("./monitor/catchup-bridge.js", () => ({
+  runIMessageCatchup: runIMessageCatchupMock,
+}));
+
+vi.mock("./monitor/catchup.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./monitor/catchup.js")>();
+  return {
+    ...actual,
+    advanceIMessageCatchupCursor: advanceIMessageCatchupCursorMock,
+  };
+});
+
+type TestIMessagePayload = IMessagePayload & {
+  coalescedMessageGuids?: string[];
+  coalescedMessageIds?: number[];
+};
+
+function createMessage(overrides: Partial<TestIMessagePayload> = {}): TestIMessagePayload {
+  return {
+    id: 50,
+    guid: "guid-50",
+    chat_id: 7,
+    sender: "+15550001111",
+    is_from_me: false,
+    text: "hello",
+    is_group: false,
+    created_at: "2026-05-22T09:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function createRuntime() {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  };
+}
+
+function createConfig(options: { debounceMs?: number } = {}) {
+  return {
+    channels: {
+      imessage: {
+        catchup: { enabled: true },
+        dmPolicy: "allowlist",
+        allowFrom: ["+15550001111"],
+      },
+    },
+    messages: { inbound: { debounceMs: options.debounceMs ?? 0 } },
+  };
+}
+
+describe("iMessage catchup live cursor coordination", () => {
+  beforeEach(() => {
+    waitForTransportReadyMock.mockReset().mockResolvedValue(undefined);
+    createIMessageRpcClientMock.mockReset();
+    runIMessageCatchupMock.mockReset();
+    advanceIMessageCatchupCursorMock.mockReset().mockResolvedValue(true);
+    readChannelAllowFromStoreMock.mockReset().mockResolvedValue([]);
+    recordInboundSessionMock.mockClear();
+    dispatchInboundMessageMock.mockClear();
+  });
+
+  afterAll(() => {
+    vi.doUnmock("openclaw/plugin-sdk/transport-ready-runtime");
+    vi.doUnmock("openclaw/plugin-sdk/conversation-runtime");
+    vi.doUnmock("openclaw/plugin-sdk/reply-runtime");
+    vi.doUnmock("./client.js");
+    vi.doUnmock("./monitor/abort-handler.js");
+    vi.doUnmock("./monitor/catchup-bridge.js");
+    vi.doUnmock("./monitor/catchup.js");
+    vi.resetModules();
+  });
+
+  it("does not run live cursor advancement for catchup replay rows", async () => {
+    runIMessageCatchupMock.mockImplementation(async (params) => {
+      await params.dispatchPayload(createMessage());
+      return {
+        querySucceeded: true,
+        fetchedCount: 1,
+        replayed: 1,
+        skippedFromMe: 0,
+        skippedPreCursor: 0,
+        skippedGivenUp: 0,
+        failed: 0,
+        givenUp: 0,
+        cursorBefore: null,
+        cursorAfter: { lastSeenMs: 1, lastSeenRowid: 50 },
+        windowStartMs: 0,
+        windowEndMs: 1,
+      };
+    });
+    createIMessageRpcClientMock.mockResolvedValue({
+      request: vi.fn(async () => ({ subscription: 1 })),
+      waitForClose: vi.fn(async () => {}),
+      stop: vi.fn(async () => {}),
+    } as never);
+
+    await monitorIMessageProvider({
+      config: createConfig() as never,
+      runtime: createRuntime(),
+    });
+
+    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+    expect(advanceIMessageCatchupCursorMock).not.toHaveBeenCalled();
+  });
+
+  it("waits for startup catchup to finish before live messages advance the cursor", async () => {
+    let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+    runIMessageCatchupMock.mockImplementation(async () => {
+      onNotification?.({
+        method: "message",
+        params: { message: createMessage({ id: 75, guid: "guid-75" }) },
+      });
+      await vi.waitFor(() => {
+        expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      });
+      expect(advanceIMessageCatchupCursorMock).not.toHaveBeenCalled();
+      return {
+        querySucceeded: true,
+        fetchedCount: 0,
+        replayed: 0,
+        skippedFromMe: 0,
+        skippedPreCursor: 0,
+        skippedGivenUp: 0,
+        failed: 0,
+        givenUp: 0,
+        cursorBefore: null,
+        cursorAfter: { lastSeenMs: 1, lastSeenRowid: 50 },
+        windowStartMs: 0,
+        windowEndMs: 1,
+      };
+    });
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      onNotification = params?.onNotification;
+      return {
+        request: vi.fn(async () => ({ subscription: 1 })),
+        waitForClose: vi.fn(async () => {}),
+        stop: vi.fn(async () => {}),
+      } as never;
+    });
+
+    await monitorIMessageProvider({
+      config: createConfig() as never,
+      runtime: createRuntime(),
+    });
+
+    expect(advanceIMessageCatchupCursorMock).toHaveBeenCalledWith(
+      "default",
+      { lastSeenMs: Date.parse("2026-05-22T09:00:00.000Z"), lastSeenRowid: 75 },
+      { maxFailureRetries: 10 },
+    );
+  });
+
+  it("skips catchup replay rows already resolved by startup live coalescing", async () => {
+    let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+    let releaseLiveDispatch!: () => void;
+    const liveDispatchStarted = new Promise<void>((resolve) => {
+      dispatchInboundMessageMock.mockImplementationOnce(async () => {
+        resolve();
+        await new Promise<void>((release) => {
+          releaseLiveDispatch = release;
+        });
+        return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } };
+      });
+    });
+    runIMessageCatchupMock.mockImplementation(async (params) => {
+      onNotification?.({
+        method: "message",
+        params: {
+          message: createMessage({
+            id: 100,
+            guid: "guid-100",
+            coalescedMessageGuids: ["guid-100", "guid-101"],
+            coalescedMessageIds: [100, 101],
+          }),
+        },
+      });
+      await liveDispatchStarted;
+
+      const replay = params.dispatchPayload(createMessage({ id: 101, guid: "guid-101" }));
+      await Promise.resolve();
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      expect(advanceIMessageCatchupCursorMock).not.toHaveBeenCalled();
+      releaseLiveDispatch();
+      await replay;
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      return {
+        querySucceeded: true,
+        fetchedCount: 1,
+        replayed: 1,
+        skippedFromMe: 0,
+        skippedPreCursor: 0,
+        skippedGivenUp: 0,
+        failed: 0,
+        givenUp: 0,
+        cursorBefore: null,
+        cursorAfter: { lastSeenMs: 1, lastSeenRowid: 101 },
+        windowStartMs: 0,
+        windowEndMs: 1,
+      };
+    });
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      onNotification = params?.onNotification;
+      return {
+        request: vi.fn(async () => ({ subscription: 1 })),
+        waitForClose: vi.fn(async () => {}),
+        stop: vi.fn(async () => {}),
+      } as never;
+    });
+
+    await monitorIMessageProvider({
+      config: createConfig() as never,
+      runtime: createRuntime(),
+    });
+
+    await vi.waitFor(() => {
+      expect(advanceIMessageCatchupCursorMock).toHaveBeenCalledWith(
+        "default",
+        { lastSeenMs: Date.parse("2026-05-22T09:00:00.000Z"), lastSeenRowid: 101 },
+        { maxFailureRetries: 10 },
+      );
+    });
+  });
+
+  it("replays startup catchup rows when the overlapping live dispatch fails", async () => {
+    let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+    let rejectLiveDispatch!: (err: Error) => void;
+    const liveDispatchStarted = new Promise<void>((resolve) => {
+      dispatchInboundMessageMock.mockImplementationOnce(async () => {
+        resolve();
+        await new Promise<void>((_resolve, reject) => {
+          rejectLiveDispatch = reject;
+        });
+        return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } };
+      });
+    });
+    runIMessageCatchupMock.mockImplementation(async (params) => {
+      const message = createMessage({ id: 125, guid: "guid-125" });
+      onNotification?.({
+        method: "message",
+        params: { message },
+      });
+      await liveDispatchStarted;
+
+      const replay = params.dispatchPayload(message);
+      await Promise.resolve();
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      rejectLiveDispatch(new Error("live dispatch failed"));
+      await replay;
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
+      expect(advanceIMessageCatchupCursorMock).not.toHaveBeenCalled();
+      return {
+        querySucceeded: true,
+        fetchedCount: 1,
+        replayed: 1,
+        skippedFromMe: 0,
+        skippedPreCursor: 0,
+        skippedGivenUp: 0,
+        failed: 0,
+        givenUp: 0,
+        cursorBefore: null,
+        cursorAfter: { lastSeenMs: 1, lastSeenRowid: 125 },
+        windowStartMs: 0,
+        windowEndMs: 1,
+      };
+    });
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      onNotification = params?.onNotification;
+      return {
+        request: vi.fn(async () => ({ subscription: 1 })),
+        waitForClose: vi.fn(async () => {}),
+        stop: vi.fn(async () => {}),
+      } as never;
+    });
+
+    await monitorIMessageProvider({
+      config: createConfig() as never,
+      runtime: createRuntime(),
+    });
+
+    expect(advanceIMessageCatchupCursorMock).not.toHaveBeenCalled();
+  });
+
+  it("tracks startup live rows before debounce flush so catchup waits for the live attempt", async () => {
+    vi.useFakeTimers();
+    try {
+      let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+      runIMessageCatchupMock.mockImplementation(async (params) => {
+        const message = createMessage({ id: 135, guid: "guid-135" });
+        onNotification?.({
+          method: "message",
+          params: { message },
+        });
+
+        const replay = params.dispatchPayload(message);
+        await Promise.resolve();
+        expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(1000);
+        await replay;
+        expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+        return {
+          querySucceeded: true,
+          fetchedCount: 1,
+          replayed: 1,
+          skippedFromMe: 0,
+          skippedPreCursor: 0,
+          skippedGivenUp: 0,
+          failed: 0,
+          givenUp: 0,
+          cursorBefore: null,
+          cursorAfter: { lastSeenMs: 1, lastSeenRowid: 135 },
+          windowStartMs: 0,
+          windowEndMs: 1,
+        };
+      });
+      createIMessageRpcClientMock.mockImplementation(async (params) => {
+        onNotification = params?.onNotification;
+        return {
+          request: vi.fn(async () => ({ subscription: 1 })),
+          waitForClose: vi.fn(async () => {}),
+          stop: vi.fn(async () => {}),
+        } as never;
+      });
+
+      await monitorIMessageProvider({
+        config: createConfig({ debounceMs: 1000 }) as never,
+        runtime: createRuntime(),
+      });
+
+      await vi.waitFor(() => {
+        expect(advanceIMessageCatchupCursorMock).toHaveBeenCalledWith(
+          "default",
+          { lastSeenMs: Date.parse("2026-05-22T09:00:00.000Z"), lastSeenRowid: 135 },
+          { maxFailureRetries: 10 },
+        );
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not advance startup live cursor past catchup rows left for a later pass", async () => {
+    let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+    runIMessageCatchupMock.mockImplementation(async () => {
+      onNotification?.({
+        method: "message",
+        params: { message: createMessage({ id: 300, guid: "guid-300" }) },
+      });
+      await vi.waitFor(() => {
+        expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      });
+      return {
+        querySucceeded: true,
+        fetchedCount: 50,
+        hasMoreRows: true,
+        replayed: 50,
+        skippedFromMe: 0,
+        skippedPreCursor: 0,
+        skippedGivenUp: 0,
+        failed: 0,
+        givenUp: 0,
+        cursorBefore: null,
+        cursorAfter: { lastSeenMs: Date.parse("2026-05-22T08:59:00.000Z"), lastSeenRowid: 100 },
+        windowStartMs: 0,
+        windowEndMs: 1,
+      };
+    });
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      onNotification = params?.onNotification;
+      return {
+        request: vi.fn(async () => ({ subscription: 1 })),
+        waitForClose: vi.fn(async () => {}),
+        stop: vi.fn(async () => {}),
+      } as never;
+    });
+
+    await monitorIMessageProvider({
+      config: createConfig() as never,
+      runtime: createRuntime(),
+    });
+
+    expect(advanceIMessageCatchupCursorMock).not.toHaveBeenCalled();
+  });
+
+  it("does not advance post-fence live cursor past catchup rows left for a later pass", async () => {
+    let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+    runIMessageCatchupMock.mockResolvedValue({
+      querySucceeded: true,
+      fetchedCount: 50,
+      hasMoreRows: true,
+      replayed: 50,
+      skippedFromMe: 0,
+      skippedPreCursor: 0,
+      skippedGivenUp: 0,
+      failed: 0,
+      givenUp: 0,
+      cursorBefore: null,
+      cursorAfter: { lastSeenMs: Date.parse("2026-05-22T08:59:00.000Z"), lastSeenRowid: 100 },
+      windowStartMs: 0,
+      windowEndMs: 1,
+    });
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      onNotification = params?.onNotification;
+      return {
+        request: vi.fn(async () => ({ subscription: 1 })),
+        waitForClose: vi.fn(async () => {
+          onNotification?.({
+            method: "message",
+            params: { message: createMessage({ id: 300, guid: "guid-300" }) },
+          });
+          await vi.waitFor(() => {
+            expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+          });
+        }),
+        stop: vi.fn(async () => {}),
+      } as never;
+    });
+
+    await monitorIMessageProvider({
+      config: createConfig() as never,
+      runtime: createRuntime(),
+    });
+
+    expect(advanceIMessageCatchupCursorMock).not.toHaveBeenCalled();
+  });
+
+  it("does not advance post-fence live cursor when startup catchup query fails", async () => {
+    let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+    runIMessageCatchupMock.mockResolvedValue({
+      querySucceeded: false,
+      fetchedCount: 0,
+      replayed: 0,
+      skippedFromMe: 0,
+      skippedPreCursor: 0,
+      skippedGivenUp: 0,
+      failed: 0,
+      givenUp: 0,
+      cursorBefore: null,
+      cursorAfter: { lastSeenMs: 0, lastSeenRowid: 0 },
+      windowStartMs: 0,
+      windowEndMs: 1,
+    });
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      onNotification = params?.onNotification;
+      return {
+        request: vi.fn(async () => ({ subscription: 1 })),
+        waitForClose: vi.fn(async () => {
+          onNotification?.({
+            method: "message",
+            params: { message: createMessage({ id: 300, guid: "guid-300" }) },
+          });
+          await vi.waitFor(() => {
+            expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+          });
+        }),
+        stop: vi.fn(async () => {}),
+      } as never;
+    });
+
+    await monitorIMessageProvider({
+      config: createConfig() as never,
+      runtime: createRuntime(),
+    });
+
+    expect(advanceIMessageCatchupCursorMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/imessage/src/monitor/catchup-bridge.test.ts
+++ b/extensions/imessage/src/monitor/catchup-bridge.test.ts
@@ -267,6 +267,7 @@ describe("runIMessageCatchup", () => {
     });
 
     expect(summary.fetchedCount).toBe(5);
+    expect(summary.hasMoreRows).toBe(true);
     expect(summary.replayed).toBe(5);
     // Oldest-first by rowid: 100, 101, 102, 103, 200 (chat 1's first 4, then chat 2's first).
     expect(dispatched).toEqual(["g-100", "g-101", "g-102", "g-103", "g-200"]);
@@ -279,6 +280,38 @@ describe("runIMessageCatchup", () => {
     // picks up the rest" warning would lie and those rows would be
     // permanently lost. Cursor must stop at the last dispatched rowid (200).
     expect(summary.cursorAfter.lastSeenRowid).toBe(200);
+  });
+
+  it("reports possible remaining rows when a per-chat history page is full", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-08T12:00:00Z"));
+    const { client } = makeFakeClient(({ method }) => {
+      if (method === "chats.list") {
+        return { chats: [{ id: 1, last_message_at: "2026-05-08T11:55:00.000Z" }] };
+      }
+      if (method === "messages.history") {
+        return {
+          messages: [
+            makeRow({ id: 100, guid: "g-100", chat_id: 1, created_at: "2026-05-08T11:55:00Z" }),
+            makeRow({ id: 101, guid: "g-101", chat_id: 1, created_at: "2026-05-08T11:56:00Z" }),
+          ],
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+
+    const summary = await runIMessageCatchup({
+      client: client as never,
+      accountId: "default",
+      config: resolveCatchupConfig({ enabled: true, perRunLimit: 2, maxAgeMinutes: 60 }),
+      includeAttachments: false,
+      dispatchPayload: async () => {},
+    });
+
+    expect(summary.querySucceeded).toBe(true);
+    expect(summary.fetchedCount).toBe(2);
+    expect(summary.hasMoreRows).toBe(true);
+    expect(summary.cursorAfter.lastSeenRowid).toBe(101);
   });
 
   it("treats a dispatch throw as a failure and holds the cursor", async () => {

--- a/extensions/imessage/src/monitor/catchup-bridge.ts
+++ b/extensions/imessage/src/monitor/catchup-bridge.ts
@@ -46,10 +46,10 @@ export type RunIMessageCatchupParams = {
   config: ResolvedCatchupConfig;
   includeAttachments: boolean;
   /**
-   * The same per-message handler the live `imsg watch` notification path
-   * runs (i.e. the post-debounce `handleMessageNow` in `monitor-provider`).
-   * Catchup feeds rows in oldest-first by rowid. Throws are recorded as
-   * dispatch failures; non-throw returns count as successful dispatch
+   * The same per-message dispatch/evaluation handler the live `imsg watch`
+   * notification path runs, excluding live cursor advancement. Catchup owns
+   * the cursor for replayed rows while this pass is active. Throws are recorded
+   * as dispatch failures; non-throw returns count as successful dispatch
    * (including non-error drops, which mirrors the live pipeline).
    */
   dispatchPayload: (message: IMessagePayload) => Promise<void>;
@@ -103,6 +103,7 @@ export async function runIMessageCatchup(
     const sinceISO = new Date(sinceMs).toISOString();
     const collected: IMessageCatchupRow[] = [];
     const perChatLimit = Math.min(limit, PER_CHAT_HISTORY_LIMIT_CAP);
+    let hitPerChatLimit = false;
     // Track the highest rowid / date the imsg bridge actually returned across
     // all chats, regardless of whether each row passed the parser. The catchup
     // loop uses this as a cursor-advance floor so an unparseable row (corrupt
@@ -145,6 +146,9 @@ export async function runIMessageCatchup(
       }
 
       const messages = Array.isArray(historyResult?.messages) ? historyResult.messages : [];
+      if (messages.length >= perChatLimit) {
+        hitPerChatLimit = true;
+      }
       for (const raw of messages) {
         // Best-effort raw-watermark probe BEFORE we run the parser, so even
         // rows we drop still let the cursor advance past them. We only trust
@@ -237,6 +241,7 @@ export async function runIMessageCatchup(
     return {
       resolved: true,
       rows: capped,
+      hasMoreRows: isCapTruncated || hitPerChatLimit,
       ...(Number.isFinite(effectiveWatermarkRowid)
         ? { highWatermarkRowid: effectiveWatermarkRowid }
         : {}),

--- a/extensions/imessage/src/monitor/catchup.test.ts
+++ b/extensions/imessage/src/monitor/catchup.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  advanceIMessageCatchupCursor,
   capFailureRetriesMap,
   loadIMessageCatchupCursor,
   performIMessageCatchup,
@@ -123,6 +124,96 @@ describe("loadIMessageCatchupCursor / saveIMessageCatchupCursor", () => {
     expect((await loadIMessageCatchupCursor("a"))?.lastSeenRowid).toBe(1);
     expect((await loadIMessageCatchupCursor("b"))?.lastSeenRowid).toBe(2);
   });
+
+  it("advances the cursor from a live-handled message", async () => {
+    const advanced = await advanceIMessageCatchupCursor("primary", {
+      lastSeenMs: 1_700_000_100_000,
+      lastSeenRowid: 100,
+    });
+
+    expect(advanced).toBe(true);
+    const cursor = await loadIMessageCatchupCursor("primary");
+    expect(cursor?.lastSeenMs).toBe(1_700_000_100_000);
+    expect(cursor?.lastSeenRowid).toBe(100);
+  });
+
+  it("does not regress the cursor from older live messages", async () => {
+    await saveIMessageCatchupCursor("primary", {
+      lastSeenMs: 1_700_000_100_000,
+      lastSeenRowid: 100,
+    });
+
+    const advanced = await advanceIMessageCatchupCursor("primary", {
+      lastSeenMs: 1_700_000_090_000,
+      lastSeenRowid: 90,
+    });
+
+    expect(advanced).toBe(false);
+    const cursor = await loadIMessageCatchupCursor("primary");
+    expect(cursor?.lastSeenMs).toBe(1_700_000_100_000);
+    expect(cursor?.lastSeenRowid).toBe(100);
+  });
+
+  it("does not rewrite the cursor for timestamp-only live movement", async () => {
+    await saveIMessageCatchupCursor("primary", {
+      lastSeenMs: 1_700_000_100_000,
+      lastSeenRowid: 100,
+      failureRetries: { "given-up-guid": 10 },
+    });
+
+    const advanced = await advanceIMessageCatchupCursor("primary", {
+      lastSeenMs: 1_700_000_200_000,
+      lastSeenRowid: 100,
+    });
+
+    expect(advanced).toBe(false);
+    const cursor = await loadIMessageCatchupCursor("primary");
+    expect(cursor?.lastSeenMs).toBe(1_700_000_100_000);
+    expect(cursor?.lastSeenRowid).toBe(100);
+    expect(cursor?.failureRetries).toEqual({ "given-up-guid": 10 });
+  });
+
+  it("does not advance past pending catchup failures", async () => {
+    await saveIMessageCatchupCursor("primary", {
+      lastSeenMs: 1_700_000_010_000,
+      lastSeenRowid: 10,
+      failureRetries: { "held-guid": 1 },
+    });
+
+    const advanced = await advanceIMessageCatchupCursor("primary", {
+      lastSeenMs: 1_700_000_200_000,
+      lastSeenRowid: 200,
+    });
+
+    expect(advanced).toBe(false);
+    const cursor = await loadIMessageCatchupCursor("primary");
+    expect(cursor?.lastSeenMs).toBe(1_700_000_010_000);
+    expect(cursor?.lastSeenRowid).toBe(10);
+    expect(cursor?.failureRetries).toEqual({ "held-guid": 1 });
+  });
+
+  it("advances past already-given-up catchup failures", async () => {
+    await saveIMessageCatchupCursor("primary", {
+      lastSeenMs: 1_700_000_010_000,
+      lastSeenRowid: 10,
+      failureRetries: { "given-up-guid": 10 },
+    });
+
+    const advanced = await advanceIMessageCatchupCursor(
+      "primary",
+      {
+        lastSeenMs: 1_700_000_200_000,
+        lastSeenRowid: 200,
+      },
+      { maxFailureRetries: 10 },
+    );
+
+    expect(advanced).toBe(true);
+    const cursor = await loadIMessageCatchupCursor("primary");
+    expect(cursor?.lastSeenMs).toBe(1_700_000_200_000);
+    expect(cursor?.lastSeenRowid).toBe(200);
+    expect(cursor?.failureRetries).toBeUndefined();
+  });
 });
 
 describe("capFailureRetriesMap", () => {
@@ -184,6 +275,40 @@ describe("performIMessageCatchup", () => {
 
     const cursor = await loadIMessageCatchupCursor("primary");
     expect(cursor?.lastSeenRowid).toBe(11);
+  });
+
+  it("serializes live cursor advances behind an active catchup pass", async () => {
+    const pendingAdvances: Promise<boolean>[] = [];
+    const dispatch: CatchupDispatchFn = vi.fn(async (dispatchedRow) => {
+      const advance = advanceIMessageCatchupCursor("primary", {
+        lastSeenMs: now + 5_000,
+        lastSeenRowid: 99,
+      });
+      pendingAdvances.push(advance);
+
+      let settled = false;
+      void advance.then(() => {
+        settled = true;
+      });
+      await Promise.resolve();
+      expect(settled).toBe(false);
+      expect(dispatchedRow.rowid).toBe(10);
+      return { ok: true };
+    });
+
+    const summary = await performIMessageCatchup({
+      accountId: "primary",
+      config,
+      now,
+      fetch: fetchOf([row({ guid: "A", rowid: 10, date: now - 30_000 })]),
+      dispatch,
+    });
+
+    expect(summary.cursorAfter.lastSeenRowid).toBe(10);
+    await expect(Promise.all(pendingAdvances)).resolves.toEqual([true]);
+    const cursor = await loadIMessageCatchupCursor("primary");
+    expect(cursor?.lastSeenMs).toBe(now + 5_000);
+    expect(cursor?.lastSeenRowid).toBe(99);
   });
 
   it("skips is_from_me rows but still advances the cursor past them", async () => {

--- a/extensions/imessage/src/monitor/catchup.ts
+++ b/extensions/imessage/src/monitor/catchup.ts
@@ -27,6 +27,7 @@ const MAX_MAX_FAILURE_RETRIES = 1_000;
 // should not balloon the cursor file. When over the bound, keep only the
 // highest-count entries (closest to give-up) and drop the rest.
 const MAX_FAILURE_RETRY_MAP_SIZE = 5_000;
+const cursorAccountLocks = new Map<string, Promise<void>>();
 
 export type IMessageCatchupConfig = {
   enabled?: boolean;
@@ -58,6 +59,15 @@ export type IMessageCatchupCursor = {
   failureRetries?: Record<string, number>;
 };
 
+export type IMessageCatchupCursorAdvance = {
+  lastSeenMs: number;
+  lastSeenRowid: number;
+};
+
+export type IMessageCatchupCursorAdvanceOptions = {
+  maxFailureRetries?: number;
+};
+
 export type IMessageCatchupRow = {
   guid: string;
   rowid: number;
@@ -69,6 +79,8 @@ export type IMessageCatchupRow = {
 export type IMessageCatchupSummary = {
   querySucceeded: boolean;
   fetchedCount: number;
+  /** True when valid fetched rows were capped out of this pass and must remain for a later pass. */
+  hasMoreRows?: boolean;
   replayed: number;
   skippedFromMe: number;
   skippedPreCursor: number;
@@ -131,6 +143,34 @@ function sanitizeFailureRetriesInput(raw: unknown): Record<string, number> {
   return out;
 }
 
+async function withIMessageCatchupCursorLock<T>(
+  accountId: string,
+  callback: () => Promise<T>,
+): Promise<T> {
+  const prior = cursorAccountLocks.get(accountId) ?? Promise.resolve();
+  let release: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const current = prior
+    .catch(() => {
+      // Keep the queue moving even if an earlier cursor operation failed.
+    })
+    .then(() => gate);
+  cursorAccountLocks.set(accountId, current);
+  await prior.catch(() => {
+    // The operation that owns `prior` has already surfaced its error.
+  });
+  try {
+    return await callback();
+  } finally {
+    release!();
+    if (cursorAccountLocks.get(accountId) === current) {
+      cursorAccountLocks.delete(accountId);
+    }
+  }
+}
+
 /**
  * Cursor file path: `<openclawStateDir>/imessage/catchup/<safePrefix>__<sha256[:12]>.json`.
  * `openclawStateDir` resolves through `OPENCLAW_STATE_DIR` (or the plugin-sdk default,
@@ -175,6 +215,43 @@ export async function saveIMessageCatchupCursor(
     ...(hasRetries ? { failureRetries: sanitized } : {}),
   };
   await writeJsonFileAtomically(filePath, cursor);
+}
+
+export async function advanceIMessageCatchupCursor(
+  accountId: string,
+  next: IMessageCatchupCursorAdvance,
+  options: IMessageCatchupCursorAdvanceOptions = {},
+): Promise<boolean> {
+  if (
+    !Number.isFinite(next.lastSeenMs) ||
+    !Number.isFinite(next.lastSeenRowid) ||
+    next.lastSeenRowid <= 0
+  ) {
+    return false;
+  }
+
+  return await withIMessageCatchupCursorLock(accountId, async () => {
+    const current = await loadIMessageCatchupCursor(accountId);
+    const maxFailureRetries = clampInt(
+      options.maxFailureRetries,
+      1,
+      MAX_MAX_FAILURE_RETRIES,
+      DEFAULT_MAX_FAILURE_RETRIES,
+    );
+    const hasHeldFailure =
+      current?.failureRetries &&
+      Object.values(current.failureRetries).some((count) => count < maxFailureRetries);
+    if (hasHeldFailure) {
+      return false;
+    }
+    const lastSeenMs = Math.max(current?.lastSeenMs ?? 0, Math.floor(next.lastSeenMs));
+    const lastSeenRowid = Math.max(current?.lastSeenRowid ?? 0, Math.floor(next.lastSeenRowid));
+    if (current !== null && lastSeenRowid <= current.lastSeenRowid) {
+      return false;
+    }
+    await saveIMessageCatchupCursor(accountId, { lastSeenMs, lastSeenRowid });
+    return true;
+  });
 }
 
 /**
@@ -246,6 +323,7 @@ export type CatchupFetchFn = (params: {
 }) => Promise<{
   resolved: boolean;
   rows: IMessageCatchupRow[];
+  hasMoreRows?: boolean;
   /**
    * Highest `rowid` the fetcher saw in the raw response, including rows it
    * dropped (parser failure, schema drift, missing fields). The replay loop
@@ -285,6 +363,14 @@ export type PerformCatchupParams = {
  * pipeline as `dispatch`.
  */
 export async function performIMessageCatchup(
+  params: PerformCatchupParams,
+): Promise<IMessageCatchupSummary> {
+  return await withIMessageCatchupCursorLock(params.accountId, () =>
+    performIMessageCatchupUnlocked(params),
+  );
+}
+
+async function performIMessageCatchupUnlocked(
   params: PerformCatchupParams,
 ): Promise<IMessageCatchupSummary> {
   const now = params.now ?? Date.now();
@@ -334,6 +420,7 @@ export async function performIMessageCatchup(
   }
   summary.querySucceeded = true;
   summary.fetchedCount = fetchResult.rows.length;
+  summary.hasMoreRows = fetchResult.hasMoreRows === true;
 
   // Stable order: process oldest-first so the cursor advances monotonically
   // and a mid-run failure leaves a usable lastSeenRowid for the next pass.

--- a/extensions/imessage/src/monitor/coalesce.test.ts
+++ b/extensions/imessage/src/monitor/coalesce.test.ts
@@ -34,8 +34,14 @@ describe("combineIMessagePayloads", () => {
   });
 
   it("merges Dump + URL split-send into one payload anchored on the first GUID", () => {
-    const text = makePayload({ text: "Dump", guid: "row-1", created_at: "2025-01-01T00:00:00Z" });
+    const text = makePayload({
+      id: 100,
+      text: "Dump",
+      guid: "row-1",
+      created_at: "2025-01-01T00:00:00Z",
+    });
     const balloon = makePayload({
+      id: 101,
       text: "https://example.com/article",
       guid: "row-2",
       created_at: "2025-01-01T00:00:01.500Z",
@@ -46,6 +52,7 @@ describe("combineIMessagePayloads", () => {
     expect(merged.guid).toBe("row-1");
     expect(merged.created_at).toBe("2025-01-01T00:00:01.500Z");
     expect(merged.coalescedMessageGuids).toEqual(["row-1", "row-2"]);
+    expect(merged.coalescedMessageIds).toEqual([100, 101]);
   });
 
   it("preserves attachments instead of dropping them on merge", () => {
@@ -137,6 +144,14 @@ describe("combineIMessagePayloads", () => {
     const merged = combineIMessagePayloads([a, b]);
 
     expect(merged.coalescedMessageGuids).toBeUndefined();
+  });
+
+  it("does not set coalescedMessageIds when no entry carries a numeric id", () => {
+    const a = makePayload({ id: null, text: "a", guid: "row-1" });
+    const b = makePayload({ id: null, text: "b", guid: "row-2" });
+    const merged = combineIMessagePayloads([a, b]);
+
+    expect(merged.coalescedMessageIds).toBeUndefined();
   });
 
   it("respects the documented entry cap value", () => {

--- a/extensions/imessage/src/monitor/coalesce.ts
+++ b/extensions/imessage/src/monitor/coalesce.ts
@@ -23,6 +23,7 @@ export type CoalescedIMessagePayload = IMessagePayload & {
    * dedupe paths can still recognize them.
    */
   coalescedMessageGuids?: string[];
+  coalescedMessageIds?: number[];
 };
 
 /**
@@ -95,13 +96,18 @@ export function combineIMessagePayloads(payloads: IMessagePayload[]): CoalescedI
   // dropped by the cap are still remembered for downstream dedupe.
   const seenGuids = new Set<string>();
   const coalescedMessageGuids: string[] = [];
+  const seenIds = new Set<number>();
+  const coalescedMessageIds: number[] = [];
   for (const payload of payloads) {
     const guid = payload.guid?.trim();
-    if (!guid || seenGuids.has(guid)) {
-      continue;
+    if (guid && !seenGuids.has(guid)) {
+      seenGuids.add(guid);
+      coalescedMessageGuids.push(guid);
     }
-    seenGuids.add(guid);
-    coalescedMessageGuids.push(guid);
+    if (typeof payload.id === "number" && Number.isFinite(payload.id) && !seenIds.has(payload.id)) {
+      seenIds.add(payload.id);
+      coalescedMessageIds.push(payload.id);
+    }
   }
 
   // Reply context: prefer any entry that carries one; the last balloon in a
@@ -118,5 +124,6 @@ export function combineIMessagePayloads(payloads: IMessagePayload[]): CoalescedI
     reply_to_text: entryWithReply?.reply_to_text ?? first.reply_to_text ?? null,
     reply_to_sender: entryWithReply?.reply_to_sender ?? first.reply_to_sender ?? null,
     coalescedMessageGuids: coalescedMessageGuids.length > 0 ? coalescedMessageGuids : undefined,
+    coalescedMessageIds: coalescedMessageIds.length > 0 ? coalescedMessageIds : undefined,
   };
 }

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -52,7 +52,7 @@ import { sendMessageIMessage } from "../send.js";
 import { normalizeIMessageHandle } from "../targets.js";
 import { attachIMessageMonitorAbortHandler } from "./abort-handler.js";
 import { runIMessageCatchup } from "./catchup-bridge.js";
-import { resolveCatchupConfig } from "./catchup.js";
+import { advanceIMessageCatchupCursor, resolveCatchupConfig } from "./catchup.js";
 import { combineIMessagePayloads } from "./coalesce.js";
 import { createIMessageEchoCachingSend, deliverReplies } from "./deliver.js";
 import { createSentMessageCache } from "./echo-cache.js";
@@ -76,6 +76,56 @@ import { sanitizeIMessageWatchErrorPayload } from "./watch-error-log.js";
 
 const WATCH_SUBSCRIBE_MAX_ATTEMPTS = 3;
 const WATCH_SUBSCRIBE_RETRY_DELAY_MS = 1_000;
+
+type IMessagePayloadWithCoalescedSources = IMessagePayload & {
+  coalescedMessageGuids?: string[];
+  coalescedMessageIds?: number[];
+};
+
+type StartupLiveResolution = {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (err: unknown) => void;
+};
+
+type IMessageDebounceEntry = {
+  message: IMessagePayload;
+  startupLiveResolution?: StartupLiveResolution;
+};
+
+function resolveLiveCatchupRowids(message: IMessagePayloadWithCoalescedSources): number[] {
+  return [
+    message.id,
+    ...(Array.isArray(message.coalescedMessageIds) ? message.coalescedMessageIds : []),
+  ]
+    .filter((value): value is number => typeof value === "number" && Number.isFinite(value))
+    .map((value) => Math.floor(value))
+    .filter((value) => value > 0);
+}
+
+function resolveLiveCatchupGuids(message: IMessagePayloadWithCoalescedSources): string[] {
+  return [
+    message.guid,
+    ...(Array.isArray(message.coalescedMessageGuids) ? message.coalescedMessageGuids : []),
+  ]
+    .map((value) => (typeof value === "string" ? value.trim() : ""))
+    .filter((value) => value.length > 0);
+}
+
+function resolveLiveCatchupAdvance(message: IMessagePayloadWithCoalescedSources) {
+  const ids = resolveLiveCatchupRowids(message);
+  if (ids.length === 0 || typeof message.created_at !== "string") {
+    return null;
+  }
+  const lastSeenMs = Date.parse(message.created_at);
+  if (!Number.isFinite(lastSeenMs)) {
+    return null;
+  }
+  return {
+    lastSeenMs,
+    lastSeenRowid: Math.max(...ids),
+  };
+}
 
 function isIMessagePluginPayloadAttachment(attachment: {
   original_path?: string | null;
@@ -219,6 +269,118 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   const cliPath = opts.cliPath ?? imessageCfg.cliPath ?? "imsg";
   const dbPath = opts.dbPath ?? imessageCfg.dbPath;
   const probeTimeoutMs = imessageCfg.probeTimeoutMs ?? DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS;
+  const catchupCfg = resolveCatchupConfig(imessageCfg.catchup);
+  let releaseInitialCatchupCursorFence: (() => void) | null = null;
+  let initialCatchupCursorFenceReleased = !catchupCfg.enabled;
+  const initialCatchupCursorFence = catchupCfg.enabled
+    ? new Promise<void>((resolve) => {
+        releaseInitialCatchupCursorFence = resolve;
+      })
+    : null;
+  const startupLiveResolvedRowids = catchupCfg.enabled ? new Set<number>() : null;
+  const startupLiveResolvedGuids = catchupCfg.enabled ? new Set<string>() : null;
+  const startupLivePendingRowids = catchupCfg.enabled ? new Map<number, Promise<void>>() : null;
+  const startupLivePendingGuids = catchupCfg.enabled ? new Map<string, Promise<void>>() : null;
+  let startupCatchupAdvanceCeiling: { lastSeenMs: number; lastSeenRowid: number } | null = null;
+  let liveCatchupCursorAdvanceBlocked = false;
+  const releaseInitialCatchupCursorFenceOnce = () => {
+    const release = releaseInitialCatchupCursorFence;
+    releaseInitialCatchupCursorFence = null;
+    initialCatchupCursorFenceReleased = true;
+    startupLiveResolvedRowids?.clear();
+    startupLiveResolvedGuids?.clear();
+    startupLivePendingRowids?.clear();
+    startupLivePendingGuids?.clear();
+    if (release) {
+      release();
+    }
+  };
+  const trackStartupLiveResolution = (message: IMessagePayload, task: Promise<void>) => {
+    if (initialCatchupCursorFenceReleased) {
+      return;
+    }
+    const rowids = resolveLiveCatchupRowids(message);
+    const guids = resolveLiveCatchupGuids(message);
+    for (const rowid of rowids) {
+      startupLivePendingRowids?.set(rowid, task);
+    }
+    for (const guid of guids) {
+      startupLivePendingGuids?.set(guid, task);
+    }
+    void task
+      .then(() => {
+        if (initialCatchupCursorFenceReleased) {
+          return;
+        }
+        for (const rowid of rowids) {
+          startupLiveResolvedRowids?.add(rowid);
+        }
+        for (const guid of guids) {
+          startupLiveResolvedGuids?.add(guid);
+        }
+      })
+      .catch(() => {
+        // A failed live attempt must remain eligible for catchup replay.
+      })
+      .finally(() => {
+        for (const rowid of rowids) {
+          if (startupLivePendingRowids?.get(rowid) === task) {
+            startupLivePendingRowids.delete(rowid);
+          }
+        }
+        for (const guid of guids) {
+          if (startupLivePendingGuids?.get(guid) === task) {
+            startupLivePendingGuids.delete(guid);
+          }
+        }
+      });
+  };
+  const createStartupLiveResolution = (
+    message: IMessagePayload,
+  ): StartupLiveResolution | undefined => {
+    if (!catchupCfg.enabled || initialCatchupCursorFenceReleased) {
+      return undefined;
+    }
+    let resolve!: () => void;
+    let reject!: (err: unknown) => void;
+    const promise = new Promise<void>((promiseResolve, promiseReject) => {
+      resolve = promiseResolve;
+      reject = promiseReject;
+    });
+    trackStartupLiveResolution(message, promise);
+    return { promise, resolve, reject };
+  };
+  const wasStartupLiveResolvedMessage = async (message: IMessagePayload): Promise<boolean> => {
+    if (initialCatchupCursorFenceReleased) {
+      return false;
+    }
+    const rowids = resolveLiveCatchupRowids(message);
+    const guids = resolveLiveCatchupGuids(message);
+    const isResolved = () =>
+      rowids.some((rowid) => startupLiveResolvedRowids?.has(rowid)) ||
+      guids.some((guid) => startupLiveResolvedGuids?.has(guid));
+    if (isResolved()) {
+      return true;
+    }
+    const pending = new Set<Promise<void>>();
+    for (const rowid of rowids) {
+      const task = startupLivePendingRowids?.get(rowid);
+      if (task) {
+        pending.add(task);
+      }
+    }
+    for (const guid of guids) {
+      const task = startupLivePendingGuids?.get(guid);
+      if (task) {
+        pending.add(task);
+      }
+    }
+    if (pending.size === 0) {
+      return false;
+    }
+    await Promise.allSettled(pending);
+    return isResolved();
+  };
   const attachmentRoots = resolveIMessageAttachmentRoots({
     cfg,
     accountId: accountInfo.accountId,
@@ -261,9 +423,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   const debounceMsOverride =
     coalesceSameSenderDms && !hasExplicitInboundDebounce ? 2500 : undefined;
 
-  const { debouncer: inboundDebouncer } = createChannelInboundDebouncer<{
-    message: IMessagePayload;
-  }>({
+  const { debouncer: inboundDebouncer } = createChannelInboundDebouncer<IMessageDebounceEntry>({
     cfg,
     channel: "imessage",
     debounceMsOverride,
@@ -322,8 +482,11 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       if (entries.length === 0) {
         return;
       }
+      const startupLiveResolutions = entries
+        .map((entry) => entry.startupLiveResolution)
+        .filter((entry): entry is StartupLiveResolution => Boolean(entry));
       if (entries.length === 1) {
-        await handleMessageNow(entries[0].message);
+        await handleLiveMessage(entries[0].message, startupLiveResolutions);
         return;
       }
 
@@ -334,7 +497,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         const ellipsis = text.length > 50 ? "..." : "";
         logVerbose(`[imessage] coalesced ${entries.length} messages: "${preview}${ellipsis}"`);
       }
-      await handleMessageNow(combined);
+      await handleLiveMessage(combined, startupLiveResolutions);
     },
     onError: (err) => {
       runtime.error?.(`imessage debounce flush failed: ${String(err)}`);
@@ -350,7 +513,46 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     return client;
   };
 
-  async function handleMessageNow(message: IMessagePayload) {
+  async function handleLiveMessage(
+    message: IMessagePayload,
+    startupLiveResolutions: StartupLiveResolution[] = [],
+  ) {
+    try {
+      await handleMessageNowResolved(message);
+      for (const resolution of startupLiveResolutions) {
+        resolution.resolve();
+      }
+    } catch (err) {
+      for (const resolution of startupLiveResolutions) {
+        resolution.reject(err);
+      }
+      throw err;
+    }
+    if (!catchupCfg.enabled) {
+      return;
+    }
+    await initialCatchupCursorFence;
+    const advance = resolveLiveCatchupAdvance(message);
+    if (liveCatchupCursorAdvanceBlocked) {
+      return;
+    }
+    if (
+      startupCatchupAdvanceCeiling &&
+      advance &&
+      advance.lastSeenRowid > startupCatchupAdvanceCeiling.lastSeenRowid
+    ) {
+      return;
+    }
+    if (advance) {
+      await advanceIMessageCatchupCursor(accountInfo.accountId, advance, {
+        maxFailureRetries: catchupCfg.maxFailureRetries,
+      }).catch((err) => {
+        runtime.error?.(`imessage catchup: live cursor advance failed: ${String(err)}`);
+      });
+    }
+  }
+
+  async function handleMessageNowResolved(message: IMessagePayload) {
     const messageText = (message.text ?? "").trim();
 
     const attachments = includeAttachments ? (message.attachments ?? []) : [];
@@ -779,7 +981,13 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       runtime.error?.(`imessage: dropping malformed RPC message payload (keys=${shape})`);
       return;
     }
-    await inboundDebouncer.enqueue({ message });
+    const startupLiveResolution = createStartupLiveResolution(message);
+    try {
+      await inboundDebouncer.enqueue({ message, startupLiveResolution });
+    } catch (err) {
+      startupLiveResolution?.reject(err);
+      throw err;
+    }
   };
 
   await waitForTransportReady({
@@ -803,6 +1011,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   });
 
   if (opts.abortSignal?.aborted) {
+    releaseInitialCatchupCursorFenceOnce();
     return;
   }
   const abort = opts.abortSignal;
@@ -835,6 +1044,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
 
   for (let attempt = 1; attempt <= WATCH_SUBSCRIBE_MAX_ATTEMPTS; attempt++) {
     if (abort?.aborted) {
+      releaseInitialCatchupCursorFenceOnce();
       return;
     }
     let attemptClient: IMessageRpcClient | undefined;
@@ -863,12 +1073,14 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       break;
     } catch (err) {
       if (abort?.aborted) {
+        releaseInitialCatchupCursorFenceOnce();
         return;
       }
       const shouldRetry =
         attempt < WATCH_SUBSCRIBE_MAX_ATTEMPTS && isRetriableWatchSubscribeStartupError(err);
       if (!shouldRetry) {
         runtime.error?.(danger(`imessage: monitor failed: ${String(err)}`));
+        releaseInitialCatchupCursorFenceOnce();
         throw err;
       }
       runtime.log?.(
@@ -887,6 +1099,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         abortSignal: abort,
       });
       if (abort?.aborted) {
+        releaseInitialCatchupCursorFenceOnce();
         return;
       }
     } finally {
@@ -899,6 +1112,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
 
   const activeClient = client;
   if (!activeClient) {
+    releaseInitialCatchupCursorFenceOnce();
     return;
   }
 
@@ -907,10 +1121,9 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   // `handleMessage` -> `handleMessageNow`; the inbound-dedupe cache absorbs
   // any overlap with replayed rows. Disabled by default — opt-in via
   // `channels.imessage.catchup.enabled`. See issue #78649.
-  const catchupCfg = resolveCatchupConfig(imessageCfg.catchup);
   if (catchupCfg.enabled && !abort?.aborted) {
     try {
-      await runIMessageCatchup({
+      const summary = await runIMessageCatchup({
         client: activeClient,
         accountId: accountInfo.accountId,
         config: catchupCfg,
@@ -920,14 +1133,29 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         // from before the gateway gap therefore arrive as separate turns
         // rather than coalesced. Live notifications continue to flow through
         // the debouncer.
-        dispatchPayload: (message) => handleMessageNow(message),
+        dispatchPayload: async (message) => {
+          if (await wasStartupLiveResolvedMessage(message)) {
+            return;
+          }
+          await handleMessageNowResolved(message);
+        },
         runtime,
       });
+      if (!summary.querySucceeded) {
+        liveCatchupCursorAdvanceBlocked = true;
+      } else if (summary.hasMoreRows) {
+        startupCatchupAdvanceCeiling = summary.cursorAfter;
+      }
     } catch (err) {
       // Catchup is opt-in recovery — surface the error but do not block the
       // monitor. The live dispatch loop is already up and running.
       runtime.error?.(`imessage catchup: pass failed: ${String(err)}`);
+      liveCatchupCursorAdvanceBlocked = true;
+    } finally {
+      releaseInitialCatchupCursorFenceOnce();
     }
+  } else {
+    releaseInitialCatchupCursorFenceOnce();
   }
 
   try {

--- a/extensions/memory-lancedb/npm-shrinkwrap.json
+++ b/extensions/memory-lancedb/npm-shrinkwrap.json
@@ -209,7 +209,6 @@
       "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-18.1.0.tgz",
       "integrity": "sha512-v/ShMp57iBnBp4lDgV8Jx3d3Q5/Hac25FWmQ98eMahUiHPXcvwIMKJD0hBIgclm/FCG+LwPkAKtkRO1O/W0YGg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.11",
         "@types/command-line-args": "^5.2.3",

--- a/extensions/twitch/npm-shrinkwrap.json
+++ b/extensions/twitch/npm-shrinkwrap.json
@@ -168,7 +168,6 @@
       "resolved": "https://registry.npmjs.org/@twurple/auth/-/auth-8.1.4.tgz",
       "integrity": "sha512-ylsJoPInCw9BwOqxKcx+1k2ce9QG3vJpKFzPdIyHh49HvM/ulQZ0CAGysydugDYXF0iO/TGryh7PluSwx5fIwA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@d-fischer/logger": "^4.2.1",
         "@d-fischer/shared-utils": "^3.6.1",
@@ -289,7 +288,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/extensions/whatsapp/npm-shrinkwrap.json
+++ b/extensions/whatsapp/npm-shrinkwrap.json
@@ -1178,7 +1178,6 @@
       "resolved": "https://registry.npmjs.org/audio-decode/-/audio-decode-2.2.3.tgz",
       "integrity": "sha512-Z0lHvMayR/Pad9+O9ddzaBJE0DrhZkQlStrC1RwcAHF3AhQAsdwKHeLGK8fYKyp2DDU6xHxzGb4CLMui12yVrg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@wasm-audio-decoders/flac": "^0.2.4",
         "@wasm-audio-decoders/ogg-vorbis": "^0.1.15",
@@ -1418,7 +1417,6 @@
       "resolved": "https://registry.npmjs.org/jimp/-/jimp-1.6.1.tgz",
       "integrity": "sha512-hNQh6rZtWfSVWSNVmvq87N5BPJsNH7k7I7qyrXf9DOma9xATQk3fsyHazCQe51nCjdkoWdTmh0vD7bjVSLoxxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jimp/core": "1.6.1",
         "@jimp/diff": "1.6.1",
@@ -1463,7 +1461,6 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1567,7 +1567,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -2814,7 +2813,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3232,7 +3230,6 @@
       "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.43.0.tgz",
       "integrity": "sha512-7dYm06A945mXuIk/5HUlSjeyIYChW8vCEiU2dkOKKqJJzwAWxTkCc91Eqbz7TgODh2rtFFKWI/fekowWHOkmjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@grammyjs/types": "3.27.3",
         "abort-controller": "^3.0.0",
@@ -3301,7 +3298,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
       "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5068,7 +5064,6 @@
       "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
       "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=22.19.0"
       }
@@ -5292,7 +5287,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
Summary
- advance the iMessage catch-up cursor from safely handled live messages
- coordinate startup catch-up, live debounce/coalescing, and cursor writes so replay does not deadlock or skip backlog
- cover held/given-up retry behavior, capped catch-up pages, failed catch-up queries, coalesced source rows, and malformed startup overlap cases
- refresh generated shrinkwrap metadata required by the current guard check

Verification
- node scripts/run-vitest.mjs extensions/imessage/src/monitor.catchup-cursor.test.ts extensions/imessage/src/monitor/catchup.test.ts extensions/imessage/src/monitor/coalesce.test.ts extensions/imessage/src/monitor/catchup-bridge.test.ts extensions/imessage/src/monitor/monitor-provider*.test.ts
- pnpm deps:shrinkwrap:check
- git diff --check

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: iMessage catch-up could replay a row that had already been handled live because the durable catch-up cursor stayed behind until the next catch-up pass.
- Real environment tested: macOS Messages host with `imsg 0.9.0`, local `~/Library/Messages/chat.db`, Full Disk Access granted to the launcher process, real redacted iMessage DM, and an isolated `OPENCLAW_STATE_DIR` under `/tmp`.
- Exact steps or command run after this patch: sent a real iMessage to a redacted test recipient, received the live reply `proof ok`, then ran the production iMessage RPC catch-up path twice against the local Messages DB: first with the cursor intentionally behind the incoming row, then after advancing the live cursor to that same row.
- Evidence after fix (redacted terminal output):

```json
{
  "proof": "real imsg rpc against local Messages chat.db",
  "targetChat": "redacted iMessage DM",
  "observedHistory": [
    {
      "id": 20105,
      "is_from_me": false,
      "created_at": "2026-05-22T16:13:40.712Z",
      "text": "proof ok "
    },
    {
      "id": 20104,
      "is_from_me": true,
      "created_at": "2026-05-22T16:13:18.603Z",
      "text": "OpenClaw proof test: please reply with '"
    }
  ],
  "behindCursor": {
    "lastSeenRowid": 20104
  },
  "beforeLiveAdvance": {
    "replayed": 1,
    "cursorAfter": {
      "lastSeenRowid": 20105
    },
    "replayedPayloads": [
      {
        "id": 20105,
        "is_from_me": false,
        "text": "proof ok "
      }
    ]
  },
  "liveAdvance": {
    "advanced": true,
    "cursorAfterAdvance": {
      "lastSeenRowid": 20105
    }
  },
  "afterLiveAdvance": {
    "replayed": 0,
    "cursorAfter": {
      "lastSeenRowid": 20105
    },
    "replayedPayloads": []
  },
  "runtimeLogs": [
    "imessage catchup: replayed=1 skippedFromMe=0 skippedGivenUp=0 failed=0 givenUp=0 fetchedCount=1"
  ]
}
```

- Observed result after fix: with the cursor still behind row `20105`, catch-up replayed that incoming live row once. After the live cursor advance moved the durable cursor to row `20105`, the restart catch-up pass replayed `0` payloads, so the already-handled live row was not delivered again.
- What was not tested: SIP/private-API-only iMessage features, attachments/media, and unrelated channel delivery paths.

Fixes #85363
