### PR TITLE
fix(skills): show all-ready note when no skill dependencies need installation

### DIFF
--- a/src/commands/onboard-skills.test.ts
+++ b/src/commands/onboard-skills.test.ts
@@ -144,6 +144,9 @@ const runtime: RuntimeEnv = {
 
 describe("setupSkills", () => {
   afterEach(() => {
+    mocks.buildWorkspaceSkillStatus.mockReset();
+    mocks.installSkill.mockReset();
+    mocks.detectBinary.mockReset();
     mocks.isContainerEnvironment.mockReset();
     mocks.resolveBrewExecutable.mockReset();
   });
@@ -240,6 +243,41 @@ describe("setupSkills", () => {
 
     const brewNote = notes.find((n) => n.title === "Homebrew recommended");
     expect(brewNote).toBeUndefined();
+  });
+
+  it("shows an all-ready note when no skill requirements are missing", async () => {
+    mocks.buildWorkspaceSkillStatus.mockReturnValue({
+      workspaceDir: "/tmp/ws",
+      managedSkillsDir: "/tmp/managed",
+      skills: [
+        {
+          ...createBundledSkill({
+            name: "video-frames",
+            description: "ffmpeg",
+            bins: [],
+            installLabel: "Install ffmpeg (brew)",
+          }),
+          eligible: true,
+          requirements: { bins: [], anyBins: [], env: [], config: [], os: [] },
+          missing: { bins: [], anyBins: [], env: [], config: [], os: [] },
+          install: [],
+        },
+      ],
+    } as never);
+
+    const { prompter, notes } = createPrompter({});
+    await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter);
+
+    expect(prompter.multiselect).not.toHaveBeenCalled();
+    expect(mocks.installSkill).not.toHaveBeenCalled();
+    expect(notes).toContainEqual({
+      title: "All skills ready",
+      message: [
+        "No missing skill dependencies to install.",
+        "To inspect available skills, run: openclaw skills list --verbose",
+        "To check skill status, run: openclaw skills check",
+      ].join("\n"),
+    });
   });
 
   it("recommends Homebrew when user selects a brew-backed install and brew is missing", async () => {

--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -116,6 +116,17 @@ export async function setupSkills(
     }
   }
   let next: OpenClawConfig = cfg;
+  if (installable.length === 0 && missing.length === 0) {
+    await prompter.note(
+      [
+        "No missing skill dependencies to install.",
+        `To inspect available skills, run: ${formatCliCommand("openclaw skills list --verbose")}`,
+        `To check skill status, run: ${formatCliCommand("openclaw skills check")}`,
+      ].join("\n"),
+      t("wizard.skills.allReadyTitle") ?? "All skills ready",
+    );
+    return next;
+  }
   if (installable.length > 0) {
     const toInstall = await prompter.multiselect({
       message: t("wizard.skills.installDeps"),

--- a/src/wizard/i18n/locales/en.ts
+++ b/src/wizard/i18n/locales/en.ts
@@ -306,6 +306,7 @@ export const en = {
       toolAccess: "This bot can read files and run actions if tools are enabled.",
     },
     skills: {
+      allReadyTitle: "All skills ready",
       configure: "Configure skills now? (recommended)",
       containerBrewHidden:
         "Brew-only skill installs are hidden in Linux containers because the official image does not ship Homebrew.",

--- a/src/wizard/i18n/locales/zh-CN.ts
+++ b/src/wizard/i18n/locales/zh-CN.ts
@@ -299,6 +299,7 @@ export const zh_CN = {
       toolAccess: "如果启用了工具，这个 bot 可以读取文件并执行操作。",
     },
     skills: {
+      allReadyTitle: "技能已就绪",
       configure: "现在配置技能？（推荐）",
       containerBrewHidden:
         "在 Linux 容器中会隐藏仅支持 brew 的技能安装项，因为官方镜像不包含 Homebrew。",

--- a/src/wizard/i18n/locales/zh-TW.ts
+++ b/src/wizard/i18n/locales/zh-TW.ts
@@ -299,6 +299,7 @@ export const zh_TW = {
       toolAccess: "如果啟用了工具，這個 bot 可以讀取檔案並執行操作。",
     },
     skills: {
+      allReadyTitle: "技能已就緒",
       configure: "現在設定技能？（建議）",
       containerBrewHidden:
         "在 Linux 容器中會隱藏僅支援 brew 的技能安裝項，因為官方映像檔不包含 Homebrew。",


### PR DESCRIPTION
## Summary

- Show an explicit all-ready note when the skills setup wizard has no missing dependencies to install.
- Add the missing localized title and regression coverage for the empty dependency state.

## Real behavior proof

Behavior addressed: `setupSkills()` could show the status summary, ask to configure skills, and then exit without any next-step note when every non-blocked skill was already eligible and no requirements were missing.
Real environment tested: local OpenClaw source checkout on macOS, Node/pnpm repo runtime, with a temporary `OPENCLAW_HOME` and the production skills status/setup path exercised directly through `node --import tsx`.
Exact steps or command run after this patch: `OPENCLAW_HOME=$(mktemp -d) TMP_WS=$(mktemp -d) node --import tsx --input-type=module` probe that builds real workspace skill status, disables the few missing non-blocked local skills to create the all-ready state, then calls `setupSkills()` with a recording prompter.
Evidence after fix:
```json
{
  "disabledMissingSkills": [
    "qqbot-channel",
    "qqbot-media",
    "qqbot-remind"
  ],
  "finalNote": {
    "title": "All skills ready",
    "message": "No missing skill dependencies to install.\nTo inspect available skills, run: openclaw skills list --verbose\nTo check skill status, run: openclaw skills check"
  }
}
```
Observed result after fix: the wizard emits an `All skills ready` note with `openclaw skills list --verbose` and `openclaw skills check`, does not show dependency multiselect, and does not call the installer.
What was not tested: no manual interactive terminal wizard session; the direct probe exercises the production setup path with a recording prompter, and the focused test covers the exact prompter calls.

## Verification

- `pnpm test src/commands/onboard-skills.test.ts`
- `git diff --check`
- Auto Review: clean, no accepted/actionable findings.
