### PR TITLE
fix(tui): surface terminal lifecycle errors

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -302,6 +302,40 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(tui.requestRender).toHaveBeenCalled();
   });
 
+  it("surfaces terminal lifecycle errors and unlocks the active run", () => {
+    const { state, chatLog, tui, setActivityStatus, handleAgentEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-lifecycle-error", activityStatus: "streaming" },
+    });
+
+    handleAgentEvent({
+      runId: "run-lifecycle-error",
+      stream: "lifecycle",
+      data: { phase: "error", endedAt: Date.now(), error: "provider disconnected" },
+    });
+
+    expect(chatLog.dismissPendingSystem).toHaveBeenCalledWith("run-lifecycle-error");
+    expect(chatLog.addSystem).toHaveBeenCalledWith("run error: provider disconnected");
+    expect(state.activeChatRunId).toBeNull();
+    expect(setActivityStatus).toHaveBeenCalledWith("error");
+    expect(tui.requestRender).toHaveBeenCalled();
+  });
+
+  it("keeps retryable lifecycle errors active until a terminal lifecycle event arrives", () => {
+    const { state, chatLog, setActivityStatus, handleAgentEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-retryable", activityStatus: "streaming" },
+    });
+
+    handleAgentEvent({
+      runId: "run-retryable",
+      stream: "lifecycle",
+      data: { phase: "error", error: "primary model timed out" },
+    });
+
+    expect(chatLog.addSystem).not.toHaveBeenCalledWith("run error: primary model timed out");
+    expect(state.activeChatRunId).toBe("run-retryable");
+    expect(setActivityStatus).toHaveBeenCalledWith("error");
+  });
+
   it("shows finishing context for a known run after assistant final", () => {
     const { state, tui, setActivityStatus, handleChatEvent, handleAgentEvent } =
       createHandlersHarness({

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -331,6 +331,23 @@ export function createEventHandlers(context: EventHandlerContext) {
     return sessionRuns.has(activeRunId);
   };
 
+  const readLifecycleErrorMessage = (evt: AgentEvent): string => {
+    const data = evt.data ?? {};
+    return asString(data.error, "") || asString(data.errorMessage, "") || "unknown";
+  };
+
+  const isTerminalLifecycleError = (evt: AgentEvent): boolean => {
+    if (evt.stream !== "lifecycle" || asString(evt.data?.phase, "") !== "error") {
+      return false;
+    }
+    return typeof evt.data?.endedAt === "number";
+  };
+
+  const renderRunError = (errorMessage: string) => {
+    const renderedError = formatRawAssistantErrorForUi(errorMessage);
+    return resolveAuthErrorHint(errorMessage) ?? `run error: ${renderedError}`;
+  };
+
   const maybeRefreshHistoryForRun = (
     runId: string,
     opts?: { allowLocalWithoutDisplayableFinal?: boolean },
@@ -493,8 +510,7 @@ export function createEventHandlers(context: EventHandlerContext) {
       forgetLocalBtwRunId?.(evt.runId);
       const wasActiveRun = state.activeChatRunId === evt.runId;
       const errorMessage = evt.errorMessage ?? "unknown";
-      const renderedError = formatRawAssistantErrorForUi(errorMessage);
-      chatLog.addSystem(resolveAuthErrorHint(errorMessage) ?? `run error: ${renderedError}`);
+      chatLog.addSystem(renderRunError(errorMessage));
       terminateRun({ runId: evt.runId, wasActiveRun, status: "error" });
       maybeRefreshHistoryForRun(evt.runId);
     }
@@ -608,6 +624,15 @@ export function createEventHandlers(context: EventHandlerContext) {
       }
       if (phase === "error") {
         postFinalizingRuns.delete(evt.runId);
+        if (isTerminalLifecycleError(evt) && (isActiveRun || isPendingRun)) {
+          const wasActiveRun = state.activeChatRunId === evt.runId;
+          const errorMessage = readLifecycleErrorMessage(evt);
+          chatLog.dismissPendingSystem(evt.runId);
+          chatLog.addSystem(renderRunError(errorMessage));
+          terminateRun({ runId: evt.runId, wasActiveRun, status: "error" });
+          tui.requestRender();
+          return;
+        }
         if (!canUpdateActivityStatus) {
           return;
         }


### PR DESCRIPTION
## Summary

- surface terminal TUI lifecycle `error` events as visible `run error: ...` system messages
- clear the active run on terminal lifecycle errors so the TUI is not left busy after the footer switches to error
- keep retryable/non-terminal lifecycle error phases as status-only so fallback/retry flows can continue

Fixes #85782.

## Tests

- `node scripts/run-vitest.mjs src/tui/tui-event-handlers.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts`
- `pnpm openclaw tui --help`

## Real behavior proof

Behavior addressed: A terminal TUI agent lifecycle error can leave the footer at `connected | error` without a visible transcript error and with the run still blocking new input.

Real environment tested: Local macOS checkout using the OpenClaw CLI/TUI entrypoint on this branch after the patch.

Exact steps or command run after this patch: Ran `pnpm openclaw tui --help` after the patch, which invoked `node scripts/run-node.mjs tui --help`, rebuilt stale TypeScript/bundled plugin assets, loaded the real OpenClaw CLI, and printed the TUI command help.

Evidence after fix: Terminal output from the real command included the runtime entrypoint and TUI help:

```text
$ node scripts/run-node.mjs tui --help
[openclaw] Building TypeScript (dist is stale: git_head_changed - git head changed).
[openclaw] Building bundled plugin assets.
OpenClaw 2026.5.22 (0ba0e95) — All your chats, one OpenClaw.
Usage: openclaw tui|terminal [options]
Open a terminal UI connected to the Gateway
Docs: https://docs.openclaw.ai/cli/tui
```

Observed result after fix: The patched tree builds and the real TUI command surface loads successfully; focused handler coverage confirms terminal lifecycle errors now add `run error: provider disconnected`, clear `activeChatRunId`, and set the activity status to `error`, while retryable lifecycle errors keep the run active.

What was not tested: No live provider failure was forced through an interactive TUI session; the behavioral edge was covered with the event-handler regression test plus the real CLI/TUI command load proof above.
