### PR TITLE
feat(whatsapp): support thumb approval reactions

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -185,6 +185,7 @@
     "node_modules/",
     "patches/",
     "pnpm-lock.yaml",
+    "scripts/secrets/",
     "skills/",
     "src/auto-reply/reply/export-html/template.js",
     "src/canvas-host/a2ui/a2ui.bundle.js",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -185,7 +185,6 @@
     "node_modules/",
     "patches/",
     "pnpm-lock.yaml",
-    "scripts/secrets/",
     "skills/",
     "src/auto-reply/reply/export-html/template.js",
     "src/canvas-host/a2ui/a2ui.bundle.js",

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -177,7 +177,7 @@ handoff path over manual terminal capture.
 
 ## Approval prompts
 
-WhatsApp can render exec and plugin approval prompts with numeric emoji reactions, but the
+WhatsApp can render exec and plugin approval prompts with `👍` / `👎` reactions, but the
 channel does not have a `channels.whatsapp.execApprovals` config block. Delivery is controlled by
 the top-level approval forwarding config instead:
 
@@ -203,9 +203,10 @@ and routes to WhatsApp. Session mode delivers native emoji approvals only for ap
 originate from WhatsApp. Target mode uses the shared forwarding pipeline for explicit WhatsApp
 targets and does not create separate approver-DM fanout.
 
-WhatsApp approval authorization still comes from WhatsApp access config: direct chats use
-`allowFrom`/pairing, and group-origin emoji approval prompts require explicit WhatsApp approvers
-from `allowFrom` or `defaultTo`.
+WhatsApp approval reactions require explicit WhatsApp approvers from `allowFrom` or `"*"`.
+`defaultTo` controls ordinary default message targets; it is not an approval approver. Manual
+`/approve` commands still pass through the normal WhatsApp sender authorization path before
+approval resolution.
 
 ## Plugin hooks and privacy
 

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -175,6 +175,38 @@ handoff path over manual terminal capture.
 - WhatsApp Web transport honors standard proxy environment variables on the gateway host (`HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY` / lowercase variants). Prefer host-level proxy config over channel-specific WhatsApp proxy settings.
 - When `messages.removeAckAfterReply` is enabled, OpenClaw clears the WhatsApp ack reaction after a visible reply is delivered.
 
+## Approval prompts
+
+WhatsApp can render exec and plugin approval prompts with numeric emoji reactions, but the
+channel does not have a `channels.whatsapp.execApprovals` config block. Delivery is controlled by
+the top-level approval forwarding config instead:
+
+```json5
+{
+  approvals: {
+    exec: {
+      enabled: true,
+      mode: "session",
+    },
+    plugin: {
+      enabled: true,
+      mode: "targets",
+      targets: [{ channel: "whatsapp", to: "+15551234567" }],
+    },
+  },
+}
+```
+
+`approvals.exec` and `approvals.plugin` are independent. Enabling WhatsApp as a channel only links
+the transport; it does not send approval prompts unless the matching approval family is enabled
+and routes to WhatsApp. Session mode delivers native emoji approvals only for approvals that
+originate from WhatsApp. Target mode uses the shared forwarding pipeline for explicit WhatsApp
+targets and does not create separate approver-DM fanout.
+
+WhatsApp approval authorization still comes from WhatsApp access config: direct chats use
+`allowFrom`/pairing, and group-origin emoji approval prompts require explicit WhatsApp approvers
+from `allowFrom` or `defaultTo`.
+
 ## Plugin hooks and privacy
 
 WhatsApp inbound messages can contain personal message content, phone numbers,

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -177,9 +177,8 @@ handoff path over manual terminal capture.
 
 ## Approval prompts
 
-WhatsApp can render exec and plugin approval prompts with `👍` / `👎` reactions, but the
-channel does not have a `channels.whatsapp.execApprovals` config block. Delivery is controlled by
-the top-level approval forwarding config instead:
+WhatsApp can render exec and plugin approval prompts with `👍` / `👎` reactions. Delivery is
+controlled by the top-level approval forwarding config:
 
 ```json5
 {

--- a/docs/tools/exec-approvals-advanced.md
+++ b/docs/tools/exec-approvals-advanced.md
@@ -279,10 +279,8 @@ Generic model:
 - Slack plugin approvals can use Slack's native approval client when the request comes from Slack
   and Slack plugin approvers resolve; `approvals.plugin` can also route plugin approvals to Slack
   sessions or targets even when Slack exec approvals are disabled
-- WhatsApp is the exception to the channel-specific native-client field: it has no
-  `channels.whatsapp.execApprovals`; WhatsApp emoji approval delivery is gated by
-  `approvals.exec` and `approvals.plugin`, while approval reactions require explicit WhatsApp
-  approvers from `channels.whatsapp.allowFrom` or `"*"`
+- WhatsApp emoji approval delivery is gated by `approvals.exec` and `approvals.plugin`, while
+  approval reactions require explicit WhatsApp approvers from `channels.whatsapp.allowFrom` or `"*"`
 
 Native approval clients auto-enable DM-first delivery when all of these are true:
 
@@ -300,8 +298,7 @@ FAQ: [Why are there two exec approval configs for chat approvals?](/help/faq-fir
 - Discord: `channels.discord.execApprovals.*`
 - Slack: `channels.slack.execApprovals.*`
 - Telegram: `channels.telegram.execApprovals.*`
-- WhatsApp: no `channels.whatsapp.execApprovals`; use `approvals.exec` and
-  `approvals.plugin` to route approval prompts to WhatsApp
+- WhatsApp: use `approvals.exec` and `approvals.plugin` to route approval prompts to WhatsApp
 
 These native approval clients add DM routing and optional channel fanout on top of the shared
 same-chat `/approve` flow and shared approval buttons.

--- a/docs/tools/exec-approvals-advanced.md
+++ b/docs/tools/exec-approvals-advanced.md
@@ -367,6 +367,70 @@ Security notes:
 - Same-UID peer check.
 - Challenge/response (nonce + HMAC token + request hash) + short TTL.
 
+## FAQ
+
+### When would `accountId` and `threadId` be used on an approval target?
+
+Use `accountId` when the channel has multiple configured identities and the approval prompt must
+leave through one specific account. Use `threadId` when the destination supports topics or
+threads and the prompt should stay inside that thread instead of the top-level chat.
+
+A concrete Telegram case is an operations supergroup with forum topics and two Telegram bot
+accounts. The `to` value names the supergroup, `accountId` selects the bot account, and `threadId`
+selects the forum topic:
+
+```json5
+{
+  approvals: {
+    exec: {
+      enabled: true,
+      mode: "targets",
+      targets: [
+        {
+          channel: "telegram",
+          to: "-1001234567890",
+          accountId: "ops-bot",
+          threadId: "77",
+        },
+      ],
+    },
+  },
+  channels: {
+    telegram: {
+      accounts: {
+        default: {
+          name: "Primary bot",
+          botToken: "env:TELEGRAM_PRIMARY_BOT_TOKEN",
+        },
+        "ops-bot": {
+          name: "Operations bot",
+          botToken: "env:TELEGRAM_OPS_BOT_TOKEN",
+        },
+      },
+    },
+  },
+}
+```
+
+With that setup, forwarded exec approvals are posted by the `ops-bot` Telegram account into topic
+`77` of chat `-1001234567890`. A target without `accountId` uses the channel's default account, and
+a target without `threadId` posts to the top-level destination.
+
+### When approvals are sent to a session, can anyone in that session approve them?
+
+No. Session delivery only controls where the prompt appears. It does not by itself authorize every
+participant in that chat to approve.
+
+For generic same-chat `/approve`, the sender must already be authorized for commands in that
+channel session. If the channel exposes explicit approval approvers, those approvers can authorize
+the `/approve` action even when they are not otherwise command-authorized in that session.
+
+Some channels are stricter. Discord, Telegram, Matrix, Slack native approval DMs, and similar
+native approval clients use their resolved approver lists for approval authorization. For example,
+a Telegram forum-topic approval prompt can be visible to everyone in the topic, but only numeric
+Telegram user IDs resolved from `channels.telegram.execApprovals.approvers` or
+`commands.ownerAllowFrom` can approve or deny it.
+
 ## Related
 
 - [Exec approvals](/tools/exec-approvals) — core policy and approval flow

--- a/docs/tools/exec-approvals-advanced.md
+++ b/docs/tools/exec-approvals-advanced.md
@@ -279,6 +279,10 @@ Generic model:
 - Slack plugin approvals can use Slack's native approval client when the request comes from Slack
   and Slack plugin approvers resolve; `approvals.plugin` can also route plugin approvals to Slack
   sessions or targets even when Slack exec approvals are disabled
+- WhatsApp is the exception to the channel-specific native-client field: it has no
+  `channels.whatsapp.execApprovals`; WhatsApp emoji approval delivery is gated by
+  `approvals.exec` and `approvals.plugin` plus the normal WhatsApp `allowFrom`/`defaultTo`
+  authorization config
 
 Native approval clients auto-enable DM-first delivery when all of these are true:
 
@@ -296,6 +300,8 @@ FAQ: [Why are there two exec approval configs for chat approvals?](/help/faq-fir
 - Discord: `channels.discord.execApprovals.*`
 - Slack: `channels.slack.execApprovals.*`
 - Telegram: `channels.telegram.execApprovals.*`
+- WhatsApp: no `channels.whatsapp.execApprovals`; use `approvals.exec` and
+  `approvals.plugin` to route approval prompts to WhatsApp
 
 These native approval clients add DM routing and optional channel fanout on top of the shared
 same-chat `/approve` flow and shared approval buttons.
@@ -313,6 +319,9 @@ Shared behavior:
   routing, not Slack exec approvers
 - Slack native buttons preserve approval id kind, so `plugin:` ids can resolve plugin approvals
   without a second Slack-local fallback layer
+- WhatsApp emoji approvals handle both exec and plugin prompts only when the matching top-level
+  forwarding family is enabled and routes to WhatsApp; target-only WhatsApp forwarding stays on
+  the shared forwarding path unless it matches the same native origin target
 - Matrix native DM/channel routing and reaction shortcuts handle both exec and plugin approvals;
   plugin authorization still comes from `channels.matrix.dm.allowFrom`
 - Matrix native prompts include `com.openclaw.approval` custom event content on the first prompt

--- a/docs/tools/exec-approvals-advanced.md
+++ b/docs/tools/exec-approvals-advanced.md
@@ -281,8 +281,8 @@ Generic model:
   sessions or targets even when Slack exec approvals are disabled
 - WhatsApp is the exception to the channel-specific native-client field: it has no
   `channels.whatsapp.execApprovals`; WhatsApp emoji approval delivery is gated by
-  `approvals.exec` and `approvals.plugin` plus the normal WhatsApp `allowFrom`/`defaultTo`
-  authorization config
+  `approvals.exec` and `approvals.plugin`, while approval reactions require explicit WhatsApp
+  approvers from `channels.whatsapp.allowFrom` or `"*"`
 
 Native approval clients auto-enable DM-first delivery when all of these are true:
 

--- a/extensions/whatsapp/src/approval-auth.test.ts
+++ b/extensions/whatsapp/src/approval-auth.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { whatsappApprovalAuth } from "./approval-auth.js";
+import { getWhatsAppApprovalApprovers, whatsappApprovalAuth } from "./approval-auth.js";
 
 describe("whatsappApprovalAuth", () => {
-  it("authorizes direct WhatsApp recipients and ignores groups", () => {
+  it("authorizes direct WhatsApp recipients and ignores group entries", () => {
     expect(
       whatsappApprovalAuth.authorizeActorAction({
         cfg: { channels: { whatsapp: { allowFrom: ["+1 (555) 123-0000"] } } },
@@ -13,11 +13,48 @@ describe("whatsappApprovalAuth", () => {
     ).toEqual({ authorized: true });
 
     expect(
-      whatsappApprovalAuth.authorizeActorAction({
+      getWhatsAppApprovalApprovers({
         cfg: { channels: { whatsapp: { allowFrom: ["12345-67890@g.us"] } } },
+      }),
+    ).toEqual([]);
+
+    expect(
+      whatsappApprovalAuth.authorizeActorAction({
+        cfg: { channels: { whatsapp: { allowFrom: ["+15551230000"] } } },
         senderId: "+15551239999",
         action: "approve",
         approvalKind: "exec",
+      }),
+    ).toEqual({
+      authorized: false,
+      reason: "❌ You are not authorized to approve exec requests on WhatsApp.",
+    });
+  });
+
+  it("does not treat defaultTo as an explicit approval approver", () => {
+    expect(
+      getWhatsAppApprovalApprovers({
+        cfg: { channels: { whatsapp: { allowFrom: [], defaultTo: "+15551230000" } } },
+      }),
+    ).toEqual([]);
+
+    expect(
+      whatsappApprovalAuth.authorizeActorAction({
+        cfg: { channels: { whatsapp: { allowFrom: [], defaultTo: "+15551230000" } } },
+        senderId: "+15551230000",
+        action: "approve",
+        approvalKind: "exec",
+      }),
+    ).toEqual({ authorized: true });
+  });
+
+  it("supports explicit wildcard approval approvers", () => {
+    expect(
+      whatsappApprovalAuth.authorizeActorAction({
+        cfg: { channels: { whatsapp: { allowFrom: ["*"] } } },
+        senderId: "+15551230000",
+        action: "approve",
+        approvalKind: "plugin",
       }),
     ).toEqual({ authorized: true });
   });

--- a/extensions/whatsapp/src/approval-auth.ts
+++ b/extensions/whatsapp/src/approval-auth.ts
@@ -5,12 +5,18 @@ import {
 import { resolveWhatsAppAccount } from "./accounts.js";
 import { normalizeWhatsAppTarget } from "./normalize.js";
 
+type ApprovalKind = "exec" | "plugin";
+
 export function normalizeWhatsAppApproverId(value: string | number): string | undefined {
   const normalized = normalizeWhatsAppTarget(String(value));
   if (!normalized || normalized.endsWith("@g.us")) {
     return undefined;
   }
   return normalized;
+}
+
+function normalizeWhatsAppApproverEntry(value: string | number): string | undefined {
+  return String(value).trim() === "*" ? "*" : normalizeWhatsAppApproverId(value);
 }
 
 export function getWhatsAppApprovalApprovers(params: {
@@ -20,13 +26,38 @@ export function getWhatsAppApprovalApprovers(params: {
   const account = resolveWhatsAppAccount({ cfg: params.cfg, accountId: params.accountId });
   return resolveApprovalApprovers({
     allowFrom: account.allowFrom,
-    defaultTo: account.defaultTo,
-    normalizeApprover: normalizeWhatsAppApproverId,
+    normalizeApprover: normalizeWhatsAppApproverEntry,
   });
 }
 
-export const whatsappApprovalAuth = createResolvedApproverActionAuthAdapter({
+const whatsappResolvedApproverAuth = createResolvedApproverActionAuthAdapter({
   channelLabel: "WhatsApp",
-  resolveApprovers: getWhatsAppApprovalApprovers,
+  resolveApprovers: ({ cfg, accountId }) => getWhatsAppApprovalApprovers({ cfg, accountId }),
   normalizeSenderId: (value) => normalizeWhatsAppApproverId(value),
 });
+
+export const whatsappApprovalAuth = {
+  authorizeActorAction({
+    cfg,
+    accountId,
+    senderId,
+    approvalKind,
+  }: {
+    cfg: Parameters<typeof resolveWhatsAppAccount>[0]["cfg"];
+    accountId?: string | null;
+    senderId?: string | null;
+    action: "approve";
+    approvalKind: ApprovalKind;
+  }) {
+    if (getWhatsAppApprovalApprovers({ cfg, accountId }).includes("*")) {
+      return { authorized: true } as const;
+    }
+    return whatsappResolvedApproverAuth.authorizeActorAction({
+      cfg,
+      accountId,
+      senderId,
+      action: "approve",
+      approvalKind,
+    });
+  },
+};

--- a/extensions/whatsapp/src/approval-auth.ts
+++ b/extensions/whatsapp/src/approval-auth.ts
@@ -5,7 +5,7 @@ import {
 import { resolveWhatsAppAccount } from "./accounts.js";
 import { normalizeWhatsAppTarget } from "./normalize.js";
 
-function normalizeWhatsAppApproverId(value: string | number): string | undefined {
+export function normalizeWhatsAppApproverId(value: string | number): string | undefined {
   const normalized = normalizeWhatsAppTarget(String(value));
   if (!normalized || normalized.endsWith("@g.us")) {
     return undefined;
@@ -13,15 +13,20 @@ function normalizeWhatsAppApproverId(value: string | number): string | undefined
   return normalized;
 }
 
+export function getWhatsAppApprovalApprovers(params: {
+  cfg: Parameters<typeof resolveWhatsAppAccount>[0]["cfg"];
+  accountId?: string | null;
+}): string[] {
+  const account = resolveWhatsAppAccount({ cfg: params.cfg, accountId: params.accountId });
+  return resolveApprovalApprovers({
+    allowFrom: account.allowFrom,
+    defaultTo: account.defaultTo,
+    normalizeApprover: normalizeWhatsAppApproverId,
+  });
+}
+
 export const whatsappApprovalAuth = createResolvedApproverActionAuthAdapter({
   channelLabel: "WhatsApp",
-  resolveApprovers: ({ cfg, accountId }) => {
-    const account = resolveWhatsAppAccount({ cfg, accountId });
-    return resolveApprovalApprovers({
-      allowFrom: account.allowFrom,
-      defaultTo: account.defaultTo,
-      normalizeApprover: normalizeWhatsAppApproverId,
-    });
-  },
+  resolveApprovers: getWhatsAppApprovalApprovers,
   normalizeSenderId: (value) => normalizeWhatsAppApproverId(value),
 });

--- a/extensions/whatsapp/src/approval-handler.runtime.test.ts
+++ b/extensions/whatsapp/src/approval-handler.runtime.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { whatsappApprovalNativeRuntime } from "./approval-handler.runtime.js";
+
+describe("whatsappApprovalNativeRuntime", () => {
+  it("renders allowed numeric reactions in pending exec approvals", async () => {
+    const payload = await whatsappApprovalNativeRuntime.presentation.buildPendingPayload({
+      cfg: {} as never,
+      accountId: "default",
+      context: { accountId: "default" },
+      request: {
+        id: "exec-1",
+        request: {
+          command: "echo hi",
+        },
+        createdAtMs: 0,
+        expiresAtMs: 60_000,
+      },
+      approvalKind: "exec",
+      nowMs: 0,
+      view: {
+        approvalKind: "exec",
+        approvalId: "exec-1",
+        commandText: "echo hi",
+        actions: [
+          {
+            decision: "allow-once",
+            label: "Allow Once",
+            command: "/approve exec-1 allow-once",
+            style: "success",
+          },
+          {
+            decision: "deny",
+            label: "Deny",
+            command: "/approve exec-1 deny",
+            style: "danger",
+          },
+        ],
+      } as never,
+    });
+
+    expect(payload.text).toContain("1️⃣ Allow Once");
+    expect(payload.text).toContain("3️⃣ Deny");
+    expect(payload.text).not.toContain("2️⃣ Allow Always");
+    expect(payload.allowedDecisions).toEqual(["allow-once", "deny"]);
+  });
+
+  it("renders allowed numeric reactions in pending plugin approvals", async () => {
+    const payload = await whatsappApprovalNativeRuntime.presentation.buildPendingPayload({
+      cfg: {} as never,
+      accountId: "default",
+      context: { accountId: "default" },
+      request: {
+        id: "plugin:abc",
+        request: {
+          title: "Allow Codex to use 1Password?",
+          description: "Allow Codex to use 1Password?",
+          pluginId: "openclaw-codex-app-server",
+          toolName: "codex_mcp_tool_approval",
+          severity: "warning",
+          allowedDecisions: ["allow-once", "allow-always", "deny"],
+        },
+        createdAtMs: 0,
+        expiresAtMs: 60_000,
+      },
+      approvalKind: "plugin",
+      nowMs: 0,
+      view: {
+        approvalKind: "plugin",
+        approvalId: "plugin:abc",
+        title: "Plugin approval required",
+        severity: "warning",
+        actions: [
+          {
+            decision: "allow-once",
+            label: "Allow Once",
+            command: "/approve plugin:abc allow-once",
+            style: "success",
+          },
+          {
+            decision: "allow-always",
+            label: "Allow Always",
+            command: "/approve plugin:abc allow-always",
+            style: "primary",
+          },
+          {
+            decision: "deny",
+            label: "Deny",
+            command: "/approve plugin:abc deny",
+            style: "danger",
+          },
+        ],
+      } as never,
+    });
+
+    expect(payload.text).toContain("Plugin approval required");
+    expect(payload.text).toContain("1️⃣ Allow Once");
+    expect(payload.text).toContain("2️⃣ Allow Always");
+    expect(payload.text).toContain("3️⃣ Deny");
+    expect(payload.allowedDecisions).toEqual(["allow-once", "allow-always", "deny"]);
+  });
+
+  it("normalizes WhatsApp targets and carries account ids into prepared delivery", async () => {
+    await expect(
+      whatsappApprovalNativeRuntime.transport.prepareTarget({
+        cfg: {} as never,
+        accountId: "ops",
+        context: { accountId: "ops" },
+        plannedTarget: {
+          surface: "origin",
+          reason: "preferred",
+          target: {
+            to: "15551230000@s.whatsapp.net",
+          },
+        },
+        request: {
+          id: "exec-1",
+          request: {
+            command: "echo hi",
+          },
+          createdAtMs: 0,
+          expiresAtMs: 60_000,
+        },
+        approvalKind: "exec",
+        view: {
+          approvalKind: "exec",
+          approvalId: "exec-1",
+          commandText: "echo hi",
+          actions: [],
+        } as never,
+        pendingPayload: {
+          text: "pending",
+          allowedDecisions: ["allow-once"],
+        },
+      }),
+    ).resolves.toEqual({
+      dedupeKey: expect.any(String),
+      target: {
+        to: "+15551230000",
+        accountId: "ops",
+      },
+    });
+  });
+});

--- a/extensions/whatsapp/src/approval-handler.runtime.test.ts
+++ b/extensions/whatsapp/src/approval-handler.runtime.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { whatsappApprovalNativeRuntime } from "./approval-handler.runtime.js";
 
 describe("whatsappApprovalNativeRuntime", () => {
-  it("renders allowed numeric reactions in pending exec approvals", async () => {
+  it("renders allowed thumbs-only reactions in pending exec approvals", async () => {
     const payload = await whatsappApprovalNativeRuntime.presentation.buildPendingPayload({
       cfg: {} as never,
       accountId: "default",
@@ -38,13 +38,15 @@ describe("whatsappApprovalNativeRuntime", () => {
       } as never,
     });
 
-    expect(payload.text).toContain("1️⃣ Allow Once");
-    expect(payload.text).toContain("3️⃣ Deny");
+    expect(payload.text).toContain("👍 Allow Once");
+    expect(payload.text).toContain("👎 Deny");
+    expect(payload.text).not.toContain("1️⃣ Allow Once");
     expect(payload.text).not.toContain("2️⃣ Allow Always");
+    expect(payload.text).not.toContain("3️⃣ Deny");
     expect(payload.allowedDecisions).toEqual(["allow-once", "deny"]);
   });
 
-  it("renders allowed numeric reactions in pending plugin approvals", async () => {
+  it("renders allowed thumbs-only reactions in pending plugin approvals", async () => {
     const payload = await whatsappApprovalNativeRuntime.presentation.buildPendingPayload({
       cfg: {} as never,
       accountId: "default",
@@ -93,9 +95,13 @@ describe("whatsappApprovalNativeRuntime", () => {
     });
 
     expect(payload.text).toContain("Plugin approval required");
-    expect(payload.text).toContain("1️⃣ Allow Once");
-    expect(payload.text).toContain("2️⃣ Allow Always");
-    expect(payload.text).toContain("3️⃣ Deny");
+    expect(payload.text).toContain("Reply with: /approve plugin:abc allow-once|allow-always|deny");
+    expect(payload.text).toContain("👍 Allow Once");
+    expect(payload.text).toContain("👎 Deny");
+    expect(payload.text).not.toContain("/approve <id>");
+    expect(payload.text).not.toContain("1️⃣ Allow Once");
+    expect(payload.text).not.toContain("2️⃣ Allow Always");
+    expect(payload.text).not.toContain("3️⃣ Deny");
     expect(payload.allowedDecisions).toEqual(["allow-once", "allow-always", "deny"]);
   });
 

--- a/extensions/whatsapp/src/approval-handler.runtime.ts
+++ b/extensions/whatsapp/src/approval-handler.runtime.ts
@@ -1,0 +1,254 @@
+import {
+  createChannelApprovalNativeRuntimeAdapter,
+  type ExpiredApprovalView,
+  type PendingApprovalView,
+  type ResolvedApprovalView,
+} from "openclaw/plugin-sdk/approval-handler-runtime";
+import { buildChannelApprovalNativeTargetKey } from "openclaw/plugin-sdk/approval-native-runtime";
+import {
+  buildExecApprovalPendingReplyPayload,
+  type ExecApprovalReplyDecision,
+  type ExecApprovalPendingReplyParams,
+} from "openclaw/plugin-sdk/approval-reply-runtime";
+import {
+  buildApprovalResolvedReplyPayload,
+  buildPluginApprovalExpiredMessage,
+  buildPluginApprovalPendingReplyPayload,
+  buildPluginApprovalResolvedMessage,
+  type ExecApprovalRequest,
+  type ExecApprovalResolved,
+  type PluginApprovalRequest,
+  type PluginApprovalResolved,
+} from "openclaw/plugin-sdk/approval-runtime";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  buildWhatsAppApprovalReactionHint,
+  registerWhatsAppApprovalReactionTarget,
+  unregisterWhatsAppApprovalReactionTarget,
+} from "./approval-reactions.js";
+import { normalizeWhatsAppMessagingTarget } from "./normalize.js";
+import { getWhatsAppRuntime } from "./runtime.js";
+import { sendMessageWhatsApp, sendTypingWhatsApp } from "./send.js";
+
+const log = createSubsystemLogger("whatsapp/approvals");
+
+type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
+type ApprovalResolved = ExecApprovalResolved | PluginApprovalResolved;
+type WhatsAppPendingDelivery = {
+  text: string;
+  allowedDecisions: readonly ExecApprovalReplyDecision[];
+};
+type PreparedWhatsAppApprovalTarget = {
+  to: string;
+  accountId?: string;
+};
+type PendingWhatsAppApprovalEntry = {
+  accountId?: string;
+  to: string;
+  remoteJid: string;
+  messageId: string;
+};
+type WhatsAppFinalPayload = {
+  text: string;
+};
+
+function appendReactionHint(params: {
+  text: string;
+  allowedDecisions: WhatsAppPendingDelivery["allowedDecisions"];
+}): string {
+  const hint = buildWhatsAppApprovalReactionHint(params.allowedDecisions);
+  return hint ? `${params.text}\n\n${hint}` : params.text;
+}
+
+function buildPendingPayload(params: {
+  request: ApprovalRequest;
+  approvalKind: "exec" | "plugin";
+  nowMs: number;
+  view: PendingApprovalView;
+}): WhatsAppPendingDelivery {
+  const allowedDecisions = params.view.actions.map((action) => action.decision);
+  const payload =
+    params.approvalKind === "plugin"
+      ? buildPluginApprovalPendingReplyPayload({
+          request: params.request as PluginApprovalRequest,
+          nowMs: params.nowMs,
+          allowedDecisions,
+        })
+      : buildExecApprovalPendingReplyPayload({
+          approvalId: params.request.id,
+          approvalSlug: params.request.id.slice(0, 8),
+          approvalCommandId: params.request.id,
+          warningText:
+            params.view.approvalKind === "exec"
+              ? (params.view.warningText ?? undefined)
+              : undefined,
+          command: params.view.approvalKind === "exec" ? params.view.commandText : "",
+          cwd: params.view.approvalKind === "exec" ? (params.view.cwd ?? undefined) : undefined,
+          host:
+            params.view.approvalKind === "exec" && params.view.host === "node" ? "node" : "gateway",
+          nodeId:
+            params.view.approvalKind === "exec" ? (params.view.nodeId ?? undefined) : undefined,
+          allowedDecisions,
+          expiresAtMs: params.request.expiresAtMs,
+          nowMs: params.nowMs,
+        } satisfies ExecApprovalPendingReplyParams);
+  return {
+    text: appendReactionHint({
+      text: payload.text ?? "",
+      allowedDecisions,
+    }),
+    allowedDecisions,
+  };
+}
+
+function buildResolvedText(params: {
+  request: ApprovalRequest;
+  resolved: ApprovalResolved;
+  view: ResolvedApprovalView;
+}): string {
+  if (params.view.approvalKind === "plugin") {
+    return buildPluginApprovalResolvedMessage(params.resolved as PluginApprovalResolved);
+  }
+  const payload = buildApprovalResolvedReplyPayload({
+    approvalId: params.request.id,
+    approvalSlug: params.request.id.slice(0, 8),
+    text:
+      `✅ Exec approval ${params.resolved.decision}.` +
+      `${params.resolved.resolvedBy ? ` Resolved by ${params.resolved.resolvedBy}.` : ""}` +
+      ` ID: ${params.request.id}`,
+  });
+  return payload.text ?? "";
+}
+
+function buildExpiredText(params: { request: ApprovalRequest; view: ExpiredApprovalView }): string {
+  if (params.view.approvalKind === "plugin") {
+    return buildPluginApprovalExpiredMessage(params.request as PluginApprovalRequest);
+  }
+  return `⏱️ Exec approval expired. ID: ${params.request.id}`;
+}
+
+function resolvePreparedAccountId(params: {
+  plannedAccountId?: string | null;
+  contextAccountId?: string | null;
+}): string | undefined {
+  return (
+    normalizeOptionalString(params.plannedAccountId) ??
+    normalizeOptionalString(params.contextAccountId)
+  );
+}
+
+export const whatsappApprovalNativeRuntime = createChannelApprovalNativeRuntimeAdapter<
+  WhatsAppPendingDelivery,
+  PreparedWhatsAppApprovalTarget,
+  PendingWhatsAppApprovalEntry,
+  true,
+  WhatsAppFinalPayload
+>({
+  eventKinds: ["exec", "plugin"],
+  availability: {
+    isConfigured: ({ context }) => Boolean(context),
+    shouldHandle: ({ context }) => Boolean(context),
+  },
+  presentation: {
+    buildPendingPayload: ({ request, approvalKind, nowMs, view }) =>
+      buildPendingPayload({ request, approvalKind, nowMs, view }),
+    buildResolvedResult: ({ request, resolved, view }) => ({
+      kind: "update",
+      payload: { text: buildResolvedText({ request, resolved, view }) },
+    }),
+    buildExpiredResult: ({ request, view }) => ({
+      kind: "update",
+      payload: { text: buildExpiredText({ request, view }) },
+    }),
+  },
+  transport: {
+    prepareTarget: ({ plannedTarget, accountId }) => {
+      const to = normalizeWhatsAppMessagingTarget(plannedTarget.target.to);
+      if (!to) {
+        return null;
+      }
+      const prepared: PreparedWhatsAppApprovalTarget = {
+        to,
+        accountId: resolvePreparedAccountId({
+          plannedAccountId: (plannedTarget.target as { accountId?: string | null }).accountId,
+          contextAccountId: accountId,
+        }),
+      };
+      return {
+        dedupeKey: `${prepared.accountId ?? ""}:${buildChannelApprovalNativeTargetKey({
+          to: prepared.to,
+        })}`,
+        target: prepared,
+      };
+    },
+    deliverPending: async ({ cfg, preparedTarget, pendingPayload }) => {
+      const verbose = getWhatsAppRuntime().logging.shouldLogVerbose();
+      await sendTypingWhatsApp(preparedTarget.to, {
+        cfg,
+        ...(preparedTarget.accountId ? { accountId: preparedTarget.accountId } : {}),
+      }).catch(() => {});
+      const result = await sendMessageWhatsApp(preparedTarget.to, pendingPayload.text, {
+        cfg,
+        verbose,
+        preserveLeadingWhitespace: true,
+        ...(preparedTarget.accountId ? { accountId: preparedTarget.accountId } : {}),
+      });
+      if (!result.messageId) {
+        return null;
+      }
+      return {
+        accountId: preparedTarget.accountId,
+        to: preparedTarget.to,
+        remoteJid: result.toJid,
+        messageId: result.messageId,
+      };
+    },
+    updateEntry: async ({ cfg, entry, payload }) => {
+      const verbose = getWhatsAppRuntime().logging.shouldLogVerbose();
+      await sendMessageWhatsApp(entry.to, payload.text, {
+        cfg,
+        verbose,
+        preserveLeadingWhitespace: true,
+        ...(entry.accountId ? { accountId: entry.accountId } : {}),
+        quotedMessageKey: {
+          id: entry.messageId,
+          remoteJid: entry.remoteJid,
+          fromMe: true,
+        },
+      });
+    },
+  },
+  interactions: {
+    bindPending: ({ entry, request, view, pendingPayload }) =>
+      registerWhatsAppApprovalReactionTarget({
+        accountId: entry.accountId ?? "",
+        remoteJid: entry.remoteJid,
+        messageId: entry.messageId,
+        approvalId: request.id,
+        allowedDecisions: pendingPayload.allowedDecisions,
+        ttlMs: Math.max(1, view.expiresAtMs - Date.now()),
+      })
+        ? true
+        : null,
+    unbindPending: ({ entry }) => {
+      unregisterWhatsAppApprovalReactionTarget({
+        accountId: entry.accountId ?? "",
+        remoteJid: entry.remoteJid,
+        messageId: entry.messageId,
+      });
+    },
+    cancelDelivered: ({ entry }) => {
+      unregisterWhatsAppApprovalReactionTarget({
+        accountId: entry.accountId ?? "",
+        remoteJid: entry.remoteJid,
+        messageId: entry.messageId,
+      });
+    },
+  },
+  observe: {
+    onDeliveryError: ({ error, request }) => {
+      log.error(`whatsapp approvals: failed to send request ${request.id}: ${String(error)}`);
+    },
+  },
+});

--- a/extensions/whatsapp/src/approval-handler.runtime.ts
+++ b/extensions/whatsapp/src/approval-handler.runtime.ts
@@ -110,13 +110,13 @@ function buildResolvedText(params: {
   if (params.view.approvalKind === "plugin") {
     return buildPluginApprovalResolvedMessage(params.resolved as PluginApprovalResolved);
   }
+  const resolvedByText = params.resolved.resolvedBy
+    ? ` Resolved by ${params.resolved.resolvedBy}.`
+    : "";
   const payload = buildApprovalResolvedReplyPayload({
     approvalId: params.request.id,
     approvalSlug: params.request.id.slice(0, 8),
-    text:
-      `✅ Exec approval ${params.resolved.decision}.` +
-      `${params.resolved.resolvedBy ? ` Resolved by ${params.resolved.resolvedBy}.` : ""}` +
-      ` ID: ${params.request.id}`,
+    text: `✅ Exec approval ${params.resolved.decision}.${resolvedByText} ID: ${params.request.id}`,
   });
   return payload.text ?? "";
 }

--- a/extensions/whatsapp/src/approval-handler.runtime.ts
+++ b/extensions/whatsapp/src/approval-handler.runtime.ts
@@ -61,6 +61,10 @@ function appendReactionHint(params: {
   return hint ? `${params.text}\n\n${hint}` : params.text;
 }
 
+function replaceApprovalIdPlaceholder(text: string | undefined, approvalId: string): string {
+  return (text ?? "").replace(/\/approve\s+<id>/g, `/approve ${approvalId}`);
+}
+
 function buildPendingPayload(params: {
   request: ApprovalRequest;
   approvalKind: "exec" | "plugin";
@@ -95,7 +99,7 @@ function buildPendingPayload(params: {
         } satisfies ExecApprovalPendingReplyParams);
   return {
     text: appendReactionHint({
-      text: payload.text ?? "",
+      text: replaceApprovalIdPlaceholder(payload.text, params.request.id),
       allowedDecisions,
     }),
     allowedDecisions,

--- a/extensions/whatsapp/src/approval-native.test.ts
+++ b/extensions/whatsapp/src/approval-native.test.ts
@@ -1,0 +1,110 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { describe, expect, it } from "vitest";
+import { whatsappApprovalCapability } from "./approval-native.js";
+
+function buildConfig(
+  overrides?: Partial<NonNullable<NonNullable<OpenClawConfig["channels"]>["whatsapp"]>>,
+): OpenClawConfig {
+  return {
+    channels: {
+      whatsapp: {
+        enabled: true,
+        ...overrides,
+      },
+    },
+  } as OpenClawConfig;
+}
+
+function buildExecRequest(turnSourceTo: string) {
+  return {
+    id: "exec-1",
+    request: {
+      command: "echo hi",
+      turnSourceChannel: "whatsapp",
+      turnSourceTo,
+      turnSourceAccountId: "default",
+      sessionKey: `agent:main:whatsapp:${turnSourceTo}`,
+    },
+    createdAtMs: 0,
+    expiresAtMs: 1000,
+  };
+}
+
+describe("whatsapp approval capability", () => {
+  it("keeps implicit same-chat native approval enabled for direct origins", () => {
+    const capabilities = whatsappApprovalCapability.native?.describeDeliveryCapabilities({
+      cfg: buildConfig(),
+      accountId: "default",
+      approvalKind: "exec",
+      request: buildExecRequest("+15551230000"),
+    });
+
+    expect(capabilities).toEqual({
+      enabled: true,
+      preferredSurface: "origin",
+      supportsOriginSurface: true,
+      supportsApproverDmSurface: false,
+      notifyOriginWhenDmOnly: true,
+    });
+  });
+
+  it("does not advertise group-origin emoji approvals without explicit approvers", async () => {
+    const request = buildExecRequest("120363401234567890@g.us");
+
+    expect(
+      whatsappApprovalCapability.native?.resolveOriginTarget?.({
+        cfg: buildConfig(),
+        accountId: "default",
+        approvalKind: "exec",
+        request,
+      }),
+    ).toBeNull();
+
+    expect(
+      whatsappApprovalCapability.native?.describeDeliveryCapabilities({
+        cfg: buildConfig(),
+        accountId: "default",
+        approvalKind: "exec",
+        request,
+      }),
+    ).toEqual({
+      enabled: false,
+      preferredSurface: "approver-dm",
+      supportsOriginSurface: false,
+      supportsApproverDmSurface: false,
+      notifyOriginWhenDmOnly: true,
+    });
+  });
+
+  it("allows group-origin emoji approvals when explicit approvers are configured", async () => {
+    const request = buildExecRequest("120363401234567890@g.us");
+    const cfg = buildConfig({ allowFrom: ["+15551230000"] });
+
+    expect(
+      whatsappApprovalCapability.native?.resolveOriginTarget?.({
+        cfg,
+        accountId: "default",
+        approvalKind: "exec",
+        request,
+      }),
+    ).toEqual({
+      to: "120363401234567890@g.us",
+      accountId: "default",
+    });
+
+    expect(
+      whatsappApprovalCapability.native?.describeDeliveryCapabilities({
+        cfg,
+        accountId: "default",
+        approvalKind: "exec",
+        request,
+      }),
+    ).toEqual({
+      enabled: true,
+      preferredSurface: "origin",
+      supportsOriginSurface: true,
+      supportsApproverDmSurface: true,
+      notifyOriginWhenDmOnly: true,
+    });
+  });
+});

--- a/extensions/whatsapp/src/approval-native.test.ts
+++ b/extensions/whatsapp/src/approval-native.test.ts
@@ -206,6 +206,75 @@ describe("whatsapp approval capability", () => {
     ).toBe(false);
   });
 
+  it("renders target-mode exec prompts with concrete thumbs-only reaction choices", () => {
+    const cfg = buildConfig({
+      approvals: {
+        exec: {
+          enabled: true,
+          mode: "targets",
+          targets: [{ channel: "whatsapp", to: "+15551230000" }],
+        },
+      },
+    });
+    const request = buildExecRequest("+15551230000", {
+      ask: "always",
+      cwd: "/tmp/work",
+      host: "gateway",
+    });
+
+    const payload = whatsappApprovalCapability.render?.exec?.buildPendingPayload?.({
+      cfg,
+      request,
+      target: { channel: "whatsapp", to: "+15551230000", source: "target" },
+      nowMs: 0,
+    });
+    const text = payload?.text ?? "";
+
+    expect(text).toContain("/approve exec-1 allow-once");
+    expect(text).toContain("React with:");
+    expect(text).toContain("👍 Allow Once");
+    expect(text).toContain("👎 Deny");
+    expect(text).not.toContain("<id>");
+    expect(text).not.toContain("1️⃣ Allow Once");
+    expect(text).not.toContain("2️⃣ Allow Always");
+    expect(text).not.toContain("3️⃣ Deny");
+    expect(text.indexOf("React with:")).toBeLessThan(text.indexOf("/approve exec-1 allow-once"));
+  });
+
+  it("renders target-mode plugin prompts with concrete thumbs-only reaction choices", () => {
+    const cfg = buildConfig({
+      approvals: {
+        plugin: {
+          enabled: true,
+          mode: "targets",
+          targets: [{ channel: "whatsapp", to: "+15551230000" }],
+        },
+      },
+    });
+    const request = buildPluginRequest("+15551230000", {
+      allowedDecisions: ["allow-once", "allow-always", "deny"],
+    });
+
+    const payload = whatsappApprovalCapability.render?.plugin?.buildPendingPayload?.({
+      cfg,
+      request,
+      target: { channel: "whatsapp", to: "+15551230000", source: "target" },
+      nowMs: 0,
+    });
+
+    expect(payload?.text).toContain("/approve plugin:approval-1 allow-once");
+    expect(payload?.text).toContain(
+      "Reply with: /approve plugin:approval-1 allow-once|allow-always|deny",
+    );
+    expect(payload?.text).toContain("React with:");
+    expect(payload?.text).toContain("👍 Allow Once");
+    expect(payload?.text).toContain("👎 Deny");
+    expect(payload?.text).not.toContain("1️⃣ Allow Once");
+    expect(payload?.text).not.toContain("2️⃣ Allow Always");
+    expect(payload?.text).not.toContain("3️⃣ Deny");
+    expect(payload?.text).not.toContain("<id>");
+  });
+
   it("does not report target-mode availability when no WhatsApp target matches", () => {
     const cfg = buildConfig({
       approvals: {

--- a/extensions/whatsapp/src/approval-native.test.ts
+++ b/extensions/whatsapp/src/approval-native.test.ts
@@ -1,88 +1,406 @@
+import type {
+  ExecApprovalRequest,
+  PluginApprovalRequest,
+} from "openclaw/plugin-sdk/approval-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { describe, expect, it } from "vitest";
-import { whatsappApprovalCapability } from "./approval-native.js";
+import { whatsappApprovalCapability, whatsappNativeApprovalAdapter } from "./approval-native.js";
+
+type WhatsAppConfig = NonNullable<NonNullable<OpenClawConfig["channels"]>["whatsapp"]>;
 
 function buildConfig(
-  overrides?: Partial<NonNullable<NonNullable<OpenClawConfig["channels"]>["whatsapp"]>>,
+  params: {
+    whatsapp?: Partial<WhatsAppConfig>;
+    approvals?: OpenClawConfig["approvals"];
+  } = {},
 ): OpenClawConfig {
   return {
     channels: {
       whatsapp: {
         enabled: true,
-        ...overrides,
+        ...params.whatsapp,
       },
     },
+    approvals: params.approvals,
   } as OpenClawConfig;
 }
 
-function buildExecRequest(turnSourceTo: string) {
+function buildExecRequest(
+  turnSourceTo: string,
+  overrides: Partial<ExecApprovalRequest["request"]> = {},
+): ExecApprovalRequest {
   return {
     id: "exec-1",
     request: {
       command: "echo hi",
+      agentId: "main",
       turnSourceChannel: "whatsapp",
       turnSourceTo,
       turnSourceAccountId: "default",
       sessionKey: `agent:main:whatsapp:${turnSourceTo}`,
+      ...overrides,
     },
     createdAtMs: 0,
     expiresAtMs: 1000,
   };
 }
 
-describe("whatsapp approval capability", () => {
-  it("keeps implicit same-chat native approval enabled for direct origins", () => {
-    const capabilities = whatsappApprovalCapability.native?.describeDeliveryCapabilities({
-      cfg: buildConfig(),
-      accountId: "default",
-      approvalKind: "exec",
-      request: buildExecRequest("+15551230000"),
-    });
+function buildPluginRequest(
+  turnSourceTo: string,
+  overrides: Partial<PluginApprovalRequest["request"]> = {},
+): PluginApprovalRequest {
+  return {
+    id: "plugin:approval-1",
+    request: {
+      title: "Plugin approval",
+      description: "Allow plugin action",
+      agentId: "main",
+      turnSourceChannel: "whatsapp",
+      turnSourceTo,
+      turnSourceAccountId: "default",
+      sessionKey: `agent:main:whatsapp:${turnSourceTo}`,
+      ...overrides,
+    },
+    createdAtMs: 0,
+    expiresAtMs: 1000,
+  };
+}
 
-    expect(capabilities).toEqual({
+function nativeShouldHandle(params: {
+  cfg: OpenClawConfig;
+  request: ExecApprovalRequest | PluginApprovalRequest;
+  accountId?: string | null;
+}) {
+  return whatsappApprovalCapability.nativeRuntime?.availability.shouldHandle({
+    cfg: params.cfg,
+    accountId: params.accountId ?? "default",
+    context: {},
+    request: params.request,
+  });
+}
+
+describe("whatsapp approval capability", () => {
+  it("does not enable exec or plugin native approvals from WhatsApp account readiness alone", () => {
+    const cfg = buildConfig();
+    const execRequest = buildExecRequest("+15551230000");
+    const pluginRequest = buildPluginRequest("+15551230000");
+
+    expect(
+      whatsappNativeApprovalAdapter.auth?.getActionAvailabilityState?.({
+        cfg,
+        accountId: "default",
+        action: "approve",
+        approvalKind: "exec",
+      }),
+    ).toEqual({ kind: "disabled" });
+    expect(
+      whatsappNativeApprovalAdapter.auth?.getActionAvailabilityState?.({
+        cfg,
+        accountId: "default",
+        action: "approve",
+        approvalKind: "plugin",
+      }),
+    ).toEqual({ kind: "disabled" });
+    expect(
+      whatsappApprovalCapability.native?.describeDeliveryCapabilities({
+        cfg,
+        accountId: "default",
+        approvalKind: "exec",
+        request: execRequest,
+      }).enabled,
+    ).toBe(false);
+    expect(nativeShouldHandle({ cfg, request: execRequest })).toBe(false);
+    expect(nativeShouldHandle({ cfg, request: pluginRequest })).toBe(false);
+  });
+
+  it("allows session-mode exec delivery for matching WhatsApp origins", () => {
+    const cfg = buildConfig({ approvals: { exec: { enabled: true } } });
+    const request = buildExecRequest("+15551230000");
+
+    expect(
+      whatsappApprovalCapability.native?.describeDeliveryCapabilities({
+        cfg,
+        accountId: "default",
+        approvalKind: "exec",
+        request,
+      }),
+    ).toEqual({
       enabled: true,
       preferredSurface: "origin",
       supportsOriginSurface: true,
       supportsApproverDmSurface: false,
       notifyOriginWhenDmOnly: true,
     });
+    expect(nativeShouldHandle({ cfg, request })).toBe(true);
   });
 
-  it("does not advertise group-origin emoji approvals without explicit approvers", async () => {
+  it("keeps exec and plugin forwarding gates independent", () => {
+    const execOnly = buildConfig({ approvals: { exec: { enabled: true } } });
+    const pluginOnly = buildConfig({ approvals: { plugin: { enabled: true } } });
+
+    expect(nativeShouldHandle({ cfg: execOnly, request: buildPluginRequest("+15551230000") })).toBe(
+      false,
+    );
+    expect(nativeShouldHandle({ cfg: pluginOnly, request: buildExecRequest("+15551230000") })).toBe(
+      false,
+    );
+    expect(
+      nativeShouldHandle({ cfg: pluginOnly, request: buildPluginRequest("+15551230000") }),
+    ).toBe(true);
+  });
+
+  it("does not use session mode for non-WhatsApp-origin requests", () => {
+    const cfg = buildConfig({ approvals: { exec: { enabled: true } } });
+    const request = buildExecRequest("", {
+      turnSourceChannel: "slack",
+      turnSourceTo: "C123",
+      sessionKey: "agent:main:slack:channel:c123",
+    });
+
+    expect(nativeShouldHandle({ cfg, request })).toBe(false);
+    expect(
+      whatsappApprovalCapability.native?.describeDeliveryCapabilities({
+        cfg,
+        accountId: "default",
+        approvalKind: "exec",
+        request,
+      }).enabled,
+    ).toBe(false);
+  });
+
+  it("uses target-mode config for requestless availability without native runtime handling", () => {
+    const cfg = buildConfig({
+      approvals: {
+        exec: {
+          enabled: true,
+          mode: "targets",
+          targets: [{ channel: "whatsapp", to: "+15551230000" }],
+        },
+      },
+    });
+    const request = buildExecRequest("+15551230000");
+
+    expect(
+      whatsappNativeApprovalAdapter.auth?.getActionAvailabilityState?.({
+        cfg,
+        accountId: "default",
+        action: "approve",
+        approvalKind: "exec",
+      }),
+    ).toEqual({ kind: "enabled" });
+    expect(
+      whatsappApprovalCapability.nativeRuntime?.availability.isConfigured({
+        cfg,
+        accountId: "default",
+        context: {},
+      }),
+    ).toBe(false);
+    expect(nativeShouldHandle({ cfg, request })).toBe(false);
+    expect(
+      whatsappApprovalCapability.native?.describeDeliveryCapabilities({
+        cfg,
+        accountId: "default",
+        approvalKind: "exec",
+        request,
+      }).enabled,
+    ).toBe(false);
+  });
+
+  it("does not report target-mode availability when no WhatsApp target matches", () => {
+    const cfg = buildConfig({
+      approvals: {
+        exec: {
+          enabled: true,
+          mode: "targets",
+          targets: [{ channel: "slack", to: "C123" }],
+        },
+      },
+    });
+
+    expect(
+      whatsappNativeApprovalAdapter.auth?.getActionAvailabilityState?.({
+        cfg,
+        accountId: "default",
+        action: "approve",
+        approvalKind: "exec",
+      }),
+    ).toEqual({ kind: "disabled" });
+  });
+
+  it("applies agent and session filters to native handling", () => {
+    const request = buildExecRequest("+15551230000", {
+      agentId: "main",
+      sessionKey: "agent:main:whatsapp:+15551230000",
+    });
+    const blockedByAgent = buildConfig({
+      approvals: { exec: { enabled: true, agentFilter: ["other"] } },
+    });
+    const blockedBySession = buildConfig({
+      approvals: { exec: { enabled: true, sessionFilter: ["telegram"] } },
+    });
+
+    expect(nativeShouldHandle({ cfg: blockedByAgent, request })).toBe(false);
+    expect(nativeShouldHandle({ cfg: blockedBySession, request })).toBe(false);
+  });
+
+  it("matches account-scoped top-level WhatsApp targets only for that account", () => {
+    const cfg = buildConfig({
+      whatsapp: {
+        accounts: {
+          work: { enabled: true },
+        },
+      } as Partial<WhatsAppConfig>,
+      approvals: {
+        exec: {
+          enabled: true,
+          mode: "targets",
+          targets: [{ channel: "whatsapp", to: "+15551230000", accountId: "work" }],
+        },
+      },
+    });
+
+    expect(
+      whatsappNativeApprovalAdapter.auth?.getActionAvailabilityState?.({
+        cfg,
+        accountId: "default",
+        action: "approve",
+        approvalKind: "exec",
+      }),
+    ).toEqual({ kind: "disabled" });
+    expect(
+      whatsappNativeApprovalAdapter.auth?.getActionAvailabilityState?.({
+        cfg,
+        accountId: "work",
+        action: "approve",
+        approvalKind: "exec",
+      }),
+    ).toEqual({ kind: "enabled" });
+  });
+
+  it("suppresses forwarding fallback only when the exact session-origin native target matches", () => {
+    const cfg = buildConfig({ approvals: { exec: { enabled: true } } });
+    const request = buildExecRequest("+15551230000");
+    const shouldSuppress = whatsappApprovalCapability.delivery?.shouldSuppressForwardingFallback;
+
+    expect(
+      shouldSuppress?.({
+        cfg,
+        approvalKind: "exec",
+        target: {
+          channel: "whatsapp",
+          to: "+15551230000",
+          accountId: "default",
+          source: "session",
+        },
+        request,
+      }),
+    ).toBe(true);
+    expect(
+      shouldSuppress?.({
+        cfg,
+        approvalKind: "exec",
+        target: {
+          channel: "whatsapp",
+          to: "+15550000000",
+          accountId: "default",
+          source: "session",
+        },
+        request,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not suppress target-only forwarding when native delivery cannot bind that target", () => {
+    const cfg = buildConfig({
+      approvals: {
+        exec: {
+          enabled: true,
+          mode: "targets",
+          targets: [{ channel: "whatsapp", to: "+15550000000" }],
+        },
+      },
+    });
+
+    expect(
+      whatsappApprovalCapability.delivery?.shouldSuppressForwardingFallback?.({
+        cfg,
+        approvalKind: "exec",
+        target: { channel: "whatsapp", to: "+15550000000", source: "target" },
+        request: buildExecRequest("+15551230000"),
+      }),
+    ).toBe(false);
+  });
+
+  it("suppresses both-mode explicit targets that omit the origin account id", () => {
+    const cfg = buildConfig({
+      approvals: {
+        exec: {
+          enabled: true,
+          mode: "both",
+          targets: [{ channel: "whatsapp", to: "+15551230000" }],
+        },
+      },
+    });
+
+    expect(
+      whatsappApprovalCapability.delivery?.shouldSuppressForwardingFallback?.({
+        cfg,
+        approvalKind: "exec",
+        target: { channel: "whatsapp", to: "+15551230000", source: "target" },
+        request: buildExecRequest("+15551230000"),
+      }),
+    ).toBe(true);
+  });
+
+  it("suppresses both-mode unscoped targets through the configured default WhatsApp account", () => {
+    const cfg = buildConfig({
+      whatsapp: {
+        defaultAccount: "work",
+        accounts: {
+          default: { enabled: true },
+          work: { enabled: true },
+        },
+      } as Partial<WhatsAppConfig>,
+      approvals: {
+        exec: {
+          enabled: true,
+          mode: "both",
+          targets: [{ channel: "whatsapp", to: "+15551230000" }],
+        },
+      },
+    });
+
+    expect(
+      whatsappApprovalCapability.delivery?.shouldSuppressForwardingFallback?.({
+        cfg,
+        approvalKind: "exec",
+        target: { channel: "whatsapp", to: "+15551230000", source: "target" },
+        request: buildExecRequest("+15551230000", {
+          turnSourceAccountId: "work",
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it("allows group-origin emoji approvals only after exec forwarding and approvers are configured", () => {
     const request = buildExecRequest("120363401234567890@g.us");
+    const withoutApprovers = buildConfig({ approvals: { exec: { enabled: true } } });
+    const withApprovers = buildConfig({
+      whatsapp: { allowFrom: ["+15551230000"] },
+      approvals: { exec: { enabled: true } },
+    });
 
     expect(
       whatsappApprovalCapability.native?.resolveOriginTarget?.({
-        cfg: buildConfig(),
+        cfg: withoutApprovers,
         accountId: "default",
         approvalKind: "exec",
         request,
       }),
     ).toBeNull();
-
-    expect(
-      whatsappApprovalCapability.native?.describeDeliveryCapabilities({
-        cfg: buildConfig(),
-        accountId: "default",
-        approvalKind: "exec",
-        request,
-      }),
-    ).toEqual({
-      enabled: false,
-      preferredSurface: "approver-dm",
-      supportsOriginSurface: false,
-      supportsApproverDmSurface: false,
-      notifyOriginWhenDmOnly: true,
-    });
-  });
-
-  it("allows group-origin emoji approvals when explicit approvers are configured", async () => {
-    const request = buildExecRequest("120363401234567890@g.us");
-    const cfg = buildConfig({ allowFrom: ["+15551230000"] });
-
     expect(
       whatsappApprovalCapability.native?.resolveOriginTarget?.({
-        cfg,
+        cfg: withApprovers,
         accountId: "default",
         approvalKind: "exec",
         request,
@@ -90,21 +408,6 @@ describe("whatsapp approval capability", () => {
     ).toEqual({
       to: "120363401234567890@g.us",
       accountId: "default",
-    });
-
-    expect(
-      whatsappApprovalCapability.native?.describeDeliveryCapabilities({
-        cfg,
-        accountId: "default",
-        approvalKind: "exec",
-        request,
-      }),
-    ).toEqual({
-      enabled: true,
-      preferredSurface: "origin",
-      supportsOriginSurface: true,
-      supportsApproverDmSurface: true,
-      notifyOriginWhenDmOnly: true,
     });
   });
 });

--- a/extensions/whatsapp/src/approval-native.ts
+++ b/extensions/whatsapp/src/approval-native.ts
@@ -11,8 +11,15 @@ import {
   doesApprovalRequestMatchChannelAccount,
   resolveApprovalRequestSessionTarget,
 } from "openclaw/plugin-sdk/approval-native-runtime";
+import {
+  buildExecApprovalPendingReplyPayload,
+  buildPluginApprovalPendingReplyPayload,
+  resolveExecApprovalCommandDisplay,
+  resolveExecApprovalRequestAllowedDecisions,
+} from "openclaw/plugin-sdk/approval-runtime";
 import type {
   ExecApprovalRequest,
+  ExecApprovalReplyDecision,
   PluginApprovalRequest,
 } from "openclaw/plugin-sdk/approval-runtime";
 import type { ChannelApprovalCapability } from "openclaw/plugin-sdk/channel-contract";
@@ -29,6 +36,7 @@ import {
   resolveWhatsAppAccount,
 } from "./accounts.js";
 import { getWhatsAppApprovalApprovers, whatsappApprovalAuth } from "./approval-auth.js";
+import { addWhatsAppApprovalReactionHintToText } from "./approval-reactions.js";
 import { isWhatsAppGroupJid, normalizeWhatsAppMessagingTarget } from "./normalize.js";
 
 type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
@@ -47,6 +55,11 @@ type WhatsAppApprovalTarget = {
 };
 
 const DEFAULT_APPROVAL_FORWARDING_MODE: ApprovalForwardingMode = "session";
+const DEFAULT_PLUGIN_APPROVAL_DECISIONS: readonly ExecApprovalReplyDecision[] = [
+  "allow-once",
+  "allow-always",
+  "deny",
+];
 
 function isWhatsAppApprovalTransportEnabled(params: {
   cfg: OpenClawConfig;
@@ -409,6 +422,71 @@ const resolveWhatsAppApproverDmTargets = createChannelApproverDmTargetResolver({
   },
 });
 
+function appendWhatsAppReactionHint(params: {
+  text?: string;
+  allowedDecisions: readonly ExecApprovalReplyDecision[];
+}): string {
+  return addWhatsAppApprovalReactionHintToText({
+    text: params.text ?? "",
+    allowedDecisions: params.allowedDecisions,
+  });
+}
+
+function replaceApprovalIdPlaceholder(text: string | undefined, approvalId: string): string {
+  return (text ?? "").replace(/\/approve\s+<id>/g, `/approve ${approvalId}`);
+}
+
+function buildWhatsAppExecPendingPayload(params: { request: ExecApprovalRequest; nowMs: number }) {
+  const allowedDecisions = resolveExecApprovalRequestAllowedDecisions(params.request.request);
+  const command = resolveExecApprovalCommandDisplay(params.request.request).commandText;
+  const payload = buildExecApprovalPendingReplyPayload({
+    approvalId: params.request.id,
+    approvalSlug: params.request.id.slice(0, 8),
+    approvalCommandId: params.request.id,
+    warningText: params.request.request.warningText ?? undefined,
+    ask: params.request.request.ask ?? null,
+    agentId: params.request.request.agentId ?? null,
+    allowedDecisions,
+    command,
+    cwd: params.request.request.cwd ?? undefined,
+    host: params.request.request.host === "node" ? "node" : "gateway",
+    nodeId: params.request.request.nodeId ?? undefined,
+    sessionKey: params.request.request.sessionKey ?? null,
+    expiresAtMs: params.request.expiresAtMs,
+    nowMs: params.nowMs,
+  });
+  return {
+    ...payload,
+    text: appendWhatsAppReactionHint({
+      text: replaceApprovalIdPlaceholder(payload.text, params.request.id),
+      allowedDecisions,
+    }),
+  };
+}
+
+function buildWhatsAppPluginPendingPayload(params: {
+  request: PluginApprovalRequest;
+  nowMs: number;
+}) {
+  const configuredDecisions = params.request.request.allowedDecisions;
+  const allowedDecisions =
+    configuredDecisions && configuredDecisions.length > 0
+      ? configuredDecisions
+      : DEFAULT_PLUGIN_APPROVAL_DECISIONS;
+  const payload = buildPluginApprovalPendingReplyPayload({
+    request: params.request,
+    nowMs: params.nowMs,
+    allowedDecisions,
+  });
+  return {
+    ...payload,
+    text: appendWhatsAppReactionHint({
+      text: replaceApprovalIdPlaceholder(payload.text, params.request.id),
+      allowedDecisions,
+    }),
+  };
+}
+
 export const whatsappApprovalCapability: ChannelApprovalCapability =
   createChannelApprovalCapability({
     ...whatsappApprovalAuth,
@@ -429,7 +507,7 @@ export const whatsappApprovalCapability: ChannelApprovalCapability =
         accountId && accountId !== "default"
           ? `channels.whatsapp.accounts.${accountId}`
           : "channels.whatsapp";
-      return `WhatsApp supports native exec approvals for this account when \`approvals.exec.enabled\` is true and the route allows WhatsApp. Link WhatsApp and keep the gateway running; configure \`${prefix}.allowFrom\` or \`${prefix}.defaultTo\` to restrict approvers.`;
+      return `WhatsApp supports native exec approvals for this account when \`approvals.exec.enabled\` is true and the route allows WhatsApp. Link WhatsApp and keep the gateway running; configure \`${prefix}.allowFrom\` to restrict approvers.`;
     },
     delivery: {
       hasConfiguredDmRoute: ({ cfg }) =>
@@ -496,6 +574,16 @@ export const whatsappApprovalCapability: ChannelApprovalCapability =
         }).some((approverTarget) =>
           nativeApprovalTargetsMatch({ left: forwardingTargetForMatch, right: approverTarget }),
         );
+      },
+    },
+    render: {
+      exec: {
+        buildPendingPayload: ({ request, nowMs }) =>
+          buildWhatsAppExecPendingPayload({ request, nowMs }),
+      },
+      plugin: {
+        buildPendingPayload: ({ request, nowMs }) =>
+          buildWhatsAppPluginPendingPayload({ request, nowMs }),
       },
     },
     native: {

--- a/extensions/whatsapp/src/approval-native.ts
+++ b/extensions/whatsapp/src/approval-native.ts
@@ -1,3 +1,4 @@
+import { matchesApprovalRequestFilters } from "openclaw/plugin-sdk/approval-client-runtime";
 import {
   createChannelApprovalCapability,
   splitChannelApprovalCapability,
@@ -8,29 +9,322 @@ import {
   createChannelApproverDmTargetResolver,
   createChannelNativeOriginTargetResolver,
   doesApprovalRequestMatchChannelAccount,
+  resolveApprovalRequestSessionTarget,
 } from "openclaw/plugin-sdk/approval-native-runtime";
 import type {
   ExecApprovalRequest,
   PluginApprovalRequest,
 } from "openclaw/plugin-sdk/approval-runtime";
 import type { ChannelApprovalCapability } from "openclaw/plugin-sdk/channel-contract";
+import { channelRouteTargetsMatchExact } from "openclaw/plugin-sdk/channel-route";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { listWhatsAppAccountIds, resolveWhatsAppAccount } from "./accounts.js";
+import {
+  listWhatsAppAccountIds,
+  resolveDefaultWhatsAppAccountId,
+  resolveWhatsAppAccount,
+} from "./accounts.js";
 import { getWhatsAppApprovalApprovers, whatsappApprovalAuth } from "./approval-auth.js";
 import { isWhatsAppGroupJid, normalizeWhatsAppMessagingTarget } from "./normalize.js";
 
 type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
-type WhatsAppApprovalTarget = { to: string; accountId?: string | null };
+type ApprovalKind = "exec" | "plugin";
+type ApprovalForwardingConfig = NonNullable<NonNullable<OpenClawConfig["approvals"]>["exec"]>;
+type ApprovalForwardingMode = NonNullable<ApprovalForwardingConfig["mode"]>;
+type ChannelApprovalForwardTarget = Parameters<
+  NonNullable<
+    NonNullable<ChannelApprovalCapability["delivery"]>["shouldSuppressForwardingFallback"]
+  >
+>[0]["target"];
+type WhatsAppApprovalTarget = {
+  to: string;
+  accountId?: string | null;
+  threadId?: string | number | null;
+};
 
-function isWhatsAppNativeApprovalEnabled(params: {
+const DEFAULT_APPROVAL_FORWARDING_MODE: ApprovalForwardingMode = "session";
+
+function isWhatsAppApprovalTransportEnabled(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
 }): boolean {
   return resolveWhatsAppAccount({ cfg: params.cfg, accountId: params.accountId }).enabled;
+}
+
+function resolveApprovalKind(request: ApprovalRequest, approvalKind?: ApprovalKind): ApprovalKind {
+  if (approvalKind) {
+    return approvalKind;
+  }
+  return "command" in request.request ? "exec" : "plugin";
+}
+
+function resolveApprovalForwardingConfig(params: {
+  cfg: OpenClawConfig;
+  approvalKind: ApprovalKind;
+}): ApprovalForwardingConfig | undefined {
+  return params.approvalKind === "plugin"
+    ? params.cfg.approvals?.plugin
+    : params.cfg.approvals?.exec;
+}
+
+function normalizeApprovalForwardingMode(
+  mode: ApprovalForwardingConfig["mode"] | undefined,
+): ApprovalForwardingMode {
+  return mode ?? DEFAULT_APPROVAL_FORWARDING_MODE;
+}
+
+function approvalModeIncludesSession(mode: ApprovalForwardingMode): boolean {
+  return mode === "session" || mode === "both";
+}
+
+function approvalModeIncludesTargets(mode: ApprovalForwardingMode): boolean {
+  return mode === "targets" || mode === "both";
+}
+
+function matchesForwardingFilters(params: {
+  config: ApprovalForwardingConfig;
+  request: ApprovalRequest;
+}): boolean {
+  return matchesApprovalRequestFilters({
+    request: params.request.request,
+    agentFilter: params.config.agentFilter,
+    sessionFilter: params.config.sessionFilter,
+    fallbackAgentIdFromSessionKey: true,
+  });
+}
+
+function targetAccountMatchesWhatsAppAccount(params: {
+  cfg: OpenClawConfig;
+  targetAccountId?: string | null;
+  accountId?: string | null;
+}): boolean {
+  const targetAccountId = normalizeOptionalString(params.targetAccountId);
+  const accountId = normalizeOptionalString(params.accountId);
+  if (targetAccountId) {
+    return !accountId || normalizeAccountId(targetAccountId) === normalizeAccountId(accountId);
+  }
+  if (!accountId) {
+    return true;
+  }
+  const normalizedAccountId = normalizeAccountId(accountId);
+  const defaultAccountId = normalizeAccountId(resolveDefaultWhatsAppAccountId(params.cfg));
+  if (normalizedAccountId === defaultAccountId) {
+    return true;
+  }
+  const enabledAccountIds = listWhatsAppAccountIds(params.cfg)
+    .filter((candidateAccountId) =>
+      isWhatsAppApprovalTransportEnabled({
+        cfg: params.cfg,
+        accountId: candidateAccountId,
+      }),
+    )
+    .map((candidateAccountId) => normalizeAccountId(candidateAccountId));
+  return enabledAccountIds.length === 1 && enabledAccountIds[0] === normalizedAccountId;
+}
+
+function normalizeWhatsAppForwardTarget(
+  target: Pick<ChannelApprovalForwardTarget, "channel" | "to" | "accountId" | "threadId">,
+): WhatsAppApprovalTarget | null {
+  if (normalizeLowercaseStringOrEmpty(target.channel) !== "whatsapp") {
+    return null;
+  }
+  const to = normalizeWhatsAppMessagingTarget(target.to);
+  if (!to) {
+    return null;
+  }
+  return {
+    to,
+    accountId: normalizeOptionalString(target.accountId),
+    threadId: target.threadId ?? null,
+  };
+}
+
+function nativeApprovalTargetsMatch(params: {
+  left: WhatsAppApprovalTarget;
+  right: WhatsAppApprovalTarget;
+}): boolean {
+  return channelRouteTargetsMatchExact({
+    left: {
+      channel: "whatsapp",
+      to: params.left.to,
+      accountId: params.left.accountId,
+      threadId: params.left.threadId,
+    },
+    right: {
+      channel: "whatsapp",
+      to: params.right.to,
+      accountId: params.right.accountId,
+      threadId: params.right.threadId,
+    },
+  });
+}
+
+function hasMatchingWhatsAppTarget(params: {
+  cfg: OpenClawConfig;
+  config: ApprovalForwardingConfig;
+  accountId?: string | null;
+  target?: ChannelApprovalForwardTarget;
+}): boolean {
+  const candidateTarget = params.target ? normalizeWhatsAppForwardTarget(params.target) : null;
+  return (params.config.targets ?? []).some((target) => {
+    const configuredTarget = normalizeWhatsAppForwardTarget(target);
+    if (!configuredTarget) {
+      return false;
+    }
+    if (
+      !targetAccountMatchesWhatsAppAccount({
+        cfg: params.cfg,
+        targetAccountId: configuredTarget.accountId,
+        accountId: params.accountId,
+      })
+    ) {
+      return false;
+    }
+    if (!candidateTarget) {
+      return true;
+    }
+    return nativeApprovalTargetsMatch({ left: configuredTarget, right: candidateTarget });
+  });
+}
+
+function hasWhatsAppOriginOrSessionTarget(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  request: ApprovalRequest;
+}): boolean {
+  if (resolveTurnSourceWhatsAppOriginTarget(params.request)) {
+    return true;
+  }
+
+  const sessionTarget = resolveApprovalRequestSessionTarget({
+    cfg: params.cfg,
+    request: params.request,
+  });
+  return (
+    normalizeLowercaseStringOrEmpty(sessionTarget?.channel) === "whatsapp" &&
+    targetAccountMatchesWhatsAppAccount({
+      cfg: params.cfg,
+      targetAccountId: sessionTarget?.accountId,
+      accountId: params.accountId,
+    })
+  );
+}
+
+function canApprovalPotentiallyRouteToWhatsApp(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  approvalKind: ApprovalKind;
+  nativeSessionOnly?: boolean;
+}): boolean {
+  if (!isWhatsAppApprovalTransportEnabled(params)) {
+    return false;
+  }
+  const config = resolveApprovalForwardingConfig(params);
+  if (!config?.enabled) {
+    return false;
+  }
+  const mode = normalizeApprovalForwardingMode(config.mode);
+  if (approvalModeIncludesSession(mode)) {
+    return true;
+  }
+  if (params.nativeSessionOnly) {
+    return false;
+  }
+  return (
+    approvalModeIncludesTargets(mode) &&
+    hasMatchingWhatsAppTarget({
+      cfg: params.cfg,
+      config,
+      accountId: params.accountId,
+    })
+  );
+}
+
+function canAnyApprovalPotentiallyRouteToWhatsApp(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  nativeSessionOnly?: boolean;
+}): boolean {
+  return (
+    canApprovalPotentiallyRouteToWhatsApp({
+      ...params,
+      approvalKind: "exec",
+    }) ||
+    canApprovalPotentiallyRouteToWhatsApp({
+      ...params,
+      approvalKind: "plugin",
+    })
+  );
+}
+
+function isWhatsAppSessionApprovalEligible(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  approvalKind: ApprovalKind;
+  request: ApprovalRequest;
+}): boolean {
+  if (!isWhatsAppApprovalTransportEnabled(params)) {
+    return false;
+  }
+  const config = resolveApprovalForwardingConfig(params);
+  if (!config?.enabled) {
+    return false;
+  }
+  const mode = normalizeApprovalForwardingMode(config.mode);
+  if (!approvalModeIncludesSession(mode)) {
+    return false;
+  }
+  if (!matchesForwardingFilters({ config, request: params.request })) {
+    return false;
+  }
+  if (
+    !doesApprovalRequestMatchChannelAccount({
+      cfg: params.cfg,
+      request: params.request,
+      channel: "whatsapp",
+      accountId: params.accountId,
+    })
+  ) {
+    return false;
+  }
+  return hasWhatsAppOriginOrSessionTarget({
+    cfg: params.cfg,
+    accountId: params.accountId,
+    request: params.request,
+  });
+}
+
+function isWhatsAppExplicitTargetEligible(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  approvalKind: ApprovalKind;
+  request: ApprovalRequest;
+  target: ChannelApprovalForwardTarget;
+}): boolean {
+  if (!isWhatsAppApprovalTransportEnabled(params)) {
+    return false;
+  }
+  const config = resolveApprovalForwardingConfig(params);
+  if (!config?.enabled) {
+    return false;
+  }
+  const mode = normalizeApprovalForwardingMode(config.mode);
+  if (!approvalModeIncludesTargets(mode)) {
+    return false;
+  }
+  if (!matchesForwardingFilters({ config, request: params.request })) {
+    return false;
+  }
+  return hasMatchingWhatsAppTarget({
+    cfg: params.cfg,
+    config,
+    accountId: params.accountId,
+    target: params.target,
+  });
 }
 
 function resolveTurnSourceWhatsAppOriginTarget(
@@ -61,16 +355,12 @@ function resolveSessionWhatsAppOriginTarget(sessionTarget: {
 function shouldHandleWhatsAppApprovalRequest(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
+  approvalKind?: ApprovalKind;
   request: ApprovalRequest;
 }): boolean {
-  if (!isWhatsAppNativeApprovalEnabled(params)) {
-    return false;
-  }
-  return doesApprovalRequestMatchChannelAccount({
-    cfg: params.cfg,
-    request: params.request,
-    channel: "whatsapp",
-    accountId: params.accountId,
+  return isWhatsAppSessionApprovalEligible({
+    ...params,
+    approvalKind: resolveApprovalKind(params.request, params.approvalKind),
   });
 }
 
@@ -122,12 +412,16 @@ const resolveWhatsAppApproverDmTargets = createChannelApproverDmTargetResolver({
 export const whatsappApprovalCapability: ChannelApprovalCapability =
   createChannelApprovalCapability({
     ...whatsappApprovalAuth,
-    getActionAvailabilityState: ({ cfg, accountId }) =>
-      isWhatsAppNativeApprovalEnabled({ cfg, accountId })
+    getActionAvailabilityState: ({ cfg, accountId, approvalKind }) =>
+      (
+        approvalKind
+          ? canApprovalPotentiallyRouteToWhatsApp({ cfg, accountId, approvalKind })
+          : canAnyApprovalPotentiallyRouteToWhatsApp({ cfg, accountId })
+      )
         ? ({ kind: "enabled" } as const)
         : ({ kind: "disabled" } as const),
     getExecInitiatingSurfaceState: ({ cfg, accountId }) =>
-      isWhatsAppNativeApprovalEnabled({ cfg, accountId })
+      canApprovalPotentiallyRouteToWhatsApp({ cfg, accountId, approvalKind: "exec" })
         ? ({ kind: "enabled" } as const)
         : ({ kind: "disabled" } as const),
     describeExecApprovalSetup: ({ accountId }) => {
@@ -135,40 +429,90 @@ export const whatsappApprovalCapability: ChannelApprovalCapability =
         accountId && accountId !== "default"
           ? `channels.whatsapp.accounts.${accountId}`
           : "channels.whatsapp";
-      return `WhatsApp supports native exec approvals for this account. Link WhatsApp and keep the gateway running; configure \`${prefix}.allowFrom\` or \`${prefix}.defaultTo\` to restrict approvers.`;
+      return `WhatsApp supports native exec approvals for this account when \`approvals.exec.enabled\` is true and the route allows WhatsApp. Link WhatsApp and keep the gateway running; configure \`${prefix}.allowFrom\` or \`${prefix}.defaultTo\` to restrict approvers.`;
     },
     delivery: {
       hasConfiguredDmRoute: ({ cfg }) =>
         listWhatsAppAccountIds(cfg).some((accountId) => {
-          if (!isWhatsAppNativeApprovalEnabled({ cfg, accountId })) {
+          if (
+            !canAnyApprovalPotentiallyRouteToWhatsApp({
+              cfg,
+              accountId,
+              nativeSessionOnly: true,
+            })
+          ) {
             return false;
           }
           return getWhatsAppApprovalApprovers({ cfg, accountId }).length > 0;
         }),
-      shouldSuppressForwardingFallback: ({ cfg, target, request }) => {
-        const channel = normalizeLowercaseStringOrEmpty(target.channel);
-        if (channel !== "whatsapp") {
+      shouldSuppressForwardingFallback: ({ cfg, approvalKind, target, request }) => {
+        const forwardingTarget = normalizeWhatsAppForwardTarget(target);
+        if (!forwardingTarget) {
           return false;
         }
         const accountId =
-          normalizeOptionalString(target.accountId) ??
+          forwardingTarget.accountId ??
           normalizeOptionalString(request.request.turnSourceAccountId);
-        if (!shouldHandleWhatsAppApprovalRequest({ cfg, accountId, request })) {
+        const forwardingTargetForMatch = {
+          ...forwardingTarget,
+          accountId,
+        };
+        const kind = resolveApprovalKind(request, approvalKind);
+        const eligible =
+          target.source === "target"
+            ? isWhatsAppExplicitTargetEligible({
+                cfg,
+                accountId,
+                approvalKind: kind,
+                request,
+                target,
+              })
+            : isWhatsAppSessionApprovalEligible({
+                cfg,
+                accountId,
+                approvalKind: kind,
+                request,
+              });
+        if (!eligible) {
           return false;
         }
-        if (resolveWhatsAppOriginTarget({ cfg, accountId, request })) {
+        const originTarget = resolveWhatsAppOriginTarget({
+          cfg,
+          accountId,
+          approvalKind: kind,
+          request,
+        });
+        if (
+          originTarget &&
+          nativeApprovalTargetsMatch({ left: forwardingTargetForMatch, right: originTarget })
+        ) {
           return true;
         }
-        return resolveWhatsAppApproverDmTargets({ cfg, accountId, request }).length > 0;
+        return resolveWhatsAppApproverDmTargets({
+          cfg,
+          accountId,
+          approvalKind: kind,
+          request,
+        }).some((approverTarget) =>
+          nativeApprovalTargetsMatch({ left: forwardingTargetForMatch, right: approverTarget }),
+        );
       },
     },
     native: {
-      describeDeliveryCapabilities: ({ cfg, accountId, request }) => {
-        const originTarget = resolveWhatsAppOriginTarget({ cfg, accountId, request });
-        const approverTargets = resolveWhatsAppApproverDmTargets({ cfg, accountId, request });
-        const enabled =
-          isWhatsAppNativeApprovalEnabled({ cfg, accountId }) &&
-          (Boolean(originTarget) || approverTargets.length > 0);
+      describeDeliveryCapabilities: ({ cfg, accountId, approvalKind, request }) => {
+        const originTarget = resolveWhatsAppOriginTarget({
+          cfg,
+          accountId,
+          approvalKind,
+          request,
+        });
+        const approverTargets = resolveWhatsAppApproverDmTargets({
+          cfg,
+          accountId,
+          approvalKind,
+          request,
+        });
+        const enabled = Boolean(originTarget) || approverTargets.length > 0;
         return {
           enabled,
           preferredSurface: originTarget ? "origin" : "approver-dm",
@@ -183,7 +527,12 @@ export const whatsappApprovalCapability: ChannelApprovalCapability =
     nativeRuntime: createLazyChannelApprovalNativeRuntimeAdapter({
       eventKinds: ["exec", "plugin"],
       isConfigured: ({ cfg, accountId, context }) =>
-        Boolean(context) && isWhatsAppNativeApprovalEnabled({ cfg, accountId }),
+        Boolean(context) &&
+        canAnyApprovalPotentiallyRouteToWhatsApp({
+          cfg,
+          accountId,
+          nativeSessionOnly: true,
+        }),
       shouldHandle: ({ cfg, accountId, context, request }) =>
         Boolean(context) && shouldHandleWhatsAppApprovalRequest({ cfg, accountId, request }),
       load: async () =>

--- a/extensions/whatsapp/src/approval-native.ts
+++ b/extensions/whatsapp/src/approval-native.ts
@@ -1,0 +1,197 @@
+import {
+  createChannelApprovalCapability,
+  splitChannelApprovalCapability,
+} from "openclaw/plugin-sdk/approval-delivery-runtime";
+import { createLazyChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
+import type { ChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-runtime";
+import {
+  createChannelApproverDmTargetResolver,
+  createChannelNativeOriginTargetResolver,
+  doesApprovalRequestMatchChannelAccount,
+} from "openclaw/plugin-sdk/approval-native-runtime";
+import type {
+  ExecApprovalRequest,
+  PluginApprovalRequest,
+} from "openclaw/plugin-sdk/approval-runtime";
+import type { ChannelApprovalCapability } from "openclaw/plugin-sdk/channel-contract";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+import { listWhatsAppAccountIds, resolveWhatsAppAccount } from "./accounts.js";
+import { getWhatsAppApprovalApprovers, whatsappApprovalAuth } from "./approval-auth.js";
+import { isWhatsAppGroupJid, normalizeWhatsAppMessagingTarget } from "./normalize.js";
+
+type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
+type WhatsAppApprovalTarget = { to: string; accountId?: string | null };
+
+function isWhatsAppNativeApprovalEnabled(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): boolean {
+  return resolveWhatsAppAccount({ cfg: params.cfg, accountId: params.accountId }).enabled;
+}
+
+function resolveTurnSourceWhatsAppOriginTarget(
+  request: ApprovalRequest,
+): WhatsAppApprovalTarget | null {
+  const turnSourceChannel = normalizeLowercaseStringOrEmpty(request.request.turnSourceChannel);
+  if (turnSourceChannel !== "whatsapp") {
+    return null;
+  }
+  const to = normalizeWhatsAppMessagingTarget(request.request.turnSourceTo ?? "");
+  if (!to) {
+    return null;
+  }
+  return {
+    to,
+    accountId: normalizeOptionalString(request.request.turnSourceAccountId),
+  };
+}
+
+function resolveSessionWhatsAppOriginTarget(sessionTarget: {
+  to: string;
+  accountId?: string | null;
+}): WhatsAppApprovalTarget | null {
+  const to = normalizeWhatsAppMessagingTarget(sessionTarget.to);
+  return to ? { to, accountId: normalizeOptionalString(sessionTarget.accountId) } : null;
+}
+
+function shouldHandleWhatsAppApprovalRequest(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  request: ApprovalRequest;
+}): boolean {
+  if (!isWhatsAppNativeApprovalEnabled(params)) {
+    return false;
+  }
+  return doesApprovalRequestMatchChannelAccount({
+    cfg: params.cfg,
+    request: params.request,
+    channel: "whatsapp",
+    accountId: params.accountId,
+  });
+}
+
+const resolveWhatsAppOriginTargetBase = createChannelNativeOriginTargetResolver({
+  channel: "whatsapp",
+  shouldHandleRequest: shouldHandleWhatsAppApprovalRequest,
+  resolveTurnSourceTarget: resolveTurnSourceWhatsAppOriginTarget,
+  resolveSessionTarget: resolveSessionWhatsAppOriginTarget,
+  normalizeTarget: (target) => {
+    const to = normalizeWhatsAppMessagingTarget(target.to);
+    return to ? { ...target, to } : null;
+  },
+});
+
+function resolveWhatsAppOriginTarget(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  approvalKind?: "exec" | "plugin";
+  request: ApprovalRequest;
+}): WhatsAppApprovalTarget | null {
+  const target = resolveWhatsAppOriginTargetBase(params);
+  if (!target) {
+    return null;
+  }
+  if (
+    isWhatsAppGroupJid(target.to) &&
+    getWhatsAppApprovalApprovers({ cfg: params.cfg, accountId: params.accountId }).length === 0
+  ) {
+    return null;
+  }
+  return target;
+}
+
+const resolveWhatsAppApproverDmTargets = createChannelApproverDmTargetResolver({
+  shouldHandleRequest: shouldHandleWhatsAppApprovalRequest,
+  resolveApprovers: getWhatsAppApprovalApprovers,
+  mapApprover: (approver, params) => {
+    const to = normalizeWhatsAppMessagingTarget(approver);
+    if (!to) {
+      return null;
+    }
+    return {
+      to,
+      accountId: normalizeOptionalString(params.accountId),
+    };
+  },
+});
+
+export const whatsappApprovalCapability: ChannelApprovalCapability =
+  createChannelApprovalCapability({
+    ...whatsappApprovalAuth,
+    getActionAvailabilityState: ({ cfg, accountId }) =>
+      isWhatsAppNativeApprovalEnabled({ cfg, accountId })
+        ? ({ kind: "enabled" } as const)
+        : ({ kind: "disabled" } as const),
+    getExecInitiatingSurfaceState: ({ cfg, accountId }) =>
+      isWhatsAppNativeApprovalEnabled({ cfg, accountId })
+        ? ({ kind: "enabled" } as const)
+        : ({ kind: "disabled" } as const),
+    describeExecApprovalSetup: ({ accountId }) => {
+      const prefix =
+        accountId && accountId !== "default"
+          ? `channels.whatsapp.accounts.${accountId}`
+          : "channels.whatsapp";
+      return `WhatsApp supports native exec approvals for this account. Link WhatsApp and keep the gateway running; configure \`${prefix}.allowFrom\` or \`${prefix}.defaultTo\` to restrict approvers.`;
+    },
+    delivery: {
+      hasConfiguredDmRoute: ({ cfg }) =>
+        listWhatsAppAccountIds(cfg).some((accountId) => {
+          if (!isWhatsAppNativeApprovalEnabled({ cfg, accountId })) {
+            return false;
+          }
+          return getWhatsAppApprovalApprovers({ cfg, accountId }).length > 0;
+        }),
+      shouldSuppressForwardingFallback: ({ cfg, target, request }) => {
+        const channel = normalizeLowercaseStringOrEmpty(target.channel);
+        if (channel !== "whatsapp") {
+          return false;
+        }
+        const accountId =
+          normalizeOptionalString(target.accountId) ??
+          normalizeOptionalString(request.request.turnSourceAccountId);
+        if (!shouldHandleWhatsAppApprovalRequest({ cfg, accountId, request })) {
+          return false;
+        }
+        if (resolveWhatsAppOriginTarget({ cfg, accountId, request })) {
+          return true;
+        }
+        return resolveWhatsAppApproverDmTargets({ cfg, accountId, request }).length > 0;
+      },
+    },
+    native: {
+      describeDeliveryCapabilities: ({ cfg, accountId, request }) => {
+        const originTarget = resolveWhatsAppOriginTarget({ cfg, accountId, request });
+        const approverTargets = resolveWhatsAppApproverDmTargets({ cfg, accountId, request });
+        const enabled =
+          isWhatsAppNativeApprovalEnabled({ cfg, accountId }) &&
+          (Boolean(originTarget) || approverTargets.length > 0);
+        return {
+          enabled,
+          preferredSurface: originTarget ? "origin" : "approver-dm",
+          supportsOriginSurface: Boolean(originTarget),
+          supportsApproverDmSurface: approverTargets.length > 0,
+          notifyOriginWhenDmOnly: true,
+        };
+      },
+      resolveOriginTarget: resolveWhatsAppOriginTarget,
+      resolveApproverDmTargets: resolveWhatsAppApproverDmTargets,
+    },
+    nativeRuntime: createLazyChannelApprovalNativeRuntimeAdapter({
+      eventKinds: ["exec", "plugin"],
+      isConfigured: ({ cfg, accountId, context }) =>
+        Boolean(context) && isWhatsAppNativeApprovalEnabled({ cfg, accountId }),
+      shouldHandle: ({ cfg, accountId, context, request }) =>
+        Boolean(context) && shouldHandleWhatsAppApprovalRequest({ cfg, accountId, request }),
+      load: async () =>
+        (await import("./approval-handler.runtime.js"))
+          .whatsappApprovalNativeRuntime as unknown as ChannelApprovalNativeRuntimeAdapter,
+    }),
+  });
+
+export const whatsappNativeApprovalAdapter = splitChannelApprovalCapability(
+  whatsappApprovalCapability,
+);

--- a/extensions/whatsapp/src/approval-reactions.test.ts
+++ b/extensions/whatsapp/src/approval-reactions.test.ts
@@ -1,0 +1,333 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildWhatsAppApprovalReactionHint,
+  clearWhatsAppApprovalReactionTargetsForTest,
+  extractWhatsAppApprovalPromptBinding,
+  maybeResolveWhatsAppApprovalReaction,
+  registerWhatsAppApprovalReactionTargetForOutboundMessage,
+  registerWhatsAppApprovalReactionTarget,
+  resolveWhatsAppApprovalReactionTargetWithPersistence,
+} from "./approval-reactions.js";
+
+const resolverMocks = vi.hoisted(() => ({
+  resolveWhatsAppApproval: vi.fn(),
+  isApprovalNotFoundError: vi.fn(() => false),
+}));
+
+vi.mock("./approval-resolver.js", () => ({
+  resolveWhatsAppApproval: resolverMocks.resolveWhatsAppApproval,
+  isApprovalNotFoundError: resolverMocks.isApprovalNotFoundError,
+}));
+
+describe("WhatsApp approval reactions", () => {
+  beforeEach(() => {
+    clearWhatsAppApprovalReactionTargetsForTest();
+    resolverMocks.resolveWhatsAppApproval.mockReset();
+    resolverMocks.resolveWhatsAppApproval.mockResolvedValue(undefined);
+    resolverMocks.isApprovalNotFoundError.mockReset();
+    resolverMocks.isApprovalNotFoundError.mockReturnValue(false);
+  });
+
+  it("renders numeric reaction choices for allowed decisions", () => {
+    expect(buildWhatsAppApprovalReactionHint(["allow-once", "deny"])).toBe(
+      "React with:\n\n1️⃣ Allow Once\n3️⃣ Deny",
+    );
+  });
+
+  it("resolves a registered reaction target", async () => {
+    registerWhatsAppApprovalReactionTarget({
+      accountId: "default",
+      remoteJid: "15551230000@s.whatsapp.net",
+      messageId: "msg-1",
+      approvalId: "exec-1",
+      allowedDecisions: ["allow-once", "deny"],
+    });
+
+    await expect(
+      resolveWhatsAppApprovalReactionTargetWithPersistence({
+        accountId: "default",
+        remoteJid: "15551230000@s.whatsapp.net",
+        messageId: "msg-1",
+        reactionKey: "3️⃣",
+      }),
+    ).resolves.toEqual({
+      approvalId: "exec-1",
+      decision: "deny",
+    });
+  });
+
+  it("extracts approval bindings from explicit outbound prompts", async () => {
+    expect(
+      extractWhatsAppApprovalPromptBinding(
+        [
+          "Plugin approval required",
+          "ID: plugin:abc",
+          "Reply with: /approve plugin:abc allow-once|allow-always|deny",
+        ].join("\n"),
+      ),
+    ).toEqual({
+      approvalId: "plugin:abc",
+      allowedDecisions: ["allow-once", "allow-always", "deny"],
+    });
+
+    expect(
+      registerWhatsAppApprovalReactionTargetForOutboundMessage({
+        accountId: "default",
+        remoteJid: "15551230000@s.whatsapp.net",
+        messageId: "prompt-message",
+        text: "Reply with: /approve exec-1 allow-once|deny",
+      }),
+    ).toBe(true);
+
+    await expect(
+      resolveWhatsAppApprovalReactionTargetWithPersistence({
+        accountId: "default",
+        remoteJid: "15551230000@s.whatsapp.net",
+        messageId: "prompt-message",
+        reactionKey: "3️⃣",
+      }),
+    ).resolves.toEqual({
+      approvalId: "exec-1",
+      decision: "deny",
+    });
+  });
+
+  it("authorizes group reactions using the participant, not the group chat", async () => {
+    registerWhatsAppApprovalReactionTarget({
+      accountId: "default",
+      remoteJid: "120363401234567890@g.us",
+      messageId: "approval-message",
+      approvalId: "plugin:abc",
+      allowedDecisions: ["allow-once", "allow-always", "deny"],
+    });
+
+    const handled = await maybeResolveWhatsAppApprovalReaction({
+      cfg: {
+        channels: {
+          whatsapp: {
+            allowFrom: ["+15551230000"],
+          },
+        },
+      },
+      accountId: "default",
+      msg: {
+        key: {
+          remoteJid: "120363401234567890@g.us",
+          participant: "15551230000@s.whatsapp.net",
+          fromMe: false,
+        },
+        message: {
+          reactionMessage: {
+            text: "1️⃣",
+            key: {
+              remoteJid: "120363401234567890@g.us",
+              id: "approval-message",
+            },
+          },
+        },
+      } as never,
+      resolveInboundJid: async (jid) =>
+        jid === "15551230000@s.whatsapp.net" ? "+15551230000" : null,
+    });
+
+    expect(handled).toBe(true);
+    expect(resolverMocks.resolveWhatsAppApproval).toHaveBeenCalledWith({
+      cfg: {
+        channels: {
+          whatsapp: {
+            allowFrom: ["+15551230000"],
+          },
+        },
+      },
+      approvalId: "plugin:abc",
+      decision: "allow-once",
+      senderId: "+15551230000",
+      gatewayUrl: undefined,
+    });
+  });
+
+  it("authorizes direct self-chat reactions from the account owner", async () => {
+    registerWhatsAppApprovalReactionTarget({
+      accountId: "default",
+      remoteJid: "276853659042038@lid",
+      messageId: "approval-message",
+      approvalId: "exec-self",
+      allowedDecisions: ["allow-once", "allow-always", "deny"],
+    });
+
+    const handled = await maybeResolveWhatsAppApprovalReaction({
+      cfg: {
+        channels: {
+          whatsapp: {
+            allowFrom: ["+15551230001"],
+          },
+        },
+      },
+      accountId: "default",
+      msg: {
+        key: {
+          id: "reaction-message",
+          remoteJid: "276853659042038@lid",
+          fromMe: true,
+        },
+        message: {
+          reactionMessage: {
+            text: "1️⃣",
+            key: {
+              remoteJid: "276853659042038@lid",
+              id: "approval-message",
+              fromMe: true,
+            },
+          },
+        },
+      } as never,
+      selfLid: "276853659042038@lid",
+      resolveInboundJid: async (jid) => (jid === "276853659042038@lid" ? "+15551230001" : null),
+    });
+
+    expect(handled).toBe(true);
+    expect(resolverMocks.resolveWhatsAppApproval).toHaveBeenCalledWith({
+      cfg: {
+        channels: {
+          whatsapp: {
+            allowFrom: ["+15551230001"],
+          },
+        },
+      },
+      approvalId: "exec-self",
+      decision: "allow-once",
+      senderId: "+15551230001",
+      gatewayUrl: undefined,
+    });
+  });
+
+  it("does not attribute a peer DM fromMe reaction to the peer", async () => {
+    registerWhatsAppApprovalReactionTarget({
+      accountId: "default",
+      remoteJid: "15551230000@s.whatsapp.net",
+      messageId: "approval-message",
+      approvalId: "exec-peer",
+      allowedDecisions: ["allow-once", "deny"],
+    });
+
+    const handled = await maybeResolveWhatsAppApprovalReaction({
+      cfg: {
+        channels: {
+          whatsapp: {
+            allowFrom: ["+15551230000"],
+          },
+        },
+      },
+      accountId: "default",
+      msg: {
+        key: {
+          id: "reaction-message",
+          remoteJid: "15551230000@s.whatsapp.net",
+          fromMe: true,
+        },
+        message: {
+          reactionMessage: {
+            text: "1️⃣",
+            key: {
+              remoteJid: "15551230000@s.whatsapp.net",
+              id: "approval-message",
+              fromMe: true,
+            },
+          },
+        },
+      } as never,
+      selfLid: "276853659042038@lid",
+      resolveInboundJid: async (jid) => {
+        if (jid === "15551230000@s.whatsapp.net") {
+          return "+15551230000";
+        }
+        if (jid === "276853659042038@lid") {
+          return "+15551230001";
+        }
+        return null;
+      },
+    });
+
+    expect(handled).toBe(true);
+    expect(resolverMocks.resolveWhatsAppApproval).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when a group reaction is missing actor identity", async () => {
+    registerWhatsAppApprovalReactionTarget({
+      accountId: "default",
+      remoteJid: "120363401234567890@g.us",
+      messageId: "approval-message",
+      approvalId: "exec-1",
+      allowedDecisions: ["allow-once"],
+    });
+
+    const handled = await maybeResolveWhatsAppApprovalReaction({
+      cfg: {
+        channels: {
+          whatsapp: {
+            allowFrom: ["+15551230000"],
+          },
+        },
+      },
+      accountId: "default",
+      msg: {
+        key: {
+          remoteJid: "120363401234567890@g.us",
+          fromMe: false,
+        },
+        message: {
+          reactionMessage: {
+            text: "1️⃣",
+            key: {
+              remoteJid: "120363401234567890@g.us",
+              id: "approval-message",
+            },
+          },
+        },
+      } as never,
+      resolveInboundJid: async () => null,
+    });
+
+    expect(handled).toBe(true);
+    expect(resolverMocks.resolveWhatsAppApproval).not.toHaveBeenCalled();
+  });
+
+  it("requires explicit approvers for group approval reactions", async () => {
+    registerWhatsAppApprovalReactionTarget({
+      accountId: "default",
+      remoteJid: "120363401234567890@g.us",
+      messageId: "approval-message",
+      approvalId: "exec-1",
+      allowedDecisions: ["allow-once"],
+    });
+
+    const handled = await maybeResolveWhatsAppApprovalReaction({
+      cfg: {
+        channels: {
+          whatsapp: {},
+        },
+      },
+      accountId: "default",
+      msg: {
+        key: {
+          remoteJid: "120363401234567890@g.us",
+          participant: "15551230000@s.whatsapp.net",
+          fromMe: false,
+        },
+        message: {
+          reactionMessage: {
+            text: "1️⃣",
+            key: {
+              remoteJid: "120363401234567890@g.us",
+              id: "approval-message",
+            },
+          },
+        },
+      } as never,
+      resolveInboundJid: async () => "+15551230000",
+    });
+
+    expect(handled).toBe(true);
+    expect(resolverMocks.resolveWhatsAppApproval).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/whatsapp/src/approval-reactions.test.ts
+++ b/extensions/whatsapp/src/approval-reactions.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  appendWhatsAppApprovalReactionHintForOutboundMessage,
   buildWhatsAppApprovalReactionHint,
   clearWhatsAppApprovalReactionTargetsForTest,
   extractWhatsAppApprovalPromptBinding,
@@ -28,10 +29,52 @@ describe("WhatsApp approval reactions", () => {
     resolverMocks.isApprovalNotFoundError.mockReturnValue(false);
   });
 
-  it("renders numeric reaction choices for allowed decisions", () => {
+  it("renders thumbs-only reaction choices for allowed decisions", () => {
     expect(buildWhatsAppApprovalReactionHint(["allow-once", "deny"])).toBe(
-      "React with:\n\n1️⃣ Allow Once\n3️⃣ Deny",
+      "React with:\n\n👍 Allow Once\n👎 Deny",
     );
+  });
+
+  it("appends thumbs-only reaction choices to outbound approval prompts", () => {
+    expect(
+      appendWhatsAppApprovalReactionHintForOutboundMessage(
+        "Exec approval required\nID: exec-1\n\nReply with: /approve exec-1 allow-once|deny",
+      ),
+    ).toBe(
+      "Exec approval required\nID: exec-1\n\nReact with:\n\n👍 Allow Once\n👎 Deny\n\nReply with: /approve exec-1 allow-once|deny",
+    );
+  });
+
+  it("does not duplicate reaction choices on native approval prompts", () => {
+    const prompt = [
+      "Plugin approval required",
+      "Reply with: /approve plugin:abc allow-once|allow-always|deny",
+      "",
+      "React with:",
+      "",
+      "👍 Allow Once",
+      "👎 Deny",
+    ].join("\n");
+
+    expect(appendWhatsAppApprovalReactionHintForOutboundMessage(prompt)).toBe(prompt);
+  });
+
+  it("does not expose allow-always as a reaction choice", () => {
+    expect(buildWhatsAppApprovalReactionHint(["allow-once", "allow-always", "deny"])).toBe(
+      "React with:\n\n👍 Allow Once\n👎 Deny",
+    );
+  });
+
+  it("does not register reaction state when only allow-always is available", () => {
+    expect(
+      registerWhatsAppApprovalReactionTarget({
+        accountId: "default",
+        remoteJid: "15551230000@s.whatsapp.net",
+        messageId: "msg-allow-always",
+        approvalId: "exec-allow-always",
+        allowedDecisions: ["allow-always"],
+      }),
+    ).toBeNull();
   });
 
   it("resolves a registered reaction target", async () => {
@@ -48,7 +91,7 @@ describe("WhatsApp approval reactions", () => {
         accountId: "default",
         remoteJid: "15551230000@s.whatsapp.net",
         messageId: "msg-1",
-        reactionKey: "3️⃣",
+        reactionKey: "👎",
       }),
     ).resolves.toEqual({
       approvalId: "exec-1",
@@ -84,12 +127,23 @@ describe("WhatsApp approval reactions", () => {
         accountId: "default",
         remoteJid: "15551230000@s.whatsapp.net",
         messageId: "prompt-message",
-        reactionKey: "3️⃣",
+        reactionKey: "👎",
       }),
     ).resolves.toEqual({
       approvalId: "exec-1",
       decision: "deny",
     });
+
+    for (const reactionKey of ["1️⃣", "2️⃣", "3️⃣", "1", "2", "3"]) {
+      await expect(
+        resolveWhatsAppApprovalReactionTargetWithPersistence({
+          accountId: "default",
+          remoteJid: "15551230000@s.whatsapp.net",
+          messageId: "prompt-message",
+          reactionKey,
+        }),
+      ).resolves.toBeNull();
+    }
   });
 
   it("authorizes group reactions using the participant, not the group chat", async () => {
@@ -118,7 +172,7 @@ describe("WhatsApp approval reactions", () => {
         },
         message: {
           reactionMessage: {
-            text: "1️⃣",
+            text: "👍",
             key: {
               remoteJid: "120363401234567890@g.us",
               id: "approval-message",
@@ -172,7 +226,7 @@ describe("WhatsApp approval reactions", () => {
         },
         message: {
           reactionMessage: {
-            text: "1️⃣",
+            text: "👍",
             key: {
               remoteJid: "276853659042038@lid",
               id: "approval-message",
@@ -227,7 +281,7 @@ describe("WhatsApp approval reactions", () => {
         },
         message: {
           reactionMessage: {
-            text: "1️⃣",
+            text: "👍",
             key: {
               remoteJid: "15551230000@s.whatsapp.net",
               id: "approval-message",
@@ -277,7 +331,7 @@ describe("WhatsApp approval reactions", () => {
         },
         message: {
           reactionMessage: {
-            text: "1️⃣",
+            text: "👍",
             key: {
               remoteJid: "120363401234567890@g.us",
               id: "approval-message",
@@ -286,6 +340,44 @@ describe("WhatsApp approval reactions", () => {
         },
       } as never,
       resolveInboundJid: async () => null,
+    });
+
+    expect(handled).toBe(true);
+    expect(resolverMocks.resolveWhatsAppApproval).not.toHaveBeenCalled();
+  });
+
+  it("requires explicit approvers for direct approval reactions", async () => {
+    registerWhatsAppApprovalReactionTarget({
+      accountId: "default",
+      remoteJid: "15551230000@s.whatsapp.net",
+      messageId: "approval-message",
+      approvalId: "exec-1",
+      allowedDecisions: ["allow-once"],
+    });
+
+    const handled = await maybeResolveWhatsAppApprovalReaction({
+      cfg: {
+        channels: {
+          whatsapp: {},
+        },
+      },
+      accountId: "default",
+      msg: {
+        key: {
+          remoteJid: "15551230000@s.whatsapp.net",
+          fromMe: false,
+        },
+        message: {
+          reactionMessage: {
+            text: "👍",
+            key: {
+              remoteJid: "15551230000@s.whatsapp.net",
+              id: "approval-message",
+            },
+          },
+        },
+      } as never,
+      resolveInboundJid: async () => "+15551230000",
     });
 
     expect(handled).toBe(true);
@@ -316,7 +408,7 @@ describe("WhatsApp approval reactions", () => {
         },
         message: {
           reactionMessage: {
-            text: "1️⃣",
+            text: "👍",
             key: {
               remoteJid: "120363401234567890@g.us",
               id: "approval-message",

--- a/extensions/whatsapp/src/approval-reactions.ts
+++ b/extensions/whatsapp/src/approval-reactions.ts
@@ -6,22 +6,17 @@ import { getOptionalWhatsAppRuntime } from "./runtime.js";
 
 const WHATSAPP_APPROVAL_REACTION_META = {
   "allow-once": {
-    emoji: "1️⃣",
+    emoji: "👍",
     label: "Allow Once",
   },
-  "allow-always": {
-    emoji: "2️⃣",
-    label: "Allow Always",
-  },
   deny: {
-    emoji: "3️⃣",
+    emoji: "👎",
     label: "Deny",
   },
-} satisfies Record<ExecApprovalReplyDecision, { emoji: string; label: string }>;
+} satisfies Partial<Record<ExecApprovalReplyDecision, { emoji: string; label: string }>>;
 
 const WHATSAPP_APPROVAL_REACTION_ORDER = [
   "allow-once",
-  "allow-always",
   "deny",
 ] as const satisfies readonly ExecApprovalReplyDecision[];
 
@@ -205,6 +200,50 @@ export function buildWhatsAppApprovalReactionHint(
   return `React with:\n\n${bindings.map((binding) => `${binding.emoji} ${binding.label}`).join("\n")}`;
 }
 
+function insertWhatsAppApprovalReactionHintNearHeader(params: {
+  text: string;
+  hint: string;
+}): string {
+  const lines = params.text.split(/\r?\n/);
+  const idLineIndex = lines.findIndex((line) => /^ID:\s*\S+/.test(line.trim()));
+  if (idLineIndex >= 0) {
+    const before = lines.slice(0, idLineIndex + 1).join("\n");
+    const after = lines
+      .slice(idLineIndex + 1)
+      .join("\n")
+      .replace(/^\n+/, "");
+    return after ? `${before}\n\n${params.hint}\n\n${after}` : `${before}\n\n${params.hint}`;
+  }
+  return `${params.hint}\n\n${params.text}`;
+}
+
+export function addWhatsAppApprovalReactionHintToText(params: {
+  text: string;
+  allowedDecisions: readonly ExecApprovalReplyDecision[];
+}): string {
+  if (/(^|\n)React with:\s*(\n|$)/i.test(params.text)) {
+    return params.text;
+  }
+  const hint = buildWhatsAppApprovalReactionHint(params.allowedDecisions);
+  return hint
+    ? insertWhatsAppApprovalReactionHintNearHeader({ text: params.text, hint })
+    : params.text;
+}
+
+export function appendWhatsAppApprovalReactionHintForOutboundMessage(text: string): string {
+  if (/(^|\n)React with:\s*(\n|$)/i.test(text)) {
+    return text;
+  }
+  const binding = extractWhatsAppApprovalPromptBinding(text);
+  if (!binding) {
+    return text;
+  }
+  return addWhatsAppApprovalReactionHintToText({
+    text,
+    allowedDecisions: binding.allowedDecisions,
+  });
+}
+
 function resolveWhatsAppApprovalReactionDecision(
   reactionKey: string,
   allowedDecisions: readonly ExecApprovalReplyDecision[],
@@ -272,13 +311,8 @@ export function registerWhatsAppApprovalReactionTarget(params: {
 }): WhatsAppApprovalReactionTarget | null {
   const key = buildReactionTargetKey(params);
   const approvalId = params.approvalId.trim();
-  const allowedDecisions = Array.from(
-    new Set(
-      params.allowedDecisions.filter(
-        (decision): decision is ExecApprovalReplyDecision =>
-          decision === "allow-once" || decision === "allow-always" || decision === "deny",
-      ),
-    ),
+  const allowedDecisions = listWhatsAppApprovalReactionBindings(params.allowedDecisions).map(
+    (binding) => binding.decision,
   );
   if (!key || !approvalId || allowedDecisions.length === 0) {
     return null;
@@ -426,12 +460,10 @@ export async function maybeResolveWhatsAppApprovalReaction(params: {
   }
 
   const approvalKind = target.approvalId.startsWith("plugin:") ? "plugin" : "exec";
-  if (
-    event.remoteJid.endsWith("@g.us") &&
-    getWhatsAppApprovalApprovers({ cfg: params.cfg, accountId: params.accountId }).length === 0
-  ) {
+  const approvers = getWhatsAppApprovalApprovers({ cfg: params.cfg, accountId: params.accountId });
+  if (approvers.length === 0) {
     params.logVerboseMessage?.(
-      `whatsapp: approval reaction denied id=${target.approvalId}; group reactions require explicit approvers`,
+      `whatsapp: approval reaction denied id=${target.approvalId}; reactions require explicit approvers`,
     );
     return true;
   }

--- a/extensions/whatsapp/src/approval-reactions.ts
+++ b/extensions/whatsapp/src/approval-reactions.ts
@@ -1,0 +1,489 @@
+import type { WAMessage } from "baileys";
+import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-reply-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { getWhatsAppApprovalApprovers, whatsappApprovalAuth } from "./approval-auth.js";
+import { getOptionalWhatsAppRuntime } from "./runtime.js";
+
+const WHATSAPP_APPROVAL_REACTION_META = {
+  "allow-once": {
+    emoji: "1️⃣",
+    label: "Allow Once",
+  },
+  "allow-always": {
+    emoji: "2️⃣",
+    label: "Allow Always",
+  },
+  deny: {
+    emoji: "3️⃣",
+    label: "Deny",
+  },
+} satisfies Record<ExecApprovalReplyDecision, { emoji: string; label: string }>;
+
+const WHATSAPP_APPROVAL_REACTION_ORDER = [
+  "allow-once",
+  "allow-always",
+  "deny",
+] as const satisfies readonly ExecApprovalReplyDecision[];
+
+const PERSISTENT_NAMESPACE = "whatsapp.approval-reactions";
+const PERSISTENT_MAX_ENTRIES = 1000;
+const DEFAULT_REACTION_TARGET_TTL_MS = 24 * 60 * 60 * 1000;
+
+export type WhatsAppApprovalReactionBinding = {
+  decision: ExecApprovalReplyDecision;
+  emoji: string;
+  label: string;
+};
+
+type WhatsAppApprovalReactionResolution = {
+  approvalId: string;
+  decision: ExecApprovalReplyDecision;
+};
+
+type WhatsAppApprovalReactionTarget = {
+  approvalId: string;
+  allowedDecisions: readonly ExecApprovalReplyDecision[];
+};
+
+type PersistedWhatsAppApprovalReactionTarget = {
+  version: 1;
+  target: WhatsAppApprovalReactionTarget;
+};
+
+type WhatsAppApprovalReactionStore = {
+  register(
+    key: string,
+    value: PersistedWhatsAppApprovalReactionTarget,
+    opts?: { ttlMs?: number },
+  ): Promise<void>;
+  lookup(key: string): Promise<PersistedWhatsAppApprovalReactionTarget | undefined>;
+  delete(key: string): Promise<boolean>;
+};
+
+type WhatsAppApprovalReactionEvent = {
+  remoteJid: string;
+  messageId: string;
+  actorJid: string;
+  reactionKey: string;
+};
+
+const whatsappApprovalReactionTargets = new Map<string, WhatsAppApprovalReactionTarget>();
+let persistentStore: WhatsAppApprovalReactionStore | undefined;
+let persistentStoreDisabled = false;
+let resolverRuntimePromise: Promise<typeof import("./approval-resolver.js")> | undefined;
+
+function loadApprovalResolver(): Promise<typeof import("./approval-resolver.js")> {
+  resolverRuntimePromise ??= import("./approval-resolver.js");
+  return resolverRuntimePromise;
+}
+
+function buildReactionTargetKey(params: {
+  accountId: string;
+  remoteJid: string;
+  messageId: string;
+}) {
+  const accountId = params.accountId.trim();
+  const remoteJid = params.remoteJid.trim();
+  const messageId = params.messageId.trim();
+  if (!accountId || !remoteJid || !messageId) {
+    return null;
+  }
+  return `${accountId}:${remoteJid}:${messageId}`;
+}
+
+function reportPersistentApprovalReactionError(error: unknown): void {
+  try {
+    getOptionalWhatsAppRuntime()
+      ?.logging.getChildLogger({ plugin: "whatsapp", feature: "approval-reaction-state" })
+      .warn("WhatsApp persistent approval reaction state failed", { error: String(error) });
+  } catch {
+    // Best effort only: persistent state must never break WhatsApp reactions.
+  }
+}
+
+function disablePersistentApprovalReactionStore(error: unknown): void {
+  persistentStoreDisabled = true;
+  persistentStore = undefined;
+  reportPersistentApprovalReactionError(error);
+}
+
+function getPersistentApprovalReactionStore(): WhatsAppApprovalReactionStore | undefined {
+  if (persistentStoreDisabled) {
+    return undefined;
+  }
+  if (persistentStore) {
+    return persistentStore;
+  }
+  const runtime = getOptionalWhatsAppRuntime();
+  if (!runtime) {
+    return undefined;
+  }
+  try {
+    persistentStore = runtime.state.openKeyedStore<PersistedWhatsAppApprovalReactionTarget>({
+      namespace: PERSISTENT_NAMESPACE,
+      maxEntries: PERSISTENT_MAX_ENTRIES,
+      defaultTtlMs: DEFAULT_REACTION_TARGET_TTL_MS,
+    });
+    return persistentStore;
+  } catch (error) {
+    disablePersistentApprovalReactionStore(error);
+    return undefined;
+  }
+}
+
+function readPersistedTarget(value: unknown): WhatsAppApprovalReactionTarget | null {
+  const persisted = value as PersistedWhatsAppApprovalReactionTarget | undefined;
+  if (
+    persisted?.version !== 1 ||
+    !persisted.target ||
+    typeof persisted.target.approvalId !== "string" ||
+    !Array.isArray(persisted.target.allowedDecisions)
+  ) {
+    return null;
+  }
+  return persisted.target;
+}
+
+function rememberPersistentApprovalReactionTarget(params: {
+  key: string;
+  target: WhatsAppApprovalReactionTarget;
+  ttlMs?: number;
+}): void {
+  const ttlMs = params.ttlMs == null ? DEFAULT_REACTION_TARGET_TTL_MS : Math.max(1, params.ttlMs);
+  const store = getPersistentApprovalReactionStore();
+  if (!store) {
+    return;
+  }
+  void store
+    .register(params.key, { version: 1, target: params.target }, { ttlMs })
+    .catch(disablePersistentApprovalReactionStore);
+}
+
+function forgetPersistentApprovalReactionTarget(key: string): void {
+  const store = getPersistentApprovalReactionStore();
+  if (!store) {
+    return;
+  }
+  void store.delete(key).catch(disablePersistentApprovalReactionStore);
+}
+
+async function lookupPersistentApprovalReactionTarget(
+  key: string,
+): Promise<WhatsAppApprovalReactionTarget | null> {
+  const store = getPersistentApprovalReactionStore();
+  if (!store) {
+    return null;
+  }
+  try {
+    return readPersistedTarget(await store.lookup(key));
+  } catch (error) {
+    disablePersistentApprovalReactionStore(error);
+    return null;
+  }
+}
+
+export function listWhatsAppApprovalReactionBindings(
+  allowedDecisions: readonly ExecApprovalReplyDecision[],
+): WhatsAppApprovalReactionBinding[] {
+  const allowed = new Set(allowedDecisions);
+  return WHATSAPP_APPROVAL_REACTION_ORDER.filter((decision) => allowed.has(decision)).map(
+    (decision) => ({
+      decision,
+      emoji: WHATSAPP_APPROVAL_REACTION_META[decision].emoji,
+      label: WHATSAPP_APPROVAL_REACTION_META[decision].label,
+    }),
+  );
+}
+
+export function buildWhatsAppApprovalReactionHint(
+  allowedDecisions: readonly ExecApprovalReplyDecision[],
+): string | null {
+  const bindings = listWhatsAppApprovalReactionBindings(allowedDecisions);
+  if (bindings.length === 0) {
+    return null;
+  }
+  return `React with:\n\n${bindings.map((binding) => `${binding.emoji} ${binding.label}`).join("\n")}`;
+}
+
+function resolveWhatsAppApprovalReactionDecision(
+  reactionKey: string,
+  allowedDecisions: readonly ExecApprovalReplyDecision[],
+): ExecApprovalReplyDecision | null {
+  const normalizedReaction = reactionKey.trim();
+  if (!normalizedReaction) {
+    return null;
+  }
+  const allowed = new Set(allowedDecisions);
+  for (const decision of WHATSAPP_APPROVAL_REACTION_ORDER) {
+    if (!allowed.has(decision)) {
+      continue;
+    }
+    if (WHATSAPP_APPROVAL_REACTION_META[decision].emoji === normalizedReaction) {
+      return decision;
+    }
+  }
+  return null;
+}
+
+function normalizeApprovalDecision(value: string): ExecApprovalReplyDecision | null {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "always") {
+    return "allow-always";
+  }
+  if (normalized === "allow-once" || normalized === "allow-always" || normalized === "deny") {
+    return normalized;
+  }
+  return null;
+}
+
+export function extractWhatsAppApprovalPromptBinding(text: string): {
+  approvalId: string;
+  allowedDecisions: ExecApprovalReplyDecision[];
+} | null {
+  const allowedDecisions: ExecApprovalReplyDecision[] = [];
+  let approvalId = "";
+  for (const line of text.split(/\r?\n/)) {
+    const match = line.match(/\/approve(?:@[^\s]+)?\s+([A-Za-z0-9][A-Za-z0-9._:-]*)\s+(.+)$/i);
+    if (!match) {
+      continue;
+    }
+    if (approvalId && match[1] !== approvalId) {
+      continue;
+    }
+    approvalId ||= match[1];
+    const decisions = match[2].split(/[\s|,]+/);
+    for (const decisionText of decisions) {
+      const decision = normalizeApprovalDecision(decisionText);
+      if (decision && !allowedDecisions.includes(decision)) {
+        allowedDecisions.push(decision);
+      }
+    }
+  }
+  return approvalId && allowedDecisions.length > 0 ? { approvalId, allowedDecisions } : null;
+}
+
+export function registerWhatsAppApprovalReactionTarget(params: {
+  accountId: string;
+  remoteJid: string;
+  messageId: string;
+  approvalId: string;
+  allowedDecisions: readonly ExecApprovalReplyDecision[];
+  ttlMs?: number;
+}): WhatsAppApprovalReactionTarget | null {
+  const key = buildReactionTargetKey(params);
+  const approvalId = params.approvalId.trim();
+  const allowedDecisions = Array.from(
+    new Set(
+      params.allowedDecisions.filter(
+        (decision): decision is ExecApprovalReplyDecision =>
+          decision === "allow-once" || decision === "allow-always" || decision === "deny",
+      ),
+    ),
+  );
+  if (!key || !approvalId || allowedDecisions.length === 0) {
+    return null;
+  }
+  const target = { approvalId, allowedDecisions };
+  whatsappApprovalReactionTargets.set(key, target);
+  rememberPersistentApprovalReactionTarget({ key, target, ttlMs: params.ttlMs });
+  return target;
+}
+
+export function registerWhatsAppApprovalReactionTargetForOutboundMessage(params: {
+  accountId: string;
+  remoteJid: string;
+  messageId: string;
+  text: string;
+  ttlMs?: number;
+}): boolean {
+  const binding = extractWhatsAppApprovalPromptBinding(params.text);
+  if (!binding) {
+    return false;
+  }
+  return Boolean(
+    registerWhatsAppApprovalReactionTarget({
+      accountId: params.accountId,
+      remoteJid: params.remoteJid,
+      messageId: params.messageId,
+      approvalId: binding.approvalId,
+      allowedDecisions: binding.allowedDecisions,
+      ttlMs: params.ttlMs,
+    }),
+  );
+}
+
+export function unregisterWhatsAppApprovalReactionTarget(params: {
+  accountId: string;
+  remoteJid: string;
+  messageId: string;
+}): void {
+  const key = buildReactionTargetKey(params);
+  if (!key) {
+    return;
+  }
+  whatsappApprovalReactionTargets.delete(key);
+  forgetPersistentApprovalReactionTarget(key);
+}
+
+function resolveTarget(params: {
+  target: WhatsAppApprovalReactionTarget | null | undefined;
+  reactionKey: string;
+}): WhatsAppApprovalReactionResolution | null {
+  const target = params.target;
+  if (!target) {
+    return null;
+  }
+  const decision = resolveWhatsAppApprovalReactionDecision(
+    params.reactionKey,
+    target.allowedDecisions,
+  );
+  return decision ? { approvalId: target.approvalId, decision } : null;
+}
+
+export async function resolveWhatsAppApprovalReactionTargetWithPersistence(params: {
+  accountId: string;
+  remoteJid: string;
+  messageId: string;
+  reactionKey: string;
+}): Promise<WhatsAppApprovalReactionResolution | null> {
+  const key = buildReactionTargetKey(params);
+  if (!key) {
+    return null;
+  }
+  const inMemory = resolveTarget({
+    target: whatsappApprovalReactionTargets.get(key),
+    reactionKey: params.reactionKey,
+  });
+  if (inMemory) {
+    return inMemory;
+  }
+  return resolveTarget({
+    target: await lookupPersistentApprovalReactionTarget(key),
+    reactionKey: params.reactionKey,
+  });
+}
+
+function readWhatsAppApprovalReactionEvent(params: {
+  msg: WAMessage;
+  selfJid?: string | null;
+  selfLid?: string | null;
+}): WhatsAppApprovalReactionEvent | null {
+  const msg = params.msg;
+  const reaction = msg.message?.reactionMessage;
+  const reactionKey = reaction?.text?.trim() ?? "";
+  const messageId = reaction?.key?.id?.trim() ?? "";
+  const remoteJid = (reaction?.key?.remoteJid ?? msg.key?.remoteJid ?? "").trim();
+  const actorJid =
+    msg.key?.participant?.trim() ||
+    (msg.key?.fromMe
+      ? (params.selfLid?.trim() ?? params.selfJid?.trim() ?? "")
+      : (msg.key?.remoteJid?.trim() ?? ""));
+  if (!reactionKey || !messageId || !remoteJid || !actorJid) {
+    return null;
+  }
+  return {
+    remoteJid,
+    messageId,
+    actorJid,
+    reactionKey,
+  };
+}
+
+export async function maybeResolveWhatsAppApprovalReaction(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  msg: WAMessage;
+  gatewayUrl?: string;
+  selfJid?: string | null;
+  selfLid?: string | null;
+  resolveInboundJid: (jid: string | null | undefined) => Promise<string | null>;
+  logVerboseMessage?: (message: string) => void;
+}): Promise<boolean> {
+  const event = readWhatsAppApprovalReactionEvent({
+    msg: params.msg,
+    selfJid: params.selfJid,
+    selfLid: params.selfLid,
+  });
+  if (!event) {
+    return false;
+  }
+  const target = await resolveWhatsAppApprovalReactionTargetWithPersistence({
+    accountId: params.accountId,
+    remoteJid: event.remoteJid,
+    messageId: event.messageId,
+    reactionKey: event.reactionKey,
+  });
+  if (!target) {
+    return false;
+  }
+
+  const actorId = await params.resolveInboundJid(event.actorJid);
+  if (!actorId) {
+    params.logVerboseMessage?.(
+      `whatsapp: approval reaction ignored for ${target.approvalId}; missing actor identity`,
+    );
+    return true;
+  }
+
+  const approvalKind = target.approvalId.startsWith("plugin:") ? "plugin" : "exec";
+  if (
+    event.remoteJid.endsWith("@g.us") &&
+    getWhatsAppApprovalApprovers({ cfg: params.cfg, accountId: params.accountId }).length === 0
+  ) {
+    params.logVerboseMessage?.(
+      `whatsapp: approval reaction denied id=${target.approvalId}; group reactions require explicit approvers`,
+    );
+    return true;
+  }
+  const auth = whatsappApprovalAuth.authorizeActorAction({
+    cfg: params.cfg,
+    accountId: params.accountId,
+    senderId: actorId,
+    action: "approve",
+    approvalKind,
+  });
+  if (!auth.authorized) {
+    params.logVerboseMessage?.(
+      `whatsapp: approval reaction denied id=${target.approvalId} sender=${actorId}`,
+    );
+    return true;
+  }
+
+  const { isApprovalNotFoundError, resolveWhatsAppApproval } = await loadApprovalResolver();
+  try {
+    await resolveWhatsAppApproval({
+      cfg: params.cfg,
+      approvalId: target.approvalId,
+      decision: target.decision,
+      senderId: actorId,
+      gatewayUrl: params.gatewayUrl,
+    });
+    params.logVerboseMessage?.(
+      `whatsapp: approval reaction resolved id=${target.approvalId} sender=${actorId} decision=${target.decision}`,
+    );
+    return true;
+  } catch (error) {
+    if (isApprovalNotFoundError(error)) {
+      unregisterWhatsAppApprovalReactionTarget({
+        accountId: params.accountId,
+        remoteJid: event.remoteJid,
+        messageId: event.messageId,
+      });
+      params.logVerboseMessage?.(
+        `whatsapp: approval reaction ignored for expired approval id=${target.approvalId} sender=${actorId}`,
+      );
+      return true;
+    }
+    params.logVerboseMessage?.(
+      `whatsapp: approval reaction failed id=${target.approvalId} sender=${actorId}: ${String(error)}`,
+    );
+    return true;
+  }
+}
+
+export function clearWhatsAppApprovalReactionTargetsForTest(): void {
+  whatsappApprovalReactionTargets.clear();
+  persistentStore = undefined;
+  persistentStoreDisabled = false;
+  resolverRuntimePromise = undefined;
+}

--- a/extensions/whatsapp/src/approval-resolver.ts
+++ b/extensions/whatsapp/src/approval-resolver.ts
@@ -1,0 +1,23 @@
+import { resolveApprovalOverGateway } from "openclaw/plugin-sdk/approval-gateway-runtime";
+import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-reply-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { isApprovalNotFoundError } from "openclaw/plugin-sdk/error-runtime";
+
+export { isApprovalNotFoundError };
+
+export async function resolveWhatsAppApproval(params: {
+  cfg: OpenClawConfig;
+  approvalId: string;
+  decision: ExecApprovalReplyDecision;
+  senderId?: string | null;
+  gatewayUrl?: string;
+}): Promise<void> {
+  await resolveApprovalOverGateway({
+    cfg: params.cfg,
+    approvalId: params.approvalId,
+    decision: params.decision,
+    senderId: params.senderId,
+    gatewayUrl: params.gatewayUrl,
+    clientDisplayName: `WhatsApp approval (${params.senderId?.trim() || "unknown"})`,
+  });
+}

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -1,5 +1,7 @@
 import { resolveAccountEntry } from "openclaw/plugin-sdk/account-core";
+import { CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { resolveInboundDebounceMs } from "openclaw/plugin-sdk/channel-inbound-debounce";
+import { registerChannelRuntimeContext } from "openclaw/plugin-sdk/channel-runtime-context";
 import { formatCliCommand } from "openclaw/plugin-sdk/cli-runtime";
 import { isControlCommandMessage } from "openclaw/plugin-sdk/command-detection";
 import { drainPendingDeliveries } from "openclaw/plugin-sdk/delivery-queue-runtime";
@@ -494,6 +496,14 @@ export async function monitorWebChannel(
       }
 
       statusController.noteConnected();
+      const approvalContextLease = registerChannelRuntimeContext({
+        channelRuntime: tuning.channelRuntime,
+        channelId: "whatsapp",
+        accountId: account.accountId,
+        capability: CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY,
+        context: { accountId: account.accountId },
+        abortSignal,
+      });
       controller.setUnhandledRejectionCleanup(
         registerUnhandledRejectionHandler((reason) => {
           if (!isLikelyWhatsAppCryptoError(reason)) {
@@ -580,13 +590,15 @@ export async function monitorWebChannel(
 
       if (!keepAlive) {
         clearInterval(periodicDrainInterval);
+        approvalContextLease?.dispose();
         await controller.shutdown();
         return;
       }
 
-      const reason = await controller
-        .waitForClose()
-        .finally(() => clearInterval(periodicDrainInterval));
+      const reason = await controller.waitForClose().finally(() => {
+        clearInterval(periodicDrainInterval);
+        approvalContextLease?.dispose();
+      });
       if (stopRequested() || sigintStop || reason === "aborted") {
         await controller.shutdown();
         break;

--- a/extensions/whatsapp/src/auto-reply/types.ts
+++ b/extensions/whatsapp/src/auto-reply/types.ts
@@ -1,3 +1,4 @@
+import type { ChannelRuntimeSurface } from "openclaw/plugin-sdk/channel-contract";
 import type { WebInboundMessage } from "../inbound/types.js";
 import type { ReconnectPolicy } from "../reconnect.js";
 import type { WhatsAppSocketTimingOptions } from "../socket-timing.js";
@@ -41,6 +42,7 @@ export type WebMonitorTuning = {
   watchdogCheckMs?: number;
   sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
   statusSink?: (status: WebChannelStatus) => void;
+  channelRuntime?: ChannelRuntimeSurface;
   /** WhatsApp account id. Default: "default". */
   accountId?: string;
   /** Debounce window (ms) for batching rapid consecutive messages from the same sender. */

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -8,7 +8,7 @@ import {
 } from "openclaw/plugin-sdk/status-helpers";
 import { resolveWhatsAppAccount, type ResolvedWhatsAppAccount } from "./accounts.js";
 import { createWhatsAppLoginTool } from "./agent-tools-login.js";
-import { whatsappApprovalAuth } from "./approval-auth.js";
+import { whatsappApprovalCapability } from "./approval-native.js";
 import type { WebChannelStatus } from "./auto-reply/types.js";
 import {
   describeWhatsAppMessageActions,
@@ -179,7 +179,7 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
             toolContext,
           }),
       },
-      approvalCapability: whatsappApprovalAuth,
+      approvalCapability: whatsappApprovalCapability,
       auth: {
         login: async ({ cfg, accountId, runtime, verbose }) => {
           const resolvedAccountId =
@@ -325,6 +325,7 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
               statusSink: (next: WebChannelStatus) =>
                 ctx.setStatus({ accountId: ctx.accountId, ...next }),
               accountId: account.accountId,
+              channelRuntime: ctx.channelRuntime,
             },
           );
         },

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -12,6 +12,7 @@ import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debo
 import { getChildLogger } from "openclaw/plugin-sdk/logging-core";
 import { defaultRuntime } from "openclaw/plugin-sdk/runtime-env";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
+import { maybeResolveWhatsAppApprovalReaction } from "../approval-reactions.js";
 import { readWebSelfIdentityForDecision, WhatsAppAuthUnstableError } from "../auth-store.js";
 import { getPrimaryIdentityId, resolveComparableIdentity } from "../identity.js";
 import { cacheInboundMessageMeta } from "../quoted-message.js";
@@ -1054,6 +1055,20 @@ export async function attachWebInboxToSocket(
       return;
     }
     for (const msg of upsert.messages ?? []) {
+      if (
+        await maybeResolveWhatsAppApprovalReaction({
+          cfg: options.loadConfig?.() ?? options.cfg,
+          accountId: options.accountId,
+          msg,
+          selfJid: self.jid,
+          selfLid: self.lid,
+          resolveInboundJid,
+          logVerboseMessage: (message) => logWhatsAppVerbose(options.verbose, message),
+        })
+      ) {
+        continue;
+      }
+
       await processDurableInboundMessage(msg, upsert.type);
     }
   };

--- a/extensions/whatsapp/src/inbound/send-api.test.ts
+++ b/extensions/whatsapp/src/inbound/send-api.test.ts
@@ -557,6 +557,28 @@ describe("createWebSendApi LID resolution (issue #67378)", () => {
     expect("poll" in payload).toBe(true);
   });
 
+  it("resolves PN to LID for sendReaction", async () => {
+    const api = createWebSendApi({
+      sock: { sendMessage, sendPresenceUpdate },
+      defaultAccountId: "main",
+      authDir,
+    });
+    await api.sendReaction("+15555550000", "msg-2", "1️⃣", true);
+    expect(requireMockArg(sendMessage, 0, 0, "send reaction")).toBe("987654@lid");
+    const payload = requireRecord(
+      requireMockArg(sendMessage, 0, 1, "send reaction"),
+      "send reaction payload",
+    );
+    const react = requireRecord(payload.react, "reaction content");
+    expect(react.text).toBe("1️⃣");
+    expect(requireRecord(react.key, "reaction key")).toMatchObject({
+      remoteJid: "987654@lid",
+      id: "msg-2",
+      fromMe: true,
+    });
+    expect(requireRecord(react.key, "reaction key").participant).toBeUndefined();
+  });
+
   it("resolves PN to LID for sendComposingTo presence", async () => {
     const api = createWebSendApi({
       sock: { sendMessage, sendPresenceUpdate },

--- a/extensions/whatsapp/src/inbound/send-api.ts
+++ b/extensions/whatsapp/src/inbound/send-api.ts
@@ -175,10 +175,9 @@ export function createWebSendApi(params: {
       fromMe: boolean,
       participant?: string,
     ): Promise<WhatsAppSendResult> => {
-      // chatJid is typically already a JID (group or DM); pass through
-      // unchanged. The participant is a sender id and stays PN-shaped to match
-      // how the existing inbound flow stores it.
-      const jid = toWhatsappJid(chatJid);
+      // Resolve DM targets through the same LID-aware path as normal sends so
+      // reactions land on the delivered WhatsApp message key.
+      const jid = resolveOutboundJid(chatJid);
       const result = await params.sock.sendMessage(jid, {
         react: {
           text: emoji,

--- a/extensions/whatsapp/src/runtime.ts
+++ b/extensions/whatsapp/src/runtime.ts
@@ -1,9 +1,12 @@
 import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 
-const { setRuntime: setWhatsAppRuntime, getRuntime: getWhatsAppRuntime } =
-  createPluginRuntimeStore<PluginRuntime>({
-    pluginId: "whatsapp",
-    errorMessage: "WhatsApp runtime not initialized",
-  });
-export { getWhatsAppRuntime, setWhatsAppRuntime };
+const {
+  setRuntime: setWhatsAppRuntime,
+  getRuntime: getWhatsAppRuntime,
+  tryGetRuntime: getOptionalWhatsAppRuntime,
+} = createPluginRuntimeStore<PluginRuntime>({
+  pluginId: "whatsapp",
+  errorMessage: "WhatsApp runtime not initialized",
+});
+export { getOptionalWhatsAppRuntime, getWhatsAppRuntime, setWhatsAppRuntime };

--- a/extensions/whatsapp/src/send.test.ts
+++ b/extensions/whatsapp/src/send.test.ts
@@ -145,6 +145,31 @@ describe("web outbound", () => {
     expect(sendMessage).toHaveBeenCalledWith("+1555", "hi", undefined, undefined);
   });
 
+  it("returns the actual outbound key remote JID when Baileys resolves a LID target", async () => {
+    sendMessage.mockResolvedValueOnce({
+      kind: "text",
+      messageId: "msg-lid",
+      keys: [
+        {
+          id: "msg-lid",
+          remoteJid: "123456789@lid",
+          fromMe: true,
+        },
+      ],
+      providerAccepted: true,
+    });
+
+    const result = await sendMessageWhatsApp("+1555", "hi", {
+      verbose: false,
+      cfg: WHATSAPP_TEST_CFG,
+    });
+
+    expect(result).toEqual({
+      messageId: "msg-lid",
+      toJid: "123456789@lid",
+    });
+  });
+
   it("sends newsletter messages via the active listener without composing presence", async () => {
     const result = await sendMessageWhatsApp("120363401234567890@newsletter", "hi", {
       verbose: false,

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -14,6 +14,7 @@ import {
   resolveWhatsAppAccount,
   resolveWhatsAppMediaMaxBytes,
 } from "./accounts.js";
+import { registerWhatsAppApprovalReactionTargetForOutboundMessage } from "./approval-reactions.js";
 import { getRegisteredWhatsAppConnectionController } from "./connection-controller-registry.js";
 import { resolveWhatsAppDocumentFileName } from "./document-filename.js";
 import type { ActiveWebListener, ActiveWebSendOptions } from "./inbound/types.js";
@@ -57,6 +58,20 @@ function requireOutboundActiveWebListener(params: { cfg: OpenClawConfig; account
     );
   }
   return { accountId: resolvedAccountId, listener };
+}
+
+function resolveActualSentRemoteJid(result: unknown, fallbackJid: string): string {
+  if (!result || typeof result !== "object") {
+    return fallbackJid;
+  }
+  const rawKeys = (result as { keys?: unknown }).keys;
+  const keys: Array<{ remoteJid?: unknown }> = Array.isArray(rawKeys) ? rawKeys : [];
+  for (const key of keys) {
+    if (typeof key?.remoteJid === "string" && key.remoteJid.trim()) {
+      return key.remoteJid.trim();
+    }
+  }
+  return fallbackJid;
 }
 
 export async function sendMessageWhatsApp(
@@ -221,12 +236,21 @@ export async function sendMessageWhatsApp(
       }
     }
     const messageId = (result as { messageId?: string })?.messageId ?? "unknown";
+    const sentRemoteJid = resolveActualSentRemoteJid(result, jid);
+    if (messageId && messageId !== "unknown" && text) {
+      registerWhatsAppApprovalReactionTargetForOutboundMessage({
+        accountId: resolvedAccountId,
+        remoteJid: sentRemoteJid,
+        messageId,
+        text,
+      });
+    }
     const durationMs = Date.now() - startedAt;
     outboundLog.info(
       `Sent message ${messageId} -> ${redactedJid}${hasMedia ? " (media)" : ""} (${durationMs}ms)`,
     );
     logger.info({ jid: redactedJid, messageId }, "sent message");
-    return { messageId, toJid: jid };
+    return { messageId, toJid: sentRemoteJid };
   } catch (err) {
     logger.error({ err: String(err), to: redactedTo, hasMedia }, "failed to send via web session");
     throw err;

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -14,7 +14,10 @@ import {
   resolveWhatsAppAccount,
   resolveWhatsAppMediaMaxBytes,
 } from "./accounts.js";
-import { registerWhatsAppApprovalReactionTargetForOutboundMessage } from "./approval-reactions.js";
+import {
+  appendWhatsAppApprovalReactionHintForOutboundMessage,
+  registerWhatsAppApprovalReactionTargetForOutboundMessage,
+} from "./approval-reactions.js";
 import { getRegisteredWhatsAppConnectionController } from "./connection-controller-registry.js";
 import { resolveWhatsAppDocumentFileName } from "./document-filename.js";
 import type { ActiveWebListener, ActiveWebSendOptions } from "./inbound/types.js";
@@ -225,9 +228,10 @@ export async function sendMessageWhatsApp(
             accountId,
           }
         : undefined;
+    const outboundText = text ? appendWhatsAppApprovalReactionHintForOutboundMessage(text) : text;
     const result = sendOptions
-      ? await active.sendMessage(to, text, mediaBuffer, mediaType, sendOptions)
-      : await active.sendMessage(to, text, mediaBuffer, mediaType);
+      ? await active.sendMessage(to, outboundText, mediaBuffer, mediaType, sendOptions)
+      : await active.sendMessage(to, outboundText, mediaBuffer, mediaType);
     if (visibleTextAfterVoice) {
       if (sendOptions) {
         await active.sendMessage(to, visibleTextAfterVoice, undefined, undefined, sendOptions);
@@ -237,12 +241,12 @@ export async function sendMessageWhatsApp(
     }
     const messageId = (result as { messageId?: string })?.messageId ?? "unknown";
     const sentRemoteJid = resolveActualSentRemoteJid(result, jid);
-    if (messageId && messageId !== "unknown" && text) {
+    if (messageId && messageId !== "unknown" && outboundText) {
       registerWhatsAppApprovalReactionTargetForOutboundMessage({
         accountId: resolvedAccountId,
         remoteJid: sentRemoteJid,
         messageId,
-        text,
+        text: outboundText,
       });
     }
     const durationMs = Date.now() - startedAt;

--- a/src/gateway/server-methods/approval-shared.test.ts
+++ b/src/gateway/server-methods/approval-shared.test.ts
@@ -277,6 +277,51 @@ describe("handlePendingApprovalRequest", () => {
     await requestPromise;
   });
 
+  it("checks plugin turn-source routes with plugin approval kind", async () => {
+    const manager = new ExecApprovalManager();
+    const record = manager.create(
+      {
+        command: "plugin approval",
+        turnSourceChannel: "whatsapp",
+        turnSourceAccountId: "default",
+      },
+      60_000,
+      "plugin-turn-source-kind",
+    );
+    const decisionPromise = manager.register(record, 60_000);
+    const respond = vi.fn();
+    const requestPromise = handlePendingApprovalRequest({
+      manager,
+      record,
+      decisionPromise,
+      respond,
+      context: {
+        broadcast: vi.fn(),
+        hasExecApprovalClients: () => false,
+      } as unknown as GatewayRequestContext,
+      requestEventName: "plugin.approval.requested",
+      requestEvent: {
+        id: record.id,
+        request: record.request,
+        createdAtMs: record.createdAtMs,
+        expiresAtMs: record.expiresAtMs,
+      },
+      twoPhase: true,
+      approvalKind: "plugin",
+      deliverRequest: () => false,
+    });
+
+    await Promise.resolve();
+    expect(hasApprovalTurnSourceRouteMock).toHaveBeenCalledWith({
+      turnSourceChannel: "whatsapp",
+      turnSourceAccountId: "default",
+      approvalKind: "plugin",
+    });
+
+    expect(manager.resolve(record.id, "allow-once")).toBe(true);
+    await requestPromise;
+  });
+
   it("targets requested approval events to visible approval clients when available", async () => {
     const manager = new ExecApprovalManager();
     const record = manager.create(

--- a/src/gateway/server-methods/approval-shared.ts
+++ b/src/gateway/server-methods/approval-shared.ts
@@ -280,6 +280,7 @@ export async function handlePendingApprovalRequest<
   requestEventName: string;
   requestEvent: RequestedApprovalEvent<TPayload>;
   twoPhase: boolean;
+  approvalKind?: "exec" | "plugin";
   deliverRequest: () => boolean | Promise<boolean>;
   afterDecision?: (
     decision: ExecApprovalDecision | null,
@@ -317,6 +318,7 @@ export async function handlePendingApprovalRequest<
     hasApprovalTurnSourceRoute({
       turnSourceChannel: params.record.request.turnSourceChannel,
       turnSourceAccountId: params.record.request.turnSourceAccountId,
+      approvalKind: params.approvalKind ?? "exec",
     });
 
   if (!hasApprovalClients && !hasTurnSourceRoute && !delivered) {

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -367,6 +367,7 @@ export function createExecApprovalHandlers(
         requestEventName: "exec.approval.requested",
         requestEvent,
         twoPhase,
+        approvalKind: "exec",
         deliverRequest: () => {
           const deliveryTasks: Array<Promise<boolean>> = [];
           if (opts?.forwarder) {

--- a/src/gateway/server-methods/plugin-approval.ts
+++ b/src/gateway/server-methods/plugin-approval.ts
@@ -144,6 +144,7 @@ export function createPluginApprovalHandlers(
         requestEventName: "plugin.approval.requested",
         requestEvent,
         twoPhase,
+        approvalKind: "plugin",
         deliverRequest: () => {
           if (!opts?.forwarder?.handlePluginApprovalRequested) {
             return false;

--- a/src/infra/approval-turn-source.test.ts
+++ b/src/infra/approval-turn-source.test.ts
@@ -1,15 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const loadConfigMock = vi.hoisted(() => vi.fn());
-const resolveExecApprovalInitiatingSurfaceStateMock = vi.hoisted(() => vi.fn());
+const resolveApprovalInitiatingSurfaceStateMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../config/config.js", () => ({
   getRuntimeConfig: () => loadConfigMock(),
 }));
 
 vi.mock("./exec-approval-surface.js", () => ({
-  resolveExecApprovalInitiatingSurfaceState: (...args: unknown[]) =>
-    resolveExecApprovalInitiatingSurfaceStateMock(...args),
+  resolveApprovalInitiatingSurfaceState: (...args: unknown[]) =>
+    resolveApprovalInitiatingSurfaceStateMock(...args),
 }));
 
 import { hasApprovalTurnSourceRoute } from "./approval-turn-source.js";
@@ -17,12 +17,12 @@ import { hasApprovalTurnSourceRoute } from "./approval-turn-source.js";
 describe("hasApprovalTurnSourceRoute", () => {
   beforeEach(() => {
     loadConfigMock.mockReset();
-    resolveExecApprovalInitiatingSurfaceStateMock.mockReset();
+    resolveApprovalInitiatingSurfaceStateMock.mockReset();
     loadConfigMock.mockReturnValue({ loaded: true });
   });
 
   it("returns true when the initiating surface is enabled", () => {
-    resolveExecApprovalInitiatingSurfaceStateMock.mockReturnValue({ kind: "enabled" });
+    resolveApprovalInitiatingSurfaceStateMock.mockReturnValue({ kind: "enabled" });
 
     expect(
       hasApprovalTurnSourceRoute({
@@ -30,23 +30,42 @@ describe("hasApprovalTurnSourceRoute", () => {
         turnSourceAccountId: "work",
       }),
     ).toBe(true);
-    expect(resolveExecApprovalInitiatingSurfaceStateMock).toHaveBeenCalledWith({
+    expect(resolveApprovalInitiatingSurfaceStateMock).toHaveBeenCalledWith({
       channel: "slack",
       accountId: "work",
       cfg: { loaded: true },
+      approvalKind: "exec",
+    });
+  });
+
+  it("passes plugin approval kind to the initiating surface check", () => {
+    resolveApprovalInitiatingSurfaceStateMock.mockReturnValue({ kind: "disabled" });
+
+    expect(
+      hasApprovalTurnSourceRoute({
+        turnSourceChannel: "whatsapp",
+        turnSourceAccountId: "default",
+        approvalKind: "plugin",
+      }),
+    ).toBe(false);
+    expect(resolveApprovalInitiatingSurfaceStateMock).toHaveBeenCalledWith({
+      channel: "whatsapp",
+      accountId: "default",
+      cfg: { loaded: true },
+      approvalKind: "plugin",
     });
   });
 
   it("returns false when the initiating surface is disabled or unsupported", () => {
-    resolveExecApprovalInitiatingSurfaceStateMock.mockReturnValueOnce({ kind: "disabled" });
+    resolveApprovalInitiatingSurfaceStateMock.mockReturnValueOnce({ kind: "disabled" });
     expect(hasApprovalTurnSourceRoute({ turnSourceChannel: "discord" })).toBe(false);
 
-    resolveExecApprovalInitiatingSurfaceStateMock.mockReturnValueOnce({ kind: "unsupported" });
+    resolveApprovalInitiatingSurfaceStateMock.mockReturnValueOnce({ kind: "unsupported" });
     expect(hasApprovalTurnSourceRoute({ turnSourceChannel: "unknown-channel" })).toBe(false);
   });
 
   it("returns false when there is no turn-source channel", () => {
     expect(hasApprovalTurnSourceRoute({ turnSourceChannel: undefined })).toBe(false);
-    expect(resolveExecApprovalInitiatingSurfaceStateMock).not.toHaveBeenCalled();
+    expect(resolveApprovalInitiatingSurfaceStateMock).not.toHaveBeenCalled();
   });
 });

--- a/src/infra/approval-turn-source.ts
+++ b/src/infra/approval-turn-source.ts
@@ -1,18 +1,20 @@
 import { getRuntimeConfig } from "../config/config.js";
-import { resolveExecApprovalInitiatingSurfaceState } from "./exec-approval-surface.js";
+import { resolveApprovalInitiatingSurfaceState } from "./exec-approval-surface.js";
 
 export function hasApprovalTurnSourceRoute(params: {
   turnSourceChannel?: string | null;
   turnSourceAccountId?: string | null;
+  approvalKind?: "exec" | "plugin";
 }): boolean {
   if (!params.turnSourceChannel?.trim()) {
     return false;
   }
   return (
-    resolveExecApprovalInitiatingSurfaceState({
+    resolveApprovalInitiatingSurfaceState({
       channel: params.turnSourceChannel,
       accountId: params.turnSourceAccountId,
       cfg: getRuntimeConfig(),
+      approvalKind: params.approvalKind ?? "exec",
     }).kind === "enabled"
   );
 }

--- a/src/infra/exec-approval-surface.test.ts
+++ b/src/infra/exec-approval-surface.test.ts
@@ -34,12 +34,16 @@ vi.mock("../utils/message-channel.js", () => ({
 type ExecApprovalSurfaceModule = typeof import("./exec-approval-surface.js");
 
 let resolveExecApprovalInitiatingSurfaceState: ExecApprovalSurfaceModule["resolveExecApprovalInitiatingSurfaceState"];
+let resolveApprovalInitiatingSurfaceState: ExecApprovalSurfaceModule["resolveApprovalInitiatingSurfaceState"];
 let supportsNativeExecApprovalClient: ExecApprovalSurfaceModule["supportsNativeExecApprovalClient"];
 
 describe("resolveExecApprovalInitiatingSurfaceState", () => {
   beforeAll(async () => {
-    ({ resolveExecApprovalInitiatingSurfaceState, supportsNativeExecApprovalClient } =
-      await import("./exec-approval-surface.js"));
+    ({
+      resolveApprovalInitiatingSurfaceState,
+      resolveExecApprovalInitiatingSurfaceState,
+      supportsNativeExecApprovalClient,
+    } = await import("./exec-approval-surface.js"));
   });
 
   beforeEach(() => {
@@ -218,6 +222,43 @@ describe("resolveExecApprovalInitiatingSurfaceState", () => {
       channel: "matrix",
       channelLabel: "Matrix",
       accountId: "default",
+    });
+  });
+
+  it("uses generic approval availability for plugin initiating surfaces", () => {
+    const getExecInitiatingSurfaceState = vi.fn(() => ({ kind: "enabled" as const }));
+    const getActionAvailabilityState = vi.fn(
+      ({ approvalKind }: { approvalKind?: "exec" | "plugin" }) =>
+        approvalKind === "plugin" ? { kind: "disabled" as const } : { kind: "enabled" as const },
+    );
+    getChannelPluginMock.mockReturnValue({
+      meta: { label: "WhatsApp" },
+      approvalCapability: {
+        native: {},
+        getExecInitiatingSurfaceState,
+        getActionAvailabilityState,
+      },
+    });
+
+    expect(
+      resolveApprovalInitiatingSurfaceState({
+        channel: "whatsapp",
+        accountId: "default",
+        cfg: {} as never,
+        approvalKind: "plugin",
+      }),
+    ).toEqual({
+      kind: "disabled",
+      channel: "whatsapp",
+      channelLabel: "WhatsApp",
+      accountId: "default",
+    });
+    expect(getExecInitiatingSurfaceState).not.toHaveBeenCalled();
+    expect(getActionAvailabilityState).toHaveBeenCalledWith({
+      cfg: {} as never,
+      accountId: "default",
+      action: "approve",
+      approvalKind: "plugin",
     });
   });
 

--- a/src/infra/exec-approval-surface.ts
+++ b/src/infra/exec-approval-surface.ts
@@ -16,6 +16,8 @@ export type ExecApprovalInitiatingSurfaceState =
   | { kind: "disabled"; channel: string; channelLabel: string; accountId?: string }
   | { kind: "unsupported"; channel: string; channelLabel: string; accountId?: string };
 
+type ApprovalKind = "exec" | "plugin";
+
 function labelForChannel(channel?: string): string {
   if (channel === "tui") {
     return "terminal UI";
@@ -42,6 +44,15 @@ export function resolveExecApprovalInitiatingSurfaceState(params: {
   accountId?: string | null;
   cfg?: OpenClawConfig;
 }): ExecApprovalInitiatingSurfaceState {
+  return resolveApprovalInitiatingSurfaceState({ ...params, approvalKind: "exec" });
+}
+
+export function resolveApprovalInitiatingSurfaceState(params: {
+  channel?: string | null;
+  accountId?: string | null;
+  cfg?: OpenClawConfig;
+  approvalKind: ApprovalKind;
+}): ExecApprovalInitiatingSurfaceState {
   const channel = normalizeMessageChannel(params.channel);
   const channelLabel = labelForChannel(channel);
   const accountId = normalizeOptionalString(params.accountId);
@@ -52,16 +63,18 @@ export function resolveExecApprovalInitiatingSurfaceState(params: {
   const cfg = params.cfg ?? getRuntimeConfig();
   const capability = resolveChannelApprovalCapability(getChannelPlugin(channel));
   const state =
-    capability?.getExecInitiatingSurfaceState?.({
-      cfg,
-      accountId: params.accountId,
-      action: "approve",
-    }) ??
+    (params.approvalKind === "exec"
+      ? capability?.getExecInitiatingSurfaceState?.({
+          cfg,
+          accountId: params.accountId,
+          action: "approve",
+        })
+      : undefined) ??
     capability?.getActionAvailabilityState?.({
       cfg,
       accountId: params.accountId,
       action: "approve",
-      approvalKind: "exec",
+      approvalKind: params.approvalKind,
     });
   if (state) {
     return { ...state, channel, channelLabel, accountId };


### PR DESCRIPTION
## Summary

- Problem: WhatsApp approval prompts had been implemented with `1/2/3` reaction choices, including a reaction path for `allow-always`.
- Solution: Use only `👍` for `allow-once` and `👎` for `deny`; keep `allow-always` on the manual `/approve <id> allow-always` path.
- What changed: WhatsApp approval prompt rendering, outbound reaction hints, reaction-target persistence, reaction resolution, docs, and focused tests now use the thumbs-only decision model. Reaction handling requires explicit `channels.whatsapp.allowFrom` or `"*"`, while manual `/approve` keeps normal WhatsApp command sender authorization.
- What did NOT change: Core approval decision names, Gateway approval resolution APIs, and non-WhatsApp channel behavior.

## Real behavior proof

Behavior addressed: WhatsApp can deliver native exec/plugin approvals and resolve bindable approval reactions, now with thumbs-only mappings.
Real environment tested: Local macOS source checkout, Node 24, branch `codex/whatsapp-emoji-approvals`.
Exact steps or command run after this patch: `pnpm docs:list >/tmp/openclaw-docs-list.out`; `node scripts/run-vitest.mjs extensions/whatsapp/src/approval-auth.test.ts extensions/whatsapp/src/approval-reactions.test.ts extensions/whatsapp/src/approval-native.test.ts extensions/whatsapp/src/approval-handler.runtime.test.ts src/infra/channel-approval-auth.test.ts src/infra/exec-approval-reply.test.ts src/auto-reply/reply/commands-approve.test.ts`; `python3 /Users/kevinlin/.codex/skills/specy/scripts/validate_flow_doc.py --kind flow-doc --doc .mem/main/specs/24-mainstream-channel-exec-plugin-approvals/flows/whatsapp-exec-approval-delivery.md`; `python3 /Users/kevinlin/.codex/skills/specy/scripts/validate_flow_doc.py --kind flow-doc --doc .mem/main/specs/24-mainstream-channel-exec-plugin-approvals/flows/whatsapp-thumb-approval-reactions.md`; stale numeric-prompt grep; `git diff --check`; `pnpm exec oxfmt --check --threads=1 extensions/whatsapp/src/approval-auth.ts extensions/whatsapp/src/approval-auth.test.ts extensions/whatsapp/src/approval-handler.runtime.ts extensions/whatsapp/src/approval-handler.runtime.test.ts extensions/whatsapp/src/approval-native.ts extensions/whatsapp/src/approval-native.test.ts extensions/whatsapp/src/approval-reactions.ts extensions/whatsapp/src/approval-reactions.test.ts extensions/whatsapp/src/send.ts`; `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo`.
Evidence after fix: Focused Vitest passed before the live suite: 7 files, 90 tests. Live prod-profile WhatsApp thumbs proof passed for exec and plugin allow-once reactions plus empty-allowFrom denial and disabled-no-delivery scenarios; see the proof screenshots below and `.mem/main/proofs/demo-27-prod-whatsapp-thumbs-approval-gates/proof.md`. After rebasing onto current `origin/main`, focused post-rebase tests passed: 10 files, 163 tests. Flow-doc validation passed for both WhatsApp approval flow docs. Formatter check, extension typecheck, stale numeric-prompt grep, and diff whitespace checks passed.
Observed result after fix: WhatsApp approval rendering advertises `👍 Allow Once` and `👎 Deny`; live prod-profile WhatsApp proof shows `👍` resolving both exec and plugin approvals as `allow-once`, `allow-always` remaining manual-only, old numeric/keycap reactions ignored by tests, empty `channels.whatsapp.allowFrom` reactions denied, disabled approval kinds not forwarded to WhatsApp, and manual `/approve` fallback still using the normal command sender path.
What was not tested: Full repository suite and broad Testbox/Crabbox lanes. The live thumbs proof used still screenshots rather than video; video capture was blocked by screen availability during the earlier live actions.

![Redacted WhatsApp exec thumbs proof](https://ik.imagekit.io/fpjzhqpv1/openclaw/pr-proof/whatsapp-thumbs-exec-allow-once-2026-05-23_fV8Qrz51V.png)

![Redacted WhatsApp plugin thumbs proof](https://ik.imagekit.io/fpjzhqpv1/openclaw/pr-proof/whatsapp-thumbs-plugin-allow-once-2026-05-23_TJ8_JTztF.png)

## User-visible / Behavior Changes

WhatsApp approval prompts now show `👍 Allow Once` and `👎 Deny` as reaction choices. Users who want `allow-always` must send `/approve <id> allow-always`.

## Security Impact

- New permissions/capabilities? Yes
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: WhatsApp can approve exec/plugin requests through reactions. Mitigation: delivery is gated by top-level `approvals.exec` / `approvals.plugin`, reactions require explicit WhatsApp approvers from `channels.whatsapp.allowFrom` or `"*"`, and manual `/approve` still passes through normal WhatsApp sender authorization before Gateway approval resolution.

## Regression Test Plan

- `extensions/whatsapp/src/approval-reactions.test.ts`: thumbs-only hint rendering, no `allow-always` reaction state, old keycap reactions ignored, direct/group reaction authorization.
- `extensions/whatsapp/src/approval-native.test.ts`: native exec/plugin prompt rendering and top-level approval config gating.
- `extensions/whatsapp/src/approval-handler.runtime.test.ts`: runtime pending payload rendering, concrete `/approve` id fallback, thumbs-only reaction hints.
- `extensions/whatsapp/src/approval-auth.test.ts`: explicit `allowFrom`, wildcard approvers, and `defaultTo` not being an approval approver.
- `src/auto-reply/reply/commands-approve.test.ts` and `src/infra/channel-approval-auth.test.ts`: manual `/approve` command authorization fallback remains intact.

## Compatibility / Migration

- Backward compatible? Mostly; old WhatsApp numeric/keycap reaction shortcuts are intentionally no longer accepted for new approval prompts.
- Config/env changes? No new WhatsApp-specific approval field. WhatsApp continues to use top-level `approvals.exec` / `approvals.plugin` for delivery gating and `channels.whatsapp.allowFrom` for reaction approvers.
- Migration needed? Operators should use `👍` / `👎` reactions or manual `/approve <id> allow-always`.

