### PR TITLE
Agents/exec: show target node name in exec tool transparency messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Docs: https://docs.openclaw.ai
 - Agents/subagents: report tool-only child progress during timeout summaries instead of showing no visible output.
 - Telegram/ACP: preserve explicit `:topic:` conversation suffixes when inbound ACP targets do not carry a separate thread id.
 - Browser/proxy: bypass the managed proxy for the exact local managed Chrome CDP readiness and DevTools WebSocket endpoints, so `openclaw browser start` works when the operator proxy blocks loopback egress. (#83255) Thanks @lightcap.
+- Agents/exec: surface the target node name in exec tool transparency messages when `host=node` is set, so users with paired nodes can tell where a command ran. (#77719)
 - Ollama: bypass the managed proxy for configured local embedding origins while keeping SSRF guardrails on unconfigured targets. Thanks @Kaspre.
 - OpenAI/images: route Codex API-key image generation through the native OpenAI Images API instead of the Codex OAuth streaming backend, avoiding 401s from valid API keys.
 - Agents/OpenAI completions: omit empty tool payload fields for proxy-like OpenAI-compatible endpoints so strict vLLM-style servers accept tool-free turns. (#85835) Thanks @rendrag-git.

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -755,6 +755,8 @@ public struct AgentParams: Codable, Sendable {
     public let internalruntimehandoffid: String?
     public let internalevents: [[String: AnyCodable]]?
     public let inputprovenance: [String: AnyCodable]?
+    public let suppresspromptpersistence: Bool?
+    public let sessioneffects: AnyCodable?
     public let sourcereplydeliverymode: AnyCodable?
     public let disablemessagetool: Bool?
     public let voicewaketrigger: String?
@@ -794,6 +796,8 @@ public struct AgentParams: Codable, Sendable {
         internalruntimehandoffid: String?,
         internalevents: [[String: AnyCodable]]?,
         inputprovenance: [String: AnyCodable]?,
+        suppresspromptpersistence: Bool?,
+        sessioneffects: AnyCodable?,
         sourcereplydeliverymode: AnyCodable?,
         disablemessagetool: Bool?,
         voicewaketrigger: String?,
@@ -832,6 +836,8 @@ public struct AgentParams: Codable, Sendable {
         self.internalruntimehandoffid = internalruntimehandoffid
         self.internalevents = internalevents
         self.inputprovenance = inputprovenance
+        self.suppresspromptpersistence = suppresspromptpersistence
+        self.sessioneffects = sessioneffects
         self.sourcereplydeliverymode = sourcereplydeliverymode
         self.disablemessagetool = disablemessagetool
         self.voicewaketrigger = voicewaketrigger
@@ -872,6 +878,8 @@ public struct AgentParams: Codable, Sendable {
         case internalruntimehandoffid = "internalRuntimeHandoffId"
         case internalevents = "internalEvents"
         case inputprovenance = "inputProvenance"
+        case suppresspromptpersistence = "suppressPromptPersistence"
+        case sessioneffects = "sessionEffects"
         case sourcereplydeliverymode = "sourceReplyDeliveryMode"
         case disablemessagetool = "disableMessageTool"
         case voicewaketrigger = "voiceWakeTrigger"

--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -452,6 +452,9 @@ export function resolveExecDetail(
     return undefined;
   }
 
+  const nodeName =
+    typeof record.node === "string" && record.node.trim() ? record.node.trim() : undefined;
+
   const unwrapped = unwrapShellWrapper(raw);
   const result = summarizeExecCommand(unwrapped) ?? summarizeExecCommand(raw);
   const summary = result?.text || "run command";
@@ -466,8 +469,11 @@ export function resolveExecDetail(
 
   const compact = compactRawCommand(unwrapped);
   const cwdSuffix = cwd ? formatCwdSuffix(cwd) : undefined;
+  const nodeFragment = nodeName ? ` · node: ${nodeName}` : "";
+
   if (result?.allGeneric !== false && isGenericSummary(summary)) {
-    return cwdSuffix ? `${compact} ${cwdSuffix}` : compact;
+    const base = cwdSuffix ? `${compact} ${cwdSuffix}` : compact;
+    return `${base}${nodeFragment}`;
   }
 
   const displaySummary = cwdSuffix ? `${summary} ${cwdSuffix}` : summary;
@@ -477,8 +483,8 @@ export function resolveExecDetail(
     compact !== displaySummary &&
     compact !== summary
   ) {
-    return `${displaySummary} · \`${compact}\``;
+    return `${displaySummary}${nodeFragment} · \`${compact}\``;
   }
 
-  return displaySummary;
+  return `${displaySummary}${nodeFragment}`;
 }

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -428,4 +428,47 @@ describe("tool display details", () => {
     expect(nodeCheckDetail).toContain("check js syntax for /tmp/test.js");
     expect(nodeShortCheckDetail).toContain("check js syntax for /tmp/test.js");
   });
+
+  it("appends node name to exec detail when node is set", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "exec",
+        args: {
+          command: "docker pull pihole/pihole:latest",
+          host: "node",
+          node: "raspberrypi",
+        },
+      }),
+    );
+
+    expect(detail).toContain("node: raspberrypi");
+  });
+
+  it("includes both cwd and node name in exec detail for known commands", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "exec",
+        args: {
+          command: "npm install",
+          workdir: "/app",
+          host: "node",
+          node: "raspberrypi",
+        },
+      }),
+    );
+
+    expect(detail).toContain("(in /app)");
+    expect(detail).toContain("node: raspberrypi");
+  });
+
+  it("omits node label when node param is absent or empty", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "exec",
+        args: { command: "npm install", host: "gateway" },
+      }),
+    );
+
+    expect(detail).not.toContain("node:");
+  });
 });


### PR DESCRIPTION
Replacement/rebase of #78288 so the exec transparency fix can be reviewed against current main.

Original PR: #78288 by @JiataiWang.

## Real behavior proof

Behavior addressed:
Exec transparency text now shows the selected target node name when an exec call is routed with `host=node` and a `node` value. That lets operators distinguish gateway-local shell work from paired-node shell work in the visible tool/status text.

Real environment tested:
Local OpenClaw checkout rebased onto current `main` on the OpenClaw VPS workspace.

Exact steps or command run after this patch:
I ran the display resolver against real OpenClaw source in the checked-out repo and then ran the focused display test file, generated protocol check, and whitespace check.

Evidence after fix:
Terminal output from the live checkout:

```text
$ node scripts/run-vitest.mjs src/agents/tool-display.test.ts
src/agents/tool-display.test.ts completed with 30 tests

$ node --import tsx scripts/protocol-gen.ts
wrote dist/protocol.schema.json

$ node --import tsx scripts/protocol-gen-swift.ts
wrote apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift

$ git diff --check
(no output)
```

Manual output from the changed display path:

```text
exec args: {"command":"docker pull pihole/pihole:latest","host":"node","node":"raspberrypi"}
display detail includes: node: raspberrypi

exec args: {"command":"npm install","workdir":"/app","host":"node","node":"raspberrypi"}
display detail includes: (in /app) and node: raspberrypi

exec args: {"command":"npm install","host":"gateway"}
display detail omits: node:
```

Observed result after fix:
The rebased helper branch applies cleanly to current `main`; GitHub reports it MERGEABLE at head `60e1c34c9cb972bdf7d9d95bca18cb541de6cec4`. The exec display helper includes the target node fragment for node-routed exec calls and keeps current cwd suffix behavior. The required generated shared Swift protocol model drift is included so the bundled-protocol check does not fail on regeneration.

What was not tested:
Full repository suite. This PR changes the exec tool display helper, focused display coverage, and one generated shared Swift protocol model file required by CI.