### PR TITLE
fix(build): normalize cache paths on Windows

### DIFF
--- a/scripts/build-all.mjs
+++ b/scripts/build-all.mjs
@@ -246,6 +246,14 @@ function listCacheFiles(rootDir, entries, fsImpl) {
     .toSorted();
 }
 
+function portableRelativePath(rootDir, filePath) {
+  return path.relative(rootDir, filePath).split(path.sep).join("/");
+}
+
+function normalizePortablePath(filePath) {
+  return filePath.replaceAll("\\", "/");
+}
+
 function resolveCachePaths(rootDir, step) {
   const safeLabel = step.label.replace(/[^a-zA-Z0-9._-]+/g, "_");
   const cacheDir = path.resolve(rootDir, ".artifacts/build-all-cache", safeLabel);
@@ -260,7 +268,7 @@ function hashInputFiles(rootDir, files, fsImpl) {
   const hash = createHash("sha256");
   hash.update(`v${BUILD_CACHE_VERSION}\0`);
   for (const file of files) {
-    hash.update(path.relative(rootDir, file));
+    hash.update(portableRelativePath(rootDir, file));
     hash.update("\0");
     hash.update(fsImpl.readFileSync(file));
     hash.update("\0");
@@ -305,8 +313,10 @@ export function resolveBuildAllStepCacheState(step, params = {}) {
   const { outputRoot, stampPath } = resolveCachePaths(rootDir, step);
   const stamp = readCacheStamp(stampPath, fsImpl);
   const outputFiles = listCacheFiles(rootDir, step.cache.outputs, fsImpl);
-  const relativeOutputFiles = outputFiles.map((file) => path.relative(rootDir, file));
-  const stampedOutputs = Array.isArray(stamp?.outputs) ? stamp.outputs : [];
+  const relativeOutputFiles = outputFiles.map((file) => portableRelativePath(rootDir, file));
+  const stampedOutputs = Array.isArray(stamp?.outputs)
+    ? stamp.outputs.map((entry) => normalizePortablePath(entry))
+    : [];
   const stampMatches = stamp?.version === BUILD_CACHE_VERSION && stamp.signature === signature;
   const actualOutputsPresent =
     stampedOutputs.length > 0 && hasAllFiles(rootDir, stampedOutputs, fsImpl);


### PR DESCRIPTION
## Summary
- store build-all cache metadata with slash-normalized relative paths
- normalize older stamped output paths before cache validation

## Verification
- `node scripts/run-vitest.mjs test/scripts/build-all.test.ts`
- Windows Parallels proof: `test/scripts/build-all.test.ts` passed 16/16 in Windows 11 VM
