### PR TITLE
fix(edit): show best matching region on mismatch instead of raw file head

### DIFF
--- a/src/agents/pi-tools.host-edit.ts
+++ b/src/agents/pi-tools.host-edit.ts
@@ -132,12 +132,103 @@ function shouldAddMismatchHint(error: unknown) {
   return error instanceof Error && error.message.includes(EDIT_MISMATCH_MESSAGE);
 }
 
-function appendMismatchHint(error: Error, currentContent: string): Error {
-  const snippet =
-    currentContent.length <= EDIT_MISMATCH_HINT_LIMIT
-      ? currentContent
-      : `${currentContent.slice(0, EDIT_MISMATCH_HINT_LIMIT)}\n... (truncated)`;
-  const enhanced = new Error(`${error.message}\nCurrent file contents:\n${snippet}`);
+/**
+ * Count shared leading lines between two strings (case-sensitive, whitespace-exact).
+ */
+function countSharedLines(a: string, b: string): number {
+  const aLines = a.split("\n");
+  const bLines = b.split("\n");
+  let shared = 0;
+  const limit = Math.min(aLines.length, bLines.length);
+  for (let i = 0; i < limit; i++) {
+    if (aLines[i] === bLines[i]) {
+      shared++;
+    } else {
+      break;
+    }
+  }
+  return shared;
+}
+
+/**
+ * Find the file region most similar to `needle` using a line-based sliding
+ * window.  Returns the best-matching region with line numbers so the model
+ * can see *where* its oldText diverged.
+ */
+function findBestMatchRegion(
+  content: string,
+  needle: string,
+  maxLen: number,
+): { snippet: string; startLine: number } | undefined {
+  if (content.length === 0 || needle.length === 0) {
+    return undefined;
+  }
+  const contentLines = content.split("\n");
+  const needleLines = needle.split("\n");
+  const windowSize = needleLines.length;
+
+  let bestScore = 0;
+  let bestStart = 0;
+
+  for (let i = 0; i <= contentLines.length - windowSize; i++) {
+    const candidate = contentLines.slice(i, i + windowSize).join("\n");
+    const score = countSharedLines(candidate, needle);
+    if (score > bestScore) {
+      bestScore = score;
+      bestStart = i;
+    }
+  }
+
+  // No meaningful match — fall back to undefined so caller uses full file head
+  if (bestScore === 0) {
+    return undefined;
+  }
+
+  // Add a small context margin (2 lines above/below)
+  const ctxBefore = Math.max(0, bestStart - 2);
+  const ctxAfter = Math.min(contentLines.length, bestStart + windowSize + 2);
+  let snippet = contentLines
+    .slice(ctxBefore, ctxAfter)
+    .map((line, idx) => `${ctxBefore + idx + 1} | ${line}`)
+    .join("\n");
+  if (snippet.length > maxLen) {
+    snippet = `${snippet.slice(0, maxLen)}\n... (truncated)`;
+  }
+  return { snippet, startLine: ctxBefore + 1 };
+}
+
+function appendMismatchHint(
+  error: Error,
+  currentContent: string,
+  edits: EditReplacement[],
+): Error {
+  const failedEdit = edits.find(
+    (e) => !normalizeToLF(currentContent).includes(normalizeToLF(e.oldText)),
+  );
+
+  // Try to locate the closest region to the failed oldText
+  const bestRegion =
+    failedEdit &&
+    findBestMatchRegion(
+      normalizeToLF(currentContent),
+      normalizeToLF(failedEdit.oldText),
+      EDIT_MISMATCH_HINT_LIMIT,
+    );
+
+  let hint: string;
+  if (bestRegion) {
+    hint =
+      `Best matching region (lines ${bestRegion.startLine}+):\n` +
+      bestRegion.snippet;
+  } else {
+    const snippet =
+      currentContent.length <= EDIT_MISMATCH_HINT_LIMIT
+        ? currentContent
+        : `${currentContent.slice(0, EDIT_MISMATCH_HINT_LIMIT)}\n... (truncated)`;
+    hint = `Current file contents:\n${snippet}`;
+  }
+
+  const enhanced = new Error(`${error.message}\n${hint}`);
   enhanced.stack = error.stack;
   return enhanced;
 }
@@ -203,7 +294,7 @@ export function wrapEditToolWithRecovery(
           err instanceof Error &&
           shouldAddMismatchHint(err)
         ) {
-          throw appendMismatchHint(err, currentContent);
+          throw appendMismatchHint(err, currentContent, edits);
         }
 
         throw err;

--- a/src/agents/pi-tools.read.host-edit-recovery.test.ts
+++ b/src/agents/pi-tools.read.host-edit-recovery.test.ts
@@ -126,6 +126,41 @@ describe("edit tool recovery hardening", () => {
     ).rejects.toThrow(/Current file contents:\nactual current content/);
   });
 
+  it("shows the best matching region when oldText partially matches a file region", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-edit-recovery-"));
+    const filePath = path.join(tmpDir, "multi.txt");
+    const content = [
+      "line 1: header",
+      "line 2: setup",
+      "line 3: the target",
+      "line 4: more code",
+      "line 5: footer",
+    ].join("\n");
+    await fs.writeFile(filePath, content, "utf-8");
+
+    const tool = createRecoveredEditTool({
+      root: tmpDir,
+      readFile: (absolutePath) => fs.readFile(absolutePath, "utf-8"),
+      execute: async () => {
+        throw new Error(
+          "Could not find the exact text in multi.txt. The old text must match exactly including all whitespace and newlines.",
+        );
+      },
+    });
+
+    // oldText shares first line with the actual region at line 3
+    await expect(
+      tool.execute(
+        "call-best",
+        {
+          path: filePath,
+          edits: [{ oldText: "line 3: the target\nline 4: WRONG", newText: "replaced" }],
+        },
+        undefined,
+      ),
+    ).rejects.toThrow(/Best matching region/);
+  });
+
   it("recovers success after a post-write throw when CRLF output contains newText and oldText is only a substring", async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-edit-recovery-"));
     const filePath = path.join(tmpDir, "demo.txt");


### PR DESCRIPTION
## Problem

When `edit` oldText doesn't match the file contents exactly, the current error hint shows the **first 800 characters** of the file regardless of where the closest match might be. For large files this is rarely helpful — the model sees the file header and has to guess where its oldText diverged.

## Solution

Replace the raw file-head dump with a **best-matching region finder** that:

1. Slides a line-based window (same height as `oldText`) across the file
2. Scores each window by counting shared leading lines with `oldText`
3. Returns the highest-scoring region with **line numbers** and ±2 lines of context

When no region scores above zero (totally unrelated content), the behavior falls back to the existing full-file-head hint.

**Before:**
```
Could not find the exact text in config.ts.
Current file contents:
import foo from 'bar';
// ... first 800 chars of a 2000-line file
```

**After:**
```
Could not find the exact text in config.ts.
Best matching region (lines 142+):
140 |   const timeout = 30_000;
141 |   const retries = 3;
142 |   const endpoint = 'https://api.example.com';
143 |   const headers = { Authorization: token };
144 |   const body = JSON.stringify(payload);
145 |   // END config block
```

## Changes

- `src/agents/pi-tools.host-edit.ts` — Add `findBestMatchRegion()` + `countSharedLines()`; update `appendMismatchHint()` to prefer region-based hints
- `src/agents/pi-tools.read.host-edit-recovery.test.ts` — Add test for best-match region behavior

## Tests

All 18 existing + new host-edit-recovery tests pass.

Supersedes #56857 and #42265 (combined approach, fresh implementation on current main).