### PR TITLE
fix(daemon): keep node tasks off gateway listener cleanup

### DIFF
--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -73,6 +73,7 @@ const {
 } = await import("./schtasks.js");
 
 function resolveStartupEntryPath(env: Record<string, string>, extension = "cmd") {
+  const taskName = env.OPENCLAW_WINDOWS_TASK_NAME ?? "OpenClaw Gateway";
   return path.join(
     env.APPDATA,
     "Microsoft",
@@ -80,7 +81,7 @@ function resolveStartupEntryPath(env: Record<string, string>, extension = "cmd")
     "Start Menu",
     "Programs",
     "Startup",
-    `OpenClaw Gateway.${extension}`,
+    `${taskName}.${extension}`,
   );
 }
 
@@ -89,6 +90,22 @@ async function writeStartupFallbackEntry(env: Record<string, string>) {
   await fs.mkdir(path.dirname(startupEntryPath), { recursive: true });
   await fs.writeFile(startupEntryPath, "@echo off\r\n", "utf8");
   return startupEntryPath;
+}
+
+async function writeNodeScript(env: Record<string, string>, port = "18789") {
+  const scriptPath = resolveTaskScriptPath(env);
+  await fs.mkdir(path.dirname(scriptPath), { recursive: true });
+  await fs.writeFile(
+    scriptPath,
+    [
+      "@echo off",
+      `set "OPENCLAW_SERVICE_KIND=node"`,
+      `set "OPENCLAW_GATEWAY_PORT=${port}"`,
+      `"C:\\bin\\openclaw.cmd" node run --host 127.0.0.1 --port ${port}`,
+      "",
+    ].join("\r\n"),
+    "utf8",
+  );
 }
 
 function expectStartupFallbackSpawn() {
@@ -134,6 +151,22 @@ function installGatewayScheduledTask(env: Record<string, string>, stdout = new P
     stdout,
     programArguments: ["node", "gateway.js", "--port", "18789"],
     environment: { OPENCLAW_GATEWAY_PORT: "18789" },
+  });
+}
+
+function installNodeScheduledTask(env: Record<string, string>, stdout = new PassThrough()) {
+  return installScheduledTask({
+    env: {
+      ...env,
+      OPENCLAW_SERVICE_KIND: "node",
+      OPENCLAW_WINDOWS_TASK_NAME: "OpenClaw Node",
+    },
+    stdout,
+    programArguments: ["node", "openclaw", "node", "run", "--host", "127.0.0.1", "--port", "18789"],
+    environment: {
+      OPENCLAW_SERVICE_KIND: "node",
+      OPENCLAW_GATEWAY_PORT: "18789",
+    },
   });
 }
 
@@ -298,6 +331,64 @@ describe("Windows startup fallback", () => {
     });
   });
 
+  it("does not treat a gateway listener as node Scheduled Task launch evidence", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      fastForwardTaskStartWait();
+      findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4242]);
+      addAcceptedRunNeverStartsResponses();
+
+      await installNodeScheduledTask(env);
+
+      expect(findVerifiedGatewayListenerPidsOnPortSync).not.toHaveBeenCalled();
+      expectStartupFallbackSpawn();
+    });
+  });
+
+  it("does not relaunch when the node Scheduled Task process is already running", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+      fastForwardTaskStartWait();
+      findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4242]);
+      spawnSync.mockImplementation((command, args) => {
+        if (
+          command === "powershell" &&
+          Array.isArray(args) &&
+          args.includes(
+            "Get-CimInstance Win32_Process | Select-Object ProcessId,CommandLine | ConvertTo-Json -Compress",
+          )
+        ) {
+          return {
+            pid: 0,
+            output: [null, "", ""],
+            stdout: JSON.stringify([
+              {
+                ProcessId: 5151,
+                CommandLine: "node openclaw node run --host 127.0.0.1 --port 18789",
+              },
+            ]),
+            stderr: "",
+            status: 0,
+            signal: null,
+          };
+        }
+        return {
+          pid: 0,
+          output: [null, "", ""],
+          stdout: "",
+          stderr: "",
+          status: 0,
+          signal: null,
+        };
+      });
+      addAcceptedRunNeverStartsResponses();
+
+      await installNodeScheduledTask(env);
+
+      expect(findVerifiedGatewayListenerPidsOnPortSync).not.toHaveBeenCalled();
+      expect(spawn).not.toHaveBeenCalled();
+    });
+  });
+
   it("does not relaunch the task script when schtasks shows startup progress after /Run", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       addStartupFallbackMissingResponses([
@@ -384,6 +475,82 @@ describe("Windows startup fallback", () => {
     });
   });
 
+  it("does not report a node task as running from a gateway listener", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      env.OPENCLAW_SERVICE_KIND = "node";
+      env.OPENCLAW_WINDOWS_TASK_NAME = "OpenClaw Node";
+      findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4242]);
+      schtasksResponses.push(
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: notYetRunTaskQueryOutput(), stderr: "" },
+      );
+
+      const runtime = await readScheduledTaskRuntime(env);
+      expect(runtime.status).toBe("stopped");
+      expect(runtime.state).toBe("Ready");
+      expect(runtime.lastRunResult).toBe("267011");
+      expect(findVerifiedGatewayListenerPidsOnPortSync).not.toHaveBeenCalled();
+    });
+  });
+
+  it("reports a registered node task as running from the matching node host process", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+      const nodeEnv = {
+        ...env,
+        OPENCLAW_SERVICE_KIND: "node",
+        OPENCLAW_WINDOWS_TASK_NAME: "OpenClaw Node",
+      };
+      await writeNodeScript(nodeEnv);
+      findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4242]);
+      schtasksResponses.push(
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: notYetRunTaskQueryOutput(), stderr: "" },
+      );
+      spawnSync.mockImplementation((command, args) => {
+        if (
+          command === "powershell" &&
+          Array.isArray(args) &&
+          args.includes(
+            "Get-CimInstance Win32_Process | Select-Object ProcessId,CommandLine | ConvertTo-Json -Compress",
+          )
+        ) {
+          return {
+            pid: 0,
+            output: [null, "", ""],
+            stdout: JSON.stringify([
+              {
+                ProcessId: 4242,
+                CommandLine: "C:\\manual\\openclaw.cmd node run --host 127.0.0.1 --port 18789",
+              },
+              {
+                ProcessId: 5151,
+                CommandLine: "C:\\bin\\openclaw.cmd node run --host 127.0.0.1 --port 18789",
+              },
+            ]),
+            stderr: "",
+            status: 0,
+            signal: null,
+          };
+        }
+        return {
+          pid: 0,
+          output: [null, "", ""],
+          stdout: "",
+          stderr: "",
+          status: 0,
+          signal: null,
+        };
+      });
+
+      const runtime = await readScheduledTaskRuntime(nodeEnv);
+      expect(runtime.status).toBe("running");
+      expect(runtime.pid).toBe(5151);
+      expect(findVerifiedGatewayListenerPidsOnPortSync).not.toHaveBeenCalled();
+      expect(inspectPortUsage).not.toHaveBeenCalled();
+    });
+  });
+
   it("does not trust an unverified busy port when schtasks still says not-yet-run", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       await writeGatewayScript(env);
@@ -462,6 +629,233 @@ describe("Windows startup fallback", () => {
       const runtime = await readScheduledTaskRuntime(env);
       expect(runtime.status).toBe("running");
       expect(runtime.pid).toBe(4242);
+    });
+  });
+
+  it("does not report a node Startup fallback as running from the gateway listener", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      const nodeEnv = {
+        ...env,
+        OPENCLAW_SERVICE_KIND: "node",
+        OPENCLAW_WINDOWS_TASK_NAME: "OpenClaw Node",
+      };
+      addStartupFallbackMissingResponses();
+      await writeStartupFallbackEntry(nodeEnv);
+      inspectPortUsage.mockResolvedValue({
+        port: 18789,
+        status: "busy",
+        listeners: [{ pid: 4242, command: "node.exe" }],
+        hints: [],
+      });
+
+      const runtime = await readScheduledTaskRuntime(nodeEnv);
+      expect(runtime.status).toBe("unknown");
+      expect(runtime.pid).toBeUndefined();
+      expect(inspectPortUsage).not.toHaveBeenCalled();
+    });
+  });
+
+  it("does not kill the gateway listener when stopping a node Startup fallback", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      const nodeEnv = {
+        ...env,
+        OPENCLAW_SERVICE_KIND: "node",
+        OPENCLAW_WINDOWS_TASK_NAME: "OpenClaw Node",
+      };
+      addStartupFallbackMissingResponses();
+      await writeStartupFallbackEntry(nodeEnv);
+      inspectPortUsage.mockResolvedValue({
+        port: 18789,
+        status: "busy",
+        listeners: [{ pid: 5151, command: "node.exe" }],
+        hints: [],
+      });
+
+      await stopScheduledTask({ env: nodeEnv, stdout: new PassThrough() });
+
+      expect(inspectPortUsage).not.toHaveBeenCalled();
+      expect(killProcessTree).not.toHaveBeenCalled();
+    });
+  });
+
+  it("stops a node Startup fallback by terminating the matching node host process", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+      const nodeEnv = {
+        ...env,
+        OPENCLAW_SERVICE_KIND: "node",
+        OPENCLAW_WINDOWS_TASK_NAME: "OpenClaw Node",
+      };
+      addStartupFallbackMissingResponses();
+      await writeStartupFallbackEntry(nodeEnv);
+      await writeNodeScript(nodeEnv);
+      spawnSync.mockImplementation((command, args) => {
+        if (
+          command === "powershell" &&
+          Array.isArray(args) &&
+          args.includes(
+            "Get-CimInstance Win32_Process | Select-Object ProcessId,CommandLine | ConvertTo-Json -Compress",
+          )
+        ) {
+          return {
+            pid: 0,
+            output: [null, "", ""],
+            stdout: JSON.stringify([
+              {
+                ProcessId: 5151,
+                CommandLine: "C:\\bin\\openclaw.cmd node run --host 127.0.0.1 --port 18789",
+              },
+            ]),
+            stderr: "",
+            status: 0,
+            signal: null,
+          };
+        }
+        return {
+          pid: 0,
+          output: [null, "", ""],
+          stdout: "",
+          stderr: "",
+          status: 0,
+          signal: null,
+        };
+      });
+
+      await stopScheduledTask({ env: nodeEnv, stdout: new PassThrough() });
+
+      expect(inspectPortUsage).not.toHaveBeenCalled();
+      expect(
+        spawnSync.mock.calls.some(
+          ([command, args]) =>
+            command.endsWith("taskkill.exe") &&
+            Array.isArray(args) &&
+            args.includes("/PID") &&
+            args.includes("5151"),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it("cleans up a stale node Startup fallback when a node Scheduled Task is registered", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+      const nodeEnv = {
+        ...env,
+        OPENCLAW_SERVICE_KIND: "node",
+        OPENCLAW_WINDOWS_TASK_NAME: "OpenClaw Node",
+      };
+      schtasksResponses.push(
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+      );
+      await writeStartupFallbackEntry(nodeEnv);
+      await writeNodeScript(nodeEnv);
+      spawnSync.mockImplementation((command, args) => {
+        if (
+          command === "powershell" &&
+          Array.isArray(args) &&
+          args.includes(
+            "Get-CimInstance Win32_Process | Select-Object ProcessId,CommandLine | ConvertTo-Json -Compress",
+          )
+        ) {
+          return {
+            pid: 0,
+            output: [null, "", ""],
+            stdout: JSON.stringify([
+              {
+                ProcessId: 5151,
+                CommandLine: "C:\\bin\\openclaw.cmd node run --host 127.0.0.1 --port 18789",
+              },
+            ]),
+            stderr: "",
+            status: 0,
+            signal: null,
+          };
+        }
+        return {
+          pid: 0,
+          output: [null, "", ""],
+          stdout: "",
+          stderr: "",
+          status: 0,
+          signal: null,
+        };
+      });
+
+      await stopScheduledTask({ env: nodeEnv, stdout: new PassThrough() });
+
+      expect(inspectPortUsage).not.toHaveBeenCalled();
+      expect(
+        spawnSync.mock.calls.some(
+          ([command, args]) =>
+            command.endsWith("taskkill.exe") &&
+            Array.isArray(args) &&
+            args.includes("/PID") &&
+            args.includes("5151"),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it("stops a registered node Scheduled Task by terminating the matching node host process", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+      const nodeEnv = {
+        ...env,
+        OPENCLAW_SERVICE_KIND: "node",
+        OPENCLAW_WINDOWS_TASK_NAME: "OpenClaw Node",
+      };
+      schtasksResponses.push(
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
+      );
+      await writeNodeScript(nodeEnv);
+      spawnSync.mockImplementation((command, args) => {
+        if (
+          command === "powershell" &&
+          Array.isArray(args) &&
+          args.includes(
+            "Get-CimInstance Win32_Process | Select-Object ProcessId,CommandLine | ConvertTo-Json -Compress",
+          )
+        ) {
+          return {
+            pid: 0,
+            output: [null, "", ""],
+            stdout: JSON.stringify([
+              {
+                ProcessId: 5151,
+                CommandLine: "C:\\bin\\openclaw.cmd node run --host 127.0.0.1 --port 18789",
+              },
+            ]),
+            stderr: "",
+            status: 0,
+            signal: null,
+          };
+        }
+        return {
+          pid: 0,
+          output: [null, "", ""],
+          stdout: "",
+          stderr: "",
+          status: 0,
+          signal: null,
+        };
+      });
+
+      await stopScheduledTask({ env: nodeEnv, stdout: new PassThrough() });
+
+      expect(inspectPortUsage).not.toHaveBeenCalled();
+      expect(
+        spawnSync.mock.calls.some(
+          ([command, args]) =>
+            command.endsWith("taskkill.exe") &&
+            Array.isArray(args) &&
+            args.includes("/PID") &&
+            args.includes("5151"),
+        ),
+      ).toBe(true);
     });
   });
 

--- a/src/daemon/schtasks.stop.test.ts
+++ b/src/daemon/schtasks.stop.test.ts
@@ -168,6 +168,27 @@ describe("Scheduled Task stop/restart cleanup", () => {
     });
   });
 
+  it("does not reclaim gateway listeners when stopping a node Scheduled Task", async () => {
+    await withPreparedGatewayTask(async ({ env, stdout }) => {
+      pushSuccessfulSchtasksResponses(3);
+      env.OPENCLAW_SERVICE_KIND = "node";
+      env.OPENCLAW_WINDOWS_TASK_NAME = "OpenClaw Node";
+      findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4242]);
+      inspectPortUsage.mockResolvedValue(busyPortUsage(4242));
+
+      await stopScheduledTask({ env, stdout });
+
+      expect(findVerifiedGatewayListenerPidsOnPortSync).not.toHaveBeenCalled();
+      expect(inspectPortUsage).not.toHaveBeenCalled();
+      expect(killProcessTree).not.toHaveBeenCalled();
+      expect(schtasksCalls).toEqual([
+        ["/Query"],
+        ["/Query", "/TN", "OpenClaw Node"],
+        ["/End", "/TN", "OpenClaw Node"],
+      ]);
+    });
+  });
+
   it("kills lingering verified gateway listeners and waits for port release before restart", async () => {
     await withPreparedGatewayTask(async ({ env, stdout }) => {
       pushSuccessfulSchtasksResponses(4);
@@ -190,6 +211,32 @@ describe("Scheduled Task stop/restart cleanup", () => {
         ["/Run", "/TN", "OpenClaw Gateway"],
         ["/Query"],
         ["/Query", "/TN", "OpenClaw Gateway", "/V", "/FO", "LIST"],
+      ]);
+    });
+  });
+
+  it("does not wait on or force-kill the gateway port when restarting a node Scheduled Task", async () => {
+    await withPreparedGatewayTask(async ({ env, stdout }) => {
+      pushSuccessfulSchtasksResponses(4);
+      env.OPENCLAW_SERVICE_KIND = "node";
+      env.OPENCLAW_WINDOWS_TASK_NAME = "OpenClaw Node";
+      findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([5151]);
+      inspectPortUsage.mockResolvedValue(busyPortUsage(5151));
+
+      await expect(restartScheduledTask({ env, stdout })).resolves.toEqual({
+        outcome: "completed",
+      });
+
+      expect(findVerifiedGatewayListenerPidsOnPortSync).not.toHaveBeenCalled();
+      expect(inspectPortUsage).not.toHaveBeenCalled();
+      expect(killProcessTree).not.toHaveBeenCalled();
+      expect(schtasksCalls).toEqual([
+        ["/Query"],
+        ["/Query", "/TN", "OpenClaw Node"],
+        ["/End", "/TN", "OpenClaw Node"],
+        ["/Run", "/TN", "OpenClaw Node"],
+        ["/Query"],
+        ["/Query", "/TN", "OpenClaw Node", "/V", "/FO", "LIST"],
       ]);
     });
   });

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -11,7 +11,11 @@ import { uniqueStrings } from "../shared/string-normalization.js";
 import { sleep } from "../utils.js";
 import { parseCmdScriptCommandLine, quoteCmdScriptArg } from "./cmd-argv.js";
 import { assertNoCmdLineBreak, parseCmdSetAssignment, renderCmdSetAssignment } from "./cmd-set.js";
-import { resolveGatewayServiceDescription, resolveGatewayWindowsTaskName } from "./constants.js";
+import {
+  NODE_SERVICE_KIND,
+  resolveGatewayServiceDescription,
+  resolveGatewayWindowsTaskName,
+} from "./constants.js";
 import { formatLine, writeFormattedLines } from "./output.js";
 import { resolveGatewayStateDir } from "./paths.js";
 import { parseKeyValueOutput } from "./runtime-parse.js";
@@ -256,6 +260,11 @@ const UNKNOWN_STATUS_DETAIL =
 const SCHEDULED_TASK_FALLBACK_POLL_MS = 250;
 const SCHEDULED_TASK_FALLBACK_TIMEOUT_MS = 15_000;
 
+type WindowsProcessSnapshotEntry = {
+  ProcessId?: number;
+  CommandLine?: string | null;
+};
+
 function deriveScheduledTaskRuntimeStatus(parsed: ScheduledTaskInfo): {
   status: GatewayServiceRuntime["status"];
   detail?: string;
@@ -440,6 +449,90 @@ function parsePortFromProgramArguments(programArguments?: string[]): number | nu
   return null;
 }
 
+function isNodeHostArgv(programArguments: string[]): boolean {
+  const normalized = programArguments.map((arg) =>
+    normalizeLowercaseStringOrEmpty(arg.replaceAll("\\", "/")),
+  );
+  return normalized.some((arg, index) => arg === "node" && normalized[index + 1] === "run");
+}
+
+function normalizeProgramArguments(programArguments: string[]): string[] {
+  return programArguments.map((arg) => normalizeLowercaseStringOrEmpty(arg.replaceAll("\\", "/")));
+}
+
+function matchesInstalledProgramArguments(
+  actualArguments: string[],
+  installedArguments: string[],
+): boolean {
+  const actual = normalizeProgramArguments(actualArguments);
+  const installed = normalizeProgramArguments(installedArguments);
+  return (
+    actual.length === installed.length && actual.every((arg, index) => arg === installed[index])
+  );
+}
+
+function getSnapshotProcessId(entry: WindowsProcessSnapshotEntry): number | null {
+  const pid = entry.ProcessId;
+  return typeof pid === "number" && Number.isFinite(pid) && pid > 0 ? pid : null;
+}
+
+function findNodeHostProcessPid(
+  entries: WindowsProcessSnapshotEntry[],
+  port: number,
+  installedArguments: string[],
+): number | null {
+  for (const entry of entries) {
+    const commandLine = normalizeLowercaseStringOrEmpty(entry.CommandLine ?? "");
+    if (!commandLine) {
+      continue;
+    }
+    const argv = parseCmdScriptCommandLine(entry.CommandLine ?? "");
+    if (
+      !isNodeHostArgv(argv) ||
+      parsePortFromProgramArguments(argv) !== port ||
+      !matchesInstalledProgramArguments(argv, installedArguments)
+    ) {
+      continue;
+    }
+    const pid = getSnapshotProcessId(entry);
+    if (pid) {
+      return pid;
+    }
+  }
+  return null;
+}
+
+async function resolveScheduledTaskNodeHostProcess(env: GatewayServiceEnv): Promise<{
+  pid: number;
+  port: number;
+} | null> {
+  const command = await readScheduledTaskCommand(env).catch(() => null);
+  const installedArguments = command?.programArguments;
+  if (!installedArguments?.length) {
+    return null;
+  }
+  const port =
+    parsePortFromProgramArguments(installedArguments) ??
+    parsePositivePort(command?.environment?.OPENCLAW_GATEWAY_PORT) ??
+    resolveConfiguredGatewayPort(env);
+  if (!port) {
+    return null;
+  }
+  const snapshot = readWindowsProcessSnapshot();
+  if (!snapshot) {
+    return null;
+  }
+  const pid = findNodeHostProcessPid(snapshot, port, installedArguments);
+  if (!pid) {
+    return null;
+  }
+  return { pid, port };
+}
+
+function shouldManageGatewayListenerPort(env: GatewayServiceEnv): boolean {
+  return normalizeLowercaseStringOrEmpty(env.OPENCLAW_SERVICE_KIND) !== NODE_SERVICE_KIND;
+}
+
 async function resolveScheduledTaskPort(env: GatewayServiceEnv): Promise<number | null> {
   const command = await readScheduledTaskCommand(env).catch(() => null);
   return (
@@ -490,6 +583,17 @@ async function resolveScheduledTaskGatewayListenerPids(port: number): Promise<nu
 async function resolveListenerBackedScheduledTaskRuntime(
   env: GatewayServiceEnv,
 ): Promise<Pick<GatewayServiceRuntime, "status" | "pid" | "detail"> | null> {
+  if (!shouldManageGatewayListenerPort(env)) {
+    const matched = await resolveScheduledTaskNodeHostProcess(env);
+    if (!matched) {
+      return null;
+    }
+    return {
+      status: "running",
+      pid: matched.pid,
+      detail: `Node host process detected for gateway port ${matched.port}.`,
+    };
+  }
   const port = await resolveScheduledTaskPort(env);
   if (!port) {
     return null;
@@ -505,7 +609,19 @@ async function resolveListenerBackedScheduledTaskRuntime(
   };
 }
 
+async function terminateScheduledTaskNodeHost(env: GatewayServiceEnv): Promise<number[]> {
+  const matched = await resolveScheduledTaskNodeHostProcess(env);
+  if (!matched) {
+    return [];
+  }
+  await terminateGatewayProcessTree(matched.pid, 300);
+  return [matched.pid];
+}
+
 async function terminateScheduledTaskGatewayListeners(env: GatewayServiceEnv): Promise<number[]> {
+  if (!shouldManageGatewayListenerPort(env)) {
+    return [];
+  }
   const port = await resolveScheduledTaskPort(env);
   if (!port) {
     return [];
@@ -589,7 +705,76 @@ async function terminateBusyPortListeners(port: number): Promise<number[]> {
   return pids;
 }
 
+function readWindowsProcessSnapshot(): WindowsProcessSnapshotEntry[] | null {
+  if (process.platform !== "win32") {
+    return null;
+  }
+
+  const processSnapshot = spawnSync(
+    "powershell",
+    [
+      "-NoProfile",
+      "-Command",
+      "Get-CimInstance Win32_Process | Select-Object ProcessId,CommandLine | ConvertTo-Json -Compress",
+    ],
+    {
+      encoding: "utf8",
+      timeout: 1_500,
+      windowsHide: true,
+    },
+  );
+  if (processSnapshot.error || processSnapshot.status !== 0) {
+    return null;
+  }
+
+  let parsedSnapshot: unknown;
+  try {
+    parsedSnapshot = JSON.parse(processSnapshot.stdout.trim() || "[]");
+  } catch {
+    return null;
+  }
+
+  return (Array.isArray(parsedSnapshot) ? parsedSnapshot : [parsedSnapshot]).filter(
+    (entry): entry is WindowsProcessSnapshotEntry => typeof entry === "object" && entry !== null,
+  );
+}
+
 async function resolveFallbackRuntime(env: GatewayServiceEnv): Promise<GatewayServiceRuntime> {
+  if (!shouldManageGatewayListenerPort(env)) {
+    const command = await readScheduledTaskCommand(env).catch(() => null);
+    const installedArguments = command?.programArguments;
+    const port =
+      parsePortFromProgramArguments(installedArguments) ??
+      parsePositivePort(command?.environment?.OPENCLAW_GATEWAY_PORT) ??
+      resolveConfiguredGatewayPort(env);
+    if (!port) {
+      return {
+        status: "unknown",
+        detail: "Startup-folder login item installed; node gateway port unknown.",
+      };
+    }
+    const snapshot = readWindowsProcessSnapshot();
+    if (!snapshot) {
+      return {
+        status: "unknown",
+        detail: `Startup-folder login item installed; could not inspect node host process for gateway port ${port}.`,
+      };
+    }
+    const pid = installedArguments?.length
+      ? findNodeHostProcessPid(snapshot, port, installedArguments)
+      : null;
+    if (pid) {
+      return {
+        status: "running",
+        pid,
+        detail: `Startup-folder login item installed; node host process detected for gateway port ${port}.`,
+      };
+    }
+    return {
+      status: "stopped",
+      detail: `Startup-folder login item installed; no node host process detected for gateway port ${port}.`,
+    };
+  }
   const port = (await resolveScheduledTaskPort(env)) ?? resolveConfiguredGatewayPort(env);
   if (!port) {
     return {
@@ -764,16 +949,18 @@ async function shouldFallbackScheduledTaskLaunch(params: {
   };
 
   const hasLaunchEvidence = async (): Promise<boolean> => {
-    const port = await resolveScheduledTaskPort(params.env);
-    if (port) {
-      const listenerPids = await resolveScheduledTaskGatewayListenerPids(port);
+    const command = await readScheduledTaskCommand(params.env).catch(() => null);
+    const installedArguments = command?.programArguments;
+    const taskPort =
+      parsePortFromProgramArguments(installedArguments) ??
+      parsePositivePort(command?.environment?.OPENCLAW_GATEWAY_PORT) ??
+      resolveConfiguredGatewayPort(params.env);
+    const manageGatewayPort = shouldManageGatewayListenerPort(params.env);
+    if (manageGatewayPort && taskPort) {
+      const listenerPids = await resolveScheduledTaskGatewayListenerPids(taskPort);
       if (listenerPids.length > 0) {
         return true;
       }
-    }
-
-    if (process.platform !== "win32") {
-      return false;
     }
 
     const scriptPathNeedle = normalizeLowercaseStringOrEmpty(
@@ -783,38 +970,10 @@ async function shouldFallbackScheduledTaskLaunch(params: {
       return false;
     }
 
-    const processSnapshot = spawnSync(
-      "powershell",
-      [
-        "-NoProfile",
-        "-Command",
-        "Get-CimInstance Win32_Process | Select-Object ProcessId,CommandLine | ConvertTo-Json -Compress",
-      ],
-      {
-        encoding: "utf8",
-        timeout: 1_500,
-        windowsHide: true,
-      },
-    );
-    if (processSnapshot.error || processSnapshot.status !== 0) {
+    const entries = readWindowsProcessSnapshot();
+    if (!entries) {
       return false;
     }
-
-    type WindowsProcessSnapshotEntry = {
-      ProcessId?: number;
-      CommandLine?: string | null;
-    };
-
-    let parsedSnapshot: unknown;
-    try {
-      parsedSnapshot = JSON.parse(processSnapshot.stdout.trim() || "[]");
-    } catch {
-      return false;
-    }
-
-    const entries = (Array.isArray(parsedSnapshot) ? parsedSnapshot : [parsedSnapshot]).filter(
-      (entry): entry is WindowsProcessSnapshotEntry => typeof entry === "object" && entry !== null,
-    );
     const matchingTaskScriptProcess = entries.some((entry) =>
       normalizeLowercaseStringOrEmpty(entry.CommandLine ?? "")
         .replaceAll("/", "\\")
@@ -824,8 +983,14 @@ async function shouldFallbackScheduledTaskLaunch(params: {
       return true;
     }
 
-    if (!port) {
+    if (!taskPort) {
       return false;
+    }
+
+    if (!manageGatewayPort) {
+      return installedArguments?.length
+        ? findNodeHostProcessPid(entries, taskPort, installedArguments) != null
+        : false;
     }
 
     return entries.some((entry) => {
@@ -834,10 +999,10 @@ async function shouldFallbackScheduledTaskLaunch(params: {
         return false;
       }
       const argv = parseCmdScriptCommandLine(entry.CommandLine ?? "");
-      if (!isGatewayArgv(argv, { allowGatewayBinary: true })) {
-        return false;
-      }
-      return parsePortFromProgramArguments(argv) === port;
+      return (
+        isGatewayArgv(argv, { allowGatewayBinary: true }) &&
+        parsePortFromProgramArguments(argv) === taskPort
+      );
     });
   };
 
@@ -1033,8 +1198,13 @@ export async function stopScheduledTask({ stdout, env }: GatewayServiceControlAr
   if (res.code !== 0 && !isTaskNotRunning(res)) {
     throw new Error(`schtasks end failed: ${res.stderr || res.stdout}`.trim());
   }
-  const stopPort = await resolveScheduledTaskPort(effectiveEnv);
-  await terminateScheduledTaskGatewayListeners(effectiveEnv);
+  const manageGatewayPort = shouldManageGatewayListenerPort(effectiveEnv);
+  const stopPort = manageGatewayPort ? await resolveScheduledTaskPort(effectiveEnv) : null;
+  if (manageGatewayPort) {
+    await terminateScheduledTaskGatewayListeners(effectiveEnv);
+  } else {
+    await terminateScheduledTaskNodeHost(effectiveEnv);
+  }
   await terminateInstalledStartupRuntime(effectiveEnv);
   if (stopPort) {
     const released = await waitForGatewayPortRelease(stopPort);
@@ -1069,8 +1239,13 @@ export async function restartScheduledTask({
   }
   const taskName = resolveTaskName(effectiveEnv);
   await execSchtasks(["/End", "/TN", taskName]);
-  const restartPort = await resolveScheduledTaskPort(effectiveEnv);
-  await terminateScheduledTaskGatewayListeners(effectiveEnv);
+  const manageGatewayPort = shouldManageGatewayListenerPort(effectiveEnv);
+  const restartPort = manageGatewayPort ? await resolveScheduledTaskPort(effectiveEnv) : null;
+  if (manageGatewayPort) {
+    await terminateScheduledTaskGatewayListeners(effectiveEnv);
+  } else {
+    await terminateScheduledTaskNodeHost(effectiveEnv);
+  }
   await terminateInstalledStartupRuntime(effectiveEnv);
   if (restartPort) {
     const released = await waitForGatewayPortRelease(restartPort);


### PR DESCRIPTION
Summary
- Keep Windows node Scheduled Task stop/restart/status from treating the gateway listener port as node-owned runtime evidence.
- Add installed-command process matching for node Scheduled Task and Startup-folder fallback paths, so node lifecycle commands can still find the managed node host without touching unrelated gateway listeners or manual node runs.
- Cover registered task, Startup fallback, mixed fallback/task, and delayed schtasks launch cases.

Fixes #85289

Verification
- `git diff --check`
- `node_modules/.bin/oxfmt --check --threads=1 src/daemon/schtasks.ts src/daemon/schtasks.stop.test.ts src/daemon/schtasks.startup-fallback.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_TEST_PROJECTS_SERIAL=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 node scripts/run-vitest.mjs run src/daemon/schtasks.stop.test.ts --reporter=verbose`
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_TEST_PROJECTS_SERIAL=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 node scripts/run-vitest.mjs run src/daemon/schtasks.startup-fallback.test.ts --reporter=dot`
- `codex review --uncommitted`

Real behavior proof
Behavior addressed: Windows node Scheduled Task lifecycle no longer reclaims or reports runtime from the Gateway listener port, while still detecting and stopping the installed node host process by matching the installed command line.
Real environment tested: WSL Ubuntu-24.04 durable OpenClaw worktree at `/root/src/openclaw-85597`; native Windows host `redmond\giodl` with Ubuntu-24.04 WSL2; Windows Task Scheduler (`schtasks`) run/end/rerun/end against task name `OpenClaw Node`; WSL loopback listener reachable from Windows on `127.0.0.1:19897`.
Exact steps or command run after this patch: From the WSL PR checkout at SHA `9204441152acbc9ace41eff1ed369eed053f3935`, ran focused daemon tests and maintainer Testbox below; then started a WSL TCP listener with Windows `Start-Process wsl.exe -u root -- node /tmp/oc85597-listener.js 19897`, created `OpenClaw Node` with `schtasks /Create`, ran `schtasks /Run`, `schtasks /End`, reran, and ended it again while probing `Test-NetConnection 127.0.0.1 -Port 19897` after each lifecycle step.
Evidence after fix: Focused daemon tests passed; Blacksmith Testbox `pnpm check:changed` passed; native Windows/WSL supplemental proof showed `tcp_127.0.0.1_19897=True` after WSL listener start, after node task run, after node task end, after node task rerun, and after node task second end.
Observed result after fix: Node service paths skip gateway listener/port cleanup, ignore unrelated manual node hosts on the same gateway port, and terminate only the matching installed node host command when stop/restart needs process cleanup. In the native Windows/WSL supplemental proof, Windows Task Scheduler lifecycle activity did not disrupt the WSL loopback listener.
What was not tested: full native `openclaw node install/start/stop/restart` against the active Sebby/OpenClaw VM setup. The local native package path was blocked by unrelated environment issues: `pnpm build` currently fails on `protobufjs` descriptor resolution in the shared WSL dependency tree, and the packaged launcher/tsx respawn hits a Windows child-process `Access is denied` failure on this host.

Additional maintainer verification
- `node scripts/run-vitest.mjs src/daemon/schtasks.stop.test.ts src/daemon/schtasks.startup-fallback.test.ts src/daemon/schtasks.test.ts src/daemon/service.test.ts src/commands/node-daemon-install-helpers.test.ts` - passed 5 files / 78 tests
- `node_modules/.bin/oxlint src/daemon/schtasks.ts src/daemon/schtasks.stop.test.ts src/daemon/schtasks.startup-fallback.test.ts`
- `node_modules/.bin/oxfmt --check --threads=1 src/daemon/schtasks.ts src/daemon/schtasks.stop.test.ts src/daemon/schtasks.startup-fallback.test.ts`
- `git diff --check`
- Blacksmith Testbox through Crabbox: `tbx_01ks9f2fmhfar6ahwqvx071pak`, Actions run https://github.com/openclaw/openclaw/actions/runs/26322648137, command `corepack pnpm check:changed`, exit 0
- Native Windows + WSL2 supplemental proof: local Windows host `redmond\giodl`, Ubuntu-24.04 WSL2, task `OpenClaw Node`, port `19897`; `Test-NetConnection` stayed true after `schtasks /Run`, `schtasks /End`, rerun, and second end; cleanup removed the task and stopped the listener.
