### PR TITLE
fix(auto-reply): turn-level NO_REPLY substrate-leak suppression (buffer-until-final)

### DIFF
--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -75,6 +75,25 @@ export type ReplyDispatcherOptions = {
   /** Human-like delay between block replies for natural rhythm. */
   humanDelay?: HumanDelayConfig;
   beforeDeliver?: ReplyDispatchBeforeDeliver;
+  /**
+   * Turn-level NO_REPLY suppression (substrate-leak fix).
+   *
+   * When enabled (default true), `block`-kind payloads are BUFFERED at enqueue time
+   * and held until the `final` payload arrives. At final-arrival:
+   *   - if final is exact NO_REPLY → drop the entire buffer + drop final (no delivery)
+   *   - otherwise                  → flush buffer in order, then deliver final
+   *
+   * This is the only correct shape for "reasoning-block-first-then-NO_REPLY-second"
+   * suppression: a pre-final flag-check cannot work because the flag is unset at the
+   * moment the reasoning block enqueues.
+   *
+   * Tool-kind payloads bypass the buffer (they are between the model and tool-runs,
+   * not user-visible chat). Setting this option false restores legacy
+   * "deliver-each-block-immediately" behavior for callers who need it.
+   *
+   * @see substrate-leak forensic 2026-05-24 session cf23b629
+   */
+  enableTurnLevelNoReplySuppression?: boolean;
 };
 
 export type ReplyDispatcherWithTypingOptions = Omit<ReplyDispatcherOptions, "onIdle"> & {
@@ -147,32 +166,24 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
     final: 0,
   };
 
+  // Turn-level NO_REPLY suppression: buffer block-kind payloads until final arrives.
+  // See ReplyDispatcherOptions.enableTurnLevelNoReplySuppression for full rationale.
+  const enableTurnLevelSuppression = options.enableTurnLevelNoReplySuppression ?? true;
+  // Buffer of block payloads enqueued before final lands. Flushed (or dropped) at final.
+  const bufferedBlocks: ReplyPayload[] = [];
+
   // Register this dispatcher globally for gateway restart coordination.
   const { unregister } = registerDispatcher({
     pending: () => pending,
     waitForIdle: () => sendChain,
   });
 
-  const enqueue = (kind: ReplyDispatchKind, payload: ReplyPayload) => {
-    const originalWasExactSilent = isSilentReplyText(payload.text, SILENT_REPLY_TOKEN);
-    const normalized = normalizeReplyPayloadInternal(payload, {
-      responsePrefix: options.responsePrefix,
-      responsePrefixContext: options.responsePrefixContext,
-      responsePrefixContextProvider: options.responsePrefixContextProvider,
-      transformReplyPayload: options.transformReplyPayload,
-      onHeartbeatStrip: options.onHeartbeatStrip,
-      onSkip: (reason) => options.onSkip?.(payload, { kind, reason }),
-    });
-    if (!normalized) {
-      if (kind === "final" && originalWasExactSilent) {
-        silentReplyLogger.debug("exact NO_REPLY final payload was skipped before delivery", {
-          hasSessionKey: Boolean(options.silentReplyContext?.sessionKey),
-          surface: options.silentReplyContext?.surface,
-          conversationType: options.silentReplyContext?.conversationType,
-        });
-      }
-      return false;
-    }
+  /**
+   * Push a normalized payload onto the serialized send chain.
+   * Returns true and bumps queued/pending counters; caller is responsible for
+   * the upstream "did anything actually get queued" boolean.
+   */
+  const dispatchNormalized = (kind: ReplyDispatchKind, normalized: ReplyPayload): void => {
     queuedCounts[kind] += 1;
     pending += 1;
 
@@ -220,7 +231,139 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
           options.onIdle?.();
         }
       });
+  };
+
+  const enqueue = (kind: ReplyDispatchKind, payload: ReplyPayload) => {
+    const originalWasExactSilent = isSilentReplyText(payload.text, SILENT_REPLY_TOKEN);
+
+    // ── Turn-level NO_REPLY suppression (buffer-until-final) ─────────────────
+    //
+    // The substrate-leak shape is:
+    //   1. enqueue(block, "reasoning text")   ← in current model output
+    //   2. enqueue(tool,  {tool-output})       ← model called a tool
+    //   3. enqueue(block, "more reasoning")    ← post-tool reasoning
+    //   4. enqueue(final, "NO_REPLY")          ← model's final answer
+    //
+    // A flag-on-NO_REPLY approach can't catch (1) or (3) because the flag is
+    // unset at the moment those blocks enqueue. The correct fix is to defer
+    // block-kind delivery until final arrives, then decide.
+    //
+    // Tool-kind is NOT buffered — it must flow to the agent loop so the model
+    // can keep running. Final-kind is the trigger for flush-or-drop.
+
+    if (enableTurnLevelSuppression && kind === "block") {
+      // Normalize NOW so transformReplyPayload / heartbeat-strip / response-prefix
+      // semantics still happen at enqueue-time-ordering. If normalization drops
+      // it (e.g. empty text, or transformer returned null), record the skip and
+      // do nothing — same as legacy behavior.
+      const normalized = normalizeReplyPayloadInternal(payload, {
+        responsePrefix: options.responsePrefix,
+        responsePrefixContext: options.responsePrefixContext,
+        responsePrefixContextProvider: options.responsePrefixContextProvider,
+        transformReplyPayload: options.transformReplyPayload,
+        onHeartbeatStrip: options.onHeartbeatStrip,
+        onSkip: (reason) => options.onSkip?.(payload, { kind, reason }),
+      });
+      if (!normalized) {
+        return false;
+      }
+      bufferedBlocks.push(normalized);
+      return true;
+    }
+
+    if (enableTurnLevelSuppression && kind === "final") {
+      if (originalWasExactSilent) {
+        // Drop everything buffered (the leak) and drop the final itself.
+        const droppedCount = bufferedBlocks.length;
+        if (droppedCount > 0) {
+          silentReplyLogger.debug(
+            "turn-level NO_REPLY suppression: dropping buffered block(s) before final NO_REPLY",
+            {
+              droppedBlockCount: droppedCount,
+              hasSessionKey: Boolean(options.silentReplyContext?.sessionKey),
+              surface: options.silentReplyContext?.surface,
+              conversationType: options.silentReplyContext?.conversationType,
+            },
+          );
+          // Emit onSkip for each dropped block so channels (e.g. Telegram) get a
+          // signal that text was intentionally suppressed.
+          for (const dropped of bufferedBlocks) {
+            options.onSkip?.(dropped, { kind: "block", reason: "silent" });
+          }
+          bufferedBlocks.length = 0;
+        }
+        // Now route the NO_REPLY final through the legacy normalize path so its
+        // existing handling (onSkip + debug log) still fires. normalize-reply
+        // already drops exact-silent text, so deliver() is never called.
+        const normalized = normalizeReplyPayloadInternal(payload, {
+          responsePrefix: options.responsePrefix,
+          responsePrefixContext: options.responsePrefixContext,
+          responsePrefixContextProvider: options.responsePrefixContextProvider,
+          transformReplyPayload: options.transformReplyPayload,
+          onHeartbeatStrip: options.onHeartbeatStrip,
+          onSkip: (reason) => options.onSkip?.(payload, { kind, reason }),
+        });
+        if (!normalized) {
+          silentReplyLogger.debug("exact NO_REPLY final payload was skipped before delivery", {
+            hasSessionKey: Boolean(options.silentReplyContext?.sessionKey),
+            surface: options.silentReplyContext?.surface,
+            conversationType: options.silentReplyContext?.conversationType,
+          });
+        }
+        return false;
+      }
+
+      // Final is a real reply — flush buffered blocks, then deliver final.
+      for (const buffered of bufferedBlocks) {
+        dispatchNormalized("block", buffered);
+      }
+      bufferedBlocks.length = 0;
+      // Fall through to legacy final-normalize path below.
+    }
+
+    const normalized = normalizeReplyPayloadInternal(payload, {
+      responsePrefix: options.responsePrefix,
+      responsePrefixContext: options.responsePrefixContext,
+      responsePrefixContextProvider: options.responsePrefixContextProvider,
+      transformReplyPayload: options.transformReplyPayload,
+      onHeartbeatStrip: options.onHeartbeatStrip,
+      onSkip: (reason) => options.onSkip?.(payload, { kind, reason }),
+    });
+    if (!normalized) {
+      if (kind === "final" && originalWasExactSilent) {
+        silentReplyLogger.debug("exact NO_REPLY final payload was skipped before delivery", {
+          hasSessionKey: Boolean(options.silentReplyContext?.sessionKey),
+          surface: options.silentReplyContext?.surface,
+          conversationType: options.silentReplyContext?.conversationType,
+        });
+      }
+      return false;
+    }
+
+    dispatchNormalized(kind, normalized);
     return true;
+  };
+
+  /**
+   * Defensive flush of any blocks that were buffered but never paired with a
+   * final. In a well-behaved turn `final` always arrives, but if the model
+   * stream tears down without emitting a final block, those buffered blocks
+   * would otherwise be dropped silently. Flush them on markComplete so the
+   * user still sees the reasoning that was already on its way.
+   */
+  const flushBufferedBlocksOnComplete = () => {
+    if (bufferedBlocks.length === 0) {
+      return;
+    }
+    silentReplyLogger.debug("flushing buffered blocks at markComplete (no final arrived)", {
+      bufferedBlockCount: bufferedBlocks.length,
+      hasSessionKey: Boolean(options.silentReplyContext?.sessionKey),
+      surface: options.silentReplyContext?.surface,
+    });
+    for (const buffered of bufferedBlocks) {
+      dispatchNormalized("block", buffered);
+    }
+    bufferedBlocks.length = 0;
   };
 
   const markComplete = () => {
@@ -228,6 +371,8 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
       return;
     }
     completeCalled = true;
+    // Defensive: flush any buffered blocks that never saw a paired final.
+    flushBufferedBlocksOnComplete();
     // If no replies were enqueued (pending is still 1 = just the reservation),
     // schedule clearing the reservation after current microtasks complete.
     // This gives any in-flight enqueue() calls a chance to increment pending.

--- a/src/auto-reply/reply/reply-dispatcher.turn-level-noreply.test.ts
+++ b/src/auto-reply/reply/reply-dispatcher.turn-level-noreply.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Turn-level NO_REPLY suppression — substrate-leak regression coverage.
+ *
+ * The leak forensic (2026-05-24 session cf23b629) showed:
+ *   intermediate `block`-kind text payloads emitted BEFORE the final `NO_REPLY`
+ *   in the same turn were being delivered to Telegram even though the final
+ *   suppressed itself. Operators saw ~140 overnight notifications of agent
+ *   reasoning ("Inbox empty, no threads…" etc) that should never have shipped.
+ *
+ * Fix lineage: woodhouse msg-20260524-183651-3206538 directed Path B (gateway-
+ * side) with the redesign requirement that suppression buffer block-kind
+ * payloads until final arrives, then flush-or-drop. A flag-on-NO_REPLY check
+ * cannot work because the flag is unset at the moment the leading block
+ * enqueues.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { ReplyPayload } from "../types.js";
+import { createReplyDispatcher } from "./reply-dispatcher.js";
+
+describe("createReplyDispatcher — turn-level NO_REPLY suppression (substrate-leak fix)", () => {
+  it("drops a leading block payload when a NO_REPLY final follows in the same turn (the actual leak shape)", async () => {
+    const delivered: Array<{ kind: string; text: string | undefined }> = [];
+    const skipped: Array<{ kind: string; text: string | undefined; reason: string }> = [];
+
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload, info) => {
+        delivered.push({ kind: info.kind, text: payload.text });
+      },
+      onSkip: (payload, info) => {
+        skipped.push({ kind: info.kind, text: payload.text, reason: info.reason });
+      },
+    });
+
+    // ── The exact leak shape from the forensic ──────────────────────────────
+    // 1. Reasoning block first ("Inbox empty…")
+    expect(
+      dispatcher.sendBlockReply({ text: "Inbox empty, no threads, no spawns. State clean." }),
+    ).toBe(true);
+    // 2. Then the final NO_REPLY arrives
+    expect(dispatcher.sendFinalReply({ text: "NO_REPLY" })).toBe(false);
+
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    // The leak shape: previously, "Inbox empty…" would have been delivered.
+    // With the buffer-until-final fix, NOTHING is delivered.
+    expect(delivered).toEqual([]);
+
+    // The dropped block must surface an onSkip(silent) signal so channels know
+    // suppression was intentional (not an empty-payload bug).
+    const blockSkips = skipped.filter((s) => s.kind === "block");
+    expect(blockSkips).toHaveLength(1);
+    expect(blockSkips[0]).toEqual({
+      kind: "block",
+      text: "Inbox empty, no threads, no spawns. State clean.",
+      reason: "silent",
+    });
+  });
+
+  it("drops multiple buffered blocks when a NO_REPLY final follows (multi-block leak shape)", async () => {
+    const delivered: string[] = [];
+    const skippedBlocks: string[] = [];
+
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload) => {
+        delivered.push(payload.text ?? "");
+      },
+      onSkip: (payload, info) => {
+        if (info.kind === "block" && info.reason === "silent") {
+          skippedBlocks.push(payload.text ?? "");
+        }
+      },
+    });
+
+    dispatcher.sendBlockReply({ text: "first reasoning chunk" });
+    dispatcher.sendBlockReply({ text: "second reasoning chunk" });
+    dispatcher.sendBlockReply({ text: "third reasoning chunk" });
+    dispatcher.sendFinalReply({ text: "NO_REPLY" });
+
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    expect(delivered).toEqual([]);
+    expect(skippedBlocks).toEqual([
+      "first reasoning chunk",
+      "second reasoning chunk",
+      "third reasoning chunk",
+    ]);
+  });
+
+  it("flushes buffered blocks in order when the final is a real reply", async () => {
+    const delivered: Array<{ kind: string; text: string | undefined }> = [];
+
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload, info) => {
+        delivered.push({ kind: info.kind, text: payload.text });
+      },
+    });
+
+    dispatcher.sendBlockReply({ text: "intro" });
+    dispatcher.sendBlockReply({ text: "middle" });
+    dispatcher.sendFinalReply({ text: "final answer" });
+
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    expect(delivered).toEqual([
+      { kind: "block", text: "intro" },
+      { kind: "block", text: "middle" },
+      { kind: "final", text: "final answer" },
+    ]);
+  });
+
+  it("does NOT buffer tool-kind payloads (they must flow to the agent loop)", async () => {
+    const delivered: Array<{ kind: string; text: string | undefined }> = [];
+
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload, info) => {
+        delivered.push({ kind: info.kind, text: payload.text });
+      },
+    });
+
+    dispatcher.sendBlockReply({ text: "reasoning A" });
+    dispatcher.sendToolResult({ text: "tool output" });
+    dispatcher.sendBlockReply({ text: "reasoning B" });
+    dispatcher.sendFinalReply({ text: "NO_REPLY" });
+
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    // Tool result must be delivered even though final is NO_REPLY.
+    // Both reasoning blocks must be dropped.
+    expect(delivered).toEqual([{ kind: "tool", text: "tool output" }]);
+  });
+
+  it("delivers normally when there is no leading block (final-only NO_REPLY turn)", async () => {
+    const delivered: ReplyPayload[] = [];
+    const skipped: Array<{ kind: string; reason: string }> = [];
+
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload) => {
+        delivered.push(payload);
+      },
+      onSkip: (_, info) => {
+        skipped.push({ kind: info.kind, reason: info.reason });
+      },
+    });
+
+    dispatcher.sendFinalReply({ text: "NO_REPLY" });
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    expect(delivered).toEqual([]);
+    // Single skip on the final (legacy normalize-reply path).
+    expect(skipped.some((s) => s.kind === "final" && s.reason === "silent")).toBe(true);
+  });
+
+  it("defensive flush at markComplete when no final ever arrives (stream tear-down)", async () => {
+    const delivered: string[] = [];
+
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload) => {
+        delivered.push(payload.text ?? "");
+      },
+    });
+
+    dispatcher.sendBlockReply({ text: "partial output before stream torn down" });
+    // No sendFinalReply — markComplete is the only turn-close signal.
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    // The buffered block must NOT be silently lost — it must be flushed on
+    // markComplete because we have no NO_REPLY evidence to justify dropping it.
+    expect(delivered).toEqual(["partial output before stream torn down"]);
+  });
+
+  it("opt-out: setting enableTurnLevelNoReplySuppression=false restores legacy behavior", async () => {
+    const delivered: Array<{ kind: string; text: string | undefined }> = [];
+
+    const dispatcher = createReplyDispatcher({
+      enableTurnLevelNoReplySuppression: false,
+      deliver: async (payload, info) => {
+        delivered.push({ kind: info.kind, text: payload.text });
+      },
+    });
+
+    // With suppression off, the leading block is delivered immediately (the
+    // legacy leak shape). The final NO_REPLY is still dropped by the existing
+    // normalize-reply path. This test pins the opt-out for callers who need
+    // bug-for-bug compatibility.
+    dispatcher.sendBlockReply({ text: "this would have leaked" });
+    dispatcher.sendFinalReply({ text: "NO_REPLY" });
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    expect(delivered).toEqual([{ kind: "block", text: "this would have leaked" }]);
+  });
+
+  it("preserves transformReplyPayload semantics on buffered blocks (normalize-at-enqueue)", async () => {
+    const delivered: string[] = [];
+
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload) => {
+        delivered.push(payload.text ?? "");
+      },
+      transformReplyPayload: (payload) => {
+        if (payload.text?.includes("BLOCKED")) {
+          return null;
+        }
+        return payload;
+      },
+    });
+
+    // BLOCKED-text block should be rejected at enqueue time (returns false),
+    // not buffered.
+    expect(dispatcher.sendBlockReply({ text: "BLOCKED reasoning" })).toBe(false);
+    expect(dispatcher.sendBlockReply({ text: "allowed reasoning" })).toBe(true);
+    dispatcher.sendFinalReply({ text: "real final" });
+
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    expect(delivered).toEqual(["allowed reasoning", "real final"]);
+  });
+
+  it("onSkip fires for each dropped buffered block (channel observability)", async () => {
+    const skipReasons: Array<{ kind: string; text: string | undefined; reason: string }> = [];
+
+    const dispatcher = createReplyDispatcher({
+      deliver: vi.fn(),
+      onSkip: (payload, info) => {
+        skipReasons.push({ kind: info.kind, text: payload.text, reason: info.reason });
+      },
+    });
+
+    dispatcher.sendBlockReply({ text: "leak chunk A" });
+    dispatcher.sendBlockReply({ text: "leak chunk B" });
+    dispatcher.sendFinalReply({ text: "NO_REPLY" });
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    // Two block skips + one final skip (final path goes through normalize-reply).
+    const blockSkips = skipReasons.filter((s) => s.kind === "block");
+    expect(blockSkips).toHaveLength(2);
+    expect(blockSkips.every((s) => s.reason === "silent")).toBe(true);
+    expect(blockSkips.map((s) => s.text)).toEqual(["leak chunk A", "leak chunk B"]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the substrate leak that delivers agent reasoning text to operator chats when a `NO_REPLY` final follows leading `block`-kind payloads in the same turn.

## The leak shape

From the 2026-05-24 forensic (fleet-ops session `cf23b629`):

```
[block] "Inbox empty, no threads, no spawns. State clean."
[tool]  { …tool output… }
[block] "more reasoning"
[final] "NO_REPLY"
```

Previously the two `block` payloads were delivered to Telegram immediately, and only the final `NO_REPLY` was suppressed by `normalize-reply`. Operators saw ~140 overnight notifications of reasoning that should never have shipped.

## Why a flag-on-NO_REPLY approach can't work

A previous iteration tried: at `enqueue` time, set `hasNoReplyInTurn = true` when the payload is exact `NO_REPLY`, and skip subsequent blocks. That fails because **the flag is unset at the moment the leading reasoning `block` enqueues** — by the time `NO_REPLY` arrives and flips the flag, the leak has already happened.

## The fix: buffer-until-final

In `createReplyDispatcher`:

| enqueue call                      | New behavior                                                |
| --------------------------------- | ----------------------------------------------------------- |
| `enqueue("block", payload)`       | Normalize at call-time; push normalized into `bufferedBlocks` instead of `sendChain`. |
| `enqueue("tool",  payload)`       | Unchanged — tool results must flow to the agent loop.       |
| `enqueue("final", "NO_REPLY")`    | Drop the entire `bufferedBlocks`, fire `onSkip("silent")` for each, drop the final too. |
| `enqueue("final", real-text)`     | Flush `bufferedBlocks` in order onto `sendChain`, then deliver the final.            |
| `markComplete()` with non-empty buffer | Defensive flush: stream tear-down without a final must not silently lose reasoning. |

Block-payload normalization (`transformReplyPayload`, heartbeat-strip, response-prefix) still happens at `enqueue` time so semantics and ordering are preserved.

A new opt-out, `enableTurnLevelNoReplySuppression: false`, restores legacy deliver-each-block-immediately behavior for callers that depend on it. The default is `true`.

## Test coverage

`src/auto-reply/reply/reply-dispatcher.turn-level-noreply.test.ts` — 9 tests, all passing:

1. **The actual leak shape**: leading `block` then `final: "NO_REPLY"` → nothing delivered; `onSkip("silent")` fired.
2. Multiple buffered blocks before `NO_REPLY` → all dropped, all skips emitted.
3. Final is a real reply → buffer flushed in order, then final delivered.
4. Tool-kind payload between blocks delivers immediately even though final is `NO_REPLY`.
5. Final-only `NO_REPLY` turn still suppressed (legacy normalize-reply path preserved).
6. Defensive `markComplete` flush when no final arrives (stream tear-down).
7. Opt-out (`enableTurnLevelNoReplySuppression: false`) restores legacy behavior — the leak shape leaks; this test pins it.
8. `transformReplyPayload` still applied at enqueue time on buffered blocks.
9. `onSkip` fires per dropped buffered block (channel observability).

```text
✓ src/auto-reply/reply/reply-dispatcher.turn-level-noreply.test.ts (9 tests) 73ms
Test Files  1 passed (1)
     Tests  9 passed (9)
```

## Authority / lineage

- Substrate-leak forensic 2026-05-24, fleet-ops session `cf23b629` (root cause = ~140 overnight reasoning leaks to Todd's Telegram).
- HEARTBEAT.md "NO_REPLY = ONLY TEXT IN THE TURN" doctrine patched across 16 agent workspaces 2026-05-24 as immediate mitigation (the prompt-level rule); this PR is the gateway-side enforcement that keeps the leak suppressed even when an agent prompt drifts.
- Design direction from woodhouse msg-20260524-183651-3206538 (Path B in-line redesign, buffer-until-final).

## Risk

- Non-suppression path (`enableTurnLevelNoReplySuppression: false`) is byte-equivalent to the previous implementation.
- Default-on path differs from previous behavior in exactly one observable way: intermediate `block` payloads are deferred until `final` arrives. The flush path on real finals re-uses the original `dispatchNormalized` helper that wraps the existing `sendChain` promise. Tool-kind is untouched. `pending`/`onIdle` accounting is preserved (each flushed block increments `pending` and decrements on settle, identical to the unbuffered path).
- Worst case if the design has a bug: a real `final` with leading blocks would still deliver everything in order (test 3); the leak-shape case would drop the leak (test 1). The only new "lossy" path is the defensive flush on premature `markComplete`, which would otherwise lose reasoning entirely (test 6 pins it as deliver-not-drop).

## Files

- `src/auto-reply/reply/reply-dispatcher.ts` — buffer-until-final implementation + new opt-out option.
- `src/auto-reply/reply/reply-dispatcher.turn-level-noreply.test.ts` — new regression coverage.
