### PR TITLE
feat(telegram): add botMessagePolicy to filter inbound messages from other bots

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -2898,6 +2898,16 @@ export const registerTelegramHandlers = ({
     if (normalizedMsg.from?.id != null && normalizedMsg.from.id === ctx.me?.id) {
       return;
     }
+    // Drop messages authored by other bots when configured to do so. Bot API 10.0
+    // Bot-to-Bot Communication Mode can deliver messages from any other bot once
+    // both sides opt in via BotFather, and the upstream gateway has no other way
+    // to refuse them structurally.
+    if (normalizedMsg.from?.is_bot === true && telegramCfg.botMessagePolicy === "ignore") {
+      logVerbose(
+        `telegram: ignoring message ${normalizedMsg.message_id} from bot ${normalizedMsg.from.username ?? normalizedMsg.from.id} (botMessagePolicy=ignore)`,
+      );
+      return;
+    }
     await handleInboundMessageLike({
       ctxForDedupe: ctx,
       ctx: buildSyntheticContext(ctx, normalizedMsg),

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -194,6 +194,16 @@ export type TelegramAccountConfig = {
    */
   reactionNotifications?: "off" | "own" | "all";
   /**
+   * Controls how inbound messages authored by other bots are handled. Telegram
+   * Bot API 10.0 (2026-05-08) added Bot-to-Bot Communication Mode, which can
+   * expose a bot to messages from other bots once both sides opt in via
+   * BotFather (`/setbot2bot`).
+   * - "allow" (default): deliver bot-authored messages like any other inbound
+   * - "ignore": drop inbound messages where `from.is_bot=true` (self-echoes
+   *   are already filtered separately)
+   */
+  botMessagePolicy?: "allow" | "ignore";
+  /**
    * Controls agent's reaction capability:
    * - "off": agent cannot react
    * - "ack" (default): bot sends acknowledgment reactions (👀 while processing)


### PR DESCRIPTION
## Summary

Adds optional `telegram.botMessagePolicy` config (default `"allow"`) that, when set to `"ignore"`, drops inbound messages where `from.is_bot=true`. Self-echoes are already filtered by the existing `from.id === ctx.me?.id` check immediately above the new filter.

## Motivation

Bot API 10.0 (2026-05-08) introduced [Bot-to-Bot Communication Mode](https://core.telegram.org/bots/features#bot-to-bot-communication), which can expose a bot to messages from other bots once both sides opt in via BotFather (`/setbot2bot`). The default-off opt-in is the right safety primitive at the API level, but once enabled the gateway has no structural way to selectively refuse those messages — operators currently have to rely on behavioral defenses in their agent loop, which are fragile against prompt drift.

We hit this in production while migrating an inter-agent bridge from a Postgres queue to native bot-to-bot Telegram messaging: the inbound bot's guards held, but we wanted a defense-in-depth opt-out on the receiving gateway side as well. The reaction handler already has an analogous `is_bot` filter (`extensions/telegram/src/bot-handlers.runtime.ts:1513`), so the precedent for treating bot-authored messages as a distinct class exists in the codebase.

## Scope

- `src/config/types.telegram.ts`: new optional field `botMessagePolicy?: "allow" | "ignore"` on `TelegramAccountConfig`, placed alongside `reactionNotifications`.
- `extensions/telegram/src/bot-handlers.runtime.ts`: in `bot.on("message", ...)`, after the existing self-echo filter, drop messages where `normalizedMsg.from?.is_bot === true` when policy is `"ignore"`. Uses the already-imported `logVerbose` helper to record the drop.

Default behavior unchanged (`"allow"`), opt-in to activate.

## Follow-up (not in this PR)

`ChannelBotLoopProtectionConfig` already exists in this repo (`src/config/types.bot-loop-protection.ts`) and is wired into the channel turn kernel (`src/channels/turn/kernel.ts`). Slack and Google Chat expose it via account/channel config. Bringing Telegram to parity would let operators configure pair-loop rate-limit/cooldown via the same primitive — but it requires threading `ChannelBotLoopProtectionFacts` through `handleInboundMessageLike → processInboundMessage` and adjacent paths. Happy to open a follow-up issue if maintainers agree the parity is worth it.

## Test plan

- [ ] Add unit test mirroring the `"skips reaction from bot users"` test at `extensions/telegram/src/bot.test.ts:3498` for the `bot.on("message")` path. (Not included in this PR — would appreciate guidance on whether the message-handler tests live in `bot.test.ts`, `bot.create-telegram-bot.test.ts`, or `bot-handlers.runtime.test.ts`.)
- [x] Default (`policy unset` or `"allow"`): inbound message from another bot is processed normally — covered by existing tests since the new code path is bypassed entirely.
- [x] `policy = "ignore"`: inbound message with `from.is_bot=true` is dropped, `logVerbose` records the drop.
- [x] `policy = "ignore"`: self-echo is still dropped by the existing filter above (unchanged behavior).
- [x] `policy = "ignore"`: inbound message from a human (`from.is_bot` falsy) is processed normally.

## Notes for reviewers

- Default `"allow"` preserves existing behavior 1:1.
- The change is purely additive; no exports or signatures touched.
- I considered adding a `"log"` mode (record but still process) — happy to add if you want it before merging, but skipped to keep the surface minimal.
