### PR TITLE
fix: preserve provider defaults during config saves

### DIFF
--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -5,8 +5,10 @@ import {
   readConfigFileSnapshot,
   readConfigFileSnapshotForWrite,
   resolveConfigSnapshotHash,
+  validateConfigObjectRawWithPlugins,
   validateConfigObjectWithPlugins,
 } from "../../config/config.js";
+import { createMergePatch, projectSourceOntoRuntimeShape } from "../../config/io.write-prepare.js";
 import { formatConfigIssueLines } from "../../config/issue-format.js";
 import { applyMergePatch } from "../../config/merge-patch.js";
 import {
@@ -17,6 +19,7 @@ import {
 import { loadGatewayRuntimeConfigSchema } from "../../config/runtime-schema.js";
 import { lookupConfigSchema, type ConfigSchemaResponse } from "../../config/schema.js";
 import type { ConfigValidationIssue, OpenClawConfig } from "../../config/types.openclaw.js";
+import { isBuiltInModelProviderOverlayId } from "../../config/zod-schema.core.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import {
   prepareSecretsRuntimeSnapshot,
@@ -189,12 +192,70 @@ function formatConfigOpenError(error: unknown): string {
   return String(error);
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasOwnRecordValue(value: unknown, key: string): boolean {
+  return isRecord(value) && Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function stripBundledProviderRuntimeDefaults(params: {
+  candidate: unknown;
+  sourceConfig: unknown;
+}): unknown {
+  if (!isRecord(params.candidate)) {
+    return params.candidate;
+  }
+  const models = params.candidate.models;
+  if (!isRecord(models) || !isRecord(models.providers)) {
+    return params.candidate;
+  }
+  const sourceModels = isRecord(params.sourceConfig) ? params.sourceConfig.models : undefined;
+  const sourceProviders = isRecord(sourceModels) ? sourceModels.providers : undefined;
+
+  let nextProviders: Record<string, unknown> | undefined;
+  for (const [providerId, provider] of Object.entries(models.providers)) {
+    if (!isBuiltInModelProviderOverlayId(providerId) || !isRecord(provider)) {
+      continue;
+    }
+    const sourceProvider = isRecord(sourceProviders) ? sourceProviders[providerId] : undefined;
+    let nextProvider: Record<string, unknown> | undefined;
+    if (provider.baseUrl === "" && !hasOwnRecordValue(sourceProvider, "baseUrl")) {
+      nextProvider = { ...provider };
+      delete nextProvider.baseUrl;
+    }
+    if (
+      Array.isArray(provider.models) &&
+      provider.models.length === 0 &&
+      !hasOwnRecordValue(sourceProvider, "models")
+    ) {
+      nextProvider ??= { ...provider };
+      delete nextProvider.models;
+    }
+    if (nextProvider) {
+      nextProviders ??= { ...models.providers };
+      nextProviders[providerId] = nextProvider;
+    }
+  }
+  if (!nextProviders) {
+    return params.candidate;
+  }
+  return {
+    ...params.candidate,
+    models: {
+      ...models,
+      providers: nextProviders,
+    },
+  };
+}
+
 function parseValidateConfigFromRawOrRespond(
   params: unknown,
   requestName: string,
   snapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>,
   respond: RespondFn,
-): { config: OpenClawConfig; schema: ConfigSchemaResponse } | null {
+): { config: OpenClawConfig; writeConfig: OpenClawConfig; schema: ConfigSchemaResponse } | null {
   const rawValue = parseRawConfigOrRespond(params, requestName, respond);
   if (!rawValue) {
     return null;
@@ -214,7 +275,32 @@ function parseValidateConfigFromRawOrRespond(
     );
     return null;
   }
-  const validated = validateConfigObjectWithPlugins(restored.result);
+  const projectedValidationCandidate = snapshot.valid
+    ? applyMergePatch(
+        projectSourceOntoRuntimeShape(snapshot.resolved, snapshot.config),
+        createMergePatch(snapshot.config, restored.result),
+      )
+    : restored.result;
+  const validationCandidate = stripBundledProviderRuntimeDefaults({
+    candidate: projectedValidationCandidate,
+    sourceConfig: snapshot.parsed,
+  });
+  const sourceValidated = validateConfigObjectRawWithPlugins(validationCandidate);
+  if (!sourceValidated.ok) {
+    respond(
+      false,
+      undefined,
+      errorShape(
+        ErrorCodes.INVALID_REQUEST,
+        summarizeConfigValidationIssues(sourceValidated.issues),
+        {
+          details: { issues: sourceValidated.issues },
+        },
+      ),
+    );
+    return null;
+  }
+  const validated = validateConfigObjectWithPlugins(validationCandidate);
   if (!validated.ok) {
     respond(
       false,
@@ -225,7 +311,11 @@ function parseValidateConfigFromRawOrRespond(
     );
     return null;
   }
-  return { config: validated.config, schema };
+  return {
+    config: validated.config,
+    writeConfig: validationCandidate as OpenClawConfig,
+    schema,
+  };
 }
 
 function summarizeConfigValidationIssues(issues: ReadonlyArray<ConfigValidationIssue>): string {
@@ -357,7 +447,7 @@ export const configHandlers: GatewayRequestHandlers = {
     const writeResult = await commitGatewayConfigWrite({
       snapshot,
       writeOptions,
-      nextConfig: parsed.config,
+      nextConfig: parsed.writeConfig,
       context,
     });
     clearConfigSchemaResponseCache();
@@ -573,7 +663,7 @@ export const configHandlers: GatewayRequestHandlers = {
     const writeResult = await commitGatewayConfigWrite({
       snapshot,
       writeOptions,
-      nextConfig: parsed.config,
+      nextConfig: parsed.writeConfig,
       context,
       disconnectSharedAuthClients,
     });

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -200,6 +200,69 @@ describe("gateway config methods", () => {
     requireConfigObject(res.payload?.config, "response config");
   });
 
+  it("accepts runtime-shaped config.set when bundled provider baseUrl was only defaulted", async () => {
+    const { createConfigIO, resetConfigRuntimeState } = await import("../config/config.js");
+    const configPath = createConfigIO().configPath;
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    try {
+      await fs.writeFile(
+        configPath,
+        `${JSON.stringify(
+          {
+            models: {
+              providers: {
+                openai: {
+                  agentRuntime: { id: "pi" },
+                },
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf-8",
+      );
+      resetConfigRuntimeState();
+
+      const current = await rpcReq<{
+        hash?: string;
+        config?: Record<string, unknown>;
+      }>(requireWs(), "config.get", {});
+      expect(current.ok).toBe(true);
+      expect(typeof current.payload?.hash).toBe("string");
+      const nextConfig = structuredClone(
+        requireConfigObject(current.payload?.config, "current config"),
+      );
+      const providers = ((nextConfig.models as Record<string, unknown>).providers ?? {}) as Record<
+        string,
+        Record<string, unknown>
+      >;
+      providers.openai ??= {};
+      providers.openai.baseUrl = "";
+      providers.openai.models = [];
+
+      const gateway = (nextConfig.gateway ??= {}) as Record<string, unknown>;
+      gateway.port = 19002;
+
+      const res = await rpcReq<{
+        ok?: boolean;
+        error?: { message?: string };
+      }>(requireWs(), "config.set", {
+        raw: JSON.stringify(nextConfig, null, 2),
+        baseHash: current.payload?.hash,
+      });
+
+      expect(res.error).toBeUndefined();
+      expect(res.ok).toBe(true);
+      const persisted = await fs.readFile(configPath, "utf-8");
+      expect(persisted).toContain('"port": 19002');
+      expect(persisted).not.toContain('"baseUrl"');
+    } finally {
+      await fs.rm(configPath, { force: true });
+      resetConfigRuntimeState();
+    }
+  });
+
   it("redacts browser cdpUrl credentials from config.get responses", async () => {
     const { createConfigIO, resetConfigRuntimeState } = await import("../config/config.js");
     const configPath = createConfigIO().configPath;


### PR DESCRIPTION
Summary
- Harden gateway config.set/config.apply so runtime-shaped bundled provider defaults from a full config payload do not get persisted or rejected as authored values.
- Strip default-only empty bundled provider fields before source validation/write, while keeping the validated runtime config for restart/secret checks.
- Add a gateway regression for an OpenAI provider with only agentRuntime configured.

Verification
- `pnpm exec oxfmt --write --threads=1 src/gateway/server-methods/config.ts src/gateway/server.config-patch.test.ts && git diff --check`
- `node scripts/run-vitest.mjs src/gateway/server.config-patch.test.ts`
- `pnpm check:changed` via Testbox `tbx_01ksbz9jcz62vp9zgpa3m71cw9`, GitHub Actions run https://github.com/openclaw/openclaw/actions/runs/26350430946
- `autoreview --mode branch --base origin/main --engine codex --model gpt-5.3-codex-spark --no-web-search`: clean, no accepted/actionable findings

Behavior addressed: Gateway full-config writes now tolerate runtime-shaped bundled provider defaults, complementing the Control UI source-snapshot fix already merged in #85879.
Real environment tested: Local OpenClaw checkout plus Blacksmith Testbox changed gate.
Exact steps or command run after this patch: Wrote a source config with models.providers.openai.agentRuntime.id, loaded it through config.get, submitted the runtime-shaped config through config.set with baseUrl empty, and verified the save succeeds.
Evidence after fix: Added regression in src/gateway/server.config-patch.test.ts; focused test passed 23/23 and check:changed passed on Testbox.
Observed result after fix: config.set returns ok and persisted config contains the unrelated gateway port edit without persisting default-only baseUrl.
What was not tested: Live browser Control UI manual save; #85879 covers the UI submit path and this patch covers the gateway RPC path directly.

Refs #85831.
