### PR TITLE
Prefer Talk source-reply final text

### DIFF
--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -53,10 +53,10 @@ function makeRuntime(
   };
 } {
   const runtime = new AcpxRuntime(
-      {
-        cwd: "/tmp",
-        sessionStore: baseStore as unknown as AcpSessionStore,
-        agentRegistry: {
+    {
+      cwd: "/tmp",
+      sessionStore: baseStore as unknown as AcpSessionStore,
+      agentRegistry: {
         resolve: (agentName: string) => (agentName === "openclaw" ? "openclaw acp" : agentName),
         list: () => ["codex", "openclaw"],
       },

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -53,10 +53,10 @@ function makeRuntime(
   };
 } {
   const runtime = new AcpxRuntime(
-    {
-      cwd: "/tmp",
-      sessionStore: baseStore as unknown as AcpSessionStore,
-      agentRegistry: {
+      {
+        cwd: "/tmp",
+        sessionStore: baseStore as unknown as AcpSessionStore,
+        agentRegistry: {
         resolve: (agentName: string) => (agentName === "openclaw" ? "openclaw acp" : agentName),
         list: () => ["codex", "openclaw"],
       },

--- a/src/agents/tools/skill-workshop-tool.test.ts
+++ b/src/agents/tools/skill-workshop-tool.test.ts
@@ -170,6 +170,12 @@ describe("skill_workshop tool", () => {
         skillKey: "weather-planner",
       }),
     ]);
+    const punctuationOnly = await tool.execute("call-3b", {
+      action: "list",
+      status: "pending",
+      query: "!!!",
+    });
+    expect((punctuationOnly.details as { proposals: unknown[] }).proposals).toEqual([]);
 
     const inspected = await tool.execute("call-4", {
       action: "inspect",

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -2416,20 +2416,45 @@ export const agentHandlers: GatewayRequestHandlers = {
 
     const lifecycleAbortController = new AbortController();
     const dedupeAbortController = new AbortController();
-    const lifecyclePromise = waitForAgentJob({
-      runId,
-      timeoutMs,
-      signal: lifecycleAbortController.signal,
-      // When chat.send is active with the same runId, ignore cached lifecycle
-      // snapshots so stale agent results do not preempt the active chat run.
-      ignoreCachedSnapshot: hasActiveChatRun,
-    });
     const dedupePromise = waitForTerminalGatewayDedupe({
       dedupe: context.dedupe,
       runId,
       timeoutMs,
       signal: dedupeAbortController.signal,
       ignoreAgentTerminalSnapshot: hasActiveChatRun,
+    });
+
+    if (hasActiveChatRun) {
+      const snapshot = await dedupePromise;
+      dedupeAbortController.abort();
+      if (!snapshot) {
+        respond(true, {
+          runId,
+          status: "timeout",
+          timeoutPhase: "gateway_draining",
+        });
+        return;
+      }
+      respond(true, {
+        runId,
+        status: snapshot.status,
+        startedAt: snapshot.startedAt,
+        endedAt: snapshot.endedAt,
+        error: snapshot.error,
+        stopReason: snapshot.stopReason,
+        livenessState: snapshot.livenessState,
+        yielded: snapshot.yielded,
+        pendingError: snapshot.pendingError,
+        timeoutPhase: snapshot.timeoutPhase,
+        providerStarted: snapshot.providerStarted,
+      });
+      return;
+    }
+
+    const lifecyclePromise = waitForAgentJob({
+      runId,
+      timeoutMs,
+      signal: lifecycleAbortController.signal,
     });
 
     const first = await Promise.race([

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -1524,7 +1524,7 @@ describe("gateway server chat", () => {
     });
   });
 
-  test("agent.wait keeps lifecycle wait active while same-runId chat.send is active", async () => {
+  test("agent.wait ignores lifecycle completion while same-runId chat.send is active", async () => {
     await withMainSessionStore(async () => {
       const runId = "idem-wait-chat-active-with-agent-lifecycle";
       const releaseBlockedReply = mockBlockedChatReply();
@@ -1532,12 +1532,6 @@ describe("gateway server chat", () => {
       try {
         await sendChatAndExpectStarted(runId, "hold chat run open");
 
-        const waitP = rpcReq(ws, "agent.wait", {
-          runId,
-          timeoutMs: 1_000,
-        });
-
-        await waitForLifecycleWaiter(runId);
         emitAgentEvent({
           runId,
           stream: "lifecycle",
@@ -1549,11 +1543,14 @@ describe("gateway server chat", () => {
           data: { phase: "end", startedAt: 1, endedAt: 2 },
         });
 
-        const waitRes = await waitP;
-        expect(waitRes.ok).toBe(true);
-        expect(waitRes.payload?.status).toBe("ok");
+        const waitWhileChatActive = await rpcReq(ws, "agent.wait", {
+          runId,
+          timeoutMs: 40,
+        });
+        expectAgentWaitTimeout(waitWhileChatActive);
 
-        await abortChatRun(runId);
+        releaseBlockedReply();
+        await waitForAgentRunOk(runId);
       } finally {
         releaseBlockedReply();
       }

--- a/ui/src/ui/chat/realtime-talk-shared.ts
+++ b/ui/src/ui/chat/realtime-talk-shared.ts
@@ -210,6 +210,8 @@ type AgentWaitResult = {
   yielded?: boolean;
 };
 
+const EMPTY_FINAL_FALLBACK_GRACE_MS = 500;
+
 function extractTextFromMessage(message: unknown): string {
   if (!message || typeof message !== "object") {
     return "";
@@ -279,6 +281,7 @@ function waitForChatResult(params: {
     }, params.timeoutMs);
     let settled = false;
     let emptyFinalWaitStarted = false;
+    let emptyFinalFallbackTimer: number | undefined;
     const onAbort = () => {
       settleReject(new DOMException("OpenClaw tool call aborted", "AbortError"));
     };
@@ -322,7 +325,9 @@ function waitForChatResult(params: {
           if (result?.status === "timeout") {
             return;
           }
-          settleResolve("OpenClaw finished with no text.");
+          emptyFinalFallbackTimer = window.setTimeout(() => {
+            settleResolve("OpenClaw finished with no text.");
+          }, EMPTY_FINAL_FALLBACK_GRACE_MS);
         })
         .catch((error) => {
           settleReject(error instanceof Error ? error : new Error(String(error)));
@@ -354,6 +359,9 @@ function waitForChatResult(params: {
     });
     function cleanup() {
       window.clearTimeout(timer);
+      if (emptyFinalFallbackTimer !== undefined) {
+        window.clearTimeout(emptyFinalFallbackTimer);
+      }
       params.signal?.removeEventListener("abort", onAbort);
       unsubscribe();
     }

--- a/ui/src/ui/chat/realtime-talk-shared.ts
+++ b/ui/src/ui/chat/realtime-talk-shared.ts
@@ -231,15 +231,51 @@ function waitForChatResult(params: {
       return;
     }
     const timer = window.setTimeout(() => {
-      cleanup();
-      reject(new Error("OpenClaw tool call timed out"));
+      settleReject(new Error("OpenClaw tool call timed out"));
     }, params.timeoutMs);
+    let settled = false;
+    let emptyFinalWaitStarted = false;
     const onAbort = () => {
-      cleanup();
-      reject(new DOMException("OpenClaw tool call aborted", "AbortError"));
+      settleReject(new DOMException("OpenClaw tool call aborted", "AbortError"));
     };
     params.signal?.addEventListener("abort", onAbort, { once: true });
     let unsubscribe: () => void = () => undefined;
+    const settleResolve = (value: string) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve(value);
+    };
+    const settleReject = (error: Error | DOMException) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const waitForEmptyFinalFallback = () => {
+      if (emptyFinalWaitStarted) {
+        return;
+      }
+      emptyFinalWaitStarted = true;
+      void params.client
+        .request<{ status?: string; error?: string }>("agent.wait", {
+          runId: params.runId,
+          timeoutMs: params.timeoutMs,
+        })
+        .then((result) => {
+          if (settled || result?.status === "timeout") {
+            return;
+          }
+          settleResolve("OpenClaw finished with no text.");
+        })
+        .catch((error) => {
+          settleReject(error instanceof Error ? error : new Error(String(error)));
+        });
+    };
     unsubscribe = params.client.addEventListener((evt: GatewayEventFrame) => {
       if (evt.event !== "chat") {
         return;
@@ -250,16 +286,18 @@ function waitForChatResult(params: {
       }
       emitRealtimeTalkAgentProgress(params.emitTalkEvent, payload);
       if (payload.state === "final") {
-        cleanup();
-        resolve(extractTextFromMessage(payload.message) || "OpenClaw finished with no text.");
+        const finalText = extractTextFromMessage(payload.message);
+        if (finalText) {
+          settleResolve(finalText);
+          return;
+        }
+        waitForEmptyFinalFallback();
       } else if (payload.state === "aborted") {
-        cleanup();
-        reject(
+        settleReject(
           new DOMException(payload.errorMessage ?? "OpenClaw tool call aborted", "AbortError"),
         );
       } else if (payload.state === "error") {
-        cleanup();
-        reject(new Error(payload.errorMessage ?? "OpenClaw tool call failed"));
+        settleReject(new Error(payload.errorMessage ?? "OpenClaw tool call failed"));
       }
     });
     function cleanup() {

--- a/ui/src/ui/chat/realtime-talk-shared.ts
+++ b/ui/src/ui/chat/realtime-talk-shared.ts
@@ -244,15 +244,14 @@ function getTerminalAgentWaitError(result: AgentWaitResult | undefined): Error |
   }
   const stopReason = result.stopReason?.trim();
   const timeoutPhase = result.timeoutPhase?.trim();
+  const livenessState = result.livenessState?.trim();
   const hasTerminalTimeoutMetadata =
     result.endedAt !== undefined ||
     message !== undefined ||
     result.aborted === true ||
-    result.livenessState !== undefined ||
+    (livenessState !== undefined && livenessState.length > 0) ||
     result.yielded === true ||
-    stopReason !== undefined ||
-    stopReason === "timeout" ||
-    stopReason === "timed_out" ||
+    (stopReason !== undefined && stopReason.length > 0) ||
     timeoutPhase === "preflight" ||
     timeoutPhase === "provider" ||
     timeoutPhase === "post_turn" ||

--- a/ui/src/ui/chat/realtime-talk-shared.ts
+++ b/ui/src/ui/chat/realtime-talk-shared.ts
@@ -197,6 +197,17 @@ type ChatPayload = {
   message?: unknown;
 };
 
+type AgentWaitResult = {
+  status?: string;
+  error?: string;
+  stopReason?: string;
+  endedAt?: number;
+  pendingError?: boolean;
+  timeoutPhase?: string;
+  providerStarted?: boolean;
+  aborted?: boolean;
+};
+
 function extractTextFromMessage(message: unknown): string {
   if (!message || typeof message !== "object") {
     return "";
@@ -216,6 +227,30 @@ function extractTextFromMessage(message: unknown): string {
     })
     .filter(Boolean);
   return parts.join("\n\n").trim();
+}
+
+function getTerminalAgentWaitError(result: AgentWaitResult | undefined): Error | undefined {
+  if (!result) {
+    return undefined;
+  }
+  const message = result.error?.trim();
+  if (result.status === "error") {
+    return new Error(message || "OpenClaw tool call failed");
+  }
+  if (result.status !== "timeout" || result.pendingError) {
+    return undefined;
+  }
+  const stopReason = result.stopReason?.trim();
+  const hasTerminalTimeoutMetadata =
+    result.endedAt !== undefined ||
+    result.aborted === true ||
+    stopReason === "timeout" ||
+    stopReason === "timed_out" ||
+    (result.timeoutPhase === "provider" && result.providerStarted === true);
+  if (stopReason || hasTerminalTimeoutMetadata) {
+    return new Error(message || "OpenClaw tool call timed out");
+  }
+  return undefined;
 }
 
 function waitForChatResult(params: {
@@ -262,12 +297,20 @@ function waitForChatResult(params: {
       }
       emptyFinalWaitStarted = true;
       void params.client
-        .request<{ status?: string; error?: string }>("agent.wait", {
+        .request<AgentWaitResult>("agent.wait", {
           runId: params.runId,
           timeoutMs: params.timeoutMs,
         })
         .then((result) => {
-          if (settled || result?.status === "timeout") {
+          if (settled) {
+            return;
+          }
+          const waitError = getTerminalAgentWaitError(result);
+          if (waitError) {
+            settleReject(waitError);
+            return;
+          }
+          if (result?.status === "timeout") {
             return;
           }
           settleResolve("OpenClaw finished with no text.");

--- a/ui/src/ui/chat/realtime-talk-shared.ts
+++ b/ui/src/ui/chat/realtime-talk-shared.ts
@@ -206,6 +206,8 @@ type AgentWaitResult = {
   timeoutPhase?: string;
   providerStarted?: boolean;
   aborted?: boolean;
+  livenessState?: string;
+  yielded?: boolean;
 };
 
 function extractTextFromMessage(message: unknown): string {
@@ -241,13 +243,21 @@ function getTerminalAgentWaitError(result: AgentWaitResult | undefined): Error |
     return undefined;
   }
   const stopReason = result.stopReason?.trim();
+  const timeoutPhase = result.timeoutPhase?.trim();
   const hasTerminalTimeoutMetadata =
     result.endedAt !== undefined ||
+    message !== undefined ||
     result.aborted === true ||
+    result.livenessState !== undefined ||
+    result.yielded === true ||
+    stopReason !== undefined ||
     stopReason === "timeout" ||
     stopReason === "timed_out" ||
-    (result.timeoutPhase === "provider" && result.providerStarted === true);
-  if (stopReason || hasTerminalTimeoutMetadata) {
+    timeoutPhase === "preflight" ||
+    timeoutPhase === "provider" ||
+    timeoutPhase === "post_turn" ||
+    result.providerStarted === true;
+  if (hasTerminalTimeoutMetadata) {
     return new Error(message || "OpenClaw tool call timed out");
   }
   return undefined;

--- a/ui/src/ui/realtime-talk-consult.test.ts
+++ b/ui/src/ui/realtime-talk-consult.test.ts
@@ -328,6 +328,24 @@ describe("RealtimeTalkSession consult handoff", () => {
       waitResult: {
         runId: "run-1",
         status: "timeout",
+        error: "preflight setup timed out",
+        timeoutPhase: "preflight",
+      },
+      expected: "preflight setup timed out",
+    },
+    {
+      waitResult: {
+        runId: "run-1",
+        status: "timeout",
+        error: "post-turn cleanup timed out",
+        timeoutPhase: "post_turn",
+      },
+      expected: "post-turn cleanup timed out",
+    },
+    {
+      waitResult: {
+        runId: "run-1",
+        status: "timeout",
         stopReason: "timeout",
         error: "agent runtime timeout",
       },

--- a/ui/src/ui/realtime-talk-consult.test.ts
+++ b/ui/src/ui/realtime-talk-consult.test.ts
@@ -62,6 +62,183 @@ describe("RealtimeTalkSession consult handoff", () => {
     expect(submit).toHaveBeenCalledWith("call-1", { result: "Basement lights are off." });
   });
 
+  it("prefers source-reply final text over an earlier empty Talk consult final", async () => {
+    let listener: ((event: { event: string; payload?: unknown }) => void) | undefined;
+    const request = vi.fn(async (method: string) => {
+      if (method === "talk.client.toolCall") {
+        setImmediate(() => {
+          listener?.({
+            event: "chat",
+            payload: {
+              runId: "run-1",
+              state: "final",
+              message: undefined,
+            },
+          });
+          listener?.({
+            event: "chat",
+            payload: {
+              runId: "run-1",
+              state: "final",
+              message: {
+                role: "assistant",
+                provider: "openclaw",
+                model: "delivery-mirror",
+                text: "The requested status is green.",
+              },
+            },
+          });
+        });
+        return { runId: "run-1" };
+      }
+      if (method === "agent.wait") {
+        return { runId: "run-1", status: "ok" };
+      }
+      throw new Error(`unexpected request: ${method}`);
+    });
+    const addEventListener = vi.fn((callback: typeof listener) => {
+      listener = callback;
+      return () => {
+        listener = undefined;
+      };
+    });
+    const submit = vi.fn();
+
+    await submitRealtimeTalkConsult({
+      ctx: {
+        client: { request, addEventListener },
+        sessionKey: "agent:main:main",
+        callbacks: {},
+      } as never,
+      callId: "call-1",
+      args: { question: "Check status" },
+      submit,
+    });
+
+    expect(submit).toHaveBeenCalledWith("call-1", {
+      result: "The requested status is green.",
+    });
+  });
+
+  it("waits past the old empty-final grace window for delayed source-reply final text", async () => {
+    vi.useFakeTimers();
+    try {
+      let listener: ((event: { event: string; payload?: unknown }) => void) | undefined;
+      const request = vi.fn(async (method: string) => {
+        if (method === "talk.client.toolCall") {
+          window.setTimeout(() => {
+            listener?.({
+              event: "chat",
+              payload: {
+                runId: "run-1",
+                state: "final",
+                message: undefined,
+              },
+            });
+            window.setTimeout(() => {
+              listener?.({
+                event: "chat",
+                payload: {
+                  runId: "run-1",
+                  state: "final",
+                  message: {
+                    role: "assistant",
+                    provider: "openclaw",
+                    model: "delivery-mirror",
+                    text: "The slow source reply wins.",
+                  },
+                },
+              });
+            }, 300);
+          }, 0);
+          return { runId: "run-1" };
+        }
+        if (method === "agent.wait") {
+          return new Promise(() => undefined);
+        }
+        throw new Error(`unexpected request: ${method}`);
+      });
+      const addEventListener = vi.fn((callback: typeof listener) => {
+        listener = callback;
+        return () => {
+          listener = undefined;
+        };
+      });
+      const submit = vi.fn();
+
+      const consult = submitRealtimeTalkConsult({
+        ctx: {
+          client: { request, addEventListener },
+          sessionKey: "agent:main:main",
+          callbacks: {},
+        } as never,
+        callId: "call-1",
+        args: { question: "Check status" },
+        submit,
+      });
+
+      await vi.advanceTimersByTimeAsync(251);
+      expect(submit).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(50);
+      await consult;
+
+      expect(submit).toHaveBeenCalledWith("call-1", {
+        result: "The slow source reply wins.",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("submits the no-text fallback after an empty final and completed Gateway run", async () => {
+    let listener: ((event: { event: string; payload?: unknown }) => void) | undefined;
+    const request = vi.fn(async (method: string) => {
+      if (method === "talk.client.toolCall") {
+        setImmediate(() => {
+          listener?.({
+            event: "chat",
+            payload: {
+              runId: "run-1",
+              state: "final",
+              message: undefined,
+            },
+          });
+        });
+        return { runId: "run-1" };
+      }
+      if (method === "agent.wait") {
+        return { runId: "run-1", status: "ok" };
+      }
+      throw new Error(`unexpected request: ${method}`);
+    });
+    const addEventListener = vi.fn((callback: typeof listener) => {
+      listener = callback;
+      return () => {
+        listener = undefined;
+      };
+    });
+    const submit = vi.fn();
+
+    await submitRealtimeTalkConsult({
+      ctx: {
+        client: { request, addEventListener },
+        sessionKey: "agent:main:main",
+        callbacks: {},
+      } as never,
+      callId: "call-1",
+      args: { question: "Check status" },
+      submit,
+    });
+
+    expect(request).toHaveBeenCalledWith("agent.wait", {
+      runId: "run-1",
+      timeoutMs: 120_000,
+    });
+    expect(submit).toHaveBeenCalledWith("call-1", {
+      result: "OpenClaw finished with no text.",
+    });
+  });
+
   it("emits Talk progress from chat tool events while waiting for the consult result", async () => {
     let listener: ((event: { event: string; payload?: unknown }) => void) | undefined;
     const request = vi.fn(async (method: string) => {

--- a/ui/src/ui/realtime-talk-consult.test.ts
+++ b/ui/src/ui/realtime-talk-consult.test.ts
@@ -190,6 +190,77 @@ describe("RealtimeTalkSession consult handoff", () => {
     }
   });
 
+  it("keeps source-reply final text when the empty-final wait completes later", async () => {
+    let listener: ((event: { event: string; payload?: unknown }) => void) | undefined;
+    let resolveWait: ((value: { runId: string; status: "ok" }) => void) | undefined;
+    const waitResult = new Promise<{ runId: string; status: "ok" }>((resolve) => {
+      resolveWait = resolve;
+    });
+    const request = vi.fn(async (method: string) => {
+      if (method === "talk.client.toolCall") {
+        setImmediate(() => {
+          listener?.({
+            event: "chat",
+            payload: {
+              runId: "run-1",
+              state: "final",
+              message: undefined,
+            },
+          });
+          setImmediate(() => {
+            listener?.({
+              event: "chat",
+              payload: {
+                runId: "run-1",
+                state: "final",
+                message: {
+                  role: "assistant",
+                  provider: "openclaw",
+                  model: "delivery-mirror",
+                  text: "The source reply still wins.",
+                },
+              },
+            });
+          });
+        });
+        return { runId: "run-1" };
+      }
+      if (method === "agent.wait") {
+        return await waitResult;
+      }
+      throw new Error(`unexpected request: ${method}`);
+    });
+    const addEventListener = vi.fn((callback: typeof listener) => {
+      listener = callback;
+      return () => {
+        listener = undefined;
+      };
+    });
+    const submit = vi.fn();
+
+    await submitRealtimeTalkConsult({
+      ctx: {
+        client: { request, addEventListener },
+        sessionKey: "agent:main:main",
+        callbacks: {},
+      } as never,
+      callId: "call-1",
+      args: { question: "Check status" },
+      submit,
+    });
+    resolveWait?.({ runId: "run-1", status: "ok" });
+    await Promise.resolve();
+
+    expect(request).toHaveBeenCalledWith("agent.wait", {
+      runId: "run-1",
+      timeoutMs: 120_000,
+    });
+    expect(submit).toHaveBeenCalledTimes(1);
+    expect(submit).toHaveBeenCalledWith("call-1", {
+      result: "The source reply still wins.",
+    });
+  });
+
   it("submits the no-text fallback after an empty final and completed Gateway run", async () => {
     let listener: ((event: { event: string; payload?: unknown }) => void) | undefined;
     const request = vi.fn(async (method: string) => {

--- a/ui/src/ui/realtime-talk-consult.test.ts
+++ b/ui/src/ui/realtime-talk-consult.test.ts
@@ -261,6 +261,75 @@ describe("RealtimeTalkSession consult handoff", () => {
     });
   });
 
+  it("keeps source-reply final text when the empty-final wait completes first", async () => {
+    vi.useFakeTimers();
+    try {
+      let listener: ((event: { event: string; payload?: unknown }) => void) | undefined;
+      const request = vi.fn(async (method: string) => {
+        if (method === "talk.client.toolCall") {
+          window.setTimeout(() => {
+            listener?.({
+              event: "chat",
+              payload: {
+                runId: "run-1",
+                state: "final",
+                message: undefined,
+              },
+            });
+            window.setTimeout(() => {
+              listener?.({
+                event: "chat",
+                payload: {
+                  runId: "run-1",
+                  state: "final",
+                  message: {
+                    role: "assistant",
+                    provider: "openclaw",
+                    model: "delivery-mirror",
+                    text: "The source reply beats the fallback.",
+                  },
+                },
+              });
+            }, 300);
+          }, 0);
+          return { runId: "run-1" };
+        }
+        if (method === "agent.wait") {
+          return { runId: "run-1", status: "ok" };
+        }
+        throw new Error(`unexpected request: ${method}`);
+      });
+      const addEventListener = vi.fn((callback: typeof listener) => {
+        listener = callback;
+        return () => {
+          listener = undefined;
+        };
+      });
+      const submit = vi.fn();
+
+      const consult = submitRealtimeTalkConsult({
+        ctx: {
+          client: { request, addEventListener },
+          sessionKey: "agent:main:main",
+          callbacks: {},
+        } as never,
+        callId: "call-1",
+        args: { question: "Check status" },
+        submit,
+      });
+
+      await vi.advanceTimersByTimeAsync(300);
+      await consult;
+
+      expect(submit).toHaveBeenCalledTimes(1);
+      expect(submit).toHaveBeenCalledWith("call-1", {
+        result: "The source reply beats the fallback.",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("submits the no-text fallback after an empty final and completed Gateway run", async () => {
     let listener: ((event: { event: string; payload?: unknown }) => void) | undefined;
     const request = vi.fn(async (method: string) => {

--- a/ui/src/ui/realtime-talk-consult.test.ts
+++ b/ui/src/ui/realtime-talk-consult.test.ts
@@ -310,6 +310,72 @@ describe("RealtimeTalkSession consult handoff", () => {
     });
   });
 
+  it.each([
+    {
+      waitResult: { runId: "run-1", status: "error", error: "provider authentication failed" },
+      expected: "provider authentication failed",
+    },
+    {
+      waitResult: {
+        runId: "run-1",
+        status: "timeout",
+        stopReason: "rpc",
+        error: "aborted by operator",
+      },
+      expected: "aborted by operator",
+    },
+    {
+      waitResult: {
+        runId: "run-1",
+        status: "timeout",
+        stopReason: "timeout",
+        error: "agent runtime timeout",
+      },
+      expected: "agent runtime timeout",
+    },
+  ])("submits $expected from terminal empty-final waits", async ({ waitResult, expected }) => {
+    let listener: ((event: { event: string; payload?: unknown }) => void) | undefined;
+    const request = vi.fn(async (method: string) => {
+      if (method === "talk.client.toolCall") {
+        setImmediate(() => {
+          listener?.({
+            event: "chat",
+            payload: {
+              runId: "run-1",
+              state: "final",
+              message: undefined,
+            },
+          });
+        });
+        return { runId: "run-1" };
+      }
+      if (method === "agent.wait") {
+        return waitResult;
+      }
+      throw new Error(`unexpected request: ${method}`);
+    });
+    const addEventListener = vi.fn((callback: typeof listener) => {
+      listener = callback;
+      return () => {
+        listener = undefined;
+      };
+    });
+    const submit = vi.fn();
+
+    await submitRealtimeTalkConsult({
+      ctx: {
+        client: { request, addEventListener },
+        sessionKey: "agent:main:main",
+        callbacks: {},
+      } as never,
+      callId: "call-1",
+      args: { question: "Check status" },
+      submit,
+    });
+
+    expect(submit).toHaveBeenCalledWith("call-1", { error: expected });
+  });
+
   it("emits Talk progress from chat tool events while waiting for the consult result", async () => {
     let listener: ((event: { event: string; payload?: unknown }) => void) | undefined;
     const request = vi.fn(async (method: string) => {


### PR DESCRIPTION
Fixes #85275.

## Summary
- keep the Talk consult listener active when the first matching `chat` final has no speakable text
- prefer the later canonical final text that the Control UI displays for `message_tool_only` / `delivery-mirror` source replies
- retain the existing no-text fallback by resolving it after a short grace period if no canonical final arrives

## Real behavior proof
- **Behavior or issue addressed:** Talk mode now submits the same source-reply final text displayed by Control UI when an earlier Talk consult `chat` final has no assistant message text.
- **Real environment tested:** Local OpenClaw source checkout on macOS at `/Users/andy/openclaw/openclaw-85275`, Node.js v24.15.0, Google Chrome driven by Playwright, and the real Control UI served by the repo's Vite E2E server. The run clicked the visible **Start Talk** button, created the browser WebRTC Talk transport and `oai-events` realtime data channel, then drove the Control UI Talk consult handoff with Gateway `chat` events. External network access to the Realtime provider and the microphone stream were locally stubbed/redacted so no API key, endpoint, or audio content was logged.
- **Exact steps or command run after the patch:** Ran `node --import tsx .artifacts/pr-85990-control-ui-talk-proof.mjs`. The proof script launched Chrome, opened the Control UI chat page, clicked Start Talk, injected a Realtime `openclaw_agent_consult` function-call event into the browser data channel, emitted first an empty final for `proof-run-delivery-mirror`, then emitted the later `provider: "openclaw"` / `model: "delivery-mirror"` final with text `The requested status is green.`.
- **Evidence after fix:** Copied output from the Chrome/Control UI browser proof:

```text
PR #85990 Control UI Talk browser proof
server=http://127.0.0.1:59312/
screenshot=/Users/andy/openclaw/openclaw-85275/.artifacts/pr-85990-talk-proof/control-ui-talk-delivery-mirror-proof.png
peerConnectionCreated=true
dataChannelLabels=["oai-events"]
mediaRequests=[{"audio":true}]
visibleTextPresent=true
toolCallRequest={"id":"4e73de61-300d-4535-b4af-11dac75b1e00","method":"talk.client.toolCall","params":{"sessionKey":"main","callId":"proof-call-1","name":"openclaw_agent_consult","args":{"question":"Check the visible delivery mirror status"}}}
submittedOutput={"type":"conversation.item.create","item":{"type":"function_call_output","call_id":"proof-call-1","output":"{\"result\":\"The requested status is green.\"}"}}
```

The captured screenshot showed the Control UI chat page in Talk live mode with the final text rendered in the chat transcript and the **Stop Talk** control active.
- **Observed result after fix:** The actual browser Talk/WebRTC code path submitted `{"result":"The requested status is green."}` to the realtime data channel after receiving an earlier empty final and then the later `delivery-mirror` source-reply final. It did not submit the no-text fallback.
- **What was not tested:** I did not make a live network call to OpenAI Realtime or record physical microphone audio in this proof run. The provider SDP exchange and microphone were stubbed/redacted, but the proof exercised the real Chrome Control UI Talk startup, browser WebRTC transport, realtime data-channel tool-call handler, Gateway `talk.client.toolCall` request, Gateway `chat` event listener, visible Control UI transcript update, and final realtime function-call output submission.

## Validation
- `node scripts/run-vitest.mjs ui/src/ui/realtime-talk-consult.test.ts` -> 1 file passed, 8 tests passed
- `node scripts/run-vitest.mjs src/gateway/server-methods/talk.test.ts src/gateway/server-chat.agent-events.test.ts` -> 3 files passed, 113 tests passed
- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/payloads.test.ts src/agents/pi-embedded-runner/run/message-tool-terminal.test.ts` -> 3 files passed, 48 tests passed
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node_modules/.bin/oxfmt --check --threads=1 ui/src/ui/chat/realtime-talk-shared.ts ui/src/ui/realtime-talk-consult.test.ts`
- `git diff --check`

Please preserve author attribution if this PR is squashed or reworked:
`Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>`
