### PR TITLE
fix(google): stop forcing preview suffix for gemini-3.1-flash-lite GA release

### DIFF
--- a/extensions/google/model-id.test.ts
+++ b/extensions/google/model-id.test.ts
@@ -36,7 +36,8 @@ describe("google model id helpers", () => {
     );
   });
 
-  it("adds the preview suffix for gemini 3.1 flash-lite", () => {
-    expect(normalizeGoogleModelId("gemini-3.1-flash-lite")).toBe("gemini-3.1-flash-lite-preview");
+  it("keeps gemini 3.1 flash-lite as-is (GA release, May 2026)", () => {
+    expect(normalizeGoogleModelId("gemini-3.1-flash-lite")).toBe("gemini-3.1-flash-lite");
+    expect(normalizeGoogleModelId("gemini-3.1-flash-lite-preview")).toBe("gemini-3.1-flash-lite-preview");
   });
 });

--- a/extensions/google/model-id.ts
+++ b/extensions/google/model-id.ts
@@ -18,7 +18,10 @@ export function normalizeGoogleModelId(id: string): string {
   if (id === "gemini-3.1-pro") {
     return "gemini-3.1-pro-preview";
   }
-  if (id === "gemini-3.1-flash-lite") {
+  // Google GA'd gemini-3.1-flash-lite in May 2026; the GA model no longer
+  // requires the -preview suffix. Keep the preview alias for users who
+  // explicitly target the older preview endpoint.
+  if (id === "gemini-3.1-flash-lite-preview") {
     return "gemini-3.1-flash-lite-preview";
   }
   if (id === "gemini-3.1-flash" || id === "gemini-3.1-flash-preview") {

--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -14,7 +14,6 @@
           "gemini-3-pro-preview": "gemini-3.1-pro-preview",
           "gemini-3-flash": "gemini-3-flash-preview",
           "gemini-3.1-pro": "gemini-3.1-pro-preview",
-          "gemini-3.1-flash-lite": "gemini-3.1-flash-lite-preview",
           "gemini-3.1-flash": "gemini-3-flash-preview",
           "gemini-3.1-flash-preview": "gemini-3-flash-preview"
         }
@@ -25,7 +24,6 @@
           "gemini-3-pro-preview": "gemini-3.1-pro-preview",
           "gemini-3-flash": "gemini-3-flash-preview",
           "gemini-3.1-pro": "gemini-3.1-pro-preview",
-          "gemini-3.1-flash-lite": "gemini-3.1-flash-lite-preview",
           "gemini-3.1-flash": "gemini-3-flash-preview",
           "gemini-3.1-flash-preview": "gemini-3-flash-preview"
         }
@@ -36,7 +34,6 @@
           "gemini-3-pro-preview": "gemini-3.1-pro-preview",
           "gemini-3-flash": "gemini-3-flash-preview",
           "gemini-3.1-pro": "gemini-3.1-pro-preview",
-          "gemini-3.1-flash-lite": "gemini-3.1-flash-lite-preview",
           "gemini-3.1-flash": "gemini-3-flash-preview",
           "gemini-3.1-flash-preview": "gemini-3-flash-preview"
         }


### PR DESCRIPTION
## Summary

Stops forcing the `-preview` suffix for `gemini-3.1-flash-lite` since Google GA'd the model in May 2026.

## Problem

OpenClaw hardcodes `gemini-3.1-flash-lite` → `gemini-3.1-flash-lite-preview`, redirecting users who configure the GA model to the older preview endpoint.

## Fix

| File | Changes |
|------|---------|
| `extensions/google/model-id.ts` | Remove forced preview mapping; keep explicit `-preview` alias passthrough |
| `extensions/google/model-id.test.ts` | Update test to expect GA name unchanged |
| `extensions/google/openclaw.plugin.json` | Remove alias mapping from all 3 providers (google, google-gemini-cli, google-vertex) |

Users who explicitly want the older preview endpoint can still use `gemini-3.1-flash-lite-preview`.

Fixes: #86151