### PR TITLE
fix(cron): stop forcing message tool for delivery

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -377,6 +377,72 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(state.delivered).toBe(true);
   });
 
+  it("sends announce fallback when source delivery is not satisfied", async () => {
+    const params = makeBaseParams({ synthesizedText: "Fallback cron summary." });
+
+    const state = await dispatchCronDelivery(params);
+
+    expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+    expectDeliveryCall(0, {
+      channel: "telegram",
+      to: "123456",
+      payloads: [{ text: "Fallback cron summary." }],
+      skipQueue: true,
+    });
+    expect(state.deliveryAttempted).toBe(true);
+    expect(state.delivered).toBe(true);
+  });
+
+  it("skips announce fallback after verified message-tool source delivery", async () => {
+    const params = makeBaseParams({ synthesizedText: "Fallback cron summary." });
+    params.sourceDeliveryOutcome = {
+      visibleDeliveries: [
+        {
+          via: "message_tool",
+          target: { tool: "message", provider: "telegram", to: "123456" },
+          verifiedTarget: true,
+        },
+      ],
+      verifiedMessageToolDelivery: true,
+      satisfiesSourceDelivery: true,
+      unverifiedMessageToolDelivery: false,
+    };
+
+    const state = await dispatchCronDelivery(params);
+
+    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+    expect(state.deliveryAttempted).toBe(true);
+    expect(state.delivered).toBe(true);
+  });
+
+  it("keeps announce fallback when message-tool delivery is not verified for the target", async () => {
+    const params = makeBaseParams({ synthesizedText: "Fallback cron summary." });
+    params.sourceDeliveryOutcome = {
+      visibleDeliveries: [
+        {
+          via: "message_tool",
+          target: { tool: "message", provider: "telegram", to: "999999" },
+          verifiedTarget: false,
+        },
+      ],
+      verifiedMessageToolDelivery: false,
+      satisfiesSourceDelivery: false,
+      unverifiedMessageToolDelivery: true,
+    };
+
+    const state = await dispatchCronDelivery(params);
+
+    expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+    expectDeliveryCall(0, {
+      channel: "telegram",
+      to: "123456",
+      payloads: [{ text: "Fallback cron summary." }],
+      skipQueue: true,
+    });
+    expect(state.deliveryAttempted).toBe(true);
+    expect(state.delivered).toBe(true);
+  });
+
   it("bestEffort delivery skips expected subagent follow-up waits", async () => {
     vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
     vi.mocked(expectsSubagentFollowup).mockReturnValue(true);

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -1208,6 +1208,52 @@ describe("runCronIsolatedAgentTurn delivery instruction", () => {
     expect(prompt).toContain("will be delivered automatically");
   });
 
+  it("prompts for the message tool when toolsAllow uses a group containing message", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: true,
+      mode: "announce",
+      channel: "messagechat",
+      to: "123",
+    });
+
+    await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: makeMessageToolPolicyJob(
+        { mode: "announce", channel: "messagechat", to: "123" },
+        { kind: "agentTurn", message: "send a message", toolsAllow: ["group:messaging"] },
+      ),
+    });
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const prompt = expectEmbeddedRunPrompt();
+    expect(prompt).toContain("Use the message tool");
+    expect(prompt).toContain("will be delivered automatically");
+  });
+
+  it("prompts for the message tool when toolsAllow names message with different casing", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: true,
+      mode: "announce",
+      channel: "messagechat",
+      to: "123",
+    });
+
+    await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: makeMessageToolPolicyJob(
+        { mode: "announce", channel: "messagechat", to: "123" },
+        { kind: "agentTurn", message: "send a message", toolsAllow: ["MESSAGE"] },
+      ),
+    });
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const prompt = expectEmbeddedRunPrompt();
+    expect(prompt).toContain("Use the message tool");
+    expect(prompt).toContain("will be delivered automatically");
+  });
+
   it("does not append a delivery instruction when delivery is not requested", async () => {
     mockRunCronFallbackPassthrough();
     resolveCronDeliveryPlanMock.mockReturnValue({ requested: false, mode: "none" });

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -1157,6 +1157,57 @@ describe("runCronIsolatedAgentTurn delivery instruction", () => {
     expect(prompt).toContain("Return your response as plain text");
   });
 
+  it("does not prompt for the message tool when toolsAllow is explicitly empty", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: true,
+      mode: "announce",
+      channel: "messagechat",
+      to: "123",
+    });
+
+    await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: makeMessageToolPolicyJob(
+        { mode: "announce", channel: "messagechat", to: "123" },
+        { kind: "agentTurn", message: "send a message", toolsAllow: [] },
+      ),
+    });
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expectEmbeddedRunFields({
+      disableMessageTool: false,
+      forceMessageTool: false,
+      toolsAllow: [],
+    });
+    const prompt = expectEmbeddedRunPrompt();
+    expect(prompt).not.toContain("Use the message tool");
+    expect(prompt).toContain("Return your response as plain text");
+  });
+
+  it("prompts for the message tool when toolsAllow uses wildcard access", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: true,
+      mode: "announce",
+      channel: "messagechat",
+      to: "123",
+    });
+
+    await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: makeMessageToolPolicyJob(
+        { mode: "announce", channel: "messagechat", to: "123" },
+        { kind: "agentTurn", message: "send a message", toolsAllow: ["*"] },
+      ),
+    });
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const prompt = expectEmbeddedRunPrompt();
+    expect(prompt).toContain("Use the message tool");
+    expect(prompt).toContain("will be delivered automatically");
+  });
+
   it("does not append a delivery instruction when delivery is not requested", async () => {
     mockRunCronFallbackPassthrough();
     resolveCronDeliveryPlanMock.mockReturnValue({ requested: false, mode: "none" });

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -204,7 +204,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
     expectEmbeddedRunFields({
       disableMessageTool: false,
-      forceMessageTool: true,
+      forceMessageTool: false,
     });
   }
 
@@ -229,7 +229,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
     expectEmbeddedRunFields({
       disableMessageTool: false,
-      forceMessageTool: true,
+      forceMessageTool: false,
       messageChannel: "messagechat",
       messageTo: "123",
       currentChannelId: "123",
@@ -335,7 +335,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
       timeoutMs: 60_000,
       suppressExecNotifyOnExit: true,
       sourceDelivery: createSourceDeliveryPlan({
-        owner: "message_tool_then_direct_fallback",
+        owner: "direct_fallback",
         reason: "cron_announce",
         target: {
           channel: resolvedDelivery.channel ?? "messagechat",
@@ -344,7 +344,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
           threadId: resolvedDelivery.threadId,
         },
         messageToolEnabled: true,
-        messageToolForced: true,
+        messageToolForced: false,
         directFallback: true,
       }),
       skillsSnapshot: emptySkillsSnapshot,
@@ -388,7 +388,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
     const embeddedRun = expectEmbeddedRunFields({
       disableMessageTool: false,
-      forceMessageTool: true,
+      forceMessageTool: false,
     });
     expect(embeddedRun.messageChannel).toBeUndefined();
     expect(embeddedRun.messageTo).toBeUndefined();
@@ -425,7 +425,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
     expectEmbeddedRunFields({
       disableMessageTool: false,
-      forceMessageTool: true,
+      forceMessageTool: false,
       messageChannel: "topicchat",
       messageTo: "room#42",
       messageThreadId: 42,
@@ -568,7 +568,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
     const embeddedRun = expectEmbeddedRunFields({
       disableMessageTool: false,
-      forceMessageTool: true,
+      forceMessageTool: false,
     });
     expect(embeddedRun.messageChannel).toBeUndefined();
     expect(embeddedRun.messageTo).toBeUndefined();
@@ -643,7 +643,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     });
   });
 
-  it("keeps cron announce source replies message-tool-only", async () => {
+  it("keeps cron announce delivery out of message-tool-only source replies", async () => {
     mockRunCronFallbackPassthrough();
     resolveCronDeliveryPlanMock.mockReturnValue(makeAnnounceDeliveryPlan());
 
@@ -654,8 +654,8 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
 
     expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
     expectEmbeddedRunFields({
-      sourceReplyDeliveryMode: "message_tool_only",
-      forceMessageTool: true,
+      sourceReplyDeliveryMode: undefined,
+      forceMessageTool: false,
       messageChannel: "messagechat",
       messageTo: "123",
       currentChannelId: "123",

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -3,6 +3,7 @@ import { resolveAgentHarnessPolicy } from "../../agents/harness/selection.js";
 import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../../agents/openai-codex-routing.js";
 import { retireSessionMcpRuntime } from "../../agents/pi-bundle-mcp-tools.js";
 import type { SkillSnapshot } from "../../agents/skills.js";
+import { expandToolGroups, normalizeToolName } from "../../agents/tool-policy.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import {
@@ -333,10 +334,13 @@ function canPromptForMessageTool(params: {
   if (!params.sourceDelivery.messageTool.enabled) {
     return false;
   }
+  const normalizedToolsAllow = params.toolsAllow
+    ? expandToolGroups(params.toolsAllow).map((toolName) => normalizeToolName(toolName))
+    : undefined;
   return (
     params.toolsAllow === undefined ||
-    params.toolsAllow.includes("*") ||
-    params.toolsAllow.includes("message")
+    normalizedToolsAllow?.includes("*") === true ||
+    normalizedToolsAllow?.includes("message") === true
   );
 }
 

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -311,16 +311,16 @@ function resolveCronSourceDeliveryPlan(params: {
       reason: "cron_none",
       target,
       messageToolEnabled: true,
-      messageToolForced: true,
+      messageToolForced: false,
       directFallback: false,
     });
   }
   return createSourceDeliveryPlan({
-    owner: params.resolvedDelivery.ok ? "message_tool_then_direct_fallback" : "direct_fallback",
+    owner: "direct_fallback",
     reason: "cron_announce",
     target,
     messageToolEnabled: true,
-    messageToolForced: true,
+    messageToolForced: false,
     directFallback: true,
     skipFallbackWhenMessageToolSentToTarget: params.resolvedDelivery.ok,
   });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -333,7 +333,11 @@ function canPromptForMessageTool(params: {
   if (!params.sourceDelivery.messageTool.enabled) {
     return false;
   }
-  return !params.toolsAllow?.length || params.toolsAllow.includes("message");
+  return (
+    params.toolsAllow === undefined ||
+    params.toolsAllow.includes("*") ||
+    params.toolsAllow.includes("message")
+  );
 }
 
 function hasExplicitCronDeliveryTarget(plan: CronDeliveryPlan): boolean {


### PR DESCRIPTION
## Summary

- Problem: Isolated cron source delivery forced the `message` tool for both `delivery.mode: none` and `delivery.mode: announce`, making the agent run own visible delivery even when cron fallback delivery already owns the final post.
- Solution: Keep the message tool available for explicit agent-initiated sends, but stop forcing it and make announce delivery direct-fallback-owned.
- What changed: `cron_none` and `cron_announce` source delivery now pass `messageToolForced: false`; `cron_announce` uses `owner: "direct_fallback"` while preserving fallback skipping when a verified same-target message-tool send happens.
- What did NOT change (scope boundary): This does not remove the message tool from cron runs, does not change webhook delivery, and does not change cron scheduling, target resolution, or channel send APIs.

AI-assisted PR: yes, authored with Codex under human direction.

## Motivation

- Operators can configure cron delivery to announce final results automatically, but the runner also pushed the agent into `message_tool_only` delivery. In a real OpenClaw cron setup this produced noisy tool/permission behavior and made delivery ownership ambiguous: the model was told to use a channel tool while the cron runner also had a fallback delivery path.
- The safer contract is one owner for routine cron final delivery: the cron runner. The agent can still call `message` when it has a concrete reason, and verified same-target sends still suppress fallback to avoid duplicates.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #85249
- Related #84874
- Related #85073
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Isolated cron runs should not force message-tool-only delivery just because the cron has `delivery.mode: none` or `delivery.mode: announce`; cron fallback delivery should own routine final delivery.
- Real environment tested: macOS local OpenClaw gateway installed from npm package `OpenClaw 2026.5.19 (3c01d4a)`, Gateway LaunchAgent, Codex provider, plus this source checkout on current `origin/main`.
- Exact steps or command run after this patch:
  - Applied the equivalent runtime change to the installed package, restarted `openclaw gateway`, and ran a disposable no-delivery isolated cron smoke job that performed one local shell/exec call and returned `tool ok`.
  - In this source checkout: `node scripts/run-vitest.mjs src/cron/isolated-agent/run.message-tool-policy.test.ts`
  - In this source checkout: `pnpm check:changed --base origin/main`
  - In this source checkout: `git diff --check`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
$ openclaw gateway status
Runtime: running (pid 77479)
Connectivity probe: ok
Capability: admin-capable

$ openclaw cron run bb2e58dd-1dc6-48a7-95be-1e4ac65b3528 --wait
{
  "ok": true,
  "completed": true,
  "status": "ok",
  "run": {
    "status": "ok",
    "summary": "tool ok",
    "deliveryStatus": "not-requested",
    "delivery": {
      "fallbackUsed": false,
      "delivered": false
    }
  }
}
```

```text
$ node scripts/run-vitest.mjs src/cron/isolated-agent/run.message-tool-policy.test.ts
Test Files  1 passed (1)
Tests  35 passed (35)
```

```text
$ pnpm check:changed --base origin/main
[check:changed] lanes=core, coreTests
[check:changed] typecheck core
[check:changed] typecheck core tests
[check:changed] lint core
Import cycle check: 0 runtime value cycle(s).
exit 0

$ git diff --check
exit 0
```

- Observed result after fix: Cron runs still receive message-target context when configured, but `forceMessageTool` is false and announce delivery no longer sets `sourceReplyDeliveryMode: "message_tool_only"`. A disposable no-delivery cron still completed successfully and did not request delivery.
- What was not tested: I did not run a live Discord announce cron from this source checkout. I did not run the full repository test suite.
- Before evidence (optional but encouraged): On the affected local install before the runtime patch, scheduled cron output showed agent/tool failures such as `tool_search heartbeat_respond (agent) failed`, local search tool failures, and an isolated Peptide sync report claiming no exec/shell tool was available while cron delivery and message-tool forcing were active.

## Root Cause (if applicable)

- Root cause: `resolveCronSourceDeliveryPlan` treated ordinary cron delivery as message-tool-owned by forcing the message tool and using `message_tool_then_direct_fallback` for announce delivery. That made the model-facing tool contract and the runner-facing fallback delivery contract overlap.
- Missing detection / guardrail: Existing message-tool policy tests asserted the old forced-message behavior, so they protected the ambiguous ownership instead of the desired cron-runner-owned delivery contract.
- Contributing context (if known): Recent cron/tool allowlist fixes made this more visible for restricted cron jobs, where forcing an extra delivery tool can change the model-visible tool surface and error reporting.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cron/isolated-agent/run.message-tool-policy.test.ts`
- Scenario the test should lock in: `delivery.mode: none` and `delivery.mode: announce` keep the message tool enabled but do not force it; announce delivery does not put source replies into `message_tool_only` mode.
- Why this is the smallest reliable guardrail: The bug is in cron source-delivery plan construction before a model turn starts, and the existing isolated-agent harness already captures the exact fields passed to the embedded runner.
- Existing test that already covers this (if any): The file already covered cron message-tool policy; this PR updates those expectations to the corrected ownership model.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Cron final delivery is less intrusive: isolated cron jobs still have access to the message tool when allowed, but are no longer instructed/forced to use it for routine final replies. The cron runner continues to deliver announce output through its automatic fallback path.

## Diagram (if applicable)

```text
Before:
cron announce -> source owner message_tool_then_direct_fallback -> force message tool -> agent owns delivery + runner fallback

After:
cron announce -> source owner direct_fallback -> message tool optional -> runner owns final delivery
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: This narrows forced tool behavior. The message tool remains enabled where it was already enabled, but the runner no longer forces its use or marks cron announce source replies as message-tool-only. Verified same-target message sends still suppress fallback to avoid duplicate delivery.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw Gateway LaunchAgent for real smoke; local source worktree with pnpm workspace for tests
- Model/provider: Codex provider in local cron smoke; mocked embedded runner in targeted source tests
- Integration/channel (if any): Cron isolated-agent delivery path; local smoke used `--no-deliver` to avoid sending to Discord
- Relevant config (redacted): isolated cron jobs with `delivery.mode: none` and `delivery.mode: announce`

### Steps

1. Create or run an isolated cron agent turn with `delivery.mode: announce`.
2. Inspect the embedded runner options passed from the cron source delivery plan.
3. Let the agent return final text and allow cron fallback delivery to handle the final post.

### Expected

- The message tool is available but not forced.
- `sourceReplyDeliveryMode` is not `message_tool_only` for ordinary cron announce delivery.
- Cron fallback delivery remains available and skips only after verified same-target message-tool delivery.

### Actual

- Before this PR, `forceMessageTool` was true and announce delivery used `message_tool_then_direct_fallback`, producing `message_tool_only` source replies.
- After this PR, `forceMessageTool` is false and announce delivery is direct-fallback-owned.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Targeted cron message-tool policy tests pass: `node scripts/run-vitest.mjs src/cron/isolated-agent/run.message-tool-policy.test.ts`.
  - Changed-file gate passes: `pnpm check:changed --base origin/main`.
  - Whitespace guard passes: `git diff --check`.
  - Local installed Gateway smoke run completed a no-delivery isolated cron with a shell/exec call and `status: ok`.
- Edge cases checked:
  - `delivery.mode: webhook` still disables the message tool.
  - `delivery.mode: none` with explicit targets still forwards target context for agent-initiated messages.
  - Verified same-target message-tool sends still suppress cron fallback delivery.
- What you did **not** verify:
  - Live Discord/Telegram announce delivery from this exact source checkout.
  - Full repository test suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: A cron prompt that implicitly relied on forced message-tool-only delivery may now return plain final text instead of calling the message tool.
  - Mitigation: That is the intended cron contract for announce delivery; final text is still delivered automatically by cron fallback. The message tool remains available for explicit sends.
- Risk: Duplicate delivery could reappear if an agent explicitly sends a message and also returns final text.
  - Mitigation: Existing verified same-target message-tool delivery detection and fallback skipping are preserved.
