### PR TITLE
Recover stuck Codex compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ Docs: https://docs.openclaw.ai
 
 - Gateway/agents: preserve fresh session overrides and metadata when stale cached agent-session entries race with store updates, so subagent model/provider overrides and routing policy survive concurrent writes. (#19328) Thanks @CodeReclaimers.
 - Control UI/chat: keep chat session search inline with the session selector so the header no longer shows a duplicate standalone search row.
-- Codex app-server: restart the native app-server and retry once when server-side compaction times out, so preflight compaction stalls recover instead of failing every dispatch.
+- Codex app-server: restart the native app-server and retry once when server-side compaction times out, so preflight compaction stalls recover instead of failing every dispatch. (#85500)
 - Restore Control UI gateway token pairing [AI]. (#85459) Thanks @pgondhi987.
 - CLI/update: repair managed npm plugin `openclaw` peer links during post-core convergence and reject stale or wrong-target peer links before restart. (#83794) Thanks @fuller-stack-dev.
 - CLI/agents: default new omitted-account bindings to all accounts when the channel has multiple configured accounts, and clarify account-scope docs. (#49769) Thanks @Gcaufy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Docs: https://docs.openclaw.ai
 
 - Gateway/agents: preserve fresh session overrides and metadata when stale cached agent-session entries race with store updates, so subagent model/provider overrides and routing policy survive concurrent writes. (#19328) Thanks @CodeReclaimers.
 - Control UI/chat: keep chat session search inline with the session selector so the header no longer shows a duplicate standalone search row.
+- Codex app-server: restart the native app-server and retry once when server-side compaction times out, so preflight compaction stalls recover instead of failing every dispatch.
 - Restore Control UI gateway token pairing [AI]. (#85459) Thanks @pgondhi987.
 - CLI/update: repair managed npm plugin `openclaw` peer links during post-core convergence and reject stale or wrong-target peer links before restart. (#83794) Thanks @fuller-stack-dev.
 - CLI/agents: default new omitted-account bindings to all accounts when the channel has multiple configured accounts, and clarify account-scope docs. (#49769) Thanks @Gcaufy.

--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -330,6 +330,89 @@ describe("maybeCompactCodexAppServerSession", () => {
     expect(result.result).toBeUndefined();
   });
 
+  it("restarts the Codex app-server and retries when native compaction times out", async () => {
+    const previousTimeout = process.env.OPENCLAW_CODEX_COMPACTION_WAIT_TIMEOUT_MS;
+    process.env.OPENCLAW_CODEX_COMPACTION_WAIT_TIMEOUT_MS = "100";
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    try {
+      const first = createFakeCodexClient();
+      const second = createFakeCodexClient();
+      let factoryCalls = 0;
+      const factory = vi.fn(async () => {
+        factoryCalls += 1;
+        if (factoryCalls === 1) {
+          return first.client;
+        }
+        return second.client;
+      });
+      setCodexAppServerClientFactoryForTest(factory);
+      const sessionFile = await writeTestBinding();
+
+      const pendingResult = startCompaction(sessionFile, { currentTokenCount: 456 });
+      await vi.waitFor(() => {
+        expect(first.request).toHaveBeenCalledWith("thread/compact/start", {
+          threadId: "thread-1",
+        });
+      });
+
+      await vi.waitFor(() => {
+        expect(first.close).toHaveBeenCalledTimes(1);
+        expect(second.request).toHaveBeenCalledWith("thread/compact/start", {
+          threadId: "thread-1",
+        });
+      });
+      second.emit({
+        method: "thread/tokenUsage/updated",
+        params: {
+          threadId: "thread-1",
+          tokenUsage: {
+            last_token_usage: {
+              total_tokens: 12_345,
+            },
+          },
+        },
+      });
+      second.emit({
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-2",
+          item: { type: "contextCompaction", id: "compact-2" },
+        },
+      });
+
+      const result = requireCompactResult(await pendingResult);
+      expect(result.ok).toBe(true);
+      expect(result.compacted).toBe(true);
+      expect(result.result?.tokensAfter).toBe(12_345);
+      expect(factory).toHaveBeenCalledTimes(2);
+      expect(second.close).not.toHaveBeenCalled();
+      expect(await readCodexAppServerBinding(sessionFile)).toBeDefined();
+      const details = compactDetails(result);
+      expect(details.signal).toBe("item/completed");
+      expect(details.itemId).toBe("compact-2");
+      expect(details.compactionAttempts).toBe(2);
+      expect(details.recoveredAfterAppServerRestart).toBe(true);
+      expect(warn).toHaveBeenCalledWith(
+        "codex app-server compaction timed out; restarting app-server",
+        expect.objectContaining({
+          sessionId: "session-1",
+          sessionKey: "agent:main:session-1",
+          threadId: "thread-1",
+          attempt: 1,
+          maxAttempts: 2,
+        }),
+      );
+    } finally {
+      if (previousTimeout === undefined) {
+        delete process.env.OPENCLAW_CODEX_COMPACTION_WAIT_TIMEOUT_MS;
+      } else {
+        process.env.OPENCLAW_CODEX_COMPACTION_WAIT_TIMEOUT_MS = previousTimeout;
+      }
+      warn.mockRestore();
+    }
+  });
+
   it("warns when stale OpenClaw compaction overrides are ignored", async () => {
     const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
     const fake = createFakeCodexClient();
@@ -1007,19 +1090,23 @@ describe("maybeCompactCodexAppServerSession", () => {
 function createFakeCodexClient(): {
   client: CodexAppServerClient;
   request: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
   emit: (notification: CodexServerNotification) => void;
 } {
   const handlers = new Set<(notification: CodexServerNotification) => void>();
   const request = vi.fn(async () => ({}));
+  const close = vi.fn();
   return {
     client: {
       request,
+      close,
       addNotificationHandler(handler: (notification: CodexServerNotification) => void) {
         handlers.add(handler);
         return () => handlers.delete(handler);
       },
     } as unknown as CodexAppServerClient,
     request,
+    close,
     emit(notification: CodexServerNotification): void {
       for (const handler of handlers) {
         handler(notification);

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -32,7 +32,14 @@ type CodexNativeCompactionWaiter = {
 
 const DEFAULT_CODEX_COMPACTION_WAIT_TIMEOUT_MS = 5 * 60 * 1000;
 const CODEX_COMPACTION_TOKEN_USAGE_GRACE_MS = 250;
+const MAX_CODEX_NATIVE_COMPACTION_ATTEMPTS = 2;
 const warnedIgnoredCompactionOverrides = new Set<string>();
+
+class CodexNativeCompactionTimeoutError extends Error {
+  constructor(readonly threadId: string) {
+    super(`timed out waiting for codex app-server compaction for ${threadId}`);
+  }
+}
 
 export async function maybeCompactCodexAppServerSession(
   params: CompactEmbeddedPiSessionParams,
@@ -354,38 +361,70 @@ async function compactCodexNativeThread(
   }
 
   const clientFactory = options.clientFactory ?? defaultCodexAppServerClientFactory;
-  const client = await clientFactory(
-    appServer.start,
-    requestedAuthProfileId ?? binding.authProfileId,
-    params.agentDir,
-    params.config,
-  );
-  const waiter = createCodexNativeCompactionWaiter(client, binding.threadId);
-  let completion: CodexNativeCompactionCompletion;
-  try {
-    await client.request("thread/compact/start", {
-      threadId: binding.threadId,
-    });
-    embeddedAgentLog.info("started codex app-server compaction", {
-      sessionId: params.sessionId,
-      threadId: binding.threadId,
-    });
-    waiter.startTimeout();
-    completion = await waiter.promise;
-  } catch (error) {
-    waiter.cancel();
-    if (isCodexThreadNotFoundError(error)) {
-      await clearCodexAppServerBinding(params.sessionFile, { config: params.config });
-      return failedCodexThreadBindingCompactionResult(params, {
+  let completion: CodexNativeCompactionCompletion | undefined;
+  let attempt = 0;
+  for (attempt = 1; attempt <= MAX_CODEX_NATIVE_COMPACTION_ATTEMPTS; attempt += 1) {
+    const client = await clientFactory(
+      appServer.start,
+      requestedAuthProfileId ?? binding.authProfileId,
+      params.agentDir,
+      params.config,
+    );
+    const waiter = createCodexNativeCompactionWaiter(client, binding.threadId);
+    try {
+      await client.request("thread/compact/start", {
         threadId: binding.threadId,
-        reason: formatCompactionError(error),
-        recovery: "stale_thread_binding",
       });
+      embeddedAgentLog.info("started codex app-server compaction", {
+        sessionId: params.sessionId,
+        threadId: binding.threadId,
+        attempt,
+      });
+      waiter.startTimeout();
+      completion = await waiter.promise;
+      break;
+    } catch (error) {
+      waiter.cancel();
+      if (isCodexThreadNotFoundError(error)) {
+        await clearCodexAppServerBinding(params.sessionFile, { config: params.config });
+        return failedCodexThreadBindingCompactionResult(params, {
+          threadId: binding.threadId,
+          reason: formatCompactionError(error),
+          recovery: "stale_thread_binding",
+        });
+      }
+      if (
+        isCodexNativeCompactionTimeoutError(error, binding.threadId) &&
+        attempt < MAX_CODEX_NATIVE_COMPACTION_ATTEMPTS
+      ) {
+        restartCodexAppServerAfterNativeCompactionTimeout(
+          client,
+          params,
+          binding.threadId,
+          attempt,
+        );
+        continue;
+      }
+      if (isCodexNativeCompactionTimeoutError(error, binding.threadId)) {
+        restartCodexAppServerAfterNativeCompactionTimeout(
+          client,
+          params,
+          binding.threadId,
+          attempt,
+        );
+      }
+      return {
+        ok: false,
+        compacted: false,
+        reason: formatCompactionError(error),
+      };
     }
+  }
+  if (!completion) {
     return {
       ok: false,
       compacted: false,
-      reason: formatCompactionError(error),
+      reason: `codex app-server compaction did not complete for ${binding.threadId}`,
     };
   }
   embeddedAgentLog.info("completed codex app-server compaction", {
@@ -409,6 +448,10 @@ async function compactCodexNativeThread(
   }
   if (completion.tokensAfter !== undefined) {
     resultDetails.tokenUsageSource = "thread/tokenUsage/updated";
+  }
+  if (attempt > 1) {
+    resultDetails.compactionAttempts = attempt;
+    resultDetails.recoveredAfterAppServerRestart = true;
   }
   return {
     ok: true,
@@ -451,6 +494,26 @@ function failedCodexThreadBindingCompactionResult(
 
 function isCodexThreadNotFoundError(error: unknown): boolean {
   return formatCompactionError(error).toLowerCase().includes("thread not found");
+}
+
+function isCodexNativeCompactionTimeoutError(error: unknown, threadId: string): boolean {
+  return error instanceof CodexNativeCompactionTimeoutError && error.threadId === threadId;
+}
+
+function restartCodexAppServerAfterNativeCompactionTimeout(
+  client: CodexAppServerClient,
+  params: CompactEmbeddedPiSessionParams,
+  threadId: string,
+  attempt: number,
+): void {
+  embeddedAgentLog.warn("codex app-server compaction timed out; restarting app-server", {
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    threadId,
+    attempt,
+    maxAttempts: MAX_CODEX_NATIVE_COMPACTION_ATTEMPTS,
+  });
+  client.close();
 }
 
 function createCodexNativeCompactionWaiter(
@@ -544,7 +607,7 @@ function createCodexNativeCompactionWaiter(
         return;
       }
       timeout = setTimeout(() => {
-        failWaiter(new Error(`timed out waiting for codex app-server compaction for ${threadId}`));
+        failWaiter(new CodexNativeCompactionTimeoutError(threadId));
       }, resolveCompactionWaitTimeoutMs());
       timeout.unref?.();
     },


### PR DESCRIPTION
## Summary

- Restart the shared Codex app-server client when native server-side compaction times out.
- Retry native compaction once on the fresh app-server while preserving stale-thread cleanup only for `thread not found`.
- Add regression coverage and changelog entry for the preflight compaction recovery path.

## Verification

- `pnpm test extensions/codex/src/app-server/compact.test.ts`
- `env -u OPENCLAW_TESTBOX -u OPENCLAW_TESTBOX_REMOTE_RUN pnpm check:changed`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean: no accepted/actionable findings reported

## Real behavior proof

Behavior addressed: Discord/OpenClaw sessions whose Codex app-server preflight compaction starts but never emits completion now recover by restarting the app-server and retrying once instead of failing every dispatch with a compaction timeout.
Real environment tested: Local OpenClaw checkout on Node 24/pnpm 11, with the Codex extension test project and changed-file gate.
Exact steps or command run after this patch: `pnpm test extensions/codex/src/app-server/compact.test.ts`; `env -u OPENCLAW_TESTBOX -u OPENCLAW_TESTBOX_REMOTE_RUN pnpm check:changed`.
Evidence after fix: Added regression test simulates a hung first Codex app-server client, verifies it is closed, then verifies the second client completes compaction and records recovery details.
Observed result after fix: Focused test passed 25/25; changed gate passed typecheck, lint, changelog attribution, boundary, duplicate, dependency, sidecar, and import-cycle checks.
What was not tested: Live Discord dispatch against a real stuck Codex app-server thread; Testbox changed-gate attempt failed before checks because the Blacksmith image had a missing pnpm global module, so validation was rerun locally with Testbox env unset.
