### PR TITLE
fix(agent): keep fallback errors candidate scoped

### DIFF
--- a/src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts
+++ b/src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts
@@ -30,15 +30,19 @@ function isCurrentAttemptAssistant(
   );
 }
 
-function setupDeepseekFallbackErrorMatchers() {
+function setupFallbackErrorMatchers(provider: string) {
   mockedIsFailoverAssistantError.mockImplementation((...args: unknown[]) => {
     const assistant = args[0];
-    return isCurrentAttemptAssistant(assistant) && assistant.provider === "deepseek";
+    return isCurrentAttemptAssistant(assistant) && assistant.provider === provider;
   });
   mockedIsRateLimitAssistantError.mockImplementation((...args: unknown[]) => {
     const assistant = args[0];
-    return isCurrentAttemptAssistant(assistant) && assistant.provider === "deepseek";
+    return isCurrentAttemptAssistant(assistant) && assistant.provider === provider;
   });
+}
+
+function setupDeepseekFallbackErrorMatchers() {
+  setupFallbackErrorMatchers("deepseek");
 }
 
 function captureFormattedAssistant() {
@@ -53,13 +57,17 @@ function captureFormattedAssistant() {
   return () => lastFormattedAssistant;
 }
 
-function expectDeepseekAssistant(value: unknown) {
+function expectAssistant(value: unknown, provider: string, model: string, errorMessage: string) {
   if (!isCurrentAttemptAssistant(value)) {
-    throw new Error(`Expected DeepSeek assistant, got ${String(value)}`);
+    throw new Error(`Expected ${provider} assistant, got ${String(value)}`);
   }
-  expect(value.provider).toBe("deepseek");
-  expect(value.model).toBe("deepseek-chat");
-  expect(value.errorMessage).toBe(DEEPSEEK_ERROR_MESSAGE);
+  expect(value.provider).toBe(provider);
+  expect(value.model).toBe(model);
+  expect(value.errorMessage).toBe(errorMessage);
+}
+
+function expectDeepseekAssistant(value: unknown) {
+  expectAssistant(value, "deepseek", "deepseek-chat", DEEPSEEK_ERROR_MESSAGE);
 }
 
 function makeCrossProviderFallbackConfig() {
@@ -130,16 +138,17 @@ describe("runEmbeddedPiAgent cross-provider fallback error handling", () => {
   });
 
   it("falls back to the session assistant when compaction removes the current attempt slice", async () => {
-    setupDeepseekFallbackErrorMatchers();
+    const anthropicErrorMessage = "429 anthropic rate limit";
+    setupFallbackErrorMatchers("anthropic");
     const getLastFormattedAssistant = captureFormattedAssistant();
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],
         lastAssistant: makeAssistantMessageFixture({
           stopReason: "error",
-          errorMessage: DEEPSEEK_ERROR_MESSAGE,
-          provider: "deepseek",
-          model: "deepseek-chat",
+          errorMessage: anthropicErrorMessage,
+          provider: "anthropic",
+          model: "test-model",
           content: [],
         }),
         currentAttemptAssistant: undefined,
@@ -152,6 +161,43 @@ describe("runEmbeddedPiAgent cross-provider fallback error handling", () => {
       config: makeCrossProviderFallbackConfig(),
     });
 
-    await expectDeepseekFallbackError(promise, getLastFormattedAssistant);
+    await expect(promise).rejects.toBeInstanceOf(MockedFailoverError);
+    await expect(promise).rejects.toThrow(`anthropic/test-model: ${anthropicErrorMessage}`);
+    expect(mockedIsRateLimitAssistantError).toHaveBeenCalledTimes(1);
+    const rateLimitCalls = mockedIsRateLimitAssistantError.mock.calls as unknown[][];
+    expectAssistant(rateLimitCalls.at(-1)?.[0], "anthropic", "test-model", anthropicErrorMessage);
+    expectAssistant(getLastFormattedAssistant(), "anthropic", "test-model", anthropicErrorMessage);
+  });
+
+  it("does not attribute a later candidate failure to stale session history", async () => {
+    setupDeepseekFallbackErrorMatchers();
+    const getLastFormattedAssistant = captureFormattedAssistant();
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: makeAssistantMessageFixture({
+          stopReason: "error",
+          errorMessage: "You have hit your ChatGPT usage limit (plus plan).",
+          provider: "openai-codex",
+          model: "gpt-5.4",
+          content: [],
+        }),
+        currentAttemptAssistant: undefined,
+      }),
+    );
+
+    const promise = runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "run-cross-provider-stale-session-error-context",
+      config: makeCrossProviderFallbackConfig(),
+    });
+
+    const result = await promise;
+
+    expect(result.payloads.map((payload) => payload.text).join("\n")).not.toContain(
+      "ChatGPT usage limit",
+    );
+    expect(mockedIsRateLimitAssistantError).not.toHaveBeenCalled();
+    expect(getLastFormattedAssistant()).toBeUndefined();
   });
 });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -141,6 +141,7 @@ import {
   buildUsageAgentMetaFields,
   createCompactionDiagId,
   resolveActiveErrorContext,
+  resolveAssistantForFailover,
   resolveFinalAssistantRawText,
   resolveFinalAssistantVisibleText,
   resolveMaxRunRetryIterations,
@@ -1644,10 +1645,16 @@ export async function runEmbeddedPiAgent(
           if (attempt.contextBudgetStatus) {
             lastContextBudgetStatus = attempt.contextBudgetStatus;
           }
+          const assistantForFailover = resolveAssistantForFailover({
+            provider,
+            model: modelId,
+            currentAttemptAssistant,
+            sessionLastAssistant,
+          });
           const activeErrorContext = resolveActiveErrorContext({
             provider,
             model: modelId,
-            assistant: currentAttemptAssistant ?? sessionLastAssistant,
+            assistant: assistantForFailover,
           });
           const resolveReplayInvalidForAttempt = (incompleteTurnText?: string | null) =>
             accumulatedReplayState.replayInvalid ||
@@ -1662,8 +1669,8 @@ export async function runEmbeddedPiAgent(
             accumulatedReplayState,
             attempt.replayMetadata,
           );
-          const formattedAssistantErrorText = sessionLastAssistant
-            ? formatAssistantErrorText(sessionLastAssistant, {
+          const formattedAssistantErrorText = assistantForFailover
+            ? formatAssistantErrorText(assistantForFailover, {
                 cfg: params.config,
                 sessionKey: resolvedSessionKey ?? params.sessionId,
                 provider: activeErrorContext.provider,
@@ -1671,8 +1678,8 @@ export async function runEmbeddedPiAgent(
               })
             : undefined;
           const assistantErrorText =
-            sessionLastAssistant?.stopReason === "error"
-              ? sessionLastAssistant.errorMessage?.trim() || formattedAssistantErrorText
+            assistantForFailover?.stopReason === "error"
+              ? assistantForFailover.errorMessage?.trim() || formattedAssistantErrorText
               : undefined;
           const canRestartForLiveSwitch =
             !hasOutboundDeliveryEvidence(attempt) &&
@@ -2469,7 +2476,6 @@ export async function runEmbeddedPiAgent(
             throw promptError;
           }
 
-          const assistantForFailover = currentAttemptAssistant ?? sessionLastAssistant;
           const fallbackThinking = pickFallbackThinkingLevel({
             message: assistantForFailover?.errorMessage,
             attempted: attemptedThinking,

--- a/src/agents/pi-embedded-runner/run/helpers.resolve-error-context.test.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.resolve-error-context.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveActiveErrorContext } from "./helpers.js";
+import { resolveActiveErrorContext, resolveAssistantForFailover } from "./helpers.js";
 
 describe("resolveActiveErrorContext", () => {
   it("returns the current provider/model", () => {
@@ -34,5 +34,57 @@ describe("resolveActiveErrorContext", () => {
     });
 
     expect(result).toEqual({ provider: "openrouter", model: "openai/gpt-5.4" });
+  });
+});
+
+describe("resolveAssistantForFailover", () => {
+  it("prefers the current attempt assistant", () => {
+    const currentAttemptAssistant = {
+      provider: "deepseek",
+      model: "deepseek-chat",
+    };
+    const sessionLastAssistant = {
+      provider: "openai-codex",
+      model: "gpt-5.4",
+    };
+
+    expect(
+      resolveAssistantForFailover({
+        provider: "deepseek",
+        model: "deepseek-chat",
+        currentAttemptAssistant,
+        sessionLastAssistant,
+      }),
+    ).toBe(currentAttemptAssistant);
+  });
+
+  it("uses session history when compaction removed the current same-candidate assistant", () => {
+    const sessionLastAssistant = {
+      provider: "deepseek",
+      model: "deepseek-chat",
+    };
+
+    expect(
+      resolveAssistantForFailover({
+        provider: "deepseek",
+        model: "deepseek-chat",
+        sessionLastAssistant,
+      }),
+    ).toBe(sessionLastAssistant);
+  });
+
+  it("does not reuse a stale assistant from a different fallback candidate", () => {
+    const sessionLastAssistant = {
+      provider: "openai-codex",
+      model: "gpt-5.4",
+    };
+
+    expect(
+      resolveAssistantForFailover({
+        provider: "deepseek",
+        model: "deepseek-chat",
+        sessionLastAssistant,
+      }),
+    ).toBeUndefined();
   });
 });

--- a/src/agents/pi-embedded-runner/run/helpers.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.ts
@@ -101,6 +101,31 @@ export function resolveActiveErrorContext(params: {
   return resolveReportedModelRef(params);
 }
 
+export function resolveAssistantForFailover<
+  T extends { provider?: string; model?: string },
+>(params: {
+  provider: string;
+  model: string;
+  currentAttemptAssistant?: T;
+  sessionLastAssistant?: T;
+}): T | undefined {
+  if (params.currentAttemptAssistant) {
+    return params.currentAttemptAssistant;
+  }
+  if (!params.sessionLastAssistant) {
+    return undefined;
+  }
+  const reportedRef = resolveReportedModelRef({
+    provider: params.provider,
+    model: params.model,
+    assistant: params.sessionLastAssistant,
+  });
+  if (reportedRef.provider !== params.provider || reportedRef.model !== params.model) {
+    return undefined;
+  }
+  return params.sessionLastAssistant;
+}
+
 function isEmbeddedHarnessProvider(provider: string): boolean {
   return provider.trim().toLowerCase() === "pi";
 }


### PR DESCRIPTION
## Summary

- Fixes #86077.
- Keeps assistant error context scoped to the current fallback candidate instead of reusing a prior provider's session assistant.
- Preserves same-candidate compaction fallback error details and adds regression coverage for stale prior-provider session history.

## Tests

- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts src/agents/pi-embedded-runner/run/helpers.resolve-error-context.test.ts`
- `pnpm openclaw --help`

## Real behavior proof

Behavior addressed: Model fallback should not attribute a later provider/candidate failure to a stale assistant error from an earlier provider in the same session; same-candidate assistant errors should still surface when compaction removes the current-attempt slice.

Real environment tested: Local macOS source checkout on branch `leno23/fix-86077-stale-fallback-assistant`, OpenClaw CLI built from commit `079d3086f2`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts src/agents/pi-embedded-runner/run/helpers.resolve-error-context.test.ts` and `pnpm openclaw --help`.

Evidence after fix: Terminal output from the after-patch commands:
```text
$ node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts src/agents/pi-embedded-runner/run/helpers.resolve-error-context.test.ts
(exit 0)

$ pnpm openclaw --help
[openclaw] Building TypeScript (dist is stale: git_head_changed - git head changed).
OpenClaw 2026.5.24 (079d308) — All your chats, one OpenClaw.
Usage: openclaw [options] [command]
...
Docs: https://docs.openclaw.ai/cli
```

Observed result after fix: The targeted regression suite passes, including coverage that stale prior-provider session assistants are ignored for later candidates while same-candidate compaction fallback still retains the provider error context. The built OpenClaw CLI starts successfully from the patched checkout.

What was not tested: I did not run a live paid multi-provider timeout cascade against external model APIs; the source-level regression covers the failing candidate-scoping path without real provider credentials.
