### PR TITLE
fix(tools): filter delivery-mirror and gateway-injected from sessions_history

### DIFF
--- a/src/agents/tools/sessions-history-tool.test.ts
+++ b/src/agents/tools/sessions-history-tool.test.ts
@@ -69,6 +69,36 @@ describe("sessions_history redaction", () => {
     expect((result.details as { contentRedacted?: unknown }).contentRedacted).toBe(true);
   });
 
+  it("filters delivery-mirror and gateway-injected messages from results", async () => {
+    useLoggingConfig("redaction-off.json", { redactSensitive: "off" });
+    const tool = createSessionsHistoryTool({
+      config: {},
+      callGateway: async <T = Record<string, unknown>>(request: CallGatewayRequest): Promise<T> => {
+        if (request.method === "chat.history") {
+          return {
+            messages: [
+              { role: "user", content: "hello" },
+              { role: "assistant", provider: "anthropic", model: "claude-sonnet-4-6", content: "real reply" },
+              { role: "assistant", provider: "openclaw", model: "delivery-mirror", content: "real reply" },
+              { role: "assistant", provider: "openclaw", model: "gateway-injected", content: "system note" },
+              { role: "user", content: "next message" },
+            ],
+          } as T;
+        }
+        return {} as T;
+      },
+    });
+
+    const result = await tool.execute("call-1", { sessionKey: "main", includeTools: true });
+    const messages = (result.details as { messages?: Array<Record<string, unknown>> }).messages ?? [];
+
+    expect(messages).toHaveLength(3);
+    expect(messages.map((m) => m.role)).toEqual(["user", "assistant", "user"]);
+    const assistantMsg = messages.find((m) => m.role === "assistant");
+    expect(assistantMsg).toBeDefined();
+    expect((assistantMsg as Record<string, unknown>).provider).toBe("anthropic");
+  });
+
   it("applies custom redaction patterns to recalled session text", async () => {
     useLoggingConfig("custom-patterns.json", {
       redactSensitive: "off",

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -257,7 +257,14 @@ export function createSessionsHistoryTool(opts?: {
         params: { sessionKey: resolvedKey, limit },
       });
       const rawMessages = Array.isArray(result?.messages) ? result.messages : [];
-      const selectedMessages = includeTools ? rawMessages : stripToolMessages(rawMessages);
+      const withoutDeliveryMirrors = rawMessages.filter((msg) => {
+        if (!msg || typeof msg !== "object" || (msg as { role?: unknown }).role !== "assistant") {
+          return true;
+        }
+        const { provider, model } = msg as { provider?: unknown; model?: unknown };
+        return !(provider === "openclaw" && (model === "delivery-mirror" || model === "gateway-injected"));
+      });
+      const selectedMessages = includeTools ? withoutDeliveryMirrors : stripToolMessages(withoutDeliveryMirrors);
       const sanitizedMessages = selectedMessages.map((message) => sanitizeHistoryMessage(message));
       const contentTruncated = sanitizedMessages.some((entry) => entry.truncated);
       const contentRedacted = sanitizedMessages.some((entry) => entry.redacted);


### PR DESCRIPTION
## Summary

- `sessions_history` tool returned raw messages without filtering openclaw-internal assistant records (`delivery-mirror`, `gateway-injected`), causing duplicate messages in the dashboard.
- The filter `isTranscriptOnlyOpenclawAssistant` already exists for replay paths (`src/agents/pi-embedded-runner/replay-history.ts`) but was not applied to the history tool output.
- Added a filter step in `sessions-history-tool.ts` between raw message fetch and sanitization that removes messages where `provider === "openclaw"` and `model` is `"delivery-mirror"` or `"gateway-injected"`.

### What did NOT change

- No changes to the replay filter in `replay-history.ts`.
- No changes to message storage, sanitization, or redaction logic.
- No changes to how `delivery-mirror` or `gateway-injected` messages are created.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Scope

- [x] Agent tools (sessions_history)

## Root Cause

`createSessionsHistoryTool` in `src/agents/tools/sessions-history-tool.ts` fetched raw messages via `chat.history` gateway call, then sanitized them (stripping details/usage/cost), but returned them without filtering delivery-mirror and gateway-injected assistant entries.

## Real behavior proof

**Behavior addressed:** sessions_history tool now filters delivery-mirror and gateway-injected assistant messages from results, eliminating duplicates in the dashboard.

**Real environment tested:** Node 22.x on Linux, production source via `node --import tsx`.

**Exact steps or command run after this patch:**

```bash
node --import tsx --no-warnings -e "
import { createSessionsHistoryTool } from './src/agents/tools/sessions-history-tool.js';
const tool = createSessionsHistoryTool({
  config: {},
  callGateway: async (request) => {
    if (request.method === 'chat.history') {
      return { messages: [
        { role: 'user', content: 'hello' },
        { role: 'assistant', provider: 'anthropic', model: 'claude-sonnet-4-6', content: 'real reply' },
        { role: 'assistant', provider: 'openclaw', model: 'delivery-mirror', content: 'real reply' },
        { role: 'assistant', provider: 'openclaw', model: 'gateway-injected', content: 'system note' },
        { role: 'user', content: 'next message' },
      ]};
    }
    return {};
  },
});
const result = await tool.execute('call-1', { sessionKey: 'main', includeTools: true });
const messages = result.details.messages;
console.log('Message count:', messages.length);
console.log('Has delivery-mirror:', JSON.stringify(messages).includes('delivery-mirror'));
console.log('Has gateway-injected:', JSON.stringify(messages).includes('gateway-injected'));
console.log('Assistant providers:', messages.filter(m => m.role === 'assistant').map(m => m.provider));
"
```

**Evidence after fix:** Terminal output from `node --import tsx` running the production `createSessionsHistoryTool` with 5 raw messages (2 delivery-mirror/gateway-injected):

```
Message count: 3
Has delivery-mirror: false
Has gateway-injected: false
Assistant providers: [ 'anthropic' ]
```

**Observed result after fix:** With 5 raw messages (2 user, 1 real assistant, 1 delivery-mirror, 1 gateway-injected), the tool correctly returns 3 messages with only the real anthropic assistant reply. Delivery-mirror and gateway-injected records are filtered before sanitization.

**What was not tested:** Live gateway with real delivery-mirror records. The filtering logic is verified at the tool level with the exact message structure that the dashboard consumes.

## Regression Test Plan

- [x] `node scripts/run-vitest.mjs src/agents/tools/sessions-history-tool.test.ts` — 6/6 pass (includes new `filters delivery-mirror and gateway-injected messages from results` test)
- [ ] Manual: open dashboard session viewer, verify no duplicate messages

## User-visible Changes

Dashboard users will no longer see duplicate assistant messages for every turn.

## Security Impact

No security boundary changes. The fix only filters internal openclaw metadata messages from tool output.

Closes #85669
