### PR TITLE
fix(sessions): stop doctor OOM on large session stores and reclaim stale store temps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Sessions/doctor: load large session stores without clone amplification during read-only doctor checks and reclaim stale `sessions.json.*.tmp` sidecars. Fixes #56827. Thanks @openperf.
 - Gateway: keep session-only Control UI tool-start mirrors flowing during diagnostic queue pressure instead of silently dropping non-terminal tool updates.
 - Agents/memory: return optional not-found context for missing date-only daily memory reads instead of logging benign first-run `ENOENT` failures. Fixes #82928. Thanks @galiniliev.
 - Gateway: avoid sending duplicate tool-event frames to Control UI connections that are subscribed by both run and session.

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.ts
@@ -560,7 +560,7 @@ async function runWhatsAppScenario(params: {
   sutAuthDir: string;
   sutPhoneE164: string;
   groupJid?: string;
-}) {
+}): Promise<WhatsAppQaScenarioResult> {
   const scenarioRun = params.scenario.buildRun();
   if (scenarioRun.target === "group" && !params.groupJid) {
     throw new Error(`WhatsApp scenario ${params.scenario.id} requires groupJid.`);

--- a/src/commands/doctor-heartbeat-session-target.ts
+++ b/src/commands/doctor-heartbeat-session-target.ts
@@ -120,7 +120,7 @@ export function describeHeartbeatSessionTargetIssues(cfg: OpenClawConfig): strin
     }
     const storeAgentId = resolvedAgentId;
     const storePath = resolveStorePath(cfg.session?.store, { agentId: storeAgentId });
-    const store = loadSessionStore(storePath);
+    const store = loadSessionStore(storePath, { skipCache: true, clone: false });
     const entry = store[canonicalSession];
     if (entry) {
       continue;

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -852,7 +852,10 @@ export async function noteStateIntegrity(
     );
   }
 
-  const store = loadSessionStore(storePath);
+  // Read-only diagnostic load: skip the cache and the defensive return clone so a
+  // very large monolithic sessions.json is materialized once, not several times.
+  // Re-cloning a multi-hundred-MB store here is what made `doctor` OOM (#56827).
+  const store = loadSessionStore(storePath, { skipCache: true, clone: false });
   const sessionPathOpts = resolveSessionFilePathOptions({ agentId, storePath });
   const entries = Object.entries(store).filter(([, entry]) => entry && typeof entry === "object");
   if (entries.length > 0) {

--- a/src/commands/doctor/shared/codex-route-warnings.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.ts
@@ -2744,7 +2744,9 @@ export async function maybeRepairCodexSessionRoutes(params: {
   }
   if (!params.shouldRepair) {
     const stale = targets.flatMap((target) => {
-      const sessionKeys = scanCodexSessionStoreRoutes(loadSessionStore(target.storePath));
+      const sessionKeys = scanCodexSessionStoreRoutes(
+        loadSessionStore(target.storePath, { skipCache: true, clone: false }),
+      );
       return sessionKeys.map((sessionKey) => `${target.agentId}:${sessionKey}`);
     });
     return {
@@ -2767,7 +2769,9 @@ export async function maybeRepairCodexSessionRoutes(params: {
   let repairedStores = 0;
   let repairedSessions = 0;
   for (const target of targets) {
-    const staleSessionKeys = scanCodexSessionStoreRoutes(loadSessionStore(target.storePath));
+    const staleSessionKeys = scanCodexSessionStoreRoutes(
+      loadSessionStore(target.storePath, { skipCache: true, clone: false }),
+    );
     if (staleSessionKeys.length === 0) {
       continue;
     }

--- a/src/config/sessions/artifacts.test.ts
+++ b/src/config/sessions/artifacts.test.ts
@@ -4,6 +4,7 @@ import {
   isCompactionCheckpointTranscriptFileName,
   isPrimarySessionTranscriptFileName,
   isSessionArchiveArtifactName,
+  isSessionStoreTempArtifactName,
   isTrajectoryPointerArtifactName,
   isTrajectoryRuntimeArtifactName,
   isTrajectorySessionArtifactName,
@@ -21,6 +22,30 @@ describe("session artifact helpers", () => {
     expect(isSessionArchiveArtifactName("sessions.json.bak.1737420882")).toBe(true);
     expect(isSessionArchiveArtifactName("keep.deleted.keep.jsonl")).toBe(false);
     expect(isSessionArchiveArtifactName("abc.jsonl")).toBe(false);
+  });
+
+  it("classifies orphaned session store atomic-write temp files", () => {
+    const uuid = "0f9c1a2b-3c4d-4e5f-8a9b-0c1d2e3f4a5b";
+    const store = "sessions.json";
+    // sessions.json.<pid>.<uuid>.tmp (current) and legacy sessions.json.<uuid>.tmp
+    expect(isSessionStoreTempArtifactName(`sessions.json.12345.${uuid}.tmp`, store)).toBe(true);
+    expect(isSessionStoreTempArtifactName(`sessions.json.${uuid}.tmp`, store)).toBe(true);
+    // Never the live store, archives, transcripts, or unrelated temp files.
+    expect(isSessionStoreTempArtifactName("sessions.json", store)).toBe(false);
+    expect(isSessionStoreTempArtifactName("sessions.json.bak.1737420882", store)).toBe(false);
+    expect(isSessionStoreTempArtifactName(`${uuid}.jsonl`, store)).toBe(false);
+    expect(isSessionStoreTempArtifactName("sessions.json.tmp", store)).toBe(false);
+    expect(isSessionStoreTempArtifactName("other.json.12345.tmp", store)).toBe(false);
+    // Tracks a custom session.store filename (and only that store's temps); the
+    // basename is regex-escaped so its dots are literal, not wildcards.
+    expect(isSessionStoreTempArtifactName(`my-store.json.99.${uuid}.tmp`, "my-store.json")).toBe(
+      true,
+    );
+    expect(isSessionStoreTempArtifactName(`my-store.json.99.${uuid}.tmp`, store)).toBe(false);
+    expect(isSessionStoreTempArtifactName(`sessions.json.99.${uuid}.tmp`, "my-store.json")).toBe(
+      false,
+    );
+    expect(isSessionStoreTempArtifactName(`sessionsXjson.99.${uuid}.tmp`, store)).toBe(false);
   });
 
   it("classifies primary transcript files", () => {

--- a/src/config/sessions/artifacts.ts
+++ b/src/config/sessions/artifacts.ts
@@ -1,3 +1,5 @@
+import { escapeRegExp } from "../../shared/regexp.js";
+
 export type SessionArchiveReason = "bak" | "reset" | "deleted";
 
 const ARCHIVE_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}(?:\.\d{3})?Z$/;
@@ -24,6 +26,36 @@ export function isSessionArchiveArtifactName(fileName: string): boolean {
     hasArchiveSuffix(fileName, "reset") ||
     hasArchiveSuffix(fileName, "bak")
   );
+}
+
+// Compiled-pattern cache keyed by store basename. A disk sweep calls the matcher
+// once per file, so compiling the per-store pattern once (basenames are few — one
+// per agent store) keeps the hot path allocation-free.
+const SESSION_STORE_TEMP_RE_CACHE = new Map<string, RegExp>();
+
+function sessionStoreTempPattern(storeBasename: string): RegExp {
+  let pattern = SESSION_STORE_TEMP_RE_CACHE.get(storeBasename);
+  if (!pattern) {
+    pattern = new RegExp(
+      `^${escapeRegExp(storeBasename)}\\.(?:\\d+\\.)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\.tmp$`,
+      "i",
+    );
+    SESSION_STORE_TEMP_RE_CACHE.set(storeBasename, pattern);
+  }
+  return pattern;
+}
+
+// Atomic writes of the session store stage into `<store>.<pid>.<uuid>.tmp`
+// (legacy: `<store>.<uuid>.tmp`) and rename into place. A crash between write and
+// rename orphans the temp; these accumulate and waste disk (#56827). They are
+// never the live store, so a stale one is safe to reclaim. `storeBasename` is the
+// store filename (the atomic write's temp prefix, e.g. `sessions.json`), so a
+// custom-named `session.store` is matched too.
+export function isSessionStoreTempArtifactName(fileName: string, storeBasename: string): boolean {
+  if (!storeBasename) {
+    return false;
+  }
+  return sessionStoreTempPattern(storeBasename).test(fileName);
 }
 
 export function parseCompactionCheckpointTranscriptFileName(fileName: string): {

--- a/src/config/sessions/disk-budget.test.ts
+++ b/src/config/sessions/disk-budget.test.ts
@@ -7,7 +7,7 @@ import {
   resolveTrajectoryPointerFilePath,
 } from "../../trajectory/paths.js";
 import { formatSessionArchiveTimestamp } from "./artifacts.js";
-import { enforceSessionDiskBudget } from "./disk-budget.js";
+import { enforceSessionDiskBudget, pruneUnreferencedSessionArtifacts } from "./disk-budget.js";
 import type { SessionEntry } from "./types.js";
 
 async function expectPathExists(targetPath: string): Promise<void> {
@@ -99,6 +99,50 @@ describe("enforceSessionDiskBudget", () => {
       expectBudgetResult(result);
       expect(result.removedFiles).toBe(1);
       expect(result.removedEntries).toBe(0);
+    });
+  });
+
+  it("reclaims stale store temps under pressure but never a fresh in-flight one (#56827)", async () => {
+    await withTempDir({ prefix: "openclaw-disk-budget-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const sessionId = "keep";
+      const transcriptPath = path.join(dir, `${sessionId}.jsonl`);
+      const staleTemp = path.join(
+        dir,
+        "sessions.json.111.0f9c1a2b-3c4d-4e5f-8a9b-0c1d2e3f4a5b.tmp",
+      );
+      const freshTemp = path.join(
+        dir,
+        "sessions.json.222.1a2b3c4d-5e6f-4a8b-9c0d-1e2f3a4b5c6d.tmp",
+      );
+      const store: Record<string, SessionEntry> = {
+        "agent:main:main": { sessionId, updatedAt: Date.now() },
+      };
+      await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf-8");
+      await fs.writeFile(transcriptPath, "k".repeat(80), "utf-8");
+      await fs.writeFile(staleTemp, "s".repeat(300), "utf-8");
+      await fs.writeFile(freshTemp, "f".repeat(300), "utf-8");
+      // Age the stale temp past the staleness window; the fresh one is in-flight.
+      const old = new Date(Date.now() - 30 * 60 * 1000);
+      await fs.utimes(staleTemp, old, old);
+
+      const result = await enforceSessionDiskBudget({
+        store,
+        storePath,
+        maintenance: {
+          maxDiskBytes: 750,
+          highWaterBytes: 600,
+        },
+        warnOnly: false,
+      });
+
+      // Stale orphan reclaimed; fresh in-flight temp (a live atomic-write source)
+      // and referenced transcript preserved even though still over the high-water mark.
+      await expectPathMissing(staleTemp);
+      await expectPathExists(freshTemp);
+      await expectPathExists(transcriptPath);
+      expectBudgetResult(result);
+      expect(result.removedFiles).toBe(1);
     });
   });
 
@@ -284,6 +328,44 @@ describe("enforceSessionDiskBudget", () => {
       expect(store).toHaveProperty(activeKey);
       expectBudgetResult(result);
       expect(result.removedEntries).toBe(1);
+    });
+  });
+});
+
+describe("pruneUnreferencedSessionArtifacts", () => {
+  it("reclaims stale store temp sidecars but preserves in-flight ones (#56827)", async () => {
+    await withTempDir({ prefix: "openclaw-prune-temp-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const staleTemp = path.join(
+        dir,
+        "sessions.json.111.0f9c1a2b-3c4d-4e5f-8a9b-0c1d2e3f4a5b.tmp",
+      );
+      const freshTemp = path.join(
+        dir,
+        "sessions.json.222.1a2b3c4d-5e6f-4a8b-9c0d-1e2f3a4b5c6d.tmp",
+      );
+      const store: Record<string, SessionEntry> = {
+        "agent:main:main": { sessionId: "keep", updatedAt: Date.now() },
+      };
+      await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf-8");
+      await fs.writeFile(staleTemp, "s".repeat(64), "utf-8");
+      await fs.writeFile(freshTemp, "f".repeat(64), "utf-8");
+      // Age the stale temp well past the temp staleness window; keep the other in-flight.
+      const old = new Date(Date.now() - 30 * 60 * 1000);
+      await fs.utimes(staleTemp, old, old);
+
+      const result = await pruneUnreferencedSessionArtifacts({
+        store,
+        storePath,
+        // 30d general cutoff: a stale temp must be reclaimed by its own short window,
+        // not by the unreferenced-artifact age threshold.
+        olderThanMs: 30 * 24 * 60 * 60 * 1000,
+      });
+
+      await expectPathMissing(staleTemp);
+      await expectPathExists(freshTemp);
+      await expectPathExists(storePath);
+      expect(result.removedFiles).toBeGreaterThanOrEqual(1);
     });
   });
 });

--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -12,6 +12,7 @@ import {
   isCompactionCheckpointTranscriptFileName,
   isPrimarySessionTranscriptFileName,
   isSessionArchiveArtifactName,
+  isSessionStoreTempArtifactName,
   isTrajectorySessionArtifactName,
 } from "./artifacts.js";
 import { resolveSessionFilePath } from "./paths.js";
@@ -228,10 +229,23 @@ function isUnreferencedSessionArtifactFile(
   );
 }
 
+// An orphaned `sessions.json.<pid>.<uuid>.tmp` older than this is never a live
+// atomic write (those rename within milliseconds), so it is safe to reclaim
+// regardless of the general unreferenced-artifact age threshold (#56827).
+const SESSION_STORE_TEMP_STALE_MS = 5 * 60 * 1000;
+
 function isDiskBudgetRemovableSessionFile(
-  file: Pick<SessionsDirFileStat, "canonicalPath" | "name">,
+  file: Pick<SessionsDirFileStat, "canonicalPath" | "name" | "mtimeMs">,
   referencedPaths: ReadonlySet<string>,
+  tempStaleCutoffMs: number,
+  storeBasename: string,
 ): boolean {
+  // Store temps are only removable once clearly stale, even under disk pressure:
+  // `replaceFileAtomic` uses this exact path as the live source before its rename,
+  // so deleting a fresh in-flight temp would make another process's save fail.
+  if (isSessionStoreTempArtifactName(file.name, storeBasename)) {
+    return file.mtimeMs <= tempStaleCutoffMs;
+  }
   return (
     isSessionArchiveArtifactName(file.name) ||
     isUnreferencedSessionArtifactFile(file, referencedPaths)
@@ -294,13 +308,20 @@ export async function pruneUnreferencedSessionArtifacts(params: {
     store: params.store,
   });
   const cutoffMs = Date.now() - olderThanMs;
+  const tempCutoffMs = Date.now() - SESSION_STORE_TEMP_STALE_MS;
+  const storeBasename = path.basename(params.storePath);
   const removableFiles = files
-    .filter(
-      (file) =>
-        !params.excludeCanonicalPaths?.has(file.canonicalPath) &&
-        file.mtimeMs <= cutoffMs &&
-        isUnreferencedSessionArtifactFile(file, referencedPaths),
-    )
+    .filter((file) => {
+      if (params.excludeCanonicalPaths?.has(file.canonicalPath)) {
+        return false;
+      }
+      // Orphaned store atomic-write temps are reclaimed on their own short
+      // staleness window, independent of the unreferenced-artifact age (#56827).
+      if (isSessionStoreTempArtifactName(file.name, storeBasename)) {
+        return file.mtimeMs <= tempCutoffMs;
+      }
+      return file.mtimeMs <= cutoffMs && isUnreferencedSessionArtifactFile(file, referencedPaths);
+    })
     .toSorted((a, b) => a.mtimeMs - b.mtimeMs);
 
   let removedFiles = 0;
@@ -396,8 +417,12 @@ export async function enforceSessionDiskBudget(params: {
     sessionsDir,
     store: params.store,
   });
+  const tempStaleCutoffMs = Date.now() - SESSION_STORE_TEMP_STALE_MS;
+  const storeBasename = path.basename(params.storePath);
   const removableFileQueue = files
-    .filter((file) => isDiskBudgetRemovableSessionFile(file, referencedPaths))
+    .filter((file) =>
+      isDiskBudgetRemovableSessionFile(file, referencedPaths, tempStaleCutoffMs, storeBasename),
+    )
     .toSorted((a, b) => a.mtimeMs - b.mtimeMs);
   for (const file of removableFileQueue) {
     if (total <= highWaterBytes) {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -593,7 +593,14 @@ async function writeSessionStoreAtomic(params: {
   store: Record<string, SessionEntry>;
   serialized: string;
 }): Promise<void> {
-  await writeTextAtomic(params.storePath, params.serialized, { durable: false, mode: 0o600 });
+  // Stage the temp as `sessions.json.<pid>.<uuid>.tmp` (not the generic
+  // `.fs-safe-replace.*`) so a temp orphaned by a crash between write and rename
+  // is identifiable as a session-store temp and reclaimable by cleanup (#56827).
+  await writeTextAtomic(params.storePath, params.serialized, {
+    durable: false,
+    mode: 0o600,
+    tempPrefix: path.basename(params.storePath),
+  });
   updateSessionStoreWriteCaches({
     storePath: params.storePath,
     store: params.store,

--- a/src/infra/json-files.test.ts
+++ b/src/infra/json-files.test.ts
@@ -130,6 +130,29 @@ describe("json file helpers", () => {
     });
   });
 
+  it("stages the atomic temp with a caller-provided prefix (#56827)", async () => {
+    await withTempDir({ prefix: "openclaw-json-files-" }, async (base) => {
+      const filePath = path.join(base, "sessions.json");
+      // Spy without mocking: rename is still performed, but we capture the staged
+      // temp path (its source) to confirm the prefix is applied.
+      const renameSpy = vi.spyOn(fsPromises, "rename");
+
+      await writeTextAtomic(filePath, "new", { tempPrefix: path.basename(filePath) });
+
+      await expect(fsPromises.readFile(filePath, "utf8")).resolves.toBe("new");
+      const stagedTemps = renameSpy.mock.calls.map((call) => path.basename(String(call[0])));
+      // The orphan a crash would leave is now identifiable as a session-store temp.
+      expect(
+        stagedTemps.some((name) =>
+          /^sessions\.json\.\d+\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.tmp$/i.test(
+            name,
+          ),
+        ),
+      ).toBe(true);
+      expect(stagedTemps.some((name) => name.startsWith(".fs-safe-replace"))).toBe(false);
+    });
+  });
+
   it("refuses Windows copy fallback through symlink destinations", async () => {
     await withTempDir({ prefix: "openclaw-json-files-" }, async (base) => {
       const filePath = path.join(base, "state.json");

--- a/src/infra/json-files.ts
+++ b/src/infra/json-files.ts
@@ -117,6 +117,12 @@ export type WriteTextAtomicOptions = {
   dirMode?: number;
   trailingNewline?: boolean;
   durable?: boolean;
+  /**
+   * Prefix for the staged `<prefix>.<pid>.<uuid>.tmp` file. Defaults to the
+   * generic `.fs-safe-replace`; pass a target-specific prefix so an orphaned
+   * temp (from a crash between write and rename) is identifiable and reclaimable.
+   */
+  tempPrefix?: string;
 };
 
 export async function writeTextAtomic(
@@ -133,5 +139,6 @@ export async function writeTextAtomic(
     copyFallbackOnPermissionError: true,
     syncTempFile: options?.durable !== false,
     syncParentDir: options?.durable !== false,
+    ...(options?.tempPrefix ? { tempPrefix: options.tempPrefix } : {}),
   });
 }


### PR DESCRIPTION
### Summary

- **Problem**: On a long-lived install with a large monolithic session store (the report: a 154 MB `sessions.json`, plus ~787 MB of stale `sessions.json.*.tmp` files), `openclaw doctor` crashes with a V8 out-of-memory deserialization stack (`ValueDeserializer::ReadObjectWrapper` / `ReadValue`), and the stale `.tmp` sidecars are never reclaimed.
- **Root Cause**: Two grounded issues.
  - **Crash (copy amplification, not a single parse)**: the read-only doctor checks call `loadSessionStore(storePath)` with defaults, which on a cold read parses the store, then **clones it again for the cache write** and **clones it a third time for the defensive return value** — re-serializing/parsing a multi-hundred-MB object two extra times. Peak memory is several times the store size, so a large store exhausts the heap. `busy_timeout`/WAL are irrelevant here; the exact frame where the heap finally fails varies (a `structuredClone(config)` elsewhere in doctor on the reporter's run, a JSON re-parse clone on mine), which is why the reported stack lands in `ValueDeserializer` while a single load succeeds.
  - **Stale temps**: atomic writes of the store stage a temp file and rename into place; a crash between write and rename orphans the temp. The store write went through the generic `writeTextAtomic`, which used `@openclaw/fs-safe`'s default temp prefix `.fs-safe-replace.<pid>.<uuid>.tmp` — a shared name not identifiable as a store temp (the reporter's older build left `sessions.json.*.tmp`). Either way these were never classified as removable, so cleanup/disk-budget never reclaimed them and they accumulated.
- **Fix**:
  - Load the store read-only in the doctor checks (state integrity, heartbeat target, codex route scan): `loadSessionStore(storePath, { skipCache: true, clone: false })`. This skips the cache-write clone and the return clone, so the store is materialized once. These call sites only read the store (mutations go through a separate `updateSessionStore` load-mutate-save), so dropping the clone is safe.
  - Give the session-store atomic write a **store-specific temp prefix** (`tempPrefix` = the store basename) so its temps stage as `sessions.json.<pid>.<uuid>.tmp` instead of the shared `.fs-safe-replace.*`. This makes a crash leftover identifiable as a store temp and matches the legacy reporter pattern, so one classifier covers both, and cleanup never has to touch the shared `.fs-safe-replace.*` name (which other in-flight atomic writes use).
  - Classify orphaned store temps (`isSessionStoreTempArtifactName`, matched against the store basename so it tracks the dynamic temp prefix and custom store names) and reclaim only **stale** ones. Both reclaim paths apply the same 5-minute staleness window (well past any in-flight atomic write, which renames within milliseconds): the unreferenced-artifact prune removes stale temps independent of the general artifact-age threshold, and the disk-budget eviction also age-gates store temps before queueing them — so even under disk pressure a fresh in-flight `sessions.json.<pid>.<uuid>.tmp` (a live `replaceFileAtomic` source) is never deleted out from under another process's save.
- **What changed**:
  - `src/commands/doctor-state-integrity.ts`, `src/commands/doctor-heartbeat-session-target.ts`, `src/commands/doctor/shared/codex-route-warnings.ts`: read-only session-store loads use `{ skipCache: true, clone: false }`.
  - `src/infra/json-files.ts`: `writeTextAtomic` accepts an optional `tempPrefix` (forwarded to the atomic replace).
  - `src/config/sessions/store.ts`: the session-store atomic write passes `tempPrefix` = the store basename so temps are store-identifiable.
  - `src/config/sessions/artifacts.ts`: add `isSessionStoreTempArtifactName(fileName, storeBasename)` — parameterized by the store basename (regex-escaped) so it stays consistent with the dynamic atomic-write `tempPrefix` and also covers a custom-named `session.store`, not just `sessions.json`.
  - `src/config/sessions/disk-budget.ts`: include stale store temps in `isDiskBudgetRemovableSessionFile` and in the `pruneUnreferencedSessionArtifacts` sweep with a short temp-staleness window.
  - `src/config/sessions/artifacts.test.ts`, `src/config/sessions/disk-budget.test.ts`, `src/infra/json-files.test.ts`: regression coverage.
- **What did NOT change (scope boundary)**:
  - `loadSessionStore`'s default behavior (cache + clone) is unchanged for the hot/gateway callers that need an isolated copy; only the read-only doctor checks opt out.
  - The unreferenced-artifact age threshold, archive classification, transcript/trajectory handling, and the atomic-write path are unchanged. No config keys or session-store format changed; this does not touch the monolithic-store-to-SQLite migration the report suggests as a longer-term direction.

### Reproduction

1. Build a large session store (the harness below generates ~120 MB; the reporter had 154 MB).
2. Run the read-only doctor session load under a realistic heap (`--max-old-space-size`).
- Before: the default load (cache-write clone + return clone) re-materializes the store and the process OOMs.
- After: the read-only load materializes it once and completes.

### Real behavior proof

- **Behavior addressed**: the read-only doctor session-store load must not OOM on a large store; the default load's extra clones are what exhausts the heap.
- **Real environment tested**: a deterministic harness that generates a ~120 MB `sessions.json` (1917 distinct entries) and runs the **real `loadSessionStore`** from this branch in two child processes under the same heap cap (`--max-old-space-size=400`). `current` = exactly what doctor called before (`loadSessionStore(storePath)`); `fixed` = exactly what doctor calls now (`loadSessionStore(storePath, { skipCache: true, clone: false })`). Linux, Node 22.
- **Exact steps or command run after this patch**: `node /tmp/qmd56827/repro56827.mjs 120 64 400` (args: store MB, entry KB, heap-cap MB).
- **Evidence after fix (verbatim harness output, no color codes)**:

```text
[gen] store on disk: 120MB

[run] heap cap = 400MB per probe process

=== CURRENT — loadSessionStore(storePath)  [parse + cache-write clone + return clone] ===
status=134 oom=true
(no stdout)  stderr-tail: 13: 0x15a750d v8::internal::JsonParser<unsigned char>::ParseJson(v8::internal::Handle<v8::internal::Object>) [/usr/local/bin/node] | 14: 0x12c1519 v8::internal::Builtin_JsonParse(int, unsigned long*, v8::internal::Isolate*) [/usr/local/bin/node] | 15: 0x1dfca36  [/usr/local/bin/node]

=== FIXED — loadSessionStore(storePath, { skipCache:true, clone:false }) ===
status=0 oom=false
OK mode=fixed entries=1917 rss=449MB

================ VERDICT ================
Current (no opts): OOM ✅ (copy amplification reproduced)
Fixed (read-only): succeeded ✅

RESULT: PASS — current OOMs where the read-only load succeeds, at the same heap cap
```

- **Observed result after fix**: at the same heap cap, the default load crashes with `out of memory` (exit 134) while the read-only load returns all 1917 entries. The OOM frame here is a JSON re-parse clone (`Builtin_JsonParse`); the reporter's frame is `ValueDeserializer` — the same root cause (heap exhaustion from re-materializing the store), differing only in which allocation finally fails.
- **Regression tests**: `artifacts.test.ts` + `disk-budget.test.ts` (16 passed) — stale-temp classifier (current `sessions.json.<pid>.<uuid>.tmp` and legacy `sessions.json.<uuid>.tmp`), disk-budget reclaim under pressure, and a prune case that removes a stale temp while preserving an in-flight one; `json-files.test.ts` (16 passed) — a case proving `writeTextAtomic` with the store `tempPrefix` stages `sessions.json.<pid>.<uuid>.tmp` and not the shared `.fs-safe-replace.*`; doctor checks `doctor-state-integrity.test.ts` + `doctor-heartbeat-session-target.test.ts` + `codex-route-warnings.test.ts` (129 passed) and store-save `sessions.test.ts` + `reset.test.ts` (35 passed).
- **What was not tested**: the harness reproduces the SQLite-store load and the OOM/fix with the real `loadSessionStore`, but does not drive a full packaged `openclaw doctor` invocation or the actual `qmd`-free large production store; the stale-temp reclaim is covered by unit tests rather than a multi-GB live directory.

### Risk / Mitigation

- **Risk**: a read-only load returning a non-cloned store could be mutated by a caller; reclaiming a temp could race an in-flight atomic write.
- **Mitigation**: the three converted call sites only read the store (writes use a separate `updateSessionStore`), and `skipCache: true` means the returned object is a fresh per-call parse not shared with the cache, so dropping the clone is safe. Temp reclaim age-gates a store temp by a 5-minute staleness window in **both** the prune path and the disk-budget eviction path (far longer than an atomic write, which renames within milliseconds), so a fresh in-flight temp is never removed even under disk pressure; the live store and referenced transcripts are never matched by the temp classifier. Tests cover both stale-removed and fresh-preserved cases.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Sessions / storage
- [x] CLI / doctor

### Linked Issue/PR

Fixes #56827
