### PR TITLE
fix(webchat): stabilize live transcript run state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -434,6 +434,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/WebChat: keep selected external-channel sessions live by mirroring Codex prompts at turn start, streaming hidden runs only to exact selected-session subscribers, and deduplicating accumulated stream snapshots around tool cards. Fixes #83528, #82611, refs #83949. Thanks @BunsDev.
 - CLI/tasks: include stale-running task maintenance decisions in `openclaw tasks maintenance --json` so retained and reconcile candidates explain backing-session, cron, CLI, and wedged-subagent state. (#84691) Thanks @efpiva.
 - Codex app-server: keep system-prompt reports working when bootstrap hooks provide workspace files with only a path and content, so hook-supplied SOUL/IDENTITY/TOOLS/USER context still reports injected characters correctly. (#84736) Thanks @JARVIS-Glasses.
 - Providers/MiniMax music: stop advertising `durationSeconds` control and remove prompt-injected duration hints, so `music_generate` reports MiniMax duration as an unsupported override instead of suggesting MiniMax can enforce track length. Fixes #84508. Thanks @neeravmakwana.

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2407,6 +2407,32 @@ describe("runCodexAppServerAttempt", () => {
     ]);
   });
 
+  it("mirrors the Codex prompt into the transcript when the turn starts", async () => {
+    const sessionFile = path.join(tempDir, "session-early-prompt.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace-early-prompt");
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    params.prompt = "external channel prompt";
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await vi.waitFor(async () => {
+      const raw = await fs.readFile(sessionFile, "utf8");
+      expect(raw).toContain('"role":"user"');
+      expect(raw).toContain('"content":"external channel prompt"');
+      expect(raw).toContain('"idempotencyKey":"codex-app-server:thread-1:turn-1:prompt"');
+    });
+
+    const rawBeforeCompletion = await fs.readFile(sessionFile, "utf8");
+    expect(rawBeforeCompletion).not.toContain('"role":"assistant"');
+
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    const rawAfterCompletion = await fs.readFile(sessionFile, "utf8");
+    expect(rawAfterCompletion.match(/"role":"user"/gu)).toHaveLength(1);
+  });
+
   it("accepts turn completions scoped by nested turn thread id", async () => {
     const harness = createStartedThreadHarness();
     const params = createParams(

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2433,6 +2433,48 @@ describe("runCodexAppServerAttempt", () => {
     expect(rawAfterCompletion.match(/"role":"user"/gu)).toHaveLength(1);
   });
 
+  it("does not mirror the Codex prompt early when user message persistence is suppressed", async () => {
+    const sessionFile = path.join(tempDir, "session-suppressed-early-prompt.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace-suppressed-early-prompt");
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    params.prompt = "already persisted prompt";
+    params.suppressNextUserMessagePersistence = true;
+    const readTranscript = async () =>
+      fs.readFile(sessionFile, "utf8").catch((error) => {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+          return "";
+        }
+        throw error;
+      });
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await expect(
+      vi.waitFor(
+        async () => {
+          const raw = await readTranscript();
+          expect(raw).toContain("already persisted prompt");
+        },
+        { interval: 1, timeout: 100 },
+      ),
+    ).rejects.toThrow();
+    const rawBeforeCompletion = await readTranscript();
+    expect(rawBeforeCompletion).not.toContain("already persisted prompt");
+    expect(rawBeforeCompletion).not.toContain(
+      '"idempotencyKey":"codex-app-server:thread-1:turn-1:prompt"',
+    );
+
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    const rawAfterCompletion = await readTranscript();
+    expect(rawAfterCompletion).not.toContain("already persisted prompt");
+    expect(rawAfterCompletion).not.toContain(
+      '"idempotencyKey":"codex-app-server:thread-1:turn-1:prompt"',
+    );
+  });
+
   it("accepts turn completions scoped by nested turn thread id", async () => {
     const harness = createStartedThreadHarness();
     const params = createParams(

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -195,6 +195,7 @@ import {
   recordCodexTrajectoryContext,
 } from "./trajectory.js";
 import {
+  attachCodexMirrorIdentity,
   buildCodexUserPromptMessage,
   mirrorCodexAppServerTranscript,
 } from "./transcript-mirror.js";
@@ -3147,6 +3148,13 @@ export async function runCodexAppServerAttempt(
     abort: () => runAbortController.abort("aborted"),
   };
   setActiveEmbeddedRun(params.sessionId, handle, params.sessionKey);
+  void mirrorPromptAtTurnStartBestEffort({
+    params,
+    agentId: sessionAgentId,
+    sessionKey: sandboxSessionKey,
+    threadId: thread.threadId,
+    turnId: activeTurnId,
+  });
   turnAttemptIdleWatchArmed = true;
   turnTerminalIdleWatchArmed = true;
   touchTurnCompletionActivity("turn:start", { attemptProgress: true });
@@ -5714,6 +5722,32 @@ async function mirrorTranscriptBestEffort(params: {
     });
   } catch (error) {
     embeddedAgentLog.warn("failed to mirror codex app-server transcript", { error });
+  }
+}
+
+async function mirrorPromptAtTurnStartBestEffort(params: {
+  params: EmbeddedRunAttemptParams;
+  agentId?: string;
+  sessionKey?: string;
+  threadId: string;
+  turnId: string;
+}): Promise<void> {
+  try {
+    await mirrorCodexAppServerTranscript({
+      sessionFile: params.params.sessionFile,
+      agentId: params.agentId,
+      sessionKey: params.sessionKey,
+      messages: [
+        attachCodexMirrorIdentity(
+          buildCodexUserPromptMessage(params.params),
+          `${params.turnId}:prompt`,
+        ),
+      ],
+      idempotencyScope: `codex-app-server:${params.threadId}`,
+      config: params.params.config,
+    });
+  } catch (error) {
+    embeddedAgentLog.warn("failed to mirror codex app-server prompt at turn start", { error });
   }
 }
 

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -5732,6 +5732,9 @@ async function mirrorPromptAtTurnStartBestEffort(params: {
   threadId: string;
   turnId: string;
 }): Promise<void> {
+  if (params.params.suppressNextUserMessagePersistence) {
+    return;
+  }
   try {
     await mirrorCodexAppServerTranscript({
       sessionFile: params.params.sessionFile,

--- a/extensions/codex/src/app-server/transcript-mirror.test.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.test.ts
@@ -151,6 +151,42 @@ describe("mirrorCodexAppServerTranscript", () => {
       content: [{ type: "text", text: "show me live" }],
       idempotencyKey: "codex-app-server:thread-1:turn-1:prompt",
     });
+    expect(updates[0]?.messageSeq).toBe(1);
+  });
+
+  it("emits stable sequence numbers for multi-message mirror batches", async () => {
+    const sessionFile = await createTempSessionFile();
+
+    await mirrorCodexAppServerTranscript({
+      sessionFile,
+      sessionKey: "agent:main:main",
+      messages: [
+        attachCodexMirrorIdentity(
+          makeAgentUserMessage({
+            content: [{ type: "text", text: "first" }],
+            timestamp: Date.now(),
+          }),
+          "turn-1:prompt",
+        ),
+        attachCodexMirrorIdentity(
+          makeAgentAssistantMessage({
+            content: [{ type: "text", text: "second" }],
+            timestamp: Date.now() + 1,
+          }),
+          "turn-1:assistant",
+        ),
+      ],
+      idempotencyScope: "codex-app-server:thread-1",
+    });
+
+    const updates = emitSessionTranscriptUpdateMock.mock.calls.map(
+      ([update]) => update as Record<string, unknown>,
+    );
+    expect(updates.map((update) => update.messageSeq)).toEqual([1, 2]);
+    expect(updates.map((update) => (update.message as { role?: string }).role)).toEqual([
+      "user",
+      "assistant",
+    ]);
   });
 
   it("creates the transcript directory on first mirror", async () => {

--- a/extensions/codex/src/app-server/transcript-mirror.test.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.test.ts
@@ -14,6 +14,10 @@ import {
   makeAgentUserMessage,
 } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it } from "vitest";
+import {
+  onSessionTranscriptUpdate,
+  type SessionTranscriptUpdate,
+} from "../../../../src/sessions/transcript-events.js";
 import { attachCodexMirrorIdentity, mirrorCodexAppServerTranscript } from "./transcript-mirror.js";
 
 type MirroredAgentMessage = Extract<AgentMessage, { role: "user" | "assistant" | "toolResult" }>;
@@ -103,6 +107,46 @@ describe("mirrorCodexAppServerTranscript", () => {
     expect(raw).toContain(
       `"idempotencyKey":"scope-1:toolResult:${expectedFingerprint(toolResultMessage)}"`,
     );
+  });
+
+  it("emits message-bearing updates for newly appended mirrored messages only", async () => {
+    const sessionFile = await createTempSessionFile();
+    const updates: SessionTranscriptUpdate[] = [];
+    const unsubscribe = onSessionTranscriptUpdate((update) => updates.push(update));
+    const userMessage = attachCodexMirrorIdentity(
+      makeAgentUserMessage({
+        content: [{ type: "text", text: "show me live" }],
+        timestamp: Date.now(),
+      }),
+      "turn-1:prompt",
+    );
+
+    try {
+      await mirrorCodexAppServerTranscript({
+        sessionFile,
+        sessionKey: "agent:main:main",
+        messages: [userMessage],
+        idempotencyScope: "codex-app-server:thread-1",
+      });
+      await mirrorCodexAppServerTranscript({
+        sessionFile,
+        sessionKey: "agent:main:main",
+        messages: [userMessage],
+        idempotencyScope: "codex-app-server:thread-1",
+      });
+    } finally {
+      unsubscribe();
+    }
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0]?.sessionFile).toBe(sessionFile);
+    expect(updates[0]?.sessionKey).toBe("agent:main:main");
+    expect(updates[0]?.messageId).toEqual(expect.any(String));
+    expect(updates[0]?.message).toMatchObject({
+      role: "user",
+      content: [{ type: "text", text: "show me live" }],
+      idempotencyKey: "codex-app-server:thread-1:turn-1:prompt",
+    });
   });
 
   it("creates the transcript directory on first mirror", async () => {

--- a/extensions/codex/src/app-server/transcript-mirror.test.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.test.ts
@@ -13,12 +13,18 @@ import {
   makeAgentAssistantMessage,
   makeAgentUserMessage,
 } from "openclaw/plugin-sdk/test-fixtures";
-import { afterEach, describe, expect, it } from "vitest";
-import {
-  onSessionTranscriptUpdate,
-  type SessionTranscriptUpdate,
-} from "../../../../src/sessions/transcript-events.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { attachCodexMirrorIdentity, mirrorCodexAppServerTranscript } from "./transcript-mirror.js";
+
+const emitSessionTranscriptUpdateMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/agent-harness-runtime")>();
+  return {
+    ...actual,
+    emitSessionTranscriptUpdate: emitSessionTranscriptUpdateMock,
+  };
+});
 
 type MirroredAgentMessage = Extract<AgentMessage, { role: "user" | "assistant" | "toolResult" }>;
 
@@ -33,6 +39,7 @@ const tempDirs: string[] = [];
 
 afterEach(async () => {
   resetGlobalHookRunner();
+  emitSessionTranscriptUpdateMock.mockReset();
   for (const dir of tempDirs.splice(0)) {
     await fs.rm(dir, { recursive: true, force: true });
   }
@@ -111,8 +118,6 @@ describe("mirrorCodexAppServerTranscript", () => {
 
   it("emits message-bearing updates for newly appended mirrored messages only", async () => {
     const sessionFile = await createTempSessionFile();
-    const updates: SessionTranscriptUpdate[] = [];
-    const unsubscribe = onSessionTranscriptUpdate((update) => updates.push(update));
     const userMessage = attachCodexMirrorIdentity(
       makeAgentUserMessage({
         content: [{ type: "text", text: "show me live" }],
@@ -121,23 +126,22 @@ describe("mirrorCodexAppServerTranscript", () => {
       "turn-1:prompt",
     );
 
-    try {
-      await mirrorCodexAppServerTranscript({
-        sessionFile,
-        sessionKey: "agent:main:main",
-        messages: [userMessage],
-        idempotencyScope: "codex-app-server:thread-1",
-      });
-      await mirrorCodexAppServerTranscript({
-        sessionFile,
-        sessionKey: "agent:main:main",
-        messages: [userMessage],
-        idempotencyScope: "codex-app-server:thread-1",
-      });
-    } finally {
-      unsubscribe();
-    }
+    await mirrorCodexAppServerTranscript({
+      sessionFile,
+      sessionKey: "agent:main:main",
+      messages: [userMessage],
+      idempotencyScope: "codex-app-server:thread-1",
+    });
+    await mirrorCodexAppServerTranscript({
+      sessionFile,
+      sessionKey: "agent:main:main",
+      messages: [userMessage],
+      idempotencyScope: "codex-app-server:thread-1",
+    });
 
+    const updates = emitSessionTranscriptUpdateMock.mock.calls.map(
+      ([update]) => update as Record<string, unknown>,
+    );
     expect(updates).toHaveLength(1);
     expect(updates[0]?.sessionFile).toBe(sessionFile);
     expect(updates[0]?.sessionKey).toBe("agent:main:main");

--- a/extensions/codex/src/app-server/transcript-mirror.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.ts
@@ -130,6 +130,7 @@ export async function mirrorCodexAppServerTranscript(params: {
     sessionFile: params.sessionFile,
     ...resolveSessionWriteLockOptions(params.config),
   });
+  const appendedUpdates: Array<{ messageId: string; message: AgentMessage }> = [];
   try {
     const existingIdempotencyKeys = await readTranscriptIdempotencyKeys(params.sessionFile);
     for (const message of messages) {
@@ -160,11 +161,12 @@ export async function mirrorCodexAppServerTranscript(params: {
             }
           : nextMessage
       ) as AgentMessage;
-      await appendSessionTranscriptMessage({
+      const { messageId, message: appendedMessage } = await appendSessionTranscriptMessage({
         transcriptPath: params.sessionFile,
         message: messageToAppend,
         config: params.config,
       });
+      appendedUpdates.push({ messageId, message: appendedMessage });
       if (idempotencyKey) {
         existingIdempotencyKeys.add(idempotencyKey);
       }
@@ -173,10 +175,13 @@ export async function mirrorCodexAppServerTranscript(params: {
     await lock.release();
   }
 
-  if (params.sessionKey) {
-    emitSessionTranscriptUpdate({ sessionFile: params.sessionFile, sessionKey: params.sessionKey });
-  } else {
-    emitSessionTranscriptUpdate(params.sessionFile);
+  for (const update of appendedUpdates) {
+    emitSessionTranscriptUpdate({
+      sessionFile: params.sessionFile,
+      ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+      message: update.message,
+      messageId: update.messageId,
+    });
   }
 }
 

--- a/extensions/codex/src/app-server/transcript-mirror.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.ts
@@ -130,15 +130,17 @@ export async function mirrorCodexAppServerTranscript(params: {
     sessionFile: params.sessionFile,
     ...resolveSessionWriteLockOptions(params.config),
   });
-  const appendedUpdates: Array<{ messageId: string; message: AgentMessage }> = [];
+  const appendedUpdates: Array<{ messageId: string; message: AgentMessage; messageSeq: number }> =
+    [];
   try {
-    const existingIdempotencyKeys = await readTranscriptIdempotencyKeys(params.sessionFile);
+    const mirrorState = await readTranscriptMirrorState(params.sessionFile);
+    let nextMessageSeq = mirrorState.messageCount;
     for (const message of messages) {
       const dedupeIdentity = buildMirrorDedupeIdentity(message);
       const idempotencyKey = params.idempotencyScope
         ? `${params.idempotencyScope}:${dedupeIdentity}`
         : undefined;
-      if (idempotencyKey && existingIdempotencyKeys.has(idempotencyKey)) {
+      if (idempotencyKey && mirrorState.idempotencyKeys.has(idempotencyKey)) {
         continue;
       }
       const transcriptMessage = {
@@ -166,9 +168,10 @@ export async function mirrorCodexAppServerTranscript(params: {
         message: messageToAppend,
         config: params.config,
       });
-      appendedUpdates.push({ messageId, message: appendedMessage });
+      nextMessageSeq += 1;
+      appendedUpdates.push({ messageId, message: appendedMessage, messageSeq: nextMessageSeq });
       if (idempotencyKey) {
-        existingIdempotencyKeys.add(idempotencyKey);
+        mirrorState.idempotencyKeys.add(idempotencyKey);
       }
     }
   } finally {
@@ -181,12 +184,16 @@ export async function mirrorCodexAppServerTranscript(params: {
       ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
       message: update.message,
       messageId: update.messageId,
+      messageSeq: update.messageSeq,
     });
   }
 }
 
-async function readTranscriptIdempotencyKeys(sessionFile: string): Promise<Set<string>> {
-  const keys = new Set<string>();
+async function readTranscriptMirrorState(
+  sessionFile: string,
+): Promise<{ idempotencyKeys: Set<string>; messageCount: number }> {
+  const idempotencyKeys = new Set<string>();
+  let messageCount = 0;
   let raw: string;
   try {
     raw = await fs.readFile(sessionFile, "utf8");
@@ -194,7 +201,7 @@ async function readTranscriptIdempotencyKeys(sessionFile: string): Promise<Set<s
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
       throw error;
     }
-    return keys;
+    return { idempotencyKeys, messageCount };
   }
   for (const line of raw.split(/\r?\n/)) {
     if (!line.trim()) {
@@ -202,12 +209,15 @@ async function readTranscriptIdempotencyKeys(sessionFile: string): Promise<Set<s
     }
     try {
       const parsed = JSON.parse(line) as { message?: { idempotencyKey?: unknown } };
+      if ((parsed as { type?: unknown }).type === "message") {
+        messageCount += 1;
+      }
       if (typeof parsed.message?.idempotencyKey === "string") {
-        keys.add(parsed.message.idempotencyKey);
+        idempotencyKeys.add(parsed.message.idempotencyKey);
       }
     } catch {
       continue;
     }
   }
-  return keys;
+  return { idempotencyKeys, messageCount };
 }

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -42,6 +42,7 @@ import {
   createAgentEventHandler,
   createChatRunState,
   createSessionEventSubscriberRegistry,
+  createSessionMessageSubscriberRegistry,
   createToolEventRecipientRegistry,
 } from "./server-chat.js";
 import { loadGatewaySessionRow } from "./server-chat.load-gateway-session-row.runtime.js";
@@ -90,6 +91,7 @@ describe("agent event handler", () => {
     const chatRunState = createChatRunState();
     const toolEventRecipients = createToolEventRecipientRegistry();
     const sessionEventSubscribers = createSessionEventSubscriberRegistry();
+    const sessionMessageSubscribers = createSessionMessageSubscriberRegistry();
 
     const handler = createAgentEventHandler({
       broadcast,
@@ -101,6 +103,7 @@ describe("agent event handler", () => {
       clearAgentRunContext,
       toolEventRecipients,
       sessionEventSubscribers,
+      sessionMessageSubscribers,
       loadGatewaySessionRowForSnapshot: loadGatewaySessionRow,
       lifecycleErrorRetryGraceMs: params?.lifecycleErrorRetryGraceMs,
       isChatSendRunActive: params?.isChatSendRunActive,
@@ -118,6 +121,7 @@ describe("agent event handler", () => {
       chatRunState,
       toolEventRecipients,
       sessionEventSubscribers,
+      sessionMessageSubscribers,
       handler,
     };
   }
@@ -2510,6 +2514,46 @@ describe("agent event handler", () => {
     const persistEvent = requireRecord(persistParams.event, "persist lifecycle event");
     expect(persistEvent.runId).toBe("run-hidden");
     expect(requireRecord(persistEvent.data, "persist lifecycle event data").phase).toBe("end");
+  });
+
+  it("sends non-control-UI-visible live chat only to exact session message subscribers", () => {
+    const { broadcast, broadcastToConnIds, nodeSendToSession, sessionMessageSubscribers, handler } =
+      createHarness({
+        resolveSessionKeyForRun: () => "session-hidden",
+      });
+    sessionMessageSubscribers.subscribe("conn-selected", "session-hidden");
+    sessionMessageSubscribers.subscribe("conn-other", "session-other");
+    registerAgentRunContext("run-hidden", {
+      sessionKey: "session-hidden",
+      isControlUiVisible: false,
+      verboseLevel: "off",
+    });
+
+    handler({
+      runId: "run-hidden",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "visible only to the selected session" },
+    });
+    emitLifecycleEnd(handler, "run-hidden", 2);
+
+    expect(chatBroadcastCalls(broadcast)).toHaveLength(0);
+    expect(nodeSendToSession).not.toHaveBeenCalled();
+    expect(requireMockArg(broadcastToConnIds, 0, 0, "hidden chat delta event")).toBe("chat");
+    expect(requireMockArg(broadcastToConnIds, 0, 2, "hidden chat delta recipients")).toEqual(
+      new Set(["conn-selected"]),
+    );
+    expect(requireMockArg(broadcastToConnIds, 1, 0, "hidden chat final event")).toBe("chat");
+    const finalPayload = requireMockPayload(broadcastToConnIds, 1, 1, "hidden chat final payload");
+    expectPayloadFields(finalPayload, {
+      runId: "run-hidden",
+      sessionKey: "session-hidden",
+      state: "final",
+    });
+    expect(requireMockArg(broadcastToConnIds, 1, 2, "hidden chat final recipients")).toEqual(
+      new Set(["conn-selected"]),
+    );
   });
 
   it("uses agent event sessionKey when run-context lookup cannot resolve", () => {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -18,6 +18,7 @@ import type {
   BufferedAgentEvent,
   ChatRunState,
   SessionEventSubscriberRegistry,
+  SessionMessageSubscriberRegistry,
   ToolEventRecipientRegistry,
 } from "./server-chat-state.js";
 import { loadGatewaySessionRow } from "./server-chat.load-gateway-session-row.runtime.js";
@@ -217,6 +218,7 @@ export type AgentEventHandlerOptions = {
   clearAgentRunContext: (runId: string) => void;
   toolEventRecipients: ToolEventRecipientRegistry;
   sessionEventSubscribers: SessionEventSubscriberRegistry;
+  sessionMessageSubscribers: SessionMessageSubscriberRegistry;
   loadGatewaySessionRowForSnapshot?: typeof loadGatewaySessionRow;
   lifecycleErrorRetryGraceMs?: number;
   isChatSendRunActive?: (runId: string) => boolean;
@@ -233,6 +235,7 @@ export function createAgentEventHandler({
   clearAgentRunContext,
   toolEventRecipients,
   sessionEventSubscribers,
+  sessionMessageSubscribers,
   loadGatewaySessionRowForSnapshot = loadGatewaySessionRow,
   lifecycleErrorRetryGraceMs = AGENT_LIFECYCLE_ERROR_RETRY_GRACE_MS,
   isChatSendRunActive = () => false,
@@ -398,7 +401,7 @@ export function createAgentEventHandler({
     const isAborted =
       chatRunState.abortedRuns.has(clientRunId) || chatRunState.abortedRuns.has(evt.runId);
 
-    if (isControlUiVisible && sessionKey) {
+    if (sessionKey && (isControlUiVisible || sessionMessageSubscribers.get(sessionKey).size > 0)) {
       if (!isAborted) {
         const evtStopReason =
           typeof evt.data?.stopReason === "string" ? evt.data.stopReason : undefined;
@@ -420,6 +423,7 @@ export function createAgentEventHandler({
               evt.data?.error,
               evtStopReason,
               evtErrorKind,
+              { controlUiVisible: isControlUiVisible },
             );
           }
         } else if (!(opts?.skipChatErrorFinal && lifecyclePhase === "error")) {
@@ -432,6 +436,7 @@ export function createAgentEventHandler({
             evt.data?.error,
             evtStopReason,
             evtErrorKind,
+            { controlUiVisible: isControlUiVisible },
           );
         }
       } else {
@@ -493,6 +498,7 @@ export function createAgentEventHandler({
     seq: number,
     text: string,
     delta?: unknown,
+    opts?: { controlUiVisible?: boolean },
   ) => {
     const cleaned = normalizeLiveAssistantEventText({ text, delta });
     const previousRawText = chatRunState.rawBuffers.get(clientRunId) ?? "";
@@ -544,8 +550,10 @@ export function createAgentEventHandler({
         timestamp: now,
       },
     };
-    broadcast("chat", payload, { dropIfSlow: true });
-    nodeSendToSession(sessionKey, "chat", payload);
+    sendChatPayload(sessionKey, payload, {
+      controlUiVisible: opts?.controlUiVisible ?? true,
+      dropIfSlow: true,
+    });
   };
 
   const resolveBufferedChatTextState = (
@@ -575,6 +583,7 @@ export function createAgentEventHandler({
     clientRunId: string,
     sourceRunId: string,
     seq: number,
+    opts?: { controlUiVisible?: boolean },
   ) => {
     const { text, shouldSuppressSilent } = resolveBufferedChatTextState(clientRunId, sourceRunId, {
       suppressLeadFragments: true,
@@ -610,11 +619,29 @@ export function createAgentEventHandler({
         timestamp: now,
       },
     };
-    broadcast("chat", flushPayload, { dropIfSlow: true });
-    nodeSendToSession(sessionKey, "chat", flushPayload);
+    sendChatPayload(sessionKey, flushPayload, {
+      controlUiVisible: opts?.controlUiVisible ?? true,
+      dropIfSlow: true,
+    });
     chatRunState.deltaLastBroadcastLen.set(clientRunId, text.length);
     chatRunState.deltaLastBroadcastText.set(clientRunId, text);
     chatRunState.deltaSentAt.set(clientRunId, now);
+  };
+
+  const sendChatPayload = (
+    sessionKey: string,
+    payload: unknown,
+    opts?: { controlUiVisible?: boolean; dropIfSlow?: boolean },
+  ) => {
+    if (opts?.controlUiVisible ?? true) {
+      broadcast("chat", payload, { dropIfSlow: opts?.dropIfSlow });
+      nodeSendToSession(sessionKey, "chat", payload);
+      return;
+    }
+    const recipients = sessionMessageSubscribers.get(sessionKey);
+    if (recipients.size > 0) {
+      broadcastToConnIds("chat", payload, recipients, { dropIfSlow: opts?.dropIfSlow });
+    }
   };
 
   const emitChatFinal = (
@@ -626,6 +653,7 @@ export function createAgentEventHandler({
     error?: unknown,
     stopReason?: string,
     errorKind?: ErrorKind,
+    opts?: { controlUiVisible?: boolean },
   ) => {
     const { text, shouldSuppressSilent } = resolveBufferedChatTextState(clientRunId, sourceRunId, {
       suppressLeadFragments: false,
@@ -634,7 +662,7 @@ export function createAgentEventHandler({
     // before the final event. The 150 ms throttle in emitChatDelta may have
     // suppressed the most recent chunk, leaving the client with stale text.
     // Only flush if the buffered text differs from the last broadcast to avoid duplicates.
-    flushBufferedChatDeltaIfNeeded(sessionKey, clientRunId, sourceRunId, seq);
+    flushBufferedChatDeltaIfNeeded(sessionKey, clientRunId, sourceRunId, seq, opts);
     chatRunState.deltaLastBroadcastLen.delete(clientRunId);
     chatRunState.deltaLastBroadcastText.delete(clientRunId);
     chatRunState.rawBuffers.delete(clientRunId);
@@ -659,8 +687,7 @@ export function createAgentEventHandler({
               }
             : undefined,
       };
-      broadcast("chat", payload);
-      nodeSendToSession(sessionKey, "chat", payload);
+      sendChatPayload(sessionKey, payload, opts);
       return;
     }
     const payload = {
@@ -672,15 +699,34 @@ export function createAgentEventHandler({
       errorMessage: error ? formatForLog(error) : undefined,
       ...(errorKind && { errorKind }),
     };
-    broadcast("chat", payload);
-    nodeSendToSession(sessionKey, "chat", payload);
+    sendChatPayload(sessionKey, payload, opts);
   };
 
   const sendAgentPayload = (
     sessionKey: string | undefined,
     payload: AgentEventPayload & { spawnedBy?: string },
+    opts?: { controlUiVisible?: boolean; dropIfSlow?: boolean },
   ) => {
-    broadcast("agent", payload);
+    if (opts?.controlUiVisible ?? true) {
+      broadcast("agent", payload);
+      if (sessionKey) {
+        nodeSendToSession(sessionKey, "agent", payload);
+      }
+      return;
+    }
+    if (!sessionKey) {
+      return;
+    }
+    const recipients = sessionMessageSubscribers.get(sessionKey);
+    if (recipients.size > 0) {
+      broadcastToConnIds("agent", payload, recipients, { dropIfSlow: opts?.dropIfSlow });
+    }
+  };
+
+  const sendNodeAgentPayload = (
+    sessionKey: string | undefined,
+    payload: AgentEventPayload & { spawnedBy?: string },
+  ) => {
     if (sessionKey) {
       nodeSendToSession(sessionKey, "agent", payload);
     }
@@ -853,6 +899,9 @@ export function createAgentEventHandler({
           ...eventForClients,
           ...(isHeartbeat !== undefined && { isHeartbeat }),
         };
+    const hasSessionMessageSubscribers = sessionKey
+      ? sessionMessageSubscribers.get(sessionKey).size > 0
+      : false;
     const last = agentRunSeq.get(evt.runId) ?? 0;
     const isToolEvent = evt.stream === "tool";
     const isItemEvent = evt.stream === "item";
@@ -894,12 +943,14 @@ export function createAgentEventHandler({
       // render complete pre-tool text above tool cards (not truncated by delta throttle).
       if (
         toolPhase === "start" &&
-        isControlUiVisible &&
+        (isControlUiVisible || hasSessionMessageSubscribers) &&
         sessionKey &&
         !isAborted &&
         !suppressHeartbeatToolEvents
       ) {
-        flushBufferedChatDeltaIfNeeded(sessionKey, clientRunId, evt.runId, evt.seq);
+        flushBufferedChatDeltaIfNeeded(sessionKey, clientRunId, evt.runId, evt.seq, {
+          controlUiVisible: isControlUiVisible,
+        });
         flushBufferedAgentDeltaIfNeeded(clientRunId);
       }
       // Always broadcast tool events to registered WS recipients with
@@ -912,6 +963,13 @@ export function createAgentEventHandler({
           "agent",
           sessionKey ? { ...agentPayload, ...buildSessionEventSnapshot(sessionKey) } : agentPayload,
           recipients,
+        );
+      }
+      if (!isControlUiVisible && sessionKey && !suppressHeartbeatToolEvents) {
+        sendAgentPayload(
+          sessionKey,
+          { ...agentPayload, ...buildSessionEventSnapshot(sessionKey) },
+          { controlUiVisible: false, dropIfSlow: true },
         );
       }
       // Session subscribers power operator UIs that attach to an existing
@@ -939,9 +997,15 @@ export function createAgentEventHandler({
       }
     } else {
       const itemPhase = isItemEvent && typeof evt.data?.phase === "string" ? evt.data.phase : "";
-      if (itemPhase === "start" && isControlUiVisible && !isAborted) {
+      if (
+        itemPhase === "start" &&
+        (isControlUiVisible || hasSessionMessageSubscribers) &&
+        !isAborted
+      ) {
         if (sessionKey) {
-          flushBufferedChatDeltaIfNeeded(sessionKey, clientRunId, evt.runId, evt.seq);
+          flushBufferedChatDeltaIfNeeded(sessionKey, clientRunId, evt.runId, evt.seq, {
+            controlUiVisible: isControlUiVisible,
+          });
         }
         flushBufferedAgentDeltaIfNeeded(clientRunId);
       }
@@ -950,7 +1014,7 @@ export function createAgentEventHandler({
           sendOrBufferAgentTextEvent(clientRunId, sessionKey, agentPayload);
         } else {
           flushBufferedAgentDeltaIfNeeded(clientRunId);
-          sendAgentPayload(sessionKey, agentPayload);
+          sendAgentPayload(sessionKey, agentPayload, { controlUiVisible: isControlUiVisible });
           const textThrottleStream = resolveAgentTextThrottleStream(evt);
           if (textThrottleStream && shouldAdvanceAgentTextThrottle(evt)) {
             chatRunState.agentDeltaSentAt.set(
@@ -962,13 +1026,17 @@ export function createAgentEventHandler({
       }
     }
 
-    if (isControlUiVisible && sessionKey) {
+    if ((isControlUiVisible || hasSessionMessageSubscribers) && sessionKey) {
       // Send tool events to node/channel subscribers only when verbose is enabled;
       // WS clients already received the event above via broadcastToConnIds.
-      if (isToolEvent && !suppressHeartbeatToolEvents && toolVerbose !== "off") {
-        nodeSendToSession(
+      if (
+        isControlUiVisible &&
+        isToolEvent &&
+        !suppressHeartbeatToolEvents &&
+        toolVerbose !== "off"
+      ) {
+        sendNodeAgentPayload(
           sessionKey,
-          "agent",
           projectToolSearchCodeEventForChannelPayload({
             ...channelToolPayload,
             ...buildSessionEventSnapshot(sessionKey),
@@ -981,7 +1049,9 @@ export function createAgentEventHandler({
         typeof evt.data?.text === "string" &&
         !shouldSuppressAssistantEventForLiveChat(evt.data)
       ) {
-        emitChatDelta(sessionKey, clientRunId, evt.runId, evt.seq, evt.data.text, evt.data.delta);
+        emitChatDelta(sessionKey, clientRunId, evt.runId, evt.seq, evt.data.text, evt.data.delta, {
+          controlUiVisible: isControlUiVisible,
+        });
       }
     }
 

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -44,6 +44,7 @@ export function startGatewayEventSubscriptions(params: {
         clearAgentRunContext,
         toolEventRecipients: params.toolEventRecipients,
         sessionEventSubscribers: params.sessionEventSubscribers,
+        sessionMessageSubscribers: params.sessionMessageSubscribers,
         isChatSendRunActive: (runId) => {
           const entry = params.chatAbortControllers.get(runId);
           return entry !== undefined && entry.kind !== "agent";

--- a/src/gateway/session-message-events.test.ts
+++ b/src/gateway/session-message-events.test.ts
@@ -585,6 +585,61 @@ describe("session.message websocket events", () => {
     });
   });
 
+  test("derives message sequence for selected-session transcript subscribers", async () => {
+    const storePath = await createSessionStoreFile();
+    const transcriptPath = path.join(path.dirname(storePath), "selected-session.jsonl");
+    await writeSessionStore({
+      entries: {
+        main: {
+          sessionId: "sess-main",
+          sessionFile: transcriptPath,
+          updatedAt: Date.now(),
+        },
+      },
+      storePath,
+    });
+    const transcriptMessage = {
+      role: "user",
+      content: [{ type: "text", text: "early selected prompt" }],
+      timestamp: Date.now(),
+    };
+    await fs.writeFile(
+      transcriptPath,
+      [
+        JSON.stringify({ type: "session", version: 1, id: "sess-main" }),
+        JSON.stringify({ id: "msg-selected", message: transcriptMessage }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const ws = await harness.openWs();
+    try {
+      await connectOk(ws, { scopes: ["operator.read"] });
+      const subscribeRes = await rpcReq(ws, "sessions.messages.subscribe", {
+        key: "main",
+      });
+      expect(subscribeRes.ok).toBe(true);
+      expect(subscribeRes.payload?.key).toBe("agent:main:main");
+
+      const messageEventPromise = waitForSessionMessageEvent(ws, "agent:main:main");
+      emitSessionTranscriptUpdate({
+        sessionFile: transcriptPath,
+        sessionKey: "agent:main:main",
+        message: transcriptMessage,
+        messageId: "msg-selected",
+      });
+
+      const messageEvent = await messageEventPromise;
+      expectRecordFields(messageEvent.payload, {
+        sessionKey: "agent:main:main",
+        messageId: "msg-selected",
+        messageSeq: 1,
+      });
+    } finally {
+      ws.close();
+    }
+  });
+
   test("includes spawnedBy metadata on session.message transcript events", async () => {
     const storePath = await createSessionStoreFile();
     const transcriptPath = path.join(path.dirname(storePath), "sess-child.jsonl");

--- a/ui/src/ui/app-gateway-chat-load.node.test.ts
+++ b/ui/src/ui/app-gateway-chat-load.node.test.ts
@@ -109,6 +109,7 @@ vi.mock("./controllers/sessions.ts", () => ({
   applySessionsChangedEvent: vi.fn(() => ({ applied: false })),
   loadSessions: vi.fn(async () => undefined),
   subscribeSessions: subscribeSessionsMock,
+  syncSelectedSessionMessageSubscription: vi.fn(),
 }));
 
 afterAll(() => {

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -56,6 +56,7 @@ vi.mock("./controllers/sessions.ts", () => ({
   applySessionsChangedEvent: applySessionsChangedEventMock,
   loadSessions: loadSessionsMock,
   subscribeSessions: vi.fn(),
+  syncSelectedSessionMessageSubscription: vi.fn(),
 }));
 vi.mock("./gateway.ts", () => ({
   GatewayBrowserClient: function GatewayBrowserClient() {},

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -529,6 +529,23 @@ describe("handleGatewayEvent session.message", () => {
     expect(loadChatHistoryMock).toHaveBeenCalledWith(host);
   });
 
+  it("reloads chat history when the selected main session receives canonical session messages", () => {
+    loadChatHistoryMock.mockReset();
+    applySessionsChangedEventMock.mockReset().mockReturnValue({ applied: false });
+    const host = createHost();
+    host.sessionKey = "main";
+
+    handleGatewayEvent(host, {
+      type: "event",
+      event: "session.message",
+      payload: { sessionKey: "agent:main:main" },
+      seq: 1,
+    });
+
+    expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
+    expect(loadChatHistoryMock).toHaveBeenCalledWith(host);
+  });
+
   it("reloads history before flushing queue when session.message clears the run", async () => {
     loadChatHistoryMock.mockReset();
     clearPendingQueueItemsForRunMock.mockReset();

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -66,7 +66,12 @@ import {
 } from "./gateway.ts";
 import { GatewayBrowserClient } from "./gateway.ts";
 import type { Tab } from "./navigation.ts";
-import { buildAgentMainSessionKey, normalizeAgentId, parseAgentSessionKey } from "./session-key.ts";
+import {
+  areUiSessionKeysEquivalent,
+  buildAgentMainSessionKey,
+  normalizeAgentId,
+  parseAgentSessionKey,
+} from "./session-key.ts";
 import type { UiSettings } from "./storage.ts";
 import type {
   AgentsListResult,
@@ -760,10 +765,10 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
   const shouldResolveDeferredSessionMessageReload = Boolean(
     deferredSessionKey &&
     payloadSessionKey &&
-    deferredSessionKey === payloadSessionKey &&
+    areUiSessionKeysEquivalent(deferredSessionKey, payloadSessionKey) &&
     isTerminalChatState(state) &&
     !terminalEventIsForDifferentActiveRun &&
-    payloadSessionKey === host.sessionKey &&
+    areUiSessionKeysEquivalent(payloadSessionKey, host.sessionKey) &&
     !host.chatRunId,
   );
   const shouldReplayDeferredSessionMessageReload =
@@ -815,13 +820,13 @@ function flushChatQueueAfterSessionRunReconcile(
   const eventSessionKey = typeof payload?.sessionKey === "string" ? payload.sessionKey.trim() : "";
   if (
     pendingSessionKey &&
-    pendingSessionKey === host.sessionKey &&
-    (!eventSessionKey || eventSessionKey === pendingSessionKey)
+    areUiSessionKeysEquivalent(pendingSessionKey, host.sessionKey) &&
+    (!eventSessionKey || areUiSessionKeysEquivalent(eventSessionKey, pendingSessionKey))
   ) {
     deferredReloadHost.pendingSessionMessageReloadSessionKey = null;
     const reloadSessionKey = pendingSessionKey;
     void Promise.resolve(loadChatHistory(host as unknown as ChatState)).finally(() => {
-      if (host.sessionKey === reloadSessionKey) {
+      if (areUiSessionKeysEquivalent(host.sessionKey, reloadSessionKey)) {
         publishRunStatus();
         flushQueue();
       }
@@ -839,17 +844,20 @@ function handleSessionMessageGatewayEvent(
 ) {
   const deferredReloadHost = host as GatewayHostWithDeferredSessionMessageReload;
   const sessionKey = payload?.sessionKey?.trim();
+  const sessionMatchesHost = Boolean(
+    sessionKey && areUiSessionKeysEquivalent(sessionKey, host.sessionKey),
+  );
   const runIdBeforeApply = host.chatRunId;
   const result = applySessionsChangedEvent(host as unknown as SessionsState, payload);
   if (result.applied && result.clearedChatRun) {
-    if (sessionKey && sessionKey === host.sessionKey) {
+    if (sessionMatchesHost) {
       deferredReloadHost.pendingSessionMessageReloadSessionKey = sessionKey;
     }
     if (flushChatQueueAfterSessionRunReconcile(host, result, payload, runIdBeforeApply)) {
       return;
     }
   }
-  if (!sessionKey || sessionKey !== host.sessionKey) {
+  if (!sessionKey || !sessionMatchesHost) {
     return;
   }
   // Skip history reload while a chat run is active. The chat event handler
@@ -886,8 +894,11 @@ function replayDeferredSessionMessageReloadAfterSessionsRefresh(
 ) {
   const deferredReloadHost = host as GatewayHostWithDeferredSessionMessageReload;
   if (
-    deferredReloadHost.pendingSessionMessageReloadSessionKey?.trim() !== sessionKey ||
-    host.sessionKey !== sessionKey
+    !areUiSessionKeysEquivalent(
+      deferredReloadHost.pendingSessionMessageReloadSessionKey?.trim() ?? "",
+      sessionKey,
+    ) ||
+    !areUiSessionKeysEquivalent(host.sessionKey, sessionKey)
   ) {
     return;
   }
@@ -909,8 +920,8 @@ function replayDeferredSessionMessageReloadAfterSessionsRefresh(
     }
     return;
   }
-  const row = (host as unknown as SessionsState).sessionsResult?.sessions.find(
-    (session) => session.key === sessionKey,
+  const row = (host as unknown as SessionsState).sessionsResult?.sessions.find((session) =>
+    areUiSessionKeysEquivalent(session.key, sessionKey),
   );
   flushChatQueueAfterSessionRunReconcile(
     host,

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -56,6 +56,7 @@ import {
   applySessionsChangedEvent,
   loadSessions,
   subscribeSessions,
+  syncSelectedSessionMessageSubscription,
   type SessionsState,
 } from "./controllers/sessions.ts";
 import {
@@ -588,6 +589,10 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
         );
       }
       void subscribeSessions(host as unknown as SessionsState);
+      void syncSelectedSessionMessageSubscription(
+        host as unknown as SessionsState & { sessionKey: string },
+        { force: true },
+      );
       void loadAssistantIdentity(host as unknown as AssistantIdentityState);
       if (host.tab !== "chat") {
         void refreshChatAvatar(host as unknown as Parameters<typeof refreshChatAvatar>[0]);

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -7,6 +7,7 @@ const {
   loadChatHistoryMock,
   createSessionAndRefreshMock,
   loadSessionsMock,
+  syncSelectedSessionMessageSubscriptionMock,
 } = vi.hoisted(() => ({
   refreshChatMock: vi.fn(),
   refreshChatAvatarMock: vi.fn(),
@@ -14,6 +15,7 @@ const {
   loadChatHistoryMock: vi.fn(),
   createSessionAndRefreshMock: vi.fn(),
   loadSessionsMock: vi.fn(),
+  syncSelectedSessionMessageSubscriptionMock: vi.fn(),
 }));
 
 vi.mock("./app-chat.ts", () => ({
@@ -41,6 +43,7 @@ vi.mock("./controllers/chat.ts", () => ({
 vi.mock("./controllers/sessions.ts", () => ({
   createSessionAndRefresh: createSessionAndRefreshMock,
   loadSessions: loadSessionsMock,
+  syncSelectedSessionMessageSubscription: syncSelectedSessionMessageSubscriptionMock,
 }));
 
 import {
@@ -67,6 +70,7 @@ beforeEach(() => {
   loadChatHistoryMock.mockReset();
   createSessionAndRefreshMock.mockReset();
   loadSessionsMock.mockReset();
+  syncSelectedSessionMessageSubscriptionMock.mockReset();
 });
 
 function row(overrides: Partial<SessionRow> & { key: string }): SessionRow {
@@ -977,6 +981,7 @@ describe("switchChatSession", () => {
       agentId: "main",
     });
     expect(loadChatHistoryMock).toHaveBeenCalledWith(state);
+    expect(syncSelectedSessionMessageSubscriptionMock).toHaveBeenCalledWith(state);
     expect(loadSessionsMock).toHaveBeenCalledWith(state, {
       activeMinutes: 120,
       limit: 50,

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -11,7 +11,11 @@ import {
 import { refreshSlashCommands } from "./chat/slash-commands.ts";
 import { resolveControlUiAuthToken } from "./control-ui-auth.ts";
 import { ChatState, loadChatHistory } from "./controllers/chat.ts";
-import { createSessionAndRefresh, loadSessions } from "./controllers/sessions.ts";
+import {
+  createSessionAndRefresh,
+  loadSessions,
+  syncSelectedSessionMessageSubscription,
+} from "./controllers/sessions.ts";
 import { icons } from "./icons.ts";
 import { iconForTab, isSettingsTab, pathForTab, titleForTab, type Tab } from "./navigation.ts";
 import { isCronSessionKey, parseSessionKey, resolveSessionDisplayName } from "./session-display.ts";
@@ -650,6 +654,9 @@ export function switchChatSession(state: AppViewState, nextSessionKey: string) {
     state as unknown as Parameters<typeof syncUrlWithSessionKey>[0],
     nextSessionKey,
     true,
+  );
+  void syncSelectedSessionMessageSubscription(
+    state as unknown as AppViewState & { chatSessionMessageSubscriptionKey?: string | null },
   );
   void loadChatHistory(state as unknown as ChatState);
   void refreshSessionOptions(state);

--- a/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
+++ b/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
@@ -121,6 +121,7 @@ vi.mock("./controllers/presence.ts", () => ({
 }));
 vi.mock("./controllers/sessions.ts", () => ({
   loadSessions: mocks.loadSessionsMock,
+  syncSelectedSessionMessageSubscription: vi.fn(),
 }));
 vi.mock("./controllers/skills.ts", () => ({
   loadSkills: mocks.loadSkillsMock,

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -88,6 +88,7 @@ export type AppViewState = {
   allowExternalEmbedUrls: boolean;
   chatMessageMaxWidth?: string | null;
   sessionKey: string;
+  chatSessionMessageSubscriptionKey?: string | null;
   chatLoading: boolean;
   chatSending: boolean;
   chatMessage: string;

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -89,6 +89,7 @@ export type AppViewState = {
   chatMessageMaxWidth?: string | null;
   sessionKey: string;
   chatSessionMessageSubscriptionKey?: string | null;
+  chatSessionMessageSubscriptionRequestedKey?: string | null;
   chatLoading: boolean;
   chatSending: boolean;
   chatMessage: string;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -208,6 +208,7 @@ export class OpenClawApp extends LitElement {
   @state() serverVersion: string | null = null;
 
   @state() sessionKey = this.settings.sessionKey;
+  chatSessionMessageSubscriptionKey: string | null = null;
   currentSessionId: string | null = null;
   @state() chatLoading = false;
   @state() chatSending = false;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -209,6 +209,7 @@ export class OpenClawApp extends LitElement {
 
   @state() sessionKey = this.settings.sessionKey;
   chatSessionMessageSubscriptionKey: string | null = null;
+  chatSessionMessageSubscriptionRequestedKey: string | null = null;
   currentSessionId: string | null = null;
   @state() chatLoading = false;
   @state() chatSending = false;

--- a/ui/src/ui/chat/build-chat-items.test.ts
+++ b/ui/src/ui/chat/build-chat-items.test.ts
@@ -198,6 +198,29 @@ describe("buildChatItems", () => {
     ]);
   });
 
+  it("deduplicates accumulated stream snapshots around tool cards", () => {
+    const items = buildChatItems(
+      createProps({
+        streamSegments: [
+          { text: "First thought.", ts: 1 },
+          { text: "First thought. After tool.", ts: 3 },
+        ],
+        toolMessages: [
+          { role: "toolResult", content: "Tool one", timestamp: 2 },
+          { role: "toolResult", content: "Tool two", timestamp: 4 },
+        ],
+        stream: "First thought. After tool. Final sentence.",
+        streamStartedAt: 5,
+      }),
+    );
+
+    expect(items.filter((item) => item.kind === "stream")).toMatchObject([
+      { text: "First thought." },
+      { text: "After tool." },
+      { text: "Final sentence." },
+    ]);
+  });
+
   it("suppresses metadata-only history messages before grouping", () => {
     const groups = messageGroups({
       messages: [

--- a/ui/src/ui/chat/build-chat-items.ts
+++ b/ui/src/ui/chat/build-chat-items.ts
@@ -285,6 +285,13 @@ function sanitizeStreamText(text: string): string {
   return stripped.trim().length > 0 ? stripped : "";
 }
 
+function trimAccumulatedStreamPrefix(text: string, previousText: string | null): string {
+  if (!previousText || !text.startsWith(previousText)) {
+    return text;
+  }
+  return text.slice(previousText.length).trimStart();
+}
+
 function rawMessageTimestamp(message: unknown): number | null {
   const timestamp = asRecord(message)?.timestamp;
   return typeof timestamp === "number" && Number.isFinite(timestamp) ? timestamp : null;
@@ -551,14 +558,19 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
   );
   const segments = props.streamSegments ?? [];
   const maxLen = Math.max(segments.length, tools.length);
+  let previousAccumulatedStreamText: string | null = null;
   for (let i = 0; i < maxLen; i++) {
     if (i < segments.length) {
       const text = sanitizeStreamText(segments[i].text);
+      const visibleText = trimAccumulatedStreamPrefix(text, previousAccumulatedStreamText);
       if (text.length > 0) {
+        previousAccumulatedStreamText = text;
+      }
+      if (visibleText.length > 0) {
         items.push({
           kind: "stream",
           key: `stream-seg:${props.sessionKey}:${i}`,
-          text,
+          text: visibleText,
           startedAt: segments[i].ts,
         });
       }
@@ -575,12 +587,13 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
   if (props.stream !== null) {
     const key = `stream:${props.sessionKey}:${props.streamStartedAt ?? "live"}`;
     const text = sanitizeStreamText(props.stream);
-    if (text.length > 0) {
-      if (!stripHeartbeatTokenForDisplay(text).shouldSkip) {
+    const visibleText = trimAccumulatedStreamPrefix(text, previousAccumulatedStreamText);
+    if (visibleText.length > 0) {
+      if (!stripHeartbeatTokenForDisplay(visibleText).shouldSkip) {
         items.push({
           kind: "stream",
           key,
-          text,
+          text: visibleText,
           startedAt: props.streamStartedAt ?? Date.now(),
         });
       }

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -157,6 +157,29 @@ describe("handleChatEvent", () => {
     expect(state.chatStreamStartedAt).toEqual(expect.any(Number));
   });
 
+  it("adopts the run id when the selected main alias receives canonical live deltas", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: null,
+      chatStream: null,
+      chatStreamStartedAt: null,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-canonical-main",
+      sessionKey: "agent:main:main",
+      state: "delta",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Canonical reply" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("delta");
+    expect(state.chatRunId).toBe("run-canonical-main");
+    expect(state.chatStream).toBe("Canonical reply");
+    expect(state.chatStreamStartedAt).toEqual(expect.any(Number));
+  });
+
   it("accepts final events for the active run when gateway emits a canonical session key", () => {
     const state = createState({
       sessionKey: "main",

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -134,6 +134,29 @@ describe("handleChatEvent", () => {
     expect(state.chatRunId).toBe("run-1");
   });
 
+  it("adopts the run id for selected-session live deltas observed from another channel", () => {
+    const state = createState({
+      sessionKey: "agent:main:feishu:direct:peer-1",
+      chatRunId: null,
+      chatStream: null,
+      chatStreamStartedAt: null,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-feishu-1",
+      sessionKey: "agent:main:feishu:direct:peer-1",
+      state: "delta",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Observed reply" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("delta");
+    expect(state.chatRunId).toBe("run-feishu-1");
+    expect(state.chatStream).toBe("Observed reply");
+    expect(state.chatStreamStartedAt).toEqual(expect.any(Number));
+  });
+
   it("accepts final events for the active run when gateway emits a canonical session key", () => {
     const state = createState({
       sessionKey: "main",

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -11,6 +11,7 @@ import { extractText } from "../chat/message-extract.ts";
 import { reconcileChatRunLifecycle } from "../chat/run-lifecycle.ts";
 import { formatConnectError } from "../connect-error.ts";
 import { GatewayRequestError, type GatewayBrowserClient } from "../gateway.ts";
+import { areUiSessionKeysEquivalent } from "../session-key.ts";
 import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
 import type { ChatAttachment } from "../ui-types.ts";
 import { generateUUID } from "../uuid.ts";
@@ -662,7 +663,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   if (!payload) {
     return null;
   }
-  const sessionMatches = payload.sessionKey === state.sessionKey;
+  const sessionMatches = areUiSessionKeysEquivalent(payload.sessionKey, state.sessionKey);
   const activeRunMatches =
     state.chatRunId !== null &&
     typeof payload.runId === "string" &&
@@ -700,7 +701,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
       sessionStatus,
       runId: terminalRunId,
       sessionKey: state.sessionKey,
-      sessionKeys: payload.sessionKey === state.sessionKey ? [payload.sessionKey] : [],
+      sessionKeys: sessionMatches ? [state.sessionKey, payload.sessionKey] : [],
       clearLocalRun: true,
       clearChatStream: true,
     });

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -670,6 +670,10 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   if (!sessionMatches && !activeRunMatches) {
     return null;
   }
+  if (!state.chatRunId && sessionMatches && typeof payload.runId === "string") {
+    state.chatRunId = payload.runId;
+    state.chatStreamStartedAt ??= Date.now();
+  }
 
   // Terminal events for the active client run carry runId; missing-runId events are unowned.
   // Final from another run (e.g. sub-agent announce): refresh history to show new message.

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -5,6 +5,7 @@ import {
   deleteSessionsAndRefresh,
   loadSessions,
   subscribeSessions,
+  syncSelectedSessionMessageSubscription,
   type SessionsState,
 } from "./sessions.ts";
 
@@ -52,6 +53,42 @@ describe("subscribeSessions", () => {
 
     expect(request).toHaveBeenCalledWith("sessions.subscribe", {});
     expect(state.sessionsError).toBeNull();
+  });
+});
+
+describe("syncSelectedSessionMessageSubscription", () => {
+  it("subscribes to the selected session message stream", async () => {
+    const request = vi.fn(async () => ({ key: "agent:main:main" }));
+    const state = createState(request, { sessionKey: "agent:main:main" } as Partial<
+      SessionsState & { sessionKey: string }
+    >) as SessionsState & { sessionKey: string };
+
+    await syncSelectedSessionMessageSubscription(state);
+
+    expect(request).toHaveBeenCalledWith("sessions.messages.subscribe", {
+      key: "agent:main:main",
+    });
+    expect(state.chatSessionMessageSubscriptionKey).toBe("agent:main:main");
+  });
+
+  it("unsubscribes the previous selected session before switching streams", async () => {
+    const request = vi.fn(async () => ({ key: "agent:main:next" }));
+    const state = createState(request, {
+      sessionKey: "agent:main:next",
+      chatSessionMessageSubscriptionKey: "agent:main:previous",
+    } as Partial<SessionsState & { sessionKey: string }>) as SessionsState & {
+      sessionKey: string;
+    };
+
+    await syncSelectedSessionMessageSubscription(state);
+
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.messages.unsubscribe", {
+      key: "agent:main:previous",
+    });
+    expect(request).toHaveBeenNthCalledWith(2, "sessions.messages.subscribe", {
+      key: "agent:main:next",
+    });
+    expect(state.chatSessionMessageSubscriptionKey).toBe("agent:main:next");
   });
 });
 

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -11,6 +11,19 @@ import {
 
 type RequestFn = (method: string, params?: unknown) => Promise<unknown>;
 
+function createDeferred<T>() {
+  let resolve: ((value: T) => void) | undefined;
+  let reject: ((reason?: unknown) => void) | undefined;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  if (!resolve || !reject) {
+    throw new Error("Expected deferred callbacks to be initialized");
+  }
+  return { promise, resolve, reject };
+}
+
 if (!("window" in globalThis)) {
   Object.assign(globalThis, {
     window: {
@@ -69,6 +82,7 @@ describe("syncSelectedSessionMessageSubscription", () => {
       key: "agent:main:main",
     });
     expect(state.chatSessionMessageSubscriptionKey).toBe("agent:main:main");
+    expect(state.chatSessionMessageSubscriptionRequestedKey).toBe("agent:main:main");
   });
 
   it("unsubscribes the previous selected session before switching streams", async () => {
@@ -89,6 +103,61 @@ describe("syncSelectedSessionMessageSubscription", () => {
       key: "agent:main:next",
     });
     expect(state.chatSessionMessageSubscriptionKey).toBe("agent:main:next");
+    expect(state.chatSessionMessageSubscriptionRequestedKey).toBe("agent:main:next");
+  });
+
+  it("does not churn when the selected alias resolves to a canonical key", async () => {
+    const request = vi.fn(async () => ({ key: "agent:main:main" }));
+    const state = createState(request, { sessionKey: "main" } as Partial<
+      SessionsState & { sessionKey: string }
+    >) as SessionsState & { sessionKey: string };
+
+    await syncSelectedSessionMessageSubscription(state);
+    await syncSelectedSessionMessageSubscription(state);
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith("sessions.messages.subscribe", { key: "main" });
+    expect(state.chatSessionMessageSubscriptionRequestedKey).toBe("main");
+    expect(state.chatSessionMessageSubscriptionKey).toBe("agent:main:main");
+  });
+
+  it("ignores stale subscription completions after the selected session changes", async () => {
+    const firstSubscribe = createDeferred<{ key: string }>();
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      const key = (params as { key?: string } | undefined)?.key;
+      if (method === "sessions.messages.subscribe" && key === "agent:main:first") {
+        return await firstSubscribe.promise;
+      }
+      if (method === "sessions.messages.subscribe" && key === "agent:main:second") {
+        return { key: "agent:main:second" };
+      }
+      if (method === "sessions.messages.unsubscribe") {
+        return { subscribed: false, key };
+      }
+      throw new Error(`unexpected request: ${method} ${String(key)}`);
+    });
+    const state = createState(request, { sessionKey: "agent:main:first" } as Partial<
+      SessionsState & { sessionKey: string }
+    >) as SessionsState & { sessionKey: string };
+
+    const firstSync = syncSelectedSessionMessageSubscription(state);
+    expect(request).toHaveBeenCalledWith("sessions.messages.subscribe", {
+      key: "agent:main:first",
+    });
+
+    state.sessionKey = "agent:main:second";
+    await syncSelectedSessionMessageSubscription(state);
+    expect(state.chatSessionMessageSubscriptionRequestedKey).toBe("agent:main:second");
+    expect(state.chatSessionMessageSubscriptionKey).toBe("agent:main:second");
+
+    firstSubscribe.resolve({ key: "agent:main:first" });
+    await firstSync;
+
+    expect(state.chatSessionMessageSubscriptionRequestedKey).toBe("agent:main:second");
+    expect(state.chatSessionMessageSubscriptionKey).toBe("agent:main:second");
+    expect(request).toHaveBeenCalledWith("sessions.messages.unsubscribe", {
+      key: "agent:main:first",
+    });
   });
 });
 

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -41,6 +41,7 @@ export type SessionsState = SessionsChatRunState & {
   sessionsCheckpointLoadingKey: string | null;
   sessionsCheckpointBusyKey: string | null;
   sessionsCheckpointErrorByKey: Record<string, string>;
+  chatSessionMessageSubscriptionKey?: string | null;
 };
 
 export type LoadSessionsOverrides = {
@@ -482,6 +483,35 @@ export async function subscribeSessions(state: SessionsState) {
   }
   try {
     await state.client.request("sessions.subscribe", {});
+  } catch (err) {
+    state.sessionsError = String(err);
+  }
+}
+
+export async function syncSelectedSessionMessageSubscription(
+  state: SessionsState & { sessionKey: string },
+  opts?: { force?: boolean },
+) {
+  if (!state.client || !state.connected) {
+    return;
+  }
+  const nextKey = state.sessionKey.trim();
+  const previousKey = state.chatSessionMessageSubscriptionKey?.trim() || null;
+  if (!nextKey) {
+    return;
+  }
+  try {
+    if (previousKey && previousKey !== nextKey) {
+      await state.client.request("sessions.messages.unsubscribe", { key: previousKey });
+      state.chatSessionMessageSubscriptionKey = null;
+    }
+    if (opts?.force || state.chatSessionMessageSubscriptionKey !== nextKey) {
+      const result = (await state.client.request("sessions.messages.subscribe", {
+        key: nextKey,
+      })) as { key?: unknown } | undefined;
+      state.chatSessionMessageSubscriptionKey =
+        typeof result?.key === "string" && result.key.trim() ? result.key : nextKey;
+    }
   } catch (err) {
     state.sessionsError = String(err);
   }

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -42,6 +42,7 @@ export type SessionsState = SessionsChatRunState & {
   sessionsCheckpointBusyKey: string | null;
   sessionsCheckpointErrorByKey: Record<string, string>;
   chatSessionMessageSubscriptionKey?: string | null;
+  chatSessionMessageSubscriptionRequestedKey?: string | null;
 };
 
 export type LoadSessionsOverrides = {
@@ -77,11 +78,55 @@ type SessionsLoadControl = {
 };
 
 const sessionsLoadControls = new WeakMap<object, SessionsLoadControl>();
+const selectedSessionMessageSubscriptionGenerations = new WeakMap<object, number>();
 
 function hasCurrentChatSession(
   state: SessionsState,
 ): state is SessionsState & { sessionKey: string } {
   return typeof state.sessionKey === "string" && state.sessionKey.trim() !== "";
+}
+
+function normalizeSubscriptionKey(value: string | null | undefined): string | null {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  return normalized ? normalized : null;
+}
+
+function beginSelectedSessionMessageSubscriptionSync(state: SessionsState): number {
+  const key = state as object;
+  const next = (selectedSessionMessageSubscriptionGenerations.get(key) ?? 0) + 1;
+  selectedSessionMessageSubscriptionGenerations.set(key, next);
+  return next;
+}
+
+function isCurrentSelectedSessionMessageSubscriptionSync(
+  state: SessionsState & { sessionKey: string },
+  params: { generation: number; client: GatewayBrowserClient; requestedKey: string },
+): boolean {
+  return (
+    selectedSessionMessageSubscriptionGenerations.get(state as object) === params.generation &&
+    state.client === params.client &&
+    state.connected &&
+    state.sessionKey.trim() === params.requestedKey
+  );
+}
+
+function readSubscribedSessionMessageKey(result: unknown, fallbackKey: string): string {
+  const key =
+    result && typeof result === "object" && typeof (result as { key?: unknown }).key === "string"
+      ? (result as { key: string }).key.trim()
+      : "";
+  return key || fallbackKey;
+}
+
+async function unsubscribeSelectedSessionMessageBestEffort(
+  client: GatewayBrowserClient,
+  key: string,
+): Promise<void> {
+  try {
+    await client.request("sessions.messages.unsubscribe", { key });
+  } catch {
+    // Best-effort cleanup for stale async subscription completions.
+  }
 }
 
 function sessionPatchTargetsCurrentChatRun(
@@ -495,25 +540,58 @@ export async function syncSelectedSessionMessageSubscription(
   if (!state.client || !state.connected) {
     return;
   }
+  const client = state.client;
   const nextKey = state.sessionKey.trim();
-  const previousKey = state.chatSessionMessageSubscriptionKey?.trim() || null;
   if (!nextKey) {
     return;
   }
+  const generation = beginSelectedSessionMessageSubscriptionSync(state);
+  const previousRequestedKey = normalizeSubscriptionKey(
+    state.chatSessionMessageSubscriptionRequestedKey,
+  );
+  const previousCanonicalKey = normalizeSubscriptionKey(state.chatSessionMessageSubscriptionKey);
+  const previousSelectedKey = previousRequestedKey ?? previousCanonicalKey;
+  const selectedKeyChanged = previousSelectedKey !== null && previousSelectedKey !== nextKey;
+  const shouldUnsubscribePrevious = previousCanonicalKey !== null && selectedKeyChanged;
+  const shouldSubscribe =
+    opts?.force === true ||
+    selectedKeyChanged ||
+    previousCanonicalKey === null ||
+    previousRequestedKey === null;
+  if (!shouldUnsubscribePrevious && !shouldSubscribe) {
+    return;
+  }
+  const isCurrent = () =>
+    isCurrentSelectedSessionMessageSubscriptionSync(state, {
+      generation,
+      client,
+      requestedKey: nextKey,
+    });
   try {
-    if (previousKey && previousKey !== nextKey) {
-      await state.client.request("sessions.messages.unsubscribe", { key: previousKey });
-      state.chatSessionMessageSubscriptionKey = null;
+    if (shouldUnsubscribePrevious && previousCanonicalKey) {
+      await client.request("sessions.messages.unsubscribe", { key: previousCanonicalKey });
+      if (isCurrent()) {
+        state.chatSessionMessageSubscriptionKey = null;
+        state.chatSessionMessageSubscriptionRequestedKey = null;
+      }
     }
-    if (opts?.force || state.chatSessionMessageSubscriptionKey !== nextKey) {
-      const result = (await state.client.request("sessions.messages.subscribe", {
-        key: nextKey,
-      })) as { key?: unknown } | undefined;
-      state.chatSessionMessageSubscriptionKey =
-        typeof result?.key === "string" && result.key.trim() ? result.key : nextKey;
+    if (!shouldSubscribe || !isCurrent()) {
+      return;
     }
+    const result = await client.request("sessions.messages.subscribe", { key: nextKey });
+    const subscribedKey = readSubscribedSessionMessageKey(result, nextKey);
+    if (!isCurrent()) {
+      if (normalizeSubscriptionKey(state.chatSessionMessageSubscriptionKey) !== subscribedKey) {
+        await unsubscribeSelectedSessionMessageBestEffort(client, subscribedKey);
+      }
+      return;
+    }
+    state.chatSessionMessageSubscriptionRequestedKey = nextKey;
+    state.chatSessionMessageSubscriptionKey = subscribedKey;
   } catch (err) {
-    state.sessionsError = String(err);
+    if (isCurrent()) {
+      state.sessionsError = String(err);
+    }
   }
 }
 

--- a/ui/src/ui/session-key.ts
+++ b/ui/src/ui/session-key.ts
@@ -66,6 +66,22 @@ export function buildAgentMainSessionKey(params: {
   return `agent:${agentId}:${mainKey}`;
 }
 
+function normalizeDefaultMainSessionAliasForUi(sessionKey: string | undefined | null): string {
+  const normalized = normalizeLowercaseStringOrEmpty(sessionKey);
+  return normalized === DEFAULT_MAIN_KEY
+    ? buildAgentMainSessionKey({ agentId: DEFAULT_AGENT_ID, mainKey: DEFAULT_MAIN_KEY })
+    : normalized;
+}
+
+export function areUiSessionKeysEquivalent(
+  left: string | undefined | null,
+  right: string | undefined | null,
+): boolean {
+  const normalizedLeft = normalizeDefaultMainSessionAliasForUi(left);
+  const normalizedRight = normalizeDefaultMainSessionAliasForUi(right);
+  return Boolean(normalizedLeft && normalizedRight && normalizedLeft === normalizedRight);
+}
+
 export function resolveAgentIdFromSessionKey(sessionKey: string | undefined | null): string {
   const parsed = parseAgentSessionKey(sessionKey);
   return normalizeAgentId(parsed?.agentId ?? DEFAULT_AGENT_ID);


### PR DESCRIPTION
## Summary

Fixes #83528 and #82611; refs #83949.

- Mirror Codex app-server inbound prompts at turn start with the existing `${turnId}:prompt` identity so WebChat can see external-channel user messages before the turn finishes, while preserving `suppressNextUserMessagePersistence` for already-persisted inbound prompts.
- Keep hidden external-channel live runs private by sending chat/tool/agent updates only to exact selected-session message subscribers instead of broadcasting globally.
- Subscribe Control UI to the selected session message stream on connect/reconnect and session switch, adopt observed run ids for non-WebChat-originated runs including the default main alias/canonical key pair, dedupe accumulated stream snapshots around tool cards, and keep selected-session `session.message` reloads alias-aware.
- Emit stable `messageSeq` values for multi-message Codex mirror batches so selected-session subscribers receive per-message transcript positions instead of post-batch duplicates.

## Real behavior proof

- Behavior addressed: WebChat/Control UI now has durable inbound prompt truth at Codex turn start, selected-session live updates for external-channel runs without unrelated-session leakage, passive run-id adoption and `session.message` handling across the default main alias/canonical key pair, reconnect-safe selected-session subscription state, stable mirrored transcript message sequences, suppression-safe prompt mirroring, and no duplicated accumulated stream text around tool cards.
- Real environment tested: Local OpenClaw Codex worktree on branch `meow/webchat-transcript-run-state-truth`, latest head `23f7c0f47037`.
- Exact steps or command run after this patch:
  - `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -- -t "does not mirror the Codex prompt early when user message persistence is suppressed"`
  - `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/transcript-mirror.test.ts`
  - `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 node scripts/run-vitest.mjs src/gateway/server-chat.agent-events.test.ts src/gateway/session-message-events.test.ts`
  - `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 node scripts/run-vitest.mjs ui/src/ui/controllers/chat.test.ts ui/src/ui/controllers/sessions.test.ts ui/src/ui/chat/build-chat-items.test.ts ui/src/ui/app-gateway.sessions.node.test.ts ui/src/ui/app-render.helpers.node.test.ts ui/src/ui/app-gateway-chat-load.node.test.ts ui/src/ui/app-settings.refresh-active-tab.node.test.ts`
  - `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
  - `node --import tsx scripts/check-no-extension-test-core-imports.ts`
  - `git diff --check origin/main..HEAD`
- Evidence after fix:
  - Suppression regression: failed before the guard because the forbidden prompt appeared; passed after the guard.
  - Codex app-server tests: 2 files passed, 233 tests passed.
  - Gateway/session event tests: 4 files passed, 116 tests passed.
  - Control UI tests: 7 files passed, 238 tests passed.
  - Rebased-base test-type command passed.
  - Boundary check passed: `check-no-extension-test-core-imports` checked 1920 extension files and 1 plugin helper.
  - `git diff --check origin/main..HEAD` passed on latest head.
  - The regressions prove message-bearing prompt transcript updates with message ids and stable sequences, suppressed prompt persistence does not early-mirror a duplicate user row, multi-message mirror batch `messageSeq` `[1, 2]`, selected-session sequence delivery, alias/canonical subscription de-dupe, stale subscription completion cleanup, main-alias `session.message` reloads, and passive main-alias run-id adoption.
- Observed result after fix: The early Codex prompt mirror writes one user transcript row and emits a message-bearing selected-session update before assistant completion only when prompt persistence is not suppressed; final mirrored batches emit correct per-message sequence metadata; hidden external-channel chat events route only to exact selected-session subscribers; selected Control UI sessions subscribe/re-subscribe without alias churn or stale async overwrite; canonical `agent:main:main` transcript events reload selected `main`; passive chat state adopts observed run ids; and accumulated stream snapshots render only their new suffix after tool cards.
- What was not tested: Live Feishu or Telegram external-channel browser proof was not run in this pass. Remote `pnpm check:changed` through Crabbox was attempted before this follow-up but blocked: Blacksmith Testbox is not configured for `.github/workflows/crabbox-hydrate.yml`, and default AWS Crabbox could not refresh credentials because no EC2 IMDS role/credentials were available on this machine.

## Verification

- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -- -t "does not mirror the Codex prompt early when user message persistence is suppressed"`
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/transcript-mirror.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 node scripts/run-vitest.mjs src/gateway/server-chat.agent-events.test.ts src/gateway/session-message-events.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 node scripts/run-vitest.mjs ui/src/ui/controllers/chat.test.ts ui/src/ui/controllers/sessions.test.ts ui/src/ui/chat/build-chat-items.test.ts ui/src/ui/app-gateway.sessions.node.test.ts ui/src/ui/app-render.helpers.node.test.ts ui/src/ui/app-gateway-chat-load.node.test.ts ui/src/ui/app-settings.refresh-active-tab.node.test.ts`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `node --import tsx scripts/check-no-extension-test-core-imports.ts`
- `git diff --check origin/main..HEAD`



