### PR TITLE
perf(whatsapp): narrow runtime setter entry

### DIFF
--- a/extensions/whatsapp/index.ts
+++ b/extensions/whatsapp/index.ts
@@ -10,7 +10,7 @@ export default defineBundledChannelEntry({
     exportName: "whatsappPlugin",
   },
   runtime: {
-    specifier: "./runtime-api.js",
+    specifier: "./runtime-setter-api.js",
     exportName: "setWhatsAppRuntime",
   },
 });

--- a/extensions/whatsapp/runtime-setter-api.ts
+++ b/extensions/whatsapp/runtime-setter-api.ts
@@ -1,0 +1,3 @@
+// Keep bundled registration fast: the runtime setter is needed during plugin
+// bootstrap, but the broad runtime-api barrel pulls in WhatsApp runtime modules.
+export { setWhatsAppRuntime } from "./src/runtime.js";


### PR DESCRIPTION
## Summary

- add a narrow WhatsApp `runtime-setter-api.ts` entry that exports only `setWhatsAppRuntime`
- point WhatsApp bundled channel registration at that setter-only entry instead of the broad `runtime-api.ts` barrel
- match the common pattern already used by Slack, Discord, Telegram, and Matrix to keep bundled plugin registration from importing broad runtime barrels during startup

## Estimated Load-Time Impact

From the post-#84649 cold-start CPU profile:

- WhatsApp-attributed startup work was about **3.11s inclusive**, or **17.9% of post-profile non-idle CPU**
- the broad `extensions/whatsapp/runtime-api.ts` import accounted for about **1.97s inclusive**, or **11.3% of post-profile non-idle CPU**
- that `runtime-api.ts` path was **63.3% of the measured WhatsApp-attributed startup work**
- this PR is expected to remove most of that **~1.97s inclusive runtime-barrel import cost** from bundled plugin registration, while leaving the remaining WhatsApp channel plugin import cost untouched

This is an estimate from CPU-profile inclusive stack attribution, not a new before/after benchmark. A follow-up cold-start profile should verify the realized wall-clock change.

## Verification

- `node scripts/run-vitest.mjs extensions/whatsapp/index.test.ts`
- `pnpm build`
- `git diff --check`

## Notes

This follows the same runtime setter split already present in:

- `extensions/slack/runtime-setter-api.ts`
- `extensions/discord/runtime-setter-api.ts`
- `extensions/telegram/runtime-setter-api.ts`
- `extensions/matrix/runtime-setter-api.ts`

The broad WhatsApp `runtime-api.ts` remains intact for compatibility/runtime callers; bundled registration only needs the setter.

Autoreview was attempted with `.agents/skills/autoreview/scripts/autoreview --mode local --no-web-search`, but the helper's Codex runner failed before review because the local Codex config contains `approval_policy = prompt`, which that runner does not accept.
