### PR TITLE
fix(cli-output): ignore cumulative usage from result events in stream-json parser (#85573)

### DIFF
--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -322,6 +322,38 @@ describe("parseCliJsonl", () => {
     });
   });
 
+  it("does not let cumulative Claude result usage overwrite assistant usage", () => {
+    const result = parseCliJsonl(
+      [
+        JSON.stringify({ type: "init", session_id: "session-stream" }),
+        JSON.stringify({
+          type: "assistant",
+          usage: { input_tokens: 10, output_tokens: 5, cache_read_input_tokens: 100 },
+        }),
+        JSON.stringify({
+          type: "result",
+          session_id: "session-stream",
+          result: "done",
+          usage: { input_tokens: 30, output_tokens: 15, cache_read_input_tokens: 300 },
+        }),
+      ].join("\n"),
+      {
+        command: "claude",
+        output: "jsonl",
+        sessionIdFields: ["session_id"],
+      },
+      "claude-cli",
+    );
+
+    expect(result?.usage).toEqual({
+      input: 10,
+      output: 5,
+      cacheRead: 100,
+      cacheWrite: undefined,
+      total: undefined,
+    });
+  });
+
   it("preserves Claude session metadata even when the final result text is empty", () => {
     const result = parseCliJsonl(
       [

--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -328,7 +328,17 @@ describe("parseCliJsonl", () => {
         JSON.stringify({ type: "init", session_id: "session-stream" }),
         JSON.stringify({
           type: "assistant",
-          usage: { input_tokens: 10, output_tokens: 5, cache_read_input_tokens: 100 },
+          message: {
+            id: "msg-1",
+            usage: { input_tokens: 10, output_tokens: 5, cache_read_input_tokens: 100 },
+          },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            id: "msg-2",
+            usage: { input_tokens: 11, output_tokens: 6, cache_read_input_tokens: 125 },
+          },
         }),
         JSON.stringify({
           type: "result",
@@ -346,9 +356,9 @@ describe("parseCliJsonl", () => {
     );
 
     expect(result?.usage).toEqual({
-      input: 10,
-      output: 5,
-      cacheRead: 100,
+      input: 11,
+      output: 6,
+      cacheRead: 125,
       cacheWrite: undefined,
       total: undefined,
     });
@@ -497,7 +507,17 @@ describe("createCliJsonlStreamingParser", () => {
         JSON.stringify({ type: "init", session_id: "session-stream" }),
         JSON.stringify({
           type: "assistant",
-          usage: { input_tokens: 10, output_tokens: 5, cache_read_input_tokens: 100 },
+          message: {
+            id: "msg-1",
+            usage: { input_tokens: 10, output_tokens: 5, cache_read_input_tokens: 100 },
+          },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            id: "msg-2",
+            usage: { input_tokens: 11, output_tokens: 6, cache_read_input_tokens: 125 },
+          },
         }),
         JSON.stringify({
           type: "result",
@@ -510,9 +530,9 @@ describe("createCliJsonlStreamingParser", () => {
 
     const output = parser.getOutput();
     expect(output?.usage).toEqual({
-      input: 10,
-      output: 5,
-      cacheRead: 100,
+      input: 11,
+      output: 6,
+      cacheRead: 125,
       cacheWrite: undefined,
       total: undefined,
     });

--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -447,4 +447,42 @@ describe("createCliJsonlStreamingParser", () => {
       { text: "hello", delta: "hello", sessionId: "session-stream", usage: undefined },
     ]);
   });
+
+  it("ignores cumulative usage from result events to avoid cache_read inflation", () => {
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "local-cli",
+      onAssistantDelta: () => {},
+    });
+
+    parser.push(
+      [
+        JSON.stringify({ type: "init", session_id: "session-stream" }),
+        JSON.stringify({
+          type: "assistant",
+          usage: { input_tokens: 10, output_tokens: 5, cache_read_input_tokens: 100 },
+        }),
+        JSON.stringify({
+          type: "result",
+          result: "done",
+          usage: { input_tokens: 30, output_tokens: 15, cache_read_input_tokens: 300 },
+        }),
+      ].join("\n"),
+    );
+    parser.finish();
+
+    const output = parser.getOutput();
+    expect(output?.usage).toEqual({
+      input: 10,
+      output: 5,
+      cacheRead: 100,
+      cacheWrite: undefined,
+      total: undefined,
+    });
+  });
 });

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -39,6 +39,14 @@ function usesClaudeStreamJsonDialect(params: {
   );
 }
 
+function shouldReadCliJsonlUsage(params: {
+  backend: CliBackendConfig;
+  providerId: string;
+  parsed: Record<string, unknown>;
+}): boolean {
+  return !(usesClaudeStreamJsonDialect(params) && params.parsed.type === "result");
+}
+
 function extractJsonObjectCandidates(raw: string): string[] {
   return extractBalancedJsonFragments(raw, { openers: ["{"] }).map((fragment) => fragment.json);
 }
@@ -396,10 +404,17 @@ export function createCliJsonlStreamingParser(params: {
     if (!sessionId && typeof parsed.thread_id === "string") {
       sessionId = parsed.thread_id.trim();
     }
-    // Only read usage from non-result events. Claude-cli's result event
-    // reports cumulative cache_read across all tool sub-calls, while
-    // assistant events carry the per-call usage we need.
-    if (parsed.type !== "result") {
+    // Claude stream-json result events report cumulative cache_read across all
+    // tool sub-calls. Keep them only as a fallback when no assistant usage
+    // arrived, but do not let them overwrite per-call assistant usage.
+    if (
+      shouldReadCliJsonlUsage({
+        backend: params.backend,
+        providerId: params.providerId,
+        parsed,
+      }) ||
+      !usage
+    ) {
       usage = readCliUsage(parsed) ?? usage;
     }
 
@@ -510,7 +525,9 @@ export function parseCliJsonl(
       if (!sessionId && typeof parsed.thread_id === "string") {
         sessionId = parsed.thread_id.trim();
       }
-      usage = readCliUsage(parsed) ?? usage;
+      if (shouldReadCliJsonlUsage({ backend, providerId, parsed }) || !usage) {
+        usage = readCliUsage(parsed) ?? usage;
+      }
 
       const claudeResult = parseClaudeCliJsonlResult({
         backend,

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -39,12 +39,12 @@ function usesClaudeStreamJsonDialect(params: {
   );
 }
 
-function shouldReadCliJsonlUsage(params: {
+function isClaudeStreamJsonResult(params: {
   backend: CliBackendConfig;
   providerId: string;
   parsed: Record<string, unknown>;
 }): boolean {
-  return !(usesClaudeStreamJsonDialect(params) && params.parsed.type === "result");
+  return usesClaudeStreamJsonDialect(params) && params.parsed.type === "result";
 }
 
 function extractJsonObjectCandidates(raw: string): string[] {
@@ -155,6 +155,12 @@ function toCliUsage(raw: Record<string, unknown>): CliUsage | undefined {
 }
 
 function readCliUsage(parsed: Record<string, unknown>): CliUsage | undefined {
+  if (isRecord(parsed.message) && isRecord(parsed.message.usage)) {
+    const usage = toCliUsage(parsed.message.usage);
+    if (usage) {
+      return usage;
+    }
+  }
   if (isRecord(parsed.usage)) {
     const usage = toCliUsage(parsed.usage);
     if (usage) {
@@ -404,18 +410,15 @@ export function createCliJsonlStreamingParser(params: {
     if (!sessionId && typeof parsed.thread_id === "string") {
       sessionId = parsed.thread_id.trim();
     }
-    // Claude stream-json result events report cumulative cache_read across all
-    // tool sub-calls. Keep them only as a fallback when no assistant usage
-    // arrived, but do not let them overwrite per-call assistant usage.
-    if (
-      shouldReadCliJsonlUsage({
+    const nextUsage = readCliUsage(parsed);
+    const shouldUseUsage =
+      !isClaudeStreamJsonResult({
         backend: params.backend,
         providerId: params.providerId,
         parsed,
-      }) ||
-      !usage
-    ) {
-      usage = readCliUsage(parsed) ?? usage;
+      }) || !usage;
+    if (shouldUseUsage) {
+      usage = nextUsage ?? usage;
     }
 
     const result = parseClaudeCliJsonlResult({
@@ -525,8 +528,10 @@ export function parseCliJsonl(
       if (!sessionId && typeof parsed.thread_id === "string") {
         sessionId = parsed.thread_id.trim();
       }
-      if (shouldReadCliJsonlUsage({ backend, providerId, parsed }) || !usage) {
-        usage = readCliUsage(parsed) ?? usage;
+      const nextUsage = readCliUsage(parsed);
+      const shouldUseUsage = !isClaudeStreamJsonResult({ backend, providerId, parsed }) || !usage;
+      if (shouldUseUsage) {
+        usage = nextUsage ?? usage;
       }
 
       const claudeResult = parseClaudeCliJsonlResult({

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -396,7 +396,12 @@ export function createCliJsonlStreamingParser(params: {
     if (!sessionId && typeof parsed.thread_id === "string") {
       sessionId = parsed.thread_id.trim();
     }
-    usage = readCliUsage(parsed) ?? usage;
+    // Only read usage from non-result events. Claude-cli's result event
+    // reports cumulative cache_read across all tool sub-calls, while
+    // assistant events carry the per-call usage we need.
+    if (parsed.type !== "result") {
+      usage = readCliUsage(parsed) ?? usage;
+    }
 
     const result = parseClaudeCliJsonlResult({
       backend: params.backend,


### PR DESCRIPTION
## Summary

Fixes `claude-cli` stream-json usage accounting for #85573. Claude assistant usage is emitted under `message.usage`, while the final `result.usage` is cumulative for the query; using the final result as the session snapshot can inflate `cache_read_input_tokens` on tool-heavy turns and trip the compaction gate. The parser now reads nested assistant usage and keeps result usage only as a fallback when no assistant usage arrived.

## Changes

- Read nested Claude assistant `message.usage` in the CLI JSON/JSONL usage parser.
- Preserve the latest assistant-step usage for Claude stream-json outputs instead of overwriting it with cumulative `result.usage`.
- Keep result-only usage working for outputs that do not include assistant usage.
- Add regression coverage for full-buffer JSONL parsing and the streaming parser.

## Real behavior proof

Behavior addressed: `claude-cli` stream-json result events can report cumulative usage for a query; OpenClaw needs the latest assistant-step usage as the session prompt snapshot so `cache_read_input_tokens` does not inflate `sessionEntry.totalTokens` on tool-heavy turns.

Real environment tested: Local OpenClaw checkout on macOS with live `claude` 2.1.148 stream-json output; upstream Claude Agent SDK docs also state that TypeScript assistant usage is nested at `message.message.usage` and the result message carries cumulative usage.

Exact steps or command run after this patch:

```bash
pnpm test src/agents/cli-output.test.ts
git diff --check origin/main...HEAD
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
claude -p "Use the Bash tool twice: first run pwd, then run printf ok. After both tool calls, answer exactly: done" --output-format stream-json --verbose --tools Bash --allowedTools 'Bash(pwd),Bash(printf ok)' --permission-mode bypassPermissions --max-budget-usd 0.10
claude -p "Reply exactly: done" --output-format stream-json --verbose --tools '' --max-budget-usd 0.20
```

Evidence after fix: Terminal output from the patched OpenClaw parser and the live Claude CLI runs:

```text
pnpm test src/agents/cli-output.test.ts
 Test Files  1 passed (1)
      Tests  17 passed (17)

.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
autoreview clean: no accepted/actionable findings reported

live claude stream-json run with Bash tools:
assistant message.usage: input_tokens=25 output_tokens=36 cache_creation_input_tokens=39960 cache_read_input_tokens=0
assistant message.usage: input_tokens=25 output_tokens=36 cache_creation_input_tokens=39960 cache_read_input_tokens=0
assistant message.usage: input_tokens=25 output_tokens=36 cache_creation_input_tokens=39960 cache_read_input_tokens=0
final result usage: separate cumulative result usage record

live claude stream-json run without tools:
assistant message.usage: input_tokens=25 output_tokens=1 cache_creation_input_tokens=38997 cache_read_input_tokens=0
budget-stop result usage: input_tokens=0 output_tokens=0 cache_creation_input_tokens=0 cache_read_input_tokens=0
```

Observed result after fix: `parseCliJsonl` and `createCliJsonlStreamingParser` now preserve the latest nested assistant usage and do not let Claude result usage overwrite it; result-only Claude JSONL output still returns result usage as before.

What was not tested: A live cache-hit run where the final `result.cache_read_input_tokens` is larger than the latest assistant `cache_read_input_tokens`; the reporter's live reproduction demonstrates that exact inflation case, and the regression fixture covers it with the documented stream-json shape.

## Verification

- `pnpm test src/agents/cli-output.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Fixes #85573
