### PR TITLE
fix(plugin-sdk): restore Codex task runtime export compat

### DIFF
--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -11,8 +11,9 @@ The plugin SDK is exposed as a set of narrow public subpaths under
 purpose. The generated compiler entrypoint inventory lives in
 `scripts/lib/plugin-sdk-entrypoints.json`; package exports are the public subset
 after subtracting repo-local test/internal subpaths listed in
-`scripts/lib/plugin-sdk-private-local-only-subpaths.json`. Maintainers can audit
-the public export count with `pnpm plugin-sdk:surface` and active reserved
+`scripts/lib/plugin-sdk-private-local-only-subpaths.json`, plus a tiny
+compatibility exception for stale official bundled-plugin installs. Maintainers
+can audit the public export count with `pnpm plugin-sdk:surface` and active reserved
 helper subpaths with `pnpm plugins:boundary-report:summary`; unused reserved
 helper exports fail the CI report instead of staying in the public SDK as
 dormant compatibility debt.

--- a/package.json
+++ b/package.json
@@ -1363,6 +1363,10 @@
       "types": "./dist/plugin-sdk/zod.d.ts",
       "default": "./dist/plugin-sdk/zod.js"
     },
+    "./plugin-sdk/codex-native-task-runtime": {
+      "types": "./dist/plugin-sdk/codex-native-task-runtime.d.ts",
+      "default": "./dist/plugin-sdk/codex-native-task-runtime.js"
+    },
     "./extension-api": "./dist/extensionAPI.js",
     "./cli-entry": "./openclaw.mjs"
   },

--- a/scripts/lib/plugin-sdk-entries.d.mts
+++ b/scripts/lib/plugin-sdk-entries.d.mts
@@ -3,6 +3,8 @@ export const pluginSdkSubpaths: string[];
 export const privateLocalOnlyPluginSdkEntrypoints: string[];
 export const publicPluginSdkEntrypoints: string[];
 export const publicPluginSdkSubpaths: string[];
+export const packageExportedCompatibilityPluginSdkEntrypoints: string[];
+export const packageExportedPluginSdkEntrypoints: string[];
 export const deprecatedPublicPluginSdkEntrypoints: string[];
 export const deprecatedBarrelPluginSdkEntrypoints: string[];
 

--- a/scripts/lib/plugin-sdk-entries.mjs
+++ b/scripts/lib/plugin-sdk-entries.mjs
@@ -25,6 +25,13 @@ export const publicPluginSdkSubpaths = publicPluginSdkEntrypoints.filter(
   (entry) => entry !== "index",
 );
 
+export const packageExportedCompatibilityPluginSdkEntrypoints = ["codex-native-task-runtime"];
+
+export const packageExportedPluginSdkEntrypoints = [
+  ...publicPluginSdkEntrypoints,
+  ...packageExportedCompatibilityPluginSdkEntrypoints,
+];
+
 export const deprecatedPublicPluginSdkEntrypoints = publicPluginSdkSubpaths.filter((entry) =>
   deprecatedPublicPluginSdkSubpathList.includes(entry),
 );
@@ -41,7 +48,7 @@ export function buildPluginSdkEntrySources() {
 
 export function buildPluginSdkPackageExports() {
   return Object.fromEntries(
-    publicPluginSdkEntrypoints.map((entry) => [
+    packageExportedPluginSdkEntrypoints.map((entry) => [
       entry === "index" ? "./plugin-sdk" : `./plugin-sdk/${entry}`,
       {
         types: `./dist/plugin-sdk/${entry}.d.ts`,

--- a/src/plugin-sdk/entrypoints.ts
+++ b/src/plugin-sdk/entrypoints.ts
@@ -25,6 +25,18 @@ export const publicPluginSdkSubpaths = publicPluginSdkEntrypoints.filter(
   (entry) => entry !== "index",
 );
 
+// Stale official Codex installs still import this legacy task-runtime subpath during
+// npm/global upgrade windows, so it stays in package exports even though source/dev
+// alias flows continue to treat it as a bundled-plugin-owned compatibility surface.
+export const packageExportedCompatibilityPluginSdkEntrypoints = [
+  "codex-native-task-runtime",
+] as const;
+
+export const packageExportedPluginSdkEntrypoints = [
+  ...publicPluginSdkEntrypoints,
+  ...packageExportedCompatibilityPluginSdkEntrypoints,
+];
+
 export const deprecatedPublicPluginSdkEntrypoints = publicPluginSdkSubpaths.filter((entry) =>
   deprecatedPublicPluginSdkSubpathList.includes(entry),
 );
@@ -89,7 +101,7 @@ export function buildPluginSdkEntrySources(entries: readonly string[] = pluginSd
 
 /** List the public package specifiers that should resolve to plugin SDK entrypoints. */
 export function buildPluginSdkSpecifiers() {
-  return publicPluginSdkEntrypoints.map((entry) =>
+  return packageExportedPluginSdkEntrypoints.map((entry) =>
     entry === "index" ? "openclaw/plugin-sdk" : `openclaw/plugin-sdk/${entry}`,
   );
 }
@@ -97,7 +109,7 @@ export function buildPluginSdkSpecifiers() {
 /** Build the package.json exports map for public plugin SDK subpaths. */
 export function buildPluginSdkPackageExports() {
   return Object.fromEntries(
-    publicPluginSdkEntrypoints.map((entry) => [
+    packageExportedPluginSdkEntrypoints.map((entry) => [
       entry === "index" ? "./plugin-sdk" : `./plugin-sdk/${entry}`,
       {
         types: `./dist/plugin-sdk/${entry}.d.ts`,

--- a/src/plugin-sdk/root-alias.cjs
+++ b/src/plugin-sdk/root-alias.cjs
@@ -10,6 +10,7 @@ const pluginSdkSubpathsCache = new Map();
 const pluginSdkPackageNames = ["openclaw/plugin-sdk", "@openclaw/plugin-sdk"];
 const pluginSdkSourceExtensions = [".ts", ".mts", ".js", ".mjs", ".cts", ".cjs"];
 const privateQaExcludedPluginSdkSubpaths = new Set(["ssrf-runtime-internal"]);
+const compatibilityOnlyExcludedPluginSdkSubpaths = new Set(["codex-native-task-runtime"]);
 const isDistRootAlias = __filename.includes(
   `${path.sep}dist${path.sep}plugin-sdk${path.sep}root-alias.cjs`,
 );
@@ -17,10 +18,9 @@ const isDistRootAlias = __filename.includes(
 // source root alias with dist compat/runtime shims can split singleton deps
 // (for example matrix-js-sdk) across two module graphs.
 const shouldPreferSourceGraph =
-  !isDistRootAlias &&
-  (process.env.NODE_ENV !== "production" ||
-    Boolean(process.env.VITEST) ||
-    process.env.OPENCLAW_PLUGIN_SDK_SOURCE_IN_TESTS === "1");
+  Boolean(process.env.VITEST) ||
+  process.env.OPENCLAW_PLUGIN_SDK_SOURCE_IN_TESTS === "1" ||
+  (!isDistRootAlias && process.env.NODE_ENV !== "production");
 
 function emptyPluginConfigSchema() {
   function error(message) {
@@ -120,6 +120,7 @@ function listPluginSdkExportedSubpaths() {
       .filter((key) => key.startsWith("./plugin-sdk/"))
       .map((key) => key.slice("./plugin-sdk/".length))
       .filter((subpath) => /^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(subpath))
+      .filter((subpath) => !compatibilityOnlyExcludedPluginSdkSubpaths.has(subpath))
       .toSorted();
   } catch {
     subpaths = [];

--- a/src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts
+++ b/src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   deprecatedBarrelPluginSdkEntrypoints,
   deprecatedPublicPluginSdkEntrypoints,
+  packageExportedPluginSdkEntrypoints,
   privateLocalOnlyPluginSdkEntrypoints,
   pluginSdkEntrypoints,
   publicPluginOwnedSdkEntrypoints,
@@ -689,7 +690,9 @@ describe("plugin-sdk package contract guardrails", () => {
   });
 
   it("keeps package.json exports aligned with built plugin-sdk entrypoints", () => {
-    expect(collectPluginSdkPackageExports()).toEqual([...publicPluginSdkEntrypoints].toSorted());
+    expect(collectPluginSdkPackageExports()).toEqual(
+      [...packageExportedPluginSdkEntrypoints].toSorted(),
+    );
   });
 
   it("keeps configured local-origin fetch helpers out of deprecated infra-runtime", () => {

--- a/src/plugins/contracts/plugin-sdk-root-alias.test.ts
+++ b/src/plugins/contracts/plugin-sdk-root-alias.test.ts
@@ -456,10 +456,25 @@ describe("plugin-sdk root alias", () => {
       "plugin-sdk",
       "codex-mcp-projection.ts",
     );
+    const sourceCodexNativeTaskRuntimePath = path.join(
+      packageRoot,
+      "src",
+      "plugin-sdk",
+      "codex-native-task-runtime.ts",
+    );
     const sourceQaRuntimePath = path.join(packageRoot, "src", "plugin-sdk", "qa-runtime.ts");
     const lazyModule = loadRootAliasWithStubs({
+      packageExports: {
+        "./plugin-sdk/codex-native-task-runtime": {
+          default: "./dist/plugin-sdk/codex-native-task-runtime.js",
+        },
+      },
       privateLocalOnlySubpaths: ["codex-mcp-projection", "qa-runtime"],
-      existingPaths: [sourceCodexMcpProjectionPath, sourceQaRuntimePath],
+      existingPaths: [
+        sourceCodexMcpProjectionPath,
+        sourceCodexNativeTaskRuntimePath,
+        sourceQaRuntimePath,
+      ],
       monolithicExports: {
         slowHelper: (): string => "loaded",
       },
@@ -469,6 +484,8 @@ describe("plugin-sdk root alias", () => {
     const aliasMap = (lazyModule.createJitiOptions.at(-1)?.alias ?? {}) as Record<string, string>;
     expect(aliasMap).not.toHaveProperty("openclaw/plugin-sdk/codex-mcp-projection");
     expect(aliasMap).not.toHaveProperty("@openclaw/plugin-sdk/codex-mcp-projection");
+    expect(aliasMap).not.toHaveProperty("openclaw/plugin-sdk/codex-native-task-runtime");
+    expect(aliasMap).not.toHaveProperty("@openclaw/plugin-sdk/codex-native-task-runtime");
     expect(aliasMap).not.toHaveProperty("openclaw/plugin-sdk/qa-runtime");
   });
 
@@ -594,7 +611,7 @@ describe("plugin-sdk root alias", () => {
     }
   });
 
-  it("does not publish private local-only plugin-sdk subpaths", () => {
+  it("does not publish private local-only plugin-sdk subpaths beyond explicit compat exceptions", () => {
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8")) as {
       exports?: Record<string, unknown>;
     };
@@ -605,8 +622,16 @@ describe("plugin-sdk root alias", () => {
       "plugin-sdk-private-local-only-subpaths.json",
     );
     const privateSubpaths = JSON.parse(fs.readFileSync(privateSubpathsPath, "utf-8")) as string[];
+    const packageExportedCompatExceptions = new Set(["codex-native-task-runtime"]);
 
     for (const subpath of privateSubpaths) {
+      if (packageExportedCompatExceptions.has(subpath)) {
+        expect(packageJson.exports?.[`./plugin-sdk/${subpath}`]).toEqual({
+          types: `./dist/plugin-sdk/${subpath}.d.ts`,
+          default: `./dist/plugin-sdk/${subpath}.js`,
+        });
+        continue;
+      }
       expect(packageJson.exports?.[`./plugin-sdk/${subpath}`]).toBeUndefined();
     }
   });

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -657,6 +657,9 @@ describe("plugin sdk alias helpers", () => {
     const fixture = createPluginSdkAliasFixture({
       packageExports: {
         "./plugin-sdk/core": { default: "./dist/plugin-sdk/core.js" },
+        "./plugin-sdk/codex-native-task-runtime": {
+          default: "./dist/plugin-sdk/codex-native-task-runtime.js",
+        },
       },
     });
     fs.rmSync(

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -56,6 +56,7 @@ function listPluginSdkSubpathsFromPackageJson(pkg: PluginSdkPackageJson): string
     .filter((key) => key.startsWith("./plugin-sdk/"))
     .map((key) => key.slice("./plugin-sdk/".length))
     .filter((subpath) => isSafePluginSdkSubpathSegment(subpath))
+    .filter((subpath) => subpath !== CODEX_NATIVE_TASK_RUNTIME_PLUGIN_SDK_SUBPATH)
     .toSorted();
 }
 

--- a/src/plugins/stage-bundled-plugin-runtime.test.ts
+++ b/src/plugins/stage-bundled-plugin-runtime.test.ts
@@ -193,6 +193,8 @@ describe("stageBundledPluginRuntime", () => {
           exports: {
             "./plugin-sdk": "./dist/plugin-sdk/index.js",
             "./plugin-sdk/channel-entry-contract": "./dist/plugin-sdk/channel-entry-contract.js",
+            "./plugin-sdk/codex-native-task-runtime":
+              "./dist/plugin-sdk/codex-native-task-runtime.js",
           },
         },
         null,
@@ -200,6 +202,8 @@ describe("stageBundledPluginRuntime", () => {
       ),
       "dist/plugin-sdk/index.js": "export const sdk = true;\n",
       "dist/plugin-sdk/channel-entry-contract.js": "export const contract = true;\n",
+      "dist/plugin-sdk/codex-native-task-runtime.js":
+        "export const codexNativeTaskRuntime = true;\n",
       "dist/plugin-sdk/source-only.js": "export const sourceOnly = true;\n",
       "dist/plugin-sdk/ssrf-runtime-internal.js": "export const internal = true;\n",
       [bundledDistPluginFile("ollama", "index.js")]: "export default {}\n",
@@ -214,9 +218,13 @@ describe("stageBundledPluginRuntime", () => {
     expect(packageJson.exports).toEqual({
       "./plugin-sdk": "./plugin-sdk/index.js",
       "./plugin-sdk/channel-entry-contract": "./plugin-sdk/channel-entry-contract.js",
+      "./plugin-sdk/codex-native-task-runtime": "./plugin-sdk/codex-native-task-runtime.js",
     });
     expect(fs.existsSync(path.join(aliasRoot, "plugin-sdk", "index.js"))).toBe(true);
     expect(fs.existsSync(path.join(aliasRoot, "plugin-sdk", "channel-entry-contract.js"))).toBe(
+      true,
+    );
+    expect(fs.existsSync(path.join(aliasRoot, "plugin-sdk", "codex-native-task-runtime.js"))).toBe(
       true,
     );
     expect(fs.existsSync(path.join(aliasRoot, "plugin-sdk", "source-only.js"))).toBe(false);


### PR DESCRIPTION
## Summary
- restore `./plugin-sdk/codex-native-task-runtime` in `openclaw` package exports as a compatibility-only path for stale official Codex installs
- keep the legacy Codex task-runtime subpath out of generic source/root alias publication so source/test/plugin loader flows stay on one module graph
- add contract, staging, root-alias, loader, and package-export coverage for the compatibility path

## Verification
- `node scripts/run-vitest.mjs src/plugins/stage-bundled-plugin-runtime.test.ts`
- `node scripts/run-vitest.mjs src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts`
- `node scripts/run-vitest.mjs src/plugins/contracts/plugin-sdk-root-alias.test.ts`
- `node scripts/run-vitest.mjs src/plugins/sdk-alias.test.ts`
- `node scripts/run-vitest.mjs src/plugins/loader.test.ts`
- `pnpm build`
- `node --input-type=module -e "const mod = await import('openclaw/plugin-sdk/codex-native-task-runtime'); console.log(JSON.stringify({ ok: typeof mod.createRunningTaskRun === 'function', keys: ['CODEX_NATIVE_SUBAGENT_RUNTIME', 'createRunningTaskRun'].map((k) => typeof mod[k]) }))"`

## Real behavior proof
Behavior addressed: Stale official `@openclaw/codex` installs from the Codex native-subagent runtime migration can still import `openclaw/plugin-sdk/codex-native-task-runtime` instead of failing with `ERR_PACKAGE_PATH_NOT_EXPORTED` during Codex turn startup.

Real environment tested: Local OpenClaw source checkout after `pnpm build`, using the package self-reference export that Node resolves from `package.json` the same way an installed `openclaw` package resolves its exported subpaths.

Exact steps or command run after this patch: Run `pnpm build`, then run `node --input-type=module -e "const mod = await import('openclaw/plugin-sdk/codex-native-task-runtime'); console.log(JSON.stringify({ ok: typeof mod.createRunningTaskRun === 'function', keys: ['CODEX_NATIVE_SUBAGENT_RUNTIME', 'createRunningTaskRun'].map((k) => typeof mod[k]) }))"` from the repo root.

Evidence after fix: Terminal output from the post-build import proof was `{"ok":true,"keys":["string","function"]}`.

Observed result after fix: The legacy `openclaw/plugin-sdk/codex-native-task-runtime` subpath resolves successfully and exposes the expected Codex task-runtime exports instead of throwing `ERR_PACKAGE_PATH_NOT_EXPORTED` during module resolution.

What was not tested: A live Windows npm/global upgrade with a stale already-installed `@openclaw/codex` package; the proof here exercises the exact exported-subpath resolution that failed in the issue report and keeps the loader/root-alias compatibility tests green.

Closes #86087
