### PR TITLE
Doctor: expose shell completion health findings

### DIFF
--- a/src/commands/doctor-completion.test.ts
+++ b/src/commands/doctor-completion.test.ts
@@ -23,7 +23,7 @@ describe("shell completion health mapping", () => {
     expect(shellCompletionStatusToHealthFindings(current)).toEqual([
       expect.objectContaining({
         checkId: "core/doctor/shell-completion",
-        severity: "warning",
+        severity: "info",
         path: "shellCompletion.zsh",
       }),
     ]);
@@ -48,6 +48,7 @@ describe("shell completion health mapping", () => {
 
     expect(shellCompletionStatusToHealthFindings(current)).toEqual([
       expect.objectContaining({
+        severity: "info",
         message: expect.stringContaining("cache is missing"),
         fixHint: expect.stringContaining("openclaw doctor --fix"),
       }),

--- a/src/commands/doctor-completion.test.ts
+++ b/src/commands/doctor-completion.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  shellCompletionStatusToHealthFindings,
+  shellCompletionStatusToRepairEffects,
+  type ShellCompletionStatus,
+} from "./doctor-completion.js";
+
+function status(overrides: Partial<ShellCompletionStatus> = {}): ShellCompletionStatus {
+  return {
+    shell: "zsh",
+    profileInstalled: true,
+    cacheExists: true,
+    cachePath: "/tmp/openclaw.zsh",
+    usesSlowPattern: false,
+    ...overrides,
+  };
+}
+
+describe("shell completion health mapping", () => {
+  it("reports slow dynamic shell completion with dry-run effects", () => {
+    const current = status({ usesSlowPattern: true, cacheExists: false });
+
+    expect(shellCompletionStatusToHealthFindings(current)).toEqual([
+      expect.objectContaining({
+        checkId: "core/doctor/shell-completion",
+        severity: "warning",
+        path: "shellCompletion.zsh",
+      }),
+    ]);
+    expect(shellCompletionStatusToRepairEffects(current)).toEqual([
+      {
+        kind: "state",
+        action: "would-generate-completion-cache",
+        target: "/tmp/openclaw.zsh",
+        dryRunSafe: true,
+      },
+      {
+        kind: "file",
+        action: "would-upgrade-shell-profile-completion",
+        target: "zsh",
+        dryRunSafe: false,
+      },
+    ]);
+  });
+
+  it("reports missing completion cache with a dry-run cache effect", () => {
+    const current = status({ profileInstalled: true, cacheExists: false });
+
+    expect(shellCompletionStatusToHealthFindings(current)).toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining("cache is missing"),
+        fixHint: expect.stringContaining("openclaw doctor --fix"),
+      }),
+    ]);
+    expect(shellCompletionStatusToRepairEffects(current)).toEqual([
+      {
+        kind: "state",
+        action: "would-regenerate-completion-cache",
+        target: "/tmp/openclaw.zsh",
+        dryRunSafe: true,
+      },
+    ]);
+  });
+
+  it("keeps healthy shell completion quiet", () => {
+    const current = status();
+
+    expect(shellCompletionStatusToHealthFindings(current)).toEqual([]);
+    expect(shellCompletionStatusToRepairEffects(current)).toEqual([]);
+  });
+});

--- a/src/commands/doctor-completion.ts
+++ b/src/commands/doctor-completion.ts
@@ -95,7 +95,7 @@ export function shellCompletionStatusToHealthFindings(
     return [
       {
         checkId,
-        severity: "warning",
+        severity: "info",
         message: `Your ${status.shell} profile uses slow dynamic completion (source <(...)).`,
         path,
         fixHint: "Run `openclaw doctor --fix` to upgrade to cached completion.",
@@ -106,7 +106,7 @@ export function shellCompletionStatusToHealthFindings(
     return [
       {
         checkId,
-        severity: "warning",
+        severity: "info",
         message: `Shell completion is configured in your ${status.shell} profile but the cache is missing.`,
         path,
         fixHint: `Run \`openclaw completion --write-state\` or \`openclaw doctor --fix\` to regenerate ${status.cachePath}.`,

--- a/src/commands/doctor-completion.ts
+++ b/src/commands/doctor-completion.ts
@@ -11,6 +11,7 @@ import {
   resolveShellFromEnv,
   usesSlowDynamicCompletion,
 } from "../cli/completion-runtime.js";
+import type { HealthFinding, HealthRepairEffect } from "../flows/health-checks.js";
 import { resolveOpenClawPackageRoot } from "../infra/openclaw-root.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { note } from "../terminal/note.js";
@@ -83,6 +84,66 @@ export async function checkShellCompletionStatus(
     cachePath,
     usesSlowPattern,
   };
+}
+
+export function shellCompletionStatusToHealthFindings(
+  status: ShellCompletionStatus,
+): readonly HealthFinding[] {
+  const checkId = "core/doctor/shell-completion";
+  const path = `shellCompletion.${status.shell}`;
+  if (status.usesSlowPattern) {
+    return [
+      {
+        checkId,
+        severity: "warning",
+        message: `Your ${status.shell} profile uses slow dynamic completion (source <(...)).`,
+        path,
+        fixHint: "Run `openclaw doctor --fix` to upgrade to cached completion.",
+      },
+    ];
+  }
+  if (status.profileInstalled && !status.cacheExists) {
+    return [
+      {
+        checkId,
+        severity: "warning",
+        message: `Shell completion is configured in your ${status.shell} profile but the cache is missing.`,
+        path,
+        fixHint: `Run \`openclaw completion --write-state\` or \`openclaw doctor --fix\` to regenerate ${status.cachePath}.`,
+      },
+    ];
+  }
+  return [];
+}
+
+export function shellCompletionStatusToRepairEffects(
+  status: ShellCompletionStatus,
+): readonly HealthRepairEffect[] {
+  const effects: HealthRepairEffect[] = [];
+  if (status.usesSlowPattern && !status.cacheExists) {
+    effects.push({
+      kind: "state",
+      action: "would-generate-completion-cache",
+      target: status.cachePath,
+      dryRunSafe: true,
+    });
+  }
+  if (status.usesSlowPattern) {
+    effects.push({
+      kind: "file",
+      action: "would-upgrade-shell-profile-completion",
+      target: status.shell,
+      dryRunSafe: false,
+    });
+  } else if (status.profileInstalled && !status.cacheExists) {
+    effects.push({
+      kind: "state",
+      action: "would-regenerate-completion-cache",
+      target: status.cachePath,
+      dryRunSafe: true,
+    });
+  }
+  return effects;
 }
 
 export type DoctorCompletionOptions = {

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -7,6 +7,11 @@ import {
   type LegacyClawdBrowserProfileResidue,
 } from "../commands/doctor-browser.js";
 import { hasConfiguredCommandOwners } from "../commands/doctor-command-owner.js";
+import {
+  checkShellCompletionStatus,
+  shellCompletionStatusToHealthFindings,
+  shellCompletionStatusToRepairEffects,
+} from "../commands/doctor-completion.js";
 import { disableUnavailableSkillsInConfig } from "../commands/doctor-skills-core.js";
 import type { ConfigValidationIssue, OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveSecretInputRef } from "../config/types.secrets.js";
@@ -715,6 +720,29 @@ const finalConfigValidationCheck: HealthCheck = {
   },
 };
 
+const shellCompletionCheck: HealthCheck = {
+  id: "core/doctor/shell-completion",
+  kind: "core",
+  description: "Shell completion uses the cached completion path when configured.",
+  source: "doctor",
+  async detect() {
+    return shellCompletionStatusToHealthFindings(await checkShellCompletionStatus());
+  },
+  async repair(ctx) {
+    const status = await checkShellCompletionStatus();
+    const effects = shellCompletionStatusToRepairEffects(status);
+    if (ctx.dryRun === true) {
+      return { status: "repaired", changes: [], effects };
+    }
+    return {
+      status: "skipped",
+      reason: "legacy doctor shell-completion repair owns real mutations",
+      changes: [],
+      effects,
+    };
+  },
+};
+
 function createWorkspaceSuggestionsCheck(deps: CoreHealthCheckDeps): HealthCheck {
   return {
     id: "core/doctor/workspace-suggestions",
@@ -742,6 +770,7 @@ function createConvertedWorkflowChecks(deps: CoreHealthCheckDeps): readonly Heal
     gatewayAuthCheck,
     legacyStateCheck,
     legacyWhatsAppCrontabCheck,
+    shellCompletionCheck,
     gatewayPlatformNotesCheck,
     createSecurityCheck(deps),
     browserCheck,

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -8,6 +8,12 @@ import {
 
 const mocks = vi.hoisted(() => ({
   maybeRunConfiguredPluginInstallReleaseStep: vi.fn(),
+  registerCoreHealthChecks: vi.fn(),
+  registerBundledHealthChecks: vi.fn(),
+  runDoctorHealthRepairs: vi.fn(),
+  listHealthChecks: vi.fn(),
+  resolveAgentWorkspaceDir: vi.fn(() => "/tmp/openclaw-workspace"),
+  resolveDefaultAgentId: vi.fn(() => "default"),
   note: vi.fn(),
   replaceConfigFile: vi.fn().mockResolvedValue(undefined),
   readConfigFileSnapshot: vi.fn().mockResolvedValue({
@@ -24,6 +30,27 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("../commands/doctor/shared/release-configured-plugin-installs.js", () => ({
   maybeRunConfiguredPluginInstallReleaseStep: mocks.maybeRunConfiguredPluginInstallReleaseStep,
+}));
+
+vi.mock("./doctor-core-checks.js", () => ({
+  registerCoreHealthChecks: mocks.registerCoreHealthChecks,
+}));
+
+vi.mock("./bundled-health-checks.js", () => ({
+  registerBundledHealthChecks: mocks.registerBundledHealthChecks,
+}));
+
+vi.mock("./doctor-repair-flow.js", () => ({
+  runDoctorHealthRepairs: mocks.runDoctorHealthRepairs,
+}));
+
+vi.mock("./health-check-registry.js", () => ({
+  listHealthChecks: mocks.listHealthChecks,
+}));
+
+vi.mock("../agents/agent-scope.js", () => ({
+  resolveAgentWorkspaceDir: mocks.resolveAgentWorkspaceDir,
+  resolveDefaultAgentId: mocks.resolveDefaultAgentId,
 }));
 
 vi.mock("../terminal/note.js", () => ({
@@ -86,6 +113,30 @@ function buildDoctorPrompter(shouldRepair: boolean): DoctorPrompter {
 describe("doctor health contributions", () => {
   beforeEach(() => {
     mocks.maybeRunConfiguredPluginInstallReleaseStep.mockReset();
+    mocks.registerCoreHealthChecks.mockReset();
+    mocks.registerBundledHealthChecks.mockReset();
+    mocks.runDoctorHealthRepairs.mockReset();
+    mocks.runDoctorHealthRepairs.mockResolvedValue({
+      config: {},
+      findings: [],
+      remainingFindings: [],
+      changes: [],
+      warnings: [],
+      diffs: [],
+      effects: [],
+      checksRun: 0,
+      checksRepaired: 0,
+      checksValidated: 0,
+    });
+    mocks.listHealthChecks.mockReset();
+    mocks.listHealthChecks.mockReturnValue([
+      { id: "core/doctor/shell-completion" },
+      { id: "core/doctor/unrelated" },
+    ]);
+    mocks.resolveAgentWorkspaceDir.mockReset();
+    mocks.resolveAgentWorkspaceDir.mockReturnValue("/tmp/openclaw-workspace");
+    mocks.resolveDefaultAgentId.mockReset();
+    mocks.resolveDefaultAgentId.mockReturnValue("default");
     mocks.note.mockReset();
     mocks.readConfigFileSnapshot.mockReset();
     mocks.readConfigFileSnapshot.mockResolvedValue({
@@ -208,6 +259,27 @@ describe("doctor health contributions", () => {
     expect(ids.indexOf("doctor:structured-health-repairs")).toBeLessThan(
       ids.indexOf("doctor:write-config"),
     );
+  });
+
+  it("keeps legacy positional shell completion out of the broad structured repair pass", async () => {
+    const contribution = requireDoctorContribution("doctor:structured-health-repairs");
+    const ctx = {
+      cfg: {},
+      configResult: { cfg: {} },
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(true),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: {},
+      cfgForPersistence: {},
+      configPath: "/tmp/fake-openclaw.json",
+      env: {},
+    } as Parameters<(typeof contribution)["run"]>[0];
+
+    await contribution.run(ctx);
+
+    expect(mocks.runDoctorHealthRepairs).toHaveBeenCalledWith(expect.any(Object), {
+      checks: [{ id: "core/doctor/unrelated" }],
+    });
   });
 
   it("skips doctor config writes under legacy update parents", () => {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -50,6 +50,8 @@ type DoctorHealthContribution = FlowContribution & {
   run: (ctx: DoctorHealthFlowContext) => Promise<void>;
 };
 
+const LEGACY_POSITIONAL_REPAIR_CHECK_IDS = new Set(["core/doctor/shell-completion"]);
+
 function isUpdateDoctorRun(env: NodeJS.ProcessEnv | Record<string, string | undefined>): boolean {
   const value = env.OPENCLAW_UPDATE_IN_PROGRESS;
   return value === "1" || value === "true";
@@ -243,6 +245,7 @@ async function runStructuredHealthRepairs(ctx: DoctorHealthFlowContext): Promise
   }
   const { registerCoreHealthChecks } = await import("./doctor-core-checks.js");
   const { registerBundledHealthChecks } = await import("./bundled-health-checks.js");
+  const { listHealthChecks } = await import("./health-check-registry.js");
   const { runDoctorHealthRepairs } = await import("./doctor-repair-flow.js");
   const { resolveAgentWorkspaceDir, resolveDefaultAgentId } =
     await import("../agents/agent-scope.js");
@@ -251,13 +254,19 @@ async function runStructuredHealthRepairs(ctx: DoctorHealthFlowContext): Promise
   registerCoreHealthChecks();
   const workspaceDir = resolveAgentWorkspaceDir(ctx.cfg, resolveDefaultAgentId(ctx.cfg));
   registerBundledHealthChecks({ cfg: ctx.cfg, cwd: workspaceDir });
-  const result = await runDoctorHealthRepairs({
-    mode: "fix",
-    runtime: ctx.runtime,
-    cfg: ctx.cfg,
-    cwd: workspaceDir,
-    configPath: ctx.configPath,
-  });
+  const checks = listHealthChecks().filter(
+    (check) => !LEGACY_POSITIONAL_REPAIR_CHECK_IDS.has(check.id),
+  );
+  const result = await runDoctorHealthRepairs(
+    {
+      mode: "fix",
+      runtime: ctx.runtime,
+      cfg: ctx.cfg,
+      cwd: workspaceDir,
+      configPath: ctx.configPath,
+    },
+    { checks },
+  );
   ctx.cfg = result.config;
   if (result.changes.length > 0) {
     note(result.changes.join("\n"), "Doctor changes");

--- a/src/flows/doctor-lint-flow.test.ts
+++ b/src/flows/doctor-lint-flow.test.ts
@@ -92,4 +92,10 @@ describe("exitCodeFromFindings", () => {
     expect(exitCodeFromFindings(findings, "warning")).toBe(1);
     expect(exitCodeFromFindings(findings, "error")).toBe(0);
   });
+
+  it("does not fail default lint for informational findings", () => {
+    const findings = [{ checkId: "a", severity: "info" as const, message: "info" }];
+
+    expect(exitCodeFromFindings(findings)).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

Adds structured doctor visibility for shell-completion health without changing public doctor/plugin SDK contracts:

- reports slow dynamic completion and missing completion caches as `core/doctor/shell-completion` findings
- keeps those findings informational so default `doctor --lint` compatibility is preserved
- adds dry-run repair effects only for the cheap previewable cases
- keeps real shell-completion repair on the existing `doctorShellCompletion` path, outside the broad structured repair pass

This is the small repeatable doctor pattern: expose structured findings first, add effects where honest, and avoid rewriting legacy repair behavior.

## Real behavior proof

Behavior or issue addressed:
Doctor lint and structured repair preview plumbing can now see shell-completion issues as `core/doctor/shell-completion` findings/effects while normal `doctor --fix` still uses the existing shell-completion repair flow. The ClawSweeper compatibility ask is addressed by making these findings informational, so default lint does not newly fail for existing slow or missing-cache shell-completion profiles.

Real environment tested:
WSL Ubuntu 24.04 worktree `/root/src/openclaw-doctor-shell-main`, branch `doctor-core-run-contract-migration`, source harness on head `1344b6d3c1`, Node 24.15.0, pnpm workspace dependencies installed. The terminal proof uses redacted synthetic shell-completion status values and imports the real branch code paths.

Exact steps or command run after this patch:
1. `git diff --check origin/main...HEAD`
2. `node_modules/.bin/oxfmt --check --threads=1 src/commands/doctor-completion.ts src/commands/doctor-completion.test.ts src/flows/doctor-lint-flow.test.ts src/flows/doctor-core-checks.ts src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts`
3. `node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/commands/doctor-completion.ts src/commands/doctor-completion.test.ts src/flows/doctor-lint-flow.test.ts src/flows/doctor-core-checks.ts src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts`
4. `node scripts/run-vitest.mjs src/commands/doctor-completion.test.ts src/flows/doctor-lint-flow.test.ts src/flows/doctor-core-checks.test.ts src/flows/doctor-health-contributions.test.ts --reporter=dot`
5. `node scripts/run-tsgo.mjs -p tsconfig.core.json --noEmit --incremental false --pretty false`
6. `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --noEmit --incremental false --pretty false`
7. `node --import tsx /tmp/85566-proof.mjs`
8. `bash /mnt/c/src/claws-hapi/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Evidence after fix:
Focused validation passed:

```text
git diff --check origin/main...HEAD -> pass
oxfmt -> All matched files use the correct format.
oxlint -> Found 0 warnings and 0 errors.
Vitest -> Test Files 4 passed (4); Tests 35 passed (35)
tsgo core -> pass
tsgo core tests -> pass
autoreview -> clean: no accepted/actionable findings reported
```

Terminal source-harness output from the changed shell-completion mapping and lint exit-code path:

```json
{
  "name": "slowDynamic",
  "findings": [
    {
      "checkId": "core/doctor/shell-completion",
      "severity": "info",
      "message": "Your zsh profile uses slow dynamic completion (source <(...)).",
      "path": "shellCompletion.zsh",
      "fixHint": "Run `openclaw doctor --fix` to upgrade to cached completion."
    }
  ],
  "defaultLintExitCode": 0,
  "effects": [
    {
      "kind": "state",
      "action": "would-generate-completion-cache",
      "target": "/redacted/home/.cache/openclaw/completion.zsh",
      "dryRunSafe": true
    },
    {
      "kind": "file",
      "action": "would-upgrade-shell-profile-completion",
      "target": "zsh",
      "dryRunSafe": false
    }
  ]
}
{
  "name": "missingCache",
  "findings": [
    {
      "checkId": "core/doctor/shell-completion",
      "severity": "info",
      "message": "Shell completion is configured in your zsh profile but the cache is missing.",
      "path": "shellCompletion.zsh",
      "fixHint": "Run `openclaw completion --write-state` or `openclaw doctor --fix` to regenerate /redacted/home/.cache/openclaw/completion.zsh."
    }
  ],
  "defaultLintExitCode": 0,
  "effects": [
    {
      "kind": "state",
      "action": "would-regenerate-completion-cache",
      "target": "/redacted/home/.cache/openclaw/completion.zsh",
      "dryRunSafe": true
    }
  ]
}
```

Observed result after fix:
Both slow dynamic completion and missing cache states produce structured shell-completion findings and dry-run effects, but the findings are `info` and `exitCodeFromFindings(findings)` returns `0`, preserving default lint compatibility. Real mutation remains delegated to the existing positional `doctorShellCompletion` repair path.

What was not tested:
No live shell startup file was modified in this proof. The proof uses a source harness with redacted synthetic shell-completion statuses to exercise the real mapping/effect/exit-code functions; existing shell profile mutation remains covered by the legacy `doctorShellCompletion` path and focused unit coverage.

## Validation

- Local WSL focused format, lint, Vitest, core typecheck, core test typecheck, and autoreview clean on `1344b6d3c1`
- ClawSweeper P1 compatibility ask addressed: shell-completion findings are informational and default lint exit remains zero
- Public plugin SDK contract unchanged by this PR

## Doctor stack

| Order | PR | Area | Status |
| --- | --- | --- | --- |
| 1 | #85566 | Shell completion health findings | Ready after compatibility/proof update; checks pending on latest push |
| 2 | #84290 | UI freshness health findings | Ready; checks passing after latest fix |
| 3 | #84326 | Sandbox registry findings | Ready/checks clean; stale labels may remain |
| 4 | #84340 | Extra gateway service findings | Ready/checks clean; stale labels may remain |
| 5 | #84366 | Session lock findings | Draft; checks/proof passing, keep draft until reviewed |
| 6 | #84450 | Config audit scrub findings | Draft; checks/proof passing, keep draft until reviewed |
| 7 | #84472 | Dry-run preview reports | Draft; broad preview surface, likely last/deferred |
