### PR TITLE
fix(cli-runner): keep claude-cli sessions alive during async sub-agent waits

### DIFF
--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -10,8 +10,22 @@ import {
 } from "../cli-output.js";
 import { FailoverError, resolveFailoverStatus } from "../failover-error.js";
 import { classifyFailoverReason } from "../pi-embedded-helpers.js";
+import { startClaudeSubagentActivityMonitor } from "./claude-subagent-progress.js";
 import { cliBackendLog } from "./log.js";
 import type { PreparedCliRunContext } from "./types.js";
+
+function extractCliSessionIdFromArgv(argv: readonly string[]): string | undefined {
+  for (let i = 0; i < argv.length - 1; i += 1) {
+    const flag = argv[i];
+    if (flag === "--session-id" || flag === "--resume" || flag === "-r") {
+      const value = argv[i + 1];
+      if (typeof value === "string" && value.length > 0) {
+        return value;
+      }
+    }
+  }
+  return undefined;
+}
 
 type ProcessSupervisor = ReturnType<
   typeof import("../../process/supervisor/index.js").getProcessSupervisor
@@ -42,6 +56,7 @@ type ClaudeLiveSession = {
   currentTurn: ClaudeLiveTurn | null;
   drainTimer: NodeJS.Timeout | null;
   drainingAbortedTurn: boolean;
+  subagentMonitor: { stop: () => void } | null;
   idleTimer: NodeJS.Timeout | null;
   cleanup: () => Promise<void>;
   cleanupDone: boolean;
@@ -608,6 +623,10 @@ function handleClaudeStdout(session: ClaudeLiveSession, chunk: string) {
 
 function handleClaudeExit(session: ClaudeLiveSession, exitCode: number | null): void {
   session.closing = true;
+  if (session.subagentMonitor) {
+    session.subagentMonitor.stop();
+    session.subagentMonitor = null;
+  }
   if (session.idleTimer) {
     clearTimeout(session.idleTimer);
     session.idleTimer = null;
@@ -723,6 +742,16 @@ async function createClaudeLiveSession(params: {
       }
     },
   });
+  const liveCliSessionId = extractCliSessionIdFromArgv(params.argv);
+  const subagentMonitor = liveCliSessionId
+    ? startClaudeSubagentActivityMonitor({
+        sessionId: params.context.params.sessionId,
+        sessionKey: params.context.params.sessionKey,
+        runId: params.context.params.runId,
+        workspaceDir: params.context.workspaceDir,
+        cliSessionId: liveCliSessionId,
+      })
+    : null;
   session = {
     key: params.key,
     fingerprint: params.fingerprint,
@@ -735,6 +764,7 @@ async function createClaudeLiveSession(params: {
     currentTurn: null,
     drainTimer: null,
     drainingAbortedTurn: false,
+    subagentMonitor,
     idleTimer: null,
     cleanup: params.cleanup,
     cleanupDone: false,

--- a/src/agents/cli-runner/claude-subagent-progress.test.ts
+++ b/src/agents/cli-runner/claude-subagent-progress.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  encodeClaudeProjectDir,
+  resolveClaudeSubagentsDir,
+  startClaudeSubagentActivityMonitor,
+} from "./claude-subagent-progress.js";
+
+describe("encodeClaudeProjectDir", () => {
+  it("encodes slashes and dots the way the Claude CLI does", () => {
+    expect(encodeClaudeProjectDir("/home/bakhtiyar/.openclaw/workspace")).toBe(
+      "-home-bakhtiyar--openclaw-workspace",
+    );
+  });
+});
+
+describe("resolveClaudeSubagentsDir", () => {
+  it("joins ~/.claude/projects/<encoded>/<cliSessionId>/subagents", () => {
+    expect(
+      resolveClaudeSubagentsDir({
+        workspaceDir: "/home/bakhtiyar/.openclaw/workspace",
+        cliSessionId: "e20c5ca6-3197-4641-979c-6a932f589d7f",
+        homeDir: "/home/bakhtiyar",
+      }),
+    ).toBe(
+      "/home/bakhtiyar/.claude/projects/-home-bakhtiyar--openclaw-workspace/e20c5ca6-3197-4641-979c-6a932f589d7f/subagents",
+    );
+  });
+});
+
+describe("startClaudeSubagentActivityMonitor", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function makeDeps(overrides: {
+    readDir?: (dir: string) => Promise<string[]>;
+    statFile?: (file: string) => Promise<{ mtimeMs: number } | null>;
+    now?: () => number;
+  }) {
+    const emit = vi.fn();
+    return {
+      emit,
+      readDir: overrides.readDir ?? (async () => []),
+      statFile: overrides.statFile ?? (async () => null),
+      now: overrides.now ?? (() => 1_000_000),
+    };
+  }
+
+  it("emits run.progress when a subagent JSONL was modified within the freshness window", async () => {
+    const now = 1_000_000;
+    const deps = makeDeps({
+      readDir: async () => ["agent-abc.jsonl", "agent-old.jsonl", "ignore.txt"],
+      statFile: async (file) => {
+        if (file.endsWith("agent-abc.jsonl")) return { mtimeMs: now - 5_000 };
+        if (file.endsWith("agent-old.jsonl")) return { mtimeMs: now - 60_000 };
+        return null;
+      },
+      now: () => now,
+    });
+    const monitor = startClaudeSubagentActivityMonitor({
+      sessionId: "sess-1",
+      sessionKey: "agent:main:invio",
+      workspaceDir: "/home/test/workspace",
+      cliSessionId: "cli-sid",
+      intervalMs: 1_000,
+      freshnessMs: 30_000,
+      deps,
+    });
+    try {
+      await vi.advanceTimersByTimeAsync(1_500);
+      expect(deps.emit).toHaveBeenCalledTimes(1);
+      expect(deps.emit).toHaveBeenCalledWith({
+        sessionId: "sess-1",
+        sessionKey: "agent:main:invio",
+        runId: undefined,
+      });
+    } finally {
+      monitor.stop();
+    }
+  });
+
+  it("does not emit when every JSONL is older than the freshness window", async () => {
+    const now = 1_000_000;
+    const deps = makeDeps({
+      readDir: async () => ["agent-a.jsonl", "agent-b.jsonl"],
+      statFile: async () => ({ mtimeMs: now - 120_000 }),
+      now: () => now,
+    });
+    const monitor = startClaudeSubagentActivityMonitor({
+      workspaceDir: "/w",
+      cliSessionId: "sid",
+      intervalMs: 1_000,
+      freshnessMs: 30_000,
+      deps,
+    });
+    try {
+      await vi.advanceTimersByTimeAsync(3_500);
+      expect(deps.emit).not.toHaveBeenCalled();
+    } finally {
+      monitor.stop();
+    }
+  });
+
+  it("does not emit when the subagents directory does not exist or is empty", async () => {
+    const deps = makeDeps({
+      readDir: async () => [],
+    });
+    const monitor = startClaudeSubagentActivityMonitor({
+      workspaceDir: "/w",
+      cliSessionId: "sid",
+      intervalMs: 1_000,
+      deps,
+    });
+    try {
+      await vi.advanceTimersByTimeAsync(3_500);
+      expect(deps.emit).not.toHaveBeenCalled();
+    } finally {
+      monitor.stop();
+    }
+  });
+
+  it("stops emitting after stop() is called", async () => {
+    const now = 1_000_000;
+    const deps = makeDeps({
+      readDir: async () => ["agent-fresh.jsonl"],
+      statFile: async () => ({ mtimeMs: now - 1_000 }),
+      now: () => now,
+    });
+    const monitor = startClaudeSubagentActivityMonitor({
+      workspaceDir: "/w",
+      cliSessionId: "sid",
+      intervalMs: 1_000,
+      freshnessMs: 30_000,
+      deps,
+    });
+    await vi.advanceTimersByTimeAsync(1_500);
+    expect(deps.emit).toHaveBeenCalledTimes(1);
+    monitor.stop();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(deps.emit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agents/cli-runner/claude-subagent-progress.test.ts
+++ b/src/agents/cli-runner/claude-subagent-progress.test.ts
@@ -54,8 +54,12 @@ describe("startClaudeSubagentActivityMonitor", () => {
     const deps = makeDeps({
       readDir: async () => ["agent-abc.jsonl", "agent-old.jsonl", "ignore.txt"],
       statFile: async (file) => {
-        if (file.endsWith("agent-abc.jsonl")) return { mtimeMs: now - 5_000 };
-        if (file.endsWith("agent-old.jsonl")) return { mtimeMs: now - 60_000 };
+        if (file.endsWith("agent-abc.jsonl")) {
+          return { mtimeMs: now - 5_000 };
+        }
+        if (file.endsWith("agent-old.jsonl")) {
+          return { mtimeMs: now - 60_000 };
+        }
         return null;
       },
       now: () => now,

--- a/src/agents/cli-runner/claude-subagent-progress.ts
+++ b/src/agents/cli-runner/claude-subagent-progress.ts
@@ -33,9 +33,9 @@ const defaultDeps: SubagentActivityMonitorDeps = {
     emitTrustedDiagnosticEvent({
       type: "run.progress",
       reason: "cli:live:subagent",
-      ...(event.sessionId ? { sessionId: event.sessionId } : {}),
-      ...(event.sessionKey ? { sessionKey: event.sessionKey } : {}),
-      ...(event.runId ? { runId: event.runId } : {}),
+      sessionId: event.sessionId,
+      sessionKey: event.sessionKey,
+      runId: event.runId,
     }),
   now: () => Date.now(),
 };
@@ -86,7 +86,7 @@ export function startClaudeSubagentActivityMonitor(params: {
   freshnessMs?: number;
   deps?: Partial<SubagentActivityMonitorDeps>;
 }): { stop: () => void } {
-  const deps: SubagentActivityMonitorDeps = { ...defaultDeps, ...(params.deps ?? {}) };
+  const deps: SubagentActivityMonitorDeps = { ...defaultDeps, ...params.deps };
   const intervalMs = params.intervalMs ?? DEFAULT_INTERVAL_MS;
   const freshnessMs = params.freshnessMs ?? DEFAULT_FRESHNESS_MS;
   const subagentsDir = resolveClaudeSubagentsDir({

--- a/src/agents/cli-runner/claude-subagent-progress.ts
+++ b/src/agents/cli-runner/claude-subagent-progress.ts
@@ -1,0 +1,150 @@
+import { promises as fsPromises } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { emitTrustedDiagnosticEvent } from "../../infra/diagnostic-events.js";
+
+const DEFAULT_INTERVAL_MS = 10_000;
+const DEFAULT_FRESHNESS_MS = 30_000;
+
+export type SubagentActivityMonitorDeps = {
+  readDir: (dir: string) => Promise<string[]>;
+  statFile: (file: string) => Promise<{ mtimeMs: number } | null>;
+  emit: (event: { sessionId?: string; sessionKey?: string; runId?: string }) => void;
+  now: () => number;
+};
+
+const defaultDeps: SubagentActivityMonitorDeps = {
+  readDir: async (dir) => {
+    try {
+      return await fsPromises.readdir(dir);
+    } catch {
+      return [];
+    }
+  },
+  statFile: async (file) => {
+    try {
+      const stat = await fsPromises.stat(file);
+      return { mtimeMs: stat.mtimeMs };
+    } catch {
+      return null;
+    }
+  },
+  emit: (event) =>
+    emitTrustedDiagnosticEvent({
+      type: "run.progress",
+      reason: "cli:live:subagent",
+      ...(event.sessionId ? { sessionId: event.sessionId } : {}),
+      ...(event.sessionKey ? { sessionKey: event.sessionKey } : {}),
+      ...(event.runId ? { runId: event.runId } : {}),
+    }),
+  now: () => Date.now(),
+};
+
+/**
+ * Encode an absolute filesystem path the same way the Claude CLI does when it
+ * computes the per-workspace directory under `~/.claude/projects/<encoded>/`:
+ * every `/` and every `.` becomes `-`.
+ */
+export function encodeClaudeProjectDir(absolutePath: string): string {
+  return absolutePath.replace(/[/.]/g, "-");
+}
+
+export function resolveClaudeSubagentsDir(params: {
+  workspaceDir: string;
+  cliSessionId: string;
+  homeDir?: string;
+}): string {
+  const home = params.homeDir ?? os.homedir();
+  return path.join(
+    home,
+    ".claude",
+    "projects",
+    encodeClaudeProjectDir(params.workspaceDir),
+    params.cliSessionId,
+    "subagents",
+  );
+}
+
+/**
+ * Watch the Claude CLI sub-agent transcript directory for the parent's
+ * CLI session and emit a `run.progress` event (reason `cli:live:subagent`)
+ * whenever a sub-agent JSONL file is being actively written. This keeps the
+ * diagnostic stuck-session watchdog from aborting a parent that is silent
+ * only because it is legitimately waiting on a background `Agent` task.
+ *
+ * The monitor stops on its own if the sub-agent stops touching the file —
+ * a genuinely hung sub-agent still gets aborted, because the parent's
+ * lastProgressAgeMs grows as expected once the file stops moving.
+ */
+export function startClaudeSubagentActivityMonitor(params: {
+  sessionId?: string;
+  sessionKey?: string;
+  runId?: string;
+  workspaceDir: string;
+  cliSessionId: string;
+  intervalMs?: number;
+  freshnessMs?: number;
+  deps?: Partial<SubagentActivityMonitorDeps>;
+}): { stop: () => void } {
+  const deps: SubagentActivityMonitorDeps = { ...defaultDeps, ...(params.deps ?? {}) };
+  const intervalMs = params.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const freshnessMs = params.freshnessMs ?? DEFAULT_FRESHNESS_MS;
+  const subagentsDir = resolveClaudeSubagentsDir({
+    workspaceDir: params.workspaceDir,
+    cliSessionId: params.cliSessionId,
+  });
+  let stopped = false;
+  let running = false;
+
+  const tick = async () => {
+    if (stopped || running) {
+      return;
+    }
+    running = true;
+    try {
+      const entries = await deps.readDir(subagentsDir);
+      const candidates = entries.filter(
+        (name) => name.startsWith("agent-") && name.endsWith(".jsonl"),
+      );
+      if (candidates.length === 0) {
+        return;
+      }
+      let latestMtimeMs = 0;
+      for (const name of candidates) {
+        const stat = await deps.statFile(path.join(subagentsDir, name));
+        if (stat && stat.mtimeMs > latestMtimeMs) {
+          latestMtimeMs = stat.mtimeMs;
+        }
+      }
+      if (latestMtimeMs === 0) {
+        return;
+      }
+      if (deps.now() - latestMtimeMs <= freshnessMs) {
+        deps.emit({
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          runId: params.runId,
+        });
+      }
+    } finally {
+      running = false;
+    }
+  };
+
+  const timer = setInterval(() => {
+    void tick();
+  }, intervalMs);
+  if (typeof timer.unref === "function") {
+    timer.unref();
+  }
+
+  return {
+    stop: () => {
+      if (stopped) {
+        return;
+      }
+      stopped = true;
+      clearInterval(timer);
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- **Problem:** A claude-cli session that launches a background `Agent` (sub-agent) goes quiet on its own stdout until the sub-agent finishes. The diagnostic stuck-session watchdog sees no `cli:live:*` progress, classifies the lane as `stalled_agent_run`, and aborts the parent's `embedded_run` — killing the parent claude process AND the running sub-agent. Real conversation context is lost even though the sub-agent was actively making progress on its own transcript.
- **Solution:** Add a small per-live-session sub-agent activity monitor that polls the Claude CLI's `~/.claude/projects/<encoded-workspace>/<cliSessionId>/subagents/agent-*.jsonl` directory and emits a `run.progress` event (reason `cli:live:subagent`) whenever a sub-agent transcript was touched within the last freshness window. The watchdog now sees genuine progress while the sub-agent is alive.
- **What changed:** new `claude-subagent-progress.ts` (monitor + path resolver + encoder); `claude-live-session.ts` starts the monitor in `createClaudeLiveSession`, stops it in `closeLiveSession` / `handleClaudeExit`; new focused regression coverage.
- **What did NOT change:** the watchdog itself, `stuckSessionAbortMs` defaults, the no-output watchdog, non-claude-cli backends, the `Agent` tool wrapper, or the `embedded_run` abort path. A genuinely hung sub-agent still aborts the parent — the monitor stops emitting as soon as the file stops moving.

## Motivation
On a real install, a routine sub-agent run lasting ~7 minutes was aborted mid-tool-call: the parent claude was silently waiting on a long playwright run inside the sub-agent, and the watchdog mistook the silence for a hang. The parent's `abort_embedded_run` cascaded to the sub-agent process, dropping the entire turn even though the sub-agent's transcript file was being actively written to disk the whole time.

## Change Type
- [x] Bug fix

## Scope
- [x] Integrations (cli-runner / claude-cli backend)
- [x] Diagnostics (run.progress source for the stall watchdog)

## Linked Issue/PR
Related: #84540, #84550 (existing `run.progress` emitters for the CLI execute and live-session stdout paths). This PR adds the missing emitter for the case where the parent's stdout is legitimately quiet because work has moved into a background sub-agent. Checked: fixes a bug/regression.

## Real behavior proof
- **Behavior addressed:** parent claude-cli session aborted with `abort_embedded_run` while its background `Agent` sub-agent was actively writing its own transcript — context lost even though work was happening.
- **Real environment tested:** OpenClaw 2026.5.20 on WSL2 Ubuntu, claude-cli backend (`@anthropic-ai/claude-code`), Anthropic Opus model. Background `Agent` sub-agent runs a playwright smoke suite that takes ~7 min and emits no stdout to the parent during the tool call.
- **Before evidence:** production gateway logs from the affected install:
  ```
  May 23 10:16:50 [diagnostic] long-running session: sessionKey=agent:main:invio age=126s lastProgress=cli:live:stdout lastProgressAge=80s recovery=none
  May 23 10:17:51 [diagnostic] stalled session:    sessionKey=agent:main:invio age=187s lastProgress=cli:live:stdout lastProgressAge=142s recovery=none
  May 23 10:21:57 [diagnostic] stalled session:    sessionKey=agent:main:invio age=433s lastProgress=cli:live:stdout lastProgressAge=141s recovery=checking
  May 23 10:21:57 [diagnostic] stuck session recovery: sessionKey=agent:main:invio age=433s action=abort_embedded_run aborted=true drained=true released=0
  ```
  The sub-agent's transcript (`~/.claude/projects/<encoded>/<cliSessionId>/subagents/agent-a4b4254ffe982b30e.jsonl`) had its last write at `10:19:42`, 2m15s before the abort — proving the sub-agent was alive and working while the parent's `cli:live:stdout` progress stayed silent.
- **Exact steps or command run after this patch:** on the affected install, ran a reproduction harness that drives the patched `startClaudeSubagentActivityMonitor` against a real temp `~/.claude/projects/<encoded>/<sid>/subagents/agent-demo.jsonl` file, touching it for 4 seconds (sub-agent alive) and then leaving it alone for 4 seconds (sub-agent dead):
  ```
  npx tsx cli-subagent-progress-repro.mts
  ```
- **Evidence after fix:** copied live terminal output from the patched run:
  ```
  [harness] subagents dir: /home/bakhtiyar/.claude/projects/-tmp-repro-ws-1779496104783/demo-cli-session/subagents
  [harness] starting monitor (interval=500ms, freshness=2000ms)

  [phase 1] sub-agent writes regularly for 4 seconds
  [emit @  500ms] run.progress cli:live:subagent sessionKey=agent:main:invio
  [emit @ 1000ms] run.progress cli:live:subagent sessionKey=agent:main:invio
  [emit @ 1500ms] run.progress cli:live:subagent sessionKey=agent:main:invio
  [emit @ 2000ms] run.progress cli:live:subagent sessionKey=agent:main:invio
  [emit @ 2500ms] run.progress cli:live:subagent sessionKey=agent:main:invio
  [emit @ 3000ms] run.progress cli:live:subagent sessionKey=agent:main:invio
  [emit @ 3500ms] run.progress cli:live:subagent sessionKey=agent:main:invio

  [phase 2] sub-agent stops touching the file; wait 4 seconds
  [emit @ 4000ms] run.progress cli:live:subagent sessionKey=agent:main:invio
  [emit @ 4500ms] run.progress cli:live:subagent sessionKey=agent:main:invio
  [emit @ 5000ms] run.progress cli:live:subagent sessionKey=agent:main:invio
  [emit @ 5500ms] run.progress cli:live:subagent sessionKey=agent:main:invio

  Phase 1 (active sub-agent):    7 progress emits  → parent kept alive
  Phase 2 (dead sub-agent):      4 progress emits   → parent allowed to time out
  RESULT: PASS — monitor emits while sub-agent is alive AND stops emitting once it dies.
  ```
- **Observed result after fix:** while the sub-agent transcript was being touched, the patched monitor emitted `run.progress` with reason `cli:live:subagent` every poll cycle; once the sub-agent stopped writing for longer than the freshness window, emissions ceased and the normal stall-and-abort path resumed. The parent's `lastProgressAgeMs` therefore reflects real sub-agent liveness instead of just the parent's own stdout silence.
- **What was not tested:** a full live gateway end-to-end run on the rebuilt binary — that would require restarting the production gateway and dropping every active session.

## Root Cause
The diagnostic stuck-session watchdog watches `lastProgressAgeMs`, fed by `run.progress` events. The two existing `run.progress` emitters for claude-cli (CLI stdout in #84540 / #84550) only fire when the parent's `claude` process writes JSONL to stdout. When the parent emits an `Agent` tool_use that returns the synchronous "Async agent launched" tool_result, the parent immediately goes quiet — all subsequent work happens in the sub-agent's own process, which writes a separate JSONL under `~/.claude/projects/<encoded-workspace>/<cliSessionId>/subagents/agent-*.jsonl`. OpenClaw had no signal that the sub-agent was still alive, so the watchdog mistook the parent's legitimate wait for a hang and aborted the lane mid-task. Missing guardrail: no progress source for parent-claude-waiting-on-sub-agent.

## Regression Test Plan
- `src/agents/cli-runner/claude-subagent-progress.test.ts`: covers `encodeClaudeProjectDir`, `resolveClaudeSubagentsDir`, and the monitor itself — emit on fresh JSONL, no emit on stale JSONL, no emit on empty/missing directory, no emit after `stop()`. The monitor uses dependency injection for `readDir` / `statFile` / `emit` / `now` so the cases are hermetic.

## User-visible / Behavior Changes
None. Continuity of in-flight sub-agent work is preserved instead of being silently aborted. No UI / API / config surface change.

## Diagram
```
Before: parent emits Agent tool_use -> parent stdout quiet -> stall watchdog -> abort_embedded_run -> sub-agent killed mid-tool
After:  parent emits Agent tool_use -> parent stdout quiet -> sub-agent JSONL still moving -> cli:live:subagent run.progress -> watchdog sees liveness -> sub-agent completes -> parent resumes
```

## Security Impact
- New permissions: No
- New secrets handling: No
- New network calls: No
- New exec surface: No
- New data access: reads directory listing + file stat under `~/.claude/projects/<encoded-workspace>/<cliSessionId>/subagents/` — the same workspace-scoped Claude CLI transcript directory the rest of the cli-runner already reads (e.g. `readClaudeCliFallbackSeed`). No file contents are read by this monitor; only `readdir` + `stat` for mtime comparison.

## Repro + Verification
- **Environment:** claude-cli backend; a parent turn that spawns a background `Agent` tool_use whose sub-agent runs for longer than `stuckSessionAbortMs`.
- **Steps:** trigger the sub-agent (e.g. a long test run); leave the parent claude untouched while the sub-agent works.
- **Expected:** the parent's lane is kept alive by `cli:live:subagent` progress and the sub-agent finishes; the parent receives the completion notification.
- **Actual (before):** `cli session reset: ... abort_embedded_run`; sub-agent killed mid-tool; parent resumed on a new CLI session that has no record of the orphaned async task.

## Evidence
- [x] Failing-then-passing regression coverage (focused on the new monitor)
- [x] Trace logs / terminal capture (before: production logs; after: patched-monitor harness)

## Human Verification
Verified: the four `claude-subagent-progress` cases pass (12 / 12 on the touched files); a reproduction harness driving the real patched monitor against a real `~/.claude/projects/<encoded>/<sid>/subagents/agent-*.jsonl` file shows progress emitted while the file is being touched and emissions cease once the file is no longer being written. NOT verified: a full patched-gateway end-to-end run (would restart the production gateway); `npx tsc --noEmit` was not run (known repo OOM) — checked via transform compilation + import review.

## Review Conversations
- [x] Will resolve bot review threads before merge
- [x] Will respond to maintainer review comments

## Compatibility / Migration
Backward compatible. No config or migration. The monitor runs only inside the claude-cli live-session lifecycle, only when an active `cliSessionId` is present in argv, and is torn down on session close / exit.

## Risks and Mitigations
- The monitor polls a small directory every 10s by default — bounded I/O (one `readdir` + a handful of `stat`s under a per-session path that typically holds 0–5 entries). The interval and freshness window are constants in the monitor file and can be tuned by future maintainers if needed.
- A sub-agent that hangs forever WITHOUT touching its transcript would still be aborted by the watchdog — same as before. Mitigated by the freshness check: only file activity within the last 30s counts as progress.
- The path encoding mirrors the Claude CLI's `~/.claude/projects/<encoded>/` convention; if the upstream Claude CLI changes the encoding the monitor degrades to "no emits", which is the safe default (falls back to the pre-patch watchdog behaviour).