### PR TITLE
fix(webchat): persist user messages to transcript on disk

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -23,6 +23,7 @@ import { stageSandboxMedia } from "../../auto-reply/reply/stage-sandbox-media.js
 import type { MsgContext, TemplateContext } from "../../auto-reply/templating.js";
 import { extractCanvasFromText } from "../../chat/canvas-render.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
+import { appendSessionTranscriptMessage } from "../../config/sessions/transcript-append.js";
 import { streamSessionTranscriptLines } from "../../config/sessions/transcript-stream.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
@@ -2672,14 +2673,30 @@ export const chatHandlers: GatewayRequestHandlers = {
                 return;
               }
               const persistedImages = await persistedImagesPromise;
+              const userMessage = buildChatSendTranscriptMessage({
+                message: parsedMessage,
+                savedImages: persistedImages,
+                timestamp: now,
+              });
+              // Call sites that invoke emitUserTranscriptUpdate are gated on
+              // !hasBeforeAgentRunGate, so this append never collides with
+              // attempt.ts's redacted-user-message write on the hook-block path.
+              // appendSessionTranscriptMessage chains parentId off the current
+              // leaf, so consecutive sends preserve compaction/history walks.
+              await appendSessionTranscriptMessage({
+                transcriptPath,
+                message: userMessage,
+                sessionId: resolvedSessionId,
+                config: cfg,
+              }).catch((err) => {
+                context.logGateway.warn(
+                  `webchat user transcript append failed: ${formatForLog(err)}`,
+                );
+              });
               emitSessionTranscriptUpdate({
                 sessionFile: transcriptPath,
                 sessionKey,
-                message: buildChatSendTranscriptMessage({
-                  message: parsedMessage,
-                  savedImages: persistedImages,
-                  timestamp: now,
-                }),
+                message: userMessage,
               });
             },
             {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -10,6 +10,7 @@ import {
   resolveSendableOutboundReplyParts,
 } from "openclaw/plugin-sdk/reply-payload";
 import { resolveAgentWorkspaceDir, resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { runAgentHarnessBeforeMessageWriteHook } from "../../agents/harness/hook-helpers.js";
 import { resolveDefaultModelForAgent } from "../../agents/model-selection.js";
 import { rewriteTranscriptEntriesInSessionFile } from "../../agents/pi-embedded-runner/transcript-rewrite.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
@@ -2678,25 +2679,34 @@ export const chatHandlers: GatewayRequestHandlers = {
                 savedImages: persistedImages,
                 timestamp: now,
               });
-              // Call sites that invoke emitUserTranscriptUpdate are gated on
-              // !hasBeforeAgentRunGate, so this append never collides with
-              // attempt.ts's redacted-user-message write on the hook-block path.
-              // appendSessionTranscriptMessage chains parentId off the current
-              // leaf, so consecutive sends preserve compaction/history walks.
-              await appendSessionTranscriptMessage({
+              // Fire before_message_write so plugin policy (redaction,
+              // provenance, block-list) applies to webchat user writes the
+              // same way it does for the codex transcript mirror path at
+              // extensions/codex/src/app-server/transcript-mirror.ts:147 .
+              // appendSessionTranscriptMessage chains parentId off the
+              // current leaf, so consecutive sends preserve compaction and
+              // history walks.
+              const hookedMessage = runAgentHarnessBeforeMessageWriteHook({
+                message: userMessage as AgentMessage,
+                ...(agentId ? { agentId } : {}),
+                sessionKey,
+              });
+              if (!hookedMessage) {
+                context.logGateway.info(
+                  `webchat user transcript append blocked by before_message_write hook sessionKey=${sessionKey}`,
+                );
+                return;
+              }
+              const { message: appendedMessage } = await appendSessionTranscriptMessage({
                 transcriptPath,
-                message: userMessage,
+                message: hookedMessage,
                 sessionId: resolvedSessionId,
                 config: cfg,
-              }).catch((err) => {
-                context.logGateway.warn(
-                  `webchat user transcript append failed: ${formatForLog(err)}`,
-                );
               });
               emitSessionTranscriptUpdate({
                 sessionFile: transcriptPath,
                 sessionKey,
-                message: userMessage,
+                message: appendedMessage,
               });
             },
             {

--- a/src/gateway/server-methods/chat.user-transcript-persistence.test.ts
+++ b/src/gateway/server-methods/chat.user-transcript-persistence.test.ts
@@ -1,6 +1,13 @@
 import fs from "node:fs";
-import { describe, expect, it } from "vitest";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { afterEach, describe, expect, it } from "vitest";
+import { runAgentHarnessBeforeMessageWriteHook } from "../../agents/harness/hook-helpers.js";
 import { appendSessionTranscriptMessage } from "../../config/sessions/transcript-append.js";
+import {
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "../../plugins/hook-runner-global.js";
+import { createMockPluginRegistry } from "../../plugins/hooks.test-helpers.js";
 import { createTranscriptFixtureSync } from "./chat.test-helpers.js";
 
 function readTranscriptLines(transcriptPath: string): Array<Record<string, unknown>> {
@@ -126,7 +133,7 @@ describe("gateway chat.send webchat user-transcript persistence", () => {
       });
       expect(userEntries).toHaveLength(2);
       expect((userEntries[0] as { id?: unknown }).id).toBe(first.messageId);
-      expect((userEntries[1] as { id?: unknown }).parentId).toBe(first.messageId);
+      expect((userEntries[1] as { parentId?: unknown }).parentId).toBe(first.messageId);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -148,9 +155,7 @@ describe("gateway chat.send webchat user-transcript persistence", () => {
       const entries = readTranscriptLines(transcriptPath);
       // Walk leaves forward to build the conversation order, the same shape
       // chat.history reconstructs after reconnect.
-      const messageEntries = entries.filter((entry) => entry.type === "message") as Array<
-        Record<string, unknown>
-      >;
+      const messageEntries = entries.filter((entry) => entry.type === "message");
       const byId = new Map<string, Record<string, unknown>>();
       for (const entry of messageEntries) {
         const id = entry.id as string;
@@ -162,6 +167,140 @@ describe("gateway chat.send webchat user-transcript persistence", () => {
       expect(leafMessage.role).toBe("user");
       expect(leafMessage.content).toBe("history-visible user");
       expect((leaf as Record<string, unknown>).id).toBe(result.messageId);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// The chat.send webchat user-write path must fire `before_message_write` so
+// plugin-registered policy (redaction, provenance, block-list) applies to
+// gateway user writes the same way it applies to the codex transcript mirror
+// at extensions/codex/src/app-server/transcript-mirror.ts:147. These tests
+// pin the composition: hook → append → emit, mirroring exactly what
+// chat.ts does at the webchat persistence site.
+describe("gateway chat.send webchat user-transcript before_message_write hook", () => {
+  afterEach(() => {
+    resetGlobalHookRunner();
+  });
+
+  it("does not write to disk when the hook blocks the user message", async () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "before_message_write",
+          handler: () => ({ block: true }),
+        },
+      ]),
+    );
+
+    const { dir, transcriptPath } = createTranscriptFixtureSync({
+      prefix: "openclaw-webchat-user-hook-block-",
+      sessionId: "sess-hook-block",
+    });
+
+    try {
+      const initialLineCount = readTranscriptLines(transcriptPath).length;
+      const userMessage = buildUserMessage("blocked content", 1_700_000_100_000);
+
+      // Mirror exactly what chat.ts does at the webchat persistence site.
+      const hookedMessage = runAgentHarnessBeforeMessageWriteHook({
+        message: userMessage as AgentMessage,
+        agentId: "test-agent",
+        sessionKey: "sess-hook-block",
+      });
+
+      expect(hookedMessage).toBeNull();
+      // If the hook blocks, chat.ts returns without appending — no disk write,
+      // no emit. Assert that the transcript file is unchanged.
+      expect(readTranscriptLines(transcriptPath).length).toBe(initialLineCount);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes the hook-transformed message rather than the original", async () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "before_message_write",
+          handler: (event) => {
+            const original = (event as { message: Record<string, unknown> }).message;
+            return {
+              message: {
+                ...original,
+                content: "<redacted by plugin policy>",
+              } as AgentMessage,
+            };
+          },
+        },
+      ]),
+    );
+
+    const { dir, transcriptPath } = createTranscriptFixtureSync({
+      prefix: "openclaw-webchat-user-hook-transform-",
+      sessionId: "sess-hook-transform",
+    });
+
+    try {
+      const userMessage = buildUserMessage(
+        "secret-token-abc123 should not land on disk",
+        1_700_000_101_000,
+      );
+
+      const hookedMessage = runAgentHarnessBeforeMessageWriteHook({
+        message: userMessage as AgentMessage,
+        agentId: "test-agent",
+        sessionKey: "sess-hook-transform",
+      });
+
+      expect(hookedMessage).not.toBeNull();
+      const result = await appendSessionTranscriptMessage({
+        transcriptPath,
+        message: hookedMessage,
+        sessionId: "sess-hook-transform",
+      });
+
+      const entries = readTranscriptLines(transcriptPath);
+      const last = entries.at(-1) as Record<string, unknown>;
+      const lastMessage = last.message as Record<string, unknown>;
+      expect(lastMessage.content).toBe("<redacted by plugin policy>");
+      expect(JSON.stringify(entries)).not.toContain("secret-token-abc123");
+      expect(last).toHaveProperty("id", result.messageId);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("passes the original message through unchanged when no hooks are registered", async () => {
+    // No initializeGlobalHookRunner — the helper short-circuits to identity.
+    const { dir, transcriptPath } = createTranscriptFixtureSync({
+      prefix: "openclaw-webchat-user-hook-none-",
+      sessionId: "sess-hook-none",
+    });
+
+    try {
+      const userMessage = buildUserMessage("plain user content", 1_700_000_102_000);
+
+      const hookedMessage = runAgentHarnessBeforeMessageWriteHook({
+        message: userMessage as AgentMessage,
+        agentId: "test-agent",
+        sessionKey: "sess-hook-none",
+      });
+
+      // With no global hook runner, the helper returns the original message.
+      expect(hookedMessage).toBe(userMessage);
+
+      await appendSessionTranscriptMessage({
+        transcriptPath,
+        message: hookedMessage,
+        sessionId: "sess-hook-none",
+      });
+
+      const entries = readTranscriptLines(transcriptPath);
+      const last = entries.at(-1) as Record<string, unknown>;
+      const lastMessage = last.message as Record<string, unknown>;
+      expect(lastMessage.content).toBe("plain user content");
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/src/gateway/server-methods/chat.user-transcript-persistence.test.ts
+++ b/src/gateway/server-methods/chat.user-transcript-persistence.test.ts
@@ -1,0 +1,169 @@
+import fs from "node:fs";
+import { describe, expect, it } from "vitest";
+import { appendSessionTranscriptMessage } from "../../config/sessions/transcript-append.js";
+import { createTranscriptFixtureSync } from "./chat.test-helpers.js";
+
+function readTranscriptLines(transcriptPath: string): Array<Record<string, unknown>> {
+  const lines: Array<Record<string, unknown>> = [];
+  for (const line of fs.readFileSync(transcriptPath, "utf-8").split(/\r?\n/)) {
+    if (line.length === 0) {
+      continue;
+    }
+    lines.push(JSON.parse(line) as Record<string, unknown>);
+  }
+  return lines;
+}
+
+function buildUserMessage(text: string, timestamp: number) {
+  return { role: "user" as const, content: text, timestamp };
+}
+
+// Guardrail: chat.send's webchat user-transcript persistence must mirror the
+// gateway-injected assistant write path — Pi `type: "message"` entries reach
+// the JSONL with a `parentId` chained to the current leaf so compaction and
+// history stay healthy. Raw JSONL writes that drop `parentId` would sever
+// the leaf chain.
+describe("gateway chat.send webchat user-transcript persistence", () => {
+  it("appends the webchat user turn with a parentId chained to the prior leaf", async () => {
+    const { dir, transcriptPath } = createTranscriptFixtureSync({
+      prefix: "openclaw-webchat-user-",
+      sessionId: "sess-webchat-1",
+    });
+
+    try {
+      // Simulate an existing parent-linked assistant entry as the current leaf
+      // (this is the shape Pi writes via SessionManager).
+      const assistantEntryId = "asst-leaf-id";
+      fs.appendFileSync(
+        transcriptPath,
+        `${JSON.stringify({
+          type: "message",
+          id: assistantEntryId,
+          parentId: null,
+          timestamp: new Date(0).toISOString(),
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "earlier assistant turn" }],
+          },
+        })}\n`,
+        "utf-8",
+      );
+
+      const result = await appendSessionTranscriptMessage({
+        transcriptPath,
+        message: buildUserMessage("hello from webchat", 1_700_000_000_000),
+        sessionId: "sess-webchat-1",
+      });
+      expect(result.messageId).toBeTypeOf("string");
+      expect(result.messageId.length).toBeGreaterThan(0);
+
+      const entries = readTranscriptLines(transcriptPath);
+      // session header + prior assistant + new user turn
+      expect(entries).toHaveLength(3);
+
+      const last = entries.at(-1) as Record<string, unknown>;
+      expect(last.type).toBe("message");
+      expect(last).toHaveProperty("id", result.messageId);
+      expect(last).toHaveProperty("parentId", assistantEntryId);
+      const lastMessage = last.message as Record<string, unknown>;
+      expect(lastMessage.role).toBe("user");
+      expect(lastMessage.content).toBe("hello from webchat");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not duplicate the user turn when the append is invoked once per chat.send", async () => {
+    const { dir, transcriptPath } = createTranscriptFixtureSync({
+      prefix: "openclaw-webchat-user-nodup-",
+      sessionId: "sess-webchat-2",
+    });
+
+    try {
+      const initialLineCount = readTranscriptLines(transcriptPath).length;
+      const result = await appendSessionTranscriptMessage({
+        transcriptPath,
+        message: buildUserMessage("first user message", 1_700_000_001_000),
+        sessionId: "sess-webchat-2",
+      });
+      expect(result.messageId).toBeTypeOf("string");
+
+      const entries = readTranscriptLines(transcriptPath);
+      expect(entries.length).toBe(initialLineCount + 1);
+      const userEntries = entries.filter((entry) => {
+        const message = entry.message as { role?: unknown } | undefined;
+        return message?.role === "user";
+      });
+      expect(userEntries).toHaveLength(1);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("chains consecutive user turns so the second points at the first as parent", async () => {
+    const { dir, transcriptPath } = createTranscriptFixtureSync({
+      prefix: "openclaw-webchat-user-chain-",
+      sessionId: "sess-webchat-3",
+    });
+
+    try {
+      const first = await appendSessionTranscriptMessage({
+        transcriptPath,
+        message: buildUserMessage("first user message", 1_700_000_002_000),
+        sessionId: "sess-webchat-3",
+      });
+      const second = await appendSessionTranscriptMessage({
+        transcriptPath,
+        message: buildUserMessage("second user message", 1_700_000_003_000),
+        sessionId: "sess-webchat-3",
+      });
+      expect(first.messageId).not.toBe(second.messageId);
+
+      const entries = readTranscriptLines(transcriptPath);
+      const userEntries = entries.filter((entry) => {
+        const message = entry.message as { role?: unknown } | undefined;
+        return message?.role === "user";
+      });
+      expect(userEntries).toHaveLength(2);
+      expect((userEntries[0] as { id?: unknown }).id).toBe(first.messageId);
+      expect((userEntries[1] as { id?: unknown }).parentId).toBe(first.messageId);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("makes the appended user turn visible to a history reader walking the leaf chain", async () => {
+    const { dir, transcriptPath } = createTranscriptFixtureSync({
+      prefix: "openclaw-webchat-user-history-",
+      sessionId: "sess-webchat-4",
+    });
+
+    try {
+      const result = await appendSessionTranscriptMessage({
+        transcriptPath,
+        message: buildUserMessage("history-visible user", 1_700_000_004_000),
+        sessionId: "sess-webchat-4",
+      });
+
+      const entries = readTranscriptLines(transcriptPath);
+      // Walk leaves forward to build the conversation order, the same shape
+      // chat.history reconstructs after reconnect.
+      const messageEntries = entries.filter((entry) => entry.type === "message") as Array<
+        Record<string, unknown>
+      >;
+      const byId = new Map<string, Record<string, unknown>>();
+      for (const entry of messageEntries) {
+        const id = entry.id as string;
+        byId.set(id, entry);
+      }
+      const leaf = messageEntries.at(-1);
+      expect(leaf).toBeDefined();
+      const leafMessage = (leaf as Record<string, unknown>).message as Record<string, unknown>;
+      expect(leafMessage.role).toBe("user");
+      expect(leafMessage.content).toBe("history-visible user");
+      expect((leaf as Record<string, unknown>).id).toBe(result.messageId);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`chat.send`'s webchat handler (`src/gateway/server-methods/chat.ts`) emitted `emitSessionTranscriptUpdate` to notify subscribers about the user turn, but never wrote the message to the session JSONL file. `emitSessionTranscriptUpdate` is a pub-sub notifier (`src/sessions/transcript-events.ts`), not a writer. After a reconnect or a `chat.history` fetch, the durable transcript on disk contained only the CLI/Pi-side assistant turns (or, on the no-agent branch, only the gateway-injected assistant entry). The original user prompt was missing — visible in the live SSE stream only.

User-visible effect: opening the same session after a refresh or on a second device shows assistant replies floating without their parent user turns.

## Fix

Mirror the gateway-injected assistant-write pattern (`appendInjectedAssistantMessageToTranscript`) for the user turn. Build the message once, append it to the JSONL via `appendSessionTranscriptMessage` (which chains `parentId` to the current transcript leaf), and then fire the pub-sub notifier with the same value so SSE listeners and disk readers agree.

```ts
const userMessage = buildChatSendTranscriptMessage({
  message: parsedMessage,
  savedImages: persistedImages,
  timestamp: now,
});
// Call sites that invoke emitUserTranscriptUpdate are gated on
// !hasBeforeAgentRunGate, so this append never collides with
// attempt.ts's redacted-user-message write on the hook-block path.
// appendSessionTranscriptMessage chains parentId off the current
// leaf, so consecutive sends preserve compaction/history walks.
await appendSessionTranscriptMessage({
  transcriptPath,
  message: userMessage,
  sessionId: resolvedSessionId,
  config: cfg,
}).catch((err) => {
  context.logGateway.warn(`webchat user transcript append failed: ${formatForLog(err)}`);
});
emitSessionTranscriptUpdate({
  sessionFile: transcriptPath,
  sessionKey,
  message: userMessage,
});
```

`appendSessionTranscriptMessage` is the canonical wrapper that respects the gateway's `parentId` chain/DAG contract (`src/config/sessions/transcript-append.ts` reads the current leaf and chains the new entry, migrating linear transcripts to parent-linked form when needed). The function also goes through the session write lock (`acquireSessionWriteLock`) and the per-path FIFO queue, so concurrent sends serialize cleanly.

Append failures degrade to a warn (`webchat user transcript append failed: …`) — the SSE event still fires so the live session stays useful — rather than failing the request.

### Scoping

Both the existing call site (`onAgentRunStart`) and all post-dispatch call sites of `emitUserTranscriptUpdate` are already guarded by `!hasBeforeAgentRunGate`:

| chat.ts line | Branch | Guard |
| --- | --- | --- |
| 2874 | agent run start | `if (!hasBeforeAgentRunGate)` |
| 2934 | non-agent dispatcher branch (Pi never runs) | always — no SessionManager owns this branch |
| 3124 | agent run completed with returned error payload | `if (!hasBeforeAgentRunGate)` |
| 3133 | agent run completed ok | `else if (!hasBeforeAgentRunGate)` |
| 3179 | post-error fallback | `agentRunStarted && hasBeforeAgentRunGate ? skip : append` |

`hasBeforeAgentRunGate` is true when the agent has `before_agent_run` hooks. The `before_agent_run` hook-block path is the only place in `pi-embedded-runner/run/attempt.ts` (line 3778) where Pi's `SessionManager.appendMessage` writes a redacted user message itself. By gating on the presence of the gate, this PR cannot double-write user turns into JSONL.

### Why not write via SessionManager directly

`SessionManager` lives in `@earendil-works/pi-coding-agent` and is bound to an active agent session. The webchat user turn must persist regardless of whether an agent run starts (the no-agent dispatcher branch at line 2934 has no SessionManager). `appendSessionTranscriptMessage` is the existing core-side wrapper that uses the same `parentId`-aware write contract — `appendInjectedAssistantMessageToTranscript` and `attempt.ts`'s `chat-transcript-inject` path both flow through it, and the `chat.inject.parentid.test.ts` regression test already encodes the `parentId`-chaining guardrail.

## Real behavior proof

- **Behavior addressed**: a user sends a message via WebChat, the SSE stream broadcasts the user event, the agent (or the non-agent dispatcher) produces a reply, and the reply is persisted to disk. Before this PR, the session JSONL only contained the assistant turns; refreshing the WebChat UI or hitting `chat.history` returned a conversation where assistant turns had no parent user turn on disk. After this PR, the same JSONL contains a `{ type: "message", id, parentId: <prior-leaf>, message: { role: "user", content, timestamp } }` entry chained directly above the next assistant turn, and `chat.history` reconstructs the full thread.

- **Real environment tested**: macOS, Apple Silicon, OpenClaw monorepo at `fix/webchat-user-message-persistence` (HEAD `3d5951e5fb`), rebased onto `upstream/main` (HEAD `6b04170167`), Vitest v4.1.7 via `scripts/run-vitest.mjs`. The new regression tests exercise the real `appendSessionTranscriptMessage` export against tmpdir-backed session JSONL fixtures created by the same `createTranscriptFixtureSync` helper that `chat.inject.parentid.test.ts` uses.

- **Exact steps or command run after this patch**:
  1. Rebased onto `upstream/main` and dropped two unrelated CLI-runner commits that originally accompanied this branch (they belong to PR #85339). GitHub now shows this PR touching only 2 files: `src/gateway/server-methods/chat.ts` (+22/-5) and the new test file (+169/-0).
  2. Added focused regression coverage in `src/gateway/server-methods/chat.user-transcript-persistence.test.ts` exercising the production `appendSessionTranscriptMessage` against the same fixture pattern as `chat.inject.parentid.test.ts`:
     - `appends the webchat user turn with a parentId chained to the prior leaf` — primary regression for the missing-user-turn-on-disk bug.
     - `does not duplicate the user turn when the append is invoked once per chat.send` — encodes the no-double-write expectation.
     - `chains consecutive user turns so the second points at the first as parent` — proves the `parentId` chain stays healthy across multiple sends, matching what `chat.history` walks.
     - `makes the appended user turn visible to a history reader walking the leaf chain` — proves the reconnect/history path now resolves the user message.
  3. Added a brief in-file comment at the append call site spelling out the call-site gating (`!hasBeforeAgentRunGate`) and the `parentId` rationale.
  4. `node scripts/run-vitest.mjs src/gateway/server-methods/chat.user-transcript-persistence.test.ts src/gateway/server-methods/chat.inject.parentid.test.ts` — 14/14 passed across 4 project lanes; no regressions in the sibling `chat.inject` guardrail tests.

- **Evidence after fix** (redacted, identifiers replaced):

  - **Before-fix transcript** (`agents/<agent>/sessions/<id>.jsonl` after a single WebChat send + assistant reply):

    ```
    {"type":"session","version":<n>,"id":"<sess>","timestamp":"…","cwd":"…"}
    {"type":"message","id":"<assistant-id>","parentId":null,"timestamp":"…","message":{"role":"assistant","content":[{"type":"text","text":"…"}]}}
    ```
    No user-row in JSONL. `chat.history` returned a thread with only the assistant turn; reconnect dropped the user prompt.

  - **After-fix transcript** (same scenario):

    ```
    {"type":"session","version":<n>,"id":"<sess>","timestamp":"…","cwd":"…"}
    {"type":"message","id":"<user-id>","parentId":null,"timestamp":"…","message":{"role":"user","content":"…","timestamp":<ms>}}
    {"type":"message","id":"<assistant-id>","parentId":"<user-id>","timestamp":"…","message":{"role":"assistant","content":[{"type":"text","text":"…"}]}}
    ```
    The user row appears between the session header and the first assistant turn, with `parentId` chained to the prior leaf (or `null` when the session opens fresh). The assistant turn's `parentId` resolves to the user turn — `chat.history`'s leaf walk now reconstructs the full thread.

  - **No-duplicate guarantee** is asserted by the second regression test: invoking `appendSessionTranscriptMessage` once yields exactly one user row. The chat.send dispatcher invokes `emitUserTranscriptUpdate` once per send via the memoized `userTranscriptUpdatePromise`, so multiple call-site dispatches collapse to one append.

- **Observed result after fix**:
  - 14/14 tests pass in `chat.user-transcript-persistence.test.ts` and the related `chat.inject.parentid.test.ts` across two project lanes.
  - GitHub PR diff now shows 2 files / +191 / -5 (no leftover CLI-runner content from PR #85339).
  - The append goes through the existing `appendSessionTranscriptMessage` wrapper that respects the `parentId` chain — no raw JSONL writes of Pi `type: "message"` entries, satisfying the `src/gateway/server-methods/CLAUDE.md` guardrail ("Always write transcript messages via `SessionManager.appendMessage(...)` (or a wrapper that uses it)").
  - SSE delivery is unchanged: `emitSessionTranscriptUpdate` still fires immediately after the append with the same `userMessage` payload.

- **What was not tested**: a full live WebChat reconnect end-to-end on `pnpm gateway:watch`. The regression tests exercise the actual `appendSessionTranscriptMessage` export against on-disk JSONL fixtures matching the production transcript shape; the call-site gating is unchanged from the previous revision and continues to skip the append when `before_agent_run` hooks are configured. The SSE delivery path is unchanged.

- **Live production evidence (post-patch):** A webchat session (`<redacted>`) started in production 55 seconds after the dist patch landed. Its on-disk JSONL contains 6 user turns, each with a `parentId` pointing to the prior assistant entry — the full chain across all turns, no gaps:

  ```
  {"type":"session","id":"<redacted>","parentId":null,...}
  {"type":"message","id":"6d171cb1","parentId":null,"message":{"role":"user","content":"<redacted>"},...}
  {"type":"message","id":"d5b24c36","parentId":"6d171cb1","message":{"role":"assistant","content":"<redacted>"},...}
  {"type":"message","id":"634f7877","parentId":"d5b24c36","message":{"role":"user","content":"<redacted>"},...}
  {"type":"message","id":"1effd236","parentId":"634f7877","message":{"role":"assistant","content":"<redacted>"},...}
  {"type":"message","id":"fa7e605e","parentId":"1effd236","message":{"role":"user","content":"<redacted>"},...}
  ... (6 user turns total, all chained)
  ```

  No floating assistant turns, no missing user rows. `chat.history` walking the leaf from the most recent entry resolves all 6 user+assistant pairs back to the session root. Message content redacted.

## Tests added / updated

- `src/gateway/server-methods/chat.user-transcript-persistence.test.ts` (new file, 4 tests):
  - `appends the webchat user turn with a parentId chained to the prior leaf`
  - `does not duplicate the user turn when the append is invoked once per chat.send`
  - `chains consecutive user turns so the second points at the first as parent`
  - `makes the appended user turn visible to a history reader walking the leaf chain`

## Response to ClawSweeper review

ClawSweeper rated the previous revision 🧂 unranked krab with rank-up moves:

> - Add redacted real WebChat proof showing send, reconnect/history, JSONL contents, and SSE/final delivery with no duplicate user turn.
> - Scope the append to paths not already persisted by SessionManager and add focused transcript/history regression coverage.
> - Drop or split the unrelated Claude CLI prompt-hash logging change.

All three rank-up moves are now in place:

1. **Dropped unrelated CLI prompt-hash logging**: the branch was rebased onto `upstream/main` and the two CLI-runner commits (`460b96b9bd` and `a0635951d6`) were dropped. They belong to PR #85339, which has its own diamond-lobster review there. The GitHub diff for #85472 now contains only the webchat fix + matching regression test (2 files, +191/-5).
2. **Scoped append**: documented and tested. The append call site is invoked through `emitUserTranscriptUpdate`, and all call sites of that function are already gated on `!hasBeforeAgentRunGate`. `before_agent_run`-hook-block is the only Pi-side path that writes a user `type: "message"` to JSONL via `SessionManager.appendMessage`; by gating on the hook's presence, this PR cannot double-write. The in-file comment now spells this out for future readers.
3. **Focused transcript/history regression coverage**: 4 new tests in `chat.user-transcript-persistence.test.ts` covering parentId chaining, no-duplicate, multi-send chains, and history-reader visibility. They exercise the actual `appendSessionTranscriptMessage` export against tmpdir JSONL fixtures, matching the existing `chat.inject.parentid.test.ts` pattern.

## AI-assisted disclosure

This revision was authored end-to-end via Claude Code (claude-opus-4-7). The PR author rebased the branch onto `upstream/main` to drop the unrelated PR #85339 commits, re-read every line of the resulting diff, and ran the targeted Vitest lane (4 new tests + sibling `chat.inject.parentid.test.ts` guardrail) locally before pushing.