### PR TITLE
fix(anthropic): synthetic-auth bypass for claude-cli + Bedrock when CLAUDE_CODE_USE_BEDROCK=1

### DIFF
--- a/extensions/anthropic/cli-auth-seam.ts
+++ b/extensions/anthropic/cli-auth-seam.ts
@@ -1,4 +1,5 @@
 import { readClaudeCliCredentialsCached } from "openclaw/plugin-sdk/provider-auth";
+import { CLAUDE_CLI_USE_BEDROCK_ENV } from "./cli-constants.js";
 
 export function readClaudeCliCredentialsForSetup() {
   return readClaudeCliCredentialsCached();
@@ -10,4 +11,13 @@ export function readClaudeCliCredentialsForSetupNonInteractive() {
 
 export function readClaudeCliCredentialsForRuntime() {
   return readClaudeCliCredentialsCached({ allowKeychainPrompt: false });
+}
+
+// Claude CLI does not write Anthropic OAuth credentials when configured to
+// authenticate through Bedrock (CLAUDE_CODE_USE_BEDROCK=1); the AWS SDK chain
+// owns auth at runtime. Surface this as a separate synthetic-auth signal so
+// the Anthropic provider hook can satisfy core auth resolution without
+// requiring an Anthropic OAuth profile that will never exist.
+export function isClaudeCliBedrockAuthEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env[CLAUDE_CLI_USE_BEDROCK_ENV]?.trim() === "1";
 }

--- a/extensions/anthropic/cli-constants.ts
+++ b/extensions/anthropic/cli-constants.ts
@@ -1,4 +1,9 @@
 export const CLAUDE_CLI_BACKEND_ID = "claude-cli";
+// Synthetic-auth marker used when an agent's runtime is the Claude CLI and the
+// CLI is configured to authenticate through Bedrock (CLAUDE_CODE_USE_BEDROCK=1)
+// rather than Anthropic OAuth. Marker only — never a real credential.
+export const CLAUDE_CLI_BEDROCK_AUTH_MARKER = "claude-cli-bedrock";
+export const CLAUDE_CLI_USE_BEDROCK_ENV = "CLAUDE_CODE_USE_BEDROCK";
 export const CLAUDE_CLI_DEFAULT_MODEL_REF = `${CLAUDE_CLI_BACKEND_ID}/claude-opus-4-7`;
 export const CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS = [
   CLAUDE_CLI_DEFAULT_MODEL_REF,

--- a/extensions/anthropic/cli-shared.ts
+++ b/extensions/anthropic/cli-shared.ts
@@ -7,10 +7,12 @@ import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coe
 import { CLAUDE_CLI_BACKEND_ID } from "./cli-constants.js";
 export {
   CLAUDE_CLI_BACKEND_ID,
+  CLAUDE_CLI_BEDROCK_AUTH_MARKER,
   CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS,
   CLAUDE_CLI_DEFAULT_MODEL_REF,
   CLAUDE_CLI_MODEL_ALIASES,
   CLAUDE_CLI_SESSION_ID_FIELDS,
+  CLAUDE_CLI_USE_BEDROCK_ENV,
 } from "./cli-constants.js";
 
 // Claude Code honors provider-routing, auth, and config-root env before

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -8,17 +8,21 @@ import {
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { readClaudeCliCredentialsForSetupMock, readClaudeCliCredentialsForRuntimeMock } = vi.hoisted(
-  () => ({
-    readClaudeCliCredentialsForSetupMock: vi.fn(),
-    readClaudeCliCredentialsForRuntimeMock: vi.fn(),
-  }),
-);
+const {
+  readClaudeCliCredentialsForSetupMock,
+  readClaudeCliCredentialsForRuntimeMock,
+  isClaudeCliBedrockAuthEnabledMock,
+} = vi.hoisted(() => ({
+  readClaudeCliCredentialsForSetupMock: vi.fn(),
+  readClaudeCliCredentialsForRuntimeMock: vi.fn(),
+  isClaudeCliBedrockAuthEnabledMock: vi.fn(() => false),
+}));
 
 vi.mock("./cli-auth-seam.js", () => {
   return {
     readClaudeCliCredentialsForSetup: readClaudeCliCredentialsForSetupMock,
     readClaudeCliCredentialsForRuntime: readClaudeCliCredentialsForRuntimeMock,
+    isClaudeCliBedrockAuthEnabled: isClaudeCliBedrockAuthEnabledMock,
   };
 });
 
@@ -27,6 +31,8 @@ import anthropicPlugin from "./index.js";
 beforeEach(() => {
   readClaudeCliCredentialsForSetupMock.mockReset();
   readClaudeCliCredentialsForRuntimeMock.mockReset();
+  isClaudeCliBedrockAuthEnabledMock.mockReset();
+  isClaudeCliBedrockAuthEnabledMock.mockReturnValue(false);
 });
 
 afterAll(() => {
@@ -674,6 +680,47 @@ describe("anthropic provider replay hooks", () => {
       mode: "token",
       expiresAt: 123,
     });
+  });
+
+  it("resolves anthropic synthetic auth via Claude CLI Bedrock marker when CLAUDE_CODE_USE_BEDROCK=1", async () => {
+    isClaudeCliBedrockAuthEnabledMock.mockReturnValue(true);
+
+    const provider = await registerSingleProviderPlugin(anthropicPlugin);
+
+    expect(
+      provider.resolveSyntheticAuth?.({
+        provider: "anthropic",
+      } as never),
+    ).toEqual({
+      apiKey: "claude-cli-bedrock",
+      source: "Claude CLI Bedrock auth (CLAUDE_CODE_USE_BEDROCK=1)",
+      mode: "api-key",
+    });
+    expect(readClaudeCliCredentialsForRuntimeMock).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined for anthropic synthetic auth when CLAUDE_CODE_USE_BEDROCK is not set", async () => {
+    isClaudeCliBedrockAuthEnabledMock.mockReturnValue(false);
+
+    const provider = await registerSingleProviderPlugin(anthropicPlugin);
+
+    expect(
+      provider.resolveSyntheticAuth?.({
+        provider: "anthropic",
+      } as never),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for unrelated providers even with CLAUDE_CODE_USE_BEDROCK=1", async () => {
+    isClaudeCliBedrockAuthEnabledMock.mockReturnValue(true);
+
+    const provider = await registerSingleProviderPlugin(anthropicPlugin);
+
+    expect(
+      provider.resolveSyntheticAuth?.({
+        provider: "openai",
+      } as never),
+    ).toBeUndefined();
   });
 
   it("stores a claude-cli auth profile during anthropic cli migration", async () => {

--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -127,7 +127,8 @@
     }
   },
   "cliBackends": ["claude-cli"],
-  "syntheticAuthRefs": ["claude-cli"],
+  "syntheticAuthRefs": ["anthropic", "claude-cli"],
+  "nonSecretAuthMarkers": ["claude-cli-bedrock"],
   "providerAuthEnvVars": {
     "anthropic": ["ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"]
   },

--- a/extensions/anthropic/provider-discovery.ts
+++ b/extensions/anthropic/provider-discovery.ts
@@ -1,7 +1,12 @@
 import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
-import { readClaudeCliCredentialsForRuntime } from "./cli-auth-seam.js";
+import {
+  isClaudeCliBedrockAuthEnabled,
+  readClaudeCliCredentialsForRuntime,
+} from "./cli-auth-seam.js";
 
+const ANTHROPIC_PROVIDER_ID = "anthropic";
 const CLAUDE_CLI_BACKEND_ID = "claude-cli";
+const CLAUDE_CLI_BEDROCK_AUTH_MARKER = "claude-cli-bedrock";
 
 function resolveClaudeCliSyntheticAuth() {
   const credential = readClaudeCliCredentialsForRuntime();
@@ -23,13 +28,34 @@ function resolveClaudeCliSyntheticAuth() {
       };
 }
 
+function resolveClaudeCliBedrockSyntheticAuth() {
+  if (!isClaudeCliBedrockAuthEnabled()) {
+    return undefined;
+  }
+  return {
+    apiKey: CLAUDE_CLI_BEDROCK_AUTH_MARKER,
+    source: "Claude CLI Bedrock auth (CLAUDE_CODE_USE_BEDROCK=1)",
+    mode: "api-key" as const,
+  };
+}
+
 const anthropicProviderDiscovery: ProviderPlugin = {
   id: CLAUDE_CLI_BACKEND_ID,
   label: "Claude CLI",
   docsPath: "/providers/models",
   auth: [],
-  resolveSyntheticAuth: ({ provider }) =>
-    provider === CLAUDE_CLI_BACKEND_ID ? resolveClaudeCliSyntheticAuth() : undefined,
+  resolveSyntheticAuth: ({ provider }) => {
+    if (provider === CLAUDE_CLI_BACKEND_ID) {
+      return resolveClaudeCliSyntheticAuth();
+    }
+    // Post-2026.5.21 model refs canonicalize as `anthropic/<model>` even when
+    // the agent's runtime is the Claude CLI; allow the Bedrock-via-CLI signal
+    // to satisfy auth resolution for the `anthropic` provider id too.
+    if (provider === ANTHROPIC_PROVIDER_ID) {
+      return resolveClaudeCliBedrockSyntheticAuth();
+    }
+    return undefined;
+  },
 };
 
 export default anthropicProviderDiscovery;

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -32,6 +32,7 @@ import { buildClaudeCliCatalogEntries } from "./cli-catalog.js";
 import { buildAnthropicCliMigrationResult } from "./cli-migration.js";
 import {
   CLAUDE_CLI_BACKEND_ID,
+  CLAUDE_CLI_BEDROCK_AUTH_MARKER,
   CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS,
   CLAUDE_CLI_DEFAULT_MODEL_REF,
 } from "./cli-shared.js";
@@ -499,6 +500,22 @@ function resolveClaudeCliSyntheticAuth() {
       };
 }
 
+// When Claude CLI is the agent's runtime AND CLAUDE_CODE_USE_BEDROCK=1, the CLI
+// authenticates through the AWS SDK chain instead of writing an Anthropic OAuth
+// credential to ~/.claude/.credentials.json. Synthesize a non-secret marker so
+// core auth resolution treats the provider as available; runtime calls are
+// owned by the Claude CLI process itself, which carries Bedrock auth forward.
+function resolveClaudeCliBedrockSyntheticAuth() {
+  if (!claudeCliAuth.isClaudeCliBedrockAuthEnabled()) {
+    return undefined;
+  }
+  return {
+    apiKey: CLAUDE_CLI_BEDROCK_AUTH_MARKER,
+    source: "Claude CLI Bedrock auth (CLAUDE_CODE_USE_BEDROCK=1)",
+    mode: "api-key" as const,
+  };
+}
+
 async function runAnthropicCliMigration(ctx: ProviderAuthContext): Promise<ProviderAuthResult> {
   const credential = claudeCliAuth.readClaudeCliCredentialsForSetup();
   if (!credential) {
@@ -665,10 +682,21 @@ export function buildAnthropicProvider(): ProviderPlugin {
       );
     },
     normalizeResolvedModel: (ctx) => normalizeAnthropicResolvedModel(ctx),
-    resolveSyntheticAuth: ({ provider }) =>
-      normalizeLowercaseStringOrEmpty(provider) === CLAUDE_CLI_BACKEND_ID
-        ? resolveClaudeCliSyntheticAuth()
-        : undefined,
+    resolveSyntheticAuth: ({ provider }) => {
+      const normalized = normalizeLowercaseStringOrEmpty(provider);
+      if (normalized === CLAUDE_CLI_BACKEND_ID) {
+        return resolveClaudeCliSyntheticAuth();
+      }
+      // Post-2026.5.21 model refs canonicalize as `anthropic/<model>` even when
+      // the agent's runtime is the Claude CLI, so the synthetic-auth hook fires
+      // for `anthropic` rather than `claude-cli`. Honor the Bedrock-via-CLI
+      // path here so Bedrock-mode Claude CLI runs do not require an Anthropic
+      // OAuth profile that does not exist on Bedrock-only hosts.
+      if (normalized === PROVIDER_ID) {
+        return resolveClaudeCliBedrockSyntheticAuth();
+      }
+      return undefined;
+    },
     // Publish Claude CLI rows through the provider catalog hook.
     augmentModelCatalog: () => buildClaudeCliCatalogEntries(),
     buildReplayPolicy: buildAnthropicReplayPolicy,


### PR DESCRIPTION
## Summary

The post-2026.5.21 model-ref canonicalization shape (`anthropic/<model>` with `agentRuntime: { id: "claude-cli" }`) breaks auth resolution for Bedrock-via-Claude-CLI multi-agent setups. Default agent works through a different code path; non-default agents fail at every Telegram (and other channel) inbound with `No API key found for provider 'anthropic'`, fall back to `openrouter/auto`, and then bail out with `Preflight compaction required but failed: no real conversation messages`.

This patch lets the synthetic-auth hook in `extensions/anthropic/register.runtime.ts` (and the duplicate in `extensions/anthropic/provider-discovery.ts`) fire a Bedrock-aware branch for `provider === "anthropic"` when `CLAUDE_CODE_USE_BEDROCK=1`. It returns a non-secret `claude-cli-bedrock` marker so core treats auth as available; the Claude CLI process itself carries Bedrock auth forward via the AWS SDK chain at exec time.

Mirrors the pattern from #68964 (Bedrock-direct provider + `auth: "aws-sdk"`): when no real Anthropic OAuth credential will ever exist on the host, surface a synthetic marker rather than rejecting the auth lookup.

## Root cause

`extensions/anthropic/register.runtime.ts` (and `extensions/anthropic/provider-discovery.ts`) gate `resolveClaudeCliSyntheticAuth()` on `provider === CLAUDE_CLI_BACKEND_ID` — which is `"claude-cli"`. After the model-ref canonicalization landed, the hook is invoked with `provider === "anthropic"` for runs whose `agentRuntime.id === "claude-cli"`, so the synthetic-auth path no longer fires. The Anthropic resolver then demands a real `auth-profiles.json` entry with credentials read from `~/.claude/.credentials.json`. With `CLAUDE_CODE_USE_BEDROCK=1`, Claude CLI never writes that file (AWS SDK chain owns auth instead), so the lookup fails.

Files:
- `extensions/anthropic/register.runtime.ts` — the runtime hook
- `extensions/anthropic/provider-discovery.ts` — the lightweight discovery duplicate

## Changes

- New helper `isClaudeCliBedrockAuthEnabled()` in `extensions/anthropic/cli-auth-seam.ts` reads `CLAUDE_CODE_USE_BEDROCK` (env-injectable for tests).
- New marker `CLAUDE_CLI_BEDROCK_AUTH_MARKER = "claude-cli-bedrock"` in `extensions/anthropic/cli-constants.ts`, re-exported through `cli-shared.ts`.
- New `resolveClaudeCliBedrockSyntheticAuth()` in both `register.runtime.ts` and `provider-discovery.ts`. Returns `{ apiKey: marker, source: "Claude CLI Bedrock auth (CLAUDE_CODE_USE_BEDROCK=1)", mode: "api-key" }` when the env var is set; `undefined` otherwise.
- `resolveSyntheticAuth` in both files now returns the bedrock branch for `provider === "anthropic"` (post-2026.5.21 ref shape) while preserving the existing `provider === "claude-cli"` branch (legacy ref shape) intact.
- Manifest registers the marker in `nonSecretAuthMarkers` and adds `anthropic` to `syntheticAuthRefs` so cold-path discovery probes the new branch.

## Tests

`extensions/anthropic/index.test.ts`:

- New: bedrock branch returns the marker when `isClaudeCliBedrockAuthEnabled()` is true and `provider === "anthropic"`
- New: returns `undefined` for `provider === "anthropic"` when the env helper returns false
- New: returns `undefined` for unrelated providers (e.g. `"openai"`) regardless of env
- Existing: claude-cli OAuth / token synthetic-auth paths still resolve correctly

## Real behavior proof

Behavior addressed: Bedrock-via-Claude-CLI multi-agent setup, non-default agents fail every channel inbound at auth resolution with `No API key found for provider 'anthropic'`, downstream `Preflight compaction required but failed: no real conversation messages`.

Real environment tested: macOS host with `CLAUDE_CODE_USE_BEDROCK=1` and `AWS_PROFILE` configured against a Bedrock-enabled account; OpenClaw multi-agent config with Claude CLI runtime override; Telegram channel inbound dispatched to a non-default agent.

Exact steps or command run after this patch:

```
node scripts/run-vitest.mjs run extensions/anthropic/
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo
pnpm exec oxfmt --check --threads=1 <changed files>
node scripts/run-oxlint.mjs <changed files>
```

Evidence after fix:

- `node scripts/run-vitest.mjs run extensions/anthropic/`: `Test Files 6 passed (6) | Tests 90 passed (90)`
- `tsgo:core`, `tsgo:core:test`, `tsgo:extensions`, `tsgo:extensions:test`: all exit 0
- `oxfmt --check`: `All matched files use the correct format.`
- `oxlint`: exit 0
- Pre-fix repro: stashed source changes, kept new tests; new bedrock test fails: `expected undefined to deeply equal { apiKey: 'claude-cli-bedrock', ... }`. Restoring source fix flips test green.

Observed result after fix: Telegram inbound to non-default agent reaches the Claude CLI dispatch path; `No API key found for provider 'anthropic'` no longer appears in gateway logs for these dispatches. AWS SDK chain (via `AWS_PROFILE`) authenticates Claude CLI to Bedrock at exec time as expected.

What was not tested: the `pnpm build` lane (omitted because the change is plugin-source-only and doesn't touch loader, registry, activation, or public-artifact code; type-checks via tsgo lanes cover ESM/strict typing). Crabbox/Testbox full-lane runs are deferred to maintainer review.

## Regression context

- Regressed in: 2026.5.21 model-ref canonicalization — `anthropic/<model>` with `agentRuntime: { id: "claude-cli" }`.
- Precedent: #68964 (Bedrock-direct + `auth: "aws-sdk"`) established the synthetic-marker pattern for "no real key, runtime owns auth."
