### PR TITLE
fix(codex): clarify sandbox http envelope errors

### DIFF
--- a/extensions/codex/src/app-server/sandbox-exec-server.http.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.http.test.ts
@@ -64,6 +64,58 @@ describe("OpenClaw Codex sandbox exec-server HTTP", () => {
     socket.close();
   });
 
+  it("reports empty sandbox HTTP response envelopes", async () => {
+    const runShellCommand = vi.fn(async () => ({
+      stdout: Buffer.alloc(0),
+      stderr: Buffer.alloc(0),
+      code: 0,
+    }));
+    const sandbox = createSandboxContext({ runShellCommand });
+    const client = createClient();
+    await ensureCodexSandboxExecServerEnvironment({
+      client: client as never,
+      sandbox,
+    });
+    const socket = await openSocket(execServerUrlFromClient(client));
+    await rpc(socket, "initialize", { clientName: "test" });
+    socket.send(JSON.stringify({ method: "initialized" }));
+
+    await expect(
+      rpc(socket, "http/request", {
+        requestId: "http-empty",
+        method: "GET",
+        url: "https://example.test/empty",
+      }),
+    ).rejects.toThrow("sandbox http/request returned an empty response envelope");
+    socket.close();
+  });
+
+  it("reports invalid sandbox HTTP JSON response envelopes", async () => {
+    const runShellCommand = vi.fn(async () => ({
+      stdout: Buffer.from("not-json"),
+      stderr: Buffer.alloc(0),
+      code: 0,
+    }));
+    const sandbox = createSandboxContext({ runShellCommand });
+    const client = createClient();
+    await ensureCodexSandboxExecServerEnvironment({
+      client: client as never,
+      sandbox,
+    });
+    const socket = await openSocket(execServerUrlFromClient(client));
+    await rpc(socket, "initialize", { clientName: "test" });
+    socket.send(JSON.stringify({ method: "initialized" }));
+
+    await expect(
+      rpc(socket, "http/request", {
+        requestId: "http-invalid-json",
+        method: "GET",
+        url: "https://example.test/invalid-json",
+      }),
+    ).rejects.toThrow("sandbox http/request returned an invalid JSON response envelope");
+    socket.close();
+  });
+
   it("streams HTTP response body deltas from the sandbox backend", async () => {
     const headerLine = JSON.stringify({
       type: "headers",

--- a/extensions/codex/src/app-server/sandbox-exec-server/http.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/http.ts
@@ -58,11 +58,20 @@ async function runSandboxHttpRequest(
     const stderr = result.stderr.toString("utf8").trim();
     throw new Error(stderr || `sandbox http/request failed with code ${result.code}`);
   }
-  const parsed = JSON.parse(result.stdout.toString("utf8")) as {
+  const stdout = result.stdout.toString("utf8").trim();
+  if (!stdout) {
+    throw new Error("sandbox http/request returned an empty response envelope");
+  }
+  let parsed: {
     status?: unknown;
     headers?: unknown;
     bodyBase64?: unknown;
   };
+  try {
+    parsed = JSON.parse(stdout) as typeof parsed;
+  } catch {
+    throw new Error("sandbox http/request returned an invalid JSON response envelope");
+  }
   if (typeof parsed.status !== "number" || !Array.isArray(parsed.headers)) {
     throw new Error("sandbox http/request returned an invalid response envelope");
   }


### PR DESCRIPTION
## Summary

- Replace raw JSON parse failures for Codex sandbox `http/request` responses with stable OpenClaw error messages.
- Distinguish empty stdout from non-JSON stdout before validating the response envelope shape.
- Add regression coverage for both malformed backend-output cases.

## Tests

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/sandbox-exec-server.http.test.ts`
- `node --import tsx .tmp-codex-http-empty-proof.ts`
- `git diff --check`

## Real behavior proof

Behavior addressed: Codex sandbox `http/request` now reports a stable OpenClaw error when the sandbox backend exits successfully but returns an empty stdout response envelope, instead of surfacing Node's raw `Unexpected end of JSON input` parser error.
Real environment tested: Local macOS OpenClaw checkout on this branch, invoking the real Codex sandbox exec-server `httpRequest` runtime entrypoint with a stub sandbox backend that returns exit code 0 and empty stdout.
Exact steps or command run after this patch: `node --import tsx .tmp-codex-http-empty-proof.ts`.
Evidence after fix: Copied terminal output from the runtime command:

```json
{
  "message": "sandbox http/request returned an empty response envelope"
}
```

Observed result after fix: The runtime command exited 0 and the real `httpRequest` entrypoint rejected with the new stable empty-envelope message.
What was not tested: No live Codex hosted sandbox was used; the proof isolates the backend result and the targeted Vitest file covers normal HTTP routing, streaming behavior, empty stdout, and invalid JSON stdout.
