### PR TITLE
Fix Control UI CJK IME composition

### DIFF
--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1650,6 +1650,66 @@ describe("chat slash menu accessibility", () => {
   });
 });
 
+describe("chat composer IME composition", () => {
+  it("defers draft sync while IME composition is active", () => {
+    const onDraftChange = vi.fn();
+    const container = renderChatView({ onDraftChange });
+    const textarea = requireElement(
+      container,
+      ".agent-chat__composer-combobox > textarea",
+      "composer textarea",
+    ) as HTMLTextAreaElement;
+
+    textarea.dispatchEvent(new CompositionEvent("compositionstart", { bubbles: true }));
+    textarea.value = "dangqian";
+    textarea.dispatchEvent(new InputEvent("input", { bubbles: true, isComposing: true }));
+
+    expect(onDraftChange).not.toHaveBeenCalled();
+
+    textarea.value = "当前";
+    textarea.dispatchEvent(new CompositionEvent("compositionend", { bubbles: true }));
+
+    expect(onDraftChange).toHaveBeenCalledTimes(1);
+    expect(onDraftChange).toHaveBeenLastCalledWith("当前");
+  });
+
+  it("preserves composing text across host rerenders with stale draft props", () => {
+    const onDraftChange = vi.fn();
+    const onRequestUpdate = vi.fn();
+    const container = document.createElement("div");
+    const props = createChatProps({ draft: "", onDraftChange, onRequestUpdate });
+
+    render(renderChat(props), container);
+    const textarea = requireElement(
+      container,
+      ".agent-chat__composer-combobox > textarea",
+      "composer textarea",
+    ) as HTMLTextAreaElement;
+
+    textarea.dispatchEvent(new CompositionEvent("compositionstart", { bubbles: true }));
+    textarea.value = "dangqian";
+    textarea.dispatchEvent(new InputEvent("input", { bubbles: true, isComposing: true }));
+
+    expect(onDraftChange).not.toHaveBeenCalled();
+    expect(onRequestUpdate).not.toHaveBeenCalled();
+
+    render(renderChat({ ...props, draft: "" }), container);
+
+    expect(container.querySelector<HTMLTextAreaElement>("textarea")?.value).toBe("dangqian");
+
+    const rerenderedTextarea = requireElement(
+      container,
+      ".agent-chat__composer-combobox > textarea",
+      "composer textarea",
+    ) as HTMLTextAreaElement;
+    rerenderedTextarea.value = "当前";
+    rerenderedTextarea.dispatchEvent(new CompositionEvent("compositionend", { bubbles: true }));
+
+    expect(onDraftChange).toHaveBeenCalledTimes(1);
+    expect(onDraftChange).toHaveBeenLastCalledWith("当前");
+  });
+});
+
 describe("chat attachment picker", () => {
   it("converts pasted data image text into an attachment", () => {
     const onAttachmentsChange = vi.fn();

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -457,6 +457,7 @@ interface ChatEphemeralState {
   searchOpen: boolean;
   searchQuery: string;
   pinnedExpanded: boolean;
+  composerComposing: boolean;
   historyRenderSessionKey: string | null;
   historyRenderMessagesRef: unknown[] | null;
   historyRenderMessageCount: number;
@@ -482,6 +483,7 @@ function createChatEphemeralState(): ChatEphemeralState {
     searchOpen: false,
     searchQuery: "",
     pinnedExpanded: false,
+    composerComposing: false,
     historyRenderSessionKey: null,
     historyRenderMessagesRef: null,
     historyRenderMessageCount: 0,
@@ -1933,12 +1935,19 @@ export function renderChat(props: ChatProps) {
     }
   };
 
-  const handleInput = (e: Event) => {
-    const target = e.target as HTMLTextAreaElement;
+  const syncComposerValue = (
+    target: HTMLTextAreaElement,
+    options: { forceCommit?: boolean } = {},
+  ) => {
     adjustTextareaHeight(target);
     draftMirror.value = target.value;
     const hostDraftNeeded = isBusy || showAbortableUi || props.queue.length > 0;
-    if (hostDraftNeeded || target.value.startsWith("/") || hasVisibleSlashMenuState()) {
+    if (
+      options.forceCommit ||
+      hostDraftNeeded ||
+      target.value.startsWith("/") ||
+      hasVisibleSlashMenuState()
+    ) {
       commitComposerDraft(props, target.value);
     }
     updateSlashMenu(target.value, requestUpdate);
@@ -1951,6 +1960,21 @@ export function renderChat(props: ChatProps) {
     commitComposerDraft(props, draftMirror.value);
     props.onSend();
     syncComposerDraftAfterSend(composerTextarea);
+  };
+
+  const handleInput = (e: InputEvent) => {
+    const target = e.target as HTMLTextAreaElement;
+    if (vs.composerComposing || e.isComposing) {
+      adjustTextareaHeight(target);
+      draftMirror.value = target.value;
+      return;
+    }
+    syncComposerValue(target);
+  };
+
+  const handleCompositionEnd = (e: CompositionEvent) => {
+    vs.composerComposing = false;
+    syncComposerValue(e.target as HTMLTextAreaElement, { forceCommit: true });
   };
   const slashMenuVisible = isSlashMenuVisible();
   const activeSlashMenuOptionId = getActiveSlashMenuOptionId();
@@ -2114,6 +2138,10 @@ export function renderChat(props: ChatProps) {
             aria-describedby=${SLASH_MENU_ACTIVE_ANNOUNCEMENT_ID}
             @keydown=${handleKeyDown}
             @input=${handleInput}
+            @compositionstart=${() => {
+              vs.composerComposing = true;
+            }}
+            @compositionend=${handleCompositionEnd}
             @blur=${handleBlur}
             @paste=${(e: ClipboardEvent) => handlePaste(e, props)}
             placeholder=${placeholder}


### PR DESCRIPTION
## Summary

- defer chat composer draft synchronization while browser IME composition is active
- sync the committed composer value on `compositionend`
- add a regression test for composing pinyin and committing Chinese text

Fixes #86035

## Real behavior proof

- **Behavior or issue addressed:** Control UI chat composer no longer overwrites the browser/macOS IME composition buffer while CJK text is being composed. The textarea now defers draft synchronization during composition and syncs the committed value on `compositionend`.
- **Real environment tested:** Local OpenClaw gateway on macOS, OpenClaw `2026.5.22 (a374c3a)` with this patch applied to the deployed Control UI bundle, Google Chrome, `http://127.0.0.1:18790/chat`, macOS Chinese/CJK input path.
- **Exact steps or command run after this patch:** Opened `http://127.0.0.1:18790/chat` in Google Chrome via Computer Use, focused `.agent-chat__composer-combobox > textarea`, entered committed Chinese text in the chat composer, and confirmed the composer retained the Chinese text instead of raw pinyin. Also verified the running local gateway and deployed bundle from the terminal.
- **Evidence after fix:** Browser evidence: a local screenshot captured with Computer Use/screencapture shows the OpenClaw Control UI composer containing `当前输入法验证：中文候选已提交到聊天输入框` at `127.0.0.1:18790/chat`. Terminal live output from the same setup:

```text
COMMAND   PID USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
node    86905  zqj   18u  IPv4 ... TCP 127.0.0.1:18790 (LISTEN)
node    86905  zqj   19u  IPv6 ... TCP [::1]:18790 (LISTEN)
HTTP/1.1 200 OK
Content-Type: text/html; charset=utf-8
Cache-Control: no-cache
Date: Wed, 03 Jun 2026 03:26:35 GMT

index-BtIuF4zW.js
composerComposing true
compositionstart true
compositionend true
```

- **Observed result after fix:** In the live Chrome Control UI, the chat composer kept the committed Chinese string `当前输入法验证：中文候选已提交到聊天输入框`; the running bundle contains the composition guard state and both `compositionstart`/`compositionend` handlers, and `/chat` was served successfully by the local gateway.
- **What was not tested:** I did not run a full multilingual matrix for Japanese and Korean IMEs; the code path is the same browser composition event handling used by CJK IMEs.

## Test plan

- `corepack pnpm --dir ui exec vitest run --config vitest.config.ts src/ui/views/chat.test.ts`
- `corepack pnpm --dir ui build`

## Notes

I also tried `corepack pnpm --dir ui test -- ui/src/ui/views/chat.test.ts`, but that script invocation ran the full UI suite instead of only the target file and hit unrelated local setup failures: missing Playwright browser binaries and path/import issues outside this change. The direct Vitest command above was used for the targeted test run.
