### PR TITLE
fix(telegram): debounce media messages to coalesce rapid sends into one agent turn

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -176,10 +176,10 @@ export const registerTelegramHandlers = ({
       if (hasText && hasControlCommand(text, cfg, { botUsername: entry.botUsername })) {
         return false;
       }
-      if (entry.debounceLane === "forward") {
-        return true;
-      }
-      return entry.allMedia.length === 0 && hasText;
+      // Debounce media messages too so rapid image/video sends from the
+      // same sender coalesce into one agent turn. The onFlush handler
+      // already merges both text and media arrays across debounced entries.
+      return hasText || entry.allMedia.length > 0;
     },
     onFlush: async (entries) => {
       const last = entries.at(-1);


### PR DESCRIPTION
## Summary

The `shouldDebounce` callback in the Telegram bot inbound handler excluded media messages (images, videos, documents, etc.) from the inbound debounce buffer. This meant each individual image sent in rapid succession triggered a separate agent turn, producing N separate replies instead of one consolidated answer.

The `onFlush` handler already correctly merges both text captions and media arrays across debounced entries into a single `processMessage` call — the merge infrastructure was correct, but media never reached it because `shouldDebounce` rejected it.

## Before

```typescript
if (entry.debounceLane === "forward") {
  return true;
}
return entry.allMedia.length === 0 && hasText;
```

Media messages returned `false` (no debounce) because `allMedia.length > 0` made the expression false. Only the forward lane debounced media.

## After

```typescript
// Debounce media messages too so rapid image/video sends from the
// same sender coalesce into one agent turn.
return hasText || entry.allMedia.length > 0;
```

All message types debounce the same way. The merge logic was already correct.

## Impact

- Rapid image/video sends now produce one consolidated reply instead of N separate replies
- No change to non-media text message behavior (they debounced before and still debounce)
- The `onFlush` merge path already handles combined media arrays correctly