### PR TITLE
fix(auth-profiles): preserve external OAuth profiles in runtime snapshot on save (#85521)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Auth: keep runtime-only external OAuth profiles in active auth-profile snapshots after save operations while still filtering those credentials from disk. Fixes #85521. (#85618) Thanks @cobenrogers and @zhouhe-xydt.
 - Models: prune retired GitHub Copilot model rows and old Claude catalog entries below 4.6, with doctor migration to upgrade existing configs to current Claude/Copilot refs.
 - Doctor/update: recognize junction-backed source checkouts as git installs by comparing canonical paths before showing package-manager update guidance. Fixes #82215. Thanks @igormf.
 - CLI/skills: show an all-ready note with next-step commands when skill setup has no missing dependencies to install. (#85032) Thanks @aniruddhaadak80.

--- a/src/agents/auth-profiles/store.runtime-snapshot.test.ts
+++ b/src/agents/auth-profiles/store.runtime-snapshot.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AUTH_STORE_VERSION } from "./constants.js";
 import { testing as externalAuthTesting } from "./external-auth.js";
+import { resolveAuthStorePath } from "./paths.js";
 import { getRuntimeAuthProfileStoreSnapshot } from "./runtime-snapshots.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
@@ -73,11 +74,11 @@ function createStore(credential = createCredential()): AuthProfileStore {
   };
 }
 
-function createAgentDir(): string {
+function createAgentDir(agentId = "main"): string {
   const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-runtime-snapshot-"));
   tempDirs.push(stateDir);
   process.env.OPENCLAW_STATE_DIR = stateDir;
-  const agentDir = path.join(stateDir, "agents", "main", "agent");
+  const agentDir = path.join(stateDir, "agents", agentId, "agent");
   fs.mkdirSync(agentDir, { recursive: true });
   return agentDir;
 }
@@ -110,6 +111,36 @@ describe("auth profile runtime snapshots", () => {
     );
     const persisted = JSON.parse(
       fs.readFileSync(path.join(agentDir, "auth-profiles.json"), "utf8"),
+    ) as AuthProfileStore;
+    expect(persisted.profiles[PROFILE_ID]).toBeUndefined();
+  });
+
+  it("does not pin inherited main OAuth profiles in child runtime snapshots", () => {
+    const childAgentDir = createAgentDir("secondary");
+    const mainCredential = createCredential();
+    const refreshedMainCredential = {
+      ...mainCredential,
+      access: "main-refreshed-access-token",
+      refresh: "main-refreshed-refresh-token",
+      expires: mainCredential.expires + 60_000,
+    };
+    saveAuthProfileStore(createStore(mainCredential));
+    const childStore = createStore(mainCredential);
+    replaceRuntimeAuthProfileStoreSnapshots([{ agentDir: childAgentDir, store: childStore }]);
+
+    saveAuthProfileStore(childStore, childAgentDir);
+    saveAuthProfileStore(createStore(refreshedMainCredential));
+
+    expect(getRuntimeAuthProfileStoreSnapshot(childAgentDir)?.profiles[PROFILE_ID]).toBeUndefined();
+    const resolvedCredential =
+      ensureAuthProfileStoreWithoutExternalProfiles(childAgentDir).profiles[PROFILE_ID];
+    expect(resolvedCredential).toMatchObject({
+      type: "oauth",
+      access: "main-refreshed-access-token",
+      refresh: "main-refreshed-refresh-token",
+    });
+    const persisted = JSON.parse(
+      fs.readFileSync(resolveAuthStorePath(childAgentDir), "utf8"),
     ) as AuthProfileStore;
     expect(persisted.profiles[PROFILE_ID]).toBeUndefined();
   });

--- a/src/agents/auth-profiles/store.runtime-snapshot.test.ts
+++ b/src/agents/auth-profiles/store.runtime-snapshot.test.ts
@@ -1,0 +1,116 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AUTH_STORE_VERSION } from "./constants.js";
+import { testing as externalAuthTesting } from "./external-auth.js";
+import { getRuntimeAuthProfileStoreSnapshot } from "./runtime-snapshots.js";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  ensureAuthProfileStoreWithoutExternalProfiles,
+  replaceRuntimeAuthProfileStoreSnapshots,
+  saveAuthProfileStore,
+} from "./store.js";
+import type { AuthProfileStore, OAuthCredential } from "./types.js";
+
+const PROFILE_ID = "anthropic:claude-cli";
+
+const envBackup: Record<string, string | undefined> = {};
+const envKeys = ["OPENCLAW_STATE_DIR"];
+const tempDirs: string[] = [];
+
+beforeEach(() => {
+  for (const key of envKeys) {
+    envBackup[key] = process.env[key];
+  }
+  clearRuntimeAuthProfileStoreSnapshots();
+  externalAuthTesting.setResolveExternalAuthProfilesForTest(() => []);
+});
+
+afterEach(() => {
+  for (const key of envKeys) {
+    if (envBackup[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = envBackup[key];
+    }
+  }
+  externalAuthTesting.resetResolveExternalAuthProfilesForTest();
+  clearRuntimeAuthProfileStoreSnapshots();
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function createCredential(): OAuthCredential {
+  return {
+    type: "oauth",
+    provider: "anthropic",
+    access: "runtime-access-token",
+    refresh: "runtime-refresh-token",
+    expires: Date.now() + 60_000,
+    accountId: "acct-runtime",
+  };
+}
+
+function createStore(credential = createCredential()): AuthProfileStore {
+  return {
+    version: AUTH_STORE_VERSION,
+    profiles: {
+      [PROFILE_ID]: credential,
+    },
+    order: {
+      anthropic: [PROFILE_ID],
+    },
+    lastGood: {
+      anthropic: PROFILE_ID,
+    },
+    usageStats: {
+      [PROFILE_ID]: {
+        lastUsed: 1,
+      },
+    },
+  };
+}
+
+function createAgentDir(): string {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-runtime-snapshot-"));
+  tempDirs.push(stateDir);
+  process.env.OPENCLAW_STATE_DIR = stateDir;
+  const agentDir = path.join(stateDir, "agents", "main", "agent");
+  fs.mkdirSync(agentDir, { recursive: true });
+  return agentDir;
+}
+
+describe("auth profile runtime snapshots", () => {
+  it("preserves runtime-only external OAuth profiles in active snapshots after save", () => {
+    const agentDir = createAgentDir();
+    const credential = createCredential();
+    const store = createStore(credential);
+    externalAuthTesting.setResolveExternalAuthProfilesForTest(() => [
+      {
+        profileId: PROFILE_ID,
+        credential,
+        persistence: "runtime-only",
+      },
+    ]);
+    replaceRuntimeAuthProfileStoreSnapshots([{ agentDir, store }]);
+
+    saveAuthProfileStore(store, agentDir);
+
+    const runtimeCredential = getRuntimeAuthProfileStoreSnapshot(agentDir)?.profiles[PROFILE_ID];
+    expect(runtimeCredential).toMatchObject({
+      type: "oauth",
+      provider: "anthropic",
+      access: "runtime-access-token",
+      refresh: "runtime-refresh-token",
+    });
+    expect(ensureAuthProfileStoreWithoutExternalProfiles(agentDir).profiles[PROFILE_ID]).toEqual(
+      runtimeCredential,
+    );
+    const persisted = JSON.parse(
+      fs.readFileSync(path.join(agentDir, "auth-profiles.json"), "utf8"),
+    ) as AuthProfileStore;
+    expect(persisted.profiles[PROFILE_ID]).toBeUndefined();
+  });
+});

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -766,6 +766,6 @@ export function saveAuthProfileStore(
     store: localStore,
   });
   if (hasRuntimeAuthProfileStoreSnapshot(agentDir)) {
-    setRuntimeAuthProfileStoreSnapshot(localStore, agentDir);
+    setRuntimeAuthProfileStoreSnapshot(store, agentDir);
   }
 }

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -433,6 +433,49 @@ function buildLocalAuthProfileStoreForSave(params: {
   return localStore;
 }
 
+function buildRuntimeAuthProfileStoreForSave(params: {
+  store: AuthProfileStore;
+  agentDir?: string;
+}): AuthProfileStore {
+  const runtimeStore = cloneAuthProfileStore(params.store);
+  runtimeStore.profiles = Object.fromEntries(
+    Object.entries(runtimeStore.profiles).filter(
+      ([profileId, credential]) =>
+        !isInheritedMainOAuthCredential({
+          agentDir: params.agentDir,
+          profileId,
+          credential,
+        }),
+    ),
+  );
+  const keptProfileIds = new Set(Object.keys(runtimeStore.profiles));
+  runtimeStore.order = runtimeStore.order
+    ? Object.fromEntries(
+        Object.entries(runtimeStore.order)
+          .map(([provider, profileIds]) => [
+            provider,
+            profileIds.filter((profileId) => keptProfileIds.has(profileId)),
+          ])
+          .filter(([, profileIds]) => profileIds.length > 0),
+      )
+    : undefined;
+  runtimeStore.lastGood = runtimeStore.lastGood
+    ? Object.fromEntries(
+        Object.entries(runtimeStore.lastGood).filter(([, profileId]) =>
+          keptProfileIds.has(profileId),
+        ),
+      )
+    : undefined;
+  runtimeStore.usageStats = runtimeStore.usageStats
+    ? Object.fromEntries(
+        Object.entries(runtimeStore.usageStats).filter(([profileId]) =>
+          keptProfileIds.has(profileId),
+        ),
+      )
+    : undefined;
+  return runtimeStore;
+}
+
 export async function updateAuthProfileStoreWithLock(params: {
   agentDir?: string;
   saveOptions?: SaveAuthProfileStoreOptions;
@@ -766,6 +809,9 @@ export function saveAuthProfileStore(
     store: localStore,
   });
   if (hasRuntimeAuthProfileStoreSnapshot(agentDir)) {
-    setRuntimeAuthProfileStoreSnapshot(store, agentDir);
+    setRuntimeAuthProfileStoreSnapshot(
+      buildRuntimeAuthProfileStoreForSave({ store, agentDir }),
+      agentDir,
+    );
   }
 }


### PR DESCRIPTION
## Summary

Fixes `saveAuthProfileStore` overwriting an active runtime auth-profile snapshot with the disk-filtered view. Runtime-only external CLI OAuth profiles stay in memory for the running gateway, while inherited main-store OAuth credentials are still removed from child snapshots so refreshed main credentials are not shadowed.

Fixes #85521.

## Changes

- Preserve runtime-only external OAuth profiles when refreshing an existing runtime snapshot after save.
- Keep disk persistence filtering unchanged for external runtime credentials.
- Keep inherited main OAuth profiles out of child runtime snapshots.
- Add regression coverage for both runtime-only external profiles and inherited-main refresh behavior.

## Verification

Behavior addressed: `saveAuthProfileStore` no longer drops runtime-only external CLI OAuth profiles from active in-process snapshots.
Real environment tested: Local source checkout, macOS, Node 24.15.0 through mise.
Exact steps or command run after this patch:
  - `mise exec node@24 -- pnpm format:check src/agents/auth-profiles/store.runtime-snapshot.test.ts src/agents/auth-profiles/store.ts CHANGELOG.md`
  - `mise exec node@24 -- node scripts/run-vitest.mjs --project agents-core src/agents/auth-profiles/store.runtime-snapshot.test.ts src/agents/auth-profiles/store.sidecar-runtime-defaults.test.ts`
  - `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
Evidence after fix: format check passed; auth-profile tests passed 6 tests across 2 files; autoreview clean with no accepted/actionable findings.
Observed result after fix: Runtime snapshots retain runtime-only external OAuth profiles after save, persisted `auth-profiles.json` still omits them, and child snapshots do not pin inherited main OAuth credentials.
What was not tested: Live gateway reload with a real Claude CLI OAuth credential.
