### PR TITLE
fix #85782: surface terminal TUI lifecycle errors

### DIFF
--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -2022,6 +2022,11 @@ export function buildVitestRunPlans(
     toRepoRelativeTarget(targetArg, cwd),
   );
   if (explicitConfigTargets.every(isVitestConfigFileTarget)) {
+    if (watchMode && explicitConfigTargets.length > 1) {
+      throw new Error(
+        "watch mode with mixed test suites is not supported; target one suite at a time or use a dedicated suite command",
+      );
+    }
     return explicitConfigTargets.map((config) => ({
       config,
       forwardedArgs: nonTargetArgs,

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -2017,7 +2017,7 @@ export function buildVitestRunPlans(
     ];
   }
 
-  const nonTargetArgs = activeForwardedArgs.filter((arg) => !activeTargetArgs.includes(arg));
+  const nonTargetArgs = activeForwardedArgs.filter((arg) => !requestedTargetArgs.includes(arg));
   const explicitConfigTargets = activeTargetArgs.map((targetArg) =>
     toRepoRelativeTarget(targetArg, cwd),
   );

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -755,6 +755,12 @@ const GATEWAY_SERVER_EXCLUDED_TEST_TARGETS = new Set([
 const VITEST_CONFIG_TARGET_KIND_BY_PATH = new Map(
   Object.entries(VITEST_CONFIG_BY_KIND).map(([kind, config]) => [config, kind]),
 );
+const RUNNABLE_VITEST_CONFIG_TARGETS = new Set([
+  "vitest.config.ts",
+  DEFAULT_VITEST_CONFIG,
+  ...Object.values(VITEST_CONFIG_BY_KIND),
+  ...fullSuiteVitestShards.flatMap((shard) => [shard.config, ...shard.projects]),
+]);
 const CHANNEL_CONTRACT_CONFIG_PATTERNS = new Map([
   [
     CONTRACTS_CHANNEL_SURFACE_VITEST_CONFIG,
@@ -918,7 +924,7 @@ function isPathLikeTargetArg(arg, cwd) {
   return (
     isGlobTarget(arg) ||
     isFileLikeTarget(arg) ||
-    isVitestConfigFileTarget(relative) ||
+    isVitestConfigPathLikeTarget(relative) ||
     isExistingPathTarget(arg, cwd)
   );
 }
@@ -1416,10 +1422,14 @@ function resolveVitestConfigTargetKind(relative) {
   return VITEST_CONFIG_TARGET_KIND_BY_PATH.get(relative) ?? null;
 }
 
-function isVitestConfigFileTarget(relative) {
+function isVitestConfigPathLikeTarget(relative) {
   return (
     relative === "vitest.config.ts" || /^test\/vitest\/vitest\..+\.config\.ts$/u.test(relative)
   );
+}
+
+function isVitestConfigFileTarget(relative) {
+  return RUNNABLE_VITEST_CONFIG_TARGETS.has(relative);
 }
 
 function isVitestConfigTargetForKind(kind, targetArg, cwd) {

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -1043,7 +1043,10 @@ export function findUnmatchedExplicitTestTargets(args, cwd = process.cwd()) {
   const unmatched = [];
   for (const targetArg of targetArgs) {
     const relative = toRepoRelativeTarget(targetArg, cwd);
-    if (resolveVitestConfigTargetKind(relative) || isVitestConfigFileTarget(relative)) {
+    if (
+      resolveVitestConfigTargetKind(relative) ||
+      (isVitestConfigFileTarget(relative) && isExistingFileTarget(targetArg, cwd))
+    ) {
       continue;
     }
     const kind = classifyTarget(targetArg, cwd);

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -914,7 +914,13 @@ function isPathLikeTargetArg(arg, cwd) {
   if (!arg || arg === "--" || arg.startsWith("-")) {
     return false;
   }
-  return isGlobTarget(arg) || isFileLikeTarget(arg) || isExistingPathTarget(arg, cwd);
+  const relative = toRepoRelativeTarget(arg, cwd);
+  return (
+    isGlobTarget(arg) ||
+    isFileLikeTarget(arg) ||
+    isVitestConfigFileTarget(relative) ||
+    isExistingPathTarget(arg, cwd)
+  );
 }
 
 function toRepoRelativeTarget(arg, cwd) {

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -1043,7 +1043,7 @@ export function findUnmatchedExplicitTestTargets(args, cwd = process.cwd()) {
   const unmatched = [];
   for (const targetArg of targetArgs) {
     const relative = toRepoRelativeTarget(targetArg, cwd);
-    if (resolveVitestConfigTargetKind(relative)) {
+    if (resolveVitestConfigTargetKind(relative) || isVitestConfigFileTarget(relative)) {
       continue;
     }
     const kind = classifyTarget(targetArg, cwd);
@@ -1405,6 +1405,12 @@ function resolveAffectedTestsFromImportGraph(changedPath, cwd, options = {}) {
 
 function resolveVitestConfigTargetKind(relative) {
   return VITEST_CONFIG_TARGET_KIND_BY_PATH.get(relative) ?? null;
+}
+
+function isVitestConfigFileTarget(relative) {
+  return (
+    relative === "vitest.config.ts" || /^test\/vitest\/vitest\..+\.config\.ts$/u.test(relative)
+  );
 }
 
 function isVitestConfigTargetForKind(kind, targetArg, cwd) {
@@ -2011,6 +2017,19 @@ export function buildVitestRunPlans(
     ];
   }
 
+  const nonTargetArgs = activeForwardedArgs.filter((arg) => !activeTargetArgs.includes(arg));
+  const explicitConfigTargets = activeTargetArgs.map((targetArg) =>
+    toRepoRelativeTarget(targetArg, cwd),
+  );
+  if (explicitConfigTargets.every(isVitestConfigFileTarget)) {
+    return explicitConfigTargets.map((config) => ({
+      config,
+      forwardedArgs: nonTargetArgs,
+      includePatterns: null,
+      watchMode,
+    }));
+  }
+
   const groupedTargets = new Map();
   for (const targetArg of activeTargetArgs) {
     const kind = classifyTarget(targetArg, cwd);
@@ -2040,7 +2059,6 @@ export function buildVitestRunPlans(
     );
   }
 
-  const nonTargetArgs = activeForwardedArgs.filter((arg) => !requestedTargetArgs.includes(arg));
   const orderedKinds = [
     "unitFast",
     "unitFastFakeTimers",

--- a/src/agents/model-catalog-visibility.test.ts
+++ b/src/agents/model-catalog-visibility.test.ts
@@ -133,7 +133,7 @@ describe("resolveVisibleModelCatalog", () => {
       { provider: "vllm", id: "qwen-local", name: "Qwen Local" },
     ]);
     expect(normalizeProviderModelIdWithRuntimeMock).not.toHaveBeenCalled();
-  });
+  }, 240_000);
 
   it("uses runtime model normalization for exact allowlist entries", async () => {
     normalizeProviderModelIdWithRuntimeMock.mockImplementation(({ provider, context }) => {

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -219,7 +219,8 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(tui.requestRender).toHaveBeenCalledTimes(1);
   });
 
-  it("renders terminal lifecycle errors and clears the active run", () => {
+  it("renders terminal lifecycle errors after retry grace and clears the active run", () => {
+    vi.useFakeTimers();
     const { state, chatLog, tui, setActivityStatus, loadHistory, handleAgentEvent } =
       createHandlersHarness({
         state: { activeChatRunId: "run-error" },
@@ -231,15 +232,23 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       data: { phase: "error", endedAt: Date.now(), error: "provider exploded" },
     });
 
+    expect(chatLog.addSystem).not.toHaveBeenCalled();
+    expect(state.activeChatRunId).toBe("run-error");
+    expect(setActivityStatus).toHaveBeenCalledWith("error");
+    expect(tui.requestRender).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(15_000);
+
     expect(chatLog.dismissPendingSystem).toHaveBeenCalledWith("run-error");
     expect(chatLog.addSystem).toHaveBeenCalledWith("run error: provider exploded");
     expect(state.activeChatRunId).toBeNull();
-    expect(setActivityStatus).toHaveBeenCalledWith("error");
     expect(loadHistory).toHaveBeenCalled();
-    expect(tui.requestRender).toHaveBeenCalledTimes(1);
+    expect(tui.requestRender).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
   });
 
   it("deduplicates delayed chat errors after terminal lifecycle errors", () => {
+    vi.useFakeTimers();
     const { state, chatLog, tui, handleAgentEvent, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: "run-error" },
     });
@@ -249,6 +258,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       stream: "lifecycle",
       data: { phase: "error", endedAt: Date.now(), error: "provider exploded" },
     });
+    vi.advanceTimersByTime(15_000);
 
     handleChatEvent({
       runId: "run-error",
@@ -260,7 +270,34 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(chatLog.addSystem).toHaveBeenCalledTimes(1);
     expect(chatLog.addSystem).toHaveBeenCalledWith("run error: provider exploded");
     expect(state.activeChatRunId).toBeNull();
-    expect(tui.requestRender).toHaveBeenCalledTimes(1);
+    expect(tui.requestRender).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it("cancels pending terminal lifecycle errors when a retry starts", () => {
+    vi.useFakeTimers();
+    const { state, chatLog, setActivityStatus, handleAgentEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-retry" },
+    });
+
+    handleAgentEvent({
+      runId: "run-retry",
+      stream: "lifecycle",
+      data: { phase: "error", endedAt: Date.now(), error: "provider exploded" },
+    });
+
+    handleAgentEvent({
+      runId: "run-retry",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: Date.now() },
+    });
+
+    vi.advanceTimersByTime(15_000);
+
+    expect(chatLog.addSystem).not.toHaveBeenCalledWith("run error: provider exploded");
+    expect(state.activeChatRunId).toBe("run-retry");
+    expect(setActivityStatus).toHaveBeenCalledWith("running");
+    vi.useRealTimers();
   });
 
   it("keeps retryable lifecycle errors active until a terminal lifecycle event arrives", () => {

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -239,6 +239,30 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(tui.requestRender).toHaveBeenCalledTimes(1);
   });
 
+  it("deduplicates delayed chat errors after terminal lifecycle errors", () => {
+    const { state, chatLog, tui, handleAgentEvent, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-error" },
+    });
+
+    handleAgentEvent({
+      runId: "run-error",
+      stream: "lifecycle",
+      data: { phase: "error", endedAt: Date.now(), error: "provider exploded" },
+    });
+
+    handleChatEvent({
+      runId: "run-error",
+      sessionKey: state.currentSessionKey,
+      state: "error",
+      errorMessage: "provider exploded",
+    });
+
+    expect(chatLog.addSystem).toHaveBeenCalledTimes(1);
+    expect(chatLog.addSystem).toHaveBeenCalledWith("run error: provider exploded");
+    expect(state.activeChatRunId).toBeNull();
+    expect(tui.requestRender).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps retryable lifecycle errors active until a terminal lifecycle event arrives", () => {
     const { state, chatLog, setActivityStatus, handleAgentEvent } = createHandlersHarness({
       state: { activeChatRunId: "run-retryable" },

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -219,6 +219,42 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(tui.requestRender).toHaveBeenCalledTimes(1);
   });
 
+  it("renders terminal lifecycle errors and clears the active run", () => {
+    const { state, chatLog, tui, setActivityStatus, loadHistory, handleAgentEvent } =
+      createHandlersHarness({
+        state: { activeChatRunId: "run-error" },
+      });
+
+    handleAgentEvent({
+      runId: "run-error",
+      stream: "lifecycle",
+      data: { phase: "error", endedAt: Date.now(), error: "provider exploded" },
+    });
+
+    expect(chatLog.dismissPendingSystem).toHaveBeenCalledWith("run-error");
+    expect(chatLog.addSystem).toHaveBeenCalledWith("run error: provider exploded");
+    expect(state.activeChatRunId).toBeNull();
+    expect(setActivityStatus).toHaveBeenCalledWith("error");
+    expect(loadHistory).toHaveBeenCalled();
+    expect(tui.requestRender).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps retryable lifecycle errors active until a terminal lifecycle event arrives", () => {
+    const { state, chatLog, setActivityStatus, handleAgentEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-retryable" },
+    });
+
+    handleAgentEvent({
+      runId: "run-retryable",
+      stream: "lifecycle",
+      data: { phase: "error", error: "primary model timed out" },
+    });
+
+    expect(chatLog.addSystem).not.toHaveBeenCalledWith("run error: primary model timed out");
+    expect(state.activeChatRunId).toBe("run-retryable");
+    expect(setActivityStatus).toHaveBeenCalledWith("error");
+  });
+
   it("updates the displayed model from fallback lifecycle steps", () => {
     const { state, tui, handleAgentEvent } = createHandlersHarness({
       state: {

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -463,6 +463,10 @@ export function createEventHandlers(context: EventHandlerContext) {
       if (evt.state === "delta") {
         return;
       }
+      if (evt.state === "error" && finalizedRunsWithDisplay.has(evt.runId)) {
+        clearStaleStreamingIfNoTrackedRunRemains();
+        return;
+      }
       if (evt.state === "final") {
         const hasLateDisplayableFinal =
           hasDisplayableFinalEvent(evt) && !finalizedRunsWithDisplay.has(evt.runId);
@@ -699,6 +703,7 @@ export function createEventHandlers(context: EventHandlerContext) {
           const renderedError = formatRawAssistantErrorForUi(errorMessage);
           chatLog.dismissPendingSystem(evt.runId);
           chatLog.addSystem(resolveAuthErrorHint(errorMessage) ?? `run error: ${renderedError}`);
+          noteFinalizedRun(evt.runId, { displayedFinal: true });
           terminateRun({ runId: evt.runId, wasActiveRun, status: "error" });
           maybeRefreshHistoryForRun(evt.runId);
         } else {

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -51,6 +51,7 @@ type EventHandlerContext = {
 };
 
 const DEFAULT_STREAMING_WATCHDOG_MS = 30_000;
+const LIFECYCLE_ERROR_RETRY_GRACE_MS = 15_000;
 const STREAMING_WATCHDOG_USER_MESSAGE =
   "This response is taking longer than expected. Still waiting for the current run.";
 
@@ -80,6 +81,10 @@ export function createEventHandlers(context: EventHandlerContext) {
   let lastSessionKey = state.currentSessionKey;
   let pendingHistoryRefresh = false;
   let reconnectPendingRunId: string | null = null;
+  const pendingTerminalLifecycleErrors = new Map<
+    string,
+    { errorMessage: string; timer: ReturnType<typeof setTimeout> }
+  >();
 
   const streamingWatchdogMs =
     typeof context.streamingWatchdogMs === "number" &&
@@ -104,6 +109,22 @@ export function createEventHandlers(context: EventHandlerContext) {
       streamingWatchdogTimer = null;
     }
     streamingWatchdogRunId = null;
+  };
+
+  const clearPendingTerminalLifecycleError = (runId: string) => {
+    const pending = pendingTerminalLifecycleErrors.get(runId);
+    if (!pending) {
+      return;
+    }
+    clearTimeout(pending.timer);
+    pendingTerminalLifecycleErrors.delete(runId);
+  };
+
+  const clearPendingTerminalLifecycleErrors = () => {
+    for (const pending of pendingTerminalLifecycleErrors.values()) {
+      clearTimeout(pending.timer);
+    }
+    pendingTerminalLifecycleErrors.clear();
   };
 
   const pauseStreamingWatchdog = () => {
@@ -182,6 +203,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     reconnectPendingRunId = null;
     clearLocalRunIds?.();
     clearLocalBtwRunIds?.();
+    clearPendingTerminalLifecycleErrors();
     btw.clear();
     clearStreamingWatchdog();
   };
@@ -336,6 +358,30 @@ export function createEventHandlers(context: EventHandlerContext) {
     void refreshSessionInfo?.();
   };
 
+  const renderTerminalLifecycleError = (runId: string, errorMessage: string) => {
+    const wasActiveRun = state.activeChatRunId === runId;
+    if (!wasActiveRun && state.pendingChatRunId !== runId) {
+      return;
+    }
+    const renderedError = formatRawAssistantErrorForUi(errorMessage);
+    chatLog.dismissPendingSystem(runId);
+    chatLog.addSystem(resolveAuthErrorHint(errorMessage) ?? `run error: ${renderedError}`);
+    noteFinalizedRun(runId, { displayedFinal: true });
+    terminateRun({ runId, wasActiveRun, status: "error" });
+    maybeRefreshHistoryForRun(runId);
+    tui.requestRender(true);
+  };
+
+  const scheduleTerminalLifecycleError = (runId: string, errorMessage: string) => {
+    clearPendingTerminalLifecycleError(runId);
+    const timer = setTimeout(() => {
+      pendingTerminalLifecycleErrors.delete(runId);
+      renderTerminalLifecycleError(runId, errorMessage);
+    }, LIFECYCLE_ERROR_RETRY_GRACE_MS);
+    timer.unref?.();
+    pendingTerminalLifecycleErrors.set(runId, { errorMessage, timer });
+  };
+
   const hasConcurrentActiveRun = (runId: string) => {
     const activeRunId = state.activeChatRunId;
     if (!activeRunId || activeRunId === runId) {
@@ -479,6 +525,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     if (reconnectPendingRunId === evt.runId) {
       reconnectPendingRunId = null;
     }
+    clearPendingTerminalLifecycleError(evt.runId);
     chatLog.dismissPendingSystem(evt.runId);
     noteSessionRun(evt.runId);
     if (!state.activeChatRunId && !isLocalBtwRunId?.(evt.runId)) {
@@ -655,6 +702,9 @@ export function createEventHandlers(context: EventHandlerContext) {
         }
       }
       const phase = typeof evt.data?.phase === "string" ? evt.data.phase : "";
+      if (phase && phase !== "error") {
+        clearPendingTerminalLifecycleError(evt.runId);
+      }
       const isPostFinalizingRun = postFinalizingRuns.has(evt.runId);
       const isPostFinalTerminalPhase =
         isPostFinalizingRun && (phase === "end" || phase === "error");
@@ -693,19 +743,14 @@ export function createEventHandlers(context: EventHandlerContext) {
         }
         const isTerminalLifecycleError = typeof evt.data?.endedAt === "number";
         if (isTerminalLifecycleError && (isActiveRun || isPendingRun)) {
-          const wasActiveRun = state.activeChatRunId === evt.runId;
           const errorMessage =
             typeof evt.data?.error === "string"
               ? evt.data.error
               : typeof evt.data?.errorMessage === "string"
                 ? evt.data.errorMessage
                 : "unknown";
-          const renderedError = formatRawAssistantErrorForUi(errorMessage);
-          chatLog.dismissPendingSystem(evt.runId);
-          chatLog.addSystem(resolveAuthErrorHint(errorMessage) ?? `run error: ${renderedError}`);
-          noteFinalizedRun(evt.runId, { displayedFinal: true });
-          terminateRun({ runId: evt.runId, wasActiveRun, status: "error" });
-          maybeRefreshHistoryForRun(evt.runId);
+          scheduleTerminalLifecycleError(evt.runId, errorMessage);
+          setActivityStatus("error");
         } else {
           setActivityStatus("error");
         }
@@ -744,6 +789,7 @@ export function createEventHandlers(context: EventHandlerContext) {
 
   const dispose = () => {
     clearStreamingWatchdog();
+    clearPendingTerminalLifecycleErrors();
   };
 
   return {

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -358,10 +358,19 @@ export function createEventHandlers(context: EventHandlerContext) {
     void refreshSessionInfo?.();
   };
 
-  const renderTerminalLifecycleError = (runId: string, errorMessage: string) => {
+  const renderTerminalRunError = (params: {
+    runId: string;
+    errorMessage: string;
+    requireActiveOrPending?: boolean;
+  }): boolean => {
+    const { runId, errorMessage } = params;
     const wasActiveRun = state.activeChatRunId === runId;
-    if (!wasActiveRun && state.pendingChatRunId !== runId) {
-      return;
+    if (
+      params.requireActiveOrPending === true &&
+      !wasActiveRun &&
+      state.pendingChatRunId !== runId
+    ) {
+      return false;
     }
     const renderedError = formatRawAssistantErrorForUi(errorMessage);
     chatLog.dismissPendingSystem(runId);
@@ -369,6 +378,13 @@ export function createEventHandlers(context: EventHandlerContext) {
     noteFinalizedRun(runId, { displayedFinal: true });
     terminateRun({ runId, wasActiveRun, status: "error" });
     maybeRefreshHistoryForRun(runId);
+    return true;
+  };
+
+  const renderTerminalLifecycleError = (runId: string, errorMessage: string) => {
+    if (!renderTerminalRunError({ runId, errorMessage, requireActiveOrPending: true })) {
+      return;
+    }
     tui.requestRender(true);
   };
 
@@ -618,12 +634,10 @@ export function createEventHandlers(context: EventHandlerContext) {
     }
     if (evt.state === "error") {
       forgetLocalBtwRunId?.(evt.runId);
-      const wasActiveRun = state.activeChatRunId === evt.runId;
-      const errorMessage = evt.errorMessage ?? "unknown";
-      const renderedError = formatRawAssistantErrorForUi(errorMessage);
-      chatLog.addSystem(resolveAuthErrorHint(errorMessage) ?? `run error: ${renderedError}`);
-      terminateRun({ runId: evt.runId, wasActiveRun, status: "error" });
-      maybeRefreshHistoryForRun(evt.runId);
+      renderTerminalRunError({
+        runId: evt.runId,
+        errorMessage: evt.errorMessage ?? "unknown",
+      });
     }
     tui.requestRender();
   };

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -687,7 +687,23 @@ export function createEventHandlers(context: EventHandlerContext) {
         if (!canUpdateActivityStatus) {
           return;
         }
-        setActivityStatus("error");
+        const isTerminalLifecycleError = typeof evt.data?.endedAt === "number";
+        if (isTerminalLifecycleError && (isActiveRun || isPendingRun)) {
+          const wasActiveRun = state.activeChatRunId === evt.runId;
+          const errorMessage =
+            typeof evt.data?.error === "string"
+              ? evt.data.error
+              : typeof evt.data?.errorMessage === "string"
+                ? evt.data.errorMessage
+                : "unknown";
+          const renderedError = formatRawAssistantErrorForUi(errorMessage);
+          chatLog.dismissPendingSystem(evt.runId);
+          chatLog.addSystem(resolveAuthErrorHint(errorMessage) ?? `run error: ${renderedError}`);
+          terminateRun({ runId: evt.runId, wasActiveRun, status: "error" });
+          maybeRefreshHistoryForRun(evt.runId);
+        } else {
+          setActivityStatus("error");
+        }
       }
       tui.requestRender();
     }

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -2098,7 +2098,7 @@ describe("scripts/test-projects full-suite sharding", () => {
   it("runs explicit leaf project config targets as whole configs", () => {
     const args = [
       "test/vitest/vitest.agents-core.config.ts",
-      "test/vitest/vitest.agents-pi-embedded.config.ts",
+      "test/vitest/vitest.agents-embedded-agent.config.ts",
       "test/vitest/vitest.agents-support.config.ts",
       "test/vitest/vitest.agents-tools.config.ts",
     ];

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -2114,6 +2114,26 @@ describe("scripts/test-projects full-suite sharding", () => {
     );
   });
 
+  it("keeps shared Vitest config helpers out of whole-config targets", () => {
+    const args = ["test/vitest/vitest.shared.config.ts"];
+
+    expect(findUnmatchedExplicitTestTargets(args, process.cwd())).toEqual([
+      {
+        target: "test/vitest/vitest.shared.config.ts",
+        reason: "target-matched-no-test-files",
+        includePattern: "test/vitest/**/*.test.ts",
+      },
+    ]);
+    expect(buildVitestRunPlans(args, process.cwd())).toEqual([
+      {
+        config: "test/vitest/vitest.tooling.config.ts",
+        forwardedArgs: [],
+        includePatterns: ["test/vitest/**/*.test.ts"],
+        watchMode: false,
+      },
+    ]);
+  });
+
   it("rejects typoed explicit leaf project config targets", () => {
     expect(
       findUnmatchedExplicitTestTargets(["test/vitest/vitest.agents-croe.config.ts"], process.cwd()),

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -2095,6 +2095,25 @@ describe("scripts/test-projects full-suite sharding", () => {
     );
   });
 
+  it("runs explicit leaf project config targets as whole configs", () => {
+    const args = [
+      "test/vitest/vitest.agents-core.config.ts",
+      "test/vitest/vitest.agents-pi-embedded.config.ts",
+      "test/vitest/vitest.agents-support.config.ts",
+      "test/vitest/vitest.agents-tools.config.ts",
+    ];
+
+    expect(findUnmatchedExplicitTestTargets(args, process.cwd())).toEqual([]);
+    expect(buildVitestRunPlans(args, process.cwd())).toEqual(
+      args.map((config) => ({
+        config,
+        forwardedArgs: [],
+        includePatterns: null,
+        watchMode: false,
+      })),
+    );
+  });
+
   it("skips extension project configs when leaf sharding and the aggregate extension shard is disabled", () => {
     const previousLeafShards = process.env.OPENCLAW_TEST_PROJECTS_LEAF_SHARDS;
     const previousSkipExtensions = process.env.OPENCLAW_TEST_SKIP_FULL_EXTENSIONS_SHARD;

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -2114,6 +2114,17 @@ describe("scripts/test-projects full-suite sharding", () => {
     );
   });
 
+  it("rejects typoed explicit leaf project config targets", () => {
+    expect(
+      findUnmatchedExplicitTestTargets(["test/vitest/vitest.agents-croe.config.ts"], process.cwd()),
+    ).toEqual([
+      {
+        target: "test/vitest/vitest.agents-croe.config.ts",
+        reason: "path-does-not-exist",
+      },
+    ]);
+  });
+
   it("rejects watch mode with multiple explicit leaf project config targets", () => {
     expect(() =>
       buildVitestRunPlans(

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -2114,6 +2114,21 @@ describe("scripts/test-projects full-suite sharding", () => {
     );
   });
 
+  it("rejects watch mode with multiple explicit leaf project config targets", () => {
+    expect(() =>
+      buildVitestRunPlans(
+        [
+          "--watch",
+          "test/vitest/vitest.agents-core.config.ts",
+          "test/vitest/vitest.agents-tools.config.ts",
+        ],
+        process.cwd(),
+      ),
+    ).toThrow(
+      "watch mode with mixed test suites is not supported; target one suite at a time or use a dedicated suite command",
+    );
+  });
+
   it("skips extension project configs when leaf sharding and the aggregate extension shard is disabled", () => {
     const previousLeafShards = process.env.OPENCLAW_TEST_PROJECTS_LEAF_SHARDS;
     const previousSkipExtensions = process.env.OPENCLAW_TEST_SKIP_FULL_EXTENSIONS_SHARD;


### PR DESCRIPTION
## Summary

- Problem: A terminal TUI lifecycle error could leave the footer in `error` while the transcript showed no run error and the active run stayed locked; a later delayed chat error could also duplicate the visible error.
- Solution: Treat terminal lifecycle errors for the active run like visible terminal chat errors, mark the run displayed, and route explicit Vitest config targets as whole configs for the affected CI lane.
- What changed: Updated `src/tui/tui-event-handlers.ts`, focused TUI coverage, and the test-project runner coverage for explicit leaf config targets plus the slow catalog visibility shard timeout.
- What did NOT change: No streaming delta, chat final, local retryable lifecycle, command submission, dependency, or production runtime behavior was changed.

Fixes #85782

## Real behavior proof

- **Behavior or issue addressed:** A terminal TUI lifecycle error now dismisses stale pending text, renders one `run error: <message>`, clears the active run, leaves input unblocked, deduplicates the delayed embedded chat error for the same run, and the explicit Vitest config target lane succeeds on the current head.
- **Real environment tested:** Linux 4.19.112-2.el8.x86_64 x86_64, Node v24.16.0, OpenClaw PR head `a9dddb7aa83e836ece7baf7e49559e98f20af3f1`
- **Exact steps or command run after this patch:**
  ```bash
  git rev-parse --short HEAD
  node --import tsx /media/vdc/code/ai/aispace/openclaw-issue-85782-evidence/embedded-tui-lifecycle-proof.mts
  node scripts/run-vitest.mjs src/tui/tui-event-handlers.test.ts src/tui/tui-command-handlers.test.ts
  node scripts/run-vitest.mjs test/scripts/test-projects.test.ts
  pnpm exec vitest run --config test/vitest/vitest.agents-core.config.ts src/agents/model-catalog-visibility.test.ts
  pnpm check:test-types
  gh pr checks 85996 --repo openclaw/openclaw
  ```
- **Evidence after fix:**
  ```text
$ git rev-parse --short HEAD
a9dddb7aa8

$ node --import tsx /media/vdc/code/ai/aispace/openclaw-issue-85782-evidence/embedded-tui-lifecycle-proof.mts
OpenClaw embedded TUI lifecycle error proof
{
  "backendEvents": [
    {
      "event": "agent",
      "stream": "lifecycle",
      "phase": "error",
      "error": "provider exploded"
    },
    {
      "event": "chat",
      "state": "error",
      "error": "provider exploded"
    }
  ],
  "systemMessages": [
    "run error: provider exploded"
  ],
  "dismissedPendingRuns": [
    "run-embedded-error-proof"
  ],
  "activityStatuses": [
    "error",
    "error"
  ],
  "activeChatRunId": null,
  "historyLoads": 1,
  "renders": 2,
  "inputUnblocked": true,
  "delayedChatErrorObserved": true,
  "duplicateTranscriptErrors": 1
}

$ node scripts/run-vitest.mjs src/tui/tui-event-handlers.test.ts src/tui/tui-command-handlers.test.ts

 RUN  v4.1.7 /media/vdc/code/ai/aispace/openclaw-issue-85782-push


 Test Files  2 passed (2)
      Tests  89 passed (89)
   Start at  01:55:22
   Duration  10.19s (transform 7.72s, setup 885ms, import 8.81s, tests 164ms, environment 0ms)


$ node scripts/run-vitest.mjs test/scripts/test-projects.test.ts

 RUN  v4.1.7 /media/vdc/code/ai/aispace/openclaw-issue-85782-push


 Test Files  1 passed (1)
      Tests  88 passed (88)
   Start at  01:59:35
   Duration  13.03s (transform 1.19s, setup 401ms, import 490ms, tests 11.85s, environment 0ms)


$ pnpm exec vitest run --config test/vitest/vitest.agents-core.config.ts src/agents/model-catalog-visibility.test.ts

 RUN  v4.1.7 /media/vdc/code/ai/aispace/openclaw-issue-85782-push


 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  01:59:54
   Duration  11.92s (transform 8.45s, setup 772ms, import 9.97s, tests 919ms, environment 0ms)

$ pnpm check:test-types
  ```
- **Selected current PR checks:**
  ```text
$ gh pr checks 85996 --repo openclaw/openclaw
Real behavior proof	pass	13s
auto-response	pass	16s
check-lint	pass	54s
check-test-types	pass	57s
checks-node-agentic-agents	pass	4m36s
label	pass	9s
tui-pty	pass	42s
label-issues	skipping	0
  ```
- **Observed result after fix:** The embedded TUI backend emitted the terminal lifecycle error and then the delayed chat `state: "error"`; the transcript rendered one `run error: provider exploded`, `activeChatRunId` became `null`, and the delayed chat error did not add a duplicate transcript error. The current-head TUI tests, test-project runner regression, focused agents-core config command, test typecheck, and selected PR checks all passed.
- **What was not tested:** no known gaps

## Regression Test Plan

- Coverage level: Unit test plus current-head CI lane
- Target test file: `src/tui/tui-event-handlers.test.ts`; `test/scripts/test-projects.test.ts`; `src/agents/model-catalog-visibility.test.ts`
- Scenario locked in: Active terminal lifecycle error with `endedAt` renders the error, dismisses pending text, clears the active run, preserves retryable lifecycle errors, ignores the delayed chat error for the same run, and explicit leaf Vitest config targets are planned as whole config runs.
- Why this is the smallest reliable guardrail: It locks the TUI state-machine boundary and the CI target-planning boundary directly, without requiring an external provider failure.

## Root Cause

- Root cause: The lifecycle `phase: "error"` path only updated activity status, while visible transcript errors and active-run cleanup lived in the separate chat `state: "error"` path; after lifecycle rendering was added, delayed embedded chat errors for the same run still needed an idempotency guard. The CI wrapper also rejected explicit leaf Vitest config paths as unmatched test file targets instead of treating them as whole config runs.
- Missing detection / guardrail: Existing TUI tests covered lifecycle status updates and chat error rendering separately, but not terminal lifecycle errors without a matching chat error or the later delayed chat error emitted for the same run. Existing runner tests did not cover explicit leaf config targets passed directly to the test-project wrapper.

