### PR TITLE
fix: route Codex image API keys through OpenAI Images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Ollama: bypass the managed proxy for configured local embedding origins while keeping SSRF guardrails on unconfigured targets. Thanks @Kaspre.
+- OpenAI/images: route Codex API-key image generation through the native OpenAI Images API instead of the Codex OAuth streaming backend, avoiding 401s from valid API keys.
 - Checks/Windows: route full `pnpm check` stage commands through the managed child runner so Windows avoids Node shell-argv deprecation warnings there too.
 - Checks/Windows: run managed child commands through explicit `cmd.exe` wrapping instead of Node shell mode with argv, avoiding Node 24 subprocess deprecation warnings during changed checks.
 - Models: prune retired Groq, GitHub Copilot, OpenAI, xAI, and old Claude catalog entries, with doctor migration to upgrade existing configs to current provider refs.

--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -172,6 +172,42 @@ function createCodexOAuthAuthStore() {
   };
 }
 
+function createCodexApiKeyAuthStore() {
+  return {
+    version: 1 as const,
+    profiles: {
+      "openai-codex:manual": {
+        type: "api_key" as const,
+        provider: "openai-codex",
+        key: "codex-api-key",
+      },
+    },
+  };
+}
+
+function createCodexTokenAuthStore() {
+  return {
+    version: 1 as const,
+    profiles: {
+      "openai-codex:token": {
+        type: "token" as const,
+        provider: "openai-codex",
+        token: "codex-token",
+      },
+    },
+  };
+}
+
+function createMixedCodexAuthStore() {
+  return {
+    version: 1 as const,
+    profiles: {
+      ...createCodexTokenAuthStore().profiles,
+      ...createCodexApiKeyAuthStore().profiles,
+    },
+  };
+}
+
 type MockWithCalls = {
   mock: {
     calls: readonly (readonly unknown[])[];
@@ -839,6 +875,180 @@ describe("openai image generation provider", () => {
         },
       ],
     });
+  });
+
+  it("does not treat Codex API key profiles as configured Codex OAuth image auth", async () => {
+    mockGeneratedPngResponse();
+    resolveApiKeyForProviderMock.mockImplementation(async (params?: { provider?: string }) => {
+      if (params?.provider === "openai") {
+        return { apiKey: "openai-key", source: "profile:openai", mode: "api-key" };
+      }
+      throw new Error(`Unexpected auth provider ${params?.provider ?? ""}`);
+    });
+
+    const provider = buildOpenAIImageGenerationProvider();
+    await provider.generateImage({
+      provider: "openai",
+      model: "gpt-image-2",
+      prompt: "Draw with OpenAI auth despite a Codex API key profile",
+      cfg: {},
+      authStore: createCodexApiKeyAuthStore(),
+    });
+
+    expect(resolveApiKeyForProviderMock).toHaveBeenCalledTimes(1);
+    expect(authResolutionCall().provider).toBe("openai");
+    expect(jsonRequestCall().url).toBe("https://api.openai.com/v1/images/generations");
+    expect(httpConfigCall().provider).toBe("openai");
+    expect(logInfoMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("transport=codex-responses"),
+    );
+  });
+
+  it("uses native OpenAI image requests when only Codex API key auth is available", async () => {
+    mockGeneratedPngResponse();
+    resolveApiKeyForProviderMock.mockImplementation(async (params?: { provider?: string }) => {
+      if (params?.provider === "openai") {
+        return {};
+      }
+      if (params?.provider === "openai-codex") {
+        return {
+          apiKey: "codex-api-key",
+          source: "profile:openai-codex:manual",
+          mode: "api-key",
+        };
+      }
+      return {};
+    });
+
+    const provider = buildOpenAIImageGenerationProvider();
+    await provider.generateImage({
+      provider: "openai",
+      model: "gpt-image-2",
+      prompt: "Draw through Codex API key auth",
+      cfg: {},
+      authStore: createCodexApiKeyAuthStore(),
+    });
+
+    expect(resolveApiKeyForProviderMock).toHaveBeenCalledTimes(2);
+    expect(authResolutionCall(0).provider).toBe("openai");
+    expect(authResolutionCall(1).provider).toBe("openai-codex");
+    const configCall = httpConfigCall();
+    expect(configCall.defaultBaseUrl).toBe("https://api.openai.com/v1");
+    expect(configCall.defaultHeaders).toEqual({
+      Authorization: "Bearer codex-api-key",
+    });
+    expect(configCall.provider).toBe("openai");
+    expect(configCall.api).toBeUndefined();
+    expect(jsonRequestCall().url).toBe("https://api.openai.com/v1/images/generations");
+    expect(postMultipartRequestMock).not.toHaveBeenCalled();
+    expect(logInfoMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("transport=codex-responses"),
+    );
+  });
+
+  it("uses native OpenAI image requests when mixed Codex profiles resolve to an API key", async () => {
+    mockGeneratedPngResponse();
+    resolveApiKeyForProviderMock.mockImplementation(async (params?: { provider?: string }) => {
+      if (params?.provider === "openai-codex") {
+        return {
+          apiKey: "codex-api-key",
+          source: "profile:openai-codex:manual",
+          mode: "api-key",
+        };
+      }
+      throw new Error(`Unexpected auth provider ${params?.provider ?? ""}`);
+    });
+
+    const provider = buildOpenAIImageGenerationProvider();
+    await provider.generateImage({
+      provider: "openai",
+      model: "gpt-image-2",
+      prompt: "Draw through resolved Codex API key auth",
+      cfg: {},
+      authStore: createMixedCodexAuthStore(),
+    });
+
+    expect(resolveApiKeyForProviderMock).toHaveBeenCalledTimes(1);
+    expect(authResolutionCall().provider).toBe("openai-codex");
+    expect(httpConfigCall().defaultBaseUrl).toBe("https://api.openai.com/v1");
+    expect(httpConfigCall().defaultHeaders).toEqual({
+      Authorization: "Bearer codex-api-key",
+    });
+    expect(httpConfigCall().provider).toBe("openai");
+    expect(jsonRequestCall().url).toBe("https://api.openai.com/v1/images/generations");
+    expect(logInfoMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("transport=codex-responses"),
+    );
+  });
+
+  it("keeps Codex token auth on the Codex image transport", async () => {
+    mockCodexImageStream({ imageData: "codex-token-image" });
+    resolveApiKeyForProviderMock.mockImplementation(async (params?: { provider?: string }) => {
+      if (params?.provider === "openai") {
+        return {};
+      }
+      if (params?.provider === "openai-codex") {
+        return {
+          apiKey: "codex-token",
+          source: "profile:openai-codex:token",
+          mode: "token",
+        };
+      }
+      return {};
+    });
+
+    const provider = buildOpenAIImageGenerationProvider();
+    const result = await provider.generateImage({
+      provider: "openai",
+      model: "gpt-image-2",
+      prompt: "Draw through Codex token auth",
+      cfg: {},
+      authStore: createCodexTokenAuthStore(),
+    });
+
+    expect(resolveApiKeyForProviderMock).toHaveBeenCalledTimes(1);
+    expect(authResolutionCall().provider).toBe("openai-codex");
+    expect(httpConfigCall().defaultBaseUrl).toBe("https://chatgpt.com/backend-api/codex");
+    expect(httpConfigCall().provider).toBe("openai-codex");
+    expect(httpConfigCall().api).toBe("openai-codex-responses");
+    expect(jsonRequestCall().url).toBe("https://chatgpt.com/backend-api/codex/responses");
+    expect(postMultipartRequestMock).not.toHaveBeenCalled();
+    expect(result.images[0]?.buffer).toEqual(Buffer.from("codex-token-image"));
+  });
+
+  it("uses configured Codex token auth before probing an available OpenAI API key", async () => {
+    mockCodexImageStream({ imageData: "codex-token-image" });
+    resolveApiKeyForProviderMock.mockImplementation(async (params?: { provider?: string }) => {
+      if (params?.provider === "openai") {
+        return { apiKey: "openai-key", source: "OPENAI_API_KEY", mode: "api-key" };
+      }
+      if (params?.provider === "openai-codex") {
+        return {
+          apiKey: "codex-token",
+          source: "profile:openai-codex:token",
+          mode: "token",
+        };
+      }
+      return {};
+    });
+
+    const provider = buildOpenAIImageGenerationProvider();
+    await provider.generateImage({
+      provider: "openai",
+      model: "gpt-image-2",
+      prompt: "Draw using configured Codex token auth",
+      cfg: {},
+      authStore: createCodexTokenAuthStore(),
+    });
+
+    expect(resolveApiKeyForProviderMock).toHaveBeenCalledTimes(1);
+    expect(authResolutionCall().provider).toBe("openai-codex");
+    expect(
+      resolveApiKeyForProviderMock.mock.calls.some(
+        ([call]) => (call as AuthResolutionCall).provider === "openai",
+      ),
+    ).toBe(false);
+    expect(jsonRequestCall().url).toBe("https://chatgpt.com/backend-api/codex/responses");
   });
 
   it("routes transparent default-model Codex OAuth requests to the alpha-capable image model", async () => {

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -340,12 +340,18 @@ function resolveRequestAuthStore(req: {
   });
 }
 
-function hasCodexOAuthProfileConfigured(req: {
+function hasCodexResponseTransportProfileConfigured(req: {
   authStore?: AuthProfileStore;
   agentDir?: string;
 }): boolean {
   const store = resolveRequestAuthStore(req);
-  return Boolean(store && listProfilesForProvider(store, "openai-codex").length > 0);
+  if (!store) {
+    return false;
+  }
+  return listProfilesForProvider(store, "openai-codex").some(
+    (profileId) =>
+      store.profiles[profileId]?.type === "oauth" || store.profiles[profileId]?.type === "token",
+  );
 }
 
 type OpenAICodexImageGenerationEvent = {
@@ -733,11 +739,12 @@ export function buildOpenAIImageGenerationProvider(): ImageGenerationProvider {
       const isEdit = inputImages.length > 0;
       const rawBaseUrl = resolveConfiguredOpenAIBaseUrl(req.cfg);
       const publicOpenAIBaseUrl = isPublicOpenAIImageBaseUrl(rawBaseUrl);
-      const useCodexOAuthRoute =
+      const useCodexResponseTransportRoute =
         publicOpenAIBaseUrl &&
         !hasExplicitOpenAIDirectProviderConfig(req.cfg) &&
-        hasCodexOAuthProfileConfigured(req);
-      if (useCodexOAuthRoute) {
+        hasCodexResponseTransportProfileConfigured(req);
+      let preResolvedImageAuth: Awaited<ReturnType<typeof resolveApiKeyForProvider>> | undefined;
+      if (useCodexResponseTransportRoute) {
         const codexAuth = await resolveApiKeyForProvider({
           provider: "openai-codex",
           cfg: req.cfg,
@@ -747,18 +754,25 @@ export function buildOpenAIImageGenerationProvider(): ImageGenerationProvider {
         if (!codexAuth.apiKey) {
           throw new Error("OpenAI Codex OAuth missing");
         }
-        const timeoutMs = resolveOpenAIImageTimeoutMs(req.timeoutMs);
-        logCodexImageAuthSelected({ req, authMode: codexAuth.mode, timeoutMs });
-        return generateOpenAICodexImage({ req, apiKey: codexAuth.apiKey });
+        if (codexAuth.mode === "api-key") {
+          preResolvedImageAuth = codexAuth;
+        } else {
+          const timeoutMs = resolveOpenAIImageTimeoutMs(req.timeoutMs);
+          logCodexImageAuthSelected({ req, authMode: codexAuth.mode, timeoutMs });
+          return generateOpenAICodexImage({ req, apiKey: codexAuth.apiKey });
+        }
       }
 
-      const auth = await resolveOptionalApiKeyForProvider({
-        provider: "openai",
-        cfg: req.cfg,
-        agentDir: req.agentDir,
-        store: req.authStore,
-      });
-      if (!auth?.apiKey) {
+      const auth =
+        preResolvedImageAuth ??
+        (await resolveOptionalApiKeyForProvider({
+          provider: "openai",
+          cfg: req.cfg,
+          agentDir: req.agentDir,
+          store: req.authStore,
+        }));
+      let imageAuth = auth;
+      if (!imageAuth?.apiKey) {
         if (!publicOpenAIBaseUrl) {
           throw new Error("OpenAI API key missing");
         }
@@ -769,11 +783,17 @@ export function buildOpenAIImageGenerationProvider(): ImageGenerationProvider {
           store: req.authStore,
         });
         if (codexAuth?.apiKey) {
-          const timeoutMs = resolveOpenAIImageTimeoutMs(req.timeoutMs);
-          logCodexImageAuthSelected({ req, authMode: codexAuth.mode, timeoutMs });
-          return generateOpenAICodexImage({ req, apiKey: codexAuth.apiKey });
+          if (codexAuth.mode === "api-key") {
+            imageAuth = codexAuth;
+          } else {
+            const timeoutMs = resolveOpenAIImageTimeoutMs(req.timeoutMs);
+            logCodexImageAuthSelected({ req, authMode: codexAuth.mode, timeoutMs });
+            return generateOpenAICodexImage({ req, apiKey: codexAuth.apiKey });
+          }
         }
-        throw new Error("OpenAI API key or Codex OAuth missing");
+        if (!imageAuth?.apiKey) {
+          throw new Error("OpenAI API key or Codex OAuth missing");
+        }
       }
       const isAzure = isAzureOpenAIBaseUrl(rawBaseUrl);
 
@@ -783,8 +803,8 @@ export function buildOpenAIImageGenerationProvider(): ImageGenerationProvider {
           defaultBaseUrl: DEFAULT_OPENAI_IMAGE_BASE_URL,
           allowPrivateNetwork: shouldAllowPrivateImageEndpoint(req),
           defaultHeaders: isAzure
-            ? { "api-key": auth.apiKey }
-            : { Authorization: `Bearer ${auth.apiKey}` },
+            ? { "api-key": imageAuth.apiKey }
+            : { Authorization: `Bearer ${imageAuth.apiKey}` },
           provider: "openai",
           capability: "image",
           transport: "http",


### PR DESCRIPTION
## Summary
- route Codex API-key image auth through the native OpenAI Images API instead of the Codex Responses backend
- keep Codex OAuth and token auth on the Codex image transport
- add regression coverage for API-key-only, mixed Codex profiles, token, and OpenAI-key precedence paths
- add changelog entry

## Behavior addressed
ClawSweeper image generation on Hetzner selected an OpenAI Codex auth profile whose resolved credential was an API key, then sent it to the Codex Responses backend. That backend rejected the valid API key with 401. This patch routes resolved API-key credentials to api.openai.com image generation and reserves the Codex backend for OAuth or token credentials.

## Real environment tested
Local OpenClaw worktree with the focused OpenAI provider test harness. The original Hetzner diagnosis showed the key was valid against api.openai.com and invalid against the chatgpt.com Codex backend.

## Verification
- SHARP_IGNORE_GLOBAL_LIBVIPS=1 pnpm install --frozen-lockfile
- OPENCLAW_VITEST_INCLUDE_FILE=/tmp/openclaw-openai-image-vitest.json OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=180000 fnm exec --using v22.22.2 node scripts/run-vitest.mjs --config test/vitest/vitest.extension-provider-openai.config.ts --run
- fnm exec --using v22.22.2 pnpm tsgo:extensions:test
- git diff --check HEAD~1..HEAD
- autoreview --mode local

## Evidence after fix
- focused Vitest: 1 file passed, 54 tests passed
- extension typecheck: passed
- whitespace check: passed
- autoreview: clean, no accepted/actionable findings

## Not tested
No live image generation call against OpenAI Images API from this PR branch. The fix is covered at the provider auth-routing layer that selects the transport and request config.
