### PR TITLE
Guard OpenAI chat payload turns

### DIFF
--- a/src/agents/openai-compatible-conversation-turn.test.ts
+++ b/src/agents/openai-compatible-conversation-turn.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { hasOpenAICompatibleConversationTurn } from "./openai-compatible-conversation-turn.js";
+
+describe("hasOpenAICompatibleConversationTurn", () => {
+  it("rejects missing, system-only, and tool-only payloads", () => {
+    expect(hasOpenAICompatibleConversationTurn(undefined)).toBe(false);
+    expect(hasOpenAICompatibleConversationTurn([{ role: "system", content: "policy" }])).toBe(
+      false,
+    );
+    expect(
+      hasOpenAICompatibleConversationTurn([
+        { role: "system", content: "policy" },
+        { role: "tool", content: "tool output", tool_call_id: "call_1" },
+      ]),
+    ).toBe(false);
+  });
+
+  it("rejects empty user and assistant placeholders", () => {
+    expect(hasOpenAICompatibleConversationTurn([{ role: "user", content: "" }])).toBe(false);
+    expect(hasOpenAICompatibleConversationTurn([{ role: "user", content: "   " }])).toBe(false);
+    expect(hasOpenAICompatibleConversationTurn([{ role: "assistant", content: null }])).toBe(false);
+    expect(hasOpenAICompatibleConversationTurn([{ role: "assistant", content: [] }])).toBe(false);
+  });
+
+  it("accepts non-empty user and assistant content", () => {
+    expect(hasOpenAICompatibleConversationTurn([{ role: "user", content: "hello" }])).toBe(true);
+    expect(
+      hasOpenAICompatibleConversationTurn([
+        { role: "user", content: [{ type: "text", text: "hello" }] },
+      ]),
+    ).toBe(true);
+    expect(
+      hasOpenAICompatibleConversationTurn([
+        { role: "user", content: [{ type: "image_url", image_url: { url: "data:image/png" } }] },
+      ]),
+    ).toBe(true);
+    expect(hasOpenAICompatibleConversationTurn([{ role: "assistant", content: "answer" }])).toBe(
+      true,
+    );
+  });
+
+  it("accepts assistant tool calls even when assistant content is empty", () => {
+    expect(
+      hasOpenAICompatibleConversationTurn([
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [{ id: "call_1", type: "function", function: { name: "status" } }],
+        },
+      ]),
+    ).toBe(true);
+  });
+});

--- a/src/agents/openai-compatible-conversation-turn.ts
+++ b/src/agents/openai-compatible-conversation-turn.ts
@@ -1,0 +1,53 @@
+function hasNonEmptyString(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function hasNonEmptyContentPart(part: unknown): boolean {
+  if (!part || typeof part !== "object") {
+    return false;
+  }
+  const record = part as Record<string, unknown>;
+  if (record.type === "text") {
+    return hasNonEmptyString(record.text);
+  }
+  return true;
+}
+
+function hasNonEmptyMessageContent(content: unknown): boolean {
+  if (hasNonEmptyString(content)) {
+    return true;
+  }
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  return content.some(hasNonEmptyContentPart);
+}
+
+function hasAssistantToolCall(message: Record<string, unknown>): boolean {
+  const toolCalls = message.tool_calls;
+  return (
+    Array.isArray(toolCalls) &&
+    toolCalls.some((toolCall) => {
+      return Boolean(toolCall && typeof toolCall === "object");
+    })
+  );
+}
+
+export function hasOpenAICompatibleConversationTurn(messages: unknown): boolean {
+  if (!Array.isArray(messages)) {
+    return false;
+  }
+  return messages.some((message) => {
+    if (!message || typeof message !== "object") {
+      return false;
+    }
+    const record = message as Record<string, unknown>;
+    if (record.role === "user") {
+      return hasNonEmptyMessageContent(record.content);
+    }
+    if (record.role === "assistant") {
+      return hasNonEmptyMessageContent(record.content) || hasAssistantToolCall(record);
+    }
+    return false;
+  });
+}

--- a/src/agents/openai-completions-compat.test.ts
+++ b/src/agents/openai-completions-compat.test.ts
@@ -82,6 +82,26 @@ describe("resolveOpenAICompletionsCompatDefaults", () => {
     expect(defaults.supportsReasoningEffort).toBe(false);
     expect(defaults.maxTokensField).toBe("max_tokens");
   });
+
+  it("requires a non-empty user or assistant turn for ModelStudio-compatible providers", () => {
+    expect(
+      resolveOpenAICompletionsCompatDefaults({
+        provider: "qwen",
+        endpointClass: "modelstudio-native",
+        knownProviderFamily: "modelstudio",
+      }).requiresNonEmptyUserOrAssistantMessage,
+    ).toBe(true);
+  });
+
+  it("does not require a non-empty user or assistant turn for generic local endpoints", () => {
+    expect(
+      resolveOpenAICompletionsCompatDefaults({
+        provider: "vllm",
+        endpointClass: "local",
+        knownProviderFamily: "vllm",
+      }).requiresNonEmptyUserOrAssistantMessage,
+    ).toBe(false);
+  });
 });
 
 describe("detectOpenAICompletionsCompat", () => {

--- a/src/agents/openai-completions-compat.ts
+++ b/src/agents/openai-completions-compat.ts
@@ -21,6 +21,7 @@ type OpenAICompletionsCompatDefaults = {
   visibleReasoningDetailTypes: string[];
   supportsStrictMode: boolean;
   requiresReasoningContentOnAssistantMessages: boolean;
+  requiresNonEmptyUserOrAssistantMessage: boolean;
 };
 
 type DetectedOpenAICompletionsCompat = {
@@ -51,6 +52,10 @@ export function resolveOpenAICompletionsCompatDefaults(
     knownProviderFamily === "modelstudio" ||
     endpointClass === "moonshot-native" ||
     endpointClass === "modelstudio-native";
+  const isModelStudioLike =
+    knownProviderFamily === "modelstudio" ||
+    endpointClass === "modelstudio-native" ||
+    (isDefaultRoute && isDefaultRouteProvider(provider, "dashscope", "modelstudio", "qwen"));
   const isZai =
     endpointClass === "zai-native" ||
     (isDefaultRoute && isDefaultRouteProvider(input.provider, "zai"));
@@ -112,6 +117,7 @@ export function resolveOpenAICompletionsCompatDefaults(
     visibleReasoningDetailTypes: isOpenRouterLike ? ["response.output_text", "response.text"] : [],
     supportsStrictMode: !isZai && !usesConfiguredNonOpenAIEndpoint,
     requiresReasoningContentOnAssistantMessages: isDeepSeek || isXiaomi,
+    requiresNonEmptyUserOrAssistantMessage: isModelStudioLike,
   };
 }
 

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1028,13 +1028,13 @@ describe("openai transport stream", () => {
     }
   });
 
-  it("refuses OpenAI-compatible chat streams with no user or assistant payload turns", async () => {
+  it("refuses ModelStudio chat streams with no user or assistant payload turns", async () => {
     const model = {
-      id: "mlx-community/Qwen3-30B-A3B-6bit",
-      name: "Qwen3 MLX",
+      id: "qwen-coder-plus",
+      name: "qwen-coder-plus",
       api: "openai-completions",
-      provider: "mlx",
-      baseUrl: "http://127.0.0.1:9/v1",
+      provider: "qwen",
+      baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
       reasoning: false,
       input: ["text"],
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -1066,6 +1066,96 @@ describe("openai transport stream", () => {
       "contains no non-empty user or assistant messages",
     );
     expect(String(errorPayload?.errorMessage)).toContain("system/tool-only request");
+  });
+
+  it("allows generic OpenAI-compatible chat streams without the ModelStudio turn guard", async () => {
+    let capturedRoles: string[] | undefined;
+    const server = createServer((req, res) => {
+      let body = "";
+      req.setEncoding("utf8");
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        const parsed = JSON.parse(body) as { messages?: Array<{ role?: string }> };
+        capturedRoles = parsed.messages?.map((message) => message.role ?? "");
+        res.writeHead(200, {
+          "content-type": "text/event-stream; charset=utf-8",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        });
+        const created = Math.floor(Date.now() / 1000);
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-system-only",
+            object: "chat.completion.chunk",
+            created,
+            model: "generic-openai-compatible",
+            choices: [
+              {
+                index: 0,
+                delta: { role: "assistant", content: "OK" },
+                finish_reason: null,
+              },
+            ],
+          })}\n\n`,
+        );
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-system-only",
+            object: "chat.completion.chunk",
+            created,
+            model: "generic-openai-compatible",
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+          })}\n\n`,
+        );
+        res.write("data: [DONE]\n\n");
+        res.end();
+      });
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Missing loopback server address");
+      }
+      const model = {
+        id: "generic-openai-compatible",
+        name: "Generic OpenAI Compatible",
+        api: "openai-completions",
+        provider: "custom-openai-compatible",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 4096,
+        maxTokens: 256,
+      } satisfies Model<"openai-completions">;
+      const stream = createOpenAICompletionsTransportStreamFn()(
+        model,
+        {
+          systemPrompt: "runtime-only system prompt",
+          messages: [],
+          tools: [],
+        } as never,
+        { apiKey: "test-key" } as never,
+      );
+
+      let doneReason: string | undefined;
+      for await (const event of stream as AsyncIterable<{ type: string; reason?: string }>) {
+        if (event.type === "done") {
+          doneReason = event.reason;
+        }
+      }
+
+      expect(capturedRoles).toEqual(["system"]);
+      expect(doneReason).toBe("stop");
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   });
 
   it("parses JSON chat completions returned to streaming requests", async () => {

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1028,6 +1028,44 @@ describe("openai transport stream", () => {
     }
   });
 
+  it("refuses OpenAI-compatible chat streams with no user or assistant payload turns", async () => {
+    const model = {
+      id: "mlx-community/Qwen3-30B-A3B-6bit",
+      name: "Qwen3 MLX",
+      api: "openai-completions",
+      provider: "mlx",
+      baseUrl: "http://127.0.0.1:9/v1",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 4096,
+      maxTokens: 256,
+    } satisfies Model<"openai-completions">;
+    const stream = createOpenAICompletionsTransportStreamFn()(
+      model,
+      {
+        systemPrompt: "runtime-only system prompt",
+        messages: [],
+        tools: [],
+      } as never,
+      { apiKey: "test-key" } as never,
+    );
+
+    let errorPayload: Record<string, unknown> | undefined;
+    for await (const event of stream as AsyncIterable<{
+      type: string;
+      error?: Record<string, unknown>;
+    }>) {
+      if (event.type === "error") {
+        errorPayload = event.error;
+      }
+    }
+
+    expect(errorPayload).toMatchObject({ stopReason: "error" });
+    expect(String(errorPayload?.errorMessage)).toContain("contains no user or assistant messages");
+    expect(String(errorPayload?.errorMessage)).toContain("system/tool-only request");
+  });
+
   it("parses JSON chat completions returned to streaming requests", async () => {
     let capturedStreamFlag: unknown;
     const server = createServer((req, res) => {

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1062,7 +1062,9 @@ describe("openai transport stream", () => {
     }
 
     expect(errorPayload).toMatchObject({ stopReason: "error" });
-    expect(String(errorPayload?.errorMessage)).toContain("contains no user or assistant messages");
+    expect(String(errorPayload?.errorMessage)).toContain(
+      "contains no non-empty user or assistant messages",
+    );
     expect(String(errorPayload?.errorMessage)).toContain("system/tool-only request");
   });
 

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2290,6 +2290,29 @@ function hasToolHistory(messages: Context["messages"]): boolean {
   );
 }
 
+function assertOpenAICompletionsPayloadHasConversationTurn(
+  params: Record<string, unknown>,
+  model: Model<Api>,
+): void {
+  const messages = params.messages;
+  if (!Array.isArray(messages)) {
+    return;
+  }
+  const hasConversationTurn = messages.some((message) => {
+    if (!message || typeof message !== "object") {
+      return false;
+    }
+    const role = (message as { role?: unknown }).role;
+    return role === "user" || role === "assistant";
+  });
+  if (hasConversationTurn) {
+    return;
+  }
+  throw new Error(
+    `OpenAI-compatible chat payload for ${model.provider}/${model.id} contains no user or assistant messages after compaction and transport transforms; refusing to send a system/tool-only request. Start a new user turn or repair the compacted session history.`,
+  );
+}
+
 function createOpenAICompletionsClient(
   model: Model<Api>,
   context: Context,
@@ -2405,6 +2428,7 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
           enforceCodeModeResponsesToolSurface(params);
           assertCodeModeResponsesToolSurface(params);
         }
+        assertOpenAICompletionsPayloadHasConversationTurn(params, model);
         const responseStream = (await client.chat.completions.create(
           params as never,
           buildOpenAISdkRequestOptions(model, options?.signal),

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2419,7 +2419,10 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
           enforceCodeModeResponsesToolSurface(params);
           assertCodeModeResponsesToolSurface(params);
         }
-        assertOpenAICompletionsPayloadHasConversationTurn(params, model);
+        const compat = getCompat(model as OpenAIModeModel);
+        if (compat.requiresNonEmptyUserOrAssistantMessage) {
+          assertOpenAICompletionsPayloadHasConversationTurn(params, model);
+        }
         const responseStream = (await client.chat.completions.create(
           params as never,
           buildOpenAISdkRequestOptions(model, options?.signal),
@@ -2869,6 +2872,7 @@ function detectCompat(model: OpenAIModeModel) {
     supportsStrictMode: compatDefaults.supportsStrictMode,
     requiresReasoningContentOnAssistantMessages:
       compatDefaults.requiresReasoningContentOnAssistantMessages,
+    requiresNonEmptyUserOrAssistantMessage: compatDefaults.requiresNonEmptyUserOrAssistantMessage,
   };
 }
 
@@ -2891,6 +2895,7 @@ function getCompat(model: OpenAIModeModel): {
   strictMessageKeys: boolean;
   visibleReasoningDetailTypes: string[];
   requiresReasoningContentOnAssistantMessages: boolean;
+  requiresNonEmptyUserOrAssistantMessage: boolean;
 } {
   const detected = detectCompat(model);
   const compat = model.compat ?? {};
@@ -2924,6 +2929,7 @@ function getCompat(model: OpenAIModeModel): {
       compat.visibleReasoningDetailTypes ?? detected.visibleReasoningDetailTypes,
     requiresReasoningContentOnAssistantMessages:
       detected.requiresReasoningContentOnAssistantMessages,
+    requiresNonEmptyUserOrAssistantMessage: detected.requiresNonEmptyUserOrAssistantMessage,
   };
 }
 

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -40,6 +40,7 @@ import {
   resolveModelSseDebugMode,
 } from "./model-transport-debug.js";
 import { formatModelTransportDebugBaseUrl } from "./model-transport-url.js";
+import { hasOpenAICompatibleConversationTurn } from "./openai-compatible-conversation-turn.js";
 import { detectOpenAICompletionsCompat } from "./openai-completions-compat.js";
 import {
   flattenCompletionMessagesToStringContent,
@@ -2295,21 +2296,11 @@ function assertOpenAICompletionsPayloadHasConversationTurn(
   model: Model<Api>,
 ): void {
   const messages = params.messages;
-  if (!Array.isArray(messages)) {
-    return;
-  }
-  const hasConversationTurn = messages.some((message) => {
-    if (!message || typeof message !== "object") {
-      return false;
-    }
-    const role = (message as { role?: unknown }).role;
-    return role === "user" || role === "assistant";
-  });
-  if (hasConversationTurn) {
+  if (!Array.isArray(messages) || hasOpenAICompatibleConversationTurn(messages)) {
     return;
   }
   throw new Error(
-    `OpenAI-compatible chat payload for ${model.provider}/${model.id} contains no user or assistant messages after compaction and transport transforms; refusing to send a system/tool-only request. Start a new user turn or repair the compacted session history.`,
+    `OpenAI-compatible chat payload for ${model.provider}/${model.id} contains no non-empty user or assistant messages after compaction and transport transforms; refusing to send a system/tool-only request. Start a new user turn or repair the compacted session history.`,
   );
 }
 

--- a/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.test.ts
@@ -143,6 +143,19 @@ describe("resolvePromptSubmissionSkipReason", () => {
     ).toBe("empty_prompt_history_images");
   });
 
+  it("treats empty user and assistant placeholders as empty history", () => {
+    expect(
+      resolvePromptSubmissionSkipReason({
+        prompt: "   ",
+        messages: [
+          { role: "user", content: "   " },
+          { role: "assistant", content: [] },
+        ],
+        imageCount: 0,
+      }),
+    ).toBe("empty_prompt_history_images");
+  });
+
   it("allows text or image prompt submissions", () => {
     expect(
       resolvePromptSubmissionSkipReason({

--- a/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.test.ts
@@ -130,6 +130,19 @@ describe("resolvePromptSubmissionSkipReason", () => {
     ).toBe("blank_user_prompt");
   });
 
+  it("treats system/tool-only replay as empty history for blank submissions", () => {
+    expect(
+      resolvePromptSubmissionSkipReason({
+        prompt: "   ",
+        messages: [
+          { role: "system", content: "runtime-only policy" },
+          { role: "toolResult", content: "old tool output", toolCallId: "call-1" },
+        ],
+        imageCount: 0,
+      }),
+    ).toBe("empty_prompt_history_images");
+  });
+
   it("allows text or image prompt submissions", () => {
     expect(
       resolvePromptSubmissionSkipReason({

--- a/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
@@ -18,6 +18,7 @@ import { listActiveProcessSessionReferences } from "../../bash-process-reference
 import { resolveHeartbeatPromptForSystemPrompt } from "../../heartbeat-system-prompt.js";
 import { buildActiveImageGenerationTaskPromptContextForSession } from "../../image-generation-task-status.js";
 import { buildActiveMusicGenerationTaskPromptContextForSession } from "../../music-generation-task-status.js";
+import { hasOpenAICompatibleConversationTurn } from "../../openai-compatible-conversation-turn.js";
 import { resolveProcessToolScopeKey } from "../../pi-tools.js";
 import { prependSystemPromptAdditionAfterCacheBoundary } from "../../system-prompt-cache-boundary.js";
 import { resolveEffectiveToolFsWorkspaceOnly } from "../../tool-fs-policy.js";
@@ -242,16 +243,6 @@ export function shouldWarnOnOrphanedUserRepair(
 
 export type PromptSubmissionSkipReason = "blank_user_prompt" | "empty_prompt_history_images";
 
-function hasProviderVisibleConversationTurn(messages: readonly unknown[]): boolean {
-  return messages.some((message) => {
-    if (!message || typeof message !== "object") {
-      return false;
-    }
-    const role = (message as { role?: unknown }).role;
-    return role === "user" || role === "assistant";
-  });
-}
-
 export function resolvePromptSubmissionSkipReason(params: {
   prompt: string;
   messages: readonly unknown[];
@@ -261,7 +252,7 @@ export function resolvePromptSubmissionSkipReason(params: {
   if (params.prompt.trim().length > 0 || params.imageCount > 0) {
     return null;
   }
-  return hasProviderVisibleConversationTurn(params.messages)
+  return hasOpenAICompatibleConversationTurn(params.messages)
     ? "blank_user_prompt"
     : "empty_prompt_history_images";
 }

--- a/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
@@ -242,6 +242,16 @@ export function shouldWarnOnOrphanedUserRepair(
 
 export type PromptSubmissionSkipReason = "blank_user_prompt" | "empty_prompt_history_images";
 
+function hasProviderVisibleConversationTurn(messages: readonly unknown[]): boolean {
+  return messages.some((message) => {
+    if (!message || typeof message !== "object") {
+      return false;
+    }
+    const role = (message as { role?: unknown }).role;
+    return role === "user" || role === "assistant";
+  });
+}
+
 export function resolvePromptSubmissionSkipReason(params: {
   prompt: string;
   messages: readonly unknown[];
@@ -251,7 +261,9 @@ export function resolvePromptSubmissionSkipReason(params: {
   if (params.prompt.trim().length > 0 || params.imageCount > 0) {
     return null;
   }
-  return params.messages.length > 0 ? "blank_user_prompt" : "empty_prompt_history_images";
+  return hasProviderVisibleConversationTurn(params.messages)
+    ? "blank_user_prompt"
+    : "empty_prompt_history_images";
 }
 
 const QUEUED_USER_MESSAGE_MARKER =

--- a/src/agents/pi-hooks/compaction-safeguard.test.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.test.ts
@@ -2262,6 +2262,75 @@ describe("compaction-safeguard double-compaction guard", () => {
     ).toBe(true);
   });
 
+  it("recovers user and assistant branch turns when compaction preparation has only tool output", async () => {
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue("branch summary with visible turns");
+
+    const now = Date.now();
+    const sessionManager = {
+      ...stubSessionManager(),
+      getBranch: () => [
+        {
+          type: "message",
+          id: "user-1",
+          parentId: null,
+          timestamp: new Date(now).toISOString(),
+          message: {
+            role: "user",
+            content: "what is the deployment status?",
+            timestamp: now,
+          },
+        },
+        {
+          type: "message",
+          id: "assistant-1",
+          parentId: "user-1",
+          timestamp: new Date(now + 1).toISOString(),
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "I will check the deploy." }],
+            timestamp: now + 1,
+          },
+        },
+      ],
+    } as ExtensionContext["sessionManager"];
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model, recentTurnsPreserve: 0 });
+
+    const mockEvent = {
+      preparation: {
+        messagesToSummarize: [
+          {
+            role: "toolResult",
+            toolCallId: "call-1",
+            toolName: "status",
+            content: [{ type: "text", text: "deploy green" }],
+            timestamp: now + 2,
+          },
+        ] as AgentMessage[],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-6",
+        tokensBefore: 38085,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 4000 },
+        isSplitTurn: true,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+    const { result } = await runCompactionScenario({
+      sessionManager,
+      event: mockEvent,
+      apiKey: "test-key",
+    });
+
+    const compaction = expectCompactionResult(result);
+    expect(compaction.summary).toContain("branch summary with visible turns");
+    const summarizeCall = requireRecord(mockCallArg(mockSummarizeInStages));
+    const messages = requireArray(summarizeCall.messages);
+    expect(messages.map((message) => requireRecord(message).role)).toEqual(["user", "assistant"]);
+  });
+
   it("continues when messages include real conversation content", async () => {
     const sessionManager = stubSessionManager();
     const model = createAnthropicModelFixture();


### PR DESCRIPTION
Fixes #86145

## Summary
- Refuse ModelStudio/DashScope OpenAI-compatible chat streams when compaction/transport transforms leave no non-empty user or assistant turn in the final outbound `messages[]` payload, without making that invariant global for every OpenAI-compatible route.
- Treat blank prompt submissions with system/tool-only replay, or empty user/assistant placeholders, as empty history instead of replay-backed blank user prompts.
- Share one content-aware OpenAI-compatible conversation-turn helper across the scoped transport backstop and prompt submission classifier.
- Add regressions for the stream-time guard, conversation-turn helper, and compaction branch recovery of user/assistant turns when preparation only contains tool output.

## Real behavior proof
Behavior addressed: Qwen/ModelStudio OpenAI-compatible chat requests no longer reach the provider with a `messages[]` payload that has no non-empty user or assistant turn after compaction and transport transforms.

Real environment tested: Local OpenClaw runtime on this PR branch, using `createOpenAICompletionsTransportStreamFn` against a real local HTTP/SSE endpoint that behaves like an OpenAI-compatible `/v1/chat/completions` server. I also tested remote Alibaba Cloud Model Studio / DashScope international with a locally supplied API key; the key was not logged or included in this PR.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/openai-completions-compat.test.ts src/agents/openai-compatible-conversation-turn.test.ts src/agents/openai-transport-stream.test.ts src/agents/pi-embedded-runner/run/attempt.prompt-helpers.test.ts src/agents/pi-hooks/compaction-safeguard.test.ts`

Evidence after fix: The focused Vitest run passed 8 files / 613 tests. The OpenAI-compatible transport test exercises the real `createOpenAICompletionsTransportStreamFn` path and verifies system-only payloads are rejected locally before sending to the configured endpoint. The new helper tests verify that system/tool-only payloads and empty user/assistant placeholders are rejected, while non-empty user/assistant content and assistant `tool_calls` are accepted. The transport regression also proves a generic local OpenAI-compatible route can still send a system-only request when it is not a ModelStudio-compatible endpoint.

Remote provider evidence: On DashScope international (`https://dashscope-intl.aliyuncs.com/compatible-mode/v1`), the tested account exposed `qwen3-coder-plus`, dated `qwen3-coder-plus` variants, `qwen3-coder-next`, and `qwen-coder-plus`. The `qwen3-coder-plus` variants accepted the tested `system`-only, `system+tool`, and `tool`-only shapes with HTTP 200 on this account, so I could not reproduce the exact reported `qwen3-coder-plus` 400. `qwen-coder-plus` returned HTTP 400 for `system+tool` and `tool`-only with: `messages with role "tool" must be a response to a preceeding message with "tool_calls".` The account did not expose `qwen-long` on the international endpoint; the China endpoint rejected this international key as `invalid_api_key`.

Observed result after fix: The malformed final payload shape is caught locally by OpenClaw before the network send. Normal payloads with a non-empty user turn still pass through, assistant tool-call turns are not blocked solely because their `content` is empty/null, and generic non-ModelStudio OpenAI-compatible routes are not newly blocked.

What was not tested: I did not reproduce the exact `qwen3-coder-plus` `Role must be user or assistant and Content length must be greater than 0` 400 with the available DashScope international account. That may require the reporter's exact captured payload, proxy/provider route, or a China-region `qwen-long` key. Local `node scripts/run-tsgo.mjs` did not complete within about 20 minutes on this checkout and was stopped; CI remains the broader type gate.

## Validation
- `node scripts/run-vitest.mjs src/agents/openai-completions-compat.test.ts src/agents/openai-compatible-conversation-turn.test.ts src/agents/openai-transport-stream.test.ts src/agents/pi-embedded-runner/run/attempt.prompt-helpers.test.ts src/agents/pi-hooks/compaction-safeguard.test.ts`
- `node_modules/.bin/oxfmt --check --threads=1 src/agents/openai-compatible-conversation-turn.ts src/agents/openai-compatible-conversation-turn.test.ts src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts src/agents/pi-embedded-runner/run/attempt.prompt-helpers.test.ts src/agents/pi-hooks/compaction-safeguard.test.ts`
- `git diff --check`

If this PR is squashed or reworked, please preserve Andy Ye as the author or include:
Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>

