### PR TITLE
fix(telegram): honor table mode in outbound chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Docs: https://docs.openclaw.ai
 - Skills: treat `openclaw.os: macos` as Darwin when checking skill requirements, so macOS-only skills no longer report as missing on macOS hosts. Fixes #61338. Thanks @Jessecq1995.
 - Control UI/logs: strip ANSI escape sequences from displayed Gateway log messages so color codes no longer appear as raw text. Fixes #64399. Thanks @guguangxin-eng.
 - Docker: pre-create the workspace and auth-profile config mount points with `node` ownership so first-run named volumes do not start root-owned. Fixes #85076. Thanks @Noerr.
+- Telegram: pass configured markdown table mode through outbound markdown chunking so chunked sends render tables consistently. Fixes #85085. Thanks @ShuaiHui.
 - CLI/update: preserve managed Gateway service environment during package cutovers so macOS LaunchAgent repair/restart reads the pre-update service state instead of caller shell state. (#83026)
 - Agents/providers: honor per-model `api` and `baseUrl` overrides in custom provider auth hooks and transport selection. Fixes #80487. (#80488) Thanks @huveewomg.
 - Gateway/restart: eager-load the lifecycle runtime before in-place upgrade signal handling so package replacement does not deadlock restart imports. (#84890) Thanks @myps6415.

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -773,6 +773,10 @@ export function markdownToTelegramChunks(
   return renderTelegramChunksWithinHtmlLimit(ir, limit);
 }
 
-export function markdownToTelegramHtmlChunks(markdown: string, limit: number): string[] {
-  return markdownToTelegramChunks(markdown, limit).map((chunk) => chunk.html);
+export function markdownToTelegramHtmlChunks(
+  markdown: string,
+  limit: number,
+  options: { tableMode?: MarkdownTableMode } = {},
+): string[] {
+  return markdownToTelegramChunks(markdown, limit, options).map((chunk) => chunk.html);
 }

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -53,7 +53,7 @@ function chunkTelegramOutboundText(
 ): string[] {
   return ctx?.formatting?.parseMode === "HTML"
     ? splitTelegramHtmlChunks(text, limit)
-    : markdownToTelegramHtmlChunks(text, limit);
+    : markdownToTelegramHtmlChunks(text, limit, { tableMode: ctx?.formatting?.tableMode });
 }
 
 async function resolveTelegramSendContext(params: {

--- a/extensions/telegram/src/telegram-outbound.test.ts
+++ b/extensions/telegram/src/telegram-outbound.test.ts
@@ -29,4 +29,16 @@ describe("telegramPlugin outbound", () => {
       markdownToTelegramHtmlChunks(text, 4000),
     );
   });
+
+  it("passes markdown table mode to the outbound markdown chunker", () => {
+    clearTelegramRuntime();
+    const text = ["| Name | Value |", "|------|-------|", "| A | 1 |"].join("\n");
+
+    const chunks = telegramOutbound.chunker?.(text, 4000, {
+      formatting: { tableMode: "bullets" },
+    });
+
+    expect(chunks?.join("\n")).toContain("Value: 1");
+    expect(chunks?.join("\n")).not.toContain("| Name | Value |");
+  });
 });


### PR DESCRIPTION
Summary:
- thread outbound `formatting.tableMode` into Telegram markdown chunk rendering
- keep explicit HTML parse-mode chunking unchanged
- add regression coverage for table-to-bullets rendering through the outbound adapter chunker

Verification:
- `pnpm test extensions/telegram/src/telegram-outbound.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Behavior addressed:
Telegram outbound markdown chunking accepted formatting metadata but dropped `tableMode`, so table rendering could differ from the configured Telegram markdown behavior once messages were chunked.

Real environment tested:
Local macOS checkout with the Telegram extension Vitest shard.

Exact steps or command run after this patch:
`pnpm test extensions/telegram/src/telegram-outbound.test.ts`

Evidence after fix:
The outbound adapter test now sends a markdown table through the chunker with `formatting.tableMode: "bullets"` and verifies the rendered chunk contains the bullet-form table content instead of the raw table syntax.

Observed result after fix:
1 Vitest file passed, 3 tests passed; autoreview reported no accepted/actionable findings.

What was not tested:
A live Telegram send; the fix is isolated to the deterministic outbound markdown chunker before network delivery.

Fixes #85085.
