### PR TITLE
fix(docker): create /home/node/.config with node ownership

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -287,13 +287,15 @@ RUN ln -sf /app/openclaw.mjs /usr/local/bin/openclaw \
 
 # Pre-create default named-volume mount points so first-run Docker volumes copy
 # node ownership from the image instead of starting as root-owned directories.
-RUN install -d -m 0700 -o node -g node \
+RUN install -d -m 0755 -o node -g node /home/node/.config && \
+    install -d -m 0700 -o node -g node \
       /home/node/.openclaw \
       /home/node/.openclaw/workspace \
       /home/node/.config/openclaw && \
     stat -c '%U:%G %a' /home/node/.openclaw | grep -qx 'node:node 700' && \
     stat -c '%U:%G %a' /home/node/.openclaw/workspace | grep -qx 'node:node 700' && \
-    stat -c '%U:%G %a' /home/node/.config/openclaw | grep -qx 'node:node 700'
+    stat -c '%U:%G %a' /home/node/.config/openclaw | grep -qx 'node:node 700' && \
+    stat -c '%U:%G %a' /home/node/.config | grep -qx 'node:node 755'
 
 ENV NODE_ENV=production
 

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -328,7 +328,7 @@ describe("Dockerfile", () => {
     const dockerfile = await readFile(dockerfilePath, "utf8");
     const runtimeStageIndex = dockerfile.lastIndexOf("FROM base-runtime");
     const stateDirIndex = dockerfile.indexOf(
-      "RUN install -d -m 0700 -o node -g node \\",
+      "RUN install -d -m 0755 -o node -g node /home/node/.config",
       runtimeStageIndex,
     );
     const userIndex = dockerfile.indexOf("USER node", runtimeStageIndex);
@@ -339,8 +339,12 @@ describe("Dockerfile", () => {
     expect(stateDirIndex).toBeGreaterThan(runtimeStageIndex);
     expect(stateDirIndex).toBeLessThan(userIndex);
     expect(dockerfile).not.toContain("mkdir -p /home/node/.openclaw");
+    expect(dockerfile).toContain("install -d -m 0755 -o node -g node /home/node/.config");
     expect(dockerfile).toContain("/home/node/.openclaw/workspace");
     expect(dockerfile).toContain("/home/node/.config/openclaw");
+    expect(dockerfile).toContain(
+      "stat -c '%U:%G %a' /home/node/.config | grep -qx 'node:node 755'",
+    );
     expect(dockerfile).toContain(
       "stat -c '%U:%G %a' /home/node/.openclaw | grep -qx 'node:node 700'",
     );


### PR DESCRIPTION
## Summary

- Fix `/home/node/.config` ownership in the Docker slim image to `node:node` instead of `root:root`.
- The `install -d` command creates intermediate directories with root ownership by default, since `-o`/`-g` flags only apply to the final target directory.
- Added stat assertions for `/home/node/.config` and the Dockerfile guard test to prevent regression.

Fixes #85968

## Verification
- `node scripts/run-vitest.mjs src/dockerfile.test.ts`
- `docker run --rm node:24-bookworm-slim sh -ceu 'install -d -m 0755 -o node -g node /home/node/.config && install -d -m 0700 -o node -g node /home/node/.openclaw /home/node/.openclaw/workspace /home/node/.config/openclaw && stat -c "%U:%G %a" /home/node/.openclaw | grep -qx "node:node 700" && stat -c "%U:%G %a" /home/node/.openclaw/workspace | grep -qx "node:node 700" && stat -c "%U:%G %a" /home/node/.config/openclaw | grep -qx "node:node 700" && stat -c "%U:%G %a" /home/node/.config | grep -qx "node:node 755"'`
- autoreview clean after rebase on `origin/main`

## Real behavior proof
Behavior addressed: Docker runtime images should let the non-root `node` user write standard config under `/home/node/.config`, while keeping OpenClaw's private state directories at mode 0700.

Real environment tested: real `node:24-bookworm-slim` container, matching the OpenClaw runtime base image family.

Exact steps or command run after this patch: `docker run --rm node:24-bookworm-slim sh -ceu 'install -d -m 0755 -o node -g node /home/node/.config && install -d -m 0700 -o node -g node /home/node/.openclaw /home/node/.openclaw/workspace /home/node/.config/openclaw && stat -c "%U:%G %a" /home/node/.openclaw | grep -qx "node:node 700" && stat -c "%U:%G %a" /home/node/.openclaw/workspace | grep -qx "node:node 700" && stat -c "%U:%G %a" /home/node/.config/openclaw | grep -qx "node:node 700" && stat -c "%U:%G %a" /home/node/.config | grep -qx "node:node 755"'`

Evidence after fix: the command exits 0 and `node scripts/run-vitest.mjs src/dockerfile.test.ts` reports `Test Files 1 passed (1)` and `Tests 19 passed (19)`.

Observed result after fix: `/home/node/.config` is `node:node 755`; `/home/node/.openclaw`, `/home/node/.openclaw/workspace`, and `/home/node/.config/openclaw` remain `node:node 700`.

What was not tested: a full multi-stage OpenClaw image build; the exact directory-creation command was tested in the matching slim base image.
