### PR TITLE
feat(secrets): humanize secrets configure prompts + Bitwarden skill

### DIFF
--- a/docs/gateway/secrets-plan-contract.md
+++ b/docs/gateway/secrets-plan-contract.md
@@ -79,6 +79,34 @@ configured`.
 }
 ```
 
+Or with Bitwarden CLI:
+
+```json5
+{
+  version: 1,
+  protocolVersion: 1,
+  providerUpserts: {
+    bitwarden_anthropic: {
+      source: "exec",
+      command: "/usr/bin/bw",
+      args: ["get", "password", "Anthropic"],
+      passEnv: ["BW_SESSION"],
+      jsonOnly: false,
+    },
+  },
+  providerDeletes: [],
+  targets: [
+    {
+      type: "models.providers.apiKey",
+      path: "models.providers.anthropic.apiKey",
+      pathSegments: ["models", "providers", "anthropic", "apiKey"],
+      providerId: "anthropic",
+      ref: { source: "exec", provider: "bitwarden_anthropic", id: "value" },
+    },
+  ],
+}
+```
+
 Exec providers introduced via `providerUpserts` are still subject to the
 exec consent rules in [Exec provider consent behavior](#exec-provider-consent-behavior):
 plans containing exec providers require `--allow-exec` in write mode.

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -311,6 +311,52 @@ the config fields that accept SecretRefs.
     }
     ```
   </Accordion>
+  <Accordion title="Bitwarden CLI (`bw`)">
+    Use the Bitwarden CLI directly for vault items. The `bw get password` command
+    returns a single value, so `jsonOnly: false` and `id: "value"` are used.
+
+    Requirements:
+
+    - Bitwarden CLI (`bw`) installed on the Gateway host.
+    - `BW_SESSION` available to the Gateway service (from `bw unlock --raw`).
+
+    ```json5
+    {
+      secrets: {
+        providers: {
+          bitwarden_openai: {
+            source: "exec",
+            command: "/opt/homebrew/bin/bw",
+            allowSymlinkCommand: true, // required for Homebrew symlinked binaries
+            trustedDirs: ["/opt/homebrew"],
+            args: ["get", "password", "OpenClaw QA API Key"],
+            passEnv: ["BW_SESSION", "HOME"],
+            jsonOnly: false,
+          },
+        },
+      },
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            models: [{ id: "gpt-5", name: "gpt-5" }],
+            apiKey: { source: "exec", provider: "bitwarden_openai", id: "value" },
+          },
+        },
+      },
+    }
+    ```
+
+    For item IDs instead of names, use `bw list items --search "OpenClaw"` to find
+    the item ID, then reference it: `args: ["get", "password", "<item-id>"]`.
+
+    After updating config, verify the command path:
+
+    ```bash
+    openclaw secrets audit --allow-exec
+    ```
+
+  </Accordion>
   <Accordion title="Bitwarden Secrets Manager (`bws`)">
     Use a resolver wrapper when you want SecretRef ids to map to Bitwarden
     Secrets Manager item keys. The repository includes

--- a/skills/bitwarden/SKILL.md
+++ b/skills/bitwarden/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: bitwarden
+description: "Set up and use Bitwarden CLI for sign-in, desktop integration, and reading or injecting secrets."
+homepage: https://bitwarden.com/help/cli/
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🛡️",
+        "requires": { "bins": ["bw"] },
+        "install":
+          [
+            {
+              "id": "npm",
+              "kind": "npm",
+              "package": "@bitwarden/cli",
+              "bins": ["bw"],
+              "label": "Install Bitwarden CLI (npm)",
+            },
+            {
+              "id": "brew",
+              "kind": "brew",
+              "formula": "bitwarden-cli",
+              "cask": false,
+              "bins": ["bw"],
+              "label": "Install Bitwarden CLI (brew)",
+            },
+          ],
+      },
+  }
+---
+
+# Bitwarden CLI
+
+Follow the official CLI get-started steps. Don't guess install commands.
+
+## References
+
+- `references/get-started.md` (install + app integration + sign-in flow)
+- `references/cli-examples.md` (real `bw` examples)
+
+## Workflow
+
+1. Check OS + shell.
+2. Verify CLI present: `bw --version`.
+3. Confirm desktop app integration is enabled and the app is unlocked.
+4. REQUIRED: create a fresh tmux session for all `bw` commands (no direct `bw` calls outside tmux).
+5. Log in / authorize inside tmux: `bw login` (expect app prompt or master password).
+6. Verify access inside tmux: `bw status` (must succeed before any secret read).
+7. If multiple accounts: use `--session` or `BW_SESSION`.
+
+## REQUIRED tmux session (tmux)
+
+The shell tool uses a fresh TTY per command. To avoid re-prompts and failures, always run `bw` inside a dedicated tmux session with a fresh socket/session name.
+
+Example (see `tmux` skill for socket conventions, do not reuse old session names):
+
+```bash
+SOCKET_DIR="${OPENCLAW_TMUX_SOCKET_DIR:-${TMPDIR:-/tmp}/openclaw-tmux-sockets}"
+mkdir -p "$SOCKET_DIR"
+SOCKET="$SOCKET_DIR/openclaw-bw.sock"
+SESSION="bw-auth-$(date +%Y%m%d-%H%M%S)"
+
+tmux -S "$SOCKET" new -d -s "$SESSION" -n shell
+tmux -S "$SOCKET" send-keys -t "$SESSION":0.0 -- "bw login" Enter
+tmux -S "$SOCKET" send-keys -t "$SESSION":0.0 -- "bw status" Enter
+tmux -S "$SOCKET" send-keys -t "$SESSION":0.0 -- "bw list items" Enter
+tmux -S "$SOCKET" capture-pane -p -J -t "$SESSION":0.0 -S -200
+tmux -S "$SOCKET" kill-session -t "$SESSION"
+```
+
+## Guardrails
+
+- Never paste secrets into logs, chat, or code.
+- Prefer `bw get password` / `bw get notes` over writing secrets to disk.
+- If login without app integration is needed, use `bw login --apikey`.
+- If a command returns "not logged in", re-run `bw login` inside tmux and authorize.
+- Do not run `bw` outside tmux; stop and ask if tmux is unavailable.

--- a/skills/bitwarden/references/cli-examples.md
+++ b/skills/bitwarden/references/cli-examples.md
@@ -1,0 +1,55 @@
+# bw CLI examples (from bw --help)
+
+## Login
+
+- `bw login`
+- `bw login <email>`
+- `bw login --apikey` (uses BW_CLIENT_ID + BW_CLIENT_SECRET)
+- `bw login --sso`
+
+## Unlock
+
+- `bw unlock`
+- `bw unlock --raw` (outputs session key only, for scripts)
+
+## Status
+
+- `bw status` (shows login state, last sync, etc.)
+
+## List
+
+- `bw list items`
+- `bw list items --search <query>`
+- `bw list items --folderid <id>`
+- `bw list folders`
+- `bw list collections`
+- `bw list organizations`
+
+## Get
+
+- `bw get item <id_or_name>`
+- `bw get password <id_or_name>`
+- `bw get username <id_or_name>`
+- `bw get notes <id_or_name>`
+- `bw get totp <id_or_name>`
+- `bw get item <id> --raw` (outputs JSON)
+
+## Search
+
+- `bw list items --search "OpenClaw"`
+
+## Sync
+
+- `bw sync` (force sync with server)
+
+## Logout
+
+- `bw logout`
+
+## Environment variables
+
+- `BW_SESSION` - session key for unlock
+- `BW_CLIENT_ID` - API key client ID
+- `BW_CLIENT_SECRET` - API key client secret
+- `BW_PASSWORD` - master password (avoid if possible)
+- `BW_NOINTERACTION` - disable interactive prompts

--- a/skills/bitwarden/references/get-started.md
+++ b/skills/bitwarden/references/get-started.md
@@ -1,0 +1,15 @@
+# Bitwarden CLI get-started (summary)
+
+- Works on macOS, Windows, and Linux.
+  - macOS/Linux shells: bash, zsh, sh, fish.
+  - Windows shell: PowerShell.
+- Requires a Bitwarden account (free or paid).
+- Install the CLI per the official doc for your OS.
+- Login methods:
+  - `bw login` - interactive login (email + master password)
+  - `bw login --apikey` - non-interactive (client_id + client_secret)
+  - `bw login --sso` - SSO login
+- After login, export the session key: `export BW_SESSION="$(bw unlock --raw)"`
+- For scripting, use `bw unlock --raw` to get a session token without interactive prompts.
+- If multiple accounts: use `bw login <email>` to pick one.
+- Session timeout: by default 30 minutes. Use `--timeout` or `BW_SESSION_TIMEOUT` to adjust.

--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -456,6 +456,43 @@ describe("buildGatewayInstallPlan", () => {
     expect(warn.mock.calls.every(([, title]) => title === "Config SecretRef")).toBe(true);
   });
 
+  it("supports Bitwarden CLI exec provider with BW_SESSION passEnv", async () => {
+    mockNodeGatewayPlanFixture({
+      serviceEnvironment: {
+        OPENCLAW_PORT: "3000",
+      },
+    });
+
+    const plan = await buildGatewayInstallPlan({
+      env: isolatedPlanEnv({
+        BW_SESSION: "bw-test-session",
+      }),
+      port: 3000,
+      runtime: "node",
+      config: {
+        secrets: {
+          providers: {
+            bitwarden: {
+              source: "exec",
+              command: "/usr/bin/bw",
+              args: ["get", "password", "Discord"],
+              passEnv: ["BW_SESSION"],
+              allowInsecurePath: true,
+            },
+          },
+        },
+        channels: {
+          discord: {
+            token: { source: "exec", provider: "bitwarden", id: "value" },
+          },
+        },
+      },
+    });
+
+    expect(plan.environment.BW_SESSION).toBe("bw-test-session");
+    expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBeUndefined();
+  });
+
   it("does not include passEnv values for unused exec SecretRef providers", async () => {
     mockNodeGatewayPlanFixture({
       serviceEnvironment: {

--- a/src/secrets/configure.ts
+++ b/src/secrets/configure.ts
@@ -146,14 +146,14 @@ function toSourceChoices(config: OpenClawConfig): Array<{ value: SecretRefSource
   const choices: Array<{ value: SecretRefSource; label: string }> = [
     {
       value: "env",
-      label: "env",
+      label: "Environment variable",
     },
   ];
   if (hasSource("file")) {
-    choices.push({ value: "file", label: "file" });
+    choices.push({ value: "file", label: "File on disk" });
   }
   if (hasSource("exec")) {
-    choices.push({ value: "exec", label: "exec" });
+    choices.push({ value: "exec", label: "Password manager (1Password, Bitwarden, etc.)" });
   }
   return choices;
 }
@@ -187,7 +187,7 @@ async function promptEnvNameCsv(params: {
       initialValue: params.initialValue,
       validate: (value) => validateEnvNameCsv(value ?? ""),
     }),
-    "Secrets configure cancelled.",
+    "Setup cancelled.",
   );
   return parseCsv(raw ?? "");
 }
@@ -213,7 +213,7 @@ async function promptOptionalPositiveInt(params: {
         return undefined;
       },
     }),
-    "Secrets configure cancelled.",
+    "Setup cancelled.",
   );
   const parsed = parseOptionalPositiveInt(
     normalizeStringifiedOptionalString(raw) ?? "",
@@ -302,7 +302,7 @@ async function promptNewAuthProfileCandidate(agentId: string): Promise<Configure
         return undefined;
       },
     }),
-    "Secrets configure cancelled.",
+    "Setup cancelled.",
   );
 
   const credentialType = assertNoCancel(
@@ -313,7 +313,7 @@ async function promptNewAuthProfileCandidate(agentId: string): Promise<Configure
         { value: "token", label: "token (token/tokenRef)" },
       ],
     }),
-    "Secrets configure cancelled.",
+    "Setup cancelled.",
   );
 
   const provider = assertNoCancel(
@@ -321,7 +321,7 @@ async function promptNewAuthProfileCandidate(agentId: string): Promise<Configure
       message: "Provider id",
       validate: (value) => (normalizeStringifiedOptionalString(value) ? undefined : "Required"),
     }),
-    "Secrets configure cancelled.",
+    "Setup cancelled.",
   );
 
   const profileIdTrimmed = normalizeStringifiedOptionalString(profileId) ?? "";
@@ -353,7 +353,7 @@ async function promptNewAuthProfileCandidate(agentId: string): Promise<Configure
 async function promptProviderAlias(params: { existingAliases: Set<string> }): Promise<string> {
   const alias = assertNoCancel(
     await text({
-      message: "Provider alias",
+      message: "Name this source (e.g. '1password', 'bitwarden', 'env')",
       initialValue: "default",
       validate: (value) => {
         const trimmed = normalizeStringifiedOptionalString(value) ?? "";
@@ -361,15 +361,15 @@ async function promptProviderAlias(params: { existingAliases: Set<string> }): Pr
           return "Required";
         }
         if (!isValidSecretProviderAlias(trimmed)) {
-          return "Must match /^[a-z][a-z0-9_-]{0,63}$/";
+          return "Use lowercase letters, numbers, hyphens, or underscores";
         }
         if (params.existingAliases.has(trimmed)) {
-          return "Alias already exists";
+          return "You already have a source with this name";
         }
         return undefined;
       },
     }),
-    "Secrets configure cancelled.",
+    "Setup cancelled.",
   );
   return normalizeStringifiedOptionalString(alias) ?? "";
 }
@@ -377,15 +377,15 @@ async function promptProviderAlias(params: { existingAliases: Set<string> }): Pr
 async function promptProviderSource(initial?: SecretRefSource): Promise<SecretRefSource> {
   const source = assertNoCancel(
     await select({
-      message: "Provider source",
+      message: "What kind of source?",
       options: [
-        { value: "env", label: "env" },
-        { value: "file", label: "file" },
-        { value: "exec", label: "exec" },
+        { value: "env", label: "Environment variables" },
+        { value: "file", label: "File on disk" },
+        { value: "exec", label: "Password manager (1Password, Bitwarden, etc.)" },
       ],
       initialValue: initial,
     }),
-    "Secrets configure cancelled.",
+    "Setup cancelled.",
   );
   return source as SecretRefSource;
 }
@@ -394,7 +394,7 @@ async function promptEnvProvider(
   base?: Extract<SecretProviderConfig, { source: "env" }>,
 ): Promise<Extract<SecretProviderConfig, { source: "env" }>> {
   const allowlist = await promptEnvNameCsv({
-    message: "Env allowlist (comma-separated, blank for unrestricted)",
+    message: "Which env vars to allow? (comma-separated, leave blank for all)",
     initialValue: base?.allowlist?.join(",") ?? "",
   });
   return {
@@ -408,7 +408,7 @@ async function promptFileProvider(
 ): Promise<Extract<SecretProviderConfig, { source: "file" }>> {
   const filePath = assertNoCancel(
     await text({
-      message: "File path (absolute)",
+      message: "Path to the file (absolute path)",
       initialValue: base?.path ?? "",
       validate: (value) => {
         const trimmed = normalizeStringifiedOptionalString(value) ?? "";
@@ -416,42 +416,42 @@ async function promptFileProvider(
           return "Required";
         }
         if (!isAbsolutePathValue(trimmed)) {
-          return "Must be an absolute path";
+          return "Must be an absolute path starting with /";
         }
         return undefined;
       },
     }),
-    "Secrets configure cancelled.",
+    "Setup cancelled.",
   );
 
   const mode = assertNoCancel(
     await select({
-      message: "File mode",
+      message: "How is the file formatted?",
       options: [
-        { value: "json", label: "json" },
-        { value: "singleValue", label: "singleValue" },
+        { value: "json", label: "JSON (key-value pairs)" },
+        { value: "singleValue", label: "Single value (just the secret)" },
       ],
       initialValue: base?.mode ?? "json",
     }),
-    "Secrets configure cancelled.",
+    "Setup cancelled.",
   );
 
   const timeoutMs = await promptOptionalPositiveInt({
-    message: "Timeout ms (blank for default)",
+    message: "Read timeout in ms (blank for default)",
     initialValue: base?.timeoutMs,
     max: 120000,
   });
   const maxBytes = await promptOptionalPositiveInt({
-    message: "Max bytes (blank for default)",
+    message: "Max file size in bytes (blank for default)",
     initialValue: base?.maxBytes,
     max: 20 * 1024 * 1024,
   });
   const allowInsecurePath = assertNoCancel(
     await confirm({
-      message: "Allow insecure file path checks?",
+      message: "Skip strict path security checks?",
       initialValue: base?.allowInsecurePath ?? false,
     }),
-    "Secrets configure cancelled.",
+    "Setup cancelled.",
   );
 
   return {
@@ -481,7 +481,7 @@ async function promptExecProvider(
 ): Promise<Extract<SecretProviderConfig, { source: "exec" }>> {
   const command = assertNoCancel(
     await text({
-      message: "Command path (absolute)",
+      message: "Path to the CLI tool (absolute)",
       initialValue: base?.command ?? "",
       validate: (value) => {
         const trimmed = normalizeStringifiedOptionalString(value) ?? "";
@@ -489,20 +489,20 @@ async function promptExecProvider(
           return "Required";
         }
         if (!isAbsolutePathValue(trimmed)) {
-          return "Must be an absolute path";
+          return "Must be an absolute path starting with /";
         }
         if (!isSafeExecutableValue(trimmed)) {
-          return "Command value is not allowed";
+          return "This command is not allowed for security";
         }
         return undefined;
       },
     }),
-    "Secrets configure cancelled.",
+    "Setup cancelled.",
   );
 
   const argsRaw = assertNoCancel(
     await text({
-      message: "Args JSON array (blank for none)",
+      message: 'Command arguments (JSON array like ["get", "password"], blank for none)',
       initialValue: JSON.stringify(base?.args ?? []),
       validate: (value) => {
         const trimmed = normalizeStringifiedOptionalString(value) ?? "";
@@ -512,7 +512,7 @@ async function promptExecProvider(
         try {
           const parsed = JSON.parse(trimmed) as unknown;
           if (!Array.isArray(parsed) || !parsed.every((entry) => typeof entry === "string")) {
-            return "Must be a JSON array of strings";
+            return 'Must be a JSON array of strings, e.g. ["get", "password"]';
           }
           return undefined;
         } catch {
@@ -520,43 +520,43 @@ async function promptExecProvider(
         }
       },
     }),
-    "Secrets configure cancelled.",
+    "Setup cancelled.",
   );
 
   const timeoutMs = await promptOptionalPositiveInt({
-    message: "Timeout ms (blank for default)",
+    message: "Command timeout in ms (blank for default)",
     initialValue: base?.timeoutMs,
     max: 120000,
   });
 
   const noOutputTimeoutMs = await promptOptionalPositiveInt({
-    message: "No-output timeout ms (blank for default)",
+    message: "Timeout if no output in ms (blank for default)",
     initialValue: base?.noOutputTimeoutMs,
     max: 120000,
   });
 
   const maxOutputBytes = await promptOptionalPositiveInt({
-    message: "Max output bytes (blank for default)",
+    message: "Max output size in bytes (blank for default)",
     initialValue: base?.maxOutputBytes,
     max: 20 * 1024 * 1024,
   });
 
   const jsonOnly = assertNoCancel(
     await confirm({
-      message: "Require JSON-only response?",
+      message: "Expect JSON output from the command?",
       initialValue: base?.jsonOnly ?? true,
     }),
-    "Secrets configure cancelled.",
+    "Setup cancelled.",
   );
 
   const passEnv = await promptEnvNameCsv({
-    message: "Pass-through env vars (comma-separated, blank for none)",
+    message: "Env vars to pass through to the command (comma-separated, blank for none)",
     initialValue: base?.passEnv?.join(",") ?? "",
   });
 
   const trustedDirsRaw = assertNoCancel(
     await text({
-      message: "Trusted dirs (comma-separated absolute paths, blank for none)",
+      message: "Trusted directories (comma-separated absolute paths, blank for none)",
       initialValue: base?.trustedDirs?.join(",") ?? "",
       validate: (value) => {
         const entries = parseCsv(value ?? "");
@@ -568,7 +568,7 @@ async function promptExecProvider(
         return undefined;
       },
     }),
-    "Secrets configure cancelled.",
+    "Setup cancelled.",
   );
 
   const allowInsecurePath = assertNoCancel(
@@ -576,14 +576,14 @@ async function promptExecProvider(
       message: "Allow insecure command path checks?",
       initialValue: base?.allowInsecurePath ?? false,
     }),
-    "Secrets configure cancelled.",
+    "Setup cancelled.",
   );
   const allowSymlinkCommand = assertNoCancel(
     await confirm({
       message: "Allow symlink command path?",
       initialValue: base?.allowSymlinkCommand ?? false,
     }),
-    "Secrets configure cancelled.",
+    "Setup cancelled.",
   );
 
   const args = await parseArgsInput(normalizeStringifiedOptionalString(argsRaw) ?? "");
@@ -628,37 +628,37 @@ async function configureProvidersInteractive(config: OpenClawConfig): Promise<vo
     const actionOptions: Array<{ value: string; label: string; hint?: string }> = [
       {
         value: "add",
-        label: "Add provider",
-        hint: "Define a new env/file/exec provider",
+        label: "Add source",
+        hint: "Connect 1Password, Bitwarden, or env/file sources",
       },
     ];
     if (providerEntries.length > 0) {
       actionOptions.push({
         value: "edit",
-        label: "Edit provider",
-        hint: "Update an existing provider",
+        label: "Edit source",
+        hint: "Update an existing source",
       });
       actionOptions.push({
         value: "remove",
-        label: "Remove provider",
-        hint: "Delete a provider alias",
+        label: "Remove source",
+        hint: "Disconnect a source",
       });
     }
     actionOptions.push({
       value: "continue",
       label: "Continue",
-      hint: "Move to credential mapping",
+      hint: "Link your credentials",
     });
 
     const action = assertNoCancel(
       await select({
         message:
           providerEntries.length > 0
-            ? "Configure secret providers"
-            : "Configure secret providers (only env refs are available until file/exec providers are added)",
+            ? "Choose how to handle your saved passwords and keys"
+            : "Choose how to handle your saved passwords and keys (env vars work out of the box — add a password manager for more options)",
         options: actionOptions,
       }),
-      "Secrets configure cancelled.",
+      "Setup cancelled.",
     );
 
     if (action === "continue") {
@@ -678,14 +678,14 @@ async function configureProvidersInteractive(config: OpenClawConfig): Promise<vo
     if (action === "edit") {
       const alias = assertNoCancel(
         await select({
-          message: "Select provider to edit",
+          message: "Which source to update?",
           options: providerEntries.map(([providerAlias, providerConfig]) => ({
             value: providerAlias,
             label: providerAlias,
             hint: providerHint(providerConfig),
           })),
         }),
-        "Secrets configure cancelled.",
+        "Setup cancelled.",
       );
       const current = providers[alias];
       if (!current) {
@@ -702,22 +702,22 @@ async function configureProvidersInteractive(config: OpenClawConfig): Promise<vo
     if (action === "remove") {
       const alias = assertNoCancel(
         await select({
-          message: "Select provider to remove",
+          message: "Which source to disconnect?",
           options: providerEntries.map(([providerAlias, providerConfig]) => ({
             value: providerAlias,
             label: providerAlias,
             hint: providerHint(providerConfig),
           })),
         }),
-        "Secrets configure cancelled.",
+        "Setup cancelled.",
       );
 
       const shouldRemove = assertNoCancel(
         await confirm({
-          message: `Remove provider "${alias}"?`,
+          message: `Disconnect "${alias}"?`,
           initialValue: false,
         }),
-        "Secrets configure cancelled.",
+        "Setup cancelled.",
       );
       if (shouldRemove) {
         removeSecretProvider(config, alias);
@@ -736,7 +736,7 @@ export async function runSecretsConfigureInteractive(
   } = {},
 ): Promise<SecretsConfigureResult> {
   if (!process.stdin.isTTY) {
-    throw new Error("secrets configure requires an interactive TTY.");
+    throw new Error("This setup needs an interactive terminal. Run it in a shell, not a script.");
   }
   if (params.providersOnly && params.skipProviderSetup) {
     throw new Error("Cannot combine --providers-only with --skip-provider-setup.");
@@ -747,7 +747,7 @@ export async function runSecretsConfigureInteractive(
   const io = createSecretsConfigIO({ env });
   const { snapshot } = await io.readConfigFileSnapshotForWrite();
   if (!snapshot.valid) {
-    throw new Error("Cannot run interactive secrets configure because config is invalid.");
+    throw new Error("Can't start setup — your config file has errors. Fix them first.");
   }
 
   const stagedConfig = structuredClone(snapshot.config);
@@ -776,7 +776,7 @@ export async function runSecretsConfigureInteractive(
       },
     });
     if (candidates.length === 0) {
-      throw new Error("No configurable secret-bearing fields found for this agent scope.");
+      throw new Error("No credentials need linking for this agent. You're all set!");
     }
 
     const sourceChoices = toSourceChoices(stagedConfig);
@@ -790,41 +790,36 @@ export async function runSecretsConfigureInteractive(
       const options = visibleCandidates.map((candidate) => ({
         value: configureCandidateKey(candidate),
         label: candidate.label,
-        hint: [
-          candidate.configFile === "auth-profiles.json" ? "auth-profiles.json" : "openclaw.json",
-          candidate.isDerived === true ? "derived" : undefined,
-        ]
-          .filter(Boolean)
-          .join(" | "),
+        hint: candidate.configFile === "auth-profiles.json" ? "per-agent" : "global",
       }));
       options.push({
         value: "__create_auth_profile__",
-        label: "Create auth profile mapping",
-        hint: `Add a new auth-profiles target for agent ${configureAgentId}`,
+        label: "Add new credential",
+        hint: `For agent ${configureAgentId}`,
       });
       if (hasDerivedCandidates) {
         options.push({
           value: "__toggle_derived__",
-          label: showDerivedCandidates ? "Hide derived targets" : "Show derived targets",
+          label: showDerivedCandidates ? "Hide auto-detected" : "Show auto-detected",
           hint: showDerivedCandidates
-            ? "Show only fields authored directly in config"
-            : "Include normalized/derived aliases",
+            ? "Show only manually configured"
+            : "Include detected from config",
         });
       }
       if (selectedByPath.size > 0) {
         options.unshift({
           value: "__done__",
           label: "Done",
-          hint: "Finish and run preflight",
+          hint: "Save and verify",
         });
       }
 
       const selectedPath = assertNoCancel(
         await select({
-          message: "Select credential field",
+          message: "Which credential do you want to link?",
           options,
         }),
-        "Secrets configure cancelled.",
+        "Setup cancelled.",
       );
 
       if (selectedPath === "__done__") {
@@ -862,11 +857,11 @@ export async function runSecretsConfigureInteractive(
 
       const source = assertNoCancel(
         await select({
-          message: "Secret source",
+          message: "Where is this credential stored?",
           options: sourceChoices,
           initialValue: sourceInitialValue,
         }),
-        "Secrets configure cancelled.",
+        "Setup cancelled.",
       ) as SecretRefSource;
 
       const defaultAlias = resolveDefaultSecretProviderAlias(stagedConfig, source, {
@@ -876,7 +871,7 @@ export async function runSecretsConfigureInteractive(
         existingRef?.source === source ? existingRef.provider : defaultAlias;
       const provider = assertNoCancel(
         await text({
-          message: "Provider alias",
+          message: "Which source? (name you gave it above)",
           initialValue: providerInitialValue,
           validate: (value) => {
             const trimmed = normalizeStringifiedOptionalString(value) ?? "";
@@ -884,12 +879,12 @@ export async function runSecretsConfigureInteractive(
               return "Required";
             }
             if (!isValidSecretProviderAlias(trimmed)) {
-              return "Must match /^[a-z][a-z0-9_-]{0,63}$/";
+              return "Use lowercase letters, numbers, hyphens, or underscores";
             }
             return undefined;
           },
         }),
-        "Secrets configure cancelled.",
+        "Setup cancelled.",
       );
       const providerAlias = normalizeStringifiedOptionalString(provider) ?? "";
       const suggestedIdFromExistingRef =
@@ -906,7 +901,7 @@ export async function runSecretsConfigureInteractive(
       }
       const id = assertNoCancel(
         await text({
-          message: "Secret id",
+          message: "What's the credential called in that source?",
           initialValue: suggestedId,
           validate: (value) => {
             const trimmed = normalizeStringifiedOptionalString(value) ?? "";
@@ -919,7 +914,7 @@ export async function runSecretsConfigureInteractive(
             return undefined;
           },
         }),
-        "Secrets configure cancelled.",
+        "Setup cancelled.",
       );
       const ref: SecretRef = {
         source,
@@ -960,7 +955,7 @@ export async function runSecretsConfigureInteractive(
           message: "Configure another credential?",
           initialValue: true,
         }),
-        "Secrets configure cancelled.",
+        "Setup cancelled.",
       );
       if (!addMore) {
         break;

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -779,6 +779,9 @@
 }
 
 .btn--icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   padding: 8px;
   min-width: 36px;
   height: 36px;

--- a/ui/src/ui/icons.ts
+++ b/ui/src/ui/icons.ts
@@ -6,25 +6,25 @@ import { html, type TemplateResult } from "lit";
 export const icons = {
   // Navigation icons
   messageSquare: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
     </svg>
   `,
   barChart: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <line x1="12" x2="12" y1="20" y2="10" />
       <line x1="18" x2="18" y1="20" y2="4" />
       <line x1="6" x2="6" y1="20" y2="16" />
     </svg>
   `,
   link: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
       <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
     </svg>
   `,
   radio: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <circle cx="12" cy="12" r="2" />
       <path
         d="M16.24 7.76a6 6 0 0 1 0 8.49m-8.48-.01a6 6 0 0 1 0-8.49m11.31-2.82a10 10 0 0 1 0 14.14m-14.14 0a10 10 0 0 1 0-14.14"
@@ -32,7 +32,7 @@ export const icons = {
     </svg>
   `,
   fileText: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
       <polyline points="14 2 14 8 20 8" />
       <line x1="16" x2="8" y1="13" y2="13" />
@@ -41,17 +41,19 @@ export const icons = {
     </svg>
   `,
   zap: html`
-    <svg viewBox="0 0 24 24"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" /></svg>
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+    </svg>
   `,
   monitor: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <rect width="20" height="14" x="2" y="3" rx="2" />
       <line x1="8" x2="16" y1="21" y2="21" />
       <line x1="12" x2="12" y1="17" y2="21" />
     </svg>
   `,
   sun: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <circle cx="12" cy="12" r="4" />
       <path d="M12 2v2" />
       <path d="M12 20v2" />
@@ -64,12 +66,12 @@ export const icons = {
     </svg>
   `,
   moon: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path d="M12 3a6.5 6.5 0 0 0 9 9 9 9 0 1 1-9-9Z" />
     </svg>
   `,
   settings: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path
         d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"
       />
@@ -77,7 +79,7 @@ export const icons = {
     </svg>
   `,
   bug: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path d="m8 2 1.88 1.88" />
       <path d="M14.12 3.88 16 2" />
       <path d="M9 7.13v-1a3.003 3.003 0 1 1 6 0v1" />
@@ -92,7 +94,7 @@ export const icons = {
     </svg>
   `,
   scrollText: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path d="M8 21h12a2 2 0 0 0 2-2v-2H10v2a2 2 0 1 1-4 0V5a2 2 0 1 0-4 0v3h4" />
       <path d="M19 17V5a2 2 0 0 0-2-2H4" />
       <path d="M15 8h-5" />
@@ -100,7 +102,7 @@ export const icons = {
     </svg>
   `,
   folder: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path
         d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"
       />
@@ -109,45 +111,49 @@ export const icons = {
 
   // UI icons
   menu: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <line x1="4" x2="20" y1="12" y2="12" />
       <line x1="4" x2="20" y1="6" y2="6" />
       <line x1="4" x2="20" y1="18" y2="18" />
     </svg>
   `,
   x: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path d="M18 6 6 18" />
       <path d="m6 6 12 12" />
     </svg>
   `,
-  check: html` <svg viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5" /></svg> `,
+  check: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M20 6 9 17l-5-5" />
+    </svg>
+  `,
   arrowDown: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path d="M12 5v14" />
       <path d="m19 12-7 7-7-7" />
     </svg>
   `,
   cornerDownRight: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <polyline points="15 10 20 15 15 20" />
       <path d="M4 4v7a4 4 0 0 0 4 4h12" />
     </svg>
   `,
   copy: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
       <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
     </svg>
   `,
   search: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <circle cx="11" cy="11" r="8" />
       <path d="m21 21-4.3-4.3" />
     </svg>
   `,
   brain: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path
         d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z"
       />
@@ -164,12 +170,12 @@ export const icons = {
     </svg>
   `,
   book: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20" />
     </svg>
   `,
   loader: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path d="M12 2v4" />
       <path d="m16.2 7.8 2.9-2.9" />
       <path d="M18 12h4" />
@@ -183,14 +189,14 @@ export const icons = {
 
   // Tool icons
   wrench: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path
         d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"
       />
     </svg>
   `,
   fileCode: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
       <polyline points="14 2 14 8 20 8" />
       <path d="m10 13-2 2 2 2" />
@@ -198,86 +204,90 @@ export const icons = {
     </svg>
   `,
   edit: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
       <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
     </svg>
   `,
   penLine: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path d="M12 20h9" />
       <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
     </svg>
   `,
   paperclip: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path
         d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48"
       />
     </svg>
   `,
   globe: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <circle cx="12" cy="12" r="10" />
       <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" />
       <path d="M2 12h20" />
     </svg>
   `,
   image: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
       <circle cx="9" cy="9" r="2" />
       <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />
     </svg>
   `,
   smartphone: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <rect width="14" height="20" x="5" y="2" rx="2" ry="2" />
       <path d="M12 18h.01" />
     </svg>
   `,
   plug: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path d="M12 22v-5" />
       <path d="M9 8V2" />
       <path d="M15 8V2" />
       <path d="M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z" />
     </svg>
   `,
-  circle: html` <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" /></svg> `,
+  circle: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <circle cx="12" cy="12" r="10" />
+    </svg>
+  `,
   puzzle: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path
         d="M19.439 7.85c-.049.322.059.648.289.878l1.568 1.568c.47.47.706 1.087.706 1.704s-.235 1.233-.706 1.704l-1.611 1.611a.98.98 0 0 1-.837.276c-.47-.07-.802-.48-.968-.925a2.501 2.501 0 1 0-3.214 3.214c.446.166.855.497.925.968a.979.979 0 0 1-.276.837l-1.61 1.61a2.404 2.404 0 0 1-1.705.707 2.402 2.402 0 0 1-1.704-.706l-1.568-1.568a1.026 1.026 0 0 0-.877-.29c-.493.074-.84.504-1.02.968a2.5 2.5 0 1 1-3.237-3.237c.464-.18.894-.527.967-1.02a1.026 1.026 0 0 0-.289-.877l-1.568-1.568A2.402 2.402 0 0 1 1.998 12c0-.617.236-1.234.706-1.704L4.23 8.77c.24-.24.581-.353.917-.303.515.076.874.54 1.02 1.02a2.5 2.5 0 1 0 3.237-3.237c-.48-.146-.944-.505-1.02-1.02a.98.98 0 0 1 .303-.917l1.526-1.526A2.402 2.402 0 0 1 11.998 2c.617 0 1.234.236 1.704.706l1.568 1.568c.23.23.556.338.877.29.493-.074.84-.504 1.02-.968a2.5 2.5 0 1 1 3.236 3.236c-.464.18-.894.527-.967 1.02Z"
       />
     </svg>
   `,
   panelLeftClose: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <rect x="3" y="3" width="18" height="18" rx="2" />
       <path d="M9 3v18" stroke-linecap="round" />
       <path d="M16 10l-3 2 3 2" stroke-linecap="round" stroke-linejoin="round" />
     </svg>
   `,
   panelLeftOpen: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <rect x="3" y="3" width="18" height="18" rx="2" />
       <path d="M9 3v18" stroke-linecap="round" />
       <path d="M14 10l3 2-3 2" stroke-linecap="round" stroke-linejoin="round" />
     </svg>
   `,
   chevronDown: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path d="M6 9l6 6 6-6" stroke-linecap="round" stroke-linejoin="round" />
     </svg>
   `,
   chevronRight: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path d="M9 18l6-6-6-6" stroke-linecap="round" stroke-linejoin="round" />
     </svg>
   `,
   externalLink: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path
         d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"
         stroke-linecap="round"
@@ -287,14 +297,18 @@ export const icons = {
     </svg>
   `,
   send: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path d="m22 2-7 20-4-9-9-4Z" />
       <path d="M22 2 11 13" />
     </svg>
   `,
-  stop: html` <svg viewBox="0 0 24 24"><rect width="14" height="14" x="5" y="5" rx="1" /></svg> `,
+  stop: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <rect width="14" height="14" x="5" y="5" rx="1" />
+    </svg>
+  `,
   pin: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <line x1="12" x2="12" y1="17" y2="22" />
       <path
         d="M5 17h14v-1.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V6h1a2 2 0 0 0 0-4H8a2 2 0 0 0 0 4h1v4.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24Z"
@@ -302,7 +316,7 @@ export const icons = {
     </svg>
   `,
   pinOff: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <line x1="2" x2="22" y1="2" y2="22" />
       <line x1="12" x2="12" y1="17" y2="22" />
       <path
@@ -311,21 +325,21 @@ export const icons = {
     </svg>
   `,
   download: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
       <polyline points="7 10 12 15 17 10" />
       <line x1="12" x2="12" y1="15" y2="3" />
     </svg>
   `,
   mic: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
       <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
       <line x1="12" x2="12" y1="19" y2="22" />
     </svg>
   `,
   micOff: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <line x1="2" x2="22" y1="2" y2="22" />
       <path d="M18.89 13.23A7.12 7.12 0 0 0 19 12v-2" />
       <path d="M5 10v2a7 7 0 0 0 12 5" />
@@ -335,36 +349,38 @@ export const icons = {
     </svg>
   `,
   volume2: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
       <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
       <path d="M19.07 4.93a10 10 0 0 1 0 14.14" />
     </svg>
   `,
   volumeOff: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
       <line x1="22" x2="16" y1="9" y2="15" />
       <line x1="16" x2="22" y1="9" y2="15" />
     </svg>
   `,
   bookmark: html`
-    <svg viewBox="0 0 24 24"><path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16z" /></svg>
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16z" />
+    </svg>
   `,
   plus: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path d="M5 12h14" />
       <path d="M12 5v14" />
     </svg>
   `,
   terminal: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <polyline points="4 17 10 11 4 5" />
       <line x1="12" x2="20" y1="19" y2="19" />
     </svg>
   `,
   spark: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path
         d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z"
       />
@@ -396,13 +412,18 @@ export const icons = {
     </svg>
   `,
   refresh: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8" />
       <path d="M21 3v5h-5" />
     </svg>
   `,
+  shield: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+    </svg>
+  `,
   trash: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path d="M3 6h18" />
       <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
       <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
@@ -411,7 +432,7 @@ export const icons = {
     </svg>
   `,
   eye: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path
         d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"
       />
@@ -419,7 +440,7 @@ export const icons = {
     </svg>
   `,
   eyeOff: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path
         d="M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49"
       />
@@ -431,14 +452,14 @@ export const icons = {
     </svg>
   `,
   moreHorizontal: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <circle cx="12" cy="12" r="1.5" />
       <circle cx="6" cy="12" r="1.5" />
       <circle cx="18" cy="12" r="1.5" />
     </svg>
   `,
   arrowUpDown: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path d="m21 16-4 4-4-4" />
       <path d="M17 20V4" />
       <path d="m3 8 4-4 4 4" />
@@ -446,14 +467,14 @@ export const icons = {
     </svg>
   `,
   panelRightOpen: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <rect x="3" y="3" width="18" height="18" rx="2" />
       <path d="M15 3v18" stroke-linecap="round" />
       <path d="M10 10l-3 2 3 2" stroke-linecap="round" stroke-linejoin="round" />
     </svg>
   `,
   maximize: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <polyline points="15 3 21 3 21 9" />
       <polyline points="9 21 3 21 3 15" />
       <line x1="21" x2="14" y1="3" y2="10" />
@@ -461,7 +482,7 @@ export const icons = {
     </svg>
   `,
   minimize: html`
-    <svg viewBox="0 0 24 24">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <polyline points="4 14 10 14 10 20" />
       <polyline points="20 10 14 10 14 4" />
       <line x1="14" x2="21" y1="10" y2="3" />


### PR DESCRIPTION
## Changes

### Humanized prompts (d69d191acc)
Replaced technical jargon in `openclaw secrets configure` with plain language:
- 'Configure secret providers' → 'Choose how to handle your saved passwords and keys'
- 'Provider alias' → 'Name this source'
- 'Secret source' → 'Where is this credential stored?'
- 'Select credential field' → 'Which credential do you want to link?'
- 'Move to credential mapping' → 'Link your credentials'
- Source choices: 'env' → 'Environment variable', 'file' → 'File on disk', 'exec' → 'Password manager (1Password, Bitwarden, etc.)'
- All cancellation messages simplified to 'Setup cancelled'

### Bitwarden CLI skill (5b38ed0de2)
- Full parity with 1Password skill
- Supports `bw` CLI and `bws` (Bitwarden Secrets Manager)
- Proper metadata, icons, documentation

## Testing
- [ ] Run `openclaw secrets configure` and verify prompts are human-readable
- [ ] Verify Bitwarden skill loads correctly