### PR TITLE
[codex] web_search: add Perplexity model override

### DIFF
--- a/docs/tools/perplexity-search.md
+++ b/docs/tools/perplexity-search.md
@@ -26,6 +26,7 @@ Optional compatibility controls:
 
 - `plugins.entries.perplexity.config.webSearch.baseUrl`
 - `plugins.entries.perplexity.config.webSearch.model`
+- `plugins.entries.perplexity.config.webSearch.allowedModels`
 
 ## Config examples
 
@@ -66,6 +67,7 @@ Optional compatibility controls:
             apiKey: "<openrouter-api-key>",
             baseUrl: "https://openrouter.ai/api/v1",
             model: "perplexity/sonar-pro",
+            allowedModels: ["perplexity/sonar", "perplexity/sonar-pro"],
           },
         },
       },
@@ -106,7 +108,7 @@ Number of results to return (1-10).
 </ParamField>
 
 <ParamField path="model" type="string">
-Optional Sonar/OpenRouter model override for the chat-completions path. Use `default` to fall back to the configured model.
+Optional Sonar/OpenRouter model override for the chat-completions path. Use `default` to fall back to the configured model. Per-call overrides must be allowlisted via `plugins.entries.perplexity.config.webSearch.allowedModels`.
 </ParamField>
 
 <ParamField path="country" type="string">
@@ -144,7 +146,7 @@ Per-page token limit.
 For the legacy Sonar/OpenRouter compatibility path:
 
 - `query`, `count`, and `freshness` are accepted
-- `model` can override the configured Sonar/OpenRouter model for a single call
+- `model` can override the configured Sonar/OpenRouter model for a single call when it is present in `plugins.entries.perplexity.config.webSearch.allowedModels`
 - `count` is compatibility-only there; the response is still one synthesized
   answer with citations rather than an N-result list
 - Search API-only filters such as `country`, `language`, `date_after`,
@@ -204,6 +206,7 @@ await web_search({
 
 - Perplexity Search API returns structured web search results (`title`, `url`, `snippet`)
 - OpenRouter or explicit `plugins.entries.perplexity.config.webSearch.baseUrl` / `model` switches Perplexity back to Sonar chat completions for compatibility
+- `plugins.entries.perplexity.config.webSearch.allowedModels` gates which per-call `model` overrides are accepted
 - Sonar/OpenRouter compatibility returns one synthesized answer with citations, not structured result rows
 - Results are cached for 15 minutes by default (configurable via `cacheTtlMinutes`)
 

--- a/docs/tools/perplexity-search.md
+++ b/docs/tools/perplexity-search.md
@@ -105,6 +105,10 @@ Search query.
 Number of results to return (1-10).
 </ParamField>
 
+<ParamField path="model" type="string">
+Optional Sonar/OpenRouter model override for the chat-completions path. Use `default` to fall back to the configured model.
+</ParamField>
+
 <ParamField path="country" type="string">
 2-letter ISO country code (e.g. `US`, `DE`).
 </ParamField>
@@ -140,6 +144,7 @@ Per-page token limit.
 For the legacy Sonar/OpenRouter compatibility path:
 
 - `query`, `count`, and `freshness` are accepted
+- `model` can override the configured Sonar/OpenRouter model for a single call
 - `count` is compatibility-only there; the response is still one synthesized
   answer with citations rather than an N-result list
 - Search API-only filters such as `country`, `language`, `date_after`,

--- a/extensions/perplexity/openclaw.plugin.json
+++ b/extensions/perplexity/openclaw.plugin.json
@@ -20,6 +20,10 @@
     "webSearch.model": {
       "label": "Perplexity Model",
       "help": "Optional Sonar/OpenRouter model override."
+    },
+    "webSearch.allowedModels": {
+      "label": "Perplexity Allowed Models",
+      "help": "Optional allowlist of model ids that can be selected per call. Use * to allow any model."
     }
   },
   "contracts": {
@@ -44,6 +48,12 @@
           },
           "model": {
             "type": "string"
+          },
+          "allowedModels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       }

--- a/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
@@ -1,6 +1,7 @@
 import {
   readNumberParam,
   readStringArrayParam,
+  normalizeToolModelOverride,
   readStringParam,
 } from "openclaw/plugin-sdk/provider-web-search";
 import {
@@ -117,7 +118,11 @@ function resolvePerplexityBaseUrl(
   return DEFAULT_PERPLEXITY_BASE_URL;
 }
 
-function resolvePerplexityModel(perplexity?: PerplexityConfig): string {
+function resolvePerplexityModel(perplexity?: PerplexityConfig, modelOverride?: string): string {
+  const override = normalizeToolModelOverride(modelOverride);
+  if (override) {
+    return override;
+  }
   const model = normalizeOptionalString(perplexity?.model) ?? "";
   return model || DEFAULT_PERPLEXITY_MODEL;
 }
@@ -147,7 +152,10 @@ async function readPerplexityJsonResponse<T>(response: Response, label: string):
   }
 }
 
-function resolvePerplexityTransport(perplexity?: PerplexityConfig): {
+function resolvePerplexityTransport(
+  perplexity?: PerplexityConfig,
+  modelOverride?: string,
+): {
   apiKey?: string;
   source: "config" | "perplexity_env" | "openrouter_env" | "none";
   baseUrl: string;
@@ -156,9 +164,11 @@ function resolvePerplexityTransport(perplexity?: PerplexityConfig): {
 } {
   const auth = resolvePerplexityApiKey(perplexity);
   const baseUrl = resolvePerplexityBaseUrl(perplexity, auth.source, auth.apiKey);
-  const model = resolvePerplexityModel(perplexity);
+  const model = resolvePerplexityModel(perplexity, modelOverride);
   const hasLegacyOverride = Boolean(
-    normalizeOptionalString(perplexity?.baseUrl) || normalizeOptionalString(perplexity?.model),
+    normalizeOptionalString(perplexity?.baseUrl) ||
+    normalizeOptionalString(perplexity?.model) ||
+    normalizeToolModelOverride(modelOverride),
   );
   return {
     ...auth,
@@ -314,7 +324,8 @@ export async function executePerplexitySearch(
   searchConfig?: SearchConfigRecord,
 ): Promise<Record<string, unknown>> {
   const perplexityConfig = resolvePerplexityConfig(searchConfig);
-  const runtime = resolvePerplexityTransport(perplexityConfig);
+  const modelOverride = normalizeToolModelOverride(readStringParam(args, "model"));
+  const runtime = resolvePerplexityTransport(perplexityConfig, modelOverride);
   if (!runtime.apiKey) {
     return {
       error: "missing_perplexity_api_key",

--- a/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
@@ -39,6 +39,7 @@ type PerplexityConfig = {
   apiKey?: string;
   baseUrl?: string;
   model?: string;
+  allowedModels?: string[];
 };
 
 type PerplexitySearchResponse = {
@@ -71,6 +72,16 @@ function resolvePerplexityConfig(searchConfig?: SearchConfigRecord): PerplexityC
   return perplexity && typeof perplexity === "object" && !Array.isArray(perplexity)
     ? (perplexity as PerplexityConfig)
     : {};
+}
+
+function normalizePerplexityAllowedModels(perplexity?: PerplexityConfig): string[] {
+  const allowedModels = perplexity?.allowedModels;
+  if (!Array.isArray(allowedModels)) {
+    return [];
+  }
+  return allowedModels
+    .map((model) => normalizeOptionalString(model))
+    .filter((model): model is string => Boolean(model));
 }
 
 function resolvePerplexityApiKey(perplexity?: PerplexityConfig): {
@@ -118,13 +129,48 @@ function resolvePerplexityBaseUrl(
   return DEFAULT_PERPLEXITY_BASE_URL;
 }
 
-function resolvePerplexityModel(perplexity?: PerplexityConfig, modelOverride?: string): string {
-  const override = normalizeToolModelOverride(modelOverride);
-  if (override) {
-    return override;
-  }
+function resolveConfiguredPerplexityModel(perplexity?: PerplexityConfig): string {
   const model = normalizeOptionalString(perplexity?.model) ?? "";
-  return model || DEFAULT_PERPLEXITY_MODEL;
+  return model;
+}
+
+function resolvePerplexityModel(perplexity?: PerplexityConfig): string {
+  return resolveConfiguredPerplexityModel(perplexity) || DEFAULT_PERPLEXITY_MODEL;
+}
+
+function resolvePerplexityModelSelection(
+  perplexity?: PerplexityConfig,
+  modelOverride?: string,
+):
+  | { model: string; overrideApplied: false }
+  | { model: string; overrideApplied: true }
+  | {
+      error: "unsupported_model_override";
+      message: string;
+      docs: string;
+    } {
+  const override = normalizeToolModelOverride(modelOverride);
+  const configuredModel = resolveConfiguredPerplexityModel(perplexity);
+  const effectiveModel = resolvePerplexityModel(perplexity);
+  if (!override) {
+    return { model: effectiveModel, overrideApplied: false };
+  }
+
+  const allowedModels = normalizePerplexityAllowedModels(perplexity);
+  if (
+    (configuredModel && override === configuredModel) ||
+    allowedModels.includes("*") ||
+    allowedModels.includes(override)
+  ) {
+    return { model: override, overrideApplied: true };
+  }
+
+  return {
+    error: "unsupported_model_override",
+    message:
+      "model overrides are only supported for allowlisted Perplexity models. Add the requested model to plugins.entries.perplexity.config.webSearch.allowedModels or use the configured default model.",
+    docs: "https://docs.openclaw.ai/tools/web",
+  };
 }
 
 function resolvePerplexityRequestModel(baseUrl: string, model: string): string {
@@ -154,7 +200,7 @@ async function readPerplexityJsonResponse<T>(response: Response, label: string):
 
 function resolvePerplexityTransport(
   perplexity?: PerplexityConfig,
-  modelOverride?: string,
+  params?: { model?: string; overrideApplied?: boolean },
 ): {
   apiKey?: string;
   source: "config" | "perplexity_env" | "openrouter_env" | "none";
@@ -164,11 +210,11 @@ function resolvePerplexityTransport(
 } {
   const auth = resolvePerplexityApiKey(perplexity);
   const baseUrl = resolvePerplexityBaseUrl(perplexity, auth.source, auth.apiKey);
-  const model = resolvePerplexityModel(perplexity, modelOverride);
+  const model = params?.model ?? resolvePerplexityModel(perplexity);
   const hasLegacyOverride = Boolean(
     normalizeOptionalString(perplexity?.baseUrl) ||
     normalizeOptionalString(perplexity?.model) ||
-    normalizeToolModelOverride(modelOverride),
+    params?.overrideApplied,
   );
   return {
     ...auth,
@@ -324,8 +370,14 @@ export async function executePerplexitySearch(
   searchConfig?: SearchConfigRecord,
 ): Promise<Record<string, unknown>> {
   const perplexityConfig = resolvePerplexityConfig(searchConfig);
-  const modelOverride = normalizeToolModelOverride(readStringParam(args, "model"));
-  const runtime = resolvePerplexityTransport(perplexityConfig, modelOverride);
+  const modelSelection = resolvePerplexityModelSelection(
+    perplexityConfig,
+    readStringParam(args, "model"),
+  );
+  if ("error" in modelSelection) {
+    return modelSelection;
+  }
+  const runtime = resolvePerplexityTransport(perplexityConfig, modelSelection);
   if (!runtime.apiKey) {
     return {
       error: "missing_perplexity_api_key",
@@ -555,6 +607,7 @@ export const testing = {
   isDirectPerplexityBaseUrl,
   resolvePerplexityRequestModel,
   resolvePerplexityApiKey,
+  resolvePerplexityModelSelection,
   readPerplexityJsonResponse,
   normalizeToIsoDate,
   isoToPerplexityDate,

--- a/extensions/perplexity/src/perplexity-web-search-provider.test.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.test.ts
@@ -1,5 +1,5 @@
-import { withEnv, withEnvAsync } from "openclaw/plugin-sdk/test-env";
-import { describe, expect, it } from "vitest";
+import { withEnv, withEnvAsync, withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createPerplexityWebSearchProvider } from "./perplexity-web-search-provider.js";
 import { testing } from "./perplexity-web-search-provider.runtime.js";
 
@@ -8,6 +8,10 @@ const perplexityApiKeyEnv = ["PERPLEXITY_API", "KEY"].join("_");
 const openRouterPerplexityApiKey = ["sk", "or", "v1", "test"].join("-");
 const directPerplexityApiKey = ["pplx", "test"].join("-");
 const enterprisePerplexityApiKey = ["enterprise", "perplexity", "test"].join("-");
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("perplexity web search provider", () => {
   it("points missing-key users to fetch/browser alternatives", async () => {
@@ -100,6 +104,54 @@ describe("perplexity web search provider", () => {
           baseUrl: "https://api.perplexity.ai",
           model: "perplexity/sonar-pro",
           transport: "search_api",
+        });
+      },
+    );
+  });
+
+  it("honors a per-call model override on the chat-completions path", async () => {
+    const mockFetch = vi.fn(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            choices: [
+              {
+                message: {
+                  content: "Grounded answer",
+                },
+              },
+            ],
+          }),
+        ),
+      ),
+    );
+    vi.stubGlobal("fetch", withFetchPreconnect(mockFetch));
+
+    await withEnvAsync(
+      { [perplexityApiKeyEnv]: undefined, [openRouterApiKeyEnv]: openRouterPerplexityApiKey },
+      async () => {
+        const provider = createPerplexityWebSearchProvider();
+        const tool = provider.createTool({
+          config: {},
+          searchConfig: {},
+        });
+        if (!tool) {
+          throw new Error("Expected tool definition");
+        }
+
+        const result = await tool.execute({
+          query: "OpenClaw docs",
+          model: "perplexity/sonar",
+        });
+
+        expect(result.model).toBe("perplexity/sonar");
+        expect(result.provider).toBe("perplexity");
+
+        const [input, init] = mockFetch.mock.calls[0] ?? [];
+        expect(String(input)).toBe("https://openrouter.ai/api/v1/chat/completions");
+        expect(JSON.parse(String(init?.body))).toMatchObject({
+          model: "perplexity/sonar",
+          messages: [{ role: "user", content: "OpenClaw docs" }],
         });
       },
     );

--- a/extensions/perplexity/src/perplexity-web-search-provider.test.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.test.ts
@@ -55,6 +55,34 @@ describe("perplexity web search provider", () => {
     ).toBe("perplexity/sonar-pro");
   });
 
+  it("rejects per-call model overrides that are not allowlisted", async () => {
+    await withEnvAsync(
+      { [perplexityApiKeyEnv]: undefined, [openRouterApiKeyEnv]: openRouterPerplexityApiKey },
+      async () => {
+        const provider = createPerplexityWebSearchProvider();
+        const tool = provider.createTool({
+          config: {},
+          searchConfig: {},
+        });
+        if (!tool) {
+          throw new Error("Expected tool definition");
+        }
+
+        await expect(
+          tool.execute({
+            query: "OpenClaw docs",
+            model: "perplexity/sonar",
+          }),
+        ).resolves.toEqual({
+          error: "unsupported_model_override",
+          message:
+            "model overrides are only supported for allowlisted Perplexity models. Add the requested model to plugins.entries.perplexity.config.webSearch.allowedModels or use the configured default model.",
+          docs: "https://docs.openclaw.ai/tools/web",
+        });
+      },
+    );
+  });
+
   it("chooses direct search_api transport only for direct base urls without legacy overrides", () => {
     expect(
       testing.resolvePerplexityTransport({
@@ -133,7 +161,11 @@ describe("perplexity web search provider", () => {
         const provider = createPerplexityWebSearchProvider();
         const tool = provider.createTool({
           config: {},
-          searchConfig: {},
+          searchConfig: {
+            perplexity: {
+              allowedModels: ["perplexity/sonar"],
+            },
+          },
         });
         if (!tool) {
           throw new Error("Expected tool definition");

--- a/extensions/perplexity/src/perplexity-web-search-provider.test.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.test.ts
@@ -179,7 +179,8 @@ describe("perplexity web search provider", () => {
         expect(result.model).toBe("perplexity/sonar");
         expect(result.provider).toBe("perplexity");
 
-        const [input, init] = mockFetch.mock.calls[0] ?? [];
+        const call = mockFetch.mock.calls[0] as [RequestInfo | URL, RequestInit?] | undefined;
+        const [input, init] = call ?? [];
         expect(String(input)).toBe("https://openrouter.ai/api/v1/chat/completions");
         expect(JSON.parse(String(init?.body))).toMatchObject({
           model: "perplexity/sonar",

--- a/extensions/perplexity/src/perplexity-web-search-provider.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.ts
@@ -33,7 +33,8 @@ function createPerplexityParameters(transport?: string): Record<string, unknown>
     },
     model: {
       type: "string",
-      description: "Optional Sonar/OpenRouter model override. Use 'default' to reset.",
+      description:
+        "Optional Sonar/OpenRouter model override. Use 'default' to reset; allowlisted overrides only.",
     },
     freshness: {
       type: "string",

--- a/extensions/perplexity/src/perplexity-web-search-provider.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.ts
@@ -31,6 +31,10 @@ function createPerplexityParameters(transport?: string): Record<string, unknown>
       minimum: 1,
       maximum: 10,
     },
+    model: {
+      type: "string",
+      description: "Optional Sonar/OpenRouter model override. Use 'default' to reset.",
+    },
     freshness: {
       type: "string",
       description: "Filter by time: 'day' (24h), 'week', 'month', or 'year'.",

--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -25,6 +25,15 @@ describe("web_search tool schema", () => {
 
     expect(parameters?.properties?.count?.maximum).toBe(MAX_SEARCH_COUNT);
   });
+
+  it("advertises an optional model override for provider-specific routing", () => {
+    const tool = createWebSearchTool();
+    const parameters = tool?.parameters as
+      | { properties?: { model?: { type?: unknown } } }
+      | undefined;
+
+    expect(parameters?.properties?.model?.type).toBe("string");
+  });
 });
 
 describe("web_search freshness normalization", () => {

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -17,6 +17,10 @@ const WebSearchSchema = {
       minimum: 1,
       maximum: MAX_SEARCH_COUNT,
     },
+    model: {
+      type: "string",
+      description: "Optional provider-specific model override. Use 'default' to reset.",
+    },
     country: {
       type: "string",
       description: "2-letter country code.",

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -19,7 +19,8 @@ const WebSearchSchema = {
     },
     model: {
       type: "string",
-      description: "Optional provider-specific model override. Use 'default' to reset.",
+      description:
+        "Optional provider-specific model override. Use 'default' to reset; Perplexity only honors allowlisted overrides.",
     },
     country: {
       type: "string",

--- a/src/plugin-sdk/provider-web-search.ts
+++ b/src/plugin-sdk/provider-web-search.ts
@@ -11,6 +11,7 @@ export {
   jsonResult,
   readNumberParam,
   readStringArrayParam,
+  normalizeToolModelOverride,
   readStringParam,
 } from "../agents/tools/common.js";
 export { resolveCitationRedirectUrl } from "../agents/tools/web-search-citation-redirect.js";

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -1161,6 +1161,10 @@
           "minimum": 1,
           "type": "number"
         },
+        "model": {
+          "description": "Optional provider-specific model override. Use 'default' to reset; Perplexity only honors allowlisted overrides.",
+          "type": "string"
+        },
         "query": {
           "description": "Search query.",
           "type": "string"

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -1193,6 +1193,10 @@
           "minimum": 1,
           "type": "number"
         },
+        "model": {
+          "description": "Optional provider-specific model override. Use 'default' to reset; Perplexity only honors allowlisted overrides.",
+          "type": "string"
+        },
         "query": {
           "description": "Search query.",
           "type": "string"

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1157,6 +1157,10 @@
           "minimum": 1,
           "type": "number"
         },
+        "model": {
+          "description": "Optional provider-specific model override. Use 'default' to reset; Perplexity only honors allowlisted overrides.",
+          "type": "string"
+        },
         "query": {
           "description": "Search query.",
           "type": "string"

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -218,8 +218,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 40441,
-    "roughTokens": 10111
+    "chars": 40639,
+    "roughTokens": 10160
   },
   "openClawDeveloperInstructions": {
     "chars": 3184,
@@ -230,8 +230,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6591
   },
   "totalWithDynamicToolsJson": {
-    "chars": 66805,
-    "roughTokens": 16702
+    "chars": 67003,
+    "roughTokens": 16751
   },
   "userInputText": {
     "chars": 1530,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -218,8 +218,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 40216,
-    "roughTokens": 10054
+    "chars": 40414,
+    "roughTokens": 10104
   },
   "openClawDeveloperInstructions": {
     "chars": 2160,
@@ -230,8 +230,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6210
   },
   "totalWithDynamicToolsJson": {
-    "chars": 65056,
-    "roughTokens": 16264
+    "chars": 65254,
+    "roughTokens": 16314
   },
   "userInputText": {
     "chars": 1030,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -219,8 +219,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 41311,
-    "roughTokens": 10328
+    "chars": 41509,
+    "roughTokens": 10378
   },
   "openClawDeveloperInstructions": {
     "chars": 2179,
@@ -231,8 +231,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6677
   },
   "totalWithDynamicToolsJson": {
-    "chars": 68020,
-    "roughTokens": 17005
+    "chars": 68218,
+    "roughTokens": 17055
   },
   "userInputText": {
     "chars": 1268,


### PR DESCRIPTION
## Summary
Perplexity web_search now accepts a per-call `model` override, but only allowlisted models from `plugins.entries.perplexity.config.webSearch.allowedModels` are honored.

## Verification
- `node scripts/run-vitest.mjs src/agents/tools/web-search.test.ts extensions/perplexity/src/perplexity-web-search-provider.test.ts src/config/config.web-search-provider.test.ts`

## Real behavior proof
Behavior addressed: An allowlisted per-call `model` override reaches the Perplexity web_search dispatch path and changes the outgoing chat-completions request body.
Real environment tested: Local OpenClaw checkout on macOS using a live `node` harness with the real Perplexity provider runtime and undici runtime deps injection.
Exact steps or command run after this patch: `node` harness executed via `pnpm exec tsx -` that called `createPerplexityWebSearchProvider()`, ran `tool.execute({ query: "OpenClaw docs", model: "perplexity/sonar" })`, and printed the captured request plus result.
Evidence after fix:
```json
{
  "captured": {
    "input": "https://openrouter.ai/api/v1/chat/completions",
    "body": {
      "model": "perplexity/sonar",
      "messages": [
        {
          "role": "user",
          "content": "OpenClaw docs"
        }
      ]
    }
  },
  "result": {
    "query": "OpenClaw docs",
    "provider": "perplexity",
    "model": "perplexity/sonar",
    "tookMs": 6,
    "externalContent": {
      "untrusted": true,
      "source": "web_search",
      "provider": "perplexity",
      "wrapped": true
    },
    "content": "
<<<EXTERNAL_UNTRUSTED_CONTENT id="d1ffc601caa2de6b">>>
Source: Web Search
---
Grounded answer
<<<END_EXTERNAL_UNTRUSTED_CONTENT id="d1ffc601caa2de6b">>>",
    "citations": []
  }
}
```
Observed result after fix: The provider sent the allowlisted override model to `https://openrouter.ai/api/v1/chat/completions`, and the tool result reported the same model back.
What was not tested: A direct third-party OpenRouter request; the live path was intercepted locally so the request body could be observed without external credentials.