### PR TITLE
fix(telegram): send typing cue from isolated ingress worker

### DIFF
--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -935,6 +935,76 @@ describe("TelegramPollingSession", () => {
     }
   });
 
+  it("keeps isolated ingress alive when ingress typing messages show worker activity", async () => {
+    const abort = new AbortController();
+    const log = vi.fn();
+    const bot = {
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        config: { use: vi.fn() },
+      },
+      init: vi.fn(async () => undefined),
+      handleUpdate: vi.fn(async () => undefined),
+      stop: vi.fn(async () => undefined),
+    };
+    createTelegramBotMock.mockReturnValue(bot);
+
+    let onMessage: WorkerMessageListener | undefined;
+    let stopWorker: (() => void) | undefined;
+    const workerDone = new Promise<void>((resolve) => {
+      stopWorker = resolve;
+    });
+    const workerStop = vi.fn(async () => {
+      stopWorker?.();
+    });
+    const createWorker = vi.fn(() => ({
+      onMessage: vi.fn((handler: WorkerMessageListener) => {
+        onMessage = handler;
+        return () => undefined;
+      }),
+      stop: workerStop,
+      task: vi.fn(async () => {
+        await workerDone;
+      }),
+    }));
+    const watchdogHarness = installPollingStallWatchdogHarness([0]);
+    const session = createPollingSession({
+      abortSignal: abort.signal,
+      log,
+      stallThresholdMs: 30_000,
+      isolatedIngress: {
+        enabled: true,
+        createWorker,
+        drainIntervalMs: 500,
+      },
+    });
+
+    try {
+      const runPromise = session.runUntilAbort();
+      const watchdog = await watchdogHarness.waitForWatchdog();
+      onMessage?.({ type: "poll-start", offset: null, startedAt: 0 });
+      watchdogHarness.setNow(31_000);
+      onMessage?.({
+        type: "ingress-typing-sent",
+        chatId: 123,
+        sentAt: 31_000,
+      });
+      watchdogHarness.setNow(45_000);
+      watchdog?.();
+
+      expect(workerStop).not.toHaveBeenCalled();
+      expectLogIncludes(log, "ingress typing sent chat 123");
+      expectLogExcludes(log, "Polling stall detected");
+
+      abort.abort();
+      stopWorker?.();
+      await runPromise;
+    } finally {
+      watchdogHarness.restore();
+      abort.abort();
+    }
+  });
+
   it("keeps failed lanes blocked for the rest of the drain pass", async () => {
     await withTempSpool(async (tempDir) => {
       const abort = new AbortController();

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -797,6 +797,19 @@ export class TelegramPollingSession {
       if (message.type === "spooled") {
         liveness.noteGetUpdatesActivity();
       }
+      if (message.type === "ingress-typing-sent") {
+        liveness.noteGetUpdatesActivity(message.sentAt);
+        this.opts.log(`[telegram] ingress typing sent chat ${message.chatId}`);
+        return;
+      }
+      if (message.type === "ingress-typing-failed") {
+        liveness.noteGetUpdatesActivity(message.sentAt);
+        this.opts.log(
+          `[telegram] ingress typing failed chat ${message.chatId}${
+            message.message ? `: ${message.message}` : ""
+          }`,
+        );
+      }
     });
     const stopOnAbort = () => {
       void stopWorker();

--- a/extensions/telegram/src/telegram-ingress-worker.runtime.ts
+++ b/extensions/telegram/src/telegram-ingress-worker.runtime.ts
@@ -88,12 +88,85 @@ async function fetchJson(params: {
   }
 }
 
+function resolveTypingTarget(update: unknown): { chatId: number | string; messageThreadId?: number } | null {
+  if (!update || typeof update !== "object" || !("message" in update)) {
+    return null;
+  }
+  const message = update.message;
+  if (!message || typeof message !== "object" || !("chat" in message)) {
+    return null;
+  }
+  const chat = message.chat;
+  if (!chat || typeof chat !== "object" || !("id" in chat)) {
+    return null;
+  }
+  if ("type" in chat && chat.type !== undefined && chat.type !== "private") {
+    return null;
+  }
+  const chatId = chat.id;
+  if (typeof chatId !== "number" && typeof chatId !== "string") {
+    return null;
+  }
+  const messageThreadId =
+    "message_thread_id" in message && typeof message.message_thread_id === "number"
+      ? message.message_thread_id
+      : undefined;
+  return { chatId, messageThreadId };
+}
+
+function sendIngressTypingCue(params: {
+  fetch: typeof fetch;
+  url: string;
+  update: unknown;
+}): void {
+  const target = resolveTypingTarget(params.update);
+  if (!target) {
+    return;
+  }
+  const body = {
+    chat_id: target.chatId,
+    action: "typing",
+    ...(target.messageThreadId === undefined
+      ? {}
+      : { message_thread_id: target.messageThreadId }),
+  };
+  void params
+    .fetch(params.url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    })
+    .then(async (response) => {
+      let ok = response.ok;
+      try {
+        const json = (await response.json()) as { ok?: unknown };
+        ok = ok && json.ok === true;
+      } catch {
+        // A successful HTTP response is enough for this best-effort cue.
+      }
+      post({
+        type: ok ? "ingress-typing-sent" : "ingress-typing-failed",
+        chatId: target.chatId,
+        sentAt: Date.now(),
+      });
+    })
+    .catch((err) => {
+      post({
+        type: "ingress-typing-failed",
+        chatId: target.chatId,
+        sentAt: Date.now(),
+        message: formatErrorMessage(err),
+      });
+    });
+}
+
 async function main(): Promise<void> {
   const proxyFetch = options.proxy ? makeProxyFetch(options.proxy) : undefined;
   const transport = resolveTelegramTransport(proxyFetch, { network: options.network });
   const fetchImpl = transport.fetch ?? globalThis.fetch;
   const apiRoot = normalizeTelegramApiRoot(options.apiRoot ?? "https://api.telegram.org");
   const getUpdatesUrl = `${apiRoot}/bot${options.token}/getUpdates`;
+  const sendChatActionUrl = `${apiRoot}/bot${options.token}/sendChatAction`;
   const pollTimeoutSeconds = resolveTelegramLongPollTimeoutSeconds(options.timeoutSeconds);
   let lastUpdateId = options.initialUpdateId;
   let failures = 0;
@@ -124,6 +197,11 @@ async function main(): Promise<void> {
           if (stopped) {
             break;
           }
+          sendIngressTypingCue({
+            fetch: fetchImpl,
+            url: sendChatActionUrl,
+            update,
+          });
           const updateId = await writeTelegramSpooledUpdate({
             spoolDir: options.spoolDir,
             update,

--- a/extensions/telegram/src/telegram-ingress-worker.ts
+++ b/extensions/telegram/src/telegram-ingress-worker.ts
@@ -22,6 +22,17 @@ export type TelegramIngressWorkerMessage =
       type: "spooled";
       updateId: number;
       queued: number;
+    }
+  | {
+      type: "ingress-typing-sent";
+      chatId: number | string;
+      sentAt: number;
+    }
+  | {
+      type: "ingress-typing-failed";
+      chatId: number | string;
+      sentAt: number;
+      message?: string;
     };
 
 export type TelegramIngressWorkerOptions = {


### PR DESCRIPTION
## Summary

Send a best-effort Telegram `sendChatAction("typing")` from the isolated polling ingress worker as soon as a private message update is received, before the update is spooled and before the main gateway/runtime drains it.

This makes Telegram DMs show immediate acknowledgement even when the main agent runtime is busy, queued, or waiting on a slow model response.

## Problem

Telegram already has later typing signals in the message handling/reply pipeline, but those are coupled to gateway drain/runtime execution. In slow turns this means the user sees no typing indicator until several seconds after Telegram has already delivered the update to OpenClaw.

## Approach

- Extend `TelegramIngressWorkerMessage` with `ingress-typing-sent` and `ingress-typing-failed`.
- In `telegram-ingress-worker.runtime.ts`, build a `sendChatAction` URL beside `getUpdates` and fire-and-forget `sendChatAction({ action: "typing" })` for private `message` updates.
- Preserve `message_thread_id` if present.
- Post success/failure telemetry back to the parent session.
- In `polling-session.ts`, treat ingress typing events as worker activity for liveness and log success/failure for diagnostics.

## Real behavior proof

Behavior or issue addressed: Telegram direct messages now show the typing indicator from the isolated ingress polling path before the main application-level inbound handling/reply pipeline starts.

Real environment tested: Production OpenClaw `2026.5.20` install with Telegram polling enabled, direct Telegram conversation, patched installed runtime used for smoke testing.

Exact steps or command run after the patch: Sent a Telegram DM to the production bot, watched OpenClaw Telegram ingress/runtime logs, and compared the first ingress typing timestamp with the application inbound log and first reply timestamp.

Evidence after fix: Redacted live runtime log timing from the production Telegram direct-message flow:

```text
2026-05-23T07:37:18.267Z ingress typing sent
2026-05-23T07:37:18.519Z application inbound log received
2026-05-23T07:37:53.077Z first reply sent
```

Observed result after fix: Telegram showed the typing indicator almost immediately after the message arrived, while the remaining delay was model/runtime response time.

What was not tested: Full project test suite on the submission machine because that clone has no installed project dependencies and `pnpm`/`corepack` are not installed there.

## Test Coverage

Added unit coverage that ingress typing worker messages count as activity and do not trigger the isolated polling stall watchdog.

Local validation:

- `git diff --check` passes.
- Production smoke test on the installed OpenClaw runtime confirms immediate typing behavior.

## Notes

The upstream PR includes only the ingress-worker cue. Local production debugging also tested later spool/runtime typing cues, but those are redundant once ingress typing is confirmed.
