### PR TITLE
fix(status): show configured cost for aws-sdk models

### DIFF
--- a/src/status/status-message.test.ts
+++ b/src/status/status-message.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatFastModeLabel } from "./status-labels.js";
+import { buildStatusMessage, type StatusArgs } from "./status-message.js";
 
 describe("formatFastModeLabel", () => {
   it("shows fast mode when enabled", () => {
@@ -8,5 +10,65 @@ describe("formatFastModeLabel", () => {
 
   it("hides fast mode when disabled", () => {
     expect(formatFastModeLabel(false)).toBeNull();
+  });
+});
+
+describe("buildStatusMessage", () => {
+  const bedrockConfig = {
+    models: {
+      providers: {
+        "amazon-bedrock": {
+          auth: "aws-sdk",
+          models: [
+            {
+              id: "us.anthropic.claude-sonnet-4-6",
+              cost: {
+                input: 3,
+                output: 15,
+                cacheRead: 0.3,
+                cacheWrite: 3.75,
+              },
+            },
+          ],
+        },
+      },
+    },
+  } satisfies OpenClawConfig;
+
+  const baseStatusArgs = {
+    agent: { model: { primary: "amazon-bedrock/us.anthropic.claude-sonnet-4-6" } },
+    config: bedrockConfig,
+    sessionEntry: {
+      inputTokens: 1000,
+      outputTokens: 1000,
+    },
+    timeLine: "Time: test",
+    uptimeLine: "Uptime: test",
+    now: 0,
+  } satisfies StatusArgs;
+
+  it("shows configured cost for aws-sdk providers", () => {
+    const message = buildStatusMessage({
+      ...baseStatusArgs,
+      modelAuth: "aws-sdk",
+      activeModelAuth: "aws-sdk",
+    });
+
+    expect(message).toContain(
+      "🧠 Model: amazon-bedrock/us.anthropic.claude-sonnet-4-6 · 🔑 aws-sdk",
+    );
+    expect(message).toContain("🧮 Tokens: 1.0k in / 1.0k out · 💵 Cost: $0.02");
+  });
+
+  it("keeps hiding cost when no pricing is configured", () => {
+    const message = buildStatusMessage({
+      ...baseStatusArgs,
+      config: undefined,
+      modelAuth: "aws-sdk",
+      activeModelAuth: "aws-sdk",
+    });
+
+    expect(message).toContain("🧮 Tokens: 1.0k in / 1.0k out");
+    expect(message).not.toContain("💵 Cost:");
   });
 });

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -897,31 +897,25 @@ export function buildStatusMessage(args: StatusArgs): string {
     activeModelRef: activeModelLabel,
     state: entry,
   });
-  const effectiveCostAuthMode = fallbackState.active
-    ? activeAuthMode
-    : (selectedAuthMode ?? activeAuthMode);
-  const showCost = effectiveCostAuthMode === "api-key" || effectiveCostAuthMode === "mixed";
   const hasUsage = typeof inputTokens === "number" || typeof outputTokens === "number";
-  const costConfig =
-    showCost && hasUsage
-      ? resolveModelCostConfig({
-          provider: activeProvider,
-          model: activeModel,
-          config: args.config,
-          allowPluginNormalization: false,
-        })
-      : undefined;
-  const cost =
-    showCost && hasUsage
-      ? estimateUsageCost({
-          usage: {
-            input: inputTokens ?? undefined,
-            output: outputTokens ?? undefined,
-          },
-          cost: costConfig,
-        })
-      : undefined;
-  const costLabel = showCost && hasUsage ? formatUsd(cost) : undefined;
+  const costConfig = hasUsage
+    ? resolveModelCostConfig({
+        provider: activeProvider,
+        model: activeModel,
+        config: args.config,
+        allowPluginNormalization: false,
+      })
+    : undefined;
+  const cost = hasUsage
+    ? estimateUsageCost({
+        usage: {
+          input: inputTokens ?? undefined,
+          output: outputTokens ?? undefined,
+        },
+        cost: costConfig,
+      })
+    : undefined;
+  const costLabel = hasUsage ? formatUsd(cost) : undefined;
 
   const selectedAuthLabel = selectedAuthLabelValue ? ` · 🔑 ${selectedAuthLabelValue}` : "";
   const modelNote = channelModelNote ? ` · ${channelModelNote}` : "";


### PR DESCRIPTION
## Summary
- Remove the auth-mode gate from `/status` cost estimation so configured model pricing is used for `aws-sdk` providers too
- Keep cost hidden when usage exists but no pricing is configured
- Add regression coverage for an Amazon Bedrock `aws-sdk` provider with explicit `cost` fields

## Why
`/status` already resolves model pricing from configured provider/model cost data. The display path then gated cost estimation to `api-key` or `mixed` auth modes, so Bedrock models using `aws-sdk` auth showed token usage without cost even when `models.providers.*.models.*.cost` was explicitly configured.

This keeps the pricing contract tied to configured cost data, not the provider authentication mechanism.

## Real behavior proof

**Behavior or issue addressed:** `/status` cost display should use explicit configured model pricing for a provider using `auth: "aws-sdk"`.

**Real environment tested:** Source checkout on Node `v22.22.1`, this PR branch, Amazon Bedrock provider config shape with `auth: "aws-sdk"`, explicit model `cost` values for `amazon-bedrock/us.anthropic.claude-sonnet-4-6`.

**Exact steps or command run after this patch:** Configured an Amazon Bedrock provider with `auth: "aws-sdk"` and explicit per-token cost values, built the status message through `buildStatusMessage`, provided `1000` input tokens and `1000` output tokens, and inspected the rendered model and token/cost lines.

**Evidence after fix:** Terminal output from the real status rendering path:

```text
$ node --import tsx - <<'NODE'
import { buildStatusMessage } from './src/status/status-message.ts';
const message = buildStatusMessage({
  agent: { model: { primary: 'amazon-bedrock/us.anthropic.claude-sonnet-4-6' } },
  config: {
    models: {
      providers: {
        'amazon-bedrock': {
          auth: 'aws-sdk',
          models: [{
            id: 'us.anthropic.claude-sonnet-4-6',
            cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
          }],
        },
      },
    },
  },
  sessionEntry: { inputTokens: 1000, outputTokens: 1000 },
  modelAuth: 'aws-sdk',
  activeModelAuth: 'aws-sdk',
  timeLine: 'Time: proof',
  uptimeLine: 'Uptime: proof',
  now: 0,
});
console.log(message.split('\n').filter((line) => line.includes('Model:') || line.includes('Tokens:')).join('\n'));
NODE
🧠 Model: amazon-bedrock/us.anthropic.claude-sonnet-4-6 · 🔑 aws-sdk
🧮 Tokens: 1.0k in / 1.0k out · 💵 Cost: $0.02
```

**Observed result after fix:** The rendered `/status` output includes `💵 Cost: $0.02` for the `aws-sdk` Amazon Bedrock model when explicit pricing is configured.

**What was not tested:** A live AWS Bedrock API call. This change only affects status cost rendering from existing usage totals and configured pricing, not Bedrock request execution or AWS authentication.

## Test Plan
- `node "$PNPM_CJS" test src/status/status-message.test.ts`
- `git diff --check`

Fixes #53286

AI-assisted: prepared with Hubert under Maurice's direction, with local validation before opening this PR.
