### PR TITLE
docs(github): make post-install restart explicit

### DIFF
--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -39,7 +39,21 @@ gh auth status
 gh auth login
 ```
 
-Gateway HOME can differ from operator HOME. If `gh` auth exists elsewhere, set `GH_CONFIG_DIR` in the gateway service env and restart.
+### Restart after installing `gh`
+
+Skill availability is snapshotted when the Gateway starts. If you installed `gh`
+(or changed your `PATH`) while OpenClaw was already running, restart the Gateway
+so the GitHub skill can load:
+
+```bash
+openclaw gateway restart
+```
+
+### Gateway `HOME` vs operator `HOME`
+
+Gateway `HOME` can differ from your shell `HOME`. If `gh auth status` works in
+your terminal but the GitHub skill still cannot see your login, set
+`GH_CONFIG_DIR` in the Gateway service environment and restart the Gateway.
 
 ## PRs
 


### PR DESCRIPTION
## Summary
- Problem: GitHub skill restart requirement after installing `gh` is easy to miss.
- Solution: Make the restart guidance explicit and add the canonical restart command.
- What changed: Expanded `skills/github/SKILL.md` Auth section with restart + HOME notes.
- What did NOT change (scope boundary): No runtime logic, binaries, tooling, or behavior.

## Motivation
Users can successfully install/auth `gh`, then assume the GitHub skill is broken until the Gateway restarts. This makes the required restart and the exact command obvious.

## Change Type (select all)
- [x] Docs

## Scope (select all touched areas)
- [x] Skills / tool execution

## Linked Issue/PR
- Closes #65958

## Real behavior proof (required for external PRs)
Documentation-only change. I verified `openclaw gateway restart` is the documented Gateway restart command (see `docs/cli/gateway.md`).
