### PR TITLE
[codex] Fix Telegram partial preview overflow bursts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Docs: https://docs.openclaw.ai
 - Directive tags: preserve message and content-part object identity when display stripping makes no directive-tag changes. (#85682) Thanks @willamhou.
 - Telegram: send local `path`/`filePath` and structured attachment media from `sendMessage` actions instead of dropping them or sending text-only messages. (#85219) Thanks @keshavbotagent.
 - Sessions/status: show the estimated context budget when fresh provider usage is unavailable and clear stale estimates across session resets and compaction boundaries. (#84830) Thanks @giodl73-repo.
+- Telegram: keep non-final partial stream previews to one editable message and reserve retained overflow pages for finalization, preventing preview bursts for one turn. Fixes #84885. Thanks @100yenadmin.
 - Gateway/config: pin relative `OPENCLAW_STATE_DIR` overrides to an absolute path at startup so later working-directory changes cannot retarget gateway state. (#52264) Thanks @PerfectPan.
 - Checks/Parallels: make changed-lane scripts, shrinkwrap generation, and Parallels package smoke host commands run through native Windows-safe paths and `npm`/`pnpm` shims.
 - Release/package: run npm release, prepublish, and postpublish verification through Windows-safe npm command shims so native Windows checks can execute `npm.cmd` instead of treating it as a binary.

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -240,6 +240,21 @@ describe("createTelegramDraftStream", () => {
     expect(api.deleteMessage).toHaveBeenCalledWith(123, 17);
   });
 
+  it("ignores updates after finalization", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api);
+
+    stream.update("Hello");
+    await stream.stop();
+
+    stream.update("stale update");
+    await stream.stop();
+
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", undefined);
+    expect(api.editMessageText).not.toHaveBeenCalled();
+  });
+
   it("creates new message after forceNewMessage is called", async () => {
     const { api, stream } = createForceNewMessageHarness();
 
@@ -399,65 +414,75 @@ describe("createTelegramDraftStream", () => {
     });
   });
 
-  it("continues in a new message when rendered preview crosses maxChars", async () => {
+  it("keeps oversized non-final previews in the existing message", async () => {
     const api = createMockDraftApi();
-    api.sendMessage
-      .mockResolvedValueOnce({ message_id: 17 })
-      .mockResolvedValueOnce({ message_id: 42 });
-    const stream = createDraftStream(api, { maxChars: 20 });
+    const onSupersededPreview = vi.fn();
+    const stream = createDraftStream(api, { maxChars: 20, onSupersededPreview });
 
     stream.update("Hello world");
     await stream.flush();
     stream.update("Hello world foo bar baz qux");
     await stream.flush();
 
-    expect(api.sendMessage).toHaveBeenCalledTimes(2);
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
     expect(api.sendMessage).toHaveBeenNthCalledWith(1, 123, "Hello world", undefined);
-    expect(api.sendMessage).toHaveBeenNthCalledWith(2, 123, "foo bar baz qux", undefined);
+    expect(api.editMessageText).toHaveBeenCalledWith(123, 17, "Hello world foo bar");
+    expect(onSupersededPreview).not.toHaveBeenCalled();
+    expect(stream.lastDeliveredText?.()).toBe("Hello world foo bar");
   });
 
-  it("splits a first oversized rendered preview into chained messages", async () => {
+  it("bounds a first oversized non-final preview to one message", async () => {
     const api = createMockDraftApi();
-    api.sendMessage
-      .mockResolvedValueOnce({ message_id: 17 })
-      .mockResolvedValueOnce({ message_id: 42 });
-    const stream = createDraftStream(api, { maxChars: 10 });
+    const onSupersededPreview = vi.fn();
+    const stream = createDraftStream(api, { maxChars: 10, onSupersededPreview });
 
     stream.update("1234567890ABCDEFGHIJ");
     await stream.flush();
 
-    expect(api.sendMessage).toHaveBeenCalledTimes(2);
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
     expect(api.sendMessage).toHaveBeenNthCalledWith(1, 123, "1234567890", undefined);
-    expect(api.sendMessage).toHaveBeenNthCalledWith(2, 123, "ABCDEFGHIJ", undefined);
+    expect(api.editMessageText).not.toHaveBeenCalled();
+    expect(onSupersededPreview).not.toHaveBeenCalled();
+    expect(stream.lastDeliveredText?.()).toBe("1234567890");
   });
 
-  it("retains overflow preview pages", async () => {
+  it("splits and retains overflow pages during finalization", async () => {
     const api = createMockDraftApi();
     api.sendMessage
       .mockResolvedValueOnce({ message_id: 17 })
-      .mockResolvedValueOnce({ message_id: 42 });
+      .mockResolvedValueOnce({ message_id: 42 })
+      .mockResolvedValueOnce({ message_id: 43 });
     const onSupersededPreview = vi.fn();
-    const stream = createDraftStream(api, {
-      maxChars: 20,
-      onSupersededPreview,
-    });
+    const stream = createDraftStream(api, { maxChars: 10, onSupersededPreview });
 
-    stream.update("Hello world");
+    stream.update("1234567890ABCDEFGHIJklmnopqrst");
     await stream.flush();
-    stream.update("Hello world foo bar baz qux");
-    await stream.flush();
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
+    expect(onSupersededPreview).not.toHaveBeenCalled();
 
-    expect(onSupersededPreview).toHaveBeenCalledTimes(1);
-    const [supersededPreview] = onSupersededPreview.mock.calls.at(0) ?? [];
-    expect(supersededPreview).toEqual({
-      messageId: 17,
-      textSnapshot: "Hello world",
-      parseMode: undefined,
-      visibleSinceMs: supersededPreview.visibleSinceMs,
-      retain: true,
-    });
-    expect(typeof supersededPreview.visibleSinceMs).toBe("number");
-    expect(Number.isFinite(supersededPreview.visibleSinceMs)).toBe(true);
+    await stream.stop();
+
+    expect(api.sendMessage).toHaveBeenCalledTimes(3);
+    expect(api.sendMessage).toHaveBeenNthCalledWith(1, 123, "1234567890", undefined);
+    expect(api.sendMessage).toHaveBeenNthCalledWith(2, 123, "ABCDEFGHIJ", undefined);
+    expect(api.sendMessage).toHaveBeenNthCalledWith(3, 123, "klmnopqrst", undefined);
+    expect(api.editMessageText).not.toHaveBeenCalled();
+    expect(onSupersededPreview).toHaveBeenCalledTimes(2);
+    for (const [index, messageId, textSnapshot] of [
+      [0, 17, "1234567890"],
+      [1, 42, "ABCDEFGHIJ"],
+    ] as const) {
+      const [supersededPreview] = onSupersededPreview.mock.calls.at(index) ?? [];
+      expect(supersededPreview).toEqual({
+        messageId,
+        textSnapshot,
+        parseMode: undefined,
+        visibleSinceMs: supersededPreview.visibleSinceMs,
+        retain: true,
+      });
+      expect(typeof supersededPreview.visibleSinceMs).toBe("number");
+      expect(Number.isFinite(supersededPreview.visibleSinceMs)).toBe(true);
+    }
   });
 
   it("enforces maxChars after renderText expansion", async () => {

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -116,7 +116,12 @@ export function createTelegramDraftStream(params: {
   let previewRevision = 0;
   let generation = 0;
   let deliveredTextOffset = 0;
-  let resetStreamToNewMessage: (options?: { keepPending?: boolean; resetOffset?: boolean }) => void;
+  let lastRequestedText = "";
+  let resetStreamToNewMessage: (options?: {
+    keepFinal?: boolean;
+    keepPending?: boolean;
+    resetOffset?: boolean;
+  }) => void;
   type PreviewSendParams = {
     renderedText: string;
     renderedParseMode: "HTML" | undefined;
@@ -197,11 +202,28 @@ export function createTelegramDraftStream(params: {
     if (!currentText) {
       return false;
     }
-    const rendered = renderTelegramDraftPreview(currentText, params.renderText);
-    const renderedText = rendered.text.trimEnd();
-    const renderedParseMode = rendered.parseMode;
+    let deliveredTextAfterSend = trimmed;
+    let rendered = renderTelegramDraftPreview(currentText, params.renderText);
+    let renderedText = rendered.text.trimEnd();
+    let renderedParseMode = rendered.parseMode;
     if (!renderedText) {
       return false;
+    }
+    if (renderedText.length > maxChars && !streamState.final) {
+      const chunkLength = findTelegramDraftChunkLength(currentText, maxChars, params.renderText);
+      const previewText = chunkLength > 0 ? currentText.slice(0, chunkLength).trimEnd() : "";
+      if (!previewText) {
+        streamState.stopped = true;
+        params.warn?.(
+          `telegram stream preview stopped (text length ${renderedText.length} > ${maxChars})`,
+        );
+        return false;
+      }
+      // Partial previews stay to one editable Telegram message; finalization owns paging.
+      deliveredTextAfterSend = `${trimmed.slice(0, deliveredTextOffset)}${previewText}`;
+      rendered = renderTelegramDraftPreview(previewText, params.renderText);
+      renderedText = rendered.text.trimEnd();
+      renderedParseMode = rendered.parseMode;
     }
     if (renderedText.length > maxChars) {
       if (lastDeliveredText.length > deliveredTextOffset) {
@@ -210,7 +232,7 @@ export function createTelegramDraftStream(params: {
         const supersededParseMode = lastSentParseMode;
         const supersededVisibleSinceMs = streamVisibleSinceMs;
         deliveredTextOffset = lastDeliveredText.length;
-        resetStreamToNewMessage({ keepPending: true, resetOffset: false });
+        resetStreamToNewMessage({ keepFinal: true, keepPending: true, resetOffset: false });
         if (typeof supersededMessageId === "number") {
           params.onSupersededPreview?.({
             messageId: supersededMessageId,
@@ -259,7 +281,7 @@ export function createTelegramDraftStream(params: {
       });
       if (sent) {
         previewRevision += 1;
-        lastDeliveredText = trimmed;
+        lastDeliveredText = deliveredTextAfterSend;
       }
       return sent;
     } catch (err) {
@@ -269,15 +291,39 @@ export function createTelegramDraftStream(params: {
     }
   };
 
-  const { loop, update, stop, stopForClear } = createFinalizableDraftStreamControlsForState({
+  const {
+    loop,
+    update: updateDraft,
+    stop: stopDraft,
+    stopForClear,
+  } = createFinalizableDraftStreamControlsForState({
     throttleMs,
     state: streamState,
     sendOrEditStreamMessage,
   });
 
+  const update = (text: string) => {
+    if (streamState.stopped || streamState.final) {
+      return;
+    }
+    lastRequestedText = text;
+    updateDraft(text);
+  };
+
+  const stop = async () => {
+    const requestedText = lastRequestedText.trimEnd();
+    if (requestedText && requestedText !== lastDeliveredText) {
+      streamState.final = true;
+      loop.update(lastRequestedText);
+    }
+    await stopDraft();
+  };
+
   resetStreamToNewMessage = (options) => {
     streamState.stopped = false;
-    streamState.final = false;
+    if (!options?.keepFinal) {
+      streamState.final = false;
+    }
     generation += 1;
     messageSendAttempted = false;
     streamMessageId = undefined;
@@ -288,6 +334,7 @@ export function createTelegramDraftStream(params: {
       deliveredTextOffset = 0;
     }
     if (!options?.keepPending) {
+      lastRequestedText = "";
       loop.resetPending();
     }
     loop.resetThrottleWindow();


### PR DESCRIPTION
## Summary

Fixes #84885 by keeping oversized non-final Telegram partial stream previews bound to a single editable preview message. Finalization still sends retained overflow pages, so long final answers are delivered without the interim preview burst.

The patch also keeps finalization safe after `update(long); flush(); stop()` by remembering the full requested text, and preserves the existing finality guard so post-final updates stay ignored.

## Verification

- `OPENCLAW_VITEST_MAX_WORKERS=1 /Users/fallmonkey/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/run-vitest.mjs extensions/telegram/src/draft-stream.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Review only CHANGELOG.md, extensions/telegram/src/draft-stream.ts, and extensions/telegram/src/draft-stream.test.ts. Ignore unrelated WhatsApp changes already present in the worktree."`

## Real behavior proof

Behavior addressed: Telegram partial streaming previews no longer create retained overflow pages before finalization when one long assistant turn exceeds the Bot API text limit.

Real environment tested: Local OpenClaw checkout on Node 24.14.0 using the Telegram draft-stream unit harness with mocked grammY Bot API calls.

Exact steps or command run after this patch: `OPENCLAW_VITEST_MAX_WORKERS=1 /Users/fallmonkey/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/run-vitest.mjs extensions/telegram/src/draft-stream.test.ts`

Evidence after fix: The focused test file passed with 33 tests, including non-final overflow staying in one preview message, `update(long); flush(); stop()` final overflow paging, and ignored post-final updates.

Observed result after fix: Non-final oversized previews send or edit only the bounded preview message; finalization sends the remaining overflow pages and marks prior pages retained.

What was not tested: A live Telegram bot account against the real Bot API was not exercised; the proof uses the existing mocked draft-stream transport tests.