### PR TITLE
fix(diagnostics): reclaim wedged session lanes with a stale leaked active run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 - Tests: give the memory fallback QA scenario enough turn budget to exercise native Windows gateway runs instead of failing on the client timeout while the mock agent is still dispatching.
 - Tests: collect QA gateway CPU/RSS metrics on native Windows and give the channel baseline enough turn budget to report slow gateway runs instead of timing out before proof.
 - Install/update: bypass npm `min-release-age` policies with `--min-release-age=0` instead of `--before` so hosted installers keep working on npm versions that reject the combined config. (#84749) Thanks @TeodoroRodrigo.
+- Diagnostics: reclaim wedged session lanes when stale active-run bookkeeping blocks queued work despite no forward progress. Fixes #85639. Thanks @openperf.
 - WebChat: keep message-tool replies visible in the chat while still summarizing internal tool results for the model. Fixes #86347. Thanks @shakkernerd.
 - Gateway/perf: fail startup benchmark samples when the Gateway process exits before benchmark teardown, including signal deaths after readiness probes.
 - Gateway/perf: fail restart benchmark samples when the Gateway exits before benchmark teardown, including clean exits and signal deaths after successful restart probes.

--- a/src/logging/diagnostic-session-recovery.ts
+++ b/src/logging/diagnostic-session-recovery.ts
@@ -28,6 +28,12 @@ export type StuckSessionRecoveryRequest = {
   allowActiveAbort?: boolean;
   expectedState?: DiagnosticSessionState;
   stateGeneration?: number;
+  /**
+   * Resolved no-forward-progress age (from `diagnostics.stuckSessionAbortMs`) after
+   * which an "active" run with queued work is treated as a leaked/dead handle and
+   * reclaimed. Honors an operator-raised threshold; falls back to a safe floor.
+   */
+  staleActiveProgressAbortMs?: number;
 };
 
 type DiagnosticSessionRecoveryBaseOutcome = {

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
@@ -130,6 +130,26 @@ describe("stuck session recovery", () => {
     ]);
   });
 
+  it("reclaims a stale active embedded run with queued work and no forward progress (#85639)", async () => {
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue("session-1");
+    mocks.getDiagnosticSessionActivitySnapshot.mockReturnValue({
+      lastProgressAgeMs: 10 * 60_000,
+    });
+    mocks.abortEmbeddedPiRun.mockReturnValue(true);
+    mocks.waitForEmbeddedPiRunEnd.mockResolvedValue(true);
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      ageMs: 180_000,
+      queueDepth: 1,
+    });
+
+    expect(mocks.abortEmbeddedPiRun).toHaveBeenCalledWith("session-1");
+    expect(outcome.status).toBe("aborted");
+    expect(warnLogMessages().some((m) => m.includes("reclaiming stale active run"))).toBe(true);
+  });
+
   it("aborts an active embedded run when active abort recovery is enabled", async () => {
     mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue("session-1");
     mocks.abortEmbeddedPiRun.mockReturnValue(true);

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   resolveActiveEmbeddedRunHandleSessionId: vi.fn(),
   resolveEmbeddedSessionLane: vi.fn((key: string) => `session:${key}`),
   waitForEmbeddedPiRunEnd: vi.fn(),
+  getDiagnosticSessionActivitySnapshot: vi.fn(),
   diag: {
     debug: vi.fn(),
     warn: vi.fn(),
@@ -60,6 +61,10 @@ vi.mock("./diagnostic-runtime.js", () => ({
   diagnosticLogger: mocks.diag,
 }));
 
+vi.mock("./diagnostic-run-activity.js", () => ({
+  getDiagnosticSessionActivitySnapshot: mocks.getDiagnosticSessionActivitySnapshot,
+}));
+
 import {
   testing,
   recoverStuckDiagnosticSession,
@@ -85,6 +90,10 @@ function resetMocks() {
   mocks.resolveActiveEmbeddedRunHandleSessionId.mockReset();
   mocks.resolveEmbeddedSessionLane.mockClear();
   mocks.waitForEmbeddedPiRunEnd.mockReset();
+  mocks.getDiagnosticSessionActivitySnapshot.mockReset();
+  // Default: no progress signal, so the staleness gate stays off unless a test
+  // opts in by returning a stale lastProgressAgeMs.
+  mocks.getDiagnosticSessionActivitySnapshot.mockReturnValue({});
   mocks.diag.debug.mockReset();
   mocks.diag.warn.mockReset();
 }
@@ -290,6 +299,107 @@ describe("stuck session recovery", () => {
     expect(warnLogMessages()).toEqual([
       "stuck session recovery outcome: status=skipped action=keep_lane sessionId=queued-reply-session sessionKey=agent:main:main activeSessionId=queued-reply-session activeWorkKind=embedded_run reason=active_reply_work",
     ]);
+  });
+
+  it("reclaims stale leaked reply work with queued work and no forward progress (#85639)", async () => {
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("queued-reply-session");
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.isEmbeddedPiRunActive.mockReturnValue(true);
+    mocks.isEmbeddedPiRunHandleActive.mockReturnValue(false);
+    // The "active" run has made no forward progress for well past the staleness
+    // window — a leaked/dead handle, not genuine work.
+    mocks.getDiagnosticSessionActivitySnapshot.mockReturnValue({ lastProgressAgeMs: 10 * 60_000 });
+    mocks.abortEmbeddedPiRun.mockReturnValue(true);
+    mocks.waitForEmbeddedPiRunEnd.mockResolvedValue(true);
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "queued-reply-session",
+      sessionKey: "agent:main:main",
+      ageMs: 180_000,
+      queueDepth: 1,
+    });
+
+    // Reclaimed (aborted) instead of skipping with active_reply_work.
+    expect(mocks.abortEmbeddedPiRun).toHaveBeenCalledWith("queued-reply-session");
+    expect(outcome.status).not.toBe("skipped");
+    expect(warnLogMessages().some((m) => m.includes("reclaiming stale active reply work"))).toBe(
+      true,
+    );
+  });
+
+  it("honors an operator-raised stuck-session abort threshold for stale reclaim (#85639)", async () => {
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("queued-reply-session");
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.isEmbeddedPiRunActive.mockReturnValue(true);
+    mocks.isEmbeddedPiRunHandleActive.mockReturnValue(false);
+    mocks.abortEmbeddedPiRun.mockReturnValue(true);
+    mocks.waitForEmbeddedPiRunEnd.mockResolvedValue(true);
+
+    // Operator raised the abort threshold to 20 min to protect slow active work.
+    const raisedAbortMs = 20 * 60_000;
+
+    // Below the raised threshold (10 min): keep the lane, do not reclaim.
+    mocks.getDiagnosticSessionActivitySnapshot.mockReturnValue({ lastProgressAgeMs: 10 * 60_000 });
+    const kept = await recoverStuckDiagnosticSession({
+      sessionId: "queued-reply-session",
+      sessionKey: "agent:main:main",
+      ageMs: 180_000,
+      queueDepth: 1,
+      staleActiveProgressAbortMs: raisedAbortMs,
+    });
+    expect(mocks.abortEmbeddedPiRun).not.toHaveBeenCalled();
+    expect(kept.status).toBe("skipped");
+
+    // Past the raised threshold (25 min): reclaim.
+    mocks.getDiagnosticSessionActivitySnapshot.mockReturnValue({ lastProgressAgeMs: 25 * 60_000 });
+    const reclaimed = await recoverStuckDiagnosticSession({
+      sessionId: "queued-reply-session",
+      sessionKey: "agent:main:main",
+      ageMs: 180_000,
+      queueDepth: 1,
+      staleActiveProgressAbortMs: raisedAbortMs,
+    });
+    expect(mocks.abortEmbeddedPiRun).toHaveBeenCalledWith("queued-reply-session");
+    expect(reclaimed.status).not.toBe("skipped");
+  });
+
+  it("keeps the lane when active reply work is still progressing", async () => {
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("queued-reply-session");
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.isEmbeddedPiRunActive.mockReturnValue(true);
+    mocks.isEmbeddedPiRunHandleActive.mockReturnValue(false);
+    // Recent forward progress: a genuinely active run must not be reclaimed.
+    mocks.getDiagnosticSessionActivitySnapshot.mockReturnValue({ lastProgressAgeMs: 5_000 });
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "queued-reply-session",
+      sessionKey: "agent:main:main",
+      ageMs: 180_000,
+      queueDepth: 1,
+    });
+
+    expect(mocks.abortEmbeddedPiRun).not.toHaveBeenCalled();
+    expect(outcome.status).toBe("skipped");
+    expect(warnLogMessages().some((m) => m.includes("reason=active_reply_work"))).toBe(true);
+  });
+
+  it("does not reclaim stale reply work when no work is queued", async () => {
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("queued-reply-session");
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.isEmbeddedPiRunActive.mockReturnValue(true);
+    mocks.isEmbeddedPiRunHandleActive.mockReturnValue(false);
+    mocks.getDiagnosticSessionActivitySnapshot.mockReturnValue({ lastProgressAgeMs: 10 * 60_000 });
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "queued-reply-session",
+      sessionKey: "agent:main:main",
+      ageMs: 180_000,
+      queueDepth: 0,
+    });
+
+    expect(mocks.abortEmbeddedPiRun).not.toHaveBeenCalled();
+    expect(outcome.status).toBe("skipped");
+    expect(warnLogMessages().some((m) => m.includes("reason=active_reply_work"))).toBe(true);
   });
 
   it("aborts stale reply work without an embedded handle when active abort recovery is enabled", async () => {

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -7,6 +7,7 @@ import {
   resolveActiveEmbeddedRunHandleSessionId,
 } from "../agents/pi-embedded-runner/runs.js";
 import { getCommandLaneSnapshot, resetCommandLane } from "../process/command-queue.js";
+import { getDiagnosticSessionActivitySnapshot } from "./diagnostic-run-activity.js";
 import { diagnosticLogger as diag } from "./diagnostic-runtime.js";
 import {
   formatStoppedCronSessionDiagnosticFields,
@@ -20,6 +21,42 @@ import {
 import { isDiagnosticSessionStateCurrent } from "./diagnostic-session-state.js";
 
 const STUCK_SESSION_ABORT_SETTLE_MS = 15_000;
+// Default no-forward-progress age used only when the caller does not carry a
+// resolved `diagnostics.stuckSessionAbortMs`. A run flagged "active" that has made
+// no forward progress (tool/model/chunk events) for at least the resolved window,
+// while queued work waits, is treated as a leaked/dead handle and reclaimed even
+// without an explicit active-abort grant. `lastProgressAgeMs` tracks real progress
+// (not incoming queued messages), so it keeps growing while a lane is wedged.
+const STUCK_SESSION_PROGRESS_STALE_MS = 5 * 60_000;
+
+function resolveStaleActiveProgressAbortMs(params: StuckSessionRecoveryParams): number {
+  const configured = params.staleActiveProgressAbortMs;
+  // Honor the resolved `diagnostics.stuckSessionAbortMs` as-is — an operator can
+  // raise it to protect slow active work (it is the same threshold the existing
+  // `session.stalled` abort uses). It is floored at the warn threshold upstream,
+  // not necessarily 5 min, so we only apply the 5-min default when no value is
+  // carried (e.g. direct callers).
+  return typeof configured === "number" && configured > 0
+    ? configured
+    : STUCK_SESSION_PROGRESS_STALE_MS;
+}
+
+function isActiveRunProgressStale(params: {
+  sessionId?: string;
+  sessionKey?: string;
+  queueDepth?: number;
+  staleAbortMs: number;
+}): boolean {
+  if ((params.queueDepth ?? 0) <= 0) {
+    return false;
+  }
+  const activity = getDiagnosticSessionActivitySnapshot({
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+  });
+  const lastProgressAgeMs = activity.lastProgressAgeMs;
+  return typeof lastProgressAgeMs === "number" && lastProgressAgeMs >= params.staleAbortMs;
+}
 const recoveriesInFlight = new Set<string>();
 
 export type StuckSessionRecoveryParams = StuckSessionRecoveryRequest;
@@ -100,9 +137,18 @@ export async function recoverStuckDiagnosticSession(
     let aborted = false;
     let drained = true;
     let forceCleared = false;
+    const staleActiveProgressAbortMs = resolveStaleActiveProgressAbortMs(params);
 
     if (activeSessionId) {
-      if (params.allowActiveAbort !== true) {
+      const reclaimStaleActiveRun =
+        params.allowActiveAbort !== true &&
+        isActiveRunProgressStale({
+          sessionId: activeSessionId,
+          sessionKey: params.sessionKey,
+          queueDepth: params.queueDepth,
+          staleAbortMs: staleActiveProgressAbortMs,
+        });
+      if (params.allowActiveAbort !== true && !reclaimStaleActiveRun) {
         const outcome: StuckSessionRecoveryOutcome = {
           status: "skipped",
           action: "observe_only",
@@ -118,6 +164,11 @@ export async function recoverStuckDiagnosticSession(
         diag.warn(`stuck session recovery outcome: ${formatRecoveryOutcome(outcome)}`);
         return outcome;
       }
+      if (reclaimStaleActiveRun) {
+        diag.warn(
+          `stuck session recovery reclaiming stale active run: ${formatRecoveryContext(params, { activeSessionId })}`,
+        );
+      }
       const result = await abortAndDrainEmbeddedPiRun({
         sessionId: activeSessionId,
         sessionKey: params.sessionKey,
@@ -131,7 +182,23 @@ export async function recoverStuckDiagnosticSession(
     }
 
     if (!activeSessionId && activeWorkSessionId && isEmbeddedPiRunActive(activeWorkSessionId)) {
-      if (params.allowActiveAbort === true) {
+      const reclaimStaleReplyWork =
+        params.allowActiveAbort !== true &&
+        isActiveRunProgressStale({
+          sessionId: activeWorkSessionId,
+          sessionKey: params.sessionKey,
+          queueDepth: params.queueDepth,
+          staleAbortMs: staleActiveProgressAbortMs,
+        });
+      if (params.allowActiveAbort === true || reclaimStaleReplyWork) {
+        if (reclaimStaleReplyWork) {
+          diag.warn(
+            `stuck session recovery reclaiming stale active reply work: ${formatRecoveryContext(
+              params,
+              { activeSessionId: activeWorkSessionId },
+            )}`,
+          );
+        }
         const result = await abortAndDrainEmbeddedPiRun({
           sessionId: activeWorkSessionId,
           sessionKey: params.sessionKey,

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -1288,6 +1288,7 @@ export function startDiagnosticHeartbeat(
               queueDepth: state.queueDepth,
               expectedState: state.state,
               stateGeneration: state.generation,
+              staleActiveProgressAbortMs: stuckSessionAbortMs,
             },
           });
         } else if (


### PR DESCRIPTION
### Summary

- **Problem**: A group session lane can wedge permanently — messages queue (`queueDepth=1`) but never dispatch. Stuck-session recovery detects the wedge but skips with `reason=active_reply_work action=keep_lane`, repeating every ~2 minutes (the reporter saw 23+ days). The bot goes silent with no user-visible error. (#85639)
- **Root Cause**: A multi-layer state divergence.
  - An embedded agent run dies abnormally (child crash / parent doesn't observe the death cleanly), so `ACTIVE_EMBEDDED_RUNS` keeps a leaked handle and `isEmbeddedPiRunActive(...)` stays `true`, while the separate diagnostic run-activity tracking already shows no active run.
  - The diagnostic heartbeat therefore classifies the lane as `stale_session_state` (`queued_work_without_active_run`), which is `recoveryEligible` **without** `allowActiveAbort` (that grant is reserved for `session.stalled` classifications).
  - `recoverStuckDiagnosticSession` then reads the leaked `isEmbeddedPiRunActive` flag and, because `allowActiveAbort !== true`, skips with `active_reply_work` — a tautology: it keeps the lane because the lane *looks* active.
  - The existing age-based escape doesn't fire: `ageMs` is the session's last-activity age, which **resets every time a new message queues**, so it never crosses a timeout (the reporter's age stayed ~124s for weeks). The existing progress-based abort (`lastProgressAgeMs`) only runs for `session.stalled` classifications, not `stale_session_state`.
- **Fix**: Make the active-run skip a **liveness check** instead of a blind flag read. Before keeping the lane for `active_embedded_run` / `active_reply_work`, consult the run's real forward-progress age (`getDiagnosticSessionActivitySnapshot(...).lastProgressAgeMs`, which is touched by tool/model/chunk events, **not** by incoming queued messages). If a run flagged active has made no forward progress for ≥ a staleness window **and** there is queued work, treat it as a leaked/dead handle and reclaim it (abort + drain + force-clear) instead of skipping. A genuinely progressing run (recent `lastProgressAgeMs`) is still kept.
- **What changed**:
  - `src/logging/diagnostic-stuck-session-recovery.runtime.ts`: add `isActiveRunProgressStale` (queued work + stale `lastProgressAgeMs`); both the `active_embedded_run` and `active_reply_work` skip branches reclaim instead of skipping when the active run's progress is stale.
  - `src/logging/diagnostic-session-recovery.ts` + `src/logging/diagnostic.ts`: thread the resolved `diagnostics.stuckSessionAbortMs` into the recovery request (`staleActiveProgressAbortMs`) so the reclaim **honors an operator-raised abort threshold**; it falls back to the `MIN_STALLED_EMBEDDED_RUN_ABORT_MS` (5 min) floor when not supplied, matching the existing stalled-run abort policy.
  - `src/logging/diagnostic-stuck-session-recovery.runtime.test.ts`: regression coverage.
- **What did NOT change (scope boundary)**:
  - The `allowActiveAbort` path, the diagnostic classifier, the heartbeat, and the run registries are unchanged. The reclaim is additive: it only fires when an active flag is paired with stale forward progress and queued work, so existing skip/abort behavior is otherwise identical.
  - No config keys, protocol, or message-delivery behavior changed.

### Reproduction

1. A run starts on a group session lane, then dies abnormally so its `ACTIVE_EMBEDDED_RUNS` handle is never cleared (diagnostic activity already shows no active run).
2. New messages keep queuing on the lane.
- Before: every heartbeat classifies `stale_session_state`, recovery reads the leaked active flag and skips with `active_reply_work` — the lane never frees (permanent wedge).
- After: once the leaked run has made no forward progress past the staleness window with queued work waiting, recovery reclaims the lane (abort + force-clear) and queued work dispatches.

### Real behavior proof

- **Behavior addressed**: when a session is stuck with queued work and a leaked "active" run flag whose forward progress is stale, recovery must reclaim the lane rather than skip with `active_reply_work`; a still-progressing run must not be reclaimed.
- **Real environment tested**: the real `recoverStuckDiagnosticSession` decision path exercised under Vitest (Linux, Node 22). The run/abort registry and lane seams are mocked exactly as the existing 15-case suite in this file does; the recovery logic, the new liveness gate, and `lastProgressAgeMs` thresholding are real.
- **Exact steps or command run after this patch**: `pnpm test src/logging/diagnostic-stuck-session-recovery.runtime.test.ts`.
- **Evidence after fix (verbatim test output)**:

```text
 Test Files  1 passed (1)
      Tests  19 passed (19)
```

- **Before evidence (same tests with the production fix reverted, on base `c91c3c6e5a`)**: the new staleness-reclaim case fails because the unpatched recovery skips (the wedge); the two control cases (still-progressing, no queued work) pass because the unpatched path also keeps the lane:

```text
 × reclaims stale leaked reply work with queued work and no forward progress (#85639)
 Test Files  1 failed (1)
      Tests  1 failed | 2 passed | 15 skipped (18)
```

- **Real-component proof (no mocked seams)**: a standalone harness (`tsx /tmp/qmd85639/repro.mts`, Linux/Node 22) drives the **real** `recoverStuckDiagnosticSession`, the **real** embedded-run registry (`setActiveEmbeddedRun` leaks a handle to simulate abnormal death), and the **real** diagnostic run-activity tracker; the clock is advanced so the run's real `lastProgressAgeMs` crosses the window. FRESH (recent progress) keeps the lane; STALE (10 min, no progress, queued work) reclaims it (real abort + force-clear), after which the handle is gone (`active=false`):

```text
=== #85639 real-component recovery repro (real registry + activity + recovery) ===
--- FRESH: leaked active handle but recent forward progress ---
[repro] FRESH: lastProgress=0s active=true -> status=skipped action=observe_only reason=active_embedded_run
--- STALE: leaked active handle, no forward progress for 10m + queued work ---
[repro] STALE: lastProgress=600s active=false -> status=aborted action=abort_embedded_run reason=-
```

(The STALE run also emitted the real gateway logs `stuck session recovery reclaiming stale active run …` and `… action=abort_embedded_run aborted=true forceCleared=true`.)
- **Observed result after fix**: the stale leaked active run is reclaimed (abort + drain + force-clear, logged `reclaiming stale active …`); the still-progressing run and the no-queued-work cases still keep the lane (no false reclaim).
- **What was not tested**: a full multi-process live gateway wedge over days was not run. The bug is in-memory recovery decision logic; the real-component harness above exercises the actual recovery + registry + activity tracker end to end, and the unit tests cover the decision branches. The staleness window honors `diagnostics.stuckSessionAbortMs` (default ≥ 5 min) so a live-but-slow run is not reclaimed.

### Risk / Mitigation

- **Risk**: reclaiming could abort a genuinely active long-running run.
- **Mitigation**: reclaim only fires when forward progress (`lastProgressAgeMs`, which is not refreshed by incoming queued messages) is stale for ≥ the resolved `diagnostics.stuckSessionAbortMs` (operator-configurable; default ≥ 5 min) **and** there is queued work; a run making any recent progress is kept. An operator who raises the threshold to protect slow active work is honored (covered by a raised-threshold test: stale at 10 min is kept, at 25 min is reclaimed). This mirrors the existing `blocked_tool_call` abort which already triggers at the same `lastProgressAgeMs`/threshold scale. Without queued work, nothing is reclaimed.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Sessions / storage

### Linked Issue/PR

Fixes #85639
