### PR TITLE
refactor(ios): consolidate manual auth override inputs

### DIFF
--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -52,6 +52,20 @@ final class GatewayConnectionController {
             else { return nil }
             return override
         }
+
+        static func currentManualInput(
+            token: String?,
+            pendingOverride: ManualAuthOverride?,
+            password: String?) -> ManualAuthOverride?
+        {
+            guard let pendingOverride else {
+                return ManualAuthOverride.normalized(token: token, bootstrapToken: nil, password: password)
+            }
+            return ManualAuthOverride.explicit(
+                token: token,
+                bootstrapToken: pendingOverride.bootstrapToken,
+                password: password)
+        }
     }
 
     private struct PendingTrustConnect {

--- a/apps/ios/Sources/Onboarding/GatewayOnboardingView.swift
+++ b/apps/ios/Sources/Onboarding/GatewayOnboardingView.swift
@@ -220,14 +220,9 @@ private struct ManualEntryStep: View {
 
         self.connectingGatewayID = "manual"
         defer { self.connectingGatewayID = nil }
-        let authOverride = self.pendingManualAuthOverride.map { pending in
-            GatewayConnectionController.ManualAuthOverride.explicit(
-                token: self.manualToken,
-                bootstrapToken: pending.bootstrapToken,
-                password: self.manualPassword)
-        } ?? GatewayConnectionController.ManualAuthOverride.normalized(
+        let authOverride = GatewayConnectionController.ManualAuthOverride.currentManualInput(
             token: self.manualToken,
-            bootstrapToken: nil,
+            pendingOverride: self.pendingManualAuthOverride,
             password: self.manualPassword)
         self.pendingManualAuthOverride = nil
         await self.gatewayController.connectManual(
@@ -293,14 +288,10 @@ private struct ManualEntryStep: View {
             }
             GatewaySettingsStore.saveGatewayBootstrapToken(trimmedBootstrapToken, instanceId: trimmedInstanceId)
         }
-        if !trimmedBootstrapToken.isEmpty || !trimmedToken.isEmpty || !trimmedPassword.isEmpty {
-            self.pendingManualAuthOverride = GatewayConnectionController.ManualAuthOverride.normalized(
-                token: trimmedToken,
-                bootstrapToken: trimmedBootstrapToken,
-                password: trimmedPassword)
-        } else {
-            self.pendingManualAuthOverride = nil
-        }
+        self.pendingManualAuthOverride = GatewayConnectionController.ManualAuthOverride.normalized(
+            token: trimmedToken,
+            bootstrapToken: trimmedBootstrapToken,
+            password: trimmedPassword)
 
         self.setupStatusText = "Setup code applied."
     }

--- a/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
@@ -764,14 +764,10 @@ struct OnboardingWizardView: View {
         } else if trimmedBootstrapToken?.isEmpty == false {
             self.gatewayPassword = ""
         }
-        if trimmedBootstrapToken?.isEmpty == false || !trimmedToken.isEmpty || !trimmedPassword.isEmpty {
-            self.pendingManualAuthOverride = GatewayConnectionController.ManualAuthOverride.normalized(
-                token: trimmedToken,
-                bootstrapToken: trimmedBootstrapToken,
-                password: trimmedPassword)
-        } else {
-            self.pendingManualAuthOverride = nil
-        }
+        self.pendingManualAuthOverride = GatewayConnectionController.ManualAuthOverride.normalized(
+            token: trimmedToken,
+            bootstrapToken: trimmedBootstrapToken,
+            password: trimmedPassword)
         self.saveGatewayCredentials(token: self.gatewayToken, password: self.gatewayPassword)
         self.showQRScanner = false
         self.connectMessage = "Connecting via QR code…"
@@ -1017,14 +1013,9 @@ struct OnboardingWizardView: View {
         self.connectMessage = "Connecting to \(host)…"
         self.statusLine = "Connecting to \(host):\(self.manualPort)…"
         defer { self.connectingGatewayID = nil }
-        let authOverride = self.pendingManualAuthOverride.map { pending in
-            GatewayConnectionController.ManualAuthOverride.explicit(
-                token: self.gatewayToken,
-                bootstrapToken: pending.bootstrapToken,
-                password: self.gatewayPassword)
-        } ?? GatewayConnectionController.ManualAuthOverride.normalized(
+        let authOverride = GatewayConnectionController.ManualAuthOverride.currentManualInput(
             token: self.gatewayToken,
-            bootstrapToken: nil,
+            pendingOverride: self.pendingManualAuthOverride,
             password: self.gatewayPassword)
         self.pendingManualAuthOverride = nil
         await self.gatewayController.connectManual(

--- a/apps/ios/Sources/Settings/SettingsTab.swift
+++ b/apps/ios/Sources/Settings/SettingsTab.swift
@@ -915,14 +915,10 @@ struct SettingsTab: View {
                 GatewaySettingsStore.saveGatewayPassword("", instanceId: trimmedInstanceId)
             }
         }
-        if !trimmedBootstrapToken.isEmpty || !trimmedToken.isEmpty || !trimmedPassword.isEmpty {
-            self.pendingManualAuthOverride = GatewayConnectionController.ManualAuthOverride.normalized(
-                token: trimmedToken,
-                bootstrapToken: trimmedBootstrapToken,
-                password: trimmedPassword)
-        } else {
-            self.pendingManualAuthOverride = nil
-        }
+        self.pendingManualAuthOverride = GatewayConnectionController.ManualAuthOverride.normalized(
+            token: trimmedToken,
+            bootstrapToken: trimmedBootstrapToken,
+            password: trimmedPassword)
     }
 
     private func openGatewayQRScanner() {
@@ -1014,14 +1010,9 @@ struct SettingsTab: View {
 
         GatewayDiagnostics.log(
             "connect manual host=\(host) port=\(self.manualGatewayPort) tls=\(self.manualGatewayTLS)")
-        let authOverride = self.pendingManualAuthOverride.map { pending in
-            GatewayConnectionController.ManualAuthOverride.explicit(
-                token: self.gatewayToken,
-                bootstrapToken: pending.bootstrapToken,
-                password: self.gatewayPassword)
-        } ?? GatewayConnectionController.ManualAuthOverride.normalized(
+        let authOverride = GatewayConnectionController.ManualAuthOverride.currentManualInput(
             token: self.gatewayToken,
-            bootstrapToken: nil,
+            pendingOverride: self.pendingManualAuthOverride,
             password: self.gatewayPassword)
         self.pendingManualAuthOverride = nil
         await self.gatewayController.connectManual(


### PR DESCRIPTION
Summary:
- Consolidates repeated iOS manual-auth override assembly into `ManualAuthOverride.currentManualInput`.
- Reuses the existing `normalized` constructor directly for setup-code pending auth state.
- Keeps behavior unchanged while removing duplicated token/bootstrap/password branching in Settings and onboarding flows.

Verification:
- `git diff --check`
- `swiftformat --lint --config config/swiftformat --unexclude apps/ios/Sources apps/ios/Sources/Gateway/GatewayConnectionController.swift apps/ios/Sources/Onboarding/GatewayOnboardingView.swift apps/ios/Sources/Onboarding/OnboardingWizardView.swift apps/ios/Sources/Settings/SettingsTab.swift`
- `swiftlint lint --config apps/ios/.swiftlint.yml apps/ios/Sources/Gateway/GatewayConnectionController.swift apps/ios/Sources/Onboarding/GatewayOnboardingView.swift apps/ios/Sources/Onboarding/OnboardingWizardView.swift apps/ios/Sources/Settings/SettingsTab.swift` (exit 0; existing `OnboardingWizardView` type length warning only)
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> clean, no accepted/actionable findings

Behavior addressed: Refactor only; no user-facing behavior change intended.
Real environment tested: Local macOS checkout.
Exact steps or command run after this patch: Commands listed above.
Evidence after fix: Autoreview clean and focused Swift format/lint checks passed.
Observed result after fix: Manual auth override behavior remains centralized around the same `explicit` and `normalized` constructors.
What was not tested: Full iOS simulator build; this is a small Swift refactor with CI expected to cover the broader app build.
