### PR TITLE
fix(discord): remove runtime.error?.() defensive shim at 4 message-handler-family sites

### DIFF
--- a/extensions/discord/src/monitor/message-handler.context.ts
+++ b/extensions/discord/src/monitor/message-handler.context.ts
@@ -297,7 +297,7 @@ export async function buildDiscordMessageProcessContext(params: {
     : undefined;
   const effectiveTo = autoThreadContext?.To ?? dmConversationTarget ?? replyTarget;
   if (!effectiveTo) {
-    runtime.error?.(danger("discord: missing reply target"));
+    runtime.error(danger("discord: missing reply target"));
     return null;
   }
   const lastRouteTo = dmConversationTarget ?? effectiveTo;

--- a/extensions/discord/src/monitor/message-handler.ts
+++ b/extensions/discord/src/monitor/message-handler.ts
@@ -261,7 +261,7 @@ export function createDiscordMessageHandler(
       }
     },
     onError: (err) => {
-      params.runtime.error?.(danger(`discord debounce flush failed: ${String(err)}`));
+      params.runtime.error(danger(`discord debounce flush failed: ${String(err)}`));
     },
   });
 
@@ -299,7 +299,7 @@ export function createDiscordMessageHandler(
         replayKey: replayKey ?? undefined,
       });
     } catch (err) {
-      params.runtime.error?.(danger(`handler failed: ${String(err)}`));
+      params.runtime.error(danger(`handler failed: ${String(err)}`));
     }
   };
 

--- a/extensions/discord/src/monitor/message-run-queue.ts
+++ b/extensions/discord/src/monitor/message-run-queue.ts
@@ -81,7 +81,7 @@ export function createDiscordMessageRunQueue(
     setStatus: params.setStatus,
     abortSignal: params.abortSignal,
     onError: (error) => {
-      params.runtime.error?.(danger(`discord message run failed: ${String(error)}`));
+      params.runtime.error(danger(`discord message run failed: ${String(error)}`));
     },
   });
 


### PR DESCRIPTION
## Summary

- Removes four `runtime.error?.(...)` optional calls in the Discord message-handler family and uses the required `RuntimeEnv.error` contract directly.
- Scope is intentionally limited to `extensions/discord/src/monitor/message-handler.ts`, `message-handler.context.ts`, and `message-run-queue.ts`.
- Production behavior is unchanged: Discord wires a concrete `RuntimeEnv` through `monitorDiscordProvider`, and `RuntimeEnv.error` is required by the plugin SDK runtime contract.

## Maintainer Verification Note

A maintainer review corrected the original proof wording. This PR should be treated as a narrow required-runtime contract cleanup, not as a guarantee that every invalid partial-runtime path now becomes a visible `TypeError`.

The invalid-runtime behavior is mixed because `createInboundDebouncer` and `createChannelRunQueue` catch reporter-hook failures. If `runtime.error` were missing in those reporter callbacks, the shared queue helpers may still swallow that secondary reporter failure. The reliable claim is narrower: the four patched callsites no longer encode an impossible optional `RuntimeEnv.error` contract, and valid production runtimes behave the same.

The remaining Discord `runtime.{log,error}?.(...)` sites outside the message-handler family are left for a separate sweep. Some are required-runtime paths, while at least the gateway metadata fallback accepts an optional runtime by design, so a broad mechanical cleanup needs its own review.

## Real behavior proof

Behavior addressed: four Discord message-handler-family callsites now call required `RuntimeEnv.error` directly instead of using optional chaining.

Real environment tested: local OpenClaw source checkout on macOS 15.5 with Node 22.19+, using patched branch HEAD `eef5e0b085`. The contributor built the package and ran a Node harness against the generated `dist/` chunks; maintainer review then checked the provider-to-handler runtime path and shared queue error handling.

Exact steps or command run after this patch: `pnpm build`, then `node /Users/umank/code/openclaw-tickets/proof/run-runtime-error-shim-proof.mjs /Users/umank/code/openclaw` against the patched checkout. Supplemental checks also included `pnpm check:changed` and focused Discord monitor tests.

Evidence after fix: copied terminal output from the built-artifact harness showed the patched generated chunks contain the direct runtime calls and no optional-chain shape at these callsites:

```text
openclaw checkout: /Users/umank/code/openclaw
dist chunks scanned: message-handler-C20TGj0D.js, message-handler.process-B1arhJMR.js
  patched non-optional calls found in dist: 4
  lingering optional-chain calls at patched callsites: 0
    [NON_OPTIONAL] message-handler-C20TGj0D.js: params.runtime.error(danger(`discord message run failed: ${String(error)}`));
    [NON_OPTIONAL] message-handler-C20TGj0D.js: params.runtime.error(danger(`discord debounce flush failed: ${String(err)}`));
    [NON_OPTIONAL] message-handler-C20TGj0D.js: params.runtime.error(danger(`handler failed: ${String(err)}`));
    [NON_OPTIONAL] message-handler.process-B1arhJMR.js: runtime.error(danger("discord: missing reply target"));
```

Observed result after fix: valid production runtimes emit the same diagnostics as before. The built output no longer represents `RuntimeEnv.error` as optional in these message-handler-family sites.

What was not tested: live Discord roundtrip, because no valid production runtime behavior changes. The broader Discord provider/startup/gateway optional-runtime cleanup is intentionally out of scope.

## Verification

- CI: `security-fast` passed after rerun; its prior failure was a checkout fetch timeout on the synthetic merge ref.
- Merge cleanliness: no textual conflict with current `origin/main` in the touched files.
- Tests covered by existing PR proof: `message-handler.queue.test.ts` and `listeners.test.ts`.

## Compatibility / Risk

- Backward compatible for valid runtimes.
- No config, auth, dependency, network, or public API changes.
- Risk is limited to exposing a malformed internal runtime object sooner at direct callsites; shared queue reporter hooks still intentionally keep secondary reporting failures best-effort.

---

AI-assisted PR. Maintainer-reviewed wording update after deeper code-path review.
