### PR TITLE
fix(outbound): auto-select single enabled message account

### DIFF
--- a/docs/channels/channel-routing.md
+++ b/docs/channels/channel-routing.md
@@ -17,7 +17,9 @@ host configuration.
 - **AccountId**: per-channel account instance (when supported).
 - Optional channel default account: `channels.<channel>.defaultAccount` chooses
   which account is used when an outbound path does not specify `accountId`.
-  - In multi-account setups, set an explicit default (`defaultAccount` or `accounts.default`) when two or more accounts are configured. Without it, fallback routing may pick the first normalized account ID.
+  - If no default account is enabled and exactly one configured account is
+    enabled, outbound message actions use that single account automatically.
+  - In multi-account setups, set an explicit default (`defaultAccount` or `accounts.default`) when two or more accounts are configured. Without it, outbound message actions require an explicit `accountId` when multiple enabled accounts are available.
 - **AgentId**: an isolated workspace + session store ("brain").
 - **SessionKey**: the bucket key used to store context and control concurrency.
 

--- a/docs/cli/message.md
+++ b/docs/cli/message.md
@@ -62,6 +62,11 @@ Name lookup:
 - Unresolved SecretRefs on unrelated channels do not block a targeted message action.
 - If the selected channel/account SecretRef is unresolved, the command fails closed for that action.
 
+When `--account` is omitted, OpenClaw first uses the selected channel's enabled
+default account. If that default is disabled or absent and exactly one
+configured account is enabled, it selects that account automatically. If zero or
+multiple configured accounts are enabled, pass `--account <id>` explicitly.
+
 ## Actions
 
 ### Core

--- a/src/infra/outbound/channel-selection.test.ts
+++ b/src/infra/outbound/channel-selection.test.ts
@@ -237,6 +237,22 @@ describe("resolveMessageAccountSelection", () => {
     });
   });
 
+  it("does not infer an account for accountless plugins", async () => {
+    mocks.resolveOutboundChannelPlugin.mockReturnValue(
+      makePlugin({
+        id: "testchat",
+        accountIds: [],
+      }),
+    );
+
+    await expect(
+      resolveMessageAccountSelection({
+        cfg: {} as never,
+        channel: "testchat",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
   it("selects the only enabled configured account when the default account is disabled", async () => {
     mocks.resolveOutboundChannelPlugin.mockReturnValue(
       makePlugin({

--- a/src/infra/outbound/channel-selection.test.ts
+++ b/src/infra/outbound/channel-selection.test.ts
@@ -52,19 +52,25 @@ type RuntimeModule = typeof import("../../runtime.js");
 
 let testing: ChannelSelectionModule["testing"];
 let listConfiguredMessageChannels: ChannelSelectionModule["listConfiguredMessageChannels"];
+let resolveMessageAccountSelection: ChannelSelectionModule["resolveMessageAccountSelection"];
 let resolveMessageChannelSelection: ChannelSelectionModule["resolveMessageChannelSelection"];
 let runtimeModule: RuntimeModule;
 
 beforeAll(async () => {
   runtimeModule = await import("../../runtime.js");
-  ({ testing, listConfiguredMessageChannels, resolveMessageChannelSelection } =
-    await import("./channel-selection.js"));
+  ({
+    testing,
+    listConfiguredMessageChannels,
+    resolveMessageAccountSelection,
+    resolveMessageChannelSelection,
+  } = await import("./channel-selection.js"));
 });
 
 function makePlugin(params: {
   id: string;
   accountIds?: string[];
   resolveAccount?: (accountId: string) => unknown;
+  defaultAccountId?: () => string;
   isEnabled?: (account: unknown) => boolean;
   isConfigured?: (account: unknown) => boolean | Promise<boolean>;
 }) {
@@ -74,6 +80,7 @@ function makePlugin(params: {
       listAccountIds: () => params.accountIds ?? ["default"],
       resolveAccount: (_cfg: unknown, accountId: string) =>
         params.resolveAccount ? params.resolveAccount(accountId) : {},
+      ...(params.defaultAccountId ? { defaultAccountId: params.defaultAccountId } : {}),
       ...(params.isEnabled ? { isEnabled: params.isEnabled } : {}),
       ...(params.isConfigured ? { isConfigured: params.isConfigured } : {}),
     },
@@ -158,6 +165,166 @@ describe("listConfiguredMessageChannels", () => {
     mocks.listChannelPlugins.mockReturnValue(plugins);
     await expect(listConfiguredMessageChannels({} as never)).resolves.toEqual(expected);
     expect(errorSpy).toHaveBeenCalledTimes(expectedErrors);
+  });
+});
+
+describe("resolveMessageAccountSelection", () => {
+  beforeEach(() => {
+    mocks.listChannelPlugins.mockReset();
+    mocks.listChannelPlugins.mockReturnValue([]);
+    mocks.resolveOutboundChannelPlugin.mockReset();
+    mocks.resolveOutboundChannelPlugin.mockImplementation(({ channel }: { channel: string }) => ({
+      id: channel,
+    }));
+  });
+
+  it("preserves an explicit account id without inspecting channel accounts", async () => {
+    mocks.resolveOutboundChannelPlugin.mockReturnValue(undefined);
+
+    await expect(
+      resolveMessageAccountSelection({
+        cfg: {} as never,
+        channel: "whatsapp",
+        accountId: " work ",
+      }),
+    ).resolves.toEqual({
+      accountId: "work",
+      source: "explicit",
+    });
+
+    expect(mocks.resolveOutboundChannelPlugin).not.toHaveBeenCalled();
+  });
+
+  it("uses the enabled configured default account", async () => {
+    mocks.resolveOutboundChannelPlugin.mockReturnValue(
+      makePlugin({
+        id: "whatsapp",
+        accountIds: ["default", "work"],
+        defaultAccountId: () => "work",
+        resolveAccount: (accountId) => ({ accountId, enabled: true, configured: true }),
+        isConfigured: (account) => (account as { configured?: boolean }).configured === true,
+      }),
+    );
+
+    await expect(
+      resolveMessageAccountSelection({
+        cfg: {} as never,
+        channel: "whatsapp",
+      }),
+    ).resolves.toEqual({
+      accountId: "work",
+      source: "configured-default",
+    });
+  });
+
+  it("uses the enabled literal default account when the plugin has no configured default hook", async () => {
+    mocks.resolveOutboundChannelPlugin.mockReturnValue(
+      makePlugin({
+        id: "whatsapp",
+        accountIds: ["default", "work"],
+        resolveAccount: (accountId) => ({ accountId, enabled: true }),
+      }),
+    );
+
+    await expect(
+      resolveMessageAccountSelection({
+        cfg: {} as never,
+        channel: "whatsapp",
+      }),
+    ).resolves.toEqual({
+      accountId: "default",
+      source: "configured-default",
+    });
+  });
+
+  it("selects the only enabled configured account when the default account is disabled", async () => {
+    mocks.resolveOutboundChannelPlugin.mockReturnValue(
+      makePlugin({
+        id: "whatsapp",
+        accountIds: ["default", "xiaomi"],
+        defaultAccountId: () => "default",
+        resolveAccount: (accountId) => ({
+          accountId,
+          enabled: accountId !== "default",
+          configured: true,
+        }),
+        isConfigured: (account) => (account as { configured?: boolean }).configured === true,
+      }),
+    );
+
+    await expect(
+      resolveMessageAccountSelection({
+        cfg: {} as never,
+        channel: "whatsapp",
+      }),
+    ).resolves.toEqual({
+      accountId: "xiaomi",
+      source: "single-configured",
+    });
+  });
+
+  it("skips enabled accounts that are not configured", async () => {
+    mocks.resolveOutboundChannelPlugin.mockReturnValue(
+      makePlugin({
+        id: "whatsapp",
+        accountIds: ["default", "xiaomi"],
+        defaultAccountId: () => "default",
+        resolveAccount: (accountId) => ({
+          accountId,
+          enabled: true,
+          configured: accountId === "xiaomi",
+        }),
+        isConfigured: (account) => (account as { configured?: boolean }).configured === true,
+      }),
+    );
+
+    await expect(
+      resolveMessageAccountSelection({
+        cfg: {} as never,
+        channel: "whatsapp",
+      }),
+    ).resolves.toEqual({
+      accountId: "xiaomi",
+      source: "single-configured",
+    });
+  });
+
+  it("requires an explicit account when no enabled configured account exists", async () => {
+    mocks.resolveOutboundChannelPlugin.mockReturnValue(
+      makePlugin({
+        id: "whatsapp",
+        accountIds: ["default", "work"],
+        resolveAccount: (accountId) => ({ accountId, enabled: false }),
+      }),
+    );
+
+    await expect(
+      resolveMessageAccountSelection({
+        cfg: {} as never,
+        channel: "whatsapp",
+      }),
+    ).rejects.toThrow(
+      "Account is required for channel whatsapp because no enabled configured accounts were found.",
+    );
+  });
+
+  it("requires an explicit account when multiple enabled configured accounts exist", async () => {
+    mocks.resolveOutboundChannelPlugin.mockReturnValue(
+      makePlugin({
+        id: "whatsapp",
+        accountIds: ["work", "personal"],
+        resolveAccount: (accountId) => ({ accountId, enabled: true }),
+      }),
+    );
+
+    await expect(
+      resolveMessageAccountSelection({
+        cfg: {} as never,
+        channel: "whatsapp",
+      }),
+    ).rejects.toThrow(
+      "Account is required for channel whatsapp because multiple enabled configured accounts are available: work, personal.",
+    );
   });
 });
 

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -351,10 +351,13 @@ export async function resolveMessageAccountSelection(params: {
   cfg: OpenClawConfig;
   channel: MessageChannelId;
   accountId?: string | null;
-}): Promise<{
-  accountId: string;
-  source: MessageAccountSelectionSource;
-}> {
+}): Promise<
+  | {
+      accountId: string;
+      source: MessageAccountSelectionSource;
+    }
+  | undefined
+> {
   const explicitAccountId = normalizeAccountId(params.accountId);
   if (explicitAccountId) {
     return { accountId: explicitAccountId, source: "explicit" };
@@ -372,6 +375,9 @@ export async function resolveMessageAccountSelection(params: {
   const accountIds: string[] = [];
   for (const accountId of plugin.config.listAccountIds(params.cfg)) {
     pushUniqueAccountId(accountIds, accountId);
+  }
+  if (accountIds.length === 0) {
+    return undefined;
   }
 
   const defaultAccountId =

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -20,6 +20,7 @@ export type MessageChannelSelectionSource =
   | "explicit"
   | "tool-context-fallback"
   | "single-configured";
+export type MessageAccountSelectionSource = "explicit" | "configured-default" | "single-configured";
 
 const getMessageChannels = () => listDeliverableMessageChannels();
 
@@ -135,6 +136,19 @@ function isAccountEnabled(account: unknown): boolean {
   return enabled !== false;
 }
 
+function normalizeAccountId(value?: string | null): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+function pushUniqueAccountId(ids: string[], value?: string | null) {
+  const normalized = normalizeAccountId(value);
+  if (!normalized || ids.includes(normalized)) {
+    return;
+  }
+  ids.push(normalized);
+}
+
 const loggedChannelSelectionErrors = new Set<string>();
 
 function logChannelSelectionError(params: {
@@ -200,6 +214,46 @@ async function isPluginConfigured(plugin: ChannelPlugin, cfg: OpenClawConfig): P
   }
 
   return false;
+}
+
+async function isPluginAccountSelectable(params: {
+  plugin: ChannelPlugin;
+  cfg: OpenClawConfig;
+  accountId: string;
+}): Promise<boolean> {
+  let account: unknown;
+  try {
+    account = params.plugin.config.resolveAccount(params.cfg, params.accountId);
+  } catch (error) {
+    logChannelSelectionError({
+      pluginId: params.plugin.id,
+      accountId: params.accountId,
+      operation: "resolveAccount",
+      error,
+    });
+    return false;
+  }
+
+  const enabled = params.plugin.config.isEnabled
+    ? params.plugin.config.isEnabled(account, params.cfg)
+    : isAccountEnabled(account);
+  if (!enabled) {
+    return false;
+  }
+  if (!params.plugin.config.isConfigured) {
+    return true;
+  }
+  try {
+    return await params.plugin.config.isConfigured(account, params.cfg);
+  } catch (error) {
+    logChannelSelectionError({
+      pluginId: params.plugin.id,
+      accountId: params.accountId,
+      operation: "isConfigured",
+      error,
+    });
+    return false;
+  }
 }
 
 export async function listConfiguredMessageChannels(
@@ -291,6 +345,79 @@ export async function resolveMessageChannelSelection(params: {
     throw new Error(formatNoConfiguredChannelsMessage());
   }
   throw new Error(formatMultipleConfiguredChannelsMessage(configured));
+}
+
+export async function resolveMessageAccountSelection(params: {
+  cfg: OpenClawConfig;
+  channel: MessageChannelId;
+  accountId?: string | null;
+}): Promise<{
+  accountId: string;
+  source: MessageAccountSelectionSource;
+}> {
+  const explicitAccountId = normalizeAccountId(params.accountId);
+  if (explicitAccountId) {
+    return { accountId: explicitAccountId, source: "explicit" };
+  }
+
+  const plugin = resolveOutboundChannelPlugin({
+    channel: params.channel,
+    cfg: params.cfg,
+    allowBootstrap: true,
+  });
+  if (!plugin) {
+    throw new Error(`Channel is unavailable: ${params.channel}`);
+  }
+
+  const accountIds: string[] = [];
+  for (const accountId of plugin.config.listAccountIds(params.cfg)) {
+    pushUniqueAccountId(accountIds, accountId);
+  }
+
+  const defaultAccountId =
+    normalizeAccountId(plugin.config.defaultAccountId?.(params.cfg)) ??
+    (accountIds.includes("default") ? "default" : undefined);
+  if (
+    defaultAccountId &&
+    (await isPluginAccountSelectable({
+      plugin,
+      cfg: params.cfg,
+      accountId: defaultAccountId,
+    }))
+  ) {
+    return {
+      accountId: defaultAccountId,
+      source: "configured-default",
+    };
+  }
+
+  const selectableAccountIds: string[] = [];
+  for (const accountId of accountIds) {
+    if (
+      await isPluginAccountSelectable({
+        plugin,
+        cfg: params.cfg,
+        accountId,
+      })
+    ) {
+      selectableAccountIds.push(accountId);
+    }
+  }
+
+  if (selectableAccountIds.length === 1) {
+    return {
+      accountId: selectableAccountIds[0],
+      source: "single-configured",
+    };
+  }
+  if (selectableAccountIds.length === 0) {
+    throw new Error(
+      `Account is required for channel ${params.channel} because no enabled configured accounts were found. Pass accountId, or --account in the CLI, to choose an account explicitly.`,
+    );
+  }
+  throw new Error(
+    `Account is required for channel ${params.channel} because multiple enabled configured accounts are available: ${selectableAccountIds.join(", ")}. Pass accountId, or --account in the CLI, to choose one.`,
+  );
 }
 
 export const testing = {

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -1755,5 +1755,82 @@ describe("runMessageAction plugin dispatch", () => {
       expect(ctx.accountId).toBe(expectedAccountId);
       expect(ctx.params.accountId).toBe(expectedAccountId);
     });
+
+    it("auto-selects the only enabled configured account when no account id is provided", async () => {
+      const autoSelectPlugin: ChannelPlugin = {
+        ...accountPlugin,
+        config: {
+          listAccountIds: () => ["default", "xiaomi"],
+          defaultAccountId: () => "default",
+          resolveAccount: (_cfg, accountId) => ({
+            accountId,
+            enabled: accountId !== "default",
+            configured: true,
+          }),
+          isConfigured: (account) => (account as { configured?: boolean }).configured === true,
+        },
+      };
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "accountchat",
+            source: "test",
+            plugin: autoSelectPlugin,
+          },
+        ]),
+      );
+
+      await runMessageAction({
+        cfg: {} as OpenClawConfig,
+        action: "send",
+        params: {
+          channel: "accountchat",
+          target: "channel:123",
+          message: "hi",
+        },
+      });
+
+      const ctx = readFirstPluginCall(handleAction) as {
+        accountId?: string | null;
+        params: Record<string, unknown>;
+      };
+      expect(ctx.accountId).toBe("xiaomi");
+      expect(ctx.params.accountId).toBe("xiaomi");
+    });
+
+    it("does not dispatch when omitted account id matches multiple enabled configured accounts", async () => {
+      const multiAccountPlugin: ChannelPlugin = {
+        ...accountPlugin,
+        config: {
+          listAccountIds: () => ["work", "personal"],
+          resolveAccount: (_cfg, accountId) => ({ accountId, enabled: true }),
+        },
+      };
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "accountchat",
+            source: "test",
+            plugin: multiAccountPlugin,
+          },
+        ]),
+      );
+
+      await expect(
+        runMessageAction({
+          cfg: {} as OpenClawConfig,
+          action: "send",
+          params: {
+            channel: "accountchat",
+            target: "channel:123",
+            message: "hi",
+          },
+        }),
+      ).rejects.toThrow(
+        "Account is required for channel accountchat because multiple enabled configured accounts are available: work, personal.",
+      );
+
+      expect(handleAction).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -1273,6 +1273,15 @@ export async function runMessageAction(
   });
 
   const channel = await resolveChannel(cfg, params, input.toolContext);
+  enforceCrossContextPolicy({
+    channel,
+    action,
+    args: params,
+    toolContext: input.toolContext,
+    cfg,
+    agentId: resolvedAgentId,
+  });
+
   let accountId = readStringParam(params, "accountId") ?? input.defaultAccountId;
   if (!accountId && resolvedAgentId) {
     accountId = resolveTargetBoundAccountId({
@@ -1350,15 +1359,6 @@ export async function runMessageAction(
     action,
     args: params,
     accountId,
-  });
-
-  enforceCrossContextPolicy({
-    channel,
-    action,
-    args: params,
-    toolContext: input.toolContext,
-    cfg,
-    agentId: resolvedAgentId,
   });
 
   const gateway = resolveGateway(input);

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -1288,7 +1288,7 @@ export async function runMessageAction(
         cfg,
         channel,
       })
-    ).accountId;
+    )?.accountId;
   }
   if (accountId) {
     params.accountId = accountId;

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -51,6 +51,7 @@ import { throwIfAborted } from "./abort.js";
 import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
 import {
   listConfiguredMessageChannels,
+  resolveMessageAccountSelection,
   resolveMessageChannelSelection,
 } from "./channel-selection.js";
 import type { OutboundSendDeps } from "./deliver.js";
@@ -1280,6 +1281,14 @@ export async function runMessageAction(
       args: params,
       agentId: resolvedAgentId,
     });
+  }
+  if (!accountId) {
+    accountId = (
+      await resolveMessageAccountSelection({
+        cfg,
+        channel,
+      })
+    ).accountId;
   }
   if (accountId) {
     params.accountId = accountId;


### PR DESCRIPTION
## Summary

Fixes #20756.

- Add a shared outbound message account resolver after channel selection.
- Preserve explicit `accountId`, CLI/default account overrides, and agent binding account IDs before inference.
- When the message tool omits an account, prefer an enabled configured default account; otherwise auto-select exactly one enabled configured account and fail clearly for zero or multiple choices.
- Leave accountless plugin/test-channel dispatch untouched so plugin-owned behavior and context guards still run.
- Enforce cross-context send policy before inferred account validation so security denials are not masked by account setup errors.
- Document the omitted-account behavior in the channel routing and message CLI docs.

No changelog entry is included because contributor-authored PRs should leave changelog credit/addition to maintainers during landing.

## Verification

- `git fetch --all --prune`
- `git rebase upstream/main`
- `node scripts/run-vitest.mjs src/infra/outbound/channel-selection.test.ts src/infra/outbound/message-action-runner.plugin-dispatch.test.ts src/infra/outbound/message-action-runner.core-send.test.ts src/infra/outbound/message-action-runner.context.test.ts`
- `node scripts/run-vitest.mjs src/infra/outbound/message.channels.test.ts src/infra/outbound/message-action-runner.media.test.ts src/infra/outbound/message-action-runner.poll.test.ts extensions/whatsapp/src/send.test.ts extensions/whatsapp/src/active-listener.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/infra/outbound/channel-selection.ts src/infra/outbound/message-action-runner.ts src/infra/outbound/channel-selection.test.ts src/infra/outbound/message-action-runner.plugin-dispatch.test.ts src/infra/outbound/message-action-runner.core-send.test.ts src/infra/outbound/message-action-runner.context.test.ts docs/channels/channel-routing.md docs/cli/message.md`
- `pnpm docs:check-mdx docs/channels/channel-routing.md docs/cli/message.md`
- `git diff --check`
- `pnpm check:changed`

## Real behavior proof

Behavior addressed: omitted message-tool `accountId` no longer falls through to a disabled `default` account when the selected channel has exactly one enabled configured account.

Real environment tested: local OpenClaw checkout on Windows 11, branch `hemant/fix-message-account-selection`, rebased onto current `upstream/main` (`99a1107b61`) and pushed as head `90a5c78a3b`.

Exact steps or command run after this patch: the verification commands listed above were run after formatting the patch, after the CI-regression adjustments for accountless plugin dispatch and cross-context policy ordering, and again after rebasing onto latest upstream.

Evidence after fix: focused resolver and plugin-dispatch tests pass, including the regression where `default` is disabled and `xiaomi` is the only enabled configured account; the CI-failing core send/context test files also pass after preserving accountless plugin dispatch and enforcing context policy before account inference. Docs MDX, formatting, diff whitespace, and `check:changed` all exit successfully.

Observed result after fix: account-aware plugins get inferred account selection before dispatch; accountless plugins continue without injected `accountId`, and cross-context denials are raised before account setup validation can mask them.

What was not tested: live WhatsApp delivery was not run. The remote Crabbox/Testbox wrapper could not start in this environment because its binary failed its own sanity check; direct `pnpm tsgo:core` was also blocked locally by an existing Windows path-with-space invocation issue, while `pnpm check:changed` completed successfully.