### PR TITLE
fix(scripts): normalize lockfile peer package specs

### DIFF
--- a/scripts/list-prod-store-packages.mjs
+++ b/scripts/list-prod-store-packages.mjs
@@ -26,11 +26,15 @@ function packageSpecFromLockfileKey(key) {
     return undefined;
   }
   const normalizedKey = key.startsWith("/") ? key.slice(1) : key;
-  const separator = normalizedKey.lastIndexOf("@");
+  const keyWithoutPeerSuffix = normalizedKey.replace(/\(.+\)$/, "");
+  const separator = keyWithoutPeerSuffix.lastIndexOf("@");
   if (separator <= 0) {
     return undefined;
   }
-  return packageSpec(normalizedKey.slice(0, separator), normalizedKey.slice(separator + 1));
+  return packageSpec(
+    keyWithoutPeerSuffix.slice(0, separator),
+    keyWithoutPeerSuffix.slice(separator + 1),
+  );
 }
 
 function visitListNode(node) {

--- a/test/scripts/list-prod-store-packages.test.ts
+++ b/test/scripts/list-prod-store-packages.test.ts
@@ -110,6 +110,8 @@ describe("list-prod-store-packages", () => {
         "packages:",
         "  recma-jsx@1.0.1(acorn@8.16.0):",
         "    resolution: {integrity: sha512-test}",
+        "  '/@scope/peer-wrapper@2.0.0(@scope/peer@1.0.0)':",
+        "    resolution: {integrity: sha512-test}",
         "",
         "snapshots: {}",
         "",
@@ -118,6 +120,6 @@ describe("list-prod-store-packages", () => {
     const result = runListProdStorePackages({ dependencies: {} }, cwd);
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toBe("recma-jsx@1.0.1");
+    expect(result.stdout).toBe("@scope/peer-wrapper@2.0.0\nrecma-jsx@1.0.1");
   });
 });


### PR DESCRIPTION
## Summary

- Strip pnpm peer-dependency suffixes from lockfile package keys before splitting package name and version.
- Preserve the existing leading-slash normalization for lockfile package keys, including scoped packages.
- Extend the regression test that caught the `build-artifacts` failure to cover both unscoped and scoped peer-suffixed package keys.

## Root cause

`packageSpecFromLockfileKey()` removed a leading `/`, then used `lastIndexOf("@")` on the full lockfile package key. For peer-suffixed pnpm package keys such as `recma-jsx@1.0.1(acorn@8.16.0)`, the last `@` belongs to the peer suffix, not the package version separator. That made the script emit `recma-jsx@1.0.1(acorn@8.16.0)` instead of the production package spec `recma-jsx@1.0.1`.

## Impact

The `build-artifacts` CI lane can fail while collecting production store package specs from lockfile-only packages with peer suffixes. The fix keeps the package spec list stable for Docker/artifact pruning without changing pnpm list traversal, registry filtering, or workspace/file/link exclusion behavior.

## Real behavior proof

- **Behavior or issue addressed:** `scripts/list-prod-store-packages.mjs` now normalizes pnpm lockfile peer suffixes before adding missing lockfile packages to the production package list.
- **Real environment tested:** Windows 11 local checkout at `C:\Users\user\Downloads\openclaw-pr`, Node v22.17.0, pnpm 11.2.2.
- **Before evidence:** GitHub `build-artifacts` failed on this current-main path with the existing regression test: [failed job log](https://github.com/openclaw/openclaw/actions/runs/26356791975/job/77584884035).

```text
FAIL ../scripts/list-prod-store-packages.test.ts > adds lockfile packages missing from pnpm list output
AssertionError: expected 'recma-jsx@1.0.1(acorn@8.16.0)' to be 'recma-jsx@1.0.1'
```

- **Exact steps or command run after this patch:**

```powershell
pnpm exec vitest run --config test/vitest/vitest.full-core-support-boundary.config.ts test/scripts/list-prod-store-packages.test.ts --reporter=verbose
```

- **Evidence after fix:**

```text
Test Files  1 passed (1)
Tests  4 passed (4)
```

- **Observed result after fix:** The focused test now emits `recma-jsx@1.0.1` for an unscoped peer-suffixed key and `@scope/peer-wrapper@2.0.0` for a scoped leading-slash peer-suffixed key.
- **What was not tested:** Full GitHub `build-artifacts` on this branch had not completed at PR creation time; the exact failing test and local changed-check lane were run locally.

## Validation

- `pnpm exec vitest run --config test/vitest/vitest.full-core-support-boundary.config.ts test/scripts/list-prod-store-packages.test.ts --reporter=verbose`
- `pnpm exec oxfmt --check --threads=1 scripts/list-prod-store-packages.mjs test/scripts/list-prod-store-packages.test.ts`
- `git diff --check`
- `pnpm check:changed`

Local `pnpm` commands emitted the existing engine warning because this machine has Node v22.17.0 while the repo requests >=22.19.0; all listed commands exited successfully.

## Security

No dependency, credential, network, command-execution, or install surface is added. This only normalizes package key parsing in an existing repository script and extends its regression coverage.
