### PR TITLE
Feat/fix dashboard timeout error display

### DIFF
--- a/src/gateway/server-methods/chat.error-broadcast.test.ts
+++ b/src/gateway/server-methods/chat.error-broadcast.test.ts
@@ -1,32 +1,19 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayRequestContext } from "../types.js";
-
-// Mock loadSessionEntry to throw a synchronous error
-vi.mock("../session-utils.js", async () => {
-  const actual = await vi.importActual<typeof import("../session-utils.js")>("../session-utils.js");
-  return {
-    ...actual,
-    loadSessionEntry: vi.fn().mockImplementation(() => {
-      throw Object.assign(new Error("LLM timeout"), { code: "TIMEOUT" });
-    }),
-  };
-});
-
-// Import chatHandlers AFTER the mock is set up
-const { chatHandlers } = await import("./chat.js");
+import { chatHandlers } from "./chat.js";
 
 function createMockContext() {
   const broadcast = vi.fn();
   const nodeSendToSession = vi.fn();
   const chatAbortControllers = new Map();
-  const chatRunSeq = new Map<string, number>();
+  const agentRunSeq = new Map<string, number>();
   const dedupe = new Map();
 
   return {
     broadcast,
     nodeSendToSession,
     chatAbortControllers,
-    chatRunSeq,
+    agentRunSeq,
     dedupe,
     logGateway: { warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
     addChatRun: vi.fn(),
@@ -34,15 +21,20 @@ function createMockContext() {
   };
 }
 
-describe("chat.send error broadcast fix", () => {
-  it("should broadcast error via broadcastChatError when synchronous error occurs", async () => {
+describe("chat.send error broadcast", () => {
+  it("should broadcast error when addChatRun throws", async () => {
     const ctx = createMockContext();
     const respond = vi.fn();
+
+    // Make addChatRun throw synchronously (inside the try block at line 2470)
+    ctx.addChatRun.mockImplementation(() => {
+      throw Object.assign(new Error("LLM timeout"), { code: "TIMEOUT" });
+    });
 
     await chatHandlers["chat.send"]({
       params: {
         sessionKey: "main",
-        message: "hello timeout-test",
+        message: "hello",
         idempotencyKey: "test-run-1",
       },
       respond: respond as never,
@@ -52,7 +44,7 @@ describe("chat.send error broadcast fix", () => {
       isWebchatConnect: () => false,
     });
 
-    // Verify that respond was called with error
+    // Verify respond was called with error
     expect(respond).toHaveBeenCalledWith(
       false,
       expect.objectContaining({ runId: "test-run-1", status: "error" }),
@@ -60,7 +52,7 @@ describe("chat.send error broadcast fix", () => {
       expect.any(Object),
     );
 
-    // Verify that broadcastChatError was called (via context.broadcast)
+    // Verify broadcastChatError was called (via context.broadcast)
     expect(ctx.broadcast).toHaveBeenCalledWith(
       "chat",
       expect.objectContaining({

--- a/src/gateway/server-methods/chat.error-broadcast.test.ts
+++ b/src/gateway/server-methods/chat.error-broadcast.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import type { GatewayRequestContext } from "../types.js";
 import { chatHandlers } from "./chat.js";
+import type { GatewayRequestContext } from "./types.js";
 
 function createMockContext() {
   const broadcast = vi.fn();

--- a/src/gateway/server-methods/chat.error-broadcast.test.ts
+++ b/src/gateway/server-methods/chat.error-broadcast.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayRequestContext } from "../types.js";
+
+// Mock loadSessionEntry to throw a synchronous error
+vi.mock("../session-utils.js", async () => {
+  const actual = await vi.importActual<typeof import("../session-utils.js")>("../session-utils.js");
+  return {
+    ...actual,
+    loadSessionEntry: vi.fn().mockImplementation(() => {
+      throw Object.assign(new Error("LLM timeout"), { code: "TIMEOUT" });
+    }),
+  };
+});
+
+// Import chatHandlers AFTER the mock is set up
+const { chatHandlers } = await import("./chat.js");
+
+function createMockContext() {
+  const broadcast = vi.fn();
+  const nodeSendToSession = vi.fn();
+  const chatAbortControllers = new Map();
+  const chatRunSeq = new Map<string, number>();
+  const dedupe = new Map();
+
+  return {
+    broadcast,
+    nodeSendToSession,
+    chatAbortControllers,
+    chatRunSeq,
+    dedupe,
+    logGateway: { warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+    addChatRun: vi.fn(),
+    removeChatRun: vi.fn(),
+  };
+}
+
+describe("chat.send error broadcast fix", () => {
+  it("should broadcast error via broadcastChatError when synchronous error occurs", async () => {
+    const ctx = createMockContext();
+    const respond = vi.fn();
+
+    await chatHandlers["chat.send"]({
+      params: {
+        sessionKey: "main",
+        message: "hello timeout-test",
+        idempotencyKey: "test-run-1",
+      },
+      respond: respond as never,
+      context: ctx as unknown as GatewayRequestContext,
+      req: {} as never,
+      client: null as never,
+      isWebchatConnect: () => false,
+    });
+
+    // Verify that respond was called with error
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      expect.objectContaining({ runId: "test-run-1", status: "error" }),
+      expect.any(Object),
+      expect.any(Object),
+    );
+
+    // Verify that broadcastChatError was called (via context.broadcast)
+    expect(ctx.broadcast).toHaveBeenCalledWith(
+      "chat",
+      expect.objectContaining({
+        runId: "test-run-1",
+        state: "error",
+        errorMessage: expect.stringContaining("LLM timeout"),
+      }),
+    );
+  });
+});

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -3178,6 +3178,12 @@ export const chatHandlers: GatewayRequestHandlers = {
         runId: clientRunId,
         error: formatForLog(err),
       });
+      broadcastChatError({
+        context,
+        runId: clientRunId,
+        sessionKey,
+        errorMessage: String(err),
+      });
     }
   },
   "chat.inject": async ({ params, respond, context }) => {


### PR DESCRIPTION
## Summary

- Problem: When `chat.send` RPC handler encounters a synchronous error (e.g., LLM timeout), the `catch (err)` block only calls `respond()` to return an RPC error, but does NOT call `broadcastChatError()`. Dashboard UI relies on WebSocket `chat` events (`state: "error"`) to update the interface, so it gets stuck with a loading spinner and no error message.
- Why it matters: Users see the UI hang forever when LLM requests timeout or fail, with no feedback about what went wrong. This is a terrible user experience that leaves users thinking the system is broken.
- What changed: Added `broadcastChatError()` call in the synchronous `catch (err)` block (line 3158) of `chat.send` handler, mirroring the async `.catch()` path (line 3117) that already had this call.
- What did NOT change (scope boundary): No changes to async error handling, no changes to other RPC handlers, no UI changes. Only the synchronous error path in `chat.send` was fixed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The `catch (err)` block in `chat.send` handler (line 3158) was missing the `broadcastChatError()` call that sends WebSocket events to Dashboard UI. Only `respond()` was called, which returns an RPC error but doesn't update the UI state.
- Missing detection / guardrail: The synchronous error path (for errors thrown before the async dispatch) was not properly broadcasting errors to connected WebSocket clients.
- Contributing context: Dashboard UI listens for WebSocket `chat` events with `state: "error"` to display errors. Without `broadcastChatError()`, the UI never receives the error event and stays in loading state forever.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seamless / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-methods/chat.error-broadcast.test.ts`
- Scenario the test should lock in: When `chat.send` encounters a synchronous error (e.g., session load failure), `broadcastChatError()` must be called so Dashboard UI receives the error event.
- Why this is the smallest reliable guardrail: Tests the exact missing path (synchronous catch block) without requiring full agent dispatch setup.
- Existing test that already covers this (if any): `src/gateway/server-methods/chat.directive-tags.test.ts` (similar patterns exist)
- If no new test is added, why not: N/A - new test was added

## User-visible / Behavior Changes

- Dashboard UI now properly displays error messages (e.g., "LLM timeout") when `chat.send` fails synchronously, instead of hanging with a loading spinner forever.
- Error appears as a chat message with error state, not just a silent RPC failure.

## Diagram (if applicable)

```text
Before:
[User sends message] -> [chat.send RPC] -> [Error thrown] -> [respond() called] -> [UI hangs, no error shown]

After:
[User sends message] -> [chat.send RPC] -> [Error thrown] -> [respond() called] -> [broadcastChatError() called] -> [UI shows error message]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+
- Model/provider: N/A (error injection)
- Integration/channel (if any): Dashboard UI
- Relevant config (redacted): N/A

### Steps

1. Open Dashboard UI at `http://localhost:19001`
2. Open browser DevTools → Network → filter WS
3. Send message containing `timeout-test` (triggers injected error for testing)
4. Observe UI behavior and WebSocket messages

### Expected

- UI shows error message "LLM timeout" (or similar)
- Loading spinner stops
- WebSocket receives `chat` event with `state: "error"` and `errorMessage`

### Actual

- Before fix: UI hangs with loading spinner forever, no error shown
- After fix: UI displays error message, loading stops

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

### Video: Before fix (UI stuck with loading spinner)


https://github.com/user-attachments/assets/b6b8f08c-e077-47aa-b84c-cc979caa9ae7



Before fix (from gateway.log):
```
[CHAT.SEND] Throwing timeout error directly...
[ws] ⇄ res ✗ chat.send errorCode=UNAVAILABLE errorMessage=Error: LLM timeout
```
UI hangs, no error displayed.

### Video: After fix (error message displayed correctly)


https://github.com/user-attachments/assets/e00b9385-a139-4760-92d8-6f3ff66471cd



After fix:
```
[CHAT.SEND] Throwing timeout error directly...
[ws] ⇄ res ✗ chat.send errorCode=UNAVAILABLE errorMessage=Error: LLM timeout
<-- WebSocket chat event: { state: "error", errorMessage: "Error: LLM timeout" }
```
UI shows error message correctly.

## Real behavior proof

- Behavior addressed: Dashboard UI now properly displays error messages when `chat.send` fails synchronously (e.g., LLM timeout), instead of hanging with a loading spinner forever.
- Real environment tested: macOS 26.3 arm64, Node v22+, OpenClaw built from source (`pnpm build` → `node dist/index.js gateway --port 19001`), model hy3-preview via tencent-tokenhub, Dashboard UI at `http://localhost:19001`.
- Exact steps or command run after this patch:
  1. Built source with fix: `pnpm build`
  2. Started dev instance: `openclaw-dev restart` (port 19001, state dir `~/.openclaw-dev/`)
  3. Opened Dashboard UI: `http://localhost:19001`
  4. Opened browser DevTools → Network → WS → Messages
  5. Sent message: `hello timeout-test` (triggers injected timeout error in `chat.send` handler)
  6. Observed UI behavior and WebSocket messages
- Evidence after fix: Screen recording showing the UI displays "LLM timeout" error message instead of hanging with loading spinner. Gateway log shows `broadcastChatError()` was called (via WebSocket `chat` event with `state: "error"`). Test file `src/gateway/server-methods/chat.error-broadcast.test.ts` passes.
- Observed result after fix: UI receives WebSocket `chat` event with `state: "error"` and `errorMessage: "Error: LLM timeout"`. Loading spinner stops. Error message appears in chat. Test passes: `broadcastChatError()` is called when synchronous error occurs in `chat.send`.
- What was not tested: Other RPC handlers that may have similar issues (separate investigation needed), real LLM timeout (vs injected error), other Dashboard UI sessions (only tested with `dashboard:` session key).

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Sent `timeout-test` message in Dashboard UI at `http://localhost:19001`, confirmed error message appears instead of hanging. Verified WebSocket message format matches expected structure (`runId`, `sessionKey`, `state: "error"`, `errorMessage`). Ran unit test: `pnpm test src/gateway/server-methods/chat.error-broadcast.test.ts`.
- Edge cases checked: Verified WebSocket event format is consistent with async error path (line 3117). Checked that `broadcastChatError()` is called with correct parameters (`runId`, `sessionKey`, `errorMessage`).
- What you did **not** verify: Other RPC handlers that may have similar missing `broadcastChatError()` calls, real LLM timeout scenario (only tested with injected error), performance impact of additional broadcast call.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: `broadcastChatError()` might be called twice if both sync and async paths trigger (e.g., error in sync path followed by async cleanup error).
  - Mitigation: `broadcastChatError()` is idempotent for the same `runId` due to `agentRunSeq` tracking and dedup. The WebSocket clients handle duplicate events gracefully.
- Risk: Change affects error visibility for all `chat.send` failures, not just timeouts.
  - Mitigation: This is intentional - all errors should be visible to users, not just timeouts. Previously, async errors were shown but sync errors were not.
