### PR TITLE
fix(ui): keep chat session search inline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/agents: preserve fresh session overrides and metadata when stale cached agent-session entries race with store updates, so subagent model/provider overrides and routing policy survive concurrent writes. (#19328) Thanks @CodeReclaimers.
+- Control UI/chat: keep chat session search inline with the session selector so the header no longer shows a duplicate standalone search row.
 - Restore Control UI gateway token pairing [AI]. (#85459) Thanks @pgondhi987.
 - CLI/update: repair managed npm plugin `openclaw` peer links during post-core convergence and reject stale or wrong-target peer links before restart. (#83794) Thanks @fuller-stack-dev.
 - CLI/agents: default new omitted-account bindings to all accounts when the channel has multiple configured accounts, and clarify account-scope docs. (#49769) Thanks @Gcaufy.

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1362,9 +1362,41 @@
   grid-template-areas: "session model thinking quota";
 }
 
+.chat-controls__session-row--session-search-open {
+  grid-template-columns:
+    minmax(116px, 5fr) minmax(300px, 9fr) minmax(124px, 4fr)
+    minmax(120px, 3fr);
+}
+
+.chat-controls__session-row--single-agent.chat-controls__session-row--session-search-open {
+  grid-template-columns: minmax(300px, 9fr) minmax(124px, 4fr) minmax(120px, 3fr);
+}
+
+.chat-controls__session-row--has-quota.chat-controls__session-row--session-search-open {
+  grid-template-columns:
+    minmax(116px, 5fr) minmax(300px, 9fr) minmax(124px, 4fr)
+    minmax(120px, 3fr) minmax(104px, auto);
+}
+
+.chat-controls__session-row--single-agent.chat-controls__session-row--has-quota.chat-controls__session-row--session-search-open {
+  grid-template-columns: minmax(300px, 9fr) minmax(124px, 4fr) minmax(120px, 3fr) minmax(
+      104px,
+      auto
+    );
+}
+
 .chat-controls__session-picker {
   grid-area: session;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
   position: relative;
+}
+
+.chat-controls__session-row--session-search-open .chat-controls__session-picker {
+  grid-template-columns: minmax(92px, 0.68fr) minmax(180px, 1fr);
 }
 
 .chat-controls__session-trigger {
@@ -1420,6 +1452,59 @@
   height: 16px;
 }
 
+.chat-controls__session-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: auto;
+  min-width: 0;
+}
+
+.chat-controls__session-search {
+  position: relative;
+  flex: 1 1 220px;
+  min-width: 160px;
+  max-width: none;
+}
+
+.field.chat-controls__session-search input {
+  box-sizing: border-box;
+  width: 100%;
+  height: 36px;
+  min-height: 36px;
+  padding: 0 12px 0 42px;
+  border-color: color-mix(in srgb, var(--input) 88%, transparent);
+  border-radius: var(--radius-lg);
+  background-color: color-mix(in srgb, var(--card) 92%, var(--bg-elevated) 8%);
+  font-size: 13px;
+}
+
+.chat-controls__session-search-icon {
+  position: absolute;
+  left: 14px;
+  top: 50%;
+  display: inline-flex;
+  width: 15px;
+  height: 15px;
+  color: var(--muted);
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+.chat-controls__session-search-icon svg {
+  width: 15px;
+  height: 15px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.5px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.chat-controls__session-search-toggle {
+  flex: 0 0 auto;
+}
+
 .chat-session-picker {
   position: absolute;
   top: calc(100% + 8px);
@@ -1436,25 +1521,6 @@
   background: var(--card);
   box-shadow: 0 18px 48px rgba(0, 0, 0, 0.34);
   overflow: hidden;
-}
-
-.chat-session-picker__search-row {
-  display: flex;
-  gap: 6px;
-  align-items: center;
-}
-
-.chat-session-picker__search {
-  flex: 1 1 auto;
-  min-width: 0;
-}
-
-.chat-session-picker__search input {
-  box-sizing: border-box;
-  width: 100%;
-  min-height: 36px;
-  padding: 0 12px;
-  font-size: 13px;
 }
 
 .chat-session-picker .chat-session-picker__icon-button.btn--icon {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -315,12 +315,13 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 2px 6px;
+  min-height: 22px;
+  padding: 3px 7px;
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   background: var(--bg);
   font-family: var(--mono);
-  font-size: 11px;
+  font-size: 12px;
   line-height: 1;
   color: var(--muted);
 }

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -511,6 +511,15 @@
 
   .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__session-picker {
     grid-area: session;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 8px;
+  }
+
+  .chat-mobile-controls-wrapper
+    .chat-controls-dropdown
+    .chat-controls__session-row--session-search-open
+    .chat-controls__session-picker {
+    grid-template-columns: minmax(96px, 0.7fr) minmax(0, 1fr);
   }
 
   .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__session-trigger {
@@ -527,9 +536,14 @@
     box-shadow: none;
   }
 
-  .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-session-picker__search input {
+  .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__session-search input {
     min-height: 44px;
+    padding-left: 42px;
     font-size: 14px;
+  }
+
+  .chat-controls__session-search input {
+    padding-left: 42px;
   }
 
   .chat-mobile-controls-wrapper

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -115,6 +115,7 @@ export type AppViewState = {
   chatModelCatalog: ModelCatalogEntry[];
   sessionSwitchNotice: { id: number; text: string } | null;
   sessionSwitchFlashKey: string | null;
+  chatSessionSearchOpen: boolean;
   chatSessionPickerOpen: boolean;
   chatSessionPickerSurface: "desktop" | "mobile" | null;
   chatSessionPickerQuery: string;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -234,6 +234,7 @@ export class OpenClawApp extends LitElement {
   @state() chatModelCatalog: ModelCatalogEntry[] = [];
   @state() sessionSwitchNotice: { id: number; text: string } | null = null;
   @state() sessionSwitchFlashKey: string | null = null;
+  @state() chatSessionSearchOpen = false;
   @state() chatSessionPickerOpen = false;
   @state() chatSessionPickerSurface: "desktop" | "mobile" | null = null;
   @state() chatSessionPickerQuery = "";

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -56,8 +56,8 @@ export function renderChatSessionSelect(
   const pickerOpen = state.chatSessionPickerOpen && state.chatSessionPickerSurface === surface;
   const sessionSearchVisible =
     state.chatSessionSearchOpen ||
-    state.chatSessionPickerQuery.trim() !== "" ||
-    state.chatSessionPickerAppliedQuery.trim() !== "";
+    (state.chatSessionPickerQuery ?? "").trim() !== "" ||
+    (state.chatSessionPickerAppliedQuery ?? "").trim() !== "";
   const flashSession = state.sessionSwitchFlashKey === state.sessionKey;
   const rowClass = [
     "chat-controls__session-row",
@@ -370,7 +370,8 @@ function renderChatSessionPickerSearchControls(
   surface: ChatSessionSelectSurface,
 ) {
   const hasQuery =
-    state.chatSessionPickerQuery.trim() !== "" || state.chatSessionPickerAppliedQuery.trim() !== "";
+    (state.chatSessionPickerQuery ?? "").trim() !== "" ||
+    (state.chatSessionPickerAppliedQuery ?? "").trim() !== "";
   const searchVisible = state.chatSessionSearchOpen || hasQuery;
   const disabled = !state.connected || !state.client || state.chatSessionPickerLoading;
   if (!searchVisible) {
@@ -400,7 +401,7 @@ function renderChatSessionPickerSearchControls(
           type="search"
           placeholder=${t("chat.selectors.sessionSearch")}
           aria-label=${t("chat.selectors.sessionSearch")}
-          .value=${state.chatSessionPickerQuery}
+          .value=${state.chatSessionPickerQuery ?? ""}
           ?disabled=${disabled}
           @input=${(event: Event) => {
             state.chatSessionPickerQuery = (event.target as HTMLInputElement).value;

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -54,12 +54,17 @@ export function renderChatSessionSelect(
   const surface = options.surface ?? "desktop";
   const selectedSessionLabel = resolveSelectedChatSessionLabel(state, sessionGroups);
   const pickerOpen = state.chatSessionPickerOpen && state.chatSessionPickerSurface === surface;
+  const sessionSearchVisible =
+    state.chatSessionSearchOpen ||
+    state.chatSessionPickerQuery.trim() !== "" ||
+    state.chatSessionPickerAppliedQuery.trim() !== "";
   const flashSession = state.sessionSwitchFlashKey === state.sessionKey;
   const rowClass = [
     "chat-controls__session-row",
     hasAgentSelect ? "" : "chat-controls__session-row--single-agent",
     quotaPill ? "chat-controls__session-row--has-quota" : "",
     flashSession ? "chat-controls__session-row--flash" : "",
+    sessionSearchVisible ? "chat-controls__session-row--session-search-open" : "",
   ]
     .filter(Boolean)
     .join(" ");
@@ -104,11 +109,15 @@ function requestHostUpdate(state: AppViewState) {
   (state as AppViewState & { requestUpdate?: () => void }).requestUpdate?.();
 }
 
-function focusChatSessionPickerSearch(state: AppViewState) {
+function focusChatSessionPickerSearch(state: AppViewState, surface: ChatSessionSelectSurface) {
   const updateComplete = (state as AppViewState & { updateComplete?: Promise<unknown> })
     .updateComplete;
   const focus = () => {
-    document.querySelector<HTMLInputElement>('[data-chat-session-picker-search="true"]')?.focus();
+    document
+      .querySelector<HTMLInputElement>(
+        `[data-chat-session-picker-search="true"][data-chat-session-picker-search-surface="${surface}"]`,
+      )
+      ?.focus();
   };
   if (updateComplete) {
     void updateComplete.then(focus);
@@ -122,13 +131,18 @@ function openChatSessionPicker(state: AppViewState, surface: ChatSessionSelectSu
   state.chatSessionPickerSurface = surface;
   state.chatSessionPickerError = null;
   requestHostUpdate(state);
-  focusChatSessionPickerSearch(state);
+  focusChatSessionPickerSearch(state, surface);
 }
 
 function closeChatSessionPicker(state: AppViewState) {
   state.chatSessionPickerOpen = false;
   state.chatSessionPickerSurface = null;
   requestHostUpdate(state);
+}
+
+function openChatSessionSearch(state: AppViewState, surface: ChatSessionSelectSurface) {
+  state.chatSessionSearchOpen = true;
+  openChatSessionPicker(state, surface);
 }
 
 function toggleChatSessionPicker(state: AppViewState, surface: ChatSessionSelectSurface) {
@@ -244,12 +258,12 @@ async function applyChatSessionPickerSearch(state: AppViewState) {
 }
 
 function clearChatSessionPickerSearch(state: AppViewState) {
+  state.chatSessionSearchOpen = false;
   state.chatSessionPickerQuery = "";
   state.chatSessionPickerAppliedQuery = "";
   state.chatSessionPickerError = null;
   state.chatSessionPickerResult = null;
   requestHostUpdate(state);
-  focusChatSessionPickerSearch(state);
 }
 
 async function loadMoreChatSessionPickerResults(state: AppViewState) {
@@ -345,7 +359,86 @@ function renderChatSessionPicker(params: {
           ${icons.chevronDown}
         </span>
       </button>
+      ${renderChatSessionPickerSearchControls(state, surface)}
       ${pickerOpen ? renderChatSessionPickerPopover(state, onSwitchSession, pickerId) : ""}
+    </div>
+  `;
+}
+
+function renderChatSessionPickerSearchControls(
+  state: AppViewState,
+  surface: ChatSessionSelectSurface,
+) {
+  const hasQuery =
+    state.chatSessionPickerQuery.trim() !== "" || state.chatSessionPickerAppliedQuery.trim() !== "";
+  const searchVisible = state.chatSessionSearchOpen || hasQuery;
+  const disabled = !state.connected || !state.client || state.chatSessionPickerLoading;
+  if (!searchVisible) {
+    return html`
+      <div class="chat-controls__session-actions">
+        <button
+          class="btn btn--ghost btn--icon chat-controls__session-search-toggle"
+          data-chat-session-search-toggle="true"
+          type="button"
+          title=${t("chat.selectors.sessionSearch")}
+          aria-label=${t("chat.selectors.sessionSearch")}
+          ?disabled=${disabled}
+          @click=${() => openChatSessionSearch(state, surface)}
+        >
+          ${icons.search}
+        </button>
+      </div>
+    `;
+  }
+  return html`
+    <div class="chat-controls__session-actions">
+      <label class="field chat-controls__session-search">
+        <span class="chat-controls__session-search-icon" aria-hidden="true">${icons.search}</span>
+        <input
+          data-chat-session-picker-search="true"
+          data-chat-session-picker-search-surface=${surface}
+          type="search"
+          placeholder=${t("chat.selectors.sessionSearch")}
+          aria-label=${t("chat.selectors.sessionSearch")}
+          .value=${state.chatSessionPickerQuery}
+          ?disabled=${disabled}
+          @input=${(event: Event) => {
+            state.chatSessionPickerQuery = (event.target as HTMLInputElement).value;
+          }}
+          @keydown=${(event: KeyboardEvent) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              void applyChatSessionPickerSearch(state);
+            } else if (event.key === "Escape") {
+              event.preventDefault();
+              event.stopPropagation();
+              closeChatSessionPicker(state);
+            }
+          }}
+        />
+      </label>
+      <button
+        class="btn btn--ghost btn--icon"
+        data-chat-session-search-submit="true"
+        type="button"
+        title=${t("common.search")}
+        aria-label=${t("common.search")}
+        ?disabled=${disabled}
+        @click=${() => void applyChatSessionPickerSearch(state)}
+      >
+        ${icons.search}
+      </button>
+      <button
+        class="btn btn--ghost btn--icon"
+        data-chat-session-search-clear="true"
+        type="button"
+        title=${t("chat.selectors.clearSessionSearch")}
+        aria-label=${t("chat.selectors.clearSessionSearch")}
+        ?disabled=${disabled}
+        @click=${() => clearChatSessionPickerSearch(state)}
+      >
+        ${icons.x}
+      </button>
     </div>
   `;
 }
@@ -358,8 +451,6 @@ function renderChatSessionPickerPopover(
   const result = resolveChatSessionPickerResult(state);
   const rows = result?.sessions ?? [];
   const disabled = !state.connected || !state.client || state.chatSessionPickerLoading;
-  const hasQuery =
-    state.chatSessionPickerQuery.trim() !== "" || state.chatSessionPickerAppliedQuery.trim() !== "";
   const loadMoreOffset = resolveNextChatSessionOffset(result);
   const shownCount = rows.length;
   const totalCount = result?.totalCount;
@@ -382,51 +473,6 @@ function renderChatSessionPickerPopover(
         }
       }}
     >
-      <div class="chat-session-picker__search-row">
-        <label class="field chat-session-picker__search">
-          <input
-            data-chat-session-picker-search="true"
-            type="search"
-            placeholder=${t("chat.selectors.sessionSearch")}
-            aria-label=${t("chat.selectors.sessionSearch")}
-            .value=${state.chatSessionPickerQuery}
-            ?disabled=${disabled}
-            @input=${(event: Event) => {
-              state.chatSessionPickerQuery = (event.target as HTMLInputElement).value;
-            }}
-            @keydown=${(event: KeyboardEvent) => {
-              if (event.key === "Enter") {
-                event.preventDefault();
-                void applyChatSessionPickerSearch(state);
-              }
-            }}
-          />
-        </label>
-        <button
-          class="btn btn--ghost btn--icon chat-session-picker__icon-button"
-          data-chat-session-search-submit="true"
-          type="button"
-          title=${t("common.search")}
-          aria-label=${t("common.search")}
-          ?disabled=${disabled}
-          @click=${() => void applyChatSessionPickerSearch(state)}
-        >
-          ${icons.search}
-        </button>
-        ${hasQuery
-          ? html`<button
-              class="btn btn--ghost btn--icon chat-session-picker__icon-button"
-              data-chat-session-search-clear="true"
-              type="button"
-              title=${t("chat.selectors.clearSessionSearch")}
-              aria-label=${t("chat.selectors.clearSessionSearch")}
-              ?disabled=${disabled}
-              @click=${() => clearChatSessionPickerSearch(state)}
-            >
-              ${icons.x}
-            </button>`
-          : ""}
-      </div>
       ${state.chatSessionPickerError
         ? html`<div class="chat-session-picker__status" role="alert">
             ${state.chatSessionPickerError}

--- a/ui/src/ui/e2e/chat-picker-pagination.e2e.test.ts
+++ b/ui/src/ui/e2e/chat-picker-pagination.e2e.test.ts
@@ -154,6 +154,7 @@ describeControlUiE2e("Control UI chat picker mocked Gateway E2E", () => {
     try {
       await page.goto(`${server.baseUrl}chat`);
       await page.getByRole("button", { name: "Chat session" }).click();
+      await page.locator('[data-chat-session-search-toggle="true"]').last().click();
 
       const searchInput = page.locator('[data-chat-session-picker-search="true"]').last();
       await searchInput.waitFor({ state: "visible", timeout: 10_000 });

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 
-import { render } from "lit";
+import { html, render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { i18n, t } from "../../i18n/index.ts";
 import type { AppViewState } from "../app-view-state.ts";
@@ -1302,7 +1302,7 @@ describe("chat session controls", () => {
     ).toEqual([t("chat.selectors.model"), t("chat.selectors.thinkingLevel")]);
   });
 
-  it("searches chat sessions inside the picker without replacing recent sessions", async () => {
+  it("searches chat sessions from the inline picker search without replacing recent sessions", async () => {
     const { state, request } = createChatHeaderState();
     state.sessionsIncludeGlobal = false;
     state.sessionsIncludeUnknown = false;
@@ -1310,7 +1310,10 @@ describe("chat session controls", () => {
     const container = document.createElement("div");
     render(renderChatSessionSelect(state), container);
 
-    container.querySelector<HTMLButtonElement>('button[data-chat-session-select="true"]')!.click();
+    expect(container.querySelector('input[data-chat-session-picker-search="true"]')).toBeNull();
+    container
+      .querySelector<HTMLButtonElement>('button[data-chat-session-search-toggle="true"]')!
+      .click();
     render(renderChatSessionSelect(state), container);
     const input = container.querySelector<HTMLInputElement>(
       'input[data-chat-session-picker-search="true"]',
@@ -1322,6 +1325,7 @@ describe("chat session controls", () => {
     input!.value = " telegram ";
     input!.dispatchEvent(new Event("input", { bubbles: true }));
     expect(state.chatSessionPickerQuery).toBe(" telegram ");
+    expect(state.chatSessionPickerOpen).toBe(true);
     expect(submit?.disabled).toBe(false);
     submit!.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
     await vi.waitFor(() => expect(state.chatSessionPickerAppliedQuery).toBe("telegram"));
@@ -1341,6 +1345,46 @@ describe("chat session controls", () => {
       search: "telegram",
     });
     expect(loadSessionsMock).not.toHaveBeenCalled();
+
+    const documentKeydown = vi.fn();
+    document.addEventListener("keydown", documentKeydown);
+    try {
+      input!.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+      expect(state.chatSessionPickerOpen).toBe(false);
+      expect(documentKeydown).not.toHaveBeenCalled();
+    } finally {
+      document.removeEventListener("keydown", documentKeydown);
+    }
+  });
+
+  it("focuses the inline search for the active picker surface", async () => {
+    const { state } = createChatHeaderState();
+    const mobileContainer = document.createElement("div");
+    const desktopContainer = document.createElement("div");
+    document.body.append(mobileContainer, desktopContainer);
+    try {
+      render(renderChatSessionSelect(state, undefined, { surface: "mobile" }), mobileContainer);
+      render(renderChatSessionSelect(state), desktopContainer);
+
+      desktopContainer
+        .querySelector<HTMLButtonElement>('button[data-chat-session-search-toggle="true"]')!
+        .click();
+      render(renderChatSessionSelect(state, undefined, { surface: "mobile" }), mobileContainer);
+      render(renderChatSessionSelect(state), desktopContainer);
+
+      const desktopInput = desktopContainer.querySelector<HTMLInputElement>(
+        'input[data-chat-session-picker-search="true"]',
+      );
+      expect(
+        mobileContainer.querySelector('input[data-chat-session-picker-search="true"]'),
+      ).toBeTruthy();
+      await vi.waitFor(() => expect(document.activeElement).toBe(desktopInput));
+    } finally {
+      render(html``, mobileContainer);
+      render(html``, desktopContainer);
+      mobileContainer.remove();
+      desktopContainer.remove();
+    }
   });
 
   it("loads another chat session picker page using the server next offset", async () => {


### PR DESCRIPTION
## Summary

- move chat session search out of the picker popover into an inline search control next to the session selector
- keep the collapsed state to a single search icon, expand the selector row only while searching, and size the keyboard shortcut badge larger
- cover the new search, pagination, active-surface focus, and Escape dismissal behavior

## Verification

- `node scripts/run-vitest.mjs run ui/src/ui/views/chat.test.ts ui/src/styles/layout.mobile.test.ts ui/src/styles/chat/layout.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/ui/e2e/chat-picker-pagination.e2e.test.ts`
- `pnpm ui:build`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof

Behavior addressed: Control UI chat session search no longer renders as a duplicate standalone row below the selectors; users get a search icon that expands into one inline field beside the session picker.
Real environment tested: Local OpenClaw checkout in `clawdbot9` with mocked Control UI Gateway E2E and production UI build.
Exact steps or command run after this patch: Ran the focused Vitest unit/style files, the targeted mocked UI E2E file, `pnpm ui:build`, `git diff --check`, and autoreview.
Evidence after fix: Unit/style tests passed 63 tests across 3 files; targeted UI E2E passed 1 test; `pnpm ui:build` completed successfully; autoreview reported no accepted/actionable findings.
Observed result after fix: The session row starts with only a search button, opens an inline search field on demand, preserves picker pagination/search requests, focuses the active surface, and closes from Escape while focused.
What was not tested: A live browser connected to a real Gateway session was not re-run from this checkout.
