### PR TITLE
Add experimental Evennia channel plugin

### DIFF
--- a/extensions/evennia/DEVELOPMENT.md
+++ b/extensions/evennia/DEVELOPMENT.md
@@ -1,0 +1,36 @@
+# Evennia plugin development workflow
+
+This plugin is developed from Patrick's host checkout, not from Scoob/Dumbledong containers.
+
+## Credential boundary
+
+- Patrick owns GitHub writes for `slimelab-ai/openclaw-evennia`.
+- Dumbledong and Scoob must not receive Patrick's GitHub SSH keys, `gh` tokens, or writable remotes.
+- Runtime agents may exercise the plugin through Evennia/The Dongeon using their own character credentials and the constrained OpenClaw tool surface.
+- Runtime agents may report bugs, propose patches, or write notes, but Patrick applies and pushes code changes from the host checkout.
+
+## Host source of truth
+
+- Repo: `/home/patrick/projects/openclaw-evennia`
+- Branch: `feat/evennia-channel-plugin`
+- Plugin source: `extensions/evennia/`
+- Live Scoob extension path: `/home/scoob/.openclaw/extensions/evennia` inside `donghouse`
+
+## Deploy loop
+
+1. Edit and test in the host checkout.
+2. Commit/push from Patrick only.
+3. Copy the built/source extension into Scoob's runtime extension directory.
+4. Restart Scoob's gateway only if required by the change.
+5. Smoke-test through The Dongeon.
+
+Example deploy copy from Patrick:
+
+```bash
+cd /home/patrick/projects/openclaw-evennia
+sudo lxc exec donghouse -- sudo -u scoob -H mkdir -p /home/scoob/.openclaw/extensions/evennia
+sudo lxc file push -r extensions/evennia/ donghouse/home/scoob/.openclaw/extensions/
+sudo lxc exec donghouse -- chown -R scoob:scoob /home/scoob/.openclaw/extensions/evennia
+```
+
+Do not clone this repo into Dumbledong or add GitHub auth there for plugin work. If a runtime agent needs to inspect behavior, give it the installed extension files or a read-only excerpt, not Patrick's writable GitHub identity.

--- a/extensions/evennia/README.md
+++ b/extensions/evennia/README.md
@@ -5,7 +5,7 @@ Experimental OpenClaw channel plugin for bridging an OpenClaw agent account to a
 Current smoke-tested paths:
 
 - Evennia room mention or private message → OpenClaw channel turn → in-world reply.
-- OpenClaw tool call → one raw Evennia command sent as the configured character.
+- OpenClaw tool call → one raw Evennia command sent as the configured character, with the immediate in-world text response returned in the tool result.
 
 This is intentionally still prototype code. The long-term direction is to add structured Evennia-side bridge events rather than relying on webclient text scraping.
 
@@ -33,4 +33,4 @@ The only transport-level checks are:
 - `command` must be non-empty
 - `command` must not contain newlines, so each tool call maps to one Evennia command
 
-Command output is delivered through the normal Evennia channel/event stream rather than synchronously returned by the tool.
+Command output is collected briefly from the Evennia webclient WebSocket and returned as `output` in the tool result, so the agent can inspect rooms, containers, and NPC replies before deciding the next action. If Evennia produces no immediate text, the tool still succeeds and returns an empty `output` plus a note.

--- a/extensions/evennia/README.md
+++ b/extensions/evennia/README.md
@@ -2,11 +2,23 @@
 
 Experimental OpenClaw channel plugin for bridging an OpenClaw agent account to an Evennia MUD character over Evennia's webclient WebSocket.
 
-Current smoke-tested path:
+Current smoke-tested paths:
 
-Evennia room mention or private message → OpenClaw channel turn → in-world reply.
+- Evennia room mention or private message → OpenClaw channel turn → in-world reply.
+- OpenClaw tool call → one raw Evennia command sent as the configured character.
 
 This is intentionally still prototype code. The long-term direction is to add structured Evennia-side bridge events rather than relying on webclient text scraping.
+
+## Command tool
+
+The plugin registers `evennia_command`, a generic tool that sends one raw command to Evennia as a configured character. Evennia remains the authority for permissions, custom commands, admin powers, and game effects; the plugin does not maintain a separate command allowlist or admin switch.
+
+The only transport-level checks are:
+
+- `command` must be non-empty
+- `command` must not contain newlines, so each tool call maps to one Evennia command
+
+Command output is delivered through the normal Evennia channel/event stream rather than synchronously returned by the tool.
 
 ## Optional autonomy loop
 

--- a/extensions/evennia/README.md
+++ b/extensions/evennia/README.md
@@ -13,6 +13,19 @@ This is intentionally still prototype code. The long-term direction is to add st
 
 The plugin registers `evennia_command`, a generic tool that sends one raw command to Evennia as a configured character. Evennia remains the authority for permissions, custom commands, admin powers, and game effects; the plugin does not maintain a separate command allowlist or admin switch.
 
+Make sure the runtime tool policy exposes the tool to the agent. For example, when using the `coding` tool profile:
+
+```json
+{
+  "tools": {
+    "profile": "coding",
+    "alsoAllow": ["evennia_command"]
+  }
+}
+```
+
+The Evennia channel adds turn-level prompt guidance telling the agent to use `evennia_command` for in-world actions instead of saying command strings aloud.
+
 The only transport-level checks are:
 
 - `command` must be non-empty

--- a/extensions/evennia/README.md
+++ b/extensions/evennia/README.md
@@ -1,0 +1,9 @@
+# Evennia channel plugin prototype
+
+Experimental OpenClaw channel plugin for bridging an OpenClaw agent account to an Evennia MUD character over Evennia's webclient WebSocket.
+
+Current smoke-tested path:
+
+Evennia room mention or private message → OpenClaw channel turn → in-world reply.
+
+This is intentionally still prototype code. The long-term direction is to add structured Evennia-side bridge events rather than relying on webclient text scraping.

--- a/extensions/evennia/README.md
+++ b/extensions/evennia/README.md
@@ -32,20 +32,3 @@ The only transport-level checks are:
 - `command` must not contain newlines, so each tool call maps to one Evennia command
 
 Command output is delivered through the normal Evennia channel/event stream rather than synchronously returned by the tool.
-
-## Optional autonomy loop
-
-Accounts may enable a small, transport-local autonomy loop. It only sends configured Evennia commands over the existing Evennia websocket; it does not grant shell, web, messaging, or other OpenClaw tools. Keep command lists narrow and game-safe.
-
-Example account config:
-
-```json
-{
-  "autonomy": {
-    "enabled": true,
-    "intervalMs": 90000,
-    "idleChance": 0.6,
-    "commands": ["look", "pose studies the room"]
-  }
-}
-```

--- a/extensions/evennia/README.md
+++ b/extensions/evennia/README.md
@@ -7,3 +7,20 @@ Current smoke-tested path:
 Evennia room mention or private message → OpenClaw channel turn → in-world reply.
 
 This is intentionally still prototype code. The long-term direction is to add structured Evennia-side bridge events rather than relying on webclient text scraping.
+
+## Optional autonomy loop
+
+Accounts may enable a small, transport-local autonomy loop. It only sends configured Evennia commands over the existing Evennia websocket; it does not grant shell, web, messaging, or other OpenClaw tools. Keep command lists narrow and game-safe.
+
+Example account config:
+
+```json
+{
+  "autonomy": {
+    "enabled": true,
+    "intervalMs": 90000,
+    "idleChance": 0.6,
+    "commands": ["look", "pose studies the room"]
+  }
+}
+```

--- a/extensions/evennia/README.md
+++ b/extensions/evennia/README.md
@@ -9,6 +9,8 @@ Current smoke-tested paths:
 
 This is intentionally still prototype code. The long-term direction is to add structured Evennia-side bridge events rather than relying on webclient text scraping.
 
+Development happens from Patrick's host checkout only. Do not give Scoob/Dumbledong Patrick's GitHub credentials or writable remotes for this plugin; see `DEVELOPMENT.md` for the safe deploy workflow.
+
 ## Command tool
 
 The plugin registers `evennia_command`, a generic tool that sends one raw command to Evennia as a configured character. Evennia remains the authority for permissions, custom commands, admin powers, and game effects; the plugin does not maintain a separate command allowlist or admin switch.

--- a/extensions/evennia/index.js
+++ b/extensions/evennia/index.js
@@ -1,12 +1,22 @@
-import { defineChannelPluginEntry } from "openclaw/plugin-sdk/channel-core";
-import { createEvenniaCommandTool, evenniaPlugin } from "./src/channel.js";
+import { createEvenniaCommandTool, evenniaPlugin, evenniaStagingPlugin } from "./src/channel.js";
 
-export default defineChannelPluginEntry({
+export default {
   id: "evennia",
   name: "Evennia",
   description: "OpenClaw channel bridge for Evennia MUD characters.",
-  plugin: evenniaPlugin,
-  registerFull(api) {
-    api.registerTool(createEvenniaCommandTool(), { name: "evennia_command" });
+  channelPlugin: evenniaPlugin,
+  register(api) {
+    if (api.registrationMode === "cli-metadata") {
+      return;
+    }
+    if (api.registrationMode === "tool-discovery") {
+      api.registerTool(createEvenniaCommandTool(), { name: "evennia_command" });
+      return;
+    }
+    api.registerChannel({ plugin: evenniaPlugin });
+    api.registerChannel({ plugin: evenniaStagingPlugin });
+    if (api.registrationMode === "full") {
+      api.registerTool(createEvenniaCommandTool(), { name: "evennia_command" });
+    }
   },
-});
+};

--- a/extensions/evennia/index.js
+++ b/extensions/evennia/index.js
@@ -1,0 +1,9 @@
+import { defineChannelPluginEntry } from "openclaw/plugin-sdk/channel-core";
+import { evenniaPlugin } from "./src/channel.js";
+
+export default defineChannelPluginEntry({
+  id: "evennia",
+  name: "Evennia",
+  description: "OpenClaw channel bridge for Evennia MUD characters.",
+  plugin: evenniaPlugin
+});

--- a/extensions/evennia/index.js
+++ b/extensions/evennia/index.js
@@ -1,9 +1,12 @@
 import { defineChannelPluginEntry } from "openclaw/plugin-sdk/channel-core";
-import { evenniaPlugin } from "./src/channel.js";
+import { createEvenniaCommandTool, evenniaPlugin } from "./src/channel.js";
 
 export default defineChannelPluginEntry({
   id: "evennia",
   name: "Evennia",
   description: "OpenClaw channel bridge for Evennia MUD characters.",
-  plugin: evenniaPlugin
+  plugin: evenniaPlugin,
+  registerFull(api) {
+    api.registerTool(createEvenniaCommandTool(), { name: "evennia_command" });
+  },
 });

--- a/extensions/evennia/openclaw.plugin.json
+++ b/extensions/evennia/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "evennia",
   "kind": "channel",
-  "channels": ["evennia"],
+  "channels": ["evennia", "evennia-staging"],
   "name": "Evennia",
   "description": "OpenClaw channel bridge for Evennia MUD characters.",
   "entry": "./index.js",
@@ -34,6 +34,50 @@
               "properties": {
                 "enabled": { "type": "boolean" },
                 "agentId": { "type": "string" },
+                "baseUrl": { "type": "string" },
+                "websocketUrl": { "type": "string" },
+                "username": { "type": "string" },
+                "passwordFile": { "type": "string" },
+                "character": { "type": "string" },
+                "triggerName": { "type": "string" },
+                "startRoom": { "type": "string" },
+                "allowFrom": { "type": "array", "items": { "type": "string" } },
+                "allowedRooms": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                },
+                "respondToAmbientMentions": { "type": "boolean" }
+              },
+              "required": ["username", "passwordFile"]
+            }
+          }
+        }
+      },
+      "uiHints": {
+        "accounts.*.passwordFile": {
+          "label": "Password file",
+          "sensitive": true
+        }
+      }
+    },
+    "evennia-staging": {
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": { "type": "boolean" },
+          "baseUrl": { "type": "string" },
+          "websocketUrl": { "type": "string" },
+          "accounts": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "agentId": { "type": "string" },
+                "baseUrl": { "type": "string" },
+                "websocketUrl": { "type": "string" },
                 "username": { "type": "string" },
                 "passwordFile": { "type": "string" },
                 "character": { "type": "string" },

--- a/extensions/evennia/openclaw.plugin.json
+++ b/extensions/evennia/openclaw.plugin.json
@@ -26,6 +26,9 @@
           "enabled": { "type": "boolean" },
           "baseUrl": { "type": "string" },
           "websocketUrl": { "type": "string" },
+          "historyLimit": { "type": "integer", "minimum": 0 },
+          "timeoutSeconds": { "type": "integer", "minimum": 0 },
+          "blockReplyTimeoutMs": { "type": "integer", "minimum": 0 },
           "accounts": {
             "type": "object",
             "additionalProperties": {
@@ -36,6 +39,9 @@
                 "agentId": { "type": "string" },
                 "baseUrl": { "type": "string" },
                 "websocketUrl": { "type": "string" },
+                "historyLimit": { "type": "integer", "minimum": 0 },
+                "timeoutSeconds": { "type": "integer", "minimum": 0 },
+                "blockReplyTimeoutMs": { "type": "integer", "minimum": 0 },
                 "username": { "type": "string" },
                 "passwordFile": { "type": "string" },
                 "character": { "type": "string" },
@@ -68,6 +74,9 @@
           "enabled": { "type": "boolean" },
           "baseUrl": { "type": "string" },
           "websocketUrl": { "type": "string" },
+          "historyLimit": { "type": "integer", "minimum": 0 },
+          "timeoutSeconds": { "type": "integer", "minimum": 0 },
+          "blockReplyTimeoutMs": { "type": "integer", "minimum": 0 },
           "accounts": {
             "type": "object",
             "additionalProperties": {
@@ -78,6 +87,9 @@
                 "agentId": { "type": "string" },
                 "baseUrl": { "type": "string" },
                 "websocketUrl": { "type": "string" },
+                "historyLimit": { "type": "integer", "minimum": 0 },
+                "timeoutSeconds": { "type": "integer", "minimum": 0 },
+                "blockReplyTimeoutMs": { "type": "integer", "minimum": 0 },
                 "username": { "type": "string" },
                 "passwordFile": { "type": "string" },
                 "character": { "type": "string" },

--- a/extensions/evennia/openclaw.plugin.json
+++ b/extensions/evennia/openclaw.plugin.json
@@ -1,0 +1,50 @@
+{
+  "id": "evennia",
+  "kind": "channel",
+  "channels": ["evennia"],
+  "name": "Evennia",
+  "description": "OpenClaw channel bridge for Evennia MUD characters.",
+  "entry": "./index.js",
+  "setupEntry": "./setup-entry.js",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  },
+  "channelConfigs": {
+    "evennia": {
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": { "type": "boolean" },
+          "baseUrl": { "type": "string" },
+          "websocketUrl": { "type": "string" },
+          "accounts": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "agentId": { "type": "string" },
+                "username": { "type": "string" },
+                "passwordFile": { "type": "string" },
+                "character": { "type": "string" },
+                "triggerName": { "type": "string" },
+                "startRoom": { "type": "string" },
+                "allowFrom": { "type": "array", "items": { "type": "string" } },
+                "allowedRooms": { "type": "array", "items": { "type": "string" } },
+                "respondToAmbientMentions": { "type": "boolean" }
+              },
+              "required": ["username", "passwordFile"]
+            }
+          }
+        }
+      },
+      "uiHints": {
+        "accounts.*.passwordFile": { "label": "Password file", "sensitive": true }
+      }
+    }
+  }
+}

--- a/extensions/evennia/openclaw.plugin.json
+++ b/extensions/evennia/openclaw.plugin.json
@@ -5,6 +5,12 @@
   "name": "Evennia",
   "description": "OpenClaw channel bridge for Evennia MUD characters.",
   "entry": "./index.js",
+  "contracts": {
+    "tools": ["evennia_command"]
+  },
+  "toolMetadata": {
+    "evennia_command": {}
+  },
   "setupEntry": "./setup-entry.js",
   "configSchema": {
     "type": "object",
@@ -34,7 +40,10 @@
                 "triggerName": { "type": "string" },
                 "startRoom": { "type": "string" },
                 "allowFrom": { "type": "array", "items": { "type": "string" } },
-                "allowedRooms": { "type": "array", "items": { "type": "string" } },
+                "allowedRooms": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                },
                 "respondToAmbientMentions": { "type": "boolean" },
                 "autonomy": {
                   "type": "object",
@@ -42,8 +51,15 @@
                   "properties": {
                     "enabled": { "type": "boolean" },
                     "intervalMs": { "type": "number" },
-                    "idleChance": { "type": "number", "minimum": 0, "maximum": 1 },
-                    "commands": { "type": "array", "items": { "type": "string" } }
+                    "idleChance": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "commands": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    }
                   }
                 }
               },
@@ -53,7 +69,10 @@
         }
       },
       "uiHints": {
-        "accounts.*.passwordFile": { "label": "Password file", "sensitive": true }
+        "accounts.*.passwordFile": {
+          "label": "Password file",
+          "sensitive": true
+        }
       }
     }
   }

--- a/extensions/evennia/openclaw.plugin.json
+++ b/extensions/evennia/openclaw.plugin.json
@@ -44,24 +44,7 @@
                   "type": "array",
                   "items": { "type": "string" }
                 },
-                "respondToAmbientMentions": { "type": "boolean" },
-                "autonomy": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "enabled": { "type": "boolean" },
-                    "intervalMs": { "type": "number" },
-                    "idleChance": {
-                      "type": "number",
-                      "minimum": 0,
-                      "maximum": 1
-                    },
-                    "commands": {
-                      "type": "array",
-                      "items": { "type": "string" }
-                    }
-                  }
-                }
+                "respondToAmbientMentions": { "type": "boolean" }
               },
               "required": ["username", "passwordFile"]
             }

--- a/extensions/evennia/openclaw.plugin.json
+++ b/extensions/evennia/openclaw.plugin.json
@@ -35,7 +35,17 @@
                 "startRoom": { "type": "string" },
                 "allowFrom": { "type": "array", "items": { "type": "string" } },
                 "allowedRooms": { "type": "array", "items": { "type": "string" } },
-                "respondToAmbientMentions": { "type": "boolean" }
+                "respondToAmbientMentions": { "type": "boolean" },
+                "autonomy": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": { "type": "boolean" },
+                    "intervalMs": { "type": "number" },
+                    "idleChance": { "type": "number", "minimum": 0, "maximum": 1 },
+                    "commands": { "type": "array", "items": { "type": "string" } }
+                  }
+                }
               },
               "required": ["username", "passwordFile"]
             }

--- a/extensions/evennia/package.json
+++ b/extensions/evennia/package.json
@@ -7,7 +7,9 @@
     "url": "https://github.com/slimelab-ai/openclaw-evennia"
   },
   "type": "module",
-  "dependencies": {},
+  "dependencies": {
+    "typebox": "1.1.38"
+  },
   "devDependencies": {
     "openclaw": "workspace:*"
   },

--- a/extensions/evennia/package.json
+++ b/extensions/evennia/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@slimelab/openclaw-evennia",
+  "version": "0.1.0",
+  "description": "OpenClaw channel bridge for Evennia MUD characters.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/slimelab-ai/openclaw-evennia"
+  },
+  "type": "module",
+  "dependencies": {},
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.5.20"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ],
+    "setupEntry": "./setup-entry.js",
+    "channel": {
+      "id": "evennia",
+      "label": "Evennia",
+      "selectionLabel": "Evennia (MUD bridge)",
+      "detailLabel": "Evennia WebSocket",
+      "docsPath": "/channels/evennia",
+      "docsLabel": "evennia",
+      "blurb": "experimental MUD bridge for agent characters.",
+      "systemImage": "sparkles.rectangle.stack",
+      "markdownCapable": false
+    },
+    "install": {
+      "npmSpec": "@slimelab/openclaw-evennia",
+      "defaultChoice": "npm",
+      "minHostVersion": ">=2026.5.20"
+    },
+    "compat": {
+      "pluginApi": ">=2026.5.20"
+    }
+  }
+}

--- a/extensions/evennia/setup-entry.js
+++ b/extensions/evennia/setup-entry.js
@@ -1,3 +1,4 @@
 import { defineSetupPluginEntry } from "openclaw/plugin-sdk/channel-core";
 import { evenniaPlugin } from "./src/channel.js";
+
 export default defineSetupPluginEntry(evenniaPlugin);

--- a/extensions/evennia/setup-entry.js
+++ b/extensions/evennia/setup-entry.js
@@ -1,0 +1,3 @@
+import { defineSetupPluginEntry } from "openclaw/plugin-sdk/channel-core";
+import { evenniaPlugin } from "./src/channel.js";
+export default defineSetupPluginEntry(evenniaPlugin);

--- a/extensions/evennia/src/channel.js
+++ b/extensions/evennia/src/channel.js
@@ -1,16 +1,21 @@
 import { readReactionParams } from "openclaw/plugin-sdk/channel-actions";
 import { createChannelPluginBase, createChatChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import { jsonResult } from "openclaw/plugin-sdk/core";
+import { createChannelHistoryWindow } from "openclaw/plugin-sdk/reply-history";
 import { Type } from "typebox";
 import { EvenniaClient } from "./evennia-client.js";
 
 const clients = new Map();
+const evenniaHistories = new Map();
 
 const ROOM_CONTEXT_MAX_CHARS = 5000;
 const HELP_CONTEXT_MAX_CHARS = 2500;
 const COMMAND_OUTPUT_MAX_CHARS = 6000;
 const COMMAND_OUTPUT_WAIT_MS = 3000;
 const COMMAND_ROOM_SNAPSHOT_MAX_CHARS = 3500;
+const DEFAULT_EVENNIA_HISTORY_LIMIT = 20;
+const DEFAULT_EVENNIA_TIMEOUT_SECONDS = 0;
+const DEFAULT_EVENNIA_BLOCK_REPLY_TIMEOUT_MS = 10 * 60 * 1000;
 const DEFAULT_CHANNEL_ID = "evennia";
 
 const EVENNIA_AGENT_PROMPT = [
@@ -58,6 +63,8 @@ function resolveAccount(cfg, accountId = null, channelId = DEFAULT_CHANNEL_ID) {
   const accounts = section.accounts || {};
   const id = accountId || Object.keys(accounts)[0] || "default";
   const raw = accounts[id] || {};
+  const historyLimit =
+    raw.historyLimit ?? section.historyLimit ?? cfg.messages?.groupChat?.historyLimit;
   return {
     channelId,
     accountId: id,
@@ -73,6 +80,15 @@ function resolveAccount(cfg, accountId = null, channelId = DEFAULT_CHANNEL_ID) {
     allowFrom: raw.allowFrom || [],
     allowedRooms: raw.allowedRooms || [],
     respondToAmbientMentions: raw.respondToAmbientMentions !== false,
+    historyLimit: Math.max(
+      DEFAULT_EVENNIA_HISTORY_LIMIT,
+      Number.isFinite(historyLimit) ? Math.floor(historyLimit) : DEFAULT_EVENNIA_HISTORY_LIMIT,
+    ),
+    timeoutSeconds: raw.timeoutSeconds ?? section.timeoutSeconds ?? DEFAULT_EVENNIA_TIMEOUT_SECONDS,
+    blockReplyTimeoutMs:
+      raw.blockReplyTimeoutMs ??
+      section.blockReplyTimeoutMs ??
+      DEFAULT_EVENNIA_BLOCK_REPLY_TIMEOUT_MS,
   };
 }
 
@@ -566,6 +582,58 @@ function isMentioned(event, account) {
   return event.text?.toLowerCase().includes(trigger) === true;
 }
 
+function isDirectEvenniaEvent(event) {
+  return event.kind === "tell" || event.kind === "whisper";
+}
+
+export function evenniaHistoryKey(account, event) {
+  const direct = isDirectEvenniaEvent(event);
+  const target = direct ? event.sender : event.room || "room";
+  return `${account.channelId}:${account.accountId}:${direct ? "direct" : "room"}:${target}`;
+}
+
+function evenniaHistoryEntry(event) {
+  const body = String(event.text ?? "").trim();
+  if (!body) {
+    return null;
+  }
+  return {
+    sender: event.sender || "unknown",
+    body,
+    timestamp: event.timestamp || Date.now(),
+    messageId: event.id,
+  };
+}
+
+function getEvenniaHistoryWindow() {
+  return createChannelHistoryWindow({ historyMap: evenniaHistories });
+}
+
+export function buildEvenniaInboundHistory(account, event) {
+  if (account.historyLimit <= 0) {
+    return undefined;
+  }
+  return getEvenniaHistoryWindow().buildInboundHistory({
+    historyKey: evenniaHistoryKey(account, event),
+    limit: account.historyLimit,
+  });
+}
+
+export function recordEvenniaHistoryEvent(account, event) {
+  if (account.historyLimit <= 0) {
+    return;
+  }
+  getEvenniaHistoryWindow().record({
+    historyKey: evenniaHistoryKey(account, event),
+    limit: account.historyLimit,
+    entry: evenniaHistoryEntry(event),
+  });
+}
+
+export function clearEvenniaHistoryForTests() {
+  evenniaHistories.clear();
+}
+
 function resolveActionClient(channelId = DEFAULT_CHANNEL_ID, accountId, params = {}) {
   const requestedChannelId =
     (typeof params.channelId === "string" && params.channelId.trim()) || channelId;
@@ -660,15 +728,19 @@ async function dispatchEvenniaEvent(ctx, account, event) {
     ctx.log?.warn?.("evennia channelRuntime unavailable; inbound ignored");
     return;
   }
-  const direct = event.kind === "tell" || event.kind === "whisper";
+  const direct = isDirectEvenniaEvent(event);
   const mentioned = isMentioned(event, account);
+  const inboundHistory = buildEvenniaInboundHistory(account, event);
   if (!direct && !account.respondToAmbientMentions) {
+    recordEvenniaHistoryEvent(account, event);
     return;
   }
   if (direct && account.respondToAmbientMentions === false) {
+    recordEvenniaHistoryEvent(account, event);
     return;
   }
   if (!direct && !mentioned) {
+    recordEvenniaHistoryEvent(account, event);
     return;
   }
 
@@ -728,6 +800,7 @@ async function dispatchEvenniaEvent(ctx, account, event) {
       body: event.text,
       bodyForAgent: `[Evennia ${direct ? "tell" : "room"} from ${event.sender}${event.room ? ` in ${event.room}` : ""}]\n${event.text}${stateContext}`,
       commandBody: event.text,
+      inboundHistory,
       envelopeFrom: event.sender,
       senderLabel: event.sender,
       preview: event.text.slice(0, 200),
@@ -765,6 +838,7 @@ async function dispatchEvenniaEvent(ctx, account, event) {
     ? createEvenniaStatusPoseController(statusClient, ctx.log)
     : null;
   await statusPoses?.setEmoji("👀");
+  recordEvenniaHistoryEvent(account, event);
 
   try {
     await rt.turn.dispatchAssembled({
@@ -779,6 +853,8 @@ async function dispatchEvenniaEvent(ctx, account, event) {
       dispatchReplyWithBufferedBlockDispatcher: rt.reply.dispatchReplyWithBufferedBlockDispatcher,
       messageId,
       replyOptions: {
+        timeoutOverrideSeconds: account.timeoutSeconds,
+        blockReplyTimeoutMs: account.blockReplyTimeoutMs,
         onToolResult: async (payload) => {
           await statusPoses?.setToolResult(payload);
         },

--- a/extensions/evennia/src/channel.js
+++ b/extensions/evennia/src/channel.js
@@ -8,6 +8,10 @@ const clients = new Map();
 
 const ROOM_CONTEXT_MAX_CHARS = 5000;
 const HELP_CONTEXT_MAX_CHARS = 2500;
+const COMMAND_OUTPUT_MAX_CHARS = 6000;
+const COMMAND_OUTPUT_WAIT_MS = 3000;
+const COMMAND_ROOM_SNAPSHOT_MAX_CHARS = 3500;
+const DEFAULT_CHANNEL_ID = "evennia";
 
 const EVENNIA_AGENT_PROMPT = [
   "You are acting as an Evennia MUD character through the Evennia channel.",
@@ -22,24 +26,44 @@ const EVENNIA_AGENT_PROMPT = [
   "Never put multiple Evennia commands in one tool call; use one tool call per command.",
 ].join("\n");
 
-function channelSection(cfg) {
-  return (cfg.channels && cfg.channels.evennia) || {};
+function channelSection(cfg, channelId = DEFAULT_CHANNEL_ID) {
+  return (cfg.channels && cfg.channels[channelId]) || {};
 }
 
-function listAccountIds(cfg) {
-  return Object.keys(channelSection(cfg).accounts || {});
+function listAccountIds(cfg, channelId = DEFAULT_CHANNEL_ID) {
+  return Object.keys(channelSection(cfg, channelId).accounts || {});
 }
 
-function resolveAccount(cfg, accountId = null) {
-  const section = channelSection(cfg);
+function clientKey(channelId, accountId) {
+  return `${channelId || DEFAULT_CHANNEL_ID}:${accountId || "default"}`;
+}
+
+function getClient(channelId, accountId) {
+  return clients.get(clientKey(channelId, accountId));
+}
+
+function setClient(account, client) {
+  clients.set(clientKey(account.channelId, account.accountId), client);
+}
+
+function deleteClient(account, client = undefined) {
+  const key = clientKey(account.channelId, account.accountId);
+  if (client === undefined || clients.get(key) === client) {
+    clients.delete(key);
+  }
+}
+
+function resolveAccount(cfg, accountId = null, channelId = DEFAULT_CHANNEL_ID) {
+  const section = channelSection(cfg, channelId);
   const accounts = section.accounts || {};
   const id = accountId || Object.keys(accounts)[0] || "default";
   const raw = accounts[id] || {};
   return {
+    channelId,
     accountId: id,
     enabled: section.enabled !== false && raw.enabled !== false,
-    baseUrl: section.baseUrl || "http://127.0.0.1:14001",
-    websocketUrl: section.websocketUrl || "ws://127.0.0.1:14002",
+    baseUrl: raw.baseUrl || section.baseUrl || "http://127.0.0.1:14001",
+    websocketUrl: raw.websocketUrl || section.websocketUrl || "ws://127.0.0.1:14002",
     agentId: raw.agentId || id,
     username: raw.username,
     passwordFile: raw.passwordFile,
@@ -52,13 +76,14 @@ function resolveAccount(cfg, accountId = null) {
   };
 }
 
-function inspectAccount(cfg, accountId = null) {
+function inspectAccount(cfg, accountId = null, channelId = DEFAULT_CHANNEL_ID) {
   try {
-    const account = resolveAccount(cfg, accountId);
+    const account = resolveAccount(cfg, accountId, channelId);
     return {
       enabled: account.enabled,
       configured: Boolean(account.username && account.passwordFile),
       tokenStatus: account.passwordFile ? "file" : "missing",
+      channelId: account.channelId,
       accountId: account.accountId,
       character: account.character,
     };
@@ -379,17 +404,43 @@ export function splitEvenniaOutboundText(text, account = undefined) {
       parts.push({ kind: "pose", text: clean });
     }
   };
+  const pushCommand = (value) => {
+    const clean = stripUnsafePoseText(value);
+    if (clean) {
+      parts.push({ kind: "command", text: clean });
+    }
+  };
+
+  const literalToolCall =
+    /`*\s*evennia_command\s*\(\s*command\s*=\s*(?:"([^"]+)"|'([^']+)'|`([^`]+)`)\s*(?:,[^)]*)?\)\s*`*/giu;
+  let toolIndex = 0;
+  let rewritten = "";
+  const literalCommands = [];
+  for (const match of raw.matchAll(literalToolCall)) {
+    const commandIndex = literalCommands.length;
+    literalCommands.push(match[1] ?? match[2] ?? match[3]);
+    rewritten += raw.slice(toolIndex, match.index);
+    rewritten += `\n__OPENCLAW_EVENNIA_COMMAND__${commandIndex}__\n`;
+    toolIndex = match.index + match[0].length;
+  }
+  rewritten += raw.slice(toolIndex);
 
   const codePose = /`+\s*pose\s+([^`]+?)\s*`+/giu;
   let index = 0;
-  for (const match of raw.matchAll(codePose)) {
-    pushSay(raw.slice(index, match.index));
+  for (const match of rewritten.matchAll(codePose)) {
+    pushSay(rewritten.slice(index, match.index));
     pushPose(match[1]);
     index = match.index + match[0].length;
   }
-  const tail = raw.slice(index);
+  const tail = rewritten.slice(index);
   for (const line of tail.split(/\n+/)) {
-    const command = line.trim().match(/^pose\s+(.+)$/iu);
+    const trimmed = line.trim();
+    const toolCommand = trimmed.match(/^__OPENCLAW_EVENNIA_COMMAND__(\d+)__$/u);
+    if (toolCommand) {
+      pushCommand(literalCommands[Number(toolCommand[1])]);
+      continue;
+    }
+    const command = trimmed.match(/^pose\s+(.+)$/iu);
     if (command) {
       pushPose(command[1]);
     } else {
@@ -404,6 +455,8 @@ async function deliverEvenniaText(client, account, text, { replyMode = "say", ta
   for (const part of parts) {
     if (part.kind === "pose") {
       await client.command(`pose ${part.text}`);
+    } else if (part.kind === "command") {
+      await client.command(normalizePoseCommand(part.text, account));
     } else if (replyMode === "tell" && target) {
       await client.tell(target, part.text);
     } else if (replyMode === "whisper" && target) {
@@ -513,20 +566,26 @@ function isMentioned(event, account) {
   return event.text?.toLowerCase().includes(trigger) === true;
 }
 
-function resolveActionClient(accountId, params = {}) {
+function resolveActionClient(channelId = DEFAULT_CHANNEL_ID, accountId, params = {}) {
+  const requestedChannelId =
+    (typeof params.channelId === "string" && params.channelId.trim()) || channelId;
   const requested =
     (typeof accountId === "string" && accountId.trim()) ||
     (typeof params.accountId === "string" && params.accountId.trim()) ||
     (typeof params.to === "string" && params.to.trim()) ||
-    clients.keys().next().value;
+    [...clients.keys()]
+      .find((key) => key.startsWith(`${requestedChannelId}:`))
+      ?.slice(requestedChannelId.length + 1);
   if (!requested) {
-    throw new Error("no connected Evennia accounts are available");
+    throw new Error(
+      `no connected Evennia accounts are available for channel ${requestedChannelId}`,
+    );
   }
-  const client = clients.get(requested);
+  const client = getClient(requestedChannelId, requested);
   if (!client) {
-    throw new Error(`evennia account ${requested} is not connected`);
+    throw new Error(`evennia account ${requestedChannelId}:${requested} is not connected`);
   }
-  return { accountId: requested, client };
+  return { channelId: requestedChannelId, accountId: requested, client };
 }
 
 export function createEvenniaCommandTool() {
@@ -546,6 +605,12 @@ export function createEvenniaCommandTool() {
             "Configured Evennia account id/character route to use. Defaults to the first connected account.",
         }),
       ),
+      channelId: Type.Optional(
+        Type.String({
+          description:
+            "Configured Evennia channel id to use, for example evennia or evennia-staging. Defaults to evennia.",
+        }),
+      ),
     }),
     async execute(_toolCallId, rawParams) {
       const command = readToolString(rawParams, "command", {
@@ -558,18 +623,33 @@ export function createEvenniaCommandTool() {
         throw new Error("command must be a single Evennia command without newlines");
       }
 
+      const channelId = readToolString(rawParams, "channelId")?.trim() || DEFAULT_CHANNEL_ID;
       const requestedAccountId = readToolString(rawParams, "accountId")?.trim();
-      const accountId = requestedAccountId || clients.keys().next().value;
-      if (!accountId) {
-        throw new Error("no connected Evennia accounts are available");
-      }
-      const client = clients.get(accountId);
-      if (!client) {
-        throw new Error(`evennia account ${accountId} is not connected`);
-      }
+      const { accountId, client } = resolveActionClient(channelId, requestedAccountId, rawParams);
       const normalizedCommand = normalizePoseCommand(command, client.account);
-      await client.command(normalizedCommand);
-      return jsonResult({ ok: true, accountId, command: normalizedCommand });
+      const output = await client.commandAndCollect(normalizedCommand, {
+        waitMs: COMMAND_OUTPUT_WAIT_MS,
+        maxChars: COMMAND_OUTPUT_MAX_CHARS,
+      });
+      const roomSnapshot =
+        normalizedCommand.toLowerCase() === "look"
+          ? ""
+          : await collectRoomContext(client, {
+              warn: () => {},
+            });
+      return jsonResult({
+        ok: true,
+        channelId,
+        accountId,
+        command: normalizedCommand,
+        output,
+        roomSnapshot: roomSnapshot
+          ? roomSnapshot.slice(0, COMMAND_ROOM_SNAPSHOT_MAX_CHARS)
+          : undefined,
+        note: output
+          ? undefined
+          : "No immediate Evennia output was observed for this command. Inspect roomSnapshot if present before assuming nothing changed.",
+      });
     },
   };
 }
@@ -592,7 +672,7 @@ async function dispatchEvenniaEvent(ctx, account, event) {
     return;
   }
 
-  const client = clients.get(account.accountId);
+  const client = getClient(account.channelId, account.accountId);
   const roomContext = client ? await collectRoomContext(client, ctx.log) : "";
   const helpContext = client ? await collectHelpContext(client, ctx.log) : "";
   const stateContext = `${formatContextBlock("Current room from automatic look", roomContext)}${formatContextBlock("Available Evennia help", helpContext)}`;
@@ -600,7 +680,7 @@ async function dispatchEvenniaEvent(ctx, account, event) {
   const messageId = event.id || `evennia-${Date.now()}`;
   const routeSessionKey = rt.routing.buildAgentSessionKey({
     agentId: account.agentId,
-    channel: "evennia",
+    channel: account.channelId,
     chatType: direct ? "direct" : "group",
     target: direct ? event.sender : event.room || "room",
   });
@@ -608,7 +688,7 @@ async function dispatchEvenniaEvent(ctx, account, event) {
     agentId: account.agentId,
   });
   const ctxPayload = rt.turn.buildContext({
-    channel: "evennia",
+    channel: account.channelId,
     accountId: account.accountId,
     provider: "evennia",
     surface: "evennia",
@@ -680,7 +760,7 @@ async function dispatchEvenniaEvent(ctx, account, event) {
     },
   });
 
-  const statusClient = clients.get(account.accountId);
+  const statusClient = getClient(account.channelId, account.accountId);
   const statusPoses = statusClient
     ? createEvenniaStatusPoseController(statusClient, ctx.log)
     : null;
@@ -689,7 +769,7 @@ async function dispatchEvenniaEvent(ctx, account, event) {
   try {
     await rt.turn.dispatchAssembled({
       cfg: ctx.cfg,
-      channel: "evennia",
+      channel: account.channelId,
       accountId: account.accountId,
       agentId: account.agentId,
       routeSessionKey,
@@ -711,7 +791,7 @@ async function dispatchEvenniaEvent(ctx, account, event) {
         deliver: async (payload) => {
           const text = payload?.text || payload?.content || "";
           if (text.trim()) {
-            const client = clients.get(account.accountId);
+            const client = getClient(account.channelId, account.accountId);
             if (client) {
               await deliverEvenniaText(client, account, text.trim(), {
                 replyMode: event.replyMode,
@@ -733,161 +813,179 @@ async function dispatchEvenniaEvent(ctx, account, event) {
   }
 }
 
-export const evenniaPlugin = createChatChannelPlugin({
-  base: createChannelPluginBase({
-    id: "evennia",
-    config: {
-      listAccountIds,
-      resolveAccount,
-      inspectAccount,
-      defaultAccountId: (cfg) => listAccountIds(cfg)[0] || "default",
-      isEnabled: (account) => account.enabled,
-      isConfigured: (account) => Boolean(account.username && account.passwordFile),
-      describeAccount: (account) => ({
-        id: account.accountId,
-        name: account.character || account.username,
-        enabled: account.enabled,
-        configured: Boolean(account.username && account.passwordFile),
-        connected: clients.has(account.accountId),
-      }),
-    },
-    setup: {
-      applyAccountConfig: ({ cfg }) => cfg,
-    },
-  }),
-  outbound: {
-    base: {
-      deliveryMode: "gateway",
-      resolveTarget: ({ to }) => ({ ok: true, to: to || "default" }),
-    },
-    attachedResults: {
-      channel: "evennia",
-      sendText: async ({ cfg, to, text, accountId }) => {
-        const id = accountId || to;
-        const client = clients.get(id);
-        if (!client) {
-          throw new Error(`evennia account ${id} is not connected`);
-        }
-        const account = inspectAccount(cfg, id);
-        await deliverEvenniaText(client, account, text);
-        return { messageId: `evennia-out-${Date.now()}` };
+export function createEvenniaPlugin(channelId = DEFAULT_CHANNEL_ID, meta = {}) {
+  const plugin = createChatChannelPlugin({
+    base: createChannelPluginBase({
+      id: channelId,
+      meta,
+      config: {
+        listAccountIds: (cfg) => listAccountIds(cfg, channelId),
+        resolveAccount: (cfg, accountId) => resolveAccount(cfg, accountId, channelId),
+        inspectAccount: (cfg, accountId) => inspectAccount(cfg, accountId, channelId),
+        defaultAccountId: (cfg) => listAccountIds(cfg, channelId)[0] || "default",
+        isEnabled: (account) => account.enabled,
+        isConfigured: (account) => Boolean(account.username && account.passwordFile),
+        describeAccount: (account) => ({
+          id: account.accountId,
+          name: account.character || account.username,
+          enabled: account.enabled,
+          configured: Boolean(account.username && account.passwordFile),
+          connected: Boolean(getClient(account.channelId, account.accountId)),
+        }),
+      },
+      setup: {
+        applyAccountConfig: ({ cfg }) => cfg,
+      },
+    }),
+    outbound: {
+      base: {
+        deliveryMode: "gateway",
+        resolveTarget: ({ to }) => ({ ok: true, to: to || "default" }),
+      },
+      attachedResults: {
+        channel: channelId,
+        sendText: async ({ cfg, to, text, accountId }) => {
+          const id = accountId || to;
+          const client = getClient(channelId, id);
+          if (!client) {
+            throw new Error(`evennia account ${channelId}:${id} is not connected`);
+          }
+          const account = inspectAccount(cfg, id, channelId);
+          await deliverEvenniaText(client, account, text);
+          return { messageId: `${channelId}-out-${Date.now()}` };
+        },
       },
     },
-  },
+  });
+
+  plugin.actions = {
+    describeMessageTool: ({ cfg, accountId }) => {
+      const accounts = accountId
+        ? [inspectAccount(cfg, accountId, channelId)]
+        : listAccountIds(cfg, channelId).map((id) => inspectAccount(cfg, id, channelId));
+      if (accounts.every((account) => !account.enabled)) {
+        return null;
+      }
+      return { actions: ["send", "react"] };
+    },
+    supportsAction: ({ action }) => action === "send" || action === "react",
+    handleAction: async ({ action, params, accountId }) => {
+      if (action !== "react") {
+        throw new Error(`Unsupported Evennia message action: ${action}`);
+      }
+      const { emoji, remove, isEmpty } = readReactionParams(params, {
+        removeErrorMessage: "Emoji is required to remove an Evennia pose reaction.",
+      });
+      if (remove) {
+        return jsonResult({ ok: true, removed: 0, note: "Evennia poses cannot be removed." });
+      }
+
+      const {
+        channelId: resolvedChannelId,
+        accountId: resolvedAccountId,
+        client,
+      } = resolveActionClient(channelId, accountId, params);
+      const pose = poseForEvenniaReaction(emoji);
+      const command = `pose ${pose}`;
+      await client.command(command);
+      return jsonResult({
+        ok: true,
+        channelId: resolvedChannelId,
+        accountId: resolvedAccountId,
+        command,
+        emoji: isEmpty ? undefined : emoji,
+      });
+    },
+  };
+
+  // createChatChannelPlugin intentionally focuses the common chat surfaces; attach
+  // the long-running gateway adapter explicitly for this external transport.
+  plugin.gateway = {
+    startAccount: async (ctx) => {
+      if (!ctx.account.enabled) {
+        return;
+      }
+
+      let retryMs = 1000;
+      while (!ctx.abortSignal.aborted) {
+        const client = new EvenniaClient(ctx.account, ctx.log);
+        setClient(ctx.account, client);
+
+        const closeOnAbort = () => client.close();
+        ctx.abortSignal.addEventListener("abort", closeOnAbort, { once: true });
+
+        if (ctx.account.respondToAmbientMentions) {
+          client.onEvent((event) =>
+            dispatchEvenniaEvent(ctx, ctx.account, event).catch((err) =>
+              ctx.log?.error?.(`evennia inbound failed: ${err?.stack || err?.message || err}`),
+            ),
+          );
+        }
+
+        try {
+          await client.connect();
+          retryMs = 1000;
+          if (ctx.account.character) {
+            await client.command(`ic ${ctx.account.character}`).catch(() => {});
+          }
+          await new Promise((resolve) => setTimeout(resolve, 750));
+          if (ctx.account.startRoom) {
+            await client.command(`teleport ${ctx.account.startRoom}`).catch(() => {});
+          }
+          await client.command("look").catch(() => {});
+          ctx.setStatus({
+            accountId: ctx.account.accountId,
+            id: ctx.account.accountId,
+            name: ctx.account.character,
+            enabled: true,
+            configured: true,
+            connected: true,
+            running: true,
+          });
+
+          await client.waitClosed(ctx.abortSignal);
+        } catch (err) {
+          ctx.log?.warn?.(
+            `evennia connection failed for ${ctx.account.channelId}:${ctx.account.accountId}: ${err?.message || err}`,
+          );
+        } finally {
+          ctx.abortSignal.removeEventListener("abort", closeOnAbort);
+          deleteClient(ctx.account, client);
+          client.close();
+          ctx.setStatus({
+            accountId: ctx.account.accountId,
+            id: ctx.account.accountId,
+            name: ctx.account.character,
+            enabled: true,
+            configured: true,
+            connected: false,
+            running: !ctx.abortSignal.aborted,
+          });
+        }
+
+        if (ctx.abortSignal.aborted) {
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, retryMs));
+        retryMs = Math.min(retryMs * 2, 30000);
+      }
+    },
+    stopAccount: async ({ account }) => {
+      const client = getClient(account.channelId, account.accountId);
+      deleteClient(account);
+      client?.close();
+    },
+  };
+
+  return plugin;
+}
+
+export const evenniaPlugin = createEvenniaPlugin(DEFAULT_CHANNEL_ID);
+export const evenniaStagingPlugin = createEvenniaPlugin("evennia-staging", {
+  label: "Evennia Staging",
+  selectionLabel: "Evennia Staging (MUD bridge)",
+  detailLabel: "Evennia Staging WebSocket",
+  docsPath: "/channels/evennia-staging",
+  docsLabel: "evennia-staging",
+  blurb: "staging MUD bridge for isolated agent character testing.",
 });
-
-evenniaPlugin.actions = {
-  describeMessageTool: ({ cfg, accountId }) => {
-    const accounts = accountId
-      ? [inspectAccount(cfg, accountId)]
-      : listAccountIds(cfg).map((id) => inspectAccount(cfg, id));
-    if (accounts.every((account) => !account.enabled)) {
-      return null;
-    }
-    return { actions: ["send", "react"] };
-  },
-  supportsAction: ({ action }) => action === "send" || action === "react",
-  handleAction: async ({ action, params, accountId }) => {
-    if (action !== "react") {
-      throw new Error(`Unsupported Evennia message action: ${action}`);
-    }
-    const { emoji, remove, isEmpty } = readReactionParams(params, {
-      removeErrorMessage: "Emoji is required to remove an Evennia pose reaction.",
-    });
-    if (remove) {
-      return jsonResult({ ok: true, removed: 0, note: "Evennia poses cannot be removed." });
-    }
-
-    const { accountId: resolvedAccountId, client } = resolveActionClient(accountId, params);
-    const pose = poseForEvenniaReaction(emoji);
-    const command = `pose ${pose}`;
-    await client.command(command);
-    return jsonResult({
-      ok: true,
-      accountId: resolvedAccountId,
-      command,
-      emoji: isEmpty ? undefined : emoji,
-    });
-  },
-};
-
-// createChatChannelPlugin intentionally focuses the common chat surfaces; attach
-// the long-running gateway adapter explicitly for this external transport.
-evenniaPlugin.gateway = {
-  startAccount: async (ctx) => {
-    if (!ctx.account.enabled) {
-      return;
-    }
-
-    let retryMs = 1000;
-    while (!ctx.abortSignal.aborted) {
-      const client = new EvenniaClient(ctx.account, ctx.log);
-      clients.set(ctx.account.accountId, client);
-
-      const closeOnAbort = () => client.close();
-      ctx.abortSignal.addEventListener("abort", closeOnAbort, { once: true });
-
-      if (ctx.account.respondToAmbientMentions) {
-        client.onEvent((event) =>
-          dispatchEvenniaEvent(ctx, ctx.account, event).catch((err) =>
-            ctx.log?.error?.(`evennia inbound failed: ${err?.stack || err?.message || err}`),
-          ),
-        );
-      }
-
-      try {
-        await client.connect();
-        retryMs = 1000;
-        if (ctx.account.character) {
-          await client.command(`ic ${ctx.account.character}`).catch(() => {});
-        }
-        await new Promise((resolve) => setTimeout(resolve, 750));
-        if (ctx.account.startRoom) {
-          await client.command(`teleport ${ctx.account.startRoom}`).catch(() => {});
-        }
-        await client.command("look").catch(() => {});
-        ctx.setStatus({
-          accountId: ctx.account.accountId,
-          id: ctx.account.accountId,
-          name: ctx.account.character,
-          enabled: true,
-          configured: true,
-          connected: true,
-          running: true,
-        });
-
-        await client.waitClosed(ctx.abortSignal);
-      } catch (err) {
-        ctx.log?.warn?.(
-          `evennia connection failed for ${ctx.account.accountId}: ${err?.message || err}`,
-        );
-      } finally {
-        ctx.abortSignal.removeEventListener("abort", closeOnAbort);
-        if (clients.get(ctx.account.accountId) === client) {
-          clients.delete(ctx.account.accountId);
-        }
-        client.close();
-        ctx.setStatus({
-          accountId: ctx.account.accountId,
-          id: ctx.account.accountId,
-          name: ctx.account.character,
-          enabled: true,
-          configured: true,
-          connected: false,
-          running: !ctx.abortSignal.aborted,
-        });
-      }
-
-      if (ctx.abortSignal.aborted) {
-        break;
-      }
-      await new Promise((resolve) => setTimeout(resolve, retryMs));
-      retryMs = Math.min(retryMs * 2, 30000);
-    }
-  },
-  stopAccount: async ({ account }) => {
-    const client = clients.get(account.accountId);
-    clients.delete(account.accountId);
-    client?.close();
-  },
-};

--- a/extensions/evennia/src/channel.js
+++ b/extensions/evennia/src/channel.js
@@ -128,12 +128,9 @@ async function dispatchEvenniaEvent(ctx, account, event) {
     ctx.log?.warn?.("evennia channelRuntime unavailable; inbound ignored");
     return;
   }
-  if (!account.respondToAmbientMentions) return;
-
-  const lower = event.text.toLowerCase();
   const direct = event.kind === "tell" || event.kind === "whisper";
-  const mentioned = lower.includes(account.triggerName.toLowerCase());
-  if (!direct && !mentioned) return;
+  if (!direct && !account.respondToAmbientMentions) return;
+  if (direct && account.respondToAmbientMentions === false) return;
 
   const messageId = event.id || `evennia-${Date.now()}`;
   const routeSessionKey = rt.routing.buildAgentSessionKey({

--- a/extensions/evennia/src/channel.js
+++ b/extensions/evennia/src/channel.js
@@ -28,6 +28,7 @@ const EVENNIA_AGENT_PROMPT = [
   "Examples of commands to send through the tool: look, north, get key, open crate, take emergency chalk from crate, get all from crate, use terminal, use chalk stub, pose studies the room.",
   "For open containers, prefer `take <item> from <container>` or `get all from <container>` rather than `get <container>` unless you mean to loot all visible contents.",
   "Never put pose commands in backticks or inline with speech. Use the tool, then send spoken text separately.",
+  "Never append commands after emojis or narration. If you need to move, send the movement command through the tool.",
   "Never put multiple Evennia commands in one tool call; use one tool call per command.",
 ].join("\n");
 
@@ -405,6 +406,33 @@ function choosePose(candidates, avoid = "") {
   return choicePool[Math.floor(Math.random() * choicePool.length)];
 }
 
+function rewriteTrailingInlineMovementCommand(value, literalCommands) {
+  const match = value.match(
+    /([\p{Extended_Pictographic}\u2600-\u27bf](?:[\ufe0e\ufe0f]|\u200d[\p{Extended_Pictographic}\u2600-\u27bf](?:[\ufe0e\ufe0f])?)*)\s*([a-z][a-z0-9'-]*(?:\s+[a-z][a-z0-9'-]*){1,3})\s*$/iu,
+  );
+  if (!match || match.index === undefined) {
+    return value;
+  }
+
+  const before = value.slice(0, match.index).trimEnd();
+  const command = match[2].replace(/\s+/g, " ").trim().toLowerCase();
+  if (!before || !command) {
+    return value;
+  }
+
+  const hasMovementIntent =
+    /\b(arrive|arrives|arriving|back|come|coming|enter|entering|enters|exit|follow|following|go|goes|going|head|headed|heading|heads|leave|leaves|leaving|meet|meeting|move|moves|moving|return|returning|returns|stride|strides|striding|toward|travel|travels|travelling|walking|walks)\b/iu.test(
+      before,
+    );
+  if (!hasMovementIntent) {
+    return value;
+  }
+
+  const commandIndex = literalCommands.length;
+  literalCommands.push(command);
+  return `${before}\n__OPENCLAW_EVENNIA_COMMAND__${commandIndex}__\n`;
+}
+
 export function splitEvenniaOutboundText(text, account = undefined) {
   const raw = String(text ?? "");
   const parts = [];
@@ -440,6 +468,7 @@ export function splitEvenniaOutboundText(text, account = undefined) {
     toolIndex = match.index + match[0].length;
   }
   rewritten += raw.slice(toolIndex);
+  rewritten = rewriteTrailingInlineMovementCommand(rewritten, literalCommands);
 
   const codePose = /`+\s*pose\s+([^`]+?)\s*`+/giu;
   let index = 0;

--- a/extensions/evennia/src/channel.js
+++ b/extensions/evennia/src/channel.js
@@ -48,17 +48,6 @@ function resolveAccount(cfg, accountId = null) {
     allowFrom: raw.allowFrom || [],
     allowedRooms: raw.allowedRooms || [],
     respondToAmbientMentions: raw.respondToAmbientMentions !== false,
-    autonomy: {
-      enabled: Boolean(raw.autonomy?.enabled),
-      intervalMs: Math.max(10000, Number(raw.autonomy?.intervalMs || 90000)),
-      idleChance: Math.max(
-        0,
-        Math.min(1, Number(raw.autonomy?.idleChance ?? 0.5)),
-      ),
-      commands: Array.isArray(raw.autonomy?.commands)
-        ? raw.autonomy.commands.map(String).filter(Boolean)
-        : ["look"],
-    },
   };
 }
 
@@ -263,35 +252,6 @@ async function dispatchEvenniaEvent(ctx, account, event) {
   });
 }
 
-function startAutonomyLoop(ctx, account, client) {
-  const autonomy = account.autonomy;
-  if (!autonomy?.enabled || !autonomy.commands.length) return () => {};
-  let busy = false;
-  const tick = async () => {
-    if (busy || client.isClosed()) return;
-    if (Math.random() < autonomy.idleChance) return;
-    const command =
-      autonomy.commands[Math.floor(Math.random() * autonomy.commands.length)];
-    if (!command || command.includes("\n") || command.includes("\r")) return;
-    busy = true;
-    try {
-      await client.command(command);
-    } catch (err) {
-      ctx.log?.warn?.(
-        `evennia autonomy command failed: ${err?.message || err}`,
-      );
-    } finally {
-      busy = false;
-    }
-  };
-  const timer = setInterval(tick, autonomy.intervalMs);
-  timer.unref?.();
-  ctx.abortSignal.addEventListener("abort", () => clearInterval(timer), {
-    once: true,
-  });
-  return () => clearInterval(timer);
-}
-
 export const evenniaPlugin = createChatChannelPlugin({
   base: createChannelPluginBase({
     id: "evennia",
@@ -351,7 +311,6 @@ evenniaPlugin.gateway = {
       ),
     );
     await client.connect();
-    startAutonomyLoop(ctx, ctx.account, client);
     if (ctx.account.character)
       await client.command(`ic ${ctx.account.character}`).catch(() => {});
     await new Promise((resolve) => setTimeout(resolve, 750));

--- a/extensions/evennia/src/channel.js
+++ b/extensions/evennia/src/channel.js
@@ -1,18 +1,24 @@
-import {
-  createChannelPluginBase,
-  createChatChannelPlugin,
-} from "openclaw/plugin-sdk/channel-core";
+import { readReactionParams } from "openclaw/plugin-sdk/channel-actions";
+import { createChannelPluginBase, createChatChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import { jsonResult } from "openclaw/plugin-sdk/core";
 import { Type } from "typebox";
 import { EvenniaClient } from "./evennia-client.js";
 
 const clients = new Map();
 
+const ROOM_CONTEXT_MAX_CHARS = 5000;
+const HELP_CONTEXT_MAX_CHARS = 2500;
+
 const EVENNIA_AGENT_PROMPT = [
   "You are acting as an Evennia MUD character through the Evennia channel.",
   "Use normal text replies when you want to speak in-character.",
+  "Before each turn, OpenClaw may include a fresh `look` snapshot and cached `help` output in your context. Treat those as the authoritative room state.",
+  "If the user asks you to look around, inspect exits, inspect objects, or check available actions, use the evennia_command tool (`look`, `help`, `examine <thing>`, etc.) before answering.",
   "When you want to perform an in-world action or run an Evennia command, call the evennia_command tool with exactly that command instead of saying the command aloud.",
-  "Examples of commands to send through the tool: look, north, get key, use terminal, use chalk stub, pose studies the room.",
+  "Never say text like `evennia_command(command=...)`; that is not an action. Use the actual tool call.",
+  "Examples of commands to send through the tool: look, north, get key, open crate, take emergency chalk from crate, get all from crate, use terminal, use chalk stub, pose studies the room.",
+  "For open containers, prefer `take <item> from <container>` or `get all from <container>` rather than `get <container>` unless you mean to loot all visible contents.",
+  "Never put pose commands in backticks or inline with speech. Use the tool, then send spoken text separately.",
   "Never put multiple Evennia commands in one tool call; use one tool call per command.",
 ].join("\n");
 
@@ -38,12 +44,7 @@ function resolveAccount(cfg, accountId = null) {
     username: raw.username,
     passwordFile: raw.passwordFile,
     character: raw.character || raw.username,
-    triggerName: (
-      raw.triggerName ||
-      raw.character ||
-      raw.username ||
-      id
-    ).toLowerCase(),
+    triggerName: (raw.triggerName || raw.character || raw.username || id).toLowerCase(),
     startRoom: raw.startRoom,
     allowFrom: raw.allowFrom || [],
     allowedRooms: raw.allowedRooms || [],
@@ -73,11 +74,459 @@ function inspectAccount(cfg, accountId = null) {
 function readToolString(raw, key, { required = false } = {}) {
   const value = raw?.[key];
   if (value === undefined || value === null) {
-    if (required) throw new Error(`${key} is required`);
+    if (required) {
+      throw new Error(`${key} is required`);
+    }
     return undefined;
   }
-  if (typeof value !== "string") throw new Error(`${key} must be a string`);
+  if (typeof value !== "string") {
+    throw new Error(`${key} must be a string`);
+  }
   return value;
+}
+
+const EVENNIA_REACTION_POSES = new Map([
+  [
+    "✅",
+    [
+      "lets out a quiet breath as a small confirmation rune fades from view.",
+      "gives one satisfied nod, the work settling into place.",
+      "relaxes their shoulders as the room's hum steadies again.",
+    ],
+  ],
+  [
+    "☑️",
+    [
+      "lets out a quiet breath as a small confirmation rune fades from view.",
+      "gives one satisfied nod, the work settling into place.",
+      "relaxes their shoulders as the room's hum steadies again.",
+    ],
+  ],
+  [
+    "👍",
+    [
+      "raises a hand in quick acknowledgement.",
+      "answers with a small, confident gesture of assent.",
+      "tilts their chin up in a brief sign of agreement.",
+    ],
+  ],
+  [
+    "👀",
+    [
+      "turns toward the speaker, attention sharpening.",
+      "stillness gathers around them as they listen closely.",
+      "glances up from the room's hum, clearly taking this in.",
+      "sets aside whatever they were holding and focuses on the moment.",
+    ],
+  ],
+  [
+    "🔎",
+    [
+      "narrows their eyes, searching the room for the hidden thread.",
+      "studies the nearest signs with careful suspicion.",
+      "leans closer, following a clue only half-visible in the air.",
+    ],
+  ],
+  [
+    "🔍",
+    [
+      "narrows their eyes, searching the room for the hidden thread.",
+      "studies the nearest signs with careful suspicion.",
+      "leans closer, following a clue only half-visible in the air.",
+    ],
+  ],
+  [
+    "🤔",
+    [
+      "tilts their head, letting the thought turn over slowly.",
+      "falls quiet for a beat, weighing the shape of the problem.",
+      "taps a finger once, then again, chasing the right answer.",
+    ],
+  ],
+  [
+    "🧠",
+    [
+      "goes still while thoughts churn behind their eyes.",
+      "draws a slow circle in the air, arranging the idea before speaking.",
+      "looks inward for a moment, listening to the old machinery of thought.",
+    ],
+  ],
+  [
+    "⏳",
+    [
+      "waits as a faint hourglass shimmer hangs nearby.",
+      "keeps watch while the moment stretches longer than expected.",
+      "holds position, patient but alert, as the air ticks softly.",
+    ],
+  ],
+  [
+    "⌛",
+    [
+      "waits as a faint hourglass shimmer hangs nearby.",
+      "keeps watch while the moment stretches longer than expected.",
+      "holds position, patient but alert, as the air ticks softly.",
+    ],
+  ],
+  [
+    "🛠️",
+    [
+      "produces a tiny toolkit and starts making careful adjustments.",
+      "rolls up their sleeves and gets to work on the invisible mechanism.",
+      "checks the seams of the situation like a machine that can be tuned.",
+    ],
+  ],
+  [
+    "🧰",
+    [
+      "rummages through a battered toolkit for exactly the right implement.",
+      "sets a small case of tools on the floor and chooses carefully.",
+      "sorts through old instruments until one gives a promising little spark.",
+    ],
+  ],
+  [
+    "💻",
+    [
+      "unfolds a little terminal of blue-white light and starts typing.",
+      "summons a floating prompt and begins entering careful commands.",
+      "watches lines of pale text crawl across an unseen console.",
+    ],
+  ],
+  [
+    "📖",
+    [
+      "opens a worn notebook and scans the page.",
+      "runs a finger down an old margin, looking for the relevant line.",
+      "consults a dog-eared page covered in cramped annotations.",
+    ],
+  ],
+  [
+    "📚",
+    [
+      "consults an improbable stack of notes.",
+      "pulls three references from nowhere and cross-checks them quickly.",
+      "balances a leaning tower of lore just long enough to find the answer.",
+    ],
+  ],
+  [
+    "✍️",
+    [
+      "scribbles a note with focused intent.",
+      "marks something down before it can slip away.",
+      "writes a quick line in a ledger that smells faintly of ozone.",
+    ],
+  ],
+  [
+    "📝",
+    [
+      "scribbles a note with focused intent.",
+      "marks something down before it can slip away.",
+      "writes a quick line in a ledger that smells faintly of ozone.",
+    ],
+  ],
+  [
+    "🌐",
+    [
+      "traces a glowing line through an invisible web of connections.",
+      "listens to distant signals threading through the walls.",
+      "follows a thin blue filament of network-light into the unseen distance.",
+    ],
+  ],
+  [
+    "🛫",
+    [
+      "sets a tiny launch sigil spinning above one palm.",
+      "checks the wind of the upper Stack and prepares to send something outward.",
+      "lets a little paper-wing charm circle once before release.",
+    ],
+  ],
+  [
+    "🏗️",
+    [
+      "summons a wireframe scaffold and checks each glowing joint.",
+      "measures the air as if preparing to raise a new support beam.",
+      "sets spectral braces into place around the work ahead.",
+    ],
+  ],
+  [
+    "💁",
+    [
+      "straightens up, ready to handle the next practical detail.",
+      "makes a small welcoming gesture, prepared to take point.",
+      "turns with attentive poise, waiting for the useful next thing.",
+    ],
+  ],
+  [
+    "🧭",
+    [
+      "checks an old brass compass and adjusts course.",
+      "sets their bearing by a compass that points toward unfinished business.",
+      "turns the compass once and watches the needle settle.",
+    ],
+  ],
+  [
+    "📊",
+    [
+      "studies a hovering set of orderly little bars.",
+      "watches a row of tiny indicators rise and fall in the air.",
+      "compares the room's pulse against a neat ghostly chart.",
+    ],
+  ],
+  [
+    "🧪",
+    [
+      "swirls a tiny vial and watches the result closely.",
+      "adds one careful drop to the problem and waits for the color to change.",
+      "holds a small experiment up to the light of the racks.",
+    ],
+  ],
+  [
+    "⚠️",
+    [
+      "stiffens as a warning spark snaps in the air.",
+      "raises one hand as the room's edge gives a cautionary flicker.",
+      "goes alert, attention pulled toward a sharp note in the hum.",
+    ],
+  ],
+  [
+    "❌",
+    [
+      "shakes their head, the air briefly crackling with refusal.",
+      "cuts the motion short with a firm, wordless no.",
+      "draws a line in the dust and does not step across it.",
+    ],
+  ],
+  [
+    "🚫",
+    [
+      "holds up a hand, blocking the path for now.",
+      "sets a small ward across the way until it is safe to continue.",
+      "plants their palm against the air and the moment stops there.",
+    ],
+  ],
+  [
+    "🗜️",
+    [
+      "compresses a bundle of glowing notes into a smaller, denser charm.",
+      "folds a long thread of thought into a tight little knot.",
+      "presses scattered context into a compact sigil and pockets it.",
+    ],
+  ],
+  [
+    "💤",
+    [
+      "settles into a quiet, watchful idle.",
+      "lets the room's hum carry the watch for a while.",
+      "goes still, present but no longer reaching for the next motion.",
+    ],
+  ],
+]);
+
+function normalizeEmojiKey(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function stripUnsafePoseText(text) {
+  return text
+    .replace(/[\r\n]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function stripLeadingCharacterName(text, account) {
+  const character = account?.character?.trim();
+  const clean = stripUnsafePoseText(text);
+  if (!character) {
+    return clean;
+  }
+  const escaped = character.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return clean.replace(new RegExp(`^${escaped}(?:\\s+|[,;:—–-]+\\s*)`, "iu"), "").trimStart();
+}
+
+function normalizePoseCommand(command, account) {
+  const match = String(command ?? "")
+    .trim()
+    .match(/^pose\s+(.+)$/iu);
+  if (!match) {
+    return command;
+  }
+  return `pose ${stripLeadingCharacterName(match[1], account)}`.trim();
+}
+
+function choosePose(candidates, avoid = "") {
+  const poses = Array.isArray(candidates)
+    ? candidates.filter(Boolean)
+    : [candidates].filter(Boolean);
+  if (poses.length === 0) {
+    return undefined;
+  }
+  const pool = poses.length > 1 ? poses.filter((pose) => pose !== avoid) : poses;
+  const choicePool = pool.length > 0 ? pool : poses;
+  return choicePool[Math.floor(Math.random() * choicePool.length)];
+}
+
+export function splitEvenniaOutboundText(text, account = undefined) {
+  const raw = String(text ?? "");
+  const parts = [];
+  const pushSay = (value) => {
+    const clean = value.replace(/\s+/g, " ").trim();
+    if (clean) {
+      parts.push({ kind: "say", text: clean });
+    }
+  };
+  const pushPose = (value) => {
+    const clean = stripLeadingCharacterName(value, account);
+    if (clean) {
+      parts.push({ kind: "pose", text: clean });
+    }
+  };
+
+  const codePose = /`+\s*pose\s+([^`]+?)\s*`+/giu;
+  let index = 0;
+  for (const match of raw.matchAll(codePose)) {
+    pushSay(raw.slice(index, match.index));
+    pushPose(match[1]);
+    index = match.index + match[0].length;
+  }
+  const tail = raw.slice(index);
+  for (const line of tail.split(/\n+/)) {
+    const command = line.trim().match(/^pose\s+(.+)$/iu);
+    if (command) {
+      pushPose(command[1]);
+    } else {
+      pushSay(line);
+    }
+  }
+  return parts;
+}
+
+async function deliverEvenniaText(client, account, text, { replyMode = "say", target } = {}) {
+  const parts = splitEvenniaOutboundText(text, account);
+  for (const part of parts) {
+    if (part.kind === "pose") {
+      await client.command(`pose ${part.text}`);
+    } else if (replyMode === "tell" && target) {
+      await client.tell(target, part.text);
+    } else if (replyMode === "whisper" && target) {
+      await client.whisper(target, part.text);
+    } else {
+      await client.say(part.text);
+    }
+  }
+}
+
+function extractLeadingEmoji(text) {
+  const match = String(text ?? "")
+    .trim()
+    .match(/^(\p{Extended_Pictographic}(?:\uFE0F|\uFE0E)?)/u);
+  return match?.[1];
+}
+
+function createEvenniaStatusPoseController(client, log) {
+  let lastPose = "";
+  async function setEmoji(emoji) {
+    const key = normalizeEmojiKey(emoji);
+    if (!key) {
+      return;
+    }
+    const pose = poseForEvenniaReaction(key, { avoid: lastPose });
+    if (!pose || pose === lastPose) {
+      return;
+    }
+    lastPose = pose;
+    try {
+      await client.command(`pose ${pose}`);
+    } catch (err) {
+      log?.warn?.(`evennia status pose failed: ${err?.message || err}`);
+    }
+  }
+  return {
+    setEmoji,
+    setToolResult: async (payload) => {
+      const emoji = extractLeadingEmoji(payload?.text);
+      if (emoji) {
+        await setEmoji(emoji);
+      } else if (payload?.isError) {
+        await setEmoji("⚠️");
+      } else {
+        await setEmoji("🛠️");
+      }
+    },
+  };
+}
+
+export function poseForEvenniaReaction(emoji, options = {}) {
+  const key = normalizeEmojiKey(emoji);
+  if (!key) {
+    return "makes a small, wordless gesture of acknowledgement.";
+  }
+  const mapped = choosePose(EVENNIA_REACTION_POSES.get(key), options.avoid);
+  if (mapped) {
+    return mapped;
+  }
+  const visible = stripUnsafePoseText(key).slice(0, 24);
+  return visible
+    ? `makes a small in-world gesture marked by ${visible}.`
+    : "makes a small, wordless gesture of acknowledgement.";
+}
+
+function formatContextBlock(title, text) {
+  const clean = String(text ?? "").trim();
+  return clean ? `\n\n[${title}]\n${clean}` : "";
+}
+
+async function collectRoomContext(client, log) {
+  try {
+    return await client.commandAndCollect("look", {
+      waitMs: 750,
+      maxChars: ROOM_CONTEXT_MAX_CHARS,
+    });
+  } catch (err) {
+    log?.warn?.(`evennia look context failed: ${err?.message || err}`);
+    return "";
+  }
+}
+
+async function collectHelpContext(client, log) {
+  if (client.helpText) {
+    return client.helpText;
+  }
+  try {
+    client.helpText = await client.commandAndCollect("help", {
+      waitMs: 900,
+      maxChars: HELP_CONTEXT_MAX_CHARS,
+    });
+  } catch (err) {
+    log?.warn?.(`evennia help context failed: ${err?.message || err}`);
+    client.helpText = "";
+  }
+  return client.helpText;
+}
+
+function isMentioned(event, account) {
+  if (event.kind === "tell" || event.kind === "whisper") {
+    return true;
+  }
+  const trigger = account.triggerName?.trim().toLowerCase();
+  if (!trigger) {
+    return false;
+  }
+  return event.text?.toLowerCase().includes(trigger) === true;
+}
+
+function resolveActionClient(accountId, params = {}) {
+  const requested =
+    (typeof accountId === "string" && accountId.trim()) ||
+    (typeof params.accountId === "string" && params.accountId.trim()) ||
+    (typeof params.to === "string" && params.to.trim()) ||
+    clients.keys().next().value;
+  if (!requested) {
+    throw new Error("no connected Evennia accounts are available");
+  }
+  const client = clients.get(requested);
+  if (!client) {
+    throw new Error(`evennia account ${requested} is not connected`);
+  }
+  return { accountId: requested, client };
 }
 
 export function createEvenniaCommandTool() {
@@ -102,22 +551,25 @@ export function createEvenniaCommandTool() {
       const command = readToolString(rawParams, "command", {
         required: true,
       }).trim();
-      if (!command) throw new Error("command must not be empty");
+      if (!command) {
+        throw new Error("command must not be empty");
+      }
       if (command.includes("\n") || command.includes("\r")) {
-        throw new Error(
-          "command must be a single Evennia command without newlines",
-        );
+        throw new Error("command must be a single Evennia command without newlines");
       }
 
       const requestedAccountId = readToolString(rawParams, "accountId")?.trim();
       const accountId = requestedAccountId || clients.keys().next().value;
-      if (!accountId)
+      if (!accountId) {
         throw new Error("no connected Evennia accounts are available");
+      }
       const client = clients.get(accountId);
-      if (!client)
+      if (!client) {
         throw new Error(`evennia account ${accountId} is not connected`);
-      await client.command(command);
-      return jsonResult({ ok: true, accountId, command });
+      }
+      const normalizedCommand = normalizePoseCommand(command, client.account);
+      await client.command(normalizedCommand);
+      return jsonResult({ ok: true, accountId, command: normalizedCommand });
     },
   };
 }
@@ -129,8 +581,21 @@ async function dispatchEvenniaEvent(ctx, account, event) {
     return;
   }
   const direct = event.kind === "tell" || event.kind === "whisper";
-  if (!direct && !account.respondToAmbientMentions) return;
-  if (direct && account.respondToAmbientMentions === false) return;
+  const mentioned = isMentioned(event, account);
+  if (!direct && !account.respondToAmbientMentions) {
+    return;
+  }
+  if (direct && account.respondToAmbientMentions === false) {
+    return;
+  }
+  if (!direct && !mentioned) {
+    return;
+  }
+
+  const client = clients.get(account.accountId);
+  const roomContext = client ? await collectRoomContext(client, ctx.log) : "";
+  const helpContext = client ? await collectHelpContext(client, ctx.log) : "";
+  const stateContext = `${formatContextBlock("Current room from automatic look", roomContext)}${formatContextBlock("Available Evennia help", helpContext)}`;
 
   const messageId = event.id || `evennia-${Date.now()}`;
   const routeSessionKey = rt.routing.buildAgentSessionKey({
@@ -181,7 +646,7 @@ async function dispatchEvenniaEvent(ctx, account, event) {
     message: {
       rawBody: event.text,
       body: event.text,
-      bodyForAgent: `[Evennia ${direct ? "tell" : "room"} from ${event.sender}${event.room ? ` in ${event.room}` : ""}]\n${event.text}`,
+      bodyForAgent: `[Evennia ${direct ? "tell" : "room"} from ${event.sender}${event.room ? ` in ${event.room}` : ""}]\n${event.text}${stateContext}`,
       commandBody: event.text,
       envelopeFrom: event.sender,
       senderLabel: event.sender,
@@ -215,40 +680,57 @@ async function dispatchEvenniaEvent(ctx, account, event) {
     },
   });
 
-  await rt.turn.dispatchAssembled({
-    cfg: ctx.cfg,
-    channel: "evennia",
-    accountId: account.accountId,
-    agentId: account.agentId,
-    routeSessionKey,
-    storePath,
-    ctxPayload,
-    recordInboundSession: rt.session.recordInboundSession,
-    dispatchReplyWithBufferedBlockDispatcher:
-      rt.reply.dispatchReplyWithBufferedBlockDispatcher,
-    messageId,
-    admission: {
-      kind: "dispatch",
-      reason: direct ? "direct-tell" : "mentioned",
-    },
-    delivery: {
-      deliver: async (payload) => {
-        const text = payload?.text || payload?.content || "";
-        if (text.trim()) {
-          const client = clients.get(account.accountId);
-          if (event.replyMode === "tell")
-            await client?.tell(event.sender, text.trim());
-          else if (event.replyMode === "whisper")
-            await client?.whisper(event.sender, text.trim());
-          else await client?.say(text.trim());
-        }
-        return {
-          messageIds: [`evennia-out-${Date.now()}`],
-          visibleReplySent: true,
-        };
+  const statusClient = clients.get(account.accountId);
+  const statusPoses = statusClient
+    ? createEvenniaStatusPoseController(statusClient, ctx.log)
+    : null;
+  await statusPoses?.setEmoji("👀");
+
+  try {
+    await rt.turn.dispatchAssembled({
+      cfg: ctx.cfg,
+      channel: "evennia",
+      accountId: account.accountId,
+      agentId: account.agentId,
+      routeSessionKey,
+      storePath,
+      ctxPayload,
+      recordInboundSession: rt.session.recordInboundSession,
+      dispatchReplyWithBufferedBlockDispatcher: rt.reply.dispatchReplyWithBufferedBlockDispatcher,
+      messageId,
+      replyOptions: {
+        onToolResult: async (payload) => {
+          await statusPoses?.setToolResult(payload);
+        },
       },
-    },
-  });
+      admission: {
+        kind: "dispatch",
+        reason: direct ? "direct-tell" : "mentioned",
+      },
+      delivery: {
+        deliver: async (payload) => {
+          const text = payload?.text || payload?.content || "";
+          if (text.trim()) {
+            const client = clients.get(account.accountId);
+            if (client) {
+              await deliverEvenniaText(client, account, text.trim(), {
+                replyMode: event.replyMode,
+                target: event.sender,
+              });
+            }
+          }
+          return {
+            messageIds: [`evennia-out-${Date.now()}`],
+            visibleReplySent: true,
+          };
+        },
+      },
+    });
+    await statusPoses?.setEmoji("✅");
+  } catch (err) {
+    await statusPoses?.setEmoji("⚠️");
+    throw err;
+  }
 }
 
 export const evenniaPlugin = createChatChannelPlugin({
@@ -260,8 +742,7 @@ export const evenniaPlugin = createChatChannelPlugin({
       inspectAccount,
       defaultAccountId: (cfg) => listAccountIds(cfg)[0] || "default",
       isEnabled: (account) => account.enabled,
-      isConfigured: (account) =>
-        Boolean(account.username && account.passwordFile),
+      isConfigured: (account) => Boolean(account.username && account.passwordFile),
       describeAccount: (account) => ({
         id: account.accountId,
         name: account.character || account.username,
@@ -281,22 +762,62 @@ export const evenniaPlugin = createChatChannelPlugin({
     },
     attachedResults: {
       channel: "evennia",
-      sendText: async ({ to, text, accountId }) => {
+      sendText: async ({ cfg, to, text, accountId }) => {
         const id = accountId || to;
         const client = clients.get(id);
-        if (!client) throw new Error(`evennia account ${id} is not connected`);
-        await client.say(text);
+        if (!client) {
+          throw new Error(`evennia account ${id} is not connected`);
+        }
+        const account = inspectAccount(cfg, id);
+        await deliverEvenniaText(client, account, text);
         return { messageId: `evennia-out-${Date.now()}` };
       },
     },
   },
 });
 
+evenniaPlugin.actions = {
+  describeMessageTool: ({ cfg, accountId }) => {
+    const accounts = accountId
+      ? [inspectAccount(cfg, accountId)]
+      : listAccountIds(cfg).map((id) => inspectAccount(cfg, id));
+    if (accounts.every((account) => !account.enabled)) {
+      return null;
+    }
+    return { actions: ["send", "react"] };
+  },
+  supportsAction: ({ action }) => action === "send" || action === "react",
+  handleAction: async ({ action, params, accountId }) => {
+    if (action !== "react") {
+      throw new Error(`Unsupported Evennia message action: ${action}`);
+    }
+    const { emoji, remove, isEmpty } = readReactionParams(params, {
+      removeErrorMessage: "Emoji is required to remove an Evennia pose reaction.",
+    });
+    if (remove) {
+      return jsonResult({ ok: true, removed: 0, note: "Evennia poses cannot be removed." });
+    }
+
+    const { accountId: resolvedAccountId, client } = resolveActionClient(accountId, params);
+    const pose = poseForEvenniaReaction(emoji);
+    const command = `pose ${pose}`;
+    await client.command(command);
+    return jsonResult({
+      ok: true,
+      accountId: resolvedAccountId,
+      command,
+      emoji: isEmpty ? undefined : emoji,
+    });
+  },
+};
+
 // createChatChannelPlugin intentionally focuses the common chat surfaces; attach
 // the long-running gateway adapter explicitly for this external transport.
 evenniaPlugin.gateway = {
   startAccount: async (ctx) => {
-    if (!ctx.account.enabled) return;
+    if (!ctx.account.enabled) {
+      return;
+    }
 
     let retryMs = 1000;
     while (!ctx.abortSignal.aborted) {
@@ -309,9 +830,7 @@ evenniaPlugin.gateway = {
       if (ctx.account.respondToAmbientMentions) {
         client.onEvent((event) =>
           dispatchEvenniaEvent(ctx, ctx.account, event).catch((err) =>
-            ctx.log?.error?.(
-              `evennia inbound failed: ${err?.stack || err?.message || err}`,
-            ),
+            ctx.log?.error?.(`evennia inbound failed: ${err?.stack || err?.message || err}`),
           ),
         );
       }
@@ -319,11 +838,13 @@ evenniaPlugin.gateway = {
       try {
         await client.connect();
         retryMs = 1000;
-        if (ctx.account.character)
+        if (ctx.account.character) {
           await client.command(`ic ${ctx.account.character}`).catch(() => {});
+        }
         await new Promise((resolve) => setTimeout(resolve, 750));
-        if (ctx.account.startRoom)
+        if (ctx.account.startRoom) {
           await client.command(`teleport ${ctx.account.startRoom}`).catch(() => {});
+        }
         await client.command("look").catch(() => {});
         ctx.setStatus({
           accountId: ctx.account.accountId,
@@ -357,7 +878,9 @@ evenniaPlugin.gateway = {
         });
       }
 
-      if (ctx.abortSignal.aborted) break;
+      if (ctx.abortSignal.aborted) {
+        break;
+      }
       await new Promise((resolve) => setTimeout(resolve, retryMs));
       retryMs = Math.min(retryMs * 2, 30000);
     }

--- a/extensions/evennia/src/channel.js
+++ b/extensions/evennia/src/channel.js
@@ -8,6 +8,14 @@ import { EvenniaClient } from "./evennia-client.js";
 
 const clients = new Map();
 
+const EVENNIA_AGENT_PROMPT = [
+  "You are acting as an Evennia MUD character through the Evennia channel.",
+  "Use normal text replies when you want to speak in-character.",
+  "When you want to perform an in-world action or run an Evennia command, call the evennia_command tool with exactly that command instead of saying the command aloud.",
+  "Examples of commands to send through the tool: look, north, get key, use terminal, use chalk stub, pose studies the room.",
+  "Never put multiple Evennia commands in one tool call; use one tool call per command.",
+].join("\n");
+
 function channelSection(cfg) {
   return (cfg.channels && cfg.channels.evennia) || {};
 }
@@ -213,6 +221,9 @@ async function dispatchEvenniaEvent(ctx, account, event) {
         wasMentioned: direct || mentioned,
         hasAnyMention: mentioned,
       },
+    },
+    supplemental: {
+      groupSystemPrompt: EVENNIA_AGENT_PROMPT,
     },
   });
 

--- a/extensions/evennia/src/channel.js
+++ b/extensions/evennia/src/channel.js
@@ -128,10 +128,12 @@ async function dispatchEvenniaEvent(ctx, account, event) {
     ctx.log?.warn?.("evennia channelRuntime unavailable; inbound ignored");
     return;
   }
+  if (!account.respondToAmbientMentions) return;
+
   const lower = event.text.toLowerCase();
   const direct = event.kind === "tell" || event.kind === "whisper";
   const mentioned = lower.includes(account.triggerName.toLowerCase());
-  if (!direct && account.respondToAmbientMentions && !mentioned) return;
+  if (!direct && !mentioned) return;
 
   const messageId = event.id || `evennia-${Date.now()}`;
   const routeSessionKey = rt.routing.buildAgentSessionKey({
@@ -307,13 +309,15 @@ evenniaPlugin.gateway = {
       const closeOnAbort = () => client.close();
       ctx.abortSignal.addEventListener("abort", closeOnAbort, { once: true });
 
-      client.onEvent((event) =>
-        dispatchEvenniaEvent(ctx, ctx.account, event).catch((err) =>
-          ctx.log?.error?.(
-            `evennia inbound failed: ${err?.stack || err?.message || err}`,
+      if (ctx.account.respondToAmbientMentions) {
+        client.onEvent((event) =>
+          dispatchEvenniaEvent(ctx, ctx.account, event).catch((err) =>
+            ctx.log?.error?.(
+              `evennia inbound failed: ${err?.stack || err?.message || err}`,
+            ),
           ),
-        ),
-      );
+        );
+      }
 
       try {
         await client.connect();

--- a/extensions/evennia/src/channel.js
+++ b/extensions/evennia/src/channel.js
@@ -298,37 +298,68 @@ export const evenniaPlugin = createChatChannelPlugin({
 evenniaPlugin.gateway = {
   startAccount: async (ctx) => {
     if (!ctx.account.enabled) return;
-    const client = new EvenniaClient(ctx.account, ctx.log);
-    clients.set(ctx.account.accountId, client);
-    ctx.abortSignal.addEventListener("abort", () => client.close(), {
-      once: true,
-    });
-    client.onEvent((event) =>
-      dispatchEvenniaEvent(ctx, ctx.account, event).catch((err) =>
-        ctx.log?.error?.(
-          `evennia inbound failed: ${err?.stack || err?.message || err}`,
+
+    let retryMs = 1000;
+    while (!ctx.abortSignal.aborted) {
+      const client = new EvenniaClient(ctx.account, ctx.log);
+      clients.set(ctx.account.accountId, client);
+
+      const closeOnAbort = () => client.close();
+      ctx.abortSignal.addEventListener("abort", closeOnAbort, { once: true });
+
+      client.onEvent((event) =>
+        dispatchEvenniaEvent(ctx, ctx.account, event).catch((err) =>
+          ctx.log?.error?.(
+            `evennia inbound failed: ${err?.stack || err?.message || err}`,
+          ),
         ),
-      ),
-    );
-    await client.connect();
-    if (ctx.account.character)
-      await client.command(`ic ${ctx.account.character}`).catch(() => {});
-    await new Promise((resolve) => setTimeout(resolve, 750));
-    if (ctx.account.startRoom)
-      await client.command(`teleport ${ctx.account.startRoom}`).catch(() => {});
-    await client.command("look").catch(() => {});
-    ctx.setStatus({
-      accountId: ctx.account.accountId,
-      id: ctx.account.accountId,
-      name: ctx.account.character,
-      enabled: true,
-      configured: true,
-      connected: true,
-      running: true,
-    });
-    await new Promise((resolve) =>
-      ctx.abortSignal.addEventListener("abort", resolve, { once: true }),
-    );
+      );
+
+      try {
+        await client.connect();
+        retryMs = 1000;
+        if (ctx.account.character)
+          await client.command(`ic ${ctx.account.character}`).catch(() => {});
+        await new Promise((resolve) => setTimeout(resolve, 750));
+        if (ctx.account.startRoom)
+          await client.command(`teleport ${ctx.account.startRoom}`).catch(() => {});
+        await client.command("look").catch(() => {});
+        ctx.setStatus({
+          accountId: ctx.account.accountId,
+          id: ctx.account.accountId,
+          name: ctx.account.character,
+          enabled: true,
+          configured: true,
+          connected: true,
+          running: true,
+        });
+
+        await client.waitClosed(ctx.abortSignal);
+      } catch (err) {
+        ctx.log?.warn?.(
+          `evennia connection failed for ${ctx.account.accountId}: ${err?.message || err}`,
+        );
+      } finally {
+        ctx.abortSignal.removeEventListener("abort", closeOnAbort);
+        if (clients.get(ctx.account.accountId) === client) {
+          clients.delete(ctx.account.accountId);
+        }
+        client.close();
+        ctx.setStatus({
+          accountId: ctx.account.accountId,
+          id: ctx.account.accountId,
+          name: ctx.account.character,
+          enabled: true,
+          configured: true,
+          connected: false,
+          running: !ctx.abortSignal.aborted,
+        });
+      }
+
+      if (ctx.abortSignal.aborted) break;
+      await new Promise((resolve) => setTimeout(resolve, retryMs));
+      retryMs = Math.min(retryMs * 2, 30000);
+    }
   },
   stopAccount: async ({ account }) => {
     const client = clients.get(account.accountId);

--- a/extensions/evennia/src/channel.js
+++ b/extensions/evennia/src/channel.js
@@ -1,4 +1,9 @@
-import { createChannelPluginBase, createChatChannelPlugin } from "openclaw/plugin-sdk/channel-core";
+import {
+  createChannelPluginBase,
+  createChatChannelPlugin,
+} from "openclaw/plugin-sdk/channel-core";
+import { jsonResult } from "openclaw/plugin-sdk/core";
+import { Type } from "typebox";
 import { EvenniaClient } from "./evennia-client.js";
 
 const clients = new Map();
@@ -25,7 +30,12 @@ function resolveAccount(cfg, accountId = null) {
     username: raw.username,
     passwordFile: raw.passwordFile,
     character: raw.character || raw.username,
-    triggerName: (raw.triggerName || raw.character || raw.username || id).toLowerCase(),
+    triggerName: (
+      raw.triggerName ||
+      raw.character ||
+      raw.username ||
+      id
+    ).toLowerCase(),
     startRoom: raw.startRoom,
     allowFrom: raw.allowFrom || [],
     allowedRooms: raw.allowedRooms || [],
@@ -33,9 +43,14 @@ function resolveAccount(cfg, accountId = null) {
     autonomy: {
       enabled: Boolean(raw.autonomy?.enabled),
       intervalMs: Math.max(10000, Number(raw.autonomy?.intervalMs || 90000)),
-      idleChance: Math.max(0, Math.min(1, Number(raw.autonomy?.idleChance ?? 0.5))),
-      commands: Array.isArray(raw.autonomy?.commands) ? raw.autonomy.commands.map(String).filter(Boolean) : ["look"]
-    }
+      idleChance: Math.max(
+        0,
+        Math.min(1, Number(raw.autonomy?.idleChance ?? 0.5)),
+      ),
+      commands: Array.isArray(raw.autonomy?.commands)
+        ? raw.autonomy.commands.map(String).filter(Boolean)
+        : ["look"],
+    },
   };
 }
 
@@ -47,11 +62,67 @@ function inspectAccount(cfg, accountId = null) {
       configured: Boolean(account.username && account.passwordFile),
       tokenStatus: account.passwordFile ? "file" : "missing",
       accountId: account.accountId,
-      character: account.character
+      character: account.character,
     };
   } catch (err) {
-    return { enabled: false, configured: false, error: String(err?.message || err) };
+    return {
+      enabled: false,
+      configured: false,
+      error: String(err?.message || err),
+    };
   }
+}
+
+function readToolString(raw, key, { required = false } = {}) {
+  const value = raw?.[key];
+  if (value === undefined || value === null) {
+    if (required) throw new Error(`${key} is required`);
+    return undefined;
+  }
+  if (typeof value !== "string") throw new Error(`${key} must be a string`);
+  return value;
+}
+
+export function createEvenniaCommandTool() {
+  return {
+    name: "evennia_command",
+    label: "Evennia Command",
+    description:
+      "Send one raw command to an Evennia character. Evennia is the authority for permissions and game effects; this tool only rejects empty or multiline transport input.",
+    parameters: Type.Object({
+      command: Type.String({
+        description:
+          "One Evennia command to execute exactly as the character, for example: look, north, get key, use terminal, say hello. Must not contain newlines.",
+      }),
+      accountId: Type.Optional(
+        Type.String({
+          description:
+            "Configured Evennia account id/character route to use. Defaults to the first connected account.",
+        }),
+      ),
+    }),
+    async execute(_toolCallId, rawParams) {
+      const command = readToolString(rawParams, "command", {
+        required: true,
+      }).trim();
+      if (!command) throw new Error("command must not be empty");
+      if (command.includes("\n") || command.includes("\r")) {
+        throw new Error(
+          "command must be a single Evennia command without newlines",
+        );
+      }
+
+      const requestedAccountId = readToolString(rawParams, "accountId")?.trim();
+      const accountId = requestedAccountId || clients.keys().next().value;
+      if (!accountId)
+        throw new Error("no connected Evennia accounts are available");
+      const client = clients.get(accountId);
+      if (!client)
+        throw new Error(`evennia account ${accountId} is not connected`);
+      await client.command(command);
+      return jsonResult({ ok: true, accountId, command });
+    },
+  };
 }
 
 async function dispatchEvenniaEvent(ctx, account, event) {
@@ -70,9 +141,11 @@ async function dispatchEvenniaEvent(ctx, account, event) {
     agentId: account.agentId,
     channel: "evennia",
     chatType: direct ? "direct" : "group",
-    target: direct ? event.sender : (event.room || "room")
+    target: direct ? event.sender : event.room || "room",
   });
-  const storePath = rt.session.resolveStorePath(undefined, { agentId: account.agentId });
+  const storePath = rt.session.resolveStorePath(undefined, {
+    agentId: account.agentId,
+  });
   const ctxPayload = rt.turn.buildContext({
     channel: "evennia",
     accountId: account.accountId,
@@ -81,15 +154,34 @@ async function dispatchEvenniaEvent(ctx, account, event) {
     messageId,
     timestamp: event.timestamp || Date.now(),
     from: event.sender,
-    sender: { id: event.sender, name: event.sender, displayLabel: event.sender, isBot: false, isSelf: false },
+    sender: {
+      id: event.sender,
+      name: event.sender,
+      displayLabel: event.sender,
+      isBot: false,
+      isSelf: false,
+    },
     conversation: {
       kind: direct ? "direct" : "group",
-      id: direct ? event.sender : (event.room || "room"),
-      label: direct ? event.sender : (event.room || "Evennia room"),
-      routePeer: { kind: direct ? "direct" : "group", id: direct ? event.sender : (event.room || "room") }
+      id: direct ? event.sender : event.room || "room",
+      label: direct ? event.sender : event.room || "Evennia room",
+      routePeer: {
+        kind: direct ? "direct" : "group",
+        id: direct ? event.sender : event.room || "room",
+      },
     },
-    route: { agentId: account.agentId, accountId: account.accountId, routeSessionKey, createIfMissing: true },
-    reply: { to: account.accountId, originatingTo: account.accountId, deliveryTarget: account.accountId, replyToId: messageId },
+    route: {
+      agentId: account.agentId,
+      accountId: account.accountId,
+      routeSessionKey,
+      createIfMissing: true,
+    },
+    reply: {
+      to: account.accountId,
+      originatingTo: account.accountId,
+      deliveryTarget: account.accountId,
+      replyToId: messageId,
+    },
     message: {
       rawBody: event.text,
       body: event.text,
@@ -97,13 +189,31 @@ async function dispatchEvenniaEvent(ctx, account, event) {
       commandBody: event.text,
       envelopeFrom: event.sender,
       senderLabel: event.sender,
-      preview: event.text.slice(0, 200)
+      preview: event.text.slice(0, 200),
     },
     access: {
-      dm: direct ? { decision: "allow", allowFrom: account.allowFrom, reason: "evennia-direct" } : undefined,
-      group: !direct ? { policy: "open", routeAllowed: true, senderAllowed: true, allowFrom: account.allowFrom, requireMention: true } : undefined,
-      mentions: { canDetectMention: true, wasMentioned: direct || mentioned, hasAnyMention: mentioned }
-    }
+      dm: direct
+        ? {
+            decision: "allow",
+            allowFrom: account.allowFrom,
+            reason: "evennia-direct",
+          }
+        : undefined,
+      group: !direct
+        ? {
+            policy: "open",
+            routeAllowed: true,
+            senderAllowed: true,
+            allowFrom: account.allowFrom,
+            requireMention: true,
+          }
+        : undefined,
+      mentions: {
+        canDetectMention: true,
+        wasMentioned: direct || mentioned,
+        hasAnyMention: mentioned,
+      },
+    },
   });
 
   await rt.turn.dispatchAssembled({
@@ -115,24 +225,32 @@ async function dispatchEvenniaEvent(ctx, account, event) {
     storePath,
     ctxPayload,
     recordInboundSession: rt.session.recordInboundSession,
-    dispatchReplyWithBufferedBlockDispatcher: rt.reply.dispatchReplyWithBufferedBlockDispatcher,
+    dispatchReplyWithBufferedBlockDispatcher:
+      rt.reply.dispatchReplyWithBufferedBlockDispatcher,
     messageId,
-    admission: { kind: "dispatch", reason: direct ? "direct-tell" : "mentioned" },
+    admission: {
+      kind: "dispatch",
+      reason: direct ? "direct-tell" : "mentioned",
+    },
     delivery: {
       deliver: async (payload) => {
         const text = payload?.text || payload?.content || "";
         if (text.trim()) {
           const client = clients.get(account.accountId);
-          if (event.replyMode === "tell") await client?.tell(event.sender, text.trim());
-          else if (event.replyMode === "whisper") await client?.whisper(event.sender, text.trim());
+          if (event.replyMode === "tell")
+            await client?.tell(event.sender, text.trim());
+          else if (event.replyMode === "whisper")
+            await client?.whisper(event.sender, text.trim());
           else await client?.say(text.trim());
         }
-        return { messageIds: [`evennia-out-${Date.now()}`], visibleReplySent: true };
-      }
-    }
+        return {
+          messageIds: [`evennia-out-${Date.now()}`],
+          visibleReplySent: true,
+        };
+      },
+    },
   });
 }
-
 
 function startAutonomyLoop(ctx, account, client) {
   const autonomy = account.autonomy;
@@ -141,20 +259,25 @@ function startAutonomyLoop(ctx, account, client) {
   const tick = async () => {
     if (busy || client.isClosed()) return;
     if (Math.random() < autonomy.idleChance) return;
-    const command = autonomy.commands[Math.floor(Math.random() * autonomy.commands.length)];
+    const command =
+      autonomy.commands[Math.floor(Math.random() * autonomy.commands.length)];
     if (!command || command.includes("\n") || command.includes("\r")) return;
     busy = true;
     try {
       await client.command(command);
     } catch (err) {
-      ctx.log?.warn?.(`evennia autonomy command failed: ${err?.message || err}`);
+      ctx.log?.warn?.(
+        `evennia autonomy command failed: ${err?.message || err}`,
+      );
     } finally {
       busy = false;
     }
   };
   const timer = setInterval(tick, autonomy.intervalMs);
   timer.unref?.();
-  ctx.abortSignal.addEventListener("abort", () => clearInterval(timer), { once: true });
+  ctx.abortSignal.addEventListener("abort", () => clearInterval(timer), {
+    once: true,
+  });
   return () => clearInterval(timer);
 }
 
@@ -167,23 +290,24 @@ export const evenniaPlugin = createChatChannelPlugin({
       inspectAccount,
       defaultAccountId: (cfg) => listAccountIds(cfg)[0] || "default",
       isEnabled: (account) => account.enabled,
-      isConfigured: (account) => Boolean(account.username && account.passwordFile),
+      isConfigured: (account) =>
+        Boolean(account.username && account.passwordFile),
       describeAccount: (account) => ({
         id: account.accountId,
         name: account.character || account.username,
         enabled: account.enabled,
         configured: Boolean(account.username && account.passwordFile),
-        connected: clients.has(account.accountId)
-      })
+        connected: clients.has(account.accountId),
+      }),
     },
     setup: {
-      applyAccountConfig: ({ cfg }) => cfg
-    }
+      applyAccountConfig: ({ cfg }) => cfg,
+    },
   }),
   outbound: {
     base: {
       deliveryMode: "gateway",
-      resolveTarget: ({ to }) => ({ ok: true, to: to || "default" })
+      resolveTarget: ({ to }) => ({ ok: true, to: to || "default" }),
     },
     attachedResults: {
       channel: "evennia",
@@ -193,9 +317,9 @@ export const evenniaPlugin = createChatChannelPlugin({
         if (!client) throw new Error(`evennia account ${id} is not connected`);
         await client.say(text);
         return { messageId: `evennia-out-${Date.now()}` };
-      }
-    }
-  }
+      },
+    },
+  },
 });
 
 // createChatChannelPlugin intentionally focuses the common chat surfaces; attach
@@ -205,20 +329,40 @@ evenniaPlugin.gateway = {
     if (!ctx.account.enabled) return;
     const client = new EvenniaClient(ctx.account, ctx.log);
     clients.set(ctx.account.accountId, client);
-    ctx.abortSignal.addEventListener("abort", () => client.close(), { once: true });
-    client.onEvent((event) => dispatchEvenniaEvent(ctx, ctx.account, event).catch((err) => ctx.log?.error?.(`evennia inbound failed: ${err?.stack || err?.message || err}`)));
+    ctx.abortSignal.addEventListener("abort", () => client.close(), {
+      once: true,
+    });
+    client.onEvent((event) =>
+      dispatchEvenniaEvent(ctx, ctx.account, event).catch((err) =>
+        ctx.log?.error?.(
+          `evennia inbound failed: ${err?.stack || err?.message || err}`,
+        ),
+      ),
+    );
     await client.connect();
     startAutonomyLoop(ctx, ctx.account, client);
-    if (ctx.account.character) await client.command(`ic ${ctx.account.character}`).catch(() => {});
+    if (ctx.account.character)
+      await client.command(`ic ${ctx.account.character}`).catch(() => {});
     await new Promise((resolve) => setTimeout(resolve, 750));
-    if (ctx.account.startRoom) await client.command(`teleport ${ctx.account.startRoom}`).catch(() => {});
+    if (ctx.account.startRoom)
+      await client.command(`teleport ${ctx.account.startRoom}`).catch(() => {});
     await client.command("look").catch(() => {});
-    ctx.setStatus({ accountId: ctx.account.accountId, id: ctx.account.accountId, name: ctx.account.character, enabled: true, configured: true, connected: true, running: true });
-    await new Promise((resolve) => ctx.abortSignal.addEventListener("abort", resolve, { once: true }));
+    ctx.setStatus({
+      accountId: ctx.account.accountId,
+      id: ctx.account.accountId,
+      name: ctx.account.character,
+      enabled: true,
+      configured: true,
+      connected: true,
+      running: true,
+    });
+    await new Promise((resolve) =>
+      ctx.abortSignal.addEventListener("abort", resolve, { once: true }),
+    );
   },
   stopAccount: async ({ account }) => {
     const client = clients.get(account.accountId);
     clients.delete(account.accountId);
     client?.close();
-  }
+  },
 };

--- a/extensions/evennia/src/channel.js
+++ b/extensions/evennia/src/channel.js
@@ -29,7 +29,13 @@ function resolveAccount(cfg, accountId = null) {
     startRoom: raw.startRoom,
     allowFrom: raw.allowFrom || [],
     allowedRooms: raw.allowedRooms || [],
-    respondToAmbientMentions: raw.respondToAmbientMentions !== false
+    respondToAmbientMentions: raw.respondToAmbientMentions !== false,
+    autonomy: {
+      enabled: Boolean(raw.autonomy?.enabled),
+      intervalMs: Math.max(10000, Number(raw.autonomy?.intervalMs || 90000)),
+      idleChance: Math.max(0, Math.min(1, Number(raw.autonomy?.idleChance ?? 0.5))),
+      commands: Array.isArray(raw.autonomy?.commands) ? raw.autonomy.commands.map(String).filter(Boolean) : ["look"]
+    }
   };
 }
 
@@ -127,6 +133,31 @@ async function dispatchEvenniaEvent(ctx, account, event) {
   });
 }
 
+
+function startAutonomyLoop(ctx, account, client) {
+  const autonomy = account.autonomy;
+  if (!autonomy?.enabled || !autonomy.commands.length) return () => {};
+  let busy = false;
+  const tick = async () => {
+    if (busy || client.isClosed()) return;
+    if (Math.random() < autonomy.idleChance) return;
+    const command = autonomy.commands[Math.floor(Math.random() * autonomy.commands.length)];
+    if (!command || command.includes("\n") || command.includes("\r")) return;
+    busy = true;
+    try {
+      await client.command(command);
+    } catch (err) {
+      ctx.log?.warn?.(`evennia autonomy command failed: ${err?.message || err}`);
+    } finally {
+      busy = false;
+    }
+  };
+  const timer = setInterval(tick, autonomy.intervalMs);
+  timer.unref?.();
+  ctx.abortSignal.addEventListener("abort", () => clearInterval(timer), { once: true });
+  return () => clearInterval(timer);
+}
+
 export const evenniaPlugin = createChatChannelPlugin({
   base: createChannelPluginBase({
     id: "evennia",
@@ -177,6 +208,7 @@ evenniaPlugin.gateway = {
     ctx.abortSignal.addEventListener("abort", () => client.close(), { once: true });
     client.onEvent((event) => dispatchEvenniaEvent(ctx, ctx.account, event).catch((err) => ctx.log?.error?.(`evennia inbound failed: ${err?.stack || err?.message || err}`)));
     await client.connect();
+    startAutonomyLoop(ctx, ctx.account, client);
     if (ctx.account.character) await client.command(`ic ${ctx.account.character}`).catch(() => {});
     await new Promise((resolve) => setTimeout(resolve, 750));
     if (ctx.account.startRoom) await client.command(`teleport ${ctx.account.startRoom}`).catch(() => {});

--- a/extensions/evennia/src/channel.js
+++ b/extensions/evennia/src/channel.js
@@ -1,0 +1,192 @@
+import { createChannelPluginBase, createChatChannelPlugin } from "openclaw/plugin-sdk/channel-core";
+import { EvenniaClient } from "./evennia-client.js";
+
+const clients = new Map();
+
+function channelSection(cfg) {
+  return (cfg.channels && cfg.channels.evennia) || {};
+}
+
+function listAccountIds(cfg) {
+  return Object.keys(channelSection(cfg).accounts || {});
+}
+
+function resolveAccount(cfg, accountId = null) {
+  const section = channelSection(cfg);
+  const accounts = section.accounts || {};
+  const id = accountId || Object.keys(accounts)[0] || "default";
+  const raw = accounts[id] || {};
+  return {
+    accountId: id,
+    enabled: section.enabled !== false && raw.enabled !== false,
+    baseUrl: section.baseUrl || "http://127.0.0.1:14001",
+    websocketUrl: section.websocketUrl || "ws://127.0.0.1:14002",
+    agentId: raw.agentId || id,
+    username: raw.username,
+    passwordFile: raw.passwordFile,
+    character: raw.character || raw.username,
+    triggerName: (raw.triggerName || raw.character || raw.username || id).toLowerCase(),
+    startRoom: raw.startRoom,
+    allowFrom: raw.allowFrom || [],
+    allowedRooms: raw.allowedRooms || [],
+    respondToAmbientMentions: raw.respondToAmbientMentions !== false
+  };
+}
+
+function inspectAccount(cfg, accountId = null) {
+  try {
+    const account = resolveAccount(cfg, accountId);
+    return {
+      enabled: account.enabled,
+      configured: Boolean(account.username && account.passwordFile),
+      tokenStatus: account.passwordFile ? "file" : "missing",
+      accountId: account.accountId,
+      character: account.character
+    };
+  } catch (err) {
+    return { enabled: false, configured: false, error: String(err?.message || err) };
+  }
+}
+
+async function dispatchEvenniaEvent(ctx, account, event) {
+  const rt = ctx.channelRuntime;
+  if (!rt) {
+    ctx.log?.warn?.("evennia channelRuntime unavailable; inbound ignored");
+    return;
+  }
+  const lower = event.text.toLowerCase();
+  const direct = event.kind === "tell" || event.kind === "whisper";
+  const mentioned = lower.includes(account.triggerName.toLowerCase());
+  if (!direct && account.respondToAmbientMentions && !mentioned) return;
+
+  const messageId = event.id || `evennia-${Date.now()}`;
+  const routeSessionKey = rt.routing.buildAgentSessionKey({
+    agentId: account.agentId,
+    channel: "evennia",
+    chatType: direct ? "direct" : "group",
+    target: direct ? event.sender : (event.room || "room")
+  });
+  const storePath = rt.session.resolveStorePath(undefined, { agentId: account.agentId });
+  const ctxPayload = rt.turn.buildContext({
+    channel: "evennia",
+    accountId: account.accountId,
+    provider: "evennia",
+    surface: "evennia",
+    messageId,
+    timestamp: event.timestamp || Date.now(),
+    from: event.sender,
+    sender: { id: event.sender, name: event.sender, displayLabel: event.sender, isBot: false, isSelf: false },
+    conversation: {
+      kind: direct ? "direct" : "group",
+      id: direct ? event.sender : (event.room || "room"),
+      label: direct ? event.sender : (event.room || "Evennia room"),
+      routePeer: { kind: direct ? "direct" : "group", id: direct ? event.sender : (event.room || "room") }
+    },
+    route: { agentId: account.agentId, accountId: account.accountId, routeSessionKey, createIfMissing: true },
+    reply: { to: account.accountId, originatingTo: account.accountId, deliveryTarget: account.accountId, replyToId: messageId },
+    message: {
+      rawBody: event.text,
+      body: event.text,
+      bodyForAgent: `[Evennia ${direct ? "tell" : "room"} from ${event.sender}${event.room ? ` in ${event.room}` : ""}]\n${event.text}`,
+      commandBody: event.text,
+      envelopeFrom: event.sender,
+      senderLabel: event.sender,
+      preview: event.text.slice(0, 200)
+    },
+    access: {
+      dm: direct ? { decision: "allow", allowFrom: account.allowFrom, reason: "evennia-direct" } : undefined,
+      group: !direct ? { policy: "open", routeAllowed: true, senderAllowed: true, allowFrom: account.allowFrom, requireMention: true } : undefined,
+      mentions: { canDetectMention: true, wasMentioned: direct || mentioned, hasAnyMention: mentioned }
+    }
+  });
+
+  await rt.turn.dispatchAssembled({
+    cfg: ctx.cfg,
+    channel: "evennia",
+    accountId: account.accountId,
+    agentId: account.agentId,
+    routeSessionKey,
+    storePath,
+    ctxPayload,
+    recordInboundSession: rt.session.recordInboundSession,
+    dispatchReplyWithBufferedBlockDispatcher: rt.reply.dispatchReplyWithBufferedBlockDispatcher,
+    messageId,
+    admission: { kind: "dispatch", reason: direct ? "direct-tell" : "mentioned" },
+    delivery: {
+      deliver: async (payload) => {
+        const text = payload?.text || payload?.content || "";
+        if (text.trim()) {
+          const client = clients.get(account.accountId);
+          if (event.replyMode === "tell") await client?.tell(event.sender, text.trim());
+          else if (event.replyMode === "whisper") await client?.whisper(event.sender, text.trim());
+          else await client?.say(text.trim());
+        }
+        return { messageIds: [`evennia-out-${Date.now()}`], visibleReplySent: true };
+      }
+    }
+  });
+}
+
+export const evenniaPlugin = createChatChannelPlugin({
+  base: createChannelPluginBase({
+    id: "evennia",
+    config: {
+      listAccountIds,
+      resolveAccount,
+      inspectAccount,
+      defaultAccountId: (cfg) => listAccountIds(cfg)[0] || "default",
+      isEnabled: (account) => account.enabled,
+      isConfigured: (account) => Boolean(account.username && account.passwordFile),
+      describeAccount: (account) => ({
+        id: account.accountId,
+        name: account.character || account.username,
+        enabled: account.enabled,
+        configured: Boolean(account.username && account.passwordFile),
+        connected: clients.has(account.accountId)
+      })
+    },
+    setup: {
+      applyAccountConfig: ({ cfg }) => cfg
+    }
+  }),
+  outbound: {
+    base: {
+      deliveryMode: "gateway",
+      resolveTarget: ({ to }) => ({ ok: true, to: to || "default" })
+    },
+    attachedResults: {
+      channel: "evennia",
+      sendText: async ({ to, text, accountId }) => {
+        const id = accountId || to;
+        const client = clients.get(id);
+        if (!client) throw new Error(`evennia account ${id} is not connected`);
+        await client.say(text);
+        return { messageId: `evennia-out-${Date.now()}` };
+      }
+    }
+  }
+});
+
+// createChatChannelPlugin intentionally focuses the common chat surfaces; attach
+// the long-running gateway adapter explicitly for this external transport.
+evenniaPlugin.gateway = {
+  startAccount: async (ctx) => {
+    if (!ctx.account.enabled) return;
+    const client = new EvenniaClient(ctx.account, ctx.log);
+    clients.set(ctx.account.accountId, client);
+    ctx.abortSignal.addEventListener("abort", () => client.close(), { once: true });
+    client.onEvent((event) => dispatchEvenniaEvent(ctx, ctx.account, event).catch((err) => ctx.log?.error?.(`evennia inbound failed: ${err?.stack || err?.message || err}`)));
+    await client.connect();
+    if (ctx.account.character) await client.command(`ic ${ctx.account.character}`).catch(() => {});
+    await new Promise((resolve) => setTimeout(resolve, 750));
+    if (ctx.account.startRoom) await client.command(`teleport ${ctx.account.startRoom}`).catch(() => {});
+    await client.command("look").catch(() => {});
+    ctx.setStatus({ accountId: ctx.account.accountId, id: ctx.account.accountId, name: ctx.account.character, enabled: true, configured: true, connected: true, running: true });
+    await new Promise((resolve) => ctx.abortSignal.addEventListener("abort", resolve, { once: true }));
+  },
+  stopAccount: async ({ account }) => {
+    const client = clients.get(account.accountId);
+    clients.delete(account.accountId);
+    client?.close();
+  }
+};

--- a/extensions/evennia/src/channel.test.ts
+++ b/extensions/evennia/src/channel.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { splitEvenniaOutboundText } from "./channel.js";
+import {
+  buildEvenniaInboundHistory,
+  clearEvenniaHistoryForTests,
+  evenniaHistoryKey,
+  recordEvenniaHistoryEvent,
+  splitEvenniaOutboundText,
+} from "./channel.js";
 
 describe("splitEvenniaOutboundText", () => {
   it("converts literal evennia_command speech into command parts", () => {
@@ -16,5 +22,58 @@ describe("splitEvenniaOutboundText", () => {
       { kind: "command", text: "look" },
       { kind: "say", text: "Okay, I checked." },
     ]);
+  });
+});
+
+describe("Evennia history window", () => {
+  const account = {
+    channelId: "evennia",
+    accountId: "scoob",
+    historyLimit: 20,
+  };
+
+  it("keys room and direct histories separately", () => {
+    expect(
+      evenniaHistoryKey(account, {
+        kind: "room",
+        room: "Server Room",
+        sender: "Bee",
+        text: "hey scoob",
+      }),
+    ).toBe("evennia:scoob:room:Server Room");
+    expect(
+      evenniaHistoryKey(account, {
+        kind: "tell",
+        room: "Server Room",
+        sender: "Bee",
+        text: "secret",
+      }),
+    ).toBe("evennia:scoob:direct:Bee");
+  });
+
+  it("returns at least the previous 20 room messages for the next turn", () => {
+    clearEvenniaHistoryForTests();
+    for (let i = 1; i <= 25; i += 1) {
+      recordEvenniaHistoryEvent(account, {
+        id: `m-${i}`,
+        kind: "room",
+        room: "Server Room",
+        sender: `User${i}`,
+        text: `message ${i}`,
+        timestamp: i,
+      });
+    }
+
+    const history = buildEvenniaInboundHistory(account, {
+      kind: "room",
+      room: "Server Room",
+      sender: "Bee",
+      text: "scoob what happened",
+      timestamp: 26,
+    });
+
+    expect(history).toHaveLength(20);
+    expect(history?.[0]).toMatchObject({ sender: "User6", body: "message 6" });
+    expect(history?.[19]).toMatchObject({ sender: "User25", body: "message 25" });
   });
 });

--- a/extensions/evennia/src/channel.test.ts
+++ b/extensions/evennia/src/channel.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { splitEvenniaOutboundText } from "./channel.js";
+
+describe("splitEvenniaOutboundText", () => {
+  it("converts literal evennia_command speech into command parts", () => {
+    expect(splitEvenniaOutboundText('evennia_command(command="pose wags tail excitedly")')).toEqual(
+      [{ kind: "command", text: "pose wags tail excitedly" }],
+    );
+  });
+
+  it("keeps surrounding speech while removing literal tool syntax from room output", () => {
+    expect(
+      splitEvenniaOutboundText('One sec. `evennia_command(command="look")` Okay, I checked.'),
+    ).toEqual([
+      { kind: "say", text: "One sec." },
+      { kind: "command", text: "look" },
+      { kind: "say", text: "Okay, I checked." },
+    ]);
+  });
+});

--- a/extensions/evennia/src/channel.test.ts
+++ b/extensions/evennia/src/channel.test.ts
@@ -23,6 +23,21 @@ describe("splitEvenniaOutboundText", () => {
       { kind: "say", text: "Okay, I checked." },
     ]);
   });
+
+  it("converts movement commands appended after emoji narration into command parts", () => {
+    expect(
+      splitEvenniaOutboundText("I'm on my way. Tell Scoob the elder arrives. 🧙‍♂️war room"),
+    ).toEqual([
+      { kind: "say", text: "I'm on my way. Tell Scoob the elder arrives." },
+      { kind: "command", text: "war room" },
+    ]);
+  });
+
+  it("does not treat normal emoji reactions as movement commands", () => {
+    expect(splitEvenniaOutboundText("Nice work 👍 good job")).toEqual([
+      { kind: "say", text: "Nice work 👍 good job" },
+    ]);
+  });
 });
 
 describe("Evennia history window", () => {

--- a/extensions/evennia/src/evennia-client.js
+++ b/extensions/evennia/src/evennia-client.js
@@ -46,6 +46,7 @@ export class EvenniaClient {
     this.handlers = [];
     this.textHandlers = [];
     this.helpText = "";
+    this.recentText = [];
     this.ws = null;
   }
   onEvent(fn) {
@@ -205,8 +206,12 @@ export class EvenniaClient {
     if (!text) {
       return;
     }
+    const clean = stripHtml(stripAnsi(text)).replace(/\r/g, "").trim();
+    this.recentText.push({ timestamp: Date.now(), text: clean });
+    const cutoff = Date.now() - 120000;
+    this.recentText = this.recentText.filter((entry) => entry.timestamp >= cutoff).slice(-100);
     for (const h of this.textHandlers) {
-      h(stripHtml(stripAnsi(text)).replace(/\r/g, "").trim());
+      h(clean);
     }
     const parsed = parseEvenniaText(text);
     if (!parsed) {

--- a/extensions/evennia/src/evennia-client.js
+++ b/extensions/evennia/src/evennia-client.js
@@ -66,6 +66,7 @@ export class EvenniaClient {
     this.ws.addEventListener("message", (ev) => this.handleMessage(String(ev.data)));
   }
   close() { try { this.ws?.close(); } catch {} }
+  isClosed() { return !this.ws || this.ws.readyState === WebSocket.CLOSING || this.ws.readyState === WebSocket.CLOSED; }
   async command(text) {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) throw new Error("Evennia websocket is not open");
     this.ws.send(JSON.stringify(["text", [text], {}]));

--- a/extensions/evennia/src/evennia-client.js
+++ b/extensions/evennia/src/evennia-client.js
@@ -64,6 +64,8 @@ export class EvenniaClient {
       this.ws.addEventListener("error", (ev) => { clearTimeout(timer); reject(new Error("Evennia websocket error")); }, { once: true });
     });
     this.ws.addEventListener("message", (ev) => this.handleMessage(String(ev.data)));
+    await this.command(`connect "${this.account.username}" "${password.replaceAll('"', '\\"')}"`);
+    await new Promise((resolve) => setTimeout(resolve, 750));
   }
   close() { try { this.ws?.close(); } catch {} }
   isClosed() { return !this.ws || this.ws.readyState === WebSocket.CLOSING || this.ws.readyState === WebSocket.CLOSED; }

--- a/extensions/evennia/src/evennia-client.js
+++ b/extensions/evennia/src/evennia-client.js
@@ -1,23 +1,37 @@
-import fs from "node:fs/promises";
 import crypto from "node:crypto";
+import fs from "node:fs/promises";
 
 function parseSetCookie(headers) {
   const out = [];
-  const raw = headers.getSetCookie ? headers.getSetCookie() : (headers.get("set-cookie") ? [headers.get("set-cookie")] : []);
-  for (const c of raw) out.push(c.split(";")[0]);
+  const raw = headers.getSetCookie
+    ? headers.getSetCookie()
+    : headers.get("set-cookie")
+      ? [headers.get("set-cookie")]
+      : [];
+  for (const c of raw) {
+    out.push(c.split(";")[0]);
+  }
   return out;
 }
-function cookieHeader(cookies) { return [...cookies.entries()].map(([k,v]) => `${k}=${v}`).join("; "); }
+function cookieHeader(cookies) {
+  return [...cookies.entries()].map(([k, v]) => `${k}=${v}`).join("; ");
+}
 function mergeCookies(cookies, headers) {
   for (const part of parseSetCookie(headers)) {
     const i = part.indexOf("=");
-    if (i > 0) cookies.set(part.slice(0,i), part.slice(i+1));
+    if (i > 0) {
+      cookies.set(part.slice(0, i), part.slice(i + 1));
+    }
   }
 }
-function htmlDecode(s) { return s.replaceAll("&quot;", '"').replaceAll("&#x27;", "'").replaceAll("&amp;", "&"); }
+function htmlDecode(s) {
+  return s.replaceAll("&quot;", '"').replaceAll("&#x27;", "'").replaceAll("&amp;", "&");
+}
 function extractCsrf(html) {
-  return html.match(/name=["']csrfmiddlewaretoken["'][^>]*value=["']([^"']+)/)?.[1]
-    || html.match(/value=["']([^"']+)["'][^>]*name=["']csrfmiddlewaretoken/)?.[1];
+  return (
+    html.match(/name=["']csrfmiddlewaretoken["'][^>]*value=["']([^"']+)/)?.[1] ||
+    html.match(/value=["']([^"']+)["'][^>]*name=["']csrfmiddlewaretoken/)?.[1]
+  );
 }
 function extractJsVar(html, name) {
   const m = html.match(new RegExp(`var\\s+${name}\\s*=\\s*["']([^"']+)["']`));
@@ -30,9 +44,19 @@ export class EvenniaClient {
     this.log = log;
     this.cookies = new Map();
     this.handlers = [];
+    this.textHandlers = [];
+    this.helpText = "";
     this.ws = null;
   }
-  onEvent(fn) { this.handlers.push(fn); }
+  onEvent(fn) {
+    this.handlers.push(fn);
+  }
+  onText(fn) {
+    this.textHandlers.push(fn);
+    return () => {
+      this.textHandlers = this.textHandlers.filter((handler) => handler !== fn);
+    };
+  }
   async connect() {
     const password = (await fs.readFile(this.account.passwordFile, "utf8")).trim();
     const loginUrl = `${this.account.baseUrl}/auth/login/`;
@@ -40,37 +64,77 @@ export class EvenniaClient {
     mergeCookies(this.cookies, res.headers);
     const loginHtml = await res.text();
     const csrf = extractCsrf(loginHtml);
-    const body = new URLSearchParams({ username: this.account.username, password, csrfmiddlewaretoken: csrf || "", next: "" });
+    const body = new URLSearchParams({
+      username: this.account.username,
+      password,
+      csrfmiddlewaretoken: csrf || "",
+      next: "",
+    });
     res = await fetch(loginUrl, {
       method: "POST",
-      headers: { "content-type": "application/x-www-form-urlencoded", "cookie": cookieHeader(this.cookies), "referer": loginUrl },
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        cookie: cookieHeader(this.cookies),
+        referer: loginUrl,
+      },
       body,
-      redirect: "manual"
+      redirect: "manual",
     });
     mergeCookies(this.cookies, res.headers);
-    if (![200,302,303].includes(res.status)) throw new Error(`Evennia login failed: HTTP ${res.status}`);
+    if (![200, 302, 303].includes(res.status)) {
+      throw new Error(`Evennia login failed: HTTP ${res.status}`);
+    }
 
-    res = await fetch(`${this.account.baseUrl}/webclient/`, { headers: { cookie: cookieHeader(this.cookies) } });
+    res = await fetch(`${this.account.baseUrl}/webclient/`, {
+      headers: { cookie: cookieHeader(this.cookies) },
+    });
     mergeCookies(this.cookies, res.headers);
     const html = await res.text();
-    const csessid = extractJsVar(html, "csessid") || this.cookies.get("sessionid") || crypto.randomUUID();
+    const csessid =
+      extractJsVar(html, "csessid") || this.cookies.get("sessionid") || crypto.randomUUID();
     const cuid = extractJsVar(html, "cuid") || crypto.randomUUID();
     const browser = "openclaw-evennia";
     const url = `${this.account.websocketUrl}/?${encodeURIComponent(csessid)}&${encodeURIComponent(cuid)}&${encodeURIComponent(browser)}`;
     this.ws = new WebSocket(url, "v1.evennia.com");
     await new Promise((resolve, reject) => {
       const timer = setTimeout(() => reject(new Error("Evennia websocket timeout")), 10000);
-      this.ws.addEventListener("open", () => { clearTimeout(timer); resolve(); }, { once: true });
-      this.ws.addEventListener("error", (ev) => { clearTimeout(timer); reject(new Error("Evennia websocket error")); }, { once: true });
+      this.ws.addEventListener(
+        "open",
+        () => {
+          clearTimeout(timer);
+          resolve();
+        },
+        { once: true },
+      );
+      this.ws.addEventListener(
+        "error",
+        (ev) => {
+          clearTimeout(timer);
+          reject(new Error("Evennia websocket error"));
+        },
+        { once: true },
+      );
     });
     this.ws.addEventListener("message", (ev) => this.handleMessage(String(ev.data)));
     await this.command(`connect "${this.account.username}" "${password.replaceAll('"', '\\"')}"`);
     await new Promise((resolve) => setTimeout(resolve, 750));
   }
-  close() { try { this.ws?.close(); } catch {} }
-  isClosed() { return !this.ws || this.ws.readyState === WebSocket.CLOSING || this.ws.readyState === WebSocket.CLOSED; }
+  close() {
+    try {
+      this.ws?.close();
+    } catch {}
+  }
+  isClosed() {
+    return (
+      !this.ws ||
+      this.ws.readyState === WebSocket.CLOSING ||
+      this.ws.readyState === WebSocket.CLOSED
+    );
+  }
   async waitClosed(abortSignal) {
-    if (this.isClosed()) return;
+    if (this.isClosed()) {
+      return;
+    }
     await new Promise((resolve) => {
       const done = () => {
         cleanup();
@@ -87,43 +151,90 @@ export class EvenniaClient {
     });
   }
   async command(text) {
-    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) throw new Error("Evennia websocket is not open");
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      throw new Error("Evennia websocket is not open");
+    }
     this.ws.send(JSON.stringify(["text", [text], {}]));
+  }
+  async commandAndCollect(text, options = {}) {
+    const waitMs = Number.isFinite(options.waitMs) ? Math.max(50, options.waitMs) : 650;
+    const maxChars = Number.isFinite(options.maxChars) ? Math.max(100, options.maxChars) : 6000;
+    const chunks = [];
+    const off = this.onText((chunk) => {
+      if (chunks.join("\n").length < maxChars) {
+        chunks.push(chunk);
+      }
+    });
+    try {
+      await this.command(text);
+      await new Promise((resolve) => setTimeout(resolve, waitMs));
+    } finally {
+      off();
+    }
+    return chunks.join("\n").slice(0, maxChars).trim();
   }
   async say(text) {
     const safe = String(text).replace(/\s+/g, " ").trim();
     await this.command(`say ${safe}`);
   }
   async tell(target, text) {
-    const safeTarget = String(target).replace(/[=\n\r]/g, " ").trim();
+    const safeTarget = String(target)
+      .replace(/[=\n\r]/g, " ")
+      .trim();
     const safe = String(text).replace(/\s+/g, " ").trim();
     await this.command(`tell ${safeTarget} = ${safe}`);
   }
   async whisper(target, text) {
-    const safeTarget = String(target).replace(/[=\n\r]/g, " ").trim();
+    const safeTarget = String(target)
+      .replace(/[=\n\r]/g, " ")
+      .trim();
     const safe = String(text).replace(/\s+/g, " ").trim();
     await this.command(`whisper ${safeTarget} = ${safe}`);
   }
   handleMessage(data) {
     let msg;
-    try { msg = JSON.parse(data); } catch { return; }
-    if (!Array.isArray(msg) || msg[0] !== "text") return;
+    try {
+      msg = JSON.parse(data);
+    } catch {
+      return;
+    }
+    if (!Array.isArray(msg) || msg[0] !== "text") {
+      return;
+    }
     const text = flattenText(msg[1]).trim();
-    if (!text) return;
+    if (!text) {
+      return;
+    }
+    for (const h of this.textHandlers) {
+      h(stripHtml(stripAnsi(text)).replace(/\r/g, "").trim());
+    }
     const parsed = parseEvenniaText(text);
-    if (!parsed) return;
+    if (!parsed) {
+      return;
+    }
     const event = { id: crypto.randomUUID(), timestamp: Date.now(), raw: msg, ...parsed };
-    for (const h of this.handlers) h(event);
+    for (const h of this.handlers) {
+      h(event);
+    }
   }
 }
 
 function flattenText(value) {
-  if (typeof value === "string") return value;
-  if (Array.isArray(value)) return value.map(flattenText).join("\n");
-  if (value && typeof value === "object") return "";
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(flattenText).join("\n");
+  }
+  if (value && typeof value === "object") {
+    return "";
+  }
   return "";
 }
-function stripAnsi(s) { return s.replace(/\x1b\[[0-9;]*m/g, ""); }
+const ANSI_PATTERN = new RegExp(`${String.fromCharCode(27)}\\\\[[0-9;]*m`, "g");
+function stripAnsi(s) {
+  return s.replace(ANSI_PATTERN, "");
+}
 function stripHtml(s) {
   return s
     .replace(/<br\s*\/?\s*>/gi, "\n")
@@ -137,12 +248,32 @@ function stripHtml(s) {
 function parseEvenniaText(text) {
   const clean = stripHtml(stripAnsi(text)).replace(/\r/g, "").trim();
   let m = clean.match(/^Account\s+([^\n:]+)\s+pages:\s*(.*)$/is);
-  if (m) return { kind: "tell", sender: m[1].trim(), text: m[2].trim(), replyMode: "tell" };
+  if (m) {
+    return { kind: "tell", sender: m[1].trim(), text: m[2].trim(), replyMode: "tell" };
+  }
   m = clean.match(/^([^\n:]+)\s+tells you,\s*["“](.*)["”]$/is);
-  if (m) return { kind: "tell", sender: m[1].trim(), text: m[2].trim(), replyMode: "tell" };
+  if (m) {
+    return { kind: "tell", sender: m[1].trim(), text: m[2].trim(), replyMode: "tell" };
+  }
   m = clean.match(/^([^\n:]+)\s+whispers:\s*["“](.*)["”]$/is);
-  if (m) return { kind: "whisper", sender: m[1].trim(), room: "current", text: m[2].trim(), replyMode: "whisper" };
+  if (m) {
+    return {
+      kind: "whisper",
+      sender: m[1].trim(),
+      room: "current",
+      text: m[2].trim(),
+      replyMode: "whisper",
+    };
+  }
   m = clean.match(/^([^\n:]+)\s+says,\s*["“](.*)["”]$/is);
-  if (m) return { kind: "say", sender: m[1].trim(), room: "current", text: m[2].trim(), replyMode: "say" };
+  if (m) {
+    return {
+      kind: "say",
+      sender: m[1].trim(),
+      room: "current",
+      text: m[2].trim(),
+      replyMode: "say",
+    };
+  }
   return null;
 }

--- a/extensions/evennia/src/evennia-client.js
+++ b/extensions/evennia/src/evennia-client.js
@@ -1,0 +1,128 @@
+import fs from "node:fs/promises";
+import crypto from "node:crypto";
+
+function parseSetCookie(headers) {
+  const out = [];
+  const raw = headers.getSetCookie ? headers.getSetCookie() : (headers.get("set-cookie") ? [headers.get("set-cookie")] : []);
+  for (const c of raw) out.push(c.split(";")[0]);
+  return out;
+}
+function cookieHeader(cookies) { return [...cookies.entries()].map(([k,v]) => `${k}=${v}`).join("; "); }
+function mergeCookies(cookies, headers) {
+  for (const part of parseSetCookie(headers)) {
+    const i = part.indexOf("=");
+    if (i > 0) cookies.set(part.slice(0,i), part.slice(i+1));
+  }
+}
+function htmlDecode(s) { return s.replaceAll("&quot;", '"').replaceAll("&#x27;", "'").replaceAll("&amp;", "&"); }
+function extractCsrf(html) {
+  return html.match(/name=["']csrfmiddlewaretoken["'][^>]*value=["']([^"']+)/)?.[1]
+    || html.match(/value=["']([^"']+)["'][^>]*name=["']csrfmiddlewaretoken/)?.[1];
+}
+function extractJsVar(html, name) {
+  const m = html.match(new RegExp(`var\\s+${name}\\s*=\\s*["']([^"']+)["']`));
+  return m ? htmlDecode(m[1]) : null;
+}
+
+export class EvenniaClient {
+  constructor(account, log) {
+    this.account = account;
+    this.log = log;
+    this.cookies = new Map();
+    this.handlers = [];
+    this.ws = null;
+  }
+  onEvent(fn) { this.handlers.push(fn); }
+  async connect() {
+    const password = (await fs.readFile(this.account.passwordFile, "utf8")).trim();
+    const loginUrl = `${this.account.baseUrl}/auth/login/`;
+    let res = await fetch(loginUrl);
+    mergeCookies(this.cookies, res.headers);
+    const loginHtml = await res.text();
+    const csrf = extractCsrf(loginHtml);
+    const body = new URLSearchParams({ username: this.account.username, password, csrfmiddlewaretoken: csrf || "", next: "" });
+    res = await fetch(loginUrl, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded", "cookie": cookieHeader(this.cookies), "referer": loginUrl },
+      body,
+      redirect: "manual"
+    });
+    mergeCookies(this.cookies, res.headers);
+    if (![200,302,303].includes(res.status)) throw new Error(`Evennia login failed: HTTP ${res.status}`);
+
+    res = await fetch(`${this.account.baseUrl}/webclient/`, { headers: { cookie: cookieHeader(this.cookies) } });
+    mergeCookies(this.cookies, res.headers);
+    const html = await res.text();
+    const csessid = extractJsVar(html, "csessid") || this.cookies.get("sessionid") || crypto.randomUUID();
+    const cuid = extractJsVar(html, "cuid") || crypto.randomUUID();
+    const browser = "openclaw-evennia";
+    const url = `${this.account.websocketUrl}/?${encodeURIComponent(csessid)}&${encodeURIComponent(cuid)}&${encodeURIComponent(browser)}`;
+    this.ws = new WebSocket(url, "v1.evennia.com");
+    await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("Evennia websocket timeout")), 10000);
+      this.ws.addEventListener("open", () => { clearTimeout(timer); resolve(); }, { once: true });
+      this.ws.addEventListener("error", (ev) => { clearTimeout(timer); reject(new Error("Evennia websocket error")); }, { once: true });
+    });
+    this.ws.addEventListener("message", (ev) => this.handleMessage(String(ev.data)));
+  }
+  close() { try { this.ws?.close(); } catch {} }
+  async command(text) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) throw new Error("Evennia websocket is not open");
+    this.ws.send(JSON.stringify(["text", [text], {}]));
+  }
+  async say(text) {
+    const safe = String(text).replace(/\s+/g, " ").trim();
+    await this.command(`say ${safe}`);
+  }
+  async tell(target, text) {
+    const safeTarget = String(target).replace(/[=\n\r]/g, " ").trim();
+    const safe = String(text).replace(/\s+/g, " ").trim();
+    await this.command(`tell ${safeTarget} = ${safe}`);
+  }
+  async whisper(target, text) {
+    const safeTarget = String(target).replace(/[=\n\r]/g, " ").trim();
+    const safe = String(text).replace(/\s+/g, " ").trim();
+    await this.command(`whisper ${safeTarget} = ${safe}`);
+  }
+  handleMessage(data) {
+    let msg;
+    try { msg = JSON.parse(data); } catch { return; }
+    if (!Array.isArray(msg) || msg[0] !== "text") return;
+    const text = flattenText(msg[1]).trim();
+    if (!text) return;
+    const parsed = parseEvenniaText(text);
+    if (!parsed) return;
+    const event = { id: crypto.randomUUID(), timestamp: Date.now(), raw: msg, ...parsed };
+    for (const h of this.handlers) h(event);
+  }
+}
+
+function flattenText(value) {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return value.map(flattenText).join("\n");
+  if (value && typeof value === "object") return "";
+  return "";
+}
+function stripAnsi(s) { return s.replace(/\x1b\[[0-9;]*m/g, ""); }
+function stripHtml(s) {
+  return s
+    .replace(/<br\s*\/?\s*>/gi, "\n")
+    .replace(/<[^>]*>/g, "")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#x27;|&#39;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+function parseEvenniaText(text) {
+  const clean = stripHtml(stripAnsi(text)).replace(/\r/g, "").trim();
+  let m = clean.match(/^Account\s+([^\n:]+)\s+pages:\s*(.*)$/is);
+  if (m) return { kind: "tell", sender: m[1].trim(), text: m[2].trim(), replyMode: "tell" };
+  m = clean.match(/^([^\n:]+)\s+tells you,\s*["“](.*)["”]$/is);
+  if (m) return { kind: "tell", sender: m[1].trim(), text: m[2].trim(), replyMode: "tell" };
+  m = clean.match(/^([^\n:]+)\s+whispers:\s*["“](.*)["”]$/is);
+  if (m) return { kind: "whisper", sender: m[1].trim(), room: "current", text: m[2].trim(), replyMode: "whisper" };
+  m = clean.match(/^([^\n:]+)\s+says,\s*["“](.*)["”]$/is);
+  if (m) return { kind: "say", sender: m[1].trim(), room: "current", text: m[2].trim(), replyMode: "say" };
+  return null;
+}

--- a/extensions/evennia/src/evennia-client.js
+++ b/extensions/evennia/src/evennia-client.js
@@ -67,6 +67,23 @@ export class EvenniaClient {
   }
   close() { try { this.ws?.close(); } catch {} }
   isClosed() { return !this.ws || this.ws.readyState === WebSocket.CLOSING || this.ws.readyState === WebSocket.CLOSED; }
+  async waitClosed(abortSignal) {
+    if (this.isClosed()) return;
+    await new Promise((resolve) => {
+      const done = () => {
+        cleanup();
+        resolve();
+      };
+      const cleanup = () => {
+        this.ws?.removeEventListener("close", done);
+        this.ws?.removeEventListener("error", done);
+        abortSignal?.removeEventListener("abort", done);
+      };
+      this.ws?.addEventListener("close", done, { once: true });
+      this.ws?.addEventListener("error", done, { once: true });
+      abortSignal?.addEventListener("abort", done, { once: true });
+    });
+  }
   async command(text) {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) throw new Error("Evennia websocket is not open");
     this.ws.send(JSON.stringify(["text", [text], {}]));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -660,6 +660,16 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/evennia:
+    dependencies:
+      typebox:
+        specifier: 1.1.38
+        version: 1.1.38
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/exa:
     devDependencies:
       '@openclaw/plugin-sdk':


### PR DESCRIPTION
## Summary

Adds an experimental Evennia channel plugin for OpenClaw-managed MUD characters.

The plugin provides:
- `evennia` and `evennia-staging` channel registrations
- multi-account routing for character connections
- an `evennia_command` tool for one-command-at-a-time in-world actions
- WebSocket/webclient login transport for Evennia
- in-room mention/direct-message dispatch into OpenClaw turns
- automatic `look` and cached `help` context for agent turns
- per-room/per-direct history windows feeding `InboundHistory` with at least 20 prior messages
- slow local/Ollama turn hardening via explicit no-run-timeout and longer block reply delivery timeout
- in-world status poses for ack/progress/error reactions

## Validation

- `pnpm exec vitest run extensions/evennia/src/channel.test.ts --reporter=dot`
- `jq . extensions/evennia/openclaw.plugin.json`
- `openclaw config validate`
- `openclaw --profile staging-dumbledong config validate`
- Booted the staging-Dumbledong gateway on port `18889` using the copied extension and verified the Evennia plugin loads cleanly.
- Deployed the extension to Patrick, Scoob, and Dumbledong local OpenClaw installs and verified `openclaw status --deep` reports Evennia OK on Scoob and Dumbledong.

## Notes

This is intentionally generic plugin code. Dongeon-specific lore/config remains local runtime configuration, not in the public plugin.
