### PR TITLE
fix(codex): add API key paste auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/chat: convert pasted `data:image/...;base64,...` clipboard text into an image attachment instead of dumping the payload into the composer. Fixes #62604. Thanks @cpwilhelmi.
 - Providers/Gemini: strip fractional seconds from web-search time range filters so Gemini accepts freshness-bound search requests. (#85071) Thanks @Noerr.
 - OpenAI Codex: preserve image input support for sparse `openai-codex/gpt-5.5` catalog rows. (#85095) Thanks @sercada.
+- CLI/models: add an API-key paste path for OpenAI Codex auth and warn when API keys are pasted into token-mode auth. (#85533) Thanks @joshavant.
 - Plugins/discovery: strip `-plugin` package suffixes when deriving plugin id hints so package names line up with manifest ids. (#85170) Thanks @JulyanXu.
 - Tlon: stop advertising a non-existent agent tool contract in the plugin manifest.
 - Telegram: preserve fenced code block languages through Markdown rendering so Telegram receives `language-*` code classes. (#85209) Thanks @leno23.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/chat: convert pasted `data:image/...;base64,...` clipboard text into an image attachment instead of dumping the payload into the composer. Fixes #62604. Thanks @cpwilhelmi.
 - Providers/Gemini: strip fractional seconds from web-search time range filters so Gemini accepts freshness-bound search requests. (#85071) Thanks @Noerr.
 - OpenAI Codex: preserve image input support for sparse `openai-codex/gpt-5.5` catalog rows. (#85095) Thanks @sercada.
-- CLI/models: add an API-key paste path for OpenAI Codex auth and warn when API keys are pasted into token-mode auth. (#85533) Thanks @joshavant.
+- CLI/models: add a piped or pasted API-key path for OpenAI Codex auth and warn when API keys are pasted into token-mode auth. (#85533) Thanks @joshavant.
 - Plugins/discovery: strip `-plugin` package suffixes when deriving plugin id hints so package names line up with manifest ids. (#85170) Thanks @JulyanXu.
 - Tlon: stop advertising a non-existent agent tool contract in the plugin manifest.
 - Telegram: preserve fenced code block languages through Markdown rendering so Telegram receives `language-*` code classes. (#85209) Thanks @leno23.

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -207,7 +207,8 @@ Notes:
 
 - `paste-api-key` accepts API keys generated elsewhere, prompts for the key
   value, and writes it to the default profile id `<provider>:manual` unless you
-  pass `--profile-id`.
+  pass `--profile-id`. In automation, pipe the key on stdin, for example
+  `printf "%s\n" "$OPENAI_API_KEY" | openclaw models auth paste-api-key --provider openai-codex`.
 - `setup-token` and `paste-token` remain generic token commands for providers
   that expose token auth methods.
 - `setup-token` requires an interactive TTY and runs the provider's token-auth

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -169,6 +169,7 @@ openclaw models fallbacks list
 openclaw models auth add
 openclaw models auth list [--provider <id>] [--json]
 openclaw models auth login --provider <id>
+openclaw models auth paste-api-key --provider <id>
 openclaw models auth setup-token --provider <id>
 openclaw models auth paste-token
 ```
@@ -185,7 +186,7 @@ filter to one provider, such as `openai-codex`, and `--json` for scripting.
 `openclaw plugins list` to see which providers are installed.
 Use `openclaw models auth --agent <id> <subcommand>` to write auth results to a
 specific configured agent store. The parent `--agent` flag is honored by
-`add`, `list`, `login`, `setup-token`, `paste-token`, and
+`add`, `list`, `login`, `paste-api-key`, `setup-token`, `paste-token`, and
 `login-github-copilot`.
 
 For OpenAI models, `--provider openai` defaults to ChatGPT/Codex account login.
@@ -198,11 +199,15 @@ Examples:
 ```bash
 openclaw models auth login --provider openai --set-default
 openclaw models auth login --provider openai --method api-key
+openclaw models auth paste-api-key --provider openai-codex
 openclaw models auth list --provider openai
 ```
 
 Notes:
 
+- `paste-api-key` accepts API keys generated elsewhere, prompts for the key
+  value, and writes it to the default profile id `<provider>:manual` unless you
+  pass `--profile-id`.
 - `setup-token` and `paste-token` remain generic token commands for providers
   that expose token auth methods.
 - `setup-token` requires an interactive TTY and runs the provider's token-auth
@@ -214,6 +219,9 @@ Notes:
   `--profile-id`.
 - `paste-token --expires-in <duration>` stores an absolute token expiry from a
   relative duration such as `365d` or `12h`.
+- For `openai-codex`, OpenAI API keys and ChatGPT/OAuth token material are
+  different auth shapes. Use `paste-api-key` for `sk-...` OpenAI API keys and
+  `paste-token` only for token auth material.
 - Anthropic note: Anthropic staff told us OpenClaw-style Claude CLI usage is allowed again, so OpenClaw treats Claude CLI reuse and `claude -p` usage as sanctioned for this integration unless Anthropic publishes a new policy.
 - Anthropic `setup-token` / `paste-token` remain available as a supported OpenClaw token path, but OpenClaw now prefers Claude CLI reuse and `claude -p` when available.
 

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -1123,6 +1123,62 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
   });
 
+  it("rejects OpenAI API keys stored as OpenAI Codex token profiles before app-server login", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const request = vi.fn(async () => ({ type: "chatgptAuthTokens" }));
+    try {
+      upsertAuthProfile({
+        agentDir,
+        profileId: "openai-codex:work",
+        credential: {
+          type: "token",
+          provider: "openai-codex",
+          token: "sk-openai-codex-api-key-value",
+        },
+      });
+
+      await expect(
+        applyCodexAppServerAuthProfile({
+          client: { request } as never,
+          agentDir,
+          authProfileId: "openai-codex:work",
+        }),
+      ).rejects.toThrow("token-mode but contains an OpenAI API key");
+
+      expect(request).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects token material stored as OpenAI Codex API-key profiles before app-server login", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const request = vi.fn(async () => ({ type: "apiKey" }));
+    try {
+      upsertAuthProfile({
+        agentDir,
+        profileId: "openai-codex:work",
+        credential: {
+          type: "api_key",
+          provider: "openai-codex",
+          key: "eyJhbGciOiJub25l.eyJzdWIiOiJjb2RleCJ9.signature123456",
+        },
+      });
+
+      await expect(
+        applyCodexAppServerAuthProfile({
+          client: { request } as never,
+          agentDir,
+          authProfileId: "openai-codex:work",
+        }),
+      ).rejects.toThrow("api_key-mode but contains ChatGPT/OAuth token material");
+
+      expect(request).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
   it("accepts a legacy Codex auth-provider alias for app-server login", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
     const request = vi.fn(async () => ({ type: "chatgptAuthTokens" }));

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -1123,7 +1123,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
   });
 
-  it("rejects OpenAI API keys stored as OpenAI Codex token profiles before app-server login", async () => {
+  it("passes OpenAI Codex token profiles through to app-server token login", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
     const request = vi.fn(async () => ({ type: "chatgptAuthTokens" }));
     try {
@@ -1143,17 +1143,23 @@ describe("bridgeCodexAppServerStartOptions", () => {
           agentDir,
           authProfileId: "openai-codex:work",
         }),
-      ).rejects.toThrow("token-mode but contains an OpenAI API key");
+      ).resolves.toBeUndefined();
 
-      expect(request).not.toHaveBeenCalled();
+      expect(request).toHaveBeenCalledWith("account/login/start", {
+        type: "chatgptAuthTokens",
+        accessToken: "sk-openai-codex-api-key-value",
+        chatgptAccountId: "openai-codex:work",
+        chatgptPlanType: null,
+      });
     } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
     }
   });
 
-  it("rejects token material stored as OpenAI Codex API-key profiles before app-server login", async () => {
+  it("passes OpenAI Codex API-key profiles through to app-server API-key login", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
     const request = vi.fn(async () => ({ type: "apiKey" }));
+    const tokenLikeKey = "eyJhbGciOiJub25l.eyJzdWIiOiJjb2RleCJ9.signature123456";
     try {
       upsertAuthProfile({
         agentDir,
@@ -1161,7 +1167,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
         credential: {
           type: "api_key",
           provider: "openai-codex",
-          key: "eyJhbGciOiJub25l.eyJzdWIiOiJjb2RleCJ9.signature123456",
+          key: tokenLikeKey,
         },
       });
 
@@ -1171,9 +1177,12 @@ describe("bridgeCodexAppServerStartOptions", () => {
           agentDir,
           authProfileId: "openai-codex:work",
         }),
-      ).rejects.toThrow("api_key-mode but contains ChatGPT/OAuth token material");
+      ).resolves.toBeUndefined();
 
-      expect(request).not.toHaveBeenCalled();
+      expect(request).toHaveBeenCalledWith("account/login/start", {
+        type: "apiKey",
+        apiKey: tokenLikeKey,
+      });
     } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
     }

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -35,8 +35,6 @@ const CODEX_API_KEY_ENV_VAR = "CODEX_API_KEY";
 const OPENAI_API_KEY_ENV_VAR = "OPENAI_API_KEY";
 const CODEX_APP_SERVER_API_KEY_ENV_VARS = [CODEX_API_KEY_ENV_VAR, OPENAI_API_KEY_ENV_VAR];
 const CODEX_APP_SERVER_HOME_ENV_VARS = [CODEX_HOME_ENV_VAR, HOME_ENV_VAR];
-const OPENAI_API_KEY_RE = /^sk-[A-Za-z0-9_-]{8,}$/;
-const JWT_TOKEN_RE = /^[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}$/;
 
 type AuthProfileOrderConfig = Parameters<typeof resolveAuthProfileOrder>[0]["cfg"];
 
@@ -416,6 +414,9 @@ async function resolveLoginParamsForCredential(
   credential: AuthProfileCredential,
   params: { agentDir: string; forceOAuthRefresh: boolean; config?: AuthProfileOrderConfig },
 ): Promise<CodexLoginAccountParams | undefined> {
+  // Runtime honors the persisted auth profile type. Shape-based remediation
+  // belongs at credential entry time so request handling does not preemptively
+  // reject opaque provider credentials.
   if (credential.type === "api_key") {
     const resolved = await resolveApiKeyForProfile({
       store: ensureAuthProfileStore(params.agentDir, { allowKeychainPrompt: false }),
@@ -423,15 +424,6 @@ async function resolveLoginParamsForCredential(
       agentDir: params.agentDir,
     });
     const apiKey = resolved?.apiKey?.trim();
-    if (
-      apiKey &&
-      isCodexAppServerAuthProfileCredential(credential, params.config) &&
-      looksLikeChatgptTokenMaterial(apiKey)
-    ) {
-      throw new Error(
-        `Codex app-server auth profile "${profileId}" is api_key-mode but contains ChatGPT/OAuth token material. Store token auth material with ${formatAuthCommand("paste-token")}.`,
-      );
-    }
     return apiKey ? { type: "apiKey", apiKey } : undefined;
   }
   if (credential.type === "token") {
@@ -441,15 +433,6 @@ async function resolveLoginParamsForCredential(
       agentDir: params.agentDir,
     });
     const accessToken = resolved?.apiKey?.trim();
-    if (
-      accessToken &&
-      isCodexAppServerAuthProvider(credential.provider, params.config) &&
-      looksLikeOpenAIApiKey(accessToken)
-    ) {
-      throw new Error(
-        `Codex app-server auth profile "${profileId}" is token-mode but contains an OpenAI API key. Store OpenAI API keys with ${formatAuthCommand("paste-api-key")}.`,
-      );
-    }
     return accessToken
       ? buildChatgptAuthTokensParams(profileId, credential, accessToken)
       : undefined;
@@ -527,25 +510,6 @@ async function resolveOAuthCredentialForCodexAppServer(
 
 function isCodexAppServerAuthProvider(provider: string, config?: AuthProfileOrderConfig): boolean {
   return resolveProviderIdForAuth(provider, { config }) === CODEX_APP_SERVER_AUTH_PROVIDER;
-}
-
-function formatAuthCommand(command: "paste-api-key" | "paste-token"): string {
-  return `\`openclaw models auth ${command} --provider openai-codex\``;
-}
-
-function looksLikeOpenAIApiKey(value: string): boolean {
-  return OPENAI_API_KEY_RE.test(value.trim());
-}
-
-function stripBearerPrefix(value: string): string {
-  return value
-    .trim()
-    .replace(/^Bearer\s+/i, "")
-    .trim();
-}
-
-function looksLikeChatgptTokenMaterial(value: string): boolean {
-  return JWT_TOKEN_RE.test(stripBearerPrefix(value));
 }
 
 function isOpenAIApiKeyBackupCredential(

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -35,6 +35,8 @@ const CODEX_API_KEY_ENV_VAR = "CODEX_API_KEY";
 const OPENAI_API_KEY_ENV_VAR = "OPENAI_API_KEY";
 const CODEX_APP_SERVER_API_KEY_ENV_VARS = [CODEX_API_KEY_ENV_VAR, OPENAI_API_KEY_ENV_VAR];
 const CODEX_APP_SERVER_HOME_ENV_VARS = [CODEX_HOME_ENV_VAR, HOME_ENV_VAR];
+const OPENAI_API_KEY_RE = /^sk-[A-Za-z0-9_-]{8,}$/;
+const JWT_TOKEN_RE = /^[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}$/;
 
 type AuthProfileOrderConfig = Parameters<typeof resolveAuthProfileOrder>[0]["cfg"];
 
@@ -421,6 +423,15 @@ async function resolveLoginParamsForCredential(
       agentDir: params.agentDir,
     });
     const apiKey = resolved?.apiKey?.trim();
+    if (
+      apiKey &&
+      isCodexAppServerAuthProfileCredential(credential, params.config) &&
+      looksLikeChatgptTokenMaterial(apiKey)
+    ) {
+      throw new Error(
+        `Codex app-server auth profile "${profileId}" is api_key-mode but contains ChatGPT/OAuth token material. Store token auth material with ${formatAuthCommand("paste-token")}.`,
+      );
+    }
     return apiKey ? { type: "apiKey", apiKey } : undefined;
   }
   if (credential.type === "token") {
@@ -430,6 +441,15 @@ async function resolveLoginParamsForCredential(
       agentDir: params.agentDir,
     });
     const accessToken = resolved?.apiKey?.trim();
+    if (
+      accessToken &&
+      isCodexAppServerAuthProvider(credential.provider, params.config) &&
+      looksLikeOpenAIApiKey(accessToken)
+    ) {
+      throw new Error(
+        `Codex app-server auth profile "${profileId}" is token-mode but contains an OpenAI API key. Store OpenAI API keys with ${formatAuthCommand("paste-api-key")}.`,
+      );
+    }
     return accessToken
       ? buildChatgptAuthTokensParams(profileId, credential, accessToken)
       : undefined;
@@ -507,6 +527,25 @@ async function resolveOAuthCredentialForCodexAppServer(
 
 function isCodexAppServerAuthProvider(provider: string, config?: AuthProfileOrderConfig): boolean {
   return resolveProviderIdForAuth(provider, { config }) === CODEX_APP_SERVER_AUTH_PROVIDER;
+}
+
+function formatAuthCommand(command: "paste-api-key" | "paste-token"): string {
+  return `\`openclaw models auth ${command} --provider openai-codex\``;
+}
+
+function looksLikeOpenAIApiKey(value: string): boolean {
+  return OPENAI_API_KEY_RE.test(value.trim());
+}
+
+function stripBearerPrefix(value: string): string {
+  return value
+    .trim()
+    .replace(/^Bearer\s+/i, "")
+    .trim();
+}
+
+function looksLikeChatgptTokenMaterial(value: string): boolean {
+  return JWT_TOKEN_RE.test(stripBearerPrefix(value));
 }
 
 function isOpenAIApiKeyBackupCredential(

--- a/src/cli/models-cli.test.ts
+++ b/src/cli/models-cli.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   modelsAuthAddCommand: vi.fn().mockResolvedValue(undefined),
   modelsAuthListCommand: vi.fn().mockResolvedValue(undefined),
   modelsAuthLoginCommand: vi.fn().mockResolvedValue(undefined),
+  modelsAuthPasteApiKeyCommand: vi.fn().mockResolvedValue(undefined),
   modelsAuthPasteTokenCommand: vi.fn().mockResolvedValue(undefined),
   modelsAuthSetupTokenCommand: vi.fn().mockResolvedValue(undefined),
 }));
@@ -19,6 +20,7 @@ const {
   modelsAuthAddCommand,
   modelsAuthListCommand,
   modelsAuthLoginCommand,
+  modelsAuthPasteApiKeyCommand,
   modelsAuthPasteTokenCommand,
   modelsAuthSetupTokenCommand,
   modelsSetCommand,
@@ -35,6 +37,7 @@ vi.mock("../commands/models/list.status-command.js", () => ({
 vi.mock("../commands/models/auth.js", () => ({
   modelsAuthAddCommand: mocks.modelsAuthAddCommand,
   modelsAuthLoginCommand: mocks.modelsAuthLoginCommand,
+  modelsAuthPasteApiKeyCommand: mocks.modelsAuthPasteApiKeyCommand,
   modelsAuthPasteTokenCommand: mocks.modelsAuthPasteTokenCommand,
   modelsAuthSetupTokenCommand: mocks.modelsAuthSetupTokenCommand,
 }));
@@ -78,6 +81,7 @@ describe("models cli", () => {
     modelsAuthAddCommand.mockClear();
     modelsAuthListCommand.mockClear();
     modelsAuthLoginCommand.mockClear();
+    modelsAuthPasteApiKeyCommand.mockClear();
     modelsAuthPasteTokenCommand.mockClear();
     modelsAuthSetupTokenCommand.mockClear();
     modelsSetCommand.mockClear();
@@ -179,6 +183,12 @@ describe("models cli", () => {
       args: ["models", "auth", "--agent", "poe", "paste-token", "--provider", "anthropic"],
       command: modelsAuthPasteTokenCommand,
       expected: { agent: "poe", provider: "anthropic" },
+    },
+    {
+      label: "paste-api-key",
+      args: ["models", "auth", "--agent", "poe", "paste-api-key", "--provider", "openai-codex"],
+      command: modelsAuthPasteApiKeyCommand,
+      expected: { agent: "poe", provider: "openai-codex" },
     },
     {
       label: "login-github-copilot",

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -401,6 +401,26 @@ export function registerModelsCli(program: Command) {
     });
 
   auth
+    .command("paste-api-key")
+    .description("Paste an API key into auth-profiles.json and update config")
+    .requiredOption("--provider <name>", "Provider id (e.g. openai-codex)")
+    .option("--profile-id <id>", "Auth profile id (default: <provider>:manual)")
+    .action(async (opts, command) => {
+      await withModelsRuntime(async ({ defaultRuntime, resolveModelAgentOption }) => {
+        const agent = resolveModelAgentOption(command);
+        const { modelsAuthPasteApiKeyCommand } = await import("../commands/models/auth.js");
+        await modelsAuthPasteApiKeyCommand(
+          {
+            provider: opts.provider as string | undefined,
+            profileId: opts.profileId as string | undefined,
+            agent,
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  auth
     .command("login-github-copilot")
     .description("Login to GitHub Copilot via GitHub device flow (TTY required)")
     .option("--yes", "Overwrite existing profile without prompting", false)

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -1252,6 +1252,20 @@ describe("modelsAuthLoginCommand", () => {
     expect(mocks.updateConfig).not.toHaveBeenCalled();
   });
 
+  it("rejects line-wrapped piped OpenAI API keys as OpenAI Codex token material", async () => {
+    const runtime = createRuntime();
+    restoreStdin?.();
+    restoreStdin = withPipedStdin("sk-openai-\ncodex-api-key-value\n");
+
+    await expect(
+      modelsAuthPasteTokenCommand({ provider: "openai-codex" }, runtime),
+    ).rejects.toThrow("paste-api-key --provider openai-codex");
+
+    expect(mocks.clackText).not.toHaveBeenCalled();
+    expect(mocks.upsertAuthProfileWithLock).not.toHaveBeenCalled();
+    expect(mocks.updateConfig).not.toHaveBeenCalled();
+  });
+
   it("writes pasted API keys to the requested agent store", async () => {
     const runtime = createRuntime();
     useCoderAgentConfig();
@@ -1282,6 +1296,29 @@ describe("modelsAuthLoginCommand", () => {
     const runtime = createRuntime();
     restoreStdin?.();
     restoreStdin = withPipedStdin("sk-openai-codex-api-key-value\n");
+
+    await modelsAuthPasteApiKeyCommand({ provider: "openai-codex" }, runtime);
+
+    expect(mocks.clackPassword).not.toHaveBeenCalled();
+    expect(mocks.upsertAuthProfileWithLock).toHaveBeenCalledWith({
+      profileId: "openai-codex:manual",
+      credential: {
+        type: "api_key",
+        provider: "openai-codex",
+        key: "sk-openai-codex-api-key-value",
+      },
+      agentDir: "/tmp/openclaw/agents/main",
+    });
+    expect(lastUpdatedConfig?.auth?.profiles?.["openai-codex:manual"]).toEqual({
+      provider: "openai-codex",
+      mode: "api_key",
+    });
+  });
+
+  it("normalizes line-wrapped piped OpenAI Codex API keys before storing", async () => {
+    const runtime = createRuntime();
+    restoreStdin?.();
+    restoreStdin = withPipedStdin("sk-openai-\ncodex-api-key-value\n");
 
     await modelsAuthPasteApiKeyCommand({ provider: "openai-codex" }, runtime);
 

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -39,6 +39,7 @@ const mocks = vi.hoisted(() => ({
   clackCancel: vi.fn(),
   clackConfirm: vi.fn(),
   clackIsCancel: vi.fn((value: unknown) => value === Symbol.for("clack:cancel")),
+  clackPassword: vi.fn(),
   clackSelect: vi.fn(),
   clackText: vi.fn(),
   resolveDefaultAgentId: vi.fn(),
@@ -108,6 +109,7 @@ vi.mock("@clack/prompts", () => ({
   cancel: mocks.clackCancel,
   confirm: mocks.clackConfirm,
   isCancel: mocks.clackIsCancel,
+  password: mocks.clackPassword,
   select: mocks.clackSelect,
   text: mocks.clackText,
 }));
@@ -256,6 +258,7 @@ vi.mock("../../plugins/provider-auth-choice-helpers.js", async (importOriginal) 
 const {
   modelsAuthAddCommand,
   modelsAuthLoginCommand,
+  modelsAuthPasteApiKeyCommand,
   modelsAuthPasteTokenCommand,
   modelsAuthSetupTokenCommand,
 } = await import("./auth.js");
@@ -322,6 +325,7 @@ describe("modelsAuthLoginCommand", () => {
     mocks.clackIsCancel.mockImplementation(
       (value: unknown) => value === Symbol.for("clack:cancel"),
     );
+    mocks.clackPassword.mockReset();
     mocks.clackSelect.mockReset();
     mocks.clackText.mockReset();
     mocks.upsertAuthProfileWithLock.mockReset();
@@ -1179,6 +1183,83 @@ describe("modelsAuthLoginCommand", () => {
       },
       agentDir: "/tmp/openclaw/agents/coder",
     });
+  });
+
+  it("rejects OpenAI API keys pasted as OpenAI Codex token material", async () => {
+    const runtime = createRuntime();
+    const validateMessages: string[] = [];
+    mocks.clackText.mockImplementation(
+      async (params: { validate?: (value: string) => string | undefined }) => {
+        const message = params.validate?.("sk-openai-codex-api-key-value");
+        if (message) {
+          validateMessages.push(message);
+          throw new Error(message);
+        }
+        return "sk-openai-codex-api-key-value";
+      },
+    );
+
+    await expect(
+      modelsAuthPasteTokenCommand({ provider: "openai-codex" }, runtime),
+    ).rejects.toThrow("paste-api-key --provider openai-codex");
+
+    expect(validateMessages).toEqual([
+      "That looks like an OpenAI API key. Use openclaw models auth paste-api-key --provider openai-codex for API-key auth.",
+    ]);
+    expect(mocks.upsertAuthProfileWithLock).not.toHaveBeenCalled();
+    expect(mocks.updateConfig).not.toHaveBeenCalled();
+  });
+
+  it("writes pasted API keys to the requested agent store", async () => {
+    const runtime = createRuntime();
+    useCoderAgentConfig();
+    mocks.clackPassword.mockResolvedValue("sk-openai-codex-api-key-value");
+
+    await modelsAuthPasteApiKeyCommand({ provider: "openai-codex", agent: "coder" }, runtime);
+
+    expect(mocks.resolveDefaultAgentId).not.toHaveBeenCalled();
+    expect(mocks.upsertAuthProfileWithLock).toHaveBeenCalledWith({
+      profileId: "openai-codex:manual",
+      credential: {
+        type: "api_key",
+        provider: "openai-codex",
+        key: "sk-openai-codex-api-key-value",
+      },
+      agentDir: "/tmp/openclaw/agents/coder",
+    });
+    expect(lastUpdatedConfig?.auth?.profiles?.["openai-codex:manual"]).toEqual({
+      provider: "openai-codex",
+      mode: "api_key",
+    });
+    expect(runtime.log).toHaveBeenCalledWith(
+      "Auth profile: openai-codex:manual (openai-codex/api_key)",
+    );
+  });
+
+  it("rejects token material pasted into the OpenAI Codex API-key command", async () => {
+    const runtime = createRuntime();
+    const jwtLikeToken = ["eyJhbGciOiJub25l", "eyJzdWIiOiJjb2RleCJ9", "signature123456"].join(".");
+    const validateMessages: string[] = [];
+    mocks.clackPassword.mockImplementation(
+      async (params: { validate?: (value: string) => string | undefined }) => {
+        const message = params.validate?.(jwtLikeToken);
+        if (message) {
+          validateMessages.push(message);
+          throw new Error(message);
+        }
+        return jwtLikeToken;
+      },
+    );
+
+    await expect(
+      modelsAuthPasteApiKeyCommand({ provider: "openai-codex" }, runtime),
+    ).rejects.toThrow("paste-token --provider openai-codex");
+
+    expect(validateMessages).toEqual([
+      "That looks like token or OAuth material, not an OpenAI API key. Use openclaw models auth paste-token --provider openai-codex for token auth material.",
+    ]);
+    expect(mocks.upsertAuthProfileWithLock).not.toHaveBeenCalled();
+    expect(mocks.updateConfig).not.toHaveBeenCalled();
   });
 
   it("rejects an unknown agent before prompting for pasted tokens", async () => {

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -289,6 +289,34 @@ function withInteractiveStdin() {
   };
 }
 
+function withPipedStdin(input: string) {
+  const stdin = process.stdin as NodeJS.ReadStream & { isTTY?: boolean };
+  const restoreInteractive = withInteractiveStdin();
+  const previousAsyncIteratorDescriptor = Object.getOwnPropertyDescriptor(
+    stdin,
+    Symbol.asyncIterator,
+  );
+  Object.defineProperty(stdin, "isTTY", {
+    configurable: true,
+    enumerable: true,
+    get: () => false,
+  });
+  Object.defineProperty(stdin, Symbol.asyncIterator, {
+    configurable: true,
+    value: async function* () {
+      yield input;
+    },
+  });
+  return () => {
+    if (previousAsyncIteratorDescriptor) {
+      Object.defineProperty(stdin, Symbol.asyncIterator, previousAsyncIteratorDescriptor);
+    } else {
+      Reflect.deleteProperty(stdin, Symbol.asyncIterator);
+    }
+    restoreInteractive();
+  };
+}
+
 function createProvider(params: {
   id: string;
   label?: string;
@@ -1210,6 +1238,20 @@ describe("modelsAuthLoginCommand", () => {
     expect(mocks.updateConfig).not.toHaveBeenCalled();
   });
 
+  it("rejects piped OpenAI API keys as OpenAI Codex token material", async () => {
+    const runtime = createRuntime();
+    restoreStdin?.();
+    restoreStdin = withPipedStdin("sk-openai-codex-api-key-value\n");
+
+    await expect(
+      modelsAuthPasteTokenCommand({ provider: "openai-codex" }, runtime),
+    ).rejects.toThrow("paste-api-key --provider openai-codex");
+
+    expect(mocks.clackText).not.toHaveBeenCalled();
+    expect(mocks.upsertAuthProfileWithLock).not.toHaveBeenCalled();
+    expect(mocks.updateConfig).not.toHaveBeenCalled();
+  });
+
   it("writes pasted API keys to the requested agent store", async () => {
     const runtime = createRuntime();
     useCoderAgentConfig();
@@ -1234,6 +1276,29 @@ describe("modelsAuthLoginCommand", () => {
     expect(runtime.log).toHaveBeenCalledWith(
       "Auth profile: openai-codex:manual (openai-codex/api_key)",
     );
+  });
+
+  it("writes piped OpenAI Codex API keys to API-key profiles", async () => {
+    const runtime = createRuntime();
+    restoreStdin?.();
+    restoreStdin = withPipedStdin("sk-openai-codex-api-key-value\n");
+
+    await modelsAuthPasteApiKeyCommand({ provider: "openai-codex" }, runtime);
+
+    expect(mocks.clackPassword).not.toHaveBeenCalled();
+    expect(mocks.upsertAuthProfileWithLock).toHaveBeenCalledWith({
+      profileId: "openai-codex:manual",
+      credential: {
+        type: "api_key",
+        provider: "openai-codex",
+        key: "sk-openai-codex-api-key-value",
+      },
+      agentDir: "/tmp/openclaw/agents/main",
+    });
+    expect(lastUpdatedConfig?.auth?.profiles?.["openai-codex:manual"]).toEqual({
+      provider: "openai-codex",
+      mode: "api_key",
+    });
   });
 
   it("rejects token material pasted into the OpenAI Codex API-key command", async () => {

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -112,7 +112,7 @@ async function readPipedStdin(): Promise<string> {
 async function readPastedSecret(params: {
   message: string;
   masked: boolean;
-  validate?: (value: string) => string | undefined;
+  validate?: (value: string | undefined) => string | undefined;
 }): Promise<string> {
   const promptParams = { message: params.message, validate: params.validate };
   const input = process.stdin.isTTY

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -2,6 +2,7 @@ import {
   cancel,
   confirm as clackConfirm,
   isCancel,
+  password as clackPassword,
   select as clackSelect,
   text as clackText,
 } from "@clack/prompts";
@@ -81,6 +82,13 @@ const text = async (params: Parameters<typeof clackText>[0]) =>
       message: stylePromptMessage(params.message),
     }),
   );
+const password = async (params: Parameters<typeof clackPassword>[0]) =>
+  guardCancel(
+    await clackPassword({
+      ...params,
+      message: stylePromptMessage(params.message),
+    }),
+  );
 const select = async <T>(params: Parameters<typeof clackSelect<T>>[0]) =>
   guardCancel(
     await clackSelect({
@@ -94,6 +102,46 @@ const select = async <T>(params: Parameters<typeof clackSelect<T>>[0]) =>
 
 function resolveDefaultTokenProfileId(provider: string): string {
   return `${normalizeProviderId(provider)}:manual`;
+}
+
+function isOpenAICodexProvider(provider: string): boolean {
+  return normalizeProviderId(provider) === "openai-codex";
+}
+
+function stripBearerPrefix(value: string): string {
+  return value
+    .trim()
+    .replace(/^Bearer\s+/i, "")
+    .trim();
+}
+
+function looksLikeOpenAIApiKey(value: string): boolean {
+  return /^sk-[A-Za-z0-9_-]{8,}$/.test(value.trim());
+}
+
+function looksLikeJwtToken(value: string): boolean {
+  const token = stripBearerPrefix(value);
+  const parts = token.split(".");
+  return parts.length === 3 && parts.every((part) => /^[A-Za-z0-9_-]{8,}$/.test(part));
+}
+
+function looksLikeStructuredCredential(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed.startsWith("{") || trimmed.startsWith("[");
+}
+
+function validateOpenAICodexApiKeyInput(value: string): string | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "Required";
+  }
+  if (looksLikeOpenAIApiKey(trimmed)) {
+    return undefined;
+  }
+  if (looksLikeJwtToken(trimmed) || looksLikeStructuredCredential(trimmed)) {
+    return `That looks like token or OAuth material, not an OpenAI API key. Use ${formatCliCommand("openclaw models auth paste-token --provider openai-codex")} for token auth material.`;
+  }
+  return "That does not look like an OpenAI API key.";
 }
 
 type ResolvedModelsAuthContext = {
@@ -512,6 +560,9 @@ export async function modelsAuthPasteTokenCommand(
       if (provider === "anthropic") {
         return validateAnthropicSetupToken(trimmed.replaceAll(/\s+/g, ""));
       }
+      if (isOpenAICodexProvider(provider) && looksLikeOpenAIApiKey(trimmed)) {
+        return `That looks like an OpenAI API key. Use ${formatCliCommand("openclaw models auth paste-api-key --provider openai-codex")} for API-key auth.`;
+      }
       return undefined;
     },
   });
@@ -547,6 +598,58 @@ export async function modelsAuthPasteTokenCommand(
     runtime.log("OpenClaw prefers Claude CLI reuse when it is available on the host.");
     runtime.log("Anthropic staff told us this OpenClaw path is allowed again.");
   }
+}
+
+export async function modelsAuthPasteApiKeyCommand(
+  opts: {
+    provider?: string;
+    profileId?: string;
+    agent?: string;
+  },
+  runtime: RuntimeEnv,
+) {
+  const agentDir = await resolveModelsAuthAgentDir(opts.agent);
+  const rawProvider = normalizeOptionalString(opts.provider);
+  if (!rawProvider) {
+    throw new Error(
+      `Missing --provider. Run ${formatCliCommand("openclaw models status")} or ${formatCliCommand("openclaw plugins list")} to choose a provider.`,
+    );
+  }
+  const provider = normalizeProviderId(rawProvider);
+  const profileId =
+    normalizeOptionalString(opts.profileId) || resolveDefaultTokenProfileId(provider);
+
+  const keyInput = await password({
+    message: `Paste API key for ${provider}`,
+    validate: (value) => {
+      const trimmed = value?.trim();
+      if (!trimmed) {
+        return "Required";
+      }
+      if (isOpenAICodexProvider(provider)) {
+        return validateOpenAICodexApiKeyInput(trimmed);
+      }
+      return undefined;
+    },
+  });
+  const key = normalizeOptionalString(keyInput) ?? "";
+
+  await upsertAuthProfileWithLockOrThrow({
+    profileId,
+    credential: {
+      type: "api_key",
+      provider,
+      key,
+    },
+    agentDir,
+  });
+
+  await updateConfig((cfg) =>
+    applyAuthProfileConfig(cfg, { profileId, provider, mode: "api_key" }),
+  );
+
+  logConfigUpdated(runtime);
+  runtime.log(`Auth profile: ${profileId} (${provider}/api_key)`);
 }
 
 async function upsertAuthProfileWithLockOrThrow(params: UpsertAuthProfileParams): Promise<void> {

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -100,6 +100,32 @@ const select = async <T>(params: Parameters<typeof clackSelect<T>>[0]) =>
     }),
   );
 
+async function readPipedStdin(): Promise<string> {
+  process.stdin.setEncoding("utf8");
+  let input = "";
+  for await (const chunk of process.stdin) {
+    input += String(chunk);
+  }
+  return input;
+}
+
+async function readPastedSecret(params: {
+  message: string;
+  masked: boolean;
+  validate?: (value: string) => string | undefined;
+}): Promise<string> {
+  const promptParams = { message: params.message, validate: params.validate };
+  const input = process.stdin.isTTY
+    ? await (params.masked ? password(promptParams) : text(promptParams))
+    : await readPipedStdin();
+  const trimmed = input.trim();
+  const validationMessage = params.validate?.(trimmed);
+  if (validationMessage) {
+    throw new Error(validationMessage);
+  }
+  return trimmed;
+}
+
 function resolveDefaultTokenProfileId(provider: string): string {
   return `${normalizeProviderId(provider)}:manual`;
 }
@@ -550,8 +576,9 @@ export async function modelsAuthPasteTokenCommand(
   const profileId =
     normalizeOptionalString(opts.profileId) || resolveDefaultTokenProfileId(provider);
 
-  const tokenInput = await text({
+  const tokenInput = await readPastedSecret({
     message: `Paste token for ${provider}`,
+    masked: false,
     validate: (value) => {
       const trimmed = value?.trim();
       if (!trimmed) {
@@ -619,8 +646,9 @@ export async function modelsAuthPasteApiKeyCommand(
   const profileId =
     normalizeOptionalString(opts.profileId) || resolveDefaultTokenProfileId(provider);
 
-  const keyInput = await password({
+  const key = await readPastedSecret({
     message: `Paste API key for ${provider}`,
+    masked: true,
     validate: (value) => {
       const trimmed = value?.trim();
       if (!trimmed) {
@@ -632,7 +660,6 @@ export async function modelsAuthPasteApiKeyCommand(
       return undefined;
     },
   });
-  const key = normalizeOptionalString(keyInput) ?? "";
 
   await upsertAuthProfileWithLockOrThrow({
     profileId,

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -52,6 +52,7 @@ import {
   normalizeStringifiedOptionalString,
 } from "../../shared/string-coerce.js";
 import { stylePromptHint, stylePromptMessage } from "../../terminal/prompt-style.js";
+import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
 import { validateAnthropicSetupToken } from "../auth-token.js";
 import { repairCodexRuntimePluginInstallForModelSelection } from "../codex-runtime-plugin-install.js";
@@ -118,12 +119,12 @@ async function readPastedSecret(params: {
   const input = process.stdin.isTTY
     ? await (params.masked ? password(promptParams) : text(promptParams))
     : await readPipedStdin();
-  const trimmed = input.trim();
-  const validationMessage = params.validate?.(trimmed);
+  const normalized = normalizeSecretInput(input);
+  const validationMessage = params.validate?.(normalized);
   if (validationMessage) {
     throw new Error(validationMessage);
   }
-  return trimmed;
+  return normalized;
 }
 
 function resolveDefaultTokenProfileId(provider: string): string {


### PR DESCRIPTION
## Summary

- Problem: `openclaw models auth paste-token --provider openai-codex` accepted OpenAI `sk-...` API keys, stored them as token-mode credentials, and the Codex app-server rejected them as malformed ChatGPT/OAuth tokens.
- Solution: add an explicit `paste-api-key` path for API-key auth and add narrow shape diagnostics for obvious OpenAI Codex auth mismatches.
- What changed: CLI routing, auth profile writing, Codex app-server auth bridge diagnostics, docs, and focused regressions.
- What did NOT change (scope boundary): ambiguous credential values still flow to the provider/app-server instead of being preemptively rejected.

## Motivation

- Fixes the live breakage from #85145 where the documented/manual paste flow made a valid OpenAI API key unusable with the `openai-codex` provider.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #85145
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: OpenAI API keys for `openai-codex` now go through API-key auth instead of token auth, and obvious wrong-paste cases fail before writing unusable profiles.
- Real environment tested: AWS Crabbox `cbx_b66dbbbb3988`, run `run_95558db27ff0`, current branch after the patch, live `openai-codex` provider with `gpt-5.5`.
- Exact steps or command run after this patch: attempted `openclaw models auth paste-token --provider openai-codex` with a fake `sk-...` value, then used `openclaw models auth paste-api-key --provider openai-codex` with a real key and ran a live Codex turn.
- Evidence after fix: Crabbox log https://crabbox.openclaw.ai/v1/runs/run_95558db27ff0/logs reported `paste_token_reject_contains_guidance=true`, `paste_token_reject_profile_written=false`, `fix_profile_shape={"type":"api_key","provider":"openai-codex","key":"<redacted>"}`, `fix_config_profile={"provider":"openai-codex","mode":"api_key"}`, and `fix_contains_expected=true`.
- Observed result after fix: the bad `paste-token` API-key path wrote no profile, `paste-api-key` wrote an `api_key` profile without echoing the secret, and the live turn returned `ISSUE-85145-FIX-OK`.
- What was not tested: non-OpenAI-Codex providers beyond existing focused unit coverage for unchanged generic paths.
- Before evidence (optional but encouraged): the original Crabbox reproduction showed `paste-token --provider openai-codex` storing `type:"token"` and the live turn failing with `failed to set external auth: invalid ID token format`.

## Root Cause (if applicable)

- Root cause: the generic pasted-token CLI path had no API-key equivalent or provider-specific guard for `openai-codex`, so OpenAI API keys were persisted as token credentials and later sent to Codex app-server as ChatGPT/OAuth token material.
- Missing detection / guardrail: neither paste time nor request time warned when the credential shape clearly belonged to the other OpenAI Codex auth mode.
- Contributing context (if known): `token` and `api_key` are both valid auth profile types, but this provider treats them as different app-server login shapes.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/models/auth.test.ts`, `src/cli/models-cli.test.ts`, `extensions/codex/src/app-server/auth-bridge.test.ts`.
- Scenario the test should lock in: API-key-shaped input is rejected by `paste-token`, `paste-api-key` writes an `api_key` profile, and request-time diagnostics catch obvious mode mismatches.
- Why this is the smallest reliable guardrail: it covers the CLI write path and the Codex app-server boundary without broad provider matrix churn.
- Existing test that already covers this (if any): none for the broken API-key paste path.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Adds `openclaw models auth paste-api-key --provider <id>`.
- For `openai-codex`, `paste-token` now rejects values that clearly look like OpenAI API keys and points users to `paste-api-key`.
- For `openai-codex`, request-time diagnostics reject obvious token/API-key mode mismatches before app-server login.

## Diagram (if applicable)

```text
Before:
[user pastes sk-... via paste-token] -> token profile -> Codex app-server token login -> invalid ID token format

After:
[user pastes sk-... via paste-api-key] -> api_key profile -> Codex app-server apiKey login -> live turn succeeds
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes
- New/changed network calls? No
- Command/tool execution surface changed? Yes
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: API-key paste now uses a masked password prompt and stores the key in the existing auth profile store. The command surface is limited to writing the existing `api_key` credential shape.

## Repro + Verification

### Environment

- OS: macOS local checkout, plus AWS Crabbox Linux live proof
- Runtime/container: Node 22/24-compatible OpenClaw checkout; AWS Crabbox `cbx_b66dbbbb3988`
- Model/provider: `openai-codex` / `gpt-5.5`
- Integration/channel (if any): Codex app-server auth bridge
- Relevant config (redacted): auth profile `openai-codex:manual` with `mode:"api_key"`

### Steps

1. Run `openclaw models auth paste-token --provider openai-codex` and paste a fake `sk-...` value.
2. Run `openclaw models auth paste-api-key --provider openai-codex` and paste a real OpenAI API key.
3. Run a live OpenAI Codex model turn using the resulting auth profile.

### Expected

- The token path rejects API-key-shaped input, the API-key path writes `type:"api_key"`, and the live turn succeeds.

### Actual

- Matches expected in AWS Crabbox run `run_95558db27ff0`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused unit tests, autoreview, whitespace check, AWS Crabbox regression repro and live fix proof.
- Edge cases checked: obvious `sk-...` values in token mode, JWT-like/token material in API-key mode, and request-time diagnostics that avoid blocking ambiguous values.
- What you did **not** verify: broad provider matrix behavior for providers that already use the generic token path.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes
- Migration needed? No
- If yes, exact upgrade steps: users who pasted an OpenAI API key as an `openai-codex` token should rerun `openclaw models auth paste-api-key --provider openai-codex`.

## Risks and Mitigations

- Risk: overly broad preemptive validation could block valid credentials.
  - Mitigation: validation only rejects high-confidence API-key/JWT/structured-token shapes for the `openai-codex` split; ambiguous values still reach provider/app-server validation.
