### PR TITLE
fix(telegram): keep native aliases out of command menus

### DIFF
--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -222,16 +222,14 @@ describe("commands registry", () => {
     ]);
   });
 
-  it("exposes /side as a BTW text and native alias", () => {
+  it("routes /side as a BTW alias without advertising it in native menus", () => {
     const btw = requireChatCommand("btw");
     expect(btw.nativeName).toBe("btw");
     expect(btw.nativeAliases).toEqual(["side"]);
     expect(btw.textAliases).toEqual(["/btw", "/side"]);
     expect(normalizeCommandBody("/side what changed?")).toBe("/btw what changed?");
     expect(requireNativeCommand("side").key).toBe("btw");
-    const sideNativeSpec = requireNativeSpec(listNativeCommandSpecs(), "side");
-    expect(sideNativeSpec.acceptsArgs).toBe(true);
-    expect(sideNativeSpec.isAlias).toBe(true);
+    expect(nativeNameSet(listNativeCommandSpecs())).not.toContain("side");
   });
 
   it("matches text command names case-insensitively without changing args", () => {

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -89,39 +89,13 @@ function toNativeCommandSpec(command: ChatCommandDefinition, provider?: string):
   return spec;
 }
 
-function resolveNativeNames(command: ChatCommandDefinition, provider?: string): string[] {
-  const primary = resolveNativeName(command, provider);
-  return [primary, ...(command.nativeAliases ?? [])].filter((name): name is string =>
-    Boolean(name),
-  );
-}
-
 function listNativeSpecsFromCommands(
   commands: ChatCommandDefinition[],
   provider?: string,
 ): NativeCommandSpec[] {
   return commands
     .filter((command) => command.scope !== "text" && command.nativeName)
-    .flatMap((command) => {
-      const spec = toNativeCommandSpec(command, provider);
-      return resolveNativeNames(command, provider).map((name, index) => {
-        const nativeSpec: NativeCommandSpec = {
-          name,
-          description: spec.description,
-          acceptsArgs: spec.acceptsArgs,
-        };
-        if (index > 0) {
-          nativeSpec.isAlias = true;
-        }
-        if (spec.args) {
-          nativeSpec.args = spec.args;
-        }
-        if (spec.descriptionLocalizations) {
-          nativeSpec.descriptionLocalizations = spec.descriptionLocalizations;
-        }
-        return nativeSpec;
-      });
-    });
+    .map((command) => toNativeCommandSpec(command, provider));
 }
 
 export function listNativeCommandSpecs(params?: {


### PR DESCRIPTION
## Summary
- Stop expanding chat command nativeAliases into native command menu specs.
- Keep native alias lookup intact so /side still resolves to the /btw command without consuming a Telegram menu slot.

Fixes #85199.

## Verification
Behavior addressed: Telegram native command registration advertises canonical native command names only; nativeAliases continue to route inbound command lookup.
Real environment tested: local OpenClaw source worktree on Linux Node 22.22.2.
Exact steps or command run after this patch: node scripts/run-vitest.mjs src/auto-reply/commands-registry.test.ts
Evidence after fix: commands-registry.test.ts passed, 28 tests.
Observed result after fix: /side remains accepted by findCommandByNativeName and text alias normalization, but listNativeCommandSpecs no longer includes side.
What was not tested: live Telegram Bot API setMyCommands registration.
