### PR TITLE
fix(sandbox): mount workspace skills read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 - Ollama: bypass the managed proxy for configured local embedding origins while keeping SSRF guardrails on unconfigured targets. Thanks @Kaspre.
 - OpenAI/images: route Codex API-key image generation through the native OpenAI Images API instead of the Codex OAuth streaming backend, avoiding 401s from valid API keys.
 - Agents/OpenAI completions: omit empty tool payload fields for proxy-like OpenAI-compatible endpoints so strict vLLM-style servers accept tool-free turns. (#85835) Thanks @rendrag-git.
+- Sandbox: keep workspace skill mounts read-only for remote container-cwd file operations and reject symlinked skill roots before creating protected overlays. (#85591) Thanks @jason-allen-oneal.
 - Checks/Windows: route full `pnpm check` stage commands through the managed child runner so Windows avoids Node shell-argv deprecation warnings there too.
 - Checks/Windows: run managed child commands through explicit `cmd.exe` wrapping instead of Node shell mode with argv, avoiding Node 24 subprocess deprecation warnings during changed checks.
 - Gateway: omit internal stream-error placeholder entries from agent prompt history so failed assistant turns are not replayed as model-authored text. (#85652) Thanks @anyech.

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -1,5 +1,7 @@
-import { readFileSync } from "node:fs";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   computeSandboxBrowserConfigHash,
   SANDBOX_DOCKER_EXPLICIT_ENV_POLICY_EPOCH,
@@ -36,6 +38,14 @@ const bridgeMocks = vi.hoisted(() => ({
   startBrowserBridgeServer: vi.fn(),
   stopBrowserBridgeServer: vi.fn(),
 }));
+
+const tmpDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "openclaw-browser-mounts-"));
+  tmpDirs.push(dir);
+  return dir;
+}
 
 vi.mock("./docker.js", async () => {
   const actual = await vi.importActual<typeof import("./docker.js")>("./docker.js");
@@ -187,6 +197,12 @@ describe("ensureSandboxBrowser create args", () => {
     await loadFreshBrowserModulesForTest();
   });
 
+  afterEach(() => {
+    for (const dir of tmpDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   beforeEach(() => {
     vi.restoreAllMocks();
     BROWSER_BRIDGES.clear();
@@ -310,6 +326,35 @@ describe("ensureSandboxBrowser create args", () => {
     expect(result?.noVncUrl).toBeUndefined();
   });
 
+  it("applies read-only skill overlays after browser custom binds", async () => {
+    const workspaceDir = makeTempDir();
+    const customRoot = makeTempDir();
+    mkdirSync(path.join(workspaceDir, "skills", "demo"), { recursive: true });
+    const cfg = buildConfig(false);
+    cfg.workspaceAccess = "rw";
+    cfg.docker.dangerouslyAllowExternalBindSources = true;
+    cfg.docker.dangerouslyAllowReservedContainerTargets = true;
+    cfg.browser.binds = [`${customRoot}:/workspace/skills:rw`];
+
+    await ensureTestSandboxBrowser({
+      scopeKey: "session:test",
+      workspaceDir,
+      agentWorkspaceDir: workspaceDir,
+      cfg,
+    });
+
+    const bindArgs = collectDockerFlagValues(requireDockerCreateArgs(), "-v");
+    const workspaceMountIdx = bindArgs.indexOf(`${workspaceDir}:/workspace:z`);
+    const customMountIdx = bindArgs.indexOf(`${customRoot}:/workspace/skills:rw`);
+    const protectedMountIdx = bindArgs.indexOf(
+      `${path.join(workspaceDir, "skills")}:/workspace/skills:ro,z`,
+    );
+
+    expect(workspaceMountIdx).toBeGreaterThanOrEqual(0);
+    expect(customMountIdx).toBeGreaterThan(workspaceMountIdx);
+    expect(protectedMountIdx).toBeGreaterThan(customMountIdx);
+  });
+
   it("includes the explicit env policy epoch in the browser config hash when needed", async () => {
     const cfg = buildConfig(false);
     cfg.docker.env = {
@@ -340,6 +385,7 @@ describe("ensureSandboxBrowser create args", () => {
       workspaceDir,
       agentWorkspaceDir,
       mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      readOnlyWorkspaceSkillMounts: [],
     });
 
     await ensureTestSandboxBrowser({

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -50,7 +50,12 @@ import { resolveSandboxAgentId, slugifySessionKey } from "./shared.js";
 import { isToolAllowed } from "./tool-policy.js";
 import type { SandboxBrowserContext, SandboxConfig } from "./types.js";
 import { validateNetworkMode } from "./validate-sandbox-security.js";
-import { appendWorkspaceMountArgs, SANDBOX_MOUNT_FORMAT_VERSION } from "./workspace-mounts.js";
+import {
+  appendWorkspaceMountArgs,
+  formatReadOnlyWorkspaceSkillMountHashState,
+  resolveReadOnlyWorkspaceSkillMounts,
+  SANDBOX_MOUNT_FORMAT_VERSION,
+} from "./workspace-mounts.js";
 
 const HOT_BROWSER_WINDOW_MS = 5 * 60 * 1000;
 const CDP_SOURCE_RANGE_ENV_KEY = "OPENCLAW_BROWSER_CDP_SOURCE_RANGE";
@@ -227,6 +232,12 @@ export async function ensureSandboxBrowser(params: {
     docker: params.cfg.docker,
     browser: { ...params.cfg.browser, image: browserImage },
   });
+  const readOnlyWorkspaceSkillMounts = resolveReadOnlyWorkspaceSkillMounts({
+    workspaceDir: params.workspaceDir,
+    agentWorkspaceDir: params.agentWorkspaceDir,
+    workdir: params.cfg.docker.workdir,
+    workspaceAccess: params.cfg.workspaceAccess,
+  });
   const expectedHash = computeSandboxBrowserConfigHash({
     docker: browserDockerCfg,
     dockerEnvPolicyEpoch: resolveDockerEnvPolicyEpoch(browserDockerCfg.env),
@@ -244,6 +255,9 @@ export async function ensureSandboxBrowser(params: {
     workspaceDir: params.workspaceDir,
     agentWorkspaceDir: params.agentWorkspaceDir,
     mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+    readOnlyWorkspaceSkillMounts: formatReadOnlyWorkspaceSkillMountHashState(
+      readOnlyWorkspaceSkillMounts,
+    ),
   });
 
   const now = Date.now();
@@ -334,6 +348,7 @@ export async function ensureSandboxBrowser(params: {
       agentWorkspaceDir: params.agentWorkspaceDir,
       workdir: params.cfg.docker.workdir,
       workspaceAccess: params.cfg.workspaceAccess,
+      readOnlyWorkspaceSkillMounts,
     });
     if (browserDockerCfg.binds?.length) {
       for (const bind of browserDockerCfg.binds) {

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -51,6 +51,7 @@ import { isToolAllowed } from "./tool-policy.js";
 import type { SandboxBrowserContext, SandboxConfig } from "./types.js";
 import { validateNetworkMode } from "./validate-sandbox-security.js";
 import {
+  appendReadOnlyWorkspaceSkillMountArgs,
   appendWorkspaceMountArgs,
   formatReadOnlyWorkspaceSkillMountHashState,
   resolveReadOnlyWorkspaceSkillMounts,
@@ -349,12 +350,17 @@ export async function ensureSandboxBrowser(params: {
       workdir: params.cfg.docker.workdir,
       workspaceAccess: params.cfg.workspaceAccess,
       readOnlyWorkspaceSkillMounts,
+      includeReadOnlyWorkspaceSkillMounts: false,
     });
     if (browserDockerCfg.binds?.length) {
       for (const bind of browserDockerCfg.binds) {
         args.push("-v", bind);
       }
     }
+    appendReadOnlyWorkspaceSkillMountArgs({
+      args,
+      readOnlyWorkspaceSkillMounts,
+    });
     args.push("-p", `127.0.0.1::${params.cfg.browser.cdpPort}`);
     if (noVncEnabled) {
       args.push("-p", `127.0.0.1::${params.cfg.browser.noVncPort}`);

--- a/src/agents/sandbox/config-hash.test.ts
+++ b/src/agents/sandbox/config-hash.test.ts
@@ -106,6 +106,28 @@ describe("computeSandboxConfigHash", () => {
     });
     expect(left).not.toBe(right);
   });
+  it("changes when read-only workspace skill mount state changes", () => {
+    const shared = {
+      docker: createDockerConfig(),
+      dockerEnvPolicyEpoch: undefined,
+      workspaceAccess: "rw" as const,
+      workspaceDir: "/tmp/workspace",
+      agentWorkspaceDir: "/tmp/workspace",
+      mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+    };
+
+    const withoutSkills = computeSandboxConfigHash({
+      ...shared,
+      readOnlyWorkspaceSkillMounts: [],
+    });
+
+    const withSkills = computeSandboxConfigHash({
+      ...shared,
+      readOnlyWorkspaceSkillMounts: ["/tmp/workspace/skills:/workspace/skills:ro"],
+    });
+
+    expect(withoutSkills).not.toBe(withSkills);
+  });
 });
 
 describe("computeSandboxBrowserConfigHash", () => {

--- a/src/agents/sandbox/config-hash.ts
+++ b/src/agents/sandbox/config-hash.ts
@@ -10,6 +10,7 @@ type SandboxHashInput = {
   workspaceDir: string;
   agentWorkspaceDir: string;
   mountFormatVersion: number;
+  readOnlyWorkspaceSkillMounts?: readonly string[];
 };
 
 type SandboxBrowserHashInput = {
@@ -30,6 +31,7 @@ type SandboxBrowserHashInput = {
   workspaceDir: string;
   agentWorkspaceDir: string;
   mountFormatVersion: number;
+  readOnlyWorkspaceSkillMounts?: readonly string[];
 };
 
 function normalizeForHash(value: unknown): unknown {

--- a/src/agents/sandbox/docker.config-hash-recreate.test.ts
+++ b/src/agents/sandbox/docker.config-hash-recreate.test.ts
@@ -1,6 +1,9 @@
 import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { Readable } from "node:stream";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   computeSandboxConfigHash,
   SANDBOX_DOCKER_EXPLICIT_ENV_POLICY_EPOCH,
@@ -31,6 +34,14 @@ const registryMocks = vi.hoisted(() => ({
   readRegistryEntry: vi.fn(),
   updateRegistry: vi.fn(),
 }));
+
+const tmpDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-docker-mounts-"));
+  tmpDirs.push(dir);
+  return dir;
+}
 
 vi.mock("./registry.js", () => ({
   readRegistryEntry: registryMocks.readRegistryEntry,
@@ -184,6 +195,12 @@ async function ensureSandboxCreateCallForTest(params: {
 }
 
 describe("ensureSandboxContainer config-hash recreation", () => {
+  afterEach(() => {
+    for (const dir of tmpDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   beforeEach(async () => {
     spawnState.calls.length = 0;
     spawnState.inspectRunning = true;
@@ -205,6 +222,7 @@ describe("ensureSandboxContainer config-hash recreation", () => {
       workspaceDir,
       agentWorkspaceDir: workspaceDir,
       mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      readOnlyWorkspaceSkillMounts: [],
     });
     const newHash = computeSandboxConfigHash({
       docker: newCfg.docker,
@@ -212,6 +230,7 @@ describe("ensureSandboxContainer config-hash recreation", () => {
       workspaceDir,
       agentWorkspaceDir: workspaceDir,
       mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      readOnlyWorkspaceSkillMounts: [],
     });
     expect(newHash).not.toBe(oldHash);
 
@@ -263,6 +282,7 @@ describe("ensureSandboxContainer config-hash recreation", () => {
       workspaceDir,
       agentWorkspaceDir: workspaceDir,
       mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      readOnlyWorkspaceSkillMounts: [],
     });
     const newHash = computeSandboxConfigHash({
       docker: cfg.docker,
@@ -271,6 +291,7 @@ describe("ensureSandboxContainer config-hash recreation", () => {
       workspaceDir,
       agentWorkspaceDir: workspaceDir,
       mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      readOnlyWorkspaceSkillMounts: [],
     });
     expect(newHash).not.toBe(oldHash);
 
@@ -307,6 +328,7 @@ describe("ensureSandboxContainer config-hash recreation", () => {
       workspaceDir,
       agentWorkspaceDir: workspaceDir,
       mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      readOnlyWorkspaceSkillMounts: [],
     });
 
     spawnState.inspectRunning = false;
@@ -328,6 +350,38 @@ describe("ensureSandboxContainer config-hash recreation", () => {
     const customMountIdx = bindArgs.indexOf("/tmp/workspace-shared/USER.md:/workspace/USER.md:ro");
     expect(workspaceMountIdx).toBeGreaterThanOrEqual(0);
     expect(customMountIdx).toBeGreaterThan(workspaceMountIdx);
+  });
+
+  it("applies read-only skill overlays after custom binds", async () => {
+    const workspaceDir = makeTempDir();
+    const customRoot = makeTempDir();
+    fs.mkdirSync(path.join(workspaceDir, "skills", "demo"), { recursive: true });
+    fs.mkdirSync(customRoot, { recursive: true });
+    const cfg = createSandboxConfig([], [`${customRoot}:/workspace/skills:rw`]);
+    cfg.docker.dangerouslyAllowExternalBindSources = true;
+
+    spawnState.inspectRunning = false;
+    spawnState.labelHash = "stale-hash";
+    registryMocks.readRegistryEntry.mockResolvedValue({
+      containerName: "oc-test-shared",
+      sessionKey: "shared",
+      createdAtMs: 1,
+      lastUsedAtMs: 0,
+      image: cfg.docker.image,
+      configHash: "stale-hash",
+    });
+
+    const createCall = await ensureSandboxCreateCallForTest({ cfg, workspaceDir });
+    const bindArgs = collectDockerFlagValues(createCall.args, "-v");
+    const workspaceMountIdx = bindArgs.indexOf(`${workspaceDir}:/workspace:z`);
+    const customMountIdx = bindArgs.indexOf(`${customRoot}:/workspace/skills:rw`);
+    const protectedMountIdx = bindArgs.indexOf(
+      `${path.join(workspaceDir, "skills")}:/workspace/skills:ro,z`,
+    );
+
+    expect(workspaceMountIdx).toBeGreaterThanOrEqual(0);
+    expect(customMountIdx).toBeGreaterThan(workspaceMountIdx);
+    expect(protectedMountIdx).toBeGreaterThan(customMountIdx);
   });
 
   it.each([

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -178,6 +178,7 @@ import { resolveSandboxAgentId, resolveSandboxScopeKey, slugifySessionKey } from
 import type { SandboxConfig, SandboxDockerConfig, SandboxWorkspaceAccess } from "./types.js";
 import { validateSandboxSecurity } from "./validate-sandbox-security.js";
 import {
+  appendReadOnlyWorkspaceSkillMountArgs,
   appendWorkspaceMountArgs,
   formatReadOnlyWorkspaceSkillMountHashState,
   resolveReadOnlyWorkspaceSkillMounts,
@@ -571,8 +572,13 @@ async function createSandboxContainer(params: {
     workdir: cfg.workdir,
     workspaceAccess: params.workspaceAccess,
     readOnlyWorkspaceSkillMounts: params.readOnlyWorkspaceSkillMounts,
+    includeReadOnlyWorkspaceSkillMounts: false,
   });
   appendCustomBinds(args, cfg);
+  appendReadOnlyWorkspaceSkillMountArgs({
+    args,
+    readOnlyWorkspaceSkillMounts: params.readOnlyWorkspaceSkillMounts,
+  });
   args.push(cfg.image, "sleep", "infinity");
 
   await execDocker(args);

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -177,7 +177,13 @@ import { readRegistryEntry, updateRegistry } from "./registry.js";
 import { resolveSandboxAgentId, resolveSandboxScopeKey, slugifySessionKey } from "./shared.js";
 import type { SandboxConfig, SandboxDockerConfig, SandboxWorkspaceAccess } from "./types.js";
 import { validateSandboxSecurity } from "./validate-sandbox-security.js";
-import { appendWorkspaceMountArgs, SANDBOX_MOUNT_FORMAT_VERSION } from "./workspace-mounts.js";
+import {
+  appendWorkspaceMountArgs,
+  formatReadOnlyWorkspaceSkillMountHashState,
+  resolveReadOnlyWorkspaceSkillMounts,
+  SANDBOX_MOUNT_FORMAT_VERSION,
+  type ReadOnlyWorkspaceSkillMount,
+} from "./workspace-mounts.js";
 
 const log = createSubsystemLogger("docker");
 
@@ -544,6 +550,7 @@ async function createSandboxContainer(params: {
   agentWorkspaceDir: string;
   scopeKey: string;
   configHash?: string;
+  readOnlyWorkspaceSkillMounts: readonly ReadOnlyWorkspaceSkillMount[];
 }) {
   const { name, cfg, workspaceDir, scopeKey } = params;
   await ensureDockerImage(cfg.image);
@@ -563,6 +570,7 @@ async function createSandboxContainer(params: {
     agentWorkspaceDir: params.agentWorkspaceDir,
     workdir: cfg.workdir,
     workspaceAccess: params.workspaceAccess,
+    readOnlyWorkspaceSkillMounts: params.readOnlyWorkspaceSkillMounts,
   });
   appendCustomBinds(args, cfg);
   args.push(cfg.image, "sleep", "infinity");
@@ -600,6 +608,12 @@ export async function ensureSandboxContainer(params: {
   const slug = params.cfg.scope === "shared" ? "shared" : slugifySessionKey(scopeKey);
   const name = `${params.cfg.docker.containerPrefix}${slug}`;
   const containerName = name.slice(0, 63);
+  const readOnlyWorkspaceSkillMounts = resolveReadOnlyWorkspaceSkillMounts({
+    workspaceDir: params.workspaceDir,
+    agentWorkspaceDir: params.agentWorkspaceDir,
+    workdir: params.cfg.docker.workdir,
+    workspaceAccess: params.cfg.workspaceAccess,
+  });
   const expectedHash = computeSandboxConfigHash({
     docker: params.cfg.docker,
     dockerEnvPolicyEpoch: resolveDockerEnvPolicyEpoch(params.cfg.docker.env),
@@ -607,6 +621,9 @@ export async function ensureSandboxContainer(params: {
     workspaceDir: params.workspaceDir,
     agentWorkspaceDir: params.agentWorkspaceDir,
     mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+    readOnlyWorkspaceSkillMounts: formatReadOnlyWorkspaceSkillMountHashState(
+      readOnlyWorkspaceSkillMounts,
+    ),
   });
   const now = Date.now();
   const state = await dockerContainerState(containerName);
@@ -653,6 +670,7 @@ export async function ensureSandboxContainer(params: {
       agentWorkspaceDir: params.agentWorkspaceDir,
       scopeKey,
       configHash: expectedHash,
+      readOnlyWorkspaceSkillMounts,
     });
   } else if (!running) {
     await execDocker(["start", containerName]);

--- a/src/agents/sandbox/fs-paths.ts
+++ b/src/agents/sandbox/fs-paths.ts
@@ -12,12 +12,13 @@ import {
   normalizeContainerPath,
   relativePathEscapesContainerRoot,
 } from "./path-utils.js";
+import { resolveReadOnlyWorkspaceSkillMounts } from "./workspace-mounts.js";
 
 export type SandboxFsMount = {
   hostRoot: string;
   containerRoot: string;
   writable: boolean;
-  source: "workspace" | "agent" | "bind";
+  source: "workspace" | "agent" | "bind" | "protectedSkill";
 };
 
 export type SandboxResolvedFsPath = {
@@ -83,6 +84,20 @@ export function buildSandboxFsMounts(sandbox: SandboxFsBridgeContext): SandboxFs
       containerRoot: SANDBOX_AGENT_WORKSPACE_MOUNT,
       writable: sandbox.workspaceAccess === "rw",
       source: "agent",
+    });
+  }
+
+  for (const mount of resolveReadOnlyWorkspaceSkillMounts({
+    workspaceDir: sandbox.workspaceDir,
+    agentWorkspaceDir: sandbox.agentWorkspaceDir,
+    workdir: sandbox.containerWorkdir,
+    workspaceAccess: sandbox.workspaceAccess,
+  })) {
+    mounts.push({
+      hostRoot: path.resolve(mount.hostPath),
+      containerRoot: normalizeContainerPath(mount.containerPath),
+      writable: false,
+      source: "protectedSkill",
     });
   }
 
@@ -246,8 +261,9 @@ function compareMountsByContainerPath(a: SandboxFsMount, b: SandboxFsMount): num
   if (byLength !== 0) {
     return byLength;
   }
-  // Keep resolver ordering aligned with docker mount precedence: custom binds can
-  // intentionally shadow default workspace mounts at the same container path.
+  // Keep resolver ordering aligned with docker mount precedence for default
+  // workspace mounts, but never let bridge policy classify protected skills
+  // as writable.
   return mountSourcePriority(b.source) - mountSourcePriority(a.source);
 }
 
@@ -260,6 +276,9 @@ function compareMountsByHostPath(a: SandboxFsMount, b: SandboxFsMount): number {
 }
 
 function mountSourcePriority(source: SandboxFsMount["source"]): number {
+  if (source === "protectedSkill") {
+    return 3;
+  }
   if (source === "bind") {
     return 2;
   }

--- a/src/agents/sandbox/remote-fs-bridge.ts
+++ b/src/agents/sandbox/remote-fs-bridge.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import { isPathInside } from "../../infra/path-guards.js";
 import type {
@@ -563,7 +564,15 @@ function buildRemoteProtectedSkillMounts(params: {
       },
     );
   }
-  return mounts;
+  return mounts.filter((mount) => isExistingDirectory(mount.localRoot));
+}
+
+function isExistingDirectory(dir: string): boolean {
+  try {
+    return fs.statSync(dir).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 function compareRemoteMountsByContainerPath(a: MountInfo, b: MountInfo): number {

--- a/src/agents/sandbox/remote-fs-bridge.ts
+++ b/src/agents/sandbox/remote-fs-bridge.ts
@@ -102,6 +102,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       containerPath: target.containerPath,
       action: "write files",
       requireWritable: true,
+      signal: params.signal,
     });
     await this.assertNoHardlinkedFile({
       containerPath: target.containerPath,
@@ -160,6 +161,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       action: "remove files",
       requireWritable: true,
       allowFinalSymlinkForUnlink: true,
+      signal: params.signal,
     });
     await this.runMutation({
       args: [
@@ -189,11 +191,13 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       action: "rename files",
       requireWritable: true,
       allowFinalSymlinkForUnlink: true,
+      signal: params.signal,
     });
     const toPinned = await this.resolvePinnedParent({
       containerPath: to.containerPath,
       action: "rename files",
       requireWritable: true,
+      signal: params.signal,
     });
     await this.runMutation({
       args: [
@@ -392,9 +396,26 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     signal?: AbortSignal,
   ): Promise<void> {
     this.ensureWritable(target, action);
-    const protectedRoot = this.findRemoteProtectedSkillRoot(target.containerPath);
-    if (protectedRoot && (await this.remotePathExists(protectedRoot, signal))) {
-      throw new Error(`Sandbox path is read-only; cannot ${action}: ${target.containerPath}`);
+    await this.assertRemoteProtectedPathWritable({
+      containerPath: target.containerPath,
+      action,
+      signal,
+    });
+  }
+
+  private async assertRemoteProtectedPathWritable(params: {
+    containerPath: string;
+    action: string;
+    displayPath?: string;
+    signal?: AbortSignal;
+  }): Promise<void> {
+    const protectedRoot = this.findRemoteProtectedSkillRoot(params.containerPath);
+    if (protectedRoot && (await this.remotePathExists(protectedRoot, params.signal))) {
+      throw new Error(
+        `Sandbox path is read-only; cannot ${params.action}: ${
+          params.displayPath ?? params.containerPath
+        }`,
+      );
     }
   }
 
@@ -503,6 +524,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     action: string;
     requireWritable?: boolean;
     allowFinalSymlinkForUnlink?: boolean;
+    signal?: AbortSignal;
   }): Promise<{ mountRootPath: string; relativeParentPath: string; basename: string }> {
     const basename = path.posix.basename(params.containerPath);
     if (!basename || basename === "." || basename === "/") {
@@ -523,6 +545,14 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       throw new Error(
         `Sandbox path is read-only; cannot ${params.action}: ${params.containerPath}`,
       );
+    }
+    if (params.requireWritable) {
+      await this.assertRemoteProtectedPathWritable({
+        containerPath: canonicalParent,
+        action: params.action,
+        displayPath: params.containerPath,
+        signal: params.signal,
+      });
     }
     const relativeParentPath = path.posix.relative(mount.containerRoot, canonicalParent);
     if (relativePathEscapesContainerRoot(relativeParentPath)) {

--- a/src/agents/sandbox/remote-fs-bridge.ts
+++ b/src/agents/sandbox/remote-fs-bridge.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import path from "node:path";
 import { isPathInside } from "../../infra/path-guards.js";
 import type {
@@ -14,6 +13,7 @@ import {
   normalizeContainerPath as normalizeSandboxContainerPath,
   relativePathEscapesContainerRoot,
 } from "./path-utils.js";
+import { isExistingWorkspaceSkillMountSource } from "./workspace-mounts.js";
 
 type RemoteMountSource = "workspace" | "agent" | "protectedSkill";
 
@@ -272,7 +272,9 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
           localRoot: agentRoot,
           workspaceContainerRoot,
           agentContainerRoot,
-          includeAgentMount: path.resolve(this.sandbox.agentWorkspaceDir) !== path.resolve(this.sandbox.workspaceDir),
+          includeAgentMount:
+            path.resolve(this.sandbox.agentWorkspaceDir) !==
+            path.resolve(this.sandbox.workspaceDir),
         }),
       );
     }
@@ -315,9 +317,13 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
         const cwdContainer = normalizeContainerPath(cwdPosix);
         const cwdMount = this.resolveMountByContainerPath(mounts, cwdContainer);
         if (cwdMount) {
+          const containerPath = normalizeContainerPath(
+            path.posix.resolve(cwdContainer, inputPosix),
+          );
+          const targetMount = this.resolveMountByContainerPath(mounts, containerPath) ?? cwdMount;
           return this.toResolvedPath({
-            mount: cwdMount,
-            containerPath: normalizeContainerPath(path.posix.resolve(cwdContainer, inputPosix)),
+            mount: targetMount,
+            containerPath,
           });
         }
       }
@@ -564,15 +570,12 @@ function buildRemoteProtectedSkillMounts(params: {
       },
     );
   }
-  return mounts.filter((mount) => isExistingDirectory(mount.localRoot));
-}
-
-function isExistingDirectory(dir: string): boolean {
-  try {
-    return fs.statSync(dir).isDirectory();
-  } catch {
-    return false;
-  }
+  return mounts.filter((mount) =>
+    isExistingWorkspaceSkillMountSource({
+      agentWorkspaceDir: params.localRoot,
+      hostPath: mount.localRoot,
+    }),
+  );
 }
 
 function compareRemoteMountsByContainerPath(a: MountInfo, b: MountInfo): number {

--- a/src/agents/sandbox/remote-fs-bridge.ts
+++ b/src/agents/sandbox/remote-fs-bridge.ts
@@ -14,16 +14,19 @@ import {
   relativePathEscapesContainerRoot,
 } from "./path-utils.js";
 
+type RemoteMountSource = "workspace" | "agent" | "protectedSkill";
+
 type ResolvedRemotePath = SandboxResolvedPath & {
   writable: boolean;
   mountRootPath: string;
-  source: "workspace" | "agent";
+  source: RemoteMountSource;
 };
 
 type MountInfo = {
+  localRoot: string;
   containerRoot: string;
   writable: boolean;
-  source: "workspace" | "agent";
+  source: RemoteMountSource;
 };
 
 export type RemoteShellSandboxHandle = {
@@ -239,9 +242,14 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
   }
 
   private getMounts(): MountInfo[] {
+    const workspaceRoot = path.resolve(this.sandbox.workspaceDir);
+    const agentRoot = path.resolve(this.sandbox.agentWorkspaceDir);
+    const workspaceContainerRoot = normalizeContainerPath(this.runtime.remoteWorkspaceDir);
+    const agentContainerRoot = normalizeContainerPath(this.runtime.remoteAgentWorkspaceDir);
     const mounts: MountInfo[] = [
       {
-        containerRoot: normalizeContainerPath(this.runtime.remoteWorkspaceDir),
+        localRoot: workspaceRoot,
+        containerRoot: workspaceContainerRoot,
         writable: this.sandbox.workspaceAccess === "rw",
         source: "workspace",
       },
@@ -251,19 +259,27 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       path.resolve(this.sandbox.agentWorkspaceDir) !== path.resolve(this.sandbox.workspaceDir)
     ) {
       mounts.push({
-        containerRoot: normalizeContainerPath(this.runtime.remoteAgentWorkspaceDir),
+        localRoot: agentRoot,
+        containerRoot: agentContainerRoot,
         writable: this.sandbox.workspaceAccess === "rw",
         source: "agent",
       });
+    }
+    if (this.sandbox.workspaceAccess === "rw") {
+      mounts.push(
+        ...buildRemoteProtectedSkillMounts({
+          localRoot: agentRoot,
+          workspaceContainerRoot,
+          agentContainerRoot,
+          includeAgentMount: path.resolve(this.sandbox.agentWorkspaceDir) !== path.resolve(this.sandbox.workspaceDir),
+        }),
+      );
     }
     return mounts;
   }
 
   private resolveTarget(params: { filePath: string; cwd?: string }): ResolvedRemotePath {
     const workspaceRoot = path.resolve(this.sandbox.workspaceDir);
-    const agentRoot = path.resolve(this.sandbox.agentWorkspaceDir);
-    const workspaceContainerRoot = normalizeContainerPath(this.runtime.remoteWorkspaceDir);
-    const agentContainerRoot = normalizeContainerPath(this.runtime.remoteAgentWorkspaceDir);
     const mounts = this.getMounts();
     const input = params.filePath.trim();
     const inputPosix = input.replace(/\\/g, "/");
@@ -281,22 +297,14 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     const hostCandidate = path.isAbsolute(input)
       ? path.resolve(input)
       : path.resolve(hostCwd, input);
-    if (isPathInside(workspaceRoot, hostCandidate)) {
-      const relative = toPosixRelative(workspaceRoot, hostCandidate);
+    const hostMount = this.resolveMountByLocalPath(mounts, hostCandidate);
+    if (hostMount) {
+      const relative = toPosixRelative(hostMount.localRoot, hostCandidate);
       return this.toResolvedPath({
-        mount: mounts[0],
+        mount: hostMount,
         containerPath: relative
-          ? path.posix.join(workspaceContainerRoot, relative)
-          : workspaceContainerRoot,
-      });
-    }
-    if (mounts[1] && isPathInside(agentRoot, hostCandidate)) {
-      const relative = toPosixRelative(agentRoot, hostCandidate);
-      return this.toResolvedPath({
-        mount: mounts[1],
-        containerPath: relative
-          ? path.posix.join(agentContainerRoot, relative)
-          : agentContainerRoot,
+          ? path.posix.join(hostMount.containerRoot, relative)
+          : hostMount.containerRoot,
       });
     }
 
@@ -326,10 +334,10 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     }
     return {
       relativePath:
-        params.mount.source === "workspace"
+        params.mount.source === "workspace" || params.mount.source === "protectedSkill"
           ? relative === "."
             ? ""
-            : relative
+            : path.posix.relative(this.runtime.remoteWorkspaceDir, params.containerPath)
           : relative === "."
             ? params.mount.containerRoot
             : `${params.mount.containerRoot}/${relative}`,
@@ -344,9 +352,19 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     mounts: MountInfo[],
     containerPath: string,
   ): MountInfo | null {
-    const ordered = [...mounts].toSorted((a, b) => b.containerRoot.length - a.containerRoot.length);
+    const ordered = [...mounts].toSorted(compareRemoteMountsByContainerPath);
     for (const mount of ordered) {
       if (isPathInsideContainerRoot(mount.containerRoot, containerPath)) {
+        return mount;
+      }
+    }
+    return null;
+  }
+
+  private resolveMountByLocalPath(mounts: MountInfo[], localPath: string): MountInfo | null {
+    const ordered = [...mounts].toSorted(compareRemoteMountsByLocalPath);
+    for (const mount of ordered) {
+      if (isPathInside(mount.localRoot, localPath)) {
         return mount;
       }
     }
@@ -507,6 +525,63 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       allowFailure: params.allowFailure,
     });
   }
+}
+
+function buildRemoteProtectedSkillMounts(params: {
+  localRoot: string;
+  workspaceContainerRoot: string;
+  agentContainerRoot: string;
+  includeAgentMount: boolean;
+}): MountInfo[] {
+  const mounts: MountInfo[] = [
+    {
+      localRoot: path.join(params.localRoot, "skills"),
+      containerRoot: path.posix.join(params.workspaceContainerRoot, "skills"),
+      writable: false,
+      source: "protectedSkill",
+    },
+    {
+      localRoot: path.join(params.localRoot, ".agents", "skills"),
+      containerRoot: path.posix.join(params.workspaceContainerRoot, ".agents", "skills"),
+      writable: false,
+      source: "protectedSkill",
+    },
+  ];
+  if (params.includeAgentMount) {
+    mounts.push(
+      {
+        localRoot: path.join(params.localRoot, "skills"),
+        containerRoot: path.posix.join(params.agentContainerRoot, "skills"),
+        writable: false,
+        source: "protectedSkill",
+      },
+      {
+        localRoot: path.join(params.localRoot, ".agents", "skills"),
+        containerRoot: path.posix.join(params.agentContainerRoot, ".agents", "skills"),
+        writable: false,
+        source: "protectedSkill",
+      },
+    );
+  }
+  return mounts;
+}
+
+function compareRemoteMountsByContainerPath(a: MountInfo, b: MountInfo): number {
+  return b.containerRoot.length - a.containerRoot.length || mountPriority(b) - mountPriority(a);
+}
+
+function compareRemoteMountsByLocalPath(a: MountInfo, b: MountInfo): number {
+  return b.localRoot.length - a.localRoot.length || mountPriority(b) - mountPriority(a);
+}
+
+function mountPriority(mount: MountInfo): number {
+  if (mount.source === "protectedSkill") {
+    return 2;
+  }
+  if (mount.source === "agent") {
+    return 1;
+  }
+  return 0;
 }
 
 function normalizeContainerPath(value: string): string {

--- a/src/agents/sandbox/remote-fs-bridge.ts
+++ b/src/agents/sandbox/remote-fs-bridge.ts
@@ -97,7 +97,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     signal?: AbortSignal;
   }): Promise<void> {
     const target = this.resolveTarget(params);
-    this.ensureWritable(target, "write files");
+    await this.ensureRemoteWritable(target, "write files", params.signal);
     const pinned = await this.resolvePinnedParent({
       containerPath: target.containerPath,
       action: "write files",
@@ -126,7 +126,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
 
   async mkdirp(params: { filePath: string; cwd?: string; signal?: AbortSignal }): Promise<void> {
     const target = this.resolveTarget(params);
-    this.ensureWritable(target, "create directories");
+    await this.ensureRemoteWritable(target, "create directories", params.signal);
     const relativePath = path.posix.relative(target.mountRootPath, target.containerPath);
     if (relativePathEscapesContainerRoot(relativePath)) {
       throw new Error(
@@ -147,7 +147,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     signal?: AbortSignal;
   }): Promise<void> {
     const target = this.resolveTarget(params);
-    this.ensureWritable(target, "remove files");
+    await this.ensureRemoteWritable(target, "remove files", params.signal);
     const exists = await this.remotePathExists(target.containerPath, params.signal);
     if (!exists) {
       if (params.force === false) {
@@ -182,6 +182,8 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     signal?: AbortSignal;
   }): Promise<void> {
     const { from, to } = this.resolveRenameTargets(params);
+    await this.ensureRemoteWritable(from, "rename files", params.signal);
+    await this.ensureRemoteWritable(to, "rename files", params.signal);
     const fromPinned = await this.resolvePinnedParent({
       containerPath: from.containerPath,
       action: "rename files",
@@ -382,6 +384,44 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     if (this.sandbox.workspaceAccess !== "rw" || !target.writable) {
       throw new Error(`Sandbox path is read-only; cannot ${action}: ${target.containerPath}`);
     }
+  }
+
+  private async ensureRemoteWritable(
+    target: ResolvedRemotePath,
+    action: string,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    this.ensureWritable(target, action);
+    const protectedRoot = this.findRemoteProtectedSkillRoot(target.containerPath);
+    if (protectedRoot && (await this.remotePathExists(protectedRoot, signal))) {
+      throw new Error(`Sandbox path is read-only; cannot ${action}: ${target.containerPath}`);
+    }
+  }
+
+  private findRemoteProtectedSkillRoot(containerPath: string): string | null {
+    const roots = this.getRemoteProtectedSkillRoots().toSorted((a, b) => b.length - a.length);
+    for (const root of roots) {
+      if (isPathInsideContainerRoot(root, containerPath)) {
+        return root;
+      }
+    }
+    return null;
+  }
+
+  private getRemoteProtectedSkillRoots(): string[] {
+    const workspaceContainerRoot = normalizeContainerPath(this.runtime.remoteWorkspaceDir);
+    const agentContainerRoot = normalizeContainerPath(this.runtime.remoteAgentWorkspaceDir);
+    const roots = [
+      path.posix.join(workspaceContainerRoot, "skills"),
+      path.posix.join(workspaceContainerRoot, ".agents", "skills"),
+    ];
+    if (path.resolve(this.sandbox.agentWorkspaceDir) !== path.resolve(this.sandbox.workspaceDir)) {
+      roots.push(
+        path.posix.join(agentContainerRoot, "skills"),
+        path.posix.join(agentContainerRoot, ".agents", "skills"),
+      );
+    }
+    return roots;
   }
 
   private async remotePathExists(containerPath: string, signal?: AbortSignal): Promise<boolean> {

--- a/src/agents/sandbox/workspace-mounts.test.ts
+++ b/src/agents/sandbox/workspace-mounts.test.ts
@@ -99,6 +99,47 @@ describe("appendWorkspaceMountArgs", () => {
     ]);
   });
 
+  it.runIf(process.platform !== "win32")("does not overlay symlinked workspace skill roots", () => {
+    const agentWorkspaceDir = makeTempWorkspace();
+    const outsideDir = makeTempWorkspace();
+    fs.mkdirSync(path.join(outsideDir, "demo"), { recursive: true });
+    fs.symlinkSync(outsideDir, path.join(agentWorkspaceDir, "skills"), "dir");
+
+    const args: string[] = [];
+    appendWorkspaceMountArgs({
+      args,
+      workspaceDir: agentWorkspaceDir,
+      agentWorkspaceDir,
+      workdir: "/workspace",
+      workspaceAccess: "rw",
+    });
+
+    const mounts = args.filter((arg) => arg.startsWith(agentWorkspaceDir));
+    expect(mounts).toEqual([`${agentWorkspaceDir}:/workspace:z`]);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "does not overlay skill roots through a symlinked parent",
+    () => {
+      const agentWorkspaceDir = makeTempWorkspace();
+      const outsideDir = makeTempWorkspace();
+      fs.mkdirSync(path.join(outsideDir, "skills", "demo"), { recursive: true });
+      fs.symlinkSync(outsideDir, path.join(agentWorkspaceDir, ".agents"), "dir");
+
+      const args: string[] = [];
+      appendWorkspaceMountArgs({
+        args,
+        workspaceDir: agentWorkspaceDir,
+        agentWorkspaceDir,
+        workdir: "/workspace",
+        workspaceAccess: "rw",
+      });
+
+      const mounts = args.filter((arg) => arg.startsWith(agentWorkspaceDir));
+      expect(mounts).toEqual([`${agentWorkspaceDir}:/workspace:z`]);
+    },
+  );
+
   it("overlays project .agents skills read-only when workspaceAccess is rw", () => {
     const agentWorkspaceDir = makeTempWorkspace();
     fs.mkdirSync(path.join(agentWorkspaceDir, ".agents", "skills", "demo"), {

--- a/src/agents/sandbox/workspace-mounts.test.ts
+++ b/src/agents/sandbox/workspace-mounts.test.ts
@@ -1,5 +1,22 @@
-import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import { appendWorkspaceMountArgs } from "./workspace-mounts.js";
+
+const tmpDirs: string[] = [];
+
+function makeTempWorkspace(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sandbox-mounts-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 describe("appendWorkspaceMountArgs", () => {
   it.each([
@@ -59,5 +76,103 @@ describe("appendWorkspaceMountArgs", () => {
 
     const mounts = args.filter((arg) => arg.startsWith("/tmp/"));
     expect(mounts).toEqual(["/tmp/workspace:/workspace:ro,z", "/tmp/agent-workspace:/agent:ro,z"]);
+  });
+
+  it("overlays workspace skills read-only when workspaceAccess is rw", () => {
+    const agentWorkspaceDir = makeTempWorkspace();
+    fs.mkdirSync(path.join(agentWorkspaceDir, "skills", "demo"), { recursive: true });
+    fs.writeFileSync(path.join(agentWorkspaceDir, "skills", "demo", "SKILL.md"), "# Demo\n");
+
+    const args: string[] = [];
+    appendWorkspaceMountArgs({
+      args,
+      workspaceDir: agentWorkspaceDir,
+      agentWorkspaceDir,
+      workdir: "/workspace",
+      workspaceAccess: "rw",
+    });
+
+    const mounts = args.filter((arg) => arg.startsWith(agentWorkspaceDir));
+    expect(mounts).toEqual([
+      `${agentWorkspaceDir}:/workspace:z`,
+      `${path.join(agentWorkspaceDir, "skills")}:/workspace/skills:ro,z`,
+    ]);
+  });
+
+  it("overlays project .agents skills read-only when workspaceAccess is rw", () => {
+    const agentWorkspaceDir = makeTempWorkspace();
+    fs.mkdirSync(path.join(agentWorkspaceDir, ".agents", "skills", "demo"), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(agentWorkspaceDir, ".agents", "skills", "demo", "SKILL.md"),
+      "# Demo\n",
+    );
+
+    const args: string[] = [];
+    appendWorkspaceMountArgs({
+      args,
+      workspaceDir: agentWorkspaceDir,
+      agentWorkspaceDir,
+      workdir: "/workspace",
+      workspaceAccess: "rw",
+    });
+
+    const mounts = args.filter((arg) => arg.startsWith(agentWorkspaceDir));
+    expect(mounts).toEqual([
+      `${agentWorkspaceDir}:/workspace:z`,
+      `${path.join(agentWorkspaceDir, ".agents", "skills")}:/workspace/.agents/skills:ro,z`,
+    ]);
+  });
+
+  it("does not add a separate synced skill overlay when workspaceAccess is ro", () => {
+    const agentWorkspaceDir = makeTempWorkspace();
+    const sandboxWorkspaceDir = makeTempWorkspace();
+    fs.mkdirSync(path.join(sandboxWorkspaceDir, "skills", "demo"), { recursive: true });
+
+    const args: string[] = [];
+    appendWorkspaceMountArgs({
+      args,
+      workspaceDir: sandboxWorkspaceDir,
+      agentWorkspaceDir,
+      workdir: "/workspace",
+      workspaceAccess: "ro",
+    });
+
+    const mounts = args.filter(
+      (arg) => arg.startsWith(agentWorkspaceDir) || arg.startsWith(sandboxWorkspaceDir),
+    );
+
+    expect(mounts).toEqual([
+      `${sandboxWorkspaceDir}:/workspace:ro,z`,
+      `${agentWorkspaceDir}:/agent:ro,z`,
+    ]);
+    expect(mounts).not.toContain(
+      `${path.join(sandboxWorkspaceDir, "skills")}:/workspace/skills:ro,z`,
+    );
+  });
+
+  it("does not add a separate synced skill overlay when workspaceAccess is none", () => {
+    const agentWorkspaceDir = makeTempWorkspace();
+    const sandboxWorkspaceDir = makeTempWorkspace();
+    fs.mkdirSync(path.join(sandboxWorkspaceDir, "skills", "demo"), { recursive: true });
+
+    const args: string[] = [];
+    appendWorkspaceMountArgs({
+      args,
+      workspaceDir: sandboxWorkspaceDir,
+      agentWorkspaceDir,
+      workdir: "/workspace",
+      workspaceAccess: "none",
+    });
+
+    const mounts = args.filter(
+      (arg) => arg.startsWith(agentWorkspaceDir) || arg.startsWith(sandboxWorkspaceDir),
+    );
+
+    expect(mounts).toEqual([`${sandboxWorkspaceDir}:/workspace:ro,z`]);
+    expect(mounts).not.toContain(
+      `${path.join(sandboxWorkspaceDir, "skills")}:/workspace/skills:ro,z`,
+    );
   });
 });

--- a/src/agents/sandbox/workspace-mounts.ts
+++ b/src/agents/sandbox/workspace-mounts.ts
@@ -1,7 +1,14 @@
+import fs from "node:fs";
+import path from "node:path";
 import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./constants.js";
 import type { SandboxWorkspaceAccess } from "./types.js";
 
-export const SANDBOX_MOUNT_FORMAT_VERSION = 2;
+export const SANDBOX_MOUNT_FORMAT_VERSION = 3;
+
+export type ReadOnlyWorkspaceSkillMount = {
+  hostPath: string;
+  containerPath: string;
+};
 
 function formatManagedWorkspaceBind(params: {
   hostPath: string;
@@ -11,12 +18,76 @@ function formatManagedWorkspaceBind(params: {
   return `${params.hostPath}:${params.containerPath}:${params.readOnly ? "ro,z" : "z"}`;
 }
 
+function containerJoin(root: string, ...parts: string[]): string {
+  const normalizedRoot = root.endsWith("/") && root !== "/" ? root.slice(0, -1) : root;
+  const suffix = parts
+    .map((part) => part.replace(/^\/+|\/+$/g, ""))
+    .filter(Boolean)
+    .join("/");
+  return suffix ? `${normalizedRoot}/${suffix}` : normalizedRoot;
+}
+
+function isExistingDirectory(dir: string): boolean {
+  try {
+    return fs.statSync(dir).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+export function resolveReadOnlyWorkspaceSkillMounts(params: {
+  workspaceDir: string;
+  agentWorkspaceDir: string;
+  workdir: string;
+  workspaceAccess: SandboxWorkspaceAccess;
+}): ReadOnlyWorkspaceSkillMount[] {
+  if (params.workspaceAccess !== "rw") {
+    return [];
+  }
+
+  const mounts = [
+    {
+      hostPath: path.join(params.agentWorkspaceDir, "skills"),
+      containerPath: containerJoin(params.workdir, "skills"),
+    },
+    {
+      hostPath: path.join(params.agentWorkspaceDir, ".agents", "skills"),
+      containerPath: containerJoin(params.workdir, ".agents", "skills"),
+    },
+  ];
+
+  return mounts.filter((mount) => isExistingDirectory(mount.hostPath));
+}
+
+export function formatReadOnlyWorkspaceSkillMountHashState(
+  mounts: readonly ReadOnlyWorkspaceSkillMount[],
+): string[] {
+  return mounts.map((mount) => `${mount.hostPath}:${mount.containerPath}:ro`);
+}
+
+function appendReadOnlyWorkspaceSkillMounts(params: {
+  args: string[];
+  readOnlyWorkspaceSkillMounts: readonly ReadOnlyWorkspaceSkillMount[];
+}): void {
+  for (const mount of params.readOnlyWorkspaceSkillMounts) {
+    params.args.push(
+      "-v",
+      formatManagedWorkspaceBind({
+        hostPath: mount.hostPath,
+        containerPath: mount.containerPath,
+        readOnly: true,
+      }),
+    );
+  }
+}
+
 export function appendWorkspaceMountArgs(params: {
   args: string[];
   workspaceDir: string;
   agentWorkspaceDir: string;
   workdir: string;
   workspaceAccess: SandboxWorkspaceAccess;
+  readOnlyWorkspaceSkillMounts?: readonly ReadOnlyWorkspaceSkillMount[];
 }) {
   const { args, workspaceDir, agentWorkspaceDir, workdir, workspaceAccess } = params;
 
@@ -28,6 +99,7 @@ export function appendWorkspaceMountArgs(params: {
       readOnly: workspaceAccess !== "rw",
     }),
   );
+
   if (workspaceAccess !== "none" && workspaceDir !== agentWorkspaceDir) {
     args.push(
       "-v",
@@ -38,4 +110,16 @@ export function appendWorkspaceMountArgs(params: {
       }),
     );
   }
+
+  appendReadOnlyWorkspaceSkillMounts({
+    args,
+    readOnlyWorkspaceSkillMounts:
+      params.readOnlyWorkspaceSkillMounts ??
+      resolveReadOnlyWorkspaceSkillMounts({
+        workspaceDir,
+        agentWorkspaceDir,
+        workdir,
+        workspaceAccess,
+      }),
+  });
 }

--- a/src/agents/sandbox/workspace-mounts.ts
+++ b/src/agents/sandbox/workspace-mounts.ts
@@ -83,7 +83,7 @@ export function formatReadOnlyWorkspaceSkillMountHashState(
   return mounts.map((mount) => `${mount.hostPath}:${mount.containerPath}:ro`);
 }
 
-function appendReadOnlyWorkspaceSkillMounts(params: {
+export function appendReadOnlyWorkspaceSkillMountArgs(params: {
   args: string[];
   readOnlyWorkspaceSkillMounts: readonly ReadOnlyWorkspaceSkillMount[];
 }): void {
@@ -106,6 +106,7 @@ export function appendWorkspaceMountArgs(params: {
   workdir: string;
   workspaceAccess: SandboxWorkspaceAccess;
   readOnlyWorkspaceSkillMounts?: readonly ReadOnlyWorkspaceSkillMount[];
+  includeReadOnlyWorkspaceSkillMounts?: boolean;
 }) {
   const { args, workspaceDir, agentWorkspaceDir, workdir, workspaceAccess } = params;
 
@@ -129,15 +130,17 @@ export function appendWorkspaceMountArgs(params: {
     );
   }
 
-  appendReadOnlyWorkspaceSkillMounts({
-    args,
-    readOnlyWorkspaceSkillMounts:
-      params.readOnlyWorkspaceSkillMounts ??
-      resolveReadOnlyWorkspaceSkillMounts({
-        workspaceDir,
-        agentWorkspaceDir,
-        workdir,
-        workspaceAccess,
-      }),
-  });
+  if (params.includeReadOnlyWorkspaceSkillMounts !== false) {
+    appendReadOnlyWorkspaceSkillMountArgs({
+      args,
+      readOnlyWorkspaceSkillMounts:
+        params.readOnlyWorkspaceSkillMounts ??
+        resolveReadOnlyWorkspaceSkillMounts({
+          workspaceDir,
+          agentWorkspaceDir,
+          workdir,
+          workspaceAccess,
+        }),
+    });
+  }
 }

--- a/src/agents/sandbox/workspace-mounts.ts
+++ b/src/agents/sandbox/workspace-mounts.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
+import { isPathInside } from "../../infra/path-guards.js";
 import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./constants.js";
+import { resolveSandboxHostPathViaExistingAncestor } from "./host-paths.js";
 import type { SandboxWorkspaceAccess } from "./types.js";
 
 export const SANDBOX_MOUNT_FORMAT_VERSION = 3;
@@ -27,12 +29,23 @@ function containerJoin(root: string, ...parts: string[]): string {
   return suffix ? `${normalizedRoot}/${suffix}` : normalizedRoot;
 }
 
-function isExistingDirectory(dir: string): boolean {
+export function isExistingWorkspaceSkillMountSource(params: {
+  agentWorkspaceDir: string;
+  hostPath: string;
+}): boolean {
   try {
-    return fs.statSync(dir).isDirectory();
+    if (!fs.lstatSync(params.hostPath).isDirectory()) {
+      return false;
+    }
   } catch {
     return false;
   }
+
+  const agentRoot = resolveSandboxHostPathViaExistingAncestor(
+    path.resolve(params.agentWorkspaceDir),
+  );
+  const canonicalSource = resolveSandboxHostPathViaExistingAncestor(path.resolve(params.hostPath));
+  return isPathInside(agentRoot, canonicalSource);
 }
 
 export function resolveReadOnlyWorkspaceSkillMounts(params: {
@@ -56,7 +69,12 @@ export function resolveReadOnlyWorkspaceSkillMounts(params: {
     },
   ];
 
-  return mounts.filter((mount) => isExistingDirectory(mount.hostPath));
+  return mounts.filter((mount) =>
+    isExistingWorkspaceSkillMountSource({
+      agentWorkspaceDir: params.agentWorkspaceDir,
+      hostPath: mount.hostPath,
+    }),
+  );
 }
 
 export function formatReadOnlyWorkspaceSkillMountHashState(

--- a/src/agents/sandbox/workspace-skills-bridge-readonly.test.ts
+++ b/src/agents/sandbox/workspace-skills-bridge-readonly.test.ts
@@ -1,0 +1,31 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { buildSandboxFsMounts, resolveSandboxFsPathWithMounts } from "./fs-paths.js";
+import { createSandbox, withTempDir } from "./fs-bridge.test-helpers.js";
+
+describe("workspace skills bridge mount policy", () => {
+  it("resolves workspace skill roots as read-only", async () => {
+    await withTempDir("openclaw-skills-bridge-", async (stateDir) => {
+      const workspaceDir = path.join(stateDir, "workspace");
+      await fs.mkdir(path.join(workspaceDir, "skills", "demo"), { recursive: true });
+      await fs.mkdir(path.join(workspaceDir, ".agents", "skills", "demo"), { recursive: true });
+
+      const sandbox = createSandbox({ workspaceDir, agentWorkspaceDir: workspaceDir });
+      const mounts = buildSandboxFsMounts(sandbox);
+      const resolve = (filePath: string) =>
+        resolveSandboxFsPathWithMounts({
+          filePath,
+          cwd: sandbox.workspaceDir,
+          defaultWorkspaceRoot: sandbox.workspaceDir,
+          defaultContainerRoot: sandbox.containerWorkdir,
+          mounts,
+        });
+
+      expect(resolve("normal.txt").writable).toBe(true);
+      expect(resolve("skills/demo/SKILL.md").writable).toBe(false);
+      expect(resolve(".agents/skills/demo/SKILL.md").writable).toBe(false);
+      expect(resolve("/workspace/skills/demo/SKILL.md").writable).toBe(false);
+    });
+  });
+});

--- a/src/agents/sandbox/workspace-skills-bridge-readonly.test.ts
+++ b/src/agents/sandbox/workspace-skills-bridge-readonly.test.ts
@@ -2,9 +2,9 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { buildSandboxFsMounts, resolveSandboxFsPathWithMounts } from "./fs-paths.js";
 import { SANDBOX_PINNED_MUTATION_PYTHON } from "./fs-bridge-mutation-helper.js";
 import { createSandbox, withTempDir } from "./fs-bridge.test-helpers.js";
+import { buildSandboxFsMounts, resolveSandboxFsPathWithMounts } from "./fs-paths.js";
 import { createRemoteShellSandboxFsBridge } from "./remote-fs-bridge.js";
 
 describe("workspace skills bridge mount policy", () => {
@@ -38,12 +38,16 @@ describe("workspace skills bridge mount policy", () => {
       await withTempDir("openclaw-skills-remote-absent-", async (stateDir) => {
         const workspaceDir = path.join(stateDir, "workspace");
         await fs.mkdir(workspaceDir, { recursive: true });
+        const canonicalWorkspaceDir = await fs.realpath(workspaceDir);
 
         const bridge = createRemoteShellSandboxFsBridge({
-          sandbox: createSandbox({ workspaceDir, agentWorkspaceDir: workspaceDir }),
+          sandbox: createSandbox({
+            workspaceDir: canonicalWorkspaceDir,
+            agentWorkspaceDir: canonicalWorkspaceDir,
+          }),
           runtime: {
-            remoteWorkspaceDir: workspaceDir,
-            remoteAgentWorkspaceDir: workspaceDir,
+            remoteWorkspaceDir: canonicalWorkspaceDir,
+            remoteAgentWorkspaceDir: canonicalWorkspaceDir,
             runRemoteShellScript: async (command) => {
               const result = command.script.includes('python3 /dev/fd/3 "$@" 3<<')
                 ? spawnSync(
@@ -55,11 +59,15 @@ describe("workspace skills bridge mount policy", () => {
                       stdio: ["pipe", "pipe", "pipe"],
                     },
                   )
-                : spawnSync("sh", ["-c", command.script, "openclaw-test", ...(command.args ?? [])], {
-                    input: command.stdin,
-                    encoding: "buffer",
-                    stdio: ["pipe", "pipe", "pipe"],
-                  });
+                : spawnSync(
+                    "sh",
+                    ["-c", command.script, "openclaw-test", ...(command.args ?? [])],
+                    {
+                      input: command.stdin,
+                      encoding: "buffer",
+                      stdio: ["pipe", "pipe", "pipe"],
+                    },
+                  );
               const stdout = Buffer.isBuffer(result.stdout)
                 ? result.stdout
                 : Buffer.from(result.stdout ?? []);
@@ -82,9 +90,79 @@ describe("workspace skills bridge mount policy", () => {
         });
 
         await bridge.writeFile({ filePath: "skills/new.txt", data: "created" });
-        await expect(fs.readFile(path.join(workspaceDir, "skills", "new.txt"), "utf8")).resolves.toBe(
-          "created",
-        );
+        await expect(
+          fs.readFile(path.join(canonicalWorkspaceDir, "skills", "new.txt"), "utf8"),
+        ).resolves.toBe("created");
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects remote bridge mkdirp under skill roots from container cwd",
+    async () => {
+      await withTempDir("openclaw-skills-remote-cwd-", async (stateDir) => {
+        const workspaceDir = path.join(stateDir, "workspace");
+        const remoteWorkspaceDir = path.join(stateDir, "remote-workspace");
+        await fs.mkdir(path.join(workspaceDir, "skills", "demo"), { recursive: true });
+        await fs.mkdir(path.join(remoteWorkspaceDir, "skills", "demo"), { recursive: true });
+        const canonicalWorkspaceDir = await fs.realpath(workspaceDir);
+        const canonicalRemoteWorkspaceDir = await fs.realpath(remoteWorkspaceDir);
+
+        const bridge = createRemoteShellSandboxFsBridge({
+          sandbox: createSandbox({
+            workspaceDir: canonicalWorkspaceDir,
+            agentWorkspaceDir: canonicalWorkspaceDir,
+          }),
+          runtime: {
+            remoteWorkspaceDir: canonicalRemoteWorkspaceDir,
+            remoteAgentWorkspaceDir: canonicalRemoteWorkspaceDir,
+            runRemoteShellScript: async (command) => {
+              const result = command.script.includes('python3 /dev/fd/3 "$@" 3<<')
+                ? spawnSync(
+                    "python3",
+                    ["-c", SANDBOX_PINNED_MUTATION_PYTHON, ...(command.args ?? [])],
+                    {
+                      input: command.stdin,
+                      encoding: "buffer",
+                      stdio: ["pipe", "pipe", "pipe"],
+                    },
+                  )
+                : spawnSync(
+                    "sh",
+                    ["-c", command.script, "openclaw-test", ...(command.args ?? [])],
+                    {
+                      input: command.stdin,
+                      encoding: "buffer",
+                      stdio: ["pipe", "pipe", "pipe"],
+                    },
+                  );
+              const stdout = Buffer.isBuffer(result.stdout)
+                ? result.stdout
+                : Buffer.from(result.stdout ?? []);
+              const stderr = Buffer.isBuffer(result.stderr)
+                ? result.stderr
+                : Buffer.from(result.stderr ?? []);
+              const code = result.status ?? (result.signal ? 128 : 1);
+              if (result.error) {
+                throw result.error;
+              }
+              if (code !== 0 && !command.allowFailure) {
+                throw Object.assign(
+                  new Error(stderr.toString("utf8").trim() || `shell exited with code ${code}`),
+                  { code, stdout, stderr },
+                );
+              }
+              return { stdout, stderr, code };
+            },
+          },
+        });
+
+        await expect(
+          bridge.mkdirp({ filePath: "skills/demo/generated", cwd: canonicalRemoteWorkspaceDir }),
+        ).rejects.toThrow(/read-only/);
+        await expect(
+          fs.stat(path.join(canonicalRemoteWorkspaceDir, "skills", "demo", "generated")),
+        ).rejects.toMatchObject({ code: "ENOENT" });
       });
     },
   );

--- a/src/agents/sandbox/workspace-skills-bridge-readonly.test.ts
+++ b/src/agents/sandbox/workspace-skills-bridge-readonly.test.ts
@@ -172,6 +172,81 @@ describe("workspace skills bridge mount policy", () => {
   );
 
   it.runIf(process.platform !== "win32")(
+    "rejects remote bridge writes through symlinks into skill roots",
+    async () => {
+      await withTempDir("openclaw-skills-remote-link-", async (stateDir) => {
+        const workspaceDir = path.join(stateDir, "workspace");
+        const remoteWorkspaceDir = path.join(stateDir, "remote-workspace");
+        await fs.mkdir(workspaceDir, { recursive: true });
+        await fs.mkdir(path.join(remoteWorkspaceDir, "skills", "demo"), { recursive: true });
+        await fs.symlink("skills", path.join(remoteWorkspaceDir, "link"), "dir");
+        const canonicalWorkspaceDir = await fs.realpath(workspaceDir);
+        const canonicalRemoteWorkspaceDir = await fs.realpath(remoteWorkspaceDir);
+
+        const bridge = createRemoteShellSandboxFsBridge({
+          sandbox: createSandbox({
+            workspaceDir: canonicalWorkspaceDir,
+            agentWorkspaceDir: canonicalWorkspaceDir,
+          }),
+          runtime: {
+            remoteWorkspaceDir: canonicalRemoteWorkspaceDir,
+            remoteAgentWorkspaceDir: canonicalRemoteWorkspaceDir,
+            runRemoteShellScript: async (command) => {
+              const result = command.script.includes('python3 /dev/fd/3 "$@" 3<<')
+                ? spawnSync(
+                    "python3",
+                    ["-c", SANDBOX_PINNED_MUTATION_PYTHON, ...(command.args ?? [])],
+                    {
+                      input: command.stdin,
+                      encoding: "buffer",
+                      stdio: ["pipe", "pipe", "pipe"],
+                    },
+                  )
+                : spawnSync(
+                    "sh",
+                    ["-c", command.script, "openclaw-test", ...(command.args ?? [])],
+                    {
+                      input: command.stdin,
+                      encoding: "buffer",
+                      stdio: ["pipe", "pipe", "pipe"],
+                    },
+                  );
+              const stdout = Buffer.isBuffer(result.stdout)
+                ? result.stdout
+                : Buffer.from(result.stdout ?? []);
+              const stderr = Buffer.isBuffer(result.stderr)
+                ? result.stderr
+                : Buffer.from(result.stderr ?? []);
+              const code = result.status ?? (result.signal ? 128 : 1);
+              if (result.error) {
+                throw result.error;
+              }
+              if (code !== 0 && !command.allowFailure) {
+                throw Object.assign(
+                  new Error(stderr.toString("utf8").trim() || `shell exited with code ${code}`),
+                  { code, stdout, stderr },
+                );
+              }
+              return { stdout, stderr, code };
+            },
+          },
+        });
+
+        await expect(
+          bridge.writeFile({
+            filePath: "link/demo/SKILL.md",
+            cwd: canonicalRemoteWorkspaceDir,
+            data: "# Demo\n",
+          }),
+        ).rejects.toThrow(/read-only/);
+        await expect(
+          fs.stat(path.join(canonicalRemoteWorkspaceDir, "skills", "demo", "SKILL.md")),
+        ).rejects.toMatchObject({ code: "ENOENT" });
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "rejects remote bridge mkdirp under skill roots from container cwd",
     async () => {
       await withTempDir("openclaw-skills-remote-cwd-", async (stateDir) => {

--- a/src/agents/sandbox/workspace-skills-bridge-readonly.test.ts
+++ b/src/agents/sandbox/workspace-skills-bridge-readonly.test.ts
@@ -1,8 +1,11 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { buildSandboxFsMounts, resolveSandboxFsPathWithMounts } from "./fs-paths.js";
+import { SANDBOX_PINNED_MUTATION_PYTHON } from "./fs-bridge-mutation-helper.js";
 import { createSandbox, withTempDir } from "./fs-bridge.test-helpers.js";
+import { createRemoteShellSandboxFsBridge } from "./remote-fs-bridge.js";
 
 describe("workspace skills bridge mount policy", () => {
   it("resolves workspace skill roots as read-only", async () => {
@@ -28,4 +31,61 @@ describe("workspace skills bridge mount policy", () => {
       expect(resolve("/workspace/skills/demo/SKILL.md").writable).toBe(false);
     });
   });
+
+  it.runIf(process.platform !== "win32")(
+    "allows remote bridge writes under absent skill roots",
+    async () => {
+      await withTempDir("openclaw-skills-remote-absent-", async (stateDir) => {
+        const workspaceDir = path.join(stateDir, "workspace");
+        await fs.mkdir(workspaceDir, { recursive: true });
+
+        const bridge = createRemoteShellSandboxFsBridge({
+          sandbox: createSandbox({ workspaceDir, agentWorkspaceDir: workspaceDir }),
+          runtime: {
+            remoteWorkspaceDir: workspaceDir,
+            remoteAgentWorkspaceDir: workspaceDir,
+            runRemoteShellScript: async (command) => {
+              const result = command.script.includes('python3 /dev/fd/3 "$@" 3<<')
+                ? spawnSync(
+                    "python3",
+                    ["-c", SANDBOX_PINNED_MUTATION_PYTHON, ...(command.args ?? [])],
+                    {
+                      input: command.stdin,
+                      encoding: "buffer",
+                      stdio: ["pipe", "pipe", "pipe"],
+                    },
+                  )
+                : spawnSync("sh", ["-c", command.script, "openclaw-test", ...(command.args ?? [])], {
+                    input: command.stdin,
+                    encoding: "buffer",
+                    stdio: ["pipe", "pipe", "pipe"],
+                  });
+              const stdout = Buffer.isBuffer(result.stdout)
+                ? result.stdout
+                : Buffer.from(result.stdout ?? []);
+              const stderr = Buffer.isBuffer(result.stderr)
+                ? result.stderr
+                : Buffer.from(result.stderr ?? []);
+              const code = result.status ?? (result.signal ? 128 : 1);
+              if (result.error) {
+                throw result.error;
+              }
+              if (code !== 0 && !command.allowFailure) {
+                throw Object.assign(
+                  new Error(stderr.toString("utf8").trim() || `shell exited with code ${code}`),
+                  { code, stdout, stderr },
+                );
+              }
+              return { stdout, stderr, code };
+            },
+          },
+        });
+
+        await bridge.writeFile({ filePath: "skills/new.txt", data: "created" });
+        await expect(fs.readFile(path.join(workspaceDir, "skills", "new.txt"), "utf8")).resolves.toBe(
+          "created",
+        );
+      });
+    },
+  );
 });

--- a/src/agents/sandbox/workspace-skills-bridge-readonly.test.ts
+++ b/src/agents/sandbox/workspace-skills-bridge-readonly.test.ts
@@ -98,6 +98,80 @@ describe("workspace skills bridge mount policy", () => {
   );
 
   it.runIf(process.platform !== "win32")(
+    "rejects remote bridge writes under remote-only skill roots",
+    async () => {
+      await withTempDir("openclaw-skills-remote-only-", async (stateDir) => {
+        const workspaceDir = path.join(stateDir, "workspace");
+        const remoteWorkspaceDir = path.join(stateDir, "remote-workspace");
+        await fs.mkdir(workspaceDir, { recursive: true });
+        await fs.mkdir(path.join(remoteWorkspaceDir, "skills", "demo"), { recursive: true });
+        const canonicalWorkspaceDir = await fs.realpath(workspaceDir);
+        const canonicalRemoteWorkspaceDir = await fs.realpath(remoteWorkspaceDir);
+
+        const bridge = createRemoteShellSandboxFsBridge({
+          sandbox: createSandbox({
+            workspaceDir: canonicalWorkspaceDir,
+            agentWorkspaceDir: canonicalWorkspaceDir,
+          }),
+          runtime: {
+            remoteWorkspaceDir: canonicalRemoteWorkspaceDir,
+            remoteAgentWorkspaceDir: canonicalRemoteWorkspaceDir,
+            runRemoteShellScript: async (command) => {
+              const result = command.script.includes('python3 /dev/fd/3 "$@" 3<<')
+                ? spawnSync(
+                    "python3",
+                    ["-c", SANDBOX_PINNED_MUTATION_PYTHON, ...(command.args ?? [])],
+                    {
+                      input: command.stdin,
+                      encoding: "buffer",
+                      stdio: ["pipe", "pipe", "pipe"],
+                    },
+                  )
+                : spawnSync(
+                    "sh",
+                    ["-c", command.script, "openclaw-test", ...(command.args ?? [])],
+                    {
+                      input: command.stdin,
+                      encoding: "buffer",
+                      stdio: ["pipe", "pipe", "pipe"],
+                    },
+                  );
+              const stdout = Buffer.isBuffer(result.stdout)
+                ? result.stdout
+                : Buffer.from(result.stdout ?? []);
+              const stderr = Buffer.isBuffer(result.stderr)
+                ? result.stderr
+                : Buffer.from(result.stderr ?? []);
+              const code = result.status ?? (result.signal ? 128 : 1);
+              if (result.error) {
+                throw result.error;
+              }
+              if (code !== 0 && !command.allowFailure) {
+                throw Object.assign(
+                  new Error(stderr.toString("utf8").trim() || `shell exited with code ${code}`),
+                  { code, stdout, stderr },
+                );
+              }
+              return { stdout, stderr, code };
+            },
+          },
+        });
+
+        await expect(
+          bridge.writeFile({
+            filePath: "skills/demo/SKILL.md",
+            cwd: canonicalRemoteWorkspaceDir,
+            data: "# Demo\n",
+          }),
+        ).rejects.toThrow(/read-only/);
+        await expect(
+          fs.stat(path.join(canonicalRemoteWorkspaceDir, "skills", "demo", "SKILL.md")),
+        ).rejects.toMatchObject({ code: "ENOENT" });
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "rejects remote bridge mkdirp under skill roots from container cwd",
     async () => {
       await withTempDir("openclaw-skills-remote-cwd-", async (stateDir) => {


### PR DESCRIPTION
## Summary

Fixes #17931.

This PR protects workspace skill paths exposed to sandboxes from in-sandbox writes.

In `workspaceAccess: "rw"`, the normal workspace remains writable, but existing workspace skill roots are protected:

- `<workspace>/skills` -> `/workspace/skills:ro,z`
- `<workspace>/.agents/skills` -> `/workspace/.agents/skills:ro,z`

In `workspaceAccess: "ro"` and `"none"`, the existing read-only `/workspace` mount provides the protection without adding a stale nested `/workspace/skills` bind.

## What changed

- Added read-only Docker overlays for existing workspace skill roots in `rw` mode.
- Kept `ro` and `none` on the existing read-only `/workspace` mount.
- Removed chmod-based copied-skill protection.
- Added stable skill-mount hash state so old containers are recreated when protected skill roots appear.
- Bumped `SANDBOX_MOUNT_FORMAT_VERSION` from `2` to `3`.
- Added generic fs bridge policy coverage so existing protected skill roots resolve read-only through OpenClaw file operations.
- Added remote fs bridge policy coverage with existing-root filtering to preserve normal writes under absent `skills/` roots.
- Added tests for Docker mount behavior, hash behavior, bridge read-only resolution, and absent-root remote write compatibility.

## Security impact

This prevents sandboxed agents from rewriting existing workspace skill instructions they are executing under. Normal workspace writes in `rw` mode still work, but writes under existing protected skill paths now fail. Absent `skills/` roots continue to behave as normal workspace paths until they exist and become protected roots.

## Validation

Targeted command:

```text
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run \
  src/agents/sandbox/workspace-mounts.test.ts \
  src/agents/sandbox/config-hash.test.ts \
  src/agents/sandbox.resolveSandboxContext.test.ts \
  src/agents/sandbox/workspace-skills-bridge-readonly.test.ts \
  src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.test.ts
```

## Real behavior proof

**Behavior addressed:** Workspace skill instructions exposed to Docker sandboxes are protected from in-sandbox writes while the normal workspace remains writable. The generic and remote OpenClaw fs bridge write paths classify existing `/workspace/skills` and `/workspace/.agents/skills` roots as read-only, so OpenClaw file operations do not bypass the Docker mount policy. The remote bridge also preserves compatibility for absent `skills/` roots by allowing normal workspace writes there until the protected root exists.

**Real environment tested:** Repository openclaw/openclaw, PR #85591, branch jason-allen-oneal:fix/sandbox-readonly-skill-mounts, current PR head `69d60b0efc1266c1e4d6ca380954102ae0c1c2ea`. Proof was run from detached worktree `/tmp/openclaw-85591-proof` using the current branch head, Docker image `openclaw-sandbox:bookworm-slim`, a temporary workspace with existing skill roots, a temporary workspace with an absent skills root, the generic OpenClaw fs bridge, and the remote OpenClaw fs bridge runtime path.

**Exact steps or command run after this patch:** Ran `.tmp-pr85591-current-proof.ts` from `/tmp/openclaw-85591-proof` at current head `69d60b0efc1266c1e4d6ca380954102ae0c1c2ea`. The script created existing `skills/demo/SKILL.md` and `.agents/skills/demo/SKILL.md` roots, created a Docker sandbox with `/workspace` writable and both existing skill roots mounted read-only, wrote a normal workspace file through the generic OpenClaw fs bridge, attempted writes to both existing protected skill roots through the generic bridge, wrote a normal workspace file through the remote OpenClaw fs bridge, attempted writes to both existing protected skill roots through the remote bridge, then verified remote bridge compatibility by writing under an absent `skills/` root.

**Evidence after fix:** Copied terminal output from the current-head proof run:

```text
head=69d60b0efc1266c1e4d6ca380954102ae0c1c2ea
workspace=/redacted/proof/workspace
docker mount: /redacted/proof/workspace/.agents/skills -> /workspace/.agents/skills RW=false
docker mount: /redacted/proof/workspace -> /workspace RW=true
docker mount: /redacted/proof/workspace/skills -> /workspace/skills RW=false
OK: generic OpenClaw fs bridge wrote normal workspace file
OK: generic bridge write to existing /workspace/skills blocked: Sandbox path is read-only; cannot write files: /workspace/skills/demo/SKILL.md
OK: generic bridge write to existing /workspace/.agents/skills blocked: Sandbox path is read-only; cannot write files: /workspace/.agents/skills/demo/SKILL.md
docker readback normal.txt=generic-normal-ok
OK: remote OpenClaw fs bridge wrote normal workspace file
OK: remote bridge write to existing /workspace/skills blocked: Sandbox path is read-only; cannot write files: /tmp/openclaw-pr85591-proof-zhcYO1/workspace/skills/demo/SKILL.md
OK: remote bridge write to existing /workspace/.agents/skills blocked: Sandbox path is read-only; cannot write files: /tmp/openclaw-pr85591-proof-zhcYO1/workspace/.agents/skills/demo/SKILL.md
host readback remote-normal.txt=remote-normal-ok
OK: remote OpenClaw fs bridge wrote under absent skills root
host readback absent skills/new.txt=absent-root-created
RESULT: current-head proof complete
```

**Observed result after fix:** Normal workspace writes succeeded through both the generic and remote OpenClaw fs bridges. Writes under existing `/workspace/skills` and `/workspace/.agents/skills` failed through both bridge paths with read-only sandbox path errors. The Docker mount table showed `/workspace` writable while both existing skill roots were mounted read-only. The remote bridge allowed a normal write under an absent `skills/` root, matching Docker/generic existing-root filtering behavior.

**What was not tested:** A full interactive UI session was not included. This proof covers the Docker mount behavior, both OpenClaw fs bridge write paths, and the final absent-root remote bridge compatibility behavior directly.
