### PR TITLE
fix: reuse provider auth lookup facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Docs: https://docs.openclaw.ai
 - Agents/OpenAI: preserve structured provider error code, type, and redacted body metadata on boundary-aware transport failures.
 - Doctor/Codex: point native Codex asset warnings at the canonical `openclaw migrate plan codex` preview command. Fixes #84948. Thanks @markoa.
 - CLI/models: make `capability model auth logout --agent` remove auth profiles from the selected non-default agent store. Fixes #85092. Thanks @islandpreneur007.
+- Gateway/models: reuse prepared provider auth metadata during model-listing auth checks so repeated lookups avoid broad plugin discovery while preserving synthetic local auth.
 - CLI/status: suppress systemd user-service setup hints when `openclaw status --deep` can already reach a running Gateway RPC service. Fixes #85094. Thanks @islandpreneur007.
 - CLI/devices: recover local approval when a same-device repair request replaces the request ID being approved.
 - CLI/agents: retry transient normal-close Gateway handshakes before falling back to embedded `openclaw agent` execution.

--- a/extensions/lmstudio/openclaw.plugin.json
+++ b/extensions/lmstudio/openclaw.plugin.json
@@ -23,6 +23,7 @@
     }
   },
   "nonSecretAuthMarkers": ["lmstudio-local"],
+  "syntheticAuthRefs": ["lmstudio"],
   "providerAuthEnvVars": {
     "lmstudio": ["LM_API_TOKEN"]
   },

--- a/src/agents/model-auth-env.ts
+++ b/src/agents/model-auth-env.ts
@@ -18,7 +18,7 @@ export type EnvApiKeyResult = {
   source: string;
 };
 
-type EnvApiKeyLookupOptions = {
+export type EnvApiKeyLookupOptions = {
   config?: OpenClawConfig;
   workspaceDir?: string;
   aliasMap?: Readonly<Record<string, string>>;

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -113,7 +113,7 @@ export function createRuntimeProviderAuthLookup(params: {
     workspaceDir: params.workspaceDir,
     env,
   };
-  const syntheticAuthProviderRefs = resolveRuntimeSyntheticAuthProviderRefState();
+  const syntheticAuthProviderRefs = resolveRuntimeSyntheticAuthProviderRefState(lookupParams);
   return {
     envApiKey: {
       aliasMap: resolveProviderAuthAliasMap(lookupParams),

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -13,7 +13,7 @@ import {
   shouldDeferProviderSyntheticProfileAuthWithPlugin,
 } from "../plugins/provider-runtime.js";
 import { resolveOwningPluginIdsForProvider } from "../plugins/providers.js";
-import type { ProviderAuthEvidence } from "../secrets/provider-env-vars.js";
+import { resolveRuntimeSyntheticAuthProviderRefState } from "../plugins/synthetic-auth.runtime.js";
 import { resolveDefaultSecretProviderAlias } from "../secrets/ref-contract.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -33,7 +33,15 @@ import {
   resolveAuthStorePathForDisplay,
 } from "./auth-profiles.js";
 import * as cliCredentials from "./cli-credentials.js";
-import { resolveEnvApiKey, type EnvApiKeyResult } from "./model-auth-env.js";
+import {
+  resolveProviderEnvApiKeyCandidates,
+  resolveProviderEnvAuthEvidence,
+} from "./model-auth-env-vars.js";
+import {
+  resolveEnvApiKey,
+  type EnvApiKeyLookupOptions,
+  type EnvApiKeyResult,
+} from "./model-auth-env.js";
 import {
   CUSTOM_LOCAL_AUTH_MARKER,
   isKnownEnvApiKeyMarker,
@@ -42,6 +50,7 @@ import {
 } from "./model-auth-markers.js";
 import { type ResolvedProviderAuth } from "./model-auth-runtime-shared.js";
 import { normalizeProviderId } from "./model-selection.js";
+import { resolveProviderAuthAliasMap } from "./provider-auth-aliases.js";
 
 export {
   ensureAuthProfileStore,
@@ -55,6 +64,11 @@ export {
 } from "./model-auth-runtime-shared.js";
 export type { ResolvedProviderAuth } from "./model-auth-runtime-shared.js";
 export type ProviderCredentialPrecedence = "profile-first" | "env-first";
+
+export type RuntimeProviderAuthLookup = {
+  envApiKey: Pick<EnvApiKeyLookupOptions, "aliasMap" | "candidateMap" | "authEvidenceMap">;
+  syntheticAuthProviderRefs?: readonly string[];
+};
 
 const log = createSubsystemLogger("model-auth");
 
@@ -86,6 +100,30 @@ function resolveProviderConfig(
     (providers[normalized] as ModelProviderConfig | undefined) ??
     Object.entries(providers).find(([key]) => normalizeProviderId(key) === normalized)?.[1]
   );
+}
+
+export function createRuntimeProviderAuthLookup(params: {
+  cfg?: OpenClawConfig;
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
+}): RuntimeProviderAuthLookup {
+  const env = params.env ?? process.env;
+  const lookupParams = {
+    config: params.cfg,
+    workspaceDir: params.workspaceDir,
+    env,
+  };
+  const syntheticAuthProviderRefs = resolveRuntimeSyntheticAuthProviderRefState();
+  return {
+    envApiKey: {
+      aliasMap: resolveProviderAuthAliasMap(lookupParams),
+      candidateMap: resolveProviderEnvApiKeyCandidates(lookupParams),
+      authEvidenceMap: resolveProviderEnvAuthEvidence(lookupParams),
+    },
+    syntheticAuthProviderRefs: syntheticAuthProviderRefs.complete
+      ? syntheticAuthProviderRefs.refs
+      : undefined,
+  };
 }
 
 export function getCustomProviderApiKey(
@@ -344,17 +382,51 @@ export function hasSyntheticLocalProviderAuthConfig(params: {
   return Boolean(providerConfig.baseUrl && isLocalBaseUrl(providerConfig.baseUrl));
 }
 
+function listProviderSyntheticAuthRefs(params: {
+  cfg: OpenClawConfig | undefined;
+  provider: string;
+  modelApi?: string;
+}): string[] {
+  const refs = [params.provider];
+  const providerConfig = resolveProviderConfig(params.cfg, params.provider);
+  if (params.modelApi) {
+    refs.push(params.modelApi);
+  }
+  if (providerConfig?.api) {
+    refs.push(providerConfig.api);
+  }
+  return [...new Set(refs.map((ref) => normalizeProviderId(ref)).filter(Boolean))];
+}
+
+function shouldResolvePluginSyntheticAuth(params: {
+  cfg: OpenClawConfig | undefined;
+  provider: string;
+  modelApi?: string;
+  runtimeLookup?: RuntimeProviderAuthLookup;
+}): boolean {
+  const syntheticAuthProviderRefs = params.runtimeLookup?.syntheticAuthProviderRefs;
+  if (!syntheticAuthProviderRefs) {
+    return true;
+  }
+  if (resolveProviderConfig(params.cfg, params.provider)) {
+    return true;
+  }
+  const eligibleRefs = new Set(
+    syntheticAuthProviderRefs.map((ref) => normalizeProviderId(ref)).filter(Boolean),
+  );
+  if (eligibleRefs.size === 0) {
+    return false;
+  }
+  return listProviderSyntheticAuthRefs(params).some((ref) => eligibleRefs.has(ref));
+}
+
 export function hasRuntimeAvailableProviderAuth(params: {
   provider: string;
   cfg?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   allowPluginSyntheticAuth?: boolean;
-  envAuthLookup?: {
-    aliasMap?: Readonly<Record<string, string>>;
-    candidateMap?: Readonly<Record<string, readonly string[]>>;
-    authEvidenceMap?: Readonly<Record<string, readonly ProviderAuthEvidence[]>>;
-  };
+  runtimeLookup?: RuntimeProviderAuthLookup;
 }): boolean {
   const provider = normalizeProviderId(params.provider);
   const authOverride = resolveProviderAuthOverride(params.cfg, provider);
@@ -368,9 +440,7 @@ export function hasRuntimeAvailableProviderAuth(params: {
     resolveEnvApiKey(provider, params.env, {
       config: params.cfg,
       workspaceDir: params.workspaceDir,
-      aliasMap: params.envAuthLookup?.aliasMap,
-      candidateMap: params.envAuthLookup?.candidateMap,
-      authEvidenceMap: params.envAuthLookup?.authEvidenceMap,
+      ...params.runtimeLookup?.envApiKey,
     })
   ) {
     return true;
@@ -383,6 +453,11 @@ export function hasRuntimeAvailableProviderAuth(params: {
   }
   if (
     params.allowPluginSyntheticAuth !== false &&
+    shouldResolvePluginSyntheticAuth({
+      cfg: params.cfg,
+      provider,
+      runtimeLookup: params.runtimeLookup,
+    }) &&
     resolveSyntheticLocalProviderAuth({ cfg: params.cfg, provider })
   ) {
     return true;

--- a/src/agents/model-provider-auth.test.ts
+++ b/src/agents/model-provider-auth.test.ts
@@ -7,24 +7,23 @@ const modelCatalogMocks = vi.hoisted(() => ({
 }));
 
 const modelAuthMocks = vi.hoisted(() => ({
+  createRuntimeProviderAuthLookup: vi.fn(() => ({
+    envApiKey: {
+      aliasMap: {},
+      candidateMap: {},
+      authEvidenceMap: {},
+    },
+    syntheticAuthProviderRefs: [],
+  })),
   hasRuntimeAvailableProviderAuth:
     vi.fn<
       (params: {
         provider: string;
         cfg?: OpenClawConfig;
         workspaceDir?: string;
-        envAuthLookup?: unknown;
+        runtimeLookup?: unknown;
       }) => boolean
     >(),
-}));
-
-const providerAuthAliasMocks = vi.hoisted(() => ({
-  resolveProviderAuthAliasMap: vi.fn(() => ({ openai: "openai" })),
-}));
-
-const modelAuthEnvVarMocks = vi.hoisted(() => ({
-  resolveProviderEnvApiKeyCandidates: vi.fn(() => ({ openai: ["OPENAI_API_KEY"] })),
-  resolveProviderEnvAuthEvidence: vi.fn(() => ({})),
 }));
 
 const authProfilesMocks = vi.hoisted(() => ({
@@ -40,16 +39,8 @@ vi.mock("./model-catalog.js", () => ({
 }));
 
 vi.mock("./model-auth.js", () => ({
+  createRuntimeProviderAuthLookup: modelAuthMocks.createRuntimeProviderAuthLookup,
   hasRuntimeAvailableProviderAuth: modelAuthMocks.hasRuntimeAvailableProviderAuth,
-}));
-
-vi.mock("./provider-auth-aliases.js", () => ({
-  resolveProviderAuthAliasMap: providerAuthAliasMocks.resolveProviderAuthAliasMap,
-}));
-
-vi.mock("./model-auth-env-vars.js", () => ({
-  resolveProviderEnvApiKeyCandidates: modelAuthEnvVarMocks.resolveProviderEnvApiKeyCandidates,
-  resolveProviderEnvAuthEvidence: modelAuthEnvVarMocks.resolveProviderEnvAuthEvidence,
 }));
 
 vi.mock("./auth-profiles.js", () => ({
@@ -81,7 +72,7 @@ describe("prepared provider auth state", () => {
     vi.clearAllMocks();
   });
 
-  it("reuses prepared env auth lookup data while warming providers", async () => {
+  it("reuses prepared runtime auth lookup data while warming providers", async () => {
     const cfg = {} as OpenClawConfig;
     modelCatalogMocks.loadModelCatalog.mockResolvedValue([
       { id: "gpt", name: "gpt", provider: "openai" },
@@ -91,13 +82,11 @@ describe("prepared provider auth state", () => {
 
     await warmCurrentProviderAuthState(cfg);
 
-    expect(providerAuthAliasMocks.resolveProviderAuthAliasMap).toHaveBeenCalledTimes(1);
-    expect(modelAuthEnvVarMocks.resolveProviderEnvApiKeyCandidates).toHaveBeenCalledTimes(1);
-    expect(modelAuthEnvVarMocks.resolveProviderEnvAuthEvidence).toHaveBeenCalledTimes(1);
+    expect(modelAuthMocks.createRuntimeProviderAuthLookup).toHaveBeenCalledTimes(1);
     const firstLookup =
-      modelAuthMocks.hasRuntimeAvailableProviderAuth.mock.calls[0]?.[0].envAuthLookup;
+      modelAuthMocks.hasRuntimeAvailableProviderAuth.mock.calls[0]?.[0].runtimeLookup;
     const secondLookup =
-      modelAuthMocks.hasRuntimeAvailableProviderAuth.mock.calls[1]?.[0].envAuthLookup;
+      modelAuthMocks.hasRuntimeAvailableProviderAuth.mock.calls[1]?.[0].runtimeLookup;
     expect(firstLookup).toBe(secondLookup);
   });
 

--- a/src/agents/model-provider-auth.ts
+++ b/src/agents/model-provider-auth.ts
@@ -1,6 +1,5 @@
 import { hashRuntimeConfigValue } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { ProviderAuthEvidence } from "../secrets/provider-env-vars.js";
 import {
   listAgentIds,
   resolveAgentDir,
@@ -16,13 +15,12 @@ import {
   type AuthProfileStore,
 } from "./auth-profiles.js";
 import {
-  resolveProviderEnvApiKeyCandidates,
-  resolveProviderEnvAuthEvidence,
-} from "./model-auth-env-vars.js";
-import { hasRuntimeAvailableProviderAuth } from "./model-auth.js";
+  createRuntimeProviderAuthLookup,
+  hasRuntimeAvailableProviderAuth,
+  type RuntimeProviderAuthLookup,
+} from "./model-auth.js";
 import { loadModelCatalog } from "./model-catalog.js";
 import { normalizeProviderId } from "./model-selection.js";
-import { resolveProviderAuthAliasMap } from "./provider-auth-aliases.js";
 import { resolveDefaultAgentWorkspaceDir } from "./workspace.js";
 
 // Prepared runtime fact: which providers have available auth given the
@@ -35,12 +33,6 @@ type PreparedProviderAuthState = {
   agentId: string;
   configFingerprint: string;
   providers: ReadonlyMap<string, boolean>;
-};
-
-type ProviderEnvAuthLookup = {
-  aliasMap?: Readonly<Record<string, string>>;
-  candidateMap?: Readonly<Record<string, readonly string[]>>;
-  authEvidenceMap?: Readonly<Record<string, readonly ProviderAuthEvidence[]>>;
 };
 
 // One entry per configured agent, keyed by agentId. Populated by
@@ -97,7 +89,8 @@ export async function hasAuthForModelProvider(params: {
   store?: AuthProfileStore;
   allowPluginSyntheticAuth?: boolean;
   discoverExternalCliAuth?: boolean;
-  envAuthLookup?: ProviderEnvAuthLookup;
+  runtimeAuthLookup?: RuntimeProviderAuthLookup;
+  resolveRuntimeAuthLookup?: () => RuntimeProviderAuthLookup;
 }): Promise<boolean> {
   const provider = normalizeProviderId(params.provider);
   // The prepared map is built by warmCurrentProviderAuthState — one entry per
@@ -144,7 +137,7 @@ export async function hasAuthForModelProvider(params: {
       workspaceDir: params.workspaceDir,
       env: params.env,
       allowPluginSyntheticAuth: params.allowPluginSyntheticAuth,
-      envAuthLookup: params.envAuthLookup,
+      runtimeLookup: params.runtimeAuthLookup ?? params.resolveRuntimeAuthLookup?.(),
     })
   ) {
     return true;
@@ -175,6 +168,7 @@ export function createProviderAuthChecker(params: {
   discoverExternalCliAuth?: boolean;
 }): (provider: string) => Promise<boolean> {
   const authCache = new Map<string, boolean>();
+  let runtimeAuthLookup: RuntimeProviderAuthLookup | undefined;
   return async (provider: string) => {
     const key = normalizeProviderId(provider);
     const cached = authCache.get(key);
@@ -189,6 +183,12 @@ export function createProviderAuthChecker(params: {
       env: params.env,
       allowPluginSyntheticAuth: params.allowPluginSyntheticAuth,
       discoverExternalCliAuth: params.discoverExternalCliAuth,
+      resolveRuntimeAuthLookup: () =>
+        (runtimeAuthLookup ??= createRuntimeProviderAuthLookup({
+          cfg: params.cfg,
+          workspaceDir: params.workspaceDir,
+          env: params.env,
+        })),
     });
     authCache.set(key, value);
     return value;
@@ -225,11 +225,10 @@ export async function warmCurrentProviderAuthState(
     }
     const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
     const agentDir = resolveAgentDir(cfg, agentId);
-    const envAuthLookup = {
-      aliasMap: resolveProviderAuthAliasMap({ config: cfg, workspaceDir }),
-      candidateMap: resolveProviderEnvApiKeyCandidates({ config: cfg, workspaceDir }),
-      authEvidenceMap: resolveProviderEnvAuthEvidence({ config: cfg, workspaceDir }),
-    };
+    const runtimeAuthLookup = createRuntimeProviderAuthLookup({
+      cfg,
+      workspaceDir,
+    });
     // One AuthProfileStore scoped to every candidate provider; without this
     // the per-provider externalCli discovery rebuilds the store ~N times.
     const store = ensureAuthProfileStore(agentDir, {
@@ -250,7 +249,7 @@ export async function warmCurrentProviderAuthState(
         workspaceDir,
         agentId,
         store,
-        envAuthLookup,
+        runtimeAuthLookup,
       });
       state.set(provider, value);
     }

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -81,6 +81,14 @@ vi.mock("../../agents/model-auth.js", () => {
   const hasWorkspaceCredential = (env: NodeJS.ProcessEnv = process.env) =>
     Boolean(env.WORKSPACE_MODEL_LIST_CREDENTIALS || env.WORKSPACE_MODEL_CREDENTIALS);
   return {
+    createRuntimeProviderAuthLookup: () => ({
+      envApiKey: {
+        aliasMap: {},
+        candidateMap: {},
+        authEvidenceMap: {},
+      },
+      syntheticAuthProviderRefs: [],
+    }),
     ensureAuthProfileStore: store,
     hasRuntimeAvailableProviderAuth: ({
       provider,

--- a/src/commands/model-picker.test.ts
+++ b/src/commands/model-picker.test.ts
@@ -83,7 +83,18 @@ const hasRuntimeAvailableProviderAuth = vi.hoisted(() =>
     },
   ),
 );
+const createRuntimeProviderAuthLookup = vi.hoisted(() =>
+  vi.fn(() => ({
+    envApiKey: {
+      aliasMap: {},
+      candidateMap: {},
+      authEvidenceMap: {},
+    },
+    syntheticAuthProviderRefs: [],
+  })),
+);
 vi.mock("../agents/model-auth.js", () => ({
+  createRuntimeProviderAuthLookup,
   resolveEnvApiKey,
   hasUsableCustomProviderApiKey,
   hasRuntimeAvailableProviderAuth,

--- a/src/plugins/synthetic-auth.runtime.test.ts
+++ b/src/plugins/synthetic-auth.runtime.test.ts
@@ -85,6 +85,34 @@ describe("synthetic auth runtime refs", () => {
     expect(pluginRegistryMocks.loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledWith({});
   });
 
+  it("loads manifest synthetic auth refs with the current runtime scope", () => {
+    const config = { plugins: { allow: ["external-local"] } };
+    const env = { OPENCLAW_HOME: "/tmp/openclaw-home" };
+    pluginRegistryMocks.loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+      source: "persisted",
+      snapshot: {
+        plugins: [{ syntheticAuthRefs: ["external-local"] }],
+      },
+      diagnostics: [],
+    });
+
+    expect(
+      resolveRuntimeSyntheticAuthProviderRefState({
+        config: config as never,
+        workspaceDir: "/tmp/workspace",
+        env,
+      }),
+    ).toEqual({
+      refs: ["external-local"],
+      complete: true,
+    });
+    expect(pluginRegistryMocks.loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledWith({
+      config,
+      workspaceDir: "/tmp/workspace",
+      env,
+    });
+  });
+
   it("uses persisted registry external auth provider refs before the runtime registry exists", () => {
     const snapshot = {
       plugins: [{ syntheticAuthRefs: [] }],

--- a/src/plugins/synthetic-auth.runtime.test.ts
+++ b/src/plugins/synthetic-auth.runtime.test.ts
@@ -46,6 +46,7 @@ vi.mock("./manifest-registry-installed.js", () => ({
 
 import {
   resolveRuntimeExternalAuthProviderRefs,
+  resolveRuntimeSyntheticAuthProviderRefState,
   resolveRuntimeSyntheticAuthProviderRefs,
 } from "./synthetic-auth.runtime.js";
 
@@ -122,6 +123,10 @@ describe("synthetic auth runtime refs", () => {
     });
 
     expect(resolveRuntimeSyntheticAuthProviderRefs()).toStrictEqual([]);
+    expect(resolveRuntimeSyntheticAuthProviderRefState()).toStrictEqual({
+      refs: [],
+      complete: false,
+    });
   });
 
   it("does not derive the registry just to resolve external auth refs", () => {
@@ -193,6 +198,7 @@ describe("synthetic auth runtime refs", () => {
         ],
         plugins: [
           {
+            syntheticAuthRefs: ["manifest-provider"],
             contracts: {
               externalAuthProviders: ["manifest-provider"],
             },
@@ -201,7 +207,15 @@ describe("synthetic auth runtime refs", () => {
       },
     });
 
-    expect(resolveRuntimeSyntheticAuthProviderRefs()).toEqual(["runtime-provider", "runtime-cli"]);
+    expect(resolveRuntimeSyntheticAuthProviderRefs()).toEqual([
+      "manifest-provider",
+      "runtime-provider",
+      "runtime-cli",
+    ]);
+    expect(resolveRuntimeSyntheticAuthProviderRefState()).toEqual({
+      refs: ["manifest-provider", "runtime-provider", "runtime-cli"],
+      complete: true,
+    });
     expect(pluginRegistryMocks.loadPluginRegistrySnapshotWithMetadata).not.toHaveBeenCalled();
   });
 

--- a/src/plugins/synthetic-auth.runtime.ts
+++ b/src/plugins/synthetic-auth.runtime.ts
@@ -19,22 +19,25 @@ function uniqueProviderRefs(values: readonly string[]): string[] {
   return next;
 }
 
-function resolveManifestSyntheticAuthProviderRefs(
+function resolveManifestSyntheticAuthProviderRefState(
   params: {
     index?: PluginRegistrySnapshot;
     registryDiagnostics?: readonly unknown[];
   } = {},
-): string[] {
+): { refs: string[]; complete: boolean } {
   if (params.index && (params.registryDiagnostics?.length ?? 0) > 0) {
-    return [];
+    return { refs: [], complete: false };
   }
   const result = loadPluginRegistrySnapshotWithMetadata({ index: params.index });
   if (result.source !== "persisted" && result.source !== "provided") {
-    return [];
+    return { refs: [], complete: false };
   }
-  return uniqueProviderRefs(
-    result.snapshot.plugins.flatMap((plugin) => plugin.syntheticAuthRefs ?? []),
-  );
+  return {
+    refs: uniqueProviderRefs(
+      result.snapshot.plugins.flatMap((plugin) => plugin.syntheticAuthRefs ?? []),
+    ),
+    complete: true,
+  };
 }
 
 function resolveManifestExternalAuthProviderRefs(
@@ -64,26 +67,39 @@ export function resolveRuntimeSyntheticAuthProviderRefs(
     registryDiagnostics?: readonly unknown[];
   } = {},
 ): string[] {
+  return resolveRuntimeSyntheticAuthProviderRefState(params).refs;
+}
+
+export function resolveRuntimeSyntheticAuthProviderRefState(
+  params: {
+    index?: PluginRegistrySnapshot;
+    registryDiagnostics?: readonly unknown[];
+  } = {},
+): { refs: string[]; complete: boolean } {
   const registry = getPluginRegistryState()?.activeRegistry;
   if (registry) {
-    return uniqueProviderRefs([
-      ...(registry.providers ?? [])
-        .filter(
-          (entry) =>
-            "resolveSyntheticAuth" in entry.provider &&
-            typeof entry.provider.resolveSyntheticAuth === "function",
-        )
-        .map((entry) => entry.provider.id),
-      ...(registry.cliBackends ?? [])
-        .filter(
-          (entry) =>
-            "resolveSyntheticAuth" in entry.backend &&
-            typeof entry.backend.resolveSyntheticAuth === "function",
-        )
-        .map((entry) => entry.backend.id),
-    ]);
+    return {
+      refs: uniqueProviderRefs([
+        ...registry.plugins.flatMap((plugin) => plugin.syntheticAuthRefs ?? []),
+        ...(registry.providers ?? [])
+          .filter(
+            (entry) =>
+              "resolveSyntheticAuth" in entry.provider &&
+              typeof entry.provider.resolveSyntheticAuth === "function",
+          )
+          .map((entry) => entry.provider.id),
+        ...(registry.cliBackends ?? [])
+          .filter(
+            (entry) =>
+              "resolveSyntheticAuth" in entry.backend &&
+              typeof entry.backend.resolveSyntheticAuth === "function",
+          )
+          .map((entry) => entry.backend.id),
+      ]),
+      complete: true,
+    };
   }
-  return resolveManifestSyntheticAuthProviderRefs({
+  return resolveManifestSyntheticAuthProviderRefState({
     index: params.index,
     registryDiagnostics: params.registryDiagnostics,
   });

--- a/src/plugins/synthetic-auth.runtime.ts
+++ b/src/plugins/synthetic-auth.runtime.ts
@@ -1,7 +1,7 @@
 import { normalizeProviderId } from "../agents/provider-id.js";
 import { loadPluginManifestRegistryForInstalledIndex } from "./manifest-registry-installed.js";
 import { loadPluginRegistrySnapshotWithMetadata } from "./plugin-registry.js";
-import type { PluginRegistrySnapshot } from "./plugin-registry.js";
+import type { LoadPluginRegistryParams, PluginRegistrySnapshot } from "./plugin-registry.js";
 import { getPluginRegistryState } from "./runtime-state.js";
 
 function uniqueProviderRefs(values: readonly string[]): string[] {
@@ -20,15 +20,12 @@ function uniqueProviderRefs(values: readonly string[]): string[] {
 }
 
 function resolveManifestSyntheticAuthProviderRefState(
-  params: {
-    index?: PluginRegistrySnapshot;
-    registryDiagnostics?: readonly unknown[];
-  } = {},
+  params: SyntheticAuthProviderRefParams = {},
 ): { refs: string[]; complete: boolean } {
   if (params.index && (params.registryDiagnostics?.length ?? 0) > 0) {
     return { refs: [], complete: false };
   }
-  const result = loadPluginRegistrySnapshotWithMetadata({ index: params.index });
+  const result = loadPluginRegistrySnapshotWithMetadata(params);
   if (result.source !== "persisted" && result.source !== "provided") {
     return { refs: [], complete: false };
   }
@@ -40,16 +37,18 @@ function resolveManifestSyntheticAuthProviderRefState(
   };
 }
 
+type SyntheticAuthProviderRefParams = LoadPluginRegistryParams & {
+  index?: PluginRegistrySnapshot;
+  registryDiagnostics?: readonly unknown[];
+};
+
 function resolveManifestExternalAuthProviderRefs(
-  params: {
-    index?: PluginRegistrySnapshot;
-    registryDiagnostics?: readonly unknown[];
-  } = {},
+  params: SyntheticAuthProviderRefParams = {},
 ): string[] {
   if (params.index && (params.registryDiagnostics?.length ?? 0) > 0) {
     return [];
   }
-  const result = loadPluginRegistrySnapshotWithMetadata({ index: params.index });
+  const result = loadPluginRegistrySnapshotWithMetadata(params);
   if (result.source !== "persisted" && result.source !== "provided") {
     return [];
   }
@@ -62,19 +61,13 @@ function resolveManifestExternalAuthProviderRefs(
 }
 
 export function resolveRuntimeSyntheticAuthProviderRefs(
-  params: {
-    index?: PluginRegistrySnapshot;
-    registryDiagnostics?: readonly unknown[];
-  } = {},
+  params: SyntheticAuthProviderRefParams = {},
 ): string[] {
   return resolveRuntimeSyntheticAuthProviderRefState(params).refs;
 }
 
 export function resolveRuntimeSyntheticAuthProviderRefState(
-  params: {
-    index?: PluginRegistrySnapshot;
-    registryDiagnostics?: readonly unknown[];
-  } = {},
+  params: SyntheticAuthProviderRefParams = {},
 ): { refs: string[]; complete: boolean } {
   const registry = getPluginRegistryState()?.activeRegistry;
   if (registry) {
@@ -99,17 +92,11 @@ export function resolveRuntimeSyntheticAuthProviderRefState(
       complete: true,
     };
   }
-  return resolveManifestSyntheticAuthProviderRefState({
-    index: params.index,
-    registryDiagnostics: params.registryDiagnostics,
-  });
+  return resolveManifestSyntheticAuthProviderRefState(params);
 }
 
 export function resolveRuntimeExternalAuthProviderRefs(
-  params: {
-    index?: PluginRegistrySnapshot;
-    registryDiagnostics?: readonly unknown[];
-  } = {},
+  params: SyntheticAuthProviderRefParams = {},
 ): string[] {
   const registry = getPluginRegistryState()?.activeRegistry;
   if (registry) {
@@ -135,8 +122,5 @@ export function resolveRuntimeExternalAuthProviderRefs(
         .map((entry) => entry.backend.id),
     ]);
   }
-  return resolveManifestExternalAuthProviderRefs({
-    index: params.index,
-    registryDiagnostics: params.registryDiagnostics,
-  });
+  return resolveManifestExternalAuthProviderRefs(params);
 }


### PR DESCRIPTION
before:

<img width="1031" height="177" alt="image" src="https://github.com/user-attachments/assets/4b433f1c-3235-4ace-a2ef-d625880553c4" />

after:

<img width="1013" height="200" alt="image" src="https://github.com/user-attachments/assets/e8943462-08ec-4c36-888d-25a13a3d79b0" />

Summary
- Reuse prepared provider auth lookup facts across gateway/model-listing provider auth checks.
- Avoid broad plugin/runtime discovery for providers that cannot have synthetic auth, while preserving fallback behavior when metadata is incomplete or a configured provider may own synthetic local auth.
- Declare LM Studio synthetic auth metadata so the lightweight manifest path matches its existing runtime hook.

Verification
- `node scripts/run-vitest.mjs src/agents/model-provider-auth.test.ts src/agents/model-auth.test.ts src/agents/model-auth.profiles.test.ts src/plugins/provider-runtime.synthetic-auth-discovery.test.ts src/plugins/synthetic-auth.runtime.test.ts src/plugins/bundled-plugin-metadata.test.ts extensions/lmstudio/index.test.ts`
- `pnpm tsgo:core`
- `git diff --check`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local`

Real behavior proof
Behavior addressed: Gateway/model-listing auth checks no longer repeatedly rediscover broad provider plugin/runtime metadata for providers that cannot satisfy plugin-owned synthetic auth.
Real environment tested: Local macOS source checkout.
Exact steps or command run after this patch: The focused Vitest command, `pnpm tsgo:core`, `git diff --check`, and autoreview command listed above.
Evidence after fix: Focused tests passed: 10 files, 281 tests. Typecheck and diff check passed. Autoreview reported no accepted/actionable findings.
Observed result after fix: Provider auth lookup facts are prepared once per checker/warm scope and reused through the loop while synthetic-auth fallback remains available when metadata is incomplete.
What was not tested: A live gateway CPU repro/profile was not rerun after the patch.
