### PR TITLE
fix(sessions): strip delivery-mirror and gateway-injected messages from sessions_history (#85669)

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -619,6 +619,46 @@ describe("sessions tools", () => {
     expect(withToolsDetails.messages).toHaveLength(2);
   });
 
+  it("sessions_history filters delivery-mirror and gateway-injected messages unconditionally", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "chat.history") {
+        return {
+          messages: [
+            { role: "user", content: [{ type: "text", text: "hello" }] },
+            { role: "assistant", provider: "openai", model: "gpt-4o", content: [{ type: "text", text: "hi" }] },
+            { role: "assistant", provider: "openclaw", model: "delivery-mirror", content: [{ type: "text", text: "hi" }] },
+            { role: "assistant", provider: "openclaw", model: "gateway-injected", content: [{ type: "text", text: "injected" }] },
+          ],
+        };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_history");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing sessions_history tool");
+    }
+
+    // Default (includeTools=false): delivery-mirror and gateway-injected must be absent
+    const result = await tool.execute("call-dm-default", { sessionKey: "main" });
+    const details = result.details as { messages?: Array<Record<string, unknown>> };
+    const models = details.messages?.map((m) => m.model).filter(Boolean);
+    expect(models).not.toContain("delivery-mirror");
+    expect(models).not.toContain("gateway-injected");
+    // real assistant message must be present
+    expect(details.messages?.some((m) => m.role === "assistant" && m.provider !== "openclaw")).toBe(true);
+
+    // includeTools=true: delivery-mirror and gateway-injected must still be absent
+    const withTools = await tool.execute("call-dm-tools", { sessionKey: "main", includeTools: true });
+    const withToolsDetails = withTools.details as { messages?: Array<Record<string, unknown>> };
+    const modelsWithTools = withToolsDetails.messages?.map((m) => m.model).filter(Boolean);
+    expect(modelsWithTools).not.toContain("delivery-mirror");
+    expect(modelsWithTools).not.toContain("gateway-injected");
+    expect(withToolsDetails.messages).toHaveLength(2); // user + real assistant
+  });
+
   it("sessions_history caps oversized payloads and strips heavy fields", async () => {
     const oversized = Array.from({ length: 80 }, (_, idx) => ({
       role: "assistant",

--- a/src/agents/tools/chat-history-text.ts
+++ b/src/agents/tools/chat-history-text.ts
@@ -2,6 +2,28 @@ import { extractAssistantTextForPhase } from "../../shared/chat-message-content.
 import { sanitizeAssistantVisibleTextWithProfile } from "../../shared/text/assistant-visible-text.js";
 import { sanitizeUserFacingText } from "../embedded-agent-helpers/sanitize-user-facing-text.js";
 
+const TRANSCRIPT_ONLY_OPENCLAW_MODELS = new Set(["delivery-mirror", "gateway-injected"]);
+
+/**
+ * Filter out OpenClaw-internal delivery-mirror and gateway-injected assistant messages.
+ * These are transcript-only entries used for delivery tracking; they duplicate real
+ * assistant turns and must not be surfaced in sessions_history results.
+ */
+export function stripTranscriptOnlyMessages(messages: unknown[]): unknown[] {
+  return messages.filter((msg) => {
+    if (!msg || typeof msg !== "object") {
+      return true;
+    }
+    const entry = msg as Record<string, unknown>;
+    if (entry.role !== "assistant") {
+      return true;
+    }
+    const provider = typeof entry.provider === "string" ? entry.provider : "";
+    const model = typeof entry.model === "string" ? entry.model : "";
+    return !(provider === "openclaw" && TRANSCRIPT_ONLY_OPENCLAW_MODELS.has(model));
+  });
+}
+
 export function stripToolMessages(messages: unknown[]): unknown[] {
   return messages.filter((msg) => {
     if (!msg || typeof msg !== "object") {

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -22,6 +22,7 @@ import {
   resolveVisibleSessionReference,
   stripToolMessages,
 } from "./sessions-helpers.js";
+import { stripTranscriptOnlyMessages } from "./chat-history-text.js";
 
 const SessionsHistoryToolSchema = Type.Object({
   sessionKey: Type.String(),
@@ -257,7 +258,11 @@ export function createSessionsHistoryTool(opts?: {
         params: { sessionKey: resolvedKey, limit },
       });
       const rawMessages = Array.isArray(result?.messages) ? result.messages : [];
-      const selectedMessages = includeTools ? rawMessages : stripToolMessages(rawMessages);
+      // Always strip delivery-mirror and gateway-injected messages regardless of includeTools.
+      // These are OpenClaw-internal transcript entries that duplicate real assistant turns;
+      // returning them causes double messages in the dashboard and tool callers (#85669).
+      const filteredMessages = stripTranscriptOnlyMessages(rawMessages);
+      const selectedMessages = includeTools ? filteredMessages : stripToolMessages(filteredMessages);
       const sanitizedMessages = selectedMessages.map((message) => sanitizeHistoryMessage(message));
       const contentTruncated = sanitizedMessages.some((entry) => entry.truncated);
       const contentRedacted = sanitizedMessages.some((entry) => entry.redacted);


### PR DESCRIPTION
## Summary

Fixes #85669

The `sessions_history` tool returned raw transcript messages without filtering OpenClaw-internal `delivery-mirror` and `gateway-injected` assistant entries. These entries duplicate every real assistant turn in the session transcript, causing double messages in the dashboard session viewer and confusing tool callers.

Telegram delivery is unaffected — messages still send once.

## Root Cause

The `isTranscriptOnlyOpenClawAssistant` guard already exists in `pi-embedded-subscribe.handlers.messages.ts` and is applied in replay/context-building paths, but was **not applied** in the `sessions_history` tool pipeline at `sessions-history-tool.ts`. The tool fetched raw messages from `chat.history`, sanitized them, but returned `delivery-mirror`/`gateway-injected` entries unfiltered.

The docs at `docs/reference/transcript-hygiene.md` state that replay filters delivery-mirror and gateway-injected assistant turns — the tool should match this contract.

## Fix

**`src/agents/tools/chat-history-text.ts`**
- Add `TRANSCRIPT_ONLY_OPENCLAW_MODELS` set (`delivery-mirror`, `gateway-injected`)
- Export `stripTranscriptOnlyMessages()`: filters assistant messages with `provider=openclaw` and a transcript-only model value

**`src/agents/tools/sessions-history-tool.ts`**
- Import `stripTranscriptOnlyMessages`
- Apply it to `rawMessages` before the `includeTools` branch — delivery-mirror entries are excluded **regardless** of the `includeTools` flag (these are internal infrastructure, not tool messages)

**`src/agents/openclaw-tools.sessions.test.ts`**
- New test: `sessions_history filters delivery-mirror and gateway-injected messages unconditionally`
- Covers both `includeTools=false` (default) and `includeTools=true` paths
- Verifies real assistant messages are preserved, delivery-mirror/gateway-injected are absent

## Testing

```
pnpm tsc --noEmit  # passes
```

New test exercises both code paths. The pre-existing `_historyCallCount` lint warning at line 698 is unrelated to this PR (pre-existing in the file).

## Related

- Issue: #85669
- `isTranscriptOnlyOpenClawAssistant` reference: `src/agents/pi-embedded-subscribe.handlers.messages.ts:55`
- Existing filter pattern in `chat-history-text.ts`: `stripToolMessages()`

---

## Real behavior proof

**Behavior or issue addressed:** The `sessions_history` tool returned raw transcript messages without filtering OpenClaw-internal `delivery-mirror` and `gateway-injected` assistant entries. These entries duplicate every real assistant turn, causing double messages in the dashboard session viewer and confusing tool callers (other agents reading session history via the tool). Closes #85669. The existing `isTranscriptOnlyOpenClawAssistant` guard was already applied in replay/context-building paths (per `docs/reference/transcript-hygiene.md`) but was not applied to the `sessions_history` tool pipeline; this PR brings the tool into compliance with the documented contract by exporting a `stripTranscriptOnlyMessages()` helper and applying it in `sessions-history-tool.ts` before the `includeTools` branch — so transcript-only entries are excluded **regardless** of the `includeTools` flag (since they are internal infrastructure, not user-visible tool messages).

**Real environment tested:**
- Date: 2026-05-27T21:15:04Z
- Host: Darwin 25.4.0 arm64 (macOS, Apple Silicon)
- Node: v25.5.0
- Repo: `fix/85669-sessions-history-filter-delivery-mirror` @ `4aed94d651` (Bartok9/openclaw fork)

**Exact steps or command run after this patch:**

```bash
git checkout fix/85669-sessions-history-filter-delivery-mirror
CI=true pnpm install --frozen-lockfile --prefer-offline
node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.agents.config.ts \
  src/agents/openclaw-tools.sessions.test.ts \
  --reporter=verbose
```

**Evidence after fix:**

```text
RUN  v4.1.7 /Users/bartokmoltbot/clawd/openclaw

 ✓  agents  src/agents/openclaw-tools.sessions.test.ts > sessions tools > uses number (not integer) in tool schemas for Gemini compatibility 5ms
 ✓  agents  src/agents/openclaw-tools.sessions.test.ts > sessions tools > sessions_list forwards mailbox filters and includes messages 5ms
 ✓  agents  src/agents/openclaw-tools.sessions.test.ts > sessions tools > derives mailbox previews only after agent visibility filtering 2ms
 ✓  agents  src/agents/openclaw-tools.sessions.test.ts > sessions tools > sessions_list resolves transcriptPath from agent state dir for multi-store listings 0ms
 ✓  agents  src/agents/openclaw-tools.sessions.test.ts > sessions tools > sessions_history filters tool messages by default 1ms
 ✓  agents  src/agents/openclaw-tools.sessions.test.ts > sessions tools > sessions_history filters delivery-mirror and gateway-injected messages unconditionally 1ms
 ✓  agents  src/agents/openclaw-tools.sessions.test.ts > sessions tools > sessions_history caps oversized payloads and strips heavy fields 10ms
 ✓  agents  src/agents/openclaw-tools.sessions.test.ts > sessions tools > sessions_history enforces a hard byte cap even when a single message is huge 1ms
 ✓  agents  src/agents/openclaw-tools.sessions.test.ts > sessions tools > sessions_history sets contentRedacted when sensitive data is redacted 3ms
 ✓  agents  src/agents/openclaw-tools.sessions.test.ts > sessions tools > sessions_history sets both contentRedacted and contentTruncated independently 0ms
 ✓  agents  src/agents/openclaw-tools.sessions.test.ts > sessions tools > sessions_history resolves sessionId inputs 0ms
 ✓  agents  src/agents/openclaw-tools.sessions.test.ts > sessions tools > sessions_history errors on missing sessionId 0ms
 ✓  agents  src/agents/openclaw-tools.sessions.test.ts > sessions tools > sessions_send supports fire-and-forget and wait 15ms
 ✓  agents  src/agents/openclaw-tools.sessions.test.ts > sessions tools > sessions_send resolves sessionId inputs 0ms
 ✓  agents  src/agents/openclaw-tools.sessions.test.ts > sessions tools > sessions_send runs ping-pong then announces 7ms
 ✓  agents  src/agents/openclaw-tools.sessions.test.ts > sessions tools > sessions_send keeps delayed requester replies alive after a wait timeout 7ms
 ✓  agents  src/agents/openclaw-tools.sessions.test.ts > sessions tools > sessions_send reroutes run-scoped active deliveries when transcript steering is rejected 2ms
 ✓  agents  src/agents/openclaw-tools.sessions.test.ts > sessions tools > sessions_send preserves active delivery when transcript commit wait is unsupported 1ms
 ✓  agents  src/agents/openclaw-tools.sessions.test.ts > sessions tools > sessions_send reports run-scoped fallback admission failures 0ms
 ✓  agents  src/agents/openclaw-tools.sessions.test.ts > sessions tools > sessions_send preserves terminal timeouts without starting A2A 0ms
 ✓  agents  src/agents/openclaw-tools.sessions.test.ts > sessions tools > sessions_send skips duplicate A2A delivery for waited parent-owned native subagents 0ms
 ✓  agents  src/agents/openclaw-tools.sessions.test.ts > sessions tools > sessions_send preserves threadId when announce target is hydrated via sessions.list 7ms

 Test Files  1 passed (1)
      Tests  22 passed (22)
   Start at  17:14:56
   Duration  4.11s (transform 2.85s, setup 219ms, import 3.73s, tests 72ms, environment 0ms)
```

**Observed result after fix:**

The new test `sessions_history filters delivery-mirror and gateway-injected messages unconditionally` (line 6 in the run output) exercises the real `sessions_history` tool with a fixture transcript containing both real assistant messages and `delivery-mirror`/`gateway-injected` entries. It verifies the output across **both** code paths: `includeTools=false` (the default) and `includeTools=true`. In both cases the real assistant turns are preserved and the `delivery-mirror`/`gateway-injected` entries are absent. Before this patch the tool returned all entries verbatim and the dashboard / other-agent callers saw doubled assistant turns. The pre-existing 21 tests (sessions_list filters, sessions_history other guards, sessions_send delivery flows) all continue to pass — no regression in the surrounding tool surface.

**What was not tested:**

- End-to-end dashboard rendering of a deduplicated session (this is a server-side tool change verified at the tool boundary)
- Manual gateway loopback (`tools-invoke-http`) — the tool entrypoint is the same code path covered by the test
- The `_historyCallCount` lint warning noted in the PR description is pre-existing in the file and unrelated to this PR's scope
