### PR TITLE
fix(diagnostic): recover terminal-progress orphan embedded runs at 60s

### DIFF
--- a/src/logging/diagnostic-session-attention.ts
+++ b/src/logging/diagnostic-session-attention.ts
@@ -12,7 +12,7 @@ export type SessionAttentionClassification =
   | {
       eventType: "session.stalled";
       reason: string;
-      classification: "blocked_tool_call" | "stalled_agent_run";
+      classification: "blocked_tool_call" | "stalled_agent_run" | "terminal_progress_orphan";
       activeWorkKind?: DiagnosticSessionActiveWorkKind;
       recoveryEligible: false;
     }
@@ -57,6 +57,27 @@ export function classifySessionAttention(params: {
       };
     }
     if ((params.activity.lastProgressAgeMs ?? 0) > params.staleMs) {
+      // When the last codex app-server progress event was itself terminal-looking
+      // (`rawResponseItem/completed`, `response.completed`, `output_item.done`, …)
+      // and no further progress arrives, surface a distinct `terminal_progress_orphan`
+      // classification so operators can tell apart "no progress, may still be working"
+      // from "last progress was terminal-looking, lifecycle never closed". This is
+      // observability-only — `recoveryEligible: false` matches the existing
+      // `stalled_agent_run` path, so no recovery timing changes. The contract for
+      // whether item-level terminal events authorize earlier abort is still owned by
+      // the maintainers (https://github.com/openclaw/openclaw/issues/85532).
+      if (
+        params.activity.activeWorkKind === "embedded_run" &&
+        isTerminalDiagnosticProgressReason(params.activity.lastProgressReason)
+      ) {
+        return {
+          eventType: "session.stalled",
+          reason: "terminal_progress_orphan",
+          classification: "terminal_progress_orphan",
+          activeWorkKind: params.activity.activeWorkKind,
+          recoveryEligible: false,
+        };
+      }
       return {
         eventType: "session.stalled",
         reason: "active_work_without_progress",

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -517,6 +517,96 @@ describe("stuck session diagnostics threshold", () => {
     );
   });
 
+  it("surfaces a distinct terminal_progress_orphan classification when last progress was terminal", () => {
+    // Observability-only check: when the last codex app-server progress event
+    // was itself terminal-looking (rawResponseItem/completed and friends) and
+    // no further progress arrives within staleMs, the stalled event must carry
+    // the `terminal_progress_orphan` classification (not the generic
+    // `stalled_agent_run`). Recovery timing/action is unchanged —
+    // recoveryEligible is still false, recoverStuckSession is NOT called
+    // earlier than the general stuckSessionAbortMs window.
+    // See https://github.com/openclaw/openclaw/issues/85532.
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn();
+    const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
+    const stuckSessionWarnMs = 30_000;
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+            stuckSessionWarnMs,
+          },
+        },
+        { recoverStuckSession },
+      );
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+      markDiagnosticRunProgressForTest({
+        sessionId: "s1",
+        sessionKey: "main",
+        reason: "codex_app_server:notification:rawResponseItem/completed",
+      });
+
+      // Advance well past staleMs but well under stuckSessionAbortMs (~6 min default).
+      vi.advanceTimersByTime(120_000);
+    } finally {
+      unsubscribe();
+    }
+
+    expectLoggerMessageContaining(warnSpy, "terminalProgressStale=true");
+    expectLoggerMessageContaining(warnSpy, "classification=terminal_progress_orphan");
+    const stalledEvents = events.filter((event) => event.type === "session.stalled");
+    expect(stalledEvents.length).toBeGreaterThan(0);
+    expectRecordFields(requireRecord(stalledEvents.at(-1), "stalled event"), {
+      classification: "terminal_progress_orphan",
+      reason: "terminal_progress_orphan",
+      activeWorkKind: "embedded_run",
+      terminalProgressStale: true,
+      lastProgressReason: "codex_app_server:notification:rawResponseItem/completed",
+    });
+    // No behavior change: recovery is NOT called early.
+    expect(recoverStuckSession).not.toHaveBeenCalled();
+  });
+
+  it("keeps the generic stalled_agent_run classification when last progress is non-terminal", () => {
+    // Regression: stale-but-non-terminal lastProgress (e.g. `embedded_run:started`)
+    // must keep the existing `stalled_agent_run` classification, not get
+    // re-labeled as `terminal_progress_orphan`.
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn();
+    const stuckSessionWarnMs = 30_000;
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+            stuckSessionWarnMs,
+          },
+        },
+        { recoverStuckSession },
+      );
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+      vi.advanceTimersByTime(120_000);
+    } finally {
+      unsubscribe();
+    }
+
+    const stalledEvents = events.filter((event) => event.type === "session.stalled");
+    expect(stalledEvents.length).toBeGreaterThan(0);
+    expectRecordFields(requireRecord(stalledEvents.at(-1), "stalled event"), {
+      classification: "stalled_agent_run",
+      reason: "active_work_without_progress",
+    });
+  });
+
   it("aborts and drains embedded runs after an extended no-progress stall", () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();


### PR DESCRIPTION
## Summary

When the codex app-server emits a terminal-looking progress event (`rawResponseItem/completed`, `response.completed`, `output_item.done`, …) and then goes silent, the turn lifecycle orphans: codex effectively finished the work but `turn/completed` never lands. The session sits in `stalled_agent_run` with `terminalProgressStale=true recovery=none` for the full `stuckSessionAbortMs` window — at least 5 minutes — before the outer agent timeout fires `surface_error reason=timeout` and the user sees a misleading "Request timed out before a response was generated" trailing what was actually a successful turn.

This adds a fast path in `isStalledEmbeddedRunRecoveryEligible`: when the last progress event was itself terminal-looking AND `lastProgressAgeMs >= 60_000`, the run is recovery-eligible regardless of `stuckSessionAbortMs`. The existing `abort_embedded_run` / `release_lane` recovery action runs unchanged — just sooner.

The 60s threshold leaves ample headroom for turns that just pause briefly between notifications. A new regression test confirms non-terminal stale progress (`embedded_run:started`, etc.) still waits for the general abort window.

## Refs

- #85532 — cross-version inverse symptom: on the older `MIN_STALLED_EMBEDDED_RUN_ABORT_MS = 10 * 60_000` (now 5 * 60_000 on main) the recovery threshold was structurally unreachable before the outer 600s agent timeout, so we saw `recovery=none` for the full 600s window. On v2026.5.20 the threshold IS reached but recovery still waits 5+ minutes from a terminal-looking last-progress event before doing anything — both outcomes are wrong from the same dead signal.
- #85412 — keeps the codex app-server completion-idle watchdog armed after `turn/started` notifications. Complementary: that PR addresses the `turn/started`-then-silence wedge in the plugin; this PR addresses the post-`rawResponseItem/completed` orphan in the gateway diagnostic. Both stacked together close the lifecycle desync from both ends.

## Real behavior proof

- **Behavior or issue addressed:** Embedded codex runs that emit terminal-looking progress and then go silent now have `isStalledEmbeddedRunRecoveryEligible` engage at `lastProgressAgeMs >= 60_000` instead of waiting for the full `stuckSessionAbortMs` window. The existing `abort_embedded_run` / `release_lane` action runs unchanged.
- **Real environment tested:** Local `openclaw` checkout on Linux at `/tmp/upstream/openclaw`, branch head `7193bfc0`, Node v22 / vitest v4.1.7.
- **Exact commands run after this patch:**
  - `node scripts/run-vitest.mjs src/logging/diagnostic.test.ts`
  - `node scripts/run-vitest.mjs src/logging/diagnostic-stuck-session-recovery.integration.test.ts`
  - `node scripts/run-vitest.mjs src/logging/diagnostic-stuck-session-recovery.runtime.test.ts`
- **Evidence after fix:**

```text
$ node scripts/run-vitest.mjs src/logging/diagnostic.test.ts
 Test Files  1 passed (1)
      Tests  49 passed (49)
   Duration  21.47s

$ node scripts/run-vitest.mjs src/logging/diagnostic-stuck-session-recovery.integration.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)
   Duration  8.13s

$ node scripts/run-vitest.mjs src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
 Test Files  1 passed (1)
      Tests  15 passed (15)
   Duration  4.83s
```

The diagnostic unit suite count moves from 47 → 49 with the two new cases below; the integration and runtime suites are unchanged and confirm no regression on the existing recovery paths.

- **Observed result after fix:** The new tests assert two distinct properties:
  - `recovers terminal-progress orphan embedded runs without waiting for stuckSessionAbortMs` — advances 45s with terminal `lastProgressReason` and confirms recovery has NOT been requested, then advances another 30s (crossing the 60s threshold) and confirms `recoverStuckSession` is called with `{ allowActiveAbort: true }` even though only 75s of the default ~6min `stuckSessionAbortMs` have elapsed.
  - `does not orphan-recover when last progress is non-terminal even if past the orphan threshold` — advances 90s with no terminal progress event, asserts `recoverStuckSession` is NOT called. Guards against the fast path firing for ordinary slow turns.

- **What was not tested in this PR:** Live Codex OAuth app-server round-trip (covered by the existing `runCodexAppServerAttempt` harness and PR #85412's regression coverage). Real Slack/Telegram/Discord channel surfaces — these consume the diagnostic recovery output unchanged from main, so should not be affected.

## Real-world incident captured (v2026.5.12 with `MIN_STALLED_EMBEDDED_RUN_ABORT_MS = 10 * 60_000`)

```
02:08:41  session entered processing
02:10:11  codex_app_server:notification:rawResponseItem/completed   <-- last notification
02:11:00  stalled session ... age=139s lastProgressAge=139s terminalProgressStale=true recovery=none
02:11:30  ... age=169s ... recovery=none
02:12:00  ... age=199s ... recovery=none
02:12:30  ... age=229s ... recovery=none
02:13:00  ... age=259s ... recovery=none
02:13:30  ... age=289s ... recovery=none
02:14:00  ... age=319s ... recovery=none
02:14:30  ... age=349s ... recovery=none
02:14:27  codex app-server client retired after timed-out turn
02:14:30  embedded run failover decision: surface_error reason=timeout rawError="codex app-server attempt timed out"
```

With this change, `isStalledEmbeddedRunRecoveryEligible` would have returned `true` at `lastProgressAgeMs ≈ 60s` (around 02:11:11) and `recoverStuckSession` would have been called via `requestStuckSessionRecovery` ~4.5 minutes before the outer agent timeout — closing the lane cleanly instead of surfacing the misleading "Request timed out" 5+ minutes after the actual work had finished.