### PR TITLE
fix(agents): omit empty tools array for proxy-like openai-completions endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Docs: https://docs.openclaw.ai
 
 - Ollama: bypass the managed proxy for configured local embedding origins while keeping SSRF guardrails on unconfigured targets. Thanks @Kaspre.
 - OpenAI/images: route Codex API-key image generation through the native OpenAI Images API instead of the Codex OAuth streaming backend, avoiding 401s from valid API keys.
+- Agents/OpenAI completions: omit empty tool payload fields for proxy-like OpenAI-compatible endpoints so strict vLLM-style servers accept tool-free turns. (#85835) Thanks @rendrag-git.
 - Checks/Windows: route full `pnpm check` stage commands through the managed child runner so Windows avoids Node shell-argv deprecation warnings there too.
 - Checks/Windows: run managed child commands through explicit `cmd.exe` wrapping instead of Node shell mode with argv, avoiding Node 24 subprocess deprecation warnings during changed checks.
 - Models: prune retired Groq, GitHub Copilot, OpenAI, xAI, and old Claude catalog entries, with doctor migration to upgrade existing configs to current provider refs.

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -5627,6 +5627,142 @@ describe("openai transport stream", () => {
     expect(params).toHaveProperty("tool_choice", "required");
   });
 
+  it("omits empty tools and tool_choice for proxy-like openai-completions endpoints when context.tools is []", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "test-model",
+        name: "Test Model",
+        api: "openai-completions",
+        provider: "vllm",
+        baseUrl: "http://localhost:8000/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 4096,
+        maxTokens: 2048,
+      } satisfies Model<"openai-completions">,
+      {
+        systemPrompt: "You are a helpful assistant",
+        messages: [],
+        tools: [],
+      } as never,
+      undefined,
+    );
+
+    expect(params).not.toHaveProperty("tools");
+    expect(params).not.toHaveProperty("tool_choice");
+  });
+
+  it("omits tools for proxy-like openai-completions endpoints when only prior tool history is present", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "test-model",
+        name: "Test Model",
+        api: "openai-completions",
+        provider: "vllm",
+        baseUrl: "http://localhost:8000/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 4096,
+        maxTokens: 2048,
+      } satisfies Model<"openai-completions">,
+      {
+        systemPrompt: "You are a helpful assistant",
+        messages: [
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "toolCall",
+                id: "call_abc",
+                name: "get_weather",
+                arguments: "{}",
+              },
+            ],
+          },
+          {
+            role: "toolResult",
+            content: [{ type: "text", text: "sunny" }],
+            toolCallId: "call_abc",
+          },
+        ],
+      } as never,
+      undefined,
+    );
+
+    expect(params).not.toHaveProperty("tools");
+    expect(params).not.toHaveProperty("tool_choice");
+  });
+
+  it("preserves empty tools array for native openai-completions endpoints (existing behavior)", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-completions",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 4096,
+        maxTokens: 2048,
+      } satisfies Model<"openai-completions">,
+      {
+        systemPrompt: "You are a helpful assistant",
+        messages: [],
+        tools: [],
+      } as never,
+      undefined,
+    );
+
+    expect(params).toHaveProperty("tools");
+    expect((params as { tools: unknown[] }).tools).toEqual([]);
+  });
+
+  it("preserves tools: [] fallback for native openai-completions endpoints when only prior tool history is present (existing behavior)", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-completions",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 4096,
+        maxTokens: 2048,
+      } satisfies Model<"openai-completions">,
+      {
+        systemPrompt: "You are a helpful assistant",
+        messages: [
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "toolCall",
+                id: "call_abc",
+                name: "get_weather",
+                arguments: "{}",
+              },
+            ],
+          },
+          {
+            role: "toolResult",
+            content: [{ type: "text", text: "sunny" }],
+            toolCallId: "call_abc",
+          },
+        ],
+      } as never,
+      undefined,
+    );
+
+    expect(params).toHaveProperty("tools");
+    expect((params as { tools: unknown[] }).tools).toEqual([]);
+  });
+
   it("resets stopReason to stop when finish_reason is tool_calls but tool_calls array is empty", async () => {
     const model = {
       id: "nemotron-3-super",

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -3403,6 +3403,14 @@ export function buildOpenAICompletionsParams(
     } else if (hasToolHistory(context.messages)) {
       params.tools = [];
     }
+    if (
+      compatDetection.capabilities.usesExplicitProxyLikeEndpoint &&
+      Array.isArray(params.tools) &&
+      params.tools.length === 0
+    ) {
+      delete params.tools;
+      delete params.tool_choice;
+    }
   }
   const completionsReasoningEffort = resolveOpenAICompletionsReasoningEffort(options);
   const resolvedCompletionsReasoningEffort = completionsReasoningEffort


### PR DESCRIPTION
## Summary

Supersedes #70790 with a smaller patch at the canonical seam. Both PRs fix the same downstream symptom (strict OpenAI-compatible servers — vLLM, LocalAI, llama.cpp, LM Studio, DashScope, GLM, Kimi — rejecting `tools: []` with HTTP 400), but #70790 wraps the stream function inside the embedded runner only. This PR fixes the canonical payload builder so every consumer benefits: gateway path (`openclaw infer model run`), embedded runner (`openclaw agent` / Discord / iMessage), and the public SDK consumers `extensions/zai`, `extensions/xiaomi`, `extensions/deepseek` that import `buildOpenAICompletionsParams` from `openclaw/plugin-sdk/provider-transport-runtime`.

- **Problem**: `buildOpenAICompletionsParams` in `src/agents/openai-transport-stream.ts` emits `tools: []` in two cases: (1) when `context.tools` is a non-undefined empty array and `convertTools([])` returns `[]`; (2) when `hasToolHistory(context.messages)` matches and the function assigns `params.tools = []`. Current OpenAI and every strict OpenAI-compatible server reject this with HTTP 400 `` `tools` must not be an empty array. Either provide at least one tool or omit the field entirely. ``.
- **Why it matters**: Local vLLM (and DashScope/GLM/Kimi) users cannot run any prompt against an agent whose runtime tool surface is empty for the current turn, even tool-free ones. PR #70790 only covers the embedded-runner path; the gateway path stays broken under it.
- **What changed**: After the existing `supportsModelTools` block, post-strip an empty `params.tools` (and orphan `params.tool_choice`) when `compatDetection.capabilities.usesExplicitProxyLikeEndpoint` is true. 7 lines added, no existing branches touched.
- **What did NOT change (scope boundary)**: Native OpenAI, Azure OpenAI, OpenRouter, and any non-proxy-like provider — byte-identical defaults. The `hasToolHistory → tools: []` branch is preserved for non-proxy paths so any historical Aliyun/Bailian-style consumer keeps existing behavior. `supportsModelTools` gate from #74738 is unchanged. Tool conversion, reasoning effort, thinking format, response_format, prompt_cache_key handling — all unchanged. `max_completion_tokens` clamp is orthogonal and tracked in #85008.

## Why a new payload-builder fix instead of extending #70790

- `buildOpenAICompletionsParams` is the single function that produces the wire payload. Fixing it covers every caller.
- #70790's interceptor at `pi-embedded-runner/stream-resolution.ts` only covers traffic through the embedded runner. `openclaw infer model run --gateway` goes through the streaming transport directly (`openai-transport-stream.ts:1716`), not the embedded runner wrapper — so #70790 alone does not fix that command against vLLM.
- `buildOpenAICompletionsParams` is re-exported from `openclaw/plugin-sdk/provider-transport-runtime` and consumed by external plugins. The interceptor approach does not flow into those plugins.
- Pattern precedent: PR #74738 (merged) already gates this same block with a compat-derived check. This PR layers an additional capability-gated post-strip in the same file.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Integrations

## Linked Issue/PR

- Supersedes #70790 (different seam; this PR fixes the canonical builder)
- Related #85008 (`max_completion_tokens` clamp — orthogonal, left to that PR)
- Related #74738 (preserved `supportsModelTools` gate; this PR layers on top)
- Related #71472 (extends the same `usesExplicitProxyLikeEndpoint` plumbing)
- Related #59669 (closed; documents upstream `@mariozechner/pi-ai` 0.64.0 removal of the same injection, attributed to Bailian/Aliyun)
- Related #61147 (closed; prior delete-the-branch attempt — this PR preserves the branch for non-proxy paths instead)
- Related #53174 (`/btw` ModelStudio empty-tools — same downstream symptom)
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed**: vLLM rejects OpenClaw OpenAI-compatible chat completions when the outbound payload contains `tools: []`.
- **Real environment tested**: Local incus container `oc-stack` running OpenClaw 2026.5.18 with this patch applied to the live `/usr/lib/node_modules/openclaw/dist/openai-transport-stream-C7fXTJ-U.js` bundle on the pmg gateway (port 18789). vLLM router at `http://10.68.198.1:31080/v1` serving `qwen3-5-122b-a10b-nvfp4` with `max_model_len=131072`. Model registered as `vllm/qwen3-5-122b-a10b-nvfp4` with provider catalog `maxTokens=8192`, `contextWindow=131072`. Route taken: Discord channel `1473797645154910382` → pm agent → embedded runner → openai-completions transport.
- **Exact steps or command run after this patch**: Sent a `"Testing"` message in the Discord channel bound to the pm agent. The patch fires when `compatDetection.capabilities.usesExplicitProxyLikeEndpoint === true` (vLLM custom baseUrl) and `params.tools` resolves to `[]`.
- **Evidence after fix**: Gateway log excerpts, redacted:

  ```text
  21:06:17.224  tool-search: cataloged 37 tools behind compact prompt surface
  21:06:20.286  embedded run prompt start: provider=vllm api=openai-completions
                endpoint=custom route=proxy-like policy=none
  21:06:20.310  pre-prompt: provider=vllm/qwen3-5-122b-a10b-nvfp4
                systemPromptChars=57970 promptChars=7
  21:06:20.349  [model-fetch] start provider=vllm api=openai-completions
                model=qwen3-5-122b-a10b-nvfp4 method=POST
                url=http://10.68.198.1:31080/v1/chat/completions
  21:06:20.471  [model-fetch] response provider=vllm
                model=qwen3-5-122b-a10b-nvfp4 status=200 elapsedMs=122
                contentType=text/event-stream; charset=utf-8
  21:06:22.744  embedded run agent end: runId=651d922c-… isError=false
  21:06:24.591  textPreview="Hey! Testing received 👋 How can I help you today?"
  ```

- **Observed result after fix**: vLLM returned HTTP 200 with `Content-Type: text/event-stream` and the model produced a normal assistant reply. Before the patch the same path returned HTTP 400 with `` `tools` must not be an empty array. Either provide at least one tool or omit the field entirely. ``.
- **What was not tested**: Live Bailian/Aliyun DashScope (no account); behavior preserved on the non-proxy path by leaving native defaults unchanged. Native OpenAI / Azure / OpenRouter behavior was not retraced live; covered by existing test suite which we extended (4 new unit cases — see Regression Test Plan).
- **Before evidence**: On the same setup pre-patch, the gateway log showed `lane task error … 400 ... tools must not be an empty array` against the same vLLM endpoint. The earlier diagnostic write-up captures the full pre-patch reproduction including the curl-level minimal repro at `tools: []`.

## Root Cause (if applicable)

- **Root cause**: OpenClaw mirrors a `tools: []` injection that originated in `@mariozechner/pi-ai`'s `openai-completions.js` as a Bailian/Aliyun (DashScope) compatibility hedge. Upstream pi-ai 0.64.0 commented out the injection (per `@GitZhangChi` investigation in #59669). OpenClaw's mirror remained and is invalid against current OpenAI and every strict OpenAI-compatible server. PR #74738 narrowed the branch with `supportsModelTools(model)`, but vLLM-style models pass that gate, so the branch still fires for them.
- **Missing detection / guardrail**: No test exercised the `context.tools = [] + proxy-like endpoint` or `transcript with tool history + no current tools + proxy-like endpoint` shape.
- **Contributing context**: Function introduced in PR #60264 (transport adapter seam refactor) inheriting the upstream pi-ai pattern.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- **Target test or file**: `src/agents/openai-transport-stream.test.ts`
- **Scenarios locked in by the new tests in this PR**:
  1. Proxy-like endpoint + `context.tools = []` → payload omits `tools` and `tool_choice`.
  2. Proxy-like endpoint + transcript with prior `toolCall`/`toolResult` + `context.tools = undefined` → payload omits `tools`.
  3. Native endpoint + `context.tools = []` → payload still emits `tools: []` (existing behavior preserved).
  4. Native endpoint + transcript with prior `toolCall`/`toolResult` → payload still emits `tools: []` (existing behavior preserved).
- **Why this is the smallest reliable guardrail**: The behavior diverges only on payload field presence; a unit test on `buildOpenAICompletionsParams` output captures it without a live provider.

## User-visible / Behavior Changes

For OpenAI-compatible endpoints routed through a non-OpenAI base URL (vLLM, LocalAI, llama.cpp, LM Studio, DashScope, GLM, Kimi, and similar): empty `tools` arrays are no longer sent on the wire. Native OpenAI, Azure OpenAI, and OpenRouter behavior is byte-identical.

## Diagram (if applicable)

```text
Before:
context.tools = []           --> params.tools = []  --> strict server HTTP 400
context.tools = undefined +
  toolHistory in messages    --> params.tools = []  --> strict server HTTP 400

After (proxy-like endpoint only):
params.tools = []            --> deleted from payload  --> HTTP 200
params.tool_choice (orphan)  --> deleted from payload

Native OpenAI / Azure / OpenRouter: unchanged.
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (only payload field presence on existing calls)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- **OS**: Ubuntu 22.04 inside incus container `oc-stack`
- **Runtime/container**: Node 22+ / 24, OpenClaw 2026.5.18 + this patch
- **Model/provider**: vLLM (current) serving `qwen3-5-122b-a10b-nvfp4`, `max_model_len=131072`; OpenClaw model id `vllm/qwen3-5-122b-a10b-nvfp4`
- **Integration/channel**: Discord channel bound to the pm agent via existing routing
- **Relevant config (redacted)**: vLLM router `http://10.68.198.1:31080/v1` (Bearer token redacted); openclaw.json provider entry registers vLLM with the proxy-like base URL.

### Steps

1. Start vLLM serving `qwen3-5-122b-a10b-nvfp4`.
2. Register the vLLM provider in OpenClaw with the proxy-like base URL.
3. Bind a Discord channel to a pm-style agent configured with `model.primary = vllm/qwen3-5-122b-a10b-nvfp4`.
4. Send a message in the channel.

### Expected

- Gateway log shows `route=proxy-like`, `[model-fetch] response status=200`, and the agent produces a reply. No outbound payload contains `tools: []`.

### Actual

- Matches expected. Trace lines above.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

## Human Verification (required)

- **Verified scenarios**: End-to-end Discord → pm agent → embedded runner → openai-completions transport against live vLLM, no `tools: []` rejection, model reply generated.
- **Edge cases checked**: Transcript with prior `toolCall`/`toolResult` but no current tools; `compat.supportsTools: false` model still respects #74738's earlier guard; `usesExplicitProxyLikeEndpoint: false` (native OpenAI) path byte-identical via unit tests.
- **What I did not verify**: Live Bailian/Aliyun DashScope (no account); Azure OpenAI live (defaults unchanged, covered by existing tests).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- **Backward compatible?** `Yes` (only proxy-like detection path changes; all native providers byte-identical)
- **Config/env changes?** `No`
- **Migration needed?** `No`

## Risks and Mitigations

- **Risk**: A strict OpenAI-compatible provider not enumerated here relies on `tools: []` to enter a tool-replay parse mode.
  - **Mitigation**: Change is gated on `usesExplicitProxyLikeEndpoint` (the same gate PR #71472 uses). The historical Aliyun/Bailian consumer documented in `@mariozechner/pi-ai` was removed in pi-ai 0.64.0. If a regression surfaces, the compat flag plumbing can be extended to whitelist that provider in a one-line change.
- **Risk**: #70790 lands instead and the gateway path stays broken.
  - **Mitigation**: This PR explicitly notes the seam difference; maintainer can choose either.

---

> AI-assisted PR. Investigation, full PR archaeology (#60264 → #44229 → #47947 → #59669 → #61147 → #70790 → #71472 → #74738 → #85008), patch authoring, and PR body were produced with Claude (Opus 4.7). Real behavior proof is from my own local vLLM setup; I personally ran the live Discord call and inspected the outbound payload against gateway access logs. `codex review --base origin/main` returned no actionable correctness issues.

