### PR TITLE
Suppress cron announce control replies

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -1391,36 +1391,55 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     }
   });
 
-  it("suppresses NO_REPLY payload in direct delivery so sentinel never leaks to external channels", async () => {
-    const params = makeBaseParams({ synthesizedText: "NO_REPLY" });
-    // Force the useDirectDelivery path (structured content) to exercise
-    // deliverViaDirect without going through finalizeTextDelivery.
-    (params as Record<string, unknown>).deliveryPayloadHasStructuredContent = true;
-    const state = await dispatchCronDelivery(params);
+  it.each([SILENT_REPLY_TOKEN, "ANNOUNCE_SKIP", "REPLY_SKIP"])(
+    "suppresses %s payload in direct delivery so control tokens never leak to external channels",
+    async (controlToken) => {
+      const params = makeBaseParams({ synthesizedText: controlToken });
+      // Force the useDirectDelivery path (structured content) to exercise
+      // deliverViaDirect without going through finalizeTextDelivery.
+      (params as Record<string, unknown>).deliveryPayloadHasStructuredContent = true;
+      const state = await dispatchCronDelivery(params);
 
-    // NO_REPLY must be filtered out before reaching the outbound adapter.
-    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
-    expectResultFields(state.result, {
-      status: "ok",
-      delivered: false,
-      deliveryAttempted: true,
-    });
-    // deliveryAttempted must be true so the heartbeat timer does not fire
-    // a fallback enqueueSystemEvent with the NO_REPLY sentinel text.
-    expect(state.deliveryAttempted).toBe(true);
+      // Control tokens must be filtered out before reaching the outbound adapter.
+      expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+      expectResultFields(state.result, {
+        status: "ok",
+        delivered: false,
+        deliveryAttempted: true,
+      });
+      // deliveryAttempted must be true so the heartbeat timer does not fire
+      // a fallback enqueueSystemEvent with the control-token text.
+      expect(state.deliveryAttempted).toBe(true);
 
-    // Verify timer guard agrees: shouldEnqueueCronMainSummary returns false
-    expect(
-      shouldEnqueueCronMainSummary({
-        summaryText: "NO_REPLY",
-        deliveryRequested: true,
-        delivered: state.result?.delivered,
-        deliveryAttempted: state.result?.deliveryAttempted,
-        suppressMainSummary: false,
-        isCronSystemEvent: () => true,
-      }),
-    ).toBe(false);
-  });
+      // Verify timer guard agrees: shouldEnqueueCronMainSummary returns false
+      expect(
+        shouldEnqueueCronMainSummary({
+          summaryText: controlToken,
+          deliveryRequested: true,
+          delivered: state.result?.delivered,
+          deliveryAttempted: state.result?.deliveryAttempted,
+          suppressMainSummary: false,
+          isCronSystemEvent: () => true,
+        }),
+      ).toBe(false);
+    },
+  );
+
+  it.each(["ANNOUNCE_SKIP", "REPLY_SKIP"])(
+    "suppresses %s payload in text delivery so control tokens never leak to external channels",
+    async (controlToken) => {
+      const params = makeBaseParams({ synthesizedText: controlToken });
+      const state = await dispatchCronDelivery(params);
+
+      expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+      expectResultFields(state.result, {
+        status: "ok",
+        delivered: false,
+        deliveryAttempted: true,
+      });
+      expect(state.deliveryAttempted).toBe(true);
+    },
+  );
 
   it("delivers explicit targets with direct text through the outbound adapter", async () => {
     const params = makeBaseParams({ synthesizedText: "hello from cron" });

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -17,6 +17,7 @@ import {
 import { resolveMirroredTranscriptText } from "../../config/sessions/transcript-mirror.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
+import { isSuppressedControlReplyText } from "../../gateway/control-reply-text.js";
 import { sleepWithAbort } from "../../infra/backoff.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type {
@@ -62,7 +63,7 @@ function normalizeSilentReplyText(text: string | undefined): NormalizedSilentRep
   if (!text) {
     return { text, strippedTrailingSilentToken: false };
   }
-  if (isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
+  if (isSuppressedControlReplyText(text)) {
     return { text: undefined, strippedTrailingSilentToken: false };
   }
 
@@ -80,7 +81,7 @@ function normalizeSilentReplyText(text: string | undefined): NormalizedSilentRep
     next = stripped;
   }
 
-  if (!next.trim() || isSilentReplyText(next, SILENT_REPLY_TOKEN)) {
+  if (!next.trim() || isSuppressedControlReplyText(next)) {
     return { text: undefined, strippedTrailingSilentToken };
   }
   return { text: next, strippedTrailingSilentToken };


### PR DESCRIPTION
Fixes #85421

## Summary
- Cron announce/direct delivery now uses the shared suppressed-control-reply predicate before sending outbound payloads, so token-only `NO_REPLY`, `ANNOUNCE_SKIP`, and `REPLY_SKIP` replies are treated as silent instead of leaking to external channels.
- Existing trailing/leading `NO_REPLY` cleanup behavior is preserved.

## Real behavior proof
**Behavior addressed:** Cron announce/direct delivery suppresses token-only `NO_REPLY`, `ANNOUNCE_SKIP`, and `REPLY_SKIP` before outbound provider send instead of leaking those internal control replies to external channels.

**Real environment tested:** Local OpenClaw checkout on macOS, branch `fix/cron-announce-control-reply-85421`, using the actual cron delivery dispatcher and gateway chat suppression code paths. External after-fix proof was also supplied through a Crabbox live Discord bot/channel run on this PR head.

**Exact steps or command run after this patch:**
```bash
node scripts/run-vitest.mjs src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat.test.ts
pnpm exec oxfmt --write --threads=1 src/cron/isolated-agent/delivery-dispatch.ts src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
git diff --check
git log --format='%h %an <%ae> %s' upstream/main..HEAD
gh run view 26304980272 --repo openclaw/openclaw --log
```

**Evidence after fix:** Terminal capture from the local OpenClaw checkout after the patch:
```text
RUN  v4.1.7 /Users/andy/openclaw/openclaw-85421

Test Files  1 passed (1)
Tests  69 passed (69)
Start at  11:02:32
Duration  2.07s (transform 1.47s, setup 243ms, import 1.52s, tests 227ms, environment 0ms)

Test Files  1 passed (1)
Tests  29 passed (29)
Start at  11:02:31
Duration  10.14s (transform 6.81s, setup 286ms, import 2.09s, tests 7.66s, environment 0ms)

Finished in 7ms on 2 files using 1 threads.

5b478fa47d Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> Suppress cron announce control replies
```

External proof gate output after the live Discord proof was posted:
```text
$ gh run view 26304980272 --repo openclaw/openclaw --log
...
Run node scripts/github/real-behavior-proof-check.mjs
External PR includes after-fix real behavior proof.
```

Redacted live Discord proof summary supplied on this PR:
- Live Discord proof ran through Crabbox using a real Discord bot/channel and redacted environment forwarding.
- A cron delivery returning an exact suppressed control token produced no external Discord message.
- A normal cron delivery in the same harness posted a marker message to Discord.
- The proof cleaned up the posted marker message afterward.

Proof comment URLs:
- https://github.com/openclaw/openclaw/pull/85471#issuecomment-4522882872
- https://github.com/openclaw/openclaw/pull/85471#issuecomment-4522893954

**Observed result after fix:** Focused cron regression exercises token-only `NO_REPLY`, `ANNOUNCE_SKIP`, and `REPLY_SKIP` through structured/direct delivery and verifies the outbound adapter is not called. It also exercises token-only `ANNOUNCE_SKIP` and `REPLY_SKIP` through text delivery and verifies delivery is marked attempted without sending. Existing gateway chat suppression behavior remains green. The later live Discord/Crabbox proof verifies the external transport behavior ClawSweeper requested: suppressed cron control-token output stayed silent, while a normal cron reply still posted.

**What was not tested:** Native Telegram proof was attempted separately but is not used as gating evidence here. The external transport proof for this PR is the live Discord/Crabbox path above.

## Attribution note
If maintainers squash or rework this PR, please preserve author attribution or include:
Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>
