### PR TITLE
fix(google): keep gemini-3.1-flash-lite on the GA model

### DIFF
--- a/extensions/google/api.test.ts
+++ b/extensions/google/api.test.ts
@@ -106,7 +106,7 @@ describe("google generative ai helpers", () => {
     });
   });
 
-  it("normalizes google-vertex model ids without rewriting the OpenAI-compatible baseUrl", () => {
+  it("keeps stable google-vertex model ids without rewriting the OpenAI-compatible baseUrl", () => {
     expect(
       normalizeGoogleProviderConfig("google-vertex", {
         api: "openai-completions",
@@ -132,7 +132,7 @@ describe("google generative ai helpers", () => {
         {
           contextWindow: 1,
           cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-          id: "gemini-3.1-flash-lite-preview",
+          id: "gemini-3.1-flash-lite",
           input: ["text"],
           maxTokens: 1,
           name: "Gemini Flash Lite",

--- a/extensions/google/cli-backend.ts
+++ b/extensions/google/cli-backend.ts
@@ -7,7 +7,7 @@ import {
 const GEMINI_MODEL_ALIASES: Record<string, string> = {
   pro: "gemini-3.1-pro-preview",
   flash: "gemini-3.1-flash-preview",
-  "flash-lite": "gemini-3.1-flash-lite-preview",
+  "flash-lite": "gemini-3.1-flash-lite",
 };
 const GEMINI_CLI_DEFAULT_MODEL_REF = "google-gemini-cli/gemini-3-flash-preview";
 

--- a/extensions/google/model-id.test.ts
+++ b/extensions/google/model-id.test.ts
@@ -36,7 +36,8 @@ describe("google model id helpers", () => {
     );
   });
 
-  it("adds the preview suffix for gemini 3.1 flash-lite", () => {
-    expect(normalizeGoogleModelId("gemini-3.1-flash-lite")).toBe("gemini-3.1-flash-lite-preview");
+  it("keeps Gemini 3.1 flash-lite on the GA id and migrates the retired preview id", () => {
+    expect(normalizeGoogleModelId("gemini-3.1-flash-lite")).toBe("gemini-3.1-flash-lite");
+    expect(normalizeGoogleModelId("gemini-3.1-flash-lite-preview")).toBe("gemini-3.1-flash-lite");
   });
 });

--- a/extensions/google/model-id.ts
+++ b/extensions/google/model-id.ts
@@ -18,8 +18,8 @@ export function normalizeGoogleModelId(id: string): string {
   if (id === "gemini-3.1-pro") {
     return "gemini-3.1-pro-preview";
   }
-  if (id === "gemini-3.1-flash-lite") {
-    return "gemini-3.1-flash-lite-preview";
+  if (id === "gemini-3.1-flash-lite-preview") {
+    return "gemini-3.1-flash-lite";
   }
   if (id === "gemini-3.1-flash" || id === "gemini-3.1-flash-preview") {
     return "gemini-3-flash-preview";

--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -14,7 +14,7 @@
           "gemini-3-pro-preview": "gemini-3.1-pro-preview",
           "gemini-3-flash": "gemini-3-flash-preview",
           "gemini-3.1-pro": "gemini-3.1-pro-preview",
-          "gemini-3.1-flash-lite": "gemini-3.1-flash-lite-preview",
+          "gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite",
           "gemini-3.1-flash": "gemini-3-flash-preview",
           "gemini-3.1-flash-preview": "gemini-3-flash-preview"
         }
@@ -25,7 +25,7 @@
           "gemini-3-pro-preview": "gemini-3.1-pro-preview",
           "gemini-3-flash": "gemini-3-flash-preview",
           "gemini-3.1-pro": "gemini-3.1-pro-preview",
-          "gemini-3.1-flash-lite": "gemini-3.1-flash-lite-preview",
+          "gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite",
           "gemini-3.1-flash": "gemini-3-flash-preview",
           "gemini-3.1-flash-preview": "gemini-3-flash-preview"
         }
@@ -36,7 +36,7 @@
           "gemini-3-pro-preview": "gemini-3.1-pro-preview",
           "gemini-3-flash": "gemini-3-flash-preview",
           "gemini-3.1-pro": "gemini-3.1-pro-preview",
-          "gemini-3.1-flash-lite": "gemini-3.1-flash-lite-preview",
+          "gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite",
           "gemini-3.1-flash": "gemini-3-flash-preview",
           "gemini-3.1-flash-preview": "gemini-3-flash-preview"
         }
@@ -133,12 +133,12 @@
       {
         "provider": "google",
         "model": "gemini-2.5-flash-lite-preview-09-25",
-        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google/gemini-3.1-flash-lite-preview."
+        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google/gemini-3.1-flash-lite."
       },
       {
         "provider": "google",
         "model": "gemini-2.5-flash-lite-preview-09-2025",
-        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google/gemini-3.1-flash-lite-preview."
+        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google/gemini-3.1-flash-lite."
       },
       {
         "provider": "google",
@@ -298,12 +298,12 @@
       {
         "provider": "google-gemini-cli",
         "model": "gemini-2.5-flash-lite-preview-09-25",
-        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google-gemini-cli/gemini-3.1-flash-lite-preview."
+        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google-gemini-cli/gemini-3.1-flash-lite."
       },
       {
         "provider": "google-gemini-cli",
         "model": "gemini-2.5-flash-lite-preview-09-2025",
-        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google-gemini-cli/gemini-3.1-flash-lite-preview."
+        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google-gemini-cli/gemini-3.1-flash-lite."
       },
       {
         "provider": "google-gemini-cli",
@@ -463,12 +463,12 @@
       {
         "provider": "google-vertex",
         "model": "gemini-2.5-flash-lite-preview-09-25",
-        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google-vertex/gemini-3.1-flash-lite-preview."
+        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google-vertex/gemini-3.1-flash-lite."
       },
       {
         "provider": "google-vertex",
         "model": "gemini-2.5-flash-lite-preview-09-2025",
-        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google-vertex/gemini-3.1-flash-lite-preview."
+        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google-vertex/gemini-3.1-flash-lite."
       },
       {
         "provider": "google-vertex",

--- a/extensions/google/provider-models.test.ts
+++ b/extensions/google/provider-models.test.ts
@@ -286,7 +286,7 @@ describe("resolveGoogleGeminiForwardCompatModel", () => {
     const models = [
       createTemplateModel("google", "gemini-3-pro-preview", { reasoning: true }),
       createTemplateModel("google", "gemini-3-flash-preview", { reasoning: true }),
-      createTemplateModel("google", "gemini-3.1-flash-lite-preview", { reasoning: true }),
+      createTemplateModel("google", "gemini-3.1-flash-lite", { reasoning: true }),
     ];
 
     expectModelFields(
@@ -409,13 +409,13 @@ describe("resolveGoogleGeminiForwardCompatModel", () => {
         providerId: "google-antigravity",
         ctx: createContext({
           provider: "google-antigravity",
-          modelId: "gemini-3.1-flash-lite-preview",
+          modelId: "gemini-3.1-flash-lite",
           models,
         }),
       }),
       {
         provider: "google-antigravity",
-        id: "gemini-3.1-flash-lite-preview",
+        id: "gemini-3.1-flash-lite",
         api: "openai-completions",
         contextWindow: 1_048_576,
       },
@@ -440,12 +440,12 @@ describe("resolveGoogleGeminiForwardCompatModel", () => {
       providerId: "google-vertex",
       ctx: createContext({
         provider: "google-vertex",
-        modelId: "gemini-3.1-flash-lite-preview",
+        modelId: "gemini-3.1-flash-lite",
         models: [
           createTemplateModel("google-gemini-cli", "gemini-3-flash-preview", {
             contextWindow: 128_000,
           }),
-          createTemplateModel("google-gemini-cli", "gemini-3.1-flash-lite-preview", {
+          createTemplateModel("google-gemini-cli", "gemini-3.1-flash-lite", {
             contextWindow: 1_048_576,
           }),
         ],
@@ -454,7 +454,7 @@ describe("resolveGoogleGeminiForwardCompatModel", () => {
 
     expectModelFields(model, {
       provider: "google-vertex",
-      id: "gemini-3.1-flash-lite-preview",
+      id: "gemini-3.1-flash-lite",
       contextWindow: 1_048_576,
       reasoning: false,
     });

--- a/extensions/google/provider-models.ts
+++ b/extensions/google/provider-models.ts
@@ -23,7 +23,10 @@ const GEMINI_2_5_PRO_TEMPLATE_IDS = ["gemini-2.5-pro"] as const;
 const GEMINI_2_5_FLASH_LITE_TEMPLATE_IDS = ["gemini-2.5-flash-lite"] as const;
 const GEMINI_2_5_FLASH_TEMPLATE_IDS = ["gemini-2.5-flash"] as const;
 const GEMINI_3_1_PRO_TEMPLATE_IDS = ["gemini-3.1-pro-preview", "gemini-3-pro-preview"] as const;
-const GEMINI_3_1_FLASH_LITE_TEMPLATE_IDS = ["gemini-3.1-flash-lite-preview"] as const;
+const GEMINI_3_1_FLASH_LITE_TEMPLATE_IDS = [
+  "gemini-3.1-flash-lite",
+  "gemini-3.1-flash-lite-preview",
+] as const;
 const GEMINI_3_1_FLASH_TEMPLATE_IDS = ["gemini-3-flash-preview", "gemini-2.5-flash"] as const;
 const GEMINI_3_PRO_ANTIGRAVITY_TEMPLATE_IDS = ["gemini-3-pro-low", "gemini-3-pro-high"] as const;
 const GEMINI_3_FLASH_ANTIGRAVITY_TEMPLATE_IDS = ["gemini-3-flash"] as const;

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -48,7 +48,7 @@ const manifestNormalizationSnapshot = vi.hoisted(() => ({
               "gemini-3-pro": "gemini-3.1-pro-preview",
               "gemini-3-flash": "gemini-3-flash-preview",
               "gemini-3.1-pro": "gemini-3.1-pro-preview",
-              "gemini-3.1-flash-lite": "gemini-3.1-flash-lite-preview",
+              "gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite",
               "gemini-3.1-flash": "gemini-3-flash-preview",
               "gemini-3.1-flash-preview": "gemini-3-flash-preview",
             },
@@ -58,7 +58,7 @@ const manifestNormalizationSnapshot = vi.hoisted(() => ({
               "gemini-3-pro": "gemini-3.1-pro-preview",
               "gemini-3-flash": "gemini-3-flash-preview",
               "gemini-3.1-pro": "gemini-3.1-pro-preview",
-              "gemini-3.1-flash-lite": "gemini-3.1-flash-lite-preview",
+              "gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite",
               "gemini-3.1-flash": "gemini-3-flash-preview",
               "gemini-3.1-flash-preview": "gemini-3-flash-preview",
             },
@@ -330,10 +330,15 @@ describe("model-selection", () => {
         expected: { provider: "google-gemini-cli", model: "gemini-3.1-pro-preview" },
       },
       {
-        name: "normalizes gemini 3.1 flash-lite ids",
-        variants: ["google/gemini-3.1-flash-lite", "gemini-3.1-flash-lite"],
+        name: "keeps Gemini 3.1 flash-lite stable and migrates the retired preview id",
+        variants: [
+          "google/gemini-3.1-flash-lite",
+          "google/gemini-3.1-flash-lite-preview",
+          "gemini-3.1-flash-lite",
+          "gemini-3.1-flash-lite-preview",
+        ],
         defaultProvider: "google",
-        expected: { provider: "google", model: "gemini-3.1-flash-lite-preview" },
+        expected: { provider: "google", model: "gemini-3.1-flash-lite" },
       },
       {
         name: "normalizes deprecated xai grok 4.20 beta ids",
@@ -405,10 +410,15 @@ describe("model-selection", () => {
         expected: { provider: "openai", model: "gpt-5.4-codex-codex" },
       },
       {
-        name: "normalizes gemini 3.1 flash-lite ids for google-vertex",
-        variants: ["google-vertex/gemini-3.1-flash-lite", "gemini-3.1-flash-lite"],
+        name: "keeps Gemini 3.1 flash-lite stable for google-vertex and migrates the retired preview id",
+        variants: [
+          "google-vertex/gemini-3.1-flash-lite",
+          "google-vertex/gemini-3.1-flash-lite-preview",
+          "gemini-3.1-flash-lite",
+          "gemini-3.1-flash-lite-preview",
+        ],
         defaultProvider: "google-vertex",
-        expected: { provider: "google-vertex", model: "gemini-3.1-flash-lite-preview" },
+        expected: { provider: "google-vertex", model: "gemini-3.1-flash-lite" },
       },
       {
         name: "normalizes anthropic-cli refs to the Claude CLI provider alias",
@@ -1784,7 +1794,7 @@ describe("model-selection", () => {
 
       expect(result).toEqual({
         provider: "google-vertex",
-        model: "gemini-3.1-flash-lite-preview",
+        model: "gemini-3.1-flash-lite",
       });
     });
 

--- a/src/agents/models-config.providers.google-antigravity.test.ts
+++ b/src/agents/models-config.providers.google-antigravity.test.ts
@@ -7,8 +7,8 @@ vi.mock("../plugins/provider-runtime.js", () => {
     if (provider === "google-antigravity") {
       return /^(gemini-3(?:[.-]1)?-pro)$/.test(modelId) ? `${modelId}-low` : modelId;
     }
-    if (provider === "google-vertex" && modelId === "gemini-3.1-flash-lite") {
-      return "gemini-3.1-flash-lite-preview";
+    if (provider === "google-vertex" && modelId === "gemini-3.1-flash-lite-preview") {
+      return "gemini-3.1-flash-lite";
     }
     return modelId;
   }
@@ -113,9 +113,9 @@ describe("google-antigravity provider normalization", () => {
 });
 
 describe("google-vertex provider normalization", () => {
-  it("normalizes gemini flash-lite IDs for google-vertex providers", () => {
+  it("normalizes retired gemini flash-lite preview IDs for google-vertex providers", () => {
     const providers = {
-      "google-vertex": buildProvider(["gemini-3.1-flash-lite", "gemini-3-flash-preview"], {
+      "google-vertex": buildProvider(["gemini-3.1-flash-lite-preview", "gemini-3-flash-preview"], {
         api: undefined,
       }),
       openai: buildProvider(["gpt-5"]),
@@ -125,7 +125,7 @@ describe("google-vertex provider normalization", () => {
 
     expect(normalized).not.toBe(providers);
     expect(normalized?.["google-vertex"]?.models.map((model) => model.id)).toEqual([
-      "gemini-3.1-flash-lite-preview",
+      "gemini-3.1-flash-lite",
       "gemini-3-flash-preview",
     ]);
     expect(normalized?.openai).toBe(providers.openai);
@@ -133,7 +133,7 @@ describe("google-vertex provider normalization", () => {
 
   it("returns original providers object when no google-vertex IDs need normalization", () => {
     const providers = {
-      "google-vertex": buildProvider(["gemini-3.1-flash-lite-preview", "gemini-3-flash-preview"], {
+      "google-vertex": buildProvider(["gemini-3.1-flash-lite", "gemini-3-flash-preview"], {
         api: undefined,
       }),
     };

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -33,10 +33,10 @@ const DEFAULT_MODEL_ALIASES: Readonly<Record<string, string>> = {
   "gpt-mini": "openai/gpt-5.4-mini",
   "gpt-nano": "openai/gpt-5.4-nano",
 
-  // Google Gemini (3.x are preview ids in the catalog)
+  // Google Gemini (3 Pro/Flash stay preview ids in the catalog; Flash-Lite is GA)
   gemini: "google/gemini-3.1-pro-preview",
   "gemini-flash": "google/gemini-3-flash-preview",
-  "gemini-flash-lite": "google/gemini-3.1-flash-lite-preview",
+  "gemini-flash-lite": "google/gemini-3.1-flash-lite",
 };
 
 const DEFAULT_MODEL_COST: ModelDefinitionConfig["cost"] = {

--- a/src/config/model-alias-defaults.test.ts
+++ b/src/config/model-alias-defaults.test.ts
@@ -110,7 +110,7 @@ describe("applyModelDefaults", () => {
           models: {
             "google/gemini-3.1-pro-preview": { alias: "" },
             "google/gemini-3-flash-preview": {},
-            "google/gemini-3.1-flash-lite-preview": {},
+            "google/gemini-3.1-flash-lite": {},
           },
         },
       },
@@ -122,7 +122,7 @@ describe("applyModelDefaults", () => {
     expect(next.agents?.defaults?.models?.["google/gemini-3-flash-preview"]?.alias).toBe(
       "gemini-flash",
     );
-    expect(next.agents?.defaults?.models?.["google/gemini-3.1-flash-lite-preview"]?.alias).toBe(
+    expect(next.agents?.defaults?.models?.["google/gemini-3.1-flash-lite"]?.alias).toBe(
       "gemini-flash-lite",
     );
   });

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -94,7 +94,7 @@ const GATEWAY_LIVE_HEARTBEAT_MS = Math.max(
 );
 const GATEWAY_LIVE_STRIP_SCAFFOLDING_MODEL_KEYS = new Set([
   "google/gemini-3-flash-preview",
-  "google/gemini-3.1-flash-lite-preview",
+  "google/gemini-3.1-flash-lite",
   "google/gemini-3.1-pro-preview",
   "google/gemini-3.1-pro-preview-customtools",
   "openai/gpt-5.4-pro",
@@ -104,7 +104,7 @@ const GATEWAY_LIVE_EXEC_READ_NONCE_MISS_SKIP_MODEL_KEYS = new Set([
   "fireworks/accounts/fireworks/models/kimi-k2p5",
   "fireworks/accounts/fireworks/models/kimi-k2p6",
   "fireworks/accounts/fireworks/routers/kimi-k2p5-turbo",
-  "google/gemini-3.1-flash-lite-preview",
+  "google/gemini-3.1-flash-lite",
 ]);
 const GATEWAY_LIVE_TOOL_NONCE_MISS_SKIP_MODEL_KEYS = new Set([
   "google/gemini-3-flash-preview",
@@ -265,7 +265,11 @@ function assertGatewayLiveDidNotSkipAllDueToTimeout(params: {
   timeoutSkippedCount: number;
   total: number;
 }): void {
-  if (params.total === 0 || params.skippedCount !== params.total || params.timeoutSkippedCount === 0) {
+  if (
+    params.total === 0 ||
+    params.skippedCount !== params.total ||
+    params.timeoutSkippedCount === 0
+  ) {
     return;
   }
   throw new Error(

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -1108,10 +1108,10 @@ describe("describeImageWithModel", () => {
   it("normalizes gemini 3.1 flash-lite ids before lookup and keeps profile auth selection", async () => {
     const findMock = vi.fn((provider: string, modelId: string) => {
       expect(provider).toBe("google");
-      expect(modelId).toBe("gemini-3.1-flash-lite-preview");
+      expect(modelId).toBe("gemini-3.1-flash-lite");
       return {
         provider: "google",
-        id: "gemini-3.1-flash-lite-preview",
+        id: "gemini-3.1-flash-lite",
         input: ["text", "image"],
         baseUrl: "https://generativelanguage.googleapis.com/v1beta",
       };
@@ -1121,7 +1121,7 @@ describe("describeImageWithModel", () => {
       role: "assistant",
       api: "google-generative-ai",
       provider: "google",
-      model: "gemini-3.1-flash-lite-preview",
+      model: "gemini-3.1-flash-lite",
       stopReason: "stop",
       timestamp: Date.now(),
       content: [{ type: "text", text: "flash lite ok" }],
@@ -1142,7 +1142,7 @@ describe("describeImageWithModel", () => {
 
     expect(result).toEqual({
       text: "flash lite ok",
-      model: "gemini-3.1-flash-lite-preview",
+      model: "gemini-3.1-flash-lite",
     });
     expect(findMock).toHaveBeenCalled();
     const authRequest = getApiKeyForModelCall();

--- a/src/plugin-sdk/provider-model-id-normalize.test.ts
+++ b/src/plugin-sdk/provider-model-id-normalize.test.ts
@@ -17,5 +17,15 @@ describe("provider model id normalization", () => {
   it("does not rewrite already-current Gemini replacement ids", () => {
     expect(normalizeGooglePreviewModelId("gemini-3.1-pro-preview")).toBe("gemini-3.1-pro-preview");
     expect(normalizeGooglePreviewModelId("gemini-2.5-flash")).toBe("gemini-2.5-flash");
+    expect(normalizeGooglePreviewModelId("gemini-3.1-flash-lite")).toBe("gemini-3.1-flash-lite");
+  });
+
+  it("migrates the retired Gemini 3.1 flash-lite preview id to the GA model", () => {
+    expect(normalizeGooglePreviewModelId("gemini-3.1-flash-lite-preview")).toBe(
+      "gemini-3.1-flash-lite",
+    );
+    expect(normalizeGooglePreviewModelId("google/gemini-3.1-flash-lite-preview")).toBe(
+      "google/gemini-3.1-flash-lite",
+    );
   });
 });

--- a/src/plugin-sdk/provider-model-id-normalize.ts
+++ b/src/plugin-sdk/provider-model-id-normalize.ts
@@ -16,8 +16,8 @@ export function normalizeGooglePreviewModelId(id: string): string {
   if (id === "gemini-3.1-pro") {
     return "gemini-3.1-pro-preview";
   }
-  if (id === "gemini-3.1-flash-lite") {
-    return "gemini-3.1-flash-lite-preview";
+  if (id === "gemini-3.1-flash-lite-preview") {
+    return "gemini-3.1-flash-lite";
   }
   if (id === "gemini-3.1-flash" || id === "gemini-3.1-flash-preview") {
     return "gemini-3-flash-preview";

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -1151,7 +1151,7 @@ describe("provider-runtime", () => {
         label: "Google",
         hookAliases: ["google-vertex"],
         auth: [],
-        normalizeModelId: ({ modelId }) => modelId.replace("flash-lite", "flash-lite-preview"),
+        normalizeModelId: ({ modelId }) => modelId.replace("flash-lite-preview", "flash-lite"),
       },
     ]);
 
@@ -1160,10 +1160,10 @@ describe("provider-runtime", () => {
         provider: "google-vertex",
         context: {
           provider: "google-vertex",
-          modelId: "gemini-3.1-flash-lite",
+          modelId: "gemini-3.1-flash-lite-preview",
         },
       }),
-    ).toBe("gemini-3.1-flash-lite-preview");
+    ).toBe("gemini-3.1-flash-lite");
     expect(resolvePluginProvidersMock).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Summary

- Stop rewriting the GA Google Flash-Lite id `gemini-3.1-flash-lite` to the retired preview id across Google model normalization, manifest aliases, CLI shorthands, and default aliases.
- Migrate the legacy preview id `gemini-3.1-flash-lite-preview` back to the GA id so older configs still land on the live model.
- Prefer the stable Flash-Lite template row first, while still allowing forward-compat fallback from an older preview template when that is the only row available.
- Update focused regression coverage for model selection, provider config normalization, media-understanding lookup, and live-profile helper behavior.

This matters now because Google made `gemini-3.1-flash-lite` the GA model on May 7, 2026, and scheduled `gemini-3.1-flash-lite-preview` to shut down on May 25, 2026.

The intended outcome is that `/model google/gemini-3.1-flash-lite`, config aliases, and legacy preview inputs all resolve to `gemini-3.1-flash-lite` instead of the retired preview endpoint.

Out of scope: changing unrelated Gemini 3 Pro / Flash preview alias behavior, or adding live-provider / Discord-specific workflow changes.

Success looks like stable Flash-Lite staying stable, legacy preview refs migrating to the stable id, and the focused Google regression suite passing.

Reviewers should focus on the Google model-id normalization path, manifest alias direction, and the Flash-Lite template preference order.

## Linked context

Closes #86151

Related #86151

Requested by a maintainer in issue follow-up through Codex branch/PR work.

## Real behavior proof (required for external PRs)

Behavior addressed: OpenClaw was rewriting `google/gemini-3.1-flash-lite` to the retired `google/gemini-3.1-flash-lite-preview` id instead of keeping the GA model id stable.

Real environment tested: Local OpenClaw source checkout on macOS after `pnpm build`, using the production runtime model-selection module from this patch.

Exact steps or command run after this patch:
`pnpm build`
`node --import tsx -e 'import { parseModelRef } from "./src/agents/model-selection.ts"; console.log(JSON.stringify({ stable: parseModelRef("google/gemini-3.1-flash-lite", "google"), legacy: parseModelRef("google/gemini-3.1-flash-lite-preview", "google"), vertexLegacy: parseModelRef("google-vertex/gemini-3.1-flash-lite-preview", "google-vertex") }, null, 2));'`

Evidence after fix:
```text
{
  "stable": {
    "provider": "google",
    "model": "gemini-3.1-flash-lite"
  },
  "legacy": {
    "provider": "google",
    "model": "gemini-3.1-flash-lite"
  },
  "vertexLegacy": {
    "provider": "google-vertex",
    "model": "gemini-3.1-flash-lite"
  }
}
```

Observed result after fix: The stable Google Flash-Lite ref stays on `gemini-3.1-flash-lite`, and both Google and Google Vertex legacy preview refs normalize to the GA id instead of the retired preview endpoint.

What was not tested: A live Discord `/model` slash command and a real Google provider request with credentials were not run in this environment.

Proof limitations or environment constraints: This proof uses a built local OpenClaw checkout and production runtime helpers because this Codex environment does not have the reporter's Discord workspace or Google provider credentials.

Before evidence (optional but encouraged): The issue report and pre-fix source/tests showed the stable `gemini-3.1-flash-lite` input being rewritten to `gemini-3.1-flash-lite-preview` across Google normalization and model-selection paths.

## Tests and validation

Focused commands run:
- `node scripts/run-vitest.mjs extensions/google/model-id.test.ts src/plugin-sdk/provider-model-id-normalize.test.ts extensions/google/provider-models.test.ts src/agents/model-selection.test.ts src/config/model-alias-defaults.test.ts extensions/google/api.test.ts src/agents/models-config.providers.google-antigravity.test.ts src/media-understanding/image.test.ts src/plugins/provider-runtime.test.ts src/gateway/gateway-models.profiles.live.test.ts`
- `git diff --check`
- `pnpm build`
- `GITHUB_EVENT_PATH=/tmp/openclaw-86151-pr-event.json node scripts/github/real-behavior-proof-check.mjs`

Regression coverage added or updated: focused Google normalization, provider-config, model-selection, media-understanding, and live helper assertions now lock the stable Flash-Lite id direction.

What failed before this fix, if known: the stable Flash-Lite id was normalized to `gemini-3.1-flash-lite-preview`, which matches the issue report and the pre-fix tests in this area.

If no test was added, why not: existing focused suites already covered the affected normalization surfaces, so this patch updates those regressions instead of adding a new broad harness.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)
Yes

Did config, environment, or migration behavior change? (`Yes/No`)
Yes

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)
No

What is the highest-risk area?
Google Flash-Lite alias migration across config/model-selection/catalog surfaces.

How is that risk mitigated?
The change is limited to the Google-owned normalization surfaces and is covered by focused tests for config normalization, runtime model selection, provider config, and media-understanding lookup.

## Current review state

What is the next action?
Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?
Waiting on CI and maintainer review; focused local proof, build, and PR-body proof validation are complete.

Which bot or reviewer comments were addressed?
Addressed the issue comment guidance to keep `gemini-3.1-flash-lite` on the GA id, migrate the retired preview id, and update the focused Google regression coverage.
