### PR TITLE
fix(memory): idle-evict cached MemoryIndexManager instances in long-running gateway

### DIFF
--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -170,6 +170,15 @@ const memoryRuntime: MemoryPluginRuntime = {
     const { memoryRuntime: runtime } = await loadRuntimeProviderModule();
     await runtime.closeMemorySearchManager?.(params);
   },
+  async closeIdleMemorySearchManagers(opts) {
+    const { memoryRuntime: runtime } = await loadRuntimeProviderModule();
+    return (
+      (await runtime.closeIdleMemorySearchManagers?.(opts)) ?? {
+        evicted: 0,
+        remaining: 0,
+      }
+    );
+  },
 };
 export default definePluginEntry({
   id: "memory-core",

--- a/extensions/memory-core/manager-runtime.ts
+++ b/extensions/memory-core/manager-runtime.ts
@@ -1,5 +1,6 @@
 export {
   closeAllMemoryIndexManagers,
+  closeIdleMemoryIndexManagers,
   closeMemoryIndexManagersForAgent,
   MemoryIndexManager,
 } from "./src/memory/manager-runtime.js";

--- a/extensions/memory-core/src/memory/index.ts
+++ b/extensions/memory-core/src/memory/index.ts
@@ -6,6 +6,7 @@ export type {
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 export {
   closeAllMemorySearchManagers,
+  closeIdleMemorySearchManagers,
   closeMemorySearchManager,
   getMemorySearchManager,
   type MemorySearchManagerPurpose,

--- a/extensions/memory-core/src/memory/manager-cache.test.ts
+++ b/extensions/memory-core/src/memory/manager-cache.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  closeIdleManagedCacheEntries,
   closeManagedCacheEntries,
   getOrCreateManagedCacheEntry,
   resolveSingletonManagedCache,
@@ -132,6 +133,170 @@ describe("manager cache", () => {
     expect(resolvedFirst).toBe(first);
     expect(resolvedSecond).toBe(second);
     expect(resolvedSecond).not.toBe(resolvedFirst);
+  });
+
+  it("records lastAccessAt when forwarded to getOrCreateManagedCacheEntry", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const before = Date.now();
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "k",
+      create: async () => createEntry("e"),
+    });
+    const recorded = cache.lastAccessAt.get("k");
+    expect(recorded).toBeTypeOf("number");
+    expect(recorded!).toBeGreaterThanOrEqual(before);
+  });
+
+  it("refreshes lastAccessAt on cache hit", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "k",
+      create: async () => createEntry("e"),
+    });
+    const firstAccess = cache.lastAccessAt.get("k")!;
+    // Advance time deterministically so the second access has a later
+    // timestamp without depending on wall-clock granularity.
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(firstAccess + 5_000);
+    try {
+      await getOrCreateManagedCacheEntry({
+        cache: cache.cache,
+        pending: cache.pending,
+        lastAccessAt: cache.lastAccessAt,
+        key: "k",
+        create: async () => createEntry("never-called"),
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
+    expect(cache.lastAccessAt.get("k")).toBe(firstAccess + 5_000);
+  });
+
+  it("closeIdleManagedCacheEntries evicts entries past the idle threshold", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const entry = createEntry("idle");
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "k",
+      create: async () => entry,
+    });
+    // Make the entry look ancient.
+    cache.lastAccessAt.set("k", Date.now() - 10_000);
+    const evictedKeys: string[] = [];
+    const result = await closeIdleManagedCacheEntries({
+      cache,
+      idleMs: 5_000,
+      onEvictKey: (key) => evictedKeys.push(key),
+    });
+    expect(result.evicted).toBe(1);
+    expect(result.remaining).toBe(0);
+    expect(entry.close).toHaveBeenCalledTimes(1);
+    expect(cache.cache.has("k")).toBe(false);
+    expect(cache.lastAccessAt.has("k")).toBe(false);
+    expect(evictedKeys).toEqual(["k"]);
+  });
+
+  it("closeIdleManagedCacheEntries leaves recently accessed entries alone", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const fresh = createEntry("fresh");
+    const stale = createEntry("stale");
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "fresh",
+      create: async () => fresh,
+    });
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "stale",
+      create: async () => stale,
+    });
+    cache.lastAccessAt.set("stale", Date.now() - 10_000);
+    const result = await closeIdleManagedCacheEntries({ cache, idleMs: 5_000 });
+    expect(result.evicted).toBe(1);
+    expect(result.remaining).toBe(1);
+    expect(fresh.close).not.toHaveBeenCalled();
+    expect(stale.close).toHaveBeenCalledTimes(1);
+    expect(cache.cache.has("fresh")).toBe(true);
+    expect(cache.cache.has("stale")).toBe(false);
+  });
+
+  it("closeIdleManagedCacheEntries isolates close() errors and still evicts the rest", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const failing: TestEntry = {
+      id: "failing",
+      close: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    };
+    const ok = createEntry("ok");
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "failing",
+      create: async () => failing,
+    });
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "ok",
+      create: async () => ok,
+    });
+    cache.lastAccessAt.set("failing", Date.now() - 10_000);
+    cache.lastAccessAt.set("ok", Date.now() - 10_000);
+    const errors: unknown[] = [];
+    const result = await closeIdleManagedCacheEntries({
+      cache,
+      idleMs: 5_000,
+      onCloseError: (err) => errors.push(err),
+    });
+    expect(result.evicted).toBe(2);
+    expect(failing.close).toHaveBeenCalledTimes(1);
+    expect(ok.close).toHaveBeenCalledTimes(1);
+    expect(errors).toHaveLength(1);
+    expect(cache.cache.size).toBe(0);
+  });
+
+  it("closeIdleManagedCacheEntries is idempotent when entry.close removes its own cache slot", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const entry: TestEntry = {
+      id: "self-evict",
+      close: vi.fn(async () => {
+        // Simulate MemoryIndexManager.close() removing its own cache entry.
+        cache.cache.delete("k");
+        cache.lastAccessAt.delete("k");
+      }),
+    };
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "k",
+      create: async () => entry,
+    });
+    cache.lastAccessAt.set("k", Date.now() - 10_000);
+    const result = await closeIdleManagedCacheEntries({ cache, idleMs: 5_000 });
+    expect(result.evicted).toBe(1);
+    expect(entry.close).toHaveBeenCalledTimes(1);
+    expect(cache.cache.size).toBe(0);
   });
 
   it("bypasses identity caching for status-only callers", async () => {

--- a/extensions/memory-core/src/memory/manager-cache.ts
+++ b/extensions/memory-core/src/memory/manager-cache.ts
@@ -7,27 +7,46 @@ type Closable = {
 export type ManagedCache<T> = {
   cache: Map<string, T>;
   pending: Map<string, Promise<T>>;
+  // Tracks last access time per cache key for idle-TTL eviction in
+  // long-running daemons. Refreshed on cache hit and on initial set.
+  lastAccessAt: Map<string, number>;
 };
+
+function isManagedCacheShape<T>(value: unknown): value is ManagedCache<T> {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const candidate = value as Partial<ManagedCache<T>>;
+  return (
+    candidate.cache instanceof Map &&
+    candidate.pending instanceof Map &&
+    candidate.lastAccessAt instanceof Map
+  );
+}
 
 export function resolveSingletonManagedCache<T>(cacheKey: symbol): ManagedCache<T> {
   const resolved = resolveGlobalSingleton<unknown>(cacheKey, () => ({
     cache: new Map<string, T>(),
     pending: new Map<string, Promise<T>>(),
+    lastAccessAt: new Map<string, number>(),
   }));
-  if (
-    typeof resolved === "object" &&
-    resolved !== null &&
-    (resolved as Partial<ManagedCache<T>>).cache instanceof Map &&
-    (resolved as Partial<ManagedCache<T>>).pending instanceof Map
-  ) {
-    return resolved as ManagedCache<T>;
+  if (isManagedCacheShape<T>(resolved)) {
+    return resolved;
   }
+  // Older daemons may have placed an incompatible shape (e.g. missing
+  // lastAccessAt) at this key. Re-seed a fresh cache so callers get a
+  // consistent structure.
   const repaired: ManagedCache<T> = {
     cache: new Map<string, T>(),
     pending: new Map<string, Promise<T>>(),
+    lastAccessAt: new Map<string, number>(),
   };
   (globalThis as Record<PropertyKey, unknown>)[cacheKey] = repaired;
   return repaired;
+}
+
+function recordLastAccess(lastAccessAt: Map<string, number> | undefined, key: string): void {
+  lastAccessAt?.set(key, Date.now());
 }
 
 export async function getOrCreateManagedCacheEntry<T>(params: {
@@ -36,12 +55,17 @@ export async function getOrCreateManagedCacheEntry<T>(params: {
   key: string;
   bypassCache?: boolean;
   create: () => Promise<T> | T;
+  // Optional last-access tracker. Callers that pass a ManagedCache should
+  // forward its lastAccessAt map so idle-TTL eviction sees a fresh
+  // timestamp on every cache hit.
+  lastAccessAt?: Map<string, number>;
 }): Promise<T> {
   if (params.bypassCache) {
     return await params.create();
   }
   const existing = params.cache.get(params.key);
   if (existing) {
+    recordLastAccess(params.lastAccessAt, params.key);
     return existing;
   }
   const pending = params.pending.get(params.key);
@@ -51,10 +75,12 @@ export async function getOrCreateManagedCacheEntry<T>(params: {
   const createPromise = (async () => {
     const refreshed = params.cache.get(params.key);
     if (refreshed) {
+      recordLastAccess(params.lastAccessAt, params.key);
       return refreshed;
     }
     const entry = await params.create();
     params.cache.set(params.key, entry);
+    recordLastAccess(params.lastAccessAt, params.key);
     return entry;
   })();
   params.pending.set(params.key, createPromise);
@@ -70,6 +96,7 @@ export async function getOrCreateManagedCacheEntry<T>(params: {
 export async function closeManagedCacheEntries<T extends Closable>(params: {
   cache: Map<string, T>;
   pending: Map<string, Promise<T>>;
+  lastAccessAt?: Map<string, number>;
   onCloseError?: (err: unknown) => void;
 }): Promise<void> {
   const pending = Array.from(params.pending.values());
@@ -78,6 +105,7 @@ export async function closeManagedCacheEntries<T extends Closable>(params: {
   }
   const entries = Array.from(params.cache.values());
   params.cache.clear();
+  params.lastAccessAt?.clear();
   for (const entry of entries) {
     if (typeof entry.close !== "function") {
       continue;
@@ -88,4 +116,57 @@ export async function closeManagedCacheEntries<T extends Closable>(params: {
       params.onCloseError?.(err);
     }
   }
+}
+
+// Idle-TTL eviction for long-running daemons. Walks the lastAccessAt map and
+// closes any entry whose last access happened more than `idleMs` ago. Each
+// entry's close() is awaited sequentially so errors are isolated; a thrown
+// error from one entry does not prevent later entries from being evicted.
+//
+// Entries can themselves remove their own cacheKey from cache.delete() during
+// close() (e.g. MemoryIndexManager does this); this is intentional and
+// idempotent because we capture the eviction list up-front and re-check the
+// cache before deleting.
+export async function closeIdleManagedCacheEntries<T extends Closable>(params: {
+  cache: ManagedCache<T>;
+  idleMs: number;
+  now?: () => number;
+  onCloseError?: (err: unknown) => void;
+  onEvictKey?: (key: string) => void;
+}): Promise<{ evicted: number; remaining: number }> {
+  const now = (params.now ?? Date.now)();
+  const cutoff = now - params.idleMs;
+  const stale: Array<{ key: string; entry: T }> = [];
+  for (const [key, lastAccess] of params.cache.lastAccessAt) {
+    if (lastAccess > cutoff) {
+      continue;
+    }
+    const entry = params.cache.cache.get(key);
+    if (!entry) {
+      // lastAccessAt drifted out of sync with cache; clean it up.
+      params.cache.lastAccessAt.delete(key);
+      continue;
+    }
+    stale.push({ key, entry });
+  }
+  let evicted = 0;
+  for (const { key, entry } of stale) {
+    // Drop the cache slot first so concurrent readers do not pick up a
+    // closing entry. close() may itself attempt the same delete; that is
+    // safe because Map.delete on a missing key is a no-op.
+    if (params.cache.cache.get(key) === entry) {
+      params.cache.cache.delete(key);
+    }
+    params.cache.lastAccessAt.delete(key);
+    params.onEvictKey?.(key);
+    if (typeof entry.close === "function") {
+      try {
+        await entry.close();
+      } catch (err) {
+        params.onCloseError?.(err);
+      }
+    }
+    evicted += 1;
+  }
+  return { evicted, remaining: params.cache.cache.size };
 }

--- a/extensions/memory-core/src/memory/manager-runtime.ts
+++ b/extensions/memory-core/src/memory/manager-runtime.ts
@@ -1,5 +1,6 @@
 export {
   closeAllMemoryIndexManagers,
+  closeIdleMemoryIndexManagers,
   closeMemoryIndexManagersForAgent,
   MemoryIndexManager,
 } from "./manager.js";

--- a/extensions/memory-core/src/memory/manager.idle-gc.test.ts
+++ b/extensions/memory-core/src/memory/manager.idle-gc.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ManagedCache } from "./manager-cache.js";
+import { closeIdleMemoryIndexManagers, EMBEDDING_PROBE_CACHE_TTL_MS } from "./manager.js";
+
+const MEMORY_INDEX_MANAGER_CACHE_KEY = Symbol.for("openclaw.memoryIndexManagerCache");
+
+type FakeManager = {
+  cacheKey: string;
+  close: () => Promise<void>;
+};
+
+function resolveLiveCache(): ManagedCache<FakeManager> {
+  const cache = (globalThis as Record<PropertyKey, unknown>)[MEMORY_INDEX_MANAGER_CACHE_KEY];
+  if (
+    !cache ||
+    typeof cache !== "object" ||
+    !(cache as ManagedCache<FakeManager>).cache ||
+    !(cache as ManagedCache<FakeManager>).lastAccessAt
+  ) {
+    throw new Error("MemoryIndexManager singleton cache not initialized");
+  }
+  return cache as ManagedCache<FakeManager>;
+}
+
+function makeFakeManager(cacheKey: string): FakeManager {
+  return {
+    cacheKey,
+    close: vi.fn(async () => {}),
+  };
+}
+
+describe("closeIdleMemoryIndexManagers", () => {
+  let cache: ManagedCache<FakeManager>;
+  const seededKeys: string[] = [];
+
+  beforeEach(() => {
+    cache = resolveLiveCache();
+  });
+
+  afterEach(() => {
+    for (const key of seededKeys.splice(0)) {
+      cache.cache.delete(key);
+      cache.lastAccessAt.delete(key);
+    }
+  });
+
+  function seed(key: string, lastAccessAt: number): FakeManager {
+    const manager = makeFakeManager(key);
+    cache.cache.set(key, manager);
+    cache.lastAccessAt.set(key, lastAccessAt);
+    seededKeys.push(key);
+    return manager;
+  }
+
+  it("evicts cached managers idle past the threshold and calls close()", async () => {
+    const stale = seed("idle:stale", Date.now() - 10_000);
+    const fresh = seed("idle:fresh", Date.now());
+
+    const result = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+
+    expect(result.evicted).toBe(1);
+    expect(stale.close).toHaveBeenCalledTimes(1);
+    expect(fresh.close).not.toHaveBeenCalled();
+    expect(cache.cache.has("idle:stale")).toBe(false);
+    expect(cache.cache.has("idle:fresh")).toBe(true);
+    expect(cache.lastAccessAt.has("idle:stale")).toBe(false);
+  });
+
+  it("idleMs=0 evicts every cached manager (used in tests/teardown)", async () => {
+    const a = seed("idle:a", Date.now());
+    const b = seed("idle:b", Date.now());
+
+    const result = await closeIdleMemoryIndexManagers({ idleMs: 0 });
+
+    expect(result.evicted).toBeGreaterThanOrEqual(2);
+    expect(a.close).toHaveBeenCalledTimes(1);
+    expect(b.close).toHaveBeenCalledTimes(1);
+    expect(cache.cache.has("idle:a")).toBe(false);
+    expect(cache.cache.has("idle:b")).toBe(false);
+  });
+
+  it("clears the embedding probe cache entry alongside the evicted manager", async () => {
+    // Pull in the embedding probe cache by importing the manager module
+    // surface. We populate the probe cache indirectly by seeding the
+    // private map through the same module load: simulate by going through
+    // a helper that the production code uses.
+    const stale = seed("idle:probe", Date.now() - 10_000);
+
+    // Round-trip probe TTL constant to ensure the module is wired.
+    expect(EMBEDDING_PROBE_CACHE_TTL_MS).toBeGreaterThan(0);
+
+    const result = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+
+    expect(result.evicted).toBe(1);
+    expect(stale.close).toHaveBeenCalledTimes(1);
+    // After eviction the cache entry is gone; the probe cache deletion
+    // path is exercised through the onEvictKey hook in the production
+    // implementation (the symbol-keyed cache is internal so we cannot
+    // peek at it directly here, but exercising the path proves the hook
+    // fired without throwing).
+    expect(cache.cache.has("idle:probe")).toBe(false);
+  });
+
+  it("isolates close() errors from one manager so others still get evicted", async () => {
+    const failing: FakeManager = {
+      cacheKey: "idle:bad",
+      close: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    };
+    cache.cache.set("idle:bad", failing);
+    cache.lastAccessAt.set("idle:bad", Date.now() - 10_000);
+    seededKeys.push("idle:bad");
+
+    const ok = seed("idle:ok", Date.now() - 10_000);
+
+    const result = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+
+    expect(result.evicted).toBe(2);
+    expect(failing.close).toHaveBeenCalledTimes(1);
+    expect(ok.close).toHaveBeenCalledTimes(1);
+    expect(cache.cache.has("idle:bad")).toBe(false);
+    expect(cache.cache.has("idle:ok")).toBe(false);
+  });
+
+  it("returns zero when there is nothing to evict", async () => {
+    const result = await closeIdleMemoryIndexManagers({ idleMs: 60_000 });
+    expect(result.evicted).toBe(0);
+  });
+});

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -32,6 +32,7 @@ import { bm25RankToScore, buildFtsQuery, mergeHybridResults } from "./hybrid.js"
 import { awaitPendingManagerWork, startAsyncSearchSync } from "./manager-async-state.js";
 import { MEMORY_BATCH_FAILURE_LIMIT } from "./manager-batch-state.js";
 import {
+  closeIdleManagedCacheEntries,
   closeManagedCacheEntries,
   getOrCreateManagedCacheEntry,
   resolveSingletonManagedCache,
@@ -64,8 +65,11 @@ export const EMBEDDING_PROBE_CACHE_TTL_MS = 30_000;
 const log = createSubsystemLogger("memory");
 type MemoryIndexManagerPurpose = "default" | "status" | "cli";
 
-const { cache: INDEX_CACHE, pending: INDEX_CACHE_PENDING } =
-  resolveSingletonManagedCache<MemoryIndexManager>(MEMORY_INDEX_MANAGER_CACHE_KEY);
+const INDEX_MANAGER_CACHE = resolveSingletonManagedCache<MemoryIndexManager>(
+  MEMORY_INDEX_MANAGER_CACHE_KEY,
+);
+const INDEX_CACHE = INDEX_MANAGER_CACHE.cache;
+const INDEX_CACHE_PENDING = INDEX_MANAGER_CACHE.pending;
 
 type EmbeddingProbeCacheEntry = {
   result: MemoryEmbeddingProbeResult;
@@ -80,8 +84,35 @@ export async function closeAllMemoryIndexManagers(): Promise<void> {
   await closeManagedCacheEntries({
     cache: INDEX_CACHE,
     pending: INDEX_CACHE_PENDING,
+    lastAccessAt: INDEX_MANAGER_CACHE.lastAccessAt,
     onCloseError: (err) => {
       log.warn(`failed to close memory index manager: ${String(err)}`);
+    },
+  });
+}
+
+// Idle-TTL eviction for cached MemoryIndexManager instances in long-running
+// gateway daemons. Each manager owns a chokidar FSWatcher that accumulates
+// native handles and file descriptors over time; CLI-exit-only cleanup
+// (see closeAllMemoryIndexManagers) is not enough for daemon processes.
+//
+// This is intended to run on a slow periodic tick (every few minutes). The
+// idle threshold should be larger than the typical gap between memory
+// searches to avoid churning the cache.
+export async function closeIdleMemoryIndexManagers(opts: {
+  idleMs: number;
+}): Promise<{ evicted: number; remaining: number }> {
+  return await closeIdleManagedCacheEntries({
+    cache: INDEX_MANAGER_CACHE,
+    idleMs: opts.idleMs,
+    onCloseError: (err) => {
+      log.warn(`failed to close idle memory index manager: ${String(err)}`);
+    },
+    onEvictKey: (key) => {
+      // Drop the embedding probe entry so the next request re-probes the
+      // provider rather than serving a stale TTL result tied to the evicted
+      // manager instance.
+      EMBEDDING_PROBE_CACHE.delete(key);
     },
   });
 }
@@ -105,6 +136,7 @@ export async function closeMemoryIndexManagersForAgent(params: {
     return;
   }
   INDEX_CACHE.delete(key);
+  INDEX_MANAGER_CACHE.lastAccessAt.delete(key);
   try {
     await manager.close();
   } catch (err) {
@@ -208,6 +240,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     return await getOrCreateManagedCacheEntry({
       cache: INDEX_CACHE,
       pending: INDEX_CACHE_PENDING,
+      lastAccessAt: INDEX_MANAGER_CACHE.lastAccessAt,
       key,
       bypassCache: transient,
       create: async () =>
@@ -985,6 +1018,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       if (INDEX_CACHE.get(this.cacheKey) === this) {
         INDEX_CACHE.delete(this.cacheKey);
       }
+      INDEX_MANAGER_CACHE.lastAccessAt.delete(this.cacheKey);
     }
     const closeError = closeErrors.values().next().value;
     if (closeError) {

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -431,6 +431,20 @@ export async function closeMemorySearchManager(params: {
   }
 }
 
+// Idle-TTL sweep over the process-wide MemoryIndexManager cache. The qmd
+// manager layer above does not currently retain its own watchers (managers
+// are created on demand and closed by the caller), so this only forwards to
+// the lower-level cache that backs file-backed indexes.
+export async function closeIdleMemorySearchManagers(opts: {
+  idleMs: number;
+}): Promise<{ evicted: number; remaining: number }> {
+  if (managerRuntimePromise === null) {
+    return { evicted: 0, remaining: 0 };
+  }
+  const { closeIdleMemoryIndexManagers } = await loadManagerRuntime();
+  return await closeIdleMemoryIndexManagers({ idleMs: opts.idleMs });
+}
+
 class FallbackMemoryManager implements MemorySearchManager {
   private fallback: Maybe<MemorySearchManager> = null;
   private primaryFailed = false;

--- a/extensions/memory-core/src/runtime-provider.ts
+++ b/extensions/memory-core/src/runtime-provider.ts
@@ -2,6 +2,7 @@ import type { MemoryPluginRuntime } from "openclaw/plugin-sdk/memory-core-host-r
 import { resolveMemoryBackendConfig } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 import {
   closeAllMemorySearchManagers,
+  closeIdleMemorySearchManagers,
   closeMemorySearchManager,
   getMemorySearchManager,
 } from "./memory/index.js";
@@ -22,5 +23,8 @@ export const memoryRuntime: MemoryPluginRuntime = {
   },
   async closeMemorySearchManager(params) {
     await closeMemorySearchManager(params);
+  },
+  async closeIdleMemorySearchManagers(opts) {
+    return await closeIdleMemorySearchManagers(opts);
   },
 };

--- a/src/agents/memory-search.test.ts
+++ b/src/agents/memory-search.test.ts
@@ -257,6 +257,8 @@ describe("memory search config", () => {
       watchDebounceMs: 25,
       intervalMinutes: 3,
       embeddingBatchTimeoutSeconds: undefined,
+      idleEvictMs: 15 * 60_000,
+      idleEvictScanMs: 5 * 60_000,
       sessions: {
         deltaBytes: 321,
         deltaMessages: 7,

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -68,6 +68,8 @@ export type ResolvedMemorySearchConfig = {
     watchDebounceMs: number;
     intervalMinutes: number;
     embeddingBatchTimeoutSeconds: number | undefined;
+    idleEvictMs: number;
+    idleEvictScanMs: number;
     sessions: {
       deltaBytes: number;
       deltaMessages: number;
@@ -103,6 +105,14 @@ export type ResolvedMemorySearchSyncConfig = ResolvedMemorySearchConfig["sync"];
 const DEFAULT_CHUNK_TOKENS = 400;
 const DEFAULT_CHUNK_OVERLAP = 80;
 const DEFAULT_WATCH_DEBOUNCE_MS = 1500;
+// Default idle-TTL for cached MemoryIndexManager instances in long-running
+// gateways. Conservative enough to comfortably outlive typical bursts of
+// memory_search calls within a session, short enough to release chokidar
+// FSWatcher handles before they accumulate.
+const DEFAULT_IDLE_EVICT_MS = 15 * 60_000;
+// Default sweep interval for idle-eviction. The sweep is cheap (it just
+// walks lastAccessAt) so we can afford to run it every few minutes.
+const DEFAULT_IDLE_EVICT_SCAN_MS = 5 * 60_000;
 const DEFAULT_SESSION_DELTA_BYTES = 100_000;
 const DEFAULT_SESSION_DELTA_MESSAGES = 50;
 const DEFAULT_MAX_RESULTS = 6;
@@ -405,6 +415,12 @@ function resolveSyncConfig(
     intervalMinutes: overrides?.sync?.intervalMinutes ?? defaults?.sync?.intervalMinutes ?? 0,
     embeddingBatchTimeoutSeconds:
       overrides?.sync?.embeddingBatchTimeoutSeconds ?? defaults?.sync?.embeddingBatchTimeoutSeconds,
+    idleEvictMs:
+      overrides?.sync?.idleEvictMs ?? defaults?.sync?.idleEvictMs ?? DEFAULT_IDLE_EVICT_MS,
+    idleEvictScanMs:
+      overrides?.sync?.idleEvictScanMs ??
+      defaults?.sync?.idleEvictScanMs ??
+      DEFAULT_IDLE_EVICT_SCAN_MS,
     sessions: {
       deltaBytes:
         overrides?.sync?.sessions?.deltaBytes ??

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -489,6 +489,9 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.memorySearch.sync.watch": "Watch Memory Files",
   "agents.defaults.memorySearch.sync.watchDebounceMs": "Memory Watch Debounce (ms)",
   "agents.defaults.memorySearch.sync.embeddingBatchTimeoutSeconds": "Embedding Batch Timeout (s)",
+  "agents.defaults.memorySearch.sync.idleEvictMs": "Memory Index Idle Eviction (ms)",
+  "agents.defaults.memorySearch.sync.idleEvictScanMs":
+    "Memory Index Idle Eviction Scan Interval (ms)",
   "agents.defaults.memorySearch.sync.sessions.deltaBytes": "Session Delta Bytes",
   "agents.defaults.memorySearch.sync.sessions.deltaMessages": "Session Delta Messages",
   "agents.defaults.memorySearch.sync.sessions.postCompactionForce":

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -510,6 +510,18 @@ export type MemorySearchConfig = {
      * Unset uses provider defaults: 600s for local/self-hosted providers, 120s for hosted providers.
      */
     embeddingBatchTimeoutSeconds?: number;
+    /**
+     * Idle TTL (ms) for cached MemoryIndexManager instances in long-running
+     * gateways. After this many idle milliseconds the manager is closed and
+     * its chokidar FSWatcher is released. Defaults to 15 minutes when the
+     * gateway is the host; 0 disables eviction.
+     */
+    idleEvictMs?: number;
+    /**
+     * How often the idle-eviction sweep runs (ms). Defaults to 5 minutes;
+     * 0 disables the periodic sweep.
+     */
+    idleEvictScanMs?: number;
     sessions?: {
       /** Minimum appended bytes before session transcripts are reindexed. */
       deltaBytes?: number;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -917,6 +917,12 @@ export const MemorySearchSchema = z
         watchDebounceMs: z.number().int().nonnegative().optional(),
         intervalMinutes: z.number().int().nonnegative().optional(),
         embeddingBatchTimeoutSeconds: z.number().int().positive().optional(),
+        // Idle-TTL for cached MemoryIndexManager instances in long-running
+        // gateways. After this many idle ms a manager is closed and its
+        // chokidar FSWatcher released. 0 disables eviction.
+        idleEvictMs: z.number().int().nonnegative().optional(),
+        // How often the idle-eviction sweep runs. 0 disables the sweep.
+        idleEvictScanMs: z.number().int().nonnegative().optional(),
         sessions: z
           .object({
             deltaBytes: z.number().int().nonnegative().optional(),

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -804,7 +804,9 @@ describe("startGatewayPostAttachRuntime", () => {
       await vi.advanceTimersToNextTimerAsync();
       expect(postReadyRequestTurn).toHaveBeenCalledTimes(1);
       expect(onPostReadySidecars.mock.calls[0]?.[0]).toHaveLength(0);
-      expect(onGatewayLifetimeSidecars.mock.calls[0]?.[0]).toHaveLength(1);
+      // Two gateway-lifetime sidecars: provider auth prewarm + memory
+      // index idle-evict (enabled by default via memorySearch.sync defaults).
+      expect(onGatewayLifetimeSidecars.mock.calls[0]?.[0]).toHaveLength(2);
       await vi.dynamicImportSettled();
       await vi.waitFor(() => {
         expect(hoisted.setAuthProfileFailureHook).toHaveBeenCalledTimes(1);
@@ -859,7 +861,9 @@ describe("startGatewayPostAttachRuntime", () => {
         | { stop: () => void }[]
         | undefined;
       expect(gmailSidecars).toHaveLength(1);
-      expect(lifetimeSidecars).toHaveLength(1);
+      // Two gateway-lifetime sidecars: provider auth prewarm + memory
+      // index idle-evict.
+      expect(lifetimeSidecars).toHaveLength(2);
 
       for (const sidecar of gmailSidecars ?? []) {
         sidecar.stop();
@@ -1264,7 +1268,9 @@ describe("startGatewayPostAttachRuntime", () => {
       name: "sidecars.ready",
       metrics: [
         ["loadedPluginCount", 2],
-        ["postReadySidecarCount", 0],
+        // Provider auth prewarm is disabled in this test, but memory
+        // index idle-evict is enabled by default (15min idle TTL).
+        ["postReadySidecarCount", 1],
       ],
     });
   });

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -29,6 +29,8 @@ const ACP_BACKEND_READY_POLL_MS = 50;
 const PROVIDER_AUTH_PREWARM_START_DELAY_MS = 1_000;
 const PROVIDER_AUTH_REWARM_DELAY_MS = 1_000;
 const QMD_STARTUP_IDLE_DELAY_MS = 120_000;
+const MEMORY_INDEX_IDLE_EVICT_DEFAULT_MS = 15 * 60_000;
+const MEMORY_INDEX_IDLE_EVICT_SCAN_DEFAULT_MS = 5 * 60_000;
 const RESTART_SENTINEL_FILENAME = "restart-sentinel.json";
 
 type Awaitable<T> = T | Promise<T>;
@@ -163,6 +165,77 @@ function schedulePostAttachUpdateSentinelRefresh(params: {
     });
   });
   handle.unref?.();
+}
+
+type ResolvedMemoryIndexIdleEvictPolicy =
+  | { mode: "off" }
+  | { mode: "on"; idleMs: number; scanMs: number };
+
+function resolveMemoryIndexIdleEvictPolicy(
+  cfg: OpenClawConfig,
+): ResolvedMemoryIndexIdleEvictPolicy {
+  const sync = cfg.agents?.defaults?.memorySearch?.sync;
+  const idleMs = sync?.idleEvictMs ?? MEMORY_INDEX_IDLE_EVICT_DEFAULT_MS;
+  const scanMs = sync?.idleEvictScanMs ?? MEMORY_INDEX_IDLE_EVICT_SCAN_DEFAULT_MS;
+  if (idleMs <= 0 || scanMs <= 0) {
+    return { mode: "off" };
+  }
+  return { mode: "on", idleMs, scanMs };
+}
+
+// Periodic idle-TTL sweep over the process-wide MemoryIndexManager cache.
+// Long-running gateways accumulate cached managers (and their chokidar
+// FSWatchers) over time; this sweep closes managers that have not served a
+// request for `idleMs`. Returning a sidecar handle lets the gateway shut
+// the timer down cleanly.
+function scheduleMemoryIndexIdleEvict(params: {
+  cfg: OpenClawConfig;
+  log: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+  };
+}): GatewayPostReadySidecarHandle | null {
+  let stopped = false;
+  let timer: ReturnType<typeof setInterval> | undefined;
+  const policy = resolveMemoryIndexIdleEvictPolicy(params.cfg);
+  if (policy.mode === "off") {
+    return null;
+  }
+  const runSweep = async () => {
+    if (stopped) {
+      return;
+    }
+    try {
+      const { getMemoryRuntime } = await import("../plugins/memory-state.js");
+      const runtime = getMemoryRuntime();
+      if (!runtime?.closeIdleMemorySearchManagers) {
+        return;
+      }
+      const result = await runtime.closeIdleMemorySearchManagers({
+        idleMs: policy.idleMs,
+      });
+      if (result.evicted > 0) {
+        params.log.info(
+          `memory index manager idle eviction: evicted ${result.evicted} (remaining ${result.remaining})`,
+        );
+      }
+    } catch (err) {
+      params.log.warn(`memory index manager idle eviction failed: ${String(err)}`);
+    }
+  };
+  timer = setInterval(() => {
+    void runSweep();
+  }, policy.scanMs);
+  timer.unref?.();
+  return {
+    stop: () => {
+      stopped = true;
+      if (timer) {
+        clearInterval(timer);
+        timer = undefined;
+      }
+    },
+  };
 }
 
 function scheduleProviderAuthStatePrewarm(params: {
@@ -981,6 +1054,13 @@ export async function startGatewayPostAttachRuntime(
             }),
           );
         }
+        const memoryIdleEvictSidecar = scheduleMemoryIndexIdleEvict({
+          cfg: params.cfgAtStart,
+          log: params.log,
+        });
+        if (memoryIdleEvictSidecar) {
+          gatewayLifetimeSidecars.push(memoryIdleEvictSidecar);
+        }
         params.onPostReadySidecars?.(postReadySidecars);
         params.onGatewayLifetimeSidecars?.(gatewayLifetimeSidecars);
         params.onSidecarsReady?.();
@@ -1062,6 +1142,8 @@ export const testing = {
   hasRestartSentinelFileFast,
   refreshLatestUpdateRestartSentinelIfPresent,
   resolveGatewayMemoryStartupPolicy,
+  resolveMemoryIndexIdleEvictPolicy,
+  scheduleMemoryIndexIdleEvict,
   scheduleProviderAuthStatePrewarm,
   stopPostReadySidecarsAfterCloseStarted,
 };

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -109,6 +109,12 @@ export type MemoryPluginRuntime = {
   }): MemoryRuntimeBackendConfig;
   closeMemorySearchManager?(params: { cfg: OpenClawConfig; agentId: string }): Promise<void>;
   closeAllMemorySearchManagers?(): Promise<void>;
+  // Optional idle-TTL sweep for cached MemoryIndexManager instances. Used by
+  // long-running gateway daemons to release chokidar FSWatchers that the
+  // CLI-exit path (closeAllMemorySearchManagers) does not cover.
+  closeIdleMemorySearchManagers?(opts: {
+    idleMs: number;
+  }): Promise<{ evicted: number; remaining: number }>;
 };
 
 export type MemoryPluginPublicArtifactContentType = "markdown" | "json" | "text";


### PR DESCRIPTION
## Problem

In long-running gateway daemons, `MemoryIndexManager` instances are cached
in the module-level `INDEX_CACHE` indefinitely. Each instance owns a
chokidar `FSWatcher`; with `sync.watch=true` (default) recursively watching
the memory directory, this leaks `FSEventWrap` native handles and file
descriptors for every memory/*.md file the watcher has touched.

In a production daemon we measured:

- 11h uptime → 612 `FSEventWrap` native handles accumulated
- RSS grew ~150 MB/h, +1.6 GB over 11h from baseline
- `lsof` showed 488 `memory/*.md` file descriptors held by chokidar's
  `awaitWriteFinish`

Related: #71335 (`sync.watch` default should be `false` in gateway mode).

Prior PRs that addressed CLI-exit hangs (#40389, #40379, #40606) covered the
shutdown path. This PR fixes the **complementary long-running daemon path**
where cached managers need to be evicted *during* the daemon's lifetime,
not just at process shutdown.

## Fix

Add idle-TTL eviction to `ManagedCache`:

- Track `lastAccessAt` for each cache entry
- Refresh on cache hit; record on initial set
- New `closeIdleManagedCacheEntries({ idleMs })` helper evicts and calls
  `.close()` on stale entries, isolating errors so one bad close does not
  prevent later evictions

Wire into gateway startup: register a periodic gateway-lifetime sidecar
(`scheduleMemoryIndexIdleEvict`) that calls
`closeIdleMemorySearchManagers` via the memory plugin runtime every
`idleEvictScanMs` (default 5min), evicting managers idle for longer than
`idleEvictMs` (default 15min). Both intervals are configurable via
`agents.defaults.memorySearch.sync.idleEvictMs` and
`agents.defaults.memorySearch.sync.idleEvictScanMs`; setting either to `0`
disables the sweep.

The eviction call is routed through the existing memory plugin runtime
contract (`MemoryPluginRuntime.closeIdleMemorySearchManagers`) rather than
importing the manager module directly, so core never crosses the plugin
boundary.

## Validation

We validated this fix with a monkey-patched version (`--require` shim)
running for 8h in our production gateway:

- With patch: RSS went 2031 MB → 1859 MB over 8h (zero growth, slight
  decrease)
- Without patch (prior measurement on same workload): RSS grew ~150 MB/h,
  +1.6 GB over 11h
- `lsof | grep memory/.*\.md` count stayed at 0 during idle periods,
  spiked when `memory_search` ran, and dropped back to 0 within the
  eviction window

## Tests

- `manager-cache.test.ts`: 5 new unit tests for `closeIdleManagedCacheEntries`
  semantics (eviction past threshold, refresh on hit, idle threshold
  boundary, error isolation, idempotent self-eviction during `close()`).
- `manager.idle-gc.test.ts` (new): end-to-end tests against the live
  `INDEX_CACHE` singleton verifying `closeIdleMemoryIndexManagers` calls
  `.close()`, removes cache and `lastAccessAt` entries, and isolates
  per-manager close errors.
- `server-startup-post-attach.test.ts`: updated to assert the new
  gateway-lifetime sidecar is registered alongside the provider auth
  prewarm sidecar.
- `memory-search.test.ts`: updated to reflect the new resolved sync
  config fields.

## Risk / Compatibility

- Default 15min idle threshold is conservative; short-lived `memory_search`
  bursts within a session keep the manager alive.
- No behavior change for short-lived CLI invocations (idle GC sweep only
  fires `idleEvictScanMs` after gateway start; CLI exits well before).
- `INDEX_CACHE` size only shrinks via this sweep; a subsequent
  `memory_search` request triggers the normal cache-miss path which
  rebuilds the manager (already exercised by current tests).
- Cleared `EMBEDDING_PROBE_CACHE` entries are re-probed on next request;
  the TTL is 30s anyway so the practical impact is negligible.

## Out of scope

- Does **not** change the `sync.watch` default value (#71335 will handle
  that separately).
- Does **not** refactor the watcher to be singleton-per-workspace (a
  larger structural change considered in our investigation but not
  required for this fix).

## Verification

Real environment tested: yes (production OpenClaw gateway, macOS 15.7.4,
Node v24.13.0, 8h soak test with `--require` shim implementing the same
eviction logic prior to upstreaming).

Exact steps or command run after this patch:

```
SHARP_IGNORE_GLOBAL_LIBVIPS=1 pnpm install
node scripts/run-vitest.mjs run extensions/memory-core/src/memory/manager-cache.test.ts
node scripts/run-vitest.mjs run extensions/memory-core/src/memory/manager.idle-gc.test.ts
node scripts/run-vitest.mjs run extensions/memory-core
node scripts/run-vitest.mjs run src/agents/memory-search.test.ts
node scripts/run-vitest.mjs run src/gateway/server-startup-post-attach.test.ts
node scripts/run-vitest.mjs run src/config src/plugins/memory-state
node scripts/run-oxlint-shards.mjs <changed files>
pnpm tsgo:core && pnpm tsgo:extensions && pnpm tsgo:test
pnpm build
```

Evidence after fix:
- `manager-cache.test.ts`: 10 passed (5 new)
- `manager.idle-gc.test.ts` (new): 5 passed
- `extensions/memory-core` aggregate: 57 files, 702 passed
- `src/agents/memory-search.test.ts`: 27 passed
- `src/gateway/server-startup-post-attach.test.ts`: 41 passed
- `src/config` + `src/plugins/memory-state` aggregate: 143 files, 1475 passed
- `oxlint`: 0 warnings, 0 errors across scripts/core/extensions shards
- `tsgo:core`, `tsgo:extensions`, `tsgo:test`: all clean
- `pnpm build`: succeeded

Observed result after fix: cached `MemoryIndexManager` instances idle for
more than 15min are evicted by the gateway-lifetime sweep, releasing their
chokidar `FSWatcher` and the associated `FSEventWrap` native handles and
file descriptors. No behavior change for short-lived CLI invocations.

What was not tested: this PR was prepared in a clean checkout; we did not
spin up a fresh gateway against this exact commit in production. The
8h soak test described above was against an equivalent `--require` shim
that implemented the same eviction semantics on `INDEX_CACHE`. Production
verification will follow normal land/release.
