### PR TITLE
fix(bootstrap): guard bootstrap name checks against undefined names (#85523)

### DIFF
--- a/src/agents/bootstrap-budget.ts
+++ b/src/agents/bootstrap-budget.ts
@@ -68,8 +68,8 @@ function formatWarningCause(cause: BootstrapTruncationCause): string {
   return cause === "per-file-limit" ? "max/file" : "max/total";
 }
 
-function isAgentsBootstrapName(name: string): boolean {
-  return name.toLowerCase() === "agents.md";
+function isAgentsBootstrapName(name: string | undefined): boolean {
+  return name?.toLowerCase() === "agents.md";
 }
 
 function normalizeSeenSignatures(signatures?: string[]): string[] {

--- a/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts
+++ b/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts
@@ -241,6 +241,21 @@ describe("buildBootstrapContextFiles", () => {
       warnings.filter((warning) => !warning.includes('missing or invalid "path" field')),
     ).toStrictEqual([]);
   });
+
+  it("handles undefined file names without crashing", () => {
+    const fileWithUndefinedName = {
+      name: undefined,
+      path: "/tmp/test.md",
+      content: "content",
+      missing: false,
+    } as unknown as WorkspaceBootstrapFile;
+    const warnings: string[] = [];
+    const result = buildBootstrapContextFiles([fileWithUndefinedName], {
+      warn: (msg) => warnings.push(msg),
+    });
+    expect(result).toBeDefined();
+    expect(Array.isArray(result)).toBe(true);
+  });
 });
 
 type BootstrapLimitResolverCase = {

--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -151,8 +151,8 @@ export function resolveBootstrapPromptTruncationWarningMode(
   return DEFAULT_BOOTSTRAP_PROMPT_TRUNCATION_WARNING_MODE;
 }
 
-function isAgentsBootstrapFile(fileName: string): boolean {
-  return fileName.toLowerCase() === AGENTS_BOOTSTRAP_FILENAME.toLowerCase();
+function isAgentsBootstrapFile(fileName: string | undefined): boolean {
+  return fileName?.toLowerCase() === AGENTS_BOOTSTRAP_FILENAME.toLowerCase();
 }
 
 function isPolicyDigestCandidate(line: string): boolean {


### PR DESCRIPTION
## Summary

Fixes a critical crash in OpenClaw 2026.5.20 where \`TypeError: Cannot read properties of undefined (reading 'toLowerCase')\` is thrown during bootstrap context building, completely blocking all agent replies.

## Problem

When a workspace bootstrap file entry has an \`undefined\` \`name\` property, two internal helper functions (\`isAgentsBootstrapFile\` and \`isAgentsBootstrapName\`) call \`.toLowerCase()\` without null-safety checks, causing every incoming message to crash before the agent can respond.

## Changes

- \`src/agents/pi-embedded-helpers/bootstrap.ts\`: \`isAgentsBootstrapFile\` now accepts \`string | undefined\` and uses optional chaining (\`?.toLowerCase()\`)
- \`src/agents/bootstrap-budget.ts\`: \`isAgentsBootstrapName\` now accepts \`string | undefined\` and uses optional chaining (\`?.toLowerCase()\`)
- Added regression test in \`src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts\` to verify \`undefined\` file names do not crash

## Verification

Behavior addressed: Prevent toLowerCase crash on undefined bootstrap file names
Real environment tested: Local source checkout, Ubuntu Linux, Node 22
Exact steps or command run after this patch:
  - pnpm test src/agents/bootstrap-budget.test.ts src/agents/pi-embedded-helpers/bootstrap.test.ts src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts
  - pnpm format:check src/agents/bootstrap-budget.ts src/agents/pi-embedded-helpers/bootstrap.ts
Evidence after fix: 43 tests pass, 0 failures; formatting check passes
Observed result after fix: No crash when processing bootstrap files with undefined names
What was not tested: Live gateway with actual Telegram channel (unit tests cover the fix path)

Fixes #85523