### PR TITLE
fix(codex): make native thread token guard configurable

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -198,11 +198,11 @@ function createStartedThreadHarness(
     async notify(notification: CodexServerNotification) {
       await notify(notification);
     },
-    async completeTurn(status: "completed" | "failed" = "completed") {
+    async completeTurn(status: "completed" | "failed" = "completed", threadId = "thread-1") {
       await notify({
         method: "turn/completed",
         params: {
-          threadId: "thread-1",
+          threadId,
           turnId: "turn-1",
           turn: {
             id: "turn-1",
@@ -543,6 +543,201 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
 
     await secondHarness.completeTurn();
     await secondRun;
+  });
+
+  it.each([
+    [
+      "token",
+      `${JSON.stringify({
+        payload: {
+          type: "token_count",
+          info: {
+            last_token_usage: {
+              total_tokens: 300_000,
+            },
+          },
+        },
+      })}\n`,
+      "1mb",
+    ],
+    ["byte", "x".repeat(2_000), 1_000],
+  ] as const)(
+    "resumes a matching thread-bootstrap binding even when the bootstrap turn exceeded the native %s guard",
+    async (_guard, rolloutContent, maxActiveTranscriptBytes) => {
+      const sessionFile = path.join(tempDir, "session.jsonl");
+      const workspaceDir = path.join(tempDir, "workspace");
+      const agentDir = path.join(tempDir, "agent");
+      await writeCodexAppServerBinding(sessionFile, {
+        threadId: "thread-bootstrapped",
+        cwd: workspaceDir,
+        dynamicToolsFingerprint: "[]",
+        contextEngine: {
+          schemaVersion: 1,
+          engineId: "lossless-claw",
+          policyFingerprint:
+            '{"schemaVersion":1,"engineId":"lossless-claw","ownsCompaction":true,"projectionMaxChars":24000}',
+          projection: {
+            schemaVersion: 1,
+            mode: "thread_bootstrap",
+            epoch: "epoch-1",
+          },
+        },
+      });
+      await fs.writeFile(
+        path.join(path.dirname(sessionFile), "sessions.json"),
+        JSON.stringify({
+          "agent:main:session-1": {
+            sessionFile,
+            totalTokens: 12_000,
+          },
+        }),
+      );
+      const rolloutDir = path.join(agentDir, "codex-home", "sessions");
+      await fs.mkdir(rolloutDir, { recursive: true });
+      await fs.writeFile(
+        path.join(rolloutDir, "rollout-thread-bootstrapped.jsonl"),
+        rolloutContent,
+      );
+      const contextEngine = createContextEngine({
+        assemble: vi.fn(async ({ prompt }) => ({
+          messages: [
+            assistantMessage("already bootstrapped context", 10),
+            userMessage(prompt ?? "", 11),
+          ],
+          estimatedTokens: 42,
+          systemPromptAddition: "context-engine system",
+          contextProjection: { mode: "thread_bootstrap" as const, epoch: "epoch-1" },
+        })),
+      });
+      const harness = createStartedThreadHarness(async (method) => {
+        if (method === "thread/resume") {
+          return threadStartResult("thread-bootstrapped");
+        }
+        if (method === "thread/start") {
+          return threadStartResult("thread-fresh");
+        }
+        return undefined;
+      });
+      const params = createParams(sessionFile, workspaceDir);
+      params.agentDir = agentDir;
+      params.contextEngine = contextEngine;
+      params.config = {
+        agents: {
+          defaults: {
+            compaction: {
+              truncateAfterCompaction: true,
+              maxActiveTranscriptBytes,
+            },
+          },
+        },
+      } as EmbeddedRunAttemptParams["config"];
+
+      const run = runCodexAppServerAttempt(params);
+      await harness.waitForMethod("turn/start");
+
+      expect(harness.requests.map((request) => request.method)).toEqual([
+        "thread/resume",
+        "turn/start",
+      ]);
+      const inputText = getRequestInputText(harness);
+      expect(inputText).not.toContain("OpenClaw assembled context for this turn:");
+      expect(inputText).not.toContain("already bootstrapped context");
+      expect(inputText).toBe("hello");
+
+      await harness.completeTurn("completed", "thread-bootstrapped");
+      await run;
+    },
+  );
+
+  it("projects mirrored history when an oversized thread-bootstrap binding has no active context engine", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const agentDir = path.join(tempDir, "agent");
+    const sessionManager = SessionManager.open(sessionFile);
+    sessionManager.appendMessage(
+      userMessage("previous stale-bootstrap request", Date.now()) as never,
+    );
+    sessionManager.appendMessage(
+      assistantMessage("previous stale-bootstrap answer", Date.now() + 1) as never,
+    );
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-stale-bootstrap",
+      cwd: workspaceDir,
+      dynamicToolsFingerprint: "[]",
+      contextEngine: {
+        schemaVersion: 1,
+        engineId: "lossless-claw",
+        policyFingerprint:
+          '{"schemaVersion":1,"engineId":"lossless-claw","ownsCompaction":true,"projectionMaxChars":24000}',
+        projection: {
+          schemaVersion: 1,
+          mode: "thread_bootstrap",
+          epoch: "epoch-stale",
+        },
+      },
+    });
+    await fs.writeFile(
+      path.join(path.dirname(sessionFile), "sessions.json"),
+      JSON.stringify({
+        "agent:main:session-1": {
+          sessionFile,
+          totalTokens: 12_000,
+        },
+      }),
+    );
+    const rolloutDir = path.join(agentDir, "codex-home", "sessions");
+    await fs.mkdir(rolloutDir, { recursive: true });
+    await fs.writeFile(
+      path.join(rolloutDir, "rollout-thread-stale-bootstrap.jsonl"),
+      `${JSON.stringify({
+        payload: {
+          type: "token_count",
+          info: {
+            last_token_usage: {
+              total_tokens: 300_000,
+            },
+          },
+        },
+      })}\n`,
+    );
+    const harness = createStartedThreadHarness(async (method) => {
+      if (method === "thread/resume") {
+        return threadStartResult("thread-stale-bootstrap");
+      }
+      if (method === "thread/start") {
+        return threadStartResult("thread-fresh");
+      }
+      return undefined;
+    });
+    const params = createParams(sessionFile, workspaceDir);
+    params.agentDir = agentDir;
+    params.config = {
+      agents: {
+        defaults: {
+          compaction: {
+            truncateAfterCompaction: true,
+            maxActiveTranscriptBytes: "1mb",
+          },
+        },
+      },
+    } as EmbeddedRunAttemptParams["config"];
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+
+    expect(harness.requests.map((request) => request.method)).toEqual([
+      "thread/start",
+      "turn/start",
+    ]);
+    const inputText = getRequestInputText(harness);
+    expect(inputText).toContain("OpenClaw assembled context for this turn:");
+    expect(inputText).toContain("previous stale-bootstrap request");
+    expect(inputText).toContain("previous stale-bootstrap answer");
+    expect(inputText).toContain("Current user request:");
+    expect(inputText).toContain("hello");
+
+    await harness.completeTurn("completed", "thread-fresh");
+    await run;
   });
 
   it("starts a fresh Codex thread and reprojects when context-engine epoch changes", async () => {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -8656,7 +8656,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(resolved).toBe(false);
     expect(
       warn.mock.calls.some(([message]) =>
-        String(message).includes("turn/completed did not match active turn"),
+        message.includes("turn/completed did not match active turn"),
       ),
     ).toBe(false);
 
@@ -9727,7 +9727,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(resumeRequestParams?.developerInstructions).not.toContain(CODEX_GPT5_BEHAVIOR_CONTRACT);
   });
 
-  it("starts a fresh Codex thread before resume when the native rollout is over budget", async () => {
+  it("starts a fresh Codex thread before resume when the native rollout reaches the fallback fuse", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     const agentDir = path.join(tempDir, "agent");
@@ -9750,7 +9750,7 @@ describe("runCodexAppServerAttempt", () => {
           type: "token_count",
           info: {
             total_token_usage: {
-              total_tokens: 70_000,
+              total_tokens: 300_000,
             },
           },
         },
@@ -9783,7 +9783,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(savedBinding?.threadId).toBe("thread-1");
   });
 
-  it("preserves bound auth when rotating an over-budget native rollout", async () => {
+  it("preserves bound auth when rotating a fallback-fuse native rollout", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     const agentDir = path.join(tempDir, "agent");
@@ -9809,7 +9809,7 @@ describe("runCodexAppServerAttempt", () => {
           type: "token_count",
           info: {
             total_token_usage: {
-              total_tokens: 70_000,
+              total_tokens: 300_000,
             },
           },
         },
@@ -9997,7 +9997,7 @@ describe("runCodexAppServerAttempt", () => {
           type: "token_count",
           info: {
             total_token_usage: {
-              total_tokens: 70_000,
+              total_tokens: 300_000,
             },
             last_token_usage: {
               total_tokens: 12_000,
@@ -10038,7 +10038,7 @@ describe("runCodexAppServerAttempt", () => {
       JSON.stringify({
         "agent:main:session-1": {
           sessionFile,
-          totalTokens: 70_000,
+          totalTokens: 300_000,
           totalTokensFresh: false,
         },
       }),
@@ -10080,7 +10080,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(savedBinding?.threadId).toBe("thread-existing");
   });
 
-  it("streams rollout token scans without reading the whole file", async () => {
+  it("clears native rollouts at Codex's reported model context window", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     const agentDir = path.join(tempDir, "agent");
@@ -10099,16 +10099,26 @@ describe("runCodexAppServerAttempt", () => {
     const rolloutFile = path.join(rolloutDir, "rollout-thread-existing.jsonl");
     await fs.writeFile(
       rolloutFile,
-      `${JSON.stringify({
-        payload: {
-          type: "token_count",
-          info: {
-            last_token_usage: {
-              total_tokens: 70_000,
+      [
+        JSON.stringify({
+          payload: {
+            type: "token_count",
+            info: {
+              last_token_usage: {
+                total_tokens: 128_000,
+              },
             },
           },
-        },
-      })}\n`,
+        }),
+        JSON.stringify({
+          payload: {
+            type: "token_count",
+            info: {
+              model_context_window: 128_000,
+            },
+          },
+        }),
+      ].join("\n") + "\n",
     );
     const readFileSpy = vi.spyOn(fs, "readFile");
 
@@ -10132,6 +10142,58 @@ describe("runCodexAppServerAttempt", () => {
     expect(readFileSpy.mock.calls.some(([file]) => file === rolloutFile)).toBe(false);
     const savedBinding = await readCodexAppServerBinding(sessionFile);
     expect(savedBinding).toBeUndefined();
+  });
+
+  it("keeps native rollouts above the old guard when Codex still has context window headroom", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const agentDir = path.join(tempDir, "agent");
+    await writeExistingBinding(sessionFile, workspaceDir, { dynamicToolsFingerprint: "[]" });
+    await fs.writeFile(
+      path.join(path.dirname(sessionFile), "sessions.json"),
+      JSON.stringify({
+        "agent:main:session-1": {
+          sessionFile,
+          totalTokens: 12_000,
+        },
+      }),
+    );
+    const rolloutDir = path.join(agentDir, "codex-home", "sessions");
+    await fs.mkdir(rolloutDir, { recursive: true });
+    await fs.writeFile(
+      path.join(rolloutDir, "rollout-thread-existing.jsonl"),
+      `${JSON.stringify({
+        payload: {
+          type: "token_count",
+          info: {
+            last_token_usage: {
+              total_tokens: 86_000,
+            },
+            model_context_window: 272_000,
+          },
+        },
+      })}\n`,
+    );
+
+    const binding = await testing.rotateOversizedCodexAppServerStartupBinding({
+      binding: await readCodexAppServerBinding(sessionFile),
+      sessionFile,
+      agentDir,
+      config: {
+        agents: {
+          defaults: {
+            compaction: {
+              truncateAfterCompaction: true,
+              maxActiveTranscriptBytes: "1mb",
+            },
+          },
+        },
+      } as never,
+    });
+
+    expect(binding?.threadId).toBe("thread-existing");
+    const savedBinding = await readCodexAppServerBinding(sessionFile);
+    expect(savedBinding?.threadId).toBe("thread-existing");
   });
 
   it("clears byte-oversized rollouts before reading their contents", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -662,7 +662,10 @@ function isCodexAppServerApprovalPolicy(value: unknown): boolean {
   );
 }
 
-const CODEX_APP_SERVER_NATIVE_THREAD_MAX_TOKENS = 70_000;
+// Codex owns proactive auto-compaction and derives its limit from the active model context
+// window. OpenClaw only clears a bound native thread as a recovery fuse when Codex does
+// not report that window, so the fallback stays well above normal compaction pressure.
+const CODEX_APP_SERVER_NATIVE_THREAD_FALLBACK_MAX_TOKENS = 300_000;
 const CODEX_APP_SERVER_BYTE_UNITS: Record<string, number> = {
   b: 1,
   k: 1024,
@@ -782,28 +785,43 @@ async function readCodexSessionRecordForSessionFile(
   return undefined;
 }
 
-async function readCodexAppServerRolloutTokenUsage(file: string): Promise<number | undefined> {
+type CodexAppServerRolloutTokenSnapshot = {
+  totalTokens?: number;
+  modelContextWindow?: number;
+};
+
+async function readCodexAppServerRolloutTokenSnapshot(
+  file: string,
+): Promise<CodexAppServerRolloutTokenSnapshot | undefined> {
   let handle: Awaited<ReturnType<typeof fs.open>>;
   try {
     handle = await fs.open(file, "r");
   } catch {
     return undefined;
   }
-  let totalTokens: number | undefined;
+  let snapshot: CodexAppServerRolloutTokenSnapshot | undefined;
   try {
     for await (const line of handle.readLines()) {
-      const lineTokens = readCodexAppServerRolloutTokenUsageLine(line);
-      if (lineTokens !== undefined) {
-        totalTokens = lineTokens;
+      const lineSnapshot = readCodexAppServerRolloutTokenSnapshotLine(line);
+      if (lineSnapshot !== undefined) {
+        snapshot ??= {};
+        if (lineSnapshot.totalTokens !== undefined) {
+          snapshot.totalTokens = lineSnapshot.totalTokens;
+        }
+        if (lineSnapshot.modelContextWindow !== undefined) {
+          snapshot.modelContextWindow = lineSnapshot.modelContextWindow;
+        }
       }
     }
   } finally {
     await handle.close();
   }
-  return totalTokens;
+  return snapshot;
 }
 
-function readCodexAppServerRolloutTokenUsageLine(line: string): number | undefined {
+function readCodexAppServerRolloutTokenSnapshotLine(
+  line: string,
+): CodexAppServerRolloutTokenSnapshot | undefined {
   if (!line.trim()) {
     return undefined;
   }
@@ -823,10 +841,31 @@ function readCodexAppServerRolloutTokenUsageLine(line: string): number | undefin
         ? info.total_token_usage
         : undefined;
     const value = usage?.total_tokens ?? usage?.totalTokens;
-    return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+    const totalTokens = typeof value === "number" && Number.isFinite(value) ? value : undefined;
+    const windowValue = info.model_context_window ?? info.modelContextWindow;
+    const modelContextWindow =
+      typeof windowValue === "number" && Number.isFinite(windowValue) && windowValue > 0
+        ? Math.floor(windowValue)
+        : undefined;
+    const snapshot: CodexAppServerRolloutTokenSnapshot = {};
+    if (totalTokens !== undefined) {
+      snapshot.totalTokens = totalTokens;
+    }
+    if (modelContextWindow !== undefined) {
+      snapshot.modelContextWindow = modelContextWindow;
+    }
+    return snapshot.totalTokens !== undefined || snapshot.modelContextWindow !== undefined
+      ? snapshot
+      : undefined;
   } catch {
     return undefined;
   }
+}
+
+function resolveCodexAppServerNativeThreadTokenFuse(
+  modelContextWindow: number | undefined,
+): number {
+  return modelContextWindow ?? CODEX_APP_SERVER_NATIVE_THREAD_FALLBACK_MAX_TOKENS;
 }
 
 function utf8JsonByteLength(value: unknown): number | undefined {
@@ -847,18 +886,35 @@ function maxFiniteNumber(values: Array<number | undefined>): number | undefined 
   return Math.max(...nums);
 }
 
+function hasContextEngineThreadBootstrapProjection(binding: CodexAppServerThreadBinding): boolean {
+  return binding.contextEngine?.projection?.mode === "thread_bootstrap";
+}
+
 async function rotateOversizedCodexAppServerStartupBinding(params: {
   binding: CodexAppServerThreadBinding | undefined;
   sessionFile: string;
   agentDir: string;
   codexHome?: string;
   config: EmbeddedRunAttemptParams["config"] | undefined;
+  contextEngineActive?: boolean;
 }): Promise<CodexAppServerThreadBinding | undefined> {
   const binding = params.binding;
   if (!binding?.threadId) {
     return binding;
   }
   if (params.config?.agents?.defaults?.compaction?.truncateAfterCompaction !== true) {
+    return binding;
+  }
+  if (params.contextEngineActive === true && hasContextEngineThreadBootstrapProjection(binding)) {
+    embeddedAgentLog.debug(
+      "codex app-server deferring native transcript size guard for context-engine thread bootstrap",
+      {
+        threadId: binding.threadId,
+        engineId: binding.contextEngine?.engineId,
+        epoch: binding.contextEngine?.projection?.epoch,
+        fingerprint: binding.contextEngine?.projection?.fingerprint,
+      },
+    );
     return binding;
   }
   const sessionRecord = await readCodexSessionRecordForSessionFile(params.sessionFile);
@@ -885,11 +941,16 @@ async function rotateOversizedCodexAppServerStartupBinding(params: {
       return undefined;
     }
   }
-  const nativeTokens = maxFiniteNumber(
-    await Promise.all(
-      rolloutFiles.map(async (file) => readCodexAppServerRolloutTokenUsage(file.path)),
-    ),
+  const nativeTokenSnapshots = await Promise.all(
+    rolloutFiles.map(async (file) => readCodexAppServerRolloutTokenSnapshot(file.path)),
   );
+  const nativeTokens = maxFiniteNumber(
+    nativeTokenSnapshots.map((snapshot) => snapshot?.totalTokens),
+  );
+  const nativeModelContextWindow = maxFiniteNumber(
+    nativeTokenSnapshots.map((snapshot) => snapshot?.modelContextWindow),
+  );
+  const maxTokens = resolveCodexAppServerNativeThreadTokenFuse(nativeModelContextWindow);
   const sessionTokens =
     sessionRecord?.totalTokensFresh !== false &&
     typeof sessionRecord?.totalTokens === "number" &&
@@ -897,15 +958,16 @@ async function rotateOversizedCodexAppServerStartupBinding(params: {
       ? sessionRecord.totalTokens
       : undefined;
   const tokenCount = maxFiniteNumber([sessionTokens, nativeTokens]);
-  if (tokenCount !== undefined && tokenCount >= CODEX_APP_SERVER_NATIVE_THREAD_MAX_TOKENS) {
+  if (tokenCount !== undefined && tokenCount >= maxTokens) {
     embeddedAgentLog.warn(
       "codex app-server native transcript exceeded active token limit; starting a fresh thread",
       {
         threadId: binding.threadId,
-        maxTokens: CODEX_APP_SERVER_NATIVE_THREAD_MAX_TOKENS,
+        maxTokens,
         sessionKey: sessionRecord?.sessionKey,
         sessionTokens,
         nativeTokens,
+        nativeModelContextWindow,
       },
     );
     await clearCodexAppServerBinding(params.sessionFile);
@@ -1030,6 +1092,7 @@ export async function runCodexAppServerAttempt(
     agentDir,
     codexHome: appServer.start.env?.CODEX_HOME,
     config: params.config,
+    contextEngineActive: isActiveHarnessContextEngine(params.contextEngine),
   });
   const startupAuthProfileCandidate =
     params.runtimePlan?.auth.forwardedAuthProfileId ??


### PR DESCRIPTION
## Summary

This is a stacked follow-up to #85978 for the hard-coded Codex app-server native-thread token reuse guard.

It makes the proactive native-token guard configurable instead of treating `70000` as the only possible policy:

- Adds `agents.defaults.compaction.maxActiveTranscriptTokens`.
- Keeps the current default at `70000` when unset, preserving existing behavior.
- Allows numeric values or token-count strings such as `"120k"` / `"1.5k"`.
- Allows `0` to disable only this proactive token guard.
- Preserves byte-limit rotation and semantic binding invalidation.
- Skips Codex rollout-directory scans when both native byte and token guards are disabled.

## Stacking / Review Order

This branch is intentionally stacked on #85978 (`codex/native-thread-reuse-budget`).

Recommended order:

1. Review/merge #85978 first. It fixes the semantic correctness bug where an active context-engine `thread_bootstrap` binding could be cleared by the startup size guard before the context-engine projection decision had a chance to preserve it.
2. Review this PR second. It makes the remaining legacy/non-bootstrap native token guard policy explicit and configurable.

If this PR is reviewed before #85978 lands, the intended new commit here is:

```text
80da76695c fix(codex): make native thread token guard configurable
```

## Why This Is Needed

The existing guard is not the model context window. It is a local Codex app-server native-thread reuse guard. Today it is hard-coded to `70000` tokens, and when it fires OpenClaw clears the saved native thread binding before startup:

```text
codex app-server native transcript exceeded active token limit; starting a fresh thread
```

That is a reasonable safety valve for legacy/stale bindings, but it is too blunt for long-running Codex sessions because the native token count can include the large bootstrap-loaded context already paid into the native thread.

Scenario:

```mermaid
sequenceDiagram
  participant OC as OpenClaw
  participant CE as Context Engine / Bootstrap
  participant CX as Codex app-server native thread

  OC->>CE: assemble bootstrap/context
  CE-->>OC: 80k-120k effective bootstrap/context
  OC->>CX: thread/start with developer instructions + projected context
  CX-->>OC: rollout token_count over 70k
  OC->>CX: next turn startup checks saved binding
  alt legacy hard guard
    OC->>OC: clear binding at 70k
    OC->>CX: cold thread/start again
  else semantic thread_bootstrap from #85978
    OC->>OC: preserve matching semantic binding
    OC->>CX: thread/resume warm path
  end
```

The bootstrap question is the crux: for legacy/non-context-engine native reuse, the guard can effectively see the native thread after it has already absorbed large startup/bootstrap instructions. For active context-engine `thread_bootstrap`, #85978 prevents that bootstrap cost from automatically invalidating the native binding on the next turn. This PR covers the remaining policy question by letting operators set the guard to match their deployment instead of forcing every installation through `70000`.

## What This Does Not Solve

This does not implement the larger #86023 architecture items:

- semantic compaction-preservation across Codex native threads;
- binding ownership across session-file rollover;
- workspace bootstrap fingerprinting as a first-class reuse reason;
- doctor/status diagnostics for native-thread rotation reason codes.

Those should stay separate because they touch lifecycle design, diagnostics, and context-engine contracts rather than just the hard-coded native guard policy.

## Real behavior proof

- **Behavior or issue addressed**: The Codex app-server native-thread startup guard no longer treats `70000` as the only possible token policy. A thread binding with `86000` recorded session tokens is preserved when configured to `"120k"` and cleared when configured to `"50k"`.
- **Real environment tested**: Local OpenClaw checkout on macOS from `/Volumes/LEXAR/repos/worktrees/openclaw-codex-semantic-reuse-guard`, using the actual patched runtime modules through `node --import tsx`.
- **Exact steps or command run after this patch**:

```text
node --import tsx - <<'EOF'
import fs from 'node:fs/promises';
import path from 'node:path';
import os from 'node:os';
import { testing } from './extensions/codex/src/app-server/run-attempt.ts';
import { readCodexAppServerBinding, writeCodexAppServerBinding } from './extensions/codex/src/app-server/session-binding.ts';

const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'openclaw-real-proof-native-token-'));
const sessionFile = path.join(tempDir, 'session.jsonl');
const agentDir = path.join(tempDir, 'agent');
const cwd = path.join(tempDir, 'workspace');
await fs.mkdir(path.dirname(sessionFile), { recursive: true });
await fs.mkdir(cwd, { recursive: true });
await fs.writeFile(sessionFile, '');
await writeCodexAppServerBinding(sessionFile, {
  threadId: 'thread-existing',
  cwd,
  model: 'gpt-5.4-codex',
  modelProvider: 'openai',
  dynamicToolsFingerprint: '[]',
});
await fs.writeFile(
  path.join(path.dirname(sessionFile), 'sessions.json'),
  JSON.stringify({
    'agent:main:session-1': {
      sessionFile,
      totalTokens: 86000,
    },
  }),
);
const preserved = await testing.rotateOversizedCodexAppServerStartupBinding({
  binding: await readCodexAppServerBinding(sessionFile),
  sessionFile,
  agentDir,
  config: {
    agents: { defaults: { compaction: { truncateAfterCompaction: true, maxActiveTranscriptTokens: '120k' } } },
  },
});
await writeCodexAppServerBinding(sessionFile, {
  threadId: 'thread-existing',
  cwd,
  model: 'gpt-5.4-codex',
  modelProvider: 'openai',
  dynamicToolsFingerprint: '[]',
});
const cleared = await testing.rotateOversizedCodexAppServerStartupBinding({
  binding: await readCodexAppServerBinding(sessionFile),
  sessionFile,
  agentDir,
  config: {
    agents: { defaults: { compaction: { truncateAfterCompaction: true, maxActiveTranscriptTokens: '50k' } } },
  },
});
console.log(JSON.stringify({
  environment: process.cwd(),
  observed: {
    overDefaultConfiguredTo120k: preserved?.threadId ?? null,
    belowConfigured50k: cleared?.threadId ?? null,
    savedBindingAfter50k: (await readCodexAppServerBinding(sessionFile))?.threadId ?? null,
  },
}, null, 2));
EOF
```

- **Evidence after fix**: Terminal output from the command above:

```text
[agent/embedded] codex app-server native transcript exceeded active token limit; starting a fresh thread
{
  "environment": "/Volumes/LEXAR/repos/worktrees/openclaw-codex-semantic-reuse-guard",
  "observed": {
    "overDefaultConfiguredTo120k": "thread-existing",
    "belowConfigured50k": null,
    "savedBindingAfter50k": null
  }
}
```

- **Observed result after fix**: The same `86000`-token recorded native/session state preserves the existing binding under `"120k"` and clears it under `"50k"`, matching the configurable guard behavior added by this PR.
- **What was not tested**: A live Discord/Codex long-running channel was not exercised in this proof. That broader end-to-end slowdown remains tracked in #86023.

## Validation

Focused local validation from `/Volumes/LEXAR/repos/worktrees/openclaw-codex-semantic-reuse-guard`:

```text
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts --run -t "configured native rollout token|token rotation when configured to zero|configured token limit below|session totals|byte rotation active|skips rollout directory scans"
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/config/zod-schema.agent-defaults.test.ts src/config/config.schema-regressions.test.ts src/config/config.compaction-settings.test.ts src/config/schema.help.quality.test.ts --run -t "compaction.truncateAfterCompaction|preserves memory flush|agent compaction safeguards"
pnpm exec oxfmt --check --threads=1 extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts src/config/types.agent-defaults.ts src/config/zod-schema.agent-defaults.ts src/config/zod-schema.agent-defaults.test.ts src/config/config.schema-regressions.test.ts src/config/config.compaction-settings.test.ts src/config/schema.help.ts src/config/schema.labels.ts src/config/schema.help.quality.test.ts
pnpm config:schema:check
pnpm config:docs:check
git diff --check
pnpm tsgo:core:test
pnpm tsgo:extensions:test
```

Results: all passed locally.

I also ran four read-only adversarial review agents over the diff. Two returned zero >=95% findings; two found test/efficiency gaps that were fixed before this PR was opened.
