### PR TITLE
fix(telegram): propagate cached forum topic names

### DIFF
--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -1,8 +1,18 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { captureEnv } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { handleTelegramAction, telegramActionRuntime } from "./action-runtime.js";
 import { beginTelegramInboundEventDeliveryCorrelation } from "./inbound-event-delivery.js";
+import {
+  clearTopicNameCache,
+  getTopicEntry,
+  getTopicName,
+  resetTopicNameCacheForTest,
+  resolveTopicNameCacheScope,
+  setTelegramTopicNameStoreFactoryForTest,
+  updateTopicName,
+} from "./topic-name-cache.js";
 
 const originalTelegramActionRuntime = { ...telegramActionRuntime };
 const reactMessageTelegram = vi.fn(async () => ({ ok: true }));
@@ -43,6 +53,8 @@ const createForumTopicTelegram = vi.fn(async () => ({
 }));
 let envSnapshot: ReturnType<typeof captureEnv>;
 
+type TopicEntry = NonNullable<Awaited<ReturnType<typeof getTopicEntry>>>;
+
 type MockCallSource = {
   mock: {
     calls: ArrayLike<ReadonlyArray<unknown>>;
@@ -62,6 +74,32 @@ function mockCall(source: MockCallSource, callIndex: number, label: string) {
     throw new Error(`Expected Telegram mock call: ${label}`);
   }
   return call;
+}
+
+function installTopicNameMemoryStores(): void {
+  const stores = new Map<string, Map<string, TopicEntry>>();
+  setTelegramTopicNameStoreFactoryForTest((namespace) => {
+    const entries = stores.get(namespace) ?? new Map<string, TopicEntry>();
+    stores.set(namespace, entries);
+    return {
+      async register(key, value) {
+        entries.set(key, value);
+      },
+      async entries() {
+        return Array.from(entries, ([key, value]) => ({ key, value }));
+      },
+      async delete(key) {
+        return entries.delete(key);
+      },
+      async clear() {
+        entries.clear();
+      },
+    };
+  });
+}
+
+function topicNameScopeForConfig(cfg: OpenClawConfig, accountId?: string): string {
+  return resolveTopicNameCacheScope(resolveStorePath(cfg.session?.store, { agentId: accountId }));
 }
 
 function resultDetails(result: Awaited<ReturnType<typeof handleTelegramAction>>) {
@@ -129,8 +167,11 @@ describe("handleTelegramAction", () => {
     expect(options.remove).toBe(false);
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     envSnapshot = captureEnv(["TELEGRAM_BOT_TOKEN"]);
+    installTopicNameMemoryStores();
+    await clearTopicNameCache();
+    resetTopicNameCacheForTest();
     Object.assign(telegramActionRuntime, originalTelegramActionRuntime, {
       reactMessageTelegram,
       sendMessageTelegram,
@@ -156,6 +197,7 @@ describe("handleTelegramAction", () => {
 
   afterEach(() => {
     envSnapshot.restore();
+    setTelegramTopicNameStoreFactoryForTest(undefined);
   });
 
   it("adds reactions when reactionLevel is minimal", async () => {
@@ -864,6 +906,53 @@ describe("handleTelegramAction", () => {
       expect(opts.gatewayClientScopes).toEqual(["operator.write"]);
     },
   );
+
+  it.each([
+    {
+      name: "createForumTopic",
+      params: { action: "createForumTopic", chatId: "123", name: "Topic" },
+      cfg: telegramConfig({ actions: { createForumTopic: true } }),
+      expectedTopicId: 99,
+      expectedName: "Topic",
+    },
+    {
+      name: "editForumTopic",
+      params: { action: "editForumTopic", chatId: "123", messageThreadId: 42, name: "New" },
+      cfg: telegramConfig({ actions: { editForumTopic: true } }),
+      expectedTopicId: 42,
+      expectedName: "New",
+    },
+  ])("persists topic names after $name succeeds", async (testCase) => {
+    await handleTelegramAction(testCase.params, testCase.cfg);
+
+    await expect(
+      getTopicName("123", testCase.expectedTopicId, topicNameScopeForConfig(testCase.cfg)),
+    ).resolves.toBe(testCase.expectedName);
+  });
+
+  it("keeps the cached topic name when editing only the forum topic icon", async () => {
+    const cfg = telegramConfig({ actions: { editForumTopic: true } });
+    const scope = topicNameScopeForConfig(cfg);
+    await updateTopicName("123", 42, { name: "Deployments" }, scope);
+    editForumTopicTelegram.mockResolvedValueOnce({
+      ok: true,
+      chatId: "123",
+      messageThreadId: 42,
+      iconCustomEmojiId: "emoji-1",
+    });
+
+    await handleTelegramAction(
+      {
+        action: "editForumTopic",
+        chatId: "123",
+        messageThreadId: 42,
+        iconCustomEmojiId: "emoji-1",
+      },
+      cfg,
+    );
+
+    await expect(getTopicName("123", 42, scope)).resolves.toBe("Deployments");
+  });
 
   it.each([
     {

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -16,6 +16,7 @@ import {
   renderMessagePresentationFallbackText,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import type { MessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
+import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { createTelegramActionGate, resolveTelegramPollActionGateState } from "./accounts.js";
 import { resolveTelegramInlineButtons } from "./button-types.js";
 import { notifyTelegramInboundEventOutboundSuccess } from "./inbound-event-delivery.js";
@@ -40,6 +41,7 @@ import {
 import { getCacheStats, searchStickers } from "./sticker-cache.js";
 import { normalizeTelegramOutboundTarget, parseTelegramTarget } from "./targets.js";
 import { resolveTelegramToken } from "./token.js";
+import { resolveTopicNameCacheScope, updateTopicName } from "./topic-name-cache.js";
 
 export const telegramActionRuntime = {
   createForumTopicTelegram,
@@ -275,6 +277,16 @@ async function maybePinTelegramActionSend(params: {
       throw err;
     }
   }
+}
+
+function resolveTelegramActionTopicNameCacheScope(params: {
+  cfg: OpenClawConfig;
+  accountId?: string;
+}): string {
+  const storePath = resolveStorePath(params.cfg.session?.store, {
+    agentId: params.accountId,
+  });
+  return resolveTopicNameCacheScope(storePath);
 }
 
 export async function handleTelegramAction(
@@ -726,6 +738,12 @@ export async function handleTelegramAction(
       iconCustomEmojiId: iconCustomEmojiId ?? undefined,
       gatewayClientScopes: options?.gatewayClientScopes,
     });
+    await updateTopicName(
+      result.chatId ?? chatId ?? "",
+      result.topicId,
+      { name: result.name, iconColor, iconCustomEmojiId: iconCustomEmojiId ?? undefined },
+      resolveTelegramActionTopicNameCacheScope({ cfg, accountId }),
+    );
     return jsonResult({
       ok: true,
       topicId: result.topicId,
@@ -762,6 +780,12 @@ export async function handleTelegramAction(
         iconCustomEmojiId: iconCustomEmojiId ?? undefined,
         gatewayClientScopes: options?.gatewayClientScopes,
       },
+    );
+    await updateTopicName(
+      result.chatId ?? chatId ?? "",
+      result.messageThreadId ?? messageThreadId,
+      { name: name ?? result.name, iconCustomEmojiId: iconCustomEmojiId ?? undefined },
+      resolveTelegramActionTopicNameCacheScope({ cfg, accountId }),
     );
     return jsonResult(result);
   }

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TelegramNativeCommandDeps } from "./bot-native-command-deps.runtime.js";
 import {
   createDeferred,
@@ -12,8 +12,18 @@ import {
   type NativeCommandTestParams,
 } from "./bot-native-commands.fixture-test-support.js";
 import { type RegisterTelegramHandlerParams } from "./bot-native-commands.js";
+import {
+  clearTopicNameCache,
+  getTopicEntry,
+  resetTopicNameCacheForTest,
+  resolveTopicNameCacheScope,
+  setTelegramTopicNameStoreFactoryForTest,
+  updateTopicName,
+} from "./topic-name-cache.js";
 
 // All mocks scoped to this file only — does not affect bot-native-commands.test.ts
+
+type TopicEntry = NonNullable<Awaited<ReturnType<typeof getTopicEntry>>>;
 
 type ResolveConfiguredBindingRouteFn =
   typeof import("openclaw/plugin-sdk/conversation-runtime").resolveConfiguredBindingRoute;
@@ -35,6 +45,28 @@ const dispatchReplyResult: DispatchReplyWithBufferedBlockDispatcherResult = {
   queuedFinal: false,
   counts: {} as DispatchReplyWithBufferedBlockDispatcherResult["counts"],
 };
+
+function installTopicNameMemoryStores(): void {
+  const stores = new Map<string, Map<string, TopicEntry>>();
+  setTelegramTopicNameStoreFactoryForTest((namespace) => {
+    const entries = stores.get(namespace) ?? new Map<string, TopicEntry>();
+    stores.set(namespace, entries);
+    return {
+      async register(key, value) {
+        entries.set(key, value);
+      },
+      async entries() {
+        return Array.from(entries, ([key, value]) => ({ key, value }));
+      },
+      async delete(key) {
+        return entries.delete(key);
+      },
+      async clear() {
+        entries.clear();
+      },
+    };
+  });
+}
 
 const persistentBindingMocks = vi.hoisted(() => ({
   resolveConfiguredBindingRoute: vi.fn<ResolveConfiguredBindingRouteFn>(({ route }) => ({
@@ -544,7 +576,10 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     ({ registerTelegramNativeCommands } = await import("./bot-native-commands.js"));
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    installTopicNameMemoryStores();
+    await clearTopicNameCache();
+    resetTopicNameCacheForTest();
     persistentBindingMocks.resolveConfiguredBindingRoute.mockClear();
     persistentBindingMocks.resolveConfiguredBindingRoute.mockImplementation(({ route }) =>
       createConfiguredBindingRoute(route, null),
@@ -584,6 +619,10 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     sessionBindingMocks.resolveByConversation.mockReset().mockReturnValue(null);
     sessionBindingMocks.touch.mockReset();
     deliveryMocks.deliverReplies.mockClear().mockResolvedValue({ delivered: true });
+  });
+
+  afterEach(() => {
+    setTelegramTopicNameStoreFactoryForTest(undefined);
   });
 
   it("calls recordSessionMetaFromInbound after a native slash command", async () => {
@@ -1059,6 +1098,36 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     expect(sessionMetaCall?.sessionKey).toBe("agent:zu:telegram:group:-1001234567890:topic:42");
     expect(sessionMetaCall?.ctx?.From).toBe("telegram:group:-1001234567890:topic:42");
     expect(sessionMetaCall?.ctx?.ChatType).toBe("group");
+  });
+
+  it("includes cached Telegram forum topic names in native command context", async () => {
+    const cacheScope = resolveTopicNameCacheScope("/tmp/openclaw-sessions.json");
+    await updateTopicName(-1001234567890, 42, { name: "Deployments" }, cacheScope);
+    const { handler } = registerAndResolveStatusHandler({
+      cfg: {},
+      allowFrom: ["200"],
+      groupAllowFrom: ["200"],
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: { requireMention: false },
+      }),
+    });
+
+    await handler(createTelegramTopicCommandContext());
+
+    const dispatchCall = (
+      replyMocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls as unknown as Array<
+        [{ ctx?: { TopicName?: string; IsForum?: boolean; MessageThreadId?: number } }]
+      >
+    )[0]?.[0];
+    expect(dispatchCall?.ctx?.IsForum).toBe(true);
+    expect(dispatchCall?.ctx?.MessageThreadId).toBe(42);
+    expect(dispatchCall?.ctx?.TopicName).toBe("Deployments");
+    const sessionMetaCall = (
+      sessionMocks.recordSessionMetaFromInbound.mock.calls as unknown as Array<
+        [{ ctx?: { TopicName?: string } }]
+      >
+    )[0]?.[0];
+    expect(sessionMetaCall?.ctx?.TopicName).toBe("Deployments");
   });
 
   it("does not mark paired Telegram DM allowlist entries as native group command owners", async () => {

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -100,6 +100,7 @@ import { resolveTelegramGroupPromptSettings } from "./group-config-helpers.js";
 import { resolveTelegramCommandIngressAuthorization } from "./ingress.js";
 import { buildInlineKeyboard } from "./inline-keyboard.js";
 import { recordSentMessage } from "./sent-message-cache.js";
+import { getTopicName, resolveTopicNameCacheScope } from "./topic-name-cache.js";
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
 const TELEGRAM_NATIVE_COMMAND_CALLBACK_PREFIX = "tgcmd:";
@@ -127,6 +128,7 @@ type TelegramCommandAuthResult = {
   senderUsername: string;
   groupConfig?: TelegramGroupConfig | TelegramDirectConfig;
   topicConfig?: TelegramTopicConfig;
+  topicName?: string;
   commandAuthorized: boolean;
   senderIsOwner: boolean;
 };
@@ -136,6 +138,7 @@ type TelegramNativeCommandThreadContext = {
   isGroup: boolean;
   isForum: boolean;
   messageThreadId: number | undefined;
+  topicName: string | undefined;
   threadSpec: ReturnType<typeof resolveTelegramThreadSpec>;
   threadParams: ReturnType<typeof buildTelegramThreadParams>;
 };
@@ -364,8 +367,10 @@ async function cleanupTelegramProgressPlaceholder(params: {
 async function resolveTelegramNativeCommandThreadContext(params: {
   msg: NonNullable<TelegramNativeCommandContext["message"]>;
   bot: Bot;
+  cfg: OpenClawConfig;
+  accountId: string;
 }): Promise<TelegramNativeCommandThreadContext> {
-  const { msg, bot } = params;
+  const { msg, bot, cfg, accountId } = params;
   const chatId = msg.chat.id;
   const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
   const messageThreadId = (msg as { message_thread_id?: number }).message_thread_id;
@@ -386,14 +391,37 @@ async function resolveTelegramNativeCommandThreadContext(params: {
     isForum,
     messageThreadId,
   });
+  const topicName = await resolveTelegramNativeCommandTopicName({
+    cfg,
+    accountId,
+    chatId,
+    threadSpec,
+    isForum,
+  });
   return {
     chatId,
     isGroup,
     isForum,
     messageThreadId,
+    topicName,
     threadSpec,
     threadParams: buildTelegramThreadParams(threadSpec),
   };
+}
+
+async function resolveTelegramNativeCommandTopicName(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  chatId: number;
+  threadSpec: ReturnType<typeof resolveTelegramThreadSpec>;
+  isForum: boolean;
+}): Promise<string | undefined> {
+  if (!params.isForum || params.threadSpec.scope !== "forum") {
+    return undefined;
+  }
+  const storePath = resolveStorePath(params.cfg.session?.store, { agentId: params.accountId });
+  const cacheScope = resolveTopicNameCacheScope(storePath);
+  return await getTopicName(params.chatId, params.threadSpec.id, cacheScope);
 }
 
 export type RegisterTelegramHandlerParams = {
@@ -513,8 +541,8 @@ async function resolveTelegramCommandAuth(params: {
     resolveTelegramGroupConfig,
     requireAuth,
   } = params;
-  const { chatId, isGroup, isForum, messageThreadId, threadParams } =
-    await resolveTelegramNativeCommandThreadContext({ msg, bot });
+  const { chatId, isGroup, isForum, messageThreadId, threadParams, topicName } =
+    await resolveTelegramNativeCommandThreadContext({ msg, bot, cfg, accountId });
   const senderId = msg.from?.id ? String(msg.from.id) : "";
   const senderUsername = msg.from?.username ?? "";
   const groupAllowContext = await resolveTelegramGroupAllowFromContext({
@@ -679,6 +707,7 @@ async function resolveTelegramCommandAuth(params: {
     senderUsername,
     groupConfig,
     topicConfig,
+    topicName,
     commandAuthorized,
     senderIsOwner: ownerAccess.senderIsOwner,
   };
@@ -983,6 +1012,7 @@ export const registerTelegramNativeCommands = ({
           senderUsername,
           groupConfig,
           topicConfig,
+          topicName,
           commandAuthorized,
         } = auth;
         const runtimeContext = await resolveCommandRuntimeContext({
@@ -1181,6 +1211,7 @@ export const registerTelegramNativeCommands = ({
           CommandTargetSessionKey: commandTargetSessionKey,
           MessageThreadId: threadSpec.id,
           IsForum: isForum,
+          TopicName: isForum && topicName ? topicName : undefined,
           // Originating context for sub-agent announce routing
           OriginatingChannel: "telegram" as const,
           OriginatingTo: originatingTo,
@@ -1279,7 +1310,12 @@ export const registerTelegramNativeCommands = ({
         const chatId = msg.chat.id;
         const runtimeCfg = loadFreshRuntimeConfig();
         const runtimeTelegramCfg = resolveFreshTelegramConfig(runtimeCfg);
-        const { threadParams } = await resolveTelegramNativeCommandThreadContext({ msg, bot });
+        const { threadParams } = await resolveTelegramNativeCommandThreadContext({
+          msg,
+          bot,
+          cfg: runtimeCfg,
+          accountId,
+        });
         const rawText = ctx.match?.trim() ?? "";
         const commandBody = `/${pluginCommand.command}${rawText ? ` ${rawText}` : ""}`;
         const nativeCommandRuntime = await loadTelegramNativeCommandRuntime();


### PR DESCRIPTION
## Summary

- Resolves cached Telegram forum topic names into native slash-command inbound context so trusted metadata includes `topic_name` when available.
- Persists topic names after successful `createForumTopic` and `editForumTopic` actions so later topic-scoped turns can reuse them.
- Adds regression coverage for native command session metadata and forum-topic action cache updates.

Refs #86024

## Tests

- `node scripts/run-vitest.mjs extensions/telegram/src/action-runtime.test.ts extensions/telegram/src/bot-native-commands.session-meta.test.ts`
- `pnpm openclaw --help >/tmp/openclaw-help-proof.txt && head -n 5 /tmp/openclaw-help-proof.txt`

## Real behavior proof

Behavior addressed: Telegram forum topic names cached by the Telegram plugin are propagated to native command trusted metadata and refreshed after successful forum-topic create/edit actions.

Real environment tested: Local macOS source checkout, Node 23.11.1, OpenClaw CLI rebuilt from this patch via `pnpm openclaw --help`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/telegram/src/action-runtime.test.ts extensions/telegram/src/bot-native-commands.session-meta.test.ts`; `pnpm openclaw --help >/tmp/openclaw-help-proof.txt && head -n 5 /tmp/openclaw-help-proof.txt`.

Evidence after fix: The native command regression test seeds a cached Telegram forum topic name and verifies both dispatch context and recorded session metadata carry `TopicName`; the action-runtime regression tests verify successful forum topic create/edit actions write the topic-name cache.

Observed result after fix: Targeted Vitest command exited 0; the runtime CLI command rebuilt OpenClaw from the patched checkout and printed `OpenClaw 2026.5.24 (48ad0be) — All your chats, one OpenClaw.`

What was not tested: Live Telegram supergroup API calls were not run because this environment does not have a real Telegram bot token or forum supergroup fixture; the runtime proof uses local command execution plus targeted Telegram runtime tests with mocked Telegram API calls.
