### PR TITLE
fix(telegram): deliver deferred long-turn replies

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -8,12 +8,17 @@ import {
   createTestDraftStream,
 } from "./draft-stream.test-helpers.js";
 import { notifyTelegramInboundEventOutboundSuccess } from "./inbound-event-delivery.js";
+import { createTelegramLongTurnDeliveryState } from "./long-turn-delivery.js";
 import {
   buildTelegramConversationContext,
   createTelegramMessageCache,
   resolveTelegramMessageCachePath,
 } from "./message-cache.js";
 import { recordOutboundMessageForPromptContext as recordOutboundMessageForPromptContextActual } from "./outbound-message-context.js";
+import {
+  getTelegramReplyFenceSizeForTests,
+  supersedeTelegramReplyFence,
+} from "./telegram-reply-fence.js";
 
 type DispatchReplyWithBufferedBlockDispatcherArgs = Parameters<
   TelegramBotDeps["dispatchReplyWithBufferedBlockDispatcher"]
@@ -482,6 +487,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
     bot?: Bot;
     replyToMode?: Parameters<typeof dispatchTelegramMessage>[0]["replyToMode"];
     textLimit?: number;
+    runId?: string;
+    longTurnDeliveryState?: Parameters<typeof dispatchTelegramMessage>[0]["longTurnDeliveryState"];
   }) {
     const bot = params.bot ?? createBot();
     await dispatchTelegramMessage({
@@ -495,6 +502,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: params.telegramCfg ?? {},
       telegramDeps: params.telegramDeps ?? telegramDepsForTest,
       opts: { token: "token" },
+      runId: params.runId,
+      longTurnDeliveryState: params.longTurnDeliveryState,
     });
   }
 
@@ -3738,6 +3747,389 @@ describe("dispatchTelegramMessage draft streaming", () => {
         ctxPayload: createDirectSessionPayload(),
       }),
       streamMode: "off",
+    });
+
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("reports deferred dispatch failures with run context instead of generic fallback", async () => {
+    const longTurnDeliveryState = createTelegramLongTurnDeliveryState({
+      runId: "run-long",
+      agentId: "default",
+      accountId: "default",
+      sessionKey: "agent:test:telegram:direct:123",
+      chatId: "123",
+      threadId: 777,
+    });
+    longTurnDeliveryState.markDeferred();
+    dispatchReplyWithBufferedBlockDispatcher.mockRejectedValue(new Error("provider down"));
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+      }),
+      streamMode: "off",
+      runId: "run-long",
+      longTurnDeliveryState,
+    });
+
+    const dispatchParams = mockCallArg(dispatchReplyWithBufferedBlockDispatcher) as {
+      replyOptions?: { runId?: string };
+    };
+    expect(dispatchParams.replyOptions?.runId).toBe("run-long");
+    const reply = expectDeliveredReply(0, {}, 0) as { text?: string };
+    expect(reply.text).toContain("The deferred run did not complete successfully.");
+    expect(reply.text).toContain("Run: run-long");
+    expect(reply.text).toContain("Agent: default");
+    expect(reply.text).toContain("Session: agent:test:telegram:direct:123");
+    expect(reply.text).toContain("Target: telegram:123/777");
+    expect(reply.text).not.toContain("provider down");
+    expect(reply.text).not.toContain("Something went wrong");
+  });
+
+  it("releases deferred reply fences when failure fallback delivery throws", async () => {
+    const longTurnDeliveryState = createTelegramLongTurnDeliveryState({
+      runId: "run-failed-send",
+      agentId: "default",
+      accountId: "default",
+      sessionKey: "agent:test:telegram:direct:123",
+      chatId: "123",
+      threadId: 777,
+    });
+    longTurnDeliveryState.markDeferred();
+    dispatchReplyWithBufferedBlockDispatcher.mockRejectedValue(new Error("provider down"));
+    deliverReplies.mockRejectedValueOnce(new Error("telegram send failed"));
+
+    await expect(
+      dispatchWithContext({
+        context: createContext({
+          ctxPayload: createDirectSessionPayload(),
+        }),
+        streamMode: "off",
+        runId: "run-failed-send",
+        longTurnDeliveryState,
+      }),
+    ).rejects.toThrow("telegram send failed");
+
+    expect(getTelegramReplyFenceSizeForTests()).toBe(0);
+  });
+
+  it("does not deliver deferred failure fallback after explicit supersede during deferral notice", async () => {
+    const longTurnDeliveryState = createTelegramLongTurnDeliveryState({
+      runId: "run-failed-aborted",
+      agentId: "default",
+      accountId: "default",
+      sessionKey: "agent:test:telegram:direct:123",
+      chatId: "123",
+      threadId: 777,
+    });
+    longTurnDeliveryState.markDeferralPending();
+    dispatchReplyWithBufferedBlockDispatcher.mockRejectedValue(new Error("provider down"));
+
+    const run = dispatchWithContext({
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+      }),
+      streamMode: "off",
+      runId: "run-failed-aborted",
+      longTurnDeliveryState,
+    });
+    await vi.waitFor(() => {
+      expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+    });
+
+    expect(supersedeTelegramReplyFence("agent:test:telegram:direct:123")).toBe(true);
+    longTurnDeliveryState.markDeferred();
+    await run;
+
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("waits for the deferral notice before delivering deferred finals", async () => {
+    const longTurnDeliveryState = createTelegramLongTurnDeliveryState({
+      runId: "run-race",
+      agentId: "default",
+      accountId: "default",
+      sessionKey: "agent:test:telegram:direct:123",
+      chatId: "123",
+      threadId: 777,
+    });
+    longTurnDeliveryState.markDeferralPending();
+    let signalFinalReady: (() => void) | undefined;
+    const finalReady = new Promise<void>((resolve) => {
+      signalFinalReady = resolve;
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      signalFinalReady?.();
+      await dispatcherOptions.deliver({ text: "Done after deferral" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+
+    const run = dispatchWithContext({
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+      }),
+      streamMode: "off",
+      runId: "run-race",
+      longTurnDeliveryState,
+    });
+    await finalReady;
+    await Promise.resolve();
+
+    expect(deliverReplies).not.toHaveBeenCalled();
+
+    longTurnDeliveryState.markDeferred();
+    await run;
+
+    expectDeliveredReply(0, { text: "Done after deferral" }, 0);
+  });
+
+  it("waits for the deferral notice before finalizing streamed deferred text", async () => {
+    const longTurnDeliveryState = createTelegramLongTurnDeliveryState({
+      runId: "run-stream-race",
+      agentId: "default",
+      accountId: "default",
+      sessionKey: "agent:test:telegram:direct:123",
+      chatId: "123",
+      threadId: 777,
+    });
+    longTurnDeliveryState.markDeferralPending();
+    let signalFinalReady: (() => void) | undefined;
+    const finalReady = new Promise<void>((resolve) => {
+      signalFinalReady = resolve;
+    });
+    const { answerDraftStream } = setupDraftStreams();
+    const finalText = "Done after deferral with enough text for an answer draft";
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      signalFinalReady?.();
+      await dispatcherOptions.deliver({ text: finalText }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+
+    const run = dispatchWithContext({
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+      }),
+      streamMode: "partial",
+      runId: "run-stream-race",
+      longTurnDeliveryState,
+    });
+    await finalReady;
+    await Promise.resolve();
+
+    expect(answerDraftStream.update).not.toHaveBeenCalled();
+
+    longTurnDeliveryState.markDeferred();
+    await run;
+
+    expect(answerDraftStream.update).toHaveBeenCalledWith(finalText);
+  });
+
+  it("does not deliver a deferred final after explicit supersede while waiting on deferral notice", async () => {
+    const longTurnDeliveryState = createTelegramLongTurnDeliveryState({
+      runId: "run-aborted",
+      agentId: "default",
+      accountId: "default",
+      sessionKey: "agent:test:telegram:direct:123",
+      chatId: "123",
+      threadId: 777,
+    });
+    longTurnDeliveryState.markDeferralPending();
+    let signalFinalReady: (() => void) | undefined;
+    const finalReady = new Promise<void>((resolve) => {
+      signalFinalReady = resolve;
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      signalFinalReady?.();
+      await dispatcherOptions.deliver({ text: "Should not deliver" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+
+    const run = dispatchWithContext({
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+      }),
+      streamMode: "off",
+      runId: "run-aborted",
+      longTurnDeliveryState,
+    });
+    await finalReady;
+
+    expect(supersedeTelegramReplyFence("agent:test:telegram:direct:123")).toBe(true);
+    longTurnDeliveryState.markDeferred();
+    await run;
+
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("keeps deferred finals deliverable after a later normal message supersedes the lane", async () => {
+    const longTurnDeliveryState = createTelegramLongTurnDeliveryState({
+      runId: "run-old",
+      agentId: "default",
+      accountId: "default",
+      sessionKey: "agent:test:telegram:direct:123",
+      chatId: "123",
+      threadId: 777,
+    });
+    longTurnDeliveryState.markDeferralPending();
+    longTurnDeliveryState.markDeferred();
+    let releaseOldFinal: (() => void) | undefined;
+    let signalOldRunning: (() => void) | undefined;
+    const oldFinalGate = new Promise<void>((resolve) => {
+      releaseOldFinal = resolve;
+    });
+    const oldRunning = new Promise<void>((resolve) => {
+      signalOldRunning = resolve;
+    });
+    dispatchReplyWithBufferedBlockDispatcher
+      .mockImplementationOnce(async ({ dispatcherOptions }) => {
+        signalOldRunning?.();
+        await oldFinalGate;
+        await dispatcherOptions.deliver({ text: "Old deferred final" }, { kind: "final" });
+        return { queuedFinal: true };
+      })
+      .mockImplementationOnce(async ({ dispatcherOptions }) => {
+        await dispatcherOptions.deliver({ text: "New normal final" }, { kind: "final" });
+        return { queuedFinal: true };
+      });
+
+    const oldRun = dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          ...createDirectSessionPayload(),
+          RawBody: "old long request",
+        } as TelegramMessageContext["ctxPayload"],
+      }),
+      streamMode: "off",
+      runId: "run-old",
+      longTurnDeliveryState,
+    });
+    await oldRunning;
+
+    const newRun = dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          ...createDirectSessionPayload(),
+          RawBody: "new normal request",
+        } as TelegramMessageContext["ctxPayload"],
+      }),
+      streamMode: "off",
+      runId: "run-new",
+    });
+    await newRun;
+
+    releaseOldFinal?.();
+    await oldRun;
+
+    const deliveredTexts = deliverReplies.mock.calls.flatMap((call) =>
+      ((call[0] as { replies?: Array<{ text?: string }> }).replies ?? []).map(
+        (reply) => reply.text,
+      ),
+    );
+    expect(deliveredTexts).toContain("New normal final");
+    expect(deliveredTexts).toContain("Old deferred final");
+  });
+
+  it("reports deferred turns that finish without a final response", async () => {
+    const longTurnDeliveryState = createTelegramLongTurnDeliveryState({
+      runId: "run-empty",
+      agentId: "default",
+      accountId: "default",
+      sessionKey: "agent:test:telegram:direct:123",
+      chatId: "123",
+      threadId: 777,
+    });
+    longTurnDeliveryState.markDeferred();
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
+      queuedFinal: false,
+      counts: { block: 0, final: 0, tool: 0 },
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+      }),
+      streamMode: "off",
+      runId: "run-empty",
+      longTurnDeliveryState,
+    });
+
+    const reply = expectDeliveredReply(0, {}, 0) as { text?: string };
+    expect(reply.text).toContain("The deferred run finished, but no final response was delivered.");
+    expect(reply.text).toContain("Run: run-empty");
+    expect(reply.text).toContain("Target: telegram:123/777");
+    expect(reply.text).not.toContain("No response generated");
+  });
+
+  it("completes deferred direct-chat silent finals without empty-response diagnostics", async () => {
+    const longTurnDeliveryState = createTelegramLongTurnDeliveryState({
+      runId: "run-silent",
+      agentId: "default",
+      accountId: "default",
+      sessionKey: "agent:test:telegram:direct:123",
+      chatId: "123",
+      threadId: 777,
+    });
+    longTurnDeliveryState.markDeferred();
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      dispatcherOptions.onSkip?.({ text: "NO_REPLY" }, { kind: "final", reason: "silent" });
+      return {
+        queuedFinal: false,
+        counts: { block: 0, final: 0, tool: 0 },
+      };
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+      }),
+      streamMode: "off",
+      runId: "run-silent",
+      longTurnDeliveryState,
+    });
+
+    const reply = expectDeliveredReply(0, {}, 0) as { text?: string };
+    expect(reply.text).toContain("The deferred run completed without sending a visible reply.");
+    expect(reply.text).toContain("Run: run-silent");
+    expect(reply.text).toContain("Target: telegram:123/777");
+    expect(reply.text).not.toContain("no final response was delivered");
+  });
+
+  it("does not report deferred empty-response diagnostics to groups", async () => {
+    const longTurnDeliveryState = createTelegramLongTurnDeliveryState({
+      runId: "run-empty-group",
+      agentId: "default",
+      accountId: "default",
+      sessionKey: "agent:test:telegram:group:-1001234",
+      chatId: "-1001234",
+      threadId: undefined,
+    });
+    longTurnDeliveryState.markDeferred();
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
+      queuedFinal: false,
+      counts: { block: 0, final: 0, tool: 0 },
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        chatId: -1001234,
+        isGroup: true,
+        ctxPayload: {
+          SessionKey: "agent:test:telegram:group:-1001234",
+          ChatType: "group",
+        } as TelegramMessageContext["ctxPayload"],
+        primaryCtx: {
+          message: { chat: { id: -1001234, type: "supergroup" } },
+        } as unknown as TelegramMessageContext["primaryCtx"],
+        msg: {
+          chat: { id: -1001234, type: "supergroup" },
+          message_id: 456,
+        } as unknown as TelegramMessageContext["msg"],
+        threadSpec: { id: undefined, scope: "none" },
+      }),
+      streamMode: "off",
+      runId: "run-empty-group",
+      longTurnDeliveryState,
     });
 
     expect(deliverReplies).not.toHaveBeenCalled();

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -119,6 +119,13 @@ import {
   type LaneDeliveryResult,
   type LaneName,
 } from "./lane-delivery.js";
+import {
+  buildTelegramDeferredRunEmptyResponseText,
+  buildTelegramDeferredRunFailureText,
+  buildTelegramDeferredRunSilentCompletionText,
+  formatTelegramDeferredRunTarget,
+  type TelegramLongTurnDeliveryState,
+} from "./long-turn-delivery.js";
 import { createNativeTelegramToolProgressDraft } from "./native-tool-progress-draft.js";
 import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
 import {
@@ -135,10 +142,11 @@ import {
   endTelegramReplyFence,
   getTelegramReplyFenceSizeForTests,
   isTelegramReplyFenceSuperseded,
+  protectTelegramReplyFenceAbortControllerFromNormalSupersede,
   releaseTelegramReplyFenceAbortController,
   resetTelegramReplyFenceForTests,
+  resolveTelegramReplyFenceSupersedeMode,
   resolveTelegramReplyFenceKey,
-  shouldSupersedeTelegramReplyFence,
   supersedeTelegramReplyFence,
 } from "./telegram-reply-fence.js";
 
@@ -147,6 +155,19 @@ export { getTelegramReplyFenceSizeForTests, resetTelegramReplyFenceForTests };
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
 const silentReplyDispatchLogger = createSubsystemLogger("telegram/silent-reply-dispatch");
+const INTERNAL_FOREGROUND_REPLY_FRESHNESS_POLICY_KEY = Symbol.for(
+  "openclaw.internal.foregroundReplyFreshnessPolicy",
+);
+
+type TelegramForegroundReplyFreshnessPolicy = {
+  allowSupersededDelivery?: () => boolean;
+};
+
+type TelegramReplyOptionsWithInternalFreshness = NonNullable<
+  Parameters<TelegramBotDeps["dispatchReplyWithBufferedBlockDispatcher"]>[0]["replyOptions"]
+> & {
+  [INTERNAL_FOREGROUND_REPLY_FRESHNESS_POLICY_KEY]?: TelegramForegroundReplyFreshnessPolicy;
+};
 
 /** Minimum chars before sending first streaming message (improves push notification UX) */
 const DRAFT_MIN_INITIAL_CHARS = 30;
@@ -245,6 +266,8 @@ type DispatchTelegramMessageParams = {
   telegramCfg: TelegramAccountConfig;
   telegramDeps?: TelegramBotDeps;
   opts: Pick<TelegramBotOptions, "token" | "mediaMaxMb">;
+  runId?: string;
+  longTurnDeliveryState?: TelegramLongTurnDeliveryState;
 };
 
 type TelegramReasoningLevel = "off" | "on" | "stream";
@@ -676,6 +699,8 @@ export const dispatchTelegramMessage = async ({
   telegramCfg,
   telegramDeps: injectedTelegramDeps,
   opts,
+  runId,
+  longTurnDeliveryState,
 }: DispatchTelegramMessageParams) => {
   const dispatchStartedAt = Date.now();
   const dispatchContext = resolveDispatchTelegramContext({ cfg, context });
@@ -703,6 +728,12 @@ export const dispatchTelegramMessage = async ({
     statusReactionController: rawStatusReactionController,
   } = dispatchContext;
   const isRoomEvent = ctxPayload.InboundEventKind === "room_event";
+  const deferredRunTarget = longTurnDeliveryState
+    ? formatTelegramDeferredRunTarget({
+        chatId,
+        threadId: threadSpec.id,
+      })
+    : undefined;
   const statusReactionController = isRoomEvent ? null : rawStatusReactionController;
   const statusReactionTiming = {
     ...DEFAULT_TIMING,
@@ -766,6 +797,7 @@ export const dispatchTelegramMessage = async ({
   let dispatchWasSuperseded = false;
   const isDispatchSuperseded = () =>
     replyFenceGeneration !== undefined &&
+    !(longTurnDeliveryState?.isDeferred() === true && !replyAbortController.signal.aborted) &&
     isTelegramReplyFenceSuperseded({
       key: activeReplyFenceKey,
       generation: replyFenceGeneration,
@@ -1199,7 +1231,8 @@ export const dispatchTelegramMessage = async ({
 
   const chunkMode = resolveChunkMode(cfg, "telegram", route.accountId);
 
-  const supersedeReplyFence = shouldSupersedeTelegramReplyFence(ctxPayload);
+  const supersedeReplyFenceMode = resolveTelegramReplyFenceSupersedeMode(ctxPayload);
+  const supersedeReplyFence = supersedeReplyFenceMode !== "none";
   activeReplyFenceKey = supersedeReplyFence
     ? replyFenceKey.activeKey
     : buildTelegramNonInterruptingReplyFenceKey({
@@ -1212,8 +1245,16 @@ export const dispatchTelegramMessage = async ({
   replyFenceGeneration = beginTelegramReplyFence({
     key: activeReplyFenceKey,
     supersede: supersedeReplyFence,
+    supersedeMode: supersedeReplyFenceMode === "abort" ? "abort" : "normal",
     abortController: replyAbortController,
     laneKey: scopedReplyFenceLaneKey,
+  });
+  longTurnDeliveryState?.setCanSendDeferralNotice(() => !isDispatchSuperseded());
+  longTurnDeliveryState?.onDeferralPending(() => {
+    protectTelegramReplyFenceAbortControllerFromNormalSupersede(
+      activeReplyFenceKey,
+      replyAbortController,
+    );
   });
 
   const implicitQuoteReplyTargetId =
@@ -1324,6 +1365,7 @@ export const dispatchTelegramMessage = async ({
   let queuedFinal = false;
   let suppressSilentReplyFallback = false;
   let hadErrorReplyFailureOrSkip = false;
+  let hadIntentionalSilentReplySkip = false;
   let isFirstTurnInSession = false;
   let dispatchError: unknown;
 
@@ -1419,6 +1461,15 @@ export const dispatchTelegramMessage = async ({
     ) => {
       if (isDispatchSuperseded()) {
         return false;
+      }
+      if (options?.durable) {
+        if (longTurnDeliveryState?.isDeferred() !== true) {
+          longTurnDeliveryState?.markFinalDeliveryStarted();
+        }
+        await longTurnDeliveryState?.waitForDeferralNotice();
+        if (isDispatchSuperseded()) {
+          return false;
+        }
       }
       const deliverablePayload = applyQuoteReplyTarget(payload);
       const silent = options?.silent ?? (silentErrorReplies && payload.isError === true);
@@ -1700,7 +1751,14 @@ export const dispatchTelegramMessage = async ({
                       answerPayload: ReplyPayload,
                       text: string,
                       buttons?: TelegramInlineButtons,
-                    ) => {
+                    ): Promise<LaneDeliveryResult> => {
+                      if (longTurnDeliveryState?.isDeferred() !== true) {
+                        longTurnDeliveryState?.markFinalDeliveryStarted();
+                      }
+                      await longTurnDeliveryState?.waitForDeferralNotice();
+                      if (isDispatchSuperseded()) {
+                        return { kind: "skipped" };
+                      }
                       const finalText = await resolveTranscriptBackedFinalText(text);
                       if (streamMode === "progress") {
                         return deliverProgressModeFinalAnswer(answerPayload, finalText);
@@ -1857,7 +1915,9 @@ export const dispatchTelegramMessage = async ({
                     if (payload.isError === true) {
                       hadErrorReplyFailureOrSkip = true;
                     }
-                    if (info.reason !== "silent") {
+                    if (info.reason === "silent") {
+                      hadIntentionalSilentReplySkip = true;
+                    } else {
                       deliveryState.markNonSilentSkip();
                     }
                   },
@@ -1889,6 +1949,16 @@ export const dispatchTelegramMessage = async ({
                   },
                 },
                 replyOptions: {
+                  runId,
+                  ...(longTurnDeliveryState
+                    ? {
+                        [INTERNAL_FOREGROUND_REPLY_FRESHNESS_POLICY_KEY]: {
+                          allowSupersededDelivery: () =>
+                            longTurnDeliveryState.isDeferred() &&
+                            !replyAbortController.signal.aborted,
+                        },
+                      }
+                    : {}),
                   skillFilter,
                   disableBlockStreaming,
                   abortSignal: replyAbortController.signal,
@@ -2061,7 +2131,7 @@ export const dispatchTelegramMessage = async ({
                       }
                     : undefined,
                   onModelSelected,
-                },
+                } satisfies TelegramReplyOptionsWithInternalFreshness,
               });
             },
           }),
@@ -2102,16 +2172,277 @@ export const dispatchTelegramMessage = async ({
     }
   } finally {
     dispatchWasSuperseded = isDispatchSuperseded();
-    releaseReplyFence();
+    if (!(longTurnDeliveryState?.isDeferred() === true && !dispatchWasSuperseded)) {
+      releaseReplyFence();
+    }
     endTelegramInboundEventDeliveryCorrelation();
   }
-  if (dispatchWasSuperseded) {
-    if (statusReactionController) {
-      void finalizeTelegramStatusReaction({ outcome: "done", hasFinalResponse: true }).catch(
+  try {
+    if (dispatchWasSuperseded) {
+      if (statusReactionController) {
+        void finalizeTelegramStatusReaction({ outcome: "done", hasFinalResponse: true }).catch(
+          (err: unknown) => {
+            logVerbose(`telegram: status reaction finalize failed: ${String(err)}`);
+          },
+        );
+      } else {
+        removeAckReactionAfterReply({
+          removeAfterReply: removeAckAfterReply,
+          ackReactionPromise,
+          ackReactionValue: ackReactionPromise ? "ack" : null,
+          remove: () =>
+            (reactionApi?.(chatId, msg.message_id ?? 0, []) ?? Promise.resolve()).then(() => {}),
+          onError: (err) => {
+            if (!msg.message_id) {
+              return;
+            }
+            logAckFailure({
+              log: logVerbose,
+              channel: "telegram",
+              target: `${chatId}/${msg.message_id}`,
+              error: err,
+            });
+          },
+        });
+      }
+      if (!isRoomEvent || deliveryState.snapshot().delivered) {
+        clearGroupHistory();
+      }
+      releaseReplyFence();
+      return;
+    }
+    let sentFallback = false;
+    let sentDeferredSilentCompletion = false;
+    const deliverySummary = deliveryState.snapshot();
+    const wasDeferredRun = longTurnDeliveryState?.isDeferred() === true;
+    const shouldSendFailureFallback =
+      !isRoomEvent &&
+      (dispatchError ||
+        (!deliverySummary.delivered &&
+          (deliverySummary.skippedNonSilent > 0 || deliverySummary.failedNonSilent > 0)));
+    if (shouldSendFailureFallback) {
+      const fallbackText = dispatchError
+        ? wasDeferredRun && deferredRunTarget && longTurnDeliveryState
+          ? buildTelegramDeferredRunFailureText({
+              runId: longTurnDeliveryState.runId,
+              agentId: longTurnDeliveryState.agentId,
+              sessionKey: longTurnDeliveryState.sessionKey,
+              target: deferredRunTarget,
+            })
+          : "Something went wrong while processing your request. Please try again."
+        : wasDeferredRun && !isGroup && deferredRunTarget && longTurnDeliveryState
+          ? buildTelegramDeferredRunEmptyResponseText({
+              runId: longTurnDeliveryState.runId,
+              agentId: longTurnDeliveryState.agentId,
+              sessionKey: longTurnDeliveryState.sessionKey,
+              target: deferredRunTarget,
+            })
+          : EMPTY_RESPONSE_FALLBACK;
+      if (longTurnDeliveryState?.isDeferred() !== true) {
+        longTurnDeliveryState?.markFinalDeliveryStarted();
+      }
+      await longTurnDeliveryState?.waitForDeferralNotice();
+      if (isDispatchSuperseded()) {
+        releaseReplyFence();
+        return;
+      }
+      const result = await (telegramDeps.deliverReplies ?? deliverReplies)({
+        replies: [{ text: fallbackText }],
+        ...deliveryBaseOptions,
+        silent: silentErrorReplies && (dispatchError != null || hadErrorReplyFailureOrSkip),
+        mediaLoader: telegramDeps.loadWebMedia,
+      });
+      sentFallback = result.delivered;
+    }
+
+    if (
+      !sentFallback &&
+      wasDeferredRun &&
+      hadIntentionalSilentReplySkip &&
+      deferredRunTarget &&
+      longTurnDeliveryState &&
+      !dispatchError &&
+      !deliverySummary.delivered &&
+      !suppressSilentReplyFallback &&
+      !queuedFinal &&
+      !isGroup &&
+      !isRoomEvent
+    ) {
+	      if (!longTurnDeliveryState.isDeferred()) {
+        longTurnDeliveryState.markFinalDeliveryStarted();
+      }
+      await longTurnDeliveryState.waitForDeferralNotice();
+      if (isDispatchSuperseded()) {
+        releaseReplyFence();
+        return;
+      }
+      const result = await (telegramDeps.deliverReplies ?? deliverReplies)({
+        replies: [
+          {
+            text: buildTelegramDeferredRunSilentCompletionText({
+              runId: longTurnDeliveryState.runId,
+              agentId: longTurnDeliveryState.agentId,
+              sessionKey: longTurnDeliveryState.sessionKey,
+              target: deferredRunTarget,
+            }),
+          },
+        ],
+        ...deliveryBaseOptions,
+        silent: false,
+        mediaLoader: telegramDeps.loadWebMedia,
+      });
+      sentFallback = result.delivered;
+      sentDeferredSilentCompletion = result.delivered;
+    }
+
+    if (
+      !sentFallback &&
+      wasDeferredRun &&
+      deferredRunTarget &&
+      longTurnDeliveryState &&
+      !dispatchError &&
+      !deliverySummary.delivered &&
+      !suppressSilentReplyFallback &&
+      !hadIntentionalSilentReplySkip &&
+      !queuedFinal &&
+      !isGroup &&
+      !isRoomEvent
+    ) {
+	      if (!longTurnDeliveryState.isDeferred()) {
+        longTurnDeliveryState.markFinalDeliveryStarted();
+      }
+      await longTurnDeliveryState.waitForDeferralNotice();
+      if (isDispatchSuperseded()) {
+        releaseReplyFence();
+        return;
+      }
+      const result = await (telegramDeps.deliverReplies ?? deliverReplies)({
+        replies: [
+          {
+            text: buildTelegramDeferredRunEmptyResponseText({
+              runId: longTurnDeliveryState.runId,
+              agentId: longTurnDeliveryState.agentId,
+              sessionKey: longTurnDeliveryState.sessionKey,
+              target: deferredRunTarget,
+            }),
+          },
+        ],
+        ...deliveryBaseOptions,
+        silent: false,
+        mediaLoader: telegramDeps.loadWebMedia,
+      });
+      sentFallback = result.delivered;
+    }
+
+    if (
+      !sentFallback &&
+      !dispatchError &&
+      !deliverySummary.delivered &&
+      !suppressSilentReplyFallback &&
+      !queuedFinal &&
+      isGroup
+    ) {
+      const policySessionKey =
+        ctxPayload.CommandSource === "native"
+          ? (ctxPayload.CommandTargetSessionKey ?? ctxPayload.SessionKey)
+          : ctxPayload.SessionKey;
+      const silentReplyFallback = projectOutboundPayloadPlanForDelivery(
+        createOutboundPayloadPlan([{ text: "NO_REPLY" }], {
+          cfg,
+          sessionKey: policySessionKey,
+          surface: "telegram",
+        }),
+      );
+      if (silentReplyFallback.length > 0) {
+        const result = await (telegramDeps.deliverReplies ?? deliverReplies)({
+          replies: silentReplyFallback,
+          ...deliveryBaseOptions,
+          silent: false,
+          mediaLoader: telegramDeps.loadWebMedia,
+        });
+        sentFallback = result.delivered;
+      }
+      silentReplyDispatchLogger.debug("telegram turn ended without visible final response", {
+        hasSessionKey: Boolean(policySessionKey),
+        hasChatId: chatId != null,
+        queuedFinal,
+        sentFallback,
+      });
+    }
+
+    const hasFinalResponse =
+      deliverySummary.delivered || sentFallback || suppressSilentReplyFallback || queuedFinal;
+
+    if (statusReactionController && !hasFinalResponse) {
+      void finalizeTelegramStatusReaction({ outcome: "error", hasFinalResponse: false }).catch(
         (err: unknown) => {
-          logVerbose(`telegram: status reaction finalize failed: ${String(err)}`);
+          logVerbose(`telegram: status reaction error finalize failed: ${String(err)}`);
         },
       );
+    }
+
+    const shouldClearGroupHistory =
+      !isRoomEvent || deliverySummary.delivered || sentFallback || queuedFinal;
+
+    if (!hasFinalResponse) {
+      if (!shouldClearGroupHistory) {
+        releaseReplyFence();
+        return;
+      }
+      clearGroupHistory();
+      releaseReplyFence();
+      return;
+    }
+
+    // Fire-and-forget: auto-rename DM topic on first message.
+    if (isDmTopic && isFirstTurnInSession) {
+      const userMessage = (ctxPayload.RawBody ?? ctxPayload.Body ?? "").slice(0, 500);
+      if (userMessage.trim()) {
+        const agentDir = resolveAgentDir(cfg, route.agentId);
+        const directAutoTopicLabel =
+          !isGroup && groupConfig && "autoTopicLabel" in groupConfig
+            ? groupConfig.autoTopicLabel
+            : undefined;
+        const accountAutoTopicLabel = telegramCfg?.autoTopicLabel;
+        const autoTopicConfig = resolveAutoTopicLabelConfig(
+          directAutoTopicLabel,
+          accountAutoTopicLabel,
+        );
+        if (autoTopicConfig) {
+          const topicThreadId = threadSpec.id!;
+          void (async () => {
+            try {
+              const label = await generateTopicLabel({
+                userMessage,
+                prompt: autoTopicConfig.prompt,
+                cfg,
+                agentId: route.agentId,
+                agentDir,
+              });
+              if (!label) {
+                logVerbose("auto-topic-label: LLM returned empty label");
+                return;
+              }
+              logVerbose(`auto-topic-label: generated label (len=${label.length})`);
+              await bot.api.editForumTopic(chatId, topicThreadId, { name: label });
+              logVerbose(`auto-topic-label: renamed topic ${chatId}/${topicThreadId}`);
+            } catch (err) {
+              logVerbose(`auto-topic-label: failed: ${formatErrorMessage(err)}`);
+            }
+          })();
+        }
+      }
+    }
+
+    if (statusReactionController) {
+      const statusReactionOutcome =
+        dispatchError || (sentFallback && !sentDeferredSilentCompletion) ? "error" : "done";
+      void finalizeTelegramStatusReaction({
+        outcome: statusReactionOutcome,
+        hasFinalResponse: true,
+      }).catch((err: unknown) => {
+        logVerbose(`telegram: status reaction finalize failed: ${String(err)}`);
+      });
     } else {
       removeAckReactionAfterReply({
         removeAfterReply: removeAckAfterReply,
@@ -2132,158 +2463,10 @@ export const dispatchTelegramMessage = async ({
         },
       });
     }
-    if (!isRoomEvent || deliveryState.snapshot().delivered) {
+    if (shouldClearGroupHistory) {
       clearGroupHistory();
     }
-    return;
-  }
-  let sentFallback = false;
-  const deliverySummary = deliveryState.snapshot();
-  const shouldSendFailureFallback =
-    !isRoomEvent &&
-    (dispatchError ||
-      (!deliverySummary.delivered &&
-        (deliverySummary.skippedNonSilent > 0 || deliverySummary.failedNonSilent > 0)));
-  if (shouldSendFailureFallback) {
-    const fallbackText = dispatchError
-      ? "Something went wrong while processing your request. Please try again."
-      : EMPTY_RESPONSE_FALLBACK;
-    const result = await (telegramDeps.deliverReplies ?? deliverReplies)({
-      replies: [{ text: fallbackText }],
-      ...deliveryBaseOptions,
-      silent: silentErrorReplies && (dispatchError != null || hadErrorReplyFailureOrSkip),
-      mediaLoader: telegramDeps.loadWebMedia,
-    });
-    sentFallback = result.delivered;
-  }
-
-  if (
-    !sentFallback &&
-    !dispatchError &&
-    !deliverySummary.delivered &&
-    !suppressSilentReplyFallback &&
-    !queuedFinal &&
-    isGroup
-  ) {
-    const policySessionKey =
-      ctxPayload.CommandSource === "native"
-        ? (ctxPayload.CommandTargetSessionKey ?? ctxPayload.SessionKey)
-        : ctxPayload.SessionKey;
-    const silentReplyFallback = projectOutboundPayloadPlanForDelivery(
-      createOutboundPayloadPlan([{ text: "NO_REPLY" }], {
-        cfg,
-        sessionKey: policySessionKey,
-        surface: "telegram",
-      }),
-    );
-    if (silentReplyFallback.length > 0) {
-      const result = await (telegramDeps.deliverReplies ?? deliverReplies)({
-        replies: silentReplyFallback,
-        ...deliveryBaseOptions,
-        silent: false,
-        mediaLoader: telegramDeps.loadWebMedia,
-      });
-      sentFallback = result.delivered;
-    }
-    silentReplyDispatchLogger.debug("telegram turn ended without visible final response", {
-      hasSessionKey: Boolean(policySessionKey),
-      hasChatId: chatId != null,
-      queuedFinal,
-      sentFallback,
-    });
-  }
-
-  const hasFinalResponse =
-    deliverySummary.delivered || sentFallback || suppressSilentReplyFallback || queuedFinal;
-
-  if (statusReactionController && !hasFinalResponse) {
-    void finalizeTelegramStatusReaction({ outcome: "error", hasFinalResponse: false }).catch(
-      (err: unknown) => {
-        logVerbose(`telegram: status reaction error finalize failed: ${String(err)}`);
-      },
-    );
-  }
-
-  const shouldClearGroupHistory =
-    !isRoomEvent || deliverySummary.delivered || sentFallback || queuedFinal;
-
-  if (!hasFinalResponse) {
-    if (!shouldClearGroupHistory) {
-      return;
-    }
-    clearGroupHistory();
-    return;
-  }
-
-  // Fire-and-forget: auto-rename DM topic on first message.
-  if (isDmTopic && isFirstTurnInSession) {
-    const userMessage = (ctxPayload.RawBody ?? ctxPayload.Body ?? "").slice(0, 500);
-    if (userMessage.trim()) {
-      const agentDir = resolveAgentDir(cfg, route.agentId);
-      const directAutoTopicLabel =
-        !isGroup && groupConfig && "autoTopicLabel" in groupConfig
-          ? groupConfig.autoTopicLabel
-          : undefined;
-      const accountAutoTopicLabel = telegramCfg?.autoTopicLabel;
-      const autoTopicConfig = resolveAutoTopicLabelConfig(
-        directAutoTopicLabel,
-        accountAutoTopicLabel,
-      );
-      if (autoTopicConfig) {
-        const topicThreadId = threadSpec.id!;
-        void (async () => {
-          try {
-            const label = await generateTopicLabel({
-              userMessage,
-              prompt: autoTopicConfig.prompt,
-              cfg,
-              agentId: route.agentId,
-              agentDir,
-            });
-            if (!label) {
-              logVerbose("auto-topic-label: LLM returned empty label");
-              return;
-            }
-            logVerbose(`auto-topic-label: generated label (len=${label.length})`);
-            await bot.api.editForumTopic(chatId, topicThreadId, { name: label });
-            logVerbose(`auto-topic-label: renamed topic ${chatId}/${topicThreadId}`);
-          } catch (err) {
-            logVerbose(`auto-topic-label: failed: ${formatErrorMessage(err)}`);
-          }
-        })();
-      }
-    }
-  }
-
-  if (statusReactionController) {
-    const statusReactionOutcome = dispatchError || sentFallback ? "error" : "done";
-    void finalizeTelegramStatusReaction({
-      outcome: statusReactionOutcome,
-      hasFinalResponse: true,
-    }).catch((err: unknown) => {
-      logVerbose(`telegram: status reaction finalize failed: ${String(err)}`);
-    });
-  } else {
-    removeAckReactionAfterReply({
-      removeAfterReply: removeAckAfterReply,
-      ackReactionPromise,
-      ackReactionValue: ackReactionPromise ? "ack" : null,
-      remove: () =>
-        (reactionApi?.(chatId, msg.message_id ?? 0, []) ?? Promise.resolve()).then(() => {}),
-      onError: (err) => {
-        if (!msg.message_id) {
-          return;
-        }
-        logAckFailure({
-          log: logVerbose,
-          channel: "telegram",
-          target: `${chatId}/${msg.message_id}`,
-          error: err,
-        });
-      },
-    });
-  }
-  if (shouldClearGroupHistory) {
-    clearGroupHistory();
+  } finally {
+    releaseReplyFence();
   }
 };

--- a/extensions/telegram/src/bot-message.test.ts
+++ b/extensions/telegram/src/bot-message.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TelegramBotDeps } from "./bot-deps.js";
+import { TELEGRAM_LONG_TURN_SOFT_DEADLINE_MS } from "./long-turn-delivery.js";
 
 const buildTelegramMessageContext = vi.hoisted(() => vi.fn());
 const dispatchTelegramMessage = vi.hoisted(() => vi.fn());
@@ -38,7 +39,7 @@ describe("telegram bot message processor", () => {
 
   beforeEach(() => {
     buildTelegramMessageContext.mockClear();
-    dispatchTelegramMessage.mockClear();
+    dispatchTelegramMessage.mockReset();
     telegramInboundInfo.mockClear();
     upsertChannelPairingRequest.mockClear();
   });
@@ -141,6 +142,246 @@ describe("telegram bot message processor", () => {
     expect(telegramInboundInfo).toHaveBeenCalledWith(
       "Inbound message telegram:123 -> @openclaw_bot (direct, 11 chars)",
     );
+  });
+
+  it("defers long-running message turns after the soft deadline", async () => {
+    vi.useFakeTimers();
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    let resolveDispatch: (() => void) | undefined;
+    buildTelegramMessageContext.mockResolvedValue(
+      createMessageContext({
+        threadSpec: { id: 456, scope: "forum" },
+      }),
+    );
+    dispatchTelegramMessage.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveDispatch = resolve;
+      }),
+    );
+    const processMessage = createTelegramMessageProcessor({
+      ...baseDeps,
+      bot: { api: { sendMessage } },
+    } as unknown as Parameters<typeof createTelegramMessageProcessor>[0]);
+
+    try {
+      const processPromise = processSampleMessage(processMessage);
+      await vi.advanceTimersByTimeAsync(TELEGRAM_LONG_TURN_SOFT_DEADLINE_MS - 1);
+      expect(sendMessage).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(processPromise).resolves.toBe(true);
+
+      const dispatchParams = dispatchTelegramMessage.mock.calls[0]?.[0] as
+        | {
+            runId?: string;
+            longTurnDeliveryState?: { runId: string; isDeferred: () => boolean };
+          }
+        | undefined;
+      const runId = dispatchParams?.runId;
+      expect(runId).toEqual(expect.any(String));
+      expect(dispatchParams?.longTurnDeliveryState?.runId).toBe(runId);
+      expect(dispatchParams?.longTurnDeliveryState?.isDeferred()).toBe(true);
+      expect(sendMessage).toHaveBeenCalledWith(
+        123,
+        `Still working on this. I will reply here when the run completes.\n\nRun: ${runId}`,
+        { message_thread_id: 456 },
+      );
+
+      resolveDispatch?.();
+      await Promise.resolve();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not send a deferral notice when final delivery already started", async () => {
+    vi.useFakeTimers();
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    let resolveDispatch: (() => void) | undefined;
+    let processResolved = false;
+    buildTelegramMessageContext.mockResolvedValue(
+      createMessageContext({
+        threadSpec: { id: 456, scope: "forum" },
+      }),
+    );
+    dispatchTelegramMessage.mockImplementation((params) => {
+      (
+        params as {
+          longTurnDeliveryState?: { markFinalDeliveryStarted: () => void };
+        }
+      ).longTurnDeliveryState?.markFinalDeliveryStarted();
+      return new Promise<void>((resolve) => {
+        resolveDispatch = resolve;
+      });
+    });
+    const processMessage = createTelegramMessageProcessor({
+      ...baseDeps,
+      bot: { api: { sendMessage } },
+    } as unknown as Parameters<typeof createTelegramMessageProcessor>[0]);
+
+    try {
+      const processPromise = processSampleMessage(processMessage).then((result) => {
+        processResolved = true;
+        return result;
+      });
+      await vi.advanceTimersByTimeAsync(TELEGRAM_LONG_TURN_SOFT_DEADLINE_MS);
+
+      expect(sendMessage).not.toHaveBeenCalled();
+      expect(processResolved).toBe(false);
+
+      resolveDispatch?.();
+      await expect(processPromise).resolves.toBe(true);
+      expect(sendMessage).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not send a deferral notice when dispatch is no longer deliverable", async () => {
+    vi.useFakeTimers();
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    let resolveDispatch: (() => void) | undefined;
+    let processResolved = false;
+    buildTelegramMessageContext.mockResolvedValue(
+      createMessageContext({
+        threadSpec: { id: 456, scope: "forum" },
+      }),
+    );
+    dispatchTelegramMessage.mockImplementation((params) => {
+      (
+        params as {
+          longTurnDeliveryState?: { setCanSendDeferralNotice: (check: () => boolean) => void };
+        }
+      ).longTurnDeliveryState?.setCanSendDeferralNotice(() => false);
+      return new Promise<void>((resolve) => {
+        resolveDispatch = resolve;
+      });
+    });
+    const processMessage = createTelegramMessageProcessor({
+      ...baseDeps,
+      bot: { api: { sendMessage } },
+    } as unknown as Parameters<typeof createTelegramMessageProcessor>[0]);
+
+    try {
+      const processPromise = processSampleMessage(processMessage).then((result) => {
+        processResolved = true;
+        return result;
+      });
+      await vi.advanceTimersByTimeAsync(TELEGRAM_LONG_TURN_SOFT_DEADLINE_MS);
+
+      expect(sendMessage).not.toHaveBeenCalled();
+      expect(processResolved).toBe(false);
+
+      resolveDispatch?.();
+      await expect(processPromise).resolves.toBe(true);
+      expect(sendMessage).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not defer group turns before visible reply eligibility is known", async () => {
+    vi.useFakeTimers();
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    let resolveDispatch: (() => void) | undefined;
+    let processResolved = false;
+    buildTelegramMessageContext.mockResolvedValue(
+      createMessageContext({
+        isGroup: true,
+        threadSpec: { id: undefined, scope: "none" },
+        ctxPayload: {
+          From: "telegram:group:-100",
+          To: "@openclaw_bot",
+          ChatType: "group",
+          RawBody: "@bot think for a while",
+        },
+      }),
+    );
+    dispatchTelegramMessage.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveDispatch = resolve;
+      }),
+    );
+    const processMessage = createTelegramMessageProcessor({
+      ...baseDeps,
+      bot: { api: { sendMessage } },
+    } as unknown as Parameters<typeof createTelegramMessageProcessor>[0]);
+
+    try {
+      const processPromise = processSampleMessage(processMessage).then((result) => {
+        processResolved = true;
+        return result;
+      });
+      await vi.advanceTimersByTimeAsync(TELEGRAM_LONG_TURN_SOFT_DEADLINE_MS);
+
+      expect(sendMessage).not.toHaveBeenCalled();
+      expect(processResolved).toBe(false);
+
+      resolveDispatch?.();
+      await expect(processPromise).resolves.toBe(true);
+      expect(sendMessage).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reports deferred background dispatch failures with run context", async () => {
+    vi.useFakeTimers();
+    let resolveFailureSend: (() => void) | undefined;
+    const failureSent = new Promise<void>((resolve) => {
+      resolveFailureSend = resolve;
+    });
+    const sendMessage = vi.fn(async (_chatId: number, _text: string, _options?: unknown) => {
+      if (sendMessage.mock.calls.length === 2) {
+        resolveFailureSend?.();
+      }
+    });
+    let rejectDispatch: ((error: unknown) => void) | undefined;
+    buildTelegramMessageContext.mockResolvedValue(
+      createMessageContext({
+        threadSpec: { id: 456, scope: "forum" },
+      }),
+    );
+    dispatchTelegramMessage.mockReturnValue(
+      new Promise<void>((_resolve, reject) => {
+        rejectDispatch = reject;
+      }),
+    );
+    const runtimeError = vi.fn();
+    const processMessage = createTelegramMessageProcessor({
+      ...baseDeps,
+      bot: { api: { sendMessage } },
+      runtime: { error: runtimeError },
+    } as unknown as Parameters<typeof createTelegramMessageProcessor>[0]);
+
+    try {
+      const processPromise = processSampleMessage(processMessage);
+      await vi.advanceTimersByTimeAsync(TELEGRAM_LONG_TURN_SOFT_DEADLINE_MS);
+      await expect(processPromise).resolves.toBe(true);
+
+      const dispatchParams = dispatchTelegramMessage.mock.calls[0]?.[0] as
+        | { runId?: string }
+        | undefined;
+      const runId = dispatchParams?.runId;
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+
+      rejectDispatch?.(new Error("provider down"));
+      await failureSent;
+
+      expect(sendMessage).toHaveBeenCalledTimes(2);
+      expect(sendMessage.mock.calls[1]?.[1]).toContain(
+        "The deferred run did not complete successfully.",
+      );
+      expect(sendMessage.mock.calls[1]?.[1]).toContain(`Run: ${runId}`);
+      expect(sendMessage.mock.calls[1]?.[1]).not.toContain("provider down");
+      expect(sendMessage.mock.calls[1]?.[1]).not.toContain("Something went wrong");
+      expect(sendMessage.mock.calls[1]?.[2]).toEqual({ message_thread_id: 456 });
+      expect(runtimeError).toHaveBeenCalledWith(
+        "telegram deferred dispatch failed: Error: provider down",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("runs the dispatch-start lifecycle after context creation and before dispatch", async () => {

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { ReplyToMode } from "openclaw/plugin-sdk/config-contracts";
 import type { TelegramAccountConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
@@ -19,6 +20,13 @@ import { dispatchTelegramMessage } from "./bot-message-dispatch.js";
 import type { TelegramBotOptions } from "./bot.types.js";
 import { buildTelegramThreadParams } from "./bot/helpers.js";
 import type { TelegramContext, TelegramStreamMode } from "./bot/types.js";
+import {
+  buildTelegramDeferredRunFailureText,
+  buildTelegramLongTurnDeferralText,
+  createTelegramLongTurnDeliveryState,
+  formatTelegramDeferredRunTarget,
+  TELEGRAM_LONG_TURN_SOFT_DEADLINE_MS,
+} from "./long-turn-delivery.js";
 import type { TelegramReplyChainEntry } from "./message-cache.js";
 
 const telegramInboundLog = createSubsystemLogger("gateway/channels/telegram").child("inbound");
@@ -50,6 +58,8 @@ type TelegramMessageProcessorDeps = Omit<
 export type TelegramMessageProcessorLifecycle = {
   onDispatchStart?: () => Promise<void> | void;
 };
+
+type TelegramDispatchOutcome = { status: "completed" } | { status: "failed"; error: unknown };
 
 export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDeps) => {
   const {
@@ -178,18 +188,101 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
     );
     await lifecycle?.onDispatchStart?.();
     try {
-      await dispatchTelegramMessage({
-        context,
-        bot,
-        cfg,
-        runtime,
-        replyToMode,
-        streamMode,
-        textLimit,
-        telegramCfg,
-        telegramDeps,
-        opts,
+      const longTurnDeliveryState = createTelegramLongTurnDeliveryState({
+        runId: randomUUID(),
+        agentId: context.route.agentId,
+        accountId: context.route.accountId,
+        sessionKey: context.ctxPayload.SessionKey,
+        chatId: String(context.chatId),
+        threadId: context.threadSpec?.id,
       });
+      const dispatchPromise = Promise.resolve().then(() =>
+        dispatchTelegramMessage({
+          context,
+          bot,
+          cfg,
+          runtime,
+          replyToMode,
+          streamMode,
+          textLimit,
+          telegramCfg,
+          telegramDeps,
+          opts,
+          runId: longTurnDeliveryState.runId,
+          longTurnDeliveryState,
+        }),
+      );
+      const dispatchOutcome: Promise<TelegramDispatchOutcome> = dispatchPromise.then(
+        () => ({ status: "completed" }),
+        (error: unknown) => ({ status: "failed", error }),
+      );
+      const canDefer = context.ctxPayload.InboundEventKind !== "room_event" && !context.isGroup;
+      let softDeadlineTimer: ReturnType<typeof setTimeout> | undefined;
+      const softDeadline = canDefer
+        ? new Promise<"soft-deadline">((resolve) => {
+            softDeadlineTimer = setTimeout(
+              () => resolve("soft-deadline"),
+              TELEGRAM_LONG_TURN_SOFT_DEADLINE_MS,
+            );
+          })
+        : undefined;
+      const firstOutcome = softDeadline
+        ? await Promise.race([dispatchOutcome, softDeadline])
+        : await dispatchOutcome;
+      if (softDeadlineTimer) {
+        clearTimeout(softDeadlineTimer);
+      }
+      if (firstOutcome === "soft-deadline") {
+        if (
+          longTurnDeliveryState.hasFinalDeliveryStarted() ||
+          !longTurnDeliveryState.canSendDeferralNotice()
+        ) {
+          const finalOutcome = await dispatchOutcome;
+          if (finalOutcome.status === "failed") {
+            throw finalOutcome.error;
+          }
+          return true;
+        }
+        longTurnDeliveryState.markDeferralPending();
+        const target = formatTelegramDeferredRunTarget({
+          chatId: context.chatId,
+          threadId: context.threadSpec?.id,
+        });
+        void dispatchOutcome.then(async (outcome) => {
+          if (outcome.status === "completed") {
+            return;
+          }
+          await longTurnDeliveryState.waitForDeferralNotice();
+          runtime.error?.(danger(`telegram deferred dispatch failed: ${String(outcome.error)}`));
+          try {
+            await bot.api.sendMessage(
+              context.chatId,
+              buildTelegramDeferredRunFailureText({
+                runId: longTurnDeliveryState.runId,
+                agentId: longTurnDeliveryState.agentId,
+                sessionKey: longTurnDeliveryState.sessionKey,
+                target,
+              }),
+              buildTelegramThreadParams(context.threadSpec),
+            );
+          } catch {}
+        });
+        try {
+          await bot.api.sendMessage(
+            context.chatId,
+            buildTelegramLongTurnDeferralText({ runId: longTurnDeliveryState.runId }),
+            buildTelegramThreadParams(context.threadSpec),
+          );
+        } catch (err) {
+          runtime.error?.(danger(`telegram long-turn deferral failed: ${String(err)}`));
+        } finally {
+          longTurnDeliveryState.markDeferred();
+        }
+        return true;
+      }
+      if (firstOutcome.status === "failed") {
+        throw firstOutcome.error;
+      }
       if (ingressDebugEnabled && ingressReceivedAtMs) {
         logVerbose(
           `telegram ingress: chatId=${context.chatId} dispatchCompleteMs=${Date.now() - ingressReceivedAtMs}` +

--- a/extensions/telegram/src/long-turn-delivery.ts
+++ b/extensions/telegram/src/long-turn-delivery.ts
@@ -1,0 +1,157 @@
+export const TELEGRAM_LONG_TURN_SOFT_DEADLINE_MS = 30_000;
+
+export type TelegramLongTurnDeliveryState = {
+  runId: string;
+  agentId: string;
+  accountId: string;
+  sessionKey?: string;
+  chatId: string;
+  threadId?: number;
+  markDeferralPending: () => void;
+  markDeferred: () => void;
+  isDeferred: () => boolean;
+  onDeferralPending: (listener: () => void) => () => void;
+  waitForDeferralNotice: () => Promise<void>;
+  markFinalDeliveryStarted: () => void;
+  hasFinalDeliveryStarted: () => boolean;
+  setCanSendDeferralNotice: (check: () => boolean) => void;
+  canSendDeferralNotice: () => boolean;
+};
+
+type TelegramLongTurnDeliveryStateParams = {
+  runId: string;
+  agentId: string;
+  accountId: string;
+  sessionKey?: string;
+  chatId: string;
+  threadId?: number;
+};
+
+export function createTelegramLongTurnDeliveryState(
+  params: TelegramLongTurnDeliveryStateParams,
+): TelegramLongTurnDeliveryState {
+  let deferred = false;
+  let deferralNoticePending = false;
+  let finalDeliveryStarted = false;
+  let canSendDeferralNotice = () => true;
+  let resolveDeferralNotice: (() => void) | undefined;
+  const deferralPendingListeners = new Set<() => void>();
+  const deferralNoticeSettled = new Promise<void>((resolve) => {
+    resolveDeferralNotice = resolve;
+  });
+  return {
+    ...params,
+    markDeferralPending: () => {
+      deferred = true;
+      deferralNoticePending = true;
+      for (const listener of deferralPendingListeners) {
+        listener();
+      }
+    },
+    markDeferred: () => {
+      deferred = true;
+      deferralNoticePending = false;
+      resolveDeferralNotice?.();
+    },
+    isDeferred: () => deferred,
+    onDeferralPending: (listener) => {
+      if (deferred) {
+        listener();
+        return () => {};
+      }
+      deferralPendingListeners.add(listener);
+      return () => {
+        deferralPendingListeners.delete(listener);
+      };
+    },
+    waitForDeferralNotice: async () => {
+      if (deferralNoticePending) {
+        await deferralNoticeSettled;
+      }
+    },
+    markFinalDeliveryStarted: () => {
+      finalDeliveryStarted = true;
+    },
+    hasFinalDeliveryStarted: () => finalDeliveryStarted,
+    setCanSendDeferralNotice: (check) => {
+      canSendDeferralNotice = check;
+    },
+    canSendDeferralNotice: () => canSendDeferralNotice(),
+  };
+}
+
+export function buildTelegramLongTurnDeferralText(params: { runId: string }): string {
+  return `Still working on this. I will reply here when the run completes.\n\nRun: ${params.runId}`;
+}
+
+export function buildTelegramDeferredRunFailureText(params: {
+  runId: string;
+  agentId: string;
+  sessionKey?: string;
+  target: string;
+}): string {
+  return buildDeferredRunSummary({
+    title: "The deferred run did not complete successfully.",
+    runId: params.runId,
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+    target: params.target,
+  });
+}
+
+export function buildTelegramDeferredRunEmptyResponseText(params: {
+  runId: string;
+  agentId: string;
+  sessionKey?: string;
+  target: string;
+}): string {
+  return buildDeferredRunSummary({
+    title: "The deferred run finished, but no final response was delivered.",
+    runId: params.runId,
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+    target: params.target,
+  });
+}
+
+export function buildTelegramDeferredRunSilentCompletionText(params: {
+  runId: string;
+  agentId: string;
+  sessionKey?: string;
+  target: string;
+}): string {
+  return buildDeferredRunSummary({
+    title: "The deferred run completed without sending a visible reply.",
+    runId: params.runId,
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+    target: params.target,
+  });
+}
+
+export function formatTelegramDeferredRunTarget(params: {
+  chatId: string | number;
+  threadId?: number;
+}): string {
+  return params.threadId == null
+    ? `telegram:${params.chatId}`
+    : `telegram:${params.chatId}/${params.threadId}`;
+}
+
+function buildDeferredRunSummary(params: {
+  title: string;
+  runId: string;
+  agentId: string;
+  sessionKey?: string;
+  target: string;
+}): string {
+  const lines = [
+    params.title,
+    "",
+    `Run: ${params.runId}`,
+    `Agent: ${params.agentId}`,
+    params.sessionKey ? `Session: ${params.sessionKey}` : undefined,
+    `Target: ${params.target}`,
+  ];
+  return lines.filter((line): line is string => line != null).join("\n");
+}

--- a/extensions/telegram/src/telegram-reply-fence.test.ts
+++ b/extensions/telegram/src/telegram-reply-fence.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   beginTelegramReplyFence,
   buildTelegramNonInterruptingReplyFenceKey,
+  protectTelegramReplyFenceAbortControllerFromNormalSupersede,
   resetTelegramReplyFenceForTests,
   shouldSupersedeTelegramReplyFence,
   supersedeTelegramReplyFence,
@@ -132,6 +133,66 @@ describe("telegram reply fence supersede", () => {
     expect(supersedeTelegramReplyFence(activeKey)).toBe(true);
     expect(mainController.signal.aborted).toBe(true);
     expect(sideController.signal.aborted).toBe(true);
+    resetTelegramReplyFenceForTests();
+  });
+
+  it("protects deferred controllers from normal supersede but not explicit aborts", () => {
+    resetTelegramReplyFenceForTests();
+    const activeKey = "agent:main:telegram:direct:123";
+    const deferredController = new AbortController();
+    const nextController = new AbortController();
+    beginTelegramReplyFence({
+      key: activeKey,
+      supersede: true,
+      abortController: deferredController,
+    });
+    protectTelegramReplyFenceAbortControllerFromNormalSupersede(activeKey, deferredController);
+
+    beginTelegramReplyFence({
+      key: activeKey,
+      supersede: true,
+      supersedeMode: "normal",
+      abortController: nextController,
+    });
+
+    expect(deferredController.signal.aborted).toBe(false);
+    expect(nextController.signal.aborted).toBe(false);
+
+    expect(supersedeTelegramReplyFence(activeKey)).toBe(true);
+    expect(deferredController.signal.aborted).toBe(true);
+    expect(nextController.signal.aborted).toBe(true);
+    resetTelegramReplyFenceForTests();
+  });
+
+  it("protects deferred child controllers from normal base supersede", () => {
+    resetTelegramReplyFenceForTests();
+    const activeKey = "agent:main:telegram:group:-100123";
+    const childKey = buildTelegramNonInterruptingReplyFenceKey({
+      activeKey,
+      laneKey: "default\0telegram:-100123:btw:100",
+    });
+    const deferredController = new AbortController();
+    const nextController = new AbortController();
+    beginTelegramReplyFence({
+      key: childKey,
+      supersede: false,
+      abortController: deferredController,
+    });
+    protectTelegramReplyFenceAbortControllerFromNormalSupersede(childKey, deferredController);
+
+    beginTelegramReplyFence({
+      key: activeKey,
+      supersede: true,
+      supersedeMode: "normal",
+      abortController: nextController,
+    });
+
+    expect(deferredController.signal.aborted).toBe(false);
+    expect(nextController.signal.aborted).toBe(false);
+
+    expect(supersedeTelegramReplyFence(activeKey)).toBe(true);
+    expect(deferredController.signal.aborted).toBe(true);
+    expect(nextController.signal.aborted).toBe(true);
     resetTelegramReplyFenceForTests();
   });
 });

--- a/extensions/telegram/src/telegram-reply-fence.ts
+++ b/extensions/telegram/src/telegram-reply-fence.ts
@@ -16,8 +16,11 @@ type TelegramReplyFenceState = {
   generation: number;
   activeDispatches: number;
   abortControllers?: Set<AbortController>;
+  normalSupersedeProtectedControllers?: Set<AbortController>;
   laneKeys?: Set<string>;
 };
+
+type TelegramReplyFenceSupersedeMode = "normal" | "abort";
 
 export type TelegramReplyFenceKey = {
   activeKey: string;
@@ -70,11 +73,22 @@ export function resolveTelegramReplyFenceKey(params: {
   };
 }
 
-function abortTelegramReplyFenceControllers(state: TelegramReplyFenceState): void {
+function abortTelegramReplyFenceControllers(
+  state: TelegramReplyFenceState,
+  mode: TelegramReplyFenceSupersedeMode,
+): void {
   for (const controller of state.abortControllers ?? []) {
+    if (mode === "normal" && state.normalSupersedeProtectedControllers?.has(controller)) {
+      continue;
+    }
     controller.abort();
+    state.abortControllers?.delete(controller);
+    state.normalSupersedeProtectedControllers?.delete(controller);
   }
-  state.abortControllers?.clear();
+  if (mode === "abort") {
+    state.abortControllers?.clear();
+    state.normalSupersedeProtectedControllers?.clear();
+  }
 }
 
 function deleteTelegramReplyFenceState(key: string, state: TelegramReplyFenceState): void {
@@ -99,6 +113,7 @@ function maybeDeleteTelegramReplyFenceState(key: string, state: TelegramReplyFen
 export function beginTelegramReplyFence(params: {
   key: string;
   supersede: boolean;
+  supersedeMode?: TelegramReplyFenceSupersedeMode;
   abortController?: AbortController;
   laneKey?: string;
 }): number {
@@ -108,9 +123,10 @@ export function beginTelegramReplyFence(params: {
     activeDispatches: 0,
   };
   if (params.supersede) {
+    const supersedeMode = params.supersedeMode ?? "abort";
     state.generation += 1;
-    abortTelegramReplyFenceControllers(state);
-    supersedeTelegramNonInterruptingReplyFenceChildren(params.key);
+    abortTelegramReplyFenceControllers(state, supersedeMode);
+    supersedeTelegramNonInterruptingReplyFenceChildren(params.key, supersedeMode);
   }
   if (params.abortController) {
     (state.abortControllers ??= new Set()).add(params.abortController);
@@ -127,31 +143,37 @@ export function beginTelegramReplyFence(params: {
   return state.generation;
 }
 
-function supersedeTelegramReplyFenceState(key: string): boolean {
+function supersedeTelegramReplyFenceState(
+  key: string,
+  mode: TelegramReplyFenceSupersedeMode,
+): boolean {
   const state = telegramReplyFenceByKey.get(key);
   if (!state) {
     return false;
   }
   state.generation += 1;
-  abortTelegramReplyFenceControllers(state);
+  abortTelegramReplyFenceControllers(state, mode);
   maybeDeleteTelegramReplyFenceState(key, state);
   return true;
 }
 
-function supersedeTelegramNonInterruptingReplyFenceChildren(key: string): boolean {
+function supersedeTelegramNonInterruptingReplyFenceChildren(
+  key: string,
+  mode: TelegramReplyFenceSupersedeMode,
+): boolean {
   let superseded = false;
   const childPrefix = buildTelegramNonInterruptingReplyFenceKeyPrefix(key);
   for (const childKey of telegramReplyFenceByKey.keys()) {
     if (childKey.startsWith(childPrefix)) {
-      superseded = supersedeTelegramReplyFenceState(childKey) || superseded;
+      superseded = supersedeTelegramReplyFenceState(childKey, mode) || superseded;
     }
   }
   return superseded;
 }
 
 export function supersedeTelegramReplyFence(key: string): boolean {
-  let superseded = supersedeTelegramReplyFenceState(key);
-  superseded = supersedeTelegramNonInterruptingReplyFenceChildren(key) || superseded;
+  let superseded = supersedeTelegramReplyFenceState(key, "abort");
+  superseded = supersedeTelegramNonInterruptingReplyFenceChildren(key, "abort") || superseded;
   return superseded;
 }
 
@@ -178,6 +200,7 @@ export function endTelegramReplyFence(key: string, abortController?: AbortContro
   }
   if (abortController) {
     state.abortControllers?.delete(abortController);
+    state.normalSupersedeProtectedControllers?.delete(abortController);
   }
   state.activeDispatches = Math.max(0, state.activeDispatches - 1);
   maybeDeleteTelegramReplyFenceState(key, state);
@@ -195,11 +218,57 @@ export function releaseTelegramReplyFenceAbortController(
     return;
   }
   state.abortControllers?.delete(abortController);
+  state.normalSupersedeProtectedControllers?.delete(abortController);
   maybeDeleteTelegramReplyFenceState(key, state);
 }
 
 function isRecognizedTelegramTextCommand(rawText: string): boolean {
   return maybeResolveTextAlias(normalizeCommandBody(rawText)) != null;
+}
+
+export function protectTelegramReplyFenceAbortControllerFromNormalSupersede(
+  key: string,
+  abortController?: AbortController,
+): void {
+  if (!abortController) {
+    return;
+  }
+  const state = telegramReplyFenceByKey.get(key);
+  if (!state?.abortControllers?.has(abortController)) {
+    return;
+  }
+  (state.normalSupersedeProtectedControllers ??= new Set()).add(abortController);
+}
+
+export function resolveTelegramReplyFenceSupersedeMode(ctxPayload: {
+  Body?: string;
+  ChatType?: string;
+  RawBody?: string;
+  CommandBody?: string;
+  CommandAuthorized: boolean;
+  CommandTurn?: CommandTurnContext;
+}): TelegramReplyFenceSupersedeMode | "none" {
+  const dispatchText = ctxPayload.CommandBody ?? ctxPayload.RawBody ?? ctxPayload.Body ?? "";
+  if (isAbortRequestText(dispatchText)) {
+    return ctxPayload.CommandAuthorized ? "abort" : "none";
+  }
+  if (
+    isBtwRequestText(dispatchText) ||
+    isTelegramReadOnlyControlLaneText({ rawText: dispatchText })
+  ) {
+    return "none";
+  }
+  if (ctxPayload.ChatType === "direct") {
+    if (
+      ctxPayload.CommandAuthorized &&
+      (isExplicitCommandTurn(ctxPayload.CommandTurn) ||
+        isRecognizedTelegramTextCommand(dispatchText))
+    ) {
+      return "normal";
+    }
+    return "none";
+  }
+  return "normal";
 }
 
 export function shouldSupersedeTelegramReplyFence(ctxPayload: {
@@ -210,27 +279,7 @@ export function shouldSupersedeTelegramReplyFence(ctxPayload: {
   CommandAuthorized: boolean;
   CommandTurn?: CommandTurnContext;
 }): boolean {
-  const dispatchText = ctxPayload.CommandBody ?? ctxPayload.RawBody ?? ctxPayload.Body ?? "";
-  if (isAbortRequestText(dispatchText)) {
-    return ctxPayload.CommandAuthorized;
-  }
-  if (
-    isBtwRequestText(dispatchText) ||
-    isTelegramReadOnlyControlLaneText({ rawText: dispatchText })
-  ) {
-    return false;
-  }
-  if (ctxPayload.ChatType === "direct") {
-    if (
-      ctxPayload.CommandAuthorized &&
-      (isExplicitCommandTurn(ctxPayload.CommandTurn) ||
-        isRecognizedTelegramTextCommand(dispatchText))
-    ) {
-      return true;
-    }
-    return false;
-  }
-  return true;
+  return resolveTelegramReplyFenceSupersedeMode(ctxPayload) !== "none";
 }
 
 export function getTelegramReplyFenceSizeForTests(): number {

--- a/src/auto-reply/dispatch.freshness.test.ts
+++ b/src/auto-reply/dispatch.freshness.test.ts
@@ -21,6 +21,19 @@ vi.mock("./reply/dispatch-from-config.js", () => ({
 }));
 
 const { dispatchInboundMessageWithBufferedDispatcher } = await import("./dispatch.js");
+const INTERNAL_FOREGROUND_REPLY_FRESHNESS_POLICY_KEY = Symbol.for(
+  "openclaw.internal.foregroundReplyFreshnessPolicy",
+);
+
+type BufferedReplyOptions = NonNullable<
+  Parameters<typeof dispatchInboundMessageWithBufferedDispatcher>[0]["replyOptions"]
+>;
+
+type BufferedReplyOptionsWithInternalFreshness = BufferedReplyOptions & {
+  [INTERNAL_FOREGROUND_REPLY_FRESHNESS_POLICY_KEY]?: {
+    allowSupersededDelivery?: () => boolean;
+  };
+};
 
 type Delivery = {
   kind: "tool" | "block" | "final";
@@ -134,6 +147,63 @@ describe("foreground reply freshness", () => {
       counts: { tool: 0, block: 0, final: 0 },
     });
     expect(deliveries).toEqual([{ kind: "final", text: "new final" }]);
+  });
+
+  it("allows protected older foreground finals after a newer inbound event starts", async () => {
+    const deliveries: Delivery[] = [];
+    const olderStarted = createDeferred<void>();
+    const releaseOlderFinal = createDeferred<void>();
+
+    hoisted.dispatchReplyFromConfigMock.mockImplementation(
+      async (params: DispatchReplyFromConfigParams) => {
+        if (params.ctx.MessageSid === "old-message") {
+          olderStarted.resolve();
+          await releaseOlderFinal.promise;
+          params.dispatcher.sendFinalReply({ text: "old final" });
+          return queuedFinalResult();
+        }
+        if (params.ctx.MessageSid === "new-message") {
+          params.dispatcher.sendFinalReply({ text: "new final" });
+          return queuedFinalResult();
+        }
+        throw new Error(`unexpected test message ${params.ctx.MessageSid ?? "<missing>"}`);
+      },
+    );
+
+    const protectedReplyOptions = {
+      runId: "old-message",
+      [INTERNAL_FOREGROUND_REPLY_FRESHNESS_POLICY_KEY]: {
+        allowSupersededDelivery: () => true,
+      },
+    } satisfies BufferedReplyOptionsWithInternalFreshness;
+    const olderDispatch = dispatchInboundMessageWithBufferedDispatcher({
+      ctx: buildForegroundCtx({ MessageSid: "old-message" }),
+      cfg: {} as OpenClawConfig,
+      dispatcherOptions: {
+        deliver: async (payload: ReplyPayload, info: { kind: Delivery["kind"] }) => {
+          deliveries.push({ kind: info.kind, text: payload.text });
+        },
+      },
+      replyOptions: protectedReplyOptions,
+    });
+    await olderStarted.promise;
+
+    await expect(
+      dispatchWithDeliveries(buildForegroundCtx({ MessageSid: "new-message" }), deliveries),
+    ).resolves.toEqual({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+    });
+
+    releaseOlderFinal.resolve();
+    await expect(olderDispatch).resolves.toEqual({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+    });
+    expect(deliveries).toEqual([
+      { kind: "final", text: "new final" },
+      { kind: "final", text: "old final" },
+    ]);
   });
 
   it("keeps an older foreground final when a newer inbound has no visible delivery while beforeDeliver is pending", async () => {

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -48,6 +48,17 @@ type ForegroundReplyFenceSnapshot = {
 };
 
 const foregroundReplyFenceByKey = new Map<string, ForegroundReplyFenceState>();
+const INTERNAL_FOREGROUND_REPLY_FRESHNESS_POLICY_KEY = Symbol.for(
+  "openclaw.internal.foregroundReplyFreshnessPolicy",
+);
+
+type ForegroundReplyFreshnessPolicy = {
+  allowSupersededDelivery?: () => boolean;
+};
+
+type ReplyOptionsWithInternalForegroundFreshness = Omit<GetReplyOptions, "onBlockReply"> & {
+  [INTERNAL_FOREGROUND_REPLY_FRESHNESS_POLICY_KEY]?: ForegroundReplyFreshnessPolicy;
+};
 
 function normalizeForegroundReplyFencePart(value: unknown): string | undefined {
   if (typeof value !== "string") {
@@ -231,6 +242,34 @@ async function runForegroundReplyFenceSettledDelivery(
     }
     throw err;
   }
+}
+
+function allowsSupersededForegroundDelivery(
+  policy: ForegroundReplyFreshnessPolicy | undefined,
+): boolean {
+  try {
+    return policy?.allowSupersededDelivery?.() === true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveForegroundReplyFreshnessPolicy(
+  replyOptions: Omit<GetReplyOptions, "onBlockReply"> | undefined,
+): ForegroundReplyFreshnessPolicy | undefined {
+  return (replyOptions as ReplyOptionsWithInternalForegroundFreshness | undefined)?.[
+    INTERNAL_FOREGROUND_REPLY_FRESHNESS_POLICY_KEY
+  ];
+}
+
+async function shouldCancelForegroundDelivery(params: {
+  snapshot: ForegroundReplyFenceSnapshot | undefined;
+  policy: ForegroundReplyFreshnessPolicy | undefined;
+}): Promise<boolean> {
+  if (allowsSupersededForegroundDelivery(params.policy)) {
+    return false;
+  }
+  return await shouldCancelForegroundReplyDelivery(params.snapshot);
 }
 
 function endForegroundReplyFence(snapshot: ForegroundReplyFenceSnapshot): void {
@@ -439,7 +478,12 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
   const beforeDeliver: ReplyDispatchBeforeDeliver | undefined =
     foregroundReplyFence || configuredBeforeDeliver
       ? async (payload, info) => {
-          if (await shouldCancelForegroundReplyDelivery(foregroundReplyFence)) {
+          if (
+            await shouldCancelForegroundDelivery({
+              snapshot: foregroundReplyFence,
+              policy: resolveForegroundReplyFreshnessPolicy(params.replyOptions),
+            })
+          ) {
             return null;
           }
           const deliverPayload = configuredBeforeDeliver
@@ -447,7 +491,10 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
             : payload;
           if (
             !deliverPayload ||
-            (await shouldCancelForegroundReplyDelivery(foregroundReplyFence))
+            (await shouldCancelForegroundDelivery({
+              snapshot: foregroundReplyFence,
+              policy: resolveForegroundReplyFreshnessPolicy(params.replyOptions),
+            }))
           ) {
             return null;
           }

--- a/src/plugin-activation-boundary.test.ts
+++ b/src/plugin-activation-boundary.test.ts
@@ -19,44 +19,46 @@ const loadBundledPluginPublicSurfaceModuleSync = vi.hoisted(() =>
   }),
 );
 
+const manifestPlugins = vi.hoisted(() => [
+  {
+    id: "test-channel-fixture",
+    channels: ["discord", "irc", "slack", "telegram"],
+    providers: [],
+    cliBackends: [],
+    channelEnvVars: {
+      discord: ["DISCORD_BOT_TOKEN"],
+      irc: ["IRC_HOST", "IRC_NICK"],
+      slack: ["SLACK_BOT_TOKEN"],
+      telegram: ["TELEGRAM_BOT_TOKEN"],
+    },
+    modelIdNormalization: {
+      providers: {
+        google: {
+          aliases: {
+            "gemini-3.1-pro": "gemini-3.1-pro-preview",
+            "gemini-3-pro-preview": "gemini-3.1-pro-preview",
+          },
+        },
+        xai: {
+          aliases: {
+            "grok-4-fast-reasoning": "grok-4-fast",
+          },
+        },
+      },
+    },
+    skills: [],
+    hooks: [],
+    origin: "bundled",
+    rootDir: "/tmp/openclaw-test-channel-fixture",
+    source: "bundled",
+    manifestPath: "/tmp/openclaw-test-channel-fixture/openclaw.plugin.json",
+  },
+]);
+
 const loadPluginManifestRegistryForPluginRegistry = vi.hoisted(() =>
   vi.fn(() => ({
     diagnostics: [],
-    plugins: [
-      {
-        id: "test-channel-fixture",
-        channels: ["discord", "irc", "slack", "telegram"],
-        providers: [],
-        cliBackends: [],
-        channelEnvVars: {
-          discord: ["DISCORD_BOT_TOKEN"],
-          irc: ["IRC_HOST", "IRC_NICK"],
-          slack: ["SLACK_BOT_TOKEN"],
-          telegram: ["TELEGRAM_BOT_TOKEN"],
-        },
-        modelIdNormalization: {
-          providers: {
-            google: {
-              aliases: {
-                "gemini-3.1-pro": "gemini-3.1-pro-preview",
-                "gemini-3-pro-preview": "gemini-3.1-pro-preview",
-              },
-            },
-            xai: {
-              aliases: {
-                "grok-4-fast-reasoning": "grok-4-fast",
-              },
-            },
-          },
-        },
-        skills: [],
-        hooks: [],
-        origin: "bundled",
-        rootDir: "/tmp/openclaw-test-channel-fixture",
-        source: "bundled",
-        manifestPath: "/tmp/openclaw-test-channel-fixture/openclaw.plugin.json",
-      },
-    ],
+    plugins: manifestPlugins,
   })),
 );
 


### PR DESCRIPTION
## Summary

- Problem: Telegram direct-message turns that run past the inbound handler deadline can leave the user without a durable final/failure response, and older foreground reply freshness can cancel valid deferred finals.
- Solution: Add explicit Telegram long-turn delivery state that sends a soft-deadline deferral, lets the run continue in the background, and delivers a terminal final/failure/silent-completion message back to the same chat/thread.
- What changed: Telegram dispatch gates deferral notices, protects deferred reply fences from ordinary supersedes, still honors explicit aborts, and uses a private internal foreground-freshness symbol so deferred finals can survive shared reply suppression without exposing a public SDK option.
- CI parity: The plugin activation boundary fixture now passes its manifest model-normalization policy directly into static normalization, matching the current pruned model catalog behavior without loading plugin runtime.
- CI stabilization: The gateway reload fixture no longer depends on caller-provided `OPENAI_API_KEY`, and the active-work timeout test now exercises the configured short timeout with real async timing instead of fake timers.
- Scope boundary: Group turns are not deferred in this PR, so existing group silence/NO_REPLY behavior stays intact; /status, /abort command UX, dedupe, and live Telegram proof remain follow-up work.

## Motivation

This is PR B from the upstream reliability handoff for OPS-0pgd, after replay-invalid recovery in #85362. It closes the direct Telegram long-turn delivery gap before the later auth-profile, config-overlay, and observability PRs.

## Linked Issue/PR

- Related #85362
- Related OPS-0pgd

## Real behavior proof (required for external PRs)

- Behavior addressed: Telegram direct-message turns that exceed the soft deadline now send a run-id deferral, continue dispatch outside the inbound handler, and resolve the visible deferral with a terminal final, failure, or silent-completion message unless explicitly aborted.
- Real environment tested: Local macOS source checkout, real Telegram burner user DM to a dedicated SUT bot, isolated Telegram Desktop burner profile recording, OpenClaw gateway on this PR head `3336ca0cb61dbdb2757024193e0a987ecd3eea6c`, and a local mock OpenAI Responses server with a 35s response delay. Node v26.0.0, pnpm 11.2.2.
- Exact steps or command run after this patch: Started `scripts/e2e/mock-openai-server.mjs` with `MOCK_RESPONSE_DELAY_MS=35000` and `SUCCESS_MARKER=LONG-TURN-PROOF-85749-DONE`; started `pnpm openclaw gateway --port 19879` with the Telegram bot token from environment and a DM allowlist for the burner user; sent one real Telegram DM via `python3 scripts/e2e/telegram-user-driver.py send --text "PR #85749 long-turn proof. Reply with exactly LONG-TURN-PROOF-85749-DONE."`; waited with `telegram-user-driver.py wait` for `Still working on this...` and `LONG-TURN-PROOF-85749-DONE`; recorded Telegram Desktop and clipped the recording to the proof window. Also ran `git diff --check origin/main...HEAD`; `node scripts/run-vitest.mjs extensions/telegram/src/bot-message.test.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/telegram-reply-fence.test.ts src/auto-reply/dispatch.freshness.test.ts src/plugin-activation-boundary.test.ts src/gateway/server.reload.test.ts`; four `node scripts/run-tsgo.mjs ...` graphs for core, extensions, core tests, and extension tests; and `pnpm run lint --threads=8`.
- Evidence after fix: The real Telegram Desktop recording shows the burner user DM, the bot posting `Still working on this. I will reply here when the run completes.` with run id `4cd8cc77-0d4a-4b2d-a918-66a9bbc765b0`, then the bot posting `LONG-TURN-PROOF-85749-DONE` in the same DM. The local proof transcript observed both bot messages, and the mock OpenAI request log recorded one `/v1/responses` request.

Clipped real-time proof (~33s GIF):

![Telegram long-turn clipped proof](https://raw.githubusercontent.com/dredozubov/openclaw/51256ec07985dc6fea79654840d0b0ec7aa77219/pr-85749/openclaw-pr-85749-telegram-proof-clipped.gif)

Fast proof from the clipped recording (~11s GIF):

![Telegram long-turn fast proof](https://raw.githubusercontent.com/dredozubov/openclaw/51256ec07985dc6fea79654840d0b0ec7aa77219/pr-85749/openclaw-pr-85749-telegram-proof-fast.gif)

Artifact commit: `dredozubov/openclaw@51256ec07985dc6fea79654840d0b0ec7aa77219`.

Local artifact checksums:

```text
30451c4bd1509b6f8ad28bbadbd4aa82ab6bffb95e8d84cff8a9d8f56ab5ce97  telegram-proof-clipped.gif
9a31a67bc46aecfeeb68cc8cdad5a8c8770c868f29edd7de060d762c89b9ae82  telegram-proof-clipped-fast.gif
```

Focused regression output:

```text
Test Files  6 passed (6)
      Tests  140 passed (140)
   Start at  09:36:04
   Duration  30.84s (transform 23.11s, setup 841ms, import 7.63s, tests 21.68s, environment 2ms)
```

Earlier targeted autoreview of the changed gateway fixture reported `autoreview clean: no accepted/actionable findings reported`; a final branch-mode autoreview attempt against the whole PR diff hung locally and was stopped before PR body update.
- Observed result after fix: The real Telegram DM shows deferred final delivery working end-to-end: the bot emits the visible long-turn deferral and later delivers the terminal marker in the same direct chat. Regression coverage also shows deferred direct turns wait for the deferral notice before final delivery, survive later ordinary same-session messages, still stop on explicit abort, release reply-fence state if fallback delivery throws, preserve group silence, and resolve deferred NO_REPLY completion with a terminal completion message instead of leaving the initial deferral hanging. The boundary test now proves static manifest normalization for the pruned xAI alias without activating plugin runtime. The gateway reload fixture now passes without `OPENAI_API_KEY` in the caller environment and no longer times out in the active-work timeout case reproduced from CI.
- What was not tested: Maintainer-only Mantis/Crabbox Telegram Desktop proof was not run because this GitHub account is not an active OpenClaw org member and Crabbox login is denied. The local proof above uses a real Telegram burner account and real Telegram Desktop with a delayed mock model server instead. Pre-submit broad remote `pnpm check:changed` was attempted but blocked locally: Blacksmith Testbox needed a missing `blacksmith` CLI, and direct AWS Crabbox failed because AWS SSO credentials were expired. PR CI should provide the broad Linux gate.
- Before evidence: Handoff OPS-0pgd documents the missing durable final delivery after the soft deadline; previous code returned from the inbound handler without a durable continuation/final-delivery contract for direct Telegram turns.

## Root Cause

- Root cause: Telegram processing was bounded by the inbound handler lifecycle and reply-freshness fences that treated all older foreground replies as stale, with no explicit long-turn state tying a visible deferral to a later terminal delivery.
- Missing detection / guardrail: There were no Telegram tests for soft-deadline deferral ordering, deferred final freshness, abort-vs-normal supersede, fallback-send failures, or intentional silent completion after a deferral notice.
- Contributing context: Shared foreground freshness is correct for ordinary turns but needed an internal channel-owned escape hatch for already-deferred runs.

## Regression Test Plan

- Coverage level that should have caught this: unit and seam/integration coverage.
- Target tests: `extensions/telegram/src/bot-message.test.ts`, `extensions/telegram/src/bot-message-dispatch.test.ts`, `extensions/telegram/src/telegram-reply-fence.test.ts`, `src/auto-reply/dispatch.freshness.test.ts`, `src/plugin-activation-boundary.test.ts`, `src/gateway/server.reload.test.ts`.
- Scenario locked in: long direct turn defers after the soft deadline, final/failure/silent-completion arrives after the deferral notice, later ordinary messages do not cancel deferred finals, explicit aborts still cancel, groups remain silent, static manifest model normalization remains runtime-cold, and gateway reload tests provide their own fake OpenAI key.
- Why this is the smallest reliable guardrail: These files exercise the Telegram processor, dispatch delivery seam, Telegram reply-fence state, shared foreground freshness gate, plugin activation boundary, and the gateway reload fixture that failed CI, without needing live credentials.

## User-visible / Behavior Changes

Direct Telegram users can now see `Still working on this... Run: <id>` after a long turn exceeds the soft deadline. That visible deferral is followed by the eventual assistant response, a failure message with run/session/target context, or a terminal silent-completion message when the run intentionally produced no visible reply. Group chats keep existing non-deferred silence behavior.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Risks and Mitigations

- Risk: A visible deferral could be sent for a run that later intentionally produces no visible assistant reply. Mitigation: Once a deferral is visible, deferred silent completion now sends a terminal completion message instead of leaving the chat hanging.
- Risk: Deferred reply protection could accidentally ignore real aborts. Mitigation: Reply-fence tests cover ordinary supersede protection separately from explicit abort behavior.


