### PR TITLE
fix(skills): accept macos os requirement on darwin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/service: include the active `openclaw` command bin directory in managed service PATH generation and doctor audit expectations for npm-global macOS installs. Fixes #84201. (#84475) Thanks @jbetala7.
 - Control UI/chat: disable the thinking selector for known non-reasoning models instead of showing duplicate Off choices. Fixes #84069. Thanks @DrippingMellow.
 - Memory: expand `~` in configured extra memory paths before resolving them, so home-relative folders are not treated as workspace-relative. Fixes #58026. Thanks @stadman.
+- Skills: treat `openclaw.os: macos` as Darwin when checking skill requirements, so macOS-only skills no longer report as missing on macOS hosts. Fixes #61338. Thanks @Jessecq1995.
 - CLI/update: preserve managed Gateway service environment during package cutovers so macOS LaunchAgent repair/restart reads the pre-update service state instead of caller shell state. (#83026)
 - Agents/providers: honor per-model `api` and `baseUrl` overrides in custom provider auth hooks and transport selection. Fixes #80487. (#80488) Thanks @huveewomg.
 - Gateway/restart: eager-load the lifecycle runtime before in-place upgrade signal handling so package replacement does not deadlock restart imports. (#84890) Thanks @myps6415.

--- a/src/shared/requirements.test.ts
+++ b/src/shared/requirements.test.ts
@@ -46,9 +46,10 @@ describe("requirements helpers", () => {
   it("resolveMissingOs allows remote platform", () => {
     expect(resolveMissingOs({ required: [], localPlatform: "linux" })).toStrictEqual([]);
     expect(resolveMissingOs({ required: ["linux"], localPlatform: "linux" })).toStrictEqual([]);
+    expect(resolveMissingOs({ required: ["macos"], localPlatform: "darwin" })).toStrictEqual([]);
     expect(
       resolveMissingOs({
-        required: ["darwin"],
+        required: ["macos"],
         localPlatform: "linux",
         remotePlatforms: ["darwin"],
       }),

--- a/src/shared/requirements.ts
+++ b/src/shared/requirements.ts
@@ -79,15 +79,15 @@ export function resolveMissingOs(params: {
     return [];
   }
   const localPlatform = normalizeOsRequirementPlatform(params.localPlatform);
-  const requiredPlatforms = params.required.map((platform) =>
-    normalizeOsRequirementPlatform(platform),
+  const requiredPlatforms = new Set(
+    params.required.map((platform) => normalizeOsRequirementPlatform(platform)),
   );
-  if (requiredPlatforms.includes(localPlatform)) {
+  if (requiredPlatforms.has(localPlatform)) {
     return [];
   }
   if (
     params.remotePlatforms?.some((platform) =>
-      requiredPlatforms.includes(normalizeOsRequirementPlatform(platform)),
+      requiredPlatforms.has(normalizeOsRequirementPlatform(platform)),
     )
   ) {
     return [];

--- a/src/shared/requirements.ts
+++ b/src/shared/requirements.ts
@@ -78,13 +78,26 @@ export function resolveMissingOs(params: {
   if (params.required.length === 0) {
     return [];
   }
-  if (params.required.includes(params.localPlatform)) {
+  const localPlatform = normalizeOsRequirementPlatform(params.localPlatform);
+  const requiredPlatforms = params.required.map((platform) =>
+    normalizeOsRequirementPlatform(platform),
+  );
+  if (requiredPlatforms.includes(localPlatform)) {
     return [];
   }
-  if (params.remotePlatforms?.some((platform) => params.required.includes(platform))) {
+  if (
+    params.remotePlatforms?.some((platform) =>
+      requiredPlatforms.includes(normalizeOsRequirementPlatform(platform)),
+    )
+  ) {
     return [];
   }
   return params.required;
+}
+
+function normalizeOsRequirementPlatform(platform: string): string {
+  const normalized = platform.trim().toLowerCase();
+  return normalized === "macos" ? "darwin" : normalized;
 }
 
 export function resolveMissingEnv(params: {


### PR DESCRIPTION
Summary:
- normalize OS requirement values before comparing them with local and remote platforms
- treat `openclaw.os: macos` as Darwin while preserving the original missing-requirement label
- add focused requirements coverage for local and remote Darwin matches

Verification:
- `pnpm test src/shared/requirements.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Behavior addressed:
Skills declaring `openclaw.os: macos` could be reported as missing on macOS because Node reports the platform as `darwin`.

Real environment tested:
Local macOS checkout with the repo test wrapper.

Exact steps or command run after this patch:
`pnpm test src/shared/requirements.test.ts`

Evidence after fix:
The OS requirements unit test now proves `required: ["macos"]` is satisfied by a local `darwin` platform and by a remote `darwin` platform.

Observed result after fix:
1 Vitest file passed, 10 tests passed; autoreview reported no accepted/actionable findings.

What was not tested:
A full `openclaw skills check` run against the reporter's local skill set; the failing comparison is covered directly in the shared requirement evaluator.

Fixes #61338.
