### PR TITLE
Guard OpenAI image compression for PNG outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/restart: honor the configured restart drain budget for embedded runs and avoid spending the deferral timeout twice after forced restart timeouts. (#85708) Thanks @Kaspre.
+- OpenAI image generation: omit `output_compression` for PNG outputs while preserving JPEG/WebP compression, matching the Images and Responses API contracts. (#85776) Thanks @AAirLin.
 - Discord/voice: recover stale realtime playback state when Discord stream-close/player-idle events do not arrive, and keep generated runtime plugin aliases available after postbuild rewrites.
 - Discord/voice: keep realtime playback running when meeting notes attaches to an existing voice session or a realtime consult starts, and route realtime user transcripts into meeting notes.
 - Config/secrets: preflight active runtime SecretRefs before root and include config writes persist, and roll back unchanged file/env state when post-write refresh fails. Fixes #46531. (#84454) Thanks @samzong.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,6 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/restart: honor the configured restart drain budget for embedded runs and avoid spending the deferral timeout twice after forced restart timeouts. (#85708) Thanks @Kaspre.
-- OpenAI image generation: omit `output_compression` for PNG outputs while preserving JPEG/WebP compression, matching the Images and Responses API contracts. (#85776) Thanks @AAirLin.
 - Discord/voice: recover stale realtime playback state when Discord stream-close/player-idle events do not arrive, and keep generated runtime plugin aliases available after postbuild rewrites.
 - Discord/voice: keep realtime playback running when meeting notes attaches to an existing voice session or a realtime consult starts, and route realtime user transcripts into meeting notes.
 - Config/secrets: preflight active runtime SecretRefs before root and include config writes persist, and roll back unchanged file/env state when post-write refresh fails. Fixes #46531. (#84454) Thanks @samzong.

--- a/docs/tools/image-generation.md
+++ b/docs/tools/image-generation.md
@@ -310,7 +310,8 @@ ComfyUI support 1.
     transparent outputs require `outputFormat` `png` or `webp` and a
     transparency-capable OpenAI image model. OpenClaw routes default
     `gpt-image-2` transparent-background requests to `gpt-image-1.5`.
-    `openai.outputCompression` applies to JPEG/WebP outputs.
+    `openai.outputCompression` applies to JPEG/WebP outputs and is ignored
+    for PNG outputs.
 
     The top-level `background` hint is provider-neutral and currently maps
     to the same OpenAI `background` request field when the OpenAI provider

--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -605,6 +605,28 @@ describe("openai image generation provider", () => {
     expect(result.images[0]?.fileName).toBe("image-1.jpg");
   });
 
+  it("omits output compression for PNG direct generations", async () => {
+    mockGeneratedPngResponse();
+
+    const provider = buildOpenAIImageGenerationProvider();
+    await provider.generateImage({
+      provider: "openai",
+      model: "gpt-image-2",
+      prompt: "Transparent PNG",
+      cfg: {},
+      outputFormat: "png",
+      providerOptions: {
+        openai: {
+          outputCompression: 60,
+        },
+      },
+    });
+
+    const body = jsonRequestCall().body as Record<string, unknown>;
+    expect(body.output_format).toBe("png");
+    expect(body.output_compression).toBeUndefined();
+  });
+
   it("routes transparent default-model requests to the OpenAI image model that supports alpha", async () => {
     mockGeneratedPngResponse();
 
@@ -1078,6 +1100,30 @@ describe("openai image generation provider", () => {
     expect(body.tools?.[0]?.output_format).toBe("png");
     expect(body.tools?.[0]?.background).toBe("transparent");
     expect(result.model).toBe("gpt-image-1.5");
+  });
+
+  it("omits output compression for PNG Codex image requests", async () => {
+    mockCodexAuthOnly();
+    mockCodexImageStream({ imageData: "codex-png-image" });
+
+    const provider = buildOpenAIImageGenerationProvider();
+    await provider.generateImage({
+      provider: "openai",
+      model: "gpt-image-2",
+      prompt: "Draw a transparent Codex badge",
+      cfg: {},
+      authStore: { version: 1, profiles: {} },
+      outputFormat: "png",
+      providerOptions: {
+        openai: {
+          outputCompression: 55,
+        },
+      },
+    });
+
+    const body = jsonRequestCall().body as { tools?: Array<Record<string, unknown>> };
+    expect(body.tools?.[0]?.output_format).toBe("png");
+    expect(body.tools?.[0]?.output_compression).toBeUndefined();
   });
 
   it("uses configured Codex OAuth directly instead of probing an available OpenAI API key", async () => {

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -186,15 +186,15 @@ function resolveOutputMime(outputFormat?: ImageGenerationOutputFormat): {
 type OpenAIImageRequest = Parameters<ImageGenerationProvider["generateImage"]>[0];
 type OpenAIImageOptions = NonNullable<OpenAIImageRequest["providerOptions"]>["openai"];
 
-function shouldForwardOpenAIImageOutputCompression(
+function resolveOpenAIImageOutputCompression(
   req: OpenAIImageRequest,
   openai: OpenAIImageOptions,
-): boolean {
+): number | undefined {
   if (openai?.outputCompression === undefined) {
-    return false;
+    return undefined;
   }
   const outputFormat = req.outputFormat ?? "png";
-  return outputFormat === "jpeg" || outputFormat === "webp";
+  return outputFormat === "jpeg" || outputFormat === "webp" ? openai.outputCompression : undefined;
 }
 
 function appendOpenAIImageOptions(
@@ -203,14 +203,13 @@ function appendOpenAIImageOptions(
 ): void {
   const openai = req.providerOptions?.openai;
   const background = openai?.background ?? req.background;
+  const outputCompression = resolveOpenAIImageOutputCompression(req, openai);
   const entries: Record<string, unknown> = {
     ...(req.quality !== undefined ? { quality: req.quality } : {}),
     ...(req.outputFormat !== undefined ? { output_format: req.outputFormat } : {}),
     ...(background !== undefined ? { background } : {}),
     ...(openai?.moderation !== undefined ? { moderation: openai.moderation } : {}),
-    ...(shouldForwardOpenAIImageOutputCompression(req, openai)
-      ? { output_compression: openai.outputCompression }
-      : {}),
+    ...(outputCompression !== undefined ? { output_compression: outputCompression } : {}),
     ...(openai?.user !== undefined ? { user: openai.user } : {}),
   };
   for (const [key, value] of Object.entries(entries)) {
@@ -651,6 +650,7 @@ async function generateOpenAICodexImage(params: {
   const timeoutMs = resolveOpenAIImageTimeoutMs(req.timeoutMs);
   const openai = req.providerOptions?.openai;
   const background = openai?.background ?? req.background;
+  const outputCompression = resolveOpenAIImageOutputCompression(req, openai);
   headers.set("Content-Type", "application/json");
   const content: Array<Record<string, unknown>> = [
     { type: "input_text", text: req.prompt },
@@ -682,9 +682,7 @@ async function generateOpenAICodexImage(params: {
             ...(req.quality !== undefined ? { quality: req.quality } : {}),
             ...(req.outputFormat !== undefined ? { output_format: req.outputFormat } : {}),
             ...(background !== undefined ? { background } : {}),
-            ...(shouldForwardOpenAIImageOutputCompression(req, openai)
-              ? { output_compression: openai.outputCompression }
-              : {}),
+            ...(outputCompression !== undefined ? { output_compression: outputCompression } : {}),
           },
         ],
         tool_choice: { type: "image_generation" },

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -183,6 +183,20 @@ function resolveOutputMime(outputFormat?: ImageGenerationOutputFormat): {
   return { mimeType: DEFAULT_OUTPUT_MIME, extension: DEFAULT_OUTPUT_EXTENSION };
 }
 
+type OpenAIImageRequest = Parameters<ImageGenerationProvider["generateImage"]>[0];
+type OpenAIImageOptions = NonNullable<OpenAIImageRequest["providerOptions"]>["openai"];
+
+function shouldForwardOpenAIImageOutputCompression(
+  req: OpenAIImageRequest,
+  openai: OpenAIImageOptions,
+): boolean {
+  if (openai?.outputCompression === undefined) {
+    return false;
+  }
+  const outputFormat = req.outputFormat ?? "png";
+  return outputFormat === "jpeg" || outputFormat === "webp";
+}
+
 function appendOpenAIImageOptions(
   target: Record<string, unknown> | FormData,
   req: Parameters<ImageGenerationProvider["generateImage"]>[0],
@@ -194,7 +208,7 @@ function appendOpenAIImageOptions(
     ...(req.outputFormat !== undefined ? { output_format: req.outputFormat } : {}),
     ...(background !== undefined ? { background } : {}),
     ...(openai?.moderation !== undefined ? { moderation: openai.moderation } : {}),
-    ...(openai?.outputCompression !== undefined
+    ...(shouldForwardOpenAIImageOutputCompression(req, openai)
       ? { output_compression: openai.outputCompression }
       : {}),
     ...(openai?.user !== undefined ? { user: openai.user } : {}),
@@ -668,7 +682,7 @@ async function generateOpenAICodexImage(params: {
             ...(req.quality !== undefined ? { quality: req.quality } : {}),
             ...(req.outputFormat !== undefined ? { output_format: req.outputFormat } : {}),
             ...(background !== undefined ? { background } : {}),
-            ...(openai?.outputCompression !== undefined
+            ...(shouldForwardOpenAIImageOutputCompression(req, openai)
               ? { output_compression: openai.outputCompression }
               : {}),
           },


### PR DESCRIPTION
## Summary
- Guard OpenAI image `output_compression` so it is only sent for JPEG/WebP outputs.
- Omit `output_compression` for PNG/default PNG in both direct image API requests and Codex Responses image tool requests.
- Document that `openai.outputCompression` is ignored for PNG outputs.

## Real behavior proof
**Behavior or issue addressed:** PNG image requests failed when `openai.outputCompression` was forwarded to OpenAI.

**Real environment tested:** OpenClaw canary deployment `bot-129` in the Kubernetes cluster on 2026-05-24.

**Exact steps or command run after the patch:**
- `kubectl -n openclaw rollout status deploy/bot-129 --timeout=60s`
- `/Users/airlin/.codex/skills/openclaw-ops/scripts/verify-cluster-patches.sh --repo /Users/airlin/Documents/Codex/2026-05-20/hi/openclaw-cluster --namespace openclaw --deploy bot-129`

**Evidence after fix:**
```text
bot=localhost/openclaw-gateway:2026.5.20-image-compression-20260523
browser=openclaw-sandbox-browser:bookworm-slim
token-exporter=localhost/openclaw-gateway:2026.5.20-image-compression-20260523

[openclaw-patch] OpenAI image compression: patched 2 output_compression call site(s) across 1 file(s); 0 patch marker(s) already present
[openclaw-patch] OpenAI image compression: patched 0 output_compression call site(s) across 0 file(s); 2 patch marker(s) already present
✔ OpenAI image compression patch drops output_compression for PNG output
ℹ tests 22
ℹ pass 22
ℹ fail 0
Patch verification passed for deploy/bot-129.
```

**Observed result after fix:** bot-129 rolled out successfully, patch verification passed, and the PNG compression guard was present in the running runtime.

**What was not tested:** I did not re-trigger a live PNG generation from bot-129 during this review; the canary verification covered the deployed runtime and patch markers.

## Tests
- `node scripts/test-projects.mjs extensions/openai/image-generation-provider.test.ts` (56 tests passed)
