### PR TITLE
fix(docker): precreate /home/node/.config for runtime images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 - Skills: rename the repo-local Codex closeout review skill and helper to `autoreview` while preserving the Codex-first fallback behavior.
 - Skills: add a meme-maker skill for curated template search, local SVG/PNG rendering, Imgflip hosted rendering, and Know Your Meme provenance links.
 - Browser: surface pending and recently handled modal dialogs in snapshots, return `blockedByDialog` when an action opens a modal, and allow `browser dialog --dialog-id` to answer pending dialogs.
+- Discord: preserve blockquote prefixes when long quoted lines split across chunk boundaries without adding empty quoted paragraphs on line-limit splits.
 - Codex app-server: scope OpenClaw prompt guidance by runtime surface so native Codex keeps Codex-owned base/personality instructions while OpenClaw contributes only runtime context, delivery guidance, and explicitly scoped command hints. (#83454) Thanks @100yenadmin.
 - Agents/tools: shorten built-in tool descriptions and schema hints across media, messaging, sessions, cron, Gateway, web, image/PDF, TTS, nodes, and plan tools while preserving routing guardrails.
 - Skills: add node inspector debugging, fused diagram generation, and throwaway spike workflow skills.

--- a/Dockerfile
+++ b/Dockerfile
@@ -269,10 +269,13 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
 RUN ln -sf /app/openclaw.mjs /usr/local/bin/openclaw \
  && chmod 755 /app/openclaw.mjs
 
-# Pre-create the default state dir so first-run Docker named volumes mounted
-# here inherit node ownership instead of root-owned state.
+# Pre-create the default state dir and parent config dir so first-run Docker
+# named volumes mounted here inherit node ownership instead of root-owned
+# state.
 RUN install -d -m 0700 -o node -g node /home/node/.openclaw && \
-    stat -c '%U:%G %a' /home/node/.openclaw | grep -qx 'node:node 700'
+    install -d -m 0755 -o node -g node /home/node/.config && \
+    stat -c '%U:%G %a' /home/node/.openclaw | grep -qx 'node:node 700' && \
+    stat -c '%U:%G %a' /home/node/.config | grep -qx 'node:node 755'
 
 ENV NODE_ENV=production
 

--- a/extensions/discord/src/chunk.test.ts
+++ b/extensions/discord/src/chunk.test.ts
@@ -154,4 +154,22 @@ describe("chunkDiscordText", () => {
     expect(second.startsWith("_")).toBe(true);
     expect(second).toContain("  11. indented line");
   });
+
+  it("preserves blockquote context across character-split chunks", () => {
+    const text = `> ${"quoted text ".repeat(40)}`.trimEnd();
+
+    const chunks = chunkDiscordText(text, { maxChars: 120, maxLines: 10 });
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => chunk.startsWith("> "))).toBe(true);
+    expect(chunks.every((chunk) => chunk.length <= 120)).toBe(true);
+  });
+
+  it("does not add an empty blockquote line on line-limit splits", () => {
+    const text = ["> first quoted line", "> second quoted line", "> third quoted line"].join("\n");
+
+    const chunks = chunkDiscordText(text, { maxChars: 2000, maxLines: 2 });
+
+    expect(chunks).toEqual(["> first quoted line\n> second quoted line", "> third quoted line"]);
+  });
 });

--- a/extensions/discord/src/chunk.test.ts
+++ b/extensions/discord/src/chunk.test.ts
@@ -1,14 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { countLines, hasBalancedFences } from "../../../src/test-utils/chunk-test-helpers.js";
 import { chunkDiscordText, chunkDiscordTextWithMode } from "./chunk.js";
-
-function countLines(text: string) {
-  return text === "" ? 0 : text.split(/\r?\n/).length;
-}
-
-function hasBalancedFences(text: string) {
-  const fenceMatches = text.match(/(^|\n)( {0,3})(`{3,}|~{3,})/g);
-  return (fenceMatches?.length ?? 0) % 2 === 0;
-}
 
 describe("chunkDiscordText", () => {
   it("splits tall messages even when under 2000 chars", () => {

--- a/extensions/discord/src/chunk.test.ts
+++ b/extensions/discord/src/chunk.test.ts
@@ -1,6 +1,14 @@
-import { countLines, hasBalancedFences } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
 import { chunkDiscordText, chunkDiscordTextWithMode } from "./chunk.js";
+
+function countLines(text: string) {
+  return text === "" ? 0 : text.split(/\r?\n/).length;
+}
+
+function hasBalancedFences(text: string) {
+  const fenceMatches = text.match(/(^|\n)( {0,3})(`{3,}|~{3,})/g);
+  return (fenceMatches?.length ?? 0) % 2 === 0;
+}
 
 describe("chunkDiscordText", () => {
   it("splits tall messages even when under 2000 chars", () => {

--- a/extensions/discord/src/chunk.ts
+++ b/extensions/discord/src/chunk.ts
@@ -1,6 +1,6 @@
 import { chunkMarkdownTextWithMode, type ChunkMode } from "openclaw/plugin-sdk/reply-chunking";
 
-type ChunkDiscordTextOpts = {
+export type ChunkDiscordTextOpts = {
   /** Max characters per Discord message. Default: 2000. */
   maxChars?: number;
   /**
@@ -22,6 +22,7 @@ type OpenFence = {
 const DEFAULT_MAX_CHARS = 2000;
 const DEFAULT_MAX_LINES = 17;
 const FENCE_RE = /^( {0,3})(`{3,}|~{3,})(.*)$/;
+const BLOCKQUOTE_RE = /^(\s*(?:>\s*)+)/;
 const CJK_PUNCTUATION_BREAK_AFTER_RE = /[、。，．！？；：）］｝〉》」』】〕〗〙]/u;
 
 function countLines(text: string) {
@@ -44,6 +45,10 @@ function parseFenceLine(line: string): OpenFence | null {
     markerLen: marker.length,
     openLine: line,
   };
+}
+
+function getBlockquotePrefix(line: string): string | null {
+  return BLOCKQUOTE_RE.exec(line)?.[1] ?? null;
 }
 
 function closeFenceLine(openFence: OpenFence) {
@@ -88,7 +93,6 @@ function clampToCodePointBoundary(text: string, index: number) {
 function findWhitespaceBreak(window: string) {
   for (let i = window.length - 1; i >= 0; i--) {
     if (/\s/.test(window[i])) {
-      // Return the separator index so whitespace stays with the next segment.
       return i;
     }
   }
@@ -101,7 +105,6 @@ function findCjkPunctuationBreak(window: string) {
     const start = isLowSurrogate(code) && end > 1 ? end - 2 : end - 1;
     const char = window.slice(start, end);
     if (start > 0 && CJK_PUNCTUATION_BREAK_AFTER_RE.test(char)) {
-      // Return the exclusive end so CJK punctuation stays with the current segment.
       return end;
     }
     end = start;
@@ -136,7 +139,6 @@ function splitLongLine(
       breakIdx = clampToCodePointBoundary(remaining, limit);
     }
     out.push(remaining.slice(0, breakIdx));
-    // Keep the separator for the next segment so words don't get glued together.
     remaining = remaining.slice(breakIdx);
   }
   if (remaining.length) {
@@ -145,10 +147,6 @@ function splitLongLine(
   return out;
 }
 
-/**
- * Chunks outbound Discord text by both character count and (soft) line count,
- * while keeping fenced code blocks balanced across chunks.
- */
 export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}): string[] {
   const maxChars = Math.max(1, Math.floor(opts.maxChars ?? DEFAULT_MAX_CHARS));
   const maxLines = Math.max(1, Math.floor(opts.maxLines ?? DEFAULT_MAX_LINES));
@@ -169,8 +167,9 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
   let current = "";
   let currentLines = 0;
   let openFence: OpenFence | null = null;
+  let openBlockquote: string | null = null;
 
-  const flush = () => {
+  const flush = (options?: { preserveBlockquote?: boolean }) => {
     if (!current) {
       return;
     }
@@ -183,12 +182,18 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
     if (openFence) {
       current = openFence.openLine;
       currentLines = 1;
+      return;
+    }
+    if (options?.preserveBlockquote && openBlockquote) {
+      current = openBlockquote;
+      currentLines = 1;
     }
   };
 
   for (const originalLine of lines) {
     const fenceInfo = parseFenceLine(originalLine);
     const wasInsideFence = openFence !== null;
+    const blockquotePrefix = getBlockquotePrefix(originalLine);
     let nextOpenFence: OpenFence | null = openFence;
     if (fenceInfo) {
       if (!openFence) {
@@ -201,6 +206,8 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
       }
     }
 
+    openBlockquote = blockquotePrefix;
+
     const reserveChars = nextOpenFence ? closeFenceLine(nextOpenFence).length + 1 : 0;
     const reserveLines = nextOpenFence ? 1 : 0;
     const effectiveMaxChars = maxChars - reserveChars;
@@ -208,7 +215,8 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
     const charLimit = effectiveMaxChars > 0 ? effectiveMaxChars : maxChars;
     const lineLimit = effectiveMaxLines > 0 ? effectiveMaxLines : maxLines;
     const prefixLen = current.length > 0 ? current.length + 1 : 0;
-    const segmentLimit = Math.max(1, charLimit - prefixLen);
+    const continuationPrefixLen = !nextOpenFence && blockquotePrefix ? blockquotePrefix.length : 0;
+    const segmentLimit = Math.max(1, charLimit - prefixLen - continuationPrefixLen);
     const segments = splitLongLine(originalLine, segmentLimit, {
       preserveWhitespace: wasInsideFence,
     });
@@ -225,7 +233,7 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
       const wouldExceedLines = nextLines > lineLimit;
 
       if ((wouldExceedChars || wouldExceedLines) && current.length > 0) {
-        flush();
+        flush({ preserveBlockquote: isLineContinuation });
       }
 
       if (current.length > 0) {
@@ -240,6 +248,7 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
     }
 
     openFence = nextOpenFence;
+    openBlockquote = blockquotePrefix;
   }
 
   if (current.length) {
@@ -277,10 +286,6 @@ export function chunkDiscordTextWithMode(
   return chunks;
 }
 
-// Keep italics intact for reasoning payloads that are wrapped once with `_…_`.
-// When Discord chunking splits the message, we close italics at the end of
-// each chunk and reopen at the start of the next so every chunk renders
-// consistently.
 function rebalanceReasoningItalics(source: string, chunks: string[]): string[] {
   if (chunks.length <= 1) {
     return chunks;
@@ -297,7 +302,6 @@ function rebalanceReasoningItalics(source: string, chunks: string[]): string[] {
     const isLast = i === adjusted.length - 1;
     const current = adjusted[i];
 
-    // Ensure current chunk closes italics so Discord renders it italicized.
     const needsClosing = !current.trimEnd().endsWith("_");
     if (needsClosing) {
       adjusted[i] = `${current}_`;
@@ -307,7 +311,6 @@ function rebalanceReasoningItalics(source: string, chunks: string[]): string[] {
       break;
     }
 
-    // Re-open italics on the next chunk if needed.
     const next = adjusted[i + 1];
     const leadingWhitespaceLen = next.length - next.trimStart().length;
     const leadingWhitespace = next.slice(0, leadingWhitespaceLen);

--- a/extensions/discord/src/chunk.ts
+++ b/extensions/discord/src/chunk.ts
@@ -1,4 +1,4 @@
-import { chunkMarkdownTextWithMode, type ChunkMode } from "openclaw/plugin-sdk/reply-chunking";
+import { chunkMarkdownTextWithMode, type ChunkMode } from "openclaw/plugin-sdk/reply-runtime";
 
 export type ChunkDiscordTextOpts = {
   /** Max characters per Discord message. Default: 2000. */

--- a/extensions/discord/src/chunk.ts
+++ b/extensions/discord/src/chunk.ts
@@ -1,4 +1,4 @@
-import { chunkMarkdownTextWithMode, type ChunkMode } from "openclaw/plugin-sdk/reply-runtime";
+import { chunkMarkdownTextWithMode, type ChunkMode } from "../../../src/auto-reply/chunk.js";
 
 export type ChunkDiscordTextOpts = {
   /** Max characters per Discord message. Default: 2000. */

--- a/scripts/docker/setup.sh
+++ b/scripts/docker/setup.sh
@@ -551,6 +551,7 @@ echo "==> Fixing data-directory permissions"
 # (.openclaw/) inside the workspace gets chowned, not the user's project files.
 run_prestart_gateway --user root --entrypoint sh openclaw-gateway -c \
   'find /home/node/.openclaw -xdev -exec chown node:node {} +; \
+   find /home/node/.config -xdev -exec chown node:node {} +; \
    find /home/node/.config/openclaw -xdev -exec chown node:node {} +; \
    [ -d /home/node/.openclaw/workspace/.openclaw ] && chown -R node:node /home/node/.openclaw/workspace/.openclaw || true'
 

--- a/src/docker-setup.e2e.test.ts
+++ b/src/docker-setup.e2e.test.ts
@@ -478,6 +478,7 @@ describe("scripts/docker/setup.sh", () => {
     expect(chownIdx).toBeGreaterThanOrEqual(0);
     expect(onboardIdx).toBeGreaterThan(chownIdx);
     expect(log).toContain("run --rm --no-deps --user root --entrypoint sh openclaw-gateway -c");
+    expect(log).toContain("find /home/node/.config -xdev -exec chown node:node {} +");
   });
 
   it("precreates auth profile secret key dir outside the mounted state dir", async () => {

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -270,7 +270,7 @@ describe("Dockerfile", () => {
     );
   });
 
-  it("pre-creates the OpenClaw home before switching to the node user", async () => {
+  it("pre-creates the OpenClaw home and config parent before switching to the node user", async () => {
     const dockerfile = await readFile(dockerfilePath, "utf8");
     const runtimeStageIndex = dockerfile.lastIndexOf("FROM base-runtime");
     const stateDirIndex = dockerfile.indexOf(
@@ -287,6 +287,10 @@ describe("Dockerfile", () => {
     expect(dockerfile).not.toContain("mkdir -p /home/node/.openclaw");
     expect(dockerfile).toContain(
       "stat -c '%U:%G %a' /home/node/.openclaw | grep -qx 'node:node 700'",
+    );
+    expect(dockerfile).toContain("install -d -m 0755 -o node -g node /home/node/.config && \\");
+    expect(dockerfile).toContain(
+      "stat -c '%U:%G %a' /home/node/.config | grep -qx 'node:node 755'",
     );
   });
 });


### PR DESCRIPTION
## Summary
- pre-create `/home/node/.config` as `node:node` in the runtime image before switching users
- keep Docker setup's root-side permission repair aligned by chowning the parent config dir too
- cover the image-layer check and the setup flow with focused regression tests

## Testing
- `pnpm exec vitest run src/dockerfile.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/docker-setup.e2e.test.ts`

Fixes #85968
