### PR TITLE
fix(codex): verify plugin elicitation source

### DIFF
--- a/extensions/codex/src/app-server/elicitation-bridge.test.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.test.ts
@@ -832,6 +832,19 @@ describe("Codex app-server elicitation bridge", () => {
     expect(mockCallGatewayTool).not.toHaveBeenCalled();
   });
 
+  it("declines app-id plugin app elicitations from unverified MCP servers", async () => {
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildPluginApprovalElicitation({ serverName: "unknown-mcp" }),
+      paramsForRun: createParams(),
+      threadId: "thread-1",
+      turnId: "turn-1",
+      pluginAppPolicyContext: createPluginAppPolicyContext({ allowDestructiveActions: true }),
+    });
+
+    expect(result).toEqual({ action: "decline", content: null, _meta: null });
+    expect(mockCallGatewayTool).not.toHaveBeenCalled();
+  });
+
   it("accepts connector-id plugin app elicitations when destructive actions are enabled", async () => {
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: buildConnectorPluginApprovalElicitation(),
@@ -855,6 +868,37 @@ describe("Codex app-server elicitation bridge", () => {
       content: null,
       _meta: null,
     });
+    expect(mockCallGatewayTool).not.toHaveBeenCalled();
+  });
+
+  it("accepts verified connector elicitations that include matching app ids", async () => {
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildConnectorPluginApprovalElicitation({
+        _meta: {
+          codex_approval_kind: "mcp_tool_call",
+          source: "connector",
+          app_id: "connector_google_calendar",
+          connector_id: "connector_google_calendar",
+          connector_name: "Google Calendar",
+          tool_title: "create_event",
+        },
+      }),
+      paramsForRun: createParams(),
+      threadId: "thread-1",
+      turnId: "turn-1",
+      pluginAppPolicyContext: createPluginAppPolicyContext({
+        allowDestructiveActions: true,
+        apps: [
+          {
+            appId: "connector_google_calendar",
+            pluginName: "google-calendar",
+            mcpServerNames: [],
+          },
+        ],
+      }),
+    });
+
+    expect(result).toEqual({ action: "accept", content: null, _meta: null });
     expect(mockCallGatewayTool).not.toHaveBeenCalled();
   });
 

--- a/extensions/codex/src/app-server/elicitation-bridge.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.ts
@@ -176,6 +176,7 @@ function resolvePluginElicitation(params: {
     readFirstString(requestParams, PLUGIN_APP_ID_META_KEYS);
   const connectorId = readFirstString(meta, PLUGIN_CONNECTOR_ID_META_KEYS);
   const isCodexConnectorApproval = isCodexConnectorApprovalElicitation(requestParams, meta);
+  const serverName = readString(requestParams, "serverName");
   if (isCodexConnectorApproval && appId && connectorId && appId !== connectorId) {
     return { kind: "decline", reason: "app_id_connector_id_mismatch" };
   }
@@ -187,7 +188,13 @@ function resolvePluginElicitation(params: {
     if (entry?.source === "account" && !isCodexConnectorApproval) {
       return { kind: "decline", reason: "account_app_source_mismatch" };
     }
-    return uniquePluginMatch(entry ? [entry] : [], "app_id");
+    if (!entry) {
+      return uniquePluginMatch([], "app_id");
+    }
+    if (!isCodexConnectorApproval && (!serverName || !entry.mcpServerNames.includes(serverName))) {
+      return { kind: "decline", reason: "app_id_source_unverified" };
+    }
+    return { kind: "matched", entry };
   }
   if (isCodexConnectorApproval && connectorId) {
     if (!context) {
@@ -197,7 +204,6 @@ function resolvePluginElicitation(params: {
     return uniquePluginMatch(entry ? [entry] : [], "connector_id");
   }
 
-  const serverName = readString(requestParams, "serverName");
   if (serverName && context) {
     const matches = entries.filter((entry) => entry.mcpServerNames.includes(serverName));
     if (matches.length > 0) {


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Prevents Codex plugin app elicitations from being auto-approved solely because the request self-declares `_meta.app_id`.
- Requires the request source to be verified before plugin destructive-action policy is applied: either the request is the trusted `codex_apps` connector approval shape, or its `serverName` belongs to the matched plugin app.
- Keeps existing connector-backed approval behavior intact while closing the confused-deputy path for unrelated MCP servers.

Why does this matter now?

- Native Codex plugin approvals can silently answer destructive-action elicitations when plugin policy allows it.
- Without source verification, an unrelated MCP server could claim another enabled plugin app id and receive an automatic approval response.

What is the intended outcome?

- Plugin app auto-approval only applies when the app identity and request source line up.
- Spoofed `app_id` requests fail closed with a decline response.

What is intentionally out of scope?

- No change to `/codex permissions yolo`.
- No change to `codex.cli.session.resume`; that is already covered by related PR #82906.
- No change to destructive-action defaults or plugin configuration shape.

What does success look like?

- Valid plugin-owned MCP elicitations and valid `codex_apps` connector elicitations still work.
- An unrelated MCP server cannot borrow another plugin’s `app_id` to trigger silent approval.

What should reviewers focus on?

- Whether the `app_id` branch now has the same source-proof property as the existing server-name and connector-id paths.
- Whether the connector exception is narrow enough and does not reopen display-name-only trust.

## Linked context

Which issue does this close?

Closes # 

Which issues, PRs, or discussions are related?

Related #80747  
Related #82906

Was this requested by a maintainer or owner?

No maintainer request; this comes from security review of the Codex plugin elicitation bridge.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: unrelated MCP servers can no longer self-assert `_meta.app_id` for an enabled plugin app and receive silent destructive-action approval.
- Real environment tested: local OpenClaw checkout on branch `codex/verify-plugin-elicitation-source`, based on current `origin/main`.
- Exact steps or command run after this patch:
  - `./node_modules/.bin/oxfmt --check --threads=1 extensions/codex/src/app-server/elicitation-bridge.ts extensions/codex/src/app-server/elicitation-bridge.test.ts`
  - `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/codex/src/app-server/elicitation-bridge.ts extensions/codex/src/app-server/elicitation-bridge.test.ts`
  - `node scripts/run-vitest.mjs` equivalent for `extensions/codex/src/app-server/elicitation-bridge.test.ts`
  - `git diff --check HEAD~1..HEAD`
- Evidence after fix:

```terminal
Test Files  1 passed (1)
     Tests  41 passed (41)
  Duration  9.09s
```

```terminal
Checking formatting...

All matched files use the correct format.
```

- Observed result after fix: spoofed app-id elicitations from an unverified MCP server decline; verified connector elicitations with matching app id still accept.
- What was not tested: no live malicious MCP server was attached to a running user Gateway.
- Proof limitations or environment constraints: this machine does not have `pnpm` or `gh` available in PATH, and `corepack pnpm` fails with a package-manager signature key error, so validation used the repo-local Node/Vitest/oxfmt entrypoints.
- Before evidence: before this patch, the new spoofed app-id regression case would have taken the `appId` branch and matched policy context without checking `serverName`.

## Tests and validation

Which commands did you run?

- `./node_modules/.bin/oxfmt --check --threads=1 extensions/codex/src/app-server/elicitation-bridge.ts extensions/codex/src/app-server/elicitation-bridge.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/codex/src/app-server/elicitation-bridge.ts extensions/codex/src/app-server/elicitation-bridge.test.ts`
- Focused Vitest run for `extensions/codex/src/app-server/elicitation-bridge.test.ts`
- `git diff --check HEAD~1..HEAD`

What regression coverage was added or updated?

- Added coverage that an app-id plugin elicitation from an unverified MCP server is declined.
- Added coverage that a verified connector elicitation with matching app id remains accepted.

What failed before this fix, if known?

- The new unverified-MCP regression would have been accepted before this change because the `appId` branch trusted the request-provided id without source verification.

If no test was added, why not?

- Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes.

What is the highest-risk area?

- Accidentally blocking legitimate plugin app approval elicitations that carry `app_id`.

How is that risk mitigated?

- The change preserves the trusted `codex_apps` connector path.
- Plugin-owned MCP server requests still pass when `serverName` matches the app policy context.
- Regression coverage covers both the blocked spoofing path and the valid connector path.

## Current review state

What is the next action?

- Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

- CI and maintainer review.
- Maintainer may request live MCP repro proof if unit-level boundary coverage is not enough.

Which bot or reviewer comments were addressed?

- None yet.
