### PR TITLE
Fix Codex native thread reuse for context-engine bootstraps

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -649,6 +649,95 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     },
   );
 
+  it("projects mirrored history when an oversized thread-bootstrap binding has no active context engine", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const agentDir = path.join(tempDir, "agent");
+    const sessionManager = SessionManager.open(sessionFile);
+    sessionManager.appendMessage(userMessage("previous stale-bootstrap request", Date.now()));
+    sessionManager.appendMessage(
+      assistantMessage("previous stale-bootstrap answer", Date.now() + 1) as never,
+    );
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-stale-bootstrap",
+      cwd: workspaceDir,
+      dynamicToolsFingerprint: "[]",
+      contextEngine: {
+        schemaVersion: 1,
+        engineId: "lossless-claw",
+        policyFingerprint:
+          '{"schemaVersion":1,"engineId":"lossless-claw","ownsCompaction":true,"projectionMaxChars":24000}',
+        projection: {
+          schemaVersion: 1,
+          mode: "thread_bootstrap",
+          epoch: "epoch-stale",
+        },
+      },
+    });
+    await fs.writeFile(
+      path.join(path.dirname(sessionFile), "sessions.json"),
+      JSON.stringify({
+        "agent:main:session-1": {
+          sessionFile,
+          totalTokens: 12_000,
+        },
+      }),
+    );
+    const rolloutDir = path.join(agentDir, "codex-home", "sessions");
+    await fs.mkdir(rolloutDir, { recursive: true });
+    await fs.writeFile(
+      path.join(rolloutDir, "rollout-thread-stale-bootstrap.jsonl"),
+      `${JSON.stringify({
+        payload: {
+          type: "token_count",
+          info: {
+            last_token_usage: {
+              total_tokens: 86_000,
+            },
+          },
+        },
+      })}\n`,
+    );
+    const harness = createStartedThreadHarness(async (method) => {
+      if (method === "thread/resume") {
+        return threadStartResult("thread-stale-bootstrap");
+      }
+      if (method === "thread/start") {
+        return threadStartResult("thread-fresh");
+      }
+      return undefined;
+    });
+    const params = createParams(sessionFile, workspaceDir);
+    params.agentDir = agentDir;
+    params.config = {
+      agents: {
+        defaults: {
+          compaction: {
+            truncateAfterCompaction: true,
+            maxActiveTranscriptBytes: "1mb",
+          },
+        },
+      },
+    } as EmbeddedRunAttemptParams["config"];
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+
+    expect(harness.requests.map((request) => request.method)).toEqual([
+      "thread/start",
+      "turn/start",
+    ]);
+    const inputText = getRequestInputText(harness);
+    expect(inputText).toContain("OpenClaw assembled context for this turn:");
+    expect(inputText).toContain("previous stale-bootstrap request");
+    expect(inputText).toContain("previous stale-bootstrap answer");
+    expect(inputText).toContain("Current user request:");
+    expect(inputText).toContain("hello");
+
+    await harness.completeTurn("completed", "thread-fresh");
+    await run;
+  });
+
   it("starts a fresh Codex thread and reprojects when context-engine epoch changes", async () => {
     const info = vi.spyOn(embeddedAgentLog, "info").mockImplementation(() => undefined);
     const sessionFile = path.join(tempDir, "session.jsonl");

--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -545,6 +545,110 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     await secondRun;
   });
 
+  it.each([
+    [
+      "token",
+      `${JSON.stringify({
+        payload: {
+          type: "token_count",
+          info: {
+            last_token_usage: {
+              total_tokens: 86_000,
+            },
+          },
+        },
+      })}\n`,
+      "1mb",
+    ],
+    ["byte", "x".repeat(2_000), 1_000],
+  ] as const)(
+    "resumes a matching thread-bootstrap binding even when the bootstrap turn exceeded the native %s guard",
+    async (_guard, rolloutContent, maxActiveTranscriptBytes) => {
+      const sessionFile = path.join(tempDir, "session.jsonl");
+      const workspaceDir = path.join(tempDir, "workspace");
+      const agentDir = path.join(tempDir, "agent");
+      await writeCodexAppServerBinding(sessionFile, {
+        threadId: "thread-bootstrapped",
+        cwd: workspaceDir,
+        dynamicToolsFingerprint: "[]",
+        contextEngine: {
+          schemaVersion: 1,
+          engineId: "lossless-claw",
+          policyFingerprint:
+            '{"schemaVersion":1,"engineId":"lossless-claw","ownsCompaction":true,"projectionMaxChars":24000}',
+          projection: {
+            schemaVersion: 1,
+            mode: "thread_bootstrap",
+            epoch: "epoch-1",
+          },
+        },
+      });
+      await fs.writeFile(
+        path.join(path.dirname(sessionFile), "sessions.json"),
+        JSON.stringify({
+          "agent:main:session-1": {
+            sessionFile,
+            totalTokens: 12_000,
+          },
+        }),
+      );
+      const rolloutDir = path.join(agentDir, "codex-home", "sessions");
+      await fs.mkdir(rolloutDir, { recursive: true });
+      await fs.writeFile(
+        path.join(rolloutDir, "rollout-thread-bootstrapped.jsonl"),
+        rolloutContent,
+      );
+      const contextEngine = createContextEngine({
+        assemble: vi.fn(async ({ prompt }) => ({
+          messages: [
+            assistantMessage("already bootstrapped context", 10),
+            userMessage(prompt ?? "", 11),
+          ],
+          estimatedTokens: 42,
+          systemPromptAddition: "context-engine system",
+          contextProjection: { mode: "thread_bootstrap" as const, epoch: "epoch-1" },
+        })),
+      });
+      const harness = createStartedThreadHarness(async (method) => {
+        if (method === "thread/resume") {
+          return threadStartResult("thread-bootstrapped");
+        }
+        if (method === "thread/start") {
+          return threadStartResult("thread-fresh");
+        }
+        return undefined;
+      });
+      const params = createParams(sessionFile, workspaceDir);
+      params.agentDir = agentDir;
+      params.contextEngine = contextEngine;
+      params.config = {
+        agents: {
+          defaults: {
+            compaction: {
+              truncateAfterCompaction: true,
+              maxActiveTranscriptBytes,
+            },
+          },
+        },
+      } as EmbeddedRunAttemptParams["config"];
+
+      const run = runCodexAppServerAttempt(params);
+      await harness.waitForMethod("turn/start");
+
+      expect(harness.requests.map((request) => request.method)).toEqual([
+        "thread/resume",
+        "turn/start",
+      ]);
+      const inputText = getRequestInputText(harness);
+      expect(inputText).not.toContain("OpenClaw assembled context for this turn:");
+      expect(inputText).not.toContain("already bootstrapped context");
+      expect(inputText).toBe("hello");
+
+      await harness.completeTurn();
+      await run;
+    },
+  );
+
   it("starts a fresh Codex thread and reprojects when context-engine epoch changes", async () => {
     const info = vi.spyOn(embeddedAgentLog, "info").mockImplementation(() => undefined);
     const sessionFile = path.join(tempDir, "session.jsonl");

--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -198,11 +198,11 @@ function createStartedThreadHarness(
     async notify(notification: CodexServerNotification) {
       await notify(notification);
     },
-    async completeTurn(status: "completed" | "failed" = "completed") {
+    async completeTurn(status: "completed" | "failed" = "completed", threadId = "thread-1") {
       await notify({
         method: "turn/completed",
         params: {
-          threadId: "thread-1",
+          threadId,
           turnId: "turn-1",
           turn: {
             id: "turn-1",
@@ -644,7 +644,7 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
       expect(inputText).not.toContain("already bootstrapped context");
       expect(inputText).toBe("hello");
 
-      await harness.completeTurn();
+      await harness.completeTurn("completed", "thread-bootstrapped");
       await run;
     },
   );

--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -654,7 +654,9 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const agentDir = path.join(tempDir, "agent");
     const sessionManager = SessionManager.open(sessionFile);
-    sessionManager.appendMessage(userMessage("previous stale-bootstrap request", Date.now()));
+    sessionManager.appendMessage(
+      userMessage("previous stale-bootstrap request", Date.now()) as never,
+    );
     sessionManager.appendMessage(
       assistantMessage("previous stale-bootstrap answer", Date.now() + 1) as never,
     );

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -848,6 +848,7 @@ async function rotateOversizedCodexAppServerStartupBinding(params: {
   agentDir: string;
   codexHome?: string;
   config: EmbeddedRunAttemptParams["config"] | undefined;
+  contextEngineActive?: boolean;
 }): Promise<CodexAppServerThreadBinding | undefined> {
   const binding = params.binding;
   if (!binding?.threadId) {
@@ -856,7 +857,7 @@ async function rotateOversizedCodexAppServerStartupBinding(params: {
   if (params.config?.agents?.defaults?.compaction?.truncateAfterCompaction !== true) {
     return binding;
   }
-  if (hasContextEngineThreadBootstrapProjection(binding)) {
+  if (params.contextEngineActive === true && hasContextEngineThreadBootstrapProjection(binding)) {
     embeddedAgentLog.debug(
       "codex app-server deferring native transcript size guard for context-engine thread bootstrap",
       {
@@ -1017,6 +1018,7 @@ export async function runCodexAppServerAttempt(
     agentDir,
     codexHome: appServer.start.env?.CODEX_HOME,
     config: params.config,
+    contextEngineActive: isActiveHarnessContextEngine(params.contextEngine),
   });
   const startupAuthProfileCandidate =
     params.runtimePlan?.auth.forwardedAuthProfileId ??

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -838,6 +838,10 @@ function maxFiniteNumber(values: Array<number | undefined>): number | undefined 
   return Math.max(...nums);
 }
 
+function hasContextEngineThreadBootstrapProjection(binding: CodexAppServerThreadBinding): boolean {
+  return binding.contextEngine?.projection?.mode === "thread_bootstrap";
+}
+
 async function rotateOversizedCodexAppServerStartupBinding(params: {
   binding: CodexAppServerThreadBinding | undefined;
   sessionFile: string;
@@ -850,6 +854,18 @@ async function rotateOversizedCodexAppServerStartupBinding(params: {
     return binding;
   }
   if (params.config?.agents?.defaults?.compaction?.truncateAfterCompaction !== true) {
+    return binding;
+  }
+  if (hasContextEngineThreadBootstrapProjection(binding)) {
+    embeddedAgentLog.debug(
+      "codex app-server deferring native transcript size guard for context-engine thread bootstrap",
+      {
+        threadId: binding.threadId,
+        engineId: binding.contextEngine?.engineId,
+        epoch: binding.contextEngine?.projection?.epoch,
+        fingerprint: binding.contextEngine?.projection?.fingerprint,
+      },
+    );
     return binding;
   }
   const sessionRecord = await readCodexSessionRecordForSessionFile(params.sessionFile);


### PR DESCRIPTION
Fixes #85975.

## Summary

- Preserve context-engine `thread_bootstrap` Codex native thread bindings through the startup token/byte transcript guard so large bootstrap turns do not force cold `thread/start` on every later turn.
- Keep native reuse bounded by the existing context-engine compatibility checks: engine/policy, projection epoch/fingerprint, dynamic tool fingerprint, and compaction-driven binding invalidation.
- Add regression coverage for token- and byte-oversized bootstrap transcripts resuming the warmed native thread while avoiding context-engine assembled-history replay.

## Why this matters

This is not about the model's maximum context window. `CODEX_APP_SERVER_NATIVE_THREAD_MAX_TOKENS = 70_000` is a local OpenClaw/Codex app-server active-thread reuse guard. It can rotate a native thread much earlier than the model's real context limit.

For example, the current repo metadata around `gpt-5.5` includes much larger limits than 70k: Copilot fallback metadata uses a `400_000` context window and related legacy Codex metadata recognizes a `272_000` prompt-token shape with `128_000` max output. So a 70k native-thread guard can invalidate the warm thread while the selected model still has plenty of context headroom.

That distinction matters because `thread_bootstrap` is the token-efficiency contract:

- First turn: OpenClaw assembles expensive context and injects it into a new Codex native thread.
- Later turns, best case: OpenClaw resumes the same native thread and does not replay the context-engine assembled history; the bootstrapped context is already inside the native thread. Other workspace/bootstrap surfaces may still contribute turn instructions or prompt context separately.
- Broken case: OpenClaw clears the native thread binding before it checks the context-engine bootstrap binding, so every turn cold-starts and re-injects/reprojects the large bootstrap payload.

Even when provider-side prompt caching helps with identical prefixes, the cold path still loses Codex native-thread reuse and creates avoidable gateway/app-server work: context assembly, prompt rendering, tool/app setup, rollout scanning, and a fresh native thread startup.

## Thread/cache flow

```mermaid
flowchart TD
  A[New Discord/user turn] --> B[OpenClaw loads saved Codex native thread binding]
  B --> C{Saved binding has contextEngine.projection.mode = thread_bootstrap?}
  C -- yes --> D[This PR: defer startup token/byte guard]
  D --> E[Context engine assembles current view]
  E --> F{Engine, policy, epoch, fingerprint, and tools still match?}
  F -- yes --> G[thread/resume warm native Codex thread]
  G --> H[turn/start avoids context-engine history replay]
  F -- no --> I[Clear stale binding and start fresh thread]
  C -- no --> J[Legacy/workspace-bootstrap path still uses 70k startup guard]
  J --> K{nativeTokens or sessionTokens >= 70k?}
  K -- yes --> L[Clear binding; thread/start cold path]
  K -- no --> G
```

## 10-turn scenario

Illustrative numbers, not exact billing math:

- A context-engine bootstrap payload renders to 90k tokens.
- Each later user turn adds a small 2k-token prompt/delta.
- Desired `thread_bootstrap` behavior over 10 turns: one large context-engine bootstrap, then 9 warm resumes. Replayed bootstrap pressure is roughly `90k + 9 * 2k = 108k` plus model-visible continuation state and any separate workspace/turn-scoped context surfaces.
- Broken startup-guard behavior: the first 90k turn records native usage over the 70k guard. Each later startup clears the binding, starts a fresh native thread, and replays/rebuilds the large bootstrap again. That can become roughly `10 * 90k = 900k` of repeated bootstrap pressure before counting deltas.

The important part is the shape, not the exact multiplier: once the native thread is rotated every turn, the system stops amortizing the bootstrap.

## What this PR fixes

Current startup order was:

1. Read saved Codex app-server thread binding.
2. Apply byte/token native transcript guard.
3. Only later ask the context engine whether the saved `thread_bootstrap` binding is still compatible.

That means an 86k-token bootstrap rollout could delete a still-valid `thread_bootstrap` binding before the code reached the compatibility check that would have allowed reuse.

This PR changes only that ordering for bindings that already declare `contextEngine.projection.mode === "thread_bootstrap"` and when a current active context engine can re-evaluate the saved binding:

- If the saved binding is a context-engine `thread_bootstrap` and the current run has an active context engine, startup defers the proactive byte/token guard.
- `startOrResumeThread` still clears the binding if the current context-engine policy/projection/tool binding is incompatible.
- If the saved binding is stale and no context engine is active for the current turn, the startup size guard still clears the oversized native thread so prompt construction projects mirrored history into the fresh thread.
- Non-bootstrap native sessions still use the existing byte/token startup guard.

So the PR fixes a concrete correctness bug: compatible context-engine bootstrap threads should be allowed to reach the existing compatibility gate instead of being preemptively deleted by a generic native transcript-size guard.

## What this PR does not fully solve

A tester reported that after locally merging this PR, their Discord channel was still slow and logged:

```text
nativeTokens=116268, max 70000
codex app-server native transcript exceeded active token limit; starting a fresh thread
```

They also observed the cold path re-injecting/truncating large bootstrap files such as `AGENTS.md`, `USER.md`, and `MEMORY.md`.

Based on the code, that exact warning after this PR means the startup exemption did not apply for that session. The most likely explanations are:

- the saved binding has no `contextEngine.projection.mode = "thread_bootstrap"` marker, so it is on the legacy/workspace-bootstrap path;
- the context engine is returning `per_turn`, no valid epoch, or no projection binding;
- the projection epoch/fingerprint, policy fingerprint, dynamic tool fingerprint, MCP/app config, or environment selection changes every turn, so lifecycle compatibility still starts a fresh thread;
- the local test build did not include the latest PR head; or
- the session is a non-context-engine native session, where the old 70k guard intentionally still applies.

In other words: this PR removes one real source of churn, but it is not the full architecture fix for all oversized Discord/Codex sessions. It makes the safe `thread_bootstrap` path behave like its contract says. Sessions that never enter or never retain that path can still cold-start every turn.

## Follow-up architecture

The broader architecture should probably move toward:

- treating context/bootstrap ownership as the lifecycle authority: rotate on semantic epoch/fingerprint/tool/config changes, not only on a hard-coded 70k native usage number;
- making the native reuse guard model/config aware instead of a fixed local threshold that can be lower than common bootstrap payloads;
- bringing workspace bootstrap files under an explicit cache/binding contract, or at least avoiding full `AGENTS.md` / `USER.md` / `MEMORY.md` reinjection when the same files are unchanged;
- logging enough provenance to diagnose every rotation: binding mode, projection epoch/fingerprint, projection decision reason, token source (`last_token_usage` vs `total_token_usage` vs `sessions.json`), and which bootstrap files dominate rendered context;
- distinguishing "provider/model context overflow" from "OpenClaw native warm-thread reuse guard" in warnings and status output.

Useful logs to compare on a slow channel after this PR:

```text
codex app-server deferring native transcript size guard for context-engine thread bootstrap
codex app-server context-engine projection decision
codex app-server wrote context-engine thread binding
codex app-server context-engine binding changed; starting a new thread
codex app-server native transcript exceeded active token limit; starting a fresh thread
```

## Real behavior proof

- Behavior or issue addressed: Codex app-server startup binding rotation should not clear a still-compatible context-engine `thread_bootstrap` native thread just because the bootstrap rollout exceeded the native token or byte guard.
- Real environment tested: local patched OpenClaw checkout at `/Volumes/LEXAR/repos/worktrees/openclaw-codex-native-thread-reuse`, using Lexar scratch under `/Volumes/LEXAR/Codex/openclaw-codex-native-thread-proof-20260524-151049`.
- Exact steps or command run after this patch: ran a live `node --import tsx --input-type=module` probe against the patched production `testing.rotateOversizedCodexAppServerStartupBinding` export. The probe wrote real Codex app-server binding, `sessions.json`, and rollout files for token-oversized and byte-oversized `thread_bootstrap` cases, then read the saved binding back from disk.
- Evidence after fix: terminal output from the local OpenClaw checkout:

```text
/Volumes/LEXAR/repos/worktrees/openclaw-codex-native-thread-reuse
REAL_BEHAVIOR_PROOF case=token-over-86k returnedThreadId=thread-bootstrapped savedThreadId=thread-bootstrapped projection=thread_bootstrap
REAL_BEHAVIOR_PROOF case=byte-over-2k returnedThreadId=thread-bootstrapped savedThreadId=thread-bootstrapped projection=thread_bootstrap
REAL_BEHAVIOR_PROOF proofRoot=/Volumes/LEXAR/Codex/openclaw-codex-native-thread-proof-20260524-151049
```

- Observed result after fix: both oversized native transcript cases returned and persisted the warmed `thread-bootstrapped` binding with `projection=thread_bootstrap`; the startup guard did not clear the binding.
- What was not tested: no live Discord channel or real Codex app-server network session was exercised from this PR branch; full broad validation is left to GitHub CI.

## Verification

- Behavior addressed: a saved `thread_bootstrap` binding whose native rollout reports 86k latest tokens now uses `thread/resume` and does not replay assembled bootstrap context into `turn/start`.
- Real environment tested: local Lexar OpenClaw worktree at `/Volumes/LEXAR/repos/worktrees/openclaw-codex-native-thread-reuse`.
- Exact commands run after this patch:

```text
pnpm exec oxfmt --check --threads=1 extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.context-engine.test.ts extensions/codex/src/app-server/run-attempt.test.ts
pnpm tsgo:extensions:test
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.context-engine.test.ts --run
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts --run -t "starts a fresh Codex thread before resume when the native rollout is over budget|uses current rollout token usage before cumulative usage|clears native rollouts at the configured byte limit"
git diff --check
```

- Evidence after fix:
  - `pnpm tsgo:extensions:test`: passed.
  - `run-attempt.context-engine.test.ts`: 20/20 passed, including the stale/no-active context-engine regression.
  - targeted `run-attempt.test.ts` native guard slice: 3 passed, 215 skipped.
  - formatting and whitespace checks passed.
- Pi/runtime risk review: parallel adversarial review found this change limited to Codex app-server startup binding rotation; Pi embedded-runner/shared compaction semantics are not changed.

Full repository-wide suites were intentionally left to GitHub CI per the local-resource policy.
