### PR TITLE
fix(memory): serialize qmd update writes across processes to stop SQLITE_BUSY

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -107,9 +107,25 @@ function firstWatchOptions(): WatchOptions {
 }
 
 function firstEmbedLockCall(): EmbedLockCall {
-  const call = withFileLockMock.mock.calls[0] as EmbedLockCall | undefined;
+  const call = withFileLockMock.mock.calls.find((entry) =>
+    entry[0].endsWith(path.join("qmd", "embed.lock")),
+  ) as EmbedLockCall | undefined;
   if (!call) {
     throw new Error("Expected qmd embed lock call");
+  }
+  return call;
+}
+
+function writeLockCalls(): EmbedLockCall[] {
+  return withFileLockMock.mock.calls.filter((entry) =>
+    entry[0].endsWith("qmd-write.lock"),
+  ) as EmbedLockCall[];
+}
+
+function firstWriteLockCall(): EmbedLockCall {
+  const call = writeLockCalls()[0];
+  if (!call) {
+    throw new Error("Expected qmd store write lock call");
   }
   return call;
 }
@@ -4087,6 +4103,52 @@ describe("QmdMemoryManager", () => {
     await expect(secondSync).resolves.toBeUndefined();
     await first.manager.close();
     await second.manager.close();
+  });
+
+  it("serializes both the qmd update and embed writes on one per-store lock (issue #66339)", async () => {
+    // Regression for #66339: the update AND embed phases both write the same
+    // qmd index.sqlite. A foreground `memory search` dirty-sync and a background
+    // gateway update/embed run in separate processes, which the in-process queues
+    // cannot serialize, so the writers collided with SQLITE_BUSY. Both writes now
+    // take one per-store cross-process write lock; embed additionally keeps the
+    // global embed lock for ML-resource serialization.
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          searchMode: "query",
+          update: { interval: "0s", debounceMs: 0, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+    spawnMock.mockImplementation(() => createMockChild());
+
+    const { manager } = await createManager({ mode: "status" });
+    await expect(manager.sync({ reason: "manual", force: true })).resolves.toBeUndefined();
+
+    const [lockPath, lockOptions, lockTask] = firstWriteLockCall();
+    // Per-store lock beside the agent qmd dir, distinct from the global embed lock.
+    expect(lockPath.endsWith("qmd-write.lock")).toBe(true);
+    expect(lockPath.endsWith(path.join("qmd", "embed.lock"))).toBe(false);
+    expect(lockOptions.retries.factor).toBe(1.2);
+    expect(lockOptions.retries.maxTimeout).toBe(10_000);
+    expect(lockOptions.retries.randomize).toBe(true);
+    expect(lockOptions.retries.retries).toBeGreaterThanOrEqual(60);
+    expect(lockOptions.stale).toBeGreaterThanOrEqual(5 * 60 * 1000);
+    expect(typeof lockTask).toBe("function");
+
+    // A forced sync runs both the update and the embed write, so both acquire the
+    // shared per-store write lock; the embed also still takes the global embed lock.
+    expect(writeLockCalls().length).toBeGreaterThanOrEqual(2);
+    const embedLockTaken = withFileLockMock.mock.calls.some((entry) =>
+      entry[0].endsWith(path.join("qmd", "embed.lock")),
+    );
+    expect(embedLockTaken).toBe(true);
+
+    await manager.close();
   });
 
   it("serializes session exports across managers for the same agent", async () => {

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -91,6 +91,16 @@ function emitAndClose(child: MockChild, stream: "stdout" | "stderr", data: strin
   });
 }
 
+async function waitUntil(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const startedAt = Date.now();
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error("Timed out waiting for condition");
+    }
+    await new Promise((resolve) => scheduleNativeTimeout(resolve, 10));
+  }
+}
+
 function isMcporterCommand(cmd: unknown): boolean {
   if (typeof cmd !== "string") {
     return false;
@@ -263,13 +273,15 @@ describe("QmdMemoryManager", () => {
   async function createManager(params?: {
     mode?: "full" | "status" | "cli";
     cfg?: OpenClawConfig;
+    agentId?: string;
   }) {
     const cfgToUse = params?.cfg ?? cfg;
-    const resolved = resolveMemoryBackendConfig({ cfg: cfgToUse, agentId });
+    const selectedAgentId = params?.agentId ?? agentId;
+    const resolved = resolveMemoryBackendConfig({ cfg: cfgToUse, agentId: selectedAgentId });
     const manager = trackManager(
       await QmdMemoryManager.create({
         cfg: cfgToUse,
-        agentId,
+        agentId: selectedAgentId,
         resolved,
         mode: params?.mode ?? "status",
       }),
@@ -289,7 +301,10 @@ describe("QmdMemoryManager", () => {
     spawnMock.mockClear();
     spawnMock.mockImplementation(() => createMockChild());
     watchMock.mockClear();
-    withFileLockMock.mockClear();
+    withFileLockMock.mockReset();
+    withFileLockMock.mockImplementation(
+      async <T>(_filePath: string, _options: unknown, fn: () => Promise<T>) => await fn(),
+    );
     logWarnMock.mockClear();
     logDebugMock.mockClear();
     logInfoMock.mockClear();
@@ -4149,6 +4164,66 @@ describe("QmdMemoryManager", () => {
     expect(embedLockTaken).toBe(true);
 
     await manager.close();
+  });
+
+  it("does not hold the per-store write lock while waiting for embed capacity", async () => {
+    cfg = {
+      ...cfg,
+      agents: {
+        ...cfg.agents,
+        list: [
+          { id: agentId, default: true, workspace: workspaceDir },
+          { id: "other", workspace: workspaceDir },
+        ],
+      },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          searchMode: "query",
+          update: { interval: "0s", debounceMs: 0, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+    spawnMock.mockImplementation(() => createMockChild());
+
+    let releaseFirstEmbed!: () => void;
+    const firstEmbedLocked = new Promise<void>((resolve) => {
+      withFileLockMock.mockImplementation(
+        async <T>(filePath: string, _options: unknown, fn: () => Promise<T>) => {
+          if (filePath.endsWith(path.join("qmd", "embed.lock")) && !releaseFirstEmbed) {
+            resolve();
+            await new Promise<void>((release) => {
+              releaseFirstEmbed = release;
+            });
+          }
+          return await fn();
+        },
+      );
+    });
+
+    const first = await createManager({ mode: "status" });
+    const second = await createManager({ mode: "status", agentId: "other" });
+    const firstSync = first.manager.sync({ reason: "manual", force: true });
+    await firstEmbedLocked;
+
+    const secondSync = second.manager.sync({ reason: "manual", force: true });
+    try {
+      await waitUntil(() => writeLockCalls().length >= 2);
+
+      // The second manager may run its update, but its embed must not take a store
+      // write lock while it is still queued behind the first embed.
+      expect(writeLockCalls().length).toBe(2);
+    } finally {
+      releaseFirstEmbed();
+    }
+
+    await Promise.all([firstSync, secondSync]);
+    expect(writeLockCalls().length).toBeGreaterThanOrEqual(4);
+
+    await first.manager.close();
+    await second.manager.close();
   });
 
   it("serializes session exports across managers for the same agent", async () => {

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -79,6 +79,7 @@ const NUL_MARKER_RE = /(?:\^@|\\0|\\x00|\\u0000|null\s*byte|nul\s*byte)/i;
 const QMD_EMBED_BACKOFF_BASE_MS = 60_000;
 const QMD_EMBED_BACKOFF_MAX_MS = 60 * 60 * 1000;
 const QMD_EMBED_LOCK_MIN_WAIT_MS = 15 * 60 * 1000;
+const QMD_WRITE_LOCK_MIN_WAIT_MS = 5 * 60 * 1000;
 const QMD_EMBED_LOCK_RETRY_TEMPLATE = {
   factor: 1.2,
   minTimeout: 250,
@@ -192,20 +193,37 @@ function resolveStableJitterMs(params: { seed: string; windowMs: number }): numb
   return bucket % (Math.floor(params.windowMs) + 1);
 }
 
-function resolveQmdEmbedLockOptions(embedTimeoutMs: number) {
-  const expectedEmbedMs = Math.max(1, embedTimeoutMs);
-  const waitBudgetMs = Math.max(QMD_EMBED_LOCK_MIN_WAIT_MS, expectedEmbedMs * 6);
+function resolveQmdWriteLockOptions(expectedMs: number, minWaitMs: number) {
+  const expected = Math.max(1, expectedMs);
+  const waitBudgetMs = Math.max(minWaitMs, expected * 6);
   return {
     retries: {
       retries: Math.max(60, Math.ceil(waitBudgetMs / QMD_EMBED_LOCK_RETRY_TEMPLATE.maxTimeout)),
       ...QMD_EMBED_LOCK_RETRY_TEMPLATE,
     },
-    stale: Math.max(QMD_EMBED_LOCK_MIN_WAIT_MS, expectedEmbedMs * 2),
+    stale: Math.max(minWaitMs, expected * 2),
   };
 }
 
 export function resolveQmdMcporterSearchProcessTimeoutMs(timeoutMs: number): number {
   return Math.max(addTimerTimeoutGraceMs(timeoutMs, 2_000) ?? 1, 5_000);
+}
+
+// Cross-process serialization for qmd embeds (heavy ML work, serialized globally).
+function resolveQmdEmbedLockOptions(embedTimeoutMs: number) {
+  return resolveQmdWriteLockOptions(embedTimeoutMs, QMD_EMBED_LOCK_MIN_WAIT_MS);
+}
+
+// One per-store write lock shared by the update and embed phases (both write the
+// same qmd index.sqlite), so a foreground `memory search` dirty-sync and a
+// background gateway update/embed never write the same store at once
+// (writer-vs-writer SQLITE_BUSY, #66339). Sized to the slower of the two writes
+// so a contending caller waits for the in-flight write instead of erroring.
+function resolveQmdStoreWriteLockOptions(updateTimeoutMs: number, embedTimeoutMs: number) {
+  return resolveQmdWriteLockOptions(
+    Math.max(updateTimeoutMs, embedTimeoutMs),
+    QMD_WRITE_LOCK_MIN_WAIT_MS,
+  );
 }
 
 function shouldIgnoreMemoryWatchPath(watchPath: string): boolean {
@@ -1534,12 +1552,18 @@ export class QmdMemoryManager implements MemorySearchManager {
       }
       if (this.shouldRunEmbed(force)) {
         try {
-          await this.withQmdEmbedLock(async () => {
-            await this.runQmd(["embed"], {
-              timeoutMs: this.qmd.update.embedTimeoutMs,
-              discardOutput: true,
-            });
-          });
+          // Take the per-store write lock first (W), then the global embed lock
+          // (E). Update only ever takes W, so this W->E order cannot deadlock with
+          // it, and a long update on this store no longer blocks other agents'
+          // embeds (we are not holding the global lock while waiting for W).
+          await this.withQmdStoreWriteLock(() =>
+            this.withQmdEmbedLock(async () => {
+              await this.runQmd(["embed"], {
+                timeoutMs: this.qmd.update.embedTimeoutMs,
+                discardOutput: true,
+              });
+            }),
+          );
           this.lastEmbedAt = Date.now();
           this.embedBackoffUntil = null;
           this.embedFailureCount = 0;
@@ -1772,6 +1796,25 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
   }
 
+  private async withQmdStoreWriteLock<T>(task: () => Promise<T>): Promise<T> {
+    // One per-store cross-process write lock guarding every qmd write (update and
+    // embed) against the same index.sqlite, so a foreground `memory search`
+    // dirty-sync and a background gateway update/embed never write concurrently
+    // (writer-vs-writer SQLITE_BUSY, #66339). It lives beside the agent's qmd dir,
+    // so writes for different agents still run in parallel. Update takes only this
+    // lock; embed takes this lock before the global embed lock, so the two never
+    // form a cross-lock cycle.
+    const lockPath = path.join(this.agentStateDir, "qmd-write.lock");
+    return await withFileLock(
+      lockPath,
+      resolveQmdStoreWriteLockOptions(
+        this.qmd.update.updateTimeoutMs,
+        this.qmd.update.embedTimeoutMs,
+      ),
+      task,
+    );
+  }
+
   private async withQmdUpdateQueue<T>(task: () => Promise<T>): Promise<T> {
     const queue = getQmdUpdateQueueState();
     const key = this.qmdDir;
@@ -1796,7 +1839,11 @@ export class QmdMemoryManager implements MemorySearchManager {
       if (waitResult === "closed") {
         return undefined as T;
       }
-      return await task();
+      // Serialize the update write across processes (gateway + CLI). The in-process
+      // queue above is keyed per store but a separate process cannot see it. The
+      // shared per-store write lock also serializes against the embed write below,
+      // which targets the same index.sqlite.
+      return await this.withQmdStoreWriteLock(task);
     } finally {
       releaseCurrent();
       void next.finally(() => {

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -1552,17 +1552,18 @@ export class QmdMemoryManager implements MemorySearchManager {
       }
       if (this.shouldRunEmbed(force)) {
         try {
-          // Take the per-store write lock first (W), then the global embed lock
-          // (E). Update only ever takes W, so this W->E order cannot deadlock with
-          // it, and a long update on this store no longer blocks other agents'
-          // embeds (we are not holding the global lock while waiting for W).
-          await this.withQmdStoreWriteLock(() =>
-            this.withQmdEmbedLock(async () => {
-              await this.runQmd(["embed"], {
-                timeoutMs: this.qmd.update.embedTimeoutMs,
-                discardOutput: true,
-              });
-            }),
+          // Wait for embed capacity before taking the per-store write lock. The
+          // store lock should protect active qmd writes only, not time spent queued
+          // behind unrelated agents' embeds.
+          await this.withQmdEmbedQueue(() =>
+            this.withQmdGlobalEmbedLock(() =>
+              this.withQmdStoreWriteLock(async () => {
+                await this.runQmd(["embed"], {
+                  timeoutMs: this.qmd.update.embedTimeoutMs,
+                  discardOutput: true,
+                });
+              }),
+            ),
           );
           this.lastEmbedAt = Date.now();
           this.embedBackoffUntil = null;
@@ -1772,8 +1773,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     });
   }
 
-  private async withQmdEmbedLock<T>(task: () => Promise<T>): Promise<T> {
-    const lockPath = path.join(this.stateDir, "qmd", "embed.lock");
+  private async withQmdEmbedQueue<T>(task: () => Promise<T>): Promise<T> {
     const queue = getQmdEmbedQueueState();
     const previous = queue.tail;
     let releaseCurrent!: () => void;
@@ -1786,14 +1786,19 @@ export class QmdMemoryManager implements MemorySearchManager {
     );
     await previous.catch(() => undefined);
     try {
-      return await withFileLock(
-        lockPath,
-        resolveQmdEmbedLockOptions(this.qmd.update.embedTimeoutMs),
-        task,
-      );
+      return await task();
     } finally {
       releaseCurrent();
     }
+  }
+
+  private async withQmdGlobalEmbedLock<T>(task: () => Promise<T>): Promise<T> {
+    const lockPath = path.join(this.stateDir, "qmd", "embed.lock");
+    return await withFileLock(
+      lockPath,
+      resolveQmdEmbedLockOptions(this.qmd.update.embedTimeoutMs),
+      task,
+    );
   }
 
   private async withQmdStoreWriteLock<T>(task: () => Promise<T>): Promise<T> {
@@ -1802,8 +1807,8 @@ export class QmdMemoryManager implements MemorySearchManager {
     // dirty-sync and a background gateway update/embed never write concurrently
     // (writer-vs-writer SQLITE_BUSY, #66339). It lives beside the agent's qmd dir,
     // so writes for different agents still run in parallel. Update takes only this
-    // lock; embed takes this lock before the global embed lock, so the two never
-    // form a cross-lock cycle.
+    // lock; embed first waits for global embed capacity, then takes this lock for
+    // the active qmd write.
     const lockPath = path.join(this.agentStateDir, "qmd-write.lock");
     return await withFileLock(
       lockPath,


### PR DESCRIPTION
### Summary

- **Problem**: With the gateway running, `openclaw memory search` intermittently logs `qmd update retry … (boot)` and `SQLiteError: database is locked` (e.g. from `cleanupOrphanedContent(...)` / `clearCache(...)`), making recall feel flaky — worst right after boot or right after new daily‑memory content was written. It persists even with `memory.qmd.update.onBoot = false`.
- **Root Cause**: The QMD manager has two write paths that both target the **same** per‑agent `index.sqlite` — `qmd update` (FTS/content) and `qmd embed` (vectors) — but they serialized inconsistently. The embed path took a cross‑process file lock; the update path only had an in‑process promise queue (which a separate process cannot see), and the two write paths used **different** lock files, so they did not exclude each other either. So a foreground `memory search` dirty‑sync (which calls `sync({ reason: "search" })` → `qmd update`) and a background gateway update/embed run against the same store at the same time. WAL plus `busy_timeout=5000` (set on the OpenClaw connection) do not help writer‑vs‑writer contention, and they do not govern the `qmd` binary's own writes — so the second writer hits `SQLITE_BUSY`.
- **Fix**: Add one per‑store cross‑process write lock (`qmd-write.lock`, beside the agent's qmd dir) that **both** the update and the embed write acquire, so no two qmd writes hit a given store at once across processes, while writes for different agents still run in parallel. The embed path keeps its existing global embed lock for ML‑resource serialization and takes the per‑store write lock **first** (write‑lock → embed‑lock); the update path takes only the write lock. Because update never takes the embed lock, the two cannot form a cross‑lock cycle (no deadlock), and taking the per‑store lock before the global one means a long update no longer blocks other agents' embeds. The in‑process queues are kept (they still cheaply dedupe within a process); a contending caller waits for the in‑flight write (bounded by the slower of the update/embed timeouts) and then proceeds instead of erroring.
- **What changed**:
  - `extensions/memory-core/src/memory/qmd-manager.ts`: add `withQmdStoreWriteLock` (one per‑store `qmd-write.lock`); the update write and the embed write both run inside it; lock options sized to `max(updateTimeoutMs, embedTimeoutMs)`; embed takes the write lock before the global embed lock. The embed/update/write lock‑option builders share one helper.
  - `extensions/memory-core/src/memory/qmd-manager.test.ts`: regression coverage that a forced sync routes both the update and the embed write through the per‑store `qmd-write.lock` while the embed also still takes the global embed lock; the existing embed‑lock helper selects its call by lock path.
- **What did NOT change (scope boundary)**:
  - The global embed lock (ML‑resource serialization across agents) is unchanged; the embed simply also takes the per‑store write lock. The in‑process update/embed queue semantics, the update retry/repair logic, and the `qmd` invocation are unchanged. Embed lock options resolve to exactly the same values as before.
  - No config keys, protocol, or search/result behavior changed. Single‑process behavior is unchanged; the new lock only adds cross‑process serialization for qmd writes.

### Reproduction

1. Run a gateway with the `qmd` memory backend and some daily‑memory content (e.g. `dreaming.enabled = true`), so the gateway periodically runs `qmd update`/`qmd embed`.
2. While the gateway is running, run `openclaw memory search …` (or write new memory then search), so the CLI process also triggers a `qmd update` dirty‑sync.
- Before: the two processes write the same `index.sqlite` concurrently and the second hits `SQLITE_BUSY` / `database is locked` (logged as `qmd update retry …`).
- After: qmd writes for a store are serialized across processes; the second waits for the first to finish, then runs cleanly.

### Real behavior proof

- **Behavior addressed**: two processes running a qmd write transaction against the same memory SQLite store must not collide with `SQLITE_BUSY`; both the update and embed writes must serialize across processes on one per‑store lock.
- **Real environment tested**: a deterministic harness using **two real OS child processes**, real `node:sqlite` `DatabaseSync` opened with the exact settings OpenClaw uses for this store (`journal_mode = WAL` + `busy_timeout = 5000`, matching `manager-db.ts`), and the **real `withFileLock`** from `openclaw/plugin-sdk/file-lock` (the same primitive both write paths use). The two writers model two same‑store qmd writers (e.g. an update and an embed) sharing one per‑store write lock. Linux, Node 22. Writer A takes the write lock and holds it ~8s; writer B is the contending second writer.
- **Exact steps or command run after this patch**: `node /tmp/qmd66339/repro.mjs` — Phase 1 runs the two writers with no shared lock (the pre‑fix state); Phase 2 runs them with each write wrapped in `withFileLock` on one shared lock file (this fix). The harness waits for A to actually hold the write lock before starting B, so the outcome is deterministic.
- **Evidence after fix (verbatim harness output, no color codes)**:

```text
=== PHASE 1 — current behavior (no shared cross-process write lock) (useLock=false) ===
[harness] A holding write lock; starting B (the contending writer) ...
[harness] A: READY | A_OK
[harness] B: B_ERR code=ERR_SQLITE_ERROR errcode=5 errstr=database is locked msg=database is locked  (B finished after 5663ms)

=== PHASE 2 — proposed fix (both writes wrapped in one cross-process write lock) (useLock=true) ===
[harness] A holding write lock; starting B (the contending writer) ...
[harness] A: READY | A_OK
[harness] B: B_OK  (B finished after 8551ms)

================ VERDICT ================
Phase 1 (no lock):   B HIT SQLITE_BUSY ✅ (collision reproduced)
Phase 2 (with lock): B succeeded ✅ (serialized, waited 8551ms for A)

RESULT: PASS — collision reproduced AND fixed by the shared cross-process write lock
```

- **Observed result after fix**: without the shared lock the second writer waits out `busy_timeout` (~5.7s) and then fails with `errcode=5` (`SQLITE_BUSY`, `database is locked`) — exactly the reporter's `SQLiteError: database is locked`. With both writes wrapped in one shared `withFileLock`, the second writer waits for the holder (~8.6s) and then succeeds; no collision.
- **Code‑path coverage**: `pnpm test extensions/memory-core/src/memory/qmd-manager.test.ts` (107 passed) including a case asserting a forced sync routes both the update and embed writes through the per‑store `qmd-write.lock` while the embed still takes the global embed lock.
- **What was not tested**: the `qmd` binary is not installed in this environment, so the harness reproduces the SQLite‑level writer‑vs‑writer contention and the lock fix using OpenClaw's exact connection settings and the real lock primitive rather than driving two real `qmd` subprocesses. A full real‑`qmd`, gateway‑plus‑CLI concurrent run on a machine with the binary installed is the remaining end‑to‑end check.

### Risk / Mitigation

- **Risk**: a cross‑process lock could make a foreground `memory search` wait, deadlock against the embed lock, or be held by a crashed process.
- **Mitigation**: a contending caller waits at most for the in‑flight write (bounded by the update/embed timeout) and then proceeds — strictly better than today's `SQLITE_BUSY`, and consistent with the existing in‑process `waitForPendingUpdateBeforeSearch`. No deadlock: update takes only the per‑store write lock, embed takes it before the global embed lock, so there is no opposing lock‑acquisition order. The lock uses the same stale/dead‑owner recovery as the embed lock (`staleRecovery: remove-if-unchanged` plus dead‑pid reclaim), so a crashed holder's lock is reclaimed. Cross‑agent writes still run in parallel (the lock is per store), and the global embed lock's behavior is unchanged.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Memory / search
- [x] Skills / tool execution

### Linked Issue/PR

Fixes #66339
