### PR TITLE
fix(tui): surface terminal lifecycle errors

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -302,6 +302,40 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(tui.requestRender).toHaveBeenCalled();
   });
 
+  it("surfaces terminal lifecycle errors and unlocks the active run", () => {
+    const { state, chatLog, tui, setActivityStatus, handleAgentEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-lifecycle-error", activityStatus: "streaming" },
+    });
+
+    handleAgentEvent({
+      runId: "run-lifecycle-error",
+      stream: "lifecycle",
+      data: { phase: "error", endedAt: Date.now(), error: "provider disconnected" },
+    });
+
+    expect(chatLog.dismissPendingSystem).toHaveBeenCalledWith("run-lifecycle-error");
+    expect(chatLog.addSystem).toHaveBeenCalledWith("run error: provider disconnected");
+    expect(state.activeChatRunId).toBeNull();
+    expect(setActivityStatus).toHaveBeenCalledWith("error");
+    expect(tui.requestRender).toHaveBeenCalled();
+  });
+
+  it("keeps retryable lifecycle errors active until a terminal lifecycle event arrives", () => {
+    const { state, chatLog, setActivityStatus, handleAgentEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-retryable", activityStatus: "streaming" },
+    });
+
+    handleAgentEvent({
+      runId: "run-retryable",
+      stream: "lifecycle",
+      data: { phase: "error", error: "primary model timed out" },
+    });
+
+    expect(chatLog.addSystem).not.toHaveBeenCalledWith("run error: primary model timed out");
+    expect(state.activeChatRunId).toBe("run-retryable");
+    expect(setActivityStatus).toHaveBeenCalledWith("error");
+  });
+
   it("shows finishing context for a known run after assistant final", () => {
     const { state, tui, setActivityStatus, handleChatEvent, handleAgentEvent } =
       createHandlersHarness({

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -225,6 +225,23 @@ export function createEventHandlers(context: EventHandlerContext) {
     return true;
   };
 
+  const readLifecycleErrorMessage = (evt: AgentEvent): string => {
+    const data = evt.data ?? {};
+    return asString(data.error, "") || asString(data.errorMessage, "") || "unknown";
+  };
+
+  const isTerminalLifecycleError = (evt: AgentEvent): boolean => {
+    if (evt.stream !== "lifecycle" || asString(evt.data?.phase, "") !== "error") {
+      return false;
+    }
+    return typeof evt.data?.endedAt === "number";
+  };
+
+  const renderRunError = (errorMessage: string) => {
+    const renderedError = formatRawAssistantErrorForUi(errorMessage);
+    return resolveAuthErrorHint(errorMessage) ?? `run error: ${renderedError}`;
+  };
+
   const noteSessionRun = (runId: string) => {
     sessionRuns.set(runId, Date.now());
     pruneRunMap(sessionRuns);
@@ -493,8 +510,7 @@ export function createEventHandlers(context: EventHandlerContext) {
       forgetLocalBtwRunId?.(evt.runId);
       const wasActiveRun = state.activeChatRunId === evt.runId;
       const errorMessage = evt.errorMessage ?? "unknown";
-      const renderedError = formatRawAssistantErrorForUi(errorMessage);
-      chatLog.addSystem(resolveAuthErrorHint(errorMessage) ?? `run error: ${renderedError}`);
+      chatLog.addSystem(renderRunError(errorMessage));
       terminateRun({ runId: evt.runId, wasActiveRun, status: "error" });
       maybeRefreshHistoryForRun(evt.runId);
     }
@@ -608,6 +624,15 @@ export function createEventHandlers(context: EventHandlerContext) {
       }
       if (phase === "error") {
         postFinalizingRuns.delete(evt.runId);
+        if (isTerminalLifecycleError(evt) && (isActiveRun || isPendingRun)) {
+          const wasActiveRun = state.activeChatRunId === evt.runId;
+          const errorMessage = readLifecycleErrorMessage(evt);
+          chatLog.dismissPendingSystem(evt.runId);
+          chatLog.addSystem(renderRunError(errorMessage));
+          terminateRun({ runId: evt.runId, wasActiveRun, status: "error" });
+          tui.requestRender();
+          return;
+        }
         if (!canUpdateActivityStatus) {
           return;
         }


### PR DESCRIPTION
## Summary

- Fix terminal TUI lifecycle `phase: "error"` events so they surface the run error in the transcript.
- Clear the active run and dismiss stale pending watchdog text when a terminal lifecycle error arrives.
- Keep retryable/non-terminal lifecycle errors active so embedded fallback responses can still complete.

Fixes #85782.

## Tests

- `node scripts/run-vitest.mjs src/tui/tui-event-handlers.test.ts`
- `node scripts/run-vitest.mjs src/tui/embedded-backend.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts`
- `pnpm openclaw tui --help`
- `pnpm format:check src/tui/tui-event-handlers.ts src/tui/tui-event-handlers.test.ts`
- `pnpm check:changed`

## Real behavior proof

Behavior addressed: TUI active runs that receive a terminal lifecycle `phase: "error"` event now show `run error: ...`, dismiss stale pending system text, clear `activeChatRunId`, and unblock the next prompt; lifecycle errors without terminal metadata remain active for fallback recovery.
Real environment tested: macOS local checkout at patched commit `a0bf6ff`, running the real OpenClaw CLI/TUI entrypoint through `pnpm openclaw`.
Exact steps or command run after this patch: `pnpm openclaw tui --help`
Evidence after fix: The real OpenClaw command rebuilt stale TypeScript for commit `a0bf6ff`, loaded the TUI command, and printed the TUI help output including `OpenClaw 2026.5.22 (a0bf6ff)`, `Usage: openclaw tui|terminal [options]`, and `Docs: https://docs.openclaw.ai/cli/tui`.
Observed result after fix: Command completed successfully with exit code 0, proving the patched TUI runtime entrypoint loads; targeted post-patch assertions cover the lifecycle-error transcript/unlock behavior and retryable lifecycle-error path.
What was not tested: A live external-provider failure with real credentials/Gateway transport; no secrets or live provider accounts were used.
