### PR TITLE
fix(agent): keep fallback errors candidate scoped

### DIFF
--- a/src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts
+++ b/src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts
@@ -154,4 +154,33 @@ describe("runEmbeddedPiAgent cross-provider fallback error handling", () => {
 
     await expectDeepseekFallbackError(promise, getLastFormattedAssistant);
   });
+
+  it("does not attribute a later candidate failure to stale session history", async () => {
+    setupDeepseekFallbackErrorMatchers();
+    const getLastFormattedAssistant = captureFormattedAssistant();
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: makeAssistantMessageFixture({
+          stopReason: "error",
+          errorMessage: "You have hit your ChatGPT usage limit (plus plan).",
+          provider: "openai-codex",
+          model: "gpt-5.4",
+          content: [],
+        }),
+        currentAttemptAssistant: undefined,
+      }),
+    );
+
+    const promise = runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "run-cross-provider-stale-session-error-context",
+      config: makeCrossProviderFallbackConfig(),
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(MockedFailoverError);
+    await expect(promise).rejects.not.toThrow("ChatGPT usage limit");
+    expect(mockedIsRateLimitAssistantError).not.toHaveBeenCalled();
+    expect(getLastFormattedAssistant()).toBeUndefined();
+  });
 });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -141,6 +141,7 @@ import {
   buildUsageAgentMetaFields,
   createCompactionDiagId,
   resolveActiveErrorContext,
+  resolveAssistantForFailover,
   resolveFinalAssistantRawText,
   resolveFinalAssistantVisibleText,
   resolveMaxRunRetryIterations,
@@ -1644,10 +1645,16 @@ export async function runEmbeddedPiAgent(
           if (attempt.contextBudgetStatus) {
             lastContextBudgetStatus = attempt.contextBudgetStatus;
           }
+          const assistantForFailover = resolveAssistantForFailover({
+            provider,
+            model: modelId,
+            currentAttemptAssistant,
+            sessionLastAssistant,
+          });
           const activeErrorContext = resolveActiveErrorContext({
             provider,
             model: modelId,
-            assistant: currentAttemptAssistant ?? sessionLastAssistant,
+            assistant: assistantForFailover,
           });
           const resolveReplayInvalidForAttempt = (incompleteTurnText?: string | null) =>
             accumulatedReplayState.replayInvalid ||
@@ -1662,8 +1669,8 @@ export async function runEmbeddedPiAgent(
             accumulatedReplayState,
             attempt.replayMetadata,
           );
-          const formattedAssistantErrorText = sessionLastAssistant
-            ? formatAssistantErrorText(sessionLastAssistant, {
+          const formattedAssistantErrorText = assistantForFailover
+            ? formatAssistantErrorText(assistantForFailover, {
                 cfg: params.config,
                 sessionKey: resolvedSessionKey ?? params.sessionId,
                 provider: activeErrorContext.provider,
@@ -1671,8 +1678,8 @@ export async function runEmbeddedPiAgent(
               })
             : undefined;
           const assistantErrorText =
-            sessionLastAssistant?.stopReason === "error"
-              ? sessionLastAssistant.errorMessage?.trim() || formattedAssistantErrorText
+            assistantForFailover?.stopReason === "error"
+              ? assistantForFailover.errorMessage?.trim() || formattedAssistantErrorText
               : undefined;
           const canRestartForLiveSwitch =
             !hasOutboundDeliveryEvidence(attempt) &&
@@ -2469,7 +2476,6 @@ export async function runEmbeddedPiAgent(
             throw promptError;
           }
 
-          const assistantForFailover = currentAttemptAssistant ?? sessionLastAssistant;
           const fallbackThinking = pickFallbackThinkingLevel({
             message: assistantForFailover?.errorMessage,
             attempted: attemptedThinking,

--- a/src/agents/pi-embedded-runner/run/helpers.resolve-error-context.test.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.resolve-error-context.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveActiveErrorContext } from "./helpers.js";
+import { resolveActiveErrorContext, resolveAssistantForFailover } from "./helpers.js";
 
 describe("resolveActiveErrorContext", () => {
   it("returns the current provider/model", () => {
@@ -34,5 +34,57 @@ describe("resolveActiveErrorContext", () => {
     });
 
     expect(result).toEqual({ provider: "openrouter", model: "openai/gpt-5.4" });
+  });
+});
+
+describe("resolveAssistantForFailover", () => {
+  it("prefers the current attempt assistant", () => {
+    const currentAttemptAssistant = {
+      provider: "deepseek",
+      model: "deepseek-chat",
+    };
+    const sessionLastAssistant = {
+      provider: "openai-codex",
+      model: "gpt-5.4",
+    };
+
+    expect(
+      resolveAssistantForFailover({
+        provider: "deepseek",
+        model: "deepseek-chat",
+        currentAttemptAssistant,
+        sessionLastAssistant,
+      }),
+    ).toBe(currentAttemptAssistant);
+  });
+
+  it("uses session history when compaction removed the current same-candidate assistant", () => {
+    const sessionLastAssistant = {
+      provider: "deepseek",
+      model: "deepseek-chat",
+    };
+
+    expect(
+      resolveAssistantForFailover({
+        provider: "deepseek",
+        model: "deepseek-chat",
+        sessionLastAssistant,
+      }),
+    ).toBe(sessionLastAssistant);
+  });
+
+  it("does not reuse a stale assistant from a different fallback candidate", () => {
+    const sessionLastAssistant = {
+      provider: "openai-codex",
+      model: "gpt-5.4",
+    };
+
+    expect(
+      resolveAssistantForFailover({
+        provider: "deepseek",
+        model: "deepseek-chat",
+        sessionLastAssistant,
+      }),
+    ).toBeUndefined();
   });
 });

--- a/src/agents/pi-embedded-runner/run/helpers.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.ts
@@ -101,6 +101,31 @@ export function resolveActiveErrorContext(params: {
   return resolveReportedModelRef(params);
 }
 
+export function resolveAssistantForFailover<
+  T extends { provider?: string; model?: string },
+>(params: {
+  provider: string;
+  model: string;
+  currentAttemptAssistant?: T;
+  sessionLastAssistant?: T;
+}): T | undefined {
+  if (params.currentAttemptAssistant) {
+    return params.currentAttemptAssistant;
+  }
+  if (!params.sessionLastAssistant) {
+    return undefined;
+  }
+  const reportedRef = resolveReportedModelRef({
+    provider: params.provider,
+    model: params.model,
+    assistant: params.sessionLastAssistant,
+  });
+  if (reportedRef.provider !== params.provider || reportedRef.model !== params.model) {
+    return undefined;
+  }
+  return params.sessionLastAssistant;
+}
+
 function isEmbeddedHarnessProvider(provider: string): boolean {
   return provider.trim().toLowerCase() === "pi";
 }


### PR DESCRIPTION
## Summary
- Fixes #86077.
- Adds a candidate-scoped assistant selector for embedded-runner failover so a later fallback candidate without a current assistant cannot reuse a prior provider's session-history error text.
- Keeps the compaction case working by still allowing same-candidate session history when the current attempt slice was removed.
- Adds helper and embedded-runner regressions for current-attempt, same-candidate compaction, and stale cross-provider history cases.

## Tests
- `pnpm exec tsx -e 'import { resolveAssistantForFailover } from "./src/agents/pi-embedded-runner/run/helpers.ts"; const stale = resolveAssistantForFailover({ provider: "deepseek", model: "deepseek-chat", sessionLastAssistant: { provider: "openai-codex", model: "gpt-5.4" } }); const same = resolveAssistantForFailover({ provider: "deepseek", model: "deepseek-chat", sessionLastAssistant: { provider: "deepseek", model: "deepseek-chat" } }); console.log(JSON.stringify({ staleCrossProviderReused: stale !== undefined, sameCandidatePreserved: same?.provider === "deepseek" && same?.model === "deepseek-chat" }));'`
- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/helpers.resolve-error-context.test.ts src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts src/agents/model-fallback.test.ts`
- `git diff --check`

## Real behavior proof
Behavior addressed: Embedded PI model fallback error attribution no longer lets a later fallback candidate with no current assistant reuse a previous provider's stale assistant error string.
Real environment tested: Local OpenClaw source checkout on macOS using the production embedded-runner failover helper through the repo runtime.
Exact steps or command run after this patch: `pnpm exec tsx -e 'import { resolveAssistantForFailover } from "./src/agents/pi-embedded-runner/run/helpers.ts"; const stale = resolveAssistantForFailover({ provider: "deepseek", model: "deepseek-chat", sessionLastAssistant: { provider: "openai-codex", model: "gpt-5.4" } }); const same = resolveAssistantForFailover({ provider: "deepseek", model: "deepseek-chat", sessionLastAssistant: { provider: "deepseek", model: "deepseek-chat" } }); console.log(JSON.stringify({ staleCrossProviderReused: stale !== undefined, sameCandidatePreserved: same?.provider === "deepseek" && same?.model === "deepseek-chat" }));'`
Evidence after fix: Console output from the production helper:
```json
{"staleCrossProviderReused":false,"sameCandidatePreserved":true}
```
Observed result after fix: The command exited 0 and printed `staleCrossProviderReused:false`, proving the reported stale OpenAI assistant is not reused for the later DeepSeek candidate; it also printed `sameCandidatePreserved:true`, proving same-candidate session history remains available for compaction cases.
What was not tested: Live provider failover with real credentials; the affected candidate-scoping behavior is deterministic and was verified directly against production helper code.
