### PR TITLE
[codex] Store Telegram caches in plugin state

### DIFF
--- a/extensions/telegram/src/bot-info-cache.test.ts
+++ b/extensions/telegram/src/bot-info-cache.test.ts
@@ -1,17 +1,12 @@
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   deleteCachedTelegramBotInfo,
   readCachedTelegramBotInfo,
-  resolveTelegramBotInfoCachePath,
+  setTelegramBotInfoCacheStoreForTest,
   TELEGRAM_BOT_INFO_CACHE_MAX_AGE_MS,
   writeCachedTelegramBotInfo,
 } from "./bot-info-cache.js";
 import type { TelegramBotInfo } from "./bot-info.js";
-
-const tempRoots: string[] = [];
 
 const botInfo: TelegramBotInfo = {
   id: 123456,
@@ -28,103 +23,104 @@ const botInfo: TelegramBotInfo = {
   allows_users_to_create_topics: false,
 };
 
-async function useTempStateDir(): Promise<NodeJS.ProcessEnv> {
-  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-tg-bot-info-"));
-  tempRoots.push(stateDir);
-  return { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+type BotInfoCacheValue = {
+  tokenFingerprint: string;
+  fetchedAt: string;
+  botInfo: TelegramBotInfo;
+};
+
+function useMemoryStore() {
+  const entries = new Map<string, BotInfoCacheValue>();
+  setTelegramBotInfoCacheStoreForTest({
+    async register(key, value) {
+      entries.set(key, value);
+    },
+    async lookup(key) {
+      return entries.get(key);
+    },
+    async delete(key) {
+      return entries.delete(key);
+    },
+  });
+  return entries;
 }
 
-afterEach(async () => {
+afterEach(() => {
   vi.unstubAllEnvs();
-  await Promise.all(
-    tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
-  );
+  setTelegramBotInfoCacheStoreForTest(undefined);
 });
 
 describe("Telegram bot info cache", () => {
   it("reads botInfo for the same account and bot token", async () => {
-    const env = await useTempStateDir();
+    useMemoryStore();
 
     await writeCachedTelegramBotInfo({
       accountId: "ops",
       botToken: "123456:secret",
       botInfo,
-      env,
     });
 
     await expect(
-      readCachedTelegramBotInfo({ accountId: "ops", botToken: "123456:secret", env }),
+      readCachedTelegramBotInfo({ accountId: "ops", botToken: "123456:secret" }),
     ).resolves.toMatchObject({ botInfo });
   });
 
   it("ignores botInfo written for a different token fingerprint", async () => {
-    const env = await useTempStateDir();
+    useMemoryStore();
 
     await writeCachedTelegramBotInfo({
       accountId: "ops",
       botToken: "123456:old-secret",
       botInfo,
-      env,
     });
 
     await expect(
-      readCachedTelegramBotInfo({ accountId: "ops", botToken: "123456:new-secret", env }),
+      readCachedTelegramBotInfo({ accountId: "ops", botToken: "123456:new-secret" }),
     ).resolves.toBeNull();
   });
 
   it("treats stale botInfo as a cache miss", async () => {
-    const env = await useTempStateDir();
+    useMemoryStore();
 
     await writeCachedTelegramBotInfo({
       accountId: "ops",
       botToken: "123456:secret",
       botInfo,
-      env,
     });
 
     await expect(
       readCachedTelegramBotInfo({
         accountId: "ops",
         botToken: "123456:secret",
-        env,
         now: new Date(Date.now() + TELEGRAM_BOT_INFO_CACHE_MAX_AGE_MS + 1),
       }),
     ).resolves.toBeNull();
   });
 
   it("deletes cached botInfo for an account", async () => {
-    const env = await useTempStateDir();
+    useMemoryStore();
 
     await writeCachedTelegramBotInfo({
       accountId: "ops",
       botToken: "123456:secret",
       botInfo,
-      env,
     });
-    await deleteCachedTelegramBotInfo({ accountId: "ops", env });
+    await deleteCachedTelegramBotInfo({ accountId: "ops" });
 
     await expect(
-      readCachedTelegramBotInfo({ accountId: "ops", botToken: "123456:secret", env }),
+      readCachedTelegramBotInfo({ accountId: "ops", botToken: "123456:secret" }),
     ).resolves.toBeNull();
   });
 
-  it("treats malformed persisted botInfo as a cache miss", async () => {
-    const env = await useTempStateDir();
-    const filePath = resolveTelegramBotInfoCachePath("ops", env);
-    await fs.mkdir(path.dirname(filePath), { recursive: true });
-    await fs.writeFile(
-      filePath,
-      JSON.stringify({
-        version: 1,
-        tokenFingerprint: "not-the-token",
-        fetchedAt: new Date().toISOString(),
-        botInfo: { id: 123456, is_bot: true },
-      }),
-      "utf8",
-    );
+  it("uses normalized account ids as store keys", async () => {
+    const entries = useMemoryStore();
 
-    await expect(
-      readCachedTelegramBotInfo({ accountId: "ops", botToken: "123456:secret", env }),
-    ).resolves.toBeNull();
+    await writeCachedTelegramBotInfo({
+      accountId: "ops team",
+      botToken: "123456:secret",
+      botInfo,
+    });
+
+    expect(entries.has("ops_team")).toBe(true);
   });
 });

--- a/extensions/telegram/src/bot-info-cache.ts
+++ b/extensions/telegram/src/bot-info-cache.ts
@@ -1,16 +1,12 @@
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
-import { readJsonFileWithFallback, writeJsonFileAtomically } from "openclaw/plugin-sdk/json-store";
-import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import { normalizeTelegramBotInfo, type TelegramBotInfo } from "./bot-info.js";
+import { getTelegramRuntime } from "./runtime.js";
 import { fingerprintTelegramBotToken } from "./token-fingerprint.js";
 
-const STORE_VERSION = 1;
+const STORE_NAMESPACE = "telegram.bot-info-cache";
+const STORE_MAX_ENTRIES = 128;
 export const TELEGRAM_BOT_INFO_CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 type TelegramBotInfoCacheState = {
-  version: number;
   tokenFingerprint: string;
   fetchedAt: string;
   botInfo: TelegramBotInfo;
@@ -20,6 +16,14 @@ export type CachedTelegramBotInfo = {
   botInfo: TelegramBotInfo;
   fetchedAt: string;
 };
+
+type TelegramBotInfoCacheStore = {
+  register(key: string, value: TelegramBotInfoCacheState): Promise<void>;
+  lookup(key: string): Promise<TelegramBotInfoCacheState | undefined>;
+  delete(key: string): Promise<boolean>;
+};
+
+let botInfoCacheStoreForTest: TelegramBotInfoCacheStore | undefined;
 
 function normalizeAccountId(accountId?: string) {
   const trimmed = accountId?.trim();
@@ -37,40 +41,28 @@ function fingerprintFromToken(botToken?: string): string | null {
   return fingerprintTelegramBotToken(trimmed);
 }
 
-export function resolveTelegramBotInfoCachePath(
-  accountId?: string,
-  env: NodeJS.ProcessEnv = process.env,
-): string {
-  const stateDir = resolveStateDir(env, os.homedir);
-  return path.join(stateDir, "telegram", `bot-info-${normalizeAccountId(accountId)}.json`);
+function openBotInfoCacheStore(): TelegramBotInfoCacheStore {
+  return (
+    botInfoCacheStoreForTest ??
+    getTelegramRuntime().state.openKeyedStore<TelegramBotInfoCacheState>({
+      namespace: STORE_NAMESPACE,
+      maxEntries: STORE_MAX_ENTRIES,
+      defaultTtlMs: TELEGRAM_BOT_INFO_CACHE_MAX_AGE_MS,
+    })
+  );
 }
 
-function parseCachedTelegramBotInfo(value: unknown): TelegramBotInfoCacheState | null {
-  if (!value || typeof value !== "object") {
+function parseCachedTelegramBotInfo(value: TelegramBotInfoCacheState | undefined) {
+  if (!value || Number.isNaN(Date.parse(value.fetchedAt))) {
     return null;
   }
-  const state = value as {
-    version?: unknown;
-    tokenFingerprint?: unknown;
-    fetchedAt?: unknown;
-    botInfo?: unknown;
-  };
-  if (
-    state.version !== STORE_VERSION ||
-    typeof state.tokenFingerprint !== "string" ||
-    typeof state.fetchedAt !== "string" ||
-    Number.isNaN(Date.parse(state.fetchedAt))
-  ) {
-    return null;
-  }
-  const botInfo = normalizeTelegramBotInfo(state.botInfo);
+  const botInfo = normalizeTelegramBotInfo(value.botInfo);
   if (!botInfo) {
     return null;
   }
   return {
-    version: STORE_VERSION,
-    tokenFingerprint: state.tokenFingerprint,
-    fetchedAt: state.fetchedAt,
+    tokenFingerprint: value.tokenFingerprint,
+    fetchedAt: value.fetchedAt,
     botInfo,
   };
 }
@@ -78,16 +70,15 @@ function parseCachedTelegramBotInfo(value: unknown): TelegramBotInfoCacheState |
 export async function readCachedTelegramBotInfo(params: {
   accountId?: string;
   botToken?: string;
-  env?: NodeJS.ProcessEnv;
   now?: Date;
 }): Promise<CachedTelegramBotInfo | null> {
   const tokenFingerprint = fingerprintFromToken(params.botToken);
   if (!tokenFingerprint) {
     return null;
   }
-  const filePath = resolveTelegramBotInfoCachePath(params.accountId, params.env);
-  const { value } = await readJsonFileWithFallback<unknown>(filePath, null);
-  const parsed = parseCachedTelegramBotInfo(value);
+  const parsed = parseCachedTelegramBotInfo(
+    await openBotInfoCacheStore().lookup(normalizeAccountId(params.accountId)),
+  );
   if (!parsed || parsed.tokenFingerprint !== tokenFingerprint) {
     return null;
   }
@@ -103,33 +94,28 @@ export async function writeCachedTelegramBotInfo(params: {
   accountId?: string;
   botToken: string;
   botInfo: TelegramBotInfo;
-  env?: NodeJS.ProcessEnv;
 }): Promise<void> {
   const tokenFingerprint = fingerprintFromToken(params.botToken);
   if (!tokenFingerprint) {
     return;
   }
-  const filePath = resolveTelegramBotInfoCachePath(params.accountId, params.env);
-  const payload: TelegramBotInfoCacheState = {
-    version: STORE_VERSION,
+  const botInfo = normalizeTelegramBotInfo(params.botInfo);
+  if (!botInfo) {
+    return;
+  }
+  await openBotInfoCacheStore().register(normalizeAccountId(params.accountId), {
     tokenFingerprint,
     fetchedAt: new Date().toISOString(),
-    botInfo: params.botInfo,
-  };
-  await writeJsonFileAtomically(filePath, payload);
+    botInfo,
+  });
 }
 
-export async function deleteCachedTelegramBotInfo(params: {
-  accountId?: string;
-  env?: NodeJS.ProcessEnv;
-}): Promise<void> {
-  const filePath = resolveTelegramBotInfoCachePath(params.accountId, params.env);
-  try {
-    await fs.unlink(filePath);
-  } catch (err) {
-    if ((err as { code?: string }).code === "ENOENT") {
-      return;
-    }
-    throw err;
-  }
+export async function deleteCachedTelegramBotInfo(params: { accountId?: string }): Promise<void> {
+  await openBotInfoCacheStore().delete(normalizeAccountId(params.accountId));
+}
+
+export function setTelegramBotInfoCacheStoreForTest(
+  store: TelegramBotInfoCacheStore | undefined,
+): void {
+  botInfoCacheStoreForTest = store;
 }

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -51,7 +51,7 @@ import {
   resolveTelegramReactionVariant,
   resolveTelegramStatusReactionEmojis,
 } from "./status-reaction-variants.js";
-import { getTopicName, resolveTopicNameCachePath, updateTopicName } from "./topic-name-cache.js";
+import { getTopicName, resolveTopicNameCacheScope, updateTopicName } from "./topic-name-cache.js";
 
 export type {
   BuildTelegramMessageContextParams,
@@ -174,7 +174,7 @@ export const buildTelegramMessageContext = async ({
   const dmThreadId = threadSpec.scope === "dm" ? threadSpec.id : undefined;
   let topicName: string | undefined;
   if (isForum && resolvedThreadId != null) {
-    const topicNameCachePath = resolveTopicNameCachePath(
+    const topicNameCacheScope = resolveTopicNameCacheScope(
       await resolveTelegramMessageContextStorePath({
         cfg,
         agentId: account.accountId,
@@ -204,14 +204,14 @@ export const buildTelegramMessageContext = async ({
             : undefined;
 
     if (topicPatch) {
-      updateTopicName(chatId, resolvedThreadId, topicPatch, topicNameCachePath);
+      await updateTopicName(chatId, resolvedThreadId, topicPatch, topicNameCacheScope);
     }
 
-    topicName = getTopicName(chatId, resolvedThreadId, topicNameCachePath);
+    topicName = await getTopicName(chatId, resolvedThreadId, topicNameCacheScope);
     if (!topicName) {
       const replyFtCreated = msg.reply_to_message?.forum_topic_created;
       if (replyFtCreated?.name) {
-        updateTopicName(
+        await updateTopicName(
           chatId,
           resolvedThreadId,
           {
@@ -219,7 +219,7 @@ export const buildTelegramMessageContext = async ({
             iconColor: replyFtCreated.icon_color,
             iconCustomEmojiId: replyFtCreated.icon_custom_emoji_id,
           },
-          topicNameCachePath,
+          topicNameCacheScope,
         );
         topicName = replyFtCreated.name;
       }

--- a/extensions/telegram/src/channel.gateway.test.ts
+++ b/extensions/telegram/src/channel.gateway.test.ts
@@ -50,8 +50,89 @@ async function useTempStateDir(): Promise<string> {
   return stateDir;
 }
 
+type MemoryPluginStateEntry<T> = { key: string; value: T; createdAt: number; expiresAt?: number };
+
+function createMemoryPluginStateStore<T>(
+  maxEntries: number,
+  defaultTtlMs: number | undefined,
+  entries: Map<string, MemoryPluginStateEntry<unknown>>,
+) {
+  type Entry = { key: string; value: T; createdAt: number; expiresAt?: number };
+  const typedEntries = entries as Map<string, Entry>;
+  const readEntry = (key: string): Entry | undefined => {
+    const entry = typedEntries.get(key);
+    if (!entry) {
+      return undefined;
+    }
+    if (entry.expiresAt !== undefined && entry.expiresAt <= Date.now()) {
+      typedEntries.delete(key);
+      return undefined;
+    }
+    return entry;
+  };
+  const writeEntry = (key: string, value: T, opts?: { ttlMs?: number }): void => {
+    const createdAt = Date.now();
+    const entry: Entry = { key, value, createdAt };
+    const ttlMs = opts?.ttlMs ?? defaultTtlMs;
+    if (ttlMs !== undefined) {
+      entry.expiresAt = createdAt + ttlMs;
+    }
+    typedEntries.set(key, entry);
+    while (typedEntries.size > maxEntries) {
+      const oldestKey = typedEntries.keys().next().value;
+      if (oldestKey === undefined) {
+        break;
+      }
+      typedEntries.delete(oldestKey);
+    }
+  };
+  return {
+    async register(key: string, value: T, opts?: { ttlMs?: number }) {
+      writeEntry(key, value, opts);
+    },
+    async registerIfAbsent(key: string, value: T, opts?: { ttlMs?: number }) {
+      if (readEntry(key)) {
+        return false;
+      }
+      writeEntry(key, value, opts);
+      return true;
+    },
+    async lookup(key: string) {
+      return readEntry(key)?.value;
+    },
+    async consume(key: string) {
+      const value = readEntry(key)?.value;
+      typedEntries.delete(key);
+      return value;
+    },
+    async delete(key: string) {
+      return typedEntries.delete(key);
+    },
+    async entries() {
+      return [...typedEntries.keys()]
+        .map((key) => readEntry(key))
+        .filter((entry): entry is Entry => Boolean(entry));
+    },
+    async clear() {
+      typedEntries.clear();
+    },
+  };
+}
+
 function installTelegramRuntime() {
-  const runtime = createPluginRuntimeMock();
+  const keyedStores = new Map<string, Map<string, MemoryPluginStateEntry<unknown>>>();
+  const runtime = createPluginRuntimeMock({
+    state: {
+      openKeyedStore: ((options) => {
+        let entries = keyedStores.get(options.namespace);
+        if (!entries) {
+          entries = new Map();
+          keyedStores.set(options.namespace, entries);
+        }
+        return createMemoryPluginStateStore(options.maxEntries, options.defaultTtlMs, entries);
+      }) as TelegramRuntime["state"]["openKeyedStore"],
+    },
+  });
   const telegramRuntime = {
     ...runtime,
     channel: {

--- a/extensions/telegram/src/topic-name-cache.test.ts
+++ b/extensions/telegram/src/topic-name-cache.test.ts
@@ -1,140 +1,145 @@
-import syncFs from "node:fs";
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearTopicNameCache,
   getTopicEntry,
   getTopicName,
   resetTopicNameCacheForTest,
+  setTelegramTopicNameStoreFactoryForTest,
   topicNameCacheSize,
   updateTopicName,
 } from "./topic-name-cache.js";
 
+type TopicEntry = NonNullable<Awaited<ReturnType<typeof getTopicEntry>>>;
+
+function installMemoryStores() {
+  const stores = new Map<string, Map<string, TopicEntry>>();
+  setTelegramTopicNameStoreFactoryForTest((namespace) => {
+    const entries = stores.get(namespace) ?? new Map<string, TopicEntry>();
+    stores.set(namespace, entries);
+    return {
+      async register(key, value) {
+        entries.set(key, value);
+      },
+      async entries() {
+        return Array.from(entries, ([key, value]) => ({ key, value }));
+      },
+      async delete(key) {
+        return entries.delete(key);
+      },
+      async clear() {
+        entries.clear();
+      },
+    };
+  });
+  return stores;
+}
+
 describe("topic-name-cache", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.useRealTimers();
-    clearTopicNameCache();
+    installMemoryStores();
+    await clearTopicNameCache();
     resetTopicNameCacheForTest();
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    setTelegramTopicNameStoreFactoryForTest(undefined);
   });
 
-  it("stores and retrieves a topic name", () => {
-    updateTopicName(-100123, 42, { name: "Deployments" });
-    expect(getTopicName(-100123, 42)).toBe("Deployments");
+  it("stores and retrieves a topic name", async () => {
+    await updateTopicName(-100123, 42, { name: "Deployments" });
+    await expect(getTopicName(-100123, 42)).resolves.toBe("Deployments");
   });
 
-  it("returns undefined for unknown topics", () => {
-    expect(getTopicName(-100123, 99)).toBeUndefined();
+  it("returns undefined for unknown topics", async () => {
+    await expect(getTopicName(-100123, 99)).resolves.toBeUndefined();
   });
 
-  it("handles renames via forum_topic_edited (overwrites previous name)", () => {
-    updateTopicName(-100123, 42, { name: "Deployments" });
-    updateTopicName(-100123, 42, { name: "CI/CD" });
-    expect(getTopicName(-100123, 42)).toBe("CI/CD");
+  it("handles renames via forum_topic_edited", async () => {
+    await updateTopicName(-100123, 42, { name: "Deployments" });
+    await updateTopicName(-100123, 42, { name: "CI/CD" });
+    await expect(getTopicName(-100123, 42)).resolves.toBe("CI/CD");
   });
 
-  it("preserves name when patching only closed status", () => {
-    updateTopicName(-100123, 42, { name: "Deployments" });
-    updateTopicName(-100123, 42, { closed: true });
-    expect(getTopicName(-100123, 42)).toBe("Deployments");
-    expect(getTopicEntry(-100123, 42)?.closed).toBe(true);
+  it("preserves name when patching only closed status", async () => {
+    await updateTopicName(-100123, 42, { name: "Deployments" });
+    await updateTopicName(-100123, 42, { closed: true });
+    await expect(getTopicName(-100123, 42)).resolves.toBe("Deployments");
+    expect((await getTopicEntry(-100123, 42))?.closed).toBe(true);
   });
 
-  it("marks topic as reopened", () => {
-    updateTopicName(-100123, 42, { name: "Deployments", closed: true });
-    updateTopicName(-100123, 42, { closed: false });
-    expect(getTopicEntry(-100123, 42)?.closed).toBe(false);
+  it("marks topic as reopened", async () => {
+    await updateTopicName(-100123, 42, { name: "Deployments", closed: true });
+    await updateTopicName(-100123, 42, { closed: false });
+    expect((await getTopicEntry(-100123, 42))?.closed).toBe(false);
   });
 
-  it("stores icon metadata", () => {
-    updateTopicName(-100123, 42, {
+  it("stores icon metadata", async () => {
+    await updateTopicName(-100123, 42, {
       name: "Design",
       iconColor: 0x6fb9f0,
       iconCustomEmojiId: "emoji123",
     });
-    const entry = getTopicEntry(-100123, 42);
+    const entry = await getTopicEntry(-100123, 42);
     expect(entry?.iconColor).toBe(0x6fb9f0);
     expect(entry?.iconCustomEmojiId).toBe("emoji123");
   });
 
-  it("does not store entries with empty name and no prior entry", () => {
-    updateTopicName(-100123, 42, { closed: true });
-    expect(getTopicName(-100123, 42)).toBeUndefined();
+  it("does not store entries with empty name and no prior entry", async () => {
+    await updateTopicName(-100123, 42, { closed: true });
+    await expect(getTopicName(-100123, 42)).resolves.toBeUndefined();
     expect(topicNameCacheSize()).toBe(0);
   });
 
   it("updates timestamps on write", async () => {
     vi.useFakeTimers();
-    updateTopicName(-100123, 42, { name: "A" });
-    const t1 = getTopicEntry(-100123, 42)?.updatedAt ?? 0;
+    await updateTopicName(-100123, 42, { name: "A" });
+    const t1 = (await getTopicEntry(-100123, 42))?.updatedAt ?? 0;
     await vi.advanceTimersByTimeAsync(10);
-    updateTopicName(-100123, 42, { name: "B" });
-    const t2 = getTopicEntry(-100123, 42)?.updatedAt ?? 0;
+    await updateTopicName(-100123, 42, { name: "B" });
+    const t2 = (await getTopicEntry(-100123, 42))?.updatedAt ?? 0;
     expect(t2).toBeGreaterThan(t1);
   });
 
-  it("works with string chatId and threadId", () => {
-    updateTopicName("-100123", "42", { name: "StringKeys" });
-    expect(getTopicName("-100123", "42")).toBe("StringKeys");
+  it("works with string chatId and threadId", async () => {
+    await updateTopicName("-100123", "42", { name: "StringKeys" });
+    await expect(getTopicName("-100123", "42")).resolves.toBe("StringKeys");
   });
 
-  it("evicts the oldest entry when cache exceeds 2048", () => {
+  it("evicts the oldest entry when cache exceeds 2048", async () => {
     for (let i = 0; i < 2049; i++) {
-      updateTopicName(-100000, i, { name: `Topic ${i}` });
+      await updateTopicName(-100000, i, { name: `Topic ${i}` });
     }
     expect(topicNameCacheSize()).toBe(2048);
-    expect(getTopicName(-100000, 0)).toBeUndefined();
-    expect(getTopicName(-100000, 2048)).toBe("Topic 2048");
+    await expect(getTopicName(-100000, 0)).resolves.toBeUndefined();
+    await expect(getTopicName(-100000, 2048)).resolves.toBe("Topic 2048");
   });
 
   it("refreshes recency on read so active topics survive eviction", async () => {
     vi.useFakeTimers();
-    updateTopicName(-100000, 1, { name: "Active" });
+    await updateTopicName(-100000, 1, { name: "Active" });
     await vi.advanceTimersByTimeAsync(10);
     for (let i = 2; i <= 2048; i++) {
-      updateTopicName(-100000, i, { name: `Topic ${i}` });
+      await updateTopicName(-100000, i, { name: `Topic ${i}` });
     }
-    getTopicName(-100000, 1);
-    updateTopicName(-100000, 9999, { name: "Newcomer" });
-    expect(getTopicName(-100000, 1)).toBe("Active");
+    await getTopicName(-100000, 1);
+    await updateTopicName(-100000, 9999, { name: "Newcomer" });
+    await expect(getTopicName(-100000, 1)).resolves.toBe("Active");
     expect(topicNameCacheSize()).toBe(2048);
   });
 
-  it("reloads persisted entries from disk", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-topic-cache-"));
-    const persistedPath = path.join(tempDir, "topic-names.json");
-    try {
-      updateTopicName(-100123, 42, { name: "Deployments" }, persistedPath);
-      resetTopicNameCacheForTest();
-      expect(getTopicName(-100123, 42, persistedPath)).toBe("Deployments");
-    } finally {
-      await fs.rm(tempDir, { recursive: true, force: true });
-      resetTopicNameCacheForTest();
-    }
+  it("reloads persisted entries from plugin state", async () => {
+    await updateTopicName(-100123, 42, { name: "Deployments" }, "first");
+    resetTopicNameCacheForTest();
+    await expect(getTopicName(-100123, 42, "first")).resolves.toBe("Deployments");
   });
 
-  it("keeps separate in-memory stores for separate persisted paths", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-topic-cache-"));
-    const firstPath = path.join(tempDir, "first-topic-names.json");
-    const secondPath = path.join(tempDir, "second-topic-names.json");
-    try {
-      updateTopicName(-100123, 42, { name: "Deployments" }, firstPath);
-      updateTopicName(-200456, 84, { name: "Incidents" }, secondPath);
+  it("keeps separate stores for separate scopes", async () => {
+    await updateTopicName(-100123, 42, { name: "Deployments" }, "first");
+    await updateTopicName(-200456, 84, { name: "Incidents" }, "second");
 
-      const readFileSpy = vi.spyOn(syncFs, "readFileSync");
-
-      expect(getTopicName(-100123, 42, firstPath)).toBe("Deployments");
-      expect(getTopicName(-200456, 84, secondPath)).toBe("Incidents");
-      expect(readFileSpy).not.toHaveBeenCalled();
-    } finally {
-      vi.restoreAllMocks();
-      await fs.rm(tempDir, { recursive: true, force: true });
-      resetTopicNameCacheForTest();
-    }
+    await expect(getTopicName(-100123, 42, "first")).resolves.toBe("Deployments");
+    await expect(getTopicName(-200456, 84, "second")).resolves.toBe("Incidents");
   });
 });

--- a/extensions/telegram/src/topic-name-cache.ts
+++ b/extensions/telegram/src/topic-name-cache.ts
@@ -1,10 +1,10 @@
-import fs from "node:fs";
-import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import { replaceFileAtomicSync } from "openclaw/plugin-sdk/security-runtime";
+import { createHash } from "node:crypto";
+import { getTelegramRuntime } from "./runtime.js";
 
 const MAX_ENTRIES = 2_048;
+const STORE_NAMESPACE_PREFIX = "telegram.topic-name-cache";
 const TOPIC_NAME_CACHE_STATE_KEY = Symbol.for("openclaw.telegramTopicNameCacheState");
-const DEFAULT_TOPIC_NAME_CACHE_KEY = "__default__";
+const DEFAULT_TOPIC_NAME_CACHE_SCOPE = "default";
 
 type TopicEntry = {
   name: string;
@@ -19,20 +19,34 @@ type TopicNameStore = Map<string, TopicEntry>;
 type TopicNameStoreState = {
   lastUpdatedAt: number;
   store: TopicNameStore;
+  hydrated: boolean;
+  hydratePromise?: Promise<void>;
+  persistentStore: TopicNamePersistentStore;
 };
 
 type TopicNameCacheState = {
   stores: Map<string, TopicNameStoreState>;
 };
 
+type TopicNamePersistentStore = {
+  register(key: string, value: TopicEntry): Promise<void>;
+  entries(): Promise<Array<{ key: string; value: TopicEntry }>>;
+  delete(key: string): Promise<boolean>;
+  clear(): Promise<void>;
+};
+
+let topicNameStoreFactoryForTest: ((namespace: string) => TopicNamePersistentStore) | undefined;
+
 function createTopicNameStore(): TopicNameStore {
   return new Map<string, TopicEntry>();
 }
 
-function createTopicNameStoreState(): TopicNameStoreState {
+function createTopicNameStoreState(namespace: string): TopicNameStoreState {
   return {
     lastUpdatedAt: 0,
     store: createTopicNameStore(),
+    hydrated: false,
+    persistentStore: openTopicNamePersistentStore(namespace),
   };
 }
 
@@ -51,13 +65,28 @@ function cacheKey(chatId: number | string, threadId: number | string): string {
   return `${chatId}:${threadId}`;
 }
 
-export function resolveTopicNameCachePath(storePath: string): string {
-  return `${storePath}.telegram-topic-names.json`;
+function namespaceForScope(scope: string): string {
+  const hash = createHash("sha256").update(scope).digest("hex").slice(0, 16);
+  return `${STORE_NAMESPACE_PREFIX}.${hash}`;
 }
 
-function evictOldest(store: TopicNameStore): void {
+export function resolveTopicNameCacheScope(storePath: string): string {
+  return storePath;
+}
+
+function openTopicNamePersistentStore(namespace: string): TopicNamePersistentStore {
+  return (
+    topicNameStoreFactoryForTest?.(namespace) ??
+    getTelegramRuntime().state.openKeyedStore<TopicEntry>({
+      namespace,
+      maxEntries: MAX_ENTRIES,
+    })
+  );
+}
+
+function evictOldest(store: TopicNameStore): string | undefined {
   if (store.size <= MAX_ENTRIES) {
-    return;
+    return undefined;
   }
   let oldestKey: string | undefined;
   let oldestTime = Infinity;
@@ -70,6 +99,7 @@ function evictOldest(store: TopicNameStore): void {
   if (oldestKey) {
     store.delete(oldestKey);
   }
+  return oldestKey;
 }
 
 function isTopicEntry(value: unknown): value is TopicEntry {
@@ -85,135 +115,130 @@ function isTopicEntry(value: unknown): value is TopicEntry {
   );
 }
 
-function readPersistedTopicNames(persistedPath: string): TopicNameStore {
-  if (!fs.existsSync(persistedPath)) {
-    return createTopicNameStore();
-  }
-  try {
-    const raw = fs.readFileSync(persistedPath, "utf-8");
-    const parsed = JSON.parse(raw) as Record<string, unknown>;
-    const entries = Object.entries(parsed)
-      .filter((entry): entry is [string, TopicEntry] => isTopicEntry(entry[1]))
-      .toSorted(([, left], [, right]) => right.updatedAt - left.updatedAt)
-      .slice(0, MAX_ENTRIES);
-    return new Map(entries);
-  } catch (error) {
-    logVerbose(`telegram: failed to read topic-name cache: ${String(error)}`);
-    return createTopicNameStore();
-  }
-}
-
-function getTopicStoreState(persistedPath?: string): TopicNameStoreState {
+function getTopicStoreState(scope?: string): TopicNameStoreState {
   const state = getTopicNameCacheState();
-  const stateKey = persistedPath ?? DEFAULT_TOPIC_NAME_CACHE_KEY;
+  const stateKey = scope ?? DEFAULT_TOPIC_NAME_CACHE_SCOPE;
   const existing = state.stores.get(stateKey);
   if (existing) {
     return existing;
   }
-  const next = persistedPath
-    ? {
-        lastUpdatedAt: 0,
-        store: readPersistedTopicNames(persistedPath),
-      }
-    : createTopicNameStoreState();
-  next.lastUpdatedAt = Math.max(0, ...Array.from(next.store.values(), (entry) => entry.updatedAt));
+  const next = createTopicNameStoreState(namespaceForScope(stateKey));
   state.stores.set(stateKey, next);
   return next;
 }
 
-function getTopicStore(persistedPath?: string): TopicNameStore {
-  return getTopicStoreState(persistedPath).store;
+async function hydrateTopicStoreState(state: TopicNameStoreState): Promise<void> {
+  if (state.hydrated) {
+    return;
+  }
+  if (state.hydratePromise) {
+    await state.hydratePromise;
+    return;
+  }
+  state.hydratePromise = (async () => {
+    const entries = await state.persistentStore.entries();
+    for (const { key, value } of entries) {
+      if (isTopicEntry(value)) {
+        state.store.set(key, value);
+      }
+    }
+    state.lastUpdatedAt = Math.max(
+      0,
+      ...Array.from(state.store.values(), (entry) => entry.updatedAt),
+    );
+    state.hydrated = true;
+  })().finally(() => {
+    state.hydratePromise = undefined;
+  });
+  await state.hydratePromise;
 }
 
-function nextUpdatedAt(persistedPath?: string): number {
-  const state = getTopicStoreState(persistedPath);
+async function getTopicStore(scope?: string): Promise<TopicNameStore> {
+  const state = getTopicStoreState(scope);
+  await hydrateTopicStoreState(state);
+  return state.store;
+}
+
+function nextUpdatedAt(scope?: string): number {
+  const state = getTopicStoreState(scope);
   const now = Date.now();
   state.lastUpdatedAt = now > state.lastUpdatedAt ? now : state.lastUpdatedAt + 1;
   return state.lastUpdatedAt;
 }
 
-function removeTopicStore(persistedPath?: string): void {
-  const state = getTopicNameCacheState();
-  const stateKey = persistedPath ?? DEFAULT_TOPIC_NAME_CACHE_KEY;
-  if (persistedPath) {
-    fs.rmSync(persistedPath, { force: true });
-  }
-  state.stores.delete(stateKey);
-}
-
-function persistTopicStore(persistedPath: string, store: TopicNameStore): void {
-  if (store.size === 0) {
-    fs.rmSync(persistedPath, { force: true });
-    return;
-  }
-  replaceFileAtomicSync({
-    filePath: persistedPath,
-    content: JSON.stringify(Object.fromEntries(store)),
-    tempPrefix: ".telegram-topic-name-cache",
-  });
-}
-
-export function updateTopicName(
+export async function updateTopicName(
   chatId: number | string,
   threadId: number | string,
   patch: Partial<Omit<TopicEntry, "updatedAt">>,
-  persistedPath?: string,
-): void {
-  const cache = getTopicStore(persistedPath);
+  scope?: string,
+): Promise<void> {
+  const state = getTopicStoreState(scope);
+  await hydrateTopicStoreState(state);
   const key = cacheKey(chatId, threadId);
-  const existing = cache.get(key);
+  const existing = state.store.get(key);
+  const iconColor = patch.iconColor ?? existing?.iconColor;
+  const iconCustomEmojiId = patch.iconCustomEmojiId ?? existing?.iconCustomEmojiId;
+  const closed = patch.closed ?? existing?.closed;
   const merged: TopicEntry = {
     name: patch.name ?? existing?.name ?? "",
-    iconColor: patch.iconColor ?? existing?.iconColor,
-    iconCustomEmojiId: patch.iconCustomEmojiId ?? existing?.iconCustomEmojiId,
-    closed: patch.closed ?? existing?.closed,
-    updatedAt: nextUpdatedAt(persistedPath),
+    updatedAt: nextUpdatedAt(scope),
+    ...(iconColor !== undefined ? { iconColor } : {}),
+    ...(iconCustomEmojiId !== undefined ? { iconCustomEmojiId } : {}),
+    ...(closed !== undefined ? { closed } : {}),
   };
   if (!merged.name) {
     return;
   }
-  cache.set(key, merged);
-  evictOldest(cache);
-  if (persistedPath) {
-    try {
-      persistTopicStore(persistedPath, cache);
-    } catch (error) {
-      logVerbose(`telegram: failed to persist topic-name cache: ${String(error)}`);
-    }
+  state.store.set(key, merged);
+  await state.persistentStore.register(key, merged);
+  const evictedKey = evictOldest(state.store);
+  if (evictedKey) {
+    await state.persistentStore.delete(evictedKey);
   }
 }
 
-export function getTopicName(
+export async function getTopicName(
   chatId: number | string,
   threadId: number | string,
-  persistedPath?: string,
-): string | undefined {
-  const entry = getTopicStore(persistedPath).get(cacheKey(chatId, threadId));
+  scope?: string,
+): Promise<string | undefined> {
+  const state = getTopicStoreState(scope);
+  await hydrateTopicStoreState(state);
+  const key = cacheKey(chatId, threadId);
+  const entry = state.store.get(key);
   if (entry) {
-    entry.updatedAt = nextUpdatedAt(persistedPath);
+    entry.updatedAt = nextUpdatedAt(scope);
+    await state.persistentStore.register(key, entry);
   }
   return entry?.name;
 }
 
-export function getTopicEntry(
+export async function getTopicEntry(
   chatId: number | string,
   threadId: number | string,
-  persistedPath?: string,
-): TopicEntry | undefined {
-  return getTopicStore(persistedPath).get(cacheKey(chatId, threadId));
+  scope?: string,
+): Promise<TopicEntry | undefined> {
+  return (await getTopicStore(scope)).get(cacheKey(chatId, threadId));
 }
 
-export function clearTopicNameCache(): void {
+export async function clearTopicNameCache(): Promise<void> {
   const state = getTopicNameCacheState();
-  for (const stateKey of state.stores.keys()) {
-    removeTopicStore(stateKey === DEFAULT_TOPIC_NAME_CACHE_KEY ? undefined : stateKey);
-  }
+  await Promise.all(
+    [...state.stores.values()].map((storeState) => storeState.persistentStore.clear()),
+  );
+  state.stores.clear();
 }
 
-export function topicNameCacheSize(): number {
-  return getTopicStore().size;
+export function topicNameCacheSize(scope?: string): number {
+  return getTopicStoreState(scope).store.size;
 }
 
 export function resetTopicNameCacheForTest(): void {
   getTopicNameCacheState().stores.clear();
+}
+
+export function setTelegramTopicNameStoreFactoryForTest(
+  factory: ((namespace: string) => TopicNamePersistentStore) | undefined,
+): void {
+  topicNameStoreFactoryForTest = factory;
 }


### PR DESCRIPTION
Summary:
- Move Telegram botInfo startup cache from per-account JSON sidecars to the plugin KV store.
- Move Telegram forum topic-name cache from sidecar files to scoped plugin KV namespaces.
- Keep regression coverage on startup botInfo reuse/deletion and topic-name persistence across cache resets.

Why:
- These were plugin-owned caches, but they bypassed the core plugin state store. botInfo was introduced after plugin KV already existed; topic names predated it.

Verification:
- node scripts/run-vitest.mjs run extensions/telegram/src/bot-info-cache.test.ts extensions/telegram/src/topic-name-cache.test.ts extensions/telegram/src/channel.gateway.test.ts
- node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
- node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo
- git diff --check
- Telegram bot-to-bot E2E with temp gateway + mock OpenAI: driver message 17722 -> SUT threaded reply 17723, text OPENCLAW_E2E_OK, mockRequests=1, plugin state row telegram.bot-info-cache/default
- Telegram forum topic E2E with temp QA topic: driver message 17725 -> SUT threaded reply 17726 in topic 17724, text OPENCLAW_E2E_OK, mockRequests=1, plugin state row telegram.topic-name-cache.71d57356a5dce902/-1003825137325:17724