### PR TITLE
fix(daemon): ignore recursive Windows gateway wrapper

### DIFF
--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -275,6 +275,42 @@ describe("buildGatewayInstallPlan", () => {
     expect(plan.environment.OPENCLAW_WRAPPER).toBe(wrapperPath);
   });
 
+  it("clears a Windows wrapper env that points at the generated gateway.cmd script", async () => {
+    const selfWrapperPath = path.join(isolatedHome, ".openclaw", "gateway.cmd");
+    const warn = vi.fn();
+    mockNodeGatewayPlanFixture({
+      serviceEnvironment: {
+        OPENCLAW_PORT: "3000",
+      },
+    });
+
+    const plan = await buildGatewayInstallPlan({
+      env: isolatedPlanEnv({
+        OPENCLAW_WRAPPER: selfWrapperPath,
+      }),
+      port: 3000,
+      runtime: "node",
+      platform: "win32",
+      warn,
+    });
+
+    expect(mocks.resolveGatewayProgramArguments).toHaveBeenCalledOnce();
+    expect(
+      firstMockArg(mocks.resolveGatewayProgramArguments, "resolveGatewayProgramArguments")
+        .wrapperPath,
+    ).toBeUndefined();
+    expect(mocks.buildServiceEnvironment).toHaveBeenCalledOnce();
+    expect(
+      firstMockArg(mocks.buildServiceEnvironment, "buildServiceEnvironment").env?.OPENCLAW_WRAPPER,
+    ).toBeUndefined();
+    expect(plan.environment.OPENCLAW_WRAPPER).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Ignoring OPENCLAW_WRAPPER because it points to the Windows task script",
+      ),
+    );
+  });
+
   it("tracks safe config env keys without embedding literal values", async () => {
     mockNodeGatewayPlanFixture({
       serviceEnvironment: {

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -7,7 +7,7 @@ import { collectDurableServiceEnvVarSources } from "../config/state-dir-dotenv.j
 import type { OpenClawConfig } from "../config/types.js";
 import { resolveSecretInputRef } from "../config/types.secrets.js";
 import { resolveGatewayLaunchAgentLabel } from "../daemon/constants.js";
-import { resolveGatewayStateDir } from "../daemon/paths.js";
+import { resolveGatewayStateDir, resolveGatewayTaskScriptPath } from "../daemon/paths.js";
 import {
   OPENCLAW_WRAPPER_ENV_KEY,
   resolveGatewayProgramArguments,
@@ -519,12 +519,24 @@ export async function buildGatewayInstallPlan(params: {
     devMode: params.devMode,
     nodePath: params.nodePath,
   });
-  const wrapperPath = await resolveOpenClawWrapperPath(
-    params.wrapperPath ?? params.env[OPENCLAW_WRAPPER_ENV_KEY],
-  );
+  const wrapperInput = params.wrapperPath ?? params.env[OPENCLAW_WRAPPER_ENV_KEY];
+  const wrapperPointsAtWindowsTaskScript =
+    Boolean(wrapperInput?.trim()) &&
+    platform === "win32" &&
+    isSameServicePath(wrapperInput, resolveGatewayTaskScriptPath(params.env), platform);
+  if (wrapperPointsAtWindowsTaskScript) {
+    params.warn?.(
+      `Ignoring ${OPENCLAW_WRAPPER_ENV_KEY} because it points to the Windows task script; using the OpenClaw gateway entrypoint directly to avoid a recursive gateway.cmd wrapper.`,
+    );
+  }
+  const wrapperPath = wrapperPointsAtWindowsTaskScript
+    ? undefined
+    : await resolveOpenClawWrapperPath(wrapperInput);
   const serviceInputEnv: Record<string, string | undefined> = wrapperPath
     ? { ...params.env, [OPENCLAW_WRAPPER_ENV_KEY]: wrapperPath }
-    : params.env;
+    : wrapperPointsAtWindowsTaskScript
+      ? omitEnvKey(params.env, OPENCLAW_WRAPPER_ENV_KEY)
+      : params.env;
   const { programArguments, workingDirectory } = await resolveGatewayProgramArguments({
     port: params.port,
     dev: devMode,
@@ -576,6 +588,36 @@ export async function buildGatewayInstallPlan(params: {
     environment,
     ...(Object.keys(environmentValueSources).length > 0 ? { environmentValueSources } : {}),
   };
+}
+
+function normalizeServicePathForCompare(
+  value: string | undefined,
+  platform: NodeJS.Platform,
+): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return platform === "win32" ? path.win32.resolve(trimmed).toLowerCase() : path.resolve(trimmed);
+}
+
+function isSameServicePath(
+  left: string | undefined,
+  right: string | undefined,
+  platform: NodeJS.Platform,
+): boolean {
+  const normalizedLeft = normalizeServicePathForCompare(left, platform);
+  const normalizedRight = normalizeServicePathForCompare(right, platform);
+  return Boolean(normalizedLeft && normalizedRight && normalizedLeft === normalizedRight);
+}
+
+function omitEnvKey(
+  env: Record<string, string | undefined>,
+  key: string,
+): Record<string, string | undefined> {
+  const next = { ...env };
+  delete next[key];
+  return next;
 }
 
 export function gatewayInstallErrorHint(platform = process.platform): string {

--- a/src/daemon/paths.ts
+++ b/src/daemon/paths.ts
@@ -41,3 +41,17 @@ export function resolveGatewayStateDir(env: Record<string, string | undefined>):
   const suffix = resolveGatewayProfileSuffix(env.OPENCLAW_PROFILE);
   return path.join(home, `.openclaw${suffix}`);
 }
+
+export function resolveGatewayTaskScriptPath(env: Record<string, string | undefined>): string {
+  const override = normalizeOptionalString(env.OPENCLAW_TASK_SCRIPT);
+  if (override) {
+    return override;
+  }
+  const scriptName = normalizeOptionalString(env.OPENCLAW_TASK_SCRIPT_NAME) || "gateway.cmd";
+  if (/[/\\]|\.\./.test(scriptName)) {
+    throw new Error(
+      `OPENCLAW_TASK_SCRIPT_NAME must be a file name only, not a path: ${scriptName}`,
+    );
+  }
+  return path.join(resolveGatewayStateDir(env), scriptName);
+}

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -13,7 +13,7 @@ import { parseCmdScriptCommandLine, quoteCmdScriptArg } from "./cmd-argv.js";
 import { assertNoCmdLineBreak, parseCmdSetAssignment, renderCmdSetAssignment } from "./cmd-set.js";
 import { resolveGatewayServiceDescription, resolveGatewayWindowsTaskName } from "./constants.js";
 import { formatLine, writeFormattedLines } from "./output.js";
-import { resolveGatewayStateDir } from "./paths.js";
+import { resolveGatewayTaskScriptPath } from "./paths.js";
 import { parseKeyValueOutput } from "./runtime-parse.js";
 import { execSchtasks } from "./schtasks-exec.js";
 import type { GatewayServiceRuntime } from "./service-runtime.js";
@@ -47,18 +47,7 @@ function shouldFallbackToStartupEntry(params: { code: number; detail: string }):
 }
 
 export function resolveTaskScriptPath(env: GatewayServiceEnv): string {
-  const override = env.OPENCLAW_TASK_SCRIPT?.trim();
-  if (override) {
-    return override;
-  }
-  const scriptName = env.OPENCLAW_TASK_SCRIPT_NAME?.trim() || "gateway.cmd";
-  if (/[/\\]|\.\./.test(scriptName)) {
-    throw new Error(
-      `OPENCLAW_TASK_SCRIPT_NAME must be a file name only, not a path: ${scriptName}`,
-    );
-  }
-  const stateDir = resolveGatewayStateDir(env);
-  return path.join(stateDir, scriptName);
+  return resolveGatewayTaskScriptPath(env);
 }
 
 function resolveWindowsStartupDir(env: GatewayServiceEnv): string {


### PR DESCRIPTION
Windows install/update can persist `OPENCLAW_WRAPPER` pointing back at the generated `gateway.cmd`, making the task script call itself and leaving gateway health stuck.

Fixes #86007

## Affected surface

- `src/commands/daemon-install-helpers.ts`
  - `buildGatewayInstallPlan()`
  - Windows-only self-wrapper guard for `OPENCLAW_WRAPPER`
- `src/daemon/paths.ts`
  - new shared `resolveGatewayTaskScriptPath()` helper for the generated Windows task script path
- `src/daemon/schtasks.ts`
  - `resolveTaskScriptPath()` now delegates to the shared task-script path helper
- `src/commands/daemon-install-helpers.test.ts`
  - regression coverage for a wrapper env pointing at generated `gateway.cmd`

## Scope

This is a narrow install-plan boundary fix:

- detects only the Windows case where `OPENCLAW_WRAPPER` resolves to the generated task script path
- clears that wrapper before deriving gateway program arguments and service environment
- preserves valid wrapper values
- reuses the existing Windows task-script path semantics instead of adding another config or policy surface
- does not change the Scheduled Task command renderer, service runtime, or non-Windows behavior

## Real behavior proof

- **Behavior or issue addressed**: Windows gateway install/update can persist `OPENCLAW_WRAPPER=<state-dir>/gateway.cmd`, causing the generated Scheduled Task script to invoke itself recursively instead of launching the OpenClaw gateway entrypoint.
- **Real environment tested**: Local OpenClaw checkout at current PR head `1c91b29acadb` on the Linux executor. I cannot honestly claim a native Windows Scheduled Task run from this environment, so this proof uses the real OpenClaw install-plan code path with `platform: "win32"` against a temporary OpenClaw home.
- **Exact steps or command run after this patch**:

```text
PROOF_HEAD=$(git rev-parse --short=12 HEAD) pnpm exec tsx /tmp/openclaw-pr86020-proof.mts
```

- **Evidence after fix**: Redacted terminal output from a temporary runtime harness outside the repo. The harness imports the actual `buildGatewayInstallPlan()` implementation, sets `platform: "win32"`, and exercises both the generated-task-script self-wrapper and a valid-wrapper control.

```text
OpenClaw PR #86020 runtime helper proof
head=1c91b29acadb
scenario=self-wrapper-env
input.OPENCLAW_WRAPPER=<temp-home>/.openclaw/gateway.cmd
programArguments=["/home/dev/.local/npm-global/bin/bun","/code/workspaces/openclaw/openclaw/src/entry.ts","gateway","--port","18789"]
serviceEnv.OPENCLAW_WRAPPER=<unset>
warnings=["Ignoring OPENCLAW_WRAPPER because it points to the Windows task script; using the OpenClaw gateway entrypoint directly to avoid a recursive gateway.cmd wrapper."]
result=PASS self-recursive gateway.cmd wrapper was not used
scenario=valid-wrapper-control
input.OPENCLAW_WRAPPER=<temp-home>/valid-wrapper
programArguments=["<temp-home>/valid-wrapper","gateway","--port","18789"]
serviceEnv.OPENCLAW_WRAPPER=<temp-home>/valid-wrapper
result=PASS valid non-recursive wrapper remains usable
```

- **Observed result after fix**: For the self-wrapper input, `programArguments` start with the OpenClaw dev entrypoint and `serviceEnv.OPENCLAW_WRAPPER=<unset>`, so the generated `gateway.cmd` is not used as its own wrapper. For the valid-wrapper control, `programArguments[0]` and `serviceEnv.OPENCLAW_WRAPPER` remain the valid wrapper path, proving the guard does not disable legitimate wrappers.
- **What was not tested**: I did not run a native Windows Scheduled Task install on this Linux executor, and I did not exercise the reporter's exact Windows profile. The native-Windows surface is covered by source-level regression plus the runtime helper proof above.

### RED

Command:

```text
OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=20000 OPENCLAW_TEST_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.commands.config.ts src/commands/daemon-install-helpers.test.ts -t "clears a Windows wrapper env"
```

Expected failure before the fix:

```text
expected wrapperPath to be undefined but received /tmp/oc-plan-test-.../.openclaw/gateway.cmd
```

### GREEN

Command:

```text
OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=30000 OPENCLAW_TEST_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.commands.config.ts src/commands/daemon-install-helpers.test.ts
```

Result:

```text
Test Files  1 passed (1)
Tests  33 passed (33)
```

Command:

```text
OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=30000 OPENCLAW_TEST_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.daemon.config.ts src/daemon/program-args.test.ts src/daemon/schtasks.install.test.ts
```

Result:

```text
Test Files  2 passed (2)
Tests  18 passed (18)
```

Command:

```text
OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=30000 OPENCLAW_TEST_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/daemon-cli/install.test.ts
```

Result:

```text
Test Files  1 passed (1)
Tests  21 passed (21)
```

Command:

```text
OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=30000 OPENCLAW_TEST_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.commands.config.ts src/commands/doctor-gateway-services.test.ts
```

Result:

```text
Test Files  1 passed (1)
Tests  28 passed (28)
```

Command:

```text
OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=30000 OPENCLAW_TEST_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.daemon.config.ts src/daemon/schtasks.startup-fallback.test.ts
```

Result:

```text
Test Files  1 passed (1)
Tests  18 passed (18)
```

Command:

```text
pnpm check:changed --base origin/main
```

Result: exited 0. It covered the changed core/coreTests lanes, including conflict markers, changelog attribution guard, dependency/package patch guards, core typecheck, core test typecheck, core lint, sidecar loader guard, runtime import cycles, webhook body guard, and pairing guards.

Command:

```text
git diff --check origin/main..HEAD
node scripts/check-no-conflict-markers.mjs
gitleaks protect --staged --redact
```

Result:

```text
git diff --check origin/main..HEAD
# exit 0

node scripts/check-no-conflict-markers.mjs
# exit 0

gitleaks protect --staged --redact
INF scan completed
INF no leaks found
```

## Coverage note

Push-time open PR searches:

```text
gh search prs --repo openclaw/openclaw --state open "Fixes #86007"
# no results

gh search prs --repo openclaw/openclaw --state open "#86007"
# no results

gh search prs --repo openclaw/openclaw --state open "buildGatewayInstallPlan"
# #68240 daemon env option, #82828 OPENCLAW_ALLOW_ROOT preservation,
# #66502 stable service path, #46502 rescue watchdog; none cover a
# Windows generated gateway.cmd self-wrapper.

gh search prs --repo openclaw/openclaw --state open "daemon-install-helpers.ts gateway.cmd"
# no results

gh search prs --repo openclaw/openclaw --state open "OPENCLAW_WRAPPER gateway.cmd"
# no results
```

Helper semantic check: `resolveGatewayTaskScriptPath()` is the existing generated Windows task script path contract extracted from `schtasks.ts`; this patch uses it only to identify the self-recursive wrapper case and does not create a second wrapper policy.

## What was not tested

- I did not run a native Windows Scheduled Task install on this Linux executor.
- I did not exercise the reporter's exact local Windows profile; the regression is source-level and uses the generated task script path behavior.
