### PR TITLE
fix(doctor): repair stale contextWindow for DeepSeek V4 Flash

### DIFF
--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import { LEGACY_CONFIG_MIGRATIONS_RUNTIME_MODELS } from "./legacy-config-migrations.runtime.models.js";
+
+describe("stale contextWindow migration", () => {
+  const migration = LEGACY_CONFIG_MIGRATIONS_RUNTIME_MODELS.find(
+    (m) => m.id === "models.providers.*.models.*.contextWindow-stale",
+  );
+
+  it("repairs deepseek-v4-flash contextWindow from 200K to 1M", () => {
+    const changes: string[] = [];
+    const raw = {
+      models: {
+        providers: {
+          deepseek: {
+            models: [
+              {
+                id: "deepseek-v4-flash",
+                contextWindow: 200_000,
+                maxTokens: 61_440,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    migration!.apply(raw, changes);
+
+    expect(raw.models.providers.deepseek.models[0].contextWindow).toBe(1_000_000);
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toContain("200000 → 1000000");
+  });
+
+  it("does not modify correct contextWindow values", () => {
+    const changes: string[] = [];
+    const raw = {
+      models: {
+        providers: {
+          deepseek: {
+            models: [
+              {
+                id: "deepseek-v4-flash",
+                contextWindow: 1_000_000,
+                maxTokens: 61_440,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    migration!.apply(raw, changes);
+
+    expect(raw.models.providers.deepseek.models[0].contextWindow).toBe(1_000_000);
+    expect(changes).toHaveLength(0);
+  });
+
+  it("handles provider-prefixed model IDs", () => {
+    const changes: string[] = [];
+    const raw = {
+      models: {
+        providers: {
+          opencode: {
+            models: [
+              {
+                id: "deepseek/deepseek-v4-flash",
+                contextWindow: 200_000,
+                maxTokens: 61_440,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    migration!.apply(raw, changes);
+
+    expect(raw.models.providers.opencode.models[0].contextWindow).toBe(1_000_000);
+    expect(changes).toHaveLength(1);
+  });
+
+  it("skips models not in the stale fixes registry", () => {
+    const changes: string[] = [];
+    const raw = {
+      models: {
+        providers: {
+          openai: {
+            models: [
+              {
+                id: "gpt-4o",
+                contextWindow: 128_000,
+                maxTokens: 16_384,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    migration!.apply(raw, changes);
+
+    expect(raw.models.providers.openai.models[0].contextWindow).toBe(128_000);
+    expect(changes).toHaveLength(0);
+  });
+
+  it("handles missing providers gracefully", () => {
+    const changes: string[] = [];
+    const raw = {};
+
+    migration!.apply(raw, changes);
+
+    expect(changes).toHaveLength(0);
+  });
+
+  it("handles non-array models gracefully", () => {
+    const changes: string[] = [];
+    const raw = {
+      models: {
+        providers: {
+          deepseek: {
+            models: "not-an-array",
+          },
+        },
+      },
+    };
+
+    migration!.apply(raw, changes);
+
+    expect(changes).toHaveLength(0);
+  });
+
+  it("handles missing model id gracefully", () => {
+    const changes: string[] = [];
+    const raw = {
+      models: {
+        providers: {
+          deepseek: {
+            models: [
+              {
+                contextWindow: 200_000,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    migration!.apply(raw, changes);
+
+    expect(changes).toHaveLength(0);
+  });
+});

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.test.ts
@@ -55,6 +55,30 @@ describe("stale contextWindow migration", () => {
     expect(changes).toHaveLength(0);
   });
 
+  it("preserves non-stale custom contextWindow values", () => {
+    const changes: string[] = [];
+    const raw = {
+      models: {
+        providers: {
+          deepseek: {
+            models: [
+              {
+                id: "deepseek-v4-flash",
+                contextWindow: 500_000,
+                maxTokens: 61_440,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    migration!.apply(raw, changes);
+
+    expect(raw.models.providers.deepseek.models[0].contextWindow).toBe(500_000);
+    expect(changes).toHaveLength(0);
+  });
+
   it("handles provider-prefixed model IDs", () => {
     const changes: string[] = [];
     const raw = {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.test.ts
@@ -107,12 +107,12 @@ describe("stale contextWindow migration", () => {
     expect(migration!.legacyRules?.[0]?.match?.(raw.models.providers, raw)).toBe(false);
   });
 
-  it("handles provider-prefixed model IDs", () => {
+  it("handles provider-prefixed model IDs under the native provider", () => {
     const changes: string[] = [];
     const raw = {
       models: {
         providers: {
-          opencode: {
+          deepseek: {
             models: [
               {
                 id: "deepseek/deepseek-v4-flash",
@@ -127,8 +127,33 @@ describe("stale contextWindow migration", () => {
 
     migration!.apply(raw, changes);
 
-    expect(raw.models.providers.opencode.models[0].contextWindow).toBe(1_000_000);
+    expect(raw.models.providers.deepseek.models[0].contextWindow).toBe(1_000_000);
     expect(changes).toHaveLength(1);
+  });
+
+  it("does not modify provider-prefixed ids from other providers", () => {
+    const changes: string[] = [];
+    const raw = {
+      models: {
+        providers: {
+          openrouter: {
+            models: [
+              {
+                id: "deepseek/deepseek-v4-flash",
+                contextWindow: 200_000,
+                maxTokens: 61_440,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    migration!.apply(raw, changes);
+
+    expect(raw.models.providers.openrouter.models[0].contextWindow).toBe(200_000);
+    expect(changes).toHaveLength(0);
+    expect(migration!.legacyRules?.[0]?.match?.(raw.models.providers, raw)).toBe(false);
   });
 
   it("skips models not in the stale fixes registry", () => {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.test.ts
@@ -24,11 +24,14 @@ describe("stale contextWindow migration", () => {
       },
     };
 
+    expect(migration!.legacyRules?.[0]?.match?.(raw.models.providers, raw)).toBe(true);
+
     migration!.apply(raw, changes);
 
     expect(raw.models.providers.deepseek.models[0].contextWindow).toBe(1_000_000);
     expect(changes).toHaveLength(1);
     expect(changes[0]).toContain("200000 → 1000000");
+    expect(migration!.legacyRules?.[0]?.match?.(raw.models.providers, raw)).toBe(false);
   });
 
   it("does not modify correct contextWindow values", () => {
@@ -77,6 +80,31 @@ describe("stale contextWindow migration", () => {
 
     expect(raw.models.providers.deepseek.models[0].contextWindow).toBe(500_000);
     expect(changes).toHaveLength(0);
+  });
+
+  it("does not modify bare ids from other providers", () => {
+    const changes: string[] = [];
+    const raw = {
+      models: {
+        providers: {
+          custom: {
+            models: [
+              {
+                id: "deepseek-v4-flash",
+                contextWindow: 200_000,
+                maxTokens: 61_440,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    migration!.apply(raw, changes);
+
+    expect(raw.models.providers.custom.models[0].contextWindow).toBe(200_000);
+    expect(changes).toHaveLength(0);
+    expect(migration!.legacyRules?.[0]?.match?.(raw.models.providers, raw)).toBe(false);
   });
 
   it("handles provider-prefixed model IDs", () => {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -16,9 +16,12 @@ function resolveStaleContextWindowFix(params: {
   modelId: string;
   contextWindow: number;
 }): { stale: number; correct: number } | undefined {
+  if (params.providerId !== "deepseek") {
+    return undefined;
+  }
   const scopedModelId = params.modelId.includes("/")
     ? params.modelId
-    : `${params.providerId}/${params.modelId}`;
+    : `deepseek/${params.modelId}`;
   const fix = STALE_CONTEXT_WINDOW_FIXES[scopedModelId];
   return fix && params.contextWindow === fix.stale ? fix : undefined;
 }

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -7,6 +7,15 @@ import {
 } from "../../../config/legacy.shared.js";
 import { isModelThinkingFormat } from "../../../config/types.models.js";
 
+/**
+ * Catalog-correct contextWindow values for models that shipped with stale
+ * defaults in older OpenClaw releases.
+ */
+const STALE_CONTEXT_WINDOW_FIXES: Record<string, number> = {
+  "deepseek/deepseek-v4-flash": 1_000_000,
+  "deepseek-v4-flash": 1_000_000,
+} as const;
+
 function hasInvalidThinkingFormat(providers: unknown): boolean {
   const providersRecord = getRecord(providers);
   if (!providersRecord) {
@@ -534,6 +543,50 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_MODELS: LegacyConfigMigrationSpec[
           delete compat.thinkingFormat;
           changes.push(
             `Removed models.providers.${providerId}.models.${index}.compat.thinkingFormat (unrecognized value ${JSON.stringify(thinkingFormat)}; runtime default applies).`,
+          );
+        }
+      }
+    },
+  }),
+  defineLegacyConfigMigration({
+    id: "models.providers.*.models.*.contextWindow-stale",
+    describe: "Repair stale contextWindow values to match catalog defaults",
+    apply: (raw, changes) => {
+      const providers = getRecord(getRecord(raw.models)?.providers);
+      if (!providers) {
+        return;
+      }
+
+      for (const [providerId, provider] of Object.entries(providers)) {
+        const models = getRecord(provider)?.models;
+        if (!Array.isArray(models)) {
+          continue;
+        }
+
+        for (const [index, model] of models.entries()) {
+          if (!getRecord(model)) {
+            continue;
+          }
+          const modelId = typeof model.id === "string" ? model.id : undefined;
+          if (!modelId) {
+            continue;
+          }
+          const contextWindow = model.contextWindow;
+          if (typeof contextWindow !== "number" || !Number.isFinite(contextWindow)) {
+            continue;
+          }
+
+          // Check against both "deepseek-v4-flash" and "deepseek/deepseek-v4-flash"
+          const correct =
+            STALE_CONTEXT_WINDOW_FIXES[modelId] ??
+            STALE_CONTEXT_WINDOW_FIXES[`${providerId}/${modelId}`];
+          if (correct === undefined || contextWindow === correct) {
+            continue;
+          }
+
+          model.contextWindow = correct;
+          changes.push(
+            `Repaired models.providers.${providerId}.models[${index}].${modelId}.contextWindow (${contextWindow} → ${correct} to match catalog default).`,
           );
         }
       }

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -9,8 +9,47 @@ import { isModelThinkingFormat } from "../../../config/types.models.js";
 
 const STALE_CONTEXT_WINDOW_FIXES: Record<string, { stale: number; correct: number }> = {
   "deepseek/deepseek-v4-flash": { stale: 200_000, correct: 1_000_000 },
-  "deepseek-v4-flash": { stale: 200_000, correct: 1_000_000 },
 } as const;
+
+function resolveStaleContextWindowFix(params: {
+  providerId: string;
+  modelId: string;
+  contextWindow: number;
+}): { stale: number; correct: number } | undefined {
+  const scopedModelId = params.modelId.includes("/")
+    ? params.modelId
+    : `${params.providerId}/${params.modelId}`;
+  const fix = STALE_CONTEXT_WINDOW_FIXES[scopedModelId];
+  return fix && params.contextWindow === fix.stale ? fix : undefined;
+}
+
+function hasStaleContextWindowValue(providers: unknown): boolean {
+  const providersRecord = getRecord(providers);
+  if (!providersRecord) {
+    return false;
+  }
+
+  for (const [providerId, provider] of Object.entries(providersRecord)) {
+    const models = getRecord(provider)?.models;
+    if (!Array.isArray(models)) {
+      continue;
+    }
+
+    for (const model of models) {
+      const modelRecord = getRecord(model);
+      const modelId = typeof modelRecord?.id === "string" ? modelRecord.id : undefined;
+      const contextWindow = modelRecord?.contextWindow;
+      if (!modelId || typeof contextWindow !== "number" || !Number.isFinite(contextWindow)) {
+        continue;
+      }
+      if (resolveStaleContextWindowFix({ providerId, modelId, contextWindow })) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
 
 function hasInvalidThinkingFormat(providers: unknown): boolean {
   const providersRecord = getRecord(providers);
@@ -41,6 +80,13 @@ const INVALID_THINKING_FORMAT_RULE: LegacyConfigRule = {
   message:
     'models.providers.<id>.models[*].compat.thinkingFormat has an unrecognized value; run "openclaw doctor --fix" to remove it and restore the runtime default.',
   match: (value) => hasInvalidThinkingFormat(value),
+};
+
+const STALE_CONTEXT_WINDOW_RULE: LegacyConfigRule = {
+  path: ["models", "providers"],
+  message:
+    'models.providers.<id>.models[*].contextWindow has a stale catalog value; run "openclaw doctor --fix" to repair it.',
+  match: (value) => hasStaleContextWindowValue(value),
 };
 
 function normalizeString(value: unknown): string {
@@ -547,6 +593,7 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_MODELS: LegacyConfigMigrationSpec[
   defineLegacyConfigMigration({
     id: "models.providers.*.models.*.contextWindow-stale",
     describe: "Repair stale contextWindow values to match catalog defaults",
+    legacyRules: [STALE_CONTEXT_WINDOW_RULE],
     apply: (raw, changes) => {
       const providers = getRecord(getRecord(raw.models)?.providers);
       if (!providers) {
@@ -572,10 +619,8 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_MODELS: LegacyConfigMigrationSpec[
             continue;
           }
 
-          const fix =
-            STALE_CONTEXT_WINDOW_FIXES[modelId] ??
-            STALE_CONTEXT_WINDOW_FIXES[`${providerId}/${modelId}`];
-          if (fix === undefined || contextWindow !== fix.stale) {
+          const fix = resolveStaleContextWindowFix({ providerId, modelId, contextWindow });
+          if (!fix) {
             continue;
           }
 

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -7,13 +7,9 @@ import {
 } from "../../../config/legacy.shared.js";
 import { isModelThinkingFormat } from "../../../config/types.models.js";
 
-/**
- * Catalog-correct contextWindow values for models that shipped with stale
- * defaults in older OpenClaw releases.
- */
-const STALE_CONTEXT_WINDOW_FIXES: Record<string, number> = {
-  "deepseek/deepseek-v4-flash": 1_000_000,
-  "deepseek-v4-flash": 1_000_000,
+const STALE_CONTEXT_WINDOW_FIXES: Record<string, { stale: number; correct: number }> = {
+  "deepseek/deepseek-v4-flash": { stale: 200_000, correct: 1_000_000 },
+  "deepseek-v4-flash": { stale: 200_000, correct: 1_000_000 },
 } as const;
 
 function hasInvalidThinkingFormat(providers: unknown): boolean {
@@ -576,17 +572,16 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_MODELS: LegacyConfigMigrationSpec[
             continue;
           }
 
-          // Check against both "deepseek-v4-flash" and "deepseek/deepseek-v4-flash"
-          const correct =
+          const fix =
             STALE_CONTEXT_WINDOW_FIXES[modelId] ??
             STALE_CONTEXT_WINDOW_FIXES[`${providerId}/${modelId}`];
-          if (correct === undefined || contextWindow === correct) {
+          if (fix === undefined || contextWindow !== fix.stale) {
             continue;
           }
 
-          model.contextWindow = correct;
+          model.contextWindow = fix.correct;
           changes.push(
-            `Repaired models.providers.${providerId}.models[${index}].${modelId}.contextWindow (${contextWindow} → ${correct} to match catalog default).`,
+            `Repaired models.providers.${providerId}.models[${index}].${modelId}.contextWindow (${contextWindow} → ${fix.correct} to match catalog default).`,
           );
         }
       }


### PR DESCRIPTION
## Summary

Repairs stale `contextWindow` values for DeepSeek V4 Flash during `openclaw doctor --fix`.

## Problem

Older OpenClaw releases configured `deepseek-v4-flash` with `contextWindow: 200000` (200K), but the current DeepSeek V4 Flash catalog default is 1,000,000 (1M). That stale override can make UI/token budgeting treat the model as much more full than it really is.

## Fix

- Detects only the known stale DeepSeek V4 Flash `contextWindow: 200000` value under the native `deepseek` provider.
- Repairs that stale value to `1000000`.
- Preserves custom non-stale values and provider-prefixed DeepSeek IDs under other providers.

Fixes: #85834

## Real behavior proof

Behavior addressed:
`openclaw doctor --fix` did not repair stale DeepSeek V4 Flash context-window overrides, so old configs could keep using 200K instead of the current 1M catalog value.

Real environment tested:
Local OpenClaw checkout on the rebased PR head, with an isolated temp OpenClaw home/config for the doctor path plus a direct runtime migration probe.

Exact steps or command run after this patch:
`HOME=/tmp/openclaw-doctor-deepseek-proof... OPENCLAW_CONFIG_PATH=/tmp/openclaw-doctor-deepseek-proof.../home/.openclaw/openclaw.json pnpm openclaw doctor --non-interactive --fix`
`pnpm exec tsx -e 'import { LEGACY_CONFIG_MIGRATIONS_RUNTIME_MODELS } from "./src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts"; ...'`

Evidence after fix:
Terminal output from the isolated doctor run showed `models.providers.deepseek.models[0].deepseek-v4-flash.contextWindow (200000 -> 1000000 to match catalog default)`. The runtime migration output was `{ "detectedBefore": true, "detectedAfter": false, "beforeDeepseek": [200000, 500000], "afterDeepseek": [1000000, 500000], "openrouterPrefixed": 200000 }`.

Observed result after fix:
The stale native DeepSeek entry is repaired to 1M, custom DeepSeek context windows are preserved, and provider-prefixed DeepSeek IDs under OpenRouter are left untouched.

What was not tested:
A live DeepSeek API request; this change only rewrites stale local configuration metadata during doctor repair.
