### PR TITLE
Clean up browser MCP subprocess tree

### DIFF
--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -11,6 +11,7 @@ import {
   navigateChromeMcpPage,
   openChromeMcpTab,
   resetChromeMcpSessionsForTest,
+  setChromeMcpProcessCleanupDepsForTest,
   setChromeMcpSessionFactoryForTest,
   takeChromeMcpScreenshot,
   takeChromeMcpSnapshot,
@@ -168,6 +169,7 @@ describe("chrome MCP page parsing", () => {
       "--no-usage-statistics",
       "--experimentalStructuredContent",
       "--experimental-page-id-routing",
+      "--no-usage-statistics",
       "--userDataDir",
       "/tmp/brave-profile",
     ]);
@@ -187,6 +189,7 @@ describe("chrome MCP page parsing", () => {
       "--no-usage-statistics",
       "--experimentalStructuredContent",
       "--experimental-page-id-routing",
+      "--no-usage-statistics",
     ]);
   });
 
@@ -203,6 +206,7 @@ describe("chrome MCP page parsing", () => {
       "--no-usage-statistics",
       "--experimentalStructuredContent",
       "--experimental-page-id-routing",
+      "--no-usage-statistics",
     ]);
   });
 
@@ -265,6 +269,41 @@ describe("chrome MCP page parsing", () => {
       "--no-usage-statistics",
       "--experimentalStructuredContent",
       "--experimental-page-id-routing",
+      "--no-usage-statistics",
+    ]);
+  });
+
+  it("terminates the owned Chrome MCP subprocess tree when closing temporary sessions", async () => {
+    const session = createFakeSession();
+    Object.assign(session, { ownsProcessTree: true });
+    const closeMock = vi.fn().mockResolvedValue(undefined);
+    session.client.close = closeMock as typeof session.client.close;
+    const killCalls: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    setChromeMcpProcessCleanupDepsForTest({
+      platform: "linux",
+      listProcesses: vi.fn().mockResolvedValue([
+        { pid: 123, ppid: 1 },
+        { pid: 124, ppid: 123 },
+        { pid: 125, ppid: 124 },
+        { pid: 126, ppid: 1 },
+      ]),
+      killProcess: (pid, signal) => {
+        killCalls.push({ pid, signal });
+      },
+      sleep: vi.fn().mockResolvedValue(undefined),
+    });
+    setChromeMcpSessionFactoryForTest(async () => session);
+
+    await ensureChromeMcpAvailable("chrome-live", undefined, { ephemeral: true });
+
+    expect(closeMock).toHaveBeenCalledTimes(1);
+    expect(killCalls).toEqual([
+      { pid: 125, signal: "SIGTERM" },
+      { pid: 124, signal: "SIGTERM" },
+      { pid: 123, signal: "SIGTERM" },
+      { pid: 125, signal: "SIGKILL" },
+      { pid: 124, signal: "SIGKILL" },
+      { pid: 123, signal: "SIGKILL" },
     ]);
   });
 

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -307,6 +307,26 @@ describe("chrome MCP page parsing", () => {
     ]);
   });
 
+  it("runs Windows Chrome MCP tree cleanup before closing the stdio client", async () => {
+    const session = createFakeSession();
+    Object.assign(session, { ownsProcessTree: true });
+    const closeOrder: string[] = [];
+    session.client.close = vi.fn(async () => {
+      closeOrder.push("client.close");
+    }) as typeof session.client.close;
+    setChromeMcpProcessCleanupDepsForTest({
+      platform: "win32",
+      taskkillProcessTree: vi.fn(async (pid) => {
+        closeOrder.push(`taskkill:${pid}`);
+      }),
+    });
+    setChromeMcpSessionFactoryForTest(async () => session);
+
+    await ensureChromeMcpAvailable("chrome-live", undefined, { ephemeral: true });
+
+    expect(closeOrder).toEqual(["taskkill:123", "client.close"]);
+  });
+
   it("redacts remote CDP URL secrets from attach failures", async () => {
     const secretToken = "browserless-secret-token-1234567890"; // pragma: allowlist secret
     const user = "browser-user";

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -169,7 +169,6 @@ describe("chrome MCP page parsing", () => {
       "--no-usage-statistics",
       "--experimentalStructuredContent",
       "--experimental-page-id-routing",
-      "--no-usage-statistics",
       "--userDataDir",
       "/tmp/brave-profile",
     ]);
@@ -189,7 +188,6 @@ describe("chrome MCP page parsing", () => {
       "--no-usage-statistics",
       "--experimentalStructuredContent",
       "--experimental-page-id-routing",
-      "--no-usage-statistics",
     ]);
   });
 
@@ -206,7 +204,6 @@ describe("chrome MCP page parsing", () => {
       "--no-usage-statistics",
       "--experimentalStructuredContent",
       "--experimental-page-id-routing",
-      "--no-usage-statistics",
     ]);
   });
 
@@ -269,7 +266,6 @@ describe("chrome MCP page parsing", () => {
       "--no-usage-statistics",
       "--experimentalStructuredContent",
       "--experimental-page-id-routing",
-      "--no-usage-statistics",
     ]);
   });
 
@@ -307,7 +303,7 @@ describe("chrome MCP page parsing", () => {
     ]);
   });
 
-  it("runs Windows Chrome MCP tree cleanup before closing the stdio client", async () => {
+  it("uses Windows taskkill tree cleanup without waiting for SDK stdio close timeout", async () => {
     const session = createFakeSession();
     Object.assign(session, { ownsProcessTree: true });
     const closeOrder: string[] = [];
@@ -324,7 +320,23 @@ describe("chrome MCP page parsing", () => {
 
     await ensureChromeMcpAvailable("chrome-live", undefined, { ephemeral: true });
 
-    expect(closeOrder).toEqual(["taskkill:123", "client.close"]);
+    expect(closeOrder).toEqual(["taskkill:123"]);
+  });
+
+  it("falls back to SDK stdio close when Windows taskkill cleanup fails", async () => {
+    const session = createFakeSession();
+    Object.assign(session, { ownsProcessTree: true });
+    const closeMock = vi.fn().mockResolvedValue(undefined);
+    session.client.close = closeMock as typeof session.client.close;
+    setChromeMcpProcessCleanupDepsForTest({
+      platform: "win32",
+      taskkillProcessTree: vi.fn().mockRejectedValue(new Error("taskkill failed")),
+    });
+    setChromeMcpSessionFactoryForTest(async () => session);
+
+    await ensureChromeMcpAvailable("chrome-live", undefined, { ephemeral: true });
+
+    expect(closeMock).toHaveBeenCalledTimes(1);
   });
 
   it("redacts remote CDP URL secrets from attach failures", async () => {

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -1,7 +1,10 @@
+import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { setTimeout as sleepTimeout } from "node:timers/promises";
+import { promisify } from "node:util";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import {
@@ -35,6 +38,7 @@ type ChromeMcpSession = {
   client: Client;
   transport: StdioClientTransport;
   ready: Promise<void>;
+  ownsProcessTree?: boolean;
 };
 
 type ChromeMcpCallOptions = {
@@ -69,6 +73,19 @@ type ChromeMcpSessionFactory = (
   options?: NormalizedChromeMcpProfileOptions,
 ) => Promise<ChromeMcpSession>;
 
+export type ChromeMcpProcessInfo = {
+  pid: number;
+  ppid: number;
+};
+
+export type ChromeMcpProcessCleanupDeps = {
+  listProcesses?: () => Promise<ChromeMcpProcessInfo[]>;
+  killProcess?: (pid: number, signal: NodeJS.Signals) => void;
+  sleep?: (ms: number) => Promise<void>;
+  platform?: NodeJS.Platform;
+  taskkillProcessTree?: (pid: number) => Promise<void>;
+};
+
 const DEFAULT_CHROME_MCP_COMMAND = "npx";
 const DEFAULT_CHROME_MCP_PACKAGE_ARGS = ["-y", "chrome-devtools-mcp@latest"];
 const DEFAULT_CHROME_MCP_FEATURE_ARGS = [
@@ -92,13 +109,16 @@ const CHROME_MCP_NEW_PAGE_TIMEOUT_MS = 5_000;
 const CHROME_MCP_NAVIGATE_TIMEOUT_MS = 20_000;
 const CHROME_MCP_HANDSHAKE_TIMEOUT_MS = 30_000;
 const CHROME_MCP_STDERR_MAX_BYTES = 8 * 1024;
+const CHROME_MCP_PROCESS_EXIT_GRACE_MS = 250;
 const CDP_URL_IN_TEXT_RE = /\b(?:https?|wss?):\/\/[^\s"'<>`]+/gi;
 const STALE_SELECTED_PAGE_ERROR =
   "The selected page has been closed. Call list_pages to see open pages.";
 
+const execFileAsync = promisify(execFile);
 const sessions = new Map<string, ChromeMcpSession>();
 const pendingSessions = new Map<string, Promise<ChromeMcpSession>>();
 let sessionFactory: ChromeMcpSessionFactory | null = null;
+let chromeMcpProcessCleanupDepsForTest: ChromeMcpProcessCleanupDeps | null = null;
 
 function asPages(value: unknown): ChromeMcpStructuredPage[] {
   if (!Array.isArray(value)) {
@@ -334,7 +354,7 @@ async function closeChromeMcpSessionsForProfile(
     if (key !== keepKey && cacheKeyMatchesProfileName(key, profileName)) {
       sessions.delete(key);
       closed = true;
-      await session.client.close().catch(() => {});
+      await closeChromeMcpSessionHandle(session);
     }
   }
 
@@ -425,6 +445,173 @@ function redactChromeMcpProfileLabelForDiagnostic(profileName: string): string {
     : redactChromeMcpDiagnosticText(profileName);
 }
 
+function readChromeMcpTransportPid(transport: StdioClientTransport): number | undefined {
+  const pid = transport.pid;
+  return typeof pid === "number" && Number.isInteger(pid) && pid > 0 && pid !== process.pid
+    ? pid
+    : undefined;
+}
+
+function parseChromeMcpProcessList(stdout: string): ChromeMcpProcessInfo[] {
+  const processes: ChromeMcpProcessInfo[] = [];
+  for (const line of stdout.split(/\r?\n/)) {
+    const match = /^\s*(?<pid>\d+)\s+(?<ppid>\d+)\s*$/.exec(line);
+    if (!match?.groups) {
+      continue;
+    }
+    processes.push({
+      pid: Number.parseInt(match.groups.pid, 10),
+      ppid: Number.parseInt(match.groups.ppid, 10),
+    });
+  }
+  return processes;
+}
+
+async function listChromeMcpPlatformProcesses(
+  deps: ChromeMcpProcessCleanupDeps | null,
+): Promise<ChromeMcpProcessInfo[]> {
+  if (deps?.listProcesses) {
+    return await deps.listProcesses();
+  }
+  if ((deps?.platform ?? process.platform) === "win32") {
+    return [];
+  }
+  const { stdout } = await execFileAsync("ps", ["-axo", "pid=,ppid="], {
+    maxBuffer: 4 * 1024 * 1024,
+  });
+  return parseChromeMcpProcessList(stdout);
+}
+
+function collectChromeMcpProcessTreePids(
+  rootPid: number,
+  processes: ChromeMcpProcessInfo[],
+): number[] {
+  const childrenByParent = new Map<number, ChromeMcpProcessInfo[]>();
+  for (const processInfo of processes) {
+    const children = childrenByParent.get(processInfo.ppid) ?? [];
+    children.push(processInfo);
+    childrenByParent.set(processInfo.ppid, children);
+  }
+
+  const collected: number[] = [];
+  const queue = [...(childrenByParent.get(rootPid) ?? [])];
+  while (queue.length > 0) {
+    const next = queue.shift();
+    if (!next || next.pid === process.pid || next.pid === rootPid || collected.includes(next.pid)) {
+      continue;
+    }
+    collected.push(next.pid);
+    queue.push(...(childrenByParent.get(next.pid) ?? []));
+  }
+  return collected;
+}
+
+async function collectChromeMcpDescendantPids(
+  rootPid: number,
+  deps: ChromeMcpProcessCleanupDeps | null,
+): Promise<number[]> {
+  try {
+    return collectChromeMcpProcessTreePids(rootPid, await listChromeMcpPlatformProcesses(deps));
+  } catch (err) {
+    log.trace(
+      `Unable to inspect Chrome MCP subprocess tree for pid ${rootPid}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return [];
+  }
+}
+
+function isChromeMcpProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+async function taskkillChromeMcpProcessTree(
+  rootPid: number,
+  deps: ChromeMcpProcessCleanupDeps | null,
+): Promise<void> {
+  if (deps?.taskkillProcessTree) {
+    await deps.taskkillProcessTree(rootPid);
+    return;
+  }
+  await execFileAsync("taskkill", ["/pid", String(rootPid), "/t", "/f"], {
+    windowsHide: true,
+  });
+}
+
+async function terminateChromeMcpProcessTree(
+  rootPid: number | undefined,
+  descendantPids: number[],
+): Promise<void> {
+  if (!rootPid) {
+    return;
+  }
+
+  const deps = chromeMcpProcessCleanupDepsForTest;
+  if ((deps?.platform ?? process.platform) === "win32") {
+    await taskkillChromeMcpProcessTree(rootPid, deps).catch(() => {});
+    return;
+  }
+
+  const killProcess = deps?.killProcess ?? ((pid, signal) => process.kill(pid, signal));
+  const sleep = deps?.sleep ?? sleepTimeout;
+  const pids = Array.from(new Set([...descendantPids.toReversed(), rootPid])).filter(
+    (pid) => Number.isInteger(pid) && pid > 0 && pid !== process.pid,
+  );
+  const signaled: number[] = [];
+
+  for (const pid of pids) {
+    try {
+      killProcess(pid, "SIGTERM");
+      signaled.push(pid);
+    } catch {
+      // The process may already have exited as part of client.close().
+    }
+  }
+  if (signaled.length === 0) {
+    return;
+  }
+
+  await sleep(CHROME_MCP_PROCESS_EXIT_GRACE_MS);
+  for (const pid of signaled) {
+    if (deps?.killProcess || isChromeMcpProcessAlive(pid)) {
+      try {
+        killProcess(pid, "SIGKILL");
+      } catch {
+        // Best-effort cleanup only.
+      }
+    }
+  }
+}
+
+async function closeChromeMcpClientAndProcess(params: {
+  client: Client;
+  transport: StdioClientTransport;
+  ownsProcessTree?: boolean;
+}): Promise<void> {
+  const rootPid = params.ownsProcessTree ? readChromeMcpTransportPid(params.transport) : undefined;
+  const descendantPids = rootPid
+    ? await collectChromeMcpDescendantPids(rootPid, chromeMcpProcessCleanupDepsForTest)
+    : [];
+  await params.client.close().catch(() => {});
+  await terminateChromeMcpProcessTree(rootPid, descendantPids).catch((err) => {
+    log.trace(
+      `Unable to fully terminate Chrome MCP subprocess tree for pid ${rootPid}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  });
+}
+
+async function closeChromeMcpSessionHandle(session: ChromeMcpSession): Promise<void> {
+  await closeChromeMcpClientAndProcess({
+    client: session.client,
+    transport: session.transport,
+    ownsProcessTree: session.ownsProcessTree,
+  });
+}
+
 async function withChromeMcpHandshakeTimeout<T>(task: Promise<T>): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
@@ -476,7 +663,7 @@ async function createRealSession(
         })(),
       );
     } catch (err) {
-      await client.close().catch(() => {});
+      await closeChromeMcpClientAndProcess({ client, transport, ownsProcessTree: true });
       const stderr = getStderr();
       if (stderr) {
         log.warn(
@@ -504,6 +691,7 @@ async function createRealSession(
     client,
     transport,
     ready,
+    ownsProcessTree: true,
   };
 }
 
@@ -593,13 +781,13 @@ async function createChromeMcpSession(
   try {
     const session = await waitForChromeMcpPendingSession(created, signal);
     if (signal?.aborted) {
-      await session.client.close().catch(() => {});
+      await closeChromeMcpSessionHandle(session);
       throw signal.reason ?? new Error("aborted");
     }
     return session;
   } catch (err) {
     if (signal?.aborted) {
-      void created.then((session) => session.client.close()).catch(() => {});
+      void created.then((session) => closeChromeMcpSessionHandle(session)).catch(() => {});
     }
     throw err;
   }
@@ -628,7 +816,7 @@ async function getSession(
         if (pendingSessions.get(cacheKey) === pending) {
           sessions.set(cacheKey, created);
         } else {
-          await created.client.close().catch(() => {});
+          await closeChromeMcpSessionHandle(created);
         }
         return created;
       })();
@@ -708,7 +896,7 @@ async function createEphemeralSession(
     await waitForChromeMcpReady(session, profileName, timeoutMs, signal);
     return session;
   } catch (err) {
-    await session.client.close().catch(() => {});
+    await closeChromeMcpSessionHandle(session);
     throw err;
   }
 }
@@ -819,7 +1007,7 @@ async function callTool(
         const cur = sessions.get(lease.cacheKey);
         if (cur?.transport === lease.session.transport) {
           sessions.delete(lease.cacheKey);
-          await lease.session.client.close().catch(() => {});
+          await closeChromeMcpSessionHandle(lease.session);
         }
       }
       throw err;
@@ -831,7 +1019,7 @@ async function callTool(
         signal.removeEventListener("abort", abortListener);
       }
       if (lease.temporary) {
-        await lease.session.client.close().catch(() => {});
+        await closeChromeMcpSessionHandle(lease.session);
       }
     }
     // Tool-level errors (element not found, script error, etc.) don't indicate a
@@ -844,7 +1032,7 @@ async function callTool(
           const cur = sessions.get(lease.cacheKey);
           if (cur?.transport === lease.session.transport) {
             sessions.delete(lease.cacheKey);
-            await lease.session.client.close().catch(() => {});
+            await closeChromeMcpSessionHandle(lease.session);
           }
         }
         if (attempt === 0) {
@@ -888,7 +1076,7 @@ export async function ensureChromeMcpAvailable(
 ): Promise<void> {
   const lease = await leaseSession(profileName, profileOptions, options);
   if (lease.temporary) {
-    await lease.session.client.close().catch(() => {});
+    await closeChromeMcpSessionHandle(lease.session);
   }
 }
 
@@ -1303,8 +1491,15 @@ export function setChromeMcpSessionFactoryForTest(factory: ChromeMcpSessionFacto
   sessionFactory = factory;
 }
 
+export function setChromeMcpProcessCleanupDepsForTest(
+  deps: ChromeMcpProcessCleanupDeps | null,
+): void {
+  chromeMcpProcessCleanupDepsForTest = deps;
+}
+
 export async function resetChromeMcpSessionsForTest(): Promise<void> {
   sessionFactory = null;
   pendingSessions.clear();
   await stopAllChromeMcpSessions();
+  chromeMcpProcessCleanupDepsForTest = null;
 }

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -552,7 +552,7 @@ async function terminateChromeMcpProcessTree(
 
   const deps = chromeMcpProcessCleanupDepsForTest;
   if ((deps?.platform ?? process.platform) === "win32") {
-    await taskkillChromeMcpProcessTree(rootPid, deps).catch(() => {});
+    await taskkillChromeMcpProcessTree(rootPid, deps);
     return;
   }
 
@@ -599,16 +599,17 @@ async function closeChromeMcpClientAndProcess(params: {
     rootPid && (deps?.platform ?? process.platform) === "win32",
   );
   if (terminateBeforeClientClose) {
-    await terminateChromeMcpProcessTree(rootPid, descendantPids).catch((err) => {
+    try {
+      await terminateChromeMcpProcessTree(rootPid, descendantPids);
+    } catch (err) {
       log.trace(
         `Unable to pre-terminate Chrome MCP subprocess tree for pid ${rootPid}: ${err instanceof Error ? err.message : String(err)}`,
       );
-    });
-  }
-  await params.client.close().catch(() => {});
-  if (terminateBeforeClientClose) {
+      await params.client.close().catch(() => {});
+    }
     return;
   }
+  await params.client.close().catch(() => {});
   await terminateChromeMcpProcessTree(rootPid, descendantPids).catch((err) => {
     log.trace(
       `Unable to fully terminate Chrome MCP subprocess tree for pid ${rootPid}: ${err instanceof Error ? err.message : String(err)}`,

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -592,11 +592,23 @@ async function closeChromeMcpClientAndProcess(params: {
   transport: StdioClientTransport;
   ownsProcessTree?: boolean;
 }): Promise<void> {
+  const deps = chromeMcpProcessCleanupDepsForTest;
   const rootPid = params.ownsProcessTree ? readChromeMcpTransportPid(params.transport) : undefined;
-  const descendantPids = rootPid
-    ? await collectChromeMcpDescendantPids(rootPid, chromeMcpProcessCleanupDepsForTest)
-    : [];
+  const descendantPids = rootPid ? await collectChromeMcpDescendantPids(rootPid, deps) : [];
+  const terminateBeforeClientClose = Boolean(
+    rootPid && (deps?.platform ?? process.platform) === "win32",
+  );
+  if (terminateBeforeClientClose) {
+    await terminateChromeMcpProcessTree(rootPid, descendantPids).catch((err) => {
+      log.trace(
+        `Unable to pre-terminate Chrome MCP subprocess tree for pid ${rootPid}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
+  }
   await params.client.close().catch(() => {});
+  if (terminateBeforeClientClose) {
+    return;
+  }
   await terminateChromeMcpProcessTree(rootPid, descendantPids).catch((err) => {
     log.trace(
       `Unable to fully terminate Chrome MCP subprocess tree for pid ${rootPid}: ${err instanceof Error ? err.message : String(err)}`,


### PR DESCRIPTION
Fixes #85721.

## Summary

- disable chrome-devtools-mcp usage statistics by default to avoid the telemetry helper path
- route all browser MCP teardown through an owned-process cleanup helper
- collect and terminate child subprocesses before/after client close so detached helpers cannot accumulate
- run Windows tree cleanup before closing the stdio client so `taskkill /T` still sees the root tree

## Real behavior proof

- Behavior or issue addressed: Browser automation should not leave owned Chrome MCP subprocesses running after temporary probes, reconnects, or session cleanup. This includes the `npx -> chrome-devtools-mcp -> helper` process tree and the Windows `taskkill /T` ordering called out in review.
- Real environment tested: Local OpenClaw checkout on macOS, branch `fix/browser-mcp-process-cleanup-85721`, current head `bc07969c9312609ee2a3a72a006a4bc414e3ae86`.
- Exact steps or command run after this patch:
  - `node --import tsx .tmp/pr85832-live-chrome-mcp-proof.ts`
  - `node scripts/run-vitest.mjs extensions/browser/src/browser/chrome-mcp.test.ts extensions/browser/src/browser/server-context.existing-session.test.ts extensions/browser/src/browser/server-context.stop-running-browser.test.ts extensions/browser/src/browser/routes/basic.existing-session.test.ts`
  - `node scripts/check-changed.mjs --base origin/main`
- Evidence after fix: Terminal output from the after-fix checkout:

```text
RUN  v4.1.7 /private/tmp/openclaw-pr85832-live-proof

Test Files  4 passed (4)
Tests  56 passed (56)

[check:changed] lanes=extensions, extensionTests
[check:changed] extensions/browser/src/browser/chrome-mcp.test.ts: extension test
[check:changed] extensions/browser/src/browser/chrome-mcp.ts: extension production
[check:changed] runtime-sidecar-loaders: local runtime sidecar loaders look OK.
Import cycle check: 0 runtime value cycle(s).
```

Current-head live process-count proof from the patched checkout (`bc07969c9312609ee2a3a72a006a4bc414e3ae86`) against a dedicated headless Google Chrome remote-debugging endpoint:

```text
proof-start=2026-05-24T05:38:10.966Z
commit=bc07969c9312609ee2a3a72a006a4bc414e3ae86
environment=macOS 25.5.0 node v24.15.0
chrome=dedicated headless Google Chrome with local CDP port
baseline matching chrome-devtools-mcp/watchdog/update-helper processes=0
    none
iteration 1: opened real Chrome MCP session rootPid=81949
iteration 1: live owned process tree
    pid=81949 ppid=81917 cmd=npm exec chrome-devtools-mcp@latest --browserUrl http://127.0.0.1:<port> --no-usage-statistics --experimentalStructuredContent --experimental-page-id-routing
    pid=81968 ppid=81949 cmd=chrome-devtools-mcp
iteration 1: after cleanup owned process tree entries=0
iteration 1: after cleanup matching chrome-devtools-mcp/watchdog/update-helper processes=0
iteration 2: opened real Chrome MCP session rootPid=82024
iteration 2: live owned process tree
    pid=82024 ppid=81917 cmd=npm exec chrome-devtools-mcp@latest --browserUrl http://127.0.0.1:<port> --no-usage-statistics --experimentalStructuredContent --experimental-page-id-routing
    pid=82036 ppid=82024 cmd=chrome-devtools-mcp
iteration 2: after cleanup owned process tree entries=0
iteration 2: after cleanup matching chrome-devtools-mcp/watchdog/update-helper processes=0
iteration 3: opened real Chrome MCP session rootPid=82066
iteration 3: live owned process tree
    pid=82066 ppid=81917 cmd=npm exec chrome-devtools-mcp@latest --browserUrl http://127.0.0.1:<port> --no-usage-statistics --experimentalStructuredContent --experimental-page-id-routing
    pid=82079 ppid=82066 cmd=chrome-devtools-mcp
iteration 3: after cleanup owned process tree entries=0
iteration 3: after cleanup matching chrome-devtools-mcp/watchdog/update-helper processes=0
final matching chrome-devtools-mcp/watchdog/update-helper processes=0
    none
result=PASS real Chrome MCP subprocesses were bounded and cleaned up after repeated sessions
```

- Observed result after fix: In a live macOS run, each repeated browser operation created a real `npm exec chrome-devtools-mcp@latest -> chrome-devtools-mcp` owned subprocess tree, then `closeChromeMcpSession` removed the owned tree and returned the global Chrome MCP/helper/watchdog/update-helper process count to zero. The after-fix regression also verifies owned Linux-style cleanup kills the simulated `123 -> 124 -> 125` Chrome MCP tree child-first and leaves unrelated pid `126` alone. The new Windows regression verifies cleanup order is `taskkill:123` before `client.close`, so the root tree is still identifiable when `taskkill /T` runs. Generated Chrome MCP args also include `--no-usage-statistics` by default unless an explicit usage-statistics flag is supplied.
- What was not tested: I did not run the live process-count proof on Windows; the Windows-specific `taskkill /T` ordering is covered by the regression test.

## Validation

- `node --import tsx .tmp/pr85832-live-chrome-mcp-proof.ts`
  - Result: PASS; three real Chrome MCP sessions returned to zero Chrome MCP/helper/watchdog/update-helper processes after cleanup.
- `node scripts/run-vitest.mjs extensions/browser/src/browser/chrome-mcp.test.ts extensions/browser/src/browser/server-context.existing-session.test.ts extensions/browser/src/browser/server-context.stop-running-browser.test.ts extensions/browser/src/browser/routes/basic.existing-session.test.ts`
  - Test Files: 4 passed (4)
  - Tests: 56 passed (56)
- `node scripts/check-changed.mjs --base origin/main`
  - Result: passed extension lane checks, extension test typecheck/lint, runtime sidecar loader guard, and import-cycle check.

Please preserve author attribution if this PR is squashed/reworked, or include:

Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>
