### PR TITLE
Disable Chrome MCP telemetry watchdog by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Docs: https://docs.openclaw.ai
 - WebChat: keep the run-complete indicator in progress until deferred history replay renders the assistant reply, so Done no longer appears before response text. (#85374) Thanks @neeravmakwana.
 - Agents/compaction: skip agent-harness preflight for provider-owned CLI runtime sessions so over-threshold Claude CLI sessions continue through normal compaction instead of failing on a missing harness. Fixes #84857. (#84878) Thanks @zhangguiping-xydt.
 - Control UI/config: save form-mode edits from the source config snapshot so runtime-only provider defaults like empty `models.providers.<id>.baseUrl` are not written back and rejected. Fixes #85831. Thanks @garyd9.
+- Browser/existing-session: launch Chrome DevTools MCP with usage statistics disabled by default so its telemetry watchdog stays off unless an operator explicitly opts in. (#85886) Thanks @rohitjavvadi.
 - Telegram: normalize legacy durable group retry targets before retry sends, polls, and pins so group retries keep using the real chat id. (#85656) Thanks @luoyanglang.
 - Agents/PDF: route MiniMax PDF fallback policy through plugin metadata so MiniMax uses text extraction instead of VLM image fallback. (#85590, fixes #85575) Thanks @neeravmakwana.
 - WebChat: summarize internal message-tool source replies so tool cards no longer duplicate the visible reply body. (#84773) Thanks @jason-allen-oneal.

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -164,6 +164,7 @@ describe("chrome MCP page parsing", () => {
       "-y",
       "chrome-devtools-mcp@latest",
       "--autoConnect",
+      "--no-usage-statistics",
       "--experimentalStructuredContent",
       "--experimental-page-id-routing",
       "--userDataDir",
@@ -182,6 +183,7 @@ describe("chrome MCP page parsing", () => {
       "chrome-devtools-mcp@latest",
       "--browserUrl",
       "http://127.0.0.1:9222",
+      "--no-usage-statistics",
       "--experimentalStructuredContent",
       "--experimental-page-id-routing",
     ]);
@@ -197,6 +199,7 @@ describe("chrome MCP page parsing", () => {
       "chrome-devtools-mcp@latest",
       "--wsEndpoint",
       "ws://127.0.0.1:9222/devtools/browser/abc",
+      "--no-usage-statistics",
       "--experimentalStructuredContent",
       "--experimental-page-id-routing",
     ]);
@@ -219,6 +222,36 @@ describe("chrome MCP page parsing", () => {
     ]);
   });
 
+  it("lets explicit Chrome MCP usage-statistics args override the default opt-out", () => {
+    expect(
+      buildChromeMcpArgs({
+        mcpArgs: ["--usage-statistics"],
+      }),
+    ).toEqual([
+      "-y",
+      "chrome-devtools-mcp@latest",
+      "--autoConnect",
+      "--experimentalStructuredContent",
+      "--experimental-page-id-routing",
+      "--usage-statistics",
+    ]);
+  });
+
+  it("does not duplicate an explicit Chrome MCP usage-statistics opt-out", () => {
+    expect(
+      buildChromeMcpArgs({
+        mcpArgs: ["--no-usage-statistics"],
+      }),
+    ).toEqual([
+      "-y",
+      "chrome-devtools-mcp@latest",
+      "--autoConnect",
+      "--experimentalStructuredContent",
+      "--experimental-page-id-routing",
+      "--no-usage-statistics",
+    ]);
+  });
+
   it("omits the npx package prefix for a custom Chrome MCP command", () => {
     expect(
       buildChromeMcpArgs({
@@ -228,6 +261,7 @@ describe("chrome MCP page parsing", () => {
     ).toEqual([
       "--browserUrl",
       "http://127.0.0.1:9222",
+      "--no-usage-statistics",
       "--experimentalStructuredContent",
       "--experimental-page-id-routing",
     ]);
@@ -338,7 +372,9 @@ describe("chrome MCP page parsing", () => {
 
     expect(message).toContain("Chrome MCP existing-session attach failed");
     expect(message).toContain("~/Library/Application Support/Google/Chrome/Profile 1");
-    expect(message).toContain("attach failed for ~/Library/Application Support/Google/Chrome/Profile 1");
+    expect(message).toContain(
+      "attach failed for ~/Library/Application Support/Google/Chrome/Profile 1",
+    );
     expect(message).not.toContain(homeDir);
     expect(message).not.toContain(userDataDir);
   });

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -72,10 +72,12 @@ type ChromeMcpSessionFactory = (
 const DEFAULT_CHROME_MCP_COMMAND = "npx";
 const DEFAULT_CHROME_MCP_PACKAGE_ARGS = ["-y", "chrome-devtools-mcp@latest"];
 const DEFAULT_CHROME_MCP_FEATURE_ARGS = [
+  "--no-usage-statistics",
   // Direct chrome-devtools-mcp launches do not enable structuredContent by default.
   "--experimentalStructuredContent",
   "--experimental-page-id-routing",
 ];
+const CHROME_MCP_USAGE_STATISTICS_FLAG_RE = /^--(?:no-)?usage-?statistics(?:=.*)?$/i;
 const CHROME_MCP_CONNECTION_FLAGS = new Set([
   "--autoConnect",
   "--auto-connect",
@@ -342,10 +344,15 @@ async function closeChromeMcpSessionsForProfile(
 function buildChromeMcpArgsFromOptions(options: NormalizedChromeMcpProfileOptions): string[] {
   const commandPrefix =
     options.command === DEFAULT_CHROME_MCP_COMMAND ? DEFAULT_CHROME_MCP_PACKAGE_ARGS : [];
+  const defaultFeatureArgs = options.extraArgs.some((arg) =>
+    CHROME_MCP_USAGE_STATISTICS_FLAG_RE.test(arg),
+  )
+    ? DEFAULT_CHROME_MCP_FEATURE_ARGS.filter((arg) => arg !== "--no-usage-statistics")
+    : DEFAULT_CHROME_MCP_FEATURE_ARGS;
   return [
     ...commandPrefix,
     ...buildChromeMcpConnectionArgs(options),
-    ...DEFAULT_CHROME_MCP_FEATURE_ARGS,
+    ...defaultFeatureArgs,
     ...buildChromeMcpUserDataDirArgs(options),
     ...options.extraArgs,
   ];


### PR DESCRIPTION
## Summary

- Pass `--no-usage-statistics` when OpenClaw launches `chrome-devtools-mcp@latest`.
- Preserve explicit profile-level `mcpArgs` overrides for usage statistics.
- Add regression coverage for the default arg list, explicit opt-in, explicit opt-out dedupe, and custom-command launches.

## Motivation / root cause

`chrome-devtools-mcp` enables usage statistics by default and can spawn a detached watchdog process. OpenClaw closes the MCP SDK stdio transport, but that only owns the direct child process. Disabling usage statistics at launch prevents the detached telemetry watchdog from being created in the default OpenClaw browser automation path.

Refs #85721

## Real behavior proof

Behavior addressed: Browser automation launches Chrome DevTools MCP without leaving a detached usage-statistics watchdog behind after the MCP client is closed.

Real environment tested: macOS local checkout, Node 24.10.0, real `npx chrome-devtools-mcp@latest` process launched through `@modelcontextprotocol/sdk` `StdioClientTransport`.

Exact steps or command run after this patch: Started a real MCP SDK `Client` with `StdioClientTransport({ command: "npx", args: buildChromeMcpArgs({ cdpUrl: "http://127.0.0.1:9" }) })`, called `client.connect()`, `client.listTools()`, then `client.close()`, waited 1.2s, and scanned `ps axo pid=,ppid=,command=` for `chrome-devtools-mcp` and `watchdog/main.js`.

Evidence after fix: Copied live console output from the real SDK stdio close/process-scan smoke:

```json
{
  "generatedArgs": [
    "-y",
    "chrome-devtools-mcp@latest",
    "--browserUrl",
    "http://127.0.0.1:9",
    "--no-usage-statistics",
    "--experimentalStructuredContent",
    "--experimental-page-id-routing"
  ],
  "transportPid": 14467,
  "remainingRelevantProcesses": [],
  "watchdogProcessesRemaining": 0
}
```

Observed result after fix: Live output shows `--no-usage-statistics` in the generated argv, `remainingRelevantProcesses: []`, and `watchdogProcessesRemaining: 0`; no `chrome-devtools-mcp` or telemetry watchdog process remained after closing the SDK client.

What was not tested: I did not run a full Chrome browser UI workflow or a Linux remote/Testbox smoke in this pass.

## Regression tests

- `node scripts/run-vitest.mjs extensions/browser/src/browser/chrome-mcp.test.ts`
- `node scripts/run-vitest.mjs extensions/browser/src/browser/server-context.existing-session.test.ts extensions/browser/src/browser/server-context.stop-running-browser.test.ts extensions/browser/src/browser/routes/basic.existing-session.test.ts`

## Exact commands run

- `./node_modules/.bin/oxfmt --check extensions/browser/src/browser/chrome-mcp.ts extensions/browser/src/browser/chrome-mcp.test.ts`
- `git diff --check origin/main...HEAD`
- `node scripts/run-vitest.mjs extensions/browser/src/browser/chrome-mcp.test.ts`
- `node scripts/run-vitest.mjs extensions/browser/src/browser/server-context.existing-session.test.ts extensions/browser/src/browser/server-context.stop-running-browser.test.ts extensions/browser/src/browser/routes/basic.existing-session.test.ts`
- Real MCP SDK stdio close/process-scan smoke described above.

## User-visible behavior

Existing-session browser automation should no longer accumulate detached Chrome DevTools MCP telemetry watchdog processes during normal OpenClaw-managed MCP launches.

## Compatibility

Users who explicitly want upstream usage statistics can still pass a usage-statistics arg in `browser.profiles.*.mcpArgs`; explicit args override OpenClaw's default opt-out.

## Risks

Low. The change adds one documented Chrome DevTools MCP flag to the existing argv list and keeps profile-level custom args as separate argv entries.
