### PR TITLE
fix: preserve plugin LLM command auth

### DIFF
--- a/extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts
+++ b/extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts
@@ -13,6 +13,7 @@ import {
   setActivePluginRegistry,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { dispatchReplyWithDispatcher } from "openclaw/plugin-sdk/reply-dispatch-runtime";
+import { getSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { defineThrowingDiscordChannelGetter } from "../test-support/partial-channel.js";
 import { resolveDiscordNativeInteractionRouteState } from "./native-command-route.js";
@@ -29,6 +30,7 @@ const runtimeModuleMocks = vi.hoisted(() => ({
   executePluginCommand: vi.fn(),
   dispatchReplyWithDispatcher: vi.fn(),
   resolveDirectStatusReplyForSession: vi.fn(),
+  getSessionEntry: vi.fn(),
 }));
 
 function createConfig(): OpenClawConfig {
@@ -408,6 +410,7 @@ describe("Discord native plugin command dispatch", () => {
     discordNativeCommandTesting.setResolveDiscordNativeInteractionRouteState(
       resolveDiscordNativeInteractionRouteState,
     );
+    discordNativeCommandTesting.setGetSessionEntry(getSessionEntry);
   });
 
   beforeEach(() => {
@@ -430,6 +433,8 @@ describe("Discord native plugin command dispatch", () => {
     runtimeModuleMocks.resolveDirectStatusReplyForSession.mockResolvedValue({
       text: "status reply",
     });
+    runtimeModuleMocks.getSessionEntry.mockReset();
+    runtimeModuleMocks.getSessionEntry.mockReturnValue(undefined);
     discordNativeCommandTesting.setMatchPluginCommand(
       runtimeModuleMocks.matchPluginCommand as typeof import("openclaw/plugin-sdk/plugin-runtime").matchPluginCommand,
     );
@@ -449,6 +454,9 @@ describe("Discord native plugin command dispatch", () => {
           : `agent:main:discord:channel:${params.conversationId}`,
         accountId: params.accountId,
       }),
+    );
+    discordNativeCommandTesting.setGetSessionEntry(
+      runtimeModuleMocks.getSessionEntry as typeof import("openclaw/plugin-sdk/session-store-runtime").getSessionEntry,
     );
   });
 
@@ -473,6 +481,43 @@ describe("Discord native plugin command dispatch", () => {
       cfg,
       commandName: "pairdiscord",
       interaction,
+    });
+  });
+
+  it("passes the active auth profile to Discord plugin commands", async () => {
+    const cfg = createConfig();
+    const interaction = createInteraction();
+    runtimeModuleMocks.getSessionEntry.mockReturnValue({
+      sessionId: "discord-session",
+      authProfileOverride: "openai-codex:owner@example.com",
+      updatedAt: Date.now(),
+    });
+
+    registerPairPlugin();
+    const command = await createPluginCommand({
+      cfg,
+      name: "pair",
+    });
+    const executeSpy = runtimeModuleMocks.executePluginCommand.mockResolvedValue({
+      text: "paired:now",
+    });
+
+    await (command as { run: (interaction: unknown) => Promise<void> }).run(
+      Object.assign(interaction, {
+        options: {
+          getString: () => "now",
+          getBoolean: () => null,
+          getFocused: () => "",
+        },
+      }) as unknown,
+    );
+
+    expectPluginCommandExecution({
+      mock: executeSpy,
+      commandName: "pair",
+      expected: {
+        authProfileId: "openai-codex:owner@example.com",
+      },
     });
   });
 

--- a/extensions/discord/src/monitor/native-command.runtime.ts
+++ b/extensions/discord/src/monitor/native-command.runtime.ts
@@ -1,6 +1,7 @@
 import { resolveDirectStatusReplyForSession } from "openclaw/plugin-sdk/command-status-runtime";
 import * as pluginRuntime from "openclaw/plugin-sdk/plugin-runtime";
 import { dispatchReplyWithDispatcher } from "openclaw/plugin-sdk/reply-dispatch-runtime";
+import { getSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { resolveDiscordNativeInteractionRouteState } from "./native-command-route.js";
 
 export const nativeCommandRuntime = {
@@ -9,6 +10,7 @@ export const nativeCommandRuntime = {
   dispatchReplyWithDispatcher,
   resolveDirectStatusReplyForSession,
   resolveDiscordNativeInteractionRouteState,
+  getSessionEntry,
 };
 
 export const testing = {
@@ -45,6 +47,11 @@ export const testing = {
   ): typeof resolveDiscordNativeInteractionRouteState {
     const previous = nativeCommandRuntime.resolveDiscordNativeInteractionRouteState;
     nativeCommandRuntime.resolveDiscordNativeInteractionRouteState = next;
+    return previous;
+  },
+  setGetSessionEntry(next: typeof getSessionEntry): typeof getSessionEntry {
+    const previous = nativeCommandRuntime.getSessionEntry;
+    nativeCommandRuntime.getSessionEntry = next;
     return previous;
   },
 };

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -550,6 +550,10 @@ async function dispatchDiscordCommandInteraction(params: {
     const messageThreadId = !isDirectMessage && isThreadChannel ? channelId : undefined;
     const pluginThreadParentId = !isDirectMessage && isThreadChannel ? threadParentId : undefined;
     const { effectiveRoute } = await getNativeRouteState();
+    const targetSessionEntry = nativeCommandRuntime.getSessionEntry({
+      agentId: effectiveRoute.agentId,
+      sessionKey: effectiveRoute.sessionKey,
+    });
     const pluginReply = await nativeCommandRuntime.executePluginCommand({
       command: pluginMatch.command,
       args: pluginMatch.args,
@@ -559,6 +563,7 @@ async function dispatchDiscordCommandInteraction(params: {
       isAuthorizedSender: commandAuthorized,
       senderIsOwner: senderIsCommandOwner,
       sessionKey: effectiveRoute.sessionKey,
+      authProfileId: targetSessionEntry?.authProfileOverride,
       commandBody: prompt,
       config: cfg,
       from: isDirectMessage

--- a/extensions/telegram/src/bot-native-commands.runtime.ts
+++ b/extensions/telegram/src/bot-native-commands.runtime.ts
@@ -13,3 +13,4 @@ export {
   resolveChunkMode,
 } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 export { resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
+export { getSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -1287,6 +1287,7 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     sessionMocks.resolveStorePath.mockReturnValue("/tmp/openclaw-sessions/sessions.json");
     sessionMocks.loadSessionStore.mockReturnValue({
       "agent:main:telegram:group:-1001234567890:topic:42": {
+        authProfileOverride: "openai-codex:owner@example.com",
         sessionId: "sess-topic",
         updatedAt: 1,
       },
@@ -1338,6 +1339,7 @@ describe("registerTelegramNativeCommands — session metadata", () => {
         sessionKey: "agent:main:telegram:group:-1001234567890:topic:42",
         sessionId: "sess-topic",
         sessionFile: path.resolve("/tmp/openclaw-sessions", "sess-topic-topic-42.jsonl"),
+        authProfileId: "openai-codex:owner@example.com",
         messageThreadId: 42,
       },
       "plugin command params",

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -177,7 +177,7 @@ async function resolveTelegramCommandSessionFile(params: {
   agentId: string;
   sessionKey: string;
   threadId?: string | number;
-}): Promise<{ sessionId?: string; sessionFile?: string }> {
+}): Promise<{ sessionId?: string; sessionFile?: string; authProfileId?: string }> {
   const sessionKey = params.sessionKey.trim();
   if (!sessionKey) {
     return {};
@@ -187,6 +187,7 @@ async function resolveTelegramCommandSessionFile(params: {
     const store = loadSessionStore(storePath);
     const resolved = resolveSessionStoreEntry({ store, sessionKey });
     const sessionId = resolved.existing?.sessionId?.trim() || randomUUID();
+    const authProfileId = normalizeOptionalString(resolved.existing?.authProfileOverride);
     const sessionsDir = path.dirname(storePath);
     const fallbackSessionFile = resolveSessionTranscriptPathInDir(
       sessionId,
@@ -203,7 +204,11 @@ async function resolveTelegramCommandSessionFile(params: {
       sessionsDir,
       fallbackSessionFile,
     });
-    return { sessionId, sessionFile: persisted.sessionFile };
+    return {
+      sessionId,
+      sessionFile: persisted.sessionFile,
+      ...(authProfileId ? { authProfileId } : {}),
+    };
   } catch {
     return {};
   }
@@ -1453,7 +1458,8 @@ export const registerTelegramNativeCommands = ({
             sessionKey: targetSessionKey,
             sessionId: sessionFileContext.sessionId,
             sessionFile: sessionFileContext.sessionFile,
-            authProfileId: targetSessionEntry?.authProfileOverride,
+            authProfileId:
+              sessionFileContext.authProfileId ?? targetSessionEntry?.authProfileOverride,
             commandBody,
             config: runtimeCfg,
             from,

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -1389,6 +1389,10 @@ export const registerTelegramNativeCommands = ({
           botHasTopicsEnabled: resolveTelegramBotHasTopicsEnabled(ctx.me),
           resolveThreadSessionKeys: nativeCommandRuntime.resolveThreadSessionKeys,
         });
+        const targetSessionEntry = nativeCommandRuntime.getSessionEntry({
+          agentId: route.agentId,
+          sessionKey: targetSessionKey,
+        });
         const deliveryBaseOptions = buildCommandDeliveryBaseOptions({
           cfg: runtimeCfg,
           chatId,
@@ -1449,6 +1453,7 @@ export const registerTelegramNativeCommands = ({
             sessionKey: targetSessionKey,
             sessionId: sessionFileContext.sessionId,
             sessionFile: sessionFileContext.sessionFile,
+            authProfileId: targetSessionEntry?.authProfileOverride,
             commandBody,
             config: runtimeCfg,
             from,

--- a/src/agents/openai-responses-payload-policy.test.ts
+++ b/src/agents/openai-responses-payload-policy.test.ts
@@ -173,4 +173,19 @@ describe("openai responses payload policy", () => {
     expect(policy.allowsServiceTier).toBe(true);
     expect(policy.shouldStripStore).toBe(false);
   });
+
+  it("emits store false for aliased native OpenAI Codex responses disable mode", () => {
+    const policy = resolveOpenAIResponsesPayloadPolicy(
+      {
+        api: "openclaw-openai-responses-transport",
+        provider: "openai-codex",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+      },
+      { storeMode: "disable" },
+    );
+
+    expect(policy.explicitStore).toBe(false);
+    expect(policy.allowsServiceTier).toBe(true);
+    expect(policy.shouldStripStore).toBe(false);
+  });
 });

--- a/src/agents/openai-responses-payload-policy.ts
+++ b/src/agents/openai-responses-payload-policy.ts
@@ -64,6 +64,7 @@ const OPENAI_RESPONSES_APIS = new Set([
   "openai-responses",
   "azure-openai-responses",
   "openai-codex-responses",
+  "openclaw-openai-responses-transport",
 ]);
 const OPENAI_RESPONSES_PROVIDERS = new Set(["openai", "azure-openai", "azure-openai-responses"]);
 const LOCAL_ENDPOINT_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
@@ -243,9 +244,13 @@ function resolveOpenAIResponsesPayloadCapabilities(
 
   return {
     allowsOpenAIServiceTier:
-      (provider === "openai" && api === "openai-responses" && endpointClass === "openai-public") ||
+      (provider === "openai" &&
+        (api === "openai-responses" || api === "openclaw-openai-responses-transport") &&
+        endpointClass === "openai-public") ||
       (provider === "openai-codex" &&
-        (api === "openai-codex-responses" || api === "openai-responses") &&
+        (api === "openai-codex-responses" ||
+          api === "openai-responses" ||
+          api === "openclaw-openai-responses-transport") &&
         endpointClass === "openai-codex"),
     allowsResponsesStore:
       supportsResponsesStoreField &&

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1,5 +1,5 @@
 import { createServer } from "node:http";
-import type { Model } from "@earendil-works/pi-ai";
+import type { Api, Model } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import {
   buildOpenAIResponsesParams,
@@ -2250,6 +2250,54 @@ describe("openai transport stream", () => {
     expect(
       params.input?.filter((item) => item.role === "system" || item.role === "developer"),
     ).toStrictEqual([]);
+    expect(params.prompt_cache_key).toBe("session-123");
+    expect(params.store).toBe(false);
+    expect(params).not.toHaveProperty("metadata");
+    expect(params).not.toHaveProperty("max_output_tokens");
+    expect(params).not.toHaveProperty("prompt_cache_retention");
+    expect(params).not.toHaveProperty("service_tier");
+    expect(params).not.toHaveProperty("temperature");
+    expect(params).not.toHaveProperty("top_p");
+  });
+
+  it("keeps Codex response shaping when simple completions use the OpenClaw transport alias", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openclaw-openai-responses-transport" as Api,
+        provider: "openai-codex",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<Api>,
+      {
+        systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix`,
+        messages: [{ role: "user", content: "Hello", timestamp: 1 }],
+        tools: [],
+      } as never,
+      {
+        cacheRetention: "long",
+        maxTokens: 1024,
+        serviceTier: "auto",
+        sessionId: "session-123",
+        temperature: 0.2,
+        topP: 0.85,
+      },
+      {
+        openclaw_session_id: "session-123",
+        openclaw_turn_id: "turn-123",
+      },
+    ) as Record<string, unknown> & {
+      input?: Array<{ role?: string }>;
+      instructions?: string;
+    };
+
+    expect(params.instructions).toBe("Stable prefix\nDynamic suffix");
+    expect(params.input?.map((item) => item.role)).toEqual(["user"]);
     expect(params.prompt_cache_key).toBe("session-123");
     expect(params.store).toBe(false);
     expect(params).not.toHaveProperty("metadata");

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1905,7 +1905,10 @@ function raiseMinimalReasoningForResponsesWebSearch(params: {
 }
 
 function isOpenAICodexResponsesModel(model: Model<Api>): boolean {
-  return model.provider === "openai-codex" && model.api === "openai-codex-responses";
+  return (
+    model.provider === "openai-codex" &&
+    (model.api === "openai-codex-responses" || model.api === "openclaw-openai-responses-transport")
+  );
 }
 
 function isNativeOpenAICodexResponsesBaseUrl(baseUrl?: string): boolean {

--- a/src/agents/pi-embedded-runner/compact.queued.ts
+++ b/src/agents/pi-embedded-runner/compact.queued.ts
@@ -526,6 +526,7 @@ function buildCompactionContextEngineRuntimeContext(params: {
       config: params.params.config,
       sessionKey: params.params.sessionKey,
       agentId: sessionAgentId,
+      authProfileId: params.params.authProfileId,
       contextEnginePluginId: params.contextEnginePluginId,
       purpose: "context-engine.compaction",
     }),

--- a/src/agents/pi-embedded-runner/context-engine-capabilities.ts
+++ b/src/agents/pi-embedded-runner/context-engine-capabilities.ts
@@ -1,15 +1,7 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ContextEngineRuntimeContext } from "../../context-engine/types.js";
-import {
-  parseAgentSessionKey,
-  normalizeAgentId,
-  normalizeMainKey,
-} from "../../routing/session-key.js";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString,
-} from "../../shared/string-coerce.js";
-import { resolveDefaultAgentId } from "../agent-scope.js";
+import { normalizeOptionalString } from "../../shared/string-coerce.js";
+import { resolveBoundAgentIdForSession } from "../session-agent-binding.js";
 
 export type ResolveContextEngineCapabilitiesParams = {
   config?: OpenClawConfig;
@@ -20,36 +12,6 @@ export type ResolveContextEngineCapabilitiesParams = {
   purpose: string;
 };
 
-function resolveBoundAgentId(params: {
-  config?: OpenClawConfig;
-  sessionKey?: string;
-  agentId?: string;
-}): string | undefined {
-  // Explicit agent ids are host-resolved at call sites that already know the
-  // active session agent, such as embedded attempts.
-  const explicitAgentId = normalizeOptionalString(params.agentId);
-  if (explicitAgentId) {
-    return normalizeAgentId(explicitAgentId);
-  }
-  // Canonical agent session keys carry the binding directly.
-  const normalizedSessionKey = normalizeOptionalString(params.sessionKey);
-  if (!normalizedSessionKey) {
-    return undefined;
-  }
-  const parsed = parseAgentSessionKey(normalizedSessionKey);
-  if (parsed?.agentId) {
-    return normalizeAgentId(parsed.agentId);
-  }
-  // Legacy main-session aliases are still active sessions; arbitrary legacy
-  // aliases stay unbound and fail closed in runtime LLM authorization.
-  const loweredSessionKey = normalizeLowercaseStringOrEmpty(normalizedSessionKey);
-  const mainKey = normalizeMainKey(params.config?.session?.mainKey);
-  if (loweredSessionKey === "main" || loweredSessionKey === mainKey) {
-    return resolveDefaultAgentId(params.config ?? {});
-  }
-  return undefined;
-}
-
 /**
  * Build host-owned capabilities that are bound to one context-engine runtime call.
  */
@@ -57,7 +19,7 @@ export function resolveContextEngineCapabilities(
   params: ResolveContextEngineCapabilitiesParams,
 ): Pick<ContextEngineRuntimeContext, "llm"> {
   const sessionKey = normalizeOptionalString(params.sessionKey);
-  const agentId = resolveBoundAgentId({
+  const agentId = resolveBoundAgentIdForSession({
     config: params.config,
     sessionKey,
     agentId: params.agentId,

--- a/src/agents/pi-embedded-runner/context-engine-capabilities.ts
+++ b/src/agents/pi-embedded-runner/context-engine-capabilities.ts
@@ -15,6 +15,7 @@ export type ResolveContextEngineCapabilitiesParams = {
   config?: OpenClawConfig;
   sessionKey?: string;
   agentId?: string;
+  authProfileId?: string;
   contextEnginePluginId?: string;
   purpose: string;
 };
@@ -73,6 +74,7 @@ export function resolveContextEngineCapabilities(
             requiresBoundAgent: true,
             ...(sessionKey ? { sessionKey } : {}),
             ...(agentId ? { agentId } : {}),
+            ...(params.authProfileId ? { preferredProfile: params.authProfileId } : {}),
             ...(contextEnginePluginId ? { pluginIdForPolicy: contextEnginePluginId } : {}),
             allowAgentIdOverride: false,
             allowModelOverride: false,

--- a/src/agents/pi-embedded-runner/context-engine-maintenance.ts
+++ b/src/agents/pi-embedded-runner/context-engine-maintenance.ts
@@ -313,6 +313,7 @@ export function buildContextEngineMaintenanceRuntimeContext(params: {
       config: params.config,
       sessionKey: params.sessionKey,
       agentId: params.agentId,
+      authProfileId: normalizeOptionalString(params.runtimeContext?.authProfileId),
       contextEnginePluginId: params.contextEnginePluginId,
       purpose: params.purpose ?? "context-engine.maintenance",
     }),

--- a/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
@@ -564,6 +564,7 @@ export function buildAfterTurnRuntimeContext(params: {
       config: params.attempt.config,
       sessionKey: params.attempt.sessionKey,
       agentId: params.activeAgentId,
+      authProfileId: params.attempt.authProfileId,
       contextEnginePluginId: params.contextEnginePluginId,
       purpose: "context-engine.after-turn",
     }),

--- a/src/agents/session-agent-binding.ts
+++ b/src/agents/session-agent-binding.ts
@@ -1,0 +1,42 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  parseAgentSessionKey,
+  normalizeAgentId,
+  normalizeMainKey,
+} from "../routing/session-key.js";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "../shared/string-coerce.js";
+import { resolveDefaultAgentId } from "./agent-scope.js";
+
+/**
+ * Resolve the trusted active agent bound to a host-owned session reference.
+ */
+export function resolveBoundAgentIdForSession(params: {
+  config?: OpenClawConfig;
+  sessionKey?: string;
+  agentId?: string;
+}): string | undefined {
+  const explicitAgentId = normalizeOptionalString(params.agentId);
+  if (explicitAgentId) {
+    return normalizeAgentId(explicitAgentId);
+  }
+
+  const normalizedSessionKey = normalizeOptionalString(params.sessionKey);
+  if (!normalizedSessionKey) {
+    return undefined;
+  }
+
+  const parsed = parseAgentSessionKey(normalizedSessionKey);
+  if (parsed?.agentId) {
+    return normalizeAgentId(parsed.agentId);
+  }
+
+  const loweredSessionKey = normalizeLowercaseStringOrEmpty(normalizedSessionKey);
+  const mainKey = normalizeMainKey(params.config?.session?.mainKey);
+  if (loweredSessionKey === "main" || loweredSessionKey === mainKey) {
+    return resolveDefaultAgentId(params.config ?? {});
+  }
+  return undefined;
+}

--- a/src/agents/simple-completion-transport.test.ts
+++ b/src/agents/simple-completion-transport.test.ts
@@ -6,7 +6,9 @@ const createAnthropicVertexStreamFnForModel = vi.fn();
 const ensureCustomApiRegistered = vi.fn();
 const resolveProviderStreamFn = vi.fn();
 const buildTransportAwareSimpleStreamFn = vi.fn();
+const createOpenClawTransportStreamFnForModel = vi.fn();
 const prepareTransportAwareSimpleModel = vi.fn();
+const resolveTransportAwareSimpleApi = vi.fn();
 
 vi.mock("./anthropic-vertex-stream.js", () => ({
   createAnthropicVertexStreamFnForModel,
@@ -18,7 +20,9 @@ vi.mock("./custom-api-registry.js", () => ({
 
 vi.mock("./provider-transport-stream.js", () => ({
   buildTransportAwareSimpleStreamFn,
+  createOpenClawTransportStreamFnForModel,
   prepareTransportAwareSimpleModel,
+  resolveTransportAwareSimpleApi,
 }));
 
 vi.mock("../plugins/provider-runtime.js", async () => {
@@ -43,11 +47,15 @@ describe("prepareModelForSimpleCompletion", () => {
     ensureCustomApiRegistered.mockReset();
     resolveProviderStreamFn.mockReset();
     buildTransportAwareSimpleStreamFn.mockReset();
+    createOpenClawTransportStreamFnForModel.mockReset();
     prepareTransportAwareSimpleModel.mockReset();
+    resolveTransportAwareSimpleApi.mockReset();
     createAnthropicVertexStreamFnForModel.mockReturnValue("vertex-stream");
     resolveProviderStreamFn.mockReturnValue("ollama-stream");
     buildTransportAwareSimpleStreamFn.mockReturnValue(undefined);
+    createOpenClawTransportStreamFnForModel.mockReturnValue(undefined);
     prepareTransportAwareSimpleModel.mockImplementation((model) => model);
+    resolveTransportAwareSimpleApi.mockReturnValue(undefined);
   });
 
   it("registers the configured Ollama transport and keeps the original api", () => {
@@ -159,5 +167,37 @@ describe("prepareModelForSimpleCompletion", () => {
       ...model,
       api: "openclaw-openai-responses-transport",
     });
+  });
+
+  it("uses OpenClaw transport for OpenAI Codex simple completions without static provider credentials", () => {
+    const model: Model<"openai-codex-responses"> = {
+      id: "gpt-5.5",
+      name: "GPT-5.5",
+      api: "openai-codex-responses",
+      provider: "openai-codex",
+      baseUrl: "https://chatgpt.com/backend-api/codex/responses",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200000,
+      maxTokens: 8192,
+    };
+
+    resolveProviderStreamFn.mockReturnValueOnce(undefined);
+    createOpenClawTransportStreamFnForModel.mockReturnValueOnce("codex-transport-stream");
+    resolveTransportAwareSimpleApi.mockReturnValueOnce("openclaw-openai-responses-transport");
+
+    const result = prepareModelForSimpleCompletion({ model });
+
+    expect(createOpenClawTransportStreamFnForModel).toHaveBeenCalledWith(model, { cfg: undefined });
+    expect(ensureCustomApiRegistered).toHaveBeenCalledWith(
+      "openclaw-openai-responses-transport",
+      "codex-transport-stream",
+    );
+    expect(result).toEqual({
+      ...model,
+      api: "openclaw-openai-responses-transport",
+    });
+    expect(prepareTransportAwareSimpleModel).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/simple-completion-transport.test.ts
+++ b/src/agents/simple-completion-transport.test.ts
@@ -169,35 +169,56 @@ describe("prepareModelForSimpleCompletion", () => {
     });
   });
 
-  it("uses OpenClaw transport for OpenAI Codex simple completions without static provider credentials", () => {
-    const model: Model<"openai-codex-responses"> = {
-      id: "gpt-5.5",
-      name: "GPT-5.5",
-      api: "openai-codex-responses",
-      provider: "openai-codex",
-      baseUrl: "https://chatgpt.com/backend-api/codex/responses",
-      reasoning: true,
-      input: ["text"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 200000,
-      maxTokens: 8192,
-    };
+  it.each([
+    ["https://chatgpt.com/backend-api", "https://chatgpt.com/backend-api/codex"],
+    ["https://chatgpt.com/backend-api/v1", "https://chatgpt.com/backend-api/codex"],
+    ["https://chatgpt.com/backend-api/codex", "https://chatgpt.com/backend-api/codex"],
+    ["https://chatgpt.com/backend-api/codex/v1", "https://chatgpt.com/backend-api/codex"],
+    ["https://chatgpt.com/backend-api/codex/responses", "https://chatgpt.com/backend-api/codex"],
+    ["https://proxy.example.test/openai", "https://proxy.example.test/openai/codex"],
+    [
+      "https://proxy.example.test/openai/codex/responses",
+      "https://proxy.example.test/openai/codex",
+    ],
+  ])(
+    "uses OpenClaw transport for OpenAI Codex simple completions with baseUrl %s",
+    (baseUrl, expectedBaseUrl) => {
+      const model: Model<"openai-codex-responses"> = {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        baseUrl,
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      };
 
-    resolveProviderStreamFn.mockReturnValueOnce(undefined);
-    createOpenClawTransportStreamFnForModel.mockReturnValueOnce("codex-transport-stream");
-    resolveTransportAwareSimpleApi.mockReturnValueOnce("openclaw-openai-responses-transport");
+      resolveProviderStreamFn.mockReturnValueOnce(undefined);
+      createOpenClawTransportStreamFnForModel.mockReturnValueOnce("codex-transport-stream");
+      resolveTransportAwareSimpleApi.mockReturnValueOnce("openclaw-openai-responses-transport");
 
-    const result = prepareModelForSimpleCompletion({ model });
+      const result = prepareModelForSimpleCompletion({ model });
 
-    expect(createOpenClawTransportStreamFnForModel).toHaveBeenCalledWith(model, { cfg: undefined });
-    expect(ensureCustomApiRegistered).toHaveBeenCalledWith(
-      "openclaw-openai-responses-transport",
-      "codex-transport-stream",
-    );
-    expect(result).toEqual({
-      ...model,
-      api: "openclaw-openai-responses-transport",
-    });
-    expect(prepareTransportAwareSimpleModel).not.toHaveBeenCalled();
-  });
+      expect(createOpenClawTransportStreamFnForModel).toHaveBeenCalledWith(
+        {
+          ...model,
+          baseUrl: expectedBaseUrl,
+        },
+        { cfg: undefined },
+      );
+      expect(ensureCustomApiRegistered).toHaveBeenCalledWith(
+        "openclaw-openai-responses-transport",
+        "codex-transport-stream",
+      );
+      expect(result).toEqual({
+        ...model,
+        baseUrl: expectedBaseUrl,
+        api: "openclaw-openai-responses-transport",
+      });
+      expect(prepareTransportAwareSimpleModel).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/src/agents/simple-completion-transport.ts
+++ b/src/agents/simple-completion-transport.ts
@@ -15,6 +15,38 @@ function resolveAnthropicVertexSimpleApi(baseUrl?: string): Api {
   return `openclaw-anthropic-vertex-simple:${suffix}`;
 }
 
+function normalizeCodexResponsesBaseUrlForOpenAISdk(baseUrl?: string): string {
+  const normalized = baseUrl?.trim().replace(/\/+$/u, "") || "https://chatgpt.com/backend-api";
+  try {
+    const parsed = new URL(normalized);
+    const path = parsed.pathname.replace(/\/+$/u, "").toLowerCase();
+    if (
+      parsed.hostname.toLowerCase() === "chatgpt.com" &&
+      [
+        "/backend-api",
+        "/backend-api/v1",
+        "/backend-api/codex",
+        "/backend-api/codex/v1",
+        "/backend-api/codex/responses",
+      ].includes(path)
+    ) {
+      parsed.pathname = "/backend-api/codex";
+      parsed.search = "";
+      parsed.hash = "";
+      return parsed.toString().replace(/\/$/u, "");
+    }
+  } catch {
+    // Keep non-URL custom values on the same suffix contract pi-ai accepts.
+  }
+  if (normalized.endsWith("/codex/responses")) {
+    return normalized.slice(0, -"/responses".length);
+  }
+  if (normalized.endsWith("/codex")) {
+    return normalized;
+  }
+  return `${normalized}/codex`;
+}
+
 function prepareCodexSimpleTransportModel<TApi extends Api>(
   model: Model<TApi>,
   cfg?: OpenClawConfig,
@@ -25,15 +57,19 @@ function prepareCodexSimpleTransportModel<TApi extends Api>(
 
   // Static Codex provider catalogs intentionally omit credentials; the simple
   // completion path must use OpenClaw's transport so resolved request auth is applied.
+  const transportModel = {
+    ...model,
+    baseUrl: normalizeCodexResponsesBaseUrlForOpenAISdk(model.baseUrl),
+  } as Model<Api>;
   const api = resolveTransportAwareSimpleApi(model.api);
-  const streamFn = createOpenClawTransportStreamFnForModel(model as Model<Api>, { cfg });
+  const streamFn = createOpenClawTransportStreamFnForModel(transportModel, { cfg });
   if (!api || !streamFn) {
     return undefined;
   }
 
   ensureCustomApiRegistered(api, streamFn);
   return {
-    ...model,
+    ...transportModel,
     api,
   };
 }

--- a/src/agents/simple-completion-transport.ts
+++ b/src/agents/simple-completion-transport.ts
@@ -5,12 +5,37 @@ import { ensureCustomApiRegistered } from "./custom-api-registry.js";
 import { registerProviderStreamForModel } from "./provider-stream.js";
 import {
   buildTransportAwareSimpleStreamFn,
+  createOpenClawTransportStreamFnForModel,
   prepareTransportAwareSimpleModel,
+  resolveTransportAwareSimpleApi,
 } from "./provider-transport-stream.js";
 
 function resolveAnthropicVertexSimpleApi(baseUrl?: string): Api {
   const suffix = baseUrl?.trim() ? encodeURIComponent(baseUrl.trim()) : "default";
   return `openclaw-anthropic-vertex-simple:${suffix}`;
+}
+
+function prepareCodexSimpleTransportModel<TApi extends Api>(
+  model: Model<TApi>,
+  cfg?: OpenClawConfig,
+): Model<Api> | undefined {
+  if (model.provider !== "openai-codex" || model.api !== "openai-codex-responses") {
+    return undefined;
+  }
+
+  // Static Codex provider catalogs intentionally omit credentials; the simple
+  // completion path must use OpenClaw's transport so resolved request auth is applied.
+  const api = resolveTransportAwareSimpleApi(model.api);
+  const streamFn = createOpenClawTransportStreamFnForModel(model as Model<Api>, { cfg });
+  if (!api || !streamFn) {
+    return undefined;
+  }
+
+  ensureCustomApiRegistered(api, streamFn);
+  return {
+    ...model,
+    api,
+  };
 }
 
 export function prepareModelForSimpleCompletion<TApi extends Api>(params: {
@@ -21,6 +46,11 @@ export function prepareModelForSimpleCompletion<TApi extends Api>(params: {
   // Only provider-owned custom APIs need runtime stream registration here.
   if (!getApiProvider(model.api) && registerProviderStreamForModel({ model, cfg })) {
     return model;
+  }
+
+  const codexTransportModel = prepareCodexSimpleTransportModel(model, cfg);
+  if (codexTransportModel) {
+    return codexTransportModel;
   }
 
   const transportAwareModel = prepareTransportAwareSimpleModel(model, { cfg });

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -92,6 +92,9 @@ type EmbeddedPiAgentParams = {
 };
 
 type CompactEmbeddedPiSessionParams = {
+  agentId?: string;
+  authProfileId?: string;
+  contextTokenBudget?: number;
   sessionKey?: string;
   sandboxSessionKey?: string;
   currentTokenCount?: number;
@@ -938,6 +941,37 @@ describe("runMemoryFlushIfNeeded", () => {
 
     expect(compactEmbeddedPiSessionMock).toHaveBeenCalledTimes(1);
     expect(incrementCompactionCountMock).not.toHaveBeenCalled();
+  });
+
+  it("passes resolved context budget and auth profile to preflight compaction", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 245_000,
+      totalTokensFresh: true,
+      compactionCount: 0,
+    };
+
+    await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({
+        authProfileId: "openai-codex:claude@martian.engineering",
+        provider: "openai",
+        model: "gpt-5.5",
+        sessionKey: "agent:main:main",
+      }),
+      defaultModel: "openai/gpt-5.5",
+      agentCfgContextTokens: 258_000,
+      sessionEntry,
+      sessionStore: { "agent:main:main": sessionEntry },
+      sessionKey: "agent:main:main",
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    const compactCall = requireCompactEmbeddedPiSessionCall();
+    expect(compactCall.authProfileId).toBe("openai-codex:claude@martian.engineering");
+    expect(compactCall.contextTokenBudget).toBe(258_000);
   });
 
   it("updates the active preflight run after transcript rotation", async () => {

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -98,7 +98,6 @@ type CompactEmbeddedPiSessionParams = {
   sessionKey?: string;
   sandboxSessionKey?: string;
   currentTokenCount?: number;
-  contextTokenBudget?: number;
   sessionFile?: string;
   sessionId?: string;
   trigger?: string;
@@ -955,12 +954,12 @@ describe("runMemoryFlushIfNeeded", () => {
     await runPreflightCompactionIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun({
-        authProfileId: "openai-codex:claude@martian.engineering",
-        provider: "openai",
-        model: "gpt-5.5",
+        authProfileId: "anthropic:claude@martian.engineering",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
         sessionKey: "agent:main:main",
       }),
-      defaultModel: "openai/gpt-5.5",
+      defaultModel: "anthropic/claude-opus-4-6",
       agentCfgContextTokens: 258_000,
       sessionEntry,
       sessionStore: { "agent:main:main": sessionEntry },
@@ -970,7 +969,7 @@ describe("runMemoryFlushIfNeeded", () => {
     });
 
     const compactCall = requireCompactEmbeddedPiSessionCall();
-    expect(compactCall.authProfileId).toBe("openai-codex:claude@martian.engineering");
+    expect(compactCall.authProfileId).toBe("anthropic:claude@martian.engineering");
     expect(compactCall.contextTokenBudget).toBe(258_000);
   });
 

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -833,6 +833,7 @@ export async function runPreflightCompactionIfNeeded(params: {
     skillsSnapshot: entry.skillsSnapshot ?? params.followupRun.run.skillsSnapshot,
     provider: params.followupRun.run.provider,
     model: params.followupRun.run.model,
+    authProfileId: params.followupRun.run.authProfileId,
     agentHarnessId:
       entry.sessionId === params.followupRun.run.sessionId ? entry.agentHarnessId : undefined,
     thinkLevel: params.followupRun.run.thinkLevel,
@@ -841,6 +842,7 @@ export async function runPreflightCompactionIfNeeded(params: {
     deferOwningContextEngineCompaction: false,
     contextTokenBudget: contextWindowTokens,
     currentTokenCount: tokenCountForCompaction ?? freshPersistedTokens,
+    contextTokenBudget: contextWindowTokens,
     ownerNumbers: params.followupRun.run.ownerNumbers,
     abortSignal: params.replyOperation.abortSignal,
   });

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -842,7 +842,6 @@ export async function runPreflightCompactionIfNeeded(params: {
     deferOwningContextEngineCompaction: false,
     contextTokenBudget: contextWindowTokens,
     currentTokenCount: tokenCountForCompaction ?? freshPersistedTokens,
-    contextTokenBudget: contextWindowTokens,
     ownerNumbers: params.followupRun.run.ownerNumbers,
     abortSignal: params.replyOperation.abortSignal,
   });

--- a/src/auto-reply/reply/commands-diagnostics.ts
+++ b/src/auto-reply/reply/commands-diagnostics.ts
@@ -453,6 +453,7 @@ async function executeCodexDiagnosticsAddon(
     sessionKey: params.sessionKey,
     sessionId: targetSessionEntry?.sessionId,
     sessionFile: targetSessionEntry?.sessionFile,
+    authProfileId: targetSessionEntry?.authProfileOverride,
     commandBody,
     config: params.cfg,
     from: params.command.from,

--- a/src/auto-reply/reply/commands-plugin.test.ts
+++ b/src/auto-reply/reply/commands-plugin.test.ts
@@ -100,6 +100,7 @@ describe("handlePluginCommand", () => {
       [params.sessionKey]: {
         sessionId: "target-session",
         sessionFile: "/tmp/target-session.jsonl",
+        authProfileOverride: "openai-codex:owner@example.com",
         updatedAt: Date.now(),
       },
     };
@@ -108,10 +109,11 @@ describe("handlePluginCommand", () => {
 
     expect(executePluginCommandMock).toHaveBeenCalledTimes(1);
     const [[commandParams]] = executePluginCommandMock.mock.calls as unknown as Array<
-      [{ sessionId?: string; sessionFile?: string }]
+      [{ authProfileId?: string; sessionId?: string; sessionFile?: string }]
     >;
     expect(commandParams.sessionId).toBe("target-session");
     expect(commandParams.sessionFile).toBe("/tmp/target-session.jsonl");
+    expect(commandParams.authProfileId).toBe("openai-codex:owner@example.com");
   });
 
   it("continues the agent without leaking continueAgent into the reply payload", async () => {

--- a/src/auto-reply/reply/commands-plugin.ts
+++ b/src/auto-reply/reply/commands-plugin.ts
@@ -44,6 +44,7 @@ export const handlePluginCommand: CommandHandler = async (
     sessionKey: params.sessionKey,
     sessionId: targetSessionEntry?.sessionId,
     sessionFile: targetSessionEntry?.sessionFile,
+    authProfileId: targetSessionEntry?.authProfileOverride,
     commandBody: command.commandBodyNormalized,
     config: cfg,
     from: command.from,

--- a/src/plugins/commands.test.ts
+++ b/src/plugins/commands.test.ts
@@ -1108,6 +1108,42 @@ describe("registerPluginCommand", () => {
     expect(receivedCtx?.sessionId).toBe("session-123");
   });
 
+  it("passes a host-bound llm runtime through to plugin command handlers", async () => {
+    let receivedCtx:
+      | {
+          runtimeContext?: {
+            llm?: {
+              complete?: unknown;
+            };
+          };
+        }
+      | undefined;
+    const handler = async (ctx: typeof receivedCtx) => {
+      receivedCtx = ctx;
+      return { text: "ok" };
+    };
+
+    const result = await executePluginCommand({
+      command: {
+        name: "runtimecheck",
+        description: "Demo command",
+        acceptsArgs: false,
+        handler,
+        pluginId: "demo-plugin",
+      },
+      channel: "telegram",
+      senderId: "U123",
+      isAuthorizedSender: true,
+      sessionKey: "agent:main:telegram:direct:runtimecheck",
+      authProfileId: "openai-codex:claude@example.com",
+      commandBody: "/runtimecheck",
+      config: {} as never,
+    });
+
+    expect(result).toEqual({ text: "ok" });
+    expect(receivedCtx?.runtimeContext?.llm?.complete).toEqual(expect.any(Function));
+  });
+
   it("normalizes undefined plugin command handler results to an empty reply payload", async () => {
     const handler = async () => undefined as never;
 

--- a/src/plugins/commands.test.ts
+++ b/src/plugins/commands.test.ts
@@ -1112,6 +1112,7 @@ describe("registerPluginCommand", () => {
     let receivedCtx:
       | {
           runtimeContext?: {
+            authProfileId?: string;
             llm?: {
               complete?: unknown;
             };
@@ -1141,6 +1142,7 @@ describe("registerPluginCommand", () => {
     });
 
     expect(result).toEqual({ text: "ok" });
+    expect(receivedCtx?.runtimeContext?.authProfileId).toBe("openai-codex:claude@example.com");
     expect(receivedCtx?.runtimeContext?.llm?.complete).toEqual(expect.any(Function));
   });
 

--- a/src/plugins/commands.test.ts
+++ b/src/plugins/commands.test.ts
@@ -1112,7 +1112,6 @@ describe("registerPluginCommand", () => {
     let receivedCtx:
       | {
           runtimeContext?: {
-            authProfileId?: string;
             llm?: {
               complete?: unknown;
             };
@@ -1142,7 +1141,6 @@ describe("registerPluginCommand", () => {
     });
 
     expect(result).toEqual({ text: "ok" });
-    expect(receivedCtx?.runtimeContext?.authProfileId).toBe("openai-codex:claude@example.com");
     expect(receivedCtx?.runtimeContext?.llm?.complete).toEqual(expect.any(Function));
   });
 

--- a/src/plugins/commands.test.ts
+++ b/src/plugins/commands.test.ts
@@ -16,6 +16,20 @@ import { createPluginRegistry, type PluginRecord } from "./registry.js";
 import { setActivePluginRegistry } from "./runtime.js";
 import type { PluginRuntime } from "./runtime/types.js";
 
+const completionMocks = vi.hoisted(() => ({
+  prepareSimpleCompletionModelForAgent: vi.fn(),
+  completeWithPreparedSimpleCompletionModel: vi.fn(),
+  resolveSimpleCompletionSelectionForAgent: vi.fn(),
+}));
+
+vi.mock("../agents/simple-completion-runtime.js", () => ({
+  prepareSimpleCompletionModelForAgent: completionMocks.prepareSimpleCompletionModelForAgent,
+  completeWithPreparedSimpleCompletionModel:
+    completionMocks.completeWithPreparedSimpleCompletionModel,
+  resolveSimpleCompletionSelectionForAgent:
+    completionMocks.resolveSimpleCompletionSelectionForAgent,
+}));
+
 type CommandsModule = typeof import("./commands.js");
 
 const commandsModuleUrl = new URL("./commands.ts", import.meta.url).href;
@@ -162,6 +176,41 @@ function expectBindingConversationCase(
 }
 
 beforeEach(() => {
+  completionMocks.prepareSimpleCompletionModelForAgent.mockReset();
+  completionMocks.prepareSimpleCompletionModelForAgent.mockResolvedValue({
+    selection: {
+      provider: "openai",
+      modelId: "gpt-5.5",
+      agentDir: "/tmp/openclaw-agent",
+    },
+    model: {
+      provider: "openai",
+      id: "gpt-5.5",
+      name: "GPT-5.5",
+      api: "openai",
+      input: ["text"],
+      reasoning: false,
+      contextWindow: 128_000,
+      maxTokens: 4096,
+      cost: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 0.2 },
+    },
+    auth: {
+      apiKey: "test-api-key",
+      source: "test",
+      mode: "api-key",
+    },
+  });
+  completionMocks.completeWithPreparedSimpleCompletionModel.mockReset();
+  completionMocks.completeWithPreparedSimpleCompletionModel.mockResolvedValue({
+    content: [{ type: "text", text: "done" }],
+    usage: {},
+  });
+  completionMocks.resolveSimpleCompletionSelectionForAgent.mockReset();
+  completionMocks.resolveSimpleCompletionSelectionForAgent.mockReturnValue({
+    provider: "openai",
+    modelId: "gpt-5.5",
+    agentDir: "/tmp/openclaw-agent",
+  });
   setActivePluginRegistry(
     createTestRegistry([
       {
@@ -1142,6 +1191,55 @@ describe("registerPluginCommand", () => {
 
     expect(result).toEqual({ text: "ok" });
     expect(receivedCtx?.runtimeContext?.llm?.complete).toEqual(expect.any(Function));
+  });
+
+  it("binds legacy main session plugin llm runtime to the default agent", async () => {
+    const handler = async (ctx: {
+      runtimeContext?: {
+        llm?: {
+          complete: (params: {
+            messages: Array<{ role: "user"; content: string }>;
+          }) => Promise<unknown>;
+        };
+      };
+    }) => {
+      await ctx.runtimeContext?.llm?.complete({
+        messages: [{ role: "user", content: "draft" }],
+      });
+      return { text: "ok" };
+    };
+
+    await executePluginCommand({
+      command: {
+        name: "runtimecheck",
+        description: "Demo command",
+        acceptsArgs: false,
+        handler,
+        pluginId: "demo-plugin",
+      },
+      channel: "telegram",
+      senderId: "U123",
+      isAuthorizedSender: true,
+      sessionKey: "main",
+      commandBody: "/runtimecheck",
+      config: {
+        agents: {
+          list: [{ id: "ops", default: true }],
+          defaults: {
+            model: "openai/gpt-5.5",
+          },
+        },
+        session: {
+          mainKey: "main",
+        },
+      } as never,
+    });
+
+    expect(completionMocks.prepareSimpleCompletionModelForAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "ops",
+      }),
+    );
   });
 
   it("normalizes undefined plugin command handler results to an empty reply payload", async () => {

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -10,10 +10,7 @@ import { resolveConversationBindingContext } from "../channels/conversation-bind
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { ADMIN_SCOPE, isOperatorScope } from "../gateway/operator-scopes.js";
 import { logVerbose } from "../globals.js";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString,
-} from "../shared/string-coerce.js";
+import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import {
   clearPluginCommands,
   clearPluginCommandsForPlugin,

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -5,16 +5,11 @@
  * These commands are processed before built-in commands and before agent invocation.
  */
 
-import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveBoundAgentIdForSession } from "../agents/session-agent-binding.js";
 import { resolveConversationBindingContext } from "../channels/conversation-binding-context.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { ADMIN_SCOPE, isOperatorScope } from "../gateway/operator-scopes.js";
 import { logVerbose } from "../globals.js";
-import {
-  normalizeAgentId,
-  normalizeMainKey,
-  parseAgentSessionKey,
-} from "../routing/session-key.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -43,7 +38,6 @@ import {
   requestPluginConversationBinding,
 } from "./conversation-binding.js";
 import { getActivePluginChannelRegistry } from "./runtime.js";
-import { createRuntimeLlm } from "./runtime/runtime-llm.runtime.js";
 import type {
   OpenClawPluginCommandDefinition,
   PluginCommandContext,
@@ -179,25 +173,10 @@ function resolveBindingConversationFromCommand(params: {
   });
 }
 
-function resolvePluginCommandAgentId(params: {
-  config: OpenClawConfig;
-  sessionKey?: string;
-}): string | undefined {
-  const normalizedSessionKey = normalizeOptionalString(params.sessionKey);
-  if (!normalizedSessionKey) {
-    return undefined;
-  }
-  const parsed = parseAgentSessionKey(normalizedSessionKey);
-  if (parsed?.agentId) {
-    return normalizeAgentId(parsed.agentId);
-  }
-  const loweredSessionKey = normalizeLowercaseStringOrEmpty(normalizedSessionKey);
-  const mainKey = normalizeMainKey(params.config.session?.mainKey);
-  if (loweredSessionKey === "main" || loweredSessionKey === mainKey) {
-    return resolveDefaultAgentId(params.config);
-  }
-  return undefined;
-}
+type PluginCommandRuntimeLlm = NonNullable<PluginCommandContext["runtimeContext"]>["llm"];
+type PluginCommandLlmCompleteParams = Parameters<
+  NonNullable<PluginCommandRuntimeLlm>["complete"]
+>[0];
 
 function buildPluginCommandRuntimeContext(params: {
   command: RegisteredPluginCommand;
@@ -206,7 +185,7 @@ function buildPluginCommandRuntimeContext(params: {
   authProfileId?: string;
 }): PluginCommandContext["runtimeContext"] {
   const sessionKey = params.sessionKey?.trim();
-  const agentId = resolvePluginCommandAgentId({
+  const agentId = resolveBoundAgentIdForSession({
     config: params.config,
     sessionKey,
   });
@@ -214,24 +193,29 @@ function buildPluginCommandRuntimeContext(params: {
     return undefined;
   }
   return {
-    llm: createRuntimeLlm({
-      getConfig: () => params.config,
-      authority: {
-        caller: {
-          kind: "plugin",
-          id: params.command.pluginId,
-          name: params.command.pluginName,
-        },
-        pluginIdForPolicy: params.command.pluginId,
-        requiresBoundAgent: true,
-        ...(sessionKey ? { sessionKey } : {}),
-        ...(agentId ? { agentId } : {}),
-        ...(params.authProfileId ? { preferredProfile: params.authProfileId } : {}),
-        allowAgentIdOverride: false,
-        allowModelOverride: false,
-        allowComplete: true,
+    llm: {
+      complete: async (request: PluginCommandLlmCompleteParams) => {
+        const { createRuntimeLlm } = await import("./runtime/runtime-llm.runtime.js");
+        return await createRuntimeLlm({
+          getConfig: () => params.config,
+          authority: {
+            caller: {
+              kind: "plugin",
+              id: params.command.pluginId,
+              name: params.command.pluginName,
+            },
+            pluginIdForPolicy: params.command.pluginId,
+            requiresBoundAgent: true,
+            ...(sessionKey ? { sessionKey } : {}),
+            ...(agentId ? { agentId } : {}),
+            ...(params.authProfileId ? { preferredProfile: params.authProfileId } : {}),
+            allowAgentIdOverride: false,
+            allowModelOverride: false,
+            allowComplete: true,
+          },
+        }).complete(request);
       },
-    }),
+    },
   };
 }
 

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -183,11 +183,10 @@ function buildPluginCommandRuntimeContext(params: {
 }): PluginCommandContext["runtimeContext"] {
   const sessionKey = params.sessionKey?.trim();
   const agentId = sessionKey ? parsePluginCommandAgentId(sessionKey) : undefined;
-  if (!sessionKey && !agentId && !params.authProfileId) {
+  if (!sessionKey && !agentId) {
     return undefined;
   }
   return {
-    ...(params.authProfileId ? { authProfileId: params.authProfileId } : {}),
     llm: createRuntimeLlm({
       getConfig: () => params.config,
       authority: {

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -34,6 +34,7 @@ import {
   requestPluginConversationBinding,
 } from "./conversation-binding.js";
 import { getActivePluginChannelRegistry } from "./runtime.js";
+import { createRuntimeLlm } from "./runtime/runtime-llm.runtime.js";
 import type {
   OpenClawPluginCommandDefinition,
   PluginCommandContext,
@@ -169,6 +170,44 @@ function resolveBindingConversationFromCommand(params: {
   });
 }
 
+function parsePluginCommandAgentId(sessionKey: string): string | undefined {
+  const parts = sessionKey.split(":");
+  return parts[0] === "agent" && parts[1]?.trim() ? parts[1].trim() : undefined;
+}
+
+function buildPluginCommandRuntimeContext(params: {
+  command: RegisteredPluginCommand;
+  config: OpenClawConfig;
+  sessionKey?: string;
+  authProfileId?: string;
+}): PluginCommandContext["runtimeContext"] {
+  const sessionKey = params.sessionKey?.trim();
+  const agentId = sessionKey ? parsePluginCommandAgentId(sessionKey) : undefined;
+  if (!sessionKey && !agentId && !params.authProfileId) {
+    return undefined;
+  }
+  return {
+    llm: createRuntimeLlm({
+      getConfig: () => params.config,
+      authority: {
+        caller: {
+          kind: "plugin",
+          id: params.command.pluginId,
+          name: params.command.pluginName,
+        },
+        pluginIdForPolicy: params.command.pluginId,
+        requiresBoundAgent: true,
+        ...(sessionKey ? { sessionKey } : {}),
+        ...(agentId ? { agentId } : {}),
+        ...(params.authProfileId ? { preferredProfile: params.authProfileId } : {}),
+        allowAgentIdOverride: false,
+        allowModelOverride: false,
+        allowComplete: true,
+      },
+    }),
+  };
+}
+
 /**
  * Execute a plugin command handler.
  *
@@ -187,6 +226,7 @@ export async function executePluginCommand(params: {
   sessionKey?: PluginCommandContext["sessionKey"];
   sessionId?: PluginCommandContext["sessionId"];
   sessionFile?: PluginCommandContext["sessionFile"];
+  authProfileId?: string;
   commandBody: string;
   config: OpenClawConfig;
   from?: PluginCommandContext["from"];
@@ -303,6 +343,12 @@ export async function executePluginCommand(params: {
     messageThreadId: params.messageThreadId,
     threadParentId: params.threadParentId,
     diagnosticsSessions: params.diagnosticsSessions,
+    runtimeContext: buildPluginCommandRuntimeContext({
+      command,
+      config,
+      sessionKey: params.sessionKey,
+      authProfileId: params.authProfileId,
+    }),
     ...(diagnosticsUploadApprovedForCommand === undefined
       ? {}
       : { diagnosticsUploadApproved: diagnosticsUploadApprovedForCommand }),

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -187,6 +187,7 @@ function buildPluginCommandRuntimeContext(params: {
     return undefined;
   }
   return {
+    ...(params.authProfileId ? { authProfileId: params.authProfileId } : {}),
     llm: createRuntimeLlm({
       getConfig: () => params.config,
       authority: {

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -5,11 +5,20 @@
  * These commands are processed before built-in commands and before agent invocation.
  */
 
+import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveConversationBindingContext } from "../channels/conversation-binding-context.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { ADMIN_SCOPE, isOperatorScope } from "../gateway/operator-scopes.js";
 import { logVerbose } from "../globals.js";
-import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import {
+  normalizeAgentId,
+  normalizeMainKey,
+  parseAgentSessionKey,
+} from "../routing/session-key.js";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "../shared/string-coerce.js";
 import {
   clearPluginCommands,
   clearPluginCommandsForPlugin,
@@ -170,9 +179,24 @@ function resolveBindingConversationFromCommand(params: {
   });
 }
 
-function parsePluginCommandAgentId(sessionKey: string): string | undefined {
-  const parts = sessionKey.split(":");
-  return parts[0] === "agent" && parts[1]?.trim() ? parts[1].trim() : undefined;
+function resolvePluginCommandAgentId(params: {
+  config: OpenClawConfig;
+  sessionKey?: string;
+}): string | undefined {
+  const normalizedSessionKey = normalizeOptionalString(params.sessionKey);
+  if (!normalizedSessionKey) {
+    return undefined;
+  }
+  const parsed = parseAgentSessionKey(normalizedSessionKey);
+  if (parsed?.agentId) {
+    return normalizeAgentId(parsed.agentId);
+  }
+  const loweredSessionKey = normalizeLowercaseStringOrEmpty(normalizedSessionKey);
+  const mainKey = normalizeMainKey(params.config.session?.mainKey);
+  if (loweredSessionKey === "main" || loweredSessionKey === mainKey) {
+    return resolveDefaultAgentId(params.config);
+  }
+  return undefined;
 }
 
 function buildPluginCommandRuntimeContext(params: {
@@ -182,7 +206,10 @@ function buildPluginCommandRuntimeContext(params: {
   authProfileId?: string;
 }): PluginCommandContext["runtimeContext"] {
   const sessionKey = params.sessionKey?.trim();
-  const agentId = sessionKey ? parsePluginCommandAgentId(sessionKey) : undefined;
+  const agentId = resolvePluginCommandAgentId({
+    config: params.config,
+    sessionKey,
+  });
   if (!sessionKey && !agentId) {
     return undefined;
   }

--- a/src/plugins/runtime/runtime-llm.runtime.test.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.test.ts
@@ -172,6 +172,26 @@ describe("runtime.llm.complete", () => {
     });
   });
 
+  it("passes the active auth profile to context-engine completions", async () => {
+    const runtimeContext = resolveContextEngineCapabilities({
+      config: cfg,
+      sessionKey: "agent:ada:session:abc",
+      authProfileId: "openai-codex:claude@martian.engineering",
+      purpose: "context-engine.compaction",
+    });
+
+    await runtimeContext.llm!.complete({
+      messages: [{ role: "user", content: "summarize" }],
+    });
+
+    expectSingleCallFirstArg(hoisted.prepareSimpleCompletionModelForAgent, {
+      cfg,
+      agentId: "ada",
+      preferredProfile: "openai-codex:claude@martian.engineering",
+      allowMissingApiKeyModes: ["aws-sdk"],
+    });
+  });
+
   it("uses trusted context-engine attribution inside plugin runtime scope", async () => {
     const runtimeContext = resolveContextEngineCapabilities({
       config: cfg,

--- a/src/plugins/runtime/runtime-llm.runtime.test.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.test.ts
@@ -162,7 +162,9 @@ describe("runtime.llm.complete", () => {
     expectSingleCallFirstArg(hoisted.prepareSimpleCompletionModelForAgent, {
       cfg,
       agentId: "ada",
+      allowBundledStaticCatalogFallback: true,
       allowMissingApiKeyModes: ["aws-sdk"],
+      skipPiDiscovery: true,
     });
     expect(result.agentId).toBe("ada");
     expectFields(requireRecord(result.audit, "audit"), {
@@ -188,7 +190,9 @@ describe("runtime.llm.complete", () => {
       cfg,
       agentId: "ada",
       preferredProfile: "openai-codex:claude@martian.engineering",
+      allowBundledStaticCatalogFallback: true,
       allowMissingApiKeyModes: ["aws-sdk"],
+      skipPiDiscovery: true,
     });
   });
 
@@ -494,6 +498,24 @@ describe("runtime.llm.complete", () => {
     expectSingleCallFirstArg(hoisted.prepareSimpleCompletionModelForAgent, {
       cfg,
       agentId: "worker",
+    });
+  });
+
+  it("uses a request auth profile preference when no authority profile is bound", async () => {
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      authority: {
+        allowComplete: true,
+      },
+    });
+
+    await llm.complete({
+      authProfileId: "openai-codex:work",
+      messages: [{ role: "user", content: "draft" }],
+    });
+
+    expectSingleCallFirstArg(hoisted.prepareSimpleCompletionModelForAgent, {
+      preferredProfile: "openai-codex:work",
     });
   });
 

--- a/src/plugins/runtime/runtime-llm.runtime.test.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.test.ts
@@ -501,7 +501,7 @@ describe("runtime.llm.complete", () => {
     });
   });
 
-  it("uses a request auth profile preference when no authority profile is bound", async () => {
+  it("ignores request auth profile preferences without a trusted authority binding", async () => {
     const llm = createRuntimeLlm({
       getConfig: () => cfg,
       authority: {
@@ -512,11 +512,13 @@ describe("runtime.llm.complete", () => {
     await llm.complete({
       authProfileId: "openai-codex:work",
       messages: [{ role: "user", content: "draft" }],
-    });
+    } as Parameters<typeof llm.complete>[0] & { authProfileId: string });
 
-    expectSingleCallFirstArg(hoisted.prepareSimpleCompletionModelForAgent, {
-      preferredProfile: "openai-codex:work",
+    const call = expectSingleCallFirstArg(hoisted.prepareSimpleCompletionModelForAgent, {
+      cfg,
+      agentId: "main",
     });
+    expect(call.preferredProfile).toBeUndefined();
   });
 
   it("allows host model overrides only when explicit authority allowlists the model", async () => {

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -384,6 +384,9 @@ export function createRuntimeLlm(options: CreateRuntimeLlmOptions = {}): PluginR
       const pluginPolicyId = resolvePluginPolicyId(options.authority, caller);
       const pluginPolicy = resolvePluginLlmOverridePolicy(cfg, pluginPolicyId);
       const authorityPolicy = resolveAuthorityModelPolicy(options.authority);
+      const preferredProfile =
+        normalizeOptionalString(options.authority?.preferredProfile) ??
+        normalizeOptionalString(params.authProfileId);
       const agentId = await resolveAgentId({
         request: params,
         cfg,
@@ -419,8 +422,10 @@ export function createRuntimeLlm(options: CreateRuntimeLlmOptions = {}): PluginR
         cfg,
         agentId,
         modelRef: params.model,
-        preferredProfile: options.authority?.preferredProfile,
+        preferredProfile,
+        allowBundledStaticCatalogFallback: true,
         allowMissingApiKeyModes: ["aws-sdk"],
+        skipPiDiscovery: true,
       });
 
       if ("error" in prepared) {

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -384,9 +384,7 @@ export function createRuntimeLlm(options: CreateRuntimeLlmOptions = {}): PluginR
       const pluginPolicyId = resolvePluginPolicyId(options.authority, caller);
       const pluginPolicy = resolvePluginLlmOverridePolicy(cfg, pluginPolicyId);
       const authorityPolicy = resolveAuthorityModelPolicy(options.authority);
-      const preferredProfile =
-        normalizeOptionalString(options.authority?.preferredProfile) ??
-        normalizeOptionalString(params.authProfileId);
+      const preferredProfile = normalizeOptionalString(options.authority?.preferredProfile);
       const agentId = await resolveAgentId({
         request: params,
         cfg,

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -26,6 +26,7 @@ export type RuntimeLlmAuthority = {
   pluginIdForPolicy?: string;
   sessionKey?: string;
   agentId?: string;
+  preferredProfile?: string;
   requiresBoundAgent?: boolean;
   allowAgentIdOverride?: boolean;
   allowModelOverride?: boolean;
@@ -418,6 +419,7 @@ export function createRuntimeLlm(options: CreateRuntimeLlmOptions = {}): PluginR
         cfg,
         agentId,
         modelRef: params.model,
+        preferredProfile: options.authority?.preferredProfile,
         allowMissingApiKeyModes: ["aws-sdk"],
       });
 

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -120,8 +120,6 @@ export type LlmCompleteParams = {
   purpose?: string;
   /** Agent whose model/credentials to use. Session-bound capabilities may disallow overrides. */
   agentId?: string;
-  /** Host-derived auth profile preference for command/runtime-scoped calls. */
-  authProfileId?: string;
 };
 
 export type LlmCompleteResult = {

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -120,6 +120,8 @@ export type LlmCompleteParams = {
   purpose?: string;
   /** Agent whose model/credentials to use. Session-bound capabilities may disallow overrides. */
   agentId?: string;
+  /** Host-derived auth profile preference for command/runtime-scoped calls. */
+  authProfileId?: string;
 };
 
 export type LlmCompleteResult = {

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1981,6 +1981,10 @@ export type PluginCommandContext = {
   threadParentId?: string;
   /** Sensitive diagnostics-only session inventory for owner-gated commands. */
   diagnosticsSessions?: PluginCommandDiagnosticsSession[];
+  /** Host-bound runtime capabilities scoped to this command invocation. */
+  runtimeContext?: {
+    llm?: import("./runtime/types-core.js").PluginRuntimeCore["llm"];
+  };
   /** Internal diagnostics-only marker that exec approval already authorized upload. */
   diagnosticsUploadApproved?: boolean;
   /** Internal diagnostics-only marker to preview upload effects without exposing ids. */

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1983,8 +1983,6 @@ export type PluginCommandContext = {
   diagnosticsSessions?: PluginCommandDiagnosticsSession[];
   /** Host-bound runtime capabilities scoped to this command invocation. */
   runtimeContext?: {
-    /** Host-derived auth profile preference for this command invocation. */
-    authProfileId?: string;
     llm?: import("./runtime/types-core.js").PluginRuntimeCore["llm"];
   };
   /** Internal diagnostics-only marker that exec approval already authorized upload. */

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1983,6 +1983,8 @@ export type PluginCommandContext = {
   diagnosticsSessions?: PluginCommandDiagnosticsSession[];
   /** Host-bound runtime capabilities scoped to this command invocation. */
   runtimeContext?: {
+    /** Host-derived auth profile preference for this command invocation. */
+    authProfileId?: string;
     llm?: import("./runtime/types-core.js").PluginRuntimeCore["llm"];
   };
   /** Internal diagnostics-only marker that exec approval already authorized upload. */


### PR DESCRIPTION
## Summary

- Preserve host-selected agent auth/profile binding when plugin command paths invoke OpenClaw runtime LLM completions.
- Carry the trusted session binding through text, Telegram, Discord native command, plugin runtime, and context-engine compaction entrypoints.
- Keep auth/profile selection host-owned rather than letting plugin-side code choose or reconstruct provider credentials.
- Intentionally out of scope: plugin-level summarizer timeout tuning, and unrelated provider routing behavior already fixed by #86408.
- Success means plugin-driven OpenClaw LLM work uses the active session's resolved auth/profile instead of falling back to default or unbound provider state.
- Reviewers should focus on auth-boundary ownership, plugin SDK/runtime seams, and whether the tests cover the command paths that can enter runtime LLM work.

## Linked context

Closes #

Related #86408

Was this requested by a maintainer or owner? Yes. This is maintainer-owned follow-up for preserving OpenClaw session/auth binding across plugin-driven runtime LLM calls.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: OpenClaw plugin runtime LLM completions preserve host-resolved Codex auth when a plugin invokes `runtime.llm.complete` through a command path.
- Real environment tested: Live OpenClaw gateway rebuilt and restarted from the patched branch, with a real plugin command exercising the plugin SDK runtime LLM surface from Telegram.
- Exact steps or command run after this patch: Ran `/lossless doctor apply`, then inspected `/tmp/openclaw/openclaw-2026-05-25.log` for the post-restart run around `2026-05-25T08:56-08:57`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): The plugin LLM request was routed through OpenClaw's transport-aware Codex path: `provider=openai-codex api=openclaw-openai-responses-transport model=gpt-5.5`, `url=https://chatgpt.com/backend-api/codex/responses`, redacted resolved auth present as `apiKey=***`, HTTP `status=200`, first SSE event `response.created`, and final `stream_done ... response.completed ... stopReason=stop`.
- Observed result after fix: OpenClaw logged a successful `plugin llm completion` for `caller.kind=plugin`, with `purpose=lossless-claw compaction summarization`, `totalTokens=9608`, and no post-restart `runtime.llm.complete error`, `provider_error`, `ALL PROVIDERS EXHAUSTED`, or `Provider openai-codex: "apiKey" or "oauth" is required` entries.
- What was not tested: This proof covers OpenClaw's plugin command/runtime LLM auth and transport path with a live Codex-backed request. It does not claim to tune plugin-level summarizer timeout behavior.
- Proof limitations or environment constraints: The first plugin summarizer attempt timed out at 60s before a fallback request completed successfully; that timeout is plugin-level behavior outside this PR's OpenClaw auth propagation fix.
- Before evidence (optional but encouraged): Before the fix, the same flow produced repeated `runtime.llm.complete error: Provider openai-codex: "apiKey" or "oauth" is required when defining models`, followed by `provider_error` and `ALL PROVIDERS EXHAUSTED` fallback logs.

## Tests and validation

Which commands did you run?

- `pnpm check:test-types`
- `node scripts/run-vitest.mjs src/plugins/runtime/runtime-llm.runtime.test.ts src/plugins/commands.test.ts src/auto-reply/reply/commands-plugin.test.ts src/auto-reply/reply/agent-runner-memory.test.ts extensions/telegram/src/bot-native-commands.session-meta.test.ts extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts src/agents/simple-completion-transport.test.ts src/agents/openai-responses-payload-policy.test.ts src/agents/openai-transport-stream.test.ts`
- `pnpm build`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main`
- Live rebuilt gateway proof described above

What regression coverage was added or updated?

- Plugin command LLM runtime coverage for host-bound auth/profile propagation.
- Text command plugin dispatch coverage for preferred auth profile and static model resolution.
- Telegram and Discord native command session metadata coverage.
- Context-engine/plugin compaction coverage for preserving host-bound agent auth.
- OpenAI transport and simple completion coverage for Codex-backed auth handling.

What failed before this fix, if known?

Plugin-driven runtime LLM calls could enter OpenClaw without the active session's trusted auth/profile binding, causing the request to resolve through the wrong or incomplete provider auth state and fail with missing `apiKey`/`oauth` errors.

If no test was added, why not?

Focused regression tests were added or updated for the affected OpenClaw command/runtime paths.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes.

What is the highest-risk area?

Auth/profile propagation across plugin command runtime and context-engine LLM entrypoints.

How is that risk mitigated?

The fix keeps auth selection in host-owned OpenClaw code, passes a trusted session binding into runtime LLM work, preserves static model resolution, and adds focused tests around the affected text, Telegram, Discord, plugin runtime, and context-engine paths.

## Current review state

What is the next action?

Await maintainer review and current PR CI on the rebased head.

What is still waiting on author, maintainer, CI, or external proof?

CI is expected to finish on the latest pushed head; real behavior proof has been supplied in the PR body.

Which bot or reviewer comments were addressed?

Prepare/review follow-ups addressed the plugin SDK import boundary, runtime LLM auth propagation, check-test-types failures, and merge conflicts with current `main`.

