### PR TITLE
fix(memory): idle-evict cached MemoryIndexManager instances in long-running gateway (v2 with in-flight protection)

### DIFF
--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -170,6 +170,15 @@ const memoryRuntime: MemoryPluginRuntime = {
     const { memoryRuntime: runtime } = await loadRuntimeProviderModule();
     await runtime.closeMemorySearchManager?.(params);
   },
+  async closeIdleMemorySearchManagers(opts) {
+    const { memoryRuntime: runtime } = await loadRuntimeProviderModule();
+    return (
+      (await runtime.closeIdleMemorySearchManagers?.(opts)) ?? {
+        evicted: 0,
+        remaining: 0,
+      }
+    );
+  },
 };
 export default definePluginEntry({
   id: "memory-core",

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -176,6 +176,7 @@ const memoryRuntime: MemoryPluginRuntime = {
       (await runtime.closeIdleMemorySearchManagers?.(opts)) ?? {
         evicted: 0,
         skippedBusy: 0,
+        skippedRevalidated: 0,
         remaining: 0,
       }
     );

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -175,6 +175,7 @@ const memoryRuntime: MemoryPluginRuntime = {
     return (
       (await runtime.closeIdleMemorySearchManagers?.(opts)) ?? {
         evicted: 0,
+        skippedBusy: 0,
         remaining: 0,
       }
     );

--- a/extensions/memory-core/manager-runtime.ts
+++ b/extensions/memory-core/manager-runtime.ts
@@ -1,5 +1,6 @@
 export {
   closeAllMemoryIndexManagers,
+  closeIdleMemoryIndexManagers,
   closeMemoryIndexManagersForAgent,
   MemoryIndexManager,
 } from "./src/memory/manager-runtime.js";

--- a/extensions/memory-core/src/memory/index.ts
+++ b/extensions/memory-core/src/memory/index.ts
@@ -6,6 +6,7 @@ export type {
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 export {
   closeAllMemorySearchManagers,
+  closeIdleMemorySearchManagers,
   closeMemorySearchManager,
   getMemorySearchManager,
   type MemorySearchManagerPurpose,

--- a/extensions/memory-core/src/memory/manager-cache.test.ts
+++ b/extensions/memory-core/src/memory/manager-cache.test.ts
@@ -455,6 +455,165 @@ describe("manager cache", () => {
     expect(cache.cache.size).toBe(0);
   });
 
+  it("closeIdleManagedCacheEntries revalidates lastAccessAt before closing (race: cache hit during scan-to-close gap)", async () => {
+    // Regression for PR #85972 ClawSweeper review:
+    //   t0: scan collects toEvict[] based on stale lastAccessAt
+    //   t1: a concurrent caller does INDEX_CACHE.get(K), refreshing
+    //       lastAccessAt without acquiring busy refcount
+    //   t2: close loop must NOT close K — the next .search() would hit a
+    //       closed manager.
+    // We use the deterministic testHookBeforeCloseLoop hook to model
+    // the gap between survey and close.
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const entry = createEntry("refreshed-during-gap");
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "k",
+      create: async () => entry,
+    });
+    const now = Date.now();
+    cache.lastAccessAt.set("k", now - 30_000); // stale by survey time
+    const skippedRevalidatedKeys: string[] = [];
+    const result = await closeIdleManagedCacheEntries({
+      cache,
+      idleMs: 5_000,
+      now: () => now,
+      onSkipRevalidated: (key) => skippedRevalidatedKeys.push(key),
+      testHookBeforeCloseLoop: () => {
+        // Simulate a cache hit during the scan-to-close gap. The hit
+        // path (getOrCreateManagedCacheEntry) bumps lastAccessAt to
+        // `Date.now()` which is necessarily > our captured `now - idleMs`.
+        cache.lastAccessAt.set("k", now);
+      },
+    });
+    expect(result.evicted).toBe(0);
+    expect(result.skippedRevalidated).toBe(1);
+    expect(result.skippedBusy).toBe(0);
+    expect(result.remaining).toBe(1);
+    expect(entry.close).not.toHaveBeenCalled();
+    expect(cache.cache.has("k")).toBe(true);
+    expect(cache.lastAccessAt.get("k")).toBe(now);
+    expect(skippedRevalidatedKeys).toEqual(["k"]);
+  });
+
+  it("closeIdleManagedCacheEntries respects busy state acquired during scan-to-close gap", async () => {
+    // Companion test: same race window, but the gap action is
+    // acquireManagedCacheKey() rather than a cache hit. Counts under
+    // skippedBusy (consistent with the survey-loop busy skip).
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const entry = createEntry("acquired-during-gap");
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "k",
+      create: async () => entry,
+    });
+    const now = Date.now();
+    cache.lastAccessAt.set("k", now - 30_000);
+    let release: (() => void) | undefined;
+    const skippedBusyKeys: string[] = [];
+    const result = await closeIdleManagedCacheEntries({
+      cache,
+      idleMs: 5_000,
+      now: () => now,
+      onSkipBusy: (key) => skippedBusyKeys.push(key),
+      testHookBeforeCloseLoop: () => {
+        // Acquire AFTER the survey loop already added the key to stale[].
+        // acquireManagedCacheKey also refreshes lastAccessAt, so we reset
+        // it to keep the busy branch (not the freshness branch) firing.
+        release = acquireManagedCacheKey(cache, "k");
+        cache.lastAccessAt.set("k", now - 30_000);
+      },
+    });
+    try {
+      expect(result.evicted).toBe(0);
+      expect(result.skippedBusy).toBe(1);
+      expect(result.skippedRevalidated).toBe(0);
+      expect(result.remaining).toBe(1);
+      expect(entry.close).not.toHaveBeenCalled();
+      expect(cache.cache.has("k")).toBe(true);
+      expect(skippedBusyKeys).toEqual(["k"]);
+    } finally {
+      release?.();
+    }
+  });
+
+  it("closeIdleManagedCacheEntries treats cache identity replacement as revalidation skip", async () => {
+    // If cache.set(key, newEntry) lands in the scan-to-close gap, the
+    // captured entry no longer matches the cache slot. We must NOT
+    // close either entry: the new one has its own fresh state and the
+    // old one was already replaced by the swap caller.
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const original = createEntry("original");
+    const replacement = createEntry("replacement");
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "k",
+      create: async () => original,
+    });
+    const now = Date.now();
+    cache.lastAccessAt.set("k", now - 30_000);
+    const result = await closeIdleManagedCacheEntries({
+      cache,
+      idleMs: 5_000,
+      now: () => now,
+      testHookBeforeCloseLoop: () => {
+        // Swap in a new instance and keep lastAccessAt stale so the
+        // revalidation branch we hit is specifically the identity
+        // mismatch one (not the freshness or busy ones).
+        cache.cache.set("k", replacement);
+      },
+    });
+    expect(result.evicted).toBe(0);
+    expect(result.skippedRevalidated).toBe(1);
+    expect(result.skippedBusy).toBe(0);
+    expect(original.close).not.toHaveBeenCalled();
+    expect(replacement.close).not.toHaveBeenCalled();
+    expect(cache.cache.get("k")).toBe(replacement);
+  });
+
+  it("closeIdleManagedCacheEntries handles disappearance of cache slot during gap", async () => {
+    // Another caller fully tore down the entry during the scan-to-close
+    // gap (e.g. a competing closeMemoryIndexManagersForAgent path). The
+    // sweep should treat that as a revalidation skip — not crash, not
+    // double-close.
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const entry = createEntry("torn-down");
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "k",
+      create: async () => entry,
+    });
+    const now = Date.now();
+    cache.lastAccessAt.set("k", now - 30_000);
+    const result = await closeIdleManagedCacheEntries({
+      cache,
+      idleMs: 5_000,
+      now: () => now,
+      testHookBeforeCloseLoop: () => {
+        cache.cache.delete("k");
+        // lastAccessAt intentionally not deleted yet — exercise the
+        // currentEntry === undefined branch which also cleans it up.
+      },
+    });
+    expect(result.evicted).toBe(0);
+    expect(result.skippedRevalidated).toBe(1);
+    expect(entry.close).not.toHaveBeenCalled();
+    expect(cache.cache.has("k")).toBe(false);
+    expect(cache.lastAccessAt.has("k")).toBe(false);
+  });
+
   it("bypasses identity caching for status-only callers", async () => {
     const cache = createTestCache();
     cachesForCleanup.push(cache);

--- a/extensions/memory-core/src/memory/manager-cache.test.ts
+++ b/extensions/memory-core/src/memory/manager-cache.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  closeIdleManagedCacheEntries,
   closeManagedCacheEntries,
   getOrCreateManagedCacheEntry,
   resolveSingletonManagedCache,
@@ -132,6 +133,170 @@ describe("manager cache", () => {
     expect(resolvedFirst).toBe(first);
     expect(resolvedSecond).toBe(second);
     expect(resolvedSecond).not.toBe(resolvedFirst);
+  });
+
+  it("records lastAccessAt when forwarded to getOrCreateManagedCacheEntry", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const before = Date.now();
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "k",
+      create: async () => createEntry("e"),
+    });
+    const recorded = cache.lastAccessAt.get("k");
+    expect(recorded).toBeTypeOf("number");
+    expect(recorded!).toBeGreaterThanOrEqual(before);
+  });
+
+  it("refreshes lastAccessAt on cache hit", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "k",
+      create: async () => createEntry("e"),
+    });
+    const firstAccess = cache.lastAccessAt.get("k")!;
+    // Advance time deterministically so the second access has a later
+    // timestamp without depending on wall-clock granularity.
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(firstAccess + 5_000);
+    try {
+      await getOrCreateManagedCacheEntry({
+        cache: cache.cache,
+        pending: cache.pending,
+        lastAccessAt: cache.lastAccessAt,
+        key: "k",
+        create: async () => createEntry("never-called"),
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
+    expect(cache.lastAccessAt.get("k")).toBe(firstAccess + 5_000);
+  });
+
+  it("closeIdleManagedCacheEntries evicts entries past the idle threshold", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const entry = createEntry("idle");
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "k",
+      create: async () => entry,
+    });
+    // Make the entry look ancient.
+    cache.lastAccessAt.set("k", Date.now() - 10_000);
+    const evictedKeys: string[] = [];
+    const result = await closeIdleManagedCacheEntries({
+      cache,
+      idleMs: 5_000,
+      onEvictKey: (key) => evictedKeys.push(key),
+    });
+    expect(result.evicted).toBe(1);
+    expect(result.remaining).toBe(0);
+    expect(entry.close).toHaveBeenCalledTimes(1);
+    expect(cache.cache.has("k")).toBe(false);
+    expect(cache.lastAccessAt.has("k")).toBe(false);
+    expect(evictedKeys).toEqual(["k"]);
+  });
+
+  it("closeIdleManagedCacheEntries leaves recently accessed entries alone", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const fresh = createEntry("fresh");
+    const stale = createEntry("stale");
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "fresh",
+      create: async () => fresh,
+    });
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "stale",
+      create: async () => stale,
+    });
+    cache.lastAccessAt.set("stale", Date.now() - 10_000);
+    const result = await closeIdleManagedCacheEntries({ cache, idleMs: 5_000 });
+    expect(result.evicted).toBe(1);
+    expect(result.remaining).toBe(1);
+    expect(fresh.close).not.toHaveBeenCalled();
+    expect(stale.close).toHaveBeenCalledTimes(1);
+    expect(cache.cache.has("fresh")).toBe(true);
+    expect(cache.cache.has("stale")).toBe(false);
+  });
+
+  it("closeIdleManagedCacheEntries isolates close() errors and still evicts the rest", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const failing: TestEntry = {
+      id: "failing",
+      close: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    };
+    const ok = createEntry("ok");
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "failing",
+      create: async () => failing,
+    });
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "ok",
+      create: async () => ok,
+    });
+    cache.lastAccessAt.set("failing", Date.now() - 10_000);
+    cache.lastAccessAt.set("ok", Date.now() - 10_000);
+    const errors: unknown[] = [];
+    const result = await closeIdleManagedCacheEntries({
+      cache,
+      idleMs: 5_000,
+      onCloseError: (err) => errors.push(err),
+    });
+    expect(result.evicted).toBe(2);
+    expect(failing.close).toHaveBeenCalledTimes(1);
+    expect(ok.close).toHaveBeenCalledTimes(1);
+    expect(errors).toHaveLength(1);
+    expect(cache.cache.size).toBe(0);
+  });
+
+  it("closeIdleManagedCacheEntries is idempotent when entry.close removes its own cache slot", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const entry: TestEntry = {
+      id: "self-evict",
+      close: vi.fn(async () => {
+        // Simulate MemoryIndexManager.close() removing its own cache entry.
+        cache.cache.delete("k");
+        cache.lastAccessAt.delete("k");
+      }),
+    };
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "k",
+      create: async () => entry,
+    });
+    cache.lastAccessAt.set("k", Date.now() - 10_000);
+    const result = await closeIdleManagedCacheEntries({ cache, idleMs: 5_000 });
+    expect(result.evicted).toBe(1);
+    expect(entry.close).toHaveBeenCalledTimes(1);
+    expect(cache.cache.size).toBe(0);
   });
 
   it("bypasses identity caching for status-only callers", async () => {

--- a/extensions/memory-core/src/memory/manager-cache.test.ts
+++ b/extensions/memory-core/src/memory/manager-cache.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  acquireManagedCacheKey,
   closeIdleManagedCacheEntries,
   closeManagedCacheEntries,
   getOrCreateManagedCacheEntry,
+  isManagedCacheKeyBusy,
   resolveSingletonManagedCache,
   type ManagedCache,
 } from "./manager-cache.js";
@@ -272,6 +274,160 @@ describe("manager cache", () => {
     expect(ok.close).toHaveBeenCalledTimes(1);
     expect(errors).toHaveLength(1);
     expect(cache.cache.size).toBe(0);
+  });
+
+  it("acquireManagedCacheKey marks the key busy until release fires", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const entry = createEntry("busy");
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "k",
+      create: async () => entry,
+    });
+    expect(isManagedCacheKeyBusy(cache, "k")).toBe(false);
+    const release = acquireManagedCacheKey(cache, "k");
+    expect(isManagedCacheKeyBusy(cache, "k")).toBe(true);
+    release();
+    expect(isManagedCacheKeyBusy(cache, "k")).toBe(false);
+  });
+
+  it("acquireManagedCacheKey refcounts nested acquires", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const release1 = acquireManagedCacheKey(cache, "k");
+    const release2 = acquireManagedCacheKey(cache, "k");
+    expect(cache.inflightCount.get("k")).toBe(2);
+    release1();
+    expect(cache.inflightCount.get("k")).toBe(1);
+    expect(isManagedCacheKeyBusy(cache, "k")).toBe(true);
+    release2();
+    expect(cache.inflightCount.has("k")).toBe(false);
+    expect(isManagedCacheKeyBusy(cache, "k")).toBe(false);
+  });
+
+  it("release is idempotent and never produces negative counts", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const release = acquireManagedCacheKey(cache, "k");
+    release();
+    release();
+    release();
+    expect(cache.inflightCount.has("k")).toBe(false);
+  });
+
+  it("acquire and release both refresh lastAccessAt", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const t0 = 1_700_000_000_000;
+    const spy = vi.spyOn(Date, "now");
+    try {
+      spy.mockReturnValue(t0);
+      const release = acquireManagedCacheKey(cache, "k");
+      expect(cache.lastAccessAt.get("k")).toBe(t0);
+      spy.mockReturnValue(t0 + 7_000);
+      release();
+      expect(cache.lastAccessAt.get("k")).toBe(t0 + 7_000);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("closeIdleManagedCacheEntries defers busy entries past idleMs", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const entry = createEntry("busy-stale");
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "k",
+      create: async () => entry,
+    });
+    // Simulate a long-running operation acquiring the key while the cache
+    // entry ages past idleMs without further refresh.
+    const release = acquireManagedCacheKey(cache, "k");
+    cache.lastAccessAt.set("k", Date.now() - 30_000);
+    const skippedKeys: string[] = [];
+    const first = await closeIdleManagedCacheEntries({
+      cache,
+      idleMs: 5_000,
+      onSkipBusy: (key) => skippedKeys.push(key),
+    });
+    expect(first.evicted).toBe(0);
+    expect(first.skippedBusy).toBe(1);
+    expect(first.remaining).toBe(1);
+    expect(entry.close).not.toHaveBeenCalled();
+    expect(cache.cache.has("k")).toBe(true);
+    expect(skippedKeys).toEqual(["k"]);
+
+    // Release the in-flight operation. release() refreshes lastAccessAt, so
+    // the next sweep is a no-op; we must age the entry again before it can
+    // be evicted.
+    release();
+    expect(isManagedCacheKeyBusy(cache, "k")).toBe(false);
+    const second = await closeIdleManagedCacheEntries({ cache, idleMs: 5_000 });
+    expect(second.evicted).toBe(0);
+    expect(entry.close).not.toHaveBeenCalled();
+
+    cache.lastAccessAt.set("k", Date.now() - 30_000);
+    const third = await closeIdleManagedCacheEntries({ cache, idleMs: 5_000 });
+    expect(third.evicted).toBe(1);
+    expect(third.skippedBusy).toBe(0);
+    expect(entry.close).toHaveBeenCalledTimes(1);
+    expect(cache.cache.has("k")).toBe(false);
+  });
+
+  it("closeIdleManagedCacheEntries evicts non-busy stale entries alongside busy deferrals", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const idle = createEntry("idle");
+    const busy = createEntry("busy");
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "idle",
+      create: async () => idle,
+    });
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "busy",
+      create: async () => busy,
+    });
+    const release = acquireManagedCacheKey(cache, "busy");
+    cache.lastAccessAt.set("idle", Date.now() - 30_000);
+    cache.lastAccessAt.set("busy", Date.now() - 30_000);
+    const result = await closeIdleManagedCacheEntries({ cache, idleMs: 5_000 });
+    expect(result.evicted).toBe(1);
+    expect(result.skippedBusy).toBe(1);
+    expect(result.remaining).toBe(1);
+    expect(idle.close).toHaveBeenCalledTimes(1);
+    expect(busy.close).not.toHaveBeenCalled();
+    release();
+  });
+
+  it("closeIdleManagedCacheEntries clears inflightCount on eviction", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const entry = createEntry("e");
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "k",
+      create: async () => entry,
+    });
+    // No in-flight refs; eviction should clean up an empty count entry too.
+    cache.inflightCount.set("k", 0);
+    cache.lastAccessAt.set("k", Date.now() - 30_000);
+    await closeIdleManagedCacheEntries({ cache, idleMs: 5_000 });
+    expect(cache.cache.has("k")).toBe(false);
+    expect(cache.inflightCount.has("k")).toBe(false);
   });
 
   it("closeIdleManagedCacheEntries is idempotent when entry.close removes its own cache slot", async () => {

--- a/extensions/memory-core/src/memory/manager-cache.ts
+++ b/extensions/memory-core/src/memory/manager-cache.ts
@@ -179,6 +179,15 @@ export function isManagedCacheKeyBusy<T>(cache: ManagedCache<T>, key: string): b
 // callback for observability, and reported back to callers via the
 // `skippedBusy` count so periodic sidecars can log them.
 //
+// Scan-to-close race protection: between the survey loop and the close
+// loop, a concurrent caller can refresh lastAccessAt (cache hit) or
+// acquire the busy refcount on a key we already added to the eviction
+// list. Before closing each entry we re-validate `lastAccessAt`
+// freshness against the same cutoff, `isBusy`, and cache identity. An
+// entry that no longer satisfies the original idle predicate is
+// reported back via the new `skippedRevalidated` counter and left in
+// the cache for the next scan to reconsider.
+//
 // Entries can themselves remove their own cacheKey from cache.delete() during
 // close() (e.g. MemoryIndexManager does this); this is intentional and
 // idempotent because we capture the eviction list up-front and re-check the
@@ -190,11 +199,22 @@ export async function closeIdleManagedCacheEntries<T extends Closable>(params: {
   onCloseError?: (err: unknown) => void;
   onEvictKey?: (key: string) => void;
   onSkipBusy?: (key: string) => void;
-}): Promise<{ evicted: number; skippedBusy: number; remaining: number }> {
+  onSkipRevalidated?: (key: string) => void;
+  // Test hook: invoked after the survey loop but before the close loop.
+  // Allows regression tests to deterministically inject a cache hit or
+  // busy acquire into the scan-to-close gap.
+  testHookBeforeCloseLoop?: () => Promise<void> | void;
+}): Promise<{
+  evicted: number;
+  skippedBusy: number;
+  skippedRevalidated: number;
+  remaining: number;
+}> {
   const now = (params.now ?? Date.now)();
   const cutoff = now - params.idleMs;
   const stale: Array<{ key: string; entry: T }> = [];
   let skippedBusy = 0;
+  let skippedRevalidated = 0;
   for (const [key, lastAccess] of params.cache.lastAccessAt) {
     if (lastAccess > cutoff) {
       continue;
@@ -215,14 +235,57 @@ export async function closeIdleManagedCacheEntries<T extends Closable>(params: {
     }
     stale.push({ key, entry });
   }
+  // Test hook: lets regression tests simulate the scan-to-close gap by
+  // injecting a cache hit or busy acquire between survey and close.
+  if (params.testHookBeforeCloseLoop) {
+    await params.testHookBeforeCloseLoop();
+  }
   let evicted = 0;
   for (const { key, entry } of stale) {
-    // Double-check the busy flag right before close in case a caller
-    // acquired the key between the survey loop and this point. Skipping
-    // here is cheap and avoids a close()-during-use race.
+    // Re-validate state immediately before close to close the race
+    // identified in PR #85972 review: between the survey loop and this
+    // point a concurrent caller may have either refreshed lastAccessAt
+    // (cache hit), acquired the busy refcount, or replaced the cache
+    // entry with a new instance. Closing in any of those cases would
+    // hand out a stale closed reference.
+    const currentTs = params.cache.lastAccessAt.get(key);
+    if (currentTs === undefined) {
+      // Another path already evicted this key (e.g. close() racing with
+      // a competing teardown). Nothing to do.
+      skippedRevalidated += 1;
+      params.onSkipRevalidated?.(key);
+      continue;
+    }
+    if (currentTs > cutoff) {
+      // Refreshed during the scan-to-close gap. Leave the entry in the
+      // cache and let the next scan reconsider it against a fresher
+      // cutoff. This is the merge-blocker case from the review.
+      skippedRevalidated += 1;
+      params.onSkipRevalidated?.(key);
+      continue;
+    }
     if (isManagedCacheKeyBusy(params.cache, key)) {
+      // Busy was acquired during the gap; treat the same as the survey
+      // loop skip so sidecar metrics stay consistent.
       skippedBusy += 1;
       params.onSkipBusy?.(key);
+      continue;
+    }
+    const currentEntry = params.cache.cache.get(key);
+    if (!currentEntry) {
+      // Cache slot disappeared during the gap. Cleanup any orphan
+      // lastAccessAt entry and move on.
+      params.cache.lastAccessAt.delete(key);
+      skippedRevalidated += 1;
+      params.onSkipRevalidated?.(key);
+      continue;
+    }
+    if (currentEntry !== entry) {
+      // Cache identity changed (cache.set(key, newEntry) happened in the
+      // gap). The new entry has its own fresh lastAccessAt and may be
+      // in-flight; leave it for the next scan instead of closing it.
+      skippedRevalidated += 1;
+      params.onSkipRevalidated?.(key);
       continue;
     }
     // Drop the cache slot first so concurrent readers do not pick up a
@@ -243,5 +306,10 @@ export async function closeIdleManagedCacheEntries<T extends Closable>(params: {
     }
     evicted += 1;
   }
-  return { evicted, skippedBusy, remaining: params.cache.cache.size };
+  return {
+    evicted,
+    skippedBusy,
+    skippedRevalidated,
+    remaining: params.cache.cache.size,
+  };
 }

--- a/extensions/memory-core/src/memory/manager-cache.ts
+++ b/extensions/memory-core/src/memory/manager-cache.ts
@@ -7,27 +7,46 @@ type Closable = {
 export type ManagedCache<T> = {
   cache: Map<string, T>;
   pending: Map<string, Promise<T>>;
+  // Tracks last access time per cache key for idle-TTL eviction in
+  // long-running daemons. Refreshed on cache hit and on initial set.
+  lastAccessAt: Map<string, number>;
 };
+
+function isManagedCacheShape<T>(value: unknown): value is ManagedCache<T> {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const candidate = value as Partial<ManagedCache<T>>;
+  return (
+    candidate.cache instanceof Map &&
+    candidate.pending instanceof Map &&
+    candidate.lastAccessAt instanceof Map
+  );
+}
 
 export function resolveSingletonManagedCache<T>(cacheKey: symbol): ManagedCache<T> {
   const resolved = resolveGlobalSingleton<unknown>(cacheKey, () => ({
     cache: new Map<string, T>(),
     pending: new Map<string, Promise<T>>(),
+    lastAccessAt: new Map<string, number>(),
   }));
-  if (
-    typeof resolved === "object" &&
-    resolved !== null &&
-    (resolved as Partial<ManagedCache<T>>).cache instanceof Map &&
-    (resolved as Partial<ManagedCache<T>>).pending instanceof Map
-  ) {
-    return resolved as ManagedCache<T>;
+  if (isManagedCacheShape<T>(resolved)) {
+    return resolved;
   }
+  // Older daemons may have placed an incompatible shape (e.g. missing
+  // lastAccessAt) at this key. Re-seed a fresh cache so callers get a
+  // consistent structure.
   const repaired: ManagedCache<T> = {
     cache: new Map<string, T>(),
     pending: new Map<string, Promise<T>>(),
+    lastAccessAt: new Map<string, number>(),
   };
   (globalThis as Record<PropertyKey, unknown>)[cacheKey] = repaired;
   return repaired;
+}
+
+function recordLastAccess(lastAccessAt: Map<string, number> | undefined, key: string): void {
+  lastAccessAt?.set(key, Date.now());
 }
 
 export async function getOrCreateManagedCacheEntry<T>(params: {
@@ -36,12 +55,17 @@ export async function getOrCreateManagedCacheEntry<T>(params: {
   key: string;
   bypassCache?: boolean;
   create: () => Promise<T> | T;
+  // Optional last-access tracker. Callers that pass a ManagedCache should
+  // forward its lastAccessAt map so idle-TTL eviction sees a fresh
+  // timestamp on every cache hit.
+  lastAccessAt?: Map<string, number>;
 }): Promise<T> {
   if (params.bypassCache) {
     return await params.create();
   }
   const existing = params.cache.get(params.key);
   if (existing) {
+    recordLastAccess(params.lastAccessAt, params.key);
     return existing;
   }
   const pending = params.pending.get(params.key);
@@ -51,10 +75,12 @@ export async function getOrCreateManagedCacheEntry<T>(params: {
   const createPromise = (async () => {
     const refreshed = params.cache.get(params.key);
     if (refreshed) {
+      recordLastAccess(params.lastAccessAt, params.key);
       return refreshed;
     }
     const entry = await params.create();
     params.cache.set(params.key, entry);
+    recordLastAccess(params.lastAccessAt, params.key);
     return entry;
   })();
   params.pending.set(params.key, createPromise);
@@ -70,6 +96,7 @@ export async function getOrCreateManagedCacheEntry<T>(params: {
 export async function closeManagedCacheEntries<T extends Closable>(params: {
   cache: Map<string, T>;
   pending: Map<string, Promise<T>>;
+  lastAccessAt?: Map<string, number>;
   onCloseError?: (err: unknown) => void;
 }): Promise<void> {
   const pending = Array.from(params.pending.values());
@@ -78,6 +105,7 @@ export async function closeManagedCacheEntries<T extends Closable>(params: {
   }
   const entries = Array.from(params.cache.values());
   params.cache.clear();
+  params.lastAccessAt?.clear();
   for (const entry of entries) {
     if (typeof entry.close !== "function") {
       continue;
@@ -88,4 +116,57 @@ export async function closeManagedCacheEntries<T extends Closable>(params: {
       params.onCloseError?.(err);
     }
   }
+}
+
+// Idle-TTL eviction for long-running daemons. Walks the lastAccessAt map and
+// closes any entry whose last access happened more than `idleMs` ago. Each
+// entry's close() is awaited sequentially so errors are isolated; a thrown
+// error from one entry does not prevent later entries from being evicted.
+//
+// Entries can themselves remove their own cacheKey from cache.delete() during
+// close() (e.g. MemoryIndexManager does this); this is intentional and
+// idempotent because we capture the eviction list up-front and re-check the
+// cache before deleting.
+export async function closeIdleManagedCacheEntries<T extends Closable>(params: {
+  cache: ManagedCache<T>;
+  idleMs: number;
+  now?: () => number;
+  onCloseError?: (err: unknown) => void;
+  onEvictKey?: (key: string) => void;
+}): Promise<{ evicted: number; remaining: number }> {
+  const now = (params.now ?? Date.now)();
+  const cutoff = now - params.idleMs;
+  const stale: Array<{ key: string; entry: T }> = [];
+  for (const [key, lastAccess] of params.cache.lastAccessAt) {
+    if (lastAccess > cutoff) {
+      continue;
+    }
+    const entry = params.cache.cache.get(key);
+    if (!entry) {
+      // lastAccessAt drifted out of sync with cache; clean it up.
+      params.cache.lastAccessAt.delete(key);
+      continue;
+    }
+    stale.push({ key, entry });
+  }
+  let evicted = 0;
+  for (const { key, entry } of stale) {
+    // Drop the cache slot first so concurrent readers do not pick up a
+    // closing entry. close() may itself attempt the same delete; that is
+    // safe because Map.delete on a missing key is a no-op.
+    if (params.cache.cache.get(key) === entry) {
+      params.cache.cache.delete(key);
+    }
+    params.cache.lastAccessAt.delete(key);
+    params.onEvictKey?.(key);
+    if (typeof entry.close === "function") {
+      try {
+        await entry.close();
+      } catch (err) {
+        params.onCloseError?.(err);
+      }
+    }
+    evicted += 1;
+  }
+  return { evicted, remaining: params.cache.cache.size };
 }

--- a/extensions/memory-core/src/memory/manager-cache.ts
+++ b/extensions/memory-core/src/memory/manager-cache.ts
@@ -10,6 +10,12 @@ export type ManagedCache<T> = {
   // Tracks last access time per cache key for idle-TTL eviction in
   // long-running daemons. Refreshed on cache hit and on initial set.
   lastAccessAt: Map<string, number>;
+  // Tracks the number of in-flight operations currently using each cache
+  // entry. Idle eviction must NOT close an entry whose count is > 0 even
+  // if its lastAccessAt has aged past the idle threshold (e.g. a long
+  // batch reindex that started before idleMs elapsed and is still
+  // running). See acquireManagedCacheKey / isManagedCacheKeyBusy.
+  inflightCount: Map<string, number>;
 };
 
 function isManagedCacheShape<T>(value: unknown): value is ManagedCache<T> {
@@ -20,7 +26,8 @@ function isManagedCacheShape<T>(value: unknown): value is ManagedCache<T> {
   return (
     candidate.cache instanceof Map &&
     candidate.pending instanceof Map &&
-    candidate.lastAccessAt instanceof Map
+    candidate.lastAccessAt instanceof Map &&
+    candidate.inflightCount instanceof Map
   );
 }
 
@@ -29,17 +36,19 @@ export function resolveSingletonManagedCache<T>(cacheKey: symbol): ManagedCache<
     cache: new Map<string, T>(),
     pending: new Map<string, Promise<T>>(),
     lastAccessAt: new Map<string, number>(),
+    inflightCount: new Map<string, number>(),
   }));
   if (isManagedCacheShape<T>(resolved)) {
     return resolved;
   }
   // Older daemons may have placed an incompatible shape (e.g. missing
-  // lastAccessAt) at this key. Re-seed a fresh cache so callers get a
-  // consistent structure.
+  // lastAccessAt or inflightCount) at this key. Re-seed a fresh cache so
+  // callers get a consistent structure.
   const repaired: ManagedCache<T> = {
     cache: new Map<string, T>(),
     pending: new Map<string, Promise<T>>(),
     lastAccessAt: new Map<string, number>(),
+    inflightCount: new Map<string, number>(),
   };
   (globalThis as Record<PropertyKey, unknown>)[cacheKey] = repaired;
   return repaired;
@@ -97,6 +106,7 @@ export async function closeManagedCacheEntries<T extends Closable>(params: {
   cache: Map<string, T>;
   pending: Map<string, Promise<T>>;
   lastAccessAt?: Map<string, number>;
+  inflightCount?: Map<string, number>;
   onCloseError?: (err: unknown) => void;
 }): Promise<void> {
   const pending = Array.from(params.pending.values());
@@ -106,6 +116,11 @@ export async function closeManagedCacheEntries<T extends Closable>(params: {
   const entries = Array.from(params.cache.values());
   params.cache.clear();
   params.lastAccessAt?.clear();
+  // Full teardown is unconditional: by the time callers reach
+  // closeManagedCacheEntries (process shutdown / agent close), they have
+  // already decided to terminate work and any lingering refcounts are
+  // stale. Drop them so subsequent test runs start clean.
+  params.inflightCount?.clear();
   for (const entry of entries) {
     if (typeof entry.close !== "function") {
       continue;
@@ -118,10 +133,51 @@ export async function closeManagedCacheEntries<T extends Closable>(params: {
   }
 }
 
+// Mark a cache key as in-flight. Returns a release function the caller
+// must invoke (typically in a try/finally) when the operation completes.
+// While inflightCount[key] > 0, closeIdleManagedCacheEntries will skip
+// the entry even if its lastAccessAt has aged past the idle threshold.
+//
+// The release function is idempotent. Both acquire() and release() also
+// touch lastAccessAt so that a manager which was busy for the whole idle
+// window gets a fresh idle countdown once it goes idle (avoiding an
+// immediate eviction on the very next scan).
+export function acquireManagedCacheKey<T>(cache: ManagedCache<T>, key: string): () => void {
+  const current = cache.inflightCount.get(key) ?? 0;
+  cache.inflightCount.set(key, current + 1);
+  cache.lastAccessAt.set(key, Date.now());
+  let released = false;
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    const c = cache.inflightCount.get(key) ?? 0;
+    if (c <= 1) {
+      cache.inflightCount.delete(key);
+    } else {
+      cache.inflightCount.set(key, c - 1);
+    }
+    cache.lastAccessAt.set(key, Date.now());
+  };
+}
+
+export function isManagedCacheKeyBusy<T>(cache: ManagedCache<T>, key: string): boolean {
+  return (cache.inflightCount.get(key) ?? 0) > 0;
+}
+
 // Idle-TTL eviction for long-running daemons. Walks the lastAccessAt map and
 // closes any entry whose last access happened more than `idleMs` ago. Each
 // entry's close() is awaited sequentially so errors are isolated; a thrown
 // error from one entry does not prevent later entries from being evicted.
+//
+// Active-use protection: entries with inflightCount[key] > 0 are skipped
+// regardless of how stale lastAccessAt looks. This is the safety net for
+// long-running operations (batch reindex, async search-time sync, ...)
+// whose runtime can exceed idleMs while only refreshing lastAccessAt at
+// the start and end. They are surfaced through the optional onSkipBusy
+// callback for observability, and reported back to callers via the
+// `skippedBusy` count so periodic sidecars can log them.
 //
 // Entries can themselves remove their own cacheKey from cache.delete() during
 // close() (e.g. MemoryIndexManager does this); this is intentional and
@@ -133,10 +189,12 @@ export async function closeIdleManagedCacheEntries<T extends Closable>(params: {
   now?: () => number;
   onCloseError?: (err: unknown) => void;
   onEvictKey?: (key: string) => void;
-}): Promise<{ evicted: number; remaining: number }> {
+  onSkipBusy?: (key: string) => void;
+}): Promise<{ evicted: number; skippedBusy: number; remaining: number }> {
   const now = (params.now ?? Date.now)();
   const cutoff = now - params.idleMs;
   const stale: Array<{ key: string; entry: T }> = [];
+  let skippedBusy = 0;
   for (const [key, lastAccess] of params.cache.lastAccessAt) {
     if (lastAccess > cutoff) {
       continue;
@@ -147,10 +205,26 @@ export async function closeIdleManagedCacheEntries<T extends Closable>(params: {
       params.cache.lastAccessAt.delete(key);
       continue;
     }
+    if (isManagedCacheKeyBusy(params.cache, key)) {
+      // Active-use protection: a long-running operation currently holds
+      // a reference to this entry. Defer eviction until the next scan
+      // after release() fires (which will also refresh lastAccessAt).
+      skippedBusy += 1;
+      params.onSkipBusy?.(key);
+      continue;
+    }
     stale.push({ key, entry });
   }
   let evicted = 0;
   for (const { key, entry } of stale) {
+    // Double-check the busy flag right before close in case a caller
+    // acquired the key between the survey loop and this point. Skipping
+    // here is cheap and avoids a close()-during-use race.
+    if (isManagedCacheKeyBusy(params.cache, key)) {
+      skippedBusy += 1;
+      params.onSkipBusy?.(key);
+      continue;
+    }
     // Drop the cache slot first so concurrent readers do not pick up a
     // closing entry. close() may itself attempt the same delete; that is
     // safe because Map.delete on a missing key is a no-op.
@@ -158,6 +232,7 @@ export async function closeIdleManagedCacheEntries<T extends Closable>(params: {
       params.cache.cache.delete(key);
     }
     params.cache.lastAccessAt.delete(key);
+    params.cache.inflightCount.delete(key);
     params.onEvictKey?.(key);
     if (typeof entry.close === "function") {
       try {
@@ -168,5 +243,5 @@ export async function closeIdleManagedCacheEntries<T extends Closable>(params: {
     }
     evicted += 1;
   }
-  return { evicted, remaining: params.cache.cache.size };
+  return { evicted, skippedBusy, remaining: params.cache.cache.size };
 }

--- a/extensions/memory-core/src/memory/manager-runtime.ts
+++ b/extensions/memory-core/src/memory/manager-runtime.ts
@@ -1,5 +1,6 @@
 export {
   closeAllMemoryIndexManagers,
+  closeIdleMemoryIndexManagers,
   closeMemoryIndexManagersForAgent,
   MemoryIndexManager,
 } from "./manager.js";

--- a/extensions/memory-core/src/memory/manager.idle-gc.test.ts
+++ b/extensions/memory-core/src/memory/manager.idle-gc.test.ts
@@ -156,6 +156,142 @@ describe("closeIdleMemoryIndexManagers", () => {
     expect(cache.cache.has("idle:in-flight")).toBe(false);
   });
 
+  it("protects manager whose sync is waiting on provider initialization", async () => {
+    // Regression for the provider-init race identified in PR #85972 review:
+    // before the fix, MemoryIndexManager.sync() awaited
+    // ensureProviderInitialized() outside the withBusy() scope, so the idle
+    // sweeper could observe busy=0 while a caller was blocked on a slow
+    // provider boot (seconds to minutes for some embedding APIs) and evict
+    // the manager before its work even started.
+    //
+    // This test simulates production's `withBusy(async () => { await
+    // ensureProviderInitialized(); ... })` ordering and verifies that the
+    // busy refcount is already held during the provider-init wait, so the
+    // sweeper reports skippedBusy === 1 and evicted === 0.
+    const stale = seed("idle:provider-init-sync", Date.now() - 30_000);
+
+    let resolveProviderInit!: () => void;
+    const providerInitPromise = new Promise<void>((resolve) => {
+      resolveProviderInit = resolve;
+    });
+
+    // Production sync(): withBusy wraps the entire body including the
+    // ensureProviderInitialized() await. Reproduce that ordering exactly.
+    const syncRun = (async () => {
+      const release = acquireManagedCacheKey(cache, stale.cacheKey);
+      try {
+        // Step out of the way of the scan below by aging lastAccessAt
+        // (acquire just refreshed it). The busy ref must be the thing
+        // keeping us alive.
+        cache.lastAccessAt.set(stale.cacheKey, Date.now() - 30_000);
+        await providerInitPromise;
+        // Provider init complete; in production this is where embedding /
+        // vector / FTS work would actually run. For the test, completing
+        // the await is enough to prove the busy ref covered the wait.
+      } finally {
+        release();
+      }
+    })();
+
+    // Let acquireManagedCacheKey fire before we run the scan.
+    await Promise.resolve();
+
+    const firstScan = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+    expect(firstScan.skippedBusy).toBe(1);
+    expect(firstScan.evicted).toBe(0);
+    expect(stale.close).not.toHaveBeenCalled();
+    expect(cache.cache.has(stale.cacheKey)).toBe(true);
+
+    // Unblock provider init and let the simulated sync drain.
+    resolveProviderInit();
+    await syncRun;
+
+    // After release the manager is evict-eligible again. Re-age lastAccessAt
+    // because release() refreshed it.
+    cache.lastAccessAt.set(stale.cacheKey, Date.now() - 30_000);
+    const secondScan = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+    expect(secondScan.skippedBusy).toBe(0);
+    expect(secondScan.evicted).toBe(1);
+    expect(stale.close).toHaveBeenCalledTimes(1);
+    expect(cache.cache.has(stale.cacheKey)).toBe(false);
+  });
+
+  it("protects manager whose search is waiting on provider initialization", async () => {
+    // Same race surface as sync(), but exercised via the search() entry
+    // point. Production search() wraps the entire searchInternal flow in
+    // withBusy, so a provider-init await deep inside searchInternal is
+    // still protected.
+    const stale = seed("idle:provider-init-search", Date.now() - 30_000);
+
+    let resolveProviderInit!: () => void;
+    const providerInitPromise = new Promise<void>((resolve) => {
+      resolveProviderInit = resolve;
+    });
+
+    const searchRun = (async () => {
+      const release = acquireManagedCacheKey(cache, stale.cacheKey);
+      try {
+        cache.lastAccessAt.set(stale.cacheKey, Date.now() - 30_000);
+        // In production this happens inside searchInternal, after the
+        // outer search() has already entered withBusy.
+        await providerInitPromise;
+      } finally {
+        release();
+      }
+    })();
+
+    await Promise.resolve();
+
+    const firstScan = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+    expect(firstScan.skippedBusy).toBe(1);
+    expect(firstScan.evicted).toBe(0);
+    expect(stale.close).not.toHaveBeenCalled();
+
+    resolveProviderInit();
+    await searchRun;
+
+    cache.lastAccessAt.set(stale.cacheKey, Date.now() - 30_000);
+    const secondScan = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+    expect(secondScan.evicted).toBe(1);
+    expect(stale.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the busy ref when provider initialization throws", async () => {
+    // If ensureProviderInitialized() rejects, the withBusy() finally block
+    // must still release the busy ref so the entry becomes evict-eligible
+    // rather than leaking inflightCount > 0 forever.
+    const stale = seed("idle:provider-init-throws", Date.now() - 30_000);
+
+    let rejectProviderInit!: (err: unknown) => void;
+    const providerInitPromise = new Promise<void>((_resolve, reject) => {
+      rejectProviderInit = reject;
+    });
+
+    const syncRun = (async () => {
+      const release = acquireManagedCacheKey(cache, stale.cacheKey);
+      try {
+        cache.lastAccessAt.set(stale.cacheKey, Date.now() - 30_000);
+        await providerInitPromise;
+      } finally {
+        release();
+      }
+    })();
+
+    await Promise.resolve();
+
+    const duringScan = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+    expect(duringScan.skippedBusy).toBe(1);
+    expect(duringScan.evicted).toBe(0);
+
+    rejectProviderInit(new Error("provider boot failed"));
+    await expect(syncRun).rejects.toThrow(/provider boot failed/);
+
+    cache.lastAccessAt.set(stale.cacheKey, Date.now() - 30_000);
+    const afterScan = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+    expect(afterScan.evicted).toBe(1);
+    expect(stale.close).toHaveBeenCalledTimes(1);
+  });
+
   it("defers multiple busy entries together in a single scan", async () => {
     const a = seed("idle:busy-a", Date.now() - 30_000);
     const b = seed("idle:busy-b", Date.now() - 30_000);

--- a/extensions/memory-core/src/memory/manager.idle-gc.test.ts
+++ b/extensions/memory-core/src/memory/manager.idle-gc.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ManagedCache } from "./manager-cache.js";
+import { closeIdleMemoryIndexManagers, EMBEDDING_PROBE_CACHE_TTL_MS } from "./manager.js";
+
+const MEMORY_INDEX_MANAGER_CACHE_KEY = Symbol.for("openclaw.memoryIndexManagerCache");
+
+type FakeManager = {
+  cacheKey: string;
+  close: () => Promise<void>;
+};
+
+function resolveLiveCache(): ManagedCache<FakeManager> {
+  const cache = (globalThis as Record<PropertyKey, unknown>)[MEMORY_INDEX_MANAGER_CACHE_KEY];
+  if (
+    !cache ||
+    typeof cache !== "object" ||
+    !(cache as ManagedCache<FakeManager>).cache ||
+    !(cache as ManagedCache<FakeManager>).lastAccessAt
+  ) {
+    throw new Error("MemoryIndexManager singleton cache not initialized");
+  }
+  return cache as ManagedCache<FakeManager>;
+}
+
+function makeFakeManager(cacheKey: string): FakeManager {
+  return {
+    cacheKey,
+    close: vi.fn(async () => {}),
+  };
+}
+
+describe("closeIdleMemoryIndexManagers", () => {
+  let cache: ManagedCache<FakeManager>;
+  const seededKeys: string[] = [];
+
+  beforeEach(() => {
+    cache = resolveLiveCache();
+  });
+
+  afterEach(() => {
+    for (const key of seededKeys.splice(0)) {
+      cache.cache.delete(key);
+      cache.lastAccessAt.delete(key);
+    }
+  });
+
+  function seed(key: string, lastAccessAt: number): FakeManager {
+    const manager = makeFakeManager(key);
+    cache.cache.set(key, manager);
+    cache.lastAccessAt.set(key, lastAccessAt);
+    seededKeys.push(key);
+    return manager;
+  }
+
+  it("evicts cached managers idle past the threshold and calls close()", async () => {
+    const stale = seed("idle:stale", Date.now() - 10_000);
+    const fresh = seed("idle:fresh", Date.now());
+
+    const result = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+
+    expect(result.evicted).toBe(1);
+    expect(stale.close).toHaveBeenCalledTimes(1);
+    expect(fresh.close).not.toHaveBeenCalled();
+    expect(cache.cache.has("idle:stale")).toBe(false);
+    expect(cache.cache.has("idle:fresh")).toBe(true);
+    expect(cache.lastAccessAt.has("idle:stale")).toBe(false);
+  });
+
+  it("idleMs=0 evicts every cached manager (used in tests/teardown)", async () => {
+    const a = seed("idle:a", Date.now());
+    const b = seed("idle:b", Date.now());
+
+    const result = await closeIdleMemoryIndexManagers({ idleMs: 0 });
+
+    expect(result.evicted).toBeGreaterThanOrEqual(2);
+    expect(a.close).toHaveBeenCalledTimes(1);
+    expect(b.close).toHaveBeenCalledTimes(1);
+    expect(cache.cache.has("idle:a")).toBe(false);
+    expect(cache.cache.has("idle:b")).toBe(false);
+  });
+
+  it("clears the embedding probe cache entry alongside the evicted manager", async () => {
+    // Pull in the embedding probe cache by importing the manager module
+    // surface. We populate the probe cache indirectly by seeding the
+    // private map through the same module load: simulate by going through
+    // a helper that the production code uses.
+    const stale = seed("idle:probe", Date.now() - 10_000);
+
+    // Round-trip probe TTL constant to ensure the module is wired.
+    expect(EMBEDDING_PROBE_CACHE_TTL_MS).toBeGreaterThan(0);
+
+    const result = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+
+    expect(result.evicted).toBe(1);
+    expect(stale.close).toHaveBeenCalledTimes(1);
+    // After eviction the cache entry is gone; the probe cache deletion
+    // path is exercised through the onEvictKey hook in the production
+    // implementation (the symbol-keyed cache is internal so we cannot
+    // peek at it directly here, but exercising the path proves the hook
+    // fired without throwing).
+    expect(cache.cache.has("idle:probe")).toBe(false);
+  });
+
+  it("isolates close() errors from one manager so others still get evicted", async () => {
+    const failing: FakeManager = {
+      cacheKey: "idle:bad",
+      close: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    };
+    cache.cache.set("idle:bad", failing);
+    cache.lastAccessAt.set("idle:bad", Date.now() - 10_000);
+    seededKeys.push("idle:bad");
+
+    const ok = seed("idle:ok", Date.now() - 10_000);
+
+    const result = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+
+    expect(result.evicted).toBe(2);
+    expect(failing.close).toHaveBeenCalledTimes(1);
+    expect(ok.close).toHaveBeenCalledTimes(1);
+    expect(cache.cache.has("idle:bad")).toBe(false);
+    expect(cache.cache.has("idle:ok")).toBe(false);
+  });
+
+  it("returns zero when there is nothing to evict", async () => {
+    const result = await closeIdleMemoryIndexManagers({ idleMs: 60_000 });
+    expect(result.evicted).toBe(0);
+  });
+});

--- a/extensions/memory-core/src/memory/manager.idle-gc.test.ts
+++ b/extensions/memory-core/src/memory/manager.idle-gc.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { ManagedCache } from "./manager-cache.js";
+import { acquireManagedCacheKey, type ManagedCache } from "./manager-cache.js";
 import { closeIdleMemoryIndexManagers, EMBEDDING_PROBE_CACHE_TTL_MS } from "./manager.js";
 
 const MEMORY_INDEX_MANAGER_CACHE_KEY = Symbol.for("openclaw.memoryIndexManagerCache");
@@ -126,5 +126,54 @@ describe("closeIdleMemoryIndexManagers", () => {
   it("returns zero when there is nothing to evict", async () => {
     const result = await closeIdleMemoryIndexManagers({ idleMs: 60_000 });
     expect(result.evicted).toBe(0);
+    expect(result.skippedBusy).toBe(0);
+  });
+
+  it("defers a manager held in-flight via acquireManagedCacheKey", async () => {
+    const stale = seed("idle:in-flight", Date.now() - 30_000);
+    // Simulate a long-running batch reindex that started before the idle
+    // window opened and is still executing.
+    const release = acquireManagedCacheKey(cache, "idle:in-flight");
+    // Override the lastAccessAt that acquire just refreshed so the scan
+    // sees a stale timestamp; the busy guard is what must keep us alive.
+    cache.lastAccessAt.set("idle:in-flight", Date.now() - 30_000);
+
+    const first = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+    expect(first.evicted).toBe(0);
+    expect(first.skippedBusy).toBe(1);
+    expect(stale.close).not.toHaveBeenCalled();
+    expect(cache.cache.has("idle:in-flight")).toBe(true);
+
+    // Once the in-flight operation completes, release() refreshes
+    // lastAccessAt; we age the entry again before the next scan to confirm
+    // it then evicts cleanly.
+    release();
+    cache.lastAccessAt.set("idle:in-flight", Date.now() - 30_000);
+    const second = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+    expect(second.evicted).toBe(1);
+    expect(second.skippedBusy).toBe(0);
+    expect(stale.close).toHaveBeenCalledTimes(1);
+    expect(cache.cache.has("idle:in-flight")).toBe(false);
+  });
+
+  it("defers multiple busy entries together in a single scan", async () => {
+    const a = seed("idle:busy-a", Date.now() - 30_000);
+    const b = seed("idle:busy-b", Date.now() - 30_000);
+    const c = seed("idle:fresh", Date.now() - 30_000);
+    const releaseA = acquireManagedCacheKey(cache, "idle:busy-a");
+    const releaseB = acquireManagedCacheKey(cache, "idle:busy-b");
+    cache.lastAccessAt.set("idle:busy-a", Date.now() - 30_000);
+    cache.lastAccessAt.set("idle:busy-b", Date.now() - 30_000);
+
+    const result = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+    expect(result.evicted).toBe(1);
+    expect(result.skippedBusy).toBe(2);
+    expect(a.close).not.toHaveBeenCalled();
+    expect(b.close).not.toHaveBeenCalled();
+    expect(c.close).toHaveBeenCalledTimes(1);
+    expect(cache.cache.has("idle:fresh")).toBe(false);
+
+    releaseA();
+    releaseB();
   });
 });

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -108,9 +108,12 @@ export async function closeAllMemoryIndexManagers(): Promise<void> {
 // cache. closeIdleManagedCacheEntries honors that refcount and skips
 // busy entries; busyDeferred is the count of such skipped keys for this
 // scan and is logged when non-zero.
-export async function closeIdleMemoryIndexManagers(opts: {
-  idleMs: number;
-}): Promise<{ evicted: number; skippedBusy: number; remaining: number }> {
+export async function closeIdleMemoryIndexManagers(opts: { idleMs: number }): Promise<{
+  evicted: number;
+  skippedBusy: number;
+  skippedRevalidated: number;
+  remaining: number;
+}> {
   return await closeIdleManagedCacheEntries({
     cache: INDEX_MANAGER_CACHE,
     idleMs: opts.idleMs,

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -32,6 +32,7 @@ import { bm25RankToScore, buildFtsQuery, mergeHybridResults } from "./hybrid.js"
 import { awaitPendingManagerWork, startAsyncSearchSync } from "./manager-async-state.js";
 import { MEMORY_BATCH_FAILURE_LIMIT } from "./manager-batch-state.js";
 import {
+  closeIdleManagedCacheEntries,
   closeManagedCacheEntries,
   getOrCreateManagedCacheEntry,
   resolveSingletonManagedCache,
@@ -64,8 +65,11 @@ export const EMBEDDING_PROBE_CACHE_TTL_MS = 30_000;
 const log = createSubsystemLogger("memory");
 type MemoryIndexManagerPurpose = "default" | "status" | "cli";
 
-const { cache: INDEX_CACHE, pending: INDEX_CACHE_PENDING } =
-  resolveSingletonManagedCache<MemoryIndexManager>(MEMORY_INDEX_MANAGER_CACHE_KEY);
+const INDEX_MANAGER_CACHE = resolveSingletonManagedCache<MemoryIndexManager>(
+  MEMORY_INDEX_MANAGER_CACHE_KEY,
+);
+const INDEX_CACHE = INDEX_MANAGER_CACHE.cache;
+const INDEX_CACHE_PENDING = INDEX_MANAGER_CACHE.pending;
 
 type EmbeddingProbeCacheEntry = {
   result: MemoryEmbeddingProbeResult;
@@ -80,8 +84,35 @@ export async function closeAllMemoryIndexManagers(): Promise<void> {
   await closeManagedCacheEntries({
     cache: INDEX_CACHE,
     pending: INDEX_CACHE_PENDING,
+    lastAccessAt: INDEX_MANAGER_CACHE.lastAccessAt,
     onCloseError: (err) => {
       log.warn(`failed to close memory index manager: ${String(err)}`);
+    },
+  });
+}
+
+// Idle-TTL eviction for cached MemoryIndexManager instances in long-running
+// gateway daemons. Each manager owns a chokidar FSWatcher that accumulates
+// native handles and file descriptors over time; CLI-exit-only cleanup
+// (see closeAllMemoryIndexManagers) is not enough for daemon processes.
+//
+// This is intended to run on a slow periodic tick (every few minutes). The
+// idle threshold should be larger than the typical gap between memory
+// searches to avoid churning the cache.
+export async function closeIdleMemoryIndexManagers(opts: {
+  idleMs: number;
+}): Promise<{ evicted: number; remaining: number }> {
+  return await closeIdleManagedCacheEntries({
+    cache: INDEX_MANAGER_CACHE,
+    idleMs: opts.idleMs,
+    onCloseError: (err) => {
+      log.warn(`failed to close idle memory index manager: ${String(err)}`);
+    },
+    onEvictKey: (key) => {
+      // Drop the embedding probe entry so the next request re-probes the
+      // provider rather than serving a stale TTL result tied to the evicted
+      // manager instance.
+      EMBEDDING_PROBE_CACHE.delete(key);
     },
   });
 }
@@ -105,6 +136,7 @@ export async function closeMemoryIndexManagersForAgent(params: {
     return;
   }
   INDEX_CACHE.delete(key);
+  INDEX_MANAGER_CACHE.lastAccessAt.delete(key);
   try {
     await manager.close();
   } catch (err) {
@@ -208,6 +240,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     return await getOrCreateManagedCacheEntry({
       cache: INDEX_CACHE,
       pending: INDEX_CACHE_PENDING,
+      lastAccessAt: INDEX_MANAGER_CACHE.lastAccessAt,
       key,
       bypassCache: transient,
       create: async () =>
@@ -985,6 +1018,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       if (INDEX_CACHE.get(this.cacheKey) === this) {
         INDEX_CACHE.delete(this.cacheKey);
       }
+      INDEX_MANAGER_CACHE.lastAccessAt.delete(this.cacheKey);
     }
     const closeError = closeErrors.values().next().value;
     if (closeError) {

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -733,23 +733,31 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     if (this.closed) {
       return;
     }
-    await this.ensureProviderInitialized();
-    if (this.syncing) {
-      if (params?.sessionFiles?.some((sessionFile) => sessionFile.trim().length > 0)) {
-        return this.enqueueTargetedSessionSync(params.sessionFiles);
+    // Hold the busy ref across the entire sync lifetime, including the
+    // provider initialization step below. Without this outer wrapper, the
+    // idle sweeper could observe a stale lastAccessAt and busy=0 while we
+    // are blocked inside ensureProviderInitialized() and evict the manager
+    // before the inner reindex even starts.
+    return await this.withBusy(async () => {
+      await this.ensureProviderInitialized();
+      if (this.syncing) {
+        if (params?.sessionFiles?.some((sessionFile) => sessionFile.trim().length > 0)) {
+          return this.enqueueTargetedSessionSync(params.sessionFiles);
+        }
+        return this.syncing;
       }
-      return this.syncing;
-    }
-    // Wrap the underlying recovery loop in withBusy so the idle sweeper
-    // does not close this manager partway through a batch reindex or
-    // long sync pass. Refcount is released in the chained finally below
-    // alongside this.syncing reset, guaranteeing they unwind together.
-    const release = acquireManagedCacheKey(INDEX_MANAGER_CACHE, this.cacheKey);
-    this.syncing = this.runSyncWithReadonlyRecovery(params).finally(() => {
-      this.syncing = null;
-      release();
+      // Wrap the underlying recovery loop in a nested busy ref so the
+      // idle sweeper still skips us after the outer withBusy() unwinds
+      // (e.g. when a search() caller awaits us but a longer reindex keeps
+      // running). Nested refcounts are additive; both releases must fire
+      // for the entry to become evict-eligible.
+      const release = acquireManagedCacheKey(INDEX_MANAGER_CACHE, this.cacheKey);
+      this.syncing = this.runSyncWithReadonlyRecovery(params).finally(() => {
+        this.syncing = null;
+        release();
+      });
+      await (this.syncing ?? Promise.resolve());
     });
-    return this.syncing ?? Promise.resolve();
   }
 
   private enqueueTargetedSessionSync(sessionFiles?: string[]): Promise<void> {
@@ -950,15 +958,19 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       this.vector.semanticAvailable = false;
       return false;
     }
-    await this.ensureProviderInitialized();
-    // FTS-only mode: vector search not available
-    if (!this.provider) {
-      this.vector.semanticAvailable = false;
-      return false;
-    }
-    const ready = await this.probeVectorStoreAvailability();
-    this.vector.semanticAvailable = ready;
-    return ready;
+    // Hold busy across provider init so idle eviction cannot close the
+    // manager mid-probe.
+    return await this.withBusy(async () => {
+      await this.ensureProviderInitialized();
+      // FTS-only mode: vector search not available
+      if (!this.provider) {
+        this.vector.semanticAvailable = false;
+        return false;
+      }
+      const ready = await this.probeVectorStoreAvailability();
+      this.vector.semanticAvailable = ready;
+      return ready;
+    });
   }
 
   async probeVectorStoreAvailability(): Promise<boolean> {
@@ -1003,21 +1015,26 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     if (cached) {
       return cached;
     }
-    await this.ensureProviderInitialized();
-    // FTS-only mode: embeddings not available but search still works
-    if (!this.provider) {
-      return this.cacheProbeResult({
-        ok: false,
-        error: this.providerUnavailableReason ?? "No embedding provider available (FTS-only mode)",
-      });
-    }
-    try {
-      await this.embedBatchWithRetry(["ping"]);
-      return this.cacheProbeResult({ ok: true });
-    } catch (err) {
-      const message = formatErrorMessage(err);
-      return this.cacheProbeResult({ ok: false, error: message });
-    }
+    // Hold busy across provider init so idle eviction cannot close the
+    // manager mid-probe.
+    return await this.withBusy(async () => {
+      await this.ensureProviderInitialized();
+      // FTS-only mode: embeddings not available but search still works
+      if (!this.provider) {
+        return this.cacheProbeResult({
+          ok: false,
+          error:
+            this.providerUnavailableReason ?? "No embedding provider available (FTS-only mode)",
+        });
+      }
+      try {
+        await this.embedBatchWithRetry(["ping"]);
+        return this.cacheProbeResult({ ok: true });
+      } catch (err) {
+        const message = formatErrorMessage(err);
+        return this.cacheProbeResult({ ok: false, error: message });
+      }
+    });
   }
 
   async close(): Promise<void> {

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -32,6 +32,7 @@ import { bm25RankToScore, buildFtsQuery, mergeHybridResults } from "./hybrid.js"
 import { awaitPendingManagerWork, startAsyncSearchSync } from "./manager-async-state.js";
 import { MEMORY_BATCH_FAILURE_LIMIT } from "./manager-batch-state.js";
 import {
+  acquireManagedCacheKey,
   closeIdleManagedCacheEntries,
   closeManagedCacheEntries,
   getOrCreateManagedCacheEntry,
@@ -85,6 +86,7 @@ export async function closeAllMemoryIndexManagers(): Promise<void> {
     cache: INDEX_CACHE,
     pending: INDEX_CACHE_PENDING,
     lastAccessAt: INDEX_MANAGER_CACHE.lastAccessAt,
+    inflightCount: INDEX_MANAGER_CACHE.inflightCount,
     onCloseError: (err) => {
       log.warn(`failed to close memory index manager: ${String(err)}`);
     },
@@ -99,9 +101,16 @@ export async function closeAllMemoryIndexManagers(): Promise<void> {
 // This is intended to run on a slow periodic tick (every few minutes). The
 // idle threshold should be larger than the typical gap between memory
 // searches to avoid churning the cache.
+//
+// Managers currently running a long-lived operation (full reindex, batch
+// reindex, async sync-on-search) wrap themselves in MemoryIndexManager.
+// withBusy(), which bumps an inflightCount refcount on the singleton
+// cache. closeIdleManagedCacheEntries honors that refcount and skips
+// busy entries; busyDeferred is the count of such skipped keys for this
+// scan and is logged when non-zero.
 export async function closeIdleMemoryIndexManagers(opts: {
   idleMs: number;
-}): Promise<{ evicted: number; remaining: number }> {
+}): Promise<{ evicted: number; skippedBusy: number; remaining: number }> {
   return await closeIdleManagedCacheEntries({
     cache: INDEX_MANAGER_CACHE,
     idleMs: opts.idleMs,
@@ -137,6 +146,7 @@ export async function closeMemoryIndexManagersForAgent(params: {
   }
   INDEX_CACHE.delete(key);
   INDEX_MANAGER_CACHE.lastAccessAt.delete(key);
+  INDEX_MANAGER_CACHE.inflightCount.delete(key);
   try {
     await manager.close();
   } catch (err) {
@@ -370,6 +380,25 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       qmdSearchModeOverride?: "query" | "search" | "vsearch";
       onDebug?: (debug: MemorySearchRuntimeDebug) => void;
       /** When set, only these chunk sources are considered (must be enabled for this manager). */
+      sources?: MemorySource[];
+    },
+  ): Promise<MemorySearchResult[]> {
+    // Mark this manager as in-flight for the full search lifetime so the
+    // idle sweeper cannot close us while embedding/vector/FTS work is in
+    // progress. The inner sync() call below will acquire its own ref
+    // (refcounting is additive), and the search() refcount drops in the
+    // finally below.
+    return await this.withBusy(async () => this.searchInternal(query, opts));
+  }
+
+  private async searchInternal(
+    query: string,
+    opts?: {
+      maxResults?: number;
+      minScore?: number;
+      sessionKey?: string;
+      qmdSearchModeOverride?: "query" | "search" | "vsearch";
+      onDebug?: (debug: MemorySearchRuntimeDebug) => void;
       sources?: MemorySource[];
     },
   ): Promise<MemorySearchResult[]> {
@@ -675,6 +704,23 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }).then((entries) => entries.map((entry) => entry as MemorySearchResult));
   }
 
+  // Runs `fn` with this manager's cache key marked as in-flight so the
+  // idle-eviction sweeper (closeIdleMemoryIndexManagers) will not close
+  // us mid-operation. Safe to nest: each call acquires its own ref.
+  //
+  // Use this on long-running operations whose runtime can exceed the
+  // configured idle threshold (full reindex, batch reindex, search-time
+  // async sync, etc.). Short-lived synchronous reads against the cached
+  // manager do not need wrapping; they refresh lastAccessAt on cache hit.
+  protected async withBusy<T>(fn: () => Promise<T>): Promise<T> {
+    const release = acquireManagedCacheKey(INDEX_MANAGER_CACHE, this.cacheKey);
+    try {
+      return await fn();
+    } finally {
+      release();
+    }
+  }
+
   async sync(params?: {
     reason?: string;
     force?: boolean;
@@ -691,8 +737,14 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       }
       return this.syncing;
     }
+    // Wrap the underlying recovery loop in withBusy so the idle sweeper
+    // does not close this manager partway through a batch reindex or
+    // long sync pass. Refcount is released in the chained finally below
+    // alongside this.syncing reset, guaranteeing they unwind together.
+    const release = acquireManagedCacheKey(INDEX_MANAGER_CACHE, this.cacheKey);
     this.syncing = this.runSyncWithReadonlyRecovery(params).finally(() => {
       this.syncing = null;
+      release();
     });
     return this.syncing ?? Promise.resolve();
   }
@@ -1019,6 +1071,10 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         INDEX_CACHE.delete(this.cacheKey);
       }
       INDEX_MANAGER_CACHE.lastAccessAt.delete(this.cacheKey);
+      // Clear any residual inflightCount for this key. Outstanding
+      // release() callbacks tied to acquireManagedCacheKey() are
+      // idempotent and safe to fire after the cache slot is gone.
+      INDEX_MANAGER_CACHE.inflightCount.delete(this.cacheKey);
     }
     const closeError = closeErrors.values().next().value;
     if (closeError) {

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -440,11 +440,19 @@ export async function closeMemorySearchManager(params: {
 // have an in-flight operation (e.g. batch reindex) holding them via
 // MemoryIndexManager.withBusy(). Those entries are eligible again on the
 // next scan after release() fires.
-export async function closeIdleMemorySearchManagers(opts: {
-  idleMs: number;
-}): Promise<{ evicted: number; skippedBusy: number; remaining: number }> {
+//
+// Returns `skippedRevalidated` for entries that aged past idleMs in the
+// initial survey but were either refreshed by a cache hit, replaced by
+// a fresh manager, or already removed by another teardown path during
+// the scan-to-close gap. They are also retried on the next scan.
+export async function closeIdleMemorySearchManagers(opts: { idleMs: number }): Promise<{
+  evicted: number;
+  skippedBusy: number;
+  skippedRevalidated: number;
+  remaining: number;
+}> {
   if (managerRuntimePromise === null) {
-    return { evicted: 0, skippedBusy: 0, remaining: 0 };
+    return { evicted: 0, skippedBusy: 0, skippedRevalidated: 0, remaining: 0 };
   }
   const { closeIdleMemoryIndexManagers } = await loadManagerRuntime();
   return await closeIdleMemoryIndexManagers({ idleMs: opts.idleMs });

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -431,6 +431,20 @@ export async function closeMemorySearchManager(params: {
   }
 }
 
+// Idle-TTL sweep over the process-wide MemoryIndexManager cache. The qmd
+// manager layer above does not currently retain its own watchers (managers
+// are created on demand and closed by the caller), so this only forwards to
+// the lower-level cache that backs file-backed indexes.
+export async function closeIdleMemorySearchManagers(opts: {
+  idleMs: number;
+}): Promise<{ evicted: number; remaining: number }> {
+  if (managerRuntimePromise === null) {
+    return { evicted: 0, remaining: 0 };
+  }
+  const { closeIdleMemoryIndexManagers } = await loadManagerRuntime();
+  return await closeIdleMemoryIndexManagers({ idleMs: opts.idleMs });
+}
+
 class FallbackMemoryManager implements MemorySearchManager {
   private fallback: Maybe<MemorySearchManager> = null;
   private primaryFailed = false;

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -435,11 +435,16 @@ export async function closeMemorySearchManager(params: {
 // manager layer above does not currently retain its own watchers (managers
 // are created on demand and closed by the caller), so this only forwards to
 // the lower-level cache that backs file-backed indexes.
+//
+// Returns `skippedBusy` for entries that aged past idleMs but currently
+// have an in-flight operation (e.g. batch reindex) holding them via
+// MemoryIndexManager.withBusy(). Those entries are eligible again on the
+// next scan after release() fires.
 export async function closeIdleMemorySearchManagers(opts: {
   idleMs: number;
-}): Promise<{ evicted: number; remaining: number }> {
+}): Promise<{ evicted: number; skippedBusy: number; remaining: number }> {
   if (managerRuntimePromise === null) {
-    return { evicted: 0, remaining: 0 };
+    return { evicted: 0, skippedBusy: 0, remaining: 0 };
   }
   const { closeIdleMemoryIndexManagers } = await loadManagerRuntime();
   return await closeIdleMemoryIndexManagers({ idleMs: opts.idleMs });

--- a/extensions/memory-core/src/runtime-provider.ts
+++ b/extensions/memory-core/src/runtime-provider.ts
@@ -2,6 +2,7 @@ import type { MemoryPluginRuntime } from "openclaw/plugin-sdk/memory-core-host-r
 import { resolveMemoryBackendConfig } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 import {
   closeAllMemorySearchManagers,
+  closeIdleMemorySearchManagers,
   closeMemorySearchManager,
   getMemorySearchManager,
 } from "./memory/index.js";
@@ -22,5 +23,8 @@ export const memoryRuntime: MemoryPluginRuntime = {
   },
   async closeMemorySearchManager(params) {
     await closeMemorySearchManager(params);
+  },
+  async closeIdleMemorySearchManagers(opts) {
+    return await closeIdleMemorySearchManagers(opts);
   },
 };

--- a/src/agents/memory-search.test.ts
+++ b/src/agents/memory-search.test.ts
@@ -257,6 +257,8 @@ describe("memory search config", () => {
       watchDebounceMs: 25,
       intervalMinutes: 3,
       embeddingBatchTimeoutSeconds: undefined,
+      idleEvictMs: 15 * 60_000,
+      idleEvictScanMs: 5 * 60_000,
       sessions: {
         deltaBytes: 321,
         deltaMessages: 7,

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -68,6 +68,8 @@ export type ResolvedMemorySearchConfig = {
     watchDebounceMs: number;
     intervalMinutes: number;
     embeddingBatchTimeoutSeconds: number | undefined;
+    idleEvictMs: number;
+    idleEvictScanMs: number;
     sessions: {
       deltaBytes: number;
       deltaMessages: number;
@@ -103,6 +105,14 @@ export type ResolvedMemorySearchSyncConfig = ResolvedMemorySearchConfig["sync"];
 const DEFAULT_CHUNK_TOKENS = 400;
 const DEFAULT_CHUNK_OVERLAP = 80;
 const DEFAULT_WATCH_DEBOUNCE_MS = 1500;
+// Default idle-TTL for cached MemoryIndexManager instances in long-running
+// gateways. Conservative enough to comfortably outlive typical bursts of
+// memory_search calls within a session, short enough to release chokidar
+// FSWatcher handles before they accumulate.
+const DEFAULT_IDLE_EVICT_MS = 15 * 60_000;
+// Default sweep interval for idle-eviction. The sweep is cheap (it just
+// walks lastAccessAt) so we can afford to run it every few minutes.
+const DEFAULT_IDLE_EVICT_SCAN_MS = 5 * 60_000;
 const DEFAULT_SESSION_DELTA_BYTES = 100_000;
 const DEFAULT_SESSION_DELTA_MESSAGES = 50;
 const DEFAULT_MAX_RESULTS = 6;
@@ -405,6 +415,12 @@ function resolveSyncConfig(
     intervalMinutes: overrides?.sync?.intervalMinutes ?? defaults?.sync?.intervalMinutes ?? 0,
     embeddingBatchTimeoutSeconds:
       overrides?.sync?.embeddingBatchTimeoutSeconds ?? defaults?.sync?.embeddingBatchTimeoutSeconds,
+    idleEvictMs:
+      overrides?.sync?.idleEvictMs ?? defaults?.sync?.idleEvictMs ?? DEFAULT_IDLE_EVICT_MS,
+    idleEvictScanMs:
+      overrides?.sync?.idleEvictScanMs ??
+      defaults?.sync?.idleEvictScanMs ??
+      DEFAULT_IDLE_EVICT_SCAN_MS,
     sessions: {
       deltaBytes:
         overrides?.sync?.sessions?.deltaBytes ??

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -109,9 +109,17 @@ const DEFAULT_WATCH_DEBOUNCE_MS = 1500;
 // gateways. Conservative enough to comfortably outlive typical bursts of
 // memory_search calls within a session, short enough to release chokidar
 // FSWatcher handles before they accumulate.
+//
+// In-flight operations are protected separately via a refcount on the
+// managed cache (acquireManagedCacheKey / MemoryIndexManager.withBusy);
+// a manager whose batch reindex or sync exceeds this idle window will
+// still survive until the operation completes, then become eligible for
+// eviction on a subsequent scan.
 const DEFAULT_IDLE_EVICT_MS = 15 * 60_000;
 // Default sweep interval for idle-eviction. The sweep is cheap (it just
-// walks lastAccessAt) so we can afford to run it every few minutes.
+// walks lastAccessAt + inflightCount) so we can afford to run it every
+// few minutes; this also keeps the worst-case extra dwell time after
+// idleMs bounded to one scan interval.
 const DEFAULT_IDLE_EVICT_SCAN_MS = 5 * 60_000;
 const DEFAULT_SESSION_DELTA_BYTES = 100_000;
 const DEFAULT_SESSION_DELTA_MESSAGES = 50;

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -489,6 +489,9 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.memorySearch.sync.watch": "Watch Memory Files",
   "agents.defaults.memorySearch.sync.watchDebounceMs": "Memory Watch Debounce (ms)",
   "agents.defaults.memorySearch.sync.embeddingBatchTimeoutSeconds": "Embedding Batch Timeout (s)",
+  "agents.defaults.memorySearch.sync.idleEvictMs": "Memory Index Idle Eviction (ms)",
+  "agents.defaults.memorySearch.sync.idleEvictScanMs":
+    "Memory Index Idle Eviction Scan Interval (ms)",
   "agents.defaults.memorySearch.sync.sessions.deltaBytes": "Session Delta Bytes",
   "agents.defaults.memorySearch.sync.sessions.deltaMessages": "Session Delta Messages",
   "agents.defaults.memorySearch.sync.sessions.postCompactionForce":

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -510,6 +510,18 @@ export type MemorySearchConfig = {
      * Unset uses provider defaults: 600s for local/self-hosted providers, 120s for hosted providers.
      */
     embeddingBatchTimeoutSeconds?: number;
+    /**
+     * Idle TTL (ms) for cached MemoryIndexManager instances in long-running
+     * gateways. After this many idle milliseconds the manager is closed and
+     * its chokidar FSWatcher is released. Defaults to 15 minutes when the
+     * gateway is the host; 0 disables eviction.
+     */
+    idleEvictMs?: number;
+    /**
+     * How often the idle-eviction sweep runs (ms). Defaults to 5 minutes;
+     * 0 disables the periodic sweep.
+     */
+    idleEvictScanMs?: number;
     sessions?: {
       /** Minimum appended bytes before session transcripts are reindexed. */
       deltaBytes?: number;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -917,6 +917,12 @@ export const MemorySearchSchema = z
         watchDebounceMs: z.number().int().nonnegative().optional(),
         intervalMinutes: z.number().int().nonnegative().optional(),
         embeddingBatchTimeoutSeconds: z.number().int().positive().optional(),
+        // Idle-TTL for cached MemoryIndexManager instances in long-running
+        // gateways. After this many idle ms a manager is closed and its
+        // chokidar FSWatcher released. 0 disables eviction.
+        idleEvictMs: z.number().int().nonnegative().optional(),
+        // How often the idle-eviction sweep runs. 0 disables the sweep.
+        idleEvictScanMs: z.number().int().nonnegative().optional(),
         sessions: z
           .object({
             deltaBytes: z.number().int().nonnegative().optional(),

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -804,7 +804,9 @@ describe("startGatewayPostAttachRuntime", () => {
       await vi.advanceTimersToNextTimerAsync();
       expect(postReadyRequestTurn).toHaveBeenCalledTimes(1);
       expect(onPostReadySidecars.mock.calls[0]?.[0]).toHaveLength(0);
-      expect(onGatewayLifetimeSidecars.mock.calls[0]?.[0]).toHaveLength(1);
+      // Two gateway-lifetime sidecars: provider auth prewarm + memory
+      // index idle-evict (enabled by default via memorySearch.sync defaults).
+      expect(onGatewayLifetimeSidecars.mock.calls[0]?.[0]).toHaveLength(2);
       await vi.dynamicImportSettled();
       await vi.waitFor(() => {
         expect(hoisted.setAuthProfileFailureHook).toHaveBeenCalledTimes(1);
@@ -859,7 +861,9 @@ describe("startGatewayPostAttachRuntime", () => {
         | { stop: () => void }[]
         | undefined;
       expect(gmailSidecars).toHaveLength(1);
-      expect(lifetimeSidecars).toHaveLength(1);
+      // Two gateway-lifetime sidecars: provider auth prewarm + memory
+      // index idle-evict.
+      expect(lifetimeSidecars).toHaveLength(2);
 
       for (const sidecar of gmailSidecars ?? []) {
         sidecar.stop();
@@ -1264,7 +1268,9 @@ describe("startGatewayPostAttachRuntime", () => {
       name: "sidecars.ready",
       metrics: [
         ["loadedPluginCount", 2],
-        ["postReadySidecarCount", 0],
+        // Provider auth prewarm is disabled in this test, but memory
+        // index idle-evict is enabled by default (15min idle TTL).
+        ["postReadySidecarCount", 1],
       ],
     });
   });

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -226,10 +226,18 @@ function scheduleMemoryIndexIdleEvict(params: {
       const result = await runtime.closeIdleMemorySearchManagers({
         idleMs: policy.idleMs,
       });
-      if (result.evicted > 0 || result.skippedBusy > 0) {
-        const busySuffix = result.skippedBusy > 0 ? ` (deferred ${result.skippedBusy} busy)` : "";
+      if (result.evicted > 0 || result.skippedBusy > 0 || result.skippedRevalidated > 0) {
+        const deferredParts: string[] = [];
+        if (result.skippedBusy > 0) {
+          deferredParts.push(`${result.skippedBusy} busy`);
+        }
+        if (result.skippedRevalidated > 0) {
+          deferredParts.push(`${result.skippedRevalidated} revalidated`);
+        }
+        const deferredSuffix =
+          deferredParts.length > 0 ? ` (deferred ${deferredParts.join(", ")})` : "";
         params.log.info(
-          `memory index manager idle eviction: evicted ${result.evicted}${busySuffix} (remaining ${result.remaining})`,
+          `memory index manager idle eviction: evicted ${result.evicted}${deferredSuffix} (remaining ${result.remaining})`,
         );
       }
     } catch (err) {

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -29,6 +29,8 @@ const ACP_BACKEND_READY_POLL_MS = 50;
 const PROVIDER_AUTH_PREWARM_START_DELAY_MS = 1_000;
 const PROVIDER_AUTH_REWARM_DELAY_MS = 1_000;
 const QMD_STARTUP_IDLE_DELAY_MS = 120_000;
+const MEMORY_INDEX_IDLE_EVICT_DEFAULT_MS = 15 * 60_000;
+const MEMORY_INDEX_IDLE_EVICT_SCAN_DEFAULT_MS = 5 * 60_000;
 const RESTART_SENTINEL_FILENAME = "restart-sentinel.json";
 
 type Awaitable<T> = T | Promise<T>;
@@ -163,6 +165,77 @@ function schedulePostAttachUpdateSentinelRefresh(params: {
     });
   });
   handle.unref?.();
+}
+
+type ResolvedMemoryIndexIdleEvictPolicy =
+  | { mode: "off" }
+  | { mode: "on"; idleMs: number; scanMs: number };
+
+function resolveMemoryIndexIdleEvictPolicy(
+  cfg: OpenClawConfig,
+): ResolvedMemoryIndexIdleEvictPolicy {
+  const sync = cfg.agents?.defaults?.memorySearch?.sync;
+  const idleMs = sync?.idleEvictMs ?? MEMORY_INDEX_IDLE_EVICT_DEFAULT_MS;
+  const scanMs = sync?.idleEvictScanMs ?? MEMORY_INDEX_IDLE_EVICT_SCAN_DEFAULT_MS;
+  if (idleMs <= 0 || scanMs <= 0) {
+    return { mode: "off" };
+  }
+  return { mode: "on", idleMs, scanMs };
+}
+
+// Periodic idle-TTL sweep over the process-wide MemoryIndexManager cache.
+// Long-running gateways accumulate cached managers (and their chokidar
+// FSWatchers) over time; this sweep closes managers that have not served a
+// request for `idleMs`. Returning a sidecar handle lets the gateway shut
+// the timer down cleanly.
+function scheduleMemoryIndexIdleEvict(params: {
+  cfg: OpenClawConfig;
+  log: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+  };
+}): GatewayPostReadySidecarHandle | null {
+  let stopped = false;
+  let timer: ReturnType<typeof setInterval> | undefined;
+  const policy = resolveMemoryIndexIdleEvictPolicy(params.cfg);
+  if (policy.mode === "off") {
+    return null;
+  }
+  const runSweep = async () => {
+    if (stopped) {
+      return;
+    }
+    try {
+      const { getMemoryRuntime } = await import("../plugins/memory-state.js");
+      const runtime = getMemoryRuntime();
+      if (!runtime?.closeIdleMemorySearchManagers) {
+        return;
+      }
+      const result = await runtime.closeIdleMemorySearchManagers({
+        idleMs: policy.idleMs,
+      });
+      if (result.evicted > 0) {
+        params.log.info(
+          `memory index manager idle eviction: evicted ${result.evicted} (remaining ${result.remaining})`,
+        );
+      }
+    } catch (err) {
+      params.log.warn(`memory index manager idle eviction failed: ${String(err)}`);
+    }
+  };
+  timer = setInterval(() => {
+    void runSweep();
+  }, policy.scanMs);
+  timer.unref?.();
+  return {
+    stop: () => {
+      stopped = true;
+      if (timer) {
+        clearInterval(timer);
+        timer = undefined;
+      }
+    },
+  };
 }
 
 function scheduleProviderAuthStatePrewarm(params: {
@@ -981,6 +1054,13 @@ export async function startGatewayPostAttachRuntime(
             }),
           );
         }
+        const memoryIdleEvictSidecar = scheduleMemoryIndexIdleEvict({
+          cfg: params.cfgAtStart,
+          log: params.log,
+        });
+        if (memoryIdleEvictSidecar) {
+          gatewayLifetimeSidecars.push(memoryIdleEvictSidecar);
+        }
         params.onPostReadySidecars?.(postReadySidecars);
         params.onGatewayLifetimeSidecars?.(gatewayLifetimeSidecars);
         params.onSidecarsReady?.();
@@ -1062,6 +1142,8 @@ export const testing = {
   hasRestartSentinelFileFast,
   refreshLatestUpdateRestartSentinelIfPresent,
   resolveGatewayMemoryStartupPolicy,
+  resolveMemoryIndexIdleEvictPolicy,
+  scheduleMemoryIndexIdleEvict,
   scheduleProviderAuthStatePrewarm,
   stopPostReadySidecarsAfterCloseStarted,
 };

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -29,7 +29,19 @@ const ACP_BACKEND_READY_POLL_MS = 50;
 const PROVIDER_AUTH_PREWARM_START_DELAY_MS = 1_000;
 const PROVIDER_AUTH_REWARM_DELAY_MS = 1_000;
 const QMD_STARTUP_IDLE_DELAY_MS = 120_000;
+// Default idle-TTL for cached MemoryIndexManager entries in long-running
+// gateway daemons. 15 minutes is comfortably longer than the typical gap
+// between memory_search invocations during a single chat session, so an
+// active session does not have its cached embedding state thrown away,
+// while idle agents release their chokidar FSWatchers within one quiet
+// window. Override per-agent via
+// `agents.defaults.memorySearch.sync.idleEvictMs`; set to 0 to disable.
 const MEMORY_INDEX_IDLE_EVICT_DEFAULT_MS = 15 * 60_000;
+// How often the idle sweep runs. 5 minutes keeps the worst-case slack
+// between idleMs and actual eviction bounded to ~20min, while making the
+// sweep itself cheap (one Map walk + at most one close() per stale
+// entry). Override via `agents.defaults.memorySearch.sync.idleEvictScanMs`;
+// set to 0 to disable.
 const MEMORY_INDEX_IDLE_EVICT_SCAN_DEFAULT_MS = 5 * 60_000;
 const RESTART_SENTINEL_FILENAME = "restart-sentinel.json";
 
@@ -214,9 +226,10 @@ function scheduleMemoryIndexIdleEvict(params: {
       const result = await runtime.closeIdleMemorySearchManagers({
         idleMs: policy.idleMs,
       });
-      if (result.evicted > 0) {
+      if (result.evicted > 0 || result.skippedBusy > 0) {
+        const busySuffix = result.skippedBusy > 0 ? ` (deferred ${result.skippedBusy} busy)` : "";
         params.log.info(
-          `memory index manager idle eviction: evicted ${result.evicted} (remaining ${result.remaining})`,
+          `memory index manager idle eviction: evicted ${result.evicted}${busySuffix} (remaining ${result.remaining})`,
         );
       }
     } catch (err) {

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -117,9 +117,18 @@ export type MemoryPluginRuntime = {
   // were held in-flight by an ongoing operation (e.g. batch reindex) and
   // therefore deferred to the next scan. Counted for observability only;
   // not an error.
-  closeIdleMemorySearchManagers?(opts: {
-    idleMs: number;
-  }): Promise<{ evicted: number; skippedBusy: number; remaining: number }>;
+  //
+  // `skippedRevalidated` reports the number of entries that aged past
+  // idleMs in the initial survey but were either refreshed by a cache
+  // hit, replaced by a fresh manager, or already torn down by another
+  // path between survey and close. Also deferred to the next scan and
+  // counted for observability only.
+  closeIdleMemorySearchManagers?(opts: { idleMs: number }): Promise<{
+    evicted: number;
+    skippedBusy: number;
+    skippedRevalidated: number;
+    remaining: number;
+  }>;
 };
 
 export type MemoryPluginPublicArtifactContentType = "markdown" | "json" | "text";

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -109,6 +109,12 @@ export type MemoryPluginRuntime = {
   }): MemoryRuntimeBackendConfig;
   closeMemorySearchManager?(params: { cfg: OpenClawConfig; agentId: string }): Promise<void>;
   closeAllMemorySearchManagers?(): Promise<void>;
+  // Optional idle-TTL sweep for cached MemoryIndexManager instances. Used by
+  // long-running gateway daemons to release chokidar FSWatchers that the
+  // CLI-exit path (closeAllMemorySearchManagers) does not cover.
+  closeIdleMemorySearchManagers?(opts: {
+    idleMs: number;
+  }): Promise<{ evicted: number; remaining: number }>;
 };
 
 export type MemoryPluginPublicArtifactContentType = "markdown" | "json" | "text";

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -112,9 +112,14 @@ export type MemoryPluginRuntime = {
   // Optional idle-TTL sweep for cached MemoryIndexManager instances. Used by
   // long-running gateway daemons to release chokidar FSWatchers that the
   // CLI-exit path (closeAllMemorySearchManagers) does not cover.
+  //
+  // `skippedBusy` reports the number of entries that aged past idleMs but
+  // were held in-flight by an ongoing operation (e.g. batch reindex) and
+  // therefore deferred to the next scan. Counted for observability only;
+  // not an error.
   closeIdleMemorySearchManagers?(opts: {
     idleMs: number;
-  }): Promise<{ evicted: number; remaining: number }>;
+  }): Promise<{ evicted: number; skippedBusy: number; remaining: number }>;
 };
 
 export type MemoryPluginPublicArtifactContentType = "markdown" | "json" | "text";


### PR DESCRIPTION
## Context

This is a revised version of #85910, which was auto-closed by ClawSweeper
within minutes of opening, without any human reviewer input. The bot gave
two reasons:

1. **Claimed duplicate of #40389.** This is incorrect. #40389 (merged
   2026-03-09) fixes *CLI one-shot exit hangs* by calling teardown in CLI
   `finally`. This PR fixes the *complementary long-running daemon path*
   where cached managers need to be evicted during normal daemon runtime,
   not just at process shutdown. The two fixes are non-overlapping and
   both necessary — see "Why this is not a duplicate of #40389" below.

2. **Legitimate technical concern: in-flight protection.**
   > "the proposed default idle sweeper can close a cached memory index
   > manager while an in-flight operation is still using it, so it should
   > not merge as-is. The patch needs active-use protection and config
   > help/docs alignment before it is the safest implementation."

   This PR addresses concern (2) directly — see "In-flight protection"
   section below.

## Problem (same as #85910, retained for reviewers)

In long-running gateway daemons, `MemoryIndexManager` instances are cached
in the module-level `INDEX_CACHE` indefinitely. Each instance owns a
chokidar `FSWatcher`; with `sync.watch=true` (default) recursively watching
the memory directory, this leaks `FSEventWrap` native handles and file
descriptors for every memory/*.md file the watcher has touched.

In a production daemon we measured:

- 11h uptime → 612 `FSEventWrap` native handles accumulated
- RSS grew ~150 MB/h, +1.6 GB over 11h from baseline
- `lsof` showed 488 `memory/*.md` file descriptors held by chokidar's
  `awaitWriteFinish`

Related: #71335.

## Fix

Same approach as #85910 — idle-TTL eviction on `ManagedCache`, wired into
gateway startup as a periodic sidecar:

- `ManagedCache.lastAccessAt` is refreshed on every cache hit and on
  initial set.
- `closeIdleManagedCacheEntries` walks `lastAccessAt`, closes stale
  entries, and isolates `close()` errors so one bad entry does not stop
  the rest.
- `closeIdleMemoryIndexManagers` (in `manager.ts`) layers in the
  embedding-probe-cache cleanup that the manager would otherwise miss.
- `scheduleMemoryIndexIdleEvict` (in `server-startup-post-attach.ts`)
  registers a gateway-lifetime sidecar that calls the idle sweep every
  `idleEvictScanMs` (default 5 min) evicting managers idle for
  `idleEvictMs` (default 15 min). Both intervals are configurable via
  `agents.defaults.memorySearch.sync.idleEvictMs` /
  `idleEvictScanMs`; setting either to `0` disables the sweep.

## In-flight protection (new in v2)

`ManagedCache` now tracks an `inflightCount` map keyed the same way as
`cache` / `lastAccessAt`:

- `acquireManagedCacheKey(cache, key)` increments the count, refreshes
  `lastAccessAt`, and returns an idempotent `release()` function.
- `isManagedCacheKeyBusy(cache, key)` reports whether the count is > 0.
- `closeIdleManagedCacheEntries` now consults `isManagedCacheKeyBusy`
  during both the survey loop and immediately before `close()`. Busy
  entries are skipped, counted, and surfaced via the new `onSkipBusy`
  callback and `skippedBusy` return field.
- `closeManagedCacheEntries` (full teardown) clears `inflightCount`
  alongside `cache` and `lastAccessAt` to keep test runs reproducible.

In `MemoryIndexManager`, a protected `withBusy(fn)` helper wraps the
acquire/release pair in try/finally. Two long-running entry points use
it today:

- `sync(...)` — wraps `runSyncWithReadonlyRecovery` (which covers batch
  reindex, targeted session sync, full sync). The refcount is released
  in the same `.finally()` that nulls `this.syncing`, so they unwind
  together.
- `search(...)` — the public entry point now calls `searchInternal` via
  `withBusy`. This protects the embedding/vector/FTS work plus the
  inline `sync({ reason: "search", force: true })` bootstrap that runs
  on the first call after process start.

`close()` and `closeMemoryIndexManagersForAgent` clear any residual
`inflightCount` entry alongside the cache slot. The `release()` returned
by `acquireManagedCacheKey` is idempotent, so a release that fires after
`close()` is a no-op.

The sidecar log now mentions deferred entries when present:

```
memory index manager idle eviction: evicted 3 (deferred 1 busy) (remaining 5)
```

This means: even if a batch reindex spans an idle window
(e.g. `lastAccessAt` ages past `idleMs` while the batch is running),
the manager will not be evicted until the batch completes and the
release callback fires. On the next scan the refcount-protected refresh
of `lastAccessAt` will have happened in `release()`, so the entry gets a
full idle window before becoming eligible again.

## Validation

Same monkey-patched validation as #85910:

- With the fix: 8h gateway uptime, RSS 2031 MB → 1859 MB (zero growth)
- Without the fix: 11h, RSS +1.6 GB (~150 MB/h)
- Memory fd count returns to 0 between memory_search invocations

The in-flight protection has not been live-soaked in production yet —
the original monkey-patch lacked it, and our production workload's batch
reindexes are short relative to the 15 min idle threshold so we never
hit the race in practice. The protection is unit-tested with:

1. Mock acquire/release during scan: verifies the busy entry is skipped
   (`skippedBusy` increments, `evicted` stays at 0).
2. After release fires (which refreshes `lastAccessAt`), the next scan
   is a no-op; ageing the entry once more and scanning again evicts it
   cleanly.
3. Mixed scan: one busy stale entry + one idle stale entry → exactly the
   idle one is closed.

## Tests

- `extensions/memory-core/src/memory/manager-cache.test.ts` — +6 new
  tests for `acquireManagedCacheKey` / `isManagedCacheKeyBusy` / busy
  deferral / refcount / lastAccessAt refresh / inflightCount cleanup.
  17 tests pass (was 11).
- `extensions/memory-core/src/memory/manager.idle-gc.test.ts` — +2 new
  tests for in-flight protection at the manager-level entry point;
  existing `returns zero` test now also asserts `skippedBusy === 0`.
  7 tests pass (was 5).
- All other extension-memory tests (711 total) still pass.
- `src/gateway/server-startup-post-attach.test.ts` (41 tests) still
  passes.
- `src/agents/memory-search.test.ts` (27 tests) still passes.
- `pnpm run lint`, `pnpm run tsgo:core`, `pnpm run tsgo:extensions`,
  `pnpm run tsgo:test`, and `pnpm run build` all green.

## Risk / Compatibility

- Default 15 min idle threshold unchanged from #85910 — conservative
  enough to comfortably outlive typical bursts of `memory_search` calls
  within a session.
- Active-use protection is enabled by default (no opt-out flag); safer
  default per ClawSweeper's recommendation. Disabling the sweep
  entirely (`idleEvictMs=0` or `idleEvictScanMs=0`) still works as in
  #85910.
- `INDEX_CACHE` size only shrinks when no in-flight operations
  reference the manager. Worst-case dwell is now `idleMs + scanMs + max
  in-flight op duration` (was `idleMs + scanMs`).
- Behavior for short-lived CLI invocations is unchanged
  (`closeAllMemoryIndexManagers` is still the exit path, and it clears
  `inflightCount` along with the rest of the cache).
- Public `MemoryPluginRuntime.closeIdleMemorySearchManagers` return
  type grows a new field `skippedBusy: number`. Existing callers that
  only read `evicted`/`remaining` continue to work; structural typing
  in TypeScript handles the additive change cleanly. The fallback path
  in `extensions/memory-core/index.ts` returns the new field as well.

## Why this is not a duplicate of #40389

|  | #40389 | This PR |
|---|---|---|
| Trigger | Process exit (CLI `finally`) | Periodic sidecar on gateway lifetime |
| Frequency | Once per process | Every `idleEvictScanMs` (default 5 min) |
| Scope | Close *all* cached managers | Close idle managers only |
| Protection | N/A (process is exiting) | `isManagedCacheKeyBusy` skip + `withBusy` wrap |
| Surface | CLI one-shot hangs on exit | Daemon FD/RSS growth during normal operation |

They are complementary: #40389 covers process shutdown; this PR covers
the continuous lifecycle of long-running daemons that never reach that
shutdown path until restart.

## Out of scope

- Does NOT change `sync.watch` default value (#71335 will handle that
  separately).
- Does NOT refactor the watcher to be singleton-per-workspace (much
  larger change).
- Does NOT introduce an opt-out for active-use protection — it's a
  safety net that should always be on; the only configurable knob is
  whether the sweep itself runs.

Refs #71335.
