### PR TITLE
fix(openrouter): use endpoint context limits

### DIFF
--- a/src/agents/pi-embedded-runner/openrouter-model-capabilities.test.ts
+++ b/src/agents/pi-embedded-runner/openrouter-model-capabilities.test.ts
@@ -92,6 +92,48 @@ describe("openrouter-model-capabilities", () => {
     });
   });
 
+  it("uses endpoint-specific OpenRouter context length when top_provider reports one", async () => {
+    await withOpenRouterStateDir(async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(
+          async () =>
+            new Response(
+              JSON.stringify({
+                data: [
+                  {
+                    id: "nvidia/nemotron-3-super-120b-a12b:free",
+                    name: "Nemotron 3 Super 120B Free",
+                    architecture: { modality: "text->text" },
+                    context_length: 1_000_000,
+                    top_provider: {
+                      context_length: 262_144,
+                      max_completion_tokens: 262_144,
+                    },
+                    pricing: { prompt: "0", completion: "0" },
+                  },
+                ],
+              }),
+              {
+                status: 200,
+                headers: { "content-type": "application/json" },
+              },
+            ),
+        ),
+      );
+
+      const module = await importOpenRouterModelCapabilities("top-provider-context-length");
+      await module.loadOpenRouterModelCapabilities("nvidia/nemotron-3-super-120b-a12b:free");
+
+      expect(
+        module.getOpenRouterModelCapabilities("nvidia/nemotron-3-super-120b-a12b:free"),
+      ).toMatchObject({
+        contextWindow: 262_144,
+        maxTokens: 262_144,
+      });
+    });
+  });
+
   it("preserves explicit OpenRouter tool support metadata", async () => {
     await withOpenRouterStateDir(async () => {
       vi.stubGlobal(

--- a/src/agents/pi-embedded-runner/openrouter-model-capabilities.ts
+++ b/src/agents/pi-embedded-runner/openrouter-model-capabilities.ts
@@ -49,6 +49,7 @@ interface OpenRouterApiModel {
   max_completion_tokens?: number;
   max_output_tokens?: number;
   top_provider?: {
+    context_length?: number;
     max_completion_tokens?: number;
   };
   pricing?: {
@@ -174,7 +175,7 @@ function parseModel(model: OpenRouterApiModel): OpenRouterModelCapabilities {
     input,
     reasoning: supportedParameters?.includes("reasoning") ?? false,
     ...(supportedParameters ? { supportsTools: supportedParameters.includes("tools") } : {}),
-    contextWindow: model.context_length || 128_000,
+    contextWindow: model.top_provider?.context_length ?? model.context_length ?? 128_000,
     maxTokens:
       model.top_provider?.max_completion_tokens ??
       model.max_completion_tokens ??


### PR DESCRIPTION
## Summary

- Prefer OpenRouter `top_provider.context_length` when parsing dynamic model capabilities.
- Keep top-level `context_length` as the fallback when endpoint-specific metadata is absent.
- Add regression coverage for the reported `nvidia/nemotron-3-super-120b-a12b:free` catalog shape.

Fixes #85921.

## Verification

- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/openrouter-model-capabilities.test.ts src/agents/pi-embedded-runner/model.test.ts src/agents/openai-transport-stream.test.ts`
- `git diff --check`
- `pnpm exec oxfmt --check --threads=1 src/agents/pi-embedded-runner/openrouter-model-capabilities.ts src/agents/pi-embedded-runner/openrouter-model-capabilities.test.ts`

## Real behavior proof

Behavior addressed: dynamic OpenRouter models with a larger top-level catalog context length but a smaller routed endpoint context length no longer carry the larger top-level value into OpenClaw's effective runtime context budget. That prevents the OpenAI-compatible transport from treating the full endpoint context as available output budget for the reported model.

Real environment tested: local macOS OpenClaw checkout on this PR branch, plus a live public OpenRouter catalog lookup for `nvidia/nemotron-3-super-120b-a12b:free`.

Exact steps or command run after this patch: fetched `https://openrouter.ai/api/v1/models` without credentials, loaded the same model through the patched OpenRouter capability parser with a temporary `OPENCLAW_STATE_DIR`, then printed the raw catalog fields and parsed runtime caps.

Evidence after fix:

```json
{
  "modelId": "nvidia/nemotron-3-super-120b-a12b:free",
  "raw": {
    "context_length": 1000000,
    "top_provider": {
      "context_length": 262144,
      "max_completion_tokens": 262144
    }
  },
  "parsed": {
    "contextWindow": 262144,
    "maxTokens": 262144
  }
}
```

Observed result after fix: the parser now resolves the runtime `contextWindow` to the endpoint-specific `262144` token limit instead of the top-level `1000000` token catalog window, while preserving the endpoint `maxTokens` cap.

What was not tested: authenticated live OpenRouter inference was not run; the reported failure is proven from the public live catalog shape, the parser output, and the focused transport/model tests.

Authorship note: Please preserve author attribution for Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> when squashing or reworking this PR, or include `Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>`.
