### PR TITLE
fix(auto-reply): fast path text control commands

### DIFF
--- a/extensions/feishu/src/bot.broadcast.test.ts
+++ b/extensions/feishu/src/bot.broadcast.test.ts
@@ -111,6 +111,7 @@ describe("broadcast dispatch", () => {
           mockWithReplyDispatcher as unknown as PluginRuntime["channel"]["reply"]["withReplyDispatcher"],
       },
       commands: {
+        isControlCommandMessage: vi.fn(() => false),
         shouldComputeCommandAuthorized: mockShouldComputeCommandAuthorized,
         resolveCommandAuthorizedFromAuthorizers: vi.fn(() => false),
       },

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -192,6 +192,7 @@ function createFeishuBotRuntime(overrides: DeepPartial<PluginRuntime> = {}): Plu
         withReplyDispatcher: withReplyDispatcherMock as never,
       },
       commands: {
+        isControlCommandMessage: vi.fn(() => false),
         shouldComputeCommandAuthorized: vi.fn(() => false),
         resolveCommandAuthorizedFromAuthorizers: vi.fn(() => false),
       },
@@ -1082,6 +1083,9 @@ describe("handleFeishuMessage command authorization", () => {
             withReplyDispatcher: mockWithReplyDispatcher as never,
           },
           commands: {
+            isControlCommandMessage: vi.fn(
+              (body?: string) => typeof body === "string" && body.trim().startsWith("/"),
+            ),
             shouldComputeCommandAuthorized: mockShouldComputeCommandAuthorized,
             resolveCommandAuthorizedFromAuthorizers: mockResolveCommandAuthorizedFromAuthorizers,
           },
@@ -1146,6 +1150,94 @@ describe("handleFeishuMessage command authorization", () => {
       BodyForCommands: "/compact",
       RawBody: "/compact",
       MessageSid: "msg-compact-command",
+    });
+  });
+
+  it("marks authorized Feishu text slash commands as text command turns", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(true);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+          allowFrom: ["ou-admin"],
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-admin",
+        },
+      },
+      message: {
+        message_id: "msg-text-command-turn",
+        chat_id: "oc-dm",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "/status" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    const context = mockCallArg<{
+      CommandAuthorized?: boolean;
+      CommandBody?: string;
+      CommandTurn?: unknown;
+    }>(mockFinalizeInboundContext, 0, 0);
+    expect(context.CommandBody).toBe("/status");
+    expect(context.CommandAuthorized).toBe(true);
+    expect(context.CommandTurn).toEqual({
+      kind: "text-slash",
+      source: "text",
+      authorized: true,
+      body: "/status",
+    });
+  });
+
+  it("does not mark inline Feishu command tokens as text command turns", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(true);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+          allowFrom: ["ou-admin"],
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-admin",
+        },
+      },
+      message: {
+        message_id: "msg-inline-command-token",
+        chat_id: "oc-dm",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "please check /status" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    const context = mockCallArg<{
+      CommandAuthorized?: boolean;
+      CommandBody?: string;
+      CommandTurn?: unknown;
+    }>(mockFinalizeInboundContext, 0, 0);
+    expect(context.CommandBody).toBe("please check /status");
+    expect(context.CommandAuthorized).toBe(true);
+    expect(context.CommandTurn).toEqual({
+      kind: "normal",
+      source: "message",
+      authorized: false,
+      body: "please check /status",
     });
   });
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -3,6 +3,7 @@ import {
   buildChannelInboundEventContext,
   formatInboundMediaUnavailableText,
   toInboundMediaFacts,
+  type CommandTurnContext,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveAgentOutboundIdentity } from "openclaw/plugin-sdk/channel-outbound";
 import { createChannelPairingController } from "openclaw/plugin-sdk/channel-pairing";
@@ -1165,6 +1166,23 @@ export async function handleFeishuMessage(params: {
               })
             ).commandAccess.authorized
       : undefined;
+    const isTextSlashCommandTurn = core.channel.commands.isControlCommandMessage(
+      effectiveCommandProbeBody,
+      effectiveCfg,
+    );
+    const commandTurn: CommandTurnContext = isTextSlashCommandTurn
+      ? {
+          kind: "text-slash",
+          source: "text",
+          authorized: Boolean(commandAuthorized),
+          body: effectiveCommandProbeBody,
+        }
+      : {
+          kind: "normal",
+          source: "message",
+          authorized: false,
+          body: agentFacingContent,
+        };
 
     const isTopicSessionForThread =
       isGroup &&
@@ -1463,6 +1481,7 @@ export async function handleFeishuMessage(params: {
             authorized: commandAuthorized,
           },
         },
+        commandTurn,
         extra: {
           RootMessageId: ctx.rootId,
           Transcript: audioTranscript,

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
@@ -12,8 +12,10 @@ import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import {
   isAuthorizedTextSlashCommandTurn,
   isNativeCommandTurn,
+  isTextSlashCommandTurn,
   resolveCommandTurnContext,
 } from "../command-turn-context.js";
+import { normalizeCommandBody, shouldHandleTextCommands } from "../commands-registry.js";
 import type { GetReplyOptions } from "../get-reply-options.types.js";
 import { markCommandReplyForDelivery, type ReplyPayload } from "../reply-payload.js";
 import type { MsgContext } from "../templating.js";
@@ -23,6 +25,7 @@ import {
   type CommandSessionMetadataChange,
 } from "./command-session-metadata.js";
 import { buildCommandContext } from "./commands-context.js";
+import { parseInlineDirectives, type InlineDirectives } from "./directive-handling.parse.js";
 import { clearInlineDirectives } from "./get-reply-directives-utils.js";
 import { resolveReplyDirectives } from "./get-reply-directives.js";
 import { initFastReplySessionState } from "./get-reply-fast-path.js";
@@ -42,6 +45,14 @@ const skillCommandsRuntimeLoader = createLazyImportLoader<SkillCommandsRuntime>(
   () => import("../../skills/discovery/chat-commands.runtime.js"),
 );
 const statusCommandRuntimeLoader = createLazyImportLoader(() => import("./commands-status.js"));
+
+type TextSlashFastPathIntent =
+  | { kind: "status"; commandBodyNormalized: string }
+  | { kind: "directive"; commandBodyNormalized: string }
+  | { kind: "command"; commandBodyNormalized: string };
+
+const TEXT_FAST_PATH_DIRECTIVE_COMMANDS = new Set(["think", "verbose", "fast", "reasoning"]);
+const TEXT_FAST_PATH_COMMAND_HANDLERS = new Set(["activation", "send", "usage", "whoami"]);
 
 function loadCommandsRuntime() {
   return commandsRuntimeLoader.load();
@@ -67,6 +78,25 @@ function resolveNativeSlashCommandName(ctx: MsgContext): string | undefined {
   return normalizeOptionalString(match?.[1])?.toLowerCase();
 }
 
+function resolveSlashCommandName(commandBodyNormalized: string): string | undefined {
+  const match = commandBodyNormalized.trim().match(/^\/([^\s:]+)(?::|\s|$)/);
+  return normalizeOptionalString(match?.[1])?.toLowerCase();
+}
+
+function resolveTextCommandBody(ctx: MsgContext): string | undefined {
+  const commandTurn = resolveCommandTurnContext(ctx);
+  if (!isTextSlashCommandTurn(commandTurn)) {
+    return undefined;
+  }
+  const commandText = stripStructuralPrefixes(
+    commandTurn.body ?? ctx.BodyForCommands ?? ctx.CommandBody ?? ctx.RawBody ?? ctx.Body ?? "",
+  ).trim();
+  if (!commandText.startsWith("/") || commandText.includes("\n")) {
+    return undefined;
+  }
+  return normalizeCommandBody(commandText, { botUsername: ctx.BotUsername });
+}
+
 function shouldRunNativeSlashCommandFastPath(ctx: MsgContext): boolean {
   const commandTurn = resolveCommandTurnContext(ctx);
   const commandName = resolveNativeSlashCommandName(ctx);
@@ -77,6 +107,96 @@ function shouldRunNativeSlashCommandFastPath(ctx: MsgContext): boolean {
     (isNativeCommandTurn(commandTurn) ||
       shouldRunInternalTextSlashCommandFastPath(ctx, commandTurn, commandName)),
   );
+}
+
+function hasOnlyTextFastPathDirectives(directives: InlineDirectives): boolean {
+  const hasAllowedDirective =
+    directives.hasThinkDirective ||
+    directives.hasVerboseDirective ||
+    directives.hasFastDirective ||
+    directives.hasReasoningDirective;
+  if (!hasAllowedDirective) {
+    return false;
+  }
+  return (
+    !directives.hasTraceDirective &&
+    !directives.hasElevatedDirective &&
+    !directives.hasExecDirective &&
+    !directives.hasStatusDirective &&
+    !directives.hasModelDirective &&
+    !directives.hasQueueDirective &&
+    directives.cleaned.trim().length === 0
+  );
+}
+
+function isTextFastPathHandlerCommand(commandName: string, commandBodyNormalized: string): boolean {
+  switch (commandName) {
+    case "activation":
+      return /^\/activation(?:\s+[a-zA-Z]+)?$/i.test(commandBodyNormalized);
+    case "send":
+      return /^\/send(?:\s+[a-zA-Z]+)?$/i.test(commandBodyNormalized);
+    case "usage":
+      return /^\/usage(?:\s+(?:off|on|tokens?|tok|minimal|min|full|session|cost|disable|disabled|enable|enabled|false|true|yes|no|0|1))?$/i.test(
+        commandBodyNormalized,
+      );
+    case "whoami":
+      return commandBodyNormalized === "/whoami";
+    default:
+      return false;
+  }
+}
+
+function resolveTextSlashFastPathIntent(params: {
+  ctx: MsgContext;
+  cfg: OpenClawConfig;
+}): TextSlashFastPathIntent | undefined {
+  if (
+    !shouldHandleTextCommands({
+      cfg: params.cfg,
+      surface: params.ctx.Surface ?? params.ctx.Provider ?? "",
+      commandSource: params.ctx.CommandSource,
+    })
+  ) {
+    return undefined;
+  }
+
+  const commandBodyNormalized = resolveTextCommandBody(params.ctx);
+  if (!commandBodyNormalized) {
+    return undefined;
+  }
+  const commandName = resolveSlashCommandName(commandBodyNormalized);
+  if (!commandName) {
+    return undefined;
+  }
+
+  if (commandName === "status") {
+    const directives = parseInlineDirectives(commandBodyNormalized, {
+      allowStatusDirective: true,
+    });
+    if (directives.hasStatusDirective && directives.cleaned.trim().length === 0) {
+      return { kind: "status", commandBodyNormalized };
+    }
+    return undefined;
+  }
+
+  if (TEXT_FAST_PATH_DIRECTIVE_COMMANDS.has(commandName)) {
+    const directives = parseInlineDirectives(commandBodyNormalized, {
+      allowStatusDirective: false,
+    });
+    if (hasOnlyTextFastPathDirectives(directives)) {
+      return { kind: "directive", commandBodyNormalized };
+    }
+    return undefined;
+  }
+
+  if (
+    TEXT_FAST_PATH_COMMAND_HANDLERS.has(commandName) &&
+    isTextFastPathHandlerCommand(commandName, commandBodyNormalized)
+  ) {
+    return { kind: "command", commandBodyNormalized };
+  }
+
+  return undefined;
 }
 
 function shouldRunInternalTextSlashCommandFastPath(
@@ -127,7 +247,12 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
 }): Promise<
   { handled: true; reply: ReplyPayload | ReplyPayload[] | undefined } | { handled: false }
 > {
-  if (!shouldRunNativeSlashCommandFastPath(params.ctx)) {
+  const isNativeSlashFastPath = shouldRunNativeSlashCommandFastPath(params.ctx);
+  const textFastPathIntent = resolveTextSlashFastPathIntent({
+    ctx: params.ctx,
+    cfg: params.cfg,
+  });
+  if (!isNativeSlashFastPath && !textFastPathIntent) {
     return { handled: false };
   }
 
@@ -166,15 +291,20 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
     sessionState.sessionStore[sessionState.sessionKey] = persistedInitialEntry;
     sessionState.sessionId = persistedInitialEntry.sessionId;
   }
+  const triggerBodyNormalized =
+    textFastPathIntent?.commandBodyNormalized ?? sessionState.triggerBodyNormalized;
   const command = buildCommandContext({
     ctx: params.ctx,
     cfg: params.cfg,
     agentId: params.agentId,
     sessionKey: sessionState.sessionKey,
     isGroup: sessionState.isGroup,
-    triggerBodyNormalized: sessionState.triggerBodyNormalized,
+    triggerBodyNormalized,
     commandAuthorized: params.commandAuthorized,
   });
+  if (textFastPathIntent && !command.isAuthorizedSender) {
+    return { handled: true, reply: undefined };
+  }
   if (command.commandBodyNormalized === "/status") {
     const targetSessionEntry =
       sessionState.sessionStore[sessionState.sessionKey] ?? sessionState.sessionEntry;
@@ -226,6 +356,101 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
     });
     return loadedSkillCommands;
   };
+
+  if (textFastPathIntent?.kind === "command") {
+    const commandResult = await (
+      await loadCommandsRuntime()
+    ).handleCommands({
+      ctx: sessionState.sessionCtx,
+      rootCtx: params.ctx,
+      cfg: params.cfg,
+      command,
+      agentId: params.agentId,
+      agentDir: params.agentDir,
+      directives: clearInlineDirectives(textFastPathIntent.commandBodyNormalized),
+      elevated: {
+        enabled: false,
+        allowed: false,
+        failures: [],
+      },
+      sessionEntry: sessionState.sessionEntry,
+      previousSessionEntry: sessionState.previousSessionEntry,
+      sessionStore: sessionState.sessionStore,
+      sessionKey: sessionState.sessionKey,
+      storePath: sessionState.storePath,
+      sessionScope: sessionState.sessionScope,
+      workspaceDir: params.workspaceDir,
+      opts: params.opts,
+      defaultGroupActivation: () => "always",
+      resolvedThinkLevel: undefined,
+      resolvedVerboseLevel: "off",
+      resolvedReasoningLevel: "off",
+      resolvedElevatedLevel: "off",
+      blockReplyChunking: undefined,
+      resolvedBlockStreamingBreak: "text_end",
+      resolveDefaultThinkingLevel: async () => undefined,
+      provider: params.provider,
+      model: params.model,
+      contextTokens: params.agentCfg?.contextTokens ?? 0,
+      isGroup: sessionState.isGroup,
+      loadSkillCommands: async () => [],
+      typing: params.typing,
+    });
+    const commandSessionMetadataChanges = takeCommandSessionMetadataChangesFromTargets([
+      sessionState.sessionCtx,
+      params.ctx,
+    ]);
+    if (commandSessionMetadataChanges) {
+      (params.opts as InternalGetReplyOptions | undefined)?.onSessionMetadataChanges?.(
+        commandSessionMetadataChanges,
+      );
+    }
+    if (!commandResult.shouldContinue) {
+      params.typing.cleanup();
+      return { handled: true, reply: markCommandReplyForDelivery(commandResult.reply) };
+    }
+    return { handled: false };
+  }
+
+  if (textFastPathIntent?.kind === "directive") {
+    const directiveResult = await resolveReplyDirectives({
+      ctx: params.ctx,
+      cfg: params.cfg,
+      agentId: params.agentId,
+      agentDir: params.agentDir,
+      workspaceDir: params.workspaceDir,
+      agentCfg: params.agentCfg,
+      sessionCtx: sessionState.sessionCtx,
+      sessionEntry: sessionState.sessionEntry,
+      sessionStore: sessionState.sessionStore,
+      sessionKey: sessionState.sessionKey,
+      storePath: sessionState.storePath,
+      sessionScope: sessionState.sessionScope,
+      groupResolution: sessionState.groupResolution,
+      isGroup: sessionState.isGroup,
+      triggerBodyNormalized,
+      resetTriggered: false,
+      commandAuthorized: params.commandAuthorized,
+      defaultProvider: params.defaultProvider,
+      defaultModel: params.defaultModel,
+      aliasIndex: params.aliasIndex,
+      provider: params.provider,
+      model: params.model,
+      hasResolvedHeartbeatModelOverride: false,
+      typing: params.typing,
+      opts: params.opts,
+      skillFilter: params.skillFilter,
+    });
+    if (directiveResult.kind === "reply") {
+      params.typing.cleanup();
+      return { handled: true, reply: markCommandReplyForDelivery(directiveResult.reply) };
+    }
+    return { handled: false };
+  }
+
+  if (!isNativeSlashFastPath) {
+    return { handled: false };
+  }
 
   const commandResult = await (
     await loadCommandsRuntime()

--- a/src/auto-reply/reply/get-reply.fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.test.ts
@@ -517,6 +517,170 @@ describe("getReplyFromConfig fast test bootstrap", () => {
     expect(vi.mocked(runPreparedReplyMock)).not.toHaveBeenCalled();
   });
 
+  it("handles authorized text /status before workspace bootstrap", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-text-status-fast-"));
+    const sessionKey = "agent:yuantai:feishu:dm:ou-user";
+    const cfg = markCompleteReplyConfig({
+      agents: {
+        defaults: {
+          workspace: path.join(home, "workspace"),
+        },
+        list: [
+          {
+            id: "yuantai",
+            model: "openai/gpt-5.5",
+          },
+        ],
+      },
+      commands: { text: true },
+      session: { store: path.join(home, "sessions.json") },
+    } as OpenClawConfig);
+    vi.mocked(resolveDefaultModelMock).mockReturnValueOnce({
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+      aliasIndex: emptyAliasIndex(),
+    });
+
+    const reply = await getReplyFromConfig(
+      buildGetReplyCtx({
+        Provider: "feishu",
+        Surface: "feishu",
+        Body: "/status",
+        BodyForAgent: "/status",
+        RawBody: "/status",
+        CommandBody: "/status",
+        BodyForCommands: "/status",
+        CommandAuthorized: true,
+        CommandTurn: {
+          kind: "text-slash",
+          source: "text",
+          authorized: true,
+          body: "/status",
+        },
+        SessionKey: sessionKey,
+      }),
+      undefined,
+      cfg,
+    );
+
+    if (!reply || Array.isArray(reply) || typeof reply.text !== "string") {
+      throw new Error("expected status reply text");
+    }
+    expect(reply.text).toContain("OpenClaw");
+    expect(reply.text).toContain("Model: openai/gpt-5.5");
+    expect(getReplyPayloadMetadata(reply)?.deliverDespiteSourceReplySuppression).toBe(true);
+    expect(mocks.ensureAgentWorkspace).not.toHaveBeenCalled();
+    expect(mocks.initSessionState).not.toHaveBeenCalled();
+    expect(mocks.resolveReplyDirectives).not.toHaveBeenCalled();
+    expect(vi.mocked(runPreparedReplyMock)).not.toHaveBeenCalled();
+  });
+
+  it("handles authorized text local directives before workspace bootstrap", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-text-directive-fast-"));
+    const sessionKey = "agent:yuantai:feishu:dm:ou-user";
+    const cfg = markCompleteReplyConfig({
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.5",
+          workspace: path.join(home, "workspace"),
+        },
+      },
+      commands: { text: true },
+      session: { store: path.join(home, "sessions.json") },
+    } as OpenClawConfig);
+    mocks.resolveReplyDirectives.mockResolvedValueOnce({
+      kind: "reply",
+      reply: { text: "Thinking level set to medium." },
+    });
+
+    const reply = await getReplyFromConfig(
+      buildGetReplyCtx({
+        Provider: "feishu",
+        Surface: "feishu",
+        Body: "/thinking medium",
+        BodyForAgent: "/thinking medium",
+        RawBody: "/thinking medium",
+        CommandBody: "/thinking medium",
+        BodyForCommands: "/thinking medium",
+        CommandAuthorized: true,
+        CommandTurn: {
+          kind: "text-slash",
+          source: "text",
+          authorized: true,
+          body: "/thinking medium",
+        },
+        SessionKey: sessionKey,
+      }),
+      undefined,
+      cfg,
+    );
+
+    expect(reply).toMatchObject({ text: "Thinking level set to medium." });
+    if (!reply || Array.isArray(reply)) {
+      throw new Error("expected single reply payload");
+    }
+    expect(getReplyPayloadMetadata(reply)?.deliverDespiteSourceReplySuppression).toBe(true);
+    expect(mocks.ensureAgentWorkspace).not.toHaveBeenCalled();
+    expect(mocks.initSessionState).not.toHaveBeenCalled();
+    expect(mocks.resolveReplyDirectives).toHaveBeenCalledOnce();
+    expect(vi.mocked(runPreparedReplyMock)).not.toHaveBeenCalled();
+    const directiveParams = requireDirectiveParams();
+    expect(directiveParams.sessionKey).toBe(sessionKey);
+    const directiveCall = mocks.resolveReplyDirectives.mock.calls[0]?.[0] as
+      | { triggerBodyNormalized?: string }
+      | undefined;
+    expect(directiveCall?.triggerBodyNormalized).toBe("/think medium");
+  });
+
+  it("handles authorized text local command handlers before workspace bootstrap", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-text-whoami-fast-"));
+    const cfg = markCompleteReplyConfig({
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.5",
+          workspace: path.join(home, "workspace"),
+        },
+      },
+      commands: { text: true },
+      session: { store: path.join(home, "sessions.json") },
+    } as OpenClawConfig);
+
+    const reply = await getReplyFromConfig(
+      buildGetReplyCtx({
+        Provider: "feishu",
+        Surface: "feishu",
+        Body: "/id",
+        BodyForAgent: "/id",
+        RawBody: "/id",
+        CommandBody: "/id",
+        BodyForCommands: "/id",
+        CommandAuthorized: true,
+        CommandTurn: {
+          kind: "text-slash",
+          source: "text",
+          authorized: true,
+          body: "/id",
+        },
+        SenderId: "ou_test_sender",
+        SessionKey: "agent:yuantai:feishu:dm:ou-user",
+      }),
+      undefined,
+      cfg,
+    );
+
+    if (!reply || Array.isArray(reply) || typeof reply.text !== "string") {
+      throw new Error("expected whoami reply text");
+    }
+    expect(reply.text).toContain("Identity");
+    expect(reply.text).toContain("Channel: feishu");
+    expect(reply.text).toContain("User id: ou_test_sender");
+    expect(getReplyPayloadMetadata(reply)?.deliverDespiteSourceReplySuppression).toBe(true);
+    expect(mocks.ensureAgentWorkspace).not.toHaveBeenCalled();
+    expect(mocks.initSessionState).not.toHaveBeenCalled();
+    expect(mocks.resolveReplyDirectives).not.toHaveBeenCalled();
+    expect(vi.mocked(runPreparedReplyMock)).not.toHaveBeenCalled();
+  });
+
   it("handles native slash directives before workspace bootstrap", async () => {
     const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-native-slash-fast-"));
     const targetSessionKey = "agent:main:telegram:123";


### PR DESCRIPTION
## Summary
- Add a strict fast path for whole-message text control commands such as `/status`, `/thinking`, `/id`, `/usage`, `/send`, and `/activation`.
- Mark Feishu/Lark whole-message text slash commands as structured text command turns so core sees `CommandTurn: text-slash` instead of an ordinary message.
- Reuse the existing status, directive, and local command handlers so these replies can return before workspace/bootstrap or Codex runtime execution.
- Keep risky or prompt-bearing commands on the normal path, including `/new`, `/reset`, `/compact`, `/model`, `/queue`, `/stop`, `/exec`, `/trace`, inline command tokens, and commands with trailing prompt text.

## Why
Feishu/Lark plain-text slash commands are not provider-native slash commands. They can arrive as authorized text command messages, and Codex/GPT-backed sessions may otherwise route local controls through the slower normal agent path. That can make `/status` or `/thinking` slow or fail to produce a visible operational reply even though they should be handled locally.

This rework is based on current `upstream/main` (`d6ed2c392c1e`) and replaces the old conflicting PR head with a narrow patch. It intentionally removes the stale job-level `NODE_OPTIONS` CI heap change and keeps the diff limited to Feishu text-command context, the safe core fast path, and focused tests.

## Review Follow-up
- Addresses ClawSweeper P1 by preserving `markCommandReplyForDelivery` on every handled fast-path reply, including text `/status`, text directive replies, text command-handler replies, native command replies, native directive replies, and inline fast-path replies.
- Removes the unrelated job-level CI heap change from the PR scope.
- Adds Feishu coverage proving whole-message text slash commands get `CommandTurn: { kind: "text-slash", source: "text" }`, while inline command tokens remain normal messages.
- Adds auto-reply coverage proving text `/status`, `/thinking`, and `/id` return before workspace/bootstrap and carry `deliverDespiteSourceReplySuppression` metadata.

## Safety
- Requires the normal text-command enablement check.
- Requires authorized senders before returning local command replies.
- Only handles single-line, whole-message commands from a small whitelist.
- Does not mark inline command tokens such as `please check /status` as text command turns.
- Falls back to the existing reply flow when any prompt text remains.

## Validation
Current-head validation on PR head `7d5fcc95ef4f`:
- `npm run format:check -- extensions/feishu/src/bot.broadcast.test.ts extensions/feishu/src/bot.test.ts extensions/feishu/src/bot.ts src/auto-reply/reply/get-reply-native-slash-fast-path.ts src/auto-reply/reply/get-reply.fast-path.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/get-reply.fast-path.test.ts src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-feishu.config.ts extensions/feishu/src/bot.broadcast.test.ts extensions/feishu/src/bot.test.ts`
- `node ../../scripts/run-vitest.mjs run --config ../../test/vitest/vitest.auto-reply-reply.config.ts reply/source-reply-delivery-mode.test.ts` from `src/auto-reply`
- `npm run check:test-types`
- `git diff --check`

## Real Behavior Proof
Behavior or issue addressed: Feishu/Lark whole-message text control commands such as `/status` should return a local operational reply instead of being routed through the slow Codex/GPT agent path and completing with no visible reply.

Real environment tested: Local macOS OpenClaw gateway started from this PR source at original proof head `c81dbf2f13c4`, OpenClaw `2026.5.22`, with the Feishu plugin loaded from `/Users/alex/Code/openclaw/extensions/feishu/index.ts`. The runtime used a real Feishu `feishu2` WebSocket account and a real p2p Feishu DM. Secrets and user/chat IDs are redacted below. After later review follow-up, this PR was rebuilt on current `upstream/main` at `d6ed2c392c1e`; the same Feishu fast-path behavior remains covered by focused current-head tests and the GitHub Real behavior proof check.

Exact steps or command run after this patch: Started a Feishu-only proof gateway from the PR source:

```sh
NODE_DISABLE_COMPILE_CACHE=1 \
OPENCLAW_CONFIG_PATH=/tmp/openclaw-pr85616-feishu2-minimal.json \
OPENCLAW_BUNDLED_PLUGINS_DIR=/Users/alex/Code/openclaw/extensions \
OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR=1 \
OPENCLAW_DISABLE_PERSISTED_PLUGIN_REGISTRY=1 \
OPENCLAW_SKIP_STARTUP_MODEL_PREWARM=1 \
OPENCLAW_GATEWAY_STARTUP_TRACE=1 \
node --import tsx src/entry.ts gateway run --bind loopback --port 18789 --force --ws-log compact --verbose
```

Then sent `/status` from the real Feishu `feishu2` DM.

Evidence after fix: Redacted runtime log excerpt from `/tmp/openclaw/openclaw-2026-05-23.log`:

```text
2026-05-23T21:49:35.639+08:00 [gateway] http server listening (1 plugin: feishu; 29.9s)
2026-05-23T21:49:39.831+08:00 [feishu] starting feishu[feishu2] (mode: websocket)
2026-05-23T21:49:56.165+08:00 [feishu] feishu[feishu2]: WebSocket client started
2026-05-23T21:49:58.334+08:00 [info]: [ '[ws]', 'ws client ready' ]
2026-05-23T21:52:22.137+08:00 [feishu] feishu[feishu2]: received message from <redacted-open-id> in <redacted-chat-id> (p2p)
2026-05-23T21:52:22.150+08:00 [feishu] feishu[feishu2]: Feishu[feishu2] DM from <redacted-open-id>: /status
2026-05-23T21:52:25.438+08:00 [feishu] feishu[feishu2]: dispatch complete (queuedFinal=true, replies=1)
```

For comparison, before this patch on installed OpenClaw `2026.5.20`, the same real Feishu2 `/status` path reached dispatch but produced no visible reply:

```text
2026-05-23T19:45:43.331+08:00 [feishu] feishu[feishu2]: Feishu[feishu2] DM from <redacted-open-id>: /status
2026-05-23T19:45:44.119+08:00 [feishu] feishu[feishu2]: dispatch complete (queuedFinal=false, replies=0)
```

Observed result after fix: The real Feishu2 `/status` DM now exits through the local control-command fast path and produces one queued final reply (`queuedFinal=true, replies=1`) instead of the previous no-reply completion (`queuedFinal=false, replies=0`).

What was not tested: This runtime proof covers the safe local text-control subset via Feishu p2p DM. It does not claim coverage for destructive/stateful commands (`/new`, `/reset`, `/compact`, `/stop`), prompt-bearing slash commands, native slash-command payloads, or group mention routing.

## Related Issues
- Related to #82356, the canonical Feishu/Lark Codex/GPT slash-command `delivered=false` report. This PR addresses the low-risk local control-command subset by returning those replies before runtime execution.
- Related to #84155, which was closed as a duplicate of #82356 and contains newer gpt-5.5 Feishu command no-response logs.
- Adjacent to #78689, but this PR does not claim to fix the broader native Codex Feishu direct-session/message-tool HTTP 400 delivery evidence.
- Adjacent to #79409, but this PR intentionally excludes stateful/destructive/complex commands such as `/compact`, `/new`, and `/stop`, so it does not close that broader authorization/command-handling issue.
