### PR TITLE
fix(memory): write fallback dream diary on narrative timeout

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -823,7 +823,7 @@ describe("generateAndAppendDreamNarrative", () => {
     expect(exists).toBe(false);
   });
 
-  it("handles subagent timeout gracefully", async () => {
+  it("writes a fallback diary entry when the subagent times out", async () => {
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
     const subagent = createMockSubagent("");
     subagent.waitForRun.mockResolvedValue({ status: "timeout" });
@@ -838,11 +838,9 @@ describe("generateAndAppendDreamNarrative", () => {
 
     // Should not throw, should warn.
     expect(logger.warn).toHaveBeenCalled();
-    const exists = await fs
-      .access(path.join(workspaceDir, "DREAMS.md"))
-      .then(() => true)
-      .catch(() => false);
-    expect(exists).toBe(false);
+    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
+    expect(content).toContain("some memory");
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("status=timeout"));
   });
 
   it("skips extra settle waits after timeout and still attempts cleanup", async () => {

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -157,6 +157,31 @@ function buildRequestScopedFallbackNarrative(data: NarrativePhaseData): string {
   );
 }
 
+async function appendFallbackNarrativeEntry(params: {
+  workspaceDir: string;
+  data: NarrativePhaseData;
+  nowMs: number;
+  timezone?: string;
+  logger: Logger;
+  reason: string;
+}): Promise<void> {
+  try {
+    await appendNarrativeEntry({
+      workspaceDir: params.workspaceDir,
+      narrative: buildRequestScopedFallbackNarrative(params.data),
+      nowMs: params.nowMs,
+      timezone: params.timezone,
+    });
+    params.logger.info(
+      `memory-core: narrative generation used fallback for ${params.data.phase} phase because ${params.reason}.`,
+    );
+  } catch (fallbackErr) {
+    params.logger.warn(
+      `memory-core: narrative fallback failed for ${params.data.phase} phase (${formatFallbackWriteFailure(fallbackErr)})`,
+    );
+  }
+}
+
 function buildNarrativeAttemptSessionKey(baseSessionKey: string, attempt: number): string {
   return attempt === 0 ? baseSessionKey : `${baseSessionKey}-retry-${attempt}`;
 }
@@ -234,21 +259,14 @@ async function startNarrativeRunOrFallback(params: {
     if (!isRequestScopedSubagentRuntimeError(runErr)) {
       throw runErr;
     }
-    try {
-      await appendNarrativeEntry({
-        workspaceDir: params.workspaceDir,
-        narrative: buildRequestScopedFallbackNarrative(params.data),
-        nowMs: params.nowMs,
-        timezone: params.timezone,
-      });
-      params.logger.info(
-        `memory-core: narrative generation used fallback for ${params.data.phase} phase because subagent runtime is request-scoped.`,
-      );
-    } catch (fallbackErr) {
-      params.logger.warn(
-        `memory-core: narrative fallback failed for ${params.data.phase} phase (${formatFallbackWriteFailure(fallbackErr)})`,
-      );
-    }
+    await appendFallbackNarrativeEntry({
+      workspaceDir: params.workspaceDir,
+      data: params.data,
+      nowMs: params.nowMs,
+      timezone: params.timezone,
+      logger: params.logger,
+      reason: "subagent runtime is request-scoped",
+    });
     return null;
   }
 }
@@ -990,8 +1008,19 @@ export async function generateAndAppendDreamNarrative(params: {
             `memory-core: narrative generation ended with ${formatNarrativeTerminalStatus({
               status: result.status,
               error: result.error,
-            })} for ${params.data.phase} phase.`,
+            })} for ${params.data.phase} phase; writing fallback diary entry.`,
           );
+          await appendFallbackNarrativeEntry({
+            workspaceDir: params.workspaceDir,
+            data: params.data,
+            nowMs,
+            timezone: params.timezone,
+            logger: params.logger,
+            reason: `the narrative run ended with ${formatNarrativeTerminalStatus({
+              status: result.status,
+              error: result.error,
+            })}`,
+          });
           return;
         } catch (err) {
           if (attemptModel && isConfiguredModelUnavailableNarrativeError(formatErrorMessage(err))) {
@@ -1016,8 +1045,16 @@ export async function generateAndAppendDreamNarrative(params: {
       const narrative = extractNarrativeText(messages);
       if (!narrative) {
         params.logger.warn(
-          `memory-core: narrative generation produced no text for ${params.data.phase} phase.`,
+          `memory-core: narrative generation produced no text for ${params.data.phase} phase; writing fallback diary entry.`,
         );
+        await appendFallbackNarrativeEntry({
+          workspaceDir: params.workspaceDir,
+          data: params.data,
+          nowMs,
+          timezone: params.timezone,
+          logger: params.logger,
+          reason: "the narrative run produced no text",
+        });
         return;
       }
 


### PR DESCRIPTION
This is the narrow replacement for #78698, keeping only the useful memory-core fallback fix and focused regression coverage.

Scope:
- update dreaming narrative fallback handling so terminal/no-text narrative outcomes still append a fallback DREAMS.md entry
- update the focused timeout regression to assert the fallback diary write

## Real behavior proof

- Behavior or issue addressed: Dream Diary fallback entries are now written when detached narrative generation reaches a terminal timeout/no-text outcome instead of silently returning without DREAMS.md output.
- Real environment tested: Local OpenClaw checkout at commit 94d4e021b62815708049e74210616c15869cb895 on Linux, Node.js v22.22.2, pnpm workspace dependencies installed.
- Exact steps or command run after this patch: Ran the focused memory-core narrative command below from the repository root after applying the patch.
- Evidence after fix: Terminal output from the local OpenClaw checkout showed the focused after-fix narrative fallback path passing and writing the expected fallback diary content through the memory-core test harness:

```text
$ pnpm exec vitest run --config test/vitest/vitest.extension-memory.config.ts extensions/memory-core/src/dreaming-narrative.test.ts

 RUN  v4.1.7 /home/amara/.openclaw/workspace/repos/openclaw

 Test Files  1 passed (1)
      Tests  49 passed (49)
   Start at  22:23:12
   Duration  9.66s (transform 6.73s, setup 624ms, import 8.16s, tests 660ms, environment 0ms)
```

- Observed result after fix: The timeout regression now reads DREAMS.md after a simulated terminal timeout and observes the fallback memory snippet in the diary content; the focused suite completed with 49/49 passing.
- What was not tested: Full production cron dreaming sweep with a live remote subagent was not run; this PR is limited to the memory-core fallback writer path and focused regression coverage.

Validation:
- pnpm exec vitest run --config test/vitest/vitest.extension-memory.config.ts extensions/memory-core/src/dreaming-narrative.test.ts