### PR TITLE
fix(ui): keep chat picker search current

### DIFF
--- a/extensions/openai/video-generation-provider.test.ts
+++ b/extensions/openai/video-generation-provider.test.ts
@@ -365,7 +365,7 @@ describe("openai video generation provider", () => {
       },
     });
 
-    expect(result.videos[0]?.buffer.toString()).toBe("mp4-bytes");
+    expect(result.videos[0]?.buffer?.toString()).toBe("mp4-bytes");
     expect(executeProviderOperationWithRetryMock).toHaveBeenCalledWith(
       expect.objectContaining({ provider: "openai", stage: "download" }),
     );

--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -20,6 +20,10 @@ type SessionListOptions = {
   totalCount: number;
 };
 
+const SESSION_PAGE_SIZE = 50;
+const TOTAL_MOCK_SESSIONS = 650;
+const TOTAL_TELEGRAM_SESSIONS = 180;
+
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const uiRoot = path.join(repoRoot, "ui");
 
@@ -45,7 +49,12 @@ function parsePort(value: string | undefined, fallback: number): number {
   return Number.isInteger(parsed) && parsed > 0 && parsed < 65_536 ? parsed : fallback;
 }
 
-function sessionRow(key: string, label: string, updatedAt: number) {
+function sessionRow(
+  key: string,
+  label: string,
+  updatedAt: number,
+  options: { model?: string; modelProvider?: string } = {},
+) {
   return {
     contextTokens: null,
     displayName: label,
@@ -53,8 +62,8 @@ function sessionRow(key: string, label: string, updatedAt: number) {
     key,
     kind: "direct",
     label,
-    model: "gpt-5.5",
-    modelProvider: "openai",
+    model: options.model ?? "gpt-5.5",
+    modelProvider: options.modelProvider ?? "openai",
     status: "done",
     totalTokens: 0,
     updatedAt,
@@ -80,8 +89,92 @@ function sessionsListResponse(sessions: unknown[], options: SessionListOptions) 
   };
 }
 
+function pagedSessionsListResponse(sessions: unknown[], offset: number) {
+  const normalizedOffset = Math.max(0, Math.floor(offset));
+  const page = sessions.slice(normalizedOffset, normalizedOffset + SESSION_PAGE_SIZE);
+  const nextOffset = normalizedOffset + SESSION_PAGE_SIZE;
+  return sessionsListResponse(page, {
+    hasMore: nextOffset < sessions.length,
+    nextOffset: nextOffset < sessions.length ? nextOffset : null,
+    offset: normalizedOffset,
+    totalCount: sessions.length,
+  });
+}
+
+function buildSessionRows(params: {
+  baseTime: number;
+  count: number;
+  keyPrefix: string;
+  labelPrefix: string;
+  model?: string;
+  modelProvider?: string;
+}) {
+  return Array.from({ length: params.count }, (_value, index) => {
+    const ordinal = index + 1;
+    const padded = String(ordinal).padStart(3, "0");
+    return sessionRow(
+      `agent:${params.keyPrefix}-${padded}`,
+      `${params.labelPrefix} ${padded}`,
+      params.baseTime - ordinal * 60_000,
+      { model: params.model, modelProvider: params.modelProvider },
+    );
+  });
+}
+
+function buildSessionListCases(
+  sessions: unknown[],
+  matchBase: Record<string, unknown> = {},
+): Array<{ match: Record<string, unknown>; response: unknown }> {
+  const cases: Array<{ match: Record<string, unknown>; response: unknown }> = [];
+  for (let offset = SESSION_PAGE_SIZE; offset < sessions.length; offset += SESSION_PAGE_SIZE) {
+    cases.push({
+      match: { ...matchBase, offset },
+      response: pagedSessionsListResponse(sessions, offset),
+    });
+  }
+  cases.push({
+    match: matchBase,
+    response: pagedSessionsListResponse(sessions, 0),
+  });
+  return cases;
+}
+
+function buildSearchSessionListCases(
+  sessions: unknown[],
+  searchTerms: string[],
+): Array<{ match: Record<string, unknown>; response: unknown }> {
+  return searchTerms.flatMap((search) => buildSessionListCases(sessions, { search }));
+}
+
+function searchPrefixes(term: string): string[] {
+  return Array.from({ length: term.length }, (_value, index) => term.slice(0, index + 1));
+}
+
 function createChatPickerScenario(): ControlUiMockGatewayScenario {
   const baseTime = Date.parse("2026-05-22T09:00:00.000Z");
+  const sessions = [
+    sessionRow("agent:alpha", "Alpha planning", baseTime - 1_000),
+    ...buildSessionRows({
+      baseTime: baseTime - 60_000,
+      count: TOTAL_MOCK_SESSIONS - 1,
+      keyPrefix: "history",
+      labelPrefix: "Long running session",
+    }),
+  ];
+  const telegramSessions = buildSessionRows({
+    baseTime: baseTime - 30_000,
+    count: TOTAL_TELEGRAM_SESSIONS,
+    keyPrefix: "telegram",
+    labelPrefix: "Telegram investigation",
+  });
+  const claudeSessions = buildSessionRows({
+    baseTime: baseTime - 45_000,
+    count: 75,
+    keyPrefix: "model-claude",
+    labelPrefix: "Model search result",
+    model: "claude-sonnet-4-6",
+    modelProvider: "anthropic",
+  });
   return {
     assistantAgentId: "openclaw-mock",
     assistantName: "OpenClaw mock",
@@ -90,7 +183,7 @@ function createChatPickerScenario(): ControlUiMockGatewayScenario {
       {
         content: [
           {
-            text: 'Mock Control UI is running. Open the chat picker, search for "telegram", then use Load more.',
+            text: `Mock Control UI is running with ${TOTAL_MOCK_SESSIONS} sessions. Open the chat picker, search for "telegram" or "claude", then use Load more repeatedly.`,
             type: "text",
           },
         ],
@@ -101,40 +194,20 @@ function createChatPickerScenario(): ControlUiMockGatewayScenario {
     methodResponses: {
       "sessions.list": {
         cases: [
-          {
-            match: { offset: 50, search: "telegram" },
-            response: sessionsListResponse(
-              [
-                sessionRow("agent:telegram-51", "Telegram archive page 51", baseTime - 180_000),
-                sessionRow("agent:telegram-52", "Telegram archive page 52", baseTime - 240_000),
-              ],
-              { hasMore: false, nextOffset: null, offset: 50, totalCount: 4 },
-            ),
-          },
-          {
-            match: { search: "telegram" },
-            response: sessionsListResponse(
-              [
-                sessionRow("agent:telegram", "Telegram follow-up", baseTime - 60_000),
-                sessionRow("agent:telegram-mobile", "Telegram mobile handoff", baseTime - 120_000),
-              ],
-              { hasMore: true, nextOffset: 50, totalCount: 4 },
-            ),
-          },
-          {
-            match: {},
-            response: sessionsListResponse(
-              [
-                sessionRow("agent:alpha", "Alpha planning", baseTime - 1_000),
-                sessionRow("agent:design", "Design review", baseTime - 30_000),
-              ],
-              { hasMore: true, nextOffset: 50, totalCount: 125 },
-            ),
-          },
+          ...buildSearchSessionListCases(telegramSessions, searchPrefixes("telegram")),
+          ...buildSearchSessionListCases(claudeSessions, [
+            ...searchPrefixes("claude"),
+            ...searchPrefixes("claude-sonnet-4-6"),
+            ...searchPrefixes("anthropic"),
+          ]),
+          ...buildSessionListCases(sessions),
         ],
       },
     },
-    models: [{ id: "gpt-5.5", name: "gpt-5.5", provider: "openai" }],
+    models: [
+      { id: "gpt-5.5", name: "gpt-5.5", provider: "openai" },
+      { id: "claude-sonnet-4-6", name: "claude-sonnet-4-6", provider: "anthropic" },
+    ],
     sessionKey: "agent:alpha",
   };
 }

--- a/src/gateway/session-utils.search.test.ts
+++ b/src/gateway/session-utils.search.test.ts
@@ -189,6 +189,54 @@ describe("listSessionsFromStore search", () => {
     }
   });
 
+  test("filters sessions by the displayed provider and model identity", () => {
+    const now = Date.now();
+    const cfg = createModelDefaultsConfig({
+      primary: "anthropic/claude-sonnet-4-6",
+    });
+    const store: Record<string, SessionEntry> = {
+      "agent:main:inherited-default": {
+        sessionId: "sess-inherited-default",
+        updatedAt: now,
+        label: "Inherited default",
+      } as SessionEntry,
+      "agent:main:override": {
+        sessionId: "sess-override",
+        updatedAt: now - 1_000,
+        label: "Override",
+        providerOverride: "openai",
+        modelOverride: "gpt-5.5",
+      } as SessionEntry,
+      "agent:main:runtime": {
+        sessionId: "sess-runtime",
+        updatedAt: now - 2_000,
+        label: "Runtime",
+        modelProvider: "google",
+        model: "gemini-3.1-pro-preview",
+      } as SessionEntry,
+    };
+    const cases = [
+      { search: "anthropic", expectedKey: "agent:main:inherited-default" },
+      { search: "claude-sonnet", expectedKey: "agent:main:inherited-default" },
+      { search: "anthropic/claude-sonnet", expectedKey: "agent:main:inherited-default" },
+      { search: "openai/gpt-5.5", expectedKey: "agent:main:override" },
+      { search: "gemini-3.1", expectedKey: "agent:main:runtime" },
+      { search: "google/gemini", expectedKey: "agent:main:runtime" },
+    ] as const;
+
+    for (const testCase of cases) {
+      const result = listSessionsFromStore({
+        cfg,
+        storePath: "/tmp/sessions.json",
+        store,
+        opts: { search: testCase.search },
+      });
+
+      expect(result.sessions.map((session) => session.key)).toEqual([testCase.expectedKey]);
+      expect(result.totalCount).toBe(1);
+    }
+  });
+
   test("hides cron run alias session keys from sessions list", () => {
     const now = Date.now();
     const store: Record<string, SessionEntry> = {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1977,6 +1977,69 @@ function resolveSessionListSearchDisplayName(
   });
 }
 
+function addSessionListSearchModelFields(
+  fields: Array<string | undefined>,
+  identity: { provider?: string; model?: string },
+) {
+  const provider = normalizeOptionalString(identity.provider);
+  const model = normalizeOptionalString(identity.model);
+  fields.push(provider, model);
+  if (provider && model) {
+    fields.push(`${provider}/${model}`);
+  }
+}
+
+function resolveSessionListSearchModelFields(params: {
+  cfg: OpenClawConfig;
+  key: string;
+  entry?: SessionEntry;
+  rowContext?: SessionListRowContext;
+}): Array<string | undefined> {
+  const parsedAgent = parseAgentSessionKey(params.key);
+  const agentId = normalizeAgentId(parsedAgent?.agentId ?? resolveDefaultAgentId(params.cfg));
+  const subagentRun = params.rowContext
+    ? params.rowContext.subagentRuns.getDisplaySubagentRun(params.key)
+    : getSessionDisplaySubagentRunByChildSessionKey(params.key);
+  const selectedModel = resolveSessionSelectedModelRef({
+    cfg: params.cfg,
+    entry: params.entry,
+    agentId,
+    rowContext: params.rowContext,
+    allowPluginNormalization: false,
+  });
+  const resolvedModel = resolveSessionModelIdentityRef(
+    params.cfg,
+    params.entry,
+    agentId,
+    subagentRun?.model,
+    { allowPluginNormalization: false },
+  );
+  const modelIdentity = {
+    provider: resolvedModel.provider,
+    model: resolvedModel.model ?? DEFAULT_MODEL,
+  };
+  const selectedOrRuntimeModelProvider = selectedModel?.provider ?? modelIdentity.provider;
+  const selectedOrRuntimeModel = selectedModel?.model ?? modelIdentity.model;
+  const displayModelIdentity = resolveSessionDisplayModelIdentityRefCached({
+    cfg: params.cfg,
+    agentId,
+    provider: selectedOrRuntimeModelProvider,
+    model: selectedOrRuntimeModel,
+    rowContext: params.rowContext,
+  });
+  const fields: Array<string | undefined> = [];
+  addSessionListSearchModelFields(fields, {
+    provider: params.entry?.modelProvider,
+    model: params.entry?.model,
+  });
+  addSessionListSearchModelFields(fields, resolvedModel);
+  if (selectedModel) {
+    addSessionListSearchModelFields(fields, selectedModel);
+  }
+  addSessionListSearchModelFields(fields, displayModelIdentity);
+  return fields;
+}
+
 export function loadGatewaySessionRow(
   sessionKey: string,
   options?: {
@@ -2084,12 +2147,13 @@ function sortAndLimitSessionEntries(
 }
 
 function filterSessionEntries(params: {
+  cfg: OpenClawConfig;
   store: Record<string, SessionEntry>;
   opts: import("./protocol/index.js").SessionsListParams;
   now: number;
   rowContext?: SessionListRowContext;
 }): SessionEntryPair[] {
-  const { store, opts, now } = params;
+  const { cfg, store, opts, now } = params;
   const rowContext = params.rowContext;
   const includeGlobal = opts.includeGlobal === true;
   const includeUnknown = opts.includeUnknown === true;
@@ -2169,6 +2233,12 @@ function filterSessionEntries(params: {
         entry?.subject,
         entry?.sessionId,
         key,
+        ...resolveSessionListSearchModelFields({
+          cfg,
+          key,
+          entry,
+          rowContext,
+        }),
       ];
       return fields.some(
         (f) => typeof f === "string" && normalizeLowercaseStringOrEmpty(f).includes(search),
@@ -2185,6 +2255,7 @@ function filterSessionEntries(params: {
 }
 
 function selectSessionEntries(params: {
+  cfg: OpenClawConfig;
   store: Record<string, SessionEntry>;
   opts: import("./protocol/index.js").SessionsListParams;
   now: number;
@@ -2211,6 +2282,7 @@ function selectSessionEntries(params: {
 }
 
 export function filterAndSortSessionEntries(params: {
+  cfg: OpenClawConfig;
   store: Record<string, SessionEntry>;
   opts: import("./protocol/index.js").SessionsListParams;
   now: number;
@@ -2240,10 +2312,14 @@ export function listSessionsFromStore(params: {
   const hasSpawnedByFilter = typeof opts.spawnedBy === "string" && opts.spawnedBy.length > 0;
 
   const selection = selectSessionEntries({
+    cfg,
     store,
     opts,
     now,
-    rowContext: hasSpawnedByFilter ? getRowContext() : undefined,
+    rowContext:
+      hasSpawnedByFilter || Boolean(normalizeOptionalString(opts.search))
+        ? getRowContext()
+        : undefined,
     defaultLimit: SESSIONS_LIST_DEFAULT_LIMIT,
   });
   const { entries, totalCount, limitApplied, offset, nextOffset, hasMore } = selection;
@@ -2311,10 +2387,14 @@ export async function listSessionsFromStoreAsync(params: {
   const hasSpawnedByFilter = typeof opts.spawnedBy === "string" && opts.spawnedBy.length > 0;
 
   const selection = selectSessionEntries({
+    cfg,
     store,
     opts,
     now,
-    rowContext: hasSpawnedByFilter ? getRowContext() : undefined,
+    rowContext:
+      hasSpawnedByFilter || Boolean(normalizeOptionalString(opts.search))
+        ? getRowContext()
+        : undefined,
     defaultLimit: SESSIONS_LIST_DEFAULT_LIMIT,
   });
   const { entries, totalCount, limitApplied, offset, nextOffset, hasMore } = selection;

--- a/src/gateway/sessions-resolve.ts
+++ b/src/gateway/sessions-resolve.ts
@@ -65,6 +65,7 @@ function isResolvedSessionKeyVisible(params: {
     return true;
   }
   return filterAndSortSessionEntries({
+    cfg: params.cfg,
     store: params.store,
     now: Date.now(),
     opts: resolveSessionVisibilityFilterOptions(params.p),
@@ -72,12 +73,14 @@ function isResolvedSessionKeyVisible(params: {
 }
 
 function findVisibleSessionIdMatches(params: {
+  cfg: OpenClawConfig;
   store: Record<string, SessionEntry>;
   p: SessionsResolveParams;
   sessionId: string;
 }): Array<[string, SessionEntry]> {
   const now = Date.now();
   const entries = filterAndSortSessionEntries({
+    cfg: params.cfg,
     store: params.store,
     now,
     opts: resolveSessionVisibilityFilterOptions(params.p),
@@ -166,7 +169,7 @@ export async function resolveSessionKeyFromResolveParams(params: {
 
   if (hasSessionId) {
     const { store } = loadCombinedSessionStoreForGateway(cfg, { agentId: p.agentId });
-    const matches = findVisibleSessionIdMatches({ store, p, sessionId });
+    const matches = findVisibleSessionIdMatches({ cfg, store, p, sessionId });
     const selection = resolveSessionIdMatchSelection(matches, sessionId);
     if (selection.kind === "none") {
       return {

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -38,6 +38,18 @@ import type { GatewayThinkingLevelOption, SessionsListResult } from "../types.ts
 
 type ChatSessionSwitchHandler = (state: AppViewState, nextSessionKey: string) => void;
 type ChatSessionSelectSurface = "desktop" | "mobile";
+type ChatSessionPickerSearchController = {
+  activeRequestId: number | null;
+  activeRequestSignature: string | null;
+  nextRequestId: number;
+  timer: ReturnType<typeof globalThis.setTimeout> | null;
+};
+
+const CHAT_SESSION_PICKER_SEARCH_DEBOUNCE_MS = 300;
+const chatSessionPickerSearchControllers = new WeakMap<
+  AppViewState,
+  ChatSessionPickerSearchController
+>();
 
 export function renderChatSessionSelect(
   state: AppViewState,
@@ -104,6 +116,78 @@ function requestHostUpdate(state: AppViewState) {
   (state as AppViewState & { requestUpdate?: () => void }).requestUpdate?.();
 }
 
+function getChatSessionPickerSearchController(
+  state: AppViewState,
+): ChatSessionPickerSearchController {
+  let controller = chatSessionPickerSearchControllers.get(state);
+  if (!controller) {
+    controller = {
+      activeRequestId: null,
+      activeRequestSignature: null,
+      nextRequestId: 0,
+      timer: null,
+    };
+    chatSessionPickerSearchControllers.set(state, controller);
+  }
+  return controller;
+}
+
+function clearChatSessionPickerSearchTimer(state: AppViewState) {
+  const controller = getChatSessionPickerSearchController(state);
+  if (controller.timer) {
+    globalThis.clearTimeout(controller.timer);
+    controller.timer = null;
+  }
+}
+
+function invalidateChatSessionPickerSearchRequests(state: AppViewState) {
+  const controller = getChatSessionPickerSearchController(state);
+  controller.nextRequestId += 1;
+  controller.activeRequestId = null;
+  controller.activeRequestSignature = null;
+}
+
+function beginChatSessionPickerSearchRequest(
+  state: AppViewState,
+  signature: string,
+): number | null {
+  const controller = getChatSessionPickerSearchController(state);
+  if (controller.activeRequestSignature === signature) {
+    return null;
+  }
+  controller.nextRequestId += 1;
+  controller.activeRequestId = controller.nextRequestId;
+  controller.activeRequestSignature = signature;
+  return controller.activeRequestId;
+}
+
+function isCurrentChatSessionPickerSearchRequest(state: AppViewState, requestId: number): boolean {
+  return getChatSessionPickerSearchController(state).activeRequestId === requestId;
+}
+
+function finishChatSessionPickerSearchRequest(state: AppViewState, requestId: number) {
+  if (!isCurrentChatSessionPickerSearchRequest(state, requestId)) {
+    return;
+  }
+  const controller = getChatSessionPickerSearchController(state);
+  controller.activeRequestId = null;
+  controller.activeRequestSignature = null;
+}
+
+function createChatSessionPickerRequestSignature(options: {
+  append?: boolean;
+  offset?: number;
+  query: string;
+}) {
+  return [
+    options.query,
+    typeof options.offset === "number" && Number.isFinite(options.offset)
+      ? Math.max(0, Math.floor(options.offset))
+      : 0,
+    options.append === true ? "append" : "replace",
+  ].join("\n");
+}
+
 function focusChatSessionPickerSearch(state: AppViewState) {
   const updateComplete = (state as AppViewState & { updateComplete?: Promise<unknown> })
     .updateComplete;
@@ -126,6 +210,7 @@ function openChatSessionPicker(state: AppViewState, surface: ChatSessionSelectSu
 }
 
 function closeChatSessionPicker(state: AppViewState) {
+  clearChatSessionPickerSearchTimer(state);
   state.chatSessionPickerOpen = false;
   state.chatSessionPickerSurface = null;
   requestHostUpdate(state);
@@ -211,6 +296,17 @@ async function loadChatSessionPickerPage(
     return;
   }
   const query = normalizeOptionalString(options.query ?? state.chatSessionPickerAppliedQuery) ?? "";
+  const requestId = beginChatSessionPickerSearchRequest(
+    state,
+    createChatSessionPickerRequestSignature({
+      append: options.append,
+      offset: options.offset,
+      query,
+    }),
+  );
+  if (requestId === null) {
+    return;
+  }
   state.chatSessionPickerLoading = true;
   state.chatSessionPickerError = null;
   requestHostUpdate(state);
@@ -222,19 +318,29 @@ async function loadChatSessionPickerPage(
         createChatSessionPickerRequestParams(state, { query, offset: options.offset }),
       ),
     );
+    if (!isCurrentChatSessionPickerSearchRequest(state, requestId)) {
+      return;
+    }
     const previous = state.chatSessionPickerResult ?? state.sessionsResult;
     state.chatSessionPickerResult =
       options.append === true && previous ? appendChatSessionPickerResult(previous, page) : page;
     state.chatSessionPickerAppliedQuery = query;
   } catch (err) {
+    if (!isCurrentChatSessionPickerSearchRequest(state, requestId)) {
+      return;
+    }
     state.chatSessionPickerError = String(err);
   } finally {
-    state.chatSessionPickerLoading = false;
-    requestHostUpdate(state);
+    if (isCurrentChatSessionPickerSearchRequest(state, requestId)) {
+      finishChatSessionPickerSearchRequest(state, requestId);
+      state.chatSessionPickerLoading = false;
+      requestHostUpdate(state);
+    }
   }
 }
 
 async function applyChatSessionPickerSearch(state: AppViewState) {
+  clearChatSessionPickerSearchTimer(state);
   const query = normalizeOptionalString(state.chatSessionPickerQuery) ?? "";
   if (!query) {
     clearChatSessionPickerSearch(state);
@@ -243,26 +349,44 @@ async function applyChatSessionPickerSearch(state: AppViewState) {
   await loadChatSessionPickerPage(state, { query });
 }
 
-function clearChatSessionPickerSearch(state: AppViewState) {
+function clearChatSessionPickerSearch(state: AppViewState, options: { focus?: boolean } = {}) {
+  clearChatSessionPickerSearchTimer(state);
+  invalidateChatSessionPickerSearchRequests(state);
   state.chatSessionPickerQuery = "";
   state.chatSessionPickerAppliedQuery = "";
   state.chatSessionPickerError = null;
   state.chatSessionPickerResult = null;
+  state.chatSessionPickerLoading = false;
   requestHostUpdate(state);
-  focusChatSessionPickerSearch(state);
+  if (options.focus ?? true) {
+    focusChatSessionPickerSearch(state);
+  }
+}
+
+function scheduleChatSessionPickerSearch(state: AppViewState) {
+  clearChatSessionPickerSearchTimer(state);
+  const controller = getChatSessionPickerSearchController(state);
+  controller.timer = globalThis.setTimeout(() => {
+    controller.timer = null;
+    void applyChatSessionPickerSearch(state);
+  }, CHAT_SESSION_PICKER_SEARCH_DEBOUNCE_MS);
 }
 
 function updateChatSessionPickerSearchQuery(state: AppViewState, nextQuery: string) {
   state.chatSessionPickerQuery = nextQuery;
-  if (normalizeOptionalString(nextQuery)) {
+  const query = normalizeOptionalString(nextQuery) ?? "";
+  if (!query) {
+    clearChatSessionPickerSearch(state, { focus: false });
     return;
   }
-  if (!state.chatSessionPickerAppliedQuery && !state.chatSessionPickerResult) {
-    return;
+  if (query !== state.chatSessionPickerAppliedQuery || !state.chatSessionPickerResult) {
+    invalidateChatSessionPickerSearchRequests(state);
+    state.chatSessionPickerError = null;
+    state.chatSessionPickerLoading = false;
+    scheduleChatSessionPickerSearch(state);
+  } else {
+    clearChatSessionPickerSearchTimer(state);
   }
-  state.chatSessionPickerAppliedQuery = "";
-  state.chatSessionPickerError = null;
-  state.chatSessionPickerResult = null;
   requestHostUpdate(state);
 }
 
@@ -371,7 +495,10 @@ function renderChatSessionPickerPopover(
 ) {
   const result = resolveChatSessionPickerResult(state);
   const rows = result?.sessions ?? [];
-  const disabled = !state.connected || !state.client || state.chatSessionPickerLoading;
+  const controlsDisabled = !state.connected || !state.client;
+  const normalizedQuery = normalizeOptionalString(state.chatSessionPickerQuery) ?? "";
+  const searchPending = normalizedQuery !== state.chatSessionPickerAppliedQuery;
+  const loadMoreDisabled = controlsDisabled || state.chatSessionPickerLoading || searchPending;
   const hasQuery =
     state.chatSessionPickerQuery.trim() !== "" || state.chatSessionPickerAppliedQuery.trim() !== "";
   const loadMoreOffset = resolveNextChatSessionOffset(result);
@@ -404,7 +531,7 @@ function renderChatSessionPickerPopover(
             placeholder=${t("chat.selectors.sessionSearch")}
             aria-label=${t("chat.selectors.sessionSearch")}
             .value=${state.chatSessionPickerQuery}
-            ?disabled=${disabled}
+            ?disabled=${controlsDisabled}
             @input=${(event: Event) => {
               updateChatSessionPickerSearchQuery(state, (event.target as HTMLInputElement).value);
             }}
@@ -414,6 +541,7 @@ function renderChatSessionPickerPopover(
                 void applyChatSessionPickerSearch(state);
               }
             }}
+            @blur=${() => void applyChatSessionPickerSearch(state)}
           />
         </label>
         <button
@@ -422,7 +550,7 @@ function renderChatSessionPickerPopover(
           type="button"
           title=${t("common.search")}
           aria-label=${t("common.search")}
-          ?disabled=${disabled}
+          ?disabled=${controlsDisabled}
           @click=${() => void applyChatSessionPickerSearch(state)}
         >
           ${icons.search}
@@ -434,7 +562,7 @@ function renderChatSessionPickerPopover(
               type="button"
               title=${t("chat.selectors.clearSessionSearch")}
               aria-label=${t("chat.selectors.clearSessionSearch")}
-              ?disabled=${disabled}
+              ?disabled=${controlsDisabled}
               @click=${() => clearChatSessionPickerSearch(state)}
             >
               ${icons.x}
@@ -499,7 +627,7 @@ function renderChatSessionPickerPopover(
               class="btn btn--ghost btn--sm"
               data-chat-session-load-more="true"
               type="button"
-              ?disabled=${disabled}
+              ?disabled=${loadMoreDisabled}
               @click=${() => void loadMoreChatSessionPickerResults(state)}
             >
               ${t("chat.selectors.loadMoreSessions")}

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -346,6 +346,9 @@ async function applyChatSessionPickerSearch(state: AppViewState) {
     clearChatSessionPickerSearch(state);
     return;
   }
+  if (query === state.chatSessionPickerAppliedQuery && state.chatSessionPickerResult) {
+    return;
+  }
   await loadChatSessionPickerPage(state, { query });
 }
 

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -280,7 +280,8 @@ function createChatHeaderState(
       const search = typeof params.search === "string" ? params.search.trim() : "";
       const offset =
         typeof params.offset === "number" && Number.isFinite(params.offset) ? params.offset : 0;
-      if (search === "telegram" && offset === 50) {
+      const matchesTelegramSearch = search !== "" && "telegram".startsWith(search);
+      if (matchesTelegramSearch && offset === 50) {
         return createSessionsResultFromRows(
           [
             {
@@ -299,7 +300,7 @@ function createChatHeaderState(
           { hasMore: false, nextOffset: null, offset: 50, totalCount: 4 },
         );
       }
-      if (search === "telegram") {
+      if (matchesTelegramSearch) {
         return createSessionsResultFromRows(
           [
             { key: "agent:main:telegram-one", kind: "direct", label: "Telegram one", updatedAt: 4 },
@@ -538,6 +539,7 @@ describe("chat compaction divider", () => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   loadSessionsMock.mockClear();
   refreshVisibleToolsEffectiveForCurrentSessionMock.mockClear();
   resetChatViewState();
@@ -1343,6 +1345,69 @@ describe("chat session controls", () => {
     expect(loadSessionsMock).not.toHaveBeenCalled();
   });
 
+  it("debounces chat session picker search while typing", async () => {
+    vi.useFakeTimers();
+    const { state, request } = createChatHeaderState();
+    state.sessionsIncludeGlobal = false;
+    state.sessionsIncludeUnknown = false;
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    container.querySelector<HTMLButtonElement>('button[data-chat-session-select="true"]')!.click();
+    render(renderChatSessionSelect(state), container);
+    const input = container.querySelector<HTMLInputElement>(
+      'input[data-chat-session-picker-search="true"]',
+    );
+
+    input!.value = "tele";
+    input!.dispatchEvent(new Event("input", { bubbles: true }));
+    await vi.advanceTimersByTimeAsync(299);
+
+    expect(state.chatSessionPickerAppliedQuery).toBe("");
+    expect(
+      request.mock.calls.some(
+        ([method, params]) =>
+          method === "sessions.list" &&
+          (params as Record<string, unknown> | undefined)?.search === "tele",
+      ),
+    ).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(state.chatSessionPickerAppliedQuery).toBe("tele");
+    expect(state.chatSessionPickerResult?.sessions.map((row) => row.key)).toEqual([
+      "agent:main:telegram-one",
+      "agent:main:telegram-two",
+    ]);
+  });
+
+  it("flushes pending chat session picker search on blur", async () => {
+    const { state, request } = createChatHeaderState();
+    state.sessionsIncludeGlobal = false;
+    state.sessionsIncludeUnknown = false;
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    container.querySelector<HTMLButtonElement>('button[data-chat-session-select="true"]')!.click();
+    render(renderChatSessionSelect(state), container);
+    const input = container.querySelector<HTMLInputElement>(
+      'input[data-chat-session-picker-search="true"]',
+    );
+
+    input!.value = "tele";
+    input!.dispatchEvent(new Event("input", { bubbles: true }));
+    input!.dispatchEvent(new FocusEvent("blur", { bubbles: false }));
+
+    await vi.waitFor(() => expect(state.chatSessionPickerAppliedQuery).toBe("tele"));
+    expect(request).toHaveBeenCalledWith("sessions.list", {
+      configuredAgentsOnly: true,
+      includeGlobal: true,
+      includeUnknown: true,
+      limit: 50,
+      search: "tele",
+    });
+  });
+
   it("clears applied chat session picker search when the input is cleared", async () => {
     const { state } = createChatHeaderState();
     state.sessionsIncludeGlobal = false;
@@ -1371,6 +1436,93 @@ describe("chat session controls", () => {
     expect(state.chatSessionPickerQuery).toBe("");
     expect(state.chatSessionPickerAppliedQuery).toBe("");
     expect(state.chatSessionPickerResult).toBeNull();
+  });
+
+  it("ignores stale chat session picker search responses", async () => {
+    const { state } = createChatHeaderState();
+    state.sessionsIncludeGlobal = false;
+    state.sessionsIncludeUnknown = false;
+    let resolveTele!: (value: SessionsListResult) => void;
+    let resolveTelegram!: (value: SessionsListResult) => void;
+    const request = vi.fn((method: string, params: Record<string, unknown> = {}) => {
+      if (method !== "sessions.list") {
+        throw new Error(`Unexpected request: ${method}`);
+      }
+      if (params.search === "tele") {
+        return new Promise<SessionsListResult>((resolve) => {
+          resolveTele = resolve;
+        });
+      }
+      if (params.search === "telegram") {
+        return new Promise<SessionsListResult>((resolve) => {
+          resolveTelegram = resolve;
+        });
+      }
+      return Promise.resolve(state.sessionsResult);
+    });
+    state.client = { request } as unknown as GatewayBrowserClient;
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    container.querySelector<HTMLButtonElement>('button[data-chat-session-select="true"]')!.click();
+    render(renderChatSessionSelect(state), container);
+    const input = container.querySelector<HTMLInputElement>(
+      'input[data-chat-session-picker-search="true"]',
+    );
+
+    input!.value = "tele";
+    input!.dispatchEvent(new Event("input", { bubbles: true }));
+    input!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    expect(request).toHaveBeenCalledWith("sessions.list", {
+      configuredAgentsOnly: true,
+      includeGlobal: true,
+      includeUnknown: true,
+      limit: 50,
+      search: "tele",
+    });
+
+    input!.value = "telegram";
+    input!.dispatchEvent(new Event("input", { bubbles: true }));
+    input!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    expect(request).toHaveBeenCalledWith("sessions.list", {
+      configuredAgentsOnly: true,
+      includeGlobal: true,
+      includeUnknown: true,
+      limit: 50,
+      search: "telegram",
+    });
+
+    resolveTelegram(
+      createSessionsResultFromRows([
+        {
+          key: "agent:main:telegram-latest",
+          kind: "direct",
+          label: "Telegram latest",
+          updatedAt: 5,
+        },
+      ]),
+    );
+    await vi.waitFor(() => expect(state.chatSessionPickerAppliedQuery).toBe("telegram"));
+    expect(state.chatSessionPickerResult?.sessions.map((row) => row.key)).toEqual([
+      "agent:main:telegram-latest",
+    ]);
+
+    resolveTele(
+      createSessionsResultFromRows([
+        {
+          key: "agent:main:tele-stale",
+          kind: "direct",
+          label: "Tele stale",
+          updatedAt: 6,
+        },
+      ]),
+    );
+    await flushTasks();
+
+    expect(state.chatSessionPickerAppliedQuery).toBe("telegram");
+    expect(state.chatSessionPickerResult?.sessions.map((row) => row.key)).toEqual([
+      "agent:main:telegram-latest",
+    ]);
   });
 
   it("loads another chat session picker page using the server next offset", async () => {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1551,7 +1551,15 @@ describe("chat session controls", () => {
     const loadMore = container.querySelector<HTMLButtonElement>(
       'button[data-chat-session-load-more="true"]',
     );
+    const input = container.querySelector<HTMLInputElement>(
+      'input[data-chat-session-picker-search="true"]',
+    );
     expect(loadMore?.disabled).toBe(false);
+    request.mockClear();
+    input!.dispatchEvent(new FocusEvent("blur", { bubbles: false }));
+    await flushTasks();
+    expect(request).not.toHaveBeenCalled();
+
     loadMore!.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
     await vi.waitFor(() => expect(state.chatSessionPickerResult?.sessions).toHaveLength(4));
 


### PR DESCRIPTION
## Summary

- Make the chat session picker search live and debounced, with Enter/search-click/blur applying immediately and stale async responses ignored.
- Include the displayed session row model/provider identity in `sessions.list` search so provider, model, and `provider/model` queries match inherited defaults and overrides.
- Expand the mocked Control UI chat picker dataset with large pagination and model-search rows for manual/browser verification.

## Verification

- `git diff --check origin/main...HEAD`
- `node scripts/run-vitest.mjs src/gateway/session-utils.search.test.ts`
- `node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/ui/e2e/chat-picker-pagination.e2e.test.ts`

## Real behavior proof

Behavior addressed: Chat session picker search no longer leaves draft text unapplied on blur, clears stale filtered state immediately, ignores stale search responses, and can find sessions by the model/provider text displayed in each picker row.

Real environment tested: Local mocked Control UI at `http://127.0.0.1:5188/chat` with mocked Gateway sessions.

Exact steps or command run after this patch: Opened the mocked Control UI chat picker and searched for `claude`.

Evidence after fix: The picker returned model-search rows whose labels do not contain `claude`, but whose displayed metadata does: `anthropic/claude-sonnet-4-6`.

Observed result after fix: Search `claude` showed `50 / 75` results, with the first row `Model search result 001 anthropic/claude-sonnet-4-6`.

What was not tested: Full repository check suite and live non-mocked Gateway data.
