### PR TITLE
fix(test): resolve temp dir outside Windows mock to prevent dirty folders on Linux

### DIFF
--- a/extensions/whatsapp/src/media.test.ts
+++ b/extensions/whatsapp/src/media.test.ts
@@ -362,13 +362,15 @@ describe("local media root guard", () => {
   });
 
   it("rejects Windows network paths before filesystem checks", async () => {
+    const realTmpRoot = resolvePreferredOpenClawTmpDir();
+
     await withMockedWindowsPlatform(async () => {
       const realpathSpy = vi.spyOn(fs, "realpath");
 
       await withRestoredMocks([realpathSpy], async () => {
         await expectLocalMediaAccessCode(
           loadWebMedia("\\\\attacker\\share\\evil.png", 1024 * 1024, {
-            localRoots: [resolvePreferredOpenClawTmpDir()],
+            localRoots: [realTmpRoot],
           }),
           "network-path-not-allowed",
         );


### PR DESCRIPTION
## Summary

Fix a path issue that causes test to create invalid directories on non-Windows platforms, preventing project directory from getting dirty after running tests.

### What

Move the `resolvePreferredOpenClawTmpDir()` call outside the `withMockedWindowsPlatform` callback in the "rejects Windows network paths before filesystem checks" test in `extensions/whatsapp/src/media.test.ts`.

### Why

**Root Cause:**
When running tests on Linux with uid=1000, `withMockedWindowsPlatform` simulates the Windows platform. If `resolvePreferredOpenClawTmpDir()` is called inside the mock, it returns a Windows-style path like `\tmp\openclaw-1000`. Since Linux doesn't recognize backslash as a path separator, this gets treated as a filename, causing a directory literally named `\tmp\openclaw-1000` to be created in the project root, dirtying the workspace.

**Fix:**
Following the same pattern used in the adjacent test "accepts win32 dev=0 stat mismatch for local file loads", resolve the temp directory path before entering the `withMockedWindowsPlatform` block. This ensures the test uses the correct platform-appropriate temp path even when mocking Windows behavior.

## Real Behavior Proof

### Test Environment

- OS: Linux (uid=1000)
- OpenClaw Version: 2026.5.20

### Steps to Reproduce

1. Run tests on Linux: `pnpm test extensions/whatsapp/src/media.test.ts`
2. Check project root directory for unexpected directories

### Before Fix

- A directory literally named `\tmp\openclaw-1000` appears in the project root
- `pnpm test` leaves the project directory dirty

**Real environment verification:**

```
$ pwd
/home/1000/openclaw
$ ls -ln | grep '\\tmp'
$
$ pnpm test extensions/whatsapp/src/media.test.ts
$ node scripts/test-projects.mjs extensions/whatsapp/src/media.test.ts
[test] starting test/vitest/vitest.extension-whatsapp.config.ts

 RUN  v4.1.6 /home/1000/openclaw

 ✓  extension-whatsapp  extensions/whatsapp/src/media.test.ts (24 tests) 423ms

  Test Files  1 passed (1)
       Tests  24 passed (24)
    Start at  17:04:49
    Duration  3.92s (transform 1.78s, setup 343ms, import 2.85s, tests 423ms, environment 0ms)

[test] passed 1 Vitest shard in 14.57s
$
$ ls -ln | grep '\\tmp' 
drwx------   2 1000 1000    4096 May 23 17:04 \tmp\openclaw-1000
```

A dirty folder `\tmp\openclaw-1000` appeared after test execution, confirming the bug exists.

### After Fix

- No invalid directories are created
- Project directory remains clean after testing

**Real environment verification:**

```
$ pwd
/home/1000/openclaw
$ ls -ln | grep '\\tmp'
$
$ pnpm test extensions/whatsapp/src/media.test.ts
$ node scripts/test-projects.mjs extensions/whatsapp/src/media.test.ts
[test] starting test/vitest/vitest.extension-whatsapp.config.ts

 RUN  v4.1.6 /home/1000/openclaw

 ✓  extension-whatsapp  extensions/whatsapp/src/media.test.ts (24 tests) 439ms

 Test Files  1 passed (1)
      Tests  24 passed (24)
   Start at  17:30:23
   Duration  3.94s (transform 1.79s, setup 322ms, import 2.94s, tests 439ms, environment 0ms)

[test] passed 1 Vitest shard in 13.65s
$ ls -ln | grep '\\tmp'
$
```

Project directory remains clean after running tests.

### Untested Areas

- Native Windows environment (this fix doesn't affect Windows behavior)
