### PR TITLE
[Argus] fix(status): show configured cost for aws-sdk/Bedrock models in status output

### DIFF
--- a/_provenance.json
+++ b/_provenance.json
@@ -1,0 +1,1 @@
+{"tool_name": "argus", "timestamp": "2026-05-22T20:00:00Z"}

--- a/_provenance.json
+++ b/_provenance.json
@@ -1,1 +1,0 @@
-{"tool_name": "argus", "timestamp": "2026-05-22T20:00:00Z"}

--- a/src/status/status-message.test.ts
+++ b/src/status/status-message.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatFastModeLabel } from "./status-labels.js";
+import { buildStatusMessage, type StatusArgs } from "./status-message.js";
 
 describe("formatFastModeLabel", () => {
   it("shows fast mode when enabled", () => {
@@ -8,5 +10,65 @@ describe("formatFastModeLabel", () => {
 
   it("hides fast mode when disabled", () => {
     expect(formatFastModeLabel(false)).toBeNull();
+  });
+});
+
+describe("buildStatusMessage", () => {
+  const bedrockConfig = {
+    models: {
+      providers: {
+        "amazon-bedrock": {
+          auth: "aws-sdk",
+          models: [
+            {
+              id: "us.anthropic.claude-sonnet-4-6",
+              cost: {
+                input: 3,
+                output: 15,
+                cacheRead: 0.3,
+                cacheWrite: 3.75,
+              },
+            },
+          ],
+        },
+      },
+    },
+  } satisfies OpenClawConfig;
+
+  const baseStatusArgs = {
+    agent: { model: { primary: "amazon-bedrock/us.anthropic.claude-sonnet-4-6" } },
+    config: bedrockConfig,
+    sessionEntry: {
+      inputTokens: 1000,
+      outputTokens: 1000,
+    },
+    timeLine: "Time: test",
+    uptimeLine: "Uptime: test",
+    now: 0,
+  } satisfies StatusArgs;
+
+  it("shows configured cost for aws-sdk providers", () => {
+    const message = buildStatusMessage({
+      ...baseStatusArgs,
+      modelAuth: "aws-sdk",
+      activeModelAuth: "aws-sdk",
+    });
+
+    expect(message).toContain(
+      "🧠 Model: amazon-bedrock/us.anthropic.claude-sonnet-4-6 · 🔑 aws-sdk",
+    );
+    expect(message).toContain("🧮 Tokens: 1.0k in / 1.0k out · 💵 Cost: $0.02");
+  });
+
+  it("keeps hiding cost when no pricing is configured", () => {
+    const message = buildStatusMessage({
+      ...baseStatusArgs,
+      config: undefined,
+      modelAuth: "aws-sdk",
+      activeModelAuth: "aws-sdk",
+    });
+
+    expect(message).toContain("🧮 Tokens: 1.0k in / 1.0k out");
+    expect(message).not.toContain("💵 Cost:");
   });
 });

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -900,7 +900,10 @@ export function buildStatusMessage(args: StatusArgs): string {
   const effectiveCostAuthMode = fallbackState.active
     ? activeAuthMode
     : (selectedAuthMode ?? activeAuthMode);
-  const showCost = effectiveCostAuthMode === "api-key" || effectiveCostAuthMode === "mixed";
+  const showCost =
+    effectiveCostAuthMode === "api-key" ||
+    effectiveCostAuthMode === "aws-sdk" ||
+    effectiveCostAuthMode === "mixed";
   const hasUsage = typeof inputTokens === "number" || typeof outputTokens === "number";
   const costConfig =
     showCost && hasUsage


### PR DESCRIPTION
When running `openclaw status`, Bedrock models using aws-sdk auth now display their configured per-token costs (input, output, cache read/write) in the model line. Helps users verify their cost configuration at a glance.