### PR TITLE
fix(openai): drop empty reasoning replay blocks

### DIFF
--- a/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
@@ -870,6 +870,134 @@ describe("downgradeOpenAIReasoningBlocks", () => {
     );
   });
 
+  it("drops empty non-replayable reasoning before tool calls while preserving tool pairing", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "   ",
+            thinkingSignature: JSON.stringify({ id: "rs_empty", type: "reasoning" }),
+          },
+          { type: "toolCall", id: "call_read", name: "read", arguments: {} },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_read",
+        toolName: "read",
+        content: [{ type: "text", text: "ok" }],
+      },
+    ];
+
+    expect(downgradeOpenAIReasoningBlocks(input as any)).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_read", name: "read", arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_read",
+        toolName: "read",
+        content: [{ type: "text", text: "ok" }],
+      },
+    ]);
+  });
+
+  it("drops non-string replayable reasoning even when followed by content", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: { text: "not replayable text" },
+            thinkingSignature: JSON.stringify({ id: "rs_non_string", type: "reasoning" }),
+          },
+          { type: "text", text: "answer" },
+        ],
+      },
+    ];
+
+    expect(downgradeOpenAIReasoningBlocks(input as any)).toEqual([
+      { role: "assistant", content: [{ type: "text", text: "answer" }] },
+    ]);
+  });
+
+  it("keeps empty-text reasoning when the signature carries content replay state", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "",
+            thinkingSignature: JSON.stringify({
+              id: "rs_content",
+              type: "reasoning",
+              content: [{ type: "reasoning_text", text: "hidden" }],
+            }),
+          },
+          { type: "text", text: "answer" },
+        ],
+      },
+    ];
+
+    expect(downgradeOpenAIReasoningBlocks(input as any)).toEqual(input);
+  });
+
+  it("keeps empty-text reasoning when the signature carries encrypted replay state", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "   ",
+            thinkingSignature: JSON.stringify({
+              id: "rs_encrypted",
+              type: "reasoning",
+              encrypted_content: "enc_payload",
+            }),
+          },
+          { type: "toolCall", id: "call_read|fc_123", name: "read", arguments: {} },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_read|fc_123",
+        toolName: "read",
+        content: [{ type: "text", text: "ok" }],
+      },
+    ];
+
+    expect(downgradeOpenAIReasoningBlocks(input as any)).toEqual(input);
+    expect(downgradeOpenAIFunctionCallReasoningPairs(input as any)).toEqual(input);
+  });
+
+  it("keeps empty-text reasoning when the signature carries summary replay state", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "",
+            thinkingSignature: JSON.stringify({
+              id: "rs_summary",
+              type: "reasoning",
+              summary: [{ type: "summary_text", text: "summary" }],
+            }),
+          },
+          { type: "text", text: "answer" },
+        ],
+      },
+    ];
+
+    expect(downgradeOpenAIReasoningBlocks(input as any)).toEqual(input);
+  });
+
   it("drops orphaned reasoning blocks without following content", () => {
     const input = [
       {

--- a/src/agents/embedded-agent-helpers/openai.ts
+++ b/src/agents/embedded-agent-helpers/openai.ts
@@ -57,6 +57,10 @@ function parseOpenAIReasoningSignature(value: unknown): OpenAIReasoningSignature
   return null;
 }
 
+function hasMeaningfulThinkingText(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
 function hasFollowingNonThinkingBlock(
   content: Extract<AgentMessage, { role: "assistant" }>["content"],
   index: number,
@@ -467,7 +471,7 @@ export function downgradeOpenAIReasoningBlocks(
         nextContent.push(block);
         continue;
       }
-      if (options.dropReplayableReasoning) {
+      if (options.dropReplayableReasoning || !hasMeaningfulThinkingText(record.thinking)) {
         changed = true;
         droppedReplayableReasoning = true;
         continue;

--- a/src/agents/embedded-agent-helpers/openai.ts
+++ b/src/agents/embedded-agent-helpers/openai.ts
@@ -15,6 +15,9 @@ type OpenAIToolCallBlock = {
 type OpenAIReasoningSignature = {
   id: string;
   type: string;
+  content?: unknown;
+  encrypted_content?: unknown;
+  summary?: unknown;
 };
 
 type DowngradeOpenAIReasoningBlocksOptions = {
@@ -52,13 +55,32 @@ function parseOpenAIReasoningSignature(value: unknown): OpenAIReasoningSignature
     return null;
   }
   if (type === "reasoning" || type.startsWith("reasoning.")) {
-    return { id, type };
+    return {
+      id,
+      type,
+      content: (candidate as { content?: unknown }).content,
+      encrypted_content: (candidate as { encrypted_content?: unknown }).encrypted_content,
+      summary: (candidate as { summary?: unknown }).summary,
+    };
   }
   return null;
 }
 
 function hasMeaningfulThinkingText(value: unknown): boolean {
   return typeof value === "string" && value.trim().length > 0;
+}
+
+function hasReplayableResponsesReasoningState(signature: OpenAIReasoningSignature): boolean {
+  if (typeof signature.encrypted_content === "string" && signature.encrypted_content.length > 0) {
+    return true;
+  }
+  if (Array.isArray(signature.content) && signature.content.length > 0) {
+    return true;
+  }
+  if (Array.isArray(signature.summary) && signature.summary.length > 0) {
+    return true;
+  }
+  return false;
 }
 
 function hasFollowingNonThinkingBlock(
@@ -471,7 +493,15 @@ export function downgradeOpenAIReasoningBlocks(
         nextContent.push(block);
         continue;
       }
-      if (options.dropReplayableReasoning || !hasMeaningfulThinkingText(record.thinking)) {
+      if (options.dropReplayableReasoning) {
+        changed = true;
+        droppedReplayableReasoning = true;
+        continue;
+      }
+      if (
+        !hasMeaningfulThinkingText(record.thinking) &&
+        !hasReplayableResponsesReasoningState(signature)
+      ) {
         changed = true;
         droppedReplayableReasoning = true;
         continue;


### PR DESCRIPTION
## Summary

- Drop replayable OpenAI Responses reasoning blocks when their persisted `thinking` text is empty, whitespace-only, or non-string.
- Preserve the rest of the assistant content, including tool calls and matching tool results.
- Keep non-empty signed reasoning replay behavior unchanged.

## Why

OpenAI Responses-compatible providers can reject replayed signed reasoning items that do not carry meaningful reasoning text. A transcript can contain a signed `type: "thinking"` block followed by a tool call, which made the previous sanitizer consider it replay-safe even when `thinking` was empty.

This narrows the replay sanitizer so only meaningful signed reasoning text is preserved. Empty or invalid reasoning text is dropped before request assembly, while the remaining assistant content is left intact.

## Tests

- `corepack pnpm test src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts`
- `corepack pnpm format:check src/agents/pi-embedded-helpers/openai.ts src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts`
- `corepack pnpm tsgo:core:test`
- `corepack pnpm lint:core -- src/agents/pi-embedded-helpers/openai.ts src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts`
- `git diff --check`

No live Gateway/runtime testing was used for this source-level sanitizer change.

## Real behavior proof

- **Behavior addressed:** OpenAI Responses replay sanitation drops signed reasoning replay blocks when the persisted `thinking` value is empty or whitespace-only, while preserving the rest of the assistant turn and the matching tool result. Replayable reasoning blocks that carry provider replay state remain preserved.
- **Real setup tested:** Disposable non-production checkout of PR head `7a76e85fbd4020902f9e854c1cb280ff3e6eacd2` on Linux arm64 with Node `v22.22.0`. The proof imported the real current-head OpenAI helper module from the checkout and did not use any live provider call, production Gateway, or live runtime state.
- **Exact steps or command run after this patch:** From the disposable checkout/artifact area, ran:

  ```bash
  cd <checkout-pr-85509>
  node --import <artifact-root>/tools/node_modules/tsx/dist/loader.mjs \
    <artifact-root>/scripts/pr-85509-openai-reasoning-proof.mjs
  ```

  The script imported `src/agents/embedded-agent-helpers/openai.ts`, fed a transcript containing a signed whitespace-only reasoning block plus text and tool-call content, then fed a separate assistant message containing replayable encrypted reasoning state.
- **Evidence after fix:** Sanitized console output copied from the current-head run:

  ```json
  {
    "head": "7a76e85fbd4020902f9e854c1cb280ff3e6eacd2",
    "emptyReasoningBlocksAfter": 0,
    "preservedAssistantBlockTypes": [
      "text",
      "toolCall"
    ],
    "textSignatureAfter": "{\"v\":1,\"phase\":\"final_answer\"}",
    "toolResultPreserved": true,
    "replayableReasoningBlocksAfter": 1
  }
  ```
- **Observed result after fix:** The whitespace-only signed reasoning block was removed (`emptyReasoningBlocksAfter: 0`). The assistant text block and tool call remained present, the matching tool result remained byte-for-byte preserved, stale `msg_*` signature id metadata was stripped from the text signature, and a separate reasoning block with encrypted replay state remained present (`replayableReasoningBlocksAfter: 1`).
- **What was not tested:** No live OpenAI Responses request, no provider credentials, and no production/live OpenClaw Gateway runtime. The proof exercises the actual current-head sanitizer code in a disposable checkout; CI/unit tests remain supplemental.