### PR TITLE
fix(usage-cost): surface unpriced-model spend as missingCostEntries instead of a confident $0

### DIFF
--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -252,6 +252,53 @@ describe("session cost usage", () => {
     });
   });
 
+  it("treats a pre-upgrade (older-version) durable cache as stale so unpriced usage is rebuilt", async () => {
+    const root = await makeSessionCostRoot("cost-cache-upgrade");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-upgrade.jsonl");
+    const entry = {
+      type: "message",
+      timestamp: "2026-02-05T12:00:00.000Z",
+      message: {
+        role: "assistant",
+        provider: "openai",
+        model: "gpt-5.5",
+        usage: {
+          input: 881,
+          output: 6,
+          cacheRead: 22400,
+          cacheWrite: 0,
+          totalTokens: 23287,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+      },
+    };
+    await fs.writeFile(sessionFile, transcriptText("sess-upgrade", entry), "utf-8");
+
+    clearGatewayModelPricingCacheState();
+    await withStateDir(root, async () => {
+      // Simulate a durable cache written by a build from before this change: refresh
+      // under the current code, then stamp the cache with an older semantics version.
+      await refreshCostUsageCache({ sessionFiles: [sessionFile] });
+      const cachePath = path.join(sessionsDir, ".usage-cost-cache.json");
+      const cache = JSON.parse(await fs.readFile(cachePath, "utf-8")) as { version: number };
+      cache.version = 3;
+      await fs.writeFile(cachePath, `${JSON.stringify(cache)}\n`, "utf-8");
+
+      // The pre-upgrade cache must be treated as stale (not served), forcing a rebuild
+      // under the new missing-cost semantics instead of reusing old complete-$0 totals.
+      const cached = await loadSessionCostSummaryFromCache({
+        sessionId: "sess-upgrade",
+        sessionFile,
+        startMs: Date.UTC(2026, 1, 5),
+        endMs: Date.UTC(2026, 1, 5) + 24 * 60 * 60 * 1000 - 1,
+        requestRefresh: false,
+      });
+      expect(cached.cacheStatus.status).toBe("stale");
+    });
+  });
+
   it("ignores compaction checkpoint transcript snapshots in daily totals and discovery", async () => {
     const root = await makeSessionCostRoot("cost-checkpoint");
     const sessionsDir = path.join(root, "agents", "main", "sessions");

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -194,13 +194,14 @@ describe("session cost usage", () => {
     });
   });
 
-  it("preserves an operator-configured zero-cost model as a complete $0, not missing", async () => {
-    const root = await makeSessionCostRoot("cost-intentional-free");
+  it("counts token usage for a configured all-zero model as missing because pricing is still unknown", async () => {
+    const root = await makeSessionCostRoot("cost-configured-zero-unknown");
     const sessionsDir = path.join(root, "agents", "main", "sessions");
     await fs.mkdir(sessionsDir, { recursive: true });
 
-    // Same shape of turn, but here the operator deliberately priced the model at 0
-    // (e.g. a local/self-hosted free model). That intentional $0 must be respected.
+    // Same shape of turn, with a configured all-zero cost block. After config defaults,
+    // omitted cost and explicit all-zero cost are indistinguishable, so a zero-rate
+    // token-burning turn is still safer to report as missing than as complete $0 spend.
     const entry = {
       type: "message",
       timestamp: new Date().toISOString(),
@@ -225,8 +226,8 @@ describe("session cost usage", () => {
       "utf-8",
     );
 
-    // The operator explicitly configured this model's price as 0 — an intentional
-    // "free" price that must be preserved as complete $0 cost data.
+    // This mirrors normalized config where a model declaration without pricing has
+    // already received default zero rates.
     const config = {
       models: {
         providers: {
@@ -247,8 +248,7 @@ describe("session cost usage", () => {
       const summary = await loadCostUsageSummary({ days: 30, config });
       expect(summary.totals.totalTokens).toBe(23287);
       expect(summary.totals.totalCost).toBe(0);
-      // Operator-configured $0 is intentional and complete — not a missing entry.
-      expect(summary.totals.missingCostEntries).toBe(0);
+      expect(summary.totals.missingCostEntries).toBe(1);
     });
   });
 

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -149,6 +149,64 @@ describe("session cost usage", () => {
     });
   });
 
+  it("counts token usage for an unpriced (all-zero cost) model as missing, not a confident $0", async () => {
+    const root = await makeSessionCostRoot("cost-unknown-pricing");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    // A real assistant turn that burned tokens. The transport recorded cost.total: 0,
+    // derived from the model's all-zero catalog pricing — exactly what codex/gpt-5.x
+    // models produce, since the Codex backend exposes no per-token price.
+    const entry = {
+      type: "message",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        provider: "openai",
+        model: "gpt-5.5",
+        usage: {
+          input: 881,
+          output: 6,
+          cacheRead: 22400,
+          cacheWrite: 0,
+          totalTokens: 23287,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+      },
+    };
+
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-1.jsonl"),
+      transcriptText("sess-1", entry),
+      "utf-8",
+    );
+
+    // The model resolves to an all-zero cost config, i.e. its pricing is unknown.
+    const config = {
+      models: {
+        providers: {
+          openai: {
+            models: [
+              {
+                id: "gpt-5.5",
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    await withStateDir(root, async () => {
+      const summary = await loadCostUsageSummary({ days: 30, config });
+      expect(summary.totals.totalTokens).toBe(23287);
+      expect(summary.totals.totalCost).toBe(0);
+      // Unknown pricing must be surfaced as missing rather than reported as a
+      // confident $0 that would blind budget/spike monitoring to real spend.
+      expect(summary.totals.missingCostEntries).toBe(1);
+    });
+  });
+
   it("ignores compaction checkpoint transcript snapshots in daily totals and discovery", async () => {
     const root = await makeSessionCostRoot("cost-checkpoint");
     const sessionsDir = path.join(root, "agents", "main", "sessions");

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -149,14 +149,14 @@ describe("session cost usage", () => {
     });
   });
 
-  it("counts token usage for an unpriced (all-zero cost) model as missing, not a confident $0", async () => {
+  it("counts token usage for an unpriced (unconfigured all-zero) model as missing, not a confident $0", async () => {
     const root = await makeSessionCostRoot("cost-unknown-pricing");
     const sessionsDir = path.join(root, "agents", "main", "sessions");
     await fs.mkdir(sessionsDir, { recursive: true });
 
     // A real assistant turn that burned tokens. The transport recorded cost.total: 0,
-    // derived from the model's all-zero catalog pricing — exactly what codex/gpt-5.x
-    // models produce, since the Codex backend exposes no per-token price.
+    // derived from an all-zero catalog price — exactly what codex/gpt-5.x models produce,
+    // since the Codex backend exposes no per-token price and the operator never set one.
     const entry = {
       type: "message",
       timestamp: new Date().toISOString(),
@@ -181,7 +181,52 @@ describe("session cost usage", () => {
       "utf-8",
     );
 
-    // The model resolves to an all-zero cost config, i.e. its pricing is unknown.
+    // No operator-configured pricing for this model, so its all-zero cost is unknown,
+    // not an intentional "free" price.
+    clearGatewayModelPricingCacheState();
+    await withStateDir(root, async () => {
+      const summary = await loadCostUsageSummary({ days: 30 });
+      expect(summary.totals.totalTokens).toBe(23287);
+      expect(summary.totals.totalCost).toBe(0);
+      // Unknown pricing must be surfaced as missing rather than reported as a
+      // confident $0 that would blind budget/spike monitoring to real spend.
+      expect(summary.totals.missingCostEntries).toBe(1);
+    });
+  });
+
+  it("preserves an operator-configured zero-cost model as a complete $0, not missing", async () => {
+    const root = await makeSessionCostRoot("cost-intentional-free");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    // Same shape of turn, but here the operator deliberately priced the model at 0
+    // (e.g. a local/self-hosted free model). That intentional $0 must be respected.
+    const entry = {
+      type: "message",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        provider: "openai",
+        model: "gpt-5.5",
+        usage: {
+          input: 881,
+          output: 6,
+          cacheRead: 22400,
+          cacheWrite: 0,
+          totalTokens: 23287,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+      },
+    };
+
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-1.jsonl"),
+      transcriptText("sess-1", entry),
+      "utf-8",
+    );
+
+    // The operator explicitly configured this model's price as 0 — an intentional
+    // "free" price that must be preserved as complete $0 cost data.
     const config = {
       models: {
         providers: {
@@ -197,13 +242,13 @@ describe("session cost usage", () => {
       },
     } as unknown as OpenClawConfig;
 
+    clearGatewayModelPricingCacheState();
     await withStateDir(root, async () => {
       const summary = await loadCostUsageSummary({ days: 30, config });
       expect(summary.totals.totalTokens).toBe(23287);
       expect(summary.totals.totalCost).toBe(0);
-      // Unknown pricing must be surfaced as missing rather than reported as a
-      // confident $0 that would blind budget/spike monitoring to real spend.
-      expect(summary.totals.missingCostEntries).toBe(1);
+      // Operator-configured $0 is intentional and complete — not a missing entry.
+      expect(summary.totals.missingCostEntries).toBe(0);
     });
   });
 

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -1013,6 +1013,22 @@ const applyCostTotal = (totals: CostUsageTotals, costTotal: number | undefined) 
   totals.totalCost += costTotal;
 };
 
+// A resolved cost config only counts as "known" pricing when it carries at least one
+// positive per-token rate (or tiered pricing). An all-zero config is indistinguishable
+// from "pricing unknown": e.g. codex models ship cost {input:0,output:0,...} in the
+// generated models.json because the Codex backend exposes no per-token price. Treating
+// such a config as a real $0 makes usage-cost report confident zero spend, which
+// silently blinds every budget/spike safeguard that keys off totalCost.
+const isModelPricingKnown = (cost: ReturnType<typeof resolveModelCostConfig>): boolean => {
+  if (!cost) {
+    return false;
+  }
+  if (cost.tieredPricing && cost.tieredPricing.length > 0) {
+    return true;
+  }
+  return cost.input > 0 || cost.output > 0 || cost.cacheRead > 0 || cost.cacheWrite > 0;
+};
+
 async function canReadJsonlFromOffset(filePath: string, startOffset: number): Promise<boolean> {
   if (startOffset <= 0) {
     return true;
@@ -1098,6 +1114,17 @@ async function scanTranscriptFile(params: {
         // Clear costBreakdown so downstream aggregation uses the recomputed total
         // instead of the stale flat-rate breakdown from the transport layer.
         entry.costTotal = estimateUsageCost({ usage: entry.usage, cost });
+        entry.costBreakdown = undefined;
+      } else if (
+        !isModelPricingKnown(cost) &&
+        computeUsageTokenTotals(entry.usage).totalTokens > 0
+      ) {
+        // Pricing for this model is unknown (no positive per-token rate). Any cost the
+        // transport recorded is a fabricated $0 derived from an all-zero catalog entry,
+        // not a real price. Drop it and surface the turn as a missing-cost entry so the
+        // tokens it burned are not reported as confident $0 spend — otherwise every
+        // budget/spike safeguard that reads totalCost stays blind to it.
+        entry.costTotal = undefined;
         entry.costBreakdown = undefined;
       } else if (entry.costTotal === undefined) {
         // Fill in missing cost estimates.

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -24,6 +24,7 @@ import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { countToolResults, extractToolCallNames } from "../utils/transcript-tools.js";
 import {
   estimateUsageCost,
+  resolveConfiguredModelCost,
   resolveModelCostConfig,
   resolveModelCostConfigFingerprint,
 } from "../utils/usage-format.js";
@@ -1117,15 +1118,23 @@ async function scanTranscriptFile(params: {
         entry.costBreakdown = undefined;
       } else if (
         !isModelPricingKnown(cost) &&
+        resolveConfiguredModelCost({
+          provider: entry.provider,
+          model: entry.model,
+          config: params.config,
+        }) === undefined &&
         (entry.costTotal === undefined || entry.costTotal === 0) &&
         computeUsageTokenTotals(entry.usage).totalTokens > 0
       ) {
-        // Pricing for this model is unknown (no positive per-token rate) and there is no
-        // trustworthy recorded cost — the transport either recorded nothing or a
-        // fabricated $0 derived from an all-zero catalog entry. Surface this token-burning
-        // turn as a missing-cost entry instead of recording a confident $0, so budget and
-        // spike safeguards that read totalCost are not left blind to it. A turn that
-        // carries a real positive recorded cost is preserved by the guard above.
+        // Pricing for this model is unknown: it has no positive per-token rate, the
+        // operator did not explicitly configure its price (so an all-zero value is a
+        // catalog default, not an intentional "free" price), and there is no trustworthy
+        // recorded cost — the transport either recorded nothing or a fabricated $0
+        // derived from an all-zero catalog entry. Surface this token-burning turn as a
+        // missing-cost entry instead of recording a confident $0, so budget and spike
+        // safeguards that read totalCost are not left blind to it. A turn with a real
+        // positive recorded cost, or a model the operator deliberately priced at 0, is
+        // preserved by the guards above.
         entry.costTotal = undefined;
         entry.costBreakdown = undefined;
       } else if (entry.costTotal === undefined) {

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -24,7 +24,6 @@ import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { countToolResults, extractToolCallNames } from "../utils/transcript-tools.js";
 import {
   estimateUsageCost,
-  resolveConfiguredModelCost,
   resolveModelCostConfig,
   resolveModelCostConfigFingerprint,
 } from "../utils/usage-format.js";
@@ -1122,23 +1121,16 @@ async function scanTranscriptFile(params: {
         entry.costBreakdown = undefined;
       } else if (
         !isModelPricingKnown(cost) &&
-        resolveConfiguredModelCost({
-          provider: entry.provider,
-          model: entry.model,
-          config: params.config,
-        }) === undefined &&
         (entry.costTotal === undefined || entry.costTotal === 0) &&
         computeUsageTokenTotals(entry.usage).totalTokens > 0
       ) {
-        // Pricing for this model is unknown: it has no positive per-token rate, the
-        // operator did not explicitly configure its price (so an all-zero value is a
-        // catalog default, not an intentional "free" price), and there is no trustworthy
-        // recorded cost — the transport either recorded nothing or a fabricated $0
-        // derived from an all-zero catalog entry. Surface this token-burning turn as a
-        // missing-cost entry instead of recording a confident $0, so budget and spike
-        // safeguards that read totalCost are not left blind to it. A turn with a real
-        // positive recorded cost, or a model the operator deliberately priced at 0, is
-        // preserved by the guards above.
+        // Pricing for this model is unknown: it has no positive per-token rate and no
+        // trustworthy recorded cost. The transport either recorded nothing or a
+        // fabricated $0 derived from an all-zero/default catalog entry. Surface this
+        // token-burning turn as a missing-cost entry instead of recording a confident
+        // $0, so budget and spike safeguards that read totalCost are not left blind to
+        // it. A turn carrying a real positive recorded cost is preserved by the guard
+        // above.
         entry.costTotal = undefined;
         entry.costBreakdown = undefined;
       } else if (entry.costTotal === undefined) {

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -82,7 +82,11 @@ const emptyTotals = (): CostUsageTotals => ({
   missingCostEntries: 0,
 });
 
-const USAGE_COST_CACHE_VERSION = 3;
+// Bump when the *meaning* of cached totals changes (not just their inputs), so durable
+// caches written by older builds are rebuilt instead of served stale. Bumped to 4:
+// unpriced (unknown) zero-cost usage now counts toward missingCostEntries, so a warm
+// cache from a pre-change build would otherwise keep reporting the old complete-$0 totals.
+const USAGE_COST_CACHE_VERSION = 4;
 const USAGE_COST_CACHE_FILE = ".usage-cost-cache.json";
 const USAGE_COST_CACHE_LOCK_WRITE_GRACE_MS = 10_000;
 const logger = createSubsystemLogger("usage-cost-cache");

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -1117,13 +1117,15 @@ async function scanTranscriptFile(params: {
         entry.costBreakdown = undefined;
       } else if (
         !isModelPricingKnown(cost) &&
+        (entry.costTotal === undefined || entry.costTotal === 0) &&
         computeUsageTokenTotals(entry.usage).totalTokens > 0
       ) {
-        // Pricing for this model is unknown (no positive per-token rate). Any cost the
-        // transport recorded is a fabricated $0 derived from an all-zero catalog entry,
-        // not a real price. Drop it and surface the turn as a missing-cost entry so the
-        // tokens it burned are not reported as confident $0 spend — otherwise every
-        // budget/spike safeguard that reads totalCost stays blind to it.
+        // Pricing for this model is unknown (no positive per-token rate) and there is no
+        // trustworthy recorded cost — the transport either recorded nothing or a
+        // fabricated $0 derived from an all-zero catalog entry. Surface this token-burning
+        // turn as a missing-cost entry instead of recording a confident $0, so budget and
+        // spike safeguards that read totalCost are not left blind to it. A turn that
+        // carries a real positive recorded cost is preserved by the guard above.
         entry.costTotal = undefined;
         entry.costBreakdown = undefined;
       } else if (entry.costTotal === undefined) {

--- a/src/utils/usage-format.ts
+++ b/src/utils/usage-format.ts
@@ -298,22 +298,6 @@ export function resolveModelCostConfigFingerprint(config?: OpenClawConfig): stri
   });
 }
 
-// Returns model pricing ONLY when the operator explicitly configured it under
-// `models.providers` in their OpenClaw config. Unlike resolveModelCostConfig this
-// ignores the generated model catalog (models.json) and the gateway pricing cache, so
-// callers can tell an intentional operator-set price (e.g. a deliberately free local
-// model priced at 0) apart from a price the catalog merely defaulted to zero.
-export function resolveConfiguredModelCost(params: {
-  provider?: string;
-  model?: string;
-  config?: OpenClawConfig;
-}): ModelCostConfig | undefined {
-  return (
-    findConfiguredProviderCost({ ...params, allowPluginNormalization: false }) ??
-    findConfiguredProviderCost(params)
-  );
-}
-
 export function resolveModelCostConfig(params: {
   provider?: string;
   model?: string;

--- a/src/utils/usage-format.ts
+++ b/src/utils/usage-format.ts
@@ -298,6 +298,22 @@ export function resolveModelCostConfigFingerprint(config?: OpenClawConfig): stri
   });
 }
 
+// Returns model pricing ONLY when the operator explicitly configured it under
+// `models.providers` in their OpenClaw config. Unlike resolveModelCostConfig this
+// ignores the generated model catalog (models.json) and the gateway pricing cache, so
+// callers can tell an intentional operator-set price (e.g. a deliberately free local
+// model priced at 0) apart from a price the catalog merely defaulted to zero.
+export function resolveConfiguredModelCost(params: {
+  provider?: string;
+  model?: string;
+  config?: OpenClawConfig;
+}): ModelCostConfig | undefined {
+  return (
+    findConfiguredProviderCost({ ...params, allowPluginNormalization: false }) ??
+    findConfiguredProviderCost(params)
+  );
+}
+
 export function resolveModelCostConfig(params: {
   provider?: string;
   model?: string;


### PR DESCRIPTION
## Summary

- Treat token-burning usage with all-zero or unknown model pricing as missing cost instead of a confident complete $0.
- Preserve positive recorded transport costs and existing tiered-pricing recomputation.
- Bump the durable usage-cost cache version so old complete-$0 summaries are rebuilt.

Fixes #85858.

## Verification

- `CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 fnm exec --using v24.15.0 -- node scripts/run-vitest.mjs run src/infra/session-cost-usage.test.ts --reporter=dot --pool=forks --no-file-parallelism`
- Autoreview clean after the zero-rate pricing fixup.

## Real behavior proof

Behavior addressed: `usage-cost` could report token-burning unpriced model usage as complete `$0` with `missingCostEntries: 0`, hiding real spend from budget and spike monitoring.

Real environment tested: live OpenClaw `2026.5.20` host with default `openai/gpt-5.5` API-key usage, plus focused regression tests on the rebased branch.

Exact steps or command run after this patch: applied the equivalent change to the live host and ran `openclaw gateway usage-cost --days 2 --json --expect-final` over the same logged usage; locally reran `src/infra/session-cost-usage.test.ts` after the maintainer fixup.

Evidence after fix: the same 1,780,235 tokens that previously reported `missingCostEntries: 0` now report `missingCostEntries: 32`; local regression suite passes 47 tests.

Observed result after fix: OpenClaw no longer treats all-zero unknown pricing as complete zero spend for token-burning turns. Positive recorded costs and tiered pricing remain intact.

What was not tested: macOS/Control UI cost views; a future explicit config contract for intentionally free zero-rate models.
