### PR TITLE
fix(plugins): return plugin gateway method results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ Docs: https://docs.openclaw.ai
 - Sessions: enforce the session write-lock max-hold policy during lock acquisition so long-held locks can be reclaimed before the stale-lock window. (#85764) Thanks @njuboy11.
 - Sessions/status: preserve user-facing model, fallback, usage, and cost attribution when internal subagent handoff runs use fallback models. (#85726, fixes #85082) Thanks @brokemac79.
 - Models: prune retired Groq, GitHub Copilot, OpenAI, xAI, and old Claude catalog entries, with doctor migration to upgrade existing configs to current provider refs.
+- Plugins/Gateway: treat non-empty return values from plugin gateway method handlers as successful responses so `openclaw gateway call` no longer times out after completed plugin work. Fixes #59470. Thanks @HTMG23.
 - Doctor/update: recognize junction-backed source checkouts as git installs by comparing canonical paths before showing package-manager update guidance. Fixes #82215. Thanks @igormf.
 - Channels: honor `/verbose on` for tool/progress summaries across direct chats, groups, channels, and forum topics while preserving quiet default behavior. (#85488) Thanks @kurplunkin.
 - Telegram: persist the prompt-context message cache through plugin state and record bot-authored replies after sends and draft streaming so later turns can include prior assistant replies without relying on the JSON sidecar. (#85231) Thanks @keshavbotagent.

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1621,6 +1621,85 @@ describe("loadOpenClawPlugins", () => {
       },
     },
     {
+      label: "adapts returned plugin gateway method values into responses",
+      run: async () => {
+        useNoBundledPlugins();
+        const plugin = writePlugin({
+          id: "returned-gateway-method",
+          filename: "returned-gateway-method.cjs",
+          body: `module.exports = {
+  id: "returned-gateway-method",
+  register(api) {
+    api.registerGatewayMethod("returned-gateway-method.status", async () => ({ ok: true, status: "ready" }));
+  },
+};`,
+        });
+
+        const registry = loadOpenClawPlugins({
+          cache: false,
+          workspaceDir: plugin.dir,
+          config: {
+            plugins: {
+              load: { paths: [plugin.file] },
+              allow: ["returned-gateway-method"],
+            },
+          },
+        });
+
+        const responses: unknown[] = [];
+        await registry.gatewayHandlers["returned-gateway-method.status"]?.({
+          params: {},
+          respond: (ok: boolean, payload: unknown, error?: unknown) =>
+            responses.push({ ok, payload, error }),
+        } as never);
+
+        expect(responses).toEqual([
+          { ok: true, payload: { ok: true, status: "ready" }, error: undefined },
+        ]);
+      },
+    },
+    {
+      label: "keeps explicit plugin gateway responses authoritative",
+      run: async () => {
+        useNoBundledPlugins();
+        const plugin = writePlugin({
+          id: "explicit-gateway-method",
+          filename: "explicit-gateway-method.cjs",
+          body: `module.exports = {
+  id: "explicit-gateway-method",
+  register(api) {
+    api.registerGatewayMethod("explicit-gateway-method.status", ({ respond }) => {
+      respond(true, { status: "responded" });
+      return { status: "returned" };
+    });
+  },
+};`,
+        });
+
+        const registry = loadOpenClawPlugins({
+          cache: false,
+          workspaceDir: plugin.dir,
+          config: {
+            plugins: {
+              load: { paths: [plugin.file] },
+              allow: ["explicit-gateway-method"],
+            },
+          },
+        });
+
+        const responses: unknown[] = [];
+        await registry.gatewayHandlers["explicit-gateway-method.status"]?.({
+          params: {},
+          respond: (ok: boolean, payload: unknown, error?: unknown) =>
+            responses.push({ ok, payload, error }),
+        } as never);
+
+        expect(responses).toEqual([
+          { ok: true, payload: { status: "responded" }, error: undefined },
+        ]);
+      },
+    },
+    {
       label: "coerces reserved gateway method namespaces to operator.admin",
       run: () => {
         useNoBundledPlugins();
@@ -2213,8 +2292,8 @@ module.exports = { id: "throws-after-import", register() {} };`,
         expect(getGlobalHookRunner()).toBeNull();
       },
     },
-  ] as const)("handles config-path and scoped plugin loads: $label", ({ run }) => {
-    run();
+  ] as const)("handles config-path and scoped plugin loads: $label", async ({ run }) => {
+    await run();
   });
 
   it("treats an explicit empty plugin scope as scoped-empty instead of unscoped", () => {

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -17,7 +17,7 @@ import {
 } from "../context-engine/registry.js";
 import { createPluginGatewayMethodDescriptor } from "../gateway/methods/registry.js";
 import { isOperatorScope, type OperatorScope } from "../gateway/operator-scopes.js";
-import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
+import type { GatewayRequestHandler, RespondFn } from "../gateway/server-methods/types.js";
 import { registerInternalHook, unregisterInternalHook } from "../hooks/internal-hooks.js";
 import type { HookEntry } from "../hooks/types.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -350,6 +350,20 @@ function resolvePluginRegistrationCapabilities(
   return {
     capabilityHandlers,
     runtimeChannel: mode !== "setup-only" && mode !== "tool-discovery",
+  };
+}
+
+function adaptPluginGatewayMethodHandler(handler: GatewayRequestHandler): GatewayRequestHandler {
+  return async (opts) => {
+    let responded = false;
+    const respond: RespondFn = (ok, payload, error, meta) => {
+      responded = true;
+      opts.respond(ok, payload, error, meta);
+    };
+    const result = (await handler({ ...opts, respond })) as unknown;
+    if (!responded && result !== undefined) {
+      respond(true, result);
+    }
   };
 }
 
@@ -723,7 +737,8 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       });
       return;
     }
-    registry.gatewayHandlers[trimmed] = handler;
+    const wrappedHandler = adaptPluginGatewayMethodHandler(handler);
+    registry.gatewayHandlers[trimmed] = wrappedHandler;
     const normalizedScope = normalizePluginGatewayMethodScope(trimmed, opts?.scope);
     if (normalizedScope.coercedToReservedAdmin) {
       pushDiagnostic({
@@ -737,7 +752,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       createPluginGatewayMethodDescriptor({
         pluginId: record.id,
         name: trimmed,
-        handler,
+        handler: wrappedHandler,
         scope: normalizedScope.scope,
       }),
     );


### PR DESCRIPTION
## Summary

- Problem: plugin gateway method handlers that completed by returning a value could leave `openclaw gateway call` waiting until timeout when the handler did not explicitly call `respond(...)`.
- Solution: wrap plugin-registered gateway handlers so non-`undefined` return values are converted into successful gateway responses.
- What changed: plugin gateway registry entries and descriptors now use the wrapped handler, with regression coverage for returned values and explicit `respond(...)` precedence.
- What did NOT change (scope boundary): handlers that return `undefined` and never call `respond(...)` still time out, preserving callback-style asynchronous semantics.

## Motivation

- Fixes user-visible gateway call timeouts for plugin gateway methods that successfully finish work but use return-value style completion.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #59470
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: plugin gateway methods that return a non-`undefined` value now complete the gateway RPC instead of leaving callers to time out.
- Real environment tested: WSL Ubuntu-24.04 source checkout on Node/pnpm repo dependencies.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/loader.test.ts --reporter=verbose`
- Evidence after fix: focused loader regression test passed with 136 tests, including `adapts returned plugin gateway method values into responses` and `keeps explicit plugin gateway responses authoritative`.
- Observed result after fix: returned `{ ok: true, status: "ready" }` produced one successful gateway response, while a handler that both called `respond(...)` and returned a value kept the explicit response authoritative.
- What was not tested: a packaged end-to-end plugin invoked through a live gateway process.

## Root Cause (if applicable)

- Root cause: plugin gateway handlers were stored as callback-style `GatewayRequestHandler`s, so a handler that returned a value without calling `respond(...)` completed locally but never sent an RPC response.
- Missing detection / guardrail: loader coverage did not exercise return-value style plugin gateway methods.
- Contributing context (if known): the SDK-facing handler shape allowed async return values even though the gateway dispatch path only observed `respond(...)`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/loader.test.ts`
- Scenario the test should lock in: config-loaded plugins can register gateway methods that complete by returning a non-`undefined` value, while explicit `respond(...)` still wins.
- Why this is the smallest reliable guardrail: it exercises the plugin registration seam that stores gateway handlers without needing a full gateway process.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Plugin gateway methods that return a non-`undefined` value now complete `openclaw gateway call` successfully instead of timing out.

## Diagram (if applicable)

```text
Before:
[plugin gateway handler returns value] -> [no respond call] -> [gateway caller times out]

After:
[plugin gateway handler returns value] -> [registry adapter responds] -> [gateway caller receives result]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: WSL Ubuntu-24.04
- Runtime/container: Node 22 repo checkout
- Model/provider: N/A
- Integration/channel (if any): plugin gateway method registration
- Relevant config (redacted): config-loaded local plugin path in test fixture

### Steps

1. Register a config-loaded plugin gateway method that returns `{ ok: true, status: "ready" }`.
2. Invoke the registered gateway handler through the plugin registry.
3. Repeat with a handler that explicitly calls `respond(...)` and also returns another value.

### Expected

- Return-value handlers produce a successful response.
- Explicit `respond(...)` handlers are not overwritten by returned values.

### Actual

- Matches expected after this patch.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: returned gateway method values are adapted into responses; explicit responses remain authoritative.
- Edge cases checked: `undefined` returns still do not auto-respond, preserving callback-style async behavior.
- What you did **not** verify: live packaged gateway call against an installed third-party plugin.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a plugin that accidentally returns a non-`undefined` internal value without calling `respond(...)` will now send that value to the caller.
  - Mitigation: the adapter only applies to plugin gateway methods, keeps explicit `respond(...)` authoritative, and ignores `undefined` so existing callback-style handlers keep their current behavior.

## 2026-05-23 update

Rebased onto current `origin/main` at `fa39bef389`; refreshed head is `e46b71ea0c`.

Fresh validation after rebase:

```text
$ node scripts/run-vitest.mjs src/plugins/loader.test.ts --reporter=verbose
Test Files  1 passed (1)
Tests  138 passed (138)

$ ./node_modules/.bin/oxfmt --check --threads=1 CHANGELOG.md src/plugins/registry.ts src/plugins/loader.test.ts && git diff --check origin/main...HEAD
passed
```

CI note: the prior `checks-node-core-fast` failure was in unrelated `src/plugin-activation-boundary.test.ts` xAI alias expectations; this branch only changes plugin gateway handler registration and loader tests.
