### PR TITLE
test(heartbeat): cover target none scheduler dispatch

### DIFF
--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -238,6 +238,29 @@ describe("startHeartbeatRunner", () => {
     runner.stop();
   });
 
+  it("dispatches scheduled heartbeats when delivery target is explicitly none", async () => {
+    useFakeHeartbeatTime();
+
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startHeartbeatRunner({
+      cfg: heartbeatConfig([{ id: "main", heartbeat: { every: "30m", target: "none" } }]),
+      runOnce: runSpy,
+      stableSchedulerSeed: TEST_SCHEDULER_SEED,
+    });
+    const mainDueMs = resolveDueFromNow(0, 30 * 60_000, "main");
+
+    await vi.advanceTimersByTimeAsync(mainDueMs + 1);
+
+    expect(runSpy).toHaveBeenCalledTimes(1);
+    expectRunCallFields(runSpy, 0, {
+      agentId: "main",
+      reason: "interval",
+      heartbeat: { every: "30m", target: "none" },
+    });
+
+    runner.stop();
+  });
+
   it("continues scheduling after runOnce throws an unhandled error", async () => {
     useFakeHeartbeatTime();
 


### PR DESCRIPTION
## Summary

- Add a regression test for scheduled heartbeat dispatch when an agent explicitly sets `heartbeat.target: "none"`.
- Verifies the scheduler still calls the heartbeat runner at the configured interval and preserves the target-none heartbeat config in the run options.

Refs #85871.

## Tests

- `node scripts/run-vitest.mjs src/infra/heartbeat-runner.scheduler.test.ts`
- `git diff --check`
- `node --import tsx -e 'import { startHeartbeatRunner } from "./src/infra/heartbeat-runner.ts"; const seen=[]; const runner=startHeartbeatRunner({ cfg: { agents: { list: [{ id: "main", heartbeat: { every: "1s", target: "none" } }] } }, stableSchedulerSeed: "pr-85898-real-proof", runOnce: async (opts) => { seen.push({ agentId: opts.agentId, reason: opts.reason, heartbeat: opts.heartbeat }); return { status: "ran", durationMs: 1 }; } }); await new Promise((resolve) => setTimeout(resolve, 2500)); runner.stop(); console.log(JSON.stringify({ observedRuns: seen.length, firstRun: seen[0] }, null, 2)); if (seen.length < 1 || seen[0]?.reason !== "interval" || seen[0]?.heartbeat?.target !== "none") process.exit(1);'`

## Real behavior proof

Behavior addressed: scheduled heartbeat dispatch for configurations that intentionally disable external delivery with `heartbeat.target: "none"`.
Real environment tested: macOS local checkout, Node runtime using OpenClaw's real `startHeartbeatRunner` implementation imported through `tsx`.
Exact steps or command run after this patch: `node --import tsx -e 'import { startHeartbeatRunner } from "./src/infra/heartbeat-runner.ts"; const seen=[]; const runner=startHeartbeatRunner({ cfg: { agents: { list: [{ id: "main", heartbeat: { every: "1s", target: "none" } }] } }, stableSchedulerSeed: "pr-85898-real-proof", runOnce: async (opts) => { seen.push({ agentId: opts.agentId, reason: opts.reason, heartbeat: opts.heartbeat }); return { status: "ran", durationMs: 1 }; } }); await new Promise((resolve) => setTimeout(resolve, 2500)); runner.stop(); console.log(JSON.stringify({ observedRuns: seen.length, firstRun: seen[0] }, null, 2)); if (seen.length < 1 || seen[0]?.reason !== "interval" || seen[0]?.heartbeat?.target !== "none") process.exit(1);'`
Evidence after fix: runtime output was:
```json
[heartbeat] started
{
  "observedRuns": 2,
  "firstRun": {
    "agentId": "main",
    "reason": "interval",
    "heartbeat": {
      "every": "1s",
      "target": "none"
    }
  }
}
```
Observed result after fix: the real heartbeat runner started, interval scheduling fired, and the first runtime dispatch preserved `target: "none"` instead of disabling the scheduled heartbeat.
What was not tested: a live gateway connected to a real model/provider was not started; this PR is a focused regression-test addition for the scheduler boundary.
