### PR TITLE
fix #85807: retain Telegram preview after generation race

### DIFF
--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -326,16 +326,11 @@ describe("createTelegramDraftStream", () => {
       deleteMessage: vi.fn().mockResolvedValue(true),
     };
     const onSupersededPreview = vi.fn();
-    const stream = createTelegramDraftStream({
-      api: api as unknown as Bot["api"],
-      chatId: 123,
-      onSupersededPreview,
-    });
+    const stream = createDraftStream(api, { onSupersededPreview });
 
     stream.update("Message A partial");
     await vi.waitFor(() => expect(api.sendMessage).toHaveBeenCalledTimes(1));
 
-    // Rotate to message B before message A send resolves.
     stream.forceNewMessage();
     stream.update("Message B partial");
 

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -315,7 +315,7 @@ describe("createTelegramDraftStream", () => {
     }
   });
 
-  it("does not rebind to an old message when forceNewMessage races an in-flight send", async () => {
+  it("retains an old message when forceNewMessage races an in-flight send", async () => {
     let resolveFirstSend: ((value: { message_id: number }) => void) | undefined;
     const firstSend = new Promise<{ message_id: number }>((resolve) => {
       resolveFirstSend = resolve;
@@ -349,6 +349,7 @@ describe("createTelegramDraftStream", () => {
       textSnapshot: "Message A partial",
       parseMode: undefined,
       visibleSinceMs: supersededPreview.visibleSinceMs,
+      retain: true,
     });
     expect(typeof supersededPreview.visibleSinceMs).toBe("number");
     expect(Number.isFinite(supersededPreview.visibleSinceMs)).toBe(true);

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -177,6 +177,7 @@ export function createTelegramDraftStream(params: {
         textSnapshot: renderedText,
         parseMode: renderedParseMode,
         visibleSinceMs,
+        retain: true,
       });
       return true;
     }


### PR DESCRIPTION
## Summary

- Problem: Telegram partial/progress preview streaming can delete a successfully sent first preview when `forceNewMessage()` advances the generation before the in-flight `sendMessage` resolves.
- Solution: Mark generation-mismatched superseded previews as retained so the dispatch cleanup path leaves landed messages visible.
- What changed: Updated `extensions/telegram/src/draft-stream.ts` and the matching race regression in `extensions/telegram/src/draft-stream.test.ts`.
- What did NOT change: No Telegram API calls, message splitting behavior, reply targeting, or cleanup behavior outside the existing retained-preview contract were changed.

Fixes #85807

## Real behavior proof

- **Behavior or issue addressed:** A Telegram preview message that already landed after a generation race should remain visible instead of being deleted as stale cleanup, while the replacement preview continues normally.
- **Real environment tested:** Darwin 25.5.0 arm64, Node v24.15.0, OpenClaw v2026.6.2, worktree SHA a881641723.
- **Exact steps or command run after this patch:**
  ```bash
  TELEGRAM_BOT_TOKEN=<redacted> TELEGRAM_CHAT_ID=<redacted> pnpm exec node --import tsx /tmp/openclaw-issue-85807-live-proof.mjs
  pnpm test extensions/telegram/src/draft-stream.test.ts
  ```
- **Evidence after fix:**
  ```text
  Live Telegram proof for PR #85961
  {"event":"environment","os":"Darwin 25.5.0 arm64","node":"v24.15.0","worktreeSha":"a881641723","chat":"private Telegram chat (redacted)"}
  {"event":"start first preview flush","text":"Message A partial <run-id>"}
  {"event":"telegram.sendMessage landed","sendNumber":1,"messageId":9,"text":"Message A partial <run-id>"}
  {"event":"first preview visible before forceNewMessage","messageId":9}
  {"event":"forceNewMessage called while first sendMessage response is still pending"}
  {"event":"first sendMessage response released after forceNewMessage","messageId":9}
  {"event":"onSupersededPreview fired","messageId":9,"retain":true,"textSnapshot":"Message A partial <run-id>"}
  {"event":"dispatch cleanup decision","messageId":9,"decision":"retained; deleteMessage skipped for superseded landed preview"}
  {"event":"telegram.sendMessage landed","sendNumber":2,"messageId":10,"text":"Message B replacement <run-id>"}
  {"event":"telegram.editMessageText succeeded","messageId":10,"text":"Message B replacement edited <run-id>"}
  {"event":"observed result","supersededRetain":true,"firstMessageStillAvailableForCleanup":"verified by successful deleteMessage cleanup below","replacementMessageContinued":true,"sentMessageIds":[9,10]}
  {"event":"telegram.deleteMessage cleanup succeeded","messageId":10}
  {"event":"telegram.deleteMessage cleanup succeeded","messageId":9}

  Test Files  1 passed (1)
       Tests  37 passed (37)
  ```
- **Observed result after fix:** The real Telegram Bot API delivered the first preview, `forceNewMessage()` advanced the stream generation while that send response was still pending, the patched stream emitted the landed preview with `retain: true`, cleanup skipped deleting that superseded preview, the replacement preview sent and edited successfully, and final cleanup could still delete both Telegram messages.
- **What was not tested:** no known behavior gaps; the proof used a live Telegram Bot API private chat rather than a screen recording.

## Regression Test Plan

- Coverage level: Unit test plus live Telegram API proof
- Target test file: `extensions/telegram/src/draft-stream.test.ts`
- Scenario locked in: `forceNewMessage()` advances the generation while the first `sendMessage` is still in flight, then the first send resolves with a valid Telegram message id.
- Why this is the smallest reliable guardrail: The unit test locks the exact draft-stream producer invariant, and the live Bot API proof confirms that the retained superseded preview is not deleted while the replacement Telegram preview continues.

## Root Cause

- Root cause: The generation-mismatch superseded-preview path reported a landed Telegram message without `retain: true`, while the dispatch cleanup callback deletes superseded previews unless they opt into retention.
- Missing detection / guardrail: The existing race test verified that the stream did not rebind to the old message, but did not assert that the old landed message was retained.
