### PR TITLE
fix(memory-core): preserve dreaming private workspace boundary[AI-assisted]

### DIFF
--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -18,7 +18,11 @@ import {
   resolveMemoryRemDreamingConfig,
 } from "openclaw/plugin-sdk/memory-core-host-status";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
-import { appendRegularFile, privateFileStore } from "openclaw/plugin-sdk/security-runtime";
+import { appendRegularFile } from "openclaw/plugin-sdk/security-runtime";
+import {
+  readDreamingPrivateJsonIfExists,
+  writeDreamingPrivateJson,
+} from "./dreaming-private-store.js";
 import { writeDailyDreamingPhaseBlock } from "./dreaming-markdown.js";
 import {
   generateAndAppendDreamNarrative,
@@ -477,7 +481,7 @@ function normalizeMemoryDay(value: unknown): string | undefined {
 async function readDailyIngestionState(workspaceDir: string): Promise<DailyIngestionState> {
   try {
     return normalizeDailyIngestionState(
-      await privateFileStore(workspaceDir).readJsonIfExists(DAILY_INGESTION_STATE_RELATIVE_PATH),
+      await readDreamingPrivateJsonIfExists(workspaceDir, DAILY_INGESTION_STATE_RELATIVE_PATH),
     );
   } catch (err) {
     if (err instanceof SyntaxError) {
@@ -491,9 +495,7 @@ async function writeDailyIngestionState(
   workspaceDir: string,
   state: DailyIngestionState,
 ): Promise<void> {
-  await privateFileStore(workspaceDir).writeJson(DAILY_INGESTION_STATE_RELATIVE_PATH, state, {
-    trailingNewline: true,
-  });
+  await writeDreamingPrivateJson(workspaceDir, DAILY_INGESTION_STATE_RELATIVE_PATH, state);
 }
 
 type SessionIngestionFileState = {
@@ -583,7 +585,7 @@ function normalizeSessionIngestionState(raw: unknown): SessionIngestionState {
 async function readSessionIngestionState(workspaceDir: string): Promise<SessionIngestionState> {
   try {
     return normalizeSessionIngestionState(
-      await privateFileStore(workspaceDir).readJsonIfExists(SESSION_INGESTION_STATE_RELATIVE_PATH),
+      await readDreamingPrivateJsonIfExists(workspaceDir, SESSION_INGESTION_STATE_RELATIVE_PATH),
     );
   } catch (err) {
     if (err instanceof SyntaxError) {
@@ -597,9 +599,7 @@ async function writeSessionIngestionState(
   workspaceDir: string,
   state: SessionIngestionState,
 ): Promise<void> {
-  await privateFileStore(workspaceDir).writeJson(SESSION_INGESTION_STATE_RELATIVE_PATH, state, {
-    trailingNewline: true,
-  });
+  await writeDreamingPrivateJson(workspaceDir, SESSION_INGESTION_STATE_RELATIVE_PATH, state);
 }
 
 function trimTrackedSessionScopes(

--- a/extensions/memory-core/src/dreaming-private-store.test.ts
+++ b/extensions/memory-core/src/dreaming-private-store.test.ts
@@ -1,0 +1,151 @@
+import { constants as fsConstants } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { __setFsSafeTestHooksForTest } from "@openclaw/fs-safe/test-hooks";
+import {
+  readDreamingPrivateJsonIfExists,
+  writeDreamingPrivateJson,
+} from "./dreaming-private-store.js";
+import { createMemoryCoreTestHarness } from "./test-helpers.js";
+
+const { createTempWorkspace } = createMemoryCoreTestHarness();
+
+afterEach(() => {
+  __setFsSafeTestHooksForTest(undefined);
+});
+
+async function chmodIfSupported(target: string, mode: number): Promise<void> {
+  if (process.platform === "win32") {
+    return;
+  }
+  await fs.chmod(target, mode);
+}
+
+async function posixMode(target: string): Promise<number | null> {
+  if (process.platform === "win32") {
+    return null;
+  }
+  return (await fs.stat(target)).mode & 0o777;
+}
+
+describe("dreaming private store", () => {
+  it("does not harden the workspace root or memory directory when writing private artifacts", async () => {
+    const workspaceDir = await createTempWorkspace("dreaming-private-store-");
+    const memoryDir = path.join(workspaceDir, "memory");
+    const dreamsDir = path.join(memoryDir, ".dreams");
+    await fs.mkdir(dreamsDir, { recursive: true });
+    await chmodIfSupported(workspaceDir, 0o770);
+    await chmodIfSupported(memoryDir, 0o770);
+    await chmodIfSupported(dreamsDir, 0o770);
+
+    await writeDreamingPrivateJson(workspaceDir, path.join("memory", ".dreams", "state.json"), {
+      ok: true,
+    });
+
+    expect(
+      await readDreamingPrivateJsonIfExists(
+        workspaceDir,
+        path.join("memory", ".dreams", "state.json"),
+      ),
+    ).toEqual({
+      ok: true,
+    });
+    expect(await posixMode(workspaceDir)).toBe(process.platform === "win32" ? null : 0o770);
+    expect(await posixMode(memoryDir)).toBe(process.platform === "win32" ? null : 0o770);
+    expect(await posixMode(dreamsDir)).toBe(process.platform === "win32" ? null : 0o700);
+    expect(await posixMode(path.join(dreamsDir, "state.json"))).toBe(
+      process.platform === "win32" ? null : 0o600,
+    );
+  });
+
+  it("rejects private artifact paths outside memory/.dreams", async () => {
+    const workspaceDir = await createTempWorkspace("dreaming-private-store-reject-");
+
+    await expect(
+      writeDreamingPrivateJson(workspaceDir, path.join("memory", "state.json"), {}),
+    ).rejects.toThrow("memory/.dreams");
+  });
+
+  it("keeps writes inside the workspace when memory is swapped to a symlink during setup", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const workspaceDir = await createTempWorkspace("dreaming-private-store-swap-");
+    const memoryDir = path.join(workspaceDir, "memory");
+    const externalDir = await createTempWorkspace("dreaming-private-store-external-");
+    await fs.mkdir(memoryDir, { recursive: true });
+    await chmodIfSupported(workspaceDir, 0o770);
+    await chmodIfSupported(memoryDir, 0o770);
+
+    let swapped = false;
+    __setFsSafeTestHooksForTest({
+      beforeRootFallbackMutation: async (operation, targetPath) => {
+        if (
+          operation !== "mkdir" ||
+          swapped ||
+          path.normalize(targetPath) !== path.join(memoryDir, ".dreams")
+        ) {
+          return;
+        }
+        swapped = true;
+        await fs.rm(memoryDir, { recursive: true, force: true });
+        await fs.symlink(externalDir, memoryDir);
+      },
+    });
+
+    await expect(
+      writeDreamingPrivateJson(workspaceDir, path.join("memory", ".dreams", "state.json"), {
+        ok: true,
+      }),
+    ).rejects.toThrow();
+    await expect(fs.access(path.join(externalDir, ".dreams", "state.json"))).rejects.toThrow();
+  });
+
+  it("does not chmod outside the workspace when .dreams is swapped to a symlink before chmod", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const workspaceDir = await createTempWorkspace("dreaming-private-store-chmod-swap-");
+    const memoryDir = path.join(workspaceDir, "memory");
+    const dreamsDir = path.join(memoryDir, ".dreams");
+    const externalDir = await createTempWorkspace("dreaming-private-store-chmod-external-");
+    await fs.mkdir(dreamsDir, { recursive: true });
+    await chmodIfSupported(workspaceDir, 0o770);
+    await chmodIfSupported(memoryDir, 0o770);
+    await chmodIfSupported(dreamsDir, 0o770);
+    await chmodIfSupported(externalDir, 0o770);
+
+    const realOpen = fs.open.bind(fs);
+    let swapped = false;
+    const openSpy = vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const [target, flags] = args;
+      if (!swapped && path.normalize(String(target)) === dreamsDir) {
+        swapped = true;
+        await fs.rm(dreamsDir, { recursive: true, force: true });
+        await fs.symlink(externalDir, dreamsDir);
+      }
+      return await realOpen(...args);
+    });
+
+    try {
+      await expect(
+        writeDreamingPrivateJson(workspaceDir, path.join("memory", ".dreams", "state.json"), {
+          ok: true,
+        }),
+      ).rejects.toThrow();
+      const openCall = openSpy.mock.calls.find(
+        ([target]) => path.normalize(String(target)) === dreamsDir,
+      );
+      expect(openCall).toBeDefined();
+      expect(typeof openCall?.[1]).toBe("number");
+      expect((Number(openCall?.[1]) & fsConstants.O_NOFOLLOW) === fsConstants.O_NOFOLLOW).toBe(
+        true,
+      );
+      expect(await posixMode(externalDir)).toBe(0o770);
+      await expect(fs.access(path.join(externalDir, "state.json"))).rejects.toThrow();
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+});

--- a/extensions/memory-core/src/dreaming-private-store.ts
+++ b/extensions/memory-core/src/dreaming-private-store.ts
@@ -1,0 +1,130 @@
+import { constants as fsConstants } from "node:fs";
+import type { FileHandle } from "node:fs/promises";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { isPathInside, root } from "openclaw/plugin-sdk/security-runtime";
+
+const DREAMING_ARTIFACTS_RELATIVE_DIR = path.join("memory", ".dreams");
+const DREAMING_PRIVATE_FILE_MODE = 0o600;
+const DREAMING_PRIVATE_DIR_MODE = 0o700;
+
+function sameFileIdentity(
+  left: { dev: number | bigint; ino: number | bigint },
+  right: { dev: number | bigint; ino: number | bigint },
+): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+async function resolveOpenedDirectoryRealPath(handle: FileHandle, ioPath: string): Promise<string> {
+  const handleStat = await handle.stat();
+  const fdCandidates =
+    process.platform === "linux"
+      ? [`/proc/self/fd/${handle.fd}`, `/dev/fd/${handle.fd}`]
+      : [`/dev/fd/${handle.fd}`];
+  for (const fdPath of fdCandidates) {
+    try {
+      const realPath = await fs.realpath(fdPath);
+      const realStat = await fs.stat(realPath);
+      if (sameFileIdentity(handleStat, realStat)) {
+        return realPath;
+      }
+    } catch {
+      // Try the next fd path, then fall back to the original path.
+    }
+  }
+  const realPath = await fs.realpath(ioPath);
+  const realStat = await fs.stat(realPath);
+  if (!sameFileIdentity(handleStat, realStat)) {
+    throw new Error(`Dreaming private artifacts path changed during chmod: ${ioPath}`);
+  }
+  return realPath;
+}
+
+async function chmodDreamingArtifactsDir(scopedRoot: Awaited<ReturnType<typeof root>>): Promise<void> {
+  if (process.platform === "win32") {
+    return;
+  }
+  const artifactsDir = await scopedRoot.resolve(DREAMING_ARTIFACTS_RELATIVE_DIR);
+  const noFollowFlag = "O_NOFOLLOW" in fsConstants ? fsConstants.O_NOFOLLOW : 0;
+  const directoryFlag = "O_DIRECTORY" in fsConstants ? fsConstants.O_DIRECTORY : 0;
+  const handle = await fs.open(artifactsDir, fsConstants.O_RDONLY | noFollowFlag | directoryFlag);
+  try {
+    const openedStat = await handle.stat();
+    if (!openedStat.isDirectory()) {
+      throw new Error(`Dreaming private artifacts path must be a directory: ${artifactsDir}`);
+    }
+    const realPath = await resolveOpenedDirectoryRealPath(handle, artifactsDir);
+    if (!isPathInside(scopedRoot.rootWithSep, realPath)) {
+      throw new Error(`Dreaming private artifacts path escapes workspace: ${artifactsDir}`);
+    }
+    await handle.chmod(DREAMING_PRIVATE_DIR_MODE);
+    const chmodStat = await handle.stat();
+    if ((chmodStat.mode & 0o777) !== DREAMING_PRIVATE_DIR_MODE) {
+      throw new Error(
+        `Dreaming private artifacts path has insecure permissions ${(chmodStat.mode & 0o777).toString(
+          8,
+        )}: ${artifactsDir}`,
+      );
+    }
+  } finally {
+    await handle.close().catch(() => undefined);
+  }
+}
+
+export async function ensureDreamingPrivateArtifactsDir(
+  scopedRoot: Awaited<ReturnType<typeof root>>,
+): Promise<void> {
+  await scopedRoot.mkdir(DREAMING_ARTIFACTS_RELATIVE_DIR);
+  await chmodDreamingArtifactsDir(scopedRoot);
+}
+
+export async function ensureDreamingPrivateArtifactsDirForWorkspace(
+  workspaceDir: string,
+): Promise<void> {
+  await ensureDreamingPrivateArtifactsDir(await root(workspaceDir, { hardlinks: "reject" }));
+}
+
+function resolveDreamingArtifactPath(workspaceRelativePath: string): string {
+  const relativePath = path.relative(DREAMING_ARTIFACTS_RELATIVE_DIR, workspaceRelativePath);
+  if (
+    !relativePath ||
+    path.isAbsolute(relativePath) ||
+    relativePath === ".." ||
+    relativePath.startsWith(`..${path.sep}`)
+  ) {
+    throw new Error(
+      `Dreaming private artifact path must be under memory/.dreams: ${workspaceRelativePath}`,
+    );
+  }
+  return path.join(DREAMING_ARTIFACTS_RELATIVE_DIR, relativePath);
+}
+
+export async function readDreamingPrivateJsonIfExists<T = unknown>(
+  workspaceDir: string,
+  workspaceRelativePath: string,
+): Promise<T | null> {
+  const scopedRoot = await root(workspaceDir, { hardlinks: "reject" });
+  const relativePath = resolveDreamingArtifactPath(workspaceRelativePath);
+  try {
+    return await scopedRoot.readJson<T>(relativePath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "not-found") {
+      return null;
+    }
+    throw err;
+  }
+}
+
+export async function writeDreamingPrivateJson(
+  workspaceDir: string,
+  workspaceRelativePath: string,
+  value: unknown,
+): Promise<void> {
+  const scopedRoot = await root(workspaceDir, { hardlinks: "reject" });
+  const relativePath = resolveDreamingArtifactPath(workspaceRelativePath);
+  await ensureDreamingPrivateArtifactsDir(scopedRoot);
+  await scopedRoot.writeJson(relativePath, value, {
+    mode: DREAMING_PRIVATE_FILE_MODE,
+    trailingNewline: true,
+  });
+}

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -4,7 +4,6 @@ import path from "node:path";
 import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 import { formatMemoryDreamingDay } from "openclaw/plugin-sdk/memory-core-host-status";
 import { appendMemoryHostEvent } from "openclaw/plugin-sdk/memory-host-events";
-import { privateFileStore } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   deriveConceptTags,
@@ -12,6 +11,11 @@ import {
   summarizeConceptTagScriptCoverage,
   type ConceptTagScriptCoverage,
 } from "./concept-vocabulary.js";
+import {
+  ensureDreamingPrivateArtifactsDirForWorkspace,
+  readDreamingPrivateJsonIfExists,
+  writeDreamingPrivateJson,
+} from "./dreaming-private-store.js";
 import { asRecord } from "./dreaming-shared.js";
 import { compactMemoryForBudget, DEFAULT_MEMORY_FILE_MAX_CHARS } from "./memory-budget.js";
 
@@ -660,8 +664,7 @@ async function ensureShortTermArtifactsDir(workspaceDir: string): Promise<void> 
     await existing;
     return;
   }
-  const ensuring = fs
-    .mkdir(artifactsDir, { recursive: true })
+  const ensuring = ensureDreamingPrivateArtifactsDirForWorkspace(workspaceDir)
     .then(() => undefined)
     .catch((err) => {
       ensuredShortTermDirs.delete(artifactsDir);
@@ -783,7 +786,7 @@ async function withShortTermLock<T>(workspaceDir: string, task: () => Promise<T>
 async function readStore(workspaceDir: string, nowIso: string): Promise<ShortTermRecallStore> {
   try {
     return normalizeStore(
-      await privateFileStore(workspaceDir).readJsonIfExists(SHORT_TERM_STORE_RELATIVE_PATH),
+      await readDreamingPrivateJsonIfExists(workspaceDir, SHORT_TERM_STORE_RELATIVE_PATH),
       nowIso,
     );
   } catch (err) {
@@ -855,7 +858,7 @@ async function readPhaseSignalStore(
 ): Promise<ShortTermPhaseSignalStore> {
   try {
     return normalizePhaseSignalStore(
-      await privateFileStore(workspaceDir).readJsonIfExists(SHORT_TERM_PHASE_SIGNAL_RELATIVE_PATH),
+      await readDreamingPrivateJsonIfExists(workspaceDir, SHORT_TERM_PHASE_SIGNAL_RELATIVE_PATH),
       nowIso,
     );
   } catch {
@@ -868,16 +871,12 @@ async function writePhaseSignalStore(
   store: ShortTermPhaseSignalStore,
 ): Promise<void> {
   await ensureShortTermArtifactsDir(workspaceDir);
-  await privateFileStore(workspaceDir).writeJson(SHORT_TERM_PHASE_SIGNAL_RELATIVE_PATH, store, {
-    trailingNewline: true,
-  });
+  await writeDreamingPrivateJson(workspaceDir, SHORT_TERM_PHASE_SIGNAL_RELATIVE_PATH, store);
 }
 
 async function writeStore(workspaceDir: string, store: ShortTermRecallStore): Promise<void> {
   await ensureShortTermArtifactsDir(workspaceDir);
-  await privateFileStore(workspaceDir).writeJson(SHORT_TERM_STORE_RELATIVE_PATH, store, {
-    trailingNewline: true,
-  });
+  await writeDreamingPrivateJson(workspaceDir, SHORT_TERM_STORE_RELATIVE_PATH, store);
 }
 
 export function isShortTermMemoryPath(filePath: string): boolean {


### PR DESCRIPTION
## Summary

- Replace workspace-rooted dreaming private JSON writes with a memory-core helper that uses `fs-safe`'s workspace-root `root()` API for read/write containment.
- Keep dreaming artifacts under `memory/.dreams` private without chmodding the user-facing workspace root or `memory/` parent directory.
- Address the ClawSweeper P1 chmod race by opening `memory/.dreams` with `O_DIRECTORY | O_NOFOLLOW`, validating the opened directory remains inside the workspace, and applying permissions through `FileHandle.chmod()` instead of path-based `fs.chmod(path)`.
- Add regression coverage for the ACL blast radius, write-path symlink escape, and chmod-time symlink swap.

Supersedes and replaces #85435. Refs #56263; this targets the memory-core dreaming private-store manifestation described in https://github.com/openclaw/openclaw/issues/56263#issuecomment-4520113754 without claiming to resolve the broader permission-policy issue.

## Why

The previous approach narrowed the private store root to `memory/.dreams`, which fixed the ACL blast radius but lost the original workspace realpath containment boundary. This version avoids both bad choices:

- it no longer calls `privateFileStore(workspaceDir)`, so fs-safe does not chmod the workspace root and `memory/` parent to `0700`;
- it also does not call `privateFileStore(workspace/memory/.dreams)`, so the write path keeps the outer workspace boundary through `root(workspaceDir)`;
- it no longer chmods a resolved path string. The private artifacts directory is pinned through an opened directory handle before chmod, so a symlink swap cannot redirect chmod outside the workspace.

## Real Behavior Proof

- **Behavior or issue addressed:** Memory-core dreaming private JSON writes should preserve the shared workspace root and `memory/` permissions while keeping private JSON artifacts under the original workspace boundary.
- **Real environment tested:** Local Linux OpenClaw checkout, live `/home/shared/workspace` shared workspace, and targeted memory-core regression run inside Docker using `node:24-bookworm`.
- **Exact steps or command run after this patch:** Ran the patched helper against the live shared workspace with `node_modules/.bin/tsx --tsconfig tsconfig.json`, writing `memory/.dreams/pr85598-live-proof.json`, checking `stat` modes and `getfacl` before/after/cleanup. Also ran this supplemental Docker command:

```text
docker run --rm -v "$PWD":/repo -w /repo node:24-bookworm bash -lc 'node --version && node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-memory.config.ts extensions/memory-core/src/dreaming-private-store.test.ts'
```

- **Evidence after fix:** Copied live output from the real shared workspace run:

```text
[before]
770 lagoon3:lagoon3 /path/to/shared/workspace
770 lagoon3:lagoon3 /path/to/shared/workspace/memory
770 lagoon3:lagoon3 /path/to/shared/workspace/memory/.dreams
missing /path/to/shared/workspace/memory/.dreams/pr85598-live-proof.json
user:www-data:rwx
mask::rwx
user:www-data:rwx
mask::rwx

[after]
770 lagoon3:lagoon3 /path/to/shared/workspace
770 lagoon3:lagoon3 /path/to/shared/workspace/memory
700 lagoon3:lagoon3 /path/to/shared/workspace/memory/.dreams
600 lagoon3:lagoon3 /path/to/shared/workspace/memory/.dreams/pr85598-live-proof.json
user:www-data:rwx
mask::rwx
user:www-data:rwx
mask::rwx

[cleanup]
770 lagoon3:lagoon3 /path/to/shared/workspace
770 lagoon3:lagoon3 /path/to/shared/workspace/memory
700 lagoon3:lagoon3 /path/to/shared/workspace/memory/.dreams
missing /path/to/shared/workspace/memory/.dreams/pr85598-live-proof.json
user:www-data:rwx
mask::rwx
user:www-data:rwx
mask::rwx
```

Supplemental Docker regression output:

```text
v24.15.0

RUN  v4.1.7 /repo

extensions/memory-core/src/dreaming-private-store.test.ts (4 tests) 64ms

Test Files  1 passed (1)
Tests       4 passed (4)
Duration    1.10s
```

- **Observed result after fix:** The live shared-workspace run preserved the workspace root and `memory/` directory at `0770` with `www-data` ACLs still present, made only `memory/.dreams` private at `0700`, wrote the proof JSON at `0600`, and removed the proof JSON during cleanup. The regressions additionally verify path rejection outside `memory/.dreams`, write-path symlink escape rejection, and chmod-time symlink swap rejection without chmodding or writing outside the workspace.
- **What was not tested:** Full `pnpm build && pnpm check && pnpm test` was not run because this PR is intentionally narrow and the requested proof was Docker-targeted validation plus live behavior proof. Lint and broad check lanes were intentionally skipped locally.

## Additional Local Validation

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-memory.config.ts extensions/memory-core/src/dreaming-private-store.test.ts

Test Files  1 passed (1)
Tests       4 passed (4)
```

```text
git diff --check
# no whitespace errors
```

## Not Run

- Full `pnpm build && pnpm check && pnpm test` was not run.
- Lint/check lanes with high memory cost were intentionally skipped locally.
- `codex review --base origin/main` was not run locally for this replacement pass.

## AI Assistance

AI-assisted change. I reviewed the previous and current ClawSweeper security-boundary findings, reworked the patch to keep workspace-root containment in the actual read/write path, pinned chmod to an opened non-followed directory handle, and ran the Docker-targeted regression plus redacted live shared-workspace proof above.
