### PR TITLE
fix(kilocode): normalize string stop payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Providers/Kilocode: normalize single-string stop sequences into arrays before proxy streaming so Kilocode requests keep provider-compatible stop payloads. (#86082) Thanks @luoyanglang.
 - Channels/iMessage: advance the startup catchup cursor from live-handled rows after a completed catchup pass, including rows received while catchup is still running, so restarts do not replay them. (#85475) Thanks @TurboTheTurtle.
 - Tests: keep kitchen-sink plugin assertion fixtures on a configurable temp root so native Windows runs no longer skip full-surface diagnostic coverage.
 - Tests: fail Gateway startup benchmarks when a child startup never produces ready probes or process metrics instead of reporting all `n/a` samples as passing.

--- a/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
@@ -150,6 +150,17 @@ function normalizeProxyReasoningPayload(payload: unknown, thinkingLevel?: ThinkL
   }
 }
 
+function normalizeKilocodeStopPayload(payload: unknown): void {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return;
+  }
+
+  const payloadObj = payload as Record<string, unknown>;
+  if (typeof payloadObj.stop === "string") {
+    payloadObj.stop = [payloadObj.stop];
+  }
+}
+
 /** @deprecated OpenRouter provider-owned stream helper; do not use from third-party plugins. */
 export function createOpenRouterSystemCacheWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
@@ -250,6 +261,7 @@ export function createKilocodeWrapper(
       },
       (payload) => {
         normalizeProxyReasoningPayload(payload, thinkingLevel);
+        normalizeKilocodeStopPayload(payload);
       },
     );
   };

--- a/src/plugin-sdk/provider-stream.test.ts
+++ b/src/plugin-sdk/provider-stream.test.ts
@@ -185,6 +185,16 @@ describe("buildProviderStreamFamilyHooks", () => {
     expectDefaultThinkingBudget(kilocodeAutoPayload);
     expect(kilocodeAutoPayload).not.toHaveProperty("reasoning");
 
+    payloadSeed = { stop: "\n" };
+    void requireStreamFn(
+      requireWrapStreamFn(kilocodeHooks.wrapStreamFn)({
+        streamFn: baseStreamFn,
+        modelId: "deepseek/deepseek-v4-flash",
+      } as never),
+    )({ provider: "kilocode", id: "deepseek/deepseek-v4-flash" } as never, {} as never, {});
+    const kilocodeStopPayload = requirePayload(capturedPayload);
+    expect(kilocodeStopPayload.stop).toEqual(["\n"]);
+
     const moonshotHooks = MOONSHOT_THINKING_STREAM_HOOKS;
     const moonshotStream = requireStreamFn(
       requireWrapStreamFn(moonshotHooks.wrapStreamFn)({


### PR DESCRIPTION
Kilo/Kilocode rejects chat completions when OpenClaw sends `stop` as a string, causing affected turns such as cron/nested subagent runs to fail before the provider can stream a response.

Fixes #86074

## Affected surface

- `src/agents/pi-embedded-runner/proxy-stream-wrappers.ts`
  - `createKilocodeWrapper`
  - new provider-local `normalizeKilocodeStopPayload`
- `src/plugin-sdk/provider-stream.test.ts`
  - Kilocode stream-family regression coverage

## Scope

- Normalize `payload.stop` from `string` to `string[]` at the Kilocode provider-owned stream wrapper boundary.
- Leave existing array/absent/non-string values untouched.
- No new config, option, provider default, or global OpenAI payload behavior change.
- Does not touch other providers or the shared stream payload patch contract.

## Real behavior proof

Behavior or issue addressed: Kilocode wrapper transforms an outgoing chat-completion payload with `stop: "\n"` into `stop: ["\n"]` before the provider request leaves the adapter boundary.

Real environment tested: Local OpenClaw source checkout at PR head `c34ad0b6089830870247225fdd8f5312fef018a0`, running Node with `tsx` from the repository root.

Exact steps or command run after this patch: Imported `createKilocodeWrapper` from `src/agents/pi-embedded-runner/proxy-stream-wrappers.ts`, wrapped a minimal stream function that creates `{ model, stop: "\n" }`, invoked it with `{ provider: "kilocode", id: "deepseek/deepseek-v4-flash" }`, and printed the observed payload shape after the Kilocode wrapper patched it.

Evidence after fix:

```text
$ node --import tsx -e 'import { createKilocodeWrapper } from "./src/agents/pi-embedded-runner/proxy-stream-wrappers.ts"; const baseStreamFn = (model, _context, options) => { const payload = { model: model.id, stop: "\n" }; options?.onPayload?.(payload, model); console.log(JSON.stringify({ behavior: "kilocode-wrapper-stop-normalization", environment: "local OpenClaw source checkout at current PR head", inputStop: "<newline>", inputStopType: "string", observedStop: payload.stop, observedStopIsArray: Array.isArray(payload.stop) }, null, 2)); return {}; }; const stream = createKilocodeWrapper(baseStreamFn, undefined); stream({ provider: "kilocode", id: "deepseek/deepseek-v4-flash" }, {}, {});'
{
  "behavior": "kilocode-wrapper-stop-normalization",
  "environment": "local OpenClaw source checkout at current PR head",
  "inputStop": "<newline>",
  "inputStopType": "string",
  "observedStop": [
    "\n"
  ],
  "observedStopIsArray": true
}
```

Observed result after fix: The current-head Kilocode provider wrapper converts the string stop value into an array, matching Kilo's strict schema expectation and preventing the reported `expected array, received string` rejection at this adapter boundary.

What was not tested: I did not run a live Kilo gateway request with real provider credentials. The runtime helper verifies the exact outbound adapter payload transform; the source-level regression below guards it.

## Supplemental validation

RED before the fix:

```text
$ pnpm test src/plugin-sdk/provider-stream.test.ts
AssertionError: expected '\n' to deeply equal [ '\n' ]
Test Files  1 failed (1)
Tests  1 failed | 5 passed (6)
```

GREEN after the fix:

```text
$ pnpm test src/plugin-sdk/provider-stream.test.ts
Test Files  1 passed (1)
Tests  6 passed (6)
[test] passed 1 Vitest shard in 25.19s
```

Changed-surface validation:

```text
$ pnpm check:changed --base origin/main
[check:changed] lanes=core, coreTests, extensions, extensionTests
[check:changed] src/agents/pi-embedded-runner/proxy-stream-wrappers.ts: core production
[check:changed] src/plugin-sdk/provider-stream.test.ts: public core/plugin contract affects extensions
...
Import cycle check: 0 runtime value cycle(s).
```

The command exited 0.

Additional local checks:

```text
$ git diff --check origin/main..HEAD

$ gitleaks protect --staged --redact
INF 1 commits scanned.
INF no leaks found
```

## Coverage note

Push-before-open searches were rerun after syncing `origin/main` to `694d45e535dbc213f6a94b3fa3284c6df3e965d1`; all returned `[]`:

```text
gh search prs --repo openclaw/openclaw --state open "Fixes #86074"
gh search prs --repo openclaw/openclaw --state open "#86074"
gh search prs --repo openclaw/openclaw --state open "createKilocodeWrapper"
gh search prs --repo openclaw/openclaw --state open "provider-stream.ts stop"
gh search prs --repo openclaw/openclaw --state open "Kilo provider stop array"
```

The fix stays in `createKilocodeWrapper`, which is the existing provider-owned payload normalization boundary for Kilocode. It does not create a second policy surface for global stop handling.
