### PR TITLE
fix(memory-wiki): show vault totals in palace summary

### DIFF
--- a/extensions/memory-wiki/src/gateway.test.ts
+++ b/extensions/memory-wiki/src/gateway.test.ts
@@ -355,7 +355,15 @@ describe("memory-wiki gateway methods", () => {
     const { config } = await createVault({ prefix: "memory-wiki-gateway-" });
     const { api, registerGatewayMethod } = createPluginApi();
     vi.mocked(listMemoryWikiPalace).mockResolvedValue({
-      totalItems: 3,
+      totalItems: 1,
+      totalPages: 3,
+      pageCounts: {
+        synthesis: 1,
+        entity: 0,
+        concept: 0,
+        source: 1,
+        report: 1,
+      },
       totalClaims: 4,
       totalQuestions: 1,
       totalContradictions: 1,
@@ -399,7 +407,15 @@ describe("memory-wiki gateway methods", () => {
     expect(syncMemoryWikiImportedSources).toHaveBeenCalledWith({ config, appConfig: undefined });
     expect(listMemoryWikiPalace).toHaveBeenCalledWith(config);
     expect(readRespondPayload(respond)).toEqual({
-      totalItems: 3,
+      totalItems: 1,
+      totalPages: 3,
+      pageCounts: {
+        synthesis: 1,
+        entity: 0,
+        concept: 0,
+        source: 1,
+        report: 1,
+      },
       totalClaims: 4,
       totalQuestions: 1,
       totalContradictions: 1,

--- a/extensions/memory-wiki/src/memory-palace.test.ts
+++ b/extensions/memory-wiki/src/memory-palace.test.ts
@@ -16,6 +16,7 @@ describe("listMemoryWikiPalace", () => {
 
     await fs.mkdir(path.join(rootDir, "syntheses"), { recursive: true });
     await fs.mkdir(path.join(rootDir, "entities"), { recursive: true });
+    await fs.mkdir(path.join(rootDir, "sources"), { recursive: true });
     await fs.writeFile(
       path.join(rootDir, "syntheses", "travel-system.md"),
       renderWikiMarkdown({
@@ -41,6 +42,22 @@ describe("listMemoryWikiPalace", () => {
       "utf8",
     );
     await fs.writeFile(
+      path.join(rootDir, "sources", "raw-chat.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.raw.chat",
+          title: "Raw chat source",
+          sourceType: "chatgpt",
+          updatedAt: "2026-04-08T08:00:00.000Z",
+        },
+        body: ["# Raw chat source", "", "Original imported source with no claim rows.", ""].join(
+          "\n",
+        ),
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
       path.join(rootDir, "entities", "mariano.md"),
       renderWikiMarkdown({
         frontmatter: {
@@ -58,6 +75,14 @@ describe("listMemoryWikiPalace", () => {
     const result = await listMemoryWikiPalace(config);
 
     expect(result.totalItems).toBe(2);
+    expect(result.totalPages).toBe(3);
+    expect(result.pageCounts).toEqual({
+      synthesis: 1,
+      entity: 1,
+      concept: 0,
+      source: 1,
+      report: 0,
+    });
     expect(result.totalClaims).toBe(3);
     expect(result.totalQuestions).toBe(1);
     expect(result.totalContradictions).toBe(1);

--- a/extensions/memory-wiki/src/memory-palace.ts
+++ b/extensions/memory-wiki/src/memory-palace.ts
@@ -39,13 +39,27 @@ type MemoryWikiPalaceCluster = {
   items: MemoryWikiPalaceItem[];
 };
 
+type MemoryWikiPalacePageCounts = Record<WikiPageKind, number>;
+
 type MemoryWikiPalaceStatus = {
   totalItems: number;
+  totalPages: number;
+  pageCounts: MemoryWikiPalacePageCounts;
   totalClaims: number;
   totalQuestions: number;
   totalContradictions: number;
   clusters: MemoryWikiPalaceCluster[];
 };
+
+function createEmptyPalacePageCounts(): MemoryWikiPalacePageCounts {
+  return {
+    synthesis: 0,
+    entity: 0,
+    concept: 0,
+    source: 0,
+    report: 0,
+  };
+}
 
 function normalizeTimestamp(value: unknown): string | undefined {
   if (typeof value !== "string") {
@@ -89,6 +103,13 @@ export async function listMemoryWikiPalace(
   config: ResolvedMemoryWikiConfig,
 ): Promise<MemoryWikiPalaceStatus> {
   const pages = await readQueryableWikiPages(config.vault.path);
+  const pageCounts = pages.reduce<MemoryWikiPalacePageCounts>((counts, page) => {
+    counts[page.kind] += 1;
+    return counts;
+  }, createEmptyPalacePageCounts());
+  const totalClaims = pages.reduce((sum, page) => sum + page.claims.length, 0);
+  const totalQuestions = pages.reduce((sum, page) => sum + page.questions.length, 0);
+  const totalContradictions = pages.reduce((sum, page) => sum + page.contradictions.length, 0);
   const items = pages
     .map((page) => {
       const parsed = parseWikiMarkdown(page.raw);
@@ -140,9 +161,11 @@ export async function listMemoryWikiPalace(
 
   return {
     totalItems: items.length,
-    totalClaims: items.reduce((sum, item) => sum + item.claimCount, 0),
-    totalQuestions: items.reduce((sum, item) => sum + item.questionCount, 0),
-    totalContradictions: items.reduce((sum, item) => sum + item.contradictionCount, 0),
+    totalPages: pages.length,
+    pageCounts,
+    totalClaims,
+    totalQuestions,
+    totalContradictions,
     clusters,
   };
 }

--- a/ui/src/ui/controllers/dreaming.test.ts
+++ b/ui/src/ui/controllers/dreaming.test.ts
@@ -421,8 +421,16 @@ describe("dreaming controller", () => {
       },
     };
     request.mockResolvedValue({
-      totalItems: 2,
-      totalClaims: 3,
+      totalItems: 1,
+      totalPages: 2,
+      pageCounts: {
+        synthesis: 1,
+        entity: 0,
+        concept: 0,
+        source: 1,
+        report: 0,
+      },
+      totalClaims: 2,
       totalQuestions: 1,
       totalContradictions: 1,
       clusters: [
@@ -454,8 +462,11 @@ describe("dreaming controller", () => {
     await loadWikiMemoryPalace(state);
 
     expect(request).toHaveBeenCalledWith("wiki.palace", {});
-    expect(state.wikiMemoryPalace?.totalItems).toBe(2);
-    expect(state.wikiMemoryPalace?.totalClaims).toBe(3);
+    expect(state.wikiMemoryPalace?.totalItems).toBe(1);
+    expect(state.wikiMemoryPalace?.totalPages).toBe(2);
+    expect(state.wikiMemoryPalace?.pageCounts.source).toBe(1);
+    expect(state.wikiMemoryPalace?.pageCounts.synthesis).toBe(1);
+    expect(state.wikiMemoryPalace?.totalClaims).toBe(2);
     expect(state.wikiMemoryPalace?.clusters).toHaveLength(1);
     expect(state.wikiMemoryPalace?.clusters[0]?.key).toBe("synthesis");
     expect(state.wikiMemoryPalace?.clusters[0]?.label).toBe("Syntheses");
@@ -466,6 +477,56 @@ describe("dreaming controller", () => {
     ]);
     expect(state.wikiMemoryPalaceError).toBeNull();
     expect(state.wikiMemoryPalaceLoading).toBe(false);
+  });
+
+  it("derives legacy wiki memory palace page counts from clusters", async () => {
+    const { state, request } = createState();
+    state.hello = {
+      type: "hello-ok",
+      protocol: 4,
+      auth: { role: "operator", scopes: [] },
+      features: { methods: ["wiki.palace"] },
+    };
+    state.configSnapshot = {
+      hash: "hash-1",
+      config: {
+        plugins: {
+          entries: {
+            "memory-wiki": {
+              enabled: true,
+            },
+          },
+        },
+      },
+    };
+    request.mockResolvedValue({
+      totalItems: 1,
+      totalClaims: 2,
+      totalQuestions: 1,
+      totalContradictions: 0,
+      clusters: [
+        {
+          key: "synthesis",
+          label: "Syntheses",
+          itemCount: 1,
+          claimCount: 2,
+          questionCount: 1,
+          contradictionCount: 0,
+          items: [],
+        },
+      ],
+    });
+
+    await loadWikiMemoryPalace(state);
+
+    expect(state.wikiMemoryPalace?.totalPages).toBe(1);
+    expect(state.wikiMemoryPalace?.pageCounts).toEqual({
+      synthesis: 1,
+      entity: 0,
+      concept: 0,
+      source: 0,
+      report: 0,
+    });
   });
 
   it("falls back to config gating for wiki memory palace when methods are not advertised", async () => {
@@ -494,6 +555,14 @@ describe("dreaming controller", () => {
 
     expect(request).toHaveBeenCalledWith("wiki.palace", {});
     expect(state.wikiMemoryPalace?.totalItems).toBe(1);
+    expect(state.wikiMemoryPalace?.totalPages).toBe(1);
+    expect(state.wikiMemoryPalace?.pageCounts).toEqual({
+      synthesis: 0,
+      entity: 0,
+      concept: 0,
+      source: 0,
+      report: 0,
+    });
     expect(state.wikiMemoryPalace?.totalClaims).toBe(2);
     expect(state.wikiMemoryPalaceError).toBeNull();
     expect(state.wikiMemoryPalaceLoading).toBe(false);
@@ -509,6 +578,14 @@ describe("dreaming controller", () => {
     };
     state.wikiMemoryPalace = {
       totalItems: 1,
+      totalPages: 1,
+      pageCounts: {
+        synthesis: 1,
+        entity: 0,
+        concept: 0,
+        source: 0,
+        report: 0,
+      },
       totalClaims: 1,
       totalQuestions: 0,
       totalContradictions: 0,
@@ -546,6 +623,14 @@ describe("dreaming controller", () => {
     };
     state.wikiMemoryPalace = {
       totalItems: 1,
+      totalPages: 1,
+      pageCounts: {
+        synthesis: 1,
+        entity: 0,
+        concept: 0,
+        source: 0,
+        report: 0,
+      },
       totalClaims: 1,
       totalQuestions: 0,
       totalContradictions: 0,

--- a/ui/src/ui/controllers/dreaming.ts
+++ b/ui/src/ui/controllers/dreaming.ts
@@ -149,8 +149,12 @@ export type WikiMemoryPalaceCluster = {
   items: WikiMemoryPalaceItem[];
 };
 
+export type WikiMemoryPalacePageCounts = Record<WikiMemoryPalaceItem["kind"], number>;
+
 export type WikiMemoryPalace = {
   totalItems: number;
+  totalPages: number;
+  pageCounts: WikiMemoryPalacePageCounts;
   totalClaims: number;
   totalQuestions: number;
   totalContradictions: number;
@@ -192,6 +196,8 @@ type WikiImportInsightsPayload = {
 
 type WikiMemoryPalacePayload = {
   totalItems?: unknown;
+  totalPages?: unknown;
+  pageCounts?: unknown;
   totalClaims?: unknown;
   totalQuestions?: unknown;
   totalContradictions?: unknown;
@@ -552,6 +558,40 @@ function normalizeWikiPageKind(value: unknown): WikiMemoryPalaceItem["kind"] | u
     : undefined;
 }
 
+function createEmptyWikiMemoryPalacePageCounts(): WikiMemoryPalacePageCounts {
+  return {
+    synthesis: 0,
+    entity: 0,
+    concept: 0,
+    source: 0,
+    report: 0,
+  };
+}
+
+function normalizeWikiMemoryPalacePageCounts(
+  raw: unknown,
+  fallback: WikiMemoryPalacePageCounts,
+): WikiMemoryPalacePageCounts {
+  const record = asRecord(raw);
+  return {
+    synthesis: normalizeFiniteInt(record?.synthesis, fallback.synthesis),
+    entity: normalizeFiniteInt(record?.entity, fallback.entity),
+    concept: normalizeFiniteInt(record?.concept, fallback.concept),
+    source: normalizeFiniteInt(record?.source, fallback.source),
+    report: normalizeFiniteInt(record?.report, fallback.report),
+  };
+}
+
+function sumWikiMemoryPalacePageCounts(pageCounts: WikiMemoryPalacePageCounts): number {
+  return (
+    pageCounts.synthesis +
+    pageCounts.entity +
+    pageCounts.concept +
+    pageCounts.source +
+    pageCounts.report
+  );
+}
+
 function normalizeWikiMemoryPalaceItem(raw: unknown): WikiMemoryPalaceItem | null {
   const record = asRecord(raw);
   const pagePath = normalizeTrimmedString(record?.pagePath);
@@ -625,11 +665,20 @@ function normalizeWikiMemoryPalace(raw: unknown): WikiMemoryPalace {
         .map((entry) => normalizeWikiMemoryPalaceCluster(entry))
         .filter((entry): entry is WikiMemoryPalaceCluster => entry !== null)
     : [];
+  const totalItems = normalizeFiniteInt(
+    record?.totalItems,
+    clusters.reduce((sum, cluster) => sum + cluster.itemCount, 0),
+  );
+  const fallbackPageCounts = createEmptyWikiMemoryPalacePageCounts();
+  for (const cluster of clusters) {
+    fallbackPageCounts[cluster.key] += cluster.itemCount;
+  }
+  const pageCounts = normalizeWikiMemoryPalacePageCounts(record?.pageCounts, fallbackPageCounts);
+  const fallbackTotalPages = sumWikiMemoryPalacePageCounts(pageCounts) || totalItems;
   return {
-    totalItems: normalizeFiniteInt(
-      record?.totalItems,
-      clusters.reduce((sum, cluster) => sum + cluster.itemCount, 0),
-    ),
+    totalItems,
+    totalPages: normalizeFiniteInt(record?.totalPages, fallbackTotalPages),
+    pageCounts,
     totalClaims: normalizeFiniteInt(
       record?.totalClaims,
       clusters.reduce((sum, cluster) => sum + cluster.claimCount, 0),

--- a/ui/src/ui/views/dreaming.test.ts
+++ b/ui/src/ui/views/dreaming.test.ts
@@ -142,8 +142,16 @@ function buildProps(overrides?: Partial<DreamingProps>): DreamingProps {
     wikiMemoryPalaceLoading: false,
     wikiMemoryPalaceError: null,
     wikiMemoryPalace: {
-      totalItems: 2,
-      totalClaims: 3,
+      totalItems: 1,
+      totalPages: 2,
+      pageCounts: {
+        synthesis: 1,
+        entity: 0,
+        concept: 0,
+        source: 1,
+        report: 0,
+      },
+      totalClaims: 2,
       totalQuestions: 1,
       totalContradictions: 1,
       clusters: [
@@ -398,7 +406,13 @@ describe("dreaming view", () => {
     setDreamDiarySubTab("palace");
     const container = renderInto(buildProps());
     expect(compactText(container.querySelector(".dreams-diary__date"))).toBe(
-      "Syntheses · 1 pages · 2 claims · 1 questions · 1 contradictions",
+      "Vault · 2 pages · 2 claim rows · 1 open question · 1 contradiction",
+    );
+    expect(compactText(container.querySelectorAll(".dreams-diary__para")[0])).toBe(
+      "Full vault breakdown: Sources · 1 page; Syntheses · 1 page.",
+    );
+    expect(compactText(container.querySelectorAll(".dreams-diary__para")[1])).toContain(
+      "Selected section: Syntheses: 1 page · 2 claim rows · 1 open question on 1 page · 1 contradiction.",
     );
     const insight = container.querySelector(".dreams-diary__insight-card");
     expect(insight?.querySelector(".dreams-diary__insight-title")?.textContent).toBe(
@@ -449,6 +463,14 @@ describe("dreaming view", () => {
       onRequestUpdate: rerender,
       wikiMemoryPalace: {
         totalItems: 1,
+        totalPages: 1,
+        pageCounts: {
+          synthesis: 0,
+          entity: 0,
+          concept: 0,
+          source: 1,
+          report: 0,
+        },
         totalClaims: 0,
         totalQuestions: 0,
         totalContradictions: 0,

--- a/ui/src/ui/views/dreaming.ts
+++ b/ui/src/ui/views/dreaming.ts
@@ -495,6 +495,61 @@ function formatKindLabel(kind: "entity" | "concept" | "source" | "synthesis" | "
   return kind;
 }
 
+function formatCount(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+const MEMORY_PALACE_PAGE_COUNT_ORDER: Array<keyof WikiMemoryPalace["pageCounts"]> = [
+  "source",
+  "synthesis",
+  "report",
+  "entity",
+  "concept",
+];
+
+function formatMemoryPalacePageCountLabel(kind: keyof WikiMemoryPalace["pageCounts"]): string {
+  switch (kind) {
+    case "source":
+      return "Sources";
+    case "synthesis":
+      return "Syntheses";
+    case "report":
+      return "Reports";
+    case "entity":
+      return "Entities";
+    case "concept":
+      return "Concepts";
+  }
+  return kind;
+}
+
+function formatMemoryPalacePageBreakdown(pageCounts: WikiMemoryPalace["pageCounts"]): string {
+  const parts = MEMORY_PALACE_PAGE_COUNT_ORDER.map((kind) => {
+    const count = pageCounts[kind];
+    return count > 0
+      ? `${formatMemoryPalacePageCountLabel(kind)} · ${formatCount(count, "page")}`
+      : null;
+  }).filter((entry): entry is string => entry !== null);
+  return parts.length > 0 ? parts.join("; ") : "No pages yet";
+}
+
+function formatMemoryPalaceClusterSummary(cluster: WikiMemoryPalace["clusters"][number]): string {
+  const parts = [`${cluster.label}: ${formatCount(cluster.itemCount, "page")}`];
+  if (cluster.claimCount > 0) {
+    parts.push(formatCount(cluster.claimCount, "claim row"));
+  }
+  if (cluster.questionCount > 0) {
+    const questionPageCount = cluster.items.filter((item) => item.questionCount > 0).length;
+    parts.push(
+      `${formatCount(cluster.questionCount, "open question")} on ${formatCount(questionPageCount, "page")}`,
+    );
+  }
+  if (cluster.contradictionCount > 0) {
+    parts.push(formatCount(cluster.contradictionCount, "contradiction"));
+  }
+  return parts.join(" · ");
+}
+
 function formatImportBadge(item: {
   digestStatus: "available" | "withheld";
   riskLevel: "low" | "medium" | "high" | "unknown";
@@ -1146,6 +1201,14 @@ function renderMemoryPalaceSection(props: DreamingProps) {
   diaryEntryCount = clusters.length;
   const clusterIndex = Math.max(0, Math.min(diaryPage, clusters.length - 1));
   const cluster = clusters[clusterIndex];
+  const totalPages = palace?.totalPages ?? palace?.totalItems ?? 0;
+  const totalClaims = palace?.totalClaims ?? 0;
+  const totalQuestions = palace?.totalQuestions ?? 0;
+  const totalContradictions = palace?.totalContradictions ?? 0;
+  const pageBreakdown = palace
+    ? formatMemoryPalacePageBreakdown(palace.pageCounts)
+    : "No pages yet";
+  const clusterSummary = formatMemoryPalaceClusterSummary(cluster);
 
   return html`
     <div class="dreams-diary__daychips">
@@ -1169,16 +1232,17 @@ function renderMemoryPalaceSection(props: DreamingProps) {
     <article class="dreams-diary__entry" key="palace-${cluster.key}">
       <div class="dreams-diary__accent"></div>
       <div class="dreams-diary__date">
-        ${cluster.label} · ${cluster.itemCount} pages
-        ${cluster.claimCount > 0 ? html`· ${cluster.claimCount} claims` : nothing}
-        ${cluster.questionCount > 0 ? html`· ${cluster.questionCount} questions` : nothing}
-        ${cluster.contradictionCount > 0
-          ? html`· ${cluster.contradictionCount} contradictions`
+        Vault · ${formatCount(totalPages, "page")}
+        ${totalClaims > 0 ? html`· ${formatCount(totalClaims, "claim row")}` : nothing}
+        ${totalQuestions > 0 ? html`· ${formatCount(totalQuestions, "open question")}` : nothing}
+        ${totalContradictions > 0
+          ? html`· ${formatCount(totalContradictions, "contradiction")}`
           : nothing}
       </div>
       <div class="dreams-diary__prose">
+        <p class="dreams-diary__para">Full vault breakdown: ${pageBreakdown}.</p>
         <p class="dreams-diary__para">
-          Compiled wiki pages currently grouped under ${cluster.label.toLowerCase()}.
+          Selected section: ${clusterSummary}.
           ${cluster.updatedAt ? ` Latest update ${formatCompactDateTime(cluster.updatedAt)}.` : ""}
         </p>
       </div>

--- a/ui/src/ui/views/dreaming.ts
+++ b/ui/src/ui/views/dreaming.ts
@@ -540,9 +540,9 @@ function formatMemoryPalaceClusterSummary(cluster: WikiMemoryPalace["clusters"][
   }
   if (cluster.questionCount > 0) {
     const questionPageCount = cluster.items.filter((item) => item.questionCount > 0).length;
-    parts.push(
-      `${formatCount(cluster.questionCount, "open question")} on ${formatCount(questionPageCount, "page")}`,
-    );
+    const questionPageSuffix =
+      questionPageCount > 0 ? ` on ${formatCount(questionPageCount, "page")}` : "";
+    parts.push(`${formatCount(cluster.questionCount, "open question")}${questionPageSuffix}`);
   }
   if (cluster.contradictionCount > 0) {
     parts.push(formatCount(cluster.contradictionCount, "contradiction"));


### PR DESCRIPTION
## Summary

- Problem: the Memory Wiki palace headline showed selected section counts such as `Syntheses · 153 pages`, which could be misread as the full vault size.
- Solution: add vault-level `totalPages` / `pageCounts` to the palace payload and render the headline as a vault summary.
- What changed: the UI now shows the full vault page breakdown separately from the selected section's local metrics.
- What did NOT change (scope boundary): `totalItems` remains the filtered palace-card count; no compile, ingest, auth, storage, network, or command-execution behavior changed.

## Motivation

- Users need the Memory Wiki status surface to distinguish full vault size from synthesis-only or selected-section counts after `openclaw wiki compile`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #84597
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Memory Wiki palace summary now exposes the full vault page total and page-kind breakdown, while the selected synthesis section remains explicitly section-local.
- Real environment tested: local OpenClaw source checkout on this branch, using the actual `listMemoryWikiPalace` implementation against a temporary on-disk Memory Wiki vault, then rendering the actual Control UI controller/view with jsdom + Lit.
- Exact steps or command run after this patch:

```bash
OPENCLAW_FS_SAFE_PYTHON=/usr/bin/python3 FS_SAFE_PYTHON=/usr/bin/python3 OPENCLAW_FS_SAFE_PYTHON_MODE=auto FS_SAFE_PYTHON_MODE=auto node --import tsx /tmp/openclaw-84597-red-palace-proof.mjs
node --import tsx /tmp/openclaw-84597-ui-proof.mjs
node --import tsx /tmp/openclaw-84597-ui-screenshot-proof.mjs
node --import tsx /tmp/openclaw-84597-before-ui-screenshot-proof.mjs
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

Terminal capture from the backend runtime proof:

```json
{
  "totalItems": 1,
  "totalPages": 2,
  "pageCounts": {
    "synthesis": 1,
    "entity": 0,
    "concept": 0,
    "source": 1,
    "report": 0
  },
  "totalClaims": 2,
  "totalQuestions": 1,
  "totalContradictions": 1,
  "clusters": [
    {
      "key": "synthesis",
      "itemCount": 1,
      "claimCount": 2,
      "questionCount": 1,
      "contradictionCount": 1
    }
  ]
}
```

Terminal capture from the UI render proof:

```json
{
  "headline": "Vault · 2 pages · 2 claim rows · 1 open question · 1 contradiction",
  "breakdown": "Full vault breakdown: Sources · 1 page; Syntheses · 1 page.",
  "section": "Selected section: Syntheses: 1 page · 2 claim rows · 1 open question on 1 page · 1 contradiction. Latest update Apr 10, 6:00 PM."
}
```

Browser screenshot artifact from the same synthetic UI render:

```text
/tmp/openclaw-84597-proof/ui-palace-proof.png
1040x752 PNG, 150323 bytes
sha256 d99c90d737ac7236b2cb3484e010891aff3d75434f26c3a7c654642d75470fe6
```

Browser text assertions from the generated after-fix screenshot page:

```text
ok: Vault · 2 pages · 2 claim rows · 1 open question · 1 contradiction
ok: Full vault breakdown: Sources · 1 page; Syntheses · 1 page.
ok: Selected section: Syntheses: 1 page · 2 claim rows · 1 open question on 1 page · 1 contradiction.
ok: Travel system
```

Before-fix screenshot artifact from upstream/main with the same synthetic UI data:

```text
/tmp/openclaw-84597-proof/ui-palace-before-proof.png
1040x718 PNG, 138761 bytes
sha256 4950b4a9738abc382967fbf12eb2862e80c0b84e4fc84c728efa8f1badc167f4
```

Browser text assertions from the generated before-fix screenshot page:

```text
ok: Syntheses · 1 pages · 2 claims · 1 questions · 1 contradictions
ok: Compiled wiki pages currently grouped under syntheses.
ok: Travel system
```

Public screenshot artifacts are hosted on a separate fork artifact branch, not committed to this PR diff.

<details open>
<summary>After fix: vault total and full vault breakdown are visible</summary>

![After fix Memory Wiki palace vault total](https://raw.githubusercontent.com/nxmxbbd/openclaw/pr-85824-ui-proof/ui-palace-proof.png)
</details>

<details open>
<summary>Before fix: synthesis-local headline looked like the page total</summary>

![Before fix Memory Wiki palace synthesis headline](https://raw.githubusercontent.com/nxmxbbd/openclaw/pr-85824-ui-proof/ui-palace-before-proof.png)
</details>

- Observed result after fix: `totalItems` remains the filtered palace-card count (`1` synthesis card), while `totalPages` and `pageCounts` report the full vault (`2` pages: one source and one synthesis). The rendered palace tab headline is vault-level, and the selected synthesis metrics are labeled as the selected section.
- What was not tested: no full browser app/server flow or recording was captured; the DOM text render path was exercised with jsdom + Lit, and a browser screenshot artifact was captured from the same rendered UI using synthetic data.
- Before evidence (optional but encouraged): the same backend proof failed on pre-patch main with `Expected vault totalPages=2, got undefined`, after printing a payload that only contained `totalItems`, aggregate claim/question/contradiction counts, and the synthesis cluster. A before-fix UI screenshot from upstream/main also shows the ambiguous `Syntheses · 1 pages · 2 claims · 1 questions · 1 contradictions` headline.

## Root Cause (if applicable)

- Root cause: `listMemoryWikiPalace` only returned filtered palace-card totals, and the Control UI rendered the selected cluster count as the diary headline.
- Missing detection / guardrail: the palace tests did not include a source page that should count toward vault size but not toward visible palace cards, and the view test asserted the ambiguous `Syntheses · ... pages` headline.
- Contributing context (if known): `pageCounts` already existed in compile/digest data, but the palace status payload did not surface an equivalent vault-level summary.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/memory-wiki/src/memory-palace.test.ts`, `extensions/memory-wiki/src/gateway.test.ts`, `ui/src/ui/controllers/dreaming.test.ts`, `ui/src/ui/views/dreaming.test.ts`.
- Scenario the test should lock in: a vault with a synthesis page and a raw source page reports `totalItems` for visible palace cards separately from `totalPages/pageCounts`, and the UI renders a vault headline plus selected-section summary.
- Why this is the smallest reliable guardrail: it exercises the backend source of the counts, the gateway response contract, the UI normalization fallback, and the rendered text that users see.
- Existing test that already covers this (if any): existing palace tests covered cluster counts but not vault-level totals.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

The Memory Wiki palace tab headline now starts with `Vault · ... pages` and includes a full page-kind breakdown in the body. Selected section metrics remain visible but are labeled separately.

## Diagram (if applicable)

```text
Before:
wiki.palace -> filtered palace clusters -> headline "Syntheses · N pages ..."

After:
wiki.palace -> vault totalPages/pageCounts + filtered clusters -> headline "Vault · N pages ..." + selected-section summary
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux source checkout
- Runtime/container: Node 22 with repo dependencies installed
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): temporary Memory Wiki vault created under `/tmp`

### Steps

1. Create a temporary wiki vault with one synthesis page and one raw source page.
2. Call the actual `listMemoryWikiPalace` source implementation.
3. Load the returned payload through the UI controller and render the palace tab with jsdom + Lit.

### Expected

- Backend payload distinguishes filtered card count from full vault page count.
- UI headline is vault-level and selected-section metrics are labeled separately.

### Actual

- Backend payload includes `totalItems: 1`, `totalPages: 2`, and `pageCounts.source: 1` / `pageCounts.synthesis: 1`.
- UI renders `Vault · 2 pages...`, `Full vault breakdown: Sources · 1 page; Syntheses · 1 page.`, and `Selected section: Syntheses...`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: backend runtime proof, before/after UI render proof, before/after browser screenshot proof, gateway pass-through test, memory-palace count test, formatting, and full tsgo type signal.
- Edge cases checked: legacy UI payload fallback derives page counts from clusters; selected-section open-question copy does not say `on 0 pages` when per-item details are unavailable.
- What you did **not** verify: full browser app/server flow; full broad CI/check suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: additive payload fields could be confused with the existing filtered `totalItems` semantics.
  - Mitigation: `totalItems` is preserved as the filtered palace-card count; tests assert `totalItems` and `totalPages` can differ.
- Risk: older UI payloads without `pageCounts` could render an empty breakdown.
  - Mitigation: controller normalization derives fallback `pageCounts` / `totalPages` from clusters and `totalItems`.

AI-assisted; contributor manually reviewed and is responsible for the change.
