### PR TITLE
fix(ui): scope chat session picker to active agent

### DIFF
--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -237,6 +237,7 @@ function createChatSessionPickerRequestParams(
     includeUnknown: overrides.includeUnknown,
     configuredAgentsOnly: overrides.configuredAgentsOnly,
     limit: overrides.limit,
+    agentId: resolveChatAgentFilterId(state, state.sessionKey),
   };
   const offset =
     typeof overrides.offset === "number" && Number.isFinite(overrides.offset)
@@ -423,6 +424,23 @@ function resolveChatSessionPickerResult(state: AppViewState): SessionsListResult
   return state.sessionsResult;
 }
 
+function resolveChatSessionPickerRows(
+  state: AppViewState,
+  result: SessionsListResult | null,
+): { row: SessionsListResult["sessions"][number]; label: string }[] {
+  const rowsByKey = new Map((result?.sessions ?? []).map((row) => [row.key, row] as const));
+  return resolveSessionOptionGroups(state, state.sessionKey, result)
+    .flatMap((group) => group.options)
+    .map((option) => ({
+      row: rowsByKey.get(option.key) ?? {
+        key: option.key,
+        kind: "direct",
+        updatedAt: null,
+      },
+      label: option.label,
+    }));
+}
+
 function resolveSelectedChatSessionLabel(
   state: AppViewState,
   sessionGroups: SessionOptionGroup[],
@@ -497,7 +515,7 @@ function renderChatSessionPickerPopover(
   pickerId: string,
 ) {
   const result = resolveChatSessionPickerResult(state);
-  const rows = result?.sessions ?? [];
+  const pickerRows = resolveChatSessionPickerRows(state, result);
   const controlsDisabled = !state.connected || !state.client;
   const normalizedQuery = normalizeOptionalString(state.chatSessionPickerQuery) ?? "";
   const searchPending = normalizedQuery !== state.chatSessionPickerAppliedQuery;
@@ -505,7 +523,7 @@ function renderChatSessionPickerPopover(
   const hasQuery =
     state.chatSessionPickerQuery.trim() !== "" || state.chatSessionPickerAppliedQuery.trim() !== "";
   const loadMoreOffset = resolveNextChatSessionOffset(result);
-  const shownCount = rows.length;
+  const shownCount = pickerRows.length;
   const totalCount = result?.totalCount;
   const countLabel =
     typeof totalCount === "number" && Number.isFinite(totalCount)
@@ -578,17 +596,17 @@ function renderChatSessionPickerPopover(
           </div>`
         : ""}
       <div class="chat-session-picker__list" role="listbox">
-        ${state.chatSessionPickerLoading && rows.length === 0
+        ${state.chatSessionPickerLoading && pickerRows.length === 0
           ? html`<div class="chat-session-picker__status">${t("common.loading")}</div>`
           : ""}
-        ${!state.chatSessionPickerLoading && rows.length === 0
+        ${!state.chatSessionPickerLoading && pickerRows.length === 0
           ? html`<div class="chat-session-picker__status">${t("sessionsView.noSessions")}</div>`
           : ""}
         ${repeat(
-          rows,
-          (row) => row.key,
-          (row) => {
-            const label = resolveSessionDisplayName(row.key, row);
+          pickerRows,
+          (entry) => entry.row.key,
+          (entry) => {
+            const { row, label } = entry;
             const meta = formatChatSessionPickerMeta(row);
             const selected = row.key === state.sessionKey;
             return html`

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1356,6 +1356,7 @@ describe("chat session controls", () => {
       "agent:main:telegram-two",
     ]);
     expect(request).toHaveBeenCalledWith("sessions.list", {
+      agentId: "main",
       configuredAgentsOnly: true,
       includeGlobal: true,
       includeUnknown: true,
@@ -1420,6 +1421,7 @@ describe("chat session controls", () => {
 
     await vi.waitFor(() => expect(state.chatSessionPickerAppliedQuery).toBe("tele"));
     expect(request).toHaveBeenCalledWith("sessions.list", {
+      agentId: "main",
       configuredAgentsOnly: true,
       includeGlobal: true,
       includeUnknown: true,
@@ -1494,6 +1496,7 @@ describe("chat session controls", () => {
     input!.dispatchEvent(new Event("input", { bubbles: true }));
     input!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
     expect(request).toHaveBeenCalledWith("sessions.list", {
+      agentId: "main",
       configuredAgentsOnly: true,
       includeGlobal: true,
       includeUnknown: true,
@@ -1505,6 +1508,7 @@ describe("chat session controls", () => {
     input!.dispatchEvent(new Event("input", { bubbles: true }));
     input!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
     expect(request).toHaveBeenCalledWith("sessions.list", {
+      agentId: "main",
       configuredAgentsOnly: true,
       includeGlobal: true,
       includeUnknown: true,
@@ -1591,6 +1595,7 @@ describe("chat session controls", () => {
       "agent:main:telegram-page-52",
     ]);
     expect(request).toHaveBeenCalledWith("sessions.list", {
+      agentId: "main",
       configuredAgentsOnly: true,
       includeGlobal: true,
       includeUnknown: true,
@@ -1641,6 +1646,35 @@ describe("chat session controls", () => {
     expect(container.querySelector('button[data-chat-session-load-more="true"]')).toBeInstanceOf(
       HTMLButtonElement,
     );
+  });
+
+  it("renders only active-agent chat sessions in the picker popover", () => {
+    const { state } = createChatHeaderState();
+    state.sessionKey = "agent:main:main";
+    state.settings.sessionKey = state.sessionKey;
+    state.chatSessionPickerOpen = true;
+    state.chatSessionPickerSurface = "desktop";
+    state.chatSessionPickerResult = createSessionsResultFromRows([
+      { key: "agent:main:main", kind: "direct", label: "Main chat", updatedAt: 6 },
+      { key: "agent:main:work", kind: "direct", label: "Main work", updatedAt: 5 },
+      { key: "agent:other:main", kind: "direct", label: "Other agent", updatedAt: 4 },
+      { key: "agent:main:cron:daily", kind: "direct", label: "Cron daily", updatedAt: 3 },
+      {
+        key: "agent:main:subagent:child",
+        kind: "direct",
+        label: "Child worker",
+        updatedAt: 2,
+        spawnedBy: "agent:main:main",
+      },
+    ]);
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const labels = Array.from(
+      container.querySelectorAll<HTMLElement>(".chat-session-picker__option-label"),
+    ).map((node) => node.textContent?.trim());
+
+    expect(labels).toEqual(["Main chat", "Main work"]);
   });
 
   it("shows provider quota in the chat header when usage data is loaded", () => {


### PR DESCRIPTION
## Summary

- Problem: the Control UI chat session picker can show sessions from other configured agents because picker search/load-more calls are not scoped by active agent and the popover renders raw `sessions.list` rows.
- Why it matters: multi-agent users can see and accidentally switch into unrelated agent/service sessions from the chat picker.
- What changed: picker requests now include the active `agentId`, and the popover renders rows through the same filtered session-option projection used by the grouped selector.
- What did NOT change (scope boundary): the full Sessions page and gateway `sessions.list` behavior remain unchanged.

AI-assisted: Yes. I understand the code path and verified the targeted behavior locally.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #85963
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: chat session picker pagination/search built `sessions.list` params without the active `agentId`, then rendered `result.sessions` directly instead of using the existing filtered session option groups.
- Missing detection / guardrail: picker tests covered search/pagination mechanics but not cross-agent/cron/subagent filtering in the popover.
- Contributing context (if known): the grouped selector already had active-agent filtering, but the newer popover path bypassed it.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/ui/views/chat.test.ts`
- Scenario the test should lock in: when the picker result includes another agent, cron session, and spawned subagent, only active-agent chat sessions render in the popover.
- Why this is the smallest reliable guardrail: the bug is in the Control UI projection/render path, so a focused DOM render test covers the visible regression without a browser E2E fixture.
- Existing test that already covers this (if any): grouped selector filtering tests in `ui/src/ui/app-render.helpers.node.test.ts` covered the helper but not this popover path.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

The chat session picker now shows active-agent chat sessions by default instead of leaking unrelated agent/service rows into the popover.

## Diagram (if applicable)

```text
Before:
[open chat picker] -> [sessions.list without agentId] -> [raw rows rendered] -> [cross-agent rows visible]

After:
[open chat picker] -> [sessions.list with active agentId] -> [filtered option rows rendered] -> [active-agent sessions visible]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): Yes
- If any `Yes`, explain risk + mitigation: UI session-list access is narrowed for this picker by passing `agentId` and filtering display rows; broader session management surfaces are unchanged.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local pnpm workspace
- Model/provider: N/A for test execution; observed setup used `openai/gpt-5.5`
- Integration/channel (if any): Control UI chat
- Relevant config (redacted): multiple configured agents with agent-scoped session keys

### Steps

1. Open the Control UI chat view with multiple configured agents and sessions.
2. Open the chat session picker.
3. Search/load more from the picker.

### Expected

- Picker requests are scoped to the active agent.
- Popover renders only sessions allowed by the grouped session selector filtering.

### Actual

- Before this PR, picker requests were unscoped and the popover rendered raw `sessions.list` rows.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```text
pnpm test ui/src/ui/views/chat.test.ts ui/src/ui/app-render.helpers.node.test.ts
[test] passed 2 Vitest shards in 11.10s

pnpm check:test-types
completed successfully

pnpm build
completed successfully
```

## Real behavior proof

- Behavior or issue addressed: the installed Control UI chat session picker was leaking unrelated configured-agent/service rows because it requested sessions without the active agent scope and rendered raw response rows.
- Real environment tested: macOS local OpenClaw install at `/opt/homebrew/lib/node_modules/openclaw`, with multiple configured agents and a live `~/.openclaw/agents/main/sessions/sessions.json` registry.
- Exact steps or command run after this patch: patched the installed Control UI asset and service worker cache version, ran the local session-label/provider guard, then inspected the live installed bundle and registry with `rg` and the guard dry-run command.
- Evidence after fix:

```text
$ rg -n "agentId:EW\(e,e\.sessionKey\)|AW\(e,e\.sessionKey,r\)" /opt/homebrew/lib/node_modules/openclaw/dist/control-ui/assets/index-BtIuF4zW.js
... agentId:EW(e,e.sessionKey) ...
... i=AW(e,e.sessionKey,r).flatMap(...)

$ rg -n "local-session-picker-fix" /opt/homebrew/lib/node_modules/openclaw/dist/control-ui/sw.js /opt/homebrew/lib/node_modules/openclaw/dist/control-ui/assets/index-BtIuF4zW.js
/opt/homebrew/lib/node_modules/openclaw/dist/control-ui/sw.js:4:const BUILD_VERSION = "2026.5.22-a374c3a5bfd5-local-session-picker-fix";
/opt/homebrew/lib/node_modules/openclaw/dist/control-ui/assets/index-BtIuF4zW.js:... __OPENCLAW_BUILD_VERSION__="2026.5.22-a374c3a5bfd5-local-session-picker-fix"

$ /Users/serkonyc/Documents/GitHub/openclaw-config/protocols/01\ -\ Operating\ Context/scripts/enforce_session_labels.py --dry-run
{
  "changed": false
}
```

- Observed result after fix: the installed picker bundle now sends `agentId` for the active chat agent and projects picker rows through the existing filtered option grouping; the affected live registry entry is normalized to `cloud-codex-main`, `modelProvider: openai`, `model: gpt-5.5`, `authProfileOverride: openai-codex:<redacted>`, and `systemPromptReport.provider: openai`.
- What was not tested: manual screenshot or screen recording of the running browser tab after cache refresh.

## Human Verification (required)

- Verified scenarios: picker search params include `agentId`; popover filters out other-agent, cron, and spawned subagent rows; targeted UI tests pass; test typecheck passes; full build passes; installed local dist contains the scoped picker request and filtered-row projection.
- Edge cases checked: active session remains visible through existing `resolveSessionOptionGroups` behavior; pagination/search test expectations were updated for the scoped request.
- What you did **not** verify: manual browser screenshots in a running Control UI instance.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: the picker count can reflect the filtered visible rows while `totalCount` still comes from the server response.
  - Mitigation: server request is now scoped by `agentId`, and existing filtered option logic is reused for display consistency.
