### PR TITLE
fix(doctor): skip empty entries and memoize routes in plugin session repairs

### DIFF
--- a/src/commands/doctor-session-state-providers.test.ts
+++ b/src/commands/doctor-session-state-providers.test.ts
@@ -1,10 +1,30 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   applySessionRouteStateRepair,
   resolveConfiguredDoctorSessionStateRoute,
+  runPluginSessionStateDoctorRepairs,
   scanSessionRouteStateOwners,
   storeMayContainPluginSessionRouteState,
 } from "./doctor-session-state-providers.js";
+
+vi.mock("../plugins/doctor-contract-registry.js", async () => {
+  const actual = await vi.importActual<typeof import("../plugins/doctor-contract-registry.js")>(
+    "../plugins/doctor-contract-registry.js",
+  );
+  return {
+    ...actual,
+    listPluginDoctorSessionRouteStateOwners: vi.fn(() => [
+      {
+        id: "codex",
+        label: "Codex",
+        providerIds: ["codex", "codex-cli", "openai-codex"],
+        runtimeIds: ["codex", "codex-cli"],
+        cliSessionKeys: ["codex-cli"],
+        authProfilePrefixes: ["codex:", "codex-cli:", "openai-codex:"],
+      },
+    ]),
+  };
+});
 
 const codexOwner = {
   id: "codex",
@@ -458,5 +478,81 @@ describe("doctor session state provider routes", () => {
     expect(entry.updatedAt).toBe(123);
     expect(entry.agentHarnessId).toBeUndefined();
     expect(entry.agentRuntimeOverride).toBe("claude-cli");
+  });
+
+  it("skips entries without plugin route state and memoizes routes per agentId", async () => {
+    // Sentinel cfg makes resolveConfiguredDoctorSessionStateRoute cheap and
+    // deterministic. The important assertions are observable through the
+    // resulting scan: entries with no route-state fields contribute no
+    // repairs/manual-review and the run completes immediately.
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-sonnet-4" },
+        },
+      },
+      models: {
+        providers: {
+          anthropic: {},
+        },
+      },
+    } as unknown as Parameters<typeof runPluginSessionStateDoctorRepairs>[0]["cfg"];
+
+    // Build a store with 200 entries belonging to one agent. Two carry route
+    // state that the codex owner cares about; the rest are bare. The old
+    // implementation resolved a route for all 200; the new one only resolves
+    // for the 2 that matter, deduplicated by agentId.
+    const store: Record<string, Record<string, unknown>> = {};
+    for (let i = 0; i < 198; i += 1) {
+      store[`agent:main:bare-${i}`] = {
+        sessionId: `sess-bare-${i}`,
+        updatedAt: i,
+        // No providerOverride/model/agentHarnessId/etc. — must be skipped.
+      };
+    }
+    store["agent:main:codex-1"] = {
+      sessionId: "sess-codex-1",
+      updatedAt: 1,
+      agentHarnessId: "codex-cli",
+    };
+    store["agent:main:codex-2"] = {
+      sessionId: "sess-codex-2",
+      updatedAt: 2,
+      agentHarnessId: "codex-cli",
+    };
+
+    const warnings: string[] = [];
+    const changes: string[] = [];
+    const prompter: Parameters<typeof runPluginSessionStateDoctorRepairs>[0]["prompter"] = {
+      confirmRuntimeRepair: vi.fn(async () => false),
+      note: vi.fn(),
+    };
+
+    const start = Date.now();
+    await runPluginSessionStateDoctorRepairs({
+      cfg,
+      store: store as unknown as Parameters<typeof runPluginSessionStateDoctorRepairs>[0]["store"],
+      absoluteStorePath: "/tmp/nonexistent-store.json",
+      prompter,
+      env: {},
+      warnings,
+      changes,
+    });
+    const elapsedMs = Date.now() - start;
+
+    // Two entries flagged for pinned-runtime repair; warning emitted once.
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/Codex/);
+    expect(warnings[0]).toMatch(/2 sessions?/);
+
+    // User declined the repair so no changes applied.
+    expect(changes).toHaveLength(0);
+    expect(prompter.confirmRuntimeRepair).toHaveBeenCalledOnce();
+
+    // Sanity check: even with 200 entries, this should complete near-
+    // instantly because route resolution is bounded by unique agentIds, not
+    // by store size. A 200-entry x 1.6s-per-call pre-fix run would exceed
+    // 5 minutes; the fixed code should run in well under a second.
+    expect(elapsedMs).toBeLessThan(2000);
   });
 });

--- a/src/commands/doctor-session-state-providers.ts
+++ b/src/commands/doctor-session-state-providers.ts
@@ -77,6 +77,7 @@ export function resolveConfiguredDoctorSessionStateRoute(params: {
     resolveAgentModelFallbackValues(params.cfg.agents?.defaults?.model);
   for (const fallback of fallbacks) {
     const parsed = parseModelRef(fallback, primary.provider, {
+      allowManifestNormalization: false,
       allowPluginNormalization: false,
     });
     if (parsed) {
@@ -167,7 +168,7 @@ function resolvePersistedOverrideModelRef(params: {
   return parseModelRef(
     overrideProvider ? `${overrideProvider}/${overrideModel}` : overrideModel,
     params.defaultProvider,
-    { allowPluginNormalization: false },
+    { allowManifestNormalization: false, allowPluginNormalization: false },
   );
 }
 
@@ -296,6 +297,7 @@ function scanEntryForOwner(params: {
     const runtimeModel = normalizeString(params.entry.model);
     const runtimeRef = runtimeModel
       ? parseModelRef(runtimeModel, normalizeString(params.entry.modelProvider) ?? "", {
+          allowManifestNormalization: false,
           allowPluginNormalization: false,
         })
       : null;

--- a/src/commands/doctor-session-state-providers.ts
+++ b/src/commands/doctor-session-state-providers.ts
@@ -459,14 +459,42 @@ export async function runPluginSessionStateDoctorRepairs(params: {
   if (owners.length === 0) {
     return;
   }
-  const routes = Object.fromEntries(
-    Object.keys(params.store).map((sessionKey) => [
-      sessionKey,
-      resolveConfiguredDoctorSessionStateRoute({ cfg: params.cfg, sessionKey, env: params.env }),
-    ]),
-  );
-  const store = params.store as unknown as Record<string, Record<string, unknown>>;
-  const scan = scanSessionRouteStateOwners({ owners, store, routes });
+  // Only entries that may carry plugin session route state can produce repairs
+  // or manual-review findings (see scanEntryForOwner — every code path reads at
+  // least one of the fields checked by entryMayContainPluginSessionRouteState).
+  // Skipping the rest avoids resolving routes for trivially-empty session rows.
+  //
+  // Within that filtered set, resolveConfiguredDoctorSessionStateRoute is a
+  // pure function of agentId (sessionKey is only used to derive agentId), so we
+  // memoize by agentId to avoid recomputing the same route for every session
+  // belonging to the same agent.
+  const scanStore: Record<string, Record<string, unknown>> = {};
+  const routes: Record<string, DoctorSessionRouteState> = {};
+  const routeByAgentId = new Map<string, DoctorSessionRouteState>();
+  for (const [sessionKey, entry] of Object.entries(params.store)) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    if (!entryMayContainPluginSessionRouteState(entry)) {
+      continue;
+    }
+    scanStore[sessionKey] = entry as unknown as Record<string, unknown>;
+    const agentId = resolveSessionAgentId(params.cfg, sessionKey);
+    let route = routeByAgentId.get(agentId);
+    if (!route) {
+      route = resolveConfiguredDoctorSessionStateRoute({
+        cfg: params.cfg,
+        sessionKey,
+        env: params.env,
+      });
+      routeByAgentId.set(agentId, route);
+    }
+    routes[sessionKey] = route;
+  }
+  if (Object.keys(scanStore).length === 0) {
+    return;
+  }
+  const scan = scanSessionRouteStateOwners({ owners, store: scanStore, routes });
   if (scan.repairs.length > 0) {
     for (const [ownerLabel, repairs] of groupRepairsByOwner(scan.repairs)) {
       const staleCount = countSessionLabel(repairs.length);


### PR DESCRIPTION
## Symptom

`openclaw doctor` could spend minutes in the state-integrity contribution on installs with sizable session stores. Visible output stopped after the plugin registry refresh while CPU and memory stayed high.

## Root cause

`runPluginSessionStateDoctorRepairs` did avoidable work in two hot paths:

- it resolved a configured route for every session-store key, including bare entries that cannot produce plugin route-state repairs or manual-review findings
- it recomputed the same route for every session belonging to the same agent, even though the route is effectively keyed by agent id in this doctor flow
- it parsed runtime model refs with manifest model-id normalization enabled even though the scan only needs provider ids, causing repeated plugin metadata snapshot loading

## Fix

- Filter the scan store to entries that pass `entryMayContainPluginSessionRouteState` before resolving routes.
- Memoize `resolveConfiguredDoctorSessionStateRoute` by agent id for the filtered entries.
- Pass `allowManifestNormalization: false` together with the existing `allowPluginNormalization: false` on the doctor scan model-ref parsing paths.

The scan still receives every entry that can contain the fields used by `scanEntryForOwner`; bare rows that cannot produce findings are skipped before expensive route/model work.

## Real behavior proof

Behavior addressed: `openclaw doctor --yes --non-interactive` spent tens of seconds in plugin session-state repair on real stores because it resolved routes for entries that could not contain plugin route state and repeatedly loaded manifest model normalization data while scanning.

Real environment tested: macOS 26.5 on Apple silicon, Node 25.9, OpenClaw 2026.5.22 patched branch, real `~/.openclaw` state directory with an 18 MB `sessions.json` reduced to 230 entries for the after-fix comparison.

Exact steps or command run after this patch: `pnpm build`; `openclaw sessions cleanup --enforce --fix-missing`; `time openclaw doctor --yes --non-interactive` from `/tmp`; focused regression command `node scripts/run-vitest.mjs src/commands/doctor-session-state-providers.test.ts src/commands/doctor-state-integrity.test.ts`.

Evidence after fix: Live terminal output from the patched checkout:

```text
Doctor complete.

real    0m56.004s
user    0m26.166s
sys     0m15.707s
```

Instrumented local timing on the same store showed the targeted contribution dropping from `38621 ms` to `2438 ms`:

```text
contribution                            before fix   after fix
doctor:state-integrity                    38621 ms     2438 ms
doctor:gateway-daemon                     15376 ms    15350 ms
doctor:structured-health-repairs          12738 ms    13206 ms
doctor:claude-cli                         10363 ms    10098 ms
total doctor wall-clock                   89539 ms    53410 ms
```

Observed result after fix: The doctor run completes on the real state directory, the plugin route-state scan avoids bare session rows, and the focused Vitest suite passes 42 tests covering provider route scans and state-integrity behavior.

What was not tested: Gateway/channel E2E behavior was not rerun because this patch is limited to the doctor session-state repair helper and does not change protocol, channel delivery, runtime dispatch, or plugin SDK surfaces.

## Tests

- `node scripts/run-vitest.mjs src/commands/doctor-session-state-providers.test.ts src/commands/doctor-state-integrity.test.ts` - 42 tests passed locally after rebase on current `origin/main`.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` - clean, no accepted/actionable findings.


<!-- proof-body-refresh: 2026-05-23T15:20:00Z -->
