### PR TITLE
fix(cli): waitForever must keep the event loop alive

### DIFF
--- a/src/cli/cli-utils.test.ts
+++ b/src/cli/cli-utils.test.ts
@@ -10,7 +10,7 @@ import {
 import { waitForever } from "./wait.js";
 
 describe("waitForever", () => {
-  it("creates an unref'ed interval and returns a pending promise", () => {
+  it("keeps the event loop alive (ref'd interval) and returns a pending promise", () => {
     const unref = vi.fn();
     const interval = { unref } as unknown as ReturnType<typeof setInterval>;
     const setIntervalSpy = vi.spyOn(global, "setInterval").mockReturnValue(interval);
@@ -20,7 +20,11 @@ describe("waitForever", () => {
       const [callback, delay] = setIntervalSpy.mock.calls[0] ?? [];
       expect(typeof callback).toBe("function");
       expect(delay).toBe(1_000_000);
-      expect(unref).toHaveBeenCalledTimes(1);
+      // Regression guard for the previous `.unref()` bug: an unref'd interval
+      // does NOT keep the event loop alive, so `await waitForever()` would
+      // exit immediately with code 13 ("unsettled top-level await"). The
+      // function must NOT unref the interval.
+      expect(unref).not.toHaveBeenCalled();
       expect(promise).toBeInstanceOf(Promise);
     } finally {
       setIntervalSpy.mockRestore();

--- a/src/cli/wait.ts
+++ b/src/cli/wait.ts
@@ -1,7 +1,12 @@
 export function waitForever() {
-  // Keep event loop alive via an unref'ed interval plus a pending promise.
-  const interval = setInterval(() => {}, 1_000_000);
-  interval.unref();
+  // Keep the event loop alive with a ref'd interval. A pending Promise is not
+  // an active handle on its own, so without the interval, Node exits the
+  // process with code 13 ("unsettled top-level await") as soon as nothing
+  // else is keeping the loop open — defeating the "wait forever" contract.
+  // The handle is intentionally not retained: there is no caller-visible way
+  // to stop a "forever" wait, and the interval lives for the lifetime of the
+  // process.
+  setInterval(() => {}, 1_000_000);
   return new Promise<void>(() => {
     /* never resolve */
   });


### PR DESCRIPTION
`waitForever()` is a public library export used by long-running embeds to block until the host process is asked to exit. It called `interval.unref()` on the keep-alive timer, which removes the timer from Node's active-handle set. With no other ref'd handles, `await waitForever()` exits the process in ~3 ms with exit code 13 ("unsettled top-level await") instead of waiting.

Drop the `.unref()` so the interval actually keeps the loop alive, and update the existing unit test (and comment) to lock in the new contract.

## Summary

- Problem: `await waitForever()` from `src/cli/wait.ts` exits the calling Node process in ~3 ms with exit code 13 ("unsettled top-level await") whenever no other ref'd handle is keeping the loop open. The function's intent is the opposite — block until the host calls `process.exit()`.
- Solution: drop `interval.unref()` so the ref'd `setInterval` actually counts as an active handle and the loop stays alive.
- What changed: `src/cli/wait.ts` (5 + / 3 −); existing unit test in `src/cli/cli-utils.test.ts` flipped from "asserts `unref` was called" to "asserts `unref` was NOT called", with a regression-guard comment.
- What did NOT change (scope boundary): the function signature, return type, callers, and lazy-import re-exports (`src/library.ts:90`, `src/index.ts`). No protocol, session, channel, gateway, or CLI command surface touched.

## Motivation

- `waitForever` is exposed as a public library API — third-party embeds use `await openclaw.waitForever()` to keep their entry point alive while a gateway or daemon does its work. Today that contract is broken: if the consumer hasn't independently ref'd another handle, the process exits ~3 ms after the `await`, with Node logging `Warning: Detected unsettled top-level await` and exit code 13. The function name and the in-source comment both claim the loop will be kept alive, so this is a real correctness defect, not a style nit.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `await waitForever()` exits the process in ~3 ms with exit code 13 instead of blocking, because the keep-alive interval was `.unref()`'d.
- Real environment tested: Windows 10 Enterprise 19045, Node v24.14.0, pnpm 11.2.2, fresh clone of `openclaw/openclaw` `main` at `bcf756ce36`.
- Exact steps or command run after this patch:

  ```bash
  # Unit-test guardrail — the existing test was updated to fail pre-fix, pass post-fix.
  node scripts/run-vitest.mjs src/cli/cli-utils.test.ts

  # Real-process probe — imports the patched src/cli/wait.ts via tsx,
  # awaits waitForever(), and schedules an unrelated 1500 ms setTimeout
  # that calls process.exit(0). Without the fix, the process exited in
  # ~3 ms with code 13; with the fix, the timer fires and the process
  # exits cleanly with code 0.
  node --import tsx ./probe-wait-forever-postfix.mjs
  ```

  Probe source (the same probe used pre-fix to reproduce the bug):

  ```js
  import { waitForever } from "file:///.../src/cli/wait.ts";
  const t0 = Date.now();
  process.on("exit", (code) => {
    process.stderr.write(`exit hook: code=${code}, elapsed=${Date.now() - t0}ms\n`);
  });
  setTimeout(() => {
    process.stderr.write(`timer fired at elapsed=${Date.now() - t0}ms\n`);
    process.exit(0);
  }, 1500);
  process.stderr.write(`pre-await:  elapsed=${Date.now() - t0}ms\n`);
  await waitForever();
  ```

- Evidence after fix (terminal capture):

  ```
  $ node scripts/run-vitest.mjs src/cli/cli-utils.test.ts
   Test Files  1 passed (1)
        Tests  39 passed (39)

  $ node --import tsx ./probe-wait-forever-postfix.mjs ; echo "exit code: $?"
  pre-await:  elapsed=0ms
  timer fired at elapsed=1514ms
  exit hook: code=0, elapsed=1515ms
  exit code: 0
  ```

  Pre-fix run (same probe, original `src/cli/wait.ts` with `.unref()` restored), for comparison:

  ```
  pre-await:  elapsed=1ms
  Warning: Detected unsettled top-level await at file:///.../probe-wait-forever-clean.mjs:15
  exit hook: code=13, elapsed=3ms
  exit code: 13
  ```

  And the existing unit test in `src/cli/cli-utils.test.ts` correctly fails pre-fix:

  ```
   FAIL  |cli| ../../src/cli/cli-utils.test.ts > waitForever > keeps the event loop alive (ref'd interval) and returns a pending promise
  AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
   ❯ ../../src/cli/cli-utils.test.ts:27:25
     expect(unref).not.toHaveBeenCalled();
                        ^
  ```

- Observed result after fix: `await waitForever()` blocks until external code (gateway shutdown, signal handler, etc.) calls `process.exit(...)`. Exit code matches whatever the caller decides instead of 13.
- What was not tested: did not exercise the full built `openclaw` CLI binary — the change is in a library helper and the regression test exercises the function directly via Vitest. Did not test on macOS or Linux; the bug and fix are platform-independent because Node's `Timeout.unref()` semantics are identical across platforms.
- Before evidence: see the pre-fix terminal capture above.

## Root Cause (if applicable)

- Root cause: `interval.unref()` removes the keep-alive timer from Node's active-handle set; a pending Promise on its own is not an active handle, so the loop has nothing to keep it alive and Node exits with code 13.
- Missing detection / guardrail: the existing test only asserted that `unref` was called and that the returned value was a Promise — it never verified the actual contract of "the process should still be alive." The flipped assertion in this PR (`expect(unref).not.toHaveBeenCalled()`) closes that gap.
- Contributing context (if known): the in-source comment confidently claimed the unref'd interval kept the loop alive, which both inverted the actual behavior and discouraged questioning it during review.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/cli-utils.test.ts` — the existing `describe("waitForever", ...)` block.
- Scenario the test should lock in: `waitForever()` calls `setInterval` once with delay 1 000 000 ms, returns a pending Promise, and does NOT call `unref` on the interval.
- Why this is the smallest reliable guardrail: it tests the function in isolation via `vi.spyOn(global, "setInterval")` so it never leaks a real interval into the Vitest process. The single assertion change (`expect(unref).toHaveBeenCalledTimes(1)` → `expect(unref).not.toHaveBeenCalled()`) is enough to flip on the regression — verified by running the test against the pre-fix source.
- Existing test that already covers this (if any): the existing test asserted the OPPOSITE — that `unref` *was* called. That test was the bug-shaped guardrail and is the one updated here.
- If no new test is added, why not: updating the existing test is the smallest reliable guardrail and matches the project's testing style; no additional test was needed.

## User-visible / Behavior Changes

For consumers of the library API `openclaw.waitForever()`:

Before:

```
$ node -e 'import("openclaw").then(({ waitForever }) => waitForever())'
Warning: Detected unsettled top-level await ...
# process exits in ~3 ms with code 13
```

After:

```
$ node -e 'import("openclaw").then(({ waitForever }) => waitForever())'
# process stays alive, blocked on the Promise, until external code exits it
```

No internal callers in this repo. No CLI command shape changed.

## Diagram (if applicable)

```text
Before (`.unref()` present):
  await waitForever()
    -> setInterval(...).unref()       (timer NOT in keep-alive set)
    -> new Promise(() => {})          (not an active handle)
    -> Node has nothing to do -> process.exit(13)   // ~3 ms

After (`.unref()` removed):
  await waitForever()
    -> setInterval(...)               (timer IN keep-alive set)
    -> new Promise(() => {})
    -> Node loop kept alive by the interval; await blocks forever
    -> external code calls process.exit(N)
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A — all answers are `No`.

## Repro + Verification

### Environment

- OS: Windows 10 Enterprise 19045
- Runtime/container: Node v24.14.0, pnpm 11.2.2
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A — bug reproduced with a small standalone Node script that imports `src/cli/wait.ts`.

### Steps

1. `node --import tsx ./probe-wait-forever-postfix.mjs` (probe source listed under "Real behavior proof").
2. Observe whether the process stays alive long enough for the 1 500 ms timer to fire.
3. Cross-check `node scripts/run-vitest.mjs src/cli/cli-utils.test.ts`.

### Expected

- Probe: 1 500 ms timer fires, process exits with code 0.
- Vitest: 39 / 39 tests pass.

### Actual

- Before this PR: probe exits at elapsed ≈ 3 ms with code 13; Vitest fails at the `expect(unref).not.toHaveBeenCalled()` assertion.
- After this PR: probe runs for ≈ 1 515 ms, exits with code 0; Vitest reports 39 / 39 passing.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets (in "Real behavior proof" above)
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What I personally verified (not just CI), and how:

- Verified scenarios:
  - Pre-fix probe (`probe-wait-forever-clean.mjs`) exits ≈ 3 ms with code 13.
  - Post-fix probe (`probe-wait-forever-postfix.mjs`) stays alive until the unrelated 1 500 ms timer fires, then exits with code 0.
  - Updated regression test fails against the pre-fix source and passes against the patched source.
  - `oxfmt --check` and `oxlint` clean on both touched files.
  - `pnpm tsgo:core` clean (exit code 0).
- Edge cases checked:
  - `interval` handle is intentionally not retained — confirmed there is no caller-visible way to stop a "forever" wait, so leaking the handle for the lifetime of the process is the intended design.
  - Existing test mocks `setInterval` via `vi.spyOn`, so the unit test does not leak a real interval into the Vitest process and the suite still exits cleanly.
- What I did **not** verify:
  - Full `pnpm build` + invocation of the bundled `openclaw` CLI binary — the change is in a library helper imported via `src/library.ts`, exercised directly by the unit test.
  - macOS / Linux — bug and fix are platform-independent (Node's `Timeout.unref()` semantics are identical across platforms).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — fixes a broken contract. Consumers that were relying on the broken "exits immediately" behavior would have been hitting code 13 and would already have a workaround.
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

- Risk: a downstream caller might have been silently depending on `waitForever()` exiting early.
  - Mitigation: the function's name, comment, and public-API placement all promise "wait forever"; any caller relying on the broken behavior was implicitly relying on a `Warning: Detected unsettled top-level await` + exit code 13. That is not a contract worth preserving. If a maintainer disagrees, the fix can ship behind an opt-in (e.g. a `waitForeverUnref()` alias) without changing the default.
- Risk: the ref'd interval keeps the loop alive even if the consumer didn't intend it.
  - Mitigation: matches the documented contract of "wait forever" and matches how every other long-running embed in the project keeps itself alive.