### PR TITLE
Harden SafeOps final config risk defaults

### DIFF
--- a/src/agents/skills/gh-config-discovery.test.ts
+++ b/src/agents/skills/gh-config-discovery.test.ts
@@ -48,7 +48,7 @@ describe("detectGhConfigDirMismatch", () => {
     });
   });
 
-  it("flags a mismatch when /root/.config/gh has hosts.yml but the agent HOME does not", () => {
+  it("does not guess /root by default when the agent HOME does not have gh auth", () => {
     const result = detectGhConfigDirMismatch(
       makeInput({
         env: { HOME: "/root/.openclaw/agents/main/agent/codex-home/home" },
@@ -56,20 +56,43 @@ describe("detectGhConfigDirMismatch", () => {
       }),
     );
     expect(result).toEqual({
-      kind: "mismatch",
+      kind: "no-known-auth",
       effectiveConfigDir: "/root/.openclaw/agents/main/agent/codex-home/home/.config/gh",
-      alternateConfigDir: "/root/.config/gh",
-      alternateHostsFile: "/root/.config/gh/hosts.yml",
-      alternateHomeHint: "/root",
-      suggestedEnvValue: "/root/.config/gh",
     });
   });
 
-  it("uses SUDO_USER home as a candidate when set", () => {
+  it("does not derive SUDO_USER home candidates unless explicitly configured", () => {
     const result = detectGhConfigDirMismatch(
       makeInput({
         env: { HOME: "/var/lib/openclaw/agent", SUDO_USER: "alice" },
         fileExists: fileSet("/home/alice/.config/gh/hosts.yml"),
+      }),
+    );
+    expect(result).toEqual({
+      kind: "no-known-auth",
+      effectiveConfigDir: "/var/lib/openclaw/agent/.config/gh",
+    });
+  });
+
+  it("does not derive USER home candidates unless explicitly configured", () => {
+    const result = detectGhConfigDirMismatch(
+      makeInput({
+        env: { HOME: "/var/lib/openclaw/agent", USER: "ops" },
+        fileExists: fileSet("/home/ops/.config/gh/hosts.yml"),
+      }),
+    );
+    expect(result).toEqual({
+      kind: "no-known-auth",
+      effectiveConfigDir: "/var/lib/openclaw/agent/.config/gh",
+    });
+  });
+
+  it("flags an explicit candidateOperatorHomes mismatch", () => {
+    const result = detectGhConfigDirMismatch(
+      makeInput({
+        env: { HOME: "/var/lib/openclaw/agent", SUDO_USER: "alice" },
+        fileExists: fileSet("/home/alice/.config/gh/hosts.yml"),
+        candidateOperatorHomes: ["/home/alice"],
       }),
     );
     expect(result).toEqual({
@@ -82,31 +105,40 @@ describe("detectGhConfigDirMismatch", () => {
     });
   });
 
-  it("uses USER home as a fallback candidate when SUDO_USER is missing", () => {
+  it("flags explicit OPENCLAW_GH_CONFIG_DISCOVERY_HOMES values", () => {
     const result = detectGhConfigDirMismatch(
       makeInput({
-        env: { HOME: "/var/lib/openclaw/agent", USER: "ops" },
-        fileExists: fileSet("/home/ops/.config/gh/hosts.yml"),
+        env: {
+          HOME: "/agent/home",
+          OPENCLAW_GH_CONFIG_DISCOVERY_HOMES: "/srv/automation,/home/operator",
+        },
+        fileExists: fileSet("/home/operator/.config/gh/hosts.yml"),
       }),
     );
     expect(result).toEqual({
       kind: "mismatch",
-      effectiveConfigDir: "/var/lib/openclaw/agent/.config/gh",
-      alternateConfigDir: "/home/ops/.config/gh",
-      alternateHostsFile: "/home/ops/.config/gh/hosts.yml",
-      alternateHomeHint: "/home/ops",
-      suggestedEnvValue: "/home/ops/.config/gh",
+      effectiveConfigDir: "/agent/home/.config/gh",
+      alternateConfigDir: "/home/operator/.config/gh",
+      alternateHostsFile: "/home/operator/.config/gh/hosts.yml",
+      alternateHomeHint: "/home/operator",
+      suggestedEnvValue: "/home/operator/.config/gh",
     });
   });
 
-  it("ignores USER=root since /root is already part of the default candidate set", () => {
+  it("ignores relative OPENCLAW_GH_CONFIG_DISCOVERY_HOMES entries", () => {
     const result = detectGhConfigDirMismatch(
       makeInput({
-        env: { HOME: "/agent/home", USER: "root" },
-        fileExists: fileSet("/root/.config/gh/hosts.yml"),
+        env: {
+          HOME: "/agent/home",
+          OPENCLAW_GH_CONFIG_DISCOVERY_HOMES: "relative-home",
+        },
+        fileExists: fileSet("relative-home/.config/gh/hosts.yml"),
       }),
     );
-    expect(result.kind).toBe("mismatch");
+    expect(result).toEqual({
+      kind: "no-known-auth",
+      effectiveConfigDir: "/agent/home/.config/gh",
+    });
   });
 
   it("returns 'no-known-auth' when no candidate has hosts.yml", () => {
@@ -260,6 +292,7 @@ describe("formatGhConfigDirMismatchHint", () => {
       "  Authenticated config:  /root/.config/gh (contains hosts.yml)",
       "  Authenticated HOME:    /root",
       "  Fix: set GH_CONFIG_DIR=/root/.config/gh on the OpenClaw service environment, then restart the gateway.",
+      "  Optional diagnostic: set OPENCLAW_GH_CONFIG_DISCOVERY_HOMES=<absolute-home> to check this path again.",
     ]);
   });
 
@@ -274,6 +307,9 @@ describe("formatGhConfigDirMismatchHint", () => {
     expect(lines.join("\n")).not.toContain("Authenticated HOME");
     expect(lines).toContain(
       "  Fix: set GH_CONFIG_DIR=/srv/automation/.config/gh on the OpenClaw service environment, then restart the gateway.",
+    );
+    expect(lines).toContain(
+      "  Optional diagnostic: set OPENCLAW_GH_CONFIG_DISCOVERY_HOMES=<absolute-home> to check this path again.",
     );
   });
 });

--- a/src/agents/skills/gh-config-discovery.ts
+++ b/src/agents/skills/gh-config-discovery.ts
@@ -8,7 +8,14 @@ function pathFor(platform: NodeJS.Platform) {
 // OpenClaw process is running with a different HOME (e.g. the per-agent
 // codex-home, a systemd service home, or a sudo'd shell). Without GH_CONFIG_DIR
 // the gh CLI looks at $XDG_CONFIG_HOME/gh or $HOME/.config/gh and reports
-// "not logged in", even though the operator HOME has a valid hosts.yml.
+// "not logged in", even though the operator HOME may have a valid hosts.yml.
+//
+// This helper intentionally does not guess broad operator-home paths by
+// default. Operators who want this diagnostic can provide explicit candidate
+// homes through candidateOperatorHomes in tests/callers or through the
+// OPENCLAW_GH_CONFIG_DISCOVERY_HOMES environment variable in production. The
+// diagnostic still only suggests setting GH_CONFIG_DIR; it never reads or copies
+// GitHub CLI auth material.
 // See https://github.com/openclaw/openclaw/issues/78063.
 
 export type GhConfigDiscoveryEnv = {
@@ -19,15 +26,17 @@ export type GhConfigDiscoveryEnv = {
   SUDO_USER?: string;
   USER?: string;
   USERPROFILE?: string;
+  OPENCLAW_GH_CONFIG_DISCOVERY_HOMES?: string;
 };
 
 export type GhConfigDiscoveryInput = {
   platform: NodeJS.Platform;
   env: GhConfigDiscoveryEnv;
   fileExists: (absolutePath: string) => boolean;
-  // Optional: well-known operator-home guesses to consider when looking for an
-  // alternate gh config dir. Defaults to a small Linux/macOS set; tests pass an
-  // explicit list to keep behavior deterministic.
+  // Optional: explicit operator-home directories to consider when looking for
+  // an alternate gh config dir. Defaults to the opt-in
+  // OPENCLAW_GH_CONFIG_DISCOVERY_HOMES env value; if that is unset, no
+  // alternate homes are probed.
   candidateOperatorHomes?: readonly string[];
 };
 
@@ -54,6 +63,7 @@ export type GhConfigDiscoveryResult =
   | ({ kind: "mismatch" } & GhConfigDirMismatch);
 
 const HOSTS_FILE = "hosts.yml";
+const OPERATOR_HOMES_ENV = "OPENCLAW_GH_CONFIG_DISCOVERY_HOMES";
 
 // gh config-dir lookup order, matching `gh help environment`.
 function resolveEffectiveGhConfigDir(input: GhConfigDiscoveryInput): string | undefined {
@@ -82,36 +92,31 @@ function resolveEffectiveGhConfigDir(input: GhConfigDiscoveryInput): string | un
   return pathFor(input.platform).join(home, ".config", "gh");
 }
 
+function parseExplicitCandidateOperatorHomes(
+  value: string | undefined,
+  platform: NodeJS.Platform,
+): string[] {
+  if (!value?.trim()) {
+    return [];
+  }
+  const pathApi = pathFor(platform);
+  return value
+    .split(/[\n,]/u)
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+    .filter((entry) => pathApi.isAbsolute(entry));
+}
+
 function defaultCandidateOperatorHomes(input: GhConfigDiscoveryInput): string[] {
-  const env = input.env;
-  const homes = new Set<string>();
-  // Common operator HOME on Linux servers running gateway as root.
-  if (input.platform !== "win32") {
-    homes.add("/root");
-  }
-  // sudo invocation: the original shell user's home is exposed through SUDO_USER.
-  if (env.SUDO_USER?.trim()) {
-    const sudoUser = env.SUDO_USER.trim();
-    homes.add(pathFor(input.platform).join("/home", sudoUser));
-    if (input.platform === "darwin") {
-      homes.add(pathFor(input.platform).join("/Users", sudoUser));
-    }
-  }
-  // USER fallback: works when HOME has been redirected but the login user is
-  // still on the env (e.g. systemd User= with PassEnvironment=USER).
-  if (env.USER?.trim()) {
-    const user = env.USER.trim();
-    if (user !== "root") {
-      if (input.platform === "darwin") {
-        homes.add(pathFor(input.platform).join("/Users", user));
-      } else if (input.platform !== "win32") {
-        homes.add(pathFor(input.platform).join("/home", user));
-      }
-    }
-  }
+  const homes = new Set(
+    parseExplicitCandidateOperatorHomes(
+      input.env.OPENCLAW_GH_CONFIG_DISCOVERY_HOMES,
+      input.platform,
+    ),
+  );
   // Drop the current process HOME from the candidate set; we want directories
   // that are NOT what gh would already consult.
-  const processHome = env.HOME?.trim();
+  const processHome = input.env.HOME?.trim();
   if (processHome) {
     homes.delete(processHome);
   }
@@ -170,6 +175,7 @@ export function formatGhConfigDirMismatchHint(mismatch: GhConfigDirMismatch): st
   }
   lines.push(
     `  Fix: set GH_CONFIG_DIR=${mismatch.suggestedEnvValue} on the OpenClaw service environment, then restart the gateway.`,
+    `  Optional diagnostic: set ${OPERATOR_HOMES_ENV}=<absolute-home> to check this path again.`,
   );
   return lines;
 }

--- a/src/config/gateway-control-ui-origins.test.ts
+++ b/src/config/gateway-control-ui-origins.test.ts
@@ -1,5 +1,37 @@
 import { describe, expect, it } from "vitest";
-import { ensureControlUiAllowedOriginsForNonLoopbackBind } from "./gateway-control-ui-origins.js";
+import {
+  buildDefaultControlUiAllowedOrigins,
+  ensureControlUiAllowedOriginsForNonLoopbackBind,
+  hasConfiguredControlUiAllowedOrigins,
+} from "./gateway-control-ui-origins.js";
+
+describe("buildDefaultControlUiAllowedOrigins", () => {
+  it("seeds loopback origins only for non-loopback bind modes", () => {
+    expect(
+      buildDefaultControlUiAllowedOrigins({
+        port: 1455,
+        bind: "custom",
+        customBindHost: "gateway.example.test",
+      }),
+    ).toEqual(["http://localhost:1455", "http://127.0.0.1:1455"]);
+  });
+
+  it("does not infer LAN or wildcard browser origins from bind mode", () => {
+    expect(
+      buildDefaultControlUiAllowedOrigins({
+        port: 1455,
+        bind: "lan",
+      }),
+    ).not.toContain("http://0.0.0.0:1455");
+    expect(
+      buildDefaultControlUiAllowedOrigins({
+        port: 1455,
+        bind: "custom",
+        customBindHost: "192.0.2.10",
+      }),
+    ).not.toContain("http://192.0.2.10:1455");
+  });
+});
 
 describe("ensureControlUiAllowedOriginsForNonLoopbackBind", () => {
   it("seeds Fly-style runtime bind and port when config is empty", () => {
@@ -66,6 +98,20 @@ describe("ensureControlUiAllowedOriginsForNonLoopbackBind", () => {
     expect(result.seededOrigins).toEqual(["http://localhost:18789", "http://127.0.0.1:18789"]);
   });
 
+  it("does not add custom bind hosts to automatic origins", () => {
+    const result = ensureControlUiAllowedOriginsForNonLoopbackBind({
+      gateway: {
+        bind: "custom",
+        customBindHost: "gateway.example.test",
+        port: 2444,
+      },
+    });
+
+    expect(result.bind).toBe("custom");
+    expect(result.seededOrigins).toEqual(["http://localhost:2444", "http://127.0.0.1:2444"]);
+    expect(result.seededOrigins).not.toContain("http://gateway.example.test:2444");
+  });
+
   it("does not overwrite explicit allowed origins", () => {
     const result = ensureControlUiAllowedOriginsForNonLoopbackBind(
       {
@@ -85,5 +131,25 @@ describe("ensureControlUiAllowedOriginsForNonLoopbackBind", () => {
     expect(result.config.gateway?.controlUi?.allowedOrigins).toEqual([
       "https://control.example.com",
     ]);
+  });
+});
+
+describe("hasConfiguredControlUiAllowedOrigins", () => {
+  it("treats explicit host-header fallback as configured", () => {
+    expect(
+      hasConfiguredControlUiAllowedOrigins({
+        allowedOrigins: [],
+        dangerouslyAllowHostHeaderOriginFallback: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores empty origin strings", () => {
+    expect(
+      hasConfiguredControlUiAllowedOrigins({
+        allowedOrigins: ["", "   "],
+        dangerouslyAllowHostHeaderOriginFallback: false,
+      }),
+    ).toBe(false);
   });
 });

--- a/src/config/gateway-control-ui-origins.ts
+++ b/src/config/gateway-control-ui-origins.ts
@@ -54,9 +54,9 @@ export function ensureControlUiAllowedOriginsForNonLoopbackBind(
     runtimePort?: unknown;
     /** Optional container-detection callback.  When provided and `gateway.bind`
      *  is unset, the function is called to determine whether the runtime will
-     *  default to `"auto"` (container) so that origins can be seeded
-     *  proactively.  Keeping this as an injected callback avoids a hard
-     *  dependency from the config layer on the gateway runtime layer. */
+     *  choose the container-friendly bind mode so loopback Control UI origins
+     *  can be prepared proactively.  Keeping this as an injected callback avoids
+     *  a hard dependency from the config layer on the gateway runtime layer. */
     isContainerEnvironment?: () => boolean;
   },
 ): {
@@ -65,10 +65,10 @@ export function ensureControlUiAllowedOriginsForNonLoopbackBind(
   bind: GatewayNonLoopbackBindMode | null;
 } {
   const bind = opts?.runtimeBind ?? config.gateway?.bind;
-  // When bind is unset (undefined) and we are inside a container, the runtime
-  // will default to "auto" → 0.0.0.0 via defaultGatewayBindMode().  We must
-  // seed origins *before* resolveGatewayRuntimeConfig runs, otherwise the
-  // non-loopback Control UI origin check will hard-fail on startup.
+  // When bind is unset and the process is containerized, the runtime chooses
+  // the container-friendly bind mode.  Prepare loopback Control UI origins here
+  // so startup keeps a concrete CORS allowlist without granting remote browser
+  // origins implicitly.
   const effectiveBind: typeof bind =
     bind ?? (opts?.isContainerEnvironment?.() ? "auto" : undefined);
   if (!isGatewayNonLoopbackBindMode(effectiveBind)) {

--- a/src/config/gateway-control-ui-origins.ts
+++ b/src/config/gateway-control-ui-origins.ts
@@ -32,15 +32,13 @@ export function buildDefaultControlUiAllowedOrigins(params: {
   bind: unknown;
   customBindHost?: string;
 }): string[] {
-  const origins = new Set<string>([
+  // Safe automatic defaults are loopback-only.  Non-loopback gateway binds still
+  // need CORS protection, but LAN/tailnet/custom browser origins must be
+  // configured explicitly by the operator instead of inferred from bind mode.
+  return [
     `http://localhost:${params.port}`,
     `http://127.0.0.1:${params.port}`,
-  ]);
-  const customBindHost = params.customBindHost?.trim();
-  if (params.bind === "custom" && customBindHost) {
-    origins.add(`http://${customBindHost}:${params.port}`);
-  }
-  return [...origins];
+  ];
 }
 
 export function ensureControlUiAllowedOriginsForNonLoopbackBind(

--- a/src/config/gateway-control-ui-origins.ts
+++ b/src/config/gateway-control-ui-origins.ts
@@ -46,17 +46,17 @@ export function ensureControlUiAllowedOriginsForNonLoopbackBind(
   opts?: {
     defaultPort?: number;
     requireControlUiEnabled?: boolean;
-    /** Resolved runtime bind override. Mirrors Gateway runtime precedence:
-     *  explicit CLI/runtime bind wins over gateway.bind. */
+    // Resolved runtime bind override. Mirrors Gateway runtime precedence:
+    // explicit CLI/runtime bind wins over gateway.bind.
     runtimeBind?: unknown;
-    /** Resolved runtime port override. Mirrors Gateway runtime precedence:
-     *  explicit CLI/runtime port wins over gateway.port. */
+    // Resolved runtime port override. Mirrors Gateway runtime precedence:
+    // explicit CLI/runtime port wins over gateway.port.
     runtimePort?: unknown;
-    /** Optional container-detection callback.  When provided and `gateway.bind`
-     *  is unset, the function is called to determine whether the runtime will
-     *  choose the container-friendly bind mode so loopback Control UI origins
-     *  can be prepared proactively.  Keeping this as an injected callback avoids
-     *  a hard dependency from the config layer on the gateway runtime layer. */
+    // Optional container-detection callback.  When provided and `gateway.bind`
+    // is unset, the function is called to determine whether the runtime will
+    // choose the container-friendly bind mode so loopback Control UI origins
+    // can be prepared proactively.  Keeping this as an injected callback avoids
+    // a hard dependency from the config layer on the gateway runtime layer.
     isContainerEnvironment?: () => boolean;
   },
 ): {


### PR DESCRIPTION
## Summary

Hardens the final SafeOps-reviewed config surfaces after the skill-doc risk cleanup pass.

Changes:

- GitHub CLI config discovery no longer guesses broad operator home paths such as root, sudo user, or login user homes by default.
- Alternate GitHub CLI config discovery now requires explicit `candidateOperatorHomes` from callers/tests or `OPENCLAW_GH_CONFIG_DISCOVERY_HOMES` in the environment.
- Control UI origin auto-seeding remains available for non-loopback gateway binds, but automatic defaults are loopback-only.
- LAN, tailnet, and custom browser origins must be configured explicitly in `gateway.controlUi.allowedOrigins` instead of inferred from bind mode or custom bind host.
- Adds focused tests for explicit GitHub config discovery homes and loopback-only Control UI origin seeding.

## Scope

Security hardening for configuration defaults and diagnostics only. No runtime browser driver, channel adapter, model, tool execution, or gateway request handling code is changed.

## Validation needed

Run focused tests:

```bash
pnpm test src/agents/skills/gh-config-discovery.test.ts src/config/gateway-control-ui-origins.test.ts
```

Run SafeOps against this branch. Expected reviewed-risk count should drop to zero when stacked with the pending doc-only SafeOps PRs.