### PR TITLE
fix: honor OpenAI video request network policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/chat: keep chat session search always inline with the session selector, remove the extra search/clear icon buttons, and keep picker chevrons/checkmarks visible in dark mode.
 - Codex app-server: restart the native app-server and retry once when server-side compaction times out, so preflight compaction stalls recover instead of failing every dispatch. (#85500)
 - Restore Control UI gateway token pairing [AI]. (#85459) Thanks @pgondhi987.
+- OpenAI video: honor configured provider request private-network opt-in for local/custom video endpoints so explicitly trusted mock and self-hosted providers are not blocked. Thanks @shakkernerd.
 - CLI/update: repair managed npm plugin `openclaw` peer links during post-core convergence and reject stale or wrong-target peer links before restart. (#83794) Thanks @fuller-stack-dev.
 - CLI/agents: default new omitted-account bindings to all accounts when the channel has multiple configured accounts, and clarify account-scope docs. (#49769) Thanks @Gcaufy.
 - Codex app-server: let authorized `/codex` control commands such as `/codex detach` escape plugin-owned conversation bindings while keeping unknown or unauthorized slash text routed to the bound plugin. Fixes #85157. (#85188) Thanks @TurboTheTurtle.

--- a/extensions/openai/video-generation-provider.test.ts
+++ b/extensions/openai/video-generation-provider.test.ts
@@ -12,6 +12,7 @@ const {
   fetchWithTimeoutGuardedMock,
   pollProviderOperationJsonMock,
   assertOkOrThrowHttpErrorMock,
+  executeProviderOperationWithRetryMock,
   resolveProviderHttpRequestConfigMock,
   sanitizeConfiguredModelProviderRequestMock,
 } = getProviderHttpMocks();
@@ -304,11 +305,84 @@ describe("openai video generation provider", () => {
     });
   });
 
-  it("releases guarded local video download requests when HTTP errors throw", async () => {
-    const release = vi.fn(async () => {});
+  it("retries guarded local video downloads after transient HTTP errors", async () => {
+    const firstRelease = vi.fn(async () => {});
+    const secondRelease = vi.fn(async () => {});
     assertOkOrThrowHttpErrorMock
       .mockImplementationOnce(async () => {})
       .mockImplementationOnce(async () => {})
+      .mockImplementationOnce(async (_response, label) => {
+        throw new Error(label);
+      })
+      .mockImplementationOnce(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: {
+        json: async () => ({
+          id: "vid_local",
+          model: "sora-2",
+          status: "queued",
+        }),
+      },
+      release: vi.fn(async () => {}),
+    });
+    fetchWithTimeoutMock.mockResolvedValueOnce({
+      json: async () => ({
+        id: "vid_local",
+        model: "sora-2",
+        status: "completed",
+      }),
+    });
+    fetchWithTimeoutGuardedMock
+      .mockResolvedValueOnce({
+        response: new Response("busy", { status: 503, statusText: "Service Unavailable" }),
+        finalUrl: "http://127.0.0.1:44080/v1/videos/vid_local/content?variant=video",
+        release: firstRelease,
+      })
+      .mockResolvedValueOnce({
+        response: {
+          headers: new Headers({ "content-type": "video/mp4" }),
+          arrayBuffer: async () => Buffer.from("mp4-bytes"),
+        },
+        finalUrl: "http://127.0.0.1:44080/v1/videos/vid_local/content?variant=video",
+        release: secondRelease,
+      });
+
+    const provider = buildOpenAIVideoGenerationProvider();
+    const result = await provider.generateVideo({
+      provider: "openai",
+      model: "sora-2",
+      prompt: "Render via local relay",
+      cfg: {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "http://127.0.0.1:44080/v1",
+              request: { allowPrivateNetwork: true },
+              models: [],
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.videos[0]?.buffer.toString()).toBe("mp4-bytes");
+    expect(executeProviderOperationWithRetryMock).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "openai", stage: "download" }),
+    );
+    expect(fetchWithTimeoutGuardedMock).toHaveBeenCalledTimes(2);
+    expect(firstRelease).toHaveBeenCalledTimes(1);
+    expect(secondRelease).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases guarded local video download requests when HTTP errors throw", async () => {
+    const firstRelease = vi.fn(async () => {});
+    const secondRelease = vi.fn(async () => {});
+    assertOkOrThrowHttpErrorMock
+      .mockImplementationOnce(async () => {})
+      .mockImplementationOnce(async () => {})
+      .mockImplementationOnce(async (_response, label) => {
+        throw new Error(label);
+      })
       .mockImplementationOnce(async (_response, label) => {
         throw new Error(label);
       });
@@ -329,11 +403,17 @@ describe("openai video generation provider", () => {
         status: "completed",
       }),
     });
-    fetchWithTimeoutGuardedMock.mockResolvedValueOnce({
-      response: new Response("busy", { status: 503, statusText: "Service Unavailable" }),
-      finalUrl: "http://127.0.0.1:44080/v1/videos/vid_local/content?variant=video",
-      release,
-    });
+    fetchWithTimeoutGuardedMock
+      .mockResolvedValueOnce({
+        response: new Response("busy", { status: 503, statusText: "Service Unavailable" }),
+        finalUrl: "http://127.0.0.1:44080/v1/videos/vid_local/content?variant=video",
+        release: firstRelease,
+      })
+      .mockResolvedValueOnce({
+        response: new Response("busy", { status: 503, statusText: "Service Unavailable" }),
+        finalUrl: "http://127.0.0.1:44080/v1/videos/vid_local/content?variant=video",
+        release: secondRelease,
+      });
 
     const provider = buildOpenAIVideoGenerationProvider();
     await expect(
@@ -355,7 +435,9 @@ describe("openai video generation provider", () => {
       }),
     ).rejects.toThrow("OpenAI video download failed");
 
-    expect(release).toHaveBeenCalledTimes(1);
+    expect(fetchWithTimeoutGuardedMock).toHaveBeenCalledTimes(2);
+    expect(firstRelease).toHaveBeenCalledTimes(1);
+    expect(secondRelease).toHaveBeenCalledTimes(1);
   });
 
   it("uses multipart input_reference for video-to-video uploads", async () => {

--- a/extensions/openai/video-generation-provider.test.ts
+++ b/extensions/openai/video-generation-provider.test.ts
@@ -5,8 +5,13 @@ import {
 import { expectExplicitVideoGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
-const { postJsonRequestMock, fetchWithTimeoutMock, resolveProviderHttpRequestConfigMock } =
-  getProviderHttpMocks();
+const {
+  postJsonRequestMock,
+  postMultipartRequestMock,
+  fetchWithTimeoutMock,
+  resolveProviderHttpRequestConfigMock,
+  sanitizeConfiguredModelProviderRequestMock,
+} = getProviderHttpMocks();
 
 let buildOpenAIVideoGenerationProvider: typeof import("./video-generation-provider.js").buildOpenAIVideoGenerationProvider;
 
@@ -20,6 +25,16 @@ function postJsonRequest(index = 0): Record<string, unknown> {
   const request = postJsonRequestMock.mock.calls[index]?.[0] as Record<string, unknown> | undefined;
   if (!request) {
     throw new Error(`expected postJsonRequest call ${index}`);
+  }
+  return request;
+}
+
+function postMultipartRequest(index = 0): Record<string, unknown> {
+  const request = postMultipartRequestMock.mock.calls[index]?.[0] as
+    | Record<string, unknown>
+    | undefined;
+  if (!request) {
+    throw new Error(`expected postMultipartRequest call ${index}`);
   }
   return request;
 }
@@ -150,7 +165,7 @@ describe("openai video generation provider", () => {
     expect(pollFetch).toBe(fetch);
   });
 
-  it("honors configured baseUrl for video requests", async () => {
+  it("keeps configured local baseUrl private-network blocked unless explicitly enabled", async () => {
     postJsonRequestMock.mockResolvedValue({
       response: {
         json: async () => ({
@@ -192,9 +207,62 @@ describe("openai video generation provider", () => {
     });
 
     expect(providerHttpConfigRequest().baseUrl).toBe("http://127.0.0.1:44080/v1");
+    expect(providerHttpConfigRequest().request).toBeUndefined();
     const createRequest = postJsonRequest();
     expect(createRequest.url).toBe("http://127.0.0.1:44080/v1/videos");
     expect(createRequest.allowPrivateNetwork).toBe(false);
+  });
+
+  it("honors configured request allowPrivateNetwork for local video providers", async () => {
+    postJsonRequestMock.mockResolvedValue({
+      response: {
+        json: async () => ({
+          id: "vid_local",
+          model: "sora-2",
+          status: "queued",
+        }),
+      },
+      release: vi.fn(async () => {}),
+    });
+    fetchWithTimeoutMock
+      .mockResolvedValueOnce({
+        json: async () => ({
+          id: "vid_local",
+          model: "sora-2",
+          status: "completed",
+        }),
+      })
+      .mockResolvedValueOnce({
+        headers: new Headers({ "content-type": "video/mp4" }),
+        arrayBuffer: async () => Buffer.from("mp4-bytes"),
+      });
+
+    const provider = buildOpenAIVideoGenerationProvider();
+    await provider.generateVideo({
+      provider: "openai",
+      model: "sora-2",
+      prompt: "Render via local relay",
+      cfg: {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "http://127.0.0.1:44080/v1",
+              request: { allowPrivateNetwork: true },
+              models: [],
+            },
+          },
+        },
+      },
+    });
+
+    expect(sanitizeConfiguredModelProviderRequestMock).toHaveBeenCalledWith({
+      allowPrivateNetwork: true,
+    });
+    expect(providerHttpConfigRequest().baseUrl).toBe("http://127.0.0.1:44080/v1");
+    expect(providerHttpConfigRequest().request).toEqual({ allowPrivateNetwork: true });
+    const createRequest = postJsonRequest();
+    expect(createRequest.url).toBe("http://127.0.0.1:44080/v1/videos");
+    expect(createRequest.allowPrivateNetwork).toBe(true);
   });
 
   it("uses multipart input_reference for video-to-video uploads", async () => {
@@ -229,12 +297,12 @@ describe("openai video generation provider", () => {
     });
 
     expect(postJsonRequestMock).not.toHaveBeenCalled();
-    const [createUrl, createInit, createTimeout, createFetch] = fetchWithTimeoutCall(0);
-    expect(createUrl).toBe("https://api.openai.com/v1/videos");
-    expect(createInit?.method).toBe("POST");
-    expect(createInit?.body).toBeInstanceOf(FormData);
-    expect(createTimeout).toBe(120000);
-    expect(createFetch).toBe(fetch);
+    const createRequest = postMultipartRequest();
+    expect(createRequest.url).toBe("https://api.openai.com/v1/videos");
+    expect(createRequest.body).toBeInstanceOf(FormData);
+    expect(createRequest.timeoutMs).toBe(120000);
+    expect(createRequest.fetchFn).toBe(fetch);
+    expect(createRequest.allowPrivateNetwork).toBe(false);
   });
 
   it("rejects multiple reference assets", async () => {

--- a/extensions/openai/video-generation-provider.test.ts
+++ b/extensions/openai/video-generation-provider.test.ts
@@ -11,6 +11,7 @@ const {
   fetchWithTimeoutMock,
   fetchWithTimeoutGuardedMock,
   pollProviderOperationJsonMock,
+  assertOkOrThrowHttpErrorMock,
   resolveProviderHttpRequestConfigMock,
   sanitizeConfiguredModelProviderRequestMock,
 } = getProviderHttpMocks();
@@ -301,6 +302,60 @@ describe("openai video generation provider", () => {
       ssrfPolicy: { allowPrivateNetwork: true },
       auditContext: "openai-video-download",
     });
+  });
+
+  it("releases guarded local video download requests when HTTP errors throw", async () => {
+    const release = vi.fn(async () => {});
+    assertOkOrThrowHttpErrorMock
+      .mockImplementationOnce(async () => {})
+      .mockImplementationOnce(async () => {})
+      .mockImplementationOnce(async (_response, label) => {
+        throw new Error(label);
+      });
+    postJsonRequestMock.mockResolvedValue({
+      response: {
+        json: async () => ({
+          id: "vid_local",
+          model: "sora-2",
+          status: "queued",
+        }),
+      },
+      release: vi.fn(async () => {}),
+    });
+    fetchWithTimeoutMock.mockResolvedValueOnce({
+      json: async () => ({
+        id: "vid_local",
+        model: "sora-2",
+        status: "completed",
+      }),
+    });
+    fetchWithTimeoutGuardedMock.mockResolvedValueOnce({
+      response: new Response("busy", { status: 503, statusText: "Service Unavailable" }),
+      finalUrl: "http://127.0.0.1:44080/v1/videos/vid_local/content?variant=video",
+      release,
+    });
+
+    const provider = buildOpenAIVideoGenerationProvider();
+    await expect(
+      provider.generateVideo({
+        provider: "openai",
+        model: "sora-2",
+        prompt: "Render via local relay",
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "http://127.0.0.1:44080/v1",
+                request: { allowPrivateNetwork: true },
+                models: [],
+              },
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow("OpenAI video download failed");
+
+    expect(release).toHaveBeenCalledTimes(1);
   });
 
   it("uses multipart input_reference for video-to-video uploads", async () => {

--- a/extensions/openai/video-generation-provider.test.ts
+++ b/extensions/openai/video-generation-provider.test.ts
@@ -9,6 +9,8 @@ const {
   postJsonRequestMock,
   postMultipartRequestMock,
   fetchWithTimeoutMock,
+  fetchWithTimeoutGuardedMock,
+  pollProviderOperationJsonMock,
   resolveProviderHttpRequestConfigMock,
   sanitizeConfiguredModelProviderRequestMock,
 } = getProviderHttpMocks();
@@ -47,6 +49,28 @@ function fetchWithTimeoutCall(index: number): [string, RequestInit | undefined, 
     throw new Error(`expected fetchWithTimeout call ${index}`);
   }
   return call;
+}
+
+function fetchWithTimeoutGuardedCall(
+  index = 0,
+): [string, RequestInit | undefined, number, unknown, Record<string, unknown> | undefined] {
+  const call = fetchWithTimeoutGuardedMock.mock.calls[index] as
+    | [string, RequestInit | undefined, number, unknown, Record<string, unknown> | undefined]
+    | undefined;
+  if (!call) {
+    throw new Error(`expected fetchWithTimeoutGuarded call ${index}`);
+  }
+  return call;
+}
+
+function pollProviderOperationRequest(index = 0): Record<string, unknown> {
+  const request = pollProviderOperationJsonMock.mock.calls[index]?.[0] as
+    | Record<string, unknown>
+    | undefined;
+  if (!request) {
+    throw new Error(`expected pollProviderOperationJson call ${index}`);
+  }
+  return request;
 }
 
 function providerHttpConfigRequest(): Record<string, unknown> {
@@ -263,6 +287,20 @@ describe("openai video generation provider", () => {
     const createRequest = postJsonRequest();
     expect(createRequest.url).toBe("http://127.0.0.1:44080/v1/videos");
     expect(createRequest.allowPrivateNetwork).toBe(true);
+    const statusRequest = pollProviderOperationRequest();
+    expect(statusRequest.url).toBe("http://127.0.0.1:44080/v1/videos/vid_local");
+    expect(statusRequest.allowPrivateNetwork).toBe(true);
+    expect(statusRequest.auditContext).toBe("openai-video-status");
+    const [downloadUrl, downloadInit, downloadTimeout, downloadFetch, downloadOptions] =
+      fetchWithTimeoutGuardedCall();
+    expect(downloadUrl).toBe("http://127.0.0.1:44080/v1/videos/vid_local/content?variant=video");
+    expect(downloadInit?.method).toBe("GET");
+    expect(downloadTimeout).toBe(120000);
+    expect(downloadFetch).toBe(fetch);
+    expect(downloadOptions).toEqual({
+      ssrfPolicy: { allowPrivateNetwork: true },
+      auditContext: "openai-video-download",
+    });
   });
 
   it("uses multipart input_reference for video-to-video uploads", async () => {
@@ -303,6 +341,59 @@ describe("openai video generation provider", () => {
     expect(createRequest.timeoutMs).toBe(120000);
     expect(createRequest.fetchFn).toBe(fetch);
     expect(createRequest.allowPrivateNetwork).toBe(false);
+  });
+
+  it("honors configured request allowPrivateNetwork for multipart video uploads", async () => {
+    fetchWithTimeoutMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: "vid_789",
+          model: "sora-2",
+          status: "queued",
+        }),
+      })
+      .mockResolvedValueOnce({
+        json: async () => ({
+          id: "vid_789",
+          model: "sora-2",
+          status: "completed",
+        }),
+      })
+      .mockResolvedValueOnce({
+        headers: new Headers({ "content-type": "video/mp4" }),
+        arrayBuffer: async () => Buffer.from("mp4-bytes"),
+      });
+
+    const provider = buildOpenAIVideoGenerationProvider();
+    await provider.generateVideo({
+      provider: "openai",
+      model: "sora-2",
+      prompt: "Remix this clip",
+      cfg: {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "http://127.0.0.1:44080/v1",
+              request: { allowPrivateNetwork: true },
+              models: [],
+            },
+          },
+        },
+      },
+      inputVideos: [{ buffer: Buffer.from("mp4-bytes"), mimeType: "video/mp4" }],
+    });
+
+    expect(postJsonRequestMock).not.toHaveBeenCalled();
+    const createRequest = postMultipartRequest();
+    expect(createRequest.url).toBe("http://127.0.0.1:44080/v1/videos");
+    expect(createRequest.body).toBeInstanceOf(FormData);
+    expect(createRequest.allowPrivateNetwork).toBe(true);
+    expect(pollProviderOperationRequest().allowPrivateNetwork).toBe(true);
+    expect(fetchWithTimeoutGuardedCall()[4]).toEqual({
+      ssrfPolicy: { allowPrivateNetwork: true },
+      auditContext: "openai-video-download",
+    });
   });
 
   it("rejects multiple reference assets", async () => {

--- a/extensions/openai/video-generation-provider.ts
+++ b/extensions/openai/video-generation-provider.ts
@@ -6,6 +6,7 @@ import {
   createProviderOperationDeadline,
   createProviderOperationTimeoutResolver,
   fetchProviderDownloadResponse,
+  fetchWithTimeoutGuarded,
   pollProviderOperationJson,
   postJsonRequest,
   postMultipartRequest,
@@ -29,6 +30,11 @@ const POLL_INTERVAL_MS = 2_500;
 const MAX_POLL_ATTEMPTS = 120;
 const OPENAI_VIDEO_SECONDS = [4, 8, 12] as const;
 const OPENAI_VIDEO_SIZES = ["720x1280", "1280x720", "1024x1792", "1792x1024"] as const;
+
+type OpenAIVideoRequestPolicy = {
+  allowPrivateNetwork: boolean;
+  dispatcherPolicy?: Parameters<typeof postJsonRequest>[0]["dispatcherPolicy"];
+};
 
 type OpenAIVideoStatus = "queued" | "in_progress" | "completed" | "failed";
 
@@ -117,13 +123,15 @@ function resolveReferenceAsset(req: VideoGenerationRequest) {
   return new File([toBlobBytes(asset.buffer)], fileName, { type: mimeType });
 }
 
-async function pollOpenAIVideo(params: {
-  videoId: string;
-  headers: Headers;
-  timeoutMs?: number;
-  baseUrl: string;
-  fetchFn: typeof fetch;
-}): Promise<OpenAIVideoResponse> {
+async function pollOpenAIVideo(
+  params: {
+    videoId: string;
+    headers: Headers;
+    timeoutMs?: number;
+    baseUrl: string;
+    fetchFn: typeof fetch;
+  } & OpenAIVideoRequestPolicy,
+): Promise<OpenAIVideoResponse> {
   const deadline = createProviderOperationDeadline({
     timeoutMs: params.timeoutMs,
     label: `OpenAI video generation task ${params.videoId}`,
@@ -138,6 +146,9 @@ async function pollOpenAIVideo(params: {
     pollIntervalMs: POLL_INTERVAL_MS,
     requestFailedMessage: "OpenAI video status request failed",
     timeoutMessage: `OpenAI video generation task ${params.videoId} did not finish in time`,
+    allowPrivateNetwork: params.allowPrivateNetwork,
+    dispatcherPolicy: params.dispatcherPolicy,
+    auditContext: "openai-video-status",
     isComplete: (payload) => payload.status === "completed",
     getFailureMessage: (payload) =>
       payload.status === "failed"
@@ -146,16 +157,63 @@ async function pollOpenAIVideo(params: {
   });
 }
 
-async function downloadOpenAIVideo(params: {
-  videoId: string;
-  headers: Headers;
-  timeoutMs?: ProviderOperationTimeoutMs;
-  baseUrl: string;
-  fetchFn: typeof fetch;
-}): Promise<GeneratedVideoAsset> {
+function resolveOpenAIVideoDownloadTimeoutMs(timeoutMs: ProviderOperationTimeoutMs | undefined) {
+  const resolved = typeof timeoutMs === "function" ? timeoutMs() : timeoutMs;
+  return typeof resolved === "number" && Number.isFinite(resolved) && resolved > 0
+    ? resolved
+    : DEFAULT_TIMEOUT_MS;
+}
+
+async function fetchOpenAIVideoDownload(
+  params: {
+    url: string;
+    init: RequestInit;
+    timeoutMs?: ProviderOperationTimeoutMs;
+    fetchFn: typeof fetch;
+  } & OpenAIVideoRequestPolicy,
+) {
+  if (!params.allowPrivateNetwork && !params.dispatcherPolicy) {
+    const response = await fetchProviderDownloadResponse({
+      url: params.url,
+      init: params.init,
+      timeoutMs: params.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      fetchFn: params.fetchFn,
+      provider: "openai",
+      requestFailedMessage: "OpenAI video download failed",
+    });
+    return {
+      response,
+      release: async () => {},
+    };
+  }
+
+  const result = await fetchWithTimeoutGuarded(
+    params.url,
+    params.init,
+    resolveOpenAIVideoDownloadTimeoutMs(params.timeoutMs),
+    params.fetchFn,
+    {
+      ...(params.allowPrivateNetwork ? { ssrfPolicy: { allowPrivateNetwork: true } } : {}),
+      ...(params.dispatcherPolicy ? { dispatcherPolicy: params.dispatcherPolicy } : {}),
+      auditContext: "openai-video-download",
+    },
+  );
+  await assertOkOrThrowHttpError(result.response, "OpenAI video download failed");
+  return result;
+}
+
+async function downloadOpenAIVideo(
+  params: {
+    videoId: string;
+    headers: Headers;
+    timeoutMs?: ProviderOperationTimeoutMs;
+    baseUrl: string;
+    fetchFn: typeof fetch;
+  } & OpenAIVideoRequestPolicy,
+): Promise<GeneratedVideoAsset> {
   const url = new URL(`${params.baseUrl}/videos/${params.videoId}/content`);
   url.searchParams.set("variant", "video");
-  const response = await fetchProviderDownloadResponse({
+  const { response, release } = await fetchOpenAIVideoDownload({
     url: url.toString(),
     init: {
       method: "GET",
@@ -164,18 +222,22 @@ async function downloadOpenAIVideo(params: {
         Accept: "application/binary",
       }),
     },
-    timeoutMs: params.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    timeoutMs: params.timeoutMs,
     fetchFn: params.fetchFn,
-    provider: "openai",
-    requestFailedMessage: "OpenAI video download failed",
+    allowPrivateNetwork: params.allowPrivateNetwork,
+    dispatcherPolicy: params.dispatcherPolicy,
   });
-  const mimeType = normalizeOptionalString(response.headers.get("content-type")) ?? "video/mp4";
-  const arrayBuffer = await response.arrayBuffer();
-  return {
-    buffer: Buffer.from(arrayBuffer),
-    mimeType,
-    fileName: `video-1.${extensionForMime(mimeType)?.slice(1) ?? "mp4"}`,
-  };
+  try {
+    const mimeType = normalizeOptionalString(response.headers.get("content-type")) ?? "video/mp4";
+    const arrayBuffer = await response.arrayBuffer();
+    return {
+      buffer: Buffer.from(arrayBuffer),
+      mimeType,
+      fileName: `video-1.${extensionForMime(mimeType)?.slice(1) ?? "mp4"}`,
+    };
+  } finally {
+    await release();
+  }
 }
 
 export function buildOpenAIVideoGenerationProvider(): VideoGenerationProvider {
@@ -351,6 +413,8 @@ export function buildOpenAIVideoGenerationProvider(): VideoGenerationProvider {
           }),
           baseUrl,
           fetchFn,
+          allowPrivateNetwork,
+          dispatcherPolicy,
         });
         const video = await downloadOpenAIVideo({
           videoId,
@@ -361,6 +425,8 @@ export function buildOpenAIVideoGenerationProvider(): VideoGenerationProvider {
           }),
           baseUrl,
           fetchFn,
+          allowPrivateNetwork,
+          dispatcherPolicy,
         });
         return {
           videos: [video],

--- a/extensions/openai/video-generation-provider.ts
+++ b/extensions/openai/video-generation-provider.ts
@@ -5,6 +5,7 @@ import {
   assertOkOrThrowHttpError,
   createProviderOperationDeadline,
   createProviderOperationTimeoutResolver,
+  executeProviderOperationWithRetry,
   fetchProviderDownloadResponse,
   fetchWithTimeoutGuarded,
   pollProviderOperationJson,
@@ -187,24 +188,30 @@ async function fetchOpenAIVideoDownload(
     };
   }
 
-  const result = await fetchWithTimeoutGuarded(
-    params.url,
-    params.init,
-    resolveOpenAIVideoDownloadTimeoutMs(params.timeoutMs),
-    params.fetchFn,
-    {
-      ...(params.allowPrivateNetwork ? { ssrfPolicy: { allowPrivateNetwork: true } } : {}),
-      ...(params.dispatcherPolicy ? { dispatcherPolicy: params.dispatcherPolicy } : {}),
-      auditContext: "openai-video-download",
+  return await executeProviderOperationWithRetry({
+    provider: "openai",
+    stage: "download",
+    operation: async () => {
+      const result = await fetchWithTimeoutGuarded(
+        params.url,
+        params.init,
+        resolveOpenAIVideoDownloadTimeoutMs(params.timeoutMs),
+        params.fetchFn,
+        {
+          ...(params.allowPrivateNetwork ? { ssrfPolicy: { allowPrivateNetwork: true } } : {}),
+          ...(params.dispatcherPolicy ? { dispatcherPolicy: params.dispatcherPolicy } : {}),
+          auditContext: "openai-video-download",
+        },
+      );
+      try {
+        await assertOkOrThrowHttpError(result.response, "OpenAI video download failed");
+        return result;
+      } catch (error) {
+        await result.release();
+        throw error;
+      }
     },
-  );
-  try {
-    await assertOkOrThrowHttpError(result.response, "OpenAI video download failed");
-    return result;
-  } catch (error) {
-    await result.release();
-    throw error;
-  }
+  });
 }
 
 async function downloadOpenAIVideo(

--- a/extensions/openai/video-generation-provider.ts
+++ b/extensions/openai/video-generation-provider.ts
@@ -198,8 +198,13 @@ async function fetchOpenAIVideoDownload(
       auditContext: "openai-video-download",
     },
   );
-  await assertOkOrThrowHttpError(result.response, "OpenAI video download failed");
-  return result;
+  try {
+    await assertOkOrThrowHttpError(result.response, "OpenAI video download failed");
+    return result;
+  } catch (error) {
+    await result.release();
+    throw error;
+  }
 }
 
 async function downloadOpenAIVideo(

--- a/extensions/openai/video-generation-provider.ts
+++ b/extensions/openai/video-generation-provider.ts
@@ -6,11 +6,12 @@ import {
   createProviderOperationDeadline,
   createProviderOperationTimeoutResolver,
   fetchProviderDownloadResponse,
-  fetchWithTimeout,
   pollProviderOperationJson,
   postJsonRequest,
+  postMultipartRequest,
   resolveProviderOperationTimeoutMs,
   resolveProviderHttpRequestConfig,
+  sanitizeConfiguredModelProviderRequest,
   type ProviderOperationTimeoutMs,
 } from "openclaw/plugin-sdk/provider-http";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -232,11 +233,12 @@ export function buildOpenAIVideoGenerationProvider(): VideoGenerationProvider {
         timeoutMs: req.timeoutMs,
         label: "OpenAI video generation",
       });
+      const providerConfig = req.cfg.models?.providers?.openai;
       const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy } =
         resolveProviderHttpRequestConfig({
           baseUrl: resolveConfiguredOpenAIBaseUrl(req.cfg),
           defaultBaseUrl: DEFAULT_OPENAI_VIDEO_BASE_URL,
-          allowPrivateNetwork: false,
+          request: sanitizeConfiguredModelProviderRequest(providerConfig?.request),
           defaultHeaders: {
             Authorization: `Bearer ${auth.apiKey}`,
           },
@@ -297,22 +299,18 @@ export function buildOpenAIVideoGenerationProvider(): VideoGenerationProvider {
               form.set("input_reference", referenceAsset);
               const multipartHeaders = new Headers(headers);
               multipartHeaders.delete("Content-Type");
-              return fetchWithTimeout(
-                requestUrl,
-                {
-                  method: "POST",
-                  headers: multipartHeaders,
-                  body: form,
-                },
-                resolveProviderOperationTimeoutMs({
+              return postMultipartRequest({
+                url: requestUrl,
+                headers: multipartHeaders,
+                body: form,
+                timeoutMs: resolveProviderOperationTimeoutMs({
                   deadline,
                   defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
                 }),
                 fetchFn,
-              ).then((response) => ({
-                response,
-                release: async () => {},
-              }));
+                allowPrivateNetwork,
+                dispatcherPolicy,
+              });
             })()
         : await (() => {
             const jsonHeaders = new Headers(headers);

--- a/src/media-understanding/shared.test.ts
+++ b/src/media-understanding/shared.test.ts
@@ -155,6 +155,39 @@ describe("provider operation deadlines", () => {
     expect(fetchFn).toHaveBeenCalledTimes(2);
   });
 
+  it("passes guarded request policy through provider status polling", async () => {
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(JSON.stringify({ status: "completed" })),
+      finalUrl: "https://api.example.com/v1/videos/task-1",
+      release,
+    });
+
+    const result = await pollProviderOperationJson<{ status?: string }>({
+      url: "https://api.example.com/v1/videos/task-1",
+      headers: new Headers({ authorization: "Bearer test" }),
+      deadline: createProviderOperationDeadline({
+        label: "video generation task task-1",
+      }),
+      defaultTimeoutMs: 5_000,
+      fetchFn: fetch,
+      maxAttempts: 3,
+      pollIntervalMs: 1_000,
+      requestFailedMessage: "status failed",
+      timeoutMessage: "task timed out",
+      allowPrivateNetwork: true,
+      dispatcherPolicy: { mode: "direct" },
+      auditContext: "provider-video-status",
+      isComplete: (payload) => payload.status === "completed",
+    });
+
+    expect(result).toEqual({ status: "completed" });
+    expect(getFirstGuardedFetchCall().policy).toEqual({ allowPrivateNetwork: true });
+    expect(getFirstGuardedFetchCall().dispatcherPolicy).toEqual({ mode: "direct" });
+    expect(getFirstGuardedFetchCall().auditContext).toBe("provider-video-status");
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
   it("throws provider failure messages while polling status JSON", async () => {
     const fetchFn = vi
       .fn<typeof fetch>()

--- a/src/media-understanding/shared.test.ts
+++ b/src/media-understanding/shared.test.ts
@@ -188,6 +188,48 @@ describe("provider operation deadlines", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
+  it("retries guarded transient provider status failures while polling", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const firstRelease = vi.fn(async () => {});
+    const secondRelease = vi.fn(async () => {});
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce({
+        response: new Response("busy", { status: 503, statusText: "Service Unavailable" }),
+        finalUrl: "https://api.example.com/v1/videos/task-1",
+        release: firstRelease,
+      })
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({ status: "completed" })),
+        finalUrl: "https://api.example.com/v1/videos/task-1",
+        release: secondRelease,
+      });
+
+    const result = pollProviderOperationJson<{ status?: string }>({
+      url: "https://api.example.com/v1/videos/task-1",
+      headers: new Headers({ authorization: "Bearer test" }),
+      deadline: createProviderOperationDeadline({
+        label: "video generation task task-1",
+        timeoutMs: 10_000,
+      }),
+      defaultTimeoutMs: 5_000,
+      fetchFn: fetch,
+      maxAttempts: 3,
+      pollIntervalMs: 1_000,
+      requestFailedMessage: "status failed",
+      timeoutMessage: "task timed out",
+      allowPrivateNetwork: true,
+      isComplete: (payload) => payload.status === "completed",
+    });
+
+    await vi.advanceTimersByTimeAsync(250);
+
+    await expect(result).resolves.toEqual({ status: "completed" });
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(2);
+    expect(firstRelease).toHaveBeenCalledTimes(1);
+    expect(secondRelease).toHaveBeenCalledTimes(1);
+  });
+
   it("throws provider failure messages while polling status JSON", async () => {
     const fetchFn = vi
       .fn<typeof fetch>()

--- a/src/media-understanding/shared.ts
+++ b/src/media-understanding/shared.ts
@@ -174,15 +174,16 @@ export async function pollProviderOperationJson<TPayload>(
     const guardedOptions = resolveGuardedRequestOptions(params);
     const payload = guardedOptions
       ? await (async () => {
-          const result = await fetchWithTimeoutGuarded(
-            params.url,
+          const result = await fetchGuardedProviderOperationResponse({
+            stage: "poll",
+            url: params.url,
             init,
-            timeoutMs(),
-            params.fetchFn,
+            timeoutMs,
+            fetchFn: params.fetchFn,
+            requestFailedMessage: params.requestFailedMessage,
             guardedOptions,
-          );
+          });
           try {
-            await assertOkOrThrowHttpError(result.response, params.requestFailedMessage);
             return (await readProviderJsonObjectResponse(
               result.response,
               params.requestFailedMessage,
@@ -471,6 +472,42 @@ function resolveGuardedRequestOptions(
     ...(params.auditContext ? { auditContext: params.auditContext } : {}),
     ...(params.mode !== undefined ? { mode: params.mode } : {}),
   };
+}
+
+async function fetchGuardedProviderOperationResponse(params: {
+  stage: ProviderOperationRetryStage;
+  url: string;
+  init: RequestInit;
+  timeoutMs?: ProviderOperationTimeoutMs;
+  fetchFn: typeof fetch;
+  provider?: string;
+  requestFailedMessage?: string;
+  retry?: TransientProviderRetryConfig;
+  guardedOptions: GuardedProviderRequestOptions;
+}): Promise<GuardedFetchResult> {
+  return await executeProviderOperationWithRetry({
+    provider: params.provider ?? "provider-http",
+    stage: params.stage,
+    retry: params.retry,
+    operation: async () => {
+      const result = await fetchWithTimeoutGuarded(
+        params.url,
+        params.init,
+        resolveProviderOperationRequestTimeoutMs(params.timeoutMs),
+        params.fetchFn,
+        params.guardedOptions,
+      );
+      try {
+        if (params.requestFailedMessage) {
+          await assertOkOrThrowHttpError(result.response, params.requestFailedMessage);
+        }
+        return result;
+      } catch (error) {
+        await result.release();
+        throw error;
+      }
+    },
+  });
 }
 
 type GuardedPostRequestRetryOptions = {

--- a/src/media-understanding/shared.ts
+++ b/src/media-understanding/shared.ts
@@ -16,6 +16,7 @@ import type {
 import {
   buildProviderRequestDispatcherPolicy,
   resolveProviderRequestPolicyConfig,
+  type ModelProviderRequestTransportOverrides,
   type ProviderRequestTransportOverrides,
   type ResolvedProviderRequestConfig,
 } from "../agents/provider-request-config.js";
@@ -269,7 +270,7 @@ export function resolveProviderHttpRequestConfig(params: {
   allowPrivateNetwork?: boolean;
   headers?: HeadersInit;
   defaultHeaders?: Record<string, string>;
-  request?: ProviderRequestTransportOverrides;
+  request?: ModelProviderRequestTransportOverrides;
   provider?: string;
   api?: string;
   capability?: ProviderRequestCapability;

--- a/src/media-understanding/shared.ts
+++ b/src/media-understanding/shared.ts
@@ -17,7 +17,6 @@ import {
   buildProviderRequestDispatcherPolicy,
   resolveProviderRequestPolicyConfig,
   type ModelProviderRequestTransportOverrides,
-  type ProviderRequestTransportOverrides,
   type ResolvedProviderRequestConfig,
 } from "../agents/provider-request-config.js";
 import type { GuardedFetchMode, GuardedFetchResult } from "../infra/net/fetch-guard.js";
@@ -82,6 +81,15 @@ export type ProviderOperationDeadline = {
 
 export type ProviderOperationTimeoutMs = number | (() => number);
 
+type GuardedProviderRequestParams = {
+  pinDns?: boolean;
+  allowPrivateNetwork?: boolean;
+  ssrfPolicy?: SsrFPolicy;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
+  auditContext?: string;
+  mode?: GuardedFetchMode;
+};
+
 export function createProviderOperationDeadline(params: {
   timeoutMs?: number;
   label: string;
@@ -139,38 +147,61 @@ export async function waitProviderOperationPollInterval(params: {
   await new Promise((resolve) => setTimeout(resolve, Math.min(params.pollIntervalMs, remainingMs)));
 }
 
-export async function pollProviderOperationJson<TPayload>(params: {
-  url: string;
-  headers: Headers;
-  deadline: ProviderOperationDeadline;
-  defaultTimeoutMs: number;
-  fetchFn: typeof fetch;
-  maxAttempts: number;
-  pollIntervalMs: number;
-  requestFailedMessage: string;
-  timeoutMessage: string;
-  isComplete: (payload: TPayload) => boolean;
-  getFailureMessage?: (payload: TPayload) => string | undefined;
-}): Promise<TPayload> {
+export async function pollProviderOperationJson<TPayload>(
+  params: {
+    url: string;
+    headers: Headers;
+    deadline: ProviderOperationDeadline;
+    defaultTimeoutMs: number;
+    fetchFn: typeof fetch;
+    maxAttempts: number;
+    pollIntervalMs: number;
+    requestFailedMessage: string;
+    timeoutMessage: string;
+    isComplete: (payload: TPayload) => boolean;
+    getFailureMessage?: (payload: TPayload) => string | undefined;
+  } & GuardedProviderRequestParams,
+): Promise<TPayload> {
   for (let attempt = 0; attempt < params.maxAttempts; attempt += 1) {
-    const response = await fetchProviderOperationResponse({
-      stage: "poll",
-      url: params.url,
-      init: {
-        method: "GET",
-        headers: params.headers,
-      },
-      timeoutMs: createProviderOperationTimeoutResolver({
-        deadline: params.deadline,
-        defaultTimeoutMs: params.defaultTimeoutMs,
-      }),
-      fetchFn: params.fetchFn,
-      requestFailedMessage: params.requestFailedMessage,
+    const init = {
+      method: "GET",
+      headers: params.headers,
+    };
+    const timeoutMs = createProviderOperationTimeoutResolver({
+      deadline: params.deadline,
+      defaultTimeoutMs: params.defaultTimeoutMs,
     });
-    const payload = (await readProviderJsonObjectResponse(
-      response,
-      params.requestFailedMessage,
-    )) as TPayload;
+    const guardedOptions = resolveGuardedRequestOptions(params);
+    const payload = guardedOptions
+      ? await (async () => {
+          const result = await fetchWithTimeoutGuarded(
+            params.url,
+            init,
+            timeoutMs(),
+            params.fetchFn,
+            guardedOptions,
+          );
+          try {
+            await assertOkOrThrowHttpError(result.response, params.requestFailedMessage);
+            return (await readProviderJsonObjectResponse(
+              result.response,
+              params.requestFailedMessage,
+            )) as TPayload;
+          } finally {
+            await result.release();
+          }
+        })()
+      : ((await readProviderJsonObjectResponse(
+          await fetchProviderOperationResponse({
+            stage: "poll",
+            url: params.url,
+            init,
+            timeoutMs,
+            fetchFn: params.fetchFn,
+            requestFailedMessage: params.requestFailedMessage,
+          }),
+          params.requestFailedMessage,
+        )) as TPayload);
     if (params.isComplete(payload)) {
       return payload;
     }
@@ -404,9 +435,9 @@ export async function fetchWithTimeoutGuarded(
   });
 }
 
-type GuardedPostRequestOptions = NonNullable<Parameters<typeof fetchWithTimeoutGuarded>[4]>;
+type GuardedProviderRequestOptions = NonNullable<Parameters<typeof fetchWithTimeoutGuarded>[4]>;
 
-function mergeGuardedPostSsrfPolicy(params: {
+function mergeGuardedRequestSsrfPolicy(params: {
   ssrfPolicy?: SsrFPolicy;
   allowPrivateNetwork?: boolean;
 }): SsrFPolicy | undefined {
@@ -419,14 +450,9 @@ function mergeGuardedPostSsrfPolicy(params: {
   return { ...params.ssrfPolicy, allowPrivateNetwork: true };
 }
 
-function resolveGuardedPostRequestOptions(params: {
-  pinDns?: boolean;
-  allowPrivateNetwork?: boolean;
-  ssrfPolicy?: SsrFPolicy;
-  dispatcherPolicy?: PinnedDispatcherPolicy;
-  auditContext?: string;
-  mode?: GuardedFetchMode;
-}): GuardedPostRequestOptions | undefined {
+function resolveGuardedRequestOptions(
+  params: GuardedProviderRequestParams,
+): GuardedProviderRequestOptions | undefined {
   if (
     !params.allowPrivateNetwork &&
     !params.ssrfPolicy &&
@@ -437,7 +463,7 @@ function resolveGuardedPostRequestOptions(params: {
   ) {
     return undefined;
   }
-  const ssrfPolicy = mergeGuardedPostSsrfPolicy(params);
+  const ssrfPolicy = mergeGuardedRequestSsrfPolicy(params);
   return {
     ...(ssrfPolicy ? { ssrfPolicy } : {}),
     ...(params.pinDns !== undefined ? { pinDns: params.pinDns } : {}),
@@ -485,7 +511,7 @@ export async function postTranscriptionRequest(
     },
     timeoutMs: params.timeoutMs,
     fetchFn: params.fetchFn,
-    guardedOptions: resolveGuardedPostRequestOptions(params),
+    guardedOptions: resolveGuardedRequestOptions(params),
     retryStage: params.retryStage,
     retry: params.retry,
   });
@@ -496,7 +522,7 @@ async function postGuardedRequest(params: {
   init: RequestInit;
   timeoutMs?: number;
   fetchFn: typeof fetch;
-  guardedOptions?: GuardedPostRequestOptions;
+  guardedOptions?: GuardedProviderRequestOptions;
   retryStage?: ProviderOperationRetryStage;
   retry?: TransientProviderRetryConfig;
 }) {
@@ -563,7 +589,7 @@ export async function postJsonRequest(
     },
     timeoutMs: params.timeoutMs,
     fetchFn: params.fetchFn,
-    guardedOptions: resolveGuardedPostRequestOptions(params),
+    guardedOptions: resolveGuardedRequestOptions(params),
     retryStage: params.retryStage,
     retry: params.retry,
   });
@@ -598,7 +624,7 @@ export async function postMultipartRequest(
     },
     timeoutMs: params.timeoutMs,
     fetchFn: params.fetchFn,
-    guardedOptions: resolveGuardedPostRequestOptions(params),
+    guardedOptions: resolveGuardedRequestOptions(params),
     retryStage: params.retryStage,
     retry: params.retry,
   });

--- a/src/plugin-sdk/test-helpers/provider-http-mocks.ts
+++ b/src/plugin-sdk/test-helpers/provider-http-mocks.ts
@@ -2,6 +2,7 @@ import { afterEach, vi, type Mock } from "vitest";
 import type {
   fetchProviderDownloadResponse,
   fetchProviderOperationResponse,
+  fetchWithTimeoutGuarded,
   pollProviderOperationJson,
   postMultipartRequest,
   resolveProviderHttpRequestConfig,
@@ -13,6 +14,7 @@ type ResolveProviderHttpRequestConfigParams = Parameters<
 >[0];
 type PollProviderOperationJsonParams = Parameters<typeof pollProviderOperationJson>[0];
 type PostMultipartRequestParams = Parameters<typeof postMultipartRequest>[0];
+type FetchWithTimeoutGuardedParams = Parameters<typeof fetchWithTimeoutGuarded>;
 type FetchProviderOperationResponseParams = Parameters<typeof fetchProviderOperationResponse>[0];
 type FetchProviderDownloadResponseParams = Parameters<typeof fetchProviderDownloadResponse>[0];
 type SanitizeConfiguredModelProviderRequestParams = Parameters<
@@ -33,6 +35,7 @@ interface ProviderHttpMocks {
   postJsonRequestMock: AnyMock;
   postMultipartRequestMock: AnyMock;
   fetchWithTimeoutMock: AnyMock;
+  fetchWithTimeoutGuardedMock: AnyMock;
   pollProviderOperationJsonMock: AnyMock;
   assertOkOrThrowHttpErrorMock: Mock<(response: Response, label: string) => Promise<void>>;
   assertOkOrThrowProviderErrorMock: Mock<(response: Response, label: string) => Promise<void>>;
@@ -51,6 +54,7 @@ const providerHttpMocks = vi.hoisted(() => ({
   postJsonRequestMock: vi.fn(),
   postMultipartRequestMock: vi.fn(),
   fetchWithTimeoutMock: vi.fn(),
+  fetchWithTimeoutGuardedMock: vi.fn(),
   fetchProviderOperationResponseMock: vi.fn(),
   fetchProviderDownloadResponseMock: vi.fn(),
   pollProviderOperationJsonMock: vi.fn(),
@@ -67,6 +71,23 @@ const providerHttpMocks = vi.hoisted(() => ({
     dispatcherPolicy: undefined,
   })),
 }));
+
+providerHttpMocks.fetchWithTimeoutGuardedMock.mockImplementation(
+  async (...args: FetchWithTimeoutGuardedParams) => {
+    const [url, init, timeoutMs, fetchFn] = args;
+    const response = await providerHttpMocks.fetchWithTimeoutMock(
+      url,
+      init ?? {},
+      timeoutMs ?? 60_000,
+      fetchFn,
+    );
+    return {
+      response,
+      finalUrl: url,
+      release: async () => {},
+    };
+  },
+);
 
 providerHttpMocks.postMultipartRequestMock.mockImplementation(
   async (params: PostMultipartRequestParams) => {
@@ -173,6 +194,7 @@ vi.mock("openclaw/plugin-sdk/provider-http", () => ({
   fetchProviderDownloadResponse: providerHttpMocks.fetchProviderDownloadResponseMock,
   fetchProviderOperationResponse: providerHttpMocks.fetchProviderOperationResponseMock,
   fetchWithTimeout: providerHttpMocks.fetchWithTimeoutMock,
+  fetchWithTimeoutGuarded: providerHttpMocks.fetchWithTimeoutGuardedMock,
   pollProviderOperationJson: providerHttpMocks.pollProviderOperationJsonMock,
   postJsonRequest: providerHttpMocks.postJsonRequestMock,
   postMultipartRequest: providerHttpMocks.postMultipartRequestMock,
@@ -195,6 +217,7 @@ export function installProviderHttpMockCleanup(): void {
     providerHttpMocks.postJsonRequestMock.mockReset();
     providerHttpMocks.postMultipartRequestMock.mockClear();
     providerHttpMocks.fetchWithTimeoutMock.mockReset();
+    providerHttpMocks.fetchWithTimeoutGuardedMock.mockClear();
     providerHttpMocks.fetchProviderOperationResponseMock.mockClear();
     providerHttpMocks.fetchProviderDownloadResponseMock.mockClear();
     providerHttpMocks.pollProviderOperationJsonMock.mockClear();

--- a/src/plugin-sdk/test-helpers/provider-http-mocks.ts
+++ b/src/plugin-sdk/test-helpers/provider-http-mocks.ts
@@ -32,6 +32,7 @@ type AnyMock = Mock<(...args: unknown[]) => unknown>;
 
 interface ProviderHttpMocks {
   resolveApiKeyForProviderMock: Mock<() => Promise<{ apiKey: string }>>;
+  executeProviderOperationWithRetryMock: AnyMock;
   postJsonRequestMock: AnyMock;
   postMultipartRequestMock: AnyMock;
   fetchWithTimeoutMock: AnyMock;
@@ -51,6 +52,7 @@ interface ProviderHttpMocks {
 
 const providerHttpMocks = vi.hoisted(() => ({
   resolveApiKeyForProviderMock: vi.fn(async () => ({ apiKey: "provider-key" })),
+  executeProviderOperationWithRetryMock: vi.fn(),
   postJsonRequestMock: vi.fn(),
   postMultipartRequestMock: vi.fn(),
   fetchWithTimeoutMock: vi.fn(),
@@ -71,6 +73,36 @@ const providerHttpMocks = vi.hoisted(() => ({
     dispatcherPolicy: undefined,
   })),
 }));
+
+providerHttpMocks.executeProviderOperationWithRetryMock.mockImplementation(
+  async (params: {
+    stage?: string;
+    retry?: boolean | { attempts?: number; sleep?: (ms: number) => Promise<void> };
+    operation: () => Promise<unknown>;
+  }) => {
+    const attempts =
+      typeof params.retry === "object"
+        ? Math.max(1, Math.round(params.retry.attempts ?? 1))
+        : params.retry === false || params.stage === "create"
+          ? 1
+          : 2;
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+      try {
+        return await params.operation();
+      } catch (error) {
+        lastError = error;
+        if (attempt >= attempts) {
+          throw error;
+        }
+        if (typeof params.retry === "object") {
+          await params.retry.sleep?.(0);
+        }
+      }
+    }
+    throw lastError;
+  },
+);
 
 providerHttpMocks.fetchWithTimeoutGuardedMock.mockImplementation(
   async (...args: FetchWithTimeoutGuardedParams) => {
@@ -189,8 +221,7 @@ vi.mock("openclaw/plugin-sdk/provider-http", () => ({
     ({ defaultTimeoutMs }: { defaultTimeoutMs: number }) =>
     () =>
       defaultTimeoutMs,
-  executeProviderOperationWithRetry: async ({ operation }: { operation: () => Promise<unknown> }) =>
-    await operation(),
+  executeProviderOperationWithRetry: providerHttpMocks.executeProviderOperationWithRetryMock,
   fetchProviderDownloadResponse: providerHttpMocks.fetchProviderDownloadResponseMock,
   fetchProviderOperationResponse: providerHttpMocks.fetchProviderOperationResponseMock,
   fetchWithTimeout: providerHttpMocks.fetchWithTimeoutMock,
@@ -214,6 +245,7 @@ export function getProviderHttpMocks(): ProviderHttpMocks {
 export function installProviderHttpMockCleanup(): void {
   afterEach(() => {
     providerHttpMocks.resolveApiKeyForProviderMock.mockClear();
+    providerHttpMocks.executeProviderOperationWithRetryMock.mockClear();
     providerHttpMocks.postJsonRequestMock.mockReset();
     providerHttpMocks.postMultipartRequestMock.mockClear();
     providerHttpMocks.fetchWithTimeoutMock.mockReset();

--- a/src/plugin-sdk/test-helpers/provider-http-mocks.ts
+++ b/src/plugin-sdk/test-helpers/provider-http-mocks.ts
@@ -3,6 +3,7 @@ import type {
   fetchProviderDownloadResponse,
   fetchProviderOperationResponse,
   pollProviderOperationJson,
+  postMultipartRequest,
   resolveProviderHttpRequestConfig,
   sanitizeConfiguredModelProviderRequest,
 } from "../provider-http.js";
@@ -11,6 +12,7 @@ type ResolveProviderHttpRequestConfigParams = Parameters<
   typeof resolveProviderHttpRequestConfig
 >[0];
 type PollProviderOperationJsonParams = Parameters<typeof pollProviderOperationJson>[0];
+type PostMultipartRequestParams = Parameters<typeof postMultipartRequest>[0];
 type FetchProviderOperationResponseParams = Parameters<typeof fetchProviderOperationResponse>[0];
 type FetchProviderDownloadResponseParams = Parameters<typeof fetchProviderDownloadResponse>[0];
 type SanitizeConfiguredModelProviderRequestParams = Parameters<
@@ -29,6 +31,7 @@ type AnyMock = Mock<(...args: unknown[]) => unknown>;
 interface ProviderHttpMocks {
   resolveApiKeyForProviderMock: Mock<() => Promise<{ apiKey: string }>>;
   postJsonRequestMock: AnyMock;
+  postMultipartRequestMock: AnyMock;
   fetchWithTimeoutMock: AnyMock;
   pollProviderOperationJsonMock: AnyMock;
   assertOkOrThrowHttpErrorMock: Mock<(response: Response, label: string) => Promise<void>>;
@@ -46,6 +49,7 @@ interface ProviderHttpMocks {
 const providerHttpMocks = vi.hoisted(() => ({
   resolveApiKeyForProviderMock: vi.fn(async () => ({ apiKey: "provider-key" })),
   postJsonRequestMock: vi.fn(),
+  postMultipartRequestMock: vi.fn(),
   fetchWithTimeoutMock: vi.fn(),
   fetchProviderOperationResponseMock: vi.fn(),
   fetchProviderDownloadResponseMock: vi.fn(),
@@ -57,11 +61,31 @@ const providerHttpMocks = vi.hoisted(() => ({
   ),
   resolveProviderHttpRequestConfigMock: vi.fn((params: ResolveProviderHttpRequestConfigParams) => ({
     baseUrl: params.baseUrl ?? params.defaultBaseUrl,
-    allowPrivateNetwork: params.allowPrivateNetwork === true,
+    allowPrivateNetwork:
+      (params.allowPrivateNetwork ?? params.request?.allowPrivateNetwork) === true,
     headers: new Headers(params.defaultHeaders),
     dispatcherPolicy: undefined,
   })),
 }));
+
+providerHttpMocks.postMultipartRequestMock.mockImplementation(
+  async (params: PostMultipartRequestParams) => {
+    const response = await providerHttpMocks.fetchWithTimeoutMock(
+      params.url,
+      {
+        method: "POST",
+        headers: params.headers,
+        body: params.body,
+      },
+      params.timeoutMs ?? 60_000,
+      params.fetchFn,
+    );
+    return {
+      response,
+      release: async () => {},
+    };
+  },
+);
 
 function resolveMockProviderTimeoutMs(
   timeoutMs: FetchProviderOperationResponseParams["timeoutMs"],
@@ -151,6 +175,7 @@ vi.mock("openclaw/plugin-sdk/provider-http", () => ({
   fetchWithTimeout: providerHttpMocks.fetchWithTimeoutMock,
   pollProviderOperationJson: providerHttpMocks.pollProviderOperationJsonMock,
   postJsonRequest: providerHttpMocks.postJsonRequestMock,
+  postMultipartRequest: providerHttpMocks.postMultipartRequestMock,
   providerOperationRetryConfig: (_stage: string) => true,
   resolveProviderOperationTimeoutMs: ({ defaultTimeoutMs }: { defaultTimeoutMs: number }) =>
     defaultTimeoutMs,
@@ -168,6 +193,7 @@ export function installProviderHttpMockCleanup(): void {
   afterEach(() => {
     providerHttpMocks.resolveApiKeyForProviderMock.mockClear();
     providerHttpMocks.postJsonRequestMock.mockReset();
+    providerHttpMocks.postMultipartRequestMock.mockClear();
     providerHttpMocks.fetchWithTimeoutMock.mockReset();
     providerHttpMocks.fetchProviderOperationResponseMock.mockClear();
     providerHttpMocks.fetchProviderDownloadResponseMock.mockClear();


### PR DESCRIPTION
Summary
- Thread the sanitized OpenAI provider request transport override into video create, upload, poll, and download requests.
- Move video multipart upload and operation polling onto the guarded request path so private-network policy is enforced consistently.
- Preserve guarded resource cleanup across successful downloads, HTTP failures, and retry exhaustion.
- Add focused tests for multipart policy, guarded polling retries/cleanup, and guarded download retry/cleanup behavior.

Verification
- `git diff --check origin/main...HEAD`
- `node_modules/.bin/oxfmt --check extensions/openai/video-generation-provider.ts extensions/openai/video-generation-provider.test.ts src/media-understanding/shared.ts src/media-understanding/shared.test.ts src/plugin-sdk/test-helpers/provider-http-mocks.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> clean, no accepted/actionable findings
- Blacksmith Testbox: `tbx_01ks90ezqjazsscrzpqsgmrpjg`, run `https://github.com/openclaw/openclaw/actions/runs/26316922757`

Behavior addressed
OpenAI video generation now applies `models.providers.openai.request.allowPrivateNetwork` consistently to JSON requests, multipart uploads, operation polling, and video download requests.

Real environment tested
Blacksmith Testbox provider `blacksmith-testbox`, lease `tbx_01ks90ezqjazsscrzpqsgmrpjg`, Linux CI checkout.

Exact steps or command run after this patch
`CI=1 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 node scripts/run-vitest.mjs extensions/openai/video-generation-provider.test.ts src/media-understanding/shared.test.ts`

Evidence after fix
The focused Testbox run completed with exit code 0: 2 files passed and 51 tests passed.

Observed result after fix
Guarded request policy is exercised by focused tests for video create/upload/poll/download, and guarded operation results are released on success, retry, and failure paths.

What was not tested
No live OpenAI video generation request was sent; coverage is via provider HTTP mocks and the shared guarded request helper tests.
