### PR TITLE
fix(ui): avoid duplicate final chat messages

### DIFF
--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -158,6 +158,65 @@ describe("handleChatEvent", () => {
     expect(state.chatStreamStartedAt).toBe(null);
   });
 
+  it("does not duplicate an active-run final already loaded from history", () => {
+    const persistedMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "Live reply" }],
+      __openclaw: { source: "chat.history" },
+    };
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Live reply",
+      chatStreamStartedAt: 100,
+      chatMessages: [persistedMessage],
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Live reply" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([persistedMessage]);
+    expect(state.chatRunId).toBe(null);
+    expect(state.chatStream).toBe(null);
+  });
+
+  it("keeps repeated assistant text when a user turn separates it from the tail", () => {
+    const priorAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "Live reply" }],
+    };
+    const userMessage = {
+      role: "user",
+      content: [{ type: "text", text: "Say it again" }],
+    };
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Live reply",
+      chatStreamStartedAt: 100,
+      chatMessages: [priorAssistant, userMessage],
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Live reply" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([priorAssistant, userMessage, payload.message]);
+  });
+
   it("reconciles cached run and indicator state on terminal events", () => {
     vi.useFakeTimers();
     try {

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -185,6 +185,15 @@ function messageDisplaySignature(message: unknown): string | null {
   }
 }
 
+function hasTailDisplayDuplicate(messages: unknown[], message: unknown): boolean {
+  const messageSignature = messageDisplaySignature(message);
+  if (!messageSignature) {
+    return false;
+  }
+  const lastMessage = messages[messages.length - 1];
+  return messageDisplaySignature(lastMessage) === messageSignature;
+}
+
 export function preserveOptimisticTailMessages(
   historyMessages: unknown[],
   previousMessages: unknown[],
@@ -677,7 +686,11 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   if (state.chatRunId && payload.runId !== state.chatRunId) {
     if (payload.state === "final") {
       const finalMessage = normalizeFinalAssistantMessage(payload.message);
-      if (finalMessage && !shouldHideAssistantChatMessage(finalMessage)) {
+      if (
+        finalMessage &&
+        !shouldHideAssistantChatMessage(finalMessage) &&
+        !hasTailDisplayDuplicate(state.chatMessages, finalMessage)
+      ) {
         state.chatMessages = [...state.chatMessages, finalMessage];
         return null;
       }
@@ -713,7 +726,9 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   } else if (payload.state === "final") {
     const finalMessage = normalizeFinalAssistantMessage(payload.message);
     if (finalMessage && !shouldHideAssistantChatMessage(finalMessage)) {
-      state.chatMessages = [...state.chatMessages, finalMessage];
+      if (!hasTailDisplayDuplicate(state.chatMessages, finalMessage)) {
+        state.chatMessages = [...state.chatMessages, finalMessage];
+      }
     } else if (
       state.chatStream?.trim() &&
       !isSilentReplyStream(state.chatStream) &&


### PR DESCRIPTION
## Summary

- Fixes #85771 by making the Control UI ignore a final assistant payload when the same assistant message is already the visible chat tail from a history reload.
- Keeps legitimate repeated assistant text when a user message separates the repeated reply from the previous assistant tail.
- Adds focused controller coverage for the history-before-final race.

## Tests

- `node scripts/run-vitest.mjs ui/src/ui/controllers/chat.test.ts --reporter=verbose`
- `./node_modules/.bin/oxfmt --check --threads=1 ui/src/ui/controllers/chat.ts ui/src/ui/controllers/chat.test.ts`
- `./node_modules/.bin/oxlint ui/src/ui/controllers/chat.ts ui/src/ui/controllers/chat.test.ts`
- `git diff --check`

## Real behavior proof

Behavior addressed: WebChat no longer renders a duplicate assistant bubble when `chat.history` has already loaded the assistant reply before the active run's `chat.status` final event arrives.

Real environment tested: Local macOS checkout using the Control UI controller runtime imported through `node --import tsx/esm`; no mocked gateway or browser DOM was needed for this controller-level race proof.

Exact steps or command run after this patch: `node --import tsx/esm --input-type=module` with a live import of `./ui/src/ui/controllers/chat.ts`, a state whose chat tail already contained the persisted assistant reply, and then a matching active-run `final` event passed to `handleChatEvent`.

Evidence after fix: Terminal capture from the runtime command showed the final event reconciled the run while keeping a single visible assistant message: `{"result":"final","count":1,"text":"Live reply","chatRunId":null}`.

Observed result after fix: The controller returned `final`, cleared `chatRunId`, and kept `chatMessages.length === 1` instead of appending a second identical assistant message.

What was not tested: No live browser/WebChat session against a running gateway was exercised; the after-fix proof covers the Control UI event reconciliation path identified in the issue, with focused Vitest coverage as supplemental regression proof.
