### PR TITLE
fix(moonshot): resolve bundled models dynamically

### DIFF
--- a/extensions/moonshot/api.ts
+++ b/extensions/moonshot/api.ts
@@ -5,5 +5,6 @@ export {
   MOONSHOT_BASE_URL,
   MOONSHOT_CN_BASE_URL,
   MOONSHOT_DEFAULT_MODEL_ID,
+  resolveMoonshotDynamicModel,
 } from "./provider-catalog.js";
 export { MOONSHOT_DEFAULT_MODEL_REF } from "./onboard.js";

--- a/extensions/moonshot/index.test.ts
+++ b/extensions/moonshot/index.test.ts
@@ -70,4 +70,24 @@ describe("moonshot provider plugin", () => {
       thinking: { type: "disabled" },
     });
   });
+
+  it("resolves bundled Moonshot models without registry discovery", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    const resolved = provider.resolveDynamicModel?.({
+      provider: "moonshot",
+      modelId: "kimi-k2.6",
+      modelRegistry: { find: () => undefined } as never,
+      providerConfig: { baseUrl: "https://api.moonshot.cn/v1" },
+    });
+
+    expect(resolved).toMatchObject({
+      id: "kimi-k2.6",
+      provider: "moonshot",
+      api: "openai-completions",
+      baseUrl: "https://api.moonshot.cn/v1",
+      contextWindow: 262144,
+      maxTokens: 262144,
+    });
+  });
 });

--- a/extensions/moonshot/index.ts
+++ b/extensions/moonshot/index.ts
@@ -8,7 +8,10 @@ import {
   applyMoonshotConfigCn,
   MOONSHOT_DEFAULT_MODEL_REF,
 } from "./onboard.js";
-import { buildMoonshotProvider } from "./provider-catalog.js";
+import {
+  buildMoonshotProvider,
+  resolveMoonshotDynamicModel,
+} from "./provider-catalog.js";
 import { createKimiWebSearchProvider } from "./src/kimi-web-search-provider.js";
 
 const PROVIDER_ID = "moonshot";
@@ -73,6 +76,7 @@ export default defineSingleProviderPluginEntry({
       ],
       defaultLevel: "off",
     }),
+    resolveDynamicModel: resolveMoonshotDynamicModel,
   },
   register(api) {
     api.registerMediaUnderstandingProvider(moonshotMediaUnderstandingProvider);

--- a/extensions/moonshot/provider-catalog.ts
+++ b/extensions/moonshot/provider-catalog.ts
@@ -3,7 +3,14 @@ import {
   applyProviderNativeStreamingUsageCompat,
   supportsNativeStreamingUsageCompat,
 } from "openclaw/plugin-sdk/provider-catalog-shared";
-import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import type {
+  ProviderResolveDynamicModelContext,
+  ProviderRuntimeModel,
+} from "openclaw/plugin-sdk/plugin-entry";
+import {
+  normalizeModelCompat,
+  type ModelProviderConfig,
+} from "openclaw/plugin-sdk/provider-model-shared";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 export const MOONSHOT_BASE_URL = "https://api.moonshot.ai/v1";
@@ -31,4 +38,20 @@ export function buildMoonshotProvider(): ModelProviderConfig {
     providerId: "moonshot",
     catalog: manifest.modelCatalog.providers.moonshot,
   });
+}
+
+export function resolveMoonshotDynamicModel(ctx: ProviderResolveDynamicModelContext) {
+  const providerConfig = ctx.providerConfig;
+  const provider = buildMoonshotProvider();
+  const model = provider.models.find((candidate) => candidate.id === ctx.modelId);
+  if (!model) {
+    return undefined;
+  }
+
+  return normalizeModelCompat({
+    ...model,
+    provider: ctx.provider,
+    api: providerConfig?.api ?? provider.api,
+    baseUrl: providerConfig?.baseUrl ?? provider.baseUrl,
+  } as ProviderRuntimeModel);
 }


### PR DESCRIPTION
## Summary

- Fixes #84783.
- Add a Moonshot-owned `resolveDynamicModel` hook so bundled Kimi models resolve from the plugin static catalog without falling back to broad registry/model discovery.
- Preserve configured Moonshot transport settings such as `.cn` base URLs while reusing the existing catalog metadata and model compat normalization.
- Add regression coverage for resolving `moonshot/kimi-k2.6` when the registry cannot find it.

## Tests

- `node scripts/run-vitest.mjs extensions/moonshot/index.test.ts extensions/moonshot/provider-catalog.test.ts`
- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/model.test.ts src/agents/models-config.providers.moonshot.test.ts`
- `node --import tsx --input-type=module <<'EOF' ... EOF` (runtime plugin registration / dynamic model resolution smoke; exact command in Real behavior proof)
- `git diff --check`

## Real behavior proof

Behavior addressed: Native Moonshot agent runs with a bundled model such as `moonshot/kimi-k2.6` no longer have to miss the fast provider-owned model hook and fall through to broad model registry / `models.json` preparation when the registry cannot resolve the model.

Real environment tested: Local macOS source checkout on this PR head with existing node_modules. No Moonshot network call or API key was needed; this exercises the provider plugin registration and the same synchronous dynamic model hook that the embedded runner can call before broad registry discovery.

Exact steps or command run after this patch:

```sh
node --import tsx --input-type=module <<'EOF'
import { registerSingleProviderPlugin } from 'openclaw/plugin-sdk/plugin-test-runtime';
import plugin from './extensions/moonshot/index.ts';
const provider = await registerSingleProviderPlugin(plugin);
const model = provider.resolveDynamicModel?.({
  provider: 'moonshot',
  modelId: 'kimi-k2.6',
  modelRegistry: { find: () => undefined },
  providerConfig: { baseUrl: 'https://api.moonshot.cn/v1' },
});
console.log(JSON.stringify({ id: model?.id, provider: model?.provider, api: model?.api, baseUrl: model?.baseUrl, contextWindow: model?.contextWindow }));
EOF
```

Evidence after fix:

```text
{"id":"kimi-k2.6","provider":"moonshot","api":"openai-completions","baseUrl":"https://api.moonshot.cn/v1","contextWindow":262144}
```

Observed result after fix: The registered Moonshot provider returned a complete runtime model for `kimi-k2.6` even though the supplied registry `find` method always returned `undefined`, and it preserved the configured `.cn` base URL instead of requiring fallback discovery.

What was not tested: A live Discord/TUI run against Moonshot was not executed because this proof does not have the reporter's channel setup or API credentials; the exercised path is the provider-owned model resolution hook that avoids the reported slow fallback before dispatch.
