### PR TITLE
fix(gateway): register chat abort controller before attachment prep

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2480,14 +2480,30 @@ export const chatHandlers: GatewayRequestHandlers = {
       } catch (err) {
         activeRunAbort.cleanup();
         logAttachmentFailure(context.logGateway, "chat.send attachment parse/stage failed", err);
-        respond(
-          false,
-          undefined,
-          errorShape(
-            err instanceof MediaOffloadError ? ErrorCodes.UNAVAILABLE : ErrorCodes.INVALID_REQUEST,
-            String(err),
-          ),
+        const error = errorShape(
+          err instanceof MediaOffloadError ? ErrorCodes.UNAVAILABLE : ErrorCodes.INVALID_REQUEST,
+          String(err),
         );
+        // Persist the terminal error under chat:<runId> so a duplicate sender
+        // that already received status:"in_flight" (and any later retry with
+        // the same idempotencyKey) sees the cached failure instead of starting
+        // a fresh run. Matches the outer-catch dedupe write below.
+        const errorPayload = {
+          runId: clientRunId,
+          status: "error" as const,
+          summary: String(err),
+        };
+        setGatewayDedupeEntry({
+          dedupe: context.dedupe,
+          key: `chat:${clientRunId}`,
+          entry: {
+            ts: Date.now(),
+            ok: false,
+            payload: errorPayload,
+            error,
+          },
+        });
+        respond(false, undefined, error);
         return;
       }
     }

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2391,6 +2391,30 @@ export const chatHandlers: GatewayRequestHandlers = {
     const explicitOriginTargetsPlugin = explicitOriginTargetsPluginBinding(
       explicitOriginResult.value,
     );
+    // Register the abort controller before any awaited attachment preparation
+    // so a chat.abort sent immediately after chat.send (issue #84176) finds the
+    // active run instead of returning aborted:false. Mirrors the agent RPC
+    // early-registration pattern (see agent.ts).
+    const activeRunAbort = registerChatAbortController({
+      chatAbortControllers: context.chatAbortControllers,
+      runId: clientRunId,
+      sessionId: backingSessionId ?? clientRunId,
+      sessionKey: rawSessionKey,
+      timeoutMs,
+      now,
+      ownerConnId: normalizeOptionalText(client?.connId),
+      ownerDeviceId: normalizeOptionalText(client?.connect?.device?.id),
+      providerId: resolvedSessionModel.provider,
+      authProviderId: resolvedSessionAuthProvider,
+      kind: "chat-send",
+    });
+    if (!activeRunAbort.registered) {
+      respond(true, { runId: clientRunId, status: "in_flight" as const }, undefined, {
+        cached: true,
+        runId: clientRunId,
+      });
+      return;
+    }
     if (normalizedAttachments.length > 0) {
       try {
         await measureDiagnosticsTimelineSpan(
@@ -2454,6 +2478,7 @@ export const chatHandlers: GatewayRequestHandlers = {
           },
         );
       } catch (err) {
+        activeRunAbort.cleanup();
         logAttachmentFailure(context.logGateway, "chat.send attachment parse/stage failed", err);
         respond(
           false,
@@ -2467,27 +2492,33 @@ export const chatHandlers: GatewayRequestHandlers = {
       }
     }
 
-    try {
-      const activeRunAbort = registerChatAbortController({
-        chatAbortControllers: context.chatAbortControllers,
+    // chat.abort may have arrived during attachment prep. abortChatRunById has
+    // already deleted the controller entry and broadcast the aborted event;
+    // skip dispatch and acknowledge the early abort instead of falsely sending
+    // a started ack. Record the aborted outcome under the chat:<runId> dedupe
+    // key so retries with the same idempotencyKey see the cached aborted result
+    // rather than starting a new run (mirrors the started/ok/error paths).
+    if (activeRunAbort.controller.signal.aborted) {
+      const stopReason = activeRunAbort.entry?.abortStopReason ?? "rpc";
+      const abortedPayload = {
         runId: clientRunId,
-        sessionId: backingSessionId ?? clientRunId,
-        sessionKey: rawSessionKey,
-        timeoutMs,
-        now,
-        ownerConnId: normalizeOptionalText(client?.connId),
-        ownerDeviceId: normalizeOptionalText(client?.connect?.device?.id),
-        providerId: resolvedSessionModel.provider,
-        authProviderId: resolvedSessionAuthProvider,
-        kind: "chat-send",
+        status: "aborted" as const,
+        stopReason,
+      };
+      setGatewayDedupeEntry({
+        dedupe: context.dedupe,
+        key: `chat:${clientRunId}`,
+        entry: {
+          ts: Date.now(),
+          ok: true,
+          payload: abortedPayload,
+        },
       });
-      if (!activeRunAbort.registered) {
-        respond(true, { runId: clientRunId, status: "in_flight" as const }, undefined, {
-          cached: true,
-          runId: clientRunId,
-        });
-        return;
-      }
+      respond(true, abortedPayload, undefined, { runId: clientRunId });
+      return;
+    }
+
+    try {
       if (activeChatSendDedupeKey) {
         context.dedupe.set(activeChatSendDedupeKey, {
           ts: now,

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -504,6 +504,138 @@ describe("gateway server chat", () => {
     }
   });
 
+  test("chat.send attachment-prep failure caches the error so a duplicate that already saw in_flight does not retry into a fresh run", async () => {
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    try {
+      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+      await writeSessionStore({
+        entries: {
+          main: {
+            sessionId: "sess-main",
+            modelProvider: "test-provider",
+            model: "vision-model",
+            updatedAt: Date.now(),
+          },
+        },
+      });
+
+      const catalogDeferred =
+        createDeferred<Awaited<ReturnType<GatewayRequestContext["loadGatewayModelCatalog"]>>>();
+      const firstRespond = vi.fn() as Mock<RespondFn>;
+      const duplicateRespond = vi.fn() as Mock<RespondFn>;
+      const retryRespond = vi.fn() as Mock<RespondFn>;
+      const context = {
+        loadGatewayModelCatalog: vi
+          .fn<GatewayRequestContext["loadGatewayModelCatalog"]>()
+          .mockImplementationOnce(() => catalogDeferred.promise),
+        logGateway: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+        agentRunSeq: new Map<string, number>(),
+        chatAbortControllers: new Map(),
+        chatAbortedRuns: new Map(),
+        chatRunBuffers: new Map(),
+        chatDeltaSentAt: new Map(),
+        chatDeltaLastBroadcastLen: new Map(),
+        chatDeltaLastBroadcastText: new Map(),
+        agentDeltaSentAt: new Map(),
+        bufferedAgentEvents: new Map(),
+        addChatRun: vi.fn(),
+        removeChatRun: vi.fn(),
+        broadcast: vi.fn(),
+        nodeSendToSession: vi.fn(),
+        registerToolEventRecipient: vi.fn(),
+        dedupe: new Map(),
+      } as unknown as GatewayRequestContext;
+
+      const runId = "idem-prep-failure";
+      const sendParams = {
+        sessionKey: "main",
+        message: "see image",
+        idempotencyKey: runId,
+        attachments: [
+          {
+            type: "image",
+            mimeType: "image/png",
+            fileName: "broken.png",
+            // Invalid base64 content forces parseMessageWithAttachments to
+            // throw inside attachment prep, after the abort controller has
+            // been registered.
+            content: "!!!not-valid-base64$$$",
+          },
+        ],
+      };
+      const { chatHandlers } = await import("./server-methods/chat.js");
+      const callSend = (respond: Mock<RespondFn>, id: string) =>
+        chatHandlers["chat.send"]({
+          req: { type: "req", id, method: "chat.send", params: sendParams },
+          params: sendParams,
+          client: null,
+          isWebchatConnect: () => false,
+          respond: respond as never,
+          context,
+        });
+
+      const first = Promise.resolve(callSend(firstRespond, "first"));
+      await vi.waitFor(() => {
+        expect(context.loadGatewayModelCatalog).toHaveBeenCalledTimes(1);
+      }, FAST_WAIT_OPTS);
+
+      await callSend(duplicateRespond, "duplicate");
+      expect(duplicateRespond).toHaveBeenCalledTimes(1);
+      expect(duplicateRespond).toHaveBeenCalledWith(
+        true,
+        { runId, status: "in_flight" },
+        undefined,
+        { cached: true, runId },
+      );
+
+      catalogDeferred.resolve([
+        {
+          id: "vision-model",
+          name: "Vision Model",
+          provider: "test-provider",
+          input: ["text", "image"],
+        },
+      ]);
+      await first;
+
+      expect(firstRespond).toHaveBeenCalledTimes(1);
+      const [firstOk, firstPayload, firstError] = firstRespond.mock.calls[0] ?? [];
+      expect(firstOk).toBe(false);
+      expect(firstPayload).toBeUndefined();
+      expect(firstError).toMatchObject({ code: "INVALID_REQUEST" });
+      expect(context.chatAbortControllers.has(runId)).toBe(false);
+
+      // The terminal error is cached under chat:<runId> so a duplicate that
+      // already received in_flight (and any later retry with the same
+      // idempotencyKey) gets the cached failure rather than a fresh run.
+      const cachedError = context.dedupe.get(`chat:${runId}`);
+      expect(cachedError).toMatchObject({
+        ok: false,
+        payload: { runId, status: "error" },
+        error: { code: "INVALID_REQUEST" },
+      });
+
+      await callSend(retryRespond, "retry");
+      expect(retryRespond).toHaveBeenCalledTimes(1);
+      expect(retryRespond).toHaveBeenCalledWith(
+        false,
+        expect.objectContaining({ runId, status: "error" }),
+        expect.objectContaining({ code: "INVALID_REQUEST" }),
+        { cached: true },
+      );
+      expect(context.loadGatewayModelCatalog).toHaveBeenCalledTimes(1);
+    } finally {
+      testState.sessionStorePath = undefined;
+      clearConfigCache();
+      await fs.rm(sessionDir, { recursive: true, force: true });
+    }
+  });
+
   test.each(configuredImageModelCases)(
     "chat.send preserves text-only image uploads as MediaPaths even with configured imageModel: $id",
     async ({ id, imageModel }) => {

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
+import type { Mock } from "vitest";
 import type { GetReplyOptions } from "../auto-reply/get-reply-options.types.js";
 import { clearConfigCache } from "../config/config.js";
 import type { AgentModelConfig } from "../config/types.agents-shared.js";
@@ -226,7 +227,7 @@ describe("gateway server chat", () => {
     }
   });
 
-  test("chat.send returns in_flight when duplicate attachment send wins parsing race", async () => {
+  test("chat.send registers the run before attachment prep so duplicates see in_flight", async () => {
     const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
     const dispatchRelease = createDeferred<void>();
     try {
@@ -312,12 +313,15 @@ describe("gateway server chat", () => {
         expect(context.loadGatewayModelCatalog).toHaveBeenCalledTimes(1);
       }, FAST_WAIT_OPTS);
 
+      // The first send registered its abort controller before awaiting
+      // attachment prep, so the duplicate immediately sees an in-flight run
+      // instead of racing to win the started ack.
       await callSend("duplicate");
       expect(responses).toEqual([
         {
           id: "duplicate",
           ok: true,
-          payload: { runId: "idem-attachment-race", status: "started" },
+          payload: { runId: "idem-attachment-race", status: "in_flight" },
           error: undefined,
         },
       ]);
@@ -336,13 +340,13 @@ describe("gateway server chat", () => {
         {
           id: "duplicate",
           ok: true,
-          payload: { runId: "idem-attachment-race", status: "started" },
+          payload: { runId: "idem-attachment-race", status: "in_flight" },
           error: undefined,
         },
         {
           id: "first",
           ok: true,
-          payload: { runId: "idem-attachment-race", status: "in_flight" },
+          payload: { runId: "idem-attachment-race", status: "started" },
           error: undefined,
         },
       ]);
@@ -352,6 +356,145 @@ describe("gateway server chat", () => {
       await vi.waitFor(() => {
         expect(context.removeChatRun).toHaveBeenCalledTimes(1);
       }, FAST_WAIT_OPTS);
+    } finally {
+      dispatchRelease.resolve();
+      dispatchInboundMessageMock.mockReset();
+      testState.sessionStorePath = undefined;
+      clearConfigCache();
+      await fs.rm(sessionDir, { recursive: true, force: true });
+    }
+  });
+
+  test("chat.abort during attachment prep finds the active run (regression for #84176)", async () => {
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const dispatchRelease = createDeferred<void>();
+    try {
+      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+      await writeSessionStore({
+        entries: {
+          main: {
+            sessionId: "sess-main",
+            modelProvider: "test-provider",
+            model: "vision-model",
+            updatedAt: Date.now(),
+          },
+        },
+      });
+
+      const catalogDeferred =
+        createDeferred<Awaited<ReturnType<GatewayRequestContext["loadGatewayModelCatalog"]>>>();
+      const sendRespond = vi.fn() as Mock<RespondFn>;
+      const abortRespond = vi.fn() as Mock<RespondFn>;
+      const context = {
+        loadGatewayModelCatalog: vi
+          .fn<GatewayRequestContext["loadGatewayModelCatalog"]>()
+          .mockImplementationOnce(() => catalogDeferred.promise),
+        logGateway: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+        agentRunSeq: new Map<string, number>(),
+        chatAbortControllers: new Map(),
+        chatAbortedRuns: new Map(),
+        chatRunBuffers: new Map(),
+        chatDeltaSentAt: new Map(),
+        chatDeltaLastBroadcastLen: new Map(),
+        chatDeltaLastBroadcastText: new Map(),
+        agentDeltaSentAt: new Map(),
+        bufferedAgentEvents: new Map(),
+        addChatRun: vi.fn(),
+        removeChatRun: vi.fn(),
+        broadcast: vi.fn(),
+        nodeSendToSession: vi.fn(),
+        registerToolEventRecipient: vi.fn(),
+        dedupe: new Map(),
+      } as unknown as GatewayRequestContext;
+      dispatchInboundMessageMock.mockImplementation(async () => dispatchRelease.promise);
+
+      const pngB64 =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+      const runId = "idem-abort-during-prep";
+      const sendParams = {
+        sessionKey: "main",
+        message: "see image",
+        idempotencyKey: runId,
+        attachments: [
+          {
+            type: "image",
+            mimeType: "image/png",
+            fileName: "dot.png",
+            content: pngB64,
+          },
+        ],
+      };
+      const { chatHandlers } = await import("./server-methods/chat.js");
+
+      const sendPromise = Promise.resolve(
+        chatHandlers["chat.send"]({
+          req: { type: "req", id: "send-1", method: "chat.send", params: sendParams },
+          params: sendParams,
+          client: null,
+          isWebchatConnect: () => false,
+          respond: sendRespond as never,
+          context,
+        }),
+      );
+
+      await vi.waitFor(() => {
+        expect(context.loadGatewayModelCatalog).toHaveBeenCalledTimes(1);
+      }, FAST_WAIT_OPTS);
+
+      // Fix verification: the run must be registered before attachment prep so
+      // chat.abort can observe it. Before #84176's fix this assertion failed.
+      expect(context.chatAbortControllers.has(runId)).toBe(true);
+
+      const abortParams = { sessionKey: "main", runId };
+      await chatHandlers["chat.abort"]({
+        req: { type: "req", id: "abort-1", method: "chat.abort", params: abortParams },
+        params: abortParams,
+        client: null,
+        isWebchatConnect: () => false,
+        respond: abortRespond as never,
+        context,
+      });
+
+      expect(abortRespond).toHaveBeenCalledTimes(1);
+      expect(abortRespond).toHaveBeenCalledWith(true, {
+        ok: true,
+        aborted: true,
+        runIds: [runId],
+      });
+      expect(context.chatAbortControllers.has(runId)).toBe(false);
+
+      catalogDeferred.resolve([
+        {
+          id: "vision-model",
+          name: "Vision Model",
+          provider: "test-provider",
+          input: ["text", "image"],
+        },
+      ]);
+      await sendPromise;
+
+      expect(sendRespond).toHaveBeenCalledTimes(1);
+      expect(sendRespond).toHaveBeenCalledWith(
+        true,
+        { runId, status: "aborted", stopReason: "rpc" },
+        undefined,
+        { runId },
+      );
+      expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+      expect(context.addChatRun).not.toHaveBeenCalled();
+      // The aborted outcome is cached under chat:<runId> so a retry with the
+      // same idempotencyKey returns the cached aborted ack rather than
+      // spawning a new run (mirrors started/ok/error dedupe writes).
+      const cachedAbort = context.dedupe.get(`chat:${runId}`);
+      expect(cachedAbort).toMatchObject({
+        ok: true,
+        payload: { runId, status: "aborted", stopReason: "rpc" },
+      });
     } finally {
       dispatchRelease.resolve();
       dispatchInboundMessageMock.mockReset();


### PR DESCRIPTION
## Summary

Fixes #84176. `chat.abort` sent right after `chat.send` returned `aborted:false` because the abort controller was only registered after the awaited attachment preparation, leaving a window where the run had no entry in `chatAbortControllers`.

The fix mirrors the agent RPC early-registration pattern (`src/gateway/server-methods/agent.ts:1746`):

- Register the abort controller before attachment prep so a concurrent `chat.abort` immediately observes the active run.
- Clean it up via `activeRunAbort.cleanup()` if attachment prep throws, and persist a terminal `chat:<runId>` error dedupe entry so duplicate senders that already received `status:"in_flight"` (and later retries with the same idempotencyKey) see the cached failure instead of spawning a fresh run.
- After prep, check `activeRunAbort.controller.signal.aborted` — if `chat.abort` already fired, `abortChatRunById` has cleared the entry and broadcast `aborted`, so the handler skips dispatch and acknowledges with `status: "aborted"` instead of falsely emitting a `started` ack.
- Cache the aborted outcome under `chat:<runId>` so retries with the same `idempotencyKey` see the cached aborted result rather than spawning a new run (mirrors the existing `started`/`ok`/`error` dedupe writes).

The pre-existing `"duplicate attachment send wins parsing race"` test gets stricter expectations as a consequence: with early registration the first send always wins (`started`) and any duplicate before it finishes always sees `in_flight`, which matches idempotency semantics. Two new regression tests cover (a) abort-during-attachment-prep and (b) duplicate-in_flight then prep-failure.

## Real behavior proof

Behavior addressed: prior to this fix, `chat.send` only inserted the abort controller into `context.chatAbortControllers` after `await gateway.chat_send.prepare_attachments`. A `chat.abort` arriving while prep was still pending called `chatAbortControllers.get(runId)`, found nothing, and returned `{ ok: true, aborted: false, runIds: [] }` even though the chat run was still active.

Real environment tested: local OpenClaw source checkout on Ubuntu 22.04, Node v24.15.0, with the production `chatHandlers["chat.send"]` and `chatHandlers["chat.abort"]` driven directly through `node --import tsx` against a real `Map` for `chatAbortControllers`/`dedupe`, real `AbortController`, and a deferred model-catalog mock that suspends chat.send mid attachment prep so chat.abort can race with it.

Exact steps or command run after this patch: `node --import tsx /tmp/probe-handler-84176.mjs` — the script imports the live `chatHandlers` map, fires `chat.send` with an image attachment, waits until the handler has registered the abort controller (early registration is the fix), fires `chat.abort` for the same runId, then releases the catalog so chat.send finishes and prints the resulting handler responses plus the cached dedupe entry.

Evidence after fix:

```json
{
  "registeredBeforeAbort": true,
  "registeredAfterAbort": false,
  "abortResponse": {
    "ok": true,
    "payload": {
      "ok": true,
      "aborted": true,
      "runIds": [
        "probe-run-84176"
      ]
    }
  },
  "sendResponse": {
    "ok": true,
    "payload": {
      "runId": "probe-run-84176",
      "status": "aborted",
      "stopReason": "rpc"
    }
  },
  "cachedChatRunDedupe": {
    "ok": true,
    "payload": {
      "runId": "probe-run-84176",
      "status": "aborted",
      "stopReason": "rpc"
    }
  }
}
```

Observed result after fix, driven through the real handlers:

- `chat.send` registered the abort controller before attachment prep finished, so `chat.abort` for the same runId returned `{ ok: true, aborted: true, runIds: [<runId>] }` instead of the buggy `aborted: false`.
- After abort, `chatAbortControllers` no longer held the entry (cleared by `abortChatRunById`).
- The suspended `chat.send`, once the catalog resolved and prep finished, detected `signal.aborted` and responded with `status: "aborted", stopReason: "rpc"` instead of falsely emitting `started` and dispatching the run.
- The aborted outcome was cached under `chat:<runId>` so a retry with the same `idempotencyKey` returns the cached aborted ack instead of starting a new run.

What was not tested: no full end-to-end gateway WS roundtrip against a live model provider; the new regression tests in `src/gateway/server.chat.gateway-server-chat-b.test.ts` exercise the same handler entry points with a real `Map` for `chatAbortControllers`/`dedupe` and a deferred catalog mock.

## Verification

- `node scripts/run-vitest.mjs src/gateway/` — 223 files / 2585 tests passed, including the two new regression tests (`chat.abort during attachment prep finds the active run (regression for #84176)` and `chat.send attachment-prep failure caches the error so a duplicate that already saw in_flight does not retry into a fresh run`).
- `node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat-b.test.ts src/gateway/chat-abort.test.ts src/gateway/server-methods/chat.abort-authorization.test.ts` — the three test files ClawSweeper named in its review of #84176 all pass.
- `node scripts/run-oxlint.mjs src/gateway/server-methods/chat.ts src/gateway/server.chat.gateway-server-chat-b.test.ts` — clean.
- `node scripts/run-tsgo.mjs` — clean.
- Auto Review (extra-high recall, 5 angles + verifier + sweep): one HIGH finding fixed (aborted-path missing `chat:<runId>` dedupe write); one LOW finding fixed (test used `.find()` without count assertion).
- ClawSweeper P2 follow-up (`chat.ts:2481`): the second commit adds the prep-failure dedupe write and its regression test.
