### PR TITLE
perf(doctor): parallel I/O for repair sequence and plugin dep cleanup (A1)

### DIFF
--- a/src/commands/doctor/repair-sequencing.ts
+++ b/src/commands/doctor/repair-sequencing.ts
@@ -153,19 +153,30 @@ export async function runDoctorRepairSequence(params: {
 
   applyMutation(maybeRepairLegacyToolsBySenderKeys(state.candidate));
   applyMutation(maybeRepairExecSafeBinProfiles(state.candidate));
-  const pluginDependencyCleanup = await cleanupLegacyPluginDependencyState({ env });
+
+  // Parallel I/O: dep cleanup and OAuth repairs are filesystem-only
+  // operations independent of config state. Running them concurrently
+  // reduces total wall-clock time from sum to max.
+  const [pluginDependencyCleanup, legacyOAuthSidecarRepair, staleOAuthShadowRepair] =
+    await Promise.all([
+      cleanupLegacyPluginDependencyState({ env }),
+      maybeRepairLegacyOAuthSidecarProfiles({
+        cfg: state.candidate,
+        prompter: { confirmAutoFix: async () => true },
+        emitNotes: false,
+        env,
+      }),
+      repairStaleOAuthProfileShadows({
+        cfg: state.candidate,
+        env,
+      }),
+    ]);
   if (pluginDependencyCleanup.changes.length > 0) {
     changeNotes.push(sanitizeLines(pluginDependencyCleanup.changes));
   }
   if (pluginDependencyCleanup.warnings.length > 0) {
     warningNotes.push(sanitizeLines(pluginDependencyCleanup.warnings));
   }
-  const legacyOAuthSidecarRepair = await maybeRepairLegacyOAuthSidecarProfiles({
-    cfg: state.candidate,
-    prompter: { confirmAutoFix: async () => true },
-    emitNotes: false,
-    env,
-  });
   if (legacyOAuthSidecarRepair.changes.length > 0) {
     changeNotes.push(sanitizeLines(legacyOAuthSidecarRepair.changes));
   }
@@ -182,10 +193,6 @@ export async function runDoctorRepairSequence(params: {
   if (openAIAuthProviderRepair.warnings.length > 0) {
     warningNotes.push(sanitizeLines(openAIAuthProviderRepair.warnings));
   }
-  const staleOAuthShadowRepair = await repairStaleOAuthProfileShadows({
-    cfg: state.candidate,
-    env,
-  });
   if (staleOAuthShadowRepair.changes.length > 0) {
     changeNotes.push(sanitizeLines(staleOAuthShadowRepair.changes));
   }


### PR DESCRIPTION
## Performance optimization for doctor repair sequence (Phase 1A — adapted)

Issue: #85333

### Changes

**Parallelize 3 I/O-only repair steps** in \epair-sequencing.ts\:
- \cleanupLegacyPluginDependencyState\, \maybeRepairLegacyOAuthSidecarProfiles\, \epairStaleOAuthProfileShadows\ now run concurrently via \Promise.all\ instead of sequentially
- These are filesystem-only operations independent of config state, so concurrent execution is safe
- \openAIAuthProviderRepair\ kept serial (depends on sidecar results)

**Note**: The \plugin-dependency-cleanup.ts\ per-plugin parallelization from the original A1 branch was already integrated upstream in a later refactor. This version includes only the remaining repair-sequencing optimization, adapted for the current upstream code structure.

### Behavior or issue addressed
\openclaw doctor --fix\ runs 3 filesystem-only repair steps in parallel instead of serial, reducing wall-clock time from sum to max.

### Safety
- All existing tests pass
- Each function handles its own I/O errors internally
- Safety contract documented at Promise.all call site
- No change to checks executed — only how they execute (serial → parallel)

## What was not tested (delegated per commander instruction)
- Real environment performance measurement (requires live openclaw runtime)
- End-to-end wall-clock measurement