### PR TITLE
perf(utils): preserve message identity in stripInlineDirectiveTagsFromMessageForDisplay

### DIFF
--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -240,6 +240,99 @@ describe("stripInlineDirectiveTagsFromMessageForDisplay", () => {
       content: "plain text",
     };
     const result = stripInlineDirectiveTagsFromMessageForDisplay(input);
-    expect(result).toEqual(input);
+    expect(result).toBe(input);
+  });
+
+  test("returns original message reference when no directives are present", () => {
+    const input = {
+      role: "assistant",
+      content: [{ type: "text", text: "plain text without directives" }],
+    };
+    const result = stripInlineDirectiveTagsFromMessageForDisplay(input);
+    expect(result).toBe(input);
+  });
+
+  test("returns original message reference when content has only non-text parts", () => {
+    const input = {
+      role: "assistant",
+      content: [{ type: "image", url: "https://example.test/x.png" }],
+    };
+    const result = stripInlineDirectiveTagsFromMessageForDisplay(input);
+    expect(result).toBe(input);
+  });
+
+  test("preserves unchanged text-part references when only some parts change", () => {
+    const unchangedPart = { type: "text" as const, text: "plain text" };
+    const changedPart = { type: "text" as const, text: "with [[reply_to_current]] tag" };
+    const nonTextPart = { type: "image" as const, url: "https://example.test/x.png" };
+    const input = {
+      role: "assistant",
+      content: [unchangedPart, changedPart, nonTextPart],
+    };
+    const result = stripInlineDirectiveTagsFromMessageForDisplay(input);
+    expect(result).not.toBe(input);
+    const content = result?.content as Array<Record<string, unknown>>;
+    expect(content[0]).toBe(unchangedPart);
+    expect(content[1]).not.toBe(changedPart);
+    expect(content[1]).toEqual({ type: "text", text: "with  tag" });
+    expect(content[2]).toBe(nonTextPart);
+  });
+
+  test("preserves trailing references when only the first part changes", () => {
+    const changedPart = { type: "text" as const, text: "first [[reply_to_current]]" };
+    const unchangedText = { type: "text" as const, text: "second" };
+    const unchangedImage = { type: "image" as const, url: "https://example.test/x.png" };
+    const input = {
+      role: "assistant",
+      content: [changedPart, unchangedText, unchangedImage],
+    };
+    const result = stripInlineDirectiveTagsFromMessageForDisplay(input);
+    expect(result).not.toBe(input);
+    const content = result?.content as Array<Record<string, unknown>>;
+    expect(content).toHaveLength(3);
+    expect(content[0]).not.toBe(changedPart);
+    expect(content[0]).toEqual({ type: "text", text: "first " });
+    expect(content[1]).toBe(unchangedText);
+    expect(content[2]).toBe(unchangedImage);
+  });
+
+  test("preserves leading references when only the last part changes", () => {
+    const unchangedText = { type: "text" as const, text: "first" };
+    const unchangedImage = { type: "image" as const, url: "https://example.test/x.png" };
+    const changedPart = { type: "text" as const, text: "last [[reply_to_current]]" };
+    const input = {
+      role: "assistant",
+      content: [unchangedText, unchangedImage, changedPart],
+    };
+    const result = stripInlineDirectiveTagsFromMessageForDisplay(input);
+    expect(result).not.toBe(input);
+    const content = result?.content as Array<Record<string, unknown>>;
+    expect(content).toHaveLength(3);
+    expect(content[0]).toBe(unchangedText);
+    expect(content[1]).toBe(unchangedImage);
+    expect(content[2]).not.toBe(changedPart);
+    expect(content[2]).toEqual({ type: "text", text: "last " });
+  });
+
+  test("preserves arbitrary extra fields on rebuilt text parts", () => {
+    const input = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "with [[reply_to_current]] tag",
+          id: "part-1",
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+    };
+    const result = stripInlineDirectiveTagsFromMessageForDisplay(input);
+    const content = result?.content as Array<Record<string, unknown>>;
+    expect(content[0]).toEqual({
+      type: "text",
+      text: "with  tag",
+      id: "part-1",
+      cache_control: { type: "ephemeral" },
+    });
   });
 });

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -137,8 +137,11 @@ function isMessageTextPart(part: MessagePart): part is MessageTextPart {
 }
 
 /**
- * Strips inline directive tags from message text blocks while preserving message shape.
+ * Strips inline directive tags from text content while preserving message shape.
  * Empty post-strip text stays empty-string to preserve caller semantics.
+ * Returns the input message reference (including the original content array) when
+ * no text part changed, and reuses unchanged text-part references in mixed content,
+ * so identity-equality consumers avoid spurious churn.
  */
 export function stripInlineDirectiveTagsFromMessageForDisplay(
   message: DisplayMessageWithContent | undefined,
@@ -149,16 +152,29 @@ export function stripInlineDirectiveTagsFromMessageForDisplay(
   if (!Array.isArray(message.content)) {
     return message;
   }
-  const cleaned = message.content.map((part) => {
-    if (!part || typeof part !== "object") {
-      return part;
+  let cleaned: unknown[] | undefined;
+  for (let i = 0; i < message.content.length; i++) {
+    const part = message.content[i];
+    let next: unknown = part;
+    if (part && typeof part === "object" && isMessageTextPart(part as MessagePart)) {
+      const record = part as MessageTextPart;
+      const stripped = stripInlineDirectiveTagsForDisplay(record.text);
+      if (stripped.changed) {
+        next = { ...record, text: stripped.text };
+      }
     }
-    const record = part as MessagePart;
-    if (!isMessageTextPart(record)) {
-      return part;
+    if (next === part) {
+      cleaned?.push(part);
+      continue;
     }
-    return { ...record, text: stripInlineDirectiveTagsForDisplay(record.text).text };
-  });
+    if (!cleaned) {
+      cleaned = message.content.slice(0, i);
+    }
+    cleaned.push(next);
+  }
+  if (!cleaned) {
+    return message;
+  }
   return { ...message, content: cleaned };
 }
 


### PR DESCRIPTION
## Summary

- Preserve the original message object when directive stripping does not change any text.
- Reuse unchanged content-part references when only some text parts need directive removal.
- Keep existing stripped text output and extra fields intact.

## Real behavior proof

Behavior addressed: `stripInlineDirectiveTagsFromMessageForDisplay()` rebuilt message/content objects even when no inline directive was removed, causing unnecessary identity churn for downstream consumers that compare message objects or content parts by reference.
Real environment tested: local OpenClaw source checkout on macOS, Node/pnpm repo runtime, with the production directive-tag helper exercised directly through `node --import tsx`.
Exact steps or command run after this patch: `node --import tsx --input-type=module` probe that imports `src/utils/directive-tags.ts`, passes unchanged and mixed message-content payloads, and prints object-identity checks.
Evidence after fix:
```json
{
  "unchangedMessageReference": true,
  "unchangedContentReference": true,
  "mixedMessageReferenceChanged": true,
  "mixedFirstPartReferenceKept": true,
  "mixedSecondPartReferenceChanged": true,
  "mixedSecondPartText": "reply  now"
}
```
Observed result after fix: unchanged display messages keep the original message/content references, while only the text part containing the directive is rebuilt and stripped.
What was not tested: no UI render benchmark; this directly exercises the production helper and the focused test shard covers edge cases.

## Verification

- `pnpm test src/utils/directive-tags.test.ts`
- `git diff --check`
- Auto Review: clean, no accepted/actionable findings.
