### PR TITLE
Recover DeepSeek DSML tool calls

### DIFF
--- a/extensions/microsoft-foundry/index.test.ts
+++ b/extensions/microsoft-foundry/index.test.ts
@@ -670,6 +670,23 @@ describe("microsoft-foundry plugin", () => {
     expect(provider?.models[0]?.compat?.maxTokensField).toBe("max_completion_tokens");
   });
 
+  it("marks Foundry DeepSeek completions deployments for DSML tool-call recovery", () => {
+    const result = buildFoundryAuthResult({
+      profileId: "microsoft-foundry:entra",
+      apiKey: "__entra_id_dynamic__",
+      endpoint: "https://example.services.ai.azure.com",
+      modelId: "prod-deepseek-v4",
+      modelNameHint: "deepseek-v4-pro",
+      api: "openai-completions",
+      authMethod: "entra-id",
+    });
+
+    const provider = result.configPatch?.models?.providers?.["microsoft-foundry"];
+    expect(provider?.api).toBe("openai-completions");
+    expect(provider?.models[0]?.api).toBe("openai-completions");
+    expect(provider?.models[0]?.compat).toEqual({ thinkingFormat: "deepseek" });
+  });
+
   it("keeps persisted response-mode routing for custom deployment aliases", async () => {
     const provider = registerProvider();
     const config: OpenClawConfig = {

--- a/extensions/microsoft-foundry/shared.ts
+++ b/extensions/microsoft-foundry/shared.ts
@@ -96,7 +96,8 @@ function normalizeModelInput(input?: unknown): Array<"text" | "image"> {
 
 type FoundryModelCompat = {
   supportsStore?: boolean;
-  maxTokensField: "max_completion_tokens" | "max_tokens";
+  maxTokensField?: "max_completion_tokens" | "max_tokens";
+  thinkingFormat?: "deepseek";
 };
 
 type FoundryConfigShape = {
@@ -124,6 +125,11 @@ export function usesFoundryResponsesByDefault(value?: string | null): boolean {
     normalized.startsWith("deepseek-v4") ||
     normalized === "computer-use-preview"
   );
+}
+
+function usesFoundryDeepSeekDsmlToolFormat(value?: string | null): boolean {
+  const normalized = normalizeFoundryModelName(value);
+  return normalized?.startsWith("deepseek-v4") === true;
 }
 
 export function supportsFoundryImageInput(value?: string | null): boolean {
@@ -219,12 +225,17 @@ function buildFoundryModelCompat(
   const resolvedApi = resolveFoundryApi(modelId, modelNameHint, configuredApi);
   const configuredModelName = resolveConfiguredModelNameHint(modelId, modelNameHint);
   const needsMaxCompletionTokens = requiresFoundryMaxCompletionTokens(configuredModelName);
-  if (resolvedApi !== DEFAULT_GPT5_API && !needsMaxCompletionTokens) {
+  const needsDeepSeekDsmlRecovery =
+    resolvedApi === DEFAULT_API && usesFoundryDeepSeekDsmlToolFormat(configuredModelName);
+  if (resolvedApi !== DEFAULT_GPT5_API && !needsMaxCompletionTokens && !needsDeepSeekDsmlRecovery) {
     return undefined;
   }
   return {
     ...(resolvedApi === DEFAULT_GPT5_API ? { supportsStore: false } : {}),
-    maxTokensField: needsMaxCompletionTokens ? "max_completion_tokens" : "max_tokens",
+    ...(resolvedApi === DEFAULT_GPT5_API || needsMaxCompletionTokens
+      ? { maxTokensField: needsMaxCompletionTokens ? "max_completion_tokens" : "max_tokens" }
+      : {}),
+    ...(needsDeepSeekDsmlRecovery ? { thinkingFormat: "deepseek" } : {}),
   };
 }
 
@@ -275,7 +286,7 @@ function buildFoundryProviderConfig(
   const isApiKeyAuth = options?.authMethod === "api-key";
   const deployments = options?.deployments?.length
     ? options.deployments
-    : [{ name: modelId, modelName: modelNameHint ?? undefined }];
+    : [{ name: modelId, modelName: modelNameHint ?? undefined, api: options?.api }];
   const resolvedApi = resolveFoundryApi(modelId, modelNameHint, options?.api);
   return {
     baseUrl: buildFoundryProviderBaseUrl(endpoint, modelId, modelNameHint, resolvedApi),

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -41,6 +41,22 @@ function createDeepSeekCompletionsModel(): Model<"openai-completions"> {
   };
 }
 
+function createFoundryDeepSeekCompletionsModel(): Model<"openai-completions"> {
+  return {
+    id: "deepseek-v4-pro",
+    name: "DeepSeek V4 Pro",
+    api: "openai-completions",
+    provider: "microsoft-foundry",
+    baseUrl: "https://example.services.ai.azure.com/openai/v1",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 16_384,
+    compat: { thinkingFormat: "deepseek" },
+  };
+}
+
 function createAssistantOutput(model: Model<"openai-completions">): OpenAICompletionsOutput {
   return {
     role: "assistant" as const,
@@ -1531,6 +1547,272 @@ describe("openai transport stream", () => {
         partialArgs: '{"path":"/tmp/native.md"}',
       },
     ]);
+    expect(JSON.stringify(events)).not.toContain("DSML");
+  });
+
+  it("recovers observed DeepSeek DSML parameter tool calls", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+    const events: CapturedStreamEvent[] = [];
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-dsml-tool",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content:
+                  "<｜DSML｜tool_calls>\n" +
+                  '<｜DSML｜invoke name="session_status">\n' +
+                  '<｜DSML｜parameter name="sessionKey" string="true">current</｜DSML｜parameter>\n' +
+                  "</｜DSML｜invoke>\n" +
+                  "</｜DSML｜tool_calls>",
+              },
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push: (event) => events.push(event as CapturedStreamEvent) },
+    );
+
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: "call_deepseek_dsml_1",
+        name: "session_status",
+        arguments: { sessionKey: "current" },
+        partialArgs: '{"sessionKey":"current"}',
+      },
+    ]);
+    expect(output.stopReason).toBe("toolUse");
+    expect(events.some((event) => event.type === "toolcall_delta")).toBe(true);
+    expect(JSON.stringify(events)).not.toContain("DSML");
+  });
+
+  it("recovers split DeepSeek DSML parameter tool calls", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-split-dsml-tool",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content:
+                  '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="session_status">\n' +
+                  '<｜DSML｜parameter name="sessionKey" string="true">',
+              },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: "chatcmpl-deepseek-split-dsml-tool",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: "current</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>",
+              },
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: "call_deepseek_dsml_1",
+        name: "session_status",
+        arguments: { sessionKey: "current" },
+        partialArgs: '{"sessionKey":"current"}',
+      },
+    ]);
+    expect(output.stopReason).toBe("toolUse");
+  });
+
+  it("preserves recovered DeepSeek DSML tool use across a later stop chunk", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-dsml-tool-final-stop",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content:
+                  "<｜DSML｜tool_calls>\n" +
+                  '<｜DSML｜invoke name="session_status">\n' +
+                  '<｜DSML｜parameter name="sessionKey" string="true">current</｜DSML｜parameter>\n' +
+                  "</｜DSML｜invoke>\n" +
+                  "</｜DSML｜tool_calls>",
+              },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: "chatcmpl-deepseek-dsml-tool-final-stop",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {},
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: "call_deepseek_dsml_1",
+        name: "session_status",
+        arguments: { sessionKey: "current" },
+        partialArgs: '{"sessionKey":"current"}',
+      },
+    ]);
+    expect(output.stopReason).toBe("toolUse");
+  });
+
+  it("recovers observed Foundry DeepSeek DSML tool calls across a later stop chunk", async () => {
+    const model = createFoundryDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+    const events: CapturedStreamEvent[] = [];
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-foundry-deepseek-dsml-tool-final-stop",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content:
+                  "<｜DSML｜tool_calls>\n" +
+                  '<｜DSML｜invoke name="session_status">\n' +
+                  '<｜DSML｜parameter name="sessionKey" string="true">current</｜DSML｜parameter>\n' +
+                  "</｜DSML｜invoke>\n" +
+                  "</｜DSML｜tool_calls>",
+              },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: "chatcmpl-foundry-deepseek-dsml-tool-final-stop",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {},
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push: (event) => events.push(event as CapturedStreamEvent) },
+    );
+
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: "call_deepseek_dsml_1",
+        name: "session_status",
+        arguments: { sessionKey: "current" },
+        partialArgs: '{"sessionKey":"current"}',
+      },
+    ]);
+    expect(output.stopReason).toBe("toolUse");
+    expect(events.some((event) => event.type === "toolcall_delta")).toBe(true);
+    expect(JSON.stringify(events)).not.toContain("DSML");
+  });
+
+  it("does not execute malformed DeepSeek DSML tool calls", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+    const events: CapturedStreamEvent[] = [];
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-malformed-dsml-tool",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content:
+                  "<｜DSML｜tool_calls>\n" +
+                  '<｜DSML｜invoke name="session_status">\n' +
+                  "</｜DSML｜invoke>\n" +
+                  "</｜DSML｜tool_calls>",
+              },
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push: (event) => events.push(event as CapturedStreamEvent) },
+    );
+
+    expect(output.content).toEqual([]);
+    expect(output.stopReason).toBe("stop");
+    expect(events.some((event) => event.type === "toolcall_delta")).toBe(false);
     expect(JSON.stringify(events)).not.toContain("DSML");
   });
 

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2441,6 +2441,9 @@ async function processOpenAICompletionsStream(
   const deepSeekTextFilter = shouldFilterDeepSeekDsmlText(compat)
     ? createDeepSeekTextFilter()
     : null;
+  const deepSeekDsmlToolCallRecovery = deepSeekTextFilter
+    ? createDeepSeekDsmlToolCallRecovery()
+    : null;
   type ToolCallBlock = {
     type: "toolCall";
     id: string;
@@ -2569,7 +2572,41 @@ async function processOpenAICompletionsStream(
       appendTextDelta(text);
     }
   };
+  let recoveredDeepSeekDsmlToolCallIndex = 0;
+  const appendRecoveredDeepSeekDsmlToolCall = (toolCall: RecoveredDeepSeekDsmlToolCall) => {
+    const switchingToolCall = currentBlock?.type === "toolCall";
+    finishCurrentBlock();
+    if (switchingToolCall) {
+      currentBlock = null;
+      flushPendingPostToolCallDeltas();
+    }
+    const block: ToolCallBlock = {
+      type: "toolCall",
+      id: `call_deepseek_dsml_${++recoveredDeepSeekDsmlToolCallIndex}`,
+      name: toolCall.name,
+      arguments: toolCall.arguments,
+      partialArgs: toolCall.partialArgs,
+    };
+    output.content.push(block);
+    currentBlock = block;
+    output.stopReason = "toolUse";
+    stream.push({
+      type: "toolcall_start",
+      contentIndex: output.content.indexOf(block),
+      partial: output,
+    });
+    stream.push({
+      type: "toolcall_delta",
+      contentIndex: output.content.indexOf(block),
+      delta: toolCall.partialArgs,
+      partial: output,
+    });
+  };
   const appendFilteredVisibleTextDelta = (text: string) => {
+    const recoveredToolCalls = deepSeekDsmlToolCallRecovery?.push(text) ?? [];
+    for (const toolCall of recoveredToolCalls) {
+      appendRecoveredDeepSeekDsmlToolCall(toolCall);
+    }
     const parts = deepSeekTextFilter?.push(text) ?? [text];
     for (const part of parts) {
       appendVisibleTextDelta(part);
@@ -2607,7 +2644,13 @@ async function processOpenAICompletionsStream(
     }
     if (choice.finish_reason) {
       const finishReasonResult = mapStopReason(choice.finish_reason);
-      output.stopReason = finishReasonResult.stopReason;
+      const preservesRecoveredToolUse =
+        output.stopReason === "toolUse" &&
+        recoveredDeepSeekDsmlToolCallIndex > 0 &&
+        finishReasonResult.stopReason === "stop";
+      if (!preservesRecoveredToolUse) {
+        output.stopReason = finishReasonResult.stopReason;
+      }
       if (finishReasonResult.errorMessage) {
         output.errorMessage = finishReasonResult.errorMessage;
       }
@@ -2737,6 +2780,160 @@ type CompletionsReasoningDelta =
 
 function shouldFilterDeepSeekDsmlText(compat: ReturnType<typeof getCompat>) {
   return compat.thinkingFormat === "deepseek";
+}
+
+type RecoveredDeepSeekDsmlToolCall = {
+  name: string;
+  arguments: Record<string, unknown>;
+  partialArgs: string;
+};
+
+const DEEPSEEK_DSML_TOOL_BLOCK_KINDS = ["tool_calls", "tool_call", "function_calls"] as const;
+const DEEPSEEK_DSML_TOOL_BLOCK_BARS = ["|", "｜"] as const;
+const DEEPSEEK_DSML_TOOL_BLOCK_OPEN_TOKENS = DEEPSEEK_DSML_TOOL_BLOCK_BARS.flatMap((bar) =>
+  DEEPSEEK_DSML_TOOL_BLOCK_KINDS.map((kind) => `<${bar}DSML${bar}${kind}>`),
+);
+const DEEPSEEK_DSML_TOOL_BLOCK_PATTERN =
+  /<([|｜])DSML\1(tool_calls|tool_call|function_calls)>([\s\S]*?)<\/\1DSML\1\2>/g;
+const DEEPSEEK_DSML_INVOKE_PATTERN = /<([|｜])DSML\1invoke\b([^>]*)>([\s\S]*?)<\/\1DSML\1invoke>/g;
+const DEEPSEEK_DSML_PARAMETER_PATTERN =
+  /<([|｜])DSML\1parameter\b([^>]*)>([\s\S]*?)<\/\1DSML\1parameter>/g;
+const MAX_DEEPSEEK_DSML_TOOL_CALL_BUFFER_BYTES = 256_000;
+
+function createDeepSeekDsmlToolCallRecovery() {
+  let buffer = "";
+
+  return {
+    push(chunk: string): RecoveredDeepSeekDsmlToolCall[] {
+      buffer += chunk;
+      if (Buffer.byteLength(buffer, "utf8") > MAX_DEEPSEEK_DSML_TOOL_CALL_BUFFER_BYTES) {
+        buffer = buffer.slice(-MAX_DEEPSEEK_DSML_TOOL_CALL_BUFFER_BYTES);
+      }
+
+      const recovered: RecoveredDeepSeekDsmlToolCall[] = [];
+      let consumedThrough = 0;
+      DEEPSEEK_DSML_TOOL_BLOCK_PATTERN.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      while ((match = DEEPSEEK_DSML_TOOL_BLOCK_PATTERN.exec(buffer))) {
+        consumedThrough = match.index + match[0].length;
+        recovered.push(...parseDeepSeekDsmlToolCalls(match[3]));
+      }
+
+      if (consumedThrough > 0) {
+        buffer = buffer.slice(consumedThrough);
+      } else {
+        buffer = trimToDeepSeekDsmlToolBlockCandidate(buffer);
+      }
+      return recovered;
+    },
+  };
+}
+
+function trimToDeepSeekDsmlToolBlockCandidate(text: string) {
+  const earliestOpen = DEEPSEEK_DSML_TOOL_BLOCK_OPEN_TOKENS.reduce<number | null>(
+    (earliest, token) => {
+      const index = text.indexOf(token);
+      return index === -1 || (earliest !== null && index >= earliest) ? earliest : index;
+    },
+    null,
+  );
+  if (earliestOpen !== null) {
+    return text.slice(earliestOpen);
+  }
+  const maxLength = Math.min(
+    text.length,
+    Math.max(...DEEPSEEK_DSML_TOOL_BLOCK_OPEN_TOKENS.map((token) => token.length)) - 1,
+  );
+  for (let length = maxLength; length > 0; length--) {
+    const suffix = text.slice(text.length - length);
+    if (DEEPSEEK_DSML_TOOL_BLOCK_OPEN_TOKENS.some((token) => token.startsWith(suffix))) {
+      return suffix;
+    }
+  }
+  return "";
+}
+
+function parseDeepSeekDsmlToolCalls(body: string): RecoveredDeepSeekDsmlToolCall[] {
+  const recovered: RecoveredDeepSeekDsmlToolCall[] = [];
+  DEEPSEEK_DSML_INVOKE_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = DEEPSEEK_DSML_INVOKE_PATTERN.exec(body))) {
+    const name = getDeepSeekDsmlAttribute(match[2], "name");
+    if (!name || !isValidRecoveredDeepSeekDsmlToolName(name)) {
+      continue;
+    }
+    const args = parseDeepSeekDsmlToolArguments(match[3]);
+    if (!args) {
+      continue;
+    }
+    recovered.push({
+      name,
+      arguments: args,
+      partialArgs: JSON.stringify(args),
+    });
+  }
+  return recovered;
+}
+
+function parseDeepSeekDsmlToolArguments(body: string): Record<string, unknown> | null {
+  const args: Record<string, unknown> = {};
+  let parameterCount = 0;
+  DEEPSEEK_DSML_PARAMETER_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = DEEPSEEK_DSML_PARAMETER_PATTERN.exec(body))) {
+    const name = getDeepSeekDsmlAttribute(match[2], "name");
+    if (!name) {
+      continue;
+    }
+    const isString = getDeepSeekDsmlAttribute(match[2], "string") === "true";
+    const decodedValue = decodeDeepSeekDsmlEntities(match[3].trim());
+    if (isString) {
+      args[name] = decodedValue;
+      parameterCount++;
+      continue;
+    }
+    if (!decodedValue) {
+      return null;
+    }
+    try {
+      args[name] = JSON.parse(decodedValue) as unknown;
+      parameterCount++;
+    } catch {
+      return null;
+    }
+  }
+  if (parameterCount > 0) {
+    return args;
+  }
+  const decodedBody = decodeDeepSeekDsmlEntities(body.trim());
+  if (!decodedBody) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(decodedBody) as unknown;
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function getDeepSeekDsmlAttribute(attrs: string, name: string) {
+  const pattern = new RegExp(`\\b${name}\\s*=\\s*(["'])(.*?)\\1`, "i");
+  const match = pattern.exec(attrs);
+  return match ? decodeDeepSeekDsmlEntities(match[2]) : null;
+}
+
+function decodeDeepSeekDsmlEntities(text: string) {
+  return text
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}
+
+function isValidRecoveredDeepSeekDsmlToolName(name: string) {
+  return name.length > 0 && name.length <= 128 && /^[A-Za-z0-9_.-]+$/.test(name);
 }
 
 function getCompletionsContentDeltas(content: unknown): CompletionsReasoningDelta[] {


### PR DESCRIPTION
Fixes #85918.

## Summary
- recover complete DeepSeek DSML `tool_calls` / `tool_call` / `function_calls` text blocks on the OpenAI completions stream into synthetic `toolCall` blocks
- keep the existing native `choiceDelta.tool_calls` path unchanged
- only execute complete `invoke` markup when the name is valid and parameters or JSON body parse into object arguments; malformed DSML remains non-executable and filtered from visible output; recovered DSML tool use is preserved across a later empty stop chunk

## Real behavior proof
- **Behavior or issue addressed:** Foundry/DeepSeek DSML tool markup that previously surfaced as assistant text is recovered into an executable OpenClaw `toolCall`, while malformed DSML remains non-executable.
- **Real environment tested:** Local OpenClaw source checkout on macOS, Node.js v24.15.0, using the patched `processOpenAICompletionsStream` runtime path via `node --import tsx --input-type=module`.
- **Exact steps or command run after the patch:** Ran a live Node command against the patched OpenClaw stream processor with the issue's observed DSML payload: `<｜DSML｜tool_calls><｜DSML｜invoke name="session_status"><｜DSML｜parameter name="sessionKey" string="true">current</｜DSML｜parameter></｜DSML｜invoke></｜DSML｜tool_calls>`.
- **Evidence after fix:** Terminal output from the patched runtime command:

```json
{
  "stopReason": "toolUse",
  "content": [
    {
      "type": "toolCall",
      "id": "call_deepseek_dsml_1",
      "name": "session_status",
      "arguments": {
        "sessionKey": "current"
      },
      "partialArgs": "{\"sessionKey\":\"current\"}"
    }
  ],
  "events": [
    {
      "type": "toolcall_start"
    },
    {
      "type": "toolcall_delta",
      "delta": "{\"sessionKey\":\"current\"}"
    }
  ]
}
containsDsml=false
```

- **Observed result after fix:** The observed DSML text no longer becomes assistant-visible text; it is surfaced as a `toolCall` named `session_status` with `{ "sessionKey": "current" }`, and the emitted event/output JSON contains no `DSML` text.
- **What was not tested:** I did not re-run a credentialed Microsoft Foundry request; the after-fix proof exercises the same patched OpenAI completions stream path with the real observed provider payload.

## Validation
- `node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts -t "DeepSeek DSML"` -> 2 files passed, 14 tests passed
- `node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts -t "tool calls"` -> 2 files passed, 16 tests passed
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node_modules/.bin/oxfmt --check --threads=1 src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts`
- `git diff --check`

Please preserve author attribution if this PR is squashed or reworked:
`Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>`