### PR TITLE
fix(media-understanding): normalize HEIC before image descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Discord/OpenAI voice: accept leading fuzzy wake-name transcripts such as "Monty" or "Moti" for a Molty agent while keeping ambient speech gated.
+- Media understanding: convert HEIC and HEIF images to JPEG before image description providers run so iPhone photos work in direct and configured image-description flows. (#86037)
 - Discord/OpenAI voice: rotate Realtime sessions at provider max duration without logging the expected session-expiry event as an error.
 - Memory/local embeddings: run local GGUF embeddings in an isolated worker sidecar and degrade to configured fallback or keyword search on worker failure so native embedding crashes do not take down the Gateway. (#85348) Thanks @osolmaz.
 - Gateway: clear the runtime config snapshot before `SIGUSR1` in-process restarts so config changes survive the next gateway loop. (#86388) Thanks @XuZehan-iCenter.

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -27,6 +27,7 @@ const hasAvailableAuthForProviderMock = vi.hoisted(() =>
 );
 const readRemoteMediaBufferMock = vi.hoisted(() => vi.fn());
 const runFfmpegMock = vi.hoisted(() => vi.fn());
+const convertHeicToJpegMock = vi.hoisted(() => vi.fn());
 const runExecMock = vi.hoisted(() => vi.fn());
 
 let applyMediaUnderstanding: typeof import("./apply.js").applyMediaUnderstanding;
@@ -34,6 +35,7 @@ let clearMediaUnderstandingBinaryCacheForTests: typeof import("./runner.js").cle
 const mockedResolveApiKey = resolveApiKeyForProviderMock;
 const mockedReadRemoteMediaBuffer = readRemoteMediaBufferMock;
 const mockedRunFfmpeg = runFfmpegMock;
+const mockedConvertHeicToJpeg = convertHeicToJpegMock;
 const mockedRunExec = runExecMock;
 
 const TEMP_MEDIA_PREFIX = "openclaw-media-";
@@ -284,6 +286,7 @@ describe("applyMediaUnderstanding", () => {
     }));
     vi.doMock("../media/media-services.js", () => ({
       runFfmpeg: runFfmpegMock,
+      convertHeicToJpeg: convertHeicToJpegMock,
     }));
     vi.doMock("../process/exec.js", () => ({
       runExec: runExecMock,
@@ -336,6 +339,8 @@ describe("applyMediaUnderstanding", () => {
     hasAvailableAuthForProviderMock.mockClear();
     mockedReadRemoteMediaBuffer.mockClear();
     mockedRunFfmpeg.mockReset();
+    mockedConvertHeicToJpeg.mockReset();
+    mockedConvertHeicToJpeg.mockResolvedValue(Buffer.from("jpeg-normalized"));
     mockedRunExec.mockReset();
     mockedReadRemoteMediaBuffer.mockResolvedValue({
       buffer: createSafeAudioFixtureBuffer(2048),
@@ -1158,6 +1163,53 @@ describe("applyMediaUnderstanding", () => {
         model: "gpt-5.4",
       }),
     );
+  });
+
+  it("normalizes HEIC images before tools.media.image provider execution", async () => {
+    const imagePath = await createTempMediaFile({
+      fileName: "photo.heic",
+      content: "heic-source",
+    });
+    const describeImage = vi.fn(async () => ({ text: "normalized image" }));
+    const ctx: MsgContext = {
+      Body: "<media:image>",
+      MediaPath: imagePath,
+      MediaType: "image/heic",
+    };
+    const cfg: OpenClawConfig = {
+      tools: {
+        media: {
+          image: {
+            enabled: true,
+            models: [{ provider: "openai", model: "gpt-5.4" }],
+          },
+        },
+      },
+    };
+
+    const result = await applyMediaUnderstanding({
+      ctx,
+      cfg,
+      agentDir: "/tmp/openclaw-agent",
+      providers: {
+        openai: {
+          id: "openai",
+          capabilities: ["image"],
+          describeImage,
+        },
+      },
+    });
+
+    expect(result.appliedImage).toBe(true);
+    expect(mockedConvertHeicToJpeg).toHaveBeenCalledWith(Buffer.from("heic-source"));
+    expect(describeImage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        buffer: Buffer.from("jpeg-normalized"),
+        fileName: "photo.heic",
+        mime: "image/jpeg",
+      }),
+    );
+    expect(ctx.Body).toBe("[Image]\nDescription:\nnormalized image");
   });
 
   it("uses active model when enabled and models are missing", async () => {

--- a/src/media-understanding/image-input-normalize.ts
+++ b/src/media-understanding/image-input-normalize.ts
@@ -1,11 +1,11 @@
-import { extractImageContentFromSource } from "../media/input-files.js";
+import { extractImageContentFromSource, normalizeMimeType } from "../media/input-files.js";
 import { DEFAULT_MAX_BYTES } from "./defaults.constants.js";
 
 const HEIC_MIME_RE = /^image\/hei[cf]$/i;
 const HEIC_EXT_RE = /\.(heic|heif)$/i;
 
 function isHeicInput(params: { mime?: string; fileName?: string }): boolean {
-  const mime = params.mime?.trim();
+  const mime = normalizeMimeType(params.mime);
   if (mime && HEIC_MIME_RE.test(mime)) {
     return true;
   }
@@ -22,7 +22,7 @@ export async function normalizeImageDescriptionInput(params: {
   if (!isHeicInput(params)) {
     return { buffer: params.buffer, mime: params.mime };
   }
-  const sourceMime = params.mime?.trim() || "image/heic";
+  const sourceMime = normalizeMimeType(params.mime) ?? "image/heic";
   const image = await extractImageContentFromSource(
     {
       type: "base64",

--- a/src/media-understanding/image-input-normalize.ts
+++ b/src/media-understanding/image-input-normalize.ts
@@ -1,0 +1,44 @@
+import { extractImageContentFromSource } from "../media/input-files.js";
+import { DEFAULT_MAX_BYTES } from "./defaults.constants.js";
+
+const HEIC_MIME_RE = /^image\/hei[cf]$/i;
+const HEIC_EXT_RE = /\.(heic|heif)$/i;
+
+function isHeicInput(params: { mime?: string; fileName?: string }): boolean {
+  const mime = params.mime?.trim();
+  if (mime && HEIC_MIME_RE.test(mime)) {
+    return true;
+  }
+  const fileName = params.fileName?.trim();
+  return Boolean(fileName && HEIC_EXT_RE.test(fileName));
+}
+
+export async function normalizeImageDescriptionInput(params: {
+  buffer: Buffer;
+  fileName?: string;
+  mime?: string;
+  maxBytes?: number;
+}): Promise<{ buffer: Buffer; mime?: string }> {
+  if (!isHeicInput(params)) {
+    return { buffer: params.buffer, mime: params.mime };
+  }
+  const sourceMime = params.mime?.trim() || "image/heic";
+  const image = await extractImageContentFromSource(
+    {
+      type: "base64",
+      data: params.buffer.toString("base64"),
+      mediaType: sourceMime,
+    },
+    {
+      allowUrl: false,
+      allowedMimes: new Set([sourceMime.toLowerCase(), "image/heic", "image/heif", "image/jpeg"]),
+      maxBytes: params.maxBytes ?? DEFAULT_MAX_BYTES.image,
+      maxRedirects: 0,
+      timeoutMs: 0,
+    },
+  );
+  return {
+    buffer: Buffer.from(image.data, "base64"),
+    mime: image.mimeType,
+  };
+}

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -32,6 +32,7 @@ import {
 } from "./defaults.constants.js";
 import { MediaUnderstandingSkipError } from "./errors.js";
 import { fileExists } from "./fs.js";
+import { normalizeImageDescriptionInput } from "./image-input-normalize.js";
 import { describeImageWithModel } from "./image-runtime.js";
 import { extractGeminiResponse } from "./output-extract.js";
 import { normalizeMediaExecutionProviderId } from "./provider-id.js";
@@ -594,12 +595,18 @@ export async function runProviderEntry(params: {
       maxBytes,
       timeoutMs,
     });
-    const requestOverrides = resolveMediaRequestOverrides(params.config);
-    const provider = getMediaUnderstandingProvider(requestProviderId, params.providerRegistry);
-    const imageInput = {
+    const normalizedMedia = await normalizeImageDescriptionInput({
       buffer: media.buffer,
       fileName: media.fileName,
       mime: media.mime,
+      maxBytes,
+    });
+    const requestOverrides = resolveMediaRequestOverrides(params.config);
+    const provider = getMediaUnderstandingProvider(requestProviderId, params.providerRegistry);
+    const imageInput = {
+      buffer: normalizedMedia.buffer,
+      fileName: media.fileName,
+      mime: normalizedMedia.mime,
       model: modelId,
       provider: requestProviderId,
       prompt: requestOverrides.prompt ?? prompt,

--- a/src/media-understanding/runtime.test.ts
+++ b/src/media-understanding/runtime.test.ts
@@ -28,6 +28,7 @@ const mocks = vi.hoisted(() => {
     getMediaUnderstandingProvider: vi.fn(),
     readLocalFileSafely: vi.fn(async () => ({ buffer: Buffer.from("image") })),
     describeImageWithModel: vi.fn(async () => ({ text: "generic image ok", model: "vision" })),
+    convertHeicToJpeg: vi.fn(async () => Buffer.from("jpeg-normalized")),
     runCapability: vi.fn(),
     cleanup,
     getBuffer,
@@ -55,6 +56,10 @@ vi.mock("./image-runtime.js", () => ({
   describeImageWithModel: mocks.describeImageWithModel,
 }));
 
+vi.mock("../media/media-services.js", () => ({
+  convertHeicToJpeg: mocks.convertHeicToJpeg,
+}));
+
 function requireRunCapabilityRequest(): unknown {
   const [call] = mocks.runCapability.mock.calls;
   if (!call) {
@@ -79,6 +84,8 @@ describe("media-understanding runtime", () => {
     mocks.readLocalFileSafely.mockResolvedValue({ buffer: Buffer.from("image") });
     mocks.describeImageWithModel.mockReset();
     mocks.describeImageWithModel.mockResolvedValue({ text: "generic image ok", model: "vision" });
+    mocks.convertHeicToJpeg.mockReset();
+    mocks.convertHeicToJpeg.mockResolvedValue(Buffer.from("jpeg-normalized"));
     mocks.runCapability.mockReset();
     mocks.cleanup.mockReset();
     mocks.cleanup.mockResolvedValue(undefined);
@@ -463,6 +470,29 @@ describe("media-understanding runtime", () => {
       cfg: {},
       agentDir: "/tmp/agent",
     });
+  });
+
+  it("normalizes local HEIC explicit image descriptions before provider execution", async () => {
+    mocks.readLocalFileSafely.mockResolvedValue({ buffer: Buffer.from("heic-source") });
+
+    await describeImageFileWithModel({
+      filePath: "/tmp/sample.heic",
+      mime: "image/heic",
+      provider: "zai",
+      model: "glm-4.6v",
+      prompt: "Describe it",
+      cfg: {} as OpenClawConfig,
+      agentDir: "/tmp/agent",
+    });
+
+    expect(mocks.convertHeicToJpeg).toHaveBeenCalledWith(Buffer.from("heic-source"));
+    expect(mocks.describeImageWithModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        buffer: Buffer.from("jpeg-normalized"),
+        fileName: "sample.heic",
+        mime: "image/jpeg",
+      }),
+    );
   });
 
   it("preserves fetched metadata for explicit model URL inputs", async () => {

--- a/src/media-understanding/runtime.test.ts
+++ b/src/media-understanding/runtime.test.ts
@@ -476,8 +476,8 @@ describe("media-understanding runtime", () => {
     mocks.readLocalFileSafely.mockResolvedValue({ buffer: Buffer.from("heic-source") });
 
     await describeImageFileWithModel({
-      filePath: "/tmp/sample.heic",
-      mime: "image/heic",
+      filePath: "/tmp/sample.bin",
+      mime: "image/heic; charset=binary",
       provider: "zai",
       model: "glm-4.6v",
       prompt: "Describe it",
@@ -489,7 +489,7 @@ describe("media-understanding runtime", () => {
     expect(mocks.describeImageWithModel).toHaveBeenCalledWith(
       expect.objectContaining({
         buffer: Buffer.from("jpeg-normalized"),
-        fileName: "sample.heic",
+        fileName: "sample.bin",
         mime: "image/jpeg",
       }),
     );

--- a/src/media-understanding/runtime.ts
+++ b/src/media-understanding/runtime.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../config/types.js";
 import { readLocalFileSafely } from "../infra/fs-safe.js";
 import { kindFromMime, mimeTypeFromFilePath } from "../media/mime.js";
 import { DEFAULT_MAX_BYTES } from "./defaults.constants.js";
+import { normalizeImageDescriptionInput } from "./image-input-normalize.js";
 import { describeImageWithModel } from "./image-runtime.js";
 import {
   buildMediaUnderstandingRegistry,
@@ -223,11 +224,17 @@ export async function describeImageFileWithModel(params: DescribeImageFileWithMo
     cfg: params.cfg,
     timeoutMs,
   });
-  const describeImage = provider?.describeImage ?? describeImageWithModel;
-  return await describeImage({
+  const normalizedImage = await normalizeImageDescriptionInput({
     buffer: image.buffer,
     fileName: image.fileName,
     mime: image.mime,
+    maxBytes: DEFAULT_MAX_BYTES.image,
+  });
+  const describeImage = provider?.describeImage ?? describeImageWithModel;
+  return await describeImage({
+    buffer: normalizedImage.buffer,
+    fileName: image.fileName,
+    mime: normalizedImage.mime,
     provider: params.provider,
     model: params.model,
     prompt: params.prompt,


### PR DESCRIPTION
HEIC/HEIF images uploaded through WebChat can reach `tools.media.image` as raw HEIC bytes, so providers that cannot read HEIC return no `[Image]` description and the agent sees only a media placeholder.

Fixes #85905.

## Affected surface

- `src/media-understanding/image-input-normalize.ts`
- `src/media-understanding/runner.entries.ts`
- `src/media-understanding/runtime.ts`
- `src/media-understanding/apply.test.ts`
- `src/media-understanding/runtime.test.ts`

## Scope

- Reuses the existing `extractImageContentFromSource()` HEIC/HEIF normalization contract from `src/media/input-files.ts`.
- Normalizes HEIC/HEIF buffers to JPEG at the media-understanding provider boundary before `describeImage`.
- Covers both `tools.media.image` pipeline execution and explicit `describeImageFileWithModel()` helper execution.
- Does not add config, flags, provider-specific behavior, or WebChat-specific policy.

## Real behavior proof

- Behavior or issue addressed: HEIC/HEIF image-description inputs are normalized before the media-understanding provider boundary, so providers receive JPEG bytes instead of raw HEIC/HEIF bytes.
- Real environment tested: Local OpenClaw checkout on Linux, Node `v22.22.2`, PR head `e39703798a5`.
- Exact steps or command run after this patch: Ran a local runtime helper with `pnpm exec tsx -e ...` that imports `src/media-understanding/image-input-normalize.ts`, creates a HEIF-family image payload, and passes it through the current-head normalization path used by media-understanding image descriptions.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
$ pnpm exec tsx -e '<runtime helper importing src/media-understanding/image-input-normalize.ts>'
{
  "head": "e39703798a5",
  "environment": {
    "platform": "linux",
    "node": "v22.22.2"
  },
  "command": "pnpm exec tsx -e <runtime helper importing src/media-understanding/image-input-normalize.ts>",
  "input": {
    "kind": "generated HEIF-family image",
    "bytes": 278,
    "brand": "ftypavif",
    "mime": "image/heif",
    "fileName": "webchat-upload.heif"
  },
  "observedResult": {
    "outputMime": "image/jpeg",
    "outputBytes": 323,
    "outputMagic": "ffd8ff",
    "jpegMagicMatches": true
  }
}
```

- Observed result after fix: The current-head media-understanding image normalization path returned `image/jpeg` and JPEG magic bytes `ffd8ff`, which is the format the downstream image-description provider boundary receives after this patch.
- What was not tested: I did not run a live WebChat browser upload or call an external image model provider live. The Linux proof uses a generated HEIF-family image because this executor cannot encode an iPhone-style HEVC HEIC fixture locally; regression coverage separately asserts the `image/heic` MIME and `.heic` filename paths.

## Regression and changed-file verification

RED before fix:

```text
$ pnpm test src/media-understanding/runtime.test.ts src/media-understanding/apply.test.ts -t HEIC
× normalizes local HEIC explicit image descriptions before provider execution
× normalizes HEIC images before tools.media.image provider execution
AssertionError: expected "vi.fn()" to be called with arguments: [ Buffer[...] ]
Number of calls: 0
```

GREEN after fix:

```text
$ pnpm test src/media-understanding/runtime.test.ts src/media-understanding/apply.test.ts -t HEIC
Test Files  2 passed (2)
Tests  2 passed | 68 skipped (70)
[test] passed 1 Vitest shard in 25.20s
```

Targeted regression suite:

```text
$ pnpm test src/media-understanding/runtime.test.ts src/media-understanding/apply.test.ts src/media/input-files.fetch-guard.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts
Test Files  1 passed (1)
Tests  13 passed (13)
Test Files  2 passed (2)
Tests  70 passed (70)
Test Files  1 passed (1)
Tests  70 passed (70)
[test] passed 3 Vitest shards in 122.03s
```

Changed-file verification:

```text
$ pnpm check:changed --base origin/main
[check:changed] lanes=core, coreTests
[check:changed] typecheck core
[check:changed] typecheck core tests
[check:changed] lint core
Import cycle check: 0 runtime value cycle(s).
exit 0

$ git diff --check origin/main..HEAD
exit 0

$ gitleaks protect --staged --redact
no leaks found
```

## Coverage note

Push-before search was repeated after implementation. No open PR was found covering this issue or path:

```text
gh search prs --repo openclaw/openclaw --state open "Fixes #85905" => no results
gh search prs --repo openclaw/openclaw --state open "#85905" => no results
gh search prs --repo openclaw/openclaw --state open "tools.media.image HEIC" => no results
gh search prs --repo openclaw/openclaw --state open "media-understanding.ts HEIC" => no results
gh search prs --repo openclaw/openclaw --state open "WebChat HEIC image description" => no results
```

Recent main already has HEIC normalization for other surfaces (`src/media/input-files.ts`, `src/media/web-media.ts`) and recent WebChat image routing fixes, but `tools.media.image` provider execution still passed raw HEIC buffers through this media-understanding boundary. This PR uses the existing shared input-image normalization contract instead of adding a second HEIC policy.
