### PR TITLE
fix(sandbox): add apt-get retries and --fix-missing to Dockerfiles

### DIFF
--- a/scripts/docker/sandbox/Dockerfile
+++ b/scripts/docker/sandbox/Dockerfile
@@ -4,8 +4,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN --mount=type=cache,id=openclaw-sandbox-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,id=openclaw-sandbox-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
-  apt-get update \
-  && apt-get install -y --no-install-recommends \
+  apt-get -o Acquire::Retries=5 update \
+  && apt-get -o Acquire::Retries=5 install -y --no-install-recommends --fix-missing \
     bash \
     ca-certificates \
     curl \

--- a/scripts/docker/sandbox/Dockerfile.common
+++ b/scripts/docker/sandbox/Dockerfile.common
@@ -23,8 +23,8 @@ ENV PATH=${BUN_INSTALL_DIR}/bin:${BREW_INSTALL_DIR}/bin:${BREW_INSTALL_DIR}/sbin
 
 RUN --mount=type=cache,id=openclaw-sandbox-common-apt-cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,id=openclaw-sandbox-common-apt-lists,target=/var/lib/apt,sharing=locked \
-  apt-get update \
-  && apt-get install -y --no-install-recommends ${PACKAGES}
+  apt-get -o Acquire::Retries=5 update \
+  && apt-get -o Acquire::Retries=5 install -y --no-install-recommends --fix-missing ${PACKAGES}
 
 RUN if [ "${INSTALL_PNPM}" = "1" ]; then npm install -g pnpm; fi
 


### PR DESCRIPTION
## Summary

Adds `-o Acquire::Retries=5` to both `apt-get update` and `apt-get install` commands, and `--fix-missing` to `apt-get install`, in both `scripts/docker/sandbox/Dockerfile` and `scripts/docker/sandbox/Dockerfile.common`.

This makes sandbox image builds more resilient to transient network failures, which is especially common in CI and low-bandwidth environments.

The Docker BuildKit cache mounts (`--mount=type=cache`) are preserved, so retries only fire when the initial attempt fails — no overhead on happy path.

## Changes

- `scripts/docker/sandbox/Dockerfile`: apt-get update/install now use `-o Acquire::Retries=5`; install adds `--fix-missing`
- `scripts/docker/sandbox/Dockerfile.common`: same changes for the common sandbox image

## Real behavior proof

- Built `openclaw-sandbox:bookworm-slim` locally with the modified `Dockerfile` — image built successfully
- Built `openclaw-sandbox-common:bookworm-slim` with the modified `Dockerfile.common` — image built successfully
- Both images include all expected packages (`curl`, `wget`, `jq`, `python3`, etc.)
- No changes to the final image content; only the build-time retry behavior differs

## Why both Dockerfiles?

`Dockerfile` is the base image (`openclaw-sandbox:bookworm-slim`) and `Dockerfile.common` builds on top of it. Both run `apt-get` during build, so both benefit from the same resilience improvement.

Closes #52665