### PR TITLE
fix(agents): count exec-path openclaw cron add in successfulCronAdds

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -375,6 +375,135 @@ describe("handleToolExecutionEnd cron.add commitment tracking", () => {
     expect(ctx.state.itemCompletedCount).toBe(1);
     expect(ctx.state.itemActiveIds.size).toBe(0);
   });
+
+  it("increments successfulCronAdds when exec runs openclaw cron add and output confirms creation", async () => {
+    const { ctx } = createTestContext();
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-cron-1",
+        args: { command: "openclaw cron add --name reminder --schedule '0 9 * * *'" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-cron-1",
+        isError: false,
+        result: {
+          details: {
+            status: "completed",
+            aggregated: "Created cron job: reminder (next run: tomorrow 09:00)",
+            exitCode: 0,
+          },
+        },
+      } as never,
+    );
+
+    expect(ctx.state.successfulCronAdds).toBe(1);
+  });
+
+  it("does not increment successfulCronAdds for a bypass attempt (substring match without anchor)", async () => {
+    const { ctx } = createTestContext();
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-cron-bypass",
+        // This would match an unanchored /\bcron\s+add\b/ regex but must NOT match.
+        args: { command: 'echo "openclaw cron add fake"' },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-cron-bypass",
+        isError: false,
+        result: {
+          details: {
+            status: "completed",
+            aggregated: "openclaw cron add fake\nCreated",
+            exitCode: 0,
+          },
+        },
+      } as never,
+    );
+
+    expect(ctx.state.successfulCronAdds).toBe(0);
+  });
+
+  it("does not increment successfulCronAdds when openclaw cron add output lacks creation receipt", async () => {
+    const { ctx } = createTestContext();
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-cron-no-receipt",
+        args: { command: "openclaw cron add --name reminder --schedule '0 9 * * *'" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-cron-no-receipt",
+        isError: false,
+        result: {
+          details: {
+            status: "completed",
+            aggregated: "Error: cron quota exceeded",
+            exitCode: 1,
+          },
+        },
+      } as never,
+    );
+
+    expect(ctx.state.successfulCronAdds).toBe(0);
+  });
+
+  it("does not increment successfulCronAdds for a cron add command without the openclaw prefix", async () => {
+    const { ctx } = createTestContext();
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-cron-no-prefix",
+        args: { command: "cron add --name reminder" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-cron-no-prefix",
+        isError: false,
+        result: {
+          details: {
+            status: "completed",
+            aggregated: "Created cron job: reminder",
+            exitCode: 0,
+          },
+        },
+      } as never,
+    );
+
+    expect(ctx.state.successfulCronAdds).toBe(0);
+  });
 });
 
 describe("handleToolExecutionEnd sessions_spawn terminal success tracking", () => {

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -1290,6 +1290,22 @@ export async function handleToolExecutionEnd(
   // Track committed reminders only when cron.add completed successfully.
   if (!isToolError && toolName === "cron" && isCronAddAction(startData?.args)) {
     ctx.state.successfulCronAdds += 1;
+  } else if (!isToolError && isExecToolName(toolName)) {
+    // Also count successful `openclaw cron add` invocations via exec/bash tools.
+    // The native cron tool branch above handles structured cron calls; this branch
+    // handles the equivalent shell command. Anchored prefix rejects substrings like
+    // `echo "openclaw cron add ..."`. Receipt check avoids counting failed runs.
+    const command = typeof startArgs.command === "string" ? startArgs.command : "";
+    if (/^\s*openclaw\s+cron\s+add\b/i.test(command)) {
+      const execDetails = readExecToolDetails(sanitizedResult);
+      const output =
+        (execDetails && "aggregated" in execDetails
+          ? (execDetails.aggregated ?? "")
+          : extractToolResultText(sanitizedResult)) ?? "";
+      if (/\b(?:created|scheduled)\b/i.test(output)) {
+        ctx.state.successfulCronAdds += 1;
+      }
+    }
   }
   if (!isToolError && toolName === HEARTBEAT_RESPONSE_TOOL_NAME) {
     const details =


### PR DESCRIPTION
### What

This PR fixes an issue where the `successfulCronAdds` counter was not incremented when an agent ran `openclaw cron add` as a shell command via `exec` or `bash`.

### Why

The existing logic only checked for the structured `cron` tool. This caused the agent runner to misread the counter and incorrectly append "I did not schedule a reminder" to the transcript after a successful shell-based cron addition.

### How

An `else if` block is added to `pi-embedded-subscribe.handlers.tools.ts` to inspect `exec`/`bash` results. It uses an anchored regex (`/^\s*openclaw\s+cron\s+add\b/i`) to identify the command and requires a success receipt (`created|scheduled`) in the output before incrementing the counter.

This approach incorporates the hardened regex requested in the prior (self-closed) PR #53024. New regression tests are included to cover the fix and prevent bypasses.

Closes #52972

## Real behavior proof

**Behavior addressed:** Agent runner incorrectly appends "I did not schedule a reminder" after the agent runs `openclaw cron add` via exec/bash shell tool (structured `cron` tool path was unaffected).

**Real environment tested:** Local openclaw/openclaw checkout, Node 24, WSL2. Exec/bash tool path exercised via direct handler calls (not a live agent run).

**Exact steps or command run after fix:**
```
pnpm test src/agents/pi-embedded-subscribe.handlers.tools.test.ts --reporter=verbose
```

**Evidence (branch-local run):**
```
 ✓ |agents| src/agents/pi-embedded-subscribe.handlers.tools.test.ts > handleToolExecutionStart read path checks > does not warn when read tool uses file_path alias 6ms
 ✓ |agents| src/agents/pi-embedded-subscribe.handlers.tools.test.ts > handleToolExecutionStart read path checks > warns when read tool has neither path nor file_path 1ms
 ✓ |agents| src/agents/pi-embedded-subscribe.handlers.tools.test.ts > handleToolExecutionStart read path checks > awaits onBlockReplyFlush before continuing tool start processing 2ms
 ✓ |agents| src/agents/pi-embedded-subscribe.handlers.tools.test.ts > handleToolExecutionEnd cron.add commitment tracking > increments successfulCronAdds when cron add succeeds 2ms
 ✓ |agents| src/agents/pi-embedded-subscribe.handlers.tools.test.ts > handleToolExecutionEnd cron.add commitment tracking > does not increment successfulCronAdds when cron add fails 1ms
 ✓ |agents| src/agents/pi-embedded-subscribe.handlers.tools.test.ts > handleToolExecutionEnd cron.add commitment tracking > increments successfulCronAdds when exec runs openclaw cron add and output confirms creation 1ms
 ✓ |agents| src/agents/pi-embedded-subscribe.handlers.tools.test.ts > handleToolExecutionEnd cron.add commitment tracking > does not increment successfulCronAdds for a bypass attempt (substring match without anchor) 1ms
 ✓ |agents| src/agents/pi-embedded-subscribe.handlers.tools.test.ts > handleToolExecutionEnd cron.add commitment tracking > does not increment successfulCronAdds when openclaw cron add output lacks creation receipt 1ms
 ✓ |agents| src/agents/pi-embedded-subscribe.handlers.tools.test.ts > handleToolExecutionEnd cron.add commitment tracking > does not increment successfulCronAdds for a cron add command without the openclaw prefix 1ms
 ✓ |agents| src/agents/pi-embedded-subscribe.handlers.tools.test.ts > handleToolExecutionEnd mutating failure recovery > clears edit failure when the retry succeeds through common file path aliases 1ms
 ✓ |agents| src/agents/pi-embedded-subscribe.handlers.tools.test.ts > handleToolExecutionEnd timeout metadata > records timeout metadata for failed exec results 1ms
 ✓ |agents| src/agents/pi-embedded-subscribe.handlers.tools.test.ts > handleToolExecutionEnd exec approval prompts > emits a deterministic approval payload and marks assistant output suppressed 3ms
 ✓ |agents| src/agents/pi-embedded-subscribe.handlers.tools.test.ts > handleToolExecutionEnd exec approval prompts > preserves filtered approval decisions from tool details 1ms
 ✓ |agents| src/agents/pi-embedded-subscribe.handlers.tools.test.ts > handleToolExecutionEnd exec approval prompts > emits a deterministic unavailable payload when the initiating surface cannot approve 1ms
 ✓ |agents| src/agents/pi-embedded-subscribe.handlers.tools.test.ts > handleToolExecutionEnd exec approval prompts > emits the shared approver-DM notice when another approval client received the request 0ms
 ✓ |agents| src/agents/pi-embedded-subscribe.handlers.tools.test.ts > handleToolExecutionEnd exec approval prompts > does not suppress assistant output when deterministic prompt delivery rejects 1ms
 ✓ |agents| src/agents/pi-embedded-subscribe.handlers.tools.test.ts > handleToolExecutionEnd exec approval prompts > emits approval + blocked command item events when exec needs approval 1ms
 ✓ |agents| src/agents/pi-embedded-subscribe.handlers.tools.test.ts > handleToolExecutionEnd derived tool events > emits command output events for exec results 1ms
 ✓ |agents| src/agents/pi-embedded-subscribe.handlers.tools.test.ts > handleToolExecutionEnd derived tool events > emits patch summary events for apply_patch results 1ms
 ✓ |agents| src/agents/pi-embedded-subscribe.handlers.tools.test.ts > messaging tool media URL tracking > tracks media arg from messaging tool as pending 1ms
 ✓ |agents| src/agents/pi-embedded-subscribe.handlers.tools.test.ts > messaging tool media URL tracking > commits pending media URL on tool success 1ms
 ✓ |agents| src/agents/pi-embedded-subscribe.handlers.tools.test.ts > messaging tool media URL tracking > commits mediaUrls from tool result payload 1ms
 ✓ |agents| src/agents/pi-embedded-subscribe.handlers.tools.test.ts > messaging tool media URL tracking > trims messagingToolSentMediaUrls to 200 on commit (FIFO) 1ms
 ✓ |agents| src/agents/pi-embedded-subscribe.handlers.tools.test.ts > messaging tool media URL tracking > discards pending media URL on tool error 1ms

 Test Files  1 passed (1)
      Tests  24 passed (24)
   Start at  20:26:38
   Duration  4.54s (transform 2.94s, setup 199ms, import 4.09s, tests 33ms, environment 0ms)
```

**Observed result:** All 24 tests pass. The 4 new exec-path cron commitment tests passed: counter increments on a valid `openclaw cron add` with receipt, and does not increment for bypass attempts, missing creation receipts, or non-openclaw commands.

**What was not tested:** Live OpenClaw server with real cron backend and actual scheduled jobs; agents using non-standard shell wrappers around `openclaw cron add`; exec timeout paths.