### PR TITLE
fix(security): replace regex wildcard matching with linear-time glob in session-visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Docs: https://docs.openclaw.ai
 - Config/secrets: preflight active runtime SecretRefs before root and include config writes persist, and roll back unchanged file/env state when post-write refresh fails. Fixes #46531. (#84454) Thanks @samzong.
 - CLI/models: preserve SecretRef-backed custom provider `apiKey` markers when `models status` regenerates `models.json`, avoiding resolved plaintext secrets on disk. Fixes #84632. (#84658) Thanks @NianJiuZst.
 - WhatsApp/auto-reply: deliver deferred media replies through the foreground reply fence so overlapping no-reply turns no longer hide already visible responses. (#85517) Thanks @cavit99.
+- Sessions/security: replace agent-to-agent wildcard allowlist regexes with a precompiled linear matcher so cross-agent access checks avoid backtracking-prone patterns. (#85849) Thanks @SebTardif.
 - WebChat: keep the run-complete indicator in progress until deferred history replay renders the assistant reply, so Done no longer appears before response text. (#85374) Thanks @neeravmakwana.
 - Agents/tools: give timed-out or cancelled process trees a bounded SIGTERM cleanup window before SIGKILL while preserving tree-aware cancellation. Fixes #66399. (#85865) Thanks @IWhatsskill.
 - Agents/subagents: treat aborted subagent stop reasons as killed terminal failures so parent sessions get error announcements instead of silent success. Fixes #72293. (#85860) Thanks @IWhatsskill.

--- a/src/agents/tools/sessions-access.test.ts
+++ b/src/agents/tools/sessions-access.test.ts
@@ -137,6 +137,20 @@ describe("createAgentToAgentPolicy", () => {
     expect(policy.matchesAllow("ops")).toBe(false);
   });
 
+  it("keeps blank configured allow patterns fail-closed", () => {
+    const policy = createAgentToAgentPolicy({
+      tools: {
+        agentToAgent: {
+          enabled: true,
+          allow: [" "],
+        },
+      },
+    } as unknown as OpenClawConfig);
+
+    expect(policy.matchesAllow("ops")).toBe(false);
+    expect(policy.isAllowed("main", "ops")).toBe(false);
+  });
+
   it("handles interior wildcards", () => {
     const policy = createAgentToAgentPolicy({
       tools: {

--- a/src/agents/tools/sessions-access.test.ts
+++ b/src/agents/tools/sessions-access.test.ts
@@ -107,6 +107,75 @@ describe("createAgentToAgentPolicy", () => {
     expect(policy.isAllowed("main", "ops-a")).toBe(true);
     expect(policy.isAllowed("guest", "ops-a")).toBe(false);
   });
+
+  it("matches wildcard patterns case-insensitively", () => {
+    const policy = createAgentToAgentPolicy({
+      tools: {
+        agentToAgent: {
+          enabled: true,
+          allow: ["Ops-*"],
+        },
+      },
+    } as unknown as OpenClawConfig);
+
+    expect(policy.matchesAllow("ops-worker")).toBe(true);
+    expect(policy.matchesAllow("OPS-WORKER")).toBe(true);
+    expect(policy.matchesAllow("guest")).toBe(false);
+  });
+
+  it("handles interior wildcards", () => {
+    const policy = createAgentToAgentPolicy({
+      tools: {
+        agentToAgent: {
+          enabled: true,
+          allow: ["team-*-prod"],
+        },
+      },
+    } as unknown as OpenClawConfig);
+
+    expect(policy.matchesAllow("team-ops-prod")).toBe(true);
+    expect(policy.matchesAllow("team-dev-prod")).toBe(true);
+    expect(policy.matchesAllow("team-ops-staging")).toBe(false);
+    expect(policy.matchesAllow("team-prod")).toBe(false);
+  });
+
+  it("handles multiple wildcards without polynomial backtracking", () => {
+    const policy = createAgentToAgentPolicy({
+      tools: {
+        agentToAgent: {
+          enabled: true,
+          allow: ["*a*b*c*d*e*"],
+        },
+      },
+    } as unknown as OpenClawConfig);
+
+    // Positive match
+    expect(policy.matchesAllow("xaxbxcxdxe")).toBe(true);
+
+    // Negative match with adversarial input that would cause O(n^k)
+    // backtracking with the old `^.*a.*b.*c.*d.*e.*$` regex.
+    const adversarial = "a".repeat(200) + "b".repeat(200) + "c".repeat(200) + "d".repeat(200);
+    const start = performance.now();
+    expect(policy.matchesAllow(adversarial)).toBe(false);
+    const elapsed = performance.now() - start;
+    // The old regex could take seconds; the segment matcher finishes sub-ms.
+    expect(elapsed).toBeLessThan(50);
+  });
+
+  it("rejects when suffix overlaps prefix", () => {
+    const policy = createAgentToAgentPolicy({
+      tools: {
+        agentToAgent: {
+          enabled: true,
+          allow: ["abc*xyz"],
+        },
+      },
+    } as unknown as OpenClawConfig);
+
+    expect(policy.matchesAllow("abcxyz")).toBe(true);
+    expect(policy.matchesAllow("abc-middle-xyz")).toBe(true);
+    expect(policy.matchesAllow("ab")).toBe(false);
+  });
 });
 
 describe("createSessionVisibilityGuard", () => {

--- a/src/agents/tools/sessions-access.test.ts
+++ b/src/agents/tools/sessions-access.test.ts
@@ -123,6 +123,20 @@ describe("createAgentToAgentPolicy", () => {
     expect(policy.matchesAllow("guest")).toBe(false);
   });
 
+  it("keeps exact allow patterns case-sensitive", () => {
+    const policy = createAgentToAgentPolicy({
+      tools: {
+        agentToAgent: {
+          enabled: true,
+          allow: ["Ops"],
+        },
+      },
+    } as unknown as OpenClawConfig);
+
+    expect(policy.matchesAllow("Ops")).toBe(true);
+    expect(policy.matchesAllow("ops")).toBe(false);
+  });
+
   it("handles interior wildcards", () => {
     const policy = createAgentToAgentPolicy({
       tools: {
@@ -175,6 +189,20 @@ describe("createAgentToAgentPolicy", () => {
     expect(policy.matchesAllow("abcxyz")).toBe(true);
     expect(policy.matchesAllow("abc-middle-xyz")).toBe(true);
     expect(policy.matchesAllow("ab")).toBe(false);
+  });
+
+  it("treats regex syntax as literal text in wildcard patterns", () => {
+    const policy = createAgentToAgentPolicy({
+      tools: {
+        agentToAgent: {
+          enabled: true,
+          allow: ["ops.[prod]*"],
+        },
+      },
+    } as unknown as OpenClawConfig);
+
+    expect(policy.matchesAllow("OPS.[PROD]-worker")).toBe(true);
+    expect(policy.matchesAllow("opsXprod-worker")).toBe(false);
   });
 });
 

--- a/src/plugin-sdk/session-visibility.ts
+++ b/src/plugin-sdk/session-visibility.ts
@@ -96,6 +96,7 @@ export function resolveSandboxSessionToolsVisibility(cfg: OpenClawConfig): "spaw
 
 type CompiledAgentAllowPattern =
   | { kind: "all" }
+  | { kind: "deny" }
   | { kind: "exact"; value: string }
   | {
       kind: "wildcard";
@@ -104,10 +105,10 @@ type CompiledAgentAllowPattern =
       interior: string[];
     };
 
-function compileAgentAllowPattern(pattern: string): CompiledAgentAllowPattern | null {
+function compileAgentAllowPattern(pattern: string): CompiledAgentAllowPattern {
   const raw = normalizeOptionalString(pattern) ?? "";
   if (!raw) {
-    return null;
+    return { kind: "deny" };
   }
   if (raw === "*") {
     return { kind: "all" };
@@ -161,9 +162,7 @@ export function createAgentToAgentPolicy(cfg: OpenClawConfig): AgentToAgentPolic
   const routingA2A = cfg.tools?.agentToAgent;
   const enabled = routingA2A?.enabled === true;
   const rawAllowPatterns = Array.isArray(routingA2A?.allow) ? routingA2A.allow : [];
-  const allowPatterns = rawAllowPatterns
-    .map((pattern) => compileAgentAllowPattern(pattern))
-    .filter((pattern): pattern is CompiledAgentAllowPattern => pattern !== null);
+  const allowPatterns = rawAllowPatterns.map((pattern) => compileAgentAllowPattern(pattern));
   const hasWildcardPatterns = allowPatterns.some((pattern) => pattern.kind === "wildcard");
   const matchesAllow = (agentId: string) => {
     if (allowPatterns.length === 0) {
@@ -173,6 +172,9 @@ export function createAgentToAgentPolicy(cfg: OpenClawConfig): AgentToAgentPolic
     return allowPatterns.some((pattern) => {
       if (pattern.kind === "all") {
         return true;
+      }
+      if (pattern.kind === "deny") {
+        return false;
       }
       if (pattern.kind === "exact") {
         return pattern.value === agentId;

--- a/src/plugin-sdk/session-visibility.ts
+++ b/src/plugin-sdk/session-visibility.ts
@@ -94,6 +94,50 @@ export function resolveSandboxSessionToolsVisibility(cfg: OpenClawConfig): "spaw
   return cfg.agents?.defaults?.sandbox?.sessionToolsVisibility ?? "spawned";
 }
 
+/**
+ * Linear-time case-insensitive glob matcher.  Splits the pattern on `*` and
+ * checks that all segments appear in order inside `value` with the first
+ * anchored to the start and the last anchored to the end.  O(n·k) where
+ * n = value length and k = segment count, avoiding the polynomial
+ * backtracking that `new RegExp("^.*a.*b.*$")` causes with multiple wildcards.
+ */
+function matchesWildcardCaseInsensitive(pattern: string, value: string): boolean {
+  const parts = pattern.toLowerCase().split("*");
+  const lower = value.toLowerCase();
+
+  // First part must be a prefix.
+  const first = parts[0];
+  let pos = 0;
+  if (first) {
+    if (!lower.startsWith(first)) {
+      return false;
+    }
+    pos = first.length;
+  }
+
+  // Last part must be a suffix.
+  const last = parts[parts.length - 1];
+  const endBound = last ? lower.length - last.length : lower.length;
+  if (last && (!lower.endsWith(last) || endBound < pos)) {
+    return false;
+  }
+
+  // Interior parts must appear in order between prefix end and suffix start.
+  for (let i = 1; i < parts.length - 1; i++) {
+    const part = parts[i];
+    if (!part) {
+      continue;
+    }
+    const idx = lower.indexOf(part, pos);
+    if (idx === -1 || idx + part.length > endBound) {
+      return false;
+    }
+    pos = idx + part.length;
+  }
+
+  return true;
+}
+
 export function createAgentToAgentPolicy(cfg: OpenClawConfig): AgentToAgentPolicy {
   const routingA2A = cfg.tools?.agentToAgent;
   const enabled = routingA2A?.enabled === true;
@@ -115,9 +159,7 @@ export function createAgentToAgentPolicy(cfg: OpenClawConfig): AgentToAgentPolic
       if (!raw.includes("*")) {
         return raw === agentId;
       }
-      const escaped = raw.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      const re = new RegExp(`^${escaped.replaceAll("\\*", ".*")}$`, "i");
-      return re.test(agentId);
+      return matchesWildcardCaseInsensitive(raw, agentId);
     });
   };
   const isAllowed = (requesterAgentId: string, targetAgentId: string) => {

--- a/src/plugin-sdk/session-visibility.ts
+++ b/src/plugin-sdk/session-visibility.ts
@@ -94,40 +94,59 @@ export function resolveSandboxSessionToolsVisibility(cfg: OpenClawConfig): "spaw
   return cfg.agents?.defaults?.sandbox?.sessionToolsVisibility ?? "spawned";
 }
 
-/**
- * Linear-time case-insensitive glob matcher.  Splits the pattern on `*` and
- * checks that all segments appear in order inside `value` with the first
- * anchored to the start and the last anchored to the end.  O(n·k) where
- * n = value length and k = segment count, avoiding the polynomial
- * backtracking that `new RegExp("^.*a.*b.*$")` causes with multiple wildcards.
- */
-function matchesWildcardCaseInsensitive(pattern: string, value: string): boolean {
-  const parts = pattern.toLowerCase().split("*");
-  const lower = value.toLowerCase();
+type CompiledAgentAllowPattern =
+  | { kind: "all" }
+  | { kind: "exact"; value: string }
+  | {
+      kind: "wildcard";
+      first: string;
+      last: string;
+      interior: string[];
+    };
 
-  // First part must be a prefix.
-  const first = parts[0];
+function compileAgentAllowPattern(pattern: string): CompiledAgentAllowPattern | null {
+  const raw = normalizeOptionalString(pattern) ?? "";
+  if (!raw) {
+    return null;
+  }
+  if (raw === "*") {
+    return { kind: "all" };
+  }
+  if (!raw.includes("*")) {
+    return { kind: "exact", value: raw };
+  }
+  const parts = raw.toLowerCase().split("*");
+  return {
+    kind: "wildcard",
+    first: parts[0] ?? "",
+    last: parts[parts.length - 1] ?? "",
+    interior: parts.slice(1, -1).filter(Boolean),
+  };
+}
+
+/**
+ * Linear-time case-insensitive glob matcher for precompiled `*` patterns.
+ * Checks prefix, suffix, then ordered interior segments without entering the
+ * regex engine, avoiding polynomial backtracking on repeated wildcards.
+ */
+function matchesCompiledWildcard(
+  pattern: Extract<CompiledAgentAllowPattern, { kind: "wildcard" }>,
+  lower: string,
+): boolean {
   let pos = 0;
-  if (first) {
-    if (!lower.startsWith(first)) {
+  if (pattern.first) {
+    if (!lower.startsWith(pattern.first)) {
       return false;
     }
-    pos = first.length;
+    pos = pattern.first.length;
   }
 
-  // Last part must be a suffix.
-  const last = parts[parts.length - 1];
-  const endBound = last ? lower.length - last.length : lower.length;
-  if (last && (!lower.endsWith(last) || endBound < pos)) {
+  const endBound = pattern.last ? lower.length - pattern.last.length : lower.length;
+  if (pattern.last && (!lower.endsWith(pattern.last) || endBound < pos)) {
     return false;
   }
 
-  // Interior parts must appear in order between prefix end and suffix start.
-  for (let i = 1; i < parts.length - 1; i++) {
-    const part = parts[i];
-    if (!part) {
-      continue;
-    }
+  for (const part of pattern.interior) {
     const idx = lower.indexOf(part, pos);
     if (idx === -1 || idx + part.length > endBound) {
       return false;
@@ -141,25 +160,24 @@ function matchesWildcardCaseInsensitive(pattern: string, value: string): boolean
 export function createAgentToAgentPolicy(cfg: OpenClawConfig): AgentToAgentPolicy {
   const routingA2A = cfg.tools?.agentToAgent;
   const enabled = routingA2A?.enabled === true;
-  const allowPatterns = Array.isArray(routingA2A?.allow) ? routingA2A.allow : [];
+  const rawAllowPatterns = Array.isArray(routingA2A?.allow) ? routingA2A.allow : [];
+  const allowPatterns = rawAllowPatterns
+    .map((pattern) => compileAgentAllowPattern(pattern))
+    .filter((pattern): pattern is CompiledAgentAllowPattern => pattern !== null);
+  const hasWildcardPatterns = allowPatterns.some((pattern) => pattern.kind === "wildcard");
   const matchesAllow = (agentId: string) => {
     if (allowPatterns.length === 0) {
       return true;
     }
+    const lowerAgentId = hasWildcardPatterns ? agentId.toLowerCase() : "";
     return allowPatterns.some((pattern) => {
-      const raw =
-        normalizeOptionalString(typeof pattern === "string" ? pattern : String(pattern ?? "")) ??
-        "";
-      if (!raw) {
-        return false;
-      }
-      if (raw === "*") {
+      if (pattern.kind === "all") {
         return true;
       }
-      if (!raw.includes("*")) {
-        return raw === agentId;
+      if (pattern.kind === "exact") {
+        return pattern.value === agentId;
       }
-      return matchesWildcardCaseInsensitive(raw, agentId);
+      return matchesCompiledWildcard(pattern, lowerAgentId);
     });
   };
   const isAllowed = (requesterAgentId: string, targetAgentId: string) => {


### PR DESCRIPTION
## Summary

The `createAgentToAgentPolicy` wildcard matcher in `session-visibility.ts` converted user-supplied `tools.agentToAgent.allow` patterns (e.g. `*a*b*c*`) into regex `^.*a.*b.*c.*$` via `new RegExp`. Multiple overlapping `.*` groups cause O(n^k) polynomial backtracking against non-matching input, where k is the number of wildcards in the pattern.

This replaces the regex path with a linear-time segment-based glob matcher that splits the pattern on `*` and checks prefix, suffix, and interior segments in order. The new algorithm runs in O(n·k) worst case and removes the regex engine entirely from this code path.
## Real behavior proof

Behavior addressed: ReDoS via polynomial backtracking in `createAgentToAgentPolicy` wildcard matching. The old regex `^.*a.*b.*c.*$` causes O(n^k) backtracking against non-matching input. Replaced with a linear-time segment-based glob matcher.

Real environment tested: macOS (Darwin 24.5.0), Node v26.0.0, OpenClaw built from patched source at commit 12ed41b137.

Exact steps or command run after this patch:

Step 1. Built OpenClaw from patched source and imported the actual compiled module

```console
$ node --input-type=module -e '
import { performance } from "node:perf_hooks";
import { createAgentToAgentPolicy } from "./dist/plugin-sdk/session-visibility.js";

const cfg = {
  tools: { agentToAgent: { enabled: true, allow: ["*a*b*c*d*e*"] } },
};
const policy = createAgentToAgentPolicy(cfg);
const adversarial = "x".repeat(800);

const t1 = performance.now();
const r1 = policy.matchesAllow(adversarial);
const d1 = performance.now() - t1;
console.log("Adversarial: pattern=*a*b*c*d*e* input=x*800");
console.log("policy.matchesAllow() result:", r1, "time:", d1.toFixed(3) + "ms");
'
Adversarial: pattern=*a*b*c*d*e* input=x*800
policy.matchesAllow() result: false time: 0.053ms
```

Step 2. Verified normal wildcard matching through the actual OpenClaw policy API

```console
$ node --input-type=module -e '
import { createAgentToAgentPolicy } from "./dist/plugin-sdk/session-visibility.js";
const tests = [
  { allow: ["*"], id: "any-agent", expected: true },
  { allow: ["agent-*"], id: "agent-foo", expected: true },
  { allow: ["agent-*"], id: "other-foo", expected: false },
  { allow: ["*-worker"], id: "bg-worker", expected: true },
  { allow: ["*mid*"], id: "has-mid-dle", expected: true },
  { allow: ["exact-id"], id: "exact-id", expected: true },
  { allow: ["exact-id"], id: "not-exact-id", expected: false },
];
for (const t of tests) {
  const p = createAgentToAgentPolicy({
    tools: { agentToAgent: { enabled: true, allow: t.allow } },
  });
  const r = p.matchesAllow(t.id);
  console.log((r === t.expected ? "PASS" : "FAIL") + ": allow=" + JSON.stringify(t.allow) + " agent=" + t.id + " -> " + r);
}
'
PASS: allow=["*"] agent=any-agent -> true
PASS: allow=["agent-*"] agent=agent-foo -> true
PASS: allow=["agent-*"] agent=other-foo -> false
PASS: allow=["*-worker"] agent=bg-worker -> true
PASS: allow=["*mid*"] agent=has-mid-dle -> true
PASS: allow=["exact-id"] agent=exact-id -> true
PASS: allow=["exact-id"] agent=not-exact-id -> false
```

Evidence after fix: The actual compiled `dist/plugin-sdk/session-visibility.js` was imported and exercised via `createAgentToAgentPolicy().matchesAllow()`. Terminal output:

```console
Adversarial: pattern=*a*b*c*d*e* input=x*800
policy.matchesAllow() result: false time: 0.053ms
```

The patched `matchesWildcardCaseInsensitive` completes adversarial input (800-char non-matching string, 5 wildcards) in 0.053ms through the real OpenClaw policy API. All 7 normal wildcard cases produce correct results.

Observed result after fix: The segment matcher is confirmed linear-time through the actual `createAgentToAgentPolicy` code path. Normal wildcard semantics (prefix, suffix, interior, exact, multi-wildcard) are preserved. The regex engine is removed from this code path entirely.

What was not tested: Live gateway with cross-agent session access using a configured `tools.agentToAgent.allow` entry. The policy function is exercised through the compiled production module; the gateway integration path adds config loading and agent lifecycle but does not change the matcher logic.
