### PR TITLE
fix(agents): normalize bootstrap file names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ Docs: https://docs.openclaw.ai
 - Secrets: show the irreversible apply warning after interactive `secrets configure` confirmation so confirmed migrations still get the final safety prompt. (#85638) Thanks @alkor2000.
 - Agents/CLI output: ignore cumulative Claude `stream-json` result usage when assistant usage events are present, preventing inflated cache-read accounting. (#85625) Thanks @zhouhe-xydt.
 - CLI: keep `waitForever()` alive by leaving its keep-alive interval ref'd so the public helper no longer exits immediately with Node's unsettled-await code. (#85694) Thanks @m1qaweb.
-- Agents/bootstrap: guard bootstrap name checks against missing file names so malformed bootstrap entries warn and truncate instead of crashing. Fixes #85523. (#85615) Thanks @zhouhe-xydt.
+- Agents/bootstrap: derive bootstrap file names from valid paths and guard name checks when hook metadata omits `name`, so malformed bootstrap entries warn and truncate instead of crashing. (#85535, #85615, fixes #85523) Thanks @luoyanglang and @zhouhe-xydt.
 - CLI/tasks: reject partially numeric `openclaw tasks audit --limit` values so audit limits must be real positive integers instead of accepting strings like `5abc`. (#84901) Thanks @jbetala7.
 - Status/diagnostics: bound deep Docker audit probes so `openclaw status --deep` reports slow container checks instead of hanging behind unbounded inspection. (#85476) Thanks @giodl73-repo.
 - Providers/Anthropic: migrate 1M context handling to GA-capable Claude 4.x models by sizing eligible models at 1M without the retired `context-1m-2025-08-07` beta, ignoring that retired beta in older configs, and preserving OAuth-required Anthropic beta headers. (#45613) Thanks @haoyu-haoyu.

--- a/src/agents/bootstrap-budget.test.ts
+++ b/src/agents/bootstrap-budget.test.ts
@@ -47,6 +47,32 @@ describe("buildBootstrapInjectionStats", () => {
     expect(stats[1]?.injectedChars).toBe(20);
     expect(stats[1]?.truncated).toBe(true);
   });
+
+  it("derives names from paths for malformed bootstrap file metadata", () => {
+    const bootstrapFiles = [
+      {
+        path: "/tmp/HOOK.md",
+        content: "a".repeat(100),
+        missing: false,
+      },
+    ] as unknown as WorkspaceBootstrapFile[];
+    const injectedFiles = [{ path: "/tmp/HOOK.md", content: "a".repeat(20) }];
+    const stats = buildBootstrapInjectionStats({
+      bootstrapFiles,
+      injectedFiles,
+    });
+
+    expect(stats).toStrictEqual([
+      {
+        name: "HOOK.md",
+        path: "/tmp/HOOK.md",
+        missing: false,
+        rawChars: 100,
+        injectedChars: 20,
+        truncated: true,
+      },
+    ]);
+  });
 });
 
 describe("analyzeBootstrapBudget", () => {
@@ -367,6 +393,29 @@ describe("bootstrap prompt warnings", () => {
     const lines = formatBootstrapTruncationWarningLines({ analysis });
 
     expect(lines).toContain(
+      "AGENTS.md was truncated; read the full AGENTS.md before relying on scoped policy.",
+    );
+  });
+
+  it("does not crash when truncation metadata has a malformed file name", () => {
+    const analysis = analyzeBootstrapBudget({
+      files: [
+        {
+          name: undefined,
+          path: "/tmp/HOOK.md",
+          missing: false,
+          rawChars: 150,
+          injectedChars: 100,
+          truncated: true,
+        } as unknown as Parameters<typeof analyzeBootstrapBudget>[0]["files"][number],
+      ],
+      bootstrapMaxChars: 120,
+      bootstrapTotalMaxChars: 200,
+    });
+    const lines = formatBootstrapTruncationWarningLines({ analysis });
+
+    expect(lines).toContain("HOOK.md: 150 raw -> 100 injected (~33% removed; max/file).");
+    expect(lines).not.toContain(
       "AGENTS.md was truncated; read the full AGENTS.md before relying on scoped policy.",
     );
   });

--- a/src/agents/bootstrap-budget.ts
+++ b/src/agents/bootstrap-budget.ts
@@ -68,8 +68,20 @@ function formatWarningCause(cause: BootstrapTruncationCause): string {
   return cause === "per-file-limit" ? "max/file" : "max/total";
 }
 
-function isAgentsBootstrapName(name: string | undefined): boolean {
-  return name?.toLowerCase() === "agents.md";
+function resolveBootstrapFileDisplayName(name: unknown, filePath?: unknown): string {
+  const nameValue = normalizeOptionalString(name);
+  if (nameValue) {
+    return nameValue;
+  }
+  const pathValue = normalizeOptionalString(filePath);
+  if (pathValue) {
+    return path.basename(pathValue) || "bootstrap file";
+  }
+  return "bootstrap file";
+}
+
+function isAgentsBootstrapName(name: unknown, filePath?: unknown): boolean {
+  return resolveBootstrapFileDisplayName(name, filePath).toLowerCase() === "agents.md";
 }
 
 function normalizeSeenSignatures(signatures?: string[]): string[] {
@@ -148,16 +160,17 @@ export function buildBootstrapInjectionStats(params: {
   }
   return params.bootstrapFiles.map((file) => {
     const pathValue = normalizeOptionalString(file.path) ?? "";
+    const name = resolveBootstrapFileDisplayName(file.name, pathValue);
     const rawChars = file.missing ? 0 : (file.content ?? "").trimEnd().length;
     const injected =
       (pathValue ? injectedByPath.get(pathValue) : undefined) ??
-      injectedByPath.get(file.name) ??
-      injectedByBaseName.get(file.name);
+      injectedByPath.get(name) ??
+      injectedByBaseName.get(name);
     const injectedChars = injected ? injected.length : 0;
     const truncated = !file.missing && injectedChars < rawChars;
     return {
-      name: file.name,
-      path: pathValue || file.name,
+      name,
+      path: pathValue || name,
       missing: file.missing,
       rawChars,
       injectedChars,
@@ -271,11 +284,14 @@ export function formatBootstrapTruncationWarningLines(params: {
       : DEFAULT_BOOTSTRAP_PROMPT_WARNING_MAX_FILES;
   const lines: string[] = [];
   const duplicateNameCounts = params.analysis.truncatedFiles.reduce((acc, file) => {
-    acc.set(file.name, (acc.get(file.name) ?? 0) + 1);
+    const name = resolveBootstrapFileDisplayName(file.name, file.path);
+    acc.set(name, (acc.get(name) ?? 0) + 1);
     return acc;
   }, new Map<string, number>());
   const topFiles = params.analysis.truncatedFiles.slice(0, maxFiles);
   for (const file of topFiles) {
+    const fileName = resolveBootstrapFileDisplayName(file.name, file.path);
+    const filePath = normalizeOptionalString(file.path) ?? "";
     const pct =
       file.rawChars > 0
         ? Math.round(((file.rawChars - file.injectedChars) / file.rawChars) * 100)
@@ -285,9 +301,9 @@ export function formatBootstrapTruncationWarningLines(params: {
         ? file.causes.map((cause) => formatWarningCause(cause)).join(", ")
         : "";
     const nameLabel =
-      (duplicateNameCounts.get(file.name) ?? 0) > 1 && file.path.trim().length > 0
-        ? `${file.name} (${file.path})`
-        : file.name;
+      (duplicateNameCounts.get(fileName) ?? 0) > 1 && filePath.length > 0
+        ? `${fileName} (${filePath})`
+        : fileName;
     lines.push(
       `${nameLabel}: ${file.rawChars} raw -> ${file.injectedChars} injected (~${Math.max(0, pct)}% removed${causeText ? `; ${causeText}` : ""}).`,
     );
@@ -297,7 +313,7 @@ export function formatBootstrapTruncationWarningLines(params: {
       `+${params.analysis.truncatedFiles.length - topFiles.length} more truncated file(s).`,
     );
   }
-  if (params.analysis.truncatedFiles.some((file) => isAgentsBootstrapName(file.name))) {
+  if (params.analysis.truncatedFiles.some((file) => isAgentsBootstrapName(file.name, file.path))) {
     lines.push("AGENTS.md was truncated; read the full AGENTS.md before relying on scoped policy.");
   }
   lines.push(

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -60,6 +60,20 @@ function registerMalformedBootstrapFileHook() {
   });
 }
 
+function registerMissingNameBootstrapFileHook() {
+  registerInternalHook("agent:bootstrap", (event) => {
+    const context = event.context as AgentBootstrapHookContext;
+    context.bootstrapFiles = [
+      ...context.bootstrapFiles,
+      {
+        path: path.join(context.workspaceDir, "HOOK.md"),
+        content: "hook content",
+        missing: false,
+      } as unknown as WorkspaceBootstrapFile,
+    ];
+  });
+}
+
 function registerDuplicateBootstrapFileHook() {
   registerInternalHook("agent:bootstrap", (event) => {
     const context = event.context as AgentBootstrapHookContext;
@@ -144,6 +158,21 @@ describe("resolveBootstrapFilesForRun", () => {
     ]);
     expect(warnings).toHaveLength(3);
     expect(warnings[0]).toContain('missing or invalid "path" field');
+  });
+
+  it("derives a safe bootstrap file name from valid hook paths", async () => {
+    registerMissingNameBootstrapFileHook();
+
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    const files = await resolveBootstrapFilesForRun({ workspaceDir });
+    const hookFile = files.find((file) => file.path === path.join(workspaceDir, "HOOK.md"));
+
+    expect(hookFile).toMatchObject({
+      name: "HOOK.md",
+      path: path.join(workspaceDir, "HOOK.md"),
+      content: "hook content",
+      missing: false,
+    });
   });
 
   it("dedupes hook-injected bootstrap paths relative to the workspace", async () => {

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -22,6 +22,7 @@ import {
   isWorkspaceBootstrapPending,
   loadWorkspaceBootstrapFiles,
   type WorkspaceBootstrapFile,
+  type WorkspaceBootstrapFileName,
 } from "./workspace.js";
 
 export type BootstrapContextMode = "full" | "lightweight";
@@ -177,12 +178,17 @@ function sanitizeBootstrapFiles(
       : pathValue.startsWith("~")
         ? resolveUserPath(pathValue)
         : path.resolve(workspaceRoot, pathValue);
+    const nameValue = normalizeOptionalString(file.name) ?? path.basename(resolvedPath);
+    if (!nameValue) {
+      warn?.(`skipping bootstrap file at "${resolvedPath}" — missing or invalid "name" field`);
+      continue;
+    }
     const dedupeKey = path.normalize(path.relative(workspaceRoot, resolvedPath));
     if (seenPaths.has(dedupeKey)) {
       continue;
     }
     seenPaths.add(dedupeKey);
-    sanitized.push({ ...file, path: resolvedPath });
+    sanitized.push({ ...file, name: nameValue as WorkspaceBootstrapFileName, path: resolvedPath });
   }
   return sanitized;
 }

--- a/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts
+++ b/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts
@@ -86,6 +86,24 @@ describe("buildBootstrapContextFiles", () => {
     expect(warnings[0]).toContain("TOOLS.md");
     expect(warnings[0]).toContain("limit 200");
   });
+  it("falls back to the file path when malformed metadata omits the bootstrap name", () => {
+    const malformedName = {
+      path: "/tmp/HOOK.md",
+      content: "a".repeat(1_000),
+      missing: false,
+    } as unknown as WorkspaceBootstrapFile;
+    const warnings: string[] = [];
+    const [result] = buildBootstrapContextFiles([malformedName], {
+      maxChars: 120,
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(result?.path).toBe("/tmp/HOOK.md");
+    expect(result?.content).toContain("[...truncated, read HOOK.md for full content...]");
+    expect(warnings).toStrictEqual([
+      "workspace bootstrap file HOOK.md is 1000 chars (limit 120); truncating in injected context",
+    ]);
+  });
   it("fits the rendered truncation marker inside the per-file budget", () => {
     const maxChars = DEFAULT_BOOTSTRAP_MAX_CHARS;
     const files = [

--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -151,8 +151,23 @@ export function resolveBootstrapPromptTruncationWarningMode(
   return DEFAULT_BOOTSTRAP_PROMPT_TRUNCATION_WARNING_MODE;
 }
 
-function isAgentsBootstrapFile(fileName: string | undefined): boolean {
-  return fileName?.toLowerCase() === AGENTS_BOOTSTRAP_FILENAME.toLowerCase();
+function resolveBootstrapFileDisplayName(fileName: unknown, filePath?: unknown): string {
+  const name = normalizeOptionalString(fileName);
+  if (name) {
+    return name;
+  }
+  const pathValue = normalizeOptionalString(filePath);
+  if (pathValue) {
+    return path.basename(pathValue) || "bootstrap file";
+  }
+  return "bootstrap file";
+}
+
+function isAgentsBootstrapFile(fileName: unknown): boolean {
+  return (
+    typeof fileName === "string" &&
+    fileName.toLowerCase() === AGENTS_BOOTSTRAP_FILENAME.toLowerCase()
+  );
 }
 
 function isPolicyDigestCandidate(line: string): boolean {
@@ -448,15 +463,16 @@ export function buildBootstrapContextFiles(
       );
       break;
     }
+    const fileName = resolveBootstrapFileDisplayName(file.name, file.path);
     const fileMaxChars = Math.max(1, Math.min(maxChars, remainingTotalChars));
-    const trimmed = trimBootstrapContent(file.content ?? "", file.name, fileMaxChars);
+    const trimmed = trimBootstrapContent(file.content ?? "", fileName, fileMaxChars);
     const contentWithinBudget = clampToBudget(trimmed.content, remainingTotalChars);
     if (!contentWithinBudget) {
       continue;
     }
     if (trimmed.truncated || contentWithinBudget.length < trimmed.content.length) {
       opts?.warn?.(
-        `workspace bootstrap file ${file.name} is ${trimmed.originalLength} chars (limit ${trimmed.maxChars}); truncating in injected context`,
+        `workspace bootstrap file ${fileName} is ${trimmed.originalLength} chars (limit ${trimmed.maxChars}); truncating in injected context`,
       );
     }
     remainingTotalChars = Math.max(0, remainingTotalChars - contentWithinBudget.length);


### PR DESCRIPTION
Upgrading to 2026.5.20 can make every Telegram message fail during bootstrap context building when a hook/workspace bootstrap entry has a valid path but missing `name`, because the bootstrap helpers call `toLowerCase()` on undefined.

Fixes #85523

## Affected Surface

- `src/agents/bootstrap-files.ts`
  - `sanitizeBootstrapFiles`
- `src/agents/pi-embedded-helpers/bootstrap.ts`
  - `isAgentsBootstrapFile`
  - `buildBootstrapContextFiles`
- `src/agents/bootstrap-budget.ts`
  - `isAgentsBootstrapName`
  - `buildBootstrapInjectionStats`
  - `formatBootstrapTruncationWarningLines`

## Scope

Defense in depth only:

- normalize malformed bootstrap metadata at the bootstrap-file boundary by deriving a safe display `name` from the resolved path when `name` is missing
- keep the lower-level AGENTS-name helpers null-safe so future malformed callers cannot crash the gateway again
- do not add config, options, feature flags, or product behavior changes

## Real Behavior Proof

**Behavior or issue addressed**: A workspace bootstrap file with a valid `path` but missing `name` could crash bootstrap context/stat/warning code through `toLowerCase()` on `undefined`, making the agent fail before it can respond.

**Real environment tested**: Local OpenClaw checkout on Linux, branch `wolf/bootstrap-file-name-normalization`, head `4c1c4d52db0de8b8861dc082732a6f9c7d57de2c`, rebased from current `origin/main`. Runtime helper proof used the real TypeScript source modules through Node with `tsx`; no mocked bootstrap helper implementation was substituted.

**Exact steps or command run after this patch**:

1. Ran a direct Node runtime helper invocation against the PR source modules with a malformed bootstrap entry: `name: undefined`, valid path `/tmp/openclaw-proof/HOOK.md`, and real content.
2. Ran the targeted regression suite for bootstrap file normalization, context building, and bootstrap budget warnings.
3. Ran changed-path validation and diff/secret checks.

**Evidence after fix**: Direct runtime helper terminal output from this PR checkout:

```text
$ node --import tsx -e 'import { buildBootstrapContextFiles } from "./src/agents/pi-embedded-helpers/bootstrap.ts"; import { buildBootstrapInjectionStats, formatBootstrapTruncationWarningLines } from "./src/agents/bootstrap-budget.ts"; const files = [{ path: "/tmp/openclaw-proof/HOOK.md", name: undefined, content: "hello from bootstrap proof" }]; const injected = buildBootstrapContextFiles(files, { maxChars: 1024, totalMaxChars: 1024 }); const stats = buildBootstrapInjectionStats({ bootstrapFiles: files, injectedFiles: injected }); const warnings = formatBootstrapTruncationWarningLines({ analysis: { hasTruncation: true, totals: { bootstrapMaxChars: 8, bootstrapTotalMaxChars: 8, rawChars: 26, injectedChars: 8 }, files: stats, truncatedFiles: [{ ...stats[0], injectedChars: 8, causes: ["perFileLimit"] }] } }); console.log(JSON.stringify({ injected, stats, warnings }, null, 2));'
{
  "injected": [
    {
      "path": "/tmp/openclaw-proof/HOOK.md",
      "content": "hello from bootstrap proof"
    }
  ],
  "stats": [
    {
      "name": "HOOK.md",
      "path": "/tmp/openclaw-proof/HOOK.md",
      "rawChars": 26,
      "injectedChars": 26,
      "truncated": false
    }
  ],
  "warnings": [
    "HOOK.md: 26 raw -> 8 injected (~69% removed; max/total).",
    "If unintentional, raise agents.defaults.bootstrapMaxChars and/or agents.defaults.bootstrapTotalMaxChars."
  ]
}
```

RED on `origin/main` before the fix:

```text
$ pnpm test src/agents/bootstrap-files.test.ts src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts src/agents/bootstrap-budget.test.ts
FAIL src/agents/bootstrap-budget.test.ts > buildBootstrapInjectionStats > derives names from paths for malformed bootstrap file metadata
AssertionError: expected name "HOOK.md"; received undefined

FAIL src/agents/bootstrap-budget.test.ts > bootstrap prompt warnings > does not crash when truncation metadata has a malformed file name
TypeError: Cannot read properties of undefined (reading 'toLowerCase')
  at isAgentsBootstrapName src/agents/bootstrap-budget.ts:72:15
```

GREEN after this patch:

```text
$ pnpm test src/agents/bootstrap-files.test.ts src/agents/pi-embedded-helpers/bootstrap.test.ts src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts src/agents/bootstrap-budget.test.ts
Test Files  2 passed (2)
Tests       21 passed (21)
Test Files  2 passed (2)
Tests       61 passed (61)
[test] passed 2 Vitest shards in 31.58s
```

Changed-path validation:

```text
$ pnpm check:changed --base origin/main
[check:changed] lanes=core, coreTests
[check:changed] conflict markers
[check:changed] changelog attributions
[check:changed] guarded extension wildcard re-exports
[check:changed] plugin-sdk wildcard re-exports
[check:changed] duplicate scan target coverage
[check:changed] dependency pin guard
[check:changed] package patch guard
[check:changed] typecheck core
[check:changed] typecheck core tests
[check:changed] lint core
[check:changed] media download helper guard
[check:changed] runtime sidecar loader guard
[check:changed] runtime import cycles
[check:changed] webhook body guard
[check:changed] pairing store guard
[check:changed] pairing account guard
exit status: 0

$ git diff --check origin/main..HEAD
exit status: 0

$ gitleaks protect --staged --redact
INF no leaks found
```

**Observed result after fix**: The malformed entry no longer crashes. The runtime helper output shows the missing `name` is derived from the path as `HOOK.md`, the bootstrap context still injects the file content, and truncation warnings can format the same malformed metadata without calling `toLowerCase()` on `undefined`.

**What was not tested**: Live Telegram upgrade reproduction on the reporter's 2026.5.20 deployment was not run from this environment. Generated `dist/` patching was not exercised; this PR fixes the TypeScript source path only.

## Coverage Note

Push-before-PR searches run against open PRs:

```text
gh search prs --repo openclaw/openclaw --state open "Fixes #85523" -> []
gh search prs --repo openclaw/openclaw --state open "#85523" -> []
gh search prs --repo openclaw/openclaw --state open "isAgentsBootstrapFile" -> []
gh search prs --repo openclaw/openclaw --state open "bootstrap-files.ts toLowerCase" -> []
gh search prs --repo openclaw/openclaw --state open "bootstrap file name undefined" -> []
```

I also checked the nearby large maintainer PR #85341. It touches `bootstrap-files.ts` / `bootstrap-budget.ts` as part of runtime internalization, but it does not mention `Fixes #85523`, `isAgentsBootstrapFile`, or the undefined bootstrap-name crash path, so it does not behavior-cover this fix.


