### PR TITLE
fix: label meeting note transcript speakers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/restart: honor the configured restart drain budget for embedded runs and avoid spending the deferral timeout twice after forced restart timeouts. (#85708) Thanks @Kaspre.
+- Meeting Notes: include a speaker-labeled transcript section in generated summaries so Discord group voice captures show who said each captured utterance.
 - Discord/voice: recover stale realtime playback state when Discord stream-close/player-idle events do not arrive, and keep generated runtime plugin aliases available after postbuild rewrites.
 - Discord/voice: keep realtime playback running when meeting notes attaches to an existing voice session or a realtime consult starts, and route realtime user transcripts into meeting notes.
 - Config/secrets: preflight active runtime SecretRefs before root and include config writes persist, and roll back unchanged file/env state when post-write refresh fails. Fixes #46531. (#84454) Thanks @samzong.

--- a/docs/plugins/meeting-notes.md
+++ b/docs/plugins/meeting-notes.md
@@ -249,9 +249,10 @@ Each file has one job:
   and provider metadata.
 - `transcript.jsonl`: append-only speaker utterances. Each line is one JSON
   object with the utterance text and the session id.
-- `summary.json`: structured summary data used by tooling.
+- `summary.json`: structured summary data used by tooling, including the
+  speaker-labeled transcript window used for the generated summary.
 - `summary.md`: human-readable notes for terminals, editors, and document
-  workflows.
+  workflows, including a speaker-labeled transcript section.
 
 The date directory comes from the session start time, so multiple meetings per
 day stay grouped. If a human session id repeats across days, use the
@@ -299,7 +300,8 @@ multi-hour call does not require unbounded summary memory.
 
 This means the transcript can keep growing on disk, while summarization stays
 bounded. Increase `maxUtterances` when you need more of a multi-hour meeting in
-the generated summary. Decrease it when summaries are too slow or too large.
+the generated summary and speaker-labeled transcript section. Decrease it when
+summaries are too slow or too large.
 
 Current summaries are generated when a session stops, after an import, or when
 the `summarize` action runs. They are not continuously rewritten for every

--- a/extensions/meeting-notes/index.test.ts
+++ b/extensions/meeting-notes/index.test.ts
@@ -96,7 +96,13 @@ describe("meeting-notes plugin", () => {
         path.join(stateDir, "meeting-notes", currentDateDir(), "design-review", "summary.md"),
         "utf8",
       ),
-    ).resolves.toContain("Action item: add Slack import later.");
+    ).resolves.toContain("Sam: Action item: add Slack import later.");
+    await expect(
+      fs.readFile(
+        path.join(stateDir, "meeting-notes", currentDateDir(), "design-review", "summary.json"),
+        "utf8",
+      ),
+    ).resolves.toContain('"Alex: We decided to ship Discord first."');
     await expect(
       fs.readFile(
         path.join(stateDir, "meeting-notes", currentDateDir(), "design-review", "transcript.jsonl"),
@@ -129,6 +135,8 @@ describe("meeting-notes plugin", () => {
     );
     expect(summary).toContain("Decision: ship the final plan.");
     expect(summary).not.toContain("Action item: write the first draft.");
+    expect(summary).toContain("## Transcript");
+    expect(summary).toContain("Sam: Decision: ship the final plan.");
     const transcript = await fs.readFile(
       path.join(stateDir, "meeting-notes", currentDateDir(), "long-meeting", "transcript.jsonl"),
       "utf8",

--- a/extensions/meeting-notes/src/summary.ts
+++ b/extensions/meeting-notes/src/summary.ts
@@ -8,6 +8,7 @@ export type MeetingNotesSummary = {
   title: string;
   generatedAt: string;
   overview: string;
+  transcript: string[];
   decisions: string[];
   actionItems: string[];
   risks: string[];
@@ -36,12 +37,22 @@ function firstSentences(utterances: MeetingNotesUtterance[], limit: number): str
 function collectMatches(utterances: MeetingNotesUtterance[], pattern: RegExp): string[] {
   return utterances
     .filter((utterance) => pattern.test(utterance.text))
-    .map((utterance) => {
-      const speaker = utterance.speaker?.label ? `${utterance.speaker.label}: ` : "";
-      return `${speaker}${utterance.text.trim()}`;
-    })
+    .map(formatSpeakerLine)
     .filter(Boolean)
     .slice(0, 12);
+}
+
+function formatSpeakerLine(utterance: MeetingNotesUtterance): string {
+  const text = utterance.text.trim();
+  if (!text) {
+    return "";
+  }
+  const speaker = utterance.speaker?.label?.trim();
+  return speaker ? `${speaker}: ${text}` : text;
+}
+
+function formatTranscript(utterances: MeetingNotesUtterance[]): string[] {
+  return utterances.map(formatSpeakerLine).filter(Boolean);
 }
 
 export function summarizeMeetingNotes(params: {
@@ -55,6 +66,7 @@ export function summarizeMeetingNotes(params: {
     title,
     generatedAt: new Date().toISOString(),
     overview,
+    transcript: formatTranscript(params.utterances),
     decisions: collectMatches(params.utterances, DECISION_PATTERNS),
     actionItems: collectMatches(params.utterances, ACTION_PATTERNS),
     risks: collectMatches(params.utterances, RISK_PATTERNS),
@@ -75,6 +87,9 @@ export function renderMeetingNotesMarkdown(summary: MeetingNotesSummary): string
     "",
     "## Overview",
     summary.overview,
+    "",
+    "## Transcript",
+    renderList(summary.transcript),
     "",
     "## Decisions",
     renderList(summary.decisions),


### PR DESCRIPTION
Summary
- Add a speaker-labeled Transcript section to generated Meeting Notes summaries.
- Persist the same bounded transcript window in summary.json for tooling.
- Update plugin docs and changelog, with regression coverage for speaker labels and maxUtterances behavior.

Verification
- pnpm test extensions/meeting-notes -- --reporter=verbose
- env -u OPENCLAW_TESTBOX pnpm check:changed
- pnpm docs:list
- git diff --check
- .agents/skills/autoreview/scripts/autoreview --mode local

Behavior addressed
Meeting Notes summaries now show the speaker beside each captured Discord/manual utterance instead of only presenting unlabeled overview text.

Real environment tested
Local OpenClaw source checkout on macOS, Node/pnpm repo wrappers, focused meeting-notes extension tests and changed checks.

Exact steps or command run after this patch
pnpm test extensions/meeting-notes -- --reporter=verbose
env -u OPENCLAW_TESTBOX pnpm check:changed
pnpm docs:list
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local

Evidence after fix
The meeting-notes import regression now asserts summary.md contains a speaker-prefixed action item and summary.json contains the speaker-prefixed transcript entry. The bounded-summary regression asserts the new Transcript section respects maxUtterances.

Observed result after fix
Focused tests passed: 15 tests across 2 meeting-notes test files. Changed checks passed for extensions, extensionTests, and docs. Autoreview reported no accepted/actionable findings.

What was not tested
No live Discord voice call was run for this patch; the Discord voice path already stores speaker.id and speaker.label on utterances, and this change consumes that existing MeetingNotesUtterance contract.
