### PR TITLE
feat(ui): add session rename slash command

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -127,6 +127,7 @@ Current source-of-truth:
     - `/new [model]` archives the current session and starts a fresh one; `/reset` wipes the current session in place. They are not aliases.
     - Control UI intercepts typed `/new` to create and switch to a fresh dashboard session, except when `session.dmScope: "main"` is configured and the current parent is the agent's main session; in that case `/new` resets the main session in place. Typed `/reset` still runs the Gateway's in-place reset.
     - `/reset soft [message]` keeps the current transcript, drops reused CLI backend session ids, and reruns startup/system-prompt loading in-place.
+    - `/rename <title>` renames the current session in the Control UI and session store. Alias: `/title`.
     - `/compact [instructions]` compacts the session context. See [Compaction](/concepts/compaction).
     - `/stop` aborts the current run.
     - `/session idle <duration|off>` and `/session max-age <duration|off>` manage thread-binding expiry.

--- a/src/auto-reply/commands-registry.shared.ts
+++ b/src/auto-reply/commands-registry.shared.ts
@@ -727,6 +727,24 @@ export function buildBuiltinChatCommands(
       tier: "essential",
     }),
     defineChatCommand({
+      key: "rename",
+      nativeName: "rename",
+      nativeAliases: ["title"],
+      description: "Rename the current session.",
+      textAliases: ["/rename", "/title"],
+      category: "session",
+      tier: "essential",
+      args: [
+        {
+          name: "title",
+          description: "Session title",
+          type: "string",
+          required: true,
+          captureRemaining: true,
+        },
+      ],
+    }),
+    defineChatCommand({
       key: "compact",
       nativeName: "compact",
       description: "Compact the session context.",

--- a/ui/src/ui/chat/slash-command-executor.node.test.ts
+++ b/ui/src/ui/chat/slash-command-executor.node.test.ts
@@ -321,6 +321,51 @@ describe("executeSlashCommand directives", () => {
     });
   });
 
+  it("renames the current session via sessions.patch", async () => {
+    const request = vi.fn(async (method: string, payload?: unknown) => {
+      if (method === "sessions.patch") {
+        return { ok: true, path: "/tmp/sessions.json", key: "main", entry: payload };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "main",
+      "rename",
+      "Launch notes",
+    );
+
+    expect(result.content).toBe("Session renamed to `Launch notes`.");
+    expect(result.action).toBe("refresh");
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "main",
+      label: "Launch notes",
+    });
+  });
+
+  it("rejects empty and too-long session rename titles before patching", async () => {
+    const request = vi.fn();
+
+    const empty = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "main",
+      "rename",
+      "   ",
+    );
+    const tooLongTitle = "x".repeat(513);
+    const tooLong = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "main",
+      "rename",
+      tooLongTitle,
+    );
+
+    expect(empty.content).toBe("Usage: `/rename <title>`");
+    expect(tooLong.content).toBe("Session title is too long (513/512 characters).");
+    expect(request).not.toHaveBeenCalled();
+  });
+
   it("uses the local model catalog to qualify raw /model overrides when the patch response omits provider", async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {
       if (method === "sessions.patch") {

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -35,6 +35,8 @@ import type {
 import { generateUUID } from "../uuid.ts";
 import { SLASH_COMMANDS } from "./slash-commands.ts";
 
+const SESSION_TITLE_MAX_LENGTH = 512;
+
 export type SlashCommandResult = {
   /** Markdown-formatted result to display in chat. */
   content: string;
@@ -101,6 +103,8 @@ export async function executeSlashCommand(
       return executeHelp();
     case "new":
       return { content: "Starting new session...", action: "new-session" };
+    case "rename":
+      return await executeRename(client, sessionKey, args);
     case "reset":
       return { content: "Resetting session...", action: "reset" };
     case "stop":
@@ -137,6 +141,35 @@ export async function executeSlashCommand(
 }
 
 // ── Command Implementations ──
+
+async function executeRename(
+  client: GatewayBrowserClient,
+  sessionKey: string,
+  args: string,
+): Promise<SlashCommandResult> {
+  const title = args.trim();
+  if (!title) {
+    return { content: "Usage: `/rename <title>`" };
+  }
+  if (title.length > SESSION_TITLE_MAX_LENGTH) {
+    return {
+      content: `Session title is too long (${title.length}/${SESSION_TITLE_MAX_LENGTH} characters).`,
+    };
+  }
+
+  try {
+    await client.request<SessionsPatchResult>("sessions.patch", {
+      key: sessionKey,
+      label: title,
+    });
+    return {
+      content: `Session renamed to \`${title}\`.`,
+      action: "refresh",
+    };
+  } catch (err) {
+    return { content: `Failed to rename session: ${String(err)}` };
+  }
+}
 
 function executeHelp(): SlashCommandResult {
   const lines = ["**Available Commands**\n"];

--- a/ui/src/ui/chat/slash-commands.node.test.ts
+++ b/ui/src/ui/chat/slash-commands.node.test.ts
@@ -134,6 +134,19 @@ describe("parseSlashCommand", () => {
     expectParsedSlash("/focus", { key: "focus", executeLocal: true }, "");
   });
 
+  it("keeps rename/title as local aliases for session titles", () => {
+    const rename = requireCommandByKey("rename");
+    expectRecordFields(rename, "rename command", {
+      name: "rename",
+      aliases: ["title"],
+      args: "<title>",
+      category: "session",
+      executeLocal: true,
+    });
+    expectParsedSlash("/rename sprint planning", { key: "rename" }, "sprint planning");
+    expectParsedSlash("/title:sprint planning", { key: "rename" }, "sprint planning");
+  });
+
   it("refreshes runtime commands from commands.list so docks, plugins, and direct skills appear", async () => {
     const request = async (method: string) => {
       expect(method).toBe("commands.list");

--- a/ui/src/ui/chat/slash-commands.ts
+++ b/ui/src/ui/chat/slash-commands.ts
@@ -61,6 +61,7 @@ const COMMAND_ICON_OVERRIDES: Partial<Record<string, IconName>> = {
   skill: "zap",
   commands: "book",
   new: "plus",
+  rename: "edit",
   reset: "refresh",
   compact: "loader",
   stop: "stop",
@@ -82,6 +83,7 @@ const COMMAND_ICON_OVERRIDES: Partial<Record<string, IconName>> = {
 const LOCAL_COMMANDS = new Set([
   "help",
   "new",
+  "rename",
   "reset",
   "stop",
   "compact",
@@ -138,6 +140,7 @@ const CATEGORY_OVERRIDES: Partial<Record<string, SlashCommandCategory>> = {
   stop: "session",
   reset: "session",
   new: "session",
+  rename: "session",
   compact: "session",
   focus: "session",
   unfocus: "session",


### PR DESCRIPTION
## Summary

- Problem: Control UI slash commands did not expose chat-side session rename commands, even though `sessions.patch` already supports session labels.
- Solution: Add `/rename <title>` with `/title` as an alias and execute it locally through `sessions.patch`.
- What changed: Shared command registry metadata, Control UI local command mapping, executor validation/patching, focused tests, and slash-command docs.
- What did NOT change (scope boundary): No archive/unarchive behavior, no session store semantics, no CHANGELOG update.

## Motivation

- Users can rename a session from other OpenClaw surfaces, but the Control UI chat command menu/executor did not provide a typed `/rename` or `/title` path.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Chat-side session rename commands should update the active session title/label from the Control UI command path.
- Real environment tested: Brandon's local OpenClaw setup on macOS, using a locally patched compiled install before this source-port PR.
- Exact steps or command run after this patch: In the local OpenClaw Control UI chat, typed `/rename <title>` and `/title <title>` against the active session.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Local setup QA confirmed both commands updated the session title through the existing `sessions.patch` path. This PR ports that already-validated behavior into TypeScript source and adds source-level tests. Copied live terminal output from Brandon's local compiled OpenClaw setup also shows the served Control UI bundle exposes `/rename`, `/title`, and calls `sessions.patch` with `label`:

  ```text
  $ openclaw --version
  OpenClaw 2026.5.20 (e510042)

  $ curl -fsS http://127.0.0.1:18789/ | rg -o "assets/index-[^\"]+\.js"
  assets/index-DIlhMoR6-archivefix.js

  $ curl -fsS http://127.0.0.1:18789/assets/index-DIlhMoR6-archivefix.js | strings | rg -o '/rename|/title|request\(`sessions\.patch`,\{key:t,label:r\}\)|Session renamed' | sort -u
  /rename
  /title
  Session renamed
  request(`sessions.patch`,{key:t,label:r})
  ```
- Observed result after fix: The active session displayed the requested title after refresh/list reload.
- What was not tested: A full source-built app smoke against this branch was not run in the live OpenClaw app; validation here used focused tests, typecheck, docs guardrail, and UI build.
- Before evidence (optional but encouraged): Existing local Control UI chat command menu/executor lacked a `/rename` or `/title` session label command; the local fix added that path.

## Root Cause (if applicable)

- Root cause: The shared command registry and Control UI local slash executor had no rename/title command entry even though `sessions.patch` accepts `label`.
- Missing detection / guardrail: No focused UI slash-command test covered session rename commands.
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/ui/chat/slash-commands.node.test.ts`, `ui/src/ui/chat/slash-command-executor.node.test.ts`, `src/docs/slash-commands-doc.test.ts`
- Scenario the test should lock in: `/rename` and `/title` are local aliases, empty/too-long titles are rejected before RPC, valid titles call `sessions.patch` with `label`.
- Why this is the smallest reliable guardrail: The behavior is local command parsing/execution over an existing RPC method.
- Existing test that already covers this (if any): Existing `sessions.patch` tests cover label persistence and validation.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Control UI chat now supports `/rename <title>` and `/title <title>` to rename the current session.

## Diagram (if applicable)

```text
Before:
/user types /rename -> no local command -> unknown/not handled by Control UI

After:
/user types /rename or /title -> local command executor -> sessions.patch { label } -> session list refresh
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: Adds a local UI command that calls the existing `sessions.patch` RPC for the active session key only. Input is trimmed, non-empty, capped at the existing 512-character session label limit, and server-side validation remains authoritative.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node.js v22.22.1 source checkout
- Model/provider: N/A
- Integration/channel (if any): Control UI
- Relevant config (redacted): N/A

### Steps

1. Open Control UI chat.
2. Type `/rename Launch notes` or `/title Launch notes`.
3. Observe active session title after refresh/list reload.

### Expected

- Active session is renamed to the requested title.

### Actual

- Local compiled OpenClaw setup evidence: active session was renamed through `sessions.patch`.
- Source branch validation: focused tests and UI build pass.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run on this branch:

```text
pnpm --dir ui test src/ui/chat/slash-commands.node.test.ts src/ui/chat/slash-command-executor.node.test.ts
PASS: 2 files, 61 tests

pnpm ui:build
PASS: Vite production build completed

pnpm exec oxfmt --check src/auto-reply/commands-registry.shared.ts ui/src/ui/chat/slash-commands.ts ui/src/ui/chat/slash-command-executor.ts ui/src/ui/chat/slash-commands.node.test.ts ui/src/ui/chat/slash-command-executor.node.test.ts
PASS

pnpm tsgo:test:ui
PASS

node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/auto-reply/commands-registry.test.ts src/docs/slash-commands-doc.test.ts
PASS: slash command docs test passed

node scripts/test-projects.mjs src/auto-reply/commands-registry.test.ts
PASS: 28 tests

node scripts/format-docs.mjs --check docs/tools/slash-commands.md
PASS

git diff --check
PASS
```

Note: `pnpm test:unit:fast src/auto-reply/commands-registry.test.ts src/docs/slash-commands-doc.test.ts` returned "No test files found" under that shard config, so I reran those files through the matching unit/test-project lanes listed above.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: command registry exposes `/rename` with `/title` alias; Control UI parses both; valid rename calls `sessions.patch` with `label`; empty and 513-character titles do not call RPC; docs include all built-in aliases.
- Edge cases checked: empty title, over-limit title, colon syntax `/title:...`.
- What you did **not** verify: Full source-built OpenClaw app live smoke with this branch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: The client-side max length could drift from the server label limit.
  - Mitigation: It matches the current `SESSION_LABEL_MAX_LENGTH` of 512, and server-side `sessions.patch` validation remains authoritative.

---

AI-assisted: This PR was prepared with AI assistance and reviewed through focused local validation before submission.



