### PR TITLE
fix(doctor): repair stale DeepSeek V4 context windows

### DIFF
--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -1316,6 +1316,70 @@ describe("legacy model compat migrate", () => {
     ]);
   });
 
+  it("restores stale DeepSeek V4 200K context windows", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          deepseek: {
+            models: [
+              {
+                id: "deepseek-v4-flash",
+                name: "DeepSeek V4 Flash",
+                contextWindow: 200_000,
+                maxTokens: 384_000,
+              },
+              {
+                id: "deepseek-v4-pro",
+                name: "DeepSeek V4 Pro",
+                contextWindow: 200_000,
+                maxTokens: 384_000,
+              },
+              {
+                id: "deepseek-chat",
+                name: "DeepSeek Chat",
+                contextWindow: 200_000,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(res.config?.models?.providers?.deepseek?.models?.[0]?.contextWindow).toBe(1_000_000);
+    expect(res.config?.models?.providers?.deepseek?.models?.[1]?.contextWindow).toBe(1_000_000);
+    expect(res.config?.models?.providers?.deepseek?.models?.[2]?.contextWindow).toBe(200_000);
+    expect(res.changes).toStrictEqual([
+      'Restored models.providers.deepseek.models.0.contextWindow for "deepseek-v4-flash" from 200000 to 1000000.',
+      'Restored models.providers.deepseek.models.1.contextWindow for "deepseek-v4-pro" from 200000 to 1000000.',
+    ]);
+  });
+
+  it("preserves intentional DeepSeek V4 context window overrides", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          deepseek: {
+            models: [
+              {
+                id: "deepseek-v4-flash",
+                name: "DeepSeek V4 Flash",
+                contextWindow: 500_000,
+              },
+              {
+                id: "deepseek-v4-pro",
+                name: "DeepSeek V4 Pro",
+                contextWindow: 1_000_000,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(res.config).toBeNull();
+    expect(res.changes).toStrictEqual([]);
+  });
+
   it("removes unrecognized model compat thinkingFormat values", () => {
     const res = migrateLegacyConfigForTest({
       models: {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -38,6 +38,35 @@ const INVALID_THINKING_FORMAT_RULE: LegacyConfigRule = {
   match: (value) => hasInvalidThinkingFormat(value),
 };
 
+const DEEPSEEK_V4_CONTEXT_WINDOW = 1_000_000;
+const DEEPSEEK_V4_STALE_CONTEXT_WINDOW = 200_000;
+const DEEPSEEK_V4_MODEL_IDS = new Set(["deepseek-v4-flash", "deepseek-v4-pro"]);
+
+function isStaleDeepSeekV4ContextWindowModel(model: unknown): boolean {
+  const record = getRecord(model);
+  if (!record || typeof record.id !== "string") {
+    return false;
+  }
+  return (
+    DEEPSEEK_V4_MODEL_IDS.has(record.id.trim().toLowerCase()) &&
+    record.contextWindow === DEEPSEEK_V4_STALE_CONTEXT_WINDOW
+  );
+}
+
+function hasStaleDeepSeekV4ContextWindow(providers: unknown): boolean {
+  const providersRecord = getRecord(providers);
+  const deepseek = getRecord(providersRecord?.deepseek);
+  const models = deepseek?.models;
+  return Array.isArray(models) && models.some(isStaleDeepSeekV4ContextWindowModel);
+}
+
+const STALE_DEEPSEEK_V4_CONTEXT_WINDOW_RULE: LegacyConfigRule = {
+  path: ["models", "providers", "deepseek", "models"],
+  message:
+    'models.providers.deepseek.models contains stale DeepSeek V4 200000-token context metadata; run "openclaw doctor --fix" to restore the bundled 1000000-token window.',
+  match: (value) => hasStaleDeepSeekV4ContextWindow({ deepseek: { models: value } }),
+};
+
 function normalizeString(value: unknown): string {
   return typeof value === "string" ? value.trim().toLowerCase() : "";
 }
@@ -503,6 +532,30 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_MODELS: LegacyConfigMigrationSpec[
         delete raw[key];
       }
       Object.assign(raw, rewritten.value);
+    },
+  }),
+  defineLegacyConfigMigration({
+    id: "models.providers.deepseek.models.deepseek-v4-contextWindow-stale",
+    describe: "Restore stale DeepSeek V4 context windows to current catalog metadata",
+    legacyRules: [STALE_DEEPSEEK_V4_CONTEXT_WINDOW_RULE],
+    apply: (raw, changes) => {
+      const providers = getRecord(getRecord(raw.models)?.providers);
+      const deepseek = getRecord(providers?.deepseek);
+      const models = deepseek?.models;
+      if (!Array.isArray(models)) {
+        return;
+      }
+
+      for (const [index, model] of models.entries()) {
+        const record = getRecord(model);
+        if (!isStaleDeepSeekV4ContextWindowModel(record)) {
+          continue;
+        }
+        record.contextWindow = DEEPSEEK_V4_CONTEXT_WINDOW;
+        changes.push(
+          `Restored models.providers.deepseek.models.${index}.contextWindow for ${JSON.stringify(record.id)} from ${DEEPSEEK_V4_STALE_CONTEXT_WINDOW} to ${DEEPSEEK_V4_CONTEXT_WINDOW}.`,
+        );
+      }
     },
   }),
   defineLegacyConfigMigration({


### PR DESCRIPTION
## Summary

- Fixes #85834 by teaching `openclaw doctor --fix` to repair stale local DeepSeek V4 model metadata generated with a 200K context window.
- Updates only the known stale `deepseek-v4-flash` / `deepseek-v4-pro` `contextWindow: 200000` entries to the bundled 1,000,000-token catalog value.
- Preserves other DeepSeek models and intentional DeepSeek V4 context-window overrides.

## Tests

- `node scripts/run-vitest.mjs src/commands/doctor/shared/legacy-config-migrate.test.ts --runInBand`
- `node scripts/run-vitest.mjs src/commands/doctor-legacy-config.migrations.test.ts --runInBand`
- `node scripts/run-oxlint.mjs src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts src/commands/doctor/shared/legacy-config-migrate.test.ts`
- `git diff --check`

## Real behavior proof

Behavior addressed: Running `openclaw doctor --fix` on a config that contains `models.providers.deepseek.models[].id = "deepseek-v4-flash"` with `contextWindow: 200000` rewrites that stale generated context window to `1000000`, so the UI/session context percentage can use the current DeepSeek V4 catalog limit after repair.

Real environment tested: Local macOS checkout using the repo CLI (`pnpm openclaw`) with an isolated temporary `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_CONFIG_PATH`.

Exact steps or command run after this patch: Created a temporary `openclaw.json` containing a DeepSeek provider model entry for `deepseek-v4-flash` with `contextWindow: 200000`, then ran `OPENCLAW_HOME="$tmpdir/home" OPENCLAW_STATE_DIR="$tmpdir/state" OPENCLAW_CONFIG_PATH="$cfg" pnpm openclaw doctor --fix` and read the resulting config file.

Evidence after fix: The command completed with exit code 0 and produced this terminal capture:

```text
$ node scripts/run-node.mjs doctor --fix
[openclaw] Building TypeScript (dist is stale: dirty_watched_tree - dirty watched source tree).
[openclaw] Building bundled plugin assets.
runtime-postbuild: plugin SDK root alias completed in 1ms
runtime-postbuild: bundled plugin metadata completed in 294ms
runtime-postbuild: official channel catalog completed in 6ms
runtime-postbuild: bundled plugin runtime overlay completed in 315ms
runtime-postbuild: static extension assets completed in 118ms
runtime-postbuild: stable root runtime imports completed in 219ms
runtime-postbuild: stable root runtime aliases completed in 42ms
runtime-postbuild: legacy root runtime compat aliases completed in 10ms
runtime-postbuild: legacy CLI exit compat chunks completed in 0ms
[memory] fts unavailable: no such module: fts5
Config write anomaly: /var/folders/.../openclaw.json (missing-meta-before-write)
contextWindow= 1000000
outputContainsRepair= True
```

Observed result after fix: The stale DeepSeek V4 Flash config entry was repaired in place from 200,000 to 1,000,000 tokens; the targeted migration tests also verify both V4 Flash and V4 Pro are repaired while `deepseek-chat` and non-200K V4 overrides are preserved.

What was not tested: I did not reproduce the original Windows npm-global UI progress bar manually; this patch exercises the remaining source-proven `doctor --fix` repair path with an isolated config.