### PR TITLE
[Fix] Deliver restart recovery replies

### DIFF
--- a/extensions/feishu/src/bot-sender-name.test.ts
+++ b/extensions/feishu/src/bot-sender-name.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveFeishuSenderName } from "./bot-sender-name.js";
+import { FeishuConfigSchema } from "./config-schema.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
 const createFeishuClientMock = vi.hoisted(() => vi.fn());
@@ -16,7 +17,7 @@ const account = {
   appId: "app-id",
   appSecret: "secret",
   domain: "feishu",
-  config: {},
+  config: FeishuConfigSchema.parse({}),
 } satisfies ResolvedFeishuAccount;
 
 function mockUserNames(...names: string[]): ReturnType<typeof vi.fn> {

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -37,6 +37,9 @@ const state = vi.hoisted(() => ({
   clearAgentRunContextMock: vi.fn(),
   updateSessionStoreAfterAgentRunMock: vi.fn(),
   deliverAgentCommandResultMock: vi.fn(),
+  resolveAgentDeliveryPlanMock: vi.fn(),
+  resolveAgentOutboundTargetMock: vi.fn(),
+  resolveMessageChannelSelectionMock: vi.fn(),
   trajectoryRecordEventMock: vi.fn(),
   trajectoryFlushMock: vi.fn(async () => undefined),
   persistSessionEntryMock: vi.fn(async (..._args: unknown[]): Promise<unknown> => undefined),
@@ -141,6 +144,7 @@ vi.mock("./harness/runtime-plugin.js", () => ({
 }));
 
 vi.mock("../acp/policy.js", () => ({
+  isAcpEnabledByPolicy: () => true,
   resolveAcpAgentPolicyError: (...args: unknown[]) => state.resolveAcpAgentPolicyErrorMock(...args),
   resolveAcpDispatchPolicyError: (...args: unknown[]) =>
     state.resolveAcpDispatchPolicyErrorMock(...args),
@@ -212,7 +216,7 @@ vi.mock("../config/sessions.js", () => ({
   mergeSessionEntry: (a: unknown, b: unknown) => ({ ...(a as object), ...(b as object) }),
   updateSessionStore: vi.fn(
     async (_path: string, fn: (store: Record<string, unknown>) => unknown) => {
-      const store = (state.sessionStoreMock ?? {}) as Record<string, unknown>;
+      const store: Record<string, unknown> = {};
       return fn(store);
     },
   ),
@@ -241,6 +245,20 @@ vi.mock("../infra/agent-events.js", () => ({
 
 vi.mock("../infra/outbound/session-context.js", () => ({
   buildOutboundSessionContext: () => ({}),
+}));
+
+vi.mock("../infra/outbound/agent-delivery.js", () => ({
+  resolveAgentDeliveryPlan: (...args: unknown[]) => state.resolveAgentDeliveryPlanMock(...args),
+  resolveAgentOutboundTarget: (...args: unknown[]) => state.resolveAgentOutboundTargetMock(...args),
+}));
+
+vi.mock("../infra/outbound/channel-selection.js", () => ({
+  resolveMessageChannelSelection: (...args: unknown[]) =>
+    state.resolveMessageChannelSelectionMock(...args),
+}));
+
+vi.mock("../infra/skills-remote.js", () => ({
+  getRemoteSkillEligibility: () => ({ eligible: false }),
 }));
 
 vi.mock("../logging/subsystem.js", () => ({
@@ -290,7 +308,7 @@ vi.mock("../sessions/send-policy.js", () => ({
   resolveSendPolicy: () => "allow",
 }));
 
-vi.mock("../../packages/terminal-core/src/ansi.js", () => ({
+vi.mock("../terminal/ansi.js", () => ({
   sanitizeForLog: (s: string) => s,
 }));
 
@@ -304,6 +322,8 @@ vi.mock("../trajectory/runtime.js", () => ({
 }));
 
 vi.mock("../utils/message-channel.js", () => ({
+  INTERNAL_MESSAGE_CHANNEL: "internal",
+  isDeliverableMessageChannel: (value: string) => value !== "internal",
   resolveMessageChannel: () => "test",
 }));
 
@@ -317,11 +337,11 @@ vi.mock("./agent-scope.js", () => ({
   resolveAutoFallbackPrimaryProbe: () => undefined,
   resolveAgentConfig: () => undefined,
   resolveAgentDir: () => "/tmp/agent",
+  resolveDefaultAgentId: () => "default",
   resolveEffectiveModelFallbacks: state.resolveEffectiveModelFallbacksMock,
   resolveSessionAgentIds: () => ({ defaultAgentId: "default", sessionAgentId: "default" }),
   resolveSessionAgentId: () => "default",
-  resolveAgentSkillsFilter: (cfg: unknown, agentId: string) =>
-    state.resolveAgentSkillsFilterMock(cfg, agentId),
+  resolveAgentSkillsFilter: () => undefined,
   resolveAgentWorkspaceDir: () => "/tmp/workspace",
 }));
 
@@ -881,6 +901,43 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       version: 0,
     });
     state.deliverAgentCommandResultMock.mockResolvedValue(undefined);
+    state.resolveAgentOutboundTargetMock.mockImplementation(
+      (params: { plan?: { resolvedTo?: string }; targetMode?: string }) => ({
+        resolvedTarget: null,
+        resolvedTo: params.plan?.resolvedTo,
+        targetMode: params.targetMode ?? "implicit",
+      }),
+    );
+    state.resolveMessageChannelSelectionMock.mockRejectedValue(new Error("channel required"));
+    state.resolveAgentDeliveryPlanMock.mockImplementation(
+      (params: {
+        accountId?: string;
+        explicitThreadId?: string | number;
+        explicitTo?: string;
+        requestedChannel?: string;
+        sessionEntry?: SessionEntry;
+      }) => {
+        const context = params.sessionEntry?.deliveryContext;
+        const channel =
+          params.requestedChannel ??
+          context?.channel ??
+          params.sessionEntry?.lastChannel ??
+          "internal";
+        const to = params.explicitTo ?? context?.to ?? params.sessionEntry?.lastTo;
+        const accountId =
+          params.accountId ?? context?.accountId ?? params.sessionEntry?.lastAccountId;
+        const threadId =
+          params.explicitThreadId ?? context?.threadId ?? params.sessionEntry?.lastThreadId;
+        return {
+          baseDelivery: {},
+          resolvedChannel: channel,
+          resolvedTo: to,
+          resolvedAccountId: accountId,
+          resolvedThreadId: threadId,
+          deliveryTargetMode: params.explicitTo ? "explicit" : to ? "implicit" : undefined,
+        };
+      },
+    );
     state.updateSessionStoreAfterAgentRunMock.mockResolvedValue(undefined);
     state.trajectoryFlushMock.mockResolvedValue(undefined);
     state.prepareInternalSessionEffectsTranscriptMock.mockResolvedValue(
@@ -968,7 +1025,11 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       skipInitialSessionTouch: true,
     });
 
-    expect(state.persistSessionEntryMock).not.toHaveBeenCalled();
+    const touchWrites = state.persistSessionEntryMock.mock.calls.filter((call) => {
+      const entry = (call[0] as { entry?: Record<string, unknown> } | undefined)?.entry;
+      return entry?.lastInteractionAt !== undefined;
+    });
+    expect(touchWrites).toHaveLength(0);
     expect(state.updateSessionStoreAfterAgentRunMock).toHaveBeenCalledTimes(1);
   });
 
@@ -1076,12 +1137,461 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       skipInitialSessionTouch: true,
     });
 
-    const touchWrite = mockCallArg(state.persistSessionEntryMock) as {
-      entry?: Record<string, unknown>;
-    };
-    expect(touchWrite.entry?.thinkingLevel).toBe("medium");
-    expect(touchWrite.entry?.lastInteractionAt).toBeDefined();
+    const touchWrite = state.persistSessionEntryMock.mock.calls.find((call) => {
+      const entry = (call[0] as { entry?: Record<string, unknown> } | undefined)?.entry;
+      return entry?.thinkingLevel === "medium";
+    })?.[0] as { entry?: Record<string, unknown> } | undefined;
+    expect(touchWrite?.entry?.lastInteractionAt).toBeDefined();
     expect(state.updateSessionStoreAfterAgentRunMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists and clears current run delivery context for restart recovery", async () => {
+    setupSingleAttemptFallback();
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 1,
+    };
+    state.sessionEntryMock = sessionEntry;
+    state.sessionStoreMock = { "agent:main:main": sessionEntry };
+    state.storePathMock = "/tmp/openclaw-sessions.json";
+    state.deliverAgentCommandResultMock.mockResolvedValue({ deliverySucceeded: true });
+
+    await agentCommand({
+      message: "hello",
+      channel: "discord",
+      to: "discord:dm:123",
+      accountId: "main",
+      threadId: "reply-1",
+      deliver: true,
+    });
+
+    const persistedContexts = state.persistSessionEntryMock.mock.calls.map((call) => {
+      const params = call[0] as { entry?: SessionEntry };
+      return params.entry?.restartRecoveryDeliveryContext;
+    });
+    expect(persistedContexts).toContainEqual({
+      channel: "discord",
+      to: "discord:dm:123",
+      accountId: "main",
+      threadId: "reply-1",
+    });
+    const stored = (state.sessionStoreMock as Record<string, SessionEntry>)["agent:main:main"];
+    expect(stored?.restartRecoveryDeliveryContext).toBeUndefined();
+  });
+
+  it("preserves parsed explicit target threads for restart recovery", async () => {
+    setupSingleAttemptFallback();
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 1,
+    };
+    state.sessionEntryMock = sessionEntry;
+    state.sessionStoreMock = { "agent:main:main": sessionEntry };
+    state.storePathMock = "/tmp/openclaw-sessions.json";
+    state.deliverAgentCommandResultMock.mockResolvedValue({ deliverySucceeded: true });
+    state.resolveAgentDeliveryPlanMock.mockReturnValueOnce({
+      baseDelivery: {
+        mode: "explicit",
+        threadId: "thread-1",
+        threadIdSource: "explicit",
+      },
+      resolvedChannel: "discord",
+      resolvedTo: "discord:channel:general",
+      resolvedAccountId: "main",
+      resolvedThreadId: "thread-1",
+      deliveryTargetMode: "explicit",
+    });
+
+    await agentCommand({
+      message: "hello",
+      channel: "discord",
+      to: "discord:channel:general/thread:thread-1",
+      accountId: "main",
+      deliver: true,
+    });
+
+    const persistedContexts = state.persistSessionEntryMock.mock.calls.map((call) => {
+      const params = call[0] as { entry?: SessionEntry };
+      return params.entry?.restartRecoveryDeliveryContext;
+    });
+    expect(persistedContexts).toContainEqual({
+      channel: "discord",
+      to: "discord:channel:general",
+      accountId: "main",
+      threadId: "thread-1",
+    });
+  });
+
+  it("does not inherit a stale thread when restart recovery uses an explicit target", async () => {
+    setupSingleAttemptFallback();
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 1,
+      lastThreadId: "stale-thread",
+    };
+    state.sessionEntryMock = sessionEntry;
+    state.sessionStoreMock = { "agent:main:main": sessionEntry };
+    state.storePathMock = "/tmp/openclaw-sessions.json";
+    state.deliverAgentCommandResultMock.mockResolvedValue({ deliverySucceeded: true });
+
+    await agentCommand({
+      message: "hello",
+      channel: "discord",
+      to: "discord:dm:123",
+      accountId: "main",
+      deliver: true,
+    });
+
+    const persistedContexts = state.persistSessionEntryMock.mock.calls.map((call) => {
+      const params = call[0] as { entry?: SessionEntry };
+      return params.entry?.restartRecoveryDeliveryContext;
+    });
+    expect(persistedContexts).toContainEqual({
+      channel: "discord",
+      to: "discord:dm:123",
+      accountId: "main",
+    });
+  });
+
+  it("persists implicit session delivery route for restart recovery", async () => {
+    setupSingleAttemptFallback();
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 1,
+      deliveryContext: {
+        channel: "discord",
+        to: "discord:channel:general",
+        accountId: "main",
+        threadId: "thread-1",
+      },
+    };
+    state.sessionEntryMock = sessionEntry;
+    state.sessionStoreMock = { "agent:main:main": sessionEntry };
+    state.storePathMock = "/tmp/openclaw-sessions.json";
+    state.deliverAgentCommandResultMock.mockResolvedValue({ deliverySucceeded: true });
+
+    await agentCommand({
+      message: "hello",
+      sessionKey: "agent:main:main",
+      deliver: true,
+    });
+
+    const persistedContexts = state.persistSessionEntryMock.mock.calls.map((call) => {
+      const params = call[0] as { entry?: SessionEntry };
+      return params.entry?.restartRecoveryDeliveryContext;
+    });
+    expect(persistedContexts).toContainEqual({
+      channel: "discord",
+      to: "discord:channel:general",
+      accountId: "main",
+      threadId: "thread-1",
+    });
+    expect(state.resolveAgentDeliveryPlanMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        explicitTo: undefined,
+        requestedChannel: undefined,
+        sessionEntry: expect.objectContaining({
+          deliveryContext: expect.objectContaining({ to: "discord:channel:general" }),
+        }),
+        wantsDelivery: true,
+      }),
+    );
+  });
+
+  it("persists default target delivery route for restart recovery", async () => {
+    setupSingleAttemptFallback();
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 1,
+    };
+    state.sessionEntryMock = sessionEntry;
+    state.sessionStoreMock = { "agent:main:main": sessionEntry };
+    state.storePathMock = "/tmp/openclaw-sessions.json";
+    state.deliverAgentCommandResultMock.mockResolvedValue({ deliverySucceeded: true });
+    state.resolveMessageChannelSelectionMock.mockResolvedValue({
+      channel: "discord",
+      configured: ["discord"],
+      source: "single-configured",
+    });
+    state.resolveAgentOutboundTargetMock.mockReturnValue({
+      resolvedTarget: { ok: true, to: "discord:channel:default" },
+      resolvedTo: "discord:channel:default",
+      targetMode: "implicit",
+    });
+
+    await agentCommand({
+      message: "hello",
+      sessionKey: "agent:main:main",
+      deliver: true,
+    });
+
+    const persistedContexts = state.persistSessionEntryMock.mock.calls.map((call) => {
+      const params = call[0] as { entry?: SessionEntry };
+      return params.entry?.restartRecoveryDeliveryContext;
+    });
+    expect(persistedContexts).toContainEqual({
+      channel: "discord",
+      to: "discord:channel:default",
+    });
+  });
+
+  it("does not overwrite another active run's restart recovery context", async () => {
+    setupSingleAttemptFallback();
+    state.runAgentAttemptMock.mockResolvedValue(makeEmptyResult("openai", "gpt-5.4"));
+    const staleEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 1,
+    };
+    const laterRunEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 2,
+      restartRecoveryDeliveryContext: {
+        channel: "discord",
+        to: "discord:dm:456",
+        accountId: "main",
+      },
+      restartRecoveryDeliveryRunId: "later-run",
+    };
+    const sessionStore: Record<string, SessionEntry> = {
+      "agent:main:main": laterRunEntry,
+    };
+    state.sessionEntryMock = staleEntry;
+    state.sessionStoreMock = sessionStore;
+    state.storePathMock = "/tmp/openclaw-sessions.json";
+
+    await agentCommand({
+      message: "hello",
+      sessionKey: "agent:main:main",
+      channel: "discord",
+      to: "discord:dm:123",
+      accountId: "main",
+      deliver: true,
+      runId: "stale-run",
+    });
+
+    expect(sessionStore["agent:main:main"]?.restartRecoveryDeliveryContext).toEqual(
+      laterRunEntry.restartRecoveryDeliveryContext,
+    );
+    expect(sessionStore["agent:main:main"]?.restartRecoveryDeliveryRunId).toBe("later-run");
+  });
+
+  it("does not clear another active run's restart recovery context", async () => {
+    setupSingleAttemptFallback();
+    state.runAgentAttemptMock.mockResolvedValue(makeEmptyResult("openai", "gpt-5.4"));
+    const staleEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 1,
+    };
+    const laterRunEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 2,
+      restartRecoveryDeliveryContext: {
+        channel: "discord",
+        to: "discord:dm:456",
+        accountId: "main",
+      },
+      restartRecoveryDeliveryRunId: "later-run",
+    };
+    const sessionStore: Record<string, SessionEntry> = {
+      "agent:main:main": laterRunEntry,
+    };
+    state.sessionEntryMock = staleEntry;
+    state.sessionStoreMock = sessionStore;
+    state.storePathMock = "/tmp/openclaw-sessions.json";
+
+    await agentCommand({
+      message: "hello",
+      sessionKey: "agent:main:main",
+      deliver: true,
+      runId: "stale-run",
+    });
+
+    expect(sessionStore["agent:main:main"]?.restartRecoveryDeliveryContext).toEqual(
+      laterRunEntry.restartRecoveryDeliveryContext,
+    );
+    expect(sessionStore["agent:main:main"]?.restartRecoveryDeliveryRunId).toBe("later-run");
+  });
+
+  it("keeps current run delivery context when restart marker wins the cleanup race", async () => {
+    setupSingleAttemptFallback();
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 1,
+    };
+    const sessionStore: Record<string, SessionEntry> = { "agent:main:main": sessionEntry };
+    state.sessionEntryMock = sessionEntry;
+    state.sessionStoreMock = sessionStore;
+    state.storePathMock = "/tmp/openclaw-sessions.json";
+    state.deliverAgentCommandResultMock.mockImplementation(async () => {
+      const current = sessionStore["agent:main:main"];
+      if (current) {
+        current.abortedLastRun = true;
+      }
+      return { deliverySucceeded: false };
+    });
+
+    await agentCommand({
+      message: "hello",
+      channel: "discord",
+      to: "discord:dm:123",
+      accountId: "main",
+      deliver: true,
+    });
+
+    expect(sessionStore["agent:main:main"]?.abortedLastRun).toBe(true);
+    expect(state.persistSessionEntryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entry: expect.objectContaining({
+          restartRecoveryDeliveryContext: {
+            channel: "discord",
+            to: "discord:dm:123",
+            accountId: "main",
+          },
+          restartRecoveryDeliveryRunId: "session-1",
+        }),
+      }),
+    );
+  });
+
+  it("does not recreate a deleted session entry during restart recovery cleanup", async () => {
+    setupSingleAttemptFallback();
+    state.runAgentAttemptMock.mockResolvedValue(makeEmptyResult("openai", "gpt-5.4"));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 1,
+    };
+    const sessionStore: Record<string, SessionEntry> = { "agent:main:main": sessionEntry };
+    state.sessionEntryMock = sessionEntry;
+    state.sessionStoreMock = sessionStore;
+    state.storePathMock = "/tmp/openclaw-sessions.json";
+    state.deliverAgentCommandResultMock.mockImplementation(async () => {
+      delete sessionStore["agent:main:main"];
+      return { deliverySucceeded: true };
+    });
+
+    await agentCommand({
+      message: "hello",
+      channel: "discord",
+      to: "discord:dm:123",
+      accountId: "main",
+      deliver: true,
+    });
+
+    expect(sessionStore["agent:main:main"]).toBeUndefined();
+  });
+
+  it("does not clear restart recovery context from a rotated session entry", async () => {
+    setupSingleAttemptFallback();
+    state.runAgentAttemptMock.mockResolvedValue(makeEmptyResult("openai", "gpt-5.4"));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 1,
+    };
+    const rotatedEntry: SessionEntry = {
+      sessionId: "session-2",
+      updatedAt: 2,
+      restartRecoveryDeliveryContext: {
+        channel: "discord",
+        to: "discord:dm:456",
+        accountId: "main",
+      },
+    };
+    const sessionStore: Record<string, SessionEntry> = { "agent:main:main": sessionEntry };
+    state.sessionEntryMock = sessionEntry;
+    state.sessionStoreMock = sessionStore;
+    state.storePathMock = "/tmp/openclaw-sessions.json";
+    state.deliverAgentCommandResultMock.mockImplementation(async () => {
+      sessionStore["agent:main:main"] = rotatedEntry;
+      return { deliverySucceeded: true };
+    });
+
+    await agentCommand({
+      message: "hello",
+      channel: "discord",
+      to: "discord:dm:123",
+      accountId: "main",
+      deliver: true,
+    });
+
+    expect(sessionStore["agent:main:main"]).toEqual(rotatedEntry);
+  });
+
+  it("does not clear restart recovery context from another active run in the same session", async () => {
+    setupSingleAttemptFallback();
+    state.runAgentAttemptMock.mockResolvedValue(makeEmptyResult("openai", "gpt-5.4"));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 1,
+    };
+    const laterRunEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 2,
+      restartRecoveryDeliveryContext: {
+        channel: "discord",
+        to: "discord:dm:456",
+        accountId: "main",
+      },
+      restartRecoveryDeliveryRunId: "later-run",
+    };
+    const sessionStore: Record<string, SessionEntry> = { "agent:main:main": sessionEntry };
+    state.sessionEntryMock = sessionEntry;
+    state.sessionStoreMock = sessionStore;
+    state.storePathMock = "/tmp/openclaw-sessions.json";
+    state.deliverAgentCommandResultMock.mockImplementation(async () => {
+      sessionStore["agent:main:main"] = laterRunEntry;
+      return { deliverySucceeded: false };
+    });
+
+    await agentCommand({
+      message: "hello",
+      channel: "discord",
+      to: "discord:dm:123",
+      accountId: "main",
+      deliver: true,
+    });
+
+    expect(sessionStore["agent:main:main"]).toEqual(laterRunEntry);
+  });
+
+  it("stores pending final delivery with the current run delivery context", async () => {
+    setupSingleAttemptFallback();
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 1,
+    };
+    state.sessionEntryMock = sessionEntry;
+    state.sessionStoreMock = { "agent:main:main": sessionEntry };
+    state.storePathMock = "/tmp/openclaw-sessions.json";
+    state.deliverAgentCommandResultMock.mockResolvedValue({ deliverySucceeded: false });
+
+    await agentCommand({
+      message: "hello",
+      channel: "discord",
+      to: "discord:dm:123",
+      accountId: "main",
+      deliver: true,
+    });
+
+    const pendingEntries = state.persistSessionEntryMock.mock.calls
+      .map((call) => (call[0] as { entry?: SessionEntry }).entry)
+      .filter((entry): entry is SessionEntry => entry?.pendingFinalDelivery === true);
+    expect(pendingEntries).toContainEqual(
+      expect.objectContaining({
+        pendingFinalDeliveryText: "ok",
+        pendingFinalDeliveryContext: {
+          channel: "discord",
+          to: "discord:dm:123",
+          accountId: "main",
+        },
+      }),
+    );
   });
 
   it("clears stale flag-only pending final delivery when there is no final payload", async () => {
@@ -1110,22 +1620,20 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       deliver: true,
     });
 
-    const clearedWrite = state.persistSessionEntryMock.mock.calls.find((call) => {
-      const entry = (call[0] as { entry?: SessionEntry } | undefined)?.entry;
-      return (
-        entry?.pendingFinalDelivery === undefined && entry?.pendingFinalDeliveryText === undefined
-      );
-    });
-    const clearedEntry = (clearedWrite?.[0] as { entry?: SessionEntry } | undefined)?.entry;
-    expect(clearedEntry).toBeDefined();
-    expect(clearedEntry?.pendingFinalDelivery).toBeUndefined();
-    expect(clearedEntry?.pendingFinalDeliveryText).toBeUndefined();
-    expect(clearedEntry?.pendingFinalDeliveryCreatedAt).toBeUndefined();
-    expect(clearedEntry?.pendingFinalDeliveryLastAttemptAt).toBeUndefined();
-    expect(clearedEntry?.pendingFinalDeliveryAttemptCount).toBeUndefined();
-    expect(clearedEntry?.pendingFinalDeliveryLastError).toBeUndefined();
-    expect(clearedEntry?.pendingFinalDeliveryContext).toBeUndefined();
-    expect(clearedEntry?.pendingFinalDeliveryIntentId).toBeUndefined();
+    expect(state.persistSessionEntryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entry: expect.objectContaining({
+          pendingFinalDelivery: undefined,
+          pendingFinalDeliveryText: undefined,
+          pendingFinalDeliveryCreatedAt: undefined,
+          pendingFinalDeliveryLastAttemptAt: undefined,
+          pendingFinalDeliveryAttemptCount: undefined,
+          pendingFinalDeliveryLastError: undefined,
+          pendingFinalDeliveryContext: undefined,
+          pendingFinalDeliveryIntentId: undefined,
+        }),
+      }),
+    );
   });
 
   it("keeps internal session-effect CLI runs out of visible session state", async () => {
@@ -1165,7 +1673,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect(attemptCalls[0]?.sessionEntry).toStrictEqual(visibleEntry);
     expect(state.persistSessionEntryMock).not.toHaveBeenCalled();
     expect(state.updateSessionStoreAfterAgentRunMock).not.toHaveBeenCalled();
-    expect(sessionStore["agent:main:main"]).toEqual(visibleEntry);
+    expect(sessionStore["agent:main:main"]).toBe(visibleEntry);
   });
 
   it("does not duplicate finishing lifecycle when an attempt already emitted finishing", async () => {
@@ -1217,7 +1725,6 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
             ],
           },
         },
-        list: [{ id: "main", default: true, skills: [] }],
       },
     };
     state.runWithModelFallbackMock.mockImplementation(async (params: FallbackRunnerParams) => {
@@ -1640,42 +2147,6 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       resolvedSkills: rebuiltSkills,
     });
     expect(state.buildWorkspaceSkillSnapshotMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("uses an empty skill snapshot without loading workspace skills for an empty skill filter", async () => {
-    state.runtimeConfigMock = {
-      agents: {
-        defaults: {
-          models: {
-            "anthropic/claude": {},
-            "openai/claude": {},
-            "openai/gpt-5.4": {},
-          },
-          skills: [],
-        },
-      },
-    };
-    state.sessionEntryMock = {
-      sessionId: "session-1",
-      updatedAt: Date.now(),
-    };
-    state.resolveAgentSkillsFilterMock.mockReturnValue([]);
-    setupSingleAttemptFallback();
-    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("anthropic", "claude"));
-
-    await runBasicAgentCommand();
-
-    const attemptParams = mockCallArg(state.runAgentAttemptMock) as {
-      skillsSnapshot?: Record<string, unknown>;
-    };
-    expectRecordFields(attemptParams?.skillsSnapshot, {
-      prompt: "",
-      skills: [],
-      resolvedSkills: [],
-      skillFilter: [],
-      version: 0,
-    });
-    expect(state.buildWorkspaceSkillSnapshotMock).not.toHaveBeenCalled();
   });
 
   it("classifies empty embedded run results before model fallback accepts them", async () => {

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -21,6 +21,11 @@ import {
   registerAgentRunContext,
 } from "../infra/agent-events.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import {
+  resolveAgentDeliveryPlan,
+  resolveAgentOutboundTarget,
+} from "../infra/outbound/agent-delivery.js";
+import { resolveMessageChannelSelection } from "../infra/outbound/channel-selection.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { parseStrictNonNegativeInteger } from "../infra/parse-finite-number.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -47,7 +52,15 @@ import type { getRemoteSkillEligibility } from "../skills/runtime/remote.js";
 import type { resolveReusableWorkspaceSkillSnapshot } from "../skills/runtime/session-snapshot.js";
 import { createTrajectoryRuntimeRecorder } from "../trajectory/runtime.js";
 import { resolveUserPath } from "../utils.js";
-import { resolveMessageChannel } from "../utils/message-channel.js";
+import {
+  normalizeDeliveryContext,
+  type DeliveryContext,
+} from "../utils/delivery-context.shared.js";
+import {
+  INTERNAL_MESSAGE_CHANNEL,
+  isDeliverableMessageChannel,
+  resolveMessageChannel,
+} from "../utils/message-channel.js";
 import { resolveAgentRuntimeConfig } from "./agent-runtime-config.js";
 import {
   clearAutoFallbackPrimaryProbeSelection,
@@ -284,6 +297,115 @@ function clearPendingFinalDeliveryFields(entry: SessionEntry, updatedAt: number)
     pendingFinalDeliveryIntentId: undefined,
     updatedAt,
   };
+}
+
+async function resolveCurrentRunDeliveryContext(params: {
+  cfg: OpenClawConfig;
+  opts: AgentCommandOpts;
+  sessionEntry?: SessionEntry;
+}): Promise<DeliveryContext | undefined> {
+  const { cfg, opts, sessionEntry } = params;
+  if (opts.deliver !== true) {
+    return undefined;
+  }
+  // Restart recovery only needs durable route fields; final delivery resolves plugin-specific routes.
+  const deliveryPlan = resolveAgentDeliveryPlan({
+    sessionEntry,
+    requestedChannel: opts.replyChannel ?? opts.channel,
+    explicitTo: opts.replyTo ?? opts.to,
+    explicitThreadId: opts.threadId,
+    accountId: opts.replyAccountId ?? opts.accountId,
+    wantsDelivery: true,
+    turnSourceChannel: opts.runContext?.messageChannel ?? opts.messageChannel,
+    turnSourceTo: opts.runContext?.currentChannelId ?? opts.to,
+    turnSourceAccountId: opts.runContext?.accountId ?? opts.accountId,
+    turnSourceThreadId: opts.runContext?.currentThreadTs ?? opts.threadId,
+  });
+  const explicitChannelHint = normalizeOptionalString(opts.replyChannel ?? opts.channel);
+  const explicitThreadId =
+    opts.threadId != null && opts.threadId !== "" ? opts.threadId : undefined;
+  let effectivePlan = deliveryPlan;
+  if (deliveryPlan.resolvedChannel === INTERNAL_MESSAGE_CHANNEL && !explicitChannelHint) {
+    try {
+      const selection = await resolveMessageChannelSelection({ cfg });
+      effectivePlan = {
+        ...deliveryPlan,
+        resolvedChannel: selection.channel,
+        deliveryTargetMode: deliveryPlan.deliveryTargetMode ?? "implicit",
+      };
+    } catch {
+      return undefined;
+    }
+  }
+  if (!isDeliverableMessageChannel(effectivePlan.resolvedChannel)) {
+    return undefined;
+  }
+  const targetMode =
+    opts.deliveryTargetMode ??
+    effectivePlan.deliveryTargetMode ??
+    (opts.to ? "explicit" : "implicit");
+  const resolvedTo =
+    effectivePlan.resolvedTo ??
+    resolveAgentOutboundTarget({
+      cfg,
+      plan: effectivePlan,
+      targetMode,
+      validateExplicitTarget: false,
+    }).resolvedTo;
+  if (!resolvedTo) {
+    return undefined;
+  }
+  const threadId =
+    targetMode === "explicit"
+      ? (explicitThreadId ??
+        (effectivePlan.baseDelivery.threadIdSource === "explicit"
+          ? effectivePlan.resolvedThreadId
+          : undefined))
+      : effectivePlan.resolvedThreadId;
+  return normalizeDeliveryContext({
+    channel: effectivePlan.resolvedChannel,
+    to: resolvedTo,
+    accountId: effectivePlan.resolvedAccountId,
+    threadId,
+  });
+}
+
+function shouldPersistCurrentRunSessionCleanup(
+  current: SessionEntry | undefined,
+  sessionId: string,
+): boolean {
+  return (
+    current !== undefined && current.sessionId === sessionId && current.abortedLastRun !== true
+  );
+}
+
+function shouldPersistRestartRecoveryContextClaim(
+  current: SessionEntry | undefined,
+  sessionId: string,
+  runId: string,
+  allowCreate: boolean,
+): boolean {
+  if (!current) {
+    return allowCreate;
+  }
+  if (!shouldPersistCurrentRunSessionCleanup(current, sessionId)) {
+    return false;
+  }
+  return (
+    current.restartRecoveryDeliveryRunId === undefined ||
+    current.restartRecoveryDeliveryRunId === runId
+  );
+}
+
+function shouldPersistRestartRecoveryCleanup(
+  current: SessionEntry | undefined,
+  sessionId: string,
+  runId: string,
+): boolean {
+  return (
+    shouldPersistCurrentRunSessionCleanup(current, sessionId) &&
+    current?.restartRecoveryDeliveryRunId === runId
+  );
 }
 
 function containsControlCharacters(value: string): boolean {
@@ -607,6 +729,8 @@ async function agentCommandInternal(
   } = prepared;
   const effectiveCwd = cwd ? resolveUserPath(cwd) : workspaceDir;
   let sessionEntry = prepared.sessionEntry;
+  let trackedRestartRecoveryDeliveryContext = false;
+  let currentRunDeliveryContext: DeliveryContext | undefined;
 
   try {
     if (opts.deliver === true) {
@@ -624,6 +748,49 @@ async function agentCommandInternal(
 
     if (!isRawModelRun && acpResolution?.kind === "stale") {
       throw acpResolution.error;
+    }
+
+    if (
+      sessionStore &&
+      sessionKey &&
+      !suppressVisibleSessionEffects &&
+      !isSubagentSessionKey(sessionKey)
+    ) {
+      const now = Date.now();
+      const currentStoreEntry = sessionStore[sessionKey];
+      const allowCreateRestartRecoveryEntry =
+        currentStoreEntry === undefined && sessionEntry === undefined;
+      const entry = currentStoreEntry ??
+        sessionEntry ?? { sessionId, updatedAt: now, sessionStartedAt: now };
+      currentRunDeliveryContext = await resolveCurrentRunDeliveryContext({
+        cfg,
+        opts,
+        sessionEntry: entry,
+      });
+      const next: SessionEntry = {
+        ...entry,
+        sessionId,
+        updatedAt: now,
+        restartRecoveryDeliveryContext: currentRunDeliveryContext,
+        restartRecoveryDeliveryRunId: currentRunDeliveryContext ? runId : undefined,
+      };
+      const persisted = await persistSessionEntry({
+        sessionStore,
+        sessionKey,
+        storePath,
+        entry: next,
+        shouldPersist: (current) =>
+          shouldPersistRestartRecoveryContextClaim(
+            current,
+            sessionId,
+            runId,
+            allowCreateRestartRecoveryEntry,
+          ),
+      });
+      sessionEntry = persisted ?? sessionEntry;
+      trackedRestartRecoveryDeliveryContext =
+        Boolean(persisted?.restartRecoveryDeliveryContext) &&
+        persisted?.restartRecoveryDeliveryRunId === runId;
     }
 
     if (!isRawModelRun && acpResolution?.kind === "ready" && sessionKey) {
@@ -1730,16 +1897,18 @@ async function agentCommandInternal(
             ...entry,
             pendingFinalDelivery: true,
             pendingFinalDeliveryText: combinedPayload,
+            pendingFinalDeliveryContext: currentRunDeliveryContext,
             pendingFinalDeliveryCreatedAt: now,
             updatedAt: now,
           };
-          await persistSessionEntry({
+          const persisted = await persistSessionEntry({
             sessionStore,
             sessionKey,
             storePath,
             entry: next,
+            shouldPersist: (current) => shouldPersistCurrentRunSessionCleanup(current, sessionId),
           });
-          sessionEntry = next;
+          sessionEntry = persisted ?? sessionEntry;
         }
       }
 
@@ -1795,13 +1964,14 @@ async function agentCommandInternal(
           !entry.pendingFinalDeliveryText;
         if (deliveryResult?.deliverySucceeded === true || noPendingTextForThisRun) {
           const next = clearPendingFinalDeliveryFields(entry, Date.now());
-          await persistSessionEntry({
+          const persisted = await persistSessionEntry({
             sessionStore,
             sessionKey,
             storePath,
             entry: next,
+            shouldPersist: (current) => shouldPersistCurrentRunSessionCleanup(current, sessionId),
           });
-          sessionEntry = next;
+          sessionEntry = persisted ?? sessionEntry;
         }
       }
 
@@ -1812,6 +1982,34 @@ async function agentCommandInternal(
       throw error;
     }
   } finally {
+    if (trackedRestartRecoveryDeliveryContext && sessionStore && sessionKey) {
+      try {
+        const entry = sessionStore[sessionKey] ?? sessionEntry;
+        if (entry?.restartRecoveryDeliveryContext && entry.restartRecoveryDeliveryRunId === runId) {
+          const next: SessionEntry = {
+            ...entry,
+            restartRecoveryDeliveryContext: undefined,
+            restartRecoveryDeliveryRunId: undefined,
+            updatedAt: Date.now(),
+          };
+          const persisted = await persistSessionEntry({
+            sessionStore,
+            sessionKey,
+            storePath,
+            entry: next,
+            shouldPersist: (current) =>
+              shouldPersistRestartRecoveryCleanup(current, sessionId, runId),
+          });
+          sessionEntry = persisted ?? sessionEntry;
+        }
+      } catch (error) {
+        log.warn(
+          `failed to clear restart recovery delivery context for ${sessionKey}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
     clearAgentRunContext(runId);
   }
 }

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -415,6 +415,106 @@ describe("main-session-restart-recovery", () => {
     expect(store["agent:main:main"]?.abortedLastRun).toBe(false);
   });
 
+  it("delivers resumed marked sessions through the current run recovery context", async () => {
+    const sessionsDir = await makeSessionsDir();
+    await writeStore(sessionsDir, {
+      "agent:main:discord:direct:123": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+        deliveryContext: {
+          channel: "discord",
+          to: "discord:dm:stale",
+          accountId: "old",
+        },
+        restartRecoveryDeliveryContext: {
+          channel: "discord",
+          to: "discord:dm:123",
+          accountId: "main",
+          threadId: 123,
+        },
+      },
+    });
+    await writeTranscript(sessionsDir, "main-session", [
+      { role: "user", content: "run the tool" },
+      { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "exec" }] },
+      { role: "toolResult", content: "done" },
+    ]);
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(result).toEqual({ recovered: 1, failed: 0, skipped: 0 });
+    const resumeParams = firstGatewayParams();
+    expect(resumeParams).toMatchObject({
+      sessionKey: "agent:main:discord:direct:123",
+      deliver: true,
+      bestEffortDeliver: true,
+      lane: "main",
+      channel: "discord",
+      to: "discord:dm:123",
+      accountId: "main",
+      threadId: "123",
+    });
+  });
+
+  it("does not infer restart delivery from historical session routes", async () => {
+    const sessionsDir = await makeSessionsDir();
+    await writeStore(sessionsDir, {
+      "agent:main:discord:direct:123": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+        deliveryContext: {
+          channel: "discord",
+          to: "discord:dm:stale",
+          accountId: "old",
+        },
+      },
+    });
+    await writeTranscript(sessionsDir, "main-session", [
+      { role: "user", content: "run the tool" },
+      { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "exec" }] },
+      { role: "toolResult", content: "done" },
+    ]);
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(result).toEqual({ recovered: 1, failed: 0, skipped: 0 });
+    expect(firstGatewayParams().deliver).toBe(false);
+  });
+
+  it("does not deliver restart recovery when session send policy denies sends", async () => {
+    const sessionsDir = await makeSessionsDir();
+    await writeStore(sessionsDir, {
+      "agent:main:discord:direct:123": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+        restartRecoveryDeliveryContext: {
+          channel: "discord",
+          to: "discord:dm:123",
+          accountId: "main",
+        },
+      },
+    });
+    await writeTranscript(sessionsDir, "main-session", [
+      { role: "user", content: "run the tool" },
+      { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "exec" }] },
+      { role: "toolResult", content: "done" },
+    ]);
+
+    const result = await recoverRestartAbortedMainSessions({
+      cfg: { session: { sendPolicy: { default: "deny" } } },
+      stateDir: tmpDir,
+    });
+
+    expect(result).toEqual({ recovered: 1, failed: 0, skipped: 0 });
+    expect(firstGatewayParams().deliver).toBe(false);
+  });
+
   it("fails marked sessions with stale approval-pending exec tool results", async () => {
     const sessionsDir = await makeSessionsDir();
     await writeStore(sessionsDir, {
@@ -460,7 +560,17 @@ describe("main-session-restart-recovery", () => {
         abortedLastRun: true,
         pendingFinalDelivery: true,
         pendingFinalDeliveryText: pendingPayload,
+        pendingFinalDeliveryContext: {
+          channel: "discord",
+          to: "discord:dm:final",
+          accountId: "main",
+        },
         pendingFinalDeliveryCreatedAt: Date.now() - 5_000,
+        restartRecoveryDeliveryContext: {
+          channel: "discord",
+          to: "discord:dm:stale",
+          accountId: "old",
+        },
       },
     });
     await writeTranscript(sessionsDir, "main-session", [
@@ -473,6 +583,13 @@ describe("main-session-restart-recovery", () => {
 
     expect(result).toEqual({ recovered: 1, failed: 0, skipped: 0 });
     expect(callGateway).toHaveBeenCalledOnce();
+    expect(firstGatewayParams()).toMatchObject({
+      deliver: true,
+      bestEffortDeliver: true,
+      channel: "discord",
+      to: "discord:dm:final",
+      accountId: "main",
+    });
     expect(firstGatewayParams().message).toContain(pendingPayload);
 
     const beforeStoreRead = Date.now();
@@ -575,7 +692,7 @@ describe("main-session-restart-recovery", () => {
     expect(store["agent:main:main"]?.abortedLastRun).toBe(true);
   });
 
-  it("sends a visible notice before failing an unresumable chat-bound main session", async () => {
+  it("sends a visible notice through legacy session route before failing an unresumable main session", async () => {
     const sessionsDir = await makeSessionsDir();
     await writeStore(sessionsDir, {
       "agent:main:demo-channel:room-1": {
@@ -583,12 +700,10 @@ describe("main-session-restart-recovery", () => {
         updatedAt: Date.now() - 10_000,
         status: "running",
         abortedLastRun: true,
-        deliveryContext: {
-          channel: "demo-channel",
-          to: "room-1",
-          accountId: "default",
-          threadId: "thread-1",
-        },
+        lastChannel: "discord",
+        lastTo: "discord:channel:room-1",
+        lastAccountId: "default",
+        lastThreadId: "thread-1",
       },
     });
     await writeTranscript(sessionsDir, "main-session", [
@@ -605,14 +720,14 @@ describe("main-session-restart-recovery", () => {
       | undefined;
     expect(gatewayCall?.method).toBe("message.action");
     expect(gatewayCall?.params).toMatchObject({
-      channel: "demo-channel",
+      channel: "discord",
       action: "send",
       accountId: "default",
       sessionKey: "agent:main:demo-channel:room-1",
       sessionId: "main-session",
     });
     expect(gatewayCall?.params?.params).toMatchObject({
-      to: "room-1",
+      to: "discord:channel:room-1",
       threadId: "thread-1",
       bestEffort: true,
     });

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -22,8 +22,14 @@ import { resolveGatewaySessionStoreTarget } from "../gateway/session-utils.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { CommandLane } from "../process/lanes.js";
 import { isAcpSessionKey, isCronSessionKey, isSubagentSessionKey } from "../routing/session-key.js";
+import { resolveSendPolicy } from "../sessions/send-policy.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
-import { deliveryContextFromSession } from "../utils/delivery-context.shared.js";
+import {
+  deliveryContextFromSession,
+  normalizeDeliveryContext,
+  type DeliveryContext,
+} from "../utils/delivery-context.shared.js";
+import { isDeliverableMessageChannel } from "../utils/message-channel.js";
 import { resolveAgentSessionDirs } from "./session-dirs.js";
 import type { SessionLockInspection } from "./session-write-lock.js";
 
@@ -272,6 +278,8 @@ async function markSessionFailed(params: {
       entry.pendingFinalDeliveryAttemptCount = undefined;
       entry.pendingFinalDeliveryLastError = undefined;
       entry.pendingFinalDeliveryContext = undefined;
+      entry.restartRecoveryDeliveryContext = undefined;
+      entry.restartRecoveryDeliveryRunId = undefined;
       store[params.sessionKey] = entry;
     },
     { skipMaintenance: true },
@@ -280,19 +288,23 @@ async function markSessionFailed(params: {
 }
 
 async function sendUnresumableSessionNotice(params: {
+  cfg?: OpenClawConfig;
   entry: SessionEntry;
   reason: string;
   sessionKey: string;
 }): Promise<boolean> {
-  const deliveryContext = deliveryContextFromSession(params.entry);
-  const channel = normalizeOptionalString(deliveryContext?.channel);
-  const to = normalizeOptionalString(deliveryContext?.to);
-  if (!channel || !to) {
+  const deliveryContext = resolveRestartRecoveryDeliveryContext({
+    cfg: params.cfg,
+    entry: params.entry,
+    includeSessionDeliveryFallback: true,
+    sessionKey: params.sessionKey,
+  });
+  if (!deliveryContext) {
     return false;
   }
 
   const messageParams: Record<string, unknown> = {
-    to,
+    to: deliveryContext.to,
     message: UNRESUMABLE_SESSION_NOTICE,
     bestEffort: true,
   };
@@ -300,7 +312,7 @@ async function sendUnresumableSessionNotice(params: {
     messageParams.threadId = deliveryContext.threadId;
   }
   const actionParams: Record<string, unknown> = {
-    channel,
+    channel: deliveryContext.channel,
     action: "send",
     sessionKey: params.sessionKey,
     sessionId: params.entry.sessionId,
@@ -330,7 +342,43 @@ async function sendUnresumableSessionNotice(params: {
   }
 }
 
+function resolveRestartRecoveryDeliveryContext(params: {
+  cfg?: OpenClawConfig;
+  entry: SessionEntry;
+  includeSessionDeliveryFallback?: boolean;
+  sessionKey: string;
+}): DeliveryContext | undefined {
+  const deliveryContext =
+    normalizeDeliveryContext(params.entry.pendingFinalDeliveryContext) ??
+    normalizeDeliveryContext(params.entry.restartRecoveryDeliveryContext) ??
+    (params.includeSessionDeliveryFallback ? deliveryContextFromSession(params.entry) : undefined);
+  const channel = normalizeOptionalString(deliveryContext?.channel);
+  const to = normalizeOptionalString(deliveryContext?.to);
+  if (!channel || !to || !isDeliverableMessageChannel(channel)) {
+    return undefined;
+  }
+  if (
+    params.cfg &&
+    resolveSendPolicy({
+      cfg: params.cfg,
+      entry: params.entry,
+      sessionKey: params.sessionKey,
+      channel,
+      chatType: params.entry.chatType,
+    }) === "deny"
+  ) {
+    return undefined;
+  }
+  return {
+    ...deliveryContext,
+    channel,
+    to,
+  };
+}
+
 async function resumeMainSession(params: {
+  cfg?: OpenClawConfig;
+  entry: SessionEntry;
   storePath: string;
   sessionKey: string;
   pendingFinalDeliveryText?: string | null;
@@ -339,16 +387,33 @@ async function resumeMainSession(params: {
     typeof params.pendingFinalDeliveryText === "string"
       ? sanitizePendingFinalDeliveryText(params.pendingFinalDeliveryText)
       : "";
+  const deliveryContext = resolveRestartRecoveryDeliveryContext({
+    cfg: params.cfg,
+    entry: params.entry,
+    sessionKey: params.sessionKey,
+  });
   try {
+    const agentParams: Record<string, unknown> = {
+      message: buildResumeMessage(sanitizedPendingText),
+      sessionKey: params.sessionKey,
+      idempotencyKey: crypto.randomUUID(),
+      deliver: Boolean(deliveryContext),
+      lane: CommandLane.Main,
+    };
+    if (deliveryContext) {
+      agentParams.channel = deliveryContext.channel;
+      agentParams.to = deliveryContext.to;
+      agentParams.bestEffortDeliver = true;
+      if (deliveryContext.accountId) {
+        agentParams.accountId = deliveryContext.accountId;
+      }
+      if (deliveryContext.threadId != null) {
+        agentParams.threadId = String(deliveryContext.threadId);
+      }
+    }
     await callGateway<{ runId: string }>({
       method: "agent",
-      params: {
-        message: buildResumeMessage(sanitizedPendingText),
-        sessionKey: params.sessionKey,
-        idempotencyKey: crypto.randomUUID(),
-        deliver: false,
-        lane: CommandLane.Main,
-      },
+      params: agentParams,
       timeoutMs: 10_000,
     });
     await updateSessionStore(
@@ -440,6 +505,7 @@ export async function markRestartAbortedMainSessionsFromLocks(params: {
 }
 
 async function recoverStore(params: {
+  cfg?: OpenClawConfig;
   storePath: string;
   resumedSessionKeys: Set<string>;
 }): Promise<{ recovered: number; failed: number; skipped: number }> {
@@ -489,6 +555,7 @@ async function recoverStore(params: {
     const resumeBlockReason = resolveMainSessionResumeBlockReason(messages);
     if (resumeBlockReason) {
       await sendUnresumableSessionNotice({
+        cfg: params.cfg,
         entry,
         sessionKey,
         reason: resumeBlockReason,
@@ -503,6 +570,8 @@ async function recoverStore(params: {
     }
 
     const resumed = await resumeMainSession({
+      cfg: params.cfg,
+      entry,
       storePath: params.storePath,
       sessionKey,
       pendingFinalDeliveryText: entry.pendingFinalDeliveryText,
@@ -548,6 +617,7 @@ export async function recoverRestartAbortedMainSessions(
 
   for (const storePath of await resolveRestartRecoveryStorePaths(params)) {
     const storeResult = await recoverStore({
+      cfg: params.cfg,
       storePath,
       resumedSessionKeys,
     });

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -513,7 +513,7 @@ describe("runReplyAgent pending final delivery capture", () => {
     };
     const sessionStore = { main: sessionEntry };
     const storePath = await createSessionStoreFile(sessionEntry);
-    state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+    state.runEmbeddedAgentMock.mockImplementationOnce(async () => {
       const storedDuringRun = await readStoredMainSession(storePath);
       expect(storedDuringRun.restartRecoveryDeliveryContext).toEqual({
         channel: "discord",

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -506,6 +506,59 @@ describe("runReplyAgent pending final delivery capture", () => {
     expect(stored.pendingFinalDeliveryText).toBe("visible final");
   });
 
+  it("persists auto-reply delivery context for restart recovery", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+    };
+    const sessionStore = { main: sessionEntry };
+    const storePath = await createSessionStoreFile(sessionEntry);
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+      const storedDuringRun = await readStoredMainSession(storePath);
+      expect(storedDuringRun.restartRecoveryDeliveryContext).toEqual({
+        channel: "discord",
+        to: "channel:24680",
+        accountId: "work",
+        threadId: "1503645939964055592",
+      });
+      expect(typeof storedDuringRun.restartRecoveryDeliveryRunId).toBe("string");
+      return {
+        payloads: [{ text: "visible final" }],
+        meta: {},
+      };
+    });
+
+    const { run } = createMinimalRun({
+      sessionCtx: {
+        Provider: "discord",
+        OriginatingChannel: "discord",
+        OriginatingTo: "channel:24680",
+        AccountId: "work",
+        MessageSid: "1503645939964055592",
+        MessageThreadId: "1503645939964055592",
+      },
+      runOverrides: { messageProvider: "discord" },
+      sessionEntry,
+      sessionStore,
+      sessionKey: "main",
+      storePath,
+    });
+
+    await run();
+
+    const stored = await readStoredMainSession(storePath);
+    expect(stored.pendingFinalDelivery).toBe(true);
+    expect(stored.pendingFinalDeliveryText).toBe("visible final");
+    expect(stored.pendingFinalDeliveryContext).toEqual({
+      channel: "discord",
+      to: "channel:24680",
+      accountId: "work",
+      threadId: "1503645939964055592",
+    });
+    expect(stored.restartRecoveryDeliveryContext).toBeUndefined();
+    expect(stored.restartRecoveryDeliveryRunId).toBeUndefined();
+  });
+
   it("keeps heartbeat replies with real content in pending final delivery", async () => {
     const sessionEntry: SessionEntry = {
       sessionId: "session",

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -23,6 +23,7 @@ import {
   resolveSessionPluginStatusLines,
   resolveSessionPluginTraceLines,
   type SessionEntry,
+  updateSessionStoreEntry,
 } from "../../config/sessions.js";
 import { parseSessionThreadInfoFast } from "../../config/sessions/thread-info.js";
 import type { TypingMode } from "../../config/types.js";

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import {
   hasSessionAutoModelFallbackProvenance,
@@ -23,6 +24,7 @@ import {
   resolveSessionPluginTraceLines,
   type SessionEntry,
 } from "../../config/sessions.js";
+import { parseSessionThreadInfoFast } from "../../config/sessions/thread-info.js";
 import type { TypingMode } from "../../config/types.js";
 import { resolveSessionTranscriptCandidates } from "../../gateway/session-utils.fs.js";
 import { logVerbose } from "../../globals.js";
@@ -38,6 +40,10 @@ import { CommandLaneClearedError, GatewayDrainingError } from "../../process/com
 import { shouldPreserveUserFacingSessionStateForInputProvenance } from "../../sessions/input-provenance.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
+import {
+  normalizeDeliveryContext,
+  type DeliveryContext,
+} from "../../utils/delivery-context.shared.js";
 import {
   estimateUsageCost,
   formatTokenCount,
@@ -80,6 +86,7 @@ import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-usage-l
 import { resolveQueuedReplyExecutionConfig } from "./agent-runner-utils.js";
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveEffectiveBlockStreamingConfig } from "./block-streaming.js";
+import { resolveEffectiveReplyRoute } from "./effective-reply-route.js";
 import { createFollowupRunner } from "./followup-runner.js";
 import { REPLY_RUN_STILL_SHUTTING_DOWN_TEXT } from "./get-reply-run-queue.js";
 import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-routing.js";
@@ -134,6 +141,59 @@ function buildSilentFallbackFailurePayload(params: {
       `⚠️ I couldn't reach the configured model backend ${params.fallbackTransition.selectedModelRef}. ` +
       `Fallback used ${params.fallbackTransition.activeModelRef}, but it produced no visible reply.`,
     isError: true,
+  });
+}
+
+function resolveSourceReplyPolicy(params: {
+  cfg: OpenClawConfig;
+  sessionCtx: TemplateContext;
+  sessionEntry?: SessionEntry;
+  sessionKey: string;
+  runtimePolicySessionKey?: string;
+  opts?: GetReplyOptions;
+}): ReturnType<typeof resolveSourceReplyVisibilityPolicy> {
+  const sendPolicy = resolveSendPolicy({
+    cfg: params.cfg,
+    entry: params.sessionEntry,
+    sessionKey: params.runtimePolicySessionKey ?? params.sessionKey,
+    channel:
+      params.sessionCtx.OriginatingChannel ??
+      params.sessionCtx.Surface ??
+      params.sessionCtx.Provider ??
+      params.sessionEntry?.channel,
+    chatType: params.sessionEntry?.chatType,
+  });
+  return resolveSourceReplyVisibilityPolicy({
+    cfg: params.cfg,
+    ctx: params.sessionCtx,
+    requested: params.opts?.sourceReplyDeliveryMode,
+    sendPolicy,
+  });
+}
+
+function resolveReplyRunDeliveryContext(params: {
+  cfg: OpenClawConfig;
+  sessionCtx: TemplateContext;
+  sessionEntry?: SessionEntry;
+  sessionKey: string;
+  runtimePolicySessionKey?: string;
+  opts?: GetReplyOptions;
+}): DeliveryContext | undefined {
+  if (resolveSourceReplyPolicy(params).suppressDelivery) {
+    return undefined;
+  }
+  const threadId =
+    normalizeOptionalString(params.sessionCtx.MessageThreadId) ??
+    normalizeOptionalString(params.sessionCtx.TransportThreadId) ??
+    normalizeOptionalString(
+      parseSessionThreadInfoFast(params.sessionCtx.SessionKey ?? params.sessionKey).threadId,
+    );
+  return normalizeDeliveryContext({
+    ...resolveEffectiveReplyRoute({
+      ctx: params.sessionCtx,
+      entry: params.sessionEntry,
+    }),
+    threadId,
   });
 }
 
@@ -1324,6 +1384,73 @@ export async function runReplyAgent(params: {
   const drainQueuedFollowupsAfterClear = () => {
     scheduleFollowupDrain(queueKey, runFollowupTurn);
   };
+  const restartRecoveryDeliveryRunId = crypto.randomUUID();
+  let trackedRestartRecoveryDeliveryContext = false;
+  const persistRestartRecoveryDeliveryContext = async (): Promise<void> => {
+    if (!sessionKey || !storePath) {
+      return;
+    }
+    const entry = activeSessionStore?.[sessionKey] ?? activeSessionEntry;
+    const deliveryContext = resolveReplyRunDeliveryContext({
+      cfg,
+      sessionCtx,
+      sessionEntry: entry,
+      sessionKey,
+      runtimePolicySessionKey,
+      opts,
+    });
+    if (!deliveryContext) {
+      return;
+    }
+    const updatedAt = Date.now();
+    const patch: Partial<SessionEntry> = {
+      restartRecoveryDeliveryContext: deliveryContext,
+      restartRecoveryDeliveryRunId,
+      updatedAt,
+    };
+    const persisted = await updateSessionStoreEntry({
+      storePath,
+      sessionKey,
+      update: async (current) =>
+        current.sessionId === replyOperation.sessionId && current.abortedLastRun !== true
+          ? patch
+          : null,
+    });
+    if (persisted) {
+      activeSessionEntry = persisted;
+      if (activeSessionStore) {
+        activeSessionStore[sessionKey] = persisted;
+      }
+      trackedRestartRecoveryDeliveryContext =
+        persisted.restartRecoveryDeliveryRunId === restartRecoveryDeliveryRunId;
+    }
+  };
+  const clearRestartRecoveryDeliveryContext = async (): Promise<void> => {
+    if (!trackedRestartRecoveryDeliveryContext || !sessionKey || !storePath) {
+      return;
+    }
+    const patch: Partial<SessionEntry> = {
+      restartRecoveryDeliveryContext: undefined,
+      restartRecoveryDeliveryRunId: undefined,
+      updatedAt: Date.now(),
+    };
+    const persisted = await updateSessionStoreEntry({
+      storePath,
+      sessionKey,
+      update: async (current) =>
+        current.sessionId === replyOperation.sessionId &&
+        current.abortedLastRun !== true &&
+        current.restartRecoveryDeliveryRunId === restartRecoveryDeliveryRunId
+          ? patch
+          : null,
+    });
+    if (persisted) {
+      activeSessionEntry = persisted;
+      if (activeSessionStore) {
+        activeSessionStore[sessionKey] = persisted;
+      }
+    }
+  };
   const prePreflightCompactionCount = activeSessionEntry?.compactionCount ?? 0;
   let preflightCompactionApplied = false;
 
@@ -1465,6 +1592,7 @@ export async function runReplyAgent(params: {
 
     replyOperation.setPhase("running");
     const runStartedAt = Date.now();
+    await persistRestartRecoveryDeliveryContext();
     const runOutcome = await traceAgentPhase("reply.run_agent_turn", () =>
       runAgentTurnWithFallback({
         commandBody,
@@ -2132,22 +2260,13 @@ export async function runReplyAgent(params: {
     // durable delivery retries. Hidden reasoning, message-tool-only replies,
     // and sendPolicy-denied replies must not become heartbeat-replayable text.
     if (sessionKey && storePath && finalPayloads.length > 0) {
-      const sendPolicy = resolveSendPolicy({
+      const sourceReplyPolicy = resolveSourceReplyPolicy({
         cfg,
-        entry: activeSessionEntry,
-        sessionKey: params.runtimePolicySessionKey ?? sessionKey,
-        channel:
-          sessionCtx.OriginatingChannel ??
-          sessionCtx.Surface ??
-          sessionCtx.Provider ??
-          activeSessionEntry?.channel,
-        chatType: activeSessionEntry?.chatType,
-      });
-      const sourceReplyPolicy = resolveSourceReplyVisibilityPolicy({
-        cfg,
-        ctx: sessionCtx,
-        requested: opts?.sourceReplyDeliveryMode,
-        sendPolicy,
+        sessionCtx,
+        sessionEntry: activeSessionEntry,
+        sessionKey,
+        runtimePolicySessionKey,
+        opts,
       });
       const pendingText = sourceReplyPolicy.suppressDelivery
         ? ""
@@ -2170,6 +2289,14 @@ export async function runReplyAgent(params: {
           })()
         : pendingText;
       if (resolvedPendingText) {
+        const pendingFinalDeliveryContext = resolveReplyRunDeliveryContext({
+          cfg,
+          sessionCtx,
+          sessionEntry: activeSessionEntry,
+          sessionKey,
+          runtimePolicySessionKey,
+          opts,
+        });
         await applySessionStoreEntryPatch({
           storePath,
           sessionKey,
@@ -2178,6 +2305,7 @@ export async function runReplyAgent(params: {
           patch: {
             pendingFinalDelivery: true,
             pendingFinalDeliveryText: resolvedPendingText,
+            pendingFinalDeliveryContext,
             pendingFinalDeliveryCreatedAt: Date.now(),
             updatedAt: Date.now(),
           },
@@ -2236,6 +2364,15 @@ export async function runReplyAgent(params: {
     returnWithQueuedFollowupDrain(undefined);
     throw error;
   } finally {
+    try {
+      await clearRestartRecoveryDeliveryContext();
+    } catch (error) {
+      logVerbose(
+        `failed to clear restart recovery delivery context for ${sessionKey ?? "unknown"}: ${String(
+          error,
+        )}`,
+      );
+    }
     if (shouldDrainQueuedFollowupsAfterClear) {
       replyOperation.completeThen(drainQueuedFollowupsAfterClear);
     } else {

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -67,6 +67,14 @@ vi.mock("../agents/command/session-store.runtime.js", () => {
   };
 });
 
+vi.mock("../agents/command/cli-compaction.js", () => {
+  return {
+    runCliTurnCompactionLifecycle: vi.fn(
+      async (params: { sessionEntry?: unknown }) => params.sessionEntry,
+    ),
+  };
+});
+
 vi.mock("../agents/command/attempt-execution.runtime.js", () => {
   return {
     buildAcpResult: vi.fn(),
@@ -577,6 +585,7 @@ describe("agentCommand", () => {
           messageChannel: "telegram",
           deliver: true,
           allowModelOverride: false,
+          sessionEffects: "internal",
         },
         runtime,
         { sendMessageTelegram },

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -385,6 +385,11 @@ describe("session store writer queue", () => {
           threadId: {},
         },
         pendingFinalDeliveryIntentId: 123,
+        restartRecoveryDeliveryContext: {
+          channel: "discord",
+          to: [],
+        },
+        restartRecoveryDeliveryRunId: 123,
       },
       "agent:main:good-pending": {
         sessionId: "s-good-pending",
@@ -402,6 +407,13 @@ describe("session store writer queue", () => {
           threadId: 42.5,
         },
         pendingFinalDeliveryIntentId: "intent-1",
+        restartRecoveryDeliveryContext: {
+          channel: "Discord",
+          to: " discord:dm:123 ",
+          accountId: "Main",
+          threadId: "reply-1",
+        },
+        restartRecoveryDeliveryRunId: "run-1",
       },
     } as unknown as Record<string, SessionEntry>);
 
@@ -421,6 +433,8 @@ describe("session store writer queue", () => {
     expect(bad?.pendingFinalDeliveryLastError).toBeUndefined();
     expect(bad?.pendingFinalDeliveryContext).toBeUndefined();
     expect(bad?.pendingFinalDeliveryIntentId).toBeUndefined();
+    expect(bad?.restartRecoveryDeliveryContext).toBeUndefined();
+    expect(bad?.restartRecoveryDeliveryRunId).toBeUndefined();
 
     expect(good).toMatchObject({
       pendingFinalDelivery: true,
@@ -436,6 +450,13 @@ describe("session store writer queue", () => {
         threadId: 42,
       },
       pendingFinalDeliveryIntentId: "intent-1",
+      restartRecoveryDeliveryContext: {
+        channel: "discord",
+        to: "discord:dm:123",
+        accountId: "main",
+        threadId: "reply-1",
+      },
+      restartRecoveryDeliveryRunId: "run-1",
     });
   });
 

--- a/src/config/sessions/store-load.ts
+++ b/src/config/sessions/store-load.ts
@@ -72,6 +72,10 @@ function normalizeOptionalStringOrNull(value: unknown): string | null | undefine
   return undefined;
 }
 
+function normalizeOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
 function normalizeRecordKey(value: string): string | undefined {
   const key = value.trim();
   return key.length > 0 ? key : undefined;
@@ -151,6 +155,16 @@ function normalizePendingFinalDeliveryFields(entry: SessionEntry): SessionEntry 
   assign(
     "pendingFinalDeliveryIntentId",
     normalizeOptionalStringOrNull(entry.pendingFinalDeliveryIntentId),
+  );
+  const restartRecoveryDeliveryContext = normalizeOptionalDeliveryContext(
+    entry.restartRecoveryDeliveryContext,
+  );
+  if (!sameDeliveryContext(entry.restartRecoveryDeliveryContext, restartRecoveryDeliveryContext)) {
+    assign("restartRecoveryDeliveryContext", restartRecoveryDeliveryContext);
+  }
+  assign(
+    "restartRecoveryDeliveryRunId",
+    normalizeOptionalString(entry.restartRecoveryDeliveryRunId),
   );
 
   return next;

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -371,6 +371,10 @@ export type SessionEntry = {
   pendingFinalDeliveryContext?: DeliveryContext;
   /** Durable send intent backing pending final delivery, when already created. */
   pendingFinalDeliveryIntentId?: string | null;
+  /** Current visible run delivery context used only for restart recovery. */
+  restartRecoveryDeliveryContext?: DeliveryContext;
+  /** Active run id that owns restartRecoveryDeliveryContext cleanup. */
+  restartRecoveryDeliveryRunId?: string;
   /**
    * Whether totalTokens reflects a fresh context snapshot for the latest run.
    * Undefined means legacy/unknown freshness; false forces consumers to treat

--- a/src/gateway/server-session-key.ts
+++ b/src/gateway/server-session-key.ts
@@ -45,10 +45,13 @@ function setResolvedSessionKeyCache(
       resolvedSessionKeyByRunId.delete(oldest);
     }
   }
-  const expiresAt =
-    sessionKey === null ? resolveExpiresAtMsFromDurationMs(RUN_LOOKUP_MISS_TTL_MS) : null;
-  if (sessionKey === null && expiresAt === undefined) {
-    return;
+  let expiresAt: number | null = null;
+  if (sessionKey === null) {
+    const missExpiresAt = resolveExpiresAtMsFromDurationMs(RUN_LOOKUP_MISS_TTL_MS);
+    if (missExpiresAt === undefined) {
+      return;
+    }
+    expiresAt = missExpiresAt;
   }
   resolvedSessionKeyByRunId.set(cacheKey, {
     sessionKey,

--- a/src/infra/outbound/targets-session.ts
+++ b/src/infra/outbound/targets-session.ts
@@ -23,6 +23,7 @@ export type SessionDeliveryTarget = {
   to?: string;
   accountId?: string;
   threadId?: string | number;
+  threadIdSource?: "explicit" | "session" | "turn-source";
   mode: ChannelOutboundTargetMode;
   lastChannel?: DeliverableMessageChannel;
   lastTo?: string;
@@ -153,6 +154,7 @@ export function resolveSessionDeliveryTarget(params: {
   const explicitThreadId = normalizeOptionalThreadValue(
     parsedExplicitTarget?.threadId ?? params.explicitThreadId,
   );
+  const explicitThreadIdSource = explicitThreadId != null ? "explicit" : undefined;
 
   let to = explicitTo;
   if (!to && lastTo) {
@@ -174,12 +176,15 @@ export function resolveSessionDeliveryTarget(params: {
         : lastThreadId
       : undefined;
 
+  const inheritedThreadIdSource =
+    threadId != null ? (hasTurnSourceThreadId ? "turn-source" : "session") : undefined;
   const resolvedThreadId = explicitThreadId ?? threadId;
   return {
     channel,
     to,
     accountId,
     threadId: resolvedThreadId,
+    threadIdSource: explicitThreadIdSource ?? inheritedThreadIdSource,
     mode,
     lastChannel,
     lastTo,

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -82,6 +82,8 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "pendingFinalDeliveryText",
   "pendingFinalDeliveryContext",
   "pendingFinalDeliveryIntentId",
+  "restartRecoveryDeliveryContext",
+  "restartRecoveryDeliveryRunId",
   "totalTokensFresh",
   "estimatedCostUsd",
   "cacheRead",


### PR DESCRIPTION
## Summary

- Problem: gateway restarts could leave in-flight Discord/chat turns silent when the previous Gateway process died mid-run.
- Solution: persist restart delivery context for direct agent and auto-reply runs, then use it when recovery resumes or emits a visible failure notice.
- What changed: restart recovery now delivers best-effort resumed replies through the captured route, preserves pending final delivery context, normalizes new session-store fields, and keeps legacy route fallback only for unresumable notices.
- What did NOT change (scope boundary): no new channel defaults, no plugin-specific policy in core, and no live transport implementation changes.

## Motivation

- Users should see either the recovered reply or a clear recovery failure notice after a Gateway restart instead of a silent aborted turn.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #69249
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

Behavior addressed: Gateway restart recovery produces visible feedback for interrupted chat-bound main sessions after a Gateway restart.
Real environment tested: Local Darwin 25.4.0 arm64, Node v24.14.0, real OpenClaw QA Gateway child over WebSocket/RPC, bundled qa-channel plugin, qa-lab synthetic bus, mock-openai provider.
Exact steps or command run after this patch: `node scripts/run-node.mjs qa suite --provider-mode mock-openai --scenario gateway-restart-inflight-run --concurrency 1 --output-dir .artifacts/qa-e2e/gateway-restart-visible-recovery-ci-fix-final`
Evidence after fix: QA suite report `.artifacts/qa-e2e/gateway-restart-visible-recovery-ci-fix-final/qa-suite-report.md` includes this copied terminal/report output from the real Gateway/qa-channel run:

```text
OpenClaw QA Scenario Suite
Passed: 1
Failed: 0

Gateway restart in-flight recovery
Status: pass
runId=3019924e-f9c4-4e3f-b970-c9a3d7e83207 interruptedStatus=ok interruptedMarkers=0
RESTART-RECOVERY-OK
Notes: qa-channel + qa-lab bus + real gateway child + mock-openai provider.
```
Observed result after fix: The in-flight run settled across Gateway restart without duplicate interrupted delivery (`interruptedMarkers=0`), Gateway and qa-channel became healthy again, and the follow-up recovery marker was delivered exactly once to the qa-channel transcript.
What was not tested: Live Discord transport/guild delivery and live model provider; this proof used qa-channel for the real Gateway/plugin transport path and mock-openai for deterministic model behavior.
Before evidence (optional but encouraged): Not collected from a real environment before the fix.

## Root Cause (if applicable)

- Root cause: restart recovery tracked run/session state but did not carry the outbound delivery route needed for a replacement Gateway process to send visible recovery output.
- Missing detection / guardrail: restart recovery tests did not assert the resumed delivery context or the visible failure notice route.
- Contributing context (if known): direct agent runs and auto-reply runs persisted delivery metadata differently, so recovery needed one normalized context path plus a scoped legacy fallback for failure notices.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/main-session-restart-recovery.test.ts`, `src/agents/agent-command.live-model-switch.test.ts`, `src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts`, `src/config/sessions/sessions.test.ts`
- Scenario the test should lock in: interrupted main sessions resume with captured route context, pending final delivery prefers pending context, unresumable notices can use legacy session route, and store loading normalizes recovery fields.
- Why this is the smallest reliable guardrail: it exercises persisted session recovery decisions without needing a live channel transport.
- Existing test that already covers this (if any): N/A before this PR.
- If no new test is added, why not: N/A - tests were added/updated.

## User-visible / Behavior Changes

Interrupted chat-bound main sessions can now produce a visible best-effort recovery reply or failure notice after Gateway restart.

## Diagram (if applicable)

```text
Before:
[gateway restart] -> [running session marked aborted] -> [recovery resumes deliver=false] -> [chat may stay silent]

After:
[gateway restart] -> [delivery context persisted] -> [recovery resumes or sends notice] -> [best-effort visible chat feedback]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): Yes
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: recovery can now call existing Gateway delivery paths after restart using persisted route context; mitigation is deliverable-channel validation, existing send policy checks, and best-effort delivery.

## Repro + Verification

### Environment

- OS: Darwin 25.4.0 arm64
- Runtime/container: Node v24.14.0 local Codex worktree
- Model/provider: mock-openai
- Integration/channel (if any): real Gateway child over WebSocket/RPC + bundled qa-channel plugin + qa-lab bus; no live Discord
- Relevant config (redacted): QA suite generated isolated config/state

### Steps

1. Run `node scripts/run-node.mjs qa suite --provider-mode mock-openai --scenario gateway-restart-inflight-run --concurrency 1 --output-dir .artifacts/qa-e2e/gateway-restart-visible-recovery-ci-fix-final`.
2. The scenario starts an agent run, applies a restart-required config change, waits for Gateway + qa-channel readiness after restart, then sends a same-session recovery follow-up.
3. Inspect `.artifacts/qa-e2e/gateway-restart-visible-recovery-ci-fix-final/qa-suite-report.md` and `qa-suite-summary.json`.

### Expected

- Gateway returns healthy after restart, qa-channel returns ready, interrupted output is not duplicated, and the same session delivers the recovery marker exactly once.

### Actual

- QA scenario passed. Report details: `runId=3019924e-f9c4-4e3f-b970-c9a3d7e83207 interruptedStatus=ok interruptedMarkers=0` followed by `RESTART-RECOVERY-OK`.

## Evidence

- [x] Real Gateway/qa-channel trace or runtime report
- [x] Supplemental focused test output
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: real QA Gateway restart in-flight recovery over qa-channel; focused restart recovery tests; local review gates.
- Edge cases checked: Gateway restart readiness, qa-channel readiness, no duplicate interrupted delivery, exactly-once recovery marker delivery, pending final delivery context precedence, legacy route notice fallback, send-policy denial, and preserving no-historical-route behavior for resumable recovery.
- What you did **not** verify: live Gateway restart against real Discord or a live model provider.

## Review Conversations

- [x] N/A - no GitHub review conversations yet.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: persisted route context could be stale.
  - Mitigation: resumable delivery uses only pending/restart recovery context, while historical route fallback is limited to unresumable failure notices and still passes send policy checks.







