### PR TITLE
docs: require visual proof for control ui e2e

### DIFF
--- a/.agents/skills/control-ui-e2e/SKILL.md
+++ b/.agents/skills/control-ui-e2e/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: control-ui-e2e
-description: Use when testing, fixing, or extending the OpenClaw Control UI GUI with Vitest + Playwright end-to-end checks, mocked Gateway WebSocket flows, or agent-verifiable browser proof.
+description: Use when testing, fixing, or extending the OpenClaw Control UI GUI with Vitest + Playwright end-to-end checks, mocked Gateway WebSocket flows, mocked dashboard runs, screenshots/videos, or agent-verifiable browser proof.
 ---
 
 # Control UI E2E
@@ -29,6 +29,17 @@ pnpm test:ui:e2e
 ```
 
 If dependencies are missing in a Codex worktree, install once with `pnpm install`; for broad GUI proof or dependency-heavy checks, use Testbox/Crabbox instead of running a wide local pnpm lane.
+
+## Visual Proof Default
+
+When running mocked Control UI/dashboard validation for a user-facing feature, produce visual proof by default unless the user explicitly opts out.
+
+- Keep the Vitest E2E assertions deterministic; do not commit generated screenshots or videos.
+- After or alongside the focused E2E test, run the mocked Control UI app when available, for example `pnpm dev:ui:mock -- --port <port>`.
+- Drive Chromium with Playwright against the local mock URL and capture a video plus screenshots for each meaningful state: initial view, interaction input, result state, and final/paginated/selected state.
+- Use `browser.newContext({ recordVideo: { dir, size }, viewport })`, `page.screenshot({ path })`, and close the context before reporting the video path.
+- Put artifacts under `.artifacts/control-ui-e2e/<short-feature-name>/` or another clearly named local temp directory, and report the absolute paths in the final answer.
+- If visual proof is blocked, state the exact blocker and still report the textual E2E evidence.
 
 ## Mock Pattern
 


### PR DESCRIPTION
## Summary

- Make the Control UI E2E skill treat mocked dashboard visual proof as the default for user-facing validation.
- Document expected Playwright video/screenshots artifacts and where agents should store and report them.

## Verification

Behavior addressed: Agents running mocked Control UI/dashboard validation now have explicit instructions to produce screenshots/video by default.

