### PR TITLE
fix(gateway): require admin scope for browser proxy invoke

### DIFF
--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -257,6 +257,10 @@ two-party event loops that do not go through the shared inbound reply runner.
 
     Plugins that expose dangerous node-host commands should register a node-invoke policy with `api.registerNodeInvokePolicy(...)`. The policy runs in the Gateway after command allowlist checks and before the command is forwarded to the node, so direct `node.invoke` calls and higher-level plugin tools share the same enforcement path.
 
+    <Warning>
+    The optional `scopes` field requests Gateway operator scopes for the invocation. OpenClaw honors it only for bundled plugins and trusted official plugin installations; requests from other plugins do not elevate the call. Use it only when a trusted plugin must invoke a node command with a stricter Gateway scope, such as `operator.admin`.
+    </Warning>
+
   </Accordion>
   <Accordion title="api.runtime.tasks.managedFlows">
     Bind a Task Flow runtime to an existing OpenClaw session key or trusted tool context, then create and manage Task Flows without passing an owner on every call.

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -443,6 +443,7 @@ function nodeInvokeCall(callIndex: number): {
       body?: Record<string, unknown>;
     };
   };
+  extra?: { scopes?: string[] };
 } {
   const toolName = mockCallArg<string>(gatewayMocks.callGatewayTool, callIndex, 0);
   const options = mockCallArg<{ timeoutMs?: number }>(gatewayMocks.callGatewayTool, callIndex, 1);
@@ -458,8 +459,13 @@ function nodeInvokeCall(callIndex: number): {
       body?: Record<string, unknown>;
     };
   }>(gatewayMocks.callGatewayTool, callIndex, 2);
+  const extra = mockCallArg<{ scopes?: string[] } | undefined>(
+    gatewayMocks.callGatewayTool,
+    callIndex,
+    3,
+  );
   expect(toolName).toBe("node.invoke");
-  return { options, request };
+  return { options, request, extra };
 }
 
 function lastNodeInvokeCall(): ReturnType<typeof nodeInvokeCall> {
@@ -855,8 +861,9 @@ describe("browser tool snapshot maxChars", () => {
     const tool = createBrowserTool();
     await tool.execute?.("call-1", { action: "status", target: "node" });
 
-    const { options, request } = lastNodeInvokeCall();
+    const { options, request, extra } = lastNodeInvokeCall();
     expect(options.timeoutMs).toBe(25_000);
+    expect(extra?.scopes).toEqual(["operator.admin"]);
     expect(request.nodeId).toBe("node-1");
     expect(request.command).toBe("browser.proxy");
     expect(request.params?.timeoutMs).toBe(20_000);

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -753,6 +753,7 @@ describe("browser tool snapshot maxChars", () => {
           timeoutMs: 7777,
         }),
       }),
+      { scopes: ["operator.admin"] },
     );
   });
 

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -358,6 +358,7 @@ async function callBrowserProxy(params: {
       },
       idempotencyKey: crypto.randomUUID(),
     },
+    { scopes: ["operator.admin"] },
   );
   const parsed = unwrapBrowserProxyPayload(payload);
   if (!parsed || typeof parsed !== "object" || !("result" in parsed)) {

--- a/extensions/google-meet/src/transports/chrome-browser-proxy.test.ts
+++ b/extensions/google-meet/src/transports/chrome-browser-proxy.test.ts
@@ -36,6 +36,7 @@ describe("Google Meet Chrome browser proxy", () => {
         timeoutMs: 100,
       },
       timeoutMs: 5_100,
+      scopes: ["operator.admin"],
     });
   });
 

--- a/extensions/google-meet/src/transports/chrome-browser-proxy.ts
+++ b/extensions/google-meet/src/transports/chrome-browser-proxy.ts
@@ -192,6 +192,7 @@ export async function callBrowserProxyOnNode(params: {
       timeoutMs: params.timeoutMs,
     },
     timeoutMs: addTimerTimeoutGraceMs(params.timeoutMs) ?? 1,
+    scopes: ["operator.admin"],
   });
   return parseBrowserProxyResult(raw);
 }

--- a/src/gateway/server-methods/nodes.invoke-wake.test.ts
+++ b/src/gateway/server-methods/nodes.invoke-wake.test.ts
@@ -326,6 +326,7 @@ async function invokeNode(params: {
       error?: { code?: string; message?: string } | null;
     }>;
   };
+  client?: unknown;
   requestParams?: Partial<Record<string, unknown>>;
 }) {
   const respond = vi.fn();
@@ -342,11 +343,30 @@ async function invokeNode(params: {
       logGateway,
       getRuntimeConfig: () => mocks.getRuntimeConfig(),
     } as never,
-    client: null,
+    client: (params.client ?? null) as never,
     req: { type: "req", id: "req-node-invoke", method: "node.invoke" },
     isWebchatConnect: () => false,
   });
   return respond;
+}
+
+function createOperatorClient(params?: { scopes?: string[]; pluginRuntimeOwnerId?: string }) {
+  return {
+    connect: {
+      role: "operator" as const,
+      scopes: params?.scopes ?? ["operator.write"],
+      client: {
+        id: "operator-test",
+        mode: "backend" as const,
+        name: "operator-test",
+        platform: "node",
+        version: "test",
+      },
+    },
+    internal: params?.pluginRuntimeOwnerId
+      ? { pluginRuntimeOwnerId: params.pluginRuntimeOwnerId }
+      : {},
+  };
 }
 
 function createNodeClient(nodeId: string, commands?: string[]) {
@@ -555,6 +575,72 @@ describe("node.invoke APNs wake path", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it("rejects browser.proxy for plugin runtime owners without admin scope", async () => {
+    const nodeRegistry = {
+      get: vi.fn(() => ({
+        nodeId: "browser-node",
+        commands: ["browser.proxy"],
+      })),
+      invoke: vi.fn().mockResolvedValue({
+        ok: true,
+        payloadJSON: '{"ok":true}',
+      }),
+    };
+
+    const respond = await invokeNode({
+      nodeRegistry,
+      client: createOperatorClient({
+        scopes: ["operator.write"],
+        pluginRuntimeOwnerId: "third-party",
+      }),
+      requestParams: {
+        nodeId: "browser-node",
+        command: "browser.proxy",
+        params: { method: "GET", path: "/profiles" },
+      },
+    });
+
+    const call = firstRespondCall(respond);
+    expect(call[0]).toBe(false);
+    expect(call[2]?.message).toContain("missing scope: operator.admin");
+    expect(nodeRegistry.invoke).not.toHaveBeenCalled();
+  });
+
+  it("allows browser.proxy for admin-scoped plugin runtime callers", async () => {
+    const nodeRegistry = {
+      get: vi.fn(() => ({
+        nodeId: "browser-node",
+        commands: ["browser.proxy"],
+      })),
+      invoke: vi.fn().mockResolvedValue({
+        ok: true,
+        payloadJSON: '{"ok":true}',
+      }),
+    };
+
+    const respond = await invokeNode({
+      nodeRegistry,
+      client: createOperatorClient({
+        scopes: ["operator.admin"],
+        pluginRuntimeOwnerId: "google-meet",
+      }),
+      requestParams: {
+        nodeId: "browser-node",
+        command: "browser.proxy",
+        params: { method: "GET", path: "/profiles" },
+      },
+    });
+
+    const call = firstRespondCall(respond);
+    expect(call[0]).toBe(true);
+    expect(nodeRegistry.invoke).toHaveBeenCalledTimes(1);
+    expectRecordFields(mockArg(nodeRegistry.invoke, 0, 0), "node invoke payload", {
+      nodeId: "browser-node",
+      command: "browser.proxy",
+      params: { method: "GET", path: "/profiles" },
+    });
   });
 
   it("keeps the existing not-connected response when wake path is unavailable", async () => {

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -111,6 +111,7 @@ const TALK_PTT_COMMANDS = new Set([
   "talk.ptt.cancel",
   "talk.ptt.once",
 ]);
+const BROWSER_PROXY_REQUIRED_SCOPE = "operator.admin";
 const talkPttEventSeqBySessionId = new Map<string, number>();
 
 type NodeWakeNudgeAttempt = {
@@ -207,6 +208,11 @@ function isForbiddenBrowserProxyMutation(params: unknown): boolean {
   const method = (normalizeOptionalString(candidate.method) ?? "").toUpperCase();
   const path = normalizeOptionalString(candidate.path) ?? "";
   return Boolean(method && path && isPersistentBrowserProxyMutation(method, path));
+}
+
+function clientHasOperatorAdminScope(client: GatewayClient | null): boolean {
+  const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
+  return scopes.includes(BROWSER_PROXY_REQUIRED_SCOPE);
 }
 
 function normalizePluginSurfaceRefreshParams(params: unknown): { surface: string } | undefined {
@@ -1322,7 +1328,14 @@ export const nodeHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-
+    if (command === "browser.proxy" && !clientHasOperatorAdminScope(client)) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, `missing scope: ${BROWSER_PROXY_REQUIRED_SCOPE}`),
+      );
+      return;
+    }
     await respondUnavailableOnThrow(respond, async () => {
       const cfg = context.getRuntimeConfig();
       let nodeSession = context.nodeRegistry.get(nodeId);

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -1,6 +1,7 @@
 // Gateway plugin tests cover plugin loading, auto-enable, runtime registry setup,
 // request-scope injection, diagnostics, and handler dispatch integration.
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { createPluginRecord } from "../plugins/loader-records.js";
 import type { PluginLookUpTable } from "../plugins/plugin-lookup-table.js";
 import type { PluginRegistry } from "../plugins/registry.js";
 import type { PluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
@@ -115,6 +116,30 @@ const createRegistry = (diagnostics: PluginDiagnostic[]): PluginRegistry => ({
   conversationBindingResolvedHandlers: [],
   diagnostics,
 });
+
+function addLoadedPlugin(
+  registry: PluginRegistry,
+  params: {
+    id: string;
+    origin?: PluginRegistry["plugins"][number]["origin"];
+    trustedOfficialInstall?: boolean;
+  },
+): PluginRegistry {
+  registry.plugins.push(
+    createPluginRecord({
+      id: params.id,
+      name: params.id,
+      source: `/tmp/${params.id}/index.js`,
+      origin: params.origin ?? "bundled",
+      enabled: true,
+      configSchema: false,
+      ...(params.trustedOfficialInstall !== undefined
+        ? { trustedOfficialInstall: params.trustedOfficialInstall }
+        : {}),
+    }),
+  );
+  return registry;
+}
 
 function createLookUpTableForTest(params: {
   manifestRegistry?: PluginLookUpTable["manifestRegistry"];
@@ -897,6 +922,67 @@ describe("loadGatewayPlugins", () => {
 
     expect(getLastDispatchedParams()).toStrictEqual({});
     expect(result.nodes).toEqual([{ nodeId: "connected", connected: true }]);
+  });
+
+  test("lets trusted official plugin runtime request admin scope for browser proxy", async () => {
+    loadOpenClawPlugins.mockReturnValue(addLoadedPlugin(createRegistry([]), { id: "google-meet" }));
+    loadGatewayStartupPluginsForTest();
+    serverPluginsModule.setFallbackGatewayContext(createTestContext("nodes-invoke-browser-proxy"));
+
+    const runtime = runtimeModule.createPluginRuntime({
+      allowGatewaySubagentBinding: true,
+    });
+    await gatewayRequestScopeModule.withPluginRuntimePluginScope(
+      { pluginId: "google-meet", pluginOrigin: "bundled" },
+      () =>
+        runtime.nodes.invoke({
+          nodeId: "node-1",
+          command: "browser.proxy",
+          params: { method: "GET", path: "/profiles" },
+          scopes: ["operator.admin"],
+        }),
+    );
+
+    expect(getLastDispatchedParams()).toMatchObject({
+      nodeId: "node-1",
+      command: "browser.proxy",
+      params: { method: "GET", path: "/profiles" },
+    });
+    expect(getLastDispatchedClientScopes()).toEqual(["operator.admin"]);
+    expect(getLastDispatchedClientInternal().pluginRuntimeOwnerId).toBe("google-meet");
+  });
+
+  test("does not let arbitrary plugin nodes runtime mint admin scope for browser proxy", async () => {
+    loadOpenClawPlugins.mockReturnValue(
+      addLoadedPlugin(createRegistry([]), { id: "third-party", origin: "global" }),
+    );
+    loadGatewayStartupPluginsForTest();
+    serverPluginsModule.setFallbackGatewayContext(
+      createTestContext("nodes-invoke-browser-proxy-no-elevate"),
+    );
+
+    const runtime = runtimeModule.createPluginRuntime({
+      allowGatewaySubagentBinding: true,
+    });
+    await gatewayRequestScopeModule.withPluginRuntimePluginScope(
+      { pluginId: "third-party", pluginOrigin: "global" },
+      () =>
+        runtime.nodes.invoke({
+          nodeId: "node-1",
+          command: "browser.proxy",
+          params: { method: "GET", path: "/profiles" },
+          scopes: ["operator.admin"],
+        }),
+    );
+
+    expect(getLastDispatchedParams()).toMatchObject({
+      nodeId: "node-1",
+      command: "browser.proxy",
+      params: { method: "GET", path: "/profiles" },
+    });
+    expect(getLastDispatchedClientScopes()).toEqual(["operator.write"]);
+    expect(getLastDispatchedClientScopes()).not.toContain("operator.admin");
+    expect(getLastDispatchedClientInternal().pluginRuntimeOwnerId).toBe("third-party");
   });
 
   test("forwards provider and model overrides when the request scope is authorized", async () => {

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -18,14 +18,15 @@ import { loadPluginLookUpTable, type PluginLookUpTable } from "../plugins/plugin
 import { getPluginModuleLoaderStats } from "../plugins/plugin-module-loader-cache.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import type { PluginRegistryParams } from "../plugins/registry-types.js";
-import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { getActivePluginRegistry, setActivePluginRegistry } from "../plugins/runtime.js";
 import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import { createPluginRuntimeLoaderLogger } from "../plugins/runtime/load-context.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
-import type { PluginLogger } from "../plugins/types.js";
+import type { PluginLogger, PluginOrigin } from "../plugins/types.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
 import { ADMIN_SCOPE, APPROVALS_SCOPE, WRITE_SCOPE } from "./method-scopes.js";
+import { isOperatorScope, type OperatorScope } from "./operator-scopes.js";
 import type {
   GatewayRequestContext,
   GatewayRequestHandler,
@@ -287,6 +288,52 @@ function hasAdminScope(client: GatewayRequestOptions["client"] | undefined): boo
 
 function canClientUseModelOverride(client: GatewayRequestOptions["client"]): boolean {
   return hasAdminScope(client) || client?.internal?.allowModelOverride === true;
+}
+
+function normalizeRuntimeNodeInvokeScopes(
+  scopes: string[] | undefined,
+): OperatorScope[] | undefined {
+  if (!Array.isArray(scopes)) {
+    return undefined;
+  }
+  const normalized: OperatorScope[] = [];
+  for (const scope of scopes) {
+    if (isOperatorScope(scope) && !normalized.includes(scope)) {
+      normalized.push(scope);
+    }
+  }
+  return normalized;
+}
+
+function canTrustedOfficialPluginRequestScopes(params: {
+  pluginId?: string;
+  pluginOrigin?: PluginOrigin;
+  pluginTrustedOfficialInstall?: boolean;
+}): boolean {
+  if (!params.pluginId) {
+    return false;
+  }
+  if (params.pluginOrigin === "bundled" || params.pluginTrustedOfficialInstall === true) {
+    return true;
+  }
+  const registry = getActivePluginRegistry();
+  const record = registry?.plugins.find((entry) => entry.id === params.pluginId);
+  return record?.origin === "bundled" || record?.trustedOfficialInstall === true;
+}
+
+function resolveRuntimeNodeInvokeSyntheticScopes(params: {
+  pluginId?: string;
+  pluginOrigin?: PluginOrigin;
+  pluginTrustedOfficialInstall?: boolean;
+  requestedScopes?: OperatorScope[];
+}): OperatorScope[] | undefined {
+  if (!params.requestedScopes) {
+    return undefined;
+  }
+  if (!canTrustedOfficialPluginRequestScopes(params)) {
+    return undefined;
+  }
+  return params.requestedScopes;
 }
 
 function mergeGatewayClientInternal(
@@ -685,13 +732,31 @@ export function createGatewayNodesRuntime(): PluginRuntime["nodes"] {
       };
     },
     async invoke(params) {
-      const payload = await dispatchGatewayMethod<unknown>("node.invoke", {
-        nodeId: params.nodeId,
-        command: params.command,
-        ...(params.params !== undefined && { params: params.params }),
-        timeoutMs: params.timeoutMs,
-        idempotencyKey: params.idempotencyKey || randomUUID(),
+      const scope = getPluginRuntimeGatewayRequestScope();
+      const pluginId =
+        typeof scope?.pluginId === "string" && scope.pluginId.trim()
+          ? scope.pluginId.trim()
+          : undefined;
+      const syntheticScopes = resolveRuntimeNodeInvokeSyntheticScopes({
+        pluginId,
+        pluginOrigin: scope?.pluginOrigin,
+        pluginTrustedOfficialInstall: scope?.pluginTrustedOfficialInstall,
+        requestedScopes: normalizeRuntimeNodeInvokeScopes(params.scopes),
       });
+      const payload = await dispatchGatewayMethod<unknown>(
+        "node.invoke",
+        {
+          nodeId: params.nodeId,
+          command: params.command,
+          ...(params.params !== undefined && { params: params.params }),
+          timeoutMs: params.timeoutMs,
+          idempotencyKey: params.idempotencyKey || randomUUID(),
+        },
+        {
+          ...(pluginId ? { pluginRuntimeOwnerId: pluginId } : {}),
+          ...(syntheticScopes ? { syntheticScopes } : {}),
+        },
+      );
       return payload;
     },
   };

--- a/src/gateway/server.node-invoke-approval-bypass.test.ts
+++ b/src/gateway/server.node-invoke-approval-bypass.test.ts
@@ -417,7 +417,9 @@ describe("node.invoke approval bypass", () => {
     });
     const ws = new WebSocket(`ws://127.0.0.1:${port}`);
     trackConnectChallengeNonce(ws);
-    await new Promise<void>((resolve) => ws.once("open", resolve));
+    await new Promise<void>((resolve) => {
+      ws.once("open", resolve);
+    });
     const res = await connectReq(ws, {
       skipDefaultAuth: true,
       deviceIdentityPath: issued.identityPath,

--- a/src/gateway/server.node-invoke-approval-bypass.test.ts
+++ b/src/gateway/server.node-invoke-approval-bypass.test.ts
@@ -13,6 +13,7 @@ import {
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { GatewayClient } from "./client.js";
 import { buildDeviceAuthPayload } from "./device-auth.js";
+import { issueOperatorToken } from "./device-authz.test-helpers.js";
 import {
   connectReq,
   installGatewayTestHooks,
@@ -261,7 +262,7 @@ describe("node.invoke approval bypass", () => {
       gateway: {
         nodes: {
           pairing: { autoApproveCidrs: ["127.0.0.1/32", "::1/128"] },
-          allowCommands: ["system.run", "system.run.prepare", "system.which"],
+          allowCommands: ["system.run", "system.run.prepare", "system.which", "browser.proxy"],
         },
       },
     });
@@ -405,6 +406,27 @@ describe("node.invoke approval bypass", () => {
         nonce,
       };
     });
+  };
+
+  const connectDeviceTokenOperator = async (scopes: string[]) => {
+    const issued = await issueOperatorToken({
+      name: `browser-proxy-scope-${crypto.randomUUID()}`,
+      approvedScopes: scopes,
+      clientId: GATEWAY_CLIENT_NAMES.TEST,
+      clientMode: GATEWAY_CLIENT_MODES.TEST,
+    });
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+    trackConnectChallengeNonce(ws);
+    await new Promise<void>((resolve) => ws.once("open", resolve));
+    const res = await connectReq(ws, {
+      skipDefaultAuth: true,
+      deviceIdentityPath: issued.identityPath,
+      deviceToken: issued.token,
+      scopes,
+      timeoutMs: CONNECT_REQ_TIMEOUT_MS,
+    });
+    expect(res.ok).toBe(true);
+    return ws;
   };
 
   const connectLinuxNode = async (
@@ -553,6 +575,72 @@ describe("node.invoke approval bypass", () => {
         "node.invoke cannot mutate persistent browser profiles via browser.proxy",
       );
       await expectNoForwardedInvoke(() => sawInvoke);
+    } finally {
+      ws.close();
+      node.stop();
+    }
+  });
+
+  test("requires admin scope for direct browser.proxy node.invoke", async () => {
+    let sawInvoke = false;
+    const nodeIdentity = createDeviceIdentity();
+    const node = await connectLinuxNode(
+      () => {
+        sawInvoke = true;
+      },
+      nodeIdentity,
+      ["browser.proxy"],
+    );
+    const ws = await connectDeviceTokenOperator(["operator.write"]);
+    try {
+      const browserRequest = await rpcReq(ws, "browser.request", {
+        method: "GET",
+        path: "/profiles",
+      });
+      expect(browserRequest.ok).toBe(false);
+      expect(browserRequest.error?.message ?? "").toContain("missing scope: operator.admin");
+
+      const directProxy = await rpcReq(ws, "node.invoke", {
+        nodeId: nodeIdentity.deviceId,
+        command: "browser.proxy",
+        params: {
+          method: "GET",
+          path: "/profiles",
+        },
+        idempotencyKey: crypto.randomUUID(),
+      });
+      expect(directProxy.ok).toBe(false);
+      expect(directProxy.error?.message ?? "").toContain("missing scope: operator.admin");
+      await expectNoForwardedInvoke(() => sawInvoke);
+    } finally {
+      ws.close();
+      node.stop();
+    }
+  });
+
+  test("allows direct browser.proxy node.invoke for admin-scoped operators", async () => {
+    let sawInvoke = false;
+    const nodeIdentity = createDeviceIdentity();
+    const node = await connectLinuxNode(
+      () => {
+        sawInvoke = true;
+      },
+      nodeIdentity,
+      ["browser.proxy"],
+    );
+    const ws = await connectDeviceTokenOperator(["operator.admin"]);
+    try {
+      const directProxy = await rpcReq(ws, "node.invoke", {
+        nodeId: nodeIdentity.deviceId,
+        command: "browser.proxy",
+        params: {
+          method: "GET",
+          path: "/profiles",
+        },
+        idempotencyKey: crypto.randomUUID(),
+      });
+      expect(directProxy.ok, JSON.stringify(directProxy.error)).toBe(true);
+      expect(sawInvoke).toBe(true);
     } finally {
       ws.close();
       node.stop();

--- a/src/plugins/cli-gateway-nodes-runtime.test.ts
+++ b/src/plugins/cli-gateway-nodes-runtime.test.ts
@@ -5,6 +5,7 @@ import {
   createPluginCliGatewayNodesRuntime,
   resolvePluginCliNodeInvokeGatewayTimeoutMs,
 } from "./cli-gateway-nodes-runtime.js";
+import { withPluginRuntimePluginScope } from "./runtime/gateway-request-scope.js";
 
 const callGatewayMock = vi.fn();
 
@@ -34,6 +35,43 @@ describe("createPluginCliGatewayNodesRuntime", () => {
         params: expect.objectContaining({
           timeoutMs: Number.MAX_SAFE_INTEGER,
         }),
+      }),
+    );
+  });
+
+  it("forwards requested node invoke scopes for bundled plugin CLI runtime", async () => {
+    const nodes = createPluginCliGatewayNodesRuntime();
+
+    await withPluginRuntimePluginScope({ pluginId: "google-meet", pluginOrigin: "bundled" }, () =>
+      nodes.invoke({
+        nodeId: "node-1",
+        command: "browser.proxy",
+        scopes: ["operator.admin"],
+      }),
+    );
+
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "node.invoke",
+        scopes: ["operator.admin"],
+      }),
+    );
+  });
+
+  it("drops requested node invoke scopes for third-party plugin CLI runtime", async () => {
+    const nodes = createPluginCliGatewayNodesRuntime();
+
+    await withPluginRuntimePluginScope({ pluginId: "third-party", pluginOrigin: "global" }, () =>
+      nodes.invoke({
+        nodeId: "node-1",
+        command: "browser.proxy",
+        scopes: ["operator.admin"],
+      }),
+    );
+
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        scopes: expect.anything(),
       }),
     );
   });

--- a/src/plugins/cli-gateway-nodes-runtime.ts
+++ b/src/plugins/cli-gateway-nodes-runtime.ts
@@ -6,6 +6,8 @@ import {
   GATEWAY_CLIENT_NAMES,
 } from "../../packages/gateway-protocol/src/client-info.js";
 import { callGateway } from "../gateway/call.js";
+import { isOperatorScope, type OperatorScope } from "../gateway/operator-scopes.js";
+import { getPluginRuntimeGatewayRequestScope } from "./runtime/gateway-request-scope.js";
 import type { PluginRuntime } from "./runtime/types.js";
 
 /** Adds Gateway timer grace for plugin CLI node invoke calls. */
@@ -15,6 +17,28 @@ export function resolvePluginCliNodeInvokeGatewayTimeoutMs(
   return typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0
     ? addTimerTimeoutGraceMs(timeoutMs)
     : undefined;
+}
+
+function normalizeRuntimeNodeInvokeScopes(
+  scopes: string[] | undefined,
+): OperatorScope[] | undefined {
+  if (!Array.isArray(scopes)) {
+    return undefined;
+  }
+  return scopes.filter(isOperatorScope);
+}
+
+function canPluginCliRuntimeRequestScopes(): boolean {
+  const scope = getPluginRuntimeGatewayRequestScope();
+  return Boolean(
+    scope?.pluginId &&
+    (scope.pluginOrigin === "bundled" || scope.pluginTrustedOfficialInstall === true),
+  );
+}
+
+function resolvePluginCliRuntimeNodeInvokeScopes(scopes: string[] | undefined) {
+  const normalizedScopes = normalizeRuntimeNodeInvokeScopes(scopes);
+  return normalizedScopes && canPluginCliRuntimeRequestScopes() ? normalizedScopes : undefined;
 }
 
 /** Creates the `runtime.nodes` implementation exposed to CLI plugin code. */
@@ -42,6 +66,7 @@ export function createPluginCliGatewayNodesRuntime(): PluginRuntime["nodes"] {
       };
     },
     async invoke(params) {
+      const scopes = resolvePluginCliRuntimeNodeInvokeScopes(params.scopes);
       return await callGateway({
         method: "node.invoke",
         params: {
@@ -54,6 +79,7 @@ export function createPluginCliGatewayNodesRuntime(): PluginRuntime["nodes"] {
         timeoutMs: resolvePluginCliNodeInvokeGatewayTimeoutMs(params.timeoutMs),
         clientName: GATEWAY_CLIENT_NAMES.CLI,
         mode: GATEWAY_CLIENT_MODES.CLI,
+        ...(scopes ? { scopes } : {}),
       });
     },
   };

--- a/src/plugins/registry.runtime-config.test.ts
+++ b/src/plugins/registry.runtime-config.test.ts
@@ -127,4 +127,46 @@ describe("plugin registry runtime config scope", () => {
       pluginSource: "/plugins/legacy-plugin/index.js",
     });
   });
+
+  it("runs node helpers with the owning plugin scope", async () => {
+    let listScope = getPluginRuntimeGatewayRequestScope();
+    let invokeScope = getPluginRuntimeGatewayRequestScope();
+    const runtime = createPluginRuntime();
+    runtime.nodes = {
+      list: vi.fn(async () => {
+        listScope = getPluginRuntimeGatewayRequestScope();
+        return { nodes: [] };
+      }),
+      invoke: vi.fn(async () => {
+        invokeScope = getPluginRuntimeGatewayRequestScope();
+        return { ok: true };
+      }),
+    };
+    const pluginRegistry = createTestRegistry(runtime);
+    const record = createPluginRecord({
+      id: "google-meet",
+      name: "Google Meet",
+      source: "/plugins/google-meet/index.js",
+      origin: "bundled",
+      enabled: true,
+      configSchema: false,
+    });
+    const api = pluginRegistry.createApi(record, { config: {} as OpenClawConfig });
+
+    await api.runtime.nodes.list({ connected: true });
+    await api.runtime.nodes.invoke({
+      nodeId: "node-1",
+      command: "browser.proxy",
+      scopes: ["operator.admin"],
+    });
+
+    expect(listScope).toMatchObject({
+      pluginId: "google-meet",
+      pluginSource: "/plugins/google-meet/index.js",
+    });
+    expect(invokeScope).toMatchObject({
+      pluginId: "google-meet",
+      pluginSource: "/plugins/google-meet/index.js",
+    });
+  });
 });

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -2661,7 +2661,15 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
             pluginRuntimeRecordById.get(pluginId) ??
             registry.plugins.find((entry) => entry.id === pluginId);
           return record?.source
-            ? withPluginRuntimePluginScope({ pluginId, pluginSource: record.source }, run)
+            ? withPluginRuntimePluginScope(
+                {
+                  pluginId,
+                  pluginSource: record.source,
+                  pluginOrigin: record.origin,
+                  pluginTrustedOfficialInstall: record.trustedOfficialInstall,
+                },
+                run,
+              )
             : withPluginRuntimePluginScope({ pluginId }, run);
         };
         const getRuntimeProperty = () => {
@@ -2724,6 +2732,13 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
             complete: (params) =>
               withPluginRuntimePluginIdScope(pluginId, () => llm.complete(params)),
           } satisfies PluginRuntime["llm"];
+        }
+        if (prop === "nodes") {
+          const nodes = getRuntimeProperty();
+          return {
+            list: (params) => runWithPluginScope(() => nodes.list(params)),
+            invoke: (params) => runWithPluginScope(() => nodes.invoke(params)),
+          } satisfies PluginRuntime["nodes"];
         }
         if (prop !== "subagent") {
           return getRuntimeProperty();

--- a/src/plugins/runtime/gateway-request-scope.ts
+++ b/src/plugins/runtime/gateway-request-scope.ts
@@ -5,6 +5,7 @@ import type {
   GatewayRequestOptions,
 } from "../../gateway/server-methods/types.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
+import type { PluginOrigin } from "../plugin-origin.types.js";
 
 export type PluginRuntimeGatewayRequestScope = {
   context?: GatewayRequestContext;
@@ -12,12 +13,16 @@ export type PluginRuntimeGatewayRequestScope = {
   isWebchatConnect: GatewayRequestOptions["isWebchatConnect"];
   pluginId?: string;
   pluginSource?: string;
+  pluginOrigin?: PluginOrigin;
+  pluginTrustedOfficialInstall?: boolean;
   gatewayMethodDispatchAllowed?: boolean;
 };
 
 export type PluginRuntimePluginScope = {
   pluginId: string;
   pluginSource?: string;
+  pluginOrigin?: PluginOrigin;
+  pluginTrustedOfficialInstall?: boolean;
 };
 
 const PLUGIN_RUNTIME_GATEWAY_REQUEST_SCOPE_KEY: unique symbol = Symbol.for(
@@ -56,6 +61,16 @@ export function withPluginRuntimePluginScope<T>(scope: PluginRuntimePluginScope,
     scoped.pluginSource = scope.pluginSource;
   } else {
     delete scoped.pluginSource;
+  }
+  if (scope.pluginOrigin !== undefined) {
+    scoped.pluginOrigin = scope.pluginOrigin;
+  } else {
+    delete scoped.pluginOrigin;
+  }
+  if (scope.pluginTrustedOfficialInstall !== undefined) {
+    scoped.pluginTrustedOfficialInstall = scope.pluginTrustedOfficialInstall;
+  } else {
+    delete scoped.pluginTrustedOfficialInstall;
   }
   return pluginRuntimeGatewayRequestScope.run(scoped, run);
 }

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -1,4 +1,5 @@
 // Plugin runtime types describe activated plugin capabilities exposed to core execution.
+import type { OperatorScope } from "../../gateway/operator-scopes.js";
 import type { PluginRuntimeCore, RuntimeLogger } from "./types-core.js";
 
 export type { RuntimeLogger };
@@ -74,7 +75,8 @@ export type RuntimeNodeInvokeParams = {
   params?: unknown;
   timeoutMs?: number;
   idempotencyKey?: string;
-  scopes?: string[];
+  /** Requested Gateway scopes. Honored only for bundled or trusted official plugins. */
+  scopes?: OperatorScope[];
 };
 
 /** Trusted in-process runtime surface injected into native plugins. */

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -74,6 +74,7 @@ export type RuntimeNodeInvokeParams = {
   params?: unknown;
   timeoutMs?: number;
   idempotencyKey?: string;
+  scopes?: string[];
 };
 
 /** Trusted in-process runtime surface injected into native plugins. */


### PR DESCRIPTION
## Summary

- Problem: `browser.request` is admin-scoped, but the equivalent node-host browser proxy command could also be reached through direct `node.invoke(browser.proxy)` from an `operator.write` caller.
- Solution: require `operator.admin` before forwarding direct `node.invoke` requests for `browser.proxy`, while keeping the bundled Google Meet browser proxy path working through an explicit official-plugin runtime scope request.
- What changed: direct write-scoped `node.invoke(browser.proxy)` is rejected before node dispatch; admin-scoped callers still dispatch; bundled/trusted official plugin runtime calls may request admin scope from their real plugin metadata; third-party plugin runtime callers cannot mint admin by passing `scopes` through either gateway or CLI runtime paths.
- What did NOT change (scope boundary): `browser.request` behavior is unchanged; node-host browser proxy implementation is unchanged; persistent browser profile mutation blocking remains unchanged.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: N/A
- Related: N/A
- [x] This PR fixes a bug or regression

## Motivation

The browser gateway surface already treats `browser.request` as admin-scoped. That route can reach a node-hosted browser through the same `browser.proxy` backend capability when a browser-capable node is connected.

Before this patch, a scoped operator token with only `operator.write` could not call `browser.request`, but could call the underlying `browser.proxy` command through direct `node.invoke`. That created an authorization mismatch between two routes to the same browser proxy capability.

This PR aligns the route semantics: the direct node invoke route for `browser.proxy` now requires the same admin scope as the browser gateway route. The Google Meet integration keeps its intended bundled-plugin path by requesting admin scope through the plugin runtime; both gateway and CLI runtime scope-forwarding paths honor that request only for bundled/trusted official plugin metadata, not for arbitrary third-party plugin runtime callers.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `browser.proxy` through direct `node.invoke` now follows the same admin boundary as `browser.request`; bundled Google Meet can still use the browser proxy through official plugin runtime metadata; third-party plugin runtime callers cannot mint admin scope by passing `scopes` through gateway or CLI runtime paths.
- Real environment tested: local macOS development checkout, branch `browser-proxy-admin-scope`, head `1ceea79bec`.
- Exact steps or command run after this patch:
  - `node --import tsx .artifacts/browser-proxy-current-head-proof.ts`
  - `node scripts/run-vitest.mjs run --config test/vitest/vitest.bundled.config.ts src/plugins/cli-gateway-nodes-runtime.test.ts src/plugins/registry.runtime-config.test.ts`
  - CI shard reproduction:
    `OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_VITEST_SHARD_NAME=agentic-control-plane-http-plugin-ws OPENCLAW_TEST_PROJECTS_PARALLEL=2 OPENCLAW_VITEST_INCLUDE_FILE=<generated include json> NODE_OPTIONS=--max-old-space-size=8192 npm exec --yes pnpm@11.1.0 -- node scripts/test-projects.mjs test/vitest/vitest.gateway-server.config.ts`
  - `npm exec --yes pnpm@11.1.0 -- node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
  - `npm exec --yes pnpm@11.1.0 -- node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
  - `npm exec --yes pnpm@11.1.0 -- oxfmt --check src/plugins/runtime/gateway-request-scope.ts src/plugins/registry.ts src/gateway/server-plugins.ts src/gateway/server-plugins.test.ts`
- Evidence after fix:

```text
[browser-proxy-proof] head=1ceea79bec06
[browser-proxy-proof] direct write-only ok=false error=missing scope: operator.admin nodeDispatch=0
[browser-proxy-proof] direct admin ok=true payloadJSON={"proof":"admin-direct","reachedNode":true,"path":"/tabs"} nodeDispatch=1
[browser-proxy-proof] google-meet runtime ok=true nodeDispatch=1 payloadJSON={"proof":"google-meet-runtime","reachedNode":true,"path":"/tabs"} message=n/a
[browser-proxy-proof] third-party runtime ok=false error=missing scope: operator.admin nodeDispatch=0
[browser-proxy-proof] completed
```

CI shard reproduction after the fix:

```text
Test Files  18 passed (18)
     Tests  176 passed (176)
  Start at  11:47:13
  Duration  5.36s (transform 3.54s, setup 326ms, import 2.34s, tests 7.66s, environment 1ms)

[test] passed 1 Vitest shard in 7.60s
```

CLI runtime scope-forwarding regression coverage after the fix:

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.bundled.config.ts src/plugins/cli-gateway-nodes-runtime.test.ts src/plugins/registry.runtime-config.test.ts
exit code: 0
```

- Observed result after fix:
  - A write-only operator caller cannot dispatch direct `node.invoke(browser.proxy)`.
  - An admin-scoped operator caller still dispatches `browser.proxy` to the node.
  - The bundled Google Meet runtime path can dispatch `browser.proxy` when it explicitly requests admin scope through official plugin metadata.
  - A third-party plugin runtime caller that requests `operator.admin` is still downgraded and rejected before node dispatch.
  - The CLI plugin runtime path now forwards requested scopes only for bundled/trusted official plugin metadata and drops requested scopes for third-party plugin metadata.
- What was not tested: a remote multi-device browser deployment or a live Google Meet call. The proof exercises the Gateway `node.invoke` auth gate, plugin runtime owner metadata propagation, and node dispatch boundary locally; targeted regression tests cover the CLI runtime scope-forwarding guardrail.
- Before evidence: the earlier regression test failed before the patch because write-scoped direct `node.invoke(browser.proxy)` reached node dispatch while `browser.request` was blocked by `operator.admin`.

## Root Cause

- Root cause: direct `node.invoke` enforced the generic `operator.write` scope for node commands, but did not apply the stricter `operator.admin` scope used by the equivalent `browser.request` gateway route.
- Missing detection / guardrail: there was no regression test comparing the authorization semantics of `browser.request` and direct `node.invoke` for the same `browser.proxy` backend command, and no test proving official plugin runtime scope requests cannot be forged by third-party plugin runtime callers through gateway or CLI runtime paths.
- Contributing context: existing code already blocked persistent browser profile mutations through direct `node.invoke`; the remaining non-persistent browser proxy paths still needed route-level admin scope alignment.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/gateway/server.node-invoke-approval-bypass.test.ts`
  - `src/gateway/server-methods/nodes.invoke-wake.test.ts`
  - `src/gateway/server-plugins.test.ts`
  - `src/plugins/cli-gateway-nodes-runtime.test.ts`
  - `src/plugins/registry.runtime-config.test.ts`
  - `extensions/google-meet/src/transports/chrome-browser-proxy.test.ts`
  - `extensions/browser/src/browser-tool.test.ts`
- Scenario the test locks in: write-scoped callers cannot bypass the admin-scoped `browser.request` route by directly invoking `browser.proxy`; admin-scoped callers still work; bundled/trusted official plugin runtime callers can request admin scope; third-party plugin runtime callers cannot mint admin scope through gateway or CLI runtime paths.
- Why this is the smallest reliable guardrail: the mismatch is in Gateway node invocation authorization and plugin runtime dispatch metadata, so focused Gateway/runtime tests cover the policy boundary directly.
- Existing test that already covers this: none before this PR.

## User-visible / Behavior Changes

Direct `node.invoke` callers now need `operator.admin` to invoke `browser.proxy`. Admin-scoped callers and `browser.request` behavior are unchanged. Bundled Google Meet browser proxy usage remains supported through the plugin runtime path.

## Diagram

```text
Before:
operator.write -> browser.request -> blocked: operator.admin required
operator.write -> node.invoke(browser.proxy) -> node dispatch

After:
operator.write -> browser.request -> blocked: operator.admin required
operator.write -> node.invoke(browser.proxy) -> blocked: operator.admin required
operator.admin -> node.invoke(browser.proxy) -> node dispatch
bundled official plugin runtime -> request operator.admin -> node dispatch
third-party plugin runtime -> request operator.admin -> blocked: operator.admin required
third-party plugin CLI runtime -> request operator.admin -> scopes dropped before callGateway
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes - this narrows direct browser proxy invocation to the same admin scope used by the browser gateway route.
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: this reduces the callable surface for scoped write-only operator tokens by preventing direct access to the node-hosted browser proxy route. The official plugin runtime compatibility path is metadata-bound to bundled/trusted official plugin records in both gateway and CLI runtime paths and does not let arbitrary plugin runtime callers mint admin scope.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local development checkout
- Model/provider: N/A
- Integration/channel: Browser extension, Google Meet extension, Gateway node invoke
- Relevant config: local Gateway/runtime proof with a connected node command handler for `browser.proxy`

### Steps

1. Exercise direct `node.invoke(browser.proxy)` as a write-only operator caller.
2. Exercise direct `node.invoke(browser.proxy)` as an admin operator caller.
3. Exercise bundled Google Meet plugin runtime `nodes.invoke` with `scopes: ["operator.admin"]`.
4. Exercise third-party plugin runtime `nodes.invoke` with the same requested admin scope.
5. Exercise CLI plugin runtime scope forwarding for bundled and third-party plugin scopes.
6. Re-run the CI gateway server shard that previously failed on plugin runtime scope propagation.

### Expected

- Write-only direct callers are rejected before node dispatch.
- Admin direct callers dispatch to the node.
- Bundled/trusted official plugin runtime callers can request admin scope for this path.
- Third-party plugin runtime callers cannot mint admin scope.
- CLI plugin runtime callers follow the same metadata gate before passing scopes into `callGateway`.

### Actual

- Matches expected in the local proof, targeted CLI runtime tests, and targeted CI shard reproduction.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers

## Human Verification

- Verified scenarios: write-only direct `browser.proxy` rejection before node dispatch; admin direct `browser.proxy` dispatch; bundled Google Meet runtime dispatch with requested admin scope; third-party runtime rejection despite requested admin scope; bundled CLI runtime forwards requested scope; third-party CLI runtime drops requested scope; CI shard `agentic-control-plane-http-plugin-ws` passes locally after the scope metadata fix.
- Edge cases checked: connected node declares `browser.proxy`; command is allowlisted so rejection is specifically the scope check; plugin runtime metadata survives through the real registry proxy; stale global registry state does not decide official-plugin scope by itself; CLI runtime does not forward requested scopes without bundled/trusted official plugin metadata.
- What was not verified: remote multi-device browser deployment and a live Google Meet call.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Mostly
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A
- Notes: callers that directly invoke `browser.proxy` through `node.invoke` now need `operator.admin`, matching the existing `browser.request` scope.

## Risks and Mitigations

- Risk: a non-admin integration relying on direct `node.invoke` for `browser.proxy` will now be rejected.
  - Mitigation: use an admin-scoped operator token for browser proxy control, or call the existing admin-scoped `browser.request` route.
