### PR TITLE
Emit command output events for approved gateway execs

### DIFF
--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -1,4 +1,9 @@
 import { beforeAll, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import {
+  getAgentRunContext,
+  onAgentEvent,
+  resetAgentEventsForTest,
+} from "../infra/agent-events.js";
 import type { ExecApprovalFollowupTarget } from "./bash-tools.exec-host-shared.js";
 import type { ExecApprovalFollowupFactory } from "./bash-tools.exec-types.js";
 
@@ -196,6 +201,7 @@ describe("processGatewayAllowlist", () => {
   });
 
   beforeEach(() => {
+    resetAgentEventsForTest();
     buildExecApprovalPendingToolResultMock.mockReset();
     buildExecApprovalFollowupTargetMock.mockReset();
     buildExecApprovalFollowupTargetMock.mockReturnValue(null);
@@ -653,6 +659,144 @@ EOF`,
     expect(approvalInput?.trigger).toBe("diagnostics");
     expect(approvalInput?.outcome?.status).toBe("completed");
     expect(approvalInput?.outcome?.exitCode).toBe(0);
+  });
+
+  it("emits command output when an async gateway exec approval finishes", async () => {
+    const events: Array<{ runId?: string; stream?: string; sessionKey?: string; data?: unknown }> =
+      [];
+    onAgentEvent((event) => {
+      events.push(event);
+    });
+    resolveApprovalDecisionOrUndefinedMock.mockResolvedValue("allow-once");
+    createExecApprovalDecisionStateMock.mockReturnValue({
+      baseDecision: { timedOut: false },
+      approvedByAsk: true,
+      deniedReason: null,
+    });
+    const outcome = {
+      status: "completed" as const,
+      exitCode: 0,
+      exitSignal: null,
+      durationMs: 12,
+      timedOut: false,
+      aggregated: "hello from approval\n",
+    };
+    runExecProcessMock.mockResolvedValue({
+      session: { id: "sess-1" },
+      promise: Promise.resolve(outcome),
+    });
+    buildExecApprovalFollowupTargetMock.mockImplementation((value) => value);
+
+    const result = await runGatewayAllowlist({
+      command: "echo hello",
+      sessionKey: "agent:main:webchat:thread:1",
+      notifySessionKey: "agent:main:telegram:direct:123",
+      turnSourceChannel: "webchat",
+      approvalFollowupMode: "direct",
+    });
+
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
+    await vi.waitFor(() => {
+      expect(events.some((event) => event.stream === "command_output")).toBe(true);
+    });
+
+    const commandOutputEvent = events.find((event) => event.stream === "command_output");
+    expect(commandOutputEvent).toEqual(
+      expect.objectContaining({
+        runId: "exec-approval-followup:req-1",
+        sessionKey: "agent:main:telegram:direct:123",
+      }),
+    );
+    expect(commandOutputEvent?.data).toEqual(
+      expect.objectContaining({
+        itemId: "command:req-1",
+        phase: "end",
+        title: "Command",
+        toolCallId: "req-1",
+        command: "echo hello",
+        name: "exec",
+        output: "hello from approval\n",
+        status: "completed",
+        exitCode: 0,
+        cwd: process.cwd(),
+        approvalId: "req-1",
+      }),
+    );
+    expect(getAgentRunContext("exec-approval-followup:req-1")).toEqual(
+      expect.objectContaining({
+        sessionKey: "agent:main:telegram:direct:123",
+        isControlUiVisible: true,
+      }),
+    );
+  });
+
+  it("redacts and keeps external-channel gateway approval command output hidden", async () => {
+    const events: Array<{ runId?: string; stream?: string; sessionKey?: string; data?: unknown }> =
+      [];
+    onAgentEvent((event) => {
+      events.push(event);
+    });
+    resolveApprovalDecisionOrUndefinedMock.mockResolvedValue("allow-once");
+    createExecApprovalDecisionStateMock.mockReturnValue({
+      baseDecision: { timedOut: false },
+      approvedByAsk: true,
+      deniedReason: null,
+    });
+    const outcome = {
+      status: "completed" as const,
+      exitCode: 0,
+      exitSignal: null,
+      durationMs: 12,
+      timedOut: false,
+      aggregated: "OPENROUTER_API_KEY=sk-or-v1-abcdef0123456789\nexternal output\n",
+    };
+    runExecProcessMock.mockResolvedValue({
+      session: { id: "sess-1" },
+      promise: Promise.resolve(outcome),
+    });
+    buildExecApprovalFollowupTargetMock.mockImplementation((value) => value);
+
+    await runGatewayAllowlist({
+      command: "echo --token ghp_abcdefghij1234567890 external",
+      sessionKey: "agent:main:telegram:direct:123",
+      notifySessionKey: "agent:main:telegram:direct:123",
+      turnSourceChannel: "telegram",
+    });
+
+    await vi.waitFor(() => {
+      expect(events.some((event) => event.stream === "command_output")).toBe(true);
+    });
+
+    const commandOutputEvent = events.find((event) => event.stream === "command_output");
+    expect(commandOutputEvent).toEqual(
+      expect.objectContaining({
+        runId: "exec-approval-followup:req-1",
+      }),
+    );
+    expect(commandOutputEvent?.sessionKey).toBeUndefined();
+    expect(commandOutputEvent?.data).toEqual(
+      expect.objectContaining({
+        status: "completed",
+        approvalId: "req-1",
+      }),
+    );
+    const serialized = JSON.stringify(commandOutputEvent?.data);
+    expect(serialized).not.toContain("sk-or-v1-abcdef0123456789");
+    expect(serialized).not.toContain("ghp_abcdefghij1234567890");
+    expect(commandOutputEvent?.data).toEqual(
+      expect.objectContaining({
+        command: expect.stringContaining("echo --token"),
+        output: expect.stringContaining("external output"),
+        status: "completed",
+        approvalId: "req-1",
+      }),
+    );
+    expect(getAgentRunContext("exec-approval-followup:req-1")).toEqual(
+      expect.objectContaining({
+        sessionKey: "agent:main:telegram:direct:123",
+        isControlUiVisible: false,
+      }),
+    );
   });
 
   it("waits inline for webchat approval so the exec tool can return real output to the model", async () => {

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -1,4 +1,5 @@
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import { emitAgentCommandOutputEvent, registerAgentRunContext } from "../infra/agent-events.js";
 import { describeInterpreterInlineEval } from "../infra/command-analysis/inline-eval.js";
 import { detectPolicyInlineEval } from "../infra/command-analysis/policy.js";
 import {
@@ -16,6 +17,8 @@ import {
   requiresExecApproval,
 } from "../infra/exec-approvals.js";
 import type { SafeBinProfile } from "../infra/exec-safe-bin-policy.js";
+import { redactToolPayloadText } from "../logging/redact.js";
+import { truncateUtf16Safe } from "../utils.js";
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../utils/message-channel.js";
 import { markBackgrounded, tail } from "./bash-process-registry.js";
 import {
@@ -83,6 +86,8 @@ export type ProcessGatewayAllowlistParams = {
   pendingMaxOutput: number;
   trustedSafeBinDirs?: ReadonlySet<string>;
 };
+
+const COMMAND_OUTPUT_MAX_CHARS = 8000;
 
 export type ProcessGatewayAllowlistResult = {
   execCommandOverride?: string;
@@ -359,6 +364,14 @@ function shouldAwaitGatewayApprovalInline(params: {
   return normalizeMessageChannel(params.turnSourceChannel) === INTERNAL_MESSAGE_CHANNEL;
 }
 
+function redactGatewayCommandOutputText(value: string): string {
+  const redacted = redactToolPayloadText(value);
+  if (redacted.length <= COMMAND_OUTPUT_MAX_CHARS) {
+    return redacted;
+  }
+  return `${truncateUtf16Safe(redacted, COMMAND_OUTPUT_MAX_CHARS)}\n...(live output truncated)...`;
+}
+
 function buildGatewayExecApprovalDeniedToolResult(params: {
   approvalId: string;
   deniedReason: string;
@@ -400,6 +413,40 @@ async function resolveGatewayExecApprovalFollowupText(params: {
     const message = error instanceof Error ? error.message : String(error);
     return `Diagnostics follow-up failed: ${message}`;
   }
+}
+
+function emitGatewayExecApprovalCommandOutput(params: {
+  approvalId: string;
+  command: string;
+  cwd?: string;
+  sessionKey?: string;
+  turnSourceChannel?: string;
+  outcome: ExecApprovalFollowupOutcome;
+}): void {
+  const runId = `exec-approval-followup:${params.approvalId}`;
+  const sessionKey = params.sessionKey?.trim();
+  registerAgentRunContext(runId, {
+    ...(sessionKey ? { sessionKey } : {}),
+    isControlUiVisible:
+      normalizeMessageChannel(params.turnSourceChannel) === INTERNAL_MESSAGE_CHANNEL,
+  });
+  emitAgentCommandOutputEvent({
+    runId,
+    ...(sessionKey ? { sessionKey } : {}),
+    data: {
+      itemId: `command:${params.approvalId}`,
+      phase: "end",
+      title: "Command",
+      toolCallId: params.approvalId,
+      command: redactGatewayCommandOutputText(params.command),
+      name: "exec",
+      output: redactGatewayCommandOutputText(params.outcome.aggregated),
+      status: params.outcome.status,
+      exitCode: params.outcome.exitCode,
+      cwd: params.cwd,
+      approvalId: params.approvalId,
+    },
+  });
 }
 
 export async function processGatewayAllowlist(
@@ -754,6 +801,14 @@ export async function processGatewayAllowlist(
       markBackgrounded(run.session);
 
       const outcome = await run.promise;
+      emitGatewayExecApprovalCommandOutput({
+        approvalId,
+        command: params.command,
+        cwd: params.workdir,
+        sessionKey: params.notifySessionKey ?? params.sessionKey,
+        turnSourceChannel: params.turnSourceChannel,
+        outcome,
+      });
       const dynamicFollowupText = await resolveGatewayExecApprovalFollowupText({
         approvalFollowup: params.approvalFollowup,
         approvalId,

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -79,12 +79,14 @@ export type AgentCommandOutputEventData = {
   phase: "delta" | "end";
   title: string;
   toolCallId: string;
+  command?: string;
   name?: string;
   output?: string;
   status?: AgentItemEventStatus | "running";
   exitCode?: number | null;
   durationMs?: number;
   cwd?: string;
+  approvalId?: string;
 };
 
 export type AgentPatchSummaryEventData = {


### PR DESCRIPTION
## Summary

- Emit a `command_output` agent event when an async approved gateway exec finishes.
- Add optional `command` and `approvalId` fields to command output event data.
- Register follow-up run context so Control UI visibility follows the originating channel, and redact/truncate command/output text before emission.
- Add gateway exec approval regression coverage for webchat-visible and external-channel-hidden paths.

## Verification

- `pnpm test src/agents/bash-tools.exec-host-gateway.test.ts -- --reporter=verbose`
- `pnpm check:changed`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean: no accepted/actionable findings)

## Screenshot Proof

Before: the main column only showed the two authorization-attempt commands, without the structured command output event.

![Before: main column missing structured output](https://raw.githubusercontent.com/carlos-sarmiento/openclaw/pr-assets-85522/openclaw-proof-before-main-column-missing-structured-output.png)

After: the last approved command shows the correct structured output in the main column.

![After: main column shows structured output](https://raw.githubusercontent.com/carlos-sarmiento/openclaw/pr-assets-85522/openclaw-proof-after-main-column-structured-output.png)

Behavior addressed: Async gateway exec approval completions now emit a redacted `command_output` event for agent event subscribers.
Real environment tested: Local source checkout on branch `codex/exec-approval-command-output-event`.
Exact steps or command run after this patch: `pnpm test src/agents/bash-tools.exec-host-gateway.test.ts -- --reporter=verbose`; `pnpm check:changed`; `.agents/skills/autoreview/scripts/autoreview --mode local`.
Evidence after fix: The focused Vitest file passed 18 tests, including new async approval command output coverage and external-channel redaction/routing coverage; the changed core/coreTests gate passed; autoreview reported no accepted/actionable findings.
Observed result after fix: Approved async gateway exec completions produce `command_output` events while external-channel outputs remain hidden from session routing and secrets are redacted.
What was not tested: Full repository test suite and a live gateway approval flow against a real channel account.
