### PR TITLE
fix(agents): preserve latest thinking replay signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/TUI: preserve source-reply metadata through reply normalization and emit message-tool-only agent replies over the live chat stream so `openclaw tui` renders Codex replies without waiting for a history refresh. Thanks @shakkernerd.
 - Codex/TUI: keep long source-reply runs alive after Codex reasoning completes so delayed visible `message` calls can still reach `openclaw tui`. Thanks @shakkernerd.
 - TUI: keep quiet active runs busy after the response watchdog notice instead of reopening the prompt and encouraging duplicate submissions while the backend turn is still running. Thanks @shakkernerd.
+- Agents: preserve the latest assistant thinking blocks while stripping invalid replay signatures from older turns, and retry Anthropic thinking failures without thinking replay. Fixes #85557. Thanks @bryanbaer.
 - Agents: keep parallel OpenAI-compatible tool-call deltas in separate argument buffers so interleaved tool calls no longer corrupt streamed arguments. (#82263) Thanks @luna-system.
 - Memory/doctor: report missing or unusable QMD workspace directories as workspace failures instead of generic binary failures. (#63167) Thanks @sercada.
 - Debug proxy: record CONNECT client-socket errors and destroy the paired upstream socket so abrupt client disconnects no longer leak tunnel resources. (#82444) Thanks @SebTardif.

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test-harness.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test-harness.ts
@@ -13,6 +13,7 @@ export type SanitizeSessionHistoryFn = (params: {
   sessionId: string;
   modelId?: string;
   policy?: TranscriptPolicy;
+  preserveLatestAssistantThinking?: boolean;
 }) => Promise<AgentMessage[]>;
 type SanitizeSessionHistoryMockedHelpers = typeof import("./pi-embedded-helpers.js");
 export type SanitizeSessionHistoryHarness = {

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -141,6 +141,7 @@ describe("sanitizeSessionHistory", () => {
     modelApi?: string;
     modelId?: string;
     policy?: TranscriptPolicy;
+    preserveLatestAssistantThinking?: boolean;
   }) =>
     sanitizeSessionHistory({
       messages: params.messages,
@@ -150,6 +151,7 @@ describe("sanitizeSessionHistory", () => {
       sessionManager: makeMockSessionManager(),
       sessionId: TEST_SESSION_ID,
       policy: params.policy,
+      preserveLatestAssistantThinking: params.preserveLatestAssistantThinking,
     });
 
   const getAssistantMessage = (messages: AgentMessage[]) => {
@@ -1489,7 +1491,14 @@ describe("sanitizeSessionHistory", () => {
       makeAssistantMessage([
         { type: "thinking", thinking: "missing signature" },
         { type: "thinking", thinking: "blank signature", thinkingSignature: "   " },
-        { type: "thinking", thinking: "signed", thinkingSignature: "sig_latest" },
+        { type: "thinking", thinking: "signed", thinkingSignature: "sig_old" },
+        { type: "text", text: "old visible answer" },
+      ]),
+      makeUserMessage("second"),
+      makeAssistantMessage([
+        { type: "thinking", thinking: "latest missing signature" },
+        { type: "thinking", thinking: "latest blank signature", thinkingSignature: "   " },
+        { type: "thinking", thinking: "latest signed", thinkingSignature: "sig_latest" },
         { type: "text", text: "latest visible answer" },
       ]),
     ]);
@@ -1502,10 +1511,57 @@ describe("sanitizeSessionHistory", () => {
     });
 
     expect((result[1] as Extract<AgentMessage, { role: "assistant" }>).content).toEqual([
-      { type: "thinking", thinking: "signed", thinkingSignature: "sig_latest" },
+      { type: "thinking", thinking: "signed", thinkingSignature: "sig_old" },
+      { type: "text", text: "old visible answer" },
+    ]);
+    expect((result[3] as Extract<AgentMessage, { role: "assistant" }>).content).toEqual([
+      { type: "thinking", thinking: "latest missing signature" },
+      { type: "thinking", thinking: "latest blank signature", thinkingSignature: "   " },
+      { type: "thinking", thinking: "latest signed", thinkingSignature: "sig_latest" },
       { type: "text", text: "latest visible answer" },
     ]);
   });
+
+  it.each([
+    {
+      provider: "anthropic",
+      modelApi: "anthropic-messages",
+      label: "anthropic",
+    },
+    {
+      provider: "amazon-bedrock",
+      modelApi: "bedrock-converse-stream",
+      label: "bedrock",
+    },
+  ])(
+    "strips invalid latest thinking signatures for $label when replay appends another turn",
+    async ({ provider, modelApi }) => {
+      setNonGoogleModelApi();
+
+      const messages = castAgentMessages([
+        makeUserMessage("first"),
+        makeAssistantMessage([
+          { type: "thinking", thinking: "latest missing signature" },
+          { type: "thinking", thinking: "latest blank signature", thinkingSignature: "   " },
+          { type: "thinking", thinking: "latest signed", thinkingSignature: "sig_latest" },
+          { type: "text", text: "latest visible answer" },
+        ]),
+      ]);
+
+      const result = await sanitizeAnthropicHistory({
+        provider,
+        modelApi,
+        messages,
+        modelId: "claude-sonnet-4-6",
+        preserveLatestAssistantThinking: false,
+      });
+
+      expect((result[1] as Extract<AgentMessage, { role: "assistant" }>).content).toEqual([
+        { type: "thinking", thinking: "latest signed", thinkingSignature: "sig_latest" },
+        { type: "text", text: "latest visible answer" },
+      ]);
+    },
+  );
 
   it.each([
     {
@@ -1526,6 +1582,10 @@ describe("sanitizeSessionHistory", () => {
       const messages = castAgentMessages([
         makeUserMessage("first"),
         makeAssistantMessage([{ type: "thinking", thinking: "blank", thinkingSignature: "" }]),
+        makeUserMessage("second"),
+        makeAssistantMessage([
+          { type: "thinking", thinking: "latest blank", thinkingSignature: "" },
+        ]),
       ]);
 
       const result = await sanitizeAnthropicHistory({
@@ -1537,6 +1597,9 @@ describe("sanitizeSessionHistory", () => {
 
       expect((result[1] as Extract<AgentMessage, { role: "assistant" }>).content).toEqual([
         { type: "text", text: OMITTED_ASSISTANT_REASONING_TEXT },
+      ]);
+      expect((result[3] as Extract<AgentMessage, { role: "assistant" }>).content).toEqual([
+        { type: "thinking", thinking: "latest blank", thinkingSignature: "" },
       ]);
     },
   );

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -1146,6 +1146,7 @@ async function compactEmbeddedPiSessionDirectOnce(
             sessionManager,
             sessionId: params.sessionId,
             policy: transcriptPolicy,
+            preserveLatestAssistantThinking: false,
           });
           const validated = await validateReplayTurns({
             messages: prior,

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -675,6 +675,7 @@ export async function sanitizeSessionHistory(params: {
   sessionManager: SessionManager;
   sessionId: string;
   policy?: TranscriptPolicy;
+  preserveLatestAssistantThinking?: boolean;
 }): Promise<AgentMessage[]> {
   // Keep docs/reference/transcript-hygiene.md in sync with any logic changes here.
   const policy =
@@ -723,7 +724,9 @@ export async function sanitizeSessionHistory(params: {
     },
   );
   const validatedThinkingSignatures = policy.preserveSignatures
-    ? stripInvalidThinkingSignatures(sanitizedImages)
+    ? stripInvalidThinkingSignatures(sanitizedImages, {
+        preserveLatestAssistant: params.preserveLatestAssistantThinking ?? true,
+      })
     : sanitizedImages;
   const droppedReasoning = policy.dropReasoningFromHistory
     ? dropReasoningFromHistory(validatedThinkingSignatures)

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -261,7 +261,11 @@ import {
   resolveEmbeddedAgentStreamFn,
 } from "../stream-resolution.js";
 import { applySystemPromptOverrideToSession } from "../system-prompt.js";
-import { dropReasoningFromHistory, dropThinkingBlocks } from "../thinking.js";
+import {
+  dropReasoningFromHistory,
+  dropThinkingBlocks,
+  wrapAnthropicStreamWithRecovery,
+} from "../thinking.js";
 import {
   collectAllowedToolNames,
   collectCoreBuiltinToolNames,
@@ -2779,10 +2783,10 @@ export async function runEmbeddedAttempt(
         activeSession.agent.streamFn = cacheTrace.wrapStreamFn(activeSession.agent.streamFn);
       }
 
-      // Anthropic Claude endpoints can reject replayed `thinking` blocks
-      // (e.g. thinkingSignature:"reasoning_text") on any follow-up provider
-      // call, including tool continuations. Wrap the stream function so every
-      // outbound request sees sanitized messages.
+      // Anthropic Claude endpoints can reject replayed `thinking` blocks on
+      // any follow-up provider call, including tool continuations. Sanitize
+      // outbound messages where policy allows rewriting; otherwise preserve
+      // latest thinking and let the recovery wrapper retry once without it.
       if (transcriptPolicy.dropThinkingBlocks || transcriptPolicy.dropReasoningFromHistory) {
         const inner = activeSession.agent.streamFn;
         activeSession.agent.streamFn = (model, context, options) => {
@@ -2806,6 +2810,18 @@ export async function runEmbeddedAttempt(
           } as unknown;
           return inner(model, nextContext as typeof context, options);
         };
+      }
+      if (
+        transcriptPolicy.preserveSignatures ||
+        transcriptPolicy.dropThinkingBlocks ||
+        transcriptPolicy.dropReasoningFromHistory
+      ) {
+        activeSession.agent.streamFn = wrapAnthropicStreamWithRecovery(
+          activeSession.agent.streamFn,
+          {
+            id: activeSession.sessionId,
+          },
+        );
       }
 
       // Mistral (and other strict providers) reject tool call IDs that don't match their

--- a/src/agents/pi-embedded-runner/thinking.test.ts
+++ b/src/agents/pi-embedded-runner/thinking.test.ts
@@ -279,7 +279,58 @@ describe("stripInvalidThinkingSignatures", () => {
     expect(result).toBe(messages);
   });
 
-  it("strips thinking blocks with missing, empty, or blank signatures", () => {
+  it("preserves invalid thinking signatures on the latest assistant message", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({ role: "user", content: "hello" }),
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "missing" },
+          { type: "thinking", thinking: "empty", thinkingSignature: "" },
+          { type: "thinking", thinking: "blank", thinkingSignature: "   " },
+          { type: "thinking", thinking: "signed", thinkingSignature: "sig" },
+          { type: "text", text: "answer" },
+        ],
+      }),
+    ];
+
+    const result = stripInvalidThinkingSignatures(messages);
+    const assistant = result[1] as Extract<AgentMessage, { role: "assistant" }>;
+
+    expect(result).toBe(messages);
+    expect(assistant.content).toEqual([
+      { type: "thinking", thinking: "missing" },
+      { type: "thinking", thinking: "empty", thinkingSignature: "" },
+      { type: "thinking", thinking: "blank", thinkingSignature: "   " },
+      { type: "thinking", thinking: "signed", thinkingSignature: "sig" },
+      { type: "text", text: "answer" },
+    ]);
+  });
+
+  it("can strip invalid thinking signatures from the latest assistant message", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({ role: "user", content: "hello" }),
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "missing" },
+          { type: "thinking", thinking: "signed", thinkingSignature: "sig" },
+          { type: "text", text: "answer" },
+        ],
+      }),
+    ];
+
+    const result = stripInvalidThinkingSignatures(messages, { preserveLatestAssistant: false });
+    const assistant = result[1] as Extract<AgentMessage, { role: "assistant" }>;
+
+    expect(result).not.toBe(messages);
+    expect(assistant.content).toEqual([
+      { type: "thinking", thinking: "signed", thinkingSignature: "sig" },
+      { type: "text", text: "answer" },
+    ]);
+  });
+
+  it("strips thinking blocks with missing, empty, or blank signatures from older assistant messages", () => {
     const messages: AgentMessage[] = [
       castAgentMessage({
         role: "assistant",
@@ -291,6 +342,8 @@ describe("stripInvalidThinkingSignatures", () => {
           { type: "text", text: "answer" },
         ],
       }),
+      castAgentMessage({ role: "user", content: "follow up" }),
+      castAgentMessage({ role: "assistant", content: [{ type: "text", text: "latest" }] }),
     ];
 
     const result = stripInvalidThinkingSignatures(messages);
@@ -309,6 +362,8 @@ describe("stripInvalidThinkingSignatures", () => {
         role: "assistant",
         content: [{ type: "thinking", thinking: "reasoning", thinkingSignature: "" }],
       }),
+      castAgentMessage({ role: "user", content: "follow up" }),
+      castAgentMessage({ role: "assistant", content: [{ type: "text", text: "latest" }] }),
     ];
 
     const result = stripInvalidThinkingSignatures(messages);
@@ -317,7 +372,7 @@ describe("stripInvalidThinkingSignatures", () => {
     expect(assistant.content).toEqual([{ type: "text", text: OMITTED_ASSISTANT_REASONING_TEXT }]);
   });
 
-  it("strips redacted thinking blocks with invalid opaque signatures", () => {
+  it("strips redacted thinking blocks with invalid opaque signatures from older assistant messages", () => {
     const messages: AgentMessage[] = [
       castAgentMessage({
         role: "assistant",
@@ -328,6 +383,8 @@ describe("stripInvalidThinkingSignatures", () => {
           { type: "text", text: "answer" },
         ],
       }),
+      castAgentMessage({ role: "user", content: "follow up" }),
+      castAgentMessage({ role: "assistant", content: [{ type: "text", text: "latest" }] }),
     ];
 
     const result = stripInvalidThinkingSignatures(messages);
@@ -497,6 +554,36 @@ describe("wrapAnthropicStreamWithRecovery", () => {
     expect(retryMessage.content).toEqual([{ type: "text", text: "visible answer" }]);
   });
 
+  it("retries Bedrock-style invalid thinking signature errors", async () => {
+    let callCount = 0;
+    const bedrockThinkingError = new Error(
+      "ValidationException: invalid signature on thinking block in message history",
+    );
+    const wrapped = wrapAnthropicStreamWithRecovery(
+      (() => {
+        callCount += 1;
+        return Promise.reject(bedrockThinkingError);
+      }) as Parameters<typeof wrapAnthropicStreamWithRecovery>[0],
+      { id: "test-session" },
+    );
+
+    await expect(
+      wrapped(
+        {} as never,
+        {
+          messages: castAgentMessages([
+            {
+              role: "assistant",
+              content: [{ type: "thinking", thinking: "secret", thinkingSignature: "" }],
+            },
+          ]),
+        } as never,
+        {} as never,
+      ),
+    ).rejects.toBe(bedrockThinkingError);
+    expect(callCount).toBe(2);
+  });
+
   it("does not retry when the stream fails after yielding a chunk", async () => {
     let callCount = 0;
     const wrapped = wrapAnthropicStreamWithRecovery(
@@ -538,6 +625,34 @@ describe("wrapAnthropicStreamWithRecovery", () => {
       rateLimitError,
     );
     expect(callCount).toBe(1);
+  });
+
+  it("allows each provider call to recover once", async () => {
+    let callCount = 0;
+    const wrapped = wrapAnthropicStreamWithRecovery(
+      (() => {
+        callCount += 1;
+        return Promise.reject(anthropicThinkingError);
+      }) as Parameters<typeof wrapAnthropicStreamWithRecovery>[0],
+      { id: "test-session" },
+    );
+    const context = {
+      messages: castAgentMessages([
+        {
+          role: "assistant",
+          content: [{ type: "thinking", thinking: "secret", thinkingSignature: "sig" }],
+        },
+      ]),
+    };
+
+    await expect(wrapped({} as never, context as never, {} as never)).rejects.toBe(
+      anthropicThinkingError,
+    );
+    await expect(wrapped({} as never, context as never, {} as never)).rejects.toBe(
+      anthropicThinkingError,
+    );
+
+    expect(callCount).toBe(4);
   });
 
   it("preserves result() for synchronous event streams", async () => {

--- a/src/agents/pi-embedded-runner/thinking.ts
+++ b/src/agents/pi-embedded-runner/thinking.ts
@@ -8,7 +8,8 @@ type AssistantMessage = Extract<AgentMessage, { role: "assistant" }>;
 type RecoveryAssessment = "valid" | "incomplete-thinking" | "incomplete-text";
 type RecoverySessionMeta = { id: string; recoveredAnthropicThinking?: boolean };
 
-const THINKING_BLOCK_ERROR_PATTERN = /thinking or redacted_thinking blocks?.* cannot be modified/i;
+const THINKING_BLOCK_ERROR_PATTERN =
+  /(?:thinking|redacted_thinking).*?(?:cannot be modified|signature|invalid|missing|empty|blank)|(?:signature|invalid|missing|empty|blank).*?(?:thinking|redacted_thinking)/i;
 export const OMITTED_ASSISTANT_REASONING_TEXT = "[assistant reasoning omitted]";
 
 export function isAssistantMessageWithContent(message: AgentMessage): message is AssistantMessage {
@@ -106,13 +107,38 @@ function hasReplayableThinkingSignature(block: AssistantContentBlock): boolean {
  * Anthropic and Bedrock reject persisted thinking blocks when the signature is
  * absent, empty, or blank. They are also the authority for opaque signature
  * validity, so this intentionally avoids local length or shape heuristics.
+ *
+ * By default, the latest assistant turn is exempt: providers reject modified
+ * latest thinking blocks, so corrupted latest turns must flow through recovery
+ * rather than being rewritten before the request. Callers that append a new
+ * user turn before provider replay can disable that exemption because the
+ * stored assistant turn is no longer latest in the outbound request.
  */
-export function stripInvalidThinkingSignatures(messages: AgentMessage[]): AgentMessage[] {
+export function stripInvalidThinkingSignatures(
+  messages: AgentMessage[],
+  options: { preserveLatestAssistant?: boolean } = {},
+): AgentMessage[] {
+  const preserveLatestAssistant = options.preserveLatestAssistant ?? true;
+  let latestAssistantIndex = -1;
+  if (preserveLatestAssistant) {
+    for (let i = messages.length - 1; i >= 0; i -= 1) {
+      if (isAssistantMessageWithContent(messages[i])) {
+        latestAssistantIndex = i;
+        break;
+      }
+    }
+  }
+
   let touched = false;
   const out: AgentMessage[] = [];
 
-  for (const message of messages) {
+  for (let i = 0; i < messages.length; i += 1) {
+    const message = messages[i];
     if (!isAssistantMessageWithContent(message)) {
+      out.push(message);
+      continue;
+    }
+    if (i === latestAssistantIndex) {
       out.push(message);
       continue;
     }
@@ -433,6 +459,7 @@ export function wrapAnthropicStreamWithRecovery(
   sessionMeta: RecoverySessionMeta,
 ): StreamFn {
   return (model, context, options) => {
+    const requestMeta: RecoverySessionMeta = { id: sessionMeta.id };
     const contextRecord = context as unknown as { messages?: unknown };
     const originalMessages = Array.isArray(contextRecord.messages)
       ? (contextRecord.messages as AgentMessage[])
@@ -449,18 +476,18 @@ export function wrapAnthropicStreamWithRecovery(
     const stream = innerStreamFn(model, context, options);
     if (stream instanceof Promise) {
       return stream.catch((error: unknown) => {
-        if (!shouldRecoverAnthropicThinkingError(error, sessionMeta)) {
+        if (!shouldRecoverAnthropicThinkingError(error, requestMeta)) {
           throw error;
         }
-        sessionMeta.recoveredAnthropicThinking = true;
+        requestMeta.recoveredAnthropicThinking = true;
         log.warn(
-          `[session-recovery] Anthropic thinking request rejected; retrying once without thinking blocks: sessionId=${sessionMeta.id}`,
+          `[session-recovery] Anthropic thinking request rejected; retrying once without thinking blocks: sessionId=${requestMeta.id}`,
         );
         return retry();
       }) as ReturnType<StreamFn>;
     }
     const outer = createAssistantMessageEventStream();
-    const finalResultPromise = pumpStreamWithRecovery(outer, stream, sessionMeta, retry).finally(
+    const finalResultPromise = pumpStreamWithRecovery(outer, stream, requestMeta, retry).finally(
       () => {
         outer.end();
       },


### PR DESCRIPTION
## Summary

Fixes #85557.

`stripInvalidThinkingSignatures` now preserves the latest assistant message by default while continuing to strip invalid thinking signatures from older replay turns. That matches the existing `dropThinkingBlocks` invariant and Anthropic's latest-turn replay contract for thinking blocks.

The normal run path now wraps preserve-signature Anthropic-compatible replay in the existing thinking recovery retry, so an opaque provider-side signature rejection retries once without thinking replay instead of wedging the session. Recovery state is request-local, so each provider call can recover once.

Compaction opts out of latest-assistant preservation because it appends a new compaction prompt before provider replay. In that path, stored assistant turns are older history again and invalid signatures are stripped before the compaction request.

## Verification

- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_TEST_PROJECTS_SERIAL=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 node scripts/run-vitest.mjs src/agents/pi-embedded-runner/thinking.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts src/agents/transcript-policy.test.ts src/agents/pi-embedded-runner/run/attempt.test.ts` - passed 7 files / 525 tests on rebased SHA `d53c7f4cd9148389c3baaad160647040ff7dd15c`
- `node_modules/.bin/oxfmt --check --threads=1 CHANGELOG.md src/agents/pi-embedded-runner/thinking.ts src/agents/pi-embedded-runner/replay-history.ts src/agents/pi-embedded-runner/compact.ts src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/thinking.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test-harness.ts`
- `node_modules/.bin/oxlint src/agents/pi-embedded-runner.sanitize-session-history.test-harness.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts src/agents/pi-embedded-runner/compact.ts src/agents/pi-embedded-runner/replay-history.ts src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/thinking.test.ts src/agents/pi-embedded-runner/thinking.ts`
- `git diff --check origin/main...HEAD`
- Blacksmith Testbox through Crabbox: `tbx_01ks9mfvrdqkqjh5kt01m3tgt9`, Actions run https://github.com/openclaw/openclaw/actions/runs/26324478275, command `corepack pnpm check:changed`, exit 0

## Real behavior proof

Behavior addressed: Anthropic-compatible replay no longer mutates the latest assistant `thinking` or `redacted_thinking` blocks when invalid-signature stripping runs, avoiding provider rejections that require latest assistant thinking content to be replayed unchanged. Older invalid thinking blocks still normalize, and provider-side opaque signature failures retry once without thinking replay.

Real environment tested: WSL2 OpenClaw worktree `/root/src/openclaw-85557` at rebased SHA `d53c7f4cd9148389c3baaad160647040ff7dd15c`, plus Blacksmith Testbox through Crabbox on Linux.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/thinking.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts src/agents/transcript-policy.test.ts src/agents/pi-embedded-runner/run/attempt.test.ts`; `corepack pnpm check:changed` on Testbox `tbx_01ks9mfvrdqkqjh5kt01m3tgt9`.

Evidence after fix: focused tests passed 7 files / 525 tests on rebased SHA `d53c7f4cd9148389c3baaad160647040ff7dd15c`, covering latest-assistant preservation, older invalid-signature stripping, compaction opt-out for appended replay prompts, Bedrock-style invalid-signature recovery, and request-local recovery. Testbox `tbx_01ks9mfvrdqkqjh5kt01m3tgt9` changed gate passed core typecheck, core test typecheck, oxlint, import cycles, runtime sidecar, changelog, dependency, and guard lanes.

Observed result after fix: older assistant turns with missing or blank thinking signatures are still stripped or replaced with the omitted-reasoning fallback; the latest assistant turn is preserved unchanged for normal continuation; compaction strips invalid signatures from all stored history before adding its compaction prompt; Anthropic/Bedrock-style thinking signature errors retry once with sanitized recovery history.

What was not tested: live Anthropic or Bedrock API replay with real provider credentials; the proof is source-level plus focused local behavior tests and Linux Testbox changed-gate validation.

## 2026-05-23 update

Rebased onto current `origin/main` at `a1eb765f0a`; refreshed head is `70ec85d145`.

Additional embedded Anthropic-compatible replay proof, run without live provider credentials, using the repo Vitest harness against the same wrapper/sanitizer path used before provider replay:

```text
$ OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_TEST_PROJECTS_SERIAL=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 node scripts/run-vitest.mjs src/agents/pi-embedded-runner/thinking.test.ts src/agents/pi-embedded-runner/run/attempt.test.ts --reporter=verbose -t "preserves invalid thinking signatures on the latest assistant message|can strip invalid thinking signatures from the latest assistant message|retries Bedrock-style invalid thinking signature errors|drops embedded Anthropic user tool_result blocks when signed-thinking replay must stay provider-owned"

✓ stripInvalidThinkingSignatures > preserves invalid thinking signatures on the latest assistant message
✓ stripInvalidThinkingSignatures > can strip invalid thinking signatures from the latest assistant message
✓ wrapAnthropicStreamWithRecovery > retries Bedrock-style invalid thinking signature errors
✓ wrapStreamFnSanitizeMalformedToolCalls > drops embedded Anthropic user tool_result blocks when signed-thinking replay must stay provider-owned

Test Files  3 passed (3)
Tests  5 passed | 318 skipped (323)
```

This targeted proof shows the embedded replay path preserves the latest assistant thinking for normal Anthropic-compatible replay, keeps the explicit compaction/recovery opt-out able to strip it, retries a Bedrock-style invalid-signature provider rejection once, and keeps provider-owned signed-thinking replay from leaking unsafe embedded tool-result blocks.

Fresh validation after rebase:

```text
$ OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_TEST_PROJECTS_SERIAL=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 node scripts/run-vitest.mjs src/agents/pi-embedded-runner/thinking.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts src/agents/transcript-policy.test.ts src/agents/pi-embedded-runner/run/attempt.test.ts --reporter=verbose
Test Files  7 passed (7)
Tests  525 passed (525)

$ ./node_modules/.bin/oxfmt --check --threads=1 CHANGELOG.md src/agents/pi-embedded-runner/thinking.ts src/agents/pi-embedded-runner/replay-history.ts src/agents/pi-embedded-runner/compact.ts src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/thinking.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test-harness.ts
All matched files use the correct format.

$ ./node_modules/.bin/oxlint src/agents/pi-embedded-runner.sanitize-session-history.test-harness.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts src/agents/pi-embedded-runner/compact.ts src/agents/pi-embedded-runner/replay-history.ts src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/thinking.test.ts src/agents/pi-embedded-runner/thinking.ts
Found 0 warnings and 0 errors.

$ git diff --check origin/main...HEAD
passed
```

Still not run: live Anthropic or Bedrock API replay with real provider credentials.
