### PR TITLE
fix(secrets): show irreversible warning after interactive apply confirmation

### DIFF
--- a/src/cli/secrets-cli.test.ts
+++ b/src/cli/secrets-cli.test.ts
@@ -293,6 +293,40 @@ describe("secrets CLI", () => {
     expect(runtimeLogs.at(-1)).toContain("Secrets applied");
   });
 
+  it("shows the irreversibility warning on the interactive apply path (#83883)", async () => {
+    runSecretsConfigureInteractive.mockResolvedValue(
+      createConfigureInteractiveResult({ changed: true }),
+    );
+    // Interactive path: no --apply flag. First confirm is "Apply this plan
+    // now?", second must be the one-way-migration irreversibility warning.
+    confirm.mockResolvedValueOnce(true); // Apply this plan now?
+    confirm.mockResolvedValueOnce(true); // one-way migration warning
+    runSecretsApply.mockResolvedValue(createSecretsApplyResult({ mode: "write", changed: true }));
+
+    await createProgram().parseAsync(["secrets", "configure"], { from: "user" });
+
+    // Before the fix the interactive path skipped the irreversibility prompt
+    // (it checked opts.apply), so confirm was called only once.
+    expect(confirm).toHaveBeenCalledTimes(2);
+    const secondPrompt = confirm.mock.calls[1]?.[0] as { message?: string } | undefined;
+    expect(secondPrompt?.message ?? "").toContain("one-way");
+    expect(runSecretsApply).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels apply when the interactive irreversibility warning is declined (#83883)", async () => {
+    runSecretsConfigureInteractive.mockResolvedValue(
+      createConfigureInteractiveResult({ changed: true }),
+    );
+    confirm.mockResolvedValueOnce(true); // Apply this plan now?
+    confirm.mockResolvedValueOnce(false); // decline the irreversibility warning
+
+    await createProgram().parseAsync(["secrets", "configure"], { from: "user" });
+
+    expect(confirm).toHaveBeenCalledTimes(2);
+    expect(runSecretsApply).not.toHaveBeenCalled();
+    expect(runtimeLogs.at(-1)).toContain("Apply cancelled");
+  });
+
   it("forwards --agent to secrets configure", async () => {
     runSecretsConfigureInteractive.mockResolvedValue(createConfigureInteractiveResult());
     confirm.mockResolvedValue(false);

--- a/src/cli/secrets-cli.ts
+++ b/src/cli/secrets-cli.ts
@@ -225,7 +225,12 @@ export function registerSecretsCli(program: Command): void {
           }
         }
         if (shouldApply) {
-          const needsIrreversiblePrompt = Boolean(opts.apply);
+          // Show the irreversibility warning whenever we are about to apply,
+          // including when the user opted in through the interactive "Apply
+          // this plan now?" confirm. Previously this checked opts.apply, so the
+          // one-way-migration warning was silently skipped on the interactive
+          // path (only --apply surfaced it). See #83883.
+          const needsIrreversiblePrompt = shouldApply;
           if (needsIrreversiblePrompt && !opts.yes && !opts.json) {
             const { confirm } = await import("@clack/prompts");
             const confirmed = await confirm({


### PR DESCRIPTION
## Summary

Fixes #83883. In `secrets configure`, the one-way-migration irreversibility warning was silently skipped when the user opted into applying through the interactive "Apply this plan now?" confirm. The guard computed `needsIrreversiblePrompt` from `opts.apply` (the original `--apply` flag) instead of `shouldApply` (which becomes true after the interactive confirm), so only the explicit `--apply` flag surfaced the warning; the interactive path applied an irreversible plaintext migration without the second confirmation.

The guard now derives from `shouldApply`, so the irreversibility warning is shown on both the `--apply` path and the interactive-confirm path before any irreversible apply.

## Real behavior proof

Behavior or issue addressed: on the interactive path the user confirms "Apply this plan now?", which sets `shouldApply = true` while `opts.apply` stays false. The irreversibility guard read `opts.apply`, so it evaluated false and the one-way-migration warning was skipped, applying the migration with no irreversible-change confirmation. The fix derives the guard from `shouldApply` so the warning fires on the interactive path too.

Real environment tested: Linux (Ubuntu 24.04, WSL2), Node.js 24.14.0, current PR head. Ran the secrets CLI test suite via the repo's vitest runner against the real registerSecretsCli command wiring, with @clack/prompts confirm mocked to drive the interactive path. Compared the pre-fix and post-fix code.

Exact steps or command run after this patch: ran the secrets-cli tests, including two new regression tests for the interactive apply path, on both the pre-fix and post-fix code.

Evidence after fix: stdout from the vitest run against the real command wiring, comparing pre-fix and post-fix:

```
$ node scripts/run-vitest.mjs src/cli/secrets-cli.test.ts

-- BEFORE the fix (guard read opts.apply): interactive path skips the warning --
  x shows the irreversibility warning on the interactive apply path (83883)
    AssertionError: expected confirm to be called 2 times, but got 1 times
  x cancels apply when the interactive irreversibility warning is declined (83883)
  Tests  2 failed | 12 passed (14)

-- AFTER the fix (guard reads shouldApply): warning fires on the interactive path --
  + shows the irreversibility warning on the interactive apply path (83883)
  + cancels apply when the interactive irreversibility warning is declined (83883)
  Tests  14 passed (14)
```

Observed result after fix: before the fix the interactive path calls confirm only once (the irreversibility warning is skipped) and applies the one-way migration; after the fix confirm is called twice, the second call carries the one-way-migration message, and declining it cancels the apply. The full secrets-cli suite passes (14 tests).

What was not tested: no end-to-end run against a real on-disk secrets store; the proof drives the real CLI command wiring with the prompt layer mocked, and the before/after comparison isolates the guard change as the only variable.