### PR TITLE
fix(ui): keep user code blocks plain in chat

### DIFF
--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -12,6 +12,7 @@ import {
 import { normalizeMessage } from "./message-normalizer.ts";
 
 const localStorageValues = vi.hoisted(() => new Map<string, string>());
+const markdownMock = vi.hoisted(() => vi.fn((value: string) => value));
 
 vi.mock("../../local-storage.ts", () => ({
   getSafeLocalStorage: () => ({
@@ -22,7 +23,7 @@ vi.mock("../../local-storage.ts", () => ({
 }));
 
 vi.mock("../markdown.ts", () => ({
-  toSanitizedMarkdownHtml: (value: string) => value,
+  toSanitizedMarkdownHtml: markdownMock,
 }));
 
 vi.mock("../icons.ts", () => ({
@@ -560,6 +561,31 @@ describe("grouped chat rendering", () => {
     const userBubble = expectElement(container, ".chat-group.user .chat-bubble", HTMLElement);
     expect(userBubble.classList.contains("has-copy")).toBe(false);
     expect(userBubble.querySelector(".chat-bubble-actions")).toBeNull();
+  });
+
+  it("keeps code block chrome off user markdown but on for assistant markdown", () => {
+    const container = document.createElement("div");
+    const markdown = "```bash\npython3 - <<'PY'\nPY\n```";
+
+    markdownMock.mockClear();
+    renderGroupedMessage(
+      container,
+      {
+        role: "user",
+        content: markdown,
+        timestamp: 1000,
+      },
+      "user",
+    );
+    expect(markdownMock).toHaveBeenCalledWith(markdown, { codeBlockChrome: false });
+
+    markdownMock.mockClear();
+    renderAssistantMessage(container, {
+      role: "assistant",
+      content: markdown,
+      timestamp: 1001,
+    });
+    expect(markdownMock).toHaveBeenCalledWith(markdown, { codeBlockChrome: true });
   });
 
   it("positions delete confirm by message side", () => {

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -1495,6 +1495,7 @@ function renderGroupedMessage(
   const markdownBase = extractedText?.trim() ? extractedText : null;
   const reasoningMarkdown = extractedThinking ? formatReasoningMarkdown(extractedThinking) : null;
   const markdown = markdownBase;
+  const markdownRenderOptions = { codeBlockChrome: role === "assistant" };
   const canCopyMarkdown = role === "assistant" && Boolean(markdown?.trim());
   const canExpand = role === "assistant" && Boolean(onOpenSidebar && markdown?.trim());
   const hasActions = canCopyMarkdown || canExpand;
@@ -1617,7 +1618,9 @@ function renderGroupedMessage(
                           </details>`
                         : markdown
                           ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">
-                              ${unsafeHTML(toSanitizedMarkdownHtml(markdown))}
+                              ${unsafeHTML(
+                                toSanitizedMarkdownHtml(markdown, markdownRenderOptions),
+                              )}
                             </div>`
                           : nothing}
                       ${hasToolCards
@@ -1679,7 +1682,7 @@ function renderGroupedMessage(
                 </details>`
               : markdown
                 ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">
-                    ${unsafeHTML(toSanitizedMarkdownHtml(markdown))}
+                    ${unsafeHTML(toSanitizedMarkdownHtml(markdown, markdownRenderOptions))}
                   </div>`
                 : nothing}
             ${hasToolCards

--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -352,6 +352,19 @@ describe("toSanitizedMarkdownHtml", () => {
       expect(code?.textContent).toBe("console.log(1)\n");
     });
 
+    it("renders code blocks without chrome when requested", () => {
+      const html = toSanitizedMarkdownHtml("```bash\npython3 - <<'PY'\nPY\n```", {
+        codeBlockChrome: false,
+      });
+      const fragment = htmlFragment(html);
+      const code = fragment.querySelector("pre code");
+
+      expect(fragment.querySelector(".code-block-wrapper")).toBeNull();
+      expect(fragment.querySelector(".code-block-copy")).toBeNull();
+      expect(code?.classList.contains("language-bash")).toBe(true);
+      expect(code?.textContent).toBe("python3 - <<'PY'\nPY\n");
+    });
+
     it("renders indented code blocks", () => {
       // markdown-it requires a blank line before indented code
       const html = toSanitizedMarkdownHtml("text\n\n    indented code");

--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -37,6 +37,17 @@ describe("toSanitizedMarkdownHtml", () => {
     expect(html).not.toContain("turn2view0");
   });
 
+  it("strips unsupported citation control markers even without code block chrome", () => {
+    const html = toSanitizedMarkdownHtml(
+      "v2026.5.20 release note citeturn2view0\n\nStill readable.",
+      { codeBlockChrome: false },
+    );
+
+    expect(html).toBe("<p>v2026.5.20 release note</p>\n<p>Still readable.</p>\n");
+    expect(html).not.toContain("cite");
+    expect(html).not.toContain("turn2view0");
+  });
+
   // ── Additional tests for markdown-it migration ──
   describe("www autolinks", () => {
     it("links www.example.com", () => {

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -87,6 +87,15 @@ const INLINE_DATA_IMAGE_RE = /^data:image\/[a-z0-9.+-]+;base64,/i;
 const markdownCache = new Map<string, string>();
 const TAIL_LINK_BLUR_CLASS = "chat-link-tail-blur";
 
+type MarkdownRenderOptions = {
+  codeBlockChrome?: boolean;
+};
+
+const DEFAULT_MARKDOWN_RENDER_OPTIONS: Required<MarkdownRenderOptions> = {
+  codeBlockChrome: true,
+};
+let currentMarkdownRenderOptions = DEFAULT_MARKDOWN_RENDER_OPTIONS;
+
 // CJK character ranges for URL boundary detection (RFC 3986: CJK is not valid in raw URLs).
 // CJK Unified Ideographs, CJK Symbols/Punctuation, Fullwidth Forms, Hiragana, Katakana,
 // Hangul Syllables, and CJK Compatibility Ideographs.
@@ -530,6 +539,9 @@ md.renderer.rules.fence = (tokens, idx) => {
   const highlighted = highlightCode(text, lang);
   const classAttr = codeClassAttribute(lang, highlighted);
   const codeBlock = `<pre><code${classAttr}>${highlighted}</code></pre>`;
+  if (!currentMarkdownRenderOptions.codeBlockChrome) {
+    return codeBlock;
+  }
   const langLabel = lang ? `<span class="code-block-lang">${escapeHtml(lang)}</span>` : "";
   const attrSafe = escapeHtml(text);
   const copyBtn = `<button type="button" class="code-block-copy" data-code="${attrSafe}" aria-label="${escapeHtml(t("common.copyCode"))}"><span class="code-block-copy__idle">${escapeHtml(t("common.copy"))}</span><span class="code-block-copy__done">${escapeHtml(t("common.copied"))}</span></button>`;
@@ -558,6 +570,9 @@ md.renderer.rules.code_block = (tokens, idx) => {
   const highlighted = highlightCode(text, "");
   const classAttr = codeClassAttribute("", highlighted);
   const codeBlock = `<pre><code${classAttr}>${highlighted}</code></pre>`;
+  if (!currentMarkdownRenderOptions.codeBlockChrome) {
+    return codeBlock;
+  }
   const attrSafe = escapeHtml(text);
   const copyBtn = `<button type="button" class="code-block-copy" data-code="${attrSafe}" aria-label="${escapeHtml(t("common.copyCode"))}"><span class="code-block-copy__idle">${escapeHtml(t("common.copy"))}</span><span class="code-block-copy__done">${escapeHtml(t("common.copied"))}</span></button>`;
   const header = `<div class="code-block-header">${copyBtn}</div>`;
@@ -576,13 +591,20 @@ md.renderer.rules.code_block = (tokens, idx) => {
   return `<div class="code-block-wrapper">${header}${codeBlock}</div>`;
 };
 
-export function toSanitizedMarkdownHtml(markdown: string): string {
+export function toSanitizedMarkdownHtml(
+  markdown: string,
+  options: MarkdownRenderOptions = {},
+): string {
   const input = stripUnsupportedCitationControlMarkers(markdown).trim();
   if (!input) {
     return "";
   }
   installHooks();
-  const cacheKey = `${i18n.getLocale()}\0${input}`;
+  const renderOptions = {
+    ...DEFAULT_MARKDOWN_RENDER_OPTIONS,
+    ...options,
+  };
+  const cacheKey = `${i18n.getLocale()}\0${renderOptions.codeBlockChrome ? "chrome" : "plain"}\0${input}`;
   if (input.length <= MARKDOWN_CACHE_MAX_CHARS) {
     const cached = getCachedMarkdown(cacheKey);
     if (cached !== null) {
@@ -605,6 +627,8 @@ export function toSanitizedMarkdownHtml(markdown: string): string {
     return sanitized;
   }
   let rendered: string;
+  const previousMarkdownRenderOptions = currentMarkdownRenderOptions;
+  currentMarkdownRenderOptions = renderOptions;
   try {
     rendered = md.render(`${truncated.text}${suffix}`);
   } catch (err) {
@@ -612,6 +636,8 @@ export function toSanitizedMarkdownHtml(markdown: string): string {
     console.warn("[markdown] md.render failed, falling back to plain text:", err);
     const escaped = escapeHtml(`${truncated.text}${suffix}`);
     rendered = `<pre class="code-block">${escaped}</pre>`;
+  } finally {
+    currentMarkdownRenderOptions = previousMarkdownRenderOptions;
   }
   const sanitized = DOMPurify.sanitize(rendered, sanitizeOptions);
   if (input.length <= MARKDOWN_CACHE_MAX_CHARS) {


### PR DESCRIPTION
## Summary

Fix Dashboard chat markdown rendering so user-authored fenced and indented code blocks render without copy-button chrome, while assistant code blocks keep the copy UI.

Fixes #85926.

## Verification

- `node scripts/run-vitest.mjs ui/src/ui/markdown.test.ts ui/src/ui/chat/grouped-render.test.ts`
- `git diff --check`

## Real behavior proof

Behavior addressed: User chat markdown code blocks render without copy-button chrome; assistant code blocks still render with copy UI.
Real environment tested: Local jsdom execution of `ui/src/ui/markdown.ts` in this workspace.
Exact steps or command run after this patch: `node --import tsx --input-type=module` with `jsdom` globals, then call `toSanitizedMarkdownHtml(markdown, { codeBlockChrome: false })` and `toSanitizedMarkdownHtml(markdown)` on the same heredoc snippet.
Evidence after fix: terminal output from the live module render.
USER: <pre><code class="hljs language-bash">python3 - &lt;&lt;<span class="hljs-string">'PY'</span>
PY
</code></pre>
ASSISTANT: <div class="code-block-wrapper"><div class="code-block-header"><span class="code-block-lang">bash</span><button type="button" class="code-block-copy" data-code="python3 - <<'PY'\nPY" aria-label="Copy code"><span class="code-block-copy__idle">Copy</span><span class="code-block-copy__done">Copied!</span></button></div><pre><code class="hljs language-bash">python3 - &lt;&lt;<span class="hljs-string">'PY'</span>
PY
</code></pre></div>
Observed result after fix: The user render is plain `<pre><code>` with no `.code-block-wrapper` or copy button, and the assistant render still keeps the wrapper plus copy button.
What was not tested: Full live Dashboard browser session.
