### PR TITLE
fix(ui): dedupe webchat final tail messages

### DIFF
--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -564,6 +564,103 @@ describe("handleChatEvent", () => {
     expect(state.chatStreamStartedAt).toBe(null);
   });
 
+  it("does not append duplicate final message already loaded from history", () => {
+    const persistedFinal = {
+      role: "assistant",
+      content: [{ type: "text", text: "Reply" }],
+      timestamp: 100,
+      __openclaw: { index: 2 },
+    };
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Reply",
+      chatStreamStartedAt: 100,
+      chatMessages: [
+        { role: "user", content: [{ type: "text", text: "Hi" }], timestamp: 99 },
+        persistedFinal,
+      ],
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Reply" }],
+        timestamp: 101,
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([
+      { role: "user", content: [{ type: "text", text: "Hi" }], timestamp: 99 },
+      persistedFinal,
+    ]);
+    expect(state.chatRunId).toBe(null);
+    expect(state.chatStream).toBe(null);
+    expect(state.chatStreamStartedAt).toBe(null);
+  });
+
+  it("does not append duplicate streamed final already loaded from history", () => {
+    const persistedFinal = {
+      role: "assistant",
+      content: [{ type: "text", text: "Streamed reply" }],
+      timestamp: 100,
+      __openclaw: { index: 2 },
+    };
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Streamed reply",
+      chatStreamStartedAt: 100,
+      chatMessages: [persistedFinal],
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([persistedFinal]);
+    expect(state.chatRunId).toBe(null);
+    expect(state.chatStream).toBe(null);
+  });
+
+  it("keeps distinct repeated assistant final after another role", () => {
+    const previousAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "Same answer" }],
+      timestamp: 100,
+    };
+    const userMessage = {
+      role: "user",
+      content: [{ type: "text", text: "Ask again" }],
+      timestamp: 101,
+    };
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Same answer",
+      chatStreamStartedAt: 102,
+      chatMessages: [previousAssistant, userMessage],
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Same answer" }],
+        timestamp: 103,
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([previousAssistant, userMessage, payload.message]);
+  });
+
   it("processes aborted from own run and keeps partial assistant message", () => {
     const existingMessage = {
       role: "user",

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -185,6 +185,15 @@ function messageDisplaySignature(message: unknown): string | null {
   }
 }
 
+function appendChatMessageUnlessDuplicateTail(messages: unknown[], message: unknown): unknown[] {
+  const nextSignature = messageDisplaySignature(message);
+  const previousSignature = messageDisplaySignature(messages.at(-1));
+  if (nextSignature && nextSignature === previousSignature) {
+    return messages;
+  }
+  return [...messages, message];
+}
+
 export function preserveOptimisticTailMessages(
   historyMessages: unknown[],
   previousMessages: unknown[],
@@ -678,7 +687,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     if (payload.state === "final") {
       const finalMessage = normalizeFinalAssistantMessage(payload.message);
       if (finalMessage && !shouldHideAssistantChatMessage(finalMessage)) {
-        state.chatMessages = [...state.chatMessages, finalMessage];
+        state.chatMessages = appendChatMessageUnlessDuplicateTail(state.chatMessages, finalMessage);
         return null;
       }
       return "final";
@@ -713,20 +722,17 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   } else if (payload.state === "final") {
     const finalMessage = normalizeFinalAssistantMessage(payload.message);
     if (finalMessage && !shouldHideAssistantChatMessage(finalMessage)) {
-      state.chatMessages = [...state.chatMessages, finalMessage];
+      state.chatMessages = appendChatMessageUnlessDuplicateTail(state.chatMessages, finalMessage);
     } else if (
       state.chatStream?.trim() &&
       !isSilentReplyStream(state.chatStream) &&
       !isHeartbeatAckStream(state.chatStream)
     ) {
-      state.chatMessages = [
-        ...state.chatMessages,
-        {
-          role: "assistant",
-          content: [{ type: "text", text: state.chatStream }],
-          timestamp: Date.now(),
-        },
-      ];
+      state.chatMessages = appendChatMessageUnlessDuplicateTail(state.chatMessages, {
+        role: "assistant",
+        content: [{ type: "text", text: state.chatStream }],
+        timestamp: Date.now(),
+      });
     }
     reconcileTerminalRun("done", "done");
   } else if (payload.state === "aborted") {


### PR DESCRIPTION
## Summary
- Fixes #85771 by deduplicating a final assistant payload when the same assistant message is already the WebChat timeline tail from a history reload.
- Applies the same tail guard to final events from other runs and stream-fallback finalization so the frontend state does not double-source one transcript entry.
- Adds focused controller coverage for final-payload/history races while preserving legitimate repeated assistant text after a new user message.

## Tests
- `node scripts/run-vitest.mjs ui/src/ui/controllers/chat.test.ts`
- `node scripts/run-vitest.mjs ui/src/ui/controllers/chat.test.ts ui/src/ui/app-gateway.sessions.node.test.ts ui/src/ui/app-gateway.node.test.ts ui/src/ui/chat/build-chat-items.test.ts`
- `pnpm format:check ui/src/ui/controllers/chat.ts ui/src/ui/controllers/chat.test.ts`
- `git diff --check`

## Real behavior proof
Behavior addressed: WebChat final assistant events no longer append a duplicate visible assistant message when `chat.history` has already loaded that same assistant turn at the chat timeline tail.
Real environment tested: Local macOS checkout running the patched OpenClaw Control UI chat controller through Node with `tsx`, using the same `handleChatEvent` runtime path that receives gateway `chat.status` final events.
Exact steps or command run after this patch: `node --import tsx --input-type=module` with a live script that imports `./ui/src/ui/controllers/chat.ts`, seeds a WebChat state whose tail already contains the persisted assistant transcript entry, then delivers the matching final `chat.status` payload.
Evidence after fix: Console output from the command:
```json
{"result":"final","messages":2,"tailText":"Reply from gateway transcript","runId":null}
```
Observed result after fix: The timeline stayed at two messages (user + persisted assistant) instead of appending a third duplicate assistant message, and the run still finalized/cleared normally.
What was not tested: I did not run a full browser/WebChat session or live DeepSeek provider round trip for the intermittent 1-in-20 production report.
