### PR TITLE
Doctor: expose UI freshness health findings

### DIFF
--- a/src/commands/doctor-ui.test.ts
+++ b/src/commands/doctor-ui.test.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { detectUiProtocolFreshnessIssues } from "./doctor-ui.js";
+
+const tempRoots: string[] = [];
+
+async function createOpenClawRoot(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-doctor-ui-"));
+  tempRoots.push(root);
+  await fs.writeFile(path.join(root, "package.json"), JSON.stringify({ name: "openclaw" }));
+  await fs.mkdir(path.join(root, "src/gateway/protocol"), { recursive: true });
+  await fs.writeFile(path.join(root, "src/gateway/protocol/schema.ts"), "export {};\n");
+  return root;
+}
+
+async function touch(filePath: string, date: Date): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, "");
+  await fs.utimes(filePath, date, date);
+}
+
+describe("detectUiProtocolFreshnessIssues", () => {
+  afterEach(async () => {
+    await Promise.all(
+      tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
+    );
+  });
+
+  it("reports missing Control UI assets when protocol schema exists", async () => {
+    const root = await createOpenClawRoot();
+    await fs.mkdir(path.join(root, "ui"), { recursive: true });
+    await fs.writeFile(path.join(root, "ui/package.json"), "{}");
+
+    await expect(detectUiProtocolFreshnessIssues({ root })).resolves.toEqual([
+      {
+        kind: "missing-assets",
+        uiIndexPath: path.join(root, "dist/control-ui/index.html"),
+        canBuild: true,
+      },
+    ]);
+  });
+
+  it("marks missing assets as not locally buildable when UI sources are absent", async () => {
+    const root = await createOpenClawRoot();
+
+    await expect(detectUiProtocolFreshnessIssues({ root })).resolves.toEqual([
+      expect.objectContaining({
+        kind: "missing-assets",
+        canBuild: false,
+      }),
+    ]);
+  });
+
+  it("does not report current Control UI assets", async () => {
+    const root = await createOpenClawRoot();
+    const schemaPath = path.join(root, "src/gateway/protocol/schema.ts");
+    const uiIndexPath = path.join(root, "dist/control-ui/index.html");
+    await touch(schemaPath, new Date("2026-01-01T00:00:00.000Z"));
+    await touch(uiIndexPath, new Date("2026-01-02T00:00:00.000Z"));
+
+    await expect(detectUiProtocolFreshnessIssues({ root })).resolves.toEqual([]);
+  });
+
+  it("reports stale assets even when git history is unavailable", async () => {
+    const root = await createOpenClawRoot();
+    const schemaPath = path.join(root, "src/gateway/protocol/schema.ts");
+    const uiIndexPath = path.join(root, "dist/control-ui/index.html");
+    await touch(uiIndexPath, new Date("2026-01-01T00:00:00.000Z"));
+    await touch(schemaPath, new Date("2026-01-02T00:00:00.000Z"));
+
+    await expect(detectUiProtocolFreshnessIssues({ root })).resolves.toEqual([
+      {
+        kind: "stale-assets",
+        uiIndexPath,
+        changesSinceBuild: [],
+        canBuild: false,
+      },
+    ]);
+  });
+});

--- a/src/commands/doctor-ui.ts
+++ b/src/commands/doctor-ui.ts
@@ -10,6 +10,19 @@ import type { RuntimeEnv } from "../runtime.js";
 import { note } from "../terminal/note.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 
+export type UiProtocolFreshnessIssue =
+  | {
+      readonly kind: "missing-assets";
+      readonly uiIndexPath: string;
+      readonly canBuild: boolean;
+    }
+  | {
+      readonly kind: "stale-assets";
+      readonly uiIndexPath: string;
+      readonly changesSinceBuild: readonly string[];
+      readonly canBuild: boolean;
+    };
+
 export async function maybeRepairUiProtocolFreshness(
   _runtime: RuntimeEnv,
   prompter: DoctorPrompter,
@@ -151,4 +164,71 @@ export async function maybeRepairUiProtocolFreshness(
     // If git fails, we silently skip.
     // runtime.debug(`UI freshness check failed: ${String(err)}`);
   }
+}
+
+export async function detectUiProtocolFreshnessIssues(
+  opts: { readonly root?: string; readonly argv1?: string; readonly cwd?: string } = {},
+): Promise<readonly UiProtocolFreshnessIssue[]> {
+  const root =
+    opts.root ??
+    (await resolveOpenClawPackageRoot({
+      moduleUrl: import.meta.url,
+      argv1: opts.argv1 ?? process.argv[1],
+      cwd: opts.cwd ?? process.cwd(),
+    }));
+  if (!root) {
+    return [];
+  }
+
+  const schemaPath = path.join(root, "src/gateway/protocol/schema.ts");
+  const uiHealth = await resolveControlUiDistIndexHealth({
+    root,
+    argv1: opts.argv1 ?? process.argv[1],
+  });
+  const uiIndexPath = uiHealth.indexPath ?? resolveControlUiDistIndexPathForRoot(root);
+  const uiSourcesPath = path.join(root, "ui/package.json");
+
+  try {
+    const [schemaStats, uiStats, uiSourcesStats] = await Promise.all([
+      fs.stat(schemaPath).catch(() => null),
+      fs.stat(uiIndexPath).catch(() => null),
+      fs.stat(uiSourcesPath).catch(() => null),
+    ]);
+    if (!schemaStats) {
+      return [];
+    }
+    const canBuild = uiSourcesStats !== null;
+    if (!uiStats) {
+      return [{ kind: "missing-assets", uiIndexPath, canBuild }];
+    }
+    if (schemaStats.mtime <= uiStats.mtime) {
+      return [];
+    }
+    const changesSinceBuild = await collectProtocolSchemaChangesSince(root, uiStats.mtime);
+    return [{ kind: "stale-assets", uiIndexPath, changesSinceBuild, canBuild }];
+  } catch {
+    return [];
+  }
+}
+
+async function collectProtocolSchemaChangesSince(
+  root: string,
+  uiMtime: Date,
+): Promise<readonly string[]> {
+  const gitLog = await runCommandWithTimeout(
+    [
+      "git",
+      "-C",
+      root,
+      "log",
+      `--since=${uiMtime.toISOString()}`,
+      "--format=%h %s",
+      "src/gateway/protocol/schema.ts",
+    ],
+    { timeoutMs: 5000 },
+  ).catch(() => null);
+  if (!gitLog || gitLog.code !== 0 || !gitLog.stdout.trim()) {
+    return [];
+  }
+  return gitLog.stdout.trim().split("\n");
 }

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -471,6 +471,47 @@ const openAIOAuthTlsCheck: HealthCheck = {
   },
 };
 
+const uiFreshnessCheck: HealthCheck = {
+  id: "core/doctor/ui-freshness",
+  kind: "core",
+  description: "Control UI assets match the gateway protocol schema.",
+  source: "doctor",
+  async detect() {
+    const { detectUiProtocolFreshnessIssues } = await import("../commands/doctor-ui.js");
+    const issues = await detectUiProtocolFreshnessIssues();
+    return issues.map((issue): HealthFinding => {
+      if (issue.kind === "missing-assets") {
+        return {
+          checkId: "core/doctor/ui-freshness",
+          severity: "warning",
+          message: "Control UI assets are missing.",
+          path: issue.uiIndexPath,
+          fixHint: issue.canBuild
+            ? "Run `openclaw doctor --fix` to build Control UI assets."
+            : "Install a package that includes Control UI sources, then run `pnpm ui:build`.",
+        };
+      }
+      return {
+        checkId: "core/doctor/ui-freshness",
+        severity: "warning",
+        message: "Control UI assets are older than the gateway protocol schema.",
+        path: issue.uiIndexPath,
+        fixHint: issue.canBuild
+          ? formatUiFreshnessFixHint(issue.changesSinceBuild)
+          : "Install a package that includes Control UI sources, then run `pnpm ui:build`.",
+      };
+    });
+  },
+};
+
+function formatUiFreshnessFixHint(changesSinceBuild: readonly string[]): string {
+  const base = "Run `openclaw doctor --fix --force` to rebuild Control UI assets.";
+  if (changesSinceBuild.length === 0) {
+    return base;
+  }
+  return `${base} Protocol changes since the last build: ${changesSinceBuild.join("; ")}`;
+}
+
 const legacyWhatsAppCrontabCheck: HealthCheck = {
   id: "core/doctor/legacy-whatsapp-crontab",
   kind: "core",
@@ -746,6 +787,7 @@ function createConvertedWorkflowChecks(deps: CoreHealthCheckDeps): readonly Heal
     createSecurityCheck(deps),
     browserCheck,
     openAIOAuthTlsCheck,
+    uiFreshnessCheck,
     hooksModelCheck,
     bootstrapSizeCheck,
     createWorkspaceSuggestionsCheck(deps),

--- a/src/flows/doctor-health-conversion-plan.ts
+++ b/src/flows/doctor-health-conversion-plan.ts
@@ -168,6 +168,12 @@ export const doctorHealthConversionRules = [
     rule: "Expose OAuth TLS prerequisites as findings; preserve deep-mode detail as finding metadata.",
   },
   {
+    contributionId: "doctor:ui-freshness",
+    conversion: "detect-only",
+    target: ["core/doctor/ui-freshness"],
+    rule: "Expose missing or stale Control UI build assets as findings; keep build/rebuild execution on the legacy doctor preflight path.",
+  },
+  {
     contributionId: "doctor:hooks-model",
     conversion: "detect-only",
     target: ["core/doctor/hooks-model"],


### PR DESCRIPTION
## Summary

Adds a small structured doctor lint check for Control UI freshness:

- detects missing dist/control-ui/index.html when the gateway protocol schema exists
- detects stale Control UI assets when the schema mtime is newer than the built index
- reports whether local UI sources are present so the finding can point users at the right repair path

The existing doctor preflight still owns the actual build/rebuild behavior. This PR does not add public SDK or CLI surface, and it does not move the legacy UI repair path.

## Real behavior proof

Behavior or issue addressed:
Doctor lint can now report missing or stale Control UI assets as structured core/doctor/ui-freshness findings while leaving existing doctor --fix UI build/rebuild behavior unchanged.

Real environment tested:
WSL Ubuntu 24.04 durable OpenClaw worktree at /root/src/openclaw-ui-freshness-main, source harness tests with temporary package roots and no live UI build.

Exact steps or command run after this patch:
1. pnpm exec oxfmt --check src/commands/doctor-ui.test.ts src/commands/doctor-ui.ts src/flows/doctor-core-checks.ts src/flows/doctor-health-conversion-plan.ts
2. pnpm exec oxlint src/commands/doctor-ui.ts src/commands/doctor-ui.test.ts src/flows/doctor-core-checks.ts src/flows/doctor-health-conversion-plan.ts
3. node scripts/run-vitest.mjs src/commands/doctor-ui.test.ts src/flows/doctor-core-checks.test.ts --reporter=dot
4. node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
5. node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
6. /mnt/c/src/claws-hapi/.agents/skills/autoreview/scripts/autoreview --mode local

Evidence after fix:
Focused Vitest output: 2 test files passed, 10 tests passed. oxfmt reported all matched files use the correct format. oxlint reported 0 warnings and 0 errors. Core and core-test tsgo commands exited 0. Autoreview reported clean: no accepted/actionable findings.

Observed result after fix:
The detector reports missing Control UI assets, distinguishes when ui/package.json is absent, ignores current assets, and still reports stale assets when git history is unavailable. The core health registry includes core/doctor/ui-freshness and the conversion inventory recognizes it.

What was not tested:
No live Control UI rebuild was run because this PR intentionally leaves build/rebuild execution on the existing doctor preflight repair path. pnpm check:changed was attempted; relevant core typecheck lanes passed, then the broad core lint wrapper failed while preparing WhatsApp boundary artifacts because this WSL worktree cannot resolve baileys in extensions/whatsapp. That failure is outside the changed files.

## Validation

- pnpm exec oxfmt --check src/commands/doctor-ui.test.ts src/commands/doctor-ui.ts src/flows/doctor-core-checks.ts src/flows/doctor-health-conversion-plan.ts
- pnpm exec oxlint src/commands/doctor-ui.ts src/commands/doctor-ui.test.ts src/flows/doctor-core-checks.ts src/flows/doctor-health-conversion-plan.ts
- node scripts/run-vitest.mjs src/commands/doctor-ui.test.ts src/flows/doctor-core-checks.test.ts --reporter=dot
- node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
- node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
- git diff --check
- autoreview clean

## Notes

This is a small main-based replacement for the old draft branch. It keeps the UI repair behavior positional and only adds structured lint visibility for the same asset freshness condition.
