### PR TITLE
test(diffs): cover viewer toolbar state sync

### DIFF
--- a/extensions/diffs/src/viewer-client.test.ts
+++ b/extensions/diffs/src/viewer-client.test.ts
@@ -59,14 +59,56 @@ const viewerPayload = JSON.stringify({
   newFile: { fileName: "a.ts", lang: "text", content: "new" },
 });
 
+const splitViewerPayload = JSON.stringify({
+  prerenderedHTML: "<div>split diff</div>",
+  options: {
+    theme: { light: "pierre-light", dark: "pierre-dark" },
+    diffStyle: "split",
+    diffIndicators: "bars",
+    disableLineNumbers: false,
+    expandUnchanged: false,
+    themeType: "light",
+    backgroundEnabled: false,
+    overflow: "scroll",
+    unsafeCSS: "",
+  },
+  langs: ["typescript"],
+  fileDiff: {
+    hunks: [],
+    oldFile: { fileName: "a.ts", lang: "typescript" },
+    newFile: { fileName: "a.ts", lang: "typescript" },
+  },
+});
+
 function renderCard(): void {
+  renderCardWithPayload(viewerPayload, false);
+}
+
+function renderCardWithPayload(payload: string, includeShadowTemplate = true): void {
+  const shadowTemplate = includeShadowTemplate
+    ? `<template shadowrootmode="open"><div data-shadow-seed>seed</div></template>`
+    : "";
   document.body.insertAdjacentHTML(
     "beforeend",
     `<section class="oc-diff-card">
-      <div data-openclaw-diff-host></div>
-      <script type="application/json" data-openclaw-diff-payload>${viewerPayload}</script>
+      <div data-openclaw-diff-host>${shadowTemplate}</div>
+      <script type="application/json" data-openclaw-diff-payload>${payload}</script>
     </section>`,
   );
+}
+
+function getLastSetOptions(): Record<string, unknown> {
+  const calls = fileDiffSetOptionsMock.mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  return calls[calls.length - 1]?.[0] as Record<string, unknown>;
+}
+
+function getToolbarButton(options: Record<string, unknown>, label: string): HTMLButtonElement {
+  const renderHeaderMetadata = options.renderHeaderMetadata as () => HTMLElement;
+  const toolbar = renderHeaderMetadata();
+  const button = toolbar.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`);
+  expect(button).not.toBeNull();
+  return button;
 }
 
 describe("createToolbarButton icon safety", () => {
@@ -99,10 +141,9 @@ describe("createToolbarButton icon safety", () => {
 
   it("SVG strings in toolbarIconSvg contain no XSS patterns", () => {
     for (const pattern of XSS_PATTERNS) {
-      expect(
-        VIEWER_CLIENT_SRC.includes(pattern),
-        `source must not contain "${pattern}"`,
-      ).toBe(false);
+      expect(VIEWER_CLIENT_SRC.includes(pattern), `source must not contain "${pattern}"`).toBe(
+        false,
+      );
     }
   });
 
@@ -171,5 +212,44 @@ describe("hydrateViewer", () => {
     );
     expect(document.documentElement.dataset.openclawDiffsError).toBeUndefined();
     warn.mockRestore();
+  });
+
+  it("seeds viewer state from the first payload and syncs toolbar toggles across controllers", async () => {
+    renderCardWithPayload(splitViewerPayload);
+    renderCardWithPayload(viewerPayload);
+    const { controllers, hydrateViewer } = await import("./viewer-client.js");
+    controllers.splice(0);
+
+    await hydrateViewer();
+
+    expect(controllers).toHaveLength(2);
+    expect(preloadHighlighterMock).toHaveBeenCalledWith({
+      themes: ["pierre-light", "pierre-dark"],
+      langs: ["typescript", "text"],
+    });
+    expect(document.body.dataset.theme).toBe("light");
+    expect(document.querySelector("[data-openclaw-diff-host]")?.shadowRoot?.textContent).toContain(
+      "seed",
+    );
+
+    const initialOptions = getLastSetOptions();
+    expect(initialOptions).toMatchObject({
+      themeType: "light",
+      diffStyle: "split",
+      overflow: "scroll",
+      disableBackground: true,
+    });
+
+    const callsBeforeClick = fileDiffSetOptionsMock.mock.calls.length;
+    getToolbarButton(initialOptions, "Switch to unified diff").click();
+
+    expect(fileDiffSetOptionsMock.mock.calls.length).toBe(callsBeforeClick + 2);
+    expect(document.body.dataset.theme).toBe("light");
+    expect(getLastSetOptions()).toMatchObject({
+      themeType: "light",
+      diffStyle: "unified",
+      overflow: "scroll",
+      disableBackground: true,
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds focused jsdom coverage for the diff viewer runtime state that was missing from issue #83915.
- Verifies first-payload state seeding, declarative shadow-root hydration, highlighter language aggregation, and toolbar layout toggles syncing options across all hydrated controllers.

## Tests

- `pnpm exec oxfmt --write extensions/diffs/src/viewer-client.test.ts`
- `git diff --check`
- `node scripts/run-vitest.mjs extensions/diffs/src/viewer-client.test.ts extensions/diffs/src/config.test.ts`
- `pnpm check:test-types`

## Real behavior proof

Behavior addressed: Test-only coverage for the diff plugin browser viewer runtime; no production runtime behavior changed.
Real environment tested: macOS OpenClaw checkout, Node v23.11.1, pnpm 11.2.2.
Exact steps or command run after this patch: Ran the focused Vitest coverage command and type checks listed above, then ran a live Node command in the patched OpenClaw checkout to confirm the diff surface stayed test-only: `node --input-type=module` with `git diff --name-only origin/main...HEAD`.
Evidence after fix: Terminal output from the live Node command:
```text
OpenClaw patched checkout diff surface: extensions/diffs/src/viewer-client.test.ts
Runtime package files changed: no
```
Observed result after fix: The new jsdom coverage now hydrates two diff cards, seeds viewer state from the first payload, clones the declarative shadow-root template, and confirms clicking the layout toolbar button calls `setOptions` for both controllers with unified layout; the live Node output confirms no production runtime files changed in this patched checkout.
What was not tested: No browser screenshot or Playwright E2E run; this is a unit-test-only coverage PR with mocked `@pierre/diffs` rendering plus a live checkout diff-surface command.

Fixes #83915
