### PR TITLE
fix(feishu): add unsend action handler using im.message.delete (recall API)

### DIFF
--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -611,6 +611,20 @@ describe("feishuPlugin actions", () => {
     expect(details.messageId).toBe("om_recall_1");
   });
 
+  it("throws on non-zero Feishu unsend response code", async () => {
+    const deleteMock = vi.fn().mockResolvedValueOnce({ code: 230001, msg: "message not found" });
+    createFeishuClientMock.mockResolvedValueOnce({ im: { message: { delete: deleteMock } } });
+
+    await expect(
+      feishuPlugin.actions?.handleAction?.({
+        action: "unsend",
+        params: { messageId: "om_bad_1" },
+        cfg,
+        accountId: undefined,
+      } as never),
+    ).rejects.toThrow("Feishu unsend failed: message not found");
+  });
+
   it("sends explicit thread replies with reply_in_thread semantics", async () => {
     sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_reply", chatId: "oc_group_1" });
 

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -232,6 +232,7 @@ describe("feishuPlugin actions", () => {
       "send",
       "read",
       "edit",
+      "unsend",
       "thread-reply",
       "pin",
       "list-pins",
@@ -262,6 +263,7 @@ describe("feishuPlugin actions", () => {
       "send",
       "read",
       "edit",
+      "unsend",
       "thread-reply",
       "pin",
       "list-pins",
@@ -300,6 +302,7 @@ describe("feishuPlugin actions", () => {
       "send",
       "read",
       "edit",
+      "unsend",
       "thread-reply",
       "pin",
       "list-pins",
@@ -312,6 +315,7 @@ describe("feishuPlugin actions", () => {
       "send",
       "read",
       "edit",
+      "unsend",
       "thread-reply",
       "pin",
       "list-pins",
@@ -587,6 +591,24 @@ describe("feishuPlugin actions", () => {
     expect(details.ok).toBe(true);
     expect(details.messageId).toBe("om_2");
     expect(details.contentType).toBe("post");
+  });
+
+  it("unsends (recalls) messages via im.message.delete", async () => {
+    const deleteMock = vi.fn().mockResolvedValueOnce({ code: 0 });
+    createFeishuClientMock.mockResolvedValueOnce({ im: { message: { delete: deleteMock } } });
+
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "unsend",
+      params: { messageId: "om_recall_1" },
+      cfg,
+      accountId: undefined,
+    } as never);
+
+    expect(deleteMock).toHaveBeenCalledWith({ path: { message_id: "om_recall_1" } });
+    const details = resultDetails(result);
+    expect(details.ok).toBe(true);
+    expect(details.action).toBe("unsend");
+    expect(details.messageId).toBe("om_recall_1");
   });
 
   it("sends explicit thread replies with reply_in_thread semantics", async () => {

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -693,12 +693,13 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
         reactions: true,
         edit: true,
         reply: true,
+        unsend: true,
       },
       agentPrompt: {
         messageToolHints: () => [
           "- Feishu targeting: omit `target` to reply to the current conversation (auto-inferred). Explicit targets: `user:open_id` or `chat:chat_id`.",
           "- Feishu supports interactive cards plus native image, file, audio, and video/media delivery.",
-          "- Feishu supports `send`, `read`, `edit`, `thread-reply`, pins, and channel/member lookup, plus reactions when enabled.",
+          "- Feishu supports `send`, `read`, `edit`, `unsend`, `thread-reply`, pins, and channel/member lookup, plus reactions when enabled.",
         ],
       },
       groups: {

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -928,7 +928,10 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
               throw new Error("Feishu unsend requires messageId.");
             }
             const client = await createFeishuActionClient(account);
-            await client.im.message.delete({ path: { message_id: messageId } });
+            const resp = await client.im.message.delete({ path: { message_id: messageId } });
+            if (resp?.code && resp.code !== 0) {
+              throw new Error(`Feishu unsend failed: ${resp.msg ?? `code ${resp.code}`}`);
+            }
             return jsonActionResult({
               ok: true,
               channel: "feishu",

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -267,6 +267,7 @@ function describeFeishuMessageTool({
     "send",
     "read",
     "edit",
+    "unsend",
     "thread-reply",
     "pin",
     "list-pins",
@@ -918,6 +919,21 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
               channel: "feishu",
               action: "edit",
               ...result,
+            });
+          }
+
+          if (ctx.action === "unsend") {
+            const messageId = resolveFeishuMessageId(ctx.params);
+            if (!messageId) {
+              throw new Error("Feishu unsend requires messageId.");
+            }
+            const client = await createFeishuActionClient(account);
+            await client.im.message.delete({ path: { message_id: messageId } });
+            return jsonActionResult({
+              ok: true,
+              channel: "feishu",
+              action: "unsend",
+              messageId,
             });
           }
 


### PR DESCRIPTION
## Summary

The Feishu plugin registered message actions (send, read, edit, etc.) but did not handle the `unsend` action, causing `"Unsupported Feishu action: unsend"` errors when agents attempted to recall sent messages.

The Feishu/Lark SDK maps `client.im.message.delete()` to the recall endpoint (`DELETE /open-apis/im/v1/messages/{message_id}`). Despite the method name, this IS the recall/unsend API that removes the message for all participants. There is no separate `recall()` method on the raw SDK client.

Closes #85587

## Changes

- `extensions/feishu/src/channel.ts`: Add `"unsend"` to advertised actions set; add unsend handler using `client.im.message.delete()` (the Feishu recall API)
- `extensions/feishu/src/channel.test.ts`: Add test for unsend action; update 3 action-list assertions to include `"unsend"`

## Real behavior proof

Behavior addressed: Feishu unsend action throws "Unsupported Feishu action" instead of recalling the message via the Lark SDK

Real environment tested: macOS 15.5, Node 22.19, openclaw built from patched source. Live Lark workspace with bot app `cli_aa984f92ac78c07e` (openclaw-test-bot), `@larksuiteoapi/node-sdk@1.64.0`, and `im:message` + `im:message:send_as_bot` scopes.

Exact steps or command run after this patch:
1. Ran `node scripts/run-vitest.mjs extensions/feishu/src/channel.test.ts` (55 tests, 0 failures)
2. Verified SDK method inventory confirms `im.message.delete` exists and `im.message.recall` does not
3. Ran a live 4-step Feishu bot send-unsend-readback cycle against a real Lark workspace (see detailed proof below)

Evidence after fix:
```
Live Feishu 4-step proof (send, readback, unsend, verify):

Step 1 - Send: POST /im/v1/messages -> code=0, message_id=om_x100b6e1bc8cb6ca10819e8cf13f9b36, deleted=false
Step 2 - Readback: GET /im/v1/messages/{id} -> code=0, deleted=false, content="openclaw unsend proof test"
Step 3 - Unsend: DELETE /im/v1/messages/{id} -> code=0, msg="success"
Step 4 - Verify: GET /im/v1/messages/{id} -> code=0, deleted=true, content="" (body emptied by Lark)

SDK method inventory (node -e check):
  SDK version: 1.64.0
  im.message.delete exists: true
  im.message.recall exists: undefined

Test suite:
  node scripts/run-vitest.mjs extensions/feishu/src/channel.test.ts
  55 passed (including new "unsends (recalls) messages via im.message.delete" test)
```

Observed result after fix: the unsend handler calls `client.im.message.delete({path:{message_id}})` and returns `{ok:true, action:"unsend", messageId}`. The live 4-step proof confirms the real Lark API recalls the message: after DELETE, readback shows `deleted: true` with empty content.

What was not tested: multi-tenant workspace recall behavior (tested with a single-tenant Lark org); no cross-org message recall was tested
