### PR TITLE
fix(security): guard plugin modelPatterns with compileSafeRegex

### DIFF
--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -865,6 +865,11 @@ Fields:
 | `modelPrefixes` | `string[]` | Prefixes matched with `startsWith` against shorthand model ids.                 |
 | `modelPatterns` | `string[]` | Regex sources matched against shorthand model ids after profile suffix removal. |
 
+`modelPatterns` entries are compiled through `compileSafeRegex`, which rejects
+patterns containing nested repetition (for example `(a+)+$`). Patterns that fail
+the safety check are silently skipped, the same as syntactically invalid regex.
+Keep patterns simple and avoid nested quantifiers.
+
 ## modelCatalog reference
 
 Use `modelCatalog` when OpenClaw should know provider model metadata before

--- a/src/plugins/providers.test.ts
+++ b/src/plugins/providers.test.ts
@@ -1705,6 +1705,24 @@ describe("resolvePluginProviders", () => {
     expectModelOwningPluginIds("gpt-5.4", ["workspace-openai"]);
   });
 
+  it("rejects ReDoS modelPatterns via compileSafeRegex guard", () => {
+    setManifestPlugins([
+      createManifestProviderPlugin({
+        id: "malicious",
+        providerIds: ["malicious"],
+        modelSupport: {
+          modelPatterns: ["(a+)+$"],
+        },
+      }),
+    ]);
+
+    // Without the guard, this input causes catastrophic backtracking.
+    // With compileSafeRegex, the pattern is rejected and the plugin is not matched.
+    const start = performance.now();
+    expectModelOwningPluginIds("a".repeat(30) + "!", undefined);
+    expect(performance.now() - start).toBeLessThan(50);
+  });
+
   it("preserves LM Studio @iq* quant suffixes when resolving model-owned provider plugins", () => {
     setManifestPlugins([
       createManifestProviderPlugin({

--- a/src/plugins/providers.ts
+++ b/src/plugins/providers.ts
@@ -455,6 +455,9 @@ function resolveModelSupportMatchKind(
 ): ModelSupportMatchKind | undefined {
   const patterns = plugin.modelSupport?.modelPatterns ?? [];
   for (const patternSource of patterns) {
+    // compileSafeRegex rejects patterns with nested repetition (ReDoS risk)
+    // and returns null. Rejected patterns are silently skipped: the plugin
+    // will not match via that pattern but other patterns/prefixes still apply.
     const regex = compileSafeRegex(patternSource, "u");
     if (regex?.test(modelId)) {
       return "pattern";

--- a/src/plugins/providers.ts
+++ b/src/plugins/providers.ts
@@ -1,5 +1,6 @@
 import { splitTrailingAuthProfile } from "../agents/model-ref-profile.js";
 import { normalizeProviderId } from "../agents/provider-id.js";
+import { compileSafeRegex } from "../security/safe-regex.js";
 import { withBundledPluginVitestCompat } from "./bundled-compat.js";
 import { resolveEffectivePluginActivationState } from "./config-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
@@ -454,12 +455,9 @@ function resolveModelSupportMatchKind(
 ): ModelSupportMatchKind | undefined {
   const patterns = plugin.modelSupport?.modelPatterns ?? [];
   for (const patternSource of patterns) {
-    try {
-      if (new RegExp(patternSource, "u").test(modelId)) {
-        return "pattern";
-      }
-    } catch {
-      continue;
+    const regex = compileSafeRegex(patternSource, "u");
+    if (regex?.test(modelId)) {
+      return "pattern";
     }
   }
   const prefixes = plugin.modelSupport?.modelPrefixes ?? [];


### PR DESCRIPTION
## Summary

`resolveModelSupportMatchKind` in `src/plugins/providers.ts` compiles plugin manifest `modelPatterns` strings with raw `new RegExp(patternSource, "u")`. A malicious or careless pattern like `(a+)+$` causes catastrophic backtracking (ReDoS) when tested against non-matching model IDs.

The codebase already has `compileSafeRegex()` in `src/security/safe-regex.ts` that detects nested repetition and rejects unsafe patterns. This PR wires it into the model pattern matching path.

**Changes:**
- Import `compileSafeRegex` in `providers.ts`
- Replace `new RegExp(patternSource, "u")` with `compileSafeRegex(patternSource, "u")` -- unsafe patterns return `null` and are skipped (same behavior as the previous `catch { continue }` for invalid regex, but also covers ReDoS patterns that are syntactically valid)
- Add a test verifying a `(a+)+$` pattern against adversarial input completes in <50ms instead of hanging

## Real behavior proof

**Behavior addressed:** Plugin manifest `modelPatterns` entries with nested quantifiers (e.g., `(a+)+$`) cause catastrophic backtracking in `resolveModelSupportMatchKind`, freezing the provider resolution hot path. With 30 repeated characters the raw RegExp hangs for over 5 seconds; with longer input it hangs indefinitely.

**Real environment tested:** macOS, Node 22.19, openclaw at commit 88a85a1fcd on branch `fix/provider-model-pattern-redos`.

**Exact steps or command run after this patch:**

Step 1. Demonstrate the vulnerability with raw RegExp (before fix behavior):

```bash
timeout 5 node -e "
const regex = new RegExp('(a+)+\$', 'u');
const input = 'a'.repeat(30) + '!';
console.log('Testing raw RegExp against 30 a + ! ...');
const start = performance.now();
regex.test(input);
console.log('Done in', (performance.now() - start).toFixed(0), 'ms');
" || echo 'TIMED OUT after 5 seconds (catastrophic backtracking)'
```

Step 2. Demonstrate the guard rejects the pattern and valid patterns still work:

```bash
node --import tsx -e "
import { compileSafeRegex } from './src/security/safe-regex.js';
const malicious = compileSafeRegex('(a+)+\$', 'u');
console.log('compileSafeRegex(\"(a+)+\$\"):', malicious);
const valid = compileSafeRegex('^qwen3\\\\.6-27b@iq3_xxs\$', 'u');
console.log('compileSafeRegex(\"^qwen3.6-27b@iq3_xxs\$\"):', valid);
console.log('valid.test(\"qwen3.6-27b@iq3_xxs\"):', valid?.test('qwen3.6-27b@iq3_xxs'));
const input = 'a'.repeat(30) + '!';
const start = performance.now();
const result = malicious?.test(input) ?? 'pattern rejected';
console.log('Adversarial input:', result, 'in', (performance.now() - start).toFixed(2), 'ms');
"
```

**Evidence after fix:**

Before (raw RegExp, unpatched behavior):
```
$ timeout 5 node -e "const regex = new RegExp('(a+)+$', 'u'); ..."
Testing raw RegExp against 30 a + ! ...
TIMED OUT after 5 seconds (catastrophic backtracking)
```

After (compileSafeRegex guard, patched behavior):
```
$ node --import tsx -e "import { compileSafeRegex } from './src/security/safe-regex.js'; ..."
compileSafeRegex("(a+)+$"): null
compileSafeRegex("^qwen3\.6-27b@iq3_xxs$"): /^qwen3\.6-27b@iq3_xxs$/u
valid.test("qwen3.6-27b@iq3_xxs"): true
Adversarial input: pattern rejected in 0.00 ms
```

The malicious pattern is rejected (returns `null`) so the adversarial input never reaches the regex engine. Valid patterns like the LM Studio quant suffix pattern compile and match correctly.

**Observed result after fix:** The `compileSafeRegex` guard detects nested repetition in `(a+)+$` and returns `null`, preventing the pattern from being used. The adversarial input that causes a 5+ second hang with raw RegExp resolves in 0.00ms. Legitimate plugin patterns like `^qwen3\.6-27b@iq3_xxs$` compile and match correctly, confirming no regression in valid model pattern support.

**What was not tested:** Live gateway startup with a real installed plugin containing a malicious `modelPatterns` entry (would require crafting and installing a plugin package). The proof exercises the same `compileSafeRegex` guard function used by the patched code path.
