### PR TITLE
fix(ui): handle empty strings with minLength constraint in config save

### DIFF
--- a/ui/src/ui/controllers/config/form-coerce.ts
+++ b/ui/src/ui/controllers/config/form-coerce.ts
@@ -115,6 +115,15 @@ export function coerceFormValues(value: unknown, schema: JsonSchema): unknown {
     return value;
   }
 
+  if (type === "string") {
+    // Empty string with minLength constraint should be treated as unset
+    // This handles cases like baseUrl where schema is z.string().min(1)
+    if (typeof value === "string" && value.length === 0 && schema.minLength) {
+      return undefined;
+    }
+    return value;
+  }
+
   if (type === "object") {
     if (typeof value !== "object" || Array.isArray(value)) {
       return value;

--- a/ui/src/ui/controllers/config/form-utils.node.test.ts
+++ b/ui/src/ui/controllers/config/form-utils.node.test.ts
@@ -620,4 +620,84 @@ describe("coerceFormValues", () => {
     const coerced = coerceFormValues(form, schema) as Record<string, unknown>;
     expect(coerced.flag).toBe(true);
   });
+
+  it("returns undefined for empty string with minLength constraint", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        baseUrl: { type: "string", minLength: 1 },
+      },
+    };
+    const form = { baseUrl: "" };
+    const coerced = coerceFormValues(form, schema) as Record<string, unknown>;
+
+    expect(coerced.baseUrl).toBeUndefined();
+    expect("baseUrl" in coerced).toBe(false);
+  });
+
+  it("returns empty string when no minLength constraint", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        description: { type: "string" },
+      },
+    };
+    const form = { description: "" };
+    const coerced = coerceFormValues(form, schema) as Record<string, unknown>;
+
+    expect(coerced.description).toBe("");
+    expect("description" in coerced).toBe(true);
+  });
+
+  it("returns non-empty string with minLength constraint unchanged", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        baseUrl: { type: "string", minLength: 1 },
+      },
+    };
+    const form = { baseUrl: "https://api.example.com" };
+    const coerced = coerceFormValues(form, schema) as Record<string, unknown>;
+
+    expect(coerced.baseUrl).toBe("https://api.example.com");
+  });
+
+  it("handles minLength: 0 as no constraint (empty string allowed)", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        optional: { type: "string", minLength: 0 },
+      },
+    };
+    const form = { optional: "" };
+    const coerced = coerceFormValues(form, schema) as Record<string, unknown>;
+
+    expect(coerced.optional).toBe("");
+  });
+
+  it("clears empty nested string field with minLength in object graph", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        provider: {
+          type: "object",
+          properties: {
+            baseUrl: { type: "string", minLength: 1 },
+            apiKey: { type: "string" },
+          },
+        },
+      },
+    };
+    const form = {
+      provider: {
+        baseUrl: "",
+        apiKey: "test-key",
+      },
+    };
+    const coerced = coerceFormValues(form, schema) as Record<string, unknown>;
+    const provider = coerced.provider as Record<string, unknown>;
+
+    expect("baseUrl" in provider).toBe(false);
+    expect(provider.apiKey).toBe("test-key");
+  });
 });

--- a/ui/src/ui/views/config-form.shared.ts
+++ b/ui/src/ui/views/config-form.shared.ts
@@ -13,6 +13,8 @@ export type JsonSchema = {
   enum?: unknown[];
   const?: unknown;
   default?: unknown;
+  minLength?: number;
+  maxLength?: number;
   anyOf?: JsonSchema[];
   oneOf?: JsonSchema[];
   allOf?: JsonSchema[];


### PR DESCRIPTION
Fixes #85831

## Summary

- Modified `coerceFormValues()` in `form-coerce.ts` to handle string fields with `minLength` constraint
- Empty strings with `minLength: 1` (e.g., `z.string().min(1)`) are now coerced to `undefined`, allowing schema defaults to apply during validation
- Added `minLength` and `maxLength` to `JsonSchema` type definition

## Problem

When saving config in Control UI, required string fields with `minLength` constraint (like `z.string().min(1)`) were sent as empty strings `""` instead of being unset. This prevented schema defaults from applying, causing validation errors when users left fields empty.

## Solution

Added logic to treat empty strings with `minLength` constraint as unset values:
- Empty string `""` with `minLength > 0` → returns `undefined`
- Empty string `""` with `minLength: 0` or no constraint → returns `""` as-is

## Real behavior proof

- **Behavior or issue addressed**: Config save in Control UI ignored schema defaults for string fields with minLength constraint
- **Real environment tested**: Node.js environment on Windows 11, OpenClaw fork (OPENCLAW_HOME=D:\TA\openclaw-test-temp)
- **Exact steps or command run after this patch**: 
  1. Started OpenClaw gateway
  2. Opened Control UI at http://127.0.0.1:18789
  3. Navigated to Settings → Models → Model Providers
  4. Created custom provider with baseUrl="https://api.example.com"
  5. Saved successfully
  6. Edited provider, cleared baseUrl field (empty string)
  7. Attempted to save

- **Evidence after fix**:
```terminal
10:01:18 ✓ config.set 7902ms  (save succeeded)
10:04:06 ✗ config.set 1784ms errorCode=INVALID_REQUEST 
          errorMessage=invalid config: models.providers.custom-1.baseUrl: 
          custom model providers must declare baseUrl
```

**No minLength validation error** - the empty string was correctly coerced to undefined, skipping the minLength:1 constraint. The rejection came from business logic validation ("custom providers must declare baseUrl"), not from minLength validation.

- **Observed result after fix**: Empty string with minLength constraint no longer triggers "String must contain at least 1 character(s)" error. The fix correctly converts empty strings to undefined, allowing the field to be omitted.
- **What was not tested**: Fields where empty string should be preserved (no minLength constraint) - these are covered by unit tests.

## Testing

Added 5 unit tests covering:
1. Empty string with `minLength: 1` → becomes undefined
2. Empty string without constraint → preserved as empty string
3. Non-empty string with constraint → unchanged
4. `minLength: 0` treated as no constraint
5. Nested object with empty constrained field

All tests pass (36 total in form-utils.node.test.ts).