### PR TITLE
fix(agents): recover subagent completion delivery after restart

### DIFF
--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -932,6 +932,57 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(queueEmbeddedPiMessageWithOutcome).not.toHaveBeenCalled();
   });
 
+  it("falls back to gateway call when in-process announce dispatch has no request scope", async () => {
+    const callGateway = createGatewayMock({
+      result: {
+        payloads: [{ text: "requester voice completion" }],
+      },
+    });
+    const dispatchGatewayMethodInProcess = vi.fn(async () => {
+      throw new Error(
+        "In-process gateway dispatch requires a gateway request scope (method: agent). No scope set and no fallback context available.",
+      );
+    }) as unknown as typeof runtimeDispatchGatewayMethodInProcess;
+    testing.setDepsForTest({
+      callGateway,
+      dispatchGatewayMethodInProcess,
+      getRequesterSessionActivity: () => ({
+        sessionId: "requester-session-local",
+        isActive: false,
+      }),
+      getRuntimeConfig: () => ({}) as never,
+    });
+
+    const result = await deliverSubagentAnnouncement({
+      requesterSessionKey: "agent:main:slack:channel:C123:thread:171.222",
+      targetRequesterSessionKey: "agent:main:slack:channel:C123:thread:171.222",
+      triggerMessage: "child done",
+      steerMessage: "child done",
+      requesterOrigin: slackThreadOrigin,
+      requesterSessionOrigin: slackThreadOrigin,
+      completionDirectOrigin: slackThreadOrigin,
+      directOrigin: slackThreadOrigin,
+      requesterIsSubagent: false,
+      expectsCompletionMessage: true,
+      bestEffortDeliver: true,
+      directIdempotencyKey: "announce-local-dispatch-fallback",
+    });
+
+    expectRecordFields(result, {
+      delivered: true,
+      path: "direct",
+    });
+    expect(dispatchGatewayMethodInProcess).toHaveBeenCalledTimes(1);
+    expectGatewayAgentParams(callGateway, {
+      deliver: true,
+      channel: "slack",
+      accountId: "acct-1",
+      to: "channel:C123",
+      threadId: "171.222",
+      bestEffortDeliver: true,
+    });
+  });
+
   it("uses in-process agent dispatch for dormant completion requesters", async () => {
     const callGateway = createGatewayMock();
     const dispatchGatewayMethodInProcess = createInProcessGatewayMock({

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -66,6 +66,7 @@ const AGENT_MEDIATED_COMPLETION_TOOLS = new Set([
 ]);
 
 type SubagentAnnounceDeliveryDeps = {
+  callGateway: typeof callGateway;
   dispatchGatewayMethodInProcess: typeof dispatchGatewayMethodInProcess;
   getRuntimeConfig: typeof getRuntimeConfig;
   getRequesterSessionActivity: (requesterSessionKey: string) => {
@@ -81,6 +82,7 @@ type SubagentAnnounceDeliveryDeps = {
 };
 
 const defaultSubagentAnnounceDeliveryDeps: SubagentAnnounceDeliveryDeps = {
+  callGateway,
   dispatchGatewayMethodInProcess,
   getRuntimeConfig,
   getRequesterSessionActivity: (requesterSessionKey: string) => {
@@ -116,14 +118,31 @@ async function runAnnounceAgentCall(params: {
   expectFinal?: boolean;
   timeoutMs?: number;
 }): Promise<unknown> {
-  return await subagentAnnounceDeliveryDeps.dispatchGatewayMethodInProcess(
-    "agent",
-    params.agentParams,
-    {
+  try {
+    return await subagentAnnounceDeliveryDeps.dispatchGatewayMethodInProcess(
+      "agent",
+      params.agentParams,
+      {
+        expectFinal: params.expectFinal,
+        timeoutMs: params.timeoutMs,
+      },
+    );
+  } catch (error) {
+    if (!isMissingGatewayRequestScopeError(error)) {
+      throw error;
+    }
+    return await subagentAnnounceDeliveryDeps.callGateway({
+      method: "agent",
+      params: params.agentParams,
       expectFinal: params.expectFinal,
       timeoutMs: params.timeoutMs,
-    },
-  );
+    });
+  }
+}
+
+function isMissingGatewayRequestScopeError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : typeof error === "string" ? error : "";
+  return message.includes("In-process gateway dispatch requires a gateway request scope");
 }
 
 function formatQueueWakeFailureError(

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -583,6 +583,111 @@ describe("subagent registry lifecycle hardening", () => {
     });
   });
 
+  it("retries suspended required completion delivery after restart instead of treating suspension as terminal", async () => {
+    const entry = createRunEntry({
+      endedAt: 4_000,
+      endedReason: SUBAGENT_ENDED_REASON_COMPLETE,
+      expectsCompletionMessage: true,
+      cleanup: "keep",
+      cleanupHandled: true,
+      pendingFinalDelivery: true,
+      pendingFinalDeliveryLastError: "previous gateway outage",
+      deliverySuspendedAt: 4_500,
+      deliverySuspendedReason: "expiry",
+      lastAnnounceDeliveryError: "previous gateway outage",
+      frozenResultText: "final answer",
+      frozenResultCapturedAt: 4_100,
+      outcome: { status: "ok" },
+      retainAttachmentsOnKeep: false,
+    });
+    let finishAnnounce!: () => void;
+    const runSubagentAnnounceFlow: LifecycleControllerParams["runSubagentAnnounceFlow"] = vi.fn(
+      (announceParams) =>
+        new Promise<boolean>((resolve) => {
+          finishAnnounce = () => {
+            announceParams.onDeliveryResult?.({
+              delivered: true,
+              path: "direct",
+              deliveredAt: 14_300,
+            });
+            resolve(true);
+          };
+        }),
+    );
+
+    const controller = createLifecycleController({
+      entry,
+      runSubagentAnnounceFlow,
+    });
+
+    expect(controller.startSubagentAnnounceCleanupFlow(entry.runId, entry)).toBe(true);
+
+    expect(entry.pendingFinalDelivery).toBe(true);
+    expect(entry.deliverySuspendedAt).toBe(4_500);
+    finishAnnounce();
+
+    await vi.waitFor(() => expect(entry.completionAnnouncedAt).toBe(14_300));
+    expect(entry.completionDeliveredAt).toBe(14_300);
+    expect(entry.pendingFinalDelivery).toBeUndefined();
+    expect(entry.pendingFinalDeliveryLastError).toBeUndefined();
+    expect(entry.deliverySuspendedAt).toBeUndefined();
+    expect(entry.deliverySuspendedReason).toBeUndefined();
+    expect(entry.lastAnnounceDeliveryError).toBeUndefined();
+    expect(entry.cleanupCompletedAt).toBeTypeOf("number");
+    expectFields(firstCallArg(taskExecutorMocks.setDetachedTaskDeliveryStatusByRunId), {
+      runId: entry.runId,
+      runtime: "subagent",
+      sessionKey: entry.childSessionKey,
+      deliveryStatus: "delivered",
+    });
+  });
+
+  it("recovers stale handled completion cleanup records that never delivered", async () => {
+    const entry = createRunEntry({
+      endedAt: 4_000,
+      endedReason: SUBAGENT_ENDED_REASON_COMPLETE,
+      expectsCompletionMessage: true,
+      cleanup: "keep",
+      cleanupHandled: true,
+      frozenResultText: "final answer",
+      frozenResultCapturedAt: 4_100,
+      outcome: { status: "ok" },
+      retainAttachmentsOnKeep: false,
+    });
+    const runSubagentAnnounceFlow: LifecycleControllerParams["runSubagentAnnounceFlow"] = vi.fn(
+      async (announceParams) => {
+        announceParams.onDeliveryResult?.({
+          delivered: true,
+          path: "direct",
+          deliveredAt: 12_300,
+        });
+        return true;
+      },
+    );
+    const persist = vi.fn();
+
+    const controller = createLifecycleController({
+      entry,
+      persist,
+      runSubagentAnnounceFlow,
+    });
+
+    expect(controller.startSubagentAnnounceCleanupFlow(entry.runId, entry)).toBe(true);
+
+    await vi.waitFor(() => expect(entry.completionAnnouncedAt).toBe(12_300));
+    expect(entry.completionDeliveredAt).toBe(12_300);
+    expect(entry.cleanupCompletedAt).toBeTypeOf("number");
+    expect(entry.pendingFinalDelivery).toBeUndefined();
+    expectFields(firstCallArg(taskExecutorMocks.setDetachedTaskDeliveryStatusByRunId), {
+      runId: entry.runId,
+      runtime: "subagent",
+      sessionKey: entry.childSessionKey,
+      deliveryStatus: "delivered",
+    });
+    expect(helperMocks.safeRemoveAttachmentsDir).toHaveBeenCalledTimes(1);
+    expect(persist).toHaveBeenCalled();
+  });
+
   it("skips announce delivery when completion messages are disabled", async () => {
     const persist = vi.fn();
     const entry = createRunEntry({

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -581,13 +581,26 @@ export function createSubagentRegistryLifecycleController(params: {
     await emitCompletionEndedHookIfNeeded(giveUpParams.entry, completionReason);
   };
 
+  const shouldResumeStaleCompletionCleanup = (entry: SubagentRunRecord): boolean =>
+    entry.expectsCompletionMessage === true &&
+    typeof entry.endedAt === "number" &&
+    typeof entry.cleanupCompletedAt !== "number" &&
+    typeof entry.completionAnnouncedAt !== "number";
+
   const beginSubagentCleanup = (runId: string) => {
     const entry = params.runs.get(runId);
     if (!entry) {
       return false;
     }
-    if (entry.cleanupCompletedAt || entry.cleanupHandled) {
+    if (entry.cleanupCompletedAt) {
       return false;
+    }
+    if (entry.cleanupHandled) {
+      if (!shouldResumeStaleCompletionCleanup(entry)) {
+        return false;
+      }
+      entry.cleanupHandled = false;
+      params.resumedRuns.delete(runId);
     }
     entry.cleanupHandled = true;
     params.persist();
@@ -604,9 +617,6 @@ export function createSubagentRegistryLifecycleController(params: {
         continue;
       }
       if (entry.cleanupCompletedAt || entry.cleanupHandled) {
-        continue;
-      }
-      if (entry.pendingFinalDelivery === true && typeof entry.deliverySuspendedAt === "number") {
         continue;
       }
       if (params.suppressAnnounceForSteerRestart(entry)) {

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -1126,7 +1126,7 @@ describe("subagent registry seam flow", () => {
     ).toBeUndefined();
   });
 
-  it("suspends retry-budgeted successful keep-mode completion deliveries during resume", async () => {
+  it("retries suspended successful keep-mode completion deliveries during resume", async () => {
     mocks.restoreSubagentRunsFromDisk.mockImplementation(((params: {
       runs: Map<string, unknown>;
       mergeOnly?: boolean;
@@ -1149,6 +1149,10 @@ describe("subagent registry seam flow", () => {
         lastAnnounceDeliveryError: "gateway request timeout for agent",
         frozenResultText: "child completed successfully",
         pendingFinalDelivery: true,
+        pendingFinalDeliveryLastError: "gateway request timeout for agent",
+        pendingFinalDeliveryAttemptCount: 1,
+        deliverySuspendedAt: Date.parse("2026-03-24T11:59:45Z"),
+        deliverySuspendedReason: "transient",
         pendingFinalDeliveryPayload: {
           requesterSessionKey: "agent:main:main",
           requesterDisplayKey: "main",
@@ -1168,20 +1172,23 @@ describe("subagent registry seam flow", () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
-    const run = mod
-      .listSubagentRunsForRequester("agent:main:main")
-      .find((entry) => entry.runId === "run-resume-keep");
-    expect(run).toMatchObject({
-      pendingFinalDelivery: true,
-      deliverySuspendedReason: "retry-limit",
-      cleanupHandled: false,
-    });
-    expect(run?.cleanupCompletedAt).toBeUndefined();
-    expect(run?.pendingFinalDeliveryPayload).toMatchObject({
-      childRunId: "run-resume-keep",
-      frozenResultText: "child completed successfully",
-    });
+    await waitForFast(() => expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1));
+    const announceArg = getMockCallArg(
+      mocks.runSubagentAnnounceFlow,
+      0,
+      0,
+      "runSubagentAnnounceFlow",
+    );
+    expectRecordFields(
+      announceArg,
+      {
+        childRunId: "run-resume-keep",
+        childSessionKey: "agent:main:subagent:child",
+        roundOneReply: "child completed successfully",
+        waitForCompletion: false,
+      },
+      "announceArg",
+    );
   });
 
   it("clears suspended final delivery fields when reactivating a subagent run", () => {
@@ -1205,7 +1212,7 @@ describe("subagent registry seam flow", () => {
       pendingFinalDelivery: true,
       pendingFinalDeliveryCreatedAt: endedAt + 1_000,
       pendingFinalDeliveryLastAttemptAt: endedAt + 2_000,
-      pendingFinalDeliveryAttemptCount: 3,
+      pendingFinalDeliveryAttemptCount: 1,
       pendingFinalDeliveryLastError: "gateway request timeout for agent",
       pendingFinalDeliveryPayload: {
         requesterSessionKey: "agent:main:main",
@@ -1788,6 +1795,7 @@ describe("subagent registry seam flow", () => {
         },
         deliverySuspendedAt: now - 60_000 + i,
         deliverySuspendedReason: "retry-limit",
+        lastAnnounceDeliveryError: "gateway request timeout for agent",
       });
     }
 
@@ -1800,11 +1808,13 @@ describe("subagent registry seam flow", () => {
     const stillSuspended = runs.filter(
       (run) => run?.pendingFinalDelivery === true && typeof run.deliverySuspendedAt === "number",
     );
-    expect(discarded).toHaveLength(41);
-    expect(stillSuspended).toHaveLength(10);
+    expect(discarded).toHaveLength(1);
+    expect(stillSuspended).toHaveLength(0);
     expect(discarded[0]?.runId).toBe("run-suspended-pressure-0");
-    expect(runs[40]?.deliveryDiscardReason).toBe("pressure-pruned");
-    expect(runs[41]?.pendingFinalDelivery).toBe(true);
+    expect(runs[0]?.deliveryDiscardReason).toBe("pressure-pruned");
+    expect(runs.slice(1)).toSatisfy((entries: Array<(typeof runs)[number]>) =>
+      entries.every((run) => run == null),
+    );
     expect(mocks.persistSubagentRunsToDisk).toHaveBeenCalled();
   });
 });

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -517,18 +517,16 @@ function resumeSubagentRun(runId: string) {
   if (entry.cleanupCompletedAt) {
     return;
   }
-  if (
-    typeof entry.endedAt === "number" &&
-    entry.pendingFinalDelivery === true &&
-    typeof entry.deliverySuspendedAt === "number"
-  ) {
-    return;
-  }
   if (entry.pauseReason === "sessions_yield") {
     return;
   }
-  // Skip entries that have exhausted their retry budget or expired (#18264).
-  if ((entry.announceRetryCount ?? 0) >= MAX_ANNOUNCE_RETRY_COUNT) {
+  // Skip entries that have exhausted their retry budget or expired (#18264),
+  // except suspended required keep-mode completions: those are durable pending
+  // deliveries and must get a restart recovery attempt instead of staying stuck.
+  if (
+    (entry.announceRetryCount ?? 0) >= MAX_ANNOUNCE_RETRY_COUNT &&
+    !isRestartRecoverableSuspendedCompletionDelivery(entry)
+  ) {
     void finalizeResumedAnnounceGiveUp({
       runId,
       entry,
@@ -680,7 +678,22 @@ function isSuspendedPendingFinalDelivery(entry: SubagentRunRecord): boolean {
   return (
     typeof entry.endedAt === "number" &&
     entry.pendingFinalDelivery === true &&
-    typeof entry.deliverySuspendedAt === "number"
+    typeof entry.deliverySuspendedAt === "number" &&
+    !isRestartRecoverableSuspendedCompletionDelivery(entry)
+  );
+}
+
+function isRestartRecoverableSuspendedCompletionDelivery(entry: SubagentRunRecord): boolean {
+  return (
+    entry.expectsCompletionMessage === true &&
+    entry.cleanup === "keep" &&
+    typeof entry.endedAt === "number" &&
+    entry.pendingFinalDelivery === true &&
+    typeof entry.deliverySuspendedAt === "number" &&
+    entry.deliverySuspendedReason !== "retry-limit" &&
+    entry.lastAnnounceDeliveryError != null &&
+    entry.pendingFinalDeliveryPayload != null &&
+    !entry.requesterSessionKey.includes(":cron:")
   );
 }
 

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -45,6 +45,7 @@ import {
   setTaskRegistryControlRuntimeForTests,
   setTaskRegistryDeliveryRuntimeForTests,
   setTaskProgressById,
+  setTaskRunDeliveryStatusByRunId,
   setTaskTimingById,
   updateTaskNotifyPolicyById,
 } from "./task-registry.js";
@@ -1990,6 +1991,49 @@ describe("task-registry", () => {
         status: "running",
         lastEventAt: now - 31 * 60_000,
       });
+    });
+  });
+
+  it("records delivery-state notification when delivery status is set by run id", async () => {
+    await withTaskRegistryTempDir(async () => {
+      const task = createTaskRecord({
+        runtime: "subagent",
+        ownerKey: "agent:main:discord:channel:C123",
+        requesterSessionKey: "agent:main:discord:channel:C123",
+        requesterOrigin: {
+          channel: "discord",
+          to: "channel:C123",
+          accountId: "default",
+        },
+        scopeKind: "session",
+        childSessionKey: "agent:worker:subagent:child",
+        runId: "run-delivery-state-by-run-id",
+        task: "Delivery state task",
+        status: "succeeded",
+        deliveryStatus: "pending",
+      });
+      setTaskTimingById({
+        taskId: task.taskId,
+        endedAt: 1_000,
+        lastEventAt: 1_500,
+      });
+
+      const [updated] = setTaskRunDeliveryStatusByRunId({
+        runId: "run-delivery-state-by-run-id",
+        runtime: "subagent",
+        sessionKey: "agent:worker:subagent:child",
+        deliveryStatus: "delivered",
+      });
+      expect(updated).toMatchObject({
+        taskId: task.taskId,
+        deliveryStatus: "delivered",
+      });
+      reloadTaskRegistryFromStore();
+      expect(await maybeDeliverTaskStateChangeUpdate(task.taskId)).toMatchObject({
+        taskId: task.taskId,
+        deliveryStatus: "delivered",
+      });
+      expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
     });
   });
 

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1734,12 +1734,23 @@ function updateTaskDeliveryByRunId(params: {
   if (params.error !== undefined) {
     patch.error = params.error;
   }
-  return updateTasksByRunId({
+  const updated = updateTasksByRunId({
     runId: params.runId,
     runtime: params.runtime,
     sessionKey: params.sessionKey,
     patch,
   });
+  if (params.deliveryStatus === "delivered") {
+    const deliveredAt = Date.now();
+    for (const task of updated) {
+      upsertTaskDeliveryState({
+        taskId: task.taskId,
+        requesterOrigin: getTaskDeliveryState(task.taskId)?.requesterOrigin,
+        lastNotifiedEventAt: Math.max(task.lastEventAt ?? 0, task.endedAt ?? 0, deliveredAt),
+      });
+    }
+  }
+  return updated;
 }
 
 export function markTaskRunningByRunId(params: {


### PR DESCRIPTION
## Summary

- Problem: subagent completion delivery could remain stranded after restart when a keep-mode completion finished but delivery/cleanup bookkeeping was suspended or stale.
- Solution: retry restart-recoverable suspended keep-mode completion deliveries, replay stale handled cleanup records, and preserve direct gateway fallback when in-process announce dispatch has no request scope.
- What changed: announce delivery fallback, subagent registry/lifecycle restart recovery, task delivery-state stamping, and focused regressions.
- What did NOT change (scope boundary): no config changes, no new user-facing commands, no channel-specific behavior changes beyond completing already-required delivery bookkeeping.

## Motivation

A real Discord-backed subagent completed successfully and preserved its child result, but the requester-visible completion bookkeeping was left split: the run completed while task delivery state stayed pending/null. That makes restart/DR behavior unreliable for subagent completions.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #67777
- Related #85716
- Related #85770
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: native subagent completion delivery could be left pending/suspended after restart even though the child result was captured.
- Real environment tested:
  - OpenClaw `2026.5.20 (e510042)` live runtime for reproduction and local dist hotfix verification.
  - Discord channel source conversation.
  - `messages.visibleReplies = message_tool`, `messages.groupChat.visibleReplies = message_tool`.
  - Forward-port branch based on upstream `main` / package version `2026.5.22` for source tests/build.
- Exact steps or command run after this patch:
  - Spawned keep-cleanup native subagent smoke from Discord, waited for completion, inspected `/home/jon/.openclaw/subagents/runs.json` and `/home/jon/.openclaw/tasks/runs.sqlite`.
  - Restarted OpenClaw and verified old stranded run recovery.
  - Ran fresh post-restart keep-cleanup smoke and inspected run registry + task ledger.
- Evidence after fix:
  - Old stranded run: `6a725c0d-1dad-42b2-bac9-22672083d841` preserved marker `TARGET_VERIFIED_DISCORD_KEEP_CLEANUP_SMOKE_20260523_0152_OK`; after fix, run record had `completionDeliveredAt`, `completionAnnouncedAt`, and `cleanupCompletedAt`; primary task row became `delivery_status=delivered`.
  - Fresh post-restart smoke: `c889b655-c73f-4791-b5c6-4040b4018d93`, child `agent:worker:subagent:ee496780-04fb-4124-af07-781c6c25d69f`, marker `FRESH_KEEP_CLEANUP_DELIVERY_STATE_SMOKE_20260523_1151_OK`.
  - Fresh task ledger: primary row `status=succeeded`, `delivery_status=delivered`, and `task_delivery_state.last_notified_event_at=1779551535175`; no pending/suspended delivery remained.
  - Historical cleanup: 42 delivered rows with requester origin but null `last_notified_event_at` were backfilled locally; remaining delivered/requester-origin/null rows = 0.
- Observed result after fix: completed keep-mode subagent results recover after restart and fresh completions stamp both run delivery state and task delivery-state notification state.
- What was not tested: full repo `pnpm check` / complete CI matrix; local `lint:core` is blocked in this fresh checkout by optional Discord boundary dependencies, detailed below.
- Before evidence: same old stranded run had completed child marker but task ledger showed `status=succeeded`, `delivery_status=pending`, and `task_delivery_state.last_notified_event_at=NULL` before the final recovery/stamping fixes.

## Root Cause (if applicable)

- Root cause:
  - announce delivery fallback could call through a dependency surface that did not include `callGateway` when in-process gateway dispatch lacked a request scope;
  - restart resume skipped or treated suspended required keep-mode completion deliveries as terminal rather than recoverable;
  - cleanup guard considered `cleanupHandled=true` terminal even when delivery/announce bookkeeping had never completed;
  - task run delivery status updates by run id did not also stamp `task_delivery_state.last_notified_event_at`.
- Missing detection / guardrail: tests covered normal completion delivery paths but not the persisted/restart state where completion result existed, cleanup was handled/stale, and delivery-state bookkeeping was still pending/null.
- Contributing context: adjacent subagent delivery work exists in beta/current PRs, but the tested failure combined request-scope fallback, restart recovery, cleanup guard, and task-ledger consistency.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/subagent-announce-delivery.test.ts`
  - `src/agents/subagent-registry.test.ts`
  - `src/agents/subagent-registry-lifecycle.test.ts`
  - `src/tasks/task-registry.test.ts`
- Scenario the test should lock in:
  - in-process announce dispatch without request scope falls back to gateway call;
  - suspended restart-recoverable keep-mode completions retry instead of remaining stuck;
  - stale handled cleanup records can replay and finish delivery bookkeeping;
  - delivered run-id updates stamp task delivery-state notification state.
- Why this is the smallest reliable guardrail: each test targets the persistence/lifecycle seam that failed without requiring a full live Discord E2E run.
- Existing test that already covers this (if any): none found for the combined persisted restart state.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Subagent completions that already succeeded should be less likely to disappear or remain stuck after restart; delivered task ledger state should stay consistent with task delivery-state notification bookkeeping.

## Diagram (if applicable)

```text
Before:
child done -> result frozen -> restart/stale cleanup -> delivery pending/null forever

After:
child done -> result frozen -> restart replay -> announce/direct delivery credited -> cleanup complete -> task ledger stamped
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` — reuses existing gateway agent call path as fallback when in-process dispatch has no request scope.
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local OpenClaw gateway/runtime
- Model/provider: Codex/OAuth-backed OpenClaw runtime locally; no OpenAI API key used
- Integration/channel: Discord channel conversation
- Relevant config (redacted): visible replies required through `message` tool for group/channel delivery

### Steps

1. Produce a keep-mode native subagent completion from Discord.
2. Restart OpenClaw with the completion in pending/suspended/stale cleanup state.
3. Verify run registry and task ledger after recovery.
4. Run a fresh keep-cleanup completion smoke after restart and inspect registry/SQLite task ledger.

### Expected

- Completed child result remains available.
- Completion delivery/announcement timestamps are set.
- Cleanup completes.
- Primary task row is `delivery_status=delivered`.
- `task_delivery_state.last_notified_event_at` is non-null for delivered requester-origin rows.

### Actual

- After this fix, old stranded run recovered at run/task level and fresh smoke fully passed with delivered task state stamped.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation on this branch:

```text
OPENCLAW_TEST_FAST=1 npm test -- --run src/agents/subagent-registry.test.ts src/agents/subagent-registry-lifecycle.test.ts src/agents/subagent-announce-delivery.test.ts
→ 121/121 passed

OPENCLAW_TEST_FAST=1 npm test -- --run src/tasks/task-registry.test.ts
→ 71/71 passed

OPENCLAW_BUILD_ALL_NO_PNPM=1 npm run build -- gatewayWatch
→ passed

git diff --check -- touched files
→ passed
```

Known local-check caveat:

```text
npm run lint:core
→ blocked in this fresh checkout before reaching this patch because Discord boundary dts prep cannot resolve optional Discord deps such as discord-api-types/v10 and @discordjs/voice. Errors are outside touched files.
```

## Human Verification (required)

- Verified scenarios:
  - old stranded run recovered at run/task level;
  - fresh post-restart keep-cleanup smoke completed with delivered task status and delivery-state timestamp;
  - historical delivered/null rows were backfilled locally and remaining delivered/requester-origin/null rows became 0;
  - forward-port tests/build passed on upstream `main` checkout.
- Edge cases checked:
  - missing request-scope in-process announce dispatch fallback;
  - suspended/stale keep-mode recovery after restart;
  - stale `cleanupHandled` state;
  - task delivery-status vs delivery-state consistency.
- What I did **not** verify:
  - full CI matrix;
  - complete `pnpm check` due local optional Discord boundary dependency issue;
  - non-Discord live channels.

AI-assisted disclosure: this PR was prepared with AI assistance, with human-approved live runtime testing and command verification. Local `codex review --base origin/main` could not be run because the `codex` CLI was not installed in this checkout environment.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

- Risk: restart recovery could retry delivery for records that were intentionally suspended.
  - Mitigation: recovery is constrained to required keep-mode completion deliveries with persisted pending-final-delivery payload/error context; retry-limit/cron pressure-pruned cases remain guarded by existing suspension/discard behavior and tests.
- Risk: task delivery-state timestamp might mask a missed notification.
  - Mitigation: stamping only occurs when the run-id delivery status is explicitly marked `delivered`; failed/blocked paths are not credited.
