### PR TITLE
Notify chat when main session restart recovery cannot resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - MiniMax: store OAuth token expiry as an absolute millisecond timestamp so OAuth profiles no longer appear expired on every request. (#83480) Thanks @NianJiuZst.
+- Agents/channels: send a visible notice when an aborted main session cannot be resumed after restart, including Telegram group targets. (#85805) Thanks @pfrederiksen.
 - Gateway/restart: honor the configured restart drain budget for embedded runs and avoid spending the deferral timeout twice after forced restart timeouts. (#85708) Thanks @Kaspre.
 - Gateway/boot: run `BOOT.md` startup checks in an isolated boot session so gateway restarts do not overwrite the agent's main session mapping. (#85479)
 - Meeting Notes: include a speaker-labeled transcript section in generated summaries so Discord group voice captures show who said each captured utterance.

--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -388,6 +388,21 @@ describe("handleTelegramAction", () => {
     });
   });
 
+  it("normalizes legacy group targets for sendMessage actions", async () => {
+    await handleTelegramAction(
+      {
+        action: "sendMessage",
+        to: "group:-1001234567890:topic:77",
+        content: "Recovered",
+      },
+      telegramConfig(),
+    );
+
+    const call = mockCall(sendMessageTelegram, 0, "legacy group target");
+    expect(call[0]).toBe("-1001234567890:topic:77");
+    expect(call[1]).toBe("Recovered");
+  });
+
   it("marks the matching inbound event delivered after a successful send", async () => {
     let count = 0;
     const end = beginTelegramInboundEventDeliveryCorrelation("telegram-session", {

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -38,7 +38,7 @@ import {
   sendStickerTelegram,
 } from "./send.js";
 import { getCacheStats, searchStickers } from "./sticker-cache.js";
-import { parseTelegramTarget } from "./targets.js";
+import { normalizeTelegramOutboundTarget, parseTelegramTarget } from "./targets.js";
 import { resolveTelegramToken } from "./token.js";
 
 export const telegramActionRuntime = {
@@ -391,7 +391,7 @@ export async function handleTelegramAction(
     if (!isActionEnabled("sendMessage")) {
       throw new Error("Telegram sendMessage is disabled.");
     }
-    const to = readStringParam(params, "to", { required: true });
+    const to = normalizeTelegramOutboundTarget(readStringParam(params, "to", { required: true }));
     const mediaUrls = readTelegramSendMediaUrls(params);
     const firstMediaUrl = mediaUrls[0];
     const presentation = normalizeMessagePresentation(params.presentation);

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -578,16 +578,16 @@ describe("main-session-restart-recovery", () => {
   it("sends a visible notice before failing an unresumable chat-bound main session", async () => {
     const sessionsDir = await makeSessionsDir();
     await writeStore(sessionsDir, {
-      "agent:main:telegram:group:12345": {
+      "agent:main:demo-channel:room-1": {
         sessionId: "main-session",
         updatedAt: Date.now() - 10_000,
         status: "running",
         abortedLastRun: true,
         deliveryContext: {
-          channel: "telegram",
-          to: "group:12345",
+          channel: "demo-channel",
+          to: "room-1",
           accountId: "default",
-          threadId: "topic-1",
+          threadId: "thread-1",
         },
       },
     });
@@ -605,15 +605,15 @@ describe("main-session-restart-recovery", () => {
       | undefined;
     expect(gatewayCall?.method).toBe("message.action");
     expect(gatewayCall?.params).toMatchObject({
-      channel: "telegram",
+      channel: "demo-channel",
       action: "send",
       accountId: "default",
-      sessionKey: "agent:main:telegram:group:12345",
+      sessionKey: "agent:main:demo-channel:room-1",
       sessionId: "main-session",
     });
     expect(gatewayCall?.params?.params).toMatchObject({
-      to: "group:12345",
-      threadId: "topic-1",
+      to: "room-1",
+      threadId: "thread-1",
       bestEffort: true,
     });
     expect(String((gatewayCall?.params?.params as Record<string, unknown>)?.message)).toContain(
@@ -621,7 +621,7 @@ describe("main-session-restart-recovery", () => {
     );
 
     const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
-    expect(store["agent:main:telegram:group:12345"]?.status).toBe("failed");
-    expect(store["agent:main:telegram:group:12345"]?.abortedLastRun).toBe(true);
+    expect(store["agent:main:demo-channel:room-1"]?.status).toBe("failed");
+    expect(store["agent:main:demo-channel:room-1"]?.abortedLastRun).toBe(true);
   });
 });

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -574,4 +574,54 @@ describe("main-session-restart-recovery", () => {
     expect(store["agent:main:main"]?.status).toBe("failed");
     expect(store["agent:main:main"]?.abortedLastRun).toBe(true);
   });
+
+  it("sends a visible notice before failing an unresumable chat-bound main session", async () => {
+    const sessionsDir = await makeSessionsDir();
+    await writeStore(sessionsDir, {
+      "agent:main:telegram:group:12345": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+        deliveryContext: {
+          channel: "telegram",
+          to: "group:12345",
+          accountId: "default",
+          threadId: "topic-1",
+        },
+      },
+    });
+    await writeTranscript(sessionsDir, "main-session", [
+      { role: "user", content: "do the thing" },
+      { role: "assistant", content: "partial answer" },
+    ]);
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(result).toEqual({ recovered: 0, failed: 1, skipped: 0 });
+    expect(callGateway).toHaveBeenCalledOnce();
+    const gatewayCall = vi.mocked(callGateway).mock.calls[0]?.[0] as
+      | { method?: string; params?: Record<string, unknown> }
+      | undefined;
+    expect(gatewayCall?.method).toBe("message.action");
+    expect(gatewayCall?.params).toMatchObject({
+      channel: "telegram",
+      action: "send",
+      accountId: "default",
+      sessionKey: "agent:main:telegram:group:12345",
+      sessionId: "main-session",
+    });
+    expect(gatewayCall?.params?.params).toMatchObject({
+      to: "group:12345",
+      threadId: "topic-1",
+      bestEffort: true,
+    });
+    expect(String((gatewayCall?.params?.params as Record<string, unknown>)?.message)).toContain(
+      "couldn't safely resume",
+    );
+
+    const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
+    expect(store["agent:main:telegram:group:12345"]?.status).toBe("failed");
+    expect(store["agent:main:telegram:group:12345"]?.abortedLastRun).toBe(true);
+  });
 });

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -22,6 +22,8 @@ import { resolveGatewaySessionStoreTarget } from "../gateway/session-utils.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { CommandLane } from "../process/lanes.js";
 import { isAcpSessionKey, isCronSessionKey, isSubagentSessionKey } from "../routing/session-key.js";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
+import { deliveryContextFromSession } from "../utils/delivery-context.shared.js";
 import { resolveAgentSessionDirs } from "./session-dirs.js";
 import type { SessionLockInspection } from "./session-write-lock.js";
 
@@ -30,6 +32,9 @@ const log = createSubsystemLogger("main-session-restart-recovery");
 const DEFAULT_RECOVERY_DELAY_MS = 5_000;
 const MAX_RECOVERY_RETRIES = 3;
 const RETRY_BACKOFF_MULTIPLIER = 2;
+const UNRESUMABLE_SESSION_NOTICE =
+  "I was interrupted by a gateway restart and couldn't safely resume the previous turn. " +
+  "Please send that last request again and I'll pick it up cleanly.";
 
 function shouldSkipMainRecovery(entry: SessionEntry, sessionKey: string): boolean {
   if (typeof entry.spawnDepth === "number" && entry.spawnDepth > 0) {
@@ -274,6 +279,57 @@ async function markSessionFailed(params: {
   log.warn(`marked interrupted main session failed: ${params.sessionKey} (${params.reason})`);
 }
 
+async function sendUnresumableSessionNotice(params: {
+  entry: SessionEntry;
+  reason: string;
+  sessionKey: string;
+}): Promise<boolean> {
+  const deliveryContext = deliveryContextFromSession(params.entry);
+  const channel = normalizeOptionalString(deliveryContext?.channel);
+  const to = normalizeOptionalString(deliveryContext?.to);
+  if (!channel || !to) {
+    return false;
+  }
+
+  const messageParams: Record<string, unknown> = {
+    to,
+    message: UNRESUMABLE_SESSION_NOTICE,
+    bestEffort: true,
+  };
+  if (deliveryContext?.threadId != null) {
+    messageParams.threadId = deliveryContext.threadId;
+  }
+  const actionParams: Record<string, unknown> = {
+    channel,
+    action: "send",
+    sessionKey: params.sessionKey,
+    sessionId: params.entry.sessionId,
+    idempotencyKey: `main-session-restart-recovery:${params.entry.sessionId}:failed-notice`,
+    params: messageParams,
+  };
+  const accountId = normalizeOptionalString(deliveryContext?.accountId);
+  if (accountId) {
+    actionParams.accountId = accountId;
+  }
+
+  try {
+    await callGateway({
+      method: "message.action",
+      params: actionParams,
+      timeoutMs: 10_000,
+    });
+    log.info(
+      `sent interrupted main session recovery notice: ${params.sessionKey} (${params.reason})`,
+    );
+    return true;
+  } catch (err) {
+    log.warn(
+      `failed to send interrupted main session recovery notice ${params.sessionKey}: ${String(err)}`,
+    );
+    return false;
+  }
+}
+
 async function resumeMainSession(params: {
   storePath: string;
   sessionKey: string;
@@ -432,6 +488,11 @@ async function recoverStore(params: {
 
     const resumeBlockReason = resolveMainSessionResumeBlockReason(messages);
     if (resumeBlockReason) {
+      await sendUnresumableSessionNotice({
+        entry,
+        sessionKey,
+        reason: resumeBlockReason,
+      });
       await markSessionFailed({
         storePath: params.storePath,
         sessionKey,

--- a/src/gateway/server.reload.test.ts
+++ b/src/gateway/server.reload.test.ts
@@ -333,6 +333,7 @@ describe("gateway hot reload", () => {
     prevSkipProviders = process.env.OPENCLAW_SKIP_PROVIDERS;
     prevOpenAiApiKey = process.env.OPENAI_API_KEY;
     process.env.OPENCLAW_SKIP_CHANNELS = "0";
+    process.env.OPENAI_API_KEY = "sk-test-reload"; // pragma: allowlist secret
     delete process.env.OPENCLAW_SKIP_GMAIL_WATCHER;
     delete process.env.OPENCLAW_SKIP_PROVIDERS;
     hoisted.cronInstances.length = 0;


### PR DESCRIPTION
## Summary

- Fixes #85804 by sending a best-effort visible recovery notice when restart recovery cannot safely resume a chat-bound main session.
- Marks the stale session failed after the notice, so later restart-recovery passes do not keep spamming the chat.
- Uses the existing gateway `message.action` send path and persisted delivery context, including account and thread/topic metadata.
- Adds focused regression coverage for the unresumable Telegram group-session path.

Fixes #85804.

## Real behavior proof

Behavior addressed: A Telegram-backed main session could be interrupted by a gateway restart, fail restart recovery with `transcript tail is not resumable`, and leave the chat silent or out of context. The fixed behavior is a visible generic recovery notice before the stale session is marked failed.

Real environment tested: OpenClaw `2026.5.20` incident logs from a real Telegram group setup, plus after-fix validation from this PR branch using the real gateway `message.action` transport against a throwaway Telegram main-session recovery state.

Exact steps or command run after this patch: Seeded a throwaway restart-aborted Telegram main session with persisted delivery context, then ran `recoverRestartAbortedMainSessions({ stateDir })` twice from this PR branch. The first pass exercised the real gateway send path; the second pass verified the failed session did not send again.

Evidence after fix: Redacted terminal output below shows the patched recovery path sending `[main-session-restart-recovery] sent interrupted main session recovery notice` through `message.action`, marking the same Telegram main session failed, and then returning `failed=0` on the second pass. The PR body also includes the copied live output block under “Live Telegram gateway proof.”

Observed result after fix: The generic recovery notice appeared once in the Telegram proof chat via the real gateway `message.action` transport. The second recovery pass stayed silent because the seeded session had already been persisted as failed.

What was not tested: I did not intentionally crash a live production gateway after installing this branch, because that would risk disrupting active sessions.

Behavior addressed: a Telegram-backed main session could be interrupted by a gateway restart, fail restart recovery with `transcript tail is not resumable`, and leave the chat silent or out of context. The fixed behavior is a visible generic recovery notice before the stale session is marked failed.

Real environment tested: OpenClaw `2026.5.20` incident logs from a real Telegram group setup, plus after-fix validation from this PR branch. Mantis Telegram Desktop proof was requested, but the secret-bearing workflow requires write/maintain/admin repository permission and this contributor account is only read-authorized there. The live gateway proof below is the transport-level evidence available from this branch.

Exact validation commands:

```bash
OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=30000 OPENCLAW_VITEST_MAX_WORKERS=1 timeout 75s node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-support.config.ts src/agents/main-session-restart-recovery.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/main-session-restart-recovery.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/plugin-activation-boundary.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway-server.config.ts src/gateway/server.reload.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.full-core-support-boundary.config.ts
```

### Live Telegram gateway proof

I exercised the patched recovery path against the real gateway transport from this PR branch with a throwaway seeded main session whose persisted delivery context pointed at the active Telegram proof chat. This intentionally sent the generic recovery notice once to Telegram, then immediately reran recovery against the same seeded state to prove no repeat after the session was marked failed.

Command shape, with private chat/session details redacted:

```bash
timeout 30s node --import tsx --input-type=module <<'PROOF_EOF'
# Seed /tmp/openclaw-pr85805-proof-*/agents/main/sessions/sessions.json with:
# - status: "running"
# - abortedLastRun: true
# - deliveryContext: { channel: "telegram", to: "<redacted-proof-chat>", accountId: "default" }
# Seed pr85805-proof-session.jsonl with a user message followed by an assistant partial,
# then call recoverRestartAbortedMainSessions({ stateDir: root }) twice.
PROOF_EOF
```

Redacted terminal output:

```text
starting proof
[main-session-restart-recovery] sent interrupted main session recovery notice: agent:main:telegram:group:<redacted-proof-chat> (transcript tail is not resumable)
[main-session-restart-recovery] marked interrupted main session failed: agent:main:telegram:group:<redacted-proof-chat> (transcript tail is not resumable)
[main-session-restart-recovery] main-session restart recovery complete: recovered=0 failed=1 skipped=0
PR #85805 live gateway Telegram proof (redacted)
stateDir=<tmp>/openclaw-pr85805-proof-XuaLdD
sessionKey=agent:main:telegram:group:<redacted-proof-chat>
first pass:  recovered=0 failed=1 skipped=0, statusAfterFirst=failed
second pass: recovered=0 failed=0 skipped=0, statusAfterSecond=failed
exit:0
```

Observed result: the generic recovery notice appeared once in the Telegram proof chat via the real gateway `message.action` transport. The second pass did not send again because the seeded session was already persisted as failed.

### Before-fix evidence

Redacted runtime log excerpt from the real setup before the fix:

```text
[agent/embedded] codex app-server connection closed during startup; retries exhausted
[agents/harness] Codex agent harness failed; not falling back to embedded PI backend
[diagnostic] lane task error: lane=main durationMs=<duration> error="Error: codex app-server client is closed"
Embedded agent failed before reply: codex app-server client is closed
[typing] TTL exceeded, auto-stopping typing indicator
[main-session-restart-recovery] marked interrupted main session failed: <telegram-main-session> (transcript tail is not resumable)
[main-session-restart-recovery] main-session restart recovery complete: recovered=0 failed=1 skipped=0
```

What was not tested: I did not intentionally crash a live production gateway after installing this branch, because that would risk disrupting active sessions.

## Testing

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/main-session-restart-recovery.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/plugin-activation-boundary.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway-server.config.ts src/gateway/server.reload.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.full-core-support-boundary.config.ts`

Focused latest-head validation after ClawSweeper P2 fix:

```text
plugin-activation-boundary.test.ts:
Test Files  1 passed (1)
Tests  1 passed (1)

main-session-restart-recovery.test.ts:
Test Files  1 passed (1)
Tests  17 passed (17)

git diff --check:
clean
```


