### PR TITLE
fix(ui): show failed tool results as errors

### DIFF
--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -19,7 +19,7 @@
 
 .chat-tool-card--expanded {
   max-height: none;
-  overflow: visible;
+  overflow: hidden;
 }
 
 .chat-tool-card:hover {
@@ -63,10 +63,13 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  flex: 1 1 auto;
   font-weight: 600;
   font-size: var(--control-ui-text-md);
   line-height: 1.2;
   min-width: 0;
+  max-width: 100%;
+  overflow-wrap: anywhere;
 }
 
 .chat-tool-card__icon {
@@ -95,7 +98,9 @@
   align-items: center;
   justify-content: center;
   gap: 4px;
+  flex-shrink: 0;
   font-size: 11px;
+  white-space: nowrap;
   color: var(--muted);
   opacity: 1;
   transition:
@@ -196,6 +201,34 @@
 
 .chat-tool-card--error {
   border-color: color-mix(in srgb, var(--destructive, var(--danger, #c0392b)) 35%, var(--border));
+  background:
+    linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--destructive, var(--danger, #c0392b)) 8%, transparent),
+      transparent 36%
+    ),
+    color-mix(in srgb, var(--card) 86%, var(--secondary) 14%);
+}
+
+.chat-tool-card--error:hover {
+  border-color: color-mix(
+    in srgb,
+    var(--destructive, var(--danger, #c0392b)) 44%,
+    var(--border-strong)
+  );
+  background:
+    linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--destructive, var(--danger, #c0392b)) 11%, transparent),
+      transparent 38%
+    ),
+    color-mix(in srgb, var(--card) 78%, var(--bg-hover) 22%);
+}
+
+.chat-tool-card--error .chat-tool-card__icon,
+.chat-tool-msg-summary.chat-tool-msg-summary--error .chat-tool-msg-summary__icon {
+  color: var(--destructive, var(--danger, #c0392b));
+  opacity: 0.9;
 }
 
 .chat-tool-msg-summary__error-badge {
@@ -429,6 +462,12 @@
   max-height: min(520px, 60vh);
 }
 
+.chat-tool-card__block-content code {
+  white-space: inherit;
+  overflow-wrap: anywhere;
+  word-break: inherit;
+}
+
 .chat-tool-card__inline {
   margin-top: 10px;
   white-space: pre-wrap;
@@ -651,6 +690,13 @@
 
 .chat-tool-msg-summary.chat-tool-msg-summary--error {
   border-color: color-mix(in srgb, var(--destructive, var(--danger, #c0392b)) 30%, var(--border));
+  background:
+    linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--destructive, var(--danger, #c0392b)) 11%, transparent),
+      transparent 36%
+    ),
+    color-mix(in srgb, var(--card) 86%, var(--secondary) 14%);
 }
 
 .chat-tool-msg-summary::-webkit-details-marker {
@@ -684,6 +730,21 @@
     linear-gradient(90deg, color-mix(in srgb, var(--accent) 13%, transparent), transparent 38%),
     color-mix(in srgb, var(--card) 76%, var(--bg-hover) 24%);
   border-color: color-mix(in srgb, var(--border-strong) 70%, transparent);
+}
+
+.chat-tool-msg-summary.chat-tool-msg-summary--error:hover {
+  background:
+    linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--destructive, var(--danger, #c0392b)) 14%, transparent),
+      transparent 38%
+    ),
+    color-mix(in srgb, var(--card) 78%, var(--bg-hover) 22%);
+  border-color: color-mix(
+    in srgb,
+    var(--destructive, var(--danger, #c0392b)) 38%,
+    var(--border-strong)
+  );
 }
 
 .chat-tool-msg-collapse--manual.is-open > .chat-tool-msg-summary,
@@ -858,6 +919,10 @@
     max-height: 100px;
   }
 
+  .chat-tool-card--expanded {
+    max-height: none;
+  }
+
   .chat-tool-card__title {
     font-size: 12px;
   }
@@ -892,6 +957,10 @@
   .chat-tool-card {
     padding: 6px 8px;
     max-height: 80px;
+  }
+
+  .chat-tool-card--expanded {
+    max-height: none;
   }
 
   .chat-tool-card__preview {

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -161,6 +161,70 @@
   margin-top: 10px;
 }
 
+/* Error state: tool returned an error payload or "Tool not found" */
+.chat-tool-card__status--error,
+.chat-tool-card__action--error,
+.chat-tool-card__status-text--error {
+  color: var(--destructive, var(--danger, #c0392b));
+}
+
+.chat-tool-card__status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 6px;
+  margin-left: 6px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--destructive, var(--danger, #c0392b)) 15%, transparent);
+  color: var(--destructive, var(--danger, #c0392b));
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  line-height: 1.4;
+}
+
+.chat-tool-card__status-badge svg {
+  width: 10px;
+  height: 10px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 2px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.chat-tool-card--error {
+  border-color: color-mix(in srgb, var(--destructive, var(--danger, #c0392b)) 35%, var(--border));
+}
+
+.chat-tool-msg-summary__error-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 6px;
+  margin-left: auto;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--destructive, var(--danger, #c0392b)) 15%, transparent);
+  color: var(--destructive, var(--danger, #c0392b));
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  flex-shrink: 0;
+}
+
+.chat-tool-msg-summary__error-badge svg {
+  width: 10px;
+  height: 10px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 2px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
 .chat-tool-card__detail {
   font-size: var(--control-ui-text-sm);
   color: var(--muted);
@@ -583,6 +647,10 @@
   background:
     linear-gradient(90deg, color-mix(in srgb, var(--accent) 9%, transparent), transparent 34%),
     color-mix(in srgb, var(--card) 86%, var(--secondary) 14%);
+}
+
+.chat-tool-msg-summary.chat-tool-msg-summary--error {
+  border-color: color-mix(in srgb, var(--destructive, var(--danger, #c0392b)) 30%, var(--border));
 }
 
 .chat-tool-msg-summary::-webkit-details-marker {

--- a/ui/src/styles/chat/tool-cards.test.ts
+++ b/ui/src/styles/chat/tool-cards.test.ts
@@ -20,4 +20,14 @@ describe("chat tool card styles", () => {
     expect(css).toContain("white-space: normal;");
     expect(css).not.toContain("max-width: 42%;");
   });
+
+  it("keeps expanded tool cards and actions usable on narrow screens", () => {
+    const css = readToolCardsCss();
+
+    expect(css).toContain(".chat-tool-card--expanded {");
+    expect(css).toContain("max-height: none;");
+    expect(css).toContain("overflow: hidden;");
+    expect(css).toContain("white-space: nowrap;");
+    expect(css).toContain(".chat-tool-card__block-content code");
+  });
 });

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -1068,7 +1068,7 @@ describe("grouped chat rendering", () => {
     const blocks = Array.from(container.querySelectorAll(".chat-tool-card__block"));
     expect(
       blocks.map((block) => block.querySelector(".chat-tool-card__block-label")?.textContent),
-    ).toEqual(["Tool input", "Tool output"]);
+    ).toEqual(["Tool input", "Tool error"]);
     expect(blocks[0]?.querySelector("code")?.textContent).toBe(
       '{\n  "mode": "session",\n  "thread": true\n}',
     );
@@ -1077,6 +1077,75 @@ describe("grouped chat rendering", () => {
       error: "Session mode is unavailable for this target.",
       childSessionKey: "agent:test:subagent:abc123",
     });
+  });
+
+  it("marks collapsed standalone tool-result summaries as errors", () => {
+    const container = document.createElement("div");
+    renderMessageGroups(
+      container,
+      [
+        createMessageGroup(
+          {
+            id: "tool-error-collapsed",
+            role: "toolResult",
+            toolCallId: "call-error-collapsed",
+            toolName: "web_search",
+            isError: false,
+            content: JSON.stringify({
+              error: "missing_brave_api_key",
+              message: "BRAVE_API_KEY is not configured",
+            }),
+            timestamp: Date.now(),
+          },
+          "tool",
+        ),
+      ],
+      {
+        isToolMessageExpanded: () => false,
+      },
+    );
+
+    const summary = expectElement(container, ".chat-tool-msg-summary", HTMLButtonElement);
+    expect(summary.classList.contains("chat-tool-msg-summary--error")).toBe(true);
+    expect(summary.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe("Tool error");
+    expect(summary.querySelector(".chat-tool-msg-summary__names")?.textContent).toBe("web_search");
+    expect(summary.querySelector(".chat-tool-msg-summary__error-badge")).not.toBeNull();
+    expect(container.querySelector(".chat-tool-msg-body")).toBeNull();
+  });
+
+  it("marks MCP-style standalone tool-result summaries as errors", () => {
+    const container = document.createElement("div");
+    renderMessageGroups(
+      container,
+      [
+        createMessageGroup(
+          {
+            id: "tool-error-collapsed-mcp",
+            role: "toolResult",
+            toolCallId: "call-error-collapsed-mcp",
+            toolName: "memory_forget",
+            isError: false,
+            content: JSON.stringify({
+              isError: true,
+              content: [{ type: "text", text: "Tool error: boom" }],
+            }),
+            timestamp: Date.now(),
+          },
+          "tool",
+        ),
+      ],
+      {
+        isToolMessageExpanded: () => false,
+      },
+    );
+
+    const summary = expectElement(container, ".chat-tool-msg-summary", HTMLButtonElement);
+    expect(summary.classList.contains("chat-tool-msg-summary--error")).toBe(true);
+    expect(summary.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe("Tool error");
+    expect(summary.querySelector(".chat-tool-msg-summary__names")?.textContent).toBe(
+      "memory_forget",
+    );
+    expect(summary.querySelector(".chat-tool-msg-summary__error-badge")).not.toBeNull();
   });
 
   it("collapses an inline tool call while keeping matching tool output visible", () => {

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -1148,6 +1148,46 @@ describe("grouped chat rendering", () => {
     expect(summary.querySelector(".chat-tool-msg-summary__error-badge")).toBeNull();
   });
 
+  it("marks status-only standalone tool-result summaries as errors", () => {
+    const container = document.createElement("div");
+    const groups = [
+      createMessageGroup(
+        {
+          id: "tool-status-error",
+          role: "toolResult",
+          toolCallId: "call-status-error",
+          toolName: "sessions_spawn",
+          content: JSON.stringify({ status: "error" }, null, 2),
+          timestamp: Date.now(),
+        },
+        "tool",
+      ),
+    ];
+
+    renderMessageGroups(container, groups, {
+      isToolMessageExpanded: () => false,
+    });
+
+    let summary = expectElement(container, ".chat-tool-msg-summary", HTMLButtonElement);
+    expect(summary.classList.contains("chat-tool-msg-summary--error")).toBe(true);
+    expect(summary.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe("Tool error");
+    expect(summary.querySelector(".chat-tool-msg-summary__names")?.textContent).toBe(
+      "sessions_spawn",
+    );
+    expect(summary.querySelector(".chat-tool-msg-summary__error-badge")).not.toBeNull();
+
+    renderMessageGroups(container, groups, {
+      isToolMessageExpanded: () => true,
+    });
+
+    summary = expectElement(container, ".chat-tool-msg-summary", HTMLButtonElement);
+    expect(summary.classList.contains("chat-tool-msg-summary--error")).toBe(true);
+    expect(summary.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe("Tool error");
+    expect(
+      JSON.parse(container.querySelector(".chat-json-content code")?.textContent ?? "{}"),
+    ).toEqual({ status: "error" });
+  });
+
   it("collapses an inline tool call while keeping matching tool output visible", () => {
     const container = document.createElement("div");
     const groups = [

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -44,7 +44,7 @@ function requireFirstMockArg(
   if (!arg || typeof arg !== "object" || Array.isArray(arg)) {
     throw new Error(`expected ${label} payload`);
   }
-  return arg as Record<string, unknown>;
+  return arg;
 }
 
 vi.mock("../views/agents-utils.ts", () => {

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -1079,7 +1079,7 @@ describe("grouped chat rendering", () => {
     });
   });
 
-  it("marks collapsed standalone tool-result summaries as errors", () => {
+  it("respects explicit success on collapsed standalone tool-result summaries", () => {
     const container = document.createElement("div");
     renderMessageGroups(
       container,
@@ -1106,14 +1106,14 @@ describe("grouped chat rendering", () => {
     );
 
     const summary = expectElement(container, ".chat-tool-msg-summary", HTMLButtonElement);
-    expect(summary.classList.contains("chat-tool-msg-summary--error")).toBe(true);
-    expect(summary.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe("Tool error");
+    expect(summary.classList.contains("chat-tool-msg-summary--error")).toBe(false);
+    expect(summary.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe("Tool output");
     expect(summary.querySelector(".chat-tool-msg-summary__names")?.textContent).toBe("web_search");
-    expect(summary.querySelector(".chat-tool-msg-summary__error-badge")).not.toBeNull();
+    expect(summary.querySelector(".chat-tool-msg-summary__error-badge")).toBeNull();
     expect(container.querySelector(".chat-tool-msg-body")).toBeNull();
   });
 
-  it("marks MCP-style standalone tool-result summaries as errors", () => {
+  it("respects explicit success on MCP-style standalone tool-result summaries", () => {
     const container = document.createElement("div");
     renderMessageGroups(
       container,
@@ -1140,12 +1140,12 @@ describe("grouped chat rendering", () => {
     );
 
     const summary = expectElement(container, ".chat-tool-msg-summary", HTMLButtonElement);
-    expect(summary.classList.contains("chat-tool-msg-summary--error")).toBe(true);
-    expect(summary.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe("Tool error");
+    expect(summary.classList.contains("chat-tool-msg-summary--error")).toBe(false);
+    expect(summary.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe("Tool output");
     expect(summary.querySelector(".chat-tool-msg-summary__names")?.textContent).toBe(
       "memory_forget",
     );
-    expect(summary.querySelector(".chat-tool-msg-summary__error-badge")).not.toBeNull();
+    expect(summary.querySelector(".chat-tool-msg-summary__error-badge")).toBeNull();
   });
 
   it("collapses an inline tool call while keeping matching tool output visible", () => {

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -27,6 +27,7 @@ import {
   extractToolCards,
   formatCollapsedToolPreviewText,
   formatCollapsedToolSummaryText,
+  isToolCardError,
   renderExpandedToolCardContent,
   renderRawOutputToggle,
   renderToolCard,
@@ -1534,6 +1535,7 @@ function renderGroupedMessage(
   const toolMessageExpanded = opts.isToolMessageExpanded?.(toolMessageDisclosureId) ?? false;
   const toolNames = [...new Set(toolCards.map((c) => c.name))];
   const singleToolCard = toolCards.length === 1 ? toolCards[0] : null;
+  const toolMessageHasError = toolCards.some(isToolCardError);
   const singleToolDisplay = singleToolCard
     ? resolveToolDisplay({
         name: singleToolCard.name,
@@ -1542,21 +1544,29 @@ function renderGroupedMessage(
       })
     : null;
   const singleToolDisplayDetail =
-    singleToolCard && singleToolDisplay
+    !toolMessageHasError && singleToolCard && singleToolDisplay
       ? resolveCollapsedToolDetail(singleToolCard, singleToolDisplay.detail)
       : undefined;
-  const toolSummaryLabelRaw = singleToolDisplayDetail
-    ? singleToolCard?.outputText?.trim()
-      ? "output"
-      : undefined
-    : toolNames.length <= 3
-      ? toolNames.join(", ")
-      : `${toolNames.slice(0, 2).join(", ")} +${toolNames.length - 2} more`;
+  const toolSummaryLabelRaw = toolMessageHasError
+    ? singleToolDisplay
+      ? singleToolDisplay.label
+      : toolNames.length <= 3
+        ? toolNames.join(", ")
+        : `${toolNames.slice(0, 2).join(", ")} +${toolNames.length - 2} more`
+    : singleToolDisplayDetail
+      ? singleToolCard?.outputText?.trim()
+        ? "output"
+        : undefined
+      : toolNames.length <= 3
+        ? toolNames.join(", ")
+        : `${toolNames.slice(0, 2).join(", ")} +${toolNames.length - 2} more`;
   const toolSummaryLabel = formatCollapsedToolSummaryText(toolSummaryLabelRaw);
   const toolPreview =
     markdown && !toolSummaryLabel ? (formatCollapsedToolPreviewText(markdown) ?? "") : "";
   const toolMessageLabelRaw =
-    singleToolDisplayDetail && !markdown && !hasImages
+    toolMessageHasError
+      ? "Tool error"
+      : singleToolDisplayDetail && !markdown && !hasImages
       ? singleToolDisplayDetail
       : singleToolDisplay && !markdown && !hasImages
         ? singleToolDisplay.label
@@ -1584,7 +1594,9 @@ function renderGroupedMessage(
                 : ""}"
             >
               <button
-                class="chat-tool-msg-summary"
+                class="chat-tool-msg-summary ${toolMessageHasError
+                  ? "chat-tool-msg-summary--error"
+                  : ""}"
                 type="button"
                 aria-expanded=${String(toolMessageExpanded)}
                 @click=${() => opts.onToggleToolMessageExpanded?.(toolMessageDisclosureId)}
@@ -1596,6 +1608,13 @@ function renderGroupedMessage(
                   : toolPreview
                     ? html`<span class="chat-tool-msg-summary__preview">${toolPreview}</span>`
                     : nothing}
+                ${toolMessageHasError
+                  ? html`<span
+                      class="chat-tool-msg-summary__error-badge"
+                      aria-label="Tool returned an error"
+                      >${icons.x}<span>Error</span></span
+                    >`
+                  : nothing}
               </button>
               ${toolMessageExpanded
                 ? html`

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -1563,10 +1563,9 @@ function renderGroupedMessage(
   const toolSummaryLabel = formatCollapsedToolSummaryText(toolSummaryLabelRaw);
   const toolPreview =
     markdown && !toolSummaryLabel ? (formatCollapsedToolPreviewText(markdown) ?? "") : "";
-  const toolMessageLabelRaw =
-    toolMessageHasError
-      ? "Tool error"
-      : singleToolDisplayDetail && !markdown && !hasImages
+  const toolMessageLabelRaw = toolMessageHasError
+    ? "Tool error"
+    : singleToolDisplayDetail && !markdown && !hasImages
       ? singleToolDisplayDetail
       : singleToolDisplay && !markdown && !hasImages
         ? singleToolDisplay.label

--- a/ui/src/ui/chat/tool-cards.node.test.ts
+++ b/ui/src/ui/chat/tool-cards.node.test.ts
@@ -163,6 +163,61 @@ describe("tool-card extraction", () => {
     expect(cards[0]?.outputText).toBe("# Heading\nfile body");
   });
 
+  it("preserves explicit tool error flags from tool result items and messages", () => {
+    const pairedCards = extractToolCards(
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolcall",
+            id: "call-error",
+            name: "lookup",
+          },
+          {
+            type: "tool_result",
+            id: "call-error",
+            name: "lookup",
+            text: "lookup failed",
+            isError: true,
+          },
+        ],
+      },
+      "msg:error-item",
+    );
+
+    expect(pairedCards[0]?.isError).toBe(true);
+
+    const messageFlagCards = extractToolCards(
+      {
+        role: "toolResult",
+        isError: true,
+        content: [
+          {
+            type: "tool_result",
+            id: "call-message-error",
+            name: "lookup",
+            text: "lookup failed",
+          },
+        ],
+      },
+      "msg:error-message-flag",
+    );
+
+    expect(messageFlagCards[0]?.isError).toBe(true);
+
+    const standaloneCards = extractToolCards(
+      {
+        role: "tool",
+        toolName: "lookup",
+        content: "lookup failed",
+        isError: true,
+      },
+      "msg:error-message",
+    );
+
+    expect(standaloneCards[0]?.isError).toBe(true);
+  });
+
   it("builds sidebar content with input and empty output status", () => {
     const [card] = extractToolCards(
       {
@@ -191,6 +246,21 @@ with Example Deck
 
 ### Tool output
 *No output — tool completed successfully.*`);
+  });
+
+  it("builds sidebar content with a failed empty-output status for explicit errors", () => {
+    const sidebar = buildToolCardSidebarContent({
+      id: "msg:error-empty",
+      name: "lookup",
+      isError: true,
+    });
+
+    expect(sidebar).toBe(`## Lookup
+
+**Tool:** \`lookup\`
+
+### Tool error
+*No output — tool failed.*`);
   });
 
   it("extracts canvas handle payloads into canvas previews", () => {

--- a/ui/src/ui/chat/tool-cards.test.ts
+++ b/ui/src/ui/chat/tool-cards.test.ts
@@ -434,7 +434,7 @@ describe("tool-cards", () => {
     expect(container.querySelector(".chat-tool-card--error")).not.toBeNull();
   });
 
-  it("still treats an error payload as failed when the status flag is false", () => {
+  it("respects an explicit success flag even when the payload looks like an error", () => {
     const container = document.createElement("div");
     render(
       renderToolCard(
@@ -451,10 +451,10 @@ describe("tool-cards", () => {
       container,
     );
 
-    expect(container.textContent).toContain("Tool error");
-    expect(container.textContent).not.toMatch(/\bTool output\b/);
-    expect(container.querySelector(".chat-tool-msg-summary--error")).not.toBeNull();
-    expect(container.querySelector(".chat-tool-msg-summary__error-badge")).not.toBeNull();
+    expect(container.textContent).toContain("Web Search");
+    expect(container.textContent).not.toContain("Tool error");
+    expect(container.querySelector(".chat-tool-msg-summary--error")).toBeNull();
+    expect(container.querySelector(".chat-tool-msg-summary__error-badge")).toBeNull();
   });
 
   it("does not render View with a checkmark for sidebar cards whose output is an error JSON", () => {

--- a/ui/src/ui/chat/tool-cards.test.ts
+++ b/ui/src/ui/chat/tool-cards.test.ts
@@ -356,6 +356,11 @@ describe("tool-cards", () => {
       expect(isToolErrorOutput(undefined)).toBe(false);
       expect(isToolErrorOutput("")).toBe(false);
       expect(isToolErrorOutput("Opened page")).toBe(false);
+      expect(
+        isToolErrorOutput(
+          JSON.stringify({ isError: false, result: "ok", error: "no validation errors" }),
+        ),
+      ).toBe(false);
       expect(isToolErrorOutput(JSON.stringify({ result: "ok", error: null }))).toBe(false);
       expect(isToolErrorOutput(JSON.stringify({ result: "ok", error: "" }))).toBe(false);
       expect(isToolErrorOutput(JSON.stringify({ result: "ok" }))).toBe(false);

--- a/ui/src/ui/chat/tool-cards.test.ts
+++ b/ui/src/ui/chat/tool-cards.test.ts
@@ -5,11 +5,19 @@ import { describe, expect, it, vi } from "vitest";
 import {
   formatCollapsedToolPreviewText,
   formatCollapsedToolSummaryText,
+  isToolErrorOutput,
   renderToolCard,
+  renderToolCardSidebar,
 } from "./tool-cards.ts";
 
 vi.mock("../icons.ts", () => ({
-  icons: {},
+  icons: {
+    check: "✓",
+    chevronDown: "",
+    panelRightOpen: "",
+    x: "✕",
+    zap: "",
+  },
 }));
 
 vi.mock("../tool-display.ts", () => ({
@@ -304,5 +312,215 @@ describe("tool-cards", () => {
     expect(sidebar.kind).toBe("canvas");
     expect(sidebar.docId).toBe("cv_sidebar");
     expect(sidebar.entryUrl).toBe("/__openclaw__/canvas/documents/cv_sidebar/index.html");
+  });
+
+  describe("isToolErrorOutput", () => {
+    it("flags JSON payloads that carry a top-level error string", () => {
+      expect(
+        isToolErrorOutput(
+          JSON.stringify({
+            error: "missing_brave_api_key",
+            message: "BRAVE_API_KEY is not configured",
+            provider: "brave",
+          }),
+        ),
+      ).toBe(true);
+    });
+
+    it("flags JSON payloads that carry a top-level isError flag", () => {
+      expect(
+        isToolErrorOutput(
+          JSON.stringify({
+            isError: true,
+            content: [{ type: "text", text: "Tool error: boom" }],
+          }),
+        ),
+      ).toBe(true);
+      expect(
+        isToolErrorOutput(
+          JSON.stringify({
+            is_error: true,
+            content: [{ type: "text", text: "Tool error: boom" }],
+          }),
+        ),
+      ).toBe(true);
+    });
+
+    it("flags 'Tool not found' bodies regardless of trailing punctuation or case", () => {
+      expect(isToolErrorOutput("Tool not found")).toBe(true);
+      expect(isToolErrorOutput("  tool not found.  ")).toBe(true);
+      expect(isToolErrorOutput("TOOL NOT FOUND")).toBe(true);
+    });
+
+    it("does not flag successful payloads or strings without a tool error signal", () => {
+      expect(isToolErrorOutput(undefined)).toBe(false);
+      expect(isToolErrorOutput("")).toBe(false);
+      expect(isToolErrorOutput("Opened page")).toBe(false);
+      expect(isToolErrorOutput(JSON.stringify({ result: "ok", error: null }))).toBe(false);
+      expect(isToolErrorOutput(JSON.stringify({ result: "ok", error: "" }))).toBe(false);
+      expect(isToolErrorOutput(JSON.stringify({ result: "ok" }))).toBe(false);
+      expect(isToolErrorOutput("{ not really json }")).toBe(false);
+    });
+  });
+
+  it("renders a Tool error label and Error badge when output is an error JSON", () => {
+    const container = document.createElement("div");
+    render(
+      renderToolCard(
+        {
+          id: "msg:err:1",
+          name: "web_search",
+          args: { query: "python stable version" },
+          inputText: '{\n  "query": "python stable version"\n}',
+          outputText: JSON.stringify({
+            error: "missing_brave_api_key",
+            message: "BRAVE_API_KEY is not configured",
+          }),
+        },
+        { expanded: true, onToggleExpanded: vi.fn() },
+      ),
+      container,
+    );
+
+    expect(container.textContent).toContain("Tool error");
+    expect(container.textContent).not.toMatch(/\bTool output\b/);
+    const summaryButton = container.querySelector("button.chat-tool-msg-summary");
+    expect(summaryButton?.classList.contains("chat-tool-msg-summary--error")).toBe(true);
+    expect(container.querySelector(".chat-tool-msg-summary__error-badge")).not.toBeNull();
+    const expandedCard = container.querySelector(".chat-tool-card--expanded");
+    expect(expandedCard?.classList.contains("chat-tool-card--error")).toBe(true);
+    expect(container.querySelector(".chat-tool-card__status-badge")).not.toBeNull();
+  });
+
+  it("renders a Tool error label when output is the literal 'Tool not found'", () => {
+    const container = document.createElement("div");
+    render(
+      renderToolCard(
+        {
+          id: "msg:err:2",
+          name: "Unknown",
+          outputText: "Tool not found",
+        },
+        { expanded: false, onToggleExpanded: vi.fn() },
+      ),
+      container,
+    );
+
+    expect(container.textContent).toContain("Tool error");
+    expect(container.textContent).not.toMatch(/\bTool output\b/);
+    const summaryButton = container.querySelector("button.chat-tool-msg-summary");
+    expect(summaryButton?.classList.contains("chat-tool-msg-summary--error")).toBe(true);
+    expect(container.querySelector(".chat-tool-msg-summary__error-badge")).not.toBeNull();
+  });
+
+  it("renders a Tool error label when the tool card has an explicit error flag", () => {
+    const container = document.createElement("div");
+    render(
+      renderToolCard(
+        {
+          id: "msg:err:explicit",
+          name: "lookup",
+          outputText: "lookup failed",
+          isError: true,
+        },
+        { expanded: true, onToggleExpanded: vi.fn() },
+      ),
+      container,
+    );
+
+    expect(container.textContent).toContain("Tool error");
+    expect(container.textContent).not.toMatch(/\bTool output\b/);
+    expect(container.querySelector(".chat-tool-msg-summary--error")).not.toBeNull();
+    expect(container.querySelector(".chat-tool-card--error")).not.toBeNull();
+  });
+
+  it("still treats an error payload as failed when the status flag is false", () => {
+    const container = document.createElement("div");
+    render(
+      renderToolCard(
+        {
+          id: "msg:err:status-false",
+          name: "web_search",
+          outputText: JSON.stringify({
+            error: "missing_brave_api_key",
+          }),
+          isError: false,
+        },
+        { expanded: false, onToggleExpanded: vi.fn() },
+      ),
+      container,
+    );
+
+    expect(container.textContent).toContain("Tool error");
+    expect(container.textContent).not.toMatch(/\bTool output\b/);
+    expect(container.querySelector(".chat-tool-msg-summary--error")).not.toBeNull();
+    expect(container.querySelector(".chat-tool-msg-summary__error-badge")).not.toBeNull();
+  });
+
+  it("does not render View with a checkmark for sidebar cards whose output is an error JSON", () => {
+    const container = document.createElement("div");
+    render(
+      renderToolCardSidebar(
+        {
+          id: "msg:err:sidebar",
+          name: "web_search",
+          outputText: JSON.stringify({
+            error: "missing_brave_api_key",
+            message: "BRAVE_API_KEY is not configured",
+          }),
+        },
+        vi.fn(),
+      ),
+      container,
+    );
+
+    const card = container.querySelector(".chat-tool-card");
+    const action = container.querySelector(".chat-tool-card__action");
+    expect(card?.classList.contains("chat-tool-card--error")).toBe(true);
+    expect(action?.classList.contains("chat-tool-card__action--error")).toBe(true);
+    expect(action?.textContent).toContain("View error");
+    expect(action?.textContent).toContain("✕");
+    expect(action?.textContent).not.toContain("✓");
+  });
+
+  it("marks Tool not found sidebar output as an error instead of View with a checkmark", () => {
+    const container = document.createElement("div");
+    render(
+      renderToolCardSidebar(
+        {
+          id: "msg:err:sidebar-tool-not-found",
+          name: "Unknown",
+          outputText: "Tool not found",
+        },
+        vi.fn(),
+      ),
+      container,
+    );
+
+    const action = container.querySelector(".chat-tool-card__action");
+    expect(container.querySelector(".chat-tool-card--error")).not.toBeNull();
+    expect(action?.textContent).toContain("View error");
+    expect(action?.textContent).toContain("✕");
+    expect(action?.textContent).not.toContain("✓");
+  });
+
+  it("keeps Tool output labelling for successful results", () => {
+    const container = document.createElement("div");
+    render(
+      renderToolCard(
+        {
+          id: "msg:ok:1",
+          name: "browser.open",
+          outputText: "Opened page",
+        },
+        { expanded: true, onToggleExpanded: vi.fn() },
+      ),
+      container,
+    );
+
+    expect(container.textContent).toContain("Tool output");
+    expect(container.textContent).not.toContain("Tool error");
+    expect(container.querySelector(".chat-tool-msg-summary--error")).toBeNull();
+    expect(container.querySelector(".chat-tool-card__status-badge")).toBeNull();
   });
 });

--- a/ui/src/ui/chat/tool-cards.test.ts
+++ b/ui/src/ui/chat/tool-cards.test.ts
@@ -352,6 +352,14 @@ describe("tool-cards", () => {
       expect(isToolErrorOutput("TOOL NOT FOUND")).toBe(true);
     });
 
+    it("flags JSON payloads with top-level failure statuses", () => {
+      expect(isToolErrorOutput(JSON.stringify({ status: "error" }))).toBe(true);
+      expect(isToolErrorOutput(JSON.stringify({ status: "failed" }))).toBe(true);
+      expect(isToolErrorOutput(JSON.stringify({ status: "timeout" }))).toBe(true);
+      expect(isToolErrorOutput(JSON.stringify({ status: "completed" }))).toBe(false);
+      expect(isToolErrorOutput(JSON.stringify({ status: "ok" }))).toBe(false);
+    });
+
     it("does not flag successful payloads or strings without a tool error signal", () => {
       expect(isToolErrorOutput(undefined)).toBe(false);
       expect(isToolErrorOutput("")).toBe(false);
@@ -395,6 +403,26 @@ describe("tool-cards", () => {
     const expandedCard = container.querySelector(".chat-tool-card--expanded");
     expect(expandedCard?.classList.contains("chat-tool-card--error")).toBe(true);
     expect(container.querySelector(".chat-tool-card__status-badge")).not.toBeNull();
+  });
+
+  it("renders a Tool error label when output has a status-only error payload", () => {
+    const container = document.createElement("div");
+    render(
+      renderToolCard(
+        {
+          id: "msg:err:status-only",
+          name: "sessions_spawn",
+          outputText: JSON.stringify({ status: "error" }),
+        },
+        { expanded: true, onToggleExpanded: vi.fn() },
+      ),
+      container,
+    );
+
+    expect(container.textContent).toContain("Tool error");
+    expect(container.textContent).not.toMatch(/\bTool output\b/);
+    expect(container.querySelector(".chat-tool-msg-summary--error")).not.toBeNull();
+    expect(container.querySelector(".chat-tool-card--error")).not.toBeNull();
   });
 
   it("renders a Tool error label when output is the literal 'Tool not found'", () => {
@@ -496,6 +524,27 @@ describe("tool-cards", () => {
           id: "msg:err:sidebar-tool-not-found",
           name: "Unknown",
           outputText: "Tool not found",
+        },
+        vi.fn(),
+      ),
+      container,
+    );
+
+    const action = container.querySelector(".chat-tool-card__action");
+    expect(container.querySelector(".chat-tool-card--error")).not.toBeNull();
+    expect(action?.textContent).toContain("View error");
+    expect(action?.textContent).toContain("✕");
+    expect(action?.textContent).not.toContain("✓");
+  });
+
+  it("marks status-only sidebar output as an error instead of View with a checkmark", () => {
+    const container = document.createElement("div");
+    render(
+      renderToolCardSidebar(
+        {
+          id: "msg:err:sidebar-status",
+          name: "sessions_wait",
+          outputText: JSON.stringify({ status: "timeout" }),
         },
         vi.fn(),
       ),

--- a/ui/src/ui/chat/tool-cards.test.ts
+++ b/ui/src/ui/chat/tool-cards.test.ts
@@ -48,7 +48,7 @@ function requireFirstMockArg(
   if (!arg || typeof arg !== "object" || Array.isArray(arg)) {
     throw new Error(`expected ${label} payload`);
   }
-  return arg as Record<string, unknown>;
+  return arg;
 }
 
 describe("tool-cards", () => {

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -63,6 +63,67 @@ function extractToolText(item: Record<string, unknown>): string | undefined {
   return undefined;
 }
 
+function readToolErrorFlag(value: Record<string, unknown>): boolean | undefined {
+  const raw = value.isError ?? value.is_error;
+  return typeof raw === "boolean" ? raw : undefined;
+}
+
+const TOOL_NOT_FOUND_PATTERN = /^tool not found\.?$/i;
+const MAX_ERROR_DETECT_CHARS = 20_000;
+
+export function isToolErrorOutput(outputText: string | undefined): boolean {
+  if (!outputText) {
+    return false;
+  }
+  const trimmed = outputText.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (TOOL_NOT_FOUND_PATTERN.test(trimmed)) {
+    return true;
+  }
+  if (trimmed.length > MAX_ERROR_DETECT_CHARS) {
+    return false;
+  }
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {
+    return false;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return false;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return false;
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (readToolErrorFlag(obj) === true) {
+    return true;
+  }
+  if ("error" in obj) {
+    const value = obj.error;
+    if (typeof value === "string") {
+      return value.trim().length > 0;
+    }
+    if (typeof value === "boolean") {
+      return value;
+    }
+    if (value && typeof value === "object") {
+      return true;
+    }
+    return false;
+  }
+  return false;
+}
+
+export function isToolCardError(card: ToolCard): boolean {
+  if (card.isError !== undefined) {
+    return card.isError;
+  }
+  return isToolErrorOutput(card.outputText);
+}
+
 export function extractToolPreview(
   outputText: string | undefined,
   toolName: string | undefined,
@@ -169,6 +230,7 @@ function findLatestCard(cards: ToolCard[], id: string, name: string): ToolCard |
 export function extractToolCards(message: unknown, prefix = "tool"): ToolCard[] {
   const m = message as Record<string, unknown>;
   const content = normalizeContent(m.content);
+  const messageIsError = readToolErrorFlag(m);
   const cards: ToolCard[] = [];
 
   for (let index = 0; index < content.length; index++) {
@@ -195,15 +257,20 @@ export function extractToolCards(message: unknown, prefix = "tool"): ToolCard[] 
       const existing = findLatestCard(cards, cardId, name);
       const text = extractToolText(item);
       const preview = extractToolPreview(text, name);
+      const isError = readToolErrorFlag(item) ?? messageIsError;
       if (existing) {
         existing.outputText = text;
         existing.preview = preview;
+        if (isError !== undefined) {
+          existing.isError = isError;
+        }
         continue;
       }
       cards.push({
         id: cardId,
         name,
         outputText: text,
+        ...(isError !== undefined ? { isError } : {}),
         preview,
       });
     }
@@ -227,6 +294,7 @@ export function extractToolCards(message: unknown, prefix = "tool"): ToolCard[] 
       id: resolveToolCardId({}, m, 0, prefix),
       name,
       outputText: text,
+      ...(messageIsError !== undefined ? { isError: messageIsError } : {}),
       preview: extractToolPreview(text, name),
     });
   }
@@ -237,6 +305,7 @@ export function extractToolCards(message: unknown, prefix = "tool"): ToolCard[] 
 export function buildToolCardSidebarContent(card: ToolCard): string {
   const display = resolveToolDisplay({ name: card.name, args: card.args });
   const detail = formatToolDetail(display);
+  const isError = isToolCardError(card);
   const sections = [`## ${display.label}`, `**Tool:** \`${display.name}\``];
 
   if (detail) {
@@ -251,9 +320,15 @@ export function buildToolCardSidebarContent(card: ToolCard): string {
   }
 
   if (card.outputText?.trim()) {
-    sections.push(`### Tool output\n${formatToolOutputForSidebar(card.outputText)}`);
+    sections.push(
+      `### ${isError ? "Tool error" : "Tool output"}\n${formatToolOutputForSidebar(card.outputText)}`,
+    );
   } else {
-    sections.push(`### Tool output\n*No output — tool completed successfully.*`);
+    sections.push(
+      isError
+        ? "### Tool error\n*No output — tool failed.*"
+        : "### Tool output\n*No output — tool completed successfully.*",
+    );
   }
 
   return sections.join("\n\n");
@@ -412,14 +487,15 @@ function renderCollapsedToolSummary(params: {
   icon: ReturnType<typeof html> | undefined;
   name?: string;
   expanded: boolean;
+  isError?: boolean;
   onToggleExpanded: () => void;
 }) {
-  const { label, icon, name, expanded, onToggleExpanded } = params;
+  const { label, icon, name, expanded, isError, onToggleExpanded } = params;
   const displayLabel = formatCollapsedToolSummaryText(label) ?? label;
   const displayName = formatCollapsedToolSummaryText(name);
   return html`
     <button
-      class="chat-tool-msg-summary"
+      class="chat-tool-msg-summary ${isError ? "chat-tool-msg-summary--error" : ""}"
       type="button"
       aria-expanded=${String(expanded)}
       @click=${() => onToggleExpanded()}
@@ -428,6 +504,11 @@ function renderCollapsedToolSummary(params: {
       <span class="chat-tool-msg-summary__label">${displayLabel}</span>
       ${displayName
         ? html`<span class="chat-tool-msg-summary__names">${displayName}</span>`
+        : nothing}
+      ${isError
+        ? html`<span class="chat-tool-msg-summary__error-badge" aria-label="Tool returned an error"
+            >${icons.x}<span>Error</span></span
+          >`
         : nothing}
     </button>
   `;
@@ -458,9 +539,10 @@ export function renderToolCard(
 ) {
   const hasOutput = Boolean(card.outputText?.trim());
   const display = resolveToolDisplay({ name: card.name, args: card.args, detailMode: "explain" });
-  const collapsedDetail = resolveCollapsedToolDetail(card, display.detail);
-  const previewLabel = collapsedDetail ?? display.label;
-  const previewName = collapsedDetail && hasOutput ? "output" : undefined;
+  const isError = isToolCardError(card);
+  const collapsedDetail = isError ? undefined : resolveCollapsedToolDetail(card, display.detail);
+  const previewLabel = isError ? "Tool error" : (collapsedDetail ?? display.label);
+  const previewName = isError ? display.label : collapsedDetail && hasOutput ? "output" : undefined;
 
   return html`
     <div
@@ -473,6 +555,7 @@ export function renderToolCard(
         icon: icons[display.icon],
         name: previewName,
         expanded: opts.expanded,
+        isError,
         onToggleExpanded: () => opts.onToggleExpanded(card.id),
       })}
       ${opts.expanded
@@ -503,6 +586,7 @@ export function renderExpandedToolCardContent(
   const detail = formatToolDetail(display);
   const hasOutput = Boolean(card.outputText?.trim());
   const hasInput = Boolean(card.inputText?.trim());
+  const isError = isToolCardError(card);
   const canOpenSidebar = Boolean(onOpenSidebar);
   const previewSidebarContent =
     card.preview?.kind === "canvas"
@@ -521,11 +605,16 @@ export function renderExpandedToolCardContent(
     : nothing;
 
   return html`
-    <div class="chat-tool-card chat-tool-card--expanded">
+    <div class="chat-tool-card chat-tool-card--expanded ${isError ? "chat-tool-card--error" : ""}">
       <div class="chat-tool-card__header">
         <div class="chat-tool-card__title">
           <span class="chat-tool-card__icon">${icons[display.icon]}</span>
           <span>${display.label}</span>
+          ${isError
+            ? html`<span class="chat-tool-card__status-badge" role="status"
+                >${icons.x}<span>Error</span></span
+              >`
+            : nothing}
         </div>
         ${canOpenSidebar
           ? html`
@@ -555,7 +644,7 @@ export function renderExpandedToolCardContent(
         ? card.preview
           ? html`${visiblePreview} ${renderRawOutputToggle(card.outputText!)}`
           : renderToolDataBlock({
-              label: "Tool output",
+              label: isError ? "Tool error" : "Tool output",
               text: card.outputText!,
               expanded: true,
             })
@@ -575,6 +664,7 @@ export function renderToolCardSidebar(
   const preview = card.preview;
   const hasText = Boolean(card.outputText?.trim());
   const hasPreview = Boolean(preview);
+  const isError = isToolCardError(card);
   const sidebarContent =
     preview?.kind === "canvas"
       ? buildPreviewSidebarContent(preview, card.outputText)
@@ -586,10 +676,13 @@ export function renderToolCardSidebar(
   const showCollapsed = hasText && !hasPreview && !isShort;
   const showInline = hasText && !hasPreview && isShort;
   const isEmpty = !hasText && !hasPreview;
+  const statusIcon = isError ? icons.x : icons.check;
 
   return html`
     <div
-      class="chat-tool-card ${canClick ? "chat-tool-card--clickable" : ""}"
+      class="chat-tool-card ${canClick ? "chat-tool-card--clickable" : ""} ${isError
+        ? "chat-tool-card--error"
+        : ""}"
       @click=${handleClick}
       role=${canClick ? "button" : nothing}
       tabindex=${canClick ? "0" : nothing}
@@ -609,16 +702,28 @@ export function renderToolCardSidebar(
           <span>${display.label}</span>
         </div>
         ${canClick
-          ? html`<span class="chat-tool-card__action"
-              >${hasText || hasPreview ? "View" : ""} ${icons.check}</span
+          ? html`<span
+              class="chat-tool-card__action ${isError ? "chat-tool-card__action--error" : ""}"
+              >${isError ? "View error" : hasText || hasPreview ? "View" : ""} ${statusIcon}</span
             >`
           : nothing}
         ${isEmpty && !canClick
-          ? html`<span class="chat-tool-card__status">${icons.check}</span>`
+          ? html`<span
+              class="chat-tool-card__status ${isError ? "chat-tool-card__status--error" : ""}"
+              >${statusIcon}</span
+            >`
           : nothing}
       </div>
       ${detail ? html`<div class="chat-tool-card__detail">${detail}</div>` : nothing}
-      ${isEmpty ? html`<div class="chat-tool-card__status-text muted">Completed</div>` : nothing}
+      ${isEmpty
+        ? html`<div
+            class="chat-tool-card__status-text ${isError
+              ? "chat-tool-card__status-text--error"
+              : "muted"}"
+          >
+            ${isError ? "Failed" : "Completed"}
+          </div>`
+        : nothing}
       ${preview
         ? html`${renderToolPreview(preview, "chat_tool", {
             onOpenSidebar,

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -70,6 +70,11 @@ function readToolErrorFlag(value: Record<string, unknown>): boolean | undefined 
 
 const TOOL_NOT_FOUND_PATTERN = /^tool not found\.?$/i;
 const MAX_ERROR_DETECT_CHARS = 20_000;
+const TOOL_ERROR_STATUSES = new Set(["error", "failed", "timeout"]);
+
+function hasToolErrorStatus(value: unknown): boolean {
+  return typeof value === "string" && TOOL_ERROR_STATUSES.has(value.trim().toLowerCase());
+}
 
 export function isToolErrorOutput(outputText: string | undefined): boolean {
   if (!outputText) {
@@ -113,9 +118,8 @@ export function isToolErrorOutput(outputText: string | undefined): boolean {
     if (value && typeof value === "object") {
       return true;
     }
-    return false;
   }
-  return false;
+  return hasToolErrorStatus(obj.status);
 }
 
 export function isToolCardError(card: ToolCard): boolean {

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -98,8 +98,9 @@ export function isToolErrorOutput(outputText: string | undefined): boolean {
     return false;
   }
   const obj = parsed as Record<string, unknown>;
-  if (readToolErrorFlag(obj) === true) {
-    return true;
+  const explicitErrorFlag = readToolErrorFlag(obj);
+  if (explicitErrorFlag !== undefined) {
+    return explicitErrorFlag;
   }
   if ("error" in obj) {
     const value = obj.error;

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -20,7 +20,9 @@ function normalizeContent(content: unknown): Array<Record<string, unknown>> {
   if (!Array.isArray(content)) {
     return [];
   }
-  return content.filter(Boolean) as Array<Record<string, unknown>>;
+  return content.filter(
+    (entry): entry is Record<string, unknown> => Boolean(entry) && typeof entry === "object",
+  );
 }
 
 function coerceArgs(value: unknown): unknown {
@@ -249,7 +251,7 @@ export function extractToolCards(message: unknown, prefix = "tool"): ToolCard[] 
       const args = coerceArgs(item.arguments ?? item.args ?? item.input);
       cards.push({
         id: resolveToolCardId(item, m, index, prefix),
-        name: (item.name as string) ?? "tool",
+        name: typeof item.name === "string" ? item.name : "tool",
         args,
         inputText: serializeToolInput(args),
       });

--- a/ui/src/ui/types/chat-types.ts
+++ b/ui/src/ui/types/chat-types.ts
@@ -77,6 +77,7 @@ export type ToolCard = {
   args?: unknown;
   inputText?: string;
   outputText?: string;
+  isError?: boolean;
   preview?: {
     kind: "canvas";
     surface: "assistant_message";


### PR DESCRIPTION
## Summary

- Problem: failed tool results in chat could look like successful tool output with a checkmark.
- Solution: propagate explicit `isError` / `is_error` flags into tool cards and add bounded fallback detection for common error payloads.
- What changed: tool cards, standalone tool-result summaries, sidebar content, and expanded output labels now render failed tool results with error styling and copy.
- What did NOT change (scope boundary): no agent execution, gateway protocol, tool runtime, or NemoClaw code paths were changed.

## Motivation

- NVIDIA/NemoClaw#2621 showed that an OpenClaw UI surface could display a tool failure as normal output, which hid the real failure mode from users during triage.
- This should be fixed in OpenClaw because the underlying tool result already carries error information or an error payload; the UI was not consistently surfacing it.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related NVIDIA/NemoClaw#2621
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: chat tool cards and standalone tool-result summaries now show failed tool results as `Tool error` with error styling instead of `Tool output` / `View` with a success checkmark.
- Real environment tested: macOS local OpenClaw worktree; Vite UI harness with system Chrome; focused Vitest UI tests.
- Exact steps or command run after this patch:
  - `node scripts/run-vitest.mjs ui/src/ui/chat/tool-cards.test.ts ui/src/ui/chat/tool-cards.node.test.ts ui/src/ui/chat/grouped-render.test.ts`
  - `pnpm exec oxfmt --check --threads=1 ui/src/ui/chat/tool-cards.ts ui/src/ui/chat/tool-cards.test.ts ui/src/ui/chat/tool-cards.node.test.ts ui/src/ui/types/chat-types.ts ui/src/styles/chat/tool-cards.css ui/src/ui/chat/grouped-render.ts ui/src/ui/chat/grouped-render.test.ts`
  - `git diff --check`
  - `codex review --base refs/remotes/tmp/openclaw-main-2621`
  - Temporary Vite proof page rendered `renderToolCardSidebar` in Chrome with one JSON error result and one successful result.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  - Vitest: `Test Files 3 passed (3)`, `Tests 66 passed (66)`.
  - Format: `All matched files use the correct format.`
  - Whitespace: `git diff --check` exited 0.
  - Codex review: `I did not find a discrete regression in the modified surfaces.`
  - Console output from the Chrome/Vite browser harness after the patch: `cardCount=2`, `errorCards=1`, `errorActionText="View error"`, success card kept `View`.
- Observed result after fix: error payloads such as `{"error":"missing_brave_api_key"}` and exact `Tool not found` output render as failed tool UI, while normal outputs continue to render as successful output.
- What was not tested: full live OpenClaw agent plus Brave or NemoClaw sandbox end-to-end; earlier Linux latest-image repro was blocked by `no space left on device` while pulling the image.
- Before evidence (optional but encouraged): existing behavior treated top-level JSON error output as normal `Tool output` in grouped rendering and successful sidebar action copy.

## Root Cause (if applicable)

- Root cause: the chat UI treated tool output text as successful unless the local rendering path explicitly knew otherwise, so common error payloads and standalone tool-result summaries were not consistently mapped to failed UI state.
- Missing detection / guardrail: focused UI tests did not assert that explicit error flags, JSON `error` payloads, `Tool not found`, and standalone collapsed tool results all render as errors.
- Contributing context (if known): OpenClaw has both explicit error flags (`isError`, `is_error`) and textual/JSON tool output surfaces, so the UI needs to respect both.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `ui/src/ui/chat/tool-cards.test.ts`
  - `ui/src/ui/chat/tool-cards.node.test.ts`
  - `ui/src/ui/chat/grouped-render.test.ts`
- Scenario the test should lock in: explicit `isError` / `is_error` flags and fallback error outputs must render as `Tool error` with error styling in card, sidebar, expanded, and collapsed standalone summary paths.
- Why this is the smallest reliable guardrail: these tests cover the UI normalization/rendering functions that decide the visible state, without requiring a live tool provider.
- Existing test that already covers this (if any): existing tool card tests covered successful rendering; this PR extends them for failed rendering.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Failed tool results now show error labels, error badges, failed empty-output copy, and `View error` actions in the chat UI.

## Diagram (if applicable)

```text
Before:
[tool result with error payload] -> [tool card] -> [Tool output / success checkmark]

After:
[tool result with error payload or isError flag] -> [tool card] -> [Tool error / error badge]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local development machine
- Runtime/container: local Node/pnpm UI workspace
- Model/provider: N/A
- Integration/channel (if any): OpenClaw chat UI rendering
- Relevant config (redacted): no secrets required

### Steps

1. Render tool cards with a JSON error payload, an explicit error flag, and a successful output.
2. Render grouped standalone tool-result messages in collapsed and expanded states.
3. Run focused chat rendering tests, formatting, whitespace check, and Codex review.

### Expected

- Failed tool results are visually and textually marked as errors.
- Successful tool results keep existing success copy and styling.

### Actual

- Failed results render as `Tool error`, include error styling/badges, and use `View error` in the sidebar card action.
- Successful results still render as `Tool output` / `View`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - JSON `error` payloads.
  - exact `Tool not found` output.
  - explicit `isError` and `is_error` flags.
  - `isError: false` combined with an error payload.
  - collapsed standalone tool-result summaries.
  - empty failed output sidebar copy.
  - successful outputs remain successful.
- Edge cases checked:
  - blank output is not treated as an error unless an explicit error flag is present.
  - non-JSON and JSON arrays are not treated as error payloads.
  - very large output skips fallback JSON parsing.
- What you did **not** verify:
  - full live OpenClaw agent plus external web-search provider end-to-end.
  - Linux latest-image repro after the local Linux host ran out of disk space while pulling the latest image.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: fallback JSON error detection could overclassify a successful tool output that intentionally returns a top-level truthy `error` field as data.
  - Mitigation: explicit `isError` / `is_error` flags are preferred, fallback parsing is bounded to top-level JSON objects and common known error shapes, and tests cover success outputs remaining unchanged.

AI-assisted: yes, implemented with Codex and reviewed with `codex review`.

