### PR TITLE
fix(ui): show WebChat done after reply renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- WebChat: keep the run-complete indicator in progress until deferred history replay renders the assistant reply, so Done no longer appears before response text. (#85374) Thanks @neeravmakwana.
 - Agents/compaction: skip agent-harness preflight for provider-owned CLI runtime sessions so over-threshold Claude CLI sessions continue through normal compaction instead of failing on a missing harness. Fixes #84857. (#84878) Thanks @zhangguiping-xydt.
 - Telegram: normalize legacy durable group retry targets before retry sends, polls, and pins so group retries keep using the real chat id. (#85656) Thanks @luoyanglang.
 - WebChat: summarize internal message-tool source replies so tool cards no longer duplicate the visible reply body. (#84773) Thanks @jason-allen-oneal.

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -191,10 +191,20 @@ describe("handleGatewayEvent sessions.changed", () => {
     flushChatQueueForEventMock.mockReset();
     applySessionsChangedEventMock
       .mockReset()
-      .mockImplementation((state: { chatRunId: string | null }) => {
-        state.chatRunId = null;
-        return { applied: true, change: "updated", clearedChatRun: true };
-      });
+      .mockImplementation(
+        (state: { chatRunId: string | null; sessionKey: string; chatRunStatus?: unknown }) => {
+          const runId = state.chatRunId;
+          const sessionKey = state.sessionKey;
+          state.chatRunStatus = null;
+          state.chatRunId = null;
+          return {
+            applied: true,
+            change: "updated",
+            clearedChatRun: true,
+            clearedChatRunStatus: { phase: "done", runId, sessionKey },
+          };
+        },
+      );
     const host = createHost();
     host.chatRunId = "run-1";
     const payload = {
@@ -223,9 +233,16 @@ describe("handleGatewayEvent sessions.changed", () => {
     flushChatQueueForEventMock.mockReset();
     applySessionsChangedEventMock
       .mockReset()
-      .mockImplementation((state: { chatRunId: string | null }) => {
+      .mockImplementation((state: { chatRunId: string | null; sessionKey: string }) => {
+        const runId = state.chatRunId;
+        const sessionKey = state.sessionKey;
         state.chatRunId = null;
-        return { applied: true, change: "updated", clearedChatRun: true };
+        return {
+          applied: true,
+          change: "updated",
+          clearedChatRun: true,
+          clearedChatRunStatus: { phase: "done", runId, sessionKey },
+        };
       });
     let resolveHistory!: () => void;
     loadChatHistoryMock.mockReturnValue(
@@ -255,10 +272,16 @@ describe("handleGatewayEvent sessions.changed", () => {
         .pendingSessionMessageReloadSessionKey,
     ).toBeNull();
     expect(flushChatQueueForEventMock).not.toHaveBeenCalled();
+    expect((host as typeof host & { chatRunStatus?: unknown }).chatRunStatus).toBeUndefined();
 
     resolveHistory();
     await Promise.resolve();
 
+    expect((host as typeof host & { chatRunStatus?: unknown }).chatRunStatus).toMatchObject({
+      phase: "done",
+      runId: "run-1",
+      sessionKey: "agent:main:main",
+    });
     expect(flushChatQueueForEventMock).toHaveBeenCalledWith(host);
     expect(loadSessionsMock).not.toHaveBeenCalled();
   });
@@ -270,9 +293,16 @@ describe("handleGatewayEvent sessions.changed", () => {
     flushChatQueueForEventMock.mockReset();
     applySessionsChangedEventMock
       .mockReset()
-      .mockImplementation((state: { chatRunId: string | null }) => {
+      .mockImplementation((state: { chatRunId: string | null; sessionKey: string }) => {
+        const runId = state.chatRunId;
+        const sessionKey = state.sessionKey;
         state.chatRunId = null;
-        return { applied: true, change: "updated", clearedChatRun: true };
+        return {
+          applied: true,
+          change: "updated",
+          clearedChatRun: true,
+          clearedChatRunStatus: { phase: "done", runId, sessionKey },
+        };
       });
     let resolveHistory!: () => void;
     loadChatHistoryMock.mockReturnValue(
@@ -504,9 +534,16 @@ describe("handleGatewayEvent session.message", () => {
     flushChatQueueForEventMock.mockReset();
     applySessionsChangedEventMock
       .mockReset()
-      .mockImplementation((state: { chatRunId: string | null }) => {
+      .mockImplementation((state: { chatRunId: string | null; sessionKey: string }) => {
+        const runId = state.chatRunId;
+        const sessionKey = state.sessionKey;
         state.chatRunId = null;
-        return { applied: true, change: "updated", clearedChatRun: true };
+        return {
+          applied: true,
+          change: "updated",
+          clearedChatRun: true,
+          clearedChatRunStatus: { phase: "done", runId, sessionKey },
+        };
       });
     let resolveHistory!: () => void;
     loadChatHistoryMock.mockReturnValue(
@@ -532,10 +569,16 @@ describe("handleGatewayEvent session.message", () => {
     expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
     expect(loadChatHistoryMock).toHaveBeenCalledWith(host);
     expect(flushChatQueueForEventMock).not.toHaveBeenCalled();
+    expect((host as typeof host & { chatRunStatus?: unknown }).chatRunStatus).toBeUndefined();
 
     resolveHistory();
     await Promise.resolve();
 
+    expect((host as typeof host & { chatRunStatus?: unknown }).chatRunStatus).toMatchObject({
+      phase: "done",
+      runId: "run-1",
+      sessionKey: "agent:qa:main",
+    });
     expect(flushChatQueueForEventMock).toHaveBeenCalledWith(host);
   });
 
@@ -558,6 +601,7 @@ describe("handleGatewayEvent session.message", () => {
     expect(loadSessionsMock).toHaveBeenCalledWith(host, {
       activeMinutes: 10,
       limit: 25,
+      publishChatRunStatus: false,
     });
     await Promise.resolve();
     expect(loadChatHistoryMock).not.toHaveBeenCalled();
@@ -570,6 +614,21 @@ describe("handleGatewayEvent session.message", () => {
     flushChatQueueForEventMock.mockReset();
     loadSessionsMock.mockReset().mockImplementation(async (state) => {
       state.chatRunId = null;
+      state.sessionsResult = {
+        ts: 1,
+        path: "(multiple)",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [
+          {
+            key: "agent:qa:main",
+            kind: "direct",
+            updatedAt: 1,
+            hasActiveRun: false,
+            status: "done",
+          },
+        ],
+      };
     });
     const host = createHost();
     host.sessionKey = "agent:qa:main";
@@ -586,6 +645,11 @@ describe("handleGatewayEvent session.message", () => {
     await Promise.resolve();
 
     expect(host.chatRunId).toBeNull();
+    expect((host as typeof host & { chatRunStatus?: unknown }).chatRunStatus).toMatchObject({
+      phase: "done",
+      runId: "run-stale",
+      sessionKey: "agent:qa:main",
+    });
     expect(clearPendingQueueItemsForRunMock).toHaveBeenCalledWith(host, "run-stale");
     expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
     expect(loadChatHistoryMock).toHaveBeenCalledWith(host);

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -772,6 +772,7 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
 
 function flushChatQueueAfterSessionRunReconcile(
   host: GatewayHost,
+  result: ReturnType<typeof applySessionsChangedEvent>,
   payload: { clientRunId?: unknown; runId?: unknown; sessionKey?: unknown } | undefined,
   fallbackRunId?: string | null,
 ): boolean {
@@ -787,6 +788,17 @@ function flushChatQueueAfterSessionRunReconcile(
   );
   const flushQueue = () =>
     void flushChatQueueForEvent(host as unknown as Parameters<typeof flushChatQueueForEvent>[0]);
+  const publishRunStatus = () => {
+    if (!result.applied || !result.clearedChatRunStatus || host.chatRunId) {
+      return;
+    }
+    reconcileChatRunLifecycle(host as unknown as Parameters<typeof reconcileChatRunLifecycle>[0], {
+      outcome: result.clearedChatRunStatus.phase,
+      runId: result.clearedChatRunStatus.runId,
+      sessionKey: result.clearedChatRunStatus.sessionKey,
+      clearIndicators: false,
+    });
+  };
   const deferredReloadHost = host as GatewayHostWithDeferredSessionMessageReload;
   const pendingSessionKey = deferredReloadHost.pendingSessionMessageReloadSessionKey?.trim();
   const eventSessionKey = typeof payload?.sessionKey === "string" ? payload.sessionKey.trim() : "";
@@ -799,11 +811,13 @@ function flushChatQueueAfterSessionRunReconcile(
     const reloadSessionKey = pendingSessionKey;
     void Promise.resolve(loadChatHistory(host as unknown as ChatState)).finally(() => {
       if (host.sessionKey === reloadSessionKey) {
+        publishRunStatus();
         flushQueue();
       }
     });
     return true;
   }
+  publishRunStatus();
   flushQueue();
   return false;
 }
@@ -820,7 +834,7 @@ function handleSessionMessageGatewayEvent(
     if (sessionKey && sessionKey === host.sessionKey) {
       deferredReloadHost.pendingSessionMessageReloadSessionKey = sessionKey;
     }
-    if (flushChatQueueAfterSessionRunReconcile(host, payload, runIdBeforeApply)) {
+    if (flushChatQueueAfterSessionRunReconcile(host, result, payload, runIdBeforeApply)) {
       return;
     }
   }
@@ -838,6 +852,7 @@ function handleSessionMessageGatewayEvent(
     const runIdBeforeRefresh = host.chatRunId;
     void loadSessions(host as unknown as SessionsState, {
       ...createChatSessionsLoadOverrides(host),
+      publishChatRunStatus: false,
     }).finally(() =>
       replayDeferredSessionMessageReloadAfterSessionsRefresh(
         host,
@@ -883,7 +898,28 @@ function replayDeferredSessionMessageReloadAfterSessionsRefresh(
     }
     return;
   }
-  flushChatQueueAfterSessionRunReconcile(host, { sessionKey }, completedRunId);
+  const row = (host as unknown as SessionsState).sessionsResult?.sessions.find(
+    (session) => session.key === sessionKey,
+  );
+  flushChatQueueAfterSessionRunReconcile(
+    host,
+    {
+      applied: true,
+      change: "updated",
+      clearedChatRun: true,
+      ...(row
+        ? {
+            clearedChatRunStatus: {
+              phase: row.status === "done" ? "done" : "interrupted",
+              runId: completedRunId ?? null,
+              sessionKey,
+            },
+          }
+        : {}),
+    },
+    { sessionKey },
+    completedRunId,
+  );
 }
 
 function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
@@ -968,6 +1004,7 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
       if (result.clearedChatRun) {
         flushChatQueueAfterSessionRunReconcile(
           host,
+          result,
           evt.payload as
             | { clientRunId?: unknown; runId?: unknown; sessionKey?: unknown }
             | undefined,

--- a/ui/src/ui/chat/run-lifecycle.ts
+++ b/ui/src/ui/chat/run-lifecycle.ts
@@ -41,6 +41,7 @@ type ReconcileOptions = {
   clearToolStream?: boolean;
   clearSideResultTerminalRuns?: boolean;
   clearRunStatus?: boolean;
+  publishRunStatus?: boolean;
 };
 
 function toSessionKey(value: string | null | undefined): string | null {
@@ -183,8 +184,10 @@ export function reconcileChatRunLifecycle(host: RunLifecycleHost, options: Recon
       occurredAt,
     };
     reconcileSessionRows(host, options, occurredAt);
-    host.chatRunStatus = status;
-    scheduleRunStatusClear(host, status);
+    if (options.publishRunStatus !== false) {
+      host.chatRunStatus = status;
+      scheduleRunStatusClear(host, status);
+    }
   } else if (options.clearRunStatus) {
     clearChatRunStatus(host);
   }
@@ -195,7 +198,10 @@ function currentSessionRow(host: RunLifecycleHost) {
   return host.sessionsResult?.sessions.find((row) => row.key === host.sessionKey);
 }
 
-export function reconcileChatRunFromCurrentSessionRow(host: RunLifecycleHost): boolean {
+export function reconcileChatRunFromCurrentSessionRow(
+  host: RunLifecycleHost,
+  options: { publishRunStatus?: boolean } = {},
+): boolean {
   if (!host.chatRunId && host.chatStream == null) {
     return false;
   }
@@ -217,6 +223,7 @@ export function reconcileChatRunFromCurrentSessionRow(host: RunLifecycleHost): b
     sessionKey: host.sessionKey,
     clearLocalRun: true,
     clearChatStream: true,
+    publishRunStatus: options.publishRunStatus,
   });
   return true;
 }

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -907,6 +907,7 @@ describe("applySessionsChangedEvent", () => {
       chatRunId: string | null;
       chatStream: string | null;
       chatStreamStartedAt: number | null;
+      chatRunStatus?: unknown;
       requestUpdate: () => void;
     } = {
       ...createState(async () => undefined, {
@@ -943,10 +944,20 @@ describe("applySessionsChangedEvent", () => {
       ts: 2,
     });
 
-    expect(applied).toEqual({ applied: true, change: "updated", clearedChatRun: true });
+    expect(applied).toEqual({
+      applied: true,
+      change: "updated",
+      clearedChatRun: true,
+      clearedChatRunStatus: {
+        phase: "done",
+        runId: "run-1",
+        sessionKey: "agent:super:main",
+      },
+    });
     expect(state.chatRunId).toBeNull();
     expect(state.chatStream).toBeNull();
     expect(state.chatStreamStartedAt).toBeNull();
+    expect(state.chatRunStatus).toBeUndefined();
     expect(requestUpdate).toHaveBeenCalled();
   });
 
@@ -957,6 +968,7 @@ describe("applySessionsChangedEvent", () => {
       chatRunId: string | null;
       chatStream: string | null;
       chatStreamStartedAt: number | null;
+      chatRunStatus?: unknown;
       requestUpdate: () => void;
     } = {
       ...createState(async () => undefined, {
@@ -994,10 +1006,20 @@ describe("applySessionsChangedEvent", () => {
       ts: 2,
     });
 
-    expect(applied).toEqual({ applied: true, change: "updated", clearedChatRun: true });
+    expect(applied).toEqual({
+      applied: true,
+      change: "updated",
+      clearedChatRun: true,
+      clearedChatRunStatus: {
+        phase: "done",
+        runId: "client-run-1",
+        sessionKey: "agent:super:main",
+      },
+    });
     expect(state.chatRunId).toBeNull();
     expect(state.chatStream).toBeNull();
     expect(state.chatStreamStartedAt).toBeNull();
+    expect(state.chatRunStatus).toBeUndefined();
     expect(requestUpdate).toHaveBeenCalled();
   });
 

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -1,4 +1,7 @@
-import { reconcileChatRunFromCurrentSessionRow } from "../chat/run-lifecycle.ts";
+import {
+  reconcileChatRunFromCurrentSessionRow,
+  type ChatRunUiStatus,
+} from "../chat/run-lifecycle.ts";
 import { toNumber } from "../format.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import type {
@@ -51,6 +54,7 @@ export type LoadSessionsOverrides = {
   showArchived?: boolean;
   configuredAgentsOnly?: boolean;
   append?: boolean;
+  publishChatRunStatus?: boolean;
 };
 
 type CreateSessionParams = {
@@ -338,7 +342,12 @@ async function runCompactionMutation<T>(
 
 export type SessionsChangedApplyResult =
   | { applied: false }
-  | { applied: true; change: "deleted" | "inserted" | "updated"; clearedChatRun?: boolean };
+  | {
+      applied: true;
+      change: "deleted" | "inserted" | "updated";
+      clearedChatRun?: boolean;
+      clearedChatRunStatus?: Pick<ChatRunUiStatus, "phase" | "runId" | "sessionKey">;
+    };
 
 export function applySessionsChangedEvent(
   state: SessionsState,
@@ -434,11 +443,19 @@ export function applySessionsChangedEvent(
     count: existingIndex >= 0 ? state.sessionsResult.count : state.sessionsResult.count + 1,
     sessions,
   };
+  const hasCurrentSession = hasCurrentChatSession(state);
+  const currentChatRunId = state.chatRunId ?? null;
+  const currentChatSessionKey = hasCurrentSession ? state.sessionKey : null;
   const clearedChatRun =
     nextRow.hasActiveRun !== true &&
-    hasCurrentChatSession(state) &&
-    sessionPatchTargetsCurrentChatRun(state, { changedSessionKey: key, eventRunId }) &&
-    reconcileChatRunFromCurrentSessionRow(state);
+    hasCurrentSession &&
+    sessionPatchTargetsCurrentChatRun(state, {
+      changedSessionKey: key,
+      eventRunId,
+    }) &&
+    reconcileChatRunFromCurrentSessionRow(state, {
+      publishRunStatus: false,
+    });
 
   if (previousCheckpointSignature !== checkpointSummarySignature(nextRow)) {
     invalidateCheckpointCacheForKey(state, key);
@@ -447,6 +464,15 @@ export function applySessionsChangedEvent(
     applied: true,
     change: existingIndex >= 0 ? "updated" : "inserted",
     ...(clearedChatRun ? { clearedChatRun: true } : {}),
+    ...(clearedChatRun && currentChatSessionKey != null
+      ? {
+          clearedChatRunStatus: {
+            phase: nextRow.status === "done" ? "done" : "interrupted",
+            runId: currentChatRunId,
+            sessionKey: currentChatSessionKey,
+          },
+        }
+      : {}),
   };
 }
 
@@ -551,7 +577,9 @@ async function loadSessionsOnce(
           ? appendSessionsResult(state.sessionsResult, projected)
           : projected;
       if (hasCurrentChatSession(state)) {
-        reconcileChatRunFromCurrentSessionRow(state);
+        reconcileChatRunFromCurrentSessionRow(state, {
+          publishRunStatus: overrides?.publishChatRunStatus !== false,
+        });
       }
       const nextKeys = new Set(state.sessionsResult.sessions.map((row) => row.key));
       for (const key of Object.keys(state.sessionsCheckpointItemsByKey)) {


### PR DESCRIPTION
## Summary

- Problem: WebChat could show the terminal `Done` run indicator before the final assistant reply was visible when a terminal session patch raced with a deferred chat-history reload.
- Solution: Keep clearing stale local run/stream state immediately, but defer publishing the visible terminal run status until after deferred history replay finishes.
- What changed: Session reconciliation now returns the terminal run-status payload separately from local run cleanup, and gateway replay publishes it after history has reloaded.
- What did NOT change (scope boundary): No provider behavior, prompt policy, auth, channel delivery, tool execution, or gateway protocol semantics changed.

## Motivation

- Closes #85374. The reported user-facing failure mode is misleading UI state: the run looked complete while WebChat still had not rendered the final assistant text.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #85374
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

Behavior addressed: WebChat no longer shows the terminal `Done` run indicator before the final assistant reply is rendered after a session completion/history reload race.

Real environment tested: Local patched checkout on macOS, Control UI served by the patched gateway on `127.0.0.1:18890`, existing normal OpenClaw state/auth store, model `google/gemini-2.5-flash`.

Exact steps or command run after this patch:

```sh
OPENCLAW_BUILD_ALL_NO_PNPM=1 node scripts/build-all.mjs
OPENCLAW_BUILD_ALL_NO_PNPM=1 node scripts/ui.js build
OPENCLAW_GATEWAY_PORT=18890 \
OPENCLAW_SKIP_CHANNELS=1 \
OPENCLAW_DEBUG_MODEL_TRANSPORT=1 \
OPENCLAW_DEBUG_SSE=events \
node scripts/run-node.mjs gateway --auth token --token <throwaway-token>
```

Opened `http://127.0.0.1:18890/chat?token=<throwaway-token>` in Chrome and sent:

```text
PROOF-85374-WEBCHAT: Reply with exactly three concise sentences about why completion indicators should wait for rendered assistant text.
```

Evidence after fix: Copied DOM timing sample and redacted gateway log from the local patched run.

Relevant DOM timing excerpt:

```json
[
  {
    "tMs": 3263,
    "phase": "poll",
    "status": "Run status: In progress ... In progress",
    "assistantTextCount": 1,
    "lastAssistantTextLength": 39,
    "lastAssistantTextPreview": "Completion indicators should accurately",
    "hasDone": false,
    "hasInProgress": true
  },
  {
    "tMs": 3515,
    "phase": "poll",
    "status": "Run status: Done \\n        Done",
    "assistantTextCount": 1,
    "lastAssistantTextLength": 407,
    "lastAssistantTextPreview": "Completion indicators should accurately reflect when the user can perceive the assistant's full response, not just when the underlying model finishes generating. Displaying them prematurely can create a confusing or jarr",
    "hasDone": true,
    "hasInProgress": false
  },
  {
    "tMs": 4516,
    "phase": "after-done-settle",
    "status": "Run status: Done \\n        Done",
    "assistantTextCount": 1,
    "lastAssistantTextLength": 407,
    "lastAssistantTextPreview": "Completion indicators should accurately reflect when the user can perceive the assistant's full response, not just when the underlying model finishes generating. Displaying them prematurely can create a confusing or jarr",
    "hasDone": true,
    "hasInProgress": false
  }
]
```

Redacted gateway log excerpt:

```text
2026-05-22T21:38:58.060-04:00 [gateway] loading configuration…
2026-05-22T21:38:58.180-04:00 [gateway] resolving authentication…
2026-05-22T21:38:58.193-04:00 [gateway] starting...
2026-05-22T21:38:59.352-04:00 [gateway] starting HTTP server...
2026-05-22T21:39:01.369-04:00 [gateway] agent model: google/gemini-2.5-flash (thinking=medium, fast=off)
2026-05-22T21:39:01.371-04:00 [gateway] http server listening (10 plugins: acpx, bonjour, browser, canvas, device-pair, file-transfer, memory-core, phone-control, talk-voice, telegram; 3.2s)
2026-05-22T21:39:01.904-04:00 [gateway] ready
2026-05-22T21:39:25.628-04:00 [ws] webchat connected conn=34e4220f-f6a7-4824-99b1-883ed6810c7a remote=127.0.0.1 client=openclaw-control-ui webchat v2026.5.22
2026-05-22T21:39:48.719-04:00 [ws] ⇄ res ✓ sessions.create 114ms conn=34e4220f…0c7a id=8a92a130…5ab8
2026-05-22T21:40:22.978-04:00 [ws] ⇄ res ✓ chat.send 482ms runId=35290c72-26e2-4936-939d-3637e3ce2006 conn=34e4220f…0c7a id=80424e20…2df1
2026-05-22T21:40:39.733-04:00 [agent/embedded] [trace:embedded-run] prep stages: runId=35290c72-26e2-4936-939d-3637e3ce2006 sessionId=0093f05a-40ff-4ceb-b7cd-12318aaf01e5 phase=stream-ready totalMs=11944 stages=workspace-sandbox:0ms@0ms,skills:1ms@1ms,core-plugin-tools:8953ms@8954ms,bootstrap-context:27ms@8981ms,bundle-tools:224ms@9205ms,system-prompt:2449ms@11654ms,session-resource-loader:253ms@11907ms,agent-session:4ms@11911ms,stream-setup:33ms@11944ms
2026-05-22T21:40:42.460-04:00 [provider-transport-fetch] [model-fetch] start provider=google api=google-generative-ai model=gemini-2.5-flash method=POST url=https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent timeoutMs=120000 proxy=none policy=custom
2026-05-22T21:40:44.400-04:00 [provider-transport-fetch] [model-fetch] response provider=google api=google-generative-ai model=gemini-2.5-flash status=200 elapsedMs=1940 contentType=text/event-stream
```

Observed result after fix: The run stayed `In progress` while the assistant message began rendering. The UI only showed `Done` once the rendered assistant reply was present in the chat DOM (`assistantTextCount: 1`, `lastAssistantTextLength: 407`).

What was not tested: I did not test Telegram/Slack/Discord channel delivery for this proof because the bug and fix are specific to WebChat/Control UI run-status ordering.

Before evidence (optional but encouraged): The linked issue describes the pre-fix symptom: the run-complete indicator appeared before WebChat displayed the assistant response text.

## Root Cause (if applicable)

- Root cause: `reconcileChatRunFromCurrentSessionRow()` treated a terminal session patch as both local run cleanup and user-visible terminal status publication. In `session.message` / `sessions.changed` paths, that could happen before the deferred `loadChatHistory()` replay finished rendering the final assistant message.
- Missing detection / guardrail: Existing tests asserted deferred history replay and queue flushing, but did not assert that `chatRunStatus` remained hidden until the replay completed.
- Contributing context (if known): Unknown.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/ui/app-gateway.sessions.node.test.ts`, `ui/src/ui/controllers/sessions.test.ts`
- Scenario the test should lock in: A terminal session patch may clear stale local run state, but must not publish `Done` until deferred history reload/replay finishes.
- Why this is the smallest reliable guardrail: The race is in the gateway/session reconciliation seam, not provider output or browser rendering primitives.
- Existing test that already covers this (if any): Existing queue-flush replay tests covered ordering around `loadChatHistory()`, but not visible run-status publication.
- If no new test is added, why not: N/A; focused regression assertions were added.

## User-visible / Behavior Changes

WebChat now keeps the in-progress run indicator visible until the final assistant reply is rendered, then shows the terminal `Done` indicator.

## Diagram (if applicable)

```text
Before:
session terminal patch -> clear run + show Done -> deferred history reload -> final reply visible

After:
session terminal patch -> clear local run state -> deferred history reload -> final reply visible -> show Done
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

Security/runtime controls unchanged: this fix does not rely on prompt text or model compliance. It only changes Control UI state publication order after runtime session state and history replay complete; existing gateway auth, provider auth, tool execution, channel startup, and session permissions are unchanged.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Local patched source checkout, Node runtime through `scripts/run-node.mjs`
- Model/provider: `google/gemini-2.5-flash`
- Integration/channel (if any): WebChat / Control UI only
- Relevant config (redacted): Gateway token override used a throwaway token; channels skipped with `OPENCLAW_SKIP_CHANNELS=1`.

### Steps

1. Run the patched gateway and built Control UI on `127.0.0.1:18890`.
2. Open WebChat with a throwaway token.
3. Send a prompt that causes a normal model-backed assistant reply.
4. Sample the DOM for run status and rendered assistant text during completion.

### Expected

- `Done` appears only after the assistant reply is visible in the chat DOM.

### Actual

- Matched expected. DOM sample showed assistant text present while status was still `In progress`, then `Done` appeared after the reply text was present.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Local WebChat send using real gateway, real model provider response, deferred history/status DOM sampling, and focused regression tests.
- Edge cases checked: Session patch clearing local run state without immediately publishing `Done`; deferred history replay publishing `Done` after reload; stale active run cleared by session refresh.
- What you did **not** verify: Non-WebChat channel delivery and broad full-suite CI beyond changed checks.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Delaying terminal status could hide `Done` if the session row is unavailable after a refresh.
  - Mitigation: Local run cleanup still happens immediately, queued work still flushes, and terminal status is only published when the terminal row/status is known rather than inventing an outcome.

## Tests

```sh
git diff --check
node scripts/run-vitest.mjs ui/src/ui/app-gateway.sessions.node.test.ts ui/src/ui/controllers/sessions.test.ts ui/src/ui/controllers/chat.test.ts ui/src/ui/chat/run-controls.test.ts
npm_config_minimum_release_age=0 pnpm check:changed
```

Also ran the direct changed-check lane commands after the first local `pnpm check:changed` attempt was blocked by local pnpm bootstrap release-age enforcement.

## Out-of-scope follow-ups

- No changes to Telegram, Slack, Discord, or other channel delivery flows.
- No changes to provider streaming behavior or model/tool runtime policy.
- No broad Control UI status-indicator redesign beyond this completion-ordering fix.

Made with [Cursor](https://cursor.com)