### PR TITLE
Fix context pressure preflight for tool-heavy sessions

### DIFF
--- a/extensions/codex/src/app-server/context-engine-projection.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.ts
@@ -19,7 +19,7 @@ const MAX_RENDERED_CONTEXT_CHARS = 1_000_000;
 const DEFAULT_TEXT_PART_CHARS = 6_000;
 const MAX_TEXT_PART_CHARS = 128_000;
 const APPROX_RENDERED_CHARS_PER_TOKEN = 4;
-const DEFAULT_PROJECTION_RESERVE_TOKENS = 20_000;
+export const DEFAULT_CODEX_PROJECTION_RESERVE_TOKENS = 20_000;
 const MIN_PROMPT_BUDGET_RATIO = 0.5;
 const MIN_PROMPT_BUDGET_TOKENS = 8_000;
 
@@ -94,7 +94,7 @@ export function resolveCodexContextEngineProjectionReserveTokens(params: {
   if (configuredReserveTokens !== undefined) {
     return Math.max(
       configuredReserveTokens,
-      configuredReserveTokensFloor ?? DEFAULT_PROJECTION_RESERVE_TOKENS,
+      configuredReserveTokensFloor ?? DEFAULT_CODEX_PROJECTION_RESERVE_TOKENS,
     );
   }
   if (configuredReserveTokensFloor !== undefined) {
@@ -112,7 +112,7 @@ function resolveProjectionPromptBudgetTokens(params: {
     Number.isFinite(params.reserveTokens) &&
     params.reserveTokens >= 0
       ? Math.floor(params.reserveTokens)
-      : DEFAULT_PROJECTION_RESERVE_TOKENS;
+      : DEFAULT_CODEX_PROJECTION_RESERVE_TOKENS;
   const minPromptBudget = Math.min(
     MIN_PROMPT_BUDGET_TOKENS,
     Math.max(1, Math.floor(params.contextTokenBudget * MIN_PROMPT_BUDGET_RATIO)),

--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -90,6 +90,23 @@ function userMessage(text: string, timestamp: number): AgentMessage {
   } as AgentMessage;
 }
 
+function toolResultMessage(payload: unknown, timestamp: number): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId: `call-${timestamp}`,
+    toolName: "bulk_context_probe",
+    content: [
+      {
+        type: "toolResult",
+        toolUseId: `call-${timestamp}`,
+        output: payload,
+      },
+    ],
+    isError: false,
+    timestamp,
+  } as unknown as AgentMessage;
+}
+
 function threadStartResult(threadId = "thread-1") {
   return {
     thread: {
@@ -989,6 +1006,61 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     expect(savedBinding?.threadId).toBe("thread-fresh");
     expect(savedBinding?.contextEngine?.engineId).toBe("lossless-claw");
     expect(savedBinding?.contextEngine?.projection?.epoch).toBe("epoch-after");
+  });
+
+  it("compacts over-budget rendered context-engine prompts before Codex turn/start", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    SessionManager.open(sessionFile).appendMessage(
+      assistantMessage("pre-compaction context", Date.now()) as never,
+    );
+    const hugePayload = {
+      rows: Array.from({ length: 10 }, (_, index) => ({
+        id: index,
+        body: "0123456789abcdef".repeat(4000),
+      })),
+    };
+    const compact = vi.fn<ContextEngine["compact"]>(async () => ({
+      ok: true,
+      compacted: true,
+      result: { summary: "summary", firstKeptEntryId: "entry-1", tokensBefore: 100_000 },
+    }));
+    const assemble = vi
+      .fn<ContextEngine["assemble"]>()
+      .mockResolvedValueOnce({
+        messages: Array.from({ length: 8 }, (_, index) =>
+          toolResultMessage(hugePayload, index + 1),
+        ),
+        estimatedTokens: 100_000,
+        contextProjection: { mode: "thread_bootstrap", epoch: "epoch-before" },
+      })
+      .mockResolvedValueOnce({
+        messages: [assistantMessage("successor compacted context", 2) as never],
+        estimatedTokens: 100,
+        contextProjection: { mode: "thread_bootstrap", epoch: "epoch-after" },
+      });
+    const contextEngine = createContextEngine({ assemble, compact });
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    params.contextEngine = contextEngine;
+    params.contextTokenBudget = 16_000;
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+
+    expect(compact).toHaveBeenCalledTimes(1);
+    expect(assemble).toHaveBeenCalledTimes(2);
+    expect(harness.requests.map((request) => request.method)).toEqual([
+      "thread/start",
+      "turn/start",
+    ]);
+    const inputText = getRequestInputText(harness);
+    expect(inputText).toContain("successor compacted context");
+    expect(inputText).not.toContain("0123456789abcdef");
+
+    await harness.completeTurn();
+    const result = await run;
+    expect(result.assistantTexts).toContain("final answer");
   });
 
   it("bounds a hung owning context-engine compaction during Codex overflow recovery", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -15,7 +15,9 @@ import {
   compactContextEngineWithSafetyTimeout,
   embeddedAgentLog,
   emitAgentEvent as emitGlobalAgentEvent,
+  estimateRenderedLlmBoundaryTokenPressure,
   finalizeHarnessContextEngineTurn,
+  formatPrePromptPrecheckLog,
   formatErrorMessage,
   hasBeforeToolCallPolicy,
   isActiveHarnessContextEngine,
@@ -35,6 +37,8 @@ import {
   runAgentHarnessLlmInputHook,
   runAgentHarnessLlmOutputHook,
   runHarnessContextEngineMaintenance,
+  shouldPreemptivelyCompactBeforePrompt,
+  PREEMPTIVE_OVERFLOW_ERROR_TEXT,
   registerNativeHookRelay,
   resolveBootstrapContextForRun,
   setActiveEmbeddedRun,
@@ -94,6 +98,7 @@ import {
   type CodexPluginConfig,
 } from "./config.js";
 import {
+  DEFAULT_CODEX_PROJECTION_RESERVE_TOKENS,
   projectContextEngineAssemblyForCodex,
   resolveCodexContextEngineProjectionMaxChars,
   resolveCodexContextEngineProjectionReserveTokens,
@@ -1061,6 +1066,86 @@ export async function runCodexAppServerAttempt(
       contextEnginePluginId: activeContextEnginePluginId,
       tokenBudget: params.contextTokenBudget,
     });
+  const forceContextEngineCompactionForCodexOverflow = async (
+    error: unknown,
+    options: { threadId?: string } = {},
+  ): Promise<boolean> => {
+    if (!activeContextEngine?.info.ownsCompaction) {
+      return false;
+    }
+    embeddedAgentLog.warn(
+      "codex app-server context-engine prompt overflowed; forcing context-engine compaction",
+      {
+        sessionId: activeSessionId,
+        sessionKey: contextSessionKey,
+        ...(options.threadId ? { threadId: options.threadId } : {}),
+        engineId: activeContextEngine.info.id,
+        tokenBudget: params.contextTokenBudget,
+        error: formatErrorMessage(error),
+      },
+    );
+    try {
+      const runtimeContext = buildActiveContextEngineRuntimeContext();
+      const overflowTokenCount = params.contextTokenBudget ?? params.contextWindowInfo?.tokens;
+      // Bound the plugin-owned compaction with the same finite safety timeout
+      // that protects native runtime compaction, and thread the run-level
+      // abort signal through, so a slow/hung plugin compact() cannot stall
+      // Codex overflow recovery indefinitely.
+      const compactResult = await compactContextEngineWithSafetyTimeout(
+        activeContextEngine,
+        {
+          sessionId: activeSessionId,
+          sessionKey: contextSessionKey,
+          sessionFile: activeSessionFile,
+          tokenBudget: params.contextTokenBudget,
+          force: true,
+          ...(overflowTokenCount ? { currentTokenCount: overflowTokenCount } : {}),
+          compactionTarget: "threshold",
+          runtimeContext: overflowTokenCount
+            ? {
+                ...runtimeContext,
+                currentTokenCount: overflowTokenCount,
+              }
+            : runtimeContext,
+        },
+        resolveCompactionTimeoutMs(params.config),
+        runAbortController.signal,
+      );
+      embeddedAgentLog.info("codex app-server context-engine forced compaction result", {
+        sessionId: activeSessionId,
+        sessionKey: contextSessionKey,
+        engineId: activeContextEngine.info.id,
+        ok: compactResult.ok,
+        compacted: compactResult.compacted,
+        reason: compactResult.reason,
+        tokensBefore: compactResult.result?.tokensBefore,
+        tokensAfter: compactResult.result?.tokensAfter,
+      });
+      if (!compactResult.ok || !compactResult.compacted) {
+        return false;
+      }
+      adoptContextEngineCompactionTranscript(compactResult);
+      const maintenanceRuntimeContext = buildActiveContextEngineRuntimeContext();
+      await runHarnessContextEngineMaintenance({
+        contextEngine: activeContextEngine,
+        sessionId: activeSessionId,
+        sessionKey: contextSessionKey,
+        sessionFile: activeSessionFile,
+        reason: "compaction",
+        runtimeContext: maintenanceRuntimeContext,
+        config: params.config,
+      });
+      return true;
+    } catch (compactErr) {
+      embeddedAgentLog.warn("codex app-server context-engine forced compaction failed", {
+        sessionId: params.sessionId,
+        sessionKey: contextSessionKey,
+        engineId: activeContextEngine.info.id,
+        error: formatErrorMessage(compactErr),
+      });
+      return false;
+    }
+  };
   if (activeContextEngine) {
     await bootstrapHarnessContextEngine({
       hadSessionFile,
@@ -1217,6 +1302,109 @@ export async function runCodexAppServerAttempt(
   const refreshCodexTurnPromptText = () => {
     codexTurnPromptText = decorateCodexTurnPromptText(promptBuild.prompt);
   };
+  const rebuildPromptAfterContextEngineCompaction = async () => {
+    historyMessages =
+      (await readMirroredSessionHistoryMessages(activeSessionFile)) ?? historyMessages;
+    resetCodexPromptInputs();
+    try {
+      await applyActiveContextEngineProjection(undefined);
+    } catch (assembleErr) {
+      embeddedAgentLog.warn(
+        "context engine assemble failed after forced compaction; using Codex baseline prompt",
+        {
+          error: formatErrorMessage(assembleErr),
+        },
+      );
+    }
+    promptBuild = await buildPromptFromCurrentInputs();
+    refreshCodexTurnPromptText();
+  };
+  const buildCodexProviderBoundaryPrecheck = () => {
+    const contextTokenBudget =
+      typeof params.contextTokenBudget === "number" && Number.isFinite(params.contextTokenBudget)
+        ? Math.floor(params.contextTokenBudget)
+        : typeof params.contextWindowInfo?.tokens === "number" &&
+            Number.isFinite(params.contextWindowInfo.tokens)
+          ? Math.floor(params.contextWindowInfo.tokens)
+          : undefined;
+    if (!contextTokenBudget || contextTokenBudget <= 0) {
+      return undefined;
+    }
+    const reserveTokens =
+      resolveCodexContextEngineProjectionReserveTokens({ config: params.config }) ??
+      DEFAULT_CODEX_PROJECTION_RESERVE_TOKENS;
+    const renderedChars =
+      codexTurnPromptText.length + (promptBuild.developerInstructions?.length ?? 0);
+    return shouldPreemptivelyCompactBeforePrompt({
+      messages: historyMessages,
+      systemPrompt: promptBuild.developerInstructions,
+      prompt: codexTurnPromptText,
+      contextTokenBudget,
+      reserveTokens,
+      llmBoundaryTokenPressure: {
+        estimatedPromptTokens: estimateRenderedLlmBoundaryTokenPressure({
+          systemPrompt: promptBuild.developerInstructions,
+          prompt: codexTurnPromptText,
+        }),
+        source: "codex_app_server_rendered_prompt",
+        renderedChars,
+      },
+    });
+  };
+  const maybeCompactContextEngineForProviderBoundaryPrecheck = async () => {
+    if (!activeContextEngine?.info.ownsCompaction || !contextEngineProjection) {
+      return;
+    }
+    const precheck = buildCodexProviderBoundaryPrecheck();
+    if (!precheck) {
+      return;
+    }
+    embeddedAgentLog.debug(
+      formatPrePromptPrecheckLog({
+        result: precheck,
+        provider: params.provider,
+        modelId: params.modelId,
+        messageCount: historyMessages.length,
+        contextTokenBudget:
+          typeof params.contextTokenBudget === "number"
+            ? params.contextTokenBudget
+            : (params.contextWindowInfo?.tokens ?? 0),
+        reserveTokens:
+          resolveCodexContextEngineProjectionReserveTokens({ config: params.config }) ??
+          DEFAULT_CODEX_PROJECTION_RESERVE_TOKENS,
+        ...(contextSessionKey ? { sessionKey: contextSessionKey } : {}),
+        ...(activeSessionId ? { sessionId: activeSessionId } : {}),
+        ...(activeSessionFile ? { sessionFile: activeSessionFile } : {}),
+      }),
+    );
+    if (precheck.route === "fits") {
+      return;
+    }
+    const compacted = await forceContextEngineCompactionForCodexOverflow(
+      PREEMPTIVE_OVERFLOW_ERROR_TEXT,
+    );
+    if (!compacted) {
+      throw new Error(PREEMPTIVE_OVERFLOW_ERROR_TEXT);
+    }
+    await rebuildPromptAfterContextEngineCompaction();
+    const afterCompactionPrecheck = buildCodexProviderBoundaryPrecheck();
+    if (!afterCompactionPrecheck || afterCompactionPrecheck.route === "fits") {
+      return;
+    }
+    embeddedAgentLog.warn(
+      "codex app-server provider-boundary precheck still overflowed after compaction",
+      {
+        sessionId: activeSessionId,
+        sessionKey: contextSessionKey,
+        route: afterCompactionPrecheck.route,
+        estimatedPromptTokens: afterCompactionPrecheck.estimatedPromptTokens,
+        promptBudgetBeforeReserve: afterCompactionPrecheck.promptBudgetBeforeReserve,
+        overflowTokens: afterCompactionPrecheck.overflowTokens,
+      },
+    );
+    throw new Error(PREEMPTIVE_OVERFLOW_ERROR_TEXT);
+  };
+  await maybeCompactContextEngineForProviderBoundaryPrecheck();
   const systemPromptReport = buildCodexSystemPromptReport({
     attempt: params,
     sessionKey: contextSessionKey,
@@ -2444,101 +2632,6 @@ export async function runCodexAppServerAttempt(
   });
   let closeCleanup: (() => void) | undefined;
 
-  const forceContextEngineCompactionForCodexOverflow = async (error: unknown): Promise<boolean> => {
-    if (!activeContextEngine?.info.ownsCompaction) {
-      return false;
-    }
-    embeddedAgentLog.warn(
-      "codex app-server context-engine turn overflowed; forcing context-engine compaction",
-      {
-        sessionId: activeSessionId,
-        sessionKey: contextSessionKey,
-        threadId: thread.threadId,
-        engineId: activeContextEngine.info.id,
-        tokenBudget: params.contextTokenBudget,
-        error: formatErrorMessage(error),
-      },
-    );
-    try {
-      const runtimeContext = buildActiveContextEngineRuntimeContext();
-      const overflowTokenCount = params.contextTokenBudget ?? params.contextWindowInfo?.tokens;
-      // Bound the plugin-owned compaction with the same finite safety timeout
-      // that protects native runtime compaction, and thread the run-level
-      // abort signal through, so a slow/hung plugin compact() cannot stall
-      // Codex overflow recovery indefinitely. A timeout/abort surfaces as a
-      // thrown error handled by the catch below.
-      const compactResult = await compactContextEngineWithSafetyTimeout(
-        activeContextEngine,
-        {
-          sessionId: activeSessionId,
-          sessionKey: contextSessionKey,
-          sessionFile: activeSessionFile,
-          tokenBudget: params.contextTokenBudget,
-          force: true,
-          ...(overflowTokenCount ? { currentTokenCount: overflowTokenCount } : {}),
-          compactionTarget: "threshold",
-          runtimeContext: overflowTokenCount
-            ? {
-                ...runtimeContext,
-                currentTokenCount: overflowTokenCount,
-              }
-            : runtimeContext,
-        },
-        resolveCompactionTimeoutMs(params.config),
-        runAbortController.signal,
-      );
-      embeddedAgentLog.info("codex app-server context-engine forced compaction result", {
-        sessionId: activeSessionId,
-        sessionKey: contextSessionKey,
-        engineId: activeContextEngine.info.id,
-        ok: compactResult.ok,
-        compacted: compactResult.compacted,
-        reason: compactResult.reason,
-        tokensBefore: compactResult.result?.tokensBefore,
-        tokensAfter: compactResult.result?.tokensAfter,
-      });
-      if (!compactResult.ok || !compactResult.compacted) {
-        return false;
-      }
-      adoptContextEngineCompactionTranscript(compactResult);
-      const maintenanceRuntimeContext = buildActiveContextEngineRuntimeContext();
-      await runHarnessContextEngineMaintenance({
-        contextEngine: activeContextEngine,
-        sessionId: activeSessionId,
-        sessionKey: contextSessionKey,
-        sessionFile: activeSessionFile,
-        reason: "compaction",
-        runtimeContext: maintenanceRuntimeContext,
-        config: params.config,
-      });
-      return true;
-    } catch (compactErr) {
-      embeddedAgentLog.warn("codex app-server context-engine forced compaction failed", {
-        sessionId: params.sessionId,
-        sessionKey: contextSessionKey,
-        engineId: activeContextEngine.info.id,
-        error: formatErrorMessage(compactErr),
-      });
-      return false;
-    }
-  };
-  const rebuildPromptAfterContextEngineCompaction = async () => {
-    historyMessages =
-      (await readMirroredSessionHistoryMessages(activeSessionFile)) ?? historyMessages;
-    resetCodexPromptInputs();
-    try {
-      await applyActiveContextEngineProjection(undefined);
-    } catch (assembleErr) {
-      embeddedAgentLog.warn(
-        "context engine assemble failed after forced compaction; using Codex baseline prompt",
-        {
-          error: formatErrorMessage(assembleErr),
-        },
-      );
-    }
-    promptBuild = await buildPromptFromCurrentInputs();
-    refreshCodexTurnPromptText();
-  };
   const buildLlmInputEvent = () => ({
     runId: params.runId,
     sessionId: params.sessionId,
@@ -2601,8 +2694,12 @@ export async function runCodexAppServerAttempt(
       );
       try {
         const preRetrySessionFile = activeSessionFile;
-        const compactedForRetry =
-          await forceContextEngineCompactionForCodexOverflow(turnStartError);
+        const compactedForRetry = await forceContextEngineCompactionForCodexOverflow(
+          turnStartError,
+          {
+            threadId: thread.threadId,
+          },
+        );
         await clearCodexAppServerBinding(preRetrySessionFile);
         if (activeSessionFile !== preRetrySessionFile) {
           await clearCodexAppServerBinding(activeSessionFile);

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2497,26 +2497,21 @@ export async function runEmbeddedAttempt(
       const onMidTurnPrecheck = (request: MidTurnPrecheckRequest) => {
         pendingMidTurnPrecheckRequest = request;
       };
-      if (!activeContextEngine || activeContextEngine.info.ownsCompaction !== true) {
-        removeToolResultContextGuard = installToolResultContextGuard({
-          agent: activeSession.agent,
-          contextWindowTokens: contextTokenBudgetForGuard,
-          ...(midTurnPrecheckEnabled
-            ? {
-                midTurnPrecheck: {
-                  enabled: true,
-                  contextTokenBudget: contextTokenBudgetForGuard,
-                  reserveTokens: () => settingsManager.getCompactionReserveTokens(),
-                  toolResultMaxChars: toolResultMaxCharsForGuard,
-                  getSystemPrompt: () => systemPromptText,
-                  getPrePromptMessageCount: () => prePromptMessageCount,
-                  onMidTurnPrecheck,
-                },
-              }
-            : {}),
-        });
-      } else {
-        removeToolResultContextGuard = installContextEngineLoopHook({
+      const midTurnPrecheckOptions = midTurnPrecheckEnabled
+        ? {
+            midTurnPrecheck: {
+              enabled: true,
+              contextTokenBudget: contextTokenBudgetForGuard,
+              reserveTokens: () => settingsManager.getCompactionReserveTokens(),
+              toolResultMaxChars: toolResultMaxCharsForGuard,
+              getSystemPrompt: () => systemPromptText,
+              getPrePromptMessageCount: () => prePromptMessageCount,
+              onMidTurnPrecheck,
+            },
+          }
+        : {};
+      if (activeContextEngine?.info.ownsCompaction === true) {
+        const removeContextEngineLoopHook = installContextEngineLoopHook({
           agent: activeSession.agent,
           contextEngine: activeContextEngine,
           sessionId: params.sessionId,
@@ -2546,6 +2541,21 @@ export async function runEmbeddedAttempt(
                   }),
                 }),
             }),
+        });
+        const removeGuard = installToolResultContextGuard({
+          agent: activeSession.agent,
+          contextWindowTokens: contextTokenBudgetForGuard,
+          ...midTurnPrecheckOptions,
+        });
+        removeToolResultContextGuard = () => {
+          removeGuard();
+          removeContextEngineLoopHook();
+        };
+      } else {
+        removeToolResultContextGuard = installToolResultContextGuard({
+          agent: activeSession.agent,
+          contextWindowTokens: contextTokenBudgetForGuard,
+          ...midTurnPrecheckOptions,
         });
       }
       const removeLoopContextGuard = removeToolResultContextGuard;

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
@@ -6,6 +6,7 @@ import { estimateToolResultReductionPotential } from "../tool-result-truncation.
 let PREEMPTIVE_OVERFLOW_ERROR_TEXT: typeof import("./preemptive-compaction.js").PREEMPTIVE_OVERFLOW_ERROR_TEXT;
 let estimateLlmBoundaryTokenPressure: typeof import("./preemptive-compaction.js").estimateLlmBoundaryTokenPressure;
 let estimatePrePromptTokens: typeof import("./preemptive-compaction.js").estimatePrePromptTokens;
+let estimateRenderedLlmBoundaryTokenPressure: typeof import("./preemptive-compaction.js").estimateRenderedLlmBoundaryTokenPressure;
 let formatPrePromptPrecheckLog: typeof import("./preemptive-compaction.js").formatPrePromptPrecheckLog;
 let shouldPreemptivelyCompactBeforePrompt: typeof import("./preemptive-compaction.js").shouldPreemptivelyCompactBeforePrompt;
 
@@ -15,6 +16,7 @@ beforeAll(async () => {
     PREEMPTIVE_OVERFLOW_ERROR_TEXT,
     estimateLlmBoundaryTokenPressure,
     estimatePrePromptTokens,
+    estimateRenderedLlmBoundaryTokenPressure,
     formatPrePromptPrecheckLog,
     shouldPreemptivelyCompactBeforePrompt,
   } = await import("./preemptive-compaction.js"));
@@ -172,6 +174,31 @@ describe("preemptive-compaction", () => {
     expect(result.shouldCompact).toBe(true);
     expect(result.route).toBe("compact_only");
     expect(result.estimatedPromptTokens).toBeGreaterThan(result.promptBudgetBeforeReserve);
+  });
+
+  it("uses rendered LLM-boundary pressure when the runtime owns the final payload shape", () => {
+    const renderedPrompt = "x".repeat(60_000);
+    const estimatedPromptTokens = estimateRenderedLlmBoundaryTokenPressure({
+      systemPrompt: "sys",
+      prompt: renderedPrompt,
+    });
+    const result = shouldPreemptivelyCompactBeforePrompt({
+      messages: [makeAssistantHistory("the transcript view is intentionally small")],
+      systemPrompt: "sys",
+      prompt: "small prompt before runtime projection",
+      contextTokenBudget: 16_000,
+      reserveTokens: 4_000,
+      llmBoundaryTokenPressure: {
+        estimatedPromptTokens,
+        source: "test_rendered_payload",
+        renderedChars: renderedPrompt.length,
+      },
+    });
+
+    expect(result.pressureSource).toBe("test_rendered_payload");
+    expect(result.estimatedPromptTokens).toBe(estimatedPromptTokens);
+    expect(result.route).toBe("compact_only");
+    expect(result.shouldCompact).toBe(true);
   });
 
   it("counts array/object tool-result payloads at the LLM boundary", () => {

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
@@ -4,6 +4,7 @@ import "../../test-helpers/pi-coding-agent-token-mock.js";
 import { estimateToolResultReductionPotential } from "../tool-result-truncation.js";
 
 let PREEMPTIVE_OVERFLOW_ERROR_TEXT: typeof import("./preemptive-compaction.js").PREEMPTIVE_OVERFLOW_ERROR_TEXT;
+let estimateLlmBoundaryTokenPressure: typeof import("./preemptive-compaction.js").estimateLlmBoundaryTokenPressure;
 let estimatePrePromptTokens: typeof import("./preemptive-compaction.js").estimatePrePromptTokens;
 let formatPrePromptPrecheckLog: typeof import("./preemptive-compaction.js").formatPrePromptPrecheckLog;
 let shouldPreemptivelyCompactBeforePrompt: typeof import("./preemptive-compaction.js").shouldPreemptivelyCompactBeforePrompt;
@@ -12,6 +13,7 @@ beforeAll(async () => {
   vi.resetModules();
   ({
     PREEMPTIVE_OVERFLOW_ERROR_TEXT,
+    estimateLlmBoundaryTokenPressure,
     estimatePrePromptTokens,
     formatPrePromptPrecheckLog,
     shouldPreemptivelyCompactBeforePrompt,
@@ -35,6 +37,32 @@ function makeToolResultMessage(...texts: string[]): AgentMessage {
     toolName: "read",
     content: texts.map((text) => ({ type: "text", text })),
     isError: false,
+    timestamp: timestamp++,
+  } as AgentMessage;
+}
+
+function makeJsonToolResultMessage(payload: unknown): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId: `call_${timestamp}`,
+    toolName: "json_tool",
+    content: [{ type: "json", payload }],
+    isError: false,
+    timestamp: timestamp++,
+  } as unknown as AgentMessage;
+}
+
+function makeAssistantToolCall(args: unknown): AgentMessage {
+  return {
+    role: "assistant",
+    content: [
+      {
+        type: "toolCall",
+        id: `call_${timestamp}`,
+        name: "bulk_lookup",
+        arguments: args,
+      },
+    ],
     timestamp: timestamp++,
   } as AgentMessage;
 }
@@ -144,6 +172,85 @@ describe("preemptive-compaction", () => {
     expect(result.shouldCompact).toBe(true);
     expect(result.route).toBe("compact_only");
     expect(result.estimatedPromptTokens).toBeGreaterThan(result.promptBudgetBeforeReserve);
+  });
+
+  it("counts array/object tool-result payloads at the LLM boundary", () => {
+    const objectPayload = {
+      rows: Array.from({ length: 120 }, (_, index) => ({
+        path: `/tmp/generated-${index}.txt`,
+        body: "x".repeat(1_500),
+      })),
+    };
+    const messages = [makeJsonToolResultMessage(objectPayload)];
+    const estimatedPromptTokens = estimateLlmBoundaryTokenPressure({
+      messages,
+      systemPrompt: "sys",
+      prompt: "continue",
+    });
+
+    expect(estimatedPromptTokens).toBeGreaterThan(80_000);
+
+    const result = shouldPreemptivelyCompactBeforePrompt({
+      messages,
+      systemPrompt: "sys",
+      prompt: "continue",
+      contextTokenBudget: 96_000,
+      reserveTokens: 20_000,
+    });
+
+    expect(result.route).not.toBe("fits");
+    expect(result.estimatedPromptTokens).toBe(estimatedPromptTokens);
+    expect(result.overflowTokens).toBeGreaterThan(0);
+  });
+
+  it("counts assistant tool-call arguments instead of trusting text-only token estimates", () => {
+    const messages = [
+      makeAssistantToolCall({
+        queryPlan: "find relevant files",
+        candidates: Array.from({ length: 100 }, (_, index) => ({
+          path: `/repo/file-${index}.ts`,
+          content: "z".repeat(1_000),
+        })),
+      }),
+    ];
+    const estimatedPromptTokens = estimatePrePromptTokens({
+      messages,
+      systemPrompt: "sys",
+      prompt: "continue",
+    });
+
+    expect(estimatedPromptTokens).toBeGreaterThan(30_000);
+  });
+
+  it("prechecks a regression-sized synthetic tool-heavy transcript as over budget", () => {
+    const toolResultCharsPerMessage = Math.ceil(427_000 / 120);
+    const generalCharsPerMessage = Math.ceil((503_000 - 427_000) / 121);
+    const messages: AgentMessage[] = [];
+    for (let index = 0; index < 241; index += 1) {
+      if (index % 2 === 0) {
+        messages.push(
+          makeToolResultMessage(
+            "t".repeat(toolResultCharsPerMessage),
+            JSON.stringify({ index, payload: "p".repeat(80) }),
+          ),
+        );
+      } else {
+        messages.push(makeAssistantHistory("h".repeat(generalCharsPerMessage)));
+      }
+    }
+
+    const result = shouldPreemptivelyCompactBeforePrompt({
+      messages,
+      systemPrompt: "system".repeat(200),
+      prompt: "continue",
+      contextTokenBudget: 200_000,
+      reserveTokens: 32_000,
+    });
+
+    expect(result.estimatedPromptTokens).toBeGreaterThan(200_000);
+    expect(result.promptBudgetBeforeReserve).toBe(168_000);
+    expect(result.route).not.toBe("fits");
+    expect(result.overflowTokens).toBeGreaterThan(0);
   });
 
   it("caps reserve tokens so small context models keep usable prompt budget", () => {

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
@@ -1,6 +1,6 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import { estimateTokens } from "@earendil-works/pi-coding-agent";
-import { SAFETY_MARGIN, estimateMessagesTokens } from "../../compaction.js";
+import { estimateStringChars } from "../../../utils/cjk-chars.js";
+import { SAFETY_MARGIN } from "../../compaction.js";
 import {
   MIN_PROMPT_BUDGET_RATIO,
   MIN_PROMPT_BUDGET_TOKENS,
@@ -12,6 +12,11 @@ export const PREEMPTIVE_OVERFLOW_ERROR_TEXT =
   "Context overflow: prompt too large for the model (precheck).";
 
 const ESTIMATED_CHARS_PER_TOKEN = 4;
+const TOOL_RESULT_CHARS_PER_TOKEN = 2;
+const JSON_PAYLOAD_CHARS_PER_TOKEN = 3;
+const MESSAGE_BOUNDARY_OVERHEAD_TOKENS = 12;
+const CONTENT_BLOCK_OVERHEAD_TOKENS = 6;
+const IMAGE_BLOCK_TOKENS = 2_000;
 const TRUNCATION_ROUTE_BUFFER_TOKENS = 512;
 
 export type { PreemptiveCompactionRoute } from "./preemptive-compaction.types.js";
@@ -26,26 +31,178 @@ export type PreemptiveCompactionDecision = {
   effectiveReserveTokens: number;
 };
 
+function estimateStringTokenPressure(text: string, charsPerToken = ESTIMATED_CHARS_PER_TOKEN) {
+  return Math.ceil(estimateStringChars(text) / charsPerToken);
+}
+
+function estimateJsonPayloadTokenPressure(
+  value: unknown,
+  charsPerToken = JSON_PAYLOAD_CHARS_PER_TOKEN,
+): number {
+  try {
+    const serialized = JSON.stringify(value);
+    return typeof serialized === "string"
+      ? Math.ceil(estimateStringChars(serialized) / charsPerToken)
+      : 1;
+  } catch {
+    return 256;
+  }
+}
+
+function estimateIdentifierTokenPressure(
+  value: unknown,
+  charsPerToken = JSON_PAYLOAD_CHARS_PER_TOKEN,
+): number {
+  if (value == null) {
+    return 0;
+  }
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint"
+  ) {
+    return estimateStringTokenPressure(String(value), charsPerToken);
+  }
+  return estimateJsonPayloadTokenPressure(value, charsPerToken);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function estimateContentBlockTokenPressure(
+  block: unknown,
+  charsPerToken = ESTIMATED_CHARS_PER_TOKEN,
+): number {
+  if (typeof block === "string") {
+    return estimateStringTokenPressure(block, charsPerToken);
+  }
+  if (!isRecord(block)) {
+    return estimateJsonPayloadTokenPressure(block, charsPerToken);
+  }
+
+  const type = block.type;
+  if (type === "text" && typeof block.text === "string") {
+    return CONTENT_BLOCK_OVERHEAD_TOKENS + estimateStringTokenPressure(block.text, charsPerToken);
+  }
+  if (type === "thinking" && typeof block.thinking === "string") {
+    return (
+      CONTENT_BLOCK_OVERHEAD_TOKENS + estimateStringTokenPressure(block.thinking, charsPerToken)
+    );
+  }
+  if (type === "image") {
+    return IMAGE_BLOCK_TOKENS;
+  }
+  return CONTENT_BLOCK_OVERHEAD_TOKENS + estimateJsonPayloadTokenPressure(block, charsPerToken);
+}
+
+function estimateToolResultContentTokenPressure(content: unknown): number {
+  if (typeof content === "string") {
+    return estimateStringTokenPressure(content, TOOL_RESULT_CHARS_PER_TOKEN);
+  }
+  if (Array.isArray(content)) {
+    return content.reduce(
+      (sum, block) => sum + estimateContentBlockTokenPressure(block, TOOL_RESULT_CHARS_PER_TOKEN),
+      0,
+    );
+  }
+  if (content !== undefined) {
+    return estimateJsonPayloadTokenPressure(content, TOOL_RESULT_CHARS_PER_TOKEN);
+  }
+  return 0;
+}
+
+function estimateAssistantToolCallTokenPressure(block: Record<string, unknown>): number {
+  const args = block.arguments ?? block.input ?? block.args ?? {};
+  return (
+    CONTENT_BLOCK_OVERHEAD_TOKENS +
+    estimateIdentifierTokenPressure(block.name, JSON_PAYLOAD_CHARS_PER_TOKEN) +
+    estimateJsonPayloadTokenPressure(args, JSON_PAYLOAD_CHARS_PER_TOKEN)
+  );
+}
+
+function estimateContentTokenPressure(content: unknown): number {
+  if (typeof content === "string") {
+    return estimateStringTokenPressure(content);
+  }
+  if (Array.isArray(content)) {
+    return content.reduce((sum, block) => sum + estimateContentBlockTokenPressure(block), 0);
+  }
+  if (content !== undefined) {
+    return estimateJsonPayloadTokenPressure(content);
+  }
+  return 0;
+}
+
+function isToolResultMessage(message: AgentMessage): boolean {
+  const record = message as unknown as { role?: unknown; type?: unknown };
+  return record.role === "toolResult" || record.role === "tool" || record.type === "toolResult";
+}
+
+function estimateMessageTokenPressure(message: AgentMessage): number {
+  const record = message as unknown as Record<string, unknown>;
+  let tokens = MESSAGE_BOUNDARY_OVERHEAD_TOKENS;
+
+  if (isToolResultMessage(message)) {
+    tokens += estimateToolResultContentTokenPressure(record.content);
+    tokens += estimateIdentifierTokenPressure(record.toolName ?? record.tool_name);
+    return tokens;
+  }
+
+  if (record.role === "assistant") {
+    const content = record.content;
+    if (Array.isArray(content)) {
+      for (const block of content) {
+        if (isRecord(block) && (block.type === "toolCall" || block.type === "tool_use")) {
+          tokens += estimateAssistantToolCallTokenPressure(block);
+        } else {
+          tokens += estimateContentBlockTokenPressure(block);
+        }
+      }
+    } else {
+      tokens += estimateContentTokenPressure(content);
+    }
+
+    const toolCalls = record.toolCalls ?? record.tool_calls;
+    if (Array.isArray(toolCalls)) {
+      for (const toolCall of toolCalls) {
+        tokens += isRecord(toolCall)
+          ? estimateAssistantToolCallTokenPressure(toolCall)
+          : estimateJsonPayloadTokenPressure(toolCall);
+      }
+    }
+    return tokens;
+  }
+
+  tokens += estimateContentTokenPressure(record.content);
+  return tokens;
+}
+
+export function estimateLlmBoundaryTokenPressure(params: {
+  messages: AgentMessage[];
+  systemPrompt?: string;
+  prompt: string;
+}): number {
+  const historyTokens = params.messages.reduce(
+    (sum, message) => sum + estimateMessageTokenPressure(message),
+    0,
+  );
+  const systemTokens =
+    typeof params.systemPrompt === "string" && params.systemPrompt.trim().length > 0
+      ? MESSAGE_BOUNDARY_OVERHEAD_TOKENS + estimateStringTokenPressure(params.systemPrompt)
+      : 0;
+  const promptTokens =
+    MESSAGE_BOUNDARY_OVERHEAD_TOKENS + estimateStringTokenPressure(params.prompt);
+  return Math.max(0, Math.ceil((historyTokens + systemTokens + promptTokens) * SAFETY_MARGIN));
+}
+
 export function estimatePrePromptTokens(params: {
   messages: AgentMessage[];
   systemPrompt?: string;
   prompt: string;
 }): number {
-  const { messages, systemPrompt, prompt } = params;
-  const syntheticMessages: AgentMessage[] = [];
-  if (typeof systemPrompt === "string" && systemPrompt.trim().length > 0) {
-    syntheticMessages.push({
-      role: "system",
-      content: systemPrompt,
-      timestamp: 0,
-    } as unknown as AgentMessage);
-  }
-  syntheticMessages.push({ role: "user", content: prompt, timestamp: 0 } as AgentMessage);
-
-  const estimated =
-    estimateMessagesTokens(messages) +
-    syntheticMessages.reduce((sum, message) => sum + estimateTokens(message), 0);
-  return Math.max(0, Math.ceil(estimated * SAFETY_MARGIN));
+  return estimateLlmBoundaryTokenPressure(params);
 }
 
 export function shouldPreemptivelyCompactBeforePrompt(params: {

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
@@ -25,10 +25,17 @@ export type PreemptiveCompactionDecision = {
   route: PreemptiveCompactionRoute;
   shouldCompact: boolean;
   estimatedPromptTokens: number;
+  pressureSource?: string;
   promptBudgetBeforeReserve: number;
   overflowTokens: number;
   toolResultReducibleChars: number;
   effectiveReserveTokens: number;
+};
+
+export type LlmBoundaryTokenPressure = {
+  estimatedPromptTokens: number;
+  source: string;
+  renderedChars?: number;
 };
 
 function estimateStringTokenPressure(text: string, charsPerToken = ESTIMATED_CHARS_PER_TOKEN) {
@@ -197,12 +204,41 @@ export function estimateLlmBoundaryTokenPressure(params: {
   return Math.max(0, Math.ceil((historyTokens + systemTokens + promptTokens) * SAFETY_MARGIN));
 }
 
+export function estimateRenderedLlmBoundaryTokenPressure(params: {
+  systemPrompt?: string;
+  prompt: string;
+}): number {
+  const systemTokens =
+    typeof params.systemPrompt === "string" && params.systemPrompt.trim().length > 0
+      ? MESSAGE_BOUNDARY_OVERHEAD_TOKENS + estimateStringTokenPressure(params.systemPrompt)
+      : 0;
+  const promptTokens =
+    MESSAGE_BOUNDARY_OVERHEAD_TOKENS + estimateStringTokenPressure(params.prompt);
+  return Math.max(0, Math.ceil((systemTokens + promptTokens) * SAFETY_MARGIN));
+}
+
 export function estimatePrePromptTokens(params: {
   messages: AgentMessage[];
   systemPrompt?: string;
   prompt: string;
 }): number {
   return estimateLlmBoundaryTokenPressure(params);
+}
+
+function normalizeLlmBoundaryTokenPressure(
+  pressure: LlmBoundaryTokenPressure | undefined,
+): LlmBoundaryTokenPressure | undefined {
+  if (!pressure || !Number.isFinite(pressure.estimatedPromptTokens)) {
+    return undefined;
+  }
+  const estimatedPromptTokens = Math.max(0, Math.ceil(pressure.estimatedPromptTokens));
+  return {
+    estimatedPromptTokens,
+    source: pressure.source.trim() || "rendered_llm_boundary",
+    ...(typeof pressure.renderedChars === "number" && Number.isFinite(pressure.renderedChars)
+      ? { renderedChars: Math.max(0, Math.ceil(pressure.renderedChars)) }
+      : {}),
+  };
 }
 
 export function shouldPreemptivelyCompactBeforePrompt(params: {
@@ -213,13 +249,20 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
   contextTokenBudget: number;
   reserveTokens: number;
   toolResultMaxChars?: number;
+  llmBoundaryTokenPressure?: LlmBoundaryTokenPressure;
 }): PreemptiveCompactionDecision {
   let messagesForPressure = params.messages;
-  let estimatedPromptTokens = estimatePrePromptTokens({
-    messages: params.messages,
-    systemPrompt: params.systemPrompt,
-    prompt: params.prompt,
-  });
+  const llmBoundaryTokenPressure = normalizeLlmBoundaryTokenPressure(
+    params.llmBoundaryTokenPressure,
+  );
+  let estimatedPromptTokens =
+    llmBoundaryTokenPressure?.estimatedPromptTokens ??
+    estimatePrePromptTokens({
+      messages: params.messages,
+      systemPrompt: params.systemPrompt,
+      prompt: params.prompt,
+    });
+  let pressureSource = llmBoundaryTokenPressure?.source ?? "transcript_estimate";
   if (params.unwindowedMessages && params.unwindowedMessages !== params.messages) {
     const unwindowedEstimatedPromptTokens = estimatePrePromptTokens({
       messages: params.unwindowedMessages,
@@ -229,6 +272,7 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
     if (unwindowedEstimatedPromptTokens > estimatedPromptTokens) {
       estimatedPromptTokens = unwindowedEstimatedPromptTokens;
       messagesForPressure = params.unwindowedMessages;
+      pressureSource = "unwindowed_transcript_estimate";
     }
   }
   const contextTokenBudget = Math.max(1, Math.floor(params.contextTokenBudget));
@@ -270,6 +314,7 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
     route,
     shouldCompact: route === "compact_only" || route === "compact_then_truncate",
     estimatedPromptTokens,
+    pressureSource,
     promptBudgetBeforeReserve,
     overflowTokens,
     toolResultReducibleChars,
@@ -296,6 +341,7 @@ export function formatPrePromptPrecheckLog(params: {
     `provider=${params.provider}/${params.modelId} ` +
     `route=${result.route} ` +
     `estimatedPromptTokens=${result.estimatedPromptTokens} ` +
+    `pressureSource=${result.pressureSource ?? "unknown"} ` +
     `promptBudgetBeforeReserve=${result.promptBudgetBeforeReserve} ` +
     `overflowTokens=${result.overflowTokens} ` +
     `toolResultReducibleChars=${result.toolResultReducibleChars} ` +

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -500,6 +500,38 @@ describe("installContextEngineLoopHook", () => {
     });
   }
 
+  function installOwnsCompactionHookWithGuard(
+    agent: ReturnType<typeof makeGuardableAgent>,
+    engine: MockedEngine,
+    options: {
+      prePromptCount?: number;
+      contextWindowTokens?: number;
+      contextTokenBudget?: number;
+      reserveTokens?: number;
+      toolResultMaxChars?: number;
+    } = {},
+  ): () => void {
+    const removeEngineHook = installHook(agent, engine, options.prePromptCount);
+    const removeGuard = installToolResultContextGuard({
+      agent,
+      contextWindowTokens: options.contextWindowTokens ?? 200_000,
+      midTurnPrecheck: {
+        enabled: true,
+        contextTokenBudget: options.contextTokenBudget ?? 20_000,
+        reserveTokens: () => options.reserveTokens ?? 12_000,
+        toolResultMaxChars: options.toolResultMaxChars,
+        getSystemPrompt: () => "sys",
+        ...(options.prePromptCount !== undefined
+          ? { getPrePromptMessageCount: () => options.prePromptCount as number }
+          : {}),
+      },
+    });
+    return () => {
+      removeGuard();
+      removeEngineHook();
+    };
+  }
+
   async function callAfterInitialToolResult(
     agent: ReturnType<typeof makeGuardableAgent>,
     options: { includeSecondUser?: boolean; firstResultText?: string } = {},
@@ -529,6 +561,46 @@ describe("installContextEngineLoopHook", () => {
     expect(transformed).toBe(messages);
     expect(engine.afterTurn).not.toHaveBeenCalled();
     expect(engine.assemble).not.toHaveBeenCalled();
+  });
+
+  it("keeps the pressure guard active around ownsCompaction loop assembly", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine();
+    installOwnsCompactionHookWithGuard(agent, engine, {
+      prePromptCount: 1,
+      contextWindowTokens: 200_000,
+      contextTokenBudget: 20_000,
+      reserveTokens: 12_000,
+      toolResultMaxChars: 16_000,
+    });
+
+    const messages = [makeUser("first"), makeToolResult("call_1", "x".repeat(80_000))];
+
+    await expect(callTransform(agent, messages)).rejects.toBeInstanceOf(MidTurnPrecheckSignal);
+    expect(engine.afterTurn).toHaveBeenCalledTimes(1);
+    expect(engine.assemble).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets ownsCompaction assembly resolve pressure before the generic guard checks", async () => {
+    const agent = makeGuardableAgent();
+    const compactedView = [makeUser("compacted")];
+    const engine = makeMockEngine({
+      assemble: async () => ({ messages: compactedView, estimatedTokens: 0 }),
+    });
+    installOwnsCompactionHookWithGuard(agent, engine, {
+      prePromptCount: 1,
+      contextWindowTokens: 200_000,
+      contextTokenBudget: 20_000,
+      reserveTokens: 12_000,
+      toolResultMaxChars: 16_000,
+    });
+
+    const messages = [makeUser("first"), makeToolResult("call_1", "x".repeat(80_000))];
+    const transformed = await callTransform(agent, messages);
+
+    expect(transformed).toBe(compactedView);
+    expect(engine.afterTurn).toHaveBeenCalledTimes(1);
+    expect(engine.assemble).toHaveBeenCalledTimes(1);
   });
 
   it("processes the first call when messages already exceed the pre-prompt baseline", async () => {

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -210,6 +210,14 @@ export {
   compactContextEngineWithSafetyTimeout,
   resolveCompactionTimeoutMs,
 } from "../agents/pi-embedded-runner/compaction-safety-timeout.js";
+export {
+  estimateRenderedLlmBoundaryTokenPressure,
+  formatPrePromptPrecheckLog,
+  PREEMPTIVE_OVERFLOW_ERROR_TEXT,
+  shouldPreemptivelyCompactBeforePrompt,
+  type LlmBoundaryTokenPressure,
+  type PreemptiveCompactionDecision,
+} from "../agents/pi-embedded-runner/run/preemptive-compaction.js";
 export { resolveContextEngineOwnerPluginId } from "../context-engine/registry.js";
 export {
   runAgentHarnessAfterToolCallHook,


### PR DESCRIPTION
## What
Fixes the generic preflight estimate path so tool-heavy persistent sessions are judged with an LLM-boundary pressure estimate instead of the compaction-safe estimator that can undercount runtime payloads.

## Changes
- Add conservative LLM-boundary pressure estimation for toolResult array/object content and assistant tool-call arguments.
- Use that pressure estimate in `shouldPreemptivelyCompactBeforePrompt`.
- Keep the generic tool-result/context guard active for context engines with `ownsCompaction` by running engine loop assembly first, then applying the guard.
- Add focused regression coverage for object payload undercount, regression-sized synthetic transcript pressure, and `ownsCompaction` guard composition.

## Real Behavior Proof
Behavior addressed: The live failed class of OpenClaw Codex turns had a tool-heavy persistent transcript that was incorrectly judged as fitting the context window, so preflight submitted to the provider instead of compacting.

Real environment tested: Local OpenClaw runtime checkout on macOS using the saved failed Codex session snapshot from the live incident, with output redacted to numeric pressure and routing fields only.

Exact steps or command run after this patch: Ran `node --import tsx` from the OpenClaw worktree to load the saved session via `SessionManager.open(...)`, rebuild the session messages, and call `shouldPreemptivelyCompactBeforePrompt(...)` with the same 272k context budget and 20k reserve used by the incident-era preflight.

Evidence after fix: Terminal output from the saved-session replay showed the preflight now detects overflow and routes to compaction:

```json
{
  "messageCount": 241,
  "compactionSafeEstimate": 10430,
  "llmBoundaryPrePromptEstimate": 286523,
  "decision": {
    "route": "compact_only",
    "shouldCompact": true,
    "estimatedPromptTokens": 286523,
    "promptBudgetBeforeReserve": 252000,
    "overflowTokens": 34523,
    "toolResultReducibleChars": 0,
    "effectiveReserveTokens": 20000
  }
}
```

Observed result after fix: The same tool-heavy persistent transcript that previously bypassed preflight now triggers preflight compaction before provider submission.

What was not tested: Live provider overflow against an actual Codex account after merging, because the saved incident transcript reproduces the preflight decision without sending another overfull provider request.

## Testing
- `pnpm exec vitest run src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts src/agents/pi-embedded-runner/tool-result-context-guard.test.ts` - 108 passed.
- `pnpm tsgo:core` - passed.
- `pnpm lint --threads=8` - passed.
- `pnpm check:test-types` - passed.
- `git diff --check` - passed.
