### PR TITLE
fix(agents): preserve claude-cli last-call usage

### DIFF
--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -385,6 +385,61 @@ describe("parseCliJsonl", () => {
     });
   });
 
+  it("does not replace Claude message_start cache usage with message_delta output usage", () => {
+    const result = parseCliJsonl(
+      [
+        JSON.stringify({ type: "init", session_id: "session-stream-usage" }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "message_start",
+            message: {
+              usage: {
+                input_tokens: 150,
+                output_tokens: 1,
+                cache_read_input_tokens: 27_142,
+              },
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "message_delta",
+            usage: {
+              output_tokens: 6,
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "result",
+          session_id: "session-stream-usage",
+          result: "Claude says hello",
+          usage: {
+            input_tokens: 300,
+            output_tokens: 10,
+            cache_read_input_tokens: 45_641,
+          },
+        }),
+      ].join("\n"),
+      {
+        command: "claude",
+        output: "jsonl",
+        sessionIdFields: ["session_id"],
+      },
+      "claude-cli",
+    );
+
+    expect(result?.usage?.cacheRead).toBe(45_641);
+    expect(result?.lastCallUsage).toEqual({
+      input: 150,
+      output: 1,
+      cacheRead: 27_142,
+      cacheWrite: undefined,
+      total: undefined,
+    });
+  });
+
   it("preserves Claude session metadata even when the final result text is empty", () => {
     const result = parseCliJsonl(
       [

--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -322,6 +322,69 @@ describe("parseCliJsonl", () => {
     });
   });
 
+  it("uses latest Claude assistant usage as lastCallUsage when result usage is aggregate", () => {
+    const result = parseCliJsonl(
+      [
+        JSON.stringify({ type: "init", session_id: "session-cache-sum" }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            usage: {
+              input_tokens: 100,
+              output_tokens: 4,
+              cache_read_input_tokens: 18_499,
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            usage: {
+              input_tokens: 120,
+              output_tokens: 6,
+              cache_read_input_tokens: 27_142,
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "result",
+          session_id: "session-cache-sum",
+          result: "Claude says hello",
+          usage: {
+            input_tokens: 220,
+            output_tokens: 10,
+            cache_read_input_tokens: 45_641,
+          },
+        }),
+      ].join("\n"),
+      {
+        command: "claude",
+        output: "jsonl",
+        sessionIdFields: ["session_id"],
+      },
+      "claude-cli",
+    );
+
+    expect(result).toEqual({
+      text: "Claude says hello",
+      sessionId: "session-cache-sum",
+      usage: {
+        input: 220,
+        output: 10,
+        cacheRead: 45_641,
+        cacheWrite: undefined,
+        total: undefined,
+      },
+      lastCallUsage: {
+        input: 120,
+        output: 6,
+        cacheRead: 27_142,
+        cacheWrite: undefined,
+        total: undefined,
+      },
+    });
+  });
+
   it("preserves Claude session metadata even when the final result text is empty", () => {
     const result = parseCliJsonl(
       [
@@ -444,7 +507,12 @@ describe("createCliJsonlStreamingParser", () => {
     parser.finish();
 
     expect(deltas).toEqual([
-      { text: "hello", delta: "hello", sessionId: "session-stream", usage: undefined },
+      {
+        text: "hello",
+        delta: "hello",
+        sessionId: "session-stream",
+        usage: undefined,
+      },
     ]);
   });
 });

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -173,9 +173,6 @@ function readClaudeAssistantUsage(parsed: Record<string, unknown>): CliUsage | u
     ) {
       return toCliUsage(event.message.usage);
     }
-    if (event.type === "message_delta" && isRecord(event.usage)) {
-      return toCliUsage(event.usage);
-    }
   }
   return undefined;
 }

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -16,6 +16,7 @@ export type CliOutput = {
   rawText?: string;
   sessionId?: string;
   usage?: CliUsage;
+  lastCallUsage?: CliUsage;
   finalPromptText?: string;
 };
 
@@ -155,6 +156,26 @@ function readCliUsage(parsed: Record<string, unknown>): CliUsage | undefined {
   }
   if (isRecord(parsed.stats)) {
     return toCliUsage(parsed.stats);
+  }
+  return undefined;
+}
+
+function readClaudeAssistantUsage(parsed: Record<string, unknown>): CliUsage | undefined {
+  if (parsed.type === "assistant" && isRecord(parsed.message) && isRecord(parsed.message.usage)) {
+    return toCliUsage(parsed.message.usage);
+  }
+  if (parsed.type === "stream_event" && isRecord(parsed.event)) {
+    const event = parsed.event;
+    if (
+      event.type === "message_start" &&
+      isRecord(event.message) &&
+      isRecord(event.message.usage)
+    ) {
+      return toCliUsage(event.message.usage);
+    }
+    if (event.type === "message_delta" && isRecord(event.usage)) {
+      return toCliUsage(event.usage);
+    }
   }
   return undefined;
 }
@@ -326,6 +347,7 @@ function parseClaudeCliJsonlResult(params: {
   parsed: Record<string, unknown>;
   sessionId?: string;
   usage?: CliUsage;
+  lastCallUsage?: CliUsage;
 }): CliOutput | null {
   if (!usesClaudeStreamJsonDialect(params)) {
     return null;
@@ -337,11 +359,21 @@ function parseClaudeCliJsonlResult(params: {
   ) {
     const resultText = unwrapNestedCliResultText(params.parsed.result).trim();
     if (resultText) {
-      return { text: resultText, sessionId: params.sessionId, usage: params.usage };
+      return {
+        text: resultText,
+        sessionId: params.sessionId,
+        usage: params.usage,
+        ...(params.lastCallUsage ? { lastCallUsage: params.lastCallUsage } : {}),
+      };
     }
     // Claude may finish with an empty result after tool-only work. Keep the
     // resolved session handle and usage instead of dropping them.
-    return { text: "", sessionId: params.sessionId, usage: params.usage };
+    return {
+      text: "",
+      sessionId: params.sessionId,
+      usage: params.usage,
+      ...(params.lastCallUsage ? { lastCallUsage: params.lastCallUsage } : {}),
+    };
   }
   return null;
 }
@@ -388,6 +420,7 @@ export function createCliJsonlStreamingParser(params: {
   let assistantText = "";
   let sessionId: string | undefined;
   let usage: CliUsage | undefined;
+  let lastCallUsage: CliUsage | undefined;
   let output: CliOutput | null = null;
   const texts: string[] = [];
 
@@ -395,6 +428,9 @@ export function createCliJsonlStreamingParser(params: {
     sessionId = pickCliSessionId(parsed, params.backend) ?? sessionId;
     if (!sessionId && typeof parsed.thread_id === "string") {
       sessionId = parsed.thread_id.trim();
+    }
+    if (usesClaudeStreamJsonDialect(params)) {
+      lastCallUsage = readClaudeAssistantUsage(parsed) ?? lastCallUsage;
     }
     usage = readCliUsage(parsed) ?? usage;
 
@@ -404,6 +440,7 @@ export function createCliJsonlStreamingParser(params: {
       parsed,
       sessionId,
       usage,
+      lastCallUsage,
     });
     if (result) {
       output = result;
@@ -496,6 +533,7 @@ export function parseCliJsonl(
   }
   let sessionId: string | undefined;
   let usage: CliUsage | undefined;
+  let lastCallUsage: CliUsage | undefined;
   const texts: string[] = [];
   for (const line of lines) {
     for (const parsed of parseJsonRecordCandidates(line)) {
@@ -505,6 +543,9 @@ export function parseCliJsonl(
       if (!sessionId && typeof parsed.thread_id === "string") {
         sessionId = parsed.thread_id.trim();
       }
+      if (usesClaudeStreamJsonDialect({ backend, providerId })) {
+        lastCallUsage = readClaudeAssistantUsage(parsed) ?? lastCallUsage;
+      }
       usage = readCliUsage(parsed) ?? usage;
 
       const claudeResult = parseClaudeCliJsonlResult({
@@ -513,6 +554,7 @@ export function parseCliJsonl(
         parsed,
         sessionId,
         usage,
+        lastCallUsage,
       });
       if (claudeResult) {
         return claudeResult;

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -516,7 +516,11 @@ export async function runPreparedCliAgent(
           provider: params.provider,
           model: context.modelId,
           usage: resultParams.output.usage,
-          ...(resultParams.output.usage ? { lastCallUsage: resultParams.output.usage } : {}),
+          ...((resultParams.output.lastCallUsage ?? resultParams.output.usage)
+            ? {
+                lastCallUsage: resultParams.output.lastCallUsage ?? resultParams.output.usage,
+              }
+            : {}),
           ...(resultParams.effectiveCliSessionId
             ? {
                 cliSessionBinding: {


### PR DESCRIPTION
## Summary
- keep Claude CLI stream-json `result` usage as aggregate run usage
- track latest complete assistant-message or `message_start` usage separately as `lastCallUsage`
- use `lastCallUsage` for CLI session context snapshots so summed `result.cache_read_input_tokens` cannot inflate fresh token accounting
- ignore Claude `message_delta.usage` for `lastCallUsage` because it can be output-only and would drop prompt/cache fields

Fixes #85573

## Real behavior proof

Before this patch, a Claude stream-json turn with assistant usage records and a final result usage sum exposed only the final aggregate result usage to the CLI runner. That made `agentMeta.lastCallUsage` equal the summed `result.cache_read_input_tokens` value:

```text
assistant[0].cache_read_input_tokens = 18499
assistant[1].cache_read_input_tokens = 27142
result.cache_read_input_tokens = 45641
old lastCallUsage.cacheRead = 45641
```

After this patch, the parser keeps aggregate `usage` unchanged for run accounting but also exposes the latest complete assistant-call usage as `lastCallUsage`, and the CLI runner prefers that for session context snapshots:

```text
usage.cacheRead = 45641
lastCallUsage.cacheRead = 27142
```

The first regression in `src/agents/cli-output.test.ts` constructs that summed Claude stream-json fixture and asserts both values separately.

ClawSweeper also pointed out that Claude `message_delta.usage` can be output-only and must not replace a complete prompt/cache snapshot from `message_start`. The second regression now covers this stream-event sequence:

```text
message_start.usage.cache_read_input_tokens = 27142
message_delta.usage.output_tokens = 6
result.usage.cache_read_input_tokens = 45641
lastCallUsage.cacheRead remains 27142
```

That is the direct after-fix behavior exercised by `does not replace Claude message_start cache usage with message_delta output usage`.

## Verification
- `node scripts/run-vitest.mjs src/agents/cli-output.test.ts` -> PASS, 17 tests
- `node scripts/run-vitest.mjs src/agents/command/session-store.test.ts` -> PASS, 54 tests
- `NODE_OPTIONS=--max-old-space-size=16384 npx tsc --noEmit` -> PASS

## Notes
- This PR has source-level proof plus the reporter-provided live issue logs for the claude-cli aggregate-result behavior. I do not have access to the reporter's live Anthropic/claude-cli setup from this cycle, so I cannot attach a fresh external-provider run.
- The code path under test is the parser/runner/session-store path ClawSweeper identified: aggregate `usage` stays aggregate, complete prompt/cache `lastCallUsage` feeds session token accounting.
