### PR TITLE
test(cli): reset banner emission guard

### DIFF
--- a/src/cli/banner.test.ts
+++ b/src/cli/banner.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { formatCliBannerLine } from "./banner.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { emitCliBanner, formatCliBannerLine, hasEmittedCliBanner, __testing } from "./banner.js";
 
 const readCliBannerTaglineModeMock = vi.hoisted(() => vi.fn());
 
@@ -12,6 +12,11 @@ vi.mock("./banner-config-lite.js", () => ({
 beforeEach(() => {
   readCliBannerTaglineModeMock.mockReset();
   readCliBannerTaglineModeMock.mockReturnValue(undefined);
+  __testing.resetBannerEmittedForTests();
+});
+
+afterEach(() => {
+  __testing.resetBannerEmittedForTests();
 });
 
 describe("formatCliBannerLine", () => {
@@ -70,5 +75,60 @@ describe("formatCliBannerLine", () => {
     });
 
     expect(line).toBe("OpenClaw 2026.3.7 (abc1234)");
+  });
+});
+
+describe("emitCliBanner", () => {
+  it("can reset the one-shot emission guard for isolated tests", () => {
+    const stdoutTty = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+    const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    try {
+      emitCliBanner("2026.3.7", {
+        argv: ["node", "openclaw"],
+        commit: "abc1234",
+        env: { LANG: "en_US.UTF-8" },
+        isTty: true,
+        platform: "darwin",
+        richTty: false,
+        mode: "off",
+      });
+
+      expect(hasEmittedCliBanner()).toBe(true);
+      expect(write).toHaveBeenCalledTimes(1);
+
+      emitCliBanner("2026.3.7", {
+        argv: ["node", "openclaw"],
+        commit: "abc1234",
+        mode: "off",
+      });
+
+      expect(write).toHaveBeenCalledTimes(1);
+
+      __testing.resetBannerEmittedForTests();
+
+      expect(hasEmittedCliBanner()).toBe(false);
+
+      emitCliBanner("2026.3.7", {
+        argv: ["node", "openclaw"],
+        commit: "abc1234",
+        env: { LANG: "en_US.UTF-8" },
+        isTty: true,
+        platform: "darwin",
+        richTty: false,
+        mode: "off",
+      });
+
+      expect(hasEmittedCliBanner()).toBe(true);
+      expect(write).toHaveBeenCalledTimes(2);
+    } finally {
+      write.mockRestore();
+      if (stdoutTty) {
+        Object.defineProperty(process.stdout, "isTTY", stdoutTty);
+      } else {
+        Reflect.deleteProperty(process.stdout, "isTTY");
+      }
+    }
   });
 });

--- a/src/cli/banner.ts
+++ b/src/cli/banner.ts
@@ -191,3 +191,10 @@ export function emitCliBanner(version: string, options: BannerOptions = {}) {
 export function hasEmittedCliBanner(): boolean {
   return bannerEmitted;
 }
+
+export const testing = {
+  resetBannerEmittedForTests(): void {
+    bannerEmitted = false;
+  },
+};
+export { testing as __testing };


### PR DESCRIPTION
## Summary
- add a test-only reset hook for the CLI banner one-shot emission guard
- cover banner emission isolation so future tests can reset the module-level guard instead of depending on execution order

## Tests
- `node scripts/run-vitest.mjs src/cli/banner.test.ts --runInBand`
- `pnpm lint src/cli/banner.ts src/cli/banner.test.ts`
- `pnpm format:check src/cli/banner.ts src/cli/banner.test.ts`
- `pnpm openclaw --version`

## Real behavior proof
Behavior addressed: CLI banner tests now have a supported test-only reset for the process-local one-shot banner guard, while normal CLI version output remains unchanged.
Real environment tested: macOS local checkout, Node/pnpm repo runtime in the OpenClaw repository.
Exact steps or command run after this patch: `pnpm openclaw --version`
Evidence after fix: Terminal output from the real OpenClaw CLI command:
```text
$ pnpm openclaw --version
$ node scripts/run-node.mjs --version
[openclaw] Building TypeScript (dist is stale: git_head_changed - git head changed).
[openclaw] Building bundled plugin assets.
[canvas] build: node scripts/bundle-a2ui.mjs
A2UI bundle up to date; skipping.
runtime-postbuild: plugin SDK root alias completed in 3ms
runtime-postbuild: bundled plugin metadata completed in 290ms
runtime-postbuild: official channel catalog completed in 6ms
runtime-postbuild: bundled plugin runtime overlay completed in 290ms
runtime-postbuild: static extension assets completed in 94ms
runtime-postbuild: stable root runtime imports completed in 246ms
runtime-postbuild: stable root runtime aliases completed in 50ms
runtime-postbuild: legacy root runtime compat aliases completed in 11ms
runtime-postbuild: legacy CLI exit compat chunks completed in 0ms
OpenClaw 2026.5.24 (d6ca307)
```
Observed result after fix: The real CLI command completed successfully and printed the expected OpenClaw version line; the test-only reset export does not change the user-facing version command behavior.
What was not tested: Interactive TTY banner rendering beyond the targeted unit coverage.
