### PR TITLE
fix(telegram): normalize legacy group queue targets

### DIFF
--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -872,6 +872,26 @@ describe("sendMessageTelegram", () => {
     });
   });
 
+  it("normalizes legacy durable group queue targets", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 1,
+      chat: { id: "-100123" },
+    });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+
+    await sendMessageTelegram("group:-100123", "hi", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith("-100123", "hi", {
+      parse_mode: "HTML",
+    });
+  });
+
   it("resolves t.me targets to numeric chat ids via getChat", async () => {
     const sendMessage = vi.fn().mockResolvedValue({
       message_id: 1,

--- a/extensions/telegram/src/targets.test.ts
+++ b/extensions/telegram/src/targets.test.ts
@@ -32,8 +32,13 @@ describe("stripTelegramInternalPrefixes", () => {
     expect(stripTelegramInternalPrefixes("telegram:group:-100123")).toBe("-100123");
   });
 
-  it("does not strip group prefix without telegram prefix", () => {
-    expect(stripTelegramInternalPrefixes("group:-100123")).toBe("group:-100123");
+  it("strips legacy group prefix without telegram prefix for numeric chat ids", () => {
+    expect(stripTelegramInternalPrefixes("group:-100123")).toBe("-100123");
+    expect(stripTelegramInternalPrefixes("group:-100123:topic:77")).toBe("-100123:topic:77");
+  });
+
+  it("does not strip group prefix without a numeric chat id", () => {
+    expect(stripTelegramInternalPrefixes("group:announcements")).toBe("group:announcements");
   });
 
   it("is idempotent", () => {
@@ -94,6 +99,13 @@ describe("parseTelegramTarget", () => {
       chatType: "group",
     });
   });
+
+  it("parses legacy group queue targets", () => {
+    expect(parseTelegramTarget("group:-1001234567890")).toEqual({
+      chatId: "-1001234567890",
+      chatType: "group",
+    });
+  });
 });
 
 describe("telegram numeric target normalization", () => {
@@ -102,6 +114,13 @@ describe("telegram numeric target normalization", () => {
     ({ normalize }) => {
       expect(normalize("-1001234567890")).toBe("-1001234567890");
       expect(normalize("123456789")).toBe("123456789");
+    },
+  );
+
+  it.each(numericTelegramTargetNormalizers)(
+    "$name accepts legacy durable group queue targets",
+    ({ normalize }) => {
+      expect(normalize("group:-1001234567890")).toBe("-1001234567890");
     },
   );
 });

--- a/extensions/telegram/src/targets.ts
+++ b/extensions/telegram/src/targets.ts
@@ -16,8 +16,9 @@ export function stripTelegramInternalPrefixes(to: string): string {
         strippedTelegramPrefix = true;
         return trimmed.replace(/^(telegram|tg):/i, "").trim();
       }
-      // Legacy internal form: `telegram:group:<id>` (still emitted by session keys).
-      if (strippedTelegramPrefix && /^group:/i.test(trimmed)) {
+      // Legacy internal forms still appear in durable queue entries.
+      const groupPrefixMatch = /^group:(-?\d+(?::(?:topic:)?\d+)?)$/i.exec(trimmed);
+      if ((strippedTelegramPrefix || groupPrefixMatch) && /^group:/i.test(trimmed)) {
         return trimmed.replace(/^group:/i, "").trim();
       }
       return trimmed;


### PR DESCRIPTION
## Summary

- Fixes #85640.
- Normalizes legacy Telegram durable queue targets like `group:-100123` back to numeric chat IDs before send resolution.
- Adds regression coverage for target parsing/normalization and the send path so recovered queue entries no longer fail with “Telegram recipient must be a numeric chat ID”.

## Tests

- `node scripts/run-vitest.mjs extensions/telegram/src/targets.test.ts extensions/telegram/src/send.test.ts extensions/telegram/src/outbound-adapter.test.ts`
- `node scripts/run-vitest.mjs src/infra/outbound/delivery-queue.recovery.test.ts src/infra/outbound/delivery-queue.reconnect-drain.test.ts`
- `node --import tsx --eval 'import { sendMessageTelegram } from "./extensions/telegram/src/send.ts"; const calls=[]; const api={sendMessage: async (...args)=>{calls.push(args); return {message_id:1, chat:{id:"-100123"}};}}; await sendMessageTelegram("group:-100123", "proof", { cfg:{}, token:"tok", api }); console.log(JSON.stringify({sentTo:calls[0]?.[0], text:calls[0]?.[1], parseMode:calls[0]?.[2]?.parse_mode}));'`
- `node_modules/.bin/oxfmt --check extensions/telegram/src/targets.ts extensions/telegram/src/targets.test.ts extensions/telegram/src/send.test.ts`
- `git diff --check`

## Real behavior proof

Behavior addressed: Telegram durable queue retry entries stored with legacy `group:-100...` recipients are normalized to numeric chat IDs instead of failing target resolution.
Real environment tested: Local macOS checkout, Node via repo tooling, real `sendMessageTelegram` runtime path with an injected local Bot API object so no secret token or external message was required.
Exact steps or command run after this patch: `node --import tsx --eval 'import { sendMessageTelegram } from "./extensions/telegram/src/send.ts"; const calls=[]; const api={sendMessage: async (...args)=>{calls.push(args); return {message_id:1, chat:{id:"-100123"}};}}; await sendMessageTelegram("group:-100123", "proof", { cfg:{}, token:"tok", api }); console.log(JSON.stringify({sentTo:calls[0]?.[0], text:calls[0]?.[1], parseMode:calls[0]?.[2]?.parse_mode}));'`
Evidence after fix: Console output from the runtime command:
```text
[telegram] outbound send ok accountId=default chatId=-100123 messageId=1 operation=sendMessage deliveryKind=text chunkCount=1
{"sentTo":"-100123","text":"proof","parseMode":"HTML"}
```
Observed result after fix: The Telegram send runtime accepted `group:-100123`, stripped the legacy group prefix, and called the API with `-100123`.
What was not tested: No live Telegram network send was performed; the Bot API call used a local injected object to avoid using secrets or sending a real message.
