### PR TITLE
fix(diagnostic): require stale progress before classifying terminal embedded runs as stalled (#85532)

### DIFF
--- a/src/logging/diagnostic-session-attention.test.ts
+++ b/src/logging/diagnostic-session-attention.test.ts
@@ -60,13 +60,29 @@ describe("classifySessionAttention", () => {
       queueDepth: 1,
       activity: {
         activeWorkKind: "embedded_run" as const,
-        lastProgressAgeMs: 100,
+        lastProgressAgeMs: 31_000,
         lastProgressReason: "codex_app_server:notification:rawResponseItem/completed",
       },
       expected: {
         eventType: "session.stalled",
         reason: "queued_behind_terminal_active_work",
         classification: "stalled_agent_run",
+        activeWorkKind: "embedded_run",
+        recoveryEligible: false,
+      },
+    },
+    {
+      name: "queued behind terminal embedded progress still making progress",
+      queueDepth: 1,
+      activity: {
+        activeWorkKind: "embedded_run" as const,
+        lastProgressAgeMs: 100,
+        lastProgressReason: "codex_app_server:notification:rawResponseItem/completed",
+      },
+      expected: {
+        eventType: "session.long_running",
+        reason: "queued_behind_active_work",
+        classification: "long_running",
         activeWorkKind: "embedded_run",
         recoveryEligible: false,
       },

--- a/src/logging/diagnostic-session-attention.ts
+++ b/src/logging/diagnostic-session-attention.ts
@@ -46,6 +46,7 @@ export function classifySessionAttention(params: {
     if (
       params.queueDepth > 0 &&
       params.activity.activeWorkKind === "embedded_run" &&
+      (params.activity.lastProgressAgeMs ?? 0) > params.staleMs &&
       isTerminalDiagnosticProgressReason(params.activity.lastProgressReason)
     ) {
       return {


### PR DESCRIPTION
## Summary

Fixes diagnostic recovery prematurely aborting active embedded Codex runs when the app-server emits terminal-looking progress notifications (e.g., `rawResponseItem/completed`) while the run is still producing real progress.

## Changes

- `src/logging/diagnostic-session-attention.ts`: Add `lastProgressAgeMs > staleMs` guard to the `queued_behind_terminal_active_work` stall classification, so terminal-looking progress only triggers stall detection when the run has actually gone stale.
- `src/logging/diagnostic-session-attention.test.ts`: Update existing test to use stale progress age; add regression test verifying active embedded runs with recent terminal-looking progress are not classified as stalled.

## Verification

Behavior addressed: Prevent diagnostic recovery from aborting active embedded runs on terminal-looking progress events
Real environment tested: Local source checkout, Linux, Node 22
Exact steps or command run after this patch:
  - pnpm test src/logging/diagnostic-session-attention.test.ts
  - pnpm format:check src/logging/diagnostic-session-attention.ts src/logging/diagnostic-session-attention.test.ts
Evidence after fix: 8 tests pass, 0 failures; formatting check passes
Observed result after fix: Embedded runs with recent terminal-looking progress are classified as long_running instead of stalled_agent_run
What was not tested: Live Codex embedded run with actual terminal progress alternation

Fixes #85532