### PR TITLE
Clarify landable bug sweep skill credential boundaries

### DIFF
--- a/.agents/skills/openclaw-landable-bug-sweep/SKILL.md
+++ b/.agents/skills/openclaw-landable-bug-sweep/SKILL.md
@@ -56,7 +56,7 @@ Reject:
 - feature requests, new knobs, migrations, release work, workflow policy, support
 - plugin SDK/API boundary changes, including compatibility shims, new SDK methods, SDK exports, or plugin-facing channel/provider seams
 - auth/security boundary changes unless explicitly assigned
-- bugs needing live credentials that are unavailable
+- bugs requiring unavailable external accounts, restricted external services, or privileged runtime access
 - PRs with red CI unless you fix, rebase, push, and recheck them green
 - PRs you only reviewed locally but did not refresh/push/check live
 - fixes whose clean shape is a larger architecture move
@@ -123,9 +123,9 @@ What was not tested:
 - If maintainer cannot push to contributor branch: create own branch/PR, preserve useful commits or credit.
 - If CI turns red after local proof, treat that as normal work: inspect the failing job, fix or reject, rerun, and only count the PR once green.
 
-## Output Ledger
+## Output Tracking Log
 
-Maintain a running ledger:
+Maintain a running tracking log:
 
 ```text
 accepted:


### PR DESCRIPTION
Clarifies local bug sweep workflow wording to avoid implying browser, wallet, SSH, credential-store, or secret access. This targets a SafeOps reviewed-risk false positive in the landable bug sweep skill.