### PR TITLE
fix: preserve message-tool delivery evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Docs: https://docs.openclaw.ai
 - Restore Control UI gateway token pairing [AI]. (#85459) Thanks @pgondhi987.
 - OpenAI video: honor configured provider request private-network opt-in for local/custom video endpoints so explicitly trusted mock and self-hosted providers are not blocked. Thanks @shakkernerd.
 - OpenAI video: send uploaded video edit requests to the documented `/videos/edits` endpoint with a `video` file instead of posting MP4 references to `/videos`. Thanks @shakkernerd.
+- Agents/channels: preserve message-tool delivery evidence through gateway agent completion handoffs so successful generated media sends are not followed by false failure messages. Thanks @shakkernerd.
 - CLI/update: repair managed npm plugin `openclaw` peer links during post-core convergence and reject stale or wrong-target peer links before restart. (#83794) Thanks @fuller-stack-dev.
 - CLI/agents: default new omitted-account bindings to all accounts when the channel has multiple configured accounts, and clarify account-scope docs. (#49769) Thanks @Gcaufy.
 - Codex app-server: let authorized `/codex` control commands such as `/codex detach` escape plugin-owned conversation bindings while keeping unknown or unauthorized slash text routed to the bound plugin. Fixes #85157. (#85188) Thanks @TurboTheTurtle.

--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -610,6 +610,54 @@ describe("normalizeAgentCommandReplyPayloads", () => {
     expect(delivered.meta.fallbackFrom).toBe("gateway");
   });
 
+  it("preserves committed message-tool delivery evidence when automatic delivery is disabled", async () => {
+    const runtime = { log: vi.fn(), error: vi.fn() };
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: runtime as never,
+      opts: {
+        message: "completion handoff",
+        deliver: false,
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [],
+      result: {
+        ...createResult(),
+        didSendViaMessagingTool: true,
+        messagingToolSentTexts: ["The image is ready."],
+        messagingToolSentMediaUrls: ["/tmp/generated-image.png"],
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "telegram",
+            to: "telegram:-100123",
+            threadId: "22",
+            text: "The image is ready.",
+            mediaUrls: ["/tmp/generated-image.png"],
+          },
+        ],
+      } as RunResult,
+    });
+
+    expect(delivered.didSendViaMessagingTool).toBe(true);
+    expect(delivered.messagingToolSentTexts).toEqual(["The image is ready."]);
+    expect(delivered.messagingToolSentMediaUrls).toEqual(["/tmp/generated-image.png"]);
+    expect(delivered.messagingToolSentTargets).toEqual([
+      {
+        tool: "message",
+        provider: "telegram",
+        to: "telegram:-100123",
+        threadId: "22",
+        text: "The image is ready.",
+        mediaUrls: ["/tmp/generated-image.png"],
+      },
+    ]);
+    expect(deliverOutboundPayloadsMock).not.toHaveBeenCalled();
+  });
+
   it("adds sent deliveryStatus to JSON output after delivery completes", async () => {
     deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "slack", messageId: "msg-1" }]);
     const runtime = {

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -27,6 +27,7 @@ import type { OutboundSessionContext } from "../../infra/outbound/session-contex
 import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import { isNestedAgentLane } from "../lanes.js";
+import type { MessagingToolSend } from "../pi-embedded-messaging.types.js";
 import type { EmbeddedPiRunMeta } from "../pi-embedded-runner/types.js";
 import type { AgentCommandOpts, AgentCommandResultMetaOverrides } from "./types.js";
 
@@ -67,6 +68,10 @@ export type AgentCommandDeliveryStatus = {
 export type AgentCommandDeliveryResult = {
   payloads: ReturnType<typeof projectOutboundPayloadPlanForJson>;
   meta: EmbeddedPiRunMeta & AgentCommandResultMetaOverrides;
+  didSendViaMessagingTool?: boolean;
+  messagingToolSentTexts?: string[];
+  messagingToolSentMediaUrls?: string[];
+  messagingToolSentTargets?: MessagingToolSend[];
   deliverySucceeded?: boolean;
   deliveryStatus?: AgentCommandDeliveryStatus;
 };
@@ -156,6 +161,45 @@ function mergeResultMetaOverrides(
   return {
     ...meta,
     ...overrides,
+  };
+}
+
+function hasNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function hasNonEmptyStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.some(hasNonEmptyString);
+}
+
+function hasNonEmptyArray<T>(value: T[] | undefined): value is T[] {
+  return Array.isArray(value) && value.length > 0;
+}
+
+function buildDeliveryResult(params: {
+  payloads: AgentCommandDeliveryResult["payloads"];
+  meta: AgentCommandDeliveryResult["meta"];
+  result: RunResult;
+  deliverySucceeded?: boolean;
+  deliveryStatus?: AgentCommandDeliveryStatus;
+}): AgentCommandDeliveryResult {
+  return {
+    payloads: params.payloads,
+    meta: params.meta,
+    ...(params.result.didSendViaMessagingTool === true ? { didSendViaMessagingTool: true } : {}),
+    ...(hasNonEmptyStringArray(params.result.messagingToolSentTexts)
+      ? { messagingToolSentTexts: params.result.messagingToolSentTexts }
+      : {}),
+    ...(hasNonEmptyStringArray(params.result.messagingToolSentMediaUrls)
+      ? { messagingToolSentMediaUrls: params.result.messagingToolSentMediaUrls }
+      : {}),
+    ...(hasNonEmptyArray(params.result.messagingToolSentTargets)
+      ? { messagingToolSentTargets: params.result.messagingToolSentTargets }
+      : {}),
+    ...(params.deliverySucceeded !== undefined
+      ? { deliverySucceeded: params.deliverySucceeded }
+      : {}),
+    ...(params.deliveryStatus ? { deliveryStatus: params.deliveryStatus } : {}),
   };
 }
 
@@ -611,12 +655,13 @@ export async function deliverAgentCommandResult(
     deliveryStatus = deliver ? (deliveryStatus ?? noVisiblePayloadStatus()) : undefined;
     const deliverySucceeded = deliveryStatus?.succeeded === true ? true : undefined;
     emitJsonEnvelope(deliveryStatus);
-    return {
+    return buildDeliveryResult({
       payloads: normalizedPayloads,
       meta: resultMeta,
-      ...(deliverySucceeded !== undefined ? { deliverySucceeded } : {}),
-      ...(deliveryStatus ? { deliveryStatus } : {}),
-    };
+      result,
+      deliverySucceeded,
+      deliveryStatus,
+    });
   }
 
   let deliverySucceeded = false;
@@ -639,7 +684,7 @@ export async function deliverAgentCommandResult(
       logPayload(payload);
     }
     emitJsonEnvelope();
-    return { payloads: normalizedPayloads, meta: resultMeta };
+    return buildDeliveryResult({ payloads: normalizedPayloads, meta: resultMeta, result });
   }
   if (deliver && deliveryChannel && !isInternalMessageChannel(deliveryChannel)) {
     if (deliveryTarget && !deliveryStatus) {
@@ -682,5 +727,11 @@ export async function deliverAgentCommandResult(
   }
 
   emitJsonEnvelope(deliveryStatus);
-  return { payloads: normalizedPayloads, meta: resultMeta, deliverySucceeded, deliveryStatus };
+  return buildDeliveryResult({
+    payloads: normalizedPayloads,
+    meta: resultMeta,
+    result,
+    deliverySucceeded,
+    deliveryStatus,
+  });
 }


### PR DESCRIPTION
## Summary

- Preserve committed message-tool delivery evidence on `agentCommand` completion results.
- Keep generated-media/text sends from being followed by false failure handling when the message tool already delivered the response.
- Add regression coverage for the no-automatic-delivery handoff path.

## Verification

- `git diff --check origin/main...HEAD`
- `node scripts/run-vitest.mjs src/agents/command/delivery.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: gateway agent completion handoffs now retain `didSendViaMessagingTool`, sent texts, sent media URLs, and sent targets when the embedded message tool already delivered output.

Real environment tested: local OpenClaw source checkout.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/command/delivery.test.ts`

Evidence after fix: the regression test verifies that message-tool evidence is preserved when automatic delivery is disabled and no extra outbound delivery is attempted.

Observed result after fix: targeted delivery tests passed, and autoreview reported no accepted/actionable findings.
