### PR TITLE
fix(codex): honor explicit native tool allowlists

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2076,7 +2076,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(testing.filterCodexDynamicToolsForAllowlist(tools, [" * "])).toEqual(tools);
   });
 
-  it("disables Codex native tool surfaces for restricted runtime allowlists", () => {
+  it("disables Codex native tool surfaces for dynamic-only runtime allowlists", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
     params.disableTools = false;
@@ -2091,6 +2091,53 @@ describe("runCodexAppServerAttempt", () => {
 
     params.toolsAllow = ["message"];
     expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+
+    params.toolsAllow = ["message", "web_search"];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+  });
+
+  it("enables Codex native tool surfaces for explicit full native runtime allowlists", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+
+    params.toolsAllow = ["exec"];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+
+    params.toolsAllow = ["BASH", "read", "message"];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+
+    params.toolsAllow = ["read", "write", "edit", "message"];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+
+    params.toolsAllow = ["apply-patch", "message"];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+
+    params.toolsAllow = ["exec", "read", "write", "edit", "message", "memory_search", "memory_get"];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+    expect(testing.shouldEnableCodexAppServerUserMcpServers(params)).toBe(false);
+  });
+
+  it("keeps user MCP servers restricted for explicit native runtime allowlists", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+
+    params.toolsAllow = undefined;
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+    expect(testing.shouldEnableCodexAppServerUserMcpServers(params)).toBe(true);
+
+    params.toolsAllow = ["*"];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+    expect(testing.shouldEnableCodexAppServerUserMcpServers(params)).toBe(true);
+
+    params.toolsAllow = ["exec", "read", "write", "edit"];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+    expect(testing.shouldEnableCodexAppServerUserMcpServers(params)).toBe(false);
+
+    params.toolsAllow = ["exec", "read", "write", "edit", "message", "memory_search"];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+    expect(testing.shouldEnableCodexAppServerUserMcpServers(params)).toBe(false);
   });
 
   it("disables Codex native tool surfaces when the effective exec target is node", () => {
@@ -2706,6 +2753,51 @@ describe("runCodexAppServerAttempt", () => {
     });
     expect(startParams?.config?.apps?.["google-calendar-app"]?.enabled).toBeUndefined();
     expect(request.mock.calls.map(([method]) => method)).not.toContain("app/list");
+  });
+
+  it("enables Codex native tool surfaces for Daily OS-style runtime toolsAllow", async () => {
+    testing.setOpenClawCodingToolsFactoryForTests(() => [
+      createRuntimeDynamicTool("message"),
+      createRuntimeDynamicTool("memory_search"),
+      createRuntimeDynamicTool("memory_get"),
+      createRuntimeDynamicTool("exec"),
+      createRuntimeDynamicTool("read"),
+      createRuntimeDynamicTool("edit"),
+    ]);
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.toolsAllow = ["exec", "read", "write", "edit", "message", "memory_search", "memory_get"];
+
+    const run = runCodexAppServerAttempt(params, {
+      pluginConfig: { appServer: { mode: "yolo" } },
+    });
+    await harness.waitForMethod("turn/start", 120_000);
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    const startRequest = harness.requests.find((entry) => entry.method === "thread/start");
+    const startParams = startRequest?.params as
+      | {
+          dynamicTools?: Array<{ name?: string }>;
+          config?: {
+            "features.code_mode"?: boolean;
+            "features.code_mode_only"?: boolean;
+          };
+        }
+      | undefined;
+    const dynamicToolNames = startParams?.dynamicTools?.map((tool) => tool.name) ?? [];
+
+    expect(startParams?.config?.["features.code_mode"]).toBe(true);
+    expect(startParams?.config?.["features.code_mode_only"]).toBe(false);
+    expect(dynamicToolNames).toEqual(["message", "memory_search", "memory_get"]);
+    expect(dynamicToolNames).not.toContain("exec");
+    expect(dynamicToolNames).not.toContain("read");
+    expect(dynamicToolNames).not.toContain("edit");
   });
 
   it("fails closed for Codex app defaults when restricted native tools have no plugin config", async () => {
@@ -8781,6 +8873,9 @@ describe("runCodexAppServerAttempt", () => {
       key: buildCodexPluginAppCacheKey({
         appServer,
         agentDir,
+        envApiKeyFingerprint: resolveCodexAppServerEnvApiKeyCacheKey({
+          startOptions: appServer.start,
+        }),
       }),
       request: async () => ({
         data: [
@@ -8872,6 +8967,28 @@ describe("runCodexAppServerAttempt", () => {
           },
         };
       }
+      if (method === "app/list") {
+        return {
+          data: [
+            {
+              id: "google-calendar-app",
+              name: "Google Calendar",
+              description: null,
+              logoUrl: null,
+              logoUrlDark: null,
+              distributionChannel: null,
+              branding: null,
+              appMetadata: null,
+              labels: null,
+              installUrl: null,
+              isAccessible: true,
+              isEnabled: true,
+              pluginDisplayNames: [],
+            },
+          ],
+          nextCursor: null,
+        };
+      }
       if (method === "thread/start") {
         return threadStartResult("thread-1");
       }
@@ -8905,6 +9022,9 @@ describe("runCodexAppServerAttempt", () => {
     params.agentDir = agentDir;
     const run = runCodexAppServerAttempt(params, { pluginConfig });
     await vi.waitFor(() => expect(handleRequest).toBeTypeOf("function"));
+    await vi.waitFor(() =>
+      expect(request.mock.calls.some(([method]) => method === "turn/start")).toBe(true),
+    );
 
     const result = await handleRequest?.({
       id: "request-elicitation-1",

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1069,6 +1069,11 @@ export async function runCodexAppServerAttempt(
     runtimeSessionKey: sandboxSessionKey,
     sandboxExecServerEnabled,
   });
+  const userMcpServersEnabled = shouldEnableCodexAppServerUserMcpServers(params, sandbox, {
+    agentId: sessionAgentId,
+    runtimeSessionKey: sandboxSessionKey,
+    sandboxExecServerEnabled,
+  });
   for (const diagnostic of bundleMcpThreadConfig.diagnostics) {
     embeddedAgentLog.warn(`bundle-mcp: ${diagnostic.pluginId}: ${diagnostic.message}`);
   }
@@ -1731,7 +1736,7 @@ export async function runCodexAppServerAttempt(
               finalConfigPatch: nativeHookRelayConfig,
               nativeCodeModeEnabled: nativeToolSurfaceEnabled,
               nativeCodeModeOnlyEnabled: appServer.codeModeOnly,
-              userMcpServersEnabled: nativeToolSurfaceEnabled,
+              userMcpServersEnabled,
               mcpServersFingerprint: bundleMcpThreadConfig.fingerprint,
               mcpServersFingerprintEvaluated: bundleMcpThreadConfig.evaluated,
               environmentSelection: startupEnvironmentSelection,
@@ -4156,15 +4161,39 @@ function shouldEnableCodexAppServerNativeToolSurface(
     return false;
   }
   const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, params);
+  const canHonorSandbox = canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox, options);
   if (toolsAllow === undefined) {
-    return canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox, options);
+    return canHonorSandbox;
   }
-  // Codex native code mode exposes its shell/file surface as one app-server
-  // capability, so narrow OpenClaw allowlists must fail closed rather than
-  // widening `message` or `web_search` into shell access.
+  // Codex native code mode exposes shell and file tools as one app-server
+  // capability. Keep partial native allowlists fail-closed; only callers that
+  // explicitly request the full native surface receive it.
   return (
-    hasWildcardCodexToolsAllow(toolsAllow) &&
-    canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox, options)
+    canHonorSandbox &&
+    (hasWildcardCodexToolsAllow(toolsAllow) || hasFullCodexNativeToolSurfaceAllow(toolsAllow))
+  );
+}
+
+function shouldEnableCodexAppServerUserMcpServers(
+  params: EmbeddedRunAttemptParams,
+  sandbox?: OpenClawSandboxContext,
+  options: {
+    agentId?: string;
+    runtimeSessionKey?: string;
+    sandboxExecServerEnabled?: boolean;
+  } = {},
+): boolean {
+  if (!shouldEnableCodexAppServerNativeToolSurface(params, sandbox, options)) {
+    return false;
+  }
+  const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, params);
+  return toolsAllow === undefined || hasWildcardCodexToolsAllow(toolsAllow);
+}
+
+function hasFullCodexNativeToolSurfaceAllow(toolsAllow: string[]): boolean {
+  const allowSet = new Set(toolsAllow.map((name) => normalizeCodexDynamicToolName(name)));
+  return (
+    allowSet.has("exec") && allowSet.has("read") && allowSet.has("write") && allowSet.has("edit")
   );
 }
 
@@ -5816,6 +5845,7 @@ export const testing = {
   filterCodexDynamicToolsForAllowlist,
   includeForcedCodexDynamicToolAllow,
   filterToolsForVisionInputs,
+  hasFullCodexNativeToolSurfaceAllow,
   hasWildcardCodexToolsAllow,
   handleDynamicToolCallWithTimeout,
   isInvalidCodexImagePayloadError,
@@ -5830,6 +5860,7 @@ export const testing = {
   resolveOpenClawCodingToolsSessionKeys,
   shouldProjectMirroredHistoryForCodexStart,
   shouldEnableCodexAppServerNativeToolSurface,
+  shouldEnableCodexAppServerUserMcpServers,
   shouldForceMessageTool,
   shouldReleaseTurnAfterTerminalDynamicTool,
   resolveTerminalDynamicToolBatchAction,

--- a/extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts
@@ -388,6 +388,47 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
     expect(startParams?.config?.mcp_servers).toBeUndefined();
   });
 
+  it("omits user MCP servers when native code mode remains enabled for native-only tools", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const request = vi.fn(async (method: string, _params: unknown) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-native-only");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await startOrResumeThread({
+      client: { request } as never,
+      params: createParams(sessionFile, workspaceDir, {
+        mcp: {
+          servers: {
+            notes: {
+              transport: "stdio",
+              command: "node",
+              args: ["/opt/notes-mcp/dist/index.js"],
+            },
+          },
+        },
+      } as unknown as EmbeddedRunAttemptParams["config"]),
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer: createAppServerOptions(),
+      nativeCodeModeEnabled: true,
+      userMcpServersEnabled: false,
+    });
+
+    const startCall = request.mock.calls.find(([method]) => method === "thread/start");
+    const startParams = startCall?.[1] as {
+      config?: {
+        "features.code_mode"?: boolean;
+        mcp_servers?: Record<string, unknown>;
+      };
+    };
+    expect(startParams?.config?.["features.code_mode"]).toBe(true);
+    expect(startParams?.config?.mcp_servers).toBeUndefined();
+  });
+
   it("resends user MCP config when resuming a thread with the matching fingerprint", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");


### PR DESCRIPTION
## Summary
- enable Codex app-server native code mode when runtime toolsAllow explicitly includes the full native surface: exec/read/write/edit
- keep dynamic-only and partial-native allowlists fail-closed
- preserve current memory-flush, node exec host, and sandbox policy gates on main

## Verification
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/app-server/run-attempt.test.ts -t "native tool surfaces"` (6 passed after rebase)
- `pnpm exec oxfmt --check --threads=1 extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts`
- Earlier before rebase: `pytest tests/test_review_wake.py` in `projects/jay-operating-system` passed 18 tests.
- Earlier before rebase: `~/.codex/skills/codex-review/scripts/codex-review` completed with no accepted/actionable findings after accepted findings were fixed.

## Real behavior proof
Behavior addressed: Daily OS Codex cron wakes can request the native tool surface through `toolsAllow=exec,read,write,edit,message,memory_search,memory_get`; the Codex app-server should enable native code mode for that full native allowlist instead of dispatching a dynamic-tool-only turn.

Real environment tested: Local OpenClaw source checkout used by the production Telegram agent host at `/root/.openclaw/openclaw-src-v5.19`, with the real Daily OS review wake job inspected at `/root/.openclaw/workspace/projects/jay-operating-system/src/jay_operating_system/review_wake.py`.

Exact steps or command run after this patch: Ran the patched OpenClaw app-server native-surface decision path in the source checkout and then reran the targeted app-server regression slice after rebasing onto `origin/main`.

Evidence after fix: Console output from the post-rebase local source checkout:

```text
$ git log --oneline -3 --decorate
1a361048f5 (HEAD -> jay/daily-os-native-tools-fix) fix(codex): honor explicit native tool allowlists
5be62e779b (origin/main) fix(scripts): harden Windows ZAI fallback repro
400d90a4da style(android): sharpen v2 screen rhythm

$ node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/app-server/run-attempt.test.ts -t "native tool surfaces"
Test Files  1 passed (1)
Tests  6 passed | 214 skipped (220)
```

Observed result after fix: The Daily OS-style allowlist path now evaluates as native-code-mode eligible in the patched app-server regression path, while dynamic-only and partial-native allowlists remain denied.

What was not tested: A live production Daily OS cron wake after deploying/restarting the gateway.

## Deploy / rollback
- Deploy target: local production gateway at `/root/.openclaw/openclaw-src` -> `openclaw-src-v5.19`
- Rollback: git revert this commit or reset local checkout to previous deployed commit, rebuild, restart `openclaw-stable`
