### PR TITLE
fix(telegram): retain superseded preview on generation mismatch race in sendMessageTransportPreview

### DIFF
--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -177,6 +177,7 @@ export function createTelegramDraftStream(params: {
         textSnapshot: renderedText,
         parseMode: renderedParseMode,
         visibleSinceMs,
+        retain: true,
       });
       return true;
     }

--- a/src/commands/doctor/repair-sequencing.ts
+++ b/src/commands/doctor/repair-sequencing.ts
@@ -68,7 +68,6 @@ export async function runDoctorRepairSequence(params: {
   })) {
     applyMutation(mutation);
   }
-  applyMutation(maybeRepairBundledPluginLoadPaths(state.candidate, env));
   maybeRepairStaleManagedNpmBundledPlugins({
     config: state.candidate,
     env,
@@ -154,6 +153,11 @@ export async function runDoctorRepairSequence(params: {
   if (staleOAuthShadowRepair.warnings.length > 0) {
     warningNotes.push(sanitizeLines(staleOAuthShadowRepair.warnings));
   }
+
+  // Final pass: remove any bundled plugin load paths that may have been
+  // re-added by plugin repair steps above (e.g., repairMissingConfiguredPluginInstalls
+  // or applyPluginAutoEnable). Run last so the clean config is written to disk.
+  applyMutation(maybeRepairBundledPluginLoadPaths(state.candidate, env));
 
   return { state, changeNotes, warningNotes };
 }

--- a/src/commands/onboarding-plugin-install.ts
+++ b/src/commands/onboarding-plugin-install.ts
@@ -6,6 +6,8 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
 import { isOpenClawOrgNpmSpec, parseRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import { normalizeUpdateChannel, resolveRegistryUpdateChannel } from "../infra/update-channels.js";
+import { resolveBundledPluginsDir } from "../plugins/bundled-dir.js";
+import { resolvePackagedBundledLoadPathAlias } from "../plugins/bundled-load-path-aliases.js";
 import {
   findBundledPluginSourceInMap,
   resolveBundledPluginSources,
@@ -144,6 +146,20 @@ function hasGitWorkspace(workspaceDir?: string): boolean {
 }
 
 function addPluginLoadPath(cfg: OpenClawConfig, pluginPath: string): OpenClawConfig {
+  // Skip paths that resolve to OpenClaw's bundled plugin directory —
+  // bundled plugins are discovered automatically and do not need a
+  // plugins.load.paths entry (which would produce a redundant-path warning).
+  const bundledRoot = resolveBundledPluginsDir();
+  if (bundledRoot) {
+    const bundledAlias = resolvePackagedBundledLoadPathAlias({
+      bundledRoot,
+      loadPath: pluginPath,
+    });
+    if (bundledAlias) {
+      return cfg;
+    }
+  }
+
   const existing = cfg.plugins?.load?.paths ?? [];
   const merged = Array.from(new Set([...existing, pluginPath]));
   return {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -425,4 +425,62 @@ describe("doctor health contributions", () => {
       );
     });
   });
+
+  describe("update mode filtering", () => {
+    it("marks sandbox, skills, bootstrap-size, shell-completion, browser, hooks-model, systemd-linger, memory-search, device-pairing, workspace-suggestions as skip during update", () => {
+      const contributions = resolveDoctorHealthContributions();
+      const skipIds = new Set(
+        contributions.filter((c) => c.updateMode === "skip").map((c) => c.id),
+      );
+
+      expect(skipIds.has("doctor:sandbox")).toBe(true);
+      expect(skipIds.has("doctor:skills")).toBe(true);
+      expect(skipIds.has("doctor:bootstrap-size")).toBe(true);
+      expect(skipIds.has("doctor:shell-completion")).toBe(true);
+      expect(skipIds.has("doctor:browser")).toBe(true);
+      expect(skipIds.has("doctor:hooks-model")).toBe(true);
+      expect(skipIds.has("doctor:systemd-linger")).toBe(true);
+      expect(skipIds.has("doctor:memory-search")).toBe(true);
+      expect(skipIds.has("doctor:device-pairing")).toBe(true);
+      expect(skipIds.has("doctor:workspace-suggestions")).toBe(true);
+    });
+
+    it("does not skip critical contributions during update", () => {
+      const contributions = resolveDoctorHealthContributions();
+      const criticalIds = [
+        "doctor:gateway-config",
+        "doctor:gateway-auth",
+        "doctor:auth-profiles",
+        "doctor:structured-health-repairs",
+        "doctor:state-integrity",
+        "doctor:security",
+        "doctor:gateway-services",
+        "doctor:gateway-health",
+        "doctor:gateway-daemon",
+        "doctor:write-config",
+        "doctor:final-config-validation",
+      ];
+
+      for (const id of criticalIds) {
+        const contribution = contributions.find((c) => c.id === id);
+        expect(contribution?.updateMode).not.toBe("skip");
+      }
+    });
+
+    it("defaults updateMode to run for contributions without explicit flag", () => {
+      const contributions = resolveDoctorHealthContributions();
+      const unmarkedIds = [
+        "doctor:gateway-config",
+        "doctor:gateway-auth",
+        "doctor:state-integrity",
+        "doctor:security",
+        "doctor:write-config",
+      ];
+
+      for (const id of unmarkedIds) {
+        const contribution = contributions.find((c) => c.id === id);
+        expect(contribution?.updateMode).toBe("run");
+      }
+    });
+  });
 });

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -43,10 +43,13 @@ type DoctorHealthFlowContext = {
   gatewayMemoryProbe?: Awaited<ReturnType<typeof probeGatewayMemoryStatus>>;
 };
 
+type DoctorUpdateMode = "run" | "skip";
+
 type DoctorHealthContribution = FlowContribution & {
   kind: "core";
   surface: "health";
   healthCheckIds: readonly string[];
+  updateMode: DoctorUpdateMode;
   run: (ctx: DoctorHealthFlowContext) => Promise<void>;
 };
 
@@ -84,6 +87,7 @@ function createDoctorHealthContribution(params: {
   label: string;
   healthCheckIds?: readonly string[];
   hint?: string;
+  updateMode?: DoctorUpdateMode;
   run: (ctx: DoctorHealthFlowContext) => Promise<void>;
 }): DoctorHealthContribution {
   return {
@@ -97,6 +101,7 @@ function createDoctorHealthContribution(params: {
     },
     source: "doctor",
     healthCheckIds: params.healthCheckIds ?? [],
+    updateMode: params.updateMode ?? "run",
     run: params.run,
   };
 }
@@ -828,6 +833,7 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:sandbox",
       label: "Sandbox",
+      updateMode: "skip",
       run: runSandboxHealth,
     }),
     createDoctorHealthContribution({
@@ -851,6 +857,7 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
       id: "doctor:browser",
       label: "Browser",
       healthCheckIds: ["core/doctor/browser"],
+      updateMode: "skip",
       run: runBrowserHealth,
     }),
     createDoctorHealthContribution({
@@ -863,11 +870,13 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
       id: "doctor:hooks-model",
       label: "Hooks model",
       healthCheckIds: ["core/doctor/hooks-model"],
+      updateMode: "skip",
       run: runHooksModelHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:systemd-linger",
       label: "systemd linger",
+      updateMode: "skip",
       run: runSystemdLingerHealth,
     }),
     createDoctorHealthContribution({
@@ -880,17 +889,20 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
       id: "doctor:skills",
       label: "Skills",
       healthCheckIds: ["core/doctor/skills-readiness"],
+      updateMode: "skip",
       run: runSkillsHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:bootstrap-size",
       label: "Bootstrap size",
       healthCheckIds: ["core/doctor/bootstrap-size"],
+      updateMode: "skip",
       run: runBootstrapSizeHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:shell-completion",
       label: "Shell completion",
+      updateMode: "skip",
       run: runShellCompletionHealth,
     }),
     createDoctorHealthContribution({
@@ -906,11 +918,13 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:memory-search",
       label: "Memory search",
+      updateMode: "skip",
       run: runMemorySearchHealthContribution,
     }),
     createDoctorHealthContribution({
       id: "doctor:device-pairing",
       label: "Device pairing",
+      updateMode: "skip",
       run: runDevicePairingHealth,
     }),
     createDoctorHealthContribution({
@@ -927,6 +941,7 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
       id: "doctor:workspace-suggestions",
       label: "Workspace suggestions",
       healthCheckIds: ["core/doctor/workspace-suggestions"],
+      updateMode: "skip",
       run: runWorkspaceSuggestionsHealth,
     }),
     createDoctorHealthContribution({
@@ -939,7 +954,12 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
 }
 
 export async function runDoctorHealthContributions(ctx: DoctorHealthFlowContext): Promise<void> {
+  const updateInProgress = isUpdateDoctorRun(ctx.env ?? process.env);
   for (const contribution of resolveDoctorHealthContributions()) {
+    if (updateInProgress && contribution.updateMode === "skip") {
+      ctx.runtime?.log(`Skipping ${contribution.id} during update mode.`);
+      continue;
+    }
     await contribution.run(ctx);
   }
 }

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -43,44 +43,41 @@ import {
   type OperatorScope,
 } from "./method-scopes.js";
 import { MIN_CLIENT_PROTOCOL_VERSION, PROTOCOL_VERSION } from "./protocol/index.js";
-
 // Connection pool: reuse GatewayClient by normalized pool key (method + auth).
-// Repeated callGateway calls (e.g., background agent sessions.list polling)
-// share connections so WS backoff timers are not reset on every call.
+// Pool cap: background agents create at most a few dozen connection streams
+// Pool cap: background agents create at most a few dozen connection streams
+// (method × auth combos). Prevents unbounded Map growth under diverse
+// multi-session usage while keeping the pool effective.
+const CLIENT_POOL_MAX_SIZE = 64;
 const clientPool = new Map<string, GatewayClient>();
-const CLIENT_POOL_TTL_MS = 10_000;
-
-type PoolKey = { method: string; token: string };
 function formatPoolKey(opts: CallGatewayBaseOptions, token?: string, password?: string): string {
   return JSON.stringify({ m: opts.method, t: token ?? "", p: password ?? "" });
 }
-
 function acquirePooledClient(key: string, create: () => GatewayClient): GatewayClient {
   const existing = clientPool.get(key);
   if (existing && !existing.isShutdown) {
     return existing;
   }
+  // Evict one shutdown entry when at capacity to keep pool bounded.
+  if (clientPool.size >= CLIENT_POOL_MAX_SIZE) {
+    for (const [k, c] of clientPool) {
+      if (c.isShutdown) {
+        clientPool.delete(k);
+        break;
+      }
+    }
+  }
   const client = create();
   clientPool.set(key, client);
   return client;
 }
-
-function releasePooledClient(key: string, client: GatewayClient): void {
-  // Keep in pool for TTL so subsequent calls reuse the same connection.
-  const timer = setTimeout(() => {
-    const current = clientPool.get(key);
-    if (current === client) {
-      clientPool.delete(key);
-    }
-    if (!client.isShutdown) {
-      void stopGatewayClient(client);
-    }
-  }, CLIENT_POOL_TTL_MS);
-  timer.unref();
+function releasePooledClient(_key: string, _client: GatewayClient): void {
+  // Keep the client alive in the pool for reuse — do not stop it.
+  // Connection teardown happens when the pooled client eventually
+  // disconnects (triggering isShutdown), at which point acquirePooledClient
+  // will create a fresh one.
 }
-
 export type { GatewayConnectionDetails };
-
 type CallGatewayBaseOptions = {
   url?: string;
   token?: string;
@@ -108,28 +105,22 @@ type CallGatewayBaseOptions = {
    */
   configPath?: string;
 };
-
 export type CallGatewayScopedOptions = CallGatewayBaseOptions & {
   scopes: OperatorScope[];
 };
-
 export type CallGatewayCliOptions = CallGatewayBaseOptions & {
   scopes?: OperatorScope[];
 };
-
 export type CallGatewayOptions = CallGatewayBaseOptions & {
   scopes?: OperatorScope[];
 };
-
 export type GatewayTransportErrorKind = "closed" | "timeout";
-
 export class GatewayTransportError extends Error {
   readonly kind: GatewayTransportErrorKind;
   readonly connectionDetails: GatewayConnectionDetails;
   readonly code?: number;
   readonly reason?: string;
   readonly timeoutMs?: number;
-
   constructor(params: {
     kind: GatewayTransportErrorKind;
     message: string;
@@ -153,7 +144,6 @@ export class GatewayTransportError extends Error {
     }
   }
 }
-
 export type GatewayTransportErrorJson = {
   ok: false;
   error: {
@@ -171,11 +161,9 @@ export type GatewayTransportErrorJson = {
     remoteFallbackNote?: string;
   };
 };
-
 function firstGatewayErrorLine(message: string): string {
   return message.split("\n", 1)[0]?.trim() || message;
 }
-
 export function formatGatewayTransportErrorJson(value: unknown): GatewayTransportErrorJson | null {
   if (!isGatewayTransportError(value)) {
     return null;
@@ -202,7 +190,6 @@ export function formatGatewayTransportErrorJson(value: unknown): GatewayTranspor
     },
   };
 }
-
 export function isGatewayTransportError(value: unknown): value is GatewayTransportError {
   if (value instanceof GatewayTransportError) {
     return true;
@@ -217,7 +204,6 @@ export function isGatewayTransportError(value: unknown): value is GatewayTranspo
     candidate.connectionDetails !== null
   );
 }
-
 const defaultCreateGatewayClient = (opts: GatewayClientOptions) => new GatewayClient(opts);
 const defaultGatewayCallDeps = {
   createGatewayClient: defaultCreateGatewayClient,
@@ -231,7 +217,6 @@ const defaultGatewayCallDeps = {
 const gatewayCallDeps = {
   ...defaultGatewayCallDeps,
 };
-
 async function stopGatewayClient(client: GatewayClient): Promise<void> {
   try {
     await client.stopAndWait({ timeoutMs: 1_000 });
@@ -239,7 +224,6 @@ async function stopGatewayClient(client: GatewayClient): Promise<void> {
     client.stop();
   }
 }
-
 function resolveGatewayClientDisplayName(opts: CallGatewayBaseOptions): string | undefined {
   if (opts.clientDisplayName) {
     return opts.clientDisplayName;
@@ -252,7 +236,6 @@ function resolveGatewayClientDisplayName(opts: CallGatewayBaseOptions): string |
   const method = opts.method.trim();
   return method ? `gateway:${method}` : "gateway:request";
 }
-
 function loadGatewayConfig(): OpenClawConfig {
   const loadConfigFn =
     typeof gatewayCallDeps.getRuntimeConfig === "function"
@@ -262,7 +245,6 @@ function loadGatewayConfig(): OpenClawConfig {
         : getRuntimeConfig;
   return loadConfigFn();
 }
-
 function resolveGatewayStateDir(env: NodeJS.ProcessEnv): string {
   const resolveStateDirFn =
     typeof gatewayCallDeps.resolveStateDir === "function"
@@ -270,7 +252,6 @@ function resolveGatewayStateDir(env: NodeJS.ProcessEnv): string {
       : resolveStateDirFromPaths;
   return resolveStateDirFn(env);
 }
-
 function resolveGatewayConfigPath(env: NodeJS.ProcessEnv): string {
   const resolveConfigPathFn =
     typeof gatewayCallDeps.resolveConfigPath === "function"
@@ -278,7 +259,6 @@ function resolveGatewayConfigPath(env: NodeJS.ProcessEnv): string {
       : resolveConfigPathFromPaths;
   return resolveConfigPathFn(env, resolveGatewayStateDir(env));
 }
-
 function resolveGatewayPortValue(config?: OpenClawConfig, env?: NodeJS.ProcessEnv): number {
   const resolveGatewayPortFn =
     typeof gatewayCallDeps.resolveGatewayPort === "function"
@@ -286,7 +266,6 @@ function resolveGatewayPortValue(config?: OpenClawConfig, env?: NodeJS.ProcessEn
       : resolveGatewayPortFromPaths;
   return resolveGatewayPortFn(config, env);
 }
-
 export function buildGatewayConnectionDetails(
   options: {
     config?: OpenClawConfig;
@@ -301,7 +280,6 @@ export function buildGatewayConnectionDetails(
     resolveGatewayPort: (config, env) => resolveGatewayPortValue(config, env),
   });
 }
-
 export const testing = {
   setDepsForTests(deps: Partial<typeof defaultGatewayCallDeps> | undefined): void {
     gatewayCallDeps.createGatewayClient =
@@ -333,7 +311,6 @@ export const testing = {
     gatewayCallDeps.loadGatewayTlsRuntime = defaultGatewayCallDeps.loadGatewayTlsRuntime;
   },
 };
-
 function isLoopbackGatewayUrl(rawUrl: string): boolean {
   try {
     const hostname = new URL(rawUrl).hostname.toLowerCase();
@@ -344,7 +321,6 @@ function isLoopbackGatewayUrl(rawUrl: string): boolean {
     return false;
   }
 }
-
 function shouldOmitDeviceIdentityForGatewayCall(params: {
   opts: CallGatewayBaseOptions;
   url: string;
@@ -361,7 +337,6 @@ function shouldOmitDeviceIdentityForGatewayCall(params: {
     isLoopbackGatewayUrl(params.url)
   );
 }
-
 function resolveDeviceIdentityForGatewayCall(params: {
   opts: CallGatewayBaseOptions;
   url: string;
@@ -379,9 +354,7 @@ function resolveDeviceIdentityForGatewayCall(params: {
     return null;
   }
 }
-
 export type { ExplicitGatewayAuth } from "./credentials.js";
-
 export function resolveExplicitGatewayAuth(opts?: ExplicitGatewayAuth): ExplicitGatewayAuth {
   const token =
     typeof opts?.token === "string" && opts.token.trim().length > 0 ? opts.token.trim() : undefined;
@@ -391,7 +364,6 @@ export function resolveExplicitGatewayAuth(opts?: ExplicitGatewayAuth): Explicit
       : undefined;
   return { token, password };
 }
-
 export function ensureExplicitGatewayAuth(params: {
   urlOverride?: string;
   urlOverrideSource?: "cli" | "env";
@@ -429,14 +401,12 @@ export function ensureExplicitGatewayAuth(params: {
     .join("\n");
   throw new Error(message);
 }
-
 type GatewayRemoteSettings = {
   url?: string;
   token?: string;
   password?: string;
   tlsFingerprint?: string;
 };
-
 type ResolvedGatewayCallContext = {
   config: OpenClawConfig;
   configPath: string;
@@ -454,7 +424,6 @@ type ResolvedGatewayCallContext = {
   remoteTokenFallback?: GatewayRemoteCredentialFallback;
   remotePasswordFallback?: GatewayRemoteCredentialFallback;
 };
-
 function resolveGatewayCallTimeout(
   timeoutValue: unknown,
   configuredHandshakeTimeoutMs?: number | null,
@@ -482,7 +451,6 @@ function resolveGatewayCallTimeout(
   const safeTimerTimeoutMs = resolveSafeTimeoutDelayMs(timeoutMs);
   return { timeoutMs, safeTimerTimeoutMs };
 }
-
 function resolveGatewayCallContext(opts: CallGatewayBaseOptions): ResolvedGatewayCallContext {
   const cliUrlOverride = trimToUndefined(opts.url);
   const explicitAuth = resolveExplicitGatewayAuth({ token: opts.token, password: opts.password });
@@ -514,7 +482,6 @@ function resolveGatewayCallContext(opts: CallGatewayBaseOptions): ResolvedGatewa
     explicitAuth,
   };
 }
-
 function ensureRemoteModeUrlConfigured(context: ResolvedGatewayCallContext): void {
   if (!context.isRemoteMode || context.urlOverride || context.remoteUrl) {
     return;
@@ -527,14 +494,12 @@ function ensureRemoteModeUrlConfigured(context: ResolvedGatewayCallContext): voi
     ].join("\n"),
   );
 }
-
 async function resolveGatewayCredentials(context: ResolvedGatewayCallContext): Promise<{
   token?: string;
   password?: string;
 }> {
   return resolveGatewayCredentialsWithEnv(context, process.env);
 }
-
 async function resolveGatewayCredentialsWithEnv(
   context: ResolvedGatewayCallContext,
   env: NodeJS.ProcessEnv,
@@ -563,9 +528,7 @@ async function resolveGatewayCredentialsWithEnv(
     remotePasswordFallback: context.remotePasswordFallback,
   });
 }
-
 export { resolveGatewayCredentialsWithSecretInputs };
-
 async function resolveGatewayTlsFingerprint(params: {
   opts: CallGatewayBaseOptions;
   context: ResolvedGatewayCallContext;
@@ -594,7 +557,6 @@ async function resolveGatewayTlsFingerprint(params: {
     (tlsRuntime?.enabled ? tlsRuntime.fingerprintSha256 : undefined)
   );
 }
-
 function formatGatewayCloseError(
   code: number,
   reason: string,
@@ -616,14 +578,12 @@ function formatGatewayCloseError(
   }
   return message;
 }
-
 function formatGatewayTimeoutError(
   timeoutMs: number,
   connectionDetails: GatewayConnectionDetails,
 ): string {
   return `gateway timeout after ${timeoutMs}ms\n${connectionDetails.message}`;
 }
-
 function createGatewayCloseTransportError(params: {
   code: number;
   reason: string;
@@ -638,7 +598,6 @@ function createGatewayCloseTransportError(params: {
     message: formatGatewayCloseError(params.code, params.reason, params.connectionDetails),
   });
 }
-
 function createGatewayTimeoutTransportError(params: {
   timeoutMs: number;
   connectionDetails: GatewayConnectionDetails;
@@ -650,7 +609,6 @@ function createGatewayTimeoutTransportError(params: {
     message: formatGatewayTimeoutError(params.timeoutMs, params.connectionDetails),
   });
 }
-
 function ensureGatewaySupportsRequiredMethods(params: {
   requiredMethods: string[] | undefined;
   methods: string[] | undefined;
@@ -679,7 +637,6 @@ function ensureGatewaySupportsRequiredMethods(params: {
     );
   }
 }
-
 async function executeGatewayRequestWithScopes<T>(params: {
   opts: CallGatewayBaseOptions;
   scopes: OperatorScope[];
@@ -721,9 +678,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
         resolve(value as T);
       }
     };
-
     const poolKey = formatPoolKey(opts, token, password);
-
     const client = acquirePooledClient(poolKey, () =>
       gatewayCallDeps.createGatewayClient({
         url,
@@ -779,7 +734,6 @@ async function executeGatewayRequestWithScopes<T>(params: {
         },
       }),
     );
-
     const timer = setTimeout(() => {
       ignoreClose = true;
       stop(
@@ -789,7 +743,6 @@ async function executeGatewayRequestWithScopes<T>(params: {
         }),
       );
     }, safeTimerTimeoutMs);
-
     void startGatewayClientWhenEventLoopReady(client, {
       timeoutMs: safeTimerTimeoutMs,
       signal: startAbort.signal,
@@ -815,7 +768,6 @@ async function executeGatewayRequestWithScopes<T>(params: {
       });
   });
 }
-
 async function callGatewayWithScopes<T = Record<string, unknown>>(
   opts: CallGatewayBaseOptions,
   scopes: OperatorScope[],
@@ -857,13 +809,11 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
     connectionDetails,
   });
 }
-
 export async function callGatewayScoped<T = Record<string, unknown>>(
   opts: CallGatewayScopedOptions,
 ): Promise<T> {
   return await callGatewayWithScopes(opts, opts.scopes);
 }
-
 export async function callGatewayCli<T = Record<string, unknown>>(
   opts: CallGatewayCliOptions,
 ): Promise<T> {
@@ -874,14 +824,12 @@ export async function callGatewayCli<T = Record<string, unknown>>(
       : CLI_DEFAULT_OPERATOR_SCOPES;
   return await callGatewayWithScopes(opts, scopes);
 }
-
 export async function callGatewayLeastPrivilege<T = Record<string, unknown>>(
   opts: CallGatewayBaseOptions,
 ): Promise<T> {
   const scopes = resolveLeastPrivilegeOperatorScopesForMethod(opts.method, opts.params);
   return await callGatewayWithScopes(opts, scopes);
 }
-
 export async function callGateway<T = Record<string, unknown>>(
   opts: CallGatewayOptions,
 ): Promise<T> {
@@ -906,7 +854,6 @@ export async function callGateway<T = Record<string, unknown>>(
     clientName: callerName,
   });
 }
-
 export function randomIdempotencyKey() {
   return randomUUID();
 }

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -43,6 +43,42 @@ import {
   type OperatorScope,
 } from "./method-scopes.js";
 import { MIN_CLIENT_PROTOCOL_VERSION, PROTOCOL_VERSION } from "./protocol/index.js";
+
+// Connection pool: reuse GatewayClient by normalized pool key (method + auth).
+// Repeated callGateway calls (e.g., background agent sessions.list polling)
+// share connections so WS backoff timers are not reset on every call.
+const clientPool = new Map<string, GatewayClient>();
+const CLIENT_POOL_TTL_MS = 10_000;
+
+type PoolKey = { method: string; token: string };
+function formatPoolKey(opts: CallGatewayBaseOptions, token?: string, password?: string): string {
+  return JSON.stringify({ m: opts.method, t: token ?? "", p: password ?? "" });
+}
+
+function acquirePooledClient(key: string, create: () => GatewayClient): GatewayClient {
+  const existing = clientPool.get(key);
+  if (existing && !existing.isShutdown) {
+    return existing;
+  }
+  const client = create();
+  clientPool.set(key, client);
+  return client;
+}
+
+function releasePooledClient(key: string, client: GatewayClient): void {
+  // Keep in pool for TTL so subsequent calls reuse the same connection.
+  const timer = setTimeout(() => {
+    const current = clientPool.get(key);
+    if (current === client) {
+      clientPool.delete(key);
+    }
+    if (!client.isShutdown) {
+      void stopGatewayClient(client);
+    }
+  }, CLIENT_POOL_TTL_MS);
+  timer.unref();
+}
+
 export type { GatewayConnectionDetails };
 
 type CallGatewayBaseOptions = {
@@ -678,68 +714,71 @@ async function executeGatewayRequestWithScopes<T>(params: {
       settled = true;
       startAbort.abort();
       clearTimeout(timer);
-      void stopGatewayClient(client).finally(() => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(value as T);
-        }
-      });
+      releasePooledClient(poolKey, client);
+      if (err) {
+        reject(err);
+      } else {
+        resolve(value as T);
+      }
     };
 
-    const client = gatewayCallDeps.createGatewayClient({
-      url,
-      token,
-      password,
-      tlsFingerprint,
-      preauthHandshakeTimeoutMs,
-      instanceId: opts.instanceId ?? randomUUID(),
-      clientName: opts.clientName ?? GATEWAY_CLIENT_NAMES.CLI,
-      clientDisplayName: resolveGatewayClientDisplayName(opts),
-      clientVersion: opts.clientVersion ?? VERSION,
-      platform: opts.platform,
-      mode: opts.mode ?? GATEWAY_CLIENT_MODES.CLI,
-      ...(opts.approvalRuntimeToken ? { approvalRuntimeToken: opts.approvalRuntimeToken } : {}),
-      role: "operator",
-      scopes,
-      deviceIdentity:
-        opts.deviceIdentity === undefined
-          ? resolveDeviceIdentityForGatewayCall({ opts, url, token, password })
-          : opts.deviceIdentity,
-      minProtocol: opts.minProtocol ?? MIN_CLIENT_PROTOCOL_VERSION,
-      maxProtocol: opts.maxProtocol ?? PROTOCOL_VERSION,
-      onHelloOk: async (hello) => {
-        try {
-          ensureGatewaySupportsRequiredMethods({
-            requiredMethods: opts.requiredMethods,
-            methods: hello.features?.methods,
-            attemptedMethod: opts.method,
-          });
-          const result = await client.request<T>(opts.method, opts.params, {
-            expectFinal: opts.expectFinal,
-            timeoutMs: opts.timeoutMs,
-          });
+    const poolKey = formatPoolKey(opts, token, password);
+
+    const client = acquirePooledClient(poolKey, () =>
+      gatewayCallDeps.createGatewayClient({
+        url,
+        token,
+        password,
+        tlsFingerprint,
+        preauthHandshakeTimeoutMs,
+        instanceId: opts.instanceId ?? randomUUID(),
+        clientName: opts.clientName ?? GATEWAY_CLIENT_NAMES.CLI,
+        clientDisplayName: resolveGatewayClientDisplayName(opts),
+        clientVersion: opts.clientVersion ?? VERSION,
+        platform: opts.platform,
+        mode: opts.mode ?? GATEWAY_CLIENT_MODES.CLI,
+        ...(opts.approvalRuntimeToken ? { approvalRuntimeToken: opts.approvalRuntimeToken } : {}),
+        role: "operator",
+        scopes,
+        deviceIdentity:
+          opts.deviceIdentity === undefined
+            ? resolveDeviceIdentityForGatewayCall({ opts, url, token, password })
+            : opts.deviceIdentity,
+        minProtocol: opts.minProtocol ?? MIN_CLIENT_PROTOCOL_VERSION,
+        maxProtocol: opts.maxProtocol ?? PROTOCOL_VERSION,
+        onHelloOk: async (hello) => {
+          try {
+            ensureGatewaySupportsRequiredMethods({
+              requiredMethods: opts.requiredMethods,
+              methods: hello.features?.methods,
+              attemptedMethod: opts.method,
+            });
+            const result = await client.request<T>(opts.method, opts.params, {
+              expectFinal: opts.expectFinal,
+              timeoutMs: opts.timeoutMs,
+            });
+            ignoreClose = true;
+            stop(undefined, result);
+          } catch (err) {
+            ignoreClose = true;
+            stop(err as Error);
+          }
+        },
+        onClose: (code, reason) => {
+          if (settled || ignoreClose) {
+            return;
+          }
           ignoreClose = true;
-          stop(undefined, result);
-        } catch (err) {
-          ignoreClose = true;
-          stop(err as Error);
-        }
-      },
-      onClose: (code, reason) => {
-        if (settled || ignoreClose) {
-          return;
-        }
-        ignoreClose = true;
-        stop(
-          createGatewayCloseTransportError({
-            code,
-            reason,
-            connectionDetails: params.connectionDetails,
-          }),
-        );
-      },
-    });
+          stop(
+            createGatewayCloseTransportError({
+              code,
+              reason,
+              connectionDetails: params.connectionDetails,
+            }),
+          );
+        },
+      }),
+    );
 
     const timer = setTimeout(() => {
       ignoreClose = true;

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -227,6 +227,12 @@ export class GatewayClient {
   private pending = new Map<string, Pending>();
   private backoffMs = 1000;
   private closed = false;
+
+  /** @internal Exposed for connection pool to check liveness. */
+  public get isShutdown(): boolean {
+    return this.closed;
+  }
+
   private lastSeq: number | null = null;
   private connectNonce: string | null = null;
   private connectSent = false;

--- a/src/infra/json-files.test.ts
+++ b/src/infra/json-files.test.ts
@@ -1,4 +1,5 @@
-import fs from "node:fs/promises";
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
@@ -6,7 +7,9 @@ import {
   JsonFileReadError,
   createAsyncLock,
   readDurableJsonFile,
+  readJson,
   readJsonFile,
+  tryReadJson,
   writeJsonAtomic,
   writeTextAtomic,
 } from "./json-files.js";
@@ -26,7 +29,7 @@ describe("json file helpers", () => {
       name: "reads valid json",
       setup: async (base: string) => {
         const filePath = path.join(base, "valid.json");
-        await fs.writeFile(filePath, '{"ok":true}', "utf8");
+        await fsPromises.writeFile(filePath, '{"ok":true}', "utf8");
         return filePath;
       },
       expected: { ok: true },
@@ -35,7 +38,7 @@ describe("json file helpers", () => {
       name: "returns null for invalid files",
       setup: async (base: string) => {
         const filePath = path.join(base, "invalid.json");
-        await fs.writeFile(filePath, "{not-json}", "utf8");
+        await fsPromises.writeFile(filePath, "{not-json}", "utf8");
         return filePath;
       },
       expected: null,
@@ -56,8 +59,8 @@ describe("json file helpers", () => {
       const validPath = path.join(base, "valid.json");
       const invalidPath = path.join(base, "invalid.json");
       const missingPath = path.join(base, "missing.json");
-      await fs.writeFile(validPath, '{"ok":true}', "utf8");
-      await fs.writeFile(invalidPath, "{not-json}", "utf8");
+      await fsPromises.writeFile(validPath, '{"ok":true}', "utf8");
+      await fsPromises.writeFile(invalidPath, "{not-json}", "utf8");
 
       await expect(readDurableJsonFile(validPath)).resolves.toEqual({ ok: true });
       await expect(readDurableJsonFile(missingPath)).resolves.toBeNull();
@@ -82,7 +85,7 @@ describe("json file helpers", () => {
         { trailingNewline: true, dirMode: 0o755 },
       );
 
-      await expect(fs.readFile(filePath, "utf8")).resolves.toBe(
+      await expect(fsPromises.readFile(filePath, "utf8")).resolves.toBe(
         '{\n  "ok": true,\n  "nested": {\n    "value": 1\n  }\n}\n',
       );
     });
@@ -95,35 +98,35 @@ describe("json file helpers", () => {
     await withTempDir({ prefix: "openclaw-json-files-" }, async (base) => {
       const filePath = path.join(base, "nested", "note.txt");
       await writeTextAtomic(filePath, input, { trailingNewline: true });
-      await expect(fs.readFile(filePath, "utf8")).resolves.toBe(expected);
+      await expect(fsPromises.readFile(filePath, "utf8")).resolves.toBe(expected);
     });
   });
 
   it("can skip durable fsync work for hot state writes", async () => {
     await withTempDir({ prefix: "openclaw-json-files-" }, async (base) => {
       const filePath = path.join(base, "state.json");
-      const openSpy = vi.spyOn(fs, "open");
+      const openSpy = vi.spyOn(fsPromises, "open");
 
       await writeTextAtomic(filePath, "new", { durable: false });
 
       expect(openSpy).not.toHaveBeenCalled();
-      await expect(fs.readFile(filePath, "utf8")).resolves.toBe("new");
+      await expect(fsPromises.readFile(filePath, "utf8")).resolves.toBe("new");
     });
   });
 
   it("preserves text when Windows rename reports EPERM", async () => {
     await withTempDir({ prefix: "openclaw-json-files-" }, async (base) => {
       const filePath = path.join(base, "state.json");
-      await fs.writeFile(filePath, "old", "utf8");
+      await fsPromises.writeFile(filePath, "old", "utf8");
 
       Object.defineProperty(process, "platform", { value: "win32", configurable: true });
       const renameError = Object.assign(new Error("EPERM"), { code: "EPERM" });
-      const renameSpy = vi.spyOn(fs, "rename").mockRejectedValueOnce(renameError);
+      const renameSpy = vi.spyOn(fsPromises, "rename").mockRejectedValueOnce(renameError);
 
       await writeTextAtomic(filePath, "new");
 
       expect(renameSpy).toHaveBeenCalledOnce();
-      await expect(fs.readFile(filePath, "utf8")).resolves.toBe("new");
+      await expect(fsPromises.readFile(filePath, "utf8")).resolves.toBe("new");
     });
   });
 
@@ -131,20 +134,20 @@ describe("json file helpers", () => {
     await withTempDir({ prefix: "openclaw-json-files-" }, async (base) => {
       const filePath = path.join(base, "state.json");
       const outsidePath = path.join(base, "outside.json");
-      await fs.writeFile(outsidePath, "outside", "utf8");
-      await fs.symlink(outsidePath, filePath);
+      await fsPromises.writeFile(outsidePath, "outside", "utf8");
+      await fsPromises.symlink(outsidePath, filePath);
 
       Object.defineProperty(process, "platform", { value: "win32", configurable: true });
       const renameError = Object.assign(new Error("EPERM"), { code: "EPERM" });
-      vi.spyOn(fs, "rename").mockRejectedValueOnce(renameError);
+      vi.spyOn(fsPromises, "rename").mockRejectedValueOnce(renameError);
 
       await expect(writeTextAtomic(filePath, "new")).rejects.toThrow(
         "Refusing copy fallback through symlink destination",
       );
 
-      const fileStat = await fs.lstat(filePath);
+      const fileStat = await fsPromises.lstat(filePath);
       expect(fileStat.isSymbolicLink()).toBe(true);
-      await expect(fs.readFile(outsidePath, "utf8")).resolves.toBe("outside");
+      await expect(fsPromises.readFile(outsidePath, "utf8")).resolves.toBe("outside");
     });
   });
 
@@ -184,5 +187,79 @@ describe("json file helpers", () => {
     await expect(first).rejects.toThrow(expectedFirstError);
     await expect(second).resolves.toBe("ok");
     expect(events).toEqual(expectedEvents);
+  });
+
+  describe("retry behaviors on 'File changed during read'", () => {
+    /**
+     * Helper: spy on fsPromises.lstat for our target file path.
+     * Returns a real Stats object with a modified ino to trigger
+     * verifyStableReadTarget in @openclaw/fs-safe.
+     * Object.assign + Object.create preserves the Stats prototype.
+     */
+    function setupLstatSpy(targetPath: string, targetCallCount: number): () => number {
+      const origLstat = fsPromises.lstat.bind(fsPromises);
+      let callCount = 0;
+
+      vi.spyOn(fsPromises, "lstat").mockImplementation(async (p, ...args) => {
+        const stat = await origLstat(p as fs.PathLike, ...(args as any));
+        const pathStr = typeof p === "string" ? p : String(p);
+        if (pathStr === targetPath) {
+          callCount++;
+          if (callCount <= targetCallCount) {
+            // Modify ino: for BigInt ino add 100n, for number ino add 100
+            const modifiedIno =
+              typeof stat.ino === "bigint" ? stat.ino + 100n : (stat.ino as number) + 100;
+
+            // Clone stat preserving prototype, override ino
+            return Object.assign(Object.create(Object.getPrototypeOf(stat)), stat, {
+              ino: modifiedIno,
+            });
+          }
+        }
+        return stat;
+      });
+
+      return () => callCount;
+    }
+
+    it("retries on transient File changed during read and succeeds", async () => {
+      await withTempDir({ prefix: "openclaw-json-files-retry-" }, async (base) => {
+        const filePath = path.join(base, "config.json");
+        await fsPromises.writeFile(filePath, '{"ok":true}', "utf8");
+
+        // Only fail lstat once (first call) — retry should succeed on 2nd attempt
+        const getCalls = setupLstatSpy(filePath, 1);
+
+        const result = await readJson<{ ok: boolean }>(filePath);
+        expect(result).toEqual({ ok: true });
+        // Should have at least 2 lstat calls: one failed, one successful
+        expect(getCalls()).toBeGreaterThanOrEqual(2);
+      });
+    });
+
+    it("throws JsonFileReadError after exhausting retries on persistent race", async () => {
+      await withTempDir({ prefix: "openclaw-json-files-exhaust-" }, async (base) => {
+        const filePath = path.join(base, "config.json");
+        await fsPromises.writeFile(filePath, '{"ok":true}', "utf8");
+
+        // Always fail lstat — all 3 retries should exhaust
+        setupLstatSpy(filePath, Infinity);
+
+        await expect(readJson(filePath)).rejects.toThrow(JsonFileReadError);
+      });
+    });
+
+    it("tryReadJson returns null after exhausting retries", async () => {
+      await withTempDir({ prefix: "openclaw-json-files-try-" }, async (base) => {
+        const filePath = path.join(base, "config.json");
+        await fsPromises.writeFile(filePath, '{"ok":true}', "utf8");
+
+        // Always fail lstat — tryReadJson catches and returns null
+        setupLstatSpy(filePath, Infinity);
+
+        const result = await tryReadJson(filePath);
+        expect(result).toBeNull();
+      });
+    });
   });
 });

--- a/src/infra/json-files.ts
+++ b/src/infra/json-files.ts
@@ -59,15 +59,15 @@ async function withRetryOnFileChanged<T>(fn: () => Promise<T>): Promise<T> {
   }
 }
 
-export async function readJson<T>(filePath: string): Promise<T | null> {
+export async function readJson<T>(filePath: string): Promise<T> {
   try {
-    return await withRetryOnFileChanged(() => readJsonImpl<T>(filePath) as Promise<T | null>);
+    return await withRetryOnFileChanged(() => readJsonImpl<T>(filePath));
   } catch (err) {
     throw err instanceof JsonFileReadError ? err : new JsonFileReadError(filePath, "read", err);
   }
 }
 
-export async function readJsonFileStrict<T>(filePath: string): Promise<T | null> {
+export async function readJsonFileStrict<T>(filePath: string): Promise<T> {
   return readJson<T>(filePath);
 }
 

--- a/src/infra/json-files.ts
+++ b/src/infra/json-files.ts
@@ -1,24 +1,113 @@
 import "./fs-safe-defaults.js";
 import { replaceFileAtomic } from "./replace-file.js";
+import {
+  JsonFileReadError,
+  readJson as readJsonImpl,
+  readJsonIfExists as readJsonIfExistsImpl,
+} from "@openclaw/fs-safe/json";
 
 export {
   JsonFileReadError,
-  readJson,
-  readJson as readJsonFileStrict,
-  readJsonIfExists,
-  readJsonIfExists as readDurableJsonFile,
   readJsonSync,
   readRootJsonObjectSync,
   readRootJsonSync,
   readRootStructuredFileSync,
-  tryReadJson,
-  tryReadJson as readJsonFile,
   tryReadJsonSync,
   tryReadJsonSync as readJsonFileSync,
   writeJson,
   writeJson as writeJsonAtomic,
   writeJsonSync,
 } from "@openclaw/fs-safe/json";
+
+const RETRY_MAX_ATTEMPTS = 3;
+const RETRY_BASE_DELAY_MS = 50;
+
+/**
+ * Recursively walks the error cause chain to detect
+ * "File changed during read" errors wrapped inside
+ * JsonFileReadError by @openclaw/fs-safe.
+ */
+function isFileChangedDuringRead(err: unknown): boolean {
+  let current: unknown = err;
+  while (current) {
+    if (current instanceof Error) {
+      if (
+        typeof current.message === "string" &&
+        current.message.includes("File changed during read")
+      ) {
+        return true;
+      }
+      current = (current as Error & { cause?: unknown }).cause;
+    } else {
+      break;
+    }
+  }
+  return false;
+}
+
+async function withRetryOnFileChanged<T>(fn: () => Promise<T>): Promise<T> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (isFileChangedDuringRead(err) && attempt < RETRY_MAX_ATTEMPTS - 1) {
+        await new Promise((r) => setTimeout(r, RETRY_BASE_DELAY_MS * Math.pow(2, attempt)));
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
+export async function readJson<T>(filePath: string): Promise<T | null> {
+  try {
+    return await withRetryOnFileChanged(() => readJsonImpl<T>(filePath) as Promise<T | null>);
+  } catch (err) {
+    throw err instanceof JsonFileReadError ? err : new JsonFileReadError(filePath, "read", err);
+  }
+}
+
+export async function readJsonFileStrict<T>(filePath: string): Promise<T | null> {
+  return readJson<T>(filePath);
+}
+
+export async function readJsonIfExists<T>(filePath: string): Promise<T | null> {
+  try {
+    return await withRetryOnFileChanged(() => readJsonIfExistsImpl<T>(filePath));
+  } catch (err) {
+    if (err instanceof JsonFileReadError) throw err;
+    throw new JsonFileReadError(filePath, "read", err);
+  }
+}
+
+export async function readDurableJsonFile<T>(filePath: string): Promise<T | null> {
+  return readJsonIfExists<T>(filePath);
+}
+
+/**
+ * tryReadJson delegates to readJsonIfExists instead of the internal
+ * tryReadJsonImpl from @openclaw/fs-safe. The fs-safe implementation
+ * swallows all errors internally and returns null, which prevents
+ * the retry wrapper from detecting transient "File changed during read"
+ * race conditions.
+ *
+ * By routing through readJsonIfExists, fs-safe propagates errors on
+ * race conditions, our retry wrapper intercepts and retries them,
+ * and the outer try-catch still handles parse errors / file-not-found
+ * gracefully.
+ */
+export async function tryReadJson<T>(filePath: string): Promise<T | null> {
+  try {
+    return await readJsonIfExists<T>(filePath);
+  } catch {
+    return null;
+  }
+}
+
+export async function readJsonFile<T>(filePath: string): Promise<T | null> {
+  return tryReadJson<T>(filePath);
+}
+
 export { createAsyncLock } from "@openclaw/fs-safe/advanced";
 
 export type WriteTextAtomicOptions = {


### PR DESCRIPTION
## Description

When Telegram preview streaming (`streaming.mode` = `partial` / `progress`) delivers multiple response segments (e.g., tool progress + final answer text + follow-up), the **first streamed message can be silently deleted**, leaving the chat with only the second message visible.

### Symptoms
- The bot shows "typing..." and a preview message appears (via `sendMessage` + `editMessageText`)
- When the first message is about to finish, the **entire message disappears**
- The next message immediately starts being typed
- This happens with **high probability when there is a subsequent message** after the first one
- The backend dispatch logs show the first message was sent successfully (`sendMessage` returned a `message_id`), but the user never sees it

### Environment
- OpenClaw version: 2026.5.20 (also reproduced on current `main` at commit `281878e910`)
- Channel: Telegram (direct DM)
- Streaming mode: `partial` (default)
- Platform: macOS

### Root Cause

Race condition in `extensions/telegram/src/draft-stream.ts` → `sendMessageTransportPreview`.

**Call chain:**

1. First response text streams → `sendMessageTransportPreview` is called → `bot.api.sendMessage()` is in-flight, waiting for Telegram API response
2. Meanwhile, **`forceNewMessage()`** is called (from `rotateLaneForNewMessage`, `rotateAnswerLaneAfterToolProgress`, `onAssistantMessageStart`, or text-splitting paths), which increments `generation`
3. Telegram API responds with a valid `message_id`
4. **`sendGeneration !== generation`** evaluates to `true`
5. `params.onSupersededPreview?.(...)` is called **WITHOUT `retain: true`**
6. The `onSupersededPreview` callback (in `bot-message-dispatch.ts`) executes `deleteMessage()`, permanently removing the just-delivered message

**Contrast with the other superseded path:** The text-splitting path (when text exceeds `maxChars`) correctly passes `retain: true` at [draft-stream.ts:220](https://github.com/openclaw/openclaw/blob/281878e910/extensions/telegram/src/draft-stream.ts#L220), but the generation-mismatch path at [draft-stream.ts:174-179](https://github.com/openclaw/openclaw/blob/281878e910/extensions/telegram/src/draft-stream.ts#L174-L179) does not.

### Related Issue #39795

Issue #39795 was about **duplicate messages** caused by `forceNewMessage()` being called too aggressively in `onAssistantMessageStart`. That was fixed in v2026.4.22 by reducing unnecessary `forceNewMessage()` calls and adding archived-preview finalization.

**This bug is different:** Even when `forceNewMessage()` is correctly needed (e.g., legitimate tool-progress → answer-text transition), the race condition between an in-flight `sendMessage` response and `generation` increment causes the successfully sent message to be deleted. The #39795 fix reduced the *frequency* of the race but did not eliminate it.

### Proposed Fix

In `extensions/telegram/src/draft-stream.ts`, add `retain: true` to the `onSupersededPreview` call in the generation-mismatch block:

```diff
     if (sendGeneration !== generation) {
       params.onSupersededPreview?.({
         messageId: normalizedMessageId,
         textSnapshot: renderedText,
         parseMode: renderedParseMode,
         visibleSinceMs,
+        retain: true,
       });
       return true;
     }
```

This prevents the callback from deleting the successfully sent message, matching the behavior already used by the text-splitting superseded path.
