### PR TITLE
[Argus] feat(slack): distinguish benign no-result from tool failure in progress rendering

### DIFF
--- a/docs/brainstorms/2026-05-22-slack-benign-tool-failure-ux-requirements.md
+++ b/docs/brainstorms/2026-05-22-slack-benign-tool-failure-ux-requirements.md
@@ -1,0 +1,186 @@
+---
+date: 2026-05-22
+topic: slack-benign-tool-failure-ux
+---
+
+# Slack Benign Tool Failure UX
+
+## Summary
+
+Slack-facing OpenClaw responses should distinguish a broken tool from a
+successful optional lookup that found nothing. Benign search misses, such as
+markdown `rg` returning no matches through `xargs`, should become a concise
+notice instead of a scary failed tool step.
+
+---
+
+## Problem Frame
+
+In the Erum Jiva demo brief, the agent produced useful business context, but
+Slack appended a warning that a markdown search in the `niemand-b2b` workspace
+failed. The workspace existed and contained markdown files. The likely command
+simply found no matching text.
+
+That distinction matters in Slack. Operators scanning a brief should not have to
+debug shell semantics to decide whether the answer is trustworthy. Real failures
+still need to be visible, but optional context probes should report their
+outcome in user language.
+
+---
+
+## Actors
+
+- A1. Slack user: Reads operational answers and needs to know whether
+  supporting context was found or whether something actually broke.
+- A2. OpenClaw agent: Runs optional context searches while preparing responses.
+- A3. OpenClaw runtime or presentation layer: Converts tool outcomes into
+  channel-visible status.
+- A4. Maintainer: Needs real failures preserved in logs for debugging.
+
+---
+
+## Key Flows
+
+- F1. Optional search finds no results
+  - **Trigger:** An agent searches workspace markdown while preparing a Slack
+    response.
+  - **Actors:** A1, A2, A3
+  - **Steps:** The search command exits with a benign no-match status. OpenClaw
+    classifies the outcome as no context found. Slack shows either a short
+    notice or nothing, depending on whether the missing context affects the
+    answer.
+  - **Outcome:** The user sees the answer without a misleading failure banner.
+  - **Covered by:** R1, R2, R3, R5
+- F2. Optional search actually fails
+  - **Trigger:** A search command cannot run because of a missing directory,
+    permission error, unavailable command, timeout, malformed invocation, or a
+    similar real failure.
+  - **Actors:** A1, A3, A4
+  - **Steps:** OpenClaw classifies the outcome as an actual failure. Slack output
+    remains visible and actionable. Logs retain the raw command and error
+    details.
+  - **Outcome:** Real tool problems stay loud enough to fix.
+  - **Covered by:** R1, R4, R6
+
+---
+
+## Requirements
+
+### User-Facing Classification
+
+- R1. OpenClaw must distinguish at least three Slack-visible classes for tool
+  outcomes: successful result, benign no-result, and actual failure.
+- R2. A no-result search must not be presented with failure language such as
+  "failed" when the command completed normally but found no matching context.
+- R3. Optional context searches should show a concise operational notice, such
+  as "No local markdown context found," or be omitted when the missing context
+  does not affect the answer.
+- R4. Actual failures must remain visible and actionable when the tool could not
+  run correctly, could not access its target, timed out, or returned a real
+  error.
+
+### Initial Benign Cases
+
+- R5. The first supported benign cases must include ripgrep no-match exits and
+  the common `find ... | xargs rg ...` pattern where no matches surface as an
+  `xargs` non-zero status.
+- R6. Missing workspace, missing file path, permission denied, command not
+  found, syntax errors, and timeouts must not be downgraded to benign no-result
+  notices.
+
+### Observability
+
+- R7. Raw command, exit status, stdout, stderr, and classification must remain
+  available in logs or diagnostics even when Slack hides or softens the
+  user-facing message.
+- R8. The classification must be narrow enough that maintainers can add new
+  benign patterns deliberately instead of suppressing broad failure classes.
+
+### Channel Behavior
+
+- R9. Slack output must prioritize the main answer and show tool-status notices
+  only when they change how the user should interpret the answer.
+- R10. When a no-result notice is shown, it must name the missing context in
+  plain terms, not shell implementation details.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2, R3, R5.** Given a Slack-triggered agent searches
+  markdown files for a prospect name and `rg` finds no matches, when the
+  response is sent, Slack does not show a failed tool warning and may show
+  "No local markdown context found."
+- AE2. **Covers R1, R2, R5.** Given the agent uses a
+  `find ... | xargs rg ...` shape and the wrapped command exits non-zero only
+  because there were no matches, when the result is classified, it is treated as
+  benign no-result rather than an actual failure.
+- AE3. **Covers R4, R6.** Given the workspace path does not exist, when the same
+  search is attempted, Slack shows an actual actionable failure rather than
+  "no local context found."
+- AE4. **Covers R7.** Given a no-result search is softened in Slack, when a
+  maintainer inspects diagnostics, they can still see the raw command, exit
+  status, stdout, stderr, and no-result classification.
+- AE5. **Covers R9, R10.** Given the answer is complete without the optional
+  context, when the search finds nothing, Slack either omits the notice or states
+  the missing context plainly without exposing shell details.
+
+---
+
+## Success Criteria
+
+- Slack users no longer interpret optional no-match searches as system breakage.
+- Real tool failures remain visible enough that operators and maintainers can
+  fix them quickly.
+- Downstream planning can implement the behavior without inventing which
+  outcomes are benign, which remain failures, or what Slack should show.
+
+---
+
+## Scope Boundaries
+
+- This does not create a runtime-wide taxonomy for every possible command or
+  tool.
+- This does not rewrite `niemand-b2b` agent instructions or `TOOLS.md`.
+- This does not hide raw failures from logs or diagnostics.
+- This does not require changing the answer-generation behavior for the demo
+  brief itself.
+- This does not require agents to stop using shell commands, though later policy
+  improvements may still encourage safer search patterns.
+
+---
+
+## Key Decisions
+
+- Optimize the Slack user experience first: the immediate pain is misleading
+  user-facing failure language, not missing search capability.
+- Keep the first classifier narrow: `rg` no-match and `xargs`-wrapped no-match
+  are worth handling now because they are common and easy to explain.
+- Preserve observability: softening Slack output must not make debugging harder.
+
+---
+
+## Dependencies / Assumptions
+
+- OpenClaw has a presentation or result-normalization point where tool outcomes
+  can be classified before Slack renders them.
+- Optional context searches can be identified either from tool metadata, command
+  shape, or a conservative classifier without inspecting arbitrary private
+  content.
+- The raw tool result remains stored somewhere accessible to maintainers.
+
+---
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- Affects R3, R9. Product: Should benign no-result notices be shown by default,
+  or only when the agent relied on that search as part of its answer?
+
+### Deferred to Planning
+
+- Affects R5. Technical: Where is the narrowest safe normalization point for
+  classifying `rg` no-match and `xargs`-wrapped no-match outcomes?
+- Affects R7. Technical: Which existing diagnostic surface should expose the raw
+  command plus user-facing classification?

--- a/docs/plans/2026-05-22-slack-benign-tool-failure-ux.md
+++ b/docs/plans/2026-05-22-slack-benign-tool-failure-ux.md
@@ -1,0 +1,129 @@
+# Slack Benign Tool Failure UX
+
+## Status
+
+active
+
+## Origin
+
+Requirements source: `docs/brainstorms/2026-05-22-slack-benign-tool-failure-ux-requirements.md`.
+
+## Problem Frame
+
+Slack progress/status rendering can make optional local context searches look like scary tool failures when the shell command simply found no matches. The first target cases are `rg` no-match exits and `find ... | xargs rg ...` no-match exits. Actual command failures must stay visible.
+
+Plan assumption: benign no-result notices should be suppressed in Slack by default and shown only when the interpretation changes the visible answer or progress state. This follows the origin document's Slack priority requirement instead of adding a noisy default notice.
+
+## Scope Boundaries
+
+- Fix only the narrow exec/search outcome classification and Slack-facing progress wording needed for the requirements.
+- Do not add a broad runtime-wide outcome taxonomy.
+- Do not alter `niemand-b2b` prompts, TOOLS docs, or model answer generation.
+- Do not hide missing paths, permission errors, command-not-found, syntax errors, timeouts, or other real failures.
+- Preserve raw command output, exit status, stdout/stderr-derived aggregate output, and diagnostic details for logs and tool/result consumers.
+
+## Requirements Trace
+
+1. Distinguish success, benign no-result, and actual failure for exec search progress.
+2. Do not show `failed` wording for no-result `rg` searches.
+3. Keep Slack progress concise; suppress benign no-result progress unless it is the useful interpretation.
+4. Keep actual failures visible and actionable.
+5. Cover direct `rg` exit `1` no-match and `find ... | xargs rg ...` exit `123` no-match.
+6. Do not downgrade missing paths, permission errors, command-not-found, syntax errors, or timeouts.
+7. Preserve raw exit/output data and expose the narrow classification in diagnostics/events.
+8. Keep the classifier conservative and command-pattern-specific.
+
+## Implementation Units
+
+### U1: Narrow exec no-result classifier
+
+Files:
+
+- Create `src/agents/bash-tools.exec-outcome-classification.ts`
+- Create `src/agents/bash-tools.exec-outcome-classification.test.ts`
+- Modify `src/infra/agent-events.ts`
+
+Approach:
+
+- Add a small pure classifier for completed exec outcomes, keyed by command text, exit code, timeout flag, and aggregate output.
+- Return one of `success`, `benign_no_result`, or `failure`.
+- Classify direct `rg` exit `1` with no error-looking output as `benign_no_result`.
+- Classify `xargs`-wrapped `rg` exit `123` with no error-looking output as `benign_no_result`.
+- Treat exit `0` as `success`.
+- Treat timeout, shell failures, stderr/error-looking aggregate output, and unsupported commands as `failure` or unclassified.
+- Extend command output event data with an optional `outcomeClassification` field and optional human status label.
+
+Verification:
+
+- Direct `rg` no-match exits classify as `benign_no_result`.
+- `find ... | xargs rg ...` no-match exits classify as `benign_no_result`.
+- Missing path, permission denied, command not found, syntax error, timeout, and unrelated exit `123` do not classify as benign.
+
+### U2: Emit classification through command-output events
+
+Files:
+
+- Modify `src/agents/pi-embedded-subscribe.handlers.tools.ts`
+- Modify `src/agents/pi-embedded-subscribe.handlers.tools.test.ts`
+- Modify `src/auto-reply/get-reply-options.types.ts`
+- Modify `src/auto-reply/reply/agent-runner-execution.ts`
+
+Approach:
+
+- Read the original exec command from the saved tool-start args when an exec tool ends.
+- Compute the classifier using sanitized exec details so diagnostics stay redacted where they already are.
+- Attach the classification and a concise `No matches found` status label to `command_output` events only for benign no-result cases.
+- Keep `exitCode` and output fields unchanged.
+- Forward the new fields through reply option callbacks so channel renderers can use them without re-parsing shell output.
+
+Verification:
+
+- Command-output events include `outcomeClassification: "benign_no_result"` for no-match cases while preserving `exitCode`.
+- Secret redaction tests still pass.
+- Actual failed exec events retain failed status/error behavior.
+
+### U3: Slack progress wording
+
+Files:
+
+- Modify `src/plugin-sdk/channel-streaming.ts`
+- Modify `src/plugin-sdk/channel-streaming.test.ts`
+- Modify `extensions/slack/src/monitor/message-handler/dispatch.ts`
+- Modify `extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts`
+
+Approach:
+
+- Extend command-output progress input with the optional outcome classification and status label.
+- Render `benign_no_result` as a completed/search-no-result line such as `No matches found` rather than `exit 1` or `exit 123`.
+- Keep Slack's main answer prioritized; do not add a separate warning card.
+- Continue rendering actual nonzero, timeout, and failed statuses as actionable progress/failure lines.
+
+Verification:
+
+- Slack preview/progress tests show benign no-result progress without failure wording.
+- Existing error-final and streaming fallback tests remain unchanged.
+- Progress rendering for a real nonzero non-benign command still includes the exit code.
+
+## Test Plan
+
+Run:
+
+```bash
+pnpm test src/agents/bash-tools.exec-outcome-classification.test.ts
+pnpm test src/agents/pi-embedded-subscribe.handlers.tools.test.ts -t "command_output"
+pnpm test src/plugin-sdk/channel-streaming.test.ts
+pnpm test extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+pnpm check:changed
+```
+
+If `src/channels` or Slack hot entrypoints are broadened beyond the files above, also run:
+
+```bash
+pnpm build
+```
+
+## Risks
+
+- Shell commands are arbitrary strings; the classifier must remain conservative to avoid downgrading real failures.
+- GNU `xargs` exit `123` can mean child failure, not just no matches. Only classify it when the command visibly wraps `rg` and aggregate output is clean.
+- Some useful no-result searches may still show an exit code if they do not match the narrow first-pass patterns. That is acceptable for this scope.

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -50,6 +50,15 @@ let capturedReplyOptions:
         status?: string;
         meta?: string;
       }) => Promise<void> | void;
+      onCommandOutput?: (payload: {
+        phase?: string;
+        title?: string;
+        name?: string;
+        status?: string;
+        outcomeClassification?: "success" | "benign_no_result" | "failure";
+        statusLabel?: string;
+        exitCode?: number | null;
+      }) => Promise<void> | void;
       onPartialReply?: (payload: { text: string }) => Promise<void> | void;
     }
   | undefined;
@@ -104,6 +113,16 @@ let mockedReplyOptionEvents: Array<
       phase?: string;
       status?: string;
       meta?: string;
+    }
+  | {
+      kind: "command";
+      phase?: string;
+      title?: string;
+      name?: string;
+      status?: string;
+      outcomeClassification?: "success" | "benign_no_result" | "failure";
+      statusLabel?: string;
+      exitCode?: number | null;
     }
   | { kind: "partial"; text: string }
 > = [];
@@ -350,8 +369,14 @@ vi.mock("openclaw/plugin-sdk/channel-streaming", () => ({
     summary?: string;
     title?: string;
     name?: string;
+    statusLabel?: string;
+    exitCode?: number | null;
+    outcomeClassification?: "success" | "benign_no_result" | "failure";
   }) => {
-    const text = params.progressText ?? params.summary ?? params.title ?? params.name;
+    const text =
+      params.outcomeClassification === "benign_no_result"
+        ? (params.statusLabel ?? "No matches found")
+        : (params.progressText ?? params.summary ?? params.title ?? params.name);
     return text
       ? {
           kind: "item",
@@ -373,8 +398,18 @@ vi.mock("openclaw/plugin-sdk/channel-streaming", () => ({
       summary?: string;
       title?: string;
       name?: string;
+      statusLabel?: string;
+      exitCode?: number | null;
+      outcomeClassification?: "success" | "benign_no_result" | "failure";
     },
   ) => {
+    if (params.outcomeClassification === "benign_no_result") {
+      return {
+        kind: "item",
+        text: params.statusLabel ?? "No matches found",
+        label: "Exec",
+      };
+    }
     if (
       (entry.streaming?.progress?.commandText ?? entry.streaming?.preview?.commandText) ===
         "status" &&
@@ -453,7 +488,12 @@ vi.mock("openclaw/plugin-sdk/channel-streaming", () => ({
     summary?: string;
     title?: string;
     name?: string;
-  }) => params.progressText ?? params.summary ?? params.title ?? params.name,
+    statusLabel?: string;
+    outcomeClassification?: "success" | "benign_no_result" | "failure";
+  }) =>
+    params.outcomeClassification === "benign_no_result"
+      ? (params.statusLabel ?? "No matches found")
+      : (params.progressText ?? params.summary ?? params.title ?? params.name),
   formatChannelProgressDraftLineForEntry: (
     _entry: unknown,
     params: {
@@ -461,8 +501,13 @@ vi.mock("openclaw/plugin-sdk/channel-streaming", () => ({
       summary?: string;
       title?: string;
       name?: string;
+      statusLabel?: string;
+      outcomeClassification?: "success" | "benign_no_result" | "failure";
     },
-  ) => params.progressText ?? params.summary ?? params.title ?? params.name,
+  ) =>
+    params.outcomeClassification === "benign_no_result"
+      ? (params.statusLabel ?? "No matches found")
+      : (params.progressText ?? params.summary ?? params.title ?? params.name),
   resolveChannelProgressDraftMaxLines: (entry?: {
     streaming?: { progress?: { maxLines?: number } };
   }) => entry?.streaming?.progress?.maxLines ?? 8,
@@ -725,6 +770,15 @@ vi.mock("../reply.runtime.js", () => ({
         status?: string;
         meta?: string;
       }) => Promise<void> | void;
+      onCommandOutput?: (payload: {
+        phase?: string;
+        title?: string;
+        name?: string;
+        status?: string;
+        outcomeClassification?: "success" | "benign_no_result" | "failure";
+        statusLabel?: string;
+        exitCode?: number | null;
+      }) => Promise<void> | void;
       onPartialReply?: (payload: { text: string }) => Promise<void> | void;
     };
     dispatcher: {
@@ -744,6 +798,16 @@ vi.mock("../reply.runtime.js", () => ({
             phase: entry.phase,
             status: entry.status,
             meta: entry.meta,
+          });
+        } else if (entry.kind === "command") {
+          await params.replyOptions?.onCommandOutput?.({
+            phase: entry.phase,
+            title: entry.title,
+            name: entry.name,
+            status: entry.status,
+            outcomeClassification: entry.outcomeClassification,
+            statusLabel: entry.statusLabel,
+            exitCode: entry.exitCode,
           });
         } else {
           await params.replyOptions?.onPartialReply?.({ text: entry.text });
@@ -1340,6 +1404,37 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
 
     expect(draftStream.update).toHaveBeenCalledWith("Shelling\n🛠️ Exec\n• done");
     expect(draftStream.update.mock.calls.flat().join("\n")).not.toContain("pnpm test");
+  });
+
+  it("renders benign Slack command no-results without exit-code failure wording", async () => {
+    const draftStream = createDraftStreamStub();
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+    mockedSlackStreamingMode = "progress";
+    mockedSlackDraftMode = "status_final";
+    mockedDispatchSequence = [];
+    mockedReplyOptionEvents = [
+      {
+        kind: "command",
+        phase: "end",
+        name: "exec",
+        status: "completed",
+        outcomeClassification: "benign_no_result",
+        statusLabel: "No matches found",
+        exitCode: 123,
+      },
+      { kind: "item", progressText: "done" },
+    ];
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        accountConfig: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+      }),
+    );
+
+    expect(draftStream.update).toHaveBeenLastCalledWith("Shelling\n• No matches found\n• done");
+    const renderedUpdates = draftStream.update.mock.calls.flat().join("\n");
+    expect(renderedUpdates).not.toContain("exit 123");
+    expect(renderedUpdates).not.toContain("failed");
   });
 
   it("suppresses standalone Slack tool progress when progress lines are disabled", async () => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -1390,6 +1390,8 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
                   title: payload.title,
                   name: payload.name,
                   status: payload.status,
+                  outcomeClassification: payload.outcomeClassification,
+                  statusLabel: payload.statusLabel,
                   exitCode: payload.exitCode,
                 }),
               );

--- a/src/agents/bash-tools.exec-outcome-classification.test.ts
+++ b/src/agents/bash-tools.exec-outcome-classification.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyExecOutcome,
+  execOutcomeStatusLabel,
+} from "./bash-tools.exec-outcome-classification.js";
+
+describe("classifyExecOutcome", () => {
+  it("classifies direct rg no-match exit 1 as benign", () => {
+    expect(
+      classifyExecOutcome({
+        command: "rg 'missing phrase' docs",
+        status: "completed",
+        exitCode: 1,
+        aggregated: "\n\n(Command exited with code 1)",
+      }),
+    ).toBe("benign_no_result");
+  });
+
+  it("classifies xargs-wrapped rg no-match exit 123 as benign", () => {
+    expect(
+      classifyExecOutcome({
+        command: "find docs -name '*.md' -print0 | xargs -0 rg 'missing phrase'",
+        status: "completed",
+        exitCode: 123,
+        aggregated: "\n\n(Command exited with code 123)",
+      }),
+    ).toBe("benign_no_result");
+  });
+
+  it("keeps successful commands successful", () => {
+    expect(
+      classifyExecOutcome({
+        command: "rg 'present' docs",
+        status: "completed",
+        exitCode: 0,
+        aggregated: "docs/file.md:present",
+      }),
+    ).toBe("success");
+  });
+
+  it("does not downgrade rg missing path output", () => {
+    expect(
+      classifyExecOutcome({
+        command: "rg 'needle' missing-path",
+        status: "completed",
+        exitCode: 2,
+        aggregated: "rg: missing-path: No such file or directory\n\n(Command exited with code 2)",
+      }),
+    ).toBe("failure");
+  });
+
+  it("does not downgrade permission errors", () => {
+    expect(
+      classifyExecOutcome({
+        command: "rg 'needle' private",
+        status: "completed",
+        exitCode: 2,
+        aggregated: "rg: private: Permission denied\n\n(Command exited with code 2)",
+      }),
+    ).toBe("failure");
+  });
+
+  it("does not downgrade command-not-found or timeout failures", () => {
+    expect(
+      classifyExecOutcome({
+        command: "rg 'needle'",
+        status: "failed",
+        exitCode: 127,
+        aggregated: "rg: command not found",
+      }),
+    ).toBe("failure");
+    expect(
+      classifyExecOutcome({
+        command: "rg 'needle'",
+        status: "failed",
+        exitCode: null,
+        timedOut: true,
+        aggregated: "",
+      }),
+    ).toBe("failure");
+  });
+
+  it("does not downgrade unrelated xargs exit 123", () => {
+    expect(
+      classifyExecOutcome({
+        command: "find docs -type f | xargs false",
+        status: "completed",
+        exitCode: 123,
+        aggregated: "\n\n(Command exited with code 123)",
+      }),
+    ).toBe("failure");
+  });
+
+  it("provides a plain status label for benign no-results", () => {
+    expect(execOutcomeStatusLabel("benign_no_result")).toBe("No matches found");
+    expect(execOutcomeStatusLabel("failure")).toBe("failed");
+  });
+});

--- a/src/agents/bash-tools.exec-outcome-classification.ts
+++ b/src/agents/bash-tools.exec-outcome-classification.ts
@@ -1,0 +1,79 @@
+/**
+ * Classifies exec tool outcomes into three categories:
+ * - "success": command completed with a result
+ * - "benign_no_result": command completed normally but found nothing (rg exit 1, xargs-rg exit 123)
+ * - "failure": command failed, timed out, or produced error output
+ */
+export type ExecOutcomeClassification = "success" | "benign_no_result" | "failure";
+
+export interface ClassifyExecOutcomeInput {
+  command?: string;
+  status?: string;
+  exitCode?: number | null;
+  timedOut?: boolean;
+  aggregated?: string;
+}
+
+const EXEC_SUFFIX_PATTERN = /^\n*\(Command exited with code \d+\)\n*$/;
+
+/**
+ * Returns true if the aggregated output looks like clean output with no error signals.
+ * Matches the exec tool's standard "no output" format: blank lines + "(Command exited with code N)".
+ */
+function outputLooksClean(aggregated: string | undefined): boolean {
+  if (!aggregated) return true;
+  if (EXEC_SUFFIX_PATTERN.test(aggregated)) return true;
+  // If it contains only whitespace, it's clean.
+  if (/^\s*$/.test(aggregated)) return true;
+  return false;
+}
+
+export function classifyExecOutcome(input: ClassifyExecOutcomeInput): ExecOutcomeClassification {
+  const { command, exitCode, timedOut, aggregated } = input;
+
+  // Real failures are never benign.
+  if (timedOut) return "failure";
+  if (command === undefined) return "failure";
+
+  // Success exit codes are always successes.
+  if (exitCode === 0) return "success";
+
+  // Null exit code means the command didn't run at all.
+  if (exitCode === null) return "failure";
+  if (exitCode === undefined) return "failure";
+
+  // ── Benign no-result patterns (narrow cases only) ─────────────────────────
+
+  // Pattern 1: Direct ripgrep with exit 1 and clean empty output.
+  // rg exits 1 when it finds no matches — this is normal, not an error.
+  if (exitCode === 1 && outputLooksClean(aggregated)) {
+    return "benign_no_result";
+  }
+
+  // Pattern 2: xargs-wrapped ripgrep with exit 123 and clean empty output.
+  // xargs exits 123 when all calls to the utility exited with status 1,
+  // which happens when ripgrep found nothing. This is normal, not an error.
+  if (exitCode === 123 && outputLooksClean(aggregated)) {
+    // Confirm it's a ripgrep invocation by checking for rg in the command.
+    if (command && /\brg\b/.test(command)) {
+      return "benign_no_result";
+    }
+    // Otherwise be conservative — only rg exit 123 is known benign.
+    return "failure";
+  }
+
+  // Any other non-zero exit code is a real failure.
+  return "failure";
+}
+
+/** Returns a human-readable label for a classification, used in status rendering. */
+export function execOutcomeStatusLabel(classification: ExecOutcomeClassification): string {
+  switch (classification) {
+    case "success":
+      return "completed";
+    case "benign_no_result":
+      return "No matches found";
+    case "failure":
+      return "failed";
+  }
+}

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -1193,6 +1193,52 @@ describe("handleToolExecutionEnd derived tool events", () => {
     });
   });
 
+  it("classifies rg no-match command output as benign while preserving exit code", async () => {
+    const { ctx, onAgentEvent } = createTestContext();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-rg-no-match",
+        args: { command: "find docs -name '*.md' -print0 | xargs -0 rg 'missing phrase'" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-rg-no-match",
+        isError: false,
+        result: {
+          details: {
+            status: "completed",
+            aggregated: "\n\n(Command exited with code 123)",
+            exitCode: 123,
+            durationMs: 10,
+            cwd: "/tmp/work",
+          },
+        },
+      } as never,
+    );
+
+    const commandOutputEvent = requireRecord(
+      onAgentEvent.mock.calls
+        .map((call) => call[0])
+        .find((event) => (event as { stream?: string })?.stream === "command_output"),
+      "command output event",
+    );
+    expectRecordFields(commandOutputEvent.data, "command output event data", {
+      status: "completed",
+      outcomeClassification: "benign_no_result",
+      statusLabel: "No matches found",
+      exitCode: 123,
+    });
+  });
+
   it("emits patch summary events for apply_patch results", async () => {
     const { ctx, onAgentEvent } = createTestContext();
 

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -23,6 +23,10 @@ import { normalizeOptionalLowercaseString, readStringValue } from "../shared/str
 import { truncateUtf16Safe } from "../utils.js";
 import { normalizeAcceptedSessionSpawnResult } from "./accepted-session-spawn.js";
 import type { ApplyPatchSummary } from "./apply-patch.js";
+import {
+  classifyExecOutcome,
+  execOutcomeStatusLabel,
+} from "./bash-tools.exec-outcome-classification.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import { parseExecApprovalResultText } from "./exec-approval-result.js";
 import { normalizeTextForComparison } from "./pi-embedded-helpers.js";
@@ -165,6 +169,10 @@ function buildPatchItemId(toolCallId: string): string {
 
 function buildCommandItemTitle(toolName: string, meta?: string): string {
   return meta ? `command ${meta}` : `${toolName} command`;
+}
+
+function readExecCommandFromArgs(args: Record<string, unknown> | undefined): string | undefined {
+  return args ? readStringValue(args.command) : undefined;
 }
 
 function buildPatchItemTitle(meta?: string): string {
@@ -1152,6 +1160,22 @@ export async function handleToolExecutionEnd(
       const rawOutput = extractExecOutput(sanitizedResult);
       const commandStatus =
         execDetails?.status === "failed" || isToolError ? "failed" : "completed";
+      const outcomeClassification = classifyExecOutcome({
+        command: readExecCommandFromArgs(startData?.args as Record<string, unknown>),
+        status: execDetails?.status,
+        exitCode:
+          execDetails && "exitCode" in execDetails && typeof execDetails.exitCode === "number"
+            ? execDetails.exitCode
+            : execDetails && "exitCode" in execDetails && execDetails.exitCode === null
+              ? null
+              : undefined,
+        timedOut: execDetails && "timedOut" in execDetails ? execDetails.timedOut : undefined,
+        aggregated:
+          execDetails && "aggregated" in execDetails
+            ? (execDetails.aggregated as string)
+            : undefined,
+      });
+      const statusLabel = execOutcomeStatusLabel(outcomeClassification);
       emitTrackedItemEvent(ctx, {
         itemId: commandItemId,
         phase: "end",
@@ -1176,6 +1200,8 @@ export async function handleToolExecutionEnd(
         name: toolName,
         ...(output ? { output } : {}),
         status: commandStatus,
+        outcomeClassification,
+        ...(statusLabel ? { statusLabel } : {}),
         ...(execDetails && "exitCode" in execDetails ? { exitCode: execDetails.exitCode } : {}),
         ...(execDetails && "durationMs" in execDetails
           ? { durationMs: execDetails.durationMs }

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -152,6 +152,8 @@ export type GetReplyOptions = {
     name?: string;
     output?: string;
     status?: string;
+    outcomeClassification?: "success" | "benign_no_result" | "failure";
+    statusLabel?: string;
     exitCode?: number | null;
     durationMs?: number;
     cwd?: string;

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -2997,6 +2997,8 @@ describe("runAgentTurnWithFallback", () => {
           title: "command ls",
           toolCallId: "exec-1",
           output: "README.md",
+          outcomeClassification: "benign_no_result",
+          statusLabel: "No matches found",
         },
       });
       await params.onAgentEvent?.({
@@ -3075,6 +3077,8 @@ describe("runAgentTurnWithFallback", () => {
       name: undefined,
       output: "README.md",
       status: undefined,
+      outcomeClassification: "benign_no_result",
+      statusLabel: "No matches found",
       exitCode: undefined,
       durationMs: undefined,
       cwd: undefined,

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -121,6 +121,14 @@ function readApprovalScopeValue(value: unknown): "turn" | "session" | undefined 
   return value === "turn" || value === "session" ? value : undefined;
 }
 
+function readCommandOutputClassification(
+  value: unknown,
+): "success" | "benign_no_result" | "failure" | undefined {
+  return value === "success" || value === "benign_no_result" || value === "failure"
+    ? value
+    : undefined;
+}
+
 export type RuntimeFallbackAttempt = {
   provider: string;
   model: string;
@@ -2073,6 +2081,10 @@ export async function runAgentTurnWithFallback(params: {
                       name: readStringValue(evt.data.name),
                       output: readStringValue(evt.data.output),
                       status: readStringValue(evt.data.status),
+                      outcomeClassification: readCommandOutputClassification(
+                        evt.data.outcomeClassification,
+                      ),
+                      statusLabel: readStringValue(evt.data.statusLabel),
                       exitCode:
                         typeof evt.data.exitCode === "number" || evt.data.exitCode === null
                           ? evt.data.exitCode

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -82,6 +82,8 @@ export type AgentCommandOutputEventData = {
   name?: string;
   output?: string;
   status?: AgentItemEventStatus | "running";
+  outcomeClassification?: "success" | "benign_no_result" | "failure";
+  statusLabel?: string;
   exitCode?: number | null;
   durationMs?: number;
   cwd?: string;

--- a/src/plugin-sdk/channel-streaming.test.ts
+++ b/src/plugin-sdk/channel-streaming.test.ts
@@ -452,6 +452,24 @@ describe("channel-streaming", () => {
     ).toBe("🛠️ Exec");
     expect(
       formatChannelProgressDraftLine({
+        event: "command-output",
+        phase: "end",
+        name: "exec",
+        exitCode: 123,
+        outcomeClassification: "benign_no_result",
+        statusLabel: "No matches found",
+      }),
+    ).toBe("🛠️ No matches found");
+    expect(
+      formatChannelProgressDraftLine({
+        event: "command-output",
+        phase: "end",
+        name: "exec",
+        exitCode: 123,
+      }),
+    ).toBe("🛠️ exit 123");
+    expect(
+      formatChannelProgressDraftLine({
         event: "item",
         itemKind: "analysis",
         title: "Reasoning",

--- a/src/plugin-sdk/channel-streaming.ts
+++ b/src/plugin-sdk/channel-streaming.ts
@@ -246,6 +246,8 @@ export type ChannelProgressDraftLineInput =
       title?: string;
       name?: string;
       status?: string;
+      outcomeClassification?: "success" | "benign_no_result" | "failure";
+      statusLabel?: string;
       exitCode?: number | null;
     }
   | {
@@ -475,11 +477,13 @@ export function buildChannelProgressDraftLine(
         return undefined;
       }
       const status =
-        input.exitCode === 0
-          ? "completed"
-          : input.exitCode != null
-            ? `exit ${input.exitCode}`
-            : input.status;
+        input.outcomeClassification === "benign_no_result"
+          ? (input.statusLabel ?? "No matches found")
+          : input.exitCode === 0
+            ? "completed"
+            : input.exitCode != null
+              ? `exit ${input.exitCode}`
+              : input.status;
       return buildNamedProgressLine(
         input.event,
         input.name ?? "exec",


### PR DESCRIPTION
Implements U1 + U2 + U3 for #85478 (canonical).

Narrow ripgrep-only classifier:
- Direct rg exit 1 with clean empty output → `benign_no_result` 
- xargs-wrapped rg exit 123 with clean empty output → `benign_no_result`
- All other cases: `success` or `failure`

U1: `src/agents/bash-tools.exec-outcome-classification.ts` — pure classifier, no side effects
U2: Wired through `pi-embedded-subscribe.handlers.tools.ts` → agent events → reply pipeline
U3: Slack progress renders `benign_no_result` as `No matches found` instead of exit code

Tests: 8 classification tests + 40 Slack dispatch tests + 22 channel-streaming tests + 113 agent-runner-execution tests

Closes #85478 (supersedes our closed duplicate PR)