### PR TITLE
fix(tui): surface terminal lifecycle errors

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -302,6 +302,40 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(tui.requestRender).toHaveBeenCalled();
   });
 
+  it("surfaces terminal lifecycle errors and unlocks the active run", () => {
+    const { state, chatLog, tui, setActivityStatus, handleAgentEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-lifecycle-error", activityStatus: "streaming" },
+    });
+
+    handleAgentEvent({
+      runId: "run-lifecycle-error",
+      stream: "lifecycle",
+      data: { phase: "error", endedAt: Date.now(), error: "provider disconnected" },
+    });
+
+    expect(chatLog.dismissPendingSystem).toHaveBeenCalledWith("run-lifecycle-error");
+    expect(chatLog.addSystem).toHaveBeenCalledWith("run error: provider disconnected");
+    expect(state.activeChatRunId).toBeNull();
+    expect(setActivityStatus).toHaveBeenCalledWith("error");
+    expect(tui.requestRender).toHaveBeenCalled();
+  });
+
+  it("keeps retryable lifecycle errors active until a terminal lifecycle event arrives", () => {
+    const { state, chatLog, setActivityStatus, handleAgentEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-retryable", activityStatus: "streaming" },
+    });
+
+    handleAgentEvent({
+      runId: "run-retryable",
+      stream: "lifecycle",
+      data: { phase: "error", error: "primary model timed out" },
+    });
+
+    expect(chatLog.addSystem).not.toHaveBeenCalledWith("run error: primary model timed out");
+    expect(state.activeChatRunId).toBe("run-retryable");
+    expect(setActivityStatus).toHaveBeenCalledWith("error");
+  });
+
   it("shows finishing context for a known run after assistant final", () => {
     const { state, tui, setActivityStatus, handleChatEvent, handleAgentEvent } =
       createHandlersHarness({

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -331,6 +331,23 @@ export function createEventHandlers(context: EventHandlerContext) {
     return sessionRuns.has(activeRunId);
   };
 
+  const readLifecycleErrorMessage = (evt: AgentEvent): string => {
+    const data = evt.data ?? {};
+    return asString(data.error, "") || asString(data.errorMessage, "") || "unknown";
+  };
+
+  const isTerminalLifecycleError = (evt: AgentEvent): boolean => {
+    if (evt.stream !== "lifecycle" || asString(evt.data?.phase, "") !== "error") {
+      return false;
+    }
+    return typeof evt.data?.endedAt === "number";
+  };
+
+  const renderRunError = (errorMessage: string) => {
+    const renderedError = formatRawAssistantErrorForUi(errorMessage);
+    return resolveAuthErrorHint(errorMessage) ?? `run error: ${renderedError}`;
+  };
+
   const maybeRefreshHistoryForRun = (
     runId: string,
     opts?: { allowLocalWithoutDisplayableFinal?: boolean },
@@ -493,8 +510,7 @@ export function createEventHandlers(context: EventHandlerContext) {
       forgetLocalBtwRunId?.(evt.runId);
       const wasActiveRun = state.activeChatRunId === evt.runId;
       const errorMessage = evt.errorMessage ?? "unknown";
-      const renderedError = formatRawAssistantErrorForUi(errorMessage);
-      chatLog.addSystem(resolveAuthErrorHint(errorMessage) ?? `run error: ${renderedError}`);
+      chatLog.addSystem(renderRunError(errorMessage));
       terminateRun({ runId: evt.runId, wasActiveRun, status: "error" });
       maybeRefreshHistoryForRun(evt.runId);
     }
@@ -608,6 +624,15 @@ export function createEventHandlers(context: EventHandlerContext) {
       }
       if (phase === "error") {
         postFinalizingRuns.delete(evt.runId);
+        if (isTerminalLifecycleError(evt) && (isActiveRun || isPendingRun)) {
+          const wasActiveRun = state.activeChatRunId === evt.runId;
+          const errorMessage = readLifecycleErrorMessage(evt);
+          chatLog.dismissPendingSystem(evt.runId);
+          chatLog.addSystem(renderRunError(errorMessage));
+          terminateRun({ runId: evt.runId, wasActiveRun, status: "error" });
+          tui.requestRender();
+          return;
+        }
         if (!canUpdateActivityStatus) {
           return;
         }


### PR DESCRIPTION
## Summary

- Fixes #85782 by treating terminal TUI lifecycle error events as visible run errors.
- Clears the pending run state and streaming watchdog when a terminal lifecycle error arrives, so the next prompt is not blocked by stale `activeChatRunId` state.
- Reuses the existing chat-error rendering path, including auth hints, and keeps retryable non-terminal lifecycle errors active until a terminal event arrives.

## Tests

- `node scripts/run-vitest.mjs src/tui/tui-event-handlers.test.ts`
- `pnpm format:check src/tui/tui-event-handlers.ts src/tui/tui-event-handlers.test.ts`
- `git diff --check`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-pty-harness.e2e.test.ts -t "blocks overlapping normal messages while a run is busy"`

## Real behavior proof

Behavior addressed: TUI runs that receive a terminal lifecycle `phase: "error"` event now show the error and unlock the active run instead of leaving the terminal stuck in a busy state.

Real environment tested: macOS checkout on this branch, running the TUI event-handler path plus the real TUI PTY loop through the repository's terminal harness.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-pty-harness.e2e.test.ts -t "blocks overlapping normal messages while a run is busy"`

Evidence after fix: Terminal capture: the command above launched the TUI PTY harness, drove a live terminal process through a busy-run prompt scenario, and exited with status 0. Supplemental focused command `node scripts/run-vitest.mjs src/tui/tui-event-handlers.test.ts` also exited with status 0 after injecting terminal and retryable lifecycle error events.

Observed result after fix: Terminal lifecycle errors with `endedAt` are rendered as `run error: ...`, pending system text is dismissed, `activeChatRunId` is cleared, and retryable lifecycle errors without `endedAt` continue to leave the run active until a terminal event arrives.

What was not tested: I did not run a live external provider failure or full interactive human TUI session; the PTY proof uses the repository TUI terminal harness and the targeted lifecycle proof injects the same gateway event shape.
