### PR TITLE
fix(memory-core): avoid double bulleting promoted snippets

### DIFF
--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1417,6 +1417,48 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("does not double-prefix promoted snippets that are already markdown bullets", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await writeDailyMemoryNote(workspaceDir, "2026-04-01", [
+        "alpha",
+        "- Gateway binds loopback and port 18789",
+      ]);
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "gateway host",
+        results: [
+          {
+            path: "memory/2026-04-01.md",
+            startLine: 2,
+            endLine: 2,
+            score: 0.92,
+            snippet: "- Gateway binds loopback and port 18789",
+            source: "memory",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        candidates: ranked,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+
+      expect(applied.applied).toBe(1);
+      const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
+      expect(memoryText).toContain("- Gateway binds loopback and port 18789");
+      expect(memoryText).not.toContain("- - Gateway binds loopback and port 18789");
+    });
+  });
+
   it("does not re-append candidates that were promoted in a prior run", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       await writeDailyMemoryNote(workspaceDir, "2026-04-01", [

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -1584,7 +1584,7 @@ function buildPromotionSection(
     const snippet = candidate.snippet || "(no snippet captured)";
     lines.push(`<!-- ${PROMOTION_MARKER_PREFIX}${candidate.key} -->`);
     lines.push(
-      `- ${snippet} [score=${candidate.score.toFixed(3)} recalls=${candidate.recallCount} avg=${candidate.avgScore.toFixed(3)} source=${source}]`,
+      `- ${snippet.replace(/^- +/, "")} [score=${candidate.score.toFixed(3)} recalls=${candidate.recallCount} avg=${candidate.avgScore.toFixed(3)} source=${source}]`,
     );
   }
 


### PR DESCRIPTION
## Summary
- strip one leading markdown bullet marker from promoted short-term snippets before writing MEMORY.md entries
- add regression coverage for snippets that already start with `- `

## Real behavior proof
- **Behavior or issue addressed**: Short-term memory promotion used to render snippets that already started with `- ` as `- - ...` in `MEMORY.md`. The patch strips one leading markdown bullet marker from the snippet before adding the promotion list marker.
- **Real environment tested**: David's live OpenClaw workspace on macOS, running the locally patched OpenClaw checkout that backs the active install.
- **Exact steps or command run after this patch**: Verified the installed OpenClaw version, verified the active runtime source contains the bullet-strip expression, and searched the live `MEMORY.md` for double-bullet promoted output.
- **Evidence after fix**: Terminal capture from the live workspace:

```text
$ openclaw --version
OpenClaw 2026.5.20 (c81ce46)

$ git show --no-patch --format="local runtime patch: %h %s" HEAD
local runtime patch: c81ce46562 fix(memory-core): preserve promoted bullet formatting

$ rg -n "snippet\.replace\(/\^- \+/" extensions/memory-core/src/short-term-promotion.ts
1587:      `- ${snippet.replace(/^- +/, "")} [score=${candidate.score.toFixed(3)} recalls=${candidate.recallCount} avg=${candidate.avgScore.toFixed(3)} source=${source}]`,

$ rg -n "^- - " /Users/davidbennett/.openclaw/workspace/MEMORY.md || true
(no output; promoted MEMORY.md entries are no longer rendered with a double bullet prefix)
```

Observed result: The live install reports the patched commit, the runtime source contains `snippet.replace(/^- +/, "")`, and the current live `MEMORY.md` has no `- - ` promoted entries.
Not tested: I did not complete an end-to-end live promotion apply, because the real promotion command currently stops before ranking on an unrelated oversized memory file:

```text
$ openclaw memory promote --include-promoted --limit 10 --json
Memory promote ranking failed: file exceeds limit of 16777216 bytes (got 16813180)
```

## Test
- `pnpm vitest run extensions/memory-core/src/short-term-promotion.test.ts`
- local result on PR commit `d7bf13311b`: 1 file passed, 55 tests passed
