### PR TITLE
fix(browser): avoid cold mac chrome version timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@ Docs: https://docs.openclaw.ai
 - CLI/agents: default new omitted-account bindings to all accounts when the channel has multiple configured accounts, and clarify account-scope docs. (#49769) Thanks @Gcaufy.
 - Codex app-server: let authorized `/codex` control commands such as `/codex detach` escape plugin-owned conversation bindings while keeping unknown or unauthorized slash text routed to the bound plugin. Fixes #85157. (#85188) Thanks @TurboTheTurtle.
 - Auto-reply/models: keep `/models` browse replies fast by sharing the bounded read-only catalog path with Gateway model listing. (#84735) Thanks @safrano9999.
+- Browser/Doctor: read macOS Chrome app bundle versions from `Info.plist` before spawning Chrome and extend the fallback version probe timeout, avoiding false cold-cache warnings from Gatekeeper latency. Fixes #85418. Thanks @davidcittadini.
 - Codex app-server: disable native Code Mode when the effective exec host is `node` and keep OpenClaw `exec`/`process` available, so `/exec host=node` routes shell commands through the selected node instead of the gateway. Fixes #85012. (#85090) Thanks @sahilsatralkar.
 - Agents: bound embedded auto-compaction session write-lock watchdogs to the compaction timeout instead of the full run timeout, so stuck compaction cannot hold the live session lock for the whole run window. (#84949) Thanks @luoyanglang.
 - Gateway/agents: return phase-aware `agent.wait` timeout attribution and only cool auth profiles on provider-started timeouts. Refs #65504. Thanks @100yenadmin.

--- a/extensions/browser/src/browser/chrome.executables.ts
+++ b/extensions/browser/src/browser/chrome.executables.ts
@@ -15,6 +15,8 @@ export type BrowserExecutable = {
 
 const CHROME_VERSION_RE = /\b(\d+)(?:\.\d+){1,3}\b/g;
 const PLAYWRIGHT_BROWSERS_PATH_ENV = "PLAYWRIGHT_BROWSERS_PATH";
+const BROWSER_VERSION_TIMEOUT_MS = 6000;
+const MAC_PLISTBUDDY_TIMEOUT_MS = 800;
 
 const CHROMIUM_BUNDLE_IDS = new Set([
   "com.google.Chrome",
@@ -732,11 +734,40 @@ export function resolveGoogleChromeExecutableForPlatform(
 }
 
 export function readBrowserVersion(executablePath: string): string | null {
-  const output = execText(executablePath, ["--version"], 2000);
+  if (process.platform === "darwin") {
+    const bundleVersion = readMacBundleBrowserVersion(executablePath);
+    if (bundleVersion) {
+      return bundleVersion;
+    }
+  }
+
+  const output = execText(executablePath, ["--version"], BROWSER_VERSION_TIMEOUT_MS);
   if (!output) {
     return null;
   }
   return output.replace(/\s+/g, " ").trim();
+}
+
+function readMacBundleBrowserVersion(executablePath: string): string | null {
+  const appBundlePath = resolveMacAppBundlePath(executablePath);
+  if (!appBundlePath) {
+    return null;
+  }
+  const plistPath = path.join(appBundlePath, "Contents", "Info.plist");
+  return execText(
+    "/usr/libexec/PlistBuddy",
+    ["-c", "Print :CFBundleShortVersionString", plistPath],
+    MAC_PLISTBUDDY_TIMEOUT_MS,
+  );
+}
+
+function resolveMacAppBundlePath(executablePath: string): string | null {
+  const parts = path.normalize(executablePath).split(path.sep);
+  const appIndex = parts.findIndex((part) => part.endsWith(".app"));
+  if (appIndex < 0) {
+    return null;
+  }
+  return parts.slice(0, appIndex + 1).join(path.sep) || path.sep;
 }
 
 export function parseBrowserMajorVersion(rawVersion: string | null | undefined): number | null {

--- a/extensions/browser/src/browser/chrome.version.test.ts
+++ b/extensions/browser/src/browser/chrome.version.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const execFileSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    execFileSync: (...args: unknown[]) => execFileSyncMock(...args),
+  };
+});
+
+import { readBrowserVersion } from "./chrome.executables.js";
+
+function stubPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: platform,
+  });
+}
+
+describe("readBrowserVersion", () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    stubPlatform(originalPlatform);
+    execFileSyncMock.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("reads macOS app bundle versions from Info.plist before spawning Chrome", () => {
+    stubPlatform("darwin");
+    execFileSyncMock.mockReturnValue("148.0.7778.179\n");
+
+    const version = readBrowserVersion(
+      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    );
+
+    expect(version).toBe("148.0.7778.179");
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      "/usr/libexec/PlistBuddy",
+      [
+        "-c",
+        "Print :CFBundleShortVersionString",
+        "/Applications/Google Chrome.app/Contents/Info.plist",
+      ],
+      expect.objectContaining({ timeout: 800 }),
+    );
+  });
+
+  it("falls back to a slower --version probe when macOS bundle metadata is unavailable", () => {
+    stubPlatform("darwin");
+    execFileSyncMock
+      .mockImplementationOnce(() => {
+        throw new Error("plist unavailable");
+      })
+      .mockReturnValueOnce("Google Chrome 148.0.7778.179\n");
+
+    const version = readBrowserVersion(
+      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    );
+
+    expect(version).toBe("Google Chrome 148.0.7778.179");
+    expect(execFileSyncMock).toHaveBeenNthCalledWith(
+      2,
+      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+      ["--version"],
+      expect.objectContaining({ timeout: 6000 }),
+    );
+  });
+
+  it("uses the slower --version probe for non-bundle paths", () => {
+    stubPlatform("darwin");
+    execFileSyncMock.mockReturnValue("Chromium 148.0.7778.179\n");
+
+    const version = readBrowserVersion("/opt/chromium/chrome");
+
+    expect(version).toBe("Chromium 148.0.7778.179");
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      "/opt/chromium/chrome",
+      ["--version"],
+      expect.objectContaining({ timeout: 6000 }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- read macOS Chromium app bundle versions from `Contents/Info.plist` before spawning the browser
- extend the fallback `--version` probe timeout so cold Gatekeeper/amfid verification has room to finish
- add focused regression coverage for plist-first, fallback, and non-bundle version probes

Fixes #85418.

## Verification

2026-05-23 update after rebasing onto `origin/main` (`32f91503be`), head `a68f25d386`:

- `node scripts/run-vitest.mjs extensions/browser/src/browser/chrome.version.test.ts --reporter=verbose` (1 file, 3 tests passed)
- `./node_modules/.bin/oxfmt --check --threads=1 CHANGELOG.md extensions/browser/src/browser/chrome.executables.ts extensions/browser/src/browser/chrome.version.test.ts`
- `./node_modules/.bin/oxlint extensions/browser/src/browser/chrome.executables.ts extensions/browser/src/browser/chrome.version.test.ts`
- `git diff --check origin/main...HEAD`

Earlier verification before the rebase:

- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/browser/src/browser/chrome.version.test.ts extensions/browser/src/browser/chrome.test.ts extensions/browser/src/doctor-browser.test.ts -- --reporter=verbose`
- `pnpm exec oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/browser/src/browser/chrome.executables.ts extensions/browser/src/browser/chrome.version.test.ts extensions/browser/src/browser/chrome.test.ts extensions/browser/src/doctor-browser.test.ts`
- `git diff --check`
- `codex review --uncommitted`

## Real behavior proof
Behavior addressed: `openclaw doctor --deep` no longer has to spawn `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome --version` to determine the Chrome version on macOS app-bundle installs, so a cold Gatekeeper/amfid spawn delay does not collapse into the misleading unknown-version warning.

Real environment tested: WSL Ubuntu-24.04 checkout at `/root/src/openclaw-85460`, Node/Vitest via repo wrapper.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/browser/src/browser/chrome.version.test.ts --reporter=verbose`

Evidence after fix: the regression test `reads macOS app bundle versions from Info.plist before spawning Chrome` stubs `process.platform=darwin`, calls production `readBrowserVersion('/Applications/Google Chrome.app/Contents/MacOS/Google Chrome')`, returns `148.0.7778.179`, and asserts only `/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' /Applications/Google Chrome.app/Contents/Info.plist` ran with an 800 ms timeout. The fallback test proves the executable `--version` probe uses a 6000 ms timeout when plist metadata is unavailable.

Observed result after fix: focused browser version test passed 3 tests; focused static checks were clean.

What was not tested: I did not reproduce a real macOS Gatekeeper cold-cache delay in this Linux/WSL checkout; the issue report provides the live macOS timing, and this patch proves the production path avoids that spawn before falling back.
