### PR TITLE
fix(twitch): evict client manager on disconnect failure

### DIFF
--- a/extensions/twitch/src/client-manager-registry.test.ts
+++ b/extensions/twitch/src/client-manager-registry.test.ts
@@ -3,6 +3,7 @@ import {
   clearRegistryForTest,
   getClientManager,
   getOrCreateClientManager,
+  removeClientManager,
 } from "./client-manager-registry.js";
 import type { ChannelLogSink } from "./types.js";
 
@@ -28,6 +29,20 @@ describe("client manager registry", () => {
     expect(getOrCreateClientManager("default", makeLogger())).toBe(firstManager);
 
     await clearRegistryForTest();
+
+    expect(disconnectAll).toHaveBeenCalledOnce();
+    expect(getClientManager("default")).toBeUndefined();
+    expect(getOrCreateClientManager("default", makeLogger())).not.toBe(firstManager);
+  });
+
+  it("removes cached managers even when disconnectAll rejects", async () => {
+    const firstManager = getOrCreateClientManager("default", makeLogger());
+    const disconnectError = new Error("disconnect failed");
+    const disconnectAll = vi
+      .spyOn(firstManager, "disconnectAll")
+      .mockRejectedValueOnce(disconnectError);
+
+    await expect(removeClientManager("default")).rejects.toBe(disconnectError);
 
     expect(disconnectAll).toHaveBeenCalledOnce();
     expect(getClientManager("default")).toBeUndefined();

--- a/extensions/twitch/src/client-manager-registry.ts
+++ b/extensions/twitch/src/client-manager-registry.ts
@@ -78,12 +78,12 @@ export async function removeClientManager(accountId: string): Promise<void> {
     return;
   }
 
-  // Disconnect the client manager
-  await entry.manager.disconnectAll();
-
-  // Remove from registry
-  registry.delete(accountId);
-  entry.logger.info(`Unregistered client manager for account: ${accountId}`);
+  try {
+    await entry.manager.disconnectAll();
+  } finally {
+    registry.delete(accountId);
+    entry.logger.info(`Unregistered client manager for account: ${accountId}`);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Evict Twitch client managers from the registry even when `disconnectAll()` rejects during account cleanup.
- Preserve the original disconnect failure for callers while preventing stale managers from being reused.
- Add focused regression coverage for the failed-disconnect cleanup path.

Fixes #83886

## Verification
- `corepack pnpm exec oxfmt --check --threads=1 extensions/twitch/src/client-manager-registry.ts extensions/twitch/src/client-manager-registry.test.ts`
- `corepack pnpm exec oxlint extensions/twitch/src/client-manager-registry.ts extensions/twitch/src/client-manager-registry.test.ts`
- `git diff --check`
- `node scripts/run-vitest.mjs extensions/twitch/src/client-manager-registry.test.ts extensions/twitch/src/twitch-client.test.ts extensions/twitch/src/plugin.lifecycle.test.ts`
- `C:\Program Files\Git\bin\bash.exe C:/Users/marti/.codex/skills/codex-review/scripts/codex-review --parallel-tests "node scripts/run-vitest.mjs extensions/twitch/src/client-manager-registry.test.ts extensions/twitch/src/twitch-client.test.ts extensions/twitch/src/plugin.lifecycle.test.ts"` -> clean

## Real behavior proof

Behavior addressed: If Twitch `removeClientManager()` sees `disconnectAll()` reject, the registry entry is still removed so later `getOrCreateClientManager()` calls create a fresh manager instead of reusing a stale/broken one.

Real environment tested: Windows desktop OpenClaw worktree at `C:\oc83886`, Node v24.13.0, pnpm 11.2.2, branch `fix/issue-83886-twitch-registry-cleanup` based on `origin/main` 208a0679e.

Exact steps or command run after this patch: `node --import tsx --input-type=module -e "import { clearRegistryForTest, getClientManager, getOrCreateClientManager, removeClientManager } from './extensions/twitch/src/client-manager-registry.ts'; ..."`

Evidence after fix: Terminal output from the patched OpenClaw module execution:

```text
[info] Registered client manager for account: proof-83886
[info] Unregistered client manager for account: proof-83886
removeClientManager=rejected:proof injected disconnect failure
disconnectAllCalls=1
registryAfterRemove=empty
[info] Registered client manager for account: proof-83886
freshManagerCreated=true
[info]  Disconnected all clients
```

Observed result after fix: The disconnect failure still propagates as `removeClientManager=rejected:proof injected disconnect failure`, but `registryAfterRemove=empty` confirms the stale registry entry was evicted and `freshManagerCreated=true` confirms the next manager is not the broken prior instance.

What was not tested: Live Twitch socket disconnect behavior with real credentials was not exercised. This issue is a source-level registry cleanup failure; the proof above executes the patched OpenClaw registry module directly, and the verification section covers the focused regression plus adjacent Twitch lifecycle/client coverage.

## Duplicate scan
- GitHub exact open PR search for `83886`: no existing open PR found before coding and again before opening this PR.
- Trello board search for `83886`: no existing work-item card found before creating the coordination card.
