### PR TITLE
fix(agents): avoid session event queue self-wait

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -1189,6 +1189,147 @@ describe("embedded attempt session lock lifecycle", () => {
     ]);
   });
 
+  it("does not wait on the session event queue from a hook running during active event processing", async () => {
+    const events: string[] = [];
+    const session = {
+      _agentEventQueue: Promise.resolve(),
+      _extensionRunner: {
+        hasHandlers: vi.fn((eventType: string) => eventType === "tool_call"),
+      },
+      _processAgentEvent: vi.fn(async (event: { type?: string }) => {
+        events.push(`process:${event.type}`);
+        await session.agent.beforeToolCall();
+        events.push("process:end");
+      }),
+      _handleAgentEvent(event: { type?: string }) {
+        events.push(`handle:${event.type}`);
+        session["_agentEventQueue"] = session["_agentEventQueue"].then(() =>
+          session["_processAgentEvent"](event),
+        );
+        session["_agentEventQueue"].catch(() => {});
+      },
+      agent: {
+        beforeToolCall: vi.fn(async () => {
+          events.push("hook");
+        }),
+      },
+    };
+
+    installSessionEventWriteLock({
+      session,
+      withSessionWriteLock: async (run) => {
+        events.push("event-lock");
+        return await run();
+      },
+    });
+    installSessionExternalHookWriteLock({
+      session,
+      withSessionWriteLock: async (run) => {
+        events.push("hook-lock");
+        return await run();
+      },
+    });
+
+    const result = session["_handleAgentEvent"]({
+      type: "tool_call",
+    }) as unknown as Promise<unknown>;
+    const completion = await Promise.race([
+      result.then(() => "done"),
+      new Promise<string>((resolve) => {
+        setTimeout(() => resolve("timeout"), 25);
+      }),
+    ]);
+
+    expect(completion).toBe("done");
+    expect(events).toEqual([
+      "event-lock",
+      "handle:tool_call",
+      "process:tool_call",
+      "hook-lock",
+      "hook",
+      "process:end",
+    ]);
+  });
+
+  it("drains queued session events for async hook work spawned after event processing returns", async () => {
+    const events: string[] = [];
+    let releaseQueue!: () => void;
+    let spawnedHook!: Promise<void>;
+    const session = {
+      _agentEventQueue: Promise.resolve(),
+      _extensionRunner: {
+        hasHandlers: vi.fn((eventType: string) => eventType === "tool_call"),
+      },
+      _processAgentEvent: vi.fn(async (event: { type?: string }) => {
+        events.push(`process:${event.type}`);
+        spawnedHook = new Promise<void>((resolve, reject) => {
+          setTimeout(() => {
+            session.agent.beforeToolCall().then(resolve, reject);
+          }, 0);
+        });
+        session["_agentEventQueue"] = new Promise<void>((resolve) => {
+          releaseQueue = resolve;
+        }).then(() => {
+          events.push("queue-drained");
+        });
+        events.push("process:end");
+      }),
+      _handleAgentEvent(event: { type?: string }) {
+        events.push(`handle:${event.type}`);
+        session["_agentEventQueue"] = session["_agentEventQueue"].then(() =>
+          session["_processAgentEvent"](event),
+        );
+        session["_agentEventQueue"].catch(() => {});
+      },
+      agent: {
+        beforeToolCall: vi.fn(async () => {
+          events.push("hook");
+        }),
+      },
+    };
+
+    installSessionEventWriteLock({
+      session,
+      withSessionWriteLock: async (run) => {
+        events.push("event-lock");
+        return await run();
+      },
+    });
+    installSessionExternalHookWriteLock({
+      session,
+      withSessionWriteLock: async (run) => {
+        events.push("hook-lock");
+        return await run();
+      },
+    });
+
+    session["_handleAgentEvent"]({ type: "tool_call" });
+    await new Promise<void>((resolve) => setTimeout(resolve, 5));
+
+    const beforeQueueRelease = await Promise.race([
+      spawnedHook.then(() => "done"),
+      new Promise<string>((resolve) => {
+        setTimeout(() => resolve("waiting"), 25);
+      }),
+    ]);
+
+    expect(beforeQueueRelease).toBe("waiting");
+    expect(events).toEqual(["event-lock", "handle:tool_call", "process:tool_call", "process:end"]);
+
+    releaseQueue();
+    await spawnedHook;
+
+    expect(events).toEqual([
+      "event-lock",
+      "handle:tool_call",
+      "process:tool_call",
+      "process:end",
+      "queue-drained",
+      "hook-lock",
+      "hook",
+    ]);
+  });
+
   it("locks OpenClaw extension hooks that can mutate the session outside agent events", async () => {
     const locked: string[] = [];
     const called: string[] = [];

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -74,6 +74,32 @@ type LockableFunction = ((...args: unknown[]) => unknown) & {
   __openclawSessionWriteLockInstalled?: boolean;
 };
 
+type SessionEventHookContext = {
+  session: unknown;
+  active: boolean;
+};
+
+const sessionEventHookContext = new AsyncLocalStorage<SessionEventHookContext>();
+
+function isProcessingAgentEventInCurrentChain(session: unknown): boolean {
+  const context = sessionEventHookContext.getStore();
+  return context?.active === true && context.session === session;
+}
+
+async function withProcessingAgentEvent<T>(
+  session: unknown,
+  run: () => Promise<T> | T,
+): Promise<T> {
+  const context: SessionEventHookContext = { session, active: true };
+  return await sessionEventHookContext.run(context, async () => {
+    try {
+      return await run();
+    } finally {
+      context.active = false;
+    }
+  });
+}
+
 function sessionHasExtensionHandlers(session: SessionEventProcessor, eventType: string): boolean {
   const extensionRunner = session["_extensionRunner"];
   const hasHandlers = extensionRunner?.hasHandlers;
@@ -662,6 +688,15 @@ async function waitForSessionEventQueue(session: unknown): Promise<void> {
   }
 }
 
+async function waitForSessionEventQueueBeforeHook(session: unknown): Promise<void> {
+  // Hook calls made by _handleAgentEvent are already inside the current queue
+  // entry. Draining there waits on itself; detached/external hook work still drains.
+  if (isProcessingAgentEventInCurrentChain(session)) {
+    return;
+  }
+  await waitForSessionEventQueue(session);
+}
+
 function installAwaitableSessionEventQueue(session: unknown): void {
   const owner = session as SessionEventQueueBridge;
   const original = owner["_handleAgentEvent"];
@@ -731,10 +766,14 @@ export function installSessionEventWriteLock(params: {
     event: unknown,
     signal?: unknown,
   ) {
-    if (!eventMayReachTranscriptWriters(session, event)) {
-      return await original.call(this, event, signal);
-    }
-    return await params.withSessionWriteLock(async () => await original.call(this, event, signal));
+    return await withProcessingAgentEvent(session, async () => {
+      if (!eventMayReachTranscriptWriters(session, event)) {
+        return await original.call(this, event, signal);
+      }
+      return await params.withSessionWriteLock(
+        async () => await original.call(this, event, signal),
+      );
+    });
   };
   wrapped["__openclawSessionEventQueueAwaitInstalled"] =
     original["__openclawSessionEventQueueAwaitInstalled"];
@@ -756,28 +795,28 @@ export function installSessionExternalHookWriteLock(params: {
       owner: agent as Record<string, unknown>,
       key: "beforeToolCall",
       shouldLock: () => true,
-      waitBeforeLock: () => waitForSessionEventQueue(session),
+      waitBeforeLock: () => waitForSessionEventQueueBeforeHook(session),
       withSessionWriteLock: params.withSessionWriteLock,
     });
     installLockableFunction({
       owner: agent as Record<string, unknown>,
       key: "afterToolCall",
       shouldLock: () => sessionHasExtensionHandlers(session, "tool_result"),
-      waitBeforeLock: () => waitForSessionEventQueue(session),
+      waitBeforeLock: () => waitForSessionEventQueueBeforeHook(session),
       withSessionWriteLock: params.withSessionWriteLock,
     });
     installLockableFunction({
       owner: agent as Record<string, unknown>,
       key: "onPayload",
       shouldLock: () => sessionHasExtensionHandlers(session, "before_provider_request"),
-      waitBeforeLock: () => waitForSessionEventQueue(session),
+      waitBeforeLock: () => waitForSessionEventQueueBeforeHook(session),
       withSessionWriteLock: params.withSessionWriteLock,
     });
     installLockableFunction({
       owner: agent as Record<string, unknown>,
       key: "onResponse",
       shouldLock: () => sessionHasExtensionHandlers(session, "after_provider_response"),
-      waitBeforeLock: () => waitForSessionEventQueue(session),
+      waitBeforeLock: () => waitForSessionEventQueueBeforeHook(session),
       withSessionWriteLock: params.withSessionWriteLock,
     });
   }


### PR DESCRIPTION
Embedded Pi tool-call processing can self-wait on its own session event queue entry, leaving the Gateway alive but unresponsive to channel replies and health/status probes.

Fixes #86093

## Affected surface

- `src/agents/pi-embedded-runner/run/attempt.session-lock.ts`
  - `waitForSessionEventQueue`
  - `installSessionEventWriteLock`
  - `installSessionExternalHookWriteLock` interaction through `beforeToolCall`
- `src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts`

## Scope

- Adds a focused active session event processing context.
- Skips `waitForSessionEventQueue(session)` only when the current hook is already running inside that same session's active event-processing entry.
- Preserves external queue-drain behavior for cleanup, external hooks, provider hooks, and compaction paths.
- No new config, flags, lock policy, timeout policy, or channel-specific behavior.

## Prior art / reporter credit

Reporter `de1tydev` provided the production diagnostics and a candidate fork commit (`e1765a6dcd fix(agents): avoid session event queue self-wait`). This PR follows that same narrow fix shape and keeps the behavior boundary explicit: self-wait is skipped only for the active same-session event-processing context; all external callers still drain pending session events normally.

## Real behavior proof

- **Behavior or issue addressed:** Embedded Pi tool-call processing no longer waits on the same active session event queue entry from inside `beforeToolCall`; this addresses the Gateway availability hang reported in #86093.
- **Real environment tested:** Local Linux OpenClaw checkout at PR head `45f14e72b8a3c34197883d8ff86d8b17cfb86442`, running the actual TypeScript source module through `node --import tsx`. This is a runtime helper proof for the session-lock path, not a mocked unit test.
- **Exact steps or command run after this patch:** `OPENCLAW_PR_HEAD=45f14e72b8a3c34197883d8ff86d8b17cfb86442 node --import tsx /tmp/openclaw-pr86123-runtime-proof.mjs`
- **Evidence after fix:** Runtime helper console output from current PR head:

  ```text
  [OpenClaw #86123 runtime helper proof] head=45f14e72b8a3c34197883d8ff86d8b17cfb86442
  [OpenClaw #86123 runtime helper proof] startedAt=2026-05-24T16:32:00.490Z
  [OpenClaw #86123 runtime helper proof] behavior=session event hook self-wait guard
  [OpenClaw #86123 runtime helper proof] command=node --import tsx /tmp/openclaw-pr86123-runtime-proof.mjs
  [OpenClaw #86123 runtime helper proof] outcome=completed
  [OpenClaw #86123 runtime helper proof] events=["process:tool_call","hook-lock","hook","process:end"]
  ```

  Current-head runtime helper refresh after the active-state follow-up:

  ```text
  $ OPENCLAW_PR_HEAD=5fb473b48e875f41c8521adf8218f16cf5abb798 node --import tsx /tmp/openclaw-pr86123-runtime-proof-current.mjs
  [OpenClaw #86123 runtime helper proof] head=5fb473b48e875f41c8521adf8218f16cf5abb798
  [OpenClaw #86123 runtime helper proof] command=node --import tsx /tmp/openclaw-pr86123-runtime-proof-current.mjs
  [OpenClaw #86123 runtime helper proof] scenario=active-same-session-event-hook outcome=completed
  [OpenClaw #86123 runtime helper proof] activeEvents=["process:tool_call","hook-lock","hook","process:end"]
  [OpenClaw #86123 runtime helper proof] scenario=detached-async-hook-after-event outcome=waited-then-completed
  [OpenClaw #86123 runtime helper proof] detachedEvents=["process:tool_call","process:end","queue-drained","hook-lock","hook"]
  ```

  Supplemental RED/GREEN regression:

  ```text
  $ node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-pi-embedded.config.ts src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts -t "does not wait on the session event queue"

  RED before implementation:
  FAIL src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts > embedded attempt session lock lifecycle > does not wait on the session event queue from a hook running during active event processing
  AssertionError: expected 'timeout' to be 'done'

  GREEN after implementation:
  Test Files  1 passed (1)
  Tests  1 passed | 32 skipped (33)
  Duration  1.45s
  ```
- **Observed result after fix:** The actual current-head session-lock module completed the active event-processing hook path within the 250ms guard and produced `events=["process:tool_call","hook-lock","hook","process:end"]`, showing the hook lock ran without waiting on the pending `_agentEventQueue` entry. Before the fix, the same regression path timed out.
- **What was not tested:** I did not run a live Feishu/Gateway production reproduction or a full Pi model/tool-call turn against an external provider. The live production evidence remains the reporter's redacted diagnostics in #86093; this PR adds current-head source/runtime proof for the exact lock path.

## Targeted test output

Full targeted file:

```text
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-pi-embedded.config.ts src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts

Test Files  1 passed (1)
Tests  33 passed (33)
Duration  3.58s
```

Changed checks:

```text
$ pnpm check:changed --base origin/main
[check:changed] lanes=core, coreTests
[check:changed] src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts: core test
[check:changed] src/agents/pi-embedded-runner/run/attempt.session-lock.ts: core production
...
Import cycle check: 0 runtime value cycle(s).
exit 0
```

Additional local checks:

```text
$ git diff --check origin/main..HEAD
exit 0

$ node scripts/check-no-conflict-markers.mjs
exit 0

$ gitleaks protect --staged --redact
no leaks found
```

## Coverage note

Push-before-PR open-PR search on current `origin/main` (`5a8ce6a88572552dc7cbc1e5b9b9920d8378789d`) found no competing fix:

```text
gh search prs --repo openclaw/openclaw --state open "Fixes #86093" => []
gh search prs --repo openclaw/openclaw --state open "#86093" => []
gh search prs --repo openclaw/openclaw --state open "waitForSessionEventQueue" => []
gh search prs --repo openclaw/openclaw --state open "attempt.session-lock.ts beforeToolCall" => []
gh search prs --repo openclaw/openclaw --state open "session event queue self-wait" => []
```

Recent main commits touch nearby embedded session-lock behavior, but none cover this same active queue-entry self-wait. This PR deliberately avoids broad lock lifecycle changes and keeps the fix at the event queue ownership boundary.
