### PR TITLE
fix(twitch): fail fast when auth provider cannot bind user

### DIFF
--- a/extensions/twitch/src/twitch-client.test.ts
+++ b/extensions/twitch/src/twitch-client.test.ts
@@ -228,6 +228,41 @@ describe("TwitchClientManager", () => {
       );
     });
 
+    it("rejects and does not cache a client when addUserForToken fails (83853)", async () => {
+      const refreshingAccount: TwitchAccountConfig = {
+        ...testAccount,
+        clientSecret: "test-client-secret",
+        refreshToken: "test-refresh-token",
+        expiresIn: 3600,
+        obtainmentTimestamp: 1_700_000_000_000,
+      };
+      mockAddUserForToken.mockRejectedValueOnce(new Error("token bind failed"));
+
+      await expect(manager.getClient(refreshingAccount)).rejects.toThrow("token bind failed");
+
+      // The broken auth provider must not be cached as a usable client;
+      // otherwise later sends fail with an opaque error instead of failing fast.
+      const key = manager.getAccountKey(refreshingAccount);
+      expect((manager as any).clients.has(key)).toBe(false);
+    });
+
+    it("retries client creation after an earlier addUserForToken failure (83853)", async () => {
+      const refreshingAccount: TwitchAccountConfig = {
+        ...testAccount,
+        clientSecret: "test-client-secret",
+        refreshToken: "test-refresh-token",
+        expiresIn: 3600,
+        obtainmentTimestamp: 1_700_000_000_000,
+      };
+      mockAddUserForToken.mockRejectedValueOnce(new Error("token bind failed"));
+
+      await expect(manager.getClient(refreshingAccount)).rejects.toThrow("token bind failed");
+      // No broken client was cached, so a second call re-attempts the bind.
+      await manager.getClient(refreshingAccount);
+
+      expect(mockAddUserForToken).toHaveBeenCalledTimes(2);
+    });
+
     it("should throw error when clientId is missing", async () => {
       const accountWithoutClientId: TwitchAccountConfig = {
         ...testAccount,

--- a/extensions/twitch/src/twitch-client.ts
+++ b/extensions/twitch/src/twitch-client.ts
@@ -54,6 +54,9 @@ export class TwitchClientManager {
           this.logger.error(
             `Failed to add user to RefreshingAuthProvider: ${formatErrorMessage(err)}`,
           );
+          // Re-throw so getClient rejects and does not cache a client backed
+          // by an auth provider with no bound user (would fail later on send).
+          throw err;
         });
 
       authProvider.onRefresh((userId, token) => {


### PR DESCRIPTION
## Summary

Fixes #83853. `TwitchClientManager.createAuthProvider` awaited `addUserForToken(...)` with a `.catch()` that only logged the error. The rejection was swallowed, so `await` resolved to `undefined`, execution continued, and `getClient` returned and cached a `ChatClient` backed by a `RefreshingAuthProvider` with no bound user. The setup failure then surfaced later as an opaque authentication error on the first send, instead of failing fast at client creation.

The catch now re-throws, so `getClient` rejects and does not store a broken client.

## Real behavior proof

Behavior or issue addressed: with a refreshing account (clientSecret + refresh token), if `addUserForToken` rejects, the old `.catch()` logged and returned, so `getClient` resolved and cached a user-less client. Re-throwing makes `getClient` reject and skip the cache, so the next call re-attempts the bind instead of reusing a broken client.

Real environment tested: Linux (Ubuntu 24.04, WSL2), Node.js 24.14.0, current PR head. Ran the Twitch client test suite via the repo's vitest runner against the real TwitchClientManager, with the Twurple RefreshingAuthProvider's addUserForToken mocked to reject. Compared the pre-fix and post-fix code.

Exact steps or command run after this patch: ran the getClient tests, including two new regression tests for the auth-bind failure path, on both the pre-fix and post-fix code.

Evidence after fix: stdout from the vitest run against the real TwitchClientManager, comparing pre-fix and post-fix:
$ node scripts/run-vitest.mjs extensions/twitch/src/twitch-client.test.ts -t 83853
-- BEFORE the fix (catch only logs): the regression tests fail --
x rejects and does not cache a client when addUserForToken fails (83853)
x retries client creation after an earlier addUserForToken failure (83853)
Tests  2 failed | 34 skipped (36)
-- AFTER the fix (catch re-throws): the regression tests pass --

rejects and does not cache a client when addUserForToken fails (83853)
retries client creation after an earlier addUserForToken failure (83853)
Tests  2 passed | 34 skipped (36)


Observed result after fix: before the fix `getClient` resolves despite the bind failure and caches the broken client (so a second call reuses it and `addUserForToken` is called only once); after the fix `getClient` rejects with the bind error, the client map stays empty, and a second call re-attempts the bind (addUserForToken called twice). The full Twitch client suite (36 tests) passes unchanged.

What was not tested: no live Twitch chat session was run; the auth-bind failure path is exercised through the real TwitchClientManager under vitest with the Twurple auth provider mocked, and the before/after comparison demonstrates the regression tests capture the exact defect.
