### PR TITLE
Fix Telegram preview retention on generation mismatch

### DIFF
--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -334,6 +334,7 @@ describe("createTelegramDraftStream", () => {
       textSnapshot: "Message A partial",
       parseMode: undefined,
       visibleSinceMs: supersededPreview.visibleSinceMs,
+      retain: true,
     });
     expect(typeof supersededPreview.visibleSinceMs).toBe("number");
     expect(Number.isFinite(supersededPreview.visibleSinceMs)).toBe(true);

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -177,6 +177,7 @@ export function createTelegramDraftStream(params: {
         textSnapshot: renderedText,
         parseMode: renderedParseMode,
         visibleSinceMs,
+        retain: true,
       });
       return true;
     }


### PR DESCRIPTION
## Summary
- Retain Telegram preview messages when `sendMessage` resolves after `generation` has already advanced.
- Keep the existing overflow-preview retention behavior unchanged.
- Fixes #85807.

## Verification
- `node scripts/run-vitest.mjs extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/bot-message-dispatch.test.ts`
- `node scripts/github/real-behavior-proof-check.mjs` with a local PR payload body matching this draft.

## Real behavior proof
Behavior addressed: Telegram preview messages that land during a generation-mismatch race are preserved instead of being deleted.
Real environment tested: Local OpenClaw checkout on macOS, Telegram draft-stream code path.
Exact steps or command run after this patch: node scripts/run-vitest.mjs extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/bot-message-dispatch.test.ts
Evidence after fix: Terminal capture from the focused Telegram regression lane:
```text
 RUN  v4.1.7 /Users/nianjiu/openclaw

 Test Files  2 passed (2)
      Tests  116 passed (116)
   Start at  04:24:53
   Duration  6.84s (transform 4.70s, setup 189ms, import 330ms, tests 6.21s, environment 0ms)
```
Observed result after fix: The generation-mismatch path now emits `retain: true`, matching the existing overflow-preview retention contract.
What was not tested: Live Telegram DM delivery against a production bot.
