### PR TITLE
fix(irc): store inbound channel routes as channel:#name and join before send

### DIFF
--- a/extensions/irc/src/inbound.behavior.test.ts
+++ b/extensions/irc/src/inbound.behavior.test.ts
@@ -202,6 +202,7 @@ describe("irc inbound behavior", () => {
 
   it("uses channel:# prefix for group channel From and OriginatingTo fields", async () => {
     const coreRuntime = createPluginRuntimeMock();
+    const runtime = createRuntimeEnv();
     setIrcRuntime(coreRuntime as never);
 
     await handleIrcInbound({
@@ -217,22 +218,28 @@ describe("irc inbound behavior", () => {
         config: {
           dmPolicy: "open",
           allowFrom: ["*"],
-          groupPolicy: "allowlist",
+          groupPolicy: "open",
           groupAllowFrom: [],
           groups: {
-            "#ops": { enabled: true },
+            "#ops": { enabled: true, requireMention: false },
           },
         },
       }),
-      config: { channels: { rc: {} } } as CoreConfig,
-      runtime: createRuntimeEnv(),
+      config: { channels: { irc: {} } } as CoreConfig,
+      runtime,
       sendReply: vi.fn(async () => {}),
     });
 
-    const assembledRequest = (
-      coreRuntime.channel.turn.runAssembled as unknown as { mock: { calls: unknown[][] } }
-    ).mock.calls[0]?.[0] as { ctxPayload?: Record<string, unknown> } | undefined;
-    const ctx = assembledRequest?.ctxPayload as Record<string, unknown> | undefined;
+    const ctx = (
+      coreRuntime.channel.reply.finalizeInboundContext as unknown as {
+        mock: { calls: unknown[][] };
+      }
+    ).mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+    expect(
+      (coreRuntime.channel.turn.runAssembled as unknown as { mock: { calls: unknown[][] } }).mock
+        .calls.length,
+    ).toBe(1);
+    expect(runtime.log).not.toHaveBeenCalled();
     expect(ctx?.From).toBe("channel:#ops");
     expect(ctx?.OriginatingTo).toBe("channel:#ops");
   });

--- a/extensions/irc/src/inbound.behavior.test.ts
+++ b/extensions/irc/src/inbound.behavior.test.ts
@@ -199,4 +199,41 @@ describe("irc inbound behavior", () => {
     ).mock.calls[0]?.[0] as { replyPipeline?: unknown } | undefined;
     expect(assembledRequest?.replyPipeline).toEqual({});
   });
+
+  it("uses channel:# prefix for group channel From and OriginatingTo fields", async () => {
+    const coreRuntime = createPluginRuntimeMock();
+    setIrcRuntime(coreRuntime as never);
+
+    await handleIrcInbound({
+      message: createMessage({
+        target: "#ops",
+        isGroup: true,
+        senderNick: "alice",
+        senderUser: "ident",
+        senderHost: "example.com",
+        text: "hello",
+      }),
+      account: createAccount({
+        config: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          groupPolicy: "allowlist",
+          groupAllowFrom: [],
+          groups: {
+            "#ops": { enabled: true },
+          },
+        },
+      }),
+      config: { channels: { rc: {} } } as CoreConfig,
+      runtime: createRuntimeEnv(),
+      sendReply: vi.fn(async () => {}),
+    });
+
+    const assembledRequest = (
+      coreRuntime.channel.turn.runAssembled as unknown as { mock: { calls: unknown[][] } }
+    ).mock.calls[0]?.[0] as { ctxPayload?: Record<string, unknown> } | undefined;
+    const ctx = assembledRequest?.ctxPayload as Record<string, unknown> | undefined;
+    expect(ctx?.From).toBe("channel:#ops");
+    expect(ctx?.OriginatingTo).toBe("channel:#ops");
+  });
 });

--- a/extensions/irc/src/inbound.ts
+++ b/extensions/irc/src/inbound.ts
@@ -345,7 +345,11 @@ export async function handleIrcInbound(params: {
     return;
   }
 
-  const peerId = message.isGroup ? message.target : message.senderNick;
+  const channelTarget =
+    message.target.startsWith("#") || message.target.startsWith("&")
+      ? message.target
+      : `#${message.target}`;
+  const peerId = message.isGroup ? channelTarget : message.senderNick;
   const { route, buildEnvelope } = resolveInboundRouteEnvelopeBuilderWithRuntime({
     cfg: config as OpenClawConfig,
     channel: CHANNEL_ID,
@@ -372,7 +376,7 @@ export async function handleIrcInbound(params: {
     Body: body,
     RawBody: rawBody,
     CommandBody: rawBody,
-    From: message.isGroup ? `channel:#${message.target}` : `irc:${senderDisplay}`,
+    From: message.isGroup ? `channel:${channelTarget}` : `irc:${senderDisplay}`,
     To: `irc:${peerId}`,
     SessionKey: route.sessionKey,
     AccountId: route.accountId,
@@ -388,7 +392,7 @@ export async function handleIrcInbound(params: {
     MessageSid: message.messageId,
     Timestamp: message.timestamp,
     OriginatingChannel: CHANNEL_ID,
-    OriginatingTo: message.isGroup ? `channel:#${peerId}` : `irc:${peerId}`,
+    OriginatingTo: message.isGroup ? `channel:${channelTarget}` : `irc:${peerId}`,
     CommandAuthorized: commandAuthorized,
   });
 

--- a/extensions/irc/src/inbound.ts
+++ b/extensions/irc/src/inbound.ts
@@ -372,7 +372,7 @@ export async function handleIrcInbound(params: {
     Body: body,
     RawBody: rawBody,
     CommandBody: rawBody,
-    From: message.isGroup ? `irc:channel:${message.target}` : `irc:${senderDisplay}`,
+    From: message.isGroup ? `channel:#${message.target}` : `irc:${senderDisplay}`,
     To: `irc:${peerId}`,
     SessionKey: route.sessionKey,
     AccountId: route.accountId,
@@ -388,7 +388,7 @@ export async function handleIrcInbound(params: {
     MessageSid: message.messageId,
     Timestamp: message.timestamp,
     OriginatingChannel: CHANNEL_ID,
-    OriginatingTo: `irc:${peerId}`,
+    OriginatingTo: message.isGroup ? `channel:#${peerId}` : `irc:${peerId}`,
     CommandAuthorized: commandAuthorized,
   });
 

--- a/extensions/irc/src/send.test.ts
+++ b/extensions/irc/src/send.test.ts
@@ -268,9 +268,13 @@ describe("sendMessageIrc cfg threading", () => {
     } as unknown as CoreConfig;
     const client = {
       isReady: vi.fn(() => true),
+      join: vi.fn(),
       sendPrivmsg: vi.fn(),
       quit: vi.fn(),
-    } as unknown as IrcClient & { quit: ReturnType<typeof vi.fn> };
+    } as unknown as IrcClient & {
+      join: ReturnType<typeof vi.fn>;
+      quit: ReturnType<typeof vi.fn>;
+    };
     hoisted.connectIrcClient.mockResolvedValue(client);
 
     const proofResults = await verifyChannelMessageAdapterCapabilityProofs({
@@ -284,6 +288,7 @@ describe("sendMessageIrc cfg threading", () => {
             text: "hello",
           });
           expect(result?.receipt.platformMessageIds).toEqual(["irc-msg-1"]);
+          expect(client.join).toHaveBeenCalledWith("#room");
           expect(client.sendPrivmsg).toHaveBeenCalledWith("#room", "hello");
         },
         media: async () => {
@@ -294,6 +299,7 @@ describe("sendMessageIrc cfg threading", () => {
             mediaUrl: "https://example.com/image.png",
           });
           expect(result?.receipt.platformMessageIds).toEqual(["irc-msg-1"]);
+          expect(client.join).toHaveBeenCalledWith("#room");
           expect(client.sendPrivmsg).toHaveBeenCalledWith(
             "#room",
             "image\n\nAttachment: https://example.com/image.png",
@@ -307,6 +313,7 @@ describe("sendMessageIrc cfg threading", () => {
             replyToId: "parent-1",
           });
           expect(result?.receipt.replyToId).toBe("parent-1");
+          expect(client.join).toHaveBeenCalledWith("#room");
           expect(client.sendPrivmsg).toHaveBeenCalledWith("#room", "threaded\n\n[reply:parent-1]");
         },
       },

--- a/extensions/irc/src/send.ts
+++ b/extensions/irc/src/send.ts
@@ -93,6 +93,9 @@ export async function sendMessageIrc(
         connectTimeoutMs: 12000,
       }),
     );
+    if (target.startsWith("#") || target.startsWith("&")) {
+      transient.join(target);
+    }
     transient.sendPrivmsg(target, payload);
     transient.quit("sent");
   }


### PR DESCRIPTION
## Summary

Fixes IRC group route identity so channel messages consistently use `channel:#name` instead of producing doubled prefixes like `channel:##ops`, and makes transient IRC channel sends JOIN before PRIVMSG.

## Verification

- `CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 fnm exec --using v24.15.0 -- node scripts/run-vitest.mjs run extensions/irc/src/inbound.behavior.test.ts extensions/irc/src/send.test.ts --reporter=dot --pool=forks --no-file-parallelism`
- autoreview clean on head `a7c0324b097edae819f8e6803776530fcb963a55`

## Real behavior proof

Behavior addressed: IRC group inbound context and outbound transient channel sends. Group inbound now records `From` and `OriginatingTo` as `channel:#ops`; transient sends JOIN `#room` before PRIVMSG.

Real environment tested: Local OpenClaw checkout on Node 24.15.0 using the bundled IRC plugin runtime path.

Exact steps or command run after this patch: `CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 fnm exec --using v24.15.0 -- node scripts/run-vitest.mjs run extensions/irc/src/inbound.behavior.test.ts extensions/irc/src/send.test.ts --reporter=dot --pool=forks --no-file-parallelism`

Evidence after fix: terminal output from the local OpenClaw run:

```text
RUN  v4.1.7 /Users/steipete/Projects/clawdbot3

.........

Test Files  2 passed (2)
Tests  9 passed (9)
```

Observed result after fix: The IRC inbound assertion observes `From === "channel:#ops"` and `OriginatingTo === "channel:#ops"`; the IRC send capability proof observes `join("#room")` before channel PRIVMSG paths complete.

What was not tested: A live external IRC network round trip; this is covered with focused plugin runtime tests and maintainer proof override because the changed behavior is local route/context normalization.
