### PR TITLE
fix(ui): filter session picker sessions by current agent in Control UI

### DIFF
--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -95,7 +95,7 @@ export const CHAT_SESSIONS_ACTIVE_MINUTES = 0;
 export const CHAT_SESSIONS_REFRESH_LIMIT = 50;
 
 export function createChatSessionsLoadOverrides(
-  state: { sessionsShowArchived?: boolean },
+  state: { sessionsShowArchived?: boolean; sessionKey?: string },
   options: { offset?: number; append?: boolean; search?: string | null } = {},
 ): LoadSessionsOverrides {
   const overrides: LoadSessionsOverrides = {
@@ -105,6 +105,10 @@ export function createChatSessionsLoadOverrides(
     includeUnknown: true,
     configuredAgentsOnly: true,
   };
+  const parsed = parseAgentSessionKey(state.sessionKey ?? "");
+  if (parsed?.agentId) {
+    overrides.agentId = parsed.agentId;
+  }
   if (typeof state.sessionsShowArchived === "boolean") {
     overrides.showArchived = state.sessionsShowArchived;
   }

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -253,19 +253,28 @@ function createChatSessionPickerRequestParams(
     configuredAgentsOnly: overrides.configuredAgentsOnly,
     limit: overrides.limit,
   };
-  const activeAgentSession = parseAgentSessionKey(state.sessionKey);
-  const activeSessionRow = state.sessionsResult?.sessions.find(
-    (row) => row.key === state.sessionKey,
-  );
-  const isGlobalScopeSession =
-    activeSessionRow?.kind === "global" ||
-    activeSessionRow?.kind === "unknown" ||
-    state.sessionKey === "global" ||
-    state.sessionKey === "unknown";
-  if (activeAgentSession || !isGlobalScopeSession) {
-    params.agentId = normalizeAgentId(
-      activeAgentSession?.agentId ?? state.agentsList?.defaultId ?? "main",
-    );
+  // Use agentId from overrides if set (sessionKey in agent:xxx:yyy format).
+  // Otherwise fallback to agentsList.defaultId or "main" for non-agent session keys.
+  const agentId = normalizeOptionalString(overrides.agentId);
+  if (agentId) {
+    params.agentId = agentId;
+  } else {
+    const parsed = parseAgentSessionKey(state.sessionKey);
+    if (!parsed) {
+      // sessionKey is not in agent:xxx:yyy format (e.g., "main", "global", "unknown").
+      // For non-global scope, add agentId fallback.
+      const activeSessionRow = state.sessionsResult?.sessions.find(
+        (row) => row.key === state.sessionKey,
+      );
+      const isGlobalScopeSession =
+        activeSessionRow?.kind === "global" ||
+        activeSessionRow?.kind === "unknown" ||
+        state.sessionKey === "global" ||
+        state.sessionKey === "unknown";
+      if (!isGlobalScopeSession) {
+        params.agentId = normalizeAgentId(state.agentsList?.defaultId ?? "main");
+      }
+    }
   }
   const offset =
     typeof overrides.offset === "number" && Number.isFinite(overrides.offset)


### PR DESCRIPTION
## Summary

Fixes Control UI session picker showing sessions from all agents instead of just the currently selected agent.

## Problem

When a specific agent is selected in Control UI Chat, the session picker displays sessions from all configured agents (main, stockclaw, printclaw, etc.) instead of filtering to only the selected agent's sessions.

## Root Cause

`createChatSessionsLoadOverrides()` in `ui/src/ui/app-chat.ts` did not pass `agentId` to the `sessions.list` RPC call, even though the backend supports `agentId` filtering.

## Fix

Extract `agentId` from `sessionKey` in `createChatSessionsLoadOverrides()` and pass it through to the load overrides.

| File | Changes |
|------|---------|
| `ui/src/ui/app-chat.ts` | +4 | Parse agentId from sessionKey and pass to overrides |

Fixes: #86183