### PR TITLE
fix(slack): keep one draft message in progress mode

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -2179,7 +2179,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
       }),
     );
 
-    expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
+    expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
     expect(draftStream.update).toHaveBeenLastCalledWith({
       text: ["Shelling", "• tool one", "• tool two"].join("\n"),
       blocks: [
@@ -2205,6 +2205,48 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     });
     expect(finalizeSlackPreviewEditMock).toHaveBeenCalledTimes(1);
     expect(deliverRepliesMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves text Slack progress lines after a draft boundary status update", async () => {
+    const draftStream = createDraftStreamStub();
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+    mockedSlackStreamingMode = "progress";
+    mockedSlackDraftMode = "status_final";
+    mockedDispatchSequence = [];
+    mockedReplyOptionEvents = [
+      { kind: "item", progressText: "tool one" },
+      { kind: "item", progressText: "tool two" },
+      { kind: "assistant_start" },
+      { kind: "partial", text: "partial answer" },
+    ];
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        accountConfig: { streaming: { progress: { label: "Working" } } },
+      }),
+    );
+
+    expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
+    expect(draftStream.update).toHaveBeenLastCalledWith(
+      ["Working", "• tool one", "• tool two"].join("\n"),
+    );
+  });
+
+  it("forces a new draft message on assistant boundaries in partial mode", async () => {
+    const draftStream = createDraftStreamStub();
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+    mockedSlackStreamingMode = "partial";
+    mockedSlackDraftMode = "replace";
+    mockedDispatchSequence = [];
+    mockedReplyOptionEvents = [
+      { kind: "partial", text: "first chunk" },
+      { kind: "assistant_start" },
+      { kind: "partial", text: "second chunk" },
+    ];
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage({}));
+
+    expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
   });
 
   it("can hide raw Slack command progress text by config", async () => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -1307,7 +1307,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       return;
     }
     const progressLines =
-      useRichProgressDraft && previewToolProgressLines.length === 0
+      previewToolProgressLines.length === 0
         ? lastNonEmptyPreviewToolProgressLines
         : previewToolProgressLines;
     const previewText = formatChannelProgressDraftText({
@@ -1610,7 +1610,10 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   const onDraftBoundary = !shouldUseDraftStream
     ? undefined
     : async () => {
-        if (hasStreamedMessage) {
+        // Progress drafts are one rolling message that's finalized in place.
+        // Keep boundary cleanup, but don't clear messageId or the next update
+        // posts a new draft instead of editing the existing preview.
+        if (hasStreamedMessage && streamMode !== "status_final") {
           draftStream?.forceNewMessage();
           hasStreamedMessage = false;
           appendRenderedText = "";


### PR DESCRIPTION
## Summary

In `channels.slack.streaming.mode = "progress"` (internally `status_final`), Slack should keep one rolling draft preview and finalize that same message in place when the final reply lands. Multi-segment assistant turns were instead posting one draft per assistant/reasoning boundary because the boundary handler called `draftStream.forceNewMessage()`, clearing the draft `messageId` before the next update.

## Fix

- Keep `status_final` drafts on the same Slack message by skipping only the `forceNewMessage()` call in progress mode.
- Preserve the existing boundary cleanup so reasoning/progress state does not leak across segments.
- Preserve the last non-empty progress lines for both rich and text progress drafts, so a boundary-triggered status refresh does not erase the visible progress preview.
- Keep partial/replace behavior unchanged: assistant boundaries still force a new draft message outside progress mode.

## Verification

- `node scripts/run-vitest.mjs extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts --reporter=dot`
- `./node_modules/.bin/oxfmt --check extensions/slack/src/monitor/message-handler/dispatch.ts extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts`
- `./node_modules/.bin/oxlint --tsconfig ./tsconfig.json extensions/slack/src/monitor/message-handler/dispatch.ts extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts`
- `git diff --check`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof

Behavior or issue addressed: In `channels.slack.streaming.mode = "progress"`, a multi-segment assistant turn was posting one new draft message per assistant segment instead of editing one rolling preview in place. Earlier drafts were left as orphaned progress messages above the final reply.

Real environment tested: Production Slack workspace, real Slack bot identity via socket mode, OpenClaw agent running the patched bundle on the same EC2 host that reproduced the bug. Slack streaming config used `channels.slack.streaming = { mode: "progress" }` per account, with replies threaded.

Exact steps or command run after this patch: Built the patched Slack extension bundle, deployed it onto the production agent host, restarted the agent so Slack reconnected with the new dispatch wiring, then sent the same kind of tool-using Slack prompt that previously produced multiple progress messages. The channel was observed during streaming and after the final reply landed.

Evidence after fix: Before screenshot showed one turn producing multiple orphaned progress messages. After screenshot showed one rolling progress draft finalized in place, with no orphaned progress messages above the final reply. Evidence images: https://github.com/mycarrysun/openclaw/releases/download/slack-progress-proof/slack-progress-before.jpg and https://github.com/mycarrysun/openclaw/releases/download/slack-progress-proof/slack-progress-after.jpg.

Observed result after fix: The Slack channel showed exactly one draft preview message for the whole multi-segment turn. Assistant text and tool-progress updates edited that single message instead of posting new drafts, and the final reply finalized the same message.

What was not tested: Partial and block/replace streaming modes were not exercised against a live Slack workspace in this run; focused regression tests cover that those modes still force a new draft on assistant boundaries.
