### PR TITLE
fix(ci): clear signal and docs guard blockers

### DIFF
--- a/docs/reference/secret-placeholder-conventions.md
+++ b/docs/reference/secret-placeholder-conventions.md
@@ -18,7 +18,7 @@ Use placeholders that are human-readable but do not resemble real secrets.
 
 ## Avoid these patterns in docs
 
-- Private key sentinels such as `-----BEGIN PRIVATE KEY-----`.
+- Literal PEM private-key header or footer text.
 - Prefixes that resemble live credentials, for example `sk-...`, `xoxb-...`, `AKIA...`.
 - Realistic-looking bearer tokens copied from runtime logs.
 

--- a/extensions/signal/src/daemon.test.ts
+++ b/extensions/signal/src/daemon.test.ts
@@ -1,12 +1,12 @@
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { __testing } from "./daemon.js";
+import { testApi } from "./daemon.js";
 
 describe("signal daemon args", () => {
   it("expands home-relative configPath before passing it to signal-cli", () => {
     expect(
-      __testing.buildDaemonArgs({
+      testApi.buildDaemonArgs({
         cliPath: "signal-cli",
         configPath: "~/.openclaw/signal-cli",
         httpHost: "127.0.0.1",

--- a/extensions/signal/src/daemon.ts
+++ b/extensions/signal/src/daemon.ts
@@ -163,7 +163,7 @@ export function spawnSignalDaemon(opts: SignalDaemonOpts): SignalDaemonHandle {
   };
 }
 
-export const __testing = {
+export const testApi = {
   buildDaemonArgs,
   resolveSignalCliConfigPath,
 } as const;


### PR DESCRIPTION
## Summary
- Rename the Signal daemon test export from `__testing` to `testApi` so changed-lane lint no longer blocks unrelated PRs on `no-underscore-dangle`.
- Reword the secret placeholder docs to avoid a literal private-key sentinel that trips the repository security-fast guard.

## Verification
- autoreview: `AUTOREVIEW_AUTO_TESTS=0 AUTOREVIEW_OPENCLAW_MAINTAINER_VALIDATION=1 .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> clean, patch correct 0.86 after rebasing onto current `origin/main`.
- focused remote proof: AWS Crabbox `run_d656f8d27c9e`, lease `cbx_7f1dce54d485`, ran `pnpm test:serial extensions/signal/src/daemon.test.ts` -> passed 1 test.
- fresh PR remote proof: AWS Crabbox `run_b0826007c267`, lease `cbx_ca39164c081a`, ran `pnpm check:changed` against openclaw/openclaw#85693 after rebasing onto current `origin/main` -> passed.
- GitHub CI note: broad CI jobs remain red on unrelated current-main surfaces (`extensions/discord/index.ts`, `meeting-notes`, and `src/commands/agent.test.ts`); this PR only changes `extensions/signal/src/daemon.ts`, `extensions/signal/src/daemon.test.ts`, and `docs/reference/secret-placeholder-conventions.md`.

## Real behavior proof
Behavior addressed: unrelated diagnostics PRs were blocked by current-main changed-gate failures in the Signal daemon test export and docs private-key sentinel guard.
Real environment tested: AWS Crabbox c7a.8xlarge fresh PR checkout for openclaw/openclaw#85693.
Exact steps or command run after this patch: `pnpm check:changed`.
Evidence after fix: `run_b0826007c267`, lease `cbx_ca39164c081a`, exited 0.
Observed result after fix: changed lanes completed with extension lint, type/test checks, docs guards, security placeholder guard, and runtime guards passing.
What was not tested: full repository test suite; unrelated broad GitHub CI jobs are red on current-main surfaces outside this patch.
