### PR TITLE
fix(docker): create /home/node/.config with node:node ownership

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -290,9 +290,11 @@ RUN ln -sf /app/openclaw.mjs /usr/local/bin/openclaw \
 RUN install -d -m 0700 -o node -g node \
       /home/node/.openclaw \
       /home/node/.openclaw/workspace \
+      /home/node/.config \
       /home/node/.config/openclaw && \
     stat -c '%U:%G %a' /home/node/.openclaw | grep -qx 'node:node 700' && \
     stat -c '%U:%G %a' /home/node/.openclaw/workspace | grep -qx 'node:node 700' && \
+    stat -c '%U:%G %a' /home/node/.config | grep -qx 'node:node 700' && \
     stat -c '%U:%G %a' /home/node/.config/openclaw | grep -qx 'node:node 700'
 
 ENV NODE_ENV=production


### PR DESCRIPTION
## Summary

Fixes EACCES errors when npx (or other tools) needs to write to `~/.config` in Docker slim images.

## Problem

The `install -d /home/node/.config/openclaw` command auto-creates the parent directory `/home/node/.config` as `root:root` when run as root. This causes EACCES errors for the `node` user when tools like `npx` try to write to `~/.config`.

## Fix

Explicitly create `/home/node/.config` with `-o node -g node` ownership, and add a stat assertion to verify.

| File | Changes |
|------|---------|
| `Dockerfile` | +2 | Add `/home/node/.config` to install -d + stat assertion |

Fixes: #85968