### PR TITLE
feat: add retries field to HealthCheckRunContext for transient failure handling

### DIFF
--- a/src/flows/doctor-repair-flow.test.ts
+++ b/src/flows/doctor-repair-flow.test.ts
@@ -422,4 +422,101 @@ describe("runDoctorHealthRepairs", () => {
     expect(repairContexts[1]).toMatchObject({ dryRun: true, diff: true });
     expect(withDiff.diffs).toMatchObject([{ kind: "config", path: "gateway.mode" }]);
   });
+
+  it("retries transient failures and succeeds on later attempt", async () => {
+    const attemptCount = { value: 0 };
+    const runnable: RunnableHealthCheck = {
+      id: "test/retry-eventually-succeeds",
+      kind: "core",
+      description: "retry eventually succeeds",
+      async run(ctx) {
+        attemptCount.value++;
+        if (attemptCount.value < 3) {
+          throw new Error(`transient failure attempt ${attemptCount.value}`);
+        }
+        return {
+          findings: [],
+          config: { ...ctx.cfg, gateway: { ...ctx.cfg.gateway, mode: "local" } },
+          changes: ["Set gateway.mode to local."],
+        };
+      },
+    };
+    const checks: HealthCheck[] = [normalizeHealthCheck(runnable)];
+
+    // Pass retries=2 via ctx — runDoctorHealthRepairs passes ctx directly to runRunnableHealthCheck
+    const ctxWithRetries: HealthRepairContext = {
+      mode: "fix",
+      runtime: { log() {}, error() {}, exit() {} },
+      cfg: {},
+      retries: 2,
+    };
+
+    const result = await runDoctorHealthRepairs(ctxWithRetries, { checks });
+
+    // Should have retried 2 times then succeeded on 3rd attempt.
+    // The 4th call is the post-repair validation check.
+    expect(attemptCount.value).toBe(4);
+    expect(result.config.gateway?.mode).toBe("local");
+    expect(result.changes).toEqual(["Set gateway.mode to local."]);
+    expect(result.checksRepaired).toBe(1);
+    expect(result.warnings).toEqual([]);
+    // Validation ran after successful repair
+    expect(result.checksValidated).toBe(1);
+  });
+
+  it("fails without retry when retries is 0", async () => {
+    const attemptCount = { value: 0 };
+    const runnable: RunnableHealthCheck = {
+      id: "test/no-retry",
+      kind: "core",
+      description: "no retry",
+      async run(ctx) {
+        attemptCount.value++;
+        throw new Error("always fails");
+      },
+    };
+    const checks: HealthCheck[] = [normalizeHealthCheck(runnable)];
+
+    const ctxNoRetries: HealthRepairContext = {
+      mode: "fix",
+      runtime: { log() {}, error() {}, exit() {} },
+      cfg: {},
+      retries: 0,
+    };
+
+    const result = await runDoctorHealthRepairs(ctxNoRetries, { checks });
+
+    expect(attemptCount.value).toBe(1);
+    expect(result.warnings).toContain("test/no-retry run failed after 1 attempts: always fails");
+    expect(result.checksRepaired).toBe(0);
+  });
+
+  it("exhausts retries and reports failure after all attempts fail", async () => {
+    const attemptCount = { value: 0 };
+    const runnable: RunnableHealthCheck = {
+      id: "test/exhausts-retries",
+      kind: "core",
+      description: "exhausts retries",
+      async run(ctx) {
+        attemptCount.value++;
+        throw new Error(`failure attempt ${attemptCount.value}`);
+      },
+    };
+    const checks: HealthCheck[] = [normalizeHealthCheck(runnable)];
+
+    const ctxWithRetries: HealthRepairContext = {
+      mode: "fix",
+      runtime: { log() {}, error() {}, exit() {} },
+      cfg: {},
+      retries: 2, // 1 initial + 2 retries = 3 total attempts
+    };
+
+    const result = await runDoctorHealthRepairs(ctxWithRetries, { checks });
+
+    expect(attemptCount.value).toBe(3);
+    expect(result.warnings).toContain(
+      "test/exhausts-retries run failed after 3 attempts: failure attempt 3",
+    );
+    expect(result.checksRepaired).toBe(0);
+  });
 });

--- a/src/flows/doctor-repair-flow.ts
+++ b/src/flows/doctor-repair-flow.ts
@@ -176,40 +176,63 @@ async function runRunnableHealthCheck(
   let checksRepaired = 0;
   let checksValidated = 0;
 
-  let result: HealthCheckRunResult;
-  try {
-    result = await check.run({
-      ...ctx,
-      repair: opts.dryRun !== true,
-      diff: opts.diff === true,
-      previewRepair: opts.dryRun === true,
-    });
-  } catch (err) {
-    warnings.push(`${check.id} run failed: ${scrubDoctorErrorMessage(err)}`);
+  const maxAttempts = (ctx.retries ?? 0) + 1; // 1 initial + retries
+  let lastError: unknown;
+  let result: HealthCheckRunResult | undefined;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    if (attempt > 0) {
+      // Exponential backoff: 100ms * attempt (1st retry=100ms, 2nd=200ms, etc.)
+      await new Promise((resolve) => setTimeout(resolve, 100 * attempt));
+    }
+    try {
+      result = await check.run({
+        ...ctx,
+        repair: opts.dryRun !== true,
+        diff: opts.diff === true,
+        previewRepair: opts.dryRun === true,
+        retries: opts.retries ?? 0,
+      });
+      lastError = undefined;
+      break; // Success, exit retry loop
+    } catch (err) {
+      lastError = err;
+      const isLastAttempt = attempt === maxAttempts - 1;
+      if (isLastAttempt) {
+        warnings.push(
+          `${check.id} run failed after ${maxAttempts} attempts: ${scrubDoctorErrorMessage(err)}`,
+        );
+      }
+      // Otherwise, retry
+    }
+  }
+
+  if (lastError !== undefined && result === undefined) {
     return repairRunResult(ctx.cfg, findings, remainingFindings, changes, warnings, diffs, effects);
   }
 
-  findings.push(...(result.findings ?? []));
-  warnings.push(...(result.warnings ?? []));
-  diffs.push(...(result.diffs ?? []));
-  effects.push(...(result.effects ?? []));
-  const status = result.status ?? "repaired";
-  const hasRepairOutput = hasHealthRepairOutput(result);
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  findings.push(...(result!.findings ?? []));
+  warnings.push(...(result!.warnings ?? []));
+  diffs.push(...(result!.diffs ?? []));
+  effects.push(...(result!.effects ?? []));
+  const status = result!.status ?? "repaired";
+  const hasRepairOutput = hasHealthRepairOutput(result!);
   if (status === "repairable") {
-    changes.push(...(result.changes ?? []));
+    changes.push(...(result!.changes ?? []));
     return repairRunResult(cfg, findings, remainingFindings, changes, warnings, diffs, effects, {
       checksRepaired: hasRepairOutput ? 1 : 0,
       checksValidated,
     });
   }
   if (status !== "repaired") {
-    warnings.push(`${check.id} repair ${status}${result.reason ? `: ${result.reason}` : ""}`);
+    warnings.push(`${check.id} repair ${status}${result!.reason ? `: ${result!.reason}` : ""}`);
     return repairRunResult(ctx.cfg, findings, remainingFindings, changes, warnings, diffs, effects);
   }
-  if (result.config !== undefined && opts.dryRun !== true) {
-    cfg = result.config;
+  if (result!.config !== undefined && opts.dryRun !== true) {
+    cfg = result!.config;
   }
-  changes.push(...(result.changes ?? []));
+  changes.push(...(result!.changes ?? []));
   if (hasRepairOutput) {
     checksRepaired++;
   }

--- a/src/flows/health-check-runner-types.ts
+++ b/src/flows/health-check-runner-types.ts
@@ -12,6 +12,8 @@ export interface HealthCheckRunContext extends HealthCheckContext {
   readonly repair: boolean;
   readonly diff?: boolean;
   readonly previewRepair?: boolean;
+  /** Number of retry attempts for transient failures (default: 0) */
+  readonly retries?: number;
 }
 
 export interface HealthCheckRunResult extends Omit<HealthRepairResult, "changes" | "status"> {

--- a/src/flows/health-checks.ts
+++ b/src/flows/health-checks.ts
@@ -55,6 +55,8 @@ export interface HealthRepairContext extends Omit<HealthCheckContext, "mode"> {
   readonly mode: "fix";
   readonly dryRun?: boolean;
   readonly diff?: boolean;
+  /** Number of retry attempts for transient failures (default: 0) */
+  readonly retries?: number;
 }
 
 export interface HealthRepairDiff {


### PR DESCRIPTION
## Summary
- Added `retries?: number` field to `HealthCheckRunContext` interface
- Implemented retry loop in `runRunnableHealthCheck` with exponential backoff (100ms × attempt)
- Add `retries` field to `HealthRepairContext` interface
- Full test coverage for retry behavior (3 new tests)

## Problem
Transient failures in health checks (network timeouts, temporary file locks) would immediately fail without retry opportunities. The original PR only added the type field without wiring up actual retry behavior.

## Solution
Implements retry logic in `doctor-repair-flow.ts`:

1. **Retry loop** — `runRunnableHealthCheck` now loops up to `maxAttempts = (ctx.retries ?? 0) + 1` attempts on `check.run()` failures
2. **Exponential backoff** — `100ms * attempt` delay between retries (1st retry: 100ms, 2nd: 200ms)
3. **Failure reporting** — final failure message reports total attempts: `"<check.id> run failed after <N> attempts: <error>"`
4. **Context wiring** — `retries` passed through from `HealthRepairContext` into `HealthCheckRunContext`

## Files Changed
- `src/flows/doctor-repair-flow.ts` — retry loop + backoff around `check.run()`
- `src/flows/health-checks.ts` — `retries` field added to `HealthRepairContext`
- `src/flows/health-check-runner-types.ts` — existing `retries` field on `HealthCheckRunContext`
- `src/flows/doctor-repair-flow.test.ts` — 3 new tests covering retry behavior

## Testing
**Test output (local vitest):**
```
✓ retries transient failures and succeeds on later attempt  303ms
✓ fails without retry when retries is 0  1ms
✓ exhausts retries and reports failure after all attempts fail  302ms

Test Files  1 passed (1)
     Tests  13 passed (13)
```

All existing tests continue to pass.

## Proof
Health check that fails twice then succeeds — retries 2 times, succeeds on 3rd call (plus 4th call for post-repair validation):

```
✓ retries transient failures and succeeds on later attempt  303ms
```

Health check with retries=0 — fails immediately with no retry:
```
✓ fails without retry when retries is 0  1ms
```

Health check that exhausts all retries — 3 total attempts, final failure warning logged:
```
✓ exhausts retries and reports failure after all attempts fail  302ms
```

## Risk
LOW — additive retry capability, defaults to no retries (existing behavior preserved). Only affects health checks that explicitly pass `retries > 0`.