### PR TITLE
fix(doctor): label auth health by agent

### DIFF
--- a/src/commands/doctor-auth.profile-health.test.ts
+++ b/src/commands/doctor-auth.profile-health.test.ts
@@ -1,9 +1,23 @@
-import { describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 
 const authProfileMocks = vi.hoisted(() => ({
-  ensureAuthProfileStore: vi.fn(() => {
+  ensureAuthProfileStore: vi.fn<
+    (
+      agentDir?: string,
+      options?: { allowKeychainPrompt?: boolean },
+    ) => {
+      version: number;
+      profiles: Record<
+        string,
+        { type: "oauth"; provider: string; access: string; refresh: string; expires: number }
+      >;
+    }
+  >(() => {
     throw new Error("unexpected auth profile load");
   }),
   hasAnyAuthProfileStoreSource: vi.fn(() => false),
@@ -20,9 +34,48 @@ vi.mock("../agents/auth-profiles.js", () => ({
 
 vi.mock("../terminal/note.js", () => ({ note: vi.fn() }));
 
+import { note } from "../terminal/note.js";
 import { noteAuthProfileHealth } from "./doctor-auth.js";
 
+const noteMock = vi.mocked(note);
+
 describe("noteAuthProfileHealth", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-auth-"));
+    authProfileMocks.ensureAuthProfileStore.mockReset();
+    authProfileMocks.hasAnyAuthProfileStoreSource.mockReset();
+    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(false);
+    authProfileMocks.resolveApiKeyForProfile.mockReset();
+    authProfileMocks.resolveProfileUnusableUntilForDisplay.mockReset();
+    noteMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function writeAuthStore(agentDir: string): void {
+    fs.mkdirSync(agentDir, { recursive: true });
+    fs.writeFileSync(path.join(agentDir, "auth-profiles.json"), "{}\n", "utf8");
+  }
+
+  function expiredStore(profileId: string, expires: number) {
+    return {
+      version: 1,
+      profiles: {
+        [profileId]: {
+          type: "oauth" as const,
+          provider: "openai-codex",
+          access: "access",
+          refresh: "refresh",
+          expires,
+        },
+      },
+    };
+  }
   it("skips external auth profile resolution when no auth source exists", async () => {
     await noteAuthProfileHealth({
       cfg: { channels: { telegram: { enabled: true } } } as OpenClawConfig,
@@ -32,5 +85,48 @@ describe("noteAuthProfileHealth", () => {
 
     expect(authProfileMocks.hasAnyAuthProfileStoreSource).toHaveBeenCalledOnce();
     expect(authProfileMocks.ensureAuthProfileStore).not.toHaveBeenCalled();
+  });
+
+  it("labels model auth diagnostics by agent when multiple agent auth stores are checked", async () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const mainDir = path.join(tempDir, "main-agent");
+    const coderDir = path.join(tempDir, "coder-agent");
+    writeAuthStore(mainDir);
+    writeAuthStore(coderDir);
+    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
+    authProfileMocks.ensureAuthProfileStore.mockImplementation((agentDir) => {
+      if (agentDir === mainDir) {
+        return expiredStore("openai-codex:main", now - 60_000);
+      }
+      if (agentDir === coderDir) {
+        return expiredStore("openai-codex:coder", now - 60_000);
+      }
+      throw new Error(`unexpected agent dir: ${agentDir ?? "<default>"}`);
+    });
+
+    await noteAuthProfileHealth({
+      cfg: {
+        agents: {
+          list: [
+            { id: "main", default: true, agentDir: mainDir },
+            { id: "coder", agentDir: coderDir },
+          ],
+        },
+      } as OpenClawConfig,
+      prompter: {
+        confirmAutoFix: vi.fn(async () => false),
+      } as unknown as DoctorPrompter,
+      allowKeychainPrompt: false,
+    });
+
+    expect(noteMock).toHaveBeenCalledWith(
+      expect.stringContaining("openai-codex:main"),
+      "Model auth (agent: main)",
+    );
+    expect(noteMock).toHaveBeenCalledWith(
+      expect.stringContaining("openai-codex:coder"),
+      "Model auth (agent: coder)",
+    );
   });
 });

--- a/src/commands/doctor-auth.profile-health.test.ts
+++ b/src/commands/doctor-auth.profile-health.test.ts
@@ -20,7 +20,7 @@ const authProfileMocks = vi.hoisted(() => ({
   >(() => {
     throw new Error("unexpected auth profile load");
   }),
-  hasAnyAuthProfileStoreSource: vi.fn(() => false),
+  hasAnyAuthProfileStoreSource: vi.fn((_agentDir?: string) => false),
   resolveApiKeyForProfile: vi.fn(),
   resolveProfileUnusableUntilForDisplay: vi.fn(),
 }));
@@ -87,6 +87,32 @@ describe("noteAuthProfileHealth", () => {
     expect(authProfileMocks.ensureAuthProfileStore).not.toHaveBeenCalled();
   });
 
+  it("checks the configured default agent auth store source", async () => {
+    const defaultDir = path.join(tempDir, "custom-default");
+    authProfileMocks.hasAnyAuthProfileStoreSource.mockImplementation(
+      (agentDir) => agentDir === defaultDir,
+    );
+    authProfileMocks.ensureAuthProfileStore.mockReturnValue({
+      version: 1,
+      profiles: {},
+    });
+
+    await noteAuthProfileHealth({
+      cfg: {
+        agents: {
+          list: [{ id: "main", default: true, agentDir: defaultDir }],
+        },
+      } as OpenClawConfig,
+      prompter: {} as DoctorPrompter,
+      allowKeychainPrompt: false,
+    });
+
+    expect(authProfileMocks.hasAnyAuthProfileStoreSource).toHaveBeenCalledWith(defaultDir);
+    expect(authProfileMocks.ensureAuthProfileStore).toHaveBeenCalledWith(defaultDir, {
+      allowKeychainPrompt: false,
+    });
+  });
+
   it("labels model auth diagnostics by agent when multiple agent auth stores are checked", async () => {
     const now = 1_700_000_000_000;
     vi.spyOn(Date, "now").mockReturnValue(now);
@@ -127,6 +153,43 @@ describe("noteAuthProfileHealth", () => {
     expect(noteMock).toHaveBeenCalledWith(
       expect.stringContaining("openai-codex:coder"),
       "Model auth (agent: coder)",
+    );
+  });
+
+  it("passes the target agent dir when refreshing OAuth profiles", async () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const coderDir = path.join(tempDir, "coder-agent");
+    writeAuthStore(coderDir);
+    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(false);
+    authProfileMocks.ensureAuthProfileStore.mockImplementation((agentDir) => {
+      if (agentDir === coderDir) {
+        return expiredStore("openai-codex:coder", now - 60_000);
+      }
+      return { version: 1, profiles: {} };
+    });
+    authProfileMocks.resolveApiKeyForProfile.mockResolvedValue("token");
+
+    await noteAuthProfileHealth({
+      cfg: {
+        agents: {
+          list: [
+            { id: "main", default: true, agentDir: path.join(tempDir, "main-agent") },
+            { id: "coder", agentDir: coderDir },
+          ],
+        },
+      } as OpenClawConfig,
+      prompter: {
+        confirmAutoFix: vi.fn(async () => true),
+      } as unknown as DoctorPrompter,
+      allowKeychainPrompt: false,
+    });
+
+    expect(authProfileMocks.resolveApiKeyForProfile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentDir: coderDir,
+        profileId: "openai-codex:coder",
+      }),
     );
   });
 });

--- a/src/commands/doctor-auth.ts
+++ b/src/commands/doctor-auth.ts
@@ -1,3 +1,11 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+  listAgentIds,
+  resolveAgentDir,
+  resolveDefaultAgentDir,
+  resolveDefaultAgentId,
+} from "../agents/agent-scope.js";
 import {
   buildAuthHealthSummary,
   DEFAULT_OAUTH_WARN_MS,
@@ -16,6 +24,11 @@ import {
   classifyOAuthRefreshFailure,
   type OAuthRefreshFailureReason,
 } from "../agents/auth-profiles/oauth-refresh-failure.js";
+import {
+  resolveAuthStatePath,
+  resolveAuthStorePath,
+  resolveLegacyAuthStorePath,
+} from "../agents/auth-profiles/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { note } from "../terminal/note.js";
@@ -119,6 +132,49 @@ type AuthIssue = {
   remainingMs?: number;
 };
 
+type AuthProfileHealthTarget = {
+  agentId: string;
+  agentDir: string;
+  isDefault: boolean;
+};
+
+function hasLocalAuthProfileStoreSource(agentDir: string): boolean {
+  return (
+    fs.existsSync(resolveAuthStorePath(agentDir)) ||
+    fs.existsSync(resolveAuthStatePath(agentDir)) ||
+    fs.existsSync(resolveLegacyAuthStorePath(agentDir))
+  );
+}
+
+function formatAgentNoteTitle(title: string, agentId: string, labelAgents: boolean): string {
+  return labelAgents ? `${title} (agent: ${agentId})` : title;
+}
+
+function listAuthProfileHealthTargets(cfg: OpenClawConfig): AuthProfileHealthTarget[] {
+  const defaultAgentId = resolveDefaultAgentId(cfg);
+  const targets = new Map<string, AuthProfileHealthTarget>();
+  const addTarget = (agentId: string, agentDir: string, isDefault: boolean) => {
+    const key = path.resolve(agentDir);
+    const existing = targets.get(key);
+    if (!existing || isDefault) {
+      targets.set(key, { agentId, agentDir, isDefault: isDefault || existing?.isDefault === true });
+    }
+  };
+
+  addTarget(defaultAgentId, resolveDefaultAgentDir(cfg), true);
+  for (const agentId of listAgentIds(cfg)) {
+    if (agentId === defaultAgentId) {
+      continue;
+    }
+    const agentDir = resolveAgentDir(cfg, agentId);
+    if (hasLocalAuthProfileStoreSource(agentDir)) {
+      addTarget(agentId, agentDir, false);
+    }
+  }
+
+  return [...targets.values()];
+}
+
 export function resolveUnusableProfileHint(params: {
   kind: "cooldown" | "disabled";
   reason?: string;
@@ -202,20 +258,18 @@ async function formatAuthIssueLine(
   return `- ${issue.profileId}: ${issue.status}${reason}${remaining}${hint ? ` — ${hint}` : ""}`;
 }
 
-export async function noteAuthProfileHealth(params: {
+async function noteAuthProfileHealthForTarget(params: {
   cfg: OpenClawConfig;
   prompter: DoctorPrompter;
   allowKeychainPrompt: boolean;
+  target: AuthProfileHealthTarget;
+  labelAgents: boolean;
 }): Promise<void> {
-  if (
-    Object.keys(params.cfg.auth?.profiles ?? {}).length === 0 &&
-    !hasAnyAuthProfileStoreSource()
-  ) {
-    return;
-  }
-  const store = ensureAuthProfileStore(undefined, {
+  const store = ensureAuthProfileStore(params.target.agentDir, {
     allowKeychainPrompt: params.allowKeychainPrompt,
   });
+  const noteTitle = (title: string) =>
+    formatAgentNoteTitle(title, params.target.agentId, params.labelAgents);
   const unusable = (() => {
     const now = Date.now();
     const out: string[] = [];
@@ -240,7 +294,7 @@ export async function noteAuthProfileHealth(params: {
   })();
 
   if (unusable.length > 0) {
-    note(unusable.join("\n"), "Auth profile cooldowns");
+    note(unusable.join("\n"), noteTitle("Auth profile cooldowns"));
   }
 
   let summary = buildAuthHealthSummary({
@@ -293,10 +347,10 @@ export async function noteAuthProfileHealth(params: {
       }
     }
     if (errors.length > 0) {
-      note(errors.join("\n"), "OAuth refresh errors");
+      note(errors.join("\n"), noteTitle("OAuth refresh errors"));
     }
     summary = buildAuthHealthSummary({
-      store: ensureAuthProfileStore(undefined, {
+      store: ensureAuthProfileStore(params.target.agentDir, {
         allowKeychainPrompt: false,
       }),
       cfg: params.cfg,
@@ -321,6 +375,32 @@ export async function noteAuthProfileHealth(params: {
         ),
       ),
     );
-    note(issueLines.join("\n"), "Model auth");
+    note(issueLines.join("\n"), noteTitle("Model auth"));
+  }
+}
+
+export async function noteAuthProfileHealth(params: {
+  cfg: OpenClawConfig;
+  prompter: DoctorPrompter;
+  allowKeychainPrompt: boolean;
+}): Promise<void> {
+  const configuredProfiles = Object.keys(params.cfg.auth?.profiles ?? {}).length > 0;
+  const targets = listAuthProfileHealthTargets(params.cfg);
+  const activeTargets = targets.filter((target) =>
+    target.isDefault
+      ? hasAnyAuthProfileStoreSource() || configuredProfiles
+      : hasLocalAuthProfileStoreSource(target.agentDir),
+  );
+  if (activeTargets.length === 0) {
+    return;
+  }
+
+  const labelAgents = activeTargets.length > 1;
+  for (const target of activeTargets) {
+    await noteAuthProfileHealthForTarget({
+      ...params,
+      target,
+      labelAgents,
+    });
   }
 }

--- a/src/commands/doctor-auth.ts
+++ b/src/commands/doctor-auth.ts
@@ -334,6 +334,7 @@ async function noteAuthProfileHealthForTarget(params: {
           cfg: params.cfg,
           store,
           profileId: profile.profileId,
+          agentDir: params.target.agentDir,
         });
       } catch (err) {
         const message = formatErrorMessage(err);
@@ -388,7 +389,7 @@ export async function noteAuthProfileHealth(params: {
   const targets = listAuthProfileHealthTargets(params.cfg);
   const activeTargets = targets.filter((target) =>
     target.isDefault
-      ? hasAnyAuthProfileStoreSource() || configuredProfiles
+      ? hasAnyAuthProfileStoreSource(target.agentDir) || configuredProfiles
       : hasLocalAuthProfileStoreSource(target.agentDir),
   );
   if (activeTargets.length === 0) {


### PR DESCRIPTION
## Summary
- enumerate configured agent auth stores during doctor auth health checks
- label auth cooldown, refresh error, and model auth notes with agent ids when multiple agent stores are reported
- preserve the unlabeled single-store output path and default-store refresh behavior
- pass the resolved target `agentDir` through OAuth refresh checks and default-store source detection

Closes #71867

## Validation

2026-05-24 update, head `a7396d4843fcc7569018962787990c9b0522fc79`:

- `node scripts/run-vitest.mjs src/commands/doctor-auth.profile-health.test.ts --reporter=dot` -> 1 file / 4 tests passed
- `./node_modules/.bin/oxfmt --check --threads=1 src/commands/doctor-auth.ts src/commands/doctor-auth.profile-health.test.ts`
- `./node_modules/.bin/oxlint src/commands/doctor-auth.ts src/commands/doctor-auth.profile-health.test.ts`
- `git diff --check`

Earlier validation:

- `node scripts/run-vitest.mjs --run src/commands/doctor-auth.profile-health.test.ts --reporter=dot`
- `pnpm check:changed`

## Real Behavior Proof

Disposable WSL proof home: `/tmp/openclaw-85924-proof`.

Setup:

- `OPENCLAW_STATE_DIR=/tmp/openclaw-85924-proof/state`
- `OPENCLAW_HOME=/tmp/openclaw-85924-proof/home`
- `openclaw.json` configured two agents:
  - `main`, default, `agentDir=/tmp/openclaw-85924-proof/main-agent`
  - `coder`, `agentDir=/tmp/openclaw-85924-proof/coder-agent`
- each agent had its own `auth-profiles.json` with an expired redacted `openai-codex` OAuth profile

Command:

```bash
OPENCLAW_STATE_DIR=/tmp/openclaw-85924-proof/state \
OPENCLAW_HOME=/tmp/openclaw-85924-proof/home \
node --import tsx src/entry.ts doctor --non-interactive --no-workspace-suggestions
```

Observed output excerpt:

```text
Model auth (agent: main)
- openai-codex:main: expired (0m) - Re-auth via `openclaw models auth ...`

Model auth (agent: coder)
- openai-codex:coder: expired (0m) - Re-auth via `openclaw models auth ...`
```

`stderr` was empty. This demonstrates the real doctor command reports separate labeled auth diagnostics for the configured per-agent auth stores.

## Notes
- No config schema or plugin public contract changes.
- No merge performed.