### PR TITLE
fix(agent): use static catalog for embedded model fast path

### DIFF
--- a/src/agents/embedded-agent-runner.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.e2e.test.ts
@@ -352,9 +352,12 @@ describe("runEmbeddedAgent", () => {
     expect(resolveModelCall?.[1]).toBe("openrouter/auto");
     expect(resolveModelCall?.[2]).toBe(agentDir);
     expect(resolveModelCall?.[3]).toBe(cfg);
-    expect(
-      (resolveModelCall?.[4] as { skipAgentDiscovery?: boolean } | undefined)?.skipAgentDiscovery,
-    ).toBe(true);
+    expect(resolveModelCall?.[4]).toEqual(
+      expect.objectContaining({
+        allowBundledStaticCatalogFallback: true,
+        skipAgentDiscovery: true,
+      }),
+    );
     expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();
   });
 

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -544,6 +544,28 @@ describe("resolveModel", () => {
       maxTokens: 8192,
     });
 
+    const runtimeHooks = createRuntimeHooks();
+    const prepareProviderDynamicModel = vi.fn(async () => {});
+    const reasoningEffortMap = {
+      off: "none",
+      minimal: "none",
+      low: "high",
+      medium: "high",
+      high: "high",
+      xhigh: "high",
+      adaptive: "high",
+      max: "high",
+    };
+    const normalizeProviderResolvedModelWithPlugin = vi.fn(({ context }) => ({
+      ...context.model,
+      compat: {
+        ...context.model.compat,
+        supportsStore: false,
+        supportsReasoningEffort: true,
+        maxTokensField: "max_tokens",
+        reasoningEffortMap,
+      },
+    }));
     const result = await resolveModelAsync(
       "mistral",
       "mistral-medium-3-5",
@@ -551,12 +573,17 @@ describe("resolveModel", () => {
       undefined,
       {
         allowBundledStaticCatalogFallback: true,
-        runtimeHooks: createRuntimeHooks(),
+        runtimeHooks: {
+          ...runtimeHooks,
+          normalizeProviderResolvedModelWithPlugin,
+          prepareProviderDynamicModel,
+        },
         skipAgentDiscovery: true,
       },
     );
 
-    expectRecordFields(expectResolvedModel(result), {
+    const model = expectResolvedModel(result);
+    expectRecordFields(model, {
       provider: "mistral",
       id: "mistral-medium-3-5",
       api: "openai-completions",
@@ -565,6 +592,22 @@ describe("resolveModel", () => {
       contextWindow: 262144,
       maxTokens: 8192,
     });
+    expect(model.compat).toMatchObject({
+      supportsStore: false,
+      supportsReasoningEffort: true,
+      maxTokensField: "max_tokens",
+      reasoningEffortMap,
+    });
+    expect(normalizeProviderResolvedModelWithPlugin).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "mistral",
+        context: expect.objectContaining({
+          provider: "mistral",
+          modelId: "mistral-medium-3-5",
+        }),
+      }),
+    );
+    expect(prepareProviderDynamicModel).not.toHaveBeenCalled();
     expect(resolveBundledStaticCatalogModelMock).toHaveBeenCalledWith({
       provider: "mistral",
       modelId: "mistral-medium-3-5",
@@ -627,7 +670,7 @@ describe("resolveModel", () => {
     expect(discoverModels).not.toHaveBeenCalled();
   });
 
-  it("falls back to bundled static catalog rows without agent discovery", async () => {
+  it("uses bundled static catalog rows before dynamic hooks without agent discovery", async () => {
     const cfg = {
       models: {
         providers: {
@@ -682,8 +725,8 @@ describe("resolveModel", () => {
         cfg,
       }),
     );
-    expect(prepareProviderDynamicModel).toHaveBeenCalled();
-    expect(runProviderDynamicModel).toHaveBeenCalled();
+    expect(prepareProviderDynamicModel).not.toHaveBeenCalled();
+    expect(runProviderDynamicModel).not.toHaveBeenCalled();
     expect(discoverAuthStorage).not.toHaveBeenCalled();
     expect(discoverModels).not.toHaveBeenCalled();
   });

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -1656,7 +1656,9 @@ export async function resolveModelAsync(
   let model =
     explicitModel?.kind === "resolved" && !providerRuntimeMetadataShouldWin
       ? explicitModel.model
-      : undefined;
+      : options?.skipAgentDiscovery && !explicitModel && !providerRuntimeMetadataShouldWin
+        ? await resolveStaticCatalogFallbackModel()
+        : undefined;
   model ??= await resolveDynamicAttempt();
   if (!model && !explicitModel && options?.retryTransientProviderRuntimeMiss) {
     // Startup can race the first provider-runtime snapshot load on a fresh

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -743,11 +743,11 @@ export async function runEmbeddedAgent(
           agentDir,
           params.config,
           {
-            // Plugin dynamic model hooks can resolve explicit model refs without
-            // first generating OpenClaw models.json. This keeps one-shot model runs from
-            // blocking on unrelated provider discovery.
+            // Static catalogs and plugin dynamic model hooks can resolve explicit model refs
+            // without first generating OpenClaw models.json. This keeps one-shot model runs
+            // from blocking on unrelated provider discovery.
+            allowBundledStaticCatalogFallback: true,
             skipAgentDiscovery: true,
-            allowBundledStaticCatalogFallback: pluginHarnessOwnsTransport,
             preferBundledStaticCatalogTransport: pluginHarnessOwnsTransport,
             workspaceDir: resolvedWorkspace,
             authProfileId: params.authProfileId,


### PR DESCRIPTION
## Summary

- Closes #84783.
- Lets the embedded agent runner use bundled static catalog rows during its skip-agent-discovery model-resolution fast path.
- Resolves static catalog rows before provider dynamic hooks on that fast path, avoiding Moonshot runtime/provider discovery before dispatch while preserving the existing dynamic fallback when no static row exists or provider runtime metadata is explicitly preferred.
- Refreshes the branch onto current `upstream/main` after the embedded-agent runner and static-catalog fallback changes.

## Test Plan

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner.e2e.test.ts src/agents/embedded-agent-runner/model.test.ts`
  - Result: passed 2 Vitest shards; `model.test.ts` 117 passed; `embedded-agent-runner.e2e.test.ts` 14 passed.
- `node scripts/run-vitest.mjs src/agents/bash-tools.exec-foreground-failures.test.ts`
  - Result: passed 1 Vitest shard; 2 passed.
- `pnpm tsgo:prod`
  - Result: passed `tsgo:core` and `tsgo:extensions`.
- `pnpm check:test-types`
  - Result: passed `tsgo:core:test` and `tsgo:extensions:test`.
- `node scripts/check-extension-package-tsc-boundary.mjs --mode=compile`
  - Result: extension package boundary check passed; 114 compiled plugins.
- `git diff --check upstream/main...HEAD`
  - Result: no whitespace errors.

## Real behavior proof

Behavior addressed: Native Moonshot embedded agent runs can resolve `moonshot/kimi-k2.6` from the bundled static manifest catalog before generating OpenClaw `models.json` or loading provider dynamic hooks, removing the reported model-resolution stall before dispatch.

Real environment tested: Local macOS OpenClaw worktree refreshed onto current `upstream/main`, using the real `src/agents/embedded-agent-runner/model.ts` runtime entrypoint with isolated temporary OpenClaw home/config directories, an isolated temporary agent directory, and the bundled Moonshot manifest catalog.

Exact steps or command run after this patch: `OPENCLAW_HOME=<temp> OPENCLAW_CONFIG_DIR=<temp>/.openclaw OPENCLAW_CONFIG_PATH=<temp>/.openclaw/openclaw.json time -l node --import tsx -e "import fs from 'node:fs/promises'; import path from 'node:path'; import { resolveModelAsync } from './src/agents/embedded-agent-runner/model.ts'; const root = process.env.OPENCLAW_HOME; if (!root) throw new Error('missing OPENCLAW_HOME'); const agentDir = path.join(root, 'agent'); await fs.mkdir(agentDir, { recursive: true }); const started = Date.now(); const result = await resolveModelAsync('moonshot', 'kimi-k2.6', agentDir, { agents: { defaults: { workspace: root } } }, { allowBundledStaticCatalogFallback: true, skipAgentDiscovery: true, workspaceDir: root }); let modelsJsonExists = true; try { await fs.access(path.join(agentDir, 'models.json')); } catch { modelsJsonExists = false; } console.log(JSON.stringify({ resolved: Boolean(result.model), provider: result.model?.provider, id: result.model?.id, api: result.model?.api, baseUrl: result.model?.baseUrl, modelsJsonExists, elapsedMs: Date.now() - started }, null, 2));"`.

Evidence after fix: Copied terminal output from the refreshed runtime command:

```json
{
  "resolved": true,
  "provider": "moonshot",
  "id": "kimi-k2.6",
  "api": "openai-completions",
  "baseUrl": "https://api.moonshot.ai/v1",
  "modelsJsonExists": false,
  "elapsedMs": 62116
}
```

The same run also reported `65.17 real` seconds and `825475072 maximum resident set size` from `time -l`.

Observed result after fix: The command exited 0, resolved the Moonshot model from static catalog metadata, did not create `models.json`, and used the `skipAgentDiscovery` fast path on current `upstream/main`.

What was not tested: No live Moonshot API call or Discord/TUI end-to-end dispatch was run; the proof isolates the model-resolution path that the issue trace identified, with targeted embedded-runner tests and type/package-boundary checks.

## Risk/Notes

- This PR intentionally changes only the model-resolution fast path for explicit model refs with `allowBundledStaticCatalogFallback` and `skipAgentDiscovery`; live provider dispatch still depends on operator credentials.
- Provider runtime metadata still wins when the runtime preference hook asks for it, so live/static catalog metadata does not replace explicitly preferred provider-resolved metadata.
