### PR TITLE
Fix Foundry DeepSeek V4 OpenAI-style reasoning compat

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -725,6 +725,27 @@ describe("applyExtraParamsToAgent", () => {
     expect(messages[2]).not.toHaveProperty("reasoning_content");
   });
 
+  it("does not add DeepSeek V4 thinking params when compat uses OpenAI-style reasoning", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "microsoft-foundry",
+      applyModelId: "deepseek-v4-pro",
+      thinkingLevel: "high",
+      model: {
+        api: "openai-completions",
+        provider: "microsoft-foundry",
+        id: "deepseek-v4-pro",
+        compat: { thinkingFormat: "openai", supportsReasoningEffort: true },
+      } as Model<"openai-completions">,
+      payload: {
+        reasoning_effort: "high",
+        messages: [{ role: "user", content: "hello" }],
+      },
+    });
+
+    expect(payload.reasoning_effort).toBe("high");
+    expect(payload).not.toHaveProperty("thinking");
+  });
+
   it("fills MiMo V2.6 reasoning_content for unowned OpenAI-compatible proxy models", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "opencode",

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -859,8 +859,11 @@ function normalizeDeepSeekV4CandidateId(modelId: unknown): string | undefined {
 
 function isDeepSeekV4OpenAICompatibleModel(model: Parameters<StreamFn>[0]): boolean {
   const normalizedModelId = normalizeDeepSeekV4CandidateId(model.id);
+  const thinkingFormat = (model as { compat?: { thinkingFormat?: unknown } }).compat
+    ?.thinkingFormat;
   return (
     model.api === "openai-completions" &&
+    thinkingFormat !== "openai" &&
     (normalizedModelId === "deepseek-v4-flash" || normalizedModelId === "deepseek-v4-pro")
   );
 }


### PR DESCRIPTION
## Summary
- skip the shared DeepSeek V4 OpenAI-compatible thinking wrapper when the resolved model compat already declares `thinkingFormat: "openai"`
- preserve `reasoning_effort` without injecting DeepSeek-style `thinking` payloads for Microsoft Foundry DeepSeek V4 models
- add a regression test covering Foundry-style compat on `deepseek-v4-pro`

## Problem
Microsoft Foundry DeepSeek V4 models can be configured to use OpenAI-style reasoning (`thinkingFormat: "openai"` + reasoning effort), but the generic post-plugin fallback wrapper still matched `deepseek-v4-pro` by model id and injected DeepSeek-style `thinking` params anyway.

That produced gateway/runtime failures like:
- `400 Unrecognized request argument supplied: thinking`

## Validation
- added focused regression test in `src/agents/pi-embedded-runner-extraparams.test.ts`
- local unit test runner completed successfully after dependency install
- confirmed failing live gateway logs before fix showed Foundry rejecting `thinking`

## Notes
I also attempted a full `tsc --noEmit`, but the local run hit Node heap OOM before completion, so typecheck evidence here is limited to the focused test path.
