### PR TITLE
fix(googlechat): auto-resolve room thread for group channel replies

### DIFF
--- a/extensions/googlechat/src/channel.adapters.ts
+++ b/extensions/googlechat/src/channel.adapters.ts
@@ -218,8 +218,15 @@ export const googlechatOutboundAdapter = {
         accountId,
       });
       const space = await resolveGoogleChatOutboundSpace({ account, target: to });
+      // patch#gchat-thread: auto-resolve thread from stored room context when no explicit threadId/replyToId
+      const _autoThread = (() => {
+        if (threadId || replyToId) return undefined;
+        const map = (process as NodeJS.Process & { __gchatRoomThreads?: Map<string, { threadId: string; ts: number }> }).__gchatRoomThreads;
+        const ctx = map?.get(to);
+        return ctx && Date.now() - ctx.ts < 3_600_000 ? ctx.threadId : undefined;
+      })();
       const thread =
-        typeof threadId === "number" ? String(threadId) : (threadId ?? replyToId ?? undefined);
+        typeof threadId === "number" ? String(threadId) : (threadId ?? replyToId ?? _autoThread ?? undefined);
       const { sendGoogleChatMessage } = await loadGoogleChatChannelRuntime();
       const result = await sendGoogleChatMessage({
         account,

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -305,6 +305,16 @@ async function processMessageWithPipeline(params: {
       accountId: route.accountId,
       routeSessionKey: route.sessionKey,
     },
+    // patch#gchat-thread: store current room thread so sendText can use it
+    ...(isGroup && message.thread?.name
+      ? (() => {
+          if (!process.__gchatRoomThreads) {
+            (process as NodeJS.Process & { __gchatRoomThreads?: Map<string, { threadId: string; ts: number }> }).__gchatRoomThreads = new Map();
+          }
+          (process as NodeJS.Process & { __gchatRoomThreads?: Map<string, { threadId: string; ts: number }> }).__gchatRoomThreads!.set(spaceId, { threadId: message.thread!.name!, ts: Date.now() });
+          return {};
+        })()
+      : {}),
     reply: {
       to: `googlechat:${spaceId}`,
       originatingTo: `googlechat:${spaceId}`,


### PR DESCRIPTION
## Summary

For `room_event` (Google Chat groups), OpenClaw uses `strictMessageToolOnly` delivery mode, which suppresses the automatic source delivery that normally passes `replyToId` to the channel. When the agent replies via the `message` tool, it does not receive the thread ID of the originating message, so **responses go to the space root instead of the correct thread**.

## Root cause

The `sendText` adapter in `channel.adapters.ts` uses `threadId ?? replyToId ?? undefined`. For room events, neither is populated by the dispatch layer (durable reply is suppressed), so `thread` is always `undefined`.

## Fix

**`extensions/googlechat/src/monitor.ts`**: When a room event with a thread arrives, store `{ spaceId → { threadId, ts } }` in `process.__gchatRoomThreads` (a process-level Map, shared across the plugin via the Node.js `process` global). The entry expires after 1 hour.

**`extensions/googlechat/src/channel.adapters.ts`** (`sendText`): When neither `threadId` nor `replyToId` is explicitly provided, look up `to` in `process.__gchatRoomThreads` and use the stored thread ID. This ensures agent replies via the `message` tool go back to the originating thread without requiring the agent to explicitly pass the thread ID.

**Config note**: Also requires `channels.googlechat.replyToMode: "all"` in `openclaw.json` (the default `"off"` strips `replyToId` from all payloads, blocking thread delivery even when it is set).

## Test plan

- [ ] Single direct Lucia response in a group thread lands in the correct thread
- [ ] Sub-agent response announced back to group (Lucia → Josefina → announce → Lucia → group) lands in the originating thread
- [ ] DM behaviour unchanged (no thread context stored for non-group events)
- [ ] Thread context expires after 1 hour (no stale routing across sessions)

Tested on production: Google Chat Sales group, responses now land in the correct thread for both direct replies and sub-agent announce deliveries.

Reported-by: jailbirt <jailbirt@theeye.io>

🤖 Generated with [Claude Code](https://claude.com/claude-code)