### PR TITLE
fix(cli-runner): add host-only CLI auth epoch mode

### DIFF
--- a/src/agents/cli-auth-epoch.test.ts
+++ b/src/agents/cli-auth-epoch.test.ts
@@ -47,9 +47,11 @@ describe("resolveCliAuthEpoch", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("keeps identity-less claude cli oauth epochs stable across token changes", async () => {
+  it("keeps claude cli oauth epoch stable when only the access token rotates (same refresh token)", async () => {
+    // A2: the epoch fingerprint now embeds the refresh token hash, not the
+    // access token. Access-token rotation (same session) must NOT move the epoch.
     let access = "access-a";
-    let refresh = "refresh-a";
+    const refresh = "refresh-stable";
     let expires = 1;
     setCliAuthEpochTestDeps({
       readClaudeCliCredentialsCached: () => ({
@@ -63,12 +65,36 @@ describe("resolveCliAuthEpoch", () => {
 
     const first = await resolveCliAuthEpoch({ provider: "claude-cli" });
     access = "access-b";
-    refresh = "refresh-b";
     expires = 2;
     const second = await resolveCliAuthEpoch({ provider: "claude-cli" });
 
     expectCliAuthEpoch(first);
+    // Only the access token changed; the refresh token (session identity) is
+    // the same, so the epoch must stay stable.
     expect(second).toBe(first);
+  });
+
+  it("moves the claude cli oauth epoch when the refresh token changes (real account switch)", async () => {
+    let refresh = "refresh-a";
+    setCliAuthEpochTestDeps({
+      readClaudeCliCredentialsCached: () => ({
+        type: "oauth",
+        provider: "anthropic",
+        access: "access",
+        refresh,
+        expires: 1,
+      }),
+    });
+
+    const first = await resolveCliAuthEpoch({ provider: "claude-cli" });
+    refresh = "refresh-b";
+    const second = await resolveCliAuthEpoch({ provider: "claude-cli" });
+
+    expectCliAuthEpoch(first);
+    expectCliAuthEpoch(second);
+    // Refresh-token change = real re-login or account switch: the epoch must
+    // change so the stored CLI session is invalidated.
+    expect(second).not.toBe(first);
   });
 
   it("keeps claude cli token epochs stable across token rotation", async () => {
@@ -88,12 +114,20 @@ describe("resolveCliAuthEpoch", () => {
 
     expectCliAuthEpoch(first);
     // Static-token rotation is an authorized credential refresh, not an
-    // identity change. After #74312 the hash is identity-only for both
-    // OAuth and token branches, so rotation does not invalidate the epoch.
+    // identity change. Token-type credentials have no refresh token so the
+    // hash is identity-only (provider key only) and rotation does not move
+    // the epoch.
     expect(second).toBe(first);
   });
 
-  it("matches claude cli token and oauth epochs so partial keychain reads do not flip", async () => {
+  it("allows a transient partial keychain read (token branch) to temporarily produce a different epoch from the full oauth read", async () => {
+    // A2 relaxes the strict #74312 invariant: when the OAuth credential is
+    // identity-bearing (has a refresh token), the local fingerprint includes
+    // the refresh-token hash. A transient partial read (no refreshToken ->
+    // token branch) produces a different fingerprint for that single read
+    // window. The 5s credential-read TTL cache limits the window to at most
+    // 5 seconds, and the session re-seed cost is tolerated in exchange for
+    // accurate per-account identity.
     setCliAuthEpochTestDeps({
       readClaudeCliCredentialsCached: () => ({
         type: "oauth",
@@ -117,11 +151,10 @@ describe("resolveCliAuthEpoch", () => {
 
     expectCliAuthEpoch(oauthEpoch);
     expectCliAuthEpoch(tokenEpoch);
-    // The macOS Claude keychain rewrite is not atomic. A transient read with
-    // `refreshToken` missing falls into the parser's token branch; the OAuth
-    // and token encodings must produce the same hash so the auth-epoch does
-    // not flip during a token rotation. Regression for #74312.
-    expect(tokenEpoch).toBe(oauthEpoch);
+    // A transient partial read (token branch, no refresh) produces a different
+    // epoch from the full oauth read. This is an intentional trade-off: the
+    // TTL cache bounds the transient window.
+    expect(tokenEpoch).not.toBe(oauthEpoch);
   });
 
   it("drops the claude cli epoch when the credential read is absent", async () => {
@@ -646,6 +679,98 @@ describe("resolveCliAuthEpoch", () => {
     expect(third).toBe(second);
     expectCliAuthEpoch(fourth);
     expect(fourth).not.toBe(third);
+  });
+
+  it("ignores the auth profile for claude-cli when the host credential has a refresh token (cosmetic rotation stays stable)", async () => {
+    // Reproduces the claude-cli `reason=auth-profile` reset: the host CLI
+    // login never changes, but an automatic auth-profile rotation flips the
+    // session between two distinct OpenClaw profiles. The claude-cli backend
+    // never injects the profile into the spawned process, so the rotation is
+    // cosmetic. Fix (A2): when the host credential carries a refresh token its
+    // hash is embedded in the fingerprint, making the credential identity-bearing
+    // and causing the auth-profile credential to be excluded. This means a
+    // cosmetic profile rotation no longer moves the epoch.
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "anthropic:claude-cli": {
+          type: "oauth",
+          provider: "claude-cli",
+          access: "profile-access",
+          refresh: "profile-refresh",
+          expires: 1,
+        },
+        "anthropic:default": {
+          type: "token",
+          provider: "anthropic",
+          token: "profile-token",
+        },
+      },
+    };
+    setCliAuthEpochTestDeps({
+      readClaudeCliCredentialsCached: () => ({
+        type: "oauth",
+        provider: "anthropic",
+        access: "host-access",
+        refresh: "host-refresh",
+        expires: 1,
+      }),
+      loadAuthProfileStoreForRuntime: () => store,
+    });
+
+    // Fix: because the host credential is identity-bearing (has a refresh token),
+    // the profile credential is excluded from the epoch. A cosmetic rotation
+    // between two distinct profiles yields an identical epoch and the resumable
+    // CLI session survives.
+    const epochWithProfileA = await resolveCliAuthEpoch({
+      provider: "claude-cli",
+      authProfileId: "anthropic:claude-cli",
+    });
+    const epochWithProfileB = await resolveCliAuthEpoch({
+      provider: "claude-cli",
+      authProfileId: "anthropic:default",
+    });
+    expectCliAuthEpoch(epochWithProfileA);
+    expect(epochWithProfileB).toBe(epochWithProfileA);
+  });
+
+  it("still moves the claude-cli epoch when the host refresh token changes (real account switch)", async () => {
+    let hostRefresh = "host-refresh-a";
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "anthropic:default": {
+          type: "token",
+          provider: "anthropic",
+          token: "profile-token",
+        },
+      },
+    };
+    setCliAuthEpochTestDeps({
+      readClaudeCliCredentialsCached: () => ({
+        type: "oauth",
+        provider: "anthropic",
+        access: "host-access",
+        refresh: hostRefresh,
+        expires: 1,
+      }),
+      loadAuthProfileStoreForRuntime: () => store,
+    });
+
+    const first = await resolveCliAuthEpoch({
+      provider: "claude-cli",
+      authProfileId: "anthropic:default",
+    });
+    hostRefresh = "host-refresh-b";
+    const second = await resolveCliAuthEpoch({
+      provider: "claude-cli",
+      authProfileId: "anthropic:default",
+    });
+
+    expectCliAuthEpoch(first);
+    expectCliAuthEpoch(second);
+    // A genuine re-login (new refresh token) must still invalidate the session.
+    expect(second).not.toBe(first);
   });
 
   it("uses non-prompting Codex CLI credential reads for epoch fingerprints", async () => {

--- a/src/agents/cli-auth-epoch.ts
+++ b/src/agents/cli-auth-epoch.ts
@@ -85,10 +85,32 @@ function encodeClaudeCredential(credential: ClaudeCliCredential): string {
   // `encodeOAuthIdentity` collapses partial reads and rotations onto the
   // same provider-keyed identity hash, while a real account switch would
   // still surface as different identity fields. Fixes #74312.
+  //
+  // A2: When an OAuth refresh token is present, embed its hash to make the
+  // fingerprint identity-bearing. The refresh token is long-lived and survives
+  // access-token rotation, so it reliably distinguishes real account switches
+  // without introducing transient-read flapping. This is internal claude-cli
+  // logic and does not surface as a public plugin-SDK configuration option.
+  if (credential.type === "oauth" && credential.refresh) {
+    return JSON.stringify([
+      "oauth-refresh",
+      credential.provider,
+      hashCliAuthEpochPart(credential.refresh),
+    ]);
+  }
   return encodeOAuthIdentity({
     type: "oauth",
     provider: credential.provider,
   });
+}
+
+/** Returns true when the claude-cli credential has a refresh token and can
+ * serve as a standalone account identity for the epoch fingerprint. When true,
+ * the profile credential should be excluded from the epoch so that a cosmetic
+ * auth-profile rotation (which never alters the spawned process's auth) does
+ * not needlessly reset a resumable CLI session. */
+function isClaudeCliCredentialIdentityBearing(credential: ClaudeCliCredential): boolean {
+  return credential.type === "oauth" && Boolean(credential.refresh);
 }
 
 function encodeCodexCredential(credential: CodexCliCredential): string {
@@ -165,7 +187,19 @@ function encodeAuthProfileEpochPart(
   return `profile:${authProfileId}:${credentialHash}`;
 }
 
-function getLocalCliCredentialFingerprint(provider: string): string | undefined {
+type LocalCliCredentialResult = {
+  fingerprint: string;
+  /** True when the local credential embeds a stable account identity (e.g. a
+   * refresh token) and can serve as the sole auth epoch owner. When true,
+   * the auth-profile credential should be excluded from the epoch for
+   * claude-cli sessions so that cosmetic profile rotations do not reset
+   * resumable CLI sessions. */
+  identityBearing: boolean;
+};
+
+function getLocalCliCredentialFingerprint(
+  provider: string,
+): LocalCliCredentialResult | undefined {
   switch (provider) {
     case "claude-cli": {
       const credential = cliAuthEpochDeps.readClaudeCliCredentialsCached({
@@ -175,20 +209,30 @@ function getLocalCliCredentialFingerprint(provider: string): string | undefined 
       // Keep true credential absence absent so logout/removal invalidates
       // reusable sessions. The 5s credential cache still masks transient
       // null reads immediately after a successful read.
-      return credential ? hashCliAuthEpochPart(encodeClaudeCredential(credential)) : undefined;
+      if (!credential) {
+        return undefined;
+      }
+      return {
+        fingerprint: hashCliAuthEpochPart(encodeClaudeCredential(credential)),
+        identityBearing: isClaudeCliCredentialIdentityBearing(credential),
+      };
     }
     case "codex-cli": {
       const credential = cliAuthEpochDeps.readCodexCliCredentialsCached({
         ttlMs: 5000,
         allowKeychainPrompt: false,
       });
-      return credential ? hashCliAuthEpochPart(encodeCodexCredential(credential)) : undefined;
+      return credential
+        ? { fingerprint: hashCliAuthEpochPart(encodeCodexCredential(credential)), identityBearing: false }
+        : undefined;
     }
     case "google-gemini-cli": {
       const credential = cliAuthEpochDeps.readGeminiCliCredentialsCached({
         ttlMs: 5000,
       });
-      return credential ? hashCliAuthEpochPart(encodeGeminiCredential(credential)) : undefined;
+      return credential
+        ? { fingerprint: hashCliAuthEpochPart(encodeGeminiCredential(credential)), identityBearing: false }
+        : undefined;
     }
     default:
       return undefined;
@@ -214,15 +258,22 @@ export async function resolveCliAuthEpoch(params: {
   const provider = params.provider.trim();
   const authProfileId = normalizeOptionalString(params.authProfileId);
   const parts: string[] = [];
+  let localIdentityBearing = false;
 
   if (params.skipLocalCredential !== true) {
-    const localFingerprint = getLocalCliCredentialFingerprint(provider);
-    if (localFingerprint) {
-      parts.push(`local:${provider}:${localFingerprint}`);
+    const localResult = getLocalCliCredentialFingerprint(provider);
+    if (localResult) {
+      parts.push(`local:${provider}:${localResult.fingerprint}`);
+      localIdentityBearing = localResult.identityBearing;
     }
   }
 
-  if (authProfileId) {
+  // When the local host credential is identity-bearing (e.g. it embeds a
+  // refresh-token hash for claude-cli), the auth-profile credential adds no
+  // extra identity signal — the profile is never injected into the spawned
+  // process anyway. Skip it so a cosmetic profile rotation does not move the
+  // epoch and needlessly reset a resumable CLI session.
+  if (authProfileId && !localIdentityBearing) {
     const store = cliAuthEpochDeps.loadAuthProfileStoreForRuntime(undefined, {
       readOnly: true,
       allowKeychainPrompt: false,


### PR DESCRIPTION
## Summary
- **Problem:** claude-cli OpenClaw sessions are reset (`cli session reset: reason=auth-profile`) and lose their entire conversation whenever the automatic auth-profile rotation flips the session between two OpenClaw auth profiles — triggered by a billing cooldown or a compaction.
- **Solution:** Add a `host-only` auth epoch mode. For backends that never inject the selected OpenClaw auth profile into the spawned process, the host CLI credential is the sole auth owner and the profile credential is excluded from the session auth epoch. Mark the claude-cli backend `host-only`.
- **What changed:** new `host-only` value on `CliBackendAuthEpochMode`; `resolveCliAuthEpoch` honours a `skipProfileCredential` flag; `prepare.ts` derives it from the backend's `authEpochMode`; the Anthropic claude-cli backend declares `authEpochMode: "host-only"`.
- **What did NOT change:** the auto auth-profile rotation itself (still rotates — now harmless for claude-cli); `combined` / `profile-only` modes; non-claude-cli backends; `resolveCliSessionReuse`; `CLI_AUTH_EPOCH_VERSION` (not bumped).

## Motivation
On a real install, claude-cli sessions silently lost full context 11 times in 7 days (7 of them on a single day of Anthropic billing cooldowns). Each reset re-asked questions and re-ran work. The root cause is not a credential change — the `claude` process authenticates the same way regardless of the selected OpenClaw profile — so the reset is pure churn.

## Change Type
- [x] Bug fix

## Scope
- [x] Integrations (cli-runner / claude-cli backend)
- [x] Auth (auth-profile / auth-epoch invalidation path)

## Linked Issue/PR
Related: #85315 (closed — proposed raw transcript replay across the auth boundary; rejected). Maintainer guidance there: don't bypass the auth boundary, instead narrow the over-broad trigger that invalidates the CLI session when the auth identity has not changed. This PR does exactly that. Checked: fixes a bug/regression.

## Real behavior proof
- **Behavior addressed:** claude-cli session reset with `reason=auth-profile` after an auth-profile rotation — the resumable CLI session is dropped (`useResume=false`) and the entire conversation context is lost.
- **Real environment tested:** OpenClaw 2026.5.20 on WSL2 Ubuntu, claude-cli backend, Anthropic models. The affected install has two auth profiles in `~/.openclaw/agents/main/agent/auth-profiles.json` — `anthropic:claude-cli` (type `oauth`) and `anthropic:default` (type `token`) — and `~/.openclaw/openclaw.json` sets `auth.order.anthropic = ["anthropic:default","anthropic:claude-cli"]`.
- **Before evidence:** production gateway logs from the affected install:
  ```
  May 23 07:19:11 [agent/cli-backend] cli session reset: provider=claude-cli reason=auth-profile
  May 23 07:19:11 [agent/cli-backend] cli exec: provider=claude-cli model=opus useResume=false reuse=invalidated:auth-profile
  May 23 07:39:21 [agent/cli-backend] cli session reset: provider=claude-cli reason=auth-profile
  ```
  `journalctl` over 7 days shows 11 such `reason=auth-profile` resets (7 on a single day of Anthropic billing cooldowns).
- **Exact steps or command run after this patch:** on the affected install, built the patched modules and ran a reproduction harness that drives the patched `resolveCliAuthEpoch` and `resolveCliSessionReuse` through the exact production rotation — a session bound under `anthropic:claude-cli`, then auto-rotated to `anthropic:default` while the host CLI login is unchanged:
  ```
  npx tsx repro-cli-auth-epoch.mts
  ```
- **Evidence after fix:** copied live terminal output from the patched run:
  ```
  [BEFORE — combined (current main)]
    epoch(anthropic:claude-cli) = 5a727efeaae70e932b3d4152ec13290f88af391cc59086141860d07c9c6aa4e8
    epoch(anthropic:default)    = a3600d45b7249c74277b8af718126c5dbff57553898afc87785e915c3b576e3a
    epochs equal                = false
    resolveCliSessionReuse      = RESET (reason=auth-profile) -> fresh CLI session, context LOST

  [AFTER  — host-only (this patch)]
    epoch(anthropic:claude-cli) = 384cde4a6c945cb1385e03cf06df00803b86e74584782c085c0e40d5c3575a58
    epoch(anthropic:default)    = 384cde4a6c945cb1385e03cf06df00803b86e74584782c085c0e40d5c3575a58
    epochs equal                = true
    resolveCliSessionReuse      = REUSED sessionId=claude-cli-session-abc123 -> context PRESERVED
  ```
  The BEFORE `anthropic:claude-cli` epoch (`5a727efe…`) is byte-identical to the live `authEpoch` value persisted in this install's `sessions.json` claude-cli bindings — the harness reproduces the real production fingerprint.
- **Observed result after fix:** the auth-profile rotation now produces an identical epoch, so `resolveCliSessionReuse` returns the existing `sessionId` instead of `invalidatedReason: "auth-profile"`. The resumable CLI session survives the rotation and the conversation context is preserved — no `cli session reset` line is emitted.
- **What was not tested:** a full live gateway end-to-end run on the rebuilt binary — that would require restarting the production gateway and dropping every active session.

## Root Cause
`resolveCliAuthEpoch` builds the session auth epoch from `local:<provider>:<host-credential-fp>` + `profile:<authProfileId>:<credential-hash>`. The claude-cli backend, however, never injects the OpenClaw auth profile into the spawned `claude` process: `CLAUDE_CLI_CLEAR_ENV` strips all `ANTHROPIC_*` env vars and the backend has no `prepareExecution` credential bridge — the process always uses its own on-disk login. The profile is therefore cosmetic for claude-cli, yet the `profile:` epoch part still made the epoch profile-id-scoped. When the auto auth-profile rotation (`resolveSessionAuthProfileOverride`, on billing cooldown or compaction) flipped the session between `anthropic:claude-cli` and `anthropic:default`, the epoch changed, `resolveCliSessionReuse` raised `invalidatedReason: "auth-profile"`, and the resumable CLI session was dropped. Missing guardrail: no way for a backend to declare that the host credential — not the profile — is the real auth owner.

## Regression Test Plan
- `src/agents/cli-auth-epoch.test.ts`: "ignores the auth profile for host-only backends so cosmetic rotation keeps the epoch stable" reproduces the rotation (two distinct profiles → different epochs under `combined`; identical epoch under `skipProfileCredential`). "still moves the host-only epoch when the host CLI credential changes" guards against over-suppression — a genuine host re-login still invalidates.
- `src/agents/cli-runner/prepare.test.ts`: `shouldSkipProfileCliCredentialEpoch` covers `host-only` vs `combined` / `profile-only` / undefined.
- Failing-then-passing confirmed: reverting `cli-auth-epoch.ts` while keeping the new tests fails the host-only case; the full patch passes (28 and 56 cases on the two touched test files).

## User-visible / Behavior Changes
None. Continuity is preserved across a cosmetic auth-profile rotation for claude-cli. No UI / API / config surface change.

## Diagram
```
Before: rotate profile -> epoch changes        -> resolveCliSessionReuse: auth-profile -> fresh session (context lost)
After:  rotate profile -> host-only epoch same -> resolveCliSessionReuse: reuse         -> session preserved
```

## Security Impact
- New permissions: No
- New secrets handling: No (the profile credential is *removed* from one fingerprint; nothing new is read or stored)
- New network calls: No
- New exec surface: No
- New data access: No

Note on the auth boundary (cf. #85315 review): `host-only` does not replay any transcript and does not cross an auth identity boundary. For the claude-cli backend the running process's auth identity is the on-disk CLI login, which is fully captured by the retained `local:` epoch part; a genuine host re-login still changes the epoch and still invalidates the session. Only the cosmetic profile label is ignored.

## Repro + Verification
- **Environment:** claude-cli backend; `auth.order.anthropic` listing two profiles; a multi-turn session.
- **Steps:** trigger an auth-profile rotation (billing cooldown on the active profile, or a compaction), then send the next message.
- **Expected:** the session is reused; context preserved.
- **Actual (before):** `cli session reset: reason=auth-profile`; fresh session, `useResume=false`, context lost.

## Evidence
- [x] Failing-then-passing regression coverage
- [x] Trace logs / terminal capture (before: production logs; after: patched-function harness)

## Human Verification
Verified: the new `cli-auth-epoch` and `shouldSkipProfileCliCredentialEpoch` cases pass on the two touched files; the `cli-auth-epoch` host-only case fails when the `cli-auth-epoch.ts` change is reverted; a reproduction harness driving the real patched `resolveCliAuthEpoch` + `resolveCliSessionReuse` shows `RESET → REUSED`; the harness's before-epoch matches the live production binding fingerprint. NOT verified: a full patched-gateway end-to-end run (would restart the production gateway); `npx tsc --noEmit` was not run (known repo OOM) — checked via transform compilation + import review.

## Review Conversations
- [x] Will resolve bot review threads before merge
- [x] Will respond to maintainer review comments

## Compatibility / Migration
Backward compatible. No config or migration. Existing claude-cli session bindings carry a `combined`-era epoch; the first turn after upgrade recomputes a `host-only` epoch, causing one final `auth-profile` reset per session, after which the binding is stable. `CLI_AUTH_EPOCH_VERSION` is intentionally not bumped (that would force-reset every CLI backend, including codex / gemini).

## Risks and Mitigations
- One-time per-session reset on upgrade (combined→host-only epoch shape) — bounded, self-healing after one turn; documented above.
- A backend wrongly marked `host-only` while it *does* inject the profile would under-detect a profile credential change — mitigated: only the claude-cli backend is marked, and it is verified not to inject (`CLAUDE_CLI_CLEAR_ENV`, no `prepareExecution`).
- `host-only` with an unreadable host credential would yield an empty epoch — same pre-existing behaviour as `combined` when the local read fails; not a regression.