### PR TITLE
fix(doctor): warn and continue when cron store is unreadable (#86102)

### DIFF
--- a/src/commands/doctor-cron.test.ts
+++ b/src/commands/doctor-cron.test.ts
@@ -650,4 +650,20 @@ describe("legacy WhatsApp crontab health check", () => {
 
     expect(noteMock).not.toHaveBeenCalled();
   });
+
+  it("warns and continues when cron store is unreadable", async () => {
+    const storePath = await makeTempStorePath();
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(storePath, JSON.stringify({ version: 1, jobs: [] }), "utf-8");
+    await fs.chmod(storePath, 0o000);
+
+    await maybeRepairLegacyCronStore({
+      cfg: createCronConfig(storePath),
+      options: {},
+      prompter: makePrompter(true),
+    });
+
+    expectNoteContaining("could not be read", "Doctor warnings");
+    expectNoNoteContaining("Legacy cron job storage detected", "Cron");
+  });
 });

--- a/src/commands/doctor-cron.ts
+++ b/src/commands/doctor-cron.ts
@@ -335,7 +335,20 @@ export async function maybeRepairLegacyCronStore(params: {
   prompter: Pick<DoctorPrompter, "confirm">;
 }) {
   const storePath = resolveCronStorePath(params.cfg.cron?.store);
-  const store = await loadCronStore(storePath);
+  let store: Awaited<ReturnType<typeof loadCronStore>>;
+  try {
+    store = await loadCronStore(storePath);
+  } catch (err) {
+    note(
+      [
+        `Cron store at ${shortenHomePath(storePath)} could not be read.`,
+        `Error: ${String(err)}`,
+        "Fix the file permissions or ownership and re-run doctor.",
+      ].join("\n"),
+      "Doctor warnings",
+    );
+    return;
+  }
   const rawJobs = (store.jobs ?? []) as unknown as Array<Record<string, unknown>>;
   if (rawJobs.length === 0) {
     return;


### PR DESCRIPTION
## Summary

- `openclaw doctor` aborts when the cron store file exists but is unreadable (e.g., wrong file permissions like `0o000` owned by `root:root`).
- The fix wraps the `loadCronStore` call inside `maybeRepairLegacyCronStore` with a try/catch that emits a warning with the store path and error message, then returns early so remaining doctor checks continue.
- The runtime scheduler's `loadCronStore` path is intentionally left strict — this is a doctor-only resilience fix.

## Real behavior proof

**Behavior addressed:** `openclaw doctor` no longer aborts when the cron job store is unreadable; it warns and continues with remaining health checks.

**Real environment tested:** Linux x86_64, Node v22, OpenClaw source checkout with this patch applied.

**Exact steps or command run after this patch:**

```bash
node --import tsx --no-warnings -e "
import { maybeRepairLegacyCronStore } from './src/commands/doctor-cron.js';
import { mkdtempSync, writeFileSync, chmodSync, rmSync } from 'node:fs';
import { join } from 'node:path';
import { tmpdir } from 'node:os';
const tmpDir = mkdtempSync(join(tmpdir(), 'openclaw-proof-'));
const storeFile = join(tmpDir, 'cron-store.json');
writeFileSync(storeFile, JSON.stringify({ version: 1, jobs: [] }));
chmodSync(storeFile, 0o000);
const cfg = { cron: { store: storeFile } };
const chunks = [];
const origWrite = process.stdout.write.bind(process.stdout);
process.stdout.write = (chunk) => { chunks.push(String(chunk)); return true; };
try {
  await maybeRepairLegacyCronStore({ cfg, options: {}, prompter: { confirm: async () => false } });
} finally {
  process.stdout.write = origWrite;
  chmodSync(storeFile, 0o600);
  rmSync(tmpDir, { recursive: true });
}
process.stdout.write(chunks.join(''));
"
```

**Evidence after fix:**

```
│
◇  Doctor warnings ───────────────────────────────────────────────────────╮
│                                                                         │
│  Cron store at /tmp/openclaw-proof-vla6wb/cron-store.json could not be  │
│  read.                                                                  │
│  Error: Error: EACCES: permission denied, open                          │
│  '/tmp/openclaw-proof-vla6wb/cron-store.json'                           │
│  Fix the file permissions or ownership and re-run doctor.               │
│                                                                         │
├─────────────────────────────────────────────────────────────────────────╯
```

Test suite:

```
Test Files  1 passed (1)
     Tests  16 passed (16)
  Duration  2.32s
```

**Observed result after fix:** `maybeRepairLegacyCronStore` catches the `EACCES` error from `loadCronStore`, renders a `Doctor warnings` note with the store path and error, and returns without crashing. All 16 tests pass (15 existing + 1 new). The function completes successfully — remaining doctor checks would continue after this step.

**What was not tested:** A full `openclaw doctor` CLI invocation with a real gateway config and root-owned cron store on a production Docker install.

Closes #86102