### PR TITLE
Clamp fetch timeout timers

### DIFF
--- a/src/utils/fetch-timeout.test.ts
+++ b/src/utils/fetch-timeout.test.ts
@@ -10,6 +10,7 @@ vi.mock("../logging/subsystem.js", () => ({
 }));
 
 import { buildTimeoutAbortSignal, fetchWithTimeout } from "./fetch-timeout.js";
+import { MAX_SAFE_TIMEOUT_DELAY_MS } from "./timer-delay.js";
 
 function requireWarnCall(callIndex: number): [string, Record<string, unknown>] {
   const call = warn.mock.calls[callIndex];
@@ -165,6 +166,27 @@ describe("buildTimeoutAbortSignal", () => {
     await assertion;
   });
 
+  it("clamps oversized fetchWithTimeout delays before fetch starts", async () => {
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const response = new Response("ok");
+    const fetchFn = vi.fn<typeof fetch>(async (_input, init) => {
+      expect(init?.signal?.aborted).toBe(false);
+      return response;
+    });
+
+    try {
+      await expect(
+        fetchWithTimeout("https://example.com/v1/slow", {}, MAX_SAFE_TIMEOUT_DELAY_MS + 1, fetchFn),
+      ).resolves.toBe(response);
+
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+      expect(timeoutSpy.mock.calls[0]?.[1]).toBe(MAX_SAFE_TIMEOUT_DELAY_MS);
+      expect(timeoutSpy.mock.calls[0]?.[3]).toBe(MAX_SAFE_TIMEOUT_DELAY_MS);
+    } finally {
+      timeoutSpy.mockRestore();
+    }
+  });
+
   it("does not log when a parent signal aborts first", async () => {
     const parent = new AbortController();
     const { signal, cleanup } = buildTimeoutAbortSignal({
@@ -219,5 +241,26 @@ describe("buildTimeoutAbortSignal", () => {
     expect(warn).toHaveBeenCalledTimes(1);
 
     cleanup();
+  });
+
+  it("clamps oversized timeouts before arming Node timers", async () => {
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    const { signal, cleanup } = buildTimeoutAbortSignal({
+      timeoutMs: MAX_SAFE_TIMEOUT_DELAY_MS + 1,
+      operation: "unit-test",
+    });
+
+    try {
+      expect(timeoutSpy.mock.calls[0]?.[1]).toBe(MAX_SAFE_TIMEOUT_DELAY_MS);
+      expect(timeoutSpy.mock.calls[0]?.[3]).toBe(MAX_SAFE_TIMEOUT_DELAY_MS);
+
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(signal?.aborted).toBe(false);
+    } finally {
+      cleanup();
+      timeoutSpy.mockRestore();
+    }
   });
 });

--- a/src/utils/fetch-timeout.ts
+++ b/src/utils/fetch-timeout.ts
@@ -1,4 +1,5 @@
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { resolveSafeTimeoutDelayMs } from "./timer-delay.js";
 
 const log = createSubsystemLogger("fetch-timeout");
 const LOG_URL_MAX_CHARS = 500;
@@ -106,7 +107,7 @@ export function buildTimeoutAbortSignal(params: TimeoutAbortSignalParams): {
   }
 
   const controller = new AbortController();
-  const normalizedTimeoutMs = Math.max(1, Math.floor(timeoutMs));
+  const normalizedTimeoutMs = resolveSafeTimeoutDelayMs(timeoutMs);
   let active = true;
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   const scheduleTimeout = () => {


### PR DESCRIPTION
﻿## Summary

- Clamp `buildTimeoutAbortSignal` delays through the existing `resolveSafeTimeoutDelayMs` helper before arming Node timers.
- Add regression tests at both the shared signal builder and public `fetchWithTimeout` wrapper so oversized timeout values are scheduled at Node's safe timer ceiling and do not abort before fetch begins.

## Root cause

`buildTimeoutAbortSignal` previously used `Math.max(1, Math.floor(timeoutMs))`, which preserved values above Node's signed-32-bit timer ceiling. Real Node timers treat those oversized delays as overflow-prone and can schedule them as 1ms, so a caller asking for a very long fetch timeout could get an immediate timeout instead.

## Impact

Long-running provider fetches and shared plugin-sdk consumers keep their intended timeout behavior instead of being cut off immediately when a large timeout reaches this shared helper. The patch reuses the repo's existing timer guardrail rather than adding a second implementation.

## Real behavior proof

- **Behavior or issue addressed:** Oversized fetch timeout values no longer overflow Node timers into effectively immediate aborts. A requested timeout one millisecond above Node's safe timer ceiling is clamped before `setTimeout` is armed.
- **Real environment tested:** Windows 11 local checkout at `C:\Users\user\Downloads\openclaw-pr`, Node v22.17.0, pnpm 11.2.2.
- **Exact steps or command run after this patch:** Ran `node --import tsx --input-type=module` from the repo root with an inline script importing `buildTimeoutAbortSignal` from `./src/utils/fetch-timeout.ts` and `MAX_SAFE_TIMEOUT_DELAY_MS` from `./src/utils/timer-delay.ts`. The script called `buildTimeoutAbortSignal({ timeoutMs: MAX_SAFE_TIMEOUT_DELAY_MS + 1, operation: "real-proof" })` while capturing the delay passed to `setTimeout`.
- **Before evidence:** Raw Node timer behavior for the same oversized delay:

```console
$ node -e "const timeout = setTimeout(() => undefined, 2147483648); console.log('nodeOverflowIdleTimeoutMs=' + timeout._idleTimeout); clearTimeout(timeout);"
nodeOverflowIdleTimeoutMs=1
(node:14804) TimeoutOverflowWarning: 2147483648 does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
```

- **Evidence after fix:** Console output from the patch-built helper in a real Node run:

```console
requestedTimeoutMs=2147483648
scheduledDelayMs=2147483647
timeoutCallbackMs=2147483647
abortedImmediately=false
```

- **Observed result after fix:** The runtime scheduled `2147483647`ms, passed the same clamped value into the timeout callback metadata, and the signal was still live immediately after setup. This confirms the shared helper no longer hands Node an overflow-sized timer delay.
- **What was not tested:** No provider-specific live network request; the changed behavior is isolated to the shared timeout scheduling helper and was verified directly through the real Node runtime plus focused wrapper-level regression coverage.

## Validation

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/utils/fetch-timeout.test.ts src/utils/timer-delay.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/utils/fetch-timeout.ts src/utils/fetch-timeout.test.ts`
- `pnpm tsgo:core:test`
- `pnpm tsgo:core`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/utils/fetch-timeout.ts src/utils/fetch-timeout.test.ts`
- `pnpm check:changed`

Local `pnpm` commands emitted the existing engine warning because this machine has Node v22.17.0 while the repo requests >=22.19.0; all listed commands exited successfully.
