### PR TITLE
Guide image generation toward safer provider timeouts

### DIFF
--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -200,7 +200,7 @@ const ImageGenerateToolSchema = Type.Object({
   ),
   timeoutMs: Type.Optional(
     Type.Number({
-      description: "Provider timeout ms.",
+      description: "Provider timeout ms (300000 tends to be a safe amount).",
       minimum: 1,
     }),
   ),


### PR DESCRIPTION
Image generation through OpenAI can legitimately run longer than the short timeouts models tend to invent when they fill in optional tool args. That made the agent more likely to give up early and report a timeout even though the provider path itself was fine.

This keeps the tool contract unchanged, but gives the model a concrete value to reach for in the schema: `300000` milliseconds. It is just guidance on the existing optional `timeoutMs` field, so callers that omit the field keep the same runtime behavior.

Checked locally with `pnpm exec oxfmt --check --threads=1 src/agents/tools/image-generate-tool.ts`, `pnpm prompt:snapshots:check`, `pnpm check:changed`, and `git diff --check origin/main...HEAD`.
