### PR TITLE
[codex] fix cron announce delivery transcript mirrors

### DIFF
--- a/src/cron/delivery.failure-notify.test.ts
+++ b/src/cron/delivery.failure-notify.test.ts
@@ -36,7 +36,8 @@ vi.mock("../logging.js", () => ({
   })),
 }));
 
-const { sendFailureNotificationAnnounce } = await import("./delivery.js");
+const { sendCronAnnouncePayloadStrict, sendFailureNotificationAnnounce } =
+  await import("./delivery.js");
 
 type DeliveryRequest = {
   abortSignal?: unknown;
@@ -46,6 +47,12 @@ type DeliveryRequest = {
   channel?: string;
   deps?: unknown;
   identity?: unknown;
+  mirror?: {
+    agentId?: string;
+    idempotencyKey?: string;
+    sessionKey?: string;
+    text?: string;
+  };
   payloads?: unknown;
   session?: unknown;
   threadId?: number;
@@ -117,6 +124,80 @@ describe("sendFailureNotificationAnnounce", () => {
     expect(deliveryRequest.bestEffort).toBe(false);
     expect(deliveryRequest.deps).toEqual({ kind: "deps" });
     expect(deliveryRequest.abortSignal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("mirrors successful announces into custom delivery session transcripts", async () => {
+    const abortController = new AbortController();
+
+    await sendCronAnnouncePayloadStrict({
+      deps: {} as never,
+      cfg: {} as never,
+      agentId: "main",
+      jobId: "job-1",
+      target: {
+        channel: "telegram",
+        sessionKey: "agent:main:session:daily-digest",
+      },
+      message: "Cron summary",
+      abortSignal: abortController.signal,
+    });
+
+    const [deliveryRequest] = mocks.deliverOutboundPayloads.mock.calls[0] as [
+      {
+        mirror?: {
+          agentId?: string;
+          idempotencyKey?: string;
+          sessionKey?: string;
+          text?: string;
+        };
+      },
+    ];
+    expect(deliveryRequest.mirror).toMatchObject({
+      sessionKey: "agent:main:session:daily-digest",
+      agentId: "main",
+      text: "Cron summary",
+    });
+    expect(deliveryRequest.mirror?.idempotencyKey).toMatch(/^cron-announce-mirror:v1:job-1:/);
+  });
+
+  it("skips mirrors for routed peer session keys to avoid active chat lock races", async () => {
+    const abortController = new AbortController();
+
+    await sendCronAnnouncePayloadStrict({
+      deps: {} as never,
+      cfg: {} as never,
+      agentId: "main",
+      jobId: "job-1",
+      target: {
+        channel: "telegram",
+        sessionKey: "agent:main:telegram:direct:123:thread:99",
+      },
+      message: "Cron summary",
+      abortSignal: abortController.signal,
+    });
+
+    const deliveryRequest = firstDeliveryRequest();
+    expect(deliveryRequest.mirror).toBeUndefined();
+  });
+
+  it("skips mirrors for legacy dm routed peer session keys", async () => {
+    const abortController = new AbortController();
+
+    await sendCronAnnouncePayloadStrict({
+      deps: {} as never,
+      cfg: {} as never,
+      agentId: "main",
+      jobId: "job-1",
+      target: {
+        channel: "telegram",
+        sessionKey: "agent:main:telegram:dm:123:thread:99",
+      },
+      message: "Cron summary",
+      abortSignal: abortController.signal,
+    });
+
+    const deliveryRequest = firstDeliveryRequest();
+    expect(deliveryRequest.mirror).toBeUndefined();
   });
 
   it("uses sessionKey for delivery-target resolution and outbound context", async () => {

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { sendDurableMessageBatch } from "../channels/message/runtime.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { createOutboundSendDeps } from "../cli/outbound-send-deps.js";
@@ -6,6 +7,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { resolveAgentOutboundIdentity } from "../infra/outbound/identity.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { getChildLogger } from "../logging.js";
+import { parseAgentSessionKey, parseThreadSessionSuffix } from "../routing/session-key.js";
 import {
   resolveFailureDestination,
   type CronFailureDeliveryPlan,
@@ -30,6 +32,7 @@ export {
 
 const FAILURE_NOTIFICATION_TIMEOUT_MS = 30_000;
 const cronDeliveryLogger = getChildLogger({ subsystem: "cron-delivery" });
+const ROUTED_PEER_SESSION_KINDS = new Set(["direct", "dm", "group", "channel"]);
 
 export type CronAnnounceTarget = {
   channel?: string;
@@ -39,6 +42,48 @@ export type CronAnnounceTarget = {
 };
 
 type SuccessfulDeliveryTarget = Extract<DeliveryTargetResolution, { ok: true }>;
+
+function buildCronAnnounceMirrorIdempotencyKey(params: {
+  jobId: string;
+  target: SuccessfulDeliveryTarget;
+  message: string;
+}): string {
+  const digest = createHash("sha256")
+    .update(
+      JSON.stringify([
+        params.target.channel,
+        params.target.accountId ?? "",
+        params.target.to,
+        params.target.threadId ?? "",
+        params.message,
+      ]),
+    )
+    .digest("hex")
+    .slice(0, 24);
+  return `cron-announce-mirror:v1:${params.jobId}:${digest}`;
+}
+
+function isRoutedPeerSessionKey(sessionKey: string): boolean {
+  const { baseSessionKey } = parseThreadSessionSuffix(sessionKey);
+  const parsed = parseAgentSessionKey(baseSessionKey ?? sessionKey);
+  if (!parsed) {
+    return false;
+  }
+
+  const parts = parsed.rest.split(":").filter(Boolean);
+  const peerKind = parts.length >= 2 ? parts[parts.length - 2] : undefined;
+  return typeof peerKind === "string" && ROUTED_PEER_SESSION_KINDS.has(peerKind);
+}
+
+function resolveCronAnnounceMirrorSessionKey(sessionKey: string | undefined): string | undefined {
+  const trimmed = sessionKey?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  // Routed peer sessions can be active embedded conversations. Mirror only
+  // into custom/main session keys here so cron delivery does not race locks.
+  return isRoutedPeerSessionKey(trimmed) ? undefined : trimmed;
+}
 
 async function resolveCronAnnounceDelivery(params: {
   cfg: OpenClawConfig;
@@ -51,6 +96,7 @@ async function resolveCronAnnounceDelivery(params: {
       resolvedTarget: SuccessfulDeliveryTarget;
       session: ReturnType<typeof buildOutboundSessionContext>;
       identity: ReturnType<typeof resolveAgentOutboundIdentity>;
+      mirrorSessionKey?: string;
     }
   | { ok: false; error: Error }
 > {
@@ -74,12 +120,14 @@ async function resolveCronAnnounceDelivery(params: {
       sessionKey: params.target.sessionKey,
     }),
   });
+  const mirrorSessionKey = resolveCronAnnounceMirrorSessionKey(params.target.sessionKey);
 
   return {
     ok: true,
     resolvedTarget,
     session,
     identity,
+    ...(mirrorSessionKey ? { mirrorSessionKey } : {}),
   };
 }
 
@@ -90,7 +138,10 @@ async function deliverCronAnnouncePayload(params: {
     resolvedTarget: SuccessfulDeliveryTarget;
     session: ReturnType<typeof buildOutboundSessionContext>;
     identity: ReturnType<typeof resolveAgentOutboundIdentity>;
+    mirrorSessionKey?: string;
   };
+  agentId: string;
+  jobId: string;
   message: string;
   abortSignal: AbortSignal;
 }): Promise<void> {
@@ -106,6 +157,18 @@ async function deliverCronAnnouncePayload(params: {
     bestEffort: false,
     deps: createOutboundSendDeps(params.deps),
     signal: params.abortSignal,
+    mirror: params.delivery.mirrorSessionKey
+      ? {
+          sessionKey: params.delivery.mirrorSessionKey,
+          agentId: params.agentId,
+          text: params.message,
+          idempotencyKey: buildCronAnnounceMirrorIdempotencyKey({
+            jobId: params.jobId,
+            target: params.delivery.resolvedTarget,
+            message: params.message,
+          }),
+        }
+      : undefined,
   });
   if (send.status === "failed" || send.status === "partial_failed") {
     throw send.error;
@@ -129,6 +192,8 @@ export async function sendCronAnnouncePayloadStrict(params: {
     deps: params.deps,
     cfg: params.cfg,
     delivery,
+    agentId: params.agentId,
+    jobId: params.jobId,
     message: params.message,
     abortSignal: params.abortSignal,
   });
@@ -162,6 +227,8 @@ export async function sendFailureNotificationAnnounce(
       deps,
       cfg,
       delivery,
+      agentId,
+      jobId,
       message,
       abortSignal: abortController.signal,
     });


### PR DESCRIPTION
## Summary
- Mirror cron announce/failure-notification delivery into a session transcript when the cron target is a custom/main session key.
- Use a stable `cron-announce-mirror:v1:*` idempotency key so repeated delivery does not duplicate transcript rows.
- Skip transcript mirrors for routed peer/channel session keys such as `agent:<id>:<channel>:direct:<peer>`, legacy `agent:<id>:<channel>:dm:<peer>`, groups, and channels so cron delivery does not race an active embedded chat session lock.
- Add targeted unit coverage.

## Verification
- Rebased onto `origin/main` `efd88dc00d8da4d5bf8fea1d928fd36169073957`; current PR head is `5af6df99e9670edc89bee19ce48bac5470e3f37c`.
- `git diff --check origin/main...HEAD`
- `pnpm changed:lanes --json` (`core`, `coreTests`)
- `pnpm test src/cron/delivery.failure-notify.test.ts` (1 file, 7 tests passed)
- `pnpm check:changed`
- Reran the unrelated CI-timeout test locally on this head: `pnpm test src/agents/model-catalog-visibility.test.ts` (1 file, 3 tests passed)

## Changelog candidate
- Cron: mirror session-bound announce and failure alert delivery into the destination transcript so follow-up replies keep the delivered message in context.

Note: the changelog line is intentionally kept out of this PR diff to avoid repeated `CHANGELOG.md` conflicts while `main` is moving quickly. It can be added at landing.

## Real behavior proof

Behavior addressed: Cron announce/failure-alert delivery that resolves to a safe session-bound target now mirrors the delivered assistant text into that session transcript before the next turn can rely on the transcript. Routed peer/channel session keys, including backward-compatible `:dm:` direct-message keys, are intentionally not mirrored by this helper to avoid the active-session lock race called out in review.

Real environment tested: Local OpenClaw checkout `/Users/dross/openclaw-cron-transcript-mirror`, branch `codex/fix-cron-session-transcript-mirror`, proof head `eade497bb55d728612dcb3b87f8390560edde533`, based on `origin/main` `07f500aa562d4f414a6b85d785b2e6c2d776cb8d`, with a temporary `OPENCLAW_STATE_DIR`. The current PR head `5af6df99e9670edc89bee19ce48bac5470e3f37c` preserves the same `src/cron/**` source/test patch, rebased onto current `main`, with the volatile `CHANGELOG.md` edit removed. The proof exercises the real runtime path `sendCronAnnouncePayloadStrict` -> `sendDurableMessageBatch` -> channel outbound adapter -> transcript append. It uses a local proof LINE outbound adapter so no private external account, phone number, endpoint, or token is needed.

Exact steps or command run after this patch: Ran `node --import tsx --input-type=module -` from the repo root with an inline harness that registered a local LINE outbound adapter, seeded the session store with a custom session key, a routed `direct` peer-session key, and a legacy routed `dm` peer-session key, invoked `sendCronAnnouncePayloadStrict` for all three targets, then read the resulting transcript files from the temporary state directory.

Evidence after fix:

```text
OPENCLAW_RUNTIME_PROOF cron announce mirror lock-safe dm
state_dir=/var/folders/69/5f9v9rq9045bwk3w75cht7wm0000gn/T/openclaw-cron-mirror-proof.UQzfSF
send_results=[{"channel":"line","to":"proof-recipient","accountId":"proof-account","text":"proof cron announce text"},{"channel":"line","to":"proof-recipient","accountId":"proof-account","text":"proof routed cron announce text"},{"channel":"line","to":"proof-recipient","accountId":"proof-account","text":"proof legacy dm cron announce text"}]
custom_session_key=agent:main:session:proof-cron
custom_session_file=<tmp-state>/agents/main/sessions/proof-session.jsonl
custom_transcript_lines=2
custom_last_role=assistant
custom_last_text=proof cron announce text
custom_idempotency_key=cron-announce-mirror:v1:proof-job:e1006f2c48036c15d4dd13a4
mirror_key_prefix_ok=true
routed_session_key=agent:main:line:direct:<redacted>:thread:99
routed_session_file_exists=false
routed_mirror_skipped=true
legacy_dm_session_key=agent:main:line:dm:<redacted>:thread:99
legacy_dm_session_file_exists=false
legacy_dm_mirror_skipped=true
```

Observed result after fix: All three cron announce sends reached the outbound adapter. The custom session transcript was created and ended with the mirrored assistant message plus the stable cron mirror idempotency key. The routed `direct` and legacy `dm` peer-session sends still delivered, but neither peer-session transcript file was created, confirming the lock-safe mirror gate covers both current and backward-compatible direct-message key shapes.

What was not tested: I did not run a real WhatsApp or Telegram network send from this branch. The original WhatsApp incident evidence was captured separately from a redacted live screenshot and logs: a cron announce was visible in WhatsApp at 17:17, the user replied at 17:18, and the live session transcript did not contain the cron announce before that reply. That before-fix evidence is privacy-redacted and not attached as a PR image.