### PR TITLE
fix(discord): show early typing for guild mentions

### DIFF
--- a/extensions/discord/src/monitor/message-handler.queue.test.ts
+++ b/extensions/discord/src/monitor/message-handler.queue.test.ts
@@ -110,13 +110,9 @@ function createPreflightContext(channelId = "ch-1") {
   };
 }
 
-function createAcceptedDmPreflightContext(overrides: Record<string, unknown> = {}) {
+function createAcceptedPreflightContext(overrides: Record<string, unknown> = {}) {
   return {
     ...createPreflightContext("dm-1"),
-    isDirectMessage: true,
-    isGuildMessage: false,
-    isGroupDm: false,
-    messageText: "hello",
     ...overrides,
   };
 }
@@ -183,7 +179,7 @@ describe("createDiscordMessageHandler queue behavior", () => {
   it("sends an accepted DM typing cue before queued processing starts", async () => {
     preflightDiscordMessageMock.mockReset();
     processDiscordMessageMock.mockReset();
-    preflightDiscordMessageMock.mockResolvedValue(createAcceptedDmPreflightContext());
+    preflightDiscordMessageMock.mockResolvedValue(createAcceptedPreflightContext());
     processDiscordMessageMock.mockResolvedValue(undefined);
 
     const handler = createDiscordMessageHandler(createDiscordHandlerParams());
@@ -213,7 +209,7 @@ describe("createDiscordMessageHandler queue behavior", () => {
     preflightDiscordMessageMock.mockReset();
     processDiscordMessageMock.mockReset();
     earlyTypingMocks.sendTyping.mockRejectedValueOnce(new Error("typing failed"));
-    preflightDiscordMessageMock.mockResolvedValue(createAcceptedDmPreflightContext());
+    preflightDiscordMessageMock.mockResolvedValue(createAcceptedPreflightContext());
     processDiscordMessageMock.mockResolvedValue(undefined);
 
     const handler = createDiscordMessageHandler(createDiscordHandlerParams());
@@ -247,7 +243,7 @@ describe("createDiscordMessageHandler queue behavior", () => {
     preflightDiscordMessageMock.mockReset();
     processDiscordMessageMock.mockReset();
     preflightDiscordMessageMock.mockResolvedValue(
-      createAcceptedDmPreflightContext({
+      createAcceptedPreflightContext({
         cfg: {
           ...createPreflightContext().cfg,
           agents: {
@@ -271,14 +267,16 @@ describe("createDiscordMessageHandler queue behavior", () => {
     expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
   });
 
-  it("does not send early typing for guild messages", async () => {
+  it("sends early typing for accepted guild mentions before queued processing starts", async () => {
     preflightDiscordMessageMock.mockReset();
     processDiscordMessageMock.mockReset();
     preflightDiscordMessageMock.mockResolvedValue(
-      createAcceptedDmPreflightContext({
+      createAcceptedPreflightContext({
         isDirectMessage: false,
         isGuildMessage: true,
         messageChannelId: "guild-channel",
+        wasMentioned: true,
+        effectiveWasMentioned: true,
       }),
     );
     processDiscordMessageMock.mockResolvedValue(undefined);
@@ -286,6 +284,44 @@ describe("createDiscordMessageHandler queue behavior", () => {
     const handler = createDiscordMessageHandler(createDiscordHandlerParams());
     await expect(
       handler(createMessageData("m-guild", "guild-channel") as never, {} as never),
+    ).resolves.toBeUndefined();
+
+    await flushQueueWork();
+
+    expect(earlyTypingMocks.createDiscordRestClient).toHaveBeenCalledTimes(1);
+    const [restClientParams] = mockCall(
+      earlyTypingMocks.createDiscordRestClient,
+      "createDiscordRestClient",
+    );
+    expect((restClientParams as { accountId?: unknown } | undefined)?.accountId).toBe("default");
+    expect((restClientParams as { token?: unknown } | undefined)?.token).toBe("test-token");
+    expect(earlyTypingMocks.sendTyping).toHaveBeenCalledWith({
+      rest: { kind: "discord-rest" },
+      channelId: "guild-channel",
+    });
+    expect(earlyTypingMocks.sendTyping.mock.invocationCallOrder[0]).toBeLessThan(
+      processDiscordMessageMock.mock.invocationCallOrder[0],
+    );
+    expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not send early typing for accepted unmentioned guild messages", async () => {
+    preflightDiscordMessageMock.mockReset();
+    processDiscordMessageMock.mockReset();
+    preflightDiscordMessageMock.mockResolvedValue(
+      createAcceptedPreflightContext({
+        isDirectMessage: false,
+        isGuildMessage: true,
+        messageChannelId: "guild-channel",
+        wasMentioned: false,
+        effectiveWasMentioned: false,
+      }),
+    );
+    processDiscordMessageMock.mockResolvedValue(undefined);
+
+    const handler = createDiscordMessageHandler(createDiscordHandlerParams());
+    await expect(
+      handler(createMessageData("m-guild-unmentioned", "guild-channel") as never, {} as never),
     ).resolves.toBeUndefined();
 
     await flushQueueWork();

--- a/extensions/discord/src/monitor/message-handler.test-helpers.ts
+++ b/extensions/discord/src/monitor/message-handler.test-helpers.ts
@@ -53,6 +53,9 @@ export function createDiscordHandlerParams(overrides?: {
 
 export function createDiscordPreflightContext(channelId = "ch-1") {
   return {
+    cfg: {},
+    accountId: "default",
+    token: "test-token",
     data: {
       channel_id: channelId,
       message: {
@@ -71,5 +74,12 @@ export function createDiscordPreflightContext(channelId = "ch-1") {
     },
     baseSessionKey: `agent:main:discord:channel:${channelId}`,
     messageChannelId: channelId,
+    isDirectMessage: true,
+    isGuildMessage: false,
+    isGroupDm: false,
+    baseText: "hello",
+    messageText: "hello",
+    wasMentioned: false,
+    effectiveWasMentioned: false,
   };
 }

--- a/extensions/discord/src/monitor/message-handler.ts
+++ b/extensions/discord/src/monitor/message-handler.ts
@@ -68,14 +68,19 @@ function shouldSendAcceptedDiscordTypingCue(ctx: DiscordMessagePreflightContext)
   if (ctx.abortSignal?.aborted) {
     return false;
   }
-  if (!ctx.isDirectMessage || ctx.isGuildMessage || ctx.isGroupDm) {
-    return false;
-  }
   if (!ctx.messageText.trim()) {
     return false;
   }
+
   const configuredTypingMode = ctx.cfg.session?.typingMode ?? ctx.cfg.agents?.defaults?.typingMode;
-  return configuredTypingMode === undefined || configuredTypingMode === "instant";
+  if (configuredTypingMode !== undefined) {
+    return configuredTypingMode === "instant";
+  }
+
+  const isDirectMessage = ctx.isDirectMessage && !ctx.isGuildMessage && !ctx.isGroupDm;
+  const isMentionedGuildMessage =
+    ctx.isGuildMessage && (ctx.effectiveWasMentioned || ctx.wasMentioned);
+  return isDirectMessage || isMentionedGuildMessage;
 }
 
 function queueAcceptedDiscordTypingCue(ctx: DiscordMessagePreflightContext): void {


### PR DESCRIPTION
## Summary

- Problem: Discord guild mentions could be accepted and queued without sending the early typing cue, so the bot appeared idle until later agent processing began.
- Solution: Allow the accepted-message early typing cue for mentioned guild messages, while preserving the existing direct-message default and non-instant typing-mode behavior.
- What changed: Updated the Discord message handler predicate and added queue tests for mentioned guild messages, unmentioned guild messages, sendTyping side effects, and processing order.
- What did NOT change (scope boundary): This does not change mention acceptance, reply authorization, model execution, token handling, or Discord message delivery policy.

## Motivation

- Fixes the user-visible delay reported in #85552 where Discord users did not see prompt typing feedback after mentioning the bot in a guild channel.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #85552
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)
<img width="1080" height="1224" alt="Screenshot_20260522-220426~2" src="https://github.com/user-attachments/assets/381555e2-9624-42d1-a372-7630efed9526" />
<img width="1080" height="1216" alt="Screenshot_20260522-220403~2" src="https://github.com/user-attachments/assets/0206fb86-7389-41e7-982d-466d01b06d54" />


Behavior addressed: Discord guild mentions should show OpenClaw typing feedback before the queued agent run finishes, instead of staying visually idle until the final reply.

Real environment tested: macOS 26 / Darwin 25.3.0, Node 24.8.0, patched `openclaw_repo` build from this branch, real Discord bot `@OpenClaw Local Dev 20260311`, Discord guild `openclaw test server` channel `#general`, Google/Gemini provider auth loaded from the local OpenClaw environment. Other channel env vars for Telegram and Slack were unset for this run.

Exact steps or command run after this patch: Stopped the existing launchd-managed OpenClaw gateway, built this branch with `pnpm --config.minimumReleaseAge=0 build`, started the compiled gateway with `node dist/index.js gateway run --force` using a Discord-only redacted config, verified `/healthz`, then sent a real Discord guild mention to the bot and observed the response in Discord.

Evidence after fix: Redacted runtime log proof from the patched gateway showed `http server listening`, `discord channels resolved: 1481298384714338398/1481298387058950239 (guild:openclaw test server; channel:general)`, `[default] Discord bot probe resolved @OpenClaw Local Dev 20260311`, `gateway ready`, `provider auth state pre-warmed`, and an embedded agent run reaching `stream-ready` after the real Discord message. Discord screenshots of the live message/response will be attached by the PR author.

Observed result after fix: The patched gateway accepted and processed the real Discord guild mention and posted a Discord response without the previous provider-auth failure. The unit regression test also verifies the bug-specific timing contract: for accepted guild mentions, `sendTyping` is called for the guild channel before queued processing starts; accepted unmentioned guild messages still do not send the early typing cue by default.

What was not tested: Screenshot attachment is pending manual PR edit. The live screenshot currently proves the real Discord message/response path; the typing-indicator-specific visual proof should be attached as a before-response screenshot or short recording showing Discord's typing indicator before the final reply.

## Root Cause (if applicable)

- Root cause: The early typing cue predicate returned false for every guild message before checking whether the accepted Discord preflight context represented a bot mention.
- Missing detection / guardrail: Queue tests covered direct-message early typing and guild non-typing behavior, but did not cover accepted mentioned guild messages.
- Contributing context (if known): The existing docs/default semantics say group chats with a mention should start typing immediately when typing mode is unset.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/discord/src/monitor/message-handler.queue.test.ts`
- Scenario the test should lock in: Accepted Discord guild mentions send the early typing cue to the guild channel before queued processing starts.
- Why this is the smallest reliable guardrail: The bug lives in the accepted-message queue predicate before agent processing, so the queue test can assert both the `sendTyping` side effect and call ordering without a live Discord dependency.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Discord guild messages that are accepted because they mention the bot now get the same immediate typing feedback that direct messages already received by default. Unmentioned accepted guild messages remain unchanged by default.

## Diagram (if applicable)

```text
Before:
mentioned guild message -> accepted preflight -> no early typing -> queued processing -> reply

After:
mentioned guild message -> accepted preflight -> Discord typing cue -> queued processing -> reply
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes, changed timing/eligibility for the existing Discord typing endpoint on accepted guild mentions only.
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: The only changed network behavior is an existing Discord typing indicator call after runtime preflight has already accepted the message. Mention gating, allowlist/group policy, bot-loop filtering, model/tool authorization, and token handling are unchanged.

Security/runtime controls unchanged: This fix does not rely on prompt text. It relies on runtime-enforced preflight facts (`isGuildMessage`, `wasMentioned` / `effectiveWasMentioned`, accepted message text, and configured typing mode). Existing Discord authorization, mention gating, channel policy, and bot self-filtering remain in place.

## Repro + Verification

### Environment

- OS: macOS 26 / Darwin 25.3.0
- Runtime/container: Node 24.8.0, compiled local OpenClaw gateway from this branch
- Model/provider: `google/gemini-2.5-flash`
- Integration/channel (if any): Discord guild channel
- Relevant config (redacted): Discord enabled; Telegram disabled/denied; Telegram and Slack env vars unset for the test process

### Steps

1. Start patched OpenClaw gateway with Discord enabled and other chat channels disabled/unset.
2. Send a real Discord guild message mentioning the bot.
3. Observe typing feedback and final Discord response.
4. Run focused Discord queue tests and changed-surface checks.

### Expected

- Mentioned guild messages that pass preflight send an early Discord typing cue before queued processing starts.
- Unmentioned guild messages do not send early typing by default.
- Non-instant typing mode still disables this early cue.

### Actual

- Targeted test asserts `sendTyping` is called for the guild channel before `processDiscordMessage`.
- Targeted test asserts accepted unmentioned guild messages do not call `sendTyping` but still process.
- Live patched gateway processed a real Discord guild mention and returned a response.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Mentioned guild early typing side effect/order in unit tests; unmentioned guild no-early-typing default; non-instant typing mode still defers; real Discord guild message/response on the patched compiled gateway.
- Edge cases checked: Empty/rejected messages do not send early typing via existing tests; typing failures do not stop processing via existing tests; test helper defaults now include production-like accepted-message facts.
- What you did **not** verify: Full multi-channel live sweep, release package install/update flow, and cross-platform behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Guild channels could receive typing indicators in more accepted mentioned-message cases than before.
  - Mitigation: The change is limited to messages already accepted by preflight, preserves default suppression for unmentioned guild messages, and respects `typingMode` when explicitly configured.

## Verification

- `pnpm test extensions/discord/src/monitor/message-handler.queue.test.ts -- --reporter=verbose`
- `pnpm test extensions/discord/src/monitor/message-handler.bot-self-filter.test.ts extensions/discord/src/monitor/message-handler.queue.test.ts -- --reporter=verbose`
- `pnpm test:extension discord`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `pnpm check:changed`

## Out-of-scope follow-ups

- No changes to session write-lock behavior.
- No changes to Discord response delivery, content streaming, or message chunking.
- No changes to Telegram, Slack, or other channel typing behavior.
- No generated config/help/docs changes because no config default changed.

Made with [Cursor](https://cursor.com)