### PR TITLE
fix(agents): match runtime policy entries when session provider is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Docs: https://docs.openclaw.ai
 - Crabbox: install Corepack shims into the writable hydration `PNPM_HOME` so local AWS runner hydration no longer tries to overwrite `/usr/local/bin/pnpm`.
 - Live tests: fail Gateway live model sweeps when selected coverage is lost to timeouts or stale high-signal filters instead of reporting false missing-profile coverage, and pin Docker OpenAI gateway coverage to the current `gpt-5.5` lane.
 - Tests: fail Docker resource-ceiling checks when stats samples or configured limits are invalid instead of silently reporting zero peaks.
+- Agents: fail closed when provider-less session models match multiple provider-prefixed runtime policies so CLI runtime routing no longer depends on config order. (#85970) Thanks @potterdigital.
 
 ## 2026.5.24
 

--- a/src/agents/model-runtime-aliases.test.ts
+++ b/src/agents/model-runtime-aliases.test.ts
@@ -81,4 +81,37 @@ describe("resolveCliRuntimeExecutionProvider", () => {
       }),
     ).toBeUndefined();
   });
+
+  it("matches a configured claude-cli policy when the caller provider is empty", () => {
+    expect(
+      resolveCliRuntimeExecutionProvider({
+        cfg: createAnthropicAuthConfig({
+          models: {
+            "anthropic/opus-4.7": { agentRuntime: { id: "claude-cli" } },
+          },
+        }),
+        provider: "",
+        modelId: "opus-4.7",
+      }),
+    ).toBe("claude-cli");
+  });
+
+  // Regression: when the caller provider is empty, a configured CLI runtime
+  // alias must still be validated against the provider on the matched entry
+  // key. claude-cli is only legal for anthropic — a misconfigured
+  // `openrouter/X: claude-cli` policy must NOT route to claude-cli execution.
+  // See PR #85970 finding [P2].
+  it("does not return a CLI runtime when the matched entry's provider is incompatible with the runtime alias", () => {
+    expect(
+      resolveCliRuntimeExecutionProvider({
+        cfg: createAnthropicAuthConfig({
+          models: {
+            "openrouter/opus-4.7": { agentRuntime: { id: "claude-cli" } },
+          },
+        }),
+        provider: "",
+        modelId: "opus-4.7",
+      }),
+    ).toBeUndefined();
+  });
 });

--- a/src/agents/model-runtime-aliases.test.ts
+++ b/src/agents/model-runtime-aliases.test.ts
@@ -96,11 +96,6 @@ describe("resolveCliRuntimeExecutionProvider", () => {
     ).toBe("claude-cli");
   });
 
-  // Regression: when the caller provider is empty, a configured CLI runtime
-  // alias must still be validated against the provider on the matched entry
-  // key. claude-cli is only legal for anthropic — a misconfigured
-  // `openrouter/X: claude-cli` policy must NOT route to claude-cli execution.
-  // See PR #85970 finding [P2].
   it("does not return a CLI runtime when the matched entry's provider is incompatible with the runtime alias", () => {
     expect(
       resolveCliRuntimeExecutionProvider({

--- a/src/agents/model-runtime-aliases.ts
+++ b/src/agents/model-runtime-aliases.ts
@@ -187,13 +187,17 @@ function resolveConfiguredRuntime(params: {
   provider: string;
   agentId?: string;
   modelId?: string;
-}): string | undefined {
-  return resolveModelRuntimePolicy({
+}): { runtime?: string; matchedProvider?: string } {
+  const policy = resolveModelRuntimePolicy({
     config: params.cfg,
     provider: params.provider,
     modelId: params.modelId,
     agentId: params.agentId,
-  }).policy?.id?.trim();
+  });
+  return {
+    runtime: policy.policy?.id?.trim() || undefined,
+    matchedProvider: policy.matchedProvider,
+  };
 }
 
 function resolveProfileRuntimeAlias(params: {
@@ -277,12 +281,21 @@ export function resolveCliRuntimeExecutionProvider(params: {
   authProfileId?: string;
 }): string | undefined {
   const provider = normalizeProviderId(params.provider);
-  const runtime = resolveConfiguredRuntime({ ...params, provider });
+  const { runtime, matchedProvider } = resolveConfiguredRuntime({ ...params, provider });
   if (runtime === "pi") {
     return undefined;
   }
   if (!runtime || runtime === "auto") {
     return resolveCliRuntimeFromAuthProfile({ ...params, provider });
   }
-  return CLI_RUNTIME_BY_PROVIDER.get(`${provider}:${runtime}`)?.runtime;
+  // When the caller provider is empty (legacy session entries that stored a
+  // bare model id without a provider prefix), validate the CLI runtime against
+  // the provider carried forward from the matched policy entry. This rejects
+  // misconfigured pairings like `agents.defaults.models["openrouter/X"]:
+  // claude-cli` (claude-cli is only a legal runtime for anthropic).
+  const effectiveProvider = provider || normalizeProviderId(matchedProvider ?? "");
+  if (!effectiveProvider) {
+    return undefined;
+  }
+  return CLI_RUNTIME_BY_PROVIDER.get(`${effectiveProvider}:${runtime}`)?.runtime;
 }

--- a/src/agents/model-runtime-aliases.ts
+++ b/src/agents/model-runtime-aliases.ts
@@ -288,11 +288,6 @@ export function resolveCliRuntimeExecutionProvider(params: {
   if (!runtime || runtime === "auto") {
     return resolveCliRuntimeFromAuthProfile({ ...params, provider });
   }
-  // When the caller provider is empty (legacy session entries that stored a
-  // bare model id without a provider prefix), validate the CLI runtime against
-  // the provider carried forward from the matched policy entry. This rejects
-  // misconfigured pairings like `agents.defaults.models["openrouter/X"]:
-  // claude-cli` (claude-cli is only a legal runtime for anthropic).
   const effectiveProvider = provider || normalizeProviderId(matchedProvider ?? "");
   if (!effectiveProvider) {
     return undefined;

--- a/src/agents/model-runtime-policy.test.ts
+++ b/src/agents/model-runtime-policy.test.ts
@@ -305,10 +305,6 @@ describe("resolveModelRuntimePolicy", () => {
     });
   });
 
-  // Regression: agents.list[].models entries must win over agents.defaults.models
-  // for empty-provider matches. Without per-scope ambiguity handling, a
-  // conflicting default would silently veto a clean agent-specific match.
-  // See docs/gateway/config-agents.md precedence and PR #85970 finding [P1].
   it("prefers an agent-specific model entry over a conflicting defaults entry when the caller provider is empty", () => {
     const config = {
       agents: {
@@ -342,13 +338,14 @@ describe("resolveModelRuntimePolicy", () => {
     });
   });
 
-  it("returns ambiguous {} when the same scope has matches under multiple providers and the caller provider is empty", () => {
+  it("does not fall back to a provider wildcard when exact bare-model matches are ambiguous", () => {
     const config = {
       agents: {
         defaults: {
           models: {
             "openai/foo-1": { agentRuntime: { id: "codex" } },
             "azure/foo-1": { agentRuntime: { id: "codex" } },
+            "anthropic/*": { agentRuntime: { id: "claude-cli" } },
           },
         },
       },

--- a/src/agents/model-runtime-policy.test.ts
+++ b/src/agents/model-runtime-policy.test.ts
@@ -121,6 +121,7 @@ describe("resolveModelRuntimePolicy", () => {
     ).toEqual({
       policy: { id: "pi" },
       source: "model",
+      matchedProvider: "vllm",
     });
   });
 
@@ -143,6 +144,7 @@ describe("resolveModelRuntimePolicy", () => {
     ).toEqual({
       policy: { id: "pi" },
       source: "model",
+      matchedProvider: "vllm",
     });
   });
 
@@ -167,6 +169,7 @@ describe("resolveModelRuntimePolicy", () => {
     ).toEqual({
       policy: { id: "codex" },
       source: "model",
+      matchedProvider: "vllm",
     });
   });
 
@@ -230,6 +233,133 @@ describe("resolveModelRuntimePolicy", () => {
     ).toEqual({
       policy: { id: "pi" },
       source: "model",
+      matchedProvider: "vllm",
     });
+  });
+
+  it("matches a provider-prefixed agent model entry when the caller provider is empty", () => {
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "anthropic/claude-opus-4-7[1m]": { agentRuntime: { id: "claude-cli" } },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveModelRuntimePolicy({
+        config,
+        provider: "",
+        modelId: "claude-opus-4-7[1m]",
+      }),
+    ).toEqual({
+      policy: { id: "claude-cli" },
+      source: "model",
+      matchedProvider: "anthropic",
+    });
+  });
+
+  it("still rejects provider-prefixed entries whose provider disagrees with a non-empty caller provider", () => {
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "openrouter/claude-opus-4-7[1m]": { agentRuntime: { id: "openrouter-stream" } },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveModelRuntimePolicy({
+        config,
+        provider: "anthropic",
+        modelId: "claude-opus-4-7[1m]",
+      }),
+    ).toEqual({});
+  });
+
+  it("matches a provider wildcard agent model entry when the caller provider is empty", () => {
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "anthropic/*": { agentRuntime: { id: "claude-cli" } },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveModelRuntimePolicy({
+        config,
+        provider: "",
+        modelId: "claude-opus-4-7[1m]",
+      }),
+    ).toEqual({
+      policy: { id: "claude-cli" },
+      source: "model",
+      matchedProvider: "anthropic",
+    });
+  });
+
+  // Regression: agents.list[].models entries must win over agents.defaults.models
+  // for empty-provider matches. Without per-scope ambiguity handling, a
+  // conflicting default would silently veto a clean agent-specific match.
+  // See docs/gateway/config-agents.md precedence and PR #85970 finding [P1].
+  it("prefers an agent-specific model entry over a conflicting defaults entry when the caller provider is empty", () => {
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/foo-1": { agentRuntime: { id: "codex" } },
+          },
+        },
+        list: [
+          {
+            id: "main",
+            models: {
+              "anthropic/foo-1": { agentRuntime: { id: "claude-cli" } },
+            },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveModelRuntimePolicy({
+        config,
+        provider: "",
+        modelId: "foo-1",
+        agentId: "main",
+      }),
+    ).toEqual({
+      policy: { id: "claude-cli" },
+      source: "model",
+      matchedProvider: "anthropic",
+    });
+  });
+
+  it("returns ambiguous {} when the same scope has matches under multiple providers and the caller provider is empty", () => {
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/foo-1": { agentRuntime: { id: "codex" } },
+            "azure/foo-1": { agentRuntime: { id: "codex" } },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveModelRuntimePolicy({
+        config,
+        provider: "",
+        modelId: "foo-1",
+      }),
+    ).toEqual({});
   });
 });

--- a/src/agents/model-runtime-policy.test.ts
+++ b/src/agents/model-runtime-policy.test.ts
@@ -338,13 +338,13 @@ describe("resolveModelRuntimePolicy", () => {
     });
   });
 
-  it("does not fall back to a provider wildcard when exact bare-model matches are ambiguous", () => {
+  it("fails closed for duplicate provider-prefixed bare-model policies", () => {
     const config = {
       agents: {
         defaults: {
           models: {
             "openai/foo-1": { agentRuntime: { id: "codex" } },
-            "azure/foo-1": { agentRuntime: { id: "codex" } },
+            "anthropic/foo-1": { agentRuntime: { id: "claude-cli" } },
             "anthropic/*": { agentRuntime: { id: "claude-cli" } },
           },
         },

--- a/src/agents/model-runtime-policy.ts
+++ b/src/agents/model-runtime-policy.ts
@@ -11,6 +11,12 @@ export type ModelRuntimePolicySource = "model" | "provider";
 export type ResolvedModelRuntimePolicy = {
   policy?: AgentRuntimePolicyConfig;
   source?: ModelRuntimePolicySource;
+  /**
+   * Provider id from the matched entry key (e.g. "anthropic" for an
+   * `anthropic/foo` agent model entry). Lets downstream resolvers validate
+   * provider/runtime pairings when the caller passed an empty provider.
+   */
+  matchedProvider?: string;
 };
 
 type ModelEntryMatchKind = "none" | "exact" | "provider-wildcard";
@@ -81,7 +87,12 @@ function modelEntryMatchKind(params: {
   if (slash <= 0) {
     return "none";
   }
-  if (normalizeProviderId(entryId.slice(0, slash)) !== normalizeProviderId(params.provider ?? "")) {
+  // Empty/undefined caller provider means "no provider constraint"; the entry's
+  // slash-prefix is itself authoritative. Distinguishes the bare-model session
+  // case (saved before provider-prefix normalization) from a real mismatch.
+  const callerProvider = normalizeProviderId(params.provider ?? "");
+  const entryProvider = normalizeProviderId(entryId.slice(0, slash));
+  if (callerProvider && callerProvider !== entryProvider) {
     return "none";
   }
   const entryModelId = entryId.slice(slash + 1).trim();
@@ -114,9 +125,9 @@ function modelKeyIsProviderWildcard(params: {
   if (slash <= 0) {
     return false;
   }
-  if (
-    normalizeProviderId(params.key.slice(0, slash)) !== normalizeProviderId(params.provider ?? "")
-  ) {
+  const callerProvider = normalizeProviderId(params.provider ?? "");
+  const entryProvider = normalizeProviderId(params.key.slice(0, slash));
+  if (callerProvider && callerProvider !== entryProvider) {
     return false;
   }
   return params.key.slice(slash + 1).trim() === "*";
@@ -146,15 +157,46 @@ function resolveAgentModelEntryRuntimePolicy(params: {
     agentEntry?.models,
     params.config.agents?.defaults?.models,
   ];
+  const callerProvider = normalizeProviderId(params.provider ?? "");
+  // Walk model maps in precedence order (agent-specific before defaults) and
+  // resolve within the first scope that has any matches. When the caller
+  // provider is empty, multiple provider-prefixed entries in the SAME scope
+  // (e.g. defaults has both "openai/gpt-5" and "azure/gpt-5") are ambiguous and
+  // return {}; a lower-precedence scope must not introduce ambiguity that
+  // overrides a clean higher-precedence match.
   for (const models of modelMaps) {
+    const scopeMatches: Array<{ provider: string; policy: AgentRuntimePolicyConfig }> = [];
     for (const [key, entry] of Object.entries(models ?? {})) {
       const matches = modelId
         ? modelKeyMatchKind({ key, provider: params.provider, modelId }) === params.matchKind
         : modelKeyIsProviderWildcard({ key, provider: params.provider });
-      if (matches && hasRuntimePolicy(entry?.agentRuntime)) {
-        return { policy: entry.agentRuntime, source: "model" };
+      const policy = entry?.agentRuntime;
+      if (!matches || !policy || !hasRuntimePolicy(policy)) {
+        continue;
       }
+      const slash = key.indexOf("/");
+      const entryProvider = slash > 0 ? normalizeProviderId(key.slice(0, slash)) : "";
+      scopeMatches.push({ provider: entryProvider, policy });
     }
+    if (scopeMatches.length === 0) {
+      continue;
+    }
+    if (callerProvider) {
+      return {
+        policy: scopeMatches[0].policy,
+        source: "model",
+        matchedProvider: scopeMatches[0].provider || callerProvider,
+      };
+    }
+    const distinctProviders = new Set(scopeMatches.map((m) => m.provider));
+    if (distinctProviders.size > 1) {
+      return {};
+    }
+    return {
+      policy: scopeMatches[0].policy,
+      source: "model",
+      matchedProvider: scopeMatches[0].provider,
+    };
   }
   return {};
 }

--- a/src/agents/model-runtime-policy.ts
+++ b/src/agents/model-runtime-policy.ts
@@ -21,6 +21,15 @@ export type ResolvedModelRuntimePolicy = {
 
 type ModelEntryMatchKind = "none" | "exact" | "provider-wildcard";
 
+type AgentModelRuntimePolicyMatch = {
+  provider: string;
+  policy: AgentRuntimePolicyConfig;
+};
+
+type AgentModelRuntimePolicyResolution = ResolvedModelRuntimePolicy & {
+  ambiguous?: true;
+};
+
 function hasRuntimePolicy(value: AgentRuntimePolicyConfig | undefined): boolean {
   return Boolean(value?.id?.trim());
 }
@@ -66,6 +75,20 @@ function normalizeModelIdForProvider(
   return trimmed.slice(slash + 1).trim() || undefined;
 }
 
+function parseProviderModelKey(key: string): { provider: string; modelId: string } | undefined {
+  const slash = key.indexOf("/");
+  if (slash <= 0) {
+    return undefined;
+  }
+  const provider = normalizeProviderId(key.slice(0, slash));
+  const modelId = key.slice(slash + 1).trim();
+  return provider && modelId ? { provider, modelId } : undefined;
+}
+
+function providerMatchesCaller(provider: string, callerProvider: string): boolean {
+  return !callerProvider || provider === callerProvider;
+}
+
 function modelEntryMatches(params: {
   entry: Pick<ModelDefinitionConfig, "id">;
   provider: string | undefined;
@@ -83,23 +106,18 @@ function modelEntryMatchKind(params: {
   if (entryId === params.modelId) {
     return "exact";
   }
-  const slash = entryId.indexOf("/");
-  if (slash <= 0) {
+  const parsed = parseProviderModelKey(entryId);
+  if (!parsed) {
     return "none";
   }
-  // Empty/undefined caller provider means "no provider constraint"; the entry's
-  // slash-prefix is itself authoritative. Distinguishes the bare-model session
-  // case (saved before provider-prefix normalization) from a real mismatch.
   const callerProvider = normalizeProviderId(params.provider ?? "");
-  const entryProvider = normalizeProviderId(entryId.slice(0, slash));
-  if (callerProvider && callerProvider !== entryProvider) {
+  if (!providerMatchesCaller(parsed.provider, callerProvider)) {
     return "none";
   }
-  const entryModelId = entryId.slice(slash + 1).trim();
-  if (entryModelId === params.modelId) {
+  if (parsed.modelId === params.modelId) {
     return "exact";
   }
-  if (entryModelId === "*") {
+  if (parsed.modelId === "*") {
     return "provider-wildcard";
   }
   return "none";
@@ -121,16 +139,12 @@ function modelKeyIsProviderWildcard(params: {
   key: string;
   provider: string | undefined;
 }): boolean {
-  const slash = params.key.indexOf("/");
-  if (slash <= 0) {
+  const parsed = parseProviderModelKey(params.key);
+  if (!parsed) {
     return false;
   }
   const callerProvider = normalizeProviderId(params.provider ?? "");
-  const entryProvider = normalizeProviderId(params.key.slice(0, slash));
-  if (callerProvider && callerProvider !== entryProvider) {
-    return false;
-  }
-  return params.key.slice(slash + 1).trim() === "*";
+  return parsed.modelId === "*" && providerMatchesCaller(parsed.provider, callerProvider);
 }
 
 function resolveAgentModelEntryRuntimePolicy(params: {
@@ -140,7 +154,7 @@ function resolveAgentModelEntryRuntimePolicy(params: {
   agentId?: string;
   sessionKey?: string;
   matchKind: Exclude<ModelEntryMatchKind, "none">;
-}): ResolvedModelRuntimePolicy {
+}): AgentModelRuntimePolicyResolution {
   const modelId = normalizeModelIdForProvider(params.provider, params.modelId);
   if (!params.config || (!modelId && params.matchKind !== "provider-wildcard")) {
     return {};
@@ -158,14 +172,8 @@ function resolveAgentModelEntryRuntimePolicy(params: {
     params.config.agents?.defaults?.models,
   ];
   const callerProvider = normalizeProviderId(params.provider ?? "");
-  // Walk model maps in precedence order (agent-specific before defaults) and
-  // resolve within the first scope that has any matches. When the caller
-  // provider is empty, multiple provider-prefixed entries in the SAME scope
-  // (e.g. defaults has both "openai/gpt-5" and "azure/gpt-5") are ambiguous and
-  // return {}; a lower-precedence scope must not introduce ambiguity that
-  // overrides a clean higher-precedence match.
   for (const models of modelMaps) {
-    const scopeMatches: Array<{ provider: string; policy: AgentRuntimePolicyConfig }> = [];
+    const scopeMatches: AgentModelRuntimePolicyMatch[] = [];
     for (const [key, entry] of Object.entries(models ?? {})) {
       const matches = modelId
         ? modelKeyMatchKind({ key, provider: params.provider, modelId }) === params.matchKind
@@ -174,9 +182,7 @@ function resolveAgentModelEntryRuntimePolicy(params: {
       if (!matches || !policy || !hasRuntimePolicy(policy)) {
         continue;
       }
-      const slash = key.indexOf("/");
-      const entryProvider = slash > 0 ? normalizeProviderId(key.slice(0, slash)) : "";
-      scopeMatches.push({ provider: entryProvider, policy });
+      scopeMatches.push({ provider: parseProviderModelKey(key)?.provider ?? "", policy });
     }
     if (scopeMatches.length === 0) {
       continue;
@@ -190,7 +196,7 @@ function resolveAgentModelEntryRuntimePolicy(params: {
     }
     const distinctProviders = new Set(scopeMatches.map((m) => m.provider));
     if (distinctProviders.size > 1) {
-      return {};
+      return { ambiguous: true };
     }
     return {
       policy: scopeMatches[0].policy,
@@ -230,6 +236,9 @@ export function resolveModelRuntimePolicy(params: {
   }
 
   const agentModelPolicy = resolveAgentModelEntryRuntimePolicy({ ...params, matchKind: "exact" });
+  if (agentModelPolicy.ambiguous) {
+    return {};
+  }
   if (agentModelPolicy.policy) {
     return agentModelPolicy;
   }

--- a/src/agents/model-runtime-policy.ts
+++ b/src/agents/model-runtime-policy.ts
@@ -11,11 +11,6 @@ export type ModelRuntimePolicySource = "model" | "provider";
 export type ResolvedModelRuntimePolicy = {
   policy?: AgentRuntimePolicyConfig;
   source?: ModelRuntimePolicySource;
-  /**
-   * Provider id from the matched entry key (e.g. "anthropic" for an
-   * `anthropic/foo` agent model entry). Lets downstream resolvers validate
-   * provider/runtime pairings when the caller passed an empty provider.
-   */
   matchedProvider?: string;
 };
 
@@ -87,6 +82,24 @@ function parseProviderModelKey(key: string): { provider: string; modelId: string
 
 function providerMatchesCaller(provider: string, callerProvider: string): boolean {
   return !callerProvider || provider === callerProvider;
+}
+
+function resolvePolicyMatch(
+  matches: AgentModelRuntimePolicyMatch[],
+  callerProvider: string,
+): AgentModelRuntimePolicyResolution {
+  const [first] = matches;
+  if (!first) {
+    return {};
+  }
+  if (!callerProvider && matches.some((match) => match.provider !== first.provider)) {
+    return { ambiguous: true };
+  }
+  return {
+    policy: first.policy,
+    source: "model",
+    matchedProvider: first.provider || callerProvider,
+  };
 }
 
 function modelEntryMatches(params: {
@@ -184,25 +197,10 @@ function resolveAgentModelEntryRuntimePolicy(params: {
       }
       scopeMatches.push({ provider: parseProviderModelKey(key)?.provider ?? "", policy });
     }
-    if (scopeMatches.length === 0) {
-      continue;
+    const resolved = resolvePolicyMatch(scopeMatches, callerProvider);
+    if (resolved.policy || resolved.ambiguous) {
+      return resolved;
     }
-    if (callerProvider) {
-      return {
-        policy: scopeMatches[0].policy,
-        source: "model",
-        matchedProvider: scopeMatches[0].provider || callerProvider,
-      };
-    }
-    const distinctProviders = new Set(scopeMatches.map((m) => m.provider));
-    if (distinctProviders.size > 1) {
-      return { ambiguous: true };
-    }
-    return {
-      policy: scopeMatches[0].policy,
-      source: "model",
-      matchedProvider: scopeMatches[0].provider,
-    };
   }
   return {};
 }


### PR DESCRIPTION
## Summary

- Session entries persisted with a bare model id (no `<provider>/` prefix) silently fell through `agents.defaults.models["<provider>/<model>"].agentRuntime` policy lookup. `modelEntryMatchKind` in `src/agents/model-runtime-policy.ts` evaluated `normalizeProviderId("anthropic") !== normalizeProviderId("")` → returned `"none"` for every provider-prefixed entry, so a configured `agentRuntime: claude-cli` was never matched.
- Consequence on a production gateway running Claude subscription OAuth via `anthropic:claude-cli`: requests fell through to the embedded Anthropic-Messages harness, which sent the OAuth token (`sk-ant-oat01-…`) to `/v1/messages` and got back 404 `model_not_found`. All anthropic auth profiles cascaded into 40-min cooldown; every subsequent request surfaced `All models failed (3): … No available auth profile for anthropic` until cooldown expired. Concurrent cron/heartbeat runs that constructed a fresh runtime context with the qualified ref kept succeeding through `provider=claude-cli`.
- Fix: treat empty/undefined caller provider as "no constraint" — the entry's slash-prefix is itself authoritative. Mirror in `modelKeyIsProviderWildcard`. When the caller provider is empty and multiple distinct providers would match the same bare model id, refuse to silently pick — return `{}` instead of relying on `Object.entries` order. Then short-circuit `resolveCliRuntimeExecutionProvider` (`src/agents/model-runtime-aliases.ts`) on known CLI aliases when caller provider is empty, because the `${provider}:${runtime}` Map lookup can't hit with empty provider.

Refs `agents/main/sessions/sessions.json` sessions `d7034f5d-ee47-4c1f-95eb-e10c5793c8df` and `b74095ee-b89b-4411-a991-46da76cd84cd`.

## Real behavior proof

Behavior addressed: session entries that persisted bare model ids (no `<provider>/` prefix) silently fell through `agentRuntime: claude-cli` policy and routed Slack DMs to the embedded Anthropic-Messages harness, where Claude subscription OAuth tokens 404 against `/v1/messages` and cascade all anthropic auth profiles into cooldown.

Real environment tested: Production OpenClaw 2026.5.20 gateway running on Proxmox LXC CT 112 (Debian, Node 24.13.0). Carries 8 active agents (main/Dobby, gabe, gabe-voice, researcher, forge, architect, marcus, scribe), 27 cron jobs, live Slack channel (`agent:main:slack:direct:u01q3fya3s4`), `anthropic:claude-cli` OAuth subscription auth (Claude Pro Max). Bundle-level equivalent of this patch applied to the installed `dist/model-runtime-policy-pAmabiPO.js` + `dist/model-runtime-aliases-CF-sDqQj.js`, gateway restarted, real Slack DM sent.

Exact steps or command run after this patch:
1. Applied the equivalent patch to the two installed bundle files, verified with `node -c`.
2. `systemctl --user restart openclaw-gateway.service`.
3. Sent a real Slack DM to the `main` agent from Brian's user account through the existing `agent:main:slack:direct:u01q3fya3s4` channel: "Confirm your runtime: which provider+model is serving this reply, and was your auth profile in cooldown?"
4. Tailed `/tmp/openclaw/openclaw-2026-05-24.log` for matching events.
5. `node scripts/run-vitest.mjs src/agents/model-runtime-policy.test.ts src/agents/model-runtime-aliases.test.ts` — 28 tests pass.

Evidence after fix:

Gateway log lines triggered by the Slack DM (timestamps CDT):
```
02:30:50.766  cli exec: provider=claude-cli model=claude-opus-4-7[1m] promptChars=834 trigger=user useResume=true session=present resumeSession=27c5793ef4a7 reuse=reusable
02:31:04.215  claude live session turn: provider=claude-cli model=claude-opus-4-7[1m] durationMs=13431 rawLines=44
```

Dobby's self-reported reply over Slack:
> "Runtime: claude-cli/claude-opus-4-7[1m] via anthropic:claude-cli (OAuth, Claude Pro Max). Not in cooldown — auth healthy, fallbacks armed (opus-4-7, opus-4-6). Gateway came up 9m ago on 2026.5.20 (e510042)."

<img width="1166" height="299" alt="image" src="https://github.com/user-attachments/assets/d68c93d5-8c16-4b6a-9ff3-50460f46c58a" />

<img width="856" height="219" alt="image" src="https://github.com/user-attachments/assets/49eb2f6e-316a-4ba7-982a-deeb96fa93a5" />



Test suite outputs (paired with the real-environment evidence above, not standalone):
- `node scripts/run-vitest.mjs src/agents/model-runtime-policy.test.ts src/agents/model-runtime-aliases.test.ts` — `Test Files 3 passed (3), Tests 28 passed (28)`.
- `node scripts/run-oxlint.mjs <touched files>` — `exit=0`.
- `pnpm tsgo:core` — `exit=0`.
- `pnpm check:changed` — typecheck core green; pre-existing `src/plugins/document-extractors.runtime.test.ts(53,74): error TS2554` on clean `origin/main e9ca3115f0` and unrelated to this patch (verified by stash/un-stash).

Observed result after fix: same Slack DM lane that was 404-cascading and cooldown-spinning yesterday now routes through the `claude-cli` subprocess. `provider=claude-cli`, `durationMs=13.4s`, 44 raw output lines, no `embedded run` events, no `errorPreview`, no `auth_profile_failure_state_updated`, no `lane task error`. Concurrent cron jobs continue to succeed in parallel as they did before.

What was not tested: `google-gemini-cli` equivalent path — no failing session existed to replay, and the fix is structurally symmetric with `claude-cli` so the same defensive logic applies. Doctor's `codex-route-warnings.ts` callers — they always pass a qualified ref via `parseModelRef`, never empty, so the empty-provider arm of the patch never fires for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
