### PR TITLE
fix(telegram): transient Telegram pairing prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents: keep parallel OpenAI-compatible tool-call deltas in separate argument buffers so interleaved tool calls no longer corrupt streamed arguments. (#82263) Thanks @luna-system.
+- Telegram: avoid false pairing prompts after transient pairing-store read failures while preserving configured `allowFrom` and per-DM pairing authorization. (#85555)
 - Memory/doctor: report missing or unusable QMD workspace directories as workspace failures instead of generic binary failures. (#63167) Thanks @sercada.
 - Debug proxy: record CONNECT client-socket errors and destroy the paired upstream socket so abrupt client disconnects no longer leak tunnel resources. (#82444) Thanks @SebTardif.
 - Diffs: continue hydrating later diff cards when one card fails so a single broken card no longer blanks the whole diff viewer. (#84775) Thanks @cosmopolitan033.

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -90,6 +90,7 @@ import {
   resolveTelegramForumThreadId,
   resolveTelegramGroupAllowFromContext,
   loadTelegramPairingStoreIfNeeded,
+  TelegramPairingStoreReadError,
   shouldUseTelegramDmThreadSession,
   withResolvedTelegramForumFlag,
 } from "./bot/helpers.js";
@@ -2899,6 +2900,23 @@ export const registerTelegramHandlers = ({
     } catch (err) {
       releaseDispatchDedupeKeys(dispatchDedupeKeys, err);
       runtime.error?.(danger(`${event.errorMessage}: ${String(err)}`));
+      if (err instanceof TelegramPairingStoreReadError) {
+        await withTelegramApiErrorLogging({
+          operation: "sendMessage",
+          runtime,
+          fn: () =>
+            bot.api.sendMessage(
+              event.chatId,
+              "⚠️ Couldn't process this message, please try again in a moment.",
+              {
+                reply_parameters: {
+                  message_id: event.msg.message_id,
+                  allow_sending_without_reply: true,
+                },
+              },
+            ),
+        }).catch(() => {});
+      }
     }
   };
 

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -89,6 +89,7 @@ import {
   resolveTelegramForumFlag,
   resolveTelegramForumThreadId,
   resolveTelegramGroupAllowFromContext,
+  isTelegramDmAllowedByConfiguredAllowFrom,
   shouldUseTelegramDmThreadSession,
   withResolvedTelegramForumFlag,
 } from "./bot/helpers.js";
@@ -935,7 +936,7 @@ export const registerTelegramHandlers = ({
         date: last.msg.date ?? first.msg.date,
       });
 
-      const storeAllowFrom = await loadStoreAllowFrom();
+      const storeAllowFrom = await loadStoreAllowFrom(first.msg);
       const baseCtx = first.ctx;
 
       const syntheticCtx = buildSyntheticContext(baseCtx, syntheticMessage);
@@ -976,8 +977,36 @@ export const registerTelegramHandlers = ({
     }, TELEGRAM_TEXT_FRAGMENT_MAX_GAP_MS);
   };
 
-  const loadStoreAllowFrom = async () =>
-    telegramDeps.readChannelAllowFromStore("telegram", process.env, accountId).catch(() => []);
+  const loadStoreAllowFrom = async (msg: Message) => {
+    const isGroup = msg.chat.type !== "private";
+    if (isGroup) {
+      return [];
+    }
+    const { groupConfig, topicConfig } = resolveTelegramGroupConfig(
+      msg.chat.id,
+      msg.message_thread_id,
+    );
+    const groupAllowOverride = firstDefined(topicConfig?.allowFrom, groupConfig?.allowFrom);
+    const effectiveDmPolicy = resolveTelegramEffectiveDmPolicy({
+      isGroup,
+      groupConfig,
+      dmPolicy: telegramCfg.dmPolicy,
+    });
+    if (effectiveDmPolicy !== "pairing") {
+      return [];
+    }
+    const senderId = msg.from?.id != null ? String(msg.from.id) : undefined;
+    const configuredDmAllowed = await isTelegramDmAllowedByConfiguredAllowFrom({
+      cfg,
+      allowFrom,
+      groupAllowOverride,
+      accountId,
+      senderId,
+    });
+    return configuredDmAllowed
+      ? []
+      : await telegramDeps.readChannelAllowFromStore("telegram", process.env, accountId);
+  };
 
   const recordMessageForReplyChain = (msg: Message, threadId?: number) =>
     messageCache.record({
@@ -1318,6 +1347,8 @@ export const registerTelegramHandlers = ({
         cfg,
         chatId: params.chatId,
         accountId,
+        dmPolicy: telegramCfg.dmPolicy,
+        allowFrom,
         senderId: params.senderId,
         isGroup: params.isGroup,
         isForum: params.isForum,

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -89,7 +89,7 @@ import {
   resolveTelegramForumFlag,
   resolveTelegramForumThreadId,
   resolveTelegramGroupAllowFromContext,
-  isTelegramDmAllowedByConfiguredAllowFrom,
+  loadTelegramPairingStoreIfNeeded,
   shouldUseTelegramDmThreadSession,
   withResolvedTelegramForumFlag,
 } from "./bot/helpers.js";
@@ -978,10 +978,7 @@ export const registerTelegramHandlers = ({
   };
 
   const loadStoreAllowFrom = async (msg: Message) => {
-    const isGroup = msg.chat.type !== "private";
-    if (isGroup) {
-      return [];
-    }
+    const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
     const { groupConfig, topicConfig } = resolveTelegramGroupConfig(
       msg.chat.id,
       msg.message_thread_id,
@@ -992,20 +989,16 @@ export const registerTelegramHandlers = ({
       groupConfig,
       dmPolicy: telegramCfg.dmPolicy,
     });
-    if (effectiveDmPolicy !== "pairing") {
-      return [];
-    }
-    const senderId = msg.from?.id != null ? String(msg.from.id) : undefined;
-    const configuredDmAllowed = await isTelegramDmAllowedByConfiguredAllowFrom({
+    return loadTelegramPairingStoreIfNeeded({
       cfg,
       allowFrom,
       groupAllowOverride,
       accountId,
-      senderId,
+      senderId: msg.from?.id != null ? String(msg.from.id) : undefined,
+      isGroup,
+      effectiveDmPolicy,
+      readChannelAllowFromStore: telegramDeps.readChannelAllowFromStore,
     });
-    return configuredDmAllowed
-      ? []
-      : await telegramDeps.readChannelAllowFromStore("telegram", process.env, accountId);
   };
 
   const recordMessageForReplyChain = (msg: Message, threadId?: number) =>

--- a/extensions/telegram/src/bot-native-commands.group-auth.test.ts
+++ b/extensions/telegram/src/bot-native-commands.group-auth.test.ts
@@ -1,9 +1,10 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ChannelGroupPolicy } from "openclaw/plugin-sdk/config-contracts";
 import type { TelegramAccountConfig } from "openclaw/plugin-sdk/config-contracts";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   createNativeCommandsHarness,
+  createTelegramDmCommandContext,
   createTelegramGroupCommandContext,
   findNotAuthorizedCalls,
 } from "./bot-native-commands.test-helpers.js";
@@ -184,6 +185,27 @@ describe("native command auth in groups", () => {
 
     const notAuthCalls = findNotAuthorizedCalls(sendMessage);
     expect(notAuthCalls.length).toBeGreaterThan(0);
+  });
+
+  it("authorizes a DM native command from commands.allowFrom.telegram when pairing-store read fails transiently", async () => {
+    const readChannelAllowFromStore = vi.fn(async () => {
+      throw new Error("store temporarily unavailable");
+    });
+    const { handlers, sendMessage } = createNativeCommandsHarness({
+      cfg: {
+        commands: { native: true, allowFrom: { telegram: ["12345"] } },
+        channels: { telegram: { dmPolicy: "pairing" } },
+      } as OpenClawConfig,
+      telegramCfg: { dmPolicy: "pairing" } as TelegramAccountConfig,
+      readChannelAllowFromStore,
+    });
+
+    const ctx = createTelegramDmCommandContext({ senderId: 12345 });
+
+    await handlers.status?.(ctx);
+
+    expect(readChannelAllowFromStore).not.toHaveBeenCalled();
+    expect(findNotAuthorizedCalls(sendMessage)).toHaveLength(0);
   });
 
   it("replies in the originating forum topic when auth is rejected", async () => {

--- a/extensions/telegram/src/bot-native-commands.test-helpers.ts
+++ b/extensions/telegram/src/bot-native-commands.test-helpers.ts
@@ -4,6 +4,7 @@ import type { TelegramAccountConfig } from "openclaw/plugin-sdk/config-contracts
 import type { MockFn } from "openclaw/plugin-sdk/plugin-test-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { vi } from "vitest";
+import type { TelegramNativeCommandDeps } from "./bot-native-command-deps.runtime.js";
 import type { RegisterTelegramNativeCommandsParams } from "./bot-native-commands.js";
 import { registerTelegramNativeCommands } from "./bot-native-commands.js";
 
@@ -134,7 +135,8 @@ export function createNativeCommandsHarness(params?: {
     params?.readChannelAllowFromStore ?? vi.fn(async () => params?.storeAllowFrom ?? []);
   const telegramDeps = {
     getRuntimeConfig: vi.fn(() => params?.cfg ?? ({} as OpenClawConfig)),
-    readChannelAllowFromStore,
+    readChannelAllowFromStore:
+      readChannelAllowFromStore as TelegramNativeCommandDeps["readChannelAllowFromStore"],
     dispatchReplyWithBufferedBlockDispatcher:
       replyPipelineMocks.dispatchReplyWithBufferedBlockDispatcher,
     getPluginCommandSpecs: pluginCommandMocks.getPluginCommandSpecs,

--- a/extensions/telegram/src/bot-native-commands.test-helpers.ts
+++ b/extensions/telegram/src/bot-native-commands.test-helpers.ts
@@ -34,6 +34,7 @@ type NativeCommandHarness = {
   setMyCommands: AnyAsyncMock;
   log: AnyMock;
   bot: RegisterTelegramNativeCommandsParams["bot"];
+  readChannelAllowFromStore: AnyAsyncMock;
 };
 
 const pluginCommandMocks = vi.hoisted(() => ({
@@ -119,6 +120,7 @@ export function createNativeCommandsHarness(params?: {
   allowFrom?: string[];
   groupAllowFrom?: string[];
   storeAllowFrom?: string[];
+  readChannelAllowFromStore?: AnyAsyncMock;
   useAccessGroups?: boolean;
   nativeEnabled?: boolean;
   groupConfig?: Record<string, unknown>;
@@ -128,9 +130,11 @@ export function createNativeCommandsHarness(params?: {
   const sendMessage: AnyAsyncMock = vi.fn(async () => undefined);
   const setMyCommands: AnyAsyncMock = vi.fn(async () => undefined);
   const log: AnyMock = vi.fn();
+  const readChannelAllowFromStore: AnyAsyncMock =
+    params?.readChannelAllowFromStore ?? vi.fn(async () => params?.storeAllowFrom ?? []);
   const telegramDeps = {
     getRuntimeConfig: vi.fn(() => params?.cfg ?? ({} as OpenClawConfig)),
-    readChannelAllowFromStore: vi.fn(async () => params?.storeAllowFrom ?? []),
+    readChannelAllowFromStore,
     dispatchReplyWithBufferedBlockDispatcher:
       replyPipelineMocks.dispatchReplyWithBufferedBlockDispatcher,
     getPluginCommandSpecs: pluginCommandMocks.getPluginCommandSpecs,
@@ -177,7 +181,23 @@ export function createNativeCommandsHarness(params?: {
     opts: { token: "token" },
   });
 
-  return { handlers, sendMessage, setMyCommands, log, bot };
+  return { handlers, sendMessage, setMyCommands, log, bot, readChannelAllowFromStore };
+}
+
+export function createTelegramDmCommandContext(params?: { senderId?: number; username?: string }) {
+  const senderId = params?.senderId ?? 12345;
+  return {
+    message: {
+      chat: { id: senderId, type: "private" },
+      from: {
+        id: senderId,
+        username: params?.username ?? "testuser",
+      },
+      message_id: 1,
+      date: 1700000000,
+    },
+    match: "",
+  };
 }
 
 export function createTelegramGroupCommandContext(params?: {

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -517,6 +517,22 @@ async function resolveTelegramCommandAuth(params: {
     await resolveTelegramNativeCommandThreadContext({ msg, bot });
   const senderId = msg.from?.id ? String(msg.from.id) : "";
   const senderUsername = msg.from?.username ?? "";
+  // Best-effort pre-context check: if commands.allowFrom already authorizes the
+  // sender at chat level, skip the pairing-store read so a transient store I/O
+  // failure cannot block a command this sender is explicitly allowed to run.
+  // resolvedThreadId is not known yet; the post-context check below is still
+  // the authoritative decision for topic-scoped command auth.
+  const commandsAllowFromConfigured = isTelegramCommandsAllowFromConfigured(cfg);
+  const preContextCommandsAllowFromAccess = commandsAllowFromConfigured
+    ? resolveTelegramCommandAuthorization({
+        cfg,
+        accountId,
+        chatId,
+        isGroup,
+        senderId,
+        senderUsername,
+      })
+    : null;
   const groupAllowContext = await resolveTelegramGroupAllowFromContext({
     cfg,
     chatId,
@@ -528,6 +544,7 @@ async function resolveTelegramCommandAuth(params: {
     isForum,
     messageThreadId,
     groupAllowFrom,
+    skipPairingStoreRead: Boolean(preContextCommandsAllowFromAccess?.isAuthorizedSender),
     readChannelAllowFromStore,
     resolveTelegramGroupConfig,
   });
@@ -553,7 +570,6 @@ async function resolveTelegramCommandAuth(params: {
     return null;
   }
   const dmAllowFrom = groupAllowOverride ?? allowFrom;
-  const commandsAllowFromConfigured = isTelegramCommandsAllowFromConfigured(cfg);
   const commandsAllowFromAccess = commandsAllowFromConfigured
     ? resolveTelegramCommandAuthorization({
         cfg,

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -521,6 +521,8 @@ async function resolveTelegramCommandAuth(params: {
     cfg,
     chatId,
     accountId,
+    dmPolicy: telegramCfg.dmPolicy,
+    allowFrom,
     senderId,
     isGroup,
     isForum,

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1350,7 +1350,7 @@ describe("createTelegramBot", () => {
     }
   });
 
-  it("does not issue a pairing challenge when the pairing allowlist store cannot be read", async () => {
+  it("sends a friendly retry hint when the pairing allowlist store cannot be read", async () => {
     loadConfig.mockReturnValue({
       channels: { telegram: { dmPolicy: "pairing" } },
     });
@@ -1366,6 +1366,7 @@ describe("createTelegramBot", () => {
       message: {
         chat: { id: 1234, type: "private" },
         text: "hello",
+        message_id: 9,
         date: 1736380800,
         from: { id: 123456789, username: "testuser" },
       },
@@ -1374,8 +1375,15 @@ describe("createTelegramBot", () => {
     });
 
     expect(upsertChannelPairingRequest).not.toHaveBeenCalled();
-    expect(sendMessageSpy).not.toHaveBeenCalled();
     expect(replySpy).not.toHaveBeenCalled();
+    expect(sendMessageSpy).toHaveBeenCalledTimes(1);
+    expect(sendMessageSpy).toHaveBeenCalledWith(
+      1234,
+      "⚠️ Couldn't process this message, please try again in a moment.",
+      expect.objectContaining({
+        reply_parameters: expect.objectContaining({ message_id: 9 }),
+      }),
+    );
   });
 
   it("keeps the same private chat usable after a transient pairing store read failure", async () => {
@@ -1417,7 +1425,9 @@ describe("createTelegramBot", () => {
 
     expect(readChannelAllowFromStore).toHaveBeenCalledTimes(2);
     expect(upsertChannelPairingRequest).not.toHaveBeenCalled();
-    expect(sendMessageSpy).not.toHaveBeenCalled();
+    // First message: failure → retry hint via sendMessageSpy. Second message: success → agent reply via replySpy.
+    expect(sendMessageSpy).toHaveBeenCalledTimes(1);
+    expect(sendMessageSpy.mock.calls[0]?.[1]).toMatch(/please try again/i);
     expect(replySpy).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1350,6 +1350,135 @@ describe("createTelegramBot", () => {
     }
   });
 
+  it("does not issue a pairing challenge when the pairing allowlist store cannot be read", async () => {
+    loadConfig.mockReturnValue({
+      channels: { telegram: { dmPolicy: "pairing" } },
+    });
+    readChannelAllowFromStore.mockRejectedValueOnce(new Error("store temporarily unavailable"));
+    upsertChannelPairingRequest.mockClear();
+    sendMessageSpy.mockClear();
+    replySpy.mockClear();
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: 1234, type: "private" },
+        text: "hello",
+        date: 1736380800,
+        from: { id: 123456789, username: "testuser" },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(upsertChannelPairingRequest).not.toHaveBeenCalled();
+    expect(sendMessageSpy).not.toHaveBeenCalled();
+    expect(replySpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps the same private chat usable after a transient pairing store read failure", async () => {
+    loadConfig.mockReturnValue({
+      channels: { telegram: { dmPolicy: "pairing" } },
+    });
+    readChannelAllowFromStore
+      .mockRejectedValueOnce(new Error("store temporarily unavailable"))
+      .mockResolvedValueOnce(["123456789"]);
+    upsertChannelPairingRequest.mockClear();
+    sendMessageSpy.mockClear();
+    replySpy.mockClear();
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    const firstMessage = {
+      chat: { id: 1234, type: "private" },
+      text: "hello",
+      date: 1736380800,
+      message_id: 10,
+      from: { id: 123456789, username: "testuser" },
+    };
+    await handler({
+      message: firstMessage,
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+    await handler({
+      message: {
+        ...firstMessage,
+        text: "still there?",
+        date: 1736380801,
+        message_id: 11,
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(readChannelAllowFromStore).toHaveBeenCalledTimes(2);
+    expect(upsertChannelPairingRequest).not.toHaveBeenCalled();
+    expect(sendMessageSpy).not.toHaveBeenCalled();
+    expect(replySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows a configured private sender when the pairing allowlist store cannot be read", async () => {
+    loadConfig.mockReturnValue({
+      channels: { telegram: { dmPolicy: "pairing", allowFrom: ["123456789"] } },
+    });
+    readChannelAllowFromStore.mockRejectedValueOnce(new Error("store temporarily unavailable"));
+    upsertChannelPairingRequest.mockClear();
+    sendMessageSpy.mockClear();
+    replySpy.mockClear();
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: 1234, type: "private" },
+        text: "hello",
+        date: 1736380800,
+        from: { id: 123456789, username: "testuser" },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(readChannelAllowFromStore).not.toHaveBeenCalled();
+    expect(upsertChannelPairingRequest).not.toHaveBeenCalled();
+    expect(sendMessageSpy).not.toHaveBeenCalled();
+    expect(replySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not require the pairing allowlist store for open private messages", async () => {
+    loadConfig.mockReturnValue({
+      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
+    });
+    readChannelAllowFromStore.mockRejectedValueOnce(new Error("store temporarily unavailable"));
+    upsertChannelPairingRequest.mockClear();
+    sendMessageSpy.mockClear();
+    replySpy.mockClear();
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: 1234, type: "private" },
+        text: "hello",
+        date: 1736380800,
+        from: { id: 123456789, username: "testuser" },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(readChannelAllowFromStore).not.toHaveBeenCalled();
+    expect(upsertChannelPairingRequest).not.toHaveBeenCalled();
+    expect(sendMessageSpy).not.toHaveBeenCalled();
+    expect(replySpy).toHaveBeenCalledTimes(1);
+  });
+
   it("ignores private self-authored message updates instead of issuing a pairing challenge", async () => {
     loadConfig.mockReturnValue({
       channels: { telegram: { dmPolicy: "pairing" } },

--- a/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
@@ -256,6 +256,74 @@ describe("telegram text fragments", () => {
   );
 
   it(
+    "keeps per-DM pairing store authorization when flushing text fragments",
+    async () => {
+      const originalLoadConfig = telegramBotDepsForTest.getRuntimeConfig;
+      telegramBotDepsForTest.getRuntimeConfig = (() => ({
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            direct: {
+              "42": { dmPolicy: "pairing" },
+            },
+          },
+        },
+      })) as typeof telegramBotDepsForTest.getRuntimeConfig;
+
+      const readAllowFromStore = vi.mocked(telegramBotDepsForTest.readChannelAllowFromStore);
+      const upsertPairingRequest = vi.mocked(telegramBotDepsForTest.upsertChannelPairingRequest);
+      readAllowFromStore.mockReset();
+      readAllowFromStore.mockResolvedValue(["777"]);
+      upsertPairingRequest.mockClear();
+
+      const runtimeError = vi.fn();
+      const { handler, replySpy } = await createBotHandlerWithOptions({ runtimeError });
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+      const part1 = "A".repeat(4050);
+      const part2 = "B".repeat(50);
+
+      try {
+        await handler({
+          message: {
+            chat: { id: 42, type: "private" },
+            from: { id: 777, is_bot: false, first_name: "Ada" },
+            message_id: 30,
+            date: 1736380800,
+            text: part1,
+          },
+          me: { username: "openclaw_bot" },
+          getFile: async () => ({}),
+        });
+
+        await handler({
+          message: {
+            chat: { id: 42, type: "private" },
+            from: { id: 777, is_bot: false, first_name: "Ada" },
+            message_id: 31,
+            date: 1736380801,
+            text: part2,
+          },
+          me: { username: "openclaw_bot" },
+          getFile: async () => ({}),
+        });
+
+        await flushScheduledTimerForDelay(setTimeoutSpy, TELEGRAM_TEST_TIMINGS.textFragmentGapMs);
+
+        expect(readAllowFromStore).toHaveBeenCalledWith("telegram", process.env, "default");
+        expect(upsertPairingRequest).not.toHaveBeenCalled();
+        expect(replySpy).toHaveBeenCalledTimes(1);
+        expect(runtimeError).not.toHaveBeenCalled();
+      } finally {
+        setTimeoutSpy.mockRestore();
+        telegramBotDepsForTest.getRuntimeConfig = originalLoadConfig;
+        readAllowFromStore.mockReset();
+        readAllowFromStore.mockResolvedValue([]);
+      }
+    },
+    TEXT_FRAGMENT_TEST_TIMEOUT_MS,
+  );
+
+  it(
     "flushes different forum topic fragments in parallel",
     async () => {
       const originalLoadConfig = telegramBotDepsForTest.getRuntimeConfig;

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -208,6 +208,10 @@ export async function resolveTelegramGroupAllowFromContext(params: {
   isForum?: boolean;
   messageThreadId?: number | null;
   groupAllowFrom?: Array<string | number>;
+  // Set when the caller has already authorized the sender by some other config
+  // path (e.g. commands.allowFrom) and the pairing-store outcome cannot change
+  // the decision. Lets command auth survive transient store I/O failures.
+  skipPairingStoreRead?: boolean;
   readChannelAllowFromStore?: typeof readChannelAllowFromStore;
   resolveTelegramGroupConfig: (
     chatId: string | number,
@@ -254,6 +258,7 @@ export async function resolveTelegramGroupAllowFromContext(params: {
     senderId: params.senderId,
     isGroup: params.isGroup ?? false,
     effectiveDmPolicy,
+    skipPairingStoreRead: params.skipPairingStoreRead,
     readChannelAllowFromStore: params.readChannelAllowFromStore,
   });
   const expandedGroupAllowFrom = await expandTelegramAllowFromWithAccessGroups({
@@ -318,9 +323,10 @@ export async function loadTelegramPairingStoreIfNeeded(params: {
   senderId?: string;
   isGroup: boolean;
   effectiveDmPolicy: DmPolicy;
+  skipPairingStoreRead?: boolean;
   readChannelAllowFromStore?: typeof readChannelAllowFromStore;
 }): Promise<string[]> {
-  if (params.isGroup || params.effectiveDmPolicy !== "pairing") {
+  if (params.skipPairingStoreRead || params.isGroup || params.effectiveDmPolicy !== "pairing") {
     return [];
   }
   const configuredDmAllowed = await isTelegramDmAllowedByConfiguredAllowFrom({

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -310,11 +310,16 @@ async function isTelegramDmAllowedByConfiguredAllowFrom(params: {
   );
 }
 
-// Only read the pairing-store file when it can affect the decision: DM, pairing
-// mode, and the sender is not already authorized by configured allowFrom.
-// readChannelAllowFromStore translates a missing pairing file to [] internally,
-// so the only errors that escape are unexpected I/O failures — letting them
-// throw lets callers drop the message instead of issuing a bogus pairing prompt.
+export class TelegramPairingStoreReadError extends Error {
+  override readonly cause: unknown;
+  constructor(cause: unknown) {
+    super(`Telegram pairing store read failed: ${String(cause)}`);
+    this.name = "TelegramPairingStoreReadError";
+    this.cause = cause;
+  }
+}
+
+// Could add bounded retries to absorb short FD-pressure spikes; deferred. See #85555.
 export async function loadTelegramPairingStoreIfNeeded(params: {
   cfg?: OpenClawConfig;
   allowFrom?: Array<string | number>;
@@ -339,11 +344,15 @@ export async function loadTelegramPairingStoreIfNeeded(params: {
   if (configuredDmAllowed) {
     return [];
   }
-  return await (params.readChannelAllowFromStore ?? readChannelAllowFromStore)(
-    "telegram",
-    process.env,
-    params.accountId,
-  );
+  try {
+    return await (params.readChannelAllowFromStore ?? readChannelAllowFromStore)(
+      "telegram",
+      process.env,
+      params.accountId,
+    );
+  } catch (cause) {
+    throw new TelegramPairingStoreReadError(cause);
+  }
 }
 
 /**

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -246,24 +246,16 @@ export async function resolveTelegramGroupAllowFromContext(params: {
     groupConfig,
     dmPolicy: params.dmPolicy,
   });
-  const shouldReadPairingStore = params.isGroup !== true && effectiveDmPolicy === "pairing";
-  const configuredDmAllowed = shouldReadPairingStore
-    ? await isTelegramDmAllowedByConfiguredAllowFrom({
-        cfg: params.cfg,
-        allowFrom: params.allowFrom,
-        groupAllowOverride,
-        accountId,
-        senderId: params.senderId,
-      })
-    : false;
-  const storeAllowFrom =
-    shouldReadPairingStore && !configuredDmAllowed
-      ? await (params.readChannelAllowFromStore ?? readChannelAllowFromStore)(
-          "telegram",
-          process.env,
-          accountId,
-        )
-      : [];
+  const storeAllowFrom = await loadTelegramPairingStoreIfNeeded({
+    cfg: params.cfg,
+    allowFrom: params.allowFrom,
+    groupAllowOverride,
+    accountId,
+    senderId: params.senderId,
+    isGroup: params.isGroup ?? false,
+    effectiveDmPolicy,
+    readChannelAllowFromStore: params.readChannelAllowFromStore,
+  });
   const expandedGroupAllowFrom = await expandTelegramAllowFromWithAccessGroups({
     cfg: params.cfg,
     allowFrom: groupAllowOverride ?? params.groupAllowFrom,
@@ -286,7 +278,7 @@ export async function resolveTelegramGroupAllowFromContext(params: {
   };
 }
 
-export async function isTelegramDmAllowedByConfiguredAllowFrom(params: {
+async function isTelegramDmAllowedByConfiguredAllowFrom(params: {
   cfg?: OpenClawConfig;
   allowFrom?: Array<string | number>;
   groupAllowOverride?: Array<string | number>;
@@ -310,6 +302,41 @@ export async function isTelegramDmAllowedByConfiguredAllowFrom(params: {
       allow: normalizedAllowFrom,
       senderId: params.senderId,
     })
+  );
+}
+
+// Only read the pairing-store file when it can affect the decision: DM, pairing
+// mode, and the sender is not already authorized by configured allowFrom.
+// readChannelAllowFromStore translates a missing pairing file to [] internally,
+// so the only errors that escape are unexpected I/O failures — letting them
+// throw lets callers drop the message instead of issuing a bogus pairing prompt.
+export async function loadTelegramPairingStoreIfNeeded(params: {
+  cfg?: OpenClawConfig;
+  allowFrom?: Array<string | number>;
+  groupAllowOverride?: Array<string | number>;
+  accountId: string;
+  senderId?: string;
+  isGroup: boolean;
+  effectiveDmPolicy: DmPolicy;
+  readChannelAllowFromStore?: typeof readChannelAllowFromStore;
+}): Promise<string[]> {
+  if (params.isGroup || params.effectiveDmPolicy !== "pairing") {
+    return [];
+  }
+  const configuredDmAllowed = await isTelegramDmAllowedByConfiguredAllowFrom({
+    cfg: params.cfg,
+    allowFrom: params.allowFrom,
+    groupAllowOverride: params.groupAllowOverride,
+    accountId: params.accountId,
+    senderId: params.senderId,
+  });
+  if (configuredDmAllowed) {
+    return [];
+  }
+  return await (params.readChannelAllowFromStore ?? readChannelAllowFromStore)(
+    "telegram",
+    process.env,
+    params.accountId,
   );
 }
 

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -6,6 +6,7 @@ import {
 } from "openclaw/plugin-sdk/command-auth-native";
 import type {
   OpenClawConfig,
+  DmPolicy,
   TelegramAccountConfig,
   TelegramDirectConfig,
   TelegramGroupConfig,
@@ -16,7 +17,13 @@ import { readChannelAllowFromStore } from "openclaw/plugin-sdk/conversation-runt
 import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { expandTelegramAllowFromWithAccessGroups } from "../access-groups.js";
-import { firstDefined, normalizeAllowFrom, type NormalizedAllowFrom } from "../bot-access.js";
+import {
+  firstDefined,
+  isSenderAllowed,
+  normalizeAllowFrom,
+  resolveTelegramEffectiveDmPolicy,
+  type NormalizedAllowFrom,
+} from "../bot-access.js";
 import { normalizeTelegramReplyToMessageId } from "../outbound-params.js";
 import { resolveTelegramPreviewStreamMode } from "../preview-streaming.js";
 import {
@@ -194,6 +201,8 @@ export async function resolveTelegramGroupAllowFromContext(params: {
   cfg?: OpenClawConfig;
   chatId: string | number;
   accountId?: string;
+  dmPolicy?: DmPolicy;
+  allowFrom?: Array<string | number>;
   senderId?: string;
   isGroup?: boolean;
   isForum?: boolean;
@@ -227,16 +236,34 @@ export async function resolveTelegramGroupAllowFromContext(params: {
   const resolvedThreadId = threadSpec.scope === "forum" ? threadSpec.id : undefined;
   const dmThreadId = threadSpec.scope === "dm" ? threadSpec.id : undefined;
   const threadIdForConfig = resolvedThreadId ?? dmThreadId;
-  const storeAllowFrom = await (params.readChannelAllowFromStore ?? readChannelAllowFromStore)(
-    "telegram",
-    process.env,
-    accountId,
-  ).catch(() => []);
   const { groupConfig, topicConfig } = params.resolveTelegramGroupConfig(
     params.chatId,
     threadIdForConfig,
   );
   const groupAllowOverride = firstDefined(topicConfig?.allowFrom, groupConfig?.allowFrom);
+  const effectiveDmPolicy = resolveTelegramEffectiveDmPolicy({
+    isGroup: params.isGroup ?? false,
+    groupConfig,
+    dmPolicy: params.dmPolicy,
+  });
+  const shouldReadPairingStore = params.isGroup !== true && effectiveDmPolicy === "pairing";
+  const configuredDmAllowed = shouldReadPairingStore
+    ? await isTelegramDmAllowedByConfiguredAllowFrom({
+        cfg: params.cfg,
+        allowFrom: params.allowFrom,
+        groupAllowOverride,
+        accountId,
+        senderId: params.senderId,
+      })
+    : false;
+  const storeAllowFrom =
+    shouldReadPairingStore && !configuredDmAllowed
+      ? await (params.readChannelAllowFromStore ?? readChannelAllowFromStore)(
+          "telegram",
+          process.env,
+          accountId,
+        )
+      : [];
   const expandedGroupAllowFrom = await expandTelegramAllowFromWithAccessGroups({
     cfg: params.cfg,
     allowFrom: groupAllowOverride ?? params.groupAllowFrom,
@@ -257,6 +284,33 @@ export async function resolveTelegramGroupAllowFromContext(params: {
     effectiveGroupAllow,
     hasGroupAllowOverride,
   };
+}
+
+export async function isTelegramDmAllowedByConfiguredAllowFrom(params: {
+  cfg?: OpenClawConfig;
+  allowFrom?: Array<string | number>;
+  groupAllowOverride?: Array<string | number>;
+  accountId: string;
+  senderId?: string;
+}): Promise<boolean> {
+  const configuredAllowFrom = params.groupAllowOverride ?? params.allowFrom;
+  if (!configuredAllowFrom || configuredAllowFrom.length === 0) {
+    return false;
+  }
+  const expandedAllowFrom = await expandTelegramAllowFromWithAccessGroups({
+    cfg: params.cfg,
+    allowFrom: configuredAllowFrom,
+    accountId: params.accountId,
+    senderId: params.senderId,
+  });
+  const normalizedAllowFrom = normalizeAllowFrom(expandedAllowFrom);
+  return (
+    normalizedAllowFrom.hasEntries &&
+    isSenderAllowed({
+      allow: normalizedAllowFrom,
+      senderId: params.senderId,
+    })
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

The behavior I'm seeing is transient Telegram pairing requests after an idle:

BEFORE

<img width="784" height="463" alt="image" src="https://github.com/user-attachments/assets/c300afe3-e0f3-4027-a4ab-d6068de23ce8" />

After a deep dive this is most likely caused by FD pressure after returning from idle - I've ONLY experienced on return from idle. In that case, I think it should error not send a confusing and potentially time-consuming pairing request. This replication was done with a chmod 800 to have same effect.

AFTER

fail loudly, better than spurious pairing request. I've added a comment in code to consider backoff retries to wait till FD pressure lowers, but feels a bit edgecasey and clever for now.

<img width="783" height="250" alt="image" src="https://github.com/user-attachments/assets/fd8a6c49-4e6e-4156-a88a-1fdbdd3aeabf" />

## Solution

- Avoid treating transient Telegram pairing-store read failures as an empty pairing allowlist that triggers a new pairing challenge.
- Skip pairing-store reads when the effective DM policy is not pairing, or when configured `allowFrom` already authorizes the sender.
- Preserve per-DM pairing policy resolution when flushing long text fragments.

## Verification

- `node scripts/run-vitest.mjs extensions/telegram/src/bot.create-telegram-bot.test.ts` -> 91 passed
- `node scripts/test-projects.mjs extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts` -> 5 passed
- `pnpm exec oxfmt --check --threads=1 extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts extensions/telegram/src/bot/helpers.ts extensions/telegram/src/bot-handlers.runtime.ts extensions/telegram/src/bot-native-commands.ts extensions/telegram/src/bot.create-telegram-bot.test.ts` -> passed
- `git diff --check` -> passed
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings

Behavior addressed: Same private Telegram chat can receive a transient pairing-store read failure without getting a bogus pairing prompt, then respond normally once the next store read succeeds.
Real environment tested: Local Codex worktree on Node/Vitest with mocked Telegram bot handlers and pairing-store dependency failures.
Exact steps or command run after this patch: Ran the two focused Telegram test files above, formatter check, `git diff --check`, and autoreview.
Evidence after fix: `bot.create-telegram-bot.test.ts` passes 91 tests, including the same-chat back-to-back message regression where the first store read rejects and the second returns the paired sender id.
Observed result after fix: No pairing request is upserted on transient store failure; configured/open DMs avoid unnecessary store reads; per-DM pairing store authorization still works for text-fragment flushes.
What was not tested: No live Telegram round trip was run; this is covered with mocked bot handler regressions rather than Crabbox/live Telegram proof.
