### PR TITLE
fix(update): allow package-manager hardlinks in swaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/update: allow package-manager-managed hardlinked package roots during global update swaps while keeping generic plugin, hook, and dependency-free install moves fail-closed. (#85569) Thanks @ai-hpc.
 - Gateway/update: avoid fetching unrelated tags during dev-channel git updates so moved release tags do not block branch-based updates. (#84737) Thanks @rubencu.
 - CLI/update: suppress the expected future-config warning while an old update parent hands off to the freshly installed post-core process.
 - MiniMax: store OAuth token expiry as an absolute millisecond timestamp so OAuth profiles no longer appear expired on every request. (#83480) Thanks @NianJiuZst.

--- a/src/infra/install-package-dir.test.ts
+++ b/src/infra/install-package-dir.test.ts
@@ -338,6 +338,7 @@ describe("installPackageDir", () => {
         timeoutMs: 1_000,
         copyErrorPrefix: "failed to copy plugin",
         hasDeps: true,
+        sourceHardlinks: "package-manager",
         depsLogMessage: "Installing deps…",
       });
 
@@ -346,6 +347,44 @@ describe("installPackageDir", () => {
       await expect(
         fs.lstat(path.join(targetDir, "node_modules", "demo-dep", "index.js")),
       ).resolves.toMatchObject({ nlink: 2 });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "requires explicit package-manager hardlink allowance for dependency installs",
+    async () => {
+      await fixtureRootTracker.setup();
+      const fixtureRoot = await fixtureRootTracker.make("case");
+      const { sourceDir, targetDir } = await createExistingInstallFixture(fixtureRoot);
+      await addHardlinkedFile(
+        path.join(targetDir, "marker.txt"),
+        path.join(fixtureRoot, "cache", "existing-marker.txt"),
+      );
+
+      vi.mocked(runCommandWithTimeout).mockResolvedValue({
+        stdout: "",
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      });
+
+      const result = await installPackageDir({
+        sourceDir,
+        targetDir,
+        mode: "update",
+        timeoutMs: 1_000,
+        copyErrorPrefix: "failed to copy plugin",
+        hasDeps: true,
+        depsLogMessage: "Installing deps…",
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain("Hardlinked source file is not allowed");
+      }
+      await expect(fs.readFile(path.join(targetDir, "marker.txt"), "utf8")).resolves.toBe("old");
     },
   );
 

--- a/src/infra/install-package-dir.test.ts
+++ b/src/infra/install-package-dir.test.ts
@@ -149,6 +149,11 @@ async function createExistingInstallFixture(fixtureRoot: string) {
   return { installBaseDir, sourceDir, targetDir };
 }
 
+async function addHardlinkedFile(filePath: string, linkPath: string): Promise<void> {
+  await fs.mkdir(path.dirname(linkPath), { recursive: true });
+  await fs.link(filePath, linkPath);
+}
+
 async function createReboundInstallFixture(params: {
   fixtureRoot: string;
   withExistingInstall?: boolean;
@@ -295,6 +300,54 @@ describe("installPackageDir", () => {
       listMatchingDirs(installBaseDir, ".openclaw-install-stage-"),
     ).resolves.toHaveLength(0);
   });
+
+  it.runIf(process.platform !== "win32")(
+    "updates package-manager installs that contain hardlinked package files",
+    async () => {
+      await fixtureRootTracker.setup();
+      const fixtureRoot = await fixtureRootTracker.make("case");
+      const { sourceDir, targetDir } = await createExistingInstallFixture(fixtureRoot);
+      await addHardlinkedFile(
+        path.join(targetDir, "marker.txt"),
+        path.join(fixtureRoot, "cache", "existing-marker.txt"),
+      );
+
+      vi.mocked(runCommandWithTimeout).mockImplementation(async (_argv, optionsOrTimeout) => {
+        const cwd = typeof optionsOrTimeout === "number" ? undefined : optionsOrTimeout.cwd;
+        if (cwd === undefined) {
+          throw new Error("expected staged package install cwd");
+        }
+        const depFile = path.join(cwd, "node_modules", "demo-dep", "index.js");
+        await fs.mkdir(path.dirname(depFile), { recursive: true });
+        await fs.writeFile(depFile, "module.exports = 1;\n", "utf8");
+        await addHardlinkedFile(depFile, path.join(fixtureRoot, "cache", "staged-dep.js"));
+        return {
+          stdout: "",
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+          termination: "exit",
+        };
+      });
+
+      const result = await installPackageDir({
+        sourceDir,
+        targetDir,
+        mode: "update",
+        timeoutMs: 1_000,
+        copyErrorPrefix: "failed to copy plugin",
+        hasDeps: true,
+        depsLogMessage: "Installing deps…",
+      });
+
+      expect(result).toEqual({ ok: true });
+      await expect(fs.readFile(path.join(targetDir, "marker.txt"), "utf8")).resolves.toBe("new");
+      await expect(
+        fs.lstat(path.join(targetDir, "node_modules", "demo-dep", "index.js")),
+      ).resolves.toMatchObject({ nlink: 2 });
+    },
+  );
 
   it("aborts without outside writes when the install base is rebound before publish", async () => {
     await fixtureRootTracker.setup();

--- a/src/infra/install-package-dir.test.ts
+++ b/src/infra/install-package-dir.test.ts
@@ -349,6 +349,69 @@ describe("installPackageDir", () => {
     },
   );
 
+  it.runIf(process.platform !== "win32")(
+    "keeps hardlinked existing installs rejected for dependency-free updates",
+    async () => {
+      await fixtureRootTracker.setup();
+      const fixtureRoot = await fixtureRootTracker.make("case");
+      const { sourceDir, targetDir } = await createExistingInstallFixture(fixtureRoot);
+      await addHardlinkedFile(
+        path.join(targetDir, "marker.txt"),
+        path.join(fixtureRoot, "cache", "existing-marker.txt"),
+      );
+
+      const result = await installPackageDir({
+        sourceDir,
+        targetDir,
+        mode: "update",
+        timeoutMs: 1_000,
+        copyErrorPrefix: "failed to copy plugin",
+        hasDeps: false,
+        depsLogMessage: "Installing deps…",
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain("Hardlinked source file is not allowed");
+      }
+      await expect(fs.readFile(path.join(targetDir, "marker.txt"), "utf8")).resolves.toBe("old");
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "keeps hardlinked staged installs rejected for dependency-free publishes",
+    async () => {
+      await fixtureRootTracker.setup();
+      const fixtureRoot = await fixtureRootTracker.make("case");
+      const sourceDir = path.join(fixtureRoot, "source");
+      const targetDir = path.join(fixtureRoot, "plugins", "demo");
+      await fs.mkdir(sourceDir, { recursive: true });
+      await fs.writeFile(path.join(sourceDir, "marker.txt"), "new");
+
+      const result = await installPackageDir({
+        sourceDir,
+        targetDir,
+        mode: "install",
+        timeoutMs: 1_000,
+        copyErrorPrefix: "failed to copy plugin",
+        hasDeps: false,
+        depsLogMessage: "Installing deps…",
+        afterCopy: async (installedDir) => {
+          await addHardlinkedFile(
+            path.join(installedDir, "marker.txt"),
+            path.join(fixtureRoot, "cache", "staged-marker.txt"),
+          );
+        },
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain("Hardlinked source file is not allowed");
+      }
+      await expectMissingPath(path.join(targetDir, "marker.txt"));
+    },
+  );
+
   it("aborts without outside writes when the install base is rebound before publish", async () => {
     await fixtureRootTracker.setup();
     const fixtureRoot = await fixtureRootTracker.make("case");

--- a/src/infra/install-package-dir.ts
+++ b/src/infra/install-package-dir.ts
@@ -7,6 +7,7 @@ import { tryReadJson, writeJson } from "./json-files.js";
 import { movePathWithCopyFallback } from "./replace-file.js";
 import { createSafeNpmInstallArgs, createSafeNpmInstallEnv } from "./safe-package-install.js";
 
+const PACKAGE_MANAGER_INSTALL_SOURCE_HARDLINKS = "allow" as const;
 const INSTALL_BASE_CHANGED_ERROR_MESSAGE = "install base directory changed during install";
 const INSTALL_BASE_CHANGED_ABORT_WARNING =
   "Install base directory changed during install; aborting staged publish.";
@@ -213,7 +214,7 @@ export async function installPackageDir(params: {
     }
     await movePathWithCopyFallback({
       from: backupDir,
-      sourceHardlinks: "reject",
+      sourceHardlinks: PACKAGE_MANAGER_INSTALL_SOURCE_HARDLINKS,
       to: canonicalTargetDir,
     }).catch(() => undefined);
     backupDir = null;
@@ -300,7 +301,7 @@ export async function installPackageDir(params: {
       });
       await movePathWithCopyFallback({
         from: canonicalTargetDir,
-        sourceHardlinks: "reject",
+        sourceHardlinks: PACKAGE_MANAGER_INSTALL_SOURCE_HARDLINKS,
         to: backupDir,
       });
     } catch (err) {
@@ -315,7 +316,7 @@ export async function installPackageDir(params: {
     });
     await movePathWithCopyFallback({
       from: stageDir,
-      sourceHardlinks: "reject",
+      sourceHardlinks: PACKAGE_MANAGER_INSTALL_SOURCE_HARDLINKS,
       to: canonicalTargetDir,
     });
     stageDir = null;

--- a/src/infra/install-package-dir.ts
+++ b/src/infra/install-package-dir.ts
@@ -8,6 +8,7 @@ import { movePathWithCopyFallback } from "./replace-file.js";
 import { createSafeNpmInstallArgs, createSafeNpmInstallEnv } from "./safe-package-install.js";
 
 const PACKAGE_MANAGER_INSTALL_SOURCE_HARDLINKS = "allow" as const;
+const DEFAULT_INSTALL_SOURCE_HARDLINKS = "reject" as const;
 const INSTALL_BASE_CHANGED_ERROR_MESSAGE = "install base directory changed during install";
 const INSTALL_BASE_CHANGED_ABORT_WARNING =
   "Install base directory changed during install; aborting staged publish.";
@@ -107,6 +108,12 @@ function isInstallBaseChangedError(error: unknown): boolean {
   return error instanceof Error && error.message === INSTALL_BASE_CHANGED_ERROR_MESSAGE;
 }
 
+function resolveInstallSourceHardlinks(params: { hasDeps: boolean }): "allow" | "reject" {
+  return params.hasDeps
+    ? PACKAGE_MANAGER_INSTALL_SOURCE_HARDLINKS
+    : DEFAULT_INSTALL_SOURCE_HARDLINKS;
+}
+
 async function assertInstallBaseStable(params: {
   installBaseDir: string;
   expectedRealPath: string;
@@ -191,6 +198,7 @@ export async function installPackageDir(params: {
 
   let stageDir: string | null = null;
   let backupDir: string | null = null;
+  const sourceHardlinks = resolveInstallSourceHardlinks({ hasDeps: params.hasDeps });
   const fail = async (error: string, cause?: unknown) => {
     const installBaseChanged = isInstallBaseChangedError(cause);
     if (installBaseChanged) {
@@ -214,7 +222,7 @@ export async function installPackageDir(params: {
     }
     await movePathWithCopyFallback({
       from: backupDir,
-      sourceHardlinks: PACKAGE_MANAGER_INSTALL_SOURCE_HARDLINKS,
+      sourceHardlinks,
       to: canonicalTargetDir,
     }).catch(() => undefined);
     backupDir = null;
@@ -301,7 +309,7 @@ export async function installPackageDir(params: {
       });
       await movePathWithCopyFallback({
         from: canonicalTargetDir,
-        sourceHardlinks: PACKAGE_MANAGER_INSTALL_SOURCE_HARDLINKS,
+        sourceHardlinks,
         to: backupDir,
       });
     } catch (err) {
@@ -316,7 +324,7 @@ export async function installPackageDir(params: {
     });
     await movePathWithCopyFallback({
       from: stageDir,
-      sourceHardlinks: PACKAGE_MANAGER_INSTALL_SOURCE_HARDLINKS,
+      sourceHardlinks,
       to: canonicalTargetDir,
     });
     stageDir = null;

--- a/src/infra/install-package-dir.ts
+++ b/src/infra/install-package-dir.ts
@@ -7,8 +7,9 @@ import { tryReadJson, writeJson } from "./json-files.js";
 import { movePathWithCopyFallback } from "./replace-file.js";
 import { createSafeNpmInstallArgs, createSafeNpmInstallEnv } from "./safe-package-install.js";
 
-const PACKAGE_MANAGER_INSTALL_SOURCE_HARDLINKS = "allow" as const;
-const DEFAULT_INSTALL_SOURCE_HARDLINKS = "reject" as const;
+type InstallSourceHardlinks = "package-manager" | "reject";
+
+const DEFAULT_INSTALL_SOURCE_HARDLINKS: InstallSourceHardlinks = "reject";
 const INSTALL_BASE_CHANGED_ERROR_MESSAGE = "install base directory changed during install";
 const INSTALL_BASE_CHANGED_ABORT_WARNING =
   "Install base directory changed during install; aborting staged publish.";
@@ -108,10 +109,8 @@ function isInstallBaseChangedError(error: unknown): boolean {
   return error instanceof Error && error.message === INSTALL_BASE_CHANGED_ERROR_MESSAGE;
 }
 
-function resolveInstallSourceHardlinks(params: { hasDeps: boolean }): "allow" | "reject" {
-  return params.hasDeps
-    ? PACKAGE_MANAGER_INSTALL_SOURCE_HARDLINKS
-    : DEFAULT_INSTALL_SOURCE_HARDLINKS;
+function resolveMoveSourceHardlinks(policy: InstallSourceHardlinks): "allow" | "reject" {
+  return policy === "package-manager" ? "allow" : "reject";
 }
 
 async function assertInstallBaseStable(params: {
@@ -160,6 +159,7 @@ export async function installPackageDir(params: {
   logger?: { info?: (message: string) => void; warn?: (message: string) => void };
   copyErrorPrefix: string;
   hasDeps: boolean;
+  sourceHardlinks?: InstallSourceHardlinks;
   depsLogMessage: string;
   afterCopy?: (installedDir: string) => void | Promise<void>;
   afterInstall?: (
@@ -198,7 +198,9 @@ export async function installPackageDir(params: {
 
   let stageDir: string | null = null;
   let backupDir: string | null = null;
-  const sourceHardlinks = resolveInstallSourceHardlinks({ hasDeps: params.hasDeps });
+  const sourceHardlinks = resolveMoveSourceHardlinks(
+    params.sourceHardlinks ?? DEFAULT_INSTALL_SOURCE_HARDLINKS,
+  );
   const fail = async (error: string, cause?: unknown) => {
     const installBaseChanged = isInstallBaseChangedError(cause);
     if (installBaseChanged) {
@@ -366,8 +368,10 @@ export async function installPackageDirWithManifestDeps(params: {
   manifestDependencies?: Record<string, unknown>;
   afterCopy?: (installedDir: string) => void | Promise<void>;
 }): Promise<{ ok: true } | { ok: false; error: string }> {
+  const hasDeps = Object.keys(params.manifestDependencies ?? {}).length > 0;
   return installPackageDir({
     ...params,
-    hasDeps: Object.keys(params.manifestDependencies ?? {}).length > 0,
+    hasDeps,
+    sourceHardlinks: hasDeps ? "package-manager" : "reject",
   });
 }

--- a/src/infra/package-update-steps.test.ts
+++ b/src/infra/package-update-steps.test.ts
@@ -20,6 +20,12 @@ async function writePackageRoot(packageRoot: string, version: string): Promise<v
   await writePackageDistInventory(packageRoot);
 }
 
+async function addHardlinkedPackageFile(packageRoot: string, linkRoot: string): Promise<void> {
+  const packageFile = path.join(packageRoot, "dist", "index.js");
+  await fs.mkdir(linkRoot, { recursive: true });
+  await fs.link(packageFile, path.join(linkRoot, `${path.basename(packageRoot)}-index.js`));
+}
+
 function createNpmTarget(globalRoot: string): ResolvedGlobalInstallTarget {
   return {
     manager: "npm",
@@ -137,6 +143,61 @@ describe("runGlobalPackageUpdateSteps", () => {
       );
     });
   });
+
+  it.runIf(process.platform !== "win32")(
+    "swaps npm package roots that contain package-manager hardlinks",
+    async () => {
+      await withTempDir({ prefix: "openclaw-package-update-hardlinks-" }, async (base) => {
+        const prefix = path.join(base, "prefix");
+        const globalRoot = path.join(prefix, "lib", "node_modules");
+        const packageRoot = path.join(globalRoot, "openclaw");
+        await writePackageRoot(packageRoot, "1.0.0");
+        await addHardlinkedPackageFile(packageRoot, path.join(base, "cache", "existing"));
+
+        const result = await runGlobalPackageUpdateSteps({
+          installTarget: createNpmTarget(globalRoot),
+          installSpec: "openclaw@2.0.0",
+          packageName: "openclaw",
+          packageRoot,
+          runCommand: createRootRunner(globalRoot),
+          runStep: async ({ name, argv, cwd }): Promise<PackageUpdateStepResult> => {
+            if (name !== "global update") {
+              throw new Error(`unexpected step ${name}`);
+            }
+            const prefixIndex = argv.indexOf("--prefix");
+            const stagePrefix = argv[prefixIndex + 1];
+            if (!stagePrefix) {
+              throw new Error("missing staged prefix");
+            }
+            const stagedPackageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
+            await writePackageRoot(stagedPackageRoot, "2.0.0");
+            await addHardlinkedPackageFile(stagedPackageRoot, path.join(base, "cache", "staged"));
+            return {
+              name,
+              command: argv.join(" "),
+              cwd: cwd ?? process.cwd(),
+              durationMs: 1,
+              exitCode: 0,
+            };
+          },
+          timeoutMs: 1000,
+        });
+
+        expect(result.failedStep).toBeNull();
+        expect(result.afterVersion).toBe("2.0.0");
+        expect(result.steps.map((step) => step.name)).toEqual([
+          "global update",
+          "global install swap",
+        ]);
+        await expect(
+          fs.readFile(path.join(packageRoot, "package.json"), "utf8"),
+        ).resolves.toContain('"version":"2.0.0"');
+        await expect(fs.lstat(path.join(packageRoot, "dist", "index.js"))).resolves.toMatchObject({
+          nlink: 2,
+        });
+      });
+    },
+  );
 
   it("swaps staged npm updates into an explicitly selected direct node_modules root", async () => {
     await withTempDir({ prefix: "openclaw-package-update-direct-root-" }, async (base) => {

--- a/src/infra/package-update-steps.ts
+++ b/src/infra/package-update-steps.ts
@@ -18,6 +18,8 @@ import {
   type ResolvedGlobalInstallTarget,
 } from "./update-global.js";
 
+const PACKAGE_MANAGER_SWAP_SOURCE_HARDLINKS = "allow" as const;
+
 export type PackageUpdateStepResult = {
   name: string;
   command: string;
@@ -423,14 +425,14 @@ async function swapStagedNpmInstall(params: {
     if (await pathExists(targetPackageRoot)) {
       await movePathWithCopyFallback({
         from: targetPackageRoot,
-        sourceHardlinks: "reject",
+        sourceHardlinks: PACKAGE_MANAGER_SWAP_SOURCE_HARDLINKS,
         to: backupRoot,
       });
       movedExisting = true;
     }
     await movePathWithCopyFallback({
       from: params.stage.packageRoot,
-      sourceHardlinks: "reject",
+      sourceHardlinks: PACKAGE_MANAGER_SWAP_SOURCE_HARDLINKS,
       to: targetPackageRoot,
     });
     movedStaged = true;
@@ -462,7 +464,7 @@ async function swapStagedNpmInstall(params: {
     if (movedExisting) {
       await movePathWithCopyFallback({
         from: backupRoot,
-        sourceHardlinks: "reject",
+        sourceHardlinks: PACKAGE_MANAGER_SWAP_SOURCE_HARDLINKS,
         to: targetPackageRoot,
       }).catch(() => undefined);
     }

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -1069,6 +1069,7 @@ async function installPluginDirectoryIntoExtensions(params: {
   dryRun: boolean;
   copyErrorPrefix: string;
   hasDeps: boolean;
+  sourceHardlinks?: "package-manager" | "reject";
   depsLogMessage: string;
   afterCopy?: (installedDir: string) => Promise<void>;
   afterInstall?: (
@@ -1117,6 +1118,7 @@ async function installPluginDirectoryIntoExtensions(params: {
     logger: params.logger,
     copyErrorPrefix: params.copyErrorPrefix,
     hasDeps: params.hasDeps,
+    sourceHardlinks: params.sourceHardlinks ?? "reject",
     depsLogMessage: params.depsLogMessage,
     afterCopy: params.afterCopy,
     afterInstall: async (installedDir) => {
@@ -1619,6 +1621,10 @@ async function installPluginFromPackageDir(
 
   preparedTarget = await resolvePreparedTargetForPluginId(plugin.pluginId);
   const hasBundleManifest = Boolean(runtime.detectBundleManifestFormat(params.packageDir));
+  const shouldInstallRuntimeDeps =
+    plugin.hasRuntimeDependencies &&
+    !hasBundleManifest &&
+    params.installPolicyRequest?.kind === "plugin-archive";
 
   return await installPluginDirectoryIntoExtensions({
     sourceDir: params.packageDir,
@@ -1633,10 +1639,8 @@ async function installPluginFromPackageDir(
     mode: preparedTarget.effectiveMode,
     dryRun,
     copyErrorPrefix: "failed to copy plugin",
-    hasDeps:
-      plugin.hasRuntimeDependencies &&
-      !hasBundleManifest &&
-      params.installPolicyRequest?.kind === "plugin-archive",
+    hasDeps: shouldInstallRuntimeDeps,
+    sourceHardlinks: shouldInstallRuntimeDeps ? "package-manager" : "reject",
     depsLogMessage: "Installing plugin dependencies…",
     nameEncoder: encodePluginInstallDirName,
     afterInstall: async (installedDir) => {


### PR DESCRIPTION
## Summary

- allow the package-manager update/install swap path to move package roots that contain source-side hardlinks
- keep the generic `movePathWithCopyFallback` reject guard unchanged for non-package-manager callers
- add regression coverage with real filesystem hardlinks for both global update swaps and install-directory swaps

Fixes #85559.

## Real behavior proof

Behavior or issue addressed: npm 11+/pnpm-style global OpenClaw installs can contain hardlinked files under the installed package root. Before this change, the updater/install swap path used `sourceHardlinks: "reject"` and could fail before replacing the package root. This patch scopes `sourceHardlinks: "allow"` to the package-manager-owned swap paths while preserving the generic reject guard.

Real environment tested: Docker `node:24-bookworm`, Node v24.16.0, npm 11.13.0, Linux container, real global npm install under `/usr/local/lib/node_modules/openclaw`. The proof used local OpenClaw tarballs built from this PR head: baseline `2026.5.22` and target `2026.5.23-proof.0`.

Exact steps or command run after fix:

```sh
docker run --rm -v /tmp/openclaw-proof-85559-aacec68753:/proof node:24-bookworm bash -lc '
set -eu
npm install -g --omit=optional /proof/baseline.tgz
root="$(npm root -g)/openclaw"
hardlink_source="$(find "$root" -type f -path "*/dist/*" -print -quit)"
mkdir -p /tmp/openclaw-hardlink-cache
ln "$hardlink_source" /tmp/openclaw-hardlink-cache/source-hardlink
find "$root" -type f -links +1 | head -n 3
OPENCLAW_ALLOW_ROOT=1 npm_config_omit=optional NPM_CONFIG_OMIT=optional openclaw update --tag /proof/target.tgz --yes --json
openclaw --version
'
```

Evidence after fix:

```text
node=v24.16.0
npm=11.13.0
baseline=OpenClaw 2026.5.22 (aacec68)
packageRoot=/usr/local/lib/node_modules/openclaw
hardlinkSource=/usr/local/lib/node_modules/openclaw/dist/setup-surface-BUJl2T9I.js
hardlinkedBefore=
/usr/local/lib/node_modules/openclaw/dist/setup-surface-BUJl2T9I.js
{
  "status": "ok",
  "mode": "npm",
  "root": "/usr/local/lib/node_modules/openclaw",
  "before": {
    "version": "2026.5.22"
  },
  "after": {
    "version": "2026.5.23-proof.0"
  },
  "steps": [
    {
      "name": "global update",
      "exitCode": 0,
      "stdoutTail": "\nadded 483 packages in 5m"
    },
    {
      "name": "global install swap",
      "exitCode": 0,
      "stdoutTail": "replaced openclaw"
    },
    {
      "name": "openclaw doctor",
      "exitCode": 0
    }
  ]
}
updated=OpenClaw 2026.5.23-proof.0 (aacec68)
```

Observed result after fix: The package root contained a real hardlinked file before the update, and `openclaw update --tag /proof/target.tgz --yes --json` completed with `status: ok`. The `global install swap` step replaced the package root successfully and the installed CLI reported `OpenClaw 2026.5.23-proof.0` afterward.

What was not tested: I did not run a separate pnpm global update E2E locally. The Docker proof covers npm 11 global install/update with a real hardlinked package root in the same package-manager swap path, and the regression tests cover both update and install swap helpers with actual filesystem hardlinks.

## Verification

```sh
git diff --check
pnpm test src/infra/replace-file.test.ts src/infra/package-update-steps.test.ts src/infra/install-package-dir.test.ts
node scripts/package-openclaw-for-docker.mjs --output-dir /tmp/openclaw-proof-85559-aacec68753 --output-name baseline.tgz
docker run --rm -v /tmp/openclaw-proof-85559-aacec68753:/proof node:24-bookworm bash -lc '...'
```

## Security notes

- This does not weaken the generic hardlink protection in `movePathWithCopyFallback`.
- The allow policy is scoped to package-manager-owned package root swaps where npm/pnpm may legitimately materialize hardlinks.
