### PR TITLE
fix(matrix): mark reaction system events as non-owner

### DIFF
--- a/extensions/matrix/src/matrix/monitor/reaction-events.test.ts
+++ b/extensions/matrix/src/matrix/monitor/reaction-events.test.ts
@@ -164,15 +164,17 @@ describe("matrix approval reactions", () => {
       client,
       core,
       targetEventId: "$msg-1",
-      reactionKey: "👍",
+      reactionKey: "needs-review",
     });
 
     expect(resolveMatrixApproval).not.toHaveBeenCalled();
     expect(core.system.enqueueSystemEvent).toHaveBeenCalledWith(
-      "Matrix reaction added: 👍 by Owner on msg $msg-1",
+      "Matrix reaction added: needs-review by Owner on msg $msg-1",
       {
         sessionKey: "agent:main:matrix:channel:!ops:example.org",
-        contextKey: "matrix:reaction:add:!ops:example.org:$msg-1:@owner:example.org:👍",
+        contextKey: "matrix:reaction:add:!ops:example.org:$msg-1:@owner:example.org:needs-review",
+        forceSenderIsOwnerFalse: true,
+        trusted: false,
       },
     );
   });

--- a/extensions/matrix/src/matrix/monitor/reaction-events.ts
+++ b/extensions/matrix/src/matrix/monitor/reaction-events.ts
@@ -190,6 +190,8 @@ export async function handleInboundMatrixReaction(params: {
   params.core.system.enqueueSystemEvent(text, {
     sessionKey: route.sessionKey,
     contextKey: `matrix:reaction:add:${params.roomId}:${reaction.eventId}:${params.senderId}:${reaction.key}`,
+    forceSenderIsOwnerFalse: true,
+    trusted: false,
   });
   params.logVerboseMessage(
     `matrix: reaction event enqueued room=${params.roomId} target=${reaction.eventId} sender=${params.senderId} emoji=${reaction.key}`,


### PR DESCRIPTION
## Summary

- Problem: Matrix reaction system events included Matrix member-controlled text but did not explicitly downgrade the event from owner trust.
- Solution: mark generic Matrix reaction system events as non-owner and untrusted before they enter the shared system-event queue.
- What changed: Matrix reaction notifications now pass `forceSenderIsOwnerFalse: true` and `trusted: false` to `enqueueSystemEvent`.
- What did NOT change (scope boundary): Matrix approval reactions, reaction routing, notification-mode checks, target-event lookup, and Matrix message sending are unchanged.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: N/A
- Related: N/A
- [x] This PR fixes a bug or regression

## Motivation

Matrix `m.reaction` events carry externally supplied Matrix room data into an OpenClaw system event. The reaction key is not limited to emoji by the Matrix event shape; OpenClaw preserves it as a string and includes it in the system-event text alongside the sender label. Since this text came from a channel member rather than the operator, the system event should not inherit owner trust in later agent turns.

This is a trust-metadata fix, not a change to Matrix reaction delivery.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: generic Matrix reactions on bot messages now enqueue non-owner, untrusted system events.
- Real environment tested: local macOS development checkout, branch `matrix-reaction-system-event-trust`, head `1209650b62`.
- Exact steps or command run after this patch:
  - `node --import tsx .artifacts/matrix-reaction-system-event-proof.ts`
  - `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-matrix.config.ts extensions/matrix/src/matrix/monitor/reaction-events.test.ts`
  - `npm exec --yes pnpm@11.1.0 -- oxfmt --check extensions/matrix/src/matrix/monitor/reaction-events.ts extensions/matrix/src/matrix/monitor/reaction-events.test.ts`
  - `git diff --check`
- Evidence after fix:

```text
[matrix-proof] matrix: reaction event enqueued room=!ops:example.org target=$bot-msg-1 sender=@mallory:example.org emoji=needs-review
[matrix-proof] enqueueSystemEvent text:
Matrix reaction added: needs-review by Mallory on msg $bot-msg-1
[matrix-proof] enqueueSystemEvent metadata:
{
  "sessionKey": "agent:main:matrix:channel:!ops:example.org",
  "contextKey": "matrix:reaction:add:!ops:example.org:$bot-msg-1:@mallory:example.org:needs-review",
  "forceSenderIsOwnerFalse": true,
  "trusted": false
}
[matrix-proof] proof completed
```

- Observed result after fix: the generic Matrix reaction path still queues the reaction system event, but the queued metadata now explicitly marks it as non-owner and untrusted.
- What was not tested: a live Matrix homeserver round trip. The proof exercises the Matrix reaction handler from the source checkout with the same event shape the Matrix client delivers after receiving an `m.reaction` event.
- Before evidence (optional but encouraged): before this change, the same Matrix reaction handler queued the generic reaction system event with only `sessionKey` and `contextKey`, so the system-event owner downgrade metadata was absent.

## Root Cause

- Root cause: the Matrix reaction notification path queued externally supplied reaction text without the system-event owner downgrade metadata used by other external channel system events.
- Missing detection / guardrail: the existing Matrix reaction test asserted the event text and routing key but did not assert the trust metadata.
- Contributing context: Matrix approval reactions are handled separately and are not generic system events, so this only affects the ordinary reaction-notification path.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/matrix/src/matrix/monitor/reaction-events.test.ts`
- Scenario the test locks in: an ordinary Matrix reaction on a bot message queues the same reaction system event, with `forceSenderIsOwnerFalse: true` and `trusted: false`.
- Why this is the smallest reliable guardrail: the changed behavior is local to `handleInboundMatrixReaction` and the existing test already exercises the generic reaction enqueue path.
- Existing test that already covers this: the ordinary reaction enqueue test existed, but did not cover trust metadata.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None for Matrix users. Matrix reaction notifications are still queued; only their internal trust metadata changes.

## Diagram

```text
Before:
Matrix m.reaction -> generic system event -> owner trust not explicitly downgraded

After:
Matrix m.reaction -> generic system event + non-owner metadata -> later agent turn can downgrade owner trust
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: this narrows the command/tool execution trust path by ensuring externally supplied Matrix reaction text cannot enter the system-event queue without non-owner trust metadata.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local development checkout
- Model/provider: N/A
- Integration/channel: Matrix
- Relevant config: local Matrix test config with redacted homeserver/token values

### Steps

1. Exercise `handleInboundMatrixReaction` with a Matrix `m.reaction` event targeting a bot message.
2. Use a non-emoji reaction key (`needs-review`) to verify the generic reaction key is preserved as string input.
3. Inspect the `enqueueSystemEvent` call.
4. Run the targeted Matrix reaction tests and formatting checks.

### Expected

- Generic Matrix reaction system events include `forceSenderIsOwnerFalse: true` and `trusted: false`.
- Matrix approval reactions remain routed to the approval resolver and do not become generic system events.

### Actual

- Matches expected in the local handler proof and targeted Matrix reaction regression test.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers

## Human Verification

- Verified scenarios: ordinary Matrix reaction on a bot message queues a generic reaction system event with non-owner trust metadata; approval reactions still bypass generic system-event enqueueing.
- Edge cases checked: `reactionNotifications = "off"` still skips generic reaction events; approval reactions still resolve without fetching the target event when registered.
- What was not verified: live Matrix homeserver round trip.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: later agent turns that include Matrix reaction notifications may be downgraded from owner trust when they previously were not.
  - Mitigation: this matches the trust boundary for externally supplied channel system events and is limited to generic Matrix reaction notifications.
