### PR TITLE
fix(ui): make local markdown file links inert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI: make Markdown Preview render host-local absolute file links as inert text links instead of misleading same-origin Gateway routes. (#84467)
 - Scripts: run the optional Discord native opus installer through the shared pnpm launcher and Windows CI coverage so native Windows installs avoid shell-mode package-manager shims.
 - Agents/MCP: bound bundled MCP `tools/list` catalog discovery so hung MCP servers do not block session tool materialization. (#85063) Thanks @nxmxbbd.
 - Scripts: run generated-module formatting through the shared pnpm launcher and Windows CI coverage so native Windows generator checks avoid shell-mode package-manager shims.

--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -537,6 +537,20 @@ describe("toSanitizedMarkdownHtml", () => {
       const html = toSanitizedMarkdownHtml("[click](file:///etc/passwd)");
       expect(html).toBe("<p><a>click</a></p>\n");
     });
+
+    it("strips href from host-local absolute file paths", () => {
+      const html = toSanitizedMarkdownHtml(
+        "[example.docx](/Users/alice/.openclaw/data/plugin/output/example.docx)",
+      );
+      expect(html).toBe("<p><a>example.docx</a></p>\n");
+    });
+
+    it("keeps regular root-relative app links clickable", () => {
+      const html = toSanitizedMarkdownHtml("[session](/chat?session=agent%3Amain)");
+      expect(html).toBe(
+        '<p><a href="/chat?session=agent%3Amain" rel="noreferrer noopener" target="_blank">session</a></p>\n',
+      );
+    });
   });
 
   describe("ReDoS protection", () => {

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -94,6 +94,14 @@ const TAIL_LINK_BLUR_CLASS = "chat-link-tail-blur";
 const CJK_RE =
   /[\u2E80-\u2FFF\u3000-\u303F\u3040-\u309F\u30A0-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uAC00-\uD7AF\uF900-\uFAFF\uFF01-\uFF60]/;
 
+function isHostLocalFilesystemHref(href: string): boolean {
+  const normalized = href.trim();
+  return (
+    /^\/(?:Users|home|private|tmp|Volumes)\//.test(normalized) ||
+    /^\/var\/folders\//.test(normalized)
+  );
+}
+
 function getCachedMarkdown(key: string): string | null {
   const cached = markdownCache.get(key);
   if (cached === undefined) {
@@ -127,6 +135,11 @@ function installHooks() {
     }
     const href = node.getAttribute("href");
     if (!href) {
+      return;
+    }
+
+    if (isHostLocalFilesystemHref(href)) {
+      node.removeAttribute("href");
       return;
     }
 


### PR DESCRIPTION
## Summary

- Fixes #84467.
- Makes Markdown Preview strip navigation from host-local absolute filesystem links such as `/Users/...` so they no longer become misleading same-origin Gateway routes.
- Keeps normal root-relative app links such as `/chat?...` clickable and adds regression coverage for both paths.

## Tests

- `pnpm format:check ui/src/ui/markdown.ts ui/src/ui/markdown.test.ts`
- `node scripts/run-vitest.mjs ui/src/ui/markdown.test.ts ui/src/ui/chat/grouped-render.test.ts`
- `node scripts/run-oxlint.mjs ui/src/ui/markdown.ts ui/src/ui/markdown.test.ts`
- `pnpm lint`
- `git diff --check`

## Real behavior proof

Behavior addressed: Control UI Markdown Preview no longer turns an explicit local filesystem Markdown link like `[example.docx](/Users/alice/.openclaw/data/plugin/output/example.docx)` into a clickable same-origin Gateway route; the rendered anchor is inert while regular root-relative UI links remain clickable.
Real environment tested: macOS 26.3.2, Node v23.11.1, pnpm 11.2.2, local source checkout using the shared Markdown Preview sanitizer with a jsdom Gateway origin of `https://127.0.0.1:18789/chat?session=agent%3Amain`.
Exact steps or command run after this patch: `node --import tsx - <<'EOF'
import { JSDOM } from 'jsdom';
const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'https://127.0.0.1:18789/chat?session=agent%3Amain' });
globalThis.window = dom.window;
globalThis.document = dom.window.document;
globalThis.Node = dom.window.Node;
globalThis.Element = dom.window.Element;
globalThis.HTMLElement = dom.window.HTMLElement;
globalThis.HTMLAnchorElement = dom.window.HTMLAnchorElement;
globalThis.HTMLImageElement = dom.window.HTMLImageElement;
globalThis.DocumentFragment = dom.window.DocumentFragment;
Object.defineProperty(globalThis, 'navigator', { value: dom.window.navigator, configurable: true });
const { toSanitizedMarkdownHtml } = await import('./ui/src/ui/markdown.ts');
const local = toSanitizedMarkdownHtml('[example.docx](/Users/alice/.openclaw/data/plugin/output/example.docx)').trim();
const route = toSanitizedMarkdownHtml('[session](/chat?session=agent%3Amain)').trim();
console.log('local-file-link:', local);
console.log('app-route-link:', route);
EOF`
Evidence after fix: Terminal output from the command above was:
`local-file-link: <p><a>example.docx</a></p>
app-route-link: <p><a href="/chat?session=agent%3Amain" rel="noreferrer noopener" target="_blank">session</a></p>`
Observed result after fix: The local `/Users/...` Markdown link renders without an `href`, so it cannot navigate to a same-origin Gateway file route; the normal `/chat?session=...` root-relative link still keeps its `href`, `rel`, and `target` attributes.
What was not tested: I did not run a live browser click against a Gateway instance; this proof executes the same shared sanitizer used by Markdown Preview and chat rendering and verifies its produced DOM HTML.