### PR TITLE
fix(gateway): clear admin scopes for backend self-pairing

### DIFF
--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -129,11 +129,18 @@ permissions without token fields:
 
 Trusted same-process backend clients (`client.id: "gateway-client"`,
 `client.mode: "backend"`) may omit `device` on direct loopback connections when
-they authenticate with the shared gateway token/password. This path is reserved
-for internal control-plane RPCs and keeps stale CLI/device pairing baselines from
-blocking local backend work such as subagent session updates. Remote clients,
-browser-origin clients, node clients, and explicit device-token/device-identity
-clients still use the normal pairing and scope-upgrade checks.
+they authenticate with the shared gateway token/password **and** either:
+
+- request no operator scopes (unscoped internal control-plane RPCs), or
+- carry the internal approval-runtime token (scoped agentic control-plane paths).
+
+Self-declared operator scopes are cleared for shared-secret backend connects
+without device identity, so scoped local backend calls must use a paired device
+identity or the internal approval-runtime token path. This keeps stale
+CLI/device pairing baselines from blocking unscoped local backend work such as
+subagent session updates. Remote clients, browser-origin clients, node clients,
+and explicit device-token/device-identity clients still use the normal pairing
+and scope-upgrade checks.
 
 When a device token is issued, `hello-ok` also includes:
 

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -688,7 +688,7 @@ describe("callGateway url resolution", () => {
     });
   });
 
-  it("passes approval runtime tokens to backend gateway clients", async () => {
+  it("keeps loopback approval-runtime backend calls device-less", async () => {
     setLocalLoopbackGatewayConfig();
 
     await callGateway({
@@ -698,6 +698,53 @@ describe("callGateway url resolution", () => {
     });
 
     expect(lastClientOptions?.approvalRuntimeToken).toBe("runtime-token");
+    expect(lastClientOptions?.deviceIdentity).toBeNull();
+  });
+
+  it("keeps loopback approval-runtime backend calls device-less even with shared token auth", async () => {
+    setLocalLoopbackGatewayConfig();
+
+    await callGateway({
+      method: "exec.approval.waitDecision",
+      scopes: ["operator.approvals"],
+      token: "explicit-token",
+      approvalRuntimeToken: "runtime-token",
+    });
+
+    expect(lastClientOptions?.token).toBe("explicit-token");
+    expect(lastClientOptions?.approvalRuntimeToken).toBe("runtime-token");
+    expect(lastClientOptions?.deviceIdentity).toBeNull();
+  });
+
+  it("keeps ordinary scoped shared-token backend calls device-bound", async () => {
+    setLocalLoopbackGatewayConfig();
+
+    await callGatewayScoped({
+      method: "exec.approval.waitDecision",
+      scopes: ["operator.approvals"],
+      token: "explicit-token",
+    });
+
+    expect(lastClientOptions?.token).toBe("explicit-token");
+    expect(lastClientOptions?.approvalRuntimeToken).toBeUndefined();
+    expect(lastClientOptions?.deviceIdentity).toEqual(deviceIdentityState.value);
+  });
+
+  it("keeps remote approval-runtime backend calls device-bound", async () => {
+    getRuntimeConfig.mockReturnValue(makeRemotePasswordGatewayConfig("remote-password"));
+    setGatewayNetworkDefaults();
+
+    await callGatewayScoped({
+      method: "exec.approval.waitDecision",
+      scopes: ["operator.approvals"],
+      token: "explicit-token",
+      approvalRuntimeToken: "runtime-token",
+    });
+
+    expect(lastClientOptions?.url).toBe("wss://remote.example:18789");
+    expect(lastClientOptions?.token).toBe("explicit-token");
+    expect(lastClientOptions?.approvalRuntimeToken).toBe("runtime-token");
+    expect(lastClientOptions?.deviceIdentity).toEqual(deviceIdentityState.value);
   });
 
   it("does not synthesize display names for CLI calls", async () => {

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -412,7 +412,7 @@ describe("callGateway url resolution", () => {
     expect(lastClientOptions?.token).toBe("test-token");
   });
 
-  it("keeps direct-local backend shared-token auth independent of paired device state", async () => {
+  it("uses device identity for scoped direct-local backend shared-token auth", async () => {
     setLocalLoopbackGatewayConfig();
 
     await callGateway({
@@ -424,7 +424,7 @@ describe("callGateway url resolution", () => {
     expect(lastClientOptions?.token).toBe("explicit-token");
     expect(lastClientOptions?.clientName).toBe(GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT);
     expect(lastClientOptions?.mode).toBe(GATEWAY_CLIENT_MODES.BACKEND);
-    expect(lastClientOptions?.deviceIdentity).toBeNull();
+    expect(lastClientOptions?.deviceIdentity).toEqual(deviceIdentityState.value);
   });
 
   it("keeps device identity enabled for explicit CLI loopback shared-token auth", async () => {
@@ -655,7 +655,7 @@ describe("callGateway url resolution", () => {
     expect(lastClientOptions?.mode).toBe(GATEWAY_CLIENT_MODES.BACKEND);
     expect(lastClientOptions?.clientDisplayName).toBe("gateway:sessions.delete");
     expect(lastClientOptions?.scopes).toEqual(["operator.admin"]);
-    expect(lastClientOptions?.deviceIdentity).toBeNull();
+    expect(lastClientOptions?.deviceIdentity).toEqual(deviceIdentityState.value);
   });
 
   it("labels default backend calls with the requested method", async () => {

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -325,26 +325,28 @@ function isLoopbackGatewayUrl(rawUrl: string): boolean {
 
 function shouldOmitDeviceIdentityForGatewayCall(params: {
   opts: CallGatewayBaseOptions;
-  scopes: readonly string[];
   url: string;
   token?: string;
   password?: string;
 }): boolean {
   const mode = params.opts.mode ?? GATEWAY_CLIENT_MODES.CLI;
   const clientName = params.opts.clientName ?? GATEWAY_CLIENT_NAMES.CLI;
-  const hasSharedAuth = Boolean(params.token || params.password);
+  // Internal approval-runtime token calls intentionally stay device-less on
+  // loopback to avoid stale scope-upgrade reconnect churn in the approval
+  // control plane. Ordinary scoped shared-auth backend calls remain device-bound.
+  const hasApprovalRuntimeToken = Boolean(
+    normalizeOptionalString(params.opts.approvalRuntimeToken),
+  );
   return (
     mode === GATEWAY_CLIENT_MODES.BACKEND &&
     clientName === GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT &&
-    hasSharedAuth &&
-    params.scopes.length === 0 &&
+    hasApprovalRuntimeToken &&
     isLoopbackGatewayUrl(params.url)
   );
 }
 
 function resolveDeviceIdentityForGatewayCall(params: {
   opts: CallGatewayBaseOptions;
-  scopes: readonly string[];
   url: string;
   token?: string;
   password?: string;
@@ -776,7 +778,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
       scopes,
       deviceIdentity:
         opts.deviceIdentity === undefined
-          ? resolveDeviceIdentityForGatewayCall({ opts, scopes, url, token, password })
+          ? resolveDeviceIdentityForGatewayCall({ opts, url, token, password })
           : opts.deviceIdentity,
       minProtocol: opts.minProtocol ?? MIN_CLIENT_PROTOCOL_VERSION,
       maxProtocol: opts.maxProtocol ?? PROTOCOL_VERSION,

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -325,6 +325,7 @@ function isLoopbackGatewayUrl(rawUrl: string): boolean {
 
 function shouldOmitDeviceIdentityForGatewayCall(params: {
   opts: CallGatewayBaseOptions;
+  scopes: readonly string[];
   url: string;
   token?: string;
   password?: string;
@@ -336,12 +337,14 @@ function shouldOmitDeviceIdentityForGatewayCall(params: {
     mode === GATEWAY_CLIENT_MODES.BACKEND &&
     clientName === GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT &&
     hasSharedAuth &&
+    params.scopes.length === 0 &&
     isLoopbackGatewayUrl(params.url)
   );
 }
 
 function resolveDeviceIdentityForGatewayCall(params: {
   opts: CallGatewayBaseOptions;
+  scopes: readonly string[];
   url: string;
   token?: string;
   password?: string;
@@ -773,7 +776,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
       scopes,
       deviceIdentity:
         opts.deviceIdentity === undefined
-          ? resolveDeviceIdentityForGatewayCall({ opts, url, token, password })
+          ? resolveDeviceIdentityForGatewayCall({ opts, scopes, url, token, password })
           : opts.deviceIdentity,
       minProtocol: opts.minProtocol ?? MIN_CLIENT_PROTOCOL_VERSION,
       maxProtocol: opts.maxProtocol ?? PROTOCOL_VERSION,

--- a/src/gateway/server.auth.compat-baseline.test.ts
+++ b/src/gateway/server.auth.compat-baseline.test.ts
@@ -63,16 +63,17 @@ async function expectSharedOperatorScopesCleared(
   }
 }
 
-async function expectLocalBackendGatewayClientScopesPreserved(
+async function expectBackendSelfDeclaredScopeBypassBlocked(
   port: number,
   auth: { token?: string; password?: string },
+  scope: string,
 ) {
   const ws = await openWs(port);
   try {
     const res = await connectReq(ws, {
       ...auth,
       client: { ...BACKEND_GATEWAY_CLIENT },
-      scopes: ["operator.admin"],
+      scopes: [scope],
       device: null,
     });
     expect(res.ok).toBe(true);
@@ -84,10 +85,11 @@ async function expectLocalBackendGatewayClientScopesPreserved(
           };
         }
       | undefined;
-    expect(helloOk?.auth?.scopes).toEqual(["operator.admin"]);
+    expect(helloOk?.auth?.scopes).toEqual([]);
 
-    const adminRes = await rpcReq(ws, "set-heartbeats", { enabled: false });
-    expect(adminRes.ok).toBe(true);
+    const readRes = await rpcReq(ws, "sessions.list", {});
+    expect(readRes.ok).toBe(false);
+    expect(readRes.error?.message ?? "").toContain("missing scope");
   } finally {
     ws.close();
   }
@@ -126,8 +128,15 @@ describe("gateway auth compatibility baseline", () => {
       await expectSharedOperatorScopesCleared(port, { token: "secret" });
     });
 
-    test("preserves scopes for direct-local backend shared-token connects without device identity", async () => {
-      await expectLocalBackendGatewayClientScopesPreserved(port, { token: "secret" });
+    test("blocks backend identity self-declared scope bypass with shared token", async () => {
+      for (const scope of [
+        "operator.admin",
+        "operator.write",
+        "operator.approvals",
+        "operator.pairing",
+      ]) {
+        await expectBackendSelfDeclaredScopeBypassBlocked(port, { token: "secret" }, scope);
+      }
     });
 
     test("returns stable token-missing details for control ui without token", async () => {
@@ -300,8 +309,15 @@ describe("gateway auth compatibility baseline", () => {
       await expectSharedOperatorScopesCleared(port, { password: "secret" });
     });
 
-    test("preserves scopes for direct-local backend shared-password connects without device identity", async () => {
-      await expectLocalBackendGatewayClientScopesPreserved(port, { password: "secret" });
+    test("blocks backend identity self-declared scope bypass with shared password", async () => {
+      for (const scope of [
+        "operator.admin",
+        "operator.write",
+        "operator.approvals",
+        "operator.pairing",
+      ]) {
+        await expectBackendSelfDeclaredScopeBypassBlocked(port, { password: "secret" }, scope);
+      }
     });
   });
 

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -1851,7 +1851,7 @@ export function registerControlUiAndPairingSuite(): void {
     }
   });
 
-  test("allows gateway backend loopback shared-auth connections without device pairing", async () => {
+  test("clears scopes for gateway backend loopback shared-auth connections without device pairing", async () => {
     const { server, ws, port, prevToken } = await startControlUiServerWithClient("secret");
     const sockets = [ws];
     try {
@@ -1873,8 +1873,18 @@ export function registerControlUiAndPairingSuite(): void {
         const backendConnect = await connectReq(socket, {
           token: "secret",
           client: BACKEND_GATEWAY_CLIENT,
+          scopes: ["operator.admin", "operator.write", "operator.approvals", "operator.pairing"],
+          device: null,
         });
         expect(backendConnect.ok, backendCase.name).toBe(true);
+        const helloOk = backendConnect.payload as
+          | {
+              auth?: {
+                scopes?: unknown;
+              };
+            }
+          | undefined;
+        expect(helloOk?.auth?.scopes, backendCase.name).toEqual([]);
       }
     } finally {
       for (const socket of sockets) {

--- a/src/gateway/server.node-invoke-approval-bypass.test.ts
+++ b/src/gateway/server.node-invoke-approval-bypass.test.ts
@@ -11,6 +11,7 @@ import {
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { GatewayClient } from "./client.js";
 import { buildDeviceAuthPayload } from "./device-auth.js";
+import { getOperatorApprovalRuntimeToken } from "./operator-approval-runtime-token.js";
 import {
   connectReq,
   installGatewayTestHooks,
@@ -282,6 +283,7 @@ describe("node.invoke approval bypass", () => {
     await new Promise<void>((resolve) => ws.once("open", resolve));
     const res = await connectReq(ws, {
       token: "secret",
+      approvalRuntimeToken: getOperatorApprovalRuntimeToken(),
       scopes,
       device: null,
       client: {

--- a/src/gateway/server.silent-scope-upgrade-reconnect.poc.test.ts
+++ b/src/gateway/server.silent-scope-upgrade-reconnect.poc.test.ts
@@ -233,7 +233,7 @@ describe("gateway silent scope-upgrade reconnect", () => {
     }
   });
 
-  test("keeps direct-local backend callGateway scoped calls off stale paired CLI baseline", async () => {
+  test("requires scope-upgrade approval for scoped backend callGateway calls with a stale paired identity", async () => {
     const started = await startServerWithClient("secret");
     const identity = loadOrCreateDeviceIdentity();
     const publicKey = publicKeyRawBase64UrlFromPem(identity.publicKeyPem);
@@ -250,14 +250,15 @@ describe("gateway silent scope-upgrade reconnect", () => {
     });
 
     try {
-      const health = await callGateway({
-        url: `ws://127.0.0.1:${started.port}`,
-        token: "secret",
-        method: "health",
-        scopes: ["operator.admin"],
-        timeoutMs: 2_000,
-      });
-      expect(health.ok).toBe(true);
+      await expect(
+        callGateway({
+          url: `ws://127.0.0.1:${started.port}`,
+          token: "secret",
+          method: "health",
+          scopes: ["operator.admin"],
+          timeoutMs: 2_000,
+        }),
+      ).rejects.toThrow("more scopes than currently approved");
 
       const paired = await getPairedDevice(identity.deviceId);
       expect(paired?.approvedScopes).toEqual(["operator.read"]);

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AuthRateLimiter } from "../../auth-rate-limit.js";
+import { getOperatorApprovalRuntimeToken } from "../../operator-approval-runtime-token.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../protocol/client-info.js";
 import type { ConnectParams } from "../../protocol/schema/types.js";
 import {
@@ -402,7 +403,62 @@ describe("handshake auth helpers", () => {
     ).toBe("shared_secret_loopback_local");
   });
 
-  it("skips backend self-pairing only for direct-local backend clients", () => {
+  it("does not skip backend self-pairing for shared-auth requests with self-declared scopes", () => {
+    for (const scope of [
+      "operator.admin",
+      "operator.write",
+      "operator.approvals",
+      "operator.pairing",
+    ]) {
+      const connectParams = {
+        client: {
+          id: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+          mode: GATEWAY_CLIENT_MODES.BACKEND,
+        },
+        scopes: [scope],
+      } as ConnectParams;
+      expect(
+        shouldSkipLocalBackendSelfPairing({
+          connectParams,
+          locality: "direct_local",
+          hasBrowserOriginHeader: false,
+          sharedAuthOk: true,
+          authMethod: "token",
+        }),
+      ).toBe(false);
+      expect(
+        shouldSkipLocalBackendSelfPairing({
+          connectParams,
+          locality: "shared_secret_loopback_local",
+          hasBrowserOriginHeader: false,
+          sharedAuthOk: true,
+          authMethod: "password",
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it("skips backend self-pairing for internal approval runtime shared-auth requests", () => {
+    const connectParams = {
+      client: {
+        id: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+        mode: GATEWAY_CLIENT_MODES.BACKEND,
+      },
+      scopes: ["operator.write", "operator.approvals"],
+    } as ConnectParams;
+    expect(
+      shouldSkipLocalBackendSelfPairing({
+        connectParams,
+        locality: "direct_local",
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "token",
+        approvalRuntimeToken: getOperatorApprovalRuntimeToken(),
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps backend self-pairing for direct-local backend clients without admin scope", () => {
     const connectParams = {
       client: {
         id: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
@@ -421,10 +477,10 @@ describe("handshake auth helpers", () => {
     expect(
       shouldSkipLocalBackendSelfPairing({
         connectParams,
-        locality: "shared_secret_loopback_local",
+        locality: "direct_local",
         hasBrowserOriginHeader: false,
         sharedAuthOk: true,
-        authMethod: "token",
+        authMethod: "password",
       }),
     ).toBe(true);
     expect(

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -10,6 +10,7 @@ import {
   isPrivateOrLoopbackHost,
   resolveHostName,
 } from "../../net.js";
+import { isOperatorApprovalRuntimeToken } from "../../operator-approval-runtime-token.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../protocol/client-info.js";
 import type { ConnectParams } from "../../protocol/index.js";
 import type { AuthProvidedKind } from "./auth-messages.js";
@@ -121,6 +122,7 @@ function isCliContainerLocalEquivalent(params: {
   hasBrowserOriginHeader: boolean;
   sharedAuthOk: boolean;
   authMethod: GatewayAuthResult["method"];
+  approvalRuntimeToken?: string;
 }): boolean {
   const isCliClient =
     params.connectParams.client.id === GATEWAY_CLIENT_IDS.CLI &&
@@ -144,6 +146,7 @@ function isSharedSecretLoopbackLocalEquivalent(params: {
   hasBrowserOriginHeader: boolean;
   sharedAuthOk: boolean;
   authMethod: GatewayAuthResult["method"];
+  approvalRuntimeToken?: string;
 }): boolean {
   const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
   return (
@@ -256,6 +259,7 @@ export function shouldSkipLocalBackendSelfPairing(params: {
   hasBrowserOriginHeader: boolean;
   sharedAuthOk: boolean;
   authMethod: GatewayAuthResult["method"];
+  approvalRuntimeToken?: string;
 }): boolean {
   const isBackendClient =
     params.connectParams.client.id === GATEWAY_CLIENT_IDS.GATEWAY_CLIENT &&
@@ -274,8 +278,14 @@ export function shouldSkipLocalBackendSelfPairing(params: {
     return true;
   }
   const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
+  if (usesSharedSecretAuth) {
+    if (isOperatorApprovalRuntimeToken(params.approvalRuntimeToken)) {
+      return params.sharedAuthOk;
+    }
+    return params.sharedAuthOk && (params.connectParams.scopes?.length ?? 0) === 0;
+  }
   const usesDeviceTokenAuth = params.authMethod === "device-token";
-  return (params.sharedAuthOk && usesSharedSecretAuth) || usesDeviceTokenAuth;
+  return usesDeviceTokenAuth;
 }
 
 function resolveSignatureToken(connectParams: ConnectParams): string | null {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -766,6 +766,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           hasBrowserOriginHeader,
           sharedAuthOk,
           authMethod,
+          approvalRuntimeToken: connectParams.auth?.approvalRuntimeToken,
         });
         const handleMissingDeviceIdentity = (): boolean => {
           const trustedProxyAuthOk = isTrustedProxyControlUiOperatorAuth({

--- a/src/gateway/test-helpers.server.ts
+++ b/src/gateway/test-helpers.server.ts
@@ -867,6 +867,7 @@ type ConnectReqOptions = {
   bootstrapToken?: string;
   deviceToken?: string;
   password?: string;
+  approvalRuntimeToken?: string;
   skipDefaultAuth?: boolean;
   minProtocol?: number;
   maxProtocol?: number;
@@ -984,6 +985,7 @@ export async function connectReq(
   const bootstrapToken = normalizeOptionalString(opts?.bootstrapToken);
   const deviceToken = normalizeOptionalString(opts?.deviceToken);
   const password = opts?.password ?? defaultPassword;
+  const approvalRuntimeToken = normalizeOptionalString(opts?.approvalRuntimeToken);
   const authTokenForSignature = resolveAuthTokenForSignature({
     token,
     bootstrapToken,
@@ -1077,12 +1079,13 @@ export async function connectReq(
         role,
         scopes: requestedScopes,
         auth:
-          token || bootstrapToken || password || deviceToken
+          token || bootstrapToken || password || deviceToken || approvalRuntimeToken
             ? {
                 token,
                 bootstrapToken,
                 deviceToken,
                 password,
+                approvalRuntimeToken,
               }
             : undefined,
         device,


### PR DESCRIPTION
Summary
- Stop treating shared token/password auth as sufficient to preserve self-declared operator scopes for local backend self-pairing.
- Keep local approval-runtime scoped backend Gateway calls device-less when they carry `approvalRuntimeToken`.
- Keep ordinary scoped local shared-token/password backend Gateway calls device-bound.
- Add focused regression coverage for approval-runtime vs ordinary scoped shared-secret behavior.

## Real behavior proof

Behavior or issue addressed:
After-fix local gateway behavior for scoped shared-secret backend clients: self-declared scoped privileges are cleared, and approval-runtime loopback calls continue to use the device-less path.

Real environment tested:
Real local OpenClaw gateway from this PR branch (`fix/issue-72418`, head `073645ff`) on Ubuntu, started in a temporary state dir with token auth on `ws://127.0.0.1:39139`.

Exact steps or command run after this patch:
```text
OPENCLAW_STATE_DIR=/tmp/openclaw-pr86192-proof-AquCdT \
OPENCLAW_CONFIG_PATH=/tmp/openclaw-pr86192-proof-AquCdT/openclaw.json \
pnpm openclaw gateway run --allow-unconfigured --bind loopback --auth token --token secret --port 39139 --ws-log compact

OPENCLAW_STATE_DIR=/tmp/openclaw-pr86192-proof-AquCdT \
OPENCLAW_CONFIG_PATH=/tmp/openclaw-pr86192-proof-AquCdT/openclaw.json \
node --import tsx --input-type=module

scope-clear probe: connect as backend shared-token client with deviceIdentity=null and requested scopes=[operator.approvals], then call exec.approval.waitDecision
device-path probe: wrap callGateway createGatewayClient and run
1) ordinary scoped shared-token backend call
2) scoped shared-token + approvalRuntimeToken backend call
```

Evidence after fix:
```text
scope-clear probe output:
{
  "ordinary": {
    "name": "ordinary-scoped-shared-token-no-device",
    "grantedScopes": [],
    "requestError": "missing scope: operator.approvals"
  },
  "approval": {
    "name": "approval-runtime-scoped-shared-token-no-device",
    "grantedScopes": [],
    "requestError": "missing scope: operator.approvals"
  }
}

gateway runtime log excerpt (redacted ids):
[ws] ⇄ res ✗ exec.approval.waitDecision 1ms errorCode=INVALID_REQUEST errorMessage=missing scope: operator.approvals conn=... id=...

device-path probe output:
ordinary-scoped-shared-token {"hasDeviceIdentity":true,"hasApprovalRuntimeToken":false,"mode":"backend","clientName":"gateway-client","scopes":["operator.approvals"],"url":"ws://127.0.0.1:39139"}
approval-runtime-scoped-shared-token {"hasDeviceIdentity":false,"hasApprovalRuntimeToken":true,"mode":"backend","clientName":"gateway-client","scopes":["operator.approvals"],"url":"ws://127.0.0.1:39139"}
```

Observed result after fix:
Scoped shared-secret backend privileges are cleared on local loopback without a paired device identity (`grantedScopes: []` and scoped RPC denied), and approval-runtime loopback backend calls carrying `approvalRuntimeToken` remain device-less while ordinary scoped shared-token backend calls remain device-bound.

What was not tested:
Remote gateway deployment behavior was not live-tested in this proof run; this proof is focused on local loopback backend caller parity and scope-clearing behavior.

## Merge risk acceptance required

Gateway/security owners should explicitly accept this compatibility and auth-boundary change before merge:
- Existing local backend scoped shared-token/password clients that relied on self-declared scopes without paired device identity now fail closed.
- Approved paths are paired device identity, or the internal approval-runtime token flow for approval-runtime callers.

Additional verification (supplemental)
```text
pnpm vitest run src/gateway/call.test.ts src/agents/tools/gateway.test.ts

Test Files  5 passed (5)
Tests  309 passed (309)
```

Fixes openclaw/openclaw#72418
