### PR TITLE
Smooth chat focus mode layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Docs: https://docs.openclaw.ai
 - QA-Lab/Codex: bundle auth/plugin fixture imports for flow scenarios and let terminal async media tools end Codex app-server turns without timing out. (#80397, refs #80323) Thanks @100yenadmin.
 - Gateway/agents: preserve fresh session overrides and metadata when stale cached agent-session entries race with store updates, so subagent model/provider overrides and routing policy survive concurrent writes. (#19328) Thanks @CodeReclaimers.
 - Control UI/chat: keep chat session search inline with the session selector so the header no longer shows a duplicate standalone search row.
+- Control UI/chat: collapse focused-mode header chrome and suppress hidden-header scroll updates so focus mode no longer jumps while scrolling. Thanks @amknight.
 - Codex app-server: restart the native app-server and retry once when server-side compaction times out, so preflight compaction stalls recover instead of failing every dispatch. (#85500)
 - Restore Control UI gateway token pairing [AI]. (#85459) Thanks @pgondhi987.
 - OpenAI video: honor configured provider request private-network opt-in for local/custom video endpoints so explicitly trusted mock and self-hosted providers are not blocked. Thanks @shakkernerd.

--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -146,6 +146,44 @@ function buildSearchSessionListCases(
   return searchTerms.flatMap((search) => buildSessionListCases(sessions, { search }));
 }
 
+function chatHistoryMessage(role: "assistant" | "user", text: string, timestamp: number) {
+  return {
+    content: [{ text, type: "text" }],
+    role,
+    timestamp,
+  };
+}
+
+function buildScrollableChatHistory(baseTime: number): unknown[] {
+  const messages: unknown[] = [
+    chatHistoryMessage(
+      "assistant",
+      `Mock Control UI is running with ${TOTAL_MOCK_SESSIONS} sessions. Open the chat picker, search for "telegram" or "claude", then use Load more repeatedly.`,
+      baseTime,
+    ),
+  ];
+
+  for (let index = 1; index <= 36; index += 1) {
+    const timestamp = baseTime + index * 60_000;
+    messages.push(
+      chatHistoryMessage(
+        "user",
+        `Mock scroll request ${index}: add enough transcript content to exercise the chat scroll container in focused mode.`,
+        timestamp,
+      ),
+      chatHistoryMessage(
+        "assistant",
+        `Mock scroll response ${index}: this deterministic history keeps the mock chat long enough to scroll while testing focus mode, header collapse, and composer anchoring. `.repeat(
+          2,
+        ),
+        timestamp + 30_000,
+      ),
+    );
+  }
+
+  return messages;
+}
+
 function searchPrefixes(term: string): string[] {
   return Array.from({ length: term.length }, (_value, index) => term.slice(0, index + 1));
 }
@@ -179,18 +217,7 @@ function createChatPickerScenario(): ControlUiMockGatewayScenario {
     assistantAgentId: "openclaw-mock",
     assistantName: "OpenClaw mock",
     defaultAgentId: "openclaw-mock",
-    historyMessages: [
-      {
-        content: [
-          {
-            text: `Mock Control UI is running with ${TOTAL_MOCK_SESSIONS} sessions. Open the chat picker, search for "telegram" or "claude", then use Load more repeatedly.`,
-            type: "text",
-          },
-        ],
-        role: "assistant",
-        timestamp: baseTime,
-      },
-    ],
+    historyMessages: buildScrollableChatHistory(baseTime),
     methodResponses: {
       "sessions.list": {
         cases: [

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -19,7 +19,9 @@
     "nav content";
   gap: 0;
   animation: dashboard-enter 0.3s var(--ease-out);
-  transition: grid-template-columns var(--shell-focus-duration) var(--shell-focus-ease);
+  transition:
+    grid-template-columns var(--shell-focus-duration) var(--shell-focus-ease),
+    grid-template-rows var(--shell-focus-duration) var(--shell-focus-ease);
   overflow: hidden;
 }
 
@@ -47,6 +49,7 @@
 
 .shell--chat-focus {
   grid-template-columns: 0px minmax(0, 1fr);
+  grid-template-rows: 0 minmax(0, 1fr);
 }
 
 .shell--onboarding {
@@ -72,6 +75,17 @@
 
 .shell--chat-focus .content > * + * {
   margin-top: 0;
+}
+
+.shell--chat-focus .topbar {
+  min-height: 0;
+  height: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+  border-bottom-width: 0;
 }
 
 /* ===========================================
@@ -1383,6 +1397,10 @@
 
 .shell--chat-focus .content--chat .content-header {
   min-height: 0;
+  max-height: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  overflow: hidden;
 }
 
 .content--chat .page-meta {

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -32,6 +32,14 @@
     row-gap: 0;
   }
 
+  .shell--chat-focus .content--chat .content-header {
+    min-height: 0;
+    max-height: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    overflow: hidden;
+  }
+
   .chat-controls__session-row {
     grid-template-columns:
       minmax(96px, 5fr) minmax(112px, 7fr) minmax(116px, 5fr)
@@ -112,7 +120,7 @@
   }
 
   .shell--chat-focus {
-    grid-template-rows: var(--shell-topbar-height) minmax(0, 1fr);
+    grid-template-rows: 0 minmax(0, 1fr);
   }
 
   .shell-nav,

--- a/ui/src/styles/layout.mobile.test.ts
+++ b/ui/src/styles/layout.mobile.test.ts
@@ -55,6 +55,38 @@ describe("chat header responsive mobile styles", () => {
     expect(css).toContain("width: 44px;");
     expect(css).toContain("min-width: 44px;");
   });
+
+  it("keeps focused chat from reserving hidden page-header height", () => {
+    const layoutCss = readLayoutCss();
+    const mobileCss = readMobileCss();
+    const focusedShell = selectorBlocks(layoutCss, ".shell--chat-focus").join("\n");
+    const focusedMobileShell = selectorBlocks(mobileCss, ".shell--chat-focus").join("\n");
+    const focusedTopbar = selectorBlocks(layoutCss, ".shell--chat-focus .topbar").join("\n");
+    const focusedHeaderSelector = ".shell--chat-focus .content--chat .content-header";
+    const expectedDeclarations = [
+      "min-height: 0;",
+      "max-height: 0;",
+      "padding-top: 0;",
+      "padding-bottom: 0;",
+      "overflow: hidden;",
+    ];
+
+    expect(focusedShell).toContain("grid-template-rows: 0 minmax(0, 1fr);");
+    expect(focusedMobileShell).toContain("grid-template-rows: 0 minmax(0, 1fr);");
+    expect(focusedTopbar).toContain("min-height: 0;");
+    expect(focusedTopbar).toContain("height: 0;");
+    expect(focusedTopbar).toContain("padding-top: 0;");
+    expect(focusedTopbar).toContain("padding-bottom: 0;");
+    expect(focusedTopbar).toContain("overflow: hidden;");
+
+    for (const css of [layoutCss, mobileCss]) {
+      const block = selectorBlocks(css, focusedHeaderSelector).join("\n");
+      expect(block).toBeTruthy();
+      for (const declaration of expectedDeclarations) {
+        expect(block).toContain(declaration);
+      }
+    }
+  });
 });
 
 describe("sidebar menu trigger styles", () => {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -910,6 +910,7 @@ export function renderApp(state: AppViewState) {
   const chatDisabledReason = state.connected ? null : t("chat.disconnected");
   const isChat = state.tab === "chat";
   const chatFocus = isChat && (state.settings.chatFocusMode || state.onboarding);
+  const chatHeaderHidden = isChat && (chatFocus || state.chatHeaderControlsHidden);
   const navDrawerOpen = state.navDrawerOpen && !chatFocus && !state.onboarding;
   const navCollapsed = state.settings.navCollapsed && !navDrawerOpen;
   const dashboardHeaderContext = resolveDashboardHeaderContext(state);
@@ -1678,7 +1679,7 @@ export function renderApp(state: AppViewState) {
           state.navDrawerOpen = false;
         }}
       ></button>
-      <header class="topbar">
+      <header class="topbar" ?inert=${chatFocus} aria-hidden=${chatFocus ? "true" : nothing}>
         <div class="topnav-shell">
           <button
             type="button"
@@ -1871,11 +1872,11 @@ export function renderApp(state: AppViewState) {
         ${state.tab === "config"
           ? nothing
           : html`<section
-              class=${isChat && state.chatHeaderControlsHidden
+              class=${chatHeaderHidden
                 ? "content-header content-header--chat-hidden"
                 : "content-header"}
-              ?inert=${isChat && state.chatHeaderControlsHidden}
-              aria-hidden=${isChat && state.chatHeaderControlsHidden ? "true" : nothing}
+              ?inert=${chatHeaderHidden}
+              aria-hidden=${chatHeaderHidden ? "true" : nothing}
             >
               <div>
                 ${isChat

--- a/ui/src/ui/app-scroll.test.ts
+++ b/ui/src/ui/app-scroll.test.ts
@@ -36,6 +36,11 @@ function createScrollHost(
     overflowY,
   } as unknown as CSSStyleDeclaration);
 
+  const settings: { chatAutoScroll?: ChatAutoScrollMode; chatFocusMode?: boolean } = {};
+  if (chatAutoScroll) {
+    settings.chatAutoScroll = chatAutoScroll;
+  }
+
   const host = {
     updateComplete: Promise.resolve(),
     querySelector: vi.fn().mockReturnValue(container),
@@ -49,7 +54,7 @@ function createScrollHost(
     chatNewMessagesBelow: false,
     chatIsProgrammaticScroll: false,
     chatProgrammaticScrollTarget: 0,
-    settings: chatAutoScroll ? { chatAutoScroll } : {},
+    settings,
     logsScrollFrame: null as number | null,
     logsAtBottom: true,
     topbarObserver: null as ResizeObserver | null,

--- a/ui/src/ui/app-scroll.test.ts
+++ b/ui/src/ui/app-scroll.test.ts
@@ -49,7 +49,7 @@ function createScrollHost(
     chatNewMessagesBelow: false,
     chatIsProgrammaticScroll: false,
     chatProgrammaticScrollTarget: 0,
-    settings: chatAutoScroll ? { chatAutoScroll } : undefined,
+    settings: chatAutoScroll ? { chatAutoScroll } : {},
     logsScrollFrame: null as number | null,
     logsAtBottom: true,
     topbarObserver: null as ResizeObserver | null,
@@ -140,6 +140,25 @@ describe("handleChatScroll", () => {
     handleChatScroll(host, event);
 
     expect(host.chatHeaderControlsHidden).toBe(false);
+  });
+
+  it("does not toggle header controls while focus mode handles hidden chrome", () => {
+    const { host } = createScrollHost({});
+    host.settings = { ...host.settings, chatFocusMode: true };
+    host.chatLastScrollTop = 100;
+    host.chatHeaderControlsHidden = false;
+
+    handleChatScroll(host, createScrollEvent(3000, 260, 500));
+
+    expect(host.chatHeaderControlsHidden).toBe(false);
+    expect(host.chatUserNearBottom).toBe(false);
+
+    host.chatHeaderControlsHidden = true;
+    host.chatLastScrollTop = 800;
+
+    handleChatScroll(host, createScrollEvent(3000, 700, 500));
+
+    expect(host.chatHeaderControlsHidden).toBe(true);
   });
 });
 

--- a/ui/src/ui/app-scroll.ts
+++ b/ui/src/ui/app-scroll.ts
@@ -20,6 +20,7 @@ type ScrollHost = {
   chatProgrammaticScrollTarget: number;
   settings?: {
     chatAutoScroll?: ChatAutoScrollMode;
+    chatFocusMode?: boolean;
   };
   logsScrollFrame: number | null;
   logsAtBottom: boolean;
@@ -187,12 +188,14 @@ export function handleChatScroll(host: ScrollHost, event: Event) {
   host.chatUserNearBottom = distanceFromBottom < NEAR_BOTTOM_THRESHOLD;
   const hasUsefulScroll = container.scrollHeight - container.clientHeight > NEAR_BOTTOM_THRESHOLD;
 
-  if (!hasUsefulScroll || scrollTop <= HEADER_SHOW_TOP_THRESHOLD || host.chatUserNearBottom) {
-    host.chatHeaderControlsHidden = false;
-  } else if (delta > HEADER_HIDE_SCROLL_DELTA) {
-    host.chatHeaderControlsHidden = true;
-  } else if (delta < -HEADER_HIDE_SCROLL_DELTA) {
-    host.chatHeaderControlsHidden = false;
+  if (!host.settings?.chatFocusMode) {
+    if (!hasUsefulScroll || scrollTop <= HEADER_SHOW_TOP_THRESHOLD || host.chatUserNearBottom) {
+      host.chatHeaderControlsHidden = false;
+    } else if (delta > HEADER_HIDE_SCROLL_DELTA) {
+      host.chatHeaderControlsHidden = true;
+    } else if (delta < -HEADER_HIDE_SCROLL_DELTA) {
+      host.chatHeaderControlsHidden = false;
+    }
   }
 
   // Clear the "new messages below" indicator when user scrolls back to bottom.

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -466,7 +466,9 @@ describe("control UI routing", () => {
 
     expect([...section.classList]).toContain("nav-section--collapsed");
     expect(
-      section.querySelector<HTMLButtonElement>(".nav-section__label")?.getAttribute("aria-expanded"),
+      section
+        .querySelector<HTMLButtonElement>(".nav-section__label")
+        ?.getAttribute("aria-expanded"),
     ).toBe("false");
   });
 
@@ -609,19 +611,34 @@ describe("control UI routing", () => {
     expect(window.location.search).toBe("?session=agent%3Amain%3Asubagent%3Atask-123");
 
     const shell = expectElement(app, ".shell", HTMLElement);
+    const topbar = expectElement(app, ".topbar", HTMLElement);
+    const contentHeader = expectElement(app, ".content-header", HTMLElement);
     expect([...shell.classList]).toEqual(["shell", "shell--chat"]);
+    expect(topbar.hasAttribute("inert")).toBe(false);
+    expect(topbar.hasAttribute("aria-hidden")).toBe(false);
+    expect(contentHeader.hasAttribute("inert")).toBe(false);
+    expect(contentHeader.hasAttribute("aria-hidden")).toBe(false);
 
     const toggle = expectElement(app, 'button[title^="Toggle focus mode"]', HTMLButtonElement);
     toggle.click();
 
     await app.updateComplete;
     expect([...shell.classList]).toEqual(["shell", "shell--chat", "shell--chat-focus"]);
+    expect(topbar.hasAttribute("inert")).toBe(true);
+    expect(topbar.getAttribute("aria-hidden")).toBe("true");
+    expect(contentHeader.hasAttribute("inert")).toBe(true);
+    expect(contentHeader.getAttribute("aria-hidden")).toBe("true");
 
     app.setTab("channels");
 
     await app.updateComplete;
     expect(app.tab).toBe("channels");
     expect([...shell.classList]).toEqual(["shell"]);
+    expect(topbar.hasAttribute("inert")).toBe(false);
+    expect(topbar.hasAttribute("aria-hidden")).toBe(false);
+    const channelsContentHeader = expectElement(app, ".content-header", HTMLElement);
+    expect(channelsContentHeader.hasAttribute("inert")).toBe(false);
+    expect(channelsContentHeader.hasAttribute("aria-hidden")).toBe(false);
 
     const chatLink = expectElement(app, 'a.nav-item[href="/chat"]', HTMLAnchorElement);
     chatLink.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 }));
@@ -629,6 +646,11 @@ describe("control UI routing", () => {
     await app.updateComplete;
     expect(app.tab).toBe("chat");
     expect([...shell.classList]).toEqual(["shell", "shell--chat", "shell--chat-focus"]);
+    expect(topbar.hasAttribute("inert")).toBe(true);
+    expect(topbar.getAttribute("aria-hidden")).toBe("true");
+    const focusedContentHeader = expectElement(app, ".content-header", HTMLElement);
+    expect(focusedContentHeader.hasAttribute("inert")).toBe(true);
+    expect(focusedContentHeader.getAttribute("aria-hidden")).toBe("true");
   });
 
   it("auto-scrolls chat history to the latest message", async () => {


### PR DESCRIPTION
## Summary

- Collapse chat focus-mode topbar and page-header chrome so hidden rows no longer reserve vertical space.
- Keep focused-mode hidden chrome `inert`/`aria-hidden`, including the topbar and chat content header.
- Stop scroll events from toggling hidden header state while focus mode is active, preventing scroll-driven chrome rerenders.
- Seed the Control UI mock dev chat with a scrollable deterministic transcript for local focused-mode testing.
- Add focused style, render-state, scroll-state tests, and a changelog entry.

## Verification

- `node scripts/run-vitest.mjs run ui/src/ui/app-scroll.test.ts ui/src/ui/navigation.browser.test.ts ui/src/styles/layout.mobile.test.ts`
- `node --import tsx --input-type=module` Playwright probe against mocked Control UI with a long transcript and 24 focused-mode scroll steps
- `node --import tsx --input-type=module` Playwright probe against `http://127.0.0.1:4188/chat?session=main` confirming 73 chat groups and a scrollable `.chat-thread`
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD` on the focused-mode layout commit; the later one-file mock-data autoreview subprocess was stopped after it remained silent for more than 10 minutes, with diff-check plus browser proof run instead

## Real behavior proof

Behavior addressed: Chat focus mode no longer leaves topbar/page-header padding, keeps the exit button near the top edge, avoids hidden-header updates while scrolling, and the mock UI now contains enough messages to test transcript scrolling.

Real environment tested: Local mocked Control UI Vite server with Playwright Chromium against `http://127.0.0.1:<mock>/chat` and `http://127.0.0.1:4188/chat?session=main`.

Exact steps or command run after this patch: Ran the targeted Vitest command above after rebasing onto latest `origin/main`; ran a Playwright mocked-Control-UI scroll probe that entered focus mode, scrolled `.chat-thread` 24 times through a long transcript, and captured `.artifacts/control-ui-e2e/chat-focus-layout/after-focus-scroll-proof.png`; restarted `pnpm dev:ui:mock -- --port 4188` and ran a Playwright probe for the in-app browser URL.

Evidence after fix: The focused scroll probe reported `mutationCount: 0` for hidden topbar/content-header chrome, monotonic scroll samples from `180` through `4320`, `.topbar.height === 0`, `.content-header.height === 0`, and both hidden chrome regions had `inert` plus `aria-hidden="true"`. The mock-dev probe reported `groups: 73`, `scrollHeight: 8792`, `clientHeight: 643`, and `canScroll: true`.

Observed result after fix: Focused chat scrolls without header chrome churn; hidden rows remain collapsed and inaccessible to keyboard focus while the floating exit button stays at the top-right. The mock UI at port `4188` now has enough transcript content to scroll.

What was not tested: Full broad UI E2E lane and a live Gateway session were not run; validation used targeted tests plus deterministic mocked Control UI browser proof.