### PR TITLE
fix(plugins): recover managed npm root after corrupt install failure (#85113)

### DIFF
--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -1159,6 +1159,28 @@ describe("plugins cli install", () => {
     expect(runtimeErrors.at(-1)).not.toContain("Also not a valid hook pack");
   });
 
+  it("does not fall back to hook pack when managed npm root recovery rebuild fails", async () => {
+    loadConfig.mockReturnValue({} as OpenClawConfig);
+    installPluginFromNpmSpec.mockResolvedValue({
+      ok: false,
+      error:
+        "managed npm root recovery failed after quarantining package-lock.json at /tmp/openclaw-state/extensions/.openclaw-managed-node_modules/_openclaw-quarantined-npm-roots/corrupt-demo: npm install failed during rebuild",
+    });
+    installHooksFromNpmSpec.mockResolvedValue({
+      ok: false,
+      error: "package.json missing openclaw.hooks",
+    });
+
+    await expect(runPluginsCommand(["plugins", "install", "npm:demo"])).rejects.toThrow(
+      "__exit__:1",
+    );
+
+    expect(installPluginFromClawHub).not.toHaveBeenCalled();
+    expect(installHooksFromNpmSpec).not.toHaveBeenCalled();
+    expect(runtimeErrors.at(-1)).toContain("managed npm root recovery failed");
+    expect(runtimeErrors.at(-1)).not.toContain("Also not a valid hook pack");
+  });
+
   it("adds a Git PATH hint when npm plugin dependency install cannot spawn git", async () => {
     loadConfig.mockReturnValue({} as OpenClawConfig);
     installPluginFromNpmSpec.mockResolvedValue({

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -1154,7 +1154,9 @@ describe("plugins cli install", () => {
     );
 
     expect(installPluginFromClawHub).not.toHaveBeenCalled();
+    expect(installHooksFromNpmSpec).not.toHaveBeenCalled();
     expect(runtimeErrors.at(-1)).toContain("npm install failed");
+    expect(runtimeErrors.at(-1)).not.toContain("Also not a valid hook pack");
   });
 
   it("adds a Git PATH hint when npm plugin dependency install cannot spawn git", async () => {
@@ -1182,7 +1184,8 @@ describe("plugins cli install", () => {
       "one of this plugin's npm dependencies is fetched from a git URL",
     );
     expect(runtimeErrors.at(-1)).toContain("winget install --id Git.Git -e");
-    expect(runtimeErrors.at(-1)).toContain("Also not a valid hook pack");
+    expect(installHooksFromNpmSpec).not.toHaveBeenCalled();
+    expect(runtimeErrors.at(-1)).not.toContain("Also not a valid hook pack");
   });
 
   it("does not resolve npm: prefixed bundled plugin ids through bundled installs", async () => {

--- a/src/cli/plugins-command-helpers.ts
+++ b/src/cli/plugins-command-helpers.ts
@@ -201,6 +201,7 @@ export function shouldSkipHookPackFallbackAfterPluginInstallError(pluginError: s
   return (
     pluginError.startsWith("npm install failed") ||
     pluginError.startsWith("npm peer dependency planning failed") ||
+    pluginError.startsWith("managed npm root recovery failed") ||
     pluginError.startsWith("Failed to stage npm pack archive in managed npm root")
   );
 }

--- a/src/cli/plugins-command-helpers.ts
+++ b/src/cli/plugins-command-helpers.ts
@@ -178,6 +178,9 @@ export function formatPluginInstallWithHookFallbackError(
 ): string {
   const formattedPluginError = formatPluginInstallAttemptError(pluginError);
   const formattedHookError = formatPluginInstallAttemptError(hookError);
+  if (shouldSkipHookPackFallbackAfterPluginInstallError(pluginError)) {
+    return formattedPluginError;
+  }
   if (/plugin already exists: .+ \(delete it first\)/.test(pluginError)) {
     return `${formattedPluginError}\nUse \`openclaw plugins update <id-or-npm-spec>\` to upgrade the tracked plugin, or rerun install with \`--force\` to replace it.`;
   }
@@ -188,6 +191,18 @@ export function formatPluginInstallWithHookFallbackError(
     return formattedPluginError;
   }
   return `${formattedPluginError}\nAlso not a valid hook pack: ${formattedHookError}`;
+}
+
+export function formatPluginInstallPrimaryError(pluginError: string): string {
+  return formatPluginInstallAttemptError(pluginError);
+}
+
+export function shouldSkipHookPackFallbackAfterPluginInstallError(pluginError: string): boolean {
+  return (
+    pluginError.startsWith("npm install failed") ||
+    pluginError.startsWith("npm peer dependency planning failed") ||
+    pluginError.startsWith("Failed to stage npm pack archive in managed npm root")
+  );
 }
 
 const MISSING_GIT_FOR_NPM_DEPENDENCY_HINT =

--- a/src/cli/plugins-install-command.ts
+++ b/src/cli/plugins-install-command.ts
@@ -50,9 +50,11 @@ import {
 import {
   createHookPackInstallLogger,
   createPluginInstallLogger,
+  formatPluginInstallPrimaryError,
   formatPluginInstallWithHookFallbackError,
   parseNpmPackPrefixPath,
   parseNpmPrefixSpec,
+  shouldSkipHookPackFallbackAfterPluginInstallError,
 } from "./plugins-command-helpers.js";
 import { persistHookPackInstall, persistPluginInstall } from "./plugins-install-persist.js";
 import type { ConfigSnapshotForInstallPersist } from "./plugins-install-persist.js";
@@ -346,6 +348,10 @@ async function tryInstallPluginOrHookPackFromNpmSpec(params: {
         });
         return { ok: true };
       }
+    }
+    if (shouldSkipHookPackFallbackAfterPluginInstallError(result.error)) {
+      (params.runtime ?? defaultRuntime).error(formatPluginInstallPrimaryError(result.error));
+      return { ok: false };
     }
     const hookFallback = await tryInstallHookPackFromNpmSpec({
       snapshot: params.snapshot,

--- a/src/infra/npm-managed-root.test.ts
+++ b/src/infra/npm-managed-root.test.ts
@@ -5,6 +5,7 @@ import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CommandOptions } from "../process/exec.js";
 import {
+  quarantineManagedNpmRootForRebuild,
   repairManagedNpmRootOpenClawPeer,
   removeManagedNpmRootDependency,
   readManagedNpmRootInstalledDependency,
@@ -77,6 +78,66 @@ function requireCommandOptions(
 }
 
 describe("managed npm root", () => {
+  it("quarantines rebuild artifacts without moving managed root metadata", async () => {
+    const npmRoot = await makeTempRoot();
+    await fs.mkdir(path.join(npmRoot, "node_modules", "@openclaw", "codex"), {
+      recursive: true,
+    });
+    await fs.mkdir(path.join(npmRoot, "_openclaw-pack-archives"), { recursive: true });
+    await fs.writeFile(
+      path.join(npmRoot, "package.json"),
+      `${JSON.stringify({
+        private: true,
+        dependencies: { "@openclaw/codex": "2026.5.20" },
+      })}\n`,
+    );
+    await fs.writeFile(
+      path.join(npmRoot, "node_modules", "@openclaw", "codex", "keep.txt"),
+      "plugin",
+    );
+    await fs.writeFile(path.join(npmRoot, "package-lock.json"), "lock");
+    await fs.writeFile(path.join(npmRoot, "npm-shrinkwrap.json"), "shrinkwrap");
+    await fs.writeFile(path.join(npmRoot, "_openclaw-pack-archives", "fixture.tgz"), "pack");
+
+    const result = await quarantineManagedNpmRootForRebuild({ npmRoot });
+
+    expect(result.movedArtifactNames).toEqual([
+      "node_modules",
+      "package-lock.json",
+      "npm-shrinkwrap.json",
+    ]);
+    await expectPathMissing(path.join(npmRoot, "node_modules"));
+    await expectPathMissing(path.join(npmRoot, "package-lock.json"));
+    await expectPathMissing(path.join(npmRoot, "npm-shrinkwrap.json"));
+    await expect(
+      fs.readFile(
+        path.join(result.quarantineDir, "node_modules", "@openclaw", "codex", "keep.txt"),
+        "utf8",
+      ),
+    ).resolves.toBe("plugin");
+    await expect(
+      fs.readFile(path.join(result.quarantineDir, "package-lock.json"), "utf8"),
+    ).resolves.toBe("lock");
+    await expect(
+      fs.readFile(path.join(result.quarantineDir, "npm-shrinkwrap.json"), "utf8"),
+    ).resolves.toBe("shrinkwrap");
+    await expect(fs.readFile(path.join(npmRoot, "package.json"), "utf8")).resolves.toContain(
+      "@openclaw/codex",
+    );
+    await expect(
+      fs.readFile(path.join(npmRoot, "_openclaw-pack-archives", "fixture.tgz"), "utf8"),
+    ).resolves.toBe("pack");
+  });
+
+  it("treats missing rebuild artifacts as an idempotent quarantine", async () => {
+    const npmRoot = await makeTempRoot();
+
+    const result = await quarantineManagedNpmRootForRebuild({ npmRoot });
+
+    expect(result.movedArtifactNames).toEqual([]);
+    expect((await fs.lstat(result.quarantineDir)).isDirectory()).toBe(true);
+  });
+
   it("keeps existing plugin dependencies when adding another managed plugin", async () => {
     const npmRoot = await makeTempRoot();
     await fs.writeFile(

--- a/src/infra/npm-managed-root.ts
+++ b/src/infra/npm-managed-root.ts
@@ -569,6 +569,7 @@ export async function quarantineManagedNpmRootForRebuild(params: {
   await fs.mkdir(params.npmRoot, { recursive: true });
   const quarantineParent = path.join(params.npmRoot, MANAGED_NPM_ROOT_QUARANTINE_DIR);
   await fs.mkdir(quarantineParent, { recursive: true });
+  // No process lock on the managed root; safe-by-construction: mkdtemp unique dir + rename ENOENT swallowed on re-quarantine.
   const quarantineDir = await fs.mkdtemp(path.join(quarantineParent, "corrupt-"));
   const movedArtifactNames: string[] = [];
   for (const artifactName of MANAGED_NPM_ROOT_REBUILD_ARTIFACT_NAMES) {

--- a/src/infra/npm-managed-root.ts
+++ b/src/infra/npm-managed-root.ts
@@ -41,6 +41,11 @@ export type ManagedNpmRootInstalledDependency = {
   resolved?: string;
 };
 
+export type ManagedNpmRootQuarantineResult = {
+  quarantineDir: string;
+  movedArtifactNames: string[];
+};
+
 type ManagedNpmRootLockfile = {
   packages?: Record<string, unknown>;
   dependencies?: Record<string, unknown>;
@@ -54,6 +59,13 @@ type ManagedNpmRootLogger = {
 type ManagedNpmRootRunCommand = typeof runCommandWithTimeout;
 
 type ManagedNpmRootOpenClawHostState = "none" | "managed-active-host" | "linked-active-host";
+
+const MANAGED_NPM_ROOT_REBUILD_ARTIFACT_NAMES = [
+  "node_modules",
+  "package-lock.json",
+  "npm-shrinkwrap.json",
+] as const;
+const MANAGED_NPM_ROOT_QUARANTINE_DIR = "_openclaw-quarantined-npm-roots";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -537,6 +549,42 @@ function isHostPeerResolutionFailure(
 ): boolean {
   const output = `${result.stdout}\n${result.stderr}`;
   return /(^|[^@\w.-])openclaw(?=$|[@\s:,"'])/i.test(output);
+}
+
+export function shouldRebuildManagedNpmRootAfterInstallFailure(result: {
+  stdout: string;
+  stderr: string;
+}): boolean {
+  const output = `${result.stderr}\n${result.stdout}`;
+  return (
+    output.includes("ERR_INVALID_ARG_TYPE") &&
+    output.includes('"from" argument') &&
+    output.includes("Received undefined")
+  );
+}
+
+export async function quarantineManagedNpmRootForRebuild(params: {
+  npmRoot: string;
+}): Promise<ManagedNpmRootQuarantineResult> {
+  await fs.mkdir(params.npmRoot, { recursive: true });
+  const quarantineParent = path.join(params.npmRoot, MANAGED_NPM_ROOT_QUARANTINE_DIR);
+  await fs.mkdir(quarantineParent, { recursive: true });
+  const quarantineDir = await fs.mkdtemp(path.join(quarantineParent, "corrupt-"));
+  const movedArtifactNames: string[] = [];
+  for (const artifactName of MANAGED_NPM_ROOT_REBUILD_ARTIFACT_NAMES) {
+    const source = path.join(params.npmRoot, artifactName);
+    const destination = path.join(quarantineDir, artifactName);
+    try {
+      await fs.rename(source, destination);
+      movedArtifactNames.push(artifactName);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        continue;
+      }
+      throw error;
+    }
+  }
+  return { quarantineDir, movedArtifactNames };
 }
 
 function createManagedNpmPeerPlanArgs(params?: {

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -37,6 +37,17 @@ function successfulSpawn(stdout = "") {
   };
 }
 
+function failedSpawn(stderr: string) {
+  return {
+    code: 1,
+    stdout: "",
+    stderr,
+    signal: null,
+    killed: false,
+    termination: "exit" as const,
+  };
+}
+
 function npmViewArgv(spec: string): string[] {
   return ["npm", "view", spec, "name", "version", "dist.integrity", "dist.shasum", "--json"];
 }
@@ -1181,6 +1192,212 @@ describe("installPluginFromNpmSpec", () => {
     await expect(
       fs.promises.access(path.join(npmRoot, "node_modules", "openclaw")),
     ).rejects.toHaveProperty("code", "ENOENT");
+  });
+
+  it("quarantines and rebuilds corrupt managed npm roots before retrying npm install", async () => {
+    const stateDir = suiteTempRootTracker.makeTempDir();
+    const npmRoot = path.join(stateDir, "npm");
+    fs.mkdirSync(path.join(npmRoot, "node_modules", "existing-plugin"), { recursive: true });
+    fs.writeFileSync(path.join(npmRoot, "node_modules", "existing-plugin", "stale.txt"), "stale");
+    fs.writeFileSync(
+      path.join(npmRoot, "package.json"),
+      `${JSON.stringify(
+        {
+          private: true,
+          dependencies: {
+            "existing-plugin": "1.0.0",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    const stalePackageLock = `${JSON.stringify(
+      {
+        lockfileVersion: 3,
+        marker: "stale lock",
+        packages: {
+          "": {
+            dependencies: {
+              "existing-plugin": "1.0.0",
+            },
+          },
+        },
+      },
+      null,
+      2,
+    )}\n`;
+    fs.writeFileSync(path.join(npmRoot, "package-lock.json"), stalePackageLock, "utf8");
+    fs.writeFileSync(path.join(npmRoot, "npm-shrinkwrap.json"), "stale shrinkwrap", "utf8");
+
+    mockNpmViewAndInstallMany([
+      {
+        packageName: "existing-plugin",
+        version: "1.0.0",
+        pluginId: "existing-plugin",
+        npmRoot,
+        expectedDependencySpec: "1.0.0",
+      },
+      {
+        spec: "@openclaw/voice-call@0.0.1",
+        packageName: "@openclaw/voice-call",
+        version: "0.0.1",
+        pluginId: "voice-call",
+        npmRoot,
+        expectedDependencySpec: "0.0.1",
+      },
+    ]);
+    const baseImplementation = runCommandWithTimeoutMock.getMockImplementation();
+    let installAttempts = 0;
+    runCommandWithTimeoutMock.mockImplementation(
+      async (argv: string[], options?: { cwd?: string }) => {
+        if (isManagedNpmInstallCommand(argv)) {
+          installAttempts += 1;
+          if (installAttempts === 1) {
+            return failedSpawn(
+              [
+                "npm error code ERR_INVALID_ARG_TYPE",
+                'npm error The "from" argument must be of type string. Received undefined',
+              ].join("\n"),
+            );
+          }
+        }
+        return await baseImplementation?.(argv, options);
+      },
+    );
+    const warnings: string[] = [];
+
+    const result = await installPluginFromNpmSpec({
+      spec: "@openclaw/voice-call@0.0.1",
+      npmDir: npmRoot,
+      logger: { info: () => {}, warn: (message) => warnings.push(message) },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.pluginId).toBe("voice-call");
+    expect(installAttempts).toBe(3);
+    expect(warnings.some((warning) => warning.includes("managed npm root corruption"))).toBe(true);
+    const quarantineRoot = path.join(npmRoot, "_openclaw-quarantined-npm-roots");
+    const quarantineEntries = fs.readdirSync(quarantineRoot);
+    expect(quarantineEntries).toHaveLength(1);
+    const quarantineDir = path.join(quarantineRoot, quarantineEntries[0] ?? "");
+    expect(
+      fs.readFileSync(
+        path.join(quarantineDir, "node_modules", "existing-plugin", "stale.txt"),
+        "utf8",
+      ),
+    ).toBe("stale");
+    expect(fs.readFileSync(path.join(quarantineDir, "package-lock.json"), "utf8")).toBe(
+      stalePackageLock,
+    );
+    expect(fs.readFileSync(path.join(quarantineDir, "npm-shrinkwrap.json"), "utf8")).toBe(
+      "stale shrinkwrap",
+    );
+    expect(fs.existsSync(path.join(npmRoot, "node_modules", "@openclaw", "voice-call"))).toBe(true);
+    expect(fs.existsSync(path.join(npmRoot, "node_modules", "existing-plugin"))).toBe(true);
+  });
+
+  it("fails closed when npm install still fails after managed npm root recovery", async () => {
+    const stateDir = suiteTempRootTracker.makeTempDir();
+    const npmRoot = path.join(stateDir, "npm");
+    fs.mkdirSync(path.join(npmRoot, "node_modules", "existing-plugin"), { recursive: true });
+    fs.writeFileSync(
+      path.join(npmRoot, "package.json"),
+      `${JSON.stringify(
+        {
+          private: true,
+          dependencies: {
+            "existing-plugin": "1.0.0",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(npmRoot, "package-lock.json"),
+      `${JSON.stringify(
+        {
+          lockfileVersion: 3,
+          marker: "stale lock",
+          packages: {
+            "": {
+              dependencies: {
+                "existing-plugin": "1.0.0",
+              },
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    mockNpmViewAndInstallMany([
+      {
+        packageName: "existing-plugin",
+        version: "1.0.0",
+        pluginId: "existing-plugin",
+        npmRoot,
+        expectedDependencySpec: "1.0.0",
+      },
+      {
+        spec: "@openclaw/voice-call@0.0.1",
+        packageName: "@openclaw/voice-call",
+        version: "0.0.1",
+        pluginId: "voice-call",
+        npmRoot,
+        expectedDependencySpec: "0.0.1",
+      },
+    ]);
+    const baseImplementation = runCommandWithTimeoutMock.getMockImplementation();
+    let installAttempts = 0;
+    runCommandWithTimeoutMock.mockImplementation(
+      async (argv: string[], options?: { cwd?: string }) => {
+        if (isManagedNpmInstallCommand(argv)) {
+          installAttempts += 1;
+          if (installAttempts === 1) {
+            return failedSpawn(
+              [
+                "npm error code ERR_INVALID_ARG_TYPE",
+                'npm error The "from" argument must be of type string. Received undefined',
+              ].join("\n"),
+            );
+          }
+          if (installAttempts === 3) {
+            return failedSpawn("registry unavailable after rebuild");
+          }
+        }
+        return await baseImplementation?.(argv, options);
+      },
+    );
+
+    const result = await installPluginFromNpmSpec({
+      spec: "@openclaw/voice-call@0.0.1",
+      npmDir: npmRoot,
+      logger: { info: () => {}, warn: () => {} },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.error).toContain("npm install failed after managed npm root recovery");
+    expect(result.error).toContain("registry unavailable after rebuild");
+    expect(installAttempts).toBeGreaterThanOrEqual(3);
+    const manifest = JSON.parse(fs.readFileSync(path.join(npmRoot, "package.json"), "utf8")) as {
+      dependencies?: Record<string, string>;
+    };
+    expect(manifest.dependencies?.["@openclaw/voice-call"]).toBeUndefined();
+    expect(fs.existsSync(path.join(npmRoot, "node_modules", "@openclaw", "voice-call"))).toBe(
+      false,
+    );
   });
 
   it("retries without npm alias overrides when npm rejects alias comparators", async () => {

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -13,6 +13,7 @@ import {
 import { resolveNpmIntegrityDriftWithDefaultMessage } from "../infra/npm-integrity.js";
 import {
   type ManagedNpmRootPeerDependencySnapshot,
+  quarantineManagedNpmRootForRebuild,
   readManagedNpmRootInstalledDependency,
   readManagedNpmRootPeerDependencySnapshot,
   readOpenClawManagedNpmRootOverrides,
@@ -20,6 +21,7 @@ import {
   removeManagedNpmRootDependency,
   resolveManagedNpmRootDependencySpec,
   restoreManagedNpmRootPeerDependencySnapshot,
+  shouldRebuildManagedNpmRootAfterInstallFailure,
   syncManagedNpmRootPeerDependencies,
   upsertManagedNpmRootDependency,
   type ManagedNpmRootInstalledDependency,
@@ -146,6 +148,8 @@ type PluginInstallPolicyRequest = {
 };
 
 const defaultLogger: PluginInstallLogger = {};
+
+type ManagedNpmInstallCommandResult = Awaited<ReturnType<typeof runCommandWithTimeout>>;
 
 function ensureOpenClawExtensions(params: { manifest: PackageManifest }):
   | {
@@ -472,6 +476,86 @@ async function rollbackManagedNpmPluginInstall(params: {
   }
 }
 
+function formatNpmCommandFailureOutput(
+  result: Pick<ManagedNpmInstallCommandResult, "stdout" | "stderr">,
+): string {
+  return result.stderr.trim() || result.stdout.trim();
+}
+
+function formatManagedNpmRootRecoveryArtifacts(artifactNames: string[]): string {
+  return artifactNames.length > 0 ? artifactNames.join(", ") : "no existing artifacts";
+}
+
+async function rebuildManagedNpmRootAfterCorruptInstallFailure(params: {
+  npmRoot: string;
+  npmInstallArgs: string[];
+  npmInstallOptions: {
+    cwd: string;
+    timeoutMs: number;
+    env: NodeJS.ProcessEnv;
+  };
+  logger: PluginInstallLogger;
+  failure: ManagedNpmInstallCommandResult;
+}): Promise<
+  | {
+      ok: true;
+      quarantineDir: string;
+      movedArtifactNames: string[];
+    }
+  | {
+      ok: false;
+      error: string;
+    }
+> {
+  const originalError = formatNpmCommandFailureOutput(params.failure);
+  let quarantine: Awaited<ReturnType<typeof quarantineManagedNpmRootForRebuild>>;
+  try {
+    quarantine = await quarantineManagedNpmRootForRebuild({ npmRoot: params.npmRoot });
+  } catch (error) {
+    return {
+      ok: false,
+      error:
+        "npm install failed with a managed npm root corruption signature, " +
+        `but OpenClaw could not quarantine ${params.npmRoot} for rebuild: ${String(error)}. ` +
+        `Original npm error: ${originalError}`,
+    };
+  }
+
+  params.logger.warn?.(
+    `npm reported a managed npm root corruption signature; quarantined ${formatManagedNpmRootRecoveryArtifacts(quarantine.movedArtifactNames)} at ${quarantine.quarantineDir} and rebuilding once before retrying.`,
+  );
+
+  let rebuild: ManagedNpmInstallCommandResult;
+  try {
+    rebuild = await runCommandWithTimeout(params.npmInstallArgs, params.npmInstallOptions);
+  } catch (error) {
+    return {
+      ok: false,
+      error:
+        "managed npm root recovery failed after quarantining " +
+        `${formatManagedNpmRootRecoveryArtifacts(quarantine.movedArtifactNames)} at ${quarantine.quarantineDir}: ` +
+        `npm rebuild threw: ${String(error)}. ` +
+        `Original npm error: ${originalError}`,
+    };
+  }
+  if (rebuild.code !== 0) {
+    return {
+      ok: false,
+      error:
+        "managed npm root recovery failed after quarantining " +
+        `${formatManagedNpmRootRecoveryArtifacts(quarantine.movedArtifactNames)} at ${quarantine.quarantineDir}: ` +
+        `npm rebuild failed: ${formatNpmCommandFailureOutput(rebuild)}. ` +
+        `Original npm error: ${originalError}`,
+    };
+  }
+
+  return {
+    ok: true,
+    quarantineDir: quarantine.quarantineDir,
+    movedArtifactNames: quarantine.movedArtifactNames,
+  };
+}
+
 function resolveInstalledNpmResolutionMismatch(params: {
   packageName: string;
   expected: NpmSpecResolution;
@@ -706,6 +790,7 @@ async function installPluginFromManagedNpmRoot(
   };
   let install = await runCommandWithTimeout(npmInstallArgs, npmInstallOptions);
   let omitUnsupportedManagedOverrides = false;
+  let managedNpmRootRecovery: { quarantineDir: string } | null = null;
   if (install.code !== 0 && isNpmAliasOverrideComparatorError(install)) {
     logger.warn?.(
       "npm rejected managed npm alias overrides; retrying plugin install without alias overrides for this npm version.",
@@ -726,6 +811,20 @@ async function installPluginFromManagedNpmRoot(
     }
     install = await runCommandWithTimeout(npmInstallArgs, npmInstallOptions);
   }
+  if (install.code !== 0 && shouldRebuildManagedNpmRootAfterInstallFailure(install)) {
+    const recovery = await rebuildManagedNpmRootAfterCorruptInstallFailure({
+      npmRoot,
+      npmInstallArgs,
+      npmInstallOptions,
+      logger,
+      failure: install,
+    });
+    if (!recovery.ok) {
+      return await rollbackFailedManagedNpmInstall(recovery.error);
+    }
+    managedNpmRootRecovery = { quarantineDir: recovery.quarantineDir };
+    install = await runCommandWithTimeout(npmInstallArgs, npmInstallOptions);
+  }
   if (install.code !== 0) {
     await rollbackManagedNpmPluginInstall({
       npmRoot,
@@ -737,7 +836,9 @@ async function installPluginFromManagedNpmRoot(
     });
     return {
       ok: false,
-      error: `npm install failed: ${install.stderr.trim() || install.stdout.trim()}`,
+      error: managedNpmRootRecovery
+        ? `npm install failed after managed npm root recovery (quarantine: ${managedNpmRootRecovery.quarantineDir}): ${formatNpmCommandFailureOutput(install)}`
+        : `npm install failed: ${formatNpmCommandFailureOutput(install)}`,
     };
   }
   let settledManagedPeerDependencies = false;


### PR DESCRIPTION
## Summary

Fixes #85113. On a managed npm root (`~/.openclaw/npm`), npm's Arborist can crash with `ERR_INVALID_ARG_TYPE` and leave the root half-broken. After that, post-update official plugin sync fails (and `disableOnFailure` disables the plugin), and subsequent `plugins install --force` keeps hitting the same corrupted root.

This adds a **generic, defensive recovery** for the managed npm root, and removes a misleading message on the failure path.

## What changed

- **`src/infra/npm-managed-root.ts`**
  - `shouldRebuildManagedNpmRootAfterInstallFailure()` — gates recovery on the specific corrupt-root npm signature only (requires `ERR_INVALID_ARG_TYPE` **and** `"from" argument` **and** `Received undefined` to co-occur, so registry/network/auth failures don't trigger it).
  - `quarantineManagedNpmRootForRebuild()` — moves **only** the managed root's own `node_modules` / `package-lock.json` / `npm-shrinkwrap.json` into `_openclaw-quarantined-npm-roots/corrupt-*` (all destinations inside the managed root; uses `fs.rename`, which does not follow symlinks; no recursive delete). Root metadata (`package.json`, `.npmrc`, pack archives) is preserved.
- **`src/plugins/install.ts`** — on the corrupt signature: quarantine → rebuild once → retry install once. If rebuild or retry still fails, it **fails closed**, preserving the quarantine and surfacing both the quarantine path and the original npm error.
- **`src/cli/plugins-command-helpers.ts` / `plugins-install-command.ts`** — when the primary npm install (or the recovery rebuild) fails, no longer attempt the hook-pack fallback or print the misleading `Also not a valid hook pack`. Manifest-type failures still keep the hook-pack fallback.

## Scope / honesty

- Recovery lives in the install path, so update / doctor / manual install all benefit, without baking post-update or any per-plugin policy into core. It is **not** specialized for Codex.
- The exact npm Arborist `ERR_INVALID_ARG_TYPE` crash is live/package/root-state dependent — I did **not** reproduce it from source. This is framed as **defensive recovery** for a corrupt managed root; proof is via mocked failures exercising both the success (quarantine → rebuild → retry → success) and fail-closed (retry-after-recovery fails) paths.
- Recovery is strictly bounded to rebuild-once + retry-once (no loop).

## Tests

All run via `node scripts/run-vitest.mjs <file> -- --reporter=verbose`:

- `src/infra/npm-managed-root.test.ts` — 20 passed
- `src/plugins/install.npm-spec.test.ts` — 39 passed (covers quarantine→rebuild→retry success and fail-closed)
- `src/cli/plugins-cli.install.test.ts` — 87 passed (incl. new regression: no hook-pack fallback / no misleading message on rebuild-failure)
- `src/cli/update-cli.test.ts` — 124 passed
- `pnpm format:check` on touched files — clean

Reviewed independently before submission (cross-model review), which caught and fixed a gap where the rebuild-failure error didn't match the hook-pack suppression predicate.