### PR TITLE
fix(voice-call): suppress duplicate OpenAI initial greeting (#85846)

### DIFF
--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -864,6 +864,176 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     );
   });
 
+  it("preserves autoRespondToAudio from raw provider config", () => {
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    const resolved = provider.resolveConfig?.({
+      cfg: {} as never,
+      rawConfig: {
+        providers: {
+          openai: {
+            autoRespondToAudio: false,
+          },
+        },
+      },
+    });
+
+    expect(resolved).toEqual({ autoRespondToAudio: false });
+  });
+
+  it("suppresses server-VAD auto-response during the initial greeting and restores it on response.done", async () => {
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
+      autoRespondToAudio: false,
+      restoreAutoRespondToAudioAfterInitialGreeting: true,
+      instructions: "Greet the caller.",
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+    const connecting = bridge.connect();
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) {
+      throw new Error("expected bridge to create a websocket");
+    }
+
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    expectRecordFields(
+      requireNestedRecord(requireSession(socket, 0), ["audio", "input", "turn_detection"]),
+      "initial turn detection",
+      {
+        create_response: false,
+        interrupt_response: false,
+      },
+    );
+
+    bridge.triggerGreeting?.("Say hi for issue 85846.");
+
+    const sentTypesAfterGreeting = parseSent(socket).map((event) => event.type);
+    expect(sentTypesAfterGreeting).toEqual([
+      "session.update",
+      "conversation.item.create",
+      "response.create",
+    ]);
+
+    socket.emit(
+      "message",
+      Buffer.from(JSON.stringify({ type: "response.created", response: { id: "resp_1" } })),
+    );
+    socket.emit(
+      "message",
+      Buffer.from(JSON.stringify({ type: "response.done", response: { id: "resp_1" } })),
+    );
+
+    const finalTypes = parseSent(socket).map((event) => event.type);
+    expect(finalTypes).toEqual([
+      "session.update",
+      "conversation.item.create",
+      "response.create",
+      "session.update",
+    ]);
+    expectRecordFields(
+      requireNestedRecord(requireSession(socket, 3), ["audio", "input", "turn_detection"]),
+      "restored turn detection",
+      {
+        create_response: true,
+        interrupt_response: true,
+      },
+    );
+
+    socket.emit(
+      "message",
+      Buffer.from(JSON.stringify({ type: "response.created", response: { id: "resp_2" } })),
+    );
+    socket.emit(
+      "message",
+      Buffer.from(JSON.stringify({ type: "response.done", response: { id: "resp_2" } })),
+    );
+
+    expect(parseSent(socket).filter((event) => event.type === "session.update")).toHaveLength(2);
+  });
+
+  it("restores server-VAD auto-response after an initial greeting is cancelled", async () => {
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
+      autoRespondToAudio: false,
+      restoreAutoRespondToAudioAfterInitialGreeting: true,
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+    const connecting = bridge.connect();
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) {
+      throw new Error("expected bridge to create a websocket");
+    }
+
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    bridge.triggerGreeting?.("Say hi.");
+    socket.emit(
+      "message",
+      Buffer.from(JSON.stringify({ type: "response.created", response: { id: "resp_1" } })),
+    );
+    socket.emit(
+      "message",
+      Buffer.from(JSON.stringify({ type: "response.cancelled", response: { id: "resp_1" } })),
+    );
+
+    const finalTypes = parseSent(socket).map((event) => event.type);
+    expect(finalTypes.filter((type) => type === "session.update")).toHaveLength(2);
+    expectRecordFields(
+      requireNestedRecord(requireSession(socket, finalTypes.lastIndexOf("session.update")), [
+        "audio",
+        "input",
+        "turn_detection",
+      ]),
+      "restored turn detection",
+      {
+        create_response: true,
+        interrupt_response: true,
+      },
+    );
+  });
+
+  it("does not send a restore session.update when restoreAutoRespondToAudioAfterInitialGreeting is not set", async () => {
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
+      autoRespondToAudio: false,
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+    const connecting = bridge.connect();
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) {
+      throw new Error("expected bridge to create a websocket");
+    }
+
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    bridge.triggerGreeting?.("Say hi.");
+    socket.emit(
+      "message",
+      Buffer.from(JSON.stringify({ type: "response.created", response: { id: "resp_1" } })),
+    );
+    socket.emit(
+      "message",
+      Buffer.from(JSON.stringify({ type: "response.done", response: { id: "resp_1" } })),
+    );
+
+    expect(parseSent(socket).filter((event) => event.type === "session.update")).toHaveLength(1);
+  });
+
   it("can disable realtime response interruption while keeping audio responses enabled", async () => {
     const provider = buildOpenAIRealtimeVoiceProvider();
     const bridge = provider.createBridge({

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -60,6 +60,7 @@ type OpenAIRealtimeVoiceProviderConfig = {
   vadThreshold?: number;
   silenceDurationMs?: number;
   prefixPaddingMs?: number;
+  autoRespondToAudio?: boolean;
   interruptResponseOnInputAudio?: boolean;
   minBargeInAudioEndMs?: number;
   reasoningEffort?: string;
@@ -213,6 +214,8 @@ function normalizeProviderConfig(
     vadThreshold: asFiniteNumber(raw?.vadThreshold),
     silenceDurationMs: asFiniteNumber(raw?.silenceDurationMs),
     prefixPaddingMs: asFiniteNumber(raw?.prefixPaddingMs),
+    autoRespondToAudio:
+      typeof raw?.autoRespondToAudio === "boolean" ? raw.autoRespondToAudio : undefined,
     interruptResponseOnInputAudio:
       typeof raw?.interruptResponseOnInputAudio === "boolean"
         ? raw.interruptResponseOnInputAudio
@@ -370,6 +373,9 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   private deliveredToolCallKeys = new Set<string>();
   private readonly flowId = randomUUID();
   private sessionReadyFired = false;
+  private initialGreetingRestoreStarted = false;
+  private waitingForInitialGreetingDone = false;
+  private autoResponseRestored = false;
   private readonly audioFormat: RealtimeVoiceAudioFormat;
 
   constructor(private readonly config: OpenAIRealtimeVoiceBridgeConfig) {
@@ -414,6 +420,13 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   triggerGreeting(instructions?: string): void {
     if (!this.isConnected() || !this.ws) {
       return;
+    }
+    if (
+      this.config.restoreAutoRespondToAudioAfterInitialGreeting === true &&
+      !this.initialGreetingRestoreStarted
+    ) {
+      this.initialGreetingRestoreStarted = true;
+      this.waitingForInitialGreetingDone = true;
     }
     this.sendUserMessage(instructions ?? this.config.instructions ?? "Greet the meeting.");
   }
@@ -933,6 +946,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         this.responseActive = false;
         this.responseCreateInFlight = false;
         this.responseCancelInFlight = false;
+        this.maybeRestoreAutoResponseAfterInitialGreeting();
         this.flushPendingResponseCreate();
         return;
 
@@ -1104,6 +1118,26 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
     }
     this.responseCreatePending = false;
     this.requestResponseCreate();
+  }
+
+  private maybeRestoreAutoResponseAfterInitialGreeting(): void {
+    if (!this.waitingForInitialGreetingDone || this.autoResponseRestored) {
+      return;
+    }
+    this.waitingForInitialGreetingDone = false;
+    this.autoResponseRestored = true;
+    const turnDetection: RealtimeTurnDetectionConfig = {
+      type: "server_vad",
+      threshold: this.config.vadThreshold ?? 0.5,
+      prefix_padding_ms: this.config.prefixPaddingMs ?? 300,
+      silence_duration_ms: this.config.silenceDurationMs ?? 500,
+      create_response: true,
+      interrupt_response: true,
+    };
+    const session = this.usesAzureDeploymentRealtimeApi()
+      ? { turn_detection: turnDetection }
+      : { audio: { input: { turn_detection: turnDetection } } };
+    this.sendEvent({ type: "session.update", session }, "reason=initial-greeting-complete");
   }
 
   private resetRealtimeSessionState(): void {
@@ -1301,6 +1335,7 @@ export function buildOpenAIRealtimeVoiceProvider(): RealtimeVoiceProviderPlugin 
         vadThreshold: config.vadThreshold,
         silenceDurationMs: config.silenceDurationMs,
         prefixPaddingMs: config.prefixPaddingMs,
+        autoRespondToAudio: req.autoRespondToAudio ?? config.autoRespondToAudio,
         interruptResponseOnInputAudio:
           req.interruptResponseOnInputAudio ?? config.interruptResponseOnInputAudio,
         minBargeInAudioEndMs: config.minBargeInAudioEndMs,

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -454,6 +454,122 @@ describe("RealtimeCallHandler path routing", () => {
     }
   });
 
+  it("suppresses OpenAI server-VAD auto response when an outbound initial greeting is queued for issue85846", async () => {
+    let callbacks: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0] | undefined;
+    const triggerGreeting = vi.fn();
+    const createBridge = vi.fn(
+      (request: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0]) => {
+        callbacks = request;
+        return makeBridge({ triggerGreeting });
+      },
+    );
+    const getCallByProviderCallId = vi.fn(
+      (): CallRecord => ({
+        callId: "call-issue85846",
+        providerCallId: "CA-issue85846",
+        provider: "twilio",
+        direction: "outbound",
+        state: "ringing",
+        from: "+15550001234",
+        to: "+15550009999",
+        startedAt: Date.now(),
+        transcript: [],
+        processedEventIds: [],
+        metadata: {
+          initialMessage: "Hi! Just a quick test of the voice setup.",
+        },
+      }),
+    );
+    const handler = makeHandler(undefined, {
+      manager: { getCallByProviderCallId },
+      realtimeProvider: makeRealtimeProvider(createBridge),
+    });
+    const server = await startRealtimeServer(handler);
+
+    try {
+      const ws = await connectWs(server.url);
+      try {
+        ws.send(
+          JSON.stringify({
+            event: "start",
+            start: { streamSid: "MZ-issue85846", callSid: "CA-issue85846" },
+          }),
+        );
+        await waitForRealtimeTest(() => {
+          expect(createBridge).toHaveBeenCalled();
+        });
+
+        expect(callbacks?.autoRespondToAudio).toBe(false);
+        expect(callbacks?.restoreAutoRespondToAudioAfterInitialGreeting).toBe(true);
+        callbacks?.onReady?.();
+        expect(triggerGreeting).toHaveBeenCalledTimes(1);
+        expect(triggerGreeting).toHaveBeenCalledWith(
+          expect.stringContaining("Hi! Just a quick test of the voice setup."),
+        );
+      } finally {
+        if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+          ws.close();
+        }
+      }
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("does not suppress OpenAI server-VAD auto response when no initial greeting is queued", async () => {
+    let callbacks: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0] | undefined;
+    const createBridge = vi.fn(
+      (request: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0]) => {
+        callbacks = request;
+        return makeBridge();
+      },
+    );
+    const getCallByProviderCallId = vi.fn(
+      (): CallRecord => ({
+        callId: "call-no-greeting",
+        providerCallId: "CA-no-greeting",
+        provider: "twilio",
+        direction: "outbound",
+        state: "ringing",
+        from: "+15550001234",
+        to: "+15550009999",
+        startedAt: Date.now(),
+        transcript: [],
+        processedEventIds: [],
+        metadata: {},
+      }),
+    );
+    const handler = makeHandler(undefined, {
+      manager: { getCallByProviderCallId },
+      realtimeProvider: makeRealtimeProvider(createBridge),
+    });
+    const server = await startRealtimeServer(handler);
+
+    try {
+      const ws = await connectWs(server.url);
+      try {
+        ws.send(
+          JSON.stringify({
+            event: "start",
+            start: { streamSid: "MZ-no-greeting", callSid: "CA-no-greeting" },
+          }),
+        );
+        await waitForRealtimeTest(() => {
+          expect(createBridge).toHaveBeenCalled();
+        });
+
+        expect(callbacks?.autoRespondToAudio).toBeUndefined();
+        expect(callbacks?.restoreAutoRespondToAudioAfterInitialGreeting).toBeUndefined();
+      } finally {
+        if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+          ws.close();
+        }
+      }
+    } finally {
+      await server.close();
+    }
+  });
+
   it("speaks through the active outbound realtime bridge by call id", async () => {
     const triggerGreeting = vi.fn();
     const createBridge = vi.fn(() => makeBridge({ triggerGreeting }));

--- a/src/talk/provider-types.ts
+++ b/src/talk/provider-types.ts
@@ -106,6 +106,13 @@ export type RealtimeVoiceBridgeCreateRequest = RealtimeVoiceBridgeCallbacks & {
   instructions?: string;
   autoRespondToAudio?: boolean;
   interruptResponseOnInputAudio?: boolean;
+  /**
+   * The runtime is starting the session with `autoRespondToAudio: false` only so its own
+   * initial greeting is the single first-turn source. Providers that arm a server-side
+   * auto-response (e.g. OpenAI server VAD) should re-enable it once the first manual
+   * greeting reaches a terminal response event so later turns auto-respond normally.
+   */
+  restoreAutoRespondToAudioAfterInitialGreeting?: boolean;
   tools?: RealtimeVoiceTool[];
 };
 

--- a/src/talk/session-runtime.test.ts
+++ b/src/talk/session-runtime.test.ts
@@ -289,4 +289,103 @@ describe("realtime voice bridge session runtime", () => {
     expect(onReady).toHaveBeenCalledWith(session);
     expect(onToolCall).toHaveBeenCalledWith(event, session);
   });
+
+  it("suppresses initial OpenAI auto-response when triggering an explicit greeting", () => {
+    let request: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0] | undefined;
+    const provider: RealtimeVoiceProviderPlugin = {
+      id: "openai",
+      label: "OpenAI",
+      isConfigured: () => true,
+      createBridge: (nextRequest) => {
+        request = nextRequest;
+        return makeBridge();
+      },
+    };
+
+    createRealtimeVoiceBridgeSession({
+      provider,
+      providerConfig: {},
+      audioSink: { sendAudio: vi.fn() },
+      initialGreetingInstructions: "Say hello",
+      triggerGreetingOnReady: true,
+    });
+
+    const bridgeRequest = expectBridgeRequest(request);
+    expect(bridgeRequest.autoRespondToAudio).toBe(false);
+    expect(bridgeRequest.restoreAutoRespondToAudioAfterInitialGreeting).toBe(true);
+  });
+
+  it("respects an explicit autoRespondToAudio:false even when triggering an OpenAI greeting", () => {
+    let request: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0] | undefined;
+    const provider: RealtimeVoiceProviderPlugin = {
+      id: "openai",
+      label: "OpenAI",
+      isConfigured: () => true,
+      createBridge: (nextRequest) => {
+        request = nextRequest;
+        return makeBridge();
+      },
+    };
+
+    createRealtimeVoiceBridgeSession({
+      provider,
+      providerConfig: {},
+      audioSink: { sendAudio: vi.fn() },
+      autoRespondToAudio: false,
+      initialGreetingInstructions: "Say hello",
+      triggerGreetingOnReady: true,
+    });
+
+    const bridgeRequest = expectBridgeRequest(request);
+    expect(bridgeRequest.autoRespondToAudio).toBe(false);
+    expect(bridgeRequest.restoreAutoRespondToAudioAfterInitialGreeting).toBeUndefined();
+  });
+
+  it("does not enable suppression for non-OpenAI providers triggering greetings", () => {
+    let request: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0] | undefined;
+    const provider: RealtimeVoiceProviderPlugin = {
+      id: "google",
+      label: "Google",
+      isConfigured: () => true,
+      createBridge: (nextRequest) => {
+        request = nextRequest;
+        return makeBridge();
+      },
+    };
+
+    createRealtimeVoiceBridgeSession({
+      provider,
+      providerConfig: {},
+      audioSink: { sendAudio: vi.fn() },
+      initialGreetingInstructions: "Say hello",
+      triggerGreetingOnReady: true,
+    });
+
+    const bridgeRequest = expectBridgeRequest(request);
+    expect(bridgeRequest.autoRespondToAudio).toBeUndefined();
+    expect(bridgeRequest.restoreAutoRespondToAudioAfterInitialGreeting).toBeUndefined();
+  });
+
+  it("does not enable suppression when no initial greeting is triggered on OpenAI", () => {
+    let request: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0] | undefined;
+    const provider: RealtimeVoiceProviderPlugin = {
+      id: "openai",
+      label: "OpenAI",
+      isConfigured: () => true,
+      createBridge: (nextRequest) => {
+        request = nextRequest;
+        return makeBridge();
+      },
+    };
+
+    createRealtimeVoiceBridgeSession({
+      provider,
+      providerConfig: {},
+      audioSink: { sendAudio: vi.fn() },
+    });
+
+    const bridgeRequest = expectBridgeRequest(request);
+    expect(bridgeRequest.autoRespondToAudio).toBeUndefined();
+    expect(bridgeRequest.restoreAutoRespondToAudioAfterInitialGreeting).toBeUndefined();
+  });
 });

--- a/src/talk/session-runtime.ts
+++ b/src/talk/session-runtime.ts
@@ -82,13 +82,23 @@ export function createRealtimeVoiceBridgeSession(
     triggerGreeting: (instructions) => requireBridge().triggerGreeting?.(instructions),
   };
   const canSendAudio = () => params.audioSink.isOpen?.() ?? true;
+  const suppressOpenAiInitialAutoResponse =
+    params.provider.id === "openai" &&
+    params.triggerGreetingOnReady === true &&
+    params.autoRespondToAudio !== false;
+  const bridgeAutoRespondToAudio = suppressOpenAiInitialAutoResponse
+    ? false
+    : params.autoRespondToAudio;
   bridge = params.provider.createBridge({
     cfg: params.cfg,
     providerConfig: params.providerConfig,
     audioFormat: params.audioFormat,
     instructions: params.instructions,
-    autoRespondToAudio: params.autoRespondToAudio,
+    autoRespondToAudio: bridgeAutoRespondToAudio,
     interruptResponseOnInputAudio: params.interruptResponseOnInputAudio,
+    ...(suppressOpenAiInitialAutoResponse
+      ? { restoreAutoRespondToAudioAfterInitialGreeting: true }
+      : {}),
     tools: params.tools,
     onAudio: (audio) => {
       if (canSendAudio()) {


### PR DESCRIPTION
Fixes #85846

## Summary
Outbound OpenAI realtime voice calls with an initial message could arm two first-turn response sources: OpenClaw's explicit `triggerGreeting()` path and OpenAI server VAD `create_response`. This keeps the explicit greeting as the startup owner by temporarily disabling OpenAI server-VAD auto-response for the initial greeting, then restoring auto-response after that manual greeting reaches a terminal response event.

## Changes
- `src/talk/provider-types.ts` - add an optional restore flag for providers that need to re-enable server-side audio auto-response after the initial greeting.
- `src/talk/session-runtime.ts` - suppress OpenAI auto-response only for initial-greeting sessions where `autoRespondToAudio` was not explicitly disabled.
- `extensions/openai/realtime-voice-provider.ts` - preserve `autoRespondToAudio` provider config, emit initial OpenAI session config with `create_response: false`, and restore `create_response: true` after `response.done` or `response.cancelled`.
- `extensions/voice-call/src/webhook/realtime-handler.test.ts` - add the regression test that fails before the fix and a no-greeting control case.
- `extensions/openai/realtime-voice-provider.test.ts` and `src/talk/session-runtime.test.ts` - cover OpenAI-only suppression, explicit false preservation, restore-on-done, restore-on-cancelled, and no-restore negative cases.

## Tests
- Added failing test reproducing the issue: `extensions/voice-call/src/webhook/realtime-handler.test.ts`
- Additional tests: `extensions/openai/realtime-voice-provider.test.ts`, `src/talk/session-runtime.test.ts`
- Local checks: install ok, build ok, check ok, focused regression tests ok

## Real Behavior Proof
Behavior addressed: OpenAI realtime outbound voice calls with an initial greeting no longer allow server VAD to auto-create a competing startup response before the explicit greeting path speaks.

Real environment tested: Local macOS checkout, Node 24 via `pnpm dlx node@24`, pnpm 11.2.2, mocked realtime WebSocket/unit-level voice-call path.

Exact steps or command run after this patch: `CI=true pnpm dlx pnpm@11.2.2 install --frozen-lockfile`; `pnpm dlx node@24 scripts/build-all.mjs`; `pnpm dlx pnpm@11.2.2 check`; `pnpm dlx node@24 scripts/run-vitest.mjs extensions/openai/realtime-voice-provider.test.ts extensions/voice-call/src/webhook/realtime-handler.test.ts src/talk/session-runtime.test.ts`

Evidence after fix: The red-phase test failed before the implementation with `expected undefined to be false`; on the fixed branch the focused suite passed with 3 files and 81 tests.

Observed result after fix: OpenAI bridge creation receives `autoRespondToAudio: false` plus the restore flag for outbound initial-greeting sessions, sends one explicit greeting `response.create`, and later sends one restore `session.update` with `create_response: true`.

What was not tested: A live Twilio/OpenAI phone call was not run because this review environment does not provide those credentials.

## Notes for Maintainer
- The restore uses a partial `session.update` scoped to turn detection rather than re-sending full session config.
- The initial-greeting restore is currently triggered on `response.done` and `response.cancelled`; generic realtime `error` events still flow through the existing error handler.
