### PR TITLE
fix(agents): treat aborted subagent runs as terminal [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Docs: https://docs.openclaw.ai
 - Discord/voice: keep realtime playback running when meeting notes attaches to an existing voice session or a realtime consult starts, and route realtime user transcripts into meeting notes.
 - WebChat: keep the run-complete indicator in progress until deferred history replay renders the assistant reply, so Done no longer appears before response text. (#85374) Thanks @neeravmakwana.
 - Agents/tools: give timed-out or cancelled process trees a bounded SIGTERM cleanup window before SIGKILL while preserving tree-aware cancellation. Fixes #66399. (#85865) Thanks @IWhatsskill.
+- Agents/subagents: treat aborted subagent stop reasons as killed terminal failures so parent sessions get error announcements instead of silent success. Fixes #72293. (#85860) Thanks @IWhatsskill.
 - Agents/compaction: skip agent-harness preflight for provider-owned CLI runtime sessions so over-threshold Claude CLI sessions continue through normal compaction instead of failing on a missing harness. Fixes #84857. (#84878) Thanks @zhangguiping-xydt.
 - Control UI/config: save form-mode edits from the source config snapshot so runtime-only provider defaults like empty `models.providers.<id>.baseUrl` are not written back and rejected. Fixes #85831. Thanks @garyd9.
 - Browser/existing-session: launch Chrome DevTools MCP with usage statistics disabled by default so its telemetry watchdog stays off unless an operator explicitly opts in. (#85886) Thanks @rohitjavvadi.

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
@@ -3,8 +3,12 @@ import { createInlineCodeState } from "../markdown/code-spans.js";
 import { handleAgentEnd } from "./pi-embedded-subscribe.handlers.lifecycle.js";
 import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
 
+const { emitAgentEventMock } = vi.hoisted(() => ({
+  emitAgentEventMock: vi.fn(),
+}));
+
 vi.mock("../infra/agent-events.js", () => ({
-  emitAgentEvent: vi.fn(),
+  emitAgentEvent: emitAgentEventMock,
 }));
 
 function createContext(
@@ -110,6 +114,31 @@ describe("handleAgentEnd", () => {
         phase: "error",
         error: "LLM request failed: connection refused by the provider endpoint.",
         livenessState: "blocked",
+      },
+    });
+  });
+
+  it("emits aborted terminal stop reasons on lifecycle end events", async () => {
+    emitAgentEventMock.mockClear();
+    const onAgentEvent = vi.fn();
+    const ctx = createContext(undefined, { onAgentEvent });
+    ctx.state.terminalStopReason = "aborted";
+
+    await handleAgentEnd(ctx);
+
+    expect(emitAgentEventMock).toHaveBeenCalledWith({
+      runId: "run-1",
+      stream: "lifecycle",
+      data: expect.objectContaining({
+        phase: "end",
+        stopReason: "aborted",
+      }),
+    });
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        stopReason: "aborted",
       },
     });
   });

--- a/src/agents/run-termination.ts
+++ b/src/agents/run-termination.ts
@@ -1,0 +1,8 @@
+export const AGENT_RUN_ABORTED_STOP_REASON = "aborted" as const;
+export const AGENT_RUN_ABORTED_ERROR = "agent run aborted" as const;
+
+export function isAbortedAgentStopReason(
+  value: unknown,
+): value is typeof AGENT_RUN_ABORTED_STOP_REASON {
+  return value === AGENT_RUN_ABORTED_STOP_REASON;
+}

--- a/src/agents/run-wait.test.ts
+++ b/src/agents/run-wait.test.ts
@@ -275,6 +275,25 @@ describe("waitForAgentRun", () => {
       livenessState: "blocked",
     });
   });
+
+  it("normalizes aborted stop reasons to errors even when gateway reports ok", async () => {
+    callGatewayMock.mockResolvedValue({
+      status: "ok",
+      startedAt: 100,
+      endedAt: 200,
+      stopReason: "aborted",
+    });
+
+    const result = await waitForAgentRun({ runId: "run-aborted", timeoutMs: 500 });
+
+    expect(result).toEqual({
+      status: "error",
+      error: "agent run aborted",
+      startedAt: 100,
+      endedAt: 200,
+      stopReason: "aborted",
+    });
+  });
 });
 
 describe("waitForAgentRunAndReadUpdatedAssistantReply", () => {

--- a/src/agents/run-wait.ts
+++ b/src/agents/run-wait.ts
@@ -1,6 +1,7 @@
 import { callGateway } from "../gateway/call.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { normalizeBlockedLivenessWaitStatus } from "../shared/agent-liveness.js";
+import { AGENT_RUN_ABORTED_ERROR, isAbortedAgentStopReason } from "./run-termination.js";
 import {
   normalizeAgentRunTimeoutPhase,
   normalizeProviderStarted,
@@ -57,17 +58,21 @@ function normalizeAgentWaitResult(
   status: AgentWaitResult["status"],
   wait?: RawAgentWaitResponse,
 ): AgentWaitResult {
+  const stopReason = typeof wait?.stopReason === "string" ? wait.stopReason : undefined;
+  const abortedStopReason = isAbortedAgentStopReason(stopReason);
+  const error =
+    abortedStopReason && typeof wait?.error !== "string" ? AGENT_RUN_ABORTED_ERROR : wait?.error;
   const normalized = normalizeBlockedLivenessWaitStatus({
-    status,
+    status: abortedStopReason ? "error" : status,
     livenessState: wait?.livenessState,
-    error: wait?.error,
+    error,
   });
   return {
     status: normalized.status,
     error: normalized.error,
     startedAt: typeof wait?.startedAt === "number" ? wait.startedAt : undefined,
     endedAt: typeof wait?.endedAt === "number" ? wait.endedAt : undefined,
-    stopReason: typeof wait?.stopReason === "string" ? wait.stopReason : undefined,
+    stopReason,
     livenessState: typeof wait?.livenessState === "string" ? wait.livenessState : undefined,
     yielded: wait?.yielded === true ? true : undefined,
     timeoutPhase: normalizeAgentRunTimeoutPhase(wait?.timeoutPhase),

--- a/src/agents/subagent-announce-output.test.ts
+++ b/src/agents/subagent-announce-output.test.ts
@@ -279,4 +279,24 @@ describe("applySubagentWaitOutcome", () => {
       elapsedMs: 50,
     });
   });
+
+  it("treats aborted ok wait snapshots as terminated subagent errors", () => {
+    const applied = applySubagentWaitOutcome({
+      wait: {
+        status: "ok",
+        startedAt: 100,
+        endedAt: 150,
+        stopReason: "aborted",
+      },
+      outcome: undefined,
+    });
+
+    expect(applied.outcome).toEqual({
+      status: "error",
+      error: "subagent run terminated",
+      startedAt: 100,
+      endedAt: 150,
+      elapsedMs: 50,
+    });
+  });
 });

--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -1,5 +1,6 @@
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { formatBlockedLivenessError, isBlockedLivenessState } from "../shared/agent-liveness.js";
+import { isAbortedAgentStopReason } from "./run-termination.js";
 import { wrapPromptDataBlock } from "./sanitize-for-prompt.js";
 import {
   captureSubagentCompletionReplyUsing,
@@ -280,6 +281,8 @@ export function applySubagentWaitOutcome(params: {
   // Capture/announcement callers can pass raw wait snapshots that bypass the primary normalizers.
   if (isBlockedLivenessState(params.wait?.livenessState)) {
     outcome = { status: "error", error: formatBlockedLivenessError(waitError) };
+  } else if (isAbortedAgentStopReason(params.wait?.stopReason)) {
+    outcome = { status: "error", error: "subagent run terminated" };
   } else if (params.wait?.status === "timeout") {
     outcome = { status: "timeout" };
   } else if (params.wait?.status === "error") {

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -8,10 +8,15 @@ import { createRunningTaskRun } from "../tasks/detached-task-runtime.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
 import { removeInternalSessionEffectsTranscript } from "./internal-session-effects.js";
+import { isAbortedAgentStopReason } from "./run-termination.js";
 import { isRecoverableAgentWaitError, waitForAgentRun } from "./run-wait.js";
 import type { ensureRuntimePluginsLoaded as ensureRuntimePluginsLoadedFn } from "./runtime-plugins.js";
 import { type SubagentRunOutcome, withSubagentOutcomeTiming } from "./subagent-announce-output.js";
-import { ensureCompletionState, normalizeSubagentRunState } from "./subagent-delivery-state.js";
+import {
+  clearDeliveryState,
+  ensureCompletionState,
+  normalizeSubagentRunState,
+} from "./subagent-delivery-state.js";
 import {
   SUBAGENT_ENDED_OUTCOME_KILLED,
   SUBAGENT_ENDED_REASON_COMPLETE,
@@ -192,6 +197,7 @@ export function createSubagentRunManager(params: {
         return;
       }
       const waitBlocked = isBlockedLivenessState(wait.livenessState);
+      const waitAborted = isAbortedAgentStopReason(wait.stopReason);
       if (wait.yielded === true && !waitBlocked) {
         if (
           markSubagentRunPausedAfterYield({
@@ -204,8 +210,8 @@ export function createSubagentRunManager(params: {
         }
         return;
       }
-      const waitStatus = waitBlocked ? "error" : wait.status;
-      if (waitStatus === "error" && isRecoverableAgentWaitError(wait.error)) {
+      const waitStatus = waitBlocked || waitAborted ? "error" : wait.status;
+      if (waitStatus === "error" && !waitAborted && isRecoverableAgentWaitError(wait.error)) {
         scheduleWaitRetry(entry, "subagent wait interrupted; scheduling recovery", wait.error);
         return;
       }
@@ -268,7 +274,11 @@ export function createSubagentRunManager(params: {
         mutated = true;
       }
       const rawWaitError = typeof wait.error === "string" ? wait.error : undefined;
-      const waitError = waitBlocked ? formatBlockedLivenessError(rawWaitError) : rawWaitError;
+      const waitError = waitAborted
+        ? "subagent run terminated"
+        : waitBlocked
+          ? formatBlockedLivenessError(rawWaitError)
+          : rawWaitError;
       const baseOutcome: SubagentRunOutcome =
         waitStatus === "error" ? { status: "error", error: waitError } : { status: "ok" };
       const outcome = withSubagentOutcomeTiming(baseOutcome, {
@@ -286,8 +296,11 @@ export function createSubagentRunManager(params: {
         runId,
         endedAt: entry.endedAt,
         outcome,
-        reason:
-          waitStatus === "error" ? SUBAGENT_ENDED_REASON_ERROR : SUBAGENT_ENDED_REASON_COMPLETE,
+        reason: waitAborted
+          ? SUBAGENT_ENDED_REASON_KILLED
+          : waitStatus === "error"
+            ? SUBAGENT_ENDED_REASON_ERROR
+            : SUBAGENT_ENDED_REASON_COMPLETE,
         sendFarewell: true,
         accountId: entry.requesterOrigin?.accountId,
         triggerCleanup: true,
@@ -454,6 +467,7 @@ export function createSubagentRunManager(params: {
       archiveAtMs,
       runTimeoutSeconds,
     });
+    clearDeliveryState(next);
 
     params.runs.set(nextRunId, next);
     params.ensureListener();

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -602,6 +602,56 @@ describe("subagent registry seam flow", () => {
     expect(run?.outcome?.status).toBe("error");
   });
 
+  it("announces aborted agent.wait snapshots as killed subagent failures", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return {
+          status: "ok",
+          startedAt: 100,
+          endedAt: 250,
+          stopReason: "aborted",
+        };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-aborted-wait",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "aborted wait",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+    });
+
+    await waitForFast(() => {
+      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    });
+    const announceParams = expectRecordFields(
+      getMockCallArg(mocks.runSubagentAnnounceFlow, 0, 0, "aborted wait announce"),
+      { childRunId: "run-aborted-wait" },
+      "aborted wait announce params",
+    );
+    expectRecordFields(
+      announceParams.outcome,
+      {
+        status: "error",
+        error: "subagent run terminated",
+        startedAt: 100,
+        endedAt: 250,
+        elapsedMs: 150,
+      },
+      "aborted wait announce outcome",
+    );
+
+    const run = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-aborted-wait");
+    expect(run?.endedReason).toBe("subagent-killed");
+    expect(run?.outcome?.status).toBe("error");
+  });
+
   it("reconciles stale active runs from persisted terminal session state during sweep", async () => {
     mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
       if (request.method === "agent.wait") {
@@ -914,6 +964,78 @@ describe("subagent registry seam flow", () => {
       .listSubagentRunsForRequester("agent:main:main")
       .find((entry) => entry.runId === "run-blocked-end");
     expect(run?.endedReason).toBe("subagent-error");
+    expect(run?.outcome?.status).toBe("error");
+  });
+
+  it("announces aborted lifecycle end events as killed subagent failures", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-aborted-end",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "aborted task",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-aborted-end",
+      stream: "lifecycle",
+      data: {
+        phase: "start",
+        startedAt: 10,
+      },
+    });
+    lifecycleHandler?.({
+      runId: "run-aborted-end",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: 10,
+        endedAt: 20,
+        stopReason: "aborted",
+      },
+    });
+
+    await waitForFast(() => {
+      expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    });
+    const announceParams = expectRecordFields(
+      getMockCallArg(mocks.runSubagentAnnounceFlow, 0, 0, "aborted announce"),
+      { childRunId: "run-aborted-end" },
+      "aborted announce params",
+    );
+    expectRecordFields(
+      announceParams.outcome,
+      {
+        status: "error",
+        error: "subagent run terminated",
+        startedAt: 10,
+        endedAt: 20,
+        elapsedMs: 10,
+      },
+      "aborted announce outcome",
+    );
+
+    const run = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-aborted-end");
+    expect(run?.endedReason).toBe("subagent-killed");
     expect(run?.outcome?.status).toBe("error");
   });
 

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -1008,6 +1008,7 @@ describe("subagent registry seam flow", () => {
         phase: "end",
         startedAt: 10,
         endedAt: 20,
+        aborted: true,
         stopReason: "aborted",
       },
     });
@@ -1037,6 +1038,9 @@ describe("subagent registry seam flow", () => {
       .find((entry) => entry.runId === "run-aborted-end");
     expect(run?.endedReason).toBe("subagent-killed");
     expect(run?.outcome?.status).toBe("error");
+
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
   });
 
   it("preserves run-mode keep entries past SESSION_RUN_TTL_MS sweep", async () => {

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -1009,6 +1009,7 @@ describe("subagent registry seam flow", () => {
         startedAt: 10,
         endedAt: 20,
         aborted: true,
+        livenessState: "blocked",
         stopReason: "aborted",
       },
     });

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -1016,13 +1016,6 @@ function ensureListener() {
         });
         return;
       }
-      if (evt.data?.aborted) {
-        schedulePendingLifecycleTimeout({
-          runId: evt.runId,
-          endedAt,
-        });
-        return;
-      }
       if (isAbortedAgentStopReason(stopReason)) {
         clearPendingLifecycleError(evt.runId);
         clearPendingLifecycleTimeout(evt.runId);
@@ -1037,6 +1030,13 @@ function ensureListener() {
           sendFarewell: true,
           accountId: entry.requesterOrigin?.accountId,
           triggerCleanup: true,
+        });
+        return;
+      }
+      if (evt.data?.aborted) {
+        schedulePendingLifecycleTimeout({
+          runId: evt.runId,
+          endedAt,
         });
         return;
       }

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -12,6 +12,7 @@ import { importRuntimeModule } from "../shared/runtime-import.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
 import { removeInternalSessionEffectsTranscript } from "./internal-session-effects.js";
+import { isAbortedAgentStopReason } from "./run-termination.js";
 import type { ensureRuntimePluginsLoaded as ensureRuntimePluginsLoadedFn } from "./runtime-plugins.js";
 import {
   ensureCompletionState,
@@ -989,6 +990,7 @@ function ensureListener() {
       const error = typeof evt.data?.error === "string" ? evt.data.error : undefined;
       const livenessState =
         typeof evt.data?.livenessState === "string" ? evt.data.livenessState : undefined;
+      const stopReason = typeof evt.data?.stopReason === "string" ? evt.data.stopReason : undefined;
       if (phase === "error") {
         schedulePendingLifecycleError({
           runId: evt.runId,
@@ -1018,6 +1020,23 @@ function ensureListener() {
         schedulePendingLifecycleTimeout({
           runId: evt.runId,
           endedAt,
+        });
+        return;
+      }
+      if (isAbortedAgentStopReason(stopReason)) {
+        clearPendingLifecycleError(evt.runId);
+        clearPendingLifecycleTimeout(evt.runId);
+        await completeSubagentRun({
+          runId: evt.runId,
+          endedAt,
+          outcome: {
+            status: "error",
+            error: "subagent run terminated",
+          },
+          reason: SUBAGENT_ENDED_REASON_KILLED,
+          sendFarewell: true,
+          accountId: entry.requesterOrigin?.accountId,
+          triggerCleanup: true,
         });
         return;
       }

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -999,23 +999,6 @@ function ensureListener() {
         });
         return;
       }
-      if (isBlockedLivenessState(livenessState)) {
-        clearPendingLifecycleError(evt.runId);
-        clearPendingLifecycleTimeout(evt.runId);
-        await completeSubagentRun({
-          runId: evt.runId,
-          endedAt,
-          outcome: {
-            status: "error",
-            error: formatBlockedLivenessError(error),
-          },
-          reason: SUBAGENT_ENDED_REASON_ERROR,
-          sendFarewell: true,
-          accountId: entry.requesterOrigin?.accountId,
-          triggerCleanup: true,
-        });
-        return;
-      }
       if (isAbortedAgentStopReason(stopReason)) {
         clearPendingLifecycleError(evt.runId);
         clearPendingLifecycleTimeout(evt.runId);
@@ -1027,6 +1010,23 @@ function ensureListener() {
             error: "subagent run terminated",
           },
           reason: SUBAGENT_ENDED_REASON_KILLED,
+          sendFarewell: true,
+          accountId: entry.requesterOrigin?.accountId,
+          triggerCleanup: true,
+        });
+        return;
+      }
+      if (isBlockedLivenessState(livenessState)) {
+        clearPendingLifecycleError(evt.runId);
+        clearPendingLifecycleTimeout(evt.runId);
+        await completeSubagentRun({
+          runId: evt.runId,
+          endedAt,
+          outcome: {
+            status: "error",
+            error: formatBlockedLivenessError(error),
+          },
+          reason: SUBAGENT_ENDED_REASON_ERROR,
           sendFarewell: true,
           accountId: entry.requesterOrigin?.accountId,
           triggerCleanup: true,

--- a/src/gateway/server-methods/agent-job.ts
+++ b/src/gateway/server-methods/agent-job.ts
@@ -1,3 +1,4 @@
+import { AGENT_RUN_ABORTED_ERROR, isAbortedAgentStopReason } from "../../agents/run-termination.js";
 import {
   normalizeAgentRunTimeoutPhase,
   normalizeProviderStarted,
@@ -149,7 +150,10 @@ function createSnapshotFromLifecycleEvent(params: {
   const stopReason = typeof data?.stopReason === "string" ? data.stopReason : undefined;
   const livenessState = typeof data?.livenessState === "string" ? data.livenessState : undefined;
   const blocked = isBlockedLivenessState(livenessState);
-  const status = phase === "error" || blocked ? "error" : data?.aborted ? "timeout" : "ok";
+  const abortedStopReason = isAbortedAgentStopReason(stopReason);
+  const status =
+    phase === "error" || blocked || abortedStopReason ? "error" : data?.aborted ? "timeout" : "ok";
+  const resolvedError = abortedStopReason && !error ? AGENT_RUN_ABORTED_ERROR : error;
   const timeoutPhase =
     status === "timeout" ? normalizeAgentRunTimeoutPhase(data?.timeoutPhase) : undefined;
   const providerStarted = normalizeProviderStarted(data?.providerStarted);
@@ -158,7 +162,7 @@ function createSnapshotFromLifecycleEvent(params: {
     status,
     startedAt,
     endedAt,
-    error: blocked ? formatBlockedLivenessError(error) : error,
+    error: blocked ? formatBlockedLivenessError(resolvedError) : resolvedError,
     stopReason,
     livenessState,
     ...(data?.yielded === true ? { yielded: true } : {}),

--- a/src/gateway/server-methods/agent-wait-dedupe.test.ts
+++ b/src/gateway/server-methods/agent-wait-dedupe.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AGENT_RUN_ABORTED_ERROR } from "../../agents/run-termination.js";
 import type { DedupeEntry } from "../server-shared.js";
 import {
   testing,
@@ -180,6 +181,74 @@ describe("agent wait dedupe helper", () => {
       error: "Context overflow: prompt too large for the model.",
       livenessState: "blocked",
     });
+  });
+
+  it("normalizes aborted ok agent snapshots to errors", () => {
+    const dedupe = new Map();
+    const runId = "run-aborted-agent";
+
+    setRunEntry({
+      dedupe,
+      kind: "agent",
+      runId,
+      payload: {
+        runId,
+        status: "ok",
+        startedAt: 100,
+        endedAt: 200,
+        result: {
+          meta: {
+            stopReason: "aborted",
+          },
+        },
+      },
+    });
+
+    expect(
+      readTerminalSnapshotFromGatewayDedupe({
+        dedupe,
+        runId,
+      }),
+    ).toEqual({
+      status: "error",
+      startedAt: 100,
+      endedAt: 200,
+      error: AGENT_RUN_ABORTED_ERROR,
+      stopReason: "aborted",
+    });
+  });
+
+  it("unblocks waiters with normalized aborted snapshots", async () => {
+    const dedupe = new Map();
+    const runId = "run-wait-aborted";
+    const waiter = waitForTerminalGatewayDedupe({
+      dedupe,
+      runId,
+      timeoutMs: 1_000,
+    });
+
+    await Promise.resolve();
+    expect(testing.getWaiterCount(runId)).toBe(1);
+
+    setRunEntry({
+      dedupe,
+      kind: "agent",
+      runId,
+      payload: {
+        runId,
+        status: "ok",
+        stopReason: "aborted",
+        endedAt: 300,
+      },
+    });
+
+    await expect(waiter).resolves.toEqual({
+      status: "error",
+      endedAt: 300,
+      error: AGENT_RUN_ABORTED_ERROR,
+      stopReason: "aborted",
+    });
+    expect(testing.getWaiterCount(runId)).toBe(0);
   });
 
   it("keeps stale chat dedupe blocked while agent dedupe is in-flight", async () => {

--- a/src/gateway/server-methods/agent-wait-dedupe.ts
+++ b/src/gateway/server-methods/agent-wait-dedupe.ts
@@ -1,3 +1,4 @@
+import { AGENT_RUN_ABORTED_ERROR, isAbortedAgentStopReason } from "../../agents/run-termination.js";
 import {
   normalizeAgentRunTimeoutPhase,
   normalizeProviderStarted,
@@ -124,12 +125,15 @@ function readTerminalSnapshotFromDedupeEntry(entry: DedupeEntry): AgentWaitTermi
       : typeof payload?.summary === "string"
         ? payload.summary
         : entry.error?.message;
+  const abortedStopReason = isAbortedAgentStopReason(stopReason);
+  const normalizedError =
+    abortedStopReason && !errorMessage ? AGENT_RUN_ABORTED_ERROR : errorMessage;
 
   if (status === "ok" || status === "timeout") {
     const normalized = normalizeBlockedLivenessWaitStatus({
-      status,
+      status: abortedStopReason ? "error" : status,
       livenessState,
-      error: errorMessage,
+      error: normalizedError,
     });
     return {
       status: normalized.status,
@@ -139,7 +143,7 @@ function readTerminalSnapshotFromDedupeEntry(entry: DedupeEntry): AgentWaitTermi
         normalized.status === "error"
           ? normalized.error
           : normalized.status === "timeout"
-            ? errorMessage
+            ? normalizedError
             : undefined,
       stopReason,
       livenessState,

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -76,6 +76,7 @@ describe("waitForAgentJob", () => {
     startedAt: number;
     endedAt: number;
     aborted?: boolean;
+    stopReason?: string;
   }) {
     const runId = `${params.runIdPrefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
     const waitPromise = waitForAgentJob({ runId, timeoutMs: 1_000 });
@@ -88,7 +89,12 @@ describe("waitForAgentJob", () => {
     emitAgentEvent({
       runId,
       stream: "lifecycle",
-      data: { phase: "end", endedAt: params.endedAt, aborted: params.aborted },
+      data: {
+        phase: "end",
+        endedAt: params.endedAt,
+        aborted: params.aborted,
+        ...(params.stopReason ? { stopReason: params.stopReason } : {}),
+      },
     });
 
     return waitPromise;
@@ -141,6 +147,22 @@ describe("waitForAgentJob", () => {
       status: "ok",
       startedAt: 300,
       endedAt: 400,
+    });
+  });
+
+  it("maps aborted stop reasons to error snapshots instead of ok", async () => {
+    const snapshot = await runLifecycleScenario({
+      runIdPrefix: "run-aborted-stop-reason",
+      startedAt: 410,
+      endedAt: 420,
+      stopReason: "aborted",
+    });
+    expectRecordFields(snapshot, {
+      status: "error",
+      startedAt: 410,
+      endedAt: 420,
+      stopReason: "aborted",
+      error: "agent run aborted",
     });
   });
 


### PR DESCRIPTION
## Summary

- Problem: subagent lifecycle/wait handling could treat terminal `stopReason: "aborted"` as a successful completion when the older `aborted: true` flag was absent.
- Solution: normalize the canonical aborted stop reason into a terminated error before gateway wait snapshots, run-wait normalization, registry completion, or announcement fallback can report success.
- What changed: added a shared aborted-stop-reason helper and applied it at the gateway, gateway dedupe cache, wait, subagent registry, lifecycle, and announcement-output boundaries.
- What did NOT change (scope boundary): no provider, channel, plugin API, config-shape, timeout, retry, or fallback policy changes.

## Motivation

Issue #72293 is a P1 session-state/message-loss bug. An aborted subagent run should not look successful to the parent session, because that can hide an interrupted child run during orchestration and produce an incorrect parent-facing completion state during the beta.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #72293
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: a real subagent lifecycle `end` event with `stopReason: "aborted"` is no longer converted into an `ok` parent-visible completion.
- Real environment tested: disposable Linux OpenClaw checkout, Node v22.22.2, pnpm 11.2.2.
- Exact steps or command run after this patch:

```text
pnpm exec tsx /tmp/openclaw-72293-runtime-proof.mjs .
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
OpenClaw aborted subagent lifecycle runtime proof
repoHead=daae39048f62
input.lifecycle.phase=end
input.lifecycle.stopReason=aborted
registry.endedReason=subagent-killed
registry.outcome.status=error
registry.outcome.error=subagent run terminated
parentAnnouncement.outcome.status=error
parentAnnouncement.outcome.error=subagent run terminated
parentAnnouncement.childRunId=proof-aborted-subagent-run
result=TERMINATED_FAILURE
```

- Observed result after fix: the same lifecycle event now becomes `endedReason=subagent-killed`, `status=error`, and the parent announcement carries `subagent run terminated`.
- What was not tested: no live external provider or channel account was used; this issue is in the local gateway/agent/subagent lifecycle path.
- Before evidence (optional but encouraged):

```text
OpenClaw aborted subagent lifecycle runtime proof
repoHead=5c4a733912a8
input.lifecycle.phase=end
input.lifecycle.stopReason=aborted
registry.endedReason=subagent-complete
registry.outcome.status=ok
registry.outcome.error=<missing>
parentAnnouncement.outcome.status=<missing>
parentAnnouncement.outcome.error=<missing>
parentAnnouncement.childRunId=<missing>
result=LEGACY_FALSE_SUCCESS
```

## Root Cause (if applicable)

- Root cause: the live wait/completion path recognized timeout-style `aborted: true`, but did not consistently treat the canonical terminal `stopReason: "aborted"` as non-success.
- Missing detection / guardrail: coverage existed for persisted killed session state, but not for raw live wait/lifecycle terminal events carrying only `stopReason: "aborted"`.
- Contributing context (if known): session lifecycle persistence already maps the same stop reason to killed, so this was a cross-layer normalization gap.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/gateway/server-methods/server-methods.test.ts`
  - `src/gateway/server-methods/agent-wait-dedupe.test.ts`
  - `src/agents/run-wait.test.ts`
  - `src/agents/subagent-registry.test.ts`
  - `src/agents/subagent-announce-output.test.ts`
  - `src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts`
- Scenario the test should lock in: `stopReason: "aborted"` cannot pass through as an `ok` wait/subagent completion, including cached gateway dedupe snapshots.
- Why this is the smallest reliable guardrail: it covers each boundary where the bad successful state could enter, be cached, or be announced.
- Existing test that already covers this (if any): session lifecycle state covered persisted killed mapping, but not the live wait/subagent completion path.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Aborted subagent runs are now reported to the parent as terminated failures instead of successful completions.

## Diagram (if applicable)

```text
Before:
lifecycle end stopReason=aborted -> agent.wait ok -> subagent complete -> parent sees success

After:
lifecycle end stopReason=aborted -> agent.wait error -> subagent-killed -> parent sees terminated failure
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux disposable checkout
- Runtime/container: Node v22.22.2, pnpm 11.2.2
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): isolated temporary OpenClaw home/config; plugins and control UI disabled

### Steps

1. Register a subagent run through the real subagent registry.
2. Emit real OpenClaw lifecycle events through the agent event bus: `start`, then `end` with `stopReason: "aborted"`.
3. Observe the registry outcome and parent announcement payload.

### Expected

- The run is treated as a terminated failure, with `endedReason: "subagent-killed"` and parent-visible `status: "error"`.

### Actual

- After this patch, matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Additional verification on pushed PR head `daae39048f62`:

```text
git diff --check origin/main...HEAD
passed

node scripts/run-vitest.mjs \
  src/gateway/server-methods/agent-wait-dedupe.test.ts \
  src/gateway/server-methods/server-methods.test.ts \
  src/agents/run-wait.test.ts
5 test files passed / 163 tests passed

node scripts/run-vitest.mjs \
  src/gateway/session-lifecycle-state.test.ts \
  src/agents/subagent-registry.test.ts \
  src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts \
  src/agents/subagent-registry-lifecycle.test.ts \
  src/agents/subagent-announce-output.test.ts
11 test files passed / 216 tests passed

node scripts/run-tsgo.mjs -p tsconfig.core.json --pretty false
passed

node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --pretty false
passed

pnpm exec oxfmt --check --threads=1 <13 touched files>
All matched files use the correct format.

node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json <13 touched files>
Found 0 warnings and 0 errors.
```

Note: `src/agents/subagent-announce.format.e2e.test.ts` is not counted as PR-specific proof because current `origin/main @ 5c4a733912a8` already fails the same 12 nested-completion fixture assertions. The focused announce-output and lifecycle tests above pass on this PR head. Crabbox was not used.

## Human Verification (required)

- Verified scenarios: gateway wait snapshot mapping; cached gateway dedupe snapshots; gateway dedupe waiter wakeup; raw wait normalization; subagent wait completion; direct lifecycle completion; announcement fallback; real registry + event-bus behavior proof for `stopReason: "aborted"`.
- Edge cases checked: existing timeout `aborted: true` behavior remains timeout; yielded runs still pause; blocked liveness remains an error; recoverable wait errors still retry unless the terminal stop reason is aborted.
- What you did **not** verify: live external provider/channel traffic; Crabbox.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: treating every `stopReason: "aborted"` as non-success could affect callers that previously relied on silent success.
  - Mitigation: this matches existing persisted lifecycle semantics for killed runs and only targets the canonical aborted terminal reason.
