### PR TITLE
Avoid post-run auth success lane delay

### DIFF
--- a/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
@@ -196,7 +196,7 @@ describe("overflow compaction in run loop", () => {
     mockedMarkAuthProfileSuccess.mockReturnValueOnce(successPromise);
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult());
 
-    const result = await runEmbeddedPiAgent(baseParams);
+    const result = await runEmbeddedAgent(baseParams);
 
     expect(result.meta.error).toBeUndefined();
     expect(mockedMarkAuthProfileSuccess).toHaveBeenCalledTimes(1);

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
@@ -14,6 +14,7 @@ import {
   mockedIsCompactionFailureError,
   mockedIsLikelyContextOverflowError,
   mockedLog,
+  mockedMarkAuthProfileSuccess,
   mockedResolveModelAsync,
   mockedRunEmbeddedAttempt,
   mockedSessionLikelyHasOversizedToolResults,
@@ -185,6 +186,22 @@ describe("overflow compaction in run loop", () => {
     });
 
     expect(requireMockCallArg(mockedRunEmbeddedAttempt, 0).thinkLevel).toBe("adaptive");
+  });
+
+  it("does not wait for post-run auth-profile success bookkeeping before returning", async () => {
+    let resolveSuccess!: () => void;
+    const successPromise = new Promise<void>((resolve) => {
+      resolveSuccess = resolve;
+    });
+    mockedMarkAuthProfileSuccess.mockReturnValueOnce(successPromise);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult());
+
+    const result = await runEmbeddedPiAgent(baseParams);
+
+    expect(result.meta.error).toBeUndefined();
+    expect(mockedMarkAuthProfileSuccess).toHaveBeenCalledTimes(1);
+    resolveSuccess();
+    await successPromise;
   });
 
   it("continues from transcript after compaction when the current inbound message was persisted", async () => {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -599,6 +599,8 @@ function resolveInitialEmbeddedRunModel(params: {
   };
 }
 
+const POST_RUN_AUTH_PROFILE_SUCCESS_SLOW_MS = 1_000;
+
 export function runEmbeddedAgent(
   paramsInput: RunEmbeddedAgentParams,
 ): Promise<EmbeddedAgentRunResult> {
@@ -1732,6 +1734,47 @@ async function runEmbeddedAgentInternal(
           runId: params.runId,
           modelId: failure.modelId,
         });
+      };
+      const markAuthProfileSuccessAfterRun = () => {
+        if (!lastProfileId) {
+          return;
+        }
+        const successProfileId = lastProfileId;
+        const successProvider = resolveAuthProfileStateProvider(
+          profileFailureStore,
+          successProfileId,
+          provider,
+        );
+        const successStarted = Date.now();
+        void markAuthProfileSuccess({
+          store: profileFailureStore,
+          provider: successProvider,
+          profileId: successProfileId,
+          agentDir: params.agentDir,
+        })
+          .then(() => {
+            const durationMs = Date.now() - successStarted;
+            if (durationMs >= POST_RUN_AUTH_PROFILE_SUCCESS_SLOW_MS) {
+              log.warn(
+                `post-run auth-profile success bookkeeping completed after ${durationMs}ms: ` +
+                  `runId=${params.runId} sessionId=${params.sessionId} ` +
+                  `provider=${sanitizeForLog(successProvider)} profileId=${sanitizeForLog(successProfileId)}`,
+              );
+            } else if (log.isEnabled("trace")) {
+              log.trace(
+                `post-run auth-profile success bookkeeping completed: ` +
+                  `runId=${params.runId} sessionId=${params.sessionId} durationMs=${durationMs}`,
+              );
+            }
+          })
+          .catch((err: unknown) => {
+            log.warn(
+              `post-run auth-profile success bookkeeping failed: ` +
+                `runId=${params.runId} sessionId=${params.sessionId} ` +
+                `provider=${sanitizeForLog(successProvider)} profileId=${sanitizeForLog(successProfileId)} ` +
+                `error=${formatErrorMessage(err)}`,
+            );
+          });
       };
       const resolveRunAuthProfileFailureReason = (
         failoverReason: FailoverReason | null,
@@ -4036,18 +4079,7 @@ async function runEmbeddedAgentInternal(
           log.debug(
             `embedded run done: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - started} aborted=${aborted}`,
           );
-          if (lastProfileId) {
-            await markAuthProfileSuccess({
-              store: profileFailureStore,
-              provider: resolveAuthProfileStateProvider(
-                profileFailureStore,
-                lastProfileId,
-                provider,
-              ),
-              profileId: lastProfileId,
-              agentDir: params.agentDir,
-            });
-          }
+          markAuthProfileSuccessAfterRun();
           const replayInvalid = resolveReplayInvalidForAttempt(null);
           const livenessState = attempt.yieldDetected
             ? "paused"

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -31,6 +31,7 @@ import {
 import { sleepWithAbort } from "../../infra/backoff.js";
 import { freezeDiagnosticTraceContext } from "../../infra/diagnostic-trace-context.js";
 import { formatErrorMessage, toErrorObject } from "../../infra/errors.js";
+import { redactIdentifier } from "../../logging/redact-identifier.js";
 import { buildAgentHookContextChannelFields } from "../../plugins/hook-agent-context.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { resolveProviderAuthProfileId } from "../../plugins/provider-runtime.js";
@@ -1740,6 +1741,7 @@ async function runEmbeddedAgentInternal(
           return;
         }
         const successProfileId = lastProfileId;
+        const safeSuccessProfileId = redactIdentifier(successProfileId, { len: 12 });
         const successProvider = resolveAuthProfileStateProvider(
           profileFailureStore,
           successProfileId,
@@ -1758,7 +1760,7 @@ async function runEmbeddedAgentInternal(
               log.warn(
                 `post-run auth-profile success bookkeeping completed after ${durationMs}ms: ` +
                   `runId=${params.runId} sessionId=${params.sessionId} ` +
-                  `provider=${sanitizeForLog(successProvider)} profileId=${sanitizeForLog(successProfileId)}`,
+                  `provider=${sanitizeForLog(successProvider)} profileId=${safeSuccessProfileId}`,
               );
             } else if (log.isEnabled("trace")) {
               log.trace(
@@ -1771,7 +1773,7 @@ async function runEmbeddedAgentInternal(
             log.warn(
               `post-run auth-profile success bookkeeping failed: ` +
                 `runId=${params.runId} sessionId=${params.sessionId} ` +
-                `provider=${sanitizeForLog(successProvider)} profileId=${sanitizeForLog(successProfileId)} ` +
+                `provider=${sanitizeForLog(successProvider)} profileId=${safeSuccessProfileId} ` +
                 `error=${formatErrorMessage(err)}`,
             );
           });


### PR DESCRIPTION
## Summary

- move post-run auth-profile success bookkeeping off the reply-blocking embedded-run path
- log slow or failed post-run auth-success bookkeeping so future lock contention is visible
- redact auth profile IDs in the new slow/failure diagnostics
- add regression coverage proving a completed embedded run returns while auth-success bookkeeping is still pending

Fixes #85822

## Real behavior proof

- Behavior or issue addressed: A completed embedded runner turn should return its reply without waiting for post-run auth-profile success bookkeeping. The follow-up fix also keeps auth-profile IDs redacted in the new slow/failure logs.
- Real environment tested: Local OpenClaw checkout on macOS, branch `fix/post-run-auth-success-nonblocking-85822`, head `25abd9b133e837d929f8fae8dc6977618325344a`.
- Exact steps or command run after this patch:
  - `/Users/andy/openclaw/openclaw-85521/node_modules/.bin/oxfmt --write --threads=1 src/agents/pi-embedded-runner/run.ts`
  - `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts src/agents/auth-profiles/profiles.test.ts src/process/command-queue.test.ts`
  - `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt-stage-timing.test.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts`
  - `node scripts/check-changed.mjs --base upstream/main`
  - `node scripts/pr85829-live-proof.mjs` from a temporary PR worktree with local-only proof instrumentation and a 3000ms auth-success bookkeeping delay
- Evidence after fix: Terminal output from the after-fix checkout:

```text
RUN  v4.1.7 /Users/andy/openclaw/openclaw-85822

Test Files  5 passed (5)
Tests  94 passed (94)

RUN  v4.1.7 /Users/andy/openclaw/openclaw-85822

Test Files  2 passed (2)
Tests  20 passed (20)

[check:changed] lanes=core, coreTests
[check:changed] src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts: core test
[check:changed] src/agents/pi-embedded-runner/run.ts: core production
[check:changed] runtime-sidecar-loaders: local runtime sidecar loaders look OK.
Import cycle check: 0 runtime value cycle(s).
```

- Live gateway-backed ordering proof: I also ran a local OpenClaw gateway on an ephemeral loopback port with `qa-channel` durable transport, an isolated `OPENCLAW_HOME`, and a mock OpenAI Responses endpoint. The only extra local instrumentation added proof markers and injected a 3000ms delay inside post-run auth-profile success bookkeeping after embedded run completion.

```text
2026-05-24T02:23:23.758Z [pr85829-proof] gateway ready: http://127.0.0.1:<gateway-port>/readyz
2026-05-24T02:23:23.758Z [pr85829-proof] command start: node scripts/run-node.mjs agent --agent qa --message Return exactly PR85829_LIVE_PROOF_OK. --model openai/gpt-5.5 --deliver --reply-channel qa-channel --reply-to channel:<proof-room> --timeout 60
2026-05-24T02:23:29.309Z [gateway stdout] 2026-05-23T19:23:29.309-07:00 [ws] ⇄ res ✓ agent 206ms runId=<redacted> conn=<redacted> id=<redacted>
2026-05-24T02:23:38.253Z [gateway stderr] 2026-05-23T19:23:38.253-07:00 [agent/embedded] [pr85829-proof] embedded run done: runId=<redacted> sessionId=<redacted> durationMs=8421 aborted=false
2026-05-24T02:23:38.255Z [gateway stderr] 2026-05-23T19:23:38.254-07:00 [agent/embedded] [pr85829-proof] delaying post-run auth-profile success bookkeeping: runId=<redacted> sessionId=<redacted> delayMs=3000 provider=openai profileId=<redacted>
2026-05-24T02:23:38.466Z [gateway stdout] 2026-05-23T19:23:38.465-07:00 [pr85829-proof] runEmbeddedPiAgent result available to delivery path: runId=<redacted> session=<redacted> durationMs=8425
2026-05-24T02:23:38.468Z [gateway stdout] 2026-05-23T19:23:38.467-07:00 [pr85829-proof] durable delivery start: runId=<redacted> channel=qa-channel payloads=1
2026-05-24T02:23:38.474Z [qa-bus stdout] [pr85829-proof] qa-channel outbound accepted: messageId=qa-msg-1 to=channel:<proof-room>
2026-05-24T02:23:38.477Z [gateway stdout] 2026-05-23T19:23:38.476-07:00 [pr85829-proof] durable delivery completed: runId=<redacted> status=sent elapsedMs=9
2026-05-24T02:23:38.530Z [pr85829-proof] command exit: code=0
2026-05-24T02:23:41.313Z [gateway stderr] 2026-05-23T19:23:41.312-07:00 [agent/embedded] post-run auth-profile success bookkeeping completed after 3055ms: runId=<redacted> sessionId=<redacted> provider=openai profileId=<redacted>
2026-05-24T02:23:43.271Z [pr85829-proof] delivered messages: 1
```

- Observed result after fix: The unit regression exercises the real `runEmbeddedPiAgent` path with auth-success bookkeeping intentionally left unresolved, and the run still resolves successfully instead of waiting for that bookkeeping promise. The live gateway-backed proof shows durable qa-channel delivery completed at `02:23:38.477Z`, while delayed post-run auth-success bookkeeping completed at `02:23:41.313Z`, about 2.8s later.
- What was not tested: This was gateway-backed `qa-channel` transport rather than a live Discord API send, so Discord-specific API behavior was not exercised. The gateway reply/durable-delivery ordering ClawSweeper requested is covered.

## Validation

- `/Users/andy/openclaw/openclaw-85521/node_modules/.bin/oxfmt --write --threads=1 src/agents/pi-embedded-runner/run.ts`
- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts src/agents/auth-profiles/profiles.test.ts src/process/command-queue.test.ts`
  - Test Files: 5 passed (5)
  - Tests: 94 passed (94)
- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt-stage-timing.test.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts`
  - Test Files: 2 passed (2)
  - Tests: 20 passed (20)
- `node scripts/check-changed.mjs --base upstream/main`
- `node scripts/pr85829-live-proof.mjs`
  - gateway-backed qa-channel delivery observed
  - delivered messages: 1
  - delayed auth-success bookkeeping completed after delivery

## Attribution

If this PR is squashed or reworked, please preserve author attribution or include:

Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>
