### PR TITLE
fix(bootstrap): guard bootstrap name checks against undefined names (#85523)

### DIFF
--- a/src/agents/bootstrap-budget.test.ts
+++ b/src/agents/bootstrap-budget.test.ts
@@ -103,6 +103,32 @@ describe("analyzeBootstrapBudget", () => {
 });
 
 describe("bootstrap prompt warnings", () => {
+  it("handles malformed truncation entries without names", () => {
+    const lines = formatBootstrapTruncationWarningLines({
+      analysis: {
+        files: [],
+        truncatedFiles: [
+          {
+            name: undefined,
+            path: "/tmp/unknown",
+            missing: false,
+            rawChars: 10,
+            injectedChars: 1,
+            truncated: true,
+            nearLimit: false,
+            causes: [],
+          } as unknown as ReturnType<typeof analyzeBootstrapBudget>["truncatedFiles"][number],
+        ],
+        nearLimitFiles: [],
+        totalRawChars: 10,
+        totalInjectedChars: 1,
+        totalNearLimit: false,
+        hasTruncation: true,
+      },
+    });
+    expect(lines.join("\n")).toContain("10 raw -> 1 injected");
+  });
+
   it("appends warning details to the turn prompt instead of mutating the system prompt", () => {
     const prompt = appendBootstrapPromptWarning("Please continue.", [
       "AGENTS.md: 200 raw -> 0 injected",

--- a/src/agents/bootstrap-budget.test.ts
+++ b/src/agents/bootstrap-budget.test.ts
@@ -104,27 +104,24 @@ describe("analyzeBootstrapBudget", () => {
 
 describe("bootstrap prompt warnings", () => {
   it("handles malformed truncation entries without names", () => {
+    const analysis = analyzeBootstrapBudget({
+      files: [
+        {
+          name: "TEMP.md",
+          path: "/tmp/unknown",
+          missing: false,
+          rawChars: 10,
+          injectedChars: 1,
+          truncated: true,
+        },
+      ],
+      bootstrapMaxChars: 5,
+      bootstrapTotalMaxChars: 5,
+    });
+    (analysis.truncatedFiles[0] as { name?: string }).name = undefined;
+
     const lines = formatBootstrapTruncationWarningLines({
-      analysis: {
-        files: [],
-        truncatedFiles: [
-          {
-            name: undefined,
-            path: "/tmp/unknown",
-            missing: false,
-            rawChars: 10,
-            injectedChars: 1,
-            truncated: true,
-            nearLimit: false,
-            causes: [],
-          } as unknown as ReturnType<typeof analyzeBootstrapBudget>["truncatedFiles"][number],
-        ],
-        nearLimitFiles: [],
-        totalRawChars: 10,
-        totalInjectedChars: 1,
-        totalNearLimit: false,
-        hasTruncation: true,
-      },
+      analysis,
     });
     expect(lines.join("\n")).toContain("10 raw -> 1 injected");
   });

--- a/src/agents/bootstrap-budget.ts
+++ b/src/agents/bootstrap-budget.ts
@@ -68,8 +68,8 @@ function formatWarningCause(cause: BootstrapTruncationCause): string {
   return cause === "per-file-limit" ? "max/file" : "max/total";
 }
 
-function isAgentsBootstrapName(name: string): boolean {
-  return name.toLowerCase() === "agents.md";
+function isAgentsBootstrapName(name: string | undefined): boolean {
+  return name?.toLowerCase() === "agents.md";
 }
 
 function normalizeSeenSignatures(signatures?: string[]): string[] {

--- a/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts
+++ b/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts
@@ -241,6 +241,21 @@ describe("buildBootstrapContextFiles", () => {
       warnings.filter((warning) => !warning.includes('missing or invalid "path" field')),
     ).toStrictEqual([]);
   });
+
+  it("handles undefined file names without crashing", () => {
+    const fileWithUndefinedName = {
+      name: undefined,
+      path: "/tmp/test.md",
+      content: "content",
+      missing: false,
+    } as unknown as WorkspaceBootstrapFile;
+    const warnings: string[] = [];
+    const result = buildBootstrapContextFiles([fileWithUndefinedName], {
+      warn: (msg) => warnings.push(msg),
+    });
+    expect(result).toBeDefined();
+    expect(Array.isArray(result)).toBe(true);
+  });
 });
 
 type BootstrapLimitResolverCase = {

--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -151,8 +151,8 @@ export function resolveBootstrapPromptTruncationWarningMode(
   return DEFAULT_BOOTSTRAP_PROMPT_TRUNCATION_WARNING_MODE;
 }
 
-function isAgentsBootstrapFile(fileName: string): boolean {
-  return fileName.toLowerCase() === AGENTS_BOOTSTRAP_FILENAME.toLowerCase();
+function isAgentsBootstrapFile(fileName: string | undefined): boolean {
+  return fileName?.toLowerCase() === AGENTS_BOOTSTRAP_FILENAME.toLowerCase();
 }
 
 function isPolicyDigestCandidate(line: string): boolean {


### PR DESCRIPTION
## Summary

Fixes #85523: a malformed workspace bootstrap file entry with an undefined `name` could crash every embedded agent run while building bootstrap context. The reported 2026.5.20 stack points at `isAgentsBootstrapFile(...).toLowerCase()` and `isAgentsBootstrapName(...).toLowerCase()`; both helpers now tolerate undefined names while preserving exact `AGENTS.md` matching for normal string names.

## Changes

- Guard the two bootstrap filename checks with optional chaining.
- Add regression coverage for `buildBootstrapContextFiles()` with an undefined name.
- Add regression coverage for bootstrap truncation warning formatting when a truncated entry has no name.

## Real behavior proof

Behavior addressed: Workspace bootstrap entries can arrive with `name: undefined`; before this patch the shared bootstrap context path throws `TypeError: Cannot read properties of undefined (reading 'toLowerCase')`, blocking agent replies before channel-specific code runs.

Real environment tested: Local OpenClaw source checkout on macOS, Node via repo `tsx`, using the patched `src/agents/pi-embedded-helpers/bootstrap.ts` and `src/agents/bootstrap-budget.ts` code paths with the malformed bootstrap entry shape from #85523.

Exact steps or command run after this patch:

```bash
node --import tsx/esm --input-type=module - <<'NODE'
import { buildBootstrapContextFiles } from './src/agents/pi-embedded-helpers/bootstrap.ts';
import { analyzeBootstrapBudget, formatBootstrapTruncationWarningLines } from './src/agents/bootstrap-budget.ts';

const warnings = [];
const files = [{ name: undefined, path: '/tmp/unnamed-bootstrap.md', content: 'x'.repeat(200), missing: false }];
const contextFiles = buildBootstrapContextFiles(files, { maxChars: 80, totalMaxChars: 80, warn: (message) => warnings.push(message) });
const analysis = analyzeBootstrapBudget({
  files: [{ name: undefined, path: '/tmp/unnamed-bootstrap.md', missing: false, rawChars: 200, injectedChars: contextFiles[0]?.content.length ?? 0, truncated: true }],
  bootstrapMaxChars: 80,
  bootstrapTotalMaxChars: 80,
});
const lines = formatBootstrapTruncationWarningLines({ analysis });
console.log(JSON.stringify({ contextFileCount: contextFiles.length, contentLength: contextFiles[0]?.content.length, warnings, lines }, null, 2));
NODE

pnpm test src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts src/agents/bootstrap-budget.test.ts
pnpm check:test-types
git diff --check origin/main...HEAD
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
```

Evidence after fix:

```text
{
  "contextFileCount": 1,
  "contentLength": 79,
  "warnings": [
    "workspace bootstrap file undefined is 200 chars (limit 80); truncating in injected context"
  ],
  "lines": [
    "undefined: 200 raw -> 79 injected (~61% removed; max/file).",
    "If unintentional, raise agents.defaults.bootstrapMaxChars and/or agents.defaults.bootstrapTotalMaxChars."
  ]
}

pnpm test src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts src/agents/bootstrap-budget.test.ts
[test] passed 2 Vitest shards in 4.24s

pnpm check:test-types
exit code 0

.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
autoreview clean: no accepted/actionable findings reported
```

Observed result after fix: Both malformed-name bootstrap paths complete without throwing; the builder still emits a truncated context file and the truncation warning formatter still reports the malformed entry instead of crashing.

What was not tested: A live Telegram message against the reporter's exact gateway workspace; the source-level repro uses the same malformed bootstrap entry shape and both throwing functions named in the reporter's stack trace.

## Verification

- `node --import tsx/esm --input-type=module -` source-level malformed bootstrap probe above
- `pnpm test src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts src/agents/bootstrap-budget.test.ts`
- `pnpm check:test-types`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Fixes #85523
