### PR TITLE
fix(agents): mirror internal ui message tool replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Docs: https://docs.openclaw.ai
 
 - Windows installer: fail Git checkout installs when `pnpm install` or `pnpm build` fails instead of writing a wrapper to a missing CLI build.
 - Sessions: surface previous-transcript archive failures during `/new` rotation so disk rename errors are logged instead of silently hiding stranded transcript files. Fixes #81984. (#85586, from #82081) Thanks @0xghost42.
+- TUI/agents: mirror internal-ui message-tool replies into final chat output so message-tool-only agents remain visible in `openclaw tui`. Fixes #85538. Thanks @danpolasek.
 - Agents: keep parallel OpenAI-compatible tool-call deltas in separate argument buffers so interleaved tool calls no longer corrupt streamed arguments. (#82263) Thanks @luna-system.
 - Memory/doctor: report missing or unusable QMD workspace directories as workspace failures instead of generic binary failures. (#63167) Thanks @sercada.
 - Debug proxy: record CONNECT client-socket errors and destroy the paired upstream socket so abrupt client disconnects no longer leak tunnel resources. (#82444) Thanks @SebTardif.

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -20,7 +20,10 @@ import {
   normalizeOptionalLowercaseString,
 } from "../../../shared/string-coerce.js";
 import type { EmbeddedContextFile } from "../../pi-embedded-helpers.js";
-import type { MessagingToolSend } from "../../pi-embedded-messaging.types.js";
+import type {
+  MessagingToolSend,
+  MessagingToolSourceReplyPayload,
+} from "../../pi-embedded-messaging.types.js";
 import type { WorkspaceBootstrapFile } from "../../workspace.js";
 
 type SubscribeEmbeddedPiSessionFn =
@@ -104,6 +107,7 @@ export function createSubscriptionMock(): SubscriptionMock {
     getMessagingToolSentTexts: () => [] as string[],
     getMessagingToolSentMediaUrls: () => [] as string[],
     getMessagingToolSentTargets: () => [] as MessagingToolSend[],
+    getMessagingToolSourceReplyPayloads: () => [] as MessagingToolSourceReplyPayload[],
     getHeartbeatToolResponse: () => undefined,
     getPendingToolMediaReply: () => null,
     getVisibleBlockReplyCount: () => 0,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -3288,6 +3288,7 @@ export async function runEmbeddedAttempt(
         getMessagingToolSentTexts,
         getMessagingToolSentMediaUrls,
         getMessagingToolSentTargets,
+        getMessagingToolSourceReplyPayloads,
         getHeartbeatToolResponse,
         getPendingToolMediaReply,
         getVisibleBlockReplyCount,
@@ -4704,6 +4705,7 @@ export async function runEmbeddedAttempt(
       const didSendDeterministicApprovalPromptNow = didSendDeterministicApprovalPrompt();
       const lastToolError = getLastToolError?.();
       const heartbeatToolResponse = getHeartbeatToolResponse();
+      const messagingToolSourceReplyPayloads = getMessagingToolSourceReplyPayloads();
       const pendingToolMediaPayloadCount = hasVisiblePendingToolMediaReply(pendingToolMediaReply)
         ? 1
         : 0;
@@ -4725,6 +4727,7 @@ export async function runEmbeddedAttempt(
       const synthesizedPayloadCount =
         visibleBlockReplyCount +
         pendingToolMediaPayloadCount +
+        messagingToolSourceReplyPayloads.length +
         (silentToolResultReplyPayload ? 1 : 0);
       const emptyAssistantReplyIsSilent = shouldTreatEmptyAssistantReplyAsSilent({
         allowEmptyAssistantReplyAsSilent: params.allowEmptyAssistantReplyAsSilent,
@@ -4866,6 +4869,7 @@ export async function runEmbeddedAttempt(
         messagingToolSentTexts: getMessagingToolSentTexts(),
         messagingToolSentMediaUrls: getMessagingToolSentMediaUrls(),
         messagingToolSentTargets: getMessagingToolSentTargets(),
+        messagingToolSourceReplyPayloads,
         heartbeatToolResponse,
         toolMediaUrls: pendingToolMediaReply?.mediaUrls,
         toolAudioAsVoice: pendingToolMediaReply?.audioAsVoice,

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -1429,6 +1429,7 @@ describe("messaging tool media URL tracking", () => {
           status: "ok",
           deliveryStatus: "sent",
           sourceReplySink: "internal-ui",
+          idempotencyKey: "stable-source-reply",
           sourceReply: {
             text: "visible in tui",
             mediaUrls: ["file:///tmp/reply.png"],
@@ -1444,6 +1445,7 @@ describe("messaging tool media URL tracking", () => {
         text: "visible in tui",
         mediaUrls: ["file:///tmp/reply.png"],
         channelData: { source: "tui" },
+        idempotencyKey: "stable-source-reply",
       },
     ]);
   });

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -63,6 +63,7 @@ function createTestContext(): {
       messagingToolSentTexts: [],
       messagingToolSentTextsNormalized: [],
       messagingToolSentMediaUrls: [],
+      messagingToolSourceReplyPayloads: [],
       messagingToolSentTargets: [],
       successfulCronAdds: 0,
       deterministicApprovalPromptSent: false,
@@ -1405,6 +1406,93 @@ describe("messaging tool media URL tracking", () => {
       text: "track ready",
       mediaUrls: ["/tmp/generated-song.mp3", "/tmp/generated-cover.png"],
     });
+  });
+
+  it("commits internal-ui source replies from successful message sends", async () => {
+    const { ctx } = createTestContext();
+
+    const startEvt: ToolExecutionStartEvent = {
+      type: "tool_execution_start",
+      toolName: "message",
+      toolCallId: "tool-internal-source-reply",
+      args: { action: "send", message: "visible in tui" },
+    };
+    await handleToolExecutionStart(ctx, startEvt);
+
+    const endEvt: ToolExecutionEndEvent = {
+      type: "tool_execution_end",
+      toolName: "message",
+      toolCallId: "tool-internal-source-reply",
+      isError: false,
+      result: {
+        details: {
+          status: "ok",
+          deliveryStatus: "sent",
+          sourceReplySink: "internal-ui",
+          sourceReply: {
+            text: "visible in tui",
+            mediaUrls: ["file:///tmp/reply.png"],
+            channelData: { source: "tui" },
+          },
+        },
+      },
+    };
+    await handleToolExecutionEnd(ctx, endEvt);
+
+    expect(ctx.state.messagingToolSourceReplyPayloads).toEqual([
+      {
+        text: "visible in tui",
+        mediaUrls: ["file:///tmp/reply.png"],
+        channelData: { source: "tui" },
+      },
+    ]);
+  });
+
+  it("does not commit dry-run or external message sends as internal-ui source replies", async () => {
+    const { ctx } = createTestContext();
+
+    await handleToolExecutionStart(ctx, {
+      type: "tool_execution_start",
+      toolName: "message",
+      toolCallId: "tool-dry-run-source-reply",
+      args: { action: "send", message: "preview" },
+    });
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "message",
+      toolCallId: "tool-dry-run-source-reply",
+      isError: false,
+      result: {
+        details: {
+          status: "ok",
+          deliveryStatus: "dry_run",
+          sourceReplySink: "internal-ui",
+          sourceReply: { text: "preview" },
+        },
+      },
+    });
+
+    await handleToolExecutionStart(ctx, {
+      type: "tool_execution_start",
+      toolName: "message",
+      toolCallId: "tool-external-source-reply",
+      args: { action: "send", to: "channel:123", message: "sent externally" },
+    });
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "message",
+      toolCallId: "tool-external-source-reply",
+      isError: false,
+      result: {
+        details: {
+          status: "ok",
+          deliveryStatus: "sent",
+          sourceReply: { text: "sent externally" },
+        },
+      },
+    });
+
+    expect(ctx.state.messagingToolSourceReplyPayloads).toHaveLength(0);
   });
 
   it("commits sendAttachment args as message delivery evidence", async () => {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -500,6 +500,11 @@ function extractMessagingToolSourceReplyPayload(
   if (channelData) {
     payload.channelData = channelData;
   }
+  const idempotencyKey =
+    readStringField(sourceReply, "idempotencyKey") ?? readStringField(details, "idempotencyKey");
+  if (idempotencyKey) {
+    payload.idempotencyKey = idempotencyKey;
+  }
   return Object.keys(payload).length > 0 ? payload : undefined;
 }
 

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -17,6 +17,7 @@ import {
   emitAgentPatchSummaryEvent,
 } from "../infra/agent-events.js";
 import type { ExecApprovalDecision } from "../infra/exec-approvals.js";
+import { normalizeInteractiveReply, normalizeMessagePresentation } from "../interactive/payload.js";
 import type { PluginHookAfterToolCallEvent } from "../plugins/types.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { normalizeOptionalLowercaseString, readStringValue } from "../shared/string-coerce.js";
@@ -27,6 +28,7 @@ import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import { parseExecApprovalResultText } from "./exec-approval-result.js";
 import { normalizeTextForComparison } from "./pi-embedded-helpers.js";
 import { isMessagingTool, isMessagingToolSendAction } from "./pi-embedded-messaging.js";
+import type { MessagingToolSourceReplyPayload } from "./pi-embedded-messaging.types.js";
 import { mergeEmbeddedRunReplayState } from "./pi-embedded-runner/replay-state.js";
 import type {
   ToolCallSummary,
@@ -423,6 +425,82 @@ function collectMessagingMediaUrlsFromToolResult(result: unknown): string[] {
   }
 
   return urls;
+}
+
+function readRecordField(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function readStringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function readStringArrayField(record: Record<string, unknown>, key: string): string[] | undefined {
+  const value = record[key];
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const strings = value.filter(
+    (item): item is string => typeof item === "string" && item.trim().length > 0,
+  );
+  return strings.length ? strings : undefined;
+}
+
+function copyRecordField(
+  record: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | undefined {
+  const value = record[key];
+  return readRecordField(value) ? { ...(value as Record<string, unknown>) } : undefined;
+}
+
+function extractMessagingToolSourceReplyPayload(
+  result: unknown,
+): MessagingToolSourceReplyPayload | undefined {
+  const details = readToolResultDetailsRecord(result);
+  if (!details || details.sourceReplySink !== "internal-ui") {
+    return undefined;
+  }
+  const status = normalizeOptionalLowercaseString(details.deliveryStatus);
+  if (status && status !== "sent") {
+    return undefined;
+  }
+  const sourceReply = readRecordField(details.sourceReply) ?? details;
+  const payload: MessagingToolSourceReplyPayload = {};
+  const text = readStringField(sourceReply, "text") ?? readStringField(details, "message");
+  if (text) {
+    payload.text = text;
+  }
+  const mediaUrl = readStringField(sourceReply, "mediaUrl") ?? readStringField(details, "mediaUrl");
+  if (mediaUrl) {
+    payload.mediaUrl = mediaUrl;
+  }
+  const mediaUrls =
+    readStringArrayField(sourceReply, "mediaUrls") ?? readStringArrayField(details, "mediaUrls");
+  if (mediaUrls) {
+    payload.mediaUrls = mediaUrls;
+  }
+  const audioAsVoice =
+    sourceReply.audioAsVoice === true || details.audioAsVoice === true ? true : undefined;
+  if (audioAsVoice) {
+    payload.audioAsVoice = true;
+  }
+  const presentation = normalizeMessagePresentation(sourceReply.presentation);
+  if (presentation) {
+    payload.presentation = presentation;
+  }
+  const interactive = normalizeInteractiveReply(sourceReply.interactive);
+  if (interactive) {
+    payload.interactive = interactive;
+  }
+  const channelData = copyRecordField(sourceReply, "channelData");
+  if (channelData) {
+    payload.channelData = channelData;
+  }
+  return Object.keys(payload).length > 0 ? payload : undefined;
 }
 
 function queuePendingToolMedia(
@@ -1031,6 +1109,11 @@ export async function handleToolExecutionEnd(
   if (!isToolError && isMessagingSend) {
     if (committedMediaUrls.length > 0) {
       ctx.state.messagingToolSentMediaUrls.push(...committedMediaUrls);
+      ctx.trimMessagingToolSent();
+    }
+    const sourceReplyPayload = extractMessagingToolSourceReplyPayload(result);
+    if (sourceReplyPayload) {
+      ctx.state.messagingToolSourceReplyPayloads.push(sourceReplyPayload);
       ctx.trimMessagingToolSent();
     }
   }

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -7,7 +7,10 @@ import type { InlineCodeState } from "../markdown/code-spans.js";
 import type { HookRunner } from "../plugins/hooks.js";
 import type { AcceptedSessionSpawn } from "./accepted-session-spawn.js";
 import type { EmbeddedBlockChunker } from "./pi-embedded-block-chunker.js";
-import type { MessagingToolSend } from "./pi-embedded-messaging.types.js";
+import type {
+  MessagingToolSend,
+  MessagingToolSourceReplyPayload,
+} from "./pi-embedded-messaging.types.js";
 import type { BlockReplyPayload } from "./pi-embedded-payloads.js";
 import type { EmbeddedRunReplayState } from "./pi-embedded-runner/replay-state.js";
 import type { EmbeddedRunLivenessState } from "./pi-embedded-runner/types.js";
@@ -103,6 +106,7 @@ export type EmbeddedPiSubscribeState = {
   messagingToolSentTargets: MessagingToolSend[];
   heartbeatToolResponse?: HeartbeatToolResponse;
   messagingToolSentMediaUrls: string[];
+  messagingToolSourceReplyPayloads: MessagingToolSourceReplyPayload[];
   pendingMessagingTexts: Map<string, string>;
   pendingMessagingTargets: Map<string, MessagingToolSend>;
   successfulCronAdds: number;
@@ -224,6 +228,7 @@ type ToolHandlerState = Pick<
   | "messagingToolSentTexts"
   | "messagingToolSentTextsNormalized"
   | "messagingToolSentMediaUrls"
+  | "messagingToolSourceReplyPayloads"
   | "messagingToolSentTargets"
   | "heartbeatToolResponse"
   | "successfulCronAdds"

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-message-end-block-replies-message-tool.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-message-end-block-replies-message-tool.test.ts
@@ -96,6 +96,29 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(subscription.getMessagingToolSentMediaUrls()).toEqual(["file:///tmp/render.mp4"]);
   });
 
+  it("tracks internal-ui source replies for message-tool-only final payloads", async () => {
+    const { emit, subscription } = createBlockReplyHarness("message_end");
+
+    await emitMessageToolLifecycle({
+      emit,
+      toolCallId: "tool-message-source-reply",
+      message: "Visible terminal answer.",
+      result: {
+        details: {
+          status: "ok",
+          deliveryStatus: "sent",
+          sourceReplySink: "internal-ui",
+          sourceReply: { text: "Visible terminal answer." },
+        },
+      },
+    });
+    await Promise.resolve();
+
+    expect(subscription.getMessagingToolSourceReplyPayloads()).toEqual([
+      { text: "Visible terminal answer." },
+    ]);
+  });
+
   it("suppresses text-only tool summaries after message-tool-only delivery", async () => {
     const onToolResult = vi.fn();
     const { emit } = createSubscribedSessionHarness({

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -185,6 +185,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     messagingToolSentTargets: [],
     heartbeatToolResponse: undefined,
     messagingToolSentMediaUrls: [],
+    messagingToolSourceReplyPayloads: [],
     pendingMessagingTexts: new Map(),
     pendingMessagingTargets: new Map(),
     successfulCronAdds: 0,
@@ -215,6 +216,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   const messagingToolSentTextsNormalized = state.messagingToolSentTextsNormalized;
   const messagingToolSentTargets = state.messagingToolSentTargets;
   const messagingToolSentMediaUrls = state.messagingToolSentMediaUrls;
+  const messagingToolSourceReplyPayloads = state.messagingToolSourceReplyPayloads;
   const pendingMessagingTexts = state.pendingMessagingTexts;
   const pendingMessagingTargets = state.pendingMessagingTargets;
   const pendingBlockReplyTasks = new Set<Promise<void>>();
@@ -375,6 +377,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   const MAX_MESSAGING_SENT_TEXTS = 200;
   const MAX_MESSAGING_SENT_TARGETS = 200;
   const MAX_MESSAGING_SENT_MEDIA_URLS = 200;
+  const MAX_MESSAGING_SOURCE_REPLY_PAYLOADS = 200;
   const trimMessagingToolSent = () => {
     if (messagingToolSentTexts.length > MAX_MESSAGING_SENT_TEXTS) {
       const overflow = messagingToolSentTexts.length - MAX_MESSAGING_SENT_TEXTS;
@@ -388,6 +391,11 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     if (messagingToolSentMediaUrls.length > MAX_MESSAGING_SENT_MEDIA_URLS) {
       const overflow = messagingToolSentMediaUrls.length - MAX_MESSAGING_SENT_MEDIA_URLS;
       messagingToolSentMediaUrls.splice(0, overflow);
+    }
+    if (messagingToolSourceReplyPayloads.length > MAX_MESSAGING_SOURCE_REPLY_PAYLOADS) {
+      const overflow =
+        messagingToolSourceReplyPayloads.length - MAX_MESSAGING_SOURCE_REPLY_PAYLOADS;
+      messagingToolSourceReplyPayloads.splice(0, overflow);
     }
   };
 
@@ -968,6 +976,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     messagingToolSentTextsNormalized.length = 0;
     messagingToolSentTargets.length = 0;
     messagingToolSentMediaUrls.length = 0;
+    messagingToolSourceReplyPayloads.length = 0;
     pendingMessagingTexts.clear();
     pendingMessagingTargets.clear();
     state.successfulCronAdds = 0;
@@ -1135,6 +1144,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     getMessagingToolSentTexts: () => messagingToolSentTexts.slice(),
     getMessagingToolSentMediaUrls: () => messagingToolSentMediaUrls.slice(),
     getMessagingToolSentTargets: () => messagingToolSentTargets.slice(),
+    getMessagingToolSourceReplyPayloads: () => messagingToolSourceReplyPayloads.slice(),
     getHeartbeatToolResponse: () =>
       state.heartbeatToolResponse ? { ...state.heartbeatToolResponse } : undefined,
     getPendingToolMediaReply: () => readPendingToolMediaReply(state),

--- a/src/agents/pi-tool-handler-state.test-helpers.ts
+++ b/src/agents/pi-tool-handler-state.test-helpers.ts
@@ -22,6 +22,7 @@ export function createBaseToolHandlerState() {
     messagingToolSentTexts: [] as string[],
     messagingToolSentTextsNormalized: [] as string[],
     messagingToolSentMediaUrls: [] as string[],
+    messagingToolSourceReplyPayloads: [],
     messagingToolSentTargets: [] as unknown[],
     deterministicApprovalPromptSent: false,
     blockBuffer: "",

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -201,10 +201,22 @@ function objectFieldEquals(entry: FixtureLogEntry, field: string, value: unknown
 async function writeTuiPtyFixtureScript(dir: string) {
   const scriptPath = path.join(dir, "run-tui-pty-fixture.ts");
   const tuiModuleUrl = pathToFileURL(path.join(process.cwd(), "src/tui/tui.ts")).href;
+  const payloadsModuleUrl = pathToFileURL(
+    path.join(process.cwd(), "src/agents/pi-embedded-runner/run/payloads.ts"),
+  ).href;
+  const replyPayloadModuleUrl = pathToFileURL(
+    path.join(process.cwd(), "src/auto-reply/reply-payload.ts"),
+  ).href;
+  const outboundPayloadsModuleUrl = pathToFileURL(
+    path.join(process.cwd(), "src/infra/outbound/payloads.ts"),
+  ).href;
   await writeFile(
     scriptPath,
     `
       import { appendFileSync } from "node:fs";
+      import { buildEmbeddedRunPayloads } from ${JSON.stringify(payloadsModuleUrl)};
+      import { getReplyPayloadMetadata } from ${JSON.stringify(replyPayloadModuleUrl)};
+      import { normalizeReplyPayloadsForDelivery } from ${JSON.stringify(outboundPayloadsModuleUrl)};
       import type { TuiBackend } from ${JSON.stringify(tuiModuleUrl.replace("/tui.ts", "/tui-backend.ts"))};
       import { runTui } from ${JSON.stringify(tuiModuleUrl)};
 
@@ -232,6 +244,32 @@ async function writeTuiPtyFixtureScript(dir: string) {
         };
       }
 
+      function assistantMessageFromSourceReplyPayloads(payloads: ReturnType<typeof buildEmbeddedRunPayloads>) {
+        if (payloads.length === 0) {
+          throw new Error("expected source reply payload");
+        }
+        for (const payload of payloads) {
+          const metadata = getReplyPayloadMetadata(payload);
+          if (!metadata?.sourceReplyTranscriptMirror) {
+            throw new Error("expected source reply transcript mirror metadata");
+          }
+          record("sourceReplyMetadata", metadata.sourceReplyTranscriptMirror);
+        }
+        const normalized = normalizeReplyPayloadsForDelivery(payloads);
+        const content = normalized.flatMap((payload) => {
+          const text = payload.text?.trim();
+          return text ? [{ type: "text", text }] : [];
+        });
+        if (content.length === 0) {
+          throw new Error("expected displayable source reply content");
+        }
+        return {
+          role: "assistant",
+          content,
+          timestamp: Date.now(),
+        };
+      }
+
       class FixtureBackend implements TuiBackend {
         connection = { url: "pty-fixture://local" };
         onEvent?: TuiBackend["onEvent"];
@@ -254,18 +292,38 @@ async function writeTuiPtyFixtureScript(dir: string) {
           });
           const runId = opts.runId ?? "run-pty-fixture";
           const responseDelayMs = opts.message === "slow prompt" ? 500 : 20;
+          const isSourceReplyProof = opts.message === "message tool only source reply proof";
           setTimeout(() => {
+            const sourceReplyPayloads = isSourceReplyProof
+              ? buildEmbeddedRunPayloads({
+                  assistantTexts: [],
+                  toolMetas: [],
+                  lastAssistant: undefined,
+                  inlineToolResultsAllowed: false,
+                  sessionKey: opts.sessionKey,
+                  sourceReplyDeliveryMode: "message_tool_only",
+                  messagingToolSourceReplyPayloads: [
+                    {
+                      text: "VISIBLE_TUI_SOURCE_REPLY_PROOF",
+                    },
+                  ],
+                  runId,
+                })
+              : [];
+            const message = isSourceReplyProof
+              ? assistantMessageFromSourceReplyPayloads(sourceReplyPayloads)
+              : {
+                  role: "assistant",
+                  content: [{ type: "text", text: "PTY_RESPONSE: " + opts.message }],
+                  timestamp: Date.now(),
+                };
             this.onEvent?.({
               event: "chat",
               payload: {
                 runId,
                 sessionKey: opts.sessionKey,
                 state: "final",
-                message: {
-                  role: "assistant",
-                  content: [{ type: "text", text: "PTY_RESPONSE: " + opts.message }],
-                  timestamp: Date.now(),
-                },
+                message,
               },
             });
           }, responseDelayMs);
@@ -434,6 +492,25 @@ describe.sequential("TUI PTY harness", () => {
       await fixture.waitForLogEntry(
         (entry) =>
           entry.method === "sendChat" && objectFieldEquals(entry, "message", "second prompt"),
+      );
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "renders message-tool-only internal ui source replies in the terminal",
+    async () => {
+      await fixture.run.write("message tool only source reply proof\r");
+      await fixture.run.waitForOutput("VISIBLE_TUI_SOURCE_REPLY_PROOF");
+      await fixture.waitForLogEntry(
+        (entry) =>
+          entry.method === "sendChat" &&
+          objectFieldEquals(entry, "message", "message tool only source reply proof"),
+      );
+      await fixture.waitForLogEntry(
+        (entry) =>
+          entry.method === "sourceReplyMetadata" &&
+          objectFieldEquals(entry, "text", "VISIBLE_TUI_SOURCE_REPLY_PROOF"),
       );
     },
     TEST_TIMEOUT_MS,


### PR DESCRIPTION
## Summary
- Capture successful `message.send` tool results that target the internal UI source reply sink.
- Feed those captured source-reply payloads into the existing message-tool-only final payload mirror so `openclaw tui` receives visible output even when trailing assistant text is suppressed.
- Preserve source-reply idempotency keys for retry/redelivery dedupe, keep dry-run and external-channel sends out of the mirror, and cover the regression with focused subscription/payload tests plus a PTY TUI proof test.

## Verification
- `node scripts/run-vitest.mjs src/agents/pi-embedded-subscribe.handlers.tools.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-message-end-block-replies-message-tool.test.ts`
- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/payloads.test.ts src/agents/pi-embedded-runner/run/message-tool-terminal.test.ts`
- `OPENCLAW_TUI_PTY_MIRROR_PATH=.artifacts/pr-85564/tui-source-reply.ansi OPENCLAW_TUI_PTY_COLS=100 OPENCLAW_TUI_PTY_ROWS=30 OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-pty-harness.e2e.test.ts -t "renders message-tool-only internal ui source replies in the terminal" --reporter=verbose`
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_TEST_PROJECTS_SERIAL=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 node scripts/run-vitest.mjs run src/agents/pi-embedded-subscribe.handlers.tools.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-message-end-block-replies-message-tool.test.ts src/agents/pi-embedded-runner/run/payloads.test.ts src/agents/pi-embedded-runner/run/message-tool-terminal.test.ts --reporter=verbose`
- `git diff --check`
- `codex review --base origin/main`
- Testbox-through-Crabbox changed gate: provider=blacksmith-testbox, id=tbx_01ks96aeradhgnxgdxzd6qm4aj, Actions run=https://github.com/openclaw/openclaw/actions/runs/26319490160, command=`corepack pnpm check:changed`

## Real behavior proof
Behavior addressed: TUI/internal UI message-tool-only turns no longer go silent after a successful `message.send`; the same message-tool source reply payload is mirrored into the final chat payload path.
Real environment tested: WSL checkout at `/root/src/openclaw-85538` using the real `runTui()` PTY loop with a fake `TuiBackend`, plus Blacksmith Testbox through Crabbox on Linux for the changed gate.
Exact steps or command run after this patch: `OPENCLAW_TUI_PTY_MIRROR_PATH=.artifacts/pr-85564/tui-source-reply.ansi OPENCLAW_TUI_PTY_COLS=100 OPENCLAW_TUI_PTY_ROWS=30 OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-pty-harness.e2e.test.ts -t "renders message-tool-only internal ui source replies in the terminal" --reporter=verbose`.
Evidence after fix: The PTY test passed and the ANSI mirror contained the visible terminal line `VISIBLE_TUI_SOURCE_REPLY_PROOF`; the fixture also asserted `sourceReplyTranscriptMirror.text` was `VISIBLE_TUI_SOURCE_REPLY_PROOF` before normalizing the payload into the chat final message shown by `runTui()`.
Observed result after fix: `openclaw tui`'s real terminal loop rendered the message-tool-only internal-ui source reply instead of an empty final turn, while the existing focused tests still prove successful internal-ui sends are captured, dry-run/external sends are excluded, and idempotency keys are preserved.
What was not tested: A live interactive Signal plus `openclaw tui` session with real channel credentials; the proof uses the production message-tool source-reply payload builder and real TUI PTY renderer without live Signal auth.

Fixes #85538.