### PR TITLE
fix(agent): honor OpenRouter endpoint context

### DIFF
--- a/src/agents/pi-embedded-runner/openrouter-model-capabilities.test.ts
+++ b/src/agents/pi-embedded-runner/openrouter-model-capabilities.test.ts
@@ -92,6 +92,46 @@ describe("openrouter-model-capabilities", () => {
     });
   });
 
+  it("uses OpenRouter top_provider context when endpoint limits are smaller", async () => {
+    await withOpenRouterStateDir(async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(
+          async () =>
+            new Response(
+              JSON.stringify({
+                data: [
+                  {
+                    id: "nvidia/nemotron-3-super-120b-a12b:free",
+                    name: "NVIDIA: Nemotron 3 Super 120B A12B (free)",
+                    modality: "text->text",
+                    context_length: 1_000_000,
+                    top_provider: {
+                      context_length: 262_144,
+                      max_completion_tokens: 262_144,
+                    },
+                  },
+                ],
+              }),
+              {
+                status: 200,
+                headers: { "content-type": "application/json" },
+              },
+            ),
+        ),
+      );
+
+      const module = await importOpenRouterModelCapabilities("top-provider-context");
+      await module.loadOpenRouterModelCapabilities("nvidia/nemotron-3-super-120b-a12b:free");
+
+      const capabilities = module.getOpenRouterModelCapabilities(
+        "nvidia/nemotron-3-super-120b-a12b:free",
+      );
+      expect(capabilities?.contextWindow).toBe(262_144);
+      expect(capabilities?.maxTokens).toBe(262_144);
+    });
+  });
+
   it("preserves explicit OpenRouter tool support metadata", async () => {
     await withOpenRouterStateDir(async () => {
       vi.stubGlobal(

--- a/src/agents/pi-embedded-runner/openrouter-model-capabilities.ts
+++ b/src/agents/pi-embedded-runner/openrouter-model-capabilities.ts
@@ -31,7 +31,7 @@ const log = createSubsystemLogger("openrouter-model-capabilities");
 const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
 const FETCH_TIMEOUT_MS = 10_000;
 const DISK_CACHE_FILENAME = "openrouter-models.json";
-const DISK_CACHE_VERSION = 2;
+const DISK_CACHE_VERSION = 3;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -49,6 +49,7 @@ interface OpenRouterApiModel {
   max_completion_tokens?: number;
   max_output_tokens?: number;
   top_provider?: {
+    context_length?: number;
     max_completion_tokens?: number;
   };
   pricing?: {
@@ -174,7 +175,7 @@ function parseModel(model: OpenRouterApiModel): OpenRouterModelCapabilities {
     input,
     reasoning: supportedParameters?.includes("reasoning") ?? false,
     ...(supportedParameters ? { supportsTools: supportedParameters.includes("tools") } : {}),
-    contextWindow: model.context_length || 128_000,
+    contextWindow: model.top_provider?.context_length ?? model.context_length ?? 128_000,
     maxTokens:
       model.top_provider?.max_completion_tokens ??
       model.max_completion_tokens ??


### PR DESCRIPTION
## Summary

- Fix OpenRouter dynamic capability parsing to prefer endpoint-specific `top_provider.context_length` when present.
- Bump the OpenRouter model capability disk-cache version so existing cached top-level-only budgets are refreshed.
- Add regression coverage for the reported Nemotron catalog shape where top-level context is 1M but the routed endpoint limit is 262144.

## Tests

- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/openrouter-model-capabilities.test.ts src/agents/pi-embedded-runner/model.test.ts src/agents/openai-transport-stream.test.ts`
- `node --import tsx -e "import { mkdtempSync, rmSync } from 'node:fs'; import { tmpdir } from 'node:os'; import { join } from 'node:path'; const state=mkdtempSync(join(tmpdir(),'openclaw-openrouter-proof-')); process.env.OPENCLAW_STATE_DIR=state; const m=await import('./src/agents/pi-embedded-runner/openrouter-model-capabilities.ts'); const id='nvidia/nemotron-3-super-120b-a12b:free'; await m.loadOpenRouterModelCapabilities(id); const caps=m.getOpenRouterModelCapabilities(id); console.log(JSON.stringify({id, contextWindow:caps?.contextWindow, maxTokens:caps?.maxTokens, input:caps?.input})); rmSync(state,{recursive:true,force:true});"`
- `git diff --check`

## Real behavior proof

Behavior addressed: OpenRouter dynamic model capability lookup now uses the selected endpoint's `top_provider.context_length` as the effective context window when the public catalog exposes a larger top-level `context_length`.

Real environment tested: macOS local checkout, Node via repo tooling, live unauthenticated OpenRouter public model catalog request for `nvidia/nemotron-3-super-120b-a12b:free`.

Exact steps or command run after this patch: `node --import tsx -e "import { mkdtempSync, rmSync } from 'node:fs'; import { tmpdir } from 'node:os'; import { join } from 'node:path'; const state=mkdtempSync(join(tmpdir(),'openclaw-openrouter-proof-')); process.env.OPENCLAW_STATE_DIR=state; const m=await import('./src/agents/pi-embedded-runner/openrouter-model-capabilities.ts'); const id='nvidia/nemotron-3-super-120b-a12b:free'; await m.loadOpenRouterModelCapabilities(id); const caps=m.getOpenRouterModelCapabilities(id); console.log(JSON.stringify({id, contextWindow:caps?.contextWindow, maxTokens:caps?.maxTokens, input:caps?.input})); rmSync(state,{recursive:true,force:true});"`

Evidence after fix: The runtime command fetched the live OpenRouter catalog into an isolated temporary state dir and resolved capabilities through the production OpenRouter capability loader. After-fix console output from that command:

```text
{"id":"nvidia/nemotron-3-super-120b-a12b:free","contextWindow":262144,"maxTokens":262144,"input":["text"]}
```

Observed result after fix: The production OpenRouter capability loader resolved the live catalog model with `contextWindow` equal to 262144, matching the endpoint-specific `top_provider.context_length`, instead of the 1,000,000-token top-level catalog context.

What was not tested: Authenticated OpenRouter inference was not run; this verifies the catalog parsing and runtime capability resolution path that feeds the transport budget clamp.

Fixes #85921
