### PR TITLE
Allow agents to harden bundled plugin discovery

### DIFF
--- a/src/agents/tools/gateway-tool-guard-coverage.test.ts
+++ b/src/agents/tools/gateway-tool-guard-coverage.test.ts
@@ -70,6 +70,7 @@ describe("gateway config mutation guard coverage", () => {
     expect(ALLOWED_GATEWAY_CONFIG_PATHS_FOR_TEST).toContain(
       "messages.groupChat.unmentionedInbound",
     );
+    expect(ALLOWED_GATEWAY_CONFIG_PATHS_FOR_TEST).toContain("plugins.bundledDiscovery");
   });
 
   it("allows documented subagent thinking default edits via config.patch", () => {
@@ -167,6 +168,25 @@ describe("gateway config mutation guard coverage", () => {
         },
       },
     );
+  });
+
+  it("allows hardening bundled plugin discovery to allowlist via config.patch", () => {
+    expectAllowed(
+      { plugins: { allow: ["codex", "telegram"], bundledDiscovery: "compat" } },
+      { plugins: { bundledDiscovery: "allowlist" } },
+    );
+  });
+
+  it("blocks loosening bundled plugin discovery back to compat via config.patch", () => {
+    expect(() =>
+      assertGatewayConfigMutationAllowedForTest({
+        action: "config.patch",
+        currentConfig: {
+          plugins: { allow: ["codex", "telegram"], bundledDiscovery: "allowlist" },
+        },
+        raw: JSON.stringify({ plugins: { bundledDiscovery: "compat" } }),
+      }),
+    ).toThrow(/cannot loosen bundled plugin discovery/);
   });
 
   it("blocks disabling sandbox mode via config.patch", () => {

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -62,6 +62,10 @@ const ALLOWED_GATEWAY_CONFIG_PATHS = [
   "messages.visibleReplies",
   "messages.groupChat.visibleReplies",
   "messages.groupChat.unmentionedInbound",
+  // Doctor may recommend switching restrictive plugin allowlists from legacy
+  // bundled-provider compatibility to strict allowlist discovery. This is a
+  // hardening edit, but keep loosening back to "compat" blocked below.
+  "plugins.bundledDiscovery",
 ] as const;
 
 /** @internal Exposed for regression tests only; do not import from runtime code. */
@@ -309,6 +313,16 @@ function assertGatewayConfigMutationAllowed(params: {
   if (disallowedPaths.length > 0) {
     throw new Error(
       `gateway ${params.action} cannot change protected config paths: ${disallowedPaths.join(", ")}`,
+    );
+  }
+
+  if (
+    changedPaths.includes("plugins.bundledDiscovery") &&
+    (nextConfig.plugins as { bundledDiscovery?: unknown } | undefined)?.bundledDiscovery !==
+      "allowlist"
+  ) {
+    throw new Error(
+      `gateway ${params.action} cannot loosen bundled plugin discovery; only plugins.bundledDiscovery="allowlist" is allowed`,
     );
   }
 


### PR DESCRIPTION
## Summary

Fixes #86136.

This PR allows agents to apply one specific doctor-recommended hardening change through the agent-facing gateway config tool:

```json
{
  "plugins": {
    "bundledDiscovery": "allowlist"
  }
}
```

It does not generally open plugin discovery config to agents. The new guard allows only the hardening value `"allowlist"` and still rejects attempts to set or restore legacy `"compat"` mode.

## Problem

`openclaw doctor` recommends `plugins.bundledDiscovery: "allowlist"` when an installation uses a restrictive `plugins.allow`. That recommendation matters because legacy `"compat"` bundled discovery can keep omitted bundled providers discoverable even when an operator is trying to restrict plugin exposure.

The config schema also presents `plugins.bundledDiscovery` as a valid hot-reloadable enum:

```text
path: plugins.bundledDiscovery
enum: ["compat", "allowlist"]
reloadKind: hot
```

Before this PR, an agent could see the schema and doctor recommendation, but could not apply the hardening patch:

```text
gateway config.patch cannot change protected config paths: plugins.bundledDiscovery
```

That forced manual config-file editing for a security-positive change.

## Root Cause

The agent gateway tool protects config mutation by computing changed config paths and rejecting paths that are not listed in `ALLOWED_GATEWAY_CONFIG_PATHS`. `plugins.bundledDiscovery` was not in that list, so the guard blocked both directions equally:

- blocked `compat -> allowlist`, which is hardening
- blocked `allowlist -> compat`, which is loosening

The desired behavior needs a path exception plus a value-direction guard, not a broad plugin config exemption.

## Implementation

This PR changes two files:

- `src/agents/tools/gateway-tool.ts`
  - adds `plugins.bundledDiscovery` to the agent-facing config path allowlist
  - adds an explicit value guard that permits only `"allowlist"`
  - rejects any agent-facing attempt to loosen bundled discovery back to `"compat"`
- `src/agents/tools/gateway-tool-guard-coverage.test.ts`
  - verifies the path is included in guard coverage
  - verifies `compat -> allowlist` is allowed
  - verifies `allowlist -> compat` is blocked

## Real behavior proof

Behavior or issue addressed: Agent-facing gateway `config.patch` hardening for `plugins.bundledDiscovery`. Agents should be able to apply doctor-recommended hardening to `"allowlist"`, while attempts to loosen back to `"compat"` remain blocked.

Real environment tested: Sanitized live OpenClaw `2026.5.22` installation with restrictive `plugins.allow` and `plugins.bundledDiscovery: "compat"`, plus this PR branch at `890a60aebcfc11b11785c079f8f0e2086336b9e2`. The live gateway was running as a Linux user service. No tokens, chat IDs, private channel names, user content, private account identifiers, hostnames, or local user paths are included.

Before-fix evidence: The live published setup exposed the failure before this PR. Schema lookup showed `plugins.bundledDiscovery` as a hot-reloadable enum, but the agent-facing patch was rejected by the protected-path guard before the gateway RPC.

```text
schema lookup:
path: plugins.bundledDiscovery
enum: ["compat", "allowlist"]
reloadKind: hot

agent-facing patch:
{"plugins":{"bundledDiscovery":"allowlist"}}

result:
gateway config.patch cannot change protected config paths: plugins.bundledDiscovery
```

Exact steps or command run after the patch: Ran this PR branch's agent-facing `config.patch` mutation guard directly against sanitized config snapshots for both directions, then ran the focused guard test file.

```text
GIT_HEAD=$(git rev-parse HEAD) node --import tsx <agent-facing config.patch guard probe>
npm test -- --run src/agents/tools/gateway-tool-guard-coverage.test.ts
```

Evidence after fix: Copied terminal output from the PR branch showing the changed `config.patch` guard accepts `"allowlist"` and rejects `"compat"`, followed by focused test output.

```text
PR branch: 890a60aebcfc11b11785c079f8f0e2086336b9e2
Command: node --import tsx <agent-facing config.patch guard probe>
agent-facing config.patch compat -> allowlist: accepted
agent-facing config.patch allowlist -> compat: rejected: gateway config.patch cannot loosen bundled plugin discovery; only plugins.bundledDiscovery="allowlist" is allowed

npm test -- --run src/agents/tools/gateway-tool-guard-coverage.test.ts
Test Files  1 passed (1)
Tests       43 passed (43)
```

Current-head validation rerun: After rebasing, I reran the focused guard coverage on the current PR head.

```text
git rev-parse HEAD
890a60aebcfc11b11785c079f8f0e2086336b9e2

npm test -- --run src/agents/tools/gateway-tool-guard-coverage.test.ts

Test Files  1 passed (1)
Tests       43 passed (43)
[test] passed 1 Vitest shard in 15.46s
```

Observed result after fix: On the PR branch, the exact agent-facing `config.patch` guard now permits the hardening transition `compat -> allowlist` and rejects the loosening transition `allowlist -> compat`. The published live setup confirmed `plugins.bundledDiscovery: "allowlist"` is the correct operational target because it cleared the doctor warning after manual workaround and restart.

What was not tested: I did not replace the live installed gateway service with this PR branch. The PR-branch proof exercises the changed agent-facing `config.patch` guard directly with sanitized config snapshots; the live gateway proof uses the published `2026.5.22` package to confirm the pre-fix failure and operational effect of the target value.

## Validation

```text
npm test -- --run src/agents/tools/gateway-tool-guard-coverage.test.ts
```

Result:

```text
1 file passed
43 tests passed
```

GitHub checks are currently passing or intentionally skipped for this PR, including the real behavior proof gate.

## Security / Risk

Risk is low and intentionally bounded.

This is not a broad plugin-configuration bypass. The PR allows a single security-positive value through the agent-facing guard and rejects the loosening value:

- `compat -> allowlist` is allowed
- `allowlist -> compat` is blocked
- any other protected config paths remain protected by the existing guard

The main security concern is accidentally letting agents re-enable legacy bundled discovery. The added value guard and tests cover that explicitly.

## Privacy / Sanitization

The linked issue, PR body, and comments are sanitized. They do not include tokens, chat IDs, private channel names, personal data, local usernames, private hostnames, or user content. Public GitHub issue/PR links and generic OpenClaw config keys are included because they are necessary to review and reproduce the fix.







