### PR TITLE
fix(telegram): edit media captions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram: let edit actions update media captions and reply markup on existing media messages. (#86161)
 - Channels/iMessage: advance the startup catchup cursor from live-handled rows after a completed catchup pass, including rows received while catchup is still running, so restarts do not replay them. (#85475) Thanks @TurboTheTurtle.
 - Tests: mount the shared Windows command helper into bare Docker E2E harness containers so published upgrade-survivor config walks can start on Linux.
 - Tests: let the generic plugin install E2E assertions use a configurable temp root and Windows home-relative install paths.

--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -25,6 +25,11 @@ const editMessageTelegram = vi.fn(async () => ({
   messageId: "456",
   chatId: "123",
 }));
+const editMessageReplyMarkupTelegram = vi.fn(async () => ({
+  ok: true,
+  messageId: "456",
+  chatId: "123",
+}));
 const editForumTopicTelegram = vi.fn(async () => ({
   ok: true,
   chatId: "123",
@@ -138,6 +143,7 @@ describe("handleTelegramAction", () => {
       sendStickerTelegram,
       deleteMessageTelegram,
       editMessageTelegram,
+      editMessageReplyMarkupTelegram,
       editForumTopicTelegram,
       pinMessageTelegram,
       createForumTopicTelegram,
@@ -148,6 +154,7 @@ describe("handleTelegramAction", () => {
     sendStickerTelegram.mockClear();
     deleteMessageTelegram.mockClear();
     editMessageTelegram.mockClear();
+    editMessageReplyMarkupTelegram.mockClear();
     editForumTopicTelegram.mockClear();
     pinMessageTelegram.mockClear();
     createForumTopicTelegram.mockClear();
@@ -864,6 +871,48 @@ describe("handleTelegramAction", () => {
       expect(opts.gatewayClientScopes).toEqual(["operator.write"]);
     },
   );
+
+  it("marks caption edits as media message edits", async () => {
+    await handleTelegramAction(
+      { action: "editMessage", chatId: "123", messageId: 1, caption: "updated caption" },
+      telegramConfig(),
+    );
+
+    expect(editMessageTelegram).toHaveBeenCalledWith(
+      "123",
+      1,
+      "updated caption",
+      expect.objectContaining({ media: true, token: "tok" }),
+    );
+    expect(editMessageReplyMarkupTelegram).not.toHaveBeenCalled();
+  });
+
+  it("edits reply markup without requiring text content", async () => {
+    await handleTelegramAction(
+      {
+        action: "editMessage",
+        chatId: "123",
+        messageId: 1,
+        presentation: {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [{ label: "Open", value: "https://example.com", style: "link" }],
+            },
+          ],
+        },
+      },
+      telegramConfig({ capabilities: { inlineButtons: "all" } }),
+    );
+
+    expect(editMessageTelegram).not.toHaveBeenCalled();
+    expect(editMessageReplyMarkupTelegram).toHaveBeenCalledWith(
+      "123",
+      1,
+      [[{ text: "Open", url: "https://example.com" }]],
+      expect.objectContaining({ token: "tok" }),
+    );
+  });
 
   it.each([
     {

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -30,6 +30,7 @@ import {
   createForumTopicTelegram,
   deleteMessageTelegram,
   editForumTopicTelegram,
+  editMessageReplyMarkupTelegram,
   editMessageTelegram,
   pinMessageTelegram,
   reactMessageTelegram,
@@ -45,6 +46,7 @@ export const telegramActionRuntime = {
   createForumTopicTelegram,
   deleteMessageTelegram,
   editForumTopicTelegram,
+  editMessageReplyMarkupTelegram,
   editMessageTelegram,
   getCacheStats,
   pinMessageTelegram,
@@ -603,8 +605,12 @@ export async function handleTelegramAction(
     });
     const content =
       readStringParam(params, "content", { allowEmpty: false }) ??
-      readStringParam(params, "message", { required: true, allowEmpty: false });
+      readStringParam(params, "message", { allowEmpty: false }) ??
+      readStringParam(params, "caption", { allowEmpty: false });
     const buttons = resolveTelegramButtonsFromParams(params);
+    if (content == null && buttons === undefined) {
+      throw new Error("content, message, caption, or inline buttons required.");
+    }
     if (buttons) {
       const inlineButtonsScope = resolveTelegramInlineButtonsScope({
         cfg,
@@ -622,18 +628,28 @@ export async function handleTelegramAction(
         "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
       );
     }
-    const result = await telegramActionRuntime.editMessageTelegram(
-      chatId ?? "",
-      messageId ?? 0,
-      content,
-      {
-        cfg,
-        token,
-        accountId: accountId ?? undefined,
-        buttons,
-        gatewayClientScopes: options?.gatewayClientScopes,
-      },
-    );
+    const editOptions = {
+      cfg,
+      token,
+      accountId: accountId ?? undefined,
+      buttons,
+      gatewayClientScopes: options?.gatewayClientScopes,
+    };
+    const result =
+      content == null
+        ? await telegramActionRuntime.editMessageReplyMarkupTelegram(
+            chatId ?? "",
+            messageId ?? 0,
+            buttons ?? [],
+            editOptions,
+          )
+        : await telegramActionRuntime.editMessageTelegram(chatId ?? "", messageId ?? 0, content, {
+            ...editOptions,
+            media:
+              readBooleanParam(params, "media") ??
+              readBooleanParam(params, "mediaMessage") ??
+              params.caption != null,
+          });
     return jsonResult({
       ok: true,
       messageId: result.messageId,

--- a/extensions/telegram/src/send.test-harness.ts
+++ b/extensions/telegram/src/send.test-harness.ts
@@ -14,6 +14,7 @@ const { botApi, botConfigUseSpy, botCtorSpy } = vi.hoisted(() => ({
     deleteMessage: vi.fn(),
     editForumTopic: vi.fn(),
     editMessageText: vi.fn(),
+    editMessageCaption: vi.fn(),
     editMessageReplyMarkup: vi.fn(),
     pinChatMessage: vi.fn(),
     sendChatAction: vi.fn(),

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -3096,6 +3096,50 @@ describe("editMessageTelegram", () => {
     expect(botApi.editMessageText).toHaveBeenCalledTimes(2);
   });
 
+  it("edits media captions with reply markup", async () => {
+    botApi.editMessageCaption.mockResolvedValue({ message_id: 1, chat: { id: "123" } });
+
+    await editMessageTelegram("123", 1, "caption", {
+      token: "tok",
+      cfg: {},
+      media: true,
+      buttons: [[{ text: "Open", url: "https://example.com" }]],
+    });
+
+    expect(botApi.editMessageText).not.toHaveBeenCalled();
+    expect(botApi.editMessageCaption).toHaveBeenCalledTimes(1);
+    const call = firstMockCall(botApi.editMessageCaption, "editMessageCaption call");
+    expect(call[0]).toBe("123");
+    expect(call[1]).toBe(1);
+    const params = requireRecord(call[2], "caption edit params");
+    expect(params.caption).toBe("caption");
+    expect(params.parse_mode).toBe("HTML");
+    expect(params.reply_markup).toEqual({
+      inline_keyboard: [[{ text: "Open", url: "https://example.com" }]],
+    });
+  });
+
+  it("falls back to plain media captions when Telegram rejects edited caption HTML", async () => {
+    botApi.editMessageCaption
+      .mockRejectedValueOnce(new Error("400: Bad Request: can't parse entities"))
+      .mockResolvedValueOnce({ message_id: 1, chat: { id: "123" } });
+
+    await editMessageTelegram("123", 1, '<a href="https://example.com">Task</a>', {
+      token: "tok",
+      cfg: {},
+      textMode: "html",
+      media: true,
+    });
+
+    expect(botApi.editMessageCaption).toHaveBeenCalledTimes(2);
+    const fallbackParams = requireRecord(
+      mockCall(botApi.editMessageCaption, 1, "plain caption fallback")[2],
+      "plain caption params",
+    );
+    expect(fallbackParams.caption).toBe("Task (https://example.com)");
+    expect(fallbackParams).not.toHaveProperty("parse_mode");
+  });
+
   it("disables link previews when linkPreview is false", async () => {
     botApi.editMessageText.mockResolvedValue({ message_id: 1, chat: { id: "123" } });
 

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -66,6 +66,7 @@ export type TelegramApiOverride = Partial<TelegramApi>;
 type TelegramSendMessageParams = Parameters<TelegramApi["sendMessage"]>[2];
 type TelegramSendPollParams = Parameters<TelegramApi["sendPoll"]>[3];
 type TelegramEditMessageTextParams = Parameters<TelegramApi["editMessageText"]>[3];
+type TelegramEditMessageCaptionParams = Parameters<TelegramApi["editMessageCaption"]>[2];
 type TelegramCreateForumTopicParams = NonNullable<Parameters<TelegramApi["createForumTopic"]>[2]>;
 type TelegramThreadScopedParams = {
   message_thread_id?: number;
@@ -1315,6 +1316,8 @@ type TelegramEditOpts = {
   linkPreview?: boolean;
   /** Inline keyboard buttons (reply markup). Pass empty array to remove buttons. */
   buttons?: TelegramInlineButtons;
+  /** Edit a media message caption instead of a text message body. */
+  media?: boolean;
   /** Resolved runtime config from the command or gateway boundary. */
   cfg: OpenClawConfig;
 };
@@ -1443,6 +1446,49 @@ export async function editMessageTelegram(
   }
   if (replyMarkup !== undefined) {
     plainParams.reply_markup = replyMarkup;
+  }
+
+  if (opts.media === true) {
+    const captionParams: TelegramEditMessageCaptionParams = {
+      caption: htmlText,
+      parse_mode: "HTML",
+    };
+    if (replyMarkup !== undefined) {
+      captionParams.reply_markup = replyMarkup;
+    }
+    const plainCaptionParams: TelegramEditMessageCaptionParams = {
+      caption: plainText,
+    };
+    if (replyMarkup !== undefined) {
+      plainCaptionParams.reply_markup = replyMarkup;
+    }
+    try {
+      await withTelegramHtmlParseFallback({
+        label: "editMessageCaption",
+        verbose: opts.verbose,
+        requestHtml: (retryLabel) =>
+          requestWithEditShouldLog(
+            () => api.editMessageCaption(chatId, messageId, captionParams),
+            retryLabel,
+            (err) => !isTelegramMessageNotModifiedError(err),
+          ),
+        requestPlain: (retryLabel) =>
+          requestWithEditShouldLog(
+            () => api.editMessageCaption(chatId, messageId, plainCaptionParams),
+            retryLabel,
+            (plainErr) => !isTelegramMessageNotModifiedError(plainErr),
+          ),
+      });
+    } catch (err) {
+      if (isTelegramMessageNotModifiedError(err)) {
+        // no-op: Telegram reports message content unchanged, treat as success
+      } else {
+        throw err;
+      }
+    }
+
+    logVerbose(`[telegram] Edited media caption ${messageId} in chat ${chatId}`);
+    return { ok: true, messageId: String(messageId), chatId };
   }
 
   try {


### PR DESCRIPTION
## Summary

- Fixes #86161.
- Routes Telegram edit actions with `caption`/`media` to Telegram's `editMessageCaption` API so existing photo/video/audio/document messages can have captions updated.
- Allows Telegram edit actions with inline-button presentation and no text body to call `editMessageReplyMarkup`, so media message buttons can be updated independently.
- Keeps HTML parse fallback and message-not-modified success behavior for caption edits.

## Tests

- `node scripts/run-vitest.mjs extensions/telegram/src/send.test.ts extensions/telegram/src/action-runtime.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/telegram/src/send.ts extensions/telegram/src/send.test.ts extensions/telegram/src/send.test-harness.ts extensions/telegram/src/action-runtime.ts extensions/telegram/src/action-runtime.test.ts`
- `pnpm exec oxlint extensions/telegram/src/send.ts extensions/telegram/src/send.test.ts extensions/telegram/src/send.test-harness.ts extensions/telegram/src/action-runtime.ts extensions/telegram/src/action-runtime.test.ts`
- `pnpm tsgo:extensions && pnpm tsgo:extensions:test`

## Real behavior proof

Behavior addressed: Telegram edit actions can now update captions and inline reply markup on existing media messages instead of only calling `editMessageText` for text messages.

Real environment tested: Local macOS checkout, Node v23.11.1, pnpm workspace dependencies from this repository, with OpenClaw's Telegram runtime pointed at a local Telegram-compatible HTTP endpoint via `channels.telegram.apiRoot`.

Exact steps or command run after this patch: `node --conditions=openclaw-source --import tsx -e 'import http from "node:http"; import { editMessageTelegram } from "./extensions/telegram/src/send.ts"; const requests=[]; const server=http.createServer((req,res)=>{let body=""; req.setEncoding("utf8"); req.on("data", chunk => { body += chunk; }); req.on("end",()=>{requests.push({method:req.method,url:req.url,body: JSON.parse(body)}); res.setHeader("content-type","application/json"); res.end(JSON.stringify({ok:true,result:{message_id:42,chat:{id:123},caption:"updated caption"}}));});}); await new Promise(resolve => server.listen(0,"127.0.0.1",resolve)); const address=server.address(); const apiRoot=`http://127.0.0.1:${address.port}`; const result=await editMessageTelegram("123",42,"updated caption",{cfg:{channels:{telegram:{botToken:"123456:ABC",apiRoot}}},media:true,buttons:[[{text:"Open",url:"https://example.com"}]]}); server.close(); console.log(JSON.stringify({result, request: requests[0]}, null, 2));'`

Evidence after fix: The command used the real `grammy` Bot path from `editMessageTelegram` with a configured `apiRoot`; the captured HTTP request was `POST /bot123456:ABC/editMessageCaption` with `chat_id`, `message_id`, `caption`, `parse_mode`, and `reply_markup.inline_keyboard` in the request body.

Observed result after fix: The command printed a successful OpenClaw result `{ "ok": true, "messageId": "42", "chatId": "123" }` and showed the outbound Telegram-compatible request body containing `"caption": "updated caption"`, `"parse_mode": "HTML"`, and the expected inline keyboard URL button.

What was not tested: A live Telegram Bot API call with real bot credentials was not run; the proof uses a local Telegram-compatible HTTP endpoint to avoid sending real messages or exposing secrets while still exercising the OpenClaw Telegram runtime and grammy HTTP path.
