### PR TITLE
perf(auto-reply): move memory flush off the user-visible reply path

### DIFF
--- a/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
+++ b/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
@@ -411,7 +411,7 @@ describe("runReplyAgent runtime config", () => {
     expect(typeof registerCall[2]).toBe("function");
 
     // The abort callback must put the maintenance ReplyOperation into a
-    // terminal aborted state so subsequent runEmbeddedPiAgent /
+    // terminal aborted state so subsequent runEmbeddedAgent /
     // runWithModelFallback calls see an aborted abortSignal and
     // short-circuit. Pull the maintenance op out of the
     // runMemoryFlushIfNeeded call args and verify.

--- a/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
+++ b/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
@@ -295,6 +295,29 @@ describe("runReplyAgent runtime config", () => {
     );
   });
 
+  it("dispatches the post-reply memory flush from the reply path's finally block even when the agent turn throws", async () => {
+    const { followupRun, replyParams } = createDirectRuntimeReplyParams({
+      shouldFollowup: false,
+      isActive: false,
+    });
+    followupRun.run.sessionKey = "agent:main:main";
+    replyParams.sessionKey = "agent:main:main";
+    runPreflightCompactionIfNeededMock.mockResolvedValue(undefined);
+    const turnError = new Error("agent turn exploded");
+    runAgentTurnWithFallbackMock.mockRejectedValue(turnError);
+
+    await runReplyAgent(replyParams).catch(() => undefined);
+
+    expect(runAgentTurnWithFallbackMock).toHaveBeenCalledTimes(1);
+    // Flush is still dispatched because the reply path was reached
+    // (set right before runAgentTurnWithFallback was invoked).
+    expect(runMemoryFlushIfNeededMock).toHaveBeenCalledTimes(1);
+    expect(registerPendingMemoryFlushMock).toHaveBeenCalledTimes(1);
+    expect(runAgentTurnWithFallbackMock.mock.invocationCallOrder[0]).toBeLessThan(
+      runMemoryFlushIfNeededMock.mock.invocationCallOrder[0] ?? Number.MAX_SAFE_INTEGER,
+    );
+  });
+
   it("does not block the start of the user-visible reply on a pending memory flush", async () => {
     const { followupRun, replyParams } = createDirectRuntimeReplyParams({
       shouldFollowup: false,

--- a/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
+++ b/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
@@ -385,6 +385,48 @@ describe("runReplyAgent runtime config", () => {
     expect(cancelMockOnCompleted).toHaveBeenCalledWith("superseded");
   });
 
+  it("registers the post-reply flush with an abort callback that aborts the maintenance ReplyOperation", async () => {
+    const { followupRun, replyParams } = createDirectRuntimeReplyParams({
+      shouldFollowup: false,
+      isActive: false,
+    });
+    followupRun.run.sessionKey = "agent:main:main";
+    replyParams.sessionKey = "agent:main:main";
+
+    runPreflightCompactionIfNeededMock.mockResolvedValue(undefined);
+    runAgentTurnWithFallbackMock.mockResolvedValue({
+      kind: "final",
+      payload: { text: "ok" },
+    });
+
+    await runReplyAgent(replyParams);
+
+    expect(registerPendingMemoryFlushMock).toHaveBeenCalledTimes(1);
+    const registerCall = registerPendingMemoryFlushMock.mock.calls[0] as [
+      string,
+      Promise<unknown>,
+      () => void,
+    ];
+    expect(registerCall[0]).toBe("agent:main:main");
+    expect(typeof registerCall[2]).toBe("function");
+
+    // The abort callback must put the maintenance ReplyOperation into a
+    // terminal aborted state so subsequent runEmbeddedPiAgent /
+    // runWithModelFallback calls see an aborted abortSignal and
+    // short-circuit. Pull the maintenance op out of the
+    // runMemoryFlushIfNeeded call args and verify.
+    const memoryCall = runMemoryFlushIfNeededMock.mock.calls[0]?.[0] as {
+      replyOperation: {
+        abortSignal: AbortSignal;
+        result: { kind: string } | null;
+      };
+    };
+    expect(memoryCall.replyOperation.abortSignal.aborted).toBe(false);
+    registerCall[2]();
+    expect(memoryCall.replyOperation.abortSignal.aborted).toBe(true);
+    expect(memoryCall.replyOperation.result?.kind).toBe("aborted");
+  });
+
   it("aborts the maintenance ReplyOperation when the original reply operation aborts upstream", async () => {
     const { followupRun, replyParams } = createDirectRuntimeReplyParams({
       shouldFollowup: false,

--- a/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
+++ b/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
@@ -59,11 +59,26 @@ vi.mock("./reply-media-paths.js", () => ({
     createReplyMediaPathNormalizerMock(...args),
 }));
 
+const registerPendingMemoryFlushMock = vi.fn();
+
 vi.mock("./agent-runner-memory.js", () => ({
   runPreflightCompactionIfNeeded: (...args: unknown[]) =>
     runPreflightCompactionIfNeededMock(...args),
   runMemoryFlushIfNeeded: (...args: unknown[]) => runMemoryFlushIfNeededMock(...args),
+  registerPendingMemoryFlush: (...args: unknown[]) => registerPendingMemoryFlushMock(...args),
 }));
+
+const runAgentTurnWithFallbackMock = vi.fn();
+
+vi.mock("./agent-runner-execution.js", async () => {
+  const actual = await vi.importActual<typeof import("./agent-runner-execution.js")>(
+    "./agent-runner-execution.js",
+  );
+  return {
+    ...actual,
+    runAgentTurnWithFallback: (...args: unknown[]) => runAgentTurnWithFallbackMock(...args),
+  };
+});
 
 vi.mock("./queue.js", async () => {
   const actual = await vi.importActual<typeof import("./queue.js")>("./queue.js");
@@ -171,6 +186,8 @@ describe("runReplyAgent runtime config", () => {
     createReplyMediaPathNormalizerMock.mockReset();
     runPreflightCompactionIfNeededMock.mockReset();
     runMemoryFlushIfNeededMock.mockReset();
+    registerPendingMemoryFlushMock.mockReset();
+    runAgentTurnWithFallbackMock.mockReset();
     enqueueFollowupRunMock.mockReset();
 
     resolveQueuedReplyExecutionConfigMock.mockResolvedValue(freshCfg);
@@ -219,7 +236,33 @@ describe("runReplyAgent runtime config", () => {
     expect(preflightCall.followupRun).toBe(followupRun);
   });
 
-  it("passes the derived runtime-policy key to pre-run maintenance", async () => {
+  it("passes the derived runtime-policy key to preflight compaction", async () => {
+    const { followupRun, replyParams } = createDirectRuntimeReplyParams({
+      shouldFollowup: false,
+      isActive: false,
+    });
+    const runtimePolicySessionKey = "agent:main:telegram:default:direct:test";
+    followupRun.run.sessionKey = "agent:main:main";
+    followupRun.run.runtimePolicySessionKey = runtimePolicySessionKey;
+    replyParams.sessionKey = "agent:main:main";
+    replyParams.runtimePolicySessionKey = runtimePolicySessionKey;
+    runPreflightCompactionIfNeededMock.mockRejectedValue(sentinelError);
+
+    await expect(runReplyAgent(replyParams)).rejects.toBe(sentinelError);
+
+    const preflightCall = requireMaintenanceCall(
+      runPreflightCompactionIfNeededMock,
+      "runPreflightCompactionIfNeeded",
+    );
+    expect(preflightCall.sessionKey).toBe("agent:main:main");
+    expect(preflightCall.runtimePolicySessionKey).toBe(runtimePolicySessionKey);
+    // The near-threshold memory flush is now dispatched after the user-visible
+    // reply path; if preflight throws, the reply never runs and the flush is
+    // not dispatched this turn.
+    expect(runMemoryFlushIfNeededMock).not.toHaveBeenCalled();
+  });
+
+  it("dispatches the post-reply memory flush after the user-visible reply path returns", async () => {
     const { followupRun, replyParams } = createDirectRuntimeReplyParams({
       shouldFollowup: false,
       isActive: false,
@@ -230,60 +273,51 @@ describe("runReplyAgent runtime config", () => {
     replyParams.sessionKey = "agent:main:main";
     replyParams.runtimePolicySessionKey = runtimePolicySessionKey;
     runPreflightCompactionIfNeededMock.mockResolvedValue(undefined);
-    runMemoryFlushIfNeededMock.mockRejectedValue(sentinelError);
+    runAgentTurnWithFallbackMock.mockResolvedValue({
+      kind: "final",
+      payload: { text: "ok" },
+    });
 
-    await expect(runReplyAgent(replyParams)).rejects.toBe(sentinelError);
+    await runReplyAgent(replyParams);
 
-    const preflightCall = requireMaintenanceCall(
-      runPreflightCompactionIfNeededMock,
-      "runPreflightCompactionIfNeeded",
+    expect(runAgentTurnWithFallbackMock).toHaveBeenCalledTimes(1);
+    expect(runMemoryFlushIfNeededMock).toHaveBeenCalledTimes(1);
+    const memoryCall = runMemoryFlushIfNeededMock.mock.calls[0]?.[0] as
+      | { sessionKey?: string; runtimePolicySessionKey?: string }
+      | undefined;
+    expect(memoryCall?.sessionKey).toBe("agent:main:main");
+    expect(memoryCall?.runtimePolicySessionKey).toBe(runtimePolicySessionKey);
+    expect(registerPendingMemoryFlushMock).toHaveBeenCalledTimes(1);
+    expect(registerPendingMemoryFlushMock.mock.calls[0]?.[0]).toBe("agent:main:main");
+    // Reply path's runAgentTurnWithFallback completed before the flush dispatch.
+    expect(runAgentTurnWithFallbackMock.mock.invocationCallOrder[0]).toBeLessThan(
+      runMemoryFlushIfNeededMock.mock.invocationCallOrder[0] ?? Number.MAX_SAFE_INTEGER,
     );
-    expect(preflightCall.sessionKey).toBe("agent:main:main");
-    expect(preflightCall.runtimePolicySessionKey).toBe(runtimePolicySessionKey);
-    const memoryCall = requireMaintenanceCall(runMemoryFlushIfNeededMock, "runMemoryFlushIfNeeded");
-    expect(memoryCall.sessionKey).toBe("agent:main:main");
-    expect(memoryCall.runtimePolicySessionKey).toBe(runtimePolicySessionKey);
   });
 
-  it("returns source-suppression-safe memory-flush error payloads before the main reply run", async () => {
-    const { replyParams } = createDirectRuntimeReplyParams({
+  it("does not block the start of the user-visible reply on a pending memory flush", async () => {
+    const { followupRun, replyParams } = createDirectRuntimeReplyParams({
       shouldFollowup: false,
       isActive: false,
     });
-    replyParams.opts = { sourceReplyDeliveryMode: "message_tool_only" };
+    followupRun.run.sessionKey = "agent:main:main";
+    replyParams.sessionKey = "agent:main:main";
     runPreflightCompactionIfNeededMock.mockResolvedValue(undefined);
-    runMemoryFlushIfNeededMock.mockImplementation(
-      async (params: {
-        onVisibleErrorPayloads?: (payloads: Array<{ text?: string; isError?: boolean }>) => void;
-      }) => {
-        params.onVisibleErrorPayloads?.([
-          {
-            text: "⚠️ write failed: Memory flush writes are restricted to memory/2023-11-14.md; use that path only.",
-            isError: true,
-          },
-        ]);
-        return undefined;
-      },
-    );
+    // Memory flush returns a promise that never resolves within the test.
+    runMemoryFlushIfNeededMock.mockImplementation(() => new Promise<undefined>(() => undefined));
+    runAgentTurnWithFallbackMock.mockResolvedValue({
+      kind: "final",
+      payload: { text: "ok" },
+    });
 
     const result = await runReplyAgent(replyParams);
 
-    if (!result || Array.isArray(result)) {
-      throw new Error("expected a single memory-flush error reply payload");
-    }
-    expect(result).toEqual({
-      text: "⚠️ write failed: Memory flush writes are restricted to memory/2023-11-14.md; use that path only.",
-      isError: true,
-      replyToId: "msg-1",
-      replyToCurrent: undefined,
-      replyToTag: false,
-      mediaUrl: undefined,
-      mediaUrls: undefined,
-      audioAsVoice: false,
-    });
-    expect(getReplyPayloadMetadata(result)).toEqual({
-      deliverDespiteSourceReplySuppression: true,
-    });
+    // Reply path completed even though the flush promise is still pending.
+    expect(runAgentTurnWithFallbackMock).toHaveBeenCalledTimes(1);
+    expect(result).toBeDefined();
+    // Flush was dispatched (fire-and-forget) but never resolved.
+    expect(runMemoryFlushIfNeededMock).toHaveBeenCalledTimes(1);
+    expect(registerPendingMemoryFlushMock).toHaveBeenCalledTimes(1);
   });
 
   it("surfaces known pre-run Codex usage-limit failures instead of dropping the reply", async () => {

--- a/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
+++ b/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
@@ -318,6 +318,110 @@ describe("runReplyAgent runtime config", () => {
     );
   });
 
+  it("passes a maintenance ReplyOperation (NOT the completed reply's operation) into the post-reply memory flush", async () => {
+    // ClawSweeper P1 regression guard: the deferred flush dispatched in the
+    // reply orchestrator's finally block must not forward the (already
+    // completed) reply ReplyOperation into runMemoryFlushIfNeeded. The
+    // embedded runner calls attachBackend(...) on whatever ReplyOperation
+    // it receives, and a completed operation cancels the attached handle
+    // with "superseded", so the deferred flush would never reach its LLM
+    // call.
+    const { followupRun, replyParams } = createDirectRuntimeReplyParams({
+      shouldFollowup: false,
+      isActive: false,
+    });
+    followupRun.run.sessionKey = "agent:main:main";
+    replyParams.sessionKey = "agent:main:main";
+
+    // Provide an external ReplyOperation so the test owns the reference
+    // for identity comparison and can observe its result transitions.
+    const externalReplyOperation = (await import("./reply-run-registry.js")).createReplyOperation({
+      sessionId: followupRun.run.sessionId,
+      sessionKey: "agent:main:main",
+      resetTriggered: false,
+    });
+    replyParams.replyOperation = externalReplyOperation;
+
+    runPreflightCompactionIfNeededMock.mockResolvedValue(undefined);
+    runAgentTurnWithFallbackMock.mockResolvedValue({
+      kind: "final",
+      payload: { text: "ok" },
+    });
+
+    await runReplyAgent(replyParams);
+
+    // Confirm the reply operation has been terminated (completed or
+    // failed) by the orchestrator before the post-reply flush runs.
+    // Either terminal state engages the attachBackend cancellation
+    // contract, which is exactly the path the maintenance op must not
+    // share.
+    expect(["completed", "failed"]).toContain(externalReplyOperation.result?.kind);
+
+    expect(runMemoryFlushIfNeededMock).toHaveBeenCalledTimes(1);
+    const memoryCall = runMemoryFlushIfNeededMock.mock.calls[0]?.[0] as {
+      replyOperation: {
+        result: { kind: string } | null;
+        attachBackend: (handle: { cancel: (reason: string) => void }) => void;
+        complete: () => void;
+        sessionId: string;
+        key: string;
+      };
+    };
+    expect(memoryCall.replyOperation).not.toBe(externalReplyOperation);
+    // The maintenance op is not yet completed at the moment of dispatch:
+    // it accepts a backend handle without immediately cancelling it.
+    expect(memoryCall.replyOperation.result).toBe(null);
+
+    const cancelMock = vi.fn();
+    memoryCall.replyOperation.attachBackend({ cancel: cancelMock });
+    expect(cancelMock).not.toHaveBeenCalled();
+
+    // Compare: attaching to the (completed) reply operation would cancel.
+    const cancelMockOnCompleted = vi.fn();
+    externalReplyOperation.attachBackend({
+      cancel: cancelMockOnCompleted,
+      detach: vi.fn(),
+    } as never);
+    expect(cancelMockOnCompleted).toHaveBeenCalledWith("superseded");
+  });
+
+  it("aborts the maintenance ReplyOperation when the original reply operation aborts upstream", async () => {
+    const { followupRun, replyParams } = createDirectRuntimeReplyParams({
+      shouldFollowup: false,
+      isActive: false,
+    });
+    followupRun.run.sessionKey = "agent:main:main";
+    replyParams.sessionKey = "agent:main:main";
+
+    // Create a reply operation whose upstreamAbortSignal we control.
+    const upstreamController = new AbortController();
+    const externalReplyOperation = (await import("./reply-run-registry.js")).createReplyOperation({
+      sessionId: followupRun.run.sessionId,
+      sessionKey: "agent:main:main",
+      resetTriggered: false,
+      upstreamAbortSignal: upstreamController.signal,
+    });
+    replyParams.replyOperation = externalReplyOperation;
+
+    runPreflightCompactionIfNeededMock.mockResolvedValue(undefined);
+    runAgentTurnWithFallbackMock.mockResolvedValue({
+      kind: "final",
+      payload: { text: "ok" },
+    });
+
+    await runReplyAgent(replyParams);
+
+    const memoryCall = runMemoryFlushIfNeededMock.mock.calls[0]?.[0] as {
+      replyOperation: { abortSignal: AbortSignal };
+    };
+    expect(memoryCall.replyOperation.abortSignal.aborted).toBe(false);
+
+    // Aborting the original reply's upstream signal must propagate into
+    // the maintenance operation so a user cancel still stops the flush.
+    upstreamController.abort(new Error("user cancelled"));
+    expect(memoryCall.replyOperation.abortSignal.aborted).toBe(true);
+  });
+
   it("does not block the start of the user-visible reply on a pending memory flush", async () => {
     const { followupRun, replyParams } = createDirectRuntimeReplyParams({
       shouldFollowup: false,

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -2116,6 +2116,67 @@ describe("runPreflightCompactionIfNeeded pending-flush barrier", () => {
     expect(compactEmbeddedPiSessionMock).toHaveBeenCalledTimes(1);
   });
 
+  it("rebinds the active run sessionId after the barrier when the prior flush rotated it, even if no compaction runs this turn", async () => {
+    const storePath = path.join(rootDir, "sessions.json");
+    const sessionKey = "main";
+    // The session store reflects the post-flush state (sessionId rotated).
+    const rotatedSessionEntry: SessionEntry = {
+      sessionId: "session-rotated-by-prior-flush",
+      updatedAt: Date.now(),
+      // Low tokens: this turn will NOT trigger compaction. Verifies that the
+      // rebind happens even on the no-compaction path.
+      totalTokens: 1,
+      totalTokensFresh: true,
+      compactionCount: 1,
+    };
+    const sessionStore = { [sessionKey]: rotatedSessionEntry };
+    await writeTestSessionStore(storePath, sessionKey, rotatedSessionEntry);
+
+    // Caller still holds the pre-flush sessionId on the active followup run.
+    const followupRun = createTestFollowupRun();
+    followupRun.run.sessionId = "session-pre-flush";
+
+    // Register a pending flush that resolves immediately to keep the test fast.
+    registerPendingMemoryFlush(sessionKey, Promise.resolve());
+
+    const replyOperation = createReplyOperation();
+    const updateSessionIdMock = replyOperation.updateSessionId as ReturnType<typeof vi.fn>;
+    const refreshQueuedFollowupSessionMock = vi.fn();
+    setAgentRunnerMemoryTestDeps({
+      compactEmbeddedPiSession: compactEmbeddedPiSessionMock as never,
+      refreshQueuedFollowupSession: refreshQueuedFollowupSessionMock as never,
+      incrementCompactionCount: incrementCompactionCountMock as never,
+      registerAgentRunContext: vi.fn() as never,
+      randomUUID: () => "00000000-0000-0000-0000-000000000003",
+      now: () => 1_700_000_000_000,
+    });
+
+    const returnedEntry = await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun,
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100_000,
+      sessionEntry: undefined,
+      sessionStore,
+      sessionKey,
+      storePath,
+      isHeartbeat: false,
+      replyOperation,
+    });
+
+    expect(returnedEntry?.sessionId).toBe("session-rotated-by-prior-flush");
+    expect(followupRun.run.sessionId).toBe("session-rotated-by-prior-flush");
+    expect(updateSessionIdMock).toHaveBeenCalledWith("session-rotated-by-prior-flush");
+    expect(refreshQueuedFollowupSessionMock).toHaveBeenCalledWith({
+      key: followupRun.run.sessionKey ?? sessionKey,
+      previousSessionId: "session-pre-flush",
+      nextSessionId: "session-rotated-by-prior-flush",
+      nextSessionFile: rotatedSessionEntry.sessionFile,
+    });
+    // No compaction was triggered this turn.
+    expect(compactEmbeddedPiSessionMock).not.toHaveBeenCalled();
+  });
+
   it("does not block heartbeat preflight on a pending flush", async () => {
     const storePath = path.join(rootDir, "sessions.json");
     const sessionKey = "main";

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -322,13 +322,14 @@ describe("runMemoryFlushIfNeeded", () => {
     // where the embedded runner ignored its AbortSignal or completed
     // concurrently with the abort.
     const replyOperationAbortController = new AbortController();
+    const updateSessionIdMock = vi.fn();
     const replyOperation = {
       abortSignal: replyOperationAbortController.signal,
       setPhase: vi.fn(),
-      updateSessionId: vi.fn(),
+      updateSessionId: updateSessionIdMock,
     } as never;
 
-    runEmbeddedPiAgentMock.mockImplementationOnce(
+    runEmbeddedAgentMock.mockImplementationOnce(
       async (params: {
         onAgentEvent?: (evt: { stream: string; data: { phase: string } }) => void;
       }) => {
@@ -372,7 +373,7 @@ describe("runMemoryFlushIfNeeded", () => {
     // sole writer.
     expect(incrementCompactionCountMock).not.toHaveBeenCalled();
     expect(refreshQueuedFollowupSessionMock).not.toHaveBeenCalled();
-    expect(replyOperation.updateSessionId).not.toHaveBeenCalled();
+    expect(updateSessionIdMock).not.toHaveBeenCalled();
     expect(followupRun.run.sessionId).toBe("session");
     expect(entry?.sessionId).toBe("session");
 
@@ -555,7 +556,7 @@ describe("runMemoryFlushIfNeeded", () => {
       totalTokens: 80_000,
       compactionCount: 1,
     };
-    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+    runEmbeddedAgentMock.mockResolvedValueOnce({
       payloads: [
         {
           text: "⚠️ write failed: Memory flush writes are restricted to memory/2023-11-14.md; use that path only.",
@@ -2073,7 +2074,7 @@ describe("pending memory-flush registry", () => {
     const flushPromise = new Promise<void>((resolve) => {
       // The flush only settles after `abort()` is called by the barrier.
       // This mirrors how the real maintenance ReplyOperation propagates
-      // abort into runEmbeddedPiAgent / runWithModelFallback and makes
+      // abort into runEmbeddedAgent / runWithModelFallback and makes
       // them short-circuit.
       const interval = setInterval(() => {
         if (aborted) {
@@ -2168,7 +2169,7 @@ describe("runPreflightCompactionIfNeeded pending-flush barrier", () => {
       systemPrompt: "noop",
       relativePath: "memory/2023-11-14.md",
     }));
-    compactEmbeddedPiSessionMock.mockReset().mockResolvedValue({
+    compactEmbeddedAgentSessionMock.mockReset().mockResolvedValue({
       ok: true,
       compacted: true,
       result: { tokensAfter: 42, sessionId: "session-after-compaction" },
@@ -2190,9 +2191,9 @@ describe("runPreflightCompactionIfNeeded pending-flush barrier", () => {
       return nextEntry.compactionCount;
     });
     setAgentRunnerMemoryTestDeps({
-      compactEmbeddedPiSession: compactEmbeddedPiSessionMock as never,
+      compactEmbeddedAgentSession: compactEmbeddedAgentSessionMock as never,
       runWithModelFallback: vi.fn() as never,
-      runEmbeddedPiAgent: vi.fn() as never,
+      runEmbeddedAgent: vi.fn() as never,
       ensureMemoryFlushTargetFile: vi.fn().mockResolvedValue(undefined) as never,
       refreshQueuedFollowupSession: vi.fn() as never,
       incrementCompactionCount: incrementCompactionCountMock as never,
@@ -2249,12 +2250,12 @@ describe("runPreflightCompactionIfNeeded pending-flush barrier", () => {
     // Give the preflight microtasks a chance to run and reach the barrier.
     await Promise.resolve();
     await Promise.resolve();
-    expect(compactEmbeddedPiSessionMock).not.toHaveBeenCalled();
+    expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
 
     resolveFlush();
     await preflightPromise;
 
-    expect(compactEmbeddedPiSessionMock).toHaveBeenCalledTimes(1);
+    expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
   });
 
   // The barrier inside runPreflightCompactionIfNeeded uses the default
@@ -2304,12 +2305,12 @@ describe("runPreflightCompactionIfNeeded pending-flush barrier", () => {
 
     await Promise.resolve();
     await Promise.resolve();
-    expect(compactEmbeddedPiSessionMock).not.toHaveBeenCalled();
+    expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
 
     resolveFlush();
     await preflightPromise;
 
-    expect(compactEmbeddedPiSessionMock).toHaveBeenCalledTimes(1);
+    expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
   });
 
   it("rebinds the active run sessionId after the barrier when the prior flush rotated it, even if no compaction runs this turn", async () => {
@@ -2341,7 +2342,7 @@ describe("runPreflightCompactionIfNeeded pending-flush barrier", () => {
     ).updateSessionId;
     const refreshQueuedFollowupSessionMock = vi.fn();
     setAgentRunnerMemoryTestDeps({
-      compactEmbeddedPiSession: compactEmbeddedPiSessionMock as never,
+      compactEmbeddedAgentSession: compactEmbeddedAgentSessionMock as never,
       refreshQueuedFollowupSession: refreshQueuedFollowupSessionMock as never,
       incrementCompactionCount: incrementCompactionCountMock as never,
       registerAgentRunContext: vi.fn() as never,
@@ -2372,7 +2373,7 @@ describe("runPreflightCompactionIfNeeded pending-flush barrier", () => {
       nextSessionFile: rotatedSessionEntry.sessionFile,
     });
     // No compaction was triggered this turn.
-    expect(compactEmbeddedPiSessionMock).not.toHaveBeenCalled();
+    expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
   });
 
   it("does not block heartbeat preflight on a pending flush", async () => {
@@ -2411,6 +2412,6 @@ describe("runPreflightCompactionIfNeeded pending-flush barrier", () => {
     ]);
 
     expect(result).not.toBe("timed-out");
-    expect(compactEmbeddedPiSessionMock).not.toHaveBeenCalled();
+    expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
   });
 });

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -1983,19 +1983,61 @@ describe("pending memory-flush registry", () => {
     expect(awaited).toBe(true);
   });
 
-  it("awaitPendingMemoryFlush proceeds after timeout when the flush hangs", async () => {
+  it("awaitPendingMemoryFlush makes the timeout terminal: on timeout it invokes the abort callback and awaits flush settlement before returning", async () => {
     const sessionKey = "session-key-await-timeout";
-    // Pending promise that never resolves within the test horizon.
-    registerPendingMemoryFlush(sessionKey, new Promise<void>(() => {}));
+
+    let abortCalled = false;
+    let aborted = false;
+    const flushPromise = new Promise<void>((resolve) => {
+      // The flush only settles after `abort()` is called by the barrier.
+      // This mirrors how the real maintenance ReplyOperation propagates
+      // abort into runEmbeddedPiAgent / runWithModelFallback and makes
+      // them short-circuit.
+      const interval = setInterval(() => {
+        if (aborted) {
+          clearInterval(interval);
+          resolve();
+        }
+      }, 5);
+    });
+    registerPendingMemoryFlush(sessionKey, flushPromise, () => {
+      abortCalled = true;
+      aborted = true;
+    });
 
     const start = Date.now();
     await awaitPendingMemoryFlush(sessionKey, { timeoutMs: 30 });
     const elapsed = Date.now() - start;
 
+    expect(abortCalled).toBe(true);
     expect(elapsed).toBeGreaterThanOrEqual(20);
-    expect(elapsed).toBeLessThan(2_000);
-    // Hung flush is still registered (next barrier will await again).
-    expect(hasPendingMemoryFlushForTest(sessionKey)).toBe(true);
+    // After the barrier returns, the flush has truly settled so the
+    // pending map entry has self-cleaned. This is the key invariant:
+    // the barrier does not return while the previous-turn flush is
+    // still in-flight.
+    expect(hasPendingMemoryFlushForTest(sessionKey)).toBe(false);
+  });
+
+  it("awaitPendingMemoryFlush stays bounded if the abort callback fails to settle the flush quickly", async () => {
+    const sessionKey = "session-key-await-timeout-abort-throws";
+    // Abort callback that throws synchronously: the barrier must still
+    // attempt to await the flush promise. The flush in this test
+    // resolves on its own after a short delay so we can verify the
+    // barrier eventually returns.
+    let abortAttempts = 0;
+    const flushPromise = new Promise<void>((resolve) => {
+      setTimeout(resolve, 80);
+    });
+    registerPendingMemoryFlush(sessionKey, flushPromise, () => {
+      abortAttempts += 1;
+      throw new Error("abort callback explodes");
+    });
+
+    await awaitPendingMemoryFlush(sessionKey, { timeoutMs: 30 });
+
+    expect(abortAttempts).toBe(1);
+    // Flush eventually settled and was cleaned up.
+    expect(hasPendingMemoryFlushForTest(sessionKey)).toBe(false);
   });
 });
 

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -2180,7 +2180,9 @@ describe("runPreflightCompactionIfNeeded pending-flush barrier", () => {
     registerPendingMemoryFlush(sessionKey, Promise.resolve());
 
     const replyOperation = createReplyOperation();
-    const updateSessionIdMock = replyOperation.updateSessionId as ReturnType<typeof vi.fn>;
+    const updateSessionIdMock = (
+      replyOperation as unknown as { updateSessionId: ReturnType<typeof vi.fn> }
+    ).updateSessionId;
     const refreshQueuedFollowupSessionMock = vi.fn();
     setAgentRunnerMemoryTestDeps({
       compactEmbeddedPiSession: compactEmbeddedPiSessionMock as never,

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -2018,6 +2018,38 @@ describe("pending memory-flush registry", () => {
     expect(hasPendingMemoryFlushForTest(sessionKey)).toBe(false);
   });
 
+  it("awaitPendingMemoryFlush abandons the pending entry when the abort callback fails to make a truly hung flush settle within the post-abort grace window", async () => {
+    const sessionKey = "session-key-await-timeout-hung-after-abort";
+    // The flush promise never settles. The abort callback is invoked
+    // but the simulated embedded runner ignores it (mirrors the case
+    // where the LLM call has no abort cooperation or the runner
+    // process is stuck). The barrier must give up and abandon the
+    // pending entry within timeoutMs + postAbortGraceMs.
+    let abortCalled = false;
+    const hungFlushPromise = new Promise<void>(() => {
+      // never resolves
+    });
+    registerPendingMemoryFlush(sessionKey, hungFlushPromise, () => {
+      abortCalled = true;
+      // Does nothing further: the flush stays hung.
+    });
+
+    const start = Date.now();
+    await awaitPendingMemoryFlush(sessionKey, {
+      timeoutMs: 20,
+      postAbortGraceMs: 30,
+    });
+    const elapsed = Date.now() - start;
+
+    expect(abortCalled).toBe(true);
+    // The barrier returned within timeoutMs + postAbortGraceMs.
+    expect(elapsed).toBeGreaterThanOrEqual(40);
+    expect(elapsed).toBeLessThan(2_000);
+    // Pending entry was abandoned (removed from the registry) so the
+    // next preflight does not pay the timeout again.
+    expect(hasPendingMemoryFlushForTest(sessionKey)).toBe(false);
+  });
+
   it("awaitPendingMemoryFlush stays bounded if the abort callback fails to settle the flush quickly", async () => {
     const sessionKey = "session-key-await-timeout-abort-throws";
     // Abort callback that throws synchronously: the barrier must still

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -303,6 +303,88 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(persisted.main.memoryFlushAt).toBe(1_700_000_000_000);
   });
 
+  it("does not mutate session state when the maintenance ReplyOperation is aborted (no late write after abandonment)", async () => {
+    const storePath = path.join(rootDir, "sessions.json");
+    const sessionKey = "main";
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 80_000,
+      compactionCount: 1,
+    };
+    const sessionStore = { [sessionKey]: sessionEntry };
+    await writeTestSessionStore(storePath, sessionKey, sessionEntry);
+
+    // Simulate the maintenance ReplyOperation getting aborted while the
+    // embedded flush run is in flight (e.g. by the next turn's pre-compaction
+    // barrier wait-cap + post-abort grace). The embedded run still returns —
+    // an `end` compaction event and a rotated sessionId — modeling the case
+    // where the embedded runner ignored its AbortSignal or completed
+    // concurrently with the abort.
+    const replyOperationAbortController = new AbortController();
+    const replyOperation = {
+      abortSignal: replyOperationAbortController.signal,
+      setPhase: vi.fn(),
+      updateSessionId: vi.fn(),
+    } as never;
+
+    runEmbeddedPiAgentMock.mockImplementationOnce(
+      async (params: {
+        onAgentEvent?: (evt: { stream: string; data: { phase: string } }) => void;
+      }) => {
+        // Trigger the abort partway through the embedded run, then continue
+        // as if the runner ignored the signal and returned a normal result.
+        replyOperationAbortController.abort();
+        params.onAgentEvent?.({ stream: "compaction", data: { phase: "end" } });
+        return {
+          payloads: [],
+          meta: { agentMeta: { sessionId: "session-rotated-after-abort" } },
+        };
+      },
+    );
+
+    const followupRun = createTestFollowupRun();
+    const entry = await runMemoryFlushIfNeeded({
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              memoryFlush: {},
+            },
+          },
+        },
+      },
+      followupRun,
+      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100_000,
+      resolvedVerboseLevel: "off",
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      isHeartbeat: false,
+      replyOperation,
+    });
+
+    // Invariant: aborted maintenance flush returns early without persisting
+    // any session-state writes. The next turn's preflight compaction is the
+    // sole writer.
+    expect(incrementCompactionCountMock).not.toHaveBeenCalled();
+    expect(refreshQueuedFollowupSessionMock).not.toHaveBeenCalled();
+    expect(replyOperation.updateSessionId).not.toHaveBeenCalled();
+    expect(followupRun.run.sessionId).toBe("session");
+    expect(entry?.sessionId).toBe("session");
+
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf8")) as {
+      main: SessionEntry;
+    };
+    expect(persisted.main.sessionId).toBe("session");
+    expect(persisted.main.compactionCount).toBe(1);
+    expect(persisted.main.memoryFlushCompactionCount).toBeUndefined();
+    expect(persisted.main.memoryFlushAt).toBeUndefined();
+  });
+
   it("reports memory-flush error payloads for visible delivery", async () => {
     const sessionEntry: SessionEntry = {
       sessionId: "session",

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -11,6 +11,10 @@ import {
 } from "../../plugins/memory-state.js";
 import type { TemplateContext } from "../templating.js";
 import {
+  awaitPendingMemoryFlush,
+  clearPendingMemoryFlushesForTest,
+  hasPendingMemoryFlushForTest,
+  registerPendingMemoryFlush,
   runMemoryFlushIfNeeded,
   runPreflightCompactionIfNeeded,
   setAgentRunnerMemoryTestDeps,
@@ -1868,5 +1872,285 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(flushCall.silentExpected).toBe(true);
     expect(flushCall.bootstrapPromptWarningSignaturesSeen).toEqual(["sig-a", "sig-b"]);
     expect(flushCall.bootstrapPromptWarningSignature).toBe("sig-b");
+  });
+});
+
+describe("pending memory-flush registry", () => {
+  afterEach(() => {
+    clearPendingMemoryFlushesForTest();
+  });
+
+  it("registers and clears a pending flush after it resolves", async () => {
+    const sessionKey = "session-key-resolve";
+    let resolveFlush: () => void = () => {};
+    const flushPromise = new Promise<void>((resolve) => {
+      resolveFlush = resolve;
+    });
+
+    registerPendingMemoryFlush(sessionKey, flushPromise);
+    expect(hasPendingMemoryFlushForTest(sessionKey)).toBe(true);
+
+    resolveFlush();
+    // Allow microtask queue to flush so the registered finally callback fires.
+    await flushPromise;
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(hasPendingMemoryFlushForTest(sessionKey)).toBe(false);
+  });
+
+  it("clears a pending flush even after it rejects", async () => {
+    const sessionKey = "session-key-reject";
+    let rejectFlush: (err: Error) => void = () => {};
+    const flushPromise = new Promise<void>((_resolve, reject) => {
+      rejectFlush = reject;
+    });
+
+    registerPendingMemoryFlush(sessionKey, flushPromise);
+    expect(hasPendingMemoryFlushForTest(sessionKey)).toBe(true);
+
+    rejectFlush(new Error("flush failed"));
+    await flushPromise.catch(() => undefined);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(hasPendingMemoryFlushForTest(sessionKey)).toBe(false);
+  });
+
+  it("awaitPendingMemoryFlush is a no-op when no flush is pending", async () => {
+    await expect(awaitPendingMemoryFlush(undefined)).resolves.toBeUndefined();
+    await expect(awaitPendingMemoryFlush("missing-key")).resolves.toBeUndefined();
+  });
+
+  it("awaitPendingMemoryFlush returns after the registered flush resolves", async () => {
+    const sessionKey = "session-key-await-resolve";
+    let resolveFlush: () => void = () => {};
+    const flushPromise = new Promise<void>((resolve) => {
+      resolveFlush = resolve;
+    });
+    registerPendingMemoryFlush(sessionKey, flushPromise);
+
+    let awaited = false;
+    const barrier = awaitPendingMemoryFlush(sessionKey, { timeoutMs: 5_000 }).then(() => {
+      awaited = true;
+    });
+
+    await Promise.resolve();
+    expect(awaited).toBe(false);
+
+    resolveFlush();
+    await barrier;
+    expect(awaited).toBe(true);
+  });
+
+  it("awaitPendingMemoryFlush proceeds after timeout when the flush hangs", async () => {
+    const sessionKey = "session-key-await-timeout";
+    // Pending promise that never resolves within the test horizon.
+    registerPendingMemoryFlush(sessionKey, new Promise<void>(() => {}));
+
+    const start = Date.now();
+    await awaitPendingMemoryFlush(sessionKey, { timeoutMs: 30 });
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeGreaterThanOrEqual(20);
+    expect(elapsed).toBeLessThan(2_000);
+    // Hung flush is still registered (next barrier will await again).
+    expect(hasPendingMemoryFlushForTest(sessionKey)).toBe(true);
+  });
+});
+
+describe("runPreflightCompactionIfNeeded pending-flush barrier", () => {
+  let rootDir = "";
+
+  beforeEach(async () => {
+    rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-barrier-"));
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 4_000,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 20_000,
+      prompt: "noop",
+      systemPrompt: "noop",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    compactEmbeddedPiSessionMock.mockReset().mockResolvedValue({
+      ok: true,
+      compacted: true,
+      result: { tokensAfter: 42, sessionId: "session-after-compaction" },
+    });
+    incrementCompactionCountMock.mockReset().mockImplementation(async (params) => {
+      const sessionKey = String(params.sessionKey ?? "");
+      if (!sessionKey || !params.sessionStore?.[sessionKey]) {
+        return undefined;
+      }
+      const previous = params.sessionStore[sessionKey] as SessionEntry;
+      const nextEntry: SessionEntry = {
+        ...previous,
+        compactionCount: (previous.compactionCount ?? 0) + 1,
+      };
+      if (typeof params.newSessionId === "string" && params.newSessionId) {
+        nextEntry.sessionId = params.newSessionId;
+      }
+      params.sessionStore[sessionKey] = nextEntry;
+      return nextEntry.compactionCount;
+    });
+    setAgentRunnerMemoryTestDeps({
+      compactEmbeddedPiSession: compactEmbeddedPiSessionMock as never,
+      runWithModelFallback: vi.fn() as never,
+      runEmbeddedPiAgent: vi.fn() as never,
+      ensureMemoryFlushTargetFile: vi.fn().mockResolvedValue(undefined) as never,
+      refreshQueuedFollowupSession: vi.fn() as never,
+      incrementCompactionCount: incrementCompactionCountMock as never,
+      ensureSelectedAgentHarnessPlugin: vi.fn().mockResolvedValue(undefined) as never,
+      registerAgentRunContext: vi.fn() as never,
+      randomUUID: () => "00000000-0000-0000-0000-000000000002",
+      now: () => 1_700_000_000_000,
+    });
+  });
+
+  afterEach(async () => {
+    clearPendingMemoryFlushesForTest();
+    setAgentRunnerMemoryTestDeps();
+    clearMemoryPluginState();
+    await fs.rm(rootDir, { recursive: true, force: true });
+  });
+
+  it("awaits a pending flush before invoking compaction on the next turn", async () => {
+    const storePath = path.join(rootDir, "sessions.json");
+    const sessionKey = "main";
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 250_000,
+      totalTokensFresh: true,
+      compactionCount: 0,
+    };
+    const sessionStore = { [sessionKey]: sessionEntry };
+    await writeTestSessionStore(storePath, sessionKey, sessionEntry);
+
+    let resolveFlush: () => void = () => {};
+    const flushPromise = new Promise<void>((resolve) => {
+      resolveFlush = resolve;
+    });
+    registerPendingMemoryFlush(sessionKey, flushPromise);
+
+    const followupRun = createTestFollowupRun();
+    const replyOperation = createReplyOperation();
+    const preflightPromise = runPreflightCompactionIfNeeded({
+      cfg: {
+        agents: { defaults: { compaction: { memoryFlush: {} } } },
+      },
+      followupRun,
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100_000,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      isHeartbeat: false,
+      replyOperation,
+    });
+
+    // Give the preflight microtasks a chance to run and reach the barrier.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(compactEmbeddedPiSessionMock).not.toHaveBeenCalled();
+
+    resolveFlush();
+    await preflightPromise;
+
+    expect(compactEmbeddedPiSessionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("proceeds with compaction after the barrier times out on a hung flush", async () => {
+    const storePath = path.join(rootDir, "sessions.json");
+    const sessionKey = "main";
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 250_000,
+      totalTokensFresh: true,
+      compactionCount: 0,
+    };
+    const sessionStore = { [sessionKey]: sessionEntry };
+    await writeTestSessionStore(storePath, sessionKey, sessionEntry);
+
+    // Register a never-resolving flush. The barrier's internal default timeout
+    // is 30s; we cannot wait that long in a test. Instead we register and then
+    // immediately observe that compaction does NOT run on the first preflight
+    // call within a short window, then we resolve the flush manually to let
+    // preflight finish quickly. This still demonstrates the barrier is
+    // serialized but proves the bound is finite (covered by the registry
+    // test above that exercises a real timeout with a short configured
+    // timeoutMs value).
+    let resolveFlush: () => void = () => {};
+    const flushPromise = new Promise<void>((resolve) => {
+      resolveFlush = resolve;
+    });
+    registerPendingMemoryFlush(sessionKey, flushPromise);
+
+    const followupRun = createTestFollowupRun();
+    const replyOperation = createReplyOperation();
+    const preflightPromise = runPreflightCompactionIfNeeded({
+      cfg: {
+        agents: { defaults: { compaction: { memoryFlush: {} } } },
+      },
+      followupRun,
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100_000,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      isHeartbeat: false,
+      replyOperation,
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(compactEmbeddedPiSessionMock).not.toHaveBeenCalled();
+
+    resolveFlush();
+    await preflightPromise;
+
+    expect(compactEmbeddedPiSessionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not block heartbeat preflight on a pending flush", async () => {
+    const storePath = path.join(rootDir, "sessions.json");
+    const sessionKey = "main";
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 250_000,
+      totalTokensFresh: true,
+      compactionCount: 0,
+    };
+    const sessionStore = { [sessionKey]: sessionEntry };
+    await writeTestSessionStore(storePath, sessionKey, sessionEntry);
+
+    // Register a hung flush. A heartbeat preflight should short-circuit
+    // before reaching the barrier so it does not stall.
+    registerPendingMemoryFlush(sessionKey, new Promise<void>(() => {}));
+
+    const followupRun = createTestFollowupRun();
+    const replyOperation = createReplyOperation();
+    const result = await Promise.race([
+      runPreflightCompactionIfNeeded({
+        cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+        followupRun,
+        defaultModel: "anthropic/claude-opus-4-6",
+        agentCfgContextTokens: 100_000,
+        sessionEntry,
+        sessionStore,
+        sessionKey,
+        storePath,
+        isHeartbeat: true,
+        replyOperation,
+      }),
+      new Promise<"timed-out">((resolve) => setTimeout(() => resolve("timed-out"), 200)),
+    ]);
+
+    expect(result).not.toBe("timed-out");
+    expect(compactEmbeddedPiSessionMock).not.toHaveBeenCalled();
   });
 });

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -2061,7 +2061,16 @@ describe("runPreflightCompactionIfNeeded pending-flush barrier", () => {
     expect(compactEmbeddedPiSessionMock).toHaveBeenCalledTimes(1);
   });
 
-  it("proceeds with compaction after the barrier times out on a hung flush", async () => {
+  // The barrier inside runPreflightCompactionIfNeeded uses the default
+  // 30 s timeout baked into awaitPendingMemoryFlush. Exercising that real
+  // timeout from a unit test is impractical, so the timeout bound itself
+  // is covered at the helper level (see
+  // "awaitPendingMemoryFlush proceeds after timeout when the flush hangs"
+  // in the registry describe block above, which uses a configurable short
+  // timeoutMs). Here we assert only that the barrier blocks until the
+  // pending flush settles and then compaction proceeds — i.e., the
+  // barrier is correctly wired into the preflight function entry.
+  it("returns from the barrier once the pending flush settles, then runs compaction", async () => {
     const storePath = path.join(rootDir, "sessions.json");
     const sessionKey = "main";
     const sessionEntry: SessionEntry = {
@@ -2074,14 +2083,6 @@ describe("runPreflightCompactionIfNeeded pending-flush barrier", () => {
     const sessionStore = { [sessionKey]: sessionEntry };
     await writeTestSessionStore(storePath, sessionKey, sessionEntry);
 
-    // Register a never-resolving flush. The barrier's internal default timeout
-    // is 30s; we cannot wait that long in a test. Instead we register and then
-    // immediately observe that compaction does NOT run on the first preflight
-    // call within a short window, then we resolve the flush manually to let
-    // preflight finish quickly. This still demonstrates the barrier is
-    // serialized but proves the bound is finite (covered by the registry
-    // test above that exercises a real timeout with a short configured
-    // timeoutMs value).
     let resolveFlush: () => void = () => {};
     const flushPromise = new Promise<void>((resolve) => {
       resolveFlush = resolve;

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -461,6 +461,46 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(payload?.text?.endsWith("…")).toBe(true);
   });
 
+  it("completes the flush turn without throwing when an embedded run returns a visible error payload and no onVisibleErrorPayloads callback is supplied", async () => {
+    // Covers the post-reply dispatch site (agent-runner.ts) which calls
+    // runMemoryFlushIfNeeded without onVisibleErrorPayloads. Previously the
+    // visible error payload was silently dropped; the flush body now forwards
+    // it to logVerbose. We exercise the no-callback path to ensure the flush
+    // run still completes cleanly.
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 80_000,
+      compactionCount: 1,
+    };
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [
+        {
+          text: "⚠️ write failed: Memory flush writes are restricted to memory/2023-11-14.md; use that path only.",
+          isError: true,
+        },
+      ],
+      meta: {},
+    });
+
+    await expect(
+      runMemoryFlushIfNeeded({
+        cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+        followupRun: createTestFollowupRun(),
+        sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+        defaultModel: "anthropic/claude-opus-4-6",
+        agentCfgContextTokens: 100_000,
+        resolvedVerboseLevel: "off",
+        sessionEntry,
+        sessionStore: { main: sessionEntry },
+        sessionKey: "main",
+        isHeartbeat: false,
+        replyOperation: createReplyOperation(),
+        // intentionally omit onVisibleErrorPayloads
+      }),
+    ).resolves.toBeDefined();
+  });
+
   it("does not surface user-abort errors as visible payloads (regression: #80755)", async () => {
     const sessionEntry: SessionEntry = {
       sessionId: "session",

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -130,6 +130,64 @@ const memoryDeps = {
   now: () => Date.now(),
 };
 
+// Pending memory-flush registry, keyed by sessionKey. Used so that a
+// near-threshold flush dispatched after the reply path can be awaited by
+// the next turn's preflight compaction before it mutates session state.
+const pendingMemoryFlushes = new Map<string, Promise<void>>();
+
+const DEFAULT_PENDING_MEMORY_FLUSH_BARRIER_TIMEOUT_MS = 30_000;
+
+export function registerPendingMemoryFlush(sessionKey: string, promise: Promise<unknown>): void {
+  const wrapped: Promise<void> = promise.then(
+    () => undefined,
+    () => undefined,
+  );
+  pendingMemoryFlushes.set(sessionKey, wrapped);
+  void wrapped.finally(() => {
+    if (pendingMemoryFlushes.get(sessionKey) === wrapped) {
+      pendingMemoryFlushes.delete(sessionKey);
+    }
+  });
+}
+
+export async function awaitPendingMemoryFlush(
+  sessionKey: string | undefined,
+  options?: { timeoutMs?: number },
+): Promise<void> {
+  if (!sessionKey) {
+    return;
+  }
+  const pending = pendingMemoryFlushes.get(sessionKey);
+  if (!pending) {
+    return;
+  }
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_PENDING_MEMORY_FLUSH_BARRIER_TIMEOUT_MS;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<"timeout">((resolve) => {
+    timer = setTimeout(() => resolve("timeout"), timeoutMs);
+  });
+  try {
+    const outcome = await Promise.race([pending.then(() => "done" as const), timeoutPromise]);
+    if (outcome === "timeout") {
+      logVerbose(
+        `pending memory flush barrier timed out after ${timeoutMs}ms for sessionKey=${sessionKey}`,
+      );
+    }
+  } finally {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+export function hasPendingMemoryFlushForTest(sessionKey: string): boolean {
+  return pendingMemoryFlushes.has(sessionKey);
+}
+
+export function clearPendingMemoryFlushesForTest(): void {
+  pendingMemoryFlushes.clear();
+}
+
 export function setAgentRunnerMemoryTestDeps(overrides?: Partial<typeof memoryDeps>): void {
   Object.assign(memoryDeps, {
     runWithModelFallback,
@@ -718,6 +776,19 @@ export async function runPreflightCompactionIfNeeded(params: {
     logVerbose(
       `preflightCompaction skipped: sessionKey=${params.sessionKey} runtime=codex reason=codex_native_auto_compaction`,
     );
+    return entry ?? params.sessionEntry;
+  }
+
+  // Pre-compaction barrier: if the previous turn dispatched a near-threshold
+  // memory flush that has not yet completed, await it before reading session
+  // state for the current preflight. The flush's embedded run can itself
+  // trigger a compaction that mutates sessionId; allowing this preflight's
+  // compaction to interleave would split session writes across two sessionIds.
+  // Best-effort: a hung flush is bounded by the timeout in
+  // awaitPendingMemoryFlush so compaction is not permanently blocked.
+  await awaitPendingMemoryFlush(params.sessionKey);
+  entry = params.sessionStore?.[params.sessionKey] ?? entry;
+  if (!entry?.sessionId) {
     return entry ?? params.sessionEntry;
   }
 

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -219,7 +219,7 @@ export async function awaitPendingMemoryFlush(
       // (e.g. the embedded runner ignores its AbortSignal), abandon
       // the pending entry so subsequent turns are not blocked
       // indefinitely. The flush's runWithModelFallback /
-      // runEmbeddedPiAgent normally see the maintenance op's aborted
+      // runEmbeddedAgent normally see the maintenance op's aborted
       // abortSignal and short-circuit well inside this window; the
       // wrapped promise always resolves (never throws) by construction.
       let graceTimer: ReturnType<typeof setTimeout> | undefined;

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -133,18 +133,40 @@ const memoryDeps = {
 // Pending memory-flush registry, keyed by sessionKey. Used so that a
 // near-threshold flush dispatched after the reply path can be awaited by
 // the next turn's preflight compaction before it mutates session state.
-const pendingMemoryFlushes = new Map<string, Promise<void>>();
+//
+// The entry stores both the flush promise and an `abort` callback so the
+// barrier can make a timeout terminal: when the barrier's wait-cap fires,
+// it triggers the abort callback (which cancels the flush's
+// AbortController + maintenance ReplyOperation) and then awaits the
+// flush promise's settlement. This preserves session serialization: the
+// barrier never returns while the previous turn's flush might still go
+// on to mutate session state after the next compaction has already
+// proceeded.
+type PendingMemoryFlush = {
+  promise: Promise<void>;
+  abort: () => void;
+};
+
+const pendingMemoryFlushes = new Map<string, PendingMemoryFlush>();
 
 const DEFAULT_PENDING_MEMORY_FLUSH_BARRIER_TIMEOUT_MS = 30_000;
 
-export function registerPendingMemoryFlush(sessionKey: string, promise: Promise<unknown>): void {
+export function registerPendingMemoryFlush(
+  sessionKey: string,
+  promise: Promise<unknown>,
+  abort?: () => void,
+): void {
   const wrapped: Promise<void> = promise.then(
     () => undefined,
     () => undefined,
   );
-  pendingMemoryFlushes.set(sessionKey, wrapped);
+  const entry: PendingMemoryFlush = {
+    promise: wrapped,
+    abort: abort ?? (() => undefined),
+  };
+  pendingMemoryFlushes.set(sessionKey, entry);
   void wrapped.finally(() => {
-    if (pendingMemoryFlushes.get(sessionKey) === wrapped) {
+    if (pendingMemoryFlushes.get(sessionKey) === entry) {
       pendingMemoryFlushes.delete(sessionKey);
     }
   });
@@ -167,11 +189,26 @@ export async function awaitPendingMemoryFlush(
     timer = setTimeout(() => resolve("timeout"), timeoutMs);
   });
   try {
-    const outcome = await Promise.race([pending.then(() => "done" as const), timeoutPromise]);
+    const outcome = await Promise.race([
+      pending.promise.then(() => "done" as const),
+      timeoutPromise,
+    ]);
     if (outcome === "timeout") {
       logVerbose(
-        `pending memory flush barrier timed out after ${timeoutMs}ms for sessionKey=${sessionKey}`,
+        `pending memory flush barrier timed out after ${timeoutMs}ms for sessionKey=${sessionKey}; aborting pending flush so session state is not mutated concurrently with the next compaction`,
       );
+      try {
+        pending.abort();
+      } catch (err) {
+        logVerbose(`pending memory flush abort callback threw: ${String(err)}`);
+      }
+      // Wait for the now-aborting flush to fully settle so the barrier
+      // cannot return while the flush is still racing the next
+      // compaction's session-state mutations. The flush's
+      // runWithModelFallback / runEmbeddedPiAgent see the maintenance
+      // op's aborted abortSignal and short-circuit quickly; the wrapped
+      // promise always resolves (never throws) by construction.
+      await pending.promise;
     }
   } finally {
     if (timer !== undefined) {

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -780,16 +780,41 @@ export async function runPreflightCompactionIfNeeded(params: {
   }
 
   // Pre-compaction barrier: if the previous turn dispatched a near-threshold
-  // memory flush that has not yet completed, await it before reading session
-  // state for the current preflight. The flush's embedded run can itself
-  // trigger a compaction that mutates sessionId; allowing this preflight's
-  // compaction to interleave would split session writes across two sessionIds.
-  // Best-effort: a hung flush is bounded by the timeout in
+  // memory flush that has not yet completed, await it before evaluating any
+  // compaction state for the current preflight. The flush's embedded run can
+  // itself trigger a compaction that mutates sessionId; allowing this
+  // preflight's compaction to interleave would split session writes across
+  // two sessionIds. Best-effort: a hung flush is bounded by the timeout in
   // awaitPendingMemoryFlush so compaction is not permanently blocked.
   await awaitPendingMemoryFlush(params.sessionKey);
-  entry = params.sessionStore?.[params.sessionKey] ?? entry;
+  const refreshedEntryAfterBarrier = params.sessionStore?.[params.sessionKey];
+  if (refreshedEntryAfterBarrier) {
+    entry = refreshedEntryAfterBarrier;
+  }
   if (!entry?.sessionId) {
     return entry ?? params.sessionEntry;
+  }
+  // If the prior flush's internal compaction rotated the active sessionId
+  // and the active run still references the pre-flush id, rebind here so
+  // downstream callers in the orchestrator (and the reply turn that follows
+  // this preflight on the current turn) see the post-flush sessionId even
+  // when the current preflight does not itself compact.
+  if (params.followupRun.run.sessionId && entry.sessionId !== params.followupRun.run.sessionId) {
+    const previousSessionId = params.followupRun.run.sessionId;
+    params.followupRun.run.sessionId = entry.sessionId;
+    params.replyOperation.updateSessionId(entry.sessionId);
+    if (entry.sessionFile) {
+      params.followupRun.run.sessionFile = entry.sessionFile;
+    }
+    const queueKey = params.followupRun.run.sessionKey ?? params.sessionKey;
+    if (queueKey) {
+      memoryDeps.refreshQueuedFollowupSession({
+        key: queueKey,
+        previousSessionId,
+        nextSessionId: entry.sessionId,
+        nextSessionFile: entry.sessionFile,
+      });
+    }
   }
 
   const contextWindowTokens = resolveMemoryFlushContextWindowTokens({
@@ -1336,7 +1361,19 @@ export async function runMemoryFlushIfNeeded(params: {
         });
         const visibleErrorPayloads = resolveVisibleMemoryFlushErrorPayloads(result.payloads);
         if (visibleErrorPayloads.length > 0) {
-          params.onVisibleErrorPayloads?.(visibleErrorPayloads);
+          if (params.onVisibleErrorPayloads) {
+            params.onVisibleErrorPayloads(visibleErrorPayloads);
+          } else {
+            // No caller-supplied surface for visible flush error payloads
+            // (e.g. the post-reply dispatch from the reply orchestrator).
+            // Record them so they are not silently dropped.
+            for (const payload of visibleErrorPayloads) {
+              const text = normalizeOptionalString(payload.text);
+              if (text) {
+                logVerbose(`memory flush visible error payload (dropped): ${text}`);
+              }
+            }
+          }
         }
         if (result.meta?.agentMeta?.sessionId) {
           postCompactionSessionId = result.meta.agentMeta.sessionId;

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -1459,6 +1459,21 @@ export async function runMemoryFlushIfNeeded(params: {
         return result;
       },
     });
+    // Invariant: an aborted maintenance flush must NOT mutate session state.
+    // If the maintenance ReplyOperation was aborted (e.g. by the next turn's
+    // pre-compaction barrier wait-cap + post-abort grace, after which the
+    // pending-flush registry entry is abandoned) but the embedded run still
+    // returned (e.g. it ignored or completed concurrently with its
+    // AbortSignal), do not persist compactionCount / sessionId rebinds /
+    // memoryFlushAt / memoryFlushCompactionCount: those would race the next
+    // turn's preflight compaction. Returning early here keeps abandoned
+    // flushes write-quiet against the live session store.
+    if (params.replyOperation.abortSignal.aborted) {
+      logVerbose(
+        `post-reply memory flush aborted for sessionKey=${params.sessionKey}; skipping session-state writes so an abandoned flush does not race the next compaction`,
+      );
+      return activeSessionEntry;
+    }
     const flushedCompactionCount =
       activeSessionEntry?.compactionCount ??
       (params.sessionKey ? activeSessionStore?.[params.sessionKey]?.compactionCount : 0) ??

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -150,6 +150,15 @@ type PendingMemoryFlush = {
 const pendingMemoryFlushes = new Map<string, PendingMemoryFlush>();
 
 const DEFAULT_PENDING_MEMORY_FLUSH_BARRIER_TIMEOUT_MS = 30_000;
+// Bounded grace period after the barrier invokes the registered abort
+// callback. If the flush promise still has not settled within this
+// window (e.g. the abort callback throws, or the embedded runner does
+// not honour its AbortSignal), the barrier abandons the pending entry
+// and returns so the next preflight is not blocked indefinitely. The
+// abandoned flush may still complete later and mutate session state;
+// that risk is bounded and explicitly preferred over an unbounded
+// availability hang.
+const POST_ABORT_GRACE_MS = 5_000;
 
 export function registerPendingMemoryFlush(
   sessionKey: string,
@@ -174,7 +183,7 @@ export function registerPendingMemoryFlush(
 
 export async function awaitPendingMemoryFlush(
   sessionKey: string | undefined,
-  options?: { timeoutMs?: number },
+  options?: { timeoutMs?: number; postAbortGraceMs?: number },
 ): Promise<void> {
   if (!sessionKey) {
     return;
@@ -184,6 +193,7 @@ export async function awaitPendingMemoryFlush(
     return;
   }
   const timeoutMs = options?.timeoutMs ?? DEFAULT_PENDING_MEMORY_FLUSH_BARRIER_TIMEOUT_MS;
+  const postAbortGraceMs = options?.postAbortGraceMs ?? POST_ABORT_GRACE_MS;
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<"timeout">((resolve) => {
     timer = setTimeout(() => resolve("timeout"), timeoutMs);
@@ -202,13 +212,38 @@ export async function awaitPendingMemoryFlush(
       } catch (err) {
         logVerbose(`pending memory flush abort callback threw: ${String(err)}`);
       }
-      // Wait for the now-aborting flush to fully settle so the barrier
-      // cannot return while the flush is still racing the next
-      // compaction's session-state mutations. The flush's
-      // runWithModelFallback / runEmbeddedPiAgent see the maintenance
-      // op's aborted abortSignal and short-circuit quickly; the wrapped
-      // promise always resolves (never throws) by construction.
-      await pending.promise;
+      // Bounded wait for the now-aborting flush to fully settle so the
+      // barrier cannot return while the flush is still racing the next
+      // compaction's session-state mutations. If the abort callback
+      // does not make the flush settle within POST_ABORT_GRACE_MS
+      // (e.g. the embedded runner ignores its AbortSignal), abandon
+      // the pending entry so subsequent turns are not blocked
+      // indefinitely. The flush's runWithModelFallback /
+      // runEmbeddedPiAgent normally see the maintenance op's aborted
+      // abortSignal and short-circuit well inside this window; the
+      // wrapped promise always resolves (never throws) by construction.
+      let graceTimer: ReturnType<typeof setTimeout> | undefined;
+      const gracePromise = new Promise<"graced">((resolve) => {
+        graceTimer = setTimeout(() => resolve("graced"), postAbortGraceMs);
+      });
+      try {
+        const graceOutcome = await Promise.race([
+          pending.promise.then(() => "settled" as const),
+          gracePromise,
+        ]);
+        if (graceOutcome === "graced") {
+          logVerbose(
+            `pending memory flush did not settle within ${postAbortGraceMs}ms after abort for sessionKey=${sessionKey}; abandoning entry so further turns are not blocked`,
+          );
+          if (pendingMemoryFlushes.get(sessionKey) === pending) {
+            pendingMemoryFlushes.delete(sessionKey);
+          }
+        }
+      } finally {
+        if (graceTimer !== undefined) {
+          clearTimeout(graceTimer);
+        }
+      }
     }
   } finally {
     if (timer !== undefined) {

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -25,6 +25,10 @@ import {
   type MemoryFlushPlanResolver,
 } from "../../plugins/memory-state.js";
 import type { TemplateContext } from "../templating.js";
+import {
+  awaitPendingMemoryFlush,
+  clearPendingMemoryFlushesForTest,
+} from "./agent-runner-memory.js";
 import type { FollowupRun, QueueSettings } from "./queue.js";
 import { scheduleFollowupDrain } from "./queue.js";
 import { testing as replyRunRegistryTesting, replyRunRegistry } from "./reply-run-registry.js";
@@ -2544,6 +2548,11 @@ describe("runReplyAgent fallback reasoning tags", () => {
         compactionCount: 0,
       },
     });
+
+    // The near-threshold memory flush is now dispatched post-reply
+    // (fire-and-forget). Wait for the pending flush before asserting on its
+    // embedded-run params.
+    await awaitPendingMemoryFlush("main");
 
     const flushCall = runEmbeddedAgentMock.mock.calls.find(([params]) =>
       (params as EmbeddedAgentParams | undefined)?.prompt?.includes("Pre-compaction memory flush."),

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -68,7 +68,11 @@ import {
   isAudioPayload,
   signalTypingIfNeeded,
 } from "./agent-runner-helpers.js";
-import { runMemoryFlushIfNeeded, runPreflightCompactionIfNeeded } from "./agent-runner-memory.js";
+import {
+  registerPendingMemoryFlush,
+  runMemoryFlushIfNeeded,
+  runPreflightCompactionIfNeeded,
+} from "./agent-runner-memory.js";
 import { buildReplyPayloads } from "./agent-runner-payloads.js";
 import {
   appendUnscheduledReminderNote,
@@ -1347,66 +1351,37 @@ export async function runReplyAgent(params: {
     preflightCompactionApplied =
       (activeSessionEntry?.compactionCount ?? 0) > prePreflightCompactionCount;
 
-    const visibleMemoryFlushErrorPayloads: ReplyPayload[] = [];
-    activeSessionEntry = await traceAgentPhase("reply.memory_flush", () =>
-      runMemoryFlushIfNeeded({
-        cfg,
-        followupRun,
-        promptForEstimate: followupRun.prompt,
-        sessionCtx,
-        opts,
-        defaultModel,
-        agentCfgContextTokens,
-        resolvedVerboseLevel,
-        sessionEntry: activeSessionEntry,
-        sessionStore: activeSessionStore,
-        sessionKey,
-        runtimePolicySessionKey,
-        storePath,
-        isHeartbeat,
-        replyOperation,
-        onVisibleErrorPayloads: (payloads) => {
-          visibleMemoryFlushErrorPayloads.push(...payloads);
-        },
-      }),
-    );
-
-    if (visibleMemoryFlushErrorPayloads.length > 0) {
-      const currentMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
-      const payloadResult = await buildReplyPayloads({
-        payloads: visibleMemoryFlushErrorPayloads,
-        isHeartbeat,
-        didLogHeartbeatStrip: false,
-        silentExpected: true,
-        blockStreamingEnabled,
-        blockReplyPipeline,
-        replyToMode,
-        replyToChannel,
-        currentMessageId,
-        replyThreading: replyThreadingOverride ?? sessionCtx.ReplyThreading,
-        messageProvider: followupRun.run.messageProvider,
-        originatingChannel: sessionCtx.OriginatingChannel,
-        originatingTo: resolveOriginMessageTo({
-          originatingTo: sessionCtx.OriginatingTo,
-          to: sessionCtx.To,
+    // Near-threshold memory flush dispatch is deferred to the post-reply
+    // path so it does not block the start of the user-visible reply turn.
+    // The flush is registered into a per-sessionKey pending map; the next
+    // turn's preflight compaction awaits it before mutating session state.
+    const dispatchPostReplyMemoryFlush = (): void => {
+      const flushPromise = traceAgentPhase("reply.memory_flush", () =>
+        runMemoryFlushIfNeeded({
+          cfg,
+          followupRun,
+          promptForEstimate: followupRun.prompt,
+          sessionCtx,
+          opts,
+          defaultModel,
+          agentCfgContextTokens,
+          resolvedVerboseLevel,
+          sessionEntry: activeSessionEntry,
+          sessionStore: activeSessionStore,
+          sessionKey,
+          runtimePolicySessionKey,
+          storePath,
+          isHeartbeat,
+          replyOperation,
         }),
-        accountId: sessionCtx.AccountId,
-        normalizeMediaPaths: replyMediaContext.normalizePayload,
-      });
-      const replyPayloads = payloadResult.replyPayloads.map((payload) =>
-        markReplyPayloadForSourceSuppressionDelivery(payload),
       );
-      if (replyPayloads.length > 0) {
-        replyOperation.fail(
-          "run_failed",
-          new Error("memory flush produced visible error payloads"),
-        );
-        await signalTypingIfNeeded(replyPayloads, typingSignals);
-        return returnWithQueuedFollowupDrain(
-          replyPayloads.length === 1 ? replyPayloads[0] : replyPayloads,
-        );
+      if (sessionKey) {
+        registerPendingMemoryFlush(sessionKey, flushPromise);
       }
-    }
+      void flushPromise.catch((err) => {
+        logVerbose(`post-reply memory flush failed: ${String(err)}`);
+      });
+    };
 
     runFollowupTurn = createFollowupRunner({
       opts,
@@ -1463,6 +1438,14 @@ export async function runReplyAgent(params: {
 
     replyOperation.setPhase("running");
     const runStartedAt = Date.now();
+    let postReplyFlushDispatched = false;
+    const ensureMemoryFlushDispatched = (): void => {
+      if (postReplyFlushDispatched) {
+        return;
+      }
+      postReplyFlushDispatched = true;
+      dispatchPostReplyMemoryFlush();
+    };
     const runOutcome = await traceAgentPhase("reply.run_agent_turn", () =>
       runAgentTurnWithFallback({
         commandBody,
@@ -1493,6 +1476,8 @@ export async function runReplyAgent(params: {
         replyMediaContext,
       }),
     );
+
+    ensureMemoryFlushDispatched();
 
     if (runOutcome.kind === "final") {
       if (!replyOperation.result) {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1329,6 +1329,48 @@ export async function runReplyAgent(params: {
   const prePreflightCompactionCount = activeSessionEntry?.compactionCount ?? 0;
   let preflightCompactionApplied = false;
 
+  // Near-threshold memory flush dispatch is deferred until after the reply
+  // path has fully unwound (after replyOperation.complete()). The flush's
+  // embedded run can internally trigger a compaction that mutates
+  // followupRun.run.sessionId and calls replyOperation.updateSessionId(...),
+  // so it must not run concurrently with the post-reply orchestrator work
+  // (usage accounting, auto-compaction handling, payload delivery state).
+  // The flush is registered into a per-sessionKey pending map; the next
+  // turn's preflight compaction awaits it before mutating session state.
+  let postReplyFlushDispatched = false;
+  let replyPathReached = false;
+  const ensureMemoryFlushDispatched = (): void => {
+    if (postReplyFlushDispatched) {
+      return;
+    }
+    postReplyFlushDispatched = true;
+    const flushPromise = traceAgentPhase("reply.memory_flush", () =>
+      runMemoryFlushIfNeeded({
+        cfg,
+        followupRun,
+        promptForEstimate: followupRun.prompt,
+        sessionCtx,
+        opts,
+        defaultModel,
+        agentCfgContextTokens,
+        resolvedVerboseLevel,
+        sessionEntry: activeSessionEntry,
+        sessionStore: activeSessionStore,
+        sessionKey,
+        runtimePolicySessionKey,
+        storePath,
+        isHeartbeat,
+        replyOperation,
+      }),
+    );
+    if (sessionKey) {
+      registerPendingMemoryFlush(sessionKey, flushPromise);
+    }
+    void flushPromise.catch((err) => {
+      logVerbose(`post-reply memory flush failed: ${String(err)}`);
+    });
+  };
+
   try {
     await typingSignals.signalRunStart();
 
@@ -1350,38 +1392,6 @@ export async function runReplyAgent(params: {
     );
     preflightCompactionApplied =
       (activeSessionEntry?.compactionCount ?? 0) > prePreflightCompactionCount;
-
-    // Near-threshold memory flush dispatch is deferred to the post-reply
-    // path so it does not block the start of the user-visible reply turn.
-    // The flush is registered into a per-sessionKey pending map; the next
-    // turn's preflight compaction awaits it before mutating session state.
-    const dispatchPostReplyMemoryFlush = (): void => {
-      const flushPromise = traceAgentPhase("reply.memory_flush", () =>
-        runMemoryFlushIfNeeded({
-          cfg,
-          followupRun,
-          promptForEstimate: followupRun.prompt,
-          sessionCtx,
-          opts,
-          defaultModel,
-          agentCfgContextTokens,
-          resolvedVerboseLevel,
-          sessionEntry: activeSessionEntry,
-          sessionStore: activeSessionStore,
-          sessionKey,
-          runtimePolicySessionKey,
-          storePath,
-          isHeartbeat,
-          replyOperation,
-        }),
-      );
-      if (sessionKey) {
-        registerPendingMemoryFlush(sessionKey, flushPromise);
-      }
-      void flushPromise.catch((err) => {
-        logVerbose(`post-reply memory flush failed: ${String(err)}`);
-      });
-    };
 
     runFollowupTurn = createFollowupRunner({
       opts,
@@ -1438,14 +1448,12 @@ export async function runReplyAgent(params: {
 
     replyOperation.setPhase("running");
     const runStartedAt = Date.now();
-    let postReplyFlushDispatched = false;
-    const ensureMemoryFlushDispatched = (): void => {
-      if (postReplyFlushDispatched) {
-        return;
-      }
-      postReplyFlushDispatched = true;
-      dispatchPostReplyMemoryFlush();
-    };
+    // Mark that the reply path has been reached. The finally block uses this
+    // flag to decide whether to dispatch the post-reply memory flush: if
+    // preflight compaction threw before the reply could start, no flush is
+    // dispatched for this turn (preserves the prior behavior where a
+    // preflight failure also skipped the flush).
+    replyPathReached = true;
     const runOutcome = await traceAgentPhase("reply.run_agent_turn", () =>
       runAgentTurnWithFallback({
         commandBody,
@@ -1476,8 +1484,6 @@ export async function runReplyAgent(params: {
         replyMediaContext,
       }),
     );
-
-    ensureMemoryFlushDispatched();
 
     if (runOutcome.kind === "final") {
       if (!replyOperation.result) {
@@ -2216,6 +2222,20 @@ export async function runReplyAgent(params: {
       replyOperation.completeThen(drainQueuedFollowupsAfterClear);
     } else {
       replyOperation.complete();
+    }
+    // Near-threshold memory flush is dispatched after the reply operation has
+    // fully completed. Calls into ReplyOperation that the flush makes after
+    // this point (setPhase, updateSessionId) are no-ops by ReplyOperation's
+    // own contract once `result` is set, so the flush can drive its embedded
+    // run, mutate sessionStore, and persist memoryFlushAt /
+    // memoryFlushCompactionCount without racing the reply path. If the reply
+    // was aborted, replyOperation.abortSignal is in the aborted state and the
+    // flush's runWithModelFallback short-circuits before starting any
+    // embedded work. The dispatch is gated on replyPathReached so a preflight
+    // compaction failure that prevented the reply from starting also skips
+    // the flush (matches the prior behavior of the inline pre-reply flush).
+    if (replyPathReached) {
+      ensureMemoryFlushDispatched();
     }
     blockReplyPipeline?.stop();
     typing.markRunComplete();

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -99,7 +99,13 @@ import {
   type QueueSettings,
 } from "./queue.js";
 import { createReplyMediaContext } from "./reply-media-paths.js";
-import { replyRunRegistry, type ReplyOperation } from "./reply-run-registry.js";
+import {
+  createMaintenanceReplyOperation,
+  createReplyOperation,
+  ReplyRunAlreadyActiveError,
+  replyRunRegistry,
+  type ReplyOperation,
+} from "./reply-run-registry.js";
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
 import { admitReplyTurn, resolveReplyTurnKind } from "./reply-turn-admission.js";
 import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-run-accounting.js";
@@ -1332,11 +1338,21 @@ export async function runReplyAgent(params: {
   // Near-threshold memory flush dispatch is deferred until after the reply
   // path has fully unwound (after replyOperation.complete()). The flush's
   // embedded run can internally trigger a compaction that mutates
-  // followupRun.run.sessionId and calls replyOperation.updateSessionId(...),
-  // so it must not run concurrently with the post-reply orchestrator work
-  // (usage accounting, auto-compaction handling, payload delivery state).
-  // The flush is registered into a per-sessionKey pending map; the next
-  // turn's preflight compaction awaits it before mutating session state.
+  // followupRun.run.sessionId, so it must not run concurrently with the
+  // post-reply orchestrator work (usage accounting, auto-compaction
+  // handling, payload delivery state). The flush is registered into a
+  // per-sessionKey pending map; the next turn's preflight compaction
+  // awaits it before mutating session state.
+  //
+  // The reply's ReplyOperation has already been `complete()`d by the
+  // outer finally block when this closure runs, so passing it into
+  // `runMemoryFlushIfNeeded` would cancel the embedded runner's
+  // `attachBackend(...)` call via the completed-operation contract in
+  // `reply-run-registry.ts:attachBackend`. Build a flush-scoped
+  // maintenance ReplyOperation per dispatch so the embedded runner sees
+  // a non-completed operation and can run its housekeeping work.
+  // Aborts on the original reply's signal propagate into the maintenance
+  // operation so a user abort still stops the flush.
   let postReplyFlushDispatched = false;
   let replyPathReached = false;
   const ensureMemoryFlushDispatched = (): void => {
@@ -1344,6 +1360,20 @@ export async function runReplyAgent(params: {
       return;
     }
     postReplyFlushDispatched = true;
+    const flushSessionKey = sessionKey ?? followupRun.run.sessionKey;
+    const flushSessionId =
+      activeSessionEntry?.sessionId ?? followupRun.run.sessionId ?? replyOperation.sessionId;
+    if (!flushSessionKey || !flushSessionId) {
+      logVerbose(
+        "post-reply memory flush skipped: missing sessionKey or sessionId at dispatch time",
+      );
+      return;
+    }
+    const maintenanceReplyOperation = createMaintenanceReplyOperation({
+      sessionKey: flushSessionKey,
+      sessionId: flushSessionId,
+      upstreamAbortSignal: replyOperation.abortSignal,
+    });
     const flushPromise = traceAgentPhase("reply.memory_flush", () =>
       runMemoryFlushIfNeeded({
         cfg,
@@ -1360,15 +1390,19 @@ export async function runReplyAgent(params: {
         runtimePolicySessionKey,
         storePath,
         isHeartbeat,
-        replyOperation,
+        replyOperation: maintenanceReplyOperation,
       }),
     );
     if (sessionKey) {
       registerPendingMemoryFlush(sessionKey, flushPromise);
     }
-    void flushPromise.catch((err) => {
-      logVerbose(`post-reply memory flush failed: ${String(err)}`);
-    });
+    void flushPromise
+      .catch((err) => {
+        logVerbose(`post-reply memory flush failed: ${String(err)}`);
+      })
+      .finally(() => {
+        maintenanceReplyOperation.complete();
+      });
   };
 
   try {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -101,8 +101,6 @@ import {
 import { createReplyMediaContext } from "./reply-media-paths.js";
 import {
   createMaintenanceReplyOperation,
-  createReplyOperation,
-  ReplyRunAlreadyActiveError,
   replyRunRegistry,
   type ReplyOperation,
 } from "./reply-run-registry.js";

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1394,7 +1394,15 @@ export async function runReplyAgent(params: {
       }),
     );
     if (sessionKey) {
-      registerPendingMemoryFlush(sessionKey, flushPromise);
+      // Pass an abort callback so the next turn's preflight barrier can
+      // make a wait-cap timeout terminal: on timeout the barrier aborts
+      // the maintenance ReplyOperation (which cancels the attached
+      // backend handle and aborts the embedded run's abortSignal) and
+      // then awaits the flush promise's settlement before proceeding to
+      // any new compaction state mutation.
+      registerPendingMemoryFlush(sessionKey, flushPromise, () => {
+        maintenanceReplyOperation.abortForRestart();
+      });
     }
     void flushPromise
       .catch((err) => {

--- a/src/auto-reply/reply/reply-run-registry.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.test.ts
@@ -6,6 +6,7 @@ import {
 import {
   testing,
   abortActiveReplyRuns,
+  createMaintenanceReplyOperation,
   createReplyOperation,
   forceClearReplyRunBySessionId,
   isReplyRunActiveForSessionId,
@@ -175,6 +176,88 @@ describe("reply run registry", () => {
 
     expect(queueReplyRunMessage("session-running", "hello")).toBe(true);
     expect(queueMessage).toHaveBeenCalledWith("hello");
+  });
+
+  describe("createMaintenanceReplyOperation", () => {
+    it("does not register the operation in the active-run registry, so it can coexist with the live reply operation for the same sessionKey", () => {
+      const liveOperation = createReplyOperation({
+        sessionKey: "agent:main:maint-coexist",
+        sessionId: "session-live",
+        resetTriggered: false,
+      });
+      // Without the maintenance distinction, creating a second op for the
+      // same sessionKey would throw ReplyRunAlreadyActiveError.
+      const maintenanceOperation = createMaintenanceReplyOperation({
+        sessionKey: "agent:main:maint-coexist",
+        sessionId: "session-live",
+      });
+      expect(liveOperation).not.toBe(maintenanceOperation);
+      expect(isReplyRunActiveForSessionId("session-live")).toBe(true);
+      expect(replyRunRegistry.get("agent:main:maint-coexist")).toBe(liveOperation);
+      liveOperation.complete();
+    });
+
+    it("attachBackend stores the handle (does NOT cancel it) when the maintenance operation has not completed", () => {
+      const op = createMaintenanceReplyOperation({
+        sessionKey: "agent:main:maint-attach",
+        sessionId: "session-maint",
+      });
+      const cancel = vi.fn();
+      const detach = vi.fn();
+      op.attachBackend({ cancel, detach } as never);
+      expect(cancel).not.toHaveBeenCalled();
+    });
+
+    it("attachBackend cancels the handle with 'superseded' if complete() ran first", () => {
+      const op = createMaintenanceReplyOperation({
+        sessionKey: "agent:main:maint-completed",
+        sessionId: "session-maint-completed",
+      });
+      op.complete();
+      const cancel = vi.fn();
+      op.attachBackend({ cancel, detach: vi.fn() } as never);
+      expect(cancel).toHaveBeenCalledWith("superseded");
+    });
+
+    it("propagates upstream abort into the maintenance operation's abortSignal", () => {
+      const upstream = new AbortController();
+      const op = createMaintenanceReplyOperation({
+        sessionKey: "agent:main:maint-abort",
+        sessionId: "session-maint-abort",
+        upstreamAbortSignal: upstream.signal,
+      });
+      expect(op.abortSignal.aborted).toBe(false);
+      upstream.abort(new Error("user cancelled"));
+      expect(op.abortSignal.aborted).toBe(true);
+    });
+
+    it("inherits the upstream's already-aborted state at construction time", () => {
+      const upstream = new AbortController();
+      upstream.abort(new Error("preempt"));
+      const op = createMaintenanceReplyOperation({
+        sessionKey: "agent:main:maint-pre-abort",
+        sessionId: "session-maint-pre-abort",
+        upstreamAbortSignal: upstream.signal,
+      });
+      expect(op.abortSignal.aborted).toBe(true);
+    });
+
+    it("complete() does not call clearReplyRunState (so it cannot disturb a live reply operation for the same sessionKey)", () => {
+      const liveOperation = createReplyOperation({
+        sessionKey: "agent:main:maint-complete-isolation",
+        sessionId: "session-live-iso",
+        resetTriggered: false,
+      });
+      const maintenanceOperation = createMaintenanceReplyOperation({
+        sessionKey: "agent:main:maint-complete-isolation",
+        sessionId: "session-live-iso",
+      });
+      maintenanceOperation.complete();
+      // The live reply operation must still be registered as active.
+      expect(replyRunRegistry.get("agent:main:maint-complete-isolation")).toBe(liveOperation);
+      expect(isReplyRunActiveForSessionId("session-live-iso")).toBe(true);
+      liveOperation.complete();
+    });
   });
 
   it("aborts compacting runs through the registry compatibility helper", () => {

--- a/src/auto-reply/reply/reply-run-registry.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.test.ts
@@ -242,6 +242,37 @@ describe("reply run registry", () => {
       expect(op.abortSignal.aborted).toBe(true);
     });
 
+    it("complete() detaches the upstream abort listener so it does not survive past terminal state", () => {
+      const upstream = new AbortController();
+      const addSpy = vi.spyOn(upstream.signal, "addEventListener");
+      const removeSpy = vi.spyOn(upstream.signal, "removeEventListener");
+      const op = createMaintenanceReplyOperation({
+        sessionKey: "agent:main:maint-listener",
+        sessionId: "session-maint-listener",
+        upstreamAbortSignal: upstream.signal,
+      });
+      expect(addSpy).toHaveBeenCalledWith("abort", expect.any(Function), { once: true });
+      const addedListener = addSpy.mock.calls[0]?.[1] as EventListener;
+      op.complete();
+      expect(removeSpy).toHaveBeenCalledWith("abort", addedListener);
+      // Aborting upstream after the maintenance op has completed must
+      // not flip the maintenance op's signal: it is already complete.
+      upstream.abort(new Error("late upstream abort"));
+      expect(op.abortSignal.aborted).toBe(false);
+    });
+
+    it("fail() also detaches the upstream abort listener", () => {
+      const upstream = new AbortController();
+      const removeSpy = vi.spyOn(upstream.signal, "removeEventListener");
+      const op = createMaintenanceReplyOperation({
+        sessionKey: "agent:main:maint-listener-fail",
+        sessionId: "session-maint-listener-fail",
+        upstreamAbortSignal: upstream.signal,
+      });
+      op.fail("run_failed", new Error("boom"));
+      expect(removeSpy).toHaveBeenCalledWith("abort", expect.any(Function));
+    });
+
     it("complete() does not call clearReplyRunState (so it cannot disturb a live reply operation for the same sessionKey)", () => {
       const liveOperation = createReplyOperation({
         sessionKey: "agent:main:maint-complete-isolation",

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -418,7 +418,7 @@ export function createReplyOperation(params: {
  * `clearReplyRunState` / `markReplyRunDiagnosticWorkEnded`.
  *
  * Use this instead of passing a completed reply operation into
- * `runEmbeddedPiAgent`: the embedded runner calls `attachBackend(...)`
+ * `runEmbeddedAgent`: the embedded runner calls `attachBackend(...)`
  * which cancels any handle attached to a completed reply operation, so
  * the deferred work would never reach its LLM call.
  *

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -408,6 +408,157 @@ export function createReplyOperation(params: {
   return operation;
 }
 
+/**
+ * Build a flush-safe ReplyOperation for background maintenance work
+ * (e.g. the deferred memory-flush dispatched after the user-visible reply
+ * has already finalized). The returned operation has its own
+ * AbortController and local lifecycle state, and is **not** registered in
+ * `replyRunState`, so it does not conflict with the active reply
+ * operation for the same `sessionKey` and does not race
+ * `clearReplyRunState` / `markReplyRunDiagnosticWorkEnded`.
+ *
+ * Use this instead of passing a completed reply operation into
+ * `runEmbeddedPiAgent`: the embedded runner calls `attachBackend(...)`
+ * which cancels any handle attached to a completed reply operation, so
+ * the deferred work would never reach its LLM call.
+ *
+ * If `upstreamAbortSignal` is supplied (e.g. the original reply's
+ * `abortSignal`), abort is propagated one-way into the maintenance
+ * operation so an explicit user-abort still stops the background work.
+ */
+export function createMaintenanceReplyOperation(params: {
+  sessionKey: string;
+  sessionId: string;
+  upstreamAbortSignal?: AbortSignal;
+}): ReplyOperation {
+  const sessionKey = normalizeOptionalString(params.sessionKey);
+  const sessionId = normalizeOptionalString(params.sessionId);
+  if (!sessionKey) {
+    throw new Error("Maintenance reply operations require a canonical sessionKey");
+  }
+  if (!sessionId) {
+    throw new Error("Maintenance reply operations require a sessionId");
+  }
+
+  const controller = new AbortController();
+  let currentSessionId = sessionId;
+  let phase: ReplyOperationPhase = "queued";
+  let result: ReplyOperationResult | null = null;
+  let attachedHandle: ReplyBackendHandle | undefined;
+
+  const abortInternally = (reason?: unknown) => {
+    if (!controller.signal.aborted) {
+      controller.abort(reason);
+    }
+  };
+
+  if (params.upstreamAbortSignal) {
+    if (params.upstreamAbortSignal.aborted) {
+      abortInternally(params.upstreamAbortSignal.reason);
+    } else {
+      params.upstreamAbortSignal.addEventListener(
+        "abort",
+        () => {
+          abortInternally(params.upstreamAbortSignal?.reason);
+        },
+        { once: true },
+      );
+    }
+  }
+
+  const operation: ReplyOperation = {
+    get key() {
+      return sessionKey;
+    },
+    get sessionId() {
+      return currentSessionId;
+    },
+    get abortSignal() {
+      return controller.signal;
+    },
+    get resetTriggered() {
+      return false;
+    },
+    get phase() {
+      return phase;
+    },
+    get result() {
+      return result;
+    },
+    setPhase(next) {
+      if (result) {
+        return;
+      }
+      phase = next;
+    },
+    updateSessionId(nextSessionId) {
+      if (result) {
+        return;
+      }
+      const normalized = normalizeOptionalString(nextSessionId);
+      if (!normalized || normalized === currentSessionId) {
+        return;
+      }
+      currentSessionId = normalized;
+    },
+    attachBackend(handle) {
+      if (result) {
+        handle.cancel(
+          result.kind === "aborted"
+            ? result.code === "aborted_for_restart"
+              ? "restart"
+              : "user_abort"
+            : "superseded",
+        );
+        return;
+      }
+      attachedHandle = handle;
+      if (controller.signal.aborted) {
+        handle.cancel("superseded");
+      }
+    },
+    detachBackend(handle) {
+      if (attachedHandle === handle) {
+        attachedHandle = undefined;
+      }
+    },
+    complete() {
+      if (!result) {
+        result = { kind: "completed" };
+        phase = "completed";
+      }
+    },
+    completeThen(afterClear) {
+      operation.complete();
+      afterClear();
+    },
+    fail(code, cause) {
+      if (!result) {
+        result = { kind: "failed", code, cause };
+        phase = "failed";
+      }
+    },
+    abortByUser() {
+      if (!result) {
+        result = { kind: "aborted", code: "aborted_by_user" };
+        phase = "aborted";
+      }
+      abortInternally(createUserAbortError());
+      attachedHandle?.cancel("user_abort");
+    },
+    abortForRestart() {
+      if (!result) {
+        result = { kind: "aborted", code: "aborted_for_restart" };
+        phase = "aborted";
+      }
+      abortInternally(new Error("Maintenance reply operation aborted for restart"));
+      attachedHandle?.cancel("restart");
+    },
+  };
+
+  return operation;
+}
+
 export const replyRunRegistry: ReplyRunRegistry = {
   begin(params) {
     return createReplyOperation(params);

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -452,17 +452,24 @@ export function createMaintenanceReplyOperation(params: {
     }
   };
 
-  if (params.upstreamAbortSignal) {
-    if (params.upstreamAbortSignal.aborted) {
-      abortInternally(params.upstreamAbortSignal.reason);
+  const upstreamSignal = params.upstreamAbortSignal;
+  let upstreamAbortListener: (() => void) | undefined;
+  const detachUpstreamListener = (): void => {
+    if (upstreamSignal && upstreamAbortListener) {
+      upstreamSignal.removeEventListener("abort", upstreamAbortListener);
+      upstreamAbortListener = undefined;
+    }
+  };
+
+  if (upstreamSignal) {
+    if (upstreamSignal.aborted) {
+      abortInternally(upstreamSignal.reason);
     } else {
-      params.upstreamAbortSignal.addEventListener(
-        "abort",
-        () => {
-          abortInternally(params.upstreamAbortSignal?.reason);
-        },
-        { once: true },
-      );
+      upstreamAbortListener = () => {
+        abortInternally(upstreamSignal.reason);
+        upstreamAbortListener = undefined;
+      };
+      upstreamSignal.addEventListener("abort", upstreamAbortListener, { once: true });
     }
   }
 
@@ -527,6 +534,7 @@ export function createMaintenanceReplyOperation(params: {
         result = { kind: "completed" };
         phase = "completed";
       }
+      detachUpstreamListener();
     },
     completeThen(afterClear) {
       operation.complete();
@@ -537,6 +545,7 @@ export function createMaintenanceReplyOperation(params: {
         result = { kind: "failed", code, cause };
         phase = "failed";
       }
+      detachUpstreamListener();
     },
     abortByUser() {
       if (!result) {
@@ -545,6 +554,7 @@ export function createMaintenanceReplyOperation(params: {
       }
       abortInternally(createUserAbortError());
       attachedHandle?.cancel("user_abort");
+      detachUpstreamListener();
     },
     abortForRestart() {
       if (!result) {
@@ -553,6 +563,7 @@ export function createMaintenanceReplyOperation(params: {
       }
       abortInternally(new Error("Maintenance reply operation aborted for restart"));
       attachedHandle?.cancel("restart");
+      detachUpstreamListener();
     },
   };
 


### PR DESCRIPTION
## Summary

- **Problem:** for a near-threshold auto-reply turn the orchestrator
  awaited the near-threshold memory flush (an embedded housekeeping
  LLM call) before starting the user-visible reply path, so every
  message that crossed the flush threshold paid the flush wall time
  on the **critical path** between user message arrival and reply
  delivery.
- **Requirement:** the user-visible reply should not wait for a flush
  whose only safety contract is "complete before the next compaction
  mutates session state."
- **Fix:** dispatch the memory flush from the reply orchestrator's
  `finally` block (after `replyOperation.complete()`), register the
  in-flight flush in a per-`sessionKey` map, and **preserve the
  pre-compaction safety contract** by gating the next turn's
  preflight compaction on a bounded barrier that awaits the prior
  pending flush.
- **Out of scope:** the flush body, the existing
  `memoryFlushCompactionCount` /
  `hasAlreadyFlushedForCurrentCompaction` dedup semantics, heartbeat
  / CLI / followup-runner paths, persisted session state format.

## Motivation

On a threshold-crossing turn the inline ordering was
`preflight compaction → runMemoryFlushIfNeeded (LLM call) →
runAgentTurnWithFallback`. The user-visible reply could not start
until the housekeeping LLM call returned. Moving the housekeeping
dispatch off the user-visible reply startup path lets the reply turn
begin as soon as preflight compaction has resolved, while still
resolving any required flush before a later compaction can mutate
session state.

## Files

- `src/auto-reply/reply/agent-runner.ts` — dispatch the housekeeping
  flush from the orchestrator's `finally` block; gate the dispatch on
  the reply path being reached; register the in-flight flush with an
  abort callback.
- `src/auto-reply/reply/agent-runner-memory.ts` — pending-flush
  registry, pre-compaction `awaitPendingMemoryFlush` barrier with a
  wait-cap and a bounded post-abort grace; post-barrier `sessionId`
  rebind; `logVerbose` forwarding for visible flush error payloads
  that have no caller-supplied surface.
- `src/auto-reply/reply/reply-run-registry.ts` — new
  `createMaintenanceReplyOperation` export. The post-reply dispatch
  passes a maintenance `ReplyOperation` (not the original, already
  `complete()`d reply op) into `runMemoryFlushIfNeeded` so the
  embedded runner's `attachBackend(queueHandle)` call is not
  cancelled by the completed-operation contract in
  `reply-run-registry.ts:attachBackend`.

## Root Cause

- The deferred housekeeping LLM call was structurally on the
  user-visible reply critical path because it was awaited inline
  before the reply turn started. Its only consumer is the next
  compaction (the flush writes
  `memoryFlushAt`/`memoryFlushCompactionCount` so subsequent threshold
  evaluation is correct). The flush therefore does not need to
  complete before the reply begins; it only needs to complete before
  the next compaction begins.
- Forwarding the original `replyOperation` into
  `runMemoryFlushIfNeeded` after `replyOperation.complete()` would
  cancel the embedded runner's `attachBackend(queueHandle)` call:
  `attachBackend` cancels any handle attached to a completed
  operation with reason `"superseded"`. The deferred dispatch
  therefore builds a flush-safe maintenance `ReplyOperation` per
  call; it is not registered in `replyRunState`, has its own
  `AbortController`, and only cancels attached backends when the
  maintenance op itself is completed or aborted. The original
  reply's `abortSignal` propagates one-way into the maintenance op
  so an explicit user cancellation still stops the flush.
- The barrier wait-cap (30 s default) is made **terminal**: on
  timeout the barrier invokes a registered abort callback that aborts
  the maintenance op via `abortForRestart()` (cancelling the attached
  backend handle and aborting the embedded run's `AbortSignal`) and
  then waits for the flush promise to settle. The post-abort wait is
  itself bounded by a 5 s default grace; if the flush still has not
  settled, the pending entry is removed from the registry and the
  barrier returns so subsequent turns are not blocked indefinitely.

## Real behavior proof (required for external PRs)

This PR is verified by two evidence tracks reported under
`Evidence after fix` below. **Track A** is a live Telegram + Gemini
real-runtime smoke that exercises the PR HEAD orchestrator
end-to-end against the real network channel and the real provider.
**Track B** is a controlled runtime proof that drives the production
`runReplyAgent` orchestrator with controlled LLM-boundary stubs to
make the next-turn pending-flush barrier ordering deterministically
observable; it is the after-fix evidence for the barrier contract
(the live track does not, and is not claimed to, cover that
contract). This PR's current HEAD is
`2f338c89d78678a12e5950835ea6617b1f7b58fe`. The original capture
of the redacted runtime logs and trajectory trace excerpts shown
below was performed at the pre-rebase HEAD
`793d43f99687e3a1047dd22b59cdffcea0857df8`. The current HEAD is
the rebase of that branch onto `upstream/main`, which absorbs the
internal-handoff provenance guards from #85726 (the
`shouldPreserveUserFacingSessionStateForInputProvenance` import
plus the six `preserveUserFacingSessionState` guard sites in
`src/auto-reply/reply/agent-runner.ts` covering fallback state
updates, fallback notices, fallback cleared notices, response
usage footer, and the maintenance state preservation flag).
Exactly one conflict was resolved during the rebase: an
import-block expansion in `src/auto-reply/reply/agent-runner.ts`
to include `createMaintenanceReplyOperation` /
`createReplyOperation` / `ReplyRunAlreadyActiveError` alongside
the existing `replyRunRegistry` / `ReplyOperation` imports (the
maintenance-flush path requires these three additional
constructors). The PR's post-reply-dispatch behavior and the
next-turn pending-flush barrier are unchanged between the two
SHAs; the focused auto-reply test suite
(`agent-runner-direct-runtime-config`, `reply-run-registry`,
`agent-runner-memory`, `agent-runner.runreplyagent.e2e`,
`followup-runner`, `session`) and the internal-handoff
provenance test (`src/sessions/input-provenance.test.ts`) all
pass on the current HEAD.

A subsequent rebase from `1c7767841489f4037d933b8f977223f1b428197b`
onto upstream/main `efebf6bfcfa89f22e7c154db4d2718c409ada335`
resolved one conflict in `src/auto-reply/reply/agent-runner-memory.ts`:
keeping the upstream-added `isRecoverableNativeHarnessBindingFailure`
helper (used by the recoverable native-harness retry path at the call
site near `runWithEmbeddedRuntime`) alongside the PR's pending
memory-flush registry (`pendingMemoryFlushes`,
`registerPendingMemoryFlush`, `awaitPendingMemoryFlush`,
`POST_ABORT_GRACE_MS`). Both additions are non-overlapping top-level
declarations and the conflict was a pure coexistence union; the
post-reply-dispatch behavior, the pending-flush barrier contract,
and the post-abort grace semantics are unchanged. Re-ran focused
suites on the new HEAD (`agent-runner-direct-runtime-config`,
`reply-run-registry`, `agent-runner-memory`,
`agent-runner.misc.runreplyagent`, `src/sessions/input-provenance`):
all pass.

- **Behavior addressed:** for the near-threshold flush-required
  turn, the user-visible reply path no longer waits for the
  housekeeping LLM call to complete. The housekeeping run still
  runs, just after the reply has finalized. A later preflight
  compaction waits for any unfinished required flush before
  modifying session state (pending-flush barrier contract).

- **Real environment tested:**
  Track A — a local OpenClaw gateway running PR HEAD code with
  `runtime/current` pointing at the PR worktree, a real Telegram
  bot endpoint, and the real `google` provider serving
  `gemini-3.1-flash-lite-preview`. `GEMINI_API_KEY` is sourced from
  a local `.env` file by the gateway's startup script; the gateway
  process env was verified to hold the key by name (no value read
  or printed).
  Track B — the **production** `runReplyAgent` orchestrator
  end-to-end on PR HEAD. Every orchestrator decision (preflight
  gating, post-reply dispatch site, pending-flush barrier,
  post-barrier `sessionId` rebind, maintenance `ReplyOperation`
  construction and abort wiring) runs unmodified. Controlled stubs
  are only at the LLM-boundary modules (`pi-embedded.js`,
  `model-fallback.js`) to inject deterministic wall-clock latency
  (housekeeping embedded LLM call: simulated 200 ms; user-visible
  reply turn: simulated 50 ms) so the barrier ordering and the
  before/after delta become deterministically observable. The stubs
  mirror the real embedded runner by calling
  `params.replyOperation.attachBackend(handle)`
  (`src/agents/pi-embedded-runner/run/attempt.ts:3378`) so the
  `createMaintenanceReplyOperation` contract is exercised on the
  production path. Timestamps are recorded via a wrapped
  `ReplyOperation` whose `setPhase`/`complete` methods call
  `performance.now()`. This track does not use a live provider or
  live channel; the controlled latency is used for ordering
  observability, not as a live-traffic benchmark.

- **Exact steps or command run after this patch:**

  Committed regression tests (ship with the PR; cover the
  invariants asserted by Track B):

  ```
  node scripts/run-vitest.mjs \
    src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts \
    src/auto-reply/reply/reply-run-registry.test.ts \
    src/auto-reply/reply/agent-runner-memory.test.ts
  ```

  Supplemental 3-case timing harness used to record the Track B
  excerpts below. The harness file is not committed; the invariants
  it asserts are already covered by the committed tests above.

  ```
  # BEFORE — checkout upstream/main copies of the three changed source files:
  git checkout upstream/main -- \
    src/auto-reply/reply/agent-runner.ts \
    src/auto-reply/reply/agent-runner-memory.ts \
    src/auto-reply/reply/reply-run-registry.ts
  # ...run the harness...
  # AFTER — restore PR HEAD copies and re-run the harness:
  git checkout HEAD -- \
    src/auto-reply/reply/agent-runner.ts \
    src/auto-reply/reply/agent-runner-memory.ts \
    src/auto-reply/reply/reply-run-registry.ts
  ```

  Track A's live runs were performed manually against the live
  Telegram bot endpoint and the live Gemini provider with the
  gateway running PR HEAD; the redacted runtime excerpts below
  capture the same `runReplyAgent` orchestrator handling real
  inbound and outbound traffic.

- **Evidence after fix:** the evidence below consists of redacted
  runtime logs (gateway log excerpts) and per-session trajectory
  trace excerpts captured from a real OpenClaw setup running PR
  HEAD. Two tracks are reported.

  **Track A — Live Telegram + Gemini runtime smoke**

  Real provider, real channel, real model call. Two live runs are
  reported as redacted runtime logs and trajectory log excerpts: a
  normal no-compaction turn, and a turn where the post-reply
  maintenance dispatch is forced to fire via the transcript-byte
  gate so it is observable in the trajectory.

  *Run set A.1 — no-compaction normal turn:*

  ```
  [gateway.log]
  <ts-redacted> [telegram] Inbound message telegram:<chat-id-redacted> -> <bot-redacted> (direct, <chars> chars)

  [<sid-redacted>.trajectory.jsonl]
  type=session.started   provider=google model=gemini-3.1-flash-lite-preview source=runtime
  type=model.completed   provider=google model=gemini-3.1-flash-lite-preview
                         usage={"input":24251,"output":212,"total":24463}
  type=session.ended
  ```

  Operator-observed Telegram delivery: a non-error assistant reply
  was received on the user's Telegram client and reconciled
  against the single `model.completed` event in the trajectory
  delta and the session-store `totalTokens` advancing to 24,251 on
  the same turn. Compaction did not run (token total stayed well
  below the flush threshold).

  *Run set A.2 — post-reply maintenance dispatch via transcript-byte
  gate:* On the same PR HEAD runtime, the session transcript byte
  size was inflated above the in-tree `forceFlushTranscriptBytes`
  default (2,097,152) by appending non-conversation `custom`-type
  JSONL filler records. These filler records were validated through
  the production session reader (`readSessionMessagesAsync`) to
  confirm they are not extracted as user/assistant/tool messages
  and therefore do not enter the model prompt. Token counters were
  left unchanged (well below the token threshold). A single short
  Telegram message was then sent.

  ```
  [gateway.log]
  <ts-redacted> [telegram] Inbound message telegram:<chat-id-redacted> -> <bot-redacted> (direct, <chars> chars)

  [<sid-redacted>.trajectory.jsonl, post-inbound delta]
  # Run 1 — user-visible reply on the orchestrator's main path
  type=session.started   provider=google model=gemini-3.1-flash-lite-preview source=runtime
  type=model.completed   provider=google model=gemini-3.1-flash-lite-preview
                         usage={"input":20756,"output":65,"cacheRead":4104,"total":24925}
  type=session.ended

  # Run 2 — distinct runId, starts ~2.1 s after Run 1 ends:
  # post-reply maintenance dispatch from the orchestrator's finally block
  type=session.started   provider=google model=gemini-3.1-flash-lite-preview source=runtime
  type=model.completed   provider=google model=gemini-3.1-flash-lite-preview
                         usage={"input":8637,"output":525,"total":9162}
  type=session.ended
  ```

  In the same window, `sessions.json["agent:main:main"].compactionCount`
  stayed at `0` (preflight compaction did not run; the preflight
  byte gate is disabled in this runtime config, and the token gate
  remained below threshold). The Telegram client received the
  Run 1 reply normally. All live session state mutated for the
  byte-gate run was backed up before mutation and restored
  byte-for-byte after capture (verified per-file with `cmp`); the
  inflated transcript was discarded.

  *Scope of Track A:* this track shows real provider + real channel
  + real model + a distinct second-runId post-reply maintenance
  dispatch from PR HEAD's `finally` block. It **does not** exercise
  the next-turn pending-flush barrier (cross-turn) — that contract
  is covered by Track B below. Run 2's embedded-run wrapper
  reported a non-fatal local-environment error in post-call
  processing after the model returned tokens; that local outcome
  does not affect the dispatch evidence and is unrelated to the
  PR's code change.

  **Track B — Controlled runtime proof for next-turn pending-flush barrier**

  The same production `runReplyAgent` orchestrator is driven by the
  3-case timing harness above with LLM-boundary modules
  (`pi-embedded.js`, `model-fallback.js`) controlled for
  deterministic wall-clock latency. Phase events are captured from
  the wrapped `ReplyOperation`.

  *B.1 — next-turn pending-flush barrier (after-fix evidence for
  the cross-turn ordering contract; captured as a redacted log
  excerpt and trace excerpt from the controlled runtime harness):*

  Setup: Turn 1 dispatched a memory flush. Turn 2 enters
  `runReplyAgent` while Turn 1's flush is still in flight.
  The barrier in `runPreflightCompactionIfNeeded` must hold any
  compaction state evaluation (and therefore the reply turn that
  follows) until Turn 1's pending flush settles.

  ```
  [controlled runtime, production runReplyAgent on PR HEAD]
  scenario: turn 1 dispatched a memory flush; turn 2 starts before
            that pending flush has settled.

  EVENT  turn2.orchestration.start
  EVENT  turn2.preflight_compacting.entered
  EVENT  turn2.preflight_compacting.awaiting_pending_flush
         probe: turn2.reply.phase.running set?       false
         probe: turn2.reply.agent_turn.invoked?      false
  EVENT  turn1.flush.embedded_run.completed
         (pending flush settled; barrier released)
  EVENT [   55.79 ms] turn2.reply.phase.running
         probe: turn2.reply.phase.running set?       true
         probe: turn2.reply.agent_turn.invoked?      true
                                                    (set ONLY after barrier resolution)
  EVENT [  295.66 ms] turn2.reply.operation.complete
  EVENT [  337.92 ms] turn2.flush.embedded_run.started
                     (this turn's own post-reply dispatch)
  EVENT [  538.40 ms] turn2.flush.embedded_run.completed

  barrier_held_reply_turn_until_release = true
  ```

  Harness assertions on this scenario:

  ```
  PASS  turn 2 reply.phase.running NOT set while the previous-turn
        pending flush was unresolved.
  PASS  turn 2 reply.agent_turn NOT invoked while the previous-turn
        pending flush was unresolved.
  PASS  turn 2 reply.phase.running set ONLY AFTER the previous-turn
        pending flush settled.
  PASS  pre-compaction safety contract preserved across the turn
        boundary: runPreflightCompactionIfNeeded awaited the
        externally-held pending flush before evaluating compaction
        state.
  ```

  Honest framing: the barrier is a concurrency / cross-turn
  session-state ordering contract whose correctness is binary
  (held vs not held) rather than a wall-clock latency. The
  production `runReplyAgent` orchestrator drives the path
  unchanged; only the LLM-boundary modules carry the controlled
  latency that makes the held / released boundary observable. This
  is the after-fix evidence for the pending-flush barrier
  contract.

  *B.2 — supporting ordering and non-regression context (same
  controlled runtime harness):*

  ```
  EVENT [    0.01 ms] orchestration.start
  EVENT [  710.44 ms] reply.phase.preflight_compacting
  EVENT [  718.94 ms] reply.phase.running         <-- reply starts here on PR HEAD
  EVENT [  816.17 ms] reply.agent_turn.invoked
  EVENT [  866.37 ms] reply.agent_turn.returning
  EVENT [  975.45 ms] reply.operation.complete    <-- reply complete here on PR HEAD
  EVENT [ 1022.77 ms] flush.embedded_run.started  <-- post-reply on PR HEAD
  EVENT [ 1223.52 ms] flush.embedded_run.completed
  ```

  Reference: `t_orchestration_start = 0.00 ms` (entry into
  `runReplyAgent`). Controlled stub latencies: 200 ms housekeeping
  flush, 50 ms reply turn.

  Flush-required near-threshold turn (ordering):

  | timestamp                    | BEFORE (upstream/main) | AFTER (PR HEAD) |
  |------------------------------|-----------------------:|----------------:|
  | t_reply_phase_running        |              1013.95 ms |       718.94 ms |
  | t_reply_complete             |              1221.74 ms |       975.45 ms |
  | t_flush_start                |               812.33 ms |      1022.77 ms |
  | t_flush_end                  |              1012.52 ms |      1223.52 ms |
  | **Δ pre-reply (reply-start)**|              1013.95 ms |       718.94 ms |
  | **Δ end-to-end (complete)**  |              1221.74 ms |       975.45 ms |

  The flush still runs; it is dispatched after the reply completes
  (`t_flush_start` moves from 812 ms pre-reply (blocking) to
  1023 ms post-reply (off the critical path)). Real flush wall
  time will scale the delta; the controlled numbers are an
  ordering proof, not a production-time claim.

  No-flush-needed turn (non-regression):

  | timestamp                  | BEFORE (upstream/main) | AFTER (PR HEAD) |
  |----------------------------|-----------------------:|----------------:|
  | t_reply_phase_running      |                96.73 ms |        58.42 ms |
  | t_reply_complete           |               336.53 ms |       309.04 ms |
  | t_flush_start              |              (not fired) |     (not fired) |
  | **Δ pre-reply**            |                96.73 ms |        58.42 ms |
  | **Δ end-to-end**           |               336.53 ms |       309.04 ms |

  Flush not fired on either side (token total below threshold).
  No functional regression in this controlled harness.

- **Observed result after fix:** observations below are from the
  redacted runtime logs and trajectory trace excerpts shown above
  (gateway log lines + per-session trajectory `model.completed`
  events).
  Track A — the PR HEAD `runReplyAgent` orchestrator handles a real
  Telegram inbound, makes a real Gemini model call, delivers the
  reply through the live channel, and dispatches a distinct
  second-runId post-reply maintenance run from the `finally`
  block. Compaction did not run on either live run.
  Track B — on the next-turn pending-flush barrier scenario the
  reply turn was held until the previous turn's pending flush
  settled; on the flush-required ordering scenario the reply
  started ~295 ms (≈29 %) sooner and completed ~246 ms (≈20 %)
  sooner under the controlled 200 ms flush latency; on the
  no-flush-needed scenario there was no regression. The
  pre-compaction safety contract is preserved.

- **What was not tested:**
  - A live wall-clock TTFT benchmark against a real model at
    scale. Track A is real-runtime validation; Track B uses
    controlled latency for ordering observability.
  - Live behavior under sustained traffic, retries, or under-load
    conditions on the real channel.
  - The next-turn pending-flush barrier was not exercised in
    Track A (live) — that contract is covered by Track B only,
    using the production `runReplyAgent` orchestrator with
    controlled LLM-boundary latency.
  - Token / cost effect.

## User-visible / Behavior Changes

- The user-visible reply turn now starts before any near-threshold
  memory flush runs. Any required flush still runs after
  `replyOperation.complete()` and is awaited by the next turn's
  preflight compaction before any new compaction state mutation.
- **Removed user-visible behavior to call out:** previously, if the
  housekeeping embedded run surfaced a visible error payload (rare;
  e.g., the housekeeping agent reported a target-path write
  restriction), the orchestrator returned that payload **in place
  of** the reply for the same turn. With the housekeeping run moved
  off the pre-reply path, that same-turn substitution is no longer
  possible. When the flush surfaces a visible error payload and the
  orchestrator (post-reply dispatch) does not supply an
  `onVisibleErrorPayloads` callback, the flush body forwards each
  dropped payload's text through `logVerbose(...)` so it is
  recorded in the gateway log rather than silently dropped. If
  maintainers prefer to retain visible surfacing, it can be added
  as a follow-up PR that emits a deferred channel notification
  after the flush settles.

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Diagram

```text
BEFORE (inline ordering on near-threshold turn):
  user message arrives
    -> preflight compaction
    -> ** memory flush embedded run (blocks the reply path) **
    -> reply turn (runAgentTurnWithFallback)
    -> reply delivered

AFTER (deferred ordering):
  user message arrives
    -> preflight compaction
         -> await any pending memory flush from the previous turn
            (bounded wait-cap + post-abort grace; abort + abandon
             on grace timeout so the next preflight never hangs)
    -> reply turn (runAgentTurnWithFallback)
    -> reply delivered
    -> replyOperation.complete()
    -> memory flush dispatched (fire-and-forget; maintenance
                                 ReplyOperation; registered in pending map)

  Next turn:
    -> preflight compaction
         -> await previous turn's pending flush (so compaction sees
            post-flush state)
    -> ...
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Regression Test Plan

- Coverage level: unit + focused integration tests.
- Target tests added in this PR (all committed under
  `src/auto-reply/reply/`):
  - `runReplyAgent runtime config > dispatches the post-reply memory
    flush after the user-visible reply path returns`
  - `runReplyAgent runtime config > dispatches the post-reply memory
    flush from the reply path's finally block even when the agent
    turn throws`
  - `runReplyAgent runtime config > does not block the start of the
    user-visible reply on a pending memory flush`
  - `runReplyAgent runtime config > passes a maintenance
    ReplyOperation (NOT the completed reply's operation) into the
    post-reply memory flush` — captures the
    `runMemoryFlushIfNeeded` `replyOperation` argument, asserts it
    is a different instance whose `attachBackend(...)` stores the
    handle (does NOT cancel), and asserts the original reply's
    operation is in a terminal state and DOES cancel handles with
    `superseded`.
  - `runReplyAgent runtime config > aborts the maintenance
    ReplyOperation when the original reply operation aborts
    upstream`
  - `runReplyAgent runtime config > registers the post-reply flush
    with an abort callback that aborts the maintenance
    ReplyOperation`
  - `runPreflightCompactionIfNeeded pending-flush barrier > awaits a
    pending flush before invoking compaction on the next turn`
  - `runPreflightCompactionIfNeeded pending-flush barrier > rebinds
    the active run sessionId after the barrier when the prior flush
    rotated it, even if no compaction runs this turn`
  - `runPreflightCompactionIfNeeded pending-flush barrier > does not
    block heartbeat preflight on a pending flush`
  - `pending memory-flush registry > awaitPendingMemoryFlush
    proceeds after timeout when the flush hangs`
  - `pending memory-flush registry > awaitPendingMemoryFlush makes
    the timeout terminal: on timeout it invokes the abort callback
    and awaits flush settlement before returning`
  - `pending memory-flush registry > awaitPendingMemoryFlush
    abandons the pending entry when the abort callback fails to
    make a truly hung flush settle within the post-abort grace
    window`
  - `pending memory-flush registry > registers and clears a pending
    flush after it resolves` / `... even after it rejects`
  - `createMaintenanceReplyOperation > does not register the
    operation in the active-run registry, so it can coexist with
    the live reply operation for the same sessionKey`
  - `createMaintenanceReplyOperation > attachBackend stores the
    handle (does NOT cancel it) when the maintenance operation has
    not completed`
  - `createMaintenanceReplyOperation > attachBackend cancels the
    handle with 'superseded' if complete() ran first`
  - `createMaintenanceReplyOperation > propagates upstream abort
    into the maintenance operation's abortSignal`
  - `createMaintenanceReplyOperation > inherits the upstream's
    already-aborted state at construction time`
  - `createMaintenanceReplyOperation > complete() detaches the
    upstream abort listener so it does not survive past terminal
    state` / `fail() also detaches`
  - `createMaintenanceReplyOperation > complete() does not call
    clearReplyRunState (so it cannot disturb a live reply
    operation for the same sessionKey)`
  - `runMemoryFlushIfNeeded > completes the flush turn without
    throwing when an embedded run returns a visible error payload
    and no onVisibleErrorPayloads callback is supplied`

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- **Visible-error surfacing change (intentional consequence of moving
  the flush off the user-visible reply path).**
  Rare memory-flush visible error payloads (for example, a flush
  agent reporting a target-path write restriction) are no longer
  surfaced in the same user-visible reply turn, because the flush
  now runs after `replyOperation.complete()`.
  - Mitigation: the flush body forwards the text of each dropped
    payload through `logVerbose(...)` so it is recorded in the
    gateway log rather than silently dropped. Remaining tradeoff:
    same-turn user-visible surfacing is gone for this rare path;
    it can be reintroduced as a deferred channel notification in a
    follow-up PR if maintainers prefer a visible surface.

- **Pending-flush barrier abandonment (bounded availability;
  serialization preserved by complementary invariant).**
  The barrier in `runPreflightCompactionIfNeeded` has a wait-cap
  (30 s default). When the cap fires, the barrier invokes a
  registered abort callback that aborts the maintenance
  `ReplyOperation` via `abortForRestart()` (cancelling the attached
  backend handle and aborting the embedded run's `AbortSignal`),
  then waits the post-abort grace (5 s default) for the flush
  promise to settle. If the flush has still not settled within the
  grace, the pending entry is removed from the registry and the
  barrier returns so subsequent turns are not blocked
  indefinitely.
  - Mitigation: `runMemoryFlushIfNeeded` enforces the complementary
    invariant — after the embedded run returns, if the maintenance
    `ReplyOperation`'s `abortSignal.aborted` is true, the flush
    returns early without persisting `compactionCount` /
    `sessionId` rebinds / `memoryFlushAt` /
    `memoryFlushCompactionCount`. So even if the embedded runner
    ignored its `AbortSignal` and completed after the registry
    entry was abandoned, the abandoned flush's session-state
    writes are no-ops; the next turn's preflight compaction is the
    sole writer. The remaining bounded outcome is that the
    abandoned flush's memory-file side effect (if the embedded
    runner already wrote the daily memory file via its own write
    path before the abort propagated) may persist on disk; a
    maintainer who wants strict serialization that also cancels
    that on-disk write can land it as a follow-up.

- **Cross-turn ordering depends on the per-`sessionKey` map.**
  - Mitigation: the map is keyed by `sessionKey`, which is stable
    across the in-flush compaction (`incrementCompactionCount`
    mutates `sessionId` but not `sessionKey`).

