### PR TITLE
fix(status): show configured cost for aws-sdk models

### DIFF
--- a/docs/reference/api-usage-costs.md
+++ b/docs/reference/api-usage-costs.md
@@ -15,7 +15,9 @@ OpenClaw features that can generate provider usage or paid API calls.
 **Per-session cost snapshot**
 
 - `/status` shows the current session model, context usage, and last response tokens.
-- If the model uses **API-key auth**, `/status` also shows **estimated cost** for the last reply.
+- If OpenClaw has usage metadata and local pricing for the active model,
+  `/status` also shows **estimated cost** for the last reply. This can include
+  explicitly priced non-API-key providers such as Bedrock `aws-sdk` models.
 - If live session metadata is sparse, `/status` can recover token/cache
   counters and the active runtime model label from the latest transcript usage
   entry. Existing nonzero live values still take precedence, and prompt-sized
@@ -23,8 +25,12 @@ OpenClaw features that can generate provider usage or paid API calls.
 
 **Per-message cost footer**
 
-- `/usage full` appends a usage footer to every reply, including **estimated cost** (API-key only).
-- `/usage tokens` shows tokens only; subscription-style OAuth/token and CLI flows hide dollar cost.
+- `/usage full` appends a usage footer to every reply, including **estimated cost**
+  when local pricing is configured for the active model and usage metadata is
+  available.
+- `/usage tokens` shows tokens only; subscription-style OAuth/token and CLI flows
+  still show tokens only unless that runtime supplies compatible usage metadata
+  and an explicit local price is configured.
 - Gemini CLI note: when the CLI returns JSON output, OpenClaw reads usage from
   `stats`, normalizes `stats.cached` into `cacheRead`, and derives input tokens
   from `stats.input_tokens - stats.cached` when needed.

--- a/docs/reference/token-use.md
+++ b/docs/reference/token-use.md
@@ -66,10 +66,12 @@ For a practical breakdown (per injected file, tools, skills, and system prompt s
 Use these in chat:
 
 - `/status` → **emoji-rich status card** with the session model, context usage,
-  last response input/output tokens, and **estimated cost** (API key only).
+  last response input/output tokens, and **estimated cost** when local pricing is
+  configured for the active model.
 - `/usage off|tokens|full` → appends a **per-response usage footer** to every reply.
   - Persists per session (stored as `responseUsage`).
-  - OAuth auth **hides cost** (tokens only).
+  - `/usage full` shows estimated cost only when OpenClaw has usage metadata and
+    local pricing for the active model. Otherwise it shows tokens only.
 - `/usage cost` → shows a local cost summary from OpenClaw session logs.
 
 Other surfaces:
@@ -119,8 +121,10 @@ models.providers.<provider>.models[].cost
 ```
 
 These are **USD per 1M tokens** for `input`, `output`, `cacheRead`, and
-`cacheWrite`. If pricing is missing, OpenClaw shows tokens only. OAuth tokens
-never show dollar cost.
+`cacheWrite`. If pricing is missing, OpenClaw shows tokens only. Cost display is
+not limited to API-key auth: non-API-key providers such as `aws-sdk` can show
+estimated cost when their configured model entry includes local pricing and the
+provider returns usage metadata.
 
 After sidecars and channels reach the Gateway ready path, OpenClaw starts an
 optional background pricing bootstrap for configured model refs that do not

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -2493,7 +2493,13 @@ describe("runReplyAgent fallback reasoning tags", () => {
 });
 
 describe("runReplyAgent response usage footer", () => {
-  function createRun(params: { responseUsage: "tokens" | "full"; sessionKey: string }) {
+  function createRun(params: {
+    responseUsage: "tokens" | "full";
+    sessionKey: string;
+    config?: unknown;
+    provider?: string;
+    model?: string;
+  }) {
     const typing = createMockTypingController();
     const sessionCtx = {
       Provider: "whatsapp",
@@ -2521,10 +2527,10 @@ describe("runReplyAgent response usage footer", () => {
         messageProvider: "whatsapp",
         sessionFile: "/tmp/session.jsonl",
         workspaceDir: "/tmp",
-        config: createCliBackendTestConfig(),
+        config: params.config ?? createCliBackendTestConfig(),
         skillsSnapshot: {},
-        provider: "anthropic",
-        model: "claude",
+        provider: params.provider ?? "anthropic",
+        model: params.model ?? "claude",
         thinkLevel: "low",
         verboseLevel: "off",
         elevatedLevel: "off",
@@ -2602,6 +2608,55 @@ describe("runReplyAgent response usage footer", () => {
     expect(text).toContain("cache 4 cached / 2 new");
     expect(text).not.toContain("· session ");
   });
+
+  it("shows configured costs for aws-sdk providers when responseUsage=full", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {
+        agentMeta: {
+          provider: "amazon-bedrock",
+          model: "us.anthropic.claude-sonnet-4-6",
+          usage: { input: 1_000, output: 2_000, cacheRead: 500, cacheWrite: 2_000 },
+        },
+      },
+    });
+
+    const sessionKey = "agent:main:whatsapp:dm:+1000";
+    const res = await createRun({
+      responseUsage: "full",
+      sessionKey,
+      provider: "amazon-bedrock",
+      model: "us.anthropic.claude-sonnet-4-6",
+      config: {
+        models: {
+          providers: {
+            "amazon-bedrock": {
+              auth: "aws-sdk",
+              models: [
+                {
+                  id: "us.anthropic.claude-sonnet-4-6",
+                  cost: {
+                    input: 3,
+                    output: 15,
+                    cacheRead: 0.3,
+                    cacheWrite: 3.75,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    const payload = Array.isArray(res) ? res[0] : res;
+    const text = payload?.text ?? "";
+
+    expect(text).toContain("Usage: 1.0k in / 2.0k out");
+    expect(text).toContain("cache 500 cached / 2.0k new");
+    expect(text).toContain("est $0.04");
+    expect(text).toContain(`· session \`${sessionKey}\``);
+  });
+
 });
 
 describe("runReplyAgent transient HTTP retry", () => {

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -2588,24 +2588,45 @@ describe("runReplyAgent response usage footer", () => {
     expect(text).toContain(`· session \`${sessionKey}\``);
   });
 
-  it("does not append session key when responseUsage=tokens", async () => {
+  it("does not append session key or cost when responseUsage=tokens", async () => {
     runEmbeddedPiAgentMock.mockResolvedValueOnce({
       payloads: [{ text: "ok" }],
       meta: {
         agentMeta: {
-          provider: "anthropic",
-          model: "claude",
+          provider: "amazon-bedrock",
+          model: "us.anthropic.claude-sonnet-4-6",
           usage: { input: 12, output: 3, cacheRead: 4, cacheWrite: 2 },
         },
       },
     });
 
     const sessionKey = "agent:main:whatsapp:dm:+1000";
-    const res = await createRun({ responseUsage: "tokens", sessionKey });
+    const res = await createRun({
+      responseUsage: "tokens",
+      sessionKey,
+      provider: "amazon-bedrock",
+      model: "us.anthropic.claude-sonnet-4-6",
+      config: {
+        models: {
+          providers: {
+            "amazon-bedrock": {
+              auth: "aws-sdk",
+              models: [
+                {
+                  id: "us.anthropic.claude-sonnet-4-6",
+                  cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
     const payload = Array.isArray(res) ? res[0] : res;
     const text = payload?.text ?? "";
     expect(text).toContain("Usage:");
     expect(text).toContain("cache 4 cached / 2 new");
+    expect(text).not.toContain("est $");
     expect(text).not.toContain("· session ");
   });
 
@@ -2656,7 +2677,6 @@ describe("runReplyAgent response usage footer", () => {
     expect(text).toContain("est $0.04");
     expect(text).toContain(`· session \`${sessionKey}\``);
   });
-
 });
 
 describe("runReplyAgent transient HTTP retry", () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1866,7 +1866,7 @@ export async function runReplyAgent(params: {
         config: cfg,
         allowPluginNormalization: false,
       });
-      const showCost = costConfig !== undefined;
+      const showCost = responseUsageMode === "full" && costConfig !== undefined;
       let formatted = formatResponseUsageLine({
         usage,
         showCost,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1860,17 +1860,13 @@ export async function runReplyAgent(params: {
       (sessionKey ? activeSessionStore?.[sessionKey]?.responseUsage : undefined);
     const responseUsageMode = resolveResponseUsageMode(responseUsageRaw);
     if (responseUsageMode !== "off" && hasNonzeroUsage(usage)) {
-      const authMode = resolveModelAuthMode(providerUsed, cfg, undefined, {
-        workspaceDir: followupRun.run.workspaceDir,
+      const costConfig = resolveModelCostConfig({
+        provider: providerUsed,
+        model: modelUsed,
+        config: cfg,
+        allowPluginNormalization: false,
       });
-      const showCost = authMode === "api-key";
-      const costConfig = showCost
-        ? resolveModelCostConfig({
-            provider: providerUsed,
-            model: modelUsed,
-            config: cfg,
-          })
-        : undefined;
+      const showCost = costConfig !== undefined;
       let formatted = formatResponseUsageLine({
         usage,
         showCost,

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -105,6 +105,57 @@ describe("buildStatusMessage", () => {
     expect(normalized).toContain("Queue: collect");
   });
 
+  it("shows configured model costs for aws-sdk providers", () => {
+    const text = buildStatusMessage({
+      config: {
+        models: {
+          providers: {
+            "amazon-bedrock": {
+              auth: "aws-sdk",
+              models: [
+                {
+                  id: "us.anthropic.claude-sonnet-4-6",
+                  cost: {
+                    input: 3,
+                    output: 15,
+                    cacheRead: 0.3,
+                    cacheWrite: 3.75,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      agent: {
+        model: "amazon-bedrock/us.anthropic.claude-sonnet-4-6",
+        contextTokens: 200_000,
+      },
+      sessionEntry: {
+        sessionId: "bedrock-session",
+        updatedAt: 0,
+        inputTokens: 1_000,
+        outputTokens: 2_000,
+        cacheRead: 500,
+        cacheWrite: 2_000,
+        totalTokens: 5_500,
+        contextTokens: 200_000,
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "aws-sdk",
+      activeModelAuth: "aws-sdk",
+      now: 10 * 60_000,
+    });
+    const normalized = normalizeTestText(text);
+
+    expect(normalized).toContain("Model: amazon-bedrock/us.anthropic.claude-sonnet-4-6");
+    expect(normalized).toContain("aws-sdk");
+    expect(normalized).toContain("Tokens: 1.0k in / 2.0k out");
+    expect(normalized).toContain("Cost: $0.04");
+  });
+
   it("does not render stale totalTokens as current context usage", () => {
     const text = buildStatusMessage({
       agent: {
@@ -1499,7 +1550,7 @@ describe("buildStatusMessage", () => {
     expect(lines[contextIndex + 1]).toContain("Usage: Claude 80% left (5h)");
   });
 
-  it("hides cost when not using an API key", () => {
+  it("shows configured model costs when not using an API key", () => {
     const text = buildStatusMessage({
       config: {
         models: {
@@ -1528,7 +1579,7 @@ describe("buildStatusMessage", () => {
       modelAuth: "oauth",
     });
 
-    expect(text).not.toContain("💵 Cost:");
+    expect(text).toContain("💵 Cost: $0.0000");
   });
 
   function writeTranscriptUsageLog(params: {

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -897,31 +897,31 @@ export function buildStatusMessage(args: StatusArgs): string {
     activeModelRef: activeModelLabel,
     state: entry,
   });
-  const effectiveCostAuthMode = fallbackState.active
-    ? activeAuthMode
-    : (selectedAuthMode ?? activeAuthMode);
-  const showCost = effectiveCostAuthMode === "api-key" || effectiveCostAuthMode === "mixed";
-  const hasUsage = typeof inputTokens === "number" || typeof outputTokens === "number";
-  const costConfig =
-    showCost && hasUsage
-      ? resolveModelCostConfig({
-          provider: activeProvider,
-          model: activeModel,
-          config: args.config,
-          allowPluginNormalization: false,
-        })
-      : undefined;
-  const cost =
-    showCost && hasUsage
-      ? estimateUsageCost({
-          usage: {
-            input: inputTokens ?? undefined,
-            output: outputTokens ?? undefined,
-          },
-          cost: costConfig,
-        })
-      : undefined;
-  const costLabel = showCost && hasUsage ? formatUsd(cost) : undefined;
+  const hasUsage =
+    typeof inputTokens === "number" ||
+    typeof outputTokens === "number" ||
+    typeof cacheRead === "number" ||
+    typeof cacheWrite === "number";
+  const costConfig = hasUsage
+    ? resolveModelCostConfig({
+        provider: activeProvider,
+        model: activeModel,
+        config: args.config,
+        allowPluginNormalization: false,
+      })
+    : undefined;
+  const cost = hasUsage
+    ? estimateUsageCost({
+        usage: {
+          input: inputTokens ?? undefined,
+          output: outputTokens ?? undefined,
+          cacheRead: cacheRead ?? undefined,
+          cacheWrite: cacheWrite ?? undefined,
+        },
+        cost: costConfig,
+      })
+    : undefined;
+  const costLabel = hasUsage ? formatUsd(cost) : undefined;
 
   const selectedAuthLabel = selectedAuthLabelValue ? ` · 🔑 ${selectedAuthLabelValue}` : "";
   const modelNote = channelModelNote ? ` · ${channelModelNote}` : "";


### PR DESCRIPTION
## Summary

- Show configured model costs in `/status` and full response-usage footers even when the provider auth mode is not `api-key`.
- Include cache read/write tokens in the status cost estimate.
- Preserve `/usage tokens` as token-only output, even when pricing metadata exists.
- Refresh the relevant docs and regression coverage.

## Real behavior proof

Behavior addressed: configured pricing for AWS SDK / Bedrock-style providers was hidden because cost display was gated on auth mode instead of configured model pricing and actual usage.
Real environment tested: local OpenClaw source checkout on macOS, Node/pnpm repo runtime, with a temporary `OPENCLAW_HOME` and the production pricing/usage-format helpers exercised directly through `node --import tsx`.
Exact steps or command run after this patch: `OPENCLAW_HOME=$(mktemp -d) node --import tsx --input-type=module` probe importing `src/utils/usage-format.ts` and `src/auto-reply/reply/agent-runner-usage-line.ts`, resolving an `aws-sdk` Bedrock model cost from config, and printing status/full/tokens-mode outputs.
Evidence after fix:
```json
{
  "resolvedAwsSdkCostConfig": {
    "input": 3,
    "output": 15,
    "cacheRead": 0.3,
    "cacheWrite": 3.75
  },
  "statusCostLabelFromConfiguredAwsSdkCost": "$0.04",
  "responseUsageTokens": "Usage: 12 in / 3 out · cache 4 cached / 2 new",
  "responseUsageFull": "Usage: 1.0k in / 2.0k out · cache 500 cached / 2.0k new · est $0.04"
}
```
Observed result after fix: Bedrock-style configured pricing resolves and formats as `$0.04` when a full cost view is requested, while `/usage tokens` style output remains token-only with no estimated dollar suffix.
What was not tested: no live Bedrock request with AWS credentials; the bug is in local formatting and pricing resolution after usage is already recorded.

## Verification

- `pnpm test src/auto-reply/status.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
- `git diff --check`
- Auto Review: clean after fixing the `/usage tokens` cost regression caught in review.
