### PR TITLE
fix(agents): guard session prompt ownership

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
@@ -560,6 +560,129 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(secondController.hasSessionTakeover()).toBe(false);
   });
 
+  it("keeps later waiters behind a newly registered same-file prompt holder", async () => {
+    const sessionFile = await createTempSessionFile();
+    const events: string[] = [];
+    let acquireCount = 0;
+    const acquireSessionWriteLock = vi.fn(async () => {
+      acquireCount += 1;
+      const lockId = acquireCount;
+      events.push(`acquire-${lockId}`);
+      return {
+        release: vi.fn(async () => {
+          events.push(`release-${lockId}`);
+        }),
+      };
+    });
+    const firstController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await firstController.releaseForPrompt();
+
+    const secondController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    const thirdController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    let secondReleasedForPrompt = false;
+    let thirdReleasedForPrompt = false;
+    const secondRelease = secondController.releaseForPrompt().then(() => {
+      secondReleasedForPrompt = true;
+      events.push("second released for prompt");
+    });
+    await Promise.resolve();
+    const thirdRelease = thirdController.releaseForPrompt().then(() => {
+      thirdReleasedForPrompt = true;
+      events.push("third released for prompt");
+    });
+    await Promise.resolve();
+
+    expect(secondReleasedForPrompt).toBe(false);
+    expect(thirdReleasedForPrompt).toBe(false);
+
+    await firstController.reacquireAfterPrompt();
+    await secondRelease;
+    await Promise.resolve();
+
+    expect(secondReleasedForPrompt).toBe(true);
+    expect(thirdReleasedForPrompt).toBe(false);
+
+    await secondController.reacquireAfterPrompt();
+    await thirdRelease;
+
+    expect(thirdReleasedForPrompt).toBe(true);
+    expect(events.indexOf("second released for prompt")).toBeGreaterThanOrEqual(0);
+    expect(events.indexOf("third released for prompt")).toBeGreaterThan(
+      events.indexOf("second released for prompt"),
+    );
+    expect(firstController.hasSessionTakeover()).toBe(false);
+    expect(secondController.hasSessionTakeover()).toBe(false);
+    expect(thirdController.hasSessionTakeover()).toBe(false);
+  });
+
+  it("releases a queued prompt holder when same-file waiter reacquire times out", async () => {
+    const sessionFile = await createTempSessionFile();
+    const events: string[] = [];
+    let acquireCount = 0;
+    const reacquireError = new SessionWriteLockTimeoutError({
+      timeoutMs: lockOptions.timeoutMs,
+      owner: "pid=789",
+      lockPath: `${sessionFile}.lock`,
+    });
+    const acquireSessionWriteLock = vi.fn(async () => {
+      acquireCount += 1;
+      const lockId = acquireCount;
+      events.push(`acquire-${lockId}`);
+      if (lockId === 5) {
+        events.push("second reacquire timeout");
+        throw reacquireError;
+      }
+      return {
+        release: vi.fn(async () => {
+          events.push(`release-${lockId}`);
+        }),
+      };
+    });
+    const firstController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await firstController.releaseForPrompt();
+
+    const secondController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    const thirdController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    const secondRelease = secondController.releaseForPrompt();
+    await Promise.resolve();
+    const thirdRelease = thirdController.releaseForPrompt().then(() => "released" as const);
+    await Promise.resolve();
+
+    await firstController.reacquireAfterPrompt();
+    await expect(secondRelease).rejects.toBe(reacquireError);
+    await expect(
+      Promise.race([
+        thirdRelease,
+        new Promise<"blocked">((resolve) => {
+          setTimeout(() => resolve("blocked"), 50);
+        }),
+      ]),
+    ).resolves.toBe("released");
+
+    expect(events).toContain("second reacquire timeout");
+    expect(thirdController.hasSessionTakeover()).toBe(false);
+  });
+
   it("does not keep a prompt holder after a compaction wait release reacquires through writes", async () => {
     const sessionFile = await createTempSessionFile();
     const events: string[] = [];

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
@@ -19,6 +19,7 @@ import {
   installPromptSubmissionLockRelease,
   installSessionEventWriteLock,
   installSessionExternalHookWriteLock,
+  resetEmbeddedAttemptSessionFilePromptGuardsForTest,
 } from "./attempt.session-lock.js";
 
 const lockOptions = {
@@ -32,6 +33,7 @@ const tempDirs: string[] = [];
 
 afterEach(async () => {
   resetSessionWriteLockStateForTest();
+  resetEmbeddedAttemptSessionFilePromptGuardsForTest();
   for (const dir of tempDirs.splice(0)) {
     await fs.rm(dir, { recursive: true, force: true });
   }
@@ -492,6 +494,7 @@ describe("embedded attempt session lock lifecycle", () => {
           },
         ),
     );
+    resetEmbeddedAttemptSessionFilePromptGuardsForTest();
     await secondController.releaseForPrompt();
 
     await expect(
@@ -504,6 +507,106 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(firstController.hasSessionTakeover()).toBe(false);
     expect(acquireSessionWriteLock).toHaveBeenCalledTimes(3);
     expect(releases).toEqual(["release", "release", "release"]);
+  });
+
+  it("waits for an existing prompt holder before releasing another prompt on the same session file", async () => {
+    const sessionFile = await createTempSessionFile();
+    const events: string[] = [];
+    let acquireCount = 0;
+    const acquireSessionWriteLock = vi.fn(async () => {
+      acquireCount += 1;
+      const lockId = acquireCount;
+      events.push(`acquire-${lockId}`);
+      return {
+        release: vi.fn(async () => {
+          events.push(`release-${lockId}`);
+        }),
+      };
+    });
+    const firstController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await firstController.releaseForPrompt();
+
+    const secondController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    let secondReleasedForPrompt = false;
+    const secondRelease = secondController.releaseForPrompt().then(() => {
+      secondReleasedForPrompt = true;
+    });
+    await Promise.resolve();
+
+    expect(secondReleasedForPrompt).toBe(false);
+    expect(events).toEqual(["acquire-1", "release-1", "acquire-2", "release-2"]);
+
+    await firstController.reacquireAfterPrompt();
+    await secondRelease;
+
+    expect(secondReleasedForPrompt).toBe(true);
+    expect(events).toEqual([
+      "acquire-1",
+      "release-1",
+      "acquire-2",
+      "release-2",
+      "acquire-3",
+      "acquire-4",
+      "release-4",
+    ]);
+    expect(firstController.hasSessionTakeover()).toBe(false);
+    expect(secondController.hasSessionTakeover()).toBe(false);
+  });
+
+  it("does not keep a prompt holder after a compaction wait release reacquires through writes", async () => {
+    const sessionFile = await createTempSessionFile();
+    const events: string[] = [];
+    let acquireCount = 0;
+    const acquireSessionWriteLock = vi.fn(async () => {
+      acquireCount += 1;
+      const lockId = acquireCount;
+      events.push(`acquire-${lockId}`);
+      return {
+        release: vi.fn(async () => {
+          events.push(`release-${lockId}`);
+        }),
+      };
+    });
+    const firstController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await firstController.releaseForSessionIdleWait();
+    await firstController.withSessionWriteLock(async () => {
+      events.push("first post-wait write");
+    });
+
+    const secondController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    let secondReleasedForPrompt = false;
+    await secondController.releaseForPrompt().then(() => {
+      secondReleasedForPrompt = true;
+      events.push("second released for prompt");
+    });
+
+    expect(secondReleasedForPrompt).toBe(true);
+    expect(events).toEqual([
+      "acquire-1",
+      "release-1",
+      "acquire-2",
+      "first post-wait write",
+      "release-2",
+      "acquire-3",
+      "release-3",
+      "second released for prompt",
+    ]);
+    expect(firstController.hasSessionTakeover()).toBe(false);
+    expect(secondController.hasSessionTakeover()).toBe(false);
   });
 
   it("rejects external edits interleaved while another controller holds cleanup lock", async () => {
@@ -525,6 +628,7 @@ describe("embedded attempt session lock lifecycle", () => {
       acquireSessionWriteLock,
       lockOptions: { ...lockOptions, sessionFile },
     });
+    resetEmbeddedAttemptSessionFilePromptGuardsForTest();
     await secondController.releaseForPrompt();
     const cleanupLock = await secondController.acquireForCleanup();
 
@@ -590,6 +694,7 @@ describe("embedded attempt session lock lifecycle", () => {
           },
         ),
     );
+    resetEmbeddedAttemptSessionFilePromptGuardsForTest();
     await secondController.releaseForPrompt();
 
     await expect(
@@ -626,6 +731,7 @@ describe("embedded attempt session lock lifecycle", () => {
       await fs.appendFile(sessionFile, '{"type":"message","id":"same-process"}\n', "utf8");
       await fs.appendFile(sessionFile, '{"type":"message","id":"external-interleaved"}\n', "utf8");
     });
+    resetEmbeddedAttemptSessionFilePromptGuardsForTest();
     await secondController.releaseForPrompt();
 
     await expect(
@@ -659,6 +765,7 @@ describe("embedded attempt session lock lifecycle", () => {
       acquireSessionWriteLock,
       lockOptions: { ...lockOptions, sessionFile },
     });
+    resetEmbeddedAttemptSessionFilePromptGuardsForTest();
     await secondController.releaseForPrompt();
 
     await expect(
@@ -695,6 +802,7 @@ describe("embedded attempt session lock lifecycle", () => {
     await secondController.withSessionWriteLock(async () => {
       await fs.appendFile(sessionFile, '{"type":"message","id":"same-process"}\n', "utf8");
     });
+    resetEmbeddedAttemptSessionFilePromptGuardsForTest();
     await secondController.releaseForPrompt();
 
     await expect(

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
@@ -398,6 +398,12 @@ type TrustedSessionFileState = {
   fingerprint: SessionFileFingerprint;
 };
 
+type ActivePromptSessionFileHolder = {
+  owner: symbol;
+  released: Promise<void>;
+  release: () => void;
+};
+
 // Controllers in the same OpenClaw process can legitimately take turns writing
 // the same session file while another attempt is released for model I/O. Track
 // only fingerprints that changed while OpenClaw held the write lock so the
@@ -405,10 +411,42 @@ type TrustedSessionFileState = {
 // external file changes.
 const ownedSessionFileWrites = new Map<string, OwnedSessionFileWrite>();
 const trustedSessionFileStates = new Map<string, TrustedSessionFileState>();
+const activePromptSessionFileHolders = new Map<string, ActivePromptSessionFileHolder>();
 let ownedSessionFileWriteGeneration = 0;
 
 function resolveSessionFileFenceKey(sessionFile: string): string {
   return path.resolve(sessionFile);
+}
+
+async function waitForPromptSessionFileTurn(sessionFileKey: string, owner: symbol): Promise<void> {
+  while (true) {
+    const holder = activePromptSessionFileHolders.get(sessionFileKey);
+    if (!holder || holder.owner === owner) {
+      return;
+    }
+    await holder.released;
+  }
+}
+
+function registerPromptSessionFileHolder(sessionFileKey: string, owner: symbol): void {
+  const current = activePromptSessionFileHolders.get(sessionFileKey);
+  if (current?.owner === owner) {
+    return;
+  }
+  let release!: () => void;
+  const released = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  activePromptSessionFileHolders.set(sessionFileKey, { owner, released, release });
+}
+
+function releasePromptSessionFileHolder(sessionFileKey: string, owner: symbol): void {
+  const holder = activePromptSessionFileHolders.get(sessionFileKey);
+  if (holder?.owner !== owner) {
+    return;
+  }
+  activePromptSessionFileHolders.delete(sessionFileKey);
+  holder.release();
 }
 
 function recordOwnedSessionFileWrite(
@@ -621,6 +659,7 @@ export function installSessionExternalHookWriteLock(params: {
 
 export type EmbeddedAttemptSessionLockController = {
   releaseForPrompt(): Promise<void>;
+  releaseForSessionIdleWait(): Promise<void>;
   refreshAfterOwnedSessionWrite(): void;
   reacquireAfterPrompt(): Promise<void>;
   waitForSessionEvents(session: unknown): Promise<void>;
@@ -652,6 +691,52 @@ export async function createEmbeddedAttemptSessionLockController(params: {
   let fenceActive = false;
   let takeoverDetected = false;
   const sessionFileFenceKey = resolveSessionFileFenceKey(params.lockOptions.sessionFile);
+  const promptSessionFileOwner = Symbol(sessionFileFenceKey);
+
+  async function releaseHeldLockForUnlockedSessionWindow(releaseParams: {
+    registerPromptHolder: boolean;
+  }): Promise<void> {
+    if (!heldLock) {
+      return;
+    }
+    if (releaseParams.registerPromptHolder) {
+      const existingPromptHolder = activePromptSessionFileHolders.get(sessionFileFenceKey);
+      if (existingPromptHolder && existingPromptHolder.owner !== promptSessionFileOwner) {
+        const waitingLock = heldLock;
+        heldLock = undefined;
+        await waitingLock.release();
+        await waitForPromptSessionFileTurn(sessionFileFenceKey, promptSessionFileOwner);
+        const reacquired = await acquireWriteLock();
+        heldLock = reacquired.lock;
+      }
+    }
+    const lock = heldLock;
+    if (!lock) {
+      return;
+    }
+    heldLock = undefined;
+    const fingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);
+    const ownedWrite = ownedSessionFileWrites.get(sessionFileFenceKey);
+    const trustedGeneration = trustSessionFileState(sessionFileFenceKey, fingerprint);
+    fenceFingerprint = fingerprint;
+    fenceSnapshot = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
+    fenceGeneration =
+      ownedWrite && sameSessionFileFingerprint(ownedWrite.fingerprint, fingerprint)
+        ? ownedWrite.generation
+        : (trustedGeneration ?? fenceGeneration);
+    fenceActive = true;
+    if (releaseParams.registerPromptHolder) {
+      registerPromptSessionFileHolder(sessionFileFenceKey, promptSessionFileOwner);
+    }
+    try {
+      await lock.release();
+    } catch (err) {
+      if (releaseParams.registerPromptHolder) {
+        releasePromptSessionFileHolder(sessionFileFenceKey, promptSessionFileOwner);
+      }
+      throw err;
+    }
+  }
 
   async function acquireWriteLock(): Promise<{ lock: SessionLock; owned: boolean }> {
     if (heldLock) {
@@ -754,22 +839,10 @@ export async function createEmbeddedAttemptSessionLockController(params: {
 
   return {
     async releaseForPrompt(): Promise<void> {
-      if (!heldLock) {
-        return;
-      }
-      const lock = heldLock;
-      heldLock = undefined;
-      const fingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);
-      const ownedWrite = ownedSessionFileWrites.get(sessionFileFenceKey);
-      const trustedGeneration = trustSessionFileState(sessionFileFenceKey, fingerprint);
-      fenceFingerprint = fingerprint;
-      fenceSnapshot = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
-      fenceGeneration =
-        ownedWrite && sameSessionFileFingerprint(ownedWrite.fingerprint, fingerprint)
-          ? ownedWrite.generation
-          : (trustedGeneration ?? fenceGeneration);
-      fenceActive = true;
-      await lock.release();
+      await releaseHeldLockForUnlockedSessionWindow({ registerPromptHolder: true });
+    },
+    async releaseForSessionIdleWait(): Promise<void> {
+      await releaseHeldLockForUnlockedSessionWindow({ registerPromptHolder: false });
     },
     refreshAfterOwnedSessionWrite(): void {
       if (fenceActive && !takeoverDetected) {
@@ -779,16 +852,22 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     },
     async reacquireAfterPrompt(): Promise<void> {
       if (takeoverDetected || heldLock) {
+        releasePromptSessionFileHolder(sessionFileFenceKey, promptSessionFileOwner);
         return;
       }
-      const lock = await acquireLock();
+      let lock: SessionLock | undefined;
       try {
+        lock = await acquireLock();
         heldLock = lock;
         await assertSessionFileFence();
       } catch (err) {
         heldLock = undefined;
-        await lock.release();
+        if (lock) {
+          await lock.release();
+        }
         throw err;
+      } finally {
+        releasePromptSessionFileHolder(sessionFileFenceKey, promptSessionFileOwner);
       }
     },
     waitForSessionEvents: waitForSessionEventQueue,
@@ -873,6 +952,13 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       return takeoverDetected;
     },
   };
+}
+
+export function resetEmbeddedAttemptSessionFilePromptGuardsForTest(): void {
+  for (const holder of activePromptSessionFileHolders.values()) {
+    holder.release();
+  }
+  activePromptSessionFileHolders.clear();
 }
 
 export function installPromptSubmissionLockRelease(params: {

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
@@ -398,10 +398,11 @@ type TrustedSessionFileState = {
   fingerprint: SessionFileFingerprint;
 };
 
-type ActivePromptSessionFileHolder = {
-  owner: symbol;
+type PromptSessionFileTurn = {
+  previous?: Promise<void>;
   released: Promise<void>;
   release: () => void;
+  tail: Promise<void>;
 };
 
 // Controllers in the same OpenClaw process can legitimately take turns writing
@@ -411,42 +412,43 @@ type ActivePromptSessionFileHolder = {
 // external file changes.
 const ownedSessionFileWrites = new Map<string, OwnedSessionFileWrite>();
 const trustedSessionFileStates = new Map<string, TrustedSessionFileState>();
-const activePromptSessionFileHolders = new Map<string, ActivePromptSessionFileHolder>();
+const promptSessionFileTurnTails = new Map<string, Promise<void>>();
+const promptSessionFileTurns = new Set<PromptSessionFileTurn>();
 let ownedSessionFileWriteGeneration = 0;
 
 function resolveSessionFileFenceKey(sessionFile: string): string {
   return path.resolve(sessionFile);
 }
 
-async function waitForPromptSessionFileTurn(sessionFileKey: string, owner: symbol): Promise<void> {
-  while (true) {
-    const holder = activePromptSessionFileHolders.get(sessionFileKey);
-    if (!holder || holder.owner === owner) {
-      return;
-    }
-    await holder.released;
-  }
-}
-
-function registerPromptSessionFileHolder(sessionFileKey: string, owner: symbol): void {
-  const current = activePromptSessionFileHolders.get(sessionFileKey);
-  if (current?.owner === owner) {
-    return;
-  }
+function enqueuePromptSessionFileTurn(sessionFileKey: string): PromptSessionFileTurn {
+  const previous = promptSessionFileTurnTails.get(sessionFileKey);
   let release!: () => void;
-  const released = new Promise<void>((resolve) => {
-    release = resolve;
+  let hasReleased = false;
+  const releasedPromise = new Promise<void>((resolve) => {
+    release = () => {
+      if (hasReleased) {
+        return;
+      }
+      hasReleased = true;
+      resolve();
+    };
   });
-  activePromptSessionFileHolders.set(sessionFileKey, { owner, released, release });
-}
-
-function releasePromptSessionFileHolder(sessionFileKey: string, owner: symbol): void {
-  const holder = activePromptSessionFileHolders.get(sessionFileKey);
-  if (holder?.owner !== owner) {
-    return;
-  }
-  activePromptSessionFileHolders.delete(sessionFileKey);
-  holder.release();
+  const tail = (previous ?? Promise.resolve()).then(() => releasedPromise);
+  const turn: PromptSessionFileTurn = {
+    previous,
+    released: releasedPromise,
+    release: () => {
+      release();
+      promptSessionFileTurns.delete(turn);
+      if (promptSessionFileTurnTails.get(sessionFileKey) === tail) {
+        promptSessionFileTurnTails.delete(sessionFileKey);
+      }
+    },
+    tail,
+  };
+  promptSessionFileTurns.add(turn);
+  promptSessionFileTurnTails.set(sessionFileKey, tail);
+  return turn;
 }
 
 function recordOwnedSessionFileWrite(
@@ -691,7 +693,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
   let fenceActive = false;
   let takeoverDetected = false;
   const sessionFileFenceKey = resolveSessionFileFenceKey(params.lockOptions.sessionFile);
-  const promptSessionFileOwner = Symbol(sessionFileFenceKey);
+  let activePromptSessionFileTurn: PromptSessionFileTurn | undefined;
 
   async function releaseHeldLockForUnlockedSessionWindow(releaseParams: {
     registerPromptHolder: boolean;
@@ -699,40 +701,46 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     if (!heldLock) {
       return;
     }
-    if (releaseParams.registerPromptHolder) {
-      const existingPromptHolder = activePromptSessionFileHolders.get(sessionFileFenceKey);
-      if (existingPromptHolder && existingPromptHolder.owner !== promptSessionFileOwner) {
+    const promptTurn = releaseParams.registerPromptHolder
+      ? enqueuePromptSessionFileTurn(sessionFileFenceKey)
+      : undefined;
+    let promptWindowReleased = false;
+    try {
+      if (promptTurn?.previous) {
         const waitingLock = heldLock;
-        heldLock = undefined;
         await waitingLock.release();
-        await waitForPromptSessionFileTurn(sessionFileFenceKey, promptSessionFileOwner);
+        if (heldLock === waitingLock) {
+          heldLock = undefined;
+        }
+        await promptTurn.previous;
         const reacquired = await acquireWriteLock();
         heldLock = reacquired.lock;
       }
-    }
-    const lock = heldLock;
-    if (!lock) {
-      return;
-    }
-    heldLock = undefined;
-    const fingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);
-    const ownedWrite = ownedSessionFileWrites.get(sessionFileFenceKey);
-    const trustedGeneration = trustSessionFileState(sessionFileFenceKey, fingerprint);
-    fenceFingerprint = fingerprint;
-    fenceSnapshot = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
-    fenceGeneration =
-      ownedWrite && sameSessionFileFingerprint(ownedWrite.fingerprint, fingerprint)
-        ? ownedWrite.generation
-        : (trustedGeneration ?? fenceGeneration);
-    fenceActive = true;
-    if (releaseParams.registerPromptHolder) {
-      registerPromptSessionFileHolder(sessionFileFenceKey, promptSessionFileOwner);
-    }
-    try {
+      const lock = heldLock;
+      if (!lock) {
+        promptTurn?.release();
+        return;
+      }
+      const fingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);
+      const ownedWrite = ownedSessionFileWrites.get(sessionFileFenceKey);
+      const trustedGeneration = trustSessionFileState(sessionFileFenceKey, fingerprint);
+      fenceFingerprint = fingerprint;
+      fenceSnapshot = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
+      fenceGeneration =
+        ownedWrite && sameSessionFileFingerprint(ownedWrite.fingerprint, fingerprint)
+          ? ownedWrite.generation
+          : (trustedGeneration ?? fenceGeneration);
+      fenceActive = true;
+      activePromptSessionFileTurn = promptTurn;
+      heldLock = undefined;
       await lock.release();
+      promptWindowReleased = true;
     } catch (err) {
-      if (releaseParams.registerPromptHolder) {
-        releasePromptSessionFileHolder(sessionFileFenceKey, promptSessionFileOwner);
+      if (!promptWindowReleased) {
+        promptTurn?.release();
+        if (activePromptSessionFileTurn === promptTurn) {
+          activePromptSessionFileTurn = undefined;
+        }
       }
       throw err;
     }
@@ -852,7 +860,8 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     },
     async reacquireAfterPrompt(): Promise<void> {
       if (takeoverDetected || heldLock) {
-        releasePromptSessionFileHolder(sessionFileFenceKey, promptSessionFileOwner);
+        activePromptSessionFileTurn?.release();
+        activePromptSessionFileTurn = undefined;
         return;
       }
       let lock: SessionLock | undefined;
@@ -867,7 +876,8 @@ export async function createEmbeddedAttemptSessionLockController(params: {
         }
         throw err;
       } finally {
-        releasePromptSessionFileHolder(sessionFileFenceKey, promptSessionFileOwner);
+        activePromptSessionFileTurn?.release();
+        activePromptSessionFileTurn = undefined;
       }
     },
     waitForSessionEvents: waitForSessionEventQueue,
@@ -955,10 +965,11 @@ export async function createEmbeddedAttemptSessionLockController(params: {
 }
 
 export function resetEmbeddedAttemptSessionFilePromptGuardsForTest(): void {
-  for (const holder of activePromptSessionFileHolders.values()) {
-    holder.release();
+  for (const turn of promptSessionFileTurns) {
+    turn.release();
   }
-  activePromptSessionFileHolders.clear();
+  promptSessionFileTurns.clear();
+  promptSessionFileTurnTails.clear();
 }
 
 export function installPromptSubmissionLockRelease(params: {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -4274,7 +4274,7 @@ export async function runEmbeddedAttempt(
         }
 
         await sessionLockController.waitForSessionEvents(activeSession);
-        await sessionLockController.releaseForPrompt();
+        await sessionLockController.releaseForSessionIdleWait();
 
         // Capture snapshot before compaction wait so we have complete messages if timeout occurs
         // Check compaction state before and after to avoid race condition where compaction starts during capture


### PR DESCRIPTION
## Summary
- serialize embedded runner prompt releases by resolved session JSONL file
- keep the file-scoped prompt holder on true provider prompt windows only
- release the post-prompt compaction wait without registering a prompt-active holder, so later same-file prompt releases cannot wait on stale ownership
- add regressions for both same-file prompt serialization and the compaction-wait lifecycle

Fixes #85913

## Verification
- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts`
  - Passed: 2 files, 68 tests, Duration 1.24s after rebasing onto latest `upstream/main`.
- `pnpm check:test-types`
  - Passed after rebasing onto latest `upstream/main`.
- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts src/infra/heartbeat-runner.skips-busy-session-lane.test.ts src/agents/model-fallback.test.ts src/agents/failover-error.test.ts`
  - Passed before the upstream rebase: 7 files, 300 tests, Duration 51.12s.
- `git diff --check`
- `pnpm exec oxfmt --check --threads=1 src/agents/pi-embedded-runner/run/attempt.session-lock.ts src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts src/agents/pi-embedded-runner/run/attempt.ts`

## Real behavior proof

- Behavior or issue addressed: duplicate embedded attempts for the same resolved session JSONL file could both release their write locks for provider prompt streaming at the same time. A follow-up review also found that the post-prompt compaction wait path must not leave a stale prompt holder after it reacquires with `withSessionWriteLock()`.
- Real environment tested: local OpenClaw checkout on macOS arm64, Node v24.15.0, branch `fix/session-file-prompt-guard-85913`, using the real `acquireSessionWriteLock` implementation against a temporary session JSONL file.
- Exact steps or command run after this patch: `node --import tsx --input-type=module` with an inline runtime script that created two `createEmbeddedAttemptSessionLockController` instances for the same temp `session.jsonl`; the first controller called `releaseForSessionIdleWait()` and then reacquired through `withSessionWriteLock()`, then the second controller called `releaseForPrompt()`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied live terminal output from that command:

```json
{
  "node": "v24.15.0",
  "platform": "darwin/arm64",
  "sessionFile": "<temp>/session.jsonl",
  "events": [
    "first released for compaction wait without prompt holder",
    "first reacquired through withSessionWriteLock",
    "second released for prompt after first compaction wait",
    "second released after compaction path: true",
    "takeover first=false second=false"
  ]
}
```

- Observed result after fix: the second same-file controller released for prompt after the first controller's compaction-wait path reacquired through `withSessionWriteLock()`; it did not wait on a stale prompt holder. Both controllers reported `hasSessionTakeover() === false`.
- What was not tested: no additional gaps.

## Authorship
Please preserve author attribution if this PR is squashed or reworked, or include:

`Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>`
