### PR TITLE
fix(telegram): retain superseded draft previews

### DIFF
--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -334,6 +334,7 @@ describe("createTelegramDraftStream", () => {
       textSnapshot: "Message A partial",
       parseMode: undefined,
       visibleSinceMs: supersededPreview.visibleSinceMs,
+      retain: true,
     });
     expect(typeof supersededPreview.visibleSinceMs).toBe("number");
     expect(Number.isFinite(supersededPreview.visibleSinceMs)).toBe(true);

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -177,6 +177,7 @@ export function createTelegramDraftStream(params: {
         textSnapshot: renderedText,
         parseMode: renderedParseMode,
         visibleSinceMs,
+        retain: true,
       });
       return true;
     }


### PR DESCRIPTION
Summary:
- Preserve Telegram draft previews that were superseded after a new generation already forced a new message.
- Recreates #85825 on a maintainer branch because the original contributor branch no longer allows maintainer updates.

Behavior addressed:
Telegram could delete a successfully visible superseded preview after a generation mismatch race when `forceNewMessage` moved the active draft forward.

Real environment tested:
Focused local Vitest coverage for the Telegram draft-stream state machine.

Exact steps or command run after this patch:
`node scripts/run-vitest.mjs extensions/telegram/src/draft-stream.test.ts`
`.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "node scripts/run-vitest.mjs extensions/telegram/src/draft-stream.test.ts"`

Evidence after fix:
The regression assertion now checks that the superseded preview carries `retain: true`, matching the retained-preview path used when a message was already visible.

Observed result after fix:
32 draft-stream tests passed and autoreview reported no accepted/actionable findings.

What was not tested:
Live Telegram delivery; the changed behavior is the deterministic local preview-retention state transition.

Credit:
Thanks @NianJiuZst for the original report/fix in #85825.
