### PR TITLE
chore(docs): add Browserbase Search discovery docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -113,6 +113,10 @@
       "destination": "/plugins/adding-capabilities"
     },
     {
+      "source": "/browserbase-search",
+      "destination": "/tools/browserbase-search"
+    },
+    {
       "source": "/brave-search",
       "destination": "/tools/brave-search"
     },
@@ -1295,6 +1299,7 @@
                     "pages": [
                       "tools/web-fetch",
                       "tools/web",
+                      "tools/browserbase-search",
                       "tools/brave-search",
                       "tools/duckduckgo-search",
                       "tools/exa-search",

--- a/docs/tools/browserbase-search.md
+++ b/docs/tools/browserbase-search.md
@@ -8,7 +8,7 @@ title: "Browserbase search"
 
 OpenClaw supports [Browserbase Search](https://docs.browserbase.com/platform/search/overview) as a native `web_search` provider.
 
-Browserbase Search is a lightweight structured search API that pairs well with Browserbase browser automation when you need fast web results before deciding whether to open a live page.
+Browserbase Search is a lightweight structured search API that pairs well with Browserbase browser agents and automations when you need fast web results before deciding whether to open a live page.
 
 ## Get an API key
 

--- a/docs/tools/browserbase-search.md
+++ b/docs/tools/browserbase-search.md
@@ -1,0 +1,96 @@
+---
+summary: "Browserbase Search setup for web_search"
+read_when:
+  - You want to use Browserbase Search for web_search
+  - You need a BROWSERBASE_API_KEY
+title: "Browserbase search"
+---
+
+OpenClaw supports [Browserbase Search](https://docs.browserbase.com/platform/search/overview) as a native `web_search` provider.
+
+Browserbase Search is a lightweight structured search API that pairs well with Browserbase browser automation when you need fast web results before deciding whether to open a live page.
+
+## Get an API key
+
+<Steps>
+  <Step title="Create an account">
+    Sign up at [browserbase.com](https://www.browserbase.com/) and generate an API key.
+  </Step>
+  <Step title="Store the key">
+    Set `BROWSERBASE_API_KEY` in the Gateway environment, or configure via:
+
+    ```bash
+    openclaw configure --section web
+    ```
+
+  </Step>
+</Steps>
+
+## Install
+
+This provider ships as an external plugin and can be installed directly with:
+
+```bash
+openclaw plugins install clawhub:@browserbasehq/openclaw-browserbase-search
+```
+
+After install, `openclaw configure --section web` can select Browserbase Search and store the credential.
+
+## Config
+
+```json5
+{
+  plugins: {
+    entries: {
+      "browserbase-search": {
+        config: {
+          webSearch: {
+            apiKey: "bb_...", // optional if BROWSERBASE_API_KEY is set
+            baseUrl: "https://api.browserbase.com/v1/search", // optional override
+          },
+        },
+      },
+    },
+  },
+  tools: {
+    web: {
+      search: {
+        provider: "browserbase-search",
+      },
+    },
+  },
+}
+```
+
+## Base URL override
+
+Set `plugins.entries.browserbase-search.config.webSearch.baseUrl` when Browserbase search requests should go through a compatible proxy or alternate endpoint.
+
+If the configured value ends in:
+
+- `/v1/search`, OpenClaw uses it directly
+- `/v1`, OpenClaw appends `/search`
+- anything else, OpenClaw appends `/v1/search`
+
+## Tool parameters
+
+<ParamField path="query" type="string" required>
+Search query.
+</ParamField>
+
+<ParamField path="count" type="number" default="5">
+Results to return (1-25).
+</ParamField>
+
+## Notes
+
+- Results are returned as structured titles, URLs, and snippets.
+- Optional Browserbase response fields such as `author`, `publishedDate`, `image`, and `favicon` are preserved when present.
+- Results are cached for 15 minutes by default (configurable via `cacheTtlMinutes`).
+- For JS-heavy pages, auth flows, or interactive scraping, use the [Web Browser](/tools/browser) instead of `web_search`.
+
+## Related
+
+- [Web Search overview](/tools/web) -- all providers and auto-detection
+- [Web Browser](/tools/browser) -- interactive browser automation
+- [Browserbase Search docs](https://docs.browserbase.com/platform/search/overview)

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -57,6 +57,9 @@ local while `web_search` and `x_search` can use xAI Responses under the hood.
 ## Choosing a provider
 
 <CardGroup cols={2}>
+  <Card title="Browserbase Search" icon="globe" href="/tools/browserbase-search">
+    Fast, token-efficient structured results from Browserbase Search.
+  </Card>
   <Card title="Brave Search" icon="shield" href="/tools/brave-search">
     Structured results with snippets. Supports `llm-context` mode, country/language filters. Free tier available.
   </Card>
@@ -99,6 +102,7 @@ local while `web_search` and `x_search` can use xAI Responses under the hood.
 
 | Provider                                  | Result style                                                   | Filters                                          | API key                                                                                 |
 | ----------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------- |
+| [Browserbase Search](/tools/browserbase-search) | Structured snippets                                            | Result count                                     | `BROWSERBASE_API_KEY`                                                                   |
 | [Brave](/tools/brave-search)              | Structured snippets                                            | Country, language, time, `llm-context` mode      | `BRAVE_API_KEY`                                                                         |
 | [DuckDuckGo](/tools/duckduckgo-search)    | Structured snippets                                            | --                                               | None (key-free)                                                                         |
 | [Exa](/tools/exa-search)                  | Structured + extracted                                         | Neural/keyword mode, date, content extraction    | `EXA_API_KEY`                                                                           |
@@ -183,13 +187,14 @@ API-backed providers first:
 6. **Perplexity** -- `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` or `plugins.entries.perplexity.config.webSearch.apiKey` (order 50)
 7. **Firecrawl** -- `FIRECRAWL_API_KEY` or `plugins.entries.firecrawl.config.webSearch.apiKey` (order 60)
 8. **Exa** -- `EXA_API_KEY` or `plugins.entries.exa.config.webSearch.apiKey`; optional `plugins.entries.exa.config.webSearch.baseUrl` overrides the Exa endpoint (order 65)
-9. **Tavily** -- `TAVILY_API_KEY` or `plugins.entries.tavily.config.webSearch.apiKey` (order 70)
+9. **Browserbase Search** -- `BROWSERBASE_API_KEY` or `plugins.entries.browserbase-search.config.webSearch.apiKey`; optional `plugins.entries.browserbase-search.config.webSearch.baseUrl` overrides the Browserbase endpoint (order 68)
+10. **Tavily** -- `TAVILY_API_KEY` or `plugins.entries.tavily.config.webSearch.apiKey` (order 70)
 
 Key-free fallbacks after that:
 
-10. **DuckDuckGo** -- key-free HTML fallback with no account or API key (order 100)
-11. **Ollama Web Search** -- key-free fallback via your configured local Ollama host when it is reachable and signed in with `ollama signin`; can reuse Ollama provider bearer auth when the host needs it, and can call direct `https://ollama.com` search when configured with `OLLAMA_API_KEY` (order 110)
-12. **SearXNG** -- `SEARXNG_BASE_URL` or `plugins.entries.searxng.config.webSearch.baseUrl` (order 200)
+11. **DuckDuckGo** -- key-free HTML fallback with no account or API key (order 100)
+12. **Ollama Web Search** -- key-free fallback via your configured local Ollama host when it is reachable and signed in with `ollama signin`; can reuse Ollama provider bearer auth when the host needs it, and can call direct `https://ollama.com` search when configured with `OLLAMA_API_KEY` (order 110)
+13. **SearXNG** -- `SEARXNG_BASE_URL` or `plugins.entries.searxng.config.webSearch.baseUrl` (order 200)
 
 If no provider is detected, it falls back to Brave (you will get a missing-key
 error prompting you to configure one).
@@ -457,5 +462,6 @@ If you use tool profiles or allowlists, add `web_search`, `x_search`, or `group:
 
 - [Web Fetch](/tools/web-fetch) -- fetch a URL and extract readable content
 - [Web Browser](/tools/browser) -- full browser automation for JS-heavy sites
+- [Browserbase Search](/tools/browserbase-search) -- Browserbase as the `web_search` provider
 - [Grok Search](/tools/grok-search) -- Grok as the `web_search` provider
 - [Ollama Web Search](/tools/ollama-search) -- key-free web search through your Ollama host

--- a/scripts/lib/official-external-plugin-catalog.json
+++ b/scripts/lib/official-external-plugin-catalog.json
@@ -51,6 +51,39 @@
       }
     },
     {
+      "name": "@browserbasehq/openclaw-browserbase-search",
+      "description": "Browserbase Search web search provider plugin for OpenClaw",
+      "source": "official",
+      "kind": "plugin",
+      "openclaw": {
+        "plugin": {
+          "id": "browserbase-search",
+          "label": "Browserbase Search"
+        },
+        "webSearchProviders": [
+          {
+            "id": "browserbase-search",
+            "label": "Browserbase Search",
+            "hint": "Fast, token-efficient Browserbase Search results.",
+            "onboardingScopes": ["text-inference"],
+            "credentialLabel": "Browserbase API key",
+            "envVars": ["BROWSERBASE_API_KEY"],
+            "placeholder": "bb_...",
+            "signupUrl": "https://www.browserbase.com/",
+            "docsUrl": "https://docs.openclaw.ai/tools/browserbase-search",
+            "credentialPath": "plugins.entries.browserbase-search.config.webSearch.apiKey",
+            "autoDetectOrder": 68
+          }
+        ],
+        "install": {
+          "clawhubSpec": "clawhub:@browserbasehq/openclaw-browserbase-search",
+          "npmSpec": "@browserbasehq/openclaw-browserbase-search",
+          "defaultChoice": "clawhub",
+          "minHostVersion": ">=2026.5.21"
+        }
+      }
+    },
+    {
       "name": "@openclaw/diagnostics-otel",
       "description": "OpenClaw diagnostics OpenTelemetry exporter",
       "source": "official",


### PR DESCRIPTION
## Summary

- add Browserbase Search to the official external plugin catalog for install-on-demand discovery
- add a dedicated Browserbase Search docs page
- list Browserbase Search in the web tools overview and docs navigation

## Validation

- `node -e 'JSON.parse(require("fs").readFileSync("scripts/lib/official-external-plugin-catalog.json","utf8")); JSON.parse(require("fs").readFileSync("docs/docs.json","utf8")); console.log("json ok")'`
