### PR TITLE
fix docs tool index links

### DIFF
--- a/docs/automation/gmail-pubsub.md
+++ b/docs/automation/gmail-pubsub.md
@@ -3,9 +3,9 @@ summary: "Redirect to /automation/cron-jobs"
 title: "Gmail PubSub"
 ---
 
-This page moved to [Scheduled Tasks](/automation/cron-jobs#gmail-pubsub-integration). See [Scheduled Tasks](/automation/cron-jobs#gmail-pubsub-integration) for Gmail PubSub documentation.
+This page moved to [Scheduled Tasks](./cron-jobs.md#gmail-pubsub-integration). See [Scheduled Tasks](./cron-jobs.md#gmail-pubsub-integration) for Gmail PubSub documentation.
 
 ## Related
 
-- [Webhook](/automation/webhook)
-- [Automation troubleshooting](/automation/troubleshooting)
+- [Webhook](./webhook.md)
+- [Automation troubleshooting](./troubleshooting.md)

--- a/docs/automation/poll.md
+++ b/docs/automation/poll.md
@@ -3,10 +3,10 @@ summary: "Redirect to /cli/message"
 title: "Polls"
 ---
 
-This page moved to [Message tool](/cli/message). See [Message tool](/cli/message) for poll documentation.
+This page moved to [Message tool](../cli/message.md). See [Message tool](../cli/message.md) for poll documentation.
 
 ## Related
 
-- [Webhook](/automation/webhook)
-- [Scheduled tasks](/automation/cron-jobs)
-- [Background tasks](/automation/tasks)
+- [Webhook](./webhook.md)
+- [Scheduled tasks](./cron-jobs.md)
+- [Background tasks](./tasks.md)

--- a/docs/automation/troubleshooting.md
+++ b/docs/automation/troubleshooting.md
@@ -3,10 +3,10 @@ summary: "Redirect to /automation/cron-jobs"
 title: "Automation troubleshooting"
 ---
 
-This page moved to [Scheduled Tasks](/automation/cron-jobs#troubleshooting). See [Scheduled Tasks](/automation/cron-jobs#troubleshooting) for troubleshooting documentation.
+This page moved to [Scheduled Tasks](./cron-jobs.md#troubleshooting). See [Scheduled Tasks](./cron-jobs.md#troubleshooting) for troubleshooting documentation.
 
 ## Related
 
-- [Hooks](/automation/hooks)
-- [Background tasks](/automation/tasks)
-- [Gateway troubleshooting](/gateway/troubleshooting)
+- [Hooks](./hooks.md)
+- [Background tasks](./tasks.md)
+- [Gateway troubleshooting](../gateway/troubleshooting.md)

--- a/docs/automation/webhook.md
+++ b/docs/automation/webhook.md
@@ -3,10 +3,10 @@ summary: "Redirect to /automation/cron-jobs"
 title: "Webhooks"
 ---
 
-This page moved to [Scheduled Tasks](/automation/cron-jobs#webhooks). See [Scheduled Tasks](/automation/cron-jobs#webhooks) for webhook documentation.
+This page moved to [Scheduled Tasks](./cron-jobs.md#webhooks). See [Scheduled Tasks](./cron-jobs.md#webhooks) for webhook documentation.
 
 ## Related
 
-- [Poll](/automation/poll)
-- [Gmail PubSub](/automation/gmail-pubsub)
-- [Hooks](/automation/hooks)
+- [Poll](./poll.md)
+- [Gmail PubSub](./gmail-pubsub.md)
+- [Hooks](./hooks.md)

--- a/docs/brave-search.md
+++ b/docs/brave-search.md
@@ -4,8 +4,8 @@ title: "Brave search"
 redirect: /tools/brave-search
 ---
 
-This page has moved to [Brave Search](/tools/brave-search).
+This page has moved to [Brave Search](./tools/brave-search.md).
 
 ## Related
 
-- [Web tools](/tools/web)
+- [Web tools](./tools/web.md)

--- a/docs/gateway/network-model.md
+++ b/docs/gateway/network-model.md
@@ -6,10 +6,10 @@ title: "Network model"
 redirect: /network#core-model
 ---
 
-This content has been merged into [Network — Core model](/network#core-model).
+This content has been merged into [Network — Core model](../network.md#core-model).
 
 ## Related
 
-- [Remote access](/gateway/remote)
-- [Trusted proxy auth](/gateway/trusted-proxy-auth)
-- [Gateway protocol](/gateway/protocol)
+- [Remote access](./remote.md)
+- [Trusted proxy auth](./trusted-proxy-auth.md)
+- [Gateway protocol](./protocol.md)

--- a/docs/gateway/remote-gateway-readme.md
+++ b/docs/gateway/remote-gateway-readme.md
@@ -4,7 +4,7 @@ read_when: "Connecting the macOS app to a remote gateway over SSH"
 title: "Remote gateway setup"
 ---
 
-> This content has been merged into [Remote Access](/gateway/remote#macos-persistent-ssh-tunnel-via-launchagent). See that page for the current guide.
+> This content has been merged into [Remote Access](./remote.md#macos-persistent-ssh-tunnel-via-launchagent). See that page for the current guide.
 
 # Running OpenClaw.app with a Remote Gateway
 
@@ -165,5 +165,5 @@ OpenClaw.app connects to `ws://127.0.0.1:18789` on your client machine. The SSH 
 
 ## Related
 
-- [Remote access](/gateway/remote)
-- [Tailscale](/gateway/tailscale)
+- [Remote access](./remote.md)
+- [Tailscale](./tailscale.md)

--- a/docs/perplexity.md
+++ b/docs/perplexity.md
@@ -4,8 +4,8 @@ title: "Perplexity search"
 redirect: /tools/perplexity-search
 ---
 
-This page has moved to [Perplexity search](/tools/perplexity-search).
+This page has moved to [Perplexity search](./tools/perplexity-search.md).
 
 ## Related
 
-- [Web tools](/tools/web)
+- [Web tools](./tools/web.md)

--- a/docs/platforms/digitalocean.md
+++ b/docs/platforms/digitalocean.md
@@ -4,9 +4,9 @@ title: "DigitalOcean (platform)"
 redirect: /install/digitalocean
 ---
 
-This page has moved to [DigitalOcean](/install/digitalocean).
+This page has moved to [DigitalOcean](../install/digitalocean.md).
 
 ## Related
 
-- [Install overview](/install)
-- [VPS hosting](/vps)
+- [Install overview](../install/index.md)
+- [VPS hosting](../vps.md)

--- a/docs/platforms/oracle.md
+++ b/docs/platforms/oracle.md
@@ -4,9 +4,9 @@ title: "Oracle Cloud (platform)"
 redirect: /install/oracle
 ---
 
-This page has moved to [Oracle Cloud](/install/oracle).
+This page has moved to [Oracle Cloud](../install/oracle.md).
 
 ## Related
 
-- [Install overview](/install)
-- [VPS hosting](/vps)
+- [Install overview](../install/index.md)
+- [VPS hosting](../vps.md)

--- a/docs/platforms/raspberry-pi.md
+++ b/docs/platforms/raspberry-pi.md
@@ -4,10 +4,10 @@ title: "Raspberry Pi (platform)"
 redirect: /install/raspberry-pi
 ---
 
-This page has moved to [Raspberry Pi](/install/raspberry-pi).
+This page has moved to [Raspberry Pi](../install/raspberry-pi.md).
 
 ## Related
 
-- [Install overview](/install)
-- [Linux server](/vps)
-- [Platforms](/platforms)
+- [Install overview](../install/index.md)
+- [Linux server](../vps.md)
+- [Platforms](./index.md)

--- a/docs/plugins/building-extensions.md
+++ b/docs/plugins/building-extensions.md
@@ -5,9 +5,9 @@ read_when:
   - Legacy link to building-extensions
 ---
 
-This page has moved to [Building Plugins](/plugins/building-plugins).
+This page has moved to [Building Plugins](./building-plugins.md).
 
 ## Related
 
-- [Building plugins](/plugins/building-plugins)
-- [Plugin architecture](/plugins/architecture)
+- [Building plugins](./building-plugins.md)
+- [Plugin architecture](./architecture.md)

--- a/docs/tools/capability-cookbook.md
+++ b/docs/tools/capability-cookbook.md
@@ -4,9 +4,9 @@ title: "Adding capabilities (redirect)"
 redirect: /plugins/adding-capabilities
 ---
 
-This contributor guide moved to [Adding capabilities](/plugins/adding-capabilities).
+This contributor guide moved to [Adding capabilities](../plugins/adding-capabilities.md).
 
 ## Related
 
-- [Plugin internals](/plugins/architecture)
-- [Building plugins](/plugins/building-plugins)
+- [Plugin internals](../plugins/architecture.md)
+- [Building plugins](../plugins/building-plugins.md)

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -14,7 +14,7 @@ capabilities such as tools, providers, channels, hooks, and packaged skills.
 
 This is an overview and routing page. For exhaustive tool policy, defaults,
 group membership, provider restrictions, and configuration fields, use
-[Tools and custom providers](/gateway/config-tools).
+[Tools and custom providers](../gateway/config-tools.md).
 
 ## Start here
 
@@ -24,12 +24,12 @@ only when the agent should see fewer tools or needs explicit host access.
 | If you need to...                           | Use this first                                 | Then read                                                               |
 | ------------------------------------------- | ---------------------------------------------- | ----------------------------------------------------------------------- |
 | Let an agent act with existing capabilities | [Built-in tools](#built-in-tool-categories)    | [Tool categories](#built-in-tool-categories)                            |
-| Control what an agent can call              | [Tool policy](#configure-access-and-approvals) | [Tools and custom providers](/gateway/config-tools)                     |
-| Teach an agent a workflow                   | [Skills](#choose-tools-skills-or-plugins)      | [Skills](/tools/skills) and [Creating skills](/tools/creating-skills)   |
-| Add a new integration or runtime surface    | [Plugins](#extend-capabilities)                | [Plugins](/tools/plugin) and [Build plugins](/plugins/building-plugins) |
-| Run work later or in the background         | [Automation](/automation)                      | [Automation overview](/automation)                                      |
-| Coordinate multiple agents or harnesses     | [Sub-agents](/tools/subagents)                 | [ACP agents](/tools/acp-agents) and [Agent send](/tools/agent-send)     |
-| Search a large PI tool catalog              | [Tool Search](/tools/tool-search)              | [Tool Search](/tools/tool-search)                                       |
+| Control what an agent can call              | [Tool policy](#configure-access-and-approvals) | [Tools and custom providers](../gateway/config-tools.md)                     |
+| Teach an agent a workflow                   | [Skills](#choose-tools-skills-or-plugins)      | [Skills](skills.md) and [Creating skills](creating-skills.md)   |
+| Add a new integration or runtime surface    | [Plugins](#extend-capabilities)                | [Plugins](plugin.md) and [Build plugins](../plugins/building-plugins.md) |
+| Run work later or in the background         | [Automation](../automation/index.md)                      | [Automation overview](../automation/index.md)                                      |
+| Coordinate multiple agents or harnesses     | [Sub-agents](subagents.md)                 | [ACP agents](acp-agents.md) and [Agent send](agent-send.md)     |
+| Search a large PI tool catalog              | [Tool Search](tool-search.md)              | [Tool Search](tool-search.md)                                       |
 
 ## Choose tools, skills, or plugins
 
@@ -55,7 +55,7 @@ only when the agent should see fewer tools or needs explicit host access.
     Skills can live in a workspace, shared skill directory, managed OpenClaw
     skill root, or plugin package.
 
-    [Skills](/tools/skills) | [Creating skills](/tools/creating-skills) | [Skills config](/tools/skills-config)
+    [Skills](skills.md) | [Creating skills](creating-skills.md) | [Skills config](skills-config.md)
 
   </Step>
 
@@ -67,7 +67,7 @@ only when the agent should see fewer tools or needs explicit host access.
     plugins can be installed from ClawHub, npm, git, local directories, or
     archives.
 
-    [Install and configure plugins](/tools/plugin) | [Build plugins](/plugins/building-plugins) | [Plugin SDK](/plugins/sdk-overview)
+    [Install and configure plugins](plugin.md) | [Build plugins](../plugins/building-plugins.md) | [Plugin SDK](../plugins/sdk-overview.md)
 
   </Step>
 </Steps>
@@ -76,20 +76,20 @@ only when the agent should see fewer tools or needs explicit host access.
 
 The table lists representative tools so you can recognize the surface. It is
 not the full policy reference. For exact groups, defaults, and allow/deny
-semantics, use [Tools and custom providers](/gateway/config-tools).
+semantics, use [Tools and custom providers](../gateway/config-tools.md).
 
 | Category               | Use when the agent needs to...                                                | Representative tools                                                 | Read next                                                              |
 | ---------------------- | ----------------------------------------------------------------------------- | -------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| Runtime                | Run commands, manage processes, or use provider-backed Python analysis        | `exec`, `process`, `code_execution`                                  | [Exec](/tools/exec), [Code execution](/tools/code-execution)           |
-| Files                  | Read and change workspace files                                               | `read`, `write`, `edit`, `apply_patch`                               | [Apply patch](/tools/apply-patch)                                      |
-| Web                    | Search the web, search X posts, or fetch readable page content                | `web_search`, `x_search`, `web_fetch`                                | [Web tools](/tools/web), [Web fetch](/tools/web-fetch)                 |
-| Browser                | Operate a browser session                                                     | `browser`                                                            | [Browser](/tools/browser)                                              |
-| Messaging and channels | Send replies or channel actions                                               | `message`                                                            | [Agent send](/tools/agent-send)                                        |
-| Sessions and agents    | Inspect sessions, delegate work, steer another run, or report status          | `sessions_*`, `subagents`, `agents_list`, `session_status`           | [Sub-agents](/tools/subagents), [Session tool](/concepts/session-tool) |
-| Automation             | Schedule work or respond to background events                                 | `cron`, `heartbeat_respond`                                          | [Automation](/automation)                                              |
-| Gateway and nodes      | Inspect Gateway state or paired target devices                                | `gateway`, `nodes`                                                   | [Gateway configuration](/gateway/configuration), [Nodes](/nodes)       |
-| Media                  | Analyze, generate, or speak media                                             | `image`, `image_generate`, `music_generate`, `video_generate`, `tts` | [Media overview](/tools/media-overview)                                |
-| Large PI catalogs      | Search and call many eligible tools without sending every schema to the model | `tool_search_code`, `tool_search`, `tool_describe`                   | [Tool Search](/tools/tool-search)                                      |
+| Runtime                | Run commands, manage processes, or use provider-backed Python analysis        | `exec`, `process`, `code_execution`                                  | [Exec](exec.md), [Code execution](code-execution.md)           |
+| Files                  | Read and change workspace files                                               | `read`, `write`, `edit`, `apply_patch`                               | [Apply patch](apply-patch.md)                                      |
+| Web                    | Search the web, search X posts, or fetch readable page content                | `web_search`, `x_search`, `web_fetch`                                | [Web tools](web.md), [Web fetch](web-fetch.md)                 |
+| Browser                | Operate a browser session                                                     | `browser`                                                            | [Browser](browser.md)                                              |
+| Messaging and channels | Send replies or channel actions                                               | `message`                                                            | [Agent send](agent-send.md)                                        |
+| Sessions and agents    | Inspect sessions, delegate work, steer another run, or report status          | `sessions_*`, `subagents`, `agents_list`, `session_status`           | [Sub-agents](subagents.md), [Session tool](../concepts/session-tool.md) |
+| Automation             | Schedule work or respond to background events                                 | `cron`, `heartbeat_respond`                                          | [Automation](../automation/index.md)                                              |
+| Gateway and nodes      | Inspect Gateway state or paired target devices                                | `gateway`, `nodes`                                                   | [Gateway configuration](../gateway/configuration.md), [Nodes](../nodes/index.md)       |
+| Media                  | Analyze, generate, or speak media                                             | `image`, `image_generate`, `music_generate`, `video_generate`, `tts` | [Media overview](media-overview.md)                                |
+| Large PI catalogs      | Search and call many eligible tools without sending every schema to the model | `tool_search_code`, `tool_search`, `tool_describe`                   | [Tool Search](tool-search.md)                                      |
 
 <Note>
 Tool Search is an experimental PI-agent surface. Codex harness runs use
@@ -101,19 +101,19 @@ tool calls instead of `tools.toolSearch`.
 
 Plugins can register additional tools. Plugin authors wire tools through
 `api.registerTool(...)` and the manifest's `contracts.tools`; use
-[Plugin SDK](/plugins/sdk-overview) and [Plugin manifest](/plugins/manifest)
+[Plugin SDK](../plugins/sdk-overview.md) and [Plugin manifest](../plugins/manifest.md)
 for contract details.
 
 Common plugin-provided tools include:
 
-- [Diffs](/tools/diffs) for rendering file and markdown diffs
-- [LLM Task](/tools/llm-task) for JSON-only workflow steps
-- [Lobster](/tools/lobster) for typed workflows with resumable approvals
-- [Tokenjuice](/tools/tokenjuice) for compacting noisy `exec` and `bash` tool
+- [Diffs](diffs.md) for rendering file and markdown diffs
+- [LLM Task](llm-task.md) for JSON-only workflow steps
+- [Lobster](lobster.md) for typed workflows with resumable approvals
+- [Tokenjuice](tokenjuice.md) for compacting noisy `exec` and `bash` tool
   output
-- [Tool Search](/tools/tool-search) for discovering and calling large tool
+- [Tool Search](tool-search.md) for discovering and calling large tool
   catalogs without putting every schema in the prompt
-- [Canvas](/plugins/reference/canvas) for node Canvas control and A2UI
+- [Canvas](../plugins/reference/canvas.md) for node Canvas control and A2UI
   rendering
 
 ## Configure access and approvals
@@ -123,30 +123,30 @@ model does not receive that tool's schema for the turn. A run can lose tools
 because of global config, per-agent config, channel policy, provider
 restrictions, sandbox rules, channel/runtime policy, or plugin availability.
 
-- [Tools and custom providers](/gateway/config-tools) documents tool profiles,
+- [Tools and custom providers](../gateway/config-tools.md) documents tool profiles,
   allow/deny lists, provider-specific restrictions, loop detection, and
   provider-backed tool settings.
-- [Exec approvals](/tools/exec-approvals) documents host command approval
+- [Exec approvals](exec-approvals.md) documents host command approval
   policy.
-- [Elevated exec](/tools/elevated) documents controlled execution outside the
+- [Elevated exec](elevated.md) documents controlled execution outside the
   sandbox.
-- [Sandbox vs tool policy vs elevated](/gateway/sandbox-vs-tool-policy-vs-elevated) explains which layer controls file and process access.
-- [Per-agent sandbox and tool restrictions](/tools/multi-agent-sandbox-tools)
+- [Sandbox vs tool policy vs elevated](../gateway/sandbox-vs-tool-policy-vs-elevated.md) explains which layer controls file and process access.
+- [Per-agent sandbox and tool restrictions](multi-agent-sandbox-tools.md)
   documents agent-specific restrictions for delegated runs.
 
 ## Extend capabilities
 
 Choose the extension path by the job you need OpenClaw to do:
 
-- Install or manage an existing plugin with [Plugins](/tools/plugin).
+- Install or manage an existing plugin with [Plugins](plugin.md).
 - Build a new integration, provider, channel, tool, or hook with
-  [Build plugins](/plugins/building-plugins).
-- Add or tune reusable agent instructions with [Skills](/tools/skills) and
-  [Creating skills](/tools/creating-skills).
+  [Build plugins](../plugins/building-plugins.md).
+- Add or tune reusable agent instructions with [Skills](skills.md) and
+  [Creating skills](creating-skills.md).
 - Package reusable workflow material with
-  [Skill workshop](/plugins/skill-workshop) when the workflow belongs in a
+  [Skill workshop](../plugins/skill-workshop.md) when the workflow belongs in a
   plugin-distributed skill bundle.
-- Use [Plugin SDK](/plugins/sdk-overview) and [Plugin manifest](/plugins/manifest) when you need implementation contracts.
+- Use [Plugin SDK](../plugins/sdk-overview.md) and [Plugin manifest](../plugins/manifest.md) when you need implementation contracts.
 
 ## Troubleshoot missing tools
 
@@ -154,25 +154,25 @@ If the model cannot see or call a tool, start with the effective policy for the
 current turn:
 
 1. Check the active profile, `tools.allow`, and `tools.deny` in
-   [Tools and custom providers](/gateway/config-tools).
+   [Tools and custom providers](../gateway/config-tools.md).
 2. Check provider-specific restrictions in
-   [Tools and custom providers](/gateway/config-tools) and confirm the selected
-   [model provider](/concepts/model-providers) supports the tool shape.
+   [Tools and custom providers](../gateway/config-tools.md) and confirm the selected
+   [model provider](../concepts/model-providers.md) supports the tool shape.
 3. Check channel permissions, sandbox state, and elevated access with
-   [Sandbox vs tool policy vs elevated](/gateway/sandbox-vs-tool-policy-vs-elevated) and [Elevated exec](/tools/elevated).
+   [Sandbox vs tool policy vs elevated](../gateway/sandbox-vs-tool-policy-vs-elevated.md) and [Elevated exec](elevated.md).
 4. Check whether the owning plugin is installed and enabled in
-   [Plugins](/tools/plugin).
+   [Plugins](plugin.md).
 5. For delegated runs, check per-agent restrictions in
-   [Per-agent sandbox and tool restrictions](/tools/multi-agent-sandbox-tools).
+   [Per-agent sandbox and tool restrictions](multi-agent-sandbox-tools.md).
 6. For large PI catalogs, confirm whether the run uses direct tool exposure or
-   [Tool Search](/tools/tool-search).
+   [Tool Search](tool-search.md).
 
 ## Related
 
-- [Automation](/automation) for cron, tasks, heartbeat, commitments, hooks, standing orders, and Task Flow
-- [Agents](/concepts/agent) for the agent model, sessions, memory, and multi-agent coordination
-- [Tools and custom providers](/gateway/config-tools) for the canonical tool policy reference
-- [Plugins](/tools/plugin) for plugin installation and management
-- [Plugin SDK](/plugins/sdk-overview) for plugin author reference
-- [Skills](/tools/skills) for skill load order, gating, and config
-- [Tool Search](/tools/tool-search) for compact PI tool catalog discovery
+- [Automation](../automation/index.md) for cron, tasks, heartbeat, commitments, hooks, standing orders, and Task Flow
+- [Agents](../concepts/agent.md) for the agent model, sessions, memory, and multi-agent coordination
+- [Tools and custom providers](../gateway/config-tools.md) for the canonical tool policy reference
+- [Plugins](plugin.md) for plugin installation and management
+- [Plugin SDK](../plugins/sdk-overview.md) for plugin author reference
+- [Skills](skills.md) for skill load order, gating, and config
+- [Tool Search](tool-search.md) for compact PI tool catalog discovery

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -4,8 +4,8 @@ title: "Text-to-speech"
 redirect: /tools/tts
 ---
 
-This page has moved to [Text-to-Speech](/tools/tts).
+This page has moved to [Text-to-Speech](./tools/tts.md).
 
 ## Related
 
-- [Text-to-speech](/tools/tts)
+- [Text-to-speech](./tools/tts.md)


### PR DESCRIPTION
## Summary

What problem does this PR solve?


Why does this matter now?


What is the intended outcome?


What is intentionally out of scope?


What does success look like?


What should reviewers focus on?

<details>
<summary>Summary guidance</summary>

This PR description is the contributor's durable explanation of the change. Write it for human maintainers first; ClawSweeper and Barnacle use the same text to understand intent, proof, risk, and current review state.

Describe the intent and outcome in 2-5 bullets. Avoid restating the diff; reviewers and bots can read the changed files.

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

</details>

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

<details>
<summary>Linked context guidance</summary>

Link the issue, PR, discussion, maintainer request, or owner request that explains why this PR should exist. Maintainer context helps reviewers and automation distinguish intended work from drive-by churn.

</details>

## Real behavior proof (required for external PRs)

- Behavior or issue addressed:
- Real environment tested:
- Exact steps or command run after this patch:
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
- Observed result after fix:
- What was not tested:
- Proof limitations or environment constraints:
- Before evidence (optional but encouraged):

<details>
<summary>Real behavior proof guidance</summary>

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only.

Screenshots are encouraged even for CLI, console, text, or log changes. Terminal screenshots, copied live output, redacted runtime logs, recordings, and linked artifacts count.

If your environment cannot produce the ideal proof, explain that under `Proof limitations or environment constraints` so reviewers and ClawSweeper can direct the next step properly.

Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

</details>

## Tests and validation

Which commands did you run?


What regression coverage was added or updated?


What failed before this fix, if known?


If no test was added, why not?

<details>
<summary>Testing guidance</summary>

List focused commands, not every incidental check. CI is useful support, but external PRs still need real behavior proof above when behavior changes.

</details>

## Risk checklist

Did user-visible behavior change? (`Yes/No`)


Did config, environment, or migration behavior change? (`Yes/No`)


Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)


What is the highest-risk area?


How is that risk mitigated?

<details>
<summary>Risk guidance</summary>

Use this for author judgment that is not obvious from the diff. ClawSweeper can see touched files, but it cannot know which behavior you think is risky, why the risk is acceptable, or what mitigation reviewers should verify.

</details>

## Current review state

What is the next action?


What is still waiting on author, maintainer, CI, or external proof?


Which bot or reviewer comments were addressed?

<details>
<summary>Review state guidance</summary>

Keep this as the durable state for review progress. If useful information appears in comments, fold the current next action or blocker back here so maintainers and ClawSweeper do not need to reconstruct state from comment history.

</details>
