### PR TITLE
fix(discord): pass defaultKind channel to parseAndResolveRecipient in send paths

### DIFF
--- a/extensions/discord/src/send.components.ts
+++ b/extensions/discord/src/send.components.ts
@@ -290,7 +290,9 @@ export async function sendDiscordComponentMessage(
   const cfg = requireRuntimeConfig(opts.cfg, "Discord component send");
   const accountInfo = resolveDiscordAccount({ cfg, accountId: opts.accountId });
   const { token, rest, request } = createDiscordClient({ ...opts, cfg });
-  const recipient = await parseAndResolveRecipient(to, cfg, opts.accountId);
+  const recipient = await parseAndResolveRecipient(to, cfg, opts.accountId, {
+    defaultKind: "channel",
+  });
   const { channelId } = await resolveChannelId(rest, recipient, request);
 
   const channelType = await resolveDiscordChannelType(rest, channelId);
@@ -353,7 +355,9 @@ export async function editDiscordComponentMessage(
   const cfg = requireRuntimeConfig(opts.cfg, "Discord component edit");
   const accountInfo = resolveDiscordAccount({ cfg, accountId: opts.accountId });
   const { token, rest, request } = createDiscordClient({ ...opts, cfg });
-  const recipient = await parseAndResolveRecipient(to, cfg, opts.accountId);
+  const recipient = await parseAndResolveRecipient(to, cfg, opts.accountId, {
+    defaultKind: "channel",
+  });
   const { channelId } = await resolveChannelId(rest, recipient, request);
   const { body, buildResult } = await buildDiscordComponentPayload({
     spec,

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -140,7 +140,9 @@ async function resolveDiscordSendTarget(
 ): Promise<{ rest: RequestClient; request: DiscordClientRequest; channelId: string }> {
   const cfg = requireRuntimeConfig(opts.cfg, "Discord send target resolution");
   const { rest, request } = createDiscordClient({ ...opts, cfg });
-  const recipient = await parseAndResolveRecipient(to, cfg, opts.accountId);
+  const recipient = await parseAndResolveRecipient(to, cfg, opts.accountId, {
+    defaultKind: "channel",
+  });
   const { channelId } = await resolveChannelId(rest, recipient, request);
   return { rest, request, channelId };
 }
@@ -181,7 +183,9 @@ export async function sendMessageDiscord(
     mentionAliases: accountInfo.config.mentionAliases,
   });
   const { token, rest, request } = createDiscordClient({ ...opts, cfg });
-  const recipient = await parseAndResolveRecipient(to, cfg, opts.accountId);
+  const recipient = await parseAndResolveRecipient(to, cfg, opts.accountId, {
+    defaultKind: "channel",
+  });
   const { channelId } = await resolveChannelId(rest, recipient, request);
 
   // Forum/Media channels reject POST /messages; auto-create a thread post instead.

--- a/extensions/discord/src/send.voice.ts
+++ b/extensions/discord/src/send.voice.ts
@@ -95,7 +95,9 @@ export async function sendVoiceMessageDiscord(
     token = client.token;
     rest = client.rest;
     const request = client.request;
-    const recipient = await parseAndResolveRecipient(to, cfg, opts.accountId);
+    const recipient = await parseAndResolveRecipient(to, cfg, opts.accountId, {
+      defaultKind: "channel",
+    });
     channelId = (await resolveChannelId(rest, recipient, request)).channelId;
 
     const ogg = await ensureOggOpus(localInputPath);

--- a/extensions/discord/src/target-parsing.test.ts
+++ b/extensions/discord/src/target-parsing.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { parseDiscordTarget } from "./target-parsing.js";
+
+describe("parseDiscordTarget", () => {
+  it("accepts bare numeric ID as channel when defaultKind is channel", () => {
+    const target = parseDiscordTarget("123456789012345678", { defaultKind: "channel" });
+    expect(target).toBeDefined();
+    expect(target!.kind).toBe("channel");
+    expect(target!.id).toBe("123456789012345678");
+  });
+
+  it("accepts bare numeric ID as user when defaultKind is user", () => {
+    const target = parseDiscordTarget("123456789012345678", { defaultKind: "user" });
+    expect(target).toBeDefined();
+    expect(target!.kind).toBe("user");
+    expect(target!.id).toBe("123456789012345678");
+  });
+
+  it("throws ambiguous error for bare numeric ID without defaultKind", () => {
+    expect(() => parseDiscordTarget("123456789012345678")).toThrow(
+      'Ambiguous Discord recipient "123456789012345678"',
+    );
+  });
+
+  it("accepts channel: prefixed ID without defaultKind", () => {
+    const target = parseDiscordTarget("channel:123456789012345678");
+    expect(target).toBeDefined();
+    expect(target!.kind).toBe("channel");
+    expect(target!.id).toBe("123456789012345678");
+  });
+
+  it("accepts user: prefixed ID without defaultKind", () => {
+    const target = parseDiscordTarget("user:123456789012345678");
+    expect(target).toBeDefined();
+    expect(target!.kind).toBe("user");
+    expect(target!.id).toBe("123456789012345678");
+  });
+
+  it("accepts <@id> mention as user", () => {
+    const target = parseDiscordTarget("<@123456789012345678>");
+    expect(target).toBeDefined();
+    expect(target!.kind).toBe("user");
+    expect(target!.id).toBe("123456789012345678");
+  });
+
+  it("accepts non-numeric bare ID as channel", () => {
+    const target = parseDiscordTarget("#general");
+    expect(target).toBeDefined();
+    expect(target!.kind).toBe("channel");
+    expect(target!.id).toBe("#general");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes "Ambiguous Discord recipient" error when using bare numeric channel IDs in Discord message-tool send paths.

## Problem

When the LLM uses a bare numeric channel ID (e.g., `123456789012345678`) as the `to` parameter, `parseAndResolveRecipient` throws:

```
Ambiguous Discord recipient "123456789012345678". For DMs use "user:<id>" or "<@<id>>"; for channels use "channel:<id>".
```

This is a regression from 2026.5.22 — channel sessions fail to reply messages.

## Root Cause

Several send path call sites omitted `{ defaultKind: "channel" }` when calling `parseAndResolveRecipient()`, while other paths (`send.shared.ts`, `channel.ts`, etc.) correctly passed it.

## Fix

Added `{ defaultKind: "channel" }` to all `parseAndResolveRecipient()` calls that previously omitted it:

| File | Call Sites Fixed |
|------|-----------------|
| `send.outbound.ts` | 2 |
| `send.voice.ts` | 1 |
| `send.components.ts` | 2 |
| `send.shared.ts` | ✅ Already correct |

| File | Changes |
|------|---------|
| `extensions/discord/src/send.outbound.ts` | +4 |
| `extensions/discord/src/send.voice.ts` | +2 |
| `extensions/discord/src/send.components.ts` | +4 |
| `extensions/discord/src/target-parsing.test.ts` | +51 | 7 unit tests |

Fixes: #86001