### PR TITLE
fix(codex): unsubscribe bound conversation turns

### DIFF
--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -469,6 +469,9 @@ describe("codex conversation binding", () => {
           });
           return { turn: { id: "turn-new" } };
         }
+        if (method === "thread/unsubscribe") {
+          return {};
+        }
         throw new Error(`unexpected method: ${method}`);
       }),
       addNotificationHandler: vi.fn((handler) => {
@@ -510,21 +513,24 @@ describe("codex conversation binding", () => {
     expect(result).toEqual({ handled: true, reply: { text: "Recovered" } });
     expect(requests.map((request) => request.method)).toEqual([
       "turn/start",
+      "thread/unsubscribe",
       "thread/start",
       "turn/start",
+      "thread/unsubscribe",
     ]);
     const sharedClientParams = mockCallArg(sharedClientMocks.getSharedCodexAppServerClient) as {
       authProfileId?: unknown;
     };
     expect(sharedClientParams?.authProfileId).toBe("work");
-    expect(requests[1]?.params.model).toBe("gpt-5.4-mini");
-    expect(requests[1]?.params.approvalPolicy).toBe("on-request");
-    expect(requests[1]?.params.sandbox).toBe("workspace-write");
-    expect(requests[1]?.params.serviceTier).toBe("priority");
-    expect(requests[1]?.params).not.toHaveProperty("modelProvider");
-    expect(requests[2]?.params.threadId).toBe("thread-new");
+    expect(requests[2]?.params.model).toBe("gpt-5.4-mini");
     expect(requests[2]?.params.approvalPolicy).toBe("on-request");
+    expect(requests[2]?.params.sandbox).toBe("workspace-write");
     expect(requests[2]?.params.serviceTier).toBe("priority");
+    expect(requests[2]?.params).not.toHaveProperty("modelProvider");
+    expect(requests[3]?.params.threadId).toBe("thread-new");
+    expect(requests[3]?.params.approvalPolicy).toBe("on-request");
+    expect(requests[3]?.params.serviceTier).toBe("priority");
+    expect(requests[4]?.params.threadId).toBe("thread-new");
     const savedBinding = JSON.parse(
       await fs.readFile(`${sessionFile}.codex-app-server.json`, "utf8"),
     );
@@ -534,6 +540,89 @@ describe("codex conversation binding", () => {
     expect(savedBinding.sandbox).toBe("workspace-write");
     expect(savedBinding.serviceTier).toBe("priority");
     expect(savedBinding).not.toHaveProperty("modelProvider");
+  });
+
+  it("unsubscribes a recreated bound thread when the recovery retry rejects", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    await fs.writeFile(
+      `${sessionFile}.codex-app-server.json`,
+      JSON.stringify({
+        schemaVersion: 1,
+        threadId: "thread-old",
+        cwd: tempDir,
+      }),
+    );
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
+        requests.push({ method, params: requestParams });
+        if (method === "turn/start" && requestParams.threadId === "thread-old") {
+          throw new Error("thread not found: thread-old");
+        }
+        if (method === "thread/start") {
+          return {
+            thread: { id: "thread-new", sessionId: "session-1", cwd: tempDir },
+            model: "gpt-5.4-mini",
+          };
+        }
+        if (method === "turn/start" && requestParams.threadId === "thread-new") {
+          throw new Error("retry failed after recovery");
+        }
+        if (method === "thread/unsubscribe") {
+          return {};
+        }
+        throw new Error(`unexpected method: ${method}`);
+      }),
+      addNotificationHandler: vi.fn(() => () => undefined),
+      addRequestHandler: vi.fn(() => () => undefined),
+    });
+
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "hi again",
+        bodyForAgent: "hi again",
+        channel: "telegram",
+        isGroup: false,
+        commandAuthorized: true,
+      },
+      {
+        channelId: "telegram",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "5185575566",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile,
+            workspaceDir: tempDir,
+          },
+        },
+      },
+      { timeoutMs: 50 },
+    );
+
+    expect(result).toEqual({
+      handled: true,
+      reply: { text: "Codex app-server turn failed: retry failed after recovery" },
+    });
+    expect(requests.map((request) => request.method)).toEqual([
+      "turn/start",
+      "thread/unsubscribe",
+      "thread/start",
+      "turn/start",
+      "thread/unsubscribe",
+    ]);
+    expect(requests[1]?.params.threadId).toBe("thread-old");
+    expect(requests[4]?.params.threadId).toBe("thread-new");
+    const savedBinding = JSON.parse(
+      await fs.readFile(`${sessionFile}.codex-app-server.json`, "utf8"),
+    );
+    expect(savedBinding.threadId).toBe("thread-new");
   });
 
   it("returns a clean failure reply when app-server turn start rejects", async () => {

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -45,6 +45,7 @@ import { buildCodexConversationTurnInput } from "./conversation-turn-input.js";
 import { resumeCodexCliSessionOnNode } from "./node-cli-sessions.js";
 
 const DEFAULT_BOUND_TURN_TIMEOUT_MS = 20 * 60_000;
+const CODEX_CONVERSATION_UNSUBSCRIBE_TIMEOUT_MS = 60_000;
 
 export {
   createCodexCliNodeConversationBindingData,
@@ -487,6 +488,22 @@ async function runBoundTurn(params: {
   } finally {
     notificationCleanup();
     requestCleanup();
+    await unsubscribeCodexConversationThreadBestEffort(client, threadId);
+  }
+}
+
+async function unsubscribeCodexConversationThreadBestEffort(
+  client: Awaited<ReturnType<typeof getSharedCodexAppServerClient>>,
+  threadId: string,
+): Promise<void> {
+  try {
+    await client.request(
+      "thread/unsubscribe",
+      { threadId },
+      { timeoutMs: CODEX_CONVERSATION_UNSUBSCRIBE_TIMEOUT_MS },
+    );
+  } catch {
+    // Best effort only: preserve the user-facing turn result even if cleanup fails.
   }
 }
 


### PR DESCRIPTION
## Summary

- Fixes #85458.
- Add best-effort `thread/unsubscribe` cleanup after Codex app-server bound conversation turns, including the missing-thread recovery retry path.
- Preserve the persisted binding while releasing app-server subscriptions, and add regression coverage for retry rejection after a recreated thread is written.

## Tests

- `node scripts/run-vitest.mjs extensions/codex/src/conversation-binding.test.ts`
- `git diff --check`
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts`

## Real behavior proof

Behavior addressed: Codex app-server conversation bindings now release their app-server thread subscription after each bound turn, including when missing-thread recovery creates `thread-new` and the retry then rejects, so the new subscription is not stranded while the persistent binding remains available for later turns.

Real environment tested: Local macOS source checkout on this PR head with existing node_modules. I exercised the Codex conversation-binding runtime path through `handleCodexConversationInboundClaim` in the focused Vitest harness, using the same app-server request methods (`turn/start`, `thread/start`, `thread/unsubscribe`) with a mock app-server client so no live Codex credentials or external app-server were required.

Exact steps or command run after this patch: Ran the after-patch behavior command:

```sh
node scripts/run-vitest.mjs extensions/codex/src/conversation-binding.test.ts
```

Evidence after fix: Terminal command exited successfully, and the regression assertion in `unsubscribes a recreated bound thread when the recovery retry rejects` observed this runtime request sequence from the bound-turn handler:

```text
turn/start threadId=thread-old -> throws "thread not found: thread-old"
thread/unsubscribe threadId=thread-old
thread/start -> writes thread-new binding
turn/start threadId=thread-new -> throws "retry failed after recovery"
thread/unsubscribe threadId=thread-new
reply text: Codex app-server turn failed: retry failed after recovery
saved binding threadId: thread-new
```

Observed result after fix: The recreated `thread-new` subscription is released with `thread/unsubscribe` even though the recovery retry fails, and the saved conversation binding still points at `thread-new` instead of being cleared on the generic retry error.

What was not tested: A live Codex app-server with real credentials was not run; this issue was filed as a source-level leak without a live reproduction, so the proof uses the focused app-server protocol mock path plus existing app-server cleanup tests.
