### PR TITLE
fix(nostr): keep subscriptions lifecycle valid

### DIFF
--- a/extensions/nostr/src/channel.outbound.test.ts
+++ b/extensions/nostr/src/channel.outbound.test.ts
@@ -48,6 +48,7 @@ function installOutboundRuntime(convertMarkdownTables = vi.fn((text: string) => 
 }
 
 async function startOutboundAccount(accountId?: string) {
+  const abort = new AbortController();
   const sendDm = vi.fn(async () => {});
   const bus = {
     sendDm,
@@ -58,13 +59,23 @@ async function startOutboundAccount(accountId?: string) {
   };
   mocks.startNostrBus.mockResolvedValueOnce(bus as unknown);
 
-  const cleanup = (await startNostrGatewayAccount(
+  const done = startNostrGatewayAccount(
     createStartAccountContext({
       account: buildResolvedNostrAccount(accountId ? { accountId } : undefined),
+      abortSignal: abort.signal,
     }),
-  )) as { stop: () => void };
+  );
+  await vi.waitFor(() => expect(mocks.startNostrBus).toHaveBeenCalledTimes(1));
 
-  return { cleanup, sendDm };
+  return {
+    cleanup: async () => {
+      abort.abort();
+      await done;
+    },
+    done,
+    close: bus.close,
+    sendDm,
+  };
 }
 
 describe("nostr outbound cfg threading", () => {
@@ -96,7 +107,21 @@ describe("nostr outbound cfg threading", () => {
     expect(mocks.normalizePubkey).toHaveBeenCalledWith("NPUB123");
     expect(sendDm).toHaveBeenCalledWith("normalized-npub123", "converted:|a|b|");
 
-    cleanup.stop();
+    await cleanup();
+  });
+
+  it("keeps the gateway account task alive until abort", async () => {
+    installOutboundRuntime();
+    const { cleanup, close, done } = await startOutboundAccount();
+    const finished = vi.fn();
+    void done.then(finished);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(finished).not.toHaveBeenCalled();
+    await cleanup();
+    expect(finished).toHaveBeenCalledTimes(1);
+    expect(close).toHaveBeenCalledTimes(1);
   });
 
   it("uses the configured defaultAccount when accountId is omitted", async () => {
@@ -125,7 +150,7 @@ describe("nostr outbound cfg threading", () => {
     });
     expect(sendDm).toHaveBeenCalledWith("normalized-npub123", "hello");
 
-    cleanup.stop();
+    await cleanup();
   });
 
   it("backs declared message adapter capabilities with outbound sends", async () => {
@@ -158,6 +183,6 @@ describe("nostr outbound cfg threading", () => {
       },
     });
 
-    cleanup.stop();
+    await cleanup();
   });
 });

--- a/extensions/nostr/src/gateway.ts
+++ b/extensions/nostr/src/gateway.ts
@@ -143,118 +143,125 @@ export const startNostrGatewayAccount: NostrGatewayStart = async (ctx) => {
     return "block";
   };
 
-  const bus = await startNostrBus({
-    accountId: account.accountId,
-    privateKey: account.privateKey,
-    relays: account.relays,
-    authorizeSender: async ({ senderPubkey, reply }) =>
-      await authorizeSender({ senderId: senderPubkey, reply }),
-    onMessage: async (senderPubkey, text, reply, meta) => {
-      const resolvedAccess = await resolveInboundAccess(senderPubkey, text);
-      if (resolvedAccess.senderAccess.decision !== "allow") {
-        ctx.log?.warn?.(
-          `[${account.accountId}] dropping Nostr DM after preflight drift (${senderPubkey}, ${resolvedAccess.senderAccess.reasonCode})`,
-        );
-        return;
-      }
+  try {
+    const bus = await startNostrBus({
+      accountId: account.accountId,
+      privateKey: account.privateKey,
+      relays: account.relays,
+      authorizeSender: async ({ senderPubkey, reply }) =>
+        await authorizeSender({ senderId: senderPubkey, reply }),
+      onMessage: async (senderPubkey, text, reply, meta) => {
+        const resolvedAccess = await resolveInboundAccess(senderPubkey, text);
+        if (resolvedAccess.senderAccess.decision !== "allow") {
+          ctx.log?.warn?.(
+            `[${account.accountId}] dropping Nostr DM after preflight drift (${senderPubkey}, ${resolvedAccess.senderAccess.reasonCode})`,
+          );
+          return;
+        }
 
-      const { dispatchInboundDirectDmWithRuntime } = await import("./inbound-direct-dm-runtime.js");
-      await dispatchInboundDirectDmWithRuntime({
-        cfg: ctx.cfg,
-        runtime,
-        channel: "nostr",
-        channelLabel: "Nostr",
-        accountId: account.accountId,
-        peer: {
-          kind: "direct",
-          id: senderPubkey,
-        },
-        senderId: senderPubkey,
-        senderAddress: `nostr:${senderPubkey}`,
-        recipientAddress: `nostr:${account.publicKey}`,
-        conversationLabel: senderPubkey,
-        rawBody: text,
-        messageId: meta.eventId,
-        timestamp: meta.createdAt * 1000,
-        commandAuthorized: resolvedAccess.commandAccess.requested
-          ? resolvedAccess.commandAccess.authorized
-          : undefined,
-        deliver: async (payload) => {
-          const outboundText =
-            payload && typeof payload === "object" && "text" in payload
-              ? ((payload as { text?: string }).text ?? "")
-              : "";
-          if (!outboundText.trim()) {
-            return;
-          }
-          const tableMode = runtime.channel.text.resolveMarkdownTableMode({
-            cfg: ctx.cfg,
-            channel: "nostr",
-            accountId: account.accountId,
-          });
-          await reply(runtime.channel.text.convertMarkdownTables(outboundText, tableMode));
-        },
-        onRecordError: (err) => {
-          ctx.log?.error?.(
-            `[${account.accountId}] failed recording Nostr inbound session: ${String(err)}`,
+        const { dispatchInboundDirectDmWithRuntime } =
+          await import("./inbound-direct-dm-runtime.js");
+        await dispatchInboundDirectDmWithRuntime({
+          cfg: ctx.cfg,
+          runtime,
+          channel: "nostr",
+          channelLabel: "Nostr",
+          accountId: account.accountId,
+          peer: {
+            kind: "direct",
+            id: senderPubkey,
+          },
+          senderId: senderPubkey,
+          senderAddress: `nostr:${senderPubkey}`,
+          recipientAddress: `nostr:${account.publicKey}`,
+          conversationLabel: senderPubkey,
+          rawBody: text,
+          messageId: meta.eventId,
+          timestamp: meta.createdAt * 1000,
+          commandAuthorized: resolvedAccess.commandAccess.requested
+            ? resolvedAccess.commandAccess.authorized
+            : undefined,
+          deliver: async (payload) => {
+            const outboundText =
+              payload && typeof payload === "object" && "text" in payload
+                ? ((payload as { text?: string }).text ?? "")
+                : "";
+            if (!outboundText.trim()) {
+              return;
+            }
+            const tableMode = runtime.channel.text.resolveMarkdownTableMode({
+              cfg: ctx.cfg,
+              channel: "nostr",
+              accountId: account.accountId,
+            });
+            await reply(runtime.channel.text.convertMarkdownTables(outboundText, tableMode));
+          },
+          onRecordError: (err) => {
+            ctx.log?.error?.(
+              `[${account.accountId}] failed recording Nostr inbound session: ${String(err)}`,
+            );
+          },
+          onDispatchError: (err, info) => {
+            ctx.log?.error?.(
+              `[${account.accountId}] Nostr ${info.kind} reply failed: ${String(err)}`,
+            );
+          },
+        });
+      },
+      onError: (error, context) => {
+        ctx.log?.error?.(`[${account.accountId}] Nostr error (${context}): ${error.message}`);
+      },
+      onConnect: (relay) => {
+        ctx.log?.debug?.(`[${account.accountId}] Connected to relay: ${relay}`);
+      },
+      onDisconnect: (relay) => {
+        ctx.log?.debug?.(`[${account.accountId}] Disconnected from relay: ${relay}`);
+      },
+      onEose: (relays) => {
+        ctx.log?.debug?.(`[${account.accountId}] EOSE received from relays: ${relays}`);
+      },
+      onMetric: (event: MetricEvent) => {
+        if (event.name.startsWith("event.rejected.")) {
+          ctx.log?.debug?.(
+            `[${account.accountId}] Metric: ${event.name} ${JSON.stringify(event.labels)}`,
           );
-        },
-        onDispatchError: (err, info) => {
-          ctx.log?.error?.(
-            `[${account.accountId}] Nostr ${info.kind} reply failed: ${String(err)}`,
+        } else if (event.name === "relay.circuit_breaker.open") {
+          ctx.log?.warn?.(
+            `[${account.accountId}] Circuit breaker opened for relay: ${event.labels?.relay}`,
           );
-        },
+        } else if (event.name === "relay.circuit_breaker.close") {
+          ctx.log?.info?.(
+            `[${account.accountId}] Circuit breaker closed for relay: ${event.labels?.relay}`,
+          );
+        } else if (event.name === "relay.error") {
+          ctx.log?.debug?.(`[${account.accountId}] Relay error: ${event.labels?.relay}`);
+        }
+        if (busHandle) {
+          metricsSnapshots.set(account.accountId, busHandle.getMetrics());
+        }
+      },
+    });
+
+    busHandle = bus;
+    activeBuses.set(account.accountId, bus);
+
+    ctx.log?.info?.(
+      `[${account.accountId}] Nostr provider started, connected to ${account.relays.length} relay(s)`,
+    );
+
+    if (!ctx.abortSignal.aborted) {
+      await new Promise<void>((resolve) => {
+        ctx.abortSignal.addEventListener("abort", () => resolve(), { once: true });
       });
-    },
-    onError: (error, context) => {
-      ctx.log?.error?.(`[${account.accountId}] Nostr error (${context}): ${error.message}`);
-    },
-    onConnect: (relay) => {
-      ctx.log?.debug?.(`[${account.accountId}] Connected to relay: ${relay}`);
-    },
-    onDisconnect: (relay) => {
-      ctx.log?.debug?.(`[${account.accountId}] Disconnected from relay: ${relay}`);
-    },
-    onEose: (relays) => {
-      ctx.log?.debug?.(`[${account.accountId}] EOSE received from relays: ${relays}`);
-    },
-    onMetric: (event: MetricEvent) => {
-      if (event.name.startsWith("event.rejected.")) {
-        ctx.log?.debug?.(
-          `[${account.accountId}] Metric: ${event.name} ${JSON.stringify(event.labels)}`,
-        );
-      } else if (event.name === "relay.circuit_breaker.open") {
-        ctx.log?.warn?.(
-          `[${account.accountId}] Circuit breaker opened for relay: ${event.labels?.relay}`,
-        );
-      } else if (event.name === "relay.circuit_breaker.close") {
-        ctx.log?.info?.(
-          `[${account.accountId}] Circuit breaker closed for relay: ${event.labels?.relay}`,
-        );
-      } else if (event.name === "relay.error") {
-        ctx.log?.debug?.(`[${account.accountId}] Relay error: ${event.labels?.relay}`);
-      }
-      if (busHandle) {
-        metricsSnapshots.set(account.accountId, busHandle.getMetrics());
-      }
-    },
-  });
-
-  busHandle = bus;
-  activeBuses.set(account.accountId, bus);
-
-  ctx.log?.info?.(
-    `[${account.accountId}] Nostr provider started, connected to ${account.relays.length} relay(s)`,
-  );
-
-  return {
-    stop: () => {
-      bus.close();
+    }
+  } finally {
+    if (busHandle) {
+      busHandle.close();
       activeBuses.delete(account.accountId);
       metricsSnapshots.delete(account.accountId);
       ctx.log?.info?.(`[${account.accountId}] Nostr provider stopped`);
-    },
-  };
+    }
+  }
 };
 
 export const nostrPairingTextAdapter = {

--- a/extensions/nostr/src/nostr-bus.inbound.test.ts
+++ b/extensions/nostr/src/nostr-bus.inbound.test.ts
@@ -18,24 +18,27 @@ const mockState = vi.hoisted(() => ({
     successes: [],
     failures: [],
   })),
-}));
-
-vi.mock("nostr-tools", () => {
-  class MockSimplePool {
-    subscribeMany(
+  subscribeMany: vi.fn(
+    (
       _relays: string[],
-      _filters: unknown,
+      _filter: unknown,
       handlers: {
         onevent: (event: Record<string, unknown>) => void | Promise<void>;
         oneose?: () => void;
         onclose?: (reason: string[]) => void;
       },
-    ) {
+    ) => {
       mockState.handlers = handlers;
       return {
         close: vi.fn(),
       };
-    }
+    },
+  ),
+}));
+
+vi.mock("nostr-tools", () => {
+  class MockSimplePool {
+    subscribeMany = mockState.subscribeMany;
 
     publish = vi.fn(async () => {});
   }
@@ -91,6 +94,7 @@ async function emitEvent(event: Record<string, unknown>) {
 describe("startNostrBus inbound guards", () => {
   beforeEach(() => {
     mockState.handlers = null;
+    mockState.subscribeMany.mockClear();
     mockState.verifyEvent.mockClear();
     mockState.verifyEvent.mockReturnValue(true);
     mockState.decrypt.mockClear();
@@ -99,6 +103,23 @@ describe("startNostrBus inbound guards", () => {
 
   afterEach(() => {
     mockState.handlers = null;
+  });
+
+  it("subscribes with a single NIP-01 filter object", async () => {
+    const bus = await startNostrBus({
+      privateKey: TEST_HEX_PRIVATE_KEY,
+      relays: ["wss://relay.example.com"],
+      onMessage: async () => {},
+      onMetric: () => {},
+    });
+
+    expect(mockState.subscribeMany).toHaveBeenCalledWith(
+      ["wss://relay.example.com"],
+      { kinds: [4], "#p": [BOT_PUBKEY], since: 0 },
+      expect.objectContaining({ onevent: expect.any(Function) }),
+    );
+
+    bus.close();
   });
 
   it("checks sender authorization after verify and before decrypt", async () => {

--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -1,4 +1,11 @@
-import { SimplePool, finalizeEvent, getPublicKey, verifyEvent, type Event } from "nostr-tools";
+import {
+  SimplePool,
+  finalizeEvent,
+  getPublicKey,
+  verifyEvent,
+  type Event,
+  type Filter,
+} from "nostr-tools";
 import { decrypt, encrypt } from "nostr-tools/nip04";
 import {
   createDirectDmPreCryptoGuardPolicy,
@@ -614,28 +621,25 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
     }
   }
 
-  const sub = pool.subscribeMany(
-    relays,
-    [{ kinds: [4], "#p": [pk], since }] as unknown as Parameters<typeof pool.subscribeMany>[1],
-    {
-      onevent: handleEvent,
-      oneose: () => {
-        // EOSE handler - called when all stored events have been received
-        for (const relay of relays) {
-          metrics.emit("relay.message.eose", 1, { relay });
-        }
-        onEose?.(relays.join(", "));
-      },
-      onclose: (reason) => {
-        // Handle subscription close
-        for (const relay of relays) {
-          metrics.emit("relay.message.closed", 1, { relay });
-          options.onDisconnect?.(relay);
-        }
-        onError?.(new Error(`Subscription closed: ${reason.join(", ")}`), "subscription");
-      },
+  const dmFilter: Filter = { kinds: [4], "#p": [pk], since };
+  const sub = pool.subscribeMany(relays, dmFilter, {
+    onevent: handleEvent,
+    oneose: () => {
+      // EOSE handler - called when all stored events have been received
+      for (const relay of relays) {
+        metrics.emit("relay.message.eose", 1, { relay });
+      }
+      onEose?.(relays.join(", "));
     },
-  );
+    onclose: (reason) => {
+      // Handle subscription close
+      for (const relay of relays) {
+        metrics.emit("relay.message.closed", 1, { relay });
+        options.onDisconnect?.(relay);
+      }
+      onError?.(new Error(`Subscription closed: ${reason.join(", ")}`), "subscription");
+    },
+  });
 
   // Public sendDm function
   const sendDm = async (toPubkey: string, text: string): Promise<void> => {

--- a/extensions/nostr/src/nostr-profile-import.ts
+++ b/extensions/nostr/src/nostr-profile-import.ts
@@ -5,7 +5,7 @@
  * Used to import existing profiles before editing.
  */
 
-import { SimplePool, verifyEvent, type Event } from "nostr-tools";
+import { SimplePool, verifyEvent, type Event, type Filter } from "nostr-tools";
 import type { NostrProfile } from "./config-schema.js";
 import { validateUrlSafety } from "./nostr-profile-url-safety.js";
 import { contentToProfile, type ProfileContent } from "./nostr-profile.js";
@@ -122,33 +122,28 @@ export async function importProfileFromRelays(
       for (const relay of relays) {
         relaysQueried.push(relay);
 
-        const sub = pool.subscribeMany(
-          [relay],
-          [
-            {
-              kinds: [0],
-              authors: [pubkey],
-              limit: 1,
-            },
-          ] as unknown as Parameters<typeof pool.subscribeMany>[1],
-          {
-            onevent(event) {
-              events.push({ event, relay });
-            },
-            oneose() {
-              completed++;
-              if (completed >= relays.length) {
-                resolve();
-              }
-            },
-            onclose() {
-              completed++;
-              if (completed >= relays.length) {
-                resolve();
-              }
-            },
+        const profileFilter: Filter = {
+          kinds: [0],
+          authors: [pubkey],
+          limit: 1,
+        };
+        const sub = pool.subscribeMany([relay], profileFilter, {
+          onevent(event) {
+            events.push({ event, relay });
           },
-        );
+          oneose() {
+            completed++;
+            if (completed >= relays.length) {
+              resolve();
+            }
+          },
+          onclose() {
+            completed++;
+            if (completed >= relays.length) {
+              resolve();
+            }
+          },
+        });
 
         // Clean up subscription after timeout
         setTimeout(() => {


### PR DESCRIPTION
## Summary

- Fix Nostr DM and profile-import subscriptions to pass a single NIP-01 filter object to `nostr-tools` `subscribeMany` instead of an array-wrapped filter.
- Keep the Nostr gateway account task alive until its abort signal fires so the generic gateway supervisor does not treat startup as a clean channel exit.
- Add focused regression coverage for the subscription filter shape and abort-driven lifecycle cleanup.

Fixes #53858.

## Tests

- `npm view nostr-tools@2.23.5 dist.tarball version --json`
- `npm pack nostr-tools@2.23.5 --pack-destination "$tmp"` then inspect `lib/types/abstract-pool.d.ts` for `subscribeMany(relays: string[], filter: Filter, params: SubscribeManyParams): SubCloser`
- `node scripts/run-vitest.mjs extensions/nostr/src/nostr-bus.inbound.test.ts extensions/nostr/src/channel.outbound.test.ts extensions/nostr/src/nostr-profile-import.test.ts`
- `pnpm tsgo:extensions && pnpm tsgo:extensions:test`
- `pnpm format:check extensions/nostr/src/nostr-bus.ts extensions/nostr/src/nostr-profile-import.ts extensions/nostr/src/gateway.ts extensions/nostr/src/nostr-bus.inbound.test.ts extensions/nostr/src/channel.outbound.test.ts`
- `OPENCLAW_LOCAL_CHECK=0 node scripts/profile-extension-memory.mjs --extension nostr --skip-combined --concurrency 1`
- `git diff --check`

## Real behavior proof

Behavior addressed: Nostr channel startup no longer sends array-wrapped subscription filters to strict NIP-01 relays, and the Nostr gateway account remains running until gateway shutdown/abort instead of returning immediately and triggering supervisor restarts.
Real environment tested: macOS local checkout, Node/pnpm repo environment, Nostr plugin runtime import path plus installed `nostr-tools@2.23.5` package contract from npm.
Exact steps or command run after this patch: `OPENCLAW_LOCAL_CHECK=0 node scripts/profile-extension-memory.mjs --extension nostr --skip-combined --concurrency 1`; `npm view nostr-tools@2.23.5 dist.tarball version --json`; `npm pack nostr-tools@2.23.5 --pack-destination "$tmp"` followed by inspecting the shipped `lib/types/abstract-pool.d.ts` declaration.
Evidence after fix: Terminal output from the after-fix runtime import profile:
```text
$ OPENCLAW_LOCAL_CHECK=0 node scripts/profile-extension-memory.mjs --extension nostr --skip-combined --concurrency 1
[extension-memory] nostr: ok 81.4 MB
[extension-memory] report: /var/folders/hy/bphml7v52zxdq_8_273nn9ph0000gn/T/openclaw-extension-memory.json
{
  "baselineMb": 40.734375,
  "combinedMb": null,
  "counts": {
    "totalEntries": 1,
    "ok": 1,
    "fail": 0,
    "timeout": 0
  },
  "topByDeltaMb": [
    {
      "dir": "nostr",
      "file": "/Users/wuyangfan/openclaw/dist/extensions/nostr/index.js",
      "status": "ok",
      "maxRssMb": 81.4375,
      "deltaFromBaselineMb": 40.703125,
      "stderrPreview": "__OPENCLAW_MAX_RSS_KB__=83392"
    }
  ]
}
```
Observed result after fix: The Nostr plugin runtime entry imported successfully from the built extension artifact with one ok entry, zero failures, and zero timeouts. The dependency contract inspection showed `nostr-tools@2.23.5` ships `subscribeMany(relays: string[], filter: Filter, params: SubscribeManyParams): SubCloser`, matching the patched single-filter calls.
What was not tested: No live public or private Nostr relay was contacted, and no real Nostr private key or DM traffic was used.