### PR TITLE
fix(telegram): honor explicit default account warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: normalize legacy durable group retry targets before retry sends, polls, and pins so group retries keep using the real chat id. (#85656) Thanks @luoyanglang.
 - Agents/PDF: route MiniMax PDF fallback policy through plugin metadata so MiniMax uses text extraction instead of VLM image fallback. (#85590, fixes #85575) Thanks @neeravmakwana.
 - CLI/plugins: tighten timeout, numeric option, media payload, permission, profile/TLS, plugin metadata, JSON, and remote URL handling; prevent stuck progress/app-server/IRC/Synology/Twitch waits; and keep imported chat history ordering stable.
+- Telegram/config: suppress the missing `accounts.default` warning when `channels.telegram.defaultAccount` names a configured account that also sorts first. Fixes #83948. Thanks @crypto86m.
 - WebChat: summarize internal message-tool source replies so tool cards no longer duplicate the visible reply body. (#84773) Thanks @jason-allen-oneal.
 - WebChat: scope the visible attachment button to its own composer file input so clicking Upload reliably opens the file picker. (#83952, fixes #47983) Thanks @jason-allen-oneal.
 - Gateway: preserve deferred lifecycle-error cleanup across later non-terminal events so provider timeouts can persist failed session state instead of leaving sessions stuck running. (#85256, fixes #63819) Thanks @samzong.

--- a/extensions/telegram/src/account-selection.ts
+++ b/extensions/telegram/src/account-selection.ts
@@ -129,16 +129,21 @@ export function resolveDefaultTelegramAccountSelection(cfg: OpenClawConfig): {
     };
   }
   const accountIds = listTelegramAccountIds(cfg);
+  const configuredDefaultAccountId =
+    normalizeOptionalAccountId(cfg.channels?.telegram?.defaultAccount) ?? undefined;
+  const hasExplicitDefaultAccount = configuredDefaultAccountId
+    ? accountIds.includes(configuredDefaultAccountId)
+    : false;
   const resolved = resolveListedDefaultAccountId({
     accountIds,
-    configuredDefaultAccountId:
-      normalizeOptionalAccountId(cfg.channels?.telegram?.defaultAccount) ?? undefined,
+    configuredDefaultAccountId,
   });
   return {
     accountId: resolved,
     accountIds,
     shouldWarnMissingDefault:
       resolved === accountIds[0] &&
+      !hasExplicitDefaultAccount &&
       !accountIds.includes(DEFAULT_ACCOUNT_ID) &&
       accountIds.length > 1,
   };

--- a/extensions/telegram/src/accounts.test.ts
+++ b/extensions/telegram/src/accounts.test.ts
@@ -227,6 +227,23 @@ describe("resolveDefaultTelegramAccountId", () => {
     expectNoMissingDefaultWarning();
   });
 
+  it("does not warn when explicit defaultAccount is first in multi-account fallback order (#83948)", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: {
+          defaultAccount: "alerts",
+          accounts: {
+            alerts: { botToken: "tok-alerts" },
+            work: { botToken: "tok-work" },
+          },
+        },
+      },
+    };
+
+    expect(resolveDefaultTelegramAccountId(cfg)).toBe("alerts");
+    expectNoMissingDefaultWarning();
+  });
+
   it("does not warn when only one non-default account is configured", () => {
     const cfg: OpenClawConfig = {
       channels: {


### PR DESCRIPTION
## Summary

- Fix Telegram default-account warning detection so a valid `channels.telegram.defaultAccount` suppresses the missing `accounts.default` warning even when that account sorts first.
- Add a regression test for the multi-account explicit-default case from #83948.
- Add a changelog entry.

Fixes #83948.

## Verification

2026-05-23 update after rebasing onto `origin/main` (`acf265d4d5`), head `71e68494c6`:

- `node scripts/run-vitest.mjs extensions/telegram/src/accounts.test.ts --reporter=verbose` (1 file, 34 tests passed)
- `./node_modules/.bin/oxfmt --check --threads=1 CHANGELOG.md extensions/telegram/src/account-selection.ts extensions/telegram/src/accounts.test.ts`
- `./node_modules/.bin/oxlint extensions/telegram/src/account-selection.ts extensions/telegram/src/accounts.test.ts`
- `git diff --check origin/main...HEAD`

Earlier verification before the rebase:

- `corepack pnpm install`
- `node_modules/.bin/oxfmt --check --threads=1 CHANGELOG.md extensions/telegram/src/account-selection.ts extensions/telegram/src/accounts.test.ts`
- `node_modules/.bin/oxlint extensions/telegram/src/account-selection.ts extensions/telegram/src/accounts.test.ts`
- `git diff --check origin/main...HEAD`
- `CI=1 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 node scripts/run-vitest.mjs extensions/telegram/src/accounts.test.ts`
- `/mnt/c/src/claws-hapi/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real Behavior Proof

Behavior addressed: `openclaw status`/Telegram account resolution no longer emits `channels.telegram: accounts.default is missing` when `channels.telegram.defaultAccount` names a configured account that also happens to be the first sorted account id.

Real environment tested: WSL Ubuntu-24.04 checkout at `/root/src/openclaw-85752`, Node/Vitest via repo wrapper.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/telegram/src/accounts.test.ts --reporter=verbose`

Evidence after fix: The regression `does not warn when explicit defaultAccount is first in multi-account fallback order (#83948)` constructs `defaultAccount: "alerts"` with `accounts.alerts` and `accounts.work`, resolves `alerts`, and asserts the missing-default warning is absent.

Observed result after fix: `extensions/telegram/src/accounts.test.ts` passed with 34 tests; focused static checks were clean.

What was not tested: I did not run a live Telegram gateway or real `openclaw status` against private Telegram credentials; the fixed branch is the account-selection/warning predicate exercised by the focused unit test.


---

2026-05-23 late update after rebasing onto `origin/main` (`40d36b5bbc`), head `16bc9c1afd`:

- `node scripts/run-vitest.mjs extensions/telegram/src/accounts.test.ts --reporter=dot` (1 file, 34 tests passed)
- `./node_modules/.bin/oxfmt --check --threads=1 CHANGELOG.md extensions/telegram/src/account-selection.ts extensions/telegram/src/accounts.test.ts`
- `./node_modules/.bin/oxlint extensions/telegram/src/account-selection.ts extensions/telegram/src/accounts.test.ts`
- `git diff --check origin/main...HEAD`
