### PR TITLE
[perf] improve reply send performance

### DIFF
--- a/docs/diagnostics/flags.md
+++ b/docs/diagnostics/flags.md
@@ -50,6 +50,50 @@ Disable all flags:
 OPENCLAW_DIAGNOSTICS=0
 ```
 
+`OPENCLAW_DIAGNOSTICS=0` is a process-level disable override: it disables
+flags from both env and config for that process.
+
+## Profiling flags
+
+Profiler flags enable targeted timing spans without raising global logging
+levels. They are disabled by default.
+
+Enable all profiler-gated spans for one gateway run:
+
+```bash
+OPENCLAW_DIAGNOSTICS=profiler openclaw gateway run
+```
+
+Enable only reply-dispatch profiler spans:
+
+```bash
+OPENCLAW_DIAGNOSTICS=reply.profiler openclaw gateway run
+```
+
+Enable only Codex app-server startup/tool/thread profiler spans:
+
+```bash
+OPENCLAW_DIAGNOSTICS=codex.profiler openclaw gateway run
+```
+
+Enable profiler flags from config:
+
+```json
+{
+  "diagnostics": {
+    "flags": ["reply.profiler", "codex.profiler"]
+  }
+}
+```
+
+Restart the gateway after changing config flags. To disable a profiler flag,
+remove it from `diagnostics.flags` and restart. To temporarily disable every
+diagnostics flag even when config enables profiler flags, start the process with:
+
+```bash
+OPENCLAW_DIAGNOSTICS=0 openclaw gateway run
+```
+
 ## Timeline artifacts
 
 The `timeline` flag writes structured startup and runtime timing events for

--- a/extensions/codex/src/app-server/profiler-flag.test.ts
+++ b/extensions/codex/src/app-server/profiler-flag.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { isCodexAppServerProfilerEnabled } from "./profiler-flag.js";
+
+describe("isCodexAppServerProfilerEnabled", () => {
+  it("is disabled by default", () => {
+    expect(isCodexAppServerProfilerEnabled(undefined, {} as NodeJS.ProcessEnv)).toBe(false);
+  });
+
+  it("matches global and Codex profiler flags", () => {
+    expect(
+      isCodexAppServerProfilerEnabled(
+        { diagnostics: { flags: ["codex.profiler"] } },
+        {} as NodeJS.ProcessEnv,
+      ),
+    ).toBe(true);
+    expect(
+      isCodexAppServerProfilerEnabled(undefined, {
+        OPENCLAW_DIAGNOSTICS: "profiler",
+      } as NodeJS.ProcessEnv),
+    ).toBe(true);
+  });
+
+  it("uses the documented diagnostics env disable override", () => {
+    expect(
+      isCodexAppServerProfilerEnabled({ diagnostics: { flags: ["codex.profiler"] } }, {
+        OPENCLAW_DIAGNOSTICS: "0",
+      } as NodeJS.ProcessEnv),
+    ).toBe(false);
+  });
+});

--- a/extensions/codex/src/app-server/profiler-flag.ts
+++ b/extensions/codex/src/app-server/profiler-flag.ts
@@ -1,0 +1,11 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { isDiagnosticFlagEnabled } from "openclaw/plugin-sdk/diagnostic-runtime";
+
+const PROFILER_FLAGS = ["profiler", "codex.profiler"] as const;
+
+export function isCodexAppServerProfilerEnabled(
+  config?: OpenClawConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return PROFILER_FLAGS.some((flag) => isDiagnosticFlagEnabled(flag, config, env));
+}

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -887,6 +887,7 @@ describe("runCodexAppServerAttempt", () => {
     await closeCodexSandboxExecServersForTests();
     resetCodexAppServerClientFactoryForTest();
     testing.resetOpenClawCodingToolsFactoryForTests();
+    testing.resetEnsuredCodexWorkspaceDirsForTests();
     testing.clearPendingCodexNativeHookRelayUnregistersForTests();
     resetCodexRateLimitCacheForTests();
     nativeHookRelayTesting.clearNativeHookRelaysForTests();
@@ -901,6 +902,16 @@ describe("runCodexAppServerAttempt", () => {
     vi.unstubAllEnvs();
     await closeCodexSandboxExecServersForTests();
     await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("recreates cached Codex workspace directories after cleanup removes them", async () => {
+    const workspaceDir = path.join(tempDir, "cached-workspace");
+
+    await testing.ensureCodexWorkspaceDirOnceForTests(workspaceDir);
+    await fs.rm(workspaceDir, { recursive: true, force: true });
+    await testing.ensureCodexWorkspaceDirOnceForTests(workspaceDir);
+
+    expect((await fs.stat(workspaceDir)).isDirectory()).toBe(true);
   });
 
   it("filters Codex-native dynamic tools from app-server tool exposure", () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -134,6 +134,7 @@ import {
   mergeCodexThreadConfigs,
   shouldBuildCodexPluginThreadConfig,
 } from "./plugin-thread-config.js";
+import { isCodexAppServerProfilerEnabled } from "./profiler-flag.js";
 import {
   assertCodexTurnStartResponse,
   readCodexDynamicToolCallParams,
@@ -278,6 +279,7 @@ type CodexWorkspaceBootstrapContext = CodexBootstrapContext & {
 };
 
 let openClawCodingToolsFactoryForTests: OpenClawCodingToolsFactory | undefined;
+const ensuredCodexWorkspaceDirs = new Set<string>();
 
 type PendingCodexNativeHookRelayUnregister = {
   timeout: ReturnType<typeof setTimeout>;
@@ -338,6 +340,30 @@ function clearPendingCodexNativeHookRelayUnregistersForTests(): void {
     clearTimeout(pending.timeout);
   }
   pendingCodexNativeHookRelayUnregisters.clear();
+}
+
+async function ensureCodexWorkspaceDirOnce(workspaceDir: string): Promise<void> {
+  const normalized = path.resolve(workspaceDir);
+  if (ensuredCodexWorkspaceDirs.has(normalized)) {
+    try {
+      const stat = await fs.stat(normalized);
+      if (stat.isDirectory()) {
+        return;
+      }
+    } catch (error) {
+      const code =
+        typeof error === "object" && error ? (error as { code?: unknown }).code : undefined;
+      if (code !== "ENOENT") {
+        throw error;
+      }
+    }
+    ensuredCodexWorkspaceDirs.delete(normalized);
+  }
+  // Codex attempts re-enter the same workspace repeatedly; caching successful
+  // mkdirs avoids repeated fs work while still recovering if cleanup prunes
+  // the directory between attempts.
+  await fs.mkdir(normalized, { recursive: true });
+  ensuredCodexWorkspaceDirs.add(normalized);
 }
 
 function emitCodexAppServerEvent(
@@ -951,6 +977,7 @@ export async function runCodexAppServerAttempt(
   } = {},
 ): Promise<EmbeddedRunAttemptResult> {
   const attemptStartedAt = Date.now();
+  const profilerEnabled = isCodexAppServerProfilerEnabled(params.config);
   const codexModelCallTrace = freezeDiagnosticTraceContext(
     createDiagnosticTraceContextFromActiveScope(),
   );
@@ -960,13 +987,20 @@ export async function runCodexAppServerAttempt(
   let codexModelCallStarted = false;
   let codexModelCallTerminalEmitted = false;
   let codexModelCallRequestPayloadBytes: number | undefined;
+  // Startup phase timings are profiler-gated because this function runs before
+  // every Codex turn; normal production should not do timing bookkeeping here.
+  const preDynamicStartupStages = createCodexDynamicToolBuildStageTracker({
+    enabled: profilerEnabled,
+  });
   const attemptClientFactory = options.clientFactory ?? defaultCodexAppServerClientFactory;
   const pluginConfig = readCodexPluginConfig(options.pluginConfig);
   const computerUseConfig = resolveCodexComputerUseConfig({ pluginConfig });
   const configuredAppServer = resolveCodexAppServerRuntimeOptions({ pluginConfig });
   const beforeToolCallPolicy = getBeforeToolCallPolicyDiagnosticState();
+  preDynamicStartupStages.mark("config");
   const resolvedWorkspace = resolveUserPath(params.workspaceDir);
-  await fs.mkdir(resolvedWorkspace, { recursive: true });
+  await ensureCodexWorkspaceDirOnce(resolvedWorkspace);
+  preDynamicStartupStages.mark("workspace");
   const sandboxSessionKey =
     params.sandboxSessionKey?.trim() || params.sessionKey?.trim() || params.sessionId;
   const contextSessionKey = params.sessionKey?.trim() || sandboxSessionKey;
@@ -975,12 +1009,14 @@ export async function runCodexAppServerAttempt(
     sessionKey: sandboxSessionKey,
     workspaceDir: resolvedWorkspace,
   });
+  preDynamicStartupStages.mark("sandbox");
   const effectiveWorkspace = sandbox?.enabled
     ? sandbox.workspaceAccess === "rw"
       ? resolvedWorkspace
       : sandbox.workspaceDir
     : resolvedWorkspace;
-  await fs.mkdir(effectiveWorkspace, { recursive: true });
+  await ensureCodexWorkspaceDirOnce(effectiveWorkspace);
+  preDynamicStartupStages.mark("effective-workspace");
   const appServer = resolveCodexAppServerForOpenClawToolPolicy({
     appServer: configuredAppServer,
     pluginConfig,
@@ -1000,11 +1036,13 @@ export async function runCodexAppServerAttempt(
       trustedToolPolicies: beforeToolCallPolicy.trustedToolPolicies,
     });
   }
+  preDynamicStartupStages.mark("app-server-policy");
   let pluginAppServer: CodexAppServerRuntimeOptions = appServer;
   const nativeHookRelayEvents = resolveCodexNativeHookRelayEvents({
     configuredEvents: options.nativeHookRelay?.events,
     appServer,
   });
+  preDynamicStartupStages.mark("native-hook-relay");
 
   const runAbortController = new AbortController();
   const abortFromUpstream = () => {
@@ -1022,7 +1060,9 @@ export async function runCodexAppServerAttempt(
     agentId: params.agentId,
   });
   const agentDir = params.agentDir ?? resolveAgentDir(params.config ?? {}, sessionAgentId);
+  preDynamicStartupStages.mark("session-agent");
   let startupBinding = await readCodexAppServerBinding(params.sessionFile);
+  preDynamicStartupStages.mark("read-binding");
   const startupBindingAuthProfileId = startupBinding?.authProfileId;
   startupBinding = await rotateOversizedCodexAppServerStartupBinding({
     binding: startupBinding,
@@ -1031,6 +1071,7 @@ export async function runCodexAppServerAttempt(
     codexHome: appServer.start.env?.CODEX_HOME,
     config: params.config,
   });
+  preDynamicStartupStages.mark("rotate-binding");
   const startupAuthProfileCandidate =
     params.runtimePlan?.auth.forwardedAuthProfileId ??
     params.authProfileId ??
@@ -1047,6 +1088,7 @@ export async function runCodexAppServerAttempt(
         agentDir,
         config: params.config,
       });
+  preDynamicStartupStages.mark("auth-profile");
   const runtimeParams = {
     ...params,
     sessionKey: contextSessionKey,
@@ -1070,11 +1112,13 @@ export async function runCodexAppServerAttempt(
     : resolveCodexAppServerEnvApiKeyCacheKey({
         startOptions: appServer.start,
       });
+  preDynamicStartupStages.mark("auth-cache");
   const nodeExecBlocksNativeExecution = isCodexNativeExecutionBlockedByNodeExecHost(params, {
     agentId: sessionAgentId,
     runtimeSessionKey: sandboxSessionKey,
     sandbox,
   });
+  preDynamicStartupStages.mark("native-exec-policy");
   const bundleMcpThreadConfig = await loadCodexBundleMcpThreadConfig({
     workspaceDir: effectiveWorkspace,
     cfg: params.config,
@@ -1082,12 +1126,14 @@ export async function runCodexAppServerAttempt(
     disableTools: params.disableTools,
     toolsAllow: nodeExecBlocksNativeExecution ? [] : params.toolsAllow,
   });
+  preDynamicStartupStages.mark("bundle-mcp");
   const sandboxExecServerEnabled = isCodexSandboxExecServerEnabled(pluginConfig);
   const nativeToolSurfaceEnabled = shouldEnableCodexAppServerNativeToolSurface(params, sandbox, {
     agentId: sessionAgentId,
     runtimeSessionKey: sandboxSessionKey,
     sandboxExecServerEnabled,
   });
+  preDynamicStartupStages.mark("native-tool-surface");
   for (const diagnostic of bundleMcpThreadConfig.diagnostics) {
     embeddedAgentLog.warn(`bundle-mcp: ${diagnostic.pluginId}: ${diagnostic.message}`);
   }
@@ -1102,6 +1148,23 @@ export async function runCodexAppServerAttempt(
     });
   }
   const hookChannelId = resolveCodexAppServerHookChannelId(params, sandboxSessionKey);
+  preDynamicStartupStages.mark("context-engine-support");
+  const preDynamicSummary = preDynamicStartupStages.snapshot();
+  if (shouldWarnCodexDynamicToolBuildStageSummary(preDynamicSummary)) {
+    embeddedAgentLog.warn(
+      `codex app-server pre-dynamic startup timings runId=${params.runId} sessionId=${params.sessionId} totalMs=${preDynamicSummary.totalMs} stages=${formatCodexDynamicToolBuildStageSummary(preDynamicSummary)}`,
+      {
+        runId: params.runId,
+        sessionId: params.sessionId,
+        totalMs: preDynamicSummary.totalMs,
+        stages: preDynamicSummary.stages,
+        hasStartupBinding: Boolean(startupBinding?.threadId),
+        startupAuthProfileId: startupAuthProfileId ?? null,
+        bundleMcpDiagnosticCount: bundleMcpThreadConfig.diagnostics.length,
+        nativeToolSurfaceEnabled,
+      },
+    );
+  }
   let yieldDetected = false;
   const tools = await buildDynamicTools({
     params,
@@ -1113,6 +1176,7 @@ export async function runCodexAppServerAttempt(
     runAbortController,
     sessionAgentId,
     pluginConfig,
+    profilerEnabled,
     onYieldDetected: () => {
       yieldDetected = true;
     },
@@ -1127,6 +1191,7 @@ export async function runCodexAppServerAttempt(
     runAbortController,
     sessionAgentId,
     pluginConfig,
+    profilerEnabled,
     forceHeartbeatTool: true,
     ignoreRuntimePlan: true,
     onYieldDetected: () => {
@@ -2722,9 +2787,8 @@ export async function runCodexAppServerAttempt(
   const codexDiagnosticToolDefinitions = codexModelContentCapture.toolDefinitions
     ? buildCodexDiagnosticToolDefinitions(tools)
     : undefined;
-  const codexModelContentPrivateData = (
-    modelContent: DiagnosticModelCallContent | undefined,
-  ) => (modelContent && Object.keys(modelContent).length > 0 ? { modelContent } : undefined);
+  const codexModelContentPrivateData = (modelContent: DiagnosticModelCallContent | undefined) =>
+    modelContent && Object.keys(modelContent).length > 0 ? { modelContent } : undefined;
   const buildCodexModelCallDiagnosticContent = (): DiagnosticModelCallContent | undefined => {
     const modelContent = {
       ...(codexModelContentCapture.inputMessages
@@ -2768,9 +2832,7 @@ export async function runCodexAppServerAttempt(
         ...buildCodexModelCallDiagnosticContent(),
         ...(codexModelContentCapture.outputMessages
           ? {
-              outputMessages: result.lastAssistant
-                ? [result.lastAssistant]
-                : result.assistantTexts,
+              outputMessages: result.lastAssistant ? [result.lastAssistant] : result.assistantTexts,
             }
           : {}),
       }),
@@ -3783,6 +3845,9 @@ function createCodexNativeHookRelay(params: {
     }),
     signal: params.signal,
     command: {
+      // Hook relay subprocesses are observational for most tool events; keep
+      // them lower priority so they do not compete with the active reply turn.
+      nice: 10,
       timeoutMs: params.options?.gatewayTimeoutMs,
     },
   });
@@ -3952,6 +4017,7 @@ type DynamicToolBuildParams = {
   runAbortController: AbortController;
   sessionAgentId: string;
   pluginConfig: CodexPluginConfig;
+  profilerEnabled?: boolean;
   forceHeartbeatTool?: boolean;
   ignoreRuntimePlan?: boolean;
   onYieldDetected: () => void;
@@ -3981,16 +4047,91 @@ function resolveCodexAppServerHookChannelId(
   }).channelId;
 }
 
+type CodexDynamicToolBuildStageTiming = {
+  name: string;
+  durationMs: number;
+  elapsedMs: number;
+};
+
+type CodexDynamicToolBuildStageSummary = {
+  totalMs: number;
+  stages: CodexDynamicToolBuildStageTiming[];
+};
+
+const CODEX_DYNAMIC_TOOL_BUILD_WARN_TOTAL_MS = 1_000;
+const CODEX_DYNAMIC_TOOL_BUILD_WARN_STAGE_MS = 500;
+
+function createCodexDynamicToolBuildStageTracker(options: { enabled?: boolean } = {}): {
+  mark: (name: string) => void;
+  snapshot: () => CodexDynamicToolBuildStageSummary;
+} {
+  if (!options.enabled) {
+    return {
+      mark() {},
+      snapshot() {
+        return { totalMs: 0, stages: [] };
+      },
+    };
+  }
+
+  const startedAt = Date.now();
+  let previousAt = startedAt;
+  const stages: CodexDynamicToolBuildStageTiming[] = [];
+  const toMs = (value: number) => Math.max(0, Math.round(value));
+  return {
+    mark(name) {
+      const currentAt = Date.now();
+      stages.push({
+        name,
+        durationMs: toMs(currentAt - previousAt),
+        elapsedMs: toMs(currentAt - startedAt),
+      });
+      previousAt = currentAt;
+    },
+    snapshot() {
+      return {
+        totalMs: toMs(Date.now() - startedAt),
+        stages: stages.slice(),
+      };
+    },
+  };
+}
+
+function shouldWarnCodexDynamicToolBuildStageSummary(
+  summary: CodexDynamicToolBuildStageSummary,
+): boolean {
+  return (
+    summary.totalMs >= CODEX_DYNAMIC_TOOL_BUILD_WARN_TOTAL_MS ||
+    summary.stages.some((stage) => stage.durationMs >= CODEX_DYNAMIC_TOOL_BUILD_WARN_STAGE_MS)
+  );
+}
+
+function formatCodexDynamicToolBuildStageSummary(
+  summary: CodexDynamicToolBuildStageSummary,
+): string {
+  return summary.stages.length > 0
+    ? summary.stages
+        .map((stage) => `${stage.name}:${stage.durationMs}ms@${stage.elapsedMs}ms`)
+        .join(",")
+    : "none";
+}
+
 async function buildDynamicTools(input: DynamicToolBuildParams) {
   const { params } = input;
   if (params.disableTools || !supportsModelTools(params.model)) {
     return [];
   }
+  // Dynamic tool construction is on the reply hot path, so per-stage
+  // Date.now/span bookkeeping runs only when the Codex profiler flag is set.
+  const toolBuildStages = createCodexDynamicToolBuildStageTracker({
+    enabled: input.profilerEnabled,
+  });
   const modelHasVision = params.model.input?.includes("image") ?? false;
   const agentDir = params.agentDir ?? resolveAgentDir(params.config ?? {}, input.sessionAgentId);
   const createOpenClawCodingTools =
     openClawCodingToolsFactoryForTests ??
     (await import("openclaw/plugin-sdk/agent-harness")).createOpenClawCodingTools;
+  toolBuildStages.mark("load-agent-harness-tools");
   const sessionKeys = resolveOpenClawCodingToolsSessionKeys(params, input.sandboxSessionKey);
   const allTools = createOpenClawCodingTools({
     agentId: input.sessionAgentId,
@@ -4060,7 +4201,11 @@ async function buildDynamicTools(input: DynamicToolBuildParams) {
         data: { name: "sessions_yield", message },
       });
     },
+    recordToolPrepStage: (name) => {
+      toolBuildStages.mark(name);
+    },
   });
+  toolBuildStages.mark("create-openclaw-coding-tools");
   const codexFilteredTools = addNodeShellDynamicToolsIfNeeded(
     addSandboxShellDynamicToolsIfAvailable(
       isCodexMemoryFlushRun(params)
@@ -4072,13 +4217,16 @@ async function buildDynamicTools(input: DynamicToolBuildParams) {
     allTools,
     input,
   );
+  toolBuildStages.mark("codex-filtering");
   const visionFilteredTools = filterToolsForVisionInputs(codexFilteredTools, {
     modelHasVision,
     hasInboundImages: (params.images?.length ?? 0) > 0,
   });
+  toolBuildStages.mark("vision-filtering");
   const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, params);
   const filteredTools = filterCodexDynamicToolsForAllowlist(visionFilteredTools, toolsAllow);
-  return normalizeAgentRuntimeTools({
+  toolBuildStages.mark("allowlist-filter");
+  const normalizedTools = normalizeAgentRuntimeTools({
     runtimePlan: input.ignoreRuntimePlan ? undefined : params.runtimePlan,
     tools: filteredTools,
     provider: params.provider,
@@ -4089,6 +4237,30 @@ async function buildDynamicTools(input: DynamicToolBuildParams) {
     modelApi: params.model.api,
     model: params.model,
   });
+  toolBuildStages.mark("runtime-normalization");
+  const summary = toolBuildStages.snapshot();
+  if (shouldWarnCodexDynamicToolBuildStageSummary(summary)) {
+    const phase = input.forceHeartbeatTool ? "registered-tools" : "runtime-tools";
+    embeddedAgentLog.warn(
+      `codex app-server dynamic tool build timings runId=${params.runId} sessionId=${params.sessionId} phase=${phase} totalMs=${summary.totalMs} stages=${formatCodexDynamicToolBuildStageSummary(summary)}`,
+      {
+        runId: params.runId,
+        sessionId: params.sessionId,
+        phase,
+        totalMs: summary.totalMs,
+        stages: summary.stages,
+        allToolCount: allTools.length,
+        codexFilteredToolCount: codexFilteredTools.length,
+        visionFilteredToolCount: visionFilteredTools.length,
+        filteredToolCount: filteredTools.length,
+        normalizedToolCount: normalizedTools.length,
+        forceHeartbeatTool: input.forceHeartbeatTool === true,
+        ignoreRuntimePlan: input.ignoreRuntimePlan === true,
+        nativeToolSurfaceEnabled: input.nativeToolSurfaceEnabled === true,
+      },
+    );
+  }
+  return normalizedTools;
 }
 
 function includeForcedCodexDynamicToolAllow(
@@ -5902,6 +6074,12 @@ export const testing = {
   },
   resetOpenClawCodingToolsFactoryForTests(): void {
     openClawCodingToolsFactoryForTests = undefined;
+  },
+  async ensureCodexWorkspaceDirOnceForTests(workspaceDir: string): Promise<void> {
+    await ensureCodexWorkspaceDirOnce(workspaceDir);
+  },
+  resetEnsuredCodexWorkspaceDirsForTests(): void {
+    ensuredCodexWorkspaceDirs.clear();
   },
   flushPendingCodexNativeHookRelayUnregistersForTests,
   clearPendingCodexNativeHookRelayUnregistersForTests,

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -19,6 +19,7 @@ import {
   mergeCodexThreadConfigs,
   type CodexPluginThreadConfig,
 } from "./plugin-thread-config.js";
+import { isCodexAppServerProfilerEnabled } from "./profiler-flag.js";
 import {
   assertCodexThreadResumeResponse,
   assertCodexThreadStartResponse,
@@ -84,6 +85,113 @@ const CODEX_LIGHTWEIGHT_CONTEXT_THREAD_CONFIG: JsonObject = {
   project_doc_max_bytes: 0,
 };
 
+type CodexThreadLifecycleTimingSpan = {
+  name: string;
+  durationMs: number;
+  elapsedMs: number;
+};
+
+type CodexThreadLifecycleTimingSummary = {
+  totalMs: number;
+  spans: CodexThreadLifecycleTimingSpan[];
+};
+
+const CODEX_THREAD_LIFECYCLE_TIMING_WARN_TOTAL_MS = 1_000;
+const CODEX_THREAD_LIFECYCLE_TIMING_WARN_STAGE_MS = 500;
+
+function createCodexThreadLifecycleTimingTracker(options: { enabled?: boolean } = {}): {
+  measure: <T>(name: string, run: () => Promise<T> | T) => Promise<T>;
+  measureSync: <T>(name: string, run: () => T) => T;
+  logIfSlow: (params: {
+    runId: string;
+    sessionId: string;
+    sessionKey?: string;
+    action: "started" | "resumed" | "rotated";
+    threadId?: string;
+  }) => void;
+} {
+  if (!options.enabled) {
+    return {
+      async measure(_name, run) {
+        return await run();
+      },
+      measureSync(_name, run) {
+        return run();
+      },
+      logIfSlow() {},
+    };
+  }
+
+  const startedAt = Date.now();
+  let didLog = false;
+  const spans: CodexThreadLifecycleTimingSpan[] = [];
+  const toMs = (value: number) => Math.max(0, Math.round(value));
+  const record = (name: string, spanStartedAt: number) => {
+    spans.push({
+      name,
+      durationMs: toMs(Date.now() - spanStartedAt),
+      elapsedMs: toMs(Date.now() - startedAt),
+    });
+  };
+  const snapshot = (): CodexThreadLifecycleTimingSummary => ({
+    totalMs: toMs(Date.now() - startedAt),
+    spans: spans.slice(),
+  });
+  const shouldLog = (summary: CodexThreadLifecycleTimingSummary) =>
+    summary.totalMs >= CODEX_THREAD_LIFECYCLE_TIMING_WARN_TOTAL_MS ||
+    summary.spans.some((span) => span.durationMs >= CODEX_THREAD_LIFECYCLE_TIMING_WARN_STAGE_MS);
+  const formatSpans = (summary: CodexThreadLifecycleTimingSummary) =>
+    summary.spans.length > 0
+      ? summary.spans
+          .map((span) => `${span.name}:${span.durationMs}ms@${span.elapsedMs}ms`)
+          .join(",")
+      : "none";
+  return {
+    async measure(name, run) {
+      const spanStartedAt = Date.now();
+      try {
+        return await run();
+      } finally {
+        record(name, spanStartedAt);
+      }
+    },
+    measureSync(name, run) {
+      const spanStartedAt = Date.now();
+      try {
+        return run();
+      } finally {
+        record(name, spanStartedAt);
+      }
+    },
+    logIfSlow(params) {
+      if (didLog) {
+        return;
+      }
+      const summary = snapshot();
+      if (!shouldLog(summary)) {
+        return;
+      }
+      didLog = true;
+      embeddedAgentLog.warn(
+        `codex app-server thread lifecycle timings runId=${params.runId} sessionId=${
+          params.sessionId
+        } sessionKey=${params.sessionKey ?? "unknown"} action=${params.action} totalMs=${
+          summary.totalMs
+        } stages=${formatSpans(summary)}`,
+        {
+          runId: params.runId,
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          action: params.action,
+          threadId: params.threadId,
+          totalMs: summary.totalMs,
+          spans: summary.spans,
+        },
+      );
+    },
+  };
+}
+
 export async function startOrResumeThread(params: {
   client: CodexAppServerClient;
   params: EmbeddedRunAttemptParams;
@@ -103,10 +211,16 @@ export async function startOrResumeThread(params: {
   pluginThreadConfig?: CodexPluginThreadConfigProvider;
   contextEngineProjection?: CodexContextEngineThreadBootstrapProjection;
 }): Promise<CodexAppServerThreadLifecycleBinding> {
-  const dynamicToolsFingerprint = fingerprintDynamicTools(params.dynamicTools);
-  const contextEngineBinding = buildContextEngineBinding(
-    params.params,
-    params.contextEngineProjection,
+  // Thread lifecycle spans are useful when profiling startup churn, but normal
+  // turns should not pay Date.now/span-array overhead while resuming threads.
+  const lifecycleTiming = createCodexThreadLifecycleTimingTracker({
+    enabled: isCodexAppServerProfilerEnabled(params.params.config),
+  });
+  const dynamicToolsFingerprint = lifecycleTiming.measureSync("fingerprint_dynamic_tools", () =>
+    fingerprintDynamicTools(params.dynamicTools),
+  );
+  const contextEngineBinding = lifecycleTiming.measureSync("context_engine_binding", () =>
+    buildContextEngineBinding(params.params, params.contextEngineProjection),
   );
   const userMcpServersConfigPatch =
     params.userMcpServersEnabled === false
@@ -118,11 +232,13 @@ export async function startOrResumeThread(params: {
   const environmentSelectionFingerprint = fingerprintEnvironmentSelection(
     params.environmentSelection,
   );
-  let binding = await readCodexAppServerBinding(params.params.sessionFile, {
-    authProfileStore: params.params.authProfileStore,
-    agentDir: params.params.agentDir,
-    config: params.params.config,
-  });
+  let binding = await lifecycleTiming.measure("read_binding", () =>
+    readCodexAppServerBinding(params.params.sessionFile, {
+      authProfileStore: params.params.authProfileStore,
+      agentDir: params.params.agentDir,
+      config: params.params.config,
+    }),
+  );
   let preserveExistingBinding = false;
   let rotatedContextEngineBinding = false;
   let prebuiltPluginThreadConfig: CodexPluginThreadConfig | undefined;
@@ -207,7 +323,9 @@ export async function startOrResumeThread(params: {
       })
     ) {
       try {
-        prebuiltPluginThreadConfig = await params.pluginThreadConfig?.build();
+        prebuiltPluginThreadConfig = await lifecycleTiming.measure("plugin_config_recovery", () =>
+          params.pluginThreadConfig?.build(),
+        );
         pluginBindingStale =
           prebuiltPluginThreadConfig?.fingerprint !== binding.pluginAppsFingerprint;
       } catch (error) {
@@ -274,19 +392,21 @@ export async function startOrResumeThread(params: {
           userMcpServersConfigPatch,
           params.finalConfigPatch,
         );
+        const resumeParams = lifecycleTiming.measureSync("thread_resume_params", () =>
+          buildThreadResumeParams(params.params, {
+            threadId: binding.threadId,
+            authProfileId,
+            appServer: params.appServer,
+            dynamicTools: params.dynamicTools,
+            developerInstructions: params.developerInstructions,
+            config: resumeConfig,
+            nativeCodeModeEnabled: params.nativeCodeModeEnabled,
+            nativeCodeModeOnlyEnabled: params.nativeCodeModeOnlyEnabled,
+          }),
+        );
         const response = assertCodexThreadResumeResponse(
-          await params.client.request(
-            "thread/resume",
-            buildThreadResumeParams(params.params, {
-              threadId: binding.threadId,
-              authProfileId,
-              appServer: params.appServer,
-              dynamicTools: params.dynamicTools,
-              developerInstructions: params.developerInstructions,
-              config: resumeConfig,
-              nativeCodeModeEnabled: params.nativeCodeModeEnabled,
-              nativeCodeModeOnlyEnabled: params.nativeCodeModeOnlyEnabled,
-            }),
+          await lifecycleTiming.measure("thread_resume_request", () =>
+            params.client.request("thread/resume", resumeParams),
           ),
         );
         const boundAuthProfileId = authProfileId;
@@ -301,29 +421,31 @@ export async function startOrResumeThread(params: {
           params.mcpServersFingerprintEvaluated === true
             ? params.mcpServersFingerprint
             : binding.mcpServersFingerprint;
-        await writeCodexAppServerBinding(
-          params.params.sessionFile,
-          {
-            threadId: response.thread.id,
-            cwd: params.cwd,
-            authProfileId: boundAuthProfileId,
-            model: params.params.modelId,
-            modelProvider: response.modelProvider ?? fallbackModelProvider,
-            dynamicToolsFingerprint,
-            userMcpServersFingerprint,
-            mcpServersFingerprint: nextMcpServersFingerprint,
-            pluginAppsFingerprint: binding.pluginAppsFingerprint,
-            pluginAppsInputFingerprint: binding.pluginAppsInputFingerprint,
-            pluginAppPolicyContext: binding.pluginAppPolicyContext,
-            contextEngine: contextEngineBinding,
-            environmentSelectionFingerprint,
-            createdAt: binding.createdAt,
-          },
-          {
-            authProfileStore: params.params.authProfileStore,
-            agentDir: params.params.agentDir,
-            config: params.params.config,
-          },
+        await lifecycleTiming.measure("thread_resume_write_binding", () =>
+          writeCodexAppServerBinding(
+            params.params.sessionFile,
+            {
+              threadId: response.thread.id,
+              cwd: params.cwd,
+              authProfileId: boundAuthProfileId,
+              model: params.params.modelId,
+              modelProvider: response.modelProvider ?? fallbackModelProvider,
+              dynamicToolsFingerprint,
+              userMcpServersFingerprint,
+              mcpServersFingerprint: nextMcpServersFingerprint,
+              pluginAppsFingerprint: binding.pluginAppsFingerprint,
+              pluginAppsInputFingerprint: binding.pluginAppsInputFingerprint,
+              pluginAppPolicyContext: binding.pluginAppPolicyContext,
+              contextEngine: contextEngineBinding,
+              environmentSelectionFingerprint,
+              createdAt: binding.createdAt,
+            },
+            {
+              authProfileStore: params.params.authProfileStore,
+              agentDir: params.params.agentDir,
+              config: params.params.config,
+            },
+          ),
         );
         if (contextEngineBinding) {
           embeddedAgentLog.info("codex app-server wrote context-engine thread binding", {
@@ -336,6 +458,13 @@ export async function startOrResumeThread(params: {
             action: "resumed",
           });
         }
+        lifecycleTiming.logIfSlow({
+          runId: params.params.runId,
+          sessionId: params.params.sessionId,
+          sessionKey: params.params.sessionKey,
+          threadId: response.thread.id,
+          action: "resumed",
+        });
         return {
           ...binding,
           threadId: response.thread.id,
@@ -366,27 +495,34 @@ export async function startOrResumeThread(params: {
   }
 
   const pluginThreadConfig = params.pluginThreadConfig?.enabled
-    ? (prebuiltPluginThreadConfig ?? (await params.pluginThreadConfig.build()))
+    ? (prebuiltPluginThreadConfig ??
+      (await lifecycleTiming.measure("plugin_config_build", () =>
+        params.pluginThreadConfig?.build(),
+      )))
     : undefined;
-  const config = mergeCodexThreadConfigs(
-    params.config,
-    userMcpServersConfigPatch,
-    pluginThreadConfig?.configPatch,
-    params.finalConfigPatch,
+  const config = lifecycleTiming.measureSync("merge_thread_config", () =>
+    mergeCodexThreadConfigs(
+      params.config,
+      userMcpServersConfigPatch,
+      pluginThreadConfig?.configPatch,
+      params.finalConfigPatch,
+    ),
+  );
+  const startParams = lifecycleTiming.measureSync("thread_start_params", () =>
+    buildThreadStartParams(params.params, {
+      cwd: params.cwd,
+      dynamicTools: params.dynamicTools,
+      appServer: params.appServer,
+      developerInstructions: params.developerInstructions,
+      config,
+      nativeCodeModeEnabled: params.nativeCodeModeEnabled,
+      nativeCodeModeOnlyEnabled: params.nativeCodeModeOnlyEnabled,
+      environmentSelection: params.environmentSelection,
+    }),
   );
   const response = assertCodexThreadStartResponse(
-    await params.client.request(
-      "thread/start",
-      buildThreadStartParams(params.params, {
-        cwd: params.cwd,
-        dynamicTools: params.dynamicTools,
-        appServer: params.appServer,
-        developerInstructions: params.developerInstructions,
-        config,
-        nativeCodeModeEnabled: params.nativeCodeModeEnabled,
-        nativeCodeModeOnlyEnabled: params.nativeCodeModeOnlyEnabled,
-        environmentSelection: params.environmentSelection,
-      }),
+    await lifecycleTiming.measure("thread_start_request", () =>
+      params.client.request("thread/start", startParams),
     ),
   );
   const modelProvider = resolveCodexAppServerModelProvider({
@@ -400,29 +536,31 @@ export async function startOrResumeThread(params: {
   const nextMcpServersFingerprint =
     params.mcpServersFingerprintEvaluated === true ? params.mcpServersFingerprint : undefined;
   if (!preserveExistingBinding) {
-    await writeCodexAppServerBinding(
-      params.params.sessionFile,
-      {
-        threadId: response.thread.id,
-        cwd: params.cwd,
-        authProfileId: params.params.authProfileId,
-        model: response.model ?? params.params.modelId,
-        modelProvider: response.modelProvider ?? modelProvider,
-        dynamicToolsFingerprint,
-        userMcpServersFingerprint,
-        mcpServersFingerprint: nextMcpServersFingerprint,
-        pluginAppsFingerprint: pluginThreadConfig?.fingerprint,
-        pluginAppsInputFingerprint: pluginThreadConfig?.inputFingerprint,
-        pluginAppPolicyContext: pluginThreadConfig?.policyContext,
-        contextEngine: contextEngineBinding,
-        environmentSelectionFingerprint,
-        createdAt,
-      },
-      {
-        authProfileStore: params.params.authProfileStore,
-        agentDir: params.params.agentDir,
-        config: params.params.config,
-      },
+    await lifecycleTiming.measure("thread_start_write_binding", () =>
+      writeCodexAppServerBinding(
+        params.params.sessionFile,
+        {
+          threadId: response.thread.id,
+          cwd: params.cwd,
+          authProfileId: params.params.authProfileId,
+          model: response.model ?? params.params.modelId,
+          modelProvider: response.modelProvider ?? modelProvider,
+          dynamicToolsFingerprint,
+          userMcpServersFingerprint,
+          mcpServersFingerprint: nextMcpServersFingerprint,
+          pluginAppsFingerprint: pluginThreadConfig?.fingerprint,
+          pluginAppsInputFingerprint: pluginThreadConfig?.inputFingerprint,
+          pluginAppPolicyContext: pluginThreadConfig?.policyContext,
+          contextEngine: contextEngineBinding,
+          environmentSelectionFingerprint,
+          createdAt,
+        },
+        {
+          authProfileStore: params.params.authProfileStore,
+          agentDir: params.params.agentDir,
+          config: params.params.config,
+        },
+      ),
     );
     if (contextEngineBinding) {
       embeddedAgentLog.info("codex app-server wrote context-engine thread binding", {
@@ -436,6 +574,13 @@ export async function startOrResumeThread(params: {
       });
     }
   }
+  lifecycleTiming.logIfSlow({
+    runId: params.params.runId,
+    sessionId: params.params.sessionId,
+    sessionKey: params.params.sessionKey,
+    threadId: response.thread.id,
+    action: rotatedContextEngineBinding ? "rotated" : "started",
+  });
   return {
     schemaVersion: 1,
     threadId: response.thread.id,

--- a/extensions/telegram/src/bot-message-context.test-harness.ts
+++ b/extensions/telegram/src/bot-message-context.test-harness.ts
@@ -24,10 +24,12 @@ type BuildTelegramMessageContextForTestParams = {
   options?: BuildTelegramMessageContextParams["options"];
   cfg?: Record<string, unknown>;
   accountId?: string;
+  dmPolicy?: BuildTelegramMessageContextParams["dmPolicy"];
   historyLimit?: number;
   groupHistories?: Map<string, import("openclaw/plugin-sdk/reply-history").HistoryEntry[]>;
   ackReactionScope?: BuildTelegramMessageContextParams["ackReactionScope"];
   botApi?: Record<string, unknown>;
+  sendChatActionHandler?: BuildTelegramMessageContextParams["sendChatActionHandler"];
   runtime?: BuildTelegramMessageContextParams["runtime"];
   sessionRuntime?: BuildTelegramMessageContextParams["sessionRuntime"] | null;
   resolveGroupActivation?: BuildTelegramMessageContextParams["resolveGroupActivation"];
@@ -127,7 +129,7 @@ export async function buildTelegramMessageContextForTest(
     account: { accountId: params.accountId ?? "default" } as never,
     historyLimit: params.historyLimit ?? 0,
     groupHistories: params.groupHistories ?? new Map(),
-    dmPolicy: "open",
+    dmPolicy: params.dmPolicy ?? "open",
     allowFrom: ["*"],
     groupAllowFrom: [],
     ackReactionScope: params.ackReactionScope ?? "off",
@@ -140,7 +142,7 @@ export async function buildTelegramMessageContextForTest(
         groupConfig: { requireMention: false },
         topicConfig: undefined,
       })),
-    sendChatActionHandler: { sendChatAction: vi.fn() } as never,
+    sendChatActionHandler: params.sendChatActionHandler ?? ({ sendChatAction: vi.fn() } as never),
   });
 }
 

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -109,6 +109,7 @@ export type TelegramMessageContext = {
   sendTyping: () => Promise<void>;
   sendRecordVoice: () => Promise<void>;
   sendChatActionHandler: BuildTelegramMessageContextParams["sendChatActionHandler"];
+  initialTypingCueSent?: boolean;
   ackReactionPromise: Promise<boolean> | null;
   reactionApi: TelegramReactionApi | null;
   removeAckAfterReply: boolean;
@@ -368,6 +369,7 @@ export const buildTelegramMessageContext = async ({
   ) {
     return null;
   }
+  let initialTypingCueSent = false;
   const ensureConfiguredBindingReady = async (): Promise<boolean> => {
     if (!configuredBinding) {
       return true;
@@ -478,6 +480,15 @@ export const buildTelegramMessageContext = async ({
 
   if (!(await ensureConfiguredBindingReady())) {
     return null;
+  }
+
+  // Direct chats are now reply-eligible; send the first typing cue before
+  // expensive context/session construction without showing typing for dropped turns.
+  if (!isGroup) {
+    initialTypingCueSent = true;
+    void sendTyping().catch((err) => {
+      logVerbose(`telegram early direct typing cue failed for chat ${chatId}: ${String(err)}`);
+    });
   }
 
   const { ctxPayload, skillFilter, turn } = await buildTelegramInboundContextPayload({
@@ -643,6 +654,7 @@ export const buildTelegramMessageContext = async ({
     sendTyping,
     sendRecordVoice,
     sendChatActionHandler,
+    initialTypingCueSent,
     ackReactionPromise,
     reactionApi,
     removeAckAfterReply,

--- a/extensions/telegram/src/bot-message-context.typing.test.ts
+++ b/extensions/telegram/src/bot-message-context.typing.test.ts
@@ -1,0 +1,80 @@
+import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
+import { describe, expect, it, vi } from "vitest";
+import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
+import type { TelegramSendChatActionHandler } from "./sendchataction-401-backoff.js";
+
+function createSendChatActionHandler(
+  sendChatAction = vi.fn(async () => undefined),
+): TelegramSendChatActionHandler & { sendChatAction: typeof sendChatAction } {
+  return {
+    sendChatAction,
+    isSuspended: () => false,
+    reset: () => undefined,
+  };
+}
+
+describe("buildTelegramMessageContext typing", () => {
+  it("sends direct typing after body resolution and before session context construction", async () => {
+    const buildInboundContext = vi.fn(buildChannelInboundEventContext);
+    const sendChatActionHandler = createSendChatActionHandler();
+
+    await expect(
+      buildTelegramMessageContextForTest({
+        message: {
+          chat: { id: 42, type: "private", first_name: "Pat" },
+          from: { id: 42, first_name: "Pat" },
+          text: "hello",
+        },
+        sendChatActionHandler,
+        sessionRuntime: {
+          buildChannelInboundEventContext: buildInboundContext,
+        },
+      }),
+    ).resolves.not.toBeNull();
+
+    expect(sendChatActionHandler.sendChatAction).toHaveBeenCalledWith(42, "typing", undefined);
+    expect(sendChatActionHandler.sendChatAction.mock.invocationCallOrder[0]).toBeLessThan(
+      buildInboundContext.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does not send direct typing when there is no replyable body", async () => {
+    const sendChatActionHandler = createSendChatActionHandler();
+
+    await expect(
+      buildTelegramMessageContextForTest({
+        message: {
+          chat: { id: 42, type: "private", first_name: "Pat" },
+          from: { id: 42, first_name: "Pat" },
+          text: undefined,
+        },
+        sendChatActionHandler,
+      }),
+    ).resolves.toBeNull();
+
+    expect(sendChatActionHandler.sendChatAction).not.toHaveBeenCalled();
+  });
+
+  it("does not send early direct typing before DM access passes", async () => {
+    const sendChatActionHandler = createSendChatActionHandler();
+
+    await expect(
+      buildTelegramMessageContextForTest({
+        message: {
+          chat: { id: 42, type: "private", first_name: "Pat" },
+          from: { id: 42, first_name: "Pat" },
+          text: "hello",
+        },
+        cfg: {
+          agents: { defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/openclaw" } },
+          channels: { telegram: { dmPolicy: "disabled", allowFrom: [] } },
+          messages: { groupChat: { mentionPatterns: [] } },
+        },
+        dmPolicy: "disabled",
+        sendChatActionHandler,
+      }),
+    ).resolves.toBeNull();
+
+    expect(sendChatActionHandler.sendChatAction).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1981,6 +1981,35 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(editMessageTelegram).not.toHaveBeenCalled();
   });
 
+  it("does not stream text-only tool results into progress drafts", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await dispatcherOptions.deliver(
+          { text: "stdout line one\nstdout line two" },
+          { kind: "tool" },
+        );
+        await replyOptions?.onItemEvent?.({ kind: "search", progressText: "docs lookup" });
+        return { queuedFinal: false };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+    });
+
+    expect(answerDraftStream.update).not.toHaveBeenCalledWith(
+      expect.stringContaining("stdout line one"),
+    );
+    expect(answerDraftStream.update).toHaveBeenLastCalledWith(
+      "Shelling\n\n`🛠️ Exec`\n`🔎 Web Search: docs lookup`",
+    );
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("does not restart progress drafts after final answer delivery", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1752,18 +1752,27 @@ export const dispatchTelegramMessage = async ({
                         reasoningStepState.noteReasoningHint();
                       }
                       if (segment.lane === "answer" && info.kind === "tool") {
-                        if (
-                          nativeToolProgressDraft &&
-                          canUseNativeToolProgressDraft({
-                            payload: effectivePayload,
-                            reply,
-                            buttons: telegramButtons,
-                          })
-                        ) {
+                        const canRepresentAsTransientProgress = canUseNativeToolProgressDraft({
+                          payload: effectivePayload,
+                          reply,
+                          buttons: telegramButtons,
+                        });
+                        if (nativeToolProgressDraft && canRepresentAsTransientProgress) {
                           if (await pushStreamToolProgress(segment.update.text)) {
                             blockDelivered = true;
                             continue;
                           }
+                        }
+                        if (
+                          canRepresentAsTransientProgress &&
+                          streamMode === "progress" &&
+                          answerLane.stream
+                        ) {
+                          // Progress-mode streams render tool status in the
+                          // live draft. Do not also emit text-only tool output
+                          // as answer text, or simple commands duplicate and
+                          // restart the progress draft.
+                          continue;
                         }
                         await prepareAnswerLaneForToolProgress();
                       }

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -160,7 +160,10 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
           (options?.ingressBuffer ? ` buffer=${options.ingressBuffer}` : ""),
       );
     }
-    if (context.ctxPayload.InboundEventKind !== "room_event") {
+    if (
+      context.ctxPayload.InboundEventKind !== "room_event" &&
+      context.initialTypingCueSent !== true
+    ) {
       void context.sendTyping().catch((err) => {
         logVerbose(`telegram early typing cue failed for chat ${context.chatId}: ${String(err)}`);
       });

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -929,6 +929,8 @@ async function agentCommandInternal(
       catalog: [],
       defaultProvider,
       defaultModel,
+      allowManifestNormalization: true,
+      allowPluginNormalization: true,
       ...modelManifestContext,
     });
 
@@ -940,6 +942,8 @@ async function agentCommandInternal(
         defaultProvider,
         defaultModel,
         agentId: sessionAgentId,
+        allowManifestNormalization: true,
+        allowPluginNormalization: true,
         ...modelManifestContext,
       });
       allowedModelCatalog = visibilityPolicy.allowedCatalog;

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -115,7 +115,28 @@ describe("native hook relay registry", () => {
     );
   });
 
-  it("preserves safety relays while marking hook-only events without handlers inactive", () => {
+  it("preserves permission relays while marking hook-only events without handlers inactive", () => {
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      sessionId: "session-1",
+      runId: "run-1",
+      command: {
+        executable: "/opt/Open Claw/openclaw.mjs",
+        nodeExecutable: "/usr/local/bin/node",
+        timeoutMs: 1234,
+      },
+    });
+
+    expect(relay.shouldRelayEvent("pre_tool_use")).toBe(false);
+    expect(relay.shouldRelayEvent("post_tool_use")).toBe(false);
+    expect(relay.shouldRelayEvent("before_agent_finalize")).toBe(false);
+    expect(relay.shouldRelayEvent("permission_request")).toBe(true);
+  });
+
+  it("builds pre-tool relay commands only when before-tool policy is active", () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: vi.fn() }]),
+    );
     const relay = registerNativeHookRelay({
       provider: "codex",
       sessionId: "session-1",
@@ -128,9 +149,42 @@ describe("native hook relay registry", () => {
     });
 
     expect(relay.shouldRelayEvent("pre_tool_use")).toBe(true);
-    expect(relay.shouldRelayEvent("post_tool_use")).toBe(false);
-    expect(relay.shouldRelayEvent("before_agent_finalize")).toBe(false);
-    expect(relay.shouldRelayEvent("permission_request")).toBe(true);
+    expect(relay.commandForEvent("pre_tool_use")).toBe(
+      "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
+        `${relay.relayId} --event pre_tool_use --timeout 1234`,
+    );
+  });
+
+  it("keeps pre-tool relays active when native loop detection is not disabled", () => {
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      runId: "run-1",
+      command: {
+        executable: "/opt/Open Claw/openclaw.mjs",
+        nodeExecutable: "/usr/local/bin/node",
+        timeoutMs: 1234,
+      },
+    });
+
+    expect(relay.shouldRelayEvent("pre_tool_use")).toBe(true);
+    expect(relay.commandForEvent("pre_tool_use")).toBe(
+      "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
+        `${relay.relayId} --event pre_tool_use --timeout 1234`,
+    );
+  });
+
+  it("omits pre-tool relays when native loop detection is explicitly disabled", () => {
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      runId: "run-1",
+      config: { tools: { loopDetection: { enabled: false } } } as never,
+    });
+
+    expect(relay.shouldRelayEvent("pre_tool_use")).toBe(false);
   });
 
   it("builds relay commands only for native events with matching local hooks", () => {
@@ -148,7 +202,7 @@ describe("native hook relay registry", () => {
       },
     });
 
-    expect(relay.shouldRelayEvent("pre_tool_use")).toBe(true);
+    expect(relay.shouldRelayEvent("pre_tool_use")).toBe(false);
     expect(relay.shouldRelayEvent("post_tool_use")).toBe(true);
     expect(relay.shouldRelayEvent("before_agent_finalize")).toBe(false);
     expect(relay.commandForEvent("post_tool_use")).toBe(
@@ -2282,6 +2336,21 @@ describe("native hook relay command builder", () => {
       }),
     ).toBe(
       "openclaw hooks relay --provider codex --relay-id relay-1 --event permission_request --timeout 5000",
+    );
+  });
+
+  it("can lower native hook relay process priority", () => {
+    const prefix = process.platform === "win32" ? "" : "nice -n 10 ";
+    expect(
+      buildNativeHookRelayCommand({
+        provider: "codex",
+        relayId: "relay-1",
+        event: "pre_tool_use",
+        executable: "openclaw",
+        nice: 10,
+      }),
+    ).toBe(
+      `${prefix}openclaw hooks relay --provider codex --relay-id relay-1 --event pre_tool_use --timeout 5000`,
     );
   });
 });

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -17,8 +17,9 @@ import { hasGlobalHooks } from "../../plugins/hook-runner-global.js";
 import { PluginApprovalResolutions } from "../../plugins/types.js";
 import { uniqueValues } from "../../shared/string-normalization.js";
 import { asBoolean } from "../../utils/boolean.js";
-import { runBeforeToolCallHook } from "../pi-tools.before-tool-call.js";
+import { hasBeforeToolCallPolicy, runBeforeToolCallHook } from "../pi-tools.before-tool-call.js";
 import { stableStringify } from "../stable-stringify.js";
+import { resolveToolLoopDetectionConfig } from "../tool-loop-detection-config.js";
 import { normalizeToolName } from "../tool-policy.js";
 import { callGatewayTool } from "../tools/gateway.js";
 import { runAgentHarnessAfterToolCallHook } from "./hook-helpers.js";
@@ -110,6 +111,7 @@ export type RegisterNativeHookRelayParams = {
 
 export type NativeHookRelayCommandOptions = {
   executable?: string;
+  nice?: number | false;
   nodeExecutable?: string;
   timeoutMs?: number;
 };
@@ -324,12 +326,13 @@ export function registerNativeHookRelay(
   registerNativeHookRelayBridge(registration);
   const handle: NativeHookRelayRegistrationHandle = {
     ...registration,
-    shouldRelayEvent: nativeHookRelayEventHasLocalWork,
+    shouldRelayEvent: (event) => nativeHookRelayEventHasLocalWork(registration, event),
     commandForEvent: (event) =>
       buildNativeHookRelayCommand({
         provider: params.provider,
         relayId,
         event,
+        nice: params.command?.nice,
         timeoutMs: params.command?.timeoutMs,
         executable: params.command?.executable,
         nodeExecutable: params.command?.nodeExecutable,
@@ -376,12 +379,24 @@ function normalizeRelayId(value: string | undefined): string | undefined {
   return trimmed;
 }
 
+function resolveNativeHookRelayNicePrefix(value: number | false | undefined): string[] {
+  if (process.platform === "win32" || value === false || value === undefined) {
+    return [];
+  }
+  const nice = normalizePositiveInteger(value, 0);
+  if (nice <= 0) {
+    return [];
+  }
+  return ["nice", "-n", String(nice)];
+}
+
 export function buildNativeHookRelayCommand(params: {
   provider: NativeHookRelayProvider;
   relayId: string;
   event: NativeHookRelayEvent;
   timeoutMs?: number;
   executable?: string;
+  nice?: number | false;
   nodeExecutable?: string;
 }): string {
   const timeoutMs = normalizePositiveInteger(params.timeoutMs, DEFAULT_RELAY_TIMEOUT_MS);
@@ -390,7 +405,9 @@ export function buildNativeHookRelayCommand(params: {
     executable === "openclaw"
       ? ["openclaw"]
       : [params.nodeExecutable ?? process.execPath, executable];
+  const nicePrefix = resolveNativeHookRelayNicePrefix(params.nice);
   return shellQuoteArgs([
+    ...nicePrefix,
     ...argv,
     "hooks",
     "relay",
@@ -405,9 +422,25 @@ export function buildNativeHookRelayCommand(params: {
   ]);
 }
 
-function nativeHookRelayEventHasLocalWork(event: NativeHookRelayEvent): boolean {
+function nativePreToolUseMayRunLoopDetection(registration: NativeHookRelayRegistration): boolean {
+  if (!registration.sessionKey) {
+    return false;
+  }
+  const loopDetection = resolveToolLoopDetectionConfig({
+    cfg: registration.config,
+    agentId: registration.agentId,
+  });
+  return loopDetection?.enabled !== false;
+}
+
+function nativeHookRelayEventHasLocalWork(
+  registration: NativeHookRelayRegistration,
+  event: NativeHookRelayEvent,
+): boolean {
   if (event === "pre_tool_use") {
-    return true;
+    // Avoid spawning a native hook relay for every Codex tool call when there
+    // is no before_tool_call hook, trusted-tool policy, or loop detector work.
+    return hasBeforeToolCallPolicy() || nativePreToolUseMayRunLoopDetection(registration);
   }
   if (event === "post_tool_use") {
     return hasGlobalHooks("after_tool_call");

--- a/src/agents/model-catalog.runtime.ts
+++ b/src/agents/model-catalog.runtime.ts
@@ -1,1 +1,1 @@
-export { loadModelCatalog } from "./model-catalog.js";
+export { loadManifestModelCatalog, loadModelCatalog } from "./model-catalog.js";

--- a/src/agents/model-ref-shared.test.ts
+++ b/src/agents/model-ref-shared.test.ts
@@ -16,6 +16,22 @@ describe("normalizeStaticProviderModelId", () => {
       "nvidia/nemotron-3-super-120b-a12b",
     );
   });
+
+  it("keeps OpenRouter bare compatibility ids provider-qualified without manifest lookup", () => {
+    expect(
+      normalizeStaticProviderModelId("openrouter", "auto", {
+        allowManifestNormalization: false,
+      }),
+    ).toBe("openrouter/auto");
+  });
+
+  it("normalizes retired XAI beta ids without manifest lookup", () => {
+    expect(
+      normalizeStaticProviderModelId("xai", "grok-4.20-experimental-beta-0304-reasoning", {
+        allowManifestNormalization: false,
+      }),
+    ).toBe("grok-4.20-beta-latest-reasoning");
+  });
 });
 
 describe("normalizeConfiguredProviderCatalogModelId", () => {

--- a/src/agents/model-ref-shared.ts
+++ b/src/agents/model-ref-shared.ts
@@ -55,6 +55,21 @@ function normalizeBuiltInProviderModelId(provider: string, model: string): strin
   if (provider === "google" || provider === "google-gemini-cli" || provider === "google-vertex") {
     return normalizeGooglePreviewModelId(model);
   }
+  if (provider === "openrouter") {
+    const trimmed = model.trim();
+    return trimmed && !trimmed.includes("/") ? `openrouter/${trimmed}` : model;
+  }
+  if (provider === "xai") {
+    const xaiAliases: Record<string, string> = {
+      "grok-4-fast-reasoning": "grok-4-fast",
+      "grok-4-1-fast-reasoning": "grok-4-1-fast",
+      "grok-4.20-experimental-beta-0304-reasoning": "grok-4.20-beta-latest-reasoning",
+      "grok-4.20-experimental-beta-0304-non-reasoning": "grok-4.20-beta-latest-non-reasoning",
+      "grok-4.20-reasoning": "grok-4.20-beta-latest-reasoning",
+      "grok-4.20-non-reasoning": "grok-4.20-beta-latest-non-reasoning",
+    };
+    return xaiAliases[normalizeLowercaseStringOrEmpty(model)] ?? model;
+  }
   return model;
 }
 

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -438,12 +438,16 @@ export function resolveAllowlistModelKey(
     cfg?: OpenClawConfig;
     raw: string;
     defaultProvider: string;
+    allowManifestNormalization?: boolean;
+    allowPluginNormalization?: boolean;
   } & ModelManifestNormalizationContext,
 ): string | null {
   const parsed = parseModelRefWithCompatAlias({
     cfg: params.cfg,
     raw: params.raw,
     defaultProvider: params.defaultProvider,
+    allowManifestNormalization: params.allowManifestNormalization,
+    allowPluginNormalization: params.allowPluginNormalization,
     manifestPlugins: params.manifestPlugins,
   });
   if (!parsed) {
@@ -540,6 +544,8 @@ function buildModelCatalogMetadata(
   params: {
     cfg: OpenClawConfig;
     defaultProvider: string;
+    allowManifestNormalization?: boolean;
+    allowPluginNormalization?: boolean;
   } & ModelManifestNormalizationContext,
 ): ModelCatalogMetadata {
   const configuredByKey = new Map<string, ModelCatalogEntry>();
@@ -564,6 +570,8 @@ function buildModelCatalogMetadata(
       cfg: params.cfg,
       raw: rawKey,
       defaultProvider: params.defaultProvider,
+      allowManifestNormalization: params.allowManifestNormalization,
+      allowPluginNormalization: params.allowPluginNormalization,
       manifestPlugins: params.manifestPlugins,
     });
     if (!key) {
@@ -800,6 +808,8 @@ export function buildAllowedModelSetWithFallbacks(
   const metadata = buildModelCatalogMetadata({
     cfg: params.cfg,
     defaultProvider: params.defaultProvider,
+    allowManifestNormalization: params.allowManifestNormalization,
+    allowPluginNormalization: params.allowPluginNormalization,
     manifestPlugins: params.manifestPlugins,
   });
   const configuredCatalog = buildConfiguredModelCatalog({
@@ -1276,9 +1286,13 @@ export function resolveAllowedModelSelection(
     allowAny: boolean;
     allowedKeys: ReadonlySet<string>;
     allowedCatalog: readonly ModelCatalogEntry[];
+    allowManifestNormalization?: boolean;
+    allowPluginNormalization?: boolean;
   } & ModelManifestNormalizationContext,
 ): ModelRef | null {
   const current = normalizeModelRef(params.provider, params.model, {
+    allowManifestNormalization: params.allowManifestNormalization,
+    allowPluginNormalization: params.allowPluginNormalization,
     manifestPlugins: params.manifestPlugins,
   });
   if (
@@ -1292,6 +1306,8 @@ export function resolveAllowedModelSelection(
     return null;
   }
   return normalizeModelRef(fallback.provider, fallback.id, {
+    allowManifestNormalization: params.allowManifestNormalization,
+    allowPluginNormalization: params.allowPluginNormalization,
     manifestPlugins: params.manifestPlugins,
   });
 }
@@ -1335,6 +1351,8 @@ export function createModelVisibilityPolicyWithFallbacks(
     defaultProvider: string;
     defaultModel?: string;
     fallbackModels: readonly string[];
+    allowManifestNormalization?: boolean;
+    allowPluginNormalization?: boolean;
   } & ModelManifestNormalizationContext,
 ): ModelVisibilityPolicy {
   const visibility = parseConfiguredModelVisibilityEntries({ cfg: params.cfg });
@@ -1347,6 +1365,8 @@ export function createModelVisibilityPolicyWithFallbacks(
       cfg: params.cfg,
       raw,
       defaultProvider: params.defaultProvider,
+      allowManifestNormalization: params.allowManifestNormalization,
+      allowPluginNormalization: params.allowPluginNormalization,
       manifestPlugins: params.manifestPlugins,
     });
     if (key) {
@@ -1370,6 +1390,8 @@ export function createModelVisibilityPolicyWithFallbacks(
         allowAny: allowed.allowAny,
         allowedKeys: allowed.allowedKeys,
         allowedCatalog: allowed.allowedCatalog,
+        allowManifestNormalization: params.allowManifestNormalization,
+        allowPluginNormalization: params.allowPluginNormalization,
         manifestPlugins: params.manifestPlugins,
       }),
     visibleCatalog: ({ catalog, defaultVisibleCatalog, view }) => {

--- a/src/agents/model-selection.plugin-runtime.test.ts
+++ b/src/agents/model-selection.plugin-runtime.test.ts
@@ -106,4 +106,118 @@ describe("model-selection plugin runtime normalization", () => {
       model: "custom-modern-model",
     });
   });
+
+  it("keeps model visibility policy construction off plugin runtime hooks by default", async () => {
+    normalizeProviderModelIdWithPluginMock.mockImplementation(({ provider, context }) => {
+      if (
+        provider === "custom-provider" &&
+        (context as { modelId?: string }).modelId === "custom-legacy-model"
+      ) {
+        return "custom-modern-model";
+      }
+      return undefined;
+    });
+
+    const { createModelVisibilityPolicy } = await import("./model-visibility-policy.js");
+
+    const policy = createModelVisibilityPolicy({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "custom-provider/custom-legacy-model": {},
+            },
+          },
+        },
+      },
+      catalog: [],
+      defaultProvider: "custom-provider",
+      defaultModel: "custom-legacy-model",
+    });
+
+    expect(policy.allowedKeys.has("custom-provider/custom-legacy-model")).toBe(true);
+    expect(policy.allowedKeys.has("custom-provider/custom-modern-model")).toBe(false);
+    expect(normalizeProviderModelIdWithPluginMock).not.toHaveBeenCalled();
+  });
+
+  it("propagates explicit plugin runtime normalization opt-in through model visibility policy", async () => {
+    normalizeProviderModelIdWithPluginMock.mockImplementation(({ provider, context }) => {
+      if (
+        provider === "custom-provider" &&
+        (context as { modelId?: string }).modelId === "custom-legacy-model"
+      ) {
+        return "custom-modern-model";
+      }
+      return undefined;
+    });
+
+    const { createModelVisibilityPolicy } = await import("./model-visibility-policy.js");
+
+    const policy = createModelVisibilityPolicy({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "custom-provider/custom-legacy-model": {},
+            },
+          },
+        },
+      },
+      catalog: [],
+      defaultProvider: "custom-provider",
+      defaultModel: "custom-legacy-model",
+      allowPluginNormalization: true,
+    });
+
+    expect(policy.allowedKeys.has("custom-provider/custom-modern-model")).toBe(true);
+    expect(normalizeProviderModelIdWithPluginMock).toHaveBeenCalled();
+  });
+
+  it("keeps plugin-normalized stored overrides allowed in auto-reply runtime selection", async () => {
+    normalizeProviderModelIdWithPluginMock.mockImplementation(({ provider, context }) => {
+      if (
+        provider === "custom-provider" &&
+        (context as { modelId?: string }).modelId === "custom-legacy-model"
+      ) {
+        return "custom-modern-model";
+      }
+      return undefined;
+    });
+
+    const { createModelSelectionState } = await import("../auto-reply/reply/model-selection.js");
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "custom-provider/custom-legacy-model": {},
+          },
+        },
+      },
+    };
+    const sessionKey = "agent:main:discord:channel:c1";
+    const sessionEntry = {
+      sessionId: sessionKey,
+      updatedAt: 1,
+      providerOverride: "custom-provider",
+      modelOverride: "custom-legacy-model",
+    };
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: cfg.agents.defaults,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider: "custom-provider",
+      defaultModel: "custom-legacy-model",
+      provider: "custom-provider",
+      model: "custom-legacy-model",
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe("custom-provider");
+    expect(state.model).toBe("custom-modern-model");
+    expect(state.resetModelOverride).toBe(false);
+  });
 });

--- a/src/agents/model-visibility-policy.ts
+++ b/src/agents/model-visibility-policy.ts
@@ -25,6 +25,8 @@ export function createModelVisibilityPolicy(
     defaultProvider: string;
     defaultModel?: string;
     agentId?: string;
+    allowManifestNormalization?: boolean;
+    allowPluginNormalization?: boolean;
   } & ModelManifestNormalizationContext,
 ): ModelVisibilityPolicy {
   return createModelVisibilityPolicyWithFallbacks({
@@ -36,6 +38,11 @@ export function createModelVisibilityPolicy(
       cfg: params.cfg,
       agentId: params.agentId,
     }),
+    // Model visibility is used by lightweight status/list paths. Keep plugin
+    // manifest normalization opt-in so those paths do not load plugin runtime
+    // metadata unless a caller explicitly needs it.
+    allowManifestNormalization: params.allowManifestNormalization ?? false,
+    allowPluginNormalization: params.allowPluginNormalization ?? false,
     manifestPlugins: params.manifestPlugins,
   });
 }

--- a/src/agents/pi-embedded-runner/compact-reasons.test.ts
+++ b/src/agents/pi-embedded-runner/compact-reasons.test.ts
@@ -34,6 +34,16 @@ describe("classifyCompactionReason", () => {
     );
   });
 
+  it('classifies "already under target" as below threshold', () => {
+    expect(classifyCompactionReason("already under target")).toBe("below_threshold");
+  });
+
+  it("classifies deferred background maintenance as a skip-like reason", () => {
+    expect(classifyCompactionReason("deferred to background context-engine maintenance")).toBe(
+      "deferred_background",
+    );
+  });
+
   it("classifies safeguard messages as guard-blocked", () => {
     expect(
       classifyCompactionReason(

--- a/src/agents/pi-embedded-runner/compact-reasons.ts
+++ b/src/agents/pi-embedded-runner/compact-reasons.ts
@@ -3,6 +3,9 @@ import { sanitizeForLog } from "../../terminal/ansi.js";
 
 const MAX_COMPACTION_REASON_DETAIL_CHARS = 100;
 
+export const DEFERRED_CONTEXT_ENGINE_COMPACTION_REASON =
+  "deferred to background context-engine maintenance";
+
 function isGenericCompactionCancelledReason(reason: string): boolean {
   const normalized = normalizeLowercaseStringOrEmpty(reason);
   return normalized === "compaction cancelled" || normalized === "error: compaction cancelled";
@@ -26,11 +29,16 @@ export function classifyCompactionReason(reason?: string): string {
   if (text.includes("nothing to compact")) {
     return "no_compactable_entries";
   }
-  if (text.includes("below threshold")) {
+  // Backends use both phrases for the same harmless state: the transcript is
+  // already small enough, so preflight compaction should skip instead of fail.
+  if (text.includes("below threshold") || text.includes("already under target")) {
     return "below_threshold";
   }
   if (text.includes("already compacted")) {
     return "already_compacted_recently";
+  }
+  if (text.includes("deferred to background")) {
+    return "deferred_background";
   }
   if (text.includes("still exceeds target")) {
     return "live_context_still_exceeds_target";

--- a/src/agents/pi-embedded-runner/compact.hooks.harness.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.harness.ts
@@ -97,6 +97,13 @@ function createDefaultSessionMessages(): unknown[] {
 export const sessionMessages: unknown[] = createDefaultSessionMessages();
 export const sessionAbortCompactionMock: Mock<(reason?: unknown) => void> = vi.fn();
 export const createOpenClawCodingToolsMock = vi.fn(() => []);
+export const guardSessionManagerMock = vi.fn(() => ({
+  flushPendingToolResults: vi.fn(),
+}));
+export const applyPiCompactionSettingsFromConfigMock = vi.fn();
+export const createPreparedEmbeddedPiSettingsManagerMock = vi.fn(() => ({
+  getGlobalSettings: vi.fn(() => ({})),
+}));
 export const listRegisteredPluginAgentPromptGuidanceMock = vi.fn((params?: { surface?: string }) =>
   params?.surface === "subagent"
     ? ["Subagent compact command guidance."]
@@ -120,6 +127,7 @@ export const rotateTranscriptAfterCompactionMock: Mock<
 > = vi.fn(async () => ({
   rotated: false,
 }));
+export const enqueueCommandInLaneMock = vi.fn((_lane: unknown, task: () => unknown) => task());
 
 function createCompactHooksRuntimePlan(params: BuildAgentRuntimePlanParams): AgentRuntimePlan {
   const modelApi = params.modelApi ?? params.model?.api ?? undefined;
@@ -272,6 +280,8 @@ export function resetCompactSessionStateMocks(): void {
   maybeCompactAgentHarnessSessionMock.mockResolvedValue(undefined);
   rotateTranscriptAfterCompactionMock.mockReset();
   rotateTranscriptAfterCompactionMock.mockResolvedValue({ rotated: false });
+  enqueueCommandInLaneMock.mockReset();
+  enqueueCommandInLaneMock.mockImplementation((_lane: unknown, task: () => unknown) => task());
   listRegisteredPluginAgentPromptGuidanceMock.mockReset();
   listRegisteredPluginAgentPromptGuidanceMock.mockImplementation((params?: { surface?: string }) =>
     params?.surface === "subagent"
@@ -332,6 +342,15 @@ export function resetCompactHooksHarnessMocks(): void {
   resetCompactSessionStateMocks();
   createOpenClawCodingToolsMock.mockReset();
   createOpenClawCodingToolsMock.mockReturnValue([]);
+  guardSessionManagerMock.mockReset();
+  guardSessionManagerMock.mockReturnValue({
+    flushPendingToolResults: vi.fn(),
+  });
+  applyPiCompactionSettingsFromConfigMock.mockReset();
+  createPreparedEmbeddedPiSettingsManagerMock.mockReset();
+  createPreparedEmbeddedPiSettingsManagerMock.mockReturnValue({
+    getGlobalSettings: vi.fn(() => ({})),
+  });
 }
 
 export async function loadCompactHooksHarness(): Promise<{
@@ -470,14 +489,12 @@ export async function loadCompactHooksHarness(): Promise<{
   }));
 
   vi.doMock("../session-tool-result-guard-wrapper.js", () => ({
-    guardSessionManager: vi.fn(() => ({
-      flushPendingToolResults: vi.fn(),
-    })),
+    guardSessionManager: guardSessionManagerMock,
   }));
 
   vi.doMock("../pi-settings.js", () => ({
     applyPiAutoCompactionGuard: vi.fn(() => ({ supported: true, disabled: false })),
-    applyPiCompactionSettingsFromConfig: vi.fn(),
+    applyPiCompactionSettingsFromConfig: applyPiCompactionSettingsFromConfigMock,
     ensurePiCompactionReserveTokens: vi.fn(),
     isSilentOverflowProneModel: vi.fn(() => false),
     resolveCompactionReserveTokensFloor: vi.fn(() => 0),
@@ -532,7 +549,7 @@ export async function loadCompactHooksHarness(): Promise<{
   }));
 
   vi.doMock("../../process/command-queue.js", () => ({
-    enqueueCommandInLane: vi.fn((_lane: unknown, task: () => unknown) => task()),
+    enqueueCommandInLane: enqueueCommandInLaneMock,
     clearCommandLane: vi.fn(() => 0),
   }));
 
@@ -793,9 +810,7 @@ export async function loadCompactHooksHarness(): Promise<{
   }));
 
   vi.doMock("../pi-project-settings.js", () => ({
-    createPreparedEmbeddedPiSettingsManager: vi.fn(() => ({
-      getGlobalSettings: vi.fn(() => ({})),
-    })),
+    createPreparedEmbeddedPiSettingsManager: createPreparedEmbeddedPiSettingsManagerMock,
   }));
 
   vi.doMock("./sandbox-info.js", () => ({

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -2,12 +2,16 @@ import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   applyExtraParamsToAgentMock,
+  applyPiCompactionSettingsFromConfigMock,
   buildEmbeddedSystemPromptMock,
   contextEngineCompactMock,
+  createPreparedEmbeddedPiSettingsManagerMock,
   createOpenClawCodingToolsMock,
+  enqueueCommandInLaneMock,
   ensureRuntimePluginsLoaded,
   estimateTokensMock,
   getMemorySearchManagerMock,
+  guardSessionManagerMock,
   hookRunner,
   listRegisteredPluginAgentPromptGuidanceMock,
   loadCompactHooksHarness,
@@ -391,6 +395,15 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
 
     expectRecordFields(mockCallArg(createOpenClawCodingToolsMock), {
       modelContextWindowTokens: 64_000,
+    });
+    expectRecordFields(mockCallArg(guardSessionManagerMock, 0, 1), {
+      contextWindowTokens: 64_000,
+    });
+    expectRecordFields(mockCallArg(createPreparedEmbeddedPiSettingsManagerMock), {
+      contextTokenBudget: 64_000,
+    });
+    expectRecordFields(mockCallArg(applyPiCompactionSettingsFromConfigMock), {
+      contextTokenBudget: 64_000,
     });
   });
 
@@ -1540,6 +1553,39 @@ describe("compactEmbeddedPiSession hooks (ownsCompaction engine)", () => {
       authProfileId: "openai:p1",
       currentTokenCount: 333,
     });
+  });
+
+  it("fails deferred budget compaction when background maintenance is not scheduled", async () => {
+    const dispose = vi.fn(async () => {});
+    const maintain = vi.fn(async () => ({
+      changed: false,
+      bytesFreed: 0,
+      rewrittenEntries: 0,
+    }));
+    resolveContextEngineMock.mockResolvedValue({
+      info: { ownsCompaction: true, turnMaintenanceMode: "background" },
+      compact: contextEngineCompactMock,
+      dispose,
+      maintain,
+    } as never);
+    enqueueCommandInLaneMock.mockImplementationOnce(() => {
+      throw new Error("scheduler offline");
+    });
+
+    const result = await compactEmbeddedPiSession(
+      wrappedCompactionArgs({
+        trigger: "budget",
+        deferOwningContextEngineCompaction: true,
+      }),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe("failed to schedule background context-engine maintenance");
+    expect(result.failure?.reason).toBe("deferred_compaction_not_scheduled");
+    expect(dispose).toHaveBeenCalledTimes(1);
+    expect(maintain).not.toHaveBeenCalled();
+    expect(contextEngineCompactMock).not.toHaveBeenCalled();
   });
 
   it("does not fall back to context-engine compaction for Codex native binding failures", async () => {

--- a/src/agents/pi-embedded-runner/compact.queued.ts
+++ b/src/agents/pi-embedded-runner/compact.queued.ts
@@ -3,7 +3,7 @@ import {
   resolveContextEngine,
   resolveContextEngineOwnerPluginId,
 } from "../../context-engine/registry.js";
-import type { ContextEngineRuntimeContext } from "../../context-engine/types.js";
+import type { ContextEngine, ContextEngineRuntimeContext } from "../../context-engine/types.js";
 import {
   captureCompactionCheckpointSnapshotAsync,
   cleanupCompactionCheckpointSnapshot,
@@ -26,6 +26,7 @@ import {
 } from "../harness/selection.js";
 import { resolveContextConfigProviderForRuntime } from "../openai-codex-routing.js";
 import { ensureRuntimePluginsLoaded } from "../runtime-plugins.js";
+import { DEFERRED_CONTEXT_ENGINE_COMPACTION_REASON } from "./compact-reasons.js";
 import type { CompactEmbeddedPiSessionParams } from "./compact.types.js";
 import { asCompactionHookRunner, runPostCompactionSideEffects } from "./compaction-hooks.js";
 import {
@@ -62,6 +63,88 @@ function shouldFallbackAfterHarnessCompaction(
     (result.failure?.reason === "missing_thread_binding" ||
       result.failure?.reason === "stale_thread_binding")
   );
+}
+
+const DEFERRED_CONTEXT_ENGINE_COMPACTION_SCHEDULE_FAILURE_REASON =
+  "failed to schedule background context-engine maintenance";
+
+function shouldDeferOwningContextEngineBudgetCompaction(params: {
+  compactParams: CompactEmbeddedPiSessionParams;
+  contextEngine: ContextEngine;
+}): boolean {
+  // Request-time budget compaction for context-engine-owned transcripts can
+  // spend the whole reply preflight budget. Only defer engines that explicitly
+  // advertise background turn maintenance, leaving native/current-session
+  // harness compaction synchronous.
+  return (
+    params.compactParams.deferOwningContextEngineCompaction === true &&
+    params.compactParams.trigger === "budget" &&
+    params.contextEngine.info.ownsCompaction === true &&
+    params.contextEngine.info.turnMaintenanceMode === "background" &&
+    typeof params.contextEngine.maintain === "function"
+  );
+}
+
+async function disposeContextEngine(contextEngine: ContextEngine): Promise<void> {
+  try {
+    await contextEngine.dispose?.();
+  } catch (err) {
+    log.warn("context engine dispose failed after deferred maintenance", {
+      errorMessage: formatErrorMessage(err),
+    });
+  }
+}
+
+async function deferOwningContextEngineBudgetCompaction(params: {
+  compactParams: CompactEmbeddedPiSessionParams;
+  contextEngine: ContextEngine;
+  contextEngineRuntimeContext: ContextEngineRuntimeContext;
+}): Promise<EmbeddedPiCompactResult> {
+  let deferredScheduled = false;
+  try {
+    await runContextEngineMaintenance({
+      contextEngine: params.contextEngine,
+      sessionId: params.compactParams.sessionId,
+      sessionKey: params.compactParams.sessionKey,
+      sessionFile: params.compactParams.sessionFile,
+      reason: "turn",
+      runtimeContext: params.contextEngineRuntimeContext,
+      config: params.compactParams.config,
+      disposeDeferredContextEngineAfterMaintenance: true,
+      onDeferredMaintenance: () => {
+        deferredScheduled = true;
+      },
+    });
+  } catch (err) {
+    log.warn("failed to defer context-engine budget compaction", {
+      errorMessage: formatErrorMessage(err),
+    });
+  }
+
+  if (!deferredScheduled) {
+    await disposeContextEngine(params.contextEngine);
+    log.warn(
+      `[compaction] failed to schedule context-engine-owned budget compaction background maintenance ` +
+        `(sessionKey=${params.compactParams.sessionKey ?? params.compactParams.sessionId})`,
+    );
+    return {
+      ok: false,
+      compacted: false,
+      reason: DEFERRED_CONTEXT_ENGINE_COMPACTION_SCHEDULE_FAILURE_REASON,
+      failure: { reason: "deferred_compaction_not_scheduled" },
+    };
+  }
+
+  log.info(
+    `[compaction] deferred context-engine-owned budget compaction to background maintenance ` +
+      `(sessionKey=${params.compactParams.sessionKey ?? params.compactParams.sessionId} ` +
+      `scheduled=${String(deferredScheduled)})`,
+  );
+  return {
+    ok: true,
+    compacted: false,
+    reason: DEFERRED_CONTEXT_ENGINE_COMPACTION_REASON,
+  };
 }
 
 /**
@@ -164,6 +247,18 @@ export async function compactEmbeddedPiSession(
     log.warn(
       `native harness compaction could not use its session binding; falling back to context engine: ${harnessResult.reason ?? "unknown"}`,
     );
+  }
+  if (
+    shouldDeferOwningContextEngineBudgetCompaction({
+      compactParams: params,
+      contextEngine,
+    })
+  ) {
+    return await deferOwningContextEngineBudgetCompaction({
+      compactParams: params,
+      contextEngine,
+      contextEngineRuntimeContext,
+    });
   }
   const sessionLane = resolveSessionLane(params.sessionKey?.trim() || params.sessionId);
   const globalLane = resolveGlobalLane(params.lane);

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -499,6 +499,8 @@ async function compactEmbeddedPiSessionDirectOnce(
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
   });
+  // Keep the configured provider for context-window policy, while auth/model loading below can
+  // route OpenAI compaction through Codex OAuth when that runtime owns the session credentials.
   const modelConfigProvider = resolvedCompactionTarget.provider ?? DEFAULT_PROVIDER;
   const modelId = resolvedCompactionTarget.model ?? DEFAULT_MODEL;
   const authProfileId = resolvedCompactionTarget.authProfileId;
@@ -727,7 +729,7 @@ async function compactEmbeddedPiSessionDirectOnce(
         model: effectiveModel,
         modelApi: effectiveModel.api,
         harnessId: params.agentHarnessId,
-        harnessRuntime: params.agentHarnessId,
+        harnessRuntime: selectedHarnessRuntime,
         authProfileProvider: authProfileId?.split(":", 1)[0],
         sessionAuthProfileId: authProfileId,
         config: params.config,

--- a/src/agents/pi-embedded-runner/compact.types.ts
+++ b/src/agents/pi-embedded-runner/compact.types.ts
@@ -62,6 +62,11 @@ export type CompactEmbeddedPiSessionParams = {
   tokenBudget?: number;
   force?: boolean;
   trigger?: "budget" | "overflow" | "manual";
+  /**
+   * Preflight callers can allow native/current-session harness compaction but
+   * move plugin-owned budget compaction onto background turn maintenance.
+   */
+  deferOwningContextEngineCompaction?: boolean;
   diagId?: string;
   attempt?: number;
   maxAttempts?: number;

--- a/src/agents/pi-embedded-runner/context-engine-maintenance.test.ts
+++ b/src/agents/pi-embedded-runner/context-engine-maintenance.test.ts
@@ -340,6 +340,7 @@ describe("createDeferredTurnMaintenanceAbortSignal", () => {
 
 describe("runContextEngineMaintenance", () => {
   beforeEach(async () => {
+    vi.useRealTimers();
     rewriteTranscriptEntriesInSessionManagerMock.mockClear();
     rewriteTranscriptEntriesInSessionFileMock.mockClear();
     await loadFreshContextEngineMaintenanceModuleForTest();
@@ -841,6 +842,118 @@ describe("runContextEngineMaintenance", () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+  });
+
+  it("disposes owned deferred engines only after their maintenance run finishes", async () => {
+    await withStateDirEnv("openclaw-turn-maintenance-dispose-", async () => {
+      resetCommandQueueStateForTest();
+      resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
+      const waitForRealAssertion = async (assertion: () => void): Promise<void> => {
+        const startedAt = Date.now();
+        for (;;) {
+          try {
+            assertion();
+            return;
+          } catch (error) {
+            if (Date.now() - startedAt >= 2_000) {
+              throw error;
+            }
+            await new Promise<void>((resolve) => setTimeout(resolve, 5));
+          }
+        }
+      };
+
+      const sessionKey = "agent:main:session-owned-dispose";
+      const events: string[] = [];
+      let releaseFirstMaintenance: (() => void) | undefined;
+      let releaseSecondMaintenance: (() => void) | undefined;
+
+      const createBackgroundEngine = (id: "first" | "second") =>
+        ({
+          info: {
+            id,
+            name: "Test Engine",
+            turnMaintenanceMode: "background" as const,
+          },
+          ingest: async () => ({ ingested: true }),
+          assemble: async ({ messages }: { messages: unknown[] }) => ({
+            messages,
+            estimatedTokens: 0,
+          }),
+          compact: async () => ({ ok: true, compacted: false }),
+          maintain: vi.fn(async () => {
+            events.push(`maintain:${id}`);
+            await new Promise<void>((resolve) => {
+              if (id === "first") {
+                releaseFirstMaintenance = resolve;
+              } else {
+                releaseSecondMaintenance = resolve;
+              }
+            });
+            return {
+              changed: false,
+              bytesFreed: 0,
+              rewrittenEntries: 0,
+            };
+          }),
+          dispose: vi.fn(async () => {
+            events.push(`dispose:${id}`);
+          }),
+        }) as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+
+      const firstEngine = createBackgroundEngine("first");
+      const secondEngine = createBackgroundEngine("second");
+      const deferredPromises: Promise<void>[] = [];
+
+      await runContextEngineMaintenance({
+        contextEngine: firstEngine,
+        sessionId: "session-owned-dispose",
+        sessionKey,
+        sessionFile: "/tmp/session-owned-dispose.jsonl",
+        reason: "turn",
+        disposeDeferredContextEngineAfterMaintenance: true,
+        onDeferredMaintenance: (promise) => {
+          deferredPromises.push(promise);
+        },
+      });
+
+      await waitForRealAssertion(() => expect(events).toContain("maintain:first"));
+
+      await runContextEngineMaintenance({
+        contextEngine: secondEngine,
+        sessionId: "session-owned-dispose",
+        sessionKey,
+        sessionFile: "/tmp/session-owned-dispose.jsonl",
+        reason: "turn",
+        disposeDeferredContextEngineAfterMaintenance: true,
+        onDeferredMaintenance: (promise) => {
+          deferredPromises.push(promise);
+        },
+      });
+
+      if (!releaseFirstMaintenance) {
+        throw new Error("Expected first maintenance release callback to be initialized");
+      }
+      releaseFirstMaintenance();
+      await waitForRealAssertion(() => expect(events).toContain("maintain:second"));
+      expect(secondEngine.dispose).not.toHaveBeenCalled();
+
+      if (!releaseSecondMaintenance) {
+        throw new Error("Expected second maintenance release callback to be initialized");
+      }
+      releaseSecondMaintenance();
+      await deferredPromises[1];
+
+      expect(firstEngine.dispose).toHaveBeenCalledTimes(1);
+      expect(secondEngine.dispose).toHaveBeenCalledTimes(1);
+      expect(events).toEqual([
+        "maintain:first",
+        "dispose:first",
+        "maintain:second",
+        "dispose:second",
+      ]);
     });
   });
 

--- a/src/agents/pi-embedded-runner/context-engine-maintenance.ts
+++ b/src/agents/pi-embedded-runner/context-engine-maintenance.ts
@@ -50,6 +50,7 @@ type DeferredTurnMaintenanceScheduleParams = {
   runtimeContext?: ContextEngineRuntimeContext;
   agentId?: string;
   config?: OpenClawConfig;
+  disposeContextEngineAfterMaintenance?: boolean;
 };
 
 type DeferredTurnMaintenanceRunState = {
@@ -109,6 +110,18 @@ function normalizeSessionKey(sessionKey?: string): string | undefined {
 
 function resolveDeferredTurnMaintenanceLane(sessionKey: string): string {
   return `${TURN_MAINTENANCE_LANE_PREFIX}${sessionKey}`;
+}
+
+async function disposeDeferredMaintenanceContextEngine(
+  contextEngine: ContextEngine,
+): Promise<void> {
+  try {
+    await contextEngine.dispose?.();
+  } catch (err) {
+    log.warn("context engine dispose failed after deferred maintenance", {
+      errorMessage: formatErrorMessage(err),
+    });
+  }
 }
 
 export function createDeferredTurnMaintenanceAbortSignal(params?: {
@@ -386,6 +399,7 @@ async function runDeferredTurnMaintenanceWorker(params: {
   agentId?: string;
   runId: string;
   config?: OpenClawConfig;
+  disposeContextEngineAfterMaintenance?: boolean;
 }): Promise<void> {
   let surfacedUserNotice = false;
   let longRunningTimer: ReturnType<typeof setTimeout> | null = null;
@@ -533,6 +547,9 @@ async function runDeferredTurnMaintenanceWorker(params: {
     log.warn(`deferred context engine maintenance failed: ${reason}`);
   } finally {
     shutdownAbort.dispose();
+    if (params.disposeContextEngineAfterMaintenance) {
+      await disposeDeferredMaintenanceContextEngine(params.contextEngine);
+    }
   }
 }
 
@@ -545,8 +562,15 @@ function scheduleDeferredTurnMaintenance(
   }
   const activeRun = activeDeferredTurnMaintenanceRuns.get(sessionKey);
   if (activeRun) {
+    const supersededParams = activeRun.rerunRequested ? activeRun.latestParams : undefined;
     activeRun.rerunRequested = true;
     activeRun.latestParams = { ...params, sessionKey };
+    if (
+      supersededParams?.disposeContextEngineAfterMaintenance &&
+      supersededParams.contextEngine !== params.contextEngine
+    ) {
+      void disposeDeferredMaintenanceContextEngine(supersededParams.contextEngine);
+    }
     return activeRun.promise;
   }
 
@@ -593,6 +617,7 @@ function scheduleDeferredTurnMaintenance(
         agentId: params.agentId,
         config: params.config,
         runId: task.runId!,
+        disposeContextEngineAfterMaintenance: params.disposeContextEngineAfterMaintenance,
       }),
     );
   } catch (err) {
@@ -622,9 +647,13 @@ function scheduleDeferredTurnMaintenance(
       const shutdownTriggered = schedulerAbort.abortSignal?.aborted === true;
       const rerunParams =
         current.rerunRequested && !shutdownTriggered ? current.latestParams : undefined;
+      const discardedRerunParams =
+        current.rerunRequested && shutdownTriggered ? current.latestParams : undefined;
       activeDeferredTurnMaintenanceRuns.delete(sessionKey);
       if (rerunParams) {
         await scheduleDeferredTurnMaintenance(rerunParams);
+      } else if (discardedRerunParams?.disposeContextEngineAfterMaintenance) {
+        await disposeDeferredMaintenanceContextEngine(discardedRerunParams.contextEngine);
       }
     });
   state = {
@@ -653,6 +682,7 @@ export async function runContextEngineMaintenance(params: {
   executionMode?: "foreground" | "background";
   onDeferredMaintenance?: (promise: Promise<void>) => void;
   config?: OpenClawConfig;
+  disposeDeferredContextEngineAfterMaintenance?: boolean;
 }): Promise<ContextEngineMaintenanceResult | undefined> {
   if (typeof params.contextEngine?.maintain !== "function") {
     return undefined;
@@ -675,6 +705,7 @@ export async function runContextEngineMaintenance(params: {
         runtimeContext: params.runtimeContext,
         agentId: params.agentId,
         config: params.config,
+        disposeContextEngineAfterMaintenance: params.disposeDeferredContextEngineAfterMaintenance,
       });
       if (deferred) {
         params.onDeferredMaintenance?.(deferred);

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -16,6 +16,7 @@ import {
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { triggerSessionPatchHook } from "../../gateway/session-patch-hooks.js";
 import { resolveSessionModelIdentityRef } from "../../gateway/session-utils.js";
+import { loadManifestMetadataSnapshot } from "../../plugins/manifest-contract-eligibility.js";
 import {
   buildAgentMainSessionKey,
   DEFAULT_AGENT_ID,
@@ -289,18 +290,33 @@ async function resolveModelOverride(params: {
     defaultProvider: currentProvider,
   });
   const catalog = await loadModelCatalog({ config: params.cfg });
+  const manifestMetadataSnapshot = loadManifestMetadataSnapshot({
+    config: params.cfg,
+    workspaceDir: params.sessionEntry?.spawnedWorkspaceDir,
+    env: process.env,
+  });
+  const modelManifestContext = {
+    manifestPlugins: manifestMetadataSnapshot.plugins,
+  };
   const policy = createModelVisibilityPolicy({
     cfg: params.cfg,
     catalog,
     defaultProvider: currentProvider,
     defaultModel: currentModel,
     agentId: params.agentId,
+    allowManifestNormalization: true,
+    allowPluginNormalization: true,
+    ...modelManifestContext,
   });
 
   const resolved = resolveModelRefFromString({
+    cfg: params.cfg,
     raw,
     defaultProvider: currentProvider,
     aliasIndex,
+    allowManifestNormalization: true,
+    allowPluginNormalization: true,
+    ...modelManifestContext,
   });
   if (!resolved) {
     throw new Error(`Unrecognized model "${raw}".`);

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -58,6 +58,7 @@ import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-event
 import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { logSessionTurnCreated } from "../../logging/diagnostic.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -110,6 +111,7 @@ import { createBlockReplyDeliveryHandler } from "./reply-delivery.js";
 import type { ReplyMediaContext } from "./reply-media-paths.js";
 import { createReplyMediaContext } from "./reply-media-paths.runtime.js";
 import type { ReplyOperation } from "./reply-run-registry.js";
+import { isReplyProfilerEnabled } from "./reply-timing-tracker.js";
 import type { TypingSignaler } from "./typing-mode.js";
 
 // Maximum number of LiveSessionModelSwitchError retries before surfacing a
@@ -117,6 +119,148 @@ import type { TypingSignaler } from "./typing-mode.js";
 // selection keeps conflicting with fallback model choices.
 // See: https://github.com/openclaw/openclaw/issues/58348
 export const MAX_LIVE_SWITCH_RETRIES = 2;
+
+type AgentTurnTimingSpan = {
+  name: string;
+  durationMs: number;
+  elapsedMs: number;
+};
+
+type AgentTurnTimingSummary = {
+  totalMs: number;
+  spans: AgentTurnTimingSpan[];
+};
+
+const agentTurnTimingLog = createSubsystemLogger("auto-reply/agent-turn-timing");
+const AGENT_TURN_TIMING_WARN_TOTAL_MS = 1_000;
+const AGENT_TURN_TIMING_WARN_STAGE_MS = 500;
+
+function createAgentTurnTimingTracker(options: { profilerEnabled?: boolean } = {}): {
+  measure: <T>(name: string, run: () => Promise<T> | T) => Promise<T>;
+  measureSync: <T>(name: string, run: () => T) => T;
+  logIfSlow: (params: {
+    runId: string;
+    sessionId?: string;
+    sessionKey?: string;
+    outcome: "completed" | "error";
+    error?: string;
+  }) => void;
+  logMilestoneIfSlow: (params: {
+    runId: string;
+    sessionId?: string;
+    sessionKey?: string;
+    milestone: string;
+  }) => void;
+} {
+  if (!options.profilerEnabled) {
+    // This tracker wraps the agent-turn hot path. Without an explicit profiler
+    // flag, keep every wrapper pass-through so normal turns avoid Date.now and
+    // span-array work entirely.
+    return {
+      async measure(_name, run) {
+        return await run();
+      },
+      measureSync(_name, run) {
+        return run();
+      },
+      logIfSlow() {},
+      logMilestoneIfSlow() {},
+    };
+  }
+
+  const startedAt = Date.now();
+  let didLog = false;
+  const spans: AgentTurnTimingSpan[] = [];
+  const toMs = (value: number) => Math.max(0, Math.round(value));
+  const record = (name: string, spanStartedAt: number) => {
+    spans.push({
+      name,
+      durationMs: toMs(Date.now() - spanStartedAt),
+      elapsedMs: toMs(Date.now() - startedAt),
+    });
+  };
+  const snapshot = (): AgentTurnTimingSummary => ({
+    totalMs: toMs(Date.now() - startedAt),
+    spans: spans.slice(),
+  });
+  const shouldLog = (summary: AgentTurnTimingSummary) =>
+    summary.totalMs >= AGENT_TURN_TIMING_WARN_TOTAL_MS ||
+    summary.spans.some((span) => span.durationMs >= AGENT_TURN_TIMING_WARN_STAGE_MS);
+  const formatSpans = (summary: AgentTurnTimingSummary) =>
+    summary.spans.length > 0
+      ? summary.spans
+          .map((span) => `${span.name}:${span.durationMs}ms@${span.elapsedMs}ms`)
+          .join(",")
+      : "none";
+  return {
+    async measure(name, run) {
+      const spanStartedAt = Date.now();
+      try {
+        return await run();
+      } finally {
+        record(name, spanStartedAt);
+      }
+    },
+    measureSync(name, run) {
+      const spanStartedAt = Date.now();
+      try {
+        return run();
+      } finally {
+        record(name, spanStartedAt);
+      }
+    },
+    logIfSlow(params) {
+      if (didLog) {
+        return;
+      }
+      const summary = snapshot();
+      if (!shouldLog(summary)) {
+        return;
+      }
+      didLog = true;
+      agentTurnTimingLog.warn(
+        `agent turn timings runId=${params.runId} sessionId=${
+          params.sessionId ?? "unknown"
+        } sessionKey=${params.sessionKey ?? "unknown"} outcome=${params.outcome} totalMs=${
+          summary.totalMs
+        } stages=${formatSpans(summary)}${params.error ? ` error="${params.error}"` : ""}`,
+        {
+          runId: params.runId,
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          outcome: params.outcome,
+          error: params.error,
+          totalMs: summary.totalMs,
+          spans: summary.spans,
+        },
+      );
+    },
+    logMilestoneIfSlow(params) {
+      if (!options.profilerEnabled) {
+        return;
+      }
+      const summary = snapshot();
+      if (!shouldLog(summary)) {
+        return;
+      }
+      agentTurnTimingLog.warn(
+        `agent turn milestone runId=${params.runId} sessionId=${
+          params.sessionId ?? "unknown"
+        } sessionKey=${params.sessionKey ?? "unknown"} milestone=${params.milestone} totalMs=${
+          summary.totalMs
+        } stages=${formatSpans(summary)}`,
+        {
+          runId: params.runId,
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          milestone: params.milestone,
+          totalMs: summary.totalMs,
+          spans: summary.spans,
+        },
+      );
+    },
+  };
+}
 
 function readApprovalScopeValue(value: unknown): "turn" | "session" | undefined {
   return value === "turn" || value === "session" ? value : undefined;
@@ -1326,6 +1470,9 @@ export async function runAgentTurnWithFallback(params: {
   };
 
   const runId = params.opts?.runId ?? crypto.randomUUID();
+  const agentTurnTiming = createAgentTurnTimingTracker({
+    profilerEnabled: isReplyProfilerEnabled({ config: runtimeConfig }),
+  });
   if (isDiagnosticsEnabled(runtimeConfig)) {
     logSessionTurnCreated({
       runId,
@@ -1341,26 +1488,30 @@ export async function runAgentTurnWithFallback(params: {
   }
   const replyMediaContext =
     params.replyMediaContext ??
-    createReplyMediaContext({
+    agentTurnTiming.measureSync("reply_media_context", () =>
+      createReplyMediaContext({
+        cfg: runtimeConfig,
+        sessionKey: params.sessionKey,
+        workspaceDir: params.followupRun.run.workspaceDir,
+        messageProvider: params.followupRun.run.messageProvider,
+        accountId: params.followupRun.originatingAccountId ?? params.followupRun.run.agentAccountId,
+        groupId: params.followupRun.run.groupId,
+        groupChannel: params.followupRun.run.groupChannel,
+        groupSpace: params.followupRun.run.groupSpace,
+        requesterSenderId: params.followupRun.run.senderId,
+        requesterSenderName: params.followupRun.run.senderName,
+        requesterSenderUsername: params.followupRun.run.senderUsername,
+        requesterSenderE164: params.followupRun.run.senderE164,
+      }),
+    );
+  const currentTurnImages = await agentTurnTiming.measure("current_turn_images", () =>
+    resolveCurrentTurnImages({
+      ctx: params.sessionCtx,
       cfg: runtimeConfig,
-      sessionKey: params.sessionKey,
-      workspaceDir: params.followupRun.run.workspaceDir,
-      messageProvider: params.followupRun.run.messageProvider,
-      accountId: params.followupRun.originatingAccountId ?? params.followupRun.run.agentAccountId,
-      groupId: params.followupRun.run.groupId,
-      groupChannel: params.followupRun.run.groupChannel,
-      groupSpace: params.followupRun.run.groupSpace,
-      requesterSenderId: params.followupRun.run.senderId,
-      requesterSenderName: params.followupRun.run.senderName,
-      requesterSenderUsername: params.followupRun.run.senderUsername,
-      requesterSenderE164: params.followupRun.run.senderE164,
-    });
-  const currentTurnImages = await resolveCurrentTurnImages({
-    ctx: params.sessionCtx,
-    cfg: runtimeConfig,
-    images: params.followupRun.images ?? params.opts?.images,
-    imageOrder: params.followupRun.imageOrder ?? params.opts?.imageOrder,
-  });
+      images: params.followupRun.images ?? params.opts?.images,
+      imageOrder: params.followupRun.imageOrder ?? params.opts?.imageOrder,
+    }),
+  );
   let didNotifyAgentRunStart = false;
   const notifyAgentRunStart = () => {
     if (didNotifyAgentRunStart) {
@@ -1714,632 +1865,683 @@ export async function runAgentTurnWithFallback(params: {
       const runLane = CommandLane.Main;
       let queuedUserMessagePersistedAcrossFallback = false;
       let assistantErrorPersistedAcrossFallback = false;
-      const fallbackResult = await runWithModelFallback<EmbeddedAgentRunResult>({
-        ...resolveModelFallbackOptions(effectiveRun, runtimeConfig),
+      // Profiler-only milestone: it separates fallback setup from the actual
+      // model run without adding extra live logs/snapshots to normal turns.
+      agentTurnTiming.logMilestoneIfSlow({
         runId,
         sessionId: params.followupRun.run.sessionId,
-        lane: runLane,
-        resolveAgentHarnessRuntimeOverride: (provider) =>
-          resolveSessionRuntimeOverrideForProvider({
-            provider,
-            entry: params.getActiveSessionEntry(),
-          }),
-        prepareAgentHarnessRuntime: async ({ provider, model, agentHarnessRuntimeOverride }) => {
-          await ensureSelectedAgentHarnessPlugin({
-            config: runtimeConfig,
-            provider,
-            modelId: model,
-            agentId: params.followupRun.run.agentId,
-            sessionKey: params.followupRun.run.runtimePolicySessionKey ?? params.sessionKey,
-            agentHarnessRuntimeOverride,
-            workspaceDir: params.followupRun.run.workspaceDir,
-          });
-        },
-        onFallbackStep: (step) => {
-          emitModelFallbackStepLifecycle({
-            runId,
-            sessionKey: params.sessionKey,
-            step,
-          });
-        },
-        classifyResult: async ({ result, provider, model }) => {
-          const classification = outcomePlan.classifyRunResult({
-            result,
-            provider,
-            model,
-            hasDirectlySentBlockReply: directlySentBlockKeys.size > 0,
-            hasBlockReplyPipelineOutput: Boolean(
-              blockReplyPipeline?.hasBuffered() || blockReplyPipeline?.didStream(),
-            ),
-          });
-          if (classification) {
-            await rollbackClassifiedFallbackCandidateSelection(provider, model);
-          }
-          return classification;
-        },
-        run: async (provider, model, runOptions) => {
-          attemptedRuntimeProvider = provider;
-          attemptedRuntimeModel = model;
-          const suppressQueuedUserPersistenceForCandidate =
-            (params.followupRun.run.suppressNextUserMessagePersistence ?? false) ||
-            queuedUserMessagePersistedAcrossFallback;
-          const suppressAssistantErrorPersistenceForCandidate =
-            assistantErrorPersistedAcrossFallback;
-          const candidateRun = resolveRunForFallbackCandidate(provider, model);
-          const activeProbe = effectiveRun.autoFallbackPrimaryProbe;
-          if (activeProbe && provider === activeProbe.provider && model === activeProbe.model) {
-            markAutoFallbackPrimaryProbe({
-              probe: activeProbe,
-              sessionKey: params.sessionKey,
-            });
-          }
-          // Notify that model selection is complete (including after fallback).
-          // This allows responsePrefix template interpolation with the actual model.
-          params.opts?.onModelSelected?.({
-            provider,
-            model,
-            thinkLevel: params.followupRun.run.thinkLevel,
-          });
-          let rollbackFallbackCandidateSelection: (() => Promise<void>) | undefined;
-          try {
-            rollbackFallbackCandidateSelection = await persistFallbackCandidateSelection(
+        sessionKey: params.sessionKey,
+        milestone: "before_model_fallback",
+      });
+      const fallbackResult = await agentTurnTiming.measure("model_fallback", () =>
+        runWithModelFallback<EmbeddedAgentRunResult>({
+          ...resolveModelFallbackOptions(effectiveRun, runtimeConfig),
+          runId,
+          sessionId: params.followupRun.run.sessionId,
+          lane: runLane,
+          resolveAgentHarnessRuntimeOverride: (provider) =>
+            resolveSessionRuntimeOverrideForProvider({
               provider,
-              model,
-              candidateRun,
-            );
-            if (rollbackFallbackCandidateSelection) {
-              pendingFallbackCandidateRollback = {
-                provider,
-                model,
-                rollback: rollbackFallbackCandidateSelection,
-              };
-            }
-          } catch (error) {
-            logVerbose(
-              `failed to persist fallback candidate selection (non-fatal): ${String(error)}`,
-            );
-          }
-
-          const sessionRuntimeOverride = resolveSessionRuntimeOverrideForProvider({
-            provider,
-            entry: params.getActiveSessionEntry(),
-          });
-          const selectedAuthProfile = resolveRunAuthProfile(candidateRun, provider, {
-            config: runtimeConfig,
-          });
-          const cliExecutionProvider =
-            sessionRuntimeOverride === "pi"
-              ? provider
-              : ((sessionRuntimeOverride && isCliProvider(sessionRuntimeOverride, runtimeConfig)
-                  ? sessionRuntimeOverride
-                  : undefined) ??
-                resolveCliRuntimeExecutionProvider({
-                  provider,
-                  cfg: runtimeConfig,
-                  agentId: params.followupRun.run.agentId,
-                  modelId: model,
-                  authProfileId: selectedAuthProfile.authProfileId,
-                }) ??
-                provider);
-
-          if (isCliProvider(cliExecutionProvider, runtimeConfig)) {
-            const isRoomEventCliRun = params.followupRun.currentInboundEventKind === "room_event";
-            const cliSessionBinding = isRoomEventCliRun
-              ? undefined
-              : getCliSessionBinding(params.getActiveSessionEntry(), cliExecutionProvider);
-            const authProfile = resolveRunAuthProfile(candidateRun, cliExecutionProvider, {
-              config: runtimeConfig,
-            });
-            const hookMessageProvider = resolveOriginMessageProvider({
-              originatingChannel: params.followupRun.originatingChannel,
-              provider: params.sessionCtx.Provider,
-            });
-            const result = await runCliAgentWithLifecycle({
-              runId,
-              provider: cliExecutionProvider,
-              onAgentRunStart: notifyAgentRunStart,
-              suppressAssistantBridge: params.followupRun.run.silentExpected,
-              onAssistantText: async (text) => {
-                const textForTyping = await handlePartialForTyping({ text } as ReplyPayload);
-                if (textForTyping === undefined || !params.opts?.onPartialReply) {
-                  return;
-                }
-                await params.opts.onPartialReply({ text: textForTyping });
-              },
-              onReasoningText: async (text) => {
-                await params.opts?.onReasoningStream?.({ text });
-              },
-              onErrorBeforeLifecycle: async () => {
-                if (!rollbackFallbackCandidateSelection) {
-                  return;
-                }
-                try {
-                  await rollbackFallbackCandidateSelection();
-                  clearPendingFallbackRollback(rollbackFallbackCandidateSelection);
-                } catch (rollbackError) {
-                  logVerbose(
-                    `failed to roll back fallback candidate selection (non-fatal): ${String(rollbackError)}`,
-                  );
-                }
-              },
-              runParams: {
-                sessionId: params.followupRun.run.sessionId,
-                sessionKey: params.sessionKey,
-                agentId: params.followupRun.run.agentId,
-                trigger: params.isHeartbeat ? "heartbeat" : "user",
-                sessionFile: params.followupRun.run.sessionFile,
-                workspaceDir: params.followupRun.run.workspaceDir,
+              entry: params.getActiveSessionEntry(),
+            }),
+          prepareAgentHarnessRuntime: async ({ provider, model, agentHarnessRuntimeOverride }) => {
+            await agentTurnTiming.measure("fallback_prepare_harness", () =>
+              ensureSelectedAgentHarnessPlugin({
                 config: runtimeConfig,
-                prompt: params.commandBody,
-                transcriptPrompt: params.transcriptCommandBody,
-                currentInboundEventKind: params.followupRun.currentInboundEventKind,
-                currentInboundContext: params.followupRun.currentInboundContext,
-                inputProvenance: params.followupRun.run.inputProvenance,
-                provider: cliExecutionProvider,
-                model,
-                thinkLevel: params.followupRun.run.thinkLevel,
-                timeoutMs: params.followupRun.run.timeoutMs,
-                runId,
-                lane: runLane,
-                extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
-                sourceReplyDeliveryMode: params.followupRun.run.sourceReplyDeliveryMode,
-                silentReplyPromptMode: params.followupRun.run.silentReplyPromptMode,
-                extraSystemPromptStatic: params.followupRun.run.extraSystemPromptStatic,
-                ownerNumbers: params.followupRun.run.ownerNumbers,
-                cliSessionId: cliSessionBinding?.sessionId,
-                cliSessionBinding,
-                authProfileId: authProfile.authProfileId,
-                bootstrapPromptWarningSignaturesSeen,
-                bootstrapPromptWarningSignature:
-                  bootstrapPromptWarningSignaturesSeen[
-                    bootstrapPromptWarningSignaturesSeen.length - 1
-                  ],
-                images: currentTurnImages.images,
-                imageOrder: currentTurnImages.imageOrder,
-                skillsSnapshot: params.followupRun.run.skillsSnapshot,
-                messageChannel: params.followupRun.originatingChannel ?? undefined,
-                messageProvider: hookMessageProvider,
-                agentAccountId: params.followupRun.run.agentAccountId,
-                senderIsOwner: params.followupRun.run.senderIsOwner,
-                disableTools: params.opts?.disableTools,
-                abortSignal: params.replyOperation?.abortSignal ?? params.opts?.abortSignal,
-                replyOperation: params.replyOperation,
-              },
-              transformResult: (rawResult) =>
-                isRoomEventCliRun && rawResult.meta.agentMeta
-                  ? (() => {
-                      const { cliSessionBinding: _cliSessionBinding, ...agentMeta } =
-                        rawResult.meta.agentMeta;
-                      return {
-                        ...rawResult,
-                        meta: {
-                          ...rawResult.meta,
-                          agentMeta: {
-                            ...agentMeta,
-                            sessionId: "",
-                          },
-                        },
-                      };
-                    })()
-                  : rawResult,
-            });
-            bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
-              result.meta?.systemPromptReport,
-            );
-            return result;
-          }
-          const { embeddedContext, senderContext, runBaseParams } = buildEmbeddedRunExecutionParams(
-            {
-              run: candidateRun,
-              sessionCtx: params.sessionCtx,
-              hasRepliedRef: params.opts?.hasRepliedRef,
-              provider,
-              runId,
-              allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
-              model,
-            },
-          );
-          const agentHarnessPolicy = sessionRuntimeOverride
-            ? ({ runtime: sessionRuntimeOverride, runtimeSource: "model" } as const)
-            : resolveAgentHarnessPolicy({
                 provider,
                 modelId: model,
-                config: runtimeConfig,
                 agentId: params.followupRun.run.agentId,
                 sessionKey: params.followupRun.run.runtimePolicySessionKey ?? params.sessionKey,
-              });
-          const embeddedRunProvider = resolveOpenAIRuntimeProviderForPi({
-            provider,
-            harnessRuntime: agentHarnessPolicy.runtime,
-            authProfileProvider: runBaseParams.authProfileId?.split(":", 1)[0],
-            authProfileId: runBaseParams.authProfileId,
-            config: runtimeConfig,
-            workspaceDir: params.followupRun.run.workspaceDir,
-          });
-          const embeddedRunHarnessOverride =
-            sessionRuntimeOverride ??
-            (agentHarnessPolicy.runtime === "pi" && embeddedRunProvider !== provider
-              ? "pi"
-              : undefined);
-          return (async () => {
-            let attemptCompactionCount = 0;
-            const lifecycleBackstop = createEmbeddedLifecycleTerminalBackstop({
+                agentHarnessRuntimeOverride,
+                workspaceDir: params.followupRun.run.workspaceDir,
+              }),
+            );
+          },
+          onFallbackStep: (step) => {
+            emitModelFallbackStepLifecycle({
               runId,
               sessionKey: params.sessionKey,
+              step,
             });
+          },
+          classifyResult: async ({ result, provider, model }) => {
+            const classification = outcomePlan.classifyRunResult({
+              result,
+              provider,
+              model,
+              hasDirectlySentBlockReply: directlySentBlockKeys.size > 0,
+              hasBlockReplyPipelineOutput: Boolean(
+                blockReplyPipeline?.hasBuffered() || blockReplyPipeline?.didStream(),
+              ),
+            });
+            if (classification) {
+              await rollbackClassifiedFallbackCandidateSelection(provider, model);
+            }
+            return classification;
+          },
+          run: async (provider, model, runOptions) => {
+            attemptedRuntimeProvider = provider;
+            attemptedRuntimeModel = model;
+            const suppressQueuedUserPersistenceForCandidate =
+              (params.followupRun.run.suppressNextUserMessagePersistence ?? false) ||
+              queuedUserMessagePersistedAcrossFallback;
+            const suppressAssistantErrorPersistenceForCandidate =
+              assistantErrorPersistedAcrossFallback;
+            const candidateRun = resolveRunForFallbackCandidate(provider, model);
+            const activeProbe = effectiveRun.autoFallbackPrimaryProbe;
+            if (activeProbe && provider === activeProbe.provider && model === activeProbe.model) {
+              markAutoFallbackPrimaryProbe({
+                probe: activeProbe,
+                sessionKey: params.sessionKey,
+              });
+            }
+            // Notify that model selection is complete (including after fallback).
+            // This allows responsePrefix template interpolation with the actual model.
+            params.opts?.onModelSelected?.({
+              provider,
+              model,
+              thinkLevel: params.followupRun.run.thinkLevel,
+            });
+            let rollbackFallbackCandidateSelection: (() => Promise<void>) | undefined;
             try {
-              const result = await runEmbeddedPiAgent({
-                ...embeddedContext,
-                allowGatewaySubagentBinding: true,
-                trigger: params.isHeartbeat ? "heartbeat" : "user",
-                groupId: resolveGroupSessionKey(params.sessionCtx)?.id,
-                groupChannel:
-                  normalizeOptionalString(params.sessionCtx.GroupChannel) ??
-                  normalizeOptionalString(params.sessionCtx.GroupSubject),
-                groupSpace: normalizeOptionalString(params.sessionCtx.GroupSpace),
-                ...senderContext,
-                ...runBaseParams,
-                provider: embeddedRunProvider,
-                agentHarnessId: embeddedRunHarnessOverride,
-                agentHarnessRuntimeOverride: embeddedRunHarnessOverride,
-                sandboxSessionKey: params.runtimePolicySessionKey,
-                prompt: params.commandBody,
-                transcriptPrompt: params.transcriptCommandBody,
-                currentInboundEventKind: params.followupRun.currentInboundEventKind,
-                currentInboundContext: params.followupRun.currentInboundContext,
-                extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
-                sourceReplyDeliveryMode: params.followupRun.run.sourceReplyDeliveryMode,
-                forceMessageTool:
-                  params.followupRun.run.sourceReplyDeliveryMode === "message_tool_only",
-                silentReplyPromptMode: params.followupRun.run.silentReplyPromptMode,
-                suppressNextUserMessagePersistence: suppressQueuedUserPersistenceForCandidate,
-                onUserMessagePersisted: () => {
-                  queuedUserMessagePersistedAcrossFallback = true;
-                },
-                suppressTranscriptOnlyAssistantPersistence:
-                  params.followupRun.run.suppressTranscriptOnlyAssistantPersistence,
-                suppressAssistantErrorPersistence: suppressAssistantErrorPersistenceForCandidate,
-                onAssistantErrorMessagePersisted: () => {
-                  assistantErrorPersistedAcrossFallback = true;
-                },
-                toolResultFormat: (() => {
-                  const channel = resolveMessageChannel(
-                    params.sessionCtx.Surface,
-                    params.sessionCtx.Provider,
-                  );
-                  if (!channel) {
-                    return "markdown";
-                  }
-                  return isMarkdownCapableMessageChannel(channel) ? "markdown" : "plain";
-                })(),
-                toolProgressDetail: params.toolProgressDetail,
-                suppressToolErrorWarnings:
-                  params.opts?.shouldSuppressToolErrorWarnings ??
-                  params.opts?.suppressToolErrorWarnings,
-                disableTools: params.opts?.disableTools,
-                enableHeartbeatTool: params.opts?.enableHeartbeatTool,
-                forceHeartbeatTool: params.opts?.forceHeartbeatTool,
-                bootstrapContextMode: params.opts?.bootstrapContextMode,
-                bootstrapContextRunKind: params.opts?.isHeartbeat ? "heartbeat" : "default",
-                images: currentTurnImages.images,
-                imageOrder: currentTurnImages.imageOrder,
-                abortSignal: params.replyOperation?.abortSignal ?? params.opts?.abortSignal,
-                replyOperation: params.replyOperation,
-                blockReplyBreak: params.resolvedBlockStreamingBreak,
-                blockReplyChunking: params.blockReplyChunking,
-                onPartialReply: async (payload) => {
-                  const textForTyping = await handlePartialForTyping(payload);
-                  if (!params.opts?.onPartialReply || textForTyping === undefined) {
-                    return;
-                  }
-                  await params.opts.onPartialReply({
-                    text: textForTyping,
-                    mediaUrls: payload.mediaUrls,
-                  });
-                },
-                onAssistantMessageStart: async () => {
-                  await params.typingSignals.signalMessageStart();
-                  await params.opts?.onAssistantMessageStart?.();
-                },
-                onReasoningStream:
-                  params.typingSignals.shouldStartOnReasoning || params.opts?.onReasoningStream
-                    ? async (payload) => {
-                        if (params.followupRun.run.silentExpected) {
-                          return;
-                        }
-                        await params.typingSignals.signalReasoningDelta();
-                        await params.opts?.onReasoningStream?.({
-                          text: payload.text,
-                          mediaUrls: payload.mediaUrls,
-                        });
-                      }
-                    : undefined,
-                onReasoningEnd: params.opts?.onReasoningEnd,
-                onAgentEvent: async (evt) => {
-                  lifecycleBackstop.note(evt);
-                  // Signal run start only after the embedded agent emits real activity.
-                  const hasLifecyclePhase =
-                    evt.stream === "lifecycle" && typeof evt.data.phase === "string";
-                  if (evt.stream !== "lifecycle" || hasLifecyclePhase) {
-                    notifyAgentRunStart();
-                  }
-                  // Trigger typing when tools start executing.
-                  // Must await to ensure typing indicator starts before tool summaries are emitted.
-                  if (evt.stream === "tool") {
-                    const phase = readStringValue(evt.data.phase) ?? "";
-                    const name = readStringValue(evt.data.name);
-                    const toolCallId = readStringValue(evt.data.toolCallId) ?? "";
-                    const args =
-                      evt.data.args && typeof evt.data.args === "object"
-                        ? (evt.data.args as Record<string, unknown>)
-                        : undefined;
-                    if (
-                      sourceRepliesAreToolOnly &&
-                      toolCallId &&
-                      name &&
-                      (phase === "start" || phase === "update") &&
-                      args &&
-                      isMessagingToolSendAction(name, args)
-                    ) {
-                      messageToolOnlyDeliveryToolCallIds.add(toolCallId);
-                    }
-                    if (shouldSuppressProgressAfterMessageToolDelivery()) {
+              rollbackFallbackCandidateSelection = await agentTurnTiming.measure(
+                "fallback_persist_selection",
+                () => persistFallbackCandidateSelection(provider, model, candidateRun),
+              );
+              if (rollbackFallbackCandidateSelection) {
+                pendingFallbackCandidateRollback = {
+                  provider,
+                  model,
+                  rollback: rollbackFallbackCandidateSelection,
+                };
+              }
+            } catch (error) {
+              logVerbose(
+                `failed to persist fallback candidate selection (non-fatal): ${String(error)}`,
+              );
+            }
+
+            const { sessionRuntimeOverride, cliExecutionProvider } = agentTurnTiming.measureSync(
+              "fallback_resolve_runtime",
+              () => {
+                const resolvedSessionRuntimeOverride = resolveSessionRuntimeOverrideForProvider({
+                  provider,
+                  entry: params.getActiveSessionEntry(),
+                });
+                const resolvedSelectedAuthProfile = resolveRunAuthProfile(candidateRun, provider, {
+                  config: runtimeConfig,
+                });
+                const resolvedCliExecutionProvider =
+                  resolvedSessionRuntimeOverride === "pi"
+                    ? provider
+                    : ((resolvedSessionRuntimeOverride &&
+                      isCliProvider(resolvedSessionRuntimeOverride, runtimeConfig)
+                        ? resolvedSessionRuntimeOverride
+                        : undefined) ??
+                      resolveCliRuntimeExecutionProvider({
+                        provider,
+                        cfg: runtimeConfig,
+                        agentId: params.followupRun.run.agentId,
+                        modelId: model,
+                        authProfileId: resolvedSelectedAuthProfile.authProfileId,
+                      }) ??
+                      provider);
+                return {
+                  sessionRuntimeOverride: resolvedSessionRuntimeOverride,
+                  cliExecutionProvider: resolvedCliExecutionProvider,
+                };
+              },
+            );
+
+            if (isCliProvider(cliExecutionProvider, runtimeConfig)) {
+              const isRoomEventCliRun = params.followupRun.currentInboundEventKind === "room_event";
+              const cliSessionBinding = isRoomEventCliRun
+                ? undefined
+                : getCliSessionBinding(params.getActiveSessionEntry(), cliExecutionProvider);
+              const authProfile = resolveRunAuthProfile(candidateRun, cliExecutionProvider, {
+                config: runtimeConfig,
+              });
+              const hookMessageProvider = resolveOriginMessageProvider({
+                originatingChannel: params.followupRun.originatingChannel,
+                provider: params.sessionCtx.Provider,
+              });
+              const result = await agentTurnTiming.measure("cli_run", () =>
+                runCliAgentWithLifecycle({
+                  runId,
+                  provider: cliExecutionProvider,
+                  onAgentRunStart: notifyAgentRunStart,
+                  suppressAssistantBridge: params.followupRun.run.silentExpected,
+                  onAssistantText: async (text) => {
+                    const textForTyping = await handlePartialForTyping({ text } as ReplyPayload);
+                    if (textForTyping === undefined || !params.opts?.onPartialReply) {
                       return;
                     }
-                    if (phase === "start" || phase === "update") {
-                      const toolStartProgressPromise = params.opts?.onToolStart?.({
-                        name,
-                        phase,
-                        args,
-                        detailMode: params.toolProgressDetail,
-                      });
-                      await Promise.all([
-                        params.typingSignals.signalToolStart(),
-                        toolStartProgressPromise,
-                      ]);
+                    await params.opts.onPartialReply({ text: textForTyping });
+                  },
+                  onReasoningText: async (text) => {
+                    await params.opts?.onReasoningStream?.({ text });
+                  },
+                  onErrorBeforeLifecycle: async () => {
+                    if (!rollbackFallbackCandidateSelection) {
+                      return;
                     }
-                  }
-                  const suppressItemChannelProgress =
-                    evt.stream === "item" &&
-                    evt.data.suppressChannelProgress === true &&
-                    Boolean(params.opts?.onToolStart);
-                  const itemPhase = evt.stream === "item" ? readStringValue(evt.data.phase) : "";
-                  const itemName = evt.stream === "item" ? readStringValue(evt.data.name) : "";
-                  const itemStatus = evt.stream === "item" ? readStringValue(evt.data.status) : "";
-                  const itemToolCallId =
-                    evt.stream === "item" ? (readStringValue(evt.data.toolCallId) ?? "") : "";
-                  const completedMessageToolDelivery =
-                    sourceRepliesAreToolOnly &&
-                    itemPhase === "end" &&
-                    itemStatus === "completed" &&
-                    itemToolCallId.length > 0 &&
-                    messageToolOnlyDeliveryToolCallIds.has(itemToolCallId);
-                  const suppressProgressAfterMessageToolDelivery =
-                    shouldSuppressProgressAfterMessageToolDelivery();
-                  if (completedMessageToolDelivery) {
-                    messageToolOnlyDeliveryToolCallIds.delete(itemToolCallId);
-                    messageToolOnlyDeliveryCompleted = true;
-                  }
-                  if (
-                    evt.stream === "item" &&
-                    !suppressItemChannelProgress &&
-                    (!suppressProgressAfterMessageToolDelivery || completedMessageToolDelivery)
-                  ) {
-                    await params.opts?.onItemEvent?.({
-                      itemId: readStringValue(evt.data.itemId),
-                      kind: readStringValue(evt.data.kind),
-                      title: readStringValue(evt.data.title),
-                      name: itemName,
-                      phase: itemPhase,
-                      status: itemStatus,
-                      summary: readStringValue(evt.data.summary),
-                      progressText: readStringValue(evt.data.progressText),
-                      meta: readStringValue(evt.data.meta),
-                      approvalId: readStringValue(evt.data.approvalId),
-                      approvalSlug: readStringValue(evt.data.approvalSlug),
-                    });
-                  }
-                  if (evt.stream === "plan" && !shouldSuppressProgressAfterMessageToolDelivery()) {
-                    await params.opts?.onPlanUpdate?.({
-                      phase: readStringValue(evt.data.phase),
-                      title: readStringValue(evt.data.title),
-                      explanation: readStringValue(evt.data.explanation),
-                      steps: Array.isArray(evt.data.steps)
-                        ? evt.data.steps.filter((step): step is string => typeof step === "string")
-                        : undefined,
-                      source: readStringValue(evt.data.source),
-                    });
-                  }
-                  if (
-                    evt.stream === "approval" &&
-                    !shouldSuppressProgressAfterMessageToolDelivery()
-                  ) {
-                    await params.opts?.onApprovalEvent?.({
-                      phase: readStringValue(evt.data.phase),
-                      kind: readStringValue(evt.data.kind),
-                      status: readStringValue(evt.data.status),
-                      title: readStringValue(evt.data.title),
-                      itemId: readStringValue(evt.data.itemId),
-                      toolCallId: readStringValue(evt.data.toolCallId),
-                      approvalId: readStringValue(evt.data.approvalId),
-                      approvalSlug: readStringValue(evt.data.approvalSlug),
-                      command: readStringValue(evt.data.command),
-                      host: readStringValue(evt.data.host),
-                      reason: readStringValue(evt.data.reason),
-                      scope: readApprovalScopeValue(evt.data.scope),
-                      message: readStringValue(evt.data.message),
-                    });
-                  }
-                  if (
-                    evt.stream === "command_output" &&
-                    !shouldSuppressProgressAfterMessageToolDelivery()
-                  ) {
-                    await params.opts?.onCommandOutput?.({
-                      itemId: readStringValue(evt.data.itemId),
-                      phase: readStringValue(evt.data.phase),
-                      title: readStringValue(evt.data.title),
-                      toolCallId: readStringValue(evt.data.toolCallId),
-                      name: readStringValue(evt.data.name),
-                      output: readStringValue(evt.data.output),
-                      status: readStringValue(evt.data.status),
-                      exitCode:
-                        typeof evt.data.exitCode === "number" || evt.data.exitCode === null
-                          ? evt.data.exitCode
-                          : undefined,
-                      durationMs:
-                        typeof evt.data.durationMs === "number" ? evt.data.durationMs : undefined,
-                      cwd: readStringValue(evt.data.cwd),
-                    });
-                  }
-                  if (evt.stream === "patch" && !shouldSuppressProgressAfterMessageToolDelivery()) {
-                    await params.opts?.onPatchSummary?.({
-                      itemId: readStringValue(evt.data.itemId),
-                      phase: readStringValue(evt.data.phase),
-                      title: readStringValue(evt.data.title),
-                      toolCallId: readStringValue(evt.data.toolCallId),
-                      name: readStringValue(evt.data.name),
-                      added: Array.isArray(evt.data.added)
-                        ? evt.data.added.filter(
-                            (entry): entry is string => typeof entry === "string",
-                          )
-                        : undefined,
-                      modified: Array.isArray(evt.data.modified)
-                        ? evt.data.modified.filter(
-                            (entry): entry is string => typeof entry === "string",
-                          )
-                        : undefined,
-                      deleted: Array.isArray(evt.data.deleted)
-                        ? evt.data.deleted.filter(
-                            (entry): entry is string => typeof entry === "string",
-                          )
-                        : undefined,
-                      summary: readStringValue(evt.data.summary),
-                    });
-                  }
-                  // Track auto-compaction and notify higher layers.
-                  if (evt.stream === "compaction") {
-                    const phase = readStringValue(evt.data.phase) ?? "";
-                    const hookMessages = readCompactionHookMessages(evt.data.messages);
-                    if (phase === "start") {
-                      // Keep custom compaction callbacks active, but gate the
-                      // fallback user-facing notice behind explicit opt-in.
-                      if (params.opts?.onCompactionStart) {
-                        await params.opts.onCompactionStart();
-                      }
-                      if (hookMessages.length > 0) {
-                        await sendCompactionHookMessages(hookMessages);
-                      } else if (
-                        !params.opts?.onCompactionStart &&
-                        shouldNotifyUserAboutCompaction
-                      ) {
-                        // Send directly via opts.onBlockReply (bypassing the
-                        // pipeline) so the notice does not cause final payloads
-                        // to be discarded on non-streaming model paths.
-                        await sendCompactionNotice("start");
-                      }
+                    try {
+                      await rollbackFallbackCandidateSelection();
+                      clearPendingFallbackRollback(rollbackFallbackCandidateSelection);
+                    } catch (rollbackError) {
+                      logVerbose(
+                        `failed to roll back fallback candidate selection (non-fatal): ${String(rollbackError)}`,
+                      );
                     }
-                    if (phase === "end") {
-                      const completed = evt.data?.completed === true;
-                      if (completed) {
-                        attemptCompactionCount += 1;
-                        if (params.opts?.onCompactionEnd) {
-                          await params.opts.onCompactionEnd();
-                        }
-                        if (hookMessages.length > 0) {
-                          await sendCompactionHookMessages(hookMessages);
-                        } else if (
-                          !params.opts?.onCompactionEnd &&
-                          shouldNotifyUserAboutCompaction
-                        ) {
-                          await sendCompactionNotice("end");
-                        }
-                      } else if (hookMessages.length > 0) {
-                        await sendCompactionHookMessages(hookMessages);
-                      } else if (shouldNotifyUserAboutCompaction) {
-                        await sendCompactionNotice("incomplete");
-                      }
-                    }
-                  }
-                },
-                // Always pass onBlockReply so flushBlockReplyBuffer works before tool execution,
-                // even when regular block streaming is disabled. The handler sends directly
-                // via opts.onBlockReply when the pipeline isn't available.
-                onBlockReply: blockReplyHandler,
-                onBlockReplyFlush:
-                  params.blockStreamingEnabled && blockReplyPipeline
-                    ? async () => {
-                        await blockReplyPipeline.flush({ force: true });
-                      }
-                    : undefined,
-                shouldEmitToolResult: params.shouldEmitToolResult,
-                shouldEmitToolOutput: params.shouldEmitToolOutput,
-                bootstrapPromptWarningSignaturesSeen,
-                bootstrapPromptWarningSignature:
-                  bootstrapPromptWarningSignaturesSeen[
-                    bootstrapPromptWarningSignaturesSeen.length - 1
-                  ],
-                onToolResult: onToolResult
-                  ? (() => {
-                      // Serialize tool result delivery to preserve message ordering.
-                      // Without this, concurrent tool callbacks race through typing signals
-                      // and message sends, causing out-of-order delivery to the user.
-                      // See: https://github.com/openclaw/openclaw/issues/11044
-                      let toolResultChain: Promise<void> = Promise.resolve();
-                      return (payload: ReplyPayload) => {
-                        toolResultChain = toolResultChain
-                          .then(async () => {
-                            const { text, skip } = normalizeStreamingText(payload);
-                            if (skip) {
-                              return;
-                            }
-                            if (text !== undefined) {
-                              await params.typingSignals.signalTextDelta(text);
-                            }
-                            await onToolResult({
-                              ...payload,
-                              text,
-                            });
-                          })
-                          .catch((err) => {
-                            // Keep chain healthy after an error so later tool results still deliver.
-                            logVerbose(`tool result delivery failed: ${String(err)}`);
-                          });
-                        const task = toolResultChain.finally(() => {
-                          params.pendingToolTasks.delete(task);
-                        });
-                        params.pendingToolTasks.add(task);
-                      };
-                    })()
-                  : undefined,
-              });
+                  },
+                  runParams: {
+                    sessionId: params.followupRun.run.sessionId,
+                    sessionKey: params.sessionKey,
+                    agentId: params.followupRun.run.agentId,
+                    trigger: params.isHeartbeat ? "heartbeat" : "user",
+                    sessionFile: params.followupRun.run.sessionFile,
+                    workspaceDir: params.followupRun.run.workspaceDir,
+                    config: runtimeConfig,
+                    prompt: params.commandBody,
+                    transcriptPrompt: params.transcriptCommandBody,
+                    currentInboundEventKind: params.followupRun.currentInboundEventKind,
+                    currentInboundContext: params.followupRun.currentInboundContext,
+                    inputProvenance: params.followupRun.run.inputProvenance,
+                    provider: cliExecutionProvider,
+                    model,
+                    thinkLevel: params.followupRun.run.thinkLevel,
+                    timeoutMs: params.followupRun.run.timeoutMs,
+                    runId,
+                    lane: runLane,
+                    extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
+                    sourceReplyDeliveryMode: params.followupRun.run.sourceReplyDeliveryMode,
+                    silentReplyPromptMode: params.followupRun.run.silentReplyPromptMode,
+                    extraSystemPromptStatic: params.followupRun.run.extraSystemPromptStatic,
+                    ownerNumbers: params.followupRun.run.ownerNumbers,
+                    cliSessionId: cliSessionBinding?.sessionId,
+                    cliSessionBinding,
+                    authProfileId: authProfile.authProfileId,
+                    bootstrapPromptWarningSignaturesSeen,
+                    bootstrapPromptWarningSignature:
+                      bootstrapPromptWarningSignaturesSeen[
+                        bootstrapPromptWarningSignaturesSeen.length - 1
+                      ],
+                    images: currentTurnImages.images,
+                    imageOrder: currentTurnImages.imageOrder,
+                    skillsSnapshot: params.followupRun.run.skillsSnapshot,
+                    messageChannel: params.followupRun.originatingChannel ?? undefined,
+                    messageProvider: hookMessageProvider,
+                    agentAccountId: params.followupRun.run.agentAccountId,
+                    senderIsOwner: params.followupRun.run.senderIsOwner,
+                    disableTools: params.opts?.disableTools,
+                    abortSignal: params.replyOperation?.abortSignal ?? params.opts?.abortSignal,
+                    replyOperation: params.replyOperation,
+                  },
+                  transformResult: (rawResult) =>
+                    isRoomEventCliRun && rawResult.meta.agentMeta
+                      ? (() => {
+                          const { cliSessionBinding: _cliSessionBinding, ...agentMeta } =
+                            rawResult.meta.agentMeta;
+                          return {
+                            ...rawResult,
+                            meta: {
+                              ...rawResult.meta,
+                              agentMeta: {
+                                ...agentMeta,
+                                sessionId: "",
+                              },
+                            },
+                          };
+                        })()
+                      : rawResult,
+                }),
+              );
               bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
                 result.meta?.systemPromptReport,
               );
-              lifecycleBackstop.emit("end", result);
-              const resultCompactionCount = Math.max(
-                0,
-                result.meta?.agentMeta?.compactionCount ?? 0,
-              );
-              attemptCompactionCount = Math.max(attemptCompactionCount, resultCompactionCount);
               return result;
-            } catch (err) {
-              if (rollbackFallbackCandidateSelection) {
-                try {
-                  await rollbackFallbackCandidateSelection();
-                  clearPendingFallbackRollback(rollbackFallbackCandidateSelection);
-                } catch (rollbackError) {
-                  logVerbose(
-                    `failed to roll back fallback candidate selection (non-fatal): ${String(rollbackError)}`,
-                  );
-                }
-              }
-              lifecycleBackstop.emit("error", err);
-              throw err;
-            } finally {
-              autoCompactionCount += attemptCompactionCount;
             }
-          })();
-        },
+            const { embeddedContext, senderContext, runBaseParams } =
+              buildEmbeddedRunExecutionParams({
+                run: candidateRun,
+                sessionCtx: params.sessionCtx,
+                hasRepliedRef: params.opts?.hasRepliedRef,
+                provider,
+                runId,
+                allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
+                model,
+              });
+            const agentHarnessPolicy = sessionRuntimeOverride
+              ? ({ runtime: sessionRuntimeOverride, runtimeSource: "model" } as const)
+              : resolveAgentHarnessPolicy({
+                  provider,
+                  modelId: model,
+                  config: runtimeConfig,
+                  agentId: params.followupRun.run.agentId,
+                  sessionKey: params.followupRun.run.runtimePolicySessionKey ?? params.sessionKey,
+                });
+            const embeddedRunProvider = resolveOpenAIRuntimeProviderForPi({
+              provider,
+              harnessRuntime: agentHarnessPolicy.runtime,
+              authProfileProvider: runBaseParams.authProfileId?.split(":", 1)[0],
+              authProfileId: runBaseParams.authProfileId,
+              config: runtimeConfig,
+              workspaceDir: params.followupRun.run.workspaceDir,
+            });
+            const embeddedRunHarnessOverride =
+              sessionRuntimeOverride ??
+              (agentHarnessPolicy.runtime === "pi" && embeddedRunProvider !== provider
+                ? "pi"
+                : undefined);
+            return (async () => {
+              let attemptCompactionCount = 0;
+              const lifecycleBackstop = createEmbeddedLifecycleTerminalBackstop({
+                runId,
+                sessionKey: params.sessionKey,
+              });
+              try {
+                // Profiler-only milestone: it exposes time spent before Codex
+                // dispatch while leaving the regular embedded run path inert.
+                agentTurnTiming.logMilestoneIfSlow({
+                  runId,
+                  sessionId: params.followupRun.run.sessionId,
+                  sessionKey: params.sessionKey,
+                  milestone: "before_embedded_run",
+                });
+                const result = await agentTurnTiming.measure("embedded_run", () =>
+                  runEmbeddedPiAgent({
+                    ...embeddedContext,
+                    allowGatewaySubagentBinding: true,
+                    trigger: params.isHeartbeat ? "heartbeat" : "user",
+                    groupId: resolveGroupSessionKey(params.sessionCtx)?.id,
+                    groupChannel:
+                      normalizeOptionalString(params.sessionCtx.GroupChannel) ??
+                      normalizeOptionalString(params.sessionCtx.GroupSubject),
+                    groupSpace: normalizeOptionalString(params.sessionCtx.GroupSpace),
+                    ...senderContext,
+                    ...runBaseParams,
+                    provider: embeddedRunProvider,
+                    agentHarnessId: embeddedRunHarnessOverride,
+                    agentHarnessRuntimeOverride: embeddedRunHarnessOverride,
+                    sandboxSessionKey: params.runtimePolicySessionKey,
+                    prompt: params.commandBody,
+                    transcriptPrompt: params.transcriptCommandBody,
+                    currentInboundEventKind: params.followupRun.currentInboundEventKind,
+                    currentInboundContext: params.followupRun.currentInboundContext,
+                    extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
+                    sourceReplyDeliveryMode: params.followupRun.run.sourceReplyDeliveryMode,
+                    forceMessageTool:
+                      params.followupRun.run.sourceReplyDeliveryMode === "message_tool_only",
+                    silentReplyPromptMode: params.followupRun.run.silentReplyPromptMode,
+                    suppressNextUserMessagePersistence: suppressQueuedUserPersistenceForCandidate,
+                    onUserMessagePersisted: () => {
+                      queuedUserMessagePersistedAcrossFallback = true;
+                    },
+                    suppressTranscriptOnlyAssistantPersistence:
+                      params.followupRun.run.suppressTranscriptOnlyAssistantPersistence,
+                    suppressAssistantErrorPersistence:
+                      suppressAssistantErrorPersistenceForCandidate,
+                    onAssistantErrorMessagePersisted: () => {
+                      assistantErrorPersistedAcrossFallback = true;
+                    },
+                    toolResultFormat: (() => {
+                      const channel = resolveMessageChannel(
+                        params.sessionCtx.Surface,
+                        params.sessionCtx.Provider,
+                      );
+                      if (!channel) {
+                        return "markdown";
+                      }
+                      return isMarkdownCapableMessageChannel(channel) ? "markdown" : "plain";
+                    })(),
+                    toolProgressDetail: params.toolProgressDetail,
+                    suppressToolErrorWarnings:
+                      params.opts?.shouldSuppressToolErrorWarnings ??
+                      params.opts?.suppressToolErrorWarnings,
+                    disableTools: params.opts?.disableTools,
+                    enableHeartbeatTool: params.opts?.enableHeartbeatTool,
+                    forceHeartbeatTool: params.opts?.forceHeartbeatTool,
+                    bootstrapContextMode: params.opts?.bootstrapContextMode,
+                    bootstrapContextRunKind: params.opts?.isHeartbeat ? "heartbeat" : "default",
+                    images: currentTurnImages.images,
+                    imageOrder: currentTurnImages.imageOrder,
+                    abortSignal: params.replyOperation?.abortSignal ?? params.opts?.abortSignal,
+                    replyOperation: params.replyOperation,
+                    blockReplyBreak: params.resolvedBlockStreamingBreak,
+                    blockReplyChunking: params.blockReplyChunking,
+                    onPartialReply: async (payload) => {
+                      const textForTyping = await handlePartialForTyping(payload);
+                      if (!params.opts?.onPartialReply || textForTyping === undefined) {
+                        return;
+                      }
+                      await params.opts.onPartialReply({
+                        text: textForTyping,
+                        mediaUrls: payload.mediaUrls,
+                      });
+                    },
+                    onAssistantMessageStart: async () => {
+                      await params.typingSignals.signalMessageStart();
+                      await params.opts?.onAssistantMessageStart?.();
+                    },
+                    onReasoningStream:
+                      params.typingSignals.shouldStartOnReasoning || params.opts?.onReasoningStream
+                        ? async (payload) => {
+                            if (params.followupRun.run.silentExpected) {
+                              return;
+                            }
+                            await params.typingSignals.signalReasoningDelta();
+                            await params.opts?.onReasoningStream?.({
+                              text: payload.text,
+                              mediaUrls: payload.mediaUrls,
+                            });
+                          }
+                        : undefined,
+                    onReasoningEnd: params.opts?.onReasoningEnd,
+                    onAgentEvent: async (evt) => {
+                      lifecycleBackstop.note(evt);
+                      // Signal run start only after the embedded agent emits real activity.
+                      const hasLifecyclePhase =
+                        evt.stream === "lifecycle" && typeof evt.data.phase === "string";
+                      if (evt.stream !== "lifecycle" || hasLifecyclePhase) {
+                        notifyAgentRunStart();
+                      }
+                      // Trigger typing when tools start executing.
+                      // Must await to ensure typing indicator starts before tool summaries are emitted.
+                      if (evt.stream === "tool") {
+                        const phase = readStringValue(evt.data.phase) ?? "";
+                        const name = readStringValue(evt.data.name);
+                        const toolCallId = readStringValue(evt.data.toolCallId) ?? "";
+                        const args =
+                          evt.data.args && typeof evt.data.args === "object"
+                            ? (evt.data.args as Record<string, unknown>)
+                            : undefined;
+                        if (
+                          sourceRepliesAreToolOnly &&
+                          toolCallId &&
+                          name &&
+                          (phase === "start" || phase === "update") &&
+                          args &&
+                          isMessagingToolSendAction(name, args)
+                        ) {
+                          messageToolOnlyDeliveryToolCallIds.add(toolCallId);
+                        }
+                        if (shouldSuppressProgressAfterMessageToolDelivery()) {
+                          return;
+                        }
+                        if (phase === "start" || phase === "update") {
+                          const toolStartProgressPromise = params.opts?.onToolStart?.({
+                            name,
+                            phase,
+                            args,
+                            detailMode: params.toolProgressDetail,
+                          });
+                          await Promise.all([
+                            params.typingSignals.signalToolStart(),
+                            toolStartProgressPromise,
+                          ]);
+                        }
+                      }
+                      const suppressItemChannelProgress =
+                        evt.stream === "item" &&
+                        evt.data.suppressChannelProgress === true &&
+                        Boolean(params.opts?.onToolStart);
+                      const itemPhase =
+                        evt.stream === "item" ? readStringValue(evt.data.phase) : "";
+                      const itemName = evt.stream === "item" ? readStringValue(evt.data.name) : "";
+                      const itemStatus =
+                        evt.stream === "item" ? readStringValue(evt.data.status) : "";
+                      const itemToolCallId =
+                        evt.stream === "item" ? (readStringValue(evt.data.toolCallId) ?? "") : "";
+                      const completedMessageToolDelivery =
+                        sourceRepliesAreToolOnly &&
+                        itemPhase === "end" &&
+                        itemStatus === "completed" &&
+                        itemToolCallId.length > 0 &&
+                        messageToolOnlyDeliveryToolCallIds.has(itemToolCallId);
+                      const suppressProgressAfterMessageToolDelivery =
+                        shouldSuppressProgressAfterMessageToolDelivery();
+                      if (completedMessageToolDelivery) {
+                        messageToolOnlyDeliveryToolCallIds.delete(itemToolCallId);
+                        messageToolOnlyDeliveryCompleted = true;
+                      }
+                      if (
+                        evt.stream === "item" &&
+                        !suppressItemChannelProgress &&
+                        (!suppressProgressAfterMessageToolDelivery || completedMessageToolDelivery)
+                      ) {
+                        await params.opts?.onItemEvent?.({
+                          itemId: readStringValue(evt.data.itemId),
+                          kind: readStringValue(evt.data.kind),
+                          title: readStringValue(evt.data.title),
+                          name: itemName,
+                          phase: itemPhase,
+                          status: itemStatus,
+                          summary: readStringValue(evt.data.summary),
+                          progressText: readStringValue(evt.data.progressText),
+                          meta: readStringValue(evt.data.meta),
+                          approvalId: readStringValue(evt.data.approvalId),
+                          approvalSlug: readStringValue(evt.data.approvalSlug),
+                        });
+                      }
+                      if (
+                        evt.stream === "plan" &&
+                        !shouldSuppressProgressAfterMessageToolDelivery()
+                      ) {
+                        await params.opts?.onPlanUpdate?.({
+                          phase: readStringValue(evt.data.phase),
+                          title: readStringValue(evt.data.title),
+                          explanation: readStringValue(evt.data.explanation),
+                          steps: Array.isArray(evt.data.steps)
+                            ? evt.data.steps.filter(
+                                (step): step is string => typeof step === "string",
+                              )
+                            : undefined,
+                          source: readStringValue(evt.data.source),
+                        });
+                      }
+                      if (
+                        evt.stream === "approval" &&
+                        !shouldSuppressProgressAfterMessageToolDelivery()
+                      ) {
+                        await params.opts?.onApprovalEvent?.({
+                          phase: readStringValue(evt.data.phase),
+                          kind: readStringValue(evt.data.kind),
+                          status: readStringValue(evt.data.status),
+                          title: readStringValue(evt.data.title),
+                          itemId: readStringValue(evt.data.itemId),
+                          toolCallId: readStringValue(evt.data.toolCallId),
+                          approvalId: readStringValue(evt.data.approvalId),
+                          approvalSlug: readStringValue(evt.data.approvalSlug),
+                          command: readStringValue(evt.data.command),
+                          host: readStringValue(evt.data.host),
+                          reason: readStringValue(evt.data.reason),
+                          scope: readApprovalScopeValue(evt.data.scope),
+                          message: readStringValue(evt.data.message),
+                        });
+                      }
+                      if (
+                        evt.stream === "command_output" &&
+                        !shouldSuppressProgressAfterMessageToolDelivery()
+                      ) {
+                        await params.opts?.onCommandOutput?.({
+                          itemId: readStringValue(evt.data.itemId),
+                          phase: readStringValue(evt.data.phase),
+                          title: readStringValue(evt.data.title),
+                          toolCallId: readStringValue(evt.data.toolCallId),
+                          name: readStringValue(evt.data.name),
+                          output: readStringValue(evt.data.output),
+                          status: readStringValue(evt.data.status),
+                          exitCode:
+                            typeof evt.data.exitCode === "number" || evt.data.exitCode === null
+                              ? evt.data.exitCode
+                              : undefined,
+                          durationMs:
+                            typeof evt.data.durationMs === "number"
+                              ? evt.data.durationMs
+                              : undefined,
+                          cwd: readStringValue(evt.data.cwd),
+                        });
+                      }
+                      if (
+                        evt.stream === "patch" &&
+                        !shouldSuppressProgressAfterMessageToolDelivery()
+                      ) {
+                        await params.opts?.onPatchSummary?.({
+                          itemId: readStringValue(evt.data.itemId),
+                          phase: readStringValue(evt.data.phase),
+                          title: readStringValue(evt.data.title),
+                          toolCallId: readStringValue(evt.data.toolCallId),
+                          name: readStringValue(evt.data.name),
+                          added: Array.isArray(evt.data.added)
+                            ? evt.data.added.filter(
+                                (entry): entry is string => typeof entry === "string",
+                              )
+                            : undefined,
+                          modified: Array.isArray(evt.data.modified)
+                            ? evt.data.modified.filter(
+                                (entry): entry is string => typeof entry === "string",
+                              )
+                            : undefined,
+                          deleted: Array.isArray(evt.data.deleted)
+                            ? evt.data.deleted.filter(
+                                (entry): entry is string => typeof entry === "string",
+                              )
+                            : undefined,
+                          summary: readStringValue(evt.data.summary),
+                        });
+                      }
+                      // Track auto-compaction and notify higher layers.
+                      if (evt.stream === "compaction") {
+                        const phase = readStringValue(evt.data.phase) ?? "";
+                        const hookMessages = readCompactionHookMessages(evt.data.messages);
+                        if (phase === "start") {
+                          // Keep custom compaction callbacks active, but gate the
+                          // fallback user-facing notice behind explicit opt-in.
+                          if (params.opts?.onCompactionStart) {
+                            await params.opts.onCompactionStart();
+                          }
+                          if (hookMessages.length > 0) {
+                            await sendCompactionHookMessages(hookMessages);
+                          } else if (
+                            !params.opts?.onCompactionStart &&
+                            shouldNotifyUserAboutCompaction
+                          ) {
+                            // Send directly via opts.onBlockReply (bypassing the
+                            // pipeline) so the notice does not cause final payloads
+                            // to be discarded on non-streaming model paths.
+                            await sendCompactionNotice("start");
+                          }
+                        }
+                        if (phase === "end") {
+                          const completed = evt.data?.completed === true;
+                          if (completed) {
+                            attemptCompactionCount += 1;
+                            if (params.opts?.onCompactionEnd) {
+                              await params.opts.onCompactionEnd();
+                            }
+                            if (hookMessages.length > 0) {
+                              await sendCompactionHookMessages(hookMessages);
+                            } else if (
+                              !params.opts?.onCompactionEnd &&
+                              shouldNotifyUserAboutCompaction
+                            ) {
+                              await sendCompactionNotice("end");
+                            }
+                          } else if (hookMessages.length > 0) {
+                            await sendCompactionHookMessages(hookMessages);
+                          } else if (shouldNotifyUserAboutCompaction) {
+                            await sendCompactionNotice("incomplete");
+                          }
+                        }
+                      }
+                    },
+                    // Always pass onBlockReply so flushBlockReplyBuffer works before tool execution,
+                    // even when regular block streaming is disabled. The handler sends directly
+                    // via opts.onBlockReply when the pipeline isn't available.
+                    onBlockReply: blockReplyHandler,
+                    onBlockReplyFlush:
+                      params.blockStreamingEnabled && blockReplyPipeline
+                        ? async () => {
+                            await blockReplyPipeline.flush({ force: true });
+                          }
+                        : undefined,
+                    shouldEmitToolResult: params.shouldEmitToolResult,
+                    shouldEmitToolOutput: params.shouldEmitToolOutput,
+                    bootstrapPromptWarningSignaturesSeen,
+                    bootstrapPromptWarningSignature:
+                      bootstrapPromptWarningSignaturesSeen[
+                        bootstrapPromptWarningSignaturesSeen.length - 1
+                      ],
+                    onToolResult: onToolResult
+                      ? (() => {
+                          // Serialize tool result delivery to preserve message ordering.
+                          // Without this, concurrent tool callbacks race through typing signals
+                          // and message sends, causing out-of-order delivery to the user.
+                          // See: https://github.com/openclaw/openclaw/issues/11044
+                          let toolResultChain: Promise<void> = Promise.resolve();
+                          return (payload: ReplyPayload) => {
+                            toolResultChain = toolResultChain
+                              .then(async () => {
+                                const { text, skip } = normalizeStreamingText(payload);
+                                if (skip) {
+                                  return;
+                                }
+                                if (text !== undefined) {
+                                  await params.typingSignals.signalTextDelta(text);
+                                }
+                                await onToolResult({
+                                  ...payload,
+                                  text,
+                                });
+                              })
+                              .catch((err) => {
+                                // Keep chain healthy after an error so later tool results still deliver.
+                                logVerbose(`tool result delivery failed: ${String(err)}`);
+                              });
+                            const task = toolResultChain.finally(() => {
+                              params.pendingToolTasks.delete(task);
+                            });
+                            params.pendingToolTasks.add(task);
+                          };
+                        })()
+                      : undefined,
+                  }),
+                );
+                bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
+                  result.meta?.systemPromptReport,
+                );
+                lifecycleBackstop.emit("end", result);
+                const resultCompactionCount = Math.max(
+                  0,
+                  result.meta?.agentMeta?.compactionCount ?? 0,
+                );
+                attemptCompactionCount = Math.max(attemptCompactionCount, resultCompactionCount);
+                return result;
+              } catch (err) {
+                if (rollbackFallbackCandidateSelection) {
+                  try {
+                    await rollbackFallbackCandidateSelection();
+                    clearPendingFallbackRollback(rollbackFallbackCandidateSelection);
+                  } catch (rollbackError) {
+                    logVerbose(
+                      `failed to roll back fallback candidate selection (non-fatal): ${String(rollbackError)}`,
+                    );
+                  }
+                }
+                lifecycleBackstop.emit("error", err);
+                throw err;
+              } finally {
+                autoCompactionCount += attemptCompactionCount;
+              }
+            })();
+          },
+        }),
+      );
+      agentTurnTiming.logIfSlow({
+        runId,
+        sessionId: params.followupRun.run.sessionId,
+        sessionKey: params.sessionKey,
+        outcome: "completed",
       });
       runResult = fallbackResult.result;
       fallbackProvider = fallbackResult.provider;
@@ -2446,6 +2648,13 @@ export async function runAgentTurnWithFallback(params: {
         continue;
       }
       const message = formatErrorMessage(err);
+      agentTurnTiming.logIfSlow({
+        runId,
+        sessionId: params.followupRun.run.sessionId,
+        sessionKey: params.sessionKey,
+        outcome: "error",
+        error: message,
+      });
       const isBilling = isFallbackSummaryError(err)
         ? hasBillingAttemptSummary(err)
         : isBillingErrorMessage(message);

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -673,6 +673,114 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(runEmbeddedPiAgentMock).not.toHaveBeenCalled();
   });
 
+  it("continues when preflight compaction reports the session is already under target", async () => {
+    const sessionFile = path.join(rootDir, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
+      "utf8",
+    );
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 1,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 0,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    compactEmbeddedPiSessionMock.mockResolvedValueOnce({
+      ok: true,
+      compacted: false,
+      reason: "already under target",
+    });
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokens: 120,
+      totalTokensFresh: true,
+    };
+
+    const entry = await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({
+        sessionId: "session",
+        sessionFile,
+        sessionKey: "agent:main:main",
+      }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100,
+      sessionEntry,
+      sessionStore: { "agent:main:main": sessionEntry },
+      sessionKey: "agent:main:main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(entry).toBe(sessionEntry);
+    expect(compactEmbeddedPiSessionMock).toHaveBeenCalledTimes(1);
+    expect(requireCompactEmbeddedPiSessionCall()).toMatchObject({
+      trigger: "budget",
+      deferOwningContextEngineCompaction: false,
+      contextTokenBudget: 100,
+    });
+    expect(incrementCompactionCountMock).not.toHaveBeenCalled();
+  });
+
+  it("fails when required preflight context-engine compaction is deferred to background maintenance", async () => {
+    const sessionFile = path.join(rootDir, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
+      "utf8",
+    );
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 1,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 0,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    compactEmbeddedPiSessionMock.mockResolvedValueOnce({
+      ok: true,
+      compacted: false,
+      reason: "deferred to background context-engine maintenance",
+    });
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokens: 120,
+      totalTokensFresh: true,
+    };
+
+    await expect(
+      runPreflightCompactionIfNeeded({
+        cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+        followupRun: createTestFollowupRun({
+          sessionId: "session",
+          sessionFile,
+          sessionKey: "agent:main:main",
+        }),
+        defaultModel: "anthropic/claude-opus-4-6",
+        agentCfgContextTokens: 100,
+        sessionEntry,
+        sessionStore: { "agent:main:main": sessionEntry },
+        sessionKey: "agent:main:main",
+        storePath: path.join(rootDir, "sessions.json"),
+        isHeartbeat: false,
+        replyOperation: createReplyOperation(),
+      }),
+    ).rejects.toThrow(
+      "Preflight compaction required but failed: deferred to background context-engine maintenance",
+    );
+
+    expect(compactEmbeddedPiSessionMock).toHaveBeenCalledTimes(1);
+    expect(incrementCompactionCountMock).not.toHaveBeenCalled();
+  });
+
   it("passes runtime policy session key to preflight compaction sandbox resolution", async () => {
     const sessionFile = path.join(rootDir, "session.jsonl");
     await fs.writeFile(
@@ -692,7 +800,8 @@ describe("runMemoryFlushIfNeeded", () => {
       sessionId: "session",
       sessionFile,
       updatedAt: Date.now(),
-      totalTokensFresh: false,
+      totalTokens: 120,
+      totalTokensFresh: true,
     };
 
     await runPreflightCompactionIfNeeded({
@@ -750,7 +859,8 @@ describe("runMemoryFlushIfNeeded", () => {
         sessionId: "session",
         sessionFile,
         updatedAt: Date.now(),
-        totalTokensFresh: false,
+        totalTokens: 120,
+        totalTokensFresh: true,
       };
       const sessionStore = { "agent:main:telegram:group:redacted": sessionEntry };
 
@@ -802,7 +912,8 @@ describe("runMemoryFlushIfNeeded", () => {
       sessionId: "session",
       sessionFile,
       updatedAt: Date.now(),
-      totalTokensFresh: false,
+      totalTokens: 120,
+      totalTokensFresh: true,
     };
     const sessionStore = { "agent:main:telegram:group:redacted": sessionEntry };
 
@@ -947,7 +1058,7 @@ describe("runMemoryFlushIfNeeded", () => {
     compactEmbeddedPiSessionMock.mockResolvedValueOnce({
       ok: true,
       compacted: false,
-      reason: "already under target",
+      reason: "plugin already stored this turn",
     });
     const sessionEntry: SessionEntry = {
       sessionId: "session",

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -10,6 +10,10 @@ import { runWithModelFallback } from "../../agents/model-fallback.js";
 import { listLegacyRuntimeModelProviderAliases } from "../../agents/model-runtime-aliases.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import { resolveContextConfigProviderForRuntime } from "../../agents/openai-codex-routing.js";
+import {
+  classifyCompactionReason,
+  DEFERRED_CONTEXT_ENGINE_COMPACTION_REASON,
+} from "../../agents/pi-embedded-runner/compact-reasons.js";
 import { resolveSandboxConfigForAgent, resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
 import {
   derivePromptTokens,
@@ -174,6 +178,22 @@ function resolveEffectivePromptTokens(
   // Flush gating projects the next input context by adding the previous
   // completion and the current user prompt estimate.
   return base + output + estimate;
+}
+
+function isPreflightCompactionSkipReason(reason?: string): boolean {
+  const classification = classifyCompactionReason(reason);
+  // Preflight compaction is a guardrail, not a hard dependency. These classes
+  // mean the context engine found nothing useful to compact, so the reply should
+  // continue instead of surfacing a generic user-facing failure.
+  return (
+    classification === "below_threshold" ||
+    classification === "no_compactable_entries" ||
+    classification === "already_compacted_recently"
+  );
+}
+
+function isDeferredPreflightCompactionReason(reason?: string): boolean {
+  return normalizeOptionalString(reason) === DEFERRED_CONTEXT_ENGINE_COMPACTION_REASON;
 }
 
 function resolveMemoryFlushModelFallbackOptions(
@@ -624,6 +644,11 @@ export async function runPreflightCompactionIfNeeded(params: {
   isHeartbeat: boolean;
   replyOperation: ReplyOperation;
 }): Promise<SessionEntry | undefined> {
+  const deps = {
+    compactEmbeddedPiSession: memoryDeps.compactEmbeddedPiSession,
+    incrementCompactionCount: memoryDeps.incrementCompactionCount,
+    refreshQueuedFollowupSession: memoryDeps.refreshQueuedFollowupSession,
+  };
   if (!params.sessionKey) {
     return params.sessionEntry;
   }
@@ -788,7 +813,7 @@ export async function runPreflightCompactionIfNeeded(params: {
     params.sessionKey ?? params.followupRun.run.sessionKey,
     { storePath: params.storePath },
   );
-  const result = await memoryDeps.compactEmbeddedPiSession({
+  const result = await deps.compactEmbeddedPiSession({
     sessionId: entry.sessionId,
     sessionKey: params.sessionKey,
     sandboxSessionKey: params.runtimePolicySessionKey,
@@ -813,14 +838,19 @@ export async function runPreflightCompactionIfNeeded(params: {
     thinkLevel: params.followupRun.run.thinkLevel,
     bashElevated: params.followupRun.run.bashElevated,
     trigger: "budget",
-    currentTokenCount: tokenCountForCompaction ?? freshPersistedTokens,
+    deferOwningContextEngineCompaction: false,
     contextTokenBudget: contextWindowTokens,
+    currentTokenCount: tokenCountForCompaction ?? freshPersistedTokens,
     ownerNumbers: params.followupRun.run.ownerNumbers,
     abortSignal: params.replyOperation.abortSignal,
   });
 
   if (!result?.ok) {
     const reason = result?.reason ?? "not_compacted";
+    if (isPreflightCompactionSkipReason(reason)) {
+      logVerbose(`preflightCompaction skipped: sessionKey=${params.sessionKey} reason=${reason}`);
+      return entry ?? params.sessionEntry;
+    }
     logVerbose(`preflightCompaction failed: sessionKey=${params.sessionKey} reason=${reason}`);
     if (isRecoverableNativeHarnessBindingFailure(result)) {
       logVerbose(
@@ -832,12 +862,18 @@ export async function runPreflightCompactionIfNeeded(params: {
   }
 
   if (!result.compacted) {
-    const reason = result.reason ?? "not_compacted";
-    logVerbose(`preflightCompaction no-op: sessionKey=${params.sessionKey} reason=${reason}`);
+    const reason = normalizeOptionalString(result.reason);
+    if (isDeferredPreflightCompactionReason(reason)) {
+      logVerbose(`preflightCompaction failed: sessionKey=${params.sessionKey} reason=${reason}`);
+      throw new Error(`Preflight compaction required but failed: ${reason}`);
+    }
+    logVerbose(
+      `preflightCompaction skipped: sessionKey=${params.sessionKey} reason=${reason ?? "not_compacted"}`,
+    );
     return entry ?? params.sessionEntry;
   }
 
-  await incrementCompactionCount({
+  await deps.incrementCompactionCount({
     cfg: params.cfg,
     sessionEntry: entry,
     sessionStore: params.sessionStore,
@@ -861,7 +897,7 @@ export async function runPreflightCompactionIfNeeded(params: {
     }
     const queueKey = params.followupRun.run.sessionKey ?? params.sessionKey;
     if (queueKey) {
-      memoryDeps.refreshQueuedFollowupSession({
+      deps.refreshQueuedFollowupSession({
         key: queueKey,
         previousSessionId,
         nextSessionId: entry.sessionId,

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -376,6 +376,77 @@ describe("runReplyAgent auto-compaction token update", () => {
     expect(stored[sessionKey].totalTokens).toBe(55_000);
   });
 
+  it("continues when preflight compaction reports a skip-like no-op result", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-preflight-skip-"));
+    const storePath = path.join(tmp, "sessions.json");
+    const sessionKey = "main";
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 1_000_000,
+    };
+    await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+
+    compactState.compactEmbeddedPiSessionMock.mockResolvedValueOnce({
+      ok: false,
+      compacted: false,
+      reason: "already under target",
+    });
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {
+        agentMeta: {
+          lastCallUsage: { input: 1_000, output: 100, total: 1_100 },
+        },
+      },
+    });
+
+    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
+      storePath,
+      sessionEntry,
+      sessionFile: path.join(tmp, "session.jsonl"),
+      workspaceDir: tmp,
+    });
+
+    const result = await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: sessionKey,
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      storePath,
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 200_000,
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expectReplyText(result, "ok");
+    expect(compactState.compactEmbeddedPiSessionMock).toHaveBeenCalledTimes(1);
+    expect(
+      firstMockCallArg(compactState.compactEmbeddedPiSessionMock, "preflight compaction"),
+    ).toMatchObject({
+      sessionId: "session",
+      sessionKey,
+      trigger: "budget",
+      deferOwningContextEngineCompaction: false,
+      currentTokenCount: 1_000_000,
+    });
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+  });
+
   it("starts queued followup drain only after clearing the active reply operation", async () => {
     const sessionKey = "main";
     const sessionEntry = {

--- a/src/auto-reply/reply/commands-compact.test.ts
+++ b/src/auto-reply/reply/commands-compact.test.ts
@@ -190,6 +190,33 @@ describe("handleCompactCommand", () => {
     expect(call.agentDir).toBe("/tmp/openclaw-agent-compact");
   });
 
+  it("treats already-under-target manual compaction as skipped", async () => {
+    vi.mocked(compactEmbeddedPiSession).mockResolvedValueOnce({
+      ok: false,
+      compacted: false,
+      reason: "already under target",
+    });
+
+    const result = await handleCompactCommand(
+      {
+        ...buildCompactParams("/compact", {
+          commands: { text: true },
+          channels: { whatsapp: { allowFrom: ["*"] } },
+        } as OpenClawConfig),
+        sessionEntry: {
+          sessionId: "session-1",
+          updatedAt: Date.now(),
+        },
+      } as HandleCommandsParams,
+      true,
+    );
+
+    expect(result?.reply?.text).toBe(
+      "⚙️ Compaction skipped: context is already under the compaction target • Context 12.1k",
+    );
+    expect(vi.mocked(incrementCompactionCount)).not.toHaveBeenCalled();
+  });
+
   it("uses the canonical session agent when resolving the compaction session file", async () => {
     vi.mocked(compactEmbeddedPiSession).mockResolvedValueOnce({
       ok: true,

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -53,9 +53,12 @@ function extractCompactInstructions(params: {
 
 function isCompactionSkipReason(reason?: string): boolean {
   const text = normalizeOptionalLowercaseString(reason) ?? "";
+  // Manual /compact mirrors preflight semantics: already-small sessions are a
+  // successful no-op, not a failed compaction.
   return (
     text.includes("nothing to compact") ||
     text.includes("below threshold") ||
+    text.includes("already under target") ||
     text.includes("already compacted") ||
     text.includes("no real conversation messages")
   );
@@ -73,6 +76,9 @@ function formatCompactionReason(reason?: string): string | undefined {
   }
   if (lower.includes("below threshold")) {
     return "context is below the compaction threshold";
+  }
+  if (lower.includes("already under target")) {
+    return "context is already under the compaction target";
   }
   if (lower.includes("already compacted")) {
     return "session was already compacted recently";

--- a/src/auto-reply/reply/commands-handlers.runtime.ts
+++ b/src/auto-reply/reply/commands-handlers.runtime.ts
@@ -14,6 +14,7 @@ import {
   handleExportTrajectoryCommand,
   handleExportSessionCommand,
   handleHelpCommand,
+  handleSkillCommandUsage,
   handleStatusCommand,
   handleToolsCommand,
 } from "./commands-info.js";
@@ -53,6 +54,9 @@ export function loadCommandHandlers(): CommandHandler[] {
     handleTtsCommands,
     handleHelpCommand,
     handleCommandsListCommand,
+    // Keep deterministic /skill usage on the native command path before the
+    // broader tool/status handlers can fall through to an agent run.
+    handleSkillCommandUsage,
     handleToolsCommand,
     handleStatusCommand,
     handleDiagnosticsCommand,

--- a/src/auto-reply/reply/commands-info.test.ts
+++ b/src/auto-reply/reply/commands-info.test.ts
@@ -3,7 +3,11 @@ import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { MsgContext } from "../templating.js";
 import { handleContextCommand } from "./commands-context-command.js";
-import { handleExportTrajectoryCommand, handleStatusCommand } from "./commands-info.js";
+import {
+  handleExportTrajectoryCommand,
+  handleSkillCommandUsage,
+  handleStatusCommand,
+} from "./commands-info.js";
 import { buildStatusReply } from "./commands-status.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 import { handleWhoamiCommand } from "./commands-whoami.js";
@@ -39,9 +43,14 @@ vi.mock("../../agents/agent-scope.js", async () => {
   };
 });
 
-vi.mock("../skill-commands.js", () => ({
-  listSkillCommandsForAgents: listSkillCommandsForAgentsMock,
-}));
+vi.mock("../skill-commands.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../skill-commands.js")>("../skill-commands.js");
+  return {
+    ...actual,
+    listSkillCommandsForAgents: listSkillCommandsForAgentsMock,
+  };
+});
 
 vi.mock("../status.js", async () => {
   const actual = await vi.importActual<typeof import("../status.js")>("../status.js");
@@ -154,6 +163,54 @@ describe("info command handlers", () => {
     expect(result?.reply?.text).toContain("User id: 12345");
     expect(result?.reply?.text).toContain("Username: @TestUser");
     expect(result?.reply?.text).toContain("AllowFrom: 12345");
+  });
+
+  it("returns usage for bare /skill without continuing to the agent", async () => {
+    const params = buildInfoParams("/skill", {
+      commands: { text: true },
+    } as OpenClawConfig);
+    params.skillCommands = [
+      {
+        name: "demo_skill",
+        skillName: "demo-skill",
+        description: "Demo skill",
+      },
+    ];
+
+    const result = await handleSkillCommandUsage(params, true);
+
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("Usage: /skill <name> [input]");
+    expect(result?.reply?.text).toContain("Available: demo-skill");
+  });
+
+  it("returns an unknown skill reply for unmatched /skill targets", async () => {
+    const params = buildInfoParams("/skill missing input", {
+      commands: { text: true },
+    } as OpenClawConfig);
+
+    const result = await handleSkillCommandUsage(params, true);
+
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("Unknown skill: missing");
+    expect(result?.reply?.text).toContain("Usage: /skill <name> [input]");
+  });
+
+  it("lets valid /skill invocations continue to the skill command path", async () => {
+    const params = buildInfoParams("/skill demo_skill input", {
+      commands: { text: true },
+    } as OpenClawConfig);
+    params.skillCommands = [
+      {
+        name: "demo_skill",
+        skillName: "demo-skill",
+        description: "Demo skill",
+      },
+    ];
+
+    const result = await handleSkillCommandUsage(params, true);
+
+    expect(result).toBeNull();
   });
 
   it("uses the canonical command sender identity for /whoami AllowFrom", async () => {

--- a/src/auto-reply/reply/commands-info.ts
+++ b/src/auto-reply/reply/commands-info.ts
@@ -2,7 +2,7 @@ import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolveEffectiveToolInventory } from "../../agents/tools-effective-inventory.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import { logVerbose } from "../../globals.js";
-import { listSkillCommandsForAgents } from "../skill-commands.js";
+import { listSkillCommandsForAgents, resolveSkillCommandInvocation } from "../skill-commands.js";
 import {
   buildCommandsMessage,
   buildCommandsMessagePaginated,
@@ -15,7 +15,7 @@ import { rejectUnauthorizedCommand } from "./command-gates.js";
 import { buildExportSessionReply } from "./commands-export-session.js";
 import { buildExportTrajectoryCommandReply } from "./commands-export-trajectory.js";
 import { buildStatusReply } from "./commands-status.js";
-import type { CommandHandler } from "./commands-types.js";
+import type { CommandHandler, HandleCommandsParams } from "./commands-types.js";
 import { extractExplicitGroupId } from "./group-id.js";
 import { resolveReplyToMode } from "./reply-threading.js";
 export { handleContextCommand } from "./commands-context-command.js";
@@ -86,6 +86,62 @@ export const handleCommandsListCommand: CommandHandler = async (params, allowTex
   return {
     shouldContinue: false,
     reply: { text: buildCommandsMessage(params.cfg, skillCommands, { surface }) },
+  };
+};
+
+function buildSkillCommandUsage(skillCommands: NonNullable<HandleCommandsParams["skillCommands"]>) {
+  const lines = ["Usage: /skill <name> [input]"];
+  if (skillCommands.length > 0) {
+    const names = skillCommands.slice(0, 8).map((command) => command.skillName || command.name);
+    lines.push("", `Available: ${names.join(", ")}`);
+    if (skillCommands.length > names.length) {
+      lines.push(`More: /commands (${skillCommands.length - names.length} more)`);
+    } else {
+      lines.push("More: /commands");
+    }
+  } else {
+    lines.push("", "Use /commands to list available skill commands.");
+  }
+  return lines.join("\n");
+}
+
+export const handleSkillCommandUsage: CommandHandler = async (params, allowTextCommands) => {
+  if (!allowTextCommands) {
+    return null;
+  }
+  const normalized = params.command.commandBodyNormalized;
+  if (normalized !== "/skill" && !normalized.startsWith("/skill ")) {
+    return null;
+  }
+  // Bare or unknown /skill commands are deterministic help responses; handling
+  // them here avoids falling through into a full agent/model turn.
+  if (!params.command.isAuthorizedSender) {
+    logVerbose(
+      `Ignoring /skill from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
+    );
+    return { shouldContinue: false };
+  }
+
+  const [, rawName] = normalized.match(/^\/skill(?:\s+([^\s]+))?/u) ?? [];
+  const agentId = params.sessionKey
+    ? resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg })
+    : params.agentId;
+  const skillCommands =
+    params.skillCommands ??
+    listSkillCommandsForAgents({
+      cfg: params.cfg,
+      agentIds: agentId ? [agentId] : undefined,
+    });
+  if (
+    rawName &&
+    resolveSkillCommandInvocation({ commandBodyNormalized: normalized, skillCommands })
+  ) {
+    return null;
+  }
+  const prefix = rawName ? `Unknown skill: ${rawName}\n\n` : "";
+  return {
+    shouldContinue: false,
+    reply: { text: `${prefix}${buildSkillCommandUsage(skillCommands)}` },
   };
 };
 

--- a/src/auto-reply/reply/commands-session-store.ts
+++ b/src/auto-reply/reply/commands-session-store.ts
@@ -12,9 +12,16 @@ export async function persistSessionEntry(params: CommandParams): Promise<boolea
   params.sessionEntry.updatedAt = Date.now();
   params.sessionStore[params.sessionKey] = params.sessionEntry;
   if (params.storePath) {
-    await updateSessionStore(params.storePath, (store) => {
-      store[params.sessionKey] = params.sessionEntry as SessionEntry;
-    });
+    // Slash commands mutate one known session entry; skipping global session
+    // maintenance avoids scanning the whole sessions directory for simple
+    // command-only writes.
+    await updateSessionStore(
+      params.storePath,
+      (store) => {
+        store[params.sessionKey] = params.sessionEntry as SessionEntry;
+      },
+      { skipMaintenance: true },
+    );
   }
   return true;
 }

--- a/src/auto-reply/reply/directive-handling.defaults.ts
+++ b/src/auto-reply/reply/directive-handling.defaults.ts
@@ -13,12 +13,16 @@ export function resolveDefaultModel(params: { cfg: OpenClawConfig; agentId?: str
   const mainModel = resolveDefaultModelForAgent({
     cfg: params.cfg,
     agentId: params.agentId,
+    // Default-model lookup is on every reply; plugin runtime normalization can
+    // cold-load plugins, so keep this to static/configured model aliases here.
+    allowPluginNormalization: false,
   });
   const defaultProvider = mainModel.provider;
   const defaultModel = mainModel.model;
   const aliasIndex = buildModelAliasIndex({
     cfg: params.cfg,
     defaultProvider,
+    allowPluginNormalization: false,
   });
   return { defaultProvider, defaultModel, aliasIndex };
 }

--- a/src/auto-reply/reply/dispatch-acp-delivery.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.test.ts
@@ -240,7 +240,7 @@ describe("createAcpDispatchDeliveryCoordinator", () => {
     expect(coordinator.getRoutedCounts().block).toBe(0);
   });
 
-  it("waits for direct block dispatcher delivery before resolving block delivery", async () => {
+  it("does not wait for direct block dispatcher delivery before resolving block delivery", async () => {
     const delivered: unknown[] = [];
     let releaseDelivery: (() => void) | undefined;
     let markDeliveryStarted: (() => void) | undefined;
@@ -276,13 +276,68 @@ describe("createAcpDispatchDeliveryCoordinator", () => {
     });
 
     await deliveryStarted;
+    await Promise.resolve();
 
     expect(delivered).toEqual([{ text: "hello" }]);
-    expect(deliverySettled).toBe(false);
+    expect(deliverySettled).toBe(true);
 
     releaseDelivery?.();
     await expect(deliveryPromise).resolves.toBe(true);
     expect(deliverySettled).toBe(true);
+    await dispatcher.waitForIdle();
+  });
+
+  it("waits for pending direct block delivery before resolving tool delivery", async () => {
+    const delivered: unknown[] = [];
+    let releaseDelivery: (() => void) | undefined;
+    let markDeliveryStarted: (() => void) | undefined;
+    const deliveryStarted = new Promise<void>((resolve) => {
+      markDeliveryStarted = resolve;
+    });
+    const deliveryGate = new Promise<void>((resolve) => {
+      releaseDelivery = resolve;
+    });
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload) => {
+        delivered.push(payload);
+        markDeliveryStarted?.();
+        await deliveryGate;
+      },
+    });
+    const coordinator = createAcpDispatchDeliveryCoordinator({
+      cfg: createAcpTestConfig(),
+      ctx: buildTestCtx({
+        Provider: "visiblechat",
+        Surface: "visiblechat",
+        SessionKey: "agent:codex-acp:session-1",
+      }),
+      dispatcher,
+      inboundAudio: false,
+      shouldRouteToOriginating: false,
+    });
+
+    await expect(coordinator.deliver("block", { text: "hello" }, { skipTts: true })).resolves.toBe(
+      true,
+    );
+    await deliveryStarted;
+
+    let toolDeliverySettled = false;
+    const toolDeliveryPromise = coordinator
+      .deliver("tool", { text: "tool result" }, { skipTts: true })
+      .then((result) => {
+        toolDeliverySettled = true;
+        return result;
+      });
+
+    await Promise.resolve();
+
+    expect(delivered).toEqual([{ text: "hello" }]);
+    expect(toolDeliverySettled).toBe(false);
+
+    releaseDelivery?.();
+    await expect(toolDeliveryPromise).resolves.toBe(true);
+    expect(toolDeliverySettled).toBe(true);
+    expect(delivered).toEqual([{ text: "hello" }, { text: "tool result" }]);
   });
 
   it("stops waiting for direct block delivery when the ACP dispatch aborts", async () => {

--- a/src/auto-reply/reply/dispatch-acp-delivery.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.ts
@@ -234,11 +234,23 @@ export function createAcpDispatchDeliveryCoordinator(params: {
     },
     toolMessageByCallId: new Map(),
   };
+  let hasPendingDirectBlockReplyDelivery = false;
+  const waitForPendingDirectBlockReplyDelivery = async () => {
+    if (!hasPendingDirectBlockReplyDelivery) {
+      return;
+    }
+    // ACP direct block replies should not block the common visible-reply path.
+    // Defer the idle wait until a later tool delivery would otherwise overtake
+    // that block reply in user-visible ordering.
+    hasPendingDirectBlockReplyDelivery = false;
+    await waitForReplyDispatcherIdle(params.dispatcher, params.abortSignal);
+  };
   const settleDirectVisibleText = async () => {
     if (state.settledDirectVisibleText || state.queuedDirectVisibleTextDeliveries === 0) {
       return;
     }
     state.settledDirectVisibleText = true;
+    hasPendingDirectBlockReplyDelivery = false;
     await params.dispatcher.waitForIdle();
     const failedCounts = params.dispatcher.getFailedCounts();
     const failedVisibleCount = failedCounts.block + failedCounts.final;
@@ -440,6 +452,10 @@ export function createAcpDispatchDeliveryCoordinator(params: {
       return true;
     }
 
+    if (kind === "tool") {
+      await waitForPendingDirectBlockReplyDelivery();
+    }
+
     const tracksVisibleText = await shouldTreatDeliveredTextAsVisible({
       channel: directChannel,
       kind,
@@ -462,7 +478,7 @@ export function createAcpDispatchDeliveryCoordinator(params: {
       state.failedVisibleTextDelivery = true;
     }
     if (kind === "block" && delivered) {
-      await waitForReplyDispatcherIdle(params.dispatcher, params.abortSignal);
+      hasPendingDirectBlockReplyDelivery = true;
     }
     return delivered;
   };

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -4738,6 +4738,78 @@ describe("dispatchReplyFromConfig", () => {
     expect(replyResolver).not.toHaveBeenCalled();
   });
 
+  it("does not run plugin-owned binding delivery when the caller already aborted", async () => {
+    setNoAbort();
+    hookMocks.runner.hasHooks.mockImplementation(
+      ((hookName?: string) =>
+        hookName === "inbound_claim" || hookName === "message_received") as () => boolean,
+    );
+    hookMocks.registry.plugins = [{ id: "openclaw-codex-app-server", status: "loaded" }];
+    hookMocks.runner.runInboundClaimForPluginOutcome.mockResolvedValue({
+      status: "handled",
+      result: { handled: true, reply: { text: "should not send" } },
+    });
+    sessionBindingMocks.resolveByConversation.mockReturnValue({
+      bindingId: "binding-aborted-1",
+      targetSessionKey: "plugin-binding:codex:abc123",
+      targetKind: "session",
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:1481858418548412579",
+      },
+      status: "active",
+      boundAt: 1710000000000,
+      metadata: {
+        pluginBindingOwner: "plugin",
+        pluginId: "openclaw-codex-app-server",
+        pluginRoot: "/workspace/openclaw-app-server",
+        data: {
+          kind: "codex-app-server-session",
+          version: 1,
+          sessionFile: "/tmp/session.jsonl",
+          workspaceDir: "/workspace/openclaw",
+        },
+      },
+    } satisfies SessionBindingRecord);
+    const abortController = new AbortController();
+    abortController.abort();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      OriginatingChannel: "discord",
+      OriginatingTo: "discord:channel:1481858418548412579",
+      To: "discord:channel:1481858418548412579",
+      AccountId: "default",
+      SenderId: "user-9",
+      SenderUsername: "ada",
+      CommandAuthorized: true,
+      WasMentioned: false,
+      CommandBody: "who are you",
+      RawBody: "who are you",
+      Body: "who are you",
+      MessageSid: "msg-claim-plugin-aborted-1",
+      SessionKey: "agent:main:discord:channel:1481858418548412579",
+    });
+    const replyResolver = vi.fn(async () => ({ text: "should not run" }) satisfies ReplyPayload);
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyOptions: { abortSignal: abortController.signal },
+      replyResolver,
+    });
+
+    expect(result).toEqual({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } });
+    expect(sessionBindingMocks.touch).not.toHaveBeenCalled();
+    expect(hookMocks.runner.runInboundClaimForPluginOutcome).not.toHaveBeenCalled();
+    expect(replyResolver).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
   it("lets authorized plugin-owned binding commands fall through to command processing", async () => {
     setNoAbort();
     expect(
@@ -5706,7 +5778,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(callOrder).toEqual(["queued:The answer is 42", "dispatch:The answer is 42"]);
   });
 
-  it("waits for same-channel block dispatcher delivery before resolving block replies", async () => {
+  it("does not wait for same-channel block dispatcher delivery before resolving block replies", async () => {
     setNoAbort();
     const ctx = buildTestCtx({ Provider: "whatsapp" });
     const delivered: ReplyPayload[] = [];
@@ -5739,10 +5811,10 @@ describe("dispatchReplyFromConfig", () => {
       await deliveryStarted;
 
       expect(delivered).toEqual([{ text: "before tool" }]);
-      expect(blockReplySettled).toBe(false);
+      await blockReplyPromise;
+      expect(blockReplySettled).toBe(true);
 
       releaseDelivery?.();
-      await blockReplyPromise;
       return undefined;
     };
 
@@ -5754,6 +5826,177 @@ describe("dispatchReplyFromConfig", () => {
     });
 
     expect(blockReplySettled).toBe(true);
+    await dispatcher.waitForIdle();
+  });
+
+  it("waits for pending same-channel block delivery before completing block-only dispatch", async () => {
+    setNoAbort();
+    const ctx = buildTestCtx({ Provider: "whatsapp" });
+    const delivered: ReplyPayload[] = [];
+    let releaseDelivery: (() => void) | undefined;
+    let markDeliveryStarted: (() => void) | undefined;
+    const deliveryStarted = new Promise<void>((resolve) => {
+      markDeliveryStarted = resolve;
+    });
+    const deliveryGate = new Promise<void>((resolve) => {
+      releaseDelivery = resolve;
+    });
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload) => {
+        delivered.push(payload);
+        markDeliveryStarted?.();
+        await deliveryGate;
+      },
+    });
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload | undefined> => {
+      await opts?.onBlockReply?.({ text: "only block" });
+      return undefined;
+    };
+
+    let dispatchSettled = false;
+    const dispatchPromise = dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    }).then((result) => {
+      dispatchSettled = true;
+      return result;
+    });
+
+    await deliveryStarted;
+
+    expect(delivered).toEqual([{ text: "only block" }]);
+    expect(dispatchSettled).toBe(false);
+
+    releaseDelivery?.();
+    await dispatchPromise;
+
+    expect(dispatchSettled).toBe(true);
+  });
+
+  it("waits for pending same-channel block delivery before forwarding tool progress", async () => {
+    setNoAbort();
+    const cfg = {
+      agents: { defaults: { verboseDefault: "on" } },
+    } as const satisfies OpenClawConfig;
+    const ctx = buildTestCtx({ Provider: "whatsapp" });
+    const delivered: ReplyPayload[] = [];
+    let releaseDelivery: (() => void) | undefined;
+    let markDeliveryStarted: (() => void) | undefined;
+    const deliveryStarted = new Promise<void>((resolve) => {
+      markDeliveryStarted = resolve;
+    });
+    const deliveryGate = new Promise<void>((resolve) => {
+      releaseDelivery = resolve;
+    });
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload) => {
+        delivered.push(payload);
+        markDeliveryStarted?.();
+        await deliveryGate;
+      },
+    });
+    const onToolStart = vi.fn();
+    let toolProgressSettled = false;
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload | undefined> => {
+      await opts?.onBlockReply?.({ text: "before tool" });
+      const toolProgressPromise = Promise.resolve(opts?.onToolStart?.({ name: "lookup" })).then(
+        () => {
+          toolProgressSettled = true;
+        },
+      );
+
+      await deliveryStarted;
+
+      expect(delivered).toEqual([{ text: "before tool" }]);
+      expect(onToolStart).not.toHaveBeenCalled();
+      expect(toolProgressSettled).toBe(false);
+
+      releaseDelivery?.();
+      await toolProgressPromise;
+      return undefined;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: { onToolStart },
+    });
+
+    expect(toolProgressSettled).toBe(true);
+    expect(onToolStart).toHaveBeenCalledWith({ name: "lookup" });
+  });
+
+  it("does not synthesize tool-start capability while ordering item progress", async () => {
+    setNoAbort();
+    const cfg = {
+      agents: { defaults: { verboseDefault: "on" } },
+    } as const satisfies OpenClawConfig;
+    const ctx = buildTestCtx({ Provider: "whatsapp" });
+    const delivered: ReplyPayload[] = [];
+    let releaseDelivery: (() => void) | undefined;
+    let markDeliveryStarted: (() => void) | undefined;
+    const deliveryStarted = new Promise<void>((resolve) => {
+      markDeliveryStarted = resolve;
+    });
+    const deliveryGate = new Promise<void>((resolve) => {
+      releaseDelivery = resolve;
+    });
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload) => {
+        delivered.push(payload);
+        markDeliveryStarted?.();
+        await deliveryGate;
+      },
+    });
+    const onItemEvent = vi.fn();
+    let itemProgressSettled = false;
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload | undefined> => {
+      await opts?.onBlockReply?.({ text: "before item" });
+      expect(opts?.onToolStart).toBeUndefined();
+      const itemProgressPromise = Promise.resolve(
+        opts?.onItemEvent?.({ itemId: "1", kind: "tool", progressText: "running" }),
+      ).then(() => {
+        itemProgressSettled = true;
+      });
+
+      await deliveryStarted;
+
+      expect(delivered).toEqual([{ text: "before item" }]);
+      expect(onItemEvent).not.toHaveBeenCalled();
+      expect(itemProgressSettled).toBe(false);
+
+      releaseDelivery?.();
+      await itemProgressPromise;
+      return undefined;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: { onItemEvent },
+    });
+
+    expect(itemProgressSettled).toBe(true);
+    expect(onItemEvent).toHaveBeenCalledWith({
+      itemId: "1",
+      kind: "tool",
+      progressText: "running",
+    });
   });
 
   it("forwards payload metadata into onBlockReplyQueued context", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -61,6 +61,7 @@ import {
   markDiagnosticSessionProgress,
 } from "../../logging/diagnostic.js";
 import { createDiagnosticMessageLifecycle } from "../../logging/message-lifecycle.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { matchPluginCommand } from "../../plugins/commands.js";
 import {
   buildPluginBindingDeclinedText,
@@ -131,6 +132,7 @@ import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { waitForReplyDispatcherIdle } from "./reply-dispatcher.js";
 import type { ReplyDispatcher } from "./reply-dispatcher.types.js";
 import { replyRunRegistry, type ReplyOperation } from "./reply-run-registry.js";
+import { isReplyProfilerEnabled } from "./reply-timing-tracker.js";
 import { admitReplyTurn, resolveReplyTurnKind } from "./reply-turn-admission.js";
 import { resolveRoutedDeliveryThreadId } from "./routed-delivery-thread.js";
 import { resolveReplyRoutingDecision } from "./routing-policy.js";
@@ -783,6 +785,102 @@ function createAbortAwareDispatcher(params: {
   return dispatcher;
 }
 
+type ReplyHotPathTimingSpan = {
+  name: string;
+  durationMs: number;
+  elapsedMs: number;
+};
+
+type ReplyHotPathTimingSummary = {
+  totalMs: number;
+  spans: ReplyHotPathTimingSpan[];
+};
+
+const replyHotPathTimingLog = createSubsystemLogger("auto-reply/reply-timing");
+const REPLY_HOT_PATH_TIMING_WARN_TOTAL_MS = 1_000;
+const REPLY_HOT_PATH_TIMING_WARN_STAGE_MS = 500;
+
+function createReplyHotPathTimingTracker(options: { profilerEnabled?: boolean } = {}): {
+  measure: <T>(name: string, run: () => Promise<T> | T) => Promise<T>;
+  logIfSlow: (params: {
+    channel: string;
+    messageId?: number | string;
+    sessionKey?: string;
+    outcome: "completed" | "skipped" | "error";
+    reason?: string;
+  }) => void;
+} {
+  if (!options.profilerEnabled) {
+    // This slow-path splitter was added for latency investigation. Keep it
+    // inert in normal production dispatches so only explicit profiler runs pay
+    // the Date.now/span allocation cost.
+    return {
+      async measure(_name, run) {
+        return await run();
+      },
+      logIfSlow() {},
+    };
+  }
+
+  const startedAt = Date.now();
+  let didLog = false;
+  const spans: ReplyHotPathTimingSpan[] = [];
+  const toMs = (value: number) => Math.max(0, Math.round(value));
+  const snapshot = (): ReplyHotPathTimingSummary => ({
+    totalMs: toMs(Date.now() - startedAt),
+    spans: spans.slice(),
+  });
+  const shouldLog = (summary: ReplyHotPathTimingSummary) =>
+    summary.totalMs >= REPLY_HOT_PATH_TIMING_WARN_TOTAL_MS ||
+    summary.spans.some((span) => span.durationMs >= REPLY_HOT_PATH_TIMING_WARN_STAGE_MS);
+  const formatSpans = (summary: ReplyHotPathTimingSummary) =>
+    summary.spans.length > 0
+      ? summary.spans
+          .map((span) => `${span.name}:${span.durationMs}ms@${span.elapsedMs}ms`)
+          .join(",")
+      : "none";
+  return {
+    async measure(name, run) {
+      const spanStartedAt = Date.now();
+      try {
+        return await run();
+      } finally {
+        spans.push({
+          name,
+          durationMs: toMs(Date.now() - spanStartedAt),
+          elapsedMs: toMs(Date.now() - startedAt),
+        });
+      }
+    },
+    logIfSlow(params) {
+      if (didLog) {
+        return;
+      }
+      const summary = snapshot();
+      if (!shouldLog(summary)) {
+        return;
+      }
+      didLog = true;
+      replyHotPathTimingLog.warn(
+        `reply hot path timings channel=${params.channel} messageId=${
+          params.messageId ?? "unknown"
+        } sessionKey=${params.sessionKey ?? "unknown"} outcome=${params.outcome} totalMs=${
+          summary.totalMs
+        } stages=${formatSpans(summary)}${params.reason ? ` reason=${params.reason}` : ""}`,
+        {
+          channel: params.channel,
+          messageId: params.messageId,
+          sessionKey: params.sessionKey,
+          outcome: params.outcome,
+          reason: params.reason,
+          totalMs: summary.totalMs,
+          spans: summary.spans,
+        },
+      );
+    },
+  };
+}
+
 export type {
   DispatchFromConfigParams,
   DispatchFromConfigResult,
@@ -822,12 +920,17 @@ export async function dispatchReplyFromConfig(
     hasSessionKey: Boolean(sessionKey),
     hasRunId: typeof params.replyOptions?.runId === "string",
   };
+  const replyHotPathTiming = createReplyHotPathTimingTracker({
+    profilerEnabled: isReplyProfilerEnabled({ config: cfg }),
+  });
   const traceReplyPhase = <T>(name: string, run: () => Promise<T> | T): Promise<T> =>
-    measureDiagnosticsTimelineSpan(name, run, {
-      phase: "agent-turn",
-      config: cfg,
-      attributes: traceAttributes,
-    });
+    replyHotPathTiming.measure(name, () =>
+      measureDiagnosticsTimelineSpan(name, run, {
+        phase: "agent-turn",
+        config: cfg,
+        attributes: traceAttributes,
+      }),
+    );
   let agentDispatchStartedAt = 0;
 
   const recordProcessed = (
@@ -837,6 +940,15 @@ export async function dispatchReplyFromConfig(
       error?: string;
     },
   ) => {
+    if (diagnosticsEnabled) {
+      replyHotPathTiming.logIfSlow({
+        channel,
+        messageId,
+        sessionKey,
+        outcome,
+        reason: opts?.reason,
+      });
+    }
     messageLifecycle.markProcessed(outcome, opts);
   };
 
@@ -1432,6 +1544,16 @@ export async function dispatchReplyFromConfig(
       counts: dispatcher.getQueuedCounts(),
     });
   };
+  const finishReplyOperationAbortedDispatch = (): DispatchFromConfigResult => {
+    commitInboundDedupeIfClaimed();
+    recordProcessed("completed", { reason: "reply_operation_aborted" });
+    markIdle("message_completed");
+    completeDispatchReplyOperation();
+    return attachSourceReplyDeliveryMode({
+      queuedFinal: false,
+      counts: dispatcher.getQueuedCounts(),
+    });
+  };
 
   let pluginFallbackReason:
     | "plugin-bound-fallback-missing-plugin"
@@ -1439,6 +1561,9 @@ export async function dispatchReplyFromConfig(
     | undefined;
 
   if (pluginOwnedBinding) {
+    if (isPreDispatchOperationAborted()) {
+      return finishReplyOperationAbortedDispatch();
+    }
     touchConversationBindingRecord(pluginOwnedBinding.bindingId);
     if (shouldBypassPluginOwnedBindingForCommand(ctx)) {
       logVerbose(
@@ -2012,6 +2137,17 @@ export async function dispatchReplyFromConfig(
     const onPatchSummaryFromReplyOptions = params.replyOptions?.onPatchSummary;
     const allowSuppressedSourceProgressCallbacks =
       params.replyOptions?.allowProgressCallbacksWhenSourceDeliverySuppressed === true;
+    let hasPendingDirectBlockReplyDelivery = false;
+    const waitForPendingDirectBlockReplyDelivery = async (abortSignal?: AbortSignal) => {
+      if (!hasPendingDirectBlockReplyDelivery) {
+        return;
+      }
+      // Direct block replies are queued asynchronously so lightweight replies do
+      // not wait for dispatcher idle. Flush only before later tool/progress
+      // callbacks and final completion where external ordering is visible.
+      hasPendingDirectBlockReplyDelivery = false;
+      await waitForReplyDispatcherIdle(dispatcher, abortSignal);
+    };
     const shouldForwardProgressCallback = (options?: {
       forwardWhenSourceDeliverySuppressed?: boolean;
       requiresToolSummaryVisibility?: boolean;
@@ -2031,9 +2167,10 @@ export async function dispatchReplyFromConfig(
         forwardWhenSourceDeliverySuppressed?: boolean;
         requiresToolSummaryVisibility?: boolean;
         onForward?: (...args: Args) => void;
+        waitForDirectBlockReplyDelivery?: boolean;
       },
     ): ((...args: Args) => Promise<void>) | undefined => {
-      if (!callback && (!suppressAutomaticSourceDelivery || !canTrackSession)) {
+      if (!callback) {
         return undefined;
       }
       return async (...args: Args) => {
@@ -2041,6 +2178,12 @@ export async function dispatchReplyFromConfig(
           return;
         }
         markProgress();
+        if (options?.waitForDirectBlockReplyDelivery) {
+          await waitForPendingDirectBlockReplyDelivery(dispatchAbortOperation?.abortSignal);
+          if (isDispatchOperationAborted()) {
+            return;
+          }
+        }
         if (shouldForwardProgressCallback(options)) {
           options?.onForward?.(...args);
           await callback?.(...args);
@@ -2077,10 +2220,12 @@ export async function dispatchReplyFromConfig(
             onToolStart: wrapProgressCallback(params.replyOptions?.onToolStart, {
               forwardWhenSourceDeliverySuppressed: true,
               requiresToolSummaryVisibility: true,
+              waitForDirectBlockReplyDelivery: true,
             }),
             onItemEvent: wrapProgressCallback(params.replyOptions?.onItemEvent, {
               forwardWhenSourceDeliverySuppressed: true,
               requiresToolSummaryVisibility: true,
+              waitForDirectBlockReplyDelivery: true,
               onForward: (payload) => {
                 if (hasFailedProgressStatus(payload)) {
                   markVisibleToolErrorProgress();
@@ -2090,6 +2235,7 @@ export async function dispatchReplyFromConfig(
             onCommandOutput: wrapProgressCallback(params.replyOptions?.onCommandOutput, {
               forwardWhenSourceDeliverySuppressed: true,
               requiresToolSummaryVisibility: true,
+              waitForDirectBlockReplyDelivery: true,
               onForward: (payload) => {
                 if (hasFailedProgressStatus(payload)) {
                   markVisibleToolErrorProgress();
@@ -2099,14 +2245,20 @@ export async function dispatchReplyFromConfig(
             onCompactionStart: wrapProgressCallback(params.replyOptions?.onCompactionStart, {
               forwardWhenSourceDeliverySuppressed: true,
               requiresToolSummaryVisibility: true,
+              waitForDirectBlockReplyDelivery: true,
             }),
             onCompactionEnd: wrapProgressCallback(params.replyOptions?.onCompactionEnd, {
               forwardWhenSourceDeliverySuppressed: true,
               requiresToolSummaryVisibility: true,
+              waitForDirectBlockReplyDelivery: true,
             }),
             onToolResult: (payload: ReplyPayload) => {
               markProgress();
               const run = async () => {
+                if (isDispatchOperationAborted()) {
+                  return;
+                }
+                await waitForPendingDirectBlockReplyDelivery(dispatchAbortOperation?.abortSignal);
                 if (isDispatchOperationAborted()) {
                   return;
                 }
@@ -2171,6 +2323,10 @@ export async function dispatchReplyFromConfig(
                 return;
               }
               markProgress();
+              await waitForPendingDirectBlockReplyDelivery(dispatchAbortOperation?.abortSignal);
+              if (isDispatchOperationAborted()) {
+                return;
+              }
               markInboundDedupeReplayUnsafe();
               if (
                 shouldForwardProgressCallback({
@@ -2193,6 +2349,10 @@ export async function dispatchReplyFromConfig(
                 return;
               }
               markProgress();
+              await waitForPendingDirectBlockReplyDelivery(dispatchAbortOperation?.abortSignal);
+              if (isDispatchOperationAborted()) {
+                return;
+              }
               markInboundDedupeReplayUnsafe();
               if (
                 shouldForwardProgressCallback({
@@ -2223,6 +2383,10 @@ export async function dispatchReplyFromConfig(
                 return;
               }
               markProgress();
+              await waitForPendingDirectBlockReplyDelivery(dispatchAbortOperation?.abortSignal);
+              if (isDispatchOperationAborted()) {
+                return;
+              }
               markInboundDedupeReplayUnsafe();
               if (
                 shouldForwardProgressCallback({
@@ -2329,7 +2493,7 @@ export async function dispatchReplyFromConfig(
                   markInboundDedupeReplayUnsafe();
                   const delivered = dispatcher.sendBlockReply(normalizedPayload);
                   if (delivered) {
-                    await waitForReplyDispatcherIdle(dispatcher, context?.abortSignal);
+                    hasPendingDirectBlockReplyDelivery = true;
                   }
                 }
               };
@@ -2461,6 +2625,7 @@ export async function dispatchReplyFromConfig(
         accumulatedBlockTtsText.trim()
       ) {
         try {
+          await waitForPendingDirectBlockReplyDelivery(getDispatchAbortSignal());
           throwIfDispatchOperationAborted();
           const ttsSyntheticReply = await maybeApplyTtsToReplyPayload({
             payload: { text: accumulatedBlockTtsText },
@@ -2520,6 +2685,7 @@ export async function dispatchReplyFromConfig(
       }
     }
 
+    await waitForPendingDirectBlockReplyDelivery(getDispatchAbortSignal());
     const counts = dispatcher.getQueuedCounts();
     counts.final += routedFinalCount;
     commitInboundDedupeIfClaimed();
@@ -2537,14 +2703,7 @@ export async function dispatchReplyFromConfig(
     });
   } catch (err) {
     if (isDispatchReplyOperationAbortedError(err)) {
-      commitInboundDedupeIfClaimed();
-      recordProcessed("completed", { reason: "reply_operation_aborted" });
-      markIdle("message_completed");
-      completeDispatchReplyOperation();
-      return attachSourceReplyDeliveryMode({
-        queuedFinal: false,
-        counts: dispatcher.getQueuedCounts(),
-      });
+      return finishReplyOperationAbortedDispatch();
     }
     if (inboundDedupeClaim.status === "claimed") {
       if (inboundDedupeReplayUnsafe) {

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -338,6 +338,39 @@ describe("runPreparedReply media-only handling", () => {
     expect(call?.followupRun.run.allowEmptyAssistantReplyAsSilent).toBe(true);
   });
 
+  it("hydrates runtime thinking metadata before trusting static provider support", async () => {
+    const resolveThinkingCatalog = vi.fn(async () => [
+      {
+        provider: "openai",
+        id: "chat-latest",
+        reasoning: false,
+      },
+    ]);
+
+    await runPreparedReply(
+      baseParams({
+        provider: "openai",
+        model: "chat-latest",
+        resolvedThinkLevel: "high",
+        modelState: {
+          resolveDefaultThinkingLevel: async () => "high",
+          resolveThinkingCatalog,
+          allowedModelCatalog: [
+            {
+              provider: "openai",
+              id: "chat-latest",
+              name: "Chat Latest",
+            },
+          ],
+        } as never,
+      }),
+    );
+
+    expect(resolveThinkingCatalog).toHaveBeenCalledOnce();
+    const call = requireRunReplyAgentCall();
+    expect(call.followupRun.run.thinkLevel).toBe("off");
+  });
+
   it("keeps empty-assistant silence disabled for direct runs by default", async () => {
     await runPreparedReply(
       baseParams({

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -11,6 +11,7 @@ import { resolveAgentHarnessPolicy } from "../../agents/harness/selection.js";
 import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../../agents/openai-codex-routing.js";
 import { resolveEmbeddedFullAccessState } from "../../agents/pi-embedded-runner/sandbox-info.js";
 import type { EmbeddedFullAccessBlockedReason } from "../../agents/pi-embedded-runner/types.js";
+import { normalizeProviderId } from "../../agents/provider-id.js";
 import { resolveIngressWorkspaceOverrideForSpawnedRun } from "../../agents/spawned-context.js";
 import type { SilentReplyPromptMode } from "../../agents/system-prompt.types.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
@@ -25,6 +26,7 @@ import { resolveSilentReplySettings } from "../../config/silent-reply.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { clearCommandLane, getQueueSize } from "../../process/command-queue.js";
 import {
   isAcpSessionKey,
@@ -46,6 +48,7 @@ import {
   normalizeThinkLevel,
   type ReasoningLevel,
   resolveSupportedThinkingLevel,
+  type ThinkingCatalogEntry,
   type ThinkLevel,
   type VerboseLevel,
 } from "../thinking.js";
@@ -83,6 +86,7 @@ import {
   waitForReplyRunEndBySessionId,
   type ReplyOperation,
 } from "./reply-run-registry.js";
+import { createReplyTimingTracker } from "./reply-timing-tracker.js";
 import { resolveRoutedDeliveryThreadId } from "./routed-delivery-thread.js";
 import { resolveRuntimePolicySessionKey } from "./runtime-policy-session-key.js";
 import { resolveBareSessionResetPromptState } from "./session-reset-prompt.js";
@@ -109,6 +113,25 @@ type InternalGetReplyOptions = GetReplyOptions & {
 
 type AgentDefaults = NonNullable<OpenClawConfig["agents"]>["defaults"];
 type ExecOverrides = Pick<ExecToolDefaults, "host" | "security" | "ask" | "node">;
+
+const preparedReplyTimingLog = createSubsystemLogger("auto-reply/pre-agent-timing");
+
+function hasResolvedThinkingCatalogEntry(params: {
+  catalog?: readonly ThinkingCatalogEntry[];
+  provider: string;
+  model: string;
+}): boolean {
+  const modelId = normalizeOptionalString(params.model);
+  if (!modelId) {
+    return false;
+  }
+  const normalizedProvider = normalizeProviderId(params.provider);
+  const entry = params.catalog?.find(
+    (candidate) =>
+      normalizeProviderId(candidate.provider) === normalizedProvider && candidate.id === modelId,
+  );
+  return entry?.reasoning !== undefined;
+}
 
 export function resolvePromptSilentReplyConversationType(params: {
   ctx: Pick<
@@ -446,12 +469,33 @@ export async function runPreparedReply(
     isHeartbeat,
     queueMode: perMessageQueueMode ?? "configured",
   };
-  const traceRunPhase = <T>(name: string, run: () => Promise<T> | T): Promise<T> =>
-    measureDiagnosticsTimelineSpan(name, run, {
-      phase: "agent-turn",
-      config: cfg,
-      attributes: traceAttributes,
+  // Keep the expensive pre-agent profiler disabled in normal production turns;
+  // when enabled it isolates catalog/auth/skill startup without changing the
+  // reply execution path.
+  const preparedTiming = createReplyTimingTracker({ log: preparedReplyTimingLog, config: cfg });
+  const logPreparedTiming = (reason: string) =>
+    preparedTiming.logIfSlow({
+      message: `prepared reply pre-agent timings provider=${provider} model=${model} sessionId=${
+        sessionId ?? "unknown"
+      } sessionKey=${sessionKey ?? "unknown"} agentId=${agentId}`,
+      outcome: "milestone",
+      reason,
+      details: {
+        provider,
+        model,
+        sessionId,
+        sessionKey,
+        agentId,
+      },
     });
+  const traceRunPhase = <T>(name: string, run: () => Promise<T> | T): Promise<T> =>
+    preparedTiming.measure(name, () =>
+      measureDiagnosticsTimelineSpan(name, run, {
+        phase: "agent-turn",
+        config: cfg,
+        attributes: traceAttributes,
+      }),
+    );
   const promptSessionCtx = resolvePromptSessionContextForSystemEvent({
     sessionCtx,
     sessionEntry,
@@ -708,7 +752,11 @@ export async function runPreparedReply(
   if (!resolvedThinkLevel && prefixedBodyBase) {
     const parts = prefixedBodyBase.split(/\s+/);
     const maybeLevel = normalizeThinkLevel(parts[0]);
-    const thinkingCatalog = maybeLevel ? await modelState.resolveThinkingCatalog() : undefined;
+    const thinkingCatalog = maybeLevel
+      ? await traceRunPhase("reply.resolve_thinking_catalog_for_hint", () =>
+          modelState.resolveThinkingCatalog(),
+        )
+      : undefined;
     if (
       maybeLevel &&
       isThinkingLevelSupported({ provider, model, level: maybeLevel, catalog: thinkingCatalog })
@@ -789,17 +837,38 @@ export async function runPreparedReply(
     await traceRunPhase("reply.build_prompt_bodies", () => rebuildPromptBodies());
   const isRoomEvent = inboundEventKind === "room_event";
   if (!resolvedThinkLevel) {
-    resolvedThinkLevel = await modelState.resolveDefaultThinkingLevel();
+    resolvedThinkLevel = await traceRunPhase("reply.resolve_default_thinking", () =>
+      modelState.resolveDefaultThinkingLevel(),
+    );
   }
-  const thinkingCatalog = await modelState.resolveThinkingCatalog();
-  if (
-    !isThinkingLevelSupported({
+  const allowedThinkingCatalog = modelState.allowedModelCatalog ?? [];
+  let thinkingCatalog = allowedThinkingCatalog.length > 0 ? allowedThinkingCatalog : undefined;
+  let thinkingLevelSupported = isThinkingLevelSupported({
+    provider,
+    model,
+    level: resolvedThinkLevel,
+    catalog: thinkingCatalog,
+  });
+  const shouldHydrateThinkingCatalog =
+    !thinkingLevelSupported ||
+    (resolvedThinkLevel !== "off" &&
+      !hasResolvedThinkingCatalogEntry({ catalog: thinkingCatalog, provider, model }));
+  if (shouldHydrateThinkingCatalog) {
+    // Hydrate the runtime model catalog only when the lightweight catalog cannot
+    // prove support or lacks reasoning metadata for the selected model. The full
+    // catalog load was a 14s+ reply-blocking cost for known Codex models that
+    // already publish authoritative thinking metadata.
+    thinkingCatalog = await traceRunPhase("reply.resolve_thinking_catalog", () =>
+      modelState.resolveThinkingCatalog(),
+    );
+    thinkingLevelSupported = isThinkingLevelSupported({
       provider,
       model,
       level: resolvedThinkLevel,
       catalog: thinkingCatalog,
-    })
-  ) {
+    });
+  }
+  if (!thinkingLevelSupported) {
     const explicitThink = directives.hasThinkDirective && directives.thinkLevel !== undefined;
     if (explicitThink) {
       typing.cleanup();
@@ -1196,6 +1265,7 @@ export async function runPreparedReply(
         }
       : undefined;
 
+  logPreparedTiming("before_run_agent");
   return runReplyAgent({
     commandBody: prefixedCommandBody,
     transcriptCommandBody,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -15,6 +15,7 @@ import { type OpenClawConfig, getRuntimeConfig } from "../../config/config.js";
 import { logVerbose } from "../../globals.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { buildAgentHookContextChannelFields } from "../../plugins/hook-agent-context.js";
 import { defaultRuntime } from "../../runtime.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
@@ -47,6 +48,7 @@ import { hasInboundMedia } from "./inbound-media.js";
 import { emitPreAgentMessageHooks } from "./message-preprocess-hooks.js";
 import { createFastTestModelSelectionState, createModelSelectionState } from "./model-selection.js";
 import { sanitizePendingFinalDeliveryText } from "./pending-final-delivery.js";
+import { createReplyTimingTracker } from "./reply-timing-tracker.js";
 import { initSessionState } from "./session.js";
 import {
   isStaleHeartbeatAutoFallbackOverride,
@@ -89,6 +91,8 @@ const mediaUnderstandingApplyRuntimeLoader = createLazyImportLoader(
 const linkUnderstandingApplyRuntimeLoader = createLazyImportLoader(
   () => import("../../link-understanding/apply.runtime.js"),
 );
+
+const replyResolverTimingLog = createSubsystemLogger("auto-reply/reply-resolver-timing");
 const commandsCoreRuntimeLoader = createLazyImportLoader(
   () => import("./commands-core.runtime.js"),
 );
@@ -214,45 +218,85 @@ export async function getReplyFromConfig(
     isFastTestEnv,
     configOverride,
   });
-  const useFastTestBootstrap = shouldUseReplyFastTestBootstrap({
-    isFastTestEnv,
-    configOverride,
-  });
-  const useFastTestRuntime = shouldUseReplyFastTestRuntime({
-    cfg,
-    isFastTestEnv,
-  });
-  const finalized = finalizeInboundContext(ctx);
-  const targetSessionKey = resolveCommandTurnTargetSessionKey(finalized);
-  const agentSessionKey = targetSessionKey || finalized.SessionKey;
-  const traceAttributes = {
+  // Profiler spans stay inert unless diagnostics enable `profiler` or
+  // `reply.profiler`, so normal replies do not pay per-stage Date.now/array
+  // bookkeeping while we can still split resolver costs on demand.
+  const resolverTiming = createReplyTimingTracker({ log: replyResolverTimingLog, config: cfg });
+  const useFastTestBootstrap = resolverTiming.measureSync("reply.resolve_fast_test_bootstrap", () =>
+    shouldUseReplyFastTestBootstrap({
+      isFastTestEnv,
+      configOverride,
+    }),
+  );
+  const useFastTestRuntime = resolverTiming.measureSync("reply.resolve_fast_test_runtime", () =>
+    shouldUseReplyFastTestRuntime({
+      cfg,
+      isFastTestEnv,
+    }),
+  );
+  const finalized = resolverTiming.measureSync("reply.finalize_context", () =>
+    finalizeInboundContext(ctx),
+  );
+  const { agentSessionKey, agentId } = resolverTiming.measureSync(
+    "reply.resolve_agent_scope",
+    () => {
+      const targetSessionKey = resolveCommandTurnTargetSessionKey(finalized);
+      const resolvedAgentSessionKey = targetSessionKey || finalized.SessionKey;
+      return {
+        agentSessionKey: resolvedAgentSessionKey,
+        agentId: resolveSessionAgentId({
+          sessionKey: resolvedAgentSessionKey,
+          config: cfg,
+        }),
+      };
+    },
+  );
+  const traceAttributes = resolverTiming.measureSync("reply.resolve_trace_context", () => ({
     surface: normalizeOptionalString(finalized.Surface ?? finalized.Provider) ?? "unknown",
     hasSessionKey: Boolean(agentSessionKey),
     isHeartbeat: opts?.isHeartbeat === true,
     hasMedia: hasInboundMedia(finalized),
-  };
-  const traceGetReplyPhase = <T>(name: string, run: () => Promise<T> | T): Promise<T> =>
-    measureDiagnosticsTimelineSpan(name, run, {
-      phase: "agent-turn",
-      config: cfg,
-      attributes: traceAttributes,
+  }));
+  const messageId = finalized.MessageSid ?? finalized.MessageSidFirst ?? finalized.MessageSidLast;
+  let resolverTimingSessionKey = agentSessionKey;
+  const logResolverTiming = (outcome: string, reason?: string, error?: string) =>
+    resolverTiming.logIfSlow({
+      message: `reply resolver timings surface=${traceAttributes.surface} messageId=${
+        messageId ?? "unknown"
+      } sessionKey=${resolverTimingSessionKey ?? "unknown"} agentId=${agentId}`,
+      outcome,
+      reason,
+      error,
+      details: {
+        surface: traceAttributes.surface,
+        messageId,
+        sessionKey: resolverTimingSessionKey,
+        agentId,
+      },
     });
-  const agentId = resolveSessionAgentId({
-    sessionKey: agentSessionKey,
-    config: cfg,
-  });
-  const mergedSkillFilter = mergeSkillFilters(
-    opts?.skillFilter,
-    resolveAgentSkillsFilter(cfg, agentId),
+  const traceGetReplyPhase = <T>(name: string, run: () => Promise<T> | T): Promise<T> =>
+    resolverTiming.measure(name, () =>
+      measureDiagnosticsTimelineSpan(name, run, {
+        phase: "agent-turn",
+        config: cfg,
+        attributes: traceAttributes,
+      }),
+    );
+  const mergedSkillFilter = resolverTiming.measureSync("reply.resolve_skill_filter", () =>
+    mergeSkillFilters(opts?.skillFilter, resolveAgentSkillsFilter(cfg, agentId)),
   );
   const resolvedOpts =
     mergedSkillFilter !== undefined ? { ...opts, skillFilter: mergedSkillFilter } : opts;
   const agentCfg = cfg.agents?.defaults;
   const sessionCfg = cfg.session;
-  const { defaultProvider, defaultModel, aliasIndex } = resolveDefaultModel({
-    cfg,
-    agentId,
-  });
+  const { defaultProvider, defaultModel, aliasIndex } = resolverTiming.measureSync(
+    "reply.resolve_default_model",
+    () =>
+      resolveDefaultModel({
+        cfg,
+        agentId,
+      }),
+  );
   let provider = defaultProvider;
   let model = defaultModel;
   let hasResolvedHeartbeatModelOverride = false;
@@ -277,22 +321,34 @@ export async function getReplyFromConfig(
     }
   }
 
-  const workspaceDirRaw = resolveAgentWorkspaceDir(cfg, agentId) ?? DEFAULT_AGENT_WORKSPACE_DIR;
-  const workspaceDirForNativeCommand = workspaceDirRaw;
-  const agentDir = resolveAgentDir(cfg, agentId);
-  const timeoutMs = resolveAgentTimeoutMs({ cfg, overrideSeconds: opts?.timeoutOverrideSeconds });
-  const configuredTypingSeconds =
-    agentCfg?.typingIntervalSeconds ?? sessionCfg?.typingIntervalSeconds;
-  const typingIntervalSeconds =
-    typeof configuredTypingSeconds === "number" ? configuredTypingSeconds : 6;
-  const typing = createTypingController({
-    onReplyStart: opts?.onReplyStart,
-    onCleanup: opts?.onTypingCleanup,
-    typingIntervalSeconds,
-    silentToken: SILENT_REPLY_TOKEN,
-    log: defaultRuntime.log,
+  const { workspaceDirRaw, workspaceDirForNativeCommand, agentDir, timeoutMs } =
+    resolverTiming.measureSync("reply.resolve_workspace_agent_dir", () => {
+      const workspaceDirRaw = resolveAgentWorkspaceDir(cfg, agentId) ?? DEFAULT_AGENT_WORKSPACE_DIR;
+      return {
+        workspaceDirRaw,
+        workspaceDirForNativeCommand: workspaceDirRaw,
+        agentDir: resolveAgentDir(cfg, agentId),
+        timeoutMs: resolveAgentTimeoutMs({
+          cfg,
+          overrideSeconds: opts?.timeoutOverrideSeconds,
+        }),
+      };
+    });
+  const typing = resolverTiming.measureSync("reply.create_typing_controller", () => {
+    const configuredTypingSeconds =
+      agentCfg?.typingIntervalSeconds ?? sessionCfg?.typingIntervalSeconds;
+    const typingIntervalSeconds =
+      typeof configuredTypingSeconds === "number" ? configuredTypingSeconds : 6;
+    const controller = createTypingController({
+      onReplyStart: opts?.onReplyStart,
+      onCleanup: opts?.onTypingCleanup,
+      typingIntervalSeconds,
+      silentToken: SILENT_REPLY_TOKEN,
+      log: defaultRuntime.log,
+    });
+    opts?.onTypingController?.(controller);
+    return controller;
   });
-  opts?.onTypingController?.(typing);
 
   const nativeSlashCommandFastReply = await traceGetReplyPhase(
     "reply.native_slash_command_fast_path",
@@ -316,6 +372,7 @@ export async function getReplyFromConfig(
       }),
   );
   if (nativeSlashCommandFastReply.handled) {
+    logResolverTiming("completed", "native_slash_command_fast_path");
     return nativeSlashCommandFastReply.reply;
   }
 
@@ -390,6 +447,7 @@ export async function getReplyFromConfig(
     triggerBodyNormalized,
     bodyStripped,
   } = sessionState;
+  resolverTimingSessionKey = sessionKey ?? resolverTimingSessionKey;
 
   if (sessionEntry?.pendingFinalDelivery && sessionEntry.pendingFinalDeliveryText) {
     const text = sanitizePendingFinalDeliveryText(sessionEntry.pendingFinalDeliveryText);
@@ -455,6 +513,7 @@ export async function getReplyFromConfig(
             }),
           });
         }
+        logResolverTiming("completed", "pending_final_delivery_replay");
         return { text: replayText };
       }
     }
@@ -579,7 +638,8 @@ export async function getReplyFromConfig(
       triggerBodyNormalized,
       commandAuthorized,
     });
-    return await traceGetReplyPhase("reply.run_prepared_reply", () =>
+    logResolverTiming("milestone", "before_fast_directive_prepared_reply");
+    const fastReplyResult = await traceGetReplyPhase("reply.run_prepared_reply", () =>
       runPreparedReply({
         ctx,
         sessionCtx,
@@ -636,6 +696,8 @@ export async function getReplyFromConfig(
         autoFallbackPrimaryProbe,
       }),
     );
+    logResolverTiming("completed", "fast_directive_prepared_reply");
+    return fastReplyResult;
   }
 
   const directiveResult = await traceGetReplyPhase("reply.resolve_directives", () =>
@@ -671,6 +733,7 @@ export async function getReplyFromConfig(
     }),
   );
   if (directiveResult.kind === "reply") {
+    logResolverTiming("completed", "directive_reply");
     return directiveResult.reply;
   }
 
@@ -771,6 +834,7 @@ export async function getReplyFromConfig(
   );
   if (inlineActionResult.kind === "reply") {
     await maybeEmitMissingResetHooks();
+    logResolverTiming("completed", "inline_action_reply");
     return inlineActionResult.reply;
   }
   await maybeEmitMissingResetHooks();
@@ -862,6 +926,7 @@ export async function getReplyFromConfig(
         ),
       );
       if (hookResult?.handled) {
+        logResolverTiming("completed", "before_agent_reply_hook");
         return hookResult.reply ?? { text: SILENT_REPLY_TOKEN };
       }
     }
@@ -884,7 +949,8 @@ export async function getReplyFromConfig(
     );
   }
 
-  return await traceGetReplyPhase("reply.run_prepared_reply", () =>
+  logResolverTiming("milestone", "before_run_prepared_reply");
+  const replyResult = await traceGetReplyPhase("reply.run_prepared_reply", () =>
     runPreparedReply({
       ctx,
       sessionCtx,
@@ -931,4 +997,6 @@ export async function getReplyFromConfig(
       autoFallbackPrimaryProbe: runAutoFallbackPrimaryProbe,
     }),
   );
+  logResolverTiming("completed", "prepared_reply");
+  return replyResult;
 }

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MODEL_CONTEXT_TOKEN_CACHE } from "../../agents/context-cache.js";
-import { loadModelCatalog } from "../../agents/model-catalog.runtime.js";
+import { loadManifestModelCatalog, loadModelCatalog } from "../../agents/model-catalog.runtime.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { createModelSelectionState, resolveContextTokens } from "./model-selection.js";
 
 vi.mock("../../agents/model-catalog.runtime.js", () => ({
+  loadManifestModelCatalog: vi.fn(() => []),
   loadModelCatalog: vi.fn(async () => [
     { provider: "anthropic", id: "claude-opus-4-6", name: "Claude Opus 4.5" },
     { provider: "inferencer", id: "deepseek-v3-4bit-mlx", name: "DeepSeek V3" },
@@ -53,6 +54,8 @@ vi.mock("../../agents/auth-profiles.runtime.js", () => ({
 
 afterEach(() => {
   MODEL_CONTEXT_TOKEN_CACHE.clear();
+  vi.mocked(loadManifestModelCatalog).mockReturnValue([]);
+  vi.mocked(loadManifestModelCatalog).mockClear();
   authProfileStoreMock.reset();
 });
 
@@ -174,6 +177,42 @@ describe("createModelSelectionState catalog loading", () => {
 
     await expect(state.resolveDefaultThinkingLevel()).resolves.toBe("medium");
     expect(loadModelCatalog).toHaveBeenCalledOnce();
+  });
+
+  it("uses manifest metadata before hydrating the runtime thinking catalog", async () => {
+    vi.mocked(loadModelCatalog).mockClear();
+    vi.mocked(loadManifestModelCatalog).mockClear();
+    vi.mocked(loadManifestModelCatalog).mockReturnValueOnce([
+      { provider: "openai", id: "gpt-5.5", name: "GPT-5.5", reasoning: true },
+    ]);
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-5.5": {},
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: cfg.agents?.defaults,
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+      provider: "openai",
+      model: "gpt-5.5",
+      hasModelDirective: false,
+    });
+
+    await expect(state.resolveThinkingCatalog()).resolves.toEqual([
+      expect.objectContaining({ provider: "openai", id: "gpt-5.5", reasoning: true }),
+    ]);
+    expect(loadManifestModelCatalog).toHaveBeenCalledWith({
+      config: cfg,
+      fallbackToMetadataScan: false,
+    });
+    expect(loadModelCatalog).not.toHaveBeenCalled();
   });
 
   it("prefers per-agent thinkingDefault over model and global defaults", async () => {

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -78,6 +78,14 @@ const modelCatalogRuntimeLoader = createLazyImportLoader(
 const sessionStoreRuntimeLoader = createLazyImportLoader(
   () => import("../../config/sessions/store.runtime.js"),
 );
+const RUNTIME_MODEL_VISIBILITY_NORMALIZATION = {
+  allowManifestNormalization: true,
+  allowPluginNormalization: true,
+} as const;
+
+function normalizeRuntimeModelRef(provider: string, model: string) {
+  return normalizeModelRef(provider, model, RUNTIME_MODEL_VISIBILITY_NORMALIZATION);
+}
 
 function loadModelCatalogRuntime() {
   return modelCatalogRuntimeLoader.load();
@@ -85,6 +93,18 @@ function loadModelCatalogRuntime() {
 
 function loadSessionStoreRuntime() {
   return sessionStoreRuntimeLoader.load();
+}
+
+function findSelectedCatalogEntry(params: {
+  catalog?: readonly ModelCatalogEntry[];
+  provider: string;
+  model: string;
+}): ModelCatalogEntry | undefined {
+  const normalizedProvider = normalizeProviderId(params.provider);
+  return params.catalog?.find(
+    (entry) =>
+      normalizeProviderId(entry.provider) === normalizedProvider && entry.id === params.model,
+  );
 }
 
 export async function createModelSelectionState(params: {
@@ -157,6 +177,7 @@ export async function createModelSelectionState(params: {
     defaultProvider,
     defaultModel,
     agentId: params.agentId,
+    ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
   });
   let modelCatalog: ModelCatalog | null = null;
   let resetModelOverride = false;
@@ -190,6 +211,7 @@ export async function createModelSelectionState(params: {
       defaultProvider,
       defaultModel,
       agentId: params.agentId,
+      ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
     });
     allowedModelCatalog = visibilityPolicy.allowedCatalog;
     allowedModelKeys = visibilityPolicy.allowedKeys;
@@ -204,6 +226,7 @@ export async function createModelSelectionState(params: {
       defaultProvider,
       defaultModel,
       agentId: params.agentId,
+      ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
     });
     allowedModelCatalog = visibilityPolicy.allowedCatalog;
     allowedModelKeys = visibilityPolicy.allowedKeys;
@@ -216,7 +239,7 @@ export async function createModelSelectionState(params: {
   }
 
   if (sessionEntry && sessionStore && sessionKey && directStoredOverride) {
-    const normalizedOverride = normalizeModelRef(
+    const normalizedOverride = normalizeRuntimeModelRef(
       directStoredOverride.provider,
       directStoredOverride.model,
     );
@@ -244,13 +267,13 @@ export async function createModelSelectionState(params: {
     }
   }
   if (staleHeartbeatAutoFallbackOverride) {
-    const normalizedCurrentSelection = normalizeModelRef(provider, model);
+    const normalizedCurrentSelection = normalizeRuntimeModelRef(provider, model);
     const currentSelectionKey = modelKey(
       normalizedCurrentSelection.provider,
       normalizedCurrentSelection.model,
     );
     const normalizedDirectOverride = directStoredOverride
-      ? normalizeModelRef(directStoredOverride.provider, directStoredOverride.model)
+      ? normalizeRuntimeModelRef(directStoredOverride.provider, directStoredOverride.model)
       : null;
     const directStoredOverrideKey = normalizedDirectOverride
       ? modelKey(normalizedDirectOverride.provider, normalizedDirectOverride.model)
@@ -278,7 +301,7 @@ export async function createModelSelectionState(params: {
     (staleHeartbeatAutoFallbackOverride && storedOverride?.source === "session");
 
   if (storedOverride?.model && !skipStoredOverride) {
-    const normalizedStoredOverride = normalizeModelRef(
+    const normalizedStoredOverride = normalizeRuntimeModelRef(
       storedOverride.provider || defaultProvider,
       storedOverride.model,
     );
@@ -340,15 +363,45 @@ export async function createModelSelectionState(params: {
   }
 
   let thinkingCatalog: ModelCatalog | undefined;
+  let manifestModelCatalog: ModelCatalog | null = null;
+  const loadManifestCatalogForThinking = async () => {
+    if (manifestModelCatalog) {
+      return manifestModelCatalog;
+    }
+    const { loadManifestModelCatalog } = await loadModelCatalogRuntime();
+    manifestModelCatalog = loadManifestModelCatalog({
+      config: cfg,
+      fallbackToMetadataScan: false,
+    });
+    logStage("manifest-catalog-loaded-for-thinking", `entries=${manifestModelCatalog.length}`);
+    return manifestModelCatalog;
+  };
   const resolveThinkingCatalog = async () => {
     if (thinkingCatalog) {
       return thinkingCatalog;
     }
     let catalogForThinking =
       modelCatalog && modelCatalog.length > 0 ? modelCatalog : allowedModelCatalog;
-    const selectedCatalogEntry = catalogForThinking?.find(
-      (entry) => entry.provider === provider && entry.id === model,
-    );
+    let selectedCatalogEntry = findSelectedCatalogEntry({
+      catalog: catalogForThinking,
+      provider,
+      model,
+    });
+    // Prefer static manifest rows before cold runtime discovery. Synthetic
+    // allowlist rows know only provider/id; manifest rows can prove reasoning
+    // support without opening the Pi auth-backed model registry.
+    if (!modelCatalog && selectedCatalogEntry?.reasoning === undefined) {
+      const manifestCatalog = await loadManifestCatalogForThinking();
+      const manifestSelectedEntry = findSelectedCatalogEntry({
+        catalog: manifestCatalog,
+        provider,
+        model,
+      });
+      if (manifestSelectedEntry?.reasoning !== undefined) {
+        catalogForThinking = manifestCatalog;
+        selectedCatalogEntry = manifestSelectedEntry;
+      }
+    }
     const shouldHydrateRuntimeCatalog =
       !modelCatalog && (!selectedCatalogEntry || selectedCatalogEntry.reasoning === undefined);
     if (shouldHydrateRuntimeCatalog) {

--- a/src/auto-reply/reply/reply-timing-tracker.test.ts
+++ b/src/auto-reply/reply/reply-timing-tracker.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createReplyTimingTracker, isReplyProfilerEnabled } from "./reply-timing-tracker.js";
+
+describe("isReplyProfilerEnabled", () => {
+  it("matches global and reply profiler diagnostic flags", () => {
+    const cfg = { diagnostics: { flags: ["reply.profiler"] } } as OpenClawConfig;
+    expect(isReplyProfilerEnabled({ config: cfg, env: {} as NodeJS.ProcessEnv })).toBe(true);
+    expect(
+      isReplyProfilerEnabled({
+        env: { OPENCLAW_DIAGNOSTICS: "profiler" } as NodeJS.ProcessEnv,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("createReplyTimingTracker", () => {
+  it("is a pass-through tracker unless the profiler flag is enabled", async () => {
+    const warn = vi.fn();
+    const tracker = createReplyTimingTracker({ log: { warn } });
+
+    expect(tracker.measureSync("sync", () => 42)).toBe(42);
+    await expect(tracker.measure("async", async () => "ok")).resolves.toBe("ok");
+    tracker.logIfSlow({ message: "reply timings" });
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("records and logs spans when the profiler flag is enabled", () => {
+    const warn = vi.fn();
+    const tracker = createReplyTimingTracker({
+      log: { warn },
+      env: { OPENCLAW_DIAGNOSTICS: "reply.profiler" } as NodeJS.ProcessEnv,
+      totalWarnMs: 0,
+      stageWarnMs: 0,
+    });
+
+    expect(tracker.measureSync("sync", () => 7)).toBe(7);
+    tracker.logIfSlow({ message: "reply timings", outcome: "completed" });
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0]?.[0]).toContain("stages=sync:");
+    expect(warn.mock.calls[0]?.[1]).toMatchObject({
+      outcome: "completed",
+      spans: [expect.objectContaining({ name: "sync" })],
+    });
+  });
+});

--- a/src/auto-reply/reply/reply-timing-tracker.ts
+++ b/src/auto-reply/reply/reply-timing-tracker.ts
@@ -1,0 +1,141 @@
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { isDiagnosticFlagEnabled } from "../../infra/diagnostic-flags.js";
+
+type ReplyTimingSpan = {
+  name: string;
+  durationMs: number;
+  elapsedMs: number;
+};
+
+type ReplyTimingSummary = {
+  totalMs: number;
+  spans: ReplyTimingSpan[];
+};
+
+type ReplyTimingLogger = {
+  warn: (message: string, details?: Record<string, unknown>) => void;
+};
+
+type ReplyTimingTracker = {
+  measure: <T>(name: string, run: () => Promise<T> | T) => Promise<T>;
+  measureSync: <T>(name: string, run: () => T) => T;
+  logIfSlow: (params: {
+    message: string;
+    outcome?: string;
+    reason?: string;
+    error?: string;
+    details?: Record<string, unknown>;
+  }) => void;
+};
+
+const DEFAULT_TIMING_WARN_TOTAL_MS = 1_000;
+const DEFAULT_TIMING_WARN_STAGE_MS = 500;
+
+export function isReplyProfilerEnabled(params?: {
+  config?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): boolean {
+  const cfg = params?.config;
+  const env = params?.env ?? process.env;
+  return (
+    isDiagnosticFlagEnabled("profiler", cfg, env) ||
+    isDiagnosticFlagEnabled("reply.profiler", cfg, env)
+  );
+}
+
+export function createReplyTimingTracker(params: {
+  log: ReplyTimingLogger;
+  config?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  enabled?: boolean;
+  totalWarnMs?: number;
+  stageWarnMs?: number;
+}): ReplyTimingTracker {
+  const enabled =
+    params.enabled ?? isReplyProfilerEnabled({ config: params.config, env: params.env });
+  if (!enabled) {
+    // Normal production turns use pass-through wrappers so added profiling
+    // calls do not allocate spans or call Date.now on the hot reply path.
+    return {
+      async measure(_name, run) {
+        return await run();
+      },
+      measureSync(_name, run) {
+        return run();
+      },
+      logIfSlow() {},
+    };
+  }
+
+  const startedAt = Date.now();
+  const spans: ReplyTimingSpan[] = [];
+  let didLog = false;
+  const totalWarnMs = params.totalWarnMs ?? DEFAULT_TIMING_WARN_TOTAL_MS;
+  const stageWarnMs = params.stageWarnMs ?? DEFAULT_TIMING_WARN_STAGE_MS;
+  const toMs = (value: number) => Math.max(0, Math.round(value));
+  const record = (name: string, spanStartedAt: number) => {
+    spans.push({
+      name,
+      durationMs: toMs(Date.now() - spanStartedAt),
+      elapsedMs: toMs(Date.now() - startedAt),
+    });
+  };
+  const snapshot = (): ReplyTimingSummary => ({
+    totalMs: toMs(Date.now() - startedAt),
+    spans: spans.slice(),
+  });
+  const shouldLog = (summary: ReplyTimingSummary) =>
+    summary.totalMs >= totalWarnMs || summary.spans.some((span) => span.durationMs >= stageWarnMs);
+  const formatSpans = (summary: ReplyTimingSummary) =>
+    summary.spans.length > 0
+      ? summary.spans
+          .map((span) => `${span.name}:${span.durationMs}ms@${span.elapsedMs}ms`)
+          .join(",")
+      : "none";
+
+  return {
+    async measure(name, run) {
+      const spanStartedAt = Date.now();
+      try {
+        return await run();
+      } finally {
+        record(name, spanStartedAt);
+      }
+    },
+    measureSync(name, run) {
+      const spanStartedAt = Date.now();
+      try {
+        return run();
+      } finally {
+        record(name, spanStartedAt);
+      }
+    },
+    logIfSlow(logParams) {
+      if (didLog) {
+        return;
+      }
+      const summary = snapshot();
+      if (!shouldLog(summary)) {
+        return;
+      }
+      didLog = true;
+      const suffix = [
+        `totalMs=${summary.totalMs}`,
+        `stages=${formatSpans(summary)}`,
+        logParams.outcome ? `outcome=${logParams.outcome}` : undefined,
+        logParams.reason ? `reason=${logParams.reason}` : undefined,
+        logParams.error ? `error="${logParams.error}"` : undefined,
+      ]
+        .filter(Boolean)
+        .join(" ");
+      params.log.warn(`${logParams.message} ${suffix}`, {
+        ...logParams.details,
+        outcome: logParams.outcome,
+        reason: logParams.reason,
+        error: logParams.error,
+        totalMs: summary.totalMs,
+        spans: summary.spans,
+      });
+    },
+  };
+}

--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -4,6 +4,7 @@ import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { modelKey, parseModelRef, resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { createModelVisibilityPolicy } from "../agents/model-visibility-policy.js";
 import { getRuntimeConfig } from "../config/io.js";
+import { loadManifestMetadataSnapshot } from "../plugins/manifest-contract-eligibility.js";
 import { buildAgentMainSessionKey, normalizeAgentId } from "../routing/session-key.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -87,7 +88,18 @@ export async function resolveOpenAiCompatModelOverride(params: {
   const cfg = getRuntimeConfig();
   const defaultModelRef = resolveDefaultModelForAgent({ cfg, agentId: params.agentId });
   const defaultProvider = defaultModelRef.provider;
-  const parsed = parseModelRef(raw, defaultProvider);
+  const manifestMetadataSnapshot = loadManifestMetadataSnapshot({
+    config: cfg,
+    env: process.env,
+  });
+  const modelManifestContext = {
+    manifestPlugins: manifestMetadataSnapshot.plugins,
+  };
+  const parsed = parseModelRef(raw, defaultProvider, {
+    allowManifestNormalization: true,
+    allowPluginNormalization: true,
+    ...modelManifestContext,
+  });
   if (!parsed) {
     return { errorMessage: "Invalid `x-openclaw-model`." };
   }
@@ -98,6 +110,9 @@ export async function resolveOpenAiCompatModelOverride(params: {
     catalog,
     defaultProvider,
     agentId: params.agentId,
+    allowManifestNormalization: true,
+    allowPluginNormalization: true,
+    ...modelManifestContext,
   });
   const normalized = modelKey(parsed.provider, parsed.model);
   if (!policy.allowsKey(normalized)) {

--- a/src/gateway/server-maintenance.test.ts
+++ b/src/gateway/server-maintenance.test.ts
@@ -133,6 +133,24 @@ describe("startGatewayMaintenanceTimers", () => {
     stopMaintenanceTimers(timers);
   });
 
+  it("refreshes automatic health snapshots without live channel probes", async () => {
+    vi.useFakeTimers();
+    const { startGatewayMaintenanceTimers } = await import("./server-maintenance.js");
+    const deps = createMaintenanceTimerDeps();
+    deps.refreshGatewayHealthSnapshot = vi.fn(async () => ({ ok: true }) as HealthSummary);
+
+    const timers = startGatewayMaintenanceTimers(deps);
+
+    expect(deps.refreshGatewayHealthSnapshot).toHaveBeenCalledWith({ probe: false });
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(deps.refreshGatewayHealthSnapshot).toHaveBeenCalledTimes(2);
+    expect(deps.refreshGatewayHealthSnapshot).toHaveBeenLastCalledWith({ probe: false });
+
+    stopMaintenanceTimers(timers);
+  });
+
   it("skips overlapping media cleanup runs", async () => {
     vi.useFakeTimers();
     let resolveCleanup = () => {};

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -72,16 +72,17 @@ export function startGatewayMaintenanceTimers(params: {
     params.nodeSendToAllSubscribed("tick", payload);
   }, TICK_INTERVAL_MS);
 
-  // periodic health refresh to keep cached snapshot warm
+  // Keep cached health warm without request-time live channel probes. Explicit
+  // status/doctor probe paths still pass probe=true when the operator asks.
   const healthInterval = setInterval(() => {
     void params
-      .refreshGatewayHealthSnapshot({ probe: true })
+      .refreshGatewayHealthSnapshot({ probe: false })
       .catch((err) => params.logHealth.error(`refresh failed: ${formatError(err)}`));
   }, HEALTH_REFRESH_INTERVAL_MS);
 
   // Prime cache so first client gets a snapshot without waiting.
   void params
-    .refreshGatewayHealthSnapshot({ probe: true })
+    .refreshGatewayHealthSnapshot({ probe: false })
     .catch((err) => params.logHealth.error(`initial refresh failed: ${formatError(err)}`));
 
   // dedupe cache cleanup

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -199,6 +199,13 @@ function deliveryCall(index = 0): Record<string, any> | undefined {
   return calls[index]?.[0];
 }
 
+function appendTranscriptCall(index = 0): Record<string, any> | undefined {
+  const calls = mocks.appendAssistantMessageToSessionTranscript.mock.calls as unknown as Array<
+    [Record<string, any>]
+  >;
+  return calls[index]?.[0];
+}
+
 function firstRespondCall(respond: ReturnType<typeof vi.fn>) {
   const calls = respond.mock.calls as unknown as Array<
     [
@@ -1453,6 +1460,178 @@ describe("gateway send mirroring", () => {
       idempotencyKey: "idem-caption-source-message-action",
       config: {},
     });
+  });
+
+  it("waits for source transcript mirroring before responding to message.action", async () => {
+    const telegramPlugin: ChannelPlugin = {
+      id: "telegram",
+      meta: {
+        id: "telegram",
+        label: "Telegram",
+        selectionLabel: "Telegram",
+        docsPath: "/channels/telegram",
+        blurb: "Telegram async source send transcript mirror test plugin.",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => ["default"],
+        resolveAccount: () => ({ enabled: true }),
+        isConfigured: () => true,
+      },
+      actions: {
+        describeMessageTool: () => ({ actions: ["send"] }),
+        supportsAction: ({ action }) => action === "send",
+        handleAction: async () => jsonResult({ ok: true, messageId: "tg-async-1" }),
+      },
+    };
+    const mirrorDeferred = createDeferred<{ ok: boolean; sessionFile: string }>();
+    mocks.getChannelPlugin.mockReturnValue(telegramPlugin);
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "telegram", source: "test", plugin: telegramPlugin }]),
+      "send-test-source-message-action-async-mirror",
+    );
+    mocks.dispatchChannelMessageAction.mockResolvedValueOnce(
+      jsonResult({ ok: true, messageId: "tg-async-1" }),
+    );
+    mocks.appendAssistantMessageToSessionTranscript.mockReturnValueOnce(mirrorDeferred.promise);
+
+    const respond = vi.fn();
+    const request = sendHandlers["message.action"]({
+      params: {
+        channel: "telegram",
+        action: "send",
+        params: {
+          to: "chat-123",
+          message: "visible media caption",
+        },
+        sessionKey: "agent:main:telegram:direct:chat-123",
+        agentId: "main",
+        toolContext: {
+          currentChannelProvider: "telegram",
+          currentChannelId: "chat-123",
+        },
+        idempotencyKey: "idem-async-source-message-action",
+      } as never,
+      respond,
+      context: makeContext(),
+      req: { type: "req", id: "1", method: "message.action" },
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledTimes(1);
+    });
+    expect(respond).not.toHaveBeenCalled();
+
+    mirrorDeferred.resolve({ ok: true, sessionFile: "x" });
+    await request;
+
+    expect(firstRespondCall(respond)[0]).toBe(true);
+  });
+
+  it("preserves source transcript mirror order before message.action responses", async () => {
+    const telegramPlugin: ChannelPlugin = {
+      id: "telegram",
+      meta: {
+        id: "telegram",
+        label: "Telegram",
+        selectionLabel: "Telegram",
+        docsPath: "/channels/telegram",
+        blurb: "Telegram ordered async source send transcript mirror test plugin.",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => ["default"],
+        resolveAccount: () => ({ enabled: true }),
+        isConfigured: () => true,
+      },
+      actions: {
+        describeMessageTool: () => ({ actions: ["send"] }),
+        supportsAction: ({ action }) => action === "send",
+        handleAction: async () => jsonResult({ ok: true, messageId: "tg-ordered" }),
+      },
+    };
+    const firstMirrorDeferred = createDeferred<{ ok: boolean; sessionFile: string }>();
+    mocks.getChannelPlugin.mockReturnValue(telegramPlugin);
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "telegram", source: "test", plugin: telegramPlugin }]),
+      "send-test-source-message-action-ordered-async-mirror",
+    );
+    mocks.dispatchChannelMessageAction.mockResolvedValue(
+      jsonResult({ ok: true, messageId: "tg-ordered" }),
+    );
+    mocks.appendAssistantMessageToSessionTranscript
+      .mockReturnValueOnce(firstMirrorDeferred.promise)
+      .mockResolvedValueOnce({ ok: true, sessionFile: "x" });
+
+    const firstRespond = vi.fn();
+    const secondRespond = vi.fn();
+    const first = sendHandlers["message.action"]({
+      params: {
+        channel: "telegram",
+        action: "send",
+        params: {
+          to: "chat-123",
+          message: "first visible reply",
+        },
+        sessionKey: "agent:main:telegram:direct:chat-123",
+        agentId: "main",
+        toolContext: {
+          currentChannelProvider: "telegram",
+          currentChannelId: "chat-123",
+        },
+        idempotencyKey: "idem-ordered-source-message-action-1",
+      } as never,
+      respond: firstRespond,
+      context: makeContext(),
+      req: { type: "req", id: "1", method: "message.action" },
+      client: null,
+      isWebchatConnect: () => false,
+    });
+    await vi.waitFor(() => {
+      expect(mocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledTimes(1);
+    });
+    const second = sendHandlers["message.action"]({
+      params: {
+        channel: "telegram",
+        action: "send",
+        params: {
+          to: "chat-123",
+          message: "second visible reply",
+        },
+        sessionKey: "agent:main:telegram:direct:chat-123",
+        agentId: "main",
+        toolContext: {
+          currentChannelProvider: "telegram",
+          currentChannelId: "chat-123",
+        },
+        idempotencyKey: "idem-ordered-source-message-action-2",
+      } as never,
+      respond: secondRespond,
+      context: makeContext(),
+      req: { type: "req", id: "2", method: "message.action" },
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(mocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledTimes(1);
+    expect(firstRespond).not.toHaveBeenCalled();
+    expect(secondRespond).not.toHaveBeenCalled();
+    expect(appendTranscriptCall(0)).toEqual(
+      expect.objectContaining({ text: "first visible reply" }),
+    );
+
+    firstMirrorDeferred.resolve({ ok: true, sessionFile: "x" });
+    await first;
+    await second;
+
+    expect(firstRespondCall(firstRespond)[0]).toBe(true);
+    expect(firstRespondCall(secondRespond)[0]).toBe(true);
+    expect(mocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledTimes(2);
+    expect(appendTranscriptCall(1)).toEqual(
+      expect.objectContaining({ text: "second visible reply" }),
+    );
   });
 
   it("mirrors presentation-only source-conversation message.action sends", async () => {

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -288,6 +288,37 @@ async function mirrorDeliveredSourceReplyToTranscriptBestEffort(params: {
   }
 }
 
+const sourceReplyTranscriptMirrorQueues = new Map<string, Promise<void>>();
+
+function resolveSourceReplyTranscriptMirrorQueueKey(
+  mirror: Parameters<typeof mirrorDeliveredSourceReplyToTranscript>[0],
+): string {
+  return mirror.sessionKey?.trim() || "__global__";
+}
+
+function scheduleDeliveredSourceReplyTranscriptMirror(params: {
+  context: GatewayRequestContext;
+  mirror: Parameters<typeof mirrorDeliveredSourceReplyToTranscript>[0];
+}): Promise<void> {
+  const queueKey = resolveSourceReplyTranscriptMirrorQueueKey(params.mirror);
+  const previous = sourceReplyTranscriptMirrorQueues.get(queueKey);
+  // Queue per session so current-conversation source replies are visible before
+  // a following turn can read the transcript.
+  const queued = (async () => {
+    await previous?.catch(() => undefined);
+    await mirrorDeliveredSourceReplyToTranscriptBestEffort(params);
+  })();
+  sourceReplyTranscriptMirrorQueues.set(queueKey, queued);
+  void queued
+    .finally(() => {
+      if (sourceReplyTranscriptMirrorQueues.get(queueKey) === queued) {
+        sourceReplyTranscriptMirrorQueues.delete(queueKey);
+      }
+    })
+    .catch(() => undefined);
+  return queued;
+}
+
 export const sendHandlers: GatewayRequestHandlers = {
   "message.action": async ({ params, respond, context, client }) => {
     const p = params;
@@ -399,7 +430,7 @@ export const sendHandlers: GatewayRequestHandlers = {
         const agentId =
           normalizeOptionalString(request.agentId) ??
           (sessionKey ? resolveSessionAgentId({ sessionKey, config: cfg }) : undefined);
-        await mirrorDeliveredSourceReplyToTranscriptBestEffort({
+        await scheduleDeliveredSourceReplyTranscriptMirror({
           context,
           mirror: {
             action: request.action,

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -224,7 +224,7 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
     expect(hello.ok).toBe(true);
 
     await vi.waitFor(() => {
-      expect(refreshHealthSnapshot).toHaveBeenCalledWith({ probe: true });
+      expect(refreshHealthSnapshot).toHaveBeenCalledWith({ probe: false });
     });
     resolveRefresh?.();
   });

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1776,7 +1776,10 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           presence: snapshot.presence.length,
           stateVersion: snapshot.stateVersion.presence,
         });
-        void refreshHealthSnapshot({ probe: true }).catch((err) =>
+        // Post-connect refresh only needs a cached/config snapshot for UI state;
+        // live channel probes here pulled slow Discord/Telegram HTTP checks into
+        // reply-adjacent websocket handshakes.
+        void refreshHealthSnapshot({ probe: false }).catch((err) =>
           logHealth.error(`post-connect health refresh failed: ${formatError(err)}`),
         );
         return;

--- a/src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
+++ b/src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
@@ -250,6 +250,78 @@ describe("heartbeat runner skips when target session lane is busy", () => {
     });
   });
 
+  it("returns requests-in-flight when another session for the same agent has an active reply run", async () => {
+    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
+      const cfg = createHeartbeatTelegramConfig();
+      await seedHeartbeatTelegramSession(storePath, cfg);
+      const listActiveReplyRunSessionKeys = vi.fn(() => [
+        "agent:main:telegram:group:-1003966283270:topic:547",
+      ]);
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: {
+          getQueueSize: vi.fn((_lane?: string) => 0),
+          listActiveReplyRunSessionKeys,
+          nowMs: () => Date.now(),
+          getReplyFromConfig: replySpy,
+        } as HeartbeatDeps,
+      });
+
+      expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT });
+      expect(listActiveReplyRunSessionKeys).toHaveBeenCalledOnce();
+      expect(replySpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it("ignores unscoped active reply runs when checking same-agent heartbeat work", async () => {
+    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
+      const cfg = createHeartbeatTelegramConfig();
+      await seedHeartbeatTelegramSession(storePath, cfg);
+      const listActiveReplyRunSessionKeys = vi.fn(() => ["legacy-session-key"]);
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: {
+          getQueueSize: vi.fn((_lane?: string) => 0),
+          listActiveReplyRunSessionKeys,
+          nowMs: () => Date.now(),
+          getReplyFromConfig: replySpy,
+        } as HeartbeatDeps,
+      });
+
+      expect(result.status).toBe("ran");
+      expect(listActiveReplyRunSessionKeys).toHaveBeenCalledOnce();
+      expect(replySpy).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("does not defer immediate heartbeat wakes for another active session", async () => {
+    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
+      const cfg = createHeartbeatTelegramConfig();
+      await seedHeartbeatTelegramSession(storePath, cfg);
+      const listActiveReplyRunSessionKeys = vi.fn(() => [
+        "agent:main:telegram:group:-1003966283270:topic:547",
+      ]);
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        intent: "immediate",
+        deps: {
+          getQueueSize: vi.fn((_lane?: string) => 0),
+          listActiveReplyRunSessionKeys,
+          nowMs: () => Date.now(),
+          getReplyFromConfig: replySpy,
+        } as HeartbeatDeps,
+      });
+
+      expect(result.status).toBe("ran");
+      expect(replySpy).toHaveBeenCalledOnce();
+    });
+  });
+
   it("does not defer on a recent heartbeat ack pending final delivery", async () => {
     await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
       const cfg = createHeartbeatTelegramConfig();

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -36,7 +36,10 @@ import {
 } from "../auto-reply/heartbeat.js";
 import { replaceGenericExternalRunFailureText } from "../auto-reply/reply/agent-runner-failure-copy.js";
 import { resolveDefaultModel } from "../auto-reply/reply/directive-handling.defaults.js";
-import { replyRunRegistry } from "../auto-reply/reply/reply-run-registry.js";
+import {
+  listActiveReplyRunSessionKeys,
+  replyRunRegistry,
+} from "../auto-reply/reply/reply-run-registry.js";
 import { resolveResponsePrefixTemplate } from "../auto-reply/reply/response-prefix-template.js";
 import { HEARTBEAT_TOKEN } from "../auto-reply/tokens.js";
 import type { ReplyPayload } from "../auto-reply/types.js";
@@ -148,6 +151,7 @@ export type HeartbeatDeps = OutboundSendDeps &
     getQueueSize?: (lane?: string) => number;
     getCommandLaneSnapshots?: () => readonly CommandLaneSnapshot[];
     isReplyRunActive?: (sessionKey: string) => boolean;
+    listActiveReplyRunSessionKeys?: () => readonly string[];
     nowMs?: () => number;
   };
 
@@ -219,6 +223,17 @@ function hasAgentOptInBusyLaneWork(
   getSnapshots: () => readonly CommandLaneSnapshot[],
 ): boolean {
   return hasQueuedWorkInLaneSnapshots(getSnapshots(), (lane) => laneBelongsToAgent(lane, agentId));
+}
+
+function hasActiveReplyRunForAgent(
+  agentId: string,
+  listSessionKeys: () => readonly string[],
+): boolean {
+  const normalizedAgentId = normalizeAgentId(agentId);
+  return listSessionKeys().some((sessionKey) => {
+    const parsed = parseAgentSessionKey(sessionKey);
+    return parsed ? normalizeAgentId(parsed.agentId) === normalizedAgentId : false;
+  });
 }
 
 function resolveHeartbeatChannelPlugin(channel: string): ChannelPlugin | undefined {
@@ -1343,6 +1358,21 @@ export async function runHeartbeatOnce(opts: {
       durationMs: Date.now() - startedAt,
     });
     return { status: "skipped", reason: HEARTBEAT_SKIP_LANES_BUSY };
+  }
+
+  const shouldHonorActiveReplyRuns = opts.intent !== "immediate" && opts.intent !== "manual";
+  const listActiveReplyRuns =
+    opts.deps?.listActiveReplyRunSessionKeys ?? listActiveReplyRunSessionKeys;
+  // Scheduled heartbeats are background work, so defer them when any session on
+  // the same agent is already replying; immediate/manual wakes keep their
+  // existing semantics for explicit user/system actions.
+  if (shouldHonorActiveReplyRuns && hasActiveReplyRunForAgent(agentId, listActiveReplyRuns)) {
+    emitHeartbeatEvent({
+      status: "skipped",
+      reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
+      durationMs: Date.now() - startedAt,
+    });
+    return { status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT };
   }
 
   // Phase 2: Stronger heartbeat deferral while a final delivery replay is pending.

--- a/src/tasks/task-flow-registry.store.sqlite.ts
+++ b/src/tasks/task-flow-registry.store.sqlite.ts
@@ -52,6 +52,27 @@ let cachedDatabase: FlowRegistryDatabase | null = null;
 const FLOW_REGISTRY_DIR_MODE = 0o700;
 const FLOW_REGISTRY_FILE_MODE = 0o600;
 const FLOW_REGISTRY_SIDECAR_SUFFIXES = ["", "-shm", "-wal"] as const;
+const FLOW_RUNS_COLUMNS = `
+  flow_id TEXT PRIMARY KEY,
+  shape TEXT,
+  sync_mode TEXT NOT NULL DEFAULT 'managed',
+  owner_key TEXT NOT NULL,
+  requester_origin_json TEXT,
+  controller_id TEXT,
+  revision INTEGER NOT NULL DEFAULT 0,
+  status TEXT NOT NULL,
+  notify_policy TEXT NOT NULL,
+  goal TEXT NOT NULL,
+  current_step TEXT,
+  blocked_task_id TEXT,
+  blocked_summary TEXT,
+  state_json TEXT,
+  wait_json TEXT,
+  cancel_requested_at INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  ended_at INTEGER
+`;
 
 function normalizeNumber(value: number | bigint | null): number | undefined {
   if (typeof value === "bigint") {
@@ -245,28 +266,70 @@ function hasFlowRunsColumn(db: DatabaseSync, columnName: string): boolean {
   return rows.some((row) => row.name === columnName);
 }
 
+function rebuildLegacyFlowRunsTable(db: DatabaseSync) {
+  // Older live registries can retain owner_session_key TEXT NOT NULL even after owner_key is
+  // added. Current inserts do not write owner_session_key, so SQLite rejects mirrored flow rows
+  // until the table is rebuilt into the canonical schema.
+  db.exec(`
+    DROP TABLE IF EXISTS flow_runs_canonical_migration;
+    CREATE TABLE flow_runs_canonical_migration (
+      ${FLOW_RUNS_COLUMNS}
+    );
+    INSERT INTO flow_runs_canonical_migration (
+      flow_id,
+      sync_mode,
+      owner_key,
+      requester_origin_json,
+      controller_id,
+      revision,
+      status,
+      notify_policy,
+      goal,
+      current_step,
+      blocked_task_id,
+      blocked_summary,
+      state_json,
+      wait_json,
+      cancel_requested_at,
+      created_at,
+      updated_at,
+      ended_at
+    )
+    SELECT
+      flow_id,
+      CASE
+        WHEN sync_mode = 'task_mirrored' THEN 'task_mirrored'
+        ELSE 'managed'
+      END,
+      COALESCE(NULLIF(trim(owner_key), ''), owner_session_key),
+      requester_origin_json,
+      CASE
+        WHEN sync_mode = 'task_mirrored' THEN NULL
+        ELSE COALESCE(NULLIF(trim(controller_id), ''), 'core/legacy-restored')
+      END,
+      COALESCE(revision, 0),
+      status,
+      notify_policy,
+      goal,
+      current_step,
+      blocked_task_id,
+      blocked_summary,
+      state_json,
+      wait_json,
+      cancel_requested_at,
+      created_at,
+      updated_at,
+      ended_at
+    FROM flow_runs;
+    DROP TABLE flow_runs;
+    ALTER TABLE flow_runs_canonical_migration RENAME TO flow_runs;
+  `);
+}
+
 function ensureSchema(db: DatabaseSync) {
   db.exec(`
     CREATE TABLE IF NOT EXISTS flow_runs (
-      flow_id TEXT PRIMARY KEY,
-      shape TEXT,
-      sync_mode TEXT NOT NULL DEFAULT 'managed',
-      owner_key TEXT NOT NULL,
-      requester_origin_json TEXT,
-      controller_id TEXT,
-      revision INTEGER NOT NULL DEFAULT 0,
-      status TEXT NOT NULL,
-      notify_policy TEXT NOT NULL,
-      goal TEXT NOT NULL,
-      current_step TEXT,
-      blocked_task_id TEXT,
-      blocked_summary TEXT,
-      state_json TEXT,
-      wait_json TEXT,
-      cancel_requested_at INTEGER,
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL,
-      ended_at INTEGER
+      ${FLOW_RUNS_COLUMNS}
     );
   `);
   if (!hasFlowRunsColumn(db, "owner_key") && hasFlowRunsColumn(db, "owner_session_key")) {
@@ -330,6 +393,35 @@ function ensureSchema(db: DatabaseSync) {
   }
   if (!hasFlowRunsColumn(db, "cancel_requested_at")) {
     db.exec(`ALTER TABLE flow_runs ADD COLUMN cancel_requested_at INTEGER;`);
+  }
+  if (hasFlowRunsColumn(db, "owner_session_key")) {
+    // Populate the canonical fields before rebuilding so existing rows survive the legacy-column
+    // drop, including pre-sync-mode single-task flows and older managed flows with no controller.
+    db.exec(`
+      UPDATE flow_runs
+      SET owner_key = owner_session_key
+      WHERE (owner_key IS NULL OR trim(owner_key) = '')
+    `);
+    db.exec(`
+      UPDATE flow_runs
+      SET sync_mode = CASE
+        WHEN shape = 'single_task' THEN 'task_mirrored'
+        ELSE 'managed'
+      END
+      WHERE sync_mode IS NULL OR trim(sync_mode) = ''
+    `);
+    db.exec(`
+      UPDATE flow_runs
+      SET revision = 0
+      WHERE revision IS NULL
+    `);
+    db.exec(`
+      UPDATE flow_runs
+      SET controller_id = 'core/legacy-restored'
+      WHERE sync_mode = 'managed'
+        AND (controller_id IS NULL OR trim(controller_id) = '')
+    `);
+    rebuildLegacyFlowRunsTable(db);
   }
   db.exec(`CREATE INDEX IF NOT EXISTS idx_flow_runs_status ON flow_runs(status);`);
   db.exec(`CREATE INDEX IF NOT EXISTS idx_flow_runs_owner_key ON flow_runs(owner_key);`);

--- a/src/tasks/task-flow-registry.store.test.ts
+++ b/src/tasks/task-flow-registry.store.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
+  createTaskFlowForTask,
   createManagedTaskFlow,
   getTaskFlowById,
   requestFlowCancel,
@@ -190,6 +191,82 @@ describe("task-flow-registry store runtime", () => {
       expect(restored?.flowId).toBe(created.flowId);
       expect(restored?.stateJson).toBeNull();
       expect(restored?.waitJson).toBeNull();
+    });
+  });
+
+  it("migrates legacy owner_session_key schema before mirrored flow inserts", async () => {
+    await withFlowRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskFlowRegistryForTests();
+
+      const sqlitePath = resolveTaskFlowRegistrySqlitePath(process.env);
+      const { DatabaseSync } = requireNodeSqlite();
+      const db = new DatabaseSync(sqlitePath);
+      // This mirrors the live pre-migration table shape that kept owner_session_key as NOT NULL,
+      // which made current owner_key-only mirrored inserts fail with SQLITE_CONSTRAINT_NOTNULL.
+      db.exec(`
+        DROP TABLE IF EXISTS flow_runs;
+        CREATE TABLE flow_runs (
+          flow_id TEXT PRIMARY KEY,
+          owner_session_key TEXT NOT NULL,
+          requester_origin_json TEXT,
+          status TEXT NOT NULL,
+          notify_policy TEXT NOT NULL,
+          goal TEXT NOT NULL,
+          current_step TEXT,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          ended_at INTEGER
+        );
+        INSERT INTO flow_runs (
+          flow_id,
+          owner_session_key,
+          status,
+          notify_policy,
+          goal,
+          current_step,
+          created_at,
+          updated_at
+        ) VALUES (
+          'legacy-flow',
+          'agent:main:legacy',
+          'running',
+          'done_only',
+          'Legacy flow',
+          'legacy_step',
+          10,
+          15
+        );
+      `);
+      db.close();
+      resetTaskFlowRegistryForTests({ persist: false });
+
+      const mirrored = createTaskFlowForTask({
+        task: {
+          ownerKey: "agent:main:main",
+          taskId: "task-mirrored",
+          notifyPolicy: "silent",
+          status: "queued",
+          label: "Context engine turn maintenance",
+          task: "Deferred context-engine maintenance after turn.",
+          createdAt: 20,
+        },
+      });
+
+      expect(mirrored.syncMode).toBe("task_mirrored");
+      expect(mirrored.ownerKey).toBe("agent:main:main");
+      expect(mirrored.controllerId).toBeUndefined();
+
+      const legacy = getTaskFlowById("legacy-flow");
+      expect(legacy?.ownerKey).toBe("agent:main:legacy");
+      expect(legacy?.controllerId).toBe("core/legacy-restored");
+
+      const migratedDb = new DatabaseSync(sqlitePath);
+      const columns = migratedDb.prepare(`PRAGMA table_info(flow_runs)`).all() as Array<{
+        name?: string;
+      }>;
+      migratedDb.close();
+      expect(columns.map((column) => column.name)).not.toContain("owner_session_key");
     });
   });
 


### PR DESCRIPTION
## Summary

- Current pushed source head is `77362be18eef50ee71d8539b496b861853803b81` on PR base `7db4b3db412d65aea81f9d7770bf1497c092dbf9`; this update was a normal fast-forward push of `77362be18e` on top of Vincent's `761178edc1` work, with no rebase and no force push.
- Latest live profiler proof after rebuilding/running `77362be18e` on Telegram topic 547, message `2336`: inbound `12:33:30.919` -> Telegram send OK `12:35:55.397` = `144.478s` total; `reply.resolve_default_model=7ms`, no `reply.resolve_thinking_catalog`, no cold `catalog-loaded-for-thinking`, LCM auto-rotate `2ms`, LCM assemble `321ms`, Codex pre-dynamic startup `1828ms`, thread lifecycle `1705ms`, and remaining dominant cost is Codex `embedded_run=139.379s`.
- Improves visible reply latency by removing hot-path dispatcher-idle waits from direct block reply delivery. Pending block delivery is now flushed only before later tool/progress callbacks where user-visible ordering matters.
- Schedules source reply transcript mirroring after successful `message.action` sends without blocking the gateway response, while serializing mirrors per session to preserve transcript chronology.
- Sends Telegram direct-message typing only after inbound body resolution and configured binding readiness, while still before expensive context/session construction, so dropped/no-reply turns do not show misleading typing.
- Prevents progress-mode text-only tool outputs from duplicating/restarting the live progress draft.
- Keeps slash-command and session-write maintenance out of the reply hot path where possible, including native handling for bare/unknown `/skill` commands and skip-full-maintenance session writes.
- Keeps timing diagnostics opt-in instead of always-on, covering reply timing and Codex app-server startup/tool timing instrumentation.
- Rebased Codex app-server profiler flag enablement onto the shared diagnostics flag matcher documented in `docs/diagnostics/flags.md`, so config flags, env flags, wildcards, and `OPENCLAW_DIAGNOSTICS=0` disable override behave consistently.
- Caches repeated Codex workspace filesystem setup, removing the repeated `workspace=3.565s` cost observed inside the `3.977s` pre-dynamic startup sample.
- Avoids expensive provider/plugin runtime model normalization on hot paths unless explicitly needed, and keeps model visibility policy construction off plugin runtime hooks by default.
- Uses lightweight/static thinking catalog checks before hydrating the full runtime catalog. The latest `77362be18e` profiler proof shows the previous thinking-catalog marker disappeared entirely on the live topic-547 turn; the captured dominant cost moved to Codex embedded execution, not gateway catalog hydration.
- Avoids live channel health probes in reply-adjacent paths by using `probe: false` for automatic gateway health refresh and WS post-connect refresh, removing the measured `11.2s` Discord `/users/@me` timeout from Telegram reply-adjacent work.
- Defers scheduled heartbeats when the same agent already has an active reply run, reducing reply/cron contention.
- Defers context-engine-owned budget compaction to background maintenance when supported, and treats no-op/under-target/deferred-background compaction as a skip instead of blocking preflight, shaving roughly `121s` from the compaction portion and about `140s` from inbound-to-assemble in the worst captured sample.
- Migrates legacy TaskFlow SQLite registries that still retain `flow_runs.owner_session_key TEXT NOT NULL` into the canonical `owner_key TEXT NOT NULL` schema, preventing deferred context-engine maintenance one-task flow inserts from failing with `SQLITE_CONSTRAINT_NOTNULL` / `errcode=1299`; the migration and regression test include comments documenting the live-DB reason.
- Documents non-obvious performance/ordering choices inline so future changes do not accidentally reintroduce the blocking behavior.


## Profiler flag control

Profiler timing is controlled by the standard diagnostics flag mechanism documented in `docs/diagnostics/flags.md`.

Enable every profiler-gated timing span for one gateway run:

```bash
OPENCLAW_DIAGNOSTICS=profiler openclaw gateway run
```

Enable only reply-dispatch profiler spans:

```bash
OPENCLAW_DIAGNOSTICS=reply.profiler openclaw gateway run
```

Enable only Codex app-server startup/tool/thread profiler spans:

```bash
OPENCLAW_DIAGNOSTICS=codex.profiler openclaw gateway run
```

Enable profiler flags from config:

```json
{
  "diagnostics": {
    "flags": ["reply.profiler", "codex.profiler"]
  }
}
```

Disable profiler flags by removing them from `diagnostics.flags` and restarting the gateway. For a one-process hard disable, use:

```bash
OPENCLAW_DIAGNOSTICS=0 openclaw gateway run
```

`OPENCLAW_DIAGNOSTICS=0` overrides profiler flags from config as well as env for that process.

## Regression source

#83722 is the merged regression source for one major latency path. It correctly fixed same-channel pre-tool block ordering by waiting for block reply delivery before tool execution could continue, but the merged implementation put that delivery barrier directly on the hot block-reply callback path.

That meant lightweight/direct replies could wait for dispatcher idle or delivery bookkeeping even when no later tool/progress event was about to be emitted. Under concurrent embedded runs, cron work, slow channel I/O, transcript mirroring pressure, request-time compaction, model/runtime catalog hydration, or health-probe overhead, those hot-path waits were amplified into user-visible latency.

This PR preserves the ordering guarantee, but moves the wait to the point where ordering matters: before later tool/progress emission. Direct block replies can resolve without waiting on dispatcher idle, while subsequent events still flush pending block delivery first.

## Real behavior proof

Behavior addressed: direct visible replies should not be delayed by dispatcher idle waits, transcript mirroring, request-time context-engine compaction, always-on diagnostics, model/runtime catalog hydration, live health probes, hook relay startup, or cron contention while preserving block-before-tool/progress ordering.

Real environment tested: live OpenClaw gateway on Keshav's host, Telegram direct message and Telegram topic `547`. The PR currently has base `5b6d03e3e2f145ffd7ffd1420ede003388ddd257` and pushed source head `8dbf5554fdb75a9d9b9c2b042e1a9203a422f36a` after the latest rebase. GitHub currently reports merge state `CLEAN` with checks passing. Keshav built and restarted pre-rebase head `bf864b094c969ebe31e37e5b26a12dd6153596b0`; the live gateway process below started after that build-info timestamp and ran the same `/home/clawuser/openclaw/dist/index.js gateway --port 18789` entrypoint.

Pre-rebase build/restart proof for `bf864b094c969ebe31e37e5b26a12dd6153596b0`:

```text
dist/build-info commit=bf864b094c969ebe31e37e5b26a12dd6153596b0
dist/build-info builtAt=2026-05-25T15:55:38.736Z
process pid=477217
process started=Mon May 25 21:44:04 2026 IST
process cmd=/usr/bin/node /home/clawuser/openclaw/dist/index.js gateway --port 18789
```

SQLite flow-registry migration proof from the same code path:

```text
Live DB before repair had flow_runs.owner_session_key TEXT NOT NULL, while current mirrored-flow inserts write owner_key only.
Live DB backup: /home/clawuser/.openclaw/flows/backups/registry.sqlite.before-owner-session-key-migration-20260525-205255.bak
Live DB after repair: /home/clawuser/.openclaw/flows/registry.sqlite has owner_key TEXT NOT NULL and no owner_session_key column.
Code coverage: src/tasks/task-flow-registry.store.test.ts migrates a legacy owner_session_key table before a mirrored flow insert.
```

Pre-rebase completed Telegram send proof after restart:

```text
2026-05-25T13:49:06.617+05:30 [auto-reply/reply-resolver-timing] surface=telegram messageId=11298 sessionKey=agent:main:telegram:direct:5185575566 totalMs=10758 outcome=completed reason=native_slash_command_fast_path
2026-05-25T13:49:07.608+05:30 [channels/telegram] telegram sendMessage ok chat=5185575566 message=11299
```

Pre-rebase live Telegram topic `547` timing sample from request `2209`:

```text
2026-05-25T13:54:18.207+05:30 [telegram] Inbound message telegram:group:-1003966283270:topic:547 -> @Klaw18_bot
2026-05-25T13:54:23.107+05:30 [auto-reply/reply-resolver-timing] messageId=2209 totalMs=4717 stages=reply.resolve_default_model:4306ms@4306ms,reply.ensure_workspace:17ms@4324ms,reply.init_session_state:56ms@4381ms,reply.resolve_directives:334ms@4715ms outcome=milestone reason=before_run_prepared_reply
2026-05-25T13:54:38.514+05:30 [agent/embedded] dynamic tool build phase=runtime-tools totalMs=1923
2026-05-25T13:54:40.273+05:30 [agent/embedded] dynamic tool build phase=registered-tools totalMs=1753
2026-05-25T13:54:40.412+05:30 [lcm] auto-rotate action=skip durationMs=0 reason=below-threshold
2026-05-25T13:54:40.848+05:30 [lcm] assemble duration=259ms
```

Additional context-engine maintenance proof after the topic request:

```text
2026-05-25T13:57:35.173+05:30 [lcm] auto-rotate action=rotate durationMs=74 bytesRemoved=1837832 preservedTailMessageCount=64 checkpointSize=275823
2026-05-25T13:57:43.762+05:30 [auto-reply/agent-turn-timing] runId=65d60c5b-f188-4ada-9980-aad2f7cd7443 milestone=before_embedded_run totalMs=8050
2026-05-25T13:57:51.034+05:30 [agent/embedded] dynamic tool build phase=runtime-tools totalMs=1728
2026-05-25T13:57:52.778+05:30 [agent/embedded] dynamic tool build phase=registered-tools totalMs=1737
2026-05-25T13:57:52.930+05:30 [lcm] auto-rotate action=skip durationMs=1 reason=below-threshold
2026-05-25T13:57:53.283+05:30 [lcm] assemble duration=232ms
```

Previous restarted-head proof retained for history:

```text
MainPID=437284
ExecMainStartTimestamp=Mon 2026-05-25 13:08:57 IST
ActiveState=active
SubState=running
dist/build-info commit=72d8cb1894826063e2e7a281c808db54d473b8ce
dist/build-info builtAt=2026-05-25T07:35:06.420Z
```

Previous restarted-head timing sample, Telegram topic `547`, user request `2204`:

```text
2026-05-25T13:11:05.481+05:30 [telegram] Inbound message telegram:group:-1003966283270:topic:547 -> @Klaw18_bot
2026-05-25T13:11:09.498+05:30 [auto-reply/reply-resolver-timing] messageId=2204 totalMs=3831 stages=reply.resolve_default_model:3411ms@3412ms,reply.ensure_workspace:21ms@3434ms,reply.init_session_state:57ms@3491ms,reply.resolve_directives:333ms@3825ms outcome=milestone reason=before_run_prepared_reply
2026-05-25T13:12:05.467+05:30 [auto-reply/agent-turn-timing] runId=f09f6aab-81fd-4456-9e6a-5a6343dc9410 milestone=before_embedded_run totalMs=6888 stages=current_turn_images:0ms@1ms,fallback_persist_selection:0ms@6744ms,fallback_resolve_runtime:2ms@6746ms
2026-05-25T13:12:11.349+05:30 [agent/embedded] dynamic tool build phase=runtime-tools totalMs=1571
2026-05-25T13:12:12.944+05:30 [agent/embedded] dynamic tool build phase=registered-tools totalMs=1589
2026-05-25T13:12:13.023+05:30 [lcm] auto-rotate action=skip durationMs=1 reason=below-threshold
2026-05-25T13:12:13.420+05:30 [lcm] assemble duration=325ms
2026-05-25T13:12:15.058+05:30 [agent/embedded] thread lifecycle action=resumed totalMs=760
```

CI follow-up after the latest rebase: restored built-in static normalization for OpenRouter bare model ids and XAI legacy aliases even when manifest normalization is disabled, and guarded media-only reply state when `allowedModelCatalog` is absent. The formerly red `checks-node-agentic-commands-agent-channel`, `checks-node-auto-reply-reply-state-routing`, and `checks-node-auto-reply-reply-dispatch` shards are green on the new source head.

Exact steps or command run after this patch: read live gateway journal and `/tmp/openclaw/openclaw-2026-05-25.log` for the current Telegram request, then checked the final rebased source head with `git diff --check origin/main...HEAD`, `pnpm exec oxfmt --check --threads=1` on the eight review-touched files, `pnpm tsgo:core`, and `pnpm tsgo:extensions`. Focused regression Vitest batches also passed during review for compaction, reply dispatch, gateway send, Telegram dispatch/typing, heartbeat deferral, Codex app-server startup/tool behavior, and plugin runtime model selection.

Evidence after fix: copied live runtime output from Keshav's current Telegram request, redacted only by omitting unrelated log lines:

```text
2026-05-25T11:02:48.759+05:30 [telegram] Inbound message telegram:group:-1003966283270:topic:547 -> @Klaw18_bot (group, 177 chars)
2026-05-25T11:02:53.084+05:30 [auto-reply/reply-resolver-timing] reply resolver timings surface=telegram messageId=2168 sessionKey=agent:main:telegram:group:-1003966283270:topic:547 agentId=main totalMs=4168 stages=reply.resolve_default_model:3699ms@3700ms,reply.ensure_workspace:42ms@3743ms,reply.init_session_state:62ms@3805ms,reply.resolve_directives:360ms@4166ms outcome=milestone reason=before_run_prepared_reply
2026-05-25T11:03:00.932+05:30 [auto-reply/agent-turn-timing] agent turn milestone runId=0581cde1-8cc6-400a-bfb0-aeab1f4e33ec sessionKey=agent:main:telegram:group:-1003966283270:topic:547 milestone=before_embedded_run totalMs=6988 stages=current_turn_images:0ms@1ms,fallback_persist_selection:0ms@6750ms,fallback_resolve_runtime:1ms@6751ms
2026-05-25T11:03:05.959+05:30 [agent/embedded] codex app-server dynamic tool build timings runId=0581cde1-8cc6-400a-bfb0-aeab1f4e33ec phase=runtime-tools totalMs=1587 stages=tool-policy:304ms@304ms,openclaw-tools:video-generate-tool:608ms@1046ms,openclaw-tools:plugin-tools:373ms@1560ms,runtime-normalization:1ms@1587ms
2026-05-25T11:03:07.812+05:30 [agent/embedded] codex app-server dynamic tool build timings runId=0581cde1-8cc6-400a-bfb0-aeab1f4e33ec phase=registered-tools totalMs=1843 stages=tool-policy:386ms@387ms,openclaw-tools:video-generate-tool:587ms@1210ms,openclaw-tools:plugin-tools:408ms@1831ms,runtime-normalization:1ms@1843ms
2026-05-25T11:03:08.780+05:30 [agent/embedded] codex app-server wrote context-engine thread binding
2026-05-25T11:03:10.546+05:30 [agent/embedded] codex app-server wrote context-engine thread binding
2026-05-25T11:03:12.941+05:30 [diagnostic] liveness warning: reasons=event_loop_delay,event_loop_utilization,cpu eventLoopDelayP99Ms=3858.8 eventLoopDelayMaxMs=10007.6 eventLoopUtilization=0.953 cpuCoreRatio=1.094 active=2 work=[active=agent:main:telegram:group:-1003966283270:topic:547(processing/embedded_run)|agent:main:main(processing/embedded_run)]
```

Observed result after fix: this live request reached resolver milestone in `4.168s`, embedded-run handoff in about `12.2s` from inbound, and Codex app-server thread binding in about `20.0-21.8s` from inbound even while another same-agent main heartbeat was active. The earlier measured start-of-PR problem was about `30.9s` before agent work became visible and `49.9s` inbound-to-prompt on the health-probe/compaction-heavy path; this live proof shows roughly `18.7s` shaved from the pre-agent/embedded handoff path and about `28s` shaved from the worst measured inbound-to-prompt-class path.

Measured blocker/delta details from the PR investigation:

- Request-time context-engine compaction: the early broken path received the Telegram message at `00:12:04.739`, did not finish compaction/assemble until `00:14:24.916`, and hit a `121087ms` compaction deadline after entering compaction. This PR defers context-engine-owned budget compaction to background maintenance where supported and treats no-op/under-target/background-deferred results as skips, shaving roughly `121s` from the compaction portion of that path and about `140s` from inbound-to-assemble in the worst captured sample.
- Discord `/users/@me` health probe: the `20:06` live run spent `11.2s` in a Discord identity fetch timeout after preflight. Automatic gateway health refresh and WS post-connect health refresh now use `probe:false`, so that external `@me` timeout is no longer paid by Telegram reply-adjacent work.
- Workspace filesystem setup: the `22:21` live run showed Codex pre-dynamic startup at `3.977s`, dominated by `workspace=3.565s`. The PR adds process-local Codex workspace mkdir caching so repeated app-server attempts stop re-paying roughly `3.6s` of filesystem setup cost.
- Model and thinking-catalog hydration: the `23:06` live run showed `reply.resolve_default_model=3.588s` and `reply.resolve_thinking_catalog=14.387s`. The PR disables plugin/provider normalization for hot-path default-model policy construction and uses lightweight/static thinking-catalog checks before hydrating the full runtime catalog, removing roughly `17.9s` of measured model/catalog startup tax from that path.
- Slash/session maintenance: command-only session preference writes previously paid full session maintenance over the sessions tree, measured at `1723ms`; the skip-maintenance path measured `78ms`, shaving about `1.6s` from slash-command persistence.
- Heartbeat/cron contention: prior live runs showed reply overlap with same-agent heartbeat/cron work and event-loop p99/max around `10-12s`. Scheduled heartbeats now defer while the same agent has an active reply run. The latest live proof is better but not solved: it still shows `eventLoopDelayP99Ms=3858.8`, max `10007.6`, when a main heartbeat overlaps the Telegram reply.
- Dynamic tool build: repeated live runs put runtime plus registered tool construction around `3s`; the current live proof still shows about `3.4s`. This PR removes avoidable surrounding blockers and keeps the diagnostic timing opt-in, but does not claim dynamic tool construction itself is fully eliminated.

What was not tested: live WhatsApp/Discord account roundtrip, or a completed final send for Telegram topic request `2209` at the moment this proof was captured. A completed pre-rebase Telegram send after restart is recorded above for direct message `11298` -> `11299`.

## Verification

- `OPENCLAW_VITEST_MAX_WORKERS=2 NODE_OPTIONS=--max-old-space-size=8192 OPENCLAW_VITEST_SHARD_NAME=agentic-agents OPENCLAW_TEST_PROJECTS_PARALLEL=2 timeout 360s node scripts/test-projects.mjs test/vitest/vitest.agents-core.config.ts test/vitest/vitest.agents-pi-embedded.config.ts test/vitest/vitest.agents-support.config.ts test/vitest/vitest.agents-tools.config.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 timeout 120s node_modules/.bin/vitest run --config test/vitest/vitest.agents-core.config.ts src/agents/code-mode.test.ts --reporter=verbose`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `pnpm exec oxfmt --check --threads=1 extensions/codex/src/app-server/run-attempt.ts extensions/telegram/src/bot-message-context.ts extensions/telegram/src/bot-message-dispatch.ts src/agents/pi-embedded-runner/compact.queued.ts src/agents/pi-embedded-runner/compact.ts src/auto-reply/reply/dispatch-acp-delivery.ts src/auto-reply/reply/dispatch-from-config.ts src/gateway/server-methods/send.ts`
- `pnpm exec oxfmt --check --threads=1 src/tasks/task-flow-registry.store.sqlite.ts src/tasks/task-flow-registry.store.test.ts`
- direct SQLite legacy `owner_session_key` flow-registry migration probe
- `pnpm tsgo:core`
- `pnpm tsgo:extensions`
- `pnpm exec tsx -e <profiler flag enable/disable probe>`
- `pnpm exec tsx -e <static model normalization probe>`
- `OPENCLAW_VITEST_MAX_WORKERS=1 timeout 70s node scripts/run-vitest.mjs extensions/codex/src/app-server/profiler-flag.test.ts --reporter=verbose` (timed out locally in the known Vitest/Rolldown hang before useful output)
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/codex/src/app-server/profiler-flag.test.ts --reporter=verbose`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/pi-embedded-runner/compact-reasons.test.ts src/agents/pi-embedded-runner/compact.hooks.test.ts src/auto-reply/reply/agent-runner-memory.test.ts src/auto-reply/reply/commands-compact.test.ts --reporter=verbose`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-acp-delivery.test.ts src/auto-reply/reply/dispatch-from-config.test.ts src/gateway/server-methods/send.test.ts src/gateway/server-maintenance.test.ts src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts src/auto-reply/reply/reply-timing-tracker.test.ts --reporter=verbose`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/telegram/src/bot-message-context.typing.test.ts extensions/telegram/src/bot-message-dispatch.test.ts src/auto-reply/reply/commands-info.test.ts src/infra/heartbeat-runner.skips-busy-session-lane.test.ts --reporter=verbose`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/run-attempt.vision-tools.test.ts extensions/codex/src/app-server/dynamic-tools.test.ts src/agents/model-selection.plugin-runtime.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts --reporter=verbose`



- `OPENCLAW_VITEST_MAX_WORKERS=1 timeout 180s node scripts/run-vitest.mjs src/agents/model-ref-shared.test.ts src/commands/agent.test.ts src/auto-reply/reply/model-selection.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts --reporter=verbose` (timed out locally in the known Vitest/Rolldown hang before useful output; corresponding GitHub shards are green on current head)









