### PR TITLE
fix(discord): add configurable REST API timeout via channels.discord.apiTimeoutMs

### DIFF
--- a/extensions/discord/src/client.ts
+++ b/extensions/discord/src/client.ts
@@ -81,9 +81,14 @@ function resolveRest(
     return rest;
   }
   const resolvedProxyFetch = proxyFetch ?? resolveDiscordProxyFetchForAccount(account, cfg);
+  const apiTimeoutMs = account.config.apiTimeoutMs;
   return createDiscordRequestClient(
     token,
-    resolvedProxyFetch ? { fetch: resolvedProxyFetch } : undefined,
+    resolvedProxyFetch
+      ? { fetch: resolvedProxyFetch, ...(apiTimeoutMs != null ? { timeout: apiTimeoutMs } : {}) }
+      : apiTimeoutMs != null
+        ? { timeout: apiTimeoutMs }
+        : undefined,
   );
 }
 

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -328,6 +328,8 @@ export type DiscordAccountConfig = {
   gatewayReadyTimeoutMs?: number;
   /** Runtime reconnect wait for the gateway READY event before force-stopping the lifecycle. Default: 30000. */
   gatewayRuntimeReadyTimeoutMs?: number;
+  /** Timeout for Discord REST API calls in milliseconds. Default: 15000. Max: 120000. */
+  apiTimeoutMs?: number;
   /** Allow bot-authored messages to trigger replies (default: false). Set "mentions" to gate on mentions. */
   allowBots?: boolean | "mentions";
   /**

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -638,6 +638,7 @@ export const DiscordAccountSchema = z
     gatewayInfoTimeoutMs: z.number().int().positive().max(120_000).optional(),
     gatewayReadyTimeoutMs: z.number().int().positive().max(120_000).optional(),
     gatewayRuntimeReadyTimeoutMs: z.number().int().positive().max(120_000).optional(),
+    apiTimeoutMs: z.number().int().positive().max(120_000).optional(),
     allowBots: z.union([z.boolean(), z.literal("mentions")]).optional(),
     botLoopProtection: BotLoopProtectionSchema.optional(),
     dangerouslyAllowNameMatching: z.boolean().optional(),


### PR DESCRIPTION
## Summary

Adds `channels.discord.apiTimeoutMs` to the Discord channel config schema (max 120000ms). Threads it through to `RequestClient` where the REST timeout was previously hardcoded at 15s.

## Root Cause

Large guild operations (ban lists, channel enumeration) and rate-limited endpoints can exceed the 15s default, causing premature `AbortError` failures. The timeout was hardcoded in `extensions/discord/src/internal/rest.ts` with no config override.

## Changes

- `src/config/types.discord.ts`: add `apiTimeoutMs` type (max 120000ms)
- `src/config/zod-schema.providers-core.ts`: add `apiTimeoutMs` to `DiscordAccountSchema`
- `extensions/discord/src/client.ts`: thread config through `resolveRest()` → `createDiscordRequestClient()`

## Config

```json
{
  "channels": {
    "discord": {
      "apiTimeoutMs": 20000
    }
  }
}
```

Default remains 15000ms for full backward compatibility.

## Testing

- [ ] Config validation: verify `apiTimeoutMs` values from 1-120000 are accepted
- [ ] Config validation: verify out-of-range values are rejected
- [ ] Functional: increase timeout, verify large guild operations no longer hit AbortError
- [ ] Backward compatibility: verify default 15s timeout when `apiTimeoutMs` is not set