### PR TITLE
fix(doctor): canonicalize git checkout detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Doctor/update: recognize junction-backed source checkouts as git installs by comparing canonical paths before showing package-manager update guidance. Fixes #82215. Thanks @igormf.
 - CLI/skills: show an all-ready note with next-step commands when skill setup has no missing dependencies to install. (#85032) Thanks @aniruddhaadak80.
 - Microsoft Foundry: route DeepSeek V4 Pro and Flash models through the Foundry Responses API while keeping older DeepSeek models on their existing path. (#85549) Thanks @roslinmahmud.
 - Status/usage: show configured cost estimates for AWS SDK models in full usage output while keeping token-only usage replies cost-free. (#85619) Thanks @ItsOtherMauridian.

--- a/src/commands/doctor-update.test.ts
+++ b/src/commands/doctor-update.test.ts
@@ -1,0 +1,111 @@
+import fs from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { maybeOfferUpdateBeforeDoctor } from "./doctor-update.js";
+
+const originalStdinIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+
+const mocks = vi.hoisted(() => ({
+  note: vi.fn(),
+  runCommandWithTimeout: vi.fn(),
+  runGatewayUpdate: vi.fn(),
+}));
+
+vi.mock("../process/exec.js", () => ({
+  runCommandWithTimeout: mocks.runCommandWithTimeout,
+}));
+
+vi.mock("../infra/update-runner.js", () => ({
+  runGatewayUpdate: mocks.runGatewayUpdate,
+}));
+
+vi.mock("../terminal/note.js", () => ({
+  note: mocks.note,
+}));
+
+async function runOffer(params?: {
+  root?: string;
+  confirm?: (p: { message: string; initialValue: boolean }) => Promise<boolean>;
+}): Promise<Awaited<ReturnType<typeof maybeOfferUpdateBeforeDoctor>>> {
+  const confirm = params?.confirm ?? vi.fn().mockResolvedValue(false);
+  return await maybeOfferUpdateBeforeDoctor({
+    runtime: {} as never,
+    options: {},
+    root: params?.root ?? "/repo/link",
+    confirm,
+    outro: vi.fn(),
+  });
+}
+
+beforeEach(async () => {
+  mocks.note.mockReset();
+  mocks.runCommandWithTimeout.mockReset();
+  mocks.runGatewayUpdate.mockReset();
+  Object.defineProperty(process.stdin, "isTTY", {
+    configurable: true,
+    value: true,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (originalStdinIsTtyDescriptor) {
+    Object.defineProperty(process.stdin, "isTTY", originalStdinIsTtyDescriptor);
+  } else {
+    delete (process.stdin as Partial<typeof process.stdin>).isTTY;
+  }
+});
+
+describe("maybeOfferUpdateBeforeDoctor", () => {
+  it("treats a linked package root as a git checkout when realpaths match", async () => {
+    const confirm = vi.fn().mockResolvedValue(false);
+    vi.spyOn(fs, "realpath").mockImplementation(async (candidate) => {
+      const value = String(candidate);
+      if (value === "/repo/link" || value === "/repo/real") {
+        return "/repo/real";
+      }
+      return value;
+    });
+    mocks.runCommandWithTimeout.mockResolvedValue({
+      stdout: "/repo/real\n",
+      stderr: "",
+      code: 0,
+      killed: false,
+      signal: null,
+      termination: "exit",
+      noOutputTimedOut: false,
+    });
+
+    await expect(runOffer({ root: "/repo/link", confirm })).resolves.toEqual({ updated: false });
+
+    expect(confirm).toHaveBeenCalledWith({
+      message: "Update OpenClaw from git before running doctor?",
+      initialValue: true,
+    });
+    expect(mocks.note).not.toHaveBeenCalledWith(
+      expect.stringContaining("This install is not a git checkout."),
+      "Update",
+    );
+  });
+
+  it("keeps package-manager guidance when git reports a different checkout", async () => {
+    const confirm = vi.fn();
+    vi.spyOn(fs, "realpath").mockImplementation(async (candidate) => String(candidate));
+    mocks.runCommandWithTimeout.mockResolvedValue({
+      stdout: "/repo/other\n",
+      stderr: "",
+      code: 0,
+      killed: false,
+      signal: null,
+      termination: "exit",
+      noOutputTimedOut: false,
+    });
+
+    await expect(runOffer({ root: "/repo/link", confirm })).resolves.toEqual({ updated: false });
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(mocks.note).toHaveBeenCalledWith(
+      expect.stringContaining("This install is not a git checkout."),
+      "Update",
+    );
+  });
+});

--- a/src/commands/doctor-update.ts
+++ b/src/commands/doctor-update.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { formatCliCommand } from "../cli/command-format.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { runGatewayUpdate } from "../infra/update-runner.js";
@@ -6,6 +8,10 @@ import type { RuntimeEnv } from "../runtime.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { note } from "../terminal/note.js";
 import type { DoctorOptions } from "./doctor-prompter.js";
+
+async function resolveComparablePath(target: string): Promise<string> {
+  return await fs.realpath(target).catch(() => path.resolve(target));
+}
 
 async function detectOpenClawGitCheckout(root: string): Promise<"git" | "not-git" | "unknown"> {
   const res = await runCommandWithTimeout(["git", "-C", root, "rev-parse", "--show-toplevel"], {
@@ -22,7 +28,10 @@ async function detectOpenClawGitCheckout(root: string): Promise<"git" | "not-git
     }
     return "unknown";
   }
-  return res.stdout.trim() === root ? "git" : "not-git";
+  const gitRoot = res.stdout.trim();
+  return (await resolveComparablePath(gitRoot)) === (await resolveComparablePath(root))
+    ? "git"
+    : "not-git";
 }
 
 export async function maybeOfferUpdateBeforeDoctor(params: {


### PR DESCRIPTION
## Summary

Fixes #82215 by canonicalizing the doctor pre-update git checkout comparison. `openclaw doctor` now compares the `git rev-parse --show-toplevel` result and the resolved OpenClaw package root by filesystem realpath, so junction/symlink-backed source installs are treated as git checkouts instead of package installs.

This keeps the existing package-manager guidance when git reports a genuinely different root or when git explicitly says the root is not a repository.

## Verification

- `corepack pnpm install`
- `node_modules/.bin/oxfmt --check --threads=1 CHANGELOG.md src/commands/doctor-update.ts src/commands/doctor-update.test.ts`
- `node_modules/.bin/oxlint src/commands/doctor-update.ts src/commands/doctor-update.test.ts`
- `git diff --check`
- Testbox-through-Crabbox, provider `blacksmith-testbox`, id `tbx_01ksak2cz5znsggspmnjce91p3`, Actions run https://github.com/openclaw/openclaw/actions/runs/26334983419:
  `CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 corepack pnpm test src/commands/doctor-update.test.ts`
  - Result: 1 file / 2 tests passed.
- Autoreview: `/mnt/c/src/claws-hapi/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
  - Result: clean, no accepted/actionable findings.

## Real behavior proof

Behavior addressed: `openclaw doctor` no longer shows package-manager update guidance for a source checkout reached through a junction/symlink when that linked package root and git's top-level path resolve to the same filesystem location.

Real environment tested: Blacksmith Testbox through Crabbox (`provider=blacksmith-testbox`, id `tbx_01ksak2cz5znsggspmnjce91p3`, GitHub Actions run https://github.com/openclaw/openclaw/actions/runs/26334983419).

Exact steps or command run after this patch: `CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 corepack pnpm test src/commands/doctor-update.test.ts`

Evidence after fix: The regression test stubs `git -C <linked-root> rev-parse --show-toplevel` to return the real checkout path and stubs `fs.realpath` so both the linked root and real root resolve to the same canonical path; doctor then offers the git update prompt instead of the not-git/package-manager note. A companion test keeps the not-git note when the canonical paths differ.

Observed result after fix: Testbox reported `src/commands/doctor-update.test.ts (2 tests)` passed.

What was not tested: A full interactive native Windows junction install was not run in this PR; the covered behavior is the internal doctor decision point that receives the linked package root and git top-level path.
Additional linked-checkout proof after maintainer review:

- Linked checkout path: `/root/src/openclaw-82215-link` -> `/root/src/openclaw-82215`.
- Command run from the linked path using a real pseudo-terminal: `yes n | timeout 75s script -q -e -c "stty cols 120 rows 40; env TERM=dumb NO_COLOR=1 FORCE_COLOR=0 CI=0 OPENCLAW_HOME=<temp> OPENCLAW_STATE_DIR=<temp>/state NODE_OPTIONS=--no-warnings node --preserve-symlinks --preserve-symlinks-main --import tsx ./src/entry.ts doctor" /tmp/openclaw-85735-symlink-doctor-2.log`.
- Environment facts: `pwd` was `/root/src/openclaw-82215-link`; `pwd -P` was `/root/src/openclaw-82215`; `git -C /root/src/openclaw-82215-link rev-parse --show-toplevel` returned `/root/src/openclaw-82215`.
- Evidence after fix: doctor displayed `Update OpenClaw from git before running doctor?` and did not print `This install is not a git checkout.`
- Observed result after fix: the linked checkout was recognized as a git checkout by the real doctor command path; I answered `No` to avoid running the update flow.