### PR TITLE
fix(codex): exclude tool_search for unsupported OpenAI nano models

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-profile.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-profile.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import {
+  filterCodexDynamicTools,
+  excludeUnsupportedDynamicToolsForModel,
+} from "./dynamic-tool-profile.js";
+
+describe("excludeUnsupportedDynamicToolsForModel", () => {
+  const makeTool = (name: string) => ({ name, description: `Tool ${name}` });
+
+  it("excludes tool_search for gpt-5.4-nano", () => {
+    const tools = [
+      makeTool("read"),
+      makeTool("tool_search"),
+      makeTool("tool_search_code"),
+      makeTool("exec"),
+    ];
+    const result = excludeUnsupportedDynamicToolsForModel(tools, {
+      provider: "openai",
+      modelId: "gpt-5.4-nano",
+    });
+    const names = result.map((t) => t.name);
+    expect(names).toContain("read");
+    expect(names).toContain("exec");
+    expect(names).not.toContain("tool_search");
+    expect(names).not.toContain("tool_search_code");
+  });
+
+  it("excludes tool_search for gpt-5-nano", () => {
+    const tools = [makeTool("tool_search"), makeTool("read")];
+    const result = excludeUnsupportedDynamicToolsForModel(tools, {
+      provider: "openai",
+      modelId: "gpt-5-nano",
+    });
+    expect(result.map((t) => t.name)).not.toContain("tool_search");
+  });
+
+  it("keeps tool_search for gpt-5.4-mini", () => {
+    const tools = [makeTool("tool_search"), makeTool("read")];
+    const result = excludeUnsupportedDynamicToolsForModel(tools, {
+      provider: "openai",
+      modelId: "gpt-5.4-mini",
+    });
+    expect(result.map((t) => t.name)).toContain("tool_search");
+  });
+
+  it("keeps tool_search for gpt-4o", () => {
+    const tools = [makeTool("tool_search"), makeTool("read")];
+    const result = excludeUnsupportedDynamicToolsForModel(tools, {
+      provider: "openai",
+      modelId: "gpt-4o",
+    });
+    expect(result.map((t) => t.name)).toContain("tool_search");
+  });
+
+  it("keeps all tools for non-OpenAI providers", () => {
+    const tools = [makeTool("tool_search"), makeTool("read")];
+    const result = excludeUnsupportedDynamicToolsForModel(tools, {
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-20250514",
+    });
+    expect(result.map((t) => t.name)).toContain("tool_search");
+  });
+
+  it("handles empty tool list", () => {
+    const result = excludeUnsupportedDynamicToolsForModel([], {
+      provider: "openai",
+      modelId: "gpt-5.4-nano",
+    });
+    expect(result).toEqual([]);
+  });
+});

--- a/extensions/codex/src/app-server/dynamic-tool-profile.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-profile.ts
@@ -14,6 +14,13 @@ export const CODEX_APP_SERVER_OWNED_DYNAMIC_TOOL_EXCLUDES = [
   "tool_search_code",
 ] as const;
 
+// Models that don't support tool_search / tool_search_code at the API level.
+// e.g. gpt-5.4-nano returns "Tool 'tool_search' is not supported" from OpenAI.
+const OPENAI_TOOL_SEARCH_UNSUPPORTED_MODELS = [
+  "gpt-5.4-nano",
+  "gpt-5-nano",
+] as const;
+
 const DYNAMIC_TOOL_NAME_ALIASES: Record<string, string> = {
   bash: "exec",
   "apply-patch": "apply_patch",
@@ -67,4 +74,25 @@ export function filterCodexDynamicTools<T extends { name: string }>(
   return excludes.size === 0
     ? tools
     : tools.filter((tool) => !excludes.has(normalizeCodexDynamicToolName(tool.name)));
+}
+
+/**
+ * Exclude dynamic tools that the target model API doesn't support.
+ *
+ * For example, OpenAI nano models return a 400 error when `tool_search` is
+ * included in the tools array, causing the entire run to fail over to a more
+ * expensive fallback model.
+ */
+export function excludeUnsupportedDynamicToolsForModel<T extends { name: string }>(
+  tools: T[],
+  model: { provider?: string; modelId?: string },
+): T[] {
+  const isUnsupported =
+    model.provider?.toLowerCase() === "openai" &&
+    OPENAI_TOOL_SEARCH_UNSUPPORTED_MODELS.includes(model.modelId as (typeof OPENAI_TOOL_SEARCH_UNSUPPORTED_MODELS)[number]);
+  if (!isUnsupported) {
+    return tools;
+  }
+  const exclude = new Set(["tool_search", "tool_search_code"]);
+  return tools.filter((tool) => !exclude.has(normalizeCodexDynamicToolName(tool.name)));
 }

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -106,6 +106,7 @@ import {
 } from "./dynamic-tool-diagnostics.js";
 import {
   filterCodexDynamicTools,
+  excludeUnsupportedDynamicToolsForModel,
   isForcedPrivateQaCodexRuntime,
   normalizeCodexDynamicToolName,
   resolveCodexDynamicToolsLoading,
@@ -3919,9 +3920,13 @@ async function buildDynamicTools(input: DynamicToolBuildParams) {
   });
   const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, params);
   const filteredTools = filterCodexDynamicToolsForAllowlist(visionFilteredTools, toolsAllow);
+  const modelFilteredTools = excludeUnsupportedDynamicToolsForModel(filteredTools, {
+    provider: params.provider,
+    modelId: params.modelId,
+  });
   return normalizeAgentRuntimeTools({
     runtimePlan: input.ignoreRuntimePlan ? undefined : params.runtimePlan,
-    tools: filteredTools,
+    tools: modelFilteredTools,
     provider: params.provider,
     config: params.config,
     workspaceDir: input.effectiveWorkspace,


### PR DESCRIPTION
## Summary

Prevents 400 errors when using gpt-5.4-nano (or gpt-5-nano) with the Codex harness by excluding `tool_search` and `tool_search_code` from the dynamic tools array.

## Problem

```
Tool 'tool_search' is not supported with gpt-5.4-nano.
```

OpenAI nano models return a 400 error when `tool_search` is included in the tools array, causing the entire run to fail over to a more expensive fallback model (e.g., gpt-5.4-mini). Users who explicitly chose nano to save costs are forced to pay for more expensive models.

## Fix

| File | Changes |
|------|---------|
| `extensions/codex/src/app-server/dynamic-tool-profile.ts` | +18 | New `excludeUnsupportedDynamicToolsForModel()` function |
| `extensions/codex/src/app-server/dynamic-tool-profile.test.ts` | +69 | 6 unit tests |
| `extensions/codex/src/app-server/run-attempt.ts` | +5 | Wire exclusion into `buildDynamicTools()` |

- Adds model-aware tool filtering: excludes `tool_search` + `tool_search_code` for OpenAI nano models
- Uses exact model ID matching for precision (not regex-based)
- 6 unit tests covering: nano exclusion, mini passthrough, non-OpenAI passthrough, empty tools

## Supported Models

| Model | tool_search |
|-------|-------------|
| gpt-5.4-nano | ❌ Excluded |
| gpt-5-nano | ❌ Excluded |
| gpt-5.4-mini | ✅ Included |
| gpt-4o | ✅ Included |
| Non-OpenAI | ✅ Included |

Fixes: #85806
