### PR TITLE
fix(feishu): render native presentation buttons

### DIFF
--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -395,7 +395,7 @@ describe("feishuPlugin actions", () => {
     expect(details.chatId).toBe("oc_group_1");
   });
 
-  it("renders presentation button labels into the card fallback", async () => {
+  it("renders presentation buttons as native Feishu card actions", async () => {
     sendCardFeishuMock.mockResolvedValueOnce({ messageId: "om_card", chatId: "oc_group_1" });
 
     await feishuPlugin.actions?.handleAction?.({
@@ -423,8 +423,54 @@ describe("feishuPlugin actions", () => {
     const card = requireRecord(sendCardArgs.card, "card");
     expect(requireRecord(card.body, "card body").elements).toEqual([
       {
+        tag: "action",
+        actions: [
+          {
+            tag: "button",
+            text: { tag: "plain_text", content: "Run help" },
+            type: "default",
+            value: {
+              oc: "ocf1",
+              k: "quick",
+              a: "feishu.payload.button",
+              q: "feishu.quick_actions.help",
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("does not duplicate title-only presentation cards in the body fallback", async () => {
+    sendCardFeishuMock.mockResolvedValueOnce({ messageId: "om_card", chatId: "oc_group_1" });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        presentation: {
+          title: "Status",
+          blocks: [],
+        },
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    const sendCardArgs = requireRecord(
+      mockCallArg(sendCardFeishuMock, 0, 0, "sendCardFeishu"),
+      "send card args",
+    );
+    const card = requireRecord(sendCardArgs.card, "card");
+    expect(card.header).toEqual({
+      title: { tag: "plain_text", content: "Status" },
+      template: "blue",
+    });
+    expect(requireRecord(card.body, "card body").elements).toEqual([
+      {
         tag: "markdown",
-        content: "- Run help",
+        content: "",
       },
     ]);
   });

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -25,10 +25,7 @@ import {
   createChannelDirectoryAdapter,
   createRuntimeDirectoryLiveAdapter,
 } from "openclaw/plugin-sdk/directory-runtime";
-import {
-  normalizeMessagePresentation,
-  renderMessagePresentationFallbackText,
-} from "openclaw/plugin-sdk/interactive-runtime";
+import { normalizeMessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
 import { createLazyRuntimeNamedExport } from "openclaw/plugin-sdk/lazy-runtime";
 import { createRuntimeOutboundDelegates } from "openclaw/plugin-sdk/outbound-runtime";
 import { createComputedAccountStatusAdapter } from "openclaw/plugin-sdk/status-helpers";
@@ -70,6 +67,7 @@ import {
 import { listFeishuDirectoryGroups, listFeishuDirectoryPeers } from "./directory.static.js";
 import { messageActionTargetAliases } from "./message-action-contract.js";
 import { resolveFeishuGroupToolPolicy } from "./policy.js";
+import { buildFeishuPresentationCard } from "./presentation-card.js";
 import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
 import { collectFeishuSecurityAuditFindings } from "./security-audit.js";
 import { createFeishuSendReceipt } from "./send-result.js";
@@ -182,41 +180,6 @@ const feishuMessageAdapter = defineChannelMessageAdapter({
     },
   },
 });
-
-function buildFeishuPresentationCard(params: {
-  presentation: NonNullable<ReturnType<typeof normalizeMessagePresentation>>;
-  fallbackText?: string;
-}): Record<string, unknown> {
-  const fallbackPresentation: NonNullable<ReturnType<typeof normalizeMessagePresentation>> = {
-    ...(params.presentation.tone ? { tone: params.presentation.tone } : {}),
-    blocks: params.presentation.blocks,
-  };
-  return {
-    schema: "2.0",
-    config: {
-      width_mode: "fill",
-    },
-    ...(params.presentation.title
-      ? {
-          header: {
-            title: { tag: "plain_text", content: params.presentation.title },
-            template: "blue",
-          },
-        }
-      : {}),
-    body: {
-      elements: [
-        {
-          tag: "markdown",
-          content: renderMessagePresentationFallbackText({
-            text: params.fallbackText,
-            presentation: fallbackPresentation,
-          }),
-        },
-      ],
-    },
-  };
-}
 
 async function createFeishuActionClient(account: ResolvedFeishuAccount) {
   const { createFeishuClient } = await import("./client.js");

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -468,6 +468,43 @@ describe("feishuOutbound.sendPayload native cards", () => {
     expectFeishuResult(result, "native_card_msg");
   });
 
+  it("does not duplicate title-only presentation cards in outbound fallbacks", async () => {
+    const presentation: MessagePresentation = {
+      title: "Status",
+      blocks: [],
+    };
+    const payload = { presentation };
+    const rendered = await feishuOutbound.renderPresentation?.({
+      payload,
+      presentation,
+      ctx: {
+        cfg: emptyConfig,
+        to: "chat_1",
+        text: "",
+        accountId: "main",
+        payload,
+      },
+    });
+
+    if (!rendered) {
+      throw new Error("expected Feishu presentation renderer to return a payload");
+    }
+    const renderedChannelData = rendered.channelData as
+      | { feishu?: { card?: Record<string, any> } }
+      | undefined;
+    const renderedCard = renderedChannelData?.feishu?.card;
+    expect(renderedCard?.header).toEqual({
+      title: { tag: "plain_text", content: "Status" },
+      template: "blue",
+    });
+    expect(renderedCard?.body?.elements).toEqual([
+      {
+        tag: "markdown",
+        content: "",
+      },
+    ]);
+  });
+
   it("sends interactive button payloads as native Feishu cards", async () => {
     const result = await feishuOutbound.sendPayload?.({
       cfg: emptyConfig,
@@ -583,6 +620,12 @@ describe("feishuOutbound.sendPayload native cards", () => {
                     actions: [
                       {
                         tag: "button",
+                        text: { tag: "plain_text", content: "Promote" },
+                        type: "success",
+                        url: "https://example.com/promote",
+                      },
+                      {
+                        tag: "button",
                         text: { tag: "plain_text", content: "Bad link" },
                         url: "file:///etc/passwd",
                       },
@@ -608,6 +651,12 @@ describe("feishuOutbound.sendPayload native cards", () => {
       {
         tag: "action",
         actions: [
+          {
+            tag: "button",
+            text: { tag: "plain_text", content: "Promote" },
+            type: "primary",
+            url: "https://example.com/promote",
+          },
           {
             tag: "button",
             text: { tag: "plain_text", content: "Good link" },

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -9,8 +9,6 @@ import {
   normalizeMessagePresentation,
   renderMessagePresentationFallbackText,
   resolveInteractiveTextFallback,
-  type MessagePresentationBlock,
-  type MessagePresentationButton,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import {
   resolvePayloadMediaUrls,
@@ -20,13 +18,13 @@ import {
 import { statRegularFileSync } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveFeishuAccount } from "./accounts.js";
-import { createFeishuCardInteractionEnvelope } from "./card-interaction.js";
 import { createFeishuClient } from "./client.js";
 import { cleanupAmbientCommentTypingReaction } from "./comment-reaction.js";
 import { parseFeishuCommentTarget } from "./comment-target.js";
 import { deliverCommentThreadText } from "./drive.js";
 import { sendMediaFeishu, shouldSuppressFeishuTextForVoiceMedia } from "./media.js";
 import { chunkTextForOutbound, type ChannelOutboundAdapter } from "./outbound-runtime-api.js";
+import { buildFeishuPresentationCardElements } from "./presentation-card.js";
 import {
   resolveFeishuCardTemplate,
   sendCardFeishu,
@@ -86,34 +84,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
-function escapeFeishuCardMarkdownText(text: string): string {
-  return text.replace(/[&<>]/g, (char) => {
-    switch (char) {
-      case "&":
-        return "&amp;";
-      case "<":
-        return "&lt;";
-      case ">":
-        return "&gt;";
-      default:
-        return char;
-    }
-  });
-}
-
-function resolveSafeFeishuButtonUrl(url: string | undefined): string | undefined {
-  const trimmed = url?.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  try {
-    const parsed = new URL(trimmed);
-    return parsed.protocol === "https:" || parsed.protocol === "http:" ? trimmed : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
 function markRenderedFeishuCard(card: Record<string, unknown>): Record<string, unknown> {
   Object.defineProperty(card, RENDERED_FEISHU_CARD, {
     value: true,
@@ -134,15 +104,33 @@ function sanitizeNativeFeishuCardButton(button: unknown): Record<string, unknown
     return undefined;
   }
   const style =
-    button.type === "danger" ? "danger" : button.type === "primary" ? "primary" : undefined;
+    button.type === "danger"
+      ? "danger"
+      : button.type === "primary" || button.type === "success"
+        ? "primary"
+        : undefined;
   const rendered: Record<string, unknown> = {
     tag: "button",
     text: { tag: "plain_text", content: text },
-    type: mapFeishuButtonType(style),
+    type:
+      style === "danger"
+        ? "danger"
+        : style === "primary" || style === "success"
+          ? "primary"
+          : "default",
   };
-  const safeUrl = resolveSafeFeishuButtonUrl(
-    typeof button.url === "string" ? button.url : undefined,
-  );
+  const safeUrl = (() => {
+    const trimmed = typeof button.url === "string" ? button.url.trim() : "";
+    if (!trimmed) {
+      return undefined;
+    }
+    try {
+      const parsed = new URL(trimmed);
+      return parsed.protocol === "https:" || parsed.protocol === "http:" ? trimmed : undefined;
+    } catch {
+      return undefined;
+    }
+  })();
   if (safeUrl) {
     rendered.url = safeUrl;
   }
@@ -160,7 +148,21 @@ function sanitizeNativeFeishuCardElement(element: unknown): Record<string, unkno
     return { tag: "hr" };
   }
   if (element.tag === "markdown" && typeof element.content === "string") {
-    return { tag: "markdown", content: escapeFeishuCardMarkdownText(element.content) };
+    return {
+      tag: "markdown",
+      content: element.content.replace(/[&<>]/g, (char) => {
+        switch (char) {
+          case "&":
+            return "&amp;";
+          case "<":
+            return "&lt;";
+          case ">":
+            return "&gt;";
+          default:
+            return char;
+        }
+      }),
+    };
   }
   if (element.tag === "action" && Array.isArray(element.actions)) {
     const actions = element.actions
@@ -221,79 +223,6 @@ function readNativeFeishuCard(payload: { channelData?: Record<string, unknown> }
   return sanitizeNativeFeishuCard(card);
 }
 
-function mapFeishuButtonType(style: MessagePresentationButton["style"]) {
-  if (style === "primary" || style === "success") {
-    return "primary";
-  }
-  if (style === "danger") {
-    return "danger";
-  }
-  return "default";
-}
-
-function buildFeishuPayloadButton(
-  button: MessagePresentationButton,
-): Record<string, unknown> | undefined {
-  const rendered: Record<string, unknown> = {
-    tag: "button",
-    text: {
-      tag: "plain_text",
-      content: button.label,
-    },
-    type: mapFeishuButtonType(button.style),
-  };
-  if (button.url) {
-    const safeUrl = resolveSafeFeishuButtonUrl(button.url);
-    if (safeUrl) {
-      rendered.url = safeUrl;
-    }
-  }
-  if (button.value) {
-    rendered.value = createFeishuCardInteractionEnvelope({
-      k: "quick",
-      a: "feishu.payload.button",
-      q: button.value,
-    });
-  }
-  return rendered.url || rendered.value ? rendered : undefined;
-}
-
-function buildFeishuCardElementForBlock(
-  block: MessagePresentationBlock,
-): Record<string, unknown> | undefined {
-  if (block.type === "text") {
-    return { tag: "markdown", content: escapeFeishuCardMarkdownText(block.text) };
-  }
-  if (block.type === "context") {
-    return {
-      tag: "markdown",
-      content: `<font color='grey'>${escapeFeishuCardMarkdownText(block.text)}</font>`,
-    };
-  }
-  if (block.type === "divider") {
-    return { tag: "hr" };
-  }
-  if (block.type === "buttons") {
-    const actions = block.buttons
-      .map((button) => buildFeishuPayloadButton(button))
-      .filter((button): button is Record<string, unknown> => Boolean(button));
-    if (actions.length === 0) {
-      return undefined;
-    }
-    return {
-      tag: "action",
-      actions,
-    };
-  }
-  const labels = block.options.map((option) => `- ${option.label}`).join("\n");
-  return {
-    tag: "markdown",
-    content: `${escapeFeishuCardMarkdownText(
-      block.placeholder?.trim() || "Options",
-    )}:\n${escapeFeishuCardMarkdownText(labels)}`,
-  };
-}
-
 function buildFeishuPayloadCard(params: {
   payload: Parameters<NonNullable<ChannelOutboundAdapter["sendPayload"]>>[0]["payload"];
   text?: string;
@@ -316,22 +245,14 @@ function buildFeishuPayloadCard(params: {
     text: params.text ?? params.payload.text,
     interactive,
   });
-  const elements: Record<string, unknown>[] = [];
-  if (text?.trim()) {
-    elements.push({ tag: "markdown", content: escapeFeishuCardMarkdownText(text) });
-  }
-  for (const block of presentation?.blocks ?? []) {
-    const element = buildFeishuCardElementForBlock(block);
-    if (element) {
-      elements.push(element);
-    }
-  }
-  if (elements.length === 0) {
-    elements.push({
-      tag: "markdown",
-      content: renderMessagePresentationFallbackText({ text, presentation }),
-    });
-  }
+  const elements = presentation
+    ? buildFeishuPresentationCardElements({ presentation, fallbackText: text })
+    : [
+        {
+          tag: "markdown",
+          content: renderMessagePresentationFallbackText({ text, presentation }),
+        },
+      ];
 
   const identityTitle = params.identity
     ? params.identity.emoji

--- a/extensions/feishu/src/presentation-card.ts
+++ b/extensions/feishu/src/presentation-card.ts
@@ -1,0 +1,183 @@
+import {
+  normalizeMessagePresentation,
+  renderMessagePresentationFallbackText,
+  type MessagePresentationBlock,
+  type MessagePresentationButton,
+} from "openclaw/plugin-sdk/interactive-runtime";
+import { createFeishuCardInteractionEnvelope } from "./card-interaction.js";
+
+type NormalizedMessagePresentation = NonNullable<ReturnType<typeof normalizeMessagePresentation>>;
+
+function escapeFeishuCardMarkdownText(text: string): string {
+  return text.replace(/[&<>]/g, (char) => {
+    switch (char) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      default:
+        return char;
+    }
+  });
+}
+
+function resolveSafeFeishuButtonUrl(url: string | undefined): string | undefined {
+  const trimmed = url?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    const parsed = new URL(trimmed);
+    return parsed.protocol === "https:" || parsed.protocol === "http:" ? trimmed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function mapFeishuButtonType(style: MessagePresentationButton["style"]) {
+  if (style === "primary" || style === "success") {
+    return "primary";
+  }
+  if (style === "danger") {
+    return "danger";
+  }
+  return "default";
+}
+
+function buildFeishuPayloadButton(
+  button: MessagePresentationButton,
+): Record<string, unknown> | undefined {
+  const rendered: Record<string, unknown> = {
+    tag: "button",
+    text: {
+      tag: "plain_text",
+      content: button.label,
+    },
+    type: mapFeishuButtonType(button.style),
+  };
+  if (button.url) {
+    const safeUrl = resolveSafeFeishuButtonUrl(button.url);
+    if (safeUrl) {
+      rendered.url = safeUrl;
+    }
+  }
+  if (button.value) {
+    rendered.value = createFeishuCardInteractionEnvelope({
+      k: "quick",
+      a: "feishu.payload.button",
+      q: button.value,
+    });
+  }
+  return rendered.url || rendered.value ? rendered : undefined;
+}
+
+export function buildFeishuCardElementForBlock(
+  block: MessagePresentationBlock,
+): Record<string, unknown> | undefined {
+  if (block.type === "text") {
+    return { tag: "markdown", content: escapeFeishuCardMarkdownText(block.text) };
+  }
+  if (block.type === "context") {
+    return {
+      tag: "markdown",
+      content: `<font color='grey'>${escapeFeishuCardMarkdownText(block.text)}</font>`,
+    };
+  }
+  if (block.type === "divider") {
+    return { tag: "hr" };
+  }
+  if (block.type === "buttons") {
+    const actions = block.buttons
+      .map((button) => buildFeishuPayloadButton(button))
+      .filter((button): button is Record<string, unknown> => Boolean(button));
+    if (actions.length === 0) {
+      return undefined;
+    }
+    return {
+      tag: "action",
+      actions,
+    };
+  }
+  const labels = block.options.map((option) => `- ${option.label}`).join("\n");
+  return {
+    tag: "markdown",
+    content: `${escapeFeishuCardMarkdownText(
+      block.placeholder?.trim() || "Options",
+    )}:\n${escapeFeishuCardMarkdownText(labels)}`,
+  };
+}
+
+function resolvePresentationHeaderTemplate(tone: NormalizedMessagePresentation["tone"]) {
+  if (tone === "danger") {
+    return "red";
+  }
+  if (tone === "warning") {
+    return "orange";
+  }
+  if (tone === "success") {
+    return "green";
+  }
+  return "blue";
+}
+
+export function buildFeishuPresentationCardElements(params: {
+  presentation: NormalizedMessagePresentation;
+  fallbackText?: string;
+}): Record<string, unknown>[] {
+  const elements: Record<string, unknown>[] = [];
+  const fallbackText = params.fallbackText?.trim();
+  if (fallbackText) {
+    elements.push({
+      tag: "markdown",
+      content: escapeFeishuCardMarkdownText(fallbackText),
+    });
+  }
+  for (const block of params.presentation.blocks) {
+    const element = buildFeishuCardElementForBlock(block);
+    if (element) {
+      elements.push(element);
+    }
+  }
+  if (elements.length > 0) {
+    return elements;
+  }
+  return [
+    {
+      tag: "markdown",
+      content: renderMessagePresentationFallbackText({
+        text: params.fallbackText,
+        presentation: params.presentation.title
+          ? {
+              ...(params.presentation.tone ? { tone: params.presentation.tone } : {}),
+              blocks: params.presentation.blocks,
+            }
+          : params.presentation,
+      }),
+    },
+  ];
+}
+
+export function buildFeishuPresentationCard(params: {
+  presentation: NormalizedMessagePresentation;
+  fallbackText?: string;
+}): Record<string, unknown> {
+  return {
+    schema: "2.0",
+    config: {
+      width_mode: "fill",
+    },
+    ...(params.presentation.title
+      ? {
+          header: {
+            title: { tag: "plain_text", content: params.presentation.title },
+            template: resolvePresentationHeaderTemplate(params.presentation.tone),
+          },
+        }
+      : {}),
+    body: {
+      elements: buildFeishuPresentationCardElements(params),
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- share the Feishu presentation-card block renderer between outbound payload rendering and message-tool card sends
- render message-tool `buttons` blocks as native Feishu `action` elements while keeping select fallback text behavior
- keep title-only fallbacks header-only across both direct channel sends and outbound renderPresentation, with regression coverage on both paths

## Verification
- node scripts/run-vitest.mjs extensions/feishu/src/channel.test.ts extensions/feishu/src/outbound.test.ts
- pnpm build
- node --input-type=module <<'PROOF'
  import { readdirSync } from 'node:fs';
  import path from 'node:path';
  import { pathToFileURL } from 'node:url';
  const file = readdirSync('dist').find((name) => name.startsWith('presentation-card-') && name.endsWith('.js'));
  const mod = await import(pathToFileURL(path.join(process.cwd(), 'dist', file)).href);
  const card = mod.t({
    presentation: {
      title: 'Approval',
      tone: 'success',
      blocks: [
        { type: 'text', text: 'Approve the request?' },
        {
          type: 'buttons',
          buttons: [
            { label: 'Approve', value: '/approve req_1 allow-once', style: 'success' },
            { label: 'Open runbook', url: 'https://example.com/runbook', style: 'primary' }
          ]
        }
      ]
    }
  });
  console.log(JSON.stringify(card, null, 2));
PROOF

## Real behavior proof
Behavior addressed: Feishu message-tool presentation buttons on channel sends were flattened into markdown fallback text instead of native interactive card actions.
Real environment tested: Local OpenClaw checkout after `pnpm build`, exercising the built Feishu presentation-card renderer from `dist/` with a message-tool-style presentation payload.
Exact steps or command run after this patch:
```bash
node --input-type=module <<'EOF'
import { readdirSync } from 'node:fs';
import path from 'node:path';
import { pathToFileURL } from 'node:url';
const file = readdirSync('dist').find((name) => name.startsWith('presentation-card-') && name.endsWith('.js'));
const mod = await import(pathToFileURL(path.join(process.cwd(), 'dist', file)).href);
const card = mod.t({
  presentation: {
    title: 'Approval',
    tone: 'success',
    blocks: [
      { type: 'text', text: 'Approve the request?' },
      {
        type: 'buttons',
        buttons: [
          { label: 'Approve', value: '/approve req_1 allow-once', style: 'success' },
          { label: 'Open runbook', url: 'https://example.com/runbook', style: 'primary' },
        ],
      },
    ],
  },
});
console.log(JSON.stringify(card, null, 2));
EOF
```
Evidence after fix:
```json
{
  "schema": "2.0",
  "config": {
    "width_mode": "fill"
  },
  "header": {
    "title": {
      "tag": "plain_text",
      "content": "Approval"
    },
    "template": "green"
  },
  "body": {
    "elements": [
      {
        "tag": "markdown",
        "content": "Approve the request?"
      },
      {
        "tag": "action",
        "actions": [
          {
            "tag": "button",
            "text": {
              "tag": "plain_text",
              "content": "Approve"
            },
            "type": "primary",
            "value": {
              "oc": "ocf1",
              "k": "quick",
              "a": "feishu.payload.button",
              "q": "/approve req_1 allow-once"
            }
          },
          {
            "tag": "button",
            "text": {
              "tag": "plain_text",
              "content": "Open runbook"
            },
            "type": "primary",
            "url": "https://example.com/runbook"
          }
        ]
      }
    ]
  }
}
```
Observed result after fix: The rendered Feishu card now contains a native `action` row with interactive buttons, and button values are emitted as structured `ocf1` envelopes instead of being flattened into markdown bullet text.
What was not tested: Live Feishu delivery and callback handling against a real tenant/app.

Fixes #85959
