### PR TITLE
fix(gateway): honor restart drain budget for embedded runs

### DIFF
--- a/src/cli/gateway-cli/lifecycle.runtime.ts
+++ b/src/cli/gateway-cli/lifecycle.runtime.ts
@@ -14,6 +14,7 @@ export {
 export {
   resolveGatewayRestartDeferralTimeoutMs,
   consumeGatewayRestartIntentPayloadSync,
+  consumeGatewaySigusr1RestartIntent,
   consumeGatewayRestartIntentSync,
   consumeGatewaySigusr1RestartAuthorization,
   isGatewaySigusr1RestartExternallyAllowed,

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -9,6 +9,9 @@ const acquireGatewayLock = vi.fn(async (_opts?: { port?: number }) => ({
 const consumeGatewayRestartIntentPayloadSync = vi.fn<
   () => { reason?: string; force?: boolean; waitMs?: number } | null
 >(() => null);
+const consumeGatewaySigusr1RestartIntent = vi.fn<
+  () => { reason?: string; force?: boolean; waitMs?: number } | null
+>(() => null);
 const consumeGatewaySigusr1RestartAuthorization = vi.fn(() => true);
 const consumeGatewayRestartIntentSync = vi.fn(() => false);
 const isGatewaySigusr1RestartExternallyAllowed = vi.fn(() => false);
@@ -81,6 +84,8 @@ const markRestartAbortedMainSessions = vi.fn(async (_params: unknown) => ({
 }));
 const waitForActiveEmbeddedRuns = vi.fn(async (_timeoutMs?: number) => ({ drained: true }));
 const DRAIN_TIMEOUT_LOG = "drain timeout reached; proceeding with restart";
+const ACTIVE_RUN_DRAIN_TIMEOUT_LOG =
+  "active embedded run drain timeout reached; aborting active run(s) before restart";
 const DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS = 300_000;
 const loadConfig = vi.fn<() => { gateway: { reload: { deferralTimeoutMs?: number } } }>(() => ({
   gateway: {
@@ -101,6 +106,7 @@ vi.mock("../../infra/gateway-lock.js", () => ({
 
 vi.mock("../../infra/restart.js", () => ({
   consumeGatewayRestartIntentPayloadSync: () => consumeGatewayRestartIntentPayloadSync(),
+  consumeGatewaySigusr1RestartIntent: () => consumeGatewaySigusr1RestartIntent(),
   consumeGatewaySigusr1RestartAuthorization: () => consumeGatewaySigusr1RestartAuthorization(),
   consumeGatewayRestartIntentSync: () => consumeGatewayRestartIntentSync(),
   isGatewaySigusr1RestartExternallyAllowed: () => isGatewaySigusr1RestartExternallyAllowed(),
@@ -430,6 +436,7 @@ describe("runGatewayLoop", () => {
     vi.clearAllMocks();
     consumeGatewayRestartIntentPayloadSync.mockReturnValueOnce({ waitMs: 2_500 });
     getActiveTaskCount.mockReturnValueOnce(1).mockReturnValue(0);
+    getActiveEmbeddedRunCount.mockReturnValueOnce(1).mockReturnValue(0);
 
     await withIsolatedSignals(async ({ captureSignal }) => {
       const { start, exited } = await createSignaledLoopHarness();
@@ -441,6 +448,7 @@ describe("runGatewayLoop", () => {
       await new Promise<void>((resolve) => setImmediate(resolve));
 
       expect(waitForActiveTasks).toHaveBeenCalledWith(2_500);
+      expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(2_500);
       expect(start).toHaveBeenCalledTimes(2);
 
       sigint();
@@ -469,7 +477,65 @@ describe("runGatewayLoop", () => {
     });
   });
 
-  it("aborts active embedded runs after a short restart drain grace", async () => {
+  it("waits indefinitely for active embedded runs on unbounded restarts", async () => {
+    vi.clearAllMocks();
+    consumeGatewayRestartIntentPayloadSync.mockReturnValueOnce({ waitMs: 0 });
+    getActiveEmbeddedRunCount.mockReturnValueOnce(1).mockReturnValue(0);
+    waitForActiveEmbeddedRuns.mockResolvedValueOnce({ drained: true });
+
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const { close, start, exited } = await createSignaledLoopHarness();
+      const sigterm = captureSignal("SIGTERM");
+      const sigint = captureSignal("SIGINT");
+
+      sigterm();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(undefined);
+      expect(abortEmbeddedPiRun).toHaveBeenCalledWith(undefined, { mode: "compacting" });
+      expect(abortEmbeddedPiRun).not.toHaveBeenCalledWith(undefined, { mode: "all" });
+      expectRestartCloseCall(close, 15_000);
+      expect(start).toHaveBeenCalledTimes(2);
+
+      sigint();
+      await expect(exited).resolves.toBe(0);
+    });
+  });
+
+  it("waits indefinitely for active embedded runs when reload config disables deferral timeout", async () => {
+    vi.clearAllMocks();
+    loadConfig.mockReturnValueOnce({
+      gateway: {
+        reload: {
+          deferralTimeoutMs: 0,
+        },
+      },
+    });
+    getActiveEmbeddedRunCount.mockReturnValueOnce(1).mockReturnValue(0);
+    waitForActiveEmbeddedRuns.mockResolvedValueOnce({ drained: true });
+
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const { close, start, exited } = await createSignaledLoopHarness();
+      const sigusr1 = captureSignal("SIGUSR1");
+      const sigint = captureSignal("SIGINT");
+
+      sigusr1();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(undefined);
+      expect(abortEmbeddedPiRun).toHaveBeenCalledWith(undefined, { mode: "compacting" });
+      expect(abortEmbeddedPiRun).not.toHaveBeenCalledWith(undefined, { mode: "all" });
+      expectRestartCloseCall(close, 15_000);
+      expect(start).toHaveBeenCalledTimes(2);
+
+      sigint();
+      await expect(exited).resolves.toBe(0);
+    });
+  });
+
+  it("uses the restart drain timeout for active embedded runs before aborting", async () => {
     vi.clearAllMocks();
     consumeGatewayRestartIntentPayloadSync.mockReturnValueOnce({});
     getActiveTaskCount.mockReturnValueOnce(1).mockReturnValue(0);
@@ -490,12 +556,10 @@ describe("runGatewayLoop", () => {
       await new Promise<void>((resolve) => setImmediate(resolve));
 
       expect(waitForActiveTasks).toHaveBeenCalledWith(90_000);
-      expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(30_000);
+      expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(90_000);
       expect(abortEmbeddedPiRun).toHaveBeenCalledWith(undefined, { mode: "compacting" });
       expect(abortEmbeddedPiRun).toHaveBeenCalledWith(undefined, { mode: "all" });
-      expect(gatewayLog.warn).toHaveBeenCalledWith(
-        "active embedded run drain grace reached; aborting active run(s) before restart",
-      );
+      expect(gatewayLog.warn).toHaveBeenCalledWith(ACTIVE_RUN_DRAIN_TIMEOUT_LOG);
       expect(gatewayLog.warn).toHaveBeenCalledWith(DRAIN_TIMEOUT_LOG);
       expect(markRestartAbortedMainSessions).toHaveBeenCalledWith({
         cfg: {
@@ -513,6 +577,51 @@ describe("runGatewayLoop", () => {
         "failed to mark interrupted main sessions for restart recovery: Error: store read-only",
       );
       expectRestartCloseCall(close, 90_000);
+      expect(start).toHaveBeenCalledTimes(2);
+
+      sigint();
+      await expect(exited).resolves.toBe(0);
+    });
+  });
+
+  it("skips a second active-work drain after a SIGUSR1 deferral timeout intent", async () => {
+    vi.clearAllMocks();
+    consumeGatewaySigusr1RestartIntent.mockReturnValueOnce({
+      force: true,
+      reason: "config reload forced restart",
+    });
+    getActiveTaskCount.mockReturnValueOnce(1).mockReturnValue(0);
+    getActiveEmbeddedRunCount.mockReturnValueOnce(1).mockReturnValue(0);
+    listActiveEmbeddedRunSessionIds.mockReturnValueOnce(["session-deferral-timeout"]);
+    listActiveEmbeddedRunSessionKeys.mockReturnValueOnce(["agent:main:deferral-timeout"]);
+
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const { close, start, exited } = await createSignaledLoopHarness();
+      const sigusr1 = captureSignal("SIGUSR1");
+      const sigint = captureSignal("SIGINT");
+
+      sigusr1();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(waitForActiveTasks).not.toHaveBeenCalled();
+      expect(waitForActiveEmbeddedRuns).not.toHaveBeenCalled();
+      expect(abortEmbeddedPiRun).toHaveBeenCalledWith(undefined, { mode: "compacting" });
+      expect(abortEmbeddedPiRun).toHaveBeenCalledWith(undefined, { mode: "all" });
+      expect(markRestartAbortedMainSessions).toHaveBeenCalledWith({
+        cfg: {
+          gateway: {
+            reload: {
+              deferralTimeoutMs: 90_000,
+            },
+          },
+        },
+        sessionIds: new Set(["session-deferral-timeout"]),
+        sessionKeys: new Set(["agent:main:deferral-timeout"]),
+        reason: "config reload forced restart",
+      });
+      expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledOnce();
+      expectRestartCloseCall(close, 0);
       expect(start).toHaveBeenCalledTimes(2);
 
       sigint();
@@ -1029,6 +1138,7 @@ describe("runGatewayLoop", () => {
 
     await withIsolatedSignals(async ({ captureSignal }) => {
       getActiveTaskCount.mockReturnValueOnce(1).mockReturnValue(0);
+      getActiveEmbeddedRunCount.mockReturnValueOnce(1).mockReturnValue(0);
 
       const { start } = await createSignaledLoopHarness();
       const sigusr1 = captureSignal("SIGUSR1");
@@ -1038,6 +1148,7 @@ describe("runGatewayLoop", () => {
       await new Promise<void>((resolve) => setImmediate(resolve));
 
       expect(waitForActiveTasks).toHaveBeenCalledWith(DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
+      expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
       expect(markGatewayDraining).toHaveBeenCalledOnce();
       expect(start).toHaveBeenCalledTimes(2);
     });
@@ -1087,6 +1198,53 @@ describe("runGatewayLoop", () => {
       expect(gatewayLog.warn).toHaveBeenCalledWith(
         "SIGUSR1 restart ignored (not authorized; commands.restart=false or use gateway tool).",
       );
+    });
+  });
+
+  it("clears the in-flight restart token when a file intent handles authorized SIGUSR1", async () => {
+    vi.clearAllMocks();
+    consumeGatewayRestartIntentPayloadSync.mockReturnValueOnce({
+      force: true,
+      reason: "file-intent restart",
+    });
+    loadConfig.mockReturnValueOnce({
+      gateway: {
+        reload: {
+          deferralTimeoutMs: 90_000,
+        },
+      },
+    });
+    getActiveEmbeddedRunCount.mockReturnValueOnce(1).mockReturnValue(0);
+    listActiveEmbeddedRunSessionIds.mockReturnValueOnce(["session-file-intent"]);
+    listActiveEmbeddedRunSessionKeys.mockReturnValueOnce(["agent:main:file-intent"]);
+
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const { start, exited } = await createSignaledLoopHarness();
+      const sigusr1 = captureSignal("SIGUSR1");
+      const sigint = captureSignal("SIGINT");
+
+      sigusr1();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(consumeGatewaySigusr1RestartAuthorization).toHaveBeenCalledOnce();
+      expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledOnce();
+      expect(markRestartAbortedMainSessions).toHaveBeenCalledWith({
+        cfg: {
+          gateway: {
+            reload: {
+              deferralTimeoutMs: 90_000,
+            },
+          },
+        },
+        sessionIds: new Set(["session-file-intent"]),
+        sessionKeys: new Set(["agent:main:file-intent"]),
+        reason: "file-intent restart",
+      });
+      expect(start).toHaveBeenCalledTimes(2);
+
+      sigint();
+      await expect(exited).resolves.toBe(0);
     });
   });
 

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -17,7 +17,6 @@ import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 const gatewayLog = createSubsystemLogger("gateway");
 const LAUNCHD_SUPERVISED_RESTART_EXIT_DELAY_MS = 1500;
 const DEFAULT_RESTART_DRAIN_TIMEOUT_MS = 300_000;
-const RESTART_ACTIVE_EMBEDDED_RUN_ABORT_GRACE_MS = 30_000;
 const RESTART_DRAIN_STILL_PENDING_WARN_MS = 30_000;
 const RESTART_CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS = 10_000;
 const UPDATE_RESPAWN_HEALTH_TIMEOUT_MS = 10_000;
@@ -434,15 +433,6 @@ export async function runGatewayLoop(params: {
         restartDrainTimeoutMs === undefined
           ? "without a timeout"
           : `with timeout ${restartDrainTimeoutMs}ms`;
-      const resolveActiveRunDrainWaitMs = (activeRuns: number): RestartDrainTimeoutMs => {
-        if (activeRuns <= 0) {
-          return restartDrainTimeoutMs;
-        }
-        if (restartDrainTimeoutMs === undefined) {
-          return RESTART_ACTIVE_EMBEDDED_RUN_ABORT_GRACE_MS;
-        }
-        return Math.min(restartDrainTimeoutMs, RESTART_ACTIVE_EMBEDDED_RUN_ABORT_GRACE_MS);
-      };
       const armCloseForceExitTimerForIndefiniteRestart = () => {
         if (isRestart && restartDrainTimeoutMs === undefined) {
           armForceExitTimer(SHUTDOWN_TIMEOUT_MS);
@@ -570,12 +560,13 @@ export async function runGatewayLoop(params: {
                 }
                 if (restartIntent?.force) {
                   gatewayLog.warn("forced restart requested; skipping active work drain");
-                  await markActiveMainSessionsForRestart("forced gateway restart");
+                  await markActiveMainSessionsForRestart(
+                    restartIntent.reason ?? "forced gateway restart",
+                  );
                   abortEmbeddedPiRun(undefined, { mode: "all" });
                 } else {
-                  const activeRunDrainWaitMs = resolveActiveRunDrainWaitMs(activeRuns);
                   const stillPendingDrainLogger = createStillPendingDrainLogger();
-                  let abortedAfterRunGrace = false;
+                  let abortedAfterRunTimeout = false;
                   let tasksDrain: { drained: boolean } = { drained: true };
                   let runsDrain: { drained: boolean } = { drained: true };
                   try {
@@ -585,14 +576,14 @@ export async function runGatewayLoop(params: {
                         : Promise.resolve({ drained: true });
                     runsDrain =
                       activeRuns > 0
-                        ? await waitForActiveEmbeddedRuns(activeRunDrainWaitMs)
+                        ? await waitForActiveEmbeddedRuns(restartDrainTimeoutMs)
                         : { drained: true };
                     if (!runsDrain.drained && activeRuns > 0) {
                       gatewayLog.warn(
-                        "active embedded run drain grace reached; aborting active run(s) before restart",
+                        "active embedded run drain timeout reached; aborting active run(s) before restart",
                       );
                       abortEmbeddedPiRun(undefined, { mode: "all" });
-                      abortedAfterRunGrace = true;
+                      abortedAfterRunTimeout = true;
                     }
                     tasksDrain = await tasksDrainPromise;
                   } finally {
@@ -606,7 +597,7 @@ export async function runGatewayLoop(params: {
                     await markActiveMainSessionsForRestart("gateway restart drain timeout");
                     // Final best-effort abort to avoid carrying active runs into the
                     // next lifecycle when drain time budget is exhausted.
-                    if (!abortedAfterRunGrace) {
+                    if (!abortedAfterRunTimeout) {
                       abortEmbeddedPiRun(undefined, { mode: "all" });
                     }
                   }
@@ -730,6 +721,7 @@ export async function runGatewayLoop(params: {
     void (async () => {
       const {
         consumeGatewayRestartIntentPayloadSync,
+        consumeGatewaySigusr1RestartIntent,
         consumeGatewaySigusr1RestartAuthorization,
         isGatewaySigusr1RestartExternallyAllowed,
         markGatewaySigusr1RestartHandled,
@@ -738,6 +730,9 @@ export async function runGatewayLoop(params: {
       } = await loadGatewayLifecycleRuntimeModule();
       const restartIntent = consumeGatewayRestartIntentPayloadSync();
       if (restartIntent) {
+        if (consumeGatewaySigusr1RestartAuthorization()) {
+          markGatewaySigusr1RestartHandled();
+        }
         request("restart", "SIGUSR1", restartIntent.reason ?? "gateway.restart", restartIntent);
         return;
       }
@@ -759,9 +754,15 @@ export async function runGatewayLoop(params: {
         scheduleGatewaySigusr1Restart({ delayMs: 0, reason: "SIGUSR1" });
         return;
       }
+      const sigusr1RestartIntent = consumeGatewaySigusr1RestartIntent();
       const restartReason = peekGatewaySigusr1RestartReason();
       markGatewaySigusr1RestartHandled();
-      request("restart", "SIGUSR1", restartReason);
+      request(
+        "restart",
+        "SIGUSR1",
+        sigusr1RestartIntent?.reason ?? restartReason,
+        sigusr1RestartIntent ?? undefined,
+      );
     })().catch((err) => {
       // Defense in depth: if anything in the listener body rejects, the
       // SIGUSR1 emit has already advanced emittedRestartToken but no one

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ConfigWriteNotification } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { consumeGatewaySigusr1RestartIntent } from "../infra/restart.js";
 import type { ChannelKind, GatewayReloadPlan } from "./config-reload-plan.js";
 import type { GatewayPluginReloadResult } from "./server-reload-handlers.js";
 import {
@@ -380,6 +381,10 @@ describe("gateway restart deferral preflight", () => {
       await Promise.resolve();
 
       expect(signalSpy).toHaveBeenCalledTimes(1);
+      expect(consumeGatewaySigusr1RestartIntent()).toEqual({
+        force: true,
+        reason: "config reload forced restart",
+      });
       expect(hoisted.markRestartAbortedMainSessions).toHaveBeenCalledWith({
         cfg: {
           gateway: { reload: { deferralTimeoutMs: 1_000 } },

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -551,6 +551,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
         maxWaitMs: resolveGatewayRestartDeferralTimeoutMs(
           nextConfig.gateway?.reload?.deferralTimeoutMs,
         ),
+        timeoutIntent: { force: true, reason: "config reload forced restart" },
         emitHooks: {
           beforeEmit: () =>
             markActiveMainSessionsForRestart(nextConfig, "config reload forced restart"),

--- a/src/infra/infra-runtime.test.ts
+++ b/src/infra/infra-runtime.test.ts
@@ -8,6 +8,7 @@ import {
 import { makeNetworkInterfacesSnapshot } from "../test-helpers/network-interfaces.js";
 import {
   testing,
+  consumeGatewaySigusr1RestartIntent,
   consumeGatewaySigusr1RestartAuthorization,
   emitGatewayRestart,
   isGatewaySigusr1RestartExternallyAllowed,
@@ -241,6 +242,29 @@ describe("infra runtime", () => {
         await vi.advanceTimersByTimeAsync(1_000);
 
         expect(peekGatewaySigusr1RestartReason()).toBe("update.run");
+      } finally {
+        process.removeListener("SIGUSR1", handler);
+      }
+    });
+
+    it("preserves update restart reason when an in-flight intent coalesces", () => {
+      const handler = () => {};
+      process.on("SIGUSR1", handler);
+      try {
+        expect(
+          emitGatewayRestart("config reload forced restart", {
+            force: true,
+            reason: "config reload forced restart",
+          }),
+        ).toBe(true);
+        const update = scheduleGatewaySigusr1Restart({ delayMs: 0, reason: "update.run" });
+
+        expect(update.coalesced).toBe(true);
+        expect(peekGatewaySigusr1RestartReason()).toBe("update.run");
+        expect(consumeGatewaySigusr1RestartIntent()).toEqual({
+          force: true,
+          reason: "update.run",
+        });
       } finally {
         process.removeListener("SIGUSR1", handler);
       }
@@ -652,6 +676,9 @@ describe("infra runtime", () => {
 
         await vi.advanceTimersByTimeAsync(1_000);
         expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
+        expect(consumeGatewaySigusr1RestartIntent()).toEqual({
+          force: true,
+        });
       } finally {
         process.removeListener("SIGUSR1", handler);
       }

--- a/src/infra/restart.deferral-timeout.test.ts
+++ b/src/infra/restart.deferral-timeout.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { testing, deferGatewayRestartUntilIdle, type RestartDeferralHooks } from "./restart.js";
+import {
+  testing,
+  consumeGatewaySigusr1RestartIntent,
+  deferGatewayRestartUntilIdle,
+  type RestartDeferralHooks,
+} from "./restart.js";
 
 describe("deferGatewayRestartUntilIdle timeout", () => {
   beforeEach(() => {
@@ -59,6 +64,28 @@ describe("deferGatewayRestartUntilIdle timeout", () => {
     // Advance past 2 minutes
     vi.advanceTimersByTime(1);
     expect(hooks.onTimeout).toHaveBeenCalledOnce();
+  });
+
+  it("carries timeout restart intent when the deferral budget is exhausted", () => {
+    const hooks: RestartDeferralHooks = {
+      onTimeout: vi.fn(),
+      onReady: vi.fn(),
+    };
+
+    deferGatewayRestartUntilIdle({
+      getPendingCount: () => 1,
+      maxWaitMs: 1_000,
+      hooks,
+      timeoutIntent: { force: true, reason: "gateway.restart.deferral-timeout" },
+    });
+
+    vi.advanceTimersByTime(1_000);
+
+    expect(hooks.onTimeout).toHaveBeenCalledOnce();
+    expect(consumeGatewaySigusr1RestartIntent()).toEqual({
+      force: true,
+      reason: "gateway.restart.deferral-timeout",
+    });
   });
 
   it("calls onReady and does not timeout when pending count drops to 0", () => {

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -39,6 +39,7 @@ let restartCycleToken = 0;
 let emittedRestartToken = 0;
 let consumedRestartToken = 0;
 let emittedRestartReason: string | undefined;
+let emittedRestartIntent: GatewayRestartIntent | undefined;
 let lastRestartEmittedAt = 0;
 let pendingRestartTimer: ReturnType<typeof setTimeout> | null = null;
 let pendingRestartDueAt = 0;
@@ -291,7 +292,10 @@ export function setPreRestartDeferralCheck(fn: () => number): void {
  * Both scheduleGatewaySigusr1Restart and the config watcher should use this
  * to ensure only one restart fires.
  */
-export function emitGatewayRestart(reasonOverride?: string): boolean {
+export function emitGatewayRestart(
+  reasonOverride?: string,
+  intent?: GatewayRestartIntent,
+): boolean {
   if (hasUnconsumedRestartSignal()) {
     clearActiveDeferralPolls();
     clearPendingScheduledRestart();
@@ -301,7 +305,8 @@ export function emitGatewayRestart(reasonOverride?: string): boolean {
   clearPendingScheduledRestart();
   const cycleToken = ++restartCycleToken;
   emittedRestartToken = cycleToken;
-  emittedRestartReason = reasonOverride ?? pendingRestartReason;
+  emittedRestartReason = reasonOverride ?? intent?.reason ?? pendingRestartReason;
+  emittedRestartIntent = intent;
   authorizeGatewaySigusr1Restart();
   try {
     if (process.listenerCount("SIGUSR1") > 0) {
@@ -378,6 +383,19 @@ export function peekGatewaySigusr1RestartReason(): string | undefined {
 }
 
 /**
+ * Reads and clears only the in-memory intent for the current emitted SIGUSR1 cycle.
+ * The restart reason and cycle token are advanced by markGatewaySigusr1RestartHandled().
+ */
+export function consumeGatewaySigusr1RestartIntent(): GatewayRestartIntent | null {
+  if (!hasUnconsumedRestartSignal()) {
+    return null;
+  }
+  const intent = emittedRestartIntent ?? null;
+  emittedRestartIntent = undefined;
+  return intent;
+}
+
+/**
  * Mark the currently emitted SIGUSR1 restart cycle as consumed by the run loop.
  * This explicitly advances the cycle state instead of resetting emit guards inside
  * consumeGatewaySigusr1RestartAuthorization().
@@ -386,12 +404,14 @@ export function markGatewaySigusr1RestartHandled(): void {
   if (hasUnconsumedRestartSignal()) {
     consumedRestartToken = emittedRestartToken;
     emittedRestartReason = undefined;
+    emittedRestartIntent = undefined;
   }
 }
 
 function rollBackGatewayRestartEmission(): void {
   emittedRestartToken = consumedRestartToken;
   emittedRestartReason = undefined;
+  emittedRestartIntent = undefined;
   consumeGatewaySigusr1RestartAuthorization();
 }
 
@@ -427,6 +447,7 @@ function updatePendingRestartEmitHooks(hooks?: RestartEmitHooks): void {
 async function emitPreparedGatewayRestart(
   hooks?: RestartEmitHooks,
   reasonOverride?: string,
+  intent?: GatewayRestartIntent,
 ): Promise<void> {
   let nextHooks = hooks ?? pendingRestartEmitHooks;
   if (!hooks) {
@@ -453,7 +474,7 @@ async function emitPreparedGatewayRestart(
     pendingRestartEmitHooks = undefined;
   }
 
-  const emitted = emitGatewayRestart(reasonOverride);
+  const emitted = emitGatewayRestart(reasonOverride, intent);
   if (!emitted) {
     await preparedHooks?.afterEmitRejected?.().catch(() => undefined);
   }
@@ -471,6 +492,7 @@ export function deferGatewayRestartUntilIdle(opts: {
   pollMs?: number;
   maxWaitMs?: number;
   reason?: string;
+  timeoutIntent?: GatewayRestartIntent;
 }): void {
   const pollMsRaw = opts.pollMs ?? DEFAULT_DEFERRAL_POLL_MS;
   const pollMs = Math.max(10, Math.floor(pollMsRaw));
@@ -523,7 +545,7 @@ export function deferGatewayRestartUntilIdle(opts: {
       clearInterval(poll);
       activeDeferralPolls.delete(poll);
       opts.hooks?.onTimeout?.(current, elapsedMs);
-      void emitPreparedGatewayRestart(opts.emitHooks, opts.reason);
+      void emitPreparedGatewayRestart(opts.emitHooks, opts.reason, opts.timeoutIntent);
     }
   }, pollMs);
   activeDeferralPolls.add(poll);
@@ -725,6 +747,10 @@ export function scheduleGatewaySigusr1Restart(opts?: {
   if (hasUnconsumedRestartSignal()) {
     if (shouldPreferRestartReason(reason, emittedRestartReason)) {
       emittedRestartReason = reason;
+      if (emittedRestartIntent) {
+        // Preserve the already-authorized force bit; only the display/recovery reason is upgraded.
+        emittedRestartIntent = { ...emittedRestartIntent, reason };
+      }
     }
     restartLog.warn(
       `restart request coalesced (already in-flight) reason=${reason ?? "unspecified"} ${formatRestartAudit(opts?.audit)}`,
@@ -812,10 +838,14 @@ export function scheduleGatewaySigusr1Restart(opts?: {
         return;
       }
       const cfg = getRuntimeConfig();
+      const deferralTimeoutMs = resolveGatewayRestartDeferralTimeoutMs(
+        cfg.gateway?.reload?.deferralTimeoutMs,
+      );
       deferGatewayRestartUntilIdle({
         getPendingCount: pendingCheck,
-        maxWaitMs: resolveGatewayRestartDeferralTimeoutMs(cfg.gateway?.reload?.deferralTimeoutMs),
+        maxWaitMs: deferralTimeoutMs,
         reason: scheduledReason,
+        timeoutIntent: { force: true, ...(scheduledReason ? { reason: scheduledReason } : {}) },
       });
     },
     Math.max(0, requestedDueAt - nowMs),
@@ -842,6 +872,7 @@ export const testing = {
     emittedRestartToken = 0;
     consumedRestartToken = 0;
     emittedRestartReason = undefined;
+    emittedRestartIntent = undefined;
     lastRestartEmittedAt = 0;
     clearActiveDeferralPolls();
     clearPendingScheduledRestart();


### PR DESCRIPTION
Problem

Gateway restarts currently treat active embedded runs differently from active task runs: embedded runs hit a hidden 30s abort grace even when the restart drain budget is configured longer, or explicitly unbounded. That can interrupt legitimate long embedded runs even though operators configured the gateway to wait.

Change and value

This PR makes active embedded runs use the same restart drain budget as active task runs. It also threads a SIGUSR1 restart intent through the scheduled restart path so a restart that already waited through the pre-restart deferral timeout is treated as forced by the run loop instead of spending the same budget a second time.

Who is affected

Operators using `gateway.reload.deferralTimeoutMs`, restart `waitMs`, config reloads that require a gateway restart, or long-running embedded Pi runs during restart.

Why now

The documented deferral timeout is the restart budget users can see and configure. Keeping a separate hidden embedded-run cap makes the behavior harder to reason about and can discard work sooner than configured.

Implementation

- Removed the separate `RESTART_ACTIVE_EMBEDDED_RUN_ABORT_GRACE_MS` cap.
- Pass `restartDrainTimeoutMs` directly to `waitForActiveEmbeddedRuns`.
- Added in-memory SIGUSR1 restart intent plumbing for scheduled restarts.
- Mark deferral-timeout restarts as `{ force: true }` so the run loop skips a second active-work drain after the deferral budget has already been exhausted.
- Carry forced restart reasons into main-session restart recovery markers.
- Clear the in-flight SIGUSR1 token when a file intent handles an authorized restart signal.

Maintainer question

This PR treats explicit unbounded restart waits (`waitMs: 0` or `gateway.reload.deferralTimeoutMs: 0`) as unbounded for embedded runs too, matching active task behavior. If maintainers prefer an embedded-run hard watchdog even when the overall restart drain is unbounded, I can revise toward a separate explicit cap instead of a hidden 30s grace.

## Real behavior proof

- Behavior or issue addressed: Active embedded runs now honor the configured restart drain budget instead of a hidden 30s cap, and deferral-timeout SIGUSR1 restarts skip a second drain.
- Real environment tested: Local contributor worktree on commit `5d8708bbc9`; remote GCP Spot validation on Crabbox lease `cbx_110fd4735a16`, VM `crabbox-pearl-hermit-22affab2`, `e2-standard-8`, zone `us-east1-b`.
- Exact steps or command run after this patch:

  Local targeted checks:

  ```sh
  env OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/gateway-cli/run-loop.test.ts --reporter=verbose
  env OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/restart.deferral-timeout.test.ts src/infra/infra-runtime.test.ts --reporter=verbose
  env OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-reload-handlers.test.ts --reporter=verbose
  pnpm exec oxfmt --check src/infra/restart.ts src/cli/gateway-cli/lifecycle.runtime.ts src/cli/gateway-cli/run-loop.ts src/cli/gateway-cli/run-loop.test.ts src/infra/restart.deferral-timeout.test.ts src/infra/infra-runtime.test.ts src/gateway/server-reload-handlers.ts src/gateway/server-reload-handlers.test.ts
  node --import tsx /tmp/openclaw-restart-drain-proof.mjs
  ```

  Remote CI-shaped validation:

  ```sh
  pnpm install --frozen-lockfile --reporter=append-only
  pnpm build
  pnpm tsgo:core:test
  env OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/gateway-cli/run-loop.test.ts --reporter=verbose
  env OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/restart.deferral-timeout.test.ts src/infra/infra-runtime.test.ts --reporter=verbose
  env OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-reload-handlers.test.ts --reporter=verbose
  ```
- Evidence after fix: Terminal transcript from `node --import tsx /tmp/openclaw-restart-drain-proof.mjs` exercised real `runGatewayLoop`, `ACTIVE_EMBEDDED_RUNS`, `emitGatewayRestart`, and `deferGatewayRestartUntilIdle` paths and printed the after-fix output below.

  ```json
  {
    "exitCode": 0,
    "startCount": 3,
    "waitZero": {
      "drainedWithoutAbort": true,
      "close": {
        "reason": "gateway restarting",
        "restartExpectedMs": 1500,
        "drainTimeoutMs": 15000
      }
    },
    "deferralTimeout": {
      "abortCount": 1,
      "close": {
        "reason": "gateway restarting",
        "restartExpectedMs": 1500,
        "drainTimeoutMs": 0
      }
    }
  }
  ```

  Remote validation exit code `0`; run summary `sync=15.796s command=7m12.875s total=7m28.79s`. CLI restart loop suite passed with 35 tests; infra restart suites passed with 34 tests; gateway reload suite passed with 11 tests; formatting check passed for all 8 changed files. Crabbox release completed; follow-up GCP instance list showed no remaining `crabbox-*` instances.
- Observed result after fix: The proof showed an explicit unbounded restart wait draining an active embedded run without aborting it, and a deferral-timeout restart aborting once with `drainTimeoutMs: 0` instead of spending a second active-work drain budget.
- What was not tested: No changed-path proof gap remains. I did not run every repository test shard locally; broad validation was run remotely with build, core test typecheck, and targeted changed-path Vitest suites.

Review gates

- Multi-lane read-only review swarm completed; accepted findings were fixed or explicitly classified.
- Claude `--print` multi-lane review completed after increasing timeout to 20 minutes per lane; no blockers remained.
- `codex review --uncommitted` completed with no actionable findings before commit/rebase; final `codex review --uncommitted` completed on the current diff with no discrete actionable bugs.

Changelog

No changelog entry added; leaving release-note/changelog ownership to maintainers.