### PR TITLE
feat(ui): add collapsible toggle for recent sessions in sidebar

### DIFF
--- a/src/gateway/server-session-key.ts
+++ b/src/gateway/server-session-key.ts
@@ -45,10 +45,13 @@ function setResolvedSessionKeyCache(
       resolvedSessionKeyByRunId.delete(oldest);
     }
   }
-  const expiresAt =
-    sessionKey === null ? resolveExpiresAtMsFromDurationMs(RUN_LOOKUP_MISS_TTL_MS) : null;
-  if (sessionKey === null && expiresAt === undefined) {
-    return;
+  let expiresAt: number | null = null;
+  if (sessionKey === null) {
+    const missExpiresAt = resolveExpiresAtMsFromDurationMs(RUN_LOOKUP_MISS_TTL_MS);
+    if (missExpiresAt === undefined) {
+      return;
+    }
+    expiresAt = missExpiresAt;
   }
   resolvedSessionKeyByRunId.set(cacheKey, {
     sessionKey,

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -395,6 +395,8 @@ export const en: TranslationMap = {
     expand: "Expand sidebar",
     collapse: "Collapse sidebar",
     resize: "Resize sidebar",
+    recentSessionsExpand: "Expand recent sessions",
+    recentSessionsCollapse: "Collapse recent sessions",
   },
   tabs: {
     agents: "Agents",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -395,8 +395,6 @@ export const en: TranslationMap = {
     expand: "Expand sidebar",
     collapse: "Collapse sidebar",
     resize: "Resize sidebar",
-    recentSessionsExpand: "Expand recent sessions",
-    recentSessionsCollapse: "Collapse recent sessions",
   },
   tabs: {
     agents: "Agents",

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -671,15 +671,64 @@
 .sidebar-recent-sessions {
   display: grid;
   gap: 6px;
+  margin: 0 -8px;
 }
 
 .sidebar-recent-sessions__label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
   padding: 0 10px;
-  font-size: 11px;
+  min-height: 28px;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-md);
+  color: color-mix(in srgb, var(--muted) 72%, var(--text) 28%);
+  cursor: pointer;
+  text-align: left;
+  transition:
+    color var(--duration-fast) ease,
+    background var(--duration-fast) ease;
+}
+
+.sidebar-recent-sessions__label:hover {
+  color: var(--text);
+  background: color-mix(in srgb, var(--bg-hover) 72%, transparent);
+}
+
+.sidebar-recent-sessions__label-text {
+  font-size: 12px;
   font-weight: 700;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--muted) 78%, var(--text) 22%);
+}
+
+.sidebar-recent-sessions__chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.5;
+  transition: transform var(--duration-fast) ease;
+}
+
+.sidebar-recent-sessions__chevron svg {
+  width: 12px;
+  height: 12px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.5px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.sidebar-recent-sessions--collapsed .sidebar-recent-sessions__chevron {
+  transform: rotate(-90deg);
+}
+
+.sidebar-recent-sessions--collapsed .sidebar-recent-sessions__list {
+  display: none;
 }
 
 .sidebar-recent-sessions__list {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -306,8 +306,31 @@ function renderSidebarSessions(state: AppViewState) {
       ${collapsed || recent.length === 0
         ? nothing
         : html`
-            <div class="sidebar-recent-sessions" aria-label=${t("overview.cards.recentSessions")}>
-              <div class="sidebar-recent-sessions__label">${t("usage.sessions.recentShort")}</div>
+            <div
+              class="sidebar-recent-sessions ${state.settings.recentSessionsCollapsed
+                ? "sidebar-recent-sessions--collapsed"
+                : ""}"
+              aria-label=${t("overview.cards.recentSessions")}
+            >
+              <button
+                class="sidebar-recent-sessions__label"
+                type="button"
+                aria-expanded=${String(!state.settings.recentSessionsCollapsed)}
+                title=${state.settings.recentSessionsCollapsed
+                  ? t("nav.recentSessionsExpand")
+                  : t("nav.recentSessionsCollapse")}
+                @click=${() => {
+                  state.applySettings({
+                    ...state.settings,
+                    recentSessionsCollapsed: !state.settings.recentSessionsCollapsed,
+                  });
+                }}
+              >
+                <span class="sidebar-recent-sessions__label-text"
+                  >${t("usage.sessions.recentShort")}</span
+                >
+                <span class="sidebar-recent-sessions__chevron"> ${icons.chevronDown} </span>
+              </button>
               <div class="sidebar-recent-sessions__list">
                 ${recent.map((row) => renderSidebarRecentSession(state, row))}
               </div>

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -316,9 +316,6 @@ function renderSidebarSessions(state: AppViewState) {
                 class="sidebar-recent-sessions__label"
                 type="button"
                 aria-expanded=${String(!state.settings.recentSessionsCollapsed)}
-                title=${state.settings.recentSessionsCollapsed
-                  ? t("nav.recentSessionsExpand")
-                  : t("nav.recentSessionsCollapse")}
                 @click=${() => {
                   state.applySettings({
                     ...state.settings,

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -496,6 +496,28 @@ describe("control UI routing", () => {
       "First workspace 5m ago",
     ]);
 
+    const recentSection = expectElement(app, ".sidebar-recent-sessions", HTMLElement);
+    const recentToggle = expectElement(
+      recentSection,
+      ".sidebar-recent-sessions__label",
+      HTMLButtonElement,
+    );
+    expect(recentToggle.getAttribute("aria-expanded")).toBe("true");
+
+    recentToggle.click();
+    await app.updateComplete;
+
+    expect(app.settings.recentSessionsCollapsed).toBe(true);
+    expect(recentToggle.getAttribute("aria-expanded")).toBe("false");
+    expect([...recentSection.classList]).toContain("sidebar-recent-sessions--collapsed");
+
+    recentToggle.click();
+    await app.updateComplete;
+
+    expect(app.settings.recentSessionsCollapsed).toBe(false);
+    expect(recentToggle.getAttribute("aria-expanded")).toBe("true");
+    expect([...recentSection.classList]).not.toContain("sidebar-recent-sessions--collapsed");
+
     recent[1]?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
     await app.updateComplete;
 

--- a/ui/src/ui/storage.node.test.ts
+++ b/ui/src/ui/storage.node.test.ts
@@ -146,6 +146,7 @@ describe("loadSettings default gateway URL derivation", () => {
       navCollapsed: false,
       navWidth: 220,
       navGroupsCollapsed: {},
+      recentSessionsCollapsed: false,
       borderRadius: 50,
       textScale: 100,
       sessionsByGateway: {
@@ -281,6 +282,7 @@ describe("loadSettings default gateway URL derivation", () => {
       navCollapsed: false,
       navWidth: 220,
       navGroupsCollapsed: {},
+      recentSessionsCollapsed: false,
       borderRadius: 50,
       textScale: 100,
       sessionsByGateway: {
@@ -291,6 +293,65 @@ describe("loadSettings default gateway URL derivation", () => {
       },
     });
     expect(sessionStorage.length).toBe(1);
+  });
+
+  it("persists recent sessions collapse state across save and load", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+
+    const gwUrl = expectedGatewayUrl("");
+    saveSettings({
+      gatewayUrl: gwUrl,
+      token: "",
+      sessionKey: "main",
+      lastActiveSessionKey: "main",
+      theme: "claw",
+      themeMode: "system",
+      chatFocusMode: false,
+      chatShowThinking: true,
+      chatShowToolCalls: true,
+      chatAutoScroll: "near-bottom",
+      splitRatio: 0.6,
+      navCollapsed: false,
+      navWidth: 220,
+      navGroupsCollapsed: {},
+      recentSessionsCollapsed: true,
+      borderRadius: 50,
+      textScale: 100,
+    });
+
+    expect(loadSettings().recentSessionsCollapsed).toBe(true);
+
+    saveSettings({
+      gatewayUrl: gwUrl,
+      token: "",
+      sessionKey: "main",
+      lastActiveSessionKey: "main",
+      theme: "claw",
+      themeMode: "system",
+      chatFocusMode: false,
+      chatShowThinking: true,
+      chatShowToolCalls: true,
+      chatAutoScroll: "near-bottom",
+      splitRatio: 0.6,
+      navCollapsed: false,
+      navWidth: 220,
+      navGroupsCollapsed: {},
+      recentSessionsCollapsed: false,
+      borderRadius: 50,
+      textScale: 100,
+    });
+
+    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
+    const persisted = JSON.parse(localStorage.getItem(scopedKey) ?? "{}") as Record<
+      string,
+      unknown
+    >;
+    expect(persisted.recentSessionsCollapsed).toBe(false);
+    expect(loadSettings().recentSessionsCollapsed).toBe(false);
   });
 
   it("normalizes persisted text scale to the nearest supported stop", () => {

--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -93,6 +93,7 @@ export type UiSettings = {
   navCollapsed: boolean; // Collapsible sidebar state
   navWidth: number; // Sidebar width when expanded (240–400px)
   navGroupsCollapsed: Record<string, boolean>; // Which nav groups are collapsed
+  recentSessionsCollapsed?: boolean; // Collapse recent sessions list in sidebar
   borderRadius: number; // Corner roundness (0–100, default 50)
   textScale?: TextScaleStop; // Browser-local text scale percentage
   customTheme?: ImportedCustomTheme;
@@ -236,6 +237,7 @@ export function loadSettings(): UiSettings {
     navCollapsed: false,
     navWidth: 220,
     navGroupsCollapsed: {},
+    recentSessionsCollapsed: false,
     borderRadius: 50,
     textScale: 100,
   };

--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -296,6 +296,10 @@ export function loadSettings(): UiSettings {
         typeof parsed.navGroupsCollapsed === "object" && parsed.navGroupsCollapsed !== null
           ? parsed.navGroupsCollapsed
           : defaults.navGroupsCollapsed,
+      recentSessionsCollapsed:
+        typeof parsed.recentSessionsCollapsed === "boolean"
+          ? parsed.recentSessionsCollapsed
+          : defaults.recentSessionsCollapsed,
       borderRadius:
         typeof parsed.borderRadius === "number" &&
         parsed.borderRadius >= 0 &&
@@ -422,6 +426,7 @@ function persistSettings(next: UiSettings) {
     navCollapsed: next.navCollapsed,
     navWidth: next.navWidth,
     navGroupsCollapsed: next.navGroupsCollapsed,
+    recentSessionsCollapsed: next.recentSessionsCollapsed ?? false,
     borderRadius: next.borderRadius,
     textScale: normalizeTextScale(next.textScale),
     ...(next.customTheme ? { customTheme: next.customTheme } : {}),


### PR DESCRIPTION
## Summary

- Adds a collapse/expand toggle to the "Recent" sessions section in the web sidebar
- Reuses the existing nav section button pattern: full-row label, chevron rotation, and `aria-expanded`
- Persists collapsed state to localStorage via `UiSettings.recentSessionsCollapsed`
- Adds focused storage and browser-render coverage for the new setting and toggle behavior
- Includes a small gateway cache-expiry type narrowing fix needed after the latest `main` rebase

## Changes

| File | Change |
|------|--------|
| `ui/src/ui/storage.ts` | Add `recentSessionsCollapsed` field, default, load normalization, and persisted serialization |
| `ui/src/ui/app-render.ts` | Replace static Recent label with a collapsible button matching the existing nav section pattern |
| `ui/src/styles/layout.css` | Add Recent-session label, chevron, hover, and collapsed-list styles |
| `ui/src/ui/storage.node.test.ts` | Cover save/load persistence for the Recent sessions collapse state |
| `ui/src/ui/navigation.browser.test.ts` | Cover click toggling, `aria-expanded`, collapsed class, and existing session switching |
| `src/gateway/server-session-key.ts` | Narrow miss-cache expiry before storing it so core typecheck stays green after the rebase |

## Real behavior proof

Behavior addressed: Sidebar recent sessions section now supports collapse/expand via a toggle button matching the nav section group pattern, and the collapsed state persists through browser-local settings.

Real environment tested: Local Control UI dev server (`pnpm ui:dev`) at http://localhost:5173/ on macOS 26 with Node 24 and pnpm 11.2.2 for the visual proof; maintainer verification on macOS with Node 26 plus Blacksmith Testbox for changed gates.

Exact steps or command run after this patch:
1. Run `pnpm ui:dev` to start the Control UI dev server.
2. Open http://localhost:5173/ in a browser.
3. Observe the "Recent" label in the sidebar as a clickable row with a chevron icon.
4. Click the "Recent" button; the session list collapses and the chevron rotates to the right.
5. Click the "Recent" button again; the session list expands and the chevron rotates back down.
6. Refresh the page and confirm the collapsed state is preserved from localStorage.
7. Maintainer reran `node scripts/run-vitest.mjs src/gateway/server-session-key.test.ts ui/src/ui/storage.node.test.ts ui/src/ui/navigation.browser.test.ts -- --reporter=verbose`.
8. Maintainer reran `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-local-pr85511.tsbuildinfo`.
9. Maintainer reran `pnpm check:changed` via Blacksmith Testbox run `tbx_01kswvhf6crq49skhghm3x05q0`.
10. Maintainer reran `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode branch --base origin/main`.

Evidence after fix:

Expanded state (chevron down, 5 recent sessions visible, 237px width matching nav groups):
![Expanded state](https://github.com/user-attachments/assets/3b7a79d4-4d14-4007-bdfc-fcc879b81be2)

Collapsed state (chevron rotated right, list hidden, only label row visible):
![Collapsed state](https://github.com/user-attachments/assets/045e6469-5121-406d-b38f-6701aea10c6b)

After-fix proof — refresh persistence video:
https://github.com/user-attachments/assets/d4059d46-552a-48ac-b68f-a19db9493fd6

Width verification via browser DevTools:
```text
recentLabelWidth: "237px"
navLabelWidth:    "237px"
match:            true
```

Maintainer command output included `Test Files  3 passed (3)`, `Tests  50 passed (50)`, core `tsgo` exit 0, Testbox `exitCode: 0`, and `autoreview clean: no accepted/actionable findings reported`.

Observed result after fix: Toggle works as expected: click collapses the list, sets `aria-expanded="false"`, and applies `sidebar-recent-sessions--collapsed`; click again expands the list and restores `aria-expanded="true"`. State persists across page refreshes. The latest maintainer checks also confirm the rebased gateway cache-expiry type narrowing keeps core typecheck green.

What was not tested: A live production gateway with real user sessions was not tested after the maintainer rebase; the changed UI behavior was covered by the contributor's local browser proof plus focused maintainer browser/storage tests, and the gateway fix was covered by the affected gateway test and core typecheck.

Closes #85510

🤖 Generated with [Claude Code](https://claude.com/claude-code)
