### PR TITLE
Advance iMessage catchup cursor after live handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Channels/iMessage: advance the startup catchup cursor from live-handled rows after a completed catchup pass, including rows received while catchup is still running, so restarts do not replay them. (#85475) Thanks @TurboTheTurtle.
 - Tests: keep kitchen-sink plugin assertion fixtures on a configurable temp root so native Windows runs no longer skip full-surface diagnostic coverage.
 - Tests: fail Gateway startup benchmarks when a child startup never produces ready probes or process metrics instead of reporting all `n/a` samples as passing.
 - Config/secrets: allow exec SecretRef ids to include `#` selectors so AWS-style `secret#json_key` ids validate consistently. (#80731) Thanks @TurboTheTurtle.

--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -701,6 +701,7 @@ Catchup keeps a per-account cursor at `<openclawStateDir>/imessage/catchup/<acco
 ```
 
 - The cursor advances on each successful dispatch and is held when a row's dispatch throws — the next startup retries the same row from the held cursor.
+- After the startup catchup query succeeds, later live-handled rows also advance the same cursor so a gateway restart does not replay messages that were already handled live. Live cursor writes do not jump past catchup failures that are still below `maxFailureRetries`.
 - After `maxFailureRetries` consecutive throws against the same `guid`, catchup logs a `warn` and force-advances the cursor past the wedged message so subsequent startups can make progress.
 - Already-given-up guids are skipped on sight (no dispatch attempt) on later runs and counted under `skippedGivenUp` in the run summary.
 

--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -20,6 +20,16 @@ const dispatchInboundMessageMock = vi.hoisted(() =>
       ({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } }) as const,
   ),
 );
+const debouncerControl = vi.hoisted(() => ({
+  holdEntries: false,
+  entries: [] as unknown[],
+  flush: undefined as undefined | (() => Promise<void>),
+  reset() {
+    this.holdEntries = false;
+    this.entries = [];
+    this.flush = undefined;
+  },
+}));
 
 vi.mock("openclaw/plugin-sdk/transport-ready-runtime", () => ({
   waitForTransportReady: waitForTransportReadyMock,
@@ -41,7 +51,17 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
     ...actual,
     createChannelInboundDebouncer: vi.fn((opts) => ({
       debouncer: {
-        enqueue: async (entry: unknown) => await opts.onFlush([entry]),
+        enqueue: async (entry: unknown) => {
+          if (!debouncerControl.holdEntries) {
+            await opts.onFlush([entry]);
+            return;
+          }
+          debouncerControl.entries.push(entry);
+          debouncerControl.flush = async () => {
+            const entries = debouncerControl.entries.splice(0);
+            await opts.onFlush(entries);
+          };
+        },
       },
     })),
     shouldDebounceTextInbound: vi.fn(() => false),
@@ -73,6 +93,7 @@ describe("iMessage monitor last-route updates", () => {
     readChannelAllowFromStoreMock.mockReset().mockResolvedValue([]);
     recordInboundSessionMock.mockClear();
     dispatchInboundMessageMock.mockClear();
+    debouncerControl.reset();
   });
 
   afterEach(() => {
@@ -212,6 +233,175 @@ describe("iMessage monitor last-route updates", () => {
 
     await vi.waitFor(async () => {
       expect((await loadIMessageCatchupCursor("default"))?.lastSeenRowid).toBe(77);
+    });
+  });
+
+  it("does not advance the live cursor after partial startup catchup", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-22T15:31:00.000Z"));
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imsg-partial-cursor-"));
+    tempDirs.push(stateDir);
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+
+    let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+    const client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method === "watch.subscribe") {
+          return { subscription: 1 };
+        }
+        if (method === "chats.list") {
+          return {
+            chats: [
+              { id: 1, last_message_at: "2026-05-22T15:15:00.000Z" },
+              { id: 2, last_message_at: "2026-05-22T15:15:00.000Z" },
+            ],
+          };
+        }
+        if (method === "messages.history") {
+          const p = params as { chat_id: number };
+          if (p.chat_id === 1) {
+            throw new Error("chat history unavailable");
+          }
+          return {
+            messages: [
+              {
+                id: 10,
+                guid: "CATCHUP-GUID-10",
+                chat_id: 2,
+                sender: "+15550001111",
+                is_from_me: false,
+                text: "catchup row",
+                is_group: false,
+                created_at: "2026-05-22T15:15:00.000Z",
+              },
+            ],
+          };
+        }
+        throw new Error(`unexpected imsg method ${method}`);
+      }),
+      waitForClose: vi.fn(async () => {
+        onNotification?.({
+          method: "message",
+          params: {
+            message: {
+              id: 77,
+              guid: "LIVE-GUID-77",
+              chat_id: 123,
+              sender: "+15550001111",
+              is_from_me: false,
+              text: "hello after partial catchup",
+              is_group: false,
+              created_at: "2026-05-22T15:30:00.000Z",
+            },
+          },
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+      }),
+      stop: vi.fn(async () => {}),
+    };
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      if (!params?.onNotification) {
+        throw new Error("expected iMessage notification handler");
+      }
+      onNotification = params.onNotification;
+      return client as never;
+    });
+
+    await monitorIMessageProvider({
+      config: {
+        channels: {
+          imessage: {
+            catchup: { enabled: true },
+            dmPolicy: "allowlist",
+            allowFrom: ["+15550001111"],
+          },
+        },
+        messages: { inbound: { debounceMs: 0 } },
+        session: { mainKey: "main" },
+      } as never,
+      runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+    });
+
+    await vi.waitFor(async () => {
+      expect((await loadIMessageCatchupCursor("default"))?.lastSeenRowid).toBe(10);
+    });
+  });
+
+  it("advances a coalesced live bucket to the highest source row", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imsg-coalesced-cursor-"));
+    tempDirs.push(stateDir);
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    debouncerControl.holdEntries = true;
+
+    let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+    const client = {
+      request: vi.fn(async (method: string) => {
+        if (method === "watch.subscribe") {
+          return { subscription: 1 };
+        }
+        if (method === "chats.list") {
+          return { chats: [] };
+        }
+        throw new Error(`unexpected imsg method ${method}`);
+      }),
+      waitForClose: vi.fn(async () => {
+        for (const row of [
+          { id: 77, guid: "LIVE-GUID-77", text: "Dump", created_at: "2026-05-22T15:30:00.000Z" },
+          {
+            id: 78,
+            guid: "LIVE-GUID-78",
+            text: "https://example.com",
+            created_at: "2026-05-22T15:30:01.000Z",
+          },
+        ]) {
+          onNotification?.({
+            method: "message",
+            params: {
+              message: {
+                ...row,
+                chat_id: 123,
+                sender: "+15550001111",
+                is_from_me: false,
+                is_group: false,
+              },
+            },
+          });
+        }
+        await vi.waitFor(() => {
+          expect(debouncerControl.flush).toBeDefined();
+        });
+        await debouncerControl.flush?.();
+        await Promise.resolve();
+      }),
+      stop: vi.fn(async () => {}),
+    };
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      if (!params?.onNotification) {
+        throw new Error("expected iMessage notification handler");
+      }
+      onNotification = params.onNotification;
+      return client as never;
+    });
+
+    await monitorIMessageProvider({
+      config: {
+        channels: {
+          imessage: {
+            catchup: { enabled: true },
+            coalesceSameSenderDms: true,
+            dmPolicy: "allowlist",
+            allowFrom: ["+15550001111"],
+          },
+        },
+        messages: { inbound: { debounceMs: 2500 } },
+        session: { mainKey: "main" },
+      } as never,
+      runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+    });
+
+    await vi.waitFor(async () => {
+      expect((await loadIMessageCatchupCursor("default"))?.lastSeenRowid).toBe(78);
     });
   });
 });

--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -97,6 +97,7 @@ describe("iMessage monitor last-route updates", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllEnvs();
     for (const dir of tempDirs.splice(0)) {
       fs.rmSync(dir, { recursive: true, force: true });
@@ -206,6 +207,93 @@ describe("iMessage monitor last-route updates", () => {
         await Promise.resolve();
         await Promise.resolve();
       }),
+      stop: vi.fn(async () => {}),
+    };
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      if (!params?.onNotification) {
+        throw new Error("expected iMessage notification handler");
+      }
+      onNotification = params.onNotification;
+      return client as never;
+    });
+
+    await monitorIMessageProvider({
+      config: {
+        channels: {
+          imessage: {
+            catchup: { enabled: true },
+            dmPolicy: "allowlist",
+            allowFrom: ["+15550001111"],
+          },
+        },
+        messages: { inbound: { debounceMs: 0 } },
+        session: { mainKey: "main" },
+      } as never,
+      runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+    });
+
+    await vi.waitFor(async () => {
+      expect((await loadIMessageCatchupCursor("default"))?.lastSeenRowid).toBe(77);
+    });
+  });
+
+  it("flushes live cursor advancement for rows handled while startup catchup is running", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-22T15:31:00.000Z"));
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imsg-live-during-catchup-"));
+    tempDirs.push(stateDir);
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+
+    let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+    const client = {
+      request: vi.fn(async (method: string, params: unknown) => {
+        if (method === "watch.subscribe") {
+          return { subscription: 1 };
+        }
+        if (method === "chats.list") {
+          return {
+            chats: [{ id: 1, last_message_at: "2026-05-22T15:15:00.000Z" }],
+          };
+        }
+        if (method === "messages.history") {
+          onNotification?.({
+            method: "message",
+            params: {
+              message: {
+                id: 77,
+                guid: "LIVE-GUID-77",
+                chat_id: 123,
+                sender: "+15550001111",
+                is_from_me: false,
+                text: "hello during catchup",
+                is_group: false,
+                created_at: "2026-05-22T15:30:00.000Z",
+              },
+            },
+          });
+          await vi.waitFor(() => {
+            expect(dispatchInboundMessageMock).toHaveBeenCalled();
+          });
+          const p = params as { chat_id: number };
+          expect(p.chat_id).toBe(1);
+          return {
+            messages: [
+              {
+                id: 10,
+                guid: "CATCHUP-GUID-10",
+                chat_id: 1,
+                sender: "+15550001111",
+                is_from_me: false,
+                text: "catchup row",
+                is_group: false,
+                created_at: "2026-05-22T15:15:00.000Z",
+              },
+            ],
+          };
+        }
+        throw new Error(`unexpected imsg method ${method}`);
+      }),
+      waitForClose: vi.fn(async () => {}),
       stop: vi.fn(async () => {}),
     };
     createIMessageRpcClientMock.mockImplementation(async (params) => {

--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -1,8 +1,12 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import type { waitForTransportReady } from "openclaw/plugin-sdk/transport-ready-runtime";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { createIMessageRpcClient } from "./client.js";
 import { monitorIMessageProvider } from "./monitor.js";
+import { loadIMessageCatchupCursor } from "./monitor/catchup.js";
 
 const waitForTransportReadyMock = vi.hoisted(() =>
   vi.fn<typeof waitForTransportReady>(async () => {}),
@@ -61,12 +65,21 @@ vi.mock("./monitor/abort-handler.js", () => ({
 }));
 
 describe("iMessage monitor last-route updates", () => {
+  const tempDirs: string[] = [];
+
   beforeEach(() => {
     waitForTransportReadyMock.mockReset().mockResolvedValue(undefined);
     createIMessageRpcClientMock.mockReset();
     readChannelAllowFromStoreMock.mockReset().mockResolvedValue([]);
     recordInboundSessionMock.mockClear();
     dispatchInboundMessageMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("keeps per-channel-peer direct-message last-route writes on the isolated session", async () => {
@@ -135,5 +148,70 @@ describe("iMessage monitor last-route updates", () => {
     expect(recordParams?.updateLastRoute?.channel).toBe("imessage");
     expect(recordParams?.updateLastRoute?.to).toBe("+15550001111");
     expect(recordParams?.updateLastRoute?.mainDmOwnerPin).toBeUndefined();
+  });
+
+  it("advances the catchup cursor after startup catchup succeeds and a live row is handled", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imsg-live-cursor-"));
+    tempDirs.push(stateDir);
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+
+    let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+    const client = {
+      request: vi.fn(async (method: string) => {
+        if (method === "watch.subscribe") {
+          return { subscription: 1 };
+        }
+        if (method === "chats.list") {
+          return { chats: [] };
+        }
+        throw new Error(`unexpected imsg method ${method}`);
+      }),
+      waitForClose: vi.fn(async () => {
+        onNotification?.({
+          method: "message",
+          params: {
+            message: {
+              id: 77,
+              guid: "LIVE-GUID-77",
+              chat_id: 123,
+              sender: "+15550001111",
+              is_from_me: false,
+              text: "hello after catchup",
+              is_group: false,
+              created_at: "2026-05-22T15:30:00.000Z",
+            },
+          },
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+      }),
+      stop: vi.fn(async () => {}),
+    };
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      if (!params?.onNotification) {
+        throw new Error("expected iMessage notification handler");
+      }
+      onNotification = params.onNotification;
+      return client as never;
+    });
+
+    await monitorIMessageProvider({
+      config: {
+        channels: {
+          imessage: {
+            catchup: { enabled: true },
+            dmPolicy: "allowlist",
+            allowFrom: ["+15550001111"],
+          },
+        },
+        messages: { inbound: { debounceMs: 0 } },
+        session: { mainKey: "main" },
+      } as never,
+      runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+    });
+
+    await vi.waitFor(async () => {
+      expect((await loadIMessageCatchupCursor("default"))?.lastSeenRowid).toBe(77);
+    });
   });
 });

--- a/extensions/imessage/src/monitor/catchup-bridge.test.ts
+++ b/extensions/imessage/src/monitor/catchup-bridge.test.ts
@@ -107,6 +107,7 @@ describe("runIMessageCatchup", () => {
     });
 
     expect(summary.querySucceeded).toBe(true);
+    expect(summary.fullyCaughtUp).toBe(true);
     expect(summary.replayed).toBe(3);
     expect(dispatched.map((m) => m.guid)).toEqual(["g-100", "g-101", "g-102"]);
     expect(calls[0]?.method).toBe("chats.list");
@@ -177,6 +178,7 @@ describe("runIMessageCatchup", () => {
     });
 
     expect(summary.querySucceeded).toBe(false);
+    expect(summary.fullyCaughtUp).toBe(false);
     expect(summary.replayed).toBe(0);
   });
 
@@ -220,6 +222,7 @@ describe("runIMessageCatchup", () => {
     });
 
     expect(summary.querySucceeded).toBe(true);
+    expect(summary.fullyCaughtUp).toBe(false);
     expect(summary.replayed).toBe(1);
     expect(dispatched).toEqual(["g-300"]);
   });
@@ -267,6 +270,7 @@ describe("runIMessageCatchup", () => {
     });
 
     expect(summary.fetchedCount).toBe(5);
+    expect(summary.fullyCaughtUp).toBe(false);
     expect(summary.replayed).toBe(5);
     // Oldest-first by rowid: 100, 101, 102, 103, 200 (chat 1's first 4, then chat 2's first).
     expect(dispatched).toEqual(["g-100", "g-101", "g-102", "g-103", "g-200"]);

--- a/extensions/imessage/src/monitor/catchup-bridge.ts
+++ b/extensions/imessage/src/monitor/catchup-bridge.ts
@@ -103,6 +103,7 @@ export async function runIMessageCatchup(
     const sinceISO = new Date(sinceMs).toISOString();
     const collected: IMessageCatchupRow[] = [];
     const perChatLimit = Math.min(limit, PER_CHAT_HISTORY_LIMIT_CAP);
+    let historyFetchFailed = false;
     // Track the highest rowid / date the imsg bridge actually returned across
     // all chats, regardless of whether each row passed the parser. The catchup
     // loop uses this as a cursor-advance floor so an unparseable row (corrupt
@@ -140,6 +141,7 @@ export async function runIMessageCatchup(
       } catch (err) {
         // Best-effort per chat. A single broken chat must not poison the
         // whole pass — drop and continue.
+        historyFetchFailed = true;
         warnLog(`imessage catchup: messages.history failed for chat_id=${chatId}: ${String(err)}`);
         continue;
       }
@@ -237,6 +239,7 @@ export async function runIMessageCatchup(
     return {
       resolved: true,
       rows: capped,
+      fullyCaughtUp: !historyFetchFailed && !isCapTruncated,
       ...(Number.isFinite(effectiveWatermarkRowid)
         ? { highWatermarkRowid: effectiveWatermarkRowid }
         : {}),

--- a/extensions/imessage/src/monitor/catchup.test.ts
+++ b/extensions/imessage/src/monitor/catchup.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  advanceIMessageCatchupCursor,
   capFailureRetriesMap,
   loadIMessageCatchupCursor,
   performIMessageCatchup,
@@ -122,6 +123,56 @@ describe("loadIMessageCatchupCursor / saveIMessageCatchupCursor", () => {
     await saveIMessageCatchupCursor("b", { lastSeenMs: 200, lastSeenRowid: 2 });
     expect((await loadIMessageCatchupCursor("a"))?.lastSeenRowid).toBe(1);
     expect((await loadIMessageCatchupCursor("b"))?.lastSeenRowid).toBe(2);
+  });
+
+  it("advances monotonically from a live-handled row and preserves given-up retry state", async () => {
+    const config = resolveCatchupConfig({ enabled: true, maxFailureRetries: 3 });
+    await saveIMessageCatchupCursor("primary", {
+      lastSeenMs: 1_700_000_000_000,
+      lastSeenRowid: 42,
+      failureRetries: { "GIVEN-UP": 3 },
+    });
+
+    await expect(
+      advanceIMessageCatchupCursor(
+        "primary",
+        { lastSeenMs: 1_700_000_001_000, lastSeenRowid: 41 },
+        config,
+      ),
+    ).resolves.toBe(false);
+    await expect(
+      advanceIMessageCatchupCursor(
+        "primary",
+        { lastSeenMs: 1_700_000_002_000, lastSeenRowid: 50 },
+        config,
+      ),
+    ).resolves.toBe(true);
+
+    const cursor = await loadIMessageCatchupCursor("primary");
+    expect(cursor?.lastSeenRowid).toBe(50);
+    expect(cursor?.lastSeenMs).toBe(1_700_000_002_000);
+    expect(cursor?.failureRetries).toEqual({ "GIVEN-UP": 3 });
+  });
+
+  it("does not advance from live rows while a catchup failure is still retrying", async () => {
+    const config = resolveCatchupConfig({ enabled: true, maxFailureRetries: 3 });
+    await saveIMessageCatchupCursor("primary", {
+      lastSeenMs: 1_700_000_000_000,
+      lastSeenRowid: 42,
+      failureRetries: { RETRYING: 1 },
+    });
+
+    await expect(
+      advanceIMessageCatchupCursor(
+        "primary",
+        { lastSeenMs: 1_700_000_002_000, lastSeenRowid: 50 },
+        config,
+      ),
+    ).resolves.toBe(false);
+
+    const cursor = await loadIMessageCatchupCursor("primary");
+    expect(cursor?.lastSeenRowid).toBe(42);
+    expect(cursor?.failureRetries).toEqual({ RETRYING: 1 });
   });
 });
 

--- a/extensions/imessage/src/monitor/catchup.test.ts
+++ b/extensions/imessage/src/monitor/catchup.test.ts
@@ -154,6 +154,35 @@ describe("loadIMessageCatchupCursor / saveIMessageCatchupCursor", () => {
     expect(cursor?.failureRetries).toEqual({ "GIVEN-UP": 3 });
   });
 
+  it("serializes concurrent live cursor advances so a lower row cannot overwrite a higher row", async () => {
+    const config = resolveCatchupConfig({ enabled: true, maxFailureRetries: 3 });
+    await saveIMessageCatchupCursor("primary", {
+      lastSeenMs: 1_700_000_000_000,
+      lastSeenRowid: 10,
+    });
+
+    const results = await Promise.all([
+      advanceIMessageCatchupCursor(
+        "primary",
+        { lastSeenMs: 1_700_000_050_000, lastSeenRowid: 50 },
+        config,
+      ),
+      ...Array.from({ length: 24 }, (_, index) =>
+        advanceIMessageCatchupCursor(
+          "primary",
+          { lastSeenMs: 1_700_000_011_000 + index, lastSeenRowid: 11 + index },
+          config,
+        ),
+      ),
+    ]);
+
+    expect(results[0]).toBe(true);
+    expect(results.slice(1).every((advanced) => !advanced)).toBe(true);
+    const cursor = await loadIMessageCatchupCursor("primary");
+    expect(cursor?.lastSeenRowid).toBe(50);
+    expect(cursor?.lastSeenMs).toBe(1_700_000_050_000);
+  });
+
   it("does not advance from live rows while a catchup failure is still retrying", async () => {
     const config = resolveCatchupConfig({ enabled: true, maxFailureRetries: 3 });
     await saveIMessageCatchupCursor("primary", {

--- a/extensions/imessage/src/monitor/catchup.ts
+++ b/extensions/imessage/src/monitor/catchup.ts
@@ -1,5 +1,7 @@
 import { createHash } from "node:crypto";
 import path from "node:path";
+import type { FileLockOptions } from "openclaw/plugin-sdk/file-lock";
+import { withFileLock } from "openclaw/plugin-sdk/file-lock";
 import { readJsonFileWithFallback, writeJsonFileAtomically } from "openclaw/plugin-sdk/json-store";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
@@ -27,6 +29,17 @@ const MAX_MAX_FAILURE_RETRIES = 1_000;
 // should not balloon the cursor file. When over the bound, keep only the
 // highest-count entries (closest to give-up) and drop the rest.
 const MAX_FAILURE_RETRY_MAP_SIZE = 5_000;
+const CATCHUP_CURSOR_LOCK_OPTIONS: FileLockOptions = {
+  retries: {
+    retries: 6,
+    factor: 1.35,
+    minTimeout: 8,
+    maxTimeout: 180,
+    randomize: true,
+  },
+  stale: 60_000,
+};
+const cursorWriteQueues = new Map<string, Promise<unknown>>();
 
 export type IMessageCatchupConfig = {
   enabled?: boolean;
@@ -115,6 +128,20 @@ function resolveCursorFilePath(accountId: string): string {
   return path.join(resolveStateDirFromEnv(), "imessage", "catchup", `${safePrefix}__${hash}.json`);
 }
 
+function enqueueCursorWrite<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
+  const prev = cursorWriteQueues.get(filePath) ?? Promise.resolve();
+  const next = prev.then(fn, fn);
+  cursorWriteQueues.set(filePath, next);
+  next
+    .finally(() => {
+      if (cursorWriteQueues.get(filePath) === next) {
+        cursorWriteQueues.delete(filePath);
+      }
+    })
+    .catch(() => {});
+  return next;
+}
+
 function sanitizeFailureRetriesInput(raw: unknown): Record<string, number> {
   if (!raw || typeof raw !== "object") {
     return {};
@@ -142,6 +169,12 @@ export async function loadIMessageCatchupCursor(
   accountId: string,
 ): Promise<IMessageCatchupCursor | null> {
   const filePath = resolveCursorFilePath(accountId);
+  return await loadIMessageCatchupCursorFromPath(filePath);
+}
+
+async function loadIMessageCatchupCursorFromPath(
+  filePath: string,
+): Promise<IMessageCatchupCursor | null> {
   const { value } = await readJsonFileWithFallback<IMessageCatchupCursor | null>(filePath, null);
   if (!value || typeof value !== "object") {
     return null;
@@ -167,6 +200,13 @@ export async function saveIMessageCatchupCursor(
   next: { lastSeenMs: number; lastSeenRowid: number; failureRetries?: Record<string, number> },
 ): Promise<void> {
   const filePath = resolveCursorFilePath(accountId);
+  await saveIMessageCatchupCursorToPath(filePath, next);
+}
+
+async function saveIMessageCatchupCursorToPath(
+  filePath: string,
+  next: { lastSeenMs: number; lastSeenRowid: number; failureRetries?: Record<string, number> },
+): Promise<void> {
   const sanitized = sanitizeFailureRetriesInput(next.failureRetries);
   const hasRetries = Object.keys(sanitized).length > 0;
   const cursor: IMessageCatchupCursor = {
@@ -289,24 +329,29 @@ export async function advanceIMessageCatchupCursor(
     return false;
   }
 
-  const cursor = await loadIMessageCatchupCursor(accountId);
-  if (cursor && next.lastSeenRowid <= cursor.lastSeenRowid) {
-    return false;
-  }
+  const filePath = resolveCursorFilePath(accountId);
+  return await enqueueCursorWrite(filePath, () =>
+    withFileLock(filePath, CATCHUP_CURSOR_LOCK_OPTIONS, async () => {
+      const cursor = await loadIMessageCatchupCursorFromPath(filePath);
+      if (cursor && next.lastSeenRowid <= cursor.lastSeenRowid) {
+        return false;
+      }
 
-  const blockingFailure = Object.values(cursor?.failureRetries ?? {}).some(
-    (count) => count < config.maxFailureRetries,
+      const blockingFailure = Object.values(cursor?.failureRetries ?? {}).some(
+        (count) => count < config.maxFailureRetries,
+      );
+      if (blockingFailure) {
+        return false;
+      }
+
+      await saveIMessageCatchupCursorToPath(filePath, {
+        lastSeenMs: Math.max(cursor?.lastSeenMs ?? next.lastSeenMs, next.lastSeenMs),
+        lastSeenRowid: next.lastSeenRowid,
+        failureRetries: cursor?.failureRetries,
+      });
+      return true;
+    }),
   );
-  if (blockingFailure) {
-    return false;
-  }
-
-  await saveIMessageCatchupCursor(accountId, {
-    lastSeenMs: Math.max(cursor?.lastSeenMs ?? next.lastSeenMs, next.lastSeenMs),
-    lastSeenRowid: next.lastSeenRowid,
-    failureRetries: cursor?.failureRetries,
-  });
-  return true;
 }
 
 /**

--- a/extensions/imessage/src/monitor/catchup.ts
+++ b/extensions/imessage/src/monitor/catchup.ts
@@ -68,6 +68,7 @@ export type IMessageCatchupRow = {
 
 export type IMessageCatchupSummary = {
   querySucceeded: boolean;
+  fullyCaughtUp: boolean;
   fetchedCount: number;
   replayed: number;
   skippedFromMe: number;
@@ -259,6 +260,12 @@ export type CatchupFetchFn = (params: {
   highWatermarkRowid?: number;
   /** Companion to `highWatermarkRowid` — highest `date` seen in the raw response. */
   highWatermarkMs?: number;
+  /**
+   * True when the fetcher reached every eligible source row for this pass.
+   * False means a best-effort partial pass occurred (for example one chat
+   * history fetch failed, or the global cap left rows for a later startup).
+   */
+  fullyCaughtUp?: boolean;
 }>;
 
 export type CatchupDispatchFn = (row: IMessageCatchupRow) => Promise<{ ok: boolean }>;
@@ -328,6 +335,7 @@ export async function performIMessageCatchup(
 
   const summary: IMessageCatchupSummary = {
     querySucceeded: false,
+    fullyCaughtUp: false,
     fetchedCount: 0,
     replayed: 0,
     skippedFromMe: 0,
@@ -362,6 +370,7 @@ export async function performIMessageCatchup(
     return summary;
   }
   summary.querySucceeded = true;
+  summary.fullyCaughtUp = fetchResult.fullyCaughtUp !== false;
   summary.fetchedCount = fetchResult.rows.length;
 
   // Stable order: process oldest-first so the cursor advances monotonically

--- a/extensions/imessage/src/monitor/catchup.ts
+++ b/extensions/imessage/src/monitor/catchup.ts
@@ -273,6 +273,35 @@ export type PerformCatchupParams = {
   warn?: (message: string) => void;
 };
 
+export async function advanceIMessageCatchupCursor(
+  accountId: string,
+  next: { lastSeenMs: number; lastSeenRowid: number },
+  config: ResolvedCatchupConfig,
+): Promise<boolean> {
+  if (!Number.isFinite(next.lastSeenMs) || !Number.isFinite(next.lastSeenRowid)) {
+    return false;
+  }
+
+  const cursor = await loadIMessageCatchupCursor(accountId);
+  if (cursor && next.lastSeenRowid <= cursor.lastSeenRowid) {
+    return false;
+  }
+
+  const blockingFailure = Object.values(cursor?.failureRetries ?? {}).some(
+    (count) => count < config.maxFailureRetries,
+  );
+  if (blockingFailure) {
+    return false;
+  }
+
+  await saveIMessageCatchupCursor(accountId, {
+    lastSeenMs: Math.max(cursor?.lastSeenMs ?? next.lastSeenMs, next.lastSeenMs),
+    lastSeenRowid: next.lastSeenRowid,
+    failureRetries: cursor?.failureRetries,
+  });
+  return true;
+}
+
 /**
  * One catchup pass. Loads the cursor, fetches `messages.history`, replays
  * each row through `dispatch`, advances the cursor on success / give-up,

--- a/extensions/imessage/src/monitor/coalesce.test.ts
+++ b/extensions/imessage/src/monitor/coalesce.test.ts
@@ -34,8 +34,14 @@ describe("combineIMessagePayloads", () => {
   });
 
   it("merges Dump + URL split-send into one payload anchored on the first GUID", () => {
-    const text = makePayload({ text: "Dump", guid: "row-1", created_at: "2025-01-01T00:00:00Z" });
+    const text = makePayload({
+      id: 41,
+      text: "Dump",
+      guid: "row-1",
+      created_at: "2025-01-01T00:00:00Z",
+    });
     const balloon = makePayload({
+      id: 42,
       text: "https://example.com/article",
       guid: "row-2",
       created_at: "2025-01-01T00:00:01.500Z",
@@ -46,6 +52,10 @@ describe("combineIMessagePayloads", () => {
     expect(merged.guid).toBe("row-1");
     expect(merged.created_at).toBe("2025-01-01T00:00:01.500Z");
     expect(merged.coalescedMessageGuids).toEqual(["row-1", "row-2"]);
+    expect(merged.coalescedCatchupCursor).toEqual({
+      lastSeenMs: Date.parse("2025-01-01T00:00:01.500Z"),
+      lastSeenRowid: 42,
+    });
   });
 
   it("preserves attachments instead of dropping them on merge", () => {
@@ -99,7 +109,12 @@ describe("combineIMessagePayloads", () => {
 
   it("keeps first + most recent when entry count exceeds the cap, but tracks every GUID", () => {
     const payloads = Array.from({ length: 25 }, (_, i) =>
-      makePayload({ text: `msg ${i}`, guid: `row-${i}` }),
+      makePayload({
+        id: i,
+        text: `msg ${i}`,
+        guid: `row-${i}`,
+        created_at: new Date(Date.UTC(2025, 0, 1, 0, 0, i)).toISOString(),
+      }),
     );
     const merged = combineIMessagePayloads(payloads);
 
@@ -113,6 +128,7 @@ describe("combineIMessagePayloads", () => {
     expect(merged.text).toContain("msg 0");
     expect(merged.text).toContain("msg 24");
     expect(merged.text).not.toContain("msg 10"); // dropped by cap
+    expect(merged.coalescedCatchupCursor?.lastSeenRowid).toBe(24);
   });
 
   it("preserves reply context from any entry that carries one", () => {

--- a/extensions/imessage/src/monitor/coalesce.ts
+++ b/extensions/imessage/src/monitor/coalesce.ts
@@ -23,6 +23,10 @@ export type CoalescedIMessagePayload = IMessagePayload & {
    * dedupe paths can still recognize them.
    */
   coalescedMessageGuids?: string[];
+  coalescedCatchupCursor?: {
+    lastSeenMs: number;
+    lastSeenRowid: number;
+  };
 };
 
 /**
@@ -91,6 +95,19 @@ export function combineIMessagePayloads(payloads: IMessagePayload[]): CoalescedI
   const latestCreatedAt =
     createdAts.length > 0 ? createdAts.reduce((a, b) => (a > b ? a : b)) : first.created_at;
 
+  let maxRowid = -Infinity;
+  let maxDateMs = -Infinity;
+  for (const payload of payloads) {
+    if (typeof payload.id === "number" && Number.isFinite(payload.id)) {
+      maxRowid = Math.max(maxRowid, payload.id);
+    }
+    const dateMs =
+      typeof payload.created_at === "string" ? Date.parse(payload.created_at) : Number.NaN;
+    if (Number.isFinite(dateMs)) {
+      maxDateMs = Math.max(maxDateMs, dateMs);
+    }
+  }
+
   // Walk the unbounded `payloads` so even GUIDs whose text/attachments were
   // dropped by the cap are still remembered for downstream dedupe.
   const seenGuids = new Set<string>();
@@ -118,5 +135,9 @@ export function combineIMessagePayloads(payloads: IMessagePayload[]): CoalescedI
     reply_to_text: entryWithReply?.reply_to_text ?? first.reply_to_text ?? null,
     reply_to_sender: entryWithReply?.reply_to_sender ?? first.reply_to_sender ?? null,
     coalescedMessageGuids: coalescedMessageGuids.length > 0 ? coalescedMessageGuids : undefined,
+    coalescedCatchupCursor:
+      Number.isFinite(maxRowid) && Number.isFinite(maxDateMs)
+        ? { lastSeenMs: maxDateMs, lastSeenRowid: maxRowid }
+        : undefined,
   };
 }

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -52,7 +52,7 @@ import { sendMessageIMessage } from "../send.js";
 import { normalizeIMessageHandle } from "../targets.js";
 import { attachIMessageMonitorAbortHandler } from "./abort-handler.js";
 import { runIMessageCatchup } from "./catchup-bridge.js";
-import { resolveCatchupConfig } from "./catchup.js";
+import { advanceIMessageCatchupCursor, resolveCatchupConfig } from "./catchup.js";
 import { combineIMessagePayloads } from "./coalesce.js";
 import { createIMessageEchoCachingSend, deliverReplies } from "./deliver.js";
 import { createSentMessageCache } from "./echo-cache.js";
@@ -214,6 +214,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     log: (message) => runtime.log?.(warn(message)),
   });
   const dmPolicy = imessageCfg.dmPolicy ?? "pairing";
+  const catchupCfg = resolveCatchupConfig(imessageCfg.catchup);
   const includeAttachments = opts.includeAttachments ?? imessageCfg.includeAttachments ?? false;
   const mediaMaxBytes = (opts.mediaMaxMb ?? imessageCfg.mediaMaxMb ?? 16) * 1024 * 1024;
   const cliPath = opts.cliPath ?? imessageCfg.cliPath ?? "imsg";
@@ -343,6 +344,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
 
   let client: IMessageRpcClient | undefined;
   let detachAbortHandler = () => {};
+  let liveCatchupCursorAdvanceEnabled = false;
   const getActiveClient = () => {
     if (!client) {
       throw new Error("imessage monitor client not initialized");
@@ -350,7 +352,38 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     return client;
   };
 
-  async function handleMessageNow(message: IMessagePayload) {
+  async function maybeAdvanceLiveCatchupCursor(message: IMessagePayload): Promise<void> {
+    if (!catchupCfg.enabled || !liveCatchupCursorAdvanceEnabled) {
+      return;
+    }
+    const rowid = typeof message.id === "number" && Number.isFinite(message.id) ? message.id : null;
+    const dateMs =
+      typeof message.created_at === "string" ? Date.parse(message.created_at) : Number.NaN;
+    if (rowid === null || !Number.isFinite(dateMs)) {
+      return;
+    }
+    try {
+      await advanceIMessageCatchupCursor(
+        accountInfo.accountId,
+        { lastSeenMs: dateMs, lastSeenRowid: rowid },
+        catchupCfg,
+      );
+    } catch (err) {
+      runtime.error?.(`imessage catchup: failed to advance live cursor: ${String(err)}`);
+    }
+  }
+
+  async function handleMessageNow(
+    message: IMessagePayload,
+    options: { advanceCatchupCursor?: boolean } = {},
+  ) {
+    await handleMessageNowInner(message);
+    if (options.advanceCatchupCursor !== false) {
+      await maybeAdvanceLiveCatchupCursor(message);
+    }
+  }
+
+  async function handleMessageNowInner(message: IMessagePayload) {
     const messageText = (message.text ?? "").trim();
 
     const attachments = includeAttachments ? (message.attachments ?? []) : [];
@@ -907,10 +940,9 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   // `handleMessage` -> `handleMessageNow`; the inbound-dedupe cache absorbs
   // any overlap with replayed rows. Disabled by default — opt-in via
   // `channels.imessage.catchup.enabled`. See issue #78649.
-  const catchupCfg = resolveCatchupConfig(imessageCfg.catchup);
   if (catchupCfg.enabled && !abort?.aborted) {
     try {
-      await runIMessageCatchup({
+      const catchupSummary = await runIMessageCatchup({
         client: activeClient,
         accountId: accountInfo.accountId,
         config: catchupCfg,
@@ -920,9 +952,10 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         // from before the gateway gap therefore arrive as separate turns
         // rather than coalesced. Live notifications continue to flow through
         // the debouncer.
-        dispatchPayload: (message) => handleMessageNow(message),
+        dispatchPayload: (message) => handleMessageNow(message, { advanceCatchupCursor: false }),
         runtime,
       });
+      liveCatchupCursorAdvanceEnabled = catchupSummary.querySucceeded;
     } catch (err) {
       // Catchup is opt-in recovery — surface the error but do not block the
       // monitor. The live dispatch loop is already up and running.

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -356,9 +356,24 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     if (!catchupCfg.enabled || !liveCatchupCursorAdvanceEnabled) {
       return;
     }
-    const rowid = typeof message.id === "number" && Number.isFinite(message.id) ? message.id : null;
+    const coalescedCursor = (
+      message as {
+        coalescedCatchupCursor?: { lastSeenMs?: unknown; lastSeenRowid?: unknown };
+      }
+    ).coalescedCatchupCursor;
+    const rowid =
+      typeof coalescedCursor?.lastSeenRowid === "number" &&
+      Number.isFinite(coalescedCursor.lastSeenRowid)
+        ? coalescedCursor.lastSeenRowid
+        : typeof message.id === "number" && Number.isFinite(message.id)
+          ? message.id
+          : null;
     const dateMs =
-      typeof message.created_at === "string" ? Date.parse(message.created_at) : Number.NaN;
+      typeof coalescedCursor?.lastSeenMs === "number" && Number.isFinite(coalescedCursor.lastSeenMs)
+        ? coalescedCursor.lastSeenMs
+        : typeof message.created_at === "string"
+          ? Date.parse(message.created_at)
+          : Number.NaN;
     if (rowid === null || !Number.isFinite(dateMs)) {
       return;
     }
@@ -955,7 +970,8 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         dispatchPayload: (message) => handleMessageNow(message, { advanceCatchupCursor: false }),
         runtime,
       });
-      liveCatchupCursorAdvanceEnabled = catchupSummary.querySucceeded;
+      liveCatchupCursorAdvanceEnabled =
+        catchupSummary.querySucceeded && catchupSummary.fullyCaughtUp;
     } catch (err) {
       // Catchup is opt-in recovery — surface the error but do not block the
       // monitor. The live dispatch loop is already up and running.

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -345,6 +345,8 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   let client: IMessageRpcClient | undefined;
   let detachAbortHandler = () => {};
   let liveCatchupCursorAdvanceEnabled = false;
+  let startupCatchupInProgress = false;
+  const pendingLiveCatchupCursorAdvances: Array<{ lastSeenMs: number; lastSeenRowid: number }> = [];
   const getActiveClient = () => {
     if (!client) {
       throw new Error("imessage monitor client not initialized");
@@ -352,10 +354,9 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     return client;
   };
 
-  async function maybeAdvanceLiveCatchupCursor(message: IMessagePayload): Promise<void> {
-    if (!catchupCfg.enabled || !liveCatchupCursorAdvanceEnabled) {
-      return;
-    }
+  function resolveLiveCatchupCursor(
+    message: IMessagePayload,
+  ): { lastSeenMs: number; lastSeenRowid: number } | null {
     const coalescedCursor = (
       message as {
         coalescedCatchupCursor?: { lastSeenMs?: unknown; lastSeenRowid?: unknown };
@@ -375,16 +376,39 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
           ? Date.parse(message.created_at)
           : Number.NaN;
     if (rowid === null || !Number.isFinite(dateMs)) {
+      return null;
+    }
+    return { lastSeenMs: dateMs, lastSeenRowid: rowid };
+  }
+
+  async function maybeAdvanceLiveCatchupCursor(message: IMessagePayload): Promise<void> {
+    if (!catchupCfg.enabled) {
+      return;
+    }
+    const cursor = resolveLiveCatchupCursor(message);
+    if (!cursor) {
+      return;
+    }
+    if (!liveCatchupCursorAdvanceEnabled) {
+      if (startupCatchupInProgress) {
+        pendingLiveCatchupCursorAdvances.push(cursor);
+      }
       return;
     }
     try {
-      await advanceIMessageCatchupCursor(
-        accountInfo.accountId,
-        { lastSeenMs: dateMs, lastSeenRowid: rowid },
-        catchupCfg,
-      );
+      await advanceIMessageCatchupCursor(accountInfo.accountId, cursor, catchupCfg);
     } catch (err) {
       runtime.error?.(`imessage catchup: failed to advance live cursor: ${String(err)}`);
+    }
+  }
+
+  async function flushPendingLiveCatchupCursorAdvances(): Promise<void> {
+    for (const cursor of pendingLiveCatchupCursorAdvances.splice(0)) {
+      try {
+        await advanceIMessageCatchupCursor(accountInfo.accountId, cursor, catchupCfg);
+      } catch (err) {
+        runtime.error?.(`imessage catchup: failed to advance pending live cursor: ${String(err)}`);
+      }
     }
   }
 
@@ -956,6 +980,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   // any overlap with replayed rows. Disabled by default — opt-in via
   // `channels.imessage.catchup.enabled`. See issue #78649.
   if (catchupCfg.enabled && !abort?.aborted) {
+    startupCatchupInProgress = true;
     try {
       const catchupSummary = await runIMessageCatchup({
         client: activeClient,
@@ -972,10 +997,18 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       });
       liveCatchupCursorAdvanceEnabled =
         catchupSummary.querySucceeded && catchupSummary.fullyCaughtUp;
+      if (liveCatchupCursorAdvanceEnabled) {
+        await flushPendingLiveCatchupCursorAdvances();
+      } else {
+        pendingLiveCatchupCursorAdvances.length = 0;
+      }
     } catch (err) {
+      pendingLiveCatchupCursorAdvances.length = 0;
       // Catchup is opt-in recovery — surface the error but do not block the
       // monitor. The live dispatch loop is already up and running.
       runtime.error?.(`imessage catchup: pass failed: ${String(err)}`);
+    } finally {
+      startupCatchupInProgress = false;
     }
   }
 


### PR DESCRIPTION
Fixes #85363

## Summary
- After iMessage startup catchup completes successfully, subsequent live-handled rows now advance the persisted catchup cursor.
- Catchup replay dispatches bypass the live cursor writer so the catchup loop remains responsible for retry/hold semantics.
- Live cursor writes are conservative: they are monotonic, preserve retry state, and refuse to jump ahead while any catchup failure is still below `maxFailureRetries`.

## Real behavior proof
**Behavior addressed:** A live iMessage notification handled after successful startup catchup now advances the persisted catchup cursor, so the same already-handled live row is not replayed again on the next catchup pass.

**Real environment tested:** Local OpenClaw checkout on macOS, branch `fix/imessage-live-catchup-cursor-85363`. The tests exercise the real catchup cursor store and monitor startup flow with real temporary OpenClaw state files; the `imsg` JSON-RPC boundary is simulated so the monitor receives deterministic `watch.subscribe`, `chats.list`, and live notification data.

**Exact steps or command run after this patch:**
```bash
pnpm docs:list
node scripts/run-vitest.mjs extensions/imessage/src/monitor/catchup.test.ts extensions/imessage/src/monitor/catchup-bridge.test.ts
node scripts/run-vitest.mjs extensions/imessage/src/monitor/monitor-provider.echo-cache.test.ts extensions/imessage/src/monitor.last-route.test.ts extensions/imessage/src/monitor.watch-subscribe-retry.test.ts extensions/imessage/src/monitor.plugin-payload.test.ts extensions/imessage/src/monitor.media-policy.test.ts
pnpm exec oxfmt --write --threads=1 extensions/imessage/src/monitor/catchup.ts extensions/imessage/src/monitor/catchup.test.ts extensions/imessage/src/monitor/monitor-provider.ts extensions/imessage/src/monitor.last-route.test.ts docs/channels/imessage.md
git diff --check
git log --format='%h %an <%ae> %s' upstream/main..HEAD
```

**Evidence after fix:** Terminal capture from the local OpenClaw checkout after the patch:
```text
RUN  v4.1.7 /Users/andy/openclaw/openclaw-85363

Test Files  2 passed (2)
Tests  31 passed (31)
Start at  11:10:47
Duration  552ms (transform 95ms, setup 101ms, import 51ms, tests 323ms, environment 0ms)

RUN  v4.1.7 /Users/andy/openclaw/openclaw-85363

Test Files  5 passed (5)
Tests  15 passed (15)
Start at  11:10:47
Duration  3.64s (transform 1.33s, setup 99ms, import 3.32s, tests 139ms, environment 0ms)

Finished in 171ms on 5 files using 1 threads.

936a0a6932 Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> Advance iMessage catchup cursor after live handling
```

**Observed result after fix:** `advanceIMessageCatchupCursor` moves the cursor forward for newer live rows, preserves given-up retry entries, and refuses to advance when a below-threshold catchup failure is still retrying. `monitorIMessageProvider` persists a live rowid after successful startup catchup and a handled live notification; the regression test reads `lastSeenRowid=77` from the catchup cursor file. Existing catchup bridge behavior, echo-cache behavior, startup retry behavior, plugin payload handling, media policy, and last-route behavior remain green.

**What was not tested:** I did not run a live macOS Messages/iMessage daemon restart against a real Apple Messages database in this branch. The proof uses the monitor and catchup code paths directly with deterministic `imsg` RPC data and real cursor files in a temp OpenClaw state directory.

## Attribution note
If maintainers squash or rework this PR, please preserve author attribution or include:
Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>
