### PR TITLE
fix(memory): prevent silent vector index degradation when embedding provider temporarily unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 - Agents/heartbeat: stop heartbeat turns after the first valid `heartbeat_respond` so repeated response loops do not burn tokens. (#86357) Thanks @udaymanish6.
 - Tasks: keep retained lost tasks out of default status health counts, explain their cleanup window during maintenance, and prune lost task records after 24 hours instead of the general 7-day terminal retention.
 - Memory-core: keep REM dreaming focused on live light-staged memories and mark staged entries as considered so old recall history no longer dominates fresh candidates. (#86302) Thanks @SebTardif.
+- Memory: abort sync instead of downgrading an existing semantic vector index to FTS-only when the configured embedding provider is temporarily unavailable. (#85704) Thanks @yaaboo-gif.
 - Telegram: propagate forum topic names through the account-scoped topic cache for native command context and topic create/edit actions. (#86299) Thanks @SebTardif.
 - Slack: keep downloaded read-only files out of reply media so Slack file reads do not echo files back to the conversation. (#86318) Thanks @neeravmakwana.
 - Cron: accept leading-plus relative durations such as `+5m` for one-shot `--at` schedules. (#86341) Thanks @mushuiyu886.

--- a/extensions/memory-core/src/memory/manager-sync-ops.archive-delta-bypass.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.archive-delta-bypass.test.ts
@@ -100,6 +100,8 @@ class SessionDeltaHarness extends MemoryManagerSyncOps {
 
   protected pruneEmbeddingCacheIfNeeded(): void {}
 
+  protected resetProviderInitializationForRetry(): void {}
+
   protected async indexFile(
     _entry: MemoryIndexEntry,
     _options: { source: MemorySource; content?: string },

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -110,6 +110,8 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
 
   protected pruneEmbeddingCacheIfNeeded(): void {}
 
+  protected resetProviderInitializationForRetry(): void {}
+
   protected async indexFile(
     _entry: MemoryIndexEntry,
     _options: { source: MemorySource; content?: string },

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -1102,14 +1102,14 @@ export abstract class MemoryManagerSyncOps {
     // Guard: if an embedding provider is configured but currently unavailable,
     // abort sync to prevent silently degrading the entire vector index to
     // fts-only and wiping existing semantic vectors.
-    // See: https://github.com/openclaw/openclaw/issues/XXXXX
+    const configuredProvider = this.settings.provider;
     if (
-      this.requestedProvider &&
-      this.requestedProvider !== "none" &&
+      configuredProvider &&
+      configuredProvider !== "none" &&
       !this.provider
     ) {
       throw new Error(
-        `Memory sync aborted: embedding provider "${this.requestedProvider}" is configured but unavailable. ` +
+        `Memory sync aborted: embedding provider "${configuredProvider}" is configured but unavailable. ` +
           `Refusing to run sync in fts-only fallback mode to protect existing vector index.`,
       );
     }

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -1099,6 +1099,21 @@ export abstract class MemoryManagerSyncOps {
     sessionFiles?: string[];
     progress?: (update: MemorySyncProgressUpdate) => void;
   }) {
+    // Guard: if an embedding provider is configured but currently unavailable,
+    // abort sync to prevent silently degrading the entire vector index to
+    // fts-only and wiping existing semantic vectors.
+    // See: https://github.com/openclaw/openclaw/issues/XXXXX
+    if (
+      this.requestedProvider &&
+      this.requestedProvider !== "none" &&
+      !this.provider
+    ) {
+      throw new Error(
+        `Memory sync aborted: embedding provider "${this.requestedProvider}" is configured but unavailable. ` +
+          `Refusing to run sync in fts-only fallback mode to protect existing vector index.`,
+      );
+    }
+
     const progress = params?.progress ? this.createSyncProgress(params.progress) : undefined;
     if (progress) {
       progress.report({

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -235,6 +235,7 @@ export abstract class MemoryManagerSyncOps {
   ): Promise<T>;
   protected abstract getIndexConcurrency(): number;
   protected abstract pruneEmbeddingCacheIfNeeded(): void;
+  protected abstract resetProviderInitializationForRetry(): void;
   protected abstract indexFile(
     entry: MemoryIndexEntry,
     options: { source: MemorySource; content?: string },
@@ -1093,6 +1094,26 @@ export abstract class MemoryManagerSyncOps {
     return state;
   }
 
+  private assertFtsOnlySyncAllowed(): void {
+    if (this.provider) {
+      return;
+    }
+    const existingMeta = this.readMeta();
+    if (
+      !existingMeta ||
+      existingMeta.model === "fts-only" ||
+      !this.settings.provider ||
+      this.settings.provider === "none"
+    ) {
+      return;
+    }
+    this.resetProviderInitializationForRetry();
+    throw new Error(
+      `Memory sync aborted: embedding provider "${this.settings.provider}" is configured but unavailable. ` +
+        `Refusing to run sync in fts-only fallback mode to protect existing vector index (current model: ${existingMeta.model}).`,
+    );
+  }
+
   protected async runSync(params?: {
     reason?: string;
     force?: boolean;
@@ -1102,22 +1123,9 @@ export abstract class MemoryManagerSyncOps {
     // Guard: if an embedding provider is configured but currently unavailable,
     // abort sync to prevent silently degrading an existing semantic vector index
     // to fts-only and wiping existing semantic vectors.
-    // This only protects existing semantic indexes — fresh or already-fts-only
+    // This only protects existing semantic indexes; fresh or already-fts-only
     // indexes can safely sync without an embedding provider.
-    if (!this.provider) {
-      const existingMeta = this.readMeta();
-      if (
-        existingMeta &&
-        existingMeta.model !== "fts-only" &&
-        this.settings.provider &&
-        this.settings.provider !== "none"
-      ) {
-        throw new Error(
-          `Memory sync aborted: embedding provider "${this.settings.provider}" is configured but unavailable. ` +
-            `Refusing to run sync in fts-only fallback mode to protect existing vector index (current model: ${existingMeta.model}).`,
-        );
-      }
-    }
+    this.assertFtsOnlySyncAllowed();
 
     const progress = params?.progress ? this.createSyncProgress(params.progress) : undefined;
     if (progress) {
@@ -1329,6 +1337,8 @@ export abstract class MemoryManagerSyncOps {
     force?: boolean;
     progress?: MemorySyncProgressState;
   }): Promise<void> {
+    this.assertFtsOnlySyncAllowed();
+
     const dbPath = resolveUserPath(this.settings.store.path);
     const tempDbPath = `${dbPath}.tmp-${randomUUID()}`;
     const tempDb = openMemoryDatabaseAtPath(tempDbPath, this.settings.store.vector.enabled);

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -1100,18 +1100,23 @@ export abstract class MemoryManagerSyncOps {
     progress?: (update: MemorySyncProgressUpdate) => void;
   }) {
     // Guard: if an embedding provider is configured but currently unavailable,
-    // abort sync to prevent silently degrading the entire vector index to
-    // fts-only and wiping existing semantic vectors.
-    const configuredProvider = this.settings.provider;
-    if (
-      configuredProvider &&
-      configuredProvider !== "none" &&
-      !this.provider
-    ) {
-      throw new Error(
-        `Memory sync aborted: embedding provider "${configuredProvider}" is configured but unavailable. ` +
-          `Refusing to run sync in fts-only fallback mode to protect existing vector index.`,
-      );
+    // abort sync to prevent silently degrading an existing semantic vector index
+    // to fts-only and wiping existing semantic vectors.
+    // This only protects existing semantic indexes — fresh or already-fts-only
+    // indexes can safely sync without an embedding provider.
+    if (!this.provider) {
+      const existingMeta = this.readMeta();
+      if (
+        existingMeta &&
+        existingMeta.model !== "fts-only" &&
+        this.settings.provider &&
+        this.settings.provider !== "none"
+      ) {
+        throw new Error(
+          `Memory sync aborted: embedding provider "${this.settings.provider}" is configured but unavailable. ` +
+            `Refusing to run sync in fts-only fallback mode to protect existing vector index (current model: ${existingMeta.model}).`,
+        );
+      }
     }
 
     const progress = params?.progress ? this.createSyncProgress(params.progress) : undefined;

--- a/extensions/memory-core/src/memory/manager-sync-yield.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-yield.test.ts
@@ -124,6 +124,8 @@ class SessionSyncYieldHarness extends MemoryManagerSyncOps {
 
   protected pruneEmbeddingCacheIfNeeded(): void {}
 
+  protected resetProviderInitializationForRetry(): void {}
+
   protected async indexFile(
     entry: MemoryIndexEntry,
     _options: { source: MemorySource; content?: string },

--- a/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
@@ -5,6 +5,7 @@ import { DatabaseSync } from "node:sqlite";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { closeAllMemorySearchManagers, getMemorySearchManager } from "./index.js";
+import type { MemoryIndexMeta } from "./manager-reindex-state.js";
 import type { MemoryIndexManager } from "./manager.js";
 import "./test-runtime-mocks.js";
 
@@ -89,6 +90,19 @@ describe("memory manager FTS-only reindex", () => {
     }
   }
 
+  function writeExistingMeta(memoryManager: MemoryIndexManager, model: string): void {
+    const metaWriter = memoryManager as unknown as {
+      writeMeta(meta: MemoryIndexMeta): void;
+    };
+    metaWriter.writeMeta({
+      model,
+      provider: "openai",
+      chunkTokens: 600,
+      chunkOverlap: 120,
+      sources: ["memory"],
+    });
+  }
+
   it("preserves indexed chunks across forced reindex in FTS-only mode", async () => {
     const memoryManager = await createManager();
 
@@ -115,5 +129,14 @@ describe("memory manager FTS-only reindex", () => {
 
     expect(countChunksContaining("refresh marker")).toBeGreaterThan(0);
     expect(countChunksContaining("Alpha topic")).toBe(0);
+  });
+
+  it("aborts instead of downgrading an existing semantic index to FTS-only", async () => {
+    const memoryManager = await createManager();
+    writeExistingMeta(memoryManager, "mock-embed");
+
+    await expect(memoryManager.sync({ force: true })).rejects.toThrow(
+      "Refusing to run sync in fts-only fallback mode to protect existing vector index (current model: mock-embed).",
+    );
   });
 });

--- a/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
@@ -138,5 +138,6 @@ describe("memory manager FTS-only reindex", () => {
     await expect(memoryManager.sync({ force: true })).rejects.toThrow(
       "Refusing to run sync in fts-only fallback mode to protect existing vector index (current model: mock-embed).",
     );
+    expect(memoryManager.status().provider).toBe("auto");
   });
 });

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -312,6 +312,11 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }
     try {
       await this.providerInitPromise;
+    } catch (err) {
+      // Clear the cached rejected promise so subsequent calls can retry
+      // initialization instead of being permanently stuck with a stale failure.
+      this.providerInitPromise = null;
+      throw err;
     } finally {
       if (this.providerInitialized) {
         this.providerInitPromise = null;

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -324,6 +324,13 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }
   }
 
+  protected resetProviderInitializationForRetry(): void {
+    this.providerInitialized = false;
+    this.providerInitPromise = null;
+    this.providerUnavailableReason = undefined;
+    this.providerLifecycle = createPendingMemoryProviderLifecycle(this.requestedProvider);
+  }
+
   protected markLocalEmbeddingProviderDegraded(err: unknown): void {
     if (this.provider?.id !== "local") {
       return;


### PR DESCRIPTION
## Summary

Prevents memory sync from silently downgrading an existing semantic vector index to FTS-only when the configured embedding provider is temporarily unavailable.

This keeps fresh/default FTS-only indexes working, but refuses destructive fallback when existing metadata proves the index was semantic.

## Changes

- Clear stale provider-null initialization state before aborting so a later sync can retry provider discovery after the embedding provider recovers.
- Guard both normal sync and safe reindex paths, including embedding-error fallback paths, before rebuilding in FTS-only mode.
- Add regression coverage for the semantic-index outage guard and update direct sync-op test harnesses for the new retry hook.
- Add changelog credit for @yaaboo-gif.

## Real behavior proof

Behavior addressed: Existing semantic memory indexes should not be rewritten as FTS-only indexes just because the configured embedding provider is temporarily unavailable.

Real environment tested: OpenClaw 2026.5.20 on macOS arm64 with a local MLX embedding server using `jina-embeddings-v5-text-small` on `127.0.0.1:8123`, plus local OpenClaw source checkout on macOS for the maintainer refresh at branch head b5f0441e6b.

Exact steps or command run after this patch:

Contributor live proof:

1. Applied the same provider-retry and semantic-index guard as a production hot-fix to the built memory-core bundle.
2. Restarted the OpenClaw Gateway.
3. Ran `openclaw memory status --deep` against a real memory store.
4. Intentionally stopped the MLX embedding server.
5. Triggered memory sync/search activity.
6. Restarted the MLX embedding server without restarting the Gateway.
7. Ran `memory_search("宙狗 方案")`.

Maintainer refresh proof:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts extensions/memory-core/src/memory/manager-sync-ops.archive-delta-bypass.test.ts extensions/memory-core/src/memory/manager-sync-yield.test.ts
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts extensions/memory-core/src/memory/manager-sync-ops.archive-delta-bypass.test.ts extensions/memory-core/src/memory/manager-sync-yield.test.ts"
```

Evidence after fix:

Contributor live runtime output from the affected setup:

```text
$ openclaw memory status --deep
main: 11,686 chunks, semantic vectors: ready, vector dims: 1024
codex: 11,673 chunks, semantic vectors: ready

$ # MLX embedding server intentionally stopped, then memory sync/search triggered
Memory sync aborted: embedding provider "openai" is configured but unavailable.
Refusing to run sync in fts-only fallback mode to protect existing vector index (current model: jina-embeddings-v5-text-small).

$ # MLX embedding server restarted; no Gateway restart
$ memory_search("宙狗 方案")
returned 6 results with vectorScore > 0.50
```

Maintainer refresh output: 4 memory-core test files passed, 11 tests passed. Autoreview completed clean with no accepted/actionable findings and reported the patch correct.

Observed result after fix: The real semantic vector store was preserved during an embedding-provider outage, sync failed loudly instead of rewriting the semantic index as FTS-only, provider initialization retried after the MLX server returned, and semantic search recovered without a Gateway restart. The refreshed branch also proves fresh and already-FTS-only indexes still sync in FTS-only mode.

What was not tested: A second live MLX/Jina outage run after the maintainer refresh commits; the refreshed code path is covered by regression tests and autoreview, and the contributor live proof covers the affected production scenario.
