### PR TITLE
fix(gateway): canonicalize fallback model override keys

### DIFF
--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -936,6 +936,73 @@ describe("loadGatewayPlugins", () => {
     expect(params.model).toBe("claude-haiku-4-5");
   });
 
+  test("dedupes provider-prefixed OpenRouter fallback deny diagnostics", async () => {
+    const serverPlugins = serverPluginsModule;
+    const runtime = await createSubagentRuntime(serverPlugins, {
+      plugins: {
+        entries: {
+          "voice-call": {
+            subagent: {
+              allowModelOverride: true,
+              allowedModels: ["openrouter/gpt-5.4-mini"],
+            },
+          },
+        },
+      },
+    });
+    serverPlugins.setFallbackGatewayContext(createTestContext("fallback-openrouter-deny"));
+
+    let rejectionMessage = "";
+    try {
+      await gatewayRequestScopeModule.withPluginRuntimePluginIdScope("voice-call", () =>
+        runtime.run({
+          sessionKey: "s-openrouter-deny",
+          message: "use disallowed OpenRouter override",
+          provider: "openrouter",
+          model: "openrouter/gpt-5.5",
+          deliver: false,
+        }),
+      );
+    } catch (error) {
+      rejectionMessage = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(rejectionMessage).toContain('model override "openrouter/gpt-5.5"');
+    expect(rejectionMessage).not.toContain("openrouter/openrouter/");
+  });
+
+  test("allows matching provider-prefixed OpenRouter fallback overrides", async () => {
+    const serverPlugins = serverPluginsModule;
+    const runtime = await createSubagentRuntime(serverPlugins, {
+      plugins: {
+        entries: {
+          "voice-call": {
+            subagent: {
+              allowModelOverride: true,
+              allowedModels: ["openrouter/gpt-5.4-mini"],
+            },
+          },
+        },
+      },
+    });
+    serverPlugins.setFallbackGatewayContext(createTestContext("fallback-openrouter-allow"));
+
+    await gatewayRequestScopeModule.withPluginRuntimePluginIdScope("voice-call", () =>
+      runtime.run({
+        sessionKey: "s-openrouter-allow",
+        message: "use allowed OpenRouter override",
+        provider: "openrouter",
+        model: "openrouter/gpt-5.4-mini",
+        deliver: false,
+      }),
+    );
+
+    const params = getRequiredLastDispatchedParams();
+    expect(params.sessionKey).toBe("s-openrouter-allow");
+    expect(params.provider).toBe("openrouter");
+    expect(params.model).toBe("openrouter/gpt-5.4-mini");
+  });
+
   test("tags plugin fallback subagent runs with the creating plugin id", async () => {
     const serverPlugins = serverPluginsModule;
     const runtime = await createSubagentRuntime(serverPlugins);

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { performance } from "node:perf_hooks";
+import { modelKey } from "../agents/model-ref-shared.js";
 import { normalizeModelRef, parseModelRef } from "../agents/model-selection.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -127,7 +128,7 @@ function normalizeAllowedModelRef(raw: string): string | null {
     return null;
   }
   const normalized = normalizeModelRef(providerRaw, modelRaw);
-  return `${normalized.provider}/${normalized.model}`;
+  return modelKey(normalized.provider, normalized.model);
 }
 
 export function setPluginSubagentOverridePolicies(cfg: OpenClawConfig): void {
@@ -227,7 +228,7 @@ function resolveRequestedFallbackModelRef(params: {
 }): string | null {
   if (params.provider && params.model) {
     const normalizedRequest = normalizeModelRef(params.provider, params.model);
-    return `${normalizedRequest.provider}/${normalizedRequest.model}`;
+    return modelKey(normalizedRequest.provider, normalizedRequest.model);
   }
   const rawModel = params.model?.trim();
   if (!rawModel || !rawModel.includes("/")) {
@@ -237,7 +238,7 @@ function resolveRequestedFallbackModelRef(params: {
   if (!parsed?.provider || !parsed.model) {
     return null;
   }
-  return `${parsed.provider}/${parsed.model}`;
+  return modelKey(parsed.provider, parsed.model);
 }
 
 // ── Internal gateway dispatch for plugin runtime ────────────────────


### PR DESCRIPTION
## Summary

- Problem: gateway fallback subagent model-override allowlist checks still raw-concatenated normalized provider/model refs, so provider-prefixed OpenRouter requests could report `openrouter/openrouter/...` in deny diagnostics.
- Solution: use the existing canonical `modelKey()` helper for both the configured allowlist side and requested fallback override side.
- What changed: `src/gateway/server-plugins.ts` now canonicalizes the three fallback comparison keys, and `src/gateway/server-plugins.test.ts` covers the OpenRouter deny diagnostic plus matching allow path.
- What did NOT change (scope boundary): no plugin config schema changes, no runtime LLM changes, no provider dispatch payload changes, no auth/SecretRef behavior changes, and no docs/changelog changes.

## Motivation

- #84946 fixed the runtime LLM path for #84887 and changed only `src/plugins/runtime/runtime-llm.runtime.ts` plus its test.
- #84940 was closed after #84946 with the gateway fallback normalization explicitly left for a separate PR if it still had a concrete repro.
- Current `main` still had the gateway fallback raw-concat sites in `src/gateway/server-plugins.ts`, and the focused repro still produced a duplicate OpenRouter provider prefix in the deny diagnostic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: N/A
- Related #84940, #84946, #84934
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: gateway fallback subagent model-override allowlist diagnostics now use canonical provider/model refs for provider-prefixed OpenRouter requests, and the matching allow path reaches the gateway agent handler instead of being falsely denied by fallback policy key comparison.
- Real environment tested: local Linux source checkout on Node 22.22.1, branch rebased on last-known-green `upstream/main` `faf2a6cb9e` (CI run `26298182034` succeeded) with head `f4ee9b72ee`. I ran a production-source gateway fallback smoke invocation through `createGatewaySubagentRuntime()` plus the real gateway `agent` handler validation path, and also ran Vitest 4.1.7 via `node scripts/run-vitest.mjs`.
- Exact steps or command run after this patch:

```sh
node --import tsx <production-source-smoke-script> .
node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-plugins.test.ts -t 'OpenRouter fallback'
node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-plugins.test.ts
```

The production-source smoke script imports `src/gateway/server-plugins.ts` and `src/plugins/runtime/gateway-request-scope.ts`, configures plugin `voice-call` with `subagent.allowModelOverride: true` and `subagent.allowedModels: ["openrouter/gpt-5.4-mini"]`, then calls `createGatewaySubagentRuntime().run()` under plugin scope. The matching-allow case intentionally uses a malformed session key so the invocation stops in the real gateway `agent` handler validation before any agent/provider execution.

- Evidence after fix:

Terminal capture from this branch, copied live output with local paths redacted:

```json
{
  "repo": "<local source checkout>",
  "proofKind": "production-source gateway fallback subagent invocation; no provider/network call",
  "policy": {
    "allowModelOverride": true,
    "allowedModels": [
      "openrouter/gpt-5.4-mini"
    ]
  },
  "deny": {
    "name": "deny disallowed provider-prefixed OpenRouter model",
    "ok": false,
    "error": "model override \"openrouter/gpt-5.5\" is not allowlisted for plugin \"voice-call\"."
  },
  "allow": {
    "name": "allow matching provider-prefixed OpenRouter model",
    "ok": false,
    "error": "invalid agent params: malformed session key \"agent::allow-proof\""
  },
  "calls": {
    "addChatRun": 0,
    "removeChatRun": 0,
    "broadcast": 0,
    "registerToolEventRecipient": 0
  },
  "dedupeEntries": 0,
  "chatAbortControllers": 0,
  "checks": {
    "denyCanonical": true,
    "denyNoDuplicateProvider": true,
    "allowReachedGatewayValidation": true,
    "noAgentRunStarted": true
  }
}
```

Supplemental regression-test output from the same branch:

```text
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-plugins.test.ts -t 'OpenRouter fallback'
RUN v4.1.7
✓ gateway src/gateway/server-plugins.test.ts (47 tests | 45 skipped) 4190ms

Test Files 1 passed (1)
Tests 2 passed | 45 skipped (47)
Duration 4.43s

$ node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-plugins.test.ts
RUN v4.1.7
✓ gateway src/gateway/server-plugins.test.ts (47 tests) 4132ms

Test Files 1 passed (1)
Tests 47 passed (47)
Duration 4.42s
```

- Observed result after fix: the production-source smoke invocation returns the canonical deny diagnostic `model override "openrouter/gpt-5.5"` without `openrouter/openrouter/`. The matching allowlisted request reaches real gateway `agent` handler validation (`malformed session key "agent::allow-proof"`) instead of failing fallback override authorization, while counters confirm no agent/provider run started. The focused OpenRouter fallback tests and the full `server-plugins.test.ts` file also pass.
- What was not tested: no live provider/network call and no actual agent run were made; the production-source smoke intentionally stops at gateway validation after fallback policy authorization. Full repo CI is not claimed. Exact-latest upstream `main` CI is not claimed green during local prep; this branch is based on the last-known-green `main` SHA `faf2a6cb9e`, while newer `main` runs were pending/in-progress or had failing jobs when checked.
- Before evidence (optional but encouraged): the same deny test failed on current `main` before the code change with `model override "openrouter/openrouter/gpt-5.5" is not allowlisted for plugin "voice-call".`

## Root Cause (if applicable)

- Root cause: `normalizeModelRef()` can return `{ provider: "openrouter", model: "openrouter/..." }` when the request model already carries the provider prefix. The gateway fallback policy then formatted keys with raw `` `${provider}/${model}` `` instead of the canonical helper that dedupes an already provider-prefixed model id.
- Missing detection / guardrail: gateway fallback tests covered generic trusted and untrusted override behavior, but did not assert the provider-prefixed OpenRouter diagnostic shape or pair that deny test with a matching allow-path guard.
- Contributing context (if known): #84946 intentionally fixed the runtime LLM policy path only; this PR handles the remaining gateway fallback policy path separately.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-plugins.test.ts`
- Scenario the test should lock in: a trusted fallback subagent with `allowedModels: ["openrouter/gpt-5.4-mini"]` rejects `provider: "openrouter"`, `model: "openrouter/gpt-5.5"` without a duplicate provider prefix, and still allows the matching `provider: "openrouter"`, `model: "openrouter/gpt-5.4-mini"` request.
- Why this is the smallest reliable guardrail: it exercises the same fallback policy builder, allowlist comparison, rejection diagnostic, and dispatch payload path without requiring a live provider call.
- Existing test that already covers this (if any): existing fallback override tests covered generic non-OpenRouter shapes and model-only canonical refs, but not provider-prefixed OpenRouter refs.
- If no new test is added, why not: N/A; new regression tests are added.

## User-visible / Behavior Changes

Gateway fallback subagent override denial messages now report the canonical OpenRouter model ref instead of a duplicate provider-prefixed ref. Matching allowlisted provider-prefixed OpenRouter requests remain authorized and dispatch unchanged.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22.22.1 in a local source checkout
- Model/provider: OpenRouter model-ref strings only; no live model/provider call
- Integration/channel (if any): gateway fallback subagent runtime test harness
- Relevant config (redacted): plugin `voice-call` with `subagent.allowModelOverride: true` and `subagent.allowedModels: ["openrouter/gpt-5.4-mini"]`

### Steps

1. Configure a trusted plugin fallback subagent allowlist with `allowedModels: ["openrouter/gpt-5.4-mini"]`.
2. Deny-path check: request `provider: "openrouter"`, `model: "openrouter/gpt-5.5"`.
3. Allow-path check: request `provider: "openrouter"`, `model: "openrouter/gpt-5.4-mini"`.
4. Run `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-plugins.test.ts -t 'OpenRouter fallback'`.

### Expected

- Deny-path diagnostic uses `openrouter/gpt-5.5` and does not contain `openrouter/openrouter/`.
- Allow-path request dispatches with `provider: "openrouter"` and `model: "openrouter/gpt-5.4-mini"`.

### Actual

- Before this patch, the deny-path diagnostic contained `openrouter/openrouter/gpt-5.5`.
- After this patch, the focused OpenRouter fallback tests and the full `server-plugins.test.ts` file pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: focused OpenRouter deny diagnostic; matching OpenRouter allow path; full `src/gateway/server-plugins.test.ts`; diff review confirmed only `src/gateway/server-plugins.ts` and `src/gateway/server-plugins.test.ts` changed.
- Edge cases checked: configured allowlist side and requested override side both use the same canonical helper; dispatch params remain caller-supplied provider/model values, not rewritten payload values.
- What you did **not** verify: live provider/network behavior and full repo CI.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No review conversations exist yet for this PR.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: canonicalizing only one side of the comparison could create false denies for matching allowlisted overrides.
  - Mitigation: the patch canonicalizes both allowlist and requested override keys, and adds a matching allow-path regression test.
- Risk: diagnostic-only tests could miss over-correction that changes the dispatch payload.
  - Mitigation: the allow-path test asserts the dispatched params still preserve `provider: "openrouter"` and `model: "openrouter/gpt-5.4-mini"`.
