### PR TITLE
fix(subagents): honor automatic completion delivery

### DIFF
--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -2533,7 +2533,52 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
-  it("keeps configured channel subagent completions on parent message-tool handoff", async () => {
+  it("allows automatic visible final delivery for channel subagent completions", async () => {
+    const callGateway = createGatewayMock({
+      result: {
+        payloads: [{ text: "The subagent is done." }],
+      },
+    });
+    const queueEmbeddedPiMessageWithOutcome = createQueueOutcomeMock(false);
+    const result = await deliverSlackChannelAnnouncement({
+      callGateway,
+      sessionId: "requester-session-channel",
+      isActive: false,
+      expectsCompletionMessage: true,
+      directIdempotencyKey: "announce-channel-subagent-automatic",
+      sourceTool: "subagent_announce",
+      runtimeConfig: { messages: { groupChat: { visibleReplies: "automatic" } } },
+      queueEmbeddedPiMessageWithOutcome,
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "subagent",
+          childSessionKey: "agent:worker:subagent:child",
+          childSessionId: "child-session-id",
+          announceType: "subagent task",
+          taskLabel: "channel completion smoke",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "child completion output",
+          replyInstruction: "Summarize the result.",
+        },
+      ],
+    });
+
+    expectRecordFields(result, {
+      delivered: true,
+      path: "direct",
+    });
+    expectGatewayAgentParams(callGateway, {
+      deliver: true,
+      channel: "slack",
+      accountId: "acct-1",
+      to: "channel:C123",
+      threadId: undefined,
+    });
+  });
+
+  it("requires message-tool delivery for configured channel subagent completions", async () => {
     const callGateway = createGatewayMock({
       result: {
         payloads: [{ text: "The subagent is done." }],


### PR DESCRIPTION
## Summary

- Stop forcing all group/channel subagent completions onto `message_tool_only` delivery.
- Let text-only subagent completions honor the configured visible-reply policy, including `messages.groupChat.visibleReplies: "automatic"`.
- Preserve strict message-tool delivery for generated media completions and for group/channel configs that explicitly set `visibleReplies: "message_tool"`.

## Why

The completion-delivery policy already resolves group/channel completions from configuration, but the subagent announce path overrode that policy by treating every group or channel completion as requiring message-tool delivery. When the requester announce agent returned a normal final text instead of using the message tool, delivery failed with `completion agent did not deliver through the message tool` even for text-only completions where automatic visible replies were configured.

This change removes the hard-coded group/channel override and keeps the existing policy and media checks as the source of truth.

## Tests

- `corepack pnpm test src/agents/subagent-announce-delivery.test.ts`
- `corepack pnpm format:check src/agents/subagent-announce-delivery.ts src/agents/subagent-announce-delivery.test.ts`
- `corepack pnpm lint:core -- src/agents/subagent-announce-delivery.ts src/agents/subagent-announce-delivery.test.ts`
- `corepack pnpm tsgo:core:test`
- `git diff --check`

No live Gateway/runtime testing was used for this source-level delivery-policy change.

## Real behavior proof

- Behavior or issue addressed: Text-only subagent completion delivery for channel/group requesters with `messages.groupChat.visibleReplies: "automatic"` should stay on automatic visible final delivery instead of being forced into message-tool-only delivery.
- Real environment tested: Disposable OpenClaw source checkout on Linux arm64 under an isolated systemd scope via `openclaw-heavy-run`; no production Gateway/runtime and no personal Telegram/live external channel were used.
- Exact steps or command run after this patch: `PATH="$PWD/.tmp-bin:$PATH" /home/ubuntu/.openclaw/workspace/.github/scripts/openclaw-heavy-run --backend systemd --force --memory-max-mb 8192 --tasks-max 1024 -- corepack pnpm exec vitest run src/agents/subagent-announce-delivery.test.ts --config test/vitest/vitest.agents.config.ts --pool=forks --maxWorkers=1 --no-fileParallelism --testNamePattern='(allows automatic visible final delivery|requires message-tool delivery|fails configured channel subagent completions)' --testTimeout=30000 --reporter=verbose`.
- Evidence after fix: Terminal output from the disposable checkout showed the targeted after-fix behavior and guard rails passing:

  ```text
  ✓ deliverSubagentAnnouncement completion delivery > allows automatic visible final delivery for channel subagent completions 3ms
  ✓ deliverSubagentAnnouncement completion delivery > requires message-tool delivery for configured channel subagent completions 2ms
  ✓ deliverSubagentAnnouncement completion delivery > fails configured channel subagent completions when parent skips required message tool 5ms

  Test Files  1 passed (1)
  Tests  5 passed | 55 skipped (60)
  Duration  4.66s
  ```
- Observed result after fix: The automatic visible-reply regression now drives the requester-agent handoff with `deliver: true` for Slack channel completion origin `channel:C123` when `visibleReplies: "automatic"`, while the adjacent message-tool-only checks still require `sourceReplyDeliveryMode: "message_tool_only"` and fail if the parent skips the message tool.
- What was not tested: No live OpenClaw Gateway/runtime and no native Telegram/Desktop transport proof. A Mantis Telegram Desktop capture attempted on 2026-05-22 but failed before behavior proof because shared Telegram proof credentials were unavailable (`POOL_EXHAUSTED`); artifact `mantis-telegram-desktop-proof-26315820808-1` contains a failing infrastructure-block manifest.
