### PR TITLE
fix(update): ignore restart script spawn failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Docs: https://docs.openclaw.ai
 - Models: prune retired Groq, GitHub Copilot, OpenAI, xAI, and old Claude catalog entries, with doctor migration to upgrade existing configs to current provider refs.
 - Doctor/update: recognize junction-backed source checkouts as git installs by comparing canonical paths before showing package-manager update guidance. Fixes #82215. Thanks @igormf.
 - Channels: honor `/verbose on` for tool/progress summaries across direct chats, groups, channels, and forum topics while preserving quiet default behavior. (#85488) Thanks @kurplunkin.
+- Update: keep the detached gateway restart handoff best-effort when the restart script process cannot be spawned. (#83892) Thanks @davinci282828.
 - Telegram: persist the prompt-context message cache through plugin state and record bot-authored replies after sends and draft streaming so later turns can include prior assistant replies without relying on the JSON sidecar. (#85231) Thanks @keshavbotagent.
 - CLI/skills: show an all-ready note with next-step commands when skill setup has no missing dependencies to install. (#85032) Thanks @aniruddhaadak80.
 - Microsoft Foundry: route DeepSeek V4 Pro and Flash models through the Foundry Responses API while keeping older DeepSeek models on their existing path. (#85549) Thanks @roslinmahmud.

--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -593,7 +593,7 @@ exit 0
     it("spawns the script as a detached process on Linux", async () => {
       Object.defineProperty(process, "platform", { value: "linux" });
       const scriptPath = "/tmp/fake-script.sh";
-      const mockChild = { unref: vi.fn() };
+      const mockChild = { on: vi.fn(), unref: vi.fn() };
       vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
       await runRestartScript(scriptPath);
@@ -603,13 +603,14 @@ exit 0
         stdio: "ignore",
         windowsHide: true,
       });
+      expect(mockChild.on).toHaveBeenCalledWith("error", expect.any(Function));
       expect(mockChild.unref).toHaveBeenCalledTimes(1);
     });
 
     it("uses cmd.exe on Windows", async () => {
       Object.defineProperty(process, "platform", { value: "win32" });
       const scriptPath = "C:\\Temp\\fake-script.bat";
-      const mockChild = { unref: vi.fn() };
+      const mockChild = { on: vi.fn(), unref: vi.fn() };
       vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
       await runRestartScript(scriptPath);
@@ -619,13 +620,14 @@ exit 0
         stdio: "ignore",
         windowsHide: true,
       });
+      expect(mockChild.on).toHaveBeenCalledWith("error", expect.any(Function));
       expect(mockChild.unref).toHaveBeenCalledTimes(1);
     });
 
     it("quotes cmd.exe /c paths with metacharacters on Windows", async () => {
       Object.defineProperty(process, "platform", { value: "win32" });
       const scriptPath = "C:\\Temp\\me&(ow)\\fake-script.bat";
-      const mockChild = { unref: vi.fn() };
+      const mockChild = { on: vi.fn(), unref: vi.fn() };
       vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
 
       await runRestartScript(scriptPath);
@@ -635,6 +637,34 @@ exit 0
         stdio: "ignore",
         windowsHide: true,
       });
+    });
+
+    it("does not throw when spawn fails synchronously", async () => {
+      Object.defineProperty(process, "platform", { value: "linux" });
+      vi.mocked(spawn).mockImplementation(() => {
+        throw Object.assign(new Error("spawn /bin/sh ENOENT"), { code: "ENOENT" });
+      });
+
+      await expect(runRestartScript("/tmp/fake-script.sh")).resolves.toBeUndefined();
+    });
+
+    it("handles child process spawn errors after the detached handoff", async () => {
+      Object.defineProperty(process, "platform", { value: "linux" });
+      let errorHandler: ((error: Error) => void) | undefined;
+      const mockChild = {
+        on: vi.fn((event: string, handler: (error: Error) => void) => {
+          if (event === "error") {
+            errorHandler = handler;
+          }
+          return mockChild;
+        }),
+        unref: vi.fn(),
+      };
+      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
+
+      await runRestartScript("/tmp/fake-script.sh");
+      expect(errorHandler).toBeDefined();
+      expect(() => errorHandler?.(new Error("spawn /bin/sh ENOENT"))).not.toThrow();
     });
   });
 });

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -406,10 +406,15 @@ export async function runRestartScript(scriptPath: string): Promise<void> {
   const file = isWindows ? "cmd.exe" : "/bin/sh";
   const args = isWindows ? ["/d", "/s", "/c", quoteCmdScriptArg(scriptPath)] : [scriptPath];
 
-  const child = spawn(file, args, {
-    detached: true,
-    stdio: "ignore",
-    windowsHide: true,
-  });
-  child.unref();
+  try {
+    const child = spawn(file, args, {
+      detached: true,
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    child.on("error", () => {});
+    child.unref();
+  } catch {
+    // Restart handoff is best-effort; update completion must not crash here.
+  }
 }


### PR DESCRIPTION
## Summary

- Make the detached gateway restart script handoff best-effort when `spawn()` fails immediately.
- Attach a child `error` listener so ENOENT/EACCES-style spawn failures after handoff do not crash the update CLI.
- Add focused Linux/Windows regression coverage and a changelog entry.

Fixes #83892.

## Verification

2026-05-23 update after rebasing onto `origin/main` (`acf265d4d5`), head `e224c84c34`:

- `node scripts/run-vitest.mjs src/cli/update-cli/restart-helper.test.ts --reporter=verbose` (1 file, 29 tests passed)
- `./node_modules/.bin/oxfmt --check --threads=1 CHANGELOG.md src/cli/update-cli/restart-helper.ts src/cli/update-cli/restart-helper.test.ts`
- `./node_modules/.bin/oxlint src/cli/update-cli/restart-helper.ts src/cli/update-cli/restart-helper.test.ts`
- `git diff --check origin/main...HEAD`

Earlier verification before the rebase:

- `corepack pnpm install`
- `corepack pnpm exec oxfmt --write --threads=1 src/cli/update-cli/restart-helper.ts src/cli/update-cli/restart-helper.test.ts CHANGELOG.md`
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 CI=1 node scripts/run-vitest.mjs src/cli/update-cli/restart-helper.test.ts` - 29 tests passed before push
- `git diff --check`
- `corepack pnpm exec oxfmt --check --threads=1 src/cli/update-cli/restart-helper.ts src/cli/update-cli/restart-helper.test.ts CHANGELOG.md`
- `corepack pnpm exec oxlint src/cli/update-cli/restart-helper.ts src/cli/update-cli/restart-helper.test.ts` - 0 warnings, 0 errors
- `codex review --uncommitted` - clean, no actionable findings before initial commit
- Rebased on latest `origin/main` after PR creation to resolve the changelog conflict with #85735.
- After rebase: `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 CI=1 node scripts/run-vitest.mjs src/cli/update-cli/restart-helper.test.ts` - 29 tests passed
- After rebase: `git diff --check fork/fix-83892-restart-script-spawn-error..HEAD`
- After rebase: `corepack pnpm exec oxfmt --check --threads=1 src/cli/update-cli/restart-helper.ts src/cli/update-cli/restart-helper.test.ts CHANGELOG.md`
- After rebase: `corepack pnpm exec oxlint src/cli/update-cli/restart-helper.ts src/cli/update-cli/restart-helper.test.ts` - 0 warnings, 0 errors
- After rebase: `codex review --base origin/main` - clean, no actionable findings

Note: `node scripts/run-oxlint.mjs src/cli/update-cli/restart-helper.ts src/cli/update-cli/restart-helper.test.ts` was attempted, but its preflight failed before linting touched files because the local checkout could not build unrelated WhatsApp boundary DTS artifacts: missing `baileys` type declarations under `extensions/whatsapp/**`. Direct oxlint on the touched TS files passed.

## Real behavior proof

Behavior addressed: `openclaw update` can crash during the gateway restart handoff when the detached restart script process cannot be spawned or emits a child-process `error` event after `spawn()` returns.

Real environment tested: WSL checkout at `/root/src/openclaw-85761` on Ubuntu-24.04, branch `fix-83892-restart-script-spawn-error`, head `e224c84c34`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/cli/update-cli/restart-helper.test.ts --reporter=verbose`

Evidence after fix: The focused regression test covers both the synchronous `spawn()` throw path and the async child-process `error` event path, while preserving the existing Linux, macOS, and Windows restart script behavior.

Observed result after fix: `restart-helper.test.ts` passed 29 tests including the new failure-mode regressions; focused static checks were clean.

What was not tested: A destructive full package self-update with an actual managed gateway restart was not run; this patch only changes the detached handoff error handling and preserves existing restart script behavior.
