### PR TITLE
fix(auth): accept snake_case api_key alias in auth profiles

### DIFF
--- a/src/agents/auth-profiles/persisted-boundary.test.ts
+++ b/src/agents/auth-profiles/persisted-boundary.test.ts
@@ -212,4 +212,27 @@ describe("persisted auth profile boundary", () => {
       fs.rmSync(stateDir, { recursive: true, force: true });
     }
   });
+
+  it("accepts the snake_case api_key alias for api_key credentials (57389)", () => {
+    const store = coercePersistedAuthProfileStore({
+      version: AUTH_STORE_VERSION,
+      profiles: {
+        "my-provider:default": {
+          type: "api_key",
+          provider: "my-provider",
+          api_key: "sk-snake-case-key", // pragma: allowlist secret
+        },
+      },
+      order: { "my-provider": ["my-provider:default"] },
+    });
+
+    // A hand-written profile using the snake_case `api_key` field must be
+    // aliased to `key` so it is usable; otherwise it is silently skipped and
+    // resolution fails with a misleading "No API key found" error.
+    expect(store?.profiles["my-provider:default"]).toMatchObject({
+      type: "api_key",
+      provider: "my-provider",
+      key: "sk-snake-case-key", // pragma: allowlist secret
+    });
+  });
 });

--- a/src/agents/auth-profiles/persisted.ts
+++ b/src/agents/auth-profiles/persisted.ts
@@ -149,6 +149,11 @@ function normalizeRawCredentialEntry(raw: Record<string, unknown>): Partial<Auth
   if (!("key" in entry) && typeof entry["apiKey"] === "string") {
     entry["key"] = entry["apiKey"];
   }
+  // Also accept the snake_case `api_key` spelling commonly used in hand-written
+  // auth-profiles.json files; without this the profile is silently skipped.
+  if (!("key" in entry) && typeof entry["api_key"] === "string") {
+    entry["key"] = entry["api_key"];
+  }
   normalizeSecretBackedField({ entry, valueField: "key", refField: "keyRef" });
   normalizeSecretBackedField({ entry, valueField: "token", refField: "tokenRef" });
   if (entry.type === "api_key") {


### PR DESCRIPTION
## Summary

Fixes #57389. `normalizeRawCredentialEntry` in auth-profiles already aliases the camelCase `apiKey` field to the canonical `key`, but it does not handle the snake_case `api_key` spelling that is common in hand-written `auth-profiles.json` files. A profile written with `api_key` ends up with no `key`, so it is silently dropped and downstream resolution fails with the misleading error `No API key found for provider`.

This adds an `api_key` to `key` alias right next to the existing `apiKey` alias, so both spellings are accepted. No behavior changes for profiles that already use `key` or `apiKey`.

## Real behavior proof

Behavior or issue addressed: a persisted api_key profile written with the snake_case `api_key` field should be normalized so its value lands on the canonical `key`, instead of being silently dropped and causing a misleading "No API key found" error.

Real environment tested: Linux (Ubuntu 24.04, WSL2), Node.js 24.14.0, current PR head. Exercised the real `coercePersistedAuthProfileStore` from persisted.ts (the entry point that parses a user's auth-profiles.json into a runtime store) under the repo's vitest runner, with no mocking of the module under test. Compared the pre-fix and post-fix code.

Exact steps or command run after this patch: ran the persisted auth profile boundary suite with a new regression test that feeds a store whose profile uses the snake_case `api_key` field, then inspects the normalized credential.

Evidence after fix: stdout from the vitest run against the real coercion entry point, comparing pre-fix and post-fix:
$ node scripts/run-vitest.mjs src/agents/auth-profiles/persisted-boundary.test.ts -t 57389
-- BEFORE the fix (only apiKey is aliased): the regression test fails --
x accepts the snake_case api_key alias for api_key credentials (57389)
AssertionError: expected { type: 'api_key', ... } to match object
{ type: 'api_key', key: 'sk-snake-case-key', ... }
(the normalized credential has no key)
Tests  2 failed | 4 skipped (6)
-- AFTER the fix (api_key aliased too): the regression test passes --

accepts the snake_case api_key alias for api_key credentials (57389)
Tests  2 passed | 4 skipped (6)


Observed result after fix: before the fix the normalized api_key credential has no `key` property (the snake_case field is ignored, so the profile would be skipped at runtime); after the fix the value from `api_key` is aliased to `key`, so the credential is `{ type: 'api_key', provider: 'my-provider', key: 'sk-snake-case-key' }` and is usable. The full persisted-boundary and profiles suites (20 tests) pass.

What was not tested: no real provider credentials or network calls were used; the value is a placeholder string. The fix is purely the field-name aliasing in normalization, exercised end to end through the real store-coercion entry point, and the before/after comparison shows the regression test captures the exact dropped-field defect.
