### PR TITLE
fix(whatsapp): serialize Error in auto-reply delivery log

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
@@ -1086,7 +1086,7 @@ describe("whatsapp inbound dispatch", () => {
 
     expect(replyLogger.error).toHaveBeenCalledWith(
       {
-        err: error,
+        err: { type: "Error", message: "send failed", stack: error.stack },
         replyKind: "final",
         correlationId: "msg-1",
         connectionId: "conn-1",
@@ -1095,6 +1095,125 @@ describe("whatsapp inbound dispatch", () => {
         to: "+15550001000",
         from: "+15550002000",
       },
+      "auto-reply delivery failed",
+    );
+  });
+
+  it("preserves Error subclass own-enumerable fields (e.g. Boom output) in the logged err", async () => {
+    const replyLogger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    } as unknown as BufferedReplyParams["replyLogger"];
+
+    class BoomLikeError extends Error {
+      output: { statusCode: number; payload: { error: string } };
+      data: { reason: string };
+      constructor(message: string) {
+        super(message);
+        this.name = "BoomLikeError";
+        this.output = { statusCode: 408, payload: { error: "Request Time-out" } };
+        this.data = { reason: "transport-stale" };
+      }
+    }
+    const error = new BoomLikeError("send timed out");
+
+    await dispatchBufferedReply({
+      connectionId: "conn-boom",
+      conversationId: "+15550020000",
+      msg: makeMsg({
+        id: "msg-boom",
+        from: "+15550020000",
+        to: "+15550021000",
+        chatId: "15550020000@s.whatsapp.net",
+      }),
+      replyLogger,
+    });
+
+    getCapturedOnError()?.(error, { kind: "final" });
+
+    expect(replyLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        err: expect.objectContaining({
+          type: "BoomLikeError",
+          message: "send timed out",
+          stack: error.stack,
+          output: { statusCode: 408, payload: { error: "Request Time-out" } },
+          data: { reason: "transport-stale" },
+        }),
+        replyKind: "final",
+        correlationId: "msg-boom",
+      }),
+      "auto-reply delivery failed",
+    );
+  });
+
+  it("logs delivery failures with non-Error rejection values via pass-through", async () => {
+    const replyLogger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    } as unknown as BufferedReplyParams["replyLogger"];
+
+    await dispatchBufferedReply({
+      connectionId: "conn-2",
+      conversationId: "+15550003000",
+      msg: makeMsg({
+        id: "msg-2",
+        from: "+15550003000",
+        to: "+15550004000",
+        chatId: "15550003000@s.whatsapp.net",
+      }),
+      replyLogger,
+    });
+
+    getCapturedOnError()?.("plain string rejection", { kind: "block" });
+
+    expect(replyLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        err: "plain string rejection",
+        replyKind: "block",
+        correlationId: "msg-2",
+      }),
+      "auto-reply delivery failed",
+    );
+  });
+
+  it("preserves structured object rejections so diagnostic fields stay queryable", async () => {
+    const replyLogger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    } as unknown as BufferedReplyParams["replyLogger"];
+
+    await dispatchBufferedReply({
+      connectionId: "conn-3",
+      conversationId: "+15550005000",
+      msg: makeMsg({
+        id: "msg-3",
+        from: "+15550005000",
+        to: "+15550006000",
+        chatId: "15550005000@s.whatsapp.net",
+      }),
+      replyLogger,
+    });
+
+    const objectRejection = {
+      error: { message: "wrapped failure", code: "BAILEYS_NACK" },
+      attempt: 2,
+    };
+
+    getCapturedOnError()?.(objectRejection, { kind: "tool" });
+
+    expect(replyLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        err: objectRejection,
+        replyKind: "tool",
+        correlationId: "msg-3",
+      }),
       "auto-reply delivery failed",
     );
   });

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -79,6 +79,14 @@ type WhatsAppMediaOnlyFlushResult = {
   droppedDuplicateMedia: number;
 };
 
+function normalizeErrForLog(err: unknown): unknown {
+  if (err instanceof Error) {
+    const ownEnumerableProps = Object.fromEntries(Object.entries(err));
+    return { ...ownEnumerableProps, type: err.name, message: err.message, stack: err.stack };
+  }
+  return err;
+}
+
 function logWhatsAppReplyDeliveryError(params: {
   err: unknown;
   info: ReplyDeliveryInfo;
@@ -89,7 +97,7 @@ function logWhatsAppReplyDeliveryError(params: {
 }) {
   params.replyLogger.error(
     {
-      err: params.err,
+      err: normalizeErrForLog(params.err),
       replyKind: params.info.kind,
       correlationId: params.msg.id ?? null,
       connectionId: params.connectionId,


### PR DESCRIPTION
## Summary

The `auto-reply delivery failed` log path in `extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts` passes a raw `Error` under the `err` field. tslog renders bare `Error` instances as `{}` because `Error`'s own data properties are non-enumerable. Every delivery failure in production logs `err: {}`, forcing operators to guess the underlying Baileys error from timestamp alone (observed 2026-05-22: two failures at 12:04:44.419/.421 cost ~30 min of code archaeology to recover what the error would have told us).

## Fix

Add a small `normalizeErrForLog` helper that converts `Error` to `{ type, message, stack }` plus own-enumerable properties, preserving Boom-style subclass diagnostics (`output.statusCode`, `data`) and custom delivery-error fields (`stage`, `results`). Non-`Error` values pass through unchanged.

`Object.fromEntries(Object.entries(err))` is used in place of `...err` to satisfy the repo's `typescript(no-misused-spread)` lint rule.

`Error.cause` is intentionally NOT walked here: it is non-enumerable and including it raises the risk of embedding a non-serializable value that breaks the logger's `JSON.stringify` (silently dropping the whole log line). Happy to add bounded cause-handling if maintainers want it.

## Real behavior proof

The file-log transport at `src/logging/logger.ts:568` does `JSON.stringify(record)` on the structured record. Reproduced that exact path with a Node probe so the on-disk log line can be compared directly before vs after the patch. All IDs/JIDs are redacted with `<...>` placeholders; the `correlationId` is a synthetic example mirroring the format actually used.

### Case 1 — plain `new Error("send failed")` (the empirical production bug)

**BEFORE (current upstream main):**

```json
{"level":"error","msg":"auto-reply delivery failed","replyKind":"final","correlationId":"3EB0928533C5D5C648ED88","connectionId":"<redacted>","conversationId":"<redacted-conv>","chatId":"<redacted>@g.us","to":"<redacted-to>","from":"<redacted-from>","err":{}}
```

`err: {}` — exactly what we observed in production logs on 2026-05-22. Useless for triage.

**AFTER (this PR):**

```json
{"level":"error","msg":"auto-reply delivery failed","replyKind":"final","correlationId":"3EB0928533C5D5C648ED88","connectionId":"<redacted>","conversationId":"<redacted-conv>","chatId":"<redacted>@g.us","to":"<redacted-to>","from":"<redacted-from>","err":{"type":"Error","message":"send failed","stack":"Error: send failed\n    at file:///private/tmp/ve514-proof.mjs:34:39\n    at ModuleJob.run (node:internal/modules/esm/module_job:345:25)\n    ..."}}
```

`err: { type, message, stack }` — operator can now classify the failure at-a-glance.

### Case 2 — Baileys/Boom-like subclass throwing a 408 timeout

**BEFORE:**

```json
{..."err":{"name":"BoomLikeError","output":{"statusCode":408,"payload":{"error":"Request Time-out"}},"data":{"reason":"transport-stale"}}}
```

Some fields visible (own-enumerable) but `message` and `stack` still missing.

**AFTER:**

```json
{..."err":{"name":"BoomLikeError","output":{"statusCode":408,"payload":{"error":"Request Time-out"}},"data":{"reason":"transport-stale"},"type":"BoomLikeError","message":"send timed out","stack":"BoomLikeError: send timed out\n    at file:///private/tmp/ve514-proof.mjs:45:42\n    ..."}}
```

All Boom diagnostic fields preserved AND `type`/`message`/`stack` now present.

### Case 3 — non-`Error` structured rejection (pass-through, no regression)

**BEFORE === AFTER:**

```json
{..."err":{"error":{"code":"BAILEYS_NACK","message":"stanza rejected"},"attempt":2}}
```

Confirmed pass-through preserves object rejection payloads unchanged.

### Probe script

The probe at `/tmp/ve514-proof.mjs` mirrors `src/logging/logger.ts:568` (`JSON.stringify(record)`) exactly. Source available on request; not committed because it's a one-off ad-hoc probe.

## Test plan

- [x] `pnpm test extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts` — 40 passed (4 new cases: Error, Boom-style subclass, string rejection, object rejection)
- [x] `pnpm exec oxfmt --check`
- [x] `pnpm lint:extensions`
- [x] `pnpm check:changed` (full lane: typecheck, lint, import cycles, deps guards)
- [x] `codex review --base upstream/main` (8 iterations addressed; settled on this middle ground after the AI reviewer oscillated between "preserve more" and "preserve less" — current shape addresses preservation concerns without serialization risk)
- [x] Real-behavior proof above (Node probe reproducing the logger's `JSON.stringify` transport, three cases redacted)

## Note on CI failure

`checks-node-core-fast` failure is unrelated to this PR: `src/plugin-activation-boundary.test.ts:147` expects `grok-4-fast` but the resolver returns `grok-4-fast-reasoning` (xAI model normalization). The same job is failing on the latest `main` CI run (26339120224), so the breakage predates this branch and is in a path this PR does not touch (`extensions/whatsapp/**` only).

## AI disclosure

Authored with Claude Code (Opus 4.7) assistance. Fully tested. Author confirms understanding of the change.