### PR TITLE
fix(gateway): hide duplicate ACP chat replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/compaction: skip agent-harness preflight for provider-owned CLI runtime sessions so over-threshold Claude CLI sessions continue through normal compaction instead of failing on a missing harness. Fixes #84857. (#84878) Thanks @zhangguiping-xydt.
 - WebChat: summarize internal message-tool source replies so tool cards no longer duplicate the visible reply body. (#84773) Thanks @jason-allen-oneal.
+- Gateway/WebChat: hide duplicate `gateway-injected` assistant rows when Cursor ACP already persisted the same `acp-runtime` reply. Fixes #85741. Thanks @lxf-lxf.
 - WebChat: scope the visible attachment button to its own composer file input so clicking Upload reliably opens the file picker. (#83952, fixes #47983) Thanks @jason-allen-oneal.
 - Gateway: preserve deferred lifecycle-error cleanup across later non-terminal events so provider timeouts can persist failed session state instead of leaving sessions stuck running. (#85256, fixes #63819) Thanks @samzong.
 - Agents/subagents: report tool-only child progress during timeout summaries instead of showing no visible output.

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -1130,6 +1130,40 @@ function shouldHideProjectedHistoryMessage(message: Record<string, unknown>): bo
   return isHeartbeatOkResponse(roleContent);
 }
 
+function openclawAssistantModel(message: Record<string, unknown>): string | undefined {
+  return message.role === "assistant" &&
+    message.provider === "openclaw" &&
+    typeof message.model === "string"
+    ? message.model
+    : undefined;
+}
+
+function displayTextForDuplicateCheck(message: Record<string, unknown>): string | undefined {
+  const text = extractProjectedText(message.content ?? message.text).trim();
+  return text ? text : undefined;
+}
+
+function isDuplicateAcpGatewayInjectedMessage(
+  current: Record<string, unknown>,
+  previousVisible: Record<string, unknown> | undefined,
+): boolean {
+  if (!previousVisible) {
+    return false;
+  }
+  if (
+    openclawAssistantModel(previousVisible) !== "acp-runtime" ||
+    openclawAssistantModel(current) !== "gateway-injected"
+  ) {
+    return false;
+  }
+  if (hasAssistantNonTextContent(previousVisible) || hasAssistantNonTextContent(current)) {
+    return false;
+  }
+  const previousText = displayTextForDuplicateCheck(previousVisible);
+  const currentText = displayTextForDuplicateCheck(current);
+  return Boolean(previousText && currentText && previousText === currentText);
+}
+
 function toProjectedMessages(messages: unknown[]): Array<Record<string, unknown>> {
   return messages.filter(
     (message): message is Record<string, unknown> =>
@@ -1164,6 +1198,10 @@ function filterVisibleProjectedHistoryMessages(
       continue;
     }
     if (shouldHideProjectedHistoryMessage(current)) {
+      changed = true;
+      continue;
+    }
+    if (isDuplicateAcpGatewayInjectedMessage(current, visible.at(-1))) {
       changed = true;
       continue;
     }

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -688,6 +688,82 @@ describe("projectRecentChatDisplayMessages", () => {
     ]);
   });
 
+  it("drops duplicate ACP gateway-injected assistant replies from chat history", () => {
+    const result = projectRecentChatDisplayMessages([
+      {
+        role: "user",
+        content: [{ type: "text", text: "good morning" }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        provider: "openclaw",
+        model: "acp-runtime",
+        content: [{ type: "text", text: "Good morning." }],
+        timestamp: 2,
+      },
+      {
+        role: "assistant",
+        provider: "openclaw",
+        model: "gateway-injected",
+        content: [{ type: "text", text: "Good morning." }],
+        idempotencyKey: "run-1",
+        timestamp: 3,
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "good morning" }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        provider: "openclaw",
+        model: "acp-runtime",
+        content: [{ type: "text", text: "Good morning." }],
+        timestamp: 2,
+      },
+    ]);
+  });
+
+  it("keeps gateway-injected assistant replies when they are not duplicate ACP text", () => {
+    const result = projectRecentChatDisplayMessages([
+      {
+        role: "assistant",
+        provider: "openclaw",
+        model: "acp-runtime",
+        content: [{ type: "text", text: "First answer." }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        provider: "openclaw",
+        model: "gateway-injected",
+        content: [{ type: "text", text: "Second answer." }],
+        timestamp: 2,
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        provider: "openclaw",
+        model: "acp-runtime",
+        content: [{ type: "text", text: "First answer." }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        provider: "openclaw",
+        model: "gateway-injected",
+        content: [{ type: "text", text: "Second answer." }],
+        timestamp: 2,
+      },
+    ]);
+  });
+
   it("applies history limits after dropping display-hidden messages", () => {
     const result = projectRecentChatDisplayMessages(
       [


### PR DESCRIPTION
## Summary

- Fixes #85741 by filtering duplicate WebChat display rows when a Cursor ACP session has already persisted an `openclaw/acp-runtime` assistant reply and WebChat later sees an identical text-only `openclaw/gateway-injected` row.
- Keeps `gateway-injected` replies visible when they are not adjacent duplicate ACP text, preserving normal WebChat final delivery display.
- Adds focused projection coverage and a changelog entry.

## Verification

2026-05-23 update after rebasing onto `origin/main` (`fa39bef389`), head `e0bfc50cde`:

- `node scripts/run-vitest.mjs src/gateway/server-methods/server-methods.test.ts --reporter=verbose` (1 file, 102 tests passed)
- `./node_modules/.bin/oxfmt --check --threads=1 CHANGELOG.md src/gateway/chat-display-projection.ts src/gateway/server-methods/server-methods.test.ts`
- `./node_modules/.bin/oxlint src/gateway/chat-display-projection.ts src/gateway/server-methods/server-methods.test.ts`
- `git diff --check origin/main...HEAD`

Earlier verification before the rebase:

- `git diff --check`
- `node_modules/.bin/oxfmt --check --threads=1 src/gateway/chat-display-projection.ts src/gateway/server-methods/server-methods.test.ts`
- `node_modules/.bin/oxlint src/gateway/chat-display-projection.ts src/gateway/server-methods/server-methods.test.ts`
- `node scripts/run-vitest.mjs src/gateway/server-methods/server-methods.test.ts --reporter=verbose` (102 tests passed)
- `.agents/skills/autoreview/scripts/autoreview --mode branch` (clean)

## Real behavior proof

Behavior addressed: WebChat/chat.history no longer returns two identical assistant bubbles for Cursor ACP sessions when `acp-runtime` is immediately followed by an identical `gateway-injected` assistant row.

Real environment tested: WSL Ubuntu-24.04 checkout at `/root/src/openclaw-85775`, Node/Vitest via the repo test wrapper.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/gateway/server-methods/server-methods.test.ts --reporter=verbose`

Evidence after fix: Added `projectRecentChatDisplayMessages` regression coverage that feeds a user message, an `openclaw/acp-runtime` assistant row, and an identical `openclaw/gateway-injected` assistant row; the projected chat history keeps only the ACP assistant reply. Added a guard test proving non-duplicate `gateway-injected` assistant replies are still retained.

Observed result after fix: Focused gateway server-methods test file passed: 1 file, 102 tests.

What was not tested: No live Cursor ACP/WebChat browser session was run; the proof is at the shared chat-history projection used by `chat.history` and WebChat display.
