### PR TITLE
Isolate boot-md startup sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/boot: run `BOOT.md` startup checks in an isolated boot session so gateway restarts do not overwrite the agent's main session mapping. (#85479)
 - WebChat: summarize internal message-tool source replies so tool cards no longer duplicate the visible reply body. (#84773) Thanks @jason-allen-oneal.
 - WebChat: scope the visible attachment button to its own composer file input so clicking Upload reliably opens the file picker. (#83952, fixes #47983) Thanks @jason-allen-oneal.
 - Gateway: preserve deferred lifecycle-error cleanup across later non-terminal events so provider timeouts can persist failed session state instead of leaving sessions stuck running. (#85256, fixes #63819) Thanks @samzong.

--- a/extensions/meeting-notes/index.test.ts
+++ b/extensions/meeting-notes/index.test.ts
@@ -437,7 +437,11 @@ describe("meeting-notes plugin", () => {
     const request = start.mock.calls[0]?.[0];
     expect(request.abortSignal?.aborted).toBe(false);
 
-    await services[0]?.stop({ config: {}, logger, stateDir });
+    const service = services[0];
+    if (!service?.stop) {
+      throw new Error("meeting-notes service stop hook was not registered");
+    }
+    await service.stop({ config: {}, logger, stateDir });
 
     expect(request.abortSignal?.aborted).toBe(true);
     expect(stop).not.toHaveBeenCalled();

--- a/extensions/meeting-notes/src/tool.ts
+++ b/extensions/meeting-notes/src/tool.ts
@@ -106,7 +106,7 @@ async function waitForPendingAutoStartsToSettle(
   let timeout: ReturnType<typeof setTimeout> | undefined;
   try {
     return await Promise.race([
-      Promise.allSettled([...pendingStarts]).then(() => true),
+      Promise.allSettled(pendingStarts).then(() => true),
       new Promise<boolean>((resolve) => {
         timeout = setTimeout(() => resolve(false), AUTO_START_STOP_TIMEOUT_MS);
         timeout.unref?.();

--- a/src/gateway/boot.test.ts
+++ b/src/gateway/boot.test.ts
@@ -71,7 +71,7 @@ describe("runBootOnce", () => {
 
   const mockAgentUpdatesRequestedSession = (storePath: string) => {
     agentCommand.mockImplementation(async (opts: { sessionId?: string; sessionKey?: string }) => {
-      const sessionKey = String(opts.sessionKey ?? "");
+      const sessionKey = opts.sessionKey ?? "";
       if (!sessionKey) {
         throw new Error("expected sessionKey");
       }

--- a/src/gateway/boot.test.ts
+++ b/src/gateway/boot.test.ts
@@ -186,6 +186,22 @@ describe("runBootOnce", () => {
     });
   });
 
+  it("keeps boot session isolation when the main session key is configured", async () => {
+    await withBootWorkspace({ bootContent: "Check status." }, async (workspaceDir) => {
+      agentCommand.mockResolvedValue(undefined);
+      const cfg = { session: { mainKey: "primary" } };
+      const agentId = "ops";
+      await expect(runBootOnce({ cfg, deps: makeDeps(), workspaceDir, agentId })).resolves.toEqual({
+        status: "ran",
+      });
+
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+      const mainSessionKey = resolveAgentMainSessionKey({ cfg, agentId });
+      expect(mainSessionKey).toBe("agent:ops:primary");
+      expect(requireAgentCall().sessionKey).toBe("agent:ops:boot");
+    });
+  });
+
   it("generates new session ID when no existing session exists", async () => {
     const content = "Say hello when you wake up.";
     await withBootWorkspace({ bootContent: content }, async (workspaceDir) => {

--- a/src/gateway/boot.test.ts
+++ b/src/gateway/boot.test.ts
@@ -32,7 +32,8 @@ describe("runBootOnce", () => {
     const sessionKey = resolveMainSessionKey(cfg);
     const agentId = resolveAgentIdFromSessionKey(sessionKey);
     const storePath = resolveStorePath(cfg.session?.store, { agentId });
-    return { sessionKey, storePath };
+    const bootSessionKey = `agent:${agentId}:boot`;
+    return { sessionKey, bootSessionKey, storePath };
   };
 
   beforeEach(async () => {
@@ -68,8 +69,12 @@ describe("runBootOnce", () => {
     }
   };
 
-  const mockAgentUpdatesMainSession = (storePath: string, sessionKey: string) => {
-    agentCommand.mockImplementation(async (opts: { sessionId?: string }) => {
+  const mockAgentUpdatesRequestedSession = (storePath: string) => {
+    agentCommand.mockImplementation(async (opts: { sessionId?: string; sessionKey?: string }) => {
+      const sessionKey = String(opts.sessionKey ?? "");
+      if (!sessionKey) {
+        throw new Error("expected sessionKey");
+      }
       const current = loadSessionStore(storePath, { skipCache: true });
       current[sessionKey] = {
         sessionId: String(opts.sessionId),
@@ -87,7 +92,7 @@ describe("runBootOnce", () => {
     return call as Record<string, unknown>;
   };
 
-  const expectMainSessionRestored = (params: {
+  const expectSessionMapping = (params: {
     storePath: string;
     sessionKey: string;
     expectedSessionId?: string;
@@ -145,7 +150,8 @@ describe("runBootOnce", () => {
       expect(agentCommand).toHaveBeenCalledTimes(1);
       const call = requireAgentCall();
       expect(call.deliver).toBe(false);
-      expect(call.sessionKey).toBe(resolveMainSessionKey({}));
+      expect(call.sessionKey).toBe("agent:main:boot");
+      expect(call.suppressPromptPersistence).toBe(true);
       expect(call.message).toContain("BOOT.md:");
       expect(call.message).toContain(content);
       expect(call.message).toContain("NO_REPLY");
@@ -173,7 +179,10 @@ describe("runBootOnce", () => {
       });
 
       expect(agentCommand).toHaveBeenCalledTimes(1);
-      expect(requireAgentCall().sessionKey).toBe(resolveAgentMainSessionKey({ cfg, agentId }));
+      const mainSessionKey = resolveAgentMainSessionKey({ cfg, agentId });
+      expect(requireAgentCall().sessionKey).toBe(
+        `agent:${resolveAgentIdFromSessionKey(mainSessionKey)}:boot`,
+      );
     });
   });
 
@@ -200,7 +209,7 @@ describe("runBootOnce", () => {
     const content = "Say hello when you wake up.";
     await withBootWorkspace({ bootContent: content }, async (workspaceDir) => {
       const cfg = {};
-      const { sessionKey, storePath } = resolveMainStore(cfg);
+      const { bootSessionKey, sessionKey, storePath } = resolveMainStore(cfg);
       const existingSessionId = "main-session-abc123";
 
       await saveSessionStore(storePath, {
@@ -222,15 +231,16 @@ describe("runBootOnce", () => {
       expect(call.sessionId).toMatch(
         /^boot-\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}-\d{3}-[0-9a-f]{8}$/,
       );
-      expect(call.sessionKey).toBe(sessionKey);
+      expect(call.sessionKey).toBe(bootSessionKey);
+      expectSessionMapping({ storePath, sessionKey, expectedSessionId: existingSessionId });
     });
   });
 
-  it("restores the original main session mapping after the boot run", async () => {
+  it("does not mutate the original main session mapping after the boot run", async () => {
     const content = "Check if the system is healthy.";
     await withBootWorkspace({ bootContent: content }, async (workspaceDir) => {
       const cfg = {};
-      const { sessionKey, storePath } = resolveMainStore(cfg);
+      const { bootSessionKey, sessionKey, storePath } = resolveMainStore(cfg);
       const existingSessionId = "main-session-xyz789";
 
       await saveSessionStore(storePath, {
@@ -240,27 +250,29 @@ describe("runBootOnce", () => {
         },
       });
 
-      mockAgentUpdatesMainSession(storePath, sessionKey);
+      mockAgentUpdatesRequestedSession(storePath);
       await expect(runBootOnce({ cfg, deps: makeDeps(), workspaceDir })).resolves.toEqual({
         status: "ran",
       });
 
-      expectMainSessionRestored({ storePath, sessionKey, expectedSessionId: existingSessionId });
+      expectSessionMapping({ storePath, sessionKey, expectedSessionId: existingSessionId });
+      expectSessionMapping({ storePath, sessionKey: bootSessionKey });
     });
   });
 
-  it("removes a boot-created main-session mapping when none existed before", async () => {
+  it("removes a boot-created boot-session mapping when none existed before", async () => {
     await withBootWorkspace({ bootContent: "health check" }, async (workspaceDir) => {
       const cfg = {};
-      const { sessionKey, storePath } = resolveMainStore(cfg);
+      const { bootSessionKey, sessionKey, storePath } = resolveMainStore(cfg);
 
-      mockAgentUpdatesMainSession(storePath, sessionKey);
+      mockAgentUpdatesRequestedSession(storePath);
 
       await expect(runBootOnce({ cfg, deps: makeDeps(), workspaceDir })).resolves.toEqual({
         status: "ran",
       });
 
-      expectMainSessionRestored({ storePath, sessionKey });
+      expectSessionMapping({ storePath, sessionKey });
+      expectSessionMapping({ storePath, sessionKey: bootSessionKey });
     });
   });
 });

--- a/src/gateway/boot.ts
+++ b/src/gateway/boot.ts
@@ -54,6 +54,11 @@ function buildBootPrompt(content: string) {
   ].join("\n");
 }
 
+function resolveBootSessionKey(sessionKey: string): string {
+  const agentId = resolveAgentIdFromSessionKey(sessionKey);
+  return `agent:${agentId}:boot`;
+}
+
 async function loadBootFile(
   workspaceDir: string,
 ): Promise<{ content?: string; status: "ok" | "missing" | "empty" }> {
@@ -74,7 +79,7 @@ async function loadBootFile(
   }
 }
 
-function snapshotMainSessionMapping(params: {
+function snapshotSessionMapping(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
 }): SessionMappingSnapshot {
@@ -99,7 +104,7 @@ function snapshotMainSessionMapping(params: {
       entry: structuredClone(entry),
     };
   } catch (err) {
-    log.debug("boot: could not snapshot main session mapping", {
+    log.debug("boot: could not snapshot session mapping", {
       sessionKey: params.sessionKey,
       error: String(err),
     });
@@ -112,7 +117,7 @@ function snapshotMainSessionMapping(params: {
   }
 }
 
-async function restoreMainSessionMapping(
+async function restoreSessionMapping(
   snapshot: SessionMappingSnapshot,
 ): Promise<string | undefined> {
   if (!snapshot.canRestore) {
@@ -160,12 +165,13 @@ export async function runBootOnce(params: {
     return { status: "skipped", reason: result.status };
   }
 
-  const sessionKey = params.agentId
+  const mainSessionKey = params.agentId
     ? resolveAgentMainSessionKey({ cfg: params.cfg, agentId: params.agentId })
     : resolveMainSessionKey(params.cfg);
+  const sessionKey = resolveBootSessionKey(mainSessionKey);
   const message = buildBootPrompt(result.content ?? "");
   const sessionId = generateBootSessionId();
-  const mappingSnapshot = snapshotMainSessionMapping({
+  const mappingSnapshot = snapshotSessionMapping({
     cfg: params.cfg,
     sessionKey,
   });
@@ -178,6 +184,7 @@ export async function runBootOnce(params: {
         sessionKey,
         sessionId,
         deliver: false,
+        suppressPromptPersistence: true,
       },
       bootRuntime,
       params.deps,
@@ -187,9 +194,9 @@ export async function runBootOnce(params: {
     log.error(`boot: agent run failed: ${agentFailure}`);
   }
 
-  const mappingRestoreFailure = await restoreMainSessionMapping(mappingSnapshot);
+  const mappingRestoreFailure = await restoreSessionMapping(mappingSnapshot);
   if (mappingRestoreFailure) {
-    log.error(`boot: failed to restore main session mapping: ${mappingRestoreFailure}`);
+    log.error(`boot: failed to restore session mapping: ${mappingRestoreFailure}`);
   }
 
   if (!agentFailure && !mappingRestoreFailure) {

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -6,10 +6,11 @@ import type {
   PluginHookGatewayContext,
   PluginHookGatewayStartEvent,
 } from "../plugins/hook-types.js";
+import type { PluginServicesHandle } from "../plugins/services.js";
 import { withEnvAsync } from "../test-utils/env.js";
 
 const hoisted = vi.hoisted(() => {
-  const startPluginServices = vi.fn(async () => null);
+  const startPluginServices = vi.fn<() => Promise<PluginServicesHandle | null>>(async () => null);
   const startGmailWatcherWithLogs = vi.fn(async () => {});
   const loadInternalHooks = vi.fn(async () => 0);
   const setInternalHooksEnabled = vi.fn();
@@ -1002,7 +1003,7 @@ describe("startGatewayPostAttachRuntime", () => {
       async () => {
         let releaseChannels: (() => void) | undefined;
         const events: string[] = [];
-        const pluginServices = { stop: vi.fn(async () => {}) } as never;
+        const pluginServices: PluginServicesHandle = { stop: vi.fn(async () => {}) };
         const onPluginServices = vi.fn();
         const onSidecarsReady = vi.fn();
         const startChannels = vi.fn(
@@ -1109,7 +1110,7 @@ describe("startGatewayPostAttachRuntime", () => {
       async () => {
         let shouldStartPluginServices = true;
         let releasePluginServices: (() => void) | undefined;
-        const pluginServices = { stop: vi.fn(async () => {}) };
+        const pluginServices: PluginServicesHandle = { stop: vi.fn(async () => {}) };
         const onPluginServices = vi.fn();
         hoisted.startPluginServices.mockImplementationOnce(
           async () =>


### PR DESCRIPTION
Fixes #84970.

## Summary
- Run bundled boot-md startup checks under an isolated `agent:<id>:boot` session key instead of the canonical main session key.
- Pass `suppressPromptPersistence: true` for the generated BOOT.md prompt so the synthetic startup instruction is not written as a normal user turn.
- Snapshot and restore the boot session mapping after the run, so a startup check cannot leave a transient boot session as active state.
- Fixed the oxlint no-unnecessary-type-conversion failure reported by CI.

## Real behavior proof
**Behavior addressed:** The bundled boot-md startup hook could feed the full synthetic `BOOT.md` prompt through the canonical main session, allowing repeated gateway restarts to persist startup-only prompts into the user-facing transcript and context-engine history.

**Real environment tested:** Local OpenClaw checkout on macOS/Darwin, branch `fix/boot-md-synthetic-prompt-84970`, using the built `dist/index.js` OpenClaw gateway entrypoint in a fresh temporary OpenClaw HOME/state/workspace. The proof configured the bundled `boot-md` internal hook, wrote an actual `BOOT.md`, seeded a canonical `agent:main:main` session transcript, restarted the real foreground gateway process twice, then inspected the file-backed session store and transcript files on disk. I did not touch the host launchd service or the user's personal OpenClaw state.

**Exact steps or command run after this patch:**
```bash
pnpm lint --threads=8
node scripts/run-vitest.mjs src/gateway/boot.test.ts src/hooks/bundled/boot-md/handler.gateway-startup.integration.test.ts
node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.context-engine.test.ts
pnpm exec oxfmt --write --threads=1 src/gateway/boot.ts src/gateway/boot.test.ts
git diff --check
git log --format='%h %an <%ae> %s' upstream/main..HEAD
node --import tsx --input-type=module <redacted boot-md gateway restart proof script>
```

**Evidence after fix:** Terminal capture from the local OpenClaw checkout after the patch:
```text
$ pnpm lint --threads=8
$ node scripts/run-oxlint-shards.mjs --threads=8
[oxlint:scripts] finished
[oxlint:core] finished
[oxlint:extensions] finished

RUN  v4.1.7 /Users/andy/openclaw/openclaw-84970

Test Files  4 passed (4)
Tests  34 passed (34)
Start at  11:24:08
Duration  1.70s (transform 746ms, setup 231ms, import 1.13s, tests 131ms, environment 0ms)

RUN  v4.1.7 /Users/andy/openclaw/openclaw-84970

Test Files  1 passed (1)
Tests  16 passed (16)
Start at  11:24:08
Duration  5.45s (transform 1.05s, setup 72ms, import 2.48s, tests 2.82s, environment 0ms)

e19815cc29 Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> Fix boot-md test lint
2da63a4eb5 Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> Isolate boot-md startup sessions
```

Redacted real gateway restart/session inspection proof:
```json
{
  "command": "node --import tsx --input-type=module <redacted proof script>",
  "gateway_entrypoint": "dist/index.js",
  "preflight_loaded_internal_hooks_from_same_config": 5,
  "preflight_registered_event_keys": [
    "agent:bootstrap",
    "command",
    "command:new",
    "command:reset",
    "gateway:startup",
    "session:compact:after",
    "session:compact:before"
  ],
  "gateway_restarts": [
    {
      "restart": 1,
      "gatewayProcessStarted": true,
      "runtimeMs": 5613
    },
    {
      "restart": 2,
      "gatewayProcessStarted": true,
      "runtimeMs": 5219
    }
  ],
  "boot_md_present": true,
  "bundled_boot_md_hook_configured": true,
  "session_store_path": "$OPENCLAW_STATE_DIR/agents/main/sessions/sessions.json",
  "canonical_session_key": "agent:main:main",
  "boot_session_key": "agent:main:boot",
  "before_store_keys": [
    "agent:main:main"
  ],
  "after_store_keys": [
    "agent:main:main"
  ],
  "canonical_entry_unchanged": true,
  "boot_entry_present_after_restarts": false,
  "canonical_transcript_file": "$OPENCLAW_STATE_DIR/agents/main/sessions/seeded-main-session-85479.jsonl",
  "canonical_transcript_unchanged": true,
  "canonical_transcript_contains_boot_marker": false,
  "all_session_files": [
    "seeded-main-session-85479.jsonl",
    "sessions.json"
  ],
  "synthetic_prompt_matches_in_all_session_files": 0,
  "cleaned_up_isolated_state": true
}
```

**Observed result after fix:** With `BOOT.md` present and the bundled `boot-md` startup hook configured, two real gateway process restarts left the canonical `agent:main:main` session mapping unchanged, left no `agent:main:boot` mapping behind, kept the canonical transcript byte-for-byte unchanged, and produced zero persisted matches for `You are running a boot check`, `BOOT.md:`, or the BOOT.md marker in all session files. Local lint now passes after removing the unnecessary type conversion flagged by CI.

**What was not tested:** I did not restart the user's host launchd-installed gateway or inspect a production LCM database, to avoid touching private local state. The runtime proof uses an isolated temporary OpenClaw HOME/state/workspace and the real built gateway entrypoint.

## Attribution note
If maintainers squash or rework this PR, please preserve author attribution for Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> or include:

Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>
