### PR TITLE
fix(docker): create /home/node/.config with node ownership before leaf dir (#85968)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 - Gateway/perf: tighten restart and startup benchmark failure handling so long profiling runs, failed probes, and fresh Linux runners no longer produce false passing or `n/a` results.
 - Checks: keep intentional Knip unused-file findings optional so full CI and sparse proof workspaces stay aligned.
+- Docker: restore writable `~/.config` in runtime images. Fixes #85968. Thanks @hkoessler and @Bartok9.
 - Tests: normalize bundled plugin lifecycle probe paths and state-root lookup so native Windows release sweeps accept valid packaged plugin installs.
 - Config: keep benign legacy metadata write anomalies out of default doctor and config command output while preserving explicit anomaly logging for diagnostics.
 - Codex: log when implicit app-server `never` approvals are promoted for OpenClaw tool policy, including whether the trigger was a `before_tool_call` hook or trusted tool policy.

--- a/Dockerfile
+++ b/Dockerfile
@@ -287,12 +287,17 @@ RUN ln -sf /app/openclaw.mjs /usr/local/bin/openclaw \
 
 # Pre-create default named-volume mount points so first-run Docker volumes copy
 # node ownership from the image instead of starting as root-owned directories.
-RUN install -d -m 0700 -o node -g node \
+# NOTE: /home/node/.config must be created with node ownership first so that
+# the leaf /home/node/.config/openclaw inherits the correct parent permissions.
+# Without this, install -d leaves /home/node/.config as root:root (issue #85968).
+RUN install -d -m 0755 -o node -g node /home/node/.config && \
+    install -d -m 0700 -o node -g node \
       /home/node/.openclaw \
       /home/node/.openclaw/workspace \
       /home/node/.config/openclaw && \
     stat -c '%U:%G %a' /home/node/.openclaw | grep -qx 'node:node 700' && \
     stat -c '%U:%G %a' /home/node/.openclaw/workspace | grep -qx 'node:node 700' && \
+    stat -c '%U:%G %a' /home/node/.config | grep -qx 'node:node 755' && \
     stat -c '%U:%G %a' /home/node/.config/openclaw | grep -qx 'node:node 700'
 
 ENV NODE_ENV=production

--- a/scripts/docker/setup.sh
+++ b/scripts/docker/setup.sh
@@ -554,6 +554,7 @@ echo "==> Fixing data-directory permissions"
 # (.openclaw/) inside the workspace gets chowned, not the user's project files.
 run_prestart_gateway --user root --entrypoint sh openclaw-gateway -c \
   'find /home/node/.openclaw -xdev -exec chown node:node {} +; \
+   chown node:node /home/node/.config; \
    find /home/node/.config/openclaw -xdev -exec chown node:node {} +; \
    [ -d /home/node/.openclaw/workspace/.openclaw ] && chown -R node:node /home/node/.openclaw/workspace/.openclaw || true'
 

--- a/src/docker-setup.e2e.test.ts
+++ b/src/docker-setup.e2e.test.ts
@@ -482,6 +482,7 @@ describe("scripts/docker/setup.sh", () => {
     expect(chownIdx).toBeGreaterThanOrEqual(0);
     expect(onboardIdx).toBeGreaterThan(chownIdx);
     expect(log).toContain("run --rm --no-deps --user root --entrypoint sh openclaw-gateway -c");
+    expect(log).toContain("chown node:node /home/node/.config");
   });
 
   it("precreates auth profile secret key dir outside the mounted state dir", async () => {

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -327,15 +327,24 @@ describe("Dockerfile", () => {
   it("pre-creates named-volume mount points before switching to the node user", async () => {
     const dockerfile = await readFile(dockerfilePath, "utf8");
     const runtimeStageIndex = dockerfile.lastIndexOf("FROM base-runtime");
-    const stateDirIndex = dockerfile.indexOf(
-      "RUN install -d -m 0700 -o node -g node \\",
+    const parentConfigDirIndex = dockerfile.indexOf(
+      "RUN install -d -m 0755 -o node -g node /home/node/.config",
       runtimeStageIndex,
+    );
+    const stateDirIndex = dockerfile.indexOf(
+      "install -d -m 0700 -o node -g node \\",
+      parentConfigDirIndex,
     );
     const userIndex = dockerfile.indexOf("USER node", runtimeStageIndex);
 
     expect(runtimeStageIndex).toBeGreaterThan(-1);
+    // Regression: /home/node/.config parent must be created with node ownership
+    // before the leaf .config/openclaw dir (issue #85968).
+    expect(parentConfigDirIndex).toBeGreaterThan(-1);
     expect(stateDirIndex).toBeGreaterThan(-1);
     expect(userIndex).toBeGreaterThan(-1);
+    expect(parentConfigDirIndex).toBeGreaterThan(runtimeStageIndex);
+    expect(parentConfigDirIndex).toBeLessThan(stateDirIndex);
     expect(stateDirIndex).toBeGreaterThan(runtimeStageIndex);
     expect(stateDirIndex).toBeLessThan(userIndex);
     expect(dockerfile).not.toContain("mkdir -p /home/node/.openclaw");
@@ -346,6 +355,10 @@ describe("Dockerfile", () => {
     );
     expect(dockerfile).toContain(
       "stat -c '%U:%G %a' /home/node/.openclaw/workspace | grep -qx 'node:node 700'",
+    );
+    // Regression: assert parent /home/node/.config is also node-owned (issue #85968).
+    expect(dockerfile).toContain(
+      "stat -c '%U:%G %a' /home/node/.config | grep -qx 'node:node 755'",
     );
     expect(dockerfile).toContain(
       "stat -c '%U:%G %a' /home/node/.config/openclaw | grep -qx 'node:node 700'",


### PR DESCRIPTION
## Summary

Fixes #85968.

The `2026.5.22-slim` Docker image ships with `/home/node/.config` owned by `root:root` instead of `node:node`, breaking `npx` skill installs and any workflow that writes to `~/.config`.

## Root Cause

The named-volume mount-point block used a single `install -d` invocation to create the leaf directory:

```dockerfile
RUN install -d -m 0700 -o node -g node \
      /home/node/.openclaw \
      /home/node/.openclaw/workspace \
      /home/node/.config/openclaw
```

When `install -d` creates missing parent directories on its way to the target leaf, it uses the process's default ownership — `root:root` inside a `RUN` layer — leaving `/home/node/.config` owned by root. Only the explicitly listed directories receive the `-o node -g node` flag.

The regression was introduced in #85454, commit `d8b973638e8d70b1a8e7035d670210526d5885b0`, merged on May 22, 2026.

## Changes

**`Dockerfile`**
- Add a dedicated `install -d -m 0755 -o node -g node /home/node/.config` step before the leaf `0700` step, so the parent is explicitly created as `node:node 755`.
- Add a `stat` assertion for `/home/node/.config` in the same `RUN` layer, mirroring the existing leaf assertions so regressions are caught at build time.

**`scripts/docker/setup.sh`**
- Add `chown node:node /home/node/.config` to the pre-start permission repair so live containers upgraded from affected images are also healed.

**`src/dockerfile.test.ts` / `src/docker-setup.e2e.test.ts`**
- Add regression assertions for the parent-dir install order, build-time ownership assertion, and setup permission repair.

## Real behavior proof

Behavior addressed: `2026.5.22-slim` leaves `/home/node/.config` owned by `root:root`, so `npx` and skill installs cannot write under `~/.config` as the runtime `node` user.

Real environment tested: Podman 5.8.2 on macOS arm64, building and running the OpenClaw Linux arm64 runtime image from maintainer-assisted commit `05855fdef5224fa43767e3d437cd245b5527cee1`.

Exact steps or command run after this patch:

```shell
node scripts/run-vitest.mjs src/dockerfile.test.ts src/docker-setup.e2e.test.ts
podman build -t openclaw-config-parent-fix -f Dockerfile .
podman run --rm openclaw-config-parent-fix stat -c '%U:%G %a %n' /home/node/.config /home/node/.config/openclaw
podman run --rm openclaw-config-parent-fix sh -lc 'touch /home/node/.config/probe && stat -c "%U:%G %a %n" /home/node/.config/probe'
```

Evidence after fix:

```shell
node:node 755 /home/node/.config
node:node 700 /home/node/.config/openclaw
node:node 644 /home/node/.config/probe
```

Observed result after fix: the rebuilt image keeps the parent config directory writable by the default `node` user while preserving the private OpenClaw leaf directory mode.

What was not tested: full GitHub CI is still running on the pushed PR head.

## Before / After

| Path | Before | After |
|------|--------|-------|
| `/home/node/.config` | `root:root 755` | `node:node 755` |
| `/home/node/.config/openclaw` | `node:node 700` | `node:node 700` (unchanged) |
| `/home/node/.openclaw` | `node:node 700` | `node:node 700` (unchanged) |
