### PR TITLE
docs: fix troubleshooting logs link

### DIFF
--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -230,7 +230,7 @@ Related:
 
 - [OpenAI-compatible endpoints](/gateway/configuration-reference#openai-compatible-endpoints)
 - [Provider configuration](/providers)
-- [Logs](/reference/logs)
+- [Logs](/logging)
 
 ## Local OpenAI-compatible backend passes direct probes but agent runs fail
 


### PR DESCRIPTION
## Summary

- Fix the broken troubleshooting related link from `/reference/logs` to the existing `/logging` docs route.
- Keep the visible link label as `Logs` to avoid unnecessary i18n glossary churn.

## Verification

- `pnpm docs:list`
- `node scripts/docs-link-audit.mjs`
- `node scripts/check-docs-i18n-glossary.mjs`
- `node scripts/format-docs.mjs --check`
- `node scripts/check-docs-mdx.mjs docs README.md`
- `pnpm lint:docs`
- `git diff --check origin/main..HEAD`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof

Behavior addressed: The dedicated Docs workflow failed because `docs/gateway/troubleshooting.md:233` linked to `/reference/logs`, which has no route or backing docs file.

Real environment tested: Local clean PR worktree with repo dependencies installed; docs link audit ran against the OpenClaw docs tree.

Exact steps or command run after this patch: `node scripts/docs-link-audit.mjs`

Evidence after fix: `checked_internal_links=4432` and `broken_links=0`

Observed result after fix: The troubleshooting page now links to `/logging`, which resolves to `docs/logging.md`.

What was not tested: The full GitHub Docs workflow was not manually rerun before opening this PR; PR CI should run the workflow path.
