### PR TITLE
fix(harness): mirror CLI-runtime short-circuit in selectAgentHarnessDecision (#85626)

### DIFF
--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -639,6 +639,15 @@ describe("selectAgentHarness", () => {
     ).toBe("codex");
   });
 
+  it("routes CLI runtimes to PI harness instead of throwing MissingAgentHarnessError", () => {
+    const harness = selectAgentHarness({
+      provider: "anthropic",
+      modelId: "sonnet-4.6",
+      config: providerRuntimeConfig("anthropic", "claude-cli"),
+    });
+    expect(harness.id).toBe("pi");
+  });
+
   it("ignores stale plugin pins during compaction when the provider no longer matches", async () => {
     registerFailingCodexHarness();
 

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -1,6 +1,8 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { isCliRuntimeAlias } from "../model-runtime-aliases.js";
+import { isCliProvider } from "../model-selection-cli.js";
 import type { CompactEmbeddedPiSessionParams } from "../pi-embedded-runner/compact.types.js";
 import type {
   EmbeddedRunAttemptParams,
@@ -68,6 +70,17 @@ type AgentHarnessSelectionDecision = {
 
 function listPluginAgentHarnesses(): AgentHarness[] {
   return listRegisteredAgentHarnesses().map((entry) => entry.harness);
+}
+
+function isCliAgentRuntime(
+  runtime: string | undefined,
+  cfg: import("../../config/types.openclaw.js").OpenClawConfig | undefined,
+): boolean {
+  const normalized = runtime?.trim();
+  if (!normalized) {
+    return false;
+  }
+  return isCliRuntimeAlias(normalized) || isCliProvider(normalized, cfg);
 }
 
 export function resolveAvailableAgentHarnessPolicy(params: {
@@ -168,6 +181,14 @@ function selectAgentHarnessDecision(params: {
           runtime: "pi",
         },
         selectedReason: "implicit_plugin_unavailable_pi",
+        candidates: listHarnessCandidates(pluginHarnesses),
+      });
+    }
+    if (isCliAgentRuntime(runtime, params.config)) {
+      return buildSelectionDecision({
+        harness: piHarness,
+        policy,
+        selectedReason: "forced_pi",
         candidates: listHarnessCandidates(pluginHarnesses),
       });
     }


### PR DESCRIPTION
## Summary

Fixes `MissingAgentHarnessError` on resumed sessions after auth/upgrade rotation. `selectAgentHarnessDecision` was missing the `isCliAgentRuntime` short-circuit that its sibling resolver `assertModelFallbackCandidateHarnessAvailable` already had.

## Changes

- `src/agents/harness/selection.ts`: Add `isCliAgentRuntime` check before throwing `MissingAgentHarnessError` for non-auto runtimes. CLI runtimes (e.g. `claude-cli`) now route to PI harness instead of failing.
- `src/agents/harness/selection.test.ts`: Add regression test verifying CLI runtimes route to PI harness.

## Verification

Behavior addressed: Prevent `MissingAgentHarnessError: claude-cli` on session resumption with stale auth bindings
Real environment tested: Local source checkout, Linux, Node 22
Exact steps or command run after this patch:
  - pnpm test src/agents/harness/selection.test.ts
  - pnpm format:check src/agents/harness/selection.ts src/agents/harness/selection.test.ts
Evidence after fix: 29 tests pass, 0 failures; formatting check passes
Observed result after fix: CLI runtimes route to PI harness instead of throwing
What was not tested: Live session resumption after auth rotation

Fixes #85626