### PR TITLE
feat(doctor): warn early when session store size will slow doctor

### DIFF
--- a/src/commands/doctor-session-store-size.test.ts
+++ b/src/commands/doctor-session-store-size.test.ts
@@ -1,0 +1,143 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import {
+  resolveSessionTranscriptsDirForAgent,
+  resolveStorePath,
+} from "../config/sessions/paths.js";
+import { evaluateSessionStoreSize } from "./doctor-session-store-size.js";
+
+type EnvSnapshot = {
+  HOME?: string;
+  OPENCLAW_HOME?: string;
+  OPENCLAW_STATE_DIR?: string;
+};
+
+function captureEnv(): EnvSnapshot {
+  return {
+    HOME: process.env.HOME,
+    OPENCLAW_HOME: process.env.OPENCLAW_HOME,
+    OPENCLAW_STATE_DIR: process.env.OPENCLAW_STATE_DIR,
+  };
+}
+
+function restoreEnv(snapshot: EnvSnapshot) {
+  for (const key of Object.keys(snapshot) as Array<keyof EnvSnapshot>) {
+    const value = snapshot[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+function seedStore(
+  cfg: OpenClawConfig,
+  entries: Record<string, { sessionId: string; updatedAt: number }>,
+) {
+  const agentId = "main";
+  const storePath = resolveStorePath(cfg.session?.store, { agentId, env: process.env });
+  fs.mkdirSync(path.dirname(storePath), { recursive: true });
+  fs.writeFileSync(storePath, JSON.stringify(entries, null, 2));
+}
+
+function seedTranscriptFiles(count: number) {
+  const sessionsDir = resolveSessionTranscriptsDirForAgent(
+    "main",
+    process.env,
+    () => process.env.HOME ?? "",
+  );
+  fs.mkdirSync(sessionsDir, { recursive: true });
+  for (let i = 0; i < count; i += 1) {
+    fs.writeFileSync(
+      path.join(sessionsDir, `00000000-0000-0000-0000-${String(i).padStart(12, "0")}.jsonl`),
+      "",
+    );
+  }
+}
+
+function buildEntries(count: number) {
+  const out: Record<string, { sessionId: string; updatedAt: number }> = {};
+  for (let i = 0; i < count; i += 1) {
+    out[`agent:main:${String(i).padStart(8, "0")}`] = {
+      sessionId: `sess-${i}`,
+      updatedAt: i,
+    };
+  }
+  return out;
+}
+
+describe("doctor session-store-size health check", () => {
+  let envSnapshot: EnvSnapshot;
+  let tempHome = "";
+
+  beforeEach(() => {
+    envSnapshot = captureEnv();
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-store-size-"));
+    process.env.HOME = tempHome;
+    process.env.OPENCLAW_HOME = tempHome;
+    process.env.OPENCLAW_STATE_DIR = path.join(tempHome, ".openclaw");
+    fs.mkdirSync(process.env.OPENCLAW_STATE_DIR, { recursive: true, mode: 0o700 });
+  });
+
+  afterEach(() => {
+    restoreEnv(envSnapshot);
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it("emits no warning when the store and sessions dir are within thresholds", () => {
+    const cfg: OpenClawConfig = {};
+    seedStore(cfg, buildEntries(50));
+    seedTranscriptFiles(50);
+    const { warnings } = evaluateSessionStoreSize({ cfg, env: process.env });
+    expect(warnings).toEqual([]);
+  });
+
+  it("emits no warning when there is no store file yet", () => {
+    const cfg: OpenClawConfig = {};
+    const { warnings } = evaluateSessionStoreSize({ cfg, env: process.env });
+    expect(warnings).toEqual([]);
+  });
+
+  it("warns when store entry count reaches the configured maxEntries cap", () => {
+    const cfg: OpenClawConfig = {
+      session: { maintenance: { mode: "enforce", maxEntries: 100 } },
+    };
+    seedStore(cfg, buildEntries(100));
+    seedTranscriptFiles(10);
+    const { warnings } = evaluateSessionStoreSize({ cfg, env: process.env });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('Agent "main" session store has 100 entries');
+    expect(warnings[0]).toContain("maxEntries=100");
+    expect(warnings[0]).toContain("openclaw sessions cleanup --enforce --fix-missing");
+    // mode is already enforce, so do not nag about switching it on.
+    expect(warnings[0]).not.toContain("session.maintenance.mode enforce");
+  });
+
+  it("warns when the sessions directory has accumulated many transcripts even with a small store", () => {
+    const cfg: OpenClawConfig = {
+      session: { maintenance: { mode: "enforce", maxEntries: 5_000 } },
+    };
+    seedStore(cfg, buildEntries(10));
+    seedTranscriptFiles(2_000);
+    const { warnings } = evaluateSessionStoreSize({ cfg, env: process.env });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("2000 transcript files");
+    expect(warnings[0]).toContain("openclaw sessions cleanup --enforce --fix-missing");
+  });
+
+  it("adds a mode hint when maintenance is in warn mode and the store is large", () => {
+    const cfg: OpenClawConfig = {
+      session: { maintenance: { mode: "warn", maxEntries: 100 } },
+    };
+    seedStore(cfg, buildEntries(150));
+    seedTranscriptFiles(5);
+    const { warnings } = evaluateSessionStoreSize({ cfg, env: process.env });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/Maintenance mode is "warn"/);
+    expect(warnings[0]).toContain("openclaw config set session.maintenance.mode enforce");
+  });
+});

--- a/src/commands/doctor-session-store-size.ts
+++ b/src/commands/doctor-session-store-size.ts
@@ -1,0 +1,131 @@
+import fs from "node:fs";
+import os from "node:os";
+import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { formatCliCommand } from "../cli/command-format.js";
+import { isPrimarySessionTranscriptFileName } from "../config/sessions/artifacts.js";
+import {
+  resolveSessionTranscriptsDirForAgent,
+  resolveStorePath,
+} from "../config/sessions/paths.js";
+import { loadSessionStore } from "../config/sessions/store-load.js";
+import { resolveMaintenanceConfigFromInput } from "../config/sessions/store-maintenance.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveRequiredHomeDir } from "../infra/home-dir.js";
+import { note } from "../terminal/note.js";
+import { shortenHomePath } from "../utils.js";
+
+/**
+ * Files in the per-agent sessions directory above which the orphan-transcript
+ * scan in `doctor:state-integrity` becomes noticeably slow on real disks. Picked
+ * to flag installs whose accumulated transcripts will keep the doctor on the
+ * order of a few seconds inside the readdir+filter+realpath loop, even after
+ * the rest of the doctor flow is healthy. Independent of `session.maintenance`
+ * because orphan-transcript files outlive the session-store entries that
+ * reference them.
+ */
+const SESSIONS_DIR_FILE_COUNT_FLOOR = 2_000;
+
+export type SessionStoreSizeEvaluation = {
+  warnings: string[];
+};
+
+/**
+ * Read-only probe that warns when the configured-default agent's session store
+ * has grown to a size that will make `doctor:state-integrity` and adjacent
+ * contributions slow, or when `session.maintenance` is configured loosely
+ * enough that the store will keep growing.
+ *
+ * Pure with respect to user-facing side effects: returns warnings; the
+ * contribution wrapper is responsible for `note(...)` output.
+ */
+export function evaluateSessionStoreSize(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  /** Override only used by tests to point the probe at a fixture state dir. */
+  homedir?: () => string;
+}): SessionStoreSizeEvaluation {
+  const warnings: string[] = [];
+  const env = params.env ?? process.env;
+  const homedir = params.homedir ?? (() => resolveRequiredHomeDir(env, os.homedir));
+  const agentId = resolveDefaultAgentId(params.cfg);
+  const sessionsDir = resolveSessionTranscriptsDirForAgent(agentId, env, homedir);
+  const storePath = resolveStorePath(params.cfg.session?.store, { agentId, env });
+  const maintenance = resolveMaintenanceConfigFromInput(params.cfg.session?.maintenance);
+
+  let storeEntryCount = 0;
+  try {
+    if (fs.existsSync(storePath)) {
+      storeEntryCount = Object.keys(loadSessionStore(storePath)).length;
+    }
+  } catch {
+    // Loader is defensive (returns {} on parse failure); if the read itself
+    // throws (permissions, etc.) other doctor contributions will surface it.
+    // Do not double-warn here.
+    return { warnings };
+  }
+
+  let transcriptFileCount = 0;
+  try {
+    const entries = fs.readdirSync(sessionsDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isFile() && isPrimarySessionTranscriptFileName(entry.name)) {
+        transcriptFileCount += 1;
+      }
+    }
+  } catch {
+    // Sessions dir missing or unreadable; skip the dir-size signal. State-
+    // integrity will surface the underlying problem.
+    transcriptFileCount = 0;
+  }
+
+  const exceedsMaxEntries = storeEntryCount >= maintenance.maxEntries;
+  const exceedsDirFloor = transcriptFileCount >= SESSIONS_DIR_FILE_COUNT_FLOOR;
+  if (!exceedsMaxEntries && !exceedsDirFloor) {
+    return { warnings };
+  }
+
+  const cleanupCmd = formatCliCommand("openclaw sessions cleanup --enforce --fix-missing");
+  const dryRunCmd = formatCliCommand("openclaw sessions cleanup --dry-run --fix-missing");
+  const lines: string[] = [];
+
+  if (exceedsMaxEntries) {
+    lines.push(
+      `- Agent "${agentId}" session store has ${storeEntryCount} entries (cap: session.maintenance.maxEntries=${maintenance.maxEntries}).`,
+    );
+  }
+  if (exceedsDirFloor) {
+    lines.push(`- ${shortenHomePath(sessionsDir)} holds ${transcriptFileCount} transcript files.`);
+  }
+  lines.push(
+    "  Large stores slow down the doctor's session-integrity and orphan-transcript checks.",
+    `  Preview cleanup: ${dryRunCmd}`,
+    `  Apply: ${cleanupCmd}`,
+  );
+
+  if (maintenance.mode !== "enforce") {
+    lines.push(
+      `  Maintenance mode is "${maintenance.mode}", so the store will keep growing on its own.`,
+      `  Switch on automatic pruning: ${formatCliCommand("openclaw config set session.maintenance.mode enforce")}`,
+    );
+  }
+
+  warnings.push(lines.join("\n"));
+  return { warnings };
+}
+
+/**
+ * Doctor contribution: warn early about session-store and sessions-dir growth
+ * that will make later doctor steps slow. Runs before plugin-registry and
+ * state-integrity so the operator sees the cleanup hint before they sit
+ * through the slow scans.
+ */
+export function noteSessionStoreSizeHealth(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): void {
+  const { warnings } = evaluateSessionStoreSize(params);
+  if (warnings.length === 0) {
+    return;
+  }
+  note(warnings.join("\n"), "Session store size");
+}

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -101,6 +101,11 @@ function createDoctorHealthContribution(params: {
   };
 }
 
+async function runSessionStoreSizeHealth(ctx: DoctorHealthFlowContext): Promise<void> {
+  const { noteSessionStoreSizeHealth } = await import("../commands/doctor-session-store-size.js");
+  noteSessionStoreSizeHealth({ cfg: ctx.cfg, env: ctx.env });
+}
+
 async function runGatewayConfigHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   const { formatCliCommand } = await import("../cli/command-format.js");
   const { hasAmbiguousGatewayAuthModeConfig } = await import("../gateway/auth-mode-policy.js");
@@ -741,6 +746,11 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
       label: "Gateway config",
       healthCheckIds: ["core/doctor/gateway-config"],
       run: runGatewayConfigHealth,
+    }),
+    createDoctorHealthContribution({
+      id: "doctor:session-store-size",
+      label: "Session store size",
+      run: runSessionStoreSizeHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:auth-profiles",

--- a/src/flows/doctor-health-conversion-plan.ts
+++ b/src/flows/doctor-health-conversion-plan.ts
@@ -22,6 +22,12 @@ export const doctorHealthConversionRules = [
     rule: "Keep as a pure config finding; doctor presentation should render the finding instead of calling note().",
   },
   {
+    contributionId: "doctor:session-store-size",
+    conversion: "detect-only",
+    target: ["core/doctor/session-store-size"],
+    rule: "Pre-flight size check; emits a warning health note when the session store is near the configured maxEntries or the transcripts directory crosses the floor. No repair, no config mutation.",
+  },
+  {
     contributionId: "doctor:auth-profiles",
     conversion: "split-detect-repair",
     target: [


### PR DESCRIPTION
## Symptom

On installations whose per-agent session store has grown past
`session.maintenance.maxEntries`, or whose sessions directory has accumulated
thousands of transcript files, `openclaw doctor` spends most of its wall-clock
inside `doctor:state-integrity` and adjacent contributions before producing
anything actionable. Today the operator gets no early signal that cleanup
would speed up the rest of the doctor run; the impression is just that doctor
"hangs" for several minutes.

Companion to #85718, which fixes the worst CPU hotspot inside state-integrity
itself. This PR is the early-warning counterpart: surface the size signal up
front so operators can run `openclaw sessions cleanup --enforce --fix-missing`
or tighten their retention before sitting through the slower checks.

## What changes

New read-only contribution `doctor:session-store-size` registered right after
`doctor:gateway-config`, so the warning lands within the first second of doctor
output (well before plugin-registry, state-integrity, or any
`runPluginSessionStateDoctorRepairs` work).

The new helper file `src/commands/doctor-session-store-size.ts` exports a pure
`evaluateSessionStoreSize({ cfg, env, homedir })` that returns warnings, plus a
thin `noteSessionStoreSizeHealth({ cfg, env })` wrapper that emits notes via the
existing terminal `note(...)` helper. The probe checks two independent signals:

- **Store entry count >= maxEntries.** Uses
  `resolveMaintenanceConfigFromInput(cfg.session?.maintenance)` so built-in
  defaults are honored when the operator has not configured the field.
- **Sessions directory primary-transcript file count >= 2,000.** Hard floor,
  independent of `maxEntries`, because orphan transcript files can outlive the
  session-store rows that referenced them and still slow the
  orphan-transcript scan in `doctor:state-integrity`.

When either trips, the warning shows the actual numbers, the configured cap,
the shortened sessions-dir path, and concrete cleanup commands. If
`session.maintenance.mode !== "enforce"` an extra hint nudges toward
`openclaw config set session.maintenance.mode enforce` so the store keeps
itself bounded.

The probe is filesystem-only and bounded: it loads the configured-default
agent's store with the existing `loadSessionStore` helper and counts dirents in
the sessions dir. No new network or plugin-runtime work is introduced.

A matching `doctor-health-conversion-plan` rule is included so the
contribution catalogue test (`classifies every current run contribution`)
stays balanced.

## Real behavior proof

- **Behavior addressed:** `openclaw doctor` on a real install with 230
  session-store entries and a tightened
  `session.maintenance.maxEntries=200` should warn about store size early in
  the run, not silently grind through state-integrity first.
- **Real environment tested:** `openclaw` 2026.5.22, macOS 26.5 (Apple
  silicon), Node 25.9. Local OpenClaw state directory at `~/.openclaw` with a
  real per-agent store at `~/.openclaw/agents/main/sessions/sessions.json`
  holding 230 entries.
- **Steps run after the patch:**
  1. `pnpm build` against this branch (clean tsdown + runtime-postbuild).
  2. `openclaw config set session.maintenance.maxEntries 200` to take a real
     store below the cap and trigger the new contribution.
  3. `openclaw doctor --yes --non-interactive` from `/tmp`.
  4. Restored `openclaw config set session.maintenance.maxEntries 500`
     afterwards.
- **Evidence after fix:**

  ```
  ┌  OpenClaw doctor
  │
  ◇  UI ───────────────────────────────╮
  ... (UI build) ...
  ├──────────────────────╯
  │
  ◇  Session store size ───────────────────────────────────────────────────╮
  │                                                                        │
  │  - Agent "main" session store has 230 entries (cap:                    │
  │    session.maintenance.maxEntries=200).                                │
  │    Large stores slow down the doctor's session-integrity and           │
  │    orphan-transcript checks.                                           │
  │    Preview cleanup: openclaw sessions cleanup --dry-run --fix-missing  │
  │    Apply: openclaw sessions cleanup --enforce --fix-missing            │
  │                                                                        │
  ├────────────────────────────────────────────────────────────────────────╯
  │
  ◇  Plugin registry ────────────────────────────────────────────╮
  ... (doctor continues with the slower steps) ...
  ```

  The contribution surfaces the actionable cleanup hint within the first
  second of doctor output, well before `doctor:state-integrity` runs. The
  warning text comes from the new `noteSessionStoreSizeHealth` helper
  (`src/commands/doctor-session-store-size.ts:78`) and the contribution is
  registered immediately after `doctor:gateway-config` in
  `src/flows/doctor-health-contributions.ts:751`.
- **Observed result after fix:** The early-warning block prints inside the
  first second of doctor output on a store with 230 entries against a
  `maxEntries=200` cap; doctor continues through the remaining checks
  unchanged. With the cap restored to 500 the warning is silent, confirming
  the threshold predicate. Companion PR #85718 cuts the downstream
  `doctor:state-integrity` step from ~38s to ~2s, so an operator who acts on
  the early warning can also expect the rest of the run to finish far faster.
- **What was not tested:** Repair behaviour for the warning is intentionally
  out of scope; this contribution is `detect-only` and points the operator at
  the existing `openclaw sessions cleanup` flow. Plugin-runtime sessions in
  non-default agents are not probed; covered by a sibling cleanup pass.

## Tests

- `node scripts/run-vitest.mjs src/commands/doctor-session-store-size.test.ts`
  — 5 / 5 pass:
  - under threshold, no warning
  - no store file yet, no warning
  - store entry count >= `maxEntries`, emits the count+cap warning and
    suppresses the mode hint when mode is already `enforce`
  - sessions directory >= 2,000 transcripts even with a small store, emits the
    directory-size warning
  - `mode: warn` with a large store, adds the "switch to enforce" hint
- `node scripts/run-vitest.mjs src/flows/doctor-health-contributions.test.ts`
  — 20 / 20 still pass (contribution-ordering assertions).
- `node scripts/run-vitest.mjs src/flows/doctor-health-conversion-plan.test.ts`
  — 3 / 3 pass (catalogue stays balanced after adding the new conversion
  rule).
- `node scripts/run-vitest.mjs src/commands/doctor-state-integrity.test.ts`
  — 30 / 30 still pass.
- `node scripts/run-oxlint.mjs` on touched files — 0 warnings, 0 errors.
- `pnpm format:check` on touched files — clean.
- `pnpm tsgo:core --noEmit` — clean.
- `pnpm build` — clean, doctor verified end-to-end on real store as above.

Scope is narrow (one new helper, one new contribution, one registration site,
one new conversion rule, one test file). No protocol, plugin SDK, channel
runtime, or gateway surface touched.
