### PR TITLE
fix(telegram): dead-letter MissingAgentHarnessError instead of infinite retry

### DIFF
--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -457,6 +457,19 @@ export class TelegramPollingSession {
     err: unknown;
     update: ClaimedTelegramSpooledUpdate;
   }): Promise<void> {
+    const { isMissingAgentHarnessError } = await import("openclaw/agents/harness/errors.js");
+    // Configuration errors that will never resolve on retry should be dead-lettered.
+    if (isMissingAgentHarnessError(params.err)) {
+      await failTelegramSpooledUpdateClaim({
+        update: params.update,
+        reason: "missing-agent-harness",
+        message: formatErrorMessage(params.err),
+      });
+      this.opts.log(
+        `[telegram][diag] spooled update ${params.update.updateId} failed with MissingAgentHarnessError; dead-lettered (will not retry): ${formatErrorMessage(params.err)}`,
+      );
+      return;
+    }
     try {
       await releaseTelegramSpooledUpdateClaim(params.update);
     } catch (releaseErr) {


### PR DESCRIPTION
## Summary

Fixes Telegram ingress spool deadlock caused by infinite retries of `MissingAgentHarnessError`.

## Problem

When a slash-command targets a session whose harness is not registered (e.g., `/compact` while the CLI harness has a registration gap), the spool worker treats `MissingAgentHarnessError` as retryable. This causes:
- Infinite retries at ~2 Hz with the same update
- Head-of-queue blocking: all subsequent messages pile up behind it
- Complete Telegram silence until manual intervention
- Observed: 6,153 retries over 53 minutes, 16 messages backed up

## Fix

- Check for `MissingAgentHarnessError` in `#releaseFailedSpooledUpdate()`
- Dead-letter (fail) these updates instead of requeuing for retry
- Configuration errors will never resolve on their own; infinite retry is harmful

## Files Changed

| File | Changes |
|------|---------|
| `extensions/telegram/src/polling-session.ts` | +13 |

Fixes: #85470