### PR TITLE
fix(gateway): dedupe probe warnings by gateway identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -521,7 +521,6 @@ Docs: https://docs.openclaw.ai
 - Sessions: enforce the session write-lock max-hold policy during lock acquisition so long-held locks can be reclaimed before the stale-lock window. (#85764) Thanks @njuboy11.
 - Models: prune retired Groq, GitHub Copilot, OpenAI, xAI, and old Claude catalog entries, with doctor migration to upgrade existing configs to current provider refs.
 - Plugins/Gateway: treat non-empty return values from plugin gateway method handlers as successful responses so `openclaw gateway call` no longer times out after completed plugin work. Fixes #59470. Thanks @HTMG23.
-- Gateway/status: suppress the multiple-gateways warning when SSH tunnel and configured remote probes identify the same gateway, while preserving warnings for distinct or ambiguous gateways. Fixes #69135. Thanks @sk8man121.
 - Doctor/update: recognize junction-backed source checkouts as git installs by comparing canonical paths before showing package-manager update guidance. Fixes #82215. Thanks @igormf.
 - Channels: honor `/verbose on` for tool/progress summaries across direct chats, groups, channels, and forum topics while preserving quiet default behavior. (#85488) Thanks @kurplunkin.
 - CLI/skills: show an all-ready note with next-step commands when skill setup has no missing dependencies to install. (#85032) Thanks @aniruddhaadak80.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -520,6 +520,8 @@ Docs: https://docs.openclaw.ai
 - Gateway: omit internal stream-error placeholder entries from agent prompt history so failed assistant turns are not replayed as model-authored text. (#85652) Thanks @anyech.
 - Sessions: enforce the session write-lock max-hold policy during lock acquisition so long-held locks can be reclaimed before the stale-lock window. (#85764) Thanks @njuboy11.
 - Models: prune retired Groq, GitHub Copilot, OpenAI, xAI, and old Claude catalog entries, with doctor migration to upgrade existing configs to current provider refs.
+- Plugins/Gateway: treat non-empty return values from plugin gateway method handlers as successful responses so `openclaw gateway call` no longer times out after completed plugin work. Fixes #59470. Thanks @HTMG23.
+- Gateway/status: suppress the multiple-gateways warning when SSH tunnel and configured remote probes identify the same gateway, while preserving warnings for distinct or ambiguous gateways. Fixes #69135. Thanks @sk8man121.
 - Doctor/update: recognize junction-backed source checkouts as git installs by comparing canonical paths before showing package-manager update guidance. Fixes #82215. Thanks @igormf.
 - Channels: honor `/verbose on` for tool/progress summaries across direct chats, groups, channels, and forum topics while preserving quiet default behavior. (#85488) Thanks @kurplunkin.
 - CLI/skills: show an all-ready note with next-step commands when skill setup has no missing dependencies to install. (#85032) Thanks @aniruddhaadak80.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -520,7 +520,6 @@ Docs: https://docs.openclaw.ai
 - Gateway: omit internal stream-error placeholder entries from agent prompt history so failed assistant turns are not replayed as model-authored text. (#85652) Thanks @anyech.
 - Sessions: enforce the session write-lock max-hold policy during lock acquisition so long-held locks can be reclaimed before the stale-lock window. (#85764) Thanks @njuboy11.
 - Models: prune retired Groq, GitHub Copilot, OpenAI, xAI, and old Claude catalog entries, with doctor migration to upgrade existing configs to current provider refs.
-- Plugins/Gateway: treat non-empty return values from plugin gateway method handlers as successful responses so `openclaw gateway call` no longer times out after completed plugin work. Fixes #59470. Thanks @HTMG23.
 - Doctor/update: recognize junction-backed source checkouts as git installs by comparing canonical paths before showing package-manager update guidance. Fixes #82215. Thanks @igormf.
 - Channels: honor `/verbose on` for tool/progress summaries across direct chats, groups, channels, and forum topics while preserving quiet default behavior. (#85488) Thanks @kurplunkin.
 - CLI/skills: show an all-ready note with next-step commands when skill setup has no missing dependencies to install. (#85032) Thanks @aniruddhaadak80.

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -335,10 +335,14 @@ If you pass `--url`, that explicit target is added ahead of both. Human output l
 
 <Note>
 <<<<<<< HEAD
+<<<<<<< HEAD
 If multiple distinct gateways are reachable, it prints all of them. Probe dedupes alternate transports that report the same gateway identity and logical port, such as an SSH tunnel plus the configured remote URL for the same gateway. Multiple gateways are supported when you use isolated profiles/ports (e.g., a rescue bot), but most installs still run a single gateway.
 =======
 If multiple probe targets are reachable, it prints all of them. An SSH tunnel and the configured remote URL can both point at the same gateway; `multiple_gateways` is reserved for distinct or identity-ambiguous reachable gateways. Multiple gateways are supported when you use isolated profiles/ports (e.g., a rescue bot), but most installs still run a single gateway.
 >>>>>>> 226af531e35 (docs(gateway): clarify multiple gateway identity warnings)
+=======
+If multiple probe targets are reachable, it prints all of them. An SSH tunnel, TLS/proxy URL, and configured remote URL can all point at the same gateway even when their transport ports differ; `multiple_gateways` is reserved for distinct or identity-ambiguous reachable gateways. Multiple gateways are supported when you use isolated profiles (e.g., a rescue bot), but most installs still run a single gateway.
+>>>>>>> 01476e23efa (fix(gateway): ignore transport port for self identity)
 </Note>
 
 ```bash
@@ -384,10 +388,14 @@ openclaw gateway probe --json
   <Accordion title="Common warning codes">
     - `ssh_tunnel_failed`: SSH tunnel setup failed; the command fell back to direct probes.
 <<<<<<< HEAD
+<<<<<<< HEAD
     - `multiple_gateways`: more than one distinct gateway identity or logical port was reachable; alternate transports to the same gateway are deduped before this warning is emitted.
 =======
     - `multiple_gateways`: distinct gateway identities were reachable, or OpenClaw could not prove reachable targets are the same gateway. An SSH tunnel plus configured remote URL to the same gateway does not trigger this warning.
 >>>>>>> 226af531e35 (docs(gateway): clarify multiple gateway identity warnings)
+=======
+    - `multiple_gateways`: distinct gateway identities were reachable, or OpenClaw could not prove reachable targets are the same gateway. An SSH tunnel, proxy URL, or configured remote URL to the same gateway does not trigger this warning.
+>>>>>>> 01476e23efa (fix(gateway): ignore transport port for self identity)
     - `auth_secretref_unresolved`: a configured auth SecretRef could not be resolved for a failed target.
     - `probe_scope_limited`: WebSocket connect succeeded, but the read probe was limited by missing `operator.read`.
 

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -334,7 +334,7 @@ If you pass `--url`, that explicit target is added ahead of both. Human output l
 - `Local loopback`
 
 <Note>
-If multiple gateways are reachable, it prints all of them. Multiple gateways are supported when you use isolated profiles/ports (e.g., a rescue bot), but most installs still run a single gateway.
+If multiple distinct gateways are reachable, it prints all of them. Probe dedupes alternate transports that report the same gateway identity and logical port, such as an SSH tunnel plus the configured remote URL for the same gateway. Multiple gateways are supported when you use isolated profiles/ports (e.g., a rescue bot), but most installs still run a single gateway.
 </Note>
 
 ```bash
@@ -379,7 +379,7 @@ openclaw gateway probe --json
   </Accordion>
   <Accordion title="Common warning codes">
     - `ssh_tunnel_failed`: SSH tunnel setup failed; the command fell back to direct probes.
-    - `multiple_gateways`: more than one target was reachable; this is unusual unless you intentionally run isolated profiles, such as a rescue bot.
+    - `multiple_gateways`: more than one distinct gateway identity or logical port was reachable; alternate transports to the same gateway are deduped before this warning is emitted.
     - `auth_secretref_unresolved`: a configured auth SecretRef could not be resolved for a failed target.
     - `probe_scope_limited`: WebSocket connect succeeded, but the read probe was limited by missing `operator.read`.
 

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -334,7 +334,11 @@ If you pass `--url`, that explicit target is added ahead of both. Human output l
 - `Local loopback`
 
 <Note>
+<<<<<<< HEAD
 If multiple distinct gateways are reachable, it prints all of them. Probe dedupes alternate transports that report the same gateway identity and logical port, such as an SSH tunnel plus the configured remote URL for the same gateway. Multiple gateways are supported when you use isolated profiles/ports (e.g., a rescue bot), but most installs still run a single gateway.
+=======
+If multiple probe targets are reachable, it prints all of them. An SSH tunnel and the configured remote URL can both point at the same gateway; `multiple_gateways` is reserved for distinct or identity-ambiguous reachable gateways. Multiple gateways are supported when you use isolated profiles/ports (e.g., a rescue bot), but most installs still run a single gateway.
+>>>>>>> 226af531e35 (docs(gateway): clarify multiple gateway identity warnings)
 </Note>
 
 ```bash
@@ -379,7 +383,11 @@ openclaw gateway probe --json
   </Accordion>
   <Accordion title="Common warning codes">
     - `ssh_tunnel_failed`: SSH tunnel setup failed; the command fell back to direct probes.
+<<<<<<< HEAD
     - `multiple_gateways`: more than one distinct gateway identity or logical port was reachable; alternate transports to the same gateway are deduped before this warning is emitted.
+=======
+    - `multiple_gateways`: distinct gateway identities were reachable, or OpenClaw could not prove reachable targets are the same gateway. An SSH tunnel plus configured remote URL to the same gateway does not trigger this warning.
+>>>>>>> 226af531e35 (docs(gateway): clarify multiple gateway identity warnings)
     - `auth_secretref_unresolved`: a configured auth SecretRef could not be resolved for a failed target.
     - `probe_scope_limited`: WebSocket connect succeeded, but the read probe was limited by missing `operator.read`.
 

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -158,7 +158,7 @@ All query commands use WebSocket RPC.
 </Tabs>
 
 <Note>
-When you set `--url`, the CLI does not fall back to config or environment credentials. Pass `--token` or `--password` explicitly. Missing explicit credentials is an error.
+When you set --url, the CLI does not fall back to config or environment credentials. Pass --token or --password explicitly. Missing explicit credentials is an error.
 </Note>
 
 ### `gateway health`
@@ -334,15 +334,7 @@ If you pass `--url`, that explicit target is added ahead of both. Human output l
 - `Local loopback`
 
 <Note>
-<<<<<<< HEAD
-<<<<<<< HEAD
-If multiple distinct gateways are reachable, it prints all of them. Probe dedupes alternate transports that report the same gateway identity and logical port, such as an SSH tunnel plus the configured remote URL for the same gateway. Multiple gateways are supported when you use isolated profiles/ports (e.g., a rescue bot), but most installs still run a single gateway.
-=======
-If multiple probe targets are reachable, it prints all of them. An SSH tunnel and the configured remote URL can both point at the same gateway; `multiple_gateways` is reserved for distinct or identity-ambiguous reachable gateways. Multiple gateways are supported when you use isolated profiles/ports (e.g., a rescue bot), but most installs still run a single gateway.
->>>>>>> 226af531e35 (docs(gateway): clarify multiple gateway identity warnings)
-=======
-If multiple probe targets are reachable, it prints all of them. An SSH tunnel, TLS/proxy URL, and configured remote URL can all point at the same gateway even when their transport ports differ; `multiple_gateways` is reserved for distinct or identity-ambiguous reachable gateways. Multiple gateways are supported when you use isolated profiles (e.g., a rescue bot), but most installs still run a single gateway.
->>>>>>> 01476e23efa (fix(gateway): ignore transport port for self identity)
+If multiple probe targets are reachable, it prints all of them. An SSH tunnel, TLS/proxy URL, and configured remote URL can all point at the same gateway even when their transport ports differ; multiple_gateways is reserved for distinct or identity-ambiguous reachable gateways. Multiple gateways are supported when you use isolated profiles (e.g., a rescue bot), but most installs still run a single gateway.
 </Note>
 
 ```bash
@@ -386,18 +378,10 @@ openclaw gateway probe --json
 
   </Accordion>
   <Accordion title="Common warning codes">
-    - `ssh_tunnel_failed`: SSH tunnel setup failed; the command fell back to direct probes.
-<<<<<<< HEAD
-<<<<<<< HEAD
-    - `multiple_gateways`: more than one distinct gateway identity or logical port was reachable; alternate transports to the same gateway are deduped before this warning is emitted.
-=======
-    - `multiple_gateways`: distinct gateway identities were reachable, or OpenClaw could not prove reachable targets are the same gateway. An SSH tunnel plus configured remote URL to the same gateway does not trigger this warning.
->>>>>>> 226af531e35 (docs(gateway): clarify multiple gateway identity warnings)
-=======
-    - `multiple_gateways`: distinct gateway identities were reachable, or OpenClaw could not prove reachable targets are the same gateway. An SSH tunnel, proxy URL, or configured remote URL to the same gateway does not trigger this warning.
->>>>>>> 01476e23efa (fix(gateway): ignore transport port for self identity)
-    - `auth_secretref_unresolved`: a configured auth SecretRef could not be resolved for a failed target.
-    - `probe_scope_limited`: WebSocket connect succeeded, but the read probe was limited by missing `operator.read`.
+    - ssh_tunnel_failed: SSH tunnel setup failed; the command fell back to direct probes.
+    - multiple_gateways: distinct gateway identities were reachable, or OpenClaw could not prove reachable targets are the same gateway. An SSH tunnel, proxy URL, or configured remote URL to the same gateway does not trigger this warning.
+    - auth_secretref_unresolved: a configured auth SecretRef could not be resolved for a failed target.
+    - probe_scope_limited: WebSocket connect succeeded, but the read probe was limited by missing operator.read.
 
   </Accordion>
 </AccordionGroup>

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -158,7 +158,7 @@ All query commands use WebSocket RPC.
 </Tabs>
 
 <Note>
-When you set --url, the CLI does not fall back to config or environment credentials. Pass --token or --password explicitly. Missing explicit credentials is an error.
+When you set `--url`, the CLI does not fall back to config or environment credentials. Pass `--token` or `--password` explicitly. Missing explicit credentials is an error.
 </Note>
 
 ### `gateway health`
@@ -334,7 +334,7 @@ If you pass `--url`, that explicit target is added ahead of both. Human output l
 - `Local loopback`
 
 <Note>
-If multiple probe targets are reachable, it prints all of them. An SSH tunnel, TLS/proxy URL, and configured remote URL can all point at the same gateway even when their transport ports differ; multiple_gateways is reserved for distinct or identity-ambiguous reachable gateways. Multiple gateways are supported when you use isolated profiles (e.g., a rescue bot), but most installs still run a single gateway.
+If multiple probe targets are reachable, it prints all of them. An SSH tunnel, TLS/proxy URL, and configured remote URL can all point at the same gateway even when their transport ports differ; `multiple_gateways` is reserved for distinct or identity-ambiguous reachable gateways. Multiple gateways are supported when you use isolated profiles (e.g., a rescue bot), but most installs still run a single gateway.
 </Note>
 
 ```bash
@@ -378,10 +378,10 @@ openclaw gateway probe --json
 
   </Accordion>
   <Accordion title="Common warning codes">
-    - ssh_tunnel_failed: SSH tunnel setup failed; the command fell back to direct probes.
-    - multiple_gateways: distinct gateway identities were reachable, or OpenClaw could not prove reachable targets are the same gateway. An SSH tunnel, proxy URL, or configured remote URL to the same gateway does not trigger this warning.
-    - auth_secretref_unresolved: a configured auth SecretRef could not be resolved for a failed target.
-    - probe_scope_limited: WebSocket connect succeeded, but the read probe was limited by missing operator.read.
+    - `ssh_tunnel_failed`: SSH tunnel setup failed; the command fell back to direct probes.
+    - `multiple_gateways`: distinct gateway identities were reachable, or OpenClaw could not prove reachable targets are the same gateway. An SSH tunnel, proxy URL, or configured remote URL to the same gateway does not trigger this warning.
+    - `auth_secretref_unresolved`: a configured auth SecretRef could not be resolved for a failed target.
+    - `probe_scope_limited`: WebSocket connect succeeded, but the read probe was limited by missing `operator.read`.
 
   </Accordion>
 </AccordionGroup>

--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -167,8 +167,10 @@ What to expect:
 
 - `gateway status --deep` can report `Other gateway-like services detected (best effort)`
   and print cleanup hints when stale launchd/systemd/schtasks installs are still around.
-- `gateway probe` can warn about `multiple reachable gateways` when more than one target
-  answers.
+- `gateway probe` can warn about `multiple reachable gateway identities` when distinct
+  gateways answer, or when OpenClaw cannot prove reachable targets are the same gateway.
+  An SSH tunnel plus configured remote URL to the same gateway is one gateway with
+  multiple transports.
 - If that is intentional, isolate ports, config/state, and workspace roots per gateway.
 
 Checklist per instance:

--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -169,8 +169,8 @@ What to expect:
   and print cleanup hints when stale launchd/systemd/schtasks installs are still around.
 - `gateway probe` can warn about `multiple reachable gateway identities` when distinct
   gateways answer, or when OpenClaw cannot prove reachable targets are the same gateway.
-  An SSH tunnel plus configured remote URL to the same gateway is one gateway with
-  multiple transports.
+  An SSH tunnel, proxy URL, or configured remote URL to the same gateway is one
+  gateway with multiple transports, even when transport ports differ.
 - If that is intentional, isolate ports, config/state, and workspace roots per gateway.
 
 Checklist per instance:

--- a/docs/gateway/multiple-gateways.md
+++ b/docs/gateway/multiple-gateways.md
@@ -169,7 +169,7 @@ openclaw --profile rescue browser status
 Interpretation:
 
 - `gateway status --deep` helps catch stale launchd/systemd/schtasks services from older installs.
-- `gateway probe` warning text such as `multiple reachable gateways detected` is expected only when you intentionally run more than one isolated gateway.
+- `gateway probe` warning text such as `multiple reachable gateway identities detected` is expected only when you intentionally run more than one isolated gateway, or when OpenClaw cannot prove reachable probe targets are the same gateway. An SSH tunnel plus configured remote URL to the same gateway is one gateway with multiple transports.
 
 ## Related
 

--- a/docs/gateway/multiple-gateways.md
+++ b/docs/gateway/multiple-gateways.md
@@ -169,7 +169,7 @@ openclaw --profile rescue browser status
 Interpretation:
 
 - `gateway status --deep` helps catch stale launchd/systemd/schtasks services from older installs.
-- `gateway probe` warning text such as `multiple reachable gateway identities detected` is expected only when you intentionally run more than one isolated gateway, or when OpenClaw cannot prove reachable probe targets are the same gateway. An SSH tunnel plus configured remote URL to the same gateway is one gateway with multiple transports.
+- `gateway probe` warning text such as `multiple reachable gateway identities detected` is expected only when you intentionally run more than one isolated gateway, or when OpenClaw cannot prove reachable probe targets are the same gateway. An SSH tunnel, proxy URL, or configured remote URL to the same gateway is one gateway with multiple transports, even when transport ports differ.
 
 ## Related
 

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -625,7 +625,7 @@ Look for:
 Common signatures:
 
 - `SSH tunnel failed to start; falling back to direct probes.` → SSH setup failed, but the command still tried direct configured/loopback targets.
-- `multiple reachable gateways detected` → more than one target answered. Usually this means an intentional multi-gateway setup or stale/duplicate listeners.
+- `multiple reachable gateways detected` → more than one distinct gateway identity or logical port answered. Alternate transports to the same gateway, such as an SSH tunnel plus the configured remote URL, are deduped before this warning is emitted. Usually this means an intentional multi-gateway setup or stale/duplicate listeners.
 - `Read-probe diagnostics are limited by gateway scopes (missing operator.read)` → connect worked, but detail RPC is scope-limited; pair device identity or use credentials with `operator.read`.
 - `Gateway accepted the WebSocket connection, but follow-up read diagnostics failed` → connect worked, but the full diagnostic RPC set timed out or failed. Treat this as a reachable Gateway with degraded diagnostics; compare `connect.ok` and `connect.rpcOk` in `--json` output.
 - `Capability: pairing-pending` or `gateway closed (1008): pairing required` → the gateway answered, but this client still needs pairing/approval before normal operator access.

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -626,10 +626,14 @@ Common signatures:
 
 - `SSH tunnel failed to start; falling back to direct probes.` → SSH setup failed, but the command still tried direct configured/loopback targets.
 <<<<<<< HEAD
+<<<<<<< HEAD
 - `multiple reachable gateways detected` → more than one distinct gateway identity or logical port answered. Alternate transports to the same gateway, such as an SSH tunnel plus the configured remote URL, are deduped before this warning is emitted. Usually this means an intentional multi-gateway setup or stale/duplicate listeners.
 =======
 - `multiple reachable gateway identities detected` → distinct gateways answered, or OpenClaw could not prove reachable targets are the same gateway. An SSH tunnel plus configured remote URL to the same gateway is treated as one gateway with multiple transports.
 >>>>>>> 226af531e35 (docs(gateway): clarify multiple gateway identity warnings)
+=======
+- `multiple reachable gateway identities detected` → distinct gateways answered, or OpenClaw could not prove reachable targets are the same gateway. An SSH tunnel, proxy URL, or configured remote URL to the same gateway is treated as one gateway with multiple transports, even when transport ports differ.
+>>>>>>> 01476e23efa (fix(gateway): ignore transport port for self identity)
 - `Read-probe diagnostics are limited by gateway scopes (missing operator.read)` → connect worked, but detail RPC is scope-limited; pair device identity or use credentials with `operator.read`.
 - `Gateway accepted the WebSocket connection, but follow-up read diagnostics failed` → connect worked, but the full diagnostic RPC set timed out or failed. Treat this as a reachable Gateway with degraded diagnostics; compare `connect.ok` and `connect.rpcOk` in `--json` output.
 - `Capability: pairing-pending` or `gateway closed (1008): pairing required` → the gateway answered, but this client still needs pairing/approval before normal operator access.

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -625,7 +625,11 @@ Look for:
 Common signatures:
 
 - `SSH tunnel failed to start; falling back to direct probes.` → SSH setup failed, but the command still tried direct configured/loopback targets.
+<<<<<<< HEAD
 - `multiple reachable gateways detected` → more than one distinct gateway identity or logical port answered. Alternate transports to the same gateway, such as an SSH tunnel plus the configured remote URL, are deduped before this warning is emitted. Usually this means an intentional multi-gateway setup or stale/duplicate listeners.
+=======
+- `multiple reachable gateway identities detected` → distinct gateways answered, or OpenClaw could not prove reachable targets are the same gateway. An SSH tunnel plus configured remote URL to the same gateway is treated as one gateway with multiple transports.
+>>>>>>> 226af531e35 (docs(gateway): clarify multiple gateway identity warnings)
 - `Read-probe diagnostics are limited by gateway scopes (missing operator.read)` → connect worked, but detail RPC is scope-limited; pair device identity or use credentials with `operator.read`.
 - `Gateway accepted the WebSocket connection, but follow-up read diagnostics failed` → connect worked, but the full diagnostic RPC set timed out or failed. Treat this as a reachable Gateway with degraded diagnostics; compare `connect.ok` and `connect.rpcOk` in `--json` output.
 - `Capability: pairing-pending` or `gateway closed (1008): pairing required` → the gateway answered, but this client still needs pairing/approval before normal operator access.

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -625,7 +625,7 @@ Look for:
 Common signatures:
 
 - `SSH tunnel failed to start; falling back to direct probes.` → SSH setup failed, but the command still tried direct configured/loopback targets.
-- multiple reachable gateway identities detected -> distinct gateways answered, or OpenClaw could not prove reachable targets are the same gateway. An SSH tunnel, proxy URL, or configured remote URL to the same gateway is treated as one gateway with multiple transports, even when transport ports differ.
+- `multiple reachable gateway identities detected` → distinct gateways answered, or OpenClaw could not prove reachable targets are the same gateway. An SSH tunnel, proxy URL, or configured remote URL to the same gateway is treated as one gateway with multiple transports, even when transport ports differ.
 - `Read-probe diagnostics are limited by gateway scopes (missing operator.read)` → connect worked, but detail RPC is scope-limited; pair device identity or use credentials with `operator.read`.
 - `Gateway accepted the WebSocket connection, but follow-up read diagnostics failed` → connect worked, but the full diagnostic RPC set timed out or failed. Treat this as a reachable Gateway with degraded diagnostics; compare `connect.ok` and `connect.rpcOk` in `--json` output.
 - `Capability: pairing-pending` or `gateway closed (1008): pairing required` → the gateway answered, but this client still needs pairing/approval before normal operator access.

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -625,15 +625,7 @@ Look for:
 Common signatures:
 
 - `SSH tunnel failed to start; falling back to direct probes.` → SSH setup failed, but the command still tried direct configured/loopback targets.
-<<<<<<< HEAD
-<<<<<<< HEAD
-- `multiple reachable gateways detected` → more than one distinct gateway identity or logical port answered. Alternate transports to the same gateway, such as an SSH tunnel plus the configured remote URL, are deduped before this warning is emitted. Usually this means an intentional multi-gateway setup or stale/duplicate listeners.
-=======
-- `multiple reachable gateway identities detected` → distinct gateways answered, or OpenClaw could not prove reachable targets are the same gateway. An SSH tunnel plus configured remote URL to the same gateway is treated as one gateway with multiple transports.
->>>>>>> 226af531e35 (docs(gateway): clarify multiple gateway identity warnings)
-=======
-- `multiple reachable gateway identities detected` → distinct gateways answered, or OpenClaw could not prove reachable targets are the same gateway. An SSH tunnel, proxy URL, or configured remote URL to the same gateway is treated as one gateway with multiple transports, even when transport ports differ.
->>>>>>> 01476e23efa (fix(gateway): ignore transport port for self identity)
+- multiple reachable gateway identities detected -> distinct gateways answered, or OpenClaw could not prove reachable targets are the same gateway. An SSH tunnel, proxy URL, or configured remote URL to the same gateway is treated as one gateway with multiple transports, even when transport ports differ.
 - `Read-probe diagnostics are limited by gateway scopes (missing operator.read)` → connect worked, but detail RPC is scope-limited; pair device identity or use credentials with `operator.read`.
 - `Gateway accepted the WebSocket connection, but follow-up read diagnostics failed` → connect worked, but the full diagnostic RPC set timed out or failed. Treat this as a reachable Gateway with degraded diagnostics; compare `connect.ok` and `connect.rpcOk` in `--json` output.
 - `Capability: pairing-pending` or `gateway closed (1008): pairing required` → the gateway answered, but this client still needs pairing/approval before normal operator access.

--- a/src/commands/gateway-presence.test.ts
+++ b/src/commands/gateway-presence.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { pickGatewaySelfPresence } from "./gateway-presence.js";
+
+describe("pickGatewaySelfPresence", () => {
+  it("extracts host and ip from legacy gateway self text", () => {
+    expect(
+      pickGatewaySelfPresence([
+        {
+          text: "Gateway: gateway-host (192.0.2.10) · app 2026.5.22 · mode gateway · reason self",
+        },
+      ]),
+    ).toStrictEqual({
+      host: "gateway-host",
+      ip: "192.0.2.10",
+      version: undefined,
+      platform: undefined,
+    });
+  });
+
+  it("prefers structured gateway self fields over legacy text", () => {
+    expect(
+      pickGatewaySelfPresence([
+        {
+          text: "Gateway: legacy-host (192.0.2.10) · app 2026.5.22 · mode gateway · reason self",
+          host: "structured-host",
+          ip: "192.0.2.11",
+          version: "2026.5.23",
+          platform: "linux",
+          mode: "gateway",
+          reason: "self",
+        },
+      ]),
+    ).toStrictEqual({
+      host: "structured-host",
+      ip: "192.0.2.11",
+      version: "2026.5.23",
+      platform: "linux",
+    });
+  });
+});

--- a/src/commands/gateway-presence.ts
+++ b/src/commands/gateway-presence.ts
@@ -6,6 +6,8 @@ type GatewaySelfPresence = {
   ip?: string;
   version?: string;
   platform?: string;
+  deviceId?: string;
+  instanceId?: string;
 };
 
 function parseLegacyGatewaySelfText(text: string): Pick<GatewaySelfPresence, "host" | "ip"> {
@@ -34,10 +36,19 @@ export function pickGatewaySelfPresence(presence: unknown): GatewaySelfPresence 
     return null;
   }
   const legacy = typeof self.text === "string" ? parseLegacyGatewaySelfText(self.text) : {};
-  return {
+  const result: GatewaySelfPresence = {
     host: readStringValue(self.host) ?? legacy.host,
     ip: readStringValue(self.ip) ?? legacy.ip,
     version: readStringValue(self.version),
     platform: readStringValue(self.platform),
   };
+  const deviceId = readStringValue(self.deviceId);
+  if (deviceId) {
+    result.deviceId = deviceId;
+  }
+  const instanceId = readStringValue(self.instanceId);
+  if (instanceId) {
+    result.instanceId = instanceId;
+  }
+  return result;
 }

--- a/src/commands/gateway-presence.ts
+++ b/src/commands/gateway-presence.ts
@@ -8,6 +8,17 @@ type GatewaySelfPresence = {
   platform?: string;
 };
 
+function parseLegacyGatewaySelfText(text: string): Pick<GatewaySelfPresence, "host" | "ip"> {
+  const match = text.match(/^Gateway:\s*([^ (·]+)(?:\s*\(([^)]+)\))?/i);
+  if (!match) {
+    return {};
+  }
+  return {
+    host: readStringValue(match[1]),
+    ip: readStringValue(match[2]),
+  };
+}
+
 /** Picks host, ip, version, and platform from the gateway self presence record. */
 export function pickGatewaySelfPresence(presence: unknown): GatewaySelfPresence | null {
   if (!Array.isArray(presence)) {
@@ -22,9 +33,10 @@ export function pickGatewaySelfPresence(presence: unknown): GatewaySelfPresence 
   if (!self) {
     return null;
   }
+  const legacy = typeof self.text === "string" ? parseLegacyGatewaySelfText(self.text) : {};
   return {
-    host: readStringValue(self.host),
-    ip: readStringValue(self.ip),
+    host: readStringValue(self.host) ?? legacy.host,
+    ip: readStringValue(self.ip) ?? legacy.ip,
     version: readStringValue(self.version),
     platform: readStringValue(self.platform),
   };

--- a/src/commands/gateway-status/output.test.ts
+++ b/src/commands/gateway-status/output.test.ts
@@ -92,6 +92,7 @@ function createReachableTarget(
   id: string,
   self: GatewayStatusProbedTarget["self"],
   target?: Partial<GatewayStatusProbedTarget["target"]>,
+  configPath = "/tmp/openclaw/config.json",
 ): GatewayStatusProbedTarget {
   const probe = createProbe("admin_capable", {
     ok: true,
@@ -108,6 +109,30 @@ function createReachableTarget(
       ...target,
     },
     self,
+    configSummary: {
+      path: configPath,
+      exists: true,
+      valid: true,
+      issues: [],
+      legacyIssues: [],
+      gateway: {
+        mode: null,
+        bind: null,
+        port: null,
+        controlUiEnabled: null,
+        controlUiBasePath: null,
+        authMode: null,
+        authTokenConfigured: false,
+        authPasswordConfigured: false,
+        remoteUrl: null,
+        remoteTokenConfigured: false,
+        remotePasswordConfigured: false,
+        tailscaleMode: null,
+      },
+      discovery: {
+        wideAreaEnabled: null,
+      },
+    },
   };
 }
 
@@ -213,6 +238,48 @@ describe("gateway status output", () => {
     });
 
     expect(warnings.find((entry) => entry.code === "multiple_gateways")).toBeUndefined();
+  });
+
+  it("warns when same-host reachable probes have different gateway config identities", () => {
+    const self = {
+      host: "gateway-host",
+      ip: "192.0.2.10",
+      version: "2026.5.22",
+      platform: "linux",
+    };
+    const warnings = buildGatewayStatusWarnings({
+      probed: [
+        createReachableTarget(
+          "localLoopback",
+          self,
+          {
+            kind: "localLoopback",
+            url: "ws://127.0.0.1:18789",
+          },
+          "/tmp/openclaw-main/config.json",
+        ),
+        createReachableTarget(
+          "explicit",
+          self,
+          {
+            kind: "explicit",
+            url: "ws://gateway-host:28789",
+          },
+          "/tmp/openclaw-rescue/config.json",
+        ),
+      ],
+      sshTarget: null,
+      sshTunnelStarted: false,
+      sshTunnelError: null,
+      discoveryCount: 0,
+    });
+
+    expect(warnings.find((entry) => entry.code === "multiple_gateways")).toStrictEqual({
+      code: "multiple_gateways",
+      message:
+        "Unconventional setup: multiple reachable gateway identities detected. Usually one gateway per network is recommended unless you intentionally run isolated profiles, like a rescue bot (see docs: /gateway#multiple-gateways-same-host).",
+      targetIds: ["localLoopback", "explicit"],
+    });
   });
 
   it("warns about multiple gateways when reachable probes report distinct identities", () => {

--- a/src/commands/gateway-status/output.test.ts
+++ b/src/commands/gateway-status/output.test.ts
@@ -215,7 +215,7 @@ describe("gateway status output", () => {
     expect(warnings.find((entry) => entry.code === "multiple_gateways")).toStrictEqual({
       code: "multiple_gateways",
       message:
-        "Unconventional setup: multiple reachable gateways detected. Usually one gateway per network is recommended unless you intentionally run isolated profiles, like a rescue bot (see docs: /gateway#multiple-gateways-same-host).",
+        "Unconventional setup: multiple reachable gateway identities detected. Usually one gateway per network is recommended unless you intentionally run isolated profiles, like a rescue bot (see docs: /gateway#multiple-gateways-same-host).",
       targetIds: ["localLoopback", "explicit"],
     });
   });
@@ -245,7 +245,7 @@ describe("gateway status output", () => {
     expect(warnings.find((entry) => entry.code === "multiple_gateways")).toStrictEqual({
       code: "multiple_gateways",
       message:
-        "Unconventional setup: multiple reachable gateways detected. Usually one gateway per network is recommended unless you intentionally run isolated profiles, like a rescue bot (see docs: /gateway#multiple-gateways-same-host).",
+        "Unconventional setup: multiple reachable gateway identities detected. Usually one gateway per network is recommended unless you intentionally run isolated profiles, like a rescue bot (see docs: /gateway#multiple-gateways-same-host).",
       targetIds: ["sshTunnel", "configRemote"],
     });
   });
@@ -265,7 +265,7 @@ describe("gateway status output", () => {
     expect(warnings.find((entry) => entry.code === "multiple_gateways")).toStrictEqual({
       code: "multiple_gateways",
       message:
-        "Unconventional setup: multiple reachable gateways detected. Usually one gateway per network is recommended unless you intentionally run isolated profiles, like a rescue bot (see docs: /gateway#multiple-gateways-same-host).",
+        "Unconventional setup: multiple reachable gateway identities detected. Usually one gateway per network is recommended unless you intentionally run isolated profiles, like a rescue bot (see docs: /gateway#multiple-gateways-same-host).",
       targetIds: ["sshTunnel", "configRemote"],
     });
   });

--- a/src/commands/gateway-status/output.test.ts
+++ b/src/commands/gateway-status/output.test.ts
@@ -188,7 +188,7 @@ describe("gateway status output", () => {
     expect(warnings.find((entry) => entry.code === "multiple_gateways")).toBeUndefined();
   });
 
-  it("warns about multiple gateways when same-host reachable probes use different gateway ports", () => {
+  it("does not warn when the same gateway identity is reached through different transport ports", () => {
     const self = {
       host: "gateway-host",
       ip: "192.0.2.10",
@@ -212,12 +212,7 @@ describe("gateway status output", () => {
       discoveryCount: 0,
     });
 
-    expect(warnings.find((entry) => entry.code === "multiple_gateways")).toStrictEqual({
-      code: "multiple_gateways",
-      message:
-        "Unconventional setup: multiple reachable gateway identities detected. Usually one gateway per network is recommended unless you intentionally run isolated profiles, like a rescue bot (see docs: /gateway#multiple-gateways-same-host).",
-      targetIds: ["localLoopback", "explicit"],
-    });
+    expect(warnings.find((entry) => entry.code === "multiple_gateways")).toBeUndefined();
   });
 
   it("warns about multiple gateways when reachable probes report distinct identities", () => {

--- a/src/commands/gateway-status/output.test.ts
+++ b/src/commands/gateway-status/output.test.ts
@@ -136,6 +136,27 @@ function createReachableTarget(
   };
 }
 
+const MULTIPLE_GATEWAYS_WARNING = {
+  code: "multiple_gateways",
+  message:
+    "Unconventional setup: multiple reachable gateway identities detected. Usually one gateway per network is recommended unless you intentionally run isolated profiles, like a rescue bot (see docs: /gateway#multiple-gateways-same-host).",
+};
+
+const GATEWAY_SELF = {
+  host: "gateway-host",
+  ip: "192.0.2.10",
+  version: "2026.5.22",
+  platform: "linux",
+  instanceId: "gateway-instance-1",
+};
+
+const GATEWAY_SELF_NO_PROCESS_ID = {
+  host: "gateway-host",
+  ip: "192.0.2.10",
+  version: "2026.5.22",
+  platform: "linux",
+};
+
 describe("gateway status output", () => {
   beforeEach(() => {
     mocks.writeRuntimeJson.mockReset();
@@ -167,162 +188,111 @@ describe("gateway status output", () => {
     });
   });
 
-  it("does not warn about multiple gateways when reachable probes share a gateway identity", () => {
-    const warnings = buildGatewayStatusWarnings({
+  it.each([
+    {
+      name: "suppresses warning for SSH tunnel and configured remote with the same self identity",
       probed: [
-        createReachableTarget(
-          "sshTunnel",
-          {
-            host: "gateway-host",
-            ip: "192.0.2.10",
-            version: "2026.5.22",
-            platform: "linux",
-            instanceId: "gateway-instance-1",
+        createReachableTarget("sshTunnel", GATEWAY_SELF, {
+          kind: "sshTunnel",
+          url: "ws://127.0.0.1:18789",
+          tunnel: {
+            kind: "ssh",
+            target: "user@gateway-host",
+            localPort: 18789,
+            remotePort: 18789,
+            pid: 1234,
           },
-          {
-            kind: "sshTunnel",
-            url: "ws://127.0.0.1:18789",
-            tunnel: {
-              kind: "ssh",
-              target: "user@gateway-host",
-              localPort: 18789,
-              remotePort: 18789,
-              pid: 1234,
-            },
-          },
-        ),
+        }),
         createReachableTarget(
           "configRemote",
           {
-            host: "GATEWAY-HOST",
-            ip: "192.0.2.10",
-            version: "2026.5.22",
-            platform: "linux",
-            instanceId: "gateway-instance-1",
+            ...GATEWAY_SELF,
+            host: GATEWAY_SELF.host.toUpperCase(),
           },
-          {
-            kind: "configRemote",
-            url: "ws://gateway-host:18789",
-          },
+          { kind: "configRemote", url: "ws://gateway-host:18789" },
         ),
       ],
       sshTarget: "user@gateway-host",
-      sshTunnelStarted: true,
-      sshTunnelError: null,
-      discoveryCount: 0,
-    });
-
-    expect(warnings.find((entry) => entry.code === "multiple_gateways")).toBeUndefined();
-  });
-
-  it("does not warn when the same gateway identity is reached through different transport ports", () => {
-    const self = {
-      host: "gateway-host",
-      ip: "192.0.2.10",
-      version: "2026.5.22",
-      platform: "linux",
-      instanceId: "gateway-instance-1",
-    };
-    const warnings = buildGatewayStatusWarnings({
+      expectedTargetIds: null,
+    },
+    {
+      name: "suppresses warning for the same self identity on different transport ports",
       probed: [
-        createReachableTarget("localLoopback", self, {
+        createReachableTarget("localLoopback", GATEWAY_SELF, {
           kind: "localLoopback",
           url: "ws://127.0.0.1:18789",
         }),
-        createReachableTarget("explicit", self, {
+        createReachableTarget("explicit", GATEWAY_SELF, {
           kind: "explicit",
           url: "ws://gateway-host:28789",
         }),
       ],
       sshTarget: null,
-      sshTunnelStarted: false,
-      sshTunnelError: null,
-      discoveryCount: 0,
-    });
-
-    expect(warnings.find((entry) => entry.code === "multiple_gateways")).toBeUndefined();
-  });
-
-  it("warns when same-host reachable probes do not report a process identity", () => {
-    const self = {
-      host: "gateway-host",
-      ip: "192.0.2.10",
-      version: "2026.5.22",
-      platform: "linux",
-    };
-    const warnings = buildGatewayStatusWarnings({
+      expectedTargetIds: null,
+    },
+    {
+      name: "warns when same-host probes do not report process identity",
       probed: [
-        createReachableTarget("localLoopback", self, {
+        createReachableTarget("localLoopback", GATEWAY_SELF_NO_PROCESS_ID, {
           kind: "localLoopback",
           url: "ws://127.0.0.1:18789",
         }),
-        createReachableTarget("explicit", self, {
+        createReachableTarget("explicit", GATEWAY_SELF_NO_PROCESS_ID, {
           kind: "explicit",
           url: "ws://gateway-host:28789",
         }),
       ],
       sshTarget: null,
-      sshTunnelStarted: false,
-      sshTunnelError: null,
-      discoveryCount: 0,
-    });
-
-    expect(warnings.find((entry) => entry.code === "multiple_gateways")).toStrictEqual({
-      code: "multiple_gateways",
-      message:
-        "Unconventional setup: multiple reachable gateway identities detected. Usually one gateway per network is recommended unless you intentionally run isolated profiles, like a rescue bot (see docs: /gateway#multiple-gateways-same-host).",
-      targetIds: ["localLoopback", "explicit"],
-    });
-  });
-
-  it("warns about multiple gateways when reachable probes report distinct identities", () => {
-    const warnings = buildGatewayStatusWarnings({
+      expectedTargetIds: ["localLoopback", "explicit"],
+    },
+    {
+      name: "warns when probes report distinct identities",
       probed: [
         createReachableTarget("sshTunnel", {
           host: "gateway-a",
           ip: "192.0.2.10",
           version: "2026.5.22",
           platform: "linux",
+          instanceId: "gateway-instance-a",
         }),
         createReachableTarget("configRemote", {
           host: "gateway-b",
           ip: "192.0.2.11",
           version: "2026.5.22",
           platform: "linux",
+          instanceId: "gateway-instance-b",
         }),
       ],
       sshTarget: "user@gateway-a",
-      sshTunnelStarted: true,
-      sshTunnelError: null,
-      discoveryCount: 0,
-    });
-
-    expect(warnings.find((entry) => entry.code === "multiple_gateways")).toStrictEqual({
-      code: "multiple_gateways",
-      message:
-        "Unconventional setup: multiple reachable gateway identities detected. Usually one gateway per network is recommended unless you intentionally run isolated profiles, like a rescue bot (see docs: /gateway#multiple-gateways-same-host).",
-      targetIds: ["sshTunnel", "configRemote"],
-    });
-  });
-
-  it("keeps the multiple gateways warning when reachable probe identity is unknown", () => {
-    const warnings = buildGatewayStatusWarnings({
+      expectedTargetIds: ["sshTunnel", "configRemote"],
+    },
+    {
+      name: "warns when probe identity is unknown",
       probed: [
         createReachableTarget("sshTunnel", null),
         createReachableTarget("configRemote", null),
       ],
       sshTarget: "user@gateway-host",
-      sshTunnelStarted: true,
+      expectedTargetIds: ["sshTunnel", "configRemote"],
+    },
+  ])("$name", ({ probed, sshTarget, expectedTargetIds }) => {
+    const warnings = buildGatewayStatusWarnings({
+      probed,
+      sshTarget,
+      sshTunnelStarted: sshTarget !== null,
       sshTunnelError: null,
       discoveryCount: 0,
     });
+    const warning = warnings.find((entry) => entry.code === "multiple_gateways");
 
-    expect(warnings.find((entry) => entry.code === "multiple_gateways")).toStrictEqual({
-      code: "multiple_gateways",
-      message:
-        "Unconventional setup: multiple reachable gateway identities detected. Usually one gateway per network is recommended unless you intentionally run isolated profiles, like a rescue bot (see docs: /gateway#multiple-gateways-same-host).",
-      targetIds: ["sshTunnel", "configRemote"],
-    });
+    if (expectedTargetIds === null) {
+      expect(warning).toBeUndefined();
+    } else {
+      expect(warning).toStrictEqual({
+        ...MULTIPLE_GATEWAYS_WARNING,
+        targetIds: expectedTargetIds,
+      });
+    }
   });
 
   it("derives summary capability from reachable probes only in json output", () => {

--- a/src/commands/gateway-status/output.test.ts
+++ b/src/commands/gateway-status/output.test.ts
@@ -88,6 +88,29 @@ function createTarget(id: string, probe: GatewayProbeResult): GatewayStatusProbe
   };
 }
 
+function createReachableTarget(
+  id: string,
+  self: GatewayStatusProbedTarget["self"],
+  target?: Partial<GatewayStatusProbedTarget["target"]>,
+): GatewayStatusProbedTarget {
+  const probe = createProbe("admin_capable", {
+    ok: true,
+    connectLatencyMs: 20,
+  });
+  if (target?.url) {
+    probe.url = target.url;
+  }
+  const base = createTarget(id, probe);
+  return {
+    ...base,
+    target: {
+      ...base.target,
+      ...target,
+    },
+    self,
+  };
+}
+
 describe("gateway status output", () => {
   beforeEach(() => {
     mocks.writeRuntimeJson.mockReset();
@@ -116,6 +139,134 @@ describe("gateway status output", () => {
       message:
         "No gateway answered any probe and Bonjour discovery returned no local gateways. Run `openclaw gateway status --deep --require-rpc` to inspect service state, config paths, listener owners, and logs; include `ss -ltnp` or `lsof -nP -iTCP:<port> -sTCP:LISTEN` for the configured port when filing a report.",
       targetIds: ["localLoopback"],
+    });
+  });
+
+  it("does not warn about multiple gateways when reachable probes share a gateway identity", () => {
+    const warnings = buildGatewayStatusWarnings({
+      probed: [
+        createReachableTarget(
+          "sshTunnel",
+          {
+            host: "gateway-host",
+            ip: "192.0.2.10",
+            version: "2026.5.22",
+            platform: "linux",
+          },
+          {
+            kind: "sshTunnel",
+            url: "ws://127.0.0.1:18789",
+            tunnel: {
+              kind: "ssh",
+              target: "user@gateway-host",
+              localPort: 18789,
+              remotePort: 18789,
+              pid: 1234,
+            },
+          },
+        ),
+        createReachableTarget(
+          "configRemote",
+          {
+            host: "GATEWAY-HOST",
+            ip: "192.0.2.10",
+            version: "2026.5.22",
+            platform: "linux",
+          },
+          {
+            kind: "configRemote",
+            url: "ws://gateway-host:18789",
+          },
+        ),
+      ],
+      sshTarget: "user@gateway-host",
+      sshTunnelStarted: true,
+      sshTunnelError: null,
+      discoveryCount: 0,
+    });
+
+    expect(warnings.find((entry) => entry.code === "multiple_gateways")).toBeUndefined();
+  });
+
+  it("warns about multiple gateways when same-host reachable probes use different gateway ports", () => {
+    const self = {
+      host: "gateway-host",
+      ip: "192.0.2.10",
+      version: "2026.5.22",
+      platform: "linux",
+    };
+    const warnings = buildGatewayStatusWarnings({
+      probed: [
+        createReachableTarget("localLoopback", self, {
+          kind: "localLoopback",
+          url: "ws://127.0.0.1:18789",
+        }),
+        createReachableTarget("explicit", self, {
+          kind: "explicit",
+          url: "ws://gateway-host:28789",
+        }),
+      ],
+      sshTarget: null,
+      sshTunnelStarted: false,
+      sshTunnelError: null,
+      discoveryCount: 0,
+    });
+
+    expect(warnings.find((entry) => entry.code === "multiple_gateways")).toStrictEqual({
+      code: "multiple_gateways",
+      message:
+        "Unconventional setup: multiple reachable gateways detected. Usually one gateway per network is recommended unless you intentionally run isolated profiles, like a rescue bot (see docs: /gateway#multiple-gateways-same-host).",
+      targetIds: ["localLoopback", "explicit"],
+    });
+  });
+
+  it("warns about multiple gateways when reachable probes report distinct identities", () => {
+    const warnings = buildGatewayStatusWarnings({
+      probed: [
+        createReachableTarget("sshTunnel", {
+          host: "gateway-a",
+          ip: "192.0.2.10",
+          version: "2026.5.22",
+          platform: "linux",
+        }),
+        createReachableTarget("configRemote", {
+          host: "gateway-b",
+          ip: "192.0.2.11",
+          version: "2026.5.22",
+          platform: "linux",
+        }),
+      ],
+      sshTarget: "user@gateway-a",
+      sshTunnelStarted: true,
+      sshTunnelError: null,
+      discoveryCount: 0,
+    });
+
+    expect(warnings.find((entry) => entry.code === "multiple_gateways")).toStrictEqual({
+      code: "multiple_gateways",
+      message:
+        "Unconventional setup: multiple reachable gateways detected. Usually one gateway per network is recommended unless you intentionally run isolated profiles, like a rescue bot (see docs: /gateway#multiple-gateways-same-host).",
+      targetIds: ["sshTunnel", "configRemote"],
+    });
+  });
+
+  it("keeps the multiple gateways warning when reachable probe identity is unknown", () => {
+    const warnings = buildGatewayStatusWarnings({
+      probed: [
+        createReachableTarget("sshTunnel", null),
+        createReachableTarget("configRemote", null),
+      ],
+      sshTarget: "user@gateway-host",
+      sshTunnelStarted: true,
+      sshTunnelError: null,
+      discoveryCount: 0,
+    });
+
+    expect(warnings.find((entry) => entry.code === "multiple_gateways")).toStrictEqual({
+      code: "multiple_gateways",
+      message:
+        "Unconventional setup: multiple reachable gateways detected. Usually one gateway per network is recommended unless you intentionally run isolated profiles, like a rescue bot (see docs: /gateway#multiple-gateways-same-host).",
+      targetIds: ["sshTunnel", "configRemote"],
     });
   });
 

--- a/src/commands/gateway-status/output.test.ts
+++ b/src/commands/gateway-status/output.test.ts
@@ -177,6 +177,7 @@ describe("gateway status output", () => {
             ip: "192.0.2.10",
             version: "2026.5.22",
             platform: "linux",
+            instanceId: "gateway-instance-1",
           },
           {
             kind: "sshTunnel",
@@ -197,6 +198,7 @@ describe("gateway status output", () => {
             ip: "192.0.2.10",
             version: "2026.5.22",
             platform: "linux",
+            instanceId: "gateway-instance-1",
           },
           {
             kind: "configRemote",
@@ -219,6 +221,7 @@ describe("gateway status output", () => {
       ip: "192.0.2.10",
       version: "2026.5.22",
       platform: "linux",
+      instanceId: "gateway-instance-1",
     };
     const warnings = buildGatewayStatusWarnings({
       probed: [
@@ -240,7 +243,7 @@ describe("gateway status output", () => {
     expect(warnings.find((entry) => entry.code === "multiple_gateways")).toBeUndefined();
   });
 
-  it("warns when same-host reachable probes have different gateway config identities", () => {
+  it("warns when same-host reachable probes do not report a process identity", () => {
     const self = {
       host: "gateway-host",
       ip: "192.0.2.10",
@@ -249,24 +252,14 @@ describe("gateway status output", () => {
     };
     const warnings = buildGatewayStatusWarnings({
       probed: [
-        createReachableTarget(
-          "localLoopback",
-          self,
-          {
-            kind: "localLoopback",
-            url: "ws://127.0.0.1:18789",
-          },
-          "/tmp/openclaw-main/config.json",
-        ),
-        createReachableTarget(
-          "explicit",
-          self,
-          {
-            kind: "explicit",
-            url: "ws://gateway-host:28789",
-          },
-          "/tmp/openclaw-rescue/config.json",
-        ),
+        createReachableTarget("localLoopback", self, {
+          kind: "localLoopback",
+          url: "ws://127.0.0.1:18789",
+        }),
+        createReachableTarget("explicit", self, {
+          kind: "explicit",
+          url: "ws://gateway-host:28789",
+        }),
       ],
       sshTarget: null,
       sshTunnelStarted: false,

--- a/src/commands/gateway-status/output.ts
+++ b/src/commands/gateway-status/output.ts
@@ -34,9 +34,7 @@ function gatewaySelfIdentityKey(entry: GatewayStatusProbedTarget): string | null
       ? `instance:${entry.self.instanceId.trim().toLowerCase()}`
       : typeof entry.self.deviceId === "string" && entry.self.deviceId.trim()
         ? `device:${entry.self.deviceId.trim().toLowerCase()}`
-        : typeof entry.configSummary?.path === "string" && entry.configSummary.path.trim()
-          ? `config:${entry.configSummary.path.trim().toLowerCase()}`
-          : "";
+        : "";
   if ((!host && !ip) || !discriminator) {
     return null;
   }

--- a/src/commands/gateway-status/output.ts
+++ b/src/commands/gateway-status/output.ts
@@ -136,7 +136,7 @@ export function buildGatewayStatusWarnings(params: {
     warnings.push({
       code: "multiple_gateways",
       message:
-        "Unconventional setup: multiple reachable gateways detected. Usually one gateway per network is recommended unless you intentionally run isolated profiles, like a rescue bot (see docs: /gateway#multiple-gateways-same-host).",
+        "Unconventional setup: multiple reachable gateway identities detected. Usually one gateway per network is recommended unless you intentionally run isolated profiles, like a rescue bot (see docs: /gateway#multiple-gateways-same-host).",
       targetIds: reachable.map((entry) => entry.target.id),
     });
   }

--- a/src/commands/gateway-status/output.ts
+++ b/src/commands/gateway-status/output.ts
@@ -23,6 +23,45 @@ export type GatewayStatusWarning = {
 const noReachableGatewayDiagnostic =
   "No gateway answered any probe and Bonjour discovery returned no local gateways. Run `openclaw gateway status --deep --require-rpc` to inspect service state, config paths, listener owners, and logs; include `ss -ltnp` or `lsof -nP -iTCP:<port> -sTCP:LISTEN` for the configured port when filing a report.";
 
+function gatewayTargetPort(entry: GatewayStatusProbedTarget): string | null {
+  if (entry.target.kind === "sshTunnel") {
+    return String(entry.target.tunnel?.remotePort ?? "");
+  }
+  try {
+    const url = new URL(entry.target.url);
+    return url.port || (url.protocol === "wss:" ? "443" : url.protocol === "ws:" ? "80" : null);
+  } catch {
+    return null;
+  }
+}
+
+function gatewaySelfIdentityKey(entry: GatewayStatusProbedTarget): string | null {
+  if (!entry.self) {
+    return null;
+  }
+  const host = typeof entry.self.host === "string" ? entry.self.host.trim().toLowerCase() : "";
+  const ip = typeof entry.self.ip === "string" ? entry.self.ip.trim().toLowerCase() : "";
+  const port = gatewayTargetPort(entry);
+  if (!host && !ip) {
+    return null;
+  }
+  if (!port) {
+    return null;
+  }
+  return `${host}\0${ip}\0${port}`;
+}
+
+function hasMultipleReachableGatewayIdentities(reachable: GatewayStatusProbedTarget[]): boolean {
+  if (reachable.length <= 1) {
+    return false;
+  }
+  const identityKeys = reachable.map((entry) => gatewaySelfIdentityKey(entry));
+  if (identityKeys.some((key) => key === null)) {
+    return true;
+  }
+  return new Set(identityKeys).size > 1;
+}
+
 function readModelPricingDegradedDetail(health: unknown): string | null {
   if (!health || typeof health !== "object") {
     return null;
@@ -91,7 +130,7 @@ export function buildGatewayStatusWarnings(params: {
       targetIds: params.probed.map((entry) => entry.target.id),
     });
   }
-  if (reachable.length > 1) {
+  if (hasMultipleReachableGatewayIdentities(reachable)) {
     // Multiple reachable gateways are valid for isolated profiles but surprising
     // enough to call out before users debug against the wrong process.
     warnings.push({

--- a/src/commands/gateway-status/output.ts
+++ b/src/commands/gateway-status/output.ts
@@ -29,10 +29,18 @@ function gatewaySelfIdentityKey(entry: GatewayStatusProbedTarget): string | null
   }
   const host = typeof entry.self.host === "string" ? entry.self.host.trim().toLowerCase() : "";
   const ip = typeof entry.self.ip === "string" ? entry.self.ip.trim().toLowerCase() : "";
-  if (!host && !ip) {
+  const discriminator =
+    typeof entry.self.instanceId === "string" && entry.self.instanceId.trim()
+      ? `instance:${entry.self.instanceId.trim().toLowerCase()}`
+      : typeof entry.self.deviceId === "string" && entry.self.deviceId.trim()
+        ? `device:${entry.self.deviceId.trim().toLowerCase()}`
+        : typeof entry.configSummary?.path === "string" && entry.configSummary.path.trim()
+          ? `config:${entry.configSummary.path.trim().toLowerCase()}`
+          : "";
+  if ((!host && !ip) || !discriminator) {
     return null;
   }
-  return `${host}\0${ip}`;
+  return `${host}\0${ip}\0${discriminator}`;
 }
 
 function hasMultipleReachableGatewayIdentities(reachable: GatewayStatusProbedTarget[]): boolean {

--- a/src/commands/gateway-status/output.ts
+++ b/src/commands/gateway-status/output.ts
@@ -23,32 +23,16 @@ export type GatewayStatusWarning = {
 const noReachableGatewayDiagnostic =
   "No gateway answered any probe and Bonjour discovery returned no local gateways. Run `openclaw gateway status --deep --require-rpc` to inspect service state, config paths, listener owners, and logs; include `ss -ltnp` or `lsof -nP -iTCP:<port> -sTCP:LISTEN` for the configured port when filing a report.";
 
-function gatewayTargetPort(entry: GatewayStatusProbedTarget): string | null {
-  if (entry.target.kind === "sshTunnel") {
-    return String(entry.target.tunnel?.remotePort ?? "");
-  }
-  try {
-    const url = new URL(entry.target.url);
-    return url.port || (url.protocol === "wss:" ? "443" : url.protocol === "ws:" ? "80" : null);
-  } catch {
-    return null;
-  }
-}
-
 function gatewaySelfIdentityKey(entry: GatewayStatusProbedTarget): string | null {
   if (!entry.self) {
     return null;
   }
   const host = typeof entry.self.host === "string" ? entry.self.host.trim().toLowerCase() : "";
   const ip = typeof entry.self.ip === "string" ? entry.self.ip.trim().toLowerCase() : "";
-  const port = gatewayTargetPort(entry);
   if (!host && !ip) {
     return null;
   }
-  if (!port) {
-    return null;
-  }
-  return `${host}\0${ip}\0${port}`;
+  return `${host}\0${ip}`;
 }
 
 function hasMultipleReachableGatewayIdentities(reachable: GatewayStatusProbedTarget[]): boolean {

--- a/src/infra/system-presence.ts
+++ b/src/infra/system-presence.ts
@@ -1,5 +1,6 @@
 // Detects system command availability for setup and diagnostics.
 import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import os from "node:os";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -38,6 +39,7 @@ type SystemPresenceUpdate = {
 const entries = new Map<string, SystemPresence>();
 const TTL_MS = 5 * 60 * 1000; // 5 minutes
 const MAX_ENTRIES = 200;
+const SELF_INSTANCE_ID = randomUUID();
 
 function normalizePresenceKey(key: string | undefined): string | undefined {
   return normalizeOptionalLowercaseString(key);
@@ -103,6 +105,7 @@ function initSelfPresence() {
     modelIdentifier,
     mode: "gateway",
     reason: "self",
+    instanceId: SELF_INSTANCE_ID,
     text,
     ts: Date.now(),
   };


### PR DESCRIPTION
## Summary
- Rebase the gateway identity warning fix onto current `main`.
- Preserve the conservative same-host gateway warning behavior while deduping probe warnings by gateway identity.
- Restore inline-code formatting around changed gateway CLI flags, warning codes, and `operator.read` docs text per review feedback.
- No config, CLI, plugin API, or public surface changes.

## Validation
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/infra/system-presence.test.ts src/infra/system-presence.version.test.ts src/commands/gateway-presence.test.ts src/commands/gateway-status/output.test.ts --reporter=dot` (3 shards, 22 tests)
- `node_modules/oxfmt/bin/oxfmt --check --threads=1 src/infra/system-presence.ts docs/cli/gateway.md docs/gateway/index.md docs/gateway/multiple-gateways.md docs/gateway/troubleshooting.md src/commands/gateway-presence.test.ts src/commands/gateway-presence.ts src/commands/gateway-status/output.test.ts src/commands/gateway-status/output.ts`
- `node_modules/oxlint/bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/infra/system-presence.ts src/commands/gateway-presence.test.ts src/commands/gateway-presence.ts src/commands/gateway-status/output.test.ts src/commands/gateway-status/output.ts`
- `git diff --check origin/main...HEAD && git diff --check`

## Current Head
- Rebased on `main` at `69df4c9136173b7387d4cf79ccd9121c93d49932`.
- Signed head: `13e3c00f56`.