### PR TITLE
feat(ui): timestamp unnamed dashboard sessions

### DIFF
--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -304,6 +304,7 @@ function emitSessionsChanged(
             deliveryContext: sessionRow.deliveryContext,
             parentSessionKey: sessionRow.parentSessionKey,
             childSessions: sessionRow.childSessions,
+            sessionStartedAt: sessionRow.sessionStartedAt,
             thinkingLevel: sessionRow.thinkingLevel,
             fastMode: sessionRow.fastMode,
             verboseLevel: sessionRow.verboseLevel,

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -52,6 +52,7 @@ function buildGatewaySessionSnapshot(params: {
     deliveryContext: sessionRow.deliveryContext,
     parentSessionKey: params.parentSessionKey ?? sessionRow.parentSessionKey,
     childSessions: sessionRow.childSessions,
+    sessionStartedAt: sessionRow.sessionStartedAt,
     thinkingLevel: sessionRow.thinkingLevel,
     fastMode: sessionRow.fastMode,
     verboseLevel: sessionRow.verboseLevel,

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -392,6 +392,34 @@ describe("gateway session utils", () => {
     });
   });
 
+  test("session rows expose the session creation timestamp", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.providers.push({
+      pluginId: "test",
+      source: "test",
+      provider: {
+        id: "test-provider",
+        label: "Test Provider",
+        auth: [],
+      },
+    });
+    setActivePluginRegistry(registry);
+
+    const row = buildGatewaySessionRow({
+      cfg: createModelDefaultsConfig({ primary: "test-provider/test-model" }),
+      storePath: "",
+      store: {},
+      key: "agent:main:dashboard:session-1",
+      entry: {
+        sessionId: "session-1",
+        updatedAt: 200,
+        sessionStartedAt: 100,
+      },
+    });
+
+    expect(row.sessionStartedAt).toBe(100);
+  });
+
   test("async session list reuses thinking metadata for lightweight rows", async () => {
     const resolveThinkingProfile = vi.fn(() => ({
       levels: [{ id: "off" as const }, { id: "medium" as const }],

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1913,6 +1913,7 @@ export function buildGatewaySessionRow(params: {
     chatType: entry?.chatType,
     origin,
     updatedAt,
+    sessionStartedAt: entry?.sessionStartedAt,
     sessionId: entry?.sessionId,
     systemSent: entry?.systemSent,
     abortedLastRun: entry?.abortedLastRun,

--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -52,6 +52,7 @@ export type GatewaySessionRow = {
   chatType?: ChatType;
   origin?: SessionEntry["origin"];
   updatedAt: number | null;
+  sessionStartedAt?: number;
   sessionId?: string;
   systemSent?: boolean;
   abortedLastRun?: boolean;

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -463,6 +463,42 @@ describe("resolveSessionDisplayName", () => {
       ),
     ).toBe("Tyler");
   });
+
+  it("uses the creation time for unlabeled same-day dashboard sessions", () => {
+    const key = "agent:ops:dashboard:chat-1";
+    const createdAt = new Date(2026, 4, 24, 14, 12).getTime();
+    const now = new Date(2026, 4, 24, 22, 0);
+
+    expect(resolveSessionDisplayName(key, row({ key, sessionStartedAt: createdAt }), { now })).toBe(
+      "14:12",
+    );
+  });
+
+  it("includes the date for unlabeled dashboard sessions from another day", () => {
+    const key = "agent:ops:dashboard:chat-2";
+    const createdAt = new Date(2026, 4, 23, 9, 5).getTime();
+    const now = new Date(2026, 4, 24, 22, 0);
+
+    expect(resolveSessionDisplayName(key, row({ key, sessionStartedAt: createdAt }), { now })).toBe(
+      "05-23 09:05",
+    );
+  });
+
+  it("preserves explicit labels for dashboard sessions", () => {
+    const key = "agent:ops:dashboard:chat-3";
+    const createdAt = new Date(2026, 4, 24, 14, 12).getTime();
+    const now = new Date(2026, 4, 24, 22, 0);
+
+    expect(
+      resolveSessionDisplayName(
+        key,
+        row({ key, label: "Bug triage", sessionStartedAt: createdAt }),
+        {
+          now,
+        },
+      ),
+    ).toBe("Bug triage");
+  });
 });
 
 describe("resolveDashboardHeaderContext", () => {

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -1262,6 +1262,36 @@ describe("applySessionsChangedEvent", () => {
     expect(state.sessionsResult?.sessions[0]?.model).toBe("gpt-5.4");
   });
 
+  it("copies creation timestamps from websocket event payloads", () => {
+    const state = createState(async () => undefined, {
+      sessionsResult: {
+        ts: 1,
+        path: "(multiple)",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [
+          {
+            key: "agent:main:dashboard:abc",
+            kind: "direct",
+            updatedAt: 20,
+          },
+        ],
+      },
+    });
+
+    const applied = applySessionsChangedEvent(state, {
+      sessionKey: "agent:main:dashboard:abc",
+      sessionId: "sess-dashboard",
+      ts: 2,
+      sessionStartedAt: 10,
+      updatedAt: 30,
+    });
+
+    expect(applied).toEqual({ applied: true, change: "updated" });
+    expect(state.sessionsResult?.sessions[0]?.updatedAt).toBe(30);
+    expect(state.sessionsResult?.sessions[0]?.sessionStartedAt).toBe(10);
+  });
+
   it("clears old token totals when the gateway marks the measurement stale", () => {
     const state = createState(async () => undefined, {
       sessionsResult: {

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -123,6 +123,7 @@ const SESSION_EVENT_ROW_FIELDS = [
   "reasoningLevel",
   "runtimeMs",
   "sessionId",
+  "sessionStartedAt",
   "spawnedBy",
   "startedAt",
   "status",

--- a/ui/src/ui/session-display.ts
+++ b/ui/src/ui/session-display.ts
@@ -23,8 +23,42 @@ export type SessionKeyInfo = {
   fallbackName: string;
 };
 
+export type SessionDisplayNameOptions = {
+  now?: Date;
+};
+
 function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function formatTwoDigits(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+function isDashboardSessionKey(key: string): boolean {
+  return key.startsWith("dashboard:") || key.includes(":dashboard:");
+}
+
+function resolveFiniteTimestamp(value: number | null | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function formatDashboardSessionTimestamp(timestamp: number, now: Date): string | undefined {
+  const date = new Date(timestamp);
+  if (!Number.isFinite(date.getTime())) {
+    return undefined;
+  }
+
+  const time = `${formatTwoDigits(date.getHours())}:${formatTwoDigits(date.getMinutes())}`;
+  const sameDay =
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth() &&
+    date.getDate() === now.getDate();
+
+  if (sameDay) {
+    return time;
+  }
+  return `${formatTwoDigits(date.getMonth() + 1)}-${formatTwoDigits(date.getDate())} ${time}`;
 }
 
 /**
@@ -80,6 +114,7 @@ export function parseSessionKey(key: string): SessionKeyInfo {
 export function resolveSessionDisplayName(
   key: string,
   row?: SessionsListResult["sessions"][number],
+  options: SessionDisplayNameOptions = {},
 ): string {
   const label = normalizeOptionalString(row?.label) ?? "";
   const displayName = normalizeOptionalString(row?.displayName) ?? "";
@@ -98,6 +133,16 @@ export function resolveSessionDisplayName(
   }
   if (displayName && displayName !== key) {
     return applyTypedPrefix(displayName);
+  }
+  if (isDashboardSessionKey(key)) {
+    const timestamp =
+      resolveFiniteTimestamp(row?.sessionStartedAt) ?? resolveFiniteTimestamp(row?.updatedAt);
+    const fallback = timestamp
+      ? formatDashboardSessionTimestamp(timestamp, options.now ?? new Date())
+      : undefined;
+    if (fallback) {
+      return fallback;
+    }
   }
   return fallbackName;
 }

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -430,6 +430,7 @@ export type GatewaySessionRow = {
   room?: string;
   space?: string;
   updatedAt: number | null;
+  sessionStartedAt?: number;
   sessionId?: string;
   systemSent?: boolean;
   abortedLastRun?: boolean;


### PR DESCRIPTION
## Summary

- Problem: new Control UI dashboard sessions without a label/displayName fall back to raw session keys, making multiple new chats hard to distinguish.
- Solution: add a Control UI fallback that renders unnamed dashboard sessions as their local creation time.
- What changed: gateway session rows now expose `sessionStartedAt`; Control UI uses it for dashboard-session display fallback, with `updatedAt` as a legacy fallback.
- What did NOT change (scope boundary): no persisted labels are written, no rename UI was added, and explicit labels/display names still win.

AI-assisted: yes. I used a local coding agent and ran the verification below myself.

## Motivation

- Closes #86040.
- This is a low-friction UX improvement for users who create several dashboard chats with `/NEW` and need to pick the right session at a glance.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #86040
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: unnamed Control UI dashboard sessions now display a local timestamp fallback instead of the raw `agent:<id>:dashboard:<uuid>` key, while named sessions still display their explicit label.
- Real environment tested: macOS 26.5 (25F71), local OpenClaw checkout at this PR branch, Node v23.11.0, pnpm 11.2.2.
- Exact steps or command run after this patch:
  - `pnpm --dir ui exec tsx -e "import { resolveSessionDisplayName } from './src/ui/session-display.ts'; const key = 'agent:ops:dashboard:chat-proof'; const now = new Date(2026, 4, 24, 22, 0); const sameDay = resolveSessionDisplayName(key, { key, kind: 'direct', updatedAt: 200, sessionStartedAt: new Date(2026, 4, 24, 14, 12).getTime() }, { now }); const priorDay = resolveSessionDisplayName('agent:ops:dashboard:chat-proof-2', { key: 'agent:ops:dashboard:chat-proof-2', kind: 'direct', updatedAt: 200, sessionStartedAt: new Date(2026, 4, 23, 9, 5).getTime() }, { now }); const named = resolveSessionDisplayName(key, { key, kind: 'direct', updatedAt: 200, label: 'Bug triage', sessionStartedAt: new Date(2026, 4, 24, 14, 12).getTime() }, { now }); console.log(JSON.stringify({ sameDay, priorDay, named }, null, 2));"`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```json
{
  "sameDay": "14:12",
  "priorDay": "05-23 09:05",
  "named": "Bug triage"
}
```

- Observed result after fix: same-day unnamed dashboard sessions render `HH:mm`, prior-day unnamed dashboard sessions render `MM-DD HH:mm`, and explicit labels remain unchanged.
- What was not tested: I did not run a full local gateway plus browser session with a live `/NEW` interaction. The focused runtime proof above imports the actual Control UI helper, and the browser/unit tests below cover the UI helper/controller surfaces.
- Before evidence (optional but encouraged): the new RED test initially failed with `expected 'agent:ops:dashboard:chat-1' to be '14:12'` before the implementation.

## Root Cause (if applicable)

- Root cause: N/A, this is a feature request.
- Missing detection / guardrail: unnamed dashboard-session display fallback was not covered.
- Contributing context (if known): dashboard session rows already had durable `sessionStartedAt`, but the projected gateway row did not expose it to the UI.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/ui/app-render.helpers.node.test.ts` and `src/gateway/session-utils.test.ts`.
- Scenario the test should lock in: unnamed dashboard sessions use `sessionStartedAt` for timestamp fallback; explicit labels still win; gateway rows include `sessionStartedAt`.
- Why this is the smallest reliable guardrail: the behavior is pure display resolution plus one projected row field.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Unnamed Control UI dashboard sessions now display a timestamp fallback in session pickers/tabs instead of the raw dashboard session key.

## Diagram (if applicable)

```text
Before:
/NEW -> agent:ops:dashboard:<uuid> -> raw key shown when unlabeled

After:
/NEW -> sessionStartedAt projected -> 14:12 / 05-24 14:12 shown when unlabeled
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any Yes, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 26.5 (25F71)
- Runtime/container: local Node v23.11.0, pnpm 11.2.2
- Model/provider: N/A
- Integration/channel (if any): Control UI dashboard sessions
- Relevant config (redacted): N/A

### Steps

1. Create or load an unlabeled dashboard session row with `key = agent:ops:dashboard:<id>` and `sessionStartedAt`.
2. Pass it through `resolveSessionDisplayName`.
3. Compare same-day, prior-day, and explicitly labeled rows.

### Expected

- Same-day unnamed dashboard row displays `14:12`.
- Prior-day unnamed dashboard row displays `05-23 09:05`.
- Explicitly labeled dashboard row displays `Bug triage`.

### Actual

- Matches expected; copied runtime output is in the Real behavior proof section.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification commands run:

- `pnpm --dir ui exec vitest run src/ui/app-render.helpers.node.test.ts src/ui/controllers/sessions.test.ts src/ui/app-render.helpers.browser.test.ts --config vitest.config.ts` -> 3 files passed, 117 tests passed.
- `pnpm exec vitest run --config test/vitest/vitest.gateway.config.ts src/gateway/session-utils.test.ts --testNamePattern "creation timestamp" --reporter verbose` -> 1 test passed, 93 skipped.
- `pnpm --dir ui exec vitest run src/ui/app-render.helpers.node.test.ts --config vitest.config.ts --reporter dot` -> 1 file passed, 68 tests passed.
- `pnpm tsgo:test:ui` -> passed.
- `git diff --check` -> passed.

Known local check note:

- `pnpm tsgo:test:src` failed on pre-existing declaration gaps for `scripts/npm-runner.mjs`, `scripts/pnpm-runner.mjs`, and `scripts/windows-cmd-helpers.mjs`; those files are unrelated to this PR.

## Human Verification (required)

- Verified scenarios: same-day dashboard fallback, previous-day dashboard fallback, explicit label preservation, gateway row projection of `sessionStartedAt`.
- Edge cases checked: missing/unnamed row falls back only for dashboard keys; existing label/displayName precedence remains unchanged.
- What I did not verify: a full live Control UI browser flow creating a session through a running gateway.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Some legacy dashboard rows may not have `sessionStartedAt`.
  - Mitigation: the display fallback uses `updatedAt` when `sessionStartedAt` is unavailable, and otherwise preserves the existing fallback behavior.
