### PR TITLE
fix: emit agent.send lifecycle hooks on rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway: emit plugin `session_end`/`session_start` hooks when `agent.send` rotates or replaces a session id, keeping hook lifecycle state aligned with `sessions.changed` notifications. Fixes #83507. (#85875) Thanks @brokemac79.
 - OpenShell/SSH: reject malformed generated exec commands before sandbox/session setup so unresolved workflow placeholders fail fast instead of reaching the remote shell. Fixes #72373. Thanks @brokemac79.
 - Installer: make Alpine apk installs cover Git, verify the Node runtime floor, try `nodejs-current`, and report Alpine version guidance when repositories only provide older Node packages.
 - Agents/media: send direct fallback for generated media still missing after an active requester wake fails. (#85489) Thanks @fuller-stack-dev.

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -144,22 +144,8 @@ function resolveSessionDefaultAccountId(params: {
 function resolveStaleSessionEndReason(params: {
   entry: SessionEntry | undefined;
   freshness?: SessionFreshness;
-  now: number;
 }): ReplySessionEndReason | undefined {
-  if (!params.entry || !params.freshness) {
-    return undefined;
-  }
-  const staleDaily =
-    params.freshness.dailyResetAt != null && params.entry.updatedAt < params.freshness.dailyResetAt;
-  const staleIdle =
-    params.freshness.idleExpiresAt != null && params.now > params.freshness.idleExpiresAt;
-  if (staleIdle) {
-    return "idle";
-  }
-  if (staleDaily) {
-    return "daily";
-  }
-  return undefined;
+  return params.entry ? params.freshness?.staleReason : undefined;
 }
 
 function hasProviderOwnedSession(entry: SessionEntry | undefined): boolean {
@@ -493,7 +479,6 @@ export async function initSessionState(params: {
     : resolveStaleSessionEndReason({
         entry,
         freshness: entryFreshness,
-        now,
       });
   clearBootstrapSnapshotOnSessionRollover({
     sessionKey,

--- a/src/config/sessions/reset-policy.ts
+++ b/src/config/sessions/reset-policy.ts
@@ -15,6 +15,7 @@ export type SessionFreshness = {
   fresh: boolean;
   dailyResetAt?: number;
   idleExpiresAt?: number;
+  staleReason?: SessionResetMode;
 };
 
 export const DEFAULT_RESET_MODE: SessionResetMode = "daily";
@@ -90,10 +91,21 @@ export function evaluateSessionFreshness(params: {
       : undefined;
   const staleDaily = dailyResetAt != null && sessionStartedAt < dailyResetAt;
   const staleIdle = idleExpiresAt != null && params.now > idleExpiresAt;
+  const staleReason =
+    staleDaily && staleIdle
+      ? (dailyResetAt ?? Number.POSITIVE_INFINITY) <= (idleExpiresAt ?? Number.POSITIVE_INFINITY)
+        ? "daily"
+        : "idle"
+      : staleIdle
+        ? "idle"
+        : staleDaily
+          ? "daily"
+          : undefined;
   return {
     fresh: !(staleDaily || staleIdle),
     dailyResetAt,
     idleExpiresAt,
+    ...(staleReason ? { staleReason } : {}),
   };
 }
 

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -174,6 +174,7 @@ describe("resolveSessionResetPolicy", () => {
     });
 
     expect(freshness.fresh).toBe(false);
+    expect(freshness.staleReason).toBe("daily");
   });
 
   it("uses lastInteractionAt, not updatedAt, for idle reset freshness", () => {
@@ -191,6 +192,7 @@ describe("resolveSessionResetPolicy", () => {
 
     expect(freshness.fresh).toBe(false);
     expect(freshness.idleExpiresAt).toBe(5 * 60_000);
+    expect(freshness.staleReason).toBe("idle");
   });
 
   it("falls back to sessionStartedAt, not updatedAt, for legacy idle freshness", () => {
@@ -208,6 +210,25 @@ describe("resolveSessionResetPolicy", () => {
 
     expect(freshness.fresh).toBe(false);
     expect(freshness.idleExpiresAt).toBe(5 * 60_000);
+    expect(freshness.staleReason).toBe("idle");
+  });
+
+  it("reports the first expired reset deadline when daily and idle are both stale", () => {
+    const now = new Date(2026, 3, 25, 12, 0, 0, 0).getTime();
+    const freshness = evaluateSessionFreshness({
+      updatedAt: now,
+      sessionStartedAt: new Date(2026, 3, 24, 23, 0, 0, 0).getTime(),
+      lastInteractionAt: new Date(2026, 3, 25, 11, 0, 0, 0).getTime(),
+      now,
+      policy: {
+        mode: "daily",
+        atHour: 4,
+        idleMinutes: 30,
+      },
+    });
+
+    expect(freshness.fresh).toBe(false);
+    expect(freshness.staleReason).toBe("daily");
   });
 
   it("does not let future legacy updatedAt values keep daily sessions fresh", () => {

--- a/src/gateway/server-methods/agent.create-event.test.ts
+++ b/src/gateway/server-methods/agent.create-event.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearActiveSessionsForShutdownTracker } from "../active-sessions-shutdown-tracker.js";
 
 const configMocks = vi.hoisted(() => ({
   storePath: "",
@@ -62,6 +63,7 @@ describe("agent handler session create events", () => {
   });
 
   afterEach(async () => {
+    clearActiveSessionsForShutdownTracker();
     await fs.rm(tempDir, { recursive: true, force: true });
     vi.restoreAllMocks();
   });

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -32,6 +32,8 @@ const mocks = vi.hoisted(() => ({
   registerAgentRunContext: vi.fn(),
   emitAgentEvent: vi.fn(),
   performGatewaySessionReset: vi.fn(),
+  emitGatewaySessionEndPluginHook: vi.fn(),
+  emitGatewaySessionStartPluginHook: vi.fn(),
   getLatestSubagentRunByChildSessionKey: vi.fn(),
   replaceSubagentRunAfterSteer: vi.fn(),
   resolveExplicitAgentSessionKey: vi.fn(),
@@ -139,6 +141,10 @@ vi.mock("../session-subagent-reactivation.runtime.js", () => ({
 }));
 
 vi.mock("../session-reset-service.js", () => ({
+  emitGatewaySessionEndPluginHook: (...args: unknown[]) =>
+    (mocks.emitGatewaySessionEndPluginHook as (...args: unknown[]) => unknown)(...args),
+  emitGatewaySessionStartPluginHook: (...args: unknown[]) =>
+    (mocks.emitGatewaySessionStartPluginHook as (...args: unknown[]) => unknown)(...args),
   performGatewaySessionReset: (...args: unknown[]) =>
     (mocks.performGatewaySessionReset as (...args: unknown[]) => unknown)(...args),
 }));
@@ -500,6 +506,8 @@ describe("gateway agent handler", () => {
     resetDetachedTaskLifecycleRuntimeForTests();
     resetTaskRegistryForTests();
     mocks.loadConfigReturn = {};
+    mocks.emitGatewaySessionEndPluginHook.mockReset();
+    mocks.emitGatewaySessionStartPluginHook.mockReset();
     mocks.resolveExplicitAgentSessionKey.mockReset().mockReturnValue(undefined);
     mocks.resolveBareResetBootstrapFileAccess.mockReset().mockReturnValue(true);
     mocks.listAgentIds.mockReset().mockReturnValue(["main"]);
@@ -2859,6 +2867,7 @@ describe("gateway agent handler", () => {
         meta: { durationMs: 100 },
       });
 
+      const broadcastToConnIds = vi.fn();
       await invokeAgent(
         {
           message: "daily rollover",
@@ -2866,7 +2875,14 @@ describe("gateway agent handler", () => {
           sessionKey: "agent:main:main",
           idempotencyKey: "daily-rollover-agent-session",
         },
-        { reqId: "daily-rollover-agent-session" },
+        {
+          reqId: "daily-rollover-agent-session",
+          context: {
+            ...makeContext(),
+            broadcastToConnIds,
+            getSessionEventSubscriberConnIds: () => new Set(["conn-1"]),
+          },
+        },
       );
 
       const call = await waitForAgentCommandCall<{
@@ -2877,6 +2893,116 @@ describe("gateway agent handler", () => {
       expect(call.sessionId).not.toBe("stale-session-id");
       expect(capturedEntry?.sessionStartedAt).toBe(now);
       expect(capturedEntry?.lastInteractionAt).toBe(now);
+      expect(mocks.emitGatewaySessionEndPluginHook).toHaveBeenCalledTimes(1);
+      expectRecordFields(
+        mockCallArg(mocks.emitGatewaySessionEndPluginHook) as Record<string, unknown>,
+        {
+          sessionKey: "agent:main:main",
+          sessionId: "stale-session-id",
+          reason: "daily",
+          storePath: "/tmp/sessions.json",
+          nextSessionId: call.sessionId,
+          nextSessionKey: "agent:main:main",
+        },
+      );
+      expect(mocks.emitGatewaySessionStartPluginHook).toHaveBeenCalledTimes(1);
+      expectRecordFields(
+        mockCallArg(mocks.emitGatewaySessionStartPluginHook) as Record<string, unknown>,
+        {
+          sessionKey: "agent:main:main",
+          sessionId: call.sessionId,
+          resumedFrom: "stale-session-id",
+          storePath: "/tmp/sessions.json",
+        },
+      );
+      expect(broadcastToConnIds.mock.calls.map((call) => call[1]?.reason)).toEqual([
+        "create",
+        "send",
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("emits lifecycle hooks and sessions.changed when an explicit sessionId replaces a fresh session", async () => {
+    const now = Date.parse("2026-04-25T12:00:00.000Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    try {
+      mockMainSessionEntry({
+        sessionId: "current-session-id",
+        updatedAt: now,
+        sessionStartedAt: now,
+        lastInteractionAt: now,
+      });
+      const loaded = mocks.loadSessionEntry();
+      let capturedEntry: Record<string, unknown> | undefined;
+      mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+        const store: Record<string, unknown> = {
+          [loaded.canonicalKey]: structuredClone(loaded.entry),
+        };
+        const result = await updater(store);
+        capturedEntry = result as Record<string, unknown>;
+        return result;
+      });
+      mocks.agentCommand.mockResolvedValue({
+        payloads: [{ text: "ok" }],
+        meta: { durationMs: 100 },
+      });
+
+      const broadcastToConnIds = vi.fn();
+      await invokeAgent(
+        {
+          message: "explicit replacement",
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          sessionId: "caller-selected-session-id",
+          idempotencyKey: "explicit-replacement-agent-session",
+        },
+        {
+          reqId: "explicit-replacement-agent-session",
+          context: {
+            ...makeContext(),
+            broadcastToConnIds,
+            getSessionEventSubscriberConnIds: () => new Set(["conn-1"]),
+          },
+        },
+      );
+
+      const call = await waitForAgentCommandCall<{
+        sessionId?: string;
+        sessionKey?: string;
+      }>();
+      expect(call.sessionKey).toBe("agent:main:main");
+      expect(call.sessionId).toBe("caller-selected-session-id");
+      expect(capturedEntry?.sessionId).toBe("caller-selected-session-id");
+      expect(capturedEntry?.sessionStartedAt).toBe(now);
+      expect(mocks.emitGatewaySessionEndPluginHook).toHaveBeenCalledTimes(1);
+      expectRecordFields(
+        mockCallArg(mocks.emitGatewaySessionEndPluginHook) as Record<string, unknown>,
+        {
+          sessionKey: "agent:main:main",
+          sessionId: "current-session-id",
+          reason: "new",
+          storePath: "/tmp/sessions.json",
+          nextSessionId: "caller-selected-session-id",
+          nextSessionKey: "agent:main:main",
+        },
+      );
+      expect(mocks.emitGatewaySessionStartPluginHook).toHaveBeenCalledTimes(1);
+      expectRecordFields(
+        mockCallArg(mocks.emitGatewaySessionStartPluginHook) as Record<string, unknown>,
+        {
+          sessionKey: "agent:main:main",
+          sessionId: "caller-selected-session-id",
+          resumedFrom: "current-session-id",
+          storePath: "/tmp/sessions.json",
+        },
+      );
+      expect(broadcastToConnIds.mock.calls.map((call) => call[1]?.reason)).toEqual([
+        "create",
+        "send",
+      ]);
     } finally {
       vi.useRealTimers();
     }
@@ -3980,6 +4106,8 @@ describe("gateway agent handler chat.abort integration", () => {
     mocks.loadGatewaySessionRow.mockReset();
     mocks.loadSessionEntry.mockReset();
     mocks.updateSessionStore.mockReset();
+    mocks.emitGatewaySessionEndPluginHook.mockReset();
+    mocks.emitGatewaySessionStartPluginHook.mockReset();
     mocks.getLatestSubagentRunByChildSessionKey.mockReset();
     mocks.replaceSubagentRunAfterSteer.mockReset();
     mocks.resolveExplicitAgentSessionKey.mockReset().mockReturnValue(undefined);

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -2924,6 +2924,79 @@ describe("gateway agent handler", () => {
     }
   });
 
+  it("emits idle lifecycle reason when inactivity rotates a gateway agent session", async () => {
+    const now = Date.parse("2026-04-25T12:00:00.000Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    try {
+      mocks.resolveExplicitAgentSessionKey.mockReturnValue("agent:main:main");
+      mockMainSessionEntry(
+        {
+          sessionId: "idle-session-id",
+          updatedAt: now,
+          sessionStartedAt: now,
+          lastInteractionAt: now - 60 * 60_000,
+        },
+        {
+          session: {
+            reset: {
+              mode: "idle",
+              idleMinutes: 5,
+            },
+          },
+        },
+      );
+      const loaded = mocks.loadSessionEntry();
+      mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+        const store: Record<string, unknown> = {
+          [loaded.canonicalKey]: structuredClone(loaded.entry),
+        };
+        return updater(store);
+      });
+      mocks.agentCommand.mockResolvedValue({
+        payloads: [{ text: "ok" }],
+        meta: { durationMs: 100 },
+      });
+
+      await invokeAgent(
+        {
+          message: "idle rollover",
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          idempotencyKey: "idle-rollover-agent-session",
+        },
+        { reqId: "idle-rollover-agent-session" },
+      );
+
+      const call = await waitForAgentCommandCall<{
+        sessionId?: string;
+        sessionKey?: string;
+      }>();
+      expect(call.sessionKey).toBe("agent:main:main");
+      expect(call.sessionId).not.toBe("idle-session-id");
+      expectRecordFields(
+        mockCallArg(mocks.emitGatewaySessionEndPluginHook) as Record<string, unknown>,
+        {
+          sessionKey: "agent:main:main",
+          sessionId: "idle-session-id",
+          reason: "idle",
+          nextSessionId: call.sessionId,
+          nextSessionKey: "agent:main:main",
+        },
+      );
+      expectRecordFields(
+        mockCallArg(mocks.emitGatewaySessionStartPluginHook) as Record<string, unknown>,
+        {
+          sessionKey: "agent:main:main",
+          sessionId: call.sessionId,
+          resumedFrom: "idle-session-id",
+        },
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("emits lifecycle hooks and sessions.changed when an explicit sessionId replaces a fresh session", async () => {
     const now = Date.parse("2026-04-25T12:00:00.000Z");
     vi.useFakeTimers();

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -2997,6 +2997,80 @@ describe("gateway agent handler", () => {
     }
   });
 
+  it("emits lifecycle hooks when a committed rotation later fails delivery validation", async () => {
+    const now = Date.parse("2026-04-25T12:00:00.000Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    try {
+      mocks.resolveExplicitAgentSessionKey.mockReturnValue("agent:main:main");
+      mockMainSessionEntry(
+        {
+          sessionId: "stale-before-validation-id",
+          updatedAt: now,
+          sessionStartedAt: now - 25 * 60 * 60_000,
+          lastInteractionAt: now - 25 * 60 * 60_000,
+        },
+        {
+          session: {
+            reset: {
+              mode: "daily",
+              atHour: 4,
+            },
+          },
+        },
+      );
+      const loaded = mocks.loadSessionEntry();
+      mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+        const store: Record<string, unknown> = {
+          [loaded.canonicalKey]: structuredClone(loaded.entry),
+        };
+        return updater(store);
+      });
+      mocks.agentCommand.mockClear();
+      const respond = vi.fn();
+
+      await invokeAgent(
+        {
+          message: "strict missing delivery target after rollover",
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          deliver: true,
+          replyChannel: "telegram",
+          bestEffortDeliver: false,
+          idempotencyKey: "lifecycle-before-delivery-validation",
+        },
+        {
+          reqId: "lifecycle-before-delivery-validation",
+          respond,
+          flushDispatch: false,
+        },
+      );
+
+      expect(mocks.agentCommand).not.toHaveBeenCalled();
+      const error = expectRespondError(respond, {});
+      expectStringFieldContains(error, "message", "requires target");
+      expect(mocks.emitGatewaySessionEndPluginHook).toHaveBeenCalledTimes(1);
+      expectRecordFields(
+        mockCallArg(mocks.emitGatewaySessionEndPluginHook) as Record<string, unknown>,
+        {
+          sessionKey: "agent:main:main",
+          sessionId: "stale-before-validation-id",
+          reason: "daily",
+        },
+      );
+      expect(mocks.emitGatewaySessionStartPluginHook).toHaveBeenCalledTimes(1);
+      expectRecordFields(
+        mockCallArg(mocks.emitGatewaySessionStartPluginHook) as Record<string, unknown>,
+        {
+          sessionKey: "agent:main:main",
+          resumedFrom: "stale-before-validation-id",
+        },
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("emits lifecycle hooks and sessions.changed when an explicit sessionId replaces a fresh session", async () => {
     const now = Date.parse("2026-04-25T12:00:00.000Z");
     vi.useFakeTimers();

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1206,7 +1206,6 @@ export const agentHandlers: GatewayRequestHandlers = {
       let isNewSession = false;
       let skipTimestampInjection = false;
       let shouldPrependStartupContext = false;
-      let sessionLifecycleTransition: AgentSendSessionLifecycleTransition | undefined;
 
       const resetCommandMatch = message.match(RESET_COMMAND_RE);
       if (resetCommandMatch && requestedSessionKey) {
@@ -1574,6 +1573,32 @@ export const agentHandlers: GatewayRequestHandlers = {
         resolvedGroupId = patchBuild.groupId;
         resolvedGroupChannel = patchBuild.groupChannel;
         resolvedGroupSpace = patchBuild.groupSpace;
+        if (
+          !suppressVisibleSessionEffects &&
+          isNewSession &&
+          resolvedSessionId &&
+          storePath &&
+          !patchBuild.freshSessionRotatedSinceLoad
+        ) {
+          const previousSessionId = rotatedSessionId ? entry?.sessionId : undefined;
+          const sessionLifecycleTransition: AgentSendSessionLifecycleTransition = {
+            cfg,
+            sessionKey: canonicalSessionKey,
+            sessionId: resolvedSessionId,
+            storePath,
+            sessionFile: sessionEntry?.sessionFile,
+            agentId,
+            previousSessionId,
+            previousSessionFile: previousSessionId ? entry?.sessionFile : undefined,
+            previousEndReason: previousSessionId
+              ? (freshness?.staleReason ??
+                (usableRequestedSessionId && entry?.sessionId !== usableRequestedSessionId
+                  ? "new"
+                  : "unknown"))
+              : undefined,
+          };
+          emitAgentSendSessionLifecycleTransition(sessionLifecycleTransition);
+        }
         if (request.deliver === true) {
           const sendPolicy = resolveSendPolicy({
             cfg,
@@ -1590,31 +1615,6 @@ export const agentHandlers: GatewayRequestHandlers = {
             );
             return;
           }
-        }
-        if (
-          !suppressVisibleSessionEffects &&
-          isNewSession &&
-          resolvedSessionId &&
-          storePath &&
-          !patchBuild.freshSessionRotatedSinceLoad
-        ) {
-          const previousSessionId = rotatedSessionId ? entry?.sessionId : undefined;
-          sessionLifecycleTransition = {
-            cfg,
-            sessionKey: canonicalSessionKey,
-            sessionId: resolvedSessionId,
-            storePath,
-            sessionFile: sessionEntry?.sessionFile,
-            agentId,
-            previousSessionId,
-            previousSessionFile: previousSessionId ? entry?.sessionFile : undefined,
-            previousEndReason: previousSessionId
-              ? (freshness?.staleReason ??
-                (usableRequestedSessionId && entry?.sessionId !== usableRequestedSessionId
-                  ? "new"
-                  : "unknown"))
-              : undefined,
-          };
         }
         if (
           !suppressVisibleSessionEffects &&
@@ -1914,7 +1914,6 @@ export const agentHandlers: GatewayRequestHandlers = {
           }
 
           if (requestedSessionKey && resolvedSessionKey && isNewSession) {
-            emitAgentSendSessionLifecycleTransition(sessionLifecycleTransition);
             emitSessionsChanged(context, {
               sessionKey: resolvedSessionKey,
               reason: "create",

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -220,50 +220,6 @@ function resolveCanUseInternalRuntimeHandoff(
   return client?.connect?.client?.mode === GATEWAY_CLIENT_MODES.BACKEND;
 }
 
-function normalizeLifecycleTimestamp(value: number | undefined, now: number): number | undefined {
-  if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || value > now) {
-    return undefined;
-  }
-  return value;
-}
-
-function resolveAgentSendRotationEndReason(params: {
-  updatedAt: number | undefined;
-  sessionStartedAt?: number;
-  lastInteractionAt?: number;
-  dailyResetAt?: number;
-  idleExpiresAt?: number;
-  now: number;
-  replacedByRequestedSessionId: boolean;
-}): PluginHookSessionEndReason {
-  const updatedAt = normalizeLifecycleTimestamp(params.updatedAt, params.now) ?? 0;
-  const sessionStartedAt =
-    normalizeLifecycleTimestamp(params.sessionStartedAt, params.now) ?? updatedAt;
-  const lastInteractionAt =
-    normalizeLifecycleTimestamp(params.lastInteractionAt, params.now) ?? sessionStartedAt;
-  const dailyExpired =
-    params.dailyResetAt != null && Number.isFinite(params.dailyResetAt)
-      ? sessionStartedAt < params.dailyResetAt
-      : false;
-  const idleExpired =
-    params.idleExpiresAt != null && Number.isFinite(params.idleExpiresAt)
-      ? params.now > params.idleExpiresAt && lastInteractionAt <= params.idleExpiresAt
-      : false;
-  if (dailyExpired && idleExpired) {
-    return (params.dailyResetAt ?? Number.POSITIVE_INFINITY) <=
-      (params.idleExpiresAt ?? Number.POSITIVE_INFINITY)
-      ? "daily"
-      : "idle";
-  }
-  if (dailyExpired) {
-    return "daily";
-  }
-  if (idleExpired) {
-    return "idle";
-  }
-  return params.replacedByRequestedSessionId ? "new" : "unknown";
-}
-
 function emitAgentSendSessionLifecycleTransition(
   transition: AgentSendSessionLifecycleTransition | undefined,
 ): void {
@@ -1653,17 +1609,10 @@ export const agentHandlers: GatewayRequestHandlers = {
             previousSessionId,
             previousSessionFile: previousSessionId ? entry?.sessionFile : undefined,
             previousEndReason: previousSessionId
-              ? resolveAgentSendRotationEndReason({
-                  updatedAt: entry?.updatedAt,
-                  sessionStartedAt: lifecycleTimestamps?.sessionStartedAt,
-                  lastInteractionAt: lifecycleTimestamps?.lastInteractionAt,
-                  dailyResetAt: freshness?.dailyResetAt,
-                  idleExpiresAt: freshness?.idleExpiresAt,
-                  now,
-                  replacedByRequestedSessionId: Boolean(
-                    usableRequestedSessionId && entry?.sessionId !== usableRequestedSessionId,
-                  ),
-                })
+              ? (freshness?.staleReason ??
+                (usableRequestedSessionId && entry?.sessionId !== usableRequestedSessionId
+                  ? "new"
+                  : "unknown"))
               : undefined,
           };
         }

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -67,6 +67,7 @@ import {
   resolveVoiceWakeRouteByTrigger,
 } from "../../infra/voicewake-routing.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
+import type { PluginHookSessionEndReason } from "../../plugins/hook-types.js";
 import {
   classifySessionKeyShape,
   isAcpSessionKey,
@@ -130,7 +131,11 @@ import {
   validateAgentParams,
   validateAgentWaitParams,
 } from "../protocol/index.js";
-import { performGatewaySessionReset } from "../session-reset-service.js";
+import {
+  emitGatewaySessionEndPluginHook,
+  emitGatewaySessionStartPluginHook,
+  performGatewaySessionReset,
+} from "../session-reset-service.js";
 import { reactivateCompletedSubagentSession } from "../session-subagent-reactivation.js";
 import {
   canonicalizeSpawnedByForAgent,
@@ -157,6 +162,18 @@ import type {
 } from "./types.js";
 
 const RESET_COMMAND_RE = /^\/(new|reset)(?:\s+([\s\S]*))?$/i;
+
+type AgentSendSessionLifecycleTransition = {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  sessionId: string;
+  storePath: string;
+  sessionFile?: string;
+  agentId?: string;
+  previousSessionId?: string;
+  previousSessionFile?: string;
+  previousEndReason?: PluginHookSessionEndReason;
+};
 
 function formatAttachmentFailureForLog(err: unknown): string {
   const primary = formatUncaughtError(err);
@@ -201,6 +218,80 @@ function resolveCanUseInternalRuntimeHandoff(
   client: GatewayRequestHandlerOptions["client"],
 ): boolean {
   return client?.connect?.client?.mode === GATEWAY_CLIENT_MODES.BACKEND;
+}
+
+function normalizeLifecycleTimestamp(value: number | undefined, now: number): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || value > now) {
+    return undefined;
+  }
+  return value;
+}
+
+function resolveAgentSendRotationEndReason(params: {
+  updatedAt: number | undefined;
+  sessionStartedAt?: number;
+  lastInteractionAt?: number;
+  dailyResetAt?: number;
+  idleExpiresAt?: number;
+  now: number;
+  replacedByRequestedSessionId: boolean;
+}): PluginHookSessionEndReason {
+  const updatedAt = normalizeLifecycleTimestamp(params.updatedAt, params.now) ?? 0;
+  const sessionStartedAt =
+    normalizeLifecycleTimestamp(params.sessionStartedAt, params.now) ?? updatedAt;
+  const lastInteractionAt =
+    normalizeLifecycleTimestamp(params.lastInteractionAt, params.now) ?? sessionStartedAt;
+  const dailyExpired =
+    params.dailyResetAt != null && Number.isFinite(params.dailyResetAt)
+      ? sessionStartedAt < params.dailyResetAt
+      : false;
+  const idleExpired =
+    params.idleExpiresAt != null && Number.isFinite(params.idleExpiresAt)
+      ? params.now > params.idleExpiresAt && lastInteractionAt <= params.idleExpiresAt
+      : false;
+  if (dailyExpired && idleExpired) {
+    return (params.dailyResetAt ?? Number.POSITIVE_INFINITY) <=
+      (params.idleExpiresAt ?? Number.POSITIVE_INFINITY)
+      ? "daily"
+      : "idle";
+  }
+  if (dailyExpired) {
+    return "daily";
+  }
+  if (idleExpired) {
+    return "idle";
+  }
+  return params.replacedByRequestedSessionId ? "new" : "unknown";
+}
+
+function emitAgentSendSessionLifecycleTransition(
+  transition: AgentSendSessionLifecycleTransition | undefined,
+): void {
+  if (!transition) {
+    return;
+  }
+  if (transition.previousSessionId) {
+    emitGatewaySessionEndPluginHook({
+      cfg: transition.cfg,
+      sessionKey: transition.sessionKey,
+      sessionId: transition.previousSessionId,
+      storePath: transition.storePath,
+      sessionFile: transition.previousSessionFile,
+      agentId: transition.agentId,
+      reason: transition.previousEndReason ?? "unknown",
+      nextSessionId: transition.sessionId,
+      nextSessionKey: transition.sessionKey,
+    });
+  }
+  emitGatewaySessionStartPluginHook({
+    cfg: transition.cfg,
+    sessionKey: transition.sessionKey,
+    sessionId: transition.sessionId,
+    resumedFrom: transition.previousSessionId,
+    storePath: transition.storePath,
+    sessionFile: transition.sessionFile,
+    agentId: transition.agentId,
+  });
 }
 
 async function runSessionResetFromAgent(params: {
@@ -1159,6 +1250,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       let isNewSession = false;
       let skipTimestampInjection = false;
       let shouldPrependStartupContext = false;
+      let sessionLifecycleTransition: AgentSendSessionLifecycleTransition | undefined;
 
       const resetCommandMatch = message.match(RESET_COMMAND_RE);
       if (resetCommandMatch && requestedSessionKey) {
@@ -1257,14 +1349,17 @@ export const agentHandlers: GatewayRequestHandlers = {
             channel: entry?.lastChannel ?? entry?.channel ?? request.channel,
           }),
         });
+        const lifecycleTimestamps = entry
+          ? resolveSessionLifecycleTimestamps({
+              entry,
+              storePath,
+              agentId: resolveAgentIdFromSessionKey(canonicalKey),
+            })
+          : undefined;
         const freshness = entry
           ? evaluateSessionFreshness({
               updatedAt: entry.updatedAt,
-              ...resolveSessionLifecycleTimestamps({
-                entry,
-                storePath,
-                agentId: resolveAgentIdFromSessionKey(canonicalKey),
-              }),
+              ...lifecycleTimestamps,
               now,
               policy: resetPolicy,
             })
@@ -1310,6 +1405,7 @@ export const agentHandlers: GatewayRequestHandlers = {
           groupId: string | undefined;
           groupChannel: string | undefined;
           groupSpace: string | undefined;
+          freshSessionRotatedSinceLoad: boolean;
         };
         const requestDeliveryHint = normalizeDeliveryContext({
           channel: request.channel?.trim(),
@@ -1447,6 +1543,7 @@ export const agentHandlers: GatewayRequestHandlers = {
             groupId: nextGroup.groupId,
             groupChannel: nextGroup.groupChannel,
             groupSpace: nextGroup.groupSpace,
+            freshSessionRotatedSinceLoad,
           };
         };
         let patchBuild = buildSessionPatch(entry);
@@ -1537,6 +1634,38 @@ export const agentHandlers: GatewayRequestHandlers = {
             );
             return;
           }
+        }
+        if (
+          !suppressVisibleSessionEffects &&
+          isNewSession &&
+          resolvedSessionId &&
+          storePath &&
+          !patchBuild.freshSessionRotatedSinceLoad
+        ) {
+          const previousSessionId = rotatedSessionId ? entry?.sessionId : undefined;
+          sessionLifecycleTransition = {
+            cfg,
+            sessionKey: canonicalSessionKey,
+            sessionId: resolvedSessionId,
+            storePath,
+            sessionFile: sessionEntry?.sessionFile,
+            agentId,
+            previousSessionId,
+            previousSessionFile: previousSessionId ? entry?.sessionFile : undefined,
+            previousEndReason: previousSessionId
+              ? resolveAgentSendRotationEndReason({
+                  updatedAt: entry?.updatedAt,
+                  sessionStartedAt: lifecycleTimestamps?.sessionStartedAt,
+                  lastInteractionAt: lifecycleTimestamps?.lastInteractionAt,
+                  dailyResetAt: freshness?.dailyResetAt,
+                  idleExpiresAt: freshness?.idleExpiresAt,
+                  now,
+                  replacedByRequestedSessionId: Boolean(
+                    usableRequestedSessionId && entry?.sessionId !== usableRequestedSessionId,
+                  ),
+                })
+              : undefined,
+          };
         }
         if (
           !suppressVisibleSessionEffects &&
@@ -1836,6 +1965,7 @@ export const agentHandlers: GatewayRequestHandlers = {
           }
 
           if (requestedSessionKey && resolvedSessionKey && isNewSession) {
+            emitAgentSendSessionLifecycleTransition(sessionLifecycleTransition);
             emitSessionsChanged(context, {
               sessionKey: resolvedSessionKey,
               reason: "create",


### PR DESCRIPTION
﻿Fixes #83507.## Summary- Emit the existing gateway `session_end` / `session_start` plugin hook helpers when `agent.send` creates a replacement session through stale-session rotation or explicit `sessionId` replacement.- Preserve the existing `sessions.changed` create/send notifications.- Pair the previous session close with the new session start so the active-session shutdown tracker does not retain the replaced session.- Add regression coverage for daily rollover and explicit replacement session IDs.This follows ClawSweeper's suggested fix shape: reuse the existing lifecycle hook helper path for `agent.send` auto-rotation and preserve the existing `sessions.changed` behavior.## Proof- `node scripts/run-vitest.mjs src/gateway/server-methods/agent.test.ts -t "emits lifecycle hooks and sessions.changed"` -> 2 passed- `node scripts/run-vitest.mjs src/gateway/server-methods/agent.create-event.test.ts src/gateway/server.sessions.reset-hooks.test.ts` -> 14 passed- `pnpm exec oxfmt --check --threads=1 src/gateway/server-methods/agent.ts src/gateway/server-methods/agent.test.ts src/gateway/server-methods/agent.create-event.test.ts` -> passed- `git diff --check` -> passed## Local Test NoteThe combined broader command `node scripts/run-vitest.mjs src/gateway/server-methods/agent.test.ts src/gateway/server-methods/agent.create-event.test.ts src/gateway/server.sessions.reset-hooks.test.ts` hit the local Windows desktop timeout; the same coverage was split into the targeted regression run plus the supporting suites above. Codex review closeout was attempted but the nested review process stalled during local timeout investigation, with no actionable code finding returned before it was stopped.

## Real behavior proof
- **Behavior or issue addressed**: `agent.send` explicit session replacement now emits the plugin session lifecycle pair that was previously missing: `session_end` for the replaced session and `session_start` for the replacement session.
- **Real environment tested**: Isolated local OpenClaw Gateway from this PR head `a2ea09de53` on Windows, temp `OPENCLAW_HOME`, `gateway.auth.mode=none`, a linked native proof plugin installed with `openclaw plugins install --link`, and a loopback OpenAI-compatible endpoint so provider credentials/latency did not affect the gateway and plugin lifecycle behavior under test.
- **Exact steps or command run after this patch**: Started the temp Gateway, ran two Gateway-backed `openclaw agent` sends against the same session key with `--session-id pr85875-before` and then `--session-id pr85875-after`, and failed the proof script if `EMBEDDED FALLBACK` or `gateway connect failed` appeared. The second send forces the explicit replacement path fixed by this PR.
- **Evidence after fix**:

```text
openclaw plugins list --json:
proof-agent-send-hooks status=loaded origin=config source=.../proof-agent-send-hooks/index.js

gateway log excerpt:
2026-05-24T03:42:28.010+01:00 [gateway] loading configuration...
2026-05-24T03:42:30.126+01:00 [gateway] auth mode=none explicitly configured; all gateway connections are unauthenticated.
2026-05-24T03:42:40.024+01:00 [gateway] ready

agent CLI proof summary:
firstExit=0 secondExit=0 modelRequests=2
fallback guard: no EMBEDDED FALLBACK and no gateway connect failed text observed

proof plugin hook log:
{"hook":"session_end","sessionKey":"agent:main:pr85875-proof","sessionId":"pr85875-before","reason":"new","nextSessionId":"pr85875-after","nextSessionKey":"agent:main:pr85875-proof","ctxSessionKey":"agent:main:pr85875-proof","ctxSessionId":"pr85875-before"}
{"hook":"session_start","sessionKey":"agent:main:pr85875-proof","sessionId":"pr85875-after","resumedFrom":"pr85875-before","ctxSessionKey":"agent:main:pr85875-proof","ctxSessionId":"pr85875-after"}
```

- **Observed result after fix**: The second Gateway-backed `agent.send` closed the previous session and immediately opened the replacement session through the real plugin hook runner. The observed hook pair matches the fixed behavior: `session_end(pr85875-before -> pr85875-after)` followed by `session_start(pr85875-after, resumedFrom=pr85875-before)`.
- **What was not tested**: Paid/live model-provider I/O and channel delivery were not tested; this proof isolates the Gateway/session/plugin lifecycle path changed by the PR.
