### PR TITLE
fix(telegram): normalize durable group retry targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/compaction: skip agent-harness preflight for provider-owned CLI runtime sessions so over-threshold Claude CLI sessions continue through normal compaction instead of failing on a missing harness. Fixes #84857. (#84878) Thanks @zhangguiping-xydt.
+- Telegram: normalize legacy durable group retry targets before retry sends, polls, and pins so group retries keep using the real chat id. (#85656) Thanks @luoyanglang.
 - WebChat: summarize internal message-tool source replies so tool cards no longer duplicate the visible reply body. (#84773) Thanks @jason-allen-oneal.
 - WebChat: scope the visible attachment button to its own composer file input so clicking Upload reliably opens the file picker. (#83952, fixes #47983) Thanks @jason-allen-oneal.
 - Gateway: preserve deferred lifecycle-error cleanup across later non-terminal events so provider timeouts can persist failed session state instead of leaving sessions stuck running. (#85256, fixes #63819) Thanks @samzong.

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -4,9 +4,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const sendMessageTelegramMock = vi.fn();
 const pinMessageTelegramMock = vi.fn();
+const sendPollTelegramMock = vi.fn();
 
 vi.mock("./send.js", () => ({
   pinMessageTelegram: (...args: unknown[]) => pinMessageTelegramMock(...args),
+  sendPollTelegram: (...args: unknown[]) => sendPollTelegramMock(...args),
   sendMessageTelegram: (...args: unknown[]) => sendMessageTelegramMock(...args),
 }));
 
@@ -57,6 +59,7 @@ function callOptionsFromEnd(
 describe("telegramOutbound", () => {
   beforeEach(() => {
     pinMessageTelegramMock.mockReset();
+    sendPollTelegramMock.mockReset();
     sendMessageTelegramMock.mockReset();
   });
 
@@ -444,6 +447,33 @@ describe("telegramOutbound", () => {
     });
 
     lastCallOptions(sendMessageTelegramMock, "group:not-a-number", "bad retry target");
+  });
+
+  it("normalizes legacy durable group retry topic targets before Telegram polls", async () => {
+    sendPollTelegramMock.mockResolvedValueOnce({
+      messageId: "tg-poll-retry",
+      chatId: "-1001234567890",
+    });
+
+    await telegramOutbound.sendPoll?.({
+      cfg: {} as never,
+      to: "group:-1001234567890:topic:77",
+      poll: { question: "Retry?", options: ["Yes", "No"] },
+      accountId: "ops",
+    });
+
+    expect(sendPollTelegramMock).toHaveBeenCalledWith(
+      "-1001234567890:topic:77",
+      { question: "Retry?", options: ["Yes", "No"] },
+      {
+        cfg: {},
+        accountId: "ops",
+        messageThreadId: undefined,
+        silent: undefined,
+        isAnonymous: undefined,
+        gatewayClientScopes: undefined,
+      },
+    );
   });
 
   it("forwards audioAsVoice payload media to Telegram voice sends", async () => {

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -572,4 +572,23 @@ describe("telegramOutbound", () => {
     expect(options.notify).toBe(true);
     expect(options.verbose).toBe(false);
   });
+
+  it("normalizes legacy durable group retry targets before Telegram pinning", async () => {
+    pinMessageTelegramMock.mockResolvedValueOnce({
+      ok: true,
+      messageId: "tg-group-retry",
+      chatId: "-1001234567890",
+    });
+
+    await telegramOutbound.pinDeliveredMessage?.({
+      cfg: {} as never,
+      target: { channel: "telegram", to: "group:-1001234567890", accountId: "ops" },
+      messageId: "tg-group-retry",
+      pin: { enabled: true, notify: false },
+    });
+
+    const options = callOptionsAt(pinMessageTelegramMock, 0, "-1001234567890", "tg-group-retry");
+    expect(options.accountId).toBe("ops");
+    expect(options.notify).toBe(false);
+  });
 });

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -381,6 +381,71 @@ describe("telegramOutbound", () => {
     expect(options.textMode).toBeUndefined();
   });
 
+  it("normalizes legacy durable group retry targets before Telegram sends", async () => {
+    sendMessageTelegramMock.mockResolvedValueOnce({
+      messageId: "tg-group-retry",
+      chatId: "-1001234567890",
+    });
+
+    await telegramOutbound.sendText!({
+      cfg: {} as never,
+      to: "group:-1001234567890",
+      text: "retry reminder",
+      deps: { sendTelegram: sendMessageTelegramMock },
+    });
+
+    lastCallOptions(sendMessageTelegramMock, "-1001234567890", "retry reminder");
+  });
+
+  it("keeps numeric durable retry targets unchanged", async () => {
+    sendMessageTelegramMock.mockResolvedValueOnce({
+      messageId: "tg-direct-retry",
+      chatId: "123456789",
+    });
+
+    await telegramOutbound.sendText!({
+      cfg: {} as never,
+      to: "123456789",
+      text: "retry direct",
+      deps: { sendTelegram: sendMessageTelegramMock },
+    });
+
+    lastCallOptions(sendMessageTelegramMock, "123456789", "retry direct");
+  });
+
+  it("normalizes legacy durable group retry targets with topic suffixes", async () => {
+    sendMessageTelegramMock.mockResolvedValueOnce({
+      messageId: "tg-topic-retry",
+      chatId: "-1001234567890",
+    });
+
+    await telegramOutbound.sendPayload!({
+      cfg: {} as never,
+      to: "group:-1001234567890:topic:77",
+      text: "",
+      payload: { text: "topic retry" },
+      deps: { sendTelegram: sendMessageTelegramMock },
+    });
+
+    lastCallOptions(sendMessageTelegramMock, "-1001234567890:topic:77", "topic retry");
+  });
+
+  it("does not make non-numeric legacy group targets look valid", async () => {
+    sendMessageTelegramMock.mockResolvedValueOnce({
+      messageId: "tg-invalid-retry",
+      chatId: "group:not-a-number",
+    });
+
+    await telegramOutbound.sendText!({
+      cfg: {} as never,
+      to: "group:not-a-number",
+      text: "bad retry target",
+      deps: { sendTelegram: sendMessageTelegramMock },
+    });
+
+    lastCallOptions(sendMessageTelegramMock, "group:not-a-number", "bad retry target");
+  });
+
   it("forwards audioAsVoice payload media to Telegram voice sends", async () => {
     sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-voice", chatId: "12345" });
 

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -591,4 +591,23 @@ describe("telegramOutbound", () => {
     expect(options.accountId).toBe("ops");
     expect(options.notify).toBe(false);
   });
+
+  it("normalizes legacy durable group retry topic targets before Telegram pinning", async () => {
+    pinMessageTelegramMock.mockResolvedValueOnce({
+      ok: true,
+      messageId: "tg-topic-retry",
+      chatId: "-1001234567890",
+    });
+
+    await telegramOutbound.pinDeliveredMessage?.({
+      cfg: {} as never,
+      target: { channel: "telegram", to: "group:-1001234567890:topic:77", accountId: "ops" },
+      messageId: "tg-topic-retry",
+      pin: { enabled: true, notify: false },
+    });
+
+    const options = callOptionsAt(pinMessageTelegramMock, 0, "-1001234567890", "tg-topic-retry");
+    expect(options.accountId).toBe("ops");
+    expect(options.notify).toBe(false);
+  });
 });

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -229,7 +229,8 @@ export function createTelegramOutboundAdapter(
     },
     pinDeliveredMessage: async ({ cfg, target, messageId, pin }) => {
       const { pinMessageTelegram } = await loadSendModule();
-      await pinMessageTelegram(target.to, messageId, {
+      const outboundTo = normalizeTelegramOutboundTarget(target.to);
+      await pinMessageTelegram(outboundTo, messageId, {
         cfg,
         accountId: target.accountId ?? undefined,
         notify: pin.notify,

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -22,7 +22,7 @@ import { resolveTelegramInlineButtons } from "./button-types.js";
 import { markdownToTelegramHtmlChunks, splitTelegramHtmlChunks } from "./format.js";
 import { resolveTelegramInteractiveTextFallback } from "./interactive-fallback.js";
 import { parseTelegramReplyToMessageId, parseTelegramThreadId } from "./outbound-params.js";
-import { normalizeTelegramOutboundTarget } from "./targets.js";
+import { normalizeTelegramOutboundTarget, parseTelegramTarget } from "./targets.js";
 
 export const TELEGRAM_TEXT_CHUNK_LIMIT = 4000;
 export const TELEGRAM_POLL_OPTION_LIMIT = 10;
@@ -230,7 +230,8 @@ export function createTelegramOutboundAdapter(
     pinDeliveredMessage: async ({ cfg, target, messageId, pin }) => {
       const { pinMessageTelegram } = await loadSendModule();
       const outboundTo = normalizeTelegramOutboundTarget(target.to);
-      await pinMessageTelegram(outboundTo, messageId, {
+      const pinTarget = parseTelegramTarget(outboundTo);
+      await pinMessageTelegram(pinTarget.chatId, messageId, {
         cfg,
         accountId: target.accountId ?? undefined,
         notify: pin.notify,

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -22,6 +22,7 @@ import { resolveTelegramInlineButtons } from "./button-types.js";
 import { markdownToTelegramHtmlChunks, splitTelegramHtmlChunks } from "./format.js";
 import { resolveTelegramInteractiveTextFallback } from "./interactive-fallback.js";
 import { parseTelegramReplyToMessageId, parseTelegramThreadId } from "./outbound-params.js";
+import { normalizeTelegramOutboundTarget } from "./targets.js";
 
 export const TELEGRAM_TEXT_CHUNK_LIMIT = 4000;
 export const TELEGRAM_POLL_OPTION_LIMIT = 10;
@@ -254,6 +255,7 @@ export function createTelegramOutboundAdapter(
         silent,
         gatewayClientScopes,
       }) => {
+        const outboundTo = normalizeTelegramOutboundTarget(to);
         const { send, baseOpts } = await resolveTelegramSendContext({
           cfg,
           deps,
@@ -265,7 +267,7 @@ export function createTelegramOutboundAdapter(
           gatewayClientScopes,
           resolveSend,
         });
-        return await send(to, text, {
+        return await send(outboundTo, text, {
           ...baseOpts,
         });
       },
@@ -285,6 +287,7 @@ export function createTelegramOutboundAdapter(
         silent,
         gatewayClientScopes,
       }) => {
+        const outboundTo = normalizeTelegramOutboundTarget(to);
         const { send, baseOpts } = await resolveTelegramSendContext({
           cfg,
           deps,
@@ -296,7 +299,7 @@ export function createTelegramOutboundAdapter(
           gatewayClientScopes,
           resolveSend,
         });
-        return await send(to, text, {
+        return await send(outboundTo, text, {
           ...baseOpts,
           mediaUrl,
           mediaLocalRoots,
@@ -320,6 +323,7 @@ export function createTelegramOutboundAdapter(
       silent,
       gatewayClientScopes,
     }) => {
+      const outboundTo = normalizeTelegramOutboundTarget(to);
       const { send, baseOpts } = await resolveTelegramSendContext({
         cfg,
         deps,
@@ -333,7 +337,7 @@ export function createTelegramOutboundAdapter(
       });
       const result = await sendTelegramPayloadMessages({
         send,
-        to,
+        to: outboundTo,
         payload,
         baseOpts: {
           ...baseOpts,
@@ -354,8 +358,9 @@ export function createTelegramOutboundAdapter(
       isAnonymous,
       gatewayClientScopes,
     }) => {
+      const outboundTo = normalizeTelegramOutboundTarget(to);
       const { sendPollTelegram } = await loadSendModule();
-      return await sendPollTelegram(to, poll, {
+      return await sendPollTelegram(outboundTo, poll, {
         cfg,
         accountId: accountId ?? undefined,
         messageThreadId: parseTelegramThreadId(threadId),

--- a/extensions/telegram/src/targets.test.ts
+++ b/extensions/telegram/src/targets.test.ts
@@ -14,6 +14,7 @@ import {
   isNumericTelegramChatId,
   normalizeTelegramChatId,
   normalizeTelegramLookupTarget,
+  normalizeTelegramOutboundTarget,
   parseTelegramTarget,
   stripTelegramInternalPrefixes,
 } from "./targets.js";
@@ -104,6 +105,25 @@ describe("telegram numeric target normalization", () => {
       expect(normalize("123456789")).toBe("123456789");
     },
   );
+});
+
+describe("normalizeTelegramOutboundTarget", () => {
+  it("normalizes legacy durable group retry targets for Telegram sends", () => {
+    expect(normalizeTelegramOutboundTarget("group:-1001234567890")).toBe("-1001234567890");
+  });
+
+  it("normalizes legacy durable group retry targets with topic suffixes", () => {
+    expect(normalizeTelegramOutboundTarget("group:-1001234567890:topic:77")).toBe(
+      "-1001234567890:topic:77",
+    );
+    expect(normalizeTelegramOutboundTarget("group:-1001234567890:77")).toBe("-1001234567890:77");
+  });
+
+  it("keeps already-valid numeric and non-numeric targets on the send path", () => {
+    expect(normalizeTelegramOutboundTarget("-1001234567890")).toBe("-1001234567890");
+    expect(normalizeTelegramOutboundTarget("group:not-a-number")).toBe("group:not-a-number");
+    expect(normalizeTelegramOutboundTarget("@mychannel")).toBe("@mychannel");
+  });
 });
 
 describe("normalizeTelegramChatId", () => {

--- a/extensions/telegram/src/targets.ts
+++ b/extensions/telegram/src/targets.ts
@@ -44,6 +44,15 @@ export function isNumericTelegramChatId(raw: string): boolean {
   return TELEGRAM_NUMERIC_CHAT_ID_REGEX.test(raw.trim());
 }
 
+export function normalizeTelegramOutboundTarget(raw: string): string {
+  const trimmed = raw.trim();
+  const legacyGroupMatch = /^group:(-?\d+(?::topic:\d+|:\d+)?)$/i.exec(trimmed);
+  if (legacyGroupMatch?.[1]) {
+    return legacyGroupMatch[1];
+  }
+  return raw;
+}
+
 export function normalizeTelegramLookupTarget(raw: string): string | undefined {
   const stripped = stripTelegramInternalPrefixes(raw);
   if (!stripped) {

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -1114,9 +1114,9 @@ describe("startGatewayPostAttachRuntime", () => {
         const onPluginServices = vi.fn();
         hoisted.startPluginServices.mockImplementationOnce(
           async () =>
-            await new Promise((resolve) => {
+            (await new Promise<typeof pluginServices>((resolve) => {
               releasePluginServices = () => resolve(pluginServices);
-            }),
+            })) as never,
         );
 
         const sidecarsPromise = startGatewaySidecars({


### PR DESCRIPTION
Telegram durable retry replay currently preserves legacy `group:-100...` targets, so Telegram rejects the retry as a non-numeric chat id and the real reminder can be lost after the retry limit.

Fixes #85640

## Affected surface

- `extensions/telegram/src/outbound-adapter.ts`
  - `sendText`
  - `sendMedia`
  - `sendPayload`
  - `sendPoll`
- `extensions/telegram/src/targets.ts`
  - new `normalizeTelegramOutboundTarget()`

## Scope

This normalizes legacy `group:<numeric>` targets at the Telegram outbound/retry boundary before calling the Telegram send functions.

It intentionally does not:

- expand `stripTelegramInternalPrefixes()` semantics, because that helper still distinguishes inbound/internal `telegram:group:...` forms from bare legacy retry targets
- modify the generic durable delivery queue
- add a config, option, or flag
- touch the announce path covered by #81229

## Coverage note

#81229 covers the announce path through `messaging.resolveSessionTarget`. This PR covers the durable retry replay path where the outbound adapter receives a stored `to: "group:-100..."` target and passes it to Telegram send logic.

Push-before-PR searches found no open PR covering this issue:

```text
$ gh search prs --repo openclaw/openclaw --state open "Fixes #85640" --json number,title,body,url,updatedAt --limit 10
[]
$ gh search prs --repo openclaw/openclaw --state open "#85640" --json number,title,body,url,updatedAt --limit 10
[]
$ gh search prs --repo openclaw/openclaw --state open "stripTelegramInternalPrefixes" --json number,title,body,url,updatedAt --limit 10
[]
$ gh search prs --repo openclaw/openclaw --state open "outbound-adapter.ts Telegram retry" --json number,title,body,url,updatedAt --limit 10
[]
$ gh search prs --repo openclaw/openclaw --state open "Telegram retry group numeric chat ID" --json number,title,body,url,updatedAt --limit 10
[]
```

## Real behavior proof

- Behavior or issue addressed: Telegram durable retry/outbound replay should send legacy stored `group:-100...` targets as numeric Telegram chat IDs so retry sends do not fail with `Telegram recipient must be a numeric chat ID`.
- Real environment tested: local OpenClaw checkout on Linux, branch `wolf/telegram-durable-retry-group-normalize`, head `94fe6cf029`, using a direct `node --import tsx` runtime import of `extensions/telegram/src/targets.ts` plus repository validation commands.
- Exact steps or command run after the patch: ran this direct runtime command from the OpenClaw repo root after the patch:
  ```text
  node --import tsx -e 'const { normalizeTelegramOutboundTarget } = await import("./extensions/telegram/src/targets.ts"); const cases = ["group:-1001234567890", "group:-1001234567890:topic:77", "123456789", "group:not-a-number"]; for (const value of cases) console.log(`${value} -> ${normalizeTelegramOutboundTarget(value)}`);'
  ```
- Evidence after fix: terminal output from the actual source module runtime import:
  ```text
  $ node --import tsx -e 'const { normalizeTelegramOutboundTarget } = await import("./extensions/telegram/src/targets.ts"); const cases = ["group:-1001234567890", "group:-1001234567890:topic:77", "123456789", "group:not-a-number"]; for (const value of cases) console.log(`${value} -> ${normalizeTelegramOutboundTarget(value)}`);'
  group:-1001234567890 -> -1001234567890
  group:-1001234567890:topic:77 -> -1001234567890:topic:77
  123456789 -> 123456789
  group:not-a-number -> group:not-a-number
  ```
- Observed result after fix: `group:-1001234567890` becomes `-1001234567890`, `group:-1001234567890:topic:77` becomes `-1001234567890:topic:77`, numeric chat IDs remain unchanged, and non-numeric `group:not-a-number` is not made valid.
- What was not tested: I did not run the full durable queue worker/retry scheduler end-to-end; the live proof below validates the Telegram outbound/retry boundary that this patch changes.

### Live Telegram delivery proof for current head `94fe6cf029`

Validates ClawSweeper-requested live Telegram proof for `mantis: telegram-visible-proof`. The Mantis automatic request path is blocked by contributor actor permissions, so this supplies contributor-side live proof instead.

Live setup:

- Head: `94fe6cf0295fd93ba6eb0ce0a4bbcb60683c1d00`
- Method: repo-external harness imports current source `createTelegramOutboundAdapter()` and `normalizeTelegramOutboundTarget()`, then sends through the live Telegram Bot API `sendMessage`.
- Credentials: read from the local secret store; token and chat ids are redacted from logs and are not committed.
- Screenshot proof: https://github.com/openclaw/openclaw/pull/85656#issuecomment-4524598788
  - `https://github.com/user-attachments/assets/91932218-7853-4c83-9903-44e0495f2524`
  - `https://github.com/user-attachments/assets/6d63c1fd-e2d1-4fdd-ab44-78c8854dd4a4`

Redacted live output:

```text
T+0s case=legacy_group_retry input=group:<redacted-topic-chat-id> normalized=<redacted-topic-chat-id> expect=success
T+1s method=sendMessage target=<redacted-topic-chat-id> http_status=200 message_id=12
T+1s case=legacy_group_retry result=success message_id=12

T+1s case=already_numeric input=<redacted-topic-chat-id> normalized=<redacted-topic-chat-id> expect=success
T+1s method=sendMessage target=<redacted-topic-chat-id> http_status=200 message_id=13
T+1s case=already_numeric result=success message_id=13

T+1s case=legacy_group_topic_retry input=group:<redacted-topic-chat-id>:topic:10 normalized=<redacted-topic-chat-id>:topic:10 expect=success
T+2s method=sendMessage target=<redacted-topic-chat-id>:topic:10 http_status=200 message_id=14
T+2s case=legacy_group_topic_retry result=success message_id=14

T+2s case=invalid_non_numeric input=notavalidchat normalized=notavalidchat expect=failure
T+2s method=sendMessage target=notavalidchat http_status=400 telegram_error_code=400 telegram_error="Bad Request: chat not found"
T+2s case=invalid_non_numeric result=expected_failure error="Telegram sendMessage failed: 400 Bad Request: chat not found"

T+2s proof_complete=true
```

Observed live behavior:

- Legacy durable retry form `group:<redacted-topic-chat-id>` is normalized and delivered (`message_id=12`).
- Already-normalized numeric target remains deliverable (`message_id=13`).
- Topic suffix form `group:<redacted-topic-chat-id>:topic:10` is normalized to `<redacted-topic-chat-id>:topic:10` and delivered to the live topic (`message_id=14`).
- Invalid non-numeric target remains invalid and is rejected by Telegram (`Bad Request: chat not found`), so the patch does not make bad targets falsely valid.

### Current-head Telegram pin proof for `c96d27df5e`

This validates the follow-up pin normalization path added after ClawSweeper's P2 finding. The harness is repo-external, imports current head `telegramOutbound.pinDeliveredMessage()`, sends one live Telegram message, then calls `pinDeliveredMessage` with the legacy durable retry target form `group:<redacted-topic-chat-id>`. A successful `pinDeliveredMessage` proves the PR path normalized the legacy target before `pinMessageTelegram`, because the unnormalized form fails Telegram chat-id resolution before the Bot API pin call.

Redacted live output:

```text
T+0s head=c96d27df5e case=legacy_group_pin input=group:<redacted-topic-chat-id> expect=success
T+1s method=sendMessage target=<redacted-topic-chat-id> http_status=200 message_id=19
T+2s method=pinDeliveredMessage input=group:<redacted-topic-chat-id> normalized_shape=numeric http_status=200 message_id=19
T+2s proof_complete=true
```

Follow-up RED/GREEN for the pin path:

```text
$ pnpm test extensions/telegram/src/outbound-adapter.test.ts -- -t "normalizes legacy durable group retry targets before Telegram pinning"
FAIL  |extension-telegram| extensions/telegram/src/outbound-adapter.test.ts > telegramOutbound > normalizes legacy durable group retry targets before Telegram pinning
AssertionError: expected 'group:-1001234567890' to be '-1001234567890'
Tests  1 failed | 18 skipped (19)

$ pnpm test extensions/telegram/src/outbound-adapter.test.ts -- -t "normalizes legacy durable group retry targets before Telegram pinning"
Test Files  1 passed (1)
Tests  1 passed | 18 skipped (19)
```

Latest-head targeted validation:

```text
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/outbound-adapter.test.ts extensions/telegram/src/targets.test.ts
Test Files  2 passed (2)
Tests  55 passed (55)
```

RED before the fix:

```text
$ pnpm test extensions/telegram/src/outbound-adapter.test.ts -t "legacy durable group retry"
FAIL  |extension-telegram| extensions/telegram/src/outbound-adapter.test.ts > telegramOutbound > normalizes legacy durable group retry targets before Telegram sends
AssertionError: expected 'group:-1001234567890' to be '-1001234567890'

FAIL  |extension-telegram| extensions/telegram/src/outbound-adapter.test.ts > telegramOutbound > normalizes legacy durable group retry targets with topic suffixes
AssertionError: expected 'group:-1001234567890:topic:77' to be '-1001234567890:topic:77'

Test Files  1 failed (1)
Tests  2 failed | 16 skipped (18)
```

GREEN after the fix:

```text
$ pnpm test extensions/telegram/src/outbound-adapter.test.ts extensions/telegram/src/targets.test.ts
Test Files  2 passed (2)
Tests  54 passed (54)
[test] passed 1 Vitest shard
```

Changed-lane validation:

```text
$ pnpm check:changed --base origin/main
[check:changed] lanes=extensions, extensionTests
[check:changed] extensions/telegram/src/outbound-adapter.test.ts: extension test
[check:changed] extensions/telegram/src/outbound-adapter.ts: extension production
[check:changed] extensions/telegram/src/targets.test.ts: extension test
[check:changed] extensions/telegram/src/targets.ts: extension production
[check:changed] conflict markers
[check:changed] changelog attributions
[check:changed] guarded extension wildcard re-exports
No guarded extension wildcard re-exports found.
[check:changed] plugin-sdk wildcard re-exports
No plugin-sdk wildcard re-exports found in extension API barrels.
[check:changed] duplicate scan target coverage
[dup:check] target coverage ok
[check:changed] dependency pin guard
PASS direct dependency pin guard
[check:changed] package patch guard
PASS package patch guard: no new pnpm patches; 3 legacy patches allowlisted.
[check:changed] typecheck extensions
[check:changed] typecheck extension tests
[check:changed] lint extensions
[check:changed] media download helper guard
[check:changed] runtime sidecar loader guard
runtime-sidecar-loaders: local runtime sidecar loaders look OK.
[check:changed] runtime import cycles
Import cycle check: 0 runtime value cycle(s).
```

Other local checks:

```text
$ git diff --check origin/main..HEAD
# exit 0

$ gitleaks protect --staged --redact
no leaks found
```

## What was not tested

- I did not run the full durable queue worker/retry scheduler end-to-end.
- The source-level regression and live Telegram proof cover the changed outbound/retry boundary by proving `group:-100...` and `group:-100...:topic:NN` are normalized before Telegram send functions receive them, while numeric targets remain unchanged and non-numeric targets remain invalid.
- Latest-head pin proof additionally covers `pinDeliveredMessage` with a legacy `group:<redacted-topic-chat-id>` target and a live Bot API pin success.
