### PR TITLE
fix(docker): precreate owned named volume targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Docs: https://docs.openclaw.ai
 - Memory: expand `~` in configured extra memory paths before resolving them, so home-relative folders are not treated as workspace-relative. Fixes #58026. Thanks @stadman.
 - Skills: treat `openclaw.os: macos` as Darwin when checking skill requirements, so macOS-only skills no longer report as missing on macOS hosts. Fixes #61338. Thanks @Jessecq1995.
 - Control UI/logs: strip ANSI escape sequences from displayed Gateway log messages so color codes no longer appear as raw text. Fixes #64399. Thanks @guguangxin-eng.
+- Docker: pre-create the workspace and auth-profile config mount points with `node` ownership so first-run named volumes do not start root-owned. Fixes #85076. Thanks @Noerr.
 - CLI/update: preserve managed Gateway service environment during package cutovers so macOS LaunchAgent repair/restart reads the pre-update service state instead of caller shell state. (#83026)
 - Agents/providers: honor per-model `api` and `baseUrl` overrides in custom provider auth hooks and transport selection. Fixes #80487. (#80488) Thanks @huveewomg.
 - Gateway/restart: eager-load the lifecycle runtime before in-place upgrade signal handling so package replacement does not deadlock restart imports. (#84890) Thanks @myps6415.

--- a/Dockerfile
+++ b/Dockerfile
@@ -285,10 +285,15 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
 RUN ln -sf /app/openclaw.mjs /usr/local/bin/openclaw \
  && chmod 755 /app/openclaw.mjs
 
-# Pre-create the default state dir so first-run Docker named volumes mounted
-# here inherit node ownership instead of root-owned state.
-RUN install -d -m 0700 -o node -g node /home/node/.openclaw && \
-    stat -c '%U:%G %a' /home/node/.openclaw | grep -qx 'node:node 700'
+# Pre-create default named-volume mount points so first-run Docker volumes copy
+# node ownership from the image instead of starting as root-owned directories.
+RUN install -d -m 0700 -o node -g node \
+      /home/node/.openclaw \
+      /home/node/.openclaw/workspace \
+      /home/node/.config/openclaw && \
+    stat -c '%U:%G %a' /home/node/.openclaw | grep -qx 'node:node 700' && \
+    stat -c '%U:%G %a' /home/node/.openclaw/workspace | grep -qx 'node:node 700' && \
+    stat -c '%U:%G %a' /home/node/.config/openclaw | grep -qx 'node:node 700'
 
 ENV NODE_ENV=production
 

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -291,11 +291,11 @@ describe("Dockerfile", () => {
     );
   });
 
-  it("pre-creates the OpenClaw home before switching to the node user", async () => {
+  it("pre-creates named-volume mount points before switching to the node user", async () => {
     const dockerfile = await readFile(dockerfilePath, "utf8");
     const runtimeStageIndex = dockerfile.lastIndexOf("FROM base-runtime");
     const stateDirIndex = dockerfile.indexOf(
-      "RUN install -d -m 0700 -o node -g node /home/node/.openclaw && \\",
+      "RUN install -d -m 0700 -o node -g node \\",
       runtimeStageIndex,
     );
     const userIndex = dockerfile.indexOf("USER node", runtimeStageIndex);
@@ -306,8 +306,16 @@ describe("Dockerfile", () => {
     expect(stateDirIndex).toBeGreaterThan(runtimeStageIndex);
     expect(stateDirIndex).toBeLessThan(userIndex);
     expect(dockerfile).not.toContain("mkdir -p /home/node/.openclaw");
+    expect(dockerfile).toContain("/home/node/.openclaw/workspace");
+    expect(dockerfile).toContain("/home/node/.config/openclaw");
     expect(dockerfile).toContain(
       "stat -c '%U:%G %a' /home/node/.openclaw | grep -qx 'node:node 700'",
+    );
+    expect(dockerfile).toContain(
+      "stat -c '%U:%G %a' /home/node/.openclaw/workspace | grep -qx 'node:node 700'",
+    );
+    expect(dockerfile).toContain(
+      "stat -c '%U:%G %a' /home/node/.config/openclaw | grep -qx 'node:node 700'",
     );
   });
 });


### PR DESCRIPTION
Summary:
- pre-create Docker named-volume mount points for workspace and auth-profile config dirs
- verify each mount point is node-owned with 0700 permissions before switching to the node user
- update Dockerfile coverage for the additional paths

Verification:
- `pnpm test src/dockerfile.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Behavior addressed:
First-run Docker named volumes mounted at `/home/node/.openclaw/workspace` and `/home/node/.config/openclaw` could start as root-owned directories, blocking the non-root `node` runtime from writing workspace or auth-profile state.

Real environment tested:
Local macOS checkout with Dockerfile unit coverage.

Exact steps or command run after this patch:
`pnpm test src/dockerfile.test.ts`

Evidence after fix:
The Dockerfile now creates `/home/node/.openclaw`, `/home/node/.openclaw/workspace`, and `/home/node/.config/openclaw` with `install -d -m 0700 -o node -g node`, and the test asserts those ownership checks happen before `USER node`.

Observed result after fix:
1 Vitest file passed, 18 tests passed; autoreview reported no accepted/actionable findings.

What was not tested:
A live Docker build/run with fresh named volumes; the patch is constrained to the image-layer mount-point ownership contract and covered by Dockerfile assertions.

Fixes #85076.
