### PR TITLE
fix(agents): file-scoped prompt-window guard for same-session embedded races

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
@@ -1431,4 +1431,45 @@ describe("embedded attempt session lock lifecycle", () => {
     await controllerB.releaseForPrompt();
     expect(controllerB.hasSessionTakeover()).toBe(false);
   });
+
+  it("dispose-after-releaseForPrompt vacates the prompt turn so the next same-file controller does not hang", async () => {
+    // Regression for the ClawSweeper P2 finding on #86067: after
+    // releaseForPrompt() opens the prompt window, heldLock is undefined but
+    // activePromptSessionTurn is still set until reacquireAfterPrompt clears
+    // it. If teardown runs in that window (mid-stream throw, etc.), dispose
+    // must release+clear the prompt turn or the file-scoped queue tail
+    // never resolves and the next same-file controller waits forever.
+    resetEmbeddedAttemptSessionFilePromptGuardsForTest();
+    const sessionFile = await createTempSessionFile();
+    const acquireSessionWriteLock = vi.fn(async () => ({
+      release: vi.fn(async () => {}),
+    }));
+    const controllerA = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controllerA.releaseForPrompt();
+    // Teardown without going through reacquireAfterPrompt — the case the
+    // outer-finally `releaseRetainedSessionLock?.()` covers when the prompt
+    // stream throws.
+    await controllerA.dispose();
+    // Idempotent: second dispose must be safe (the outer finally can run
+    // even after acquireForCleanup has handed off the lock).
+    await controllerA.dispose();
+
+    // A new controller on the same file must be able to open its own
+    // prompt window without hanging on A's vacated turn.
+    const controllerB = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    await expect(
+      Promise.race([
+        controllerB.releaseForPrompt().then(() => "released"),
+        new Promise<string>((resolve) => setTimeout(() => resolve("timeout"), 200)),
+      ]),
+    ).resolves.toBe("released");
+    expect(controllerB.hasSessionTakeover()).toBe(false);
+  });
 });

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
@@ -19,6 +19,7 @@ import {
   installPromptSubmissionLockRelease,
   installSessionEventWriteLock,
   installSessionExternalHookWriteLock,
+  resetEmbeddedAttemptSessionFilePromptGuardsForTest,
 } from "./attempt.session-lock.js";
 
 const lockOptions = {
@@ -32,6 +33,7 @@ const tempDirs: string[] = [];
 
 afterEach(async () => {
   resetSessionWriteLockStateForTest();
+  resetEmbeddedAttemptSessionFilePromptGuardsForTest();
   for (const dir of tempDirs.splice(0)) {
     await fs.rm(dir, { recursive: true, force: true });
   }
@@ -531,6 +533,7 @@ describe("embedded attempt session lock lifecycle", () => {
           },
         ),
     );
+    resetEmbeddedAttemptSessionFilePromptGuardsForTest();
     await secondController.releaseForPrompt();
 
     await expect(
@@ -564,6 +567,7 @@ describe("embedded attempt session lock lifecycle", () => {
       acquireSessionWriteLock,
       lockOptions: { ...lockOptions, sessionFile },
     });
+    resetEmbeddedAttemptSessionFilePromptGuardsForTest();
     await secondController.releaseForPrompt();
     const cleanupLock = await secondController.acquireForCleanup();
 
@@ -629,6 +633,7 @@ describe("embedded attempt session lock lifecycle", () => {
           },
         ),
     );
+    resetEmbeddedAttemptSessionFilePromptGuardsForTest();
     await secondController.releaseForPrompt();
 
     await expect(
@@ -665,6 +670,7 @@ describe("embedded attempt session lock lifecycle", () => {
       await fs.appendFile(sessionFile, '{"type":"message","id":"same-process"}\n', "utf8");
       await fs.appendFile(sessionFile, '{"type":"message","id":"external-interleaved"}\n', "utf8");
     });
+    resetEmbeddedAttemptSessionFilePromptGuardsForTest();
     await secondController.releaseForPrompt();
 
     await expect(
@@ -698,6 +704,7 @@ describe("embedded attempt session lock lifecycle", () => {
       acquireSessionWriteLock,
       lockOptions: { ...lockOptions, sessionFile },
     });
+    resetEmbeddedAttemptSessionFilePromptGuardsForTest();
     await secondController.releaseForPrompt();
 
     await expect(
@@ -734,6 +741,7 @@ describe("embedded attempt session lock lifecycle", () => {
     await secondController.withSessionWriteLock(async () => {
       await fs.appendFile(sessionFile, '{"type":"message","id":"same-process"}\n', "utf8");
     });
+    resetEmbeddedAttemptSessionFilePromptGuardsForTest();
     await secondController.releaseForPrompt();
 
     await expect(
@@ -1204,5 +1212,223 @@ describe("embedded attempt session lock lifecycle", () => {
     await hookPromise;
 
     expect(events).toEqual(["queue-drained", "lock", "hook-start", "hook-end"]);
+  });
+
+  it("serialises prompt windows on the same session file across two controllers", async () => {
+    const sessionFile = await createTempSessionFile();
+    const events: string[] = [];
+    let acquireCount = 0;
+    const acquireSessionWriteLock = vi.fn(async () => {
+      acquireCount += 1;
+      const id = acquireCount;
+      events.push(`acquire-${id}`);
+      return {
+        release: vi.fn(async () => {
+          events.push(`release-${id}`);
+        }),
+      };
+    });
+
+    const firstController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    const secondController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await firstController.releaseForPrompt();
+
+    let secondCompletedRelease = false;
+    const secondReleasePromise = secondController.releaseForPrompt().then(() => {
+      secondCompletedRelease = true;
+    });
+    // Yield several microtasks; the second release must still be blocked
+    // because the first controller has not yet reacquired its prompt turn.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(secondCompletedRelease).toBe(false);
+
+    await firstController.reacquireAfterPrompt();
+    await secondReleasePromise;
+
+    expect(secondCompletedRelease).toBe(true);
+    expect(firstController.hasSessionTakeover()).toBe(false);
+    expect(secondController.hasSessionTakeover()).toBe(false);
+  });
+
+  it("vacates the prompt turn so later waiters proceed when reacquireAfterPrompt throws", async () => {
+    // Regression for the file-scoped guard's cleanup-on-failure path. If
+    // reacquireAfterPrompt's error branch did not release the turn, the
+    // next same-file waiter would block forever — i.e. one failed prompt
+    // window would wedge the session file for the rest of the process.
+    const sessionFile = await createTempSessionFile();
+    const events: string[] = [];
+
+    const firstInitialRelease = vi.fn(async () => {
+      events.push("first-initial-release");
+    });
+    const secondInitialRelease = vi.fn(async () => {
+      events.push("second-initial-release");
+    });
+    const secondReacquireRelease = vi.fn(async () => {
+      events.push("second-reacquire-release");
+    });
+
+    const acquireSessionWriteLock = vi.fn();
+    acquireSessionWriteLock
+      .mockResolvedValueOnce({ release: firstInitialRelease })
+      .mockResolvedValueOnce({ release: secondInitialRelease })
+      // First controller's reacquireAfterPrompt rejects with a real
+      // lock-timeout error (the same shape the production code would see if
+      // another process or lane held the lock past timeoutMs).
+      .mockRejectedValueOnce(
+        new SessionWriteLockTimeoutError({
+          timeoutMs: lockOptions.timeoutMs,
+          owner: "pid=external",
+          lockPath: `${sessionFile}.lock`,
+        }),
+      )
+      .mockResolvedValueOnce({ release: secondReacquireRelease });
+
+    const firstController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    const secondController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await firstController.releaseForPrompt();
+
+    let secondCompletedRelease = false;
+    const secondReleasePromise = secondController.releaseForPrompt().then(() => {
+      secondCompletedRelease = true;
+    });
+    await Promise.resolve();
+    expect(secondCompletedRelease).toBe(false);
+
+    await expect(firstController.reacquireAfterPrompt()).rejects.toBeInstanceOf(
+      SessionWriteLockTimeoutError,
+    );
+
+    // The first turn must have been released by reacquireAfterPrompt's
+    // finally block, even though the body threw. The second waiter is now
+    // free to proceed through its own release-for-prompt.
+    await secondReleasePromise;
+    expect(secondCompletedRelease).toBe(true);
+
+    // The second controller observes a clean prompt window; the file-scoped
+    // queue did not get wedged by the first lane's failed reacquire.
+    expect(secondController.hasSessionTakeover()).toBe(false);
+  });
+
+  it("vacates the prompt turn when releaseForPrompt itself fails mid-flight", async () => {
+    // Regression for the same cleanup-on-failure path on the other side of
+    // the prompt window. If releaseForPrompt throws partway — for example
+    // the held lock's release rejects — the turn slot must still be
+    // vacated. Otherwise the next same-file waiter blocks forever even
+    // though no prompt is actually in flight.
+    const sessionFile = await createTempSessionFile();
+
+    const firstInitialRelease = vi.fn(async () => {
+      throw new Error("simulated lock-release failure");
+    });
+    const secondInitialRelease = vi.fn(async () => {});
+    const secondReacquireRelease = vi.fn(async () => {});
+    const thirdInitialRelease = vi.fn(async () => {});
+
+    const acquireSessionWriteLock = vi.fn();
+    acquireSessionWriteLock
+      // First and second start with their own locks; the second is
+      // blocked waiting on the first's turn at the point first throws.
+      .mockResolvedValueOnce({ release: firstInitialRelease })
+      .mockResolvedValueOnce({ release: secondInitialRelease })
+      // The second controller's prior-wait dance reacquires here after
+      // the first turn vacates on its release failure.
+      .mockResolvedValueOnce({ release: secondReacquireRelease })
+      .mockResolvedValueOnce({ release: thirdInitialRelease });
+
+    const firstController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    const secondController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    // First controller's releaseForPrompt now reaches lock.release() which
+    // rejects. The turn must be vacated by the catch block.
+    await expect(firstController.releaseForPrompt()).rejects.toThrow(
+      "simulated lock-release failure",
+    );
+
+    // Second controller's releaseForPrompt must complete without blocking
+    // on a dangling turn from the failed first release.
+    await secondController.releaseForPrompt();
+    expect(secondController.hasSessionTakeover()).toBe(false);
+  });
+
+  it("does not block prompt-window waiters behind a compaction-wait release on the same file", async () => {
+    // releaseForSessionIdleWait is for the post-prompt compaction window;
+    // it must not register a prompt-turn or other lanes will wait on it
+    // unnecessarily.
+    const sessionFile = await createTempSessionFile();
+    const events: string[] = [];
+    let acquireCount = 0;
+    const acquireSessionWriteLock = vi.fn(async () => {
+      acquireCount += 1;
+      const id = acquireCount;
+      events.push(`acquire-${id}`);
+      return {
+        release: vi.fn(async () => {
+          events.push(`release-${id}`);
+        }),
+      };
+    });
+
+    const firstController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    const secondController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await firstController.releaseForSessionIdleWait();
+
+    // Second controller's prompt window should run without waiting on
+    // anything from the idle-wait release.
+    await secondController.releaseForPrompt();
+
+    expect(firstController.hasSessionTakeover()).toBe(false);
+    expect(secondController.hasSessionTakeover()).toBe(false);
+  });
+
+  it("does not serialise prompt windows across different session files", async () => {
+    const sessionFileA = await createTempSessionFile();
+    const sessionFileB = await createTempSessionFile();
+    const acquireSessionWriteLock = vi.fn(async () => ({
+      release: vi.fn(async () => {}),
+    }));
+
+    const controllerA = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile: sessionFileA },
+    });
+    const controllerB = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile: sessionFileB },
+    });
+
+    await controllerA.releaseForPrompt();
+    // B's prompt window targets a different session file — it must not
+    // block on A's outstanding turn.
+    await controllerB.releaseForPrompt();
+    expect(controllerB.hasSessionTakeover()).toBe(false);
   });
 });

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
@@ -981,6 +981,18 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       return takeoverDetected;
     },
     async dispose(): Promise<void> {
+      // Vacate the prompt turn first, regardless of whether heldLock is set.
+      // After `releaseForPrompt`, heldLock is undefined but
+      // activePromptSessionTurn is still set until `reacquireAfterPrompt`
+      // clears it. If teardown runs in that window without going through
+      // reacquireAfterPrompt (e.g. mid-stream throw before the outer
+      // finally hits acquireForCleanup), the file-scoped queue tail never
+      // resolves and later same-file controllers block on it forever.
+      // Release the turn here so dispose-after-releaseForPrompt is safe.
+      if (activePromptSessionTurn) {
+        activePromptSessionTurn.release();
+        activePromptSessionTurn = undefined;
+      }
       if (!heldLock) {
         return;
       }

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
@@ -402,6 +402,50 @@ const ownedSessionFileWrites = new Map<string, OwnedSessionFileWrite>();
 const trustedSessionFileStates = new Map<string, TrustedSessionFileState>();
 let ownedSessionFileWriteGeneration = 0;
 
+// File-scoped prompt-window queue. Two lanes (e.g. a heartbeat and a channel
+// reply) can end up on the same resolved session JSONL through aliased session
+// UUIDs or stuck-session recovery. The takeover fence catches the symptom
+// after one lane is mid-stream, but by then the losing lane's reply has
+// already been dropped. The queue below serialises prompt windows on the same
+// file so the second entrant waits for the first to finish reacquiring rather
+// than racing it into the provider stream.
+type SessionFilePromptTurn = {
+  // Defined only when another controller already held a prompt turn on this
+  // file at acquisition time. Awaiting it serialises the new entrant behind
+  // the existing holder's reacquire (or its cleanup-on-failure).
+  awaitPrior: Promise<void> | undefined;
+  // Resolves the chain so the next waiter can proceed. Must be called on
+  // every exit path: success, takeover, reacquire failure, abort. Failing to
+  // call it leaves later same-file waiters blocked indefinitely.
+  release: () => void;
+};
+
+const promptSessionFileTurnTails = new Map<string, Promise<void>>();
+
+function acquirePromptSessionFileTurn(sessionFileKey: string): SessionFilePromptTurn {
+  const previous = promptSessionFileTurnTails.get(sessionFileKey);
+  let releaseFn!: () => void;
+  let alreadyReleased = false;
+  const released = new Promise<void>((resolve) => {
+    releaseFn = resolve;
+  });
+  const tail = previous ? previous.then(() => released) : released;
+  promptSessionFileTurnTails.set(sessionFileKey, tail);
+  return {
+    awaitPrior: previous,
+    release: () => {
+      if (alreadyReleased) {
+        return;
+      }
+      alreadyReleased = true;
+      releaseFn();
+      if (promptSessionFileTurnTails.get(sessionFileKey) === tail) {
+        promptSessionFileTurnTails.delete(sessionFileKey);
+      }
+    },
+  };
+}
+
 function resolveSessionFileFenceKey(sessionFile: string): string {
   return path.resolve(sessionFile);
 }
@@ -616,6 +660,7 @@ export function installSessionExternalHookWriteLock(params: {
 
 export type EmbeddedAttemptSessionLockController = {
   releaseForPrompt(): Promise<void>;
+  releaseForSessionIdleWait(): Promise<void>;
   refreshAfterOwnedSessionWrite(): void;
   reacquireAfterPrompt(): Promise<void>;
   waitForSessionEvents(session: unknown): Promise<void>;
@@ -648,6 +693,12 @@ export async function createEmbeddedAttemptSessionLockController(params: {
   let fenceActive = false;
   let takeoverDetected = false;
   const sessionFileFenceKey = resolveSessionFileFenceKey(params.lockOptions.sessionFile);
+  // Tracks the prompt-window turn this controller has registered in the
+  // file-scoped queue. Set when releaseForPrompt() promotes the controller to
+  // turn-owner; cleared when reacquireAfterPrompt() returns or throws.
+  // releaseForSessionIdleWait() never sets this — compaction-wait release is
+  // not a provider-prompt window and must not block other lanes.
+  let activePromptSessionTurn: SessionFilePromptTurn | undefined;
 
   async function acquireWriteLock(): Promise<{ lock: SessionLock; owned: boolean }> {
     if (heldLock) {
@@ -748,12 +799,36 @@ export async function createEmbeddedAttemptSessionLockController(params: {
 
   const noopLock: SessionLock = { release: async () => {} };
 
-  return {
-    async releaseForPrompt(): Promise<void> {
-      if (!heldLock) {
+  async function performHeldLockReleaseForWindow(registerPromptHolder: boolean): Promise<void> {
+    if (!heldLock) {
+      return;
+    }
+
+    const promptTurn = registerPromptHolder
+      ? acquirePromptSessionFileTurn(sessionFileFenceKey)
+      : undefined;
+
+    try {
+      // If another lane on this file is still in its prompt window, give up
+      // our write lock so they can reacquire after their provider call, wait
+      // for them to finish, then take the lock back fresh. This serialises
+      // entrants on the same file rather than letting both stride into the
+      // provider stream and force the takeover fence to pick a survivor.
+      // No contention (no prior tail) means we fall through to the normal
+      // single-release path below, without an extra acquire/release cycle.
+      if (promptTurn?.awaitPrior !== undefined) {
+        const yieldedLock = heldLock;
+        heldLock = undefined;
+        await yieldedLock.release();
+        await promptTurn.awaitPrior;
+        const reacquired = await acquireLock();
+        heldLock = reacquired;
+      }
+
+      const lock = heldLock;
+      if (!lock) {
         return;
       }
-      const lock = heldLock;
       heldLock = undefined;
       const fingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);
       const ownedWrite = ownedSessionFileWrites.get(sessionFileFenceKey);
@@ -765,7 +840,31 @@ export async function createEmbeddedAttemptSessionLockController(params: {
           ? ownedWrite.generation
           : (trustedGeneration ?? fenceGeneration);
       fenceActive = true;
+      // Promote the turn to controller ownership only after every step that
+      // can throw is past. reacquireAfterPrompt() will clear it.
+      activePromptSessionTurn = promptTurn;
       await lock.release();
+    } catch (err) {
+      // Any exception between acquiring the turn and the controller taking
+      // ownership leaves the turn dangling — and a dangling turn in the
+      // file-scoped queue blocks every later same-file waiter forever. Vacate
+      // the slot before rethrowing so other lanes can make progress.
+      if (promptTurn) {
+        promptTurn.release();
+        if (activePromptSessionTurn === promptTurn) {
+          activePromptSessionTurn = undefined;
+        }
+      }
+      throw err;
+    }
+  }
+
+  return {
+    async releaseForPrompt(): Promise<void> {
+      await performHeldLockReleaseForWindow(true);
+    },
+    async releaseForSessionIdleWait(): Promise<void> {
+      await performHeldLockReleaseForWindow(false);
     },
     refreshAfterOwnedSessionWrite(): void {
       if (fenceActive && !takeoverDetected) {
@@ -775,16 +874,29 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     },
     async reacquireAfterPrompt(): Promise<void> {
       if (takeoverDetected || heldLock) {
+        // No-op exits must still vacate the turn so the next same-file
+        // waiter does not block on a holder that never ran a real prompt.
+        activePromptSessionTurn?.release();
+        activePromptSessionTurn = undefined;
         return;
       }
-      const lock = await acquireLock();
+      let lock: SessionLock | undefined;
       try {
+        lock = await acquireLock();
         heldLock = lock;
         await assertSessionFileFence();
       } catch (err) {
         heldLock = undefined;
-        await lock.release();
+        if (lock) {
+          await lock.release();
+        }
         throw err;
+      } finally {
+        // finally, not catch — the turn must release on the success path too,
+        // and the takeover/lock-timeout paths above set takeoverDetected
+        // before throwing so this branch covers both.
+        activePromptSessionTurn?.release();
+        activePromptSessionTurn = undefined;
       }
     },
     waitForSessionEvents: waitForSessionEventQueue,
@@ -877,6 +989,10 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       await lock.release();
     },
   };
+}
+
+export function resetEmbeddedAttemptSessionFilePromptGuardsForTest(): void {
+  promptSessionFileTurnTails.clear();
 }
 
 export function installPromptSubmissionLockRelease(params: {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -4329,7 +4329,7 @@ export async function runEmbeddedAttempt(
         }
 
         await sessionLockController.waitForSessionEvents(activeSession);
-        await sessionLockController.releaseForPrompt();
+        await sessionLockController.releaseForSessionIdleWait();
 
         // Capture snapshot before compaction wait so we have complete messages if timeout occurs
         // Check compaction state before and after to avoid race condition where compaction starts during capture


### PR DESCRIPTION
> **Update 2026-05-25**: An earlier revision of this PR also included a `waitForSessionEvents` drain in `installPromptSubmissionLockRelease`'s finally block (reported by @kesslerio against AlphaClaw). That commit has been moved to its own focused PR with honest framing — see the followup discussion on #85913. This PR is scoped strictly to the file-scoped prompt-window guard. The vanilla-openclaw same-lane race (a separate failure mode from the cross-lane race this PR addresses) is being fixed in #86584.

## Summary

- Adds a file-scoped prompt-window guard that serialises embedded-runner prompt windows on the same resolved session JSONL across concurrent lanes.
- Introduces `releaseForSessionIdleWait()` for the post-prompt compaction window so it does not block other lanes' real prompt windows.
- Routes every exit path through a turn-release `try/catch` and `try/finally` so the file-scoped queue is vacated on success, takeover, lock-timeout, fence-mismatch, and mid-flight release errors. A wedge in one lane never leaves later same-file waiters blocked.

Fixes #85913.

## Background

`createEmbeddedAttemptSessionLockController` releases the OS-level session write lock during provider streaming so long model calls don't hold the lock for minutes at a time. After streaming, `reacquireAfterPrompt()` reacquires the lock and `assertSessionFileFence()` checks an inode/size/mtime fingerprint to detect external mutation. If the file changed in an unowned way, the controller throws `EmbeddedAttemptSessionTakeoverError`.

The fence is a symptom-catcher, not a race preventer. The live-repro evidence on the issue shows the underlying race: two lanes on the same OpenClaw process can both resolve to the same JSONL (stuck-session recovery firing a fresh embedded run on a session UUID whose file resolution aliases to an already-active file). Both lanes release for prompt simultaneously, both stride into provider streams, the slower one's reacquire trips the fence after the provider call has already produced output, and the chain falls all the way to `Embedded agent failed before reply: All models failed`. The user sees a dropped reply.

`RuntimeEnv` is module-scoped at `ownedSessionFileWrites` / `trustedSessionFileStates` — both keyed by `path.resolve(sessionFile)`. The fix extends that pattern with a third process-global map: a per-file queue of prompt turns.

## What changed

`src/agents/pi-embedded-runner/run/attempt.session-lock.ts`

- New module-level `promptSessionFileTurnTails: Map<string, Promise<void>>` keyed by the same `resolveSessionFileFenceKey` the fence already uses.
- `acquirePromptSessionFileTurn(sessionFileKey)` returns `{ awaitPrior, release }`. The first entrant on a file gets `awaitPrior: undefined` and falls through with no extra acquire/release. The second entrant gets the first's tail and waits on it before its own prompt window opens.
- `performHeldLockReleaseForWindow(registerPromptHolder)` consolidates the held-lock release path. When `registerPromptHolder` is true and a prior turn exists, the entrant yields its OS lock, awaits the prior turn, reacquires fresh, and then continues with the existing fingerprint/snapshot/release sequence. Wrapped in `try/catch` so any exception between acquiring the turn and the controller taking ownership releases the turn slot before rethrowing.
- `releaseForPrompt()` becomes a one-liner over `performHeldLockReleaseForWindow(true)`.
- `releaseForSessionIdleWait()` (new public method) becomes a one-liner over `performHeldLockReleaseForWindow(false)`. Used for the post-prompt compaction window, which is not a provider-prompt window and must not serialise other lanes' prompts.
- `reacquireAfterPrompt()` releases the turn in a `finally` block — the success path and every error branch (lock-timeout, takeover fence, any other exception) all vacate the slot. The no-op-early-return branch (`takeoverDetected || heldLock`) also releases the turn so a no-op entrant cannot strand the queue.
- `resetEmbeddedAttemptSessionFilePromptGuardsForTest()` (new test helper) clears the module-level map so tests start from a clean slate.
- Exported `releaseForSessionIdleWait` on the `EmbeddedAttemptSessionLockController` type.

`src/agents/pi-embedded-runner/run/attempt.ts`

- Line 4277: the post-prompt compaction wait uses `releaseForSessionIdleWait()` instead of `releaseForPrompt()`. This path was already a non-prompt release — the rename makes it not contend with real prompt windows on the same file. The matching post-compaction `withSessionWriteLock` reacquires the OS lock internally; no other behavior changes.

`src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts`

- `afterEach` clears the new queue alongside the existing `resetSessionWriteLockStateForTest()` cleanup.
- Six existing multi-controller test bodies call `resetEmbeddedAttemptSessionFilePromptGuardsForTest()` between the first controller's `releaseForPrompt()` and the second controller's `releaseForPrompt()`. These tests were written before the file-scoped guard existed and use `releaseForPrompt()` as a "drop the OS lock" call without a paired `reacquireAfterPrompt()`. The reset preserves their existing assertions without forcing them to invent reacquire calls they don't need.
- Five new test cases under the same `describe` block:
  - Serialisation happy path — second same-file controller's `releaseForPrompt()` blocks until the first calls `reacquireAfterPrompt()`.
  - **Cleanup-on-reacquire-failure** — first controller's `reacquireAfterPrompt()` rejects with a `SessionWriteLockTimeoutError`; the second controller's `releaseForPrompt()` still completes (the turn was released in the `finally`).
  - **Cleanup-on-release-failure** — first controller's held-lock release rejects partway through `releaseForPrompt()`; the second controller's `releaseForPrompt()` still completes (the turn was released in the `catch` before re-throwing).
  - Compaction-wait isolation — `releaseForSessionIdleWait()` does not block another lane's `releaseForPrompt()` on the same file.
  - Cross-file isolation — controllers on different `sessionFile`s do not serialise.

## Verification

```sh
# All acceptance-criteria tests from the issue's bot review:
node scripts/run-vitest.mjs \
  src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts \
  src/logging/diagnostic-stuck-session-recovery.runtime.test.ts \
  src/infra/heartbeat-runner.skips-busy-session-lane.test.ts \
  src/agents/model-fallback.test.ts \
  src/agents/failover-error.test.ts

# Test Files  7 passed (7)
#      Tests  306 passed (306)
```

`pnpm check:changed` exit 0 (typecheck, lint, runtime import cycles, repo guards).

## Real behavior proof

- **Behavior or issue addressed:** Two concurrent embedded attempts on the same resolved session JSONL no longer race during the provider-streaming window. The losing lane's reply was being dropped because the takeover fence fired mid-stream after the provider had already started producing output. With the file-scoped turn queue, the second entrant waits for the first to reacquire (or fail cleanly) before its own prompt window opens. Failure-path cleanup ensures one wedged prompt cannot block later prompts on the same file.

- **Real environment tested:** Local OpenClaw source checkout (macOS 15.5, Node 22.19+) at the patched branch HEAD `65705d8c39`. The patched `createEmbeddedAttemptSessionLockController` runs in two real concurrent controllers against a shared session JSONL with the production `acquireSessionWriteLock` contract; per-microsecond timestamps and the lock-acquire/release event ledger are captured below. The acceptance-criteria test sweep from the issue's bot review runs against the same patched source.

- **Exact steps or command run after this patch:**

  ```sh
  pnpm install
  pnpm build
  node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts

  # Acceptance-criteria sweep from the issue's bot review:
  node scripts/run-vitest.mjs \
    src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts \
    src/logging/diagnostic-stuck-session-recovery.runtime.test.ts \
    src/infra/heartbeat-runner.skips-busy-session-lane.test.ts \
    src/agents/model-fallback.test.ts \
    src/agents/failover-error.test.ts

  # Drive the patched controller end-to-end against a shared session JSONL:
  npx tsx /abs/path/to/pr-proof/run-session-takeover-guard-proof.mjs /abs/path/to/openclaw
  ```

- **Evidence after fix:**

  **Before/after reproduction** — same scenario run against pre-patch (`5be62e779b`, the commit one before this fix) and post-patch (`65705d8c39`) source via the same `run-same-file-race-repro.mjs` script. Two real `EmbeddedAttemptSessionLockController` instances on a shared temp session JSONL; production `acquireSessionWriteLock` (no test mocks); external mutation injected mid-prompt to simulate the aliased-UUID concurrent lane from the live-repro evidence in #85913:

  ```
  PRE-PATCH (5be62e779b):
    [   2.60ms] ctrl-A   prompt in flight (200ms hold)
    [   9.47ms] ctrl-B   prompt in flight (200ms hold)
    [ 111.70ms] external appending bytes outside the ownership chain
    [ 209.67ms] ctrl-A   THREW on reacquire: TAKEOVER (EmbeddedAttemptSessionTakeoverError)
    [ 210.98ms] ctrl-B   THREW on reacquire: TAKEOVER (EmbeddedAttemptSessionTakeoverError)
    Result:  replies delivered 0 of 2  ·  takeover errors 2

  POST-PATCH (65705d8c39):
    [   2.64ms] ctrl-A   prompt in flight (200ms hold)
    [ 111.53ms] external appending bytes outside the ownership chain
    [ 209.33ms] ctrl-A   THREW on reacquire: TAKEOVER (EmbeddedAttemptSessionTakeoverError)
    [ 210.89ms] ctrl-B   prompt in flight (200ms hold)
    [ 415.45ms] ctrl-B   DELIVERED (reacquire succeeded)
    Result:  replies delivered 1 of 2  ·  takeover errors 1
  ```

  Read the timestamps: on pre-patch, both controllers enter their mid-prompt sleep at ms 2 and 9 simultaneously (both have active fences capturing the same stale fingerprint), so when the external write hits at ms 111, both lanes observe the mutation when they reacquire at ms ~210. On post-patch, lane B's `prompt in flight` log line does not appear until ms 210 — which is the same moment lane A's reacquire throws. The file-scoped queue held lane B's `releaseForPrompt` until lane A's turn vacated; by then the file was stable, so lane B's release captured a fresh fingerprint and its reacquire succeeded at ms 415.

  Lane A's takeover is the unavoidable case (a true external mutation during its prompt window — no coordination primitive can save it; the fence correctly fires as the safety net). Lane B is the cascade casualty the patch saves.

  **Internal controller proof** — earlier in the proof pipeline, two real controllers driven through same-file contention with timestamped event ledger. Verbatim stdout from the run on this branch (`65705d8c39`):

  ```
  ============================================================
  PR #86067 — file-scoped prompt-window guard proof
  ============================================================

  openclaw checkout: /Users/.../openclaw
  source under test:  src/agents/pi-embedded-runner/run/attempt.session-lock.ts

  ============================================================
  Scenario A — same-file prompt windows serialise
  ============================================================

    [  509.55ms] setup                  two controllers on /tmp/proof-session.jsonl
    [  509.59ms] first                  releaseForPrompt() — register turn-1
    [  514.63ms] second                 releaseForPrompt() — should block on turn-1
    [  514.69ms] observe                t+0.06ms: secondCompleted=false (expected: false)
    [  514.70ms] first                  reacquireAfterPrompt() — release turn-1, second waiter unblocks
    [  515.86ms] observe                t+1.23ms: secondCompleted=true (expected: true)

    event ledger:
      acquire(A-1)
      acquire(A-2)
      release(A-1)
      release(A-2)
      acquire(A-3)
      acquire(A-4)
      release(A-4)

    Scenario A: PASS — second controller waited for first's reacquire

  ============================================================
  Scenario B — cleanup-on-failure: first's reacquire throws
  ============================================================

    [  516.19ms] setup                  two controllers; first's reacquire mocked to throw SessionWriteLockTimeoutError
    [  516.21ms] first                  releaseForPrompt() — register turn-1
    [  516.31ms] second                 releaseForPrompt() — should block on turn-1
    [  516.37ms] observe                t+0.05ms: secondCompleted=false (expected: false)
    [  516.38ms] first                  reacquireAfterPrompt() — throws SessionWriteLockTimeoutError
    [  516.41ms] first                  threw: SessionWriteLockTimeoutError (OPENCLAW_SESSION_WRITE_LOCK_TIMEOUT)
    [  516.42ms] observe                turn-1 must have been vacated in reacquire's finally
    [  516.50ms] observe                t+0.18ms: secondCompleted=true (expected: true)

    Scenario B: PASS — second waiter completed despite first's reacquire failure
  ```

  Scenario A's event ledger is the key observable: lock A-1 is the first controller's initial acquire, A-2 the second's initial acquire, A-3 is the first controller's reacquire-after-prompt (which fires the turn release on the queue), and A-4 is the second controller's reacquire-fresh after its prior-wait dance. Without the file-scoped guard, both A-1 and A-2 would release simultaneously and both controllers would stride into provider streams.

  Scenario B's timestamps prove the cleanup-on-failure path is wired correctly: `secondCompleted` flips from `false` → `true` within 80 µs of the first controller's reacquire throwing. If `reacquireAfterPrompt`'s finally block weren't releasing the turn on the error path, this assertion would have timed out instead.

  Targeted session-lock suite (74 tests including the 5 new file-scoped guard regressions):

  ```
  RUN  v4.1.7 /Users/.../openclaw
   Test Files  2 passed (2)
        Tests  74 passed (74)
     Duration  919ms
  ```

  Full acceptance-criteria sweep (the five files the issue's bot review named):

  ```
  RUN  v4.1.7 /Users/.../openclaw
   Test Files  7 passed (7)
        Tests  306 passed (306)
     Duration  46.34s
  ```

  The two regression tests that distinguish a correct fix from a half-fix are:

  - `vacates the prompt turn so later waiters proceed when reacquireAfterPrompt throws` — drives the first controller's reacquire mock to reject with `SessionWriteLockTimeoutError`. Asserts that a second waiter blocked on the first's turn completes its `releaseForPrompt()` after the throw. If the cleanup is wired only on the success path, this test times out (the second waiter blocks forever on a turn promise that never resolves).
  - `vacates the prompt turn when releaseForPrompt itself fails mid-flight` — drives the first controller's held-lock release to reject. The first `releaseForPrompt()` throws partway, but the `catch` in `performHeldLockReleaseForWindow` releases the turn before rethrowing. A second `releaseForPrompt()` then completes cleanly. If the cleanup is only in `reacquireAfterPrompt`, this test also times out.

  Both of these are deterministic — they trigger the failure path via `vi.fn().mockRejectedValueOnce(...)`, not via timing.

- **Observed result after fix:** Concurrent same-file prompt windows serialise instead of racing. Failed prompt windows (lock-timeout, takeover, release error) vacate the file-scoped queue so subsequent prompts on the same file proceed. The takeover fence remains in place as a defense-in-depth check against external mutation.

- **What was not tested:** A live multi-agent gateway run that fires stuck-session recovery on an aliased session UUID. The unit tests cover the locking primitive directly through its public contract; the existing `heartbeat-runner.skips-busy-session-lane.test.ts` and `diagnostic-stuck-session-recovery.runtime.test.ts` continue to pass and exercise the surrounding flows. Verifying the end-to-end fix against the real 122-event/3-day takeover pattern from the issue would require running a patched gateway under that workload for the same window.

- **Before evidence:** Without the file-scoped guard, two same-file controllers both call `releaseForPrompt()`, both stride into provider streams, and whichever reacquires second observes the other's writes and throws `EmbeddedAttemptSessionTakeoverError`. The chain falls through `model-fallback` → `failover-error` → `Embedded agent failed before reply: All models failed`. The live log slices in #85913 show 122 such events across 3 days on one local gateway, including the user-visible drop trace at `9dada894-1cb4-4610-a135-68d5ece67e51` on 2026-05-19 02:42:34.

### Refreshed proof for current HEAD `2606e52d74` (post-rebase + dispose cleanup)

The PR was rebased onto current `upstream/main` (which includes #86427's retained-lock `dispose()` from `32ddfc22f5`). The merge conflict in `attempt.session-lock.ts` was resolved by keeping the new `activePromptSessionTurn.release()` block at the top of `dispose()` and preserving the existing `heldLock` release that landed in main. Run against the rebased HEAD `2606e52d74`:

**Test suite** — 80 cases across 2 files green:

```
 Test Files  2 passed (2)
      Tests  80 passed (80)
```

The two existing dispose tests from #86014 ("releases the eagerly-held attempt lock on dispose when cleanup is skipped" and "dispose does not double-release a lock already handed to cleanup") still pass after the rebase — the dispose extension is backward-compatible.

**Dispose-after-releaseForPrompt proof harness** — three scenarios driven against real `EmbeddedAttemptSessionLockController` instances on a shared temp session JSONL with production `acquireSessionWriteLock`. Verbatim stdout:

```
============================================================
PR #86067 — dispose-after-releaseForPrompt proof
============================================================

-------- Scenario A — happy path: releaseForPrompt -> reacquireAfterPrompt --------
  [   1.46ms] ctrlA       constructed, eager lock held
  [   2.38ms] ctrlA       releaseForPrompt — activePromptSessionTurn set
  [   2.71ms] ctrlA       reacquireAfterPrompt — turn cleared via finally
  [   2.95ms] ctrlA       acquireForCleanup -> release — OS lock fully released
  [   3.21ms] ctrlB       constructed on same session file
  [   3.55ms] ctrlB       releaseForPrompt: completed

-------- Scenario B — pre-fix bug shape: skip reacquire AND skip dispose --------
  [   0.27ms] ctrlA       constructed, eager lock held
  [   0.54ms] ctrlA       releaseForPrompt — activePromptSessionTurn set
  [   0.55ms] ctrlA       SKIP reacquireAfterPrompt AND SKIP dispose (pre-fix bug shape)
  [   0.77ms] ctrlB       constructed on same session file
  [ 202.09ms] ctrlB       releaseForPrompt: timeout

-------- Scenario C — post-fix: dispose() vacates the prompt turn --------
  [   0.98ms] ctrlA       constructed, eager lock held
  [   1.85ms] ctrlA       releaseForPrompt — activePromptSessionTurn set
  [   1.89ms] ctrlA       dispose() — prompt turn released, heldLock already absent
  [   1.90ms] ctrlA       dispose() again — idempotent, no-op
  [   2.56ms] ctrlB       constructed on same session file
  [   3.52ms] ctrlB       releaseForPrompt: completed

============================================================
  Scenario A (happy):              ctrlB releaseForPrompt = completed
  Scenario B (pre-fix leak shape): ctrlB releaseForPrompt = timeout
  Scenario C (post-fix dispose):   ctrlB releaseForPrompt = completed

  RESULT: PASS
============================================================
```

Scenario B is the bug-shape proof: `ctrlA.releaseForPrompt()` sets `activePromptSessionTurn` without subsequently releasing it via either `reacquireAfterPrompt` or `dispose`. `ctrlB.releaseForPrompt()` then blocks on the prior turn's tail, the 200ms test timeout fires, and the harness records `timeout`. Scenario C confirms that `dispose()`'s new `activePromptSessionTurn.release()` call at the top of the body fixes this — `ctrlB`'s release completes in 3.52ms.

Harness: `/Users/umank/code/openclaw-tickets/proof/run-dispose-after-release-proof.mjs`.

## Risk / compatibility

- Public Plugin SDK surface: unchanged. `EmbeddedAttemptSessionLockController` is internal to `src/agents/pi-embedded-runner/run/` and not exposed through `openclaw/plugin-sdk/*`.
- Backward compatibility: `releaseForPrompt()` keeps its prior signature; `releaseForSessionIdleWait()` is additive. The only production caller of `releaseForPrompt` is `installPromptSubmissionLockRelease` (`attempt.session-lock.ts:1014`), which already pairs it with `reacquireAfterPrompt` in a `try/finally` — that wrapper is what makes the file-scoped guard correct in production.
- Single new module-level map (`promptSessionFileTurnTails`) sits alongside the existing `ownedSessionFileWrites` and `trustedSessionFileStates` singletons; same lifetime, same key scheme, same reset hook. No persistent state, no disk artefacts, no cross-process coordination.
- Performance: no contention path is a single map lookup + an early continue. Contention path adds one extra `acquireLock + release` pair on the second entrant to yield the OS lock during the wait — this is necessary because the prior turn-holder must be able to reacquire after their provider call.

## Security

- New permissions/capabilities? No.
- Secrets/tokens handling changed? No.
- New/changed network calls? No.
- Command/tool execution surface changed? No.
- Data access scope changed? No. Touches in-process lock state and one new process-global map keyed by resolved session file paths.

---

*This PR is AI-assisted. Code authored with Claude.*

