### PR TITLE
fix(cron): suppress control replies in announce delivery

### DIFF
--- a/src/cron/isolated-agent.direct-delivery-core-channels.test.ts
+++ b/src/cron/isolated-agent.direct-delivery-core-channels.test.ts
@@ -320,6 +320,34 @@ describe("runCronIsolatedAgentTurn core-channel direct delivery", () => {
       });
     });
 
+    it.each(["REPLY_SKIP", "ANNOUNCE_SKIP"])(
+      `suppresses %s cron announce delivery for ${testCase.name}`,
+      async (controlReply) => {
+        await withTempCronHome(async (home) => {
+          const storePath = await writeSessionStore(home, {
+            lastProvider: "webchat",
+            lastTo: "",
+          });
+          const cfg = makeCfg(home, storePath);
+          const deps = createCliDeps();
+          mockAgentPayloads([{ text: controlReply }]);
+
+          const res = await runExplicitAnnounceTurn({
+            cfg,
+            deps,
+            channel: testCase.channel,
+            to: testCase.to,
+          });
+
+          expect(res.status).toBe("ok");
+          expect(res.delivered).toBe(false);
+          expect(res.deliveryAttempted).toBe(true);
+          expect(deps[testCase.sendKey]).not.toHaveBeenCalled();
+          expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+        });
+      },
+    );
+
     if (testCase.channel === "discord") {
       it("keeps isolated Discord delivery on the active runtime snapshot after agent-default derivation", async () => {
         await withTempCronHome(async (home) => {

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -58,11 +58,23 @@ type NormalizedSilentReplyText = {
   strippedTrailingSilentToken: boolean;
 };
 
+const CRON_SUPPRESSED_CONTROL_REPLY_TOKENS = [
+  SILENT_REPLY_TOKEN,
+  "ANNOUNCE_SKIP",
+  "REPLY_SKIP",
+] as const;
+
+function isSuppressedCronControlReplyText(text: string | undefined): boolean {
+  return CRON_SUPPRESSED_CONTROL_REPLY_TOKENS.some((token) =>
+    isSilentReplyText(text, token),
+  );
+}
+
 function normalizeSilentReplyText(text: string | undefined): NormalizedSilentReplyText {
   if (!text) {
     return { text, strippedTrailingSilentToken: false };
   }
-  if (isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
+  if (isSuppressedCronControlReplyText(text)) {
     return { text: undefined, strippedTrailingSilentToken: false };
   }
 
@@ -1162,7 +1174,7 @@ export async function dispatchCronDelivery(
       hadDescendants &&
       synthesizedText.trim() === initialSynthesizedText &&
       isLikelyInterimCronMessage(initialSynthesizedText) &&
-      !isSilentReplyText(initialSynthesizedText, SILENT_REPLY_TOKEN)
+      !isSuppressedCronControlReplyText(initialSynthesizedText)
     ) {
       // Descendants existed but no post-orchestration synthesis arrived AND
       // no descendant fallback reply was available. Suppress stale parent


### PR DESCRIPTION
## Summary
- Treat REPLY_SKIP and ANNOUNCE_SKIP as suppressed control replies in isolated cron announce delivery.
- Suppress those tokens before direct outbound sends and transcript/awareness mirroring, matching the existing NO_REPLY path.

Fixes #85421.

## Verification
Behavior addressed: isolated cron announce delivery does not post literal REPLY_SKIP or ANNOUNCE_SKIP to configured channel targets.
Real environment tested: local OpenClaw source worktree on Linux Node 22.22.2.
Exact steps or command run after this patch: node scripts/run-vitest.mjs src/cron/isolated-agent.direct-delivery-core-channels.test.ts
Evidence after fix: isolated-agent.direct-delivery-core-channels.test.ts passed, 21 tests.
Observed result after fix: core-channel direct cron announce delivery reports deliveryAttempted=true, delivered=false, and does not call outbound send for REPLY_SKIP or ANNOUNCE_SKIP.
What was not tested: live Discord/Telegram cron execution against real channel credentials.
