### PR TITLE
fix(agents): recover DeepSeek DSML tool markup into synthetic tool calls

### DIFF
--- a/src/agents/embedded-agent-runner-extraparams.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams.test.ts
@@ -733,6 +733,27 @@ describe("applyExtraParamsToAgent", () => {
     expect(messages[2]).not.toHaveProperty("reasoning_content");
   });
 
+  it("does not add DeepSeek V4 thinking params when compat uses OpenAI-style reasoning", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "microsoft-foundry",
+      applyModelId: "deepseek-v4-pro",
+      thinkingLevel: "high",
+      model: {
+        api: "openai-completions",
+        provider: "microsoft-foundry",
+        id: "deepseek-v4-pro",
+        compat: { thinkingFormat: "openai", supportsReasoningEffort: true },
+      } as Model<"openai-completions">,
+      payload: {
+        reasoning_effort: "high",
+        messages: [{ role: "user", content: "hello" }],
+      },
+    });
+
+    expect(payload.reasoning_effort).toBe("high");
+    expect(payload).not.toHaveProperty("thinking");
+  });
+
   it("fills MiMo V2.6 reasoning_content for unowned OpenAI-compatible proxy models", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "opencode",

--- a/src/agents/embedded-agent-runner-extraparams.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams.test.ts
@@ -733,7 +733,7 @@ describe("applyExtraParamsToAgent", () => {
     expect(messages[2]).not.toHaveProperty("reasoning_content");
   });
 
-  it("does not add DeepSeek V4 thinking params when compat uses OpenAI-style reasoning", () => {
+  it("does not add DeepSeek V4 thinking params on the Foundry fallback path", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "microsoft-foundry",
       applyModelId: "deepseek-v4-pro",
@@ -742,7 +742,6 @@ describe("applyExtraParamsToAgent", () => {
         api: "openai-completions",
         provider: "microsoft-foundry",
         id: "deepseek-v4-pro",
-        compat: { thinkingFormat: "openai", supportsReasoningEffort: true },
       } as Model<"openai-completions">,
       payload: {
         reasoning_effort: "high",

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -898,11 +898,9 @@ function normalizeDeepSeekV4CandidateId(modelId: unknown): string | undefined {
 
 function isDeepSeekV4OpenAICompatibleModel(model: Parameters<StreamFn>[0]): boolean {
   const normalizedModelId = normalizeDeepSeekV4CandidateId(model.id);
-  const thinkingFormat = (model as { compat?: { thinkingFormat?: unknown } }).compat
-    ?.thinkingFormat;
   return (
     model.api === "openai-completions" &&
-    thinkingFormat !== "openai" &&
+    model.provider !== "microsoft-foundry" &&
     (normalizedModelId === "deepseek-v4-flash" || normalizedModelId === "deepseek-v4-pro")
   );
 }

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -898,8 +898,11 @@ function normalizeDeepSeekV4CandidateId(modelId: unknown): string | undefined {
 
 function isDeepSeekV4OpenAICompatibleModel(model: Parameters<StreamFn>[0]): boolean {
   const normalizedModelId = normalizeDeepSeekV4CandidateId(model.id);
+  const thinkingFormat = (model as { compat?: { thinkingFormat?: unknown } }).compat
+    ?.thinkingFormat;
   return (
     model.api === "openai-completions" &&
+    thinkingFormat !== "openai" &&
     (normalizedModelId === "deepseek-v4-flash" || normalizedModelId === "deepseek-v4-pro")
   );
 }

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1664,6 +1664,104 @@ describe("openai transport stream", () => {
     expect(JSON.stringify(events)).not.toContain("DSML");
   });
 
+  it("recovers observed DeepSeek DSML parameter tool call emitted as text", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-dsml-tool",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content:
+                  '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="session_status">\n<｜DSML｜parameter name="sessionKey" string="true">current</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>',
+              },
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: "deepseek_dsml_1",
+        name: "session_status",
+        arguments: { sessionKey: "current" },
+        partialArgs: '{"sessionKey":"current"}',
+      },
+    ]);
+    expect(output.stopReason).toBe("toolUse");
+  });
+
+  it("recovers observed DeepSeek DSML parameter tool call split across chunks", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-dsml-tool-split",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content:
+                  '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="session_status">\n<｜DSML｜parameter name="sessionKey" string="true">',
+              },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: "chatcmpl-deepseek-dsml-tool-split",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: "current</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>",
+              },
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: "deepseek_dsml_1",
+        name: "session_status",
+        arguments: { sessionKey: "current" },
+        partialArgs: '{"sessionKey":"current"}',
+      },
+    ]);
+    expect(output.stopReason).toBe("toolUse");
+  });
+
   it("preserves DeepSeek visible content before same-chunk native tool calls", async () => {
     const model = createDeepSeekCompletionsModel();
     const output = createAssistantOutput(model);

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1709,7 +1709,7 @@ describe("openai transport stream", () => {
         type: "toolCall",
         id: "call_native_1",
         name: "read",
-        arguments: {},
+        arguments: { path: "/tmp/test.md" },
         partialArgs: '{"path":"/tmp/test.md"}',
       },
     ]);

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1664,6 +1664,57 @@ describe("openai transport stream", () => {
     expect(JSON.stringify(events)).not.toContain("DSML");
   });
 
+  it("skips DSML recovery when native tool calls are present", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-dsml-native-mix",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content:
+                  '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="session_status">\n<｜DSML｜parameter name="sessionKey" string="true">current</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>',
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "call_native_1",
+                    type: "function",
+                    function: {
+                      name: "read",
+                      arguments: '{"path":"/tmp/test.md"}',
+                    },
+                  },
+                ],
+              },
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: "call_native_1",
+        name: "read",
+        arguments: {},
+        partialArgs: '{"path":"/tmp/test.md"}',
+      },
+    ]);
+  });
+
   it("recovers observed DeepSeek DSML parameter tool call emitted as text", async () => {
     const model = createDeepSeekCompletionsModel();
     const output = createAssistantOutput(model);

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1903,6 +1903,63 @@ describe("openai transport stream", () => {
     expect(output.stopReason).toBe("toolUse");
   });
 
+  it("does not accumulate unbounded non-DSML visible text while waiting for a tool block", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+    const largeVisiblePrefix = "x".repeat(80_000);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-large-prefix",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: { content: largeVisiblePrefix },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: "chatcmpl-deepseek-large-prefix",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content:
+                  '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="session_status">\n<｜DSML｜parameter name="sessionKey" string="true">current</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>',
+              },
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.content).toEqual([
+      { type: "text", text: largeVisiblePrefix },
+      {
+        type: "toolCall",
+        id: "deepseek_dsml_1",
+        name: "session_status",
+        arguments: { sessionKey: "current" },
+        partialArgs: '{"sessionKey":"current"}',
+      },
+    ]);
+    expect(output.stopReason).toBe("toolUse");
+  });
+
   it("preserves DeepSeek visible content before same-chunk native tool calls", async () => {
     const model = createDeepSeekCompletionsModel();
     const output = createAssistantOutput(model);

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1762,6 +1762,96 @@ describe("openai transport stream", () => {
     expect(output.stopReason).toBe("toolUse");
   });
 
+  it("recovers observed DeepSeek DSML tool call while preserving surrounding visible text", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-dsml-visible",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content:
+                  'Hello! <｜DSML｜tool_calls>\n<｜DSML｜invoke name="session_status">\n<｜DSML｜parameter name="sessionKey" string="true">current</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls> Done.',
+              },
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.content).toEqual([
+      { type: "text", text: "Hello!  Done." },
+      {
+        type: "toolCall",
+        id: "deepseek_dsml_1",
+        name: "session_status",
+        arguments: { sessionKey: "current" },
+        partialArgs: '{"sessionKey":"current"}',
+      },
+    ]);
+    expect(output.stopReason).toBe("toolUse");
+  });
+
+  it("recovers multiple DSML invoke entries in a single response", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-dsml-multiple",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content:
+                  '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="session_status">\n<｜DSML｜parameter name="sessionKey" string="true">current</｜DSML｜parameter>\n</｜DSML｜invoke>\n<｜DSML｜invoke name="read">\n<｜DSML｜parameter name="path" string="true">/tmp/test.md</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>',
+              },
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: "deepseek_dsml_1",
+        name: "session_status",
+        arguments: { sessionKey: "current" },
+        partialArgs: '{"sessionKey":"current"}',
+      },
+      {
+        type: "toolCall",
+        id: "deepseek_dsml_2",
+        name: "read",
+        arguments: { path: "/tmp/test.md" },
+        partialArgs: '{"path":"/tmp/test.md"}',
+      },
+    ]);
+    expect(output.stopReason).toBe("toolUse");
+  });
+
   it("preserves DeepSeek visible content before same-chunk native tool calls", async () => {
     const model = createDeepSeekCompletionsModel();
     const output = createAssistantOutput(model);

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2639,7 +2639,6 @@ async function processOpenAICompletionsStream(
       for (const part of parts) {
         appendVisibleTextDelta(part);
       }
-      tryFlushDeepSeekDsmlToolText(false);
       return;
     }
     appendVisibleTextDelta(text);

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2491,6 +2491,7 @@ async function processOpenAICompletionsStream(
     : null;
   let pendingDeepSeekDsmlText = "";
   let deepSeekDsmlSyntheticCallCount = 0;
+  let hasSeenNativeToolCalls = false;
   type ToolCallBlock = {
     type: "toolCall";
     id: string;
@@ -2659,6 +2660,9 @@ async function processOpenAICompletionsStream(
     return true;
   };
   const tryFlushDeepSeekDsmlToolText = (final: boolean) => {
+    if (hasSeenNativeToolCalls) {
+      return false;
+    }
     if (!pendingDeepSeekDsmlText) {
       return false;
     }
@@ -2777,6 +2781,7 @@ async function processOpenAICompletionsStream(
       }
     }
     if (choiceDelta.tool_calls && choiceDelta.tool_calls.length > 0) {
+      hasSeenNativeToolCalls = true;
       for (const toolCall of choiceDelta.tool_calls) {
         const streamIndex = typeof toolCall.index === "number" ? toolCall.index : undefined;
         let block = streamIndex !== undefined ? toolCallBlocksByIndex.get(streamIndex) : undefined;

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2623,12 +2623,10 @@ async function processOpenAICompletionsStream(
     if (deepSeekTextFilter) {
       pendingDeepSeekDsmlText += text;
       const parts = deepSeekTextFilter.push(text);
-      const recovered = tryFlushDeepSeekDsmlToolText(false);
-      if (!recovered) {
-        for (const part of parts) {
-          appendVisibleTextDelta(part);
-        }
+      for (const part of parts) {
+        appendVisibleTextDelta(part);
       }
+      tryFlushDeepSeekDsmlToolText(false);
       return;
     }
     appendVisibleTextDelta(text);
@@ -2647,7 +2645,7 @@ async function processOpenAICompletionsStream(
       type: "toolCall",
       id: `deepseek_dsml_${++deepSeekDsmlSyntheticCallCount}`,
       name,
-      arguments: parsedArgs as Record<string, unknown>,
+      arguments: parsedArgs,
       partialArgs,
     };
     output.content.push(currentBlock);
@@ -2696,12 +2694,12 @@ async function processOpenAICompletionsStream(
         const fenceMatch = trimmedBody.match(DEEPSEEK_DSML_JSON_FENCE_RE);
         argsText = (fenceMatch?.[1] ?? trimmedBody).trim();
       }
-      matched ||= emitDeepSeekDsmlToolCall(name, argsText);
+      if (emitDeepSeekDsmlToolCall(name, argsText)) {
+        matched = true;
+      }
     }
     if (matched) {
       output.stopReason = "toolUse";
-    } else if (final) {
-      appendVisibleTextDelta(source);
     }
     return matched;
   };

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -83,6 +83,12 @@ const OPENAI_CODEX_RESPONSES_EMPTY_INPUT_TEXT = " ";
 const OPENAI_CODEX_RESPONSES_DEFAULT_INSTRUCTIONS = "Follow the user request.";
 const GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP = "skip_thought_signature_validator";
 const AZURE_RESPONSES_FIRST_EVENT_TIMEOUT_MS = 30_000;
+const DEEPSEEK_DSML_TOOL_CALLS_END = /<[/]?[｜|]DSML[｜|]tool_calls>/giu;
+const DEEPSEEK_DSML_INVOKE_RE =
+  /<[｜|]DSML[｜|]invoke\s+name="([^"]+)"\s*>\s*([\s\S]*?)\s*<\/[｜|]DSML[｜|]invoke>/giu;
+const DEEPSEEK_DSML_PARAMETER_RE =
+  /<[｜|]DSML[｜|]parameter\s+name="([^"]+)"(?:\s+[^>]*)?>([\s\S]*?)<\/[｜|]DSML[｜|]parameter>/giu;
+const DEEPSEEK_DSML_JSON_FENCE_RE = /^```(?:json)?\s*([\s\S]*?)\s*```$/iu;
 const MODEL_STREAM_COOPERATIVE_YIELD_INTERVAL_MS = 12;
 const MODEL_STREAM_COOPERATIVE_YIELD_MAX_EVENTS = 64;
 const RESPONSE_FAILED_NO_DETAILS_MESSAGE = "Unknown error (no error details in response)";
@@ -2483,6 +2489,8 @@ async function processOpenAICompletionsStream(
   const deepSeekTextFilter = shouldFilterDeepSeekDsmlText(compat)
     ? createDeepSeekTextFilter()
     : null;
+  let pendingDeepSeekDsmlText = "";
+  let deepSeekDsmlSyntheticCallCount = 0;
   type ToolCallBlock = {
     type: "toolCall";
     id: string;
@@ -2612,19 +2620,99 @@ async function processOpenAICompletionsStream(
     }
   };
   const appendFilteredVisibleTextDelta = (text: string) => {
-    const parts = deepSeekTextFilter?.push(text) ?? [text];
-    for (const part of parts) {
-      appendVisibleTextDelta(part);
+    if (deepSeekTextFilter) {
+      pendingDeepSeekDsmlText += text;
+      const parts = deepSeekTextFilter.push(text);
+      const recovered = tryFlushDeepSeekDsmlToolText(false);
+      if (!recovered) {
+        for (const part of parts) {
+          appendVisibleTextDelta(part);
+        }
+      }
+      return;
     }
+    appendVisibleTextDelta(text);
+  };
+  const emitDeepSeekDsmlToolCall = (name: string, argsText: string) => {
+    const partialArgs = argsText.trim();
+    if (!partialArgs) {
+      return false;
+    }
+    const parsedArgs = parseStreamingJson(partialArgs);
+    if (!parsedArgs || typeof parsedArgs !== "object" || Array.isArray(parsedArgs)) {
+      return false;
+    }
+    finishCurrentBlock();
+    currentBlock = {
+      type: "toolCall",
+      id: `deepseek_dsml_${++deepSeekDsmlSyntheticCallCount}`,
+      name,
+      arguments: parsedArgs as Record<string, unknown>,
+      partialArgs,
+    };
+    output.content.push(currentBlock);
+    stream.push({ type: "toolcall_start", contentIndex: blockIndex(), partial: output });
+    stream.push({
+      type: "toolcall_delta",
+      contentIndex: blockIndex(),
+      delta: partialArgs,
+      partial: output,
+    });
+    return true;
+  };
+  const tryFlushDeepSeekDsmlToolText = (final: boolean) => {
+    if (!pendingDeepSeekDsmlText) {
+      return false;
+    }
+    const closeMatches = [...pendingDeepSeekDsmlText.matchAll(DEEPSEEK_DSML_TOOL_CALLS_END)];
+    const hasClosingTag = closeMatches.some((match) => match[0].startsWith("</"));
+    if (!final && !hasClosingTag) {
+      return false;
+    }
+    const source = pendingDeepSeekDsmlText;
+    pendingDeepSeekDsmlText = "";
+    let matched = false;
+    for (const invokeMatch of source.matchAll(DEEPSEEK_DSML_INVOKE_RE)) {
+      const name = invokeMatch[1]?.trim();
+      const body = invokeMatch[2] ?? "";
+      if (!name) {
+        continue;
+      }
+      let argsText = "";
+      const params = [...body.matchAll(DEEPSEEK_DSML_PARAMETER_RE)];
+      if (params.length > 0) {
+        const args: Record<string, unknown> = {};
+        for (const paramMatch of params) {
+          const paramName = paramMatch[1]?.trim();
+          const rawValue = (paramMatch[2] ?? "").trim();
+          if (!paramName) {
+            continue;
+          }
+          args[paramName] = rawValue;
+        }
+        argsText = JSON.stringify(args);
+      } else {
+        const trimmedBody = body.trim();
+        const fenceMatch = trimmedBody.match(DEEPSEEK_DSML_JSON_FENCE_RE);
+        argsText = (fenceMatch?.[1] ?? trimmedBody).trim();
+      }
+      matched ||= emitDeepSeekDsmlToolCall(name, argsText);
+    }
+    if (matched) {
+      output.stopReason = "toolUse";
+    } else if (final) {
+      appendVisibleTextDelta(source);
+    }
+    return matched;
   };
   const flushDeepSeekTextFilterAtEnd = () => {
     const parts = deepSeekTextFilter?.flush();
-    if (!parts) {
-      return;
+    if (parts) {
+      for (const part of parts) {
+        appendVisibleTextDelta(part);
+      }
     }
-    for (const part of parts) {
-      appendVisibleTextDelta(part);
-    }
+    tryFlushDeepSeekDsmlToolText(true);
   };
   const cooperativeScheduler = createModelStreamCooperativeScheduler(options?.signal);
   for await (const rawChunk of responseStream as AsyncIterable<unknown>) {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2751,6 +2751,9 @@ async function processOpenAICompletionsStream(
       await cooperativeScheduler.afterEvent();
       continue;
     }
+    if (choiceDelta.tool_calls && choiceDelta.tool_calls.length > 0) {
+      hasSeenNativeToolCalls = true;
+    }
     if (choiceDelta.content) {
       // Structured content can contain visible text and thinking blocks in the
       // same delta, so route each extracted block through the normal stream path.

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2688,7 +2688,7 @@ async function processOpenAICompletionsStream(
       }
       const closeMatch = DEEPSEEK_DSML_CLOSE_RE.exec(deepSeekDsmlBuffer);
       if (!closeMatch || closeMatch.index === undefined) {
-        if (final || !deepSeekDsmlBuffer.match(DEEPSEEK_DSML_END_RE)) {
+        if (final || !DEEPSEEK_DSML_END_RE.test(deepSeekDsmlBuffer)) {
           deepSeekDsmlBuffer = final ? "" : deepSeekDsmlBuffer;
         }
         return matched;

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -83,12 +83,15 @@ const OPENAI_CODEX_RESPONSES_EMPTY_INPUT_TEXT = " ";
 const OPENAI_CODEX_RESPONSES_DEFAULT_INSTRUCTIONS = "Follow the user request.";
 const GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP = "skip_thought_signature_validator";
 const AZURE_RESPONSES_FIRST_EVENT_TIMEOUT_MS = 30_000;
-const DEEPSEEK_DSML_TOOL_CALLS_END = /<[/]?[｜|]DSML[｜|]tool_calls>/giu;
+const DEEPSEEK_DSML_OPEN_RE = /<[｜|]DSML[｜|]tool_calls>/iu;
+const DEEPSEEK_DSML_CLOSE_RE = /<\/[｜|]DSML[｜|]tool_calls>/iu;
+const DEEPSEEK_DSML_END_RE = /<\/[｜|]DSML[｜|]tool_calls>/giu;
 const DEEPSEEK_DSML_INVOKE_RE =
   /<[｜|]DSML[｜|]invoke\s+name="([^"]+)"\s*>\s*([\s\S]*?)\s*<\/[｜|]DSML[｜|]invoke>/giu;
 const DEEPSEEK_DSML_PARAMETER_RE =
   /<[｜|]DSML[｜|]parameter\s+name="([^"]+)"(?:\s+[^>]*)?>([\s\S]*?)<\/[｜|]DSML[｜|]parameter>/giu;
 const DEEPSEEK_DSML_JSON_FENCE_RE = /^```(?:json)?\s*([\s\S]*?)\s*```$/iu;
+const MAX_DEEPSEEK_DSML_BUFFER_BYTES = 64_000;
 const MODEL_STREAM_COOPERATIVE_YIELD_INTERVAL_MS = 12;
 const MODEL_STREAM_COOPERATIVE_YIELD_MAX_EVENTS = 64;
 const RESPONSE_FAILED_NO_DETAILS_MESSAGE = "Unknown error (no error details in response)";
@@ -2489,7 +2492,7 @@ async function processOpenAICompletionsStream(
   const deepSeekTextFilter = shouldFilterDeepSeekDsmlText(compat)
     ? createDeepSeekTextFilter()
     : null;
-  let pendingDeepSeekDsmlText = "";
+  let deepSeekDsmlBuffer = "";
   let deepSeekDsmlSyntheticCallCount = 0;
   let hasSeenNativeToolCalls = false;
   type ToolCallBlock = {
@@ -2622,7 +2625,16 @@ async function processOpenAICompletionsStream(
   };
   const appendFilteredVisibleTextDelta = (text: string) => {
     if (deepSeekTextFilter) {
-      pendingDeepSeekDsmlText += text;
+      if (!hasSeenNativeToolCalls) {
+        deepSeekDsmlBuffer += text;
+        if (measureUtf8Bytes(deepSeekDsmlBuffer) > MAX_DEEPSEEK_DSML_BUFFER_BYTES) {
+          const openMatch = deepSeekDsmlBuffer.match(DEEPSEEK_DSML_OPEN_RE);
+          deepSeekDsmlBuffer = openMatch ? deepSeekDsmlBuffer.slice(openMatch.index ?? 0) : "";
+          if (measureUtf8Bytes(deepSeekDsmlBuffer) > MAX_DEEPSEEK_DSML_BUFFER_BYTES) {
+            deepSeekDsmlBuffer = "";
+          }
+        }
+      }
       const parts = deepSeekTextFilter.push(text);
       for (const part of parts) {
         appendVisibleTextDelta(part);
@@ -2660,48 +2672,62 @@ async function processOpenAICompletionsStream(
     return true;
   };
   const tryFlushDeepSeekDsmlToolText = (final: boolean) => {
-    if (hasSeenNativeToolCalls) {
+    if (hasSeenNativeToolCalls || !deepSeekDsmlBuffer) {
       return false;
     }
-    if (!pendingDeepSeekDsmlText) {
-      return false;
-    }
-    const closeMatches = [...pendingDeepSeekDsmlText.matchAll(DEEPSEEK_DSML_TOOL_CALLS_END)];
-    const hasClosingTag = closeMatches.some((match) => match[0].startsWith("</"));
-    if (!final && !hasClosingTag) {
-      return false;
-    }
-    const source = pendingDeepSeekDsmlText;
-    pendingDeepSeekDsmlText = "";
+
     let matched = false;
-    for (const invokeMatch of source.matchAll(DEEPSEEK_DSML_INVOKE_RE)) {
-      const name = invokeMatch[1]?.trim();
-      const body = invokeMatch[2] ?? "";
-      if (!name) {
-        continue;
+    while (deepSeekDsmlBuffer) {
+      const openIndex = deepSeekDsmlBuffer.search(DEEPSEEK_DSML_OPEN_RE);
+      if (openIndex === -1) {
+        deepSeekDsmlBuffer = "";
+        return matched;
       }
-      let argsText = "";
-      const params = [...body.matchAll(DEEPSEEK_DSML_PARAMETER_RE)];
-      if (params.length > 0) {
-        const args: Record<string, unknown> = {};
-        for (const paramMatch of params) {
-          const paramName = paramMatch[1]?.trim();
-          const rawValue = (paramMatch[2] ?? "").trim();
-          if (!paramName) {
-            continue;
-          }
-          args[paramName] = rawValue;
+      if (openIndex > 0) {
+        deepSeekDsmlBuffer = deepSeekDsmlBuffer.slice(openIndex);
+      }
+      const closeMatch = DEEPSEEK_DSML_CLOSE_RE.exec(deepSeekDsmlBuffer);
+      if (!closeMatch || closeMatch.index === undefined) {
+        if (final || !deepSeekDsmlBuffer.match(DEEPSEEK_DSML_END_RE)) {
+          deepSeekDsmlBuffer = final ? "" : deepSeekDsmlBuffer;
         }
-        argsText = JSON.stringify(args);
-      } else {
-        const trimmedBody = body.trim();
-        const fenceMatch = trimmedBody.match(DEEPSEEK_DSML_JSON_FENCE_RE);
-        argsText = (fenceMatch?.[1] ?? trimmedBody).trim();
+        return matched;
       }
-      if (emitDeepSeekDsmlToolCall(name, argsText)) {
-        matched = true;
+
+      const endIndex = closeMatch.index + closeMatch[0].length;
+      const source = deepSeekDsmlBuffer.slice(0, endIndex);
+      deepSeekDsmlBuffer = deepSeekDsmlBuffer.slice(endIndex);
+
+      for (const invokeMatch of source.matchAll(DEEPSEEK_DSML_INVOKE_RE)) {
+        const name = invokeMatch[1]?.trim();
+        const body = invokeMatch[2] ?? "";
+        if (!name) {
+          continue;
+        }
+        let argsText = "";
+        const params = [...body.matchAll(DEEPSEEK_DSML_PARAMETER_RE)];
+        if (params.length > 0) {
+          const args: Record<string, unknown> = {};
+          for (const paramMatch of params) {
+            const paramName = paramMatch[1]?.trim();
+            const rawValue = (paramMatch[2] ?? "").trim();
+            if (!paramName) {
+              continue;
+            }
+            args[paramName] = rawValue;
+          }
+          argsText = JSON.stringify(args);
+        } else {
+          const trimmedBody = body.trim();
+          const fenceMatch = trimmedBody.match(DEEPSEEK_DSML_JSON_FENCE_RE);
+          argsText = (fenceMatch?.[1] ?? trimmedBody).trim();
+        }
+        if (emitDeepSeekDsmlToolCall(name, argsText)) {
+          matched = true;
+        }
       }
     }
+
     if (matched) {
       output.stopReason = "toolUse";
     }
@@ -2714,7 +2740,11 @@ async function processOpenAICompletionsStream(
         appendVisibleTextDelta(part);
       }
     }
-    tryFlushDeepSeekDsmlToolText(true);
+    const matched = tryFlushDeepSeekDsmlToolText(true);
+    if (matched) {
+      output.stopReason = "toolUse";
+    }
+    deepSeekDsmlBuffer = "";
   };
   const cooperativeScheduler = createModelStreamCooperativeScheduler(options?.signal);
   for await (const rawChunk of responseStream as AsyncIterable<unknown>) {
@@ -2857,6 +2887,9 @@ async function processOpenAICompletionsStream(
   const hasToolCalls = output.content.some((block) => block.type === "toolCall");
   if (output.stopReason === "toolUse" && !hasToolCalls) {
     output.stopReason = "stop";
+  }
+  if (output.stopReason === "stop" && hasToolCalls && deepSeekDsmlSyntheticCallCount > 0) {
+    output.stopReason = "toolUse";
   }
 }
 


### PR DESCRIPTION
## Summary
`microsoft-foundry/deepseek-v4-pro` can emit DSML tool markup as plain assistant text on the `openai-completions` route instead of native `tool_calls`. This PR adds a conservative recovery path that turns complete, valid DSML `invoke` blocks into synthetic `toolCall` blocks while preserving surrounding visible text and emitting every valid invoke in the response.

This branch now also includes the missing Foundry fallback fix that stops the generic DeepSeek V4 thinking wrapper from injecting unsupported `payload.thinking` on the Foundry-hosted OpenAI-compatible route. Without that, the real CLI proof for the DSML fix was blocked earlier by `400 Unrecognized request argument supplied: thinking` before tool execution could even be exercised.

## What changed
- recover complete DeepSeek DSML `tool_calls` text blocks into synthetic `toolCall` events in `src/agents/openai-transport-stream.ts`
- preserve visible text around recovered DSML markup
- emit every valid recovered `invoke` entry in a DSML block
- keep malformed or incomplete DSML non-executable
- skip the generic DeepSeek V4 thinking wrapper on the `microsoft-foundry` fallback path so the real Foundry route can be exercised without the earlier request-shaping failure
- add focused regression tests for both the DSML recovery behavior and the Foundry fallback-path guard

## Real behavior proof

- **Behavior addressed**: DeepSeek V4 (`microsoft-foundry/deepseek-v4-pro`) request-shaping/thinking-wrapper failures on OpenAI-compatible routes, and mixed same-chunk stream processing precedence causing duplicate synthetic + native tool call execution.
- **Real environment tested**: local macOS operator environment, source build of OpenClaw 2026.5.24 (`f52dcddb04`).
- **Exact steps or command run after this patch**:
  Run unit tests verifying same-chunk native tool calls win and suppress synthetic recovery:
  ```bash
  ./node_modules/.bin/vitest run src/agents/openai-transport-stream.test.ts -t 'skips DSML recovery'
  ```
  Run live one-shot model inference to verify Foundry request execution:
  ```bash
  node openclaw.mjs infer model run --model microsoft-foundry/deepseek-v4-pro --prompt "Reply with exactly HELLO_FOUNDRY" --local --json
  ```
- **Evidence**: Copied CLI stdout of successful local test execution and live model run.
- **Observed result**:
  All unit tests for same-chunk precedence passed successfully:
  ```
  ✓ agents-core ../../src/agents/openai-transport-stream.test.ts (197 tests | 196 skipped)
  ✓ agents-support ../../src/agents/openai-transport-stream.test.ts (197 tests | 196 skipped)
  ```
  Live inference correctly skipped `payload.thinking` and returned `HELLO_FOUNDRY` cleanly:
  ```json
  {
    "ok": true,
    "capability": "model.run",
    "transport": "local",
    "provider": "microsoft-foundry",
    "model": "deepseek-v4-pro",
    "outputs": [
      {
        "text": "HELLO_FOUNDRY",
        "mediaUrl": null
      }
    ]
  }
  ```
- **Not tested**: Direct native `deepseek/...` API endpoints since only the Microsoft Foundry-hosted route is currently configured in this environment.

## Original live evidence for the DSML symptom
Installed runtime checked locally before the patched-build proof work:
- `openclaw --version` -> `OpenClaw 2026.5.20 (e510042)`

Tool-use repro against the real CLI/runtime:
```bash
openclaw agent --local --agent main --model microsoft-foundry/deepseek-v4-pro --thinking minimal --message 'Call the session_status tool exactly once with sessionKey current and then stop.' --json
```

Observed assistant payload returned as visible text instead of an executed tool call:
```xml
<｜DSML｜tool_calls>
<｜DSML｜invoke name="session_status">
<｜DSML｜parameter name="sessionKey" string="true">current</｜DSML｜parameter>
</｜DSML｜invoke>
</｜DSML｜tool_calls>
```

A second live variant was malformed/incomplete and omitted the parameter body entirely:
```xml
<｜DSML｜tool_calls>
<｜DSML｜invoke name="session_status">
</｜DSML｜invoke>
</｜DSML｜tool_calls>
```

Subagent/history verification also showed that the tool was not actually executed; the markup was emitted as assistant text.

## Source diagnosis
Relevant repo inspected locally at `/Users/manos/Code/openclaw`.

### What the current code did before this patch
`src/agents/deepseek-text-filter.ts` strips DSML wrapper text from visible output.

`src/agents/openai-transport-stream.ts` used that filter in `processOpenAICompletionsStream(...)`, but executable tool calls still came only from native `choiceDelta.tool_calls`.

So the prior behavior was:
- if DeepSeek/Foundry emitted native `tool_calls`, OpenClaw could handle them
- if DeepSeek/Foundry emitted DSML tool markup as plain text, OpenClaw filtered/streamed text but did not promote it to `toolCall`

### Why this is likely not just expected model behavior
DeepSeek's own tool-calls docs describe OpenAI-compatible native `message.tool_calls` as the intended path:
- https://api-docs.deepseek.com/guides/tool_calls

There is also upstream evidence that DeepSeek V4 Pro can intermittently emit tool calls as plain text with `tool_calls: null`:
- https://github.com/deepseek-ai/DeepSeek-V3/issues/1244

So the remaining problem looks like a combination of:
1. upstream/provider instability in DeepSeek tool emission
2. missing defensive recovery in OpenClaw for DSML/textual tool intent on the `openai-completions` stream path

## Validation
Targeted tests run locally:
```bash
pnpm exec vitest run src/agents/openai-transport-stream.test.ts -t 'DeepSeek DSML|tool calls'
pnpm exec vitest run src/agents/pi-embedded-runner-extraparams.test.ts -t 'DeepSeek V4|MiMo V2.6'
git diff --check
pnpm build
```

Results:
- `src/agents/openai-transport-stream.test.ts`: 2 files passed, 18 tests passed, 374 skipped
- `src/agents/pi-embedded-runner-extraparams.test.ts`: 2 files passed, 6 tests passed, 250 skipped
- `git diff --check`: clean
- `pnpm build`: succeeded

## Labels / framing suggestion
- bug
- providers
- microsoft-foundry
- deepseek
- streaming
- tool-calls