### PR TITLE
fix(agents): let reasoning-only retry fire in group chats

### DIFF
--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -502,7 +502,7 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     expectWarnMessageWith("reasoning-only assistant turn detected");
   });
 
-  it("returns NO_REPLY without retrying reasoning-only assistant turns when silence is allowed", async () => {
+  it("retries reasoning-only assistant turns even when silence is allowed (group chat)", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
@@ -522,8 +522,20 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
         } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
       }),
     );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Visible answer after retry."],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "end_turn",
+          provider: "openai-codex",
+          model: "gpt-5.5",
+          content: [{ type: "text", text: "Visible answer after retry." }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
 
-    const result = await runEmbeddedPiAgent({
+    await runEmbeddedPiAgent({
       ...overflowBaseRunParams,
       allowEmptyAssistantReplyAsSilent: true,
       provider: "openai-codex",
@@ -531,14 +543,12 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
       runId: "run-reasoning-only-silent",
     });
 
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
-    const onlyCall = runAttemptCall(0);
-    expect(onlyCall.prompt).not.toContain(REASONING_ONLY_RETRY_INSTRUCTION);
-    expect(onlyCall.prompt).not.toContain(EMPTY_RESPONSE_RETRY_INSTRUCTION);
-    expectNoWarnMessageWith("reasoning-only assistant turn detected");
-    expect(result.payloads).toEqual([{ text: "NO_REPLY" }]);
-    expect(result.meta.terminalReplyKind).toBe("silent-empty");
-    expect(result.meta.livenessState).toBe("working");
+    // Reasoning-only turns should trigger retry even in group chats
+    // where allowEmptyAssistantReplyAsSilent is true.
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    const secondCall = runAttemptCall(1);
+    expect(secondCall.prompt).toContain(REASONING_ONLY_RETRY_INSTRUCTION);
+    expectWarnMessageWith("reasoning-only assistant turn detected");
   });
 
   it("does not retry or warn on reasoning-only turns when a messaging tool already delivered", async () => {
@@ -2229,7 +2239,7 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     ).toBe(false);
   });
 
-  it("treats reasoning-only assistant turns as silent only when the caller allows it", () => {
+  it("does not treat reasoning-only assistant turns as silent — they should be retried", () => {
     const attempt = makeAttemptResult({
       assistantTexts: [],
       lastAssistant: {
@@ -2247,6 +2257,9 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
       } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
     });
 
+    // Reasoning-only turns are model errors that should trigger the
+    // reasoning-only retry mechanism, not be silently absorbed — even
+    // in group chats where allowEmptyAssistantReplyAsSilent is true.
     expect(
       shouldTreatEmptyAssistantReplyAsSilent({
         allowEmptyAssistantReplyAsSilent: true,
@@ -2255,7 +2268,7 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
         timedOut: false,
         attempt,
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       shouldTreatEmptyAssistantReplyAsSilent({
         allowEmptyAssistantReplyAsSilent: false,

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -476,7 +476,10 @@ function isNonVisibleAssistantTurnEligibleForSilentReply(params: {
   ) {
     return false;
   }
-  return isReasoningOnlyAssistantTurn(assistant);
+  // Reasoning-only turns (thinking blocks but no text) are model errors that
+  // should be retried via resolveReasoningOnlyRetryInstruction, not silently
+  // absorbed.  Only truly empty responses are eligible for silent reply.
+  return false;
 }
 
 function shouldSkipPlanningOnlyRetry(params: {


### PR DESCRIPTION
## Summary

Fixes #85684 — reasoning-only retry mechanism was short-circuited in group chats by the `silentReplyPolicy` default.

## Problem

In group chats, `DEFAULT_SILENT_REPLY_POLICY.group = "allow"` sets `allowEmptyAssistantReplyAsSilent = true`. When a model returned a reasoning-only response (thinking blocks but no text blocks), `isNonVisibleAssistantTurnEligibleForSilentReply` returned `true`, causing `shouldTreatEmptyAssistantReplyAsSilent` to return `true`. This short-circuited all three retry mechanisms:

```typescript
const nextReasoningOnlyRetryInstruction = emptyAssistantReplyIsSilent
  ? null  // ← always null in group chats for reasoning-only turns
  : resolveReasoningOnlyRetryInstruction({...});
```

The turn was silently absorbed instead of being retried with a visible-answer continuation. In direct chats, the same response correctly triggered the retry.

## Root Cause

`isNonVisibleAssistantTurnEligibleForSilentReply` (in `incomplete-turn.ts`) conflated two semantically different cases:
- **Deliberate silence**: model explicitly chose not to reply (empty content) → should be absorbed in group chats ✅
- **Reasoning-only error**: model produced thinking blocks but no text → should be retried ❌ was being absorbed

## Fix

Changed `isNonVisibleAssistantTurnEligibleForSilentReply` to return `false` for reasoning-only turns instead of `true`. Reasoning-only turns are model errors that should trigger `resolveReasoningOnlyRetryInstruction`, not be silently absorbed. Truly empty responses (no reasoning content) remain eligible for silent reply via the separate `isEmptyResponseAssistantTurn` path.

## Changes

- `src/agents/pi-embedded-runner/run/incomplete-turn.ts`: 1-line fix — replaced `return isReasoningOnlyAssistantTurn(assistant)` with `return false` and added explanatory comment
- `run.incomplete-turn.test.ts`: Updated 2 tests to verify reasoning-only turns trigger retry even when `allowEmptyAssistantReplyAsSilent = true`

## Testing

```
$ npx vitest run src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
 ✓ agents-core (104 tests)
 ✓ agents-pi-embedded (104 tests)
 Test Files  2 passed (2)
 Tests  208 passed (208)
```

### Behavior addressed
Reasoning-only retry mechanism no longer short-circuited by group chat silentReplyPolicy default.

### Real environment tested
Linux x64, Node.js v24.14.1, vitest 4.1.6

### Exact steps or command run after this patch
`NODE_OPTIONS="--max-old-space-size=2048" npx vitest run src/agents/pi-embedded-runner/run.incomplete-turn.test.ts`

### Evidence after fix
208/208 tests pass. New test "retries reasoning-only assistant turns even when silence is allowed (group chat)" verifies 2 attempt calls with REASONING_ONLY_RETRY_INSTRUCTION in the retry prompt. Unit test "does not treat reasoning-only assistant turns as silent" confirms `shouldTreatEmptyAssistantReplyAsSilent` returns `false` for reasoning-only turns regardless of `allowEmptyAssistantReplyAsSilent`.

### Observed result after fix
Reasoning-only turns in group chats now trigger retry continuation instead of silent absorption.

### What was not tested
Live group chat with a reasoning-capable model (no test Telegram/Discord/Slack bot available). The fix is pure logic in `isNonVisibleAssistantTurnEligibleForSilentReply` and covered by the integration-level `runEmbeddedPiAgent` test.