### PR TITLE
fix: render Codex source replies in TUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ Docs: https://docs.openclaw.ai
 - Sessions: surface previous-transcript archive failures during `/new` rotation so disk rename errors are logged instead of silently hiding stranded transcript files. Fixes #81984. (#85586, from #82081) Thanks @0xghost42.
 - TUI/agents: mirror internal-ui message-tool replies into final chat output so message-tool-only agents remain visible in `openclaw tui`. Fixes #85538. Thanks @danpolasek.
 - Gateway/TUI: preserve source-reply metadata through reply normalization and emit message-tool-only agent replies over the live chat stream so `openclaw tui` renders Codex replies without waiting for a history refresh. Thanks @shakkernerd.
+- Codex/TUI: keep long source-reply runs alive after Codex reasoning completes so delayed visible `message` calls can still reach `openclaw tui`. Thanks @shakkernerd.
 - TUI: keep quiet active runs busy after the response watchdog notice instead of reopening the prompt and encouraging duplicate submissions while the backend turn is still running. Thanks @shakkernerd.
 - Agents: keep parallel OpenAI-compatible tool-call deltas in separate argument buffers so interleaved tool calls no longer corrupt streamed arguments. (#82263) Thanks @luna-system.
 - Memory/doctor: report missing or unusable QMD workspace directories as workspace failures instead of generic binary failures. (#63167) Thanks @sercada.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ Docs: https://docs.openclaw.ai
 - Sessions: surface previous-transcript archive failures during `/new` rotation so disk rename errors are logged instead of silently hiding stranded transcript files. Fixes #81984. (#85586, from #82081) Thanks @0xghost42.
 - TUI/agents: mirror internal-ui message-tool replies into final chat output so message-tool-only agents remain visible in `openclaw tui`. Fixes #85538. Thanks @danpolasek.
 - Gateway/TUI: preserve source-reply metadata through reply normalization and emit message-tool-only agent replies over the live chat stream so `openclaw tui` renders Codex replies without waiting for a history refresh. Thanks @shakkernerd.
+- TUI: keep quiet active runs busy after the response watchdog notice instead of reopening the prompt and encouraging duplicate submissions while the backend turn is still running. Thanks @shakkernerd.
 - Agents: keep parallel OpenAI-compatible tool-call deltas in separate argument buffers so interleaved tool calls no longer corrupt streamed arguments. (#82263) Thanks @luna-system.
 - Memory/doctor: report missing or unusable QMD workspace directories as workspace failures instead of generic binary failures. (#63167) Thanks @sercada.
 - Debug proxy: record CONNECT client-socket errors and destroy the paired upstream socket so abrupt client disconnects no longer leak tunnel resources. (#82444) Thanks @SebTardif.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ Docs: https://docs.openclaw.ai
 - Windows installer: fail Git checkout installs when `pnpm install` or `pnpm build` fails instead of writing a wrapper to a missing CLI build.
 - Sessions: surface previous-transcript archive failures during `/new` rotation so disk rename errors are logged instead of silently hiding stranded transcript files. Fixes #81984. (#85586, from #82081) Thanks @0xghost42.
 - TUI/agents: mirror internal-ui message-tool replies into final chat output so message-tool-only agents remain visible in `openclaw tui`. Fixes #85538. Thanks @danpolasek.
+- Gateway/TUI: preserve source-reply metadata through reply normalization and emit message-tool-only agent replies over the live chat stream so `openclaw tui` renders Codex replies without waiting for a history refresh. Thanks @shakkernerd.
 - Agents: keep parallel OpenAI-compatible tool-call deltas in separate argument buffers so interleaved tool calls no longer corrupt streamed arguments. (#82263) Thanks @luna-system.
 - Memory/doctor: report missing or unusable QMD workspace directories as workspace failures instead of generic binary failures. (#63167) Thanks @sercada.
 - Debug proxy: record CONNECT client-socket errors and destroy the paired upstream socket so abrupt client disconnects no longer leak tunnel resources. (#82444) Thanks @SebTardif.

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -5255,6 +5255,50 @@ describe("runCodexAppServerAttempt", () => {
     expect(queueActiveRunMessageForTest("session-1", "after silent turn")).toBe(false);
   });
 
+  it("keeps waiting after reasoning completes before a visible message call", async () => {
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.timeoutMs = 60_000;
+
+    let settled = false;
+    const run = runCodexAppServerAttempt(params, {
+      turnCompletionIdleTimeoutMs: 15,
+      turnTerminalIdleTimeoutMs: 500,
+    }).finally(() => {
+      settled = true;
+    });
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "item/started",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { id: "reasoning-1", type: "reasoning" },
+      },
+    });
+    await harness.notify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { id: "reasoning-1", type: "reasoning" },
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(settled).toBe(false);
+
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    const result = await run;
+    expect(result.aborted).toBe(false);
+    expect(result.timedOut).toBe(false);
+    expect(result.promptError).toBeNull();
+    expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
+  });
+
   it("does not treat global rate-limit notifications as turn progress", async () => {
     const harness = createStartedThreadHarness();
     const params = createParams(

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -5262,6 +5262,7 @@ describe("runCodexAppServerAttempt", () => {
       path.join(tempDir, "workspace"),
     );
     params.timeoutMs = 60_000;
+    params.sourceReplyDeliveryMode = "message_tool_only";
 
     let settled = false;
     const run = runCodexAppServerAttempt(params, {
@@ -5297,6 +5298,44 @@ describe("runCodexAppServerAttempt", () => {
     expect(result.timedOut).toBe(false);
     expect(result.promptError).toBeNull();
     expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
+  });
+
+  it("keeps the normal completion idle guard after non-source reasoning completes", async () => {
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.timeoutMs = 60_000;
+
+    const run = runCodexAppServerAttempt(params, {
+      turnCompletionIdleTimeoutMs: 15,
+      turnTerminalIdleTimeoutMs: 500,
+    });
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "item/started",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { id: "reasoning-1", type: "reasoning" },
+      },
+    });
+    await harness.notify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { id: "reasoning-1", type: "reasoning" },
+      },
+    });
+
+    const result = await run;
+    expect(result.aborted).toBe(true);
+    expect(result.timedOut).toBe(true);
+    expect(result.promptError).toBe(
+      "codex app-server turn idle timed out waiting for turn/completed",
+    );
   });
 
   it("does not treat global rate-limit notifications as turn progress", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -213,6 +213,7 @@ const CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS = 5_000;
 const CODEX_USAGE_LIMIT_RATE_LIMIT_REFRESH_TIMEOUT_MS = 5_000;
 const CODEX_TURN_COMPLETION_IDLE_TIMEOUT_MS = 60_000;
 const CODEX_TURN_ASSISTANT_COMPLETION_IDLE_TIMEOUT_MS = 10_000;
+const CODEX_POST_REASONING_SOURCE_REPLY_IDLE_TIMEOUT_MS = 5 * 60_000;
 const CODEX_TURN_TERMINAL_IDLE_TIMEOUT_MS = 30 * 60_000;
 const CODEX_NATIVE_HOOK_RELAY_MIN_TTL_MS = 30 * 60_000;
 const CODEX_NATIVE_HOOK_RELAY_TTL_GRACE_MS = 5 * 60_000;
@@ -2405,13 +2406,18 @@ export async function runCodexAppServerAttempt(
       turnCrossedToolHandoff &&
       isRawAssistantCompletionNotification(notification) &&
       activeTurnItemIds.size === 0;
+    const shouldArmPostReasoningSourceReplyWatch =
+      isCurrentTurnNotification &&
+      isReasoningItemCompletionNotification(notification) &&
+      activeTurnItemIds.size === 0 &&
+      params.sourceReplyDeliveryMode === "message_tool_only";
     const shouldRearmCompletionIdleWatchAfterLastCurrentTurnItem =
       isCurrentTurnNotification &&
       notification.method === "item/completed" &&
       activeTurnItemIds.size === 0 &&
       !trackedDynamicToolCompletion &&
       !assistantCompletionCanRelease &&
-      !isReasoningItemCompletionNotification(notification);
+      !shouldArmPostReasoningSourceReplyWatch;
     if (isCurrentTurnNotification && notification.method === "error") {
       if (isRetryableErrorNotification(notification.params)) {
         disarmTurnCompletionIdleWatch();
@@ -2425,6 +2431,8 @@ export async function runCodexAppServerAttempt(
       armTurnAssistantCompletionIdleWatch(describeNotificationActivity(notification));
     } else if (postToolRawAssistantCompletionNeedsTerminalGuard) {
       armTurnCompletionIdleWatch({ timeoutMs: postToolRawAssistantCompletionIdleTimeoutMs });
+    } else if (shouldArmPostReasoningSourceReplyWatch) {
+      armTurnCompletionIdleWatch({ timeoutMs: CODEX_POST_REASONING_SOURCE_REPLY_IDLE_TIMEOUT_MS });
     } else if (unblockedAssistantCompletionRelease) {
       armTurnAssistantCompletionIdleWatch(describeNotificationActivity(notification));
     } else if (shouldRearmCompletionIdleWatchAfterLastCurrentTurnItem) {
@@ -2450,6 +2458,7 @@ export async function runCodexAppServerAttempt(
       !trackedDynamicToolCompletion &&
       !rawToolOutputCompletion &&
       !postToolRawAssistantCompletionNeedsTerminalGuard &&
+      !shouldArmPostReasoningSourceReplyWatch &&
       !shouldRearmCompletionIdleWatchAfterLastCurrentTurnItem
     ) {
       // The short completion-idle watchdog guards blind gaps after Codex

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2410,7 +2410,8 @@ export async function runCodexAppServerAttempt(
       notification.method === "item/completed" &&
       activeTurnItemIds.size === 0 &&
       !trackedDynamicToolCompletion &&
-      !assistantCompletionCanRelease;
+      !assistantCompletionCanRelease &&
+      !isReasoningItemCompletionNotification(notification);
     if (isCurrentTurnNotification && notification.method === "error") {
       if (isRetryableErrorNotification(notification.params)) {
         disarmTurnCompletionIdleWatch();
@@ -4822,6 +4823,14 @@ function isCompletedAssistantNotification(notification: CodexServerNotification)
     readString(item, "type") === "agentMessage" &&
     readString(item, "phase") !== "commentary",
   );
+}
+
+function isReasoningItemCompletionNotification(notification: CodexServerNotification): boolean {
+  if (!isJsonObject(notification.params) || notification.method !== "item/completed") {
+    return false;
+  }
+  const item = isJsonObject(notification.params.item) ? notification.params.item : undefined;
+  return item ? readString(item, "type") === "reasoning" : false;
 }
 
 function isAssistantCompletionReleaseNotification(

--- a/src/agents/pi-embedded-runner/transcript-rewrite.test.ts
+++ b/src/agents/pi-embedded-runner/transcript-rewrite.test.ts
@@ -294,6 +294,74 @@ describe("rewriteTranscriptEntriesInSessionManager", () => {
 });
 
 describe("rewriteTranscriptEntriesInSessionFile", () => {
+  it("aborts under the write lock when the active suffix contains an unexpected entry", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-transcript-rewrite-guard-"));
+    const sessionManager = SessionManager.create(dir, dir);
+    const entryIds = appendSessionMessages(sessionManager, [
+      asAppendMessage({
+        role: "user",
+        content: "start",
+        timestamp: 1,
+      }),
+      asAppendMessage({
+        role: "assistant",
+        content: createTextContent("source reply media"),
+        timestamp: 2,
+      }),
+      asAppendMessage({
+        role: "assistant",
+        content: createTextContent("source reply text"),
+        timestamp: 3,
+      }),
+      asAppendMessage({
+        role: "user",
+        content: "concurrent append",
+        timestamp: 4,
+      }),
+    ]);
+    const sessionFile = requireString(sessionManager.getSessionFile(), "persisted session file");
+    const mediaEntryId = entryIds[1];
+    const textEntryId = entryIds[2];
+    const listener = vi.fn();
+    const cleanup = onSessionTranscriptUpdate(listener);
+
+    try {
+      const result = await rewriteTranscriptEntriesInSessionFile({
+        sessionFile,
+        sessionKey: "agent:main:test",
+        request: {
+          allowedRewriteSuffixEntryIds: [mediaEntryId, textEntryId],
+          replacements: [
+            {
+              entryId: mediaEntryId,
+              message: asAppendMessage({
+                role: "assistant",
+                content: createTextContent("rewritten source reply media"),
+                timestamp: 2,
+              }) as AgentMessage,
+            },
+          ],
+        },
+      });
+
+      expect(result).toMatchObject({
+        changed: false,
+        reason: "rewrite suffix guard failed",
+      });
+      expect(listener).not.toHaveBeenCalled();
+
+      const unchangedSession = SessionManager.open(sessionFile);
+      expect(getBranchMessages(unchangedSession).map((message) => message.content)).toEqual([
+        "start",
+        createTextContent("source reply media"),
+        createTextContent("source reply text"),
+        "concurrent append",
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+
   it("emits transcript updates when the active branch changes without opening a manager", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-transcript-rewrite-"));
     const sessionManager = SessionManager.create(dir, dir);

--- a/src/agents/pi-embedded-runner/transcript-rewrite.test.ts
+++ b/src/agents/pi-embedded-runner/transcript-rewrite.test.ts
@@ -47,6 +47,10 @@ function createTextContent(text: string) {
   return [{ type: "text", text }];
 }
 
+function getMessageContent(message: AgentMessage): unknown {
+  return "content" in message ? message.content : undefined;
+}
+
 function createReadRewriteSession(options?: { tailAssistantText?: string }) {
   const sessionManager = SessionManager.inMemory();
   const entryIds = appendSessionMessages(sessionManager, [
@@ -351,7 +355,7 @@ describe("rewriteTranscriptEntriesInSessionFile", () => {
       expect(listener).not.toHaveBeenCalled();
 
       const unchangedSession = SessionManager.open(sessionFile);
-      expect(getBranchMessages(unchangedSession).map((message) => message.content)).toEqual([
+      expect(getBranchMessages(unchangedSession).map(getMessageContent)).toEqual([
         "start",
         createTextContent("source reply media"),
         createTextContent("source reply text"),

--- a/src/agents/pi-embedded-runner/transcript-rewrite.ts
+++ b/src/agents/pi-embedded-runner/transcript-rewrite.ts
@@ -252,6 +252,7 @@ export function rewriteTranscriptEntriesInSessionManager(params: {
 export function rewriteTranscriptEntriesInState(params: {
   state: TranscriptFileState;
   replacements: TranscriptRewriteReplacement[];
+  allowedRewriteSuffixEntryIds?: string[];
 }): TranscriptRewriteResult & { appendedEntries: SessionBranchEntry[] } {
   const replacementsById = new Map(
     params.replacements
@@ -320,6 +321,22 @@ export function rewriteTranscriptEntriesInState(params: {
     };
   }
 
+  if (params.allowedRewriteSuffixEntryIds) {
+    const allowedIds = new Set(params.allowedRewriteSuffixEntryIds);
+    const hasUnexpectedSuffixEntry = branch
+      .slice(matchedIndices[0])
+      .some((entry) => typeof entry.id === "string" && !allowedIds.has(entry.id));
+    if (hasUnexpectedSuffixEntry) {
+      return {
+        changed: false,
+        bytesFreed: 0,
+        rewrittenEntries: 0,
+        reason: "rewrite suffix guard failed",
+        appendedEntries: [],
+      };
+    }
+  }
+
   if (!firstMatchedEntry.parentId) {
     params.state.resetLeaf();
   } else {
@@ -372,6 +389,9 @@ export async function rewriteTranscriptEntriesInSessionFile(params: {
     const result = rewriteTranscriptEntriesInState({
       state,
       replacements: params.request.replacements,
+      ...(params.request.allowedRewriteSuffixEntryIds
+        ? { allowedRewriteSuffixEntryIds: params.request.allowedRewriteSuffixEntryIds }
+        : {}),
     });
     if (result.changed) {
       await persistTranscriptStateMutation({

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -25,6 +25,7 @@ import {
   createTestRegistry,
 } from "../../test-utils/channel-plugins.js";
 import { createInternalHookEventPayload } from "../../test-utils/internal-hook-event-payload.js";
+import { getReplyPayloadMetadata } from "../reply-payload.js";
 import type { MsgContext } from "../templating.js";
 import { setReplyPayloadMetadata, type GetReplyOptions, type ReplyPayload } from "../types.js";
 import { PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE } from "./provider-request-error-classifier.js";
@@ -6364,6 +6365,53 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       idempotencyKey: "run-1:internal-source-reply:0",
       updateMode: "inline",
       config: emptyConfig,
+    });
+  });
+
+  it("keeps internal source reply metadata on TTS-cloned final payloads", async () => {
+    setNoAbort();
+    ttsMocks.state.synthesizeFinalAudio = true;
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const sourceReply = setReplyPayloadMetadata(
+      { text: "message tool reply" },
+      {
+        deliverDespiteSourceReplySuppression: true,
+        sourceReplyTranscriptMirror: {
+          sessionKey: "agent:main",
+          agentId: "main",
+          text: "message tool reply",
+          idempotencyKey: "run-tts:internal-source-reply:0",
+        },
+      },
+    );
+    const replyResolver = vi.fn(async () => sourceReply satisfies ReplyPayload);
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({ Provider: "webchat", Surface: "webchat", SessionKey: "agent:main" }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    });
+
+    expect(result.queuedFinal).toBe(true);
+    const queuedPayload = (dispatcher.sendFinalReply as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[0];
+    expect(queuedPayload).toMatchObject({
+      text: "message tool reply",
+      mediaUrl: "https://example.com/tts-synth.opus",
+      audioAsVoice: true,
+    });
+    expect(getReplyPayloadMetadata(queuedPayload)?.sourceReplyTranscriptMirror).toMatchObject({
+      sessionKey: "agent:main",
+      idempotencyKey: "run-tts:internal-source-reply:0",
     });
   });
 

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -103,6 +103,7 @@ import {
 } from "../commands-registry.js";
 import type { BlockReplyContext } from "../get-reply-options.types.js";
 import {
+  copyReplyPayloadMetadata,
   getReplyPayloadMetadata,
   isReplyPayloadStatusNotice,
   markReplyPayloadAsTtsSupplement,
@@ -235,7 +236,10 @@ async function maybeApplyTtsToReplyPayload(
     return params.payload;
   }
   const { maybeApplyTtsToPayload } = await loadTtsRuntime();
-  return maybeApplyTtsToPayload(params);
+  const ttsPayload = await maybeApplyTtsToPayload(params);
+  return ttsPayload === params.payload
+    ? ttsPayload
+    : copyReplyPayloadMetadata(params.payload, ttsPayload);
 }
 
 const AUDIO_PLACEHOLDER_RE = /^<media:audio>(\s*\([^)]*\))?$/i;

--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -2,6 +2,7 @@ import { sanitizeUserFacingText } from "../../agents/pi-embedded-helpers/sanitiz
 import { hasReplyPayloadContent } from "../../interactive/payload.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
+import { copyReplyPayloadMetadata } from "../reply-payload.js";
 import {
   HEARTBEAT_TOKEN,
   isSilentReplyPayloadText,
@@ -103,13 +104,15 @@ export function normalizeReplyPayload(
     return null;
   }
 
-  let enrichedPayload: ReplyPayload = { ...payload, text };
+  let enrichedPayload: ReplyPayload = copyReplyPayloadMetadata(payload, { ...payload, text });
   if (applyChannelTransforms && opts.transformReplyPayload) {
     const transformedPayload = opts.transformReplyPayload(enrichedPayload);
     if (transformedPayload === null) {
       return null;
     }
-    enrichedPayload = transformedPayload ?? enrichedPayload;
+    enrichedPayload = transformedPayload
+      ? copyReplyPayloadMetadata(enrichedPayload, transformedPayload)
+      : enrichedPayload;
     text = enrichedPayload.text;
   }
 
@@ -127,6 +130,6 @@ export function normalizeReplyPayload(
     text = `${effectivePrefix} ${text}`;
   }
 
-  enrichedPayload = { ...enrichedPayload, text };
+  enrichedPayload = copyReplyPayloadMetadata(enrichedPayload, { ...enrichedPayload, text });
   return enrichedPayload;
 }

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
 
 const ensureSandboxWorkspaceForSession = vi.hoisted(() => vi.fn());
 const resolveOutboundAttachmentFromUrl = vi.hoisted(() => vi.fn());
@@ -106,6 +107,39 @@ describe("createReplyMediaPathNormalizer", () => {
     );
     const mediaAccess = requireRecord(options.mediaAccess, "media access");
     expect(mediaAccess.workspaceDir).toBe("/tmp/agent-workspace");
+  });
+
+  it("preserves reply metadata when media normalization clones the payload", async () => {
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+    const payload = setReplyPayloadMetadata(
+      {
+        text: "Here is the image",
+        mediaUrls: ["./out/photo.png"],
+      },
+      {
+        sourceReplyTranscriptMirror: {
+          sessionKey: "main",
+          text: "Here is the image",
+          mediaUrls: ["./out/photo.png"],
+          idempotencyKey: "source-reply:0",
+        },
+      },
+    );
+
+    const result = await normalize(payload);
+
+    expect(result).not.toBe(payload);
+    expectMedia(result, "/tmp/outbound-media/photo.png", ["/tmp/outbound-media/photo.png"]);
+    expect(getReplyPayloadMetadata(result)?.sourceReplyTranscriptMirror).toEqual({
+      sessionKey: "main",
+      text: "Here is the image",
+      mediaUrls: ["./out/photo.png"],
+      idempotencyKey: "source-reply:0",
+    });
   });
 
   it("maps sandbox-relative media back to the host sandbox workspace before staging", async () => {

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -15,7 +15,7 @@ import { isPassThroughRemoteMediaSource } from "../../media/media-source-url.js"
 import { resolveOutboundAttachmentFromUrl } from "../../media/outbound-attachment.js";
 import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
 import { MEDIA_MAX_BYTES } from "../../media/store.js";
-import { appendReplyMediaFailureWarning } from "../reply-payload.js";
+import { appendReplyMediaFailureWarning, copyReplyPayloadMetadata } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
 
 const FILE_URL_RE = /^file:\/\//i;
@@ -223,20 +223,20 @@ export function createReplyMediaPathNormalizer(params: {
         : appendReplyMediaFailureWarning(payload.text);
 
     if (normalizedMedia.length === 0) {
-      return {
+      return copyReplyPayloadMetadata(payload, {
         ...payload,
         text,
         mediaUrl: undefined,
         mediaUrls: undefined,
-      };
+      });
     }
 
-    return {
+    return copyReplyPayloadMetadata(payload, {
       ...payload,
       text,
       mediaUrl: normalizedMedia[0],
       mediaUrls: normalizedMedia,
-    };
+    });
   };
 }
 

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import { parseAudioTag } from "./audio-tags.js";
 import { createBlockReplyCoalescer } from "./block-reply-coalescer.js";
@@ -107,6 +108,31 @@ describe("matchesMentionWithExplicit", () => {
 
 // Keep channelData-only payloads so channel-specific replies survive normalization.
 describe("normalizeReplyPayload", () => {
+  it("preserves reply payload metadata across normalization clones", () => {
+    const payload = setReplyPayloadMetadata(
+      {
+        text: " Visible reply ",
+      },
+      {
+        sourceReplyTranscriptMirror: {
+          sessionKey: "main",
+          text: " Visible reply ",
+          idempotencyKey: "run-1:source-reply",
+        },
+      },
+    );
+
+    const normalized = normalizeReplyPayload(payload);
+
+    const reply = expectNormalizedReply(normalized);
+    expect(reply).not.toBe(payload);
+    expect(getReplyPayloadMetadata(reply)?.sourceReplyTranscriptMirror).toEqual({
+      sessionKey: "main",
+      text: " Visible reply ",
+      idempotencyKey: "run-1:source-reply",
+    });
+  });
+
   it("keeps channelData-only replies", () => {
     const payload = {
       channelData: {

--- a/src/context-engine/types.ts
+++ b/src/context-engine/types.ts
@@ -135,6 +135,8 @@ export type TranscriptRewriteReplacement = {
 export type TranscriptRewriteRequest = {
   /** Message entry replacements to apply in one branch-and-reappend pass. */
   replacements: TranscriptRewriteReplacement[];
+  /** Optional entry-id set that must cover every active-branch entry from the first replacement onward. */
+  allowedRewriteSuffixEntryIds?: string[];
 };
 
 export type TranscriptRewriteResult = {

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { CURRENT_SESSION_VERSION } from "@earendil-works/pi-coding-agent";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
+import { setReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import {
   GATEWAY_CLIENT_CAPS,
@@ -960,6 +961,63 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     );
     // Normal agent-run final text must not be mirrored into JSONL by WebChat;
     // Pi persists the model-visible assistant turn from message_end.
+    expect(assistantUpdates).toStrictEqual([]);
+    const transcriptLines = readTranscriptJsonLines(mockState.transcriptPath);
+    const assistantEntries = transcriptLines.filter(
+      (entry) =>
+        (entry as { message?: { role?: string } }).message?.role === "assistant" ||
+        (entry as { role?: string }).role === "assistant",
+    );
+    expect(assistantEntries).toStrictEqual([]);
+  });
+
+  it("broadcasts agent-run internal-ui source replies without duplicating transcript", async () => {
+    createTranscriptFixture("openclaw-chat-send-agent-source-reply-");
+    mockState.triggerAgentRunStart = true;
+    const sourceReply = setReplyPayloadMetadata(
+      {
+        text: "Codex source reply",
+      },
+      {
+        sourceReplyTranscriptMirror: {
+          sessionKey: "main",
+          text: "Codex source reply",
+          idempotencyKey: "idem-agent-source-reply:internal-source-reply:0",
+        },
+      },
+    );
+    mockState.dispatchedReplies = [
+      {
+        kind: "final",
+        payload: sourceReply,
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    const broadcast = await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-agent-source-reply",
+      message: "hello from codex",
+    });
+
+    expect(broadcast).toMatchObject({
+      runId: "idem-agent-source-reply",
+      sessionKey: "main",
+      state: "final",
+    });
+    expect(extractFirstTextBlock(broadcast)).toBe("Codex source reply");
+    const nodeSend = lastNodeSendCall(context);
+    expect(nodeSend?.[0]).toBe("main");
+    expect(nodeSend?.[1]).toBe("chat");
+    expect(extractFirstTextBlock(nodeSend?.[2])).toBe("Codex source reply");
+    const assistantUpdates = mockState.emittedTranscriptUpdates.filter(
+      (update) =>
+        typeof update.message === "object" &&
+        update.message !== null &&
+        (update.message as { role?: unknown }).role === "assistant",
+    );
     expect(assistantUpdates).toStrictEqual([]);
     const transcriptLines = readTranscriptJsonLines(mockState.transcriptPath);
     const assistantEntries = transcriptLines.filter(

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -1028,6 +1028,61 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(assistantEntries).toStrictEqual([]);
   });
 
+  it("does not duplicate media-bearing internal-ui source replies in the transcript", async () => {
+    createTranscriptFixture("openclaw-chat-send-agent-source-reply-media-");
+    mockState.triggerAgentRunStart = true;
+    const sourceReply = setReplyPayloadMetadata(
+      {
+        text: "Codex source reply with media",
+        mediaUrls: ["https://example.com/chart.png"],
+      },
+      {
+        sourceReplyTranscriptMirror: {
+          sessionKey: "main",
+          text: "Codex source reply with media",
+          mediaUrls: ["https://example.com/chart.png"],
+          idempotencyKey: "idem-agent-source-reply-media:internal-source-reply:0",
+        },
+      },
+    );
+    mockState.dispatchedReplies = [
+      {
+        kind: "final",
+        payload: sourceReply,
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    const broadcast = await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-agent-source-reply-media",
+      message: "hello from codex",
+    });
+
+    expect(broadcast).toMatchObject({
+      runId: "idem-agent-source-reply-media",
+      sessionKey: "main",
+      state: "final",
+    });
+    expect(extractFirstTextBlock(broadcast)).toBe("Codex source reply with media");
+    const assistantUpdates = mockState.emittedTranscriptUpdates.filter(
+      (update) =>
+        typeof update.message === "object" &&
+        update.message !== null &&
+        (update.message as { role?: unknown }).role === "assistant",
+    );
+    expect(assistantUpdates).toStrictEqual([]);
+    const transcriptLines = readTranscriptJsonLines(mockState.transcriptPath);
+    const assistantEntries = transcriptLines.filter(
+      (entry) =>
+        (entry as { message?: { role?: string } }).message?.role === "assistant" ||
+        (entry as { role?: string }).role === "assistant",
+    );
+    expect(assistantEntries).toStrictEqual([]);
+  });
+
   it("does not broadcast an error terminal after an internal-ui source reply final", async () => {
     createTranscriptFixture("openclaw-chat-send-agent-source-reply-error-");
     mockState.triggerAgentRunStart = true;

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -1028,6 +1028,62 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(assistantEntries).toStrictEqual([]);
   });
 
+  it("does not broadcast an error terminal after an internal-ui source reply final", async () => {
+    createTranscriptFixture("openclaw-chat-send-agent-source-reply-error-");
+    mockState.triggerAgentRunStart = true;
+    const sourceReply = setReplyPayloadMetadata(
+      {
+        text: "Codex source reply",
+      },
+      {
+        sourceReplyTranscriptMirror: {
+          sessionKey: "main",
+          text: "Codex source reply",
+          idempotencyKey: "idem-agent-source-reply-error:internal-source-reply:0",
+        },
+      },
+    );
+    mockState.dispatchedReplies = [
+      {
+        kind: "final",
+        payload: sourceReply,
+      },
+      {
+        kind: "final",
+        payload: {
+          text: "tool warning",
+          isError: true,
+        },
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    const broadcast = await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-agent-source-reply-error",
+      message: "hello from codex",
+    });
+
+    expect(broadcast).toMatchObject({
+      runId: "idem-agent-source-reply-error",
+      sessionKey: "main",
+      state: "final",
+    });
+    expect(extractFirstTextBlock(broadcast)).toBe("Codex source reply");
+    const errorBroadcasts = (
+      context.broadcast as unknown as ReturnType<typeof vi.fn>
+    ).mock.calls.filter(([, payload]) => (payload as { state?: unknown })?.state === "error");
+    expect(errorBroadcasts).toStrictEqual([]);
+    const dedupe = context.dedupe.get("chat:idem-agent-source-reply-error");
+    expect(dedupe?.ok).toBe(true);
+    expect(dedupe?.payload).toMatchObject({
+      runId: "idem-agent-source-reply-error",
+      status: "ok",
+    });
+  });
+
   it("broadcasts returned agent-run error payloads after an agent starts", async () => {
     createTranscriptFixture("openclaw-chat-send-agent-returned-error-");
     const errorMessage = "LLM idle timeout (120s): no response from model";

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -6,6 +6,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import { setReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
+import { appendSessionTranscriptMessage } from "../../config/sessions/transcript-append.js";
+import { resolveMirroredTranscriptText } from "../../config/sessions/transcript-mirror.js";
 import {
   GATEWAY_CLIENT_CAPS,
   GATEWAY_CLIENT_MODES,
@@ -13,6 +15,7 @@ import {
 } from "../protocol/client-info.js";
 import { ErrorCodes } from "../protocol/index.js";
 import { CHAT_SEND_SESSION_KEY_MAX_LENGTH } from "../protocol/schema/primitives.js";
+import { readSessionTranscriptIndex } from "../session-transcript-index.fs.js";
 import type { GatewayRequestContext } from "./types.js";
 
 const mockState = vi.hoisted(() => ({
@@ -107,6 +110,9 @@ UNTRUSTED channel metadata (discord)
 Sender labels:
 example
 <<<END_EXTERNAL_UNTRUSTED_CONTENT id="deadbeefdeadbeef">>>`;
+
+const TINY_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=";
 
 vi.mock("../session-utils.js", async () => {
   const original =
@@ -361,6 +367,56 @@ function createTranscriptFixture(prefix: string) {
   );
   mockState.transcriptPath = transcriptPath;
   return dir;
+}
+
+async function appendSourceReplyMirrorEntry(params: {
+  idempotencyKey?: string;
+  text: string;
+  provider?: string;
+  model?: string;
+}) {
+  await appendSessionTranscriptMessage({
+    transcriptPath: mockState.transcriptPath,
+    now: 0,
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text: params.text }],
+      api: "openai-responses",
+      provider: params.provider ?? "openclaw",
+      model: params.model ?? "delivery-mirror",
+      ...(params.idempotencyKey ? { idempotencyKey: params.idempotencyKey } : {}),
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+        },
+      },
+      stopReason: "stop",
+      timestamp: 0,
+    },
+  });
+}
+
+async function readActiveAssistantTranscriptMessages(): Promise<Array<Record<string, unknown>>> {
+  const index = await readSessionTranscriptIndex(mockState.transcriptPath);
+  return (
+    index?.entries
+      .map((entry) => entry.record.message)
+      .filter(
+        (message): message is Record<string, unknown> =>
+          typeof message === "object" &&
+          message !== null &&
+          (message as { role?: unknown }).role === "assistant",
+      ) ?? []
+  );
 }
 
 function extractFirstTextBlock(payload: unknown): string | undefined {
@@ -973,6 +1029,11 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("broadcasts agent-run internal-ui source replies without duplicating transcript", async () => {
     createTranscriptFixture("openclaw-chat-send-agent-source-reply-");
+    const mirrorIdempotencyKey = "idem-agent-source-reply:internal-source-reply:0";
+    await appendSourceReplyMirrorEntry({
+      idempotencyKey: mirrorIdempotencyKey,
+      text: "Codex source reply",
+    });
     mockState.triggerAgentRunStart = true;
     const sourceReply = setReplyPayloadMetadata(
       {
@@ -982,7 +1043,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         sourceReplyTranscriptMirror: {
           sessionKey: "main",
           text: "Codex source reply",
-          idempotencyKey: "idem-agent-source-reply:internal-source-reply:0",
+          idempotencyKey: mirrorIdempotencyKey,
         },
       },
     );
@@ -1019,29 +1080,37 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         (update.message as { role?: unknown }).role === "assistant",
     );
     expect(assistantUpdates).toStrictEqual([]);
-    const transcriptLines = readTranscriptJsonLines(mockState.transcriptPath);
-    const assistantEntries = transcriptLines.filter(
-      (entry) =>
-        (entry as { message?: { role?: string } }).message?.role === "assistant" ||
-        (entry as { role?: string }).role === "assistant",
-    );
-    expect(assistantEntries).toStrictEqual([]);
+    const assistantEntries = await readActiveAssistantTranscriptMessages();
+    expect(assistantEntries.map((entry) => entry.idempotencyKey)).toStrictEqual([
+      mirrorIdempotencyKey,
+    ]);
   });
 
   it("does not duplicate media-bearing internal-ui source replies in the transcript", async () => {
-    createTranscriptFixture("openclaw-chat-send-agent-source-reply-media-");
+    const fixtureDir = createTranscriptFixture("openclaw-chat-send-agent-source-reply-media-");
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = fixtureDir;
+    const mediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
+    const savedImagePath = path.join(fixtureDir, "source-reply.png");
+    fs.writeFileSync(savedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+    mockState.savedMediaResults = [{ path: savedImagePath, contentType: "image/png" }];
+    const mirrorIdempotencyKey = "idem-agent-source-reply-media:internal-source-reply:0";
+    await appendSourceReplyMirrorEntry({
+      idempotencyKey: mirrorIdempotencyKey,
+      text: "Codex source reply with media",
+    });
     mockState.triggerAgentRunStart = true;
     const sourceReply = setReplyPayloadMetadata(
       {
         text: "Codex source reply with media",
-        mediaUrls: ["https://example.com/chart.png"],
+        mediaUrls: [mediaUrl],
       },
       {
         sourceReplyTranscriptMirror: {
           sessionKey: "main",
           text: "Codex source reply with media",
-          mediaUrls: ["https://example.com/chart.png"],
-          idempotencyKey: "idem-agent-source-reply-media:internal-source-reply:0",
+          mediaUrls: [mediaUrl],
+          idempotencyKey: mirrorIdempotencyKey,
         },
       },
     );
@@ -1054,33 +1123,630 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     const respond = vi.fn();
     const context = createChatContext();
 
-    const broadcast = await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-agent-source-reply-media",
-      message: "hello from codex",
-    });
+    try {
+      const broadcast = await runNonStreamingChatSend({
+        context,
+        respond,
+        idempotencyKey: "idem-agent-source-reply-media",
+        message: "hello from codex",
+      });
 
-    expect(broadcast).toMatchObject({
-      runId: "idem-agent-source-reply-media",
-      sessionKey: "main",
-      state: "final",
+      expect(broadcast).toMatchObject({
+        runId: "idem-agent-source-reply-media",
+        sessionKey: "main",
+        state: "final",
+      });
+      expect(extractFirstTextBlock(broadcast)).toBe("Codex source reply with media");
+      const broadcastContent = getMessageContent(broadcast);
+      expect(String(broadcastContent[1]?.url)).toContain("/api/chat/media/outgoing/");
+      expect(String(broadcastContent[1]?.openUrl)).toContain("/api/chat/media/outgoing/");
+      const assistantUpdates = mockState.emittedTranscriptUpdates.filter(
+        (update) =>
+          typeof update.message === "object" &&
+          update.message !== null &&
+          (update.message as { role?: unknown }).role === "assistant",
+      );
+      expect(assistantUpdates).toStrictEqual([]);
+      const assistantEntries = await readActiveAssistantTranscriptMessages();
+      expect(assistantEntries).toHaveLength(1);
+      expect(assistantEntries[0]?.idempotencyKey).toBe(mirrorIdempotencyKey);
+      expect(JSON.stringify(assistantEntries[0])).toContain("/api/chat/media/outgoing/");
+      expect(JSON.stringify(assistantEntries[0])).not.toContain(mediaUrl);
+    } finally {
+      if (previousStateDir == null) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+    }
+  });
+
+  it("backs source reply media with an equivalent deduped delivery mirror", async () => {
+    const fixtureDir = createTranscriptFixture("openclaw-chat-send-agent-source-reply-deduped-");
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = fixtureDir;
+    const mediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
+    const savedImagePath = path.join(fixtureDir, "source-reply-deduped.png");
+    fs.writeFileSync(savedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+    mockState.savedMediaResults = [{ path: savedImagePath, contentType: "image/png" }];
+    const mirrorIdempotencyKey = "idem-agent-source-reply-deduped:internal-source-reply:0";
+    await appendSourceReplyMirrorEntry({
+      text: resolveMirroredTranscriptText({ mediaUrls: [mediaUrl] }) ?? "media",
     });
-    expect(extractFirstTextBlock(broadcast)).toBe("Codex source reply with media");
-    const assistantUpdates = mockState.emittedTranscriptUpdates.filter(
-      (update) =>
-        typeof update.message === "object" &&
-        update.message !== null &&
-        (update.message as { role?: unknown }).role === "assistant",
+    mockState.triggerAgentRunStart = true;
+    mockState.dispatchedReplies = [
+      {
+        kind: "final",
+        payload: setReplyPayloadMetadata(
+          {
+            mediaUrls: [mediaUrl],
+          },
+          {
+            sourceReplyTranscriptMirror: {
+              sessionKey: "main",
+              mediaUrls: [mediaUrl],
+              idempotencyKey: mirrorIdempotencyKey,
+            },
+          },
+        ),
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    try {
+      const broadcast = await runNonStreamingChatSend({
+        context,
+        respond,
+        idempotencyKey: "idem-agent-source-reply-deduped",
+        message: "hello from codex",
+      });
+
+      const broadcastContent = getMessageContent(broadcast);
+      expect(broadcastContent.filter((block) => block.type === "image")).toHaveLength(1);
+      expect(JSON.stringify(broadcastContent)).toContain("/api/chat/media/outgoing/");
+      const assistantEntries = await readActiveAssistantTranscriptMessages();
+      expect(assistantEntries).toHaveLength(1);
+      expect(assistantEntries[0]?.idempotencyKey).toBe(mirrorIdempotencyKey);
+      expect(JSON.stringify(assistantEntries[0])).toContain("/api/chat/media/outgoing/");
+      expect(JSON.stringify(assistantEntries[0])).not.toContain(mediaUrl);
+    } finally {
+      if (previousStateDir == null) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+    }
+  });
+
+  it("updates each media-bearing source reply mirror independently", async () => {
+    const fixtureDir = createTranscriptFixture("openclaw-chat-send-agent-source-reply-multi-");
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = fixtureDir;
+    const firstMediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
+    const secondMediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
+    const firstSavedImagePath = path.join(fixtureDir, "source-reply-1.png");
+    const secondSavedImagePath = path.join(fixtureDir, "source-reply-2.png");
+    fs.writeFileSync(firstSavedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+    fs.writeFileSync(secondSavedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+    mockState.savedMediaResults = [
+      { path: firstSavedImagePath, contentType: "image/png" },
+      { path: secondSavedImagePath, contentType: "image/png" },
+    ];
+    const firstMirrorKey = "idem-agent-source-reply-multi:internal-source-reply:0";
+    const secondMirrorKey = "idem-agent-source-reply-multi:internal-source-reply:1";
+    await appendSourceReplyMirrorEntry({
+      idempotencyKey: firstMirrorKey,
+      text: "First source reply",
+    });
+    await appendSourceReplyMirrorEntry({
+      idempotencyKey: secondMirrorKey,
+      text: "Second source reply",
+    });
+    mockState.triggerAgentRunStart = true;
+    mockState.dispatchedReplies = [
+      {
+        kind: "final",
+        payload: setReplyPayloadMetadata(
+          {
+            text: "First source reply",
+            mediaUrls: [firstMediaUrl],
+          },
+          {
+            sourceReplyTranscriptMirror: {
+              sessionKey: "main",
+              text: "First source reply",
+              mediaUrls: [firstMediaUrl],
+              idempotencyKey: firstMirrorKey,
+            },
+          },
+        ),
+      },
+      {
+        kind: "final",
+        payload: setReplyPayloadMetadata(
+          {
+            text: "Second source reply",
+            mediaUrls: [secondMediaUrl],
+          },
+          {
+            sourceReplyTranscriptMirror: {
+              sessionKey: "main",
+              text: "Second source reply",
+              mediaUrls: [secondMediaUrl],
+              idempotencyKey: secondMirrorKey,
+            },
+          },
+        ),
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    try {
+      const broadcast = await runNonStreamingChatSend({
+        context,
+        respond,
+        idempotencyKey: "idem-agent-source-reply-multi",
+        message: "hello from codex",
+      });
+
+      const broadcastContent = getMessageContent(broadcast);
+      expect(broadcastContent.filter((block) => block.type === "image")).toHaveLength(2);
+      expect(mockState.savedMediaCalls).toHaveLength(2);
+      const assistantEntries = await readActiveAssistantTranscriptMessages();
+      expect(assistantEntries.map((entry) => entry.idempotencyKey)).toStrictEqual([
+        firstMirrorKey,
+        secondMirrorKey,
+      ]);
+      expect(JSON.stringify(assistantEntries[0])).toContain("/api/chat/media/outgoing/");
+      expect(JSON.stringify(assistantEntries[1])).toContain("/api/chat/media/outgoing/");
+      expect(JSON.stringify(assistantEntries[0])).not.toContain(firstMediaUrl);
+      expect(JSON.stringify(assistantEntries[1])).not.toContain(secondMediaUrl);
+    } finally {
+      if (previousStateDir == null) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+    }
+  });
+
+  it("keeps backed media source replies when a sibling mirror is missing", async () => {
+    const fixtureDir = createTranscriptFixture("openclaw-chat-send-agent-source-reply-partial-");
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = fixtureDir;
+    const firstMediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
+    const secondMediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
+    const firstSavedImagePath = path.join(fixtureDir, "source-reply-backed.png");
+    const secondSavedImagePath = path.join(fixtureDir, "source-reply-missing.png");
+    fs.writeFileSync(firstSavedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+    fs.writeFileSync(secondSavedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+    mockState.savedMediaResults = [
+      { path: firstSavedImagePath, contentType: "image/png" },
+      { path: secondSavedImagePath, contentType: "image/png" },
+    ];
+    const backedMirrorKey = "idem-agent-source-reply-partial:internal-source-reply:0";
+    const missingMirrorKey = "idem-agent-source-reply-partial:internal-source-reply:1";
+    await appendSourceReplyMirrorEntry({
+      idempotencyKey: backedMirrorKey,
+      text: "Backed source reply",
+    });
+    mockState.triggerAgentRunStart = true;
+    mockState.dispatchedReplies = [
+      {
+        kind: "final",
+        payload: setReplyPayloadMetadata(
+          {
+            text: "Backed source reply",
+            mediaUrls: [firstMediaUrl],
+          },
+          {
+            sourceReplyTranscriptMirror: {
+              sessionKey: "main",
+              text: "Backed source reply",
+              mediaUrls: [firstMediaUrl],
+              idempotencyKey: backedMirrorKey,
+            },
+          },
+        ),
+      },
+      {
+        kind: "final",
+        payload: setReplyPayloadMetadata(
+          {
+            text: "Missing mirror source reply",
+            mediaUrls: [secondMediaUrl],
+          },
+          {
+            sourceReplyTranscriptMirror: {
+              sessionKey: "main",
+              text: "Missing mirror source reply",
+              mediaUrls: [secondMediaUrl],
+              idempotencyKey: missingMirrorKey,
+            },
+          },
+        ),
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    try {
+      const broadcast = await runNonStreamingChatSend({
+        context,
+        respond,
+        idempotencyKey: "idem-agent-source-reply-partial",
+        message: "hello from codex",
+      });
+
+      const broadcastContent = getMessageContent(broadcast);
+      expect(broadcastContent.filter((block) => block.type === "image")).toHaveLength(1);
+      expect(extractFirstTextBlock(broadcast)).toBe("Backed source reply");
+      expect(String(broadcastContent[1]?.url)).toContain("/api/chat/media/outgoing/");
+      const assistantEntries = await readActiveAssistantTranscriptMessages();
+      expect(assistantEntries).toHaveLength(1);
+      expect(assistantEntries[0]?.idempotencyKey).toBe(backedMirrorKey);
+      expect(JSON.stringify(assistantEntries[0])).toContain("/api/chat/media/outgoing/");
+      expect(JSON.stringify(assistantEntries[0])).not.toContain(firstMediaUrl);
+      expect(JSON.stringify(broadcastContent)).not.toContain(secondMediaUrl);
+    } finally {
+      if (previousStateDir == null) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+    }
+  });
+
+  it("keeps media source replies when followed by text-only source reply mirrors", async () => {
+    const fixtureDir = createTranscriptFixture("openclaw-chat-send-agent-source-reply-text-tail-");
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = fixtureDir;
+    const mediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
+    const savedImagePath = path.join(fixtureDir, "source-reply-text-tail.png");
+    fs.writeFileSync(savedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+    mockState.savedMediaResults = [{ path: savedImagePath, contentType: "image/png" }];
+    const mediaMirrorKey = "idem-agent-source-reply-text-tail:internal-source-reply:0";
+    const textMirrorKey = "idem-agent-source-reply-text-tail:internal-source-reply:1";
+    await appendSourceReplyMirrorEntry({
+      idempotencyKey: mediaMirrorKey,
+      text: "Media source reply",
+    });
+    await appendSourceReplyMirrorEntry({
+      idempotencyKey: textMirrorKey,
+      text: "Text-only source reply",
+    });
+    mockState.triggerAgentRunStart = true;
+    mockState.dispatchedReplies = [
+      {
+        kind: "final",
+        payload: setReplyPayloadMetadata(
+          {
+            text: "Media source reply",
+            mediaUrls: [mediaUrl],
+          },
+          {
+            sourceReplyTranscriptMirror: {
+              sessionKey: "main",
+              text: "Media source reply",
+              mediaUrls: [mediaUrl],
+              idempotencyKey: mediaMirrorKey,
+            },
+          },
+        ),
+      },
+      {
+        kind: "final",
+        payload: setReplyPayloadMetadata(
+          {
+            text: "Text-only source reply",
+          },
+          {
+            sourceReplyTranscriptMirror: {
+              sessionKey: "main",
+              text: "Text-only source reply",
+              idempotencyKey: textMirrorKey,
+            },
+          },
+        ),
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    try {
+      const broadcast = await runNonStreamingChatSend({
+        context,
+        respond,
+        idempotencyKey: "idem-agent-source-reply-text-tail",
+        message: "hello from codex",
+      });
+
+      const broadcastContent = getMessageContent(broadcast);
+      expect(broadcastContent.filter((block) => block.type === "image")).toHaveLength(1);
+      expect(mockState.savedMediaCalls).toHaveLength(1);
+      const assistantEntries = await readActiveAssistantTranscriptMessages();
+      expect(assistantEntries.map((entry) => entry.idempotencyKey)).toStrictEqual([
+        mediaMirrorKey,
+        textMirrorKey,
+      ]);
+      expect(JSON.stringify(assistantEntries[0])).toContain("/api/chat/media/outgoing/");
+      expect(JSON.stringify(assistantEntries[1])).toContain("Text-only source reply");
+    } finally {
+      if (previousStateDir == null) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+    }
+  });
+
+  it("does not rewrite unrelated assistant messages with colliding source reply keys", async () => {
+    const fixtureDir = createTranscriptFixture("openclaw-chat-send-agent-source-reply-collision-");
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = fixtureDir;
+    const mediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
+    const savedImagePath = path.join(fixtureDir, "source-reply-collision.png");
+    fs.writeFileSync(savedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+    mockState.savedMediaResults = [{ path: savedImagePath, contentType: "image/png" }];
+    const collidingMirrorKey = "idem-agent-source-reply-collision:internal-source-reply:0";
+    await appendSourceReplyMirrorEntry({
+      idempotencyKey: collidingMirrorKey,
+      text: "Existing assistant content",
+      model: "gateway-injected",
+    });
+    mockState.triggerAgentRunStart = true;
+    mockState.dispatchedReplies = [
+      {
+        kind: "final",
+        payload: setReplyPayloadMetadata(
+          {
+            text: "Source reply with media",
+            mediaUrls: [mediaUrl],
+          },
+          {
+            sourceReplyTranscriptMirror: {
+              sessionKey: "main",
+              text: "Source reply with media",
+              mediaUrls: [mediaUrl],
+              idempotencyKey: collidingMirrorKey,
+            },
+          },
+        ),
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    try {
+      const broadcast = await runNonStreamingChatSend({
+        context,
+        respond,
+        idempotencyKey: "idem-agent-source-reply-collision",
+        message: "hello from codex",
+      });
+
+      expect(JSON.stringify(getMessageContent(broadcast))).not.toContain(
+        "/api/chat/media/outgoing/",
+      );
+      const assistantEntries = await readActiveAssistantTranscriptMessages();
+      expect(assistantEntries).toHaveLength(1);
+      expect(assistantEntries[0]?.content).toStrictEqual([
+        { type: "text", text: "Existing assistant content" },
+      ]);
+      expect(assistantEntries[0]?.model).toBe("gateway-injected");
+    } finally {
+      if (previousStateDir == null) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+    }
+  });
+
+  it("does not expose raw media refs when an unbacked source reply has no text", async () => {
+    const fixtureDir = createTranscriptFixture("openclaw-chat-send-agent-source-reply-media-only-");
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = fixtureDir;
+    const mediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
+    const savedImagePath = path.join(fixtureDir, "source-reply-media-only.png");
+    fs.writeFileSync(savedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+    mockState.savedMediaResults = [{ path: savedImagePath, contentType: "image/png" }];
+    const missingMirrorKey = "idem-agent-source-reply-media-only:internal-source-reply:0";
+    mockState.triggerAgentRunStart = true;
+    mockState.dispatchedReplies = [
+      {
+        kind: "final",
+        payload: setReplyPayloadMetadata(
+          {
+            mediaUrls: [mediaUrl],
+          },
+          {
+            sourceReplyTranscriptMirror: {
+              sessionKey: "main",
+              mediaUrls: [mediaUrl],
+              idempotencyKey: missingMirrorKey,
+            },
+          },
+        ),
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    try {
+      const broadcast = await runNonStreamingChatSend({
+        context,
+        respond,
+        idempotencyKey: "idem-agent-source-reply-media-only",
+        message: "hello from codex",
+      });
+
+      expect(extractFirstTextBlock(broadcast)).toBe("Media reply could not be displayed.");
+      const broadcastJson = JSON.stringify(broadcast);
+      expect(broadcastJson).not.toContain("MEDIA:");
+      expect(broadcastJson).not.toContain(mediaUrl);
+      expect(broadcastJson).not.toContain("/api/chat/media/outgoing/");
+      expect(await readActiveAssistantTranscriptMessages()).toStrictEqual([]);
+    } finally {
+      if (previousStateDir == null) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+    }
+  });
+
+  it("keeps a placeholder for unbacked media-only source reply siblings", async () => {
+    const fixtureDir = createTranscriptFixture(
+      "openclaw-chat-send-agent-source-reply-media-only-sibling-",
     );
-    expect(assistantUpdates).toStrictEqual([]);
-    const transcriptLines = readTranscriptJsonLines(mockState.transcriptPath);
-    const assistantEntries = transcriptLines.filter(
-      (entry) =>
-        (entry as { message?: { role?: string } }).message?.role === "assistant" ||
-        (entry as { role?: string }).role === "assistant",
-    );
-    expect(assistantEntries).toStrictEqual([]);
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = fixtureDir;
+    const mediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
+    const savedImagePath = path.join(fixtureDir, "source-reply-media-only-sibling.png");
+    fs.writeFileSync(savedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+    mockState.savedMediaResults = [{ path: savedImagePath, contentType: "image/png" }];
+    const textMirrorKey = "idem-agent-source-reply-media-only-sibling:internal-source-reply:0";
+    const missingMirrorKey = "idem-agent-source-reply-media-only-sibling:internal-source-reply:1";
+    await appendSourceReplyMirrorEntry({
+      idempotencyKey: textMirrorKey,
+      text: "Text source reply",
+    });
+    mockState.triggerAgentRunStart = true;
+    mockState.dispatchedReplies = [
+      {
+        kind: "final",
+        payload: setReplyPayloadMetadata(
+          {
+            text: "Text source reply",
+          },
+          {
+            sourceReplyTranscriptMirror: {
+              sessionKey: "main",
+              text: "Text source reply",
+              idempotencyKey: textMirrorKey,
+            },
+          },
+        ),
+      },
+      {
+        kind: "final",
+        payload: setReplyPayloadMetadata(
+          {
+            mediaUrls: [mediaUrl],
+          },
+          {
+            sourceReplyTranscriptMirror: {
+              sessionKey: "main",
+              mediaUrls: [mediaUrl],
+              idempotencyKey: missingMirrorKey,
+            },
+          },
+        ),
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    try {
+      const broadcast = await runNonStreamingChatSend({
+        context,
+        respond,
+        idempotencyKey: "idem-agent-source-reply-media-only-sibling",
+        message: "hello from codex",
+      });
+
+      const broadcastContent = getMessageContent(broadcast);
+      expect(broadcastContent).toContainEqual({ type: "text", text: "Text source reply" });
+      expect(broadcastContent).toContainEqual({
+        type: "text",
+        text: "Media reply could not be displayed.",
+      });
+      const broadcastJson = JSON.stringify(broadcast);
+      expect(broadcastJson).not.toContain("MEDIA:");
+      expect(broadcastJson).not.toContain(mediaUrl);
+      expect(broadcastJson).not.toContain("/api/chat/media/outgoing/");
+    } finally {
+      if (previousStateDir == null) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+    }
+  });
+
+  it("does not rewrite source reply mirrors when later transcript entries would be replayed", async () => {
+    const fixtureDir = createTranscriptFixture("openclaw-chat-send-agent-source-reply-later-");
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = fixtureDir;
+    const mediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
+    const savedImagePath = path.join(fixtureDir, "source-reply-later.png");
+    fs.writeFileSync(savedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+    mockState.savedMediaResults = [{ path: savedImagePath, contentType: "image/png" }];
+    const mirrorKey = "idem-agent-source-reply-later:internal-source-reply:0";
+    await appendSourceReplyMirrorEntry({
+      idempotencyKey: mirrorKey,
+      text: "Source reply with media",
+    });
+    await appendSourceReplyMirrorEntry({
+      idempotencyKey: "later-assistant-entry",
+      text: "Later assistant content",
+      model: "gateway-injected",
+    });
+    mockState.triggerAgentRunStart = true;
+    mockState.dispatchedReplies = [
+      {
+        kind: "final",
+        payload: setReplyPayloadMetadata(
+          {
+            text: "Source reply with media",
+            mediaUrls: [mediaUrl],
+          },
+          {
+            sourceReplyTranscriptMirror: {
+              sessionKey: "main",
+              text: "Source reply with media",
+              mediaUrls: [mediaUrl],
+              idempotencyKey: mirrorKey,
+            },
+          },
+        ),
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    try {
+      const broadcast = await runNonStreamingChatSend({
+        context,
+        respond,
+        idempotencyKey: "idem-agent-source-reply-later",
+        message: "hello from codex",
+      });
+
+      expect(JSON.stringify(getMessageContent(broadcast))).not.toContain(
+        "/api/chat/media/outgoing/",
+      );
+      const assistantEntries = await readActiveAssistantTranscriptMessages();
+      expect(assistantEntries.map((entry) => entry.idempotencyKey)).toStrictEqual([
+        mirrorKey,
+        "later-assistant-entry",
+      ]);
+      expect(assistantEntries[0]?.content).toStrictEqual([
+        { type: "text", text: "Source reply with media" },
+      ]);
+      expect(assistantEntries[1]?.content).toStrictEqual([
+        { type: "text", text: "Later assistant content" },
+      ]);
+    } finally {
+      if (previousStateDir == null) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+    }
   });
 
   it("does not broadcast an error terminal after an internal-ui source reply final", async () => {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -15,7 +15,7 @@ import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js"
 import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox/context.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
-import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import { getReplyPayloadMetadata, type ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
 import { stageSandboxMedia } from "../../auto-reply/reply/stage-sandbox-media.js";
 import type { MsgContext, TemplateContext } from "../../auto-reply/templating.js";
@@ -1974,6 +1974,10 @@ function broadcastChatError(params: {
   params.context.agentRunSeq.delete(params.runId);
 }
 
+function isSourceReplyTranscriptMirrorPayload(payload: ReplyPayload | undefined) {
+  return Boolean(payload && getReplyPayloadMetadata(payload)?.sourceReplyTranscriptMirror);
+}
+
 export const chatHandlers: GatewayRequestHandlers = {
   "chat.history": async ({ params, respond, context }) => {
     if (!validateChatHistoryParams(params)) {
@@ -3067,7 +3071,90 @@ export const chatHandlers: GatewayRequestHandlers = {
                     message,
                   });
                 }
-              } else if (returnedAgentErrorPayloads.length > 0) {
+              } else {
+                const sourceReplyPayloads = deliveredReplies
+                  .filter((entry) => entry.kind === "final")
+                  .map((entry) => entry.payload)
+                  .filter(isSourceReplyTranscriptMirrorPayload);
+                if (sourceReplyPayloads.length > 0) {
+                  const finalPayloads = await normalizeWebchatReplyMediaPathsForDisplay({
+                    cfg,
+                    sessionKey,
+                    agentId,
+                    accountId,
+                    payloads: sourceReplyPayloads,
+                  });
+                  const { storePath: latestStorePath, entry: latestEntry } =
+                    loadSessionEntry(sessionKey);
+                  const sessionId = latestEntry?.sessionId ?? backingSessionId ?? clientRunId;
+                  const resolvedTranscriptPath = resolveTranscriptPath({
+                    sessionId,
+                    storePath: latestStorePath,
+                    sessionFile: latestEntry?.sessionFile ?? entry?.sessionFile,
+                    agentId,
+                  });
+                  const mediaLocalRoots = appendLocalMediaParentRoots(
+                    getAgentScopedMediaLocalRoots(cfg, agentId),
+                    resolvedTranscriptPath ? [resolvedTranscriptPath] : undefined,
+                  );
+                  const assistantContent = await buildAssistantDisplayContentFromReplyPayloads({
+                    sessionKey,
+                    payloads: finalPayloads,
+                    managedImageLocalRoots: mediaLocalRoots,
+                    includeSensitiveMedia: false,
+                    onLocalAudioAccessDenied: (message) => {
+                      context.logGateway.warn(
+                        `webchat audio embedding denied local path: ${message}`,
+                      );
+                    },
+                    onManagedImagePrepareError: (message) => {
+                      context.logGateway.warn(
+                        `webchat image embedding skipped attachment: ${message}`,
+                      );
+                    },
+                  });
+                  const mediaMessage = await buildWebchatAssistantMediaMessage(finalPayloads, {
+                    localRoots: mediaLocalRoots,
+                    onLocalAudioAccessDenied: (message) => {
+                      context.logGateway.warn(
+                        `webchat audio embedding denied local path: ${message}`,
+                      );
+                    },
+                  });
+                  const broadcastAssistantContent = hasAssistantDisplayMediaContent(
+                    assistantContent,
+                  )
+                    ? assistantContent
+                    : hasAssistantDisplayMediaContent(mediaMessage?.content)
+                      ? mediaMessage?.content
+                      : assistantContent;
+                  const displayReply =
+                    extractAssistantDisplayTextFromContent(assistantContent) ??
+                    buildTranscriptReplyText(finalPayloads);
+                  if (broadcastAssistantContent?.length || displayReply) {
+                    const now = Date.now();
+                    const message = {
+                      role: "assistant",
+                      ...(broadcastAssistantContent?.length
+                        ? { content: broadcastAssistantContent }
+                        : displayReply
+                          ? { content: [{ type: "text", text: displayReply }] }
+                          : {}),
+                      ...(displayReply ? { text: displayReply } : {}),
+                      timestamp: now,
+                      stopReason: "stop",
+                      usage: { input: 0, output: 0, totalTokens: 0 },
+                    };
+                    broadcastChatFinal({
+                      context,
+                      runId: clientRunId,
+                      sessionKey,
+                      message,
+                    });
+                  }
+                }
+              }
+              if (returnedAgentErrorPayloads.length > 0) {
                 if (!hasBeforeAgentRunGate) {
                   await emitUserTranscriptUpdateAfterAgentRun();
                 }

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2695,6 +2695,9 @@ export const chatHandlers: GatewayRequestHandlers = {
         if (!agentRunStarted || appendedWebchatAgentMedia || !isMediaBearingPayload(payload)) {
           return;
         }
+        if (isSourceReplyTranscriptMirrorPayload(payload)) {
+          return;
+        }
         const ttsSupplementMarker = buildTtsSupplementTranscriptMarker(payload);
         const [transcriptPayload] = await normalizeWebchatReplyMediaPathsForDisplay({
           cfg,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2875,6 +2875,7 @@ export const chatHandlers: GatewayRequestHandlers = {
                   .map((payload) => payload.text?.trim())
                   .filter((text): text is string => Boolean(text))
                   .join(" | ") || undefined;
+              let broadcastedSourceReplyFinal = false;
               // WebChat persistence has two owners. Agent runs persist model-visible turns
               // through Pi's SessionManager; this dispatcher only owns live delivery payloads.
               // Do not blindly mirror agent-run final payloads into JSONL or chat.history can
@@ -3151,10 +3152,13 @@ export const chatHandlers: GatewayRequestHandlers = {
                       sessionKey,
                       message,
                     });
+                    broadcastedSourceReplyFinal = true;
                   }
                 }
               }
-              if (returnedAgentErrorPayloads.length > 0) {
+              const shouldBroadcastAgentError =
+                returnedAgentErrorPayloads.length > 0 && !broadcastedSourceReplyFinal;
+              if (shouldBroadcastAgentError) {
                 if (!hasBeforeAgentRunGate) {
                   await emitUserTranscriptUpdateAfterAgentRun();
                 }
@@ -3168,27 +3172,25 @@ export const chatHandlers: GatewayRequestHandlers = {
                 await emitUserTranscriptUpdateAfterAgentRun();
               }
               if (!context.chatAbortedRuns.has(clientRunId)) {
-                const returnedAgentError =
-                  returnedAgentErrorPayloads.length > 0
-                    ? errorShape(
-                        ErrorCodes.UNAVAILABLE,
-                        returnedAgentErrorMessage ?? "agent returned an error payload",
-                      )
-                    : undefined;
+                const returnedAgentError = shouldBroadcastAgentError
+                  ? errorShape(
+                      ErrorCodes.UNAVAILABLE,
+                      returnedAgentErrorMessage ?? "agent returned an error payload",
+                    )
+                  : undefined;
                 setGatewayDedupeEntry({
                   dedupe: context.dedupe,
                   key: `chat:${clientRunId}`,
                   entry: {
                     ts: Date.now(),
-                    ok: returnedAgentErrorPayloads.length === 0,
-                    payload:
-                      returnedAgentErrorPayloads.length > 0
-                        ? {
-                            runId: clientRunId,
-                            status: "error" as const,
-                            summary: returnedAgentErrorMessage ?? "agent returned an error payload",
-                          }
-                        : { runId: clientRunId, status: "ok" as const },
+                    ok: !shouldBroadcastAgentError,
+                    payload: shouldBroadcastAgentError
+                      ? {
+                          runId: clientRunId,
+                          status: "error" as const,
+                          summary: returnedAgentErrorMessage ?? "agent returned an error payload",
+                        }
+                      : { runId: clientRunId, status: "ok" as const },
                     ...(returnedAgentError ? { error: returnedAgentError } : {}),
                   },
                 });

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -21,6 +21,7 @@ import { stageSandboxMedia } from "../../auto-reply/reply/stage-sandbox-media.js
 import type { MsgContext, TemplateContext } from "../../auto-reply/templating.js";
 import { extractCanvasFromText } from "../../chat/canvas-render.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
+import { resolveMirroredTranscriptText } from "../../config/sessions/transcript-mirror.js";
 import { streamSessionTranscriptLines } from "../../config/sessions/transcript-stream.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
@@ -605,6 +606,18 @@ function hasAssistantDisplayMediaContent(
   content: readonly AssistantDisplayContentBlock[] | undefined,
 ): boolean {
   return Boolean(content?.some((block) => block?.type !== "text"));
+}
+
+function hasManagedOutgoingAssistantContent(
+  content: readonly AssistantDisplayContentBlock[] | undefined,
+): boolean {
+  return Boolean(
+    content?.some(
+      (block) =>
+        block?.type === "image" &&
+        (isManagedOutgoingImageUrl(block.url) || isManagedOutgoingImageUrl(block.openUrl)),
+    ),
+  );
 }
 
 function scheduleChatHistoryManagedImageCleanup(params: {
@@ -1439,6 +1452,103 @@ async function transcriptHasIdempotencyKey(
   }
 }
 
+async function findAssistantTranscriptMessageByIdempotencyKey(
+  transcriptPath: string,
+  idempotencyKey: string,
+): Promise<{ messageId: string; message: Record<string, unknown> } | null> {
+  const trimmedIdempotencyKey = idempotencyKey.trim();
+  if (!trimmedIdempotencyKey) {
+    return null;
+  }
+  const index = await readSessionTranscriptIndex(transcriptPath);
+  const target = index?.entries.toReversed().find((entry) => {
+    const message = entry.record.message as Record<string, unknown> | undefined;
+    return (
+      typeof entry.id === "string" &&
+      entry.id.trim().length > 0 &&
+      message?.role === "assistant" &&
+      message.idempotencyKey === trimmedIdempotencyKey
+    );
+  });
+  const message = target?.record.message as Record<string, unknown> | undefined;
+  if (!target?.id || !message) {
+    return null;
+  }
+  return { messageId: target.id, message };
+}
+
+async function findSourceReplyTranscriptMirrorByIdempotencyKey(
+  transcriptPath: string,
+  idempotencyKey: string,
+): Promise<{ messageId: string; message: Record<string, unknown> } | null> {
+  const found = await findAssistantTranscriptMessageByIdempotencyKey(
+    transcriptPath,
+    idempotencyKey,
+  );
+  if (found?.message.provider !== "openclaw" || found.message.model !== "delivery-mirror") {
+    return null;
+  }
+  return found;
+}
+
+function extractAssistantTranscriptText(message: Record<string, unknown>): string | undefined {
+  const content = message.content;
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  const text = content
+    .map((block) =>
+      block &&
+      typeof block === "object" &&
+      (block as { type?: unknown }).type === "text" &&
+      typeof (block as { text?: unknown }).text === "string"
+        ? ((block as { text: string }).text.trim() ?? "")
+        : "",
+    )
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+  return text || undefined;
+}
+
+async function findSourceReplyTranscriptMirrorByMetadata(params: {
+  transcriptPath: string;
+  idempotencyKey: string;
+  metadata: NonNullable<ReturnType<typeof getReplyPayloadMetadata>>["sourceReplyTranscriptMirror"];
+}): Promise<{ messageId: string; message: Record<string, unknown> } | null> {
+  const byIdempotencyKey = await findSourceReplyTranscriptMirrorByIdempotencyKey(
+    params.transcriptPath,
+    params.idempotencyKey,
+  );
+  if (byIdempotencyKey) {
+    return byIdempotencyKey;
+  }
+  const expectedText = resolveMirroredTranscriptText({
+    text: params.metadata?.text,
+    mediaUrls: params.metadata?.mediaUrls,
+  });
+  if (!expectedText) {
+    return null;
+  }
+  const index = await readSessionTranscriptIndex(params.transcriptPath);
+  const target = index?.entries.toReversed().find((entry) => {
+    const message = entry.record.message as Record<string, unknown> | undefined;
+    return (
+      typeof entry.id === "string" &&
+      entry.id.trim().length > 0 &&
+      message?.role === "assistant" &&
+      message.provider === "openclaw" &&
+      message.model === "delivery-mirror" &&
+      extractAssistantTranscriptText(message) === expectedText
+    );
+  });
+  const message = target?.record.message as Record<string, unknown> | undefined;
+  if (!target?.id || !message) {
+    return null;
+  }
+  return { messageId: target.id, message };
+}
+
 async function appendAssistantTranscriptMessage(params: {
   message: string;
   label?: string;
@@ -1484,7 +1594,13 @@ async function appendAssistantTranscriptMessage(params: {
     params.idempotencyKey &&
     (await transcriptHasIdempotencyKey(transcriptPath, params.idempotencyKey))
   ) {
-    return { ok: true };
+    const existing = await findAssistantTranscriptMessageByIdempotencyKey(
+      transcriptPath,
+      params.idempotencyKey,
+    );
+    return existing
+      ? { ok: true, messageId: existing.messageId, message: existing.message }
+      : { ok: true };
   }
 
   return await appendInjectedAssistantMessageToTranscript({
@@ -3101,50 +3217,269 @@ export const chatHandlers: GatewayRequestHandlers = {
                     getAgentScopedMediaLocalRoots(cfg, agentId),
                     resolvedTranscriptPath ? [resolvedTranscriptPath] : undefined,
                   );
-                  const assistantContent = await buildAssistantDisplayContentFromReplyPayloads({
-                    sessionKey,
-                    payloads: finalPayloads,
-                    managedImageLocalRoots: mediaLocalRoots,
-                    includeSensitiveMedia: false,
-                    onLocalAudioAccessDenied: (message) => {
-                      context.logGateway.warn(
-                        `webchat audio embedding denied local path: ${message}`,
-                      );
-                    },
-                    onManagedImagePrepareError: (message) => {
-                      context.logGateway.warn(
-                        `webchat image embedding skipped attachment: ${message}`,
-                      );
-                    },
-                  });
-                  const mediaMessage = await buildWebchatAssistantMediaMessage(finalPayloads, {
-                    localRoots: mediaLocalRoots,
-                    onLocalAudioAccessDenied: (message) => {
-                      context.logGateway.warn(
-                        `webchat audio embedding denied local path: ${message}`,
-                      );
-                    },
-                  });
-                  const broadcastAssistantContent = hasAssistantDisplayMediaContent(
-                    assistantContent,
-                  )
-                    ? assistantContent
-                    : hasAssistantDisplayMediaContent(mediaMessage?.content)
-                      ? mediaMessage?.content
-                      : assistantContent;
+                  const buildReplyAssistantContent = async (
+                    payloads: typeof finalPayloads,
+                  ): Promise<AssistantDisplayContentBlock[] | undefined> =>
+                    await buildAssistantDisplayContentFromReplyPayloads({
+                      sessionKey,
+                      payloads,
+                      managedImageLocalRoots: mediaLocalRoots,
+                      includeSensitiveMedia: false,
+                      onLocalAudioAccessDenied: (message) => {
+                        context.logGateway.warn(
+                          `webchat audio embedding denied local path: ${message}`,
+                        );
+                      },
+                      onManagedImagePrepareError: (message) => {
+                        context.logGateway.warn(
+                          `webchat image embedding skipped attachment: ${message}`,
+                        );
+                      },
+                    });
+                  const buildReplyMediaMessage = async (payloads: typeof finalPayloads) =>
+                    await buildWebchatAssistantMediaMessage(payloads, {
+                      localRoots: mediaLocalRoots,
+                      onLocalAudioAccessDenied: (message) => {
+                        context.logGateway.warn(
+                          `webchat audio embedding denied local path: ${message}`,
+                        );
+                      },
+                    });
+                  const combinedAssistantContent =
+                    sourceReplyPayloads.length === 1
+                      ? await buildReplyAssistantContent(finalPayloads)
+                      : undefined;
+                  const combinedMediaMessage =
+                    sourceReplyPayloads.length === 1
+                      ? await buildReplyMediaMessage(finalPayloads)
+                      : undefined;
+                  type SourceReplyContentState = {
+                    broadcastContent: AssistantDisplayContentBlock[];
+                    persistedContent: AssistantDisplayContentBlock[];
+                    hasManagedOutgoingContent: boolean;
+                    backedManagedOutgoingContent: boolean;
+                  };
+                  const sourceReplyContentStates: SourceReplyContentState[] = [];
+                  const sourceReplyBroadcastContent: AssistantDisplayContentBlock[] = [];
+                  for (const [replyIndex] of sourceReplyPayloads.entries()) {
+                    const finalPayload = finalPayloads[replyIndex];
+                    if (!finalPayload) {
+                      continue;
+                    }
+                    const replyAssistantContent =
+                      sourceReplyPayloads.length === 1
+                        ? combinedAssistantContent
+                        : await buildReplyAssistantContent([finalPayload]);
+                    const replyMediaMessage =
+                      sourceReplyPayloads.length === 1
+                        ? combinedMediaMessage
+                        : await buildReplyMediaMessage([finalPayload]);
+                    const replyBroadcastContent = hasAssistantDisplayMediaContent(
+                      replyAssistantContent,
+                    )
+                      ? replyAssistantContent
+                      : hasAssistantDisplayMediaContent(replyMediaMessage?.content)
+                        ? replyMediaMessage?.content
+                        : replyAssistantContent;
+                    const persistedContent = replaceAssistantContentTextBlocks(
+                      replyAssistantContent,
+                      replyMediaMessage ?? null,
+                    );
+                    const state: SourceReplyContentState = {
+                      broadcastContent: replyBroadcastContent ? [...replyBroadcastContent] : [],
+                      persistedContent: persistedContent ? [...persistedContent] : [],
+                      hasManagedOutgoingContent:
+                        hasManagedOutgoingAssistantContent(persistedContent),
+                      backedManagedOutgoingContent: false,
+                    };
+                    sourceReplyContentStates[replyIndex] = state;
+                    if (state.broadcastContent.length > 0) {
+                      sourceReplyBroadcastContent.push(...state.broadcastContent);
+                    }
+                  }
+
                   const displayReply =
-                    extractAssistantDisplayTextFromContent(assistantContent) ??
+                    extractAssistantDisplayTextFromContent(sourceReplyBroadcastContent) ??
                     buildTranscriptReplyText(finalPayloads);
-                  if (broadcastAssistantContent?.length || displayReply) {
+                  if (sourceReplyBroadcastContent.length || displayReply) {
+                    const sourceReplyPersistenceRequests: Array<{
+                      idempotencyKey: string;
+                      metadata: NonNullable<
+                        ReturnType<typeof getReplyPayloadMetadata>
+                      >["sourceReplyTranscriptMirror"];
+                      state: SourceReplyContentState;
+                    }> = [];
+                    for (const [replyIndex, sourceReplyPayload] of sourceReplyPayloads.entries()) {
+                      const state = sourceReplyContentStates[replyIndex];
+                      if (!state || !hasAssistantDisplayMediaContent(state.persistedContent)) {
+                        continue;
+                      }
+                      const mirrorMetadata =
+                        getReplyPayloadMetadata(sourceReplyPayload)?.sourceReplyTranscriptMirror;
+                      const mirrorIdempotencyKey = mirrorMetadata?.idempotencyKey;
+                      if (
+                        typeof mirrorIdempotencyKey !== "string" ||
+                        mirrorIdempotencyKey.trim().length === 0
+                      ) {
+                        continue;
+                      }
+                      if (!state.hasManagedOutgoingContent) {
+                        state.backedManagedOutgoingContent = true;
+                      }
+                      sourceReplyPersistenceRequests.push({
+                        idempotencyKey: mirrorIdempotencyKey,
+                        metadata: mirrorMetadata,
+                        state,
+                      });
+                    }
+
+                    const attachSourceReplyManagedImages = async (params: {
+                      messageId?: string;
+                      request: (typeof sourceReplyPersistenceRequests)[number];
+                    }) => {
+                      if (!params.request.state.hasManagedOutgoingContent) {
+                        params.request.state.backedManagedOutgoingContent = true;
+                        return;
+                      }
+                      if (!params.messageId) {
+                        return;
+                      }
+                      await attachManagedOutgoingImagesToMessage({
+                        messageId: params.messageId,
+                        blocks: params.request.state.persistedContent,
+                      });
+                      params.request.state.backedManagedOutgoingContent = true;
+                    };
+
+                    if (resolvedTranscriptPath && sourceReplyPersistenceRequests.length > 0) {
+                      const allowedSourceReplyMirrorIds = new Set<string>();
+                      for (const [
+                        replyIndex,
+                        sourceReplyPayload,
+                      ] of sourceReplyPayloads.entries()) {
+                        if (!sourceReplyContentStates[replyIndex]) {
+                          continue;
+                        }
+                        const mirrorIdempotencyKey =
+                          getReplyPayloadMetadata(sourceReplyPayload)?.sourceReplyTranscriptMirror
+                            ?.idempotencyKey;
+                        const mirrorMetadata =
+                          getReplyPayloadMetadata(sourceReplyPayload)?.sourceReplyTranscriptMirror;
+                        if (
+                          typeof mirrorIdempotencyKey !== "string" ||
+                          mirrorIdempotencyKey.trim().length === 0 ||
+                          !mirrorMetadata
+                        ) {
+                          continue;
+                        }
+                        const target = await findSourceReplyTranscriptMirrorByMetadata({
+                          transcriptPath: resolvedTranscriptPath,
+                          idempotencyKey: mirrorIdempotencyKey,
+                          metadata: mirrorMetadata,
+                        });
+                        if (target) {
+                          allowedSourceReplyMirrorIds.add(target.messageId);
+                        }
+                      }
+                      const rewriteTargets: Array<{
+                        request: (typeof sourceReplyPersistenceRequests)[number];
+                        messageId: string;
+                        message: Record<string, unknown>;
+                      }> = [];
+                      for (const request of sourceReplyPersistenceRequests) {
+                        const target = await findSourceReplyTranscriptMirrorByMetadata({
+                          transcriptPath: resolvedTranscriptPath,
+                          idempotencyKey: request.idempotencyKey,
+                          metadata: request.metadata,
+                        });
+                        if (target) {
+                          rewriteTargets.push({ request, ...target });
+                        }
+                      }
+
+                      if (rewriteTargets.length > 0) {
+                        const rewriteTargetIds = new Set(
+                          rewriteTargets.map((target) => target.messageId),
+                        );
+                        const rewriteIndex =
+                          await readSessionTranscriptIndex(resolvedTranscriptPath);
+                        const firstRewriteEntryIndex =
+                          rewriteIndex?.entries.findIndex(
+                            (entry) =>
+                              typeof entry.id === "string" && rewriteTargetIds.has(entry.id),
+                          ) ?? -1;
+                        const canRewriteSourceReplyMirrors =
+                          firstRewriteEntryIndex >= 0 &&
+                          rewriteIndex?.entries
+                            .slice(firstRewriteEntryIndex)
+                            .every(
+                              (entry) =>
+                                typeof entry.id !== "string" ||
+                                allowedSourceReplyMirrorIds.has(entry.id),
+                            ) === true;
+                        if (canRewriteSourceReplyMirrors) {
+                          const result = await rewriteTranscriptEntriesInSessionFile({
+                            sessionFile: resolvedTranscriptPath,
+                            sessionKey,
+                            config: cfg,
+                            request: {
+                              allowedRewriteSuffixEntryIds: [...allowedSourceReplyMirrorIds],
+                              replacements: rewriteTargets.map((target) => ({
+                                entryId: target.messageId,
+                                message: {
+                                  ...(target.message as unknown as AgentMessage),
+                                  idempotencyKey: target.request.idempotencyKey,
+                                  content: target.request.state.persistedContent,
+                                } as unknown as AgentMessage,
+                              })),
+                            },
+                          });
+                          if (result.changed) {
+                            for (const target of rewriteTargets) {
+                              const rewritten =
+                                await findSourceReplyTranscriptMirrorByIdempotencyKey(
+                                  resolvedTranscriptPath,
+                                  target.request.idempotencyKey,
+                                );
+                              await attachSourceReplyManagedImages({
+                                messageId: rewritten?.messageId,
+                                request: target.request,
+                              });
+                            }
+                          }
+                        }
+                      }
+                    }
+                    const sourceReplyContent = sourceReplyContentStates
+                      .flatMap((state) => {
+                        if (
+                          state.hasManagedOutgoingContent &&
+                          !state.backedManagedOutgoingContent
+                        ) {
+                          const stripped = stripManagedOutgoingAssistantContentBlocks(
+                            state.broadcastContent,
+                          );
+                          return stripped?.length
+                            ? stripped
+                            : [{ type: "text", text: "Media reply could not be displayed." }];
+                        }
+                        return state.broadcastContent;
+                      })
+                      .filter((block): block is AssistantDisplayContentBlock => Boolean(block));
+                    const sourceReplyTextFromContent =
+                      extractAssistantDisplayTextFromContent(sourceReplyContent);
+                    const sourceReplyText =
+                      sourceReplyTextFromContent ??
+                      (sourceReplyContent.length === 0 ? displayReply : undefined);
                     const now = Date.now();
                     const message = {
                       role: "assistant",
-                      ...(broadcastAssistantContent?.length
-                        ? { content: broadcastAssistantContent }
-                        : displayReply
-                          ? { content: [{ type: "text", text: displayReply }] }
+                      ...(sourceReplyContent?.length
+                        ? { content: sourceReplyContent }
+                        : sourceReplyText
+                          ? { content: [{ type: "text", text: sourceReplyText }] }
                           : {}),
-                      ...(displayReply ? { text: displayReply } : {}),
+                      ...(sourceReplyText ? { text: sourceReplyText } : {}),
                       timestamp: now,
                       stopReason: "stop",
                       usage: { input: 0, output: 0, totalTokens: 0 },

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -1046,6 +1046,36 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(chatLog.finalizeAssistant).not.toHaveBeenCalled();
   });
 
+  it("renders a late displayable final after an earlier empty final for the same run", () => {
+    const { state, chatLog, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-source-reply" },
+    });
+
+    handleChatEvent({
+      runId: "run-source-reply",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+    });
+    chatLog.dropAssistant.mockClear();
+    chatLog.finalizeAssistant.mockClear();
+
+    handleChatEvent({
+      runId: "run-source-reply",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hey Shakker. I’m here." }],
+      },
+    });
+
+    expect(chatLog.dropAssistant).not.toHaveBeenCalled();
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledWith(
+      "Hey Shakker. I’m here.",
+      "run-source-reply",
+    );
+  });
+
   it("reloads history when a local run ends without a displayable final message", () => {
     const { state, loadHistory, noteLocalRunId, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: "run-local-silent" },

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -1135,7 +1135,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
 describe("tui-event-handlers: streaming watchdog", () => {
   const expectedTimeoutMessage =
-    "This response is taking longer than expected. Send another message to continue.";
+    "This response is taking longer than expected. Still waiting for the current run.";
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -1195,7 +1195,7 @@ describe("tui-event-handlers: streaming watchdog", () => {
     return { state, chatLog, tui, setActivityStatus, loadHistory, noteLocalRunId, handlers };
   };
 
-  it("resets activityStatus to idle when no stream delta arrives for the watchdog window", () => {
+  it("keeps the active run busy when no stream delta arrives for the watchdog window", () => {
     const { state, chatLog, setActivityStatus, handlers } = createHarness({
       streamingWatchdogMs: 5_000,
     });
@@ -1212,14 +1212,14 @@ describe("tui-event-handlers: streaming watchdog", () => {
 
     vi.advanceTimersByTime(5_001);
 
-    expect(setActivityStatus).toHaveBeenLastCalledWith("idle");
-    expect(state.activeChatRunId).toBeNull();
+    expect(setActivityStatus).not.toHaveBeenCalledWith("idle");
+    expect(state.activeChatRunId).toBe("run-stuck");
     expect(chatLog.addPendingSystem).toHaveBeenCalledWith("run-stuck", expectedTimeoutMessage);
 
     handlers.dispose?.();
   });
 
-  it("flushes a deferred history reload when the watchdog clears the active run", () => {
+  it("keeps deferred history reload pending while the watchdog waits on the active run", () => {
     const { state, loadHistory, noteLocalRunId, setActivityStatus, handlers } = createHarness({
       streamingWatchdogMs: 5_000,
     });
@@ -1242,10 +1242,9 @@ describe("tui-event-handlers: streaming watchdog", () => {
 
     vi.advanceTimersByTime(5_001);
 
-    expect(state.activeChatRunId).toBeNull();
-    expect(state.activityStatus).toBe("idle");
-    expect(setActivityStatus).toHaveBeenLastCalledWith("idle");
-    expect(loadHistory).toHaveBeenCalledTimes(1);
+    expect(state.activeChatRunId).toBe("run-stuck");
+    expect(setActivityStatus).not.toHaveBeenCalledWith("idle");
+    expect(loadHistory).not.toHaveBeenCalled();
 
     handlers.dispose?.();
   });
@@ -1278,8 +1277,8 @@ describe("tui-event-handlers: streaming watchdog", () => {
 
     vi.advanceTimersByTime(2_500);
 
-    expect(setActivityStatus).toHaveBeenLastCalledWith("idle");
-    expect(state.activeChatRunId).toBeNull();
+    expect(setActivityStatus).not.toHaveBeenCalledWith("idle");
+    expect(state.activeChatRunId).toBe("run-flow");
 
     handlers.dispose?.();
   });
@@ -1312,8 +1311,8 @@ describe("tui-event-handlers: streaming watchdog", () => {
 
     vi.advanceTimersByTime(2_001);
 
-    expect(setActivityStatus).toHaveBeenLastCalledWith("idle");
-    expect(state.activeChatRunId).toBeNull();
+    expect(setActivityStatus).not.toHaveBeenCalledWith("idle");
+    expect(state.activeChatRunId).toBe("run-tools");
 
     handlers.dispose?.();
   });
@@ -1474,7 +1473,7 @@ describe("tui-event-handlers: streaming watchdog", () => {
     handlers.dispose?.();
   });
 
-  it("does not let an older run steal the active run watchdog", () => {
+  it("does not let another run replace a watchdog-noticed active run", () => {
     const { state, chatLog, setActivityStatus, handlers } = createHarness({
       streamingWatchdogMs: 5_000,
     });
@@ -1487,7 +1486,8 @@ describe("tui-event-handlers: streaming watchdog", () => {
     } satisfies ChatEvent);
 
     vi.advanceTimersByTime(5_001);
-    expect(state.activeChatRunId).toBeNull();
+    expect(state.activeChatRunId).toBe("run-old");
+    expect(chatLog.addPendingSystem).toHaveBeenCalledWith("run-old", expectedTimeoutMessage);
 
     handlers.handleChatEvent({
       runId: "run-new",
@@ -1495,7 +1495,7 @@ describe("tui-event-handlers: streaming watchdog", () => {
       state: "delta",
       message: { content: "new" },
     } satisfies ChatEvent);
-    expect(state.activeChatRunId).toBe("run-new");
+    expect(state.activeChatRunId).toBe("run-old");
 
     vi.advanceTimersByTime(3_000);
 
@@ -1508,9 +1508,9 @@ describe("tui-event-handlers: streaming watchdog", () => {
 
     vi.advanceTimersByTime(2_001);
 
-    expect(setActivityStatus).toHaveBeenLastCalledWith("idle");
-    expect(state.activeChatRunId).toBeNull();
-    expect(chatLog.addPendingSystem).toHaveBeenCalledTimes(2);
+    expect(setActivityStatus).not.toHaveBeenCalledWith("idle");
+    expect(state.activeChatRunId).toBe("run-old");
+    expect(chatLog.addPendingSystem).toHaveBeenCalledTimes(1);
 
     handlers.dispose?.();
   });

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -1076,6 +1076,35 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     );
   });
 
+  it("ignores duplicate empty final envelopes after a run already finalized empty", () => {
+    const { state, chatLog, loadHistory, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-empty-replay" },
+    });
+
+    handleChatEvent({
+      runId: "run-empty-replay",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+    });
+    chatLog.dropAssistant.mockClear();
+    chatLog.finalizeAssistant.mockClear();
+    loadHistory.mockClear();
+
+    handleChatEvent({
+      runId: "run-empty-replay",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [],
+      },
+    });
+
+    expect(chatLog.dropAssistant).not.toHaveBeenCalled();
+    expect(chatLog.finalizeAssistant).not.toHaveBeenCalled();
+    expect(loadHistory).not.toHaveBeenCalled();
+  });
+
   it("reloads history when a local run ends without a displayable final message", () => {
     const { state, loadHistory, noteLocalRunId, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: "run-local-silent" },

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -362,6 +362,45 @@ export function createEventHandlers(context: EventHandlerContext) {
     void loadHistory?.();
   };
 
+  const messageHasDisplayableNonTextContent = (message: unknown): boolean => {
+    if (!message || typeof message !== "object") {
+      return false;
+    }
+    const record = message as Record<string, unknown>;
+    if (typeof record.mediaUrl === "string" && record.mediaUrl.trim()) {
+      return true;
+    }
+    if (
+      Array.isArray(record.mediaUrls) &&
+      record.mediaUrls.some((media) => typeof media === "string" && media.trim())
+    ) {
+      return true;
+    }
+    if (!Array.isArray(record.content)) {
+      return false;
+    }
+    return record.content.some((block) => {
+      if (!block || typeof block !== "object") {
+        return false;
+      }
+      const type = (block as Record<string, unknown>).type;
+      return typeof type === "string" && type !== "text" && type !== "thinking";
+    });
+  };
+
+  const hasDisplayableFinalEvent = (evt: ChatEvent): boolean => {
+    if (typeof evt.errorMessage === "string" && evt.errorMessage.trim()) {
+      return true;
+    }
+    if (!evt.message) {
+      return false;
+    }
+    if (extractTextFromMessage(evt.message, { includeThinking: state.showThinking }).trim()) {
+      return true;
+    }
+    return messageHasDisplayableNonTextContent(evt.message);
+  };
+
   const isSameSessionKey = (left: string | undefined, right: string | undefined): boolean => {
     const normalizedLeft = normalizeLowercaseStringOrEmpty(left);
     const normalizedRight = normalizeLowercaseStringOrEmpty(right);
@@ -400,7 +439,7 @@ export function createEventHandlers(context: EventHandlerContext) {
       }
       if (evt.state === "final") {
         const hasLateDisplayableFinal =
-          Boolean(evt.message) && !finalizedRunsWithDisplay.has(evt.runId);
+          hasDisplayableFinalEvent(evt) && !finalizedRunsWithDisplay.has(evt.runId);
         if (!hasLateDisplayableFinal) {
           clearStaleStreamingIfNoTrackedRunRemains();
           return;

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -52,7 +52,7 @@ type EventHandlerContext = {
 
 const DEFAULT_STREAMING_WATCHDOG_MS = 30_000;
 const STREAMING_WATCHDOG_USER_MESSAGE =
-  "This response is taking longer than expected. Send another message to continue.";
+  "This response is taking longer than expected. Still waiting for the current run.";
 
 export function createEventHandlers(context: EventHandlerContext) {
   const {
@@ -124,17 +124,16 @@ export function createEventHandlers(context: EventHandlerContext) {
         return;
       }
       streamingWatchdogRunId = null;
-      state.activeChatRunId = null;
-      state.activityStatus = "idle";
-      setActivityStatus("idle");
       if (reconnectPendingRunId === runId) {
         reconnectPendingRunId = null;
+        state.activeChatRunId = null;
+        state.activityStatus = "idle";
+        setActivityStatus("idle");
         pendingHistoryRefresh = false;
         void loadHistory?.();
         tui.requestRender();
         return;
       }
-      flushPendingHistoryRefreshIfIdle();
       chatLog.addPendingSystem(runId, STREAMING_WATCHDOG_USER_MESSAGE);
       tui.requestRender();
     }, streamingWatchdogMs);

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -72,8 +72,9 @@ export function createEventHandlers(context: EventHandlerContext) {
     clearLocalBtwRunIds,
     localMode,
   } = context;
-  const finalizedRuns = new Map<string, number>();
   const sessionRuns = new Map<string, number>();
+  const finalizedRuns = new Map<string, number>();
+  const finalizedRunsWithDisplay = new Map<string, number>();
   const postFinalizingRuns = new Map<string, number>();
   let streamAssembler = new TuiStreamAssembler();
   let lastSessionKey = state.currentSessionKey;
@@ -172,6 +173,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     }
     lastSessionKey = state.currentSessionKey;
     finalizedRuns.clear();
+    finalizedRunsWithDisplay.clear();
     sessionRuns.clear();
     postFinalizingRuns.clear();
     streamAssembler = new TuiStreamAssembler();
@@ -230,11 +232,15 @@ export function createEventHandlers(context: EventHandlerContext) {
     pruneRunMap(sessionRuns);
   };
 
-  const noteFinalizedRun = (runId: string) => {
+  const noteFinalizedRun = (runId: string, opts?: { displayedFinal?: boolean }) => {
     finalizedRuns.set(runId, Date.now());
+    if (opts?.displayedFinal === true) {
+      finalizedRunsWithDisplay.set(runId, Date.now());
+    }
     sessionRuns.delete(runId);
     streamAssembler.drop(runId);
     pruneRunMap(finalizedRuns);
+    pruneRunMap(finalizedRunsWithDisplay);
   };
 
   const notePostFinalizingRun = (runId: string) => {
@@ -287,8 +293,9 @@ export function createEventHandlers(context: EventHandlerContext) {
     runId: string;
     wasActiveRun: boolean;
     status: "idle" | "error";
+    displayedFinal?: boolean;
   }) => {
-    noteFinalizedRun(params.runId);
+    noteFinalizedRun(params.runId, { displayedFinal: params.displayedFinal });
     clearActiveRunIfMatch(params.runId);
     flushPendingHistoryRefreshIfIdle();
     if (params.wasActiveRun) {
@@ -393,8 +400,12 @@ export function createEventHandlers(context: EventHandlerContext) {
         return;
       }
       if (evt.state === "final") {
-        clearStaleStreamingIfNoTrackedRunRemains();
-        return;
+        const hasLateDisplayableFinal =
+          Boolean(evt.message) && !finalizedRunsWithDisplay.has(evt.runId);
+        if (!hasLateDisplayableFinal) {
+          clearStaleStreamingIfNoTrackedRunRemains();
+          return;
+        }
       }
     }
     if (reconnectPendingRunId === evt.runId) {
@@ -451,7 +462,7 @@ export function createEventHandlers(context: EventHandlerContext) {
         if (text) {
           chatLog.addSystem(text);
         }
-        finalizeRun({ runId: evt.runId, wasActiveRun, status: "idle" });
+        finalizeRun({ runId: evt.runId, wasActiveRun, status: "idle", displayedFinal: true });
         tui.requestRender();
         return;
       }
@@ -480,6 +491,7 @@ export function createEventHandlers(context: EventHandlerContext) {
         runId: evt.runId,
         wasActiveRun,
         status: stopReason === "error" ? "error" : "idle",
+        displayedFinal: !suppressEmptyExternalPlaceholder,
       });
     }
     if (evt.state === "aborted") {

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -1131,6 +1131,55 @@ describe("connectGateway", () => {
     expect(loadChatHistoryMock).not.toHaveBeenCalled();
   });
 
+  it("keeps source-reply finals live even when message tool events were seen", () => {
+    const { host, client } = connectHostGateway();
+    host.chatRunId = "main-run-with-message-tool";
+    host.chatMessages = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "Hey there" }],
+        timestamp: 100,
+      },
+    ];
+    emitToolResultEvent(client);
+    expect(host.toolStreamOrder).toHaveLength(1);
+    loadChatHistoryMock.mockClear();
+
+    client.emitEvent({
+      event: "session.message",
+      payload: {
+        sessionKey: "main",
+      },
+    });
+    client.emitEvent({
+      event: "chat",
+      payload: {
+        runId: "main-run-with-message-tool",
+        sessionKey: "main",
+        state: "final",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Final answer" }],
+        },
+      },
+    });
+
+    expect(host.chatRunId).toBeNull();
+    expect(host.chatMessages).toEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "Hey there" }],
+        timestamp: 100,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Final answer" }],
+      },
+    ]);
+    expect(host.toolStreamOrder).toHaveLength(1);
+    expect(loadChatHistoryMock).not.toHaveBeenCalled();
+  });
+
   it("replays deferred session.message reloads after legacy silent final payload", () => {
     const { host, client } = connectHostGateway();
     host.chatRunId = "main-run-silent";

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -693,9 +693,15 @@ function handleTerminalChatEvent(
       });
     }
   }
-  // Reload history when tools were used so the persisted tool results
-  // replace the now-cleared streaming state.
+  // Reload history when tools were used only if the terminal event did not carry
+  // a renderable assistant message. Source-reply finals already contain the UI
+  // response; an immediate transcript reload replaces the optimistic user bubble
+  // with the persisted copy and causes a visible disappear/reappear flicker.
   if (hadToolEvents && state === "final") {
+    if (activeRunIdBeforeEvent && !shouldReloadHistoryForFinalEvent(payload)) {
+      flushQueue();
+      return false;
+    }
     const completedRunId = runId ?? null;
     void loadChatHistory(host as unknown as ChatState).finally(() => {
       if (completedRunId && host.chatRunId && host.chatRunId !== completedRunId) {


### PR DESCRIPTION
## Summary

Fixes TUI rendering for Codex source replies that are delivered through the `message` tool instead of the normal assistant-text final path.

This PR:
- preserves source-reply metadata through reply normalization, media handling, and TTS paths
- broadcasts message-tool-only source replies onto the live chat stream so `openclaw tui` renders them immediately
- keeps long Codex source-reply turns alive after reasoning completes while waiting for delayed visible `message` calls
- keeps the TUI input blocked while a backend run is still active after the watchdog notice, instead of encouraging duplicate submissions
- avoids duplicate/empty terminal chat events from replayed source-reply finals

## Verification

Behavior addressed: Codex replies could be visible through some surfaces/history refreshes but not render immediately in `openclaw tui`.

Real environment tested: OCM local runtimes using `CodexClaw-tui-latest` and `CodexClaw-tui-beta`.

Exact steps or command run after this patch:
```sh
git diff --check origin/main...HEAD
node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts src/gateway/server-methods/chat.directive-tags.test.ts src/auto-reply/reply/reply-media-paths.test.ts src/auto-reply/reply/dispatch-from-config.test.ts src/tui/tui-event-handlers.test.ts -- --runInBand
ocm runtime build-local tui-source-reply-fix --repo . --force
ocm start CodexClaw-tui-latest --runtime tui-source-reply-fix
ocm @CodexClaw-tui-latest -- gateway probe
```

Evidence after fix:
- Focused local Vitest pass: 6 files, 588 tests passed.
- Built local runtime `tui-source-reply-fix`.
- `CodexClaw-tui-latest` ran `OpenClaw 2026.5.22 (2d0eab9)`.
- Gateway probe connected on loopback; read diagnostics were limited by missing `operator.read`.
- User verified the local TUI behavior against the rebuilt runtime.
- Remote Testbox proof passed for TUI/gateway/auto-reply touched shards and the new Codex watchdog tests.
- Testbox id: `tbx_01ksaspa0jp9ytxkzxd431fbdh`.
- Actions run: `26337467682`.

Observed result after fix:
- `openclaw tui` receives live source-reply finals instead of waiting for a later history refresh.
- Long Codex reasoning-then-message responses remain active long enough for the visible reply to arrive.
- TUI no longer reopens the prompt while the backend turn is still running.

What was not tested:
- None.
