### PR TITLE
docs: use concrete URLs in markdown examples

### DIFF
--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -11,7 +11,7 @@ Text is supported everywhere; media and reactions vary by channel.
 
 ## Delivery notes
 
-- Telegram replies that contain markdown image syntax, such as `![alt](url)`,
+- Telegram replies that contain markdown image syntax, such as `![alt](https://example.com/image.png)`,
   are converted into media replies on the final outbound path when possible.
 - Slack multi-person DMs route as group chats, so group policy, mention
   behavior, and group-session rules apply to MPIM conversations.

--- a/docs/concepts/markdown-formatting.md
+++ b/docs/concepts/markdown-formatting.md
@@ -32,7 +32,7 @@ stay consistent across channels.
 3. **Render per channel**
    - **Slack:** mrkdwn tokens (bold/italic/strike/code), links as `<url|label>`.
    - **Telegram:** HTML tags (`<b>`, `<i>`, `<s>`, `<code>`, `<pre><code>`, `<a href>`).
-   - **Signal:** plain text + `text-style` ranges; links become `label (url)` when label differs.
+   - **Signal:** plain text + `text-style` ranges; links become `label (https://example.com)` when label differs.
 
 ## IR example
 
@@ -96,10 +96,10 @@ If you need more on chunking behavior across channels, see
 
 ## Link policy
 
-- **Slack:** `[label](url)` -> `<url|label>`; bare URLs remain bare. Autolink
+- **Slack:** `[label](https://example.com)` -> `<url|label>`; bare URLs remain bare. Autolink
   is disabled during parse to avoid double-linking.
-- **Telegram:** `[label](url)` -> `<a href="url">label</a>` (HTML parse mode).
-- **Signal:** `[label](url)` -> `label (url)` unless label matches the URL.
+- **Telegram:** `[label](https://example.com)` -> `<a href="https://example.com">label</a>` (HTML parse mode).
+- **Signal:** `[label](https://example.com)` -> `label (https://example.com)` unless label matches the URL.
 
 ## Spoilers
 

--- a/docs/reference/rich-output-protocol.md
+++ b/docs/reference/rich-output-protocol.md
@@ -45,7 +45,7 @@ Keep `MEDIA:` on its own line, in plain text, with no surrounding formatting.
 
 Plain Markdown image syntax stays text by default. Channels that intentionally
 map Markdown image replies to media attachments opt in at their outbound
-adapter; Telegram does this so `![alt](url)` can still become a media reply.
+adapter; Telegram does this so `![alt](https://example.com/image.png)` can still become a media reply.
 
 These directives are separate. `MEDIA:` and reply/voice tags remain delivery metadata; `[embed ...]` is the web-only rich render path.
 Trusted tool-result media uses the same `MEDIA:` / `[[audio_as_voice]]` parser before delivery, so text tool outputs can still mark an audio attachment as a voice note.


### PR DESCRIPTION
## Summary
- replace placeholder `url` targets in inline markdown examples with concrete `https://example.com/...` URLs
- do the same for markdown image examples used in channel docs

## Why
Several docs pages currently use inline examples like `[label](url)` and `![alt](url)` outside code fences. In rendered docs, those become broken relative links instead of readable example markup.

## Testing
- inspect `docs/concepts/markdown-formatting.md`
- inspect `docs/reference/rich-output-protocol.md`
- inspect `docs/channels/index.md`
