### PR TITLE
fix(daemon): avoid node task gateway port cleanup

### DIFF
--- a/src/daemon/schtasks.stop.test.ts
+++ b/src/daemon/schtasks.stop.test.ts
@@ -9,6 +9,7 @@ import {
   schtasksResponses,
   withWindowsEnv,
   writeGatewayScript,
+  writeNodeScript,
 } from "./test-helpers/schtasks-fixtures.js";
 const findVerifiedGatewayListenerPidsOnPortSync = vi.hoisted(() =>
   vi.fn<(port: number) => number[]>(() => []),
@@ -90,6 +91,16 @@ async function withPreparedGatewayTask(
   });
 }
 
+async function withPreparedNodeTask(
+  run: (context: { env: Record<string, string>; stdout: PassThrough }) => Promise<void>,
+) {
+  await withWindowsEnv("openclaw-win-node-stop-", async ({ env }) => {
+    await writeNodeScript(env, GATEWAY_PORT);
+    const stdout = new PassThrough();
+    await run({ env, stdout });
+  });
+}
+
 beforeEach(() => {
   resetSchtasksBaseMocks();
   findVerifiedGatewayListenerPidsOnPortSync.mockReset();
@@ -133,7 +144,12 @@ describe("Scheduled Task stop/restart cleanup", () => {
         inspectPortUsage.mockResolvedValueOnce(busyPortUsage(4242));
       }
       inspectPortUsage
-        .mockResolvedValueOnce(busyPortUsage(5252))
+        .mockResolvedValueOnce(
+          busyPortUsage(5252, {
+            commandLine:
+              '"C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\steipete\\AppData\\Roaming\\npm\\node_modules\\openclaw\\dist\\index.js" gateway --port 18789',
+          }),
+        )
         .mockResolvedValueOnce(freePortUsage());
 
       await stopScheduledTask({ env, stdout });
@@ -165,6 +181,64 @@ describe("Scheduled Task stop/restart cleanup", () => {
 
       expectGatewayTermination(6262);
       expect(inspectPortUsage).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("does not kill unrelated listeners on the scheduled task port", async () => {
+    await withPreparedGatewayTask(async ({ env, stdout }) => {
+      pushSuccessfulSchtasksResponses(3);
+      findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([]);
+      inspectPortUsage.mockResolvedValue(busyPortUsage(7331, { command: "wslhost.exe" }));
+
+      await expect(stopScheduledTask({ env, stdout })).rejects.toThrow(
+        "gateway port 18789 is still busy after stop",
+      );
+
+      expect(killProcessTree).not.toHaveBeenCalled();
+      expect(inspectPortUsage.mock.calls.length).toBeGreaterThanOrEqual(28);
+    });
+  });
+
+  it("does not reclaim the remote gateway port when stopping a node task", async () => {
+    await withPreparedNodeTask(async ({ env, stdout }) => {
+      pushSuccessfulSchtasksResponses(3);
+      findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4242]);
+      inspectPortUsage.mockResolvedValue(busyPortUsage(7331, { command: "wslhost.exe" }));
+
+      await stopScheduledTask({ env, stdout });
+
+      expect(findVerifiedGatewayListenerPidsOnPortSync).not.toHaveBeenCalled();
+      expect(inspectPortUsage).not.toHaveBeenCalled();
+      expect(killProcessTree).not.toHaveBeenCalled();
+      expect(schtasksCalls).toEqual([
+        ["/Query"],
+        ["/Query", "/TN", "OpenClaw Gateway"],
+        ["/End", "/TN", "OpenClaw Gateway"],
+      ]);
+    });
+  });
+
+  it("does not wait for the remote gateway port when restarting a node task", async () => {
+    await withPreparedNodeTask(async ({ env, stdout }) => {
+      pushSuccessfulSchtasksResponses(6);
+      findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([5151]);
+      inspectPortUsage.mockResolvedValue(busyPortUsage(7331, { command: "wslhost.exe" }));
+
+      await expect(restartScheduledTask({ env, stdout })).resolves.toEqual({
+        outcome: "completed",
+      });
+
+      expect(findVerifiedGatewayListenerPidsOnPortSync).not.toHaveBeenCalled();
+      expect(inspectPortUsage).not.toHaveBeenCalled();
+      expect(killProcessTree).not.toHaveBeenCalled();
+      expect(schtasksCalls).toEqual([
+        ["/Query"],
+        ["/Query", "/TN", "OpenClaw Gateway"],
+        ["/End", "/TN", "OpenClaw Gateway"],
+        ["/Run", "/TN", "OpenClaw Gateway"],
+        ["/Query"],
+        ["/Query", "/TN", "OpenClaw Gateway", "/V", "/FO", "LIST"],
+      ]);
     });
   });
 

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -10,7 +10,11 @@ import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { sleep } from "../utils.js";
 import { parseCmdScriptCommandLine, quoteCmdScriptArg } from "./cmd-argv.js";
 import { assertNoCmdLineBreak, parseCmdSetAssignment, renderCmdSetAssignment } from "./cmd-set.js";
-import { resolveGatewayServiceDescription, resolveGatewayWindowsTaskName } from "./constants.js";
+import {
+  NODE_SERVICE_KIND,
+  resolveGatewayServiceDescription,
+  resolveGatewayWindowsTaskName,
+} from "./constants.js";
 import { formatLine, writeFormattedLines } from "./output.js";
 import { resolveGatewayStateDir } from "./paths.js";
 import { parseKeyValueOutput } from "./runtime-parse.js";
@@ -439,6 +443,29 @@ function parsePortFromProgramArguments(programArguments?: string[]): number | nu
   return null;
 }
 
+function isNodeScheduledTaskEnv(env: GatewayServiceEnv): boolean {
+  return env.OPENCLAW_SERVICE_KIND?.trim() === NODE_SERVICE_KIND;
+}
+
+function collectGatewayListenerPids(
+  listeners: Array<{ pid?: number; commandLine?: string }>,
+): number[] {
+  return Array.from(
+    new Set(
+      listeners
+        .filter(
+          (listener) =>
+            typeof listener.pid === "number" &&
+            listener.commandLine &&
+            isGatewayArgv(parseCmdScriptCommandLine(listener.commandLine), {
+              allowGatewayBinary: true,
+            }),
+        )
+        .map((listener) => listener.pid as number),
+    ),
+  );
+}
+
 async function resolveScheduledTaskPort(env: GatewayServiceEnv): Promise<number | null> {
   const command = await readScheduledTaskCommand(env).catch(() => null);
   return (
@@ -459,31 +486,7 @@ async function resolveScheduledTaskGatewayListenerPids(port: number): Promise<nu
     return [];
   }
 
-  const matchedGatewayPids = Array.from(
-    new Set(
-      diagnostics.listeners
-        .filter(
-          (listener) =>
-            typeof listener.pid === "number" &&
-            listener.commandLine &&
-            isGatewayArgv(parseCmdScriptCommandLine(listener.commandLine), {
-              allowGatewayBinary: true,
-            }),
-        )
-        .map((listener) => listener.pid as number),
-    ),
-  );
-  if (matchedGatewayPids.length > 0) {
-    return matchedGatewayPids;
-  }
-
-  return Array.from(
-    new Set(
-      diagnostics.listeners
-        .map((listener) => listener.pid)
-        .filter((pid): pid is number => typeof pid === "number" && Number.isFinite(pid) && pid > 0),
-    ),
-  );
+  return collectGatewayListenerPids(diagnostics.listeners);
 }
 
 async function resolveListenerBackedScheduledTaskRuntime(
@@ -575,13 +578,7 @@ async function terminateBusyPortListeners(port: number): Promise<number[]> {
   if (diagnostics?.status !== "busy") {
     return [];
   }
-  const pids = Array.from(
-    new Set(
-      diagnostics.listeners
-        .map((listener) => listener.pid)
-        .filter((pid): pid is number => typeof pid === "number" && Number.isFinite(pid) && pid > 0),
-    ),
-  );
+  const pids = collectGatewayListenerPids(diagnostics.listeners);
   for (const pid of pids) {
     await terminateGatewayProcessTree(pid, 300);
   }
@@ -1032,6 +1029,10 @@ export async function stopScheduledTask({ stdout, env }: GatewayServiceControlAr
   if (res.code !== 0 && !isTaskNotRunning(res)) {
     throw new Error(`schtasks end failed: ${res.stderr || res.stdout}`.trim());
   }
+  if (isNodeScheduledTaskEnv(effectiveEnv)) {
+    stdout.write(`${formatLine("Stopped Scheduled Task", taskName)}\n`);
+    return;
+  }
   const stopPort = await resolveScheduledTaskPort(effectiveEnv);
   await terminateScheduledTaskGatewayListeners(effectiveEnv);
   await terminateInstalledStartupRuntime(effectiveEnv);
@@ -1068,6 +1069,15 @@ export async function restartScheduledTask({
   }
   const taskName = resolveTaskName(effectiveEnv);
   await execSchtasks(["/End", "/TN", taskName]);
+  if (isNodeScheduledTaskEnv(effectiveEnv)) {
+    await runScheduledTaskOrThrow({
+      taskName,
+      env: effectiveEnv,
+      scriptPath: resolveTaskScriptPath(effectiveEnv),
+    });
+    stdout.write(`${formatLine("Restarted Scheduled Task", taskName)}\n`);
+    return { outcome: "completed" };
+  }
   const restartPort = await resolveScheduledTaskPort(effectiveEnv);
   await terminateScheduledTaskGatewayListeners(effectiveEnv);
   await terminateInstalledStartupRuntime(effectiveEnv);

--- a/src/daemon/test-helpers/schtasks-fixtures.ts
+++ b/src/daemon/test-helpers/schtasks-fixtures.ts
@@ -55,3 +55,22 @@ export async function writeGatewayScript(
     "utf8",
   );
 }
+
+export async function writeNodeScript(
+  env: Record<string, string>,
+  port = Number(env.OPENCLAW_GATEWAY_PORT || "18789"),
+) {
+  env.OPENCLAW_SERVICE_KIND = "node";
+  const scriptPath = resolveTaskScriptPath(env);
+  await fs.mkdir(path.dirname(scriptPath), { recursive: true });
+  await fs.writeFile(
+    scriptPath,
+    [
+      "@echo off",
+      `set "OPENCLAW_SERVICE_KIND=node"`,
+      `"C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\steipete\\AppData\\Roaming\\npm\\node_modules\\openclaw\\dist\\index.js" node run --host 127.0.0.1 --port ${port}`,
+      "",
+    ].join("\r\n"),
+    "utf8",
+  );
+}


### PR DESCRIPTION
## Summary

- Fixes #85289.
- Skip Gateway port reclaim/wait logic when the Windows Scheduled Task represents an OpenClaw node service, so `node stop` / `node restart` does not treat the node's remote Gateway port as a local listener to clean up.
- Keep Gateway service cleanup intact, while tightening fallback PID collection to OpenClaw Gateway command lines only.
- Add regression coverage for node stop/restart and unrelated WSL-style port listeners.

## Tests

- `node scripts/run-vitest.mjs src/daemon/schtasks.stop.test.ts src/daemon/schtasks.startup-fallback.test.ts src/daemon/schtasks.test.ts src/daemon/service.test.ts src/commands/node-daemon-install-helpers.test.ts`
- `OPENCLAW_VITEST_SHARD_NAME=agentic-command-support OPENCLAW_TEST_PROJECTS_PARALLEL=2 node scripts/test-projects.mjs test/vitest/vitest.daemon.config.ts`
- `node scripts/run-oxlint.mjs src/daemon/schtasks.ts src/daemon/schtasks.stop.test.ts src/daemon/test-helpers/schtasks-fixtures.ts`

## Real behavior proof

Behavior addressed: Windows node Scheduled Task lifecycle commands no longer reclaim, kill, or wait on the remote Gateway connection port from `node run --port`, avoiding disruption of unrelated WSL2 localhost forwarding on that port.

Real environment tested: macOS 26.3.2 source checkout on Node v23.11.1, using the repository's Windows Scheduled Task harness to execute the post-fix `stopScheduledTask` / `restartScheduledTask` control paths with mocked `schtasks`, listener PID discovery, and port diagnostics.

Exact steps or command run after this patch: `OPENCLAW_VITEST_SHARD_NAME=agentic-command-support OPENCLAW_TEST_PROJECTS_PARALLEL=2 node scripts/test-projects.mjs test/vitest/vitest.daemon.config.ts`

Evidence after fix: The new node-task cases set `OPENCLAW_SERVICE_KIND=node`, install a `node run --host 127.0.0.1 --port 18789` task script, simulate WSL-style busy listeners and verified Gateway PID candidates, then assert `findVerifiedGatewayListenerPidsOnPortSync`, `inspectPortUsage`, and `killProcessTree` are not called for node stop/restart. The daemon shard passed with 16 files, 393 tests passed, and 5 skipped.

Observed result after fix: Targeted daemon, explicit daemon-shard, and targeted oxlint commands exited 0 after the fix.

What was not tested: I did not run a live Windows 11 + WSL2 VM with real `schtasks` and WSL2 localhost proxy processes; the proof is source-level execution of the affected Windows lifecycle paths through the repo harness.
