### PR TITLE
Fix Telegram media message edits

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -587,7 +587,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     - `sendMessage` (`to`, `content`, optional `mediaUrl`, `replyToMessageId`, `messageThreadId`)
     - `react` (`chatId`, `messageId`, `emoji`)
     - `deleteMessage` (`chatId`, `messageId`)
-    - `editMessage` (`chatId`, `messageId`, `content`)
+    - `editMessage` (`chatId`, `messageId`, `content` or `caption`, optional `presentation` inline buttons; button-only edits update reply markup)
     - `createForumTopic` (`chatId`, `name`, optional `iconColor`, `iconCustomEmojiId`)
 
     Channel message actions expose ergonomic aliases (`send`, `react`, `delete`, `edit`, `sticker`, `sticker-search`, `topic-create`).

--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -152,6 +152,11 @@ const editMessageTelegram = vi.fn(async () => ({
   messageId: "456",
   chatId: "123",
 }));
+const editMessageReplyMarkupTelegram = vi.fn(async () => ({
+  ok: true,
+  messageId: "456",
+  chatId: "123",
+}));
 const editForumTopicTelegram = vi.fn(async () => ({
   ok: true,
   chatId: "123",
@@ -320,6 +325,7 @@ describe("handleTelegramAction", () => {
       sendStickerTelegram,
       deleteMessageTelegram,
       editMessageTelegram,
+      editMessageReplyMarkupTelegram,
       editForumTopicTelegram,
       pinMessageTelegram,
       createForumTopicTelegram,
@@ -331,6 +337,7 @@ describe("handleTelegramAction", () => {
     sendStickerTelegram.mockClear();
     deleteMessageTelegram.mockClear();
     editMessageTelegram.mockClear();
+    editMessageReplyMarkupTelegram.mockClear();
     editForumTopicTelegram.mockClear();
     pinMessageTelegram.mockClear();
     createForumTopicTelegram.mockClear();
@@ -1428,6 +1435,50 @@ describe("handleTelegramAction", () => {
     expect(requireRecord(call[2], "button-only fallback options").buttons).toEqual([
       [{ text: "Approve", callback_data: "approve" }],
     ]);
+  });
+
+  it("edits reply markup when editMessage only changes buttons", async () => {
+    await handleTelegramAction(
+      {
+        action: "editMessage",
+        chatId: "123456",
+        messageId: 321,
+        presentation: {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [{ label: "Open", url: "https://example.com" }],
+            },
+          ],
+        },
+      },
+      telegramConfig({ capabilities: { inlineButtons: "all" } }),
+    );
+
+    expect(editMessageTelegram).not.toHaveBeenCalled();
+    const call = mockCall(editMessageReplyMarkupTelegram, 0, "reply markup edit");
+    expect(call[0]).toBe("123456");
+    expect(call[1]).toBe(321);
+    expect(call[2]).toEqual([[{ text: "Open", url: "https://example.com" }]]);
+    expect(requireRecord(call[3], "reply markup edit options").token).toBe("tok");
+  });
+
+  it("uses Telegram caption edits when editMessage receives a caption", async () => {
+    await handleTelegramAction(
+      {
+        action: "editMessage",
+        chatId: "123456",
+        messageId: 321,
+        caption: "Updated caption",
+      },
+      telegramConfig(),
+    );
+
+    const call = mockCall(editMessageTelegram, 0, "caption edit");
+    expect(call[0]).toBe("123456");
+    expect(call[1]).toBe(321);
+    expect(call[2]).toBe("Updated caption");
+    expect(requireRecord(call[3], "caption edit options").editMode).toBe("caption");
   });
 
   it("pins action sends when delivery pin is requested", async () => {

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -41,6 +41,7 @@ import {
   createForumTopicTelegram,
   deleteMessageTelegram,
   editForumTopicTelegram,
+  editMessageReplyMarkupTelegram,
   editMessageTelegram,
   pinMessageTelegram,
   reactMessageTelegram,
@@ -57,6 +58,7 @@ export const telegramActionRuntime = {
   createForumTopicTelegram,
   deleteMessageTelegram,
   editForumTopicTelegram,
+  editMessageReplyMarkupTelegram,
   editMessageTelegram,
   getCacheStats,
   pinMessageTelegram,
@@ -666,9 +668,13 @@ export async function handleTelegramAction(
     }
     const content =
       readStringParam(params, "content", { allowEmpty: false }) ??
-      readStringParam(params, "message", { required: true, allowEmpty: false });
+      readStringParam(params, "message", { allowEmpty: false });
+    const caption = readStringParam(params, "caption", { allowEmpty: false });
     const buttons = resolveTelegramButtonsFromParams(params);
-    if (buttons) {
+    if (content == null && caption == null && buttons === undefined) {
+      throw new Error("content required.");
+    }
+    if (buttons !== undefined) {
       const inlineButtonsScope = resolveTelegramInlineButtonsScope({
         cfg,
         accountId: accountId ?? undefined,
@@ -685,15 +691,34 @@ export async function handleTelegramAction(
         "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
       );
     }
+    if (content == null && caption == null && buttons !== undefined) {
+      const result = await telegramActionRuntime.editMessageReplyMarkupTelegram(
+        chatId ?? "",
+        messageId ?? 0,
+        buttons,
+        {
+          cfg,
+          token,
+          accountId: accountId ?? undefined,
+          gatewayClientScopes: options?.gatewayClientScopes,
+        },
+      );
+      return jsonResult({
+        ok: true,
+        messageId: result.messageId,
+        chatId: result.chatId,
+      });
+    }
     const result = await telegramActionRuntime.editMessageTelegram(
       chatId ?? "",
       messageId ?? 0,
-      content,
+      caption ?? content ?? "",
       {
         cfg,
         token,
         accountId: accountId ?? undefined,
         buttons,
+        editMode: caption != null ? "caption" : "auto",
         gatewayClientScopes: options?.gatewayClientScopes,
       },
     );

--- a/extensions/telegram/src/send.test-harness.ts
+++ b/extensions/telegram/src/send.test-harness.ts
@@ -13,6 +13,7 @@ const { botApi, botConfigUseSpy, botCtorSpy } = vi.hoisted(() => ({
   botApi: {
     deleteMessage: vi.fn(),
     editForumTopic: vi.fn(),
+    editMessageCaption: vi.fn(),
     editMessageText: vi.fn(),
     editMessageReplyMarkup: vi.fn(),
     pinChatMessage: vi.fn(),

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -3133,6 +3133,51 @@ describe("editMessageTelegram", () => {
     expect(botApi.editMessageText).toHaveBeenCalledTimes(1);
   });
 
+  it("uses editMessageCaption when requested for media captions", async () => {
+    botApi.editMessageCaption.mockResolvedValue({ message_id: 1, chat: { id: "123" } });
+
+    await editMessageTelegram("123", 1, "Media **caption**", {
+      token: "tok",
+      cfg: {},
+      editMode: "caption",
+      buttons: [[{ text: "Open", url: "https://example.com" }]],
+    });
+
+    expect(botApi.editMessageText).not.toHaveBeenCalled();
+    expect(botApi.editMessageCaption).toHaveBeenCalledTimes(1);
+    const captionParams = requireRecord(
+      firstMockCall(botApi.editMessageCaption, "editMessageCaption call")[2],
+      "caption edit params",
+    );
+    expect(captionParams.caption).toBe("Media <b>caption</b>");
+    expect(captionParams.parse_mode).toBe("HTML");
+    expect(captionParams.reply_markup).toEqual({
+      inline_keyboard: [[{ text: "Open", url: "https://example.com" }]],
+    });
+  });
+
+  it("falls back to editMessageCaption when Telegram reports a media message has no text", async () => {
+    botApi.editMessageText.mockRejectedValueOnce(
+      new Error("400: Bad Request: there is no text in the message to edit"),
+    );
+    botApi.editMessageCaption.mockResolvedValue({ message_id: 1, chat: { id: "123" } });
+
+    await editMessageTelegram("123", 1, "New caption", {
+      token: "tok",
+      cfg: {},
+      editMode: "auto",
+    });
+
+    expect(botApi.editMessageText).toHaveBeenCalledTimes(1);
+    expect(botApi.editMessageCaption).toHaveBeenCalledTimes(1);
+    const captionParams = requireRecord(
+      firstMockCall(botApi.editMessageCaption, "fallback editMessageCaption call")[2],
+      "fallback caption edit params",
+    );
+    expect(captionParams.caption).toBe("New caption");
+    expect(captionParams.parse_mode).toBe("HTML");
+  });
+
   it("derives readable plain text when Telegram rejects edited HTML", async () => {
     botApi.editMessageText
       .mockRejectedValueOnce(new Error("400: Bad Request: can't parse entities"))

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -67,6 +67,7 @@ export type TelegramApiOverride = Partial<TelegramApi>;
 type TelegramSendMessageParams = Parameters<TelegramApi["sendMessage"]>[2];
 type TelegramSendPollParams = Parameters<TelegramApi["sendPoll"]>[3];
 type TelegramEditMessageTextParams = Parameters<TelegramApi["editMessageText"]>[3];
+type TelegramEditMessageCaptionParams = Parameters<TelegramApi["editMessageCaption"]>[2];
 type TelegramCreateForumTopicParams = NonNullable<Parameters<TelegramApi["createForumTopic"]>[2]>;
 type TelegramThreadScopedParams = {
   message_thread_id?: number;
@@ -230,6 +231,7 @@ function logTelegramOutboundSendOk(params: TelegramOutboundSuccessLogParams): vo
 const PARSE_ERR_RE = /can't parse entities|parse entities|find end of the entity/i;
 const MESSAGE_NOT_MODIFIED_RE =
   /400:\s*Bad Request:\s*message is not modified|MESSAGE_NOT_MODIFIED/i;
+const MESSAGE_HAS_NO_TEXT_RE = /400:\s*Bad Request:\s*there is no text in the message to edit/i;
 const MESSAGE_DELETE_NOOP_RE =
   /message to delete not found|message can't be deleted|MESSAGE_ID_INVALID|MESSAGE_DELETE_FORBIDDEN/i;
 const CHAT_NOT_FOUND_RE = /400: Bad Request: chat not found/i;
@@ -420,6 +422,10 @@ function normalizeMessageId(raw: string | number): number {
 
 function isTelegramMessageNotModifiedError(err: unknown): boolean {
   return MESSAGE_NOT_MODIFIED_RE.test(formatErrorMessage(err));
+}
+
+function isTelegramMessageHasNoTextError(err: unknown): boolean {
+  return MESSAGE_HAS_NO_TEXT_RE.test(formatErrorMessage(err));
 }
 
 function isTelegramMessageDeleteNoopError(err: unknown): boolean {
@@ -1316,6 +1322,8 @@ type TelegramEditOpts = {
   linkPreview?: boolean;
   /** Inline keyboard buttons (reply markup). Pass empty array to remove buttons. */
   buttons?: TelegramInlineButtons;
+  /** Use Telegram's media-caption edit endpoint, or fall back to it when text edits target media. */
+  editMode?: "text" | "caption" | "auto";
   /** Resolved runtime config from the command or gateway boundary. */
   cfg: OpenClawConfig;
 };
@@ -1429,43 +1437,90 @@ export async function editMessageTelegram(
   const builtKeyboard = shouldTouchButtons ? buildInlineKeyboard(opts.buttons) : undefined;
   const replyMarkup = shouldTouchButtons ? (builtKeyboard ?? { inline_keyboard: [] }) : undefined;
 
-  const editParams: TelegramEditMessageTextParams = {
+  const textEditParams: TelegramEditMessageTextParams = {
     parse_mode: "HTML",
   };
   if (opts.linkPreview === false) {
-    editParams.link_preview_options = { is_disabled: true };
+    textEditParams.link_preview_options = { is_disabled: true };
   }
   if (replyMarkup !== undefined) {
-    editParams.reply_markup = replyMarkup;
+    textEditParams.reply_markup = replyMarkup;
   }
-  const plainParams: TelegramEditMessageTextParams = {};
+  const plainTextParams: TelegramEditMessageTextParams = {};
   if (opts.linkPreview === false) {
-    plainParams.link_preview_options = { is_disabled: true };
+    plainTextParams.link_preview_options = { is_disabled: true };
   }
   if (replyMarkup !== undefined) {
-    plainParams.reply_markup = replyMarkup;
+    plainTextParams.reply_markup = replyMarkup;
+  }
+  const captionEditParams: TelegramEditMessageCaptionParams = {
+    caption: htmlText,
+    parse_mode: "HTML",
+  };
+  if (replyMarkup !== undefined) {
+    captionEditParams.reply_markup = replyMarkup;
+  }
+  const plainCaptionParams: TelegramEditMessageCaptionParams = {
+    caption: plainText,
+  };
+  if (replyMarkup !== undefined) {
+    plainCaptionParams.reply_markup = replyMarkup;
   }
 
-  try {
-    await withTelegramHtmlParseFallback({
+  const performTextEdit = () =>
+    withTelegramHtmlParseFallback({
       label: "editMessage",
       verbose: opts.verbose,
       requestHtml: (retryLabel) =>
         requestWithEditShouldLog(
-          () => api.editMessageText(chatId, messageId, htmlText, editParams),
+          () => api.editMessageText(chatId, messageId, htmlText, textEditParams),
           retryLabel,
           (err) => !isTelegramMessageNotModifiedError(err),
         ),
       requestPlain: (retryLabel) =>
         requestWithEditShouldLog(
           () =>
-            Object.keys(plainParams).length > 0
-              ? api.editMessageText(chatId, messageId, plainText, plainParams)
+            Object.keys(plainTextParams).length > 0
+              ? api.editMessageText(chatId, messageId, plainText, plainTextParams)
               : api.editMessageText(chatId, messageId, plainText),
           retryLabel,
           (plainErr) => !isTelegramMessageNotModifiedError(plainErr),
         ),
     });
+
+  const performCaptionEdit = () =>
+    withTelegramHtmlParseFallback({
+      label: "editMessageCaption",
+      verbose: opts.verbose,
+      requestHtml: (retryLabel) =>
+        requestWithEditShouldLog(
+          () => api.editMessageCaption(chatId, messageId, captionEditParams),
+          retryLabel,
+          (err) => !isTelegramMessageNotModifiedError(err),
+        ),
+      requestPlain: (retryLabel) =>
+        requestWithEditShouldLog(
+          () => api.editMessageCaption(chatId, messageId, plainCaptionParams),
+          retryLabel,
+          (plainErr) => !isTelegramMessageNotModifiedError(plainErr),
+        ),
+    });
+
+  try {
+    const editMode = opts.editMode ?? "text";
+    if (editMode === "caption") {
+      await performCaptionEdit();
+    } else {
+      try {
+        await performTextEdit();
+      } catch (err) {
+        if (editMode === "auto" && isTelegramMessageHasNoTextError(err)) {
+          await performCaptionEdit();
+        } else {
+          throw err;
+        }
+      }
+    }
   } catch (err) {
     if (isTelegramMessageNotModifiedError(err)) {
       // no-op: Telegram reports message content unchanged, treat as success

--- a/src/agents/model-catalog-browse.test.ts
+++ b/src/agents/model-catalog-browse.test.ts
@@ -30,6 +30,7 @@ describe("loadModelCatalogForBrowse", () => {
 
   afterEach(() => {
     vi.clearAllTimers();
+    vi.restoreAllMocks();
     vi.useRealTimers();
   });
 

--- a/src/agents/model-catalog-browse.test.ts
+++ b/src/agents/model-catalog-browse.test.ts
@@ -119,22 +119,28 @@ describe("loadModelCatalogForBrowse", () => {
   it("caps oversized browse timeouts before scheduling the fallback timer", async () => {
     vi.useFakeTimers();
     const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
-    const loadCatalog = vi.fn(
-      () =>
-        new Promise<ModelCatalogEntry[]>((resolve) => {
-          setTimeout(() => resolve(readOnlyCatalog), 5);
-        }),
-    );
+    try {
+      const loadCatalog = vi.fn(
+        () =>
+          new Promise<ModelCatalogEntry[]>((resolve) => {
+            setTimeout(() => resolve(readOnlyCatalog), 5);
+          }),
+      );
 
-    const resultPromise = loadModelCatalogForBrowse({
-      cfg: config(),
-      loadCatalog,
-      timeoutMs: Number.MAX_SAFE_INTEGER,
-    });
+      const resultPromise = loadModelCatalogForBrowse({
+        cfg: config(),
+        loadCatalog,
+        timeoutMs: Number.MAX_SAFE_INTEGER,
+      });
 
-    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
-    await vi.advanceTimersByTimeAsync(5);
+      expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+      await vi.advanceTimersByTimeAsync(5);
 
-    await expect(resultPromise).resolves.toBe(readOnlyCatalog);
+      await expect(resultPromise).resolves.toBe(readOnlyCatalog);
+    } finally {
+      timeoutSpy.mockRestore();
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/plugins/plugin-module-loader-cache.ts
+++ b/src/plugins/plugin-module-loader-cache.ts
@@ -61,11 +61,6 @@ const pluginModuleLoaderStats = {
   sourceTransformTargets: new Map<string, number>(),
 };
 
-function isJitiLoaderModule(value: unknown): value is { createJiti: PluginModuleLoaderFactory } {
-  const canHaveProperties = (value && typeof value === "object") || typeof value === "function";
-  return canHaveProperties && "createJiti" in value && typeof value.createJiti === "function";
-}
-
 function recordSourceTransformTarget(target: string): void {
   const current = pluginModuleLoaderStats.sourceTransformTargets.get(target) ?? 0;
   pluginModuleLoaderStats.sourceTransformTargets.set(target, current + 1);


### PR DESCRIPTION
Fixes #86161

## Summary
- Route Telegram edit actions with only inline buttons through the existing `editMessageReplyMarkup` helper so markup-only media edits do not require text.
- Add a caption edit mode that calls Telegram `editMessageCaption` when `caption` is supplied.
- Let normal edit actions retry through `editMessageCaption` when Telegram reports the target message has no editable text.

## Real behavior proof
**Behavior addressed:** Telegram `editMessage` can now update media-message captions and reply markup instead of always requiring text and calling `editMessageText`.

**Real environment tested:** Isolated local worktree checked out at PR head `0f1c16069acef70ec83e93f52be2538d3f50ddb3`; Node `v24.15.0`; repository-pinned `grammy@1.43.0`; real Telegram Bot API private chat using `Andy_ATLAS_bot`; bot id, chat id, token, and private chat identifiers redacted.

**Exact steps or command run after this patch:** Sent a real Telegram photo message with an initial caption, confirmed raw Telegram `editMessageText` against that media message returned `400: Bad Request: there is no text in the message to edit`, then ran the patched OpenClaw Telegram action surface with `handleTelegramAction({ action: "editMessage", chatId, messageId, caption })`. Sent a real Telegram text message with inline button `Before`, then ran `handleTelegramAction({ action: "editMessage", chatId, messageId, presentation: { blocks: [{ type: "buttons", buttons: [{ label: "After", url: "https://github.com/openclaw/openclaw/issues/86161" }] }] } })` with no content/caption. Also ran `pnpm install --frozen-lockfile` and `pnpm exec vitest run extensions/telegram/src/action-runtime.test.ts extensions/telegram/src/send.test.ts`.

**Evidence after fix:** Redacted live Bot API request/response log showed `editMessageCaption` returned the same media `message_id` with the updated caption, and `editMessageReplyMarkup` returned the same text-message `message_id` with inline keyboard changed from `Before` to `After`. Assertion summary:
```json
{
  "rawEditMessageTextFailedForMedia": true,
  "actionCaptionEndpointUsed": true,
  "actionCaptionEditedSameMessageId": true,
  "actionReplyMarkupEditedSameMessageId": true
}
```
Additional helper-level proof showed `editMessageTelegram(..., editMode: "auto")` first observed the real `editMessageText` no-text failure, then fell back to real `editMessageCaption` and edited the same message id in place.

**Observed result after fix:** The media caption edit succeeded in place through `editMessageCaption`; the button-only edit succeeded in place through `editMessageReplyMarkup` with message text unchanged; focused Telegram tests passed (2 files, 177 tests).

**What was not tested:** No public screenshot or screen recording is attached; proof is from redacted live Bot API request/response logs against real Telegram messages.


## Validation
- `node scripts/run-vitest.mjs extensions/telegram/src/action-runtime.test.ts extensions/telegram/src/send.test.ts`
- `node scripts/run-vitest.mjs src/agents/tools/message-tool.test.ts`
- `node scripts/run-tsgo.mjs`
- `node_modules/.bin/oxfmt --check --threads=1 extensions/telegram/src/send.ts extensions/telegram/src/send.test-harness.ts extensions/telegram/src/send.test.ts extensions/telegram/src/action-runtime.ts extensions/telegram/src/action-runtime.test.ts`
- `git diff --check`

If this PR is squashed or reworked, please preserve Andy Ye as the author or include:
Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>


