### PR TITLE
test: fix OpenAI video provider type check

### DIFF
--- a/extensions/openai/video-generation-provider.test.ts
+++ b/extensions/openai/video-generation-provider.test.ts
@@ -365,7 +365,7 @@ describe("openai video generation provider", () => {
       },
     });
 
-    expect(result.videos[0]?.buffer.toString()).toBe("mp4-bytes");
+    expect(result.videos[0]?.buffer?.toString()).toBe("mp4-bytes");
     expect(executeProviderOperationWithRetryMock).toHaveBeenCalledWith(
       expect.objectContaining({ provider: "openai", stage: "download" }),
     );


### PR DESCRIPTION
## Summary
- Fix the OpenAI video provider test assertion so TypeScript narrows the optional generated video buffer before calling `toString()`.

## Validation
- `pnpm check:test-types`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-provider-openai.config.ts extensions/openai/video-generation-provider.test.ts`

Note: `pnpm test:extensions -- extensions/openai/video-generation-provider.test.ts` passed the OpenAI shard, then continued into unrelated extension shards and failed in `extensions/acpx/src/codex-auth-bridge.test.ts` because this OpenClaw agent environment sets `CODEX_HOME`; the direct OpenAI provider test command above passes.
