### PR TITLE
fix(codex): unsubscribe bound threads after turns

### DIFF
--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const sharedClientMocks = vi.hoisted(() => ({
   getSharedCodexAppServerClient: vi.fn(),
+  releaseLeasedSharedCodexAppServerClient: vi.fn(),
 }));
 
 const execApprovalsRuntimeMocks = vi.hoisted(() => ({
@@ -57,7 +58,8 @@ vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importOriginal) => {
 vi.mock("./app-server/shared-client.js", () => ({
   ...sharedClientMocks,
   getLeasedSharedCodexAppServerClient: sharedClientMocks.getSharedCodexAppServerClient,
-  releaseLeasedSharedCodexAppServerClient: vi.fn(),
+  releaseLeasedSharedCodexAppServerClient:
+    sharedClientMocks.releaseLeasedSharedCodexAppServerClient,
 }));
 vi.mock("openclaw/plugin-sdk/exec-approvals-runtime", async (importOriginal) => {
   const actual =
@@ -92,6 +94,7 @@ describe("codex conversation binding", () => {
 
   afterEach(async () => {
     sharedClientMocks.getSharedCodexAppServerClient.mockReset();
+    sharedClientMocks.releaseLeasedSharedCodexAppServerClient.mockReset();
     execApprovalsRuntimeMocks.loadExecApprovals.mockReset();
     execApprovalsRuntimeMocks.loadExecApprovals.mockReturnValue({ version: 1, agents: {} });
     agentRuntimeMocks.ensureAuthProfileStore.mockReset();
@@ -616,6 +619,108 @@ describe("codex conversation binding", () => {
     expect(resumeCodexCliSessionOnNode).not.toHaveBeenCalled();
   });
 
+  it("unsubscribes bound app-server turns before removing handlers and releasing the lease", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    await fs.writeFile(
+      `${sessionFile}.codex-app-server.json`,
+      JSON.stringify({
+        schemaVersion: 1,
+        threadId: "thread-1",
+        cwd: tempDir,
+        approvalPolicy: "never",
+        sandbox: "danger-full-access",
+      }),
+    );
+    const lifecycle: string[] = [];
+    const requests: Array<{
+      method: string;
+      params: Record<string, unknown>;
+      options?: Record<string, unknown>;
+    }> = [];
+    let notificationHandler: ((notification: Record<string, unknown>) => void) | undefined;
+    sharedClientMocks.releaseLeasedSharedCodexAppServerClient.mockImplementation(() => {
+      lifecycle.push("release");
+    });
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(
+        async (
+          method: string,
+          requestParams: Record<string, unknown>,
+          requestOptions?: Record<string, unknown>,
+        ) => {
+          lifecycle.push(`request:${method}`);
+          requests.push({ method, params: requestParams, options: requestOptions });
+          if (method === "turn/start") {
+            setImmediate(() =>
+              notificationHandler?.({
+                method: "turn/completed",
+                params: {
+                  threadId: "thread-1",
+                  turn: {
+                    id: "turn-1",
+                    status: "completed",
+                    items: [{ id: "assistant-1", type: "agentMessage", text: "Done" }],
+                  },
+                },
+              }),
+            );
+            return { turn: { id: "turn-1" } };
+          }
+          if (method === "thread/unsubscribe") {
+            return {};
+          }
+          throw new Error(`unexpected method: ${method}`);
+        },
+      ),
+      addNotificationHandler: vi.fn((handler: (notification: Record<string, unknown>) => void) => {
+        notificationHandler = handler;
+        return () => lifecycle.push("notification-cleanup");
+      }),
+      addRequestHandler: vi.fn(() => () => lifecycle.push("request-cleanup")),
+    });
+
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "finish it",
+        bodyForAgent: "finish it",
+        channel: "telegram",
+        isGroup: false,
+        commandAuthorized: true,
+      },
+      {
+        channelId: "telegram",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "5185575566",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile,
+            workspaceDir: tempDir,
+          },
+        },
+      },
+      { timeoutMs: 500 },
+    );
+
+    expect(result).toEqual({ handled: true, reply: { text: "Done" } });
+    expect(requests.map((request) => request.method)).toEqual(["turn/start", "thread/unsubscribe"]);
+    expect(requests[1]?.params).toEqual({ threadId: "thread-1" });
+    expect(requests[1]?.options).toEqual({ timeoutMs: 5_000 });
+    expect(lifecycle).toEqual([
+      "request:turn/start",
+      "request:thread/unsubscribe",
+      "notification-cleanup",
+      "request-cleanup",
+      "release",
+    ]);
+  });
+
   it("recreates a missing bound thread and preserves auth plus turn overrides", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     agentRuntimeMocks.ensureAuthProfileStore.mockReturnValue({
@@ -649,6 +754,9 @@ describe("codex conversation binding", () => {
         requests.push({ method, params: requestParams });
         if (method === "turn/start" && requestParams.threadId === "thread-old") {
           throw new Error("thread not found: thread-old");
+        }
+        if (method === "thread/unsubscribe") {
+          return {};
         }
         if (method === "thread/start") {
           return {
@@ -721,21 +829,25 @@ describe("codex conversation binding", () => {
     expect(result).toEqual({ handled: true, reply: { text: "Recovered" } });
     expect(requests.map((request) => request.method)).toEqual([
       "turn/start",
+      "thread/unsubscribe",
       "thread/start",
       "turn/start",
+      "thread/unsubscribe",
     ]);
+    expect(requests[1]?.params.threadId).toBe("thread-old");
     const sharedClientParams = mockCallArg(sharedClientMocks.getSharedCodexAppServerClient) as {
       authProfileId?: unknown;
     };
     expect(sharedClientParams?.authProfileId).toBe("work");
-    expect(requests[1]?.params.model).toBe("gpt-5.4-mini");
-    expect(requests[1]?.params.approvalPolicy).toBe("on-request");
-    expect(requests[1]?.params.sandbox).toBe("workspace-write");
-    expect(requests[1]?.params.serviceTier).toBe("priority");
-    expect(requests[1]?.params).not.toHaveProperty("modelProvider");
-    expect(requests[2]?.params.threadId).toBe("thread-new");
+    expect(requests[2]?.params.model).toBe("gpt-5.4-mini");
     expect(requests[2]?.params.approvalPolicy).toBe("on-request");
+    expect(requests[2]?.params.sandbox).toBe("workspace-write");
     expect(requests[2]?.params.serviceTier).toBe("priority");
+    expect(requests[2]?.params).not.toHaveProperty("modelProvider");
+    expect(requests[3]?.params.threadId).toBe("thread-new");
+    expect(requests[3]?.params.approvalPolicy).toBe("on-request");
+    expect(requests[3]?.params.serviceTier).toBe("priority");
+    expect(requests[4]?.params.threadId).toBe("thread-new");
     const savedBinding = JSON.parse(
       await fs.readFile(`${sessionFile}.codex-app-server.json`, "utf8"),
     );
@@ -766,6 +878,9 @@ describe("codex conversation binding", () => {
         requests.push({ method, params: requestParams });
         if (method === "turn/start" && requestParams.threadId === "thread-old") {
           throw new Error("thread not found: thread-old");
+        }
+        if (method === "thread/unsubscribe") {
+          return {};
         }
         if (method === "thread/start") {
           return {
@@ -876,6 +991,9 @@ describe("codex conversation binding", () => {
           });
           return { turn: { id: "turn-new" } };
         }
+        if (method === "thread/unsubscribe") {
+          return {};
+        }
         throw new Error(`unexpected method: ${method}`);
       }),
       addNotificationHandler: vi.fn((handler) => {
@@ -915,9 +1033,14 @@ describe("codex conversation binding", () => {
     );
 
     expect(result).toEqual({ handled: true, reply: { text: "Recovered fresh" } });
-    expect(requests.map((request) => request.method)).toEqual(["thread/start", "turn/start"]);
+    expect(requests.map((request) => request.method)).toEqual([
+      "thread/start",
+      "turn/start",
+      "thread/unsubscribe",
+    ]);
     expect(requests[1]?.params.threadId).toBe("thread-new");
     expect(requests[1]?.params.personality).toBe("none");
+    expect(requests[2]?.params.threadId).toBe("thread-new");
     const savedBinding = JSON.parse(
       await fs.readFile(`${sessionFile}.codex-app-server.json`, "utf8"),
     );

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -17,6 +17,10 @@ import {
   resolveStorePath,
 } from "openclaw/plugin-sdk/session-store-runtime";
 import { resolveCodexAppServerForModelProvider } from "./app-server/app-server-policy.js";
+import {
+  CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+  unsubscribeCodexThreadBestEffort,
+} from "./app-server/attempt-client-cleanup.js";
 import { resolveCodexAppServerAuthProfileIdForAgent } from "./app-server/auth-bridge.js";
 import { CODEX_CONTROL_METHODS } from "./app-server/capabilities.js";
 import {
@@ -669,6 +673,10 @@ async function runBoundTurn(params: {
       },
     };
   } finally {
+    await unsubscribeCodexThreadBestEffort(client, {
+      threadId,
+      timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+    });
     notificationCleanup();
     requestCleanup();
     releaseLeasedSharedCodexAppServerClient(client);


### PR DESCRIPTION
## Summary

- Fixes #85458.
- Adds best-effort `thread/unsubscribe` cleanup after Codex app-server bound turns finish or fail.
- Reuses the canonical app-server cleanup helper and covers missing-thread recovery when the replacement thread retry fails, preserving the saved replacement binding while releasing app-server subscriptions.

## Test Plan

- `node scripts/run-vitest.mjs extensions/codex/src/conversation-binding.test.ts`
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts`
- `git diff --check`
- `node_modules/.bin/oxfmt --check extensions/codex/src/conversation-binding.ts extensions/codex/src/conversation-binding.test.ts`
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm check:changed --base HEAD --head HEAD -- extensions/codex/src/conversation-binding.test.ts extensions/codex/src/conversation-binding.ts`

## Real behavior proof

Behavior addressed: Codex app-server conversation bindings now best-effort unsubscribe the bound thread after every turn attempt, including the missing-thread recovery retry path, so a recreated bound thread is not left subscribed when the retry rejects.
Real environment tested: Local macOS OpenClaw checkout on the PR branch, using the real Codex app-server conversation-binding runtime entrypoint with an isolated temporary HOME/CODEX_HOME and a stdio app-server process that records JSON-RPC calls.
Exact steps or command run after this patch: `node --import tsx .tmp-codex-proof.ts`.
Evidence after fix: Copied terminal output from the runtime command:

```json
{
  "result": {
    "handled": true,
    "reply": {
      "text": "Codex app-server turn failed: retry failed after recovery"
    }
  },
  "calls": [
    { "id": 2, "method": "turn/start", "threadId": "thread-old" },
    { "id": 3, "method": "thread/unsubscribe", "threadId": "thread-old" },
    { "id": 4, "method": "thread/start" },
    { "id": 5, "method": "turn/start", "threadId": "thread-new" },
    { "id": 6, "method": "thread/unsubscribe", "threadId": "thread-new" }
  ],
  "savedThreadId": "thread-new"
}
```

Observed result after fix: The command exited 0 and returned `Codex app-server turn failed: retry failed after recovery`, with both old and replacement thread unsubscribe calls recorded in order.
What was not tested: No live Codex hosted session was used; the proof isolates auth and exercises the OpenClaw runtime entrypoint against a local stdio app-server process, plus the targeted Vitest coverage listed above.

## Risk/Notes

- Scope is limited to Codex app-server conversation binding turn cleanup; it does not change thread creation/resume or hosted Codex behavior.
- The default `pnpm check:changed --staged` path attempted local crabbox delegation and failed its binary sanity check in this checkout, so the equivalent non-delegated changed gate above was run against the touched files and passed.

Closes #85458
