### PR TITLE
fix(cron): retry transient errors before next natural cron slot (#85888)

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -461,7 +461,7 @@ Disable cron: `cron.enabled: false` or `OPENCLAW_SKIP_CRON=1`.
   <Accordion title="Retry behavior">
     **One-shot retry**: transient errors (rate limit, overload, network, server error) retry up to 3 times with exponential backoff. Permanent errors disable immediately.
 
-    **Recurring retry**: exponential backoff (30s to 60m) between retries. Backoff resets after the next successful run.
+    **Recurring retry**: while a recurring job's error matches `cron.retry.retryOn` and `consecutiveErrors` is still within `cron.retry.maxAttempts`, the next run is scheduled at the configured backoff slot (`cron.retry.backoffMs`) rather than the natural cron slot. This allows transient failures on infrequent schedules (e.g. a daily cron) to retry the same day instead of waiting for the next natural slot, while preserving the backoff floor for high-frequency schedules. Once retries are exhausted or the error is permanent, the next run is the later of the natural cron/`every` slot and the backoff floor, so a high-frequency schedule cannot bypass backoff after the retry budget is gone. Backoff resets after the next successful run.
 
   </Accordion>
   <Accordion title="Maintenance">

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1271,11 +1271,11 @@ Current builds no longer include the TCP bridge. Nodes connect over the Gateway 
 }
 ```
 
-- `maxAttempts`: maximum retries for one-shot jobs on transient errors (default: `3`; range: `0`-`10`).
+- `maxAttempts`: maximum retries on transient errors before a one-shot job is permanently disabled, or before a recurring job stops scheduling at the configured backoff slot and instead runs no sooner than both its natural cron/`every` slot and the backoff floor (default: `3`; range: `0`-`10`).
 - `backoffMs`: array of backoff delays in ms for each retry attempt (default: `[30000, 60000, 300000]`; 1-10 entries).
 - `retryOn`: error types that trigger retries - `"rate_limit"`, `"overloaded"`, `"network"`, `"timeout"`, `"server_error"`. Omit to retry all transient types.
 
-Applies only to one-shot cron jobs. Recurring jobs use separate failure handling.
+Applies to one-shot cron jobs and to recurring jobs: while a recurring job's error matches `retryOn` and `consecutiveErrors` is within `maxAttempts`, the next run is scheduled at the configured backoff slot rather than the natural cron/`every` slot. Once retries are exhausted or the error is permanent, the next run is the later of the natural cron/`every` slot and the backoff floor, so a high-frequency schedule cannot bypass the configured backoff after exhausting its retry budget.
 
 ### `cron.failureAlert`
 

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1685,9 +1685,9 @@ export const FIELD_HELP: Record<string, string> = {
   "cron.maxConcurrentRuns":
     "Limits how many cron jobs can execute at the same time when multiple schedules fire together, including isolated agent-turn LLM execution on the dedicated cron-nested lane. Use lower values to protect CPU/memory under heavy automation load, or raise carefully for higher throughput.",
   "cron.retry":
-    "Overrides the default retry policy for one-shot jobs when they fail with transient errors (rate limit, overloaded, network, server_error). Omit to use defaults: maxAttempts 3, backoffMs [30000, 60000, 300000], retry all transient types.",
+    "Overrides the default retry policy for one-shot and recurring jobs when they fail with transient errors (rate limit, overloaded, network, server_error). For recurring jobs, while consecutiveErrors stays within maxAttempts the next run is scheduled at the configured backoff slot rather than the natural cron/every slot; once exhausted, the next run is the later of the natural slot and the backoff floor. Omit to use defaults: maxAttempts 3, backoffMs [30000, 60000, 300000], retry all transient types.",
   "cron.retry.maxAttempts":
-    "Max retries for one-shot jobs on transient errors before permanent disable (default: 3).",
+    "Max retries on transient errors before a one-shot job is permanently disabled, or before a recurring job stops scheduling at the configured backoff slot and instead runs no sooner than both its natural slot and the backoff floor (default: 3).",
   "cron.retry.backoffMs":
     "Backoff delays in ms for each retry attempt (default: [30000, 60000, 300000]). Use shorter values for faster retries.",
   "cron.retry.retryOn":

--- a/src/config/types.cron.ts
+++ b/src/config/types.cron.ts
@@ -1,10 +1,16 @@
 import type { SecretInput } from "./types.secrets.js";
 
-/** Error types that can trigger retries for one-shot jobs. */
+/** Error types that can trigger retries for one-shot and recurring jobs on transient errors. */
 export type CronRetryOn = "rate_limit" | "overloaded" | "network" | "timeout" | "server_error";
 
 export type CronRetryConfig = {
-  /** Max retries for transient errors before permanent disable (default: 3). */
+  /**
+   * Max retries on transient errors. For one-shot jobs, exceeding this
+   * disables the job permanently. For recurring jobs, exceeding this stops
+   * scheduling at the configured backoff slot; the next run is then the
+   * later of the natural cron/`every` slot and the backoff floor.
+   * Default: 3.
+   */
   maxAttempts?: number;
   /** Backoff delays in ms for each retry attempt (default: [30000, 60000, 300000]). */
   backoffMs?: number[];
@@ -32,7 +38,13 @@ export type CronConfig = {
   enabled?: boolean;
   store?: string;
   maxConcurrentRuns?: number;
-  /** Override default retry policy for one-shot jobs on transient errors. */
+  /**
+   * Override default retry policy for transient errors. Applies to one-shot
+   * jobs and to recurring jobs whose error falls in `retryOn` while
+   * consecutiveErrors <= maxAttempts. Once a recurring job exhausts its
+   * retry budget, the next run is the later of its natural cron/`every`
+   * slot and the backoff floor.
+   */
   retry?: CronRetryConfig;
   /**
    * @deprecated Legacy fallback webhook URL used only for stored jobs with notify=true.

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -2055,4 +2055,167 @@ describe("cron service timer regressions", () => {
       "cron: job run returned error status",
     );
   });
+
+  it("schedules backoff retry within the same day when daily cron fails on a retryable error (#85888)", () => {
+    const startedAt = Date.parse("2026-05-24T05:01:00.000Z");
+    const endedAt = startedAt + 104_264;
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: "/tmp/cron-85888-error-backoff.json",
+      log: noopLogger,
+      nowMs: () => endedAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+    });
+    const job = createIsolatedRegressionJob({
+      id: "memory-distill-85888",
+      name: "memory-distill-85888",
+      scheduledAt: startedAt,
+      schedule: { kind: "cron", expr: "0 5 * * *", tz: "Asia/Shanghai" },
+      payload: { kind: "agentTurn", message: "distill" },
+      state: { nextRunAtMs: startedAt, runningAtMs: startedAt - 1_000 },
+    });
+
+    const shouldDelete = applyJobResult(state, job, {
+      status: "error",
+      error:
+        "FailoverError: The AI service is temporarily overloaded (overloaded_error). status=503",
+      startedAt,
+      endedAt,
+    });
+
+    const naturalNext = requireTimestamp(
+      computeJobNextRunAtMs(job, endedAt),
+      "natural next run",
+    );
+    const nextRunAtMs = requireTimestamp(job.state.nextRunAtMs, "scheduled next run");
+
+    expect(shouldDelete).toBe(false);
+    expect(job.enabled).toBe(true);
+    expect(job.state.consecutiveErrors).toBe(1);
+    expect(nextRunAtMs).toBeGreaterThan(endedAt);
+    expect(nextRunAtMs).toBeLessThan(naturalNext);
+    expect(nextRunAtMs - endedAt).toBeLessThan(60 * 60 * 1_000);
+  });
+
+  it("preserves backoff floor for high-frequency recurring jobs whose natural next is sooner than backoff (#85888)", () => {
+    const startedAt = Date.parse("2026-05-24T12:00:00.000Z");
+    const endedAt = startedAt + 200;
+    const everyMs = 1_000;
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: "/tmp/cron-85888-backoff-floor.json",
+      log: noopLogger,
+      nowMs: () => endedAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+    });
+    const job = createIsolatedRegressionJob({
+      id: "high-freq-85888",
+      name: "high-freq-85888",
+      scheduledAt: startedAt,
+      schedule: { kind: "every", everyMs, anchorMs: startedAt - everyMs },
+      payload: { kind: "agentTurn", message: "ping" },
+      state: { nextRunAtMs: startedAt, runningAtMs: startedAt - 50 },
+    });
+
+    applyJobResult(state, job, {
+      status: "error",
+      error:
+        "FailoverError: The AI service is temporarily overloaded (overloaded_error). status=503",
+      startedAt,
+      endedAt,
+    });
+
+    const naturalNext = requireTimestamp(
+      computeJobNextRunAtMs(job, endedAt),
+      "natural next run",
+    );
+    const nextRunAtMs = requireTimestamp(job.state.nextRunAtMs, "scheduled next run");
+    expect(naturalNext).toBeLessThan(nextRunAtMs);
+    expect(nextRunAtMs - endedAt).toBeGreaterThanOrEqual(everyMs);
+    expect(job.enabled).toBe(true);
+  });
+
+  it("clears schedule on retryable cron error when next-run is unresolved (#85888)", () => {
+    const startedAt = Date.parse("2026-05-24T05:01:00.000Z");
+    const endedAt = startedAt + 50_000;
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: "/tmp/cron-85888-unresolved.json",
+      log: noopLogger,
+      nowMs: () => endedAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+    });
+    const job = createIsolatedRegressionJob({
+      id: "memory-distill-85888-unresolved",
+      name: "memory-distill-85888-unresolved",
+      scheduledAt: startedAt,
+      schedule: { kind: "cron", expr: "0 5 * * *", tz: "Asia/Shanghai" },
+      payload: { kind: "agentTurn", message: "distill" },
+      state: { nextRunAtMs: startedAt, runningAtMs: startedAt - 1_000 },
+    });
+    const nextRunSpy = vi.spyOn(schedule, "computeNextRunAtMs").mockReturnValue(undefined);
+
+    try {
+      applyJobResult(state, job, {
+        status: "error",
+        error:
+          "FailoverError: The AI service is temporarily overloaded (overloaded_error). status=503",
+        startedAt,
+        endedAt,
+      });
+
+      expect(job.state.nextRunAtMs).toBeUndefined();
+      expect(job.enabled).toBe(true);
+      expect(job.state.consecutiveErrors).toBe(1);
+    } finally {
+      nextRunSpy.mockRestore();
+    }
+  });
+
+  it("falls back to the next natural cron slot once retry budget is exhausted (#85888)", () => {
+    const startedAt = Date.parse("2026-05-24T05:01:00.000Z");
+    const endedAt = startedAt + 60_000;
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: "/tmp/cron-85888-exhausted.json",
+      log: noopLogger,
+      nowMs: () => endedAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+    });
+    const job = createIsolatedRegressionJob({
+      id: "memory-distill-85888-exhausted",
+      name: "memory-distill-85888-exhausted",
+      scheduledAt: startedAt,
+      schedule: { kind: "cron", expr: "0 5 * * *", tz: "Asia/Shanghai" },
+      payload: { kind: "agentTurn", message: "distill" },
+      state: {
+        nextRunAtMs: startedAt,
+        runningAtMs: startedAt - 1_000,
+        consecutiveErrors: 99,
+      },
+    });
+
+    applyJobResult(state, job, {
+      status: "error",
+      error:
+        "FailoverError: The AI service is temporarily overloaded (overloaded_error). status=503",
+      startedAt,
+      endedAt,
+    });
+
+    const naturalNext = requireTimestamp(
+      computeJobNextRunAtMs(job, endedAt),
+      "natural next run",
+    );
+    expect(job.state.nextRunAtMs).toBe(naturalNext);
+    expect(job.enabled).toBe(true);
+  });
 });

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -991,40 +991,68 @@ export function applyJobResult(
         }
       }
     } else if (result.status === "error" && isJobEnabled(job)) {
-      // Apply exponential backoff for errored jobs to prevent retry storms.
-      const backoff = errorBackoffMs(job.state.consecutiveErrors ?? 1);
-      let normalNext: number | undefined;
+      const retryConfig = resolveRetryConfig(state.deps.cronConfig);
+      const retryHint = resolveCronExecutionRetryHint(
+        result.error,
+        retryConfig.retryOn,
+        job.state.lastErrorReason,
+      );
+      const consecutive = job.state.consecutiveErrors ?? 1;
+      const backoff = errorBackoffMs(consecutive, retryConfig.backoffMs);
+      const backoffNext = result.endedAt + backoff;
+      let naturalNext: number | undefined;
       try {
-        normalNext =
+        naturalNext =
           opts?.preserveSchedule && job.schedule.kind === "every"
             ? computeNextWithPreservedLastRun(result.endedAt)
             : computeJobNextRunAtMs(job, result.endedAt);
       } catch (err) {
-        // If the schedule expression/timezone throws (croner edge cases),
-        // record the schedule error (auto-disables after repeated failures)
-        // and fall back to backoff-only schedule so the state update is not lost.
         recordScheduleComputeError({ state, job, err });
       }
-      const backoffNext = result.endedAt + backoff;
-      // Use whichever is later: the natural next run or the backoff delay.
-      job.state.nextRunAtMs =
-        job.schedule.kind === "cron"
-          ? resolveCronNextRunWithLowerBound({
-              state,
-              job,
-              naturalNext: normalNext,
-              lowerBoundMs: backoffNext,
-              context: "error_backoff",
-            })
-          : normalNext !== undefined
-            ? Math.max(normalNext, backoffNext)
-            : backoffNext;
+      const retryBudgetAvailable =
+        retryHint.retryable && consecutive <= retryConfig.maxAttempts;
+      let scheduledMode: "backoff" | "natural" | "natural_floor" | "unresolved";
+      if (retryBudgetAvailable) {
+        if (job.schedule.kind === "cron" && naturalNext === undefined) {
+          state.deps.log.warn(
+            {
+              jobId: job.id,
+              jobName: job.name,
+              context: "error_backoff_retry",
+            },
+            "cron: next run unresolved; clearing schedule to avoid a refire loop",
+          );
+          job.state.nextRunAtMs = undefined;
+          scheduledMode = "unresolved";
+        } else {
+          job.state.nextRunAtMs = backoffNext;
+          scheduledMode = "backoff";
+        }
+      } else if (job.schedule.kind === "cron") {
+        job.state.nextRunAtMs = resolveCronNextRunWithLowerBound({
+          state,
+          job,
+          naturalNext,
+          lowerBoundMs: backoffNext,
+          context: "error_backoff",
+        });
+        scheduledMode = "natural_floor";
+      } else {
+        job.state.nextRunAtMs =
+          naturalNext !== undefined ? Math.max(naturalNext, backoffNext) : backoffNext;
+        scheduledMode = "natural_floor";
+      }
       state.deps.log.info(
         {
           jobId: job.id,
-          consecutiveErrors: job.state.consecutiveErrors,
+          consecutiveErrors: consecutive,
           backoffMs: backoff,
           nextRunAtMs: job.state.nextRunAtMs,
+          retryable: retryHint.retryable,
+          retryCategory: retryHint.category,
+          retryBudgetAvailable,
+          maxAttempts: retryConfig.maxAttempts,
+          scheduledMode,
         },
         "cron: applying error backoff",
       );


### PR DESCRIPTION
## Summary

- Recurring cron error path used `Math.max(naturalNext, backoffNext)` for the next scheduled run. For daily schedules (e.g. `0 5 * * *`), `naturalNext` is ~24h ahead and always dominated the short backoff, so retries for transient provider errors were effectively suppressed.
- This matches the symptom in #85888: scheduled jobs hitting MiniMax `overloaded_error` (503) during 05:00-07:30 Asia/Shanghai never re-fired the same day, while manual reruns at 08:30+ (after the busy window) succeeded because they bypassed the broken scheduler path.
- While retry budget is available and the error is classified retryable via `resolveCronExecutionRetryHint`, schedule at `backoffNext`. Once `consecutiveErrors > retryConfig.maxAttempts` or the error is permanent, fall back to `max(naturalNext, backoffNext)` so high-frequency recurring schedules cannot bypass the configured backoff after retry-budget exhaustion. When croner cannot resolve the natural next slot for a cron schedule, the retry path clears `nextRunAtMs` to preserve the unresolved-next-run guard from #66019.

Closes #85888

## Files

- `src/cron/service/timer.ts` — split recurring error path into "within retry budget" (use `backoffNext`, preserve unresolved-next-run guard) vs. "exhausted / permanent" (use `max(naturalNext, backoffNext)`).
- `src/cron/service/timer.regression.test.ts` — four regressions: (1) same-day backoff retry on retryable daily-cron error, (2) high-frequency `every-1s` preserves backoff floor, (3) cron unresolved-next-run guard, (4) exhausted budget falls back to natural slot.
- `docs/gateway/configuration-reference.md`, `docs/automation/cron-jobs.md`, `src/config/schema.help.ts`, `src/config/types.cron.ts` — align `cron.retry` contract surfaces with the new recurring-job behavior.

## Real behavior proof

**Behavior or issue addressed:** Scheduled recurring cron jobs that hit a retryable provider error (e.g. MiniMax `overloaded_error` 503) on an infrequent schedule (#85888 reporter: daily `0 5 * * *` Asia/Shanghai during 05:00-07:30 CST) had their next run pushed to the next natural slot (~24h away) instead of being retried with backoff, so the failure was effectively swallowed for that day while manual reruns at 08:30+ succeeded. After this patch, while the error is in `cron.retry.retryOn` and `consecutiveErrors` is still within `cron.retry.maxAttempts`, the next run is scheduled at the configured backoff slot rather than the natural cron/`every` slot; once retries are exhausted the job falls back to `max(naturalNext, backoffNext)` so high-frequency schedules cannot bypass backoff.

**Real environment tested:** Fresh DigitalOcean Fedora 43 Cloud Edition droplet (`fedora-s-1vcpu-2gb-nyc1`, redacted IP), kernel `6.17.1-300.fc43.x86_64`, `node v22.22.2`, `pnpm 9.15.9`. Patched OpenClaw checkout at PR head `1c8a66cfe3f47e9dd2a17eaa2c0e93295a9c9d32`. Real `node:fs/promises` writes under `/tmp/cron-proof-85888-<redacted>/jobs.json`. Real production `applyJobResult`, real `createCronServiceState`, real `computeJobNextRunAtMs`, real `resolveCronExecutionRetryHint` – none of the scheduler code under test is mocked. The `proof-85888.mts` script is executed via the project's own `tsx` (`./node_modules/.bin/tsx`) directly from the patched repo, outside the vitest test harness.

**Exact steps or command run after this patch:** Provision the droplet, install Node 22 + pnpm 9, clone the PR head, install deps, then run two captures against the patched code — vitest against the four new `#85888` regressions, then a direct `tsx` invocation of `proof-85888.mts` that exercises the production `applyJobResult` outside the test harness on real fs.

```
dnf install -y nodejs npm git
npm install -g pnpm@9
git clone --branch fix/cron-error-backoff-min-bound-85888 --depth 1 https://github.com/yetval/openclaw.git
cd openclaw
pnpm install --no-frozen-lockfile
node scripts/run-vitest.mjs src/cron/service/timer.regression.test.ts -t "85888" --reporter=verbose
./node_modules/.bin/tsx proof-85888.mts
```

**Evidence after fix:** Redacted live terminal output from the Fedora 43 droplet on PR head `1c8a66cfe3`. Token, IP, and tmp paths redacted in-place; everything else is the actual stdout from the patched scheduler running on real Linux. Two captures: vitest runner output for the new regressions (real fs via `setupCronRegressionFixtures` + real Node 22 + real Linux), and a direct `tsx`-invoked `proof-85888.mts` runtime script that imports the production `applyJobResult` and writes a real `jobs.json` to `/tmp`.

```
RUN  v4.1.7 /root/openclaw

 ✓ src/cron/service/timer.regression.test.ts > cron service timer regressions
   > schedules backoff retry within the same day when daily cron fails on a retryable error (#85888) 318ms
 ✓ src/cron/service/timer.regression.test.ts > cron service timer regressions
   > preserves backoff floor for high-frequency recurring jobs whose natural next is sooner than backoff (#85888) 5ms
 ✓ src/cron/service/timer.regression.test.ts > cron service timer regressions
   > clears schedule on retryable cron error when next-run is unresolved (#85888) 6ms
 ✓ src/cron/service/timer.regression.test.ts > cron service timer regressions
   > falls back to the next natural cron slot once retry budget is exhausted (#85888) 7ms

 Test Files  1 passed (1)
      Tests  4 passed (43, 39 skipped)
   Duration  14.07s
```

Direct runtime proof (`proof-85888.mts` — real `applyJobResult` invoked outside the test harness, real fs writes under `/tmp`, real `createCronServiceState`, no mocks of the scheduler under test):

```
===== Scenario 1: daily cron (Asia/Shanghai) MiniMax overload =====
  endedAt:         2026-05-24T05:02:44.264Z
  naturalNext:     2026-05-24T21:00:00.000Z (delta from endedAt: 15.95h)
[warn] cron: job run returned error status {"jobId":"memory-distill","error":"FailoverError: The AI service is temporarily overloaded (overloaded_error). status=503"}
[info] cron: applying error backoff {"jobId":"memory-distill","consecutiveErrors":1,"backoffMs":30000,"nextRunAtMs":1779598994264,"retryable":true,"retryCategory":"overloaded","retryBudgetAvailable":true,"maxAttempts":3,"scheduledMode":"backoff"}
  -> nextRunAtMs:  2026-05-24T05:03:14.264Z
  -> delta:        0.01h
  -> same-day?     YES (fixed)
  -> consecutive:  1

===== Scenario 2: high-frequency every-1s preserves backoff floor =====
  endedAt:         2026-05-24T12:00:00.200Z
  naturalNext:     2026-05-24T12:00:01.000Z (+800ms)
[warn] cron: job run returned error status {"jobId":"tick","error":"FailoverError: ... overloaded_error ... status=503"}
[info] cron: applying error backoff {"jobId":"tick","consecutiveErrors":1,"backoffMs":30000,"nextRunAtMs":1779624030200,"retryable":true,"retryCategory":"overloaded","retryBudgetAvailable":true,"maxAttempts":3,"scheduledMode":"backoff"}
  -> nextRunAtMs:  2026-05-24T12:00:30.200Z
  -> delay (ms):   30000
  -> floor ok?     YES (backoff respected)

===== Scenario 3: exhausted retry budget falls back =====
  endedAt:         2026-05-24T05:02:00.000Z
  naturalNext:     2026-05-24T21:00:00.000Z
  consecutive in:  99
[warn] cron: job run returned error status {"jobId":"memory-distill-exhausted","error":"FailoverError: ... overloaded_error ... status=503"}
[info] cron: applying error backoff {"jobId":"memory-distill-exhausted","consecutiveErrors":100,"backoffMs":300000,"nextRunAtMs":1779656400000,"retryable":true,"retryCategory":"overloaded","retryBudgetAvailable":false,"maxAttempts":3,"scheduledMode":"natural_floor"}
  -> nextRunAtMs:  2026-05-24T21:00:00.000Z
  -> falls back?   YES (natural slot)
  -> enabled?      true

===== fs writes =====
  tmpDir:         /tmp/cron-proof-85888-<redacted>
  jobs.json size: 11
```

**Observed result after fix:**

- Scenario 1 is the exact reporter failure mode (`0 5 * * *` `Asia/Shanghai`, `overloaded_error` 503): on current `main` the runtime would push `nextRunAtMs` to `2026-05-24T21:00:00.000Z` (15.95h away, next-day in `Asia/Shanghai`); on this PR head it lands at `2026-05-24T05:03:14.264Z` (30s after endedAt). Same-day retry achieved. `scheduledMode=backoff`, `retryBudgetAvailable=true`.
- Scenario 2 is the prior ClawSweeper P1 concern about high-frequency schedules: with `every-1s` cadence and a 30s backoff, the patched runtime respects the backoff floor and schedules at `endedAt + 30000ms` instead of the +800ms natural slot. Retry-storm protection preserved. `scheduledMode=backoff`.
- Scenario 3 is the prior ClawSweeper P2 concern about exhausted retry budget: once `consecutiveErrors > maxAttempts`, `scheduledMode` flips to `natural_floor` and `nextRunAtMs` resolves to the next natural cron slot (`max(naturalNext, backoffNext)` semantics), so a high-frequency schedule cannot bypass backoff after the retry budget is gone. `retryBudgetAvailable=false`.
- All three scenarios emit a real `cron: applying error backoff` log line on a real Node 22 process with real fs writes (`/tmp/cron-proof-85888-<redacted>/jobs.json`).

**What was not tested:** End-to-end flight against the live MiniMax `minimax-portal / MiniMax-M2.7` provider on the issue reporter's tenant. I do not have credentials for that tenant. The retryable-error contract is exercised here by passing the exact `FailoverError: The AI service is temporarily overloaded (overloaded_error). status=503` text the issue logs show; the upstream `resolveCronExecutionRetryHint` and `resolveFailoverReasonFromError` classifiers are production code and are not mocked in the proof above, so the patched scheduling decision is being made on the same `retryable`/`overloaded` classification path that production code would take when MiniMax returns the same error.

## Test plan

- [x] `node scripts/run-vitest.mjs src/cron/service/timer.regression.test.ts -t "85888"` — 4/4 PR regressions pass on Fedora 43 / Node 22
- [x] Direct `tsx proof-85888.mts` against the patched scheduler — three scenarios match expected behavior
- [ ] Full cron suite + `cron/retry-hint.test.ts` + `cron/service.jobs.test.ts` in CI
