### PR TITLE
fix(feishu): clear cached clients on test SDK swap

### DIFF
--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -370,6 +370,32 @@ describe("createFeishuClient HTTP timeout", () => {
       timeout: 45_000,
     });
   });
+
+  it("recreates cached client when test runtime SDK changes", () => {
+    const firstClient = createFeishuClient({
+      appId: "app_7",
+      appSecret: "secret_7", // pragma: allowlist secret
+      accountId: "runtime-cache-change",
+    });
+    const replacementClientCtor = vi.fn(function replacementClientCtor() {
+      return { connected: "replacement" };
+    });
+
+    setFeishuClientRuntimeForTest({
+      sdk: {
+        Client: replacementClientCtor as never,
+      },
+    });
+    const secondClient = createFeishuClient({
+      appId: "app_7",
+      appSecret: "secret_7", // pragma: allowlist secret
+      accountId: "runtime-cache-change",
+    });
+
+    expect(secondClient).not.toBe(firstClient);
+    expect(replacementClientCtor).toHaveBeenCalledTimes(1);
+    expect(clientCtorMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("createFeishuWSClient proxy handling", () => {

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -256,6 +256,7 @@ export function clearClientCache(accountId?: string): void {
 export function setFeishuClientRuntimeForTest(overrides?: {
   sdk?: Partial<FeishuClientSdk>;
 }): void {
+  clearClientCache();
   feishuClientSdk = overrides?.sdk
     ? { ...defaultFeishuClientSdk, ...overrides.sdk }
     : defaultFeishuClientSdk;


### PR DESCRIPTION
## Summary

- Fixes #83911.
- Clears the Feishu client cache whenever `setFeishuClientRuntimeForTest` swaps or resets the injected SDK.
- Adds a regression test proving a cached Feishu client is recreated after the test runtime SDK changes.

## Tests

- `node scripts/run-vitest.mjs extensions/feishu/src/client.test.ts`
- `pnpm tsgo:extensions:test`
- `pnpm tsgo:core:test`
- `git diff --check`

## Real behavior proof

Behavior addressed: Feishu test-runtime SDK swaps no longer reuse a cached client that was constructed by the previous SDK runtime.
Real environment tested: Local source checkout on macOS using the real `extensions/feishu/src/client.ts` module through Node with `tsx`; no Feishu network call or credentialed API request was made.
Exact steps or command run after this patch: `node --import tsx - <<'EOF' ... EOF` imported `createFeishuClient` and `setFeishuClientRuntimeForTest`, installed a first injected SDK constructor, created a client for account `proof`, swapped to a second injected SDK constructor, and created the same account again.
Evidence after fix: Console output after fix:

```json
{"first":{"sdk":"first"},"second":{"sdk":"second"},"firstCalls":1,"secondCalls":1,"cacheReused":false}
```
Observed result after fix: The second same-account client was built by the replacement SDK constructor, and the cached first client was not reused (`cacheReused:false`).
What was not tested: No live Feishu API calls were run; the affected surface is the local Feishu client factory test-runtime seam and cache lifecycle, not outbound Feishu service behavior.
