### PR TITLE
fix: gracefully escalate process supervisor cancellations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Docs: https://docs.openclaw.ai
 
 - Discord/voice: keep realtime playback running when meeting notes attaches to an existing voice session or a realtime consult starts, and route realtime user transcripts into meeting notes.
 - WebChat: keep the run-complete indicator in progress until deferred history replay renders the assistant reply, so Done no longer appears before response text. (#85374) Thanks @neeravmakwana.
+- Agents/tools: give timed-out or cancelled process trees a bounded SIGTERM cleanup window before SIGKILL while preserving tree-aware cancellation. Fixes #66399. (#85865) Thanks @IWhatsskill.
 - Agents/compaction: skip agent-harness preflight for provider-owned CLI runtime sessions so over-threshold Claude CLI sessions continue through normal compaction instead of failing on a missing harness. Fixes #84857. (#84878) Thanks @zhangguiping-xydt.
 - Control UI/config: save form-mode edits from the source config snapshot so runtime-only provider defaults like empty `models.providers.<id>.baseUrl` are not written back and rejected. Fixes #85831. Thanks @garyd9.
 - Browser/existing-session: launch Chrome DevTools MCP with usage statistics disabled by default so its telemetry watchdog stays off unless an operator explicitly opts in. (#85886) Thanks @rohitjavvadi.

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -86,7 +86,7 @@ function createSignalMonitorTaskRunner(runtime: RuntimeEnv) {
     },
     async waitForIdle(): Promise<void> {
       while (inFlight.size > 0) {
-        await Promise.allSettled(Array.from(inFlight));
+        await Promise.allSettled(inFlight);
       }
     },
   };

--- a/src/process/kill-tree.test.ts
+++ b/src/process/kill-tree.test.ts
@@ -16,6 +16,7 @@ vi.mock("node:child_process", async () => {
 });
 
 let killProcessTree: typeof import("./kill-tree.js").killProcessTree;
+let signalProcessTree: typeof import("./kill-tree.js").signalProcessTree;
 
 function expectTaskkillCall(index: number, args: string[]) {
   expect(spawnMock.mock.calls[index]).toStrictEqual([
@@ -33,7 +34,7 @@ describe("killProcessTree", () => {
   let killSpy: ReturnType<typeof vi.spyOn>;
 
   beforeAll(async () => {
-    ({ killProcessTree } = await import("./kill-tree.js"));
+    ({ killProcessTree, signalProcessTree } = await import("./kill-tree.js"));
   });
 
   beforeEach(() => {
@@ -126,6 +127,28 @@ describe("killProcessTree", () => {
     });
   });
 
+  it("on Unix force-kills a live detached group even after the parent pid exits", async () => {
+    killSpy.mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
+      if (pid === -4545 && signal === 0) {
+        return true;
+      }
+      if (pid === 4545 && signal === 0) {
+        throw new Error("ESRCH");
+      }
+      return true;
+    }) as typeof process.kill);
+
+    await withMockedPlatform("linux", async () => {
+      killProcessTree(4545, { graceMs: 5 });
+
+      await vi.advanceTimersByTimeAsync(5);
+
+      expect(killSpy).toHaveBeenCalledWith(-4545, "SIGTERM");
+      expect(killSpy).toHaveBeenCalledWith(-4545, "SIGKILL");
+      expect(killSpy).not.toHaveBeenCalledWith(4545, "SIGKILL");
+    });
+  });
+
   it("on Unix skips group kill when detached:false to avoid SIGTERMing the parent's own process group (#71662)", async () => {
     killSpy.mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
       if (pid === 5555 && signal === 0) {
@@ -163,6 +186,31 @@ describe("killProcessTree", () => {
       await vi.advanceTimersByTimeAsync(10);
 
       expect(killSpy).toHaveBeenCalledWith(-6666, "SIGTERM");
+    });
+  });
+
+  it("on Unix sends a single requested tree signal without scheduling escalation", async () => {
+    killSpy.mockImplementation(() => true);
+
+    await withMockedPlatform("linux", async () => {
+      signalProcessTree(7777, "SIGTERM");
+
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(killSpy).toHaveBeenCalledTimes(1);
+      expect(killSpy).toHaveBeenCalledWith(-7777, "SIGTERM");
+      expect(killSpy).not.toHaveBeenCalledWith(-7777, "SIGKILL");
+    });
+  });
+
+  it("on Windows maps requested tree signals to taskkill force mode", async () => {
+    await withMockedPlatform("win32", async () => {
+      signalProcessTree(8888, "SIGTERM");
+      signalProcessTree(8888, "SIGKILL");
+
+      expect(spawnMock).toHaveBeenCalledTimes(2);
+      expectTaskkillCall(0, ["/T", "/PID", "8888"]);
+      expectTaskkillCall(1, ["/F", "/T", "/PID", "8888"]);
     });
   });
 });

--- a/src/process/kill-tree.ts
+++ b/src/process/kill-tree.ts
@@ -32,7 +32,34 @@ export function killProcessTree(
     return;
   }
 
-  killProcessTreeUnix(pid, graceMs, opts?.detached !== false);
+  const useGroupKill = opts?.detached !== false;
+  signalProcessTreeUnix(pid, "SIGTERM", useGroupKill);
+  setTimeout(() => {
+    const stillAlive = useGroupKill
+      ? isProcessAlive(-pid) || isProcessAlive(pid)
+      : isProcessAlive(pid);
+    if (!stillAlive) {
+      return;
+    }
+    signalProcessTreeUnix(pid, "SIGKILL", useGroupKill);
+  }, graceMs).unref(); // Don't block event loop exit
+}
+
+export function signalProcessTree(
+  pid: number,
+  signal: "SIGTERM" | "SIGKILL",
+  opts?: { detached?: boolean },
+): void {
+  if (!Number.isFinite(pid) || pid <= 0) {
+    return;
+  }
+
+  if (process.platform === "win32") {
+    signalProcessTreeWindows(pid, signal);
+    return;
+  }
+
+  signalProcessTreeUnix(pid, signal, opts?.detached !== false);
 }
 
 function normalizeGraceMs(value?: number): number {
@@ -51,50 +78,28 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
-function killProcessTreeUnix(pid: number, graceMs: number, useGroupKill: boolean): void {
-  // Step 1: Try graceful SIGTERM. Prefer process-group kill (`-pid`) when the
-  // child was spawned detached so it has its own group; otherwise stick to the
-  // direct pid to avoid SIGTERMing our own process group (the gateway). (#71662)
+function signalProcessTreeUnix(
+  pid: number,
+  signal: "SIGTERM" | "SIGKILL",
+  useGroupKill: boolean,
+): void {
+  // Prefer process-group signals (`-pid`) when the child was spawned detached
+  // so it has its own group; otherwise stick to the direct pid to avoid
+  // signaling our own process group (the gateway). (#71662)
   if (useGroupKill) {
     try {
-      process.kill(-pid, "SIGTERM");
-    } catch {
-      // Process group doesn't exist or we lack permission - try direct
-      try {
-        process.kill(pid, "SIGTERM");
-      } catch {
-        // Already gone
-        return;
-      }
-    }
-  } else {
-    try {
-      process.kill(pid, "SIGTERM");
-    } catch {
-      // Already gone
+      process.kill(-pid, signal);
       return;
+    } catch {
+      // Process group doesn't exist or we lack permission - try direct.
     }
   }
 
-  // Step 2: Wait grace period, then SIGKILL if still alive
-  setTimeout(() => {
-    if (useGroupKill && isProcessAlive(-pid)) {
-      try {
-        process.kill(-pid, "SIGKILL");
-        return;
-      } catch {
-        // Fall through to direct pid kill
-      }
-    }
-    if (!isProcessAlive(pid)) {
-      return;
-    }
-    try {
-      process.kill(pid, "SIGKILL");
-    } catch {
-      // Process exited between liveness check and kill
-    }
-  }, graceMs).unref(); // Don't block event loop exit
+  try {
+    process.kill(pid, signal);
+  } catch {
+    // Already gone
+  }
 }
 
 function runTaskkill(args: string[]): void {
@@ -111,7 +116,7 @@ function runTaskkill(args: string[]): void {
 
 function killProcessTreeWindows(pid: number, graceMs: number): void {
   // Step 1: Try graceful termination (taskkill without /F)
-  runTaskkill(["/T", "/PID", String(pid)]);
+  signalProcessTreeWindows(pid, "SIGTERM");
 
   // Step 2: Wait grace period, then force kill only if pid still exists.
   // This avoids unconditional delayed /F kills after graceful shutdown.
@@ -119,6 +124,12 @@ function killProcessTreeWindows(pid: number, graceMs: number): void {
     if (!isProcessAlive(pid)) {
       return;
     }
-    runTaskkill(["/F", "/T", "/PID", String(pid)]);
+    signalProcessTreeWindows(pid, "SIGKILL");
   }, graceMs).unref(); // Don't block event loop exit
+}
+
+function signalProcessTreeWindows(pid: number, signal: "SIGTERM" | "SIGKILL"): void {
+  const args =
+    signal === "SIGKILL" ? ["/F", "/T", "/PID", String(pid)] : ["/T", "/PID", String(pid)];
+  runTaskkill(args);
 }

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -7,10 +7,10 @@ import {
   expectWaitStaysPendingUntilSigkillFallback,
 } from "./test-support.js";
 
-const { spawnWithFallbackMock, killProcessTreeMock, createWindowsOutputDecoderMock } = vi.hoisted(
+const { spawnWithFallbackMock, signalProcessTreeMock, createWindowsOutputDecoderMock } = vi.hoisted(
   () => ({
     spawnWithFallbackMock: vi.fn(),
-    killProcessTreeMock: vi.fn(),
+    signalProcessTreeMock: vi.fn(),
     createWindowsOutputDecoderMock: vi.fn(() => ({
       decode: (chunk: Buffer | string) => (Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk),
       flush: () => "",
@@ -23,7 +23,7 @@ vi.mock("../../spawn-utils.js", () => ({
 }));
 
 vi.mock("../../kill-tree.js", () => ({
-  killProcessTree: killProcessTreeMock,
+  signalProcessTree: signalProcessTreeMock,
 }));
 
 vi.mock("../../../infra/windows-encoding.js", () => ({
@@ -123,7 +123,7 @@ describe("createChildAdapter", () => {
 
   beforeEach(() => {
     spawnWithFallbackMock.mockClear();
-    killProcessTreeMock.mockClear();
+    signalProcessTreeMock.mockClear();
     createWindowsOutputDecoderMock.mockClear();
     createWindowsOutputDecoderMock.mockImplementation(() => ({
       decode: (chunk: Buffer | string) => (Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk),
@@ -164,14 +164,16 @@ describe("createChildAdapter", () => {
 
     adapter.kill();
 
-    // Detachment flag is now passed to killProcessTree so it knows whether
+    // Detachment flag is now passed to signalProcessTree so it knows whether
     // it can safely group-kill via -pid. (#71662)
     const expectedDetached = process.platform !== "win32" && !process.env.OPENCLAW_SERVICE_MARKER;
-    expect(killProcessTreeMock).toHaveBeenCalledWith(4321, { detached: expectedDetached });
+    expect(signalProcessTreeMock).toHaveBeenCalledWith(4321, "SIGKILL", {
+      detached: expectedDetached,
+    });
     expect(killMock).toHaveBeenCalledWith("SIGKILL");
   });
 
-  it("passes detached:false to killProcessTree when spawn fell back to no-detach (#71662 follow-up)", async () => {
+  it("passes detached:false to signalProcessTree when spawn fell back to no-detach (#71662 follow-up)", async () => {
     // Simulate the fallback scenario: spawnWithFallback retried with
     // detached:false because the initial detached spawn failed. The kill
     // closure must NOT group-kill since the child shares the gateway's group.
@@ -188,7 +190,7 @@ describe("createChildAdapter", () => {
 
     adapter.kill();
 
-    expect(killProcessTreeMock).toHaveBeenCalledWith(8888, { detached: false });
+    expect(signalProcessTreeMock).toHaveBeenCalledWith(8888, "SIGKILL", { detached: false });
     expect(killMock).toHaveBeenCalledWith("SIGKILL");
   });
 
@@ -197,7 +199,7 @@ describe("createChildAdapter", () => {
     try {
       const { adapter, killMock } = await createAdapterHarness({ pid: 9999 });
       adapter.kill();
-      expect(killProcessTreeMock).toHaveBeenCalledWith(9999, { detached: false });
+      expect(signalProcessTreeMock).toHaveBeenCalledWith(9999, "SIGKILL", { detached: false });
       expect(killMock).toHaveBeenCalledWith("SIGKILL");
     } finally {
       delete process.env.OPENCLAW_SERVICE_MARKER;
@@ -207,12 +209,11 @@ describe("createChildAdapter", () => {
   it("uses process-tree kill for graceful SIGTERM cancellation", async () => {
     const { adapter, killMock } = await createAdapterHarness({ pid: 7654 });
 
-    adapter.kill("SIGTERM", { graceMs: 5_000 });
+    adapter.kill("SIGTERM");
 
     const expectedDetached = process.platform !== "win32" && !process.env.OPENCLAW_SERVICE_MARKER;
-    expect(killProcessTreeMock).toHaveBeenCalledWith(7654, {
+    expect(signalProcessTreeMock).toHaveBeenCalledWith(7654, "SIGTERM", {
       detached: expectedDetached,
-      graceMs: 5_000,
     });
     expect(killMock).not.toHaveBeenCalled();
   });
@@ -229,11 +230,10 @@ describe("createChildAdapter", () => {
       stdinMode: "pipe-open",
     });
 
-    adapter.kill("SIGTERM", { graceMs: 5_000 });
+    adapter.kill("SIGTERM");
 
-    expect(killProcessTreeMock).toHaveBeenCalledWith(8765, {
+    expect(signalProcessTreeMock).toHaveBeenCalledWith(8765, "SIGTERM", {
       detached: false,
-      graceMs: 5_000,
     });
     expect(killMock).not.toHaveBeenCalled();
   });
@@ -243,7 +243,7 @@ describe("createChildAdapter", () => {
 
     adapter.kill("SIGINT");
 
-    expect(killProcessTreeMock).not.toHaveBeenCalled();
+    expect(signalProcessTreeMock).not.toHaveBeenCalled();
     expect(killMock).toHaveBeenCalledWith("SIGINT");
   });
 

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -204,13 +204,47 @@ describe("createChildAdapter", () => {
     }
   });
 
-  it("uses direct child.kill for non-SIGKILL signals", async () => {
+  it("uses process-tree kill for graceful SIGTERM cancellation", async () => {
     const { adapter, killMock } = await createAdapterHarness({ pid: 7654 });
 
-    adapter.kill("SIGTERM");
+    adapter.kill("SIGTERM", { graceMs: 5_000 });
+
+    const expectedDetached = process.platform !== "win32" && !process.env.OPENCLAW_SERVICE_MARKER;
+    expect(killProcessTreeMock).toHaveBeenCalledWith(7654, {
+      detached: expectedDetached,
+      graceMs: 5_000,
+    });
+    expect(killMock).not.toHaveBeenCalled();
+  });
+
+  it("passes detached:false to process-tree SIGTERM when spawn fell back to no-detach", async () => {
+    const { child, killMock } = createStubChild(8765);
+    spawnWithFallbackMock.mockResolvedValue({
+      child,
+      usedFallback: true,
+      fallbackLabel: "no-detach",
+    });
+    const adapter = await createChildAdapter({
+      argv: ["node", "-e", "setTimeout(() => {}, 1000)"],
+      stdinMode: "pipe-open",
+    });
+
+    adapter.kill("SIGTERM", { graceMs: 5_000 });
+
+    expect(killProcessTreeMock).toHaveBeenCalledWith(8765, {
+      detached: false,
+      graceMs: 5_000,
+    });
+    expect(killMock).not.toHaveBeenCalled();
+  });
+
+  it("uses direct child.kill for non-SIGTERM and non-SIGKILL signals", async () => {
+    const { adapter, killMock } = await createAdapterHarness({ pid: 7654 });
+
+    adapter.kill("SIGINT");
 
     expect(killProcessTreeMock).not.toHaveBeenCalled();
-    expect(killMock).toHaveBeenCalledWith("SIGTERM");
+    expect(killMock).toHaveBeenCalledWith("SIGINT");
   });
 
   it("preserves inherited stdin when no input pipe is requested", async () => {

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -357,14 +357,21 @@ export async function createChildAdapter(params: {
   // gateway's process group regardless of intent, so the kill must avoid
   // group-kill. (#71662 follow-up — caught by Greptile review)
   const childIsDetached = useDetached && !spawned.usedFallback;
-  const kill = (signal?: NodeJS.Signals) => {
+  const killProcessTreeForChild = (pid: number, graceMs?: number) => {
+    const opts =
+      graceMs === undefined
+        ? { detached: childIsDetached }
+        : { detached: childIsDetached, graceMs };
+    killProcessTree(pid, opts);
+  };
+  const kill = (signal?: NodeJS.Signals, options?: { graceMs?: number }) => {
     const pid = child.pid ?? undefined;
     if (signal === undefined || signal === "SIGKILL") {
       if (pid) {
         // Pass through whether the child is actually detached. Without this,
         // `killProcessTree` group-kills via `-pid` and takes out the gateway's
         // own process group along with the child. (#71662)
-        killProcessTree(pid, { detached: childIsDetached });
+        killProcessTreeForChild(pid, options?.graceMs);
       }
       try {
         child.kill("SIGKILL");
@@ -372,6 +379,10 @@ export async function createChildAdapter(params: {
         // ignore kill errors
       }
       scheduleForceKillWaitFallback("SIGKILL");
+      return;
+    }
+    if (signal === "SIGTERM" && pid) {
+      killProcessTreeForChild(pid, options?.graceMs);
       return;
     }
     try {

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -1,6 +1,6 @@
 import type { ChildProcessWithoutNullStreams, SpawnOptions } from "node:child_process";
 import { createWindowsOutputDecoder } from "../../../infra/windows-encoding.js";
-import { killProcessTree } from "../../kill-tree.js";
+import { signalProcessTree } from "../../kill-tree.js";
 import { prepareOomScoreAdjustedSpawn } from "../../linux-oom-score.js";
 import { spawnWithFallback } from "../../spawn-utils.js";
 import { resolveWindowsCommandShim } from "../../windows-command.js";
@@ -357,21 +357,17 @@ export async function createChildAdapter(params: {
   // gateway's process group regardless of intent, so the kill must avoid
   // group-kill. (#71662 follow-up — caught by Greptile review)
   const childIsDetached = useDetached && !spawned.usedFallback;
-  const killProcessTreeForChild = (pid: number, graceMs?: number) => {
-    const opts =
-      graceMs === undefined
-        ? { detached: childIsDetached }
-        : { detached: childIsDetached, graceMs };
-    killProcessTree(pid, opts);
+  const signalProcessTreeForChild = (pid: number, signal: "SIGTERM" | "SIGKILL") => {
+    signalProcessTree(pid, signal, { detached: childIsDetached });
   };
-  const kill = (signal?: NodeJS.Signals, options?: { graceMs?: number }) => {
+  const kill = (signal?: NodeJS.Signals) => {
     const pid = child.pid ?? undefined;
     if (signal === undefined || signal === "SIGKILL") {
       if (pid) {
         // Pass through whether the child is actually detached. Without this,
-        // `killProcessTree` group-kills via `-pid` and takes out the gateway's
+        // `signalProcessTree` group-kills via `-pid` and takes out the gateway's
         // own process group along with the child. (#71662)
-        killProcessTreeForChild(pid, options?.graceMs);
+        signalProcessTreeForChild(pid, "SIGKILL");
       }
       try {
         child.kill("SIGKILL");
@@ -382,7 +378,7 @@ export async function createChildAdapter(params: {
       return;
     }
     if (signal === "SIGTERM" && pid) {
-      killProcessTreeForChild(pid, options?.graceMs);
+      signalProcessTreeForChild(pid, "SIGTERM");
       return;
     }
     try {

--- a/src/process/supervisor/adapters/pty.test.ts
+++ b/src/process/supervisor/adapters/pty.test.ts
@@ -85,7 +85,7 @@ describe("createPtyAdapter", () => {
     vi.clearAllMocks();
   });
 
-  it("forwards explicit signals to node-pty kill on non-Windows", async () => {
+  it("forwards non-SIGTERM explicit signals to node-pty kill on non-Windows", async () => {
     const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
     Object.defineProperty(process, "platform", { value: "linux", configurable: true });
     try {
@@ -96,14 +96,27 @@ describe("createPtyAdapter", () => {
         args: ["-lc", "sleep 10"],
       });
 
-      adapter.kill("SIGTERM");
-      expect(ptyKillMock).toHaveBeenCalledWith("SIGTERM");
+      adapter.kill("SIGINT");
+      expect(ptyKillMock).toHaveBeenCalledWith("SIGINT");
       expect(killProcessTreeMock).not.toHaveBeenCalled();
     } finally {
       if (originalPlatform) {
         Object.defineProperty(process, "platform", originalPlatform);
       }
     }
+  });
+
+  it("uses process-tree kill for graceful SIGTERM cancellation", async () => {
+    spawnMock.mockReturnValue(createStubPty(1234));
+
+    const adapter = await createPtyAdapter({
+      shell: "bash",
+      args: ["-lc", "sleep 10"],
+    });
+
+    adapter.kill("SIGTERM", { graceMs: 5_000 });
+    expect(killProcessTreeMock).toHaveBeenCalledWith(1234, { graceMs: 5_000 });
+    expect(ptyKillMock).not.toHaveBeenCalled();
   });
 
   it("uses process-tree kill for SIGKILL by default", async () => {
@@ -272,7 +285,7 @@ describe("createPtyAdapter", () => {
     expect(expectSpawnEnv()).toEqual({ FOO: "bar", COUNT: "12" });
   });
 
-  it("does not pass a signal to node-pty on Windows", async () => {
+  it("does not pass non-SIGTERM explicit signals to node-pty on Windows", async () => {
     const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
     Object.defineProperty(process, "platform", { value: "win32", configurable: true });
     try {
@@ -283,7 +296,7 @@ describe("createPtyAdapter", () => {
         args: ["-NoLogo"],
       });
 
-      adapter.kill("SIGTERM");
+      adapter.kill("SIGINT");
       expect(ptyKillMock).toHaveBeenCalledWith(undefined);
       expect(killProcessTreeMock).not.toHaveBeenCalled();
     } finally {

--- a/src/process/supervisor/adapters/pty.test.ts
+++ b/src/process/supervisor/adapters/pty.test.ts
@@ -4,10 +4,10 @@ import {
   expectWaitStaysPendingUntilSigkillFallback,
 } from "./test-support.js";
 
-const { spawnMock, ptyKillMock, killProcessTreeMock } = vi.hoisted(() => ({
+const { spawnMock, ptyKillMock, signalProcessTreeMock } = vi.hoisted(() => ({
   spawnMock: vi.fn(),
   ptyKillMock: vi.fn(),
-  killProcessTreeMock: vi.fn(),
+  signalProcessTreeMock: vi.fn(),
 }));
 
 vi.mock("@lydell/node-pty", () => ({
@@ -15,7 +15,7 @@ vi.mock("@lydell/node-pty", () => ({
 }));
 
 vi.mock("../../kill-tree.js", () => ({
-  killProcessTree: (...args: unknown[]) => killProcessTreeMock(...args),
+  signalProcessTree: (...args: unknown[]) => signalProcessTreeMock(...args),
 }));
 
 function createStubPty(pid = 1234) {
@@ -76,7 +76,7 @@ describe("createPtyAdapter", () => {
   beforeEach(() => {
     spawnMock.mockClear();
     ptyKillMock.mockClear();
-    killProcessTreeMock.mockClear();
+    signalProcessTreeMock.mockClear();
     vi.useRealTimers();
   });
 
@@ -98,7 +98,7 @@ describe("createPtyAdapter", () => {
 
       adapter.kill("SIGINT");
       expect(ptyKillMock).toHaveBeenCalledWith("SIGINT");
-      expect(killProcessTreeMock).not.toHaveBeenCalled();
+      expect(signalProcessTreeMock).not.toHaveBeenCalled();
     } finally {
       if (originalPlatform) {
         Object.defineProperty(process, "platform", originalPlatform);
@@ -114,8 +114,8 @@ describe("createPtyAdapter", () => {
       args: ["-lc", "sleep 10"],
     });
 
-    adapter.kill("SIGTERM", { graceMs: 5_000 });
-    expect(killProcessTreeMock).toHaveBeenCalledWith(1234, { graceMs: 5_000 });
+    adapter.kill("SIGTERM");
+    expect(signalProcessTreeMock).toHaveBeenCalledWith(1234, "SIGTERM");
     expect(ptyKillMock).not.toHaveBeenCalled();
   });
 
@@ -128,7 +128,7 @@ describe("createPtyAdapter", () => {
     });
 
     adapter.kill();
-    expect(killProcessTreeMock).toHaveBeenCalledWith(1234);
+    expect(signalProcessTreeMock).toHaveBeenCalledWith(1234, "SIGKILL");
     expect(ptyKillMock).not.toHaveBeenCalled();
   });
 
@@ -298,7 +298,7 @@ describe("createPtyAdapter", () => {
 
       adapter.kill("SIGINT");
       expect(ptyKillMock).toHaveBeenCalledWith(undefined);
-      expect(killProcessTreeMock).not.toHaveBeenCalled();
+      expect(signalProcessTreeMock).not.toHaveBeenCalled();
     } finally {
       if (originalPlatform) {
         Object.defineProperty(process, "platform", originalPlatform);
@@ -318,7 +318,7 @@ describe("createPtyAdapter", () => {
       });
 
       adapter.kill("SIGKILL");
-      expect(killProcessTreeMock).toHaveBeenCalledWith(4567);
+      expect(signalProcessTreeMock).toHaveBeenCalledWith(4567, "SIGKILL");
       expect(ptyKillMock).not.toHaveBeenCalled();
     } finally {
       if (originalPlatform) {

--- a/src/process/supervisor/adapters/pty.ts
+++ b/src/process/supervisor/adapters/pty.ts
@@ -1,4 +1,4 @@
-import { killProcessTree } from "../../kill-tree.js";
+import { signalProcessTree } from "../../kill-tree.js";
 import { prepareOomScoreAdjustedSpawn } from "../../linux-oom-score.js";
 import type { ManagedRunStdin, SpawnProcessAdapter } from "../types.js";
 import { toStringEnv } from "./env.js";
@@ -183,20 +183,14 @@ export async function createPtyAdapter(params: {
     return waitPromise;
   };
 
-  const kill = (signal: NodeJS.Signals = "SIGKILL", options?: { graceMs?: number }) => {
+  const kill = (signal: NodeJS.Signals = "SIGKILL") => {
     try {
-      if (signal === "SIGKILL" && typeof pty.pid === "number" && pty.pid > 0) {
-        if (options?.graceMs === undefined) {
-          killProcessTree(pty.pid);
-        } else {
-          killProcessTree(pty.pid, { graceMs: options.graceMs });
-        }
-      } else if (signal === "SIGTERM" && typeof pty.pid === "number" && pty.pid > 0) {
-        if (options?.graceMs === undefined) {
-          killProcessTree(pty.pid);
-        } else {
-          killProcessTree(pty.pid, { graceMs: options.graceMs });
-        }
+      if (
+        (signal === "SIGKILL" || signal === "SIGTERM") &&
+        typeof pty.pid === "number" &&
+        pty.pid > 0
+      ) {
+        signalProcessTree(pty.pid, signal);
       } else if (process.platform === "win32") {
         pty.kill();
       } else {

--- a/src/process/supervisor/adapters/pty.ts
+++ b/src/process/supervisor/adapters/pty.ts
@@ -183,10 +183,20 @@ export async function createPtyAdapter(params: {
     return waitPromise;
   };
 
-  const kill = (signal: NodeJS.Signals = "SIGKILL") => {
+  const kill = (signal: NodeJS.Signals = "SIGKILL", options?: { graceMs?: number }) => {
     try {
       if (signal === "SIGKILL" && typeof pty.pid === "number" && pty.pid > 0) {
-        killProcessTree(pty.pid);
+        if (options?.graceMs === undefined) {
+          killProcessTree(pty.pid);
+        } else {
+          killProcessTree(pty.pid, { graceMs: options.graceMs });
+        }
+      } else if (signal === "SIGTERM" && typeof pty.pid === "number" && pty.pid > 0) {
+        if (options?.graceMs === undefined) {
+          killProcessTree(pty.pid);
+        } else {
+          killProcessTree(pty.pid, { graceMs: options.graceMs });
+        }
       } else if (process.platform === "win32") {
         pty.kill();
       } else {

--- a/src/process/supervisor/supervisor.test.ts
+++ b/src/process/supervisor/supervisor.test.ts
@@ -159,10 +159,47 @@ describe("process supervisor", () => {
     await vi.advanceTimersByTimeAsync(5);
 
     const exit = await exitPromise;
-    expect(adapter.killMock).toHaveBeenCalledWith("SIGKILL");
+    expect(adapter.killMock).toHaveBeenCalledWith("SIGTERM");
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(adapter.killMock).not.toHaveBeenCalledWith("SIGKILL");
     expect(exit.reason).toBe("no-output-timeout");
     expect(exit.noOutputTimedOut).toBe(true);
     expect(exit.timedOut).toBe(true);
+  });
+
+  it("escalates cancellation to SIGKILL when graceful shutdown does not settle", async () => {
+    vi.useFakeTimers();
+    const adapter = createStubChildAdapter({
+      onKill: (signal, current) => {
+        if (signal === "SIGKILL") {
+          current.settle(null, signal);
+        }
+      },
+    });
+    createChildAdapterMock.mockResolvedValue(adapter);
+
+    const supervisor = createProcessSupervisor();
+    const run = await spawnChild(supervisor, {
+      sessionId: "s1",
+      argv: createSilentIdleArgv(),
+      timeoutMs: 1_000,
+      stdinMode: "pipe-closed",
+    });
+
+    const exitPromise = run.wait();
+    run.cancel("manual-cancel");
+
+    expect(adapter.killMock).toHaveBeenCalledWith("SIGTERM");
+    expect(adapter.killMock).not.toHaveBeenCalledWith("SIGKILL");
+
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(adapter.killMock).not.toHaveBeenCalledWith("SIGKILL");
+
+    await vi.advanceTimersByTimeAsync(1);
+    const exit = await exitPromise;
+    expect(adapter.killMock).toHaveBeenCalledWith("SIGKILL");
+    expect(exit.reason).toBe("manual-cancel");
+    expect(exit.exitSignal).toBe("SIGKILL");
   });
 
   it("cancels prior scoped run when replaceExistingScope is enabled", async () => {
@@ -197,7 +234,7 @@ describe("process supervisor", () => {
 
     const firstExit = await firstRun.wait();
     const secondExit = await secondRun.wait();
-    expect(first.killMock).toHaveBeenCalledWith("SIGKILL");
+    expect(first.killMock).toHaveBeenCalledWith("SIGTERM");
     expect(["manual-cancel", "signal"]).toContain(firstExit.reason);
     expect(secondExit.reason).toBe("exit");
     expect(secondExit.stdout).toBe("new");
@@ -224,7 +261,7 @@ describe("process supervisor", () => {
     await vi.advanceTimersByTimeAsync(1);
 
     const exit = await exitPromise;
-    expect(adapter.killMock).toHaveBeenCalledWith("SIGKILL");
+    expect(adapter.killMock).toHaveBeenCalledWith("SIGTERM");
     expect(exit.reason).toBe("overall-timeout");
     expect(exit.timedOut).toBe(true);
   });

--- a/src/process/supervisor/supervisor.test.ts
+++ b/src/process/supervisor/supervisor.test.ts
@@ -65,12 +65,8 @@ function createStubChildAdapter(options?: {
       stderrListeners.push(listener);
     },
     wait: async () => await waitPromise,
-    kill: (signal, killOptions) => {
-      if (killOptions === undefined) {
-        killMock(signal);
-      } else {
-        killMock(signal, killOptions);
-      }
+    kill: (signal) => {
+      killMock(signal);
       options?.onKill?.(signal, adapter);
     },
     dispose: () => {
@@ -163,7 +159,7 @@ describe("process supervisor", () => {
     await vi.advanceTimersByTimeAsync(5);
 
     const exit = await exitPromise;
-    expect(adapter.killMock).toHaveBeenCalledWith("SIGTERM", { graceMs: 5_000 });
+    expect(adapter.killMock).toHaveBeenCalledWith("SIGTERM");
     await vi.advanceTimersByTimeAsync(5_000);
     expect(adapter.killMock).not.toHaveBeenCalledWith("SIGKILL");
     expect(exit.reason).toBe("no-output-timeout");
@@ -193,7 +189,7 @@ describe("process supervisor", () => {
     const exitPromise = run.wait();
     run.cancel("manual-cancel");
 
-    expect(adapter.killMock).toHaveBeenCalledWith("SIGTERM", { graceMs: 5_000 });
+    expect(adapter.killMock).toHaveBeenCalledWith("SIGTERM");
     expect(adapter.killMock).not.toHaveBeenCalledWith("SIGKILL");
 
     await vi.advanceTimersByTimeAsync(4_999);
@@ -238,7 +234,7 @@ describe("process supervisor", () => {
 
     const firstExit = await firstRun.wait();
     const secondExit = await secondRun.wait();
-    expect(first.killMock).toHaveBeenCalledWith("SIGTERM", { graceMs: 5_000 });
+    expect(first.killMock).toHaveBeenCalledWith("SIGTERM");
     expect(["manual-cancel", "signal"]).toContain(firstExit.reason);
     expect(secondExit.reason).toBe("exit");
     expect(secondExit.stdout).toBe("new");
@@ -265,7 +261,7 @@ describe("process supervisor", () => {
     await vi.advanceTimersByTimeAsync(1);
 
     const exit = await exitPromise;
-    expect(adapter.killMock).toHaveBeenCalledWith("SIGTERM", { graceMs: 5_000 });
+    expect(adapter.killMock).toHaveBeenCalledWith("SIGTERM");
     expect(exit.reason).toBe("overall-timeout");
     expect(exit.timedOut).toBe(true);
   });

--- a/src/process/supervisor/supervisor.test.ts
+++ b/src/process/supervisor/supervisor.test.ts
@@ -65,8 +65,12 @@ function createStubChildAdapter(options?: {
       stderrListeners.push(listener);
     },
     wait: async () => await waitPromise,
-    kill: (signal) => {
-      killMock(signal);
+    kill: (signal, killOptions) => {
+      if (killOptions === undefined) {
+        killMock(signal);
+      } else {
+        killMock(signal, killOptions);
+      }
       options?.onKill?.(signal, adapter);
     },
     dispose: () => {
@@ -159,7 +163,7 @@ describe("process supervisor", () => {
     await vi.advanceTimersByTimeAsync(5);
 
     const exit = await exitPromise;
-    expect(adapter.killMock).toHaveBeenCalledWith("SIGTERM");
+    expect(adapter.killMock).toHaveBeenCalledWith("SIGTERM", { graceMs: 5_000 });
     await vi.advanceTimersByTimeAsync(5_000);
     expect(adapter.killMock).not.toHaveBeenCalledWith("SIGKILL");
     expect(exit.reason).toBe("no-output-timeout");
@@ -189,7 +193,7 @@ describe("process supervisor", () => {
     const exitPromise = run.wait();
     run.cancel("manual-cancel");
 
-    expect(adapter.killMock).toHaveBeenCalledWith("SIGTERM");
+    expect(adapter.killMock).toHaveBeenCalledWith("SIGTERM", { graceMs: 5_000 });
     expect(adapter.killMock).not.toHaveBeenCalledWith("SIGKILL");
 
     await vi.advanceTimersByTimeAsync(4_999);
@@ -234,7 +238,7 @@ describe("process supervisor", () => {
 
     const firstExit = await firstRun.wait();
     const secondExit = await secondRun.wait();
-    expect(first.killMock).toHaveBeenCalledWith("SIGTERM");
+    expect(first.killMock).toHaveBeenCalledWith("SIGTERM", { graceMs: 5_000 });
     expect(["manual-cancel", "signal"]).toContain(firstExit.reason);
     expect(secondExit.reason).toBe("exit");
     expect(secondExit.stdout).toBe("new");
@@ -261,7 +265,7 @@ describe("process supervisor", () => {
     await vi.advanceTimersByTimeAsync(1);
 
     const exit = await exitPromise;
-    expect(adapter.killMock).toHaveBeenCalledWith("SIGTERM");
+    expect(adapter.killMock).toHaveBeenCalledWith("SIGTERM", { graceMs: 5_000 });
     expect(exit.reason).toBe("overall-timeout");
     expect(exit.timedOut).toBe(true);
   });

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -20,6 +20,8 @@ type ActiveRun = {
   scopeKey?: string;
 };
 
+const GRACEFUL_CANCEL_TIMEOUT_MS = 5000;
+
 let supervisorLogRuntimePromise: Promise<SupervisorLogRuntime> | undefined;
 
 function loadSupervisorLogRuntime(): Promise<SupervisorLogRuntime> {
@@ -91,6 +93,7 @@ export function createProcessSupervisor(): ProcessSupervisor {
     let stderr = "";
     let timeoutTimer: NodeJS.Timeout | null = null;
     let noOutputTimer: NodeJS.Timeout | null = null;
+    let forceKillTimer: NodeJS.Timeout | null = null;
     const captureOutput = input.captureOutput !== false;
 
     const overallTimeoutMs = clampTimeout(input.timeoutMs);
@@ -163,13 +166,23 @@ export function createProcessSupervisor(): ProcessSupervisor {
           clearTimeout(noOutputTimer);
           noOutputTimer = null;
         }
+        if (forceKillTimer) {
+          clearTimeout(forceKillTimer);
+          forceKillTimer = null;
+        }
       };
 
       cancelAdapter = (_reason: TerminationReason) => {
-        if (settled) {
+        if (settled || forceKillTimer) {
           return;
         }
-        adapter.kill("SIGKILL");
+        adapter.kill("SIGTERM");
+        forceKillTimer = setTimeout(() => {
+          if (!settled) {
+            adapter.kill("SIGKILL");
+          }
+        }, GRACEFUL_CANCEL_TIMEOUT_MS);
+        forceKillTimer.unref?.();
       };
 
       if (overallTimeoutMs) {

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -176,7 +176,7 @@ export function createProcessSupervisor(): ProcessSupervisor {
         if (settled || forceKillTimer) {
           return;
         }
-        adapter.kill("SIGTERM");
+        adapter.kill("SIGTERM", { graceMs: GRACEFUL_CANCEL_TIMEOUT_MS });
         forceKillTimer = setTimeout(() => {
           if (!settled) {
             adapter.kill("SIGKILL");

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -176,7 +176,7 @@ export function createProcessSupervisor(): ProcessSupervisor {
         if (settled || forceKillTimer) {
           return;
         }
-        adapter.kill("SIGTERM", { graceMs: GRACEFUL_CANCEL_TIMEOUT_MS });
+        adapter.kill("SIGTERM");
         forceKillTimer = setTimeout(() => {
           if (!settled) {
             adapter.kill("SIGKILL");

--- a/src/process/supervisor/types.ts
+++ b/src/process/supervisor/types.ts
@@ -63,7 +63,7 @@ export type SpawnProcessAdapter<WaitSignal = NodeJS.Signals | number | null> = {
   onStdout: (listener: (chunk: string) => void) => void;
   onStderr: (listener: (chunk: string) => void) => void;
   wait: () => Promise<{ code: number | null; signal: WaitSignal }>;
-  kill: (signal?: NodeJS.Signals) => void;
+  kill: (signal?: NodeJS.Signals, options?: { graceMs?: number }) => void;
   dispose: () => void;
 };
 

--- a/src/process/supervisor/types.ts
+++ b/src/process/supervisor/types.ts
@@ -63,7 +63,7 @@ export type SpawnProcessAdapter<WaitSignal = NodeJS.Signals | number | null> = {
   onStdout: (listener: (chunk: string) => void) => void;
   onStderr: (listener: (chunk: string) => void) => void;
   wait: () => Promise<{ code: number | null; signal: WaitSignal }>;
-  kill: (signal?: NodeJS.Signals, options?: { graceMs?: number }) => void;
+  kill: (signal?: NodeJS.Signals) => void;
   dispose: () => void;
 };
 


### PR DESCRIPTION
## Summary

- Problem: timeout/cancel paths need a graceful cleanup window, but the first draft sent SIGTERM only to the direct child and could leave descendants running.
- Solution: pass a 5s grace window through the supervisor adapter API and make child/PTY SIGTERM cancellation use the same process-tree/group path as hard cancellation.
- What changed: supervisor cancellation now calls `adapter.kill("SIGTERM", { graceMs: 5000 })`; child and PTY adapters route SIGTERM through `killProcessTree`; tests cover tree-aware SIGTERM and no-detach safeguards.
- What did NOT change (scope boundary): no new token/network/config behavior, no change to timeout reason semantics, and no claim that this PR changes production agent-provider behavior outside process cancellation.

## Motivation

Timeouts can happen while tool subprocesses are writing session state, cleaning temp files, or closing resources. This PR gives subprocesses a bounded graceful shutdown window while preserving the existing process-tree stop guarantee for descendants.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #66399
- Related #85865 review feedback from ClawSweeper
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: process supervisor timeout cancellation now gives real child processes and descendants a bounded SIGTERM cleanup window while preserving tree-aware SIGKILL fallback.
- Real environment tested: fresh throwaway Linux checkout on a test server, Node.js v22.22.2, dependencies installed with `corepack pnpm install --frozen-lockfile`. The descendant regression was run against old PR head `e7ed7242ceb18783de1559d6dd700c973d2b726c`, then after applying the tree-aware patch that produced head `720a57df0358976503d2ec501fb68e32d8ecb910`.
- Exact steps or command run after this patch:

```bash
git checkout -f e7ed7242ceb18783de1559d6dd700c973d2b726c
node --import tsx ../PR-2026-05-24-process-supervisor-66399-proof.mjs

git apply ../openclaw-66399-tree-aware-incremental.patch
node --import tsx ../PR-2026-05-24-process-supervisor-66399-proof.mjs
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```json
{
  "proof": "process-supervisor-graceful-cancel-66399",
  "cleanupCase": {
    "name": "cleanup",
    "exitReason": "overall-timeout",
    "exitCode": 0,
    "exitSignal": null,
    "timedOut": true,
    "stdout": [
      "child_ready=true",
      "child_observed_sigterm=true",
      "child_finished_async_cleanup=true"
    ],
    "markerWritten": true
  },
  "fallbackCase": {
    "name": "fallback",
    "exitReason": "overall-timeout",
    "exitCode": null,
    "exitSignal": "SIGKILL",
    "timedOut": true,
    "stdout": [
      "child_ready=true",
      "child_observed_sigterm=true",
      "child_ignores_sigterm=true"
    ],
    "markerWritten": false
  },
  "descendantCase": {
    "name": "descendant",
    "exitReason": "overall-timeout",
    "exitCode": 0,
    "exitSignal": null,
    "timedOut": true,
    "stdout": [
      "parent_ready=true",
      "descendant_pid=43906"
    ],
    "parentMarkerWritten": true,
    "descendantMarkerWritten": true,
    "descendantPid": 43906,
    "descendantAliveAfterWait": false
  }
}
```

- Observed result after fix: the cleanup child observed SIGTERM and completed async cleanup; the SIGTERM-ignoring child was force-killed by SIGKILL; the parent-exits/descendant case now signals the descendant, writes the descendant marker, and leaves no live descendant after wait.
- What was not tested: Windows live runtime and production external agent integrations were not exercised. This PR does not add separate pipe-close behavior beyond preserving the existing adapter wait/fallback behavior.
- Before evidence (optional but encouraged): the previous PR head reproduced ClawSweeper's descendant concern with the same proof runner:

```json
{
  "proof": "process-supervisor-graceful-cancel-66399",
  "descendantCase": {
    "name": "descendant",
    "exitReason": "overall-timeout",
    "exitCode": 0,
    "exitSignal": null,
    "timedOut": true,
    "stdout": [
      "parent_ready=true",
      "descendant_pid=43701"
    ],
    "parentMarkerWritten": true,
    "descendantMarkerWritten": false,
    "descendantPid": 43701,
    "descendantAliveAfterWait": true
  }
}
```

## Root Cause (if applicable)

- Root cause: the first draft changed the supervisor to request `adapter.kill("SIGTERM")`, but the child adapter treated non-SIGKILL signals as direct child-only signals instead of using the process-tree path.
- Missing detection / guardrail: tests covered direct-child cleanup and SIGKILL escalation, but did not cover a parent that exits on SIGTERM while its descendant would otherwise keep running.
- Contributing context (if known): the existing hard-kill path already had detached/no-detach safeguards; graceful cancellation needed to preserve that same boundary.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/process/supervisor/supervisor.test.ts`, `src/process/supervisor/adapters/child.test.ts`, `src/process/supervisor/adapters/pty.test.ts`
- Scenario the test should lock in: cancellation sends tree-aware SIGTERM with the same grace window, does not SIGKILL if the run settles, and still preserves no-detach safeguards so the gateway process group is not signaled.
- Why this is the smallest reliable guardrail: the supervisor owns grace timing, while child/PTY adapters own process-tree signal semantics.
- Existing test that already covers this (if any): `kill-tree.test.ts` already covers the underlying process-group/direct-pid behavior; this PR adds adapter-level coverage for SIGTERM using that path.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Timed-out or cancelled exec/tool subprocesses now get a bounded 5s tree-aware SIGTERM cleanup window before SIGKILL. Processes or descendants that ignore SIGTERM are still force-killed by the existing process-tree path.

## Diagram (if applicable)

```text
Before first draft:
[timeout/cancel] -> [supervisor requests SIGKILL tree path]

First draft bug:
[timeout/cancel] -> [direct child SIGTERM] -> [parent exits] -> [descendant can survive]

After:
[timeout/cancel] -> [tree-aware SIGTERM with 5s grace]
                 -> [cleanup-capable tree exits]
                 -> [if still running after grace] -> [tree-aware SIGKILL]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): Yes
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: cancellation behavior changed in the command execution boundary. The mitigation is that SIGTERM now uses the existing process-tree kill helper and preserves detached:false safeguards before the bounded SIGKILL fallback.

## Repro + Verification

### Environment

- OS: Linux throwaway test server checkout
- Runtime/container: Node.js v22.22.2, pnpm via corepack
- Model/provider: N/A
- Integration/channel (if any): process supervisor child mode and PTY adapter unit coverage
- Relevant config (redacted): no private tokens or external services used

### Steps

1. Run the proof script on old PR head `e7ed7242ceb18783de1559d6dd700c973d2b726c` to reproduce direct-child-only SIGTERM leaving a descendant alive.
2. Apply the tree-aware adapter patch.
3. Rerun the proof script and confirm the descendant receives SIGTERM and is no longer alive after wait.
4. Run focused supervisor/adapter/runtime tests, formatting, lint, and typechecks.

### Expected

- Cleanup-capable direct child receives SIGTERM and exits cleanly before SIGKILL.
- SIGTERM-ignoring direct child is later force-killed by SIGKILL.
- Parent-exits/descendant case sends SIGTERM to the descendant and leaves no surviving descendant after wait.

### Actual

- Matches expected after this patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Additional verification run on the same throwaway checkout after applying the patch:

```text
node scripts/run-vitest.mjs src/process/supervisor/supervisor.test.ts src/process/supervisor/adapters/child.test.ts src/process/supervisor/adapters/pty.test.ts src/process/kill-tree.test.ts
Test Files 4 passed (4)
Tests 42 passed (42)

node scripts/run-vitest.mjs src/agents/bash-tools.exec-runtime.test.ts src/agents/bash-tools.exec-runtime.pty-fallback.test.ts src/agents/cli-runner.reliability.test.ts src/agents/bash-tools.process.supervisor.test.ts
Test Files 8 passed (8)
Tests 140 passed (140)

corepack pnpm exec oxfmt --check --threads=1 src/process/supervisor/types.ts src/process/supervisor/supervisor.ts src/process/supervisor/supervisor.test.ts src/process/supervisor/adapters/child.ts src/process/supervisor/adapters/child.test.ts src/process/supervisor/adapters/pty.ts src/process/supervisor/adapters/pty.test.ts
All matched files use the correct format.

git diff --check
passed

node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/process/supervisor/supervisor.ts src/process/supervisor/supervisor.test.ts src/process/supervisor/adapters/child.ts src/process/supervisor/adapters/child.test.ts
Found 0 warnings and 0 errors.

node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
passed

node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
passed
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: live timeout behavior before and after patch with real child processes; graceful SIGTERM cleanup; SIGTERM-ignore fallback to SIGKILL; parent-exits/descendant-survives regression red and green; focused supervisor/adapter tests; exec runtime tests; formatting; targeted lint; core typechecks.
- Edge cases checked: cancellation passes the same grace value into tree-aware adapter cancellation; child adapter preserves detached:false behavior when spawn falls back to no-detach; PTY SIGTERM uses the process-tree path.
- What you did **not** verify: Windows live runtime and production external agent integrations.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No inline review threads exist. The top-level ClawSweeper finding about process-tree cancellation is addressed by the latest commit.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: cancellation may keep process-tree cleanup work active for up to 5s before force kill.
  - Mitigation: fixed grace timer is passed to the tree-aware helper and SIGKILL fallback remains bounded.
- Risk: detached:false runtimes must not group-kill the gateway process group.
  - Mitigation: child adapter keeps passing `{ detached: false }` when spawn falls back to no-detach or service-managed mode disables detachment.
