### PR TITLE
fix(feishu): clear client cache when replacing test SDK runtime

### DIFF
--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -387,6 +387,40 @@ describe("createFeishuClient HTTP timeout", () => {
   });
 });
 
+describe("createFeishuClient cache invalidation on SDK swap (83911)", () => {
+  it("rebuilds the client after setFeishuClientRuntimeForTest replaces the SDK", () => {
+    const creds = {
+      appId: "app_swap",
+      appSecret: "secret_swap", // pragma: allowlist secret
+      accountId: "sdk-swap-test",
+    };
+    const first = createFeishuClient(creds);
+    expect(clientCtorMock.mock.calls.length).toBe(1);
+
+    // Swapping the SDK runtime mid-suite must evict clients built with the
+    // previous SDK; otherwise a later create with identical creds returns the
+    // stale cached client constructed by the old runtime.
+    setFeishuClientRuntimeForTest({
+      sdk: {
+        AppType: { SelfBuild: "self" } as never,
+        Domain: {
+          Feishu: "https://open.feishu.cn",
+          Lark: "https://open.larksuite.com",
+        } as never,
+        LoggerLevel: { info: "info" } as never,
+        Client: clientCtorMock as never,
+        WSClient: wsClientCtorMock as never,
+        EventDispatcher: vi.fn() as never,
+        defaultHttpInstance: mockBaseHttpInstance as never,
+      },
+    });
+
+    const second = createFeishuClient(creds);
+    expect(clientCtorMock.mock.calls.length).toBe(2);
+    expect(second).not.toBe(first);
+  });
+});
+
 describe("createFeishuWSClient proxy handling", () => {
   it("passes heartbeat wsConfig defaults to Lark.WSClient", async () => {
     await createFeishuWSClient(baseAccount);

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -259,4 +259,7 @@ export function setFeishuClientRuntimeForTest(overrides?: {
   feishuClientSdk = overrides?.sdk
     ? { ...defaultFeishuClientSdk, ...overrides.sdk }
     : defaultFeishuClientSdk;
+  // Evict clients built with the previous SDK so a later createFeishuClient
+  // does not return a stale client constructed by the old runtime.
+  clearClientCache();
 }


### PR DESCRIPTION
## Summary

Fixes #83911. `setFeishuClientRuntimeForTest` replaced the module SDK (`feishuClientSdk`) but did not evict `clientCache`. A later `createFeishuClient` call with the same `accountId` and identical credentials hit the cache and returned the client constructed by the *previous* SDK instance, so a test that swaps the SDK mid-suite could receive a stale client and make unreliable mock assertions.

The reset path now calls the existing `clearClientCache()` so any SDK swap also evicts clients built with the old SDK.

## Real behavior proof

Behavior or issue addressed: after `setFeishuClientRuntimeForTest` swaps the SDK, a subsequent `createFeishuClient` with unchanged credentials should rebuild the client against the new SDK instead of returning the cached client from the old SDK.

Real environment tested: Linux (Ubuntu 24.04, WSL2), Node.js 24.14.0, current PR head. Exercised the real `createFeishuClient` / `setFeishuClientRuntimeForTest` from client.ts under the repo's vitest runner (the suite imports the real module; only unrelated sibling modules are mocked). Compared the pre-fix and post-fix code.

Exact steps or command run after this patch: ran the client test suite, including a new regression test that creates a client, swaps the SDK runtime, then creates again with identical credentials.

Evidence after fix: stdout from the vitest run against the real client factory, comparing pre-fix and post-fix:
$ node scripts/run-vitest.mjs extensions/feishu/src/client.test.ts -t 83911
-- BEFORE the fix (reset leaves cache intact): the regression test fails --
x rebuilds the client after setFeishuClientRuntimeForTest replaces the SDK
AssertionError: expected 1 to be 2
Tests  1 failed | 15 passed (16)
-- AFTER the fix (reset clears the cache): the regression test passes --

rebuilds the client after setFeishuClientRuntimeForTest replaces the SDK
Tests  16 passed (16)


Observed result after fix: before the fix the second `createFeishuClient` hits the stale cache, so the client constructor is called only once and the same client object is returned; after the fix the cache is cleared on SDK swap, so the constructor runs again (called twice) and a new client object is returned. The full client suite (16 tests) passes.

What was not tested: no live Feishu/Lark account was used; the client factory and cache behavior are exercised through the real module under vitest with the Lark SDK constructor mocked, and the before/after comparison shows the regression test captures the exact stale-cache defect.
