### PR TITLE
fix(agents): add openai-responses family to non-visible turn retry guard

### DIFF
--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -1594,6 +1594,54 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     expect(retryInstruction).toBeNull();
   });
 
+  it("retries empty openai-codex-responses turns with non-zero output tokens (#85364)", () => {
+    const retryInstruction = resolveEmptyResponseRetryInstruction({
+      provider: "openai-codex",
+      modelId: "gpt-5.5",
+      modelApi: "openai-codex-responses",
+      payloadCount: 0,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai-codex",
+          model: "gpt-5.5",
+          content: [],
+          usage: { input: 24794, output: 111, cacheRead: 4608, totalTokens: 29513 },
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    });
+
+    expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
+  });
+
+  it("retries empty openai-responses turns without visible text", () => {
+    const retryInstruction = resolveEmptyResponseRetryInstruction({
+      provider: "openai",
+      modelId: "gpt-5.5",
+      modelApi: "openai-responses",
+      payloadCount: 0,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.5",
+          content: [],
+          usage: { input: 5000, output: 200, totalTokens: 5200 },
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    });
+
+    expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
+  });
+
   it("retries generic empty OpenAI-compatible turns from custom endpoints", () => {
     const retryInstruction = resolveEmptyResponseRetryInstruction({
       provider: "llama-cpp-local",

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -133,6 +133,19 @@ const GEMINI_INCOMPLETE_TURN_MODEL_ID_PATTERN = /^gemini(?:[.-]|$)/;
 // Ollama native `/api/chat` can finish with only thinking/internal blocks when
 // constrained, but it should not inherit the stricter planning-only/ack prompts.
 const OLLAMA_INCOMPLETE_TURN_PROVIDER_ID_PATTERN = /^ollama(?:-|$)/;
+// Model APIs eligible for the non-visible turn retry guard.  OpenAI Responses
+// family can produce reasoning-only turns where usage.output > 0 but no visible
+// text is emitted; without the guard these pass through as successful. (#85364)
+const RETRY_GUARD_MODEL_APIS = new Set([
+  "openai-completions",
+  "anthropic-messages",
+  "bedrock-converse-stream",
+  "openai-responses",
+  "openai-codex-responses",
+  "azure-openai-responses",
+  "openclaw-openai-responses-transport",
+  "openclaw-azure-openai-responses-transport",
+]);
 const DEFAULT_PLANNING_ONLY_RETRY_LIMIT = 1;
 const STRICT_AGENTIC_PLANNING_ONLY_RETRY_LIMIT = 2;
 // Allow one immediate continuation plus one follow-up continuation before
@@ -627,11 +640,7 @@ function shouldApplyNonVisibleTurnRetryGuard(params: {
   if (shouldApplyPlanningOnlyRetryGuard(params)) {
     return true;
   }
-  if (
-    normalizeLowercaseStringOrEmpty(params.modelApi ?? "") === "openai-completions" ||
-    normalizeLowercaseStringOrEmpty(params.modelApi ?? "") === "anthropic-messages" ||
-    normalizeLowercaseStringOrEmpty(params.modelApi ?? "") === "bedrock-converse-stream"
-  ) {
+  if (RETRY_GUARD_MODEL_APIS.has(normalizeLowercaseStringOrEmpty(params.modelApi ?? ""))) {
     return true;
   }
   // Non-visible final turns are narrower than planning-only turns: there is no


### PR DESCRIPTION
## Summary

- Add the OpenAI Responses API family to the non-visible turn retry guard.
- Preserve the existing Bedrock and Ollama retry behavior while adding coverage for empty OpenAI Responses turns with non-zero output usage.

## Real behavior proof

Behavior addressed: `openai-responses` / `openai-codex-responses` turns with output tokens but no visible assistant text could be treated as successful completions, leaving the user with no visible reply instead of triggering the retry instruction.
Real environment tested: local OpenClaw source checkout on macOS, Node/pnpm repo runtime, with the production incomplete-turn guard exercised directly through `node --import tsx`.
Exact steps or command run after this patch: `node --import tsx --input-type=module` probe importing `src/agents/pi-embedded-runner/run/incomplete-turn.ts`, passing replay-safe empty assistant turns, and printing whether each model API receives `EMPTY_RESPONSE_RETRY_INSTRUCTION`.
Evidence after fix:
```json
{
  "openai-codex-responses": true,
  "openai-responses": true,
  "unknown-api": false
}
```
Observed result after fix: OpenAI Responses-family invisible turns now follow the same retry path as the existing guarded APIs instead of silently succeeding with no user-visible text; an unknown model API still does not get broadened into the guard.
What was not tested: no live OpenAI/Codex provider request; this path is a deterministic retry classifier around already-normalized run results.

## Verification

- `pnpm test src/agents/pi-embedded-runner/run.incomplete-turn.test.ts`
- `git diff --check`
- Auto Review: clean, no accepted/actionable findings.
