### PR TITLE
fix #86077: keep fallback errors candidate scoped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: route normal `[telegram][diag]` polling diagnostics through `runtime.log` while keeping non-diag warnings and persistence failures on `runtime.error`, so healthy polling startup no longer looks like an error. Fixes #82957. (#82958) Thanks @galiniliev.
 
 - Gateway: require Talk secret authority before setup-code handoff can include Talk secrets. (#85690) Thanks @ngutman.
+- Agents: keep fallback error reporting scoped to the active model candidate so stale prior-provider quota/auth text is not reported for later fallback attempts. (#86134) thanks @zhangguiping-xydt.
 
 ## 2026.5.25
 
@@ -114,7 +115,6 @@ Docs: https://docs.openclaw.ai
 - Tests: fail Docker resource-ceiling checks when stats samples or configured limits are invalid instead of silently reporting zero peaks.
 - Agents: fail closed when provider-less session models match multiple provider-prefixed runtime policies so CLI runtime routing no longer depends on config order. (#85970) Thanks @potterdigital.
 - Control UI/agents: keep collapsed tool rows readable without early ellipses, preserve raw expanded tool details, and make post-compaction AGENTS.md reinjection opt-in to avoid duplicated project context. Fixes #45649 and #45488. Thanks @BunsDev.
-- Agents: keep fallback error reporting scoped to the active model candidate so stale prior-provider quota/auth text is not reported for later fallback attempts. (#86134) thanks @zhangguiping-xydt.
 
 ## 2026.5.24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ Docs: https://docs.openclaw.ai
 - Tests: fail Docker resource-ceiling checks when stats samples or configured limits are invalid instead of silently reporting zero peaks.
 - Agents: fail closed when provider-less session models match multiple provider-prefixed runtime policies so CLI runtime routing no longer depends on config order. (#85970) Thanks @potterdigital.
 - Control UI/agents: keep collapsed tool rows readable without early ellipses, preserve raw expanded tool details, and make post-compaction AGENTS.md reinjection opt-in to avoid duplicated project context. Fixes #45649 and #45488. Thanks @BunsDev.
+- Agents: keep fallback error reporting scoped to the active model candidate so stale prior-provider quota/auth text is not reported for later fallback attempts. (#86134) thanks @zhangguiping-xydt.
 
 ## 2026.5.24
 

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1055,6 +1055,42 @@ describe("runWithModelFallback", () => {
     expect(attempt.status).toBe(400);
   });
 
+  it("uses the candidate message instead of mismatched provider raw errors", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-7",
+            fallbacks: ["google/gemini-3-pro-preview"],
+          },
+        },
+      },
+    });
+    const rawError = "You exceeded your current OpenAI quota.";
+    const run = vi.fn().mockRejectedValue(
+      new FailoverError("LLM request timed out.", {
+        provider: "openai-codex",
+        model: "gpt-5.4",
+        reason: "timeout",
+        status: 408,
+        rawError,
+      }),
+    );
+
+    const error = requireFallbackSummaryError(
+      await captureRejection(
+        runWithModelFallback({
+          cfg,
+          provider: "anthropic",
+          model: "claude-opus-4-7",
+          run,
+        }),
+      ),
+    );
+    expect(error.attempts[0]?.error).toBe("LLM request timed out.");
+    expect(error.attempts[0]?.error).not.toBe(rawError);
+  });
+
   it("carries request attribution through exhausted fallback summaries", async () => {
     const cfg = makeCfg({
       agents: {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -400,6 +400,21 @@ async function assertModelFallbackCandidateHarnessAvailable(
   }
 }
 
+function resolveCandidateAttemptError(
+  described: ReturnType<typeof describeFailoverError>,
+  candidate: ModelCandidate,
+): string {
+  if (
+    described.rawError &&
+    (!described.provider ||
+      (described.provider === candidate.provider &&
+        (!described.model || described.model === candidate.model)))
+  ) {
+    return described.rawError;
+  }
+  return described.message;
+}
+
 function recordFailedCandidateAttempt(params: {
   attempts: FallbackAttempt[];
   candidate: ModelCandidate;
@@ -417,10 +432,11 @@ function recordFailedCandidateAttempt(params: {
   fallbackConfigured: boolean;
 }): ModelFallbackStepFields | undefined {
   const described = describeFailoverError(params.error);
+  const error = resolveCandidateAttemptError(described, params.candidate);
   params.attempts.push({
     provider: params.candidate.provider,
     model: params.candidate.model,
-    error: described.rawError ?? described.message,
+    error,
     reason: described.reason ?? "unknown",
     status: described.status,
     code: described.code,
@@ -438,7 +454,7 @@ function recordFailedCandidateAttempt(params: {
     reason: described.reason,
     status: described.status,
     code: described.code,
-    error: described.rawError ?? described.message,
+    error,
     nextCandidate: params.nextCandidate,
     isPrimary: params.isPrimary,
     requestedModelMatched: params.requestedModelMatched,
@@ -455,7 +471,7 @@ function appendFailedCandidateAttempt(params: {
   params.attempts.push({
     provider: params.candidate.provider,
     model: params.candidate.model,
-    error: described.rawError ?? described.message,
+    error: resolveCandidateAttemptError(described, params.candidate),
     reason: described.reason ?? "unknown",
     status: described.status,
     code: described.code,

--- a/src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts
+++ b/src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts
@@ -130,16 +130,24 @@ describe("runEmbeddedPiAgent cross-provider fallback error handling", () => {
   });
 
   it("falls back to the session assistant when compaction removes the current attempt slice", async () => {
-    setupDeepseekFallbackErrorMatchers();
     const getLastFormattedAssistant = captureFormattedAssistant();
+    const sameCandidateErrorMessage = "429 current candidate rate limit";
+    mockedIsFailoverAssistantError.mockImplementation((...args: unknown[]) => {
+      const assistant = args[0];
+      return isCurrentAttemptAssistant(assistant) && assistant.provider === "anthropic";
+    });
+    mockedIsRateLimitAssistantError.mockImplementation((...args: unknown[]) => {
+      const assistant = args[0];
+      return isCurrentAttemptAssistant(assistant) && assistant.provider === "anthropic";
+    });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],
         lastAssistant: makeAssistantMessageFixture({
           stopReason: "error",
-          errorMessage: DEEPSEEK_ERROR_MESSAGE,
-          provider: "deepseek",
-          model: "deepseek-chat",
+          errorMessage: sameCandidateErrorMessage,
+          provider: "anthropic",
+          model: "test-model",
           content: [],
         }),
         currentAttemptAssistant: undefined,
@@ -152,7 +160,14 @@ describe("runEmbeddedPiAgent cross-provider fallback error handling", () => {
       config: makeCrossProviderFallbackConfig(),
     });
 
-    await expectDeepseekFallbackError(promise, getLastFormattedAssistant);
+    await expect(promise).rejects.toBeInstanceOf(MockedFailoverError);
+    await expect(promise).rejects.toThrow(`anthropic/test-model: ${sameCandidateErrorMessage}`);
+    expect(mockedIsRateLimitAssistantError).toHaveBeenCalledTimes(1);
+    expect(getLastFormattedAssistant()).toMatchObject({
+      provider: "anthropic",
+      model: "test-model",
+      errorMessage: sameCandidateErrorMessage,
+    });
   });
 
   it("does not reuse a prior provider session assistant when the current candidate times out", async () => {
@@ -181,6 +196,36 @@ describe("runEmbeddedPiAgent cross-provider fallback error handling", () => {
     await expect(promise).rejects.toBeInstanceOf(MockedFailoverError);
     await expect(promise).rejects.toThrow("LLM request timed out.");
     await expect(promise).rejects.not.toThrow("OpenAI quota");
+    expect(getLastFormattedAssistant()).toBeUndefined();
+  });
+
+  it("does not reuse a prior provider session assistant for non-timeout failover", async () => {
+    mockedIsFailoverAssistantError.mockImplementation((...args: unknown[]) => {
+      const assistant = args[0];
+      return isCurrentAttemptAssistant(assistant) && assistant.errorMessage.includes("quota");
+    });
+    const getLastFormattedAssistant = captureFormattedAssistant();
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: makeAssistantMessageFixture({
+          stopReason: "error",
+          errorMessage: "You exceeded your current OpenAI quota.",
+          provider: "openai-codex",
+          model: "gpt-5.4",
+          content: [],
+        }),
+        currentAttemptAssistant: undefined,
+      }),
+    );
+
+    await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "run-stale-session-assistant-non-timeout",
+      config: makeCrossProviderFallbackConfig(),
+    });
+
+    expect(mockedIsFailoverAssistantError).toHaveBeenCalledWith(undefined);
     expect(getLastFormattedAssistant()).toBeUndefined();
   });
 });

--- a/src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts
+++ b/src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts
@@ -17,16 +17,20 @@ import type { EmbeddedRunAttemptResult } from "./run/types.js";
 
 let runEmbeddedPiAgent: typeof import("./run.js").runEmbeddedPiAgent;
 const DEEPSEEK_ERROR_MESSAGE = "429 deepseek rate limit";
+type CurrentAttemptAssistantWithError = NonNullable<
+  EmbeddedRunAttemptResult["currentAttemptAssistant"]
+> & { errorMessage: string };
 
 function isCurrentAttemptAssistant(
   value: unknown,
-): value is NonNullable<EmbeddedRunAttemptResult["currentAttemptAssistant"]> {
+): value is CurrentAttemptAssistantWithError {
   return (
     typeof value === "object" &&
     value !== null &&
     "provider" in value &&
     "model" in value &&
-    "errorMessage" in value
+    "errorMessage" in value &&
+    typeof value.errorMessage === "string"
   );
 }
 

--- a/src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts
+++ b/src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts
@@ -174,6 +174,53 @@ describe("runEmbeddedPiAgent cross-provider fallback error handling", () => {
     });
   });
 
+  it("keeps PI-stamped session assistant errors for the current candidate after compaction", async () => {
+    const getLastFormattedAssistant = captureFormattedAssistant();
+    const sameCandidateErrorMessage = "429 current PI-stamped candidate rate limit";
+    mockedIsFailoverAssistantError.mockImplementation((...args: unknown[]) => {
+      const assistant = args[0];
+      return isCurrentAttemptAssistant(assistant) && assistant.provider === "pi";
+    });
+    mockedIsRateLimitAssistantError.mockImplementation((...args: unknown[]) => {
+      const assistant = args[0];
+      return isCurrentAttemptAssistant(assistant) && assistant.provider === "pi";
+    });
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: makeAssistantMessageFixture({
+          stopReason: "error",
+          errorMessage: sameCandidateErrorMessage,
+          provider: "pi",
+          model: "pi",
+          content: [],
+        }),
+        currentAttemptAssistant: undefined,
+      }),
+    );
+
+    const promise = runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "run-compaction-pi-stamped-fallback-error-context",
+      config: makeCrossProviderFallbackConfig(),
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(MockedFailoverError);
+    await expect(promise).rejects.toThrow(sameCandidateErrorMessage);
+    expect(mockedIsRateLimitAssistantError).toHaveBeenCalledTimes(1);
+    const rateLimitCalls = mockedIsRateLimitAssistantError.mock.calls as unknown[][];
+    expect(rateLimitCalls.at(-1)?.[0]).toMatchObject({
+      provider: "pi",
+      model: "pi",
+      errorMessage: sameCandidateErrorMessage,
+    });
+    expect(getLastFormattedAssistant()).toMatchObject({
+      provider: "pi",
+      model: "pi",
+      errorMessage: sameCandidateErrorMessage,
+    });
+  });
+
   it("does not reuse a prior provider session assistant when the current candidate times out", async () => {
     const getLastFormattedAssistant = captureFormattedAssistant();
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(

--- a/src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts
+++ b/src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts
@@ -154,4 +154,33 @@ describe("runEmbeddedPiAgent cross-provider fallback error handling", () => {
 
     await expectDeepseekFallbackError(promise, getLastFormattedAssistant);
   });
+
+  it("does not reuse a prior provider session assistant when the current candidate times out", async () => {
+    const getLastFormattedAssistant = captureFormattedAssistant();
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        timedOut: true,
+        lastAssistant: makeAssistantMessageFixture({
+          stopReason: "error",
+          errorMessage: "You exceeded your current OpenAI quota.",
+          provider: "openai-codex",
+          model: "gpt-5.4",
+          content: [],
+        }),
+        currentAttemptAssistant: undefined,
+      }),
+    );
+
+    const promise = runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "run-stale-session-assistant-timeout",
+      config: makeCrossProviderFallbackConfig(),
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(MockedFailoverError);
+    await expect(promise).rejects.toThrow("LLM request timed out.");
+    await expect(promise).rejects.not.toThrow("OpenAI quota");
+    expect(getLastFormattedAssistant()).toBeUndefined();
+  });
 });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1650,10 +1650,8 @@ export async function runEmbeddedPiAgent(
           if (attempt.contextBudgetStatus) {
             lastContextBudgetStatus = attempt.contextBudgetStatus;
           }
-          const timedOutWithoutCurrentAssistant =
-            !currentAttemptAssistant && (timedOut || idleTimedOut);
           const sessionAssistantForCandidate =
-            timedOutWithoutCurrentAssistant &&
+            !currentAttemptAssistant &&
             !isAssistantForModelRef(sessionLastAssistant, {
               provider,
               model: modelId,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -140,6 +140,7 @@ import {
   buildErrorAgentMeta,
   buildUsageAgentMetaFields,
   createCompactionDiagId,
+  isAssistantForModelRef,
   resolveActiveErrorContext,
   resolveFinalAssistantRawText,
   resolveFinalAssistantVisibleText,
@@ -1649,10 +1650,20 @@ export async function runEmbeddedPiAgent(
           if (attempt.contextBudgetStatus) {
             lastContextBudgetStatus = attempt.contextBudgetStatus;
           }
+          const timedOutWithoutCurrentAssistant =
+            !currentAttemptAssistant && (timedOut || idleTimedOut);
+          const sessionAssistantForCandidate =
+            timedOutWithoutCurrentAssistant &&
+            !isAssistantForModelRef(sessionLastAssistant, {
+              provider,
+              model: modelId,
+            })
+              ? undefined
+              : sessionLastAssistant;
           const activeErrorContext = resolveActiveErrorContext({
             provider,
             model: modelId,
-            assistant: currentAttemptAssistant ?? sessionLastAssistant,
+            assistant: currentAttemptAssistant ?? sessionAssistantForCandidate,
           });
           const resolveReplayInvalidForAttempt = (incompleteTurnText?: string | null) =>
             accumulatedReplayState.replayInvalid ||
@@ -1667,8 +1678,8 @@ export async function runEmbeddedPiAgent(
             accumulatedReplayState,
             attempt.replayMetadata,
           );
-          const formattedAssistantErrorText = sessionLastAssistant
-            ? formatAssistantErrorText(sessionLastAssistant, {
+          const formattedAssistantErrorText = sessionAssistantForCandidate
+            ? formatAssistantErrorText(sessionAssistantForCandidate, {
                 cfg: params.config,
                 sessionKey: resolvedSessionKey ?? params.sessionId,
                 provider: activeErrorContext.provider,
@@ -1676,8 +1687,8 @@ export async function runEmbeddedPiAgent(
               })
             : undefined;
           const assistantErrorText =
-            sessionLastAssistant?.stopReason === "error"
-              ? sessionLastAssistant.errorMessage?.trim() || formattedAssistantErrorText
+            sessionAssistantForCandidate?.stopReason === "error"
+              ? sessionAssistantForCandidate.errorMessage?.trim() || formattedAssistantErrorText
               : undefined;
           const canRestartForLiveSwitch =
             !hasOutboundDeliveryEvidence(attempt) &&
@@ -2474,7 +2485,7 @@ export async function runEmbeddedPiAgent(
             throw promptError;
           }
 
-          const assistantForFailover = currentAttemptAssistant ?? sessionLastAssistant;
+          const assistantForFailover = currentAttemptAssistant ?? sessionAssistantForCandidate;
           const fallbackThinking = pickFallbackThinkingLevel({
             message: assistantForFailover?.errorMessage,
             attempted: attemptedThinking,

--- a/src/agents/pi-embedded-runner/run/helpers.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.ts
@@ -105,7 +105,14 @@ export function isAssistantForModelRef(
   assistant: { provider?: string; model?: string } | undefined,
   ref: { provider: string; model: string },
 ): boolean {
-  return assistant?.provider?.trim() === ref.provider && assistant?.model?.trim() === ref.model;
+  if (!assistant) {
+    return false;
+  }
+  const resolved = resolveReportedModelRef({
+    ...ref,
+    assistant,
+  });
+  return resolved.provider === ref.provider && resolved.model === ref.model;
 }
 
 function isEmbeddedHarnessProvider(provider: string): boolean {

--- a/src/agents/pi-embedded-runner/run/helpers.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.ts
@@ -101,6 +101,13 @@ export function resolveActiveErrorContext(params: {
   return resolveReportedModelRef(params);
 }
 
+export function isAssistantForModelRef(
+  assistant: { provider?: string; model?: string } | undefined,
+  ref: { provider: string; model: string },
+): boolean {
+  return assistant?.provider?.trim() === ref.provider && assistant?.model?.trim() === ref.model;
+}
+
 function isEmbeddedHarnessProvider(provider: string): boolean {
   return provider.trim().toLowerCase() === "pi";
 }


### PR DESCRIPTION
## Summary

- Problem: later fallback candidates that timed out without a current assistant could surface a previous provider's raw error text, making provider triage misleading.
- Solution: scope reused session assistant errors to the current candidate on timeout and only prefer raw fallback errors when their provider/model attribution matches the candidate.
- What changed: updated embedded-runner assistant selection, model-fallback attempt error selection, and added focused regressions for both paths.
- What did NOT change: no provider routing, auth refresh, profile rotation, external API payloads, or fallback candidate ordering changed.

Fixes #86077

## Real behavior proof

- **Behavior or issue addressed:** stale prior-provider quota text is no longer surfaced for a later candidate timeout.
- **Real environment tested:** Linux 4.19.112-2.el8.x86_64, Node v24.16.0, OpenClaw v2026.5.24, worktree SHA 1a6d54
- **Exact steps or command run after this patch:**
  ```bash
  OPENCLAW_SKIP_CHANNELS=1 pnpm gateway:dev
  node --import tsx /media/vdc/code/ai/aispace/openclaw-issue-86077-evidence/proof-after.mts
  node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts src/agents/model-fallback.test.ts
  pnpm check:test-types
  ```
- **Evidence after fix:**
  ```text
  $ OPENCLAW_SKIP_CHANNELS=1 node scripts/run-node.mjs --dev gateway
  [openclaw] Building TypeScript (dist is stale: config_newer - config newer than build stamp).
  runtime-postbuild: bundled plugin metadata completed in 352ms
  2026-05-25T01:13:33.187+08:00 [gateway] loading configuration…
  2026-05-25T01:13:33.356+08:00 [gateway] resolving authentication…
  2026-05-25T01:13:33.388+08:00 [gateway] starting...
  2026-05-25T01:13:40.050+08:00 [gateway] starting HTTP server...
  2026-05-25T01:13:41.305+08:00 [gateway] agent model: openai/gpt-5.5 (thinking=medium, fast=off)
  2026-05-25T01:13:41.308+08:00 [gateway] http server listening (8 plugins: acpx, browser, canvas, device-pair, file-transfer, memory-core, phone-control, talk-voice; 7.9s)
  2026-05-25T01:13:41.322+08:00 [gateway/channels] skipping channel start (OPENCLAW_SKIP_CHANNELS=1 or OPENCLAW_SKIP_PROVIDERS=1)
  2026-05-25T01:13:44.326+08:00 [gateway] ready
  2026-05-25T01:13:44.349+08:00 [heartbeat] started

  [model-fallback/decision] model fallback decision: decision=candidate_failed requested=anthropic/opus-4-7 candidate=anthropic/opus-4-7 reason=timeout next=google/gemini-3.1-pro-preview detail=LLM request timed out.
  [model-fallback/decision] model fallback decision: decision=candidate_failed requested=anthropic/opus-4-7 candidate=google/gemini-3.1-pro-preview reason=timeout next=none detail=LLM request timed out.
  {
    "candidate": "anthropic/opus-4-7",
    "reason": "timeout",
    "surfacedError": "LLM request timed out.",
    "staleOpenAITextSuppressed": true
  }

  Test Files  4 passed (4)
  Tests  140 passed (140)
  ```
- **Observed result after fix:** OpenClaw started successfully in gateway dev mode, and the candidate failure detail remained the timeout message; the stale OpenAI quota text was suppressed instead of being attributed to the later candidate.
- **What was not tested:** external provider outage calls were not made; the runtime started locally with channels skipped, and the patched fallback attribution logic was exercised through a direct local function proof.

## Regression Test Plan

- Coverage level: Unit test
- Target test file: src/agents/pi-embedded-runner/run.cross-provider-fallback-error-context.test.ts; src/agents/model-fallback.test.ts
- Scenario locked in: a later candidate timeout with no current assistant does not reuse the previous provider's session assistant, and model-fallback summaries ignore raw errors whose provider/model does not match the candidate.
- Why this is the smallest reliable guardrail: it exercises the exact attribution boundary without needing real provider failures or slow timeout cascades.

## Root Cause

- Root cause: `sessionLastAssistant` was reused when `currentAttemptAssistant` was absent, even when the last assistant belonged to a previous provider/model; model-fallback then preferred that raw error text for the current candidate.
- Missing detection / guardrail: no regression covered a later fallback candidate timeout with no current assistant and stale prior-provider session history.

