### PR TITLE
[Feature]: Channel Broker Phase 2B Telegram migration proof

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,6 +15,12 @@
       - any-glob-to-any-file:
           - "extensions/discord/**"
           - "docs/channels/discord.md"
+"channel: channel-broker":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/channel-broker/**"
+          - "docs/channels/channel-broker.md"
+          - "docs/plugins/sdk-channel-broker.md"
 "channel: irc":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-8882e41620deeed05be9526981c32a034444abc232903b946c48d416f46f06c3  plugin-sdk-api-baseline.json
-40b22ddad62692447717a2b4f0ecdbd9f6209fa86eaf4e66f85d37c48e26d394  plugin-sdk-api-baseline.jsonl
+28fcbbe21ee8088d78774a17e8906d408345dfe210f3b3511a18e26efad6904c  plugin-sdk-api-baseline.json
+8076e25cda96fd463e800064ff6c56a872cf61de73ca0353e0911e0b47f89751  plugin-sdk-api-baseline.jsonl

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -68,6 +68,14 @@
     "target": "频道消息 API"
   },
   {
+    "source": "Channel Broker",
+    "target": "Channel Broker"
+  },
+  {
+    "source": "Channel broker SDK",
+    "target": "Channel broker SDK"
+  },
+  {
     "source": "Channel ingress API",
     "target": "频道入口 API"
   },

--- a/docs/channels/channel-broker.md
+++ b/docs/channels/channel-broker.md
@@ -1,0 +1,114 @@
+---
+summary: "Provider-owned broker channel for consolidating Slack, Discord, Telegram, WhatsApp, Signal, iMessage, Matrix, and long-tail messaging providers"
+title: "Channel Broker"
+read_when:
+  - You want one provider-owned channel surface instead of platform-specific OpenClaw channel plugins
+  - You are building a broker provider for Slack, Discord, Telegram, WhatsApp, Signal, iMessage, or Matrix
+  - You are migrating channel behavior onto the broker protocol
+---
+
+`channel-broker` is the consolidation channel for provider-owned messaging
+integrations. OpenClaw keeps the common message lifecycle, session routing,
+allowlists, `/verbose` and streaming policy, durable final sends, receipts,
+retries, and audit fields. Broker providers own platform mechanics such as bot
+APIs, bridge daemons, device-bound connectors, native ids, and per-platform
+quirks.
+
+The V1 transport is outbound HTTP from OpenClaw to the provider plus signed
+inbound HTTP webhooks from the provider to OpenClaw. WebSocket and provider
+polling transports are reserved for later protocol versions.
+
+## Target syntax
+
+Use the platform as the target prefix:
+
+```text
+telegram:chat%20123?threadId=topic%2F77
+discord:123456789012345678
+slack:C12345678?threadId=1700000000.000100
+matrix:!roomid:example.org
+```
+
+The broker plugin declares prefixes for the major channel platforms, so a
+configured broker can accept targets such as `telegram:...`, `discord:...`, and
+`slack:...` without forcing users to write `broker:` everywhere. Native channel
+plugins still keep their own channel ids; use `channel-broker` when routing
+through a broker provider.
+
+## Config
+
+```json5
+{
+  channels: {
+    "channel-broker": {
+      defaultProviderId: "acme",
+      accounts: {
+        acme: {
+          enabled: true,
+          baseUrl: "https://broker.example.com",
+          outboundToken: "op://openclaw/acme-broker/token",
+          signingSecret: "op://openclaw/acme-broker/webhook-secret",
+          platforms: ["slack", "discord", "telegram"],
+          defaultConversationType: "channel",
+          allowFrom: ["*"],
+        },
+      },
+    },
+  },
+}
+```
+
+Provider keys:
+
+- `baseUrl` - provider HTTP endpoint. OpenClaw posts outbound requests to
+  `/v1/outbound`.
+- `outboundToken` - optional bearer token for outbound provider calls.
+- `signingSecret` - provider webhook signature secret for inbound events.
+- `platforms` - normalized platform ids the provider can handle.
+- `platformAliases` - optional alias map for provider-local platform names.
+- `defaultConversationType` - fallback conversation type when a target does not
+  encode one; defaults to `channel`.
+- `allowFrom` - sender allowlist used by broker inbound events.
+- `capabilities` - optional per-platform capability metadata for UI/status.
+
+`providers` is accepted as an alias for `accounts` when a broker service wants
+that naming, but `accounts` is preferred because it matches the rest of
+OpenClaw's multi-account channel tooling.
+
+## Provider contract
+
+Providers import the broker protocol types from
+`openclaw/plugin-sdk/channel-broker`:
+
+- `BrokerInboundEventV1`
+- `BrokerOutboundRequestV1`
+- `BrokerReceiptV1`
+- `BrokerProviderCapabilities`
+- `BrokerProviderHealth`
+
+Outbound requests include platform id, provider id, provider account id,
+conversation id/type/thread id, payloads, reply/silent relation fields,
+delivery requirements, and opaque native metadata. Receipts must return stable
+message ids and can include edit/delete tokens plus opaque native metadata.
+
+## Migration notes
+
+Broker-compatible platforms:
+
+- Slack, Discord, Telegram, Microsoft Teams, Google Chat, and Matrix fit the
+  broker model through official bot/app APIs or mature bridge APIs.
+- WhatsApp fits through Business/Cloud-style providers or QR-device providers
+  with capability badges.
+- Signal and iMessage require self-hosted or device-bound providers; expose
+  those limits through provider capabilities instead of pretending they match
+  hosted bot APIs.
+
+Keep legacy channel plugins available for security and compatibility while new
+channel behavior moves through broker conformance tests.
+
+## Related
+
+- [Channel message API](/plugins/sdk-channel-message)
+- [Channel broker SDK](/plugins/sdk-channel-broker)
+- [Streaming](/concepts/streaming)
+- [Thinking and verbose directives](/tools/thinking)

--- a/docs/channels/channel-broker.md
+++ b/docs/channels/channel-broker.md
@@ -20,20 +20,20 @@ polling transports are reserved for later protocol versions.
 
 ## Target syntax
 
-Use the platform as the target prefix:
+Use the broker-owned prefix when native channel plugins are still installed:
 
 ```text
-telegram:chat%20123?threadId=topic%2F77
-discord:123456789012345678
-slack:C12345678?threadId=1700000000.000100
-matrix:!roomid:example.org
+broker:telegram:chat%20123?threadId=topic%2F77
+channel-broker:discord:123456789012345678
+broker:slack:C12345678?threadId=1700000000.000100
+channel-broker:matrix:!roomid:example.org
 ```
 
-The broker plugin declares prefixes for the major channel platforms, so a
-configured broker can accept targets such as `telegram:...`, `discord:...`, and
-`slack:...` without forcing users to write `broker:` everywhere. Native channel
-plugins still keep their own channel ids; use `channel-broker` when routing
-through a broker provider.
+The broker also declares platform prefixes for migration environments, but
+native channel plugins keep ownership of their own prefixes while they are
+registered. For example, `telegram:...` still routes to the native Telegram
+plugin when both Telegram and the broker are installed; if Telegram is not
+registered, a configured broker can own `telegram:...`.
 
 ## Config
 
@@ -46,8 +46,8 @@ through a broker provider.
         acme: {
           enabled: true,
           baseUrl: "https://broker.example.com",
-          outboundToken: "op://openclaw/acme-broker/token",
-          signingSecret: "op://openclaw/acme-broker/webhook-secret",
+          outboundToken: { source: "env", provider: "default", id: "BROKER_TOKEN" },
+          signingSecret: { source: "env", provider: "default", id: "BROKER_SIGNING_SECRET" },
           platforms: ["slack", "discord", "telegram"],
           defaultConversationType: "channel",
           allowFrom: ["*"],
@@ -62,8 +62,10 @@ Provider keys:
 
 - `baseUrl` - provider HTTP endpoint. OpenClaw posts outbound requests to
   `/v1/outbound`.
-- `outboundToken` - optional bearer token for outbound provider calls.
+- `outboundToken` - optional bearer token for outbound provider calls. Plaintext
+  strings and SecretRef objects are supported.
 - `signingSecret` - provider webhook signature secret for inbound events.
+  Plaintext strings and SecretRef objects are supported.
 - `platforms` - normalized platform ids the provider can handle.
 - `platformAliases` - optional alias map for provider-local platform names.
 - `defaultConversationType` - fallback conversation type when a target does not

--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -27,6 +27,7 @@ Text is supported everywhere; media and reactions vary by channel.
 
 ## Supported channels
 
+- [Channel Broker](/channels/channel-broker) - Provider-owned broker for consolidating Slack, Discord, Telegram, WhatsApp, Signal, iMessage, Matrix, and long-tail messaging providers behind one OpenClaw message lifecycle.
 - [Discord](/channels/discord) - Discord Bot API + Gateway; supports servers, channels, and DMs.
 - [Feishu](/channels/feishu) - Feishu/Lark bot via WebSocket (bundled plugin).
 - [Google Chat](/channels/googlechat) - Google Chat API app via HTTP webhook (downloadable plugin).

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1059,7 +1059,11 @@
             "groups": [
               {
                 "group": "Overview",
-                "pages": ["channels/index", "announcements/bluebubbles-imessage"]
+                "pages": [
+                  "channels/index",
+                  "channels/channel-broker",
+                  "announcements/bluebubbles-imessage"
+                ]
               },
               {
                 "group": "Mainstream messaging",
@@ -1743,6 +1747,7 @@
                   "plugins/architecture-internals",
                   "plugins/sdk-migration",
                   "plugins/compatibility",
+                  "plugins/sdk-channel-broker",
                   "plugins/sdk-channel-message",
                   "plugins/sdk-channel-turn",
                   "plugins/sdk-channel-ingress",

--- a/docs/plugins/sdk-channel-broker.md
+++ b/docs/plugins/sdk-channel-broker.md
@@ -1,0 +1,73 @@
+---
+summary: "Channel broker SDK protocol for provider-owned messaging integrations"
+title: "Channel broker SDK"
+read_when:
+  - You are implementing a channel broker provider
+  - You need the broker protocol types for inbound events, outbound requests, receipts, capabilities, or health
+  - You are migrating platform channel behavior behind the broker contract
+---
+
+The channel broker SDK lives at `openclaw/plugin-sdk/channel-broker`. It is a
+small, versioned protocol surface for providers that want OpenClaw to own common
+message semantics while the provider owns platform mechanics.
+
+## V1 types
+
+```typescript
+import type {
+  BrokerInboundEventV1,
+  BrokerOutboundRequestV1,
+  BrokerReceiptV1,
+  BrokerProviderCapabilities,
+  BrokerProviderHealth,
+} from "openclaw/plugin-sdk/channel-broker";
+```
+
+V1 uses signed inbound HTTP webhooks and outbound HTTP calls. WebSocket and
+provider polling transports are intentionally deferred so providers can first
+prove the stable message lifecycle contract.
+
+## Outbound request
+
+`BrokerOutboundRequestV1` includes:
+
+- `requestId`, `providerId`, `platform`, and optional provider `accountId`.
+- `conversation` with id, type, parent id, thread id, and title.
+- `mode`, including final sends, preview updates, preview finalization, typing,
+  and reactions.
+- `payloads` with text, attachments, and provider-owned `channelData`.
+- `relation` for reply, silent, and native quote references.
+- `requirements` describing durable delivery features OpenClaw expects.
+
+Providers should return `BrokerReceiptV1` with stable message ids, status,
+optional edit/delete tokens, timestamps, and native metadata.
+
+## Target helpers
+
+Use these helpers to normalize provider target ids:
+
+```typescript
+import {
+  buildBrokerConversationTarget,
+  createBrokerOutboundRequest,
+  createBrokerReceipt,
+  normalizeBrokerPlatformId,
+  parseBrokerConversationTarget,
+} from "openclaw/plugin-sdk/channel-broker";
+```
+
+`buildBrokerConversationTarget({ platform: "Telegram", conversationId:
+"chat 123", threadId: "topic/7" })` produces a stable target like
+`telegram:chat%20123?threadId=topic%2F7`.
+
+## Responsibilities
+
+OpenClaw owns sessions, allowlists, routing, model-run lifecycle, `/verbose`,
+streaming policy, durable final sends, receipt commits, retries, and audit
+fields. Broker providers own platform APIs, delivery fanout, bridge/device
+state, native ids, attachment hosting, and platform-specific metadata.
+
+## Related
+
+- [Channel Broker](/channels/channel-broker)
+- [Channel message API](/plugins/sdk-channel-message)

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -92,6 +92,7 @@ focused channel/runtime subpaths, `config-contracts`, `string-coerce-runtime`,
     | `plugin-sdk/config-schema` | Root `openclaw.json` Zod schema export (`OpenClawSchema`) |
     | `plugin-sdk/json-schema-runtime` | Cached JSON Schema validation helper for plugin-owned schemas |
     | `plugin-sdk/channel-setup` | `createOptionalChannelSetupSurface`, `createOptionalChannelSetupAdapter`, `createOptionalChannelSetupWizard`, plus `DEFAULT_ACCOUNT_ID`, `createTopLevelChannelDmPolicy`, `setSetupChannelEnabled`, `splitSetupEntries` |
+    | `plugin-sdk/channel-broker` | Versioned broker protocol types and helpers for provider-owned messaging integrations: `BrokerInboundEventV1`, `BrokerOutboundRequestV1`, `BrokerReceiptV1`, `BrokerProviderCapabilities`, `BrokerProviderHealth`, target normalization helpers, and receipt/request builders. See [Channel broker SDK](/plugins/sdk-channel-broker). |
     | `plugin-sdk/setup` | Shared setup wizard helpers, setup translator, allowlist prompts, setup status builders |
     | `plugin-sdk/setup-runtime` | `createSetupTranslator`, `createPatchedAccountSetupAdapter`, `createEnvPatchedAccountSetupAdapter`, `createSetupInputPresenceValidator`, `noteChannelLookupFailure`, `noteChannelLookupSummary`, `promptResolvedAllowFrom`, `splitSetupEntries`, `createAllowlistSetupWizardProxy`, `createDelegatedSetupWizardProxy` |
     | `plugin-sdk/setup-adapter-runtime` | Deprecated compatibility alias; use `plugin-sdk/setup-runtime` |

--- a/docs/reference/secretref-credential-surface.md
+++ b/docs/reference/secretref-credential-surface.md
@@ -40,7 +40,6 @@ Scope intent:
 - `talk.providers.*.apiKey`
 - `messages.tts.providers.*.apiKey`
 - `tools.web.fetch.firecrawl.apiKey`
-- `plugins.entries.acpx.config.mcpServers.*.env.*`
 - `plugins.entries.brave.config.webSearch.apiKey`
 - `plugins.entries.exa.config.webSearch.apiKey`
 - `plugins.entries.google.config.webSearch.apiKey`
@@ -54,6 +53,7 @@ Scope intent:
 - `plugins.entries.voice-call.config.streaming.providers.*.apiKey`
 - `plugins.entries.voice-call.config.tts.providers.*.apiKey`
 - `plugins.entries.voice-call.config.twilio.authToken`
+- `plugins.entries.acpx.config.mcpServers.*.env.*`
 - `tools.web.search.*.apiKey`
 - `tools.web.search.apiKey`
 - `gateway.auth.password`

--- a/docs/reference/secretref-credential-surface.md
+++ b/docs/reference/secretref-credential-surface.md
@@ -79,6 +79,12 @@ Scope intent:
 - `channels.discord.accounts.*.token`
 - `channels.discord.accounts.*.pluralkit.token`
 - `channels.discord.accounts.*.voice.tts.providers.*.apiKey`
+- `channels.channel-broker.outboundToken`
+- `channels.channel-broker.signingSecret`
+- `channels.channel-broker.accounts.*.outboundToken`
+- `channels.channel-broker.accounts.*.signingSecret`
+- `channels.channel-broker.providers.*.outboundToken`
+- `channels.channel-broker.providers.*.signingSecret`
 - `channels.irc.password`
 - `channels.irc.nickserv.password`
 - `channels.irc.accounts.*.password`

--- a/docs/reference/secretref-user-supplied-credentials-matrix.json
+++ b/docs/reference/secretref-user-supplied-credentials-matrix.json
@@ -61,6 +61,48 @@
       "notes": "Compatibility exception: sibling ref field remains canonical."
     },
     {
+      "id": "channels.channel-broker.accounts.*.outboundToken",
+      "configFile": "openclaw.json",
+      "path": "channels.channel-broker.accounts.*.outboundToken",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
+      "id": "channels.channel-broker.accounts.*.signingSecret",
+      "configFile": "openclaw.json",
+      "path": "channels.channel-broker.accounts.*.signingSecret",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
+      "id": "channels.channel-broker.outboundToken",
+      "configFile": "openclaw.json",
+      "path": "channels.channel-broker.outboundToken",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
+      "id": "channels.channel-broker.providers.*.outboundToken",
+      "configFile": "openclaw.json",
+      "path": "channels.channel-broker.providers.*.outboundToken",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
+      "id": "channels.channel-broker.providers.*.signingSecret",
+      "configFile": "openclaw.json",
+      "path": "channels.channel-broker.providers.*.signingSecret",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
+      "id": "channels.channel-broker.signingSecret",
+      "configFile": "openclaw.json",
+      "path": "channels.channel-broker.signingSecret",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
       "id": "channels.discord.accounts.*.pluralkit.token",
       "configFile": "openclaw.json",
       "path": "channels.discord.accounts.*.pluralkit.token",

--- a/extensions/channel-broker/api.ts
+++ b/extensions/channel-broker/api.ts
@@ -1,0 +1,15 @@
+export {
+  DEFAULT_ACCOUNT_ID,
+  listChannelBrokerProviderIds,
+  resolveChannelBrokerAccount,
+  resolveDefaultChannelBrokerProviderId,
+  type ResolvedChannelBrokerAccount,
+} from "./src/accounts.js";
+export { channelBrokerPlugin } from "./src/channel.js";
+export {
+  getChannelBrokerRuntime,
+  resetChannelBrokerRuntimeForTest,
+  sendBrokerOutboundRequest,
+  setChannelBrokerRuntime,
+  type ChannelBrokerRuntime,
+} from "./src/runtime.js";

--- a/extensions/channel-broker/channel-plugin-api.ts
+++ b/extensions/channel-broker/channel-plugin-api.ts
@@ -1,0 +1,1 @@
+export { channelBrokerPlugin } from "./src/channel.js";

--- a/extensions/channel-broker/index.ts
+++ b/extensions/channel-broker/index.ts
@@ -1,0 +1,16 @@
+import { defineBundledChannelEntry } from "openclaw/plugin-sdk/channel-entry-contract";
+
+export default defineBundledChannelEntry({
+  id: "channel-broker",
+  name: "Channel Broker",
+  description: "Provider-owned universal messaging channel broker",
+  importMetaUrl: import.meta.url,
+  plugin: {
+    specifier: "./api.js",
+    exportName: "channelBrokerPlugin",
+  },
+  runtime: {
+    specifier: "./api.js",
+    exportName: "setChannelBrokerRuntime",
+  },
+});

--- a/extensions/channel-broker/index.ts
+++ b/extensions/channel-broker/index.ts
@@ -9,6 +9,10 @@ export default defineBundledChannelEntry({
     specifier: "./api.js",
     exportName: "channelBrokerPlugin",
   },
+  secrets: {
+    specifier: "./secret-contract-api.js",
+    exportName: "channelSecrets",
+  },
   runtime: {
     specifier: "./api.js",
     exportName: "setChannelBrokerRuntime",

--- a/extensions/channel-broker/index.ts
+++ b/extensions/channel-broker/index.ts
@@ -6,7 +6,7 @@ export default defineBundledChannelEntry({
   description: "Provider-owned universal messaging channel broker",
   importMetaUrl: import.meta.url,
   plugin: {
-    specifier: "./api.js",
+    specifier: "./channel-plugin-api.js",
     exportName: "channelBrokerPlugin",
   },
   secrets: {
@@ -14,7 +14,7 @@ export default defineBundledChannelEntry({
     exportName: "channelSecrets",
   },
   runtime: {
-    specifier: "./api.js",
+    specifier: "./runtime-api.js",
     exportName: "setChannelBrokerRuntime",
   },
 });

--- a/extensions/channel-broker/openclaw.plugin.json
+++ b/extensions/channel-broker/openclaw.plugin.json
@@ -1,0 +1,12 @@
+{
+  "id": "channel-broker",
+  "activation": {
+    "onStartup": false
+  },
+  "channels": ["channel-broker"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/channel-broker/package.json
+++ b/extensions/channel-broker/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": "./index.ts",
     "./api.js": "./api.ts",
+    "./channel-plugin-api.js": "./channel-plugin-api.ts",
     "./runtime-api.js": "./runtime-api.ts",
     "./secret-contract-api.js": "./secret-contract-api.ts"
   },

--- a/extensions/channel-broker/package.json
+++ b/extensions/channel-broker/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@openclaw/channel-broker",
+  "version": "2026.5.24",
+  "private": true,
+  "description": "OpenClaw channel broker plugin",
+  "type": "module",
+  "exports": {
+    ".": "./index.ts",
+    "./api.js": "./api.ts",
+    "./runtime-api.js": "./runtime-api.ts"
+  },
+  "dependencies": {
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*",
+    "openclaw": "workspace:*"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.5.24"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "channel": {
+      "id": "channel-broker",
+      "label": "Channel Broker",
+      "selectionLabel": "Channel Broker",
+      "detailLabel": "Channel Broker",
+      "docsPath": "/channels/channel-broker",
+      "docsLabel": "channel-broker",
+      "blurb": "Provider-owned broker for Slack, Discord, Telegram, WhatsApp, Signal, iMessage, Matrix, and other messaging platforms.",
+      "systemImage": "network",
+      "order": 60,
+      "exposure": {
+        "configured": true,
+        "setup": true,
+        "docs": true
+      }
+    }
+  }
+}

--- a/extensions/channel-broker/package.json
+++ b/extensions/channel-broker/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": "./index.ts",
     "./api.js": "./api.ts",
-    "./runtime-api.js": "./runtime-api.ts"
+    "./runtime-api.js": "./runtime-api.ts",
+    "./secret-contract-api.js": "./secret-contract-api.ts"
   },
   "dependencies": {
     "zod": "4.4.3"

--- a/extensions/channel-broker/runtime-api.ts
+++ b/extensions/channel-broker/runtime-api.ts
@@ -1,0 +1,18 @@
+export {
+  buildChannelConfigSchema,
+  buildChannelOutboundSessionRoute,
+  type ChannelPlugin,
+  createChatChannelPlugin,
+  type OpenClawConfig,
+  type PluginRuntime,
+} from "openclaw/plugin-sdk/channel-core";
+export { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
+export { getChatChannelMeta } from "openclaw/plugin-sdk/channel-plugin-common";
+export {
+  createMessageReceiptFromOutboundResults,
+  defineChannelMessageAdapter,
+} from "openclaw/plugin-sdk/channel-message";
+export {
+  createComputedAccountStatusAdapter,
+  createDefaultChannelRuntimeState,
+} from "openclaw/plugin-sdk/status-helpers";

--- a/extensions/channel-broker/secret-contract-api.ts
+++ b/extensions/channel-broker/secret-contract-api.ts
@@ -1,0 +1,5 @@
+export {
+  channelSecrets,
+  collectRuntimeConfigAssignments,
+  secretTargetRegistryEntries,
+} from "./src/secret-contract.js";

--- a/extensions/channel-broker/src/accounts.ts
+++ b/extensions/channel-broker/src/accounts.ts
@@ -6,6 +6,7 @@ import {
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import { resolveMergedAccountConfig } from "openclaw/plugin-sdk/account-resolution-runtime";
 import { normalizeBrokerPlatformId } from "openclaw/plugin-sdk/channel-broker";
+import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type {
   ChannelBrokerConfig,
@@ -85,6 +86,52 @@ function normalizeCapabilities(
   return normalized;
 }
 
+function hasOwnProperty(record: Record<string, unknown> | undefined, key: string): boolean {
+  return Boolean(record && Object.prototype.hasOwnProperty.call(record, key));
+}
+
+function resolveProviderConfigRecord(
+  config: ChannelBrokerConfig | undefined,
+  accountId: string,
+): { key: "accounts" | "providers"; value: ChannelBrokerProviderConfig } | undefined {
+  const normalizedAccountId = normalizeAccountId(accountId);
+  const accounts = config?.accounts ?? {};
+  if (hasOwnProperty(accounts, normalizedAccountId)) {
+    return { key: "accounts", value: accounts[normalizedAccountId] ?? {} };
+  }
+  const providers = config?.providers ?? {};
+  if (hasOwnProperty(providers, normalizedAccountId)) {
+    return { key: "providers", value: providers[normalizedAccountId] ?? {} };
+  }
+  return undefined;
+}
+
+function resolveSecretInputPath(params: {
+  config: ChannelBrokerConfig | undefined;
+  accountId: string;
+  field: "outboundToken" | "signingSecret";
+}): string {
+  const provider = resolveProviderConfigRecord(params.config, params.accountId);
+  if (provider && hasOwnProperty(provider.value, params.field)) {
+    return `channels.channel-broker.${provider.key}.${normalizeAccountId(params.accountId)}.${params.field}`;
+  }
+  return `channels.channel-broker.${params.field}`;
+}
+
+function normalizeRuntimeSecretInput(params: {
+  cfg: CoreConfig;
+  value: unknown;
+  path: string;
+}): string | null {
+  return (
+    normalizeResolvedSecretInputString({
+      value: params.value,
+      defaults: params.cfg.secrets?.defaults,
+      path: params.path,
+    }) ?? null
+  );
+}
+
 export function resolveChannelBrokerAccount(params: {
   cfg: CoreConfig;
   accountId?: string | null;
@@ -110,8 +157,24 @@ export function resolveChannelBrokerAccount(params: {
     configured: Boolean(baseUrl),
     name: normalizeOptionalString(merged.name),
     baseUrl,
-    outboundToken: normalizeOptionalString(merged.outboundToken) ?? null,
-    signingSecret: normalizeOptionalString(merged.signingSecret) ?? null,
+    outboundToken: normalizeRuntimeSecretInput({
+      cfg: params.cfg,
+      value: merged.outboundToken,
+      path: resolveSecretInputPath({
+        config: channelConfig,
+        accountId: normalizedAccountId,
+        field: "outboundToken",
+      }),
+    }),
+    signingSecret: normalizeRuntimeSecretInput({
+      cfg: params.cfg,
+      value: merged.signingSecret,
+      path: resolveSecretInputPath({
+        config: channelConfig,
+        accountId: normalizedAccountId,
+        field: "signingSecret",
+      }),
+    }),
     platforms: normalizePlatformList(merged.platforms),
     platformAliases: normalizePlatformAliasMap(merged.platformAliases),
     defaultPlatform,

--- a/extensions/channel-broker/src/accounts.ts
+++ b/extensions/channel-broker/src/accounts.ts
@@ -1,0 +1,126 @@
+import {
+  hasConfiguredAccountValue,
+  listCombinedAccountIds,
+  resolveListedDefaultAccountId,
+} from "openclaw/plugin-sdk/account-core";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
+import { resolveMergedAccountConfig } from "openclaw/plugin-sdk/account-resolution-runtime";
+import { normalizeBrokerPlatformId } from "openclaw/plugin-sdk/channel-broker";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type {
+  ChannelBrokerConfig,
+  ChannelBrokerProviderConfig,
+  CoreConfig,
+  ResolvedChannelBrokerAccount,
+} from "./types.js";
+
+export { DEFAULT_ACCOUNT_ID };
+
+function getChannelBrokerConfig(cfg: CoreConfig): ChannelBrokerConfig | undefined {
+  return cfg.channels?.["channel-broker"];
+}
+
+function resolveMergedBrokerProviderConfig(
+  cfg: CoreConfig,
+  accountId: string,
+): ChannelBrokerProviderConfig {
+  const channelConfig = getChannelBrokerConfig(cfg);
+  const accounts = {
+    ...(channelConfig?.providers ?? {}),
+    ...(channelConfig?.accounts ?? {}),
+  };
+  return resolveMergedAccountConfig<ChannelBrokerProviderConfig>({
+    channelConfig,
+    accounts,
+    accountId,
+    omitKeys: ["accounts", "defaultAccount", "defaultProviderId", "providers"],
+    normalizeAccountId,
+  });
+}
+
+export function listChannelBrokerProviderIds(cfg: CoreConfig): string[] {
+  const channelConfig = getChannelBrokerConfig(cfg);
+  const providerIds = Object.keys(channelConfig?.providers ?? {});
+  const accountIds = Object.keys(channelConfig?.accounts ?? {});
+  return listCombinedAccountIds({
+    configuredAccountIds: [...providerIds, ...accountIds].map(normalizeAccountId),
+    implicitAccountId: hasConfiguredAccountValue(channelConfig?.baseUrl)
+      ? DEFAULT_ACCOUNT_ID
+      : undefined,
+    fallbackAccountIdWhenEmpty: DEFAULT_ACCOUNT_ID,
+  });
+}
+
+export function resolveDefaultChannelBrokerProviderId(cfg: CoreConfig): string {
+  const channelConfig = getChannelBrokerConfig(cfg);
+  const preferred = channelConfig?.defaultProviderId ?? channelConfig?.defaultAccount;
+  return resolveListedDefaultAccountId({
+    accountIds: listChannelBrokerProviderIds(cfg),
+    configuredDefaultAccountId: preferred ? normalizeAccountId(preferred) : undefined,
+  });
+}
+
+function normalizePlatformList(values: readonly string[] | undefined): string[] {
+  return Array.from(new Set((values ?? []).map((value) => normalizeBrokerPlatformId(value))));
+}
+
+function normalizePlatformAliasMap(
+  aliases: Record<string, string> | undefined,
+): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  for (const [rawAlias, rawTarget] of Object.entries(aliases ?? {})) {
+    normalized[normalizeBrokerPlatformId(rawAlias)] = normalizeBrokerPlatformId(rawTarget);
+  }
+  return normalized;
+}
+
+function normalizeCapabilities(
+  capabilities: ChannelBrokerProviderConfig["capabilities"],
+): NonNullable<ResolvedChannelBrokerAccount["capabilities"]> {
+  const normalized: NonNullable<ResolvedChannelBrokerAccount["capabilities"]> = {};
+  for (const [rawPlatform, value] of Object.entries(capabilities ?? {})) {
+    const platform = normalizeBrokerPlatformId(rawPlatform);
+    normalized[platform] = { ...value, platform };
+  }
+  return normalized;
+}
+
+export function resolveChannelBrokerAccount(params: {
+  cfg: CoreConfig;
+  accountId?: string | null;
+}): ResolvedChannelBrokerAccount {
+  const channelConfig = getChannelBrokerConfig(params.cfg);
+  const accountId =
+    normalizeOptionalString(params.accountId) ??
+    normalizeOptionalString(channelConfig?.defaultProviderId) ??
+    normalizeOptionalString(channelConfig?.defaultAccount) ??
+    resolveDefaultChannelBrokerProviderId(params.cfg as never);
+  const normalizedAccountId = normalizeAccountId(accountId);
+  const merged = resolveMergedBrokerProviderConfig(params.cfg, normalizedAccountId);
+  const baseEnabled = channelConfig?.enabled !== false;
+  const enabled = baseEnabled && merged.enabled !== false;
+  const baseUrl = normalizeOptionalString(merged.baseUrl) ?? null;
+  const defaultPlatform = merged.defaultPlatform
+    ? normalizeBrokerPlatformId(merged.defaultPlatform)
+    : null;
+  return {
+    accountId: normalizeOptionalString(merged.accountId) ?? normalizedAccountId,
+    providerId: normalizedAccountId,
+    enabled,
+    configured: Boolean(baseUrl),
+    name: normalizeOptionalString(merged.name),
+    baseUrl,
+    outboundToken: normalizeOptionalString(merged.outboundToken) ?? null,
+    signingSecret: normalizeOptionalString(merged.signingSecret) ?? null,
+    platforms: normalizePlatformList(merged.platforms),
+    platformAliases: normalizePlatformAliasMap(merged.platformAliases),
+    defaultPlatform,
+    defaultConversationType: merged.defaultConversationType ?? "channel",
+    defaultTo: normalizeOptionalString(merged.defaultTo),
+    allowFrom: merged.allowFrom ?? ["*"],
+    capabilities: normalizeCapabilities(merged.capabilities),
+    config: merged,
+  };
+}
+
+export type { ResolvedChannelBrokerAccount };

--- a/extensions/channel-broker/src/accounts.ts
+++ b/extensions/channel-broker/src/accounts.ts
@@ -26,10 +26,7 @@ function resolveMergedBrokerProviderConfig(
   accountId: string,
 ): ChannelBrokerProviderConfig {
   const channelConfig = getChannelBrokerConfig(cfg);
-  const accounts = {
-    ...(channelConfig?.providers ?? {}),
-    ...(channelConfig?.accounts ?? {}),
-  };
+  const accounts = Object.assign({}, channelConfig?.providers, channelConfig?.accounts);
   return resolveMergedAccountConfig<ChannelBrokerProviderConfig>({
     channelConfig,
     accounts,

--- a/extensions/channel-broker/src/channel.test.ts
+++ b/extensions/channel-broker/src/channel.test.ts
@@ -1,0 +1,125 @@
+import { createBrokerReceipt } from "openclaw/plugin-sdk/channel-broker";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { channelBrokerPlugin } from "./channel.js";
+import { resetChannelBrokerRuntimeForTest, setChannelBrokerRuntime } from "./runtime.js";
+
+describe("channel-broker plugin", () => {
+  beforeEach(() => {
+    resetChannelBrokerRuntimeForTest();
+  });
+
+  it("declares one generic channel owned by provider capabilities", () => {
+    expect(channelBrokerPlugin.id).toBe("channel-broker");
+    expect(channelBrokerPlugin.message?.receive).toEqual({
+      defaultAckPolicy: "after_durable_send",
+      supportedAckPolicies: ["after_receive_record", "after_agent_dispatch", "after_durable_send"],
+    });
+    expect(channelBrokerPlugin.message?.live?.capabilities).toEqual({
+      draftPreview: true,
+      previewFinalization: true,
+      progressUpdates: true,
+    });
+  });
+
+  it("delivers text through the configured provider and maps the provider receipt", async () => {
+    const sendOutboundRequest = vi.fn(async () =>
+      createBrokerReceipt({
+        requestId: "broker-send-1",
+        providerId: "acme",
+        platform: "Telegram",
+        status: "sent",
+        messageIds: ["native-1"],
+        editToken: "edit-native-1",
+      }),
+    );
+    setChannelBrokerRuntime({ sendOutboundRequest, createRequestId: () => "broker-send-1" });
+
+    const cfg = {
+      channels: {
+        "channel-broker": {
+          defaultProviderId: "acme",
+          accounts: {
+            acme: {
+              enabled: true,
+              baseUrl: "https://broker.example.test",
+              platforms: ["telegram", "discord"],
+            },
+          },
+        },
+      },
+    };
+
+    const result = await channelBrokerPlugin.message?.send.text?.({
+      cfg,
+      to: "telegram:chat%20123?threadId=topic%2Fa",
+      text: "hello",
+      accountId: "acme",
+      replyToId: "native-parent",
+      threadId: "topic/a",
+    } as never);
+
+    expect(sendOutboundRequest).toHaveBeenCalledWith({
+      account: expect.objectContaining({ providerId: "acme" }),
+      request: {
+        version: 1,
+        requestId: "broker-send-1",
+        providerId: "acme",
+        platform: "telegram",
+        accountId: "acme",
+        conversation: {
+          id: "chat 123",
+          type: "channel",
+          threadId: "topic/a",
+        },
+        mode: "final",
+        payloads: [{ text: "hello" }],
+        relation: { replyToId: "native-parent" },
+        requirements: { text: true, replyTo: true, thread: true },
+      },
+    });
+    expect(result?.messageId).toBe("native-1");
+    expect(result?.receipt).toEqual({
+      primaryPlatformMessageId: "native-1",
+      platformMessageIds: ["native-1"],
+      parts: [
+        {
+          platformMessageId: "native-1",
+          kind: "text",
+          index: 0,
+          threadId: "topic/a",
+          replyToId: "native-parent",
+          raw: {
+            channel: "channel-broker",
+            messageId: "native-1",
+            conversationId: "chat 123",
+            timestamp: expect.any(Number),
+            meta: {
+              providerId: "acme",
+              platform: "telegram",
+              status: "sent",
+              requestId: "broker-send-1",
+            },
+          },
+        },
+      ],
+      threadId: "topic/a",
+      replyToId: "native-parent",
+      editToken: "edit-native-1",
+      sentAt: expect.any(Number),
+      raw: [
+        {
+          channel: "channel-broker",
+          messageId: "native-1",
+          conversationId: "chat 123",
+          timestamp: expect.any(Number),
+          meta: {
+            providerId: "acme",
+            platform: "telegram",
+            status: "sent",
+            requestId: "broker-send-1",
+          },
+        },
+      ],
+    });
+  });
+});

--- a/extensions/channel-broker/src/channel.test.ts
+++ b/extensions/channel-broker/src/channel.test.ts
@@ -22,6 +22,7 @@ describe("channel-broker plugin", () => {
   });
 
   it("delivers text through the configured provider and maps the provider receipt", async () => {
+    const controller = new AbortController();
     const sendOutboundRequest = vi.fn(async () =>
       createBrokerReceipt({
         requestId: "broker-send-1",
@@ -56,10 +57,12 @@ describe("channel-broker plugin", () => {
       accountId: "acme",
       replyToId: "native-parent",
       threadId: "topic/a",
+      signal: controller.signal,
     } as never);
 
     expect(sendOutboundRequest).toHaveBeenCalledWith({
       account: expect.objectContaining({ providerId: "acme" }),
+      signal: controller.signal,
       request: {
         version: 1,
         requestId: "broker-send-1",
@@ -121,5 +124,51 @@ describe("channel-broker plugin", () => {
         },
       ],
     });
+  });
+
+  it("passes cancellation through the default HTTP transport", async () => {
+    const controller = new AbortController();
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () =>
+        createBrokerReceipt({
+          requestId: "broker-send-2",
+          providerId: "acme",
+          platform: "Slack",
+          status: "sent",
+          messageIds: ["native-2"],
+        }),
+    }));
+    setChannelBrokerRuntime({ fetch: fetchMock as never, createRequestId: () => "broker-send-2" });
+
+    const result = await channelBrokerPlugin.message?.send.text?.({
+      cfg: {
+        channels: {
+          "channel-broker": {
+            accounts: {
+              acme: {
+                enabled: true,
+                baseUrl: "https://broker.example.test/",
+                outboundToken: "resolved-token",
+              },
+            },
+          },
+        },
+      },
+      to: "slack:C123",
+      text: "hello",
+      accountId: "acme",
+      signal: controller.signal,
+    } as never);
+
+    expect(result?.messageId).toBe("native-2");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://broker.example.test/v1/outbound",
+      expect.objectContaining({
+        method: "POST",
+        signal: controller.signal,
+        headers: expect.objectContaining({ authorization: "Bearer resolved-token" }),
+      }),
+    );
   });
 });

--- a/extensions/channel-broker/src/channel.test.ts
+++ b/extensions/channel-broker/src/channel.test.ts
@@ -126,6 +126,85 @@ describe("channel-broker plugin", () => {
     });
   });
 
+  it("maps broker-prefixed Telegram topics into provider thread requests", async () => {
+    const sendOutboundRequest = vi.fn(async () =>
+      createBrokerReceipt({
+        requestId: "broker-telegram-topic-1",
+        providerId: "acme",
+        platform: "Telegram",
+        status: "sent",
+        messageIds: ["telegram-message-1"],
+      }),
+    );
+    setChannelBrokerRuntime({
+      sendOutboundRequest,
+      createRequestId: () => "broker-telegram-topic-1",
+    });
+
+    await channelBrokerPlugin.message?.send?.text?.({
+      cfg: {
+        channels: {
+          "channel-broker": {
+            defaultProviderId: "acme",
+            accounts: {
+              acme: {
+                enabled: true,
+                baseUrl: "https://broker.example.test",
+                platforms: ["telegram"],
+              },
+            },
+          },
+        },
+      },
+      to: "broker:telegram:-1001234567890:topic:42",
+      text: "topic proof",
+      accountId: "acme",
+    } as never);
+
+    expect(sendOutboundRequest).toHaveBeenCalledWith({
+      account: expect.objectContaining({ providerId: "acme" }),
+      request: expect.objectContaining({
+        requestId: "broker-telegram-topic-1",
+        providerId: "acme",
+        platform: "telegram",
+        conversation: {
+          id: "-1001234567890",
+          type: "channel",
+          threadId: "42",
+        },
+        requirements: { text: true, thread: true },
+      }),
+    });
+  });
+
+  it("canonicalizes Telegram topic routes without changing native default ownership", () => {
+    const route = channelBrokerPlugin.messaging?.resolveOutboundSessionRoute?.({
+      cfg: {
+        channels: {
+          "channel-broker": {
+            accounts: {
+              acme: {
+                enabled: true,
+                baseUrl: "https://broker.example.test",
+                platforms: ["telegram"],
+              },
+            },
+          },
+        },
+      },
+      agentId: "agent",
+      accountId: "acme",
+      target: "broker:telegram:-1001234567890:topic:42",
+    } as never);
+
+    expect(route).toMatchObject({
+      chatType: "channel",
+      peer: { kind: "channel", id: "telegram:-1001234567890" },
+      to: "telegram:-1001234567890?threadId=42",
+      threadId: "42",
+    });
+  });
+
   it("passes cancellation through the default HTTP transport", async () => {
     const controller = new AbortController();
     const fetchMock = vi.fn(async () => ({

--- a/extensions/channel-broker/src/channel.test.ts
+++ b/extensions/channel-broker/src/channel.test.ts
@@ -50,7 +50,7 @@ describe("channel-broker plugin", () => {
       },
     };
 
-    const result = await channelBrokerPlugin.message?.send.text?.({
+    const result = await channelBrokerPlugin.message?.send?.text?.({
       cfg,
       to: "telegram:chat%20123?threadId=topic%2Fa",
       text: "hello",
@@ -141,7 +141,7 @@ describe("channel-broker plugin", () => {
     }));
     setChannelBrokerRuntime({ fetch: fetchMock as never, createRequestId: () => "broker-send-2" });
 
-    const result = await channelBrokerPlugin.message?.send.text?.({
+    const result = await channelBrokerPlugin.message?.send?.text?.({
       cfg: {
         channels: {
           "channel-broker": {

--- a/extensions/channel-broker/src/channel.ts
+++ b/extensions/channel-broker/src/channel.ts
@@ -1,4 +1,8 @@
-import { parseBrokerConversationTarget } from "openclaw/plugin-sdk/channel-broker";
+import {
+  buildBrokerConversationTarget,
+  parseBrokerConversationTarget,
+  type BrokerConversationTarget,
+} from "openclaw/plugin-sdk/channel-broker";
 import {
   buildChannelOutboundSessionRoute,
   buildThreadAwareOutboundSessionRoute,
@@ -79,6 +83,14 @@ function resolveBrokerSessionConversation(rawId: string) {
   } catch {
     return null;
   }
+}
+
+function buildCanonicalBrokerTarget(target: BrokerConversationTarget): string {
+  return buildBrokerConversationTarget({
+    platform: target.platform,
+    conversationId: target.conversationId,
+    ...(target.threadId ? { threadId: target.threadId } : {}),
+  });
 }
 
 const channelBrokerMessageAdapter = defineChannelMessageAdapter({
@@ -189,7 +201,7 @@ export const channelBrokerPlugin = createChatChannelPlugin({
         const parsed = parseChannelBrokerTarget({ rawTarget: target, account, threadId });
         const brokerConversationType = parsed.conversationType ?? "channel";
         const chatType = brokerConversationType === "thread" ? "channel" : brokerConversationType;
-        const to = normalizeBrokerTarget(target) ?? target;
+        const to = buildCanonicalBrokerTarget(parsed);
         const route = buildChannelOutboundSessionRoute({
           cfg,
           agentId,

--- a/extensions/channel-broker/src/channel.ts
+++ b/extensions/channel-broker/src/channel.ts
@@ -1,0 +1,245 @@
+import { parseBrokerConversationTarget } from "openclaw/plugin-sdk/channel-broker";
+import {
+  buildChannelOutboundSessionRoute,
+  buildThreadAwareOutboundSessionRoute,
+  createChatChannelPlugin,
+} from "openclaw/plugin-sdk/channel-core";
+import { defineChannelMessageAdapter } from "openclaw/plugin-sdk/channel-message";
+import { getChatChannelMeta } from "openclaw/plugin-sdk/channel-plugin-common";
+import { DEFAULT_ACCOUNT_ID } from "./accounts.js";
+import {
+  listChannelBrokerProviderIds,
+  resolveChannelBrokerAccount,
+  resolveDefaultChannelBrokerProviderId,
+} from "./accounts.js";
+import { channelBrokerPluginConfigSchema } from "./config-schema.js";
+import { sendChannelBrokerOutboundText, sendChannelBrokerText } from "./outbound.js";
+import { channelBrokerStatus } from "./status.js";
+import { normalizeBrokerTarget, parseChannelBrokerTarget } from "./target.js";
+import type { CoreConfig, ResolvedChannelBrokerAccount } from "./types.js";
+
+const CHANNEL_ID = "channel-broker" as const;
+
+const BROKER_PLATFORM_TARGET_PREFIXES = [
+  "broker",
+  "channel-broker",
+  "slack",
+  "discord",
+  "telegram",
+  "whatsapp",
+  "signal",
+  "imessage",
+  "matrix",
+  "msteams",
+  "teams",
+  "googlechat",
+  "google-chat",
+  "line",
+  "wechat",
+  "qq",
+  "feishu",
+  "zalo",
+  "irc",
+  "mattermost",
+  "nextcloud-talk",
+  "nostr",
+  "tlon",
+  "synology-chat",
+  "twitch",
+] as const;
+
+function inferBrokerTargetChatType(to: string) {
+  try {
+    const parsed = parseBrokerConversationTarget(to);
+    const [maybeType] = parsed.conversationId.split(":", 1);
+    if (maybeType === "direct" || maybeType === "group" || maybeType === "channel") {
+      return maybeType;
+    }
+    if (maybeType === "thread") {
+      return "channel";
+    }
+    return "channel";
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveBrokerSessionConversation(rawId: string) {
+  try {
+    const parsed = parseBrokerConversationTarget(rawId);
+    if (parsed.conversationType === "direct") {
+      return null;
+    }
+    return {
+      id: parsed.conversationId,
+      threadId: parsed.threadId,
+      baseConversationId: parsed.conversationId,
+      parentConversationCandidates: [parsed.conversationId],
+    };
+  } catch {
+    return null;
+  }
+}
+
+const channelBrokerMessageAdapter = defineChannelMessageAdapter({
+  id: CHANNEL_ID,
+  durableFinal: {
+    capabilities: {
+      text: true,
+      replyTo: true,
+      thread: true,
+      messageSendingHooks: true,
+      reconcileUnknownSend: true,
+      afterCommit: true,
+    },
+  },
+  receive: {
+    defaultAckPolicy: "after_durable_send",
+    supportedAckPolicies: ["after_receive_record", "after_agent_dispatch", "after_durable_send"],
+  },
+  live: {
+    capabilities: {
+      draftPreview: true,
+      previewFinalization: true,
+      progressUpdates: true,
+    },
+    finalizer: {
+      capabilities: {
+        finalEdit: true,
+        normalFallback: true,
+        previewReceipt: true,
+        retainOnAmbiguousFailure: true,
+      },
+    },
+  },
+  send: {
+    text: async (ctx) =>
+      await sendChannelBrokerText({
+        cfg: ctx.cfg as CoreConfig,
+        accountId: ctx.accountId,
+        to: ctx.to,
+        text: ctx.text,
+        threadId: ctx.threadId,
+        replyToId: ctx.replyToId,
+        silent: ctx.silent,
+        signal: ctx.signal,
+      }),
+  },
+});
+
+export const channelBrokerPlugin = createChatChannelPlugin({
+  base: {
+    id: CHANNEL_ID,
+    meta: {
+      ...getChatChannelMeta(CHANNEL_ID),
+      preferOver: ["slack", "discord", "telegram"],
+    },
+    capabilities: {
+      chatTypes: ["direct", "group", "channel", "thread"],
+      media: true,
+      reply: true,
+      threads: true,
+      reactions: true,
+      edit: true,
+    },
+    reload: { configPrefixes: ["channels.channel-broker"] },
+    configSchema: channelBrokerPluginConfigSchema,
+    config: {
+      listAccountIds: (cfg) => listChannelBrokerProviderIds(cfg as CoreConfig),
+      resolveAccount: (cfg, accountId) =>
+        resolveChannelBrokerAccount({ cfg: cfg as CoreConfig, accountId }),
+      defaultAccountId: (cfg) => resolveDefaultChannelBrokerProviderId(cfg as CoreConfig),
+      isConfigured: (account) => account.configured,
+      isEnabled: (account) => account.enabled,
+      resolveAllowFrom: ({ cfg, accountId }) =>
+        resolveChannelBrokerAccount({ cfg: cfg as CoreConfig, accountId }).allowFrom,
+      resolveDefaultTo: ({ cfg, accountId }) =>
+        resolveChannelBrokerAccount({ cfg: cfg as CoreConfig, accountId }).defaultTo,
+      describeAccount: (account) => ({
+        accountId: account.providerId,
+        name: account.name,
+        enabled: account.enabled,
+        configured: account.configured,
+        baseUrl: account.baseUrl ?? undefined,
+        allowFrom: account.allowFrom.map(String),
+        extra: {
+          platforms: account.platforms,
+          defaultPlatform: account.defaultPlatform,
+        },
+      }),
+    },
+    messaging: {
+      targetPrefixes: BROKER_PLATFORM_TARGET_PREFIXES,
+      normalizeTarget: normalizeBrokerTarget,
+      inferTargetChatType: ({ to }) => inferBrokerTargetChatType(to),
+      targetResolver: {
+        looksLikeId: (raw) => Boolean(normalizeBrokerTarget(raw)),
+        hint: "<platform>:<conversationId>[?threadId=<threadId>]",
+      },
+      resolveOutboundSessionRoute: ({
+        cfg,
+        agentId,
+        accountId,
+        target,
+        replyToId,
+        threadId,
+        currentSessionKey,
+      }) => {
+        const account = resolveChannelBrokerAccount({ cfg: cfg as CoreConfig, accountId });
+        const parsed = parseChannelBrokerTarget({ rawTarget: target, account, threadId });
+        const brokerConversationType = parsed.conversationType ?? "channel";
+        const chatType = brokerConversationType === "thread" ? "channel" : brokerConversationType;
+        const to = normalizeBrokerTarget(target) ?? target;
+        const route = buildChannelOutboundSessionRoute({
+          cfg,
+          agentId,
+          channel: CHANNEL_ID,
+          accountId: account.providerId || DEFAULT_ACCOUNT_ID,
+          peer: {
+            kind: chatType === "direct" ? "direct" : chatType === "group" ? "group" : "channel",
+            id: `${parsed.platform}:${parsed.conversationId}`,
+          },
+          chatType,
+          from: `${CHANNEL_ID}:${account.providerId || DEFAULT_ACCOUNT_ID}`,
+          to,
+        });
+        return buildThreadAwareOutboundSessionRoute({
+          route,
+          replyToId,
+          threadId: parsed.threadId ?? threadId,
+          currentSessionKey,
+          canRecoverCurrentThread: ({ route }) =>
+            route.chatType !== "direct" || (cfg.session?.dmScope ?? "main") !== "main",
+        });
+      },
+      resolveSessionConversation: ({ rawId }) => resolveBrokerSessionConversation(rawId),
+    },
+    status: channelBrokerStatus,
+    message: channelBrokerMessageAdapter,
+  },
+  outbound: {
+    base: {
+      deliveryMode: "direct",
+      deliveryCapabilities: {
+        durableFinal: {
+          text: true,
+          replyTo: true,
+          thread: true,
+          messageSendingHooks: true,
+          reconcileUnknownSend: true,
+        },
+      },
+      resolveTarget: ({ to, cfg, accountId }) => {
+        const account = resolveChannelBrokerAccount({ cfg: cfg as CoreConfig, accountId });
+        const resolved = to?.trim() || account.defaultTo;
+        return resolved
+          ? { ok: true, to: normalizeBrokerTarget(resolved) ?? resolved }
+          : { ok: false, error: new Error("Channel broker target is required.") };
+      },
+    },
+    attachedResults: {
+      channel: CHANNEL_ID,
+      sendText: async (ctx) => await sendChannelBrokerOutboundText(ctx),
+    },
+  },
+}) satisfies import("openclaw/plugin-sdk/channel-core").ChannelPlugin<ResolvedChannelBrokerAccount>;

--- a/extensions/channel-broker/src/config-schema.ts
+++ b/extensions/channel-broker/src/config-schema.ts
@@ -1,4 +1,5 @@
 import { buildChannelConfigSchema } from "openclaw/plugin-sdk/channel-config-schema";
+import { buildSecretInputSchema } from "openclaw/plugin-sdk/secret-input";
 import { z } from "zod";
 
 const BrokerPlatformCapabilitiesSchema = z
@@ -26,8 +27,8 @@ const ProviderSchema = z
     name: z.string().optional(),
     enabled: z.boolean().optional(),
     baseUrl: z.string().url().optional(),
-    outboundToken: z.string().optional(),
-    signingSecret: z.string().optional(),
+    outboundToken: buildSecretInputSchema().optional(),
+    signingSecret: buildSecretInputSchema().optional(),
     accountId: z.string().optional(),
     platforms: z.array(z.string()).optional(),
     platformAliases: z.record(z.string(), z.string()).optional(),

--- a/extensions/channel-broker/src/config-schema.ts
+++ b/extensions/channel-broker/src/config-schema.ts
@@ -1,0 +1,49 @@
+import { buildChannelConfigSchema } from "openclaw/plugin-sdk/channel-config-schema";
+import { z } from "zod";
+
+const BrokerPlatformCapabilitiesSchema = z
+  .object({
+    inbound: z.boolean().optional(),
+    outbound: z.boolean().optional(),
+    receipts: z.boolean().optional(),
+    threads: z.boolean().optional(),
+    topics: z.boolean().optional(),
+    attachments: z.boolean().optional(),
+    reactions: z.boolean().optional(),
+    edits: z.boolean().optional(),
+    deletes: z.boolean().optional(),
+    draftPreview: z.boolean().optional(),
+    progressPreview: z.boolean().optional(),
+    finalEdit: z.boolean().optional(),
+    businessApi: z.boolean().optional(),
+    deviceBound: z.boolean().optional(),
+    selfHosted: z.boolean().optional(),
+  })
+  .strict();
+
+const ProviderSchema = z
+  .object({
+    name: z.string().optional(),
+    enabled: z.boolean().optional(),
+    baseUrl: z.string().url().optional(),
+    outboundToken: z.string().optional(),
+    signingSecret: z.string().optional(),
+    accountId: z.string().optional(),
+    platforms: z.array(z.string()).optional(),
+    platformAliases: z.record(z.string(), z.string()).optional(),
+    defaultPlatform: z.string().optional(),
+    defaultConversationType: z.enum(["direct", "group", "channel", "thread"]).optional(),
+    defaultTo: z.string().optional(),
+    allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    capabilities: z.record(z.string(), BrokerPlatformCapabilitiesSchema).optional(),
+  })
+  .strict();
+
+const ChannelBrokerConfigSchema = ProviderSchema.extend({
+  accounts: z.record(z.string(), ProviderSchema.partial()).optional(),
+  providers: z.record(z.string(), ProviderSchema.partial()).optional(),
+  defaultAccount: z.string().optional(),
+  defaultProviderId: z.string().optional(),
+}).strict();
+
+export const channelBrokerPluginConfigSchema = buildChannelConfigSchema(ChannelBrokerConfigSchema);

--- a/extensions/channel-broker/src/conformance.test.ts
+++ b/extensions/channel-broker/src/conformance.test.ts
@@ -1,0 +1,334 @@
+import {
+  brokerPlatformSupports,
+  buildBrokerInboundDedupeKey,
+  createBrokerInboundEvent,
+  createBrokerOutboundRequest,
+  createBrokerReceipt,
+} from "openclaw/plugin-sdk/channel-broker";
+import {
+  createDurableInboundReceiveJournal,
+  resolveChannelMessageSourceReplyDeliveryMode,
+} from "openclaw/plugin-sdk/channel-message";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { sendChannelBrokerText } from "./outbound.js";
+import { resetChannelBrokerRuntimeForTest, setChannelBrokerRuntime } from "./runtime.js";
+
+type ConformancePayload = {
+  providerId: string;
+  platform: string;
+  nativeMessageId: string;
+};
+
+type ConformanceMetadata = {
+  phase: "received" | "completed";
+};
+
+type MemoryStoreEntry<T> = {
+  key: string;
+  value: T;
+  createdAt: number;
+};
+
+function createMemoryStore<T>() {
+  const values = new Map<string, MemoryStoreEntry<T>>();
+  return {
+    async register(key, value) {
+      values.set(key, { key, value, createdAt: 1 });
+    },
+    async registerIfAbsent(key, value) {
+      if (values.has(key)) {
+        return false;
+      }
+      values.set(key, { key, value, createdAt: 1 });
+      return true;
+    },
+    async lookup(key) {
+      return values.get(key)?.value;
+    },
+    async consume(key) {
+      const value = values.get(key)?.value;
+      values.delete(key);
+      return value;
+    },
+    async delete(key) {
+      return values.delete(key);
+    },
+    async entries() {
+      return Array.from(values.values());
+    },
+    async clear() {
+      values.clear();
+    },
+  };
+}
+
+describe("channel-broker conformance baseline", () => {
+  beforeEach(() => {
+    resetChannelBrokerRuntimeForTest();
+  });
+
+  it("normalizes inbound events before duplicate/redelivery durable receive handling", async () => {
+    const inbound = createBrokerInboundEvent({
+      eventId: " update-1 ",
+      providerId: " acme ",
+      platform: "Telegram",
+      accountId: " bot-main ",
+      conversation: {
+        id: " -100123 ",
+        type: "thread",
+        parentId: "-100123",
+        threadId: " 77 ",
+      },
+      sender: { id: " user-1 ", handle: " lume " },
+      message: {
+        id: " 101 ",
+        text: " /verbose status ",
+        nativeIds: { message_id: " 101 " },
+      },
+    });
+    const dedupeKey = buildBrokerInboundDedupeKey(inbound);
+    const journal = createDurableInboundReceiveJournal<
+      ConformancePayload,
+      ConformanceMetadata,
+      ConformanceMetadata
+    >({
+      pendingStore: createMemoryStore(),
+      completedStore: createMemoryStore(),
+      now: () => 100,
+    });
+    const payload = {
+      providerId: inbound.providerId,
+      platform: inbound.platform,
+      nativeMessageId: inbound.message.id,
+    };
+
+    await expect(
+      journal.accept(dedupeKey, payload, { metadata: { phase: "received" } }),
+    ).resolves.toMatchObject({
+      kind: "accepted",
+      duplicate: false,
+      record: {
+        id: "acme:bot-main:telegram:update-1",
+        payload,
+        metadata: { phase: "received" },
+      },
+    });
+    await expect(
+      journal.accept(dedupeKey, { ...payload, nativeMessageId: "changed" }),
+    ).resolves.toMatchObject({
+      kind: "pending",
+      duplicate: true,
+      record: { payload },
+    });
+
+    await expect(journal.release(dedupeKey, { lastError: "provider redelivery" })).resolves.toBe(
+      true,
+    );
+    await expect(journal.pending()).resolves.toMatchObject([
+      {
+        id: "acme:bot-main:telegram:update-1",
+        attempts: 1,
+        lastError: "provider redelivery",
+      },
+    ]);
+
+    await journal.complete(dedupeKey, { metadata: { phase: "completed" }, completedAt: 200 });
+    await expect(journal.accept(dedupeKey, payload)).resolves.toMatchObject({
+      kind: "completed",
+      duplicate: true,
+      record: { completedAt: 200, metadata: { phase: "completed" } },
+    });
+  });
+
+  it("proves durable final send, receipt commit material, and multi-id provider receipts", async () => {
+    const sendOutboundRequest = vi.fn(async () =>
+      createBrokerReceipt({
+        requestId: "broker-final-1",
+        providerId: "acme",
+        platform: "Slack",
+        status: "sent",
+        messageIds: ["1716500000.000100", "1716500000.000101"],
+        timestamp: 123,
+        editToken: "1716500000.000101",
+        deleteToken: "delete-token",
+      }),
+    );
+    setChannelBrokerRuntime({ createRequestId: () => "broker-final-1", sendOutboundRequest });
+
+    const result = await sendChannelBrokerText({
+      cfg: {
+        channels: {
+          "channel-broker": {
+            accounts: {
+              acme: {
+                enabled: true,
+                baseUrl: "https://broker.example.test",
+                defaultConversationType: "channel",
+              },
+            },
+          },
+        },
+      },
+      accountId: "acme",
+      to: "slack:C123?threadId=1716500000.000001",
+      text: "final answer",
+      replyToId: "1716500000.000000",
+    });
+
+    expect(sendOutboundRequest).toHaveBeenCalledWith({
+      account: expect.objectContaining({ providerId: "acme" }),
+      request: expect.objectContaining({
+        requestId: "broker-final-1",
+        providerId: "acme",
+        platform: "slack",
+        conversation: {
+          id: "C123",
+          type: "channel",
+          threadId: "1716500000.000001",
+        },
+        mode: "final",
+        payloads: [{ text: "final answer" }],
+        relation: { replyToId: "1716500000.000000" },
+        requirements: { text: true, replyTo: true, thread: true },
+      }),
+    });
+    expect(result).toMatchObject({
+      messageId: "1716500000.000100",
+      receipt: {
+        primaryPlatformMessageId: "1716500000.000100",
+        platformMessageIds: ["1716500000.000100", "1716500000.000101"],
+        threadId: "1716500000.000001",
+        replyToId: "1716500000.000000",
+        editToken: "1716500000.000101",
+        deleteToken: "delete-token",
+        sentAt: 123,
+      },
+    });
+  });
+
+  it("turns retryable, failed, and unsupported provider receipts into durable-send failures", async () => {
+    setChannelBrokerRuntime({
+      createRequestId: () => "broker-retry-1",
+      sendOutboundRequest: vi.fn(async () =>
+        createBrokerReceipt({
+          requestId: "broker-retry-1",
+          providerId: "acme",
+          platform: "Discord",
+          status: "retryable",
+          messageIds: [],
+          retryAfterMs: 5000,
+          error: { code: "rate_limited", message: "rate limited", retryable: true },
+        }),
+      ),
+    });
+
+    await expect(
+      sendChannelBrokerText({
+        cfg: {
+          channels: {
+            "channel-broker": {
+              accounts: { acme: { enabled: true, baseUrl: "https://broker.example.test" } },
+            },
+          },
+        },
+        accountId: "acme",
+        to: "discord:channel%3A123",
+        text: "retry me",
+      }),
+    ).rejects.toMatchObject({
+      name: "ChannelBrokerProviderReceiptError",
+      receipt: { status: "retryable", retryAfterMs: 5000 },
+    });
+  });
+
+  it("requires preview and progress behavior to flow through provider capabilities", () => {
+    const capabilities = {
+      providerId: "acme",
+      platforms: [
+        {
+          platform: "Discord",
+          delivery: { text: true, previewFinalization: true, progressUpdates: true },
+          live: { draftPreview: true, progressUpdates: true, previewFinalization: true },
+          receive: { webhook: true, ackAfterDurableSend: true },
+        },
+      ],
+    };
+    const preview = createBrokerOutboundRequest({
+      requestId: "preview-1",
+      providerId: "acme",
+      platform: "discord",
+      conversation: { id: "channel:123", type: "channel", threadId: "thread-1" },
+      mode: "preview_update",
+      payloads: [{ text: "Working..." }],
+      requirements: { text: true, progressUpdates: true },
+    });
+    const finalize = createBrokerOutboundRequest({
+      requestId: "preview-2",
+      providerId: "acme",
+      platform: "discord",
+      conversation: { id: "channel:123", type: "channel", threadId: "thread-1" },
+      mode: "finalize_preview",
+      payloads: [{ text: "Done" }],
+      requirements: { text: true, previewFinalization: true },
+    });
+
+    expect(preview.mode).toBe("preview_update");
+    expect(finalize.mode).toBe("finalize_preview");
+    expect(
+      brokerPlatformSupports({
+        capabilities,
+        platform: "discord",
+        requirements: {
+          delivery: { text: true, progressUpdates: true, previewFinalization: true },
+          live: { draftPreview: true, progressUpdates: true, previewFinalization: true },
+          receive: { webhook: true, ackAfterDurableSend: true },
+        },
+      }),
+    ).toBe(true);
+    expect(
+      brokerPlatformSupports({
+        capabilities,
+        platform: "discord",
+        requirements: { delivery: { nativeStreaming: true } },
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps /verbose and tool-message policy in broker channelData instead of platform branches", () => {
+    const sourceReplyDeliveryMode = resolveChannelMessageSourceReplyDeliveryMode({
+      cfg: { messages: { visibleReplies: "message_tool" } } as never,
+      ctx: { ChatType: "channel" },
+      requested: "message_tool_only",
+      messageToolAvailable: true,
+    });
+    const request = createBrokerOutboundRequest({
+      requestId: "tool-1",
+      providerId: "acme",
+      platform: "Slack",
+      conversation: { id: "C123", type: "channel", threadId: "1716500000.000001" },
+      mode: "preview_update",
+      payloads: [
+        {
+          text: "Tool output",
+          channelData: {
+            openclaw: {
+              sourceReplyDeliveryMode,
+              verboseLevel: "full",
+              toolCallId: "tool-call-1",
+            },
+          },
+        },
+      ],
+      requirements: { text: true, progressUpdates: true },
+    });
+
+    expect(sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(request.payloads[0]?.channelData).toEqual({
+      openclaw: {
+        sourceReplyDeliveryMode: "message_tool_only",
+        verboseLevel: "full",
+        toolCallId: "tool-call-1",
+      },
+    });
+  });
+});

--- a/extensions/channel-broker/src/outbound.ts
+++ b/extensions/channel-broker/src/outbound.ts
@@ -1,0 +1,141 @@
+import {
+  createBrokerOutboundRequest,
+  type BrokerReceiptV1,
+} from "openclaw/plugin-sdk/channel-broker";
+import type { ChannelOutboundContext } from "openclaw/plugin-sdk/channel-contract";
+import {
+  createMessageReceiptFromOutboundResults,
+  type ChannelMessageSendResult,
+  type MessageReceiptSourceResult,
+} from "openclaw/plugin-sdk/channel-message";
+import { resolveChannelBrokerAccount } from "./accounts.js";
+import { createBrokerRequestId, sendBrokerOutboundRequest } from "./runtime.js";
+import { parseChannelBrokerTarget } from "./target.js";
+import type { CoreConfig } from "./types.js";
+
+const CHANNEL_ID = "channel-broker" as const;
+
+function normalizeMaybeString(value: string | number | null | undefined): string | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  const trimmed = String(value).trim();
+  return trimmed || undefined;
+}
+
+function resolvePrimaryMessageId(receipt: BrokerReceiptV1): string {
+  const messageId = receipt.messageIds[0]?.trim();
+  if (!messageId) {
+    throw new Error(`Channel broker provider ${receipt.providerId} did not return a message id.`);
+  }
+  return messageId;
+}
+
+function buildReceiptSourceResults(params: {
+  receipt: BrokerReceiptV1;
+  conversationId: string;
+}): MessageReceiptSourceResult[] {
+  const { receipt } = params;
+  const timestamp = receipt.timestamp ?? Date.now();
+  return receipt.messageIds.map((messageId) => ({
+    channel: CHANNEL_ID,
+    messageId,
+    conversationId: params.conversationId,
+    timestamp,
+    meta: {
+      providerId: receipt.providerId,
+      platform: receipt.platform,
+      status: receipt.status,
+      requestId: receipt.requestId,
+      ...(receipt.native ? { native: receipt.native } : {}),
+    },
+  }));
+}
+
+export async function sendChannelBrokerText(params: {
+  cfg: CoreConfig;
+  accountId?: string | null;
+  to: string;
+  text: string;
+  threadId?: string | number | null;
+  replyToId?: string | number | null;
+  silent?: boolean;
+  signal?: AbortSignal;
+}): Promise<ChannelMessageSendResult> {
+  const account = resolveChannelBrokerAccount({ cfg: params.cfg, accountId: params.accountId });
+  const target = parseChannelBrokerTarget({
+    rawTarget: params.to,
+    account,
+    threadId: params.threadId,
+  });
+  const threadId = normalizeMaybeString(target.threadId);
+  const replyToId = normalizeMaybeString(params.replyToId);
+  const request = createBrokerOutboundRequest({
+    requestId: createBrokerRequestId(),
+    providerId: account.providerId,
+    platform: target.platform,
+    accountId: account.accountId,
+    conversation: {
+      id: target.conversationId,
+      type: target.conversationType ?? account.defaultConversationType,
+      ...(threadId ? { threadId } : {}),
+    },
+    mode: "final",
+    payloads: [{ text: params.text }],
+    ...(replyToId || params.silent
+      ? {
+          relation: {
+            ...(replyToId ? { replyToId } : {}),
+            ...(params.silent ? { silent: true } : {}),
+          },
+        }
+      : {}),
+    requirements: {
+      text: true,
+      ...(replyToId ? { replyTo: true } : {}),
+      ...(threadId ? { thread: true } : {}),
+    },
+  });
+  const receipt = await sendBrokerOutboundRequest({ account, request });
+  const messageId = resolvePrimaryMessageId(receipt);
+  return {
+    messageId,
+    receipt: {
+      ...createMessageReceiptFromOutboundResults({
+        results: buildReceiptSourceResults({
+          receipt,
+          conversationId: target.conversationId,
+        }),
+        threadId,
+        replyToId,
+        kind: "text",
+        sentAt: receipt.timestamp,
+      }),
+      ...(receipt.editToken ? { editToken: receipt.editToken } : {}),
+      ...(receipt.deleteToken ? { deleteToken: receipt.deleteToken } : {}),
+    },
+  };
+}
+
+export async function sendChannelBrokerOutboundText(
+  ctx: ChannelOutboundContext,
+): Promise<{ ok: boolean; messageId: string; error?: Error }> {
+  try {
+    const result = await sendChannelBrokerText({
+      cfg: ctx.cfg as CoreConfig,
+      accountId: ctx.accountId,
+      to: ctx.to,
+      text: ctx.text,
+      threadId: ctx.threadId,
+      replyToId: ctx.replyToId,
+      silent: ctx.silent,
+    });
+    return { ok: true, messageId: result.messageId ?? "" };
+  } catch (error) {
+    return {
+      ok: false,
+      messageId: "",
+      error: error instanceof Error ? error : new Error(String(error)),
+    };
+  }
+}

--- a/extensions/channel-broker/src/outbound.ts
+++ b/extensions/channel-broker/src/outbound.ts
@@ -96,7 +96,11 @@ export async function sendChannelBrokerText(params: {
       ...(threadId ? { thread: true } : {}),
     },
   });
-  const receipt = await sendBrokerOutboundRequest({ account, request });
+  const receipt = await sendBrokerOutboundRequest({
+    account,
+    request,
+    ...(params.signal ? { signal: params.signal } : {}),
+  });
   const messageId = resolvePrimaryMessageId(receipt);
   return {
     messageId,
@@ -121,6 +125,7 @@ export async function sendChannelBrokerOutboundText(
   ctx: ChannelOutboundContext,
 ): Promise<{ ok: boolean; messageId: string; error?: Error }> {
   try {
+    const signal = (ctx as ChannelOutboundContext & { signal?: AbortSignal }).signal;
     const result = await sendChannelBrokerText({
       cfg: ctx.cfg as CoreConfig,
       accountId: ctx.accountId,
@@ -129,6 +134,7 @@ export async function sendChannelBrokerOutboundText(
       threadId: ctx.threadId,
       replyToId: ctx.replyToId,
       silent: ctx.silent,
+      ...(signal ? { signal } : {}),
     });
     return { ok: true, messageId: result.messageId ?? "" };
   } catch (error) {

--- a/extensions/channel-broker/src/outbound.ts
+++ b/extensions/channel-broker/src/outbound.ts
@@ -15,6 +15,20 @@ import type { CoreConfig } from "./types.js";
 
 const CHANNEL_ID = "channel-broker" as const;
 
+export class ChannelBrokerProviderReceiptError extends Error {
+  readonly receipt: BrokerReceiptV1;
+
+  constructor(receipt: BrokerReceiptV1) {
+    const providerMessage = receipt.error?.message?.trim();
+    const retryAfter = receipt.retryAfterMs ? ` retryAfterMs=${receipt.retryAfterMs}` : "";
+    super(
+      `Channel broker provider ${receipt.providerId} returned ${receipt.status} receipt for request ${receipt.requestId}${providerMessage ? `: ${providerMessage}` : ""}${retryAfter}.`,
+    );
+    this.name = "ChannelBrokerProviderReceiptError";
+    this.receipt = receipt;
+  }
+}
+
 function normalizeMaybeString(value: string | number | null | undefined): string | undefined {
   if (value == null) {
     return undefined;
@@ -23,7 +37,15 @@ function normalizeMaybeString(value: string | number | null | undefined): string
   return trimmed || undefined;
 }
 
+function assertProviderReceiptSent(receipt: BrokerReceiptV1): void {
+  if (receipt.status === "sent") {
+    return;
+  }
+  throw new ChannelBrokerProviderReceiptError(receipt);
+}
+
 function resolvePrimaryMessageId(receipt: BrokerReceiptV1): string {
+  assertProviderReceiptSent(receipt);
   const messageId = receipt.messageIds[0]?.trim();
   if (!messageId) {
     throw new Error(`Channel broker provider ${receipt.providerId} did not return a message id.`);

--- a/extensions/channel-broker/src/runtime.ts
+++ b/extensions/channel-broker/src/runtime.ts
@@ -1,0 +1,85 @@
+import type { BrokerOutboundRequestV1, BrokerReceiptV1 } from "openclaw/plugin-sdk/channel-broker";
+import type { ResolvedChannelBrokerAccount } from "./types.js";
+
+export type ChannelBrokerRuntime = {
+  createRequestId?: () => string;
+  fetch?: typeof fetch;
+  sendOutboundRequest?: (params: {
+    account: ResolvedChannelBrokerAccount;
+    request: BrokerOutboundRequestV1;
+  }) => Promise<BrokerReceiptV1>;
+};
+
+let runtime: ChannelBrokerRuntime = {};
+
+export function setChannelBrokerRuntime(next: ChannelBrokerRuntime): void {
+  runtime = { ...runtime, ...next };
+}
+
+export function resetChannelBrokerRuntimeForTest(): void {
+  runtime = {};
+}
+
+export function getChannelBrokerRuntime(): ChannelBrokerRuntime {
+  return runtime;
+}
+
+export function createBrokerRequestId(): string {
+  const custom = runtime.createRequestId?.();
+  if (custom?.trim()) {
+    return custom.trim();
+  }
+  return `broker-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function requireBrokerBaseUrl(account: ResolvedChannelBrokerAccount): string {
+  const baseUrl = account.baseUrl?.trim();
+  if (!baseUrl) {
+    throw new Error(
+      `Channel broker provider ${account.providerId} is not configured (missing baseUrl).`,
+    );
+  }
+  return baseUrl.replace(/\/+$/u, "");
+}
+
+function parseBrokerReceipt(value: unknown): BrokerReceiptV1 {
+  if (!value || typeof value !== "object") {
+    throw new Error("Channel broker provider returned a non-object receipt.");
+  }
+  return value as BrokerReceiptV1;
+}
+
+async function sendBrokerOutboundHttp(params: {
+  account: ResolvedChannelBrokerAccount;
+  request: BrokerOutboundRequestV1;
+}): Promise<BrokerReceiptV1> {
+  const fetchImpl = runtime.fetch ?? globalThis.fetch;
+  if (typeof fetchImpl !== "function") {
+    throw new Error("Channel broker outbound HTTP transport requires fetch.");
+  }
+  const response = await fetchImpl(`${requireBrokerBaseUrl(params.account)}/v1/outbound`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-openclaw-broker-provider": params.account.providerId,
+      ...(params.account.outboundToken
+        ? { authorization: `Bearer ${params.account.outboundToken}` }
+        : {}),
+    },
+    body: JSON.stringify(params.request),
+  });
+  if (!response.ok) {
+    throw new Error(`Channel broker provider returned HTTP ${response.status}.`);
+  }
+  return parseBrokerReceipt(await response.json());
+}
+
+export async function sendBrokerOutboundRequest(params: {
+  account: ResolvedChannelBrokerAccount;
+  request: BrokerOutboundRequestV1;
+}): Promise<BrokerReceiptV1> {
+  if (runtime.sendOutboundRequest) {
+    return await runtime.sendOutboundRequest(params);
+  }
+  return await sendBrokerOutboundHttp(params);
+}

--- a/extensions/channel-broker/src/runtime.ts
+++ b/extensions/channel-broker/src/runtime.ts
@@ -7,6 +7,7 @@ export type ChannelBrokerRuntime = {
   sendOutboundRequest?: (params: {
     account: ResolvedChannelBrokerAccount;
     request: BrokerOutboundRequestV1;
+    signal?: AbortSignal;
   }) => Promise<BrokerReceiptV1>;
 };
 
@@ -52,6 +53,7 @@ function parseBrokerReceipt(value: unknown): BrokerReceiptV1 {
 async function sendBrokerOutboundHttp(params: {
   account: ResolvedChannelBrokerAccount;
   request: BrokerOutboundRequestV1;
+  signal?: AbortSignal;
 }): Promise<BrokerReceiptV1> {
   const fetchImpl = runtime.fetch ?? globalThis.fetch;
   if (typeof fetchImpl !== "function") {
@@ -67,6 +69,7 @@ async function sendBrokerOutboundHttp(params: {
         : {}),
     },
     body: JSON.stringify(params.request),
+    ...(params.signal ? { signal: params.signal } : {}),
   });
   if (!response.ok) {
     throw new Error(`Channel broker provider returned HTTP ${response.status}.`);
@@ -77,6 +80,7 @@ async function sendBrokerOutboundHttp(params: {
 export async function sendBrokerOutboundRequest(params: {
   account: ResolvedChannelBrokerAccount;
   request: BrokerOutboundRequestV1;
+  signal?: AbortSignal;
 }): Promise<BrokerReceiptV1> {
   if (runtime.sendOutboundRequest) {
     return await runtime.sendOutboundRequest(params);

--- a/extensions/channel-broker/src/secret-contract.test.ts
+++ b/extensions/channel-broker/src/secret-contract.test.ts
@@ -1,0 +1,73 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  applyResolvedAssignments,
+  createResolverContext,
+  resolveSecretRefValues,
+} from "openclaw/plugin-sdk/secret-ref-runtime";
+import { describe, expect, it } from "vitest";
+import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
+
+describe("channel-broker secret contract", () => {
+  it("declares outbound and inbound signing credentials for accounts and provider aliases", () => {
+    expect(secretTargetRegistryEntries.map((entry) => entry.pathPattern)).toEqual([
+      "channels.channel-broker.outboundToken",
+      "channels.channel-broker.accounts.*.outboundToken",
+      "channels.channel-broker.providers.*.outboundToken",
+      "channels.channel-broker.signingSecret",
+      "channels.channel-broker.accounts.*.signingSecret",
+      "channels.channel-broker.providers.*.signingSecret",
+    ]);
+  });
+
+  it("resolves active provider SecretRefs into the runtime config snapshot", async () => {
+    const sourceConfig = {
+      channels: {
+        "channel-broker": {
+          enabled: true,
+          providers: {
+            acme: {
+              enabled: true,
+              baseUrl: "https://broker.example.test",
+              outboundToken: { source: "env", provider: "default", id: "BROKER_TOKEN" },
+              signingSecret: { source: "env", provider: "default", id: "BROKER_SIGNING_SECRET" },
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+    const resolvedConfig: OpenClawConfig = structuredClone(sourceConfig);
+    const context = createResolverContext({
+      sourceConfig,
+      env: {
+        BROKER_TOKEN: "resolved-token",
+        BROKER_SIGNING_SECRET: "resolved-signing-secret",
+      },
+    });
+
+    collectRuntimeConfigAssignments({
+      config: resolvedConfig,
+      defaults: undefined,
+      context,
+    });
+    const resolved = await resolveSecretRefValues(
+      context.assignments.map((assignment) => assignment.ref),
+      {
+        config: sourceConfig,
+        env: context.env,
+        cache: context.cache,
+      },
+    );
+    applyResolvedAssignments({
+      assignments: context.assignments,
+      resolved,
+    });
+
+    expect(resolvedConfig.channels?.["channel-broker"]?.providers?.acme?.outboundToken).toBe(
+      "resolved-token",
+    );
+    expect(resolvedConfig.channels?.["channel-broker"]?.providers?.acme?.signingSecret).toBe(
+      "resolved-signing-secret",
+    );
+    expect(context.warnings).toStrictEqual([]);
+  });
+});

--- a/extensions/channel-broker/src/secret-contract.ts
+++ b/extensions/channel-broker/src/secret-contract.ts
@@ -1,0 +1,155 @@
+import {
+  collectSecretInputAssignment,
+  hasOwnProperty,
+  isEnabledFlag,
+  isRecord,
+  type ResolverContext,
+  type SecretDefaults,
+} from "openclaw/plugin-sdk/channel-secret-basic-runtime";
+
+const CHANNEL_KEY = "channel-broker";
+const SECRET_FIELDS = ["outboundToken", "signingSecret"] as const;
+
+type SecretField = (typeof SECRET_FIELDS)[number];
+
+type ProviderEntry = {
+  key: "accounts" | "providers";
+  accountId: string;
+  account: Record<string, unknown>;
+  enabled: boolean;
+};
+
+export const secretTargetRegistryEntries: import("openclaw/plugin-sdk/channel-secret-basic-runtime").SecretTargetRegistryEntry[] =
+  SECRET_FIELDS.flatMap((field) => [
+    {
+      id: `channels.${CHANNEL_KEY}.${field}`,
+      targetType: `channels.${CHANNEL_KEY}.${field}`,
+      configFile: "openclaw.json",
+      pathPattern: `channels.${CHANNEL_KEY}.${field}`,
+      secretShape: "secret_input",
+      expectedResolvedValue: "string",
+      includeInPlan: true,
+      includeInConfigure: true,
+      includeInAudit: true,
+    },
+    {
+      id: `channels.${CHANNEL_KEY}.accounts.*.${field}`,
+      targetType: `channels.${CHANNEL_KEY}.accounts.*.${field}`,
+      configFile: "openclaw.json",
+      pathPattern: `channels.${CHANNEL_KEY}.accounts.*.${field}`,
+      secretShape: "secret_input",
+      expectedResolvedValue: "string",
+      includeInPlan: true,
+      includeInConfigure: true,
+      includeInAudit: true,
+    },
+    {
+      id: `channels.${CHANNEL_KEY}.providers.*.${field}`,
+      targetType: `channels.${CHANNEL_KEY}.providers.*.${field}`,
+      configFile: "openclaw.json",
+      pathPattern: `channels.${CHANNEL_KEY}.providers.*.${field}`,
+      secretShape: "secret_input",
+      expectedResolvedValue: "string",
+      includeInPlan: true,
+      includeInConfigure: true,
+      includeInAudit: true,
+    },
+  ]);
+
+function getChannelBrokerRecord(config: {
+  channels?: Record<string, unknown>;
+}): Record<string, unknown> | undefined {
+  const channel = config.channels?.[CHANNEL_KEY];
+  return isRecord(channel) ? channel : undefined;
+}
+
+function collectProviderEntries(channel: Record<string, unknown>): ProviderEntry[] {
+  return (["accounts", "providers"] as const).flatMap((key) => {
+    const accounts = channel[key];
+    if (!isRecord(accounts)) {
+      return [];
+    }
+    return Object.entries(accounts).flatMap(([accountId, account]) => {
+      if (!isRecord(account)) {
+        return [];
+      }
+      return [
+        {
+          key,
+          accountId,
+          account,
+          enabled: isEnabledFlag(channel) && isEnabledFlag(account),
+        },
+      ];
+    });
+  });
+}
+
+function collectBrokerSecretFieldAssignments(params: {
+  channel: Record<string, unknown>;
+  field: SecretField;
+  defaults: SecretDefaults | undefined;
+  context: ResolverContext;
+}): void {
+  const providerEntries = collectProviderEntries(params.channel);
+  const channelEnabled = isEnabledFlag(params.channel);
+  const topLevelActive =
+    channelEnabled &&
+    (providerEntries.length === 0 ||
+      providerEntries.some(
+        (entry) => entry.enabled && !hasOwnProperty(entry.account, params.field),
+      ));
+  collectSecretInputAssignment({
+    value: params.channel[params.field],
+    path: `channels.${CHANNEL_KEY}.${params.field}`,
+    expected: "string",
+    defaults: params.defaults,
+    context: params.context,
+    active: topLevelActive,
+    inactiveReason: `no enabled broker provider inherits this top-level ${params.field}.`,
+    apply: (value) => {
+      params.channel[params.field] = value;
+    },
+  });
+  for (const entry of providerEntries) {
+    if (!hasOwnProperty(entry.account, params.field)) {
+      continue;
+    }
+    collectSecretInputAssignment({
+      value: entry.account[params.field],
+      path: `channels.${CHANNEL_KEY}.${entry.key}.${entry.accountId}.${params.field}`,
+      expected: "string",
+      defaults: params.defaults,
+      context: params.context,
+      active: entry.enabled,
+      inactiveReason: "Channel broker provider is disabled.",
+      apply: (value) => {
+        entry.account[params.field] = value;
+      },
+    });
+  }
+}
+
+export function collectRuntimeConfigAssignments(params: {
+  config: { channels?: Record<string, unknown> };
+  defaults?: SecretDefaults;
+  context: ResolverContext;
+}): void {
+  const channel = getChannelBrokerRecord(params.config);
+  if (!channel) {
+    return;
+  }
+  for (const field of SECRET_FIELDS) {
+    collectBrokerSecretFieldAssignments({
+      channel,
+      field,
+      defaults: params.defaults,
+      context: params.context,
+    });
+  }
+}
+
+export const channelSecrets = {
+  secretTargetRegistryEntries,
+  collectRuntimeConfigAssignments,
+};

--- a/extensions/channel-broker/src/status.ts
+++ b/extensions/channel-broker/src/status.ts
@@ -1,0 +1,48 @@
+import {
+  createComputedAccountStatusAdapter,
+  createDefaultChannelRuntimeState,
+} from "openclaw/plugin-sdk/status-helpers";
+import { DEFAULT_ACCOUNT_ID } from "./accounts.js";
+import type { ResolvedChannelBrokerAccount } from "./types.js";
+
+export const channelBrokerStatus = createComputedAccountStatusAdapter<ResolvedChannelBrokerAccount>(
+  {
+    defaultRuntime: createDefaultChannelRuntimeState(DEFAULT_ACCOUNT_ID),
+    collectStatusIssues: (accounts) =>
+      accounts.flatMap((account) => {
+        if (account.configured) {
+          return [];
+        }
+        return [
+          {
+            channel: "channel-broker",
+            accountId: account.accountId,
+            kind: "config",
+            message: "Provider not configured (missing baseUrl)",
+          },
+        ];
+      }),
+    buildChannelSummary: ({ snapshot }) => ({
+      configured: snapshot.configured ?? false,
+      baseUrl: snapshot.baseUrl ?? null,
+    }),
+    probeAccount: async ({ account }) => ({
+      ok: account.configured,
+      providerId: account.providerId,
+      platforms: account.platforms,
+    }),
+    resolveAccountSnapshot: ({ account }) => ({
+      accountId: account.providerId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.configured,
+      baseUrl: account.baseUrl ?? undefined,
+      allowFrom: account.allowFrom.map(String),
+      extra: {
+        platforms: account.platforms,
+        defaultPlatform: account.defaultPlatform,
+        defaultConversationType: account.defaultConversationType,
+      },
+    }),
+  },
+);

--- a/extensions/channel-broker/src/target.ts
+++ b/extensions/channel-broker/src/target.ts
@@ -32,6 +32,37 @@ export function normalizeBrokerTarget(raw: string): string | undefined {
   }
 }
 
+function parseTelegramTopicConversation(rawConversationId: string): {
+  conversationId: string;
+  threadId?: string;
+} {
+  const topicMatch = /^(.*):topic:([^:]+)$/i.exec(rawConversationId);
+  if (topicMatch?.[1] && topicMatch[2]) {
+    return {
+      conversationId: topicMatch[1],
+      threadId: topicMatch[2],
+    };
+  }
+  const numericTopicMatch = /^(-?\d+):(\d+)$/.exec(rawConversationId);
+  if (numericTopicMatch?.[1] && numericTopicMatch[2]) {
+    return {
+      conversationId: numericTopicMatch[1],
+      threadId: numericTopicMatch[2],
+    };
+  }
+  return { conversationId: rawConversationId };
+}
+
+function parsePlatformConversation(params: { platform: string; rawConversationId: string }): {
+  conversationId: string;
+  threadId?: string;
+} {
+  if (params.platform === "telegram") {
+    return parseTelegramTopicConversation(params.rawConversationId);
+  }
+  return { conversationId: params.rawConversationId };
+}
+
 export function parseChannelBrokerTarget(params: {
   rawTarget: string;
   account: ResolvedChannelBrokerAccount;
@@ -57,12 +88,17 @@ export function parseChannelBrokerTarget(params: {
     normalizeBrokerPlatformId(rawPlatform);
   const colonParts = rawConversationId.split(":");
   const explicitType = normalizeConversationType(colonParts[0]);
-  const conversationId = explicitType ? colonParts.slice(1).join(":") : rawConversationId;
+  const platformConversation = parsePlatformConversation({
+    platform,
+    rawConversationId: explicitType ? colonParts.slice(1).join(":") : rawConversationId,
+  });
   const threadId =
-    params.threadId == null ? parsed.threadId : String(params.threadId).trim() || parsed.threadId;
+    params.threadId == null
+      ? (parsed.threadId ?? platformConversation.threadId)
+      : String(params.threadId).trim() || parsed.threadId || platformConversation.threadId;
   return {
     platform,
-    conversationId,
+    conversationId: platformConversation.conversationId,
     conversationType:
       explicitType ?? parsed.conversationType ?? params.account.defaultConversationType,
     ...(threadId ? { threadId } : {}),

--- a/extensions/channel-broker/src/target.ts
+++ b/extensions/channel-broker/src/target.ts
@@ -1,0 +1,81 @@
+import {
+  buildBrokerConversationTarget,
+  normalizeBrokerPlatformId,
+  parseBrokerConversationTarget,
+  type BrokerConversationTarget,
+  type BrokerConversationType,
+} from "openclaw/plugin-sdk/channel-broker";
+import type { ResolvedChannelBrokerAccount } from "./types.js";
+
+const CONVERSATION_TYPE_PREFIXES = new Set(["direct", "group", "channel", "thread"]);
+
+function normalizeConversationType(raw: string | undefined): BrokerConversationType | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  const normalized = raw.trim().toLowerCase();
+  return CONVERSATION_TYPE_PREFIXES.has(normalized)
+    ? (normalized as BrokerConversationType)
+    : undefined;
+}
+
+export function normalizeBrokerTarget(raw: string): string | undefined {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    const parsed = parseBrokerConversationTarget(trimmed);
+    return buildBrokerConversationTarget(parsed);
+  } catch {
+    return trimmed;
+  }
+}
+
+export function parseChannelBrokerTarget(params: {
+  rawTarget: string;
+  account: ResolvedChannelBrokerAccount;
+  threadId?: string | number | null;
+}): BrokerConversationTarget {
+  const parsed = parseBrokerConversationTarget(params.rawTarget);
+  const brokerPrefixed = parsed.platform === "broker" || parsed.platform === "channel-broker";
+  const brokerPrefixSeparator = brokerPrefixed ? parsed.conversationId.indexOf(":") : -1;
+  const rawPlatform =
+    brokerPrefixed && brokerPrefixSeparator > 0
+      ? parsed.conversationId.slice(0, brokerPrefixSeparator)
+      : brokerPrefixed && params.account.defaultPlatform
+        ? params.account.defaultPlatform
+        : parsed.platform;
+  const rawConversationId =
+    brokerPrefixed && brokerPrefixSeparator > 0
+      ? parsed.conversationId.slice(brokerPrefixSeparator + 1)
+      : brokerPrefixed && params.account.defaultPlatform
+        ? parsed.conversationId
+        : parsed.conversationId;
+  const platform =
+    params.account.platformAliases[normalizeBrokerPlatformId(rawPlatform)] ??
+    normalizeBrokerPlatformId(rawPlatform);
+  const colonParts = rawConversationId.split(":");
+  const explicitType = normalizeConversationType(colonParts[0]);
+  const conversationId = explicitType ? colonParts.slice(1).join(":") : rawConversationId;
+  const threadId =
+    params.threadId == null ? parsed.threadId : String(params.threadId).trim() || parsed.threadId;
+  return {
+    platform,
+    conversationId,
+    conversationType:
+      explicitType ?? parsed.conversationType ?? params.account.defaultConversationType,
+    ...(threadId ? { threadId } : {}),
+  };
+}
+
+export function resolveBrokerOutboundTo(params: {
+  to?: string | null;
+  account: ResolvedChannelBrokerAccount;
+}): string | undefined {
+  const explicit = params.to?.trim();
+  if (explicit) {
+    return normalizeBrokerTarget(explicit);
+  }
+  return params.account.defaultTo;
+}

--- a/extensions/channel-broker/src/types.ts
+++ b/extensions/channel-broker/src/types.ts
@@ -1,4 +1,5 @@
 import type { BrokerPlatformCapabilities } from "openclaw/plugin-sdk/channel-broker";
+import type { SecretInput } from "openclaw/plugin-sdk/secret-input";
 
 export type ChannelBrokerPlatformCapabilityConfig = Omit<BrokerPlatformCapabilities, "platform"> & {
   platform?: string;
@@ -8,8 +9,8 @@ export type ChannelBrokerProviderConfig = {
   name?: string;
   enabled?: boolean;
   baseUrl?: string;
-  outboundToken?: string;
-  signingSecret?: string;
+  outboundToken?: SecretInput;
+  signingSecret?: SecretInput;
   accountId?: string;
   platforms?: string[];
   platformAliases?: Record<string, string>;
@@ -33,6 +34,13 @@ export type CoreConfig = {
   };
   session?: {
     store?: string;
+  };
+  secrets?: {
+    defaults?: {
+      env?: string;
+      file?: string;
+      exec?: string;
+    };
   };
 };
 

--- a/extensions/channel-broker/src/types.ts
+++ b/extensions/channel-broker/src/types.ts
@@ -1,0 +1,56 @@
+import type { BrokerPlatformCapabilities } from "openclaw/plugin-sdk/channel-broker";
+
+export type ChannelBrokerPlatformCapabilityConfig = Omit<BrokerPlatformCapabilities, "platform"> & {
+  platform?: string;
+};
+
+export type ChannelBrokerProviderConfig = {
+  name?: string;
+  enabled?: boolean;
+  baseUrl?: string;
+  outboundToken?: string;
+  signingSecret?: string;
+  accountId?: string;
+  platforms?: string[];
+  platformAliases?: Record<string, string>;
+  defaultPlatform?: string;
+  defaultConversationType?: "direct" | "group" | "channel" | "thread";
+  defaultTo?: string;
+  allowFrom?: Array<string | number>;
+  capabilities?: Record<string, ChannelBrokerPlatformCapabilityConfig>;
+};
+
+export type ChannelBrokerConfig = ChannelBrokerProviderConfig & {
+  accounts?: Record<string, ChannelBrokerProviderConfig>;
+  providers?: Record<string, ChannelBrokerProviderConfig>;
+  defaultAccount?: string;
+  defaultProviderId?: string;
+};
+
+export type CoreConfig = {
+  channels?: {
+    "channel-broker"?: ChannelBrokerConfig;
+  };
+  session?: {
+    store?: string;
+  };
+};
+
+export type ResolvedChannelBrokerAccount = {
+  accountId: string;
+  providerId: string;
+  enabled: boolean;
+  configured: boolean;
+  name?: string;
+  baseUrl: string | null;
+  outboundToken: string | null;
+  signingSecret: string | null;
+  platforms: string[];
+  platformAliases: Record<string, string>;
+  defaultPlatform: string | null;
+  defaultConversationType: "direct" | "group" | "channel" | "thread";
+  defaultTo?: string;
+  allowFrom: Array<string | number>;
+  capabilities: Record<string, BrokerPlatformCapabilities>;
+  config: ChannelBrokerProviderConfig;
+};

--- a/extensions/channel-broker/tsconfig.json
+++ b/extensions/channel-broker/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "!dist/extensions/diagnostics-otel/**",
     "!dist/extensions/diagnostics-prometheus/**",
     "!dist/extensions/diffs/**",
+    "!dist/extensions/channel-broker/**",
     "!dist/extensions/discord/**",
     "!dist/extensions/feishu/**",
     "!dist/extensions/google-meet/**",
@@ -178,6 +179,10 @@
     "./plugin-sdk/channel-setup": {
       "types": "./dist/plugin-sdk/channel-setup.d.ts",
       "default": "./dist/plugin-sdk/channel-setup.js"
+    },
+    "./plugin-sdk/channel-broker": {
+      "types": "./dist/plugin-sdk/channel-broker.d.ts",
+      "default": "./dist/plugin-sdk/channel-broker.js"
     },
     "./plugin-sdk/channel-streaming": {
       "types": "./dist/plugin-sdk/channel-streaming.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,6 +456,19 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/channel-broker:
+    dependencies:
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/chutes:
     devDependencies:
       '@openclaw/plugin-sdk':

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -18,6 +18,7 @@
   "setup-adapter-runtime",
   "setup-runtime",
   "channel-setup",
+  "channel-broker",
   "channel-streaming",
   "setup-tools",
   "approval-auth-runtime",

--- a/src/infra/outbound/channel-target-prefix.test.ts
+++ b/src/infra/outbound/channel-target-prefix.test.ts
@@ -1,5 +1,18 @@
-import { describe, expect, it } from "vitest";
-import { stripTargetTopicSuffix } from "./channel-target-prefix.js";
+import { beforeEach, describe, expect, it } from "vitest";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
+import {
+  resolveTargetPrefixedChannel,
+  stripTargetTopicSuffix,
+  validateTargetProviderPrefix,
+} from "./channel-target-prefix.js";
+
+beforeEach(() => {
+  resetPluginRuntimeStateForTest();
+});
 
 describe("stripTargetTopicSuffix", () => {
   it("strips explicit topic suffixes", () => {
@@ -15,5 +28,57 @@ describe("stripTargetTopicSuffix", () => {
   it("keeps generic colon targets intact", () => {
     expect(stripTargetTopicSuffix("room:123")).toBe("room:123");
     expect(stripTargetTopicSuffix("room-a:child")).toBe("room-a:child");
+  });
+});
+
+describe("resolveTargetPrefixedChannel", () => {
+  it("keeps native channel prefixes owned by native plugins when broker aliases overlap", () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "channel-broker",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({ id: "channel-broker" }),
+            messaging: { targetPrefixes: ["broker", "telegram", "discord", "slack"] },
+          },
+        },
+        {
+          pluginId: "telegram",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({ id: "telegram" }),
+            messaging: { targetPrefixes: ["telegram"] },
+          },
+        },
+      ]),
+    );
+
+    expect(resolveTargetPrefixedChannel("telegram:123")).toBe("telegram");
+    expect(validateTargetProviderPrefix({ channel: "telegram", to: "telegram:123" })).toBe(
+      undefined,
+    );
+    expect(
+      validateTargetProviderPrefix({ channel: "channel-broker", to: "telegram:123" }),
+    ).toMatchInlineSnapshot(
+      `[Error: Target prefix "telegram:" belongs to telegram, not channel-broker.]`,
+    );
+  });
+
+  it("lets broker aliases own platform prefixes when no native plugin declares them", () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "channel-broker",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({ id: "channel-broker" }),
+            messaging: { targetPrefixes: ["broker", "telegram"] },
+          },
+        },
+      ]),
+    );
+
+    expect(resolveTargetPrefixedChannel("telegram:123")).toBe("channel-broker");
   });
 });

--- a/src/infra/outbound/channel-target-prefix.ts
+++ b/src/infra/outbound/channel-target-prefix.ts
@@ -58,6 +58,7 @@ function resolvePluginTargetPrefix(prefix: string): string | undefined {
     return undefined;
   }
   const registry = getActivePluginChannelRegistryFromState();
+  const matches: string[] = [];
   for (const entry of registry?.channels ?? []) {
     const plugin = entry.plugin;
     const channelId = normalizeOptionalLowercaseString(plugin.id);
@@ -68,10 +69,10 @@ function resolvePluginTargetPrefix(prefix: string): string | undefined {
         (candidate) => normalizeOptionalLowercaseString(candidate) === normalizedPrefix,
       )
     ) {
-      return channelId;
+      matches.push(channelId);
     }
   }
-  return undefined;
+  return matches.find((channelId) => channelId !== "channel-broker") ?? matches[0];
 }
 
 function resolveChannelTargetProviderPrefix(

--- a/src/plugin-sdk/channel-broker.test.ts
+++ b/src/plugin-sdk/channel-broker.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  BROKER_PROTOCOL_VERSION,
+  buildBrokerConversationTarget,
+  createBrokerOutboundRequest,
+  createBrokerReceipt,
+  normalizeBrokerPlatformId,
+  parseBrokerConversationTarget,
+} from "./channel-broker.js";
+
+describe("channel-broker SDK", () => {
+  it("normalizes provider platform ids for capability and routing keys", () => {
+    expect(normalizeBrokerPlatformId(" Telegram ")).toBe("telegram");
+    expect(normalizeBrokerPlatformId("Google Chat")).toBe("google-chat");
+
+    expect(() => normalizeBrokerPlatformId("")).toThrow("broker platform id is required");
+    expect(() => normalizeBrokerPlatformId("../telegram")).toThrow("invalid broker platform id");
+  });
+
+  it("round-trips broker conversation targets without losing thread scope", () => {
+    const target = buildBrokerConversationTarget({
+      platform: "Telegram",
+      conversationId: "chat 123",
+      threadId: "topic/a",
+    });
+
+    expect(target).toBe("telegram:chat%20123?threadId=topic%2Fa");
+    expect(parseBrokerConversationTarget(target)).toEqual({
+      platform: "telegram",
+      conversationId: "chat 123",
+      threadId: "topic/a",
+    });
+  });
+
+  it("creates a versioned outbound request for provider-owned delivery", () => {
+    const request = createBrokerOutboundRequest({
+      requestId: "send-1",
+      providerId: "acme",
+      platform: "Discord",
+      accountId: "workspace-a",
+      conversation: {
+        id: "channel-1",
+        type: "channel",
+        threadId: "thread-1",
+      },
+      mode: "final",
+      payloads: [{ text: "hello", channelData: { discord: { suppressEmbeds: true } } }],
+      relation: { replyToId: "native-parent", silent: false },
+      requirements: { text: true, thread: true, replyTo: true },
+    });
+
+    expect(request).toEqual({
+      version: BROKER_PROTOCOL_VERSION,
+      requestId: "send-1",
+      providerId: "acme",
+      platform: "discord",
+      accountId: "workspace-a",
+      conversation: {
+        id: "channel-1",
+        type: "channel",
+        threadId: "thread-1",
+      },
+      mode: "final",
+      payloads: [{ text: "hello", channelData: { discord: { suppressEmbeds: true } } }],
+      relation: { replyToId: "native-parent", silent: false },
+      requirements: { text: true, thread: true, replyTo: true },
+    });
+  });
+
+  it("creates versioned receipts with normalized platform ids", () => {
+    expect(
+      createBrokerReceipt({
+        requestId: "send-1",
+        providerId: "acme",
+        platform: "Slack",
+        status: "sent",
+        messageIds: ["1716500000.000100"],
+        editToken: "1716500000.000100",
+      }),
+    ).toEqual({
+      version: BROKER_PROTOCOL_VERSION,
+      requestId: "send-1",
+      providerId: "acme",
+      platform: "slack",
+      status: "sent",
+      messageIds: ["1716500000.000100"],
+      editToken: "1716500000.000100",
+    });
+  });
+});

--- a/src/plugin-sdk/channel-broker.test.ts
+++ b/src/plugin-sdk/channel-broker.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it } from "vitest";
 import {
   BROKER_PROTOCOL_VERSION,
+  brokerPlatformSupports,
+  buildBrokerInboundDedupeKey,
   buildBrokerConversationTarget,
+  createBrokerInboundEvent,
   createBrokerOutboundRequest,
   createBrokerReceipt,
   normalizeBrokerPlatformId,
+  normalizeBrokerInboundEvent,
+  resolveBrokerPlatformCapabilities,
   parseBrokerConversationTarget,
 } from "./channel-broker.js";
+import type { BrokerProviderCapabilities } from "./channel-broker.js";
 
 describe("channel-broker SDK", () => {
   it("normalizes provider platform ids for capability and routing keys", () => {
@@ -65,6 +71,173 @@ describe("channel-broker SDK", () => {
       relation: { replyToId: "native-parent", silent: false },
       requirements: { text: true, thread: true, replyTo: true },
     });
+  });
+
+  it("normalizes inbound events without losing provider-native metadata", () => {
+    const event = createBrokerInboundEvent({
+      eventId: " evt-1 ",
+      providerId: " acme ",
+      platform: "Telegram",
+      accountId: " bot-main ",
+      conversation: {
+        id: " -100123 ",
+        type: "thread",
+        parentId: " -100123 ",
+        threadId: " 77 ",
+        title: " Ops ",
+      },
+      sender: {
+        id: " user-1 ",
+        handle: " lume ",
+        displayName: " Lume ",
+        raw: { native: "sender" },
+      },
+      message: {
+        id: " msg-1 ",
+        text: " hello ",
+        attachments: [
+          {
+            id: " file-1 ",
+            mediaType: " image ",
+            mimeType: " image/png ",
+            url: " https://cdn.example.test/file.png ",
+          },
+        ],
+        nativeIds: { " telegram.message_id ": " 123 ", empty: " " },
+        rawRef: " update-1 ",
+        raw: { update_id: 99 },
+      },
+      capabilities: {
+        providerId: " acme ",
+        delivery: { text: true },
+        platforms: [{ platform: "Telegram", delivery: { thread: true } }],
+      },
+      raw: { update_id: 99 },
+    });
+
+    expect(event).toMatchObject({
+      version: BROKER_PROTOCOL_VERSION,
+      eventId: "evt-1",
+      providerId: "acme",
+      platform: "telegram",
+      accountId: "bot-main",
+      conversation: {
+        id: "-100123",
+        type: "thread",
+        parentId: "-100123",
+        threadId: "77",
+        title: "Ops",
+      },
+      sender: {
+        id: "user-1",
+        handle: "lume",
+        displayName: "Lume",
+        raw: { native: "sender" },
+      },
+      message: {
+        id: "msg-1",
+        text: "hello",
+        attachments: [
+          {
+            id: "file-1",
+            mediaType: "image",
+            mimeType: "image/png",
+            url: "https://cdn.example.test/file.png",
+          },
+        ],
+        nativeIds: { "telegram.message_id": "123" },
+        rawRef: "update-1",
+        raw: { update_id: 99 },
+      },
+      capabilities: {
+        providerId: "acme",
+        delivery: { text: true },
+        platforms: [{ platform: "telegram", delivery: { thread: true } }],
+      },
+      raw: { update_id: 99 },
+    });
+    expect(buildBrokerInboundDedupeKey(event)).toBe("acme:bot-main:telegram:evt-1");
+  });
+
+  it("rejects malformed inbound events before durable receive dispatch", () => {
+    expect(() =>
+      normalizeBrokerInboundEvent({
+        version: 2,
+        eventId: "evt-1",
+        providerId: "acme",
+        platform: "telegram",
+        conversation: { id: "chat-1", type: "channel" },
+        sender: { id: "user-1" },
+        message: { id: "msg-1" },
+      } as never),
+    ).toThrow("unsupported broker inbound event version: 2");
+    expect(() =>
+      createBrokerInboundEvent({
+        eventId: " ",
+        providerId: "acme",
+        platform: "telegram",
+        conversation: { id: "chat-1", type: "channel" },
+        sender: { id: "user-1" },
+        message: { id: "msg-1" },
+      }),
+    ).toThrow("broker inbound event id is required");
+  });
+
+  it("merges provider-wide and platform-specific capability badges", () => {
+    const capabilities: BrokerProviderCapabilities = {
+      providerId: "acme",
+      delivery: {
+        text: true,
+        thread: true,
+      },
+      live: {
+        draftPreview: true,
+      },
+      receive: {
+        webhook: true,
+      },
+      platforms: [
+        {
+          platform: "Slack",
+          delivery: { replyTo: true },
+          live: { progressUpdates: true, previewFinalization: true },
+          receive: { ackAfterDurableSend: true },
+          native: { enterpriseGrid: true },
+        },
+        {
+          platform: "Signal",
+          delivery: { text: true, thread: false },
+          native: { deviceBound: true },
+        },
+      ],
+    };
+
+    expect(resolveBrokerPlatformCapabilities({ capabilities, platform: "slack" })).toEqual({
+      platform: "slack",
+      delivery: { text: true, thread: true, replyTo: true },
+      live: { draftPreview: true, progressUpdates: true, previewFinalization: true },
+      receive: { webhook: true, ackAfterDurableSend: true },
+      native: { enterpriseGrid: true },
+    });
+    expect(
+      brokerPlatformSupports({
+        capabilities,
+        platform: "slack",
+        requirements: {
+          delivery: { text: true, thread: true, replyTo: true },
+          live: { previewFinalization: true },
+          receive: { webhook: true },
+          native: { enterpriseGrid: true },
+        },
+      }),
+    ).toBe(true);
+    expect(
+      brokerPlatformSupports({
+        capabilities,
+        platform: "signal",
+        requirements: { delivery: { thread: true } },
+      }),
+    ).toBe(false);
   });
 
   it("creates versioned receipts with normalized platform ids", () => {

--- a/src/plugin-sdk/channel-broker.ts
+++ b/src/plugin-sdk/channel-broker.ts
@@ -1,0 +1,231 @@
+export const BROKER_PROTOCOL_VERSION = 1 as const;
+export const CHANNEL_BROKER_CHANNEL_ID = "channel-broker" as const;
+
+export type BrokerProtocolVersion = typeof BROKER_PROTOCOL_VERSION;
+
+export type BrokerConversationType = "direct" | "group" | "channel" | "thread";
+
+export type BrokerOutboundMode =
+  | "final"
+  | "preview_update"
+  | "finalize_preview"
+  | "delete_preview"
+  | "typing"
+  | "reaction";
+
+export type BrokerReceiptStatus = "sent" | "suppressed" | "failed" | "retryable" | "unsupported";
+
+export type BrokerDeliveryRequirements = Partial<
+  Record<
+    | "text"
+    | "media"
+    | "payload"
+    | "silent"
+    | "replyTo"
+    | "thread"
+    | "nativeQuote"
+    | "previewFinalization"
+    | "progressUpdates"
+    | "nativeStreaming"
+    | "reconcileUnknownSend",
+    boolean
+  >
+>;
+
+export type BrokerConversationRef = {
+  id: string;
+  type: BrokerConversationType;
+  parentId?: string;
+  threadId?: string;
+  title?: string;
+};
+
+export type BrokerMessageActor = {
+  id: string;
+  displayName?: string;
+  handle?: string;
+  isBot?: boolean;
+  raw?: unknown;
+};
+
+export type BrokerMessageAttachment = {
+  id?: string;
+  mediaType?: string;
+  mimeType?: string;
+  name?: string;
+  url?: string;
+  contentBase64?: string;
+  sizeBytes?: number;
+  raw?: unknown;
+};
+
+export type BrokerInboundEventV1 = {
+  version: BrokerProtocolVersion;
+  eventId: string;
+  providerId: string;
+  platform: string;
+  accountId?: string;
+  conversation: BrokerConversationRef;
+  sender: BrokerMessageActor;
+  message: {
+    id: string;
+    text?: string;
+    attachments?: BrokerMessageAttachment[];
+    timestamp?: string;
+    replyToId?: string;
+    nativeIds?: Record<string, string>;
+    rawRef?: string;
+    raw?: unknown;
+  };
+  capabilities?: BrokerProviderCapabilities;
+  raw?: unknown;
+};
+
+export type BrokerOutboundPayload = {
+  text?: string;
+  attachments?: BrokerMessageAttachment[];
+  channelData?: Record<string, unknown>;
+};
+
+export type BrokerOutboundRequestV1 = {
+  version: BrokerProtocolVersion;
+  requestId: string;
+  providerId: string;
+  platform: string;
+  accountId?: string;
+  conversation: BrokerConversationRef;
+  mode: BrokerOutboundMode;
+  payloads: BrokerOutboundPayload[];
+  relation?: {
+    replyToId?: string;
+    silent?: boolean;
+    nativeQuoteId?: string;
+  };
+  requirements?: BrokerDeliveryRequirements;
+  raw?: unknown;
+};
+
+export type BrokerReceiptV1 = {
+  version: BrokerProtocolVersion;
+  requestId: string;
+  providerId: string;
+  platform: string;
+  status: BrokerReceiptStatus;
+  messageIds: string[];
+  timestamp?: number;
+  editToken?: string;
+  deleteToken?: string;
+  retryAfterMs?: number;
+  error?: {
+    code?: string;
+    message: string;
+    retryable?: boolean;
+  };
+  native?: unknown;
+  raw?: unknown;
+};
+
+export type BrokerPlatformCapabilities = {
+  platform: string;
+  delivery?: BrokerDeliveryRequirements;
+  live?: Partial<Record<"draftPreview" | "previewFinalization" | "progressUpdates", boolean>>;
+  receive?: Partial<Record<"webhook" | "polling" | "ackAfterDurableSend" | "manualAck", boolean>>;
+  native?: Record<string, boolean>;
+};
+
+export type BrokerProviderCapabilities = {
+  providerId?: string;
+  platforms: BrokerPlatformCapabilities[];
+  delivery?: BrokerDeliveryRequirements;
+  live?: Partial<Record<"draftPreview" | "previewFinalization" | "progressUpdates", boolean>>;
+  receive?: Partial<Record<"webhook" | "polling" | "ackAfterDurableSend" | "manualAck", boolean>>;
+};
+
+export type BrokerProviderHealth = {
+  providerId: string;
+  state: "ok" | "degraded" | "down" | "unknown";
+  checkedAt: string;
+  platforms?: Array<{
+    platform: string;
+    state: "ok" | "degraded" | "down" | "unknown";
+    message?: string;
+  }>;
+  message?: string;
+  details?: Record<string, unknown>;
+};
+
+export type BrokerConversationTarget = {
+  platform: string;
+  conversationId: string;
+  conversationType?: BrokerConversationType;
+  threadId?: string;
+};
+
+export function normalizeBrokerPlatformId(value: string): string {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[\s_]+/gu, "-");
+  if (!normalized) {
+    throw new Error("broker platform id is required");
+  }
+  if (!/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/u.test(normalized)) {
+    throw new Error(`invalid broker platform id: ${value}`);
+  }
+  return normalized;
+}
+
+export function buildBrokerConversationTarget(target: BrokerConversationTarget): string {
+  const platform = normalizeBrokerPlatformId(target.platform);
+  const conversationId = target.conversationId.trim();
+  if (!conversationId) {
+    throw new Error("broker conversation id is required");
+  }
+  const base = `${platform}:${encodeURIComponent(conversationId)}`;
+  const threadId = target.threadId?.trim();
+  if (!threadId) {
+    return base;
+  }
+  const search = new URLSearchParams({ threadId });
+  return `${base}?${search.toString()}`;
+}
+
+export function parseBrokerConversationTarget(value: string): BrokerConversationTarget {
+  const [head, query = ""] = value.trim().split("?", 2);
+  const separatorIndex = head.indexOf(":");
+  if (separatorIndex <= 0) {
+    throw new Error(`invalid broker conversation target: ${value}`);
+  }
+  const platform = normalizeBrokerPlatformId(head.slice(0, separatorIndex));
+  const encodedConversationId = head.slice(separatorIndex + 1);
+  if (!encodedConversationId) {
+    throw new Error(`invalid broker conversation target: ${value}`);
+  }
+  const conversationId = decodeURIComponent(encodedConversationId);
+  const threadId = new URLSearchParams(query).get("threadId") ?? undefined;
+  return {
+    platform,
+    conversationId,
+    ...(threadId ? { threadId } : {}),
+  };
+}
+
+export function createBrokerOutboundRequest(
+  request: Omit<BrokerOutboundRequestV1, "version" | "platform"> & { platform: string },
+): BrokerOutboundRequestV1 {
+  return {
+    ...request,
+    version: BROKER_PROTOCOL_VERSION,
+    platform: normalizeBrokerPlatformId(request.platform),
+  };
+}
+
+export function createBrokerReceipt(
+  receipt: Omit<BrokerReceiptV1, "version" | "platform"> & { platform: string },
+): BrokerReceiptV1 {
+  return {
+    ...receipt,
+    version: BROKER_PROTOCOL_VERSION,
+    platform: normalizeBrokerPlatformId(receipt.platform),
+  };
+}

--- a/src/plugin-sdk/channel-broker.ts
+++ b/src/plugin-sdk/channel-broker.ts
@@ -141,6 +141,13 @@ export type BrokerProviderCapabilities = {
   receive?: Partial<Record<"webhook" | "polling" | "ackAfterDurableSend" | "manualAck", boolean>>;
 };
 
+export type BrokerCapabilityRequirements = {
+  delivery?: BrokerDeliveryRequirements;
+  live?: Partial<Record<"draftPreview" | "previewFinalization" | "progressUpdates", boolean>>;
+  receive?: Partial<Record<"webhook" | "polling" | "ackAfterDurableSend" | "manualAck", boolean>>;
+  native?: Record<string, boolean>;
+};
+
 export type BrokerProviderHealth = {
   providerId: string;
   state: "ok" | "degraded" | "down" | "unknown";
@@ -208,6 +215,223 @@ export function parseBrokerConversationTarget(value: string): BrokerConversation
     conversationId,
     ...(threadId ? { threadId } : {}),
   };
+}
+
+function requireBrokerString(value: string | undefined, field: string): string {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    throw new Error(`${field} is required`);
+  }
+  return trimmed;
+}
+
+function normalizeOptionalBrokerString(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+function normalizeBrokerConversationType(value: BrokerConversationType): BrokerConversationType {
+  if (value === "direct" || value === "group" || value === "channel" || value === "thread") {
+    return value;
+  }
+  throw new Error(`invalid broker conversation type: ${String(value)}`);
+}
+
+function normalizeBrokerAttachments(
+  attachments: BrokerMessageAttachment[] | undefined,
+): BrokerMessageAttachment[] | undefined {
+  if (!attachments?.length) {
+    return undefined;
+  }
+  return attachments.map((attachment) => ({
+    ...(normalizeOptionalBrokerString(attachment.id) ? { id: attachment.id?.trim() } : {}),
+    ...(normalizeOptionalBrokerString(attachment.mediaType)
+      ? { mediaType: attachment.mediaType?.trim() }
+      : {}),
+    ...(normalizeOptionalBrokerString(attachment.mimeType)
+      ? { mimeType: attachment.mimeType?.trim() }
+      : {}),
+    ...(normalizeOptionalBrokerString(attachment.name) ? { name: attachment.name?.trim() } : {}),
+    ...(normalizeOptionalBrokerString(attachment.url) ? { url: attachment.url?.trim() } : {}),
+    ...(attachment.contentBase64 !== undefined ? { contentBase64: attachment.contentBase64 } : {}),
+    ...(attachment.sizeBytes !== undefined ? { sizeBytes: attachment.sizeBytes } : {}),
+    ...(attachment.raw !== undefined ? { raw: attachment.raw } : {}),
+  }));
+}
+
+function normalizeNativeIds(
+  nativeIds: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  const normalized: Record<string, string> = {};
+  for (const [key, value] of Object.entries(nativeIds ?? {})) {
+    const normalizedKey = key.trim();
+    const normalizedValue = value.trim();
+    if (normalizedKey && normalizedValue) {
+      normalized[normalizedKey] = normalizedValue;
+    }
+  }
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function normalizeBrokerPlatformCapabilities(
+  capabilities: BrokerPlatformCapabilities,
+): BrokerPlatformCapabilities {
+  return {
+    platform: normalizeBrokerPlatformId(capabilities.platform),
+    ...(capabilities.delivery ? { delivery: { ...capabilities.delivery } } : {}),
+    ...(capabilities.live ? { live: { ...capabilities.live } } : {}),
+    ...(capabilities.receive ? { receive: { ...capabilities.receive } } : {}),
+    ...(capabilities.native ? { native: { ...capabilities.native } } : {}),
+  };
+}
+
+export function normalizeBrokerProviderCapabilities(
+  capabilities: BrokerProviderCapabilities,
+): BrokerProviderCapabilities {
+  return {
+    ...(normalizeOptionalBrokerString(capabilities.providerId)
+      ? { providerId: capabilities.providerId?.trim() }
+      : {}),
+    platforms: capabilities.platforms.map(normalizeBrokerPlatformCapabilities),
+    ...(capabilities.delivery ? { delivery: { ...capabilities.delivery } } : {}),
+    ...(capabilities.live ? { live: { ...capabilities.live } } : {}),
+    ...(capabilities.receive ? { receive: { ...capabilities.receive } } : {}),
+  };
+}
+
+export function createBrokerInboundEvent(
+  event: Omit<BrokerInboundEventV1, "version" | "platform"> & { platform: string },
+): BrokerInboundEventV1 {
+  return normalizeBrokerInboundEvent({
+    ...event,
+    version: BROKER_PROTOCOL_VERSION,
+  });
+}
+
+export function normalizeBrokerInboundEvent(event: BrokerInboundEventV1): BrokerInboundEventV1 {
+  if (event.version !== BROKER_PROTOCOL_VERSION) {
+    throw new Error(`unsupported broker inbound event version: ${String(event.version)}`);
+  }
+  const attachments = normalizeBrokerAttachments(event.message.attachments);
+  const nativeIds = normalizeNativeIds(event.message.nativeIds);
+  return {
+    version: BROKER_PROTOCOL_VERSION,
+    eventId: requireBrokerString(event.eventId, "broker inbound event id"),
+    providerId: requireBrokerString(event.providerId, "broker provider id"),
+    platform: normalizeBrokerPlatformId(event.platform),
+    ...(normalizeOptionalBrokerString(event.accountId)
+      ? { accountId: event.accountId?.trim() }
+      : {}),
+    conversation: {
+      id: requireBrokerString(event.conversation.id, "broker conversation id"),
+      type: normalizeBrokerConversationType(event.conversation.type),
+      ...(normalizeOptionalBrokerString(event.conversation.parentId)
+        ? { parentId: event.conversation.parentId?.trim() }
+        : {}),
+      ...(normalizeOptionalBrokerString(event.conversation.threadId)
+        ? { threadId: event.conversation.threadId?.trim() }
+        : {}),
+      ...(normalizeOptionalBrokerString(event.conversation.title)
+        ? { title: event.conversation.title?.trim() }
+        : {}),
+    },
+    sender: {
+      id: requireBrokerString(event.sender.id, "broker sender id"),
+      ...(normalizeOptionalBrokerString(event.sender.displayName)
+        ? { displayName: event.sender.displayName?.trim() }
+        : {}),
+      ...(normalizeOptionalBrokerString(event.sender.handle)
+        ? { handle: event.sender.handle?.trim() }
+        : {}),
+      ...(event.sender.isBot !== undefined ? { isBot: event.sender.isBot } : {}),
+      ...(event.sender.raw !== undefined ? { raw: event.sender.raw } : {}),
+    },
+    message: {
+      id: requireBrokerString(event.message.id, "broker message id"),
+      ...(normalizeOptionalBrokerString(event.message.text)
+        ? { text: event.message.text?.trim() }
+        : {}),
+      ...(attachments ? { attachments } : {}),
+      ...(normalizeOptionalBrokerString(event.message.timestamp)
+        ? { timestamp: event.message.timestamp?.trim() }
+        : {}),
+      ...(normalizeOptionalBrokerString(event.message.replyToId)
+        ? { replyToId: event.message.replyToId?.trim() }
+        : {}),
+      ...(nativeIds ? { nativeIds } : {}),
+      ...(normalizeOptionalBrokerString(event.message.rawRef)
+        ? { rawRef: event.message.rawRef?.trim() }
+        : {}),
+      ...(event.message.raw !== undefined ? { raw: event.message.raw } : {}),
+    },
+    ...(event.capabilities
+      ? { capabilities: normalizeBrokerProviderCapabilities(event.capabilities) }
+      : {}),
+    ...(event.raw !== undefined ? { raw: event.raw } : {}),
+  };
+}
+
+export function buildBrokerInboundDedupeKey(event: BrokerInboundEventV1): string {
+  const normalized = normalizeBrokerInboundEvent(event);
+  return [
+    normalized.providerId,
+    normalized.accountId ?? "",
+    normalized.platform,
+    normalized.eventId,
+  ]
+    .map((part) => encodeURIComponent(part))
+    .join(":");
+}
+
+export function resolveBrokerPlatformCapabilities(params: {
+  capabilities: BrokerProviderCapabilities;
+  platform: string;
+}): BrokerPlatformCapabilities | undefined {
+  const normalized = normalizeBrokerProviderCapabilities(params.capabilities);
+  const platform = normalizeBrokerPlatformId(params.platform);
+  const platformCapabilities = normalized.platforms.find((entry) => entry.platform === platform);
+  if (!platformCapabilities) {
+    return undefined;
+  }
+  return {
+    platform,
+    delivery: Object.assign({}, normalized.delivery, platformCapabilities.delivery),
+    live: Object.assign({}, normalized.live, platformCapabilities.live),
+    receive: Object.assign({}, normalized.receive, platformCapabilities.receive),
+    ...(platformCapabilities.native ? { native: { ...platformCapabilities.native } } : {}),
+  };
+}
+
+function supportsRequiredFlags(
+  supported: Record<string, boolean> | undefined,
+  required: Record<string, boolean> | undefined,
+): boolean {
+  for (const [key, value] of Object.entries(required ?? {})) {
+    if (value === true && supported?.[key] !== true) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function brokerPlatformSupports(params: {
+  capabilities: BrokerProviderCapabilities;
+  platform: string;
+  requirements: BrokerCapabilityRequirements;
+}): boolean {
+  const platformCapabilities = resolveBrokerPlatformCapabilities({
+    capabilities: params.capabilities,
+    platform: params.platform,
+  });
+  if (!platformCapabilities) {
+    return false;
+  }
+  return (
+    supportsRequiredFlags(platformCapabilities.delivery, params.requirements.delivery) &&
+    supportsRequiredFlags(platformCapabilities.live, params.requirements.live) &&
+    supportsRequiredFlags(platformCapabilities.receive, params.requirements.receive) &&
+    supportsRequiredFlags(platformCapabilities.native, params.requirements.native)
+  );
 }
 
 export function createBrokerOutboundRequest(

--- a/src/plugin-sdk/entrypoints.ts
+++ b/src/plugin-sdk/entrypoints.ts
@@ -56,6 +56,7 @@ export const supportedBundledFacadeSdkEntrypoints = [
 // Plugin-owned surfaces that are intentionally public and documented for third-party plugins.
 export const publicPluginOwnedSdkEntrypoints = [
   "browser-config",
+  "channel-broker",
   "image-generation-core",
   "memory-core",
   "memory-core-host-engine-embeddings",

--- a/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
+++ b/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
@@ -132,6 +132,17 @@ const RUNTIME_API_EXPORT_GUARDS: Record<string, readonly string[]> = {
     'export { DEFAULT_WEBHOOK_MAX_BODY_BYTES } from "openclaw/plugin-sdk/webhook-ingress";',
     'export { setMSTeamsRuntime } from "./src/runtime.js";',
   ],
+  [bundledPluginFile({
+    rootDir: ROOT_DIR,
+    pluginId: "channel-broker",
+    relativePath: "runtime-api.ts",
+  })]: [
+    'export { buildChannelConfigSchema, buildChannelOutboundSessionRoute, type ChannelPlugin, createChatChannelPlugin, type OpenClawConfig, type PluginRuntime } from "openclaw/plugin-sdk/channel-core";',
+    'export { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";',
+    'export { getChatChannelMeta } from "openclaw/plugin-sdk/channel-plugin-common";',
+    'export { createMessageReceiptFromOutboundResults, defineChannelMessageAdapter } from "openclaw/plugin-sdk/channel-message";',
+    'export { createComputedAccountStatusAdapter, createDefaultChannelRuntimeState } from "openclaw/plugin-sdk/status-helpers";',
+  ],
   [bundledPluginFile({ rootDir: ROOT_DIR, pluginId: "irc", relativePath: "runtime-api.ts" })]: [
     'export { setIrcRuntime } from "./src/runtime.js";',
   ],

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1317,6 +1317,7 @@ describe("scripts/test-projects full-suite sharding", () => {
       "test/vitest/vitest.auto-reply-top-level.config.ts",
       "test/vitest/vitest.auto-reply-reply.config.ts",
       "test/vitest/vitest.extension-acpx.config.ts",
+      "test/vitest/vitest.extension-channel-broker.config.ts",
       "test/vitest/vitest.extension-diffs.config.ts",
       "test/vitest/vitest.extension-discord.config.ts",
       "test/vitest/vitest.extension-feishu.config.ts",

--- a/test/vitest/vitest.config.ts
+++ b/test/vitest/vitest.config.ts
@@ -55,6 +55,7 @@ export const rootVitestProjects = [
   "test/vitest/vitest.wizard.config.ts",
   "test/vitest/vitest.channels.config.ts",
   "test/vitest/vitest.extension-acpx.config.ts",
+  "test/vitest/vitest.extension-channel-broker.config.ts",
   "test/vitest/vitest.extension-diffs.config.ts",
   "test/vitest/vitest.extension-discord.config.ts",
   "test/vitest/vitest.extension-feishu.config.ts",

--- a/test/vitest/vitest.extension-channel-broker.config.ts
+++ b/test/vitest/vitest.extension-channel-broker.config.ts
@@ -1,0 +1,9 @@
+import { createSingleChannelExtensionVitestConfig } from "./vitest.extension-channel-single-config.ts";
+
+export function createExtensionChannelBrokerVitestConfig(
+  env: Record<string, string | undefined> = process.env,
+) {
+  return createSingleChannelExtensionVitestConfig("channel-broker", env);
+}
+
+export default createExtensionChannelBrokerVitestConfig();

--- a/test/vitest/vitest.extension-channel-split-paths.mjs
+++ b/test/vitest/vitest.extension-channel-split-paths.mjs
@@ -2,6 +2,11 @@ import { bundledPluginRoot } from "../../scripts/lib/bundled-plugin-paths.mjs";
 
 export const splitChannelExtensionShardSpecs = [
   {
+    id: "channel-broker",
+    kind: "extensionChannelBroker",
+    config: "test/vitest/vitest.extension-channel-broker.config.ts",
+  },
+  {
     id: "discord",
     kind: "extensionDiscord",
     config: "test/vitest/vitest.extension-discord.config.ts",

--- a/test/vitest/vitest.test-shards.mjs
+++ b/test/vitest/vitest.test-shards.mjs
@@ -112,6 +112,7 @@ export const fullSuiteVitestShards = [
     name: "extensions",
     projects: [
       "test/vitest/vitest.extension-acpx.config.ts",
+      "test/vitest/vitest.extension-channel-broker.config.ts",
       "test/vitest/vitest.extension-diffs.config.ts",
       "test/vitest/vitest.extension-discord.config.ts",
       "test/vitest/vitest.extension-feishu.config.ts",


### PR DESCRIPTION
## Summary

- Adds the Phase 2B Telegram broker routing proof on top of #86133 and #86096.
- Normalizes Telegram topic shorthand in the broker plugin, including `broker:telegram:<chat>:topic:<id>` and numeric `<chat>:<topic>` targets.
- Canonicalizes outbound broker session routes to `telegram:<chat>?threadId=<id>` so topic routing is stable without importing native Telegram internals.

## Rollout Context

Closes #86110
Related #86108
Related #86105
Stacked on #86133
Stacked on #86096

Native Telegram defaults stay unchanged. Existing target-prefix ownership still keeps `telegram:` owned by the native Telegram plugin when that plugin is installed; this PR proves the opt-in broker route through `broker:telegram:...` and the broker alias path when native Telegram is absent.

For review, the focused stack diff is:
https://github.com/100yenadmin/openclaw/compare/feat/channel-broker-conformance...feat/channel-broker-telegram-routing

## Real Behavior Proof

- **Behavior or issue addressed:** Telegram topic targets can route through `channel-broker` and become provider requests with canonical `telegram` platform, channel conversation id, and topic `threadId`.
- **Real environment tested:** Local OpenClaw checkout at `/Volumes/LEXAR/repos/openclaw-channel-broker`, using the Channel Broker plugin and SDK from the stacked rollout branch on May 24, 2026.
- **Exact steps or command run after this patch:** Ran a `node --import tsx --input-type=module` terminal proof that called `channelBrokerPlugin.message.send.text` with `to: "broker:telegram:-1001234567890:topic:42"` and captured the provider request passed to the configured broker runtime.
- **Evidence after fix:** Terminal output excerpt from that local command:

```json
{
  "label": "telegram-topic",
  "messageId": "native-telegram-topic",
  "platform": "telegram",
  "conversation": {
    "id": "-1001234567890",
    "type": "channel",
    "threadId": "42"
  },
  "requirements": {
    "text": true,
    "thread": true
  }
}
```

- **Observed result after fix:** The live plugin path normalized Telegram topic shorthand into the broker provider request shape without importing native Telegram extension internals.
- **What was not tested:** Live Telegram Bot API traffic and the full local suite; this PR stays scoped to opt-in broker routing proof.

### Behavior

OpenClaw can route a Telegram topic through `channel-broker` without Telegram extension code. The broker receives a normalized platform `telegram`, conversation id, and thread id; OpenClaw keeps the session route canonical and leaves native Telegram prefix ownership intact.

### Environment

- Local checkout: `/Volumes/LEXAR/repos/openclaw-channel-broker`
- Branch: `feat/channel-broker-telegram-routing`
- Head: `40a181b5b2 Add Telegram broker routing proof`

### Steps

1. Sent a synthetic message to `broker:telegram:-1001234567890:topic:42` through `channelBrokerPlugin.message.send.text`.
2. Verified the provider request used `platform: "telegram"`, `conversation.id: "-1001234567890"`, and `conversation.threadId: "42"`.
3. Resolved the outbound session route for the same target.
4. Verified the route canonicalized to `telegram:-1001234567890?threadId=42` and preserved channel chat semantics.

### Evidence

- `pnpm exec vitest run extensions/channel-broker/src/channel.test.ts extensions/channel-broker/src/conformance.test.ts --config test/vitest/vitest.extension-channel-broker.config.ts`
  - 2 files passed, 10 tests passed.
- `pnpm exec tsc --noEmit -p extensions/channel-broker/tsconfig.json`
  - passed.
- `pnpm exec oxfmt --check extensions/channel-broker/src/target.ts extensions/channel-broker/src/channel.ts extensions/channel-broker/src/channel.test.ts`
  - passed.
- `pnpm exec oxlint extensions/channel-broker --format unix`
  - passed.
- `git diff --check`
  - passed.

### Observed Result

Telegram topic routing is represented by broker-owned target normalization and provider request semantics, not by core importing or calling native Telegram extension internals.

### Not Tested

- Live Telegram Bot API traffic; this PR is the opt-in broker migration proof, not a live provider connector.
- Full local suite. Per `/Volumes/LEXAR` policy, broad validation is left to GitHub Actions.

## Current Upstream Gate Context

PR #86096 currently has one unrelated `checks-node-agentic-agents` CI timeout in `src/agents/model-catalog-visibility.test.ts`; the failed test is outside this broker stack. I attempted to rerun the failed job, but GitHub blocked it because this account does not have repository admin rights.
