### PR TITLE
fix(daemon): avoid killing unrelated Windows port listeners

### DIFF
--- a/src/daemon/schtasks.stop.test.ts
+++ b/src/daemon/schtasks.stop.test.ts
@@ -133,7 +133,12 @@ describe("Scheduled Task stop/restart cleanup", () => {
         inspectPortUsage.mockResolvedValueOnce(busyPortUsage(4242));
       }
       inspectPortUsage
-        .mockResolvedValueOnce(busyPortUsage(5252))
+        .mockResolvedValueOnce(
+          busyPortUsage(5252, {
+            commandLine:
+              '"C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\steipete\\AppData\\Roaming\\npm\\node_modules\\openclaw\\dist\\index.js" gateway --port 18789',
+          }),
+        )
         .mockResolvedValueOnce(freePortUsage());
 
       await stopScheduledTask({ env, stdout });
@@ -165,6 +170,21 @@ describe("Scheduled Task stop/restart cleanup", () => {
 
       expectGatewayTermination(6262);
       expect(inspectPortUsage).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("does not kill unrelated listeners on the scheduled task port", async () => {
+    await withPreparedGatewayTask(async ({ env, stdout }) => {
+      pushSuccessfulSchtasksResponses(3);
+      findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([]);
+      inspectPortUsage.mockResolvedValue(busyPortUsage(7331, { command: "wslhost.exe" }));
+
+      await expect(stopScheduledTask({ env, stdout })).rejects.toThrow(
+        "gateway port 18789 is still busy after stop",
+      );
+
+      expect(killProcessTree).not.toHaveBeenCalled();
+      expect(inspectPortUsage.mock.calls.length).toBeGreaterThanOrEqual(28);
     });
   });
 

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -439,6 +439,25 @@ function parsePortFromProgramArguments(programArguments?: string[]): number | nu
   return null;
 }
 
+function collectGatewayListenerPids(
+  listeners: Array<{ pid?: number; commandLine?: string }>,
+): number[] {
+  return Array.from(
+    new Set(
+      listeners
+        .filter(
+          (listener) =>
+            typeof listener.pid === "number" &&
+            listener.commandLine &&
+            isGatewayArgv(parseCmdScriptCommandLine(listener.commandLine), {
+              allowGatewayBinary: true,
+            }),
+        )
+        .map((listener) => listener.pid as number),
+    ),
+  );
+}
+
 async function resolveScheduledTaskPort(env: GatewayServiceEnv): Promise<number | null> {
   const command = await readScheduledTaskCommand(env).catch(() => null);
   return (
@@ -459,31 +478,7 @@ async function resolveScheduledTaskGatewayListenerPids(port: number): Promise<nu
     return [];
   }
 
-  const matchedGatewayPids = Array.from(
-    new Set(
-      diagnostics.listeners
-        .filter(
-          (listener) =>
-            typeof listener.pid === "number" &&
-            listener.commandLine &&
-            isGatewayArgv(parseCmdScriptCommandLine(listener.commandLine), {
-              allowGatewayBinary: true,
-            }),
-        )
-        .map((listener) => listener.pid as number),
-    ),
-  );
-  if (matchedGatewayPids.length > 0) {
-    return matchedGatewayPids;
-  }
-
-  return Array.from(
-    new Set(
-      diagnostics.listeners
-        .map((listener) => listener.pid)
-        .filter((pid): pid is number => typeof pid === "number" && Number.isFinite(pid) && pid > 0),
-    ),
-  );
+  return collectGatewayListenerPids(diagnostics.listeners);
 }
 
 async function resolveListenerBackedScheduledTaskRuntime(
@@ -575,13 +570,7 @@ async function terminateBusyPortListeners(port: number): Promise<number[]> {
   if (diagnostics?.status !== "busy") {
     return [];
   }
-  const pids = Array.from(
-    new Set(
-      diagnostics.listeners
-        .map((listener) => listener.pid)
-        .filter((pid): pid is number => typeof pid === "number" && Number.isFinite(pid) && pid > 0),
-    ),
-  );
+  const pids = collectGatewayListenerPids(diagnostics.listeners);
   for (const pid of pids) {
     await terminateGatewayProcessTree(pid, 300);
   }


### PR DESCRIPTION
## Summary

- Fixes #85289.
- Keeps Windows Scheduled Task stop/restart cleanup scoped to verified OpenClaw Gateway listener command lines after the primary verified-PID lookup misses.
- Stops the fallback cleanup path from terminating arbitrary processes that merely listen on the configured Gateway port, such as WSL2 localhost forwarding helpers.

## Tests

- `node scripts/run-vitest.mjs src/daemon/schtasks.stop.test.ts`
- `node_modules/.bin/oxfmt --check src/daemon/schtasks.ts src/daemon/schtasks.stop.test.ts`
- `git diff --check`

## Real behavior proof

Behavior addressed: `openclaw node stop` / `openclaw node restart` on Windows no longer force-kills unrelated listener PIDs returned by port inspection when they are not identifiable OpenClaw Gateway processes.
Real environment tested: Local macOS OpenClaw checkout on this branch, exercising the real Scheduled Task stop/restart module through the repository Vitest runtime with Windows Scheduled Task and port-inspection dependencies mocked at the process boundary.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/daemon/schtasks.stop.test.ts`.
Evidence after fix: The command exited 0. The new regression case simulates a busy Gateway port owned by `wslhost.exe`; `stopScheduledTask()` reports `gateway port 18789 is still busy after stop` and `killProcessTree` is not called, while the adjacent verified-Gateway listener cases still terminate OpenClaw Gateway command lines.
Observed result after fix: Non-Gateway listener PIDs on the Scheduled Task port are skipped instead of terminated; verified OpenClaw Gateway listeners are still cleaned up.
What was not tested: No live Windows 11 + WSL2 host was available in this scheduled run, so the proof uses the existing Windows Scheduled Task test harness rather than a real WSL2 localhost-forwarding process.
