### PR TITLE
fix(media): replace Gemini CLI fallback with sandboxed Antigravity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Packaging: exclude documentation images and assets from the npm tarball, reducing published package size without affecting runtime docs search or CLI behavior. Thanks @SebTardif.
+- Media understanding: stop auto-probing Gemini CLI and use Antigravity CLI only as a lower-priority image/video fallback after configured provider APIs.
 - Agents/subagents: limit default sub-agent bootstrap context to `AGENTS.md` and `TOOLS.md`, keeping persona, identity, user, memory, heartbeat, and setup files out of delegated workers by default. (#85283) Thanks @100yenadmin.
 - Maintainer skills: exclude plugin SDK/API boundary work from `openclaw-landable-bug-sweep` so bugbash sweeps stay focused on small paper-cut fixes.
 - Plugin SDK: add a generic channel-message poll sender so channel plugins can expose poll delivery without depending on channel-specific SDK facades.

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -989,7 +989,7 @@ describe("applyMediaUnderstanding", () => {
     });
     mockedRunExec.mockImplementation(async (_command, args) => {
       if (Array.isArray(args) && args.includes("--help")) {
-        return { stdout: "--print\n--add-dir\n", stderr: "" };
+        return { stdout: "--print\n--add-dir\n--sandbox\n", stderr: "" };
       }
       return { stdout: "antigravity image description\n", stderr: "" };
     });
@@ -1002,14 +1002,20 @@ describe("applyMediaUnderstanding", () => {
     expect(ctx.Body).toBe("[Image]\nDescription:\nantigravity image description");
     expect(mockedRunExec).toHaveBeenCalledTimes(2);
     const realImagePath = await fs.realpath(imagePath);
-    const [command, args] = getRunExecCall(1);
+    const [command, args, options] = getRunExecCall(1);
     expect(command).toBe(path.join(binDir, "agy"));
     expect(args).toEqual([
+      "--sandbox",
       "--add-dir",
       path.dirname(realImagePath),
       "--print",
       expect.stringContaining(realImagePath),
     ]);
+    expect(options).toEqual({
+      timeoutMs: 60_000,
+      maxBuffer: CLI_OUTPUT_MAX_BUFFER,
+      cwd: path.dirname(realImagePath),
+    });
   });
 
   it("uses CLI image understanding and preserves caption for commands", async () => {

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -936,6 +936,82 @@ describe("applyMediaUnderstanding", () => {
     expect(mockedRunExec).not.toHaveBeenCalled();
   });
 
+  it("does not probe Gemini CLI during media auto-detect", async () => {
+    clearMediaUnderstandingBinaryCacheForTests();
+    const binDir = await createTempMediaDir();
+    const isolatedAgentDir = await createTempMediaDir();
+    await createMockExecutable(binDir, "gemini");
+    const ctx = await createAudioCtx({
+      fileName: "sample.wav",
+      mediaType: "audio/wav",
+      content: createSafeAudioFixtureBuffer(2048),
+    });
+    const cfg: OpenClawConfig = { tools: { media: { audio: {} } } };
+    mockedResolveApiKey.mockResolvedValue({
+      source: "none",
+      mode: "api-key",
+    });
+
+    await withMediaAutoDetectEnv(
+      {
+        PATH: binDir,
+        OPENCLAW_AGENT_DIR: isolatedAgentDir,
+        PI_CODING_AGENT_DIR: isolatedAgentDir,
+      },
+      async () => {
+        const result = await applyMediaUnderstanding({ ctx, cfg });
+        expect(result.appliedAudio).toBe(false);
+      },
+    );
+
+    expect(ctx.Transcript).toBeUndefined();
+    expect(ctx.Body).toBe("<media:audio>");
+    expect(mockedRunExec).not.toHaveBeenCalled();
+  });
+
+  it("uses Antigravity CLI as the last auto image fallback", async () => {
+    clearMediaUnderstandingBinaryCacheForTests();
+    const binDir = await createTempMediaDir();
+    await createMockExecutable(binDir, "agy");
+    const imagePath = await createTempMediaFile({
+      fileName: "photo.jpg",
+      content: "image-bytes",
+    });
+    const ctx: MsgContext = {
+      Body: "<media:image>",
+      MediaPath: imagePath,
+      MediaType: "image/jpeg",
+    };
+    const cfg: OpenClawConfig = { tools: { media: { image: {} } } };
+    mockedResolveApiKey.mockResolvedValue({
+      source: "none",
+      mode: "api-key",
+    });
+    mockedRunExec.mockImplementation(async (_command, args) => {
+      if (Array.isArray(args) && args.includes("--help")) {
+        return { stdout: "--print\n--add-dir\n", stderr: "" };
+      }
+      return { stdout: "antigravity image description\n", stderr: "" };
+    });
+
+    await withMediaAutoDetectEnv({ PATH: binDir }, async () => {
+      const result = await applyMediaUnderstanding({ ctx, cfg });
+      expect(result.appliedImage).toBe(true);
+    });
+
+    expect(ctx.Body).toBe("[Image]\nDescription:\nantigravity image description");
+    expect(mockedRunExec).toHaveBeenCalledTimes(2);
+    const realImagePath = await fs.realpath(imagePath);
+    const [command, args] = getRunExecCall(1);
+    expect(command).toBe(path.join(binDir, "agy"));
+    expect(args).toEqual([
+      "--print",
+      expect.stringContaining(realImagePath),
+      "--add-dir",
+      path.dirname(realImagePath),
+    ]);
+  });
+
   it("uses CLI image understanding and preserves caption for commands", async () => {
     const imagePath = await createTempMediaFile({
       fileName: "photo.jpg",

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -193,6 +193,7 @@ async function withMediaAutoDetectEnv<T>(
       GROQ_API_KEY: undefined,
       DEEPGRAM_API_KEY: undefined,
       GEMINI_API_KEY: undefined,
+      OPENCLAW_ANTIGRAVITY_CLI: undefined,
       OPENCLAW_AGENT_DIR: undefined,
       PI_CODING_AGENT_DIR: undefined,
       ...env,

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -1005,10 +1005,10 @@ describe("applyMediaUnderstanding", () => {
     const [command, args] = getRunExecCall(1);
     expect(command).toBe(path.join(binDir, "agy"));
     expect(args).toEqual([
-      "--print",
-      expect.stringContaining(realImagePath),
       "--add-dir",
       path.dirname(realImagePath),
+      "--print",
+      expect.stringContaining(realImagePath),
     ]);
   });
 

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -1003,6 +1003,11 @@ describe("applyMediaUnderstanding", () => {
     expect(ctx.Body).toBe("[Image]\nDescription:\nantigravity image description");
     expect(mockedRunExec).toHaveBeenCalledTimes(2);
     const realImagePath = await fs.realpath(imagePath);
+    const [_probeCommand, _probeArgs, probeOptions] = getRunExecCall(0);
+    expect(probeOptions).toEqual({
+      timeoutMs: 3000,
+      cwd: expect.stringContaining("openclaw-antigravity-probe-"),
+    });
     const [command, args, options] = getRunExecCall(1);
     expect(command).toBe(path.join(binDir, "agy"));
     expect(args).toEqual([

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -144,6 +144,11 @@ function commandBase(command: string): string {
   return path.parse(command).name;
 }
 
+function isAntigravityCliCommand(command: string): boolean {
+  const commandId = commandBase(command);
+  return commandId === "agy" || commandId === "antigravity";
+}
+
 function findArgValue(args: string[], keys: string[]): string | undefined {
   for (let i = 0; i < args.length; i += 1) {
     if (keys.includes(args[i] ?? "")) {
@@ -808,6 +813,7 @@ export async function runCliEntry(params: {
     const { stdout } = await runExec(argv[0], argv.slice(1), {
       timeoutMs,
       maxBuffer: CLI_OUTPUT_MAX_BUFFER,
+      cwd: isAntigravityCliCommand(command) ? path.dirname(mediaPath) : undefined,
     });
     const resolved = await resolveCliOutput({
       command,

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -544,7 +544,7 @@ async function resolveAntigravityCliEntry(
       "--add-dir",
       "{{MediaDir}}",
       "--print",
-      "{{Prompt}}\n\nInspect {{MediaPath}} and reply with only the requested media description.",
+      "{{Prompt}} Inspect {{MediaPath}} and reply with only the requested media description.",
     ],
   };
 }

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -26,7 +26,6 @@ import type { ActiveMediaModel } from "./active-model.types.js";
 import { MediaAttachmentCache, selectAttachments } from "./attachments.js";
 import { isMediaUnderstandingSkipError } from "./errors.js";
 import { fileExists } from "./fs.js";
-import { extractGeminiResponse } from "./output-extract.js";
 import { normalizeMediaExecutionProviderId, normalizeMediaProviderId } from "./provider-id.js";
 import {
   buildMediaUnderstandingRegistry,
@@ -304,11 +303,11 @@ export function resolveMediaAttachmentLocalRoots(params: {
 }
 
 const binaryCache = new Map<string, Promise<string | null>>();
-const geminiProbeCache = new Map<string, Promise<boolean>>();
+const antigravityCliCache = new Map<string, Promise<string | null>>();
 
 export function clearMediaUnderstandingBinaryCacheForTests(): void {
   binaryCache.clear();
-  geminiProbeCache.clear();
+  antigravityCliCache.clear();
 }
 
 function expandHomeDir(value: string): string {
@@ -406,27 +405,38 @@ async function hasBinary(name: string): Promise<boolean> {
   return Boolean(await findBinary(name));
 }
 
-async function probeGeminiCli(): Promise<boolean> {
-  const cached = geminiProbeCache.get("gemini");
+async function probeAntigravityCliCandidate(command: string): Promise<string | null> {
+  const resolved = await findBinary(command);
+  if (!resolved) {
+    return null;
+  }
+  try {
+    const { stdout } = await runExec(resolved, ["--help"], { timeoutMs: 3000 });
+    return stdout.includes("--print") && stdout.includes("--add-dir") ? resolved : null;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveAntigravityCliBinary(): Promise<string | null> {
+  const cached = antigravityCliCache.get("agy");
   if (cached) {
     return cached;
   }
   const resolved = (async () => {
-    if (!(await hasBinary("gemini"))) {
-      return false;
+    const configured = process.env.OPENCLAW_ANTIGRAVITY_CLI?.trim();
+    const candidates = [configured, "agy", "antigravity"].filter((value): value is string =>
+      Boolean(value),
+    );
+    for (const candidate of candidates) {
+      const command = await probeAntigravityCliCandidate(candidate);
+      if (command) {
+        return command;
+      }
     }
-    try {
-      const { stdout } = await runExec("gemini", ["--output-format", "json", "ok"], {
-        timeoutMs: 8000,
-      });
-      return Boolean(
-        extractGeminiResponse(stdout) ?? normalizeLowercaseStringOrEmpty(stdout).includes("ok"),
-      );
-    } catch {
-      return false;
-    }
+    return null;
   })();
-  geminiProbeCache.set("gemini", resolved);
+  antigravityCliCache.set("agy", resolved);
   return resolved;
 }
 
@@ -517,24 +527,24 @@ async function resolveLocalAudioEntry(): Promise<MediaUnderstandingModelConfig |
   return await resolveLocalWhisperEntry();
 }
 
-async function resolveGeminiCliEntry(
-  _capability: MediaUnderstandingCapability,
+async function resolveAntigravityCliEntry(
+  capability: MediaUnderstandingCapability,
 ): Promise<MediaUnderstandingModelConfig | null> {
-  if (!(await probeGeminiCli())) {
+  if (capability === "audio") {
+    return null;
+  }
+  const command = await resolveAntigravityCliBinary();
+  if (!command) {
     return null;
   }
   return {
     type: "cli",
-    command: "gemini",
+    command,
     args: [
-      "--output-format",
-      "json",
-      "--allowed-tools",
-      "read_many_files",
-      "--include-directories",
+      "--print",
+      "{{Prompt}}\n\nInspect {{MediaPath}} and reply with only the requested media description.",
+      "--add-dir",
       "{{MediaDir}}",
-      "{{Prompt}}",
-      "Use read_many_files to read {{MediaPath}} and respond with only the text output.",
     ],
   };
 }
@@ -682,13 +692,13 @@ async function resolveAutoEntries(params: {
       return [localAudio];
     }
   }
-  const gemini = await resolveGeminiCliEntry(params.capability);
-  if (gemini) {
-    return [gemini];
-  }
   const keys = await resolveKeyEntry(params);
   if (keys) {
     return [keys];
+  }
+  const antigravity = await resolveAntigravityCliEntry(params.capability);
+  if (antigravity) {
+    return [antigravity];
   }
   return [];
 }

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -541,10 +541,10 @@ async function resolveAntigravityCliEntry(
     type: "cli",
     command,
     args: [
-      "--print",
-      "{{Prompt}}\n\nInspect {{MediaPath}} and reply with only the requested media description.",
       "--add-dir",
       "{{MediaDir}}",
+      "--print",
+      "{{Prompt}}\n\nInspect {{MediaPath}} and reply with only the requested media description.",
     ],
   };
 }

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -15,6 +15,7 @@ import type {
   MediaUnderstandingModelConfig,
 } from "../config/types.tools.js";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
+import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { logWarn } from "../logger.js";
 import { resolveChannelInboundAttachmentRoots } from "../media/channel-inbound-roots.js";
 import { mergeInboundPathRoots } from "../media/inbound-path-policy.js";
@@ -410,8 +411,14 @@ async function probeAntigravityCliCandidate(command: string): Promise<string | n
   if (!resolved) {
     return null;
   }
+  const probeDir = await fs.mkdtemp(
+    path.join(resolvePreferredOpenClawTmpDir(), "openclaw-antigravity-probe-"),
+  );
   try {
-    const { stdout } = await runExec(resolved, ["--help"], { timeoutMs: 3000 });
+    const { stdout } = await runExec(resolved, ["--help"], {
+      timeoutMs: 3000,
+      cwd: probeDir,
+    });
     return stdout.includes("--print") &&
       stdout.includes("--add-dir") &&
       stdout.includes("--sandbox")
@@ -419,6 +426,8 @@ async function probeAntigravityCliCandidate(command: string): Promise<string | n
       : null;
   } catch {
     return null;
+  } finally {
+    await fs.rm(probeDir, { recursive: true, force: true }).catch(() => {});
   }
 }
 

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -412,7 +412,11 @@ async function probeAntigravityCliCandidate(command: string): Promise<string | n
   }
   try {
     const { stdout } = await runExec(resolved, ["--help"], { timeoutMs: 3000 });
-    return stdout.includes("--print") && stdout.includes("--add-dir") ? resolved : null;
+    return stdout.includes("--print") &&
+      stdout.includes("--add-dir") &&
+      stdout.includes("--sandbox")
+      ? resolved
+      : null;
   } catch {
     return null;
   }
@@ -541,6 +545,7 @@ async function resolveAntigravityCliEntry(
     type: "cli",
     command,
     args: [
+      "--sandbox",
       "--add-dir",
       "{{MediaDir}}",
       "--print",


### PR DESCRIPTION
## Summary

- remove Gemini CLI as an implicit media-understanding auto fallback
- add Antigravity CLI as a lower-priority image/video fallback after configured provider APIs
- sandbox Antigravity fallback execution in the media directory and isolate capability probing from the service cwd

## Verification

- `node scripts/run-vitest.mjs src/media-understanding/apply.test.ts --reporter=verbose`
- `node scripts/run-vitest.mjs src/media-understanding/runner.video.test.ts --reporter=verbose`
- `git diff --check -- src/media-understanding/runner.ts src/media-understanding/runner.entries.ts src/media-understanding/apply.test.ts CHANGELOG.md`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- Live Antigravity CLI smoke: installed `/Users/steipete/.local/bin/agy` 1.0.1, authenticated, verified `--print`, `--add-dir`, and generated-PNG OCR returned expected text.

Behavior addressed: media-understanding no longer probes phased-out Gemini CLI automatically; Antigravity CLI is only a lower-priority image/video fallback after real provider APIs.
Real environment tested: local macOS checkout with installed Antigravity CLI 1.0.1 and targeted Vitest media-understanding suites.
Exact steps or command run after this patch: commands listed above, plus live `agy --sandbox --add-dir <tmpdir> --print <prompt>` file-read smoke.
Evidence after fix: targeted media-understanding tests passed, live Antigravity CLI returned expected file/image text, autoreview clean after accepted fixes.
Observed result after fix: provider API selection stays ahead of CLI fallback, Gemini CLI is not probed, Antigravity runs sandboxed from the media directory.
What was not tested: full `pnpm check`; scope is limited to media auto-selection and CLI fallback wiring.
