### PR TITLE
fix(gateway): omit stream-error placeholders from agent prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Docs: https://docs.openclaw.ai
 
 - Checks/Windows: route full `pnpm check` stage commands through the managed child runner so Windows avoids Node shell-argv deprecation warnings there too.
 - Checks/Windows: run managed child commands through explicit `cmd.exe` wrapping instead of Node shell mode with argv, avoiding Node 24 subprocess deprecation warnings during changed checks.
+- Gateway: omit internal stream-error placeholder entries from agent prompt history so failed assistant turns are not replayed as model-authored text. (#85652) Thanks @anyech.
 - Models: prune retired Groq, GitHub Copilot, OpenAI, xAI, and old Claude catalog entries, with doctor migration to upgrade existing configs to current provider refs.
 - Doctor/update: recognize junction-backed source checkouts as git installs by comparing canonical paths before showing package-manager update guidance. Fixes #82215. Thanks @igormf.
 - CLI/skills: show an all-ready note with next-step commands when skill setup has no missing dependencies to install. (#85032) Thanks @aniruddhaadak80.

--- a/src/gateway/agent-prompt.test.ts
+++ b/src/gateway/agent-prompt.test.ts
@@ -125,4 +125,14 @@ describe("gateway agent prompt", () => {
     const prompt = buildAgentMessageFromConversationEntries([...entries]);
     expect(prompt).toContain(mention);
   });
+
+  it("preserves exact stream-error placeholder text from user history", () => {
+    const entries = [
+      { role: "user", entry: { sender: "User", body: STREAM_ERROR_FALLBACK_TEXT } },
+      { role: "user", entry: { sender: "User", body: "next" } },
+    ] as const;
+
+    const prompt = buildAgentMessageFromConversationEntries([...entries]);
+    expect(prompt).toContain(`User: ${STREAM_ERROR_FALLBACK_TEXT}`);
+  });
 });

--- a/src/gateway/agent-prompt.test.ts
+++ b/src/gateway/agent-prompt.test.ts
@@ -110,6 +110,7 @@ describe("gateway agent prompt", () => {
 
     const prompt = buildAgentMessageFromConversationEntries([...entries]);
     expect(prompt).not.toContain(STREAM_ERROR_FALLBACK_TEXT);
+    expect(prompt).not.toContain("Assistant:");
     expect(prompt).toContain("User: first");
     expect(prompt).toContain("User: retry");
   });

--- a/src/gateway/agent-prompt.test.ts
+++ b/src/gateway/agent-prompt.test.ts
@@ -147,6 +147,18 @@ describe("gateway agent prompt", () => {
     expect(prompt).toContain(`Assistant: ${STREAM_ERROR_FALLBACK_TEXT}`);
   });
 
+  it("preserves empty tool outputs in replay history", () => {
+    const entries = [
+      { role: "user", entry: { sender: "User", body: "lookup" } },
+      { role: "tool", entry: { sender: "Tool:call_1", body: "" } },
+      { role: "user", entry: { sender: "User", body: "continue" } },
+    ] as const;
+
+    const prompt = buildAgentMessageFromConversationEntries([...entries]);
+    expect(prompt).toContain("Tool:call_1: ");
+    expect(prompt).toContain("User: continue");
+  });
+
   it("preserves current user text that looks like internal display metadata", () => {
     const body = "[Thu 2026-03-12 07:00 UTC] what happened then?";
     expect(

--- a/src/gateway/agent-prompt.test.ts
+++ b/src/gateway/agent-prompt.test.ts
@@ -100,6 +100,7 @@ describe("gateway agent prompt", () => {
       { role: "user", entry: { sender: "User", body: "first" } },
       {
         role: "assistant",
+        internalStreamError: true,
         entry: {
           sender: "Assistant",
           body: [{ type: "text", text: STREAM_ERROR_FALLBACK_TEXT }] as unknown as string,
@@ -134,6 +135,16 @@ describe("gateway agent prompt", () => {
 
     const prompt = buildAgentMessageFromConversationEntries([...entries]);
     expect(prompt).toContain(`User: ${STREAM_ERROR_FALLBACK_TEXT}`);
+  });
+
+  it("preserves exact stream-error placeholder text from assistant history without provenance", () => {
+    const entries = [
+      { role: "assistant", entry: { sender: "Assistant", body: STREAM_ERROR_FALLBACK_TEXT } },
+      { role: "user", entry: { sender: "User", body: "next" } },
+    ] as const;
+
+    const prompt = buildAgentMessageFromConversationEntries([...entries]);
+    expect(prompt).toContain(`Assistant: ${STREAM_ERROR_FALLBACK_TEXT}`);
   });
 
   it("preserves current user text that looks like internal display metadata", () => {

--- a/src/gateway/agent-prompt.test.ts
+++ b/src/gateway/agent-prompt.test.ts
@@ -135,4 +135,11 @@ describe("gateway agent prompt", () => {
     const prompt = buildAgentMessageFromConversationEntries([...entries]);
     expect(prompt).toContain(`User: ${STREAM_ERROR_FALLBACK_TEXT}`);
   });
+
+  it("preserves current user text that looks like internal display metadata", () => {
+    const body = "[Thu 2026-03-12 07:00 UTC] what happened then?";
+    expect(
+      buildAgentMessageFromConversationEntries([{ role: "user", entry: { sender: "User", body } }]),
+    ).toBe(body);
+  });
 });

--- a/src/gateway/agent-prompt.test.ts
+++ b/src/gateway/agent-prompt.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
 import { buildHistoryContextFromEntries } from "../auto-reply/reply/history.js";
 import { extractTextFromChatContent } from "../shared/chat-content.js";
 import { buildAgentMessageFromConversationEntries } from "./agent-prompt.js";
@@ -93,5 +94,34 @@ describe("gateway agent prompt", () => {
     });
 
     expect(buildAgentMessageFromConversationEntries([...entries])).toBe(expected);
+  });
+  it("omits internal stream-error placeholder text from replay history", () => {
+    const entries = [
+      { role: "user", entry: { sender: "User", body: "first" } },
+      {
+        role: "assistant",
+        entry: {
+          sender: "Assistant",
+          body: [{ type: "text", text: STREAM_ERROR_FALLBACK_TEXT }] as unknown as string,
+        },
+      },
+      { role: "user", entry: { sender: "User", body: "retry" } },
+    ] as const;
+
+    const prompt = buildAgentMessageFromConversationEntries([...entries]);
+    expect(prompt).not.toContain(STREAM_ERROR_FALLBACK_TEXT);
+    expect(prompt).toContain("User: first");
+    expect(prompt).toContain("User: retry");
+  });
+
+  it("preserves ordinary assistant text that merely mentions the stream-error placeholder", () => {
+    const mention = `Diagnostic note: ${STREAM_ERROR_FALLBACK_TEXT}`;
+    const entries = [
+      { role: "assistant", entry: { sender: "Assistant", body: mention } },
+      { role: "user", entry: { sender: "User", body: "next" } },
+    ] as const;
+
+    const prompt = buildAgentMessageFromConversationEntries([...entries]);
+    expect(prompt).toContain(mention);
   });
 });

--- a/src/gateway/agent-prompt.ts
+++ b/src/gateway/agent-prompt.ts
@@ -5,6 +5,7 @@ import { extractTextFromChatContent } from "../shared/chat-content.js";
 export type ConversationEntry = {
   role: "user" | "assistant" | "tool";
   entry: HistoryEntry;
+  internalStreamError?: boolean;
 };
 
 /**
@@ -18,7 +19,11 @@ function safeBody(body: unknown): string {
 
 function toPromptEntry(entry: ConversationEntry): HistoryEntry | null {
   const body = safeBody(entry.entry.body);
-  if (entry.role === "assistant" && body.trim() === STREAM_ERROR_FALLBACK_TEXT) {
+  if (
+    entry.role === "assistant" &&
+    entry.internalStreamError === true &&
+    body.trim() === STREAM_ERROR_FALLBACK_TEXT
+  ) {
     return null;
   }
   return {

--- a/src/gateway/agent-prompt.ts
+++ b/src/gateway/agent-prompt.ts
@@ -60,7 +60,7 @@ export function buildAgentMessageFromConversationEntries(entries: ConversationEn
   const historyEntries = entries
     .slice(0, currentIndex)
     .map(toPromptEntry)
-    .filter((entry): entry is HistoryEntry => entry !== null && entry.body.trim().length > 0);
+    .filter((entry): entry is HistoryEntry => entry !== null);
   const currentPromptEntry = toPromptEntry(currentConversationEntry);
   if (!currentPromptEntry) {
     return "";

--- a/src/gateway/agent-prompt.ts
+++ b/src/gateway/agent-prompt.ts
@@ -1,5 +1,4 @@
 import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
-import { stripInternalMetadataForDisplay } from "../auto-reply/reply/display-text-sanitize.js";
 import { buildHistoryContextFromEntries, type HistoryEntry } from "../auto-reply/reply/history.js";
 import { extractTextFromChatContent } from "../shared/chat-content.js";
 
@@ -14,8 +13,7 @@ export type ConversationEntry = {
  * [object Object] if used directly in a template literal.
  */
 function safeBody(body: unknown): string {
-  const text = typeof body === "string" ? body : (extractTextFromChatContent(body) ?? "");
-  return stripInternalMetadataForDisplay(text);
+  return typeof body === "string" ? body : (extractTextFromChatContent(body) ?? "");
 }
 
 function toPromptEntry(entry: ConversationEntry): HistoryEntry | null {

--- a/src/gateway/agent-prompt.ts
+++ b/src/gateway/agent-prompt.ts
@@ -1,3 +1,5 @@
+import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
+import { stripInternalMetadataForDisplay } from "../auto-reply/reply/display-text-sanitize.js";
 import { buildHistoryContextFromEntries, type HistoryEntry } from "../auto-reply/reply/history.js";
 import { extractTextFromChatContent } from "../shared/chat-content.js";
 
@@ -11,11 +13,13 @@ export type ConversationEntry = {
  * (e.g. [{type:"text", text:"hello"}]) that would serialize as
  * [object Object] if used directly in a template literal.
  */
+function stripInternalReplayPlaceholder(text: string): string {
+  return text.trim() === STREAM_ERROR_FALLBACK_TEXT ? "" : text;
+}
+
 function safeBody(body: unknown): string {
-  if (typeof body === "string") {
-    return body;
-  }
-  return extractTextFromChatContent(body) ?? "";
+  const text = typeof body === "string" ? body : (extractTextFromChatContent(body) ?? "");
+  return stripInternalReplayPlaceholder(stripInternalMetadataForDisplay(text));
 }
 
 export function buildAgentMessageFromConversationEntries(entries: ConversationEntry[]): string {

--- a/src/gateway/agent-prompt.ts
+++ b/src/gateway/agent-prompt.ts
@@ -46,7 +46,10 @@ export function buildAgentMessageFromConversationEntries(entries: ConversationEn
     return "";
   }
 
-  const historyEntries = entries.slice(0, currentIndex).map((e) => e.entry);
+  const historyEntries = entries
+    .slice(0, currentIndex)
+    .map((e) => e.entry)
+    .filter((entry) => safeBody(entry.body).trim().length > 0);
   if (historyEntries.length === 0) {
     return safeBody(currentEntry.body);
   }

--- a/src/gateway/agent-prompt.ts
+++ b/src/gateway/agent-prompt.ts
@@ -13,13 +13,20 @@ export type ConversationEntry = {
  * (e.g. [{type:"text", text:"hello"}]) that would serialize as
  * [object Object] if used directly in a template literal.
  */
-function stripInternalReplayPlaceholder(text: string): string {
-  return text.trim() === STREAM_ERROR_FALLBACK_TEXT ? "" : text;
-}
-
 function safeBody(body: unknown): string {
   const text = typeof body === "string" ? body : (extractTextFromChatContent(body) ?? "");
-  return stripInternalReplayPlaceholder(stripInternalMetadataForDisplay(text));
+  return stripInternalMetadataForDisplay(text);
+}
+
+function toPromptEntry(entry: ConversationEntry): HistoryEntry | null {
+  const body = safeBody(entry.entry.body);
+  if (entry.role === "assistant" && body.trim() === STREAM_ERROR_FALLBACK_TEXT) {
+    return null;
+  }
+  return {
+    ...entry.entry,
+    body,
+  };
 }
 
 export function buildAgentMessageFromConversationEntries(entries: ConversationEntry[]): string {
@@ -41,23 +48,28 @@ export function buildAgentMessageFromConversationEntries(entries: ConversationEn
     currentIndex = entries.length - 1;
   }
 
-  const currentEntry = entries[currentIndex]?.entry;
-  if (!currentEntry) {
+  const currentConversationEntry = entries[currentIndex];
+  const currentEntry = currentConversationEntry?.entry;
+  if (!currentConversationEntry || !currentEntry) {
     return "";
   }
 
   const historyEntries = entries
     .slice(0, currentIndex)
-    .map((e) => e.entry)
-    .filter((entry) => safeBody(entry.body).trim().length > 0);
+    .map(toPromptEntry)
+    .filter((entry): entry is HistoryEntry => entry !== null && entry.body.trim().length > 0);
+  const currentPromptEntry = toPromptEntry(currentConversationEntry);
+  if (!currentPromptEntry) {
+    return "";
+  }
   if (historyEntries.length === 0) {
-    return safeBody(currentEntry.body);
+    return currentPromptEntry.body;
   }
 
-  const formatEntry = (entry: HistoryEntry) => `${entry.sender}: ${safeBody(entry.body)}`;
+  const formatEntry = (entry: HistoryEntry) => `${entry.sender}: ${entry.body}`;
   return buildHistoryContextFromEntries({
-    entries: [...historyEntries, currentEntry],
-    currentMessage: formatEntry(currentEntry),
+    entries: [...historyEntries, currentPromptEntry],
+    currentMessage: formatEntry(currentPromptEntry),
     formatEntry,
   });
 }

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -3,6 +3,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { ClientToolDefinition } from "../agents/command/shared-types.js";
 import type { ImageContent } from "../agents/command/types.js";
 import { isClientToolNameConflictError } from "../agents/pi-tool-definition-adapter.js";
+import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
 import {
   hasNonzeroUsage,
   normalizeUsage,
@@ -62,6 +63,7 @@ type OpenAiChatMessage = {
   name?: unknown;
   tool_call_id?: unknown;
   tool_calls?: unknown;
+  stopReason?: unknown;
 };
 
 type OpenAiChatCompletionRequest = {
@@ -654,6 +656,10 @@ function buildAgentPrompt(
     conversationEntries.push({
       role: normalizedRole,
       entry: { sender, body: messageContent },
+      internalStreamError:
+        normalizedRole === "assistant" &&
+        normalizeOptionalString(msg.stopReason) === "error" &&
+        messageContent.trim() === STREAM_ERROR_FALLBACK_TEXT,
     });
   }
 

--- a/src/plugin-activation-boundary.test.ts
+++ b/src/plugin-activation-boundary.test.ts
@@ -146,7 +146,7 @@ describe("plugin activation boundary", () => {
     });
     expect(normalizeModelRef("xai", "grok-4-fast-reasoning", staticNormalize)).toEqual({
       provider: "xai",
-      model: "grok-4-fast",
+      model: "grok-4-fast-reasoning",
     });
     expect(loadBundledPluginPublicSurfaceModuleSync).not.toHaveBeenCalled();
 

--- a/src/plugin-activation-boundary.test.ts
+++ b/src/plugin-activation-boundary.test.ts
@@ -146,7 +146,7 @@ describe("plugin activation boundary", () => {
     });
     expect(normalizeModelRef("xai", "grok-4-fast-reasoning", staticNormalize)).toEqual({
       provider: "xai",
-      model: "grok-4-fast-reasoning",
+      model: "grok-4-fast",
     });
     expect(loadBundledPluginPublicSurfaceModuleSync).not.toHaveBeenCalled();
 


### PR DESCRIPTION
## Summary

Omit exact internal assistant stream-error placeholder entries from Gateway agent prompt history so failed assistant turns are not replayed as model-authored text.

## Changes

- Drop only assistant history entries whose extracted body is exactly the internal fallback sentinel.
- Preserve user/tool text, including text that exactly matches or merely mentions the sentinel.
- Keep content-array extraction behavior unchanged.
- Add regression coverage for assistant omission, ordinary mentions, exact user text, and current user text that looks like display metadata.

## Verification

Behavior addressed: Internal failed-assistant sentinel text is no longer replayed into Gateway agent prompts as assistant-authored content.
Real environment tested: Local source checkout, macOS, Node 24.15.0 through mise.
Exact steps or command run after this patch:
  - `mise exec node@24 -- pnpm format:check CHANGELOG.md src/gateway/agent-prompt.ts src/gateway/agent-prompt.test.ts`
  - `mise exec node@24 -- node scripts/run-vitest.mjs --project gateway-core src/gateway/agent-prompt.test.ts`
  - `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
Evidence after fix: format check passed; gateway prompt test passed 10 tests; autoreview clean with no accepted/actionable findings.
Observed result after fix: Assistant sentinel entries are omitted, while user/tool content and ordinary assistant diagnostic mentions are preserved.
What was not tested: Live Gateway/OpenAI-compatible client replay; this is covered as source-level prompt formatting behavior.
