### PR TITLE
fix(slack): keep DM thread turns out of active steering

### DIFF
--- a/extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts
@@ -490,11 +490,11 @@ describe("thread-level session keys", () => {
     expect(sessionKey).not.toContain(":thread:");
   });
 
-  it("keeps top-level DMs on the direct session when replyToMode=all", () => {
+  it("keeps top-level DMs on the stable DM session when replyToMode=all", () => {
     const ctx = buildCtx({ replyToMode: "all", dmScope: "per-channel-peer" });
     const account = buildAccount("all");
 
-    const routing = resolveSlackRoutingContext({
+    const first = resolveSlackRoutingContext({
       ctx,
       account,
       message: {
@@ -509,9 +509,26 @@ describe("thread-level session keys", () => {
       isRoom: false,
       isRoomish: false,
     });
+    const second = resolveSlackRoutingContext({
+      ctx,
+      account,
+      message: {
+        channel: "D456",
+        channel_type: "im",
+        user: "U3",
+        text: "second dm message",
+        ts: "1770408531.000000",
+      } as SlackMessageEvent,
+      isDirectMessage: true,
+      isGroupDm: false,
+      isRoom: false,
+      isRoomish: false,
+    });
 
-    expect(routing.sessionKey).toBe("agent:main:slack:direct:u3");
-    expect(routing.threadContext.messageThreadId).toBe("1770408530.000000");
+    expect(first.sessionKey).toBe("agent:main:slack:direct:u3");
+    expect(second.sessionKey).toBe("agent:main:slack:direct:u3");
+    expect(first.threadContext.messageThreadId).toBe("1770408530.000000");
+    expect(second.threadContext.messageThreadId).toBe("1770408531.000000");
   });
 
   it("routes DM thread replies to the main DM session, not a thread-scoped session", () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -106,6 +106,7 @@ import { createReplyMediaContext } from "./reply-media-paths.js";
 import { replyRunRegistry, type ReplyOperation } from "./reply-run-registry.js";
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
 import { admitReplyTurn, resolveReplyTurnKind } from "./reply-turn-admission.js";
+import { resolveRoutedDeliveryThreadId } from "./routed-delivery-thread.js";
 import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-run-accounting.js";
 import { resolveSourceReplyVisibilityPolicy } from "./source-reply-delivery-mode.js";
 import { createTypingSignaler } from "./typing-mode.js";
@@ -1335,6 +1336,10 @@ export async function runReplyAgent(params: {
       : null;
 
   const replySessionKey = sessionKey ?? followupRun.run.sessionKey;
+  const replyRouteThreadId = resolveRoutedDeliveryThreadId({
+    ctx: sessionCtx,
+    sessionKey: replySessionKey,
+  });
   let replyOperation: ReplyOperation;
   if (providedReplyOperation) {
     replyOperation = providedReplyOperation;
@@ -1345,6 +1350,7 @@ export async function runReplyAgent(params: {
       sessionKey: replySessionKey ?? "",
       kind: replyTurnKind,
       resetTriggered: effectiveResetTriggered,
+      routeThreadId: replyRouteThreadId,
       upstreamAbortSignal: opts?.abortSignal,
     });
     if (admission.status === "skipped") {

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1135,6 +1135,126 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 
+  it("records routed Slack thread id on dispatch-owned reply operations", async () => {
+    setNoAbort();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "slack",
+      Surface: "slack",
+      OriginatingChannel: "slack",
+      OriginatingTo: "user:U1",
+      ChatType: "direct",
+      SessionKey: "agent:main:slack:direct:U1",
+      MessageThreadId: "501.000",
+    });
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      const operation = (
+        opts as { replyOperation?: { routeThreadId?: string | number } } | undefined
+      )?.replyOperation;
+      expect(operation?.routeThreadId).toBe("501.000");
+      return { text: "hi" } satisfies ReplyPayload;
+    });
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets a different Slack DM routed thread reach reply resolution while another thread is active", async () => {
+    setNoAbort();
+    const sessionKey = "agent:main:slack:direct:U1";
+    const activeOperation = createReplyOperation({
+      sessionKey,
+      sessionId: "active-session",
+      resetTriggered: false,
+      routeThreadId: "500.000",
+    });
+    activeOperation.setPhase("running");
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => ({ text: "thread B reply" }) satisfies ReplyPayload);
+
+    try {
+      const resultPromise = dispatchReplyFromConfig({
+        ctx: buildTestCtx({
+          Provider: "slack",
+          Surface: "slack",
+          OriginatingChannel: "slack",
+          OriginatingTo: "user:U1",
+          ChatType: "direct",
+          SessionKey: sessionKey,
+          MessageThreadId: "501.000",
+          BodyForAgent: "second top-level DM",
+        }),
+        cfg: emptyConfig,
+        dispatcher,
+        replyResolver,
+      });
+
+      const result = await Promise.race([
+        resultPromise,
+        new Promise<"timed-out">((resolve) => setTimeout(() => resolve("timed-out"), 1_000)),
+      ]);
+      if (result === "timed-out") {
+        activeOperation.complete();
+        await resultPromise;
+        throw new Error("Slack routed thread was blocked by the active reply operation");
+      }
+
+      expect(result).toMatchObject({
+        queuedFinal: true,
+        counts: { tool: 0, block: 0, final: 0 },
+      });
+      expect(replyResolver).toHaveBeenCalledTimes(1);
+      expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+    } finally {
+      activeOperation.complete();
+    }
+  });
+
+  it("keeps non-Slack routed direct turns behind the active reply operation", async () => {
+    setNoAbort();
+    const sessionKey = "agent:main:telegram:direct:1";
+    const activeOperation = createReplyOperation({
+      sessionKey,
+      sessionId: "active-session",
+      resetTriggered: false,
+      routeThreadId: "500.000",
+    });
+    activeOperation.setPhase("running");
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => ({ text: "telegram reply" }) satisfies ReplyPayload);
+
+    const resultPromise = dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "telegram",
+        Surface: "telegram",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "user:1",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+        MessageThreadId: "501.000",
+        BodyForAgent: "second telegram direct turn",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    try {
+      const result = await Promise.race([
+        resultPromise,
+        new Promise<"blocked">((resolve) => setTimeout(() => resolve("blocked"), 1_000)),
+      ]);
+
+      expect(result).toBe("blocked");
+      expect(replyResolver).not.toHaveBeenCalled();
+    } finally {
+      activeOperation.complete();
+      await resultPromise;
+    }
+  });
+
   it("routes when OriginatingChannel differs from Provider", async () => {
     setNoAbort();
     mocks.routeReply.mockClear();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -192,6 +192,44 @@ function composeAbortSignals(...signals: Array<AbortSignal | undefined>): AbortS
   return controller.signal;
 }
 
+function routeThreadIdsDiffer(
+  left: string | number | undefined,
+  right: string | number | undefined,
+): boolean {
+  if (left === undefined || right === undefined) {
+    return false;
+  }
+  return String(left) !== String(right);
+}
+
+function isSlackDirectRoutedThreadTurn(
+  ctx: Pick<
+    FinalizedMsgContext,
+    "ChatType" | "MessageThreadId" | "OriginatingChannel" | "Provider" | "Surface" | "TransportThreadId"
+  >,
+): boolean {
+  if (normalizeChatType(ctx.ChatType) !== "direct") {
+    return false;
+  }
+  if (ctx.MessageThreadId == null && ctx.TransportThreadId == null) {
+    return false;
+  }
+  return [ctx.Provider, ctx.Surface, ctx.OriginatingChannel].some(
+    (value) => normalizeOptionalString(value)?.toLowerCase() === "slack",
+  );
+}
+
+function shouldLetSlackRoutedThreadBypassBusyReplyOperation(params: {
+  activeOperation?: ReplyOperation;
+  ctx: FinalizedMsgContext;
+  routeThreadId?: string | number;
+}): boolean {
+  return (
+    isSlackDirectRoutedThreadTurn(params.ctx) &&
+    routeThreadIdsDiffer(params.activeOperation?.routeThreadId, params.routeThreadId)
+  );
+}
+
 const routeReplyRuntimeLoader = createLazyImportLoader(() => import("./route-reply.runtime.js"));
 const getReplyFromConfigRuntimeLoader = createLazyImportLoader(
   () => import("./get-reply-from-config.runtime.js"),
@@ -1178,17 +1216,38 @@ export async function dispatchReplyFromConfig(
       crypto.randomUUID();
     const replyTurnKind = resolveReplyTurnKind(params.replyOptions);
     const allowActivePreDispatch = phase === "pre_dispatch" && replyTurnKind === "visible";
+    const allowSlackRoutedThreadBypass =
+      phase === "dispatch" &&
+      shouldLetSlackRoutedThreadBypassBusyReplyOperation({
+        activeOperation: replyRunRegistry.get(dispatchOperationSessionKey),
+        ctx,
+        routeThreadId,
+      });
     const admission = await admitReplyTurn({
       sessionKey: dispatchOperationSessionKey,
       sessionId: operationSessionId,
       kind: replyTurnKind,
       resetTriggered: false,
+      routeThreadId,
       upstreamAbortSignal: params.replyOptions?.abortSignal,
-      waitForActive: !allowActivePreDispatch,
+      waitForActive: !allowActivePreDispatch && !allowSlackRoutedThreadBypass,
     });
     if (admission.status === "skipped") {
       if (allowActivePreDispatch && admission.reason === "active-run") {
         preDispatchAbortOperation = admission.activeOperation;
+        return { status: "ready" };
+      }
+      if (
+        admission.reason === "active-run" &&
+        shouldLetSlackRoutedThreadBypassBusyReplyOperation({
+          activeOperation: admission.activeOperation,
+          ctx,
+          routeThreadId,
+        })
+      ) {
+        logVerbose(
+          `dispatch-from-config: allowing Slack routed thread ${routeThreadId} while ${dispatchOperationSessionKey} has an active reply operation in another Slack thread`,
+        );
         return { status: "ready" };
       }
       dispatchAbortOperation = admission.activeOperation;

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1646,7 +1646,7 @@ describe("createFollowupRunner progress forwarding", () => {
         messageProvider: "slack",
       },
     });
-    runEmbeddedPiAgentMock.mockImplementationOnce(
+    runEmbeddedAgentMock.mockImplementationOnce(
       async (args: { replyOperation?: { routeThreadId?: string | number } }) => {
         expect(args.replyOperation?.routeThreadId).toBe("501.000");
         return { payloads: [], meta: { agentMeta: {} } };
@@ -1661,7 +1661,7 @@ describe("createFollowupRunner progress forwarding", () => {
 
     await runner(queued);
 
-    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
   });
 
   it("forwards queued follow-up tool progress and verbose tool result payloads", async () => {

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1637,6 +1637,33 @@ describe("createFollowupRunner runtime config", () => {
 });
 
 describe("createFollowupRunner progress forwarding", () => {
+  it("records queued thread id on follow-up reply operations", async () => {
+    const queued = createQueuedRun({
+      originatingChannel: "slack",
+      originatingTo: "user:U1",
+      originatingThreadId: "501.000",
+      run: {
+        messageProvider: "slack",
+      },
+    });
+    runEmbeddedPiAgentMock.mockImplementationOnce(
+      async (args: { replyOperation?: { routeThreadId?: string | number } }) => {
+        expect(args.replyOperation?.routeThreadId).toBe("501.000");
+        return { payloads: [], meta: { agentMeta: {} } };
+      },
+    );
+
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "claude",
+    });
+
+    await runner(queued);
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+  });
+
   it("forwards queued follow-up tool progress and verbose tool result payloads", async () => {
     const onToolStart = vi.fn(async () => {});
     const queued = createQueuedRun({

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -507,6 +507,7 @@ export function createFollowupRunner(params: {
         sessionKey: replySessionKey ?? "",
         kind: "queued_followup",
         resetTriggered: false,
+        routeThreadId: queued.originatingThreadId,
         upstreamAbortSignal: queued.abortSignal,
       });
       if (admission.status === "skipped") {

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -1335,6 +1335,135 @@ describe("runPreparedReply media-only handling", () => {
     expect(call?.isActive).toBe(true);
     expect(call?.isStreaming).toBe(true);
   });
+
+  it.each([
+    ["message thread id", { MessageThreadId: "501.000" }],
+    ["transport thread id", { TransportThreadId: "501.000" }],
+  ] as const)(
+    "queues same-session Slack DM turns instead of steering across Slack threads using %s",
+    async (_label, threadContext) => {
+      const queueSettings = await import("./queue/settings-runtime.js");
+      const piRuntime = await import("../../agents/pi-embedded.runtime.js");
+      vi.mocked(queueSettings.resolveQueueSettings).mockReturnValueOnce({
+        mode: "steer",
+        debounceMs: 500,
+        cap: 20,
+        dropPolicy: "summarize",
+      });
+      const activeRun = createReplyOperation({
+        sessionId: "active-session",
+        sessionKey: "session-key",
+        resetTriggered: false,
+        routeThreadId: "500.000",
+      });
+      activeRun.setPhase("running");
+      vi.mocked(piRuntime.resolveActiveEmbeddedRunSessionId)
+        .mockReturnValueOnce("active-session")
+        .mockReturnValueOnce("active-session");
+      vi.mocked(piRuntime.isEmbeddedPiRunActive).mockReturnValueOnce(true);
+      vi.mocked(piRuntime.isEmbeddedPiRunStreaming).mockReturnValueOnce(true);
+
+      try {
+        await runPreparedReply(
+          baseParams({
+            isNewSession: false,
+            ctx: {
+              Body: "second top-level DM",
+              RawBody: "second top-level DM",
+              CommandBody: "second top-level DM",
+              Provider: "slack",
+              Surface: "slack",
+              ChatType: "direct",
+              OriginatingChannel: "slack",
+              OriginatingTo: "user:U1",
+              ...threadContext,
+            },
+            sessionCtx: {
+              Body: "second top-level DM",
+              BodyStripped: "second top-level DM",
+              Provider: "slack",
+              Surface: "slack",
+              ChatType: "direct",
+              OriginatingChannel: "slack",
+              OriginatingTo: "user:U1",
+              ...threadContext,
+            },
+          }),
+        );
+      } finally {
+        activeRun.complete();
+      }
+
+      const call = requireLastRunReplyAgentCall();
+      expect(call.shouldSteer).toBe(false);
+      expect(call.shouldFollowup).toBe(true);
+      expect(call.isActive).toBe(true);
+      expect(call.isStreaming).toBe(true);
+      expect(call.followupRun.originatingThreadId).toBe("501.000");
+    },
+  );
+
+  it("keeps non-Slack same-session turns steerable when route threads differ", async () => {
+    const queueSettings = await import("./queue/settings-runtime.js");
+    const piRuntime = await import("../../agents/pi-embedded.runtime.js");
+    vi.mocked(queueSettings.resolveQueueSettings).mockReturnValueOnce({
+      mode: "steer",
+      debounceMs: 500,
+      cap: 20,
+      dropPolicy: "summarize",
+    });
+    const activeRun = createReplyOperation({
+      sessionId: "active-session",
+      sessionKey: "session-key",
+      resetTriggered: false,
+      routeThreadId: 42,
+    });
+    activeRun.setPhase("running");
+    vi.mocked(piRuntime.resolveActiveEmbeddedRunSessionId)
+      .mockReturnValueOnce("active-session")
+      .mockReturnValueOnce("active-session");
+    vi.mocked(piRuntime.isEmbeddedPiRunActive).mockReturnValueOnce(true);
+    vi.mocked(piRuntime.isEmbeddedPiRunStreaming).mockReturnValueOnce(true);
+
+    try {
+      await runPreparedReply(
+        baseParams({
+          isNewSession: false,
+          ctx: {
+            Body: "follow-up in another transport thread",
+            RawBody: "follow-up in another transport thread",
+            CommandBody: "follow-up in another transport thread",
+            Provider: "telegram",
+            Surface: "telegram",
+            ChatType: "direct",
+            OriginatingChannel: "telegram",
+            OriginatingTo: "user:1",
+            MessageThreadId: 43,
+          },
+          sessionCtx: {
+            Body: "follow-up in another transport thread",
+            BodyStripped: "follow-up in another transport thread",
+            Provider: "telegram",
+            Surface: "telegram",
+            ChatType: "direct",
+            OriginatingChannel: "telegram",
+            OriginatingTo: "user:1",
+            MessageThreadId: 43,
+          },
+        }),
+      );
+    } finally {
+      activeRun.complete();
+    }
+
+    const call = requireLastRunReplyAgentCall();
+    expect(call.shouldSteer).toBe(true);
+    expect(call.shouldFollowup).toBe(true);
+    expect(call.isActive).toBe(true);
+    expect(call.isStreaming).toBe(true);
+    expect(call.followupRun.originatingThreadId).toBe(43);
+  });
+
   it("rechecks same-session ownership after async prep before registering a new reply operation", async () => {
     const { resolveSessionAuthProfileOverride } =
       await import("../../agents/auth-profiles/session-override.js");

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -1343,7 +1343,7 @@ describe("runPreparedReply media-only handling", () => {
     "queues same-session Slack DM turns instead of steering across Slack threads using %s",
     async (_label, threadContext) => {
       const queueSettings = await import("./queue/settings-runtime.js");
-      const piRuntime = await import("../../agents/pi-embedded.runtime.js");
+      const embeddedAgentRuntime = await import("../../agents/embedded-agent.runtime.js");
       vi.mocked(queueSettings.resolveQueueSettings).mockReturnValueOnce({
         mode: "steer",
         debounceMs: 500,
@@ -1357,11 +1357,11 @@ describe("runPreparedReply media-only handling", () => {
         routeThreadId: "500.000",
       });
       activeRun.setPhase("running");
-      vi.mocked(piRuntime.resolveActiveEmbeddedRunSessionId)
+      vi.mocked(embeddedAgentRuntime.resolveActiveEmbeddedRunSessionId)
         .mockReturnValueOnce("active-session")
         .mockReturnValueOnce("active-session");
-      vi.mocked(piRuntime.isEmbeddedPiRunActive).mockReturnValueOnce(true);
-      vi.mocked(piRuntime.isEmbeddedPiRunStreaming).mockReturnValueOnce(true);
+      vi.mocked(embeddedAgentRuntime.isEmbeddedAgentRunActive).mockReturnValueOnce(true);
+      vi.mocked(embeddedAgentRuntime.isEmbeddedAgentRunStreaming).mockReturnValueOnce(true);
 
       try {
         await runPreparedReply(
@@ -1405,7 +1405,7 @@ describe("runPreparedReply media-only handling", () => {
 
   it("keeps non-Slack same-session turns steerable when route threads differ", async () => {
     const queueSettings = await import("./queue/settings-runtime.js");
-    const piRuntime = await import("../../agents/pi-embedded.runtime.js");
+    const embeddedAgentRuntime = await import("../../agents/embedded-agent.runtime.js");
     vi.mocked(queueSettings.resolveQueueSettings).mockReturnValueOnce({
       mode: "steer",
       debounceMs: 500,
@@ -1419,11 +1419,11 @@ describe("runPreparedReply media-only handling", () => {
       routeThreadId: 42,
     });
     activeRun.setPhase("running");
-    vi.mocked(piRuntime.resolveActiveEmbeddedRunSessionId)
+    vi.mocked(embeddedAgentRuntime.resolveActiveEmbeddedRunSessionId)
       .mockReturnValueOnce("active-session")
       .mockReturnValueOnce("active-session");
-    vi.mocked(piRuntime.isEmbeddedPiRunActive).mockReturnValueOnce(true);
-    vi.mocked(piRuntime.isEmbeddedPiRunStreaming).mockReturnValueOnce(true);
+    vi.mocked(embeddedAgentRuntime.isEmbeddedAgentRunActive).mockReturnValueOnce(true);
+    vi.mocked(embeddedAgentRuntime.isEmbeddedAgentRunStreaming).mockReturnValueOnce(true);
 
     try {
       await runPreparedReply(

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -88,6 +88,7 @@ import {
   abortReplyRunBySessionId,
   isReplyRunActiveForSessionId,
   isReplyRunStreamingForSessionId,
+  resolveActiveReplyRunThreadId,
   resolveActiveReplyRunSessionId,
   waitForReplyRunEndBySessionId,
   type ReplyOperation,
@@ -135,6 +136,28 @@ function hasResolvedThinkingCatalogEntry(params: {
       normalizeProviderId(candidate.provider) === normalizedProvider && candidate.id === modelId,
   );
   return entry?.reasoning !== undefined;
+}
+
+function routeThreadIdsMatch(
+  activeThreadId: string | number | undefined,
+  currentThreadId: string | number | undefined,
+): boolean {
+  if (activeThreadId === undefined || currentThreadId === undefined) {
+    return true;
+  }
+  return String(activeThreadId) === String(currentThreadId);
+}
+
+function isSlackDirectRoutedThreadTurn(ctx: MsgContext): boolean {
+  if (normalizeChatType(ctx.ChatType) !== "direct") {
+    return false;
+  }
+  if (ctx.MessageThreadId == null && ctx.TransportThreadId == null) {
+    return false;
+  }
+  return [ctx.Provider, ctx.Surface, ctx.OriginatingChannel].some(
+    (value) => normalizeOptionalString(value)?.toLowerCase() === "slack",
+  );
 }
 
 export function resolvePromptSilentReplyConversationType(params: {
@@ -1046,6 +1069,17 @@ export async function runPreparedReply(
   );
   const queueKey = sessionKey ?? sessionIdFinal;
   preparedSessionState = resolvePreparedSessionState();
+  const currentRouteThreadId = resolveRoutedDeliveryThreadId({
+    ctx,
+    sessionKey,
+  });
+  const applySlackRouteThreadSteeringGuard = isSlackDirectRoutedThreadTurn(ctx);
+  const resolveActiveRunAcceptsCurrentThread = (busy: { isActive: boolean }) => {
+    if (!busy.isActive || !sessionKey || !applySlackRouteThreadSteeringGuard) {
+      return true;
+    }
+    return routeThreadIdsMatch(resolveActiveReplyRunThreadId(sessionKey), currentRouteThreadId);
+  };
   const resolveActiveReplyOperationSessionId = () =>
     sessionKey ? resolveActiveReplyRunSessionId(sessionKey) : undefined;
   const resolveActiveQueueSessionId = () =>
@@ -1080,9 +1114,14 @@ export async function runPreparedReply(
     };
   };
   let { activeSessionId, isActive, isStreaming } = resolveQueueBusyState();
+  let activeRunAcceptsCurrentThread = resolveActiveRunAcceptsCurrentThread({ isActive });
   const isHeartbeatRun = opts?.isHeartbeat === true;
   const shouldSteer =
-    !isRoomEvent && !isHeartbeatRun && !effectiveResetTriggered && resolvedQueue.mode === "steer";
+    !isRoomEvent &&
+    activeRunAcceptsCurrentThread &&
+    !isHeartbeatRun &&
+    !effectiveResetTriggered &&
+    resolvedQueue.mode === "steer";
   const shouldFollowup =
     !effectiveResetTriggered &&
     ((isRoomEvent && isActive) ||
@@ -1133,6 +1172,7 @@ export async function runPreparedReply(
       return queueState.reply;
     }
     ({ activeSessionId, isActive, isStreaming } = queueState.busyState);
+    activeRunAcceptsCurrentThread = resolveActiveRunAcceptsCurrentThread({ isActive });
   }
   const runHasSessionModelOverride = Boolean(
     normalizeOptionalString(preparedSessionState.sessionEntry?.modelOverride) ||

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -49,6 +49,7 @@ export type ReplyOperationResult =
 export type ReplyOperation = {
   readonly key: ReplyRunKey;
   readonly sessionId: string;
+  readonly routeThreadId?: string | number;
   readonly abortSignal: AbortSignal;
   readonly resetTriggered: boolean;
   readonly phase: ReplyOperationPhase;
@@ -73,6 +74,7 @@ export type ReplyRunRegistry = {
     sessionKey: string;
     sessionId: string;
     resetTriggered: boolean;
+    routeThreadId?: string | number;
     upstreamAbortSignal?: AbortSignal;
   }): ReplyOperation;
   get(sessionKey: string): ReplyOperation | undefined;
@@ -226,6 +228,7 @@ export function createReplyOperation(params: {
   sessionKey: string;
   sessionId: string;
   resetTriggered: boolean;
+  routeThreadId?: string | number;
   upstreamAbortSignal?: AbortSignal;
 }): ReplyOperation {
   const sessionKey = normalizeOptionalString(params.sessionKey);
@@ -297,6 +300,9 @@ export function createReplyOperation(params: {
     },
     get sessionId() {
       return currentSessionId;
+    },
+    get routeThreadId() {
+      return params.routeThreadId;
     },
     get abortSignal() {
       return controller.signal;
@@ -497,6 +503,10 @@ export const replyRunRegistry: ReplyRunRegistry = {
 
 export function resolveActiveReplyRunSessionId(sessionKey: string): string | undefined {
   return replyRunRegistry.resolveSessionId(sessionKey);
+}
+
+export function resolveActiveReplyRunThreadId(sessionKey: string): string | number | undefined {
+  return replyRunRegistry.get(sessionKey)?.routeThreadId;
 }
 
 export function isReplyRunActiveForSessionId(sessionId: string): boolean {

--- a/src/auto-reply/reply/reply-turn-admission.ts
+++ b/src/auto-reply/reply/reply-turn-admission.ts
@@ -25,6 +25,7 @@ export async function admitReplyTurn(params: {
   sessionId: string;
   kind: ReplyTurnKind;
   resetTriggered: boolean;
+  routeThreadId?: string | number;
   upstreamAbortSignal?: AbortSignal;
   waitTimeoutMs?: number;
   waitForActive?: boolean;
@@ -41,6 +42,7 @@ export async function admitReplyTurn(params: {
           sessionKey: params.sessionKey,
           sessionId,
           resetTriggered: params.resetTriggered,
+          routeThreadId: params.routeThreadId,
           upstreamAbortSignal: params.upstreamAbortSignal,
         }),
       };


### PR DESCRIPTION
## Summary

- Preserve OpenClaw's stable Slack DM `SessionKey` contract for top-level DMs and ordinary DM thread replies.
- Track routed Slack thread ids on active reply operations, including agent-runner-owned, dispatch-owned, and queued follow-up operations.
- Suppress active-run steering and dispatch admission blocking only for Slack direct-message turns that carry Slack routed thread metadata and target a different Slack thread, so non-Slack IM steering/admission behavior remains unchanged.

## Verification

- Confirmed latest `origin/main` at `1d1a7c26d8867fdfa98c97d8b510ad0ce1951858` still does not include this fix.
- Watched the original Slack regression fail before the fix: `expected true to be false` for `call.shouldSteer`, proving the second Slack DM thread would still steer into the active run.
- Watched the dispatch admission regression fail before the latest fix: `Slack routed thread was blocked by the active reply operation`, matching the live Slack symptom where B was skipped as `reply-operation-active`.
- Watched the non-Slack compatibility regression fail before the Slack-only scoping change: `expected false to be true` for `call.shouldSteer`, proving the generic route-thread guard changed existing non-Slack same-session steering.
- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run src/auto-reply/reply/dispatch-from-config.test.ts -- -t "different Slack DM routed thread|non-Slack routed direct turns|records routed Slack thread id" --test-timeout 5000 --hook-timeout 5000` - 1 file passed, 156 tests passed.
- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts extensions/slack/src/monitor/message-handler/prepare.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts src/auto-reply/reply/dispatch-from-config.test.ts src/auto-reply/reply/followup-runner.test.ts` - 5 files passed, 378 tests passed, duration 19.71s.
- `git diff --check FETCH_HEAD` - passed.
- Attempted `node scripts/crabbox-wrapper.mjs run slack-dm-thread-isolation-check-changed --provider blacksmith-testbox --shell -- "pnpm check:changed"`; it did not start because this local environment has no usable `crabbox` binary (`selected binary failed basic --version/--help sanity checks`).

## Real behavior proof

- Behavior addressed: Two overlapping top-level Slack DMs from the same Slack sender should keep the stable DM `SessionKey`, but the second top-level Slack thread must not be steered into, or blocked behind dispatch admission for, the first active run. Ordinary DM thread follow-up should continue to work in the original Slack thread. The steering and dispatch-admission guards are Slack-scoped, so non-Slack same-session direct-message turns keep their prior behavior even when their transport thread ids differ.
- Real environment tested: Real Slack workspace `w1773415900-eqa641873.slack.com`, OpenClaw source checkout `d0d5a354e77e5650f0ff3126eea42cae04a008e3`, foreground gateway started from this branch with `OPENCLAW_HOME=/tmp/openclaw-pr85904-live-root WORKSPACE=/tmp/openclaw-pr85904-live-workspace node scripts/run-node.mjs gateway run --port 18790 --verbose --ws-log compact`. The normal installed gateway was stopped before the smoke and restarted after proof capture.
- Exact steps or command run after this patch: Started the PR gateway with a temporary redacted proof config using Slack Socket Mode, `replyToMode=all`, and `allowBots=true` because the available automated Slack acceptance sender posts app-authored Slack messages. The OpenClaw bot under test was a different bot id, so this did not exercise self-message handling. Sent top-level DM A and top-level DM B from the same sender in the same DM channel about 1.00s apart, then sent ordinary follow-up D inside B's Slack thread. After the dispatch-admission repair, ran the current-head local regression set above.
- Evidence after fix: Redacted Slack API and gateway evidence from the live workspace:

```text
Gateway under test: OpenClaw 2026.5.24 (d0d5a35)
Loaded channel runtime: Slack Socket Mode connected; octoclaw-runtime was not loaded in this proof gateway.
Workspace: w1773415900-eqa641873.slack.com
Sender: user=U...9Z bot_id=B...N2
OpenClaw bot: user=U...CQ bot_id=B...57
DM channel: D...QL
Nonce: oc-proof-8e6bc0a0

Top-level A sent: ts=1779642174.068849 thread_ts=1779642174.068849
Top-level B sent: ts=1779642175.071749 thread_ts=1779642175.071749
Delta between A and B sends: 1.002900s

Gateway current-head routing evidence:
- Slack B inbound used stable SessionKey agent:main:slack:default:direct:u0...9z.
- While A was active, gateway logged: dispatch-from-config: allowing Slack routed thread 1779642175.071749 while agent:main:slack:default:direct:u0...9z has an active reply operation in another Slack thread.
- No `reply-operation-active` skip occurred for B on current head d0d5a354e77e.

A thread replies:
- user=U...9Z bot_id=B...N2 ts=1779642174.068849 thread_ts=1779642174.068849 text="[oc-proof-8e6bc0a0] top-level DM A... FINAL-A=oc-proof-8e6bc0a0-A"
- user=U...CQ bot_id=B...57 ts=1779642207.663989 thread_ts=1779642174.068849 text="... oc-proof-8e6bc0a0-A ..."

B thread replies:
- user=U...9Z bot_id=B...N2 ts=1779642175.071749 thread_ts=1779642175.071749 text="[oc-proof-8e6bc0a0] top-level DM B... FINAL-B=oc-proof-8e6bc0a0-B"
- user=U...CQ bot_id=B...57 ts=1779642212.717829 thread_ts=1779642175.071749 text="... FINAL-B=oc-proof-8e6bc0a0-B"

Ordinary DM thread follow-up in B:
- user=U...9Z bot_id=B...N2 ts=1779642234.122779 thread_ts=1779642175.071749 text="[oc-proof-8e6bc0a0] ordinary DM thread follow-up D in B thread... FINAL-D=oc-proof-8e6bc0a0-D"
- user=U...CQ bot_id=B...57 ts=1779642247.227079 thread_ts=1779642175.071749 text="... FINAL-D=oc-proof-8e6bc0a0-D"

Local compatibility proof after Slack-only scoping:
- Slack direct dispatch turn with MessageThreadId 501.000 vs active routeThreadId 500.000: reached reply resolution and sent a final reply.
- Non-Slack Telegram direct dispatch turn with MessageThreadId 501.000 vs active routeThreadId 500.000: stayed blocked behind the active reply operation and did not call reply resolution.
- Slack direct run-prep turn with MessageThreadId 501.000 vs active routeThreadId 500.000: shouldSteer=false, shouldFollowup=true.
- Slack direct run-prep turn with TransportThreadId 501.000 vs active routeThreadId 500.000: shouldSteer=false, shouldFollowup=true.
- Telegram direct run-prep turn with MessageThreadId 43 vs active routeThreadId 42: shouldSteer=true, shouldFollowup=true.
```

- Observed result after fix: The two overlapping top-level Slack DMs did not collapse into one Slack reply thread and B was not skipped as `reply-operation-active`. A received an OpenClaw reply in A's Slack thread, B received an OpenClaw reply in B's Slack thread, and the later B-thread follow-up continued in B's thread. The final active-run routing and dispatch-admission guards apply only when `ChatType=direct`, routed thread metadata exists, and `Provider`, `Surface`, or `OriginatingChannel` resolves to `slack`.
- What was not tested: The automated sender available in this environment posts Slack app-authored messages, so the temporary proof config enabled `allowBots=true`. This live proof still exercises the real Slack Socket Mode transport, real Slack thread ids, and the PR checkout's active-run routing and dispatch-admission boundaries; it does not prove Slack's human-user token UX separately. The local Crabbox/Testbox `pnpm check:changed` gate was attempted but could not start because the local `crabbox` binary is missing or unusable.
- Before evidence (optional but encouraged): Before the fix, the same local runtime scenario failed with `AssertionError: expected true to be false` at `src/auto-reply/reply/get-reply-run.media-only.test.ts`, showing the same-session/different-thread second turn would steer into the active run. Before the latest dispatch-admission fix, live current-head proof failed with B missing a reply and gateway logged `dispatch-from-config: skipped reply operation admission ... reason=active-run`; the new dispatch regression failed with `Slack routed thread was blocked by the active reply operation`. Before the Slack-only scoping update, the non-Slack compatibility test failed with `expected false to be true`, showing the generic guard would have changed non-Slack same-session steering.

## Root Cause

- Root cause: Slack DMs intentionally share the stable direct-message session key, but active-run decisions originally compared only session identity. A second top-level DM from the same user could therefore steer into, or later be blocked by dispatch admission for, the active run for the first Slack message thread. A later generic route-thread guard fixed Slack but also changed other IM providers that may use same-session/different-thread steering, so both guards are now constrained to Slack direct-message routed-thread turns.
- Missing detection / guardrail: Existing Slack prepare tests covered the stable DM session contract, but auto-reply routing tests did not cover same-session, different-thread active runs, Slack `TransportThreadId` DM thread replies, dispatch admission blocking, non-Slack compatibility, or every operation creation path.
- Contributing context: The fix belongs at the active-run routing and dispatch-admission boundaries, not in Slack session-key generation, because Slack DM session continuity is a shipped contract.

## Regression Test Plan

- Coverage level that should have caught this: Unit test plus Slack prepare-path contract test.
- Target test or file: `src/auto-reply/reply/get-reply-run.media-only.test.ts`, `src/auto-reply/reply/dispatch-from-config.test.ts`, `src/auto-reply/reply/followup-runner.test.ts`, and `extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts`.
- Scenario the test should lock in: Same stable Slack DM session, different routed Slack thread id, active prior run, second Slack turn must not steer into or be dispatch-blocked by the first run; Slack DM thread replies using `TransportThreadId` get the same guard; non-Slack same-session direct-message turns remain steerable/admission-blocked as before; every created active reply operation should carry the routed thread id when one exists.
- Why this is the smallest reliable guardrail: It exercises the auto-reply and dispatch decisions that caused the overlap while separately preserving the Slack session-key contract, non-Slack compatibility, and the dispatch/follow-up operation creation paths ClawSweeper flagged.

## CI Retry Head Note

- Current PR head `01d5d36d391a273e760f183aa8ee41dff3a455e8` is an empty CI retry commit on top of the proofed implementation commit `d0d5a354e77e5650f0ff3126eea42cae04a008e3`.
- It changes no files: `git diff --stat d0d5a354e77e5650f0ff3126eea42cae04a008e3 01d5d36d391a273e760f183aa8ee41dff3a455e8` is empty.
- The tree hash is identical for both heads: `9ed2ef2eaf662139510339e7a886be62c2d46ddf`. The Slack live proof above therefore applies to the current code tree; this commit exists only to trigger GitHub CI after the unrelated `checks-node-agentic-agents` timeout could not be rerun without maintainer/admin permissions.