### PR TITLE
[perf] improve reply send performance

### DIFF
--- a/extensions/telegram/src/bot-message-context.test-harness.ts
+++ b/extensions/telegram/src/bot-message-context.test-harness.ts
@@ -15,10 +15,12 @@ type BuildTelegramMessageContextForTestParams = {
   options?: BuildTelegramMessageContextParams["options"];
   cfg?: Record<string, unknown>;
   accountId?: string;
+  dmPolicy?: BuildTelegramMessageContextParams["dmPolicy"];
   historyLimit?: number;
   groupHistories?: Map<string, import("openclaw/plugin-sdk/reply-history").HistoryEntry[]>;
   ackReactionScope?: BuildTelegramMessageContextParams["ackReactionScope"];
   botApi?: Record<string, unknown>;
+  sendChatActionHandler?: BuildTelegramMessageContextParams["sendChatActionHandler"];
   runtime?: BuildTelegramMessageContextParams["runtime"];
   sessionRuntime?: BuildTelegramMessageContextParams["sessionRuntime"] | null;
   resolveGroupActivation?: BuildTelegramMessageContextParams["resolveGroupActivation"];
@@ -81,7 +83,7 @@ export async function buildTelegramMessageContextForTest(
     account: { accountId: params.accountId ?? "default" } as never,
     historyLimit: params.historyLimit ?? 0,
     groupHistories: params.groupHistories ?? new Map(),
-    dmPolicy: "open",
+    dmPolicy: params.dmPolicy ?? "open",
     allowFrom: ["*"],
     groupAllowFrom: [],
     ackReactionScope: params.ackReactionScope ?? "off",
@@ -94,7 +96,7 @@ export async function buildTelegramMessageContextForTest(
         groupConfig: { requireMention: false },
         topicConfig: undefined,
       })),
-    sendChatActionHandler: { sendChatAction: vi.fn() } as never,
+    sendChatActionHandler: params.sendChatActionHandler ?? ({ sendChatAction: vi.fn() } as never),
   });
 }
 

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -108,6 +108,7 @@ export type TelegramMessageContext = {
   skillFilter: TelegramMessageContextPayload["skillFilter"];
   sendTyping: () => Promise<void>;
   sendRecordVoice: () => Promise<void>;
+  initialTypingCueSent?: boolean;
   ackReactionPromise: Promise<boolean> | null;
   reactionApi: TelegramReactionApi | null;
   removeAckAfterReply: boolean;
@@ -366,6 +367,12 @@ export const buildTelegramMessageContext = async ({
     }))
   ) {
     return null;
+  }
+  const initialTypingCueSent = !isGroup;
+  if (initialTypingCueSent) {
+    void sendTyping().catch((err) => {
+      logVerbose(`telegram early direct typing cue failed for chat ${chatId}: ${String(err)}`);
+    });
   }
   const ensureConfiguredBindingReady = async (): Promise<boolean> => {
     if (!configuredBinding) {
@@ -641,6 +648,7 @@ export const buildTelegramMessageContext = async ({
     skillFilter,
     sendTyping,
     sendRecordVoice,
+    initialTypingCueSent,
     ackReactionPromise,
     reactionApi,
     removeAckAfterReply,

--- a/extensions/telegram/src/bot-message-context.typing.test.ts
+++ b/extensions/telegram/src/bot-message-context.typing.test.ts
@@ -1,0 +1,52 @@
+import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
+import { describe, expect, it, vi } from "vitest";
+import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
+
+describe("buildTelegramMessageContext typing", () => {
+  it("sends direct typing before session context construction", async () => {
+    const buildInboundContext = vi.fn(buildChannelInboundEventContext);
+    const sendChatAction = vi.fn(async () => undefined);
+
+    await expect(
+      buildTelegramMessageContextForTest({
+        message: {
+          chat: { id: 42, type: "private", first_name: "Pat" },
+          from: { id: 42, first_name: "Pat" },
+          text: "hello",
+        },
+        sendChatActionHandler: { sendChatAction },
+        sessionRuntime: {
+          buildChannelInboundEventContext: buildInboundContext,
+        },
+      }),
+    ).resolves.not.toBeNull();
+
+    expect(sendChatAction).toHaveBeenCalledWith(42, "typing", undefined);
+    expect(sendChatAction.mock.invocationCallOrder[0]).toBeLessThan(
+      buildInboundContext.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does not send early direct typing before DM access passes", async () => {
+    const sendChatAction = vi.fn(async () => undefined);
+
+    await expect(
+      buildTelegramMessageContextForTest({
+        message: {
+          chat: { id: 42, type: "private", first_name: "Pat" },
+          from: { id: 42, first_name: "Pat" },
+          text: "hello",
+        },
+        cfg: {
+          agents: { defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/openclaw" } },
+          channels: { telegram: { dmPolicy: "disabled", allowFrom: [] } },
+          messages: { groupChat: { mentionPatterns: [] } },
+        },
+        dmPolicy: "disabled",
+        sendChatActionHandler: { sendChatAction },
+      }),
+    ).resolves.toBeNull();
+
+    expect(sendChatAction).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1726,6 +1726,35 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(editMessageTelegram).not.toHaveBeenCalled();
   });
 
+  it("does not stream text-only tool results into progress drafts", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await dispatcherOptions.deliver(
+          { text: "stdout line one\nstdout line two" },
+          { kind: "tool" },
+        );
+        await replyOptions?.onItemEvent?.({ kind: "search", progressText: "docs lookup" });
+        return { queuedFinal: false };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+    });
+
+    expect(answerDraftStream.update).not.toHaveBeenCalledWith(
+      expect.stringContaining("stdout line one"),
+    );
+    expect(answerDraftStream.update).toHaveBeenLastCalledWith(
+      "Shelling\n\n`🛠️ Exec`\n`🔎 Web Search: docs lookup`",
+    );
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("does not restart progress drafts after final answer delivery", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1463,18 +1463,23 @@ export const dispatchTelegramMessage = async ({
                         reasoningStepState.noteReasoningHint();
                       }
                       if (segment.lane === "answer" && info.kind === "tool") {
-                        if (
-                          nativeToolProgressDraft &&
-                          canUseNativeToolProgressDraft({
-                            payload: effectivePayload,
-                            reply,
-                            buttons: telegramButtons,
-                          })
-                        ) {
+                        const canRepresentAsTransientProgress = canUseNativeToolProgressDraft({
+                          payload: effectivePayload,
+                          reply,
+                          buttons: telegramButtons,
+                        });
+                        if (nativeToolProgressDraft && canRepresentAsTransientProgress) {
                           if (await pushStreamToolProgress(segment.update.text)) {
                             blockDelivered = true;
                             continue;
                           }
+                        }
+                        if (
+                          canRepresentAsTransientProgress &&
+                          streamMode === "progress" &&
+                          answerLane.stream
+                        ) {
+                          continue;
                         }
                         await prepareAnswerLaneForToolProgress();
                       }

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -160,7 +160,10 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
           (options?.ingressBuffer ? ` buffer=${options.ingressBuffer}` : ""),
       );
     }
-    if (context.ctxPayload.InboundEventKind !== "room_event") {
+    if (
+      context.ctxPayload.InboundEventKind !== "room_event" &&
+      context.initialTypingCueSent !== true
+    ) {
       void context.sendTyping().catch((err) => {
         logVerbose(`telegram early typing cue failed for chat ${context.chatId}: ${String(err)}`);
       });

--- a/src/auto-reply/reply/dispatch-acp-delivery.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.test.ts
@@ -240,7 +240,7 @@ describe("createAcpDispatchDeliveryCoordinator", () => {
     expect(coordinator.getRoutedCounts().block).toBe(0);
   });
 
-  it("waits for direct block dispatcher delivery before resolving block delivery", async () => {
+  it("does not wait for direct block dispatcher delivery before resolving block delivery", async () => {
     const delivered: unknown[] = [];
     let releaseDelivery: (() => void) | undefined;
     let markDeliveryStarted: (() => void) | undefined;
@@ -276,13 +276,68 @@ describe("createAcpDispatchDeliveryCoordinator", () => {
     });
 
     await deliveryStarted;
+    await Promise.resolve();
 
     expect(delivered).toEqual([{ text: "hello" }]);
-    expect(deliverySettled).toBe(false);
+    expect(deliverySettled).toBe(true);
 
     releaseDelivery?.();
     await expect(deliveryPromise).resolves.toBe(true);
     expect(deliverySettled).toBe(true);
+    await dispatcher.waitForIdle();
+  });
+
+  it("waits for pending direct block delivery before resolving tool delivery", async () => {
+    const delivered: unknown[] = [];
+    let releaseDelivery: (() => void) | undefined;
+    let markDeliveryStarted: (() => void) | undefined;
+    const deliveryStarted = new Promise<void>((resolve) => {
+      markDeliveryStarted = resolve;
+    });
+    const deliveryGate = new Promise<void>((resolve) => {
+      releaseDelivery = resolve;
+    });
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload) => {
+        delivered.push(payload);
+        markDeliveryStarted?.();
+        await deliveryGate;
+      },
+    });
+    const coordinator = createAcpDispatchDeliveryCoordinator({
+      cfg: createAcpTestConfig(),
+      ctx: buildTestCtx({
+        Provider: "visiblechat",
+        Surface: "visiblechat",
+        SessionKey: "agent:codex-acp:session-1",
+      }),
+      dispatcher,
+      inboundAudio: false,
+      shouldRouteToOriginating: false,
+    });
+
+    await expect(coordinator.deliver("block", { text: "hello" }, { skipTts: true })).resolves.toBe(
+      true,
+    );
+    await deliveryStarted;
+
+    let toolDeliverySettled = false;
+    const toolDeliveryPromise = coordinator
+      .deliver("tool", { text: "tool result" }, { skipTts: true })
+      .then((result) => {
+        toolDeliverySettled = true;
+        return result;
+      });
+
+    await Promise.resolve();
+
+    expect(delivered).toEqual([{ text: "hello" }]);
+    expect(toolDeliverySettled).toBe(false);
+
+    releaseDelivery?.();
+    await expect(toolDeliveryPromise).resolves.toBe(true);
+    expect(toolDeliverySettled).toBe(true);
+    expect(delivered).toEqual([{ text: "hello" }, { text: "tool result" }]);
   });
 
   it("stops waiting for direct block delivery when the ACP dispatch aborts", async () => {

--- a/src/auto-reply/reply/dispatch-acp-delivery.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.ts
@@ -234,11 +234,20 @@ export function createAcpDispatchDeliveryCoordinator(params: {
     },
     toolMessageByCallId: new Map(),
   };
+  let hasPendingDirectBlockReplyDelivery = false;
+  const waitForPendingDirectBlockReplyDelivery = async () => {
+    if (!hasPendingDirectBlockReplyDelivery) {
+      return;
+    }
+    hasPendingDirectBlockReplyDelivery = false;
+    await waitForReplyDispatcherIdle(params.dispatcher, params.abortSignal);
+  };
   const settleDirectVisibleText = async () => {
     if (state.settledDirectVisibleText || state.queuedDirectVisibleTextDeliveries === 0) {
       return;
     }
     state.settledDirectVisibleText = true;
+    hasPendingDirectBlockReplyDelivery = false;
     await params.dispatcher.waitForIdle();
     const failedCounts = params.dispatcher.getFailedCounts();
     const failedVisibleCount = failedCounts.block + failedCounts.final;
@@ -440,6 +449,10 @@ export function createAcpDispatchDeliveryCoordinator(params: {
       return true;
     }
 
+    if (kind === "tool") {
+      await waitForPendingDirectBlockReplyDelivery();
+    }
+
     const tracksVisibleText = await shouldTreatDeliveredTextAsVisible({
       channel: directChannel,
       kind,
@@ -462,7 +475,7 @@ export function createAcpDispatchDeliveryCoordinator(params: {
       state.failedVisibleTextDelivery = true;
     }
     if (kind === "block" && delivered) {
-      await waitForReplyDispatcherIdle(params.dispatcher, params.abortSignal);
+      hasPendingDirectBlockReplyDelivery = true;
     }
     return delivered;
   };

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -5469,7 +5469,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(callOrder).toEqual(["queued:The answer is 42", "dispatch:The answer is 42"]);
   });
 
-  it("waits for same-channel block dispatcher delivery before resolving block replies", async () => {
+  it("does not wait for same-channel block dispatcher delivery before resolving block replies", async () => {
     setNoAbort();
     const ctx = buildTestCtx({ Provider: "whatsapp" });
     const delivered: ReplyPayload[] = [];
@@ -5502,10 +5502,10 @@ describe("dispatchReplyFromConfig", () => {
       await deliveryStarted;
 
       expect(delivered).toEqual([{ text: "before tool" }]);
-      expect(blockReplySettled).toBe(false);
+      await blockReplyPromise;
+      expect(blockReplySettled).toBe(true);
 
       releaseDelivery?.();
-      await blockReplyPromise;
       return undefined;
     };
 
@@ -5517,6 +5517,65 @@ describe("dispatchReplyFromConfig", () => {
     });
 
     expect(blockReplySettled).toBe(true);
+    await dispatcher.waitForIdle();
+  });
+
+  it("waits for pending same-channel block delivery before forwarding tool progress", async () => {
+    setNoAbort();
+    const cfg = {
+      agents: { defaults: { verboseDefault: "on" } },
+    } as const satisfies OpenClawConfig;
+    const ctx = buildTestCtx({ Provider: "whatsapp" });
+    const delivered: ReplyPayload[] = [];
+    let releaseDelivery: (() => void) | undefined;
+    let markDeliveryStarted: (() => void) | undefined;
+    const deliveryStarted = new Promise<void>((resolve) => {
+      markDeliveryStarted = resolve;
+    });
+    const deliveryGate = new Promise<void>((resolve) => {
+      releaseDelivery = resolve;
+    });
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload) => {
+        delivered.push(payload);
+        markDeliveryStarted?.();
+        await deliveryGate;
+      },
+    });
+    const onToolStart = vi.fn();
+    let toolProgressSettled = false;
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload | undefined> => {
+      await opts?.onBlockReply?.({ text: "before tool" });
+      const toolProgressPromise = Promise.resolve(opts?.onToolStart?.({ name: "lookup" })).then(
+        () => {
+          toolProgressSettled = true;
+        },
+      );
+
+      await deliveryStarted;
+
+      expect(delivered).toEqual([{ text: "before tool" }]);
+      expect(onToolStart).not.toHaveBeenCalled();
+      expect(toolProgressSettled).toBe(false);
+
+      releaseDelivery?.();
+      await toolProgressPromise;
+      return undefined;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: { onToolStart },
+    });
+
+    expect(toolProgressSettled).toBe(true);
+    expect(onToolStart).toHaveBeenCalledWith({ name: "lookup" });
   });
 
   it("forwards payload metadata into onBlockReplyQueued context", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1881,6 +1881,14 @@ export async function dispatchReplyFromConfig(
     const onPatchSummaryFromReplyOptions = params.replyOptions?.onPatchSummary;
     const allowSuppressedSourceProgressCallbacks =
       params.replyOptions?.allowProgressCallbacksWhenSourceDeliverySuppressed === true;
+    let hasPendingDirectBlockReplyDelivery = false;
+    const waitForPendingDirectBlockReplyDelivery = async (abortSignal?: AbortSignal) => {
+      if (!hasPendingDirectBlockReplyDelivery) {
+        return;
+      }
+      hasPendingDirectBlockReplyDelivery = false;
+      await waitForReplyDispatcherIdle(dispatcher, abortSignal);
+    };
     const shouldForwardProgressCallback = (options?: {
       forwardWhenSourceDeliverySuppressed?: boolean;
       requiresToolSummaryVisibility?: boolean;
@@ -1900,9 +1908,14 @@ export async function dispatchReplyFromConfig(
         forwardWhenSourceDeliverySuppressed?: boolean;
         requiresToolSummaryVisibility?: boolean;
         onForward?: (...args: Args) => void;
+        waitForDirectBlockReplyDelivery?: boolean;
       },
     ): ((...args: Args) => Promise<void>) | undefined => {
-      if (!callback && (!suppressAutomaticSourceDelivery || !canTrackSession)) {
+      if (
+        !callback &&
+        !options?.waitForDirectBlockReplyDelivery &&
+        (!suppressAutomaticSourceDelivery || !canTrackSession)
+      ) {
         return undefined;
       }
       return async (...args: Args) => {
@@ -1910,6 +1923,12 @@ export async function dispatchReplyFromConfig(
           return;
         }
         markProgress();
+        if (options?.waitForDirectBlockReplyDelivery) {
+          await waitForPendingDirectBlockReplyDelivery(dispatchAbortOperation?.abortSignal);
+          if (isDispatchOperationAborted()) {
+            return;
+          }
+        }
         if (shouldForwardProgressCallback(options)) {
           options?.onForward?.(...args);
           await callback?.(...args);
@@ -1946,10 +1965,12 @@ export async function dispatchReplyFromConfig(
             onToolStart: wrapProgressCallback(params.replyOptions?.onToolStart, {
               forwardWhenSourceDeliverySuppressed: true,
               requiresToolSummaryVisibility: true,
+              waitForDirectBlockReplyDelivery: true,
             }),
             onItemEvent: wrapProgressCallback(params.replyOptions?.onItemEvent, {
               forwardWhenSourceDeliverySuppressed: true,
               requiresToolSummaryVisibility: true,
+              waitForDirectBlockReplyDelivery: true,
               onForward: (payload) => {
                 if (hasFailedProgressStatus(payload)) {
                   markVisibleToolErrorProgress();
@@ -1959,6 +1980,7 @@ export async function dispatchReplyFromConfig(
             onCommandOutput: wrapProgressCallback(params.replyOptions?.onCommandOutput, {
               forwardWhenSourceDeliverySuppressed: true,
               requiresToolSummaryVisibility: true,
+              waitForDirectBlockReplyDelivery: true,
               onForward: (payload) => {
                 if (hasFailedProgressStatus(payload)) {
                   markVisibleToolErrorProgress();
@@ -1968,14 +1990,20 @@ export async function dispatchReplyFromConfig(
             onCompactionStart: wrapProgressCallback(params.replyOptions?.onCompactionStart, {
               forwardWhenSourceDeliverySuppressed: true,
               requiresToolSummaryVisibility: true,
+              waitForDirectBlockReplyDelivery: true,
             }),
             onCompactionEnd: wrapProgressCallback(params.replyOptions?.onCompactionEnd, {
               forwardWhenSourceDeliverySuppressed: true,
               requiresToolSummaryVisibility: true,
+              waitForDirectBlockReplyDelivery: true,
             }),
             onToolResult: (payload: ReplyPayload) => {
               markProgress();
               const run = async () => {
+                if (isDispatchOperationAborted()) {
+                  return;
+                }
+                await waitForPendingDirectBlockReplyDelivery(dispatchAbortOperation?.abortSignal);
                 if (isDispatchOperationAborted()) {
                   return;
                 }
@@ -2040,6 +2068,10 @@ export async function dispatchReplyFromConfig(
                 return;
               }
               markProgress();
+              await waitForPendingDirectBlockReplyDelivery(dispatchAbortOperation?.abortSignal);
+              if (isDispatchOperationAborted()) {
+                return;
+              }
               markInboundDedupeReplayUnsafe();
               if (
                 shouldForwardProgressCallback({
@@ -2062,6 +2094,10 @@ export async function dispatchReplyFromConfig(
                 return;
               }
               markProgress();
+              await waitForPendingDirectBlockReplyDelivery(dispatchAbortOperation?.abortSignal);
+              if (isDispatchOperationAborted()) {
+                return;
+              }
               markInboundDedupeReplayUnsafe();
               if (
                 shouldForwardProgressCallback({
@@ -2092,6 +2128,10 @@ export async function dispatchReplyFromConfig(
                 return;
               }
               markProgress();
+              await waitForPendingDirectBlockReplyDelivery(dispatchAbortOperation?.abortSignal);
+              if (isDispatchOperationAborted()) {
+                return;
+              }
               markInboundDedupeReplayUnsafe();
               if (
                 shouldForwardProgressCallback({
@@ -2198,7 +2238,7 @@ export async function dispatchReplyFromConfig(
                   markInboundDedupeReplayUnsafe();
                   const delivered = dispatcher.sendBlockReply(normalizedPayload);
                   if (delivered) {
-                    await waitForReplyDispatcherIdle(dispatcher, context?.abortSignal);
+                    hasPendingDirectBlockReplyDelivery = true;
                   }
                 }
               };

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -1455,6 +1455,145 @@ describe("gateway send mirroring", () => {
     });
   });
 
+  it("does not block message.action responses on source transcript mirroring", async () => {
+    const telegramPlugin: ChannelPlugin = {
+      id: "telegram",
+      meta: {
+        id: "telegram",
+        label: "Telegram",
+        selectionLabel: "Telegram",
+        docsPath: "/channels/telegram",
+        blurb: "Telegram async source send transcript mirror test plugin.",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => ["default"],
+        resolveAccount: () => ({ enabled: true }),
+        isConfigured: () => true,
+      },
+      actions: {
+        describeMessageTool: () => ({ actions: ["send"] }),
+        supportsAction: ({ action }) => action === "send",
+        handleAction: async () => jsonResult({ ok: true, messageId: "tg-async-1" }),
+      },
+    };
+    const mirrorDeferred = createDeferred<{ ok: boolean; sessionFile: string }>();
+    mocks.getChannelPlugin.mockReturnValue(telegramPlugin);
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "telegram", source: "test", plugin: telegramPlugin }]),
+      "send-test-source-message-action-async-mirror",
+    );
+    mocks.dispatchChannelMessageAction.mockResolvedValueOnce(
+      jsonResult({ ok: true, messageId: "tg-async-1" }),
+    );
+    mocks.appendAssistantMessageToSessionTranscript.mockReturnValueOnce(mirrorDeferred.promise);
+
+    const { respond } = await runMessageActionRequest({
+      channel: "telegram",
+      action: "send",
+      params: {
+        to: "chat-123",
+        message: "visible media caption",
+      },
+      sessionKey: "agent:main:telegram:direct:chat-123",
+      agentId: "main",
+      toolContext: {
+        currentChannelProvider: "telegram",
+        currentChannelId: "chat-123",
+      },
+      idempotencyKey: "idem-async-source-message-action",
+    });
+
+    expect(firstRespondCall(respond)[0]).toBe(true);
+    expect(mocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledTimes(1);
+
+    mirrorDeferred.resolve({ ok: true, sessionFile: "x" });
+    await Promise.resolve();
+  });
+
+  it("preserves source transcript mirror order without blocking message.action responses", async () => {
+    const telegramPlugin: ChannelPlugin = {
+      id: "telegram",
+      meta: {
+        id: "telegram",
+        label: "Telegram",
+        selectionLabel: "Telegram",
+        docsPath: "/channels/telegram",
+        blurb: "Telegram ordered async source send transcript mirror test plugin.",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => ["default"],
+        resolveAccount: () => ({ enabled: true }),
+        isConfigured: () => true,
+      },
+      actions: {
+        describeMessageTool: () => ({ actions: ["send"] }),
+        supportsAction: ({ action }) => action === "send",
+        handleAction: async () => jsonResult({ ok: true, messageId: "tg-ordered" }),
+      },
+    };
+    const firstMirrorDeferred = createDeferred<{ ok: boolean; sessionFile: string }>();
+    mocks.getChannelPlugin.mockReturnValue(telegramPlugin);
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "telegram", source: "test", plugin: telegramPlugin }]),
+      "send-test-source-message-action-ordered-async-mirror",
+    );
+    mocks.dispatchChannelMessageAction.mockResolvedValue(
+      jsonResult({ ok: true, messageId: "tg-ordered" }),
+    );
+    mocks.appendAssistantMessageToSessionTranscript
+      .mockReturnValueOnce(firstMirrorDeferred.promise)
+      .mockResolvedValueOnce({ ok: true, sessionFile: "x" });
+
+    const first = await runMessageActionRequest({
+      channel: "telegram",
+      action: "send",
+      params: {
+        to: "chat-123",
+        message: "first visible reply",
+      },
+      sessionKey: "agent:main:telegram:direct:chat-123",
+      agentId: "main",
+      toolContext: {
+        currentChannelProvider: "telegram",
+        currentChannelId: "chat-123",
+      },
+      idempotencyKey: "idem-ordered-source-message-action-1",
+    });
+    const second = await runMessageActionRequest({
+      channel: "telegram",
+      action: "send",
+      params: {
+        to: "chat-123",
+        message: "second visible reply",
+      },
+      sessionKey: "agent:main:telegram:direct:chat-123",
+      agentId: "main",
+      toolContext: {
+        currentChannelProvider: "telegram",
+        currentChannelId: "chat-123",
+      },
+      idempotencyKey: "idem-ordered-source-message-action-2",
+    });
+
+    expect(firstRespondCall(first.respond)[0]).toBe(true);
+    expect(firstRespondCall(second.respond)[0]).toBe(true);
+    expect(mocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledTimes(1);
+    expect(mocks.appendAssistantMessageToSessionTranscript.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({ text: "first visible reply" }),
+    );
+
+    firstMirrorDeferred.resolve({ ok: true, sessionFile: "x" });
+    await vi.waitFor(() => {
+      expect(mocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mocks.appendAssistantMessageToSessionTranscript.mock.calls[1]?.[0]).toEqual(
+      expect.objectContaining({ text: "second visible reply" }),
+    );
+  });
+
   it("mirrors presentation-only source-conversation message.action sends", async () => {
     const telegramPlugin: ChannelPlugin = {
       id: "telegram",

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -280,6 +280,34 @@ async function mirrorDeliveredSourceReplyToTranscriptBestEffort(params: {
   }
 }
 
+const sourceReplyTranscriptMirrorQueues = new Map<string, Promise<void>>();
+
+function resolveSourceReplyTranscriptMirrorQueueKey(
+  mirror: Parameters<typeof mirrorDeliveredSourceReplyToTranscript>[0],
+): string {
+  return mirror.sessionKey?.trim() || "__global__";
+}
+
+function scheduleDeliveredSourceReplyTranscriptMirror(params: {
+  context: GatewayRequestContext;
+  mirror: Parameters<typeof mirrorDeliveredSourceReplyToTranscript>[0];
+}) {
+  const queueKey = resolveSourceReplyTranscriptMirrorQueueKey(params.mirror);
+  const previous = sourceReplyTranscriptMirrorQueues.get(queueKey);
+  const queued = (async () => {
+    await previous?.catch(() => undefined);
+    await mirrorDeliveredSourceReplyToTranscriptBestEffort(params);
+  })();
+  sourceReplyTranscriptMirrorQueues.set(queueKey, queued);
+  void queued
+    .finally(() => {
+      if (sourceReplyTranscriptMirrorQueues.get(queueKey) === queued) {
+        sourceReplyTranscriptMirrorQueues.delete(queueKey);
+      }
+    })
+    .catch(() => undefined);
+}
+
 export const sendHandlers: GatewayRequestHandlers = {
   "message.action": async ({ params, respond, context, client }) => {
     const p = params;
@@ -391,7 +419,7 @@ export const sendHandlers: GatewayRequestHandlers = {
         const agentId =
           normalizeOptionalString(request.agentId) ??
           (sessionKey ? resolveSessionAgentId({ sessionKey, config: cfg }) : undefined);
-        await mirrorDeliveredSourceReplyToTranscriptBestEffort({
+        scheduleDeliveredSourceReplyTranscriptMirror({
           context,
           mirror: {
             action: request.action,


### PR DESCRIPTION
## Summary
- improve reply latency by avoiding dispatcher-idle waits on every direct block reply callback
- flush pending block delivery only before subsequent tool/progress events, preserving block-before-tool ordering
- keep ACP direct block replies non-blocking while preserving visible reply chronology
- schedule source reply transcript mirroring after successful `message.action` sends without blocking the gateway response
- serialize async source transcript mirrors per session so same-session transcript chronology is preserved
- send Telegram direct-message typing once access has passed, before later context/session construction can delay the indicator, while avoiding a duplicate immediate cue

## Root Cause
Recent reply-path changes moved delivery bookkeeping into hot paths for lightweight replies: block callbacks waited for dispatcher idle, and `message.action` waited for transcript mirroring after platform delivery. Under concurrent embedded runs, cron work, or slow channel/transcript I/O, this amplified reply latency and event-loop starvation. The 36-54h window also includes Telegram dispatch replay dedupe changes that added work before the existing typing cue path.

## Impact
Simple visible replies can return sooner without compromising user-visible send order. The existing block-before-tool/progress ordering guarantee is preserved by flushing only when later progress is about to be emitted. Transcript mirroring remains best-effort and still runs after successful source-conversation sends, with per-session ordering to avoid mirrored transcript reordering. Telegram direct typing starts earlier after authorization without sending an extra duplicate initial cue.

## Validation
- `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts src/auto-reply/reply/dispatch-acp-delivery.test.ts src/gateway/server-methods/send.test.ts extensions/telegram/src/bot-message-context.typing.test.ts extensions/telegram/src/bot-message.test.ts`
- `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-context.typing.test.ts extensions/telegram/src/bot-message.test.ts`
- `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-context.typing.test.ts`
- `git diff --check`