### PR TITLE
fix(heartbeat): bound pending final delivery replay

### DIFF
--- a/src/auto-reply/reply/get-reply.fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.test.ts
@@ -315,6 +315,86 @@ describe("getReplyFromConfig fast test bootstrap", () => {
     expect(stored.pendingFinalDeliveryAttemptCount).toBe(1);
   });
 
+  it("clears stale heartbeat pending delivery after the replay attempt limit", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-heartbeat-pending-limit-"));
+    const storePath = path.join(home, "sessions.json");
+    const sessionKey = "agent:main:telegram:123";
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        [sessionKey]: {
+          sessionId: "pending-limit",
+          updatedAt: Date.now(),
+          pendingFinalDelivery: true,
+          pendingFinalDeliveryText: "HEARTBEAT_OK short",
+          pendingFinalDeliveryCreatedAt: Date.now(),
+          pendingFinalDeliveryAttemptCount: 10,
+          pendingFinalDeliveryLastError: null,
+        },
+      }),
+      "utf8",
+    );
+    const cfg = withFastReplyConfig({
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.5",
+          workspace: home,
+          heartbeat: { ackMaxChars: 0 },
+        },
+      },
+      session: { store: storePath },
+    } as OpenClawConfig);
+
+    await expect(
+      getReplyFromConfig(buildGetReplyCtx(), { isHeartbeat: true }, cfg),
+    ).resolves.toEqual({ text: "ok" });
+
+    const stored = JSON.parse(await fs.readFile(storePath, "utf8"))[sessionKey];
+    expect(stored.pendingFinalDelivery).toBeUndefined();
+    expect(stored.pendingFinalDeliveryText).toBeUndefined();
+    expect(stored.pendingFinalDeliveryAttemptCount).toBeUndefined();
+  });
+
+  it("clears stale heartbeat pending delivery after the replay TTL", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-heartbeat-pending-ttl-"));
+    const storePath = path.join(home, "sessions.json");
+    const sessionKey = "agent:main:telegram:123";
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        [sessionKey]: {
+          sessionId: "pending-expired",
+          updatedAt: Date.now(),
+          pendingFinalDelivery: true,
+          pendingFinalDeliveryText: "HEARTBEAT_OK short",
+          pendingFinalDeliveryCreatedAt: Date.now() - 24 * 60 * 60 * 1000 - 1,
+          pendingFinalDeliveryAttemptCount: 2,
+          pendingFinalDeliveryLastError: null,
+        },
+      }),
+      "utf8",
+    );
+    const cfg = withFastReplyConfig({
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.5",
+          workspace: home,
+          heartbeat: { ackMaxChars: 0 },
+        },
+      },
+      session: { store: storePath },
+    } as OpenClawConfig);
+
+    await expect(
+      getReplyFromConfig(buildGetReplyCtx(), { isHeartbeat: true }, cfg),
+    ).resolves.toEqual({ text: "ok" });
+
+    const stored = JSON.parse(await fs.readFile(storePath, "utf8"))[sessionKey];
+    expect(stored.pendingFinalDelivery).toBeUndefined();
+    expect(stored.pendingFinalDeliveryText).toBeUndefined();
+    expect(stored.pendingFinalDeliveryAttemptCount).toBeUndefined();
+  });
+
   it("sanitizes stale heartbeat pending delivery before replay", async () => {
     const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-heartbeat-pending-sanitize-"));
     const storePath = path.join(home, "sessions.json");

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -56,6 +56,9 @@ import { createTypingController } from "./typing.js";
 
 type ResetCommandAction = "new" | "reset";
 
+const PENDING_FINAL_DELIVERY_MAX_HEARTBEAT_ATTEMPTS = 10;
+const PENDING_FINAL_DELIVERY_HEARTBEAT_TTL_MS = 24 * 60 * 60 * 1000;
+
 function classifyHeartbeatPendingFinalDelivery(text: string, ackMaxChars: number) {
   const stripped = stripHeartbeatToken(text, {
     mode: "heartbeat",
@@ -75,6 +78,28 @@ function resolveHeartbeatAckMaxChars(cfg: OpenClawConfig, agentId: string): numb
       cfg.agents?.defaults?.heartbeat?.ackMaxChars ??
       DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
   );
+}
+
+function resolveHeartbeatPendingFinalDeliveryGiveUp(args: {
+  attemptCount: number;
+  now: number;
+  createdAt?: number;
+}) {
+  const ageMs =
+    typeof args.createdAt === "number" ? Math.max(0, args.now - args.createdAt) : undefined;
+  if (args.attemptCount > PENDING_FINAL_DELIVERY_MAX_HEARTBEAT_ATTEMPTS) {
+    return {
+      reason: "retry-limit" as const,
+      ageMs,
+    };
+  }
+  if (typeof ageMs === "number" && ageMs > PENDING_FINAL_DELIVERY_HEARTBEAT_TTL_MS) {
+    return {
+      reason: "expiry" as const,
+      ageMs,
+    };
+  }
+  return null;
 }
 
 const sessionResetModelRuntimeLoader = createLazyImportLoader(
@@ -412,6 +437,34 @@ export async function getReplyFromConfig(
 
   if (sessionEntry?.pendingFinalDelivery && sessionEntry.pendingFinalDeliveryText) {
     const text = sanitizePendingFinalDeliveryText(sessionEntry.pendingFinalDeliveryText);
+    const clearPendingFinalDelivery = async () => {
+      sessionEntry.pendingFinalDelivery = undefined;
+      sessionEntry.pendingFinalDeliveryText = undefined;
+      sessionEntry.pendingFinalDeliveryCreatedAt = undefined;
+      sessionEntry.pendingFinalDeliveryLastAttemptAt = undefined;
+      sessionEntry.pendingFinalDeliveryAttemptCount = undefined;
+      sessionEntry.pendingFinalDeliveryLastError = undefined;
+      sessionEntry.pendingFinalDeliveryContext = undefined;
+      if (sessionKey && sessionStore) {
+        sessionStore[sessionKey] = sessionEntry;
+      }
+      if (sessionKey && storePath) {
+        const { updateSessionStoreEntry } = await import("../../config/sessions.js");
+        await updateSessionStoreEntry({
+          storePath,
+          sessionKey,
+          update: async () => ({
+            pendingFinalDelivery: undefined,
+            pendingFinalDeliveryText: undefined,
+            pendingFinalDeliveryCreatedAt: undefined,
+            pendingFinalDeliveryLastAttemptAt: undefined,
+            pendingFinalDeliveryAttemptCount: undefined,
+            pendingFinalDeliveryLastError: undefined,
+            pendingFinalDeliveryContext: undefined,
+          }),
+        });
+      }
+    };
 
     // If it's a heartbeat, we definitely want to try delivering the lost reply now.
     // If it's a user message, we deliver the lost reply first, then continue.
@@ -422,59 +475,49 @@ export async function getReplyFromConfig(
         resolveHeartbeatAckMaxChars(cfg, agentId),
       );
       if (heartbeatPending.shouldClear) {
-        sessionEntry.pendingFinalDelivery = undefined;
-        sessionEntry.pendingFinalDeliveryText = undefined;
-        sessionEntry.pendingFinalDeliveryCreatedAt = undefined;
-        sessionEntry.pendingFinalDeliveryLastAttemptAt = undefined;
-        sessionEntry.pendingFinalDeliveryAttemptCount = undefined;
-        sessionEntry.pendingFinalDeliveryLastError = undefined;
-        sessionEntry.pendingFinalDeliveryContext = undefined;
-        if (sessionKey && sessionStore) {
-          sessionStore[sessionKey] = sessionEntry;
-        }
-        if (sessionKey && storePath) {
-          const { updateSessionStoreEntry } = await import("../../config/sessions.js");
-          await updateSessionStoreEntry({
-            storePath,
-            sessionKey,
-            update: async () => ({
-              pendingFinalDelivery: undefined,
-              pendingFinalDeliveryText: undefined,
-              pendingFinalDeliveryCreatedAt: undefined,
-              pendingFinalDeliveryLastAttemptAt: undefined,
-              pendingFinalDeliveryAttemptCount: undefined,
-              pendingFinalDeliveryLastError: undefined,
-              pendingFinalDeliveryContext: undefined,
-            }),
-          });
-        }
+        await clearPendingFinalDelivery();
       } else {
         const updatedAt = Date.now();
         const attemptCount = (sessionEntry.pendingFinalDeliveryAttemptCount ?? 0) + 1;
-        sessionEntry.pendingFinalDeliveryLastAttemptAt = updatedAt;
-        sessionEntry.pendingFinalDeliveryAttemptCount = attemptCount;
-        sessionEntry.pendingFinalDeliveryLastError = null;
-        const replayText = sanitizePendingFinalDeliveryText(heartbeatPending.replayText);
-        sessionEntry.pendingFinalDeliveryText = replayText;
-        sessionEntry.updatedAt = updatedAt;
-        if (sessionKey && sessionStore) {
-          sessionStore[sessionKey] = sessionEntry;
+        const giveUp = resolveHeartbeatPendingFinalDeliveryGiveUp({
+          attemptCount,
+          now: updatedAt,
+          createdAt: sessionEntry.pendingFinalDeliveryCreatedAt,
+        });
+        if (giveUp) {
+          const replayAgeSuffix = typeof giveUp.ageMs === "number" ? ` ageMs=${giveUp.ageMs}` : "";
+          defaultRuntime.log(
+            `[warn] Clearing stale heartbeat pending final delivery (${giveUp.reason}) after ${attemptCount} attempts${replayAgeSuffix}${
+              sessionKey ? ` for session ${sessionKey}` : ""
+            }.`,
+          );
+          await clearPendingFinalDelivery();
+        } else {
+          sessionEntry.pendingFinalDeliveryLastAttemptAt = updatedAt;
+          sessionEntry.pendingFinalDeliveryAttemptCount = attemptCount;
+          sessionEntry.pendingFinalDeliveryLastError = null;
+          const replayText = sanitizePendingFinalDeliveryText(heartbeatPending.replayText);
+          sessionEntry.pendingFinalDeliveryText = replayText;
+          sessionEntry.updatedAt = updatedAt;
+          if (sessionKey && sessionStore) {
+            sessionStore[sessionKey] = sessionEntry;
+          }
+          if (sessionKey && storePath) {
+            const { updateSessionStoreEntry } = await import("../../config/sessions.js");
+            await updateSessionStoreEntry({
+              storePath,
+              sessionKey,
+              update: async () => ({
+                pendingFinalDeliveryText: replayText,
+                pendingFinalDeliveryLastAttemptAt: updatedAt,
+                pendingFinalDeliveryAttemptCount: attemptCount,
+                pendingFinalDeliveryLastError: null,
+                updatedAt,
+              }),
+            });
+          }
+          return { text: replayText };
         }
-        if (sessionKey && storePath) {
-          const { updateSessionStoreEntry } = await import("../../config/sessions.js");
-          await updateSessionStoreEntry({
-            storePath,
-            sessionKey,
-            update: async () => ({
-              pendingFinalDeliveryText: replayText,
-              pendingFinalDeliveryLastAttemptAt: updatedAt,
-              pendingFinalDeliveryAttemptCount: attemptCount,
-              pendingFinalDeliveryLastError: null,
-              updatedAt,
-            }),
-          });
-        }
-        return { text: replayText };
       }
     }
   }


### PR DESCRIPTION
## Summary

- Problem: heartbeat replay kept re-sending orphaned `pendingFinalDeliveryText` forever because the replay branch had no terminal retry or age bound.
- Solution: add a heartbeat-only replay give-up gate that clears stale pending final delivery after 10 replay attempts or 24 hours.
- What changed: `src/auto-reply/reply/get-reply.ts` now shares one clear helper, logs `retry-limit` / `expiry` give-up reasons, and skips replay once the bound trips; `src/auto-reply/reply/get-reply.fast-path.test.ts` now locks both bounds in with regression coverage.
- What did NOT change (scope boundary): this does not alter the existing clear-on-success dispatch path, restart recovery flow, or subagent pending-final-delivery lifecycle semantics.

## Motivation

- Issue #85743 shows a real production failure mode where an orphaned session replayed the same stale heartbeat delivery for days.
- The open related fixes addressed narrower causes (`send-success` cleanup and `target:none`) but left the generic fail-safe missing.
- Bounding the replay path keeps the intended retry-after-restart behavior without leaving dead session state in an infinite resend loop.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #85743
- Related #83184
- Related #83187
- Related #84679
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: stale heartbeat pending-final-delivery replay now stops after a bounded number of attempts or once the pending payload ages past the TTL instead of replaying forever.
- Real environment tested: local macOS source checkout, Node v24.14.1, repo runtime loaded through `node --import tsx`, real `sessions.json` persistence under a temp directory.
- Exact steps or command run after this patch:
```bash
node --import tsx --input-type=module <<'EOF'
import fs from 'node:fs/promises';
import os from 'node:os';
import path from 'node:path';
import { getReplyFromConfig } from './src/auto-reply/reply/get-reply.ts';

const home = await fs.mkdtemp(path.join(os.tmpdir(), 'openclaw-85743-proof-'));
const storePath = path.join(home, 'sessions.json');
const sessionKey = 'agent:main:telegram:123';
await fs.writeFile(
  storePath,
  JSON.stringify({
    [sessionKey]: {
      sessionId: 'pending-limit',
      updatedAt: Date.now(),
      pendingFinalDelivery: true,
      pendingFinalDeliveryText: 'HEARTBEAT_OK short',
      pendingFinalDeliveryCreatedAt: Date.now(),
      pendingFinalDeliveryAttemptCount: 10,
      pendingFinalDeliveryLastError: null,
    },
  }),
  'utf8',
);
const cfg = {
  agents: {
    defaults: {
      model: 'openai/gpt-5.5',
      workspace: home,
      heartbeat: { ackMaxChars: 0 },
    },
  },
  session: { store: storePath },
};
const ctx = {
  Provider: 'telegram',
  Surface: 'telegram',
  ChatType: 'direct',
  Body: 'heartbeat',
  BodyForAgent: 'heartbeat',
  RawBody: 'heartbeat',
  CommandBody: 'heartbeat',
  SessionKey: sessionKey,
  From: 'telegram:user:42',
  To: 'telegram:123',
  Timestamp: 1710000000000,
};
const reply = await getReplyFromConfig(ctx, { isHeartbeat: true }, cfg);
const stored = JSON.parse(await fs.readFile(storePath, 'utf8'))[sessionKey];
console.log(JSON.stringify({ reply, stored }, null, 2));
EOF
```
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
```text
[warn] Clearing stale heartbeat pending final delivery (retry-limit) after 11 attempts ageMs=6996 for session agent:main:telegram:123.
```
and the persisted session record printed with `pendingFinalDelivery`, `pendingFinalDeliveryText`, and `pendingFinalDeliveryAttemptCount` cleared.
- Observed result after fix: once the replay branch computed the 11th attempt, it logged the give-up reason, cleared the durable pending-final-delivery fields, and did not replay `short` again.
- What was not tested: a real remote Crabbox/Testbox `pnpm check:changed` run is still blocked in this environment because no usable `crabbox` binary is installed locally; only focused local tests and the local persisted-session proof above were run.
- Before evidence (optional but encouraged): before this patch, the same heartbeat replay branch incremented `pendingFinalDeliveryAttemptCount`, rewrote the replay text, and returned the cached replay payload without any retry-limit or TTL gate.

## Root Cause (if applicable)

- Root cause: the heartbeat replay branch in `src/auto-reply/reply/get-reply.ts` incremented `pendingFinalDeliveryAttemptCount` and returned the replay text every tick, but never checked whether the replay had already been retried too many times or had gone stale by age.
- Missing detection / guardrail: there was no heartbeat-side terminal condition comparable to the existing `retry-limit` / `expiry` give-up vocabulary already used by the subagent pending-final-delivery lifecycle.
- Contributing context (if known): durable pending final delivery was introduced in `c240e718e91` and later replay cleanups only handled ack-only stripping and adjacent narrower causes, not this general orphan-session fail-safe.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/get-reply.fast-path.test.ts`
- Scenario the test should lock in: heartbeat replay clears stale pending-final-delivery state once retry count exceeds the cap, and also clears it when the pending payload is older than the TTL.
- Why this is the smallest reliable guardrail: the bug lives entirely inside the heartbeat replay branch’s state transition logic, so a focused store-backed `getReplyFromConfig` test exercises the exact persisted-session mutation without needing a broader dispatcher harness.
- Existing test that already covers this (if any): existing adjacent tests already covered ack-only clear and substantive replay, but not terminal cleanup after repeated or old replays.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Heartbeat sessions no longer replay stale pending final delivery forever. Once a pending heartbeat replay exceeds 10 attempts or stays pending for more than 24 hours, OpenClaw drops the stale replay state and proceeds instead of re-sending the same cached alert on every heartbeat tick.

## Diagram (if applicable)

```text
Before:
[heartbeat tick] -> [pendingFinalDelivery replay branch] -> [increment attempt count] -> [return stale replay forever]

After:
[heartbeat tick] -> [pendingFinalDelivery replay branch] -> [check attempts + age]
               -> [under bound] -> [replay once more]
               -> [over bound] -> [clear pending final delivery] -> [continue without stale replay]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v24.14.1 local source checkout
- Model/provider: not required for the focused replay-state tests; local runtime proof entered the heartbeat replay path before any successful model call
- Integration/channel (if any): Telegram-shaped heartbeat session metadata
- Relevant config (redacted): `agents.defaults.model=openai/gpt-5.5`, `agents.defaults.heartbeat.ackMaxChars=0`, temp `session.store`

### Steps

1. Seed `sessions.json` with a main-session entry whose `pendingFinalDelivery` is `true`, `pendingFinalDeliveryText` is substantive (`HEARTBEAT_OK short`), and `pendingFinalDeliveryAttemptCount` is already 10 or whose `pendingFinalDeliveryCreatedAt` is older than 24 hours.
2. Invoke `getReplyFromConfig(..., { isHeartbeat: true }, cfg)` against that store-backed session.
3. Inspect the persisted session entry after the heartbeat replay branch runs.

### Expected

- A stale replay should be cleared instead of replayed again.
- The durable pending-final-delivery fields should be unset.

### Actual

- The branch logs a `retry-limit` or `expiry` warning, clears the stale pending-final-delivery fields, and does not return the stale replay text.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: retry-limit cleanup in the heartbeat replay branch, TTL cleanup in the same branch, existing ack-only clear behavior, existing substantive replay behavior, adjacent e2e durable-pending-final-delivery capture behavior, and heartbeat busy-lane skip behavior.
- Edge cases checked: ack-only heartbeat payloads still clear immediately; short substantive heartbeat payloads still replay when below the new bounds; sanitize-before-replay still preserves visible payload text.
- What you did **not** verify: remote Linux/Testbox broad changed gate proof is still blocked by the missing local `crabbox` binary in this environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: a legitimately recoverable pending final delivery that stays orphaned past 10 heartbeats or 24 hours will now be dropped instead of replayed indefinitely.
  - Mitigation: the bound is heartbeat-only, preserves normal replay behavior below the threshold, and is intentionally conservative to stop proven user-visible duplication failures.
- Risk: future durable-delivery intent migration might want a shared clear helper across more replay surfaces.
  - Mitigation: this patch keeps the new helper local to the current heartbeat replay owner boundary and does not pre-empt the later intent-store migration.
