### PR TITLE
fix(ui): run ui script through junction paths

### DIFF
--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -207,10 +207,29 @@ export function main(argv = process.argv.slice(2)) {
   run(runner.cmd, ["run", script, ...rest]);
 }
 
-const isDirectExecution = (() => {
-  const entry = process.argv[1];
-  return Boolean(entry && path.resolve(entry) === fileURLToPath(import.meta.url));
-})();
+export function resolveDirectExecutionPath(entry, realpath = fs.realpathSync.native) {
+  const resolved = path.resolve(entry);
+  try {
+    return realpath(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+export function isDirectScriptExecution(
+  entry = process.argv[1],
+  scriptPath = fileURLToPath(import.meta.url),
+  realpath = fs.realpathSync.native,
+) {
+  if (!entry) {
+    return false;
+  }
+  return (
+    resolveDirectExecutionPath(entry, realpath) === resolveDirectExecutionPath(scriptPath, realpath)
+  );
+}
+
+const isDirectExecution = isDirectScriptExecution();
 
 if (isDirectExecution) {
   main();

--- a/test/scripts/ui.test.ts
+++ b/test/scripts/ui.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   isDirectScriptExecution,
@@ -94,8 +95,8 @@ describe("scripts/ui windows spawn behavior", () => {
   });
 
   it("detects direct execution through a junctioned script path", () => {
-    const realScriptPath = "/repo/openclaw/scripts/ui.js";
-    const junctionScriptPath = "/linked/openclaw/scripts/ui.js";
+    const realScriptPath = path.resolve("repo/openclaw/scripts/ui.js");
+    const junctionScriptPath = path.resolve("linked/openclaw/scripts/ui.js");
     const realpath = (entry: string) => (entry === junctionScriptPath ? realScriptPath : entry);
 
     expect(isDirectScriptExecution(junctionScriptPath, realScriptPath, realpath)).toBe(true);

--- a/test/scripts/ui.test.ts
+++ b/test/scripts/ui.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { resolveSpawnCall, shouldUseCmdExeForCommand } from "../../scripts/ui.js";
+import {
+  isDirectScriptExecution,
+  resolveSpawnCall,
+  shouldUseCmdExeForCommand,
+} from "../../scripts/ui.js";
 
 describe("scripts/ui windows spawn behavior", () => {
   it("wraps Windows command launchers with cmd.exe without enabling shell mode", () => {
@@ -87,5 +91,13 @@ describe("scripts/ui windows spawn behavior", () => {
         shell: false,
       },
     });
+  });
+
+  it("detects direct execution through a junctioned script path", () => {
+    const realScriptPath = "/repo/openclaw/scripts/ui.js";
+    const junctionScriptPath = "/linked/openclaw/scripts/ui.js";
+    const realpath = (entry: string) => (entry === junctionScriptPath ? realScriptPath : entry);
+
+    expect(isDirectScriptExecution(junctionScriptPath, realScriptPath, realpath)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Problem: Windows linked source installs can launch `scripts/ui.js` through a global npm junction, causing the direct-execution guard to miss and skip `main()`.
- Solution: canonicalize both the entrypoint path and module path with native realpath before comparing them.
- What changed: added a small exported direct-execution helper plus regression coverage for a junctioned entry path.
- What did NOT change (scope boundary): UI dependency install, pnpm/cmd.exe launch wrapping, and Vite build behavior are unchanged.

## Motivation

- Fixes #73059.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Closes #73059
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

Behavior addressed: `scripts/ui.js` now treats a junction/symlink-launched entrypoint as direct execution after canonicalizing both paths, so gateway/UI auto-build entrypoints do not silently skip `main()`.

Real environment tested: WSL Ubuntu 24.04 durable checkout at `/root/src/openclaw-ui-junction-73059` with Node v24.15.0 and pnpm v11.2.2; Windows smoke also run from the local Windows OpenClaw checkout using a temporary directory junction.

Exact steps or command run after this patch:

```sh
git diff --check
pnpm exec oxfmt --check --threads=1 scripts/ui.js test/scripts/ui.test.ts
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/ui.test.ts -- --reporter=verbose
codex review --uncommitted
```

Evidence after fix:

```text
node scripts/run-vitest.mjs test/scripts/ui.test.ts -- --reporter=verbose
Test Files  1 passed (1)
Tests       5 passed (5)
```

```text
Windows junction smoke:
node <temp-junction>\scripts\ui.js
exitCode: 2
stderr: Usage: node scripts/ui.js <install|dev|build|test> [...args]
```

Observed result after fix: The focused unit regression passes, formatting/diff checks pass, and the Windows junction smoke reaches the script usage path instead of silently no-oping.

What was not tested: Full gateway startup and full Control UI Vite build were not rerun for this small wrapper guard change.

Before evidence (optional but encouraged): #73059 includes the before behavior where a junction-launched `scripts/ui.js build` exits without Vite output and leaves `dist/control-ui/index.html` missing.

## Root Cause (if applicable)

- Root cause: `scripts/ui.js` compared `path.resolve(process.argv[1])` directly with `fileURLToPath(import.meta.url)`, so a junction path and the real repo path did not compare equal even though they pointed to the same file.
- Missing detection / guardrail: Existing script tests covered Windows `.cmd` wrapping but not linked or junctioned direct execution.
- Contributing context (if known): Windows `pnpm link --global` installs commonly expose the package through a directory junction.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `test/scripts/ui.test.ts`
- Scenario the test should lock in: a junctioned entry path realpaths to the actual `scripts/ui.js` path and is treated as direct execution.
- Why this is the smallest reliable guardrail: the bug is isolated to the direct-execution predicate; unit coverage can prove the path canonicalization without running Vite.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Linked Windows source installs should run the Control UI wrapper when launched through a global npm junction instead of skipping the build path.

## Diagram (if applicable)

```text
Before:
[junction path] -> [raw path compare fails] -> [main() skipped]

After:
[junction path] -> [native realpath compare] -> [main() runs]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: WSL Ubuntu 24.04 for focused tests; Windows host for temporary junction smoke
- Runtime/container: Node v24.15.0 in WSL
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run the focused script test file.
2. Run formatting and diff checks.
3. Run a direct script invocation through a junction path and confirm `main()` handles the no-argument usage path.

### Expected

- The direct-execution predicate treats the linked entry path and real script path as the same file.

### Actual

- The new regression test passes and the junction smoke prints `Usage: node scripts/ui.js ...` with exit code 2.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

## Human Verification (required)

- Verified scenarios: focused WSL test run, oxfmt check, diff check, Windows junction no-argument smoke, Codex review.
- Edge cases checked: missing `process.argv[1]` still returns false; realpath failures fall back to resolved paths.
- What you did not verify: full gateway startup and full UI Vite build.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Realpath lookup can fail for unusual paths.
  - Mitigation: the helper falls back to the previous resolved-path behavior.