### PR TITLE
Retain Telegram preview messages after generation races

### DIFF
--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -300,7 +300,7 @@ describe("createTelegramDraftStream", () => {
     }
   });
 
-  it("does not rebind to an old message when forceNewMessage races an in-flight send", async () => {
+  it("retains the old message when forceNewMessage races an in-flight send", async () => {
     let resolveFirstSend: ((value: { message_id: number }) => void) | undefined;
     const firstSend = new Promise<{ message_id: number }>((resolve) => {
       resolveFirstSend = resolve;
@@ -334,6 +334,7 @@ describe("createTelegramDraftStream", () => {
       textSnapshot: "Message A partial",
       parseMode: undefined,
       visibleSinceMs: supersededPreview.visibleSinceMs,
+      retain: true,
     });
     expect(typeof supersededPreview.visibleSinceMs).toBe("number");
     expect(Number.isFinite(supersededPreview.visibleSinceMs)).toBe(true);

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -177,6 +177,7 @@ export function createTelegramDraftStream(params: {
         textSnapshot: renderedText,
         parseMode: renderedParseMode,
         visibleSinceMs,
+        retain: true,
       });
       return true;
     }


### PR DESCRIPTION
## Summary
- retain Telegram preview messages that land after a stream generation rotation
- update the in-flight `forceNewMessage()` race regression test to require `retain: true`

## Root Cause
When `sendMessage` resolved after `forceNewMessage()` advanced the draft generation, `sendMessageTransportPreview` reported the successfully landed Telegram message as superseded without `retain: true`. The dispatch layer deletes superseded previews unless that retain flag is present, so the first streamed message could disappear when a follow-up segment started.

## Real behavior proof
- **Behavior addressed**: A Telegram draft preview `sendMessage` can resolve after `forceNewMessage()` rotates the stream generation. The old landed preview must be retained instead of being deleted by superseded-preview cleanup.
- **Real setup tested**: Local OpenClaw checkout on macOS using the real `extensions/telegram/src/draft-stream.ts` runtime through `node --import tsx`. The proof used a Telegram-compatible API harness so no external Telegram chat was modified.
- **Exact steps or command run after the patch**: Ran a Node runtime script that imports `createTelegramDraftStream`, starts message A with an in-flight `sendMessage`, rotates via `forceNewMessage()`, starts message B, resolves message A with `message_id: 17`, and runs the same superseded-preview deletion callback shape used by dispatch.
- **Evidence after fix**: Console output from that runtime proof:

```json
{
  "sendMessageCount": 2,
  "firstSentText": "Message A partial",
  "secondSentText": "Message B partial",
  "supersededPreview": {
    "messageId": 17,
    "textSnapshot": "Message A partial",
    "visibleSinceMs": 1779596581815,
    "retain": true
  },
  "deleteMessageCount": 0,
  "deleteCalls": []
}
```

- **Observed result after fix**: The first landed preview is reported with `retain: true`, the second preview is still sent separately, and the dispatch-style cleanup callback performs zero `deleteMessage` calls for the landed first message.
- **What was not tested**: A live Telegram bot token/chat was not used, to avoid posting/deleting messages in an external user chat. The local proof exercises the real OpenClaw Telegram draft stream code path and the same deletion decision contract, while the focused test suite covers the regression.

## Supplemental checks
- `node scripts/run-vitest.mjs extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/bot-message-dispatch.test.ts`
  - `Test Files 2 passed (2)`
  - `Tests 117 passed (117)`
- `git diff --check`

Fixes #85807

If this PR is squashed or reworked, please preserve author attribution or include:
Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>

