### PR TITLE
fix(microsoft-foundry): DeepSeek models incorrectly use openai-completions API

### DIFF
--- a/extensions/microsoft-foundry/index.test.ts
+++ b/extensions/microsoft-foundry/index.test.ts
@@ -559,6 +559,8 @@ describe("microsoft-foundry plugin", () => {
     expect(usesFoundryResponsesByDefault("gpt-5.4")).toBe(true);
     expect(usesFoundryResponsesByDefault("gpt-5.2-codex")).toBe(true);
     expect(usesFoundryResponsesByDefault("o4-mini")).toBe(true);
+    expect(usesFoundryResponsesByDefault("DeepSeek-V4-Pro")).toBe(true);
+    expect(usesFoundryResponsesByDefault("DeepSeek-V4-Flash")).toBe(true);
     expect(usesFoundryResponsesByDefault("MAI-DS-R1")).toBe(false);
     expect(requiresFoundryMaxCompletionTokens("gpt-5.4")).toBe(true);
     expect(requiresFoundryMaxCompletionTokens("o3")).toBe(true);

--- a/extensions/microsoft-foundry/shared.ts
+++ b/extensions/microsoft-foundry/shared.ts
@@ -121,6 +121,7 @@ export function usesFoundryResponsesByDefault(value?: string | null): boolean {
     normalized.startsWith("o1") ||
     normalized.startsWith("o3") ||
     normalized.startsWith("o4") ||
+    normalized.startsWith("deepseek-v4") ||
     normalized === "computer-use-preview"
   );
 }


### PR DESCRIPTION
## Summary

- Route Microsoft Foundry DeepSeek V4 deployments through the Responses API heuristic.
- Keep older DeepSeek families on the existing completions default until separately proven.
- Add focused Microsoft Foundry model-family coverage.

## Real behavior proof

Behavior addressed: Foundry-hosted `DeepSeek-V4-Pro` and `DeepSeek-V4-Flash` model IDs were classified like older DeepSeek models and defaulted to `openai-completions`, which sends the wrong request adapter for this V4 family.
Real environment tested: local OpenClaw source checkout on macOS, Node/pnpm repo runtime, with the production Microsoft Foundry model-family selector exercised directly through `node --import tsx`.
Exact steps or command run after this patch: `node --import tsx --input-type=module` probe importing `extensions/microsoft-foundry/shared.ts` and printing `usesFoundryResponsesByDefault()` results for the affected and adjacent model IDs.
Evidence after fix:
```json
{
  "DeepSeek-V4-Pro": true,
  "DeepSeek-V4-Flash": true,
  "MAI-DS-R1": false,
  "gpt-5": true
}
```
Observed result after fix: only the DeepSeek V4 prefix joins the existing Foundry Responses default family, so onboarding/config selection chooses the Responses adapter for that family without broadening older DeepSeek behavior.
What was not tested: no live Microsoft Foundry request with real Foundry credentials.

## Verification

- `pnpm test extensions/microsoft-foundry/index.test.ts`
- `git diff --check`
- Auto Review: clean, no accepted/actionable findings.
