### PR TITLE
fix(channels): honor /verbose in group sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Docs: https://docs.openclaw.ai
 - Checks/Windows: run managed child commands through explicit `cmd.exe` wrapping instead of Node shell mode with argv, avoiding Node 24 subprocess deprecation warnings during changed checks.
 - Models: prune retired Groq, GitHub Copilot, OpenAI, xAI, and old Claude catalog entries, with doctor migration to upgrade existing configs to current provider refs.
 - Doctor/update: recognize junction-backed source checkouts as git installs by comparing canonical paths before showing package-manager update guidance. Fixes #82215. Thanks @igormf.
+- Channels: honor `/verbose on` for tool/progress summaries across direct chats, groups, channels, and forum topics while preserving quiet default behavior. (#85488) Thanks @kurplunkin.
 - CLI/skills: show an all-ready note with next-step commands when skill setup has no missing dependencies to install. (#85032) Thanks @aniruddhaadak80.
 - Microsoft Foundry: route DeepSeek V4 Pro and Flash models through the Foundry Responses API while keeping older DeepSeek models on their existing path. (#85549) Thanks @roslinmahmud.
 - Status/usage: show configured cost estimates for AWS SDK models in full usage output while keeping token-only usage replies cost-free. (#85619) Thanks @ItsOtherMauridian.

--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -60,6 +60,8 @@ Typing indicators are still sent for direct group requests. Ambient always-on ro
 Group sessions suppress verbose tool/progress summaries by default. Use
 `/verbose on` to show those summaries for the current group session while
 debugging, and `/verbose off` to return the group to final-reply-only behavior.
+Inherited agent `verboseDefault` settings do not opt normal groups into these
+summaries; each group session needs its own explicit `/verbose on`.
 
 To submit unmentioned always-on group chatter as quiet room context instead of user requests, use [Ambient room events](/channels/ambient-room-events):
 

--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -58,12 +58,9 @@ This replaces the old pattern of forcing the model to answer `NO_REPLY` for most
 Typing indicators are still sent for direct group requests. Ambient always-on room events, when enabled, stay strict and quiet unless the agent calls the message tool.
 
 Group sessions suppress verbose tool/progress summaries by default. Use
-`/verbose on` to show those summaries for the current group session while
-debugging on group-capable channels that support visible verbose delivery, and
-`/verbose off` to return the group to final-reply-only behavior. Slack
-non-direct surfaces remain excluded by the current dispatch policy. Inherited
-agent `verboseDefault` settings do not opt normal groups into these summaries;
-each group session needs its own explicit `/verbose on`.
+`/verbose on` to show those summaries for the current session while debugging,
+and `/verbose off` to return to final-reply-only behavior. The same verbose
+state applies across direct chats, groups, channels, and forum topics.
 
 To submit unmentioned always-on group chatter as quiet room context instead of user requests, use [Ambient room events](/channels/ambient-room-events):
 

--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -59,9 +59,11 @@ Typing indicators are still sent for direct group requests. Ambient always-on ro
 
 Group sessions suppress verbose tool/progress summaries by default. Use
 `/verbose on` to show those summaries for the current group session while
-debugging, and `/verbose off` to return the group to final-reply-only behavior.
-Inherited agent `verboseDefault` settings do not opt normal groups into these
-summaries; each group session needs its own explicit `/verbose on`.
+debugging on group-capable channels that support visible verbose delivery, and
+`/verbose off` to return the group to final-reply-only behavior. Slack
+non-direct surfaces remain excluded by the current dispatch policy. Inherited
+agent `verboseDefault` settings do not opt normal groups into these summaries;
+each group session needs its own explicit `/verbose on`.
 
 To submit unmentioned always-on group chatter as quiet room context instead of user requests, use [Ambient room events](/channels/ambient-room-events):
 

--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -57,10 +57,10 @@ This replaces the old pattern of forcing the model to answer `NO_REPLY` for most
 
 Typing indicators are still sent for direct group requests. Ambient always-on room events, when enabled, stay strict and quiet unless the agent calls the message tool.
 
-Group sessions suppress verbose tool/progress summaries by default. Use
-`/verbose on` to show those summaries for the current session while debugging,
-and `/verbose off` to return to final-reply-only behavior. The same verbose
-state applies across direct chats, groups, channels, and forum topics.
+Sessions suppress verbose tool/progress summaries by default. Use `/verbose on`
+to show those summaries for the current session while debugging, and
+`/verbose off` to return to final-reply-only behavior. The same verbose state
+applies across direct chats, groups, channels, and forum topics.
 
 To submit unmentioned always-on group chatter as quiet room context instead of user requests, use [Ambient room events](/channels/ambient-room-events):
 

--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -57,6 +57,10 @@ This replaces the old pattern of forcing the model to answer `NO_REPLY` for most
 
 Typing indicators are still sent for direct group requests. Ambient always-on room events, when enabled, stay strict and quiet unless the agent calls the message tool.
 
+Group sessions suppress verbose tool/progress summaries by default. Use
+`/verbose on` to show those summaries for the current group session while
+debugging, and `/verbose off` to return the group to final-reply-only behavior.
+
 To submit unmentioned always-on group chatter as quiet room context instead of user requests, use [Ambient room events](/channels/ambient-room-events):
 
 ```json5

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -131,7 +131,7 @@ export type RunEmbeddedPiAgentParams = {
   toolResultFormat?: ToolResultFormat;
   toolProgressDetail?: ToolProgressDetailMode;
   /** If true, suppress tool error warning payloads for this run (including mutating tools). */
-  suppressToolErrorWarnings?: boolean;
+  suppressToolErrorWarnings?: boolean | (() => boolean | undefined);
   /** Bootstrap context mode for workspace file injection. */
   bootstrapContextMode?: "full" | "lightweight";
   /** Run kind hint for context mode behavior. */

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -476,6 +476,19 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     });
   });
 
+  it("keeps stale full-verbose tool errors compact when live verbose is off", () => {
+    const payloads = buildPayloads({
+      lastToolError: { toolName: "write", error: "permission denied" },
+      suppressToolErrorWarnings: () => false,
+      verboseLevel: "full",
+    });
+
+    expectSingleToolErrorPayload(payloads, {
+      title: "Write",
+      absentDetail: "permission denied",
+    });
+  });
+
   it("keeps non-exec mutating tool failures visible", () => {
     const payloads = buildPayloads({
       lastToolError: { toolName: "write", error: "permission denied" },

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -489,6 +489,19 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     });
   });
 
+  it("preserves full-verbose tool error details with static suppression disabled", () => {
+    const payloads = buildPayloads({
+      lastToolError: { toolName: "write", error: "permission denied" },
+      suppressToolErrorWarnings: false,
+      verboseLevel: "full",
+    });
+
+    expectSingleToolErrorPayload(payloads, {
+      title: "Write",
+      detail: "permission denied",
+    });
+  });
+
   it("keeps non-exec mutating tool failures visible", () => {
     const payloads = buildPayloads({
       lastToolError: { toolName: "write", error: "permission denied" },

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -152,13 +152,16 @@ function resolveToolErrorWarningPolicy(params: {
   verboseLevel?: VerboseLevel;
 }): ToolErrorWarningPolicy {
   const normalizedToolName = normalizeOptionalLowercaseString(params.lastToolError.toolName) ?? "";
-  const toolErrorWarningOverride =
-    typeof params.suppressToolErrorWarnings === "function"
-      ? params.suppressToolErrorWarnings()
-      : params.suppressToolErrorWarnings;
+  const hasDynamicToolErrorWarningOverride = typeof params.suppressToolErrorWarnings === "function";
+  const toolErrorWarningOverride = hasDynamicToolErrorWarningOverride
+    ? params.suppressToolErrorWarnings?.()
+    : params.suppressToolErrorWarnings;
   const includeDetails = shouldIncludeToolErrorDetails({
     ...params,
-    verboseLevel: toolErrorWarningOverride === false ? "off" : params.verboseLevel,
+    verboseLevel:
+      hasDynamicToolErrorWarningOverride && toolErrorWarningOverride === false
+        ? "off"
+        : params.verboseLevel,
   });
   const suppressToolErrorWarnings = toolErrorWarningOverride === true;
   if (suppressToolErrorWarnings) {

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -152,16 +152,17 @@ function resolveToolErrorWarningPolicy(params: {
   verboseLevel?: VerboseLevel;
 }): ToolErrorWarningPolicy {
   const normalizedToolName = normalizeOptionalLowercaseString(params.lastToolError.toolName) ?? "";
-  const hasDynamicToolErrorWarningOverride = typeof params.suppressToolErrorWarnings === "function";
-  const toolErrorWarningOverride = hasDynamicToolErrorWarningOverride
-    ? params.suppressToolErrorWarnings?.()
-    : params.suppressToolErrorWarnings;
+  let toolErrorWarningOverride: boolean | undefined;
+  let dynamicToolErrorWarningsDisabled = false;
+  if (typeof params.suppressToolErrorWarnings === "function") {
+    toolErrorWarningOverride = params.suppressToolErrorWarnings();
+    dynamicToolErrorWarningsDisabled = toolErrorWarningOverride === false;
+  } else {
+    toolErrorWarningOverride = params.suppressToolErrorWarnings;
+  }
   const includeDetails = shouldIncludeToolErrorDetails({
     ...params,
-    verboseLevel:
-      hasDynamicToolErrorWarningOverride && toolErrorWarningOverride === false
-        ? "off"
-        : params.verboseLevel,
+    verboseLevel: dynamicToolErrorWarningsDisabled ? "off" : params.verboseLevel,
   });
   const suppressToolErrorWarnings = toolErrorWarningOverride === true;
   if (suppressToolErrorWarnings) {

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -152,11 +152,15 @@ function resolveToolErrorWarningPolicy(params: {
   verboseLevel?: VerboseLevel;
 }): ToolErrorWarningPolicy {
   const normalizedToolName = normalizeOptionalLowercaseString(params.lastToolError.toolName) ?? "";
-  const includeDetails = shouldIncludeToolErrorDetails(params);
-  const suppressToolErrorWarnings =
+  const toolErrorWarningOverride =
     typeof params.suppressToolErrorWarnings === "function"
-      ? params.suppressToolErrorWarnings() === true
-      : params.suppressToolErrorWarnings === true;
+      ? params.suppressToolErrorWarnings()
+      : params.suppressToolErrorWarnings;
+  const includeDetails = shouldIncludeToolErrorDetails({
+    ...params,
+    verboseLevel: toolErrorWarningOverride === false ? "off" : params.verboseLevel,
+  });
+  const suppressToolErrorWarnings = toolErrorWarningOverride === true;
   if (suppressToolErrorWarnings) {
     return { showWarning: false, includeDetails };
   }

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -146,14 +146,18 @@ function resolveToolErrorWarningPolicy(params: {
   hasUserFacingErrorReply: boolean;
   hasUserFacingFailureAcknowledgement: boolean;
   suppressToolErrors: boolean;
-  suppressToolErrorWarnings?: boolean;
+  suppressToolErrorWarnings?: boolean | (() => boolean | undefined);
   isCronTrigger?: boolean;
   sessionKey: string;
   verboseLevel?: VerboseLevel;
 }): ToolErrorWarningPolicy {
   const normalizedToolName = normalizeOptionalLowercaseString(params.lastToolError.toolName) ?? "";
   const includeDetails = shouldIncludeToolErrorDetails(params);
-  if (params.suppressToolErrorWarnings) {
+  const suppressToolErrorWarnings =
+    typeof params.suppressToolErrorWarnings === "function"
+      ? params.suppressToolErrorWarnings() === true
+      : params.suppressToolErrorWarnings === true;
+  if (suppressToolErrorWarnings) {
     return { showWarning: false, includeDetails };
   }
   // sessions_send timeouts and errors are transient inter-session communication
@@ -197,7 +201,7 @@ export function buildEmbeddedRunPayloads(params: {
   reasoningLevel?: ReasoningLevel;
   thinkingLevel?: ThinkLevel;
   toolResultFormat?: ToolResultFormat;
-  suppressToolErrorWarnings?: boolean;
+  suppressToolErrorWarnings?: boolean | (() => boolean | undefined);
   inlineToolResultsAllowed: boolean;
   didSendViaMessagingTool?: boolean;
   messagingToolSourceReplyPayloads?: MessagingToolSourceReplyPayload[];

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -75,6 +75,8 @@ export type GetReplyOptions = {
   bootstrapContextMode?: "full" | "lightweight";
   /** If true, suppress tool error warning payloads for this run. */
   suppressToolErrorWarnings?: boolean;
+  /** Dynamic form used when verbose progress visibility can change mid-run. */
+  shouldSuppressToolErrorWarnings?: () => boolean | undefined;
   /** If true, run the model without OpenClaw tools for this turn. */
   disableTools?: boolean;
   /** If true, include the heartbeat response tool for structured heartbeat outcomes. */

--- a/src/auto-reply/reply/acp-projector.test.ts
+++ b/src/auto-reply/reply/acp-projector.test.ts
@@ -224,6 +224,93 @@ describe("createAcpReplyProjector", () => {
     expect(deliveries).toEqual([{ kind: "final", text: "a".repeat(70) }]);
   });
 
+  it("rechecks the dynamic tool-summary gate for each ACP event", async () => {
+    let allowToolSummaries = false;
+    const deliveries: Delivery[] = [];
+    const projector = createAcpReplyProjector({
+      cfg: createCfg(
+        createLiveCfgOverrides({
+          tagVisibility: {
+            tool_call: true,
+          },
+        }),
+      ),
+      shouldSendToolSummaries: false,
+      shouldSendToolSummariesNow: () => allowToolSummaries,
+      deliver: async (kind, payload) => {
+        deliveries.push({ kind, text: payload.text });
+        return true;
+      },
+    });
+
+    await projector.onEvent({
+      type: "tool_call",
+      tag: "tool_call",
+      toolCallId: "tool-1",
+      status: "in_progress",
+      title: "Run hidden command",
+      text: "Run hidden command",
+    });
+    expect(deliveries).toEqual([]);
+
+    allowToolSummaries = true;
+    await projector.onEvent({
+      type: "tool_call",
+      tag: "tool_call",
+      toolCallId: "tool-2",
+      status: "in_progress",
+      title: "Run visible command",
+      text: "Run visible command",
+    });
+
+    expectToolCallSummary(deliveries[0]);
+  });
+
+  it("drops buffered final-only tool summaries when the dynamic gate turns off before flush", async () => {
+    let allowToolSummaries = true;
+    const deliveries: Delivery[] = [];
+    const projector = createAcpReplyProjector({
+      cfg: createCfg({
+        acp: {
+          enabled: true,
+          stream: {
+            deliveryMode: "final_only",
+            tagVisibility: {
+              available_commands_update: true,
+              tool_call: true,
+            },
+          },
+        },
+      }),
+      shouldSendToolSummaries: true,
+      shouldSendToolSummariesNow: () => allowToolSummaries,
+      deliver: async (kind, payload) => {
+        deliveries.push({ kind, text: payload.text });
+        return true;
+      },
+    });
+
+    await projector.onEvent({
+      type: "status",
+      text: "available commands updated (7)",
+      tag: "available_commands_update",
+    });
+    await projector.onEvent({
+      type: "tool_call",
+      tag: "tool_call",
+      toolCallId: "tool-1",
+      status: "in_progress",
+      title: "Run hidden command",
+      text: "Run hidden command",
+    });
+    await projector.onEvent({ type: "text_delta", text: "done", tag: "agent_message_chunk" });
+    allowToolSummaries = false;
+
+    await projector.onEvent({ type: "done" });
+
+    expect(deliveries).toEqual([{ kind: "final", text: "done" }]);
+  });
+
   it("does not suppress identical short text across terminal turn boundaries", async () => {
     const { deliveries, projector } = createProjectorHarness(
       createLiveCfgOverrides({
@@ -701,6 +788,48 @@ describe("createAcpReplyProjector", () => {
       toolCallId: "call_hidden_1",
       expectedText: "fallback. I don't",
     });
+  });
+
+  it("preserves hidden boundary when the dynamic tool-summary gate hides a visible tool event", async () => {
+    const deliveries: Delivery[] = [];
+    const projector = createAcpReplyProjector({
+      cfg: createCfg(
+        createHiddenBoundaryCfg({
+          tagVisibility: {
+            tool_call: true,
+          },
+        }),
+      ),
+      shouldSendToolSummaries: false,
+      shouldSendToolSummariesNow: () => false,
+      deliver: async (kind, payload) => {
+        deliveries.push({ kind, text: payload.text });
+        return true;
+      },
+    });
+
+    await projector.onEvent({
+      type: "text_delta",
+      text: "fallback.",
+      tag: "agent_message_chunk",
+    });
+    await projector.onEvent({
+      type: "tool_call",
+      tag: "tool_call",
+      toolCallId: "call_dynamic_hidden",
+      status: "in_progress",
+      title: "Run test",
+      text: "Run test (in_progress)",
+    });
+    await projector.onEvent({
+      type: "text_delta",
+      text: "I don't",
+      tag: "agent_message_chunk",
+    });
+    await projector.flush(true);
+
+    expect(combinedBlockText(deliveries)).toBe("fallback. I don't");
+    expect(deliveries.some((delivery) => delivery.kind === "tool")).toBe(false);
   });
 
   it("preserves hidden boundary across nonterminal hidden tool updates", async () => {

--- a/src/auto-reply/reply/acp-projector.test.ts
+++ b/src/auto-reply/reply/acp-projector.test.ts
@@ -311,6 +311,55 @@ describe("createAcpReplyProjector", () => {
     expect(deliveries).toEqual([{ kind: "final", text: "done" }]);
   });
 
+  it("preserves final-only text boundary when a buffered tool summary is dropped", async () => {
+    let allowToolSummaries = true;
+    const deliveries: Delivery[] = [];
+    const projector = createAcpReplyProjector({
+      cfg: createCfg({
+        acp: {
+          enabled: true,
+          stream: {
+            deliveryMode: "final_only",
+            hiddenBoundarySeparator: "space",
+            tagVisibility: {
+              tool_call: true,
+            },
+          },
+        },
+      }),
+      shouldSendToolSummaries: true,
+      shouldSendToolSummariesNow: () => allowToolSummaries,
+      deliver: async (kind, payload) => {
+        deliveries.push({ kind, text: payload.text });
+        return true;
+      },
+    });
+
+    await projector.onEvent({
+      type: "text_delta",
+      text: "fallback.",
+      tag: "agent_message_chunk",
+    });
+    await projector.onEvent({
+      type: "tool_call",
+      tag: "tool_call",
+      toolCallId: "tool-dropped-before-flush",
+      status: "in_progress",
+      title: "Run test",
+      text: "Run test (in_progress)",
+    });
+    await projector.onEvent({
+      type: "text_delta",
+      text: "I don't",
+      tag: "agent_message_chunk",
+    });
+    allowToolSummaries = false;
+
+    await projector.onEvent({ type: "done" });
+
+    expect(deliveries).toEqual([{ kind: "final", text: "fallback. I don't" }]);
+  });
+
   it("does not suppress identical short text across terminal turn boundaries", async () => {
     const { deliveries, projector } = createProjectorHarness(
       createLiveCfgOverrides({

--- a/src/auto-reply/reply/acp-projector.ts
+++ b/src/auto-reply/reply/acp-projector.ts
@@ -408,6 +408,7 @@ export function createAcpReplyProjector(params: {
         payload: { text: toolSummary },
         meta: deliveryMeta,
       });
+      markHiddenToolBoundary(event);
     } else {
       await flush(true);
       await params.deliver("tool", { text: toolSummary }, deliveryMeta);

--- a/src/auto-reply/reply/acp-projector.ts
+++ b/src/auto-reply/reply/acp-projector.ts
@@ -168,6 +168,7 @@ export type AcpReplyProjector = {
 export function createAcpReplyProjector(params: {
   cfg: OpenClawConfig;
   shouldSendToolSummaries: boolean;
+  shouldSendToolSummariesNow?: () => boolean;
   deliver: (
     kind: ReplyDispatchKind,
     payload: ReplyPayload,
@@ -208,6 +209,9 @@ export function createAcpReplyProjector(params: {
   let liveIdleTimer: NodeJS.Timeout | undefined;
   const pendingToolDeliveries: BufferedToolDelivery[] = [];
   const toolLifecycleById = new Map<string, ToolLifecycleState>();
+
+  const shouldSendToolSummaries = () =>
+    params.shouldSendToolSummariesNow?.() ?? params.shouldSendToolSummaries;
 
   const clearLiveIdleTimer = () => {
     if (!liveIdleTimer) {
@@ -282,6 +286,10 @@ export function createAcpReplyProjector(params: {
     if (!(settings.deliveryMode === "final_only" && force)) {
       return;
     }
+    if (!shouldSendToolSummaries()) {
+      pendingToolDeliveries.length = 0;
+      return;
+    }
     for (const entry of pendingToolDeliveries.splice(0)) {
       await params.deliver("tool", entry.payload, entry.meta);
     }
@@ -310,7 +318,7 @@ export function createAcpReplyProjector(params: {
     meta?: AcpProjectedDeliveryMeta,
     opts?: { dedupe?: boolean },
   ) => {
-    if (!params.shouldSendToolSummaries) {
+    if (!shouldSendToolSummaries()) {
       return;
     }
     const bounded = truncateText(text.trim(), settings.maxSessionUpdateChars);
@@ -335,8 +343,18 @@ export function createAcpReplyProjector(params: {
     lastStatusHash = hash;
   };
 
+  const markHiddenToolBoundary = (event: Extract<AcpRuntimeEvent, { type: "tool_call" }>) => {
+    if (!event.tag || !HIDDEN_BOUNDARY_TAGS.has(event.tag)) {
+      return;
+    }
+    const status = normalizeToolStatus(event.status);
+    const isTerminal = status ? TERMINAL_TOOL_STATUSES.has(status) : false;
+    pendingHiddenBoundary = pendingHiddenBoundary || event.tag === "tool_call" || isTerminal;
+  };
+
   const emitToolSummary = async (event: Extract<AcpRuntimeEvent, { type: "tool_call" }>) => {
-    if (!params.shouldSendToolSummaries) {
+    if (!shouldSendToolSummaries()) {
+      markHiddenToolBoundary(event);
       return;
     }
     if (!isAcpTagVisible(settings, event.tag)) {
@@ -486,11 +504,7 @@ export function createAcpReplyProjector(params: {
 
     if (event.type === "tool_call") {
       if (!isAcpTagVisible(settings, event.tag)) {
-        if (event.tag && HIDDEN_BOUNDARY_TAGS.has(event.tag)) {
-          const status = normalizeToolStatus(event.status);
-          const isTerminal = status ? TERMINAL_TOOL_STATUSES.has(status) : false;
-          pendingHiddenBoundary = pendingHiddenBoundary || event.tag === "tool_call" || isTerminal;
-        }
+        markHiddenToolBoundary(event);
         return;
       }
       await emitToolSummary(event);

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1903,7 +1903,9 @@ export async function runAgentTurnWithFallback(params: {
                   return isMarkdownCapableMessageChannel(channel) ? "markdown" : "plain";
                 })(),
                 toolProgressDetail: params.toolProgressDetail,
-                suppressToolErrorWarnings: params.opts?.suppressToolErrorWarnings,
+                suppressToolErrorWarnings:
+                  params.opts?.shouldSuppressToolErrorWarnings ??
+                  params.opts?.suppressToolErrorWarnings,
                 disableTools: params.opts?.disableTools,
                 enableHeartbeatTool: params.opts?.enableHeartbeatTool,
                 forceHeartbeatTool: params.opts?.forceHeartbeatTool,

--- a/src/auto-reply/reply/dispatch-acp-command-bypass.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-command-bypass.test.ts
@@ -85,6 +85,30 @@ describe("shouldBypassAcpDispatchForCommand", () => {
     expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
   });
 
+  it("returns true for local verbose commands", () => {
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      CommandBody: "/verbose on",
+      BodyForCommands: "/verbose on",
+      BodyForAgent: "/verbose on",
+    });
+
+    expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
+  });
+
+  it("returns true for local verbose alias commands", () => {
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      CommandBody: "/v off",
+      BodyForCommands: "/v off",
+      BodyForAgent: "/v off",
+    });
+
+    expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
+  });
+
   it("returns true for ACP reset-tail slash commands", () => {
     const ctx = buildTestCtx({
       Provider: "discord",

--- a/src/auto-reply/reply/dispatch-acp-command-bypass.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-command-bypass.test.ts
@@ -109,6 +109,21 @@ describe("shouldBypassAcpDispatchForCommand", () => {
     expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
   });
 
+  it.each(["/verbose:on", "/v:off", "/verbose:"])(
+    "returns true for colon-form local verbose command %s",
+    (command) => {
+      const ctx = buildTestCtx({
+        Provider: "discord",
+        Surface: "discord",
+        CommandBody: command,
+        BodyForCommands: command,
+        BodyForAgent: command,
+      });
+
+      expect(shouldBypassAcpDispatchForCommand(ctx, {} as OpenClawConfig)).toBe(true);
+    },
+  );
+
   it("returns true for ACP reset-tail slash commands", () => {
     const ctx = buildTestCtx({
       Provider: "discord",

--- a/src/auto-reply/reply/dispatch-acp-command-bypass.ts
+++ b/src/auto-reply/reply/dispatch-acp-command-bypass.ts
@@ -30,7 +30,7 @@ function isAcpCommandCandidate(text: string): boolean {
 }
 
 function isLocalCommandCandidate(text: string): boolean {
-  return /^\/(?:status|unfocus|verbose|v)(?:\s|$)/i.test(text);
+  return /^\/(?:status|unfocus)(?:\s|$)/i.test(text) || /^\/(?:verbose|v)(?:[\s:]|$)/i.test(text);
 }
 
 export function shouldBypassAcpDispatchForCommand(

--- a/src/auto-reply/reply/dispatch-acp-command-bypass.ts
+++ b/src/auto-reply/reply/dispatch-acp-command-bypass.ts
@@ -30,7 +30,7 @@ function isAcpCommandCandidate(text: string): boolean {
 }
 
 function isLocalCommandCandidate(text: string): boolean {
-  return /^\/(?:status|unfocus)(?:\s|$)/i.test(text);
+  return /^\/(?:status|unfocus|verbose|v)(?:\s|$)/i.test(text);
 }
 
 export function shouldBypassAcpDispatchForCommand(

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -331,6 +331,7 @@ export async function tryDispatchAcpReply(params: {
   originatingChannel?: string;
   originatingTo?: string;
   shouldSendToolSummaries: boolean;
+  shouldSendToolSummariesNow?: () => boolean;
   bypassForCommand: boolean;
   onReplyStart?: () => Promise<void> | void;
   recordProcessed: DispatchProcessedRecorder;
@@ -428,6 +429,7 @@ export async function tryDispatchAcpReply(params: {
   const projector = createAcpReplyProjector({
     cfg: params.cfg,
     shouldSendToolSummaries: params.shouldSendToolSummaries,
+    shouldSendToolSummariesNow: params.shouldSendToolSummariesNow,
     deliver: delivery.deliver,
     onProgress: markAcpProgress,
     provider: params.ctx.Surface ?? params.ctx.Provider,

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1519,6 +1519,170 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 
+  it("allows group tool summaries when session verbose is enabled despite preview suppression", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      verboseLevel: "on",
+    };
+    const cfg = automaticGroupReplyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      ChatType: "group",
+      From: "whatsapp:group:123@g.us",
+      SessionKey: "agent:main:whatsapp:group:123@g.us",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      const onToolResult = requireToolResultHandler(opts?.onToolResult);
+      await onToolResult({ text: "🔧 exec: ls" });
+      return { text: "hi" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: { suppressDefaultToolProgressMessages: true },
+    });
+
+    expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
+    expect(firstToolResultPayload(dispatcher)?.text).toBe("🔧 exec: ls");
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows group tool summaries when the agent verbose default is enabled", async () => {
+    setNoAbort();
+    const cfg = {
+      ...automaticGroupReplyConfig,
+      agents: {
+        defaults: {
+          verboseDefault: "on",
+        },
+      },
+    } as const satisfies OpenClawConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "matrix",
+      Surface: "matrix",
+      ChatType: "group",
+      From: "matrix:group:!room:example.org",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      const onToolResult = requireToolResultHandler(opts?.onToolResult);
+      await onToolResult({ text: "🔧 exec: pwd" });
+      return { text: "hi" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: { suppressDefaultToolProgressMessages: true },
+    });
+
+    expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
+    expect(firstToolResultPayload(dispatcher)?.text).toBe("🔧 exec: pwd");
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps group tool summaries suppressed when session verbose is disabled", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      verboseLevel: "off",
+    };
+    const cfg = {
+      ...automaticGroupReplyConfig,
+      agents: {
+        defaults: {
+          verboseDefault: "on",
+        },
+      },
+    } as const satisfies OpenClawConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      ChatType: "group",
+      From: "whatsapp:group:456@g.us",
+      SessionKey: "agent:main:whatsapp:group:456@g.us",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      const onToolResult = requireToolResultHandler(opts?.onToolResult);
+      await onToolResult({ text: "🔧 exec: date" });
+      return { text: "hi" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: { suppressDefaultToolProgressMessages: true },
+    });
+
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows group tool summaries when verbose is enabled during the run", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      verboseLevel: "off",
+    };
+    const cfg = automaticGroupReplyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      ChatType: "group",
+      From: "whatsapp:group:789@g.us",
+      SessionKey: "agent:main:whatsapp:group:789@g.us",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      const onToolResult = requireToolResultHandler(opts?.onToolResult);
+      sessionStoreMocks.currentEntry = {
+        verboseLevel: "on",
+      };
+      await onToolResult({ text: "🔧 exec: whoami" });
+      return { text: "hi" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: { suppressDefaultToolProgressMessages: true },
+    });
+
+    expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
+    expect(firstToolResultPayload(dispatcher)?.text).toBe("🔧 exec: whoami");
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+  });
+
   it("normalizes tool-result media before delivery and drops blocked file URLs", async () => {
     setNoAbort();
     replyMediaPathMocks.createReplyMediaPathNormalizer.mockReturnValue(

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1683,6 +1683,160 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps tool-error fallbacks available when group verbose is disabled during the run", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      verboseLevel: "on",
+    };
+    const cfg = automaticGroupReplyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      ChatType: "group",
+      From: "whatsapp:group:789@g.us",
+      SessionKey: "agent:main:whatsapp:group:789@g.us",
+    });
+    let receivedOptions: GetReplyOptions | undefined;
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      receivedOptions = opts;
+      const onToolResult = requireToolResultHandler(opts?.onToolResult);
+      sessionStoreMocks.currentEntry = {
+        verboseLevel: "off",
+      };
+      await onToolResult({ text: "🔧 exec: failed", isError: true });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: { suppressDefaultToolProgressMessages: true },
+    });
+
+    expect(receivedOptions?.suppressToolErrorWarnings).toBeUndefined();
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses channel-owned group progress callbacks while verbose is off", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      verboseLevel: "off",
+    };
+    const cfg = automaticGroupReplyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "group",
+      From: "telegram:group:-100123",
+      SessionKey: "agent:main:telegram:group:-100123",
+    });
+    const onToolStart = vi.fn();
+    const onItemEvent = vi.fn();
+    const onPlanUpdate = vi.fn();
+    const onApprovalEvent = vi.fn();
+    const onCommandOutput = vi.fn();
+    const onPatchSummary = vi.fn();
+    const onCompactionStart = vi.fn();
+    const onCompactionEnd = vi.fn();
+    const onToolResult = vi.fn();
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await opts?.onToolStart?.({ name: "exec", phase: "start" });
+      await opts?.onItemEvent?.({ itemId: "1", kind: "tool", progressText: "running exec" });
+      await opts?.onPlanUpdate?.({ phase: "update", steps: ["Run command"] });
+      await opts?.onApprovalEvent?.({ phase: "requested", command: "pnpm test" });
+      await opts?.onCommandOutput?.({ phase: "end", name: "exec", status: "ok", exitCode: 0 });
+      await opts?.onPatchSummary?.({ phase: "end", summary: "1 modified" });
+      await opts?.onCompactionStart?.();
+      await opts?.onCompactionEnd?.();
+      await opts?.onToolResult?.({ text: "🔧 exec: ok" });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        suppressDefaultToolProgressMessages: true,
+        onToolStart,
+        onItemEvent,
+        onPlanUpdate,
+        onApprovalEvent,
+        onCommandOutput,
+        onPatchSummary,
+        onCompactionStart,
+        onCompactionEnd,
+        onToolResult,
+      },
+    });
+
+    expect(onToolStart).not.toHaveBeenCalled();
+    expect(onItemEvent).not.toHaveBeenCalled();
+    expect(onPlanUpdate).not.toHaveBeenCalled();
+    expect(onApprovalEvent).not.toHaveBeenCalled();
+    expect(onCommandOutput).not.toHaveBeenCalled();
+    expect(onPatchSummary).not.toHaveBeenCalled();
+    expect(onCompactionStart).not.toHaveBeenCalled();
+    expect(onCompactionEnd).not.toHaveBeenCalled();
+    expect(onToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes live group tool-summary state to reply_dispatch hooks", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      verboseLevel: "off",
+    };
+    const cfg = automaticGroupReplyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "matrix",
+      Surface: "matrix",
+      ChatType: "group",
+      From: "matrix:!room:test",
+      SessionKey: "agent:main:matrix:group:!room:test",
+    });
+    let initialHookState: boolean | undefined;
+    let updatedHookState: boolean | undefined;
+    hookMocks.runner.runReplyDispatch.mockImplementationOnce(async (event: unknown) => {
+      const replyDispatchEvent = event as { shouldSendToolSummaries: boolean };
+      initialHookState = replyDispatchEvent.shouldSendToolSummaries;
+      sessionStoreMocks.currentEntry = {
+        verboseLevel: "on",
+      };
+      updatedHookState = replyDispatchEvent.shouldSendToolSummaries;
+      return undefined;
+    });
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver: async () => ({ text: "hi" }) satisfies ReplyPayload,
+    });
+
+    expect(initialHookState).toBe(false);
+    expect(updatedHookState).toBe(true);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+  });
+
   it("normalizes tool-result media before delivery and drops blocked file URLs", async () => {
     setNoAbort();
     replyMediaPathMocks.createReplyMediaPathNormalizer.mockReturnValue(

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -2753,7 +2753,7 @@ describe("dispatchReplyFromConfig", () => {
         ...(sessionStoreMocks.currentEntry ?? {}),
         verboseLevel: "off",
       };
-      expect(opts?.shouldSuppressToolErrorWarnings?.()).toBeUndefined();
+      expect(opts?.shouldSuppressToolErrorWarnings?.()).toBe(false);
       return { text: "done" } satisfies ReplyPayload;
     });
 
@@ -2765,7 +2765,7 @@ describe("dispatchReplyFromConfig", () => {
     });
 
     expect(receivedOptions?.suppressToolErrorWarnings).toBeUndefined();
-    expect(receivedOptions?.shouldSuppressToolErrorWarnings?.()).toBeUndefined();
+    expect(receivedOptions?.shouldSuppressToolErrorWarnings?.()).toBe(false);
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
   });
 

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -2498,6 +2498,50 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
+  it("keeps terminal tool-error fallbacks available when message-tool-only error text is hidden", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+      verboseLevel: "on",
+    };
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      ChatType: "direct",
+      SessionKey: "agent:main:telegram:direct:U1",
+    });
+    let receivedOptions: GetReplyOptions | undefined;
+
+    const replyResolver = async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      receivedOptions = opts;
+      expect(opts?.shouldSuppressToolErrorWarnings?.()).toBeUndefined();
+      await opts?.onToolResult?.({
+        text: "🛠️ Bash: `ls /tmp/missing`\n```txt\nNo such file or directory\n```",
+        isError: true,
+      });
+      expect(opts?.shouldSuppressToolErrorWarnings?.()).toBeUndefined();
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    });
+
+    expect(receivedOptions?.suppressToolErrorWarnings).toBeUndefined();
+    expect(receivedOptions?.shouldSuppressToolErrorWarnings?.()).toBeUndefined();
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
   it("allows message-tool-only failed tool output in verbose full mode", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -2550,6 +2550,7 @@ describe("dispatchReplyFromConfig", () => {
       verboseLevel: "on",
     };
     const dispatcher = createDispatcher();
+    const onCommandOutput = vi.fn();
     const ctx = buildTestCtx({
       Provider: "telegram",
       ChatType: "direct",
@@ -2559,7 +2560,12 @@ describe("dispatchReplyFromConfig", () => {
     const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
       receivedOptions = opts;
       expect(opts?.shouldSuppressToolErrorWarnings?.()).toBeUndefined();
-      await opts?.onToolResult?.({ text: "raw failed command output", isError: true });
+      await opts?.onCommandOutput?.({
+        phase: "end",
+        name: "exec",
+        status: "failed",
+        exitCode: 1,
+      });
       return { text: "done" } satisfies ReplyPayload;
     });
 
@@ -2568,8 +2574,15 @@ describe("dispatchReplyFromConfig", () => {
       cfg: emptyConfig,
       dispatcher,
       replyResolver,
+      replyOptions: { onCommandOutput },
     });
 
+    expect(onCommandOutput).toHaveBeenCalledWith({
+      phase: "end",
+      name: "exec",
+      status: "failed",
+      exitCode: 1,
+    });
     expect(receivedOptions?.suppressToolErrorWarnings).toBeUndefined();
     expect(receivedOptions?.shouldSuppressToolErrorWarnings?.()).toBe(true);
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
@@ -2584,6 +2597,7 @@ describe("dispatchReplyFromConfig", () => {
       verboseLevel: "on",
     };
     const dispatcher = createDispatcher();
+    const onItemEvent = vi.fn();
     const ctx = buildTestCtx({
       Provider: "whatsapp",
       Surface: "whatsapp",
@@ -2595,7 +2609,12 @@ describe("dispatchReplyFromConfig", () => {
     const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
       receivedOptions = opts;
       expect(opts?.shouldSuppressToolErrorWarnings?.()).toBeUndefined();
-      await opts?.onToolResult?.({ text: "raw failed command output", isError: true });
+      await opts?.onItemEvent?.({
+        itemId: "item-1",
+        kind: "tool",
+        name: "exec",
+        status: "failed",
+      });
       return { text: "done" } satisfies ReplyPayload;
     });
 
@@ -2604,8 +2623,15 @@ describe("dispatchReplyFromConfig", () => {
       cfg: automaticGroupReplyConfig,
       dispatcher,
       replyResolver,
+      replyOptions: { onItemEvent },
     });
 
+    expect(onItemEvent).toHaveBeenCalledWith({
+      itemId: "item-1",
+      kind: "tool",
+      name: "exec",
+      status: "failed",
+    });
     expect(receivedOptions?.suppressToolErrorWarnings).toBeUndefined();
     expect(receivedOptions?.shouldSuppressToolErrorWarnings?.()).toBe(true);
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
@@ -2620,6 +2646,7 @@ describe("dispatchReplyFromConfig", () => {
       verboseLevel: "off",
     };
     const dispatcher = createDispatcher();
+    const onCommandOutput = vi.fn();
     const ctx = buildTestCtx({
       Provider: "telegram",
       ChatType: "direct",
@@ -2628,7 +2655,12 @@ describe("dispatchReplyFromConfig", () => {
     let receivedOptions: GetReplyOptions | undefined;
     const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
       receivedOptions = opts;
-      await opts?.onToolResult?.({ text: "raw failed command output", isError: true });
+      await opts?.onCommandOutput?.({
+        phase: "end",
+        name: "exec",
+        status: "failed",
+        exitCode: 1,
+      });
       sessionStoreMocks.currentEntry = {
         ...(sessionStoreMocks.currentEntry ?? {}),
         verboseLevel: "on",
@@ -2643,10 +2675,12 @@ describe("dispatchReplyFromConfig", () => {
       dispatcher,
       replyResolver,
       replyOptions: {
+        onCommandOutput,
         sourceReplyDeliveryMode: "message_tool_only",
       },
     });
 
+    expect(onCommandOutput).not.toHaveBeenCalled();
     expect(receivedOptions?.suppressToolErrorWarnings).toBeUndefined();
     expect(receivedOptions?.shouldSuppressToolErrorWarnings?.()).toBeUndefined();
     expect(dispatcher.sendToolResult).not.toHaveBeenCalled();

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -2731,6 +2731,44 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
+  it("does not pre-latch terminal tool-error suppression when diagnostics are disabled", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+      verboseLevel: "on",
+    };
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      ChatType: "direct",
+      SessionKey: "agent:main:telegram:direct:U1",
+    });
+    let receivedOptions: GetReplyOptions | undefined;
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      receivedOptions = opts;
+      expect(opts?.shouldSuppressToolErrorWarnings?.()).toBeUndefined();
+      sessionStoreMocks.currentEntry = {
+        ...(sessionStoreMocks.currentEntry ?? {}),
+        verboseLevel: "off",
+      };
+      expect(opts?.shouldSuppressToolErrorWarnings?.()).toBeUndefined();
+      return { text: "done" } satisfies ReplyPayload;
+    });
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: { diagnostics: { enabled: false } } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(receivedOptions?.suppressToolErrorWarnings).toBeUndefined();
+    expect(receivedOptions?.shouldSuppressToolErrorWarnings?.()).toBeUndefined();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
+  });
+
   it("keeps terminal tool-error fallbacks available in verbose full mode", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1518,7 +1518,7 @@ describe("dispatchReplyFromConfig", () => {
       cfg,
       dispatcher,
       replyResolver,
-      replyOptions: { suppressDefaultToolProgressMessages: true },
+      replyOptions: { suppressDefaultToolProgressMessages: false },
     });
 
     expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -140,6 +140,7 @@ const agentEventMocks = vi.hoisted(() => ({
 const ttsMocks = vi.hoisted(() => {
   const state = {
     synthesizeFinalAudio: false,
+    synthesizeToolAudio: false,
   };
   return {
     state,
@@ -157,6 +158,19 @@ const ttsMocks = vi.hoisted(() => {
         return {
           ...params.payload,
           mediaUrl: "https://example.com/tts-synth.opus",
+          audioAsVoice: true,
+          trustedLocalMedia: true,
+        };
+      }
+      if (
+        state.synthesizeToolAudio &&
+        params.kind === "tool" &&
+        typeof params.payload?.text === "string" &&
+        params.payload.text.trim()
+      ) {
+        return {
+          ...params.payload,
+          mediaUrl: "https://example.com/tts-tool.opus",
           audioAsVoice: true,
           trustedLocalMedia: true,
         };
@@ -891,6 +905,7 @@ describe("dispatchReplyFromConfig", () => {
     threadInfoMocks.parseSessionThreadInfo.mockReset();
     threadInfoMocks.parseSessionThreadInfo.mockImplementation(parseGenericThreadSessionInfo);
     ttsMocks.state.synthesizeFinalAudio = false;
+    ttsMocks.state.synthesizeToolAudio = false;
     ttsMocks.maybeApplyTtsToPayload.mockClear();
     ttsMocks.normalizeTtsAutoMode.mockClear();
     ttsMocks.resolveTtsConfig.mockClear();
@@ -1460,6 +1475,35 @@ describe("dispatchReplyFromConfig", () => {
     await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
     expect(dispatcher.sendToolResult).toHaveBeenCalledWith({ text: "tool output" });
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not synthesize hidden text-only tool summaries into TTS media", async () => {
+    setNoAbort();
+    ttsMocks.state.synthesizeToolAudio = true;
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      ChatType: "direct",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      const onToolResult = requireToolResultHandler(opts?.onToolResult);
+      await onToolResult({ text: "tool output" });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(ttsMocks.maybeApplyTtsToPayload).not.toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "tool" }),
+    );
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
   });
 
   it("suppresses late text-only tool results after final delivery starts", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1744,6 +1744,7 @@ describe("dispatchReplyFromConfig", () => {
     });
 
     expect(receivedOptions?.suppressToolErrorWarnings).toBeUndefined();
+    expect(receivedOptions?.shouldSuppressToolErrorWarnings?.()).toBeUndefined();
     expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
@@ -2559,6 +2560,41 @@ describe("dispatchReplyFromConfig", () => {
     });
 
     expect(receivedOptions?.suppressToolErrorWarnings).toBe(true);
+    expect(receivedOptions?.shouldSuppressToolErrorWarnings?.()).toBe(true);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
+  });
+
+  it("suppresses terminal tool-error fallbacks in group sessions when verbose progress is visible", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+      verboseLevel: "on",
+    };
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      ChatType: "group",
+      From: "whatsapp:group:123@g.us",
+      SessionKey: "agent:main:whatsapp:group:123@g.us",
+    });
+    let receivedOptions: GetReplyOptions | undefined;
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      receivedOptions = opts;
+      return { text: "done" } satisfies ReplyPayload;
+    });
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: automaticGroupReplyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(receivedOptions?.suppressToolErrorWarnings).toBeUndefined();
+    expect(receivedOptions?.shouldSuppressToolErrorWarnings?.()).toBe(true);
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
   });
 

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1747,7 +1747,7 @@ describe("dispatchReplyFromConfig", () => {
     });
 
     expect(receivedOptions?.suppressToolErrorWarnings).toBeUndefined();
-    expect(receivedOptions?.shouldSuppressToolErrorWarnings?.()).toBeUndefined();
+    expect(receivedOptions?.shouldSuppressToolErrorWarnings?.()).toBe(false);
     expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1420,7 +1420,13 @@ describe("dispatchReplyFromConfig", () => {
       return undefined;
     };
 
-    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: { suppressDefaultToolProgressMessages: true },
+    });
 
     const normalizerOptions = replyMediaPathMocks.createReplyMediaPathNormalizer.mock
       .calls[0]?.[0] as { cfg?: unknown; messageProvider?: unknown } | undefined;
@@ -1510,7 +1516,13 @@ describe("dispatchReplyFromConfig", () => {
       return { text: "hi" } satisfies ReplyPayload;
     };
 
-    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: { suppressDefaultToolProgressMessages: true },
+    });
 
     expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
     const sent = firstToolResultPayload(dispatcher);
@@ -1557,7 +1569,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps group tool summaries suppressed when only the agent verbose default is enabled", async () => {
+  it("allows group tool summaries when the agent verbose default is enabled", async () => {
     setNoAbort();
     const cfg = {
       ...automaticGroupReplyConfig,
@@ -1593,7 +1605,8 @@ describe("dispatchReplyFromConfig", () => {
       replyOptions: { suppressDefaultToolProgressMessages: true },
     });
 
-    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
+    expect(firstToolResultPayload(dispatcher)?.text).toBe("🔧 exec: pwd");
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 
@@ -1682,7 +1695,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps tool-error fallbacks available when group verbose is disabled during the run", async () => {
+  it("keeps tool-error fallbacks available when verbose is disabled during the run", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {
       verboseLevel: "on",
@@ -1829,6 +1842,7 @@ describe("dispatchReplyFromConfig", () => {
       cfg,
       dispatcher,
       replyResolver: async () => ({ text: "hi" }) satisfies ReplyPayload,
+      replyOptions: { suppressDefaultToolProgressMessages: true },
     });
 
     expect(initialHookState).toBe(false);
@@ -1865,7 +1879,13 @@ describe("dispatchReplyFromConfig", () => {
       return { text: "done" } satisfies ReplyPayload;
     };
 
-    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: { suppressDefaultToolProgressMessages: true },
+    });
 
     const normalizerOptions = replyMediaPathMocks.createReplyMediaPathNormalizer.mock
       .calls[0]?.[0] as { cfg?: unknown; messageProvider?: unknown } | undefined;
@@ -2144,7 +2164,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
   });
 
-  it("suppresses Slack non-DM verbose progress even when verbose is enabled", async () => {
+  it("delivers Slack non-DM verbose progress when verbose is enabled", async () => {
     setNoAbort();
     const cfg = {
       ...emptyConfig,
@@ -2180,9 +2200,15 @@ describe("dispatchReplyFromConfig", () => {
       return { text: "done" } satisfies ReplyPayload;
     };
 
-    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: { suppressDefaultToolProgressMessages: true },
+    });
 
-    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendToolResult).toHaveBeenCalled();
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
   });
 

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -2558,6 +2558,8 @@ describe("dispatchReplyFromConfig", () => {
     let receivedOptions: GetReplyOptions | undefined;
     const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
       receivedOptions = opts;
+      expect(opts?.shouldSuppressToolErrorWarnings?.()).toBeUndefined();
+      await opts?.onToolResult?.({ text: "raw failed command output", isError: true });
       return { text: "done" } satisfies ReplyPayload;
     });
 
@@ -2592,6 +2594,8 @@ describe("dispatchReplyFromConfig", () => {
     let receivedOptions: GetReplyOptions | undefined;
     const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
       receivedOptions = opts;
+      expect(opts?.shouldSuppressToolErrorWarnings?.()).toBeUndefined();
+      await opts?.onToolResult?.({ text: "raw failed command output", isError: true });
       return { text: "done" } satisfies ReplyPayload;
     });
 
@@ -2605,6 +2609,48 @@ describe("dispatchReplyFromConfig", () => {
     expect(receivedOptions?.suppressToolErrorWarnings).toBeUndefined();
     expect(receivedOptions?.shouldSuppressToolErrorWarnings?.()).toBe(true);
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
+  });
+
+  it("keeps terminal tool-error fallbacks available when verbose turns on after a quiet failure", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+      verboseLevel: "off",
+    };
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      ChatType: "direct",
+      SessionKey: "agent:main:telegram:direct:U1",
+    });
+    let receivedOptions: GetReplyOptions | undefined;
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      receivedOptions = opts;
+      await opts?.onToolResult?.({ text: "raw failed command output", isError: true });
+      sessionStoreMocks.currentEntry = {
+        ...(sessionStoreMocks.currentEntry ?? {}),
+        verboseLevel: "on",
+      };
+      expect(opts?.shouldSuppressToolErrorWarnings?.()).toBeUndefined();
+      return { text: "done" } satisfies ReplyPayload;
+    });
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    });
+
+    expect(receivedOptions?.suppressToolErrorWarnings).toBeUndefined();
+    expect(receivedOptions?.shouldSuppressToolErrorWarnings?.()).toBeUndefined();
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
   it("keeps terminal tool-error fallbacks available in verbose full mode", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1420,13 +1420,7 @@ describe("dispatchReplyFromConfig", () => {
       return undefined;
     };
 
-    await dispatchReplyFromConfig({
-      ctx,
-      cfg,
-      dispatcher,
-      replyResolver,
-      replyOptions: { suppressDefaultToolProgressMessages: true },
-    });
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
 
     const normalizerOptions = replyMediaPathMocks.createReplyMediaPathNormalizer.mock
       .calls[0]?.[0] as { cfg?: unknown; messageProvider?: unknown } | undefined;
@@ -1531,7 +1525,35 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 
-  it("allows group tool summaries when session verbose is enabled despite preview suppression", async () => {
+  it("keeps group tool summaries suppressed when the channel omits the quiet-default flag", async () => {
+    setNoAbort();
+    const cfg = automaticGroupReplyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      ChatType: "group",
+      From: "whatsapp:group:123@g.us",
+      SessionKey: "agent:main:whatsapp:group:123@g.us",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      const onToolResult = requireToolResultHandler(opts?.onToolResult);
+      await onToolResult({ text: "🔧 exec: ls" });
+      return { text: "hi" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows group tool summaries when session verbose is enabled without a channel quiet-default flag", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {
       verboseLevel: "on",
@@ -1556,13 +1578,7 @@ describe("dispatchReplyFromConfig", () => {
       return { text: "hi" } satisfies ReplyPayload;
     };
 
-    await dispatchReplyFromConfig({
-      ctx,
-      cfg,
-      dispatcher,
-      replyResolver,
-      replyOptions: { suppressDefaultToolProgressMessages: true },
-    });
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
 
     expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
     expect(firstToolResultPayload(dispatcher)?.text).toBe("🔧 exec: ls");
@@ -1597,13 +1613,7 @@ describe("dispatchReplyFromConfig", () => {
       return { text: "hi" } satisfies ReplyPayload;
     };
 
-    await dispatchReplyFromConfig({
-      ctx,
-      cfg,
-      dispatcher,
-      replyResolver,
-      replyOptions: { suppressDefaultToolProgressMessages: true },
-    });
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
 
     expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
     expect(firstToolResultPayload(dispatcher)?.text).toBe("🔧 exec: pwd");
@@ -1895,9 +1905,16 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
   });
 
-  it("delivers tool summaries in forum topic sessions (group + IsForum)", async () => {
+  it("delivers tool summaries in forum topic sessions when verbose is enabled", async () => {
     setNoAbort();
-    const cfg = automaticGroupReplyConfig;
+    const cfg = {
+      ...automaticGroupReplyConfig,
+      agents: {
+        defaults: {
+          verboseDefault: "on",
+        },
+      },
+    } satisfies OpenClawConfig;
     const dispatcher = createDispatcher();
     const ctx = buildTestCtx({
       Provider: "telegram",
@@ -4093,7 +4110,14 @@ describe("dispatchReplyFromConfig", () => {
 
   it("forwards non-answer progress callbacks when source replies are suppressed", async () => {
     setNoAbort();
-    const cfg = { diagnostics: { enabled: true } } as OpenClawConfig;
+    const cfg = {
+      diagnostics: { enabled: true },
+      agents: {
+        defaults: {
+          verboseDefault: "on",
+        },
+      },
+    } satisfies OpenClawConfig;
     const dispatcher = createDispatcher();
     const ctx = buildTestCtx({
       Provider: "discord",

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -2706,7 +2706,7 @@ describe("dispatchReplyFromConfig", () => {
         exitCode: 1,
       });
       sessionStoreMocks.currentEntry = {
-        ...(sessionStoreMocks.currentEntry ?? {}),
+        ...sessionStoreMocks.currentEntry,
         verboseLevel: "on",
       };
       expect(opts?.shouldSuppressToolErrorWarnings?.()).toBeUndefined();
@@ -2750,7 +2750,7 @@ describe("dispatchReplyFromConfig", () => {
       receivedOptions = opts;
       expect(opts?.shouldSuppressToolErrorWarnings?.()).toBeUndefined();
       sessionStoreMocks.currentEntry = {
-        ...(sessionStoreMocks.currentEntry ?? {}),
+        ...sessionStoreMocks.currentEntry,
         verboseLevel: "off",
       };
       expect(opts?.shouldSuppressToolErrorWarnings?.()).toBe(false);

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1437,7 +1437,10 @@ describe("dispatchReplyFromConfig", () => {
   it("provides onToolResult in DM sessions", async () => {
     setNoAbort();
     mocks.routeReply.mockClear();
-    const cfg = emptyConfig;
+    const cfg = {
+      ...emptyConfig,
+      agents: { defaults: { verboseDefault: "on" } },
+    } satisfies OpenClawConfig;
     const dispatcher = createDispatcher();
     const ctx = buildTestCtx({
       Provider: "telegram",
@@ -1985,7 +1988,10 @@ describe("dispatchReplyFromConfig", () => {
 
   it("sends tool results via dispatcher in DM sessions", async () => {
     setNoAbort();
-    const cfg = emptyConfig;
+    const cfg = {
+      ...emptyConfig,
+      agents: { defaults: { verboseDefault: "on" } },
+    } satisfies OpenClawConfig;
     const dispatcher = createDispatcher();
     const ctx = buildTestCtx({
       Provider: "telegram",
@@ -2009,7 +2015,10 @@ describe("dispatchReplyFromConfig", () => {
 
   it("delivers native tool summaries and tool media", async () => {
     setNoAbort();
-    const cfg = emptyConfig;
+    const cfg = {
+      ...emptyConfig,
+      agents: { defaults: { verboseDefault: "on" } },
+    } satisfies OpenClawConfig;
     const dispatcher = createDispatcher();
     const ctx = buildTestCtx({
       Provider: "telegram",
@@ -2115,6 +2124,10 @@ describe("dispatchReplyFromConfig", () => {
 
   it("sends only one plan status notice per reply run", async () => {
     setNoAbort();
+    const cfg = {
+      ...emptyConfig,
+      agents: { defaults: { verboseDefault: "on" } },
+    } satisfies OpenClawConfig;
     const dispatcher = createDispatcher();
     const ctx = buildTestCtx({
       Provider: "telegram",
@@ -2137,7 +2150,7 @@ describe("dispatchReplyFromConfig", () => {
       return { text: "done" } satisfies ReplyPayload;
     };
 
-    await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
 
     expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
     expect(firstToolResultPayload(dispatcher)).toMatchObject({
@@ -2230,7 +2243,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
   });
 
-  it("keeps plan notices when session verbose is off but suppresses working statuses", async () => {
+  it("suppresses plan notices when session verbose is off", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {
       verboseLevel: "off",
@@ -2275,20 +2288,16 @@ describe("dispatchReplyFromConfig", () => {
 
     await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
 
-    expect(firstToolResultPayload(dispatcher)).toMatchObject({
-      text: "1. Inspect code\n2. Patch code\n3. Run tests",
-      isStatusNotice: true,
-    });
-    expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
   });
 
   it("refreshes verbose progress with session entry snapshots", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {
-      verboseLevel: "on",
+      verboseLevel: "off",
     };
-    sessionStoreMocks.readSessionEntry.mockReturnValue({ verboseLevel: "off" });
+    sessionStoreMocks.readSessionEntry.mockReturnValue({ verboseLevel: "on" });
     const cfg = {
       ...emptyConfig,
       agents: {
@@ -2559,7 +2568,7 @@ describe("dispatchReplyFromConfig", () => {
       replyResolver,
     });
 
-    expect(receivedOptions?.suppressToolErrorWarnings).toBe(true);
+    expect(receivedOptions?.suppressToolErrorWarnings).toBeUndefined();
     expect(receivedOptions?.shouldSuppressToolErrorWarnings?.()).toBe(true);
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
   });

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1557,7 +1557,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 
-  it("allows group tool summaries when the agent verbose default is enabled", async () => {
+  it("keeps group tool summaries suppressed when only the agent verbose default is enabled", async () => {
     setNoAbort();
     const cfg = {
       ...automaticGroupReplyConfig,
@@ -1593,8 +1593,7 @@ describe("dispatchReplyFromConfig", () => {
       replyOptions: { suppressDefaultToolProgressMessages: true },
     });
 
-    expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
-    expect(firstToolResultPayload(dispatcher)?.text).toBe("🔧 exec: pwd");
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1852,12 +1852,14 @@ export async function dispatchReplyFromConfig(
       ctx.InboundEventKind !== "room_event" &&
       !shouldSuppressProgressDelivery();
     const hasLiveVerboseProgressGate = suppressDefaultToolProgressMessages && canTrackSession;
+    let observedVisibleToolErrorProgress =
+      hasVisibleRegularVerboseToolProgress() && !hasLiveVerboseProgressGate;
     const shouldSuppressToolErrorWarnings = () =>
       params.replyOptions?.suppressToolErrorWarnings ??
-      (hasVisibleRegularVerboseToolProgress() ? true : undefined);
+      (observedVisibleToolErrorProgress ? true : undefined);
     const suppressToolErrorWarnings =
       params.replyOptions?.suppressToolErrorWarnings ??
-      (hasVisibleRegularVerboseToolProgress() && !hasLiveVerboseProgressGate ? true : undefined);
+      (observedVisibleToolErrorProgress ? true : undefined);
     const onToolResultFromReplyOptions = params.replyOptions?.onToolResult;
     const onPlanUpdateFromReplyOptions = params.replyOptions?.onPlanUpdate;
     const onApprovalEventFromReplyOptions = params.replyOptions?.onApprovalEvent;
@@ -1946,6 +1948,9 @@ export async function dispatchReplyFromConfig(
             }),
             onToolResult: (payload: ReplyPayload) => {
               markProgress();
+              if (payload.isError === true && hasVisibleRegularVerboseToolProgress()) {
+                observedVisibleToolErrorProgress = true;
+              }
               const run = async () => {
                 if (isDispatchOperationAborted()) {
                   return;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1863,9 +1863,15 @@ export async function dispatchReplyFromConfig(
       payload.status === "failed" ||
       payload.status === "error" ||
       (typeof payload.exitCode === "number" && payload.exitCode !== 0);
-    const shouldSuppressToolErrorWarnings = () =>
-      params.replyOptions?.suppressToolErrorWarnings ??
-      (observedVisibleToolErrorProgress ? true : undefined);
+    const shouldSuppressToolErrorWarnings = () => {
+      if (params.replyOptions?.suppressToolErrorWarnings !== undefined) {
+        return params.replyOptions.suppressToolErrorWarnings;
+      }
+      if (!shouldEmitVerboseProgress()) {
+        return false;
+      }
+      return observedVisibleToolErrorProgress ? true : undefined;
+    };
     const suppressToolErrorWarnings =
       params.replyOptions?.suppressToolErrorWarnings ??
       (observedVisibleToolErrorProgress ? true : undefined);

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1474,11 +1474,17 @@ export async function dispatchReplyFromConfig(
     // so /stop can abort pre-run and in-run stalls through the same session lane.
     ensureDispatchReplyOperation();
 
+    const chatType = normalizeChatType(ctx.ChatType);
     const isSlackNonDirectSurface =
-      (ctx.Surface === "slack" || ctx.Provider === "slack") && ctx.ChatType !== "direct";
-    const shouldSendVerboseProgressMessages =
-      !isSlackNonDirectSurface && (ctx.ChatType !== "group" || ctx.IsForum === true);
-    const shouldSendToolSummaries = shouldSendVerboseProgressMessages;
+      (ctx.Surface === "slack" || ctx.Provider === "slack") && chatType !== "direct";
+    const isGroupChat = chatType === "group";
+    const isForumTopic = ctx.IsForum === true;
+    const shouldAllowGroupVerboseProgress = () =>
+      isGroupChat && !isForumTopic && shouldEmitVerboseProgress();
+    const shouldSendVerboseProgressMessages = () =>
+      !isSlackNonDirectSurface &&
+      (!isGroupChat || isForumTopic || shouldAllowGroupVerboseProgress());
+    const shouldSendToolSummaries = () => shouldSendVerboseProgressMessages();
     const shouldSendToolStartStatuses = false;
     const shouldDeliverVerboseProgressDespiteSourceSuppression = () =>
       suppressAutomaticSourceDelivery &&
@@ -1486,7 +1492,7 @@ export async function dispatchReplyFromConfig(
       ctx.InboundEventKind !== "room_event" &&
       !sendPolicyDenied &&
       shouldEmitVerboseProgress() &&
-      shouldSendVerboseProgressMessages;
+      shouldSendVerboseProgressMessages();
     let finalReplyDeliveryStarted = false;
     const hasExecApprovalPayload = (payload: ReplyPayload) => {
       const execApproval =
@@ -1635,7 +1641,8 @@ export async function dispatchReplyFromConfig(
               shouldRouteToOriginating,
               originatingChannel: routeReplyChannel,
               originatingTo: routeReplyTo,
-              shouldSendToolSummaries,
+              shouldSendToolSummaries: shouldSendToolSummaries(),
+              shouldSendToolSummariesNow: shouldSendToolSummaries,
               sendPolicy,
             },
             {
@@ -1720,7 +1727,7 @@ export async function dispatchReplyFromConfig(
     }): Promise<void> => {
       if (
         shouldSuppressProgressDelivery() ||
-        !shouldSendVerboseProgressMessages ||
+        !shouldSendVerboseProgressMessages() ||
         didSendPlanStatusNotice
       ) {
         return;
@@ -1796,7 +1803,7 @@ export async function dispatchReplyFromConfig(
       ) {
         return null;
       }
-      if (shouldSendToolSummaries) {
+      if (shouldSendToolSummaries()) {
         return payload;
       }
       const execApproval =
@@ -1832,7 +1839,7 @@ export async function dispatchReplyFromConfig(
     const hasVisibleRegularVerboseToolProgress =
       shouldEmitVerboseProgress() &&
       !shouldEmitFullVerboseProgress() &&
-      shouldSendVerboseProgressMessages &&
+      shouldSendVerboseProgressMessages() &&
       ctx.InboundEventKind !== "room_event" &&
       !shouldSuppressProgressDelivery();
     const suppressToolErrorWarnings =
@@ -2145,7 +2152,8 @@ export async function dispatchReplyFromConfig(
               shouldRouteToOriginating,
               originatingChannel: routeReplyChannel,
               originatingTo: routeReplyTo,
-              shouldSendToolSummaries,
+              shouldSendToolSummaries: shouldSendToolSummaries(),
+              shouldSendToolSummariesNow: shouldSendToolSummaries,
               sendPolicy,
               isTailDispatch: true,
             },

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1854,6 +1854,20 @@ export async function dispatchReplyFromConfig(
     const hasLiveVerboseProgressGate = suppressDefaultToolProgressMessages && canTrackSession;
     let observedVisibleToolErrorProgress =
       hasVisibleRegularVerboseToolProgress() && !hasLiveVerboseProgressGate;
+    const markVisibleToolErrorProgress = () => {
+      if (hasVisibleRegularVerboseToolProgress()) {
+        observedVisibleToolErrorProgress = true;
+      }
+    };
+    const hasFailedProgressStatus = (payload: {
+      phase?: string;
+      status?: string;
+      exitCode?: number | null;
+    }) =>
+      payload.phase === "error" ||
+      payload.status === "failed" ||
+      payload.status === "error" ||
+      (typeof payload.exitCode === "number" && payload.exitCode !== 0);
     const shouldSuppressToolErrorWarnings = () =>
       params.replyOptions?.suppressToolErrorWarnings ??
       (observedVisibleToolErrorProgress ? true : undefined);
@@ -1884,6 +1898,7 @@ export async function dispatchReplyFromConfig(
       options?: {
         forwardWhenSourceDeliverySuppressed?: boolean;
         requiresToolSummaryVisibility?: boolean;
+        onForward?: (...args: Args) => void;
       },
     ): ((...args: Args) => Promise<void>) | undefined => {
       if (!callback && (!suppressAutomaticSourceDelivery || !canTrackSession)) {
@@ -1895,6 +1910,7 @@ export async function dispatchReplyFromConfig(
         }
         markProgress();
         if (shouldForwardProgressCallback(options)) {
+          options?.onForward?.(...args);
           await callback?.(...args);
         }
       };
@@ -1933,10 +1949,20 @@ export async function dispatchReplyFromConfig(
             onItemEvent: wrapProgressCallback(params.replyOptions?.onItemEvent, {
               forwardWhenSourceDeliverySuppressed: true,
               requiresToolSummaryVisibility: true,
+              onForward: (payload) => {
+                if (hasFailedProgressStatus(payload)) {
+                  markVisibleToolErrorProgress();
+                }
+              },
             }),
             onCommandOutput: wrapProgressCallback(params.replyOptions?.onCommandOutput, {
               forwardWhenSourceDeliverySuppressed: true,
               requiresToolSummaryVisibility: true,
+              onForward: (payload) => {
+                if (hasFailedProgressStatus(payload)) {
+                  markVisibleToolErrorProgress();
+                }
+              },
             }),
             onCompactionStart: wrapProgressCallback(params.replyOptions?.onCompactionStart, {
               forwardWhenSourceDeliverySuppressed: true,
@@ -1948,8 +1974,8 @@ export async function dispatchReplyFromConfig(
             }),
             onToolResult: (payload: ReplyPayload) => {
               markProgress();
-              if (payload.isError === true && hasVisibleRegularVerboseToolProgress()) {
-                observedVisibleToolErrorProgress = true;
+              if (payload.isError === true) {
+                markVisibleToolErrorProgress();
               }
               const run = async () => {
                 if (isDispatchOperationAborted()) {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1974,9 +1974,6 @@ export async function dispatchReplyFromConfig(
             }),
             onToolResult: (payload: ReplyPayload) => {
               markProgress();
-              if (payload.isError === true) {
-                markVisibleToolErrorProgress();
-              }
               const run = async () => {
                 if (isDispatchOperationAborted()) {
                   return;
@@ -2020,6 +2017,9 @@ export async function dispatchReplyFromConfig(
                   if (!hasMedia && !hasExecApprovalPayload(deliveryPayload)) {
                     return;
                   }
+                }
+                if (deliveryPayload.isError === true) {
+                  markVisibleToolErrorProgress();
                 }
                 if (shouldRouteToOriginating) {
                   await sendPayloadAsync(deliveryPayload, undefined, false);

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -379,10 +379,6 @@ const createShouldEmitVerboseProgress = (params: {
   };
   return {
     shouldEmit: () => resolveLevel() !== "off",
-    shouldEmitExplicit: () => {
-      const explicitLevel = resolveCurrentExplicitLevel();
-      return explicitLevel != null && explicitLevel !== "off";
-    },
     shouldEmitFull: () => resolveLevel() === "full",
   };
 };
@@ -1497,16 +1493,11 @@ export async function dispatchReplyFromConfig(
     // so /stop can abort pre-run and in-run stalls through the same session lane.
     ensureDispatchReplyOperation();
 
-    const chatType = normalizeChatType(ctx.ChatType);
-    const isSlackNonDirectSurface =
-      (ctx.Surface === "slack" || ctx.Provider === "slack") && chatType !== "direct";
-    const isGroupChat = chatType === "group";
-    const isForumTopic = ctx.IsForum === true;
-    const shouldAllowGroupVerboseProgress = () =>
-      isGroupChat && !isForumTopic && verboseProgress.shouldEmitExplicit();
-    const shouldSendVerboseProgressMessages = () =>
-      !isSlackNonDirectSurface &&
-      (!isGroupChat || isForumTopic || shouldAllowGroupVerboseProgress());
+    const suppressDefaultToolProgressMessages =
+      params.replyOptions?.suppressDefaultToolProgressMessages === true;
+    const shouldSuppressDefaultToolProgressMessages = () =>
+      suppressDefaultToolProgressMessages && !shouldEmitVerboseProgress();
+    const shouldSendVerboseProgressMessages = () => !shouldSuppressDefaultToolProgressMessages();
     const shouldSendToolSummaries = () => shouldSendVerboseProgressMessages();
     const shouldSendToolStartStatuses = false;
     const shouldDeliverVerboseProgressDespiteSourceSuppression = () =>
@@ -1851,10 +1842,6 @@ export async function dispatchReplyFromConfig(
       originatingChannel: routeReplyChannel,
       systemEvent: shouldRouteToOriginating,
     });
-    const suppressDefaultToolProgressMessages =
-      params.replyOptions?.suppressDefaultToolProgressMessages === true;
-    const shouldSuppressDefaultToolProgressMessages = () =>
-      suppressDefaultToolProgressMessages && !shouldEmitVerboseProgress();
     const shouldSuppressProgressDelivery = () =>
       sendPolicyDenied ||
       (suppressDelivery && !shouldDeliverVerboseProgressDespiteSourceSuppression());
@@ -1864,12 +1851,10 @@ export async function dispatchReplyFromConfig(
       shouldSendVerboseProgressMessages() &&
       ctx.InboundEventKind !== "room_event" &&
       !shouldSuppressProgressDelivery();
-    const hasDynamicallyGatedGroupVerboseProgress = isGroupChat && !isForumTopic;
+    const hasLiveVerboseProgressGate = suppressDefaultToolProgressMessages && canTrackSession;
     const suppressToolErrorWarnings =
       params.replyOptions?.suppressToolErrorWarnings ??
-      (hasVisibleRegularVerboseToolProgress && !hasDynamicallyGatedGroupVerboseProgress
-        ? true
-        : undefined);
+      (hasVisibleRegularVerboseToolProgress && !hasLiveVerboseProgressGate ? true : undefined);
     const onToolResultFromReplyOptions = params.replyOptions?.onToolResult;
     const onPlanUpdateFromReplyOptions = params.replyOptions?.onPlanUpdate;
     const onApprovalEventFromReplyOptions = params.replyOptions?.onApprovalEvent;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1989,8 +1989,12 @@ export async function dispatchReplyFromConfig(
                 if (shouldSuppressProgressDelivery()) {
                   return;
                 }
+                const visibleToolPayload = resolveToolDeliveryPayload(payload);
+                if (!visibleToolPayload) {
+                  return;
+                }
                 const ttsPayload = await maybeApplyTtsToReplyPayload({
-                  payload,
+                  payload: visibleToolPayload,
                   cfg,
                   channel: deliveryChannel,
                   kind: "tool",

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1493,11 +1493,8 @@ export async function dispatchReplyFromConfig(
     // so /stop can abort pre-run and in-run stalls through the same session lane.
     ensureDispatchReplyOperation();
 
-    const chatType = normalizeChatType(ctx.ChatType);
     const suppressDefaultToolProgressMessages =
-      params.replyOptions?.suppressDefaultToolProgressMessages === true ||
-      chatType === "group" ||
-      chatType === "channel";
+      params.replyOptions?.suppressDefaultToolProgressMessages !== false;
     const shouldSuppressDefaultToolProgressMessages = () =>
       suppressDefaultToolProgressMessages && !shouldEmitVerboseProgress();
     const shouldSendVerboseProgressMessages = () => !shouldSuppressDefaultToolProgressMessages();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1848,9 +1848,7 @@ export async function dispatchReplyFromConfig(
       shouldSendVerboseProgressMessages() &&
       ctx.InboundEventKind !== "room_event" &&
       !shouldSuppressProgressDelivery();
-    const hasLiveVerboseProgressGate = canTrackSession;
-    let observedVisibleToolErrorProgress =
-      hasVisibleRegularVerboseToolProgress() && !hasLiveVerboseProgressGate;
+    let observedVisibleToolErrorProgress = false;
     const markVisibleToolErrorProgress = () => {
       if (hasVisibleRegularVerboseToolProgress()) {
         observedVisibleToolErrorProgress = true;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1848,16 +1848,19 @@ export async function dispatchReplyFromConfig(
     const shouldSuppressProgressDelivery = () =>
       sendPolicyDenied ||
       (suppressDelivery && !shouldDeliverVerboseProgressDespiteSourceSuppression());
-    const hasVisibleRegularVerboseToolProgress =
+    const hasVisibleRegularVerboseToolProgress = () =>
       shouldEmitVerboseProgress() &&
       !shouldEmitFullVerboseProgress() &&
       shouldSendVerboseProgressMessages() &&
       ctx.InboundEventKind !== "room_event" &&
       !shouldSuppressProgressDelivery();
     const hasLiveVerboseProgressGate = suppressDefaultToolProgressMessages && canTrackSession;
+    const shouldSuppressToolErrorWarnings = () =>
+      params.replyOptions?.suppressToolErrorWarnings ??
+      (hasVisibleRegularVerboseToolProgress() ? true : undefined);
     const suppressToolErrorWarnings =
       params.replyOptions?.suppressToolErrorWarnings ??
-      (hasVisibleRegularVerboseToolProgress && !hasLiveVerboseProgressGate ? true : undefined);
+      (hasVisibleRegularVerboseToolProgress() && !hasLiveVerboseProgressGate ? true : undefined);
     const onToolResultFromReplyOptions = params.replyOptions?.onToolResult;
     const onPlanUpdateFromReplyOptions = params.replyOptions?.onPlanUpdate;
     const onApprovalEventFromReplyOptions = params.replyOptions?.onApprovalEvent;
@@ -1914,6 +1917,7 @@ export async function dispatchReplyFromConfig(
             ...getReplyOptions(),
             sourceReplyDeliveryMode,
             suppressToolErrorWarnings,
+            shouldSuppressToolErrorWarnings,
             typingPolicy: typing.typingPolicy,
             suppressTyping: typing.suppressTyping,
             onPartialReply: wrapProgressCallback(params.replyOptions?.onPartialReply),

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1493,10 +1493,7 @@ export async function dispatchReplyFromConfig(
     // so /stop can abort pre-run and in-run stalls through the same session lane.
     ensureDispatchReplyOperation();
 
-    const suppressDefaultToolProgressMessages =
-      params.replyOptions?.suppressDefaultToolProgressMessages !== false;
-    const shouldSuppressDefaultToolProgressMessages = () =>
-      suppressDefaultToolProgressMessages && !shouldEmitVerboseProgress();
+    const shouldSuppressDefaultToolProgressMessages = () => !shouldEmitVerboseProgress();
     const shouldSendVerboseProgressMessages = () => !shouldSuppressDefaultToolProgressMessages();
     const shouldSendToolSummaries = () => shouldSendVerboseProgressMessages();
     const shouldSendToolStartStatuses = false;
@@ -1851,7 +1848,7 @@ export async function dispatchReplyFromConfig(
       shouldSendVerboseProgressMessages() &&
       ctx.InboundEventKind !== "room_event" &&
       !shouldSuppressProgressDelivery();
-    const hasLiveVerboseProgressGate = suppressDefaultToolProgressMessages && canTrackSession;
+    const hasLiveVerboseProgressGate = canTrackSession;
     let observedVisibleToolErrorProgress =
       hasVisibleRegularVerboseToolProgress() && !hasLiveVerboseProgressGate;
     const markVisibleToolErrorProgress = () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1493,8 +1493,11 @@ export async function dispatchReplyFromConfig(
     // so /stop can abort pre-run and in-run stalls through the same session lane.
     ensureDispatchReplyOperation();
 
+    const chatType = normalizeChatType(ctx.ChatType);
     const suppressDefaultToolProgressMessages =
-      params.replyOptions?.suppressDefaultToolProgressMessages === true;
+      params.replyOptions?.suppressDefaultToolProgressMessages === true ||
+      chatType === "group" ||
+      chatType === "channel";
     const shouldSuppressDefaultToolProgressMessages = () =>
       suppressDefaultToolProgressMessages && !shouldEmitVerboseProgress();
     const shouldSendVerboseProgressMessages = () => !shouldSuppressDefaultToolProgressMessages();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -74,6 +74,7 @@ import {
   toPluginConversationBinding,
 } from "../../plugins/conversation-binding.js";
 import { getGlobalHookRunner, getGlobalPluginRegistry } from "../../plugins/hook-runner-global.js";
+import type { PluginHookReplyDispatchEvent } from "../../plugins/hook-types.js";
 import { isAcpSessionKey } from "../../routing/session-key.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
@@ -383,6 +384,18 @@ type HarnessDefaultCandidate = {
   provider: string;
   model?: string;
 };
+
+function createReplyDispatchEvent(
+  params: Omit<PluginHookReplyDispatchEvent, "shouldSendToolSummaries"> & {
+    shouldSendToolSummaries: () => boolean;
+  },
+): PluginHookReplyDispatchEvent {
+  const { shouldSendToolSummaries, ...event } = params;
+  return Object.defineProperty(event, "shouldSendToolSummaries", {
+    enumerable: true,
+    get: shouldSendToolSummaries,
+  }) as PluginHookReplyDispatchEvent;
+}
 
 function resolveHarnessDefaultChannel(params: {
   ctx: FinalizedMsgContext;
@@ -1627,7 +1640,7 @@ export async function dispatchReplyFromConfig(
       const replyDispatchResult = await traceReplyPhase("reply.reply_dispatch_hooks", () =>
         runWithReplyOperationAbort(dispatchAbortOperation, () =>
           hookRunner.runReplyDispatch(
-            {
+            createReplyDispatchEvent({
               ctx,
               runId: params.replyOptions?.runId,
               sessionKey: acpDispatchSessionKey,
@@ -1641,10 +1654,9 @@ export async function dispatchReplyFromConfig(
               shouldRouteToOriginating,
               originatingChannel: routeReplyChannel,
               originatingTo: routeReplyTo,
-              shouldSendToolSummaries: shouldSendToolSummaries(),
-              shouldSendToolSummariesNow: shouldSendToolSummaries,
+              shouldSendToolSummaries,
               sendPolicy,
-            },
+            }),
             {
               cfg,
               dispatcher: dispatchHookDispatcher,
@@ -1842,9 +1854,12 @@ export async function dispatchReplyFromConfig(
       shouldSendVerboseProgressMessages() &&
       ctx.InboundEventKind !== "room_event" &&
       !shouldSuppressProgressDelivery();
+    const hasDynamicallyGatedGroupVerboseProgress = isGroupChat && !isForumTopic;
     const suppressToolErrorWarnings =
       params.replyOptions?.suppressToolErrorWarnings ??
-      (hasVisibleRegularVerboseToolProgress ? true : undefined);
+      (hasVisibleRegularVerboseToolProgress && !hasDynamicallyGatedGroupVerboseProgress
+        ? true
+        : undefined);
     const onToolResultFromReplyOptions = params.replyOptions?.onToolResult;
     const onPlanUpdateFromReplyOptions = params.replyOptions?.onPlanUpdate;
     const onApprovalEventFromReplyOptions = params.replyOptions?.onApprovalEvent;
@@ -1853,13 +1868,23 @@ export async function dispatchReplyFromConfig(
       params.replyOptions?.allowProgressCallbacksWhenSourceDeliverySuppressed === true;
     const shouldForwardProgressCallback = (options?: {
       forwardWhenSourceDeliverySuppressed?: boolean;
-    }) =>
-      !suppressAutomaticSourceDelivery ||
-      (allowSuppressedSourceProgressCallbacks &&
-        options?.forwardWhenSourceDeliverySuppressed === true);
+      requiresToolSummaryVisibility?: boolean;
+    }) => {
+      if (options?.requiresToolSummaryVisibility === true && !shouldSendToolSummaries()) {
+        return false;
+      }
+      return (
+        !suppressAutomaticSourceDelivery ||
+        (allowSuppressedSourceProgressCallbacks &&
+          options?.forwardWhenSourceDeliverySuppressed === true)
+      );
+    };
     const wrapProgressCallback = <Args extends unknown[]>(
       callback: ((...args: Args) => Promise<void> | void) | undefined,
-      options?: { forwardWhenSourceDeliverySuppressed?: boolean },
+      options?: {
+        forwardWhenSourceDeliverySuppressed?: boolean;
+        requiresToolSummaryVisibility?: boolean;
+      },
     ): ((...args: Args) => Promise<void>) | undefined => {
       if (!callback && (!suppressAutomaticSourceDelivery || !canTrackSession)) {
         return undefined;
@@ -1902,18 +1927,23 @@ export async function dispatchReplyFromConfig(
             onBlockReplyQueued: wrapProgressCallback(params.replyOptions?.onBlockReplyQueued),
             onToolStart: wrapProgressCallback(params.replyOptions?.onToolStart, {
               forwardWhenSourceDeliverySuppressed: true,
+              requiresToolSummaryVisibility: true,
             }),
             onItemEvent: wrapProgressCallback(params.replyOptions?.onItemEvent, {
               forwardWhenSourceDeliverySuppressed: true,
+              requiresToolSummaryVisibility: true,
             }),
             onCommandOutput: wrapProgressCallback(params.replyOptions?.onCommandOutput, {
               forwardWhenSourceDeliverySuppressed: true,
+              requiresToolSummaryVisibility: true,
             }),
             onCompactionStart: wrapProgressCallback(params.replyOptions?.onCompactionStart, {
               forwardWhenSourceDeliverySuppressed: true,
+              requiresToolSummaryVisibility: true,
             }),
             onCompactionEnd: wrapProgressCallback(params.replyOptions?.onCompactionEnd, {
               forwardWhenSourceDeliverySuppressed: true,
+              requiresToolSummaryVisibility: true,
             }),
             onToolResult: (payload: ReplyPayload) => {
               markProgress();
@@ -1922,7 +1952,7 @@ export async function dispatchReplyFromConfig(
                   return;
                 }
                 markInboundDedupeReplayUnsafe();
-                if (!suppressAutomaticSourceDelivery) {
+                if (!suppressAutomaticSourceDelivery && shouldSendToolSummaries()) {
                   await onToolResultFromReplyOptions?.(payload);
                 }
                 if (isDispatchOperationAborted()) {
@@ -1976,7 +2006,12 @@ export async function dispatchReplyFromConfig(
               }
               markProgress();
               markInboundDedupeReplayUnsafe();
-              if (shouldForwardProgressCallback({ forwardWhenSourceDeliverySuppressed: true })) {
+              if (
+                shouldForwardProgressCallback({
+                  forwardWhenSourceDeliverySuppressed: true,
+                  requiresToolSummaryVisibility: true,
+                })
+              ) {
                 await onPlanUpdateFromReplyOptions?.(payload);
               }
               if (isDispatchOperationAborted()) {
@@ -1993,7 +2028,12 @@ export async function dispatchReplyFromConfig(
               }
               markProgress();
               markInboundDedupeReplayUnsafe();
-              if (shouldForwardProgressCallback({ forwardWhenSourceDeliverySuppressed: true })) {
+              if (
+                shouldForwardProgressCallback({
+                  forwardWhenSourceDeliverySuppressed: true,
+                  requiresToolSummaryVisibility: true,
+                })
+              ) {
                 await onApprovalEventFromReplyOptions?.(payload);
               }
               if (isDispatchOperationAborted()) {
@@ -2018,7 +2058,12 @@ export async function dispatchReplyFromConfig(
               }
               markProgress();
               markInboundDedupeReplayUnsafe();
-              if (shouldForwardProgressCallback({ forwardWhenSourceDeliverySuppressed: true })) {
+              if (
+                shouldForwardProgressCallback({
+                  forwardWhenSourceDeliverySuppressed: true,
+                  requiresToolSummaryVisibility: true,
+                })
+              ) {
                 await onPatchSummaryFromReplyOptions?.(payload);
               }
               if (isDispatchOperationAborted()) {
@@ -2138,7 +2183,7 @@ export async function dispatchReplyFromConfig(
       if (hookRunner?.hasHooks("reply_dispatch")) {
         const tailDispatchResult = await runWithReplyOperationAbort(dispatchAbortOperation, () =>
           hookRunner.runReplyDispatch(
-            {
+            createReplyDispatchEvent({
               ctx,
               runId: params.replyOptions?.runId,
               sessionKey: acpDispatchSessionKey,
@@ -2152,11 +2197,10 @@ export async function dispatchReplyFromConfig(
               shouldRouteToOriginating,
               originatingChannel: routeReplyChannel,
               originatingTo: routeReplyTo,
-              shouldSendToolSummaries: shouldSendToolSummaries(),
-              shouldSendToolSummariesNow: shouldSendToolSummaries,
+              shouldSendToolSummaries,
               sendPolicy,
               isTailDispatch: true,
-            },
+            }),
             {
               cfg,
               dispatcher: dispatchHookDispatcher,

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -356,24 +356,33 @@ const resolveBoundAcpDispatchSessionKey = (params: {
 const createShouldEmitVerboseProgress = (params: {
   sessionKey?: string;
   storePath?: string;
+  initialExplicitLevel?: string;
   fallbackLevel: string;
 }) => {
-  const resolveLevel = () => {
+  const resolveCurrentExplicitLevel = () => {
     if (params.sessionKey && params.storePath) {
       try {
         const entry = readSessionEntry(params.storePath, params.sessionKey);
-        const currentLevel = normalizeVerboseLevel(entry?.verboseLevel ?? "");
-        if (currentLevel) {
-          return currentLevel;
-        }
+        return normalizeVerboseLevel(entry?.verboseLevel ?? "");
       } catch {
         // Ignore transient store read failures and fall back to the current dispatch snapshot.
       }
+    }
+    return normalizeVerboseLevel(params.initialExplicitLevel ?? "");
+  };
+  const resolveLevel = () => {
+    const explicitLevel = resolveCurrentExplicitLevel();
+    if (explicitLevel) {
+      return explicitLevel;
     }
     return normalizeVerboseLevel(params.fallbackLevel) ?? "off";
   };
   return {
     shouldEmit: () => resolveLevel() !== "off",
+    shouldEmitExplicit: () => {
+      const explicitLevel = resolveCurrentExplicitLevel();
+      return explicitLevel != null && explicitLevel !== "off";
+    },
     shouldEmitFull: () => resolveLevel() === "full",
   };
 };
@@ -884,6 +893,7 @@ export async function dispatchReplyFromConfig(
   const verboseProgress = createShouldEmitVerboseProgress({
     sessionKey: acpDispatchSessionKey,
     storePath: sessionStoreEntry.storePath,
+    initialExplicitLevel: sessionStoreEntry.entry?.verboseLevel,
     fallbackLevel:
       normalizeVerboseLevel(
         sessionStoreEntry.entry?.verboseLevel ??
@@ -1493,7 +1503,7 @@ export async function dispatchReplyFromConfig(
     const isGroupChat = chatType === "group";
     const isForumTopic = ctx.IsForum === true;
     const shouldAllowGroupVerboseProgress = () =>
-      isGroupChat && !isForumTopic && shouldEmitVerboseProgress();
+      isGroupChat && !isForumTopic && verboseProgress.shouldEmitExplicit();
     const shouldSendVerboseProgressMessages = () =>
       !isSlackNonDirectSurface &&
       (!isGroupChat || isForumTopic || shouldAllowGroupVerboseProgress());

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1423,7 +1423,7 @@ describe("createFollowupRunner progress forwarding", () => {
     );
 
     const runner = createFollowupRunner({
-      opts: { onToolStart, onCommandOutput },
+      opts: { suppressDefaultToolProgressMessages: false, onToolStart, onCommandOutput },
       typing: createMockTypingController(),
       typingMode: "instant",
       defaultModel: "claude",

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1548,6 +1548,45 @@ describe("createFollowupRunner progress forwarding", () => {
 
     expect(onCommandOutput).toHaveBeenCalledTimes(1);
   });
+
+  it("keeps queued tool-error fallbacks when failed progress has no callback", async () => {
+    runEmbeddedPiAgentMock.mockImplementationOnce(
+      async (args: {
+        onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => Promise<void>;
+        suppressToolErrorWarnings?: boolean | (() => boolean | undefined);
+      }) => {
+        const shouldSuppress = args.suppressToolErrorWarnings as () => boolean | undefined;
+        expect(shouldSuppress()).toBeUndefined();
+        await args.onAgentEvent?.({
+          stream: "command_output",
+          data: {
+            phase: "end",
+            name: "exec",
+            status: "failed",
+            exitCode: 1,
+          },
+        });
+        expect(shouldSuppress()).toBeUndefined();
+        return { payloads: [], meta: { agentMeta: {} } };
+      },
+    );
+
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "claude",
+    });
+
+    await runner(
+      createQueuedRun({
+        run: {
+          messageProvider: "discord",
+          sourceReplyDeliveryMode: "message_tool_only",
+          verboseLevel: "on",
+        },
+      }),
+    );
+  });
 });
 
 describe("createFollowupRunner compaction", () => {

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1443,6 +1443,67 @@ describe("createFollowupRunner progress forwarding", () => {
     expect(onCommandOutput).not.toHaveBeenCalled();
     expect(routeReplyMock).not.toHaveBeenCalled();
   });
+
+  it("does not reuse dispatch-scoped tool-error suppression across queued follow-ups", async () => {
+    const onCommandOutput = vi.fn(async () => {});
+
+    runEmbeddedPiAgentMock
+      .mockImplementationOnce(
+        async (args: {
+          onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => Promise<void>;
+          suppressToolErrorWarnings?: boolean | (() => boolean | undefined);
+        }) => {
+          const shouldSuppress = args.suppressToolErrorWarnings as () => boolean | undefined;
+          expect(shouldSuppress()).toBeUndefined();
+          await args.onAgentEvent?.({
+            stream: "command_output",
+            data: {
+              phase: "end",
+              name: "exec",
+              status: "failed",
+              exitCode: 1,
+            },
+          });
+          expect(shouldSuppress()).toBe(true);
+          return { payloads: [], meta: { agentMeta: {} } };
+        },
+      )
+      .mockImplementationOnce(
+        async (args: { suppressToolErrorWarnings?: boolean | (() => boolean | undefined) }) => {
+          const shouldSuppress = args.suppressToolErrorWarnings as () => boolean | undefined;
+          expect(shouldSuppress()).toBeUndefined();
+          return { payloads: [], meta: { agentMeta: {} } };
+        },
+      );
+
+    const runner = createFollowupRunner({
+      opts: { onCommandOutput, shouldSuppressToolErrorWarnings: () => true },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "claude",
+    });
+
+    await runner(
+      createQueuedRun({
+        run: {
+          messageProvider: "discord",
+          sourceReplyDeliveryMode: "message_tool_only",
+          verboseLevel: "on",
+        },
+      }),
+    );
+    await runner(
+      createQueuedRun({
+        run: {
+          messageProvider: "discord",
+          sourceReplyDeliveryMode: "message_tool_only",
+          verboseLevel: "off",
+        },
+      }),
+    );
+
+    expect(onCommandOutput).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("createFollowupRunner compaction", () => {

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1395,6 +1395,54 @@ describe("createFollowupRunner progress forwarding", () => {
     expect(onCommandOutput).not.toHaveBeenCalled();
     expect(sessionStore.main.compactionCount).toBe(1);
   });
+
+  it("keeps queued follow-up progress quiet when verbose state is missing", async () => {
+    const onToolStart = vi.fn(async () => {});
+    const onCommandOutput = vi.fn(async () => {});
+
+    runEmbeddedPiAgentMock.mockImplementationOnce(
+      async (args: {
+        onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => Promise<void>;
+        onToolResult?: (payload: { text: string }) => Promise<void>;
+        shouldEmitToolResult?: () => boolean;
+        shouldEmitToolOutput?: () => boolean;
+      }) => {
+        expect(args.shouldEmitToolResult?.()).toBe(false);
+        expect(args.shouldEmitToolOutput?.()).toBe(false);
+        await args.onAgentEvent?.({
+          stream: "tool",
+          data: { phase: "start", name: "exec", args: { command: "echo hidden" } },
+        });
+        await args.onAgentEvent?.({
+          stream: "command_output",
+          data: { phase: "chunk", output: "hidden output" },
+        });
+        await args.onToolResult?.({ text: "🛠️ Exec: echo hidden" });
+        return { payloads: [{ text: "final" }], meta: { agentMeta: {} } };
+      },
+    );
+
+    const runner = createFollowupRunner({
+      opts: { onToolStart, onCommandOutput },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "claude",
+    });
+
+    await runner(
+      createQueuedRun({
+        run: {
+          messageProvider: "discord",
+          sourceReplyDeliveryMode: "message_tool_only",
+          verboseLevel: undefined,
+        },
+      }),
+    );
+
+    expect(onToolStart).not.toHaveBeenCalled();
+    expect(onCommandOutput).not.toHaveBeenCalled();
+    expect(routeReplyMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("createFollowupRunner compaction", () => {

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1587,6 +1587,53 @@ describe("createFollowupRunner progress forwarding", () => {
       }),
     );
   });
+
+  it("uses current session verbose state for queued follow-up progress", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      verboseLevel: "off",
+    };
+    const sessionStore: Record<string, SessionEntry> = { main: sessionEntry };
+    const onToolStart = vi.fn(async () => {});
+
+    runEmbeddedPiAgentMock.mockImplementationOnce(
+      async (args: {
+        onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => Promise<void>;
+        shouldEmitToolResult?: () => boolean;
+      }) => {
+        expect(args.shouldEmitToolResult?.()).toBe(false);
+        await args.onAgentEvent?.({
+          stream: "tool",
+          data: { phase: "start", name: "exec", args: { command: "echo hidden" } },
+        });
+        return { payloads: [], meta: { agentMeta: {} } };
+      },
+    );
+
+    const runner = createFollowupRunner({
+      opts: { onToolStart },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      sessionEntry,
+      sessionStore,
+      sessionKey: "main",
+      defaultModel: "claude",
+    });
+
+    await runner(
+      createQueuedRun({
+        run: {
+          messageProvider: "discord",
+          sessionKey: "main",
+          sourceReplyDeliveryMode: "message_tool_only",
+          verboseLevel: "on",
+        },
+      }),
+    );
+
+    expect(onToolStart).not.toHaveBeenCalled();
+  });
 });
 
 describe("createFollowupRunner compaction", () => {

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1682,6 +1682,51 @@ describe("createFollowupRunner compaction", () => {
     expect(sessionStore.main.compactionCount).toBe(1);
   });
 
+  it("suppresses queued auto-compaction notice when verbose is turned off", async () => {
+    const storePath = path.join(
+      await fs.mkdtemp(path.join(tmpdir(), "openclaw-compaction-quiet-")),
+      "sessions.json",
+    );
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      verboseLevel: "off",
+    };
+    const sessionStore: Record<string, SessionEntry> = {
+      main: sessionEntry,
+    };
+    const onBlockReply = vi.fn(async () => {});
+    registerFollowupTestSessionStore(storePath, sessionStore);
+
+    mockCompactionRun({
+      willRetry: true,
+      result: { payloads: [{ text: "final" }], meta: {} },
+    });
+
+    const runner = createFollowupRunner({
+      opts: { onBlockReply },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      sessionEntry,
+      sessionStore,
+      sessionKey: "main",
+      storePath,
+      defaultModel: "anthropic/claude-opus-4-6",
+    });
+
+    const queued = createQueuedRun({
+      run: {
+        verboseLevel: "on",
+      },
+    });
+
+    await runner(queued);
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    expectNoBlockReplyTextIncludes(onBlockReply, "Auto-compaction complete");
+    expect(sessionStore.main.compactionCount).toBe(1);
+  });
+
   it("tracks auto-compaction from embedded result metadata even when no compaction event is emitted", async () => {
     const storePath = path.join(
       await fs.mkdtemp(path.join(tmpdir(), "openclaw-compaction-meta-")),

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1471,7 +1471,7 @@ describe("createFollowupRunner progress forwarding", () => {
       .mockImplementationOnce(
         async (args: { suppressToolErrorWarnings?: boolean | (() => boolean | undefined) }) => {
           const shouldSuppress = args.suppressToolErrorWarnings as () => boolean | undefined;
-          expect(shouldSuppress()).toBeUndefined();
+          expect(shouldSuppress()).toBe(false);
           return { payloads: [], meta: { agentMeta: {} } };
         },
       );

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1339,6 +1339,8 @@ describe("createFollowupRunner progress forwarding", () => {
     const onToolStart = vi.fn(async () => {});
     const onItemEvent = vi.fn(async () => {});
     const onCommandOutput = vi.fn(async () => {});
+    const onCompactionStart = vi.fn(async () => {});
+    const onCompactionEnd = vi.fn(async () => {});
     registerFollowupTestSessionStore(storePath, sessionStore);
 
     runEmbeddedPiAgentMock.mockImplementationOnce(
@@ -1370,7 +1372,7 @@ describe("createFollowupRunner progress forwarding", () => {
     );
 
     const runner = createFollowupRunner({
-      opts: { onToolStart, onItemEvent, onCommandOutput },
+      opts: { onToolStart, onItemEvent, onCommandOutput, onCompactionStart, onCompactionEnd },
       typing: createMockTypingController(),
       typingMode: "instant",
       sessionEntry,
@@ -1393,6 +1395,8 @@ describe("createFollowupRunner progress forwarding", () => {
     expect(onToolStart).not.toHaveBeenCalled();
     expect(onItemEvent).not.toHaveBeenCalled();
     expect(onCommandOutput).not.toHaveBeenCalled();
+    expect(onCompactionStart).not.toHaveBeenCalled();
+    expect(onCompactionEnd).not.toHaveBeenCalled();
     expect(sessionStore.main.compactionCount).toBe(1);
   });
 

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1504,6 +1504,50 @@ describe("createFollowupRunner progress forwarding", () => {
 
     expect(onCommandOutput).toHaveBeenCalledTimes(1);
   });
+
+  it("keeps queued full-verbose tool-error fallbacks available after failed progress", async () => {
+    const onCommandOutput = vi.fn(async () => {});
+
+    runEmbeddedPiAgentMock.mockImplementationOnce(
+      async (args: {
+        onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => Promise<void>;
+        suppressToolErrorWarnings?: boolean | (() => boolean | undefined);
+      }) => {
+        const shouldSuppress = args.suppressToolErrorWarnings as () => boolean | undefined;
+        expect(shouldSuppress()).toBeUndefined();
+        await args.onAgentEvent?.({
+          stream: "command_output",
+          data: {
+            phase: "end",
+            name: "exec",
+            status: "failed",
+            exitCode: 1,
+          },
+        });
+        expect(shouldSuppress()).toBeUndefined();
+        return { payloads: [], meta: { agentMeta: {} } };
+      },
+    );
+
+    const runner = createFollowupRunner({
+      opts: { onCommandOutput },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "claude",
+    });
+
+    await runner(
+      createQueuedRun({
+        run: {
+          messageProvider: "discord",
+          sourceReplyDeliveryMode: "message_tool_only",
+          verboseLevel: "full",
+        },
+      }),
+    );
+
+    expect(onCommandOutput).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("createFollowupRunner compaction", () => {

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -1001,7 +1001,7 @@ export function createFollowupRunner(params: {
             });
           }
         }
-        if (run.verboseLevel && run.verboseLevel !== "off") {
+        if (shouldEmitVerboseProgress()) {
           const suffix = typeof count === "number" ? ` (count ${count})` : "";
           deliveryPayloads = [
             {

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -81,6 +81,22 @@ function hasFailedFollowupProgressEvent(evt: FollowupAgentEvent): boolean {
   );
 }
 
+function canForwardFailedFollowupProgressEvent(
+  evt: FollowupAgentEvent,
+  opts?: GetReplyOptions,
+): boolean {
+  if (evt.stream === "command_output") {
+    return typeof opts?.onCommandOutput === "function";
+  }
+  if (evt.stream !== "item") {
+    return false;
+  }
+  if (evt.data.suppressChannelProgress === true && Boolean(opts?.onToolStart)) {
+    return false;
+  }
+  return typeof opts?.onItemEvent === "function";
+}
+
 async function forwardFollowupProgressEvent(params: {
   evt: FollowupAgentEvent;
   opts?: GetReplyOptions;
@@ -808,7 +824,10 @@ export function createFollowupRunner(params: {
                         attemptCompactionCount += 1;
                       },
                     });
-                    if (hasFailedFollowupProgressEvent(evt)) {
+                    if (
+                      hasFailedFollowupProgressEvent(evt) &&
+                      canForwardFailedFollowupProgressEvent(evt, opts)
+                    ) {
                       markVisibleToolErrorProgress();
                     }
                   }),

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -414,7 +414,7 @@ export function createFollowupRunner(params: {
         run.verboseLevel === "full" && !shouldSuppressDefaultToolProgressMessages();
       let observedVisibleToolErrorProgress = false;
       const markVisibleToolErrorProgress = () => {
-        if (shouldEmitToolResultProgress()) {
+        if (run.verboseLevel === "on" && shouldEmitToolResultProgress()) {
           observedVisibleToolErrorProgress = true;
         }
       };

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -393,7 +393,7 @@ export function createFollowupRunner(params: {
       }
       const shouldEmitVerboseProgress = () => run.verboseLevel !== "off";
       const shouldSuppressDefaultToolProgressMessages = () =>
-        opts?.suppressDefaultToolProgressMessages === true && !shouldEmitVerboseProgress();
+        opts?.suppressDefaultToolProgressMessages !== false && !shouldEmitVerboseProgress();
       const shouldEmitToolResultProgress = () =>
         shouldEmitVerboseProgress() && !shouldSuppressDefaultToolProgressMessages();
       const shouldEmitToolOutputProgress = () =>

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -453,8 +453,15 @@ export function createFollowupRunner(params: {
           observedVisibleToolErrorProgress = true;
         }
       };
-      const shouldSuppressToolErrorWarnings = () =>
-        opts?.suppressToolErrorWarnings ?? (observedVisibleToolErrorProgress ? true : undefined);
+      const shouldSuppressToolErrorWarnings = () => {
+        if (opts?.suppressToolErrorWarnings !== undefined) {
+          return opts.suppressToolErrorWarnings;
+        }
+        if (!shouldEmitVerboseProgress()) {
+          return false;
+        }
+        return observedVisibleToolErrorProgress ? true : undefined;
+      };
       let progressDeliveryChain: Promise<void> = Promise.resolve();
       const pendingProgressDeliveries = new Set<Promise<void>>();
       const enqueueProgressDelivery = (deliver: () => Promise<void>) => {

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -391,7 +391,8 @@ export function createFollowupRunner(params: {
       if (run !== effectiveQueued.run) {
         effectiveQueued = { ...effectiveQueued, run };
       }
-      const shouldEmitVerboseProgress = () => run.verboseLevel !== "off";
+      const shouldEmitVerboseProgress = () =>
+        run.verboseLevel === "on" || run.verboseLevel === "full";
       const shouldSuppressDefaultToolProgressMessages = () =>
         opts?.suppressDefaultToolProgressMessages !== false && !shouldEmitVerboseProgress();
       const shouldEmitToolResultProgress = () =>
@@ -759,7 +760,7 @@ export function createFollowupRunner(params: {
                   enqueueProgressDelivery(async () => {
                     if (
                       run.sourceReplyDeliveryMode === "message_tool_only" &&
-                      run.verboseLevel === "off"
+                      !shouldEmitToolResultProgress()
                     ) {
                       return;
                     }

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -67,6 +67,20 @@ function filterStringArray(value: unknown): string[] | undefined {
     : undefined;
 }
 
+function hasFailedFollowupProgressEvent(evt: FollowupAgentEvent): boolean {
+  if (evt.stream !== "item" && evt.stream !== "command_output") {
+    return false;
+  }
+  const phase = readStringValue(evt.data.phase);
+  const status = readStringValue(evt.data.status);
+  return (
+    phase === "error" ||
+    status === "failed" ||
+    status === "error" ||
+    (typeof evt.data.exitCode === "number" && evt.data.exitCode !== 0)
+  );
+}
+
 async function forwardFollowupProgressEvent(params: {
   evt: FollowupAgentEvent;
   opts?: GetReplyOptions;
@@ -398,6 +412,14 @@ export function createFollowupRunner(params: {
         shouldEmitVerboseProgress() && !shouldSuppressDefaultToolProgressMessages();
       const shouldEmitToolOutputProgress = () =>
         run.verboseLevel === "full" && !shouldSuppressDefaultToolProgressMessages();
+      let observedVisibleToolErrorProgress = false;
+      const markVisibleToolErrorProgress = () => {
+        if (shouldEmitToolResultProgress()) {
+          observedVisibleToolErrorProgress = true;
+        }
+      };
+      const shouldSuppressToolErrorWarnings = () =>
+        opts?.suppressToolErrorWarnings ?? (observedVisibleToolErrorProgress ? true : undefined);
       let progressDeliveryChain: Promise<void> = Promise.resolve();
       const pendingProgressDeliveries = new Set<Promise<void>>();
       const enqueueProgressDelivery = (deliver: () => Promise<void>) => {
@@ -736,8 +758,7 @@ export function createFollowupRunner(params: {
                 thinkLevel: run.thinkLevel,
                 verboseLevel: run.verboseLevel,
                 reasoningLevel: run.reasoningLevel,
-                suppressToolErrorWarnings:
-                  opts?.shouldSuppressToolErrorWarnings ?? opts?.suppressToolErrorWarnings,
+                suppressToolErrorWarnings: shouldSuppressToolErrorWarnings,
                 execOverrides: run.execOverrides,
                 bashElevated: run.bashElevated,
                 timeoutMs: run.timeoutMs,
@@ -772,6 +793,9 @@ export function createFollowupRunner(params: {
                       },
                       { mirror: false },
                     );
+                    if (payload.isError === true) {
+                      markVisibleToolErrorProgress();
+                    }
                   }),
                 onAgentEvent: (evt) =>
                   enqueueProgressDelivery(async () => {
@@ -784,6 +808,9 @@ export function createFollowupRunner(params: {
                         attemptCompactionCount += 1;
                       },
                     });
+                    if (hasFailedFollowupProgressEvent(evt)) {
+                      markVisibleToolErrorProgress();
+                    }
                   }),
               });
               bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -209,12 +209,14 @@ async function forwardFollowupProgressEvent(params: {
 
   if (evt.stream === "compaction") {
     const phase = readStringValue(evt.data.phase) ?? "";
-    if (phase === "start") {
+    if (phase === "start" && emitChannelProgress) {
       await opts?.onCompactionStart?.();
     }
     if (phase === "end" && evt.data?.completed === true) {
       params.onCompactionComplete?.();
-      await opts?.onCompactionEnd?.();
+      if (emitChannelProgress) {
+        await opts?.onCompactionEnd?.();
+      }
     }
   }
 }

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -19,6 +19,7 @@ import {
   buildAgentRuntimeOutcomePlan,
 } from "../../agents/runtime-plan/build.js";
 import { updateSessionStore, type SessionEntry } from "../../config/sessions.js";
+import { readSessionEntry } from "../../config/sessions/store-load.js";
 import type { TypingMode } from "../../config/types.js";
 import { logVerbose } from "../../globals.js";
 import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
@@ -421,16 +422,34 @@ export function createFollowupRunner(params: {
       if (run !== effectiveQueued.run) {
         effectiveQueued = { ...effectiveQueued, run };
       }
-      const shouldEmitVerboseProgress = () =>
-        run.verboseLevel === "on" || run.verboseLevel === "full";
+      const resolveCurrentVerboseLevel = () => {
+        if (replySessionKey && storePath) {
+          try {
+            const level = readSessionEntry(storePath, replySessionKey)?.verboseLevel;
+            if (typeof level === "string" && level.trim()) {
+              return level;
+            }
+          } catch {
+            // Keep queued delivery resilient to transient session-store reads.
+          }
+        }
+        const liveEntryLevel = replySessionKey
+          ? sessionStore?.[replySessionKey]?.verboseLevel
+          : undefined;
+        return liveEntryLevel ?? activeSessionEntry?.verboseLevel ?? run.verboseLevel;
+      };
+      const shouldEmitVerboseProgress = () => {
+        const verboseLevel = resolveCurrentVerboseLevel();
+        return verboseLevel === "on" || verboseLevel === "full";
+      };
       const shouldSuppressDefaultToolProgressMessages = () => !shouldEmitVerboseProgress();
       const shouldEmitToolResultProgress = () =>
         shouldEmitVerboseProgress() && !shouldSuppressDefaultToolProgressMessages();
       const shouldEmitToolOutputProgress = () =>
-        run.verboseLevel === "full" && !shouldSuppressDefaultToolProgressMessages();
+        resolveCurrentVerboseLevel() === "full" && !shouldSuppressDefaultToolProgressMessages();
       let observedVisibleToolErrorProgress = false;
       const markVisibleToolErrorProgress = () => {
-        if (run.verboseLevel === "on" && shouldEmitToolResultProgress()) {
+        if (resolveCurrentVerboseLevel() === "on" && shouldEmitToolResultProgress()) {
           observedVisibleToolErrorProgress = true;
         }
       };

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -393,8 +393,7 @@ export function createFollowupRunner(params: {
       }
       const shouldEmitVerboseProgress = () =>
         run.verboseLevel === "on" || run.verboseLevel === "full";
-      const shouldSuppressDefaultToolProgressMessages = () =>
-        opts?.suppressDefaultToolProgressMessages !== false && !shouldEmitVerboseProgress();
+      const shouldSuppressDefaultToolProgressMessages = () => !shouldEmitVerboseProgress();
       const shouldEmitToolResultProgress = () =>
         shouldEmitVerboseProgress() && !shouldSuppressDefaultToolProgressMessages();
       const shouldEmitToolOutputProgress = () =>

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -736,7 +736,8 @@ export function createFollowupRunner(params: {
                 thinkLevel: run.thinkLevel,
                 verboseLevel: run.verboseLevel,
                 reasoningLevel: run.reasoningLevel,
-                suppressToolErrorWarnings: opts?.suppressToolErrorWarnings,
+                suppressToolErrorWarnings:
+                  opts?.shouldSuppressToolErrorWarnings ?? opts?.suppressToolErrorWarnings,
                 execOverrides: run.execOverrides,
                 bashElevated: run.bashElevated,
                 timeoutMs: run.timeoutMs,

--- a/src/plugin-sdk/acp-runtime-backend.ts
+++ b/src/plugin-sdk/acp-runtime-backend.ts
@@ -99,7 +99,7 @@ export async function tryDispatchAcpReplyHook(
     originatingChannel: event.originatingChannel,
     originatingTo: event.originatingTo,
     shouldSendToolSummaries: event.shouldSendToolSummaries,
-    shouldSendToolSummariesNow: event.shouldSendToolSummariesNow,
+    shouldSendToolSummariesNow: () => event.shouldSendToolSummaries,
     bypassForCommand,
     onReplyStart: ctx.onReplyStart,
     recordProcessed: ctx.recordProcessed,

--- a/src/plugin-sdk/acp-runtime-backend.ts
+++ b/src/plugin-sdk/acp-runtime-backend.ts
@@ -99,6 +99,7 @@ export async function tryDispatchAcpReplyHook(
     originatingChannel: event.originatingChannel,
     originatingTo: event.originatingTo,
     shouldSendToolSummaries: event.shouldSendToolSummaries,
+    shouldSendToolSummariesNow: event.shouldSendToolSummariesNow,
     bypassForCommand,
     onReplyStart: ctx.onReplyStart,
     recordProcessed: ctx.recordProcessed,

--- a/src/plugin-sdk/acp-runtime.test.ts
+++ b/src/plugin-sdk/acp-runtime.test.ts
@@ -114,6 +114,22 @@ describe("tryDispatchAcpReplyHook", () => {
     });
   });
 
+  it("passes the dynamic tool-summary predicate through to ACP runtime", async () => {
+    bypassMock.mockResolvedValue(false);
+    dispatchMock.mockResolvedValue({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+    const shouldSendToolSummariesNow = vi.fn(() => true);
+
+    await tryDispatchAcpReplyHook({ ...event, shouldSendToolSummariesNow }, ctx);
+
+    expectDispatchPayloadFields({
+      shouldSendToolSummaries: true,
+      shouldSendToolSummariesNow,
+    });
+  });
+
   it("returns unhandled when ACP dispatcher declines the turn", async () => {
     bypassMock.mockResolvedValue(false);
     dispatchMock.mockResolvedValue(undefined);

--- a/src/plugin-sdk/acp-runtime.test.ts
+++ b/src/plugin-sdk/acp-runtime.test.ts
@@ -114,20 +114,33 @@ describe("tryDispatchAcpReplyHook", () => {
     });
   });
 
-  it("passes the dynamic tool-summary predicate through to ACP runtime", async () => {
+  it("passes a live tool-summary predicate through to ACP runtime", async () => {
     bypassMock.mockResolvedValue(false);
     dispatchMock.mockResolvedValue({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
     });
-    const shouldSendToolSummariesNow = vi.fn(() => true);
+    let shouldSendToolSummaries = true;
+    const eventWithGetter = {
+      ...event,
+      get shouldSendToolSummaries() {
+        return shouldSendToolSummaries;
+      },
+    };
 
-    await tryDispatchAcpReplyHook({ ...event, shouldSendToolSummariesNow }, ctx);
+    await tryDispatchAcpReplyHook(eventWithGetter, ctx);
 
     expectDispatchPayloadFields({
       shouldSendToolSummaries: true,
-      shouldSendToolSummariesNow,
     });
+    const [payload] = dispatchMock.mock.calls[0] ?? [];
+    const livePredicate = (payload as { shouldSendToolSummariesNow?: () => boolean })
+      .shouldSendToolSummariesNow;
+    expect(livePredicate).toBeTypeOf("function");
+    expect(livePredicate?.()).toBe(true);
+
+    shouldSendToolSummaries = false;
+    expect(livePredicate?.()).toBe(false);
   });
 
   it("returns unhandled when ACP dispatcher declines the turn", async () => {

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -403,6 +403,7 @@ export type PluginHookReplyDispatchEvent = {
   originatingChannel?: string;
   originatingTo?: string;
   shouldSendToolSummaries: boolean;
+  shouldSendToolSummariesNow?: () => boolean;
   sendPolicy: "allow" | "deny";
   isTailDispatch?: boolean;
 };

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -403,7 +403,6 @@ export type PluginHookReplyDispatchEvent = {
   originatingChannel?: string;
   originatingTo?: string;
   shouldSendToolSummaries: boolean;
-  shouldSendToolSummariesNow?: () => boolean;
   sendPolicy: "allow" | "deny";
   isTailDispatch?: boolean;
 };


### PR DESCRIPTION
## Summary

This fixes normal group verbose tool/progress summary delivery by honoring explicit group `/verbose` state.

- Problem: normal group sessions suppressed text-only tool/progress summaries even when `/verbose on` was enabled for that group.
- Solution: make shared group dispatch respect explicit group `/verbose` session state.
- What changed: normal groups remain quiet by default, but `/verbose on` now allows tool/progress summaries; `/verbose off` hides them again.
- What did NOT change (scope boundary): no new config flag, no new permissions, no token handling changes, no command/tool execution behavior changes, and inherited verbose defaults do not opt normal groups into visible summaries.

## Motivation

Private/group QA needs to show what the agent actually did when verbose mode is explicitly enabled. `/verbose` already controls that visibility, but normal group dispatch ignored it.

Although the live proof uses Telegram because that is the configured QA environment, the implementation is intentionally in shared group/ACP dispatch code so group-capable channels use the same verbose gating policy.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed:
  `/verbose on` did not show tool/progress summaries in a normal Telegram group.

- Real environment tested:
  Private Telegram QA supergroup with a Driver bot prompting a SUT bot running OpenClaw from this PR branch. Tokens, chat IDs, and private config are omitted.

- Exact steps or command run after this patch:
  1. Built current PR worktree at `207742e506`.
  2. Started the isolated QA SUT gateway from that build.
  3. Sent `/verbose@qa_sut_bot off`.
  4. Prompted: `Use exactly one shell command: pwd. Then reply exactly: qa-current-verbose-off-done.`
  5. Sent `/verbose@qa_sut_bot on`.
  6. Prompted: `Use exactly one shell command: pwd. Then reply exactly: qa-current-verbose-on-done.`

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  Copied live output from the Telegram QA group after the fix:

  ```text
  /verbose@qa_sut_bot off
  QA SUT: ⚙️ Verbose logging disabled.

  @qa_sut_bot Use exactly one shell command: pwd. Then reply exactly: qa-current-verbose-off-done.
  QA SUT: qa-current-verbose-off-done

  /verbose@qa_sut_bot on
  QA SUT: ⚙️ Verbose logging enabled.

  @qa_sut_bot Use exactly one shell command: pwd. Then reply exactly: qa-current-verbose-on-done.
  QA SUT: 🛠️ pwd
  QA SUT: qa-current-verbose-on-done
  ```

- Observed result after fix:
  `/verbose off` hides the tool summary. `/verbose on` shows `🛠️ pwd` before the final reply.

- What was not tested:
  I did not run the full repository test suite on this low-memory VPS. I do not have live Slack/Matrix/WhatsApp bots configured for proof, so non-Telegram channels are covered by focused shared-dispatch tests rather than live channel proof.

- Before evidence:
  Copied live Telegram transcript from `origin/main` showed that `/verbose on` still produced only the final marker in a normal group:

  ```text
  /verbose@qa_sut_bot off
  QA SUT: ⚙️ Verbose logging disabled.

  @qa_sut_bot Use exactly one shell command: pwd. Then reply exactly: qa-main-verbose-off-done.
  QA SUT: qa-main-verbose-off-done

  /verbose@qa_sut_bot on
  QA SUT: ⚙️ Verbose logging enabled.

  @qa_sut_bot Use exactly one shell command: pwd. Then reply exactly: qa-main-verbose-on-done.
  QA SUT: qa-main-verbose-on-done
  ```

## Root Cause (if applicable)

- Root cause:
  Shared group dispatch had a normal-group suppression path for text-only tool/progress summaries that did not account for explicit `/verbose` session state.

- Missing detection / guardrail:
  Existing tests covered default group suppression and topic/non-DM behavior, but not explicit `/verbose on` in normal groups.

- Contributing context:
  Telegram QA exposed the issue, but the fix is in shared group dispatch/projection logic.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient

- Target test or file:
  - `src/auto-reply/reply/dispatch-from-config.test.ts`
  - `src/auto-reply/reply/acp-projector.test.ts`
  - `src/plugin-sdk/acp-runtime.test.ts`

- Scenario the test should lock in:
  Groups suppress tool summaries by default, allow them only when explicit group `/verbose on` is active, respect live `/verbose off`, preserve hidden-tool text boundaries, and keep existing topic/non-DM behavior unchanged.

- Why this is the smallest reliable guardrail:
  The bug is in shared dispatch/projection gates, so focused tests cover it without requiring live credentials for every channel.

- Existing test that already covers this (if any):
  Existing coverage was partial; new focused tests cover this case.

- If no new test is added, why not:
  N/A. New focused tests are included.

## User-visible / Behavior Changes

`/verbose on` now shows tool/progress summaries in normal group sessions. Groups remain quiet by default, with inherited verbose defaults, and with `/verbose off`.

## Diagram (if applicable)

```text
Before:
group + /verbose on -> tool summary suppressed -> final reply only

After:
group + default/off -> final reply only
group + explicit /verbose on -> tool summary -> final reply
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No execution behavior changed; visible summary output can change only after explicit group `/verbose on`.
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:
  Risk: visible tool/progress summaries can expose command names or arguments to group members. Mitigation: normal groups remain quiet by default; inherited verbose defaults do not opt normal groups into visible summaries; users must explicitly enable `/verbose on` in that group session, and `/verbose off` hides summaries again.

## Repro + Verification

### Environment

- OS: Linux VPS
- Runtime/container: OpenClaw gateway built from this PR branch
- Model/provider: existing QA SUT config
- Integration/channel: Telegram normal supergroup
- Relevant config (redacted): private QA group with Driver bot and SUT bot

### Steps

1. Start QA SUT from this PR branch.
2. Send `/verbose@qa_sut_bot off`.
3. Prompt SUT to run `pwd` and reply with a marker.
4. Confirm only the final marker appears.
5. Send `/verbose@qa_sut_bot on`.
6. Prompt SUT to run `pwd` and reply with a marker.
7. Confirm `🛠️ pwd` appears before the final marker.

### Expected

Group tool/progress summaries are hidden with default/off state and visible with explicit `/verbose on`.

### Actual

Matches expected in live Telegram QA proof.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets / copied live output
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- AI assistance disclosure: Codex helped implement, review, and test this PR; I reviewed the diff and verified the behavior in a live OpenClaw Telegram QA setup.

- Verified scenarios:
  - `origin/main`: `/verbose on` still produced final reply only in a normal Telegram group.
  - This PR at `207742e506`: `/verbose off` produced final reply only.
  - This PR at `207742e506`: `/verbose on` produced visible `🛠️ pwd`, then final reply.

- Local checks:
  - `git diff --check`
  - `./node_modules/.bin/oxlint src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.test.ts`
  - `OPENCLAW_TEST_PROJECTS_SERIAL=1 OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts -t "group tool summaries|group progress callbacks|live group tool-summary state|verbose progress"` -> `10 passed | 135 skipped`
  - `OPENCLAW_TEST_PROJECTS_SERIAL=1 OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts` -> `145 passed`

- Codex review:
  - Local Codex review passed before the final explicit-group-verbose tightening.
  - After the final tightening, focused tests and live Telegram proof above were rerun on `207742e506`.

- Edge cases checked:
  - Groups stay quiet by default.
  - Inherited `agents.defaults.verboseDefault: "on"` does not opt normal groups into visible summaries.
  - Explicit group `/verbose on` enables summaries.
  - `/verbose off` hides them again.

- What you did **not** verify:
  - Full repository suite.
  - Live non-Telegram channels.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: group members can see tool/progress summaries when verbose mode is enabled.
  - Mitigation: normal groups remain quiet by default; inherited verbose defaults do not enable normal group summaries; visible summaries require explicit `/verbose on` in that group session, and `/verbose off` hides them again.



