### PR TITLE
test(heartbeat): cover target none scheduler dispatch

### DIFF
--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -238,6 +238,29 @@ describe("startHeartbeatRunner", () => {
     runner.stop();
   });
 
+  it("dispatches scheduled heartbeats when delivery target is explicitly none", async () => {
+    useFakeHeartbeatTime();
+
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startHeartbeatRunner({
+      cfg: heartbeatConfig([{ id: "main", heartbeat: { every: "30m", target: "none" } }]),
+      runOnce: runSpy,
+      stableSchedulerSeed: TEST_SCHEDULER_SEED,
+    });
+    const mainDueMs = resolveDueFromNow(0, 30 * 60_000, "main");
+
+    await vi.advanceTimersByTimeAsync(mainDueMs + 1);
+
+    expect(runSpy).toHaveBeenCalledTimes(1);
+    expectRunCallFields(runSpy, 0, {
+      agentId: "main",
+      reason: "interval",
+      heartbeat: { every: "30m", target: "none" },
+    });
+
+    runner.stop();
+  });
+
   it("continues scheduling after runOnce throws an unhandled error", async () => {
     useFakeHeartbeatTime();
 


### PR DESCRIPTION
## Summary

- Add a focused heartbeat scheduler regression test for an agent whose heartbeat delivery target is explicitly `none`.
- Assert the interval scheduler still dispatches the agent run and preserves the `target: "none"` heartbeat config on the run request.

Refs #85871.

## Tests

- `node scripts/run-vitest.mjs src/infra/heartbeat-runner.scheduler.test.ts`
- `node --import tsx -e 'const { startHeartbeatRunner } = await import("./src/infra/heartbeat-runner.ts"); let calls=[]; const runner=startHeartbeatRunner({ cfg:{agents:{list:[{id:"main",heartbeat:{every:"1s",target:"none"}}]}}, stableSchedulerSeed:"pr-85881-runtime-proof", runOnce: async (opts)=>{calls.push(opts); return {status:"ran", durationMs:1};} }); await new Promise((resolve,reject)=>{const deadline=setTimeout(()=>reject(new Error("heartbeat did not dispatch within 2500ms")),2500); const poll=setInterval(()=>{if(calls.length>0){clearTimeout(deadline); clearInterval(poll); resolve();}},25);}); runner.stop(); const first=calls[0]; console.log(`HEARTBEAT_TARGET_NONE_INTERVAL_DISPATCHED agent=${first.agentId} reason=${first.reason} target=${first.heartbeat?.target} every=${first.heartbeat?.every} calls=${calls.length}`);'`

## Real behavior proof

Behavior addressed: Scheduled heartbeat configuration with `target: "none"` should still trigger the heartbeat runner on the configured interval; `none` disables external delivery, not the internal agent run.
Real environment tested: macOS local checkout, actual OpenClaw heartbeat runner loaded from `src/infra/heartbeat-runner.ts` with Node plus the repo's `tsx` runtime loader.
Exact steps or command run after this patch: `node --import tsx -e 'const { startHeartbeatRunner } = await import("./src/infra/heartbeat-runner.ts"); let calls=[]; const runner=startHeartbeatRunner({ cfg:{agents:{list:[{id:"main",heartbeat:{every:"1s",target:"none"}}]}}, stableSchedulerSeed:"pr-85881-runtime-proof", runOnce: async (opts)=>{calls.push(opts); return {status:"ran", durationMs:1};} }); await new Promise((resolve,reject)=>{const deadline=setTimeout(()=>reject(new Error("heartbeat did not dispatch within 2500ms")),2500); const poll=setInterval(()=>{if(calls.length>0){clearTimeout(deadline); clearInterval(poll); resolve();}},25);}); runner.stop(); const first=calls[0]; console.log(`HEARTBEAT_TARGET_NONE_INTERVAL_DISPATCHED agent=${first.agentId} reason=${first.reason} target=${first.heartbeat?.target} every=${first.heartbeat?.every} calls=${calls.length}`);'`
Evidence after fix: Runtime console output after the patch was `[heartbeat] started` followed by `HEARTBEAT_TARGET_NONE_INTERVAL_DISPATCHED agent=main reason=interval target=none every=1s calls=1`.
Observed result after fix: The command exited 0 and showed that the actual heartbeat scheduler dispatched one interval run for an explicit `target: "none"` heartbeat config. The focused Vitest file also exited 0.
What was not tested: No live gateway daemon, external delivery channel, or real model/provider inference was run; this PR adds scheduler-path coverage rather than a full reproduction of #85871's deployed Ubuntu gateway report.
