### PR TITLE
refactor(ios): centralize setup auth parsing

### DIFF
--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -21,6 +21,31 @@ import UIKit
 @Observable
 final class GatewayConnectionController {
     struct ManualAuthOverride: Equatable {
+        struct SetupAuth {
+            let token: String
+            let bootstrapToken: String
+            let password: String
+
+            var hasBootstrapToken: Bool {
+                !self.bootstrapToken.isEmpty
+            }
+
+            var shouldApplyTokenField: Bool {
+                !self.token.isEmpty || self.hasBootstrapToken
+            }
+
+            var shouldApplyPasswordField: Bool {
+                !self.password.isEmpty || self.hasBootstrapToken
+            }
+
+            var manualAuthOverride: ManualAuthOverride? {
+                ManualAuthOverride.normalized(
+                    token: self.token,
+                    bootstrapToken: self.bootstrapToken,
+                    password: self.password)
+            }
+        }
+
         let token: String?
         let bootstrapToken: String?
         let password: String?
@@ -65,6 +90,13 @@ final class GatewayConnectionController {
                 token: token,
                 bootstrapToken: pendingOverride.bootstrapToken,
                 password: password)
+        }
+
+        static func setupAuth(from link: GatewayConnectDeepLink) -> SetupAuth {
+            SetupAuth(
+                token: link.token?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "",
+                bootstrapToken: link.bootstrapToken?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "",
+                password: link.password?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "")
         }
     }
 

--- a/apps/ios/Sources/Onboarding/GatewayOnboardingView.swift
+++ b/apps/ios/Sources/Onboarding/GatewayOnboardingView.swift
@@ -264,34 +264,24 @@ private struct ManualEntryStep: View {
         self.manualPortText = String(link.port)
         self.manualUseTLS = link.tls
 
-        let trimmedToken = link.token?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        let trimmedPassword = link.password?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        let trimmedBootstrapToken =
-            link.bootstrapToken?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if !trimmedToken.isEmpty {
-            self.manualToken = trimmedToken
-        } else if link.bootstrapToken?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
-            self.manualToken = ""
+        let setupAuth = GatewayConnectionController.ManualAuthOverride.setupAuth(from: link)
+        if setupAuth.shouldApplyTokenField {
+            self.manualToken = setupAuth.token
         }
-        if !trimmedPassword.isEmpty {
-            self.manualPassword = trimmedPassword
-        } else if link.bootstrapToken?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
-            self.manualPassword = ""
+        if setupAuth.shouldApplyPasswordField {
+            self.manualPassword = setupAuth.password
         }
 
         let trimmedInstanceId = GatewaySettingsStore.currentInstanceID()
         if !trimmedInstanceId.isEmpty {
-            if !trimmedBootstrapToken.isEmpty {
+            if setupAuth.hasBootstrapToken {
                 GatewayOnboardingReset.prepareForBootstrapPairing(
                     appModel: self.appModel,
                     instanceId: trimmedInstanceId)
             }
-            GatewaySettingsStore.saveGatewayBootstrapToken(trimmedBootstrapToken, instanceId: trimmedInstanceId)
+            GatewaySettingsStore.saveGatewayBootstrapToken(setupAuth.bootstrapToken, instanceId: trimmedInstanceId)
         }
-        self.pendingManualAuthOverride = GatewayConnectionController.ManualAuthOverride.normalized(
-            token: trimmedToken,
-            bootstrapToken: trimmedBootstrapToken,
-            password: trimmedPassword)
+        self.pendingManualAuthOverride = setupAuth.manualAuthOverride
 
         self.setupStatusText = "Setup code applied."
     }

--- a/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
@@ -745,29 +745,20 @@ struct OnboardingWizardView: View {
         self.manualHost = link.host
         self.manualPort = link.port
         self.manualTLS = link.tls
-        let trimmedBootstrapToken = link.bootstrapToken?.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmedBootstrapToken?.isEmpty == false {
+        let setupAuth = GatewayConnectionController.ManualAuthOverride.setupAuth(from: link)
+        if setupAuth.hasBootstrapToken {
             GatewayOnboardingReset.prepareForBootstrapPairing(
                 appModel: self.appModel,
                 instanceId: GatewaySettingsStore.currentInstanceID())
         }
-        self.saveGatewayBootstrapToken(trimmedBootstrapToken)
-        let trimmedToken = link.token?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        let trimmedPassword = link.password?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if !trimmedToken.isEmpty {
-            self.gatewayToken = trimmedToken
-        } else if trimmedBootstrapToken?.isEmpty == false {
-            self.gatewayToken = ""
+        self.saveGatewayBootstrapToken(setupAuth.bootstrapToken)
+        if setupAuth.shouldApplyTokenField {
+            self.gatewayToken = setupAuth.token
         }
-        if !trimmedPassword.isEmpty {
-            self.gatewayPassword = trimmedPassword
-        } else if trimmedBootstrapToken?.isEmpty == false {
-            self.gatewayPassword = ""
+        if setupAuth.shouldApplyPasswordField {
+            self.gatewayPassword = setupAuth.password
         }
-        self.pendingManualAuthOverride = GatewayConnectionController.ManualAuthOverride.normalized(
-            token: trimmedToken,
-            bootstrapToken: trimmedBootstrapToken,
-            password: trimmedPassword)
+        self.pendingManualAuthOverride = setupAuth.manualAuthOverride
         self.saveGatewayCredentials(token: self.gatewayToken, password: self.gatewayPassword)
         self.showQRScanner = false
         self.connectMessage = "Connecting via QR code…"

--- a/apps/ios/Sources/Settings/SettingsTab.swift
+++ b/apps/ios/Sources/Settings/SettingsTab.swift
@@ -881,44 +881,28 @@ struct SettingsTab: View {
         self.manualGatewayTLS = link.tls
 
         let trimmedInstanceId = GatewaySettingsStore.currentInstanceID()
-        let trimmedBootstrapToken =
-            link.bootstrapToken?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if !trimmedBootstrapToken.isEmpty {
+        let setupAuth = GatewayConnectionController.ManualAuthOverride.setupAuth(from: link)
+        if setupAuth.hasBootstrapToken {
             GatewayOnboardingReset.prepareForBootstrapPairing(
                 appModel: self.appModel,
                 instanceId: trimmedInstanceId)
         }
         if !trimmedInstanceId.isEmpty {
-            GatewaySettingsStore.saveGatewayBootstrapToken(trimmedBootstrapToken, instanceId: trimmedInstanceId)
+            GatewaySettingsStore.saveGatewayBootstrapToken(setupAuth.bootstrapToken, instanceId: trimmedInstanceId)
         }
-        let trimmedToken = link.token?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        let trimmedPassword = link.password?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if !trimmedToken.isEmpty {
-            self.gatewayToken = trimmedToken
+        if setupAuth.shouldApplyTokenField {
+            self.gatewayToken = setupAuth.token
             if !trimmedInstanceId.isEmpty {
-                GatewaySettingsStore.saveGatewayToken(trimmedToken, instanceId: trimmedInstanceId)
-            }
-        } else if !trimmedBootstrapToken.isEmpty {
-            self.gatewayToken = ""
-            if !trimmedInstanceId.isEmpty {
-                GatewaySettingsStore.saveGatewayToken("", instanceId: trimmedInstanceId)
+                GatewaySettingsStore.saveGatewayToken(setupAuth.token, instanceId: trimmedInstanceId)
             }
         }
-        if !trimmedPassword.isEmpty {
-            self.gatewayPassword = trimmedPassword
+        if setupAuth.shouldApplyPasswordField {
+            self.gatewayPassword = setupAuth.password
             if !trimmedInstanceId.isEmpty {
-                GatewaySettingsStore.saveGatewayPassword(trimmedPassword, instanceId: trimmedInstanceId)
-            }
-        } else if !trimmedBootstrapToken.isEmpty {
-            self.gatewayPassword = ""
-            if !trimmedInstanceId.isEmpty {
-                GatewaySettingsStore.saveGatewayPassword("", instanceId: trimmedInstanceId)
+                GatewaySettingsStore.saveGatewayPassword(setupAuth.password, instanceId: trimmedInstanceId)
             }
         }
-        self.pendingManualAuthOverride = GatewayConnectionController.ManualAuthOverride.normalized(
-            token: trimmedToken,
-            bootstrapToken: trimmedBootstrapToken,
-            password: trimmedPassword)
+        self.pendingManualAuthOverride = setupAuth.manualAuthOverride
     }
 
     private func openGatewayQRScanner() {


### PR DESCRIPTION
Summary:
- Adds a parsed setup-auth value for iOS gateway setup links.
- Centralizes token/bootstrap/password trimming and the "bootstrap clears stale credential fields" rule.
- Reuses the parsed setup auth across onboarding, QR scan, and Settings setup-code flows without behavior changes.

Verification:
- `git diff --check`
- `swiftformat --lint --config config/swiftformat --unexclude apps/ios/Sources apps/ios/Sources/Gateway/GatewayConnectionController.swift apps/ios/Sources/Onboarding/GatewayOnboardingView.swift apps/ios/Sources/Onboarding/OnboardingWizardView.swift apps/ios/Sources/Settings/SettingsTab.swift`
- `swiftlint lint --config apps/ios/.swiftlint.yml apps/ios/Sources/Gateway/GatewayConnectionController.swift apps/ios/Sources/Onboarding/GatewayOnboardingView.swift apps/ios/Sources/Onboarding/OnboardingWizardView.swift apps/ios/Sources/Settings/SettingsTab.swift` (exit 0; existing `OnboardingWizardView` type length warning only)
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> clean, no accepted/actionable findings

Behavior addressed: Refactor only; no user-facing behavior change intended.
Real environment tested: Local macOS checkout.
Exact steps or command run after this patch: Commands listed above.
Evidence after fix: Autoreview clean and focused Swift format/lint checks passed.
Observed result after fix: Setup-code auth handling is centralized while preserving existing bootstrap/token/password semantics.
What was not tested: Full iOS simulator build; CI should cover the app build path.
