### PR TITLE
fix(agents): audit tool policy blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ Docs: https://docs.openclaw.ai
 - Codex app-server: keep native web search observations out of mirrored chat transcripts while preserving tool progress telemetry. Fixes #85109. Thanks @ugitmebaby.
 - OpenCode Go: strip unsupported Kimi reasoning replay fields before provider requests so repeated `kimi-k2.6` turns do not fail schema validation. Fixes #83812. Thanks @Sleeck.
 - Browser/CDP: add a WSL2 portproxy self-loop hint when Chrome DevTools endpoints accept connections but return an empty HTTP reply. Fixes #59209. Thanks @Owlock.
+- Agents/tools: add bounded tool-policy audit log entries that identify which allow/deny rule removed tools or blocked a sandboxed tool call. Fixes #55801. Thanks @justinjkline.
 - Agents/OpenAI: preserve structured provider error code, type, and redacted body metadata on boundary-aware transport failures.
 - Doctor/Codex: point native Codex asset warnings at the canonical `openclaw migrate plan codex` preview command. Fixes #84948. Thanks @markoa.
 - CLI/models: make `capability model auth logout --agent` remove auth profiles from the selected non-default agent store. Fixes #85092. Thanks @islandpreneur007.

--- a/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
+++ b/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
@@ -67,6 +67,7 @@ Rules of thumb:
 - Tool policy filters tool availability by name; it does not inspect side effects inside `exec`. If `exec` is allowed, denying `write`, `edit`, or `apply_patch` does not make shell commands read-only.
 - `/exec` only changes session defaults for authorized senders; it does not grant tool access.
   Provider tool keys accept either `provider` (e.g. `google-antigravity`) or `provider/model` (e.g. `openai/gpt-5.4`).
+- Gateway logs include `agents/tool-policy` audit entries when a tool policy step removes tools or a sandbox tool policy blocks a call. Use `openclaw logs` to see the rule label, config key, and affected tool names.
 
 ### Tool groups (shorthands)
 
@@ -134,6 +135,7 @@ Fix-it keys (pick one):
 - Allow the tool inside sandbox:
   - remove it from `tools.sandbox.tools.deny` (or per-agent `agents.list[].tools.sandbox.tools.deny`)
   - or add it to `tools.sandbox.tools.allow` (or per-agent allow)
+- Check `openclaw logs` for the `agents/tool-policy` entry. It records the sandbox mode and whether the allow or deny rule blocked the tool.
 
 ### "I thought this was main, why is it sandboxed?"
 

--- a/src/agents/pi-embedded-helpers/errors.test.ts
+++ b/src/agents/pi-embedded-helpers/errors.test.ts
@@ -1,10 +1,28 @@
 import type { AssistantMessage } from "@earendil-works/pi-ai";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../../shared/assistant-error-format.js";
 import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
 import { formatAssistantErrorText } from "./errors.js";
 
+const { toolPolicyAuditInfo } = vi.hoisted(() => ({
+  toolPolicyAuditInfo: vi.fn(),
+}));
+
+vi.mock("../../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: toolPolicyAuditInfo,
+    warn: vi.fn(),
+  }),
+}));
+
 describe("formatAssistantErrorText streaming JSON parse classification", () => {
+  beforeEach(() => {
+    toolPolicyAuditInfo.mockClear();
+  });
+
   const makeAssistantError = (errorMessage: string): AssistantMessage =>
     makeAssistantMessageFixture({
       errorMessage,
@@ -33,6 +51,41 @@ describe("formatAssistantErrorText streaming JSON parse classification", () => {
     );
     expect(formatAssistantErrorText(msg)).toBe(
       "LLM request rejected: Expected value in JSON at position 12 for messages.0.content",
+    );
+  });
+
+  it("audits a sandbox tool-policy block once per assistant error", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: { mode: "non-main", scope: "agent" },
+        },
+      },
+      tools: {
+        sandbox: {
+          tools: {
+            deny: ["browser"],
+          },
+        },
+      },
+    };
+    const msg = makeAssistantError("unknown tool: browser");
+
+    expect(formatAssistantErrorText(msg, { cfg, sessionKey: "agent:main:mobilechat:g1" }))
+      .toContain('Tool "browser" blocked by sandbox tool policy');
+    expect(formatAssistantErrorText(msg, { cfg, sessionKey: "agent:main:mobilechat:g1" }))
+      .toContain('Tool "browser" blocked by sandbox tool policy');
+
+    expect(toolPolicyAuditInfo).toHaveBeenCalledTimes(1);
+    expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
+      "sandbox tool policy blocked browser via tools.sandbox.tools.deny",
+      {
+        tool: "browser",
+        ruleKind: "deny",
+        ruleSource: "global",
+        configKey: "tools.sandbox.tools.deny",
+        sandboxMode: "non-main",
+      },
     );
   });
 });

--- a/src/agents/pi-embedded-helpers/errors.test.ts
+++ b/src/agents/pi-embedded-helpers/errors.test.ts
@@ -71,19 +71,22 @@ describe("formatAssistantErrorText streaming JSON parse classification", () => {
     };
     const msg = makeAssistantError("unknown tool: browser");
 
-    expect(formatAssistantErrorText(msg, { cfg, sessionKey: "agent:main:mobilechat:g1" }))
-      .toContain('Tool "browser" blocked by sandbox tool policy');
-    expect(formatAssistantErrorText(msg, { cfg, sessionKey: "agent:main:mobilechat:g1" }))
-      .toContain('Tool "browser" blocked by sandbox tool policy');
+    expect(
+      formatAssistantErrorText(msg, { cfg, sessionKey: "agent:main:mobilechat:g1" }),
+    ).toContain('Tool "browser" blocked by sandbox tool policy');
+    expect(
+      formatAssistantErrorText(msg, { cfg, sessionKey: "agent:main:mobilechat:g1" }),
+    ).toContain('Tool "browser" blocked by sandbox tool policy');
 
     expect(toolPolicyAuditInfo).toHaveBeenCalledTimes(1);
     expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
-      "sandbox tool policy blocked browser via tools.sandbox.tools.deny",
+      "sandbox tool policy blocked browser via tools.sandbox.tools.deny; matched browser",
       {
         tool: "browser",
         ruleKind: "deny",
         ruleSource: "global",
         configKey: "tools.sandbox.tools.deny",
+        matchedRule: "browser",
         sandboxMode: "non-main",
       },
     );

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -68,6 +68,7 @@ export {
 } from "./failover-matches.js";
 
 const log = createSubsystemLogger("errors");
+const sandboxToolPolicyAuditMessages = new WeakSet<AssistantMessage>();
 
 export function isReasoningConstraintErrorMessage(raw: string): boolean {
   if (!raw) {
@@ -1036,12 +1037,17 @@ export function formatAssistantErrorText(
     raw.match(/unknown tool[:\s]+["']?([a-z0-9_-]+)["']?/i) ??
     raw.match(/tool\s+["']?([a-z0-9_-]+)["']?\s+(?:not found|is not available)/i);
   if (unknownTool?.[1]) {
+    const audit = !sandboxToolPolicyAuditMessages.has(msg);
     const rewritten = formatSandboxToolPolicyBlockedMessage({
       cfg: opts?.cfg,
       sessionKey: opts?.sessionKey,
       toolName: unknownTool[1],
+      audit,
     });
     if (rewritten) {
+      if (audit) {
+        sandboxToolPolicyAuditMessages.add(msg);
+      }
       return rewritten;
     }
   }

--- a/src/agents/sandbox-explain.test.ts
+++ b/src/agents/sandbox-explain.test.ts
@@ -128,12 +128,13 @@ describe("sandbox explain helpers", () => {
     expect(msg).toContain("agents.defaults.sandbox.mode=off");
     expect(msg).toContain("Use the agent main session instead of a non-main session.");
     expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
-      "sandbox tool policy blocked browser via tools.sandbox.tools.deny",
+      "sandbox tool policy blocked browser via tools.sandbox.tools.deny; matched browser",
       {
         tool: "browser",
         ruleKind: "deny",
         ruleSource: "global",
         configKey: "tools.sandbox.tools.deny",
+        matchedRule: "browser",
         sandboxMode: "non-main",
       },
     );

--- a/src/agents/sandbox-explain.test.ts
+++ b/src/agents/sandbox-explain.test.ts
@@ -1,10 +1,24 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveSandboxConfigForAgent } from "./sandbox/config.js";
 import { formatSandboxToolPolicyBlockedMessage } from "./sandbox/runtime-status.js";
 import { resolveSandboxToolPolicyForAgent } from "./sandbox/tool-policy.js";
 
+const { toolPolicyAuditInfo } = vi.hoisted(() => ({
+  toolPolicyAuditInfo: vi.fn(),
+}));
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    info: toolPolicyAuditInfo,
+  }),
+}));
+
 describe("sandbox explain helpers", () => {
+  beforeEach(() => {
+    toolPolicyAuditInfo.mockClear();
+  });
+
   it("prefers agent overrides > global > defaults (sandbox tool policy)", () => {
     const cfg: OpenClawConfig = {
       agents: {
@@ -106,11 +120,48 @@ describe("sandbox explain helpers", () => {
       cfg,
       sessionKey: "agent:main:mobilechat:group:g1",
       toolName: "browser",
+      audit: true,
     });
     expect(msg).toContain('Tool "browser" blocked by sandbox tool policy');
     expect(msg).toContain("mode=non-main");
     expect(msg).toContain("tools.sandbox.tools.deny");
     expect(msg).toContain("agents.defaults.sandbox.mode=off");
     expect(msg).toContain("Use the agent main session instead of a non-main session.");
+    expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
+      "sandbox tool policy blocked browser via tools.sandbox.tools.deny",
+      {
+        tool: "browser",
+        ruleKind: "deny",
+        ruleSource: "global",
+        configKey: "tools.sandbox.tools.deny",
+        sandboxMode: "non-main",
+      },
+    );
+  });
+
+  it("does not audit sandbox tool-policy formatting unless requested", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: { mode: "non-main", scope: "agent" },
+        },
+      },
+      tools: {
+        sandbox: {
+          tools: {
+            deny: ["browser"],
+          },
+        },
+      },
+    };
+
+    const msg = formatSandboxToolPolicyBlockedMessage({
+      cfg,
+      sessionKey: "agent:main:mobilechat:group:g1",
+      toolName: "browser",
+    });
+
+    expect(msg).toContain('Tool "browser" blocked by sandbox tool policy');
+    expect(toolPolicyAuditInfo).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/sandbox/runtime-status.ts
+++ b/src/agents/sandbox/runtime-status.ts
@@ -162,6 +162,7 @@ export function formatSandboxToolPolicyBlockedMessage(params: {
       ruleType: blockedByDeny ? "deny" : "allow",
       ruleSource: blockingSource.source,
       configKey: blockingSource.key,
+      policy: runtime.toolPolicy,
       mode: runtime.mode,
     });
   }

--- a/src/agents/sandbox/runtime-status.ts
+++ b/src/agents/sandbox/runtime-status.ts
@@ -6,6 +6,7 @@ import {
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { normalizeOptionalLowercaseString } from "../../shared/string-coerce.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
+import { auditSandboxToolPolicyBlock } from "../tool-policy-audit.js";
 import { resolveSandboxConfigForAgent } from "./config.js";
 import {
   classifyToolAgainstSandboxToolPolicy,
@@ -129,6 +130,7 @@ export function formatSandboxToolPolicyBlockedMessage(params: {
   cfg?: OpenClawConfig;
   sessionKey?: string;
   toolName: string;
+  audit?: boolean;
 }): string | undefined {
   const tool = normalizeOptionalLowercaseString(params.toolName);
   if (!tool) {
@@ -149,6 +151,19 @@ export function formatSandboxToolPolicyBlockedMessage(params: {
   );
   if (!blockedByDeny && !blockedByAllow) {
     return undefined;
+  }
+
+  const blockingSource = blockedByDeny
+    ? runtime.toolPolicy.sources.deny
+    : runtime.toolPolicy.sources.allow;
+  if (params.audit === true) {
+    auditSandboxToolPolicyBlock({
+      toolName: tool,
+      ruleType: blockedByDeny ? "deny" : "allow",
+      ruleSource: blockingSource.source,
+      configKey: blockingSource.key,
+      mode: runtime.mode,
+    });
   }
 
   const reasons: string[] = [];

--- a/src/agents/tool-policy-audit.ts
+++ b/src/agents/tool-policy-audit.ts
@@ -1,0 +1,146 @@
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import type { SandboxConfig } from "./sandbox/types.js";
+import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
+import { normalizeToolName, type ToolPolicyLike } from "./tool-policy.js";
+
+const MAX_AUDIT_TOOL_NAMES = 50;
+const toolPolicyAuditLogger = createSubsystemLogger("agents/tool-policy");
+
+type ToolPolicyRuleKind = "allow" | "deny" | "allow+deny" | "unknown";
+
+function toolPolicyRuleKind(policy: ToolPolicyLike): ToolPolicyRuleKind {
+  const hasAllow = Array.isArray(policy.allow) && policy.allow.length > 0;
+  const hasDeny = Array.isArray(policy.deny) && policy.deny.length > 0;
+  if (hasAllow && hasDeny) {
+    return "allow+deny";
+  }
+  if (hasDeny) {
+    return "deny";
+  }
+  if (hasAllow) {
+    return "allow";
+  }
+  return "unknown";
+}
+
+function normalizedToolNames(tools: readonly { name: string }[]): string[] {
+  return tools.map((tool) => normalizeToolName(tool.name)).filter((name) => name.length > 0);
+}
+
+function removedToolNamesByRule(params: {
+  policy: ToolPolicyLike;
+  before: readonly { name: string }[];
+  after: readonly { name: string }[];
+}): Map<ToolPolicyRuleKind, string[]> {
+  const remainingCounts = new Map<string, number>();
+  for (const name of normalizedToolNames(params.after)) {
+    remainingCounts.set(name, (remainingCounts.get(name) ?? 0) + 1);
+  }
+
+  const removed = new Map<ToolPolicyRuleKind, Set<string>>();
+  for (const name of normalizedToolNames(params.before)) {
+    const remaining = remainingCounts.get(name) ?? 0;
+    if (remaining > 0) {
+      remainingCounts.set(name, remaining - 1);
+      continue;
+    }
+    const ruleKind = removedToolRuleKind(name, params.policy);
+    const names = removed.get(ruleKind) ?? new Set<string>();
+    names.add(name);
+    removed.set(ruleKind, names);
+  }
+  return new Map([...removed].map(([ruleKind, names]) => [ruleKind, [...names].toSorted()]));
+}
+
+function removedToolRuleKind(toolName: string, policy: ToolPolicyLike): ToolPolicyRuleKind {
+  if (
+    Array.isArray(policy.deny) &&
+    policy.deny.length > 0 &&
+    !isToolAllowedByPolicyName(toolName, { deny: policy.deny })
+  ) {
+    return "deny";
+  }
+  if (Array.isArray(policy.allow) && policy.allow.length > 0) {
+    return "allow";
+  }
+  return toolPolicyRuleKind(policy);
+}
+
+function labelForRuleKind(stepLabel: string, ruleKind: ToolPolicyRuleKind): string {
+  if (ruleKind !== "deny") {
+    return stepLabel;
+  }
+  if (stepLabel.includes(".allow")) {
+    return stepLabel.replaceAll(".allow", ".deny");
+  }
+  if (/\ballow\b/u.test(stepLabel)) {
+    return stepLabel.replace(/\ballow\b/u, "deny");
+  }
+  return `${stepLabel}.deny`;
+}
+
+function boundedToolNames(names: readonly string[]): {
+  toolNames: string[];
+  truncated: boolean;
+} {
+  if (names.length <= MAX_AUDIT_TOOL_NAMES) {
+    return { toolNames: [...names], truncated: false };
+  }
+  return {
+    toolNames: names.slice(0, MAX_AUDIT_TOOL_NAMES),
+    truncated: true,
+  };
+}
+
+export function auditToolPolicyFilter(params: {
+  stepLabel: string;
+  policy: ToolPolicyLike;
+  before: readonly { name: string }[];
+  after: readonly { name: string }[];
+}): void {
+  const removedByRule = removedToolNamesByRule({
+    policy: params.policy,
+    before: params.before,
+    after: params.after,
+  });
+  for (const [ruleKind, removed] of removedByRule) {
+    if (removed.length === 0) {
+      continue;
+    }
+    const rule = labelForRuleKind(params.stepLabel, ruleKind);
+    const { toolNames, truncated } = boundedToolNames(removed);
+    toolPolicyAuditLogger.info(
+      `tool policy removed ${removed.length} tool(s) via ${rule}: ${toolNames.join(", ")}`,
+      {
+        rule,
+        ruleKind,
+        removedToolCount: removed.length,
+        removedTools: toolNames,
+        removedToolsTruncated: truncated,
+      },
+    );
+  }
+}
+
+export function auditSandboxToolPolicyBlock(params: {
+  toolName: string;
+  ruleType: "allow" | "deny";
+  ruleSource: "agent" | "global" | "default";
+  configKey: string;
+  mode: SandboxConfig["mode"];
+}): void {
+  const toolName = normalizeToolName(params.toolName);
+  if (!toolName) {
+    return;
+  }
+  toolPolicyAuditLogger.info(
+    `sandbox tool policy blocked ${toolName} via ${params.configKey}`,
+    {
+      tool: toolName,
+      ruleKind: params.ruleType,
+      ruleSource: params.ruleSource,
+      configKey: params.configKey,
+      sandboxMode: params.mode,
+    },
+  );
+}

--- a/src/agents/tool-policy-audit.ts
+++ b/src/agents/tool-policy-audit.ts
@@ -4,6 +4,7 @@ import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
 import { normalizeToolName, type ToolPolicyLike } from "./tool-policy.js";
 
 const MAX_AUDIT_TOOL_NAMES = 50;
+const MAX_AUDIT_FIELD_LENGTH = 160;
 const toolPolicyAuditLogger = createSubsystemLogger("agents/tool-policy");
 
 type ToolPolicyRuleKind = "allow" | "deny" | "allow+deny" | "unknown";
@@ -83,13 +84,40 @@ function boundedToolNames(names: readonly string[]): {
   toolNames: string[];
   truncated: boolean;
 } {
+  const sanitizedNames = names.map(sanitizeAuditField);
   if (names.length <= MAX_AUDIT_TOOL_NAMES) {
-    return { toolNames: [...names], truncated: false };
+    return { toolNames: sanitizedNames, truncated: false };
   }
   return {
-    toolNames: names.slice(0, MAX_AUDIT_TOOL_NAMES),
+    toolNames: sanitizedNames.slice(0, MAX_AUDIT_TOOL_NAMES),
     truncated: true,
   };
+}
+
+function sanitizeAuditField(value: string): string {
+  const sanitized = Array.from(value.trim(), (char) => {
+    if (char === "\n") {
+      return "\\n";
+    }
+    if (char === "\r") {
+      return "\\r";
+    }
+    if (char === "\t") {
+      return "\\t";
+    }
+    const codePoint = char.codePointAt(0) ?? 0;
+    if (codePoint < 0x20 || codePoint === 0x7f) {
+      return `\\x${codePoint.toString(16).padStart(2, "0")}`;
+    }
+    return char;
+  }).join("");
+  if (!sanitized) {
+    return "(unknown)";
+  }
+  if (sanitized.length <= MAX_AUDIT_FIELD_LENGTH) {
+    return sanitized;
+  }
+  return `${sanitized.slice(0, MAX_AUDIT_FIELD_LENGTH)}...`;
 }
 
 export function auditToolPolicyFilter(params: {
@@ -107,7 +135,7 @@ export function auditToolPolicyFilter(params: {
     if (removed.length === 0) {
       continue;
     }
-    const rule = labelForRuleKind(params.stepLabel, ruleKind);
+    const rule = sanitizeAuditField(labelForRuleKind(params.stepLabel, ruleKind));
     const { toolNames, truncated } = boundedToolNames(removed);
     toolPolicyAuditLogger.info(
       `tool policy removed ${removed.length} tool(s) via ${rule}: ${toolNames.join(", ")}`,
@@ -129,18 +157,17 @@ export function auditSandboxToolPolicyBlock(params: {
   configKey: string;
   mode: SandboxConfig["mode"];
 }): void {
-  const toolName = normalizeToolName(params.toolName);
-  if (!toolName) {
+  const normalizedToolName = normalizeToolName(params.toolName);
+  if (!normalizedToolName) {
     return;
   }
-  toolPolicyAuditLogger.info(
-    `sandbox tool policy blocked ${toolName} via ${params.configKey}`,
-    {
-      tool: toolName,
-      ruleKind: params.ruleType,
-      ruleSource: params.ruleSource,
-      configKey: params.configKey,
-      sandboxMode: params.mode,
-    },
-  );
+  const toolName = sanitizeAuditField(normalizedToolName);
+  const configKey = sanitizeAuditField(params.configKey);
+  toolPolicyAuditLogger.info(`sandbox tool policy blocked ${toolName} via ${configKey}`, {
+    tool: toolName,
+    ruleKind: params.ruleType,
+    ruleSource: params.ruleSource,
+    configKey,
+    sandboxMode: params.mode,
+  });
 }

--- a/src/agents/tool-policy-audit.ts
+++ b/src/agents/tool-policy-audit.ts
@@ -67,6 +67,19 @@ function removedToolRuleKind(toolName: string, policy: ToolPolicyLike): ToolPoli
   return toolPolicyRuleKind(policy);
 }
 
+function matchedPolicyRuleForTool(params: {
+  toolName: string;
+  policy: ToolPolicyLike;
+  ruleKind: ToolPolicyRuleKind;
+}): string | undefined {
+  if (params.ruleKind === "deny" && Array.isArray(params.policy.deny)) {
+    return params.policy.deny.find(
+      (entry) => !isToolAllowedByPolicyName(params.toolName, { deny: [entry] }),
+    );
+  }
+  return undefined;
+}
+
 function labelForRuleKind(stepLabel: string, ruleKind: ToolPolicyRuleKind): string {
   if (ruleKind !== "deny") {
     return stepLabel;
@@ -120,6 +133,25 @@ function sanitizeAuditField(value: string): string {
   return `${sanitized.slice(0, MAX_AUDIT_FIELD_LENGTH)}...`;
 }
 
+function matchedPolicyRules(params: {
+  policy: ToolPolicyLike;
+  ruleKind: ToolPolicyRuleKind;
+  tools: readonly string[];
+}): string[] {
+  const rules = new Set<string>();
+  for (const toolName of params.tools) {
+    const rule = matchedPolicyRuleForTool({
+      toolName,
+      policy: params.policy,
+      ruleKind: params.ruleKind,
+    });
+    if (rule) {
+      rules.add(sanitizeAuditField(rule));
+    }
+  }
+  return [...rules].toSorted();
+}
+
 export function auditToolPolicyFilter(params: {
   stepLabel: string;
   policy: ToolPolicyLike;
@@ -137,11 +169,18 @@ export function auditToolPolicyFilter(params: {
     }
     const rule = sanitizeAuditField(labelForRuleKind(params.stepLabel, ruleKind));
     const { toolNames, truncated } = boundedToolNames(removed);
+    const matchedRules = matchedPolicyRules({
+      policy: params.policy,
+      ruleKind,
+      tools: removed,
+    });
+    const matchedRuleSuffix = matchedRules.length > 0 ? `; matched ${matchedRules.join(", ")}` : "";
     toolPolicyAuditLogger.info(
-      `tool policy removed ${removed.length} tool(s) via ${rule}: ${toolNames.join(", ")}`,
+      `tool policy removed ${removed.length} tool(s) via ${rule}: ${toolNames.join(", ")}${matchedRuleSuffix}`,
       {
         rule,
         ruleKind,
+        ...(matchedRules.length > 0 ? { matchedRules } : {}),
         removedToolCount: removed.length,
         removedTools: toolNames,
         removedToolsTruncated: truncated,
@@ -155,6 +194,7 @@ export function auditSandboxToolPolicyBlock(params: {
   ruleType: "allow" | "deny";
   ruleSource: "agent" | "global" | "default";
   configKey: string;
+  policy?: ToolPolicyLike;
   mode: SandboxConfig["mode"];
 }): void {
   const normalizedToolName = normalizeToolName(params.toolName);
@@ -163,11 +203,25 @@ export function auditSandboxToolPolicyBlock(params: {
   }
   const toolName = sanitizeAuditField(normalizedToolName);
   const configKey = sanitizeAuditField(params.configKey);
-  toolPolicyAuditLogger.info(`sandbox tool policy blocked ${toolName} via ${configKey}`, {
-    tool: toolName,
-    ruleKind: params.ruleType,
-    ruleSource: params.ruleSource,
-    configKey,
-    sandboxMode: params.mode,
-  });
+  const matchedRule =
+    params.policy && params.ruleType === "deny"
+      ? matchedPolicyRuleForTool({
+          toolName: normalizedToolName,
+          policy: params.policy,
+          ruleKind: "deny",
+        })
+      : undefined;
+  const sanitizedMatchedRule = matchedRule ? sanitizeAuditField(matchedRule) : undefined;
+  const matchedRuleSuffix = sanitizedMatchedRule ? `; matched ${sanitizedMatchedRule}` : "";
+  toolPolicyAuditLogger.info(
+    `sandbox tool policy blocked ${toolName} via ${configKey}${matchedRuleSuffix}`,
+    {
+      tool: toolName,
+      ruleKind: params.ruleType,
+      ruleSource: params.ruleSource,
+      configKey,
+      ...(sanitizedMatchedRule ? { matchedRule: sanitizedMatchedRule } : {}),
+      sandboxMode: params.mode,
+    },
+  );
 }

--- a/src/agents/tool-policy-audit.ts
+++ b/src/agents/tool-policy-audit.ts
@@ -169,10 +169,11 @@ export function auditToolPolicyFilter(params: {
     }
     const rule = sanitizeAuditField(labelForRuleKind(params.stepLabel, ruleKind));
     const { toolNames, truncated } = boundedToolNames(removed);
+    const matchedRuleSourceTools = removed.slice(0, MAX_AUDIT_TOOL_NAMES);
     const matchedRules = matchedPolicyRules({
       policy: params.policy,
       ruleKind,
-      tools: removed,
+      tools: matchedRuleSourceTools,
     });
     const matchedRuleSuffix = matchedRules.length > 0 ? `; matched ${matchedRules.join(", ")}` : "";
     toolPolicyAuditLogger.info(
@@ -180,7 +181,12 @@ export function auditToolPolicyFilter(params: {
       {
         rule,
         ruleKind,
-        ...(matchedRules.length > 0 ? { matchedRules } : {}),
+        ...(matchedRules.length > 0
+          ? {
+              matchedRules,
+              ...(truncated ? { matchedRulesTruncated: true } : {}),
+            }
+          : {}),
         removedToolCount: removed.length,
         removedTools: toolNames,
         removedToolsTruncated: truncated,

--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -336,10 +336,11 @@ describe("tool-policy-pipeline", () => {
     });
 
     expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
-      "tool policy removed 1 tool(s) via tools.deny: browser",
+      "tool policy removed 1 tool(s) via tools.deny: browser; matched browser",
       {
         rule: "tools.deny",
         ruleKind: "deny",
+        matchedRules: ["browser"],
         removedToolCount: 1,
         removedTools: ["browser"],
         removedToolsTruncated: false,
@@ -367,10 +368,11 @@ describe("tool-policy-pipeline", () => {
     });
 
     expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
-      "tool policy removed 1 tool(s) via agents.worker.tools.deny: browser",
+      "tool policy removed 1 tool(s) via agents.worker.tools.deny: browser; matched browser",
       {
         rule: "agents.worker.tools.deny",
         ruleKind: "deny",
+        matchedRules: ["browser"],
         removedToolCount: 1,
         removedTools: ["browser"],
         removedToolsTruncated: false,

--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -1,10 +1,20 @@
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import {
   applyToolPolicyPipeline,
   buildDefaultToolPolicyPipelineSteps,
   resetToolPolicyWarningCacheForTest,
 } from "./tool-policy-pipeline.js";
 import { resolveToolProfilePolicy } from "./tool-policy.js";
+
+const { toolPolicyAuditInfo } = vi.hoisted(() => ({
+  toolPolicyAuditInfo: vi.fn(),
+}));
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    info: toolPolicyAuditInfo,
+  }),
+}));
 
 type DummyTool = { name: string };
 
@@ -39,6 +49,7 @@ function runAllowlistWarningStep(params: {
 describe("tool-policy-pipeline", () => {
   beforeEach(() => {
     resetToolPolicyWarningCacheForTest();
+    toolPolicyAuditInfo.mockClear();
   });
 
   test("preserves plugin-only allowlists instead of silently stripping them", () => {
@@ -275,5 +286,123 @@ describe("tool-policy-pipeline", () => {
       ],
     });
     expect(filtered.map((t) => (t as unknown as DummyTool).name)).toEqual(["exec"]);
+  });
+
+  test("audits the policy rule that removes tools", () => {
+    const tools = [
+      { name: "exec" },
+      { name: "browser" },
+      { name: "write" },
+      { name: "read" },
+    ] as unknown as DummyTool[];
+
+    applyToolPolicyPipeline({
+      tools: tools as any,
+      toolMeta: () => undefined,
+      warn: () => {},
+      steps: [
+        {
+          policy: { allow: ["exec", "read"] },
+          label: "agent tools.allow",
+        },
+      ],
+    });
+
+    expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
+      "tool policy removed 2 tool(s) via agent tools.allow: browser, write",
+      {
+        rule: "agent tools.allow",
+        ruleKind: "allow",
+        removedToolCount: 2,
+        removedTools: ["browser", "write"],
+        removedToolsTruncated: false,
+      },
+    );
+  });
+
+  test("audits deny removals with the deny config key", () => {
+    const tools = [{ name: "exec" }, { name: "browser" }] as unknown as DummyTool[];
+
+    applyToolPolicyPipeline({
+      tools: tools as any,
+      toolMeta: () => undefined,
+      warn: () => {},
+      steps: [
+        {
+          policy: { deny: ["browser"] },
+          label: "tools.allow",
+        },
+      ],
+    });
+
+    expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
+      "tool policy removed 1 tool(s) via tools.deny: browser",
+      {
+        rule: "tools.deny",
+        ruleKind: "deny",
+        removedToolCount: 1,
+        removedTools: ["browser"],
+        removedToolsTruncated: false,
+      },
+    );
+  });
+
+  test("splits mixed allow and deny policy audit entries by cause", () => {
+    const tools = [
+      { name: "exec" },
+      { name: "browser" },
+      { name: "write" },
+    ] as unknown as DummyTool[];
+
+    applyToolPolicyPipeline({
+      tools: tools as any,
+      toolMeta: () => undefined,
+      warn: () => {},
+      steps: [
+        {
+          policy: { allow: ["exec"], deny: ["browser"] },
+          label: "agents.worker.tools.allow",
+        },
+      ],
+    });
+
+    expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
+      "tool policy removed 1 tool(s) via agents.worker.tools.deny: browser",
+      {
+        rule: "agents.worker.tools.deny",
+        ruleKind: "deny",
+        removedToolCount: 1,
+        removedTools: ["browser"],
+        removedToolsTruncated: false,
+      },
+    );
+    expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
+      "tool policy removed 1 tool(s) via agents.worker.tools.allow: write",
+      {
+        rule: "agents.worker.tools.allow",
+        ruleKind: "allow",
+        removedToolCount: 1,
+        removedTools: ["write"],
+        removedToolsTruncated: false,
+      },
+    );
+  });
+
+  test("does not audit policy steps that leave the tool surface unchanged", () => {
+    const tools = [{ name: "exec" }] as unknown as DummyTool[];
+
+    applyToolPolicyPipeline({
+      tools: tools as any,
+      toolMeta: () => undefined,
+      warn: () => {},
+      steps: [
+        {
+          policy: { allow: ["exec"] },
+          label: "tools.allow",
+        },
+      ],
+    });
+
+    expect(toolPolicyAuditInfo).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -405,4 +405,31 @@ describe("tool-policy-pipeline", () => {
 
     expect(toolPolicyAuditInfo).not.toHaveBeenCalled();
   });
+
+  test("sanitizes audit labels and tool names before logging", () => {
+    const tools = [{ name: "exec\nbad" }] as unknown as DummyTool[];
+
+    applyToolPolicyPipeline({
+      tools: tools as any,
+      toolMeta: () => undefined,
+      warn: () => {},
+      steps: [
+        {
+          policy: { allow: ["read"] },
+          label: "agents.worker\nbad.tools.allow",
+        },
+      ],
+    });
+
+    expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
+      "tool policy removed 1 tool(s) via agents.worker\\nbad.tools.allow: exec\\nbad",
+      {
+        rule: "agents.worker\\nbad.tools.allow",
+        ruleKind: "allow",
+        removedToolCount: 1,
+        removedTools: ["exec\\nbad"],
+        removedToolsTruncated: false,
+      },
+    );
+  });
 });

--- a/src/agents/tool-policy-pipeline.ts
+++ b/src/agents/tool-policy-pipeline.ts
@@ -1,6 +1,7 @@
 import { filterToolsByPolicy } from "./pi-tools.policy.js";
 import type { AnyAgentTool } from "./pi-tools.types.js";
 import { isKnownCoreToolId } from "./tool-catalog.js";
+import { auditToolPolicyFilter } from "./tool-policy-audit.js";
 import {
   analyzeAllowlistByToolType,
   buildPluginToolGroups,
@@ -180,7 +181,17 @@ export function applyToolPolicyPipeline(params: {
     }
 
     const expanded = expandPolicyWithPluginGroups(policy, pluginGroups);
-    filtered = expanded ? filterToolsByPolicy(filtered, expanded) : filtered;
+    if (!expanded) {
+      continue;
+    }
+    const before = filtered;
+    filtered = filterToolsByPolicy(before, expanded);
+    auditToolPolicyFilter({
+      stepLabel: step.label,
+      policy: expanded,
+      before,
+      after: filtered,
+    });
   }
   return filtered;
 }


### PR DESCRIPTION
## Summary

- Replaces the closed, non-maintainer-editable #55826 with a maintained repair for #55801.
- Adds bounded `agents/tool-policy` audit logs when tool-policy filtering removes tools, including sanitized rule labels, matched deny rules, removed tool count, bounded removed tool names, and truncation metadata.
- Adds sandbox blocked-tool audit logs through the assistant-error path, with one audit record per assistant error object and matched deny-rule metadata when available.
- Documents where operators can find the tool-policy audit records.

Fixes #55801
Replaces #55826

## Verification

- `git diff --check origin/main...HEAD`
- `AUTOREVIEW_AUTO_TESTS=0 AUTOREVIEW_OPENCLAW_MAINTAINER_VALIDATION=1 .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- AWS Crabbox `run_794b027caabf`, lease `cbx_902e9680470f`, provider AWS c7a.8xlarge: `pnpm test:serial src/agents/tool-policy-pipeline.test.ts src/agents/sandbox-explain.test.ts src/agents/pi-embedded-helpers/errors.test.ts` passed 3 files / 26 tests.
- AWS Crabbox `run_5c75d7a80df3`, lease `cbx_326555e58483`, provider AWS c7a.8xlarge: production logger + policy smoke emitted and asserted the new `agents/tool-policy` file-log records.
- AWS Crabbox fresh-PR `run_e718a8a93e4e`, lease `cbx_51c87b9aa125`, provider AWS c7a.8xlarge: `pnpm check:changed` passed from PR #85673 checkout.

## Real behavior proof

Behavior addressed: operators can see which tool-policy allow/deny rule removed tools, and which sandbox allow/deny config key blocked a sandboxed tool call, without unbounded log payloads.

Real environment tested: AWS Crabbox Linux runner, provider AWS, instance type c7a.8xlarge, raw source checkout synced from this PR branch and fresh GitHub PR checkout for the changed gate.

Exact steps or command run after this patch: `pnpm test:serial src/agents/tool-policy-pipeline.test.ts src/agents/sandbox-explain.test.ts src/agents/pi-embedded-helpers/errors.test.ts`; a production logger smoke that called the real tool-policy pipeline and sandbox blocked-tool formatter with file logging enabled; `pnpm check:changed` from a fresh PR checkout.

Evidence after fix: focused runner proof `run_794b027caabf` passed 3 files / 26 tests. Real log smoke `run_5c75d7a80df3` printed `TOOL_POLICY_AUDIT_LOG_LINES_START` / `TOOL_POLICY_AUDIT_LOG_LINES_END` and included file-log records from subsystem `agents/tool-policy`. Fresh PR changed gate `run_e718a8a93e4e` passed.

Observed result after fix: the runner log contained `tool policy removed 1 tool(s) via tools.deny: browser; matched browser`, `tool policy removed 1 tool(s) via tools.allow: write`, and `sandbox tool policy blocked browser via tools.sandbox.tools.deny; matched browser`.

What was not tested: full repository test suite.
