### PR TITLE
Clarify QQBot passive group event wording

### DIFF
--- a/extensions/qqbot/src/engine/gateway/constants.ts
+++ b/extensions/qqbot/src/engine/gateway/constants.ts
@@ -98,9 +98,9 @@ export const GatewayEvent = {
   /** Group message that explicitly @-mentions the bot. */
   GROUP_AT_MESSAGE_CREATE: "GROUP_AT_MESSAGE_CREATE",
   /**
-   * Group message that does NOT mention the bot. Still dispatched to the
-   * pipeline so the group history buffer and the `requireMention=false`
-   * path can observe it.
+   * Passive group message event without an explicit bot mention. The dispatch
+   * path records group context for history-aware routing; visible replies still
+   * depend on the channel activation policy.
    */
   GROUP_MESSAGE_CREATE: "GROUP_MESSAGE_CREATE",
   INTERACTION_CREATE: "INTERACTION_CREATE",


### PR DESCRIPTION
## Summary

Clarifies the QQBot group-message event comment to describe passive context collection and visible-reply gating without implying that non-mentioned group messages directly trigger agent replies.

## Scope

Comment-only advisory cleanup. No runtime behavior, dispatch constants, permissions, channel activation policy, or gateway code changed.

## Validation

SafeOps target: reduce the advisory group-chat wording hit for `extensions/qqbot/src/engine/gateway/constants.ts`.

Recommended local check:

```bash
make audit-openclaw
jq -r '
  .findings[]
  | select(.file=="extensions/qqbot/src/engine/gateway/constants.ts")
  | [.id, .file, (.evidence.line // "n/a"), (.evidence.excerpt // "")]
  | @tsv
' reports/v3/openclaw-audit/openclaw-audit.json
```