### PR TITLE
Fix TUI Esc abort stale busy state

### DIFF
--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -4,11 +4,12 @@ import {
   TUI_RECENT_SESSIONS_ACTIVE_MINUTES,
   TUI_SESSION_PICKER_LIMIT,
 } from "./tui-session-list-policy.js";
+import type { TuiAbortActiveResult } from "./tui-types.js";
 
 type LoadHistoryMock = ReturnType<typeof vi.fn> & (() => Promise<void>);
 type RunAuthFlow = NonNullable<Parameters<typeof createCommandHandlers>[0]["runAuthFlow"]>;
 type AbortActiveMock = ReturnType<typeof vi.fn> &
-  ((params?: { preferActive?: boolean }) => Promise<void>);
+  ((params?: { preferActive?: boolean }) => Promise<TuiAbortActiveResult>);
 type SelectableOverlay = {
   items?: Array<{ value: string; label?: string; description?: string }>;
   onSelect?: (item: { value: string; label?: string; description?: string }) => void;
@@ -102,6 +103,9 @@ function createHarness(params?: {
   const setEmptySession =
     params?.setEmptySession ?? (vi.fn().mockResolvedValue(undefined) as SetEmptySessionMock);
   const addUser = vi.fn();
+  const addPendingUser = vi.fn();
+  const commitPendingUser = vi.fn();
+  const dropPendingUser = vi.fn();
   const addSystem = vi.fn();
   const clearTools = vi.fn();
   const reserveAssistantSlot = vi.fn();
@@ -119,7 +123,8 @@ function createHarness(params?: {
   const closeOverlay = vi.fn();
   const requestExit = vi.fn();
   const abortActive =
-    params?.abortActive ?? (vi.fn().mockResolvedValue(undefined) as AbortActiveMock);
+    params?.abortActive ??
+    (vi.fn().mockResolvedValue({ aborted: false, runId: null }) as AbortActiveMock);
   const runAuthFlow: RunAuthFlow | undefined =
     params?.runAuthFlow ??
     (params?.opts?.local
@@ -147,7 +152,15 @@ function createHarness(params?: {
       resetSession,
       runGoalCommand,
     } as never,
-    chatLog: { addUser, addSystem, clearTools, reserveAssistantSlot } as never,
+    chatLog: {
+      addUser,
+      addPendingUser,
+      commitPendingUser,
+      dropPendingUser,
+      addSystem,
+      clearTools,
+      reserveAssistantSlot,
+    } as never,
     tui: { requestRender } as never,
     opts: params?.opts ?? {},
     state: state as never,
@@ -189,6 +202,9 @@ function createHarness(params?: {
     setSession,
     setEmptySession,
     addUser,
+    addPendingUser,
+    commitPendingUser,
+    dropPendingUser,
     addSystem,
     clearTools,
     reserveAssistantSlot,
@@ -263,12 +279,12 @@ describe("tui command handlers", () => {
   });
 
   it("forwards unknown slash commands to the gateway", async () => {
-    const { handleCommand, sendChat, addUser, addSystem, requestRender } = createHarness();
+    const { handleCommand, sendChat, addPendingUser, addSystem, requestRender } = createHarness();
 
     await handleCommand("/unregistered-command");
 
     expect(addSystem).not.toHaveBeenCalled();
-    expect(addUser).toHaveBeenCalledWith("/unregistered-command");
+    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "/unregistered-command");
     expectSendChatFields(sendChat, {
       sessionKey: "agent:main:main",
       message: "/unregistered-command",
@@ -292,7 +308,7 @@ describe("tui command handlers", () => {
 
   it("starts local goals and sends the objective to the model", async () => {
     const runGoalCommand = vi.fn().mockResolvedValue({ text: "Goal started: ship" });
-    const { handleCommand, sendChat, addSystem, refreshSessionInfo, addUser } = createHarness({
+    const { handleCommand, sendChat, addSystem, refreshSessionInfo, addPendingUser } = createHarness({
       opts: { local: true },
       runGoalCommand,
     });
@@ -308,7 +324,7 @@ describe("tui command handlers", () => {
       sessionKey: "agent:main:main",
       message: "ship",
     });
-    expect(addUser).toHaveBeenCalledWith("ship");
+    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "ship");
     expect(addSystem).toHaveBeenCalledWith("Goal started: ship");
     expect(refreshSessionInfo).toHaveBeenCalled();
   });
@@ -326,7 +342,7 @@ describe("tui command handlers", () => {
       sessionKey: "agent:main:main",
       message: slashPrompt,
     });
-    expect(slashHarness.addUser).toHaveBeenCalledWith(slashPrompt);
+    expect(slashHarness.addPendingUser).toHaveBeenCalledWith(expect.any(String), slashPrompt);
 
     const bangRunGoalCommand = vi.fn().mockResolvedValue({ text: "Goal started" });
     const bangHarness = createHarness({
@@ -340,7 +356,7 @@ describe("tui command handlers", () => {
       sessionKey: "agent:main:main",
       message: bangPrompt,
     });
-    expect(bangHarness.addUser).toHaveBeenCalledWith(bangPrompt);
+    expect(bangHarness.addPendingUser).toHaveBeenCalledWith(expect.any(String), bangPrompt);
   });
 
   it("keeps local goal status as a control command", async () => {
@@ -358,7 +374,7 @@ describe("tui command handlers", () => {
 
   it("wraps command-prefixed local goal resume notes before sending", async () => {
     const runGoalCommand = vi.fn().mockResolvedValue({ text: "Goal resumed: ship" });
-    const { handleCommand, sendChat, addUser } = createHarness({
+    const { handleCommand, sendChat, addPendingUser } = createHarness({
       opts: { local: true },
       runGoalCommand,
     });
@@ -370,7 +386,7 @@ describe("tui command handlers", () => {
       sessionKey: "agent:main:main",
       message: prompt,
     });
-    expect(addUser).toHaveBeenCalledWith(prompt);
+    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), prompt);
   });
 
   it("passes the selected agent for local global goal commands", async () => {
@@ -467,12 +483,12 @@ describe("tui command handlers", () => {
   });
 
   it("forwards /status to the shared gateway command path", async () => {
-    const { handleCommand, sendChat, addUser, addSystem } = createHarness();
+    const { handleCommand, sendChat, addPendingUser, addSystem } = createHarness();
 
     await handleCommand("/status");
 
     expect(addSystem).not.toHaveBeenCalled();
-    expect(addUser).toHaveBeenCalledWith("/status");
+    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "/status");
     expectSendChatFields(sendChat, {
       sessionKey: "agent:main:main",
       message: "/status",
@@ -820,14 +836,14 @@ describe("tui command handlers", () => {
   });
 
   it("reports disconnected status and skips gateway send when offline", async () => {
-    const { handleCommand, sendChat, addUser, addSystem, setActivityStatus } = createHarness({
+    const { handleCommand, sendChat, addPendingUser, addSystem, setActivityStatus } = createHarness({
       isConnected: false,
     });
 
     await handleCommand("/context detail");
 
     expect(sendChat).not.toHaveBeenCalled();
-    expect(addUser).not.toHaveBeenCalled();
+    expect(addPendingUser).not.toHaveBeenCalled();
     expect(addSystem).toHaveBeenCalledWith("not connected to gateway — message not sent");
     expect(setActivityStatus).toHaveBeenLastCalledWith("disconnected");
   });
@@ -836,7 +852,7 @@ describe("tui command handlers", () => {
     const {
       handleCommand,
       sendChat,
-      addUser,
+      addPendingUser,
       addSystem,
       reserveAssistantSlot,
       requestRender,
@@ -856,9 +872,9 @@ describe("tui command handlers", () => {
     });
     expect(reserveAssistantSlot).toHaveBeenCalledWith("run-active");
     const reserveCallOrder = reserveAssistantSlot.mock.invocationCallOrder[0];
-    const addUserCallOrder = addUser.mock.invocationCallOrder[0];
-    expect(reserveCallOrder).toBeLessThan(addUserCallOrder);
-    expect(addUser).toHaveBeenCalledWith("/context detail");
+    const addPendingUserCallOrder = addPendingUser.mock.invocationCallOrder[0];
+    expect(reserveCallOrder).toBeLessThan(addPendingUserCallOrder);
+    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "/context detail");
     expect(addSystem).not.toHaveBeenCalledWith(
       "agent is busy — press Esc to abort before sending a new message",
     );
@@ -868,7 +884,7 @@ describe("tui command handlers", () => {
   });
 
   it("blocks gateway slash prompts while a run is active", async () => {
-    const { handleCommand, sendChat, addUser, addSystem } = createHarness({
+    const { handleCommand, sendChat, addPendingUser, addSystem } = createHarness({
       activeChatRunId: "run-active",
       activityStatus: "streaming",
     });
@@ -876,14 +892,14 @@ describe("tui command handlers", () => {
     await handleCommand("/context detail");
 
     expect(sendChat).not.toHaveBeenCalled();
-    expect(addUser).not.toHaveBeenCalled();
+    expect(addPendingUser).not.toHaveBeenCalled();
     expect(addSystem).toHaveBeenCalledWith(
       "agent is busy — press Esc to abort before sending a new message",
     );
   });
 
   it("routes slash stop to the abort path instead of queueing a chat send", async () => {
-    const abortActive = vi.fn().mockResolvedValue(undefined);
+    const abortActive = vi.fn().mockResolvedValue({ aborted: false, runId: null });
     const { handleCommand, sendChat, addUser } = createHarness({
       activeChatRunId: "run-active",
       activityStatus: "streaming",
@@ -898,8 +914,8 @@ describe("tui command handlers", () => {
   });
 
   it("sends slash stop to the backend when there is no tracked run", async () => {
-    const abortActive = vi.fn().mockResolvedValue(undefined);
-    const { handleCommand, sendChat, addUser } = createHarness({ abortActive });
+    const abortActive = vi.fn().mockResolvedValue({ aborted: false, runId: null });
+    const { handleCommand, sendChat, addPendingUser } = createHarness({ abortActive });
 
     await handleCommand("/stop");
 
@@ -909,22 +925,22 @@ describe("tui command handlers", () => {
       message: "/stop",
       sessionKey: "agent:main:main",
     });
-    expect(addUser).toHaveBeenCalledWith("/stop");
+    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "/stop");
   });
 
   it("sends broad stop-like text as a normal prompt when idle", async () => {
-    const abortActive = vi.fn().mockResolvedValue(undefined);
-    const { handleCommand, sendChat, addUser } = createHarness({ abortActive });
+    const abortActive = vi.fn().mockResolvedValue({ aborted: false, runId: null });
+    const { handleCommand, sendChat, addPendingUser } = createHarness({ abortActive });
 
     await handleCommand("do not do that");
 
     expect(abortActive).not.toHaveBeenCalled();
     expect(sendChat).toHaveBeenCalledTimes(1);
-    expect(addUser).toHaveBeenCalledWith("do not do that");
+    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "do not do that");
   });
 
   it("rejects normal sends while a queued submit is pending registration", async () => {
-    const { handleCommand, sendChat, addUser, addSystem } = createHarness({
+    const { handleCommand, sendChat, addPendingUser, addSystem } = createHarness({
       activeChatRunId: "run-active",
       pendingChatRunId: "run-queued",
       activityStatus: "waiting",
@@ -933,14 +949,14 @@ describe("tui command handlers", () => {
     await handleCommand("/context detail");
 
     expect(sendChat).not.toHaveBeenCalled();
-    expect(addUser).not.toHaveBeenCalled();
+    expect(addPendingUser).not.toHaveBeenCalled();
     expect(addSystem).toHaveBeenCalledWith(
       "agent is busy — press Esc to abort before sending a new message",
     );
   });
 
   it("allows local sends to queue while the current run is finishing", async () => {
-    const { handleCommand, sendChat, addUser, addSystem } = createHarness({
+    const { handleCommand, sendChat, addPendingUser, addSystem } = createHarness({
       opts: { local: true },
       activeChatRunId: "run-active",
       activityStatus: "finishing context",
@@ -949,7 +965,7 @@ describe("tui command handlers", () => {
     await handleCommand("/context detail");
 
     expect(sendChat).toHaveBeenCalledTimes(1);
-    expect(addUser).toHaveBeenCalledWith("/context detail");
+    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "/context detail");
     expect(addSystem).not.toHaveBeenCalledWith(
       "agent is busy — press Esc to abort before sending a new message",
     );

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -33,6 +33,7 @@ import { formatStatusSummary } from "./tui-status-summary.js";
 import type {
   AgentSummary,
   GatewayStatusSummary,
+  TuiAbortActiveResult,
   TuiResult,
   TuiOptions,
   TuiStateAccess,

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -52,7 +52,7 @@ type CommandHandlerContext = {
   setSession: (key: string) => Promise<void>;
   setEmptySession: (key: string) => Promise<void>;
   refreshAgents: () => Promise<void>;
-  abortActive: (params?: { preferActive?: boolean }) => Promise<void>;
+  abortActive: (params?: { preferActive?: boolean }) => Promise<TuiAbortActiveResult>;
   setActivityStatus: (text: string) => void;
   formatSessionKey: (key: string) => string;
   applySessionInfoFromPatch: (result: SessionsPatchResult) => void;
@@ -747,7 +747,8 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         ) {
           chatLog.reserveAssistantSlot(state.activeChatRunId);
         }
-        chatLog.addUser(text);
+        state.pendingSubmitDraft = { runId, text };
+        chatLog.addPendingUser(runId, text);
         noteLocalRunId?.(runId);
         state.pendingOptimisticUserMessage = true;
         setActivityStatus("sending");
@@ -774,9 +775,19 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           if (!acceptedRunAlreadyCompleted) {
             noteLocalRunId?.(acceptedRunId);
           }
+          if (state.pendingSubmitDraft?.runId === runId) {
+            state.pendingSubmitDraft = { runId: acceptedRunId, text };
+          }
+          if (chatLog.dropPendingUser(runId)) {
+            chatLog.addPendingUser(acceptedRunId, text);
+          }
         }
         if (state.pendingOptimisticUserMessage) {
           if (acceptedRunAlreadyCompleted) {
+            chatLog.commitPendingUser(acceptedRunId);
+            if (state.pendingSubmitDraft?.runId === acceptedRunId) {
+              state.pendingSubmitDraft = null;
+            }
             state.pendingOptimisticUserMessage = false;
             state.pendingChatRunId = null;
             setActivityStatus("idle");
@@ -797,8 +808,10 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       }
       if (!isBtw) {
         forgetLocalRunId?.(runId);
-      }
-      if (!isBtw) {
+        chatLog.commitPendingUser(runId);
+        if (state.pendingSubmitDraft?.runId === runId) {
+          state.pendingSubmitDraft = null;
+        }
         state.pendingOptimisticUserMessage = false;
         state.pendingChatRunId = null;
         state.activeChatRunId = null;

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -1106,6 +1106,10 @@ describe("tui-event-handlers: handleAgentEvent", () => {
         activeChatRunId: null,
         pendingOptimisticUserMessage: true,
         pendingChatRunId: "run-pending",
+        pendingSubmitDraft: {
+          runId: "run-pending",
+          text: "hello",
+        },
       },
     });
 
@@ -1117,6 +1121,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     });
 
     expect(state.pendingChatRunId).toBeNull();
+    expect(state.pendingSubmitDraft).toBeNull();
     expect(state.activeChatRunId).toBe("run-pending");
   });
 

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -270,6 +270,12 @@ export function createEventHandlers(context: EventHandlerContext) {
     pruneRunMap(sessionRuns);
   };
 
+  const markSubmittedRunRegistered = (runId: string) => {
+    if (state.pendingSubmitDraft?.runId === runId) {
+      state.pendingSubmitDraft = null;
+    }
+  };
+
   const noteFinalizedRun = (runId: string, opts?: { displayedFinal?: boolean }) => {
     finalizedRuns.set(runId, Date.now());
     completedRuns.set(runId, Date.now());
@@ -572,6 +578,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     clearPendingTerminalLifecycleError(evt.runId);
     chatLog.dismissPendingSystem(evt.runId);
     noteSessionRun(evt.runId);
+    markSubmittedRunRegistered(evt.runId);
     const isPendingChatRun = state.pendingChatRunId === evt.runId;
     const isLocalChatRun = isLocalRunId?.(evt.runId) ?? false;
     const isLocalBtwRun = isLocalBtwRunId?.(evt.runId) ?? false;
@@ -749,6 +756,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     if (evt.stream === "lifecycle") {
       if (isPendingRun) {
         noteSessionRun(evt.runId);
+        markSubmittedRunRegistered(evt.runId);
         state.activeChatRunId = evt.runId;
         state.pendingChatRunId = null;
         if (state.pendingOptimisticUserMessage) {

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { ChatLog } from "./components/chat-log.js";
 import type { TuiBackend } from "./tui-backend.js";
 import { createSessionActions } from "./tui-session-actions.js";
 import { TUI_SESSION_LOOKUP_LIMIT } from "./tui-session-list-policy.js";
@@ -9,6 +10,22 @@ describe("tui session actions", () => {
     clear: vi.fn(),
     showResult: vi.fn(),
   });
+
+  const createChatLog = (overrides: Record<string, unknown> = {}) =>
+    ({
+      addSystem: vi.fn(),
+      addUser: vi.fn(),
+      clearAll: vi.fn(),
+      clearPendingUsers: vi.fn(),
+      countPendingUsers: vi.fn(() => 0),
+      reconcilePendingUsers: vi.fn(() => []),
+      restorePendingUsers: vi.fn(),
+      startTool: vi.fn(),
+      finalizeAssistant: vi.fn(),
+      updateAssistant: vi.fn(),
+      dropPendingUser: vi.fn(),
+      ...overrides,
+    }) as unknown as import("./components/chat-log.js").ChatLog;
 
   const createBaseState = (overrides: Partial<TuiStateAccess> = {}): TuiStateAccess => ({
     agentDefaultId: "main",
@@ -38,10 +55,7 @@ describe("tui session actions", () => {
   ) =>
     createSessionActions({
       client: { listSessions: vi.fn() } as unknown as TuiBackend,
-      chatLog: {
-        addSystem: vi.fn(),
-        clearAll: vi.fn(),
-      } as unknown as import("./components/chat-log.js").ChatLog,
+      chatLog: createChatLog(),
       btw: createBtwPresenter(),
       tui: { requestRender: vi.fn() } as unknown as import("@earendil-works/pi-tui").TUI,
       opts: {},
@@ -497,14 +511,7 @@ describe("tui session actions", () => {
     });
     const updateAssistant = vi.fn();
     const setActivityStatus = vi.fn();
-    const chatLog = {
-      addSystem: vi.fn(),
-      clearAll: vi.fn(),
-      addUser: vi.fn(),
-      finalizeAssistant: vi.fn(),
-      updateAssistant,
-      startTool: vi.fn(),
-    } as unknown as import("./components/chat-log.js").ChatLog;
+    const chatLog = createChatLog({ updateAssistant });
     const state = createBaseState({ currentSessionKey: "agent:main:other" });
 
     const { setSession } = createTestSessionActions({
@@ -529,14 +536,7 @@ describe("tui session actions", () => {
     });
     const updateAssistant = vi.fn();
     const setActivityStatus = vi.fn();
-    const chatLog = {
-      addSystem: vi.fn(),
-      clearAll: vi.fn(),
-      addUser: vi.fn(),
-      finalizeAssistant: vi.fn(),
-      updateAssistant,
-      startTool: vi.fn(),
-    } as unknown as import("./components/chat-log.js").ChatLog;
+    const chatLog = createChatLog({ updateAssistant });
     const state = createBaseState({ currentSessionKey: "agent:main:other" });
 
     const { setSession } = createTestSessionActions({
@@ -558,14 +558,7 @@ describe("tui session actions", () => {
     const loadHistory = vi.fn().mockResolvedValue({ sessionId: "session-x", messages: [] });
     const updateAssistant = vi.fn();
     const setActivityStatus = vi.fn();
-    const chatLog = {
-      addSystem: vi.fn(),
-      clearAll: vi.fn(),
-      addUser: vi.fn(),
-      finalizeAssistant: vi.fn(),
-      updateAssistant,
-      startTool: vi.fn(),
-    } as unknown as import("./components/chat-log.js").ChatLog;
+    const chatLog = createChatLog({ updateAssistant });
     const state = createBaseState({ currentSessionKey: "agent:main:other" });
 
     const { setSession } = createTestSessionActions({
@@ -737,10 +730,7 @@ describe("tui session actions", () => {
 
     const { setEmptySession } = createTestSessionActions({
       client: { listSessions, loadHistory } as unknown as TuiBackend,
-      chatLog: {
-        addSystem,
-        clearAll,
-      } as unknown as import("./components/chat-log.js").ChatLog,
+      chatLog: createChatLog({ addSystem, clearAll }),
       tui: { requestRender } as unknown as import("@earendil-works/pi-tui").TUI,
       state,
       rememberSessionKey,
@@ -857,10 +847,7 @@ describe("tui session actions", () => {
 
     const { abortActive } = createSessionActions({
       client: { listSessions: vi.fn(), abortChat } as unknown as TuiBackend,
-      chatLog: {
-        addSystem,
-        clearAll: vi.fn(),
-      } as unknown as import("./components/chat-log.js").ChatLog,
+      chatLog: createChatLog({ addSystem }),
       btw: createBtwPresenter(),
       tui: { requestRender: vi.fn() } as unknown as import("@earendil-works/pi-tui").TUI,
       opts: {},
@@ -875,15 +862,54 @@ describe("tui session actions", () => {
       setActivityStatus,
     });
 
-    await abortActive();
+    const result = await abortActive();
 
     expect(abortChat).toHaveBeenCalledWith({
       sessionKey: "agent:main:main",
       runId: "run-pending",
     });
     expect(addSystem).not.toHaveBeenCalledWith("no active run");
+    expect(result).toEqual({ aborted: true, runId: "run-pending" });
     expect(state.pendingChatRunId).toBeNull();
     expect(setActivityStatus).toHaveBeenCalledWith("aborted");
+  });
+
+  it("cleans up pending drafts after command aborts of a pending run", async () => {
+    const abortChat = vi.fn().mockResolvedValue({ ok: true, aborted: true });
+    const chatLog = new ChatLog(40);
+    chatLog.addPendingUser("run-pending", "restore me");
+    const state = createBaseState({
+      activeChatRunId: "run-active",
+      pendingChatRunId: "run-pending",
+      pendingOptimisticUserMessage: true,
+      pendingSubmitDraft: { runId: "run-pending", text: "restore me" },
+    });
+
+    const { abortActive } = createTestSessionActions({
+      client: { listSessions: vi.fn(), abortChat } as unknown as TuiBackend,
+      state,
+      chatLog,
+    });
+
+    const result = await abortActive({ preferActive: true });
+
+    expect(abortChat).toHaveBeenCalledWith({
+      sessionKey: "agent:main:main",
+      runId: "run-pending",
+    });
+    expect(abortChat).toHaveBeenCalledWith({
+      sessionKey: "agent:main:main",
+      runId: "run-active",
+    });
+    expect(result).toEqual({
+      aborted: true,
+      runId: "run-pending",
+      restoredDraftText: "restore me",
+    });
+    expect(state.pendingSubmitDraft).toBeNull();
+    expect(state.pendingOptimisticUserMessage).toBe(false);
+    expect(chatLog.countPendingUsers()).toBe(0);
+    expect(chatLog.render(120).join("\n")).not.toContain("restore me");
   });
 
   it("passes the selected agent when aborting selected global runs", async () => {

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -12,7 +12,7 @@ import type { ChatLog } from "./components/chat-log.js";
 import type { TuiAgentsList, TuiBackend, TuiSessionMutationResult } from "./tui-backend.js";
 import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
 import { TUI_SESSION_LOOKUP_LIMIT } from "./tui-session-list-policy.js";
-import type { SessionInfo, TuiOptions, TuiStateAccess } from "./tui-types.js";
+import type { SessionInfo, TuiAbortActiveResult, TuiOptions, TuiStateAccess } from "./tui-types.js";
 
 type SessionActionBtwPresenter = {
   clear: () => void;
@@ -612,7 +612,9 @@ export function createSessionActions(context: SessionActionContext) {
     clearDisplayedSession();
   };
 
-  const abortActive = async (params?: { preferActive?: boolean }): Promise<TuiAbortActiveResult> => {
+  const abortActive = async (params?: {
+    preferActive?: boolean;
+  }): Promise<TuiAbortActiveResult> => {
     if (
       opts.local === true &&
       state.activityStatus === "finishing context" &&

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -92,6 +92,25 @@ function sessionInfoUiEquals(left: SessionInfo, right: SessionInfo): boolean {
   );
 }
 
+function coerceHistoryTimestamp(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value !== "string" || !value.trim()) {
+    return null;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function extractHistoryUserTimestamp(message: Record<string, unknown>): number | null {
+  return (
+    coerceHistoryTimestamp(message.timestamp) ??
+    coerceHistoryTimestamp(message.createdAt) ??
+    coerceHistoryTimestamp(message.updatedAt)
+  );
+}
+
 export function createSessionActions(context: SessionActionContext) {
   const {
     client,
@@ -448,7 +467,9 @@ export function createSessionActions(context: SessionActionContext) {
         await refreshSessionInfo();
       }
       const showTools = (state.sessionInfo.verboseLevel ?? "off") !== "off";
-      chatLog.clearAll();
+      const preservePendingUsers = chatLog.countPendingUsers() > 0;
+      const historyUsers: Array<{ text: string; timestamp?: number | null }> = [];
+      chatLog.clearAll({ preservePendingUsers });
       btw.clear();
       chatLog.addSystem(`session ${state.currentSessionKey}`);
       for (const entry of record.messages ?? []) {
@@ -467,6 +488,10 @@ export function createSessionActions(context: SessionActionContext) {
           const text = extractTextFromMessage(message);
           if (text) {
             chatLog.addUser(text);
+            historyUsers.push({
+              text,
+              timestamp: extractHistoryUserTimestamp(message),
+            });
           }
           continue;
         }
@@ -499,6 +524,13 @@ export function createSessionActions(context: SessionActionContext) {
             { isError: Boolean(message.isError) },
           );
         }
+      }
+      if (preservePendingUsers) {
+        const reconciledRunIds = chatLog.reconcilePendingUsers(historyUsers);
+        if (state.pendingSubmitDraft && reconciledRunIds.includes(state.pendingSubmitDraft.runId)) {
+          state.pendingSubmitDraft = null;
+        }
+        chatLog.restorePendingUsers();
       }
       // Restore a run still streaming for this session+agent that the gateway
       // reports as in-flight. Its live deltas were delivered to a per-agent key
@@ -533,6 +565,8 @@ export function createSessionActions(context: SessionActionContext) {
     state.activeChatRunId = null;
     state.pendingChatRunId = null;
     state.pendingOptimisticUserMessage = false;
+    state.pendingSubmitDraft = null;
+    chatLog.clearPendingUsers();
     setActivityStatus("idle");
     state.currentSessionId = null;
     // Session keys can move backwards in updatedAt ordering; drop previous session freshness
@@ -553,6 +587,8 @@ export function createSessionActions(context: SessionActionContext) {
     state.activeChatRunId = null;
     state.pendingChatRunId = null;
     state.pendingOptimisticUserMessage = false;
+    state.pendingSubmitDraft = null;
+    chatLog.clearPendingUsers();
     setActivityStatus("idle");
     state.currentSessionId = null;
     const defaults = lastSessionDefaults;
@@ -576,7 +612,7 @@ export function createSessionActions(context: SessionActionContext) {
     clearDisplayedSession();
   };
 
-  const abortActive = async (params?: { preferActive?: boolean }) => {
+  const abortActive = async (params?: { preferActive?: boolean }): Promise<TuiAbortActiveResult> => {
     if (
       opts.local === true &&
       state.activityStatus === "finishing context" &&
@@ -585,7 +621,7 @@ export function createSessionActions(context: SessionActionContext) {
     ) {
       chatLog.addSystem("agent is finishing context; wait for it to finish before aborting");
       tui.requestRender();
-      return;
+      return { aborted: false, runId: null };
     }
     const runIds =
       params?.preferActive && state.activeChatRunId && state.pendingChatRunId
@@ -598,11 +634,13 @@ export function createSessionActions(context: SessionActionContext) {
     if (runIds.length === 0) {
       chatLog.addSystem("no active run", { coalesceConsecutive: true });
       tui.requestRender();
-      return;
+      return { aborted: false, runId: null };
     }
     const abortsPendingRun = Boolean(
       state.pendingChatRunId && runIds.includes(state.pendingChatRunId),
     );
+    const pendingRunId = state.pendingChatRunId;
+    let restoredDraftText: string | undefined;
     try {
       for (const runId of runIds) {
         await client.abortChat({
@@ -614,13 +652,25 @@ export function createSessionActions(context: SessionActionContext) {
       state.pendingChatRunId = null;
       if (abortsPendingRun) {
         state.pendingOptimisticUserMessage = false;
+        if (pendingRunId && state.pendingSubmitDraft?.runId === pendingRunId) {
+          restoredDraftText = state.pendingSubmitDraft.text;
+          chatLog.dropPendingUser(pendingRunId);
+          state.pendingSubmitDraft = null;
+        }
       }
       setActivityStatus("aborted");
+      return {
+        aborted: true,
+        runId: pendingRunId ?? runIds[0] ?? null,
+        ...(restoredDraftText !== undefined ? { restoredDraftText } : {}),
+      };
     } catch (err) {
       chatLog.addSystem(`abort failed: ${String(err)}`);
       setActivityStatus("abort failed");
+      return { aborted: false, runId: pendingRunId ?? runIds[0] ?? null };
+    } finally {
+      tui.requestRender();
     }
-    tui.requestRender();
   };
 
   return {

--- a/src/tui/tui-types.ts
+++ b/src/tui/tui-types.ts
@@ -25,6 +25,12 @@ export type TuiResult = {
   crestodianMessage?: string;
 };
 
+export type TuiAbortActiveResult = {
+  aborted: boolean;
+  runId: string | null;
+  restoredDraftText?: string;
+};
+
 export type ChatEvent = {
   runId: string;
   sessionKey: string;
@@ -138,6 +144,7 @@ export type TuiStateAccess = {
   activeChatRunId: string | null;
   pendingOptimisticUserMessage?: boolean;
   pendingChatRunId?: string | null;
+  pendingSubmitDraft?: { runId: string; text: string } | null;
   queuedMessages?: QueuedMessage[];
   historyLoaded: boolean;
   sessionInfo: SessionInfo;

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -504,6 +504,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   let activeChatRunId: string | null = null;
   let pendingOptimisticUserMessage = false;
   let pendingChatRunId: string | null = null;
+  let pendingSubmitDraft: { runId: string; text: string } | null = null;
   let historyLoaded = false;
   let isConnected = false;
   let wasDisconnected = false;
@@ -593,6 +594,12 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     },
     set pendingChatRunId(value) {
       pendingChatRunId = value ?? null;
+    },
+    get pendingSubmitDraft() {
+      return pendingSubmitDraft;
+    },
+    set pendingSubmitDraft(value) {
+      pendingSubmitDraft = value ?? null;
     },
     get historyLoaded() {
       return historyLoaded;
@@ -1396,7 +1403,13 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       tui.requestRender();
       return;
     }
-    void abortActive();
+    void abortActive().then((result) => {
+      if (!result.aborted || !result.restoredDraftText) {
+        return;
+      }
+      editor.setText(result.restoredDraftText);
+      tui.requestRender();
+    });
   };
   const handleCtrlC = () => {
     const now = Date.now();


### PR DESCRIPTION
## Summary

- Clear `pendingOptimisticUserMessage` after a successful TUI abort of a pending submit, alongside `pendingChatRunId`.
- Track submitted prompts as TUI pending drafts keyed by the generated run id so early Esc abort can redact the pending transcript row and restore the text into the editor before gateway registration.
- Share pending draft/pending row cleanup through `abortActive()` so Esc, `/stop`, and stop-text abort paths handle pending submits consistently.
- Preserve/reconcile pending user rows across history reloads, and clear the draft-restore candidate as soon as chat/lifecycle/history proves the run is registered or durable.

Fixes #86199

## Verification

- `node scripts/run-vitest.mjs src/tui/tui-command-handlers.test.ts src/tui/tui-session-actions.test.ts src/tui/tui-event-handlers.test.ts src/tui/components/chat-log.test.ts src/tui/tui.test.ts`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-ui.tsbuildinfo`
- `git diff --check`

## Real behavior proof

Behavior addressed: TUI Esc abort could clear the pending run id while leaving `pendingOptimisticUserMessage` set, causing the next prompt to be blocked as busy even though a second Esc reported `no active run`. During the earliest submit window, a same-session history reload could also erase the just-submitted prompt before the run id was fully bound. Early Esc abort now restores the still-unregistered prompt to the editor instead of leaving it as a lost transcript row, and command-driven aborts share the same pending draft cleanup.

Real environment tested: macOS arm64, Node v22.22.0, OpenClaw worktree `tui-contradicting-esc-pattern`, commit 4504b2c8457623cf9898c2b9cc8ad0483b28dc56.

Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs src/tui/tui-command-handlers.test.ts src/tui/tui-session-actions.test.ts src/tui/tui-event-handlers.test.ts src/tui/components/chat-log.test.ts src/tui/tui.test.ts
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-ui.tsbuildinfo
git diff --check
```

Evidence after fix:

```text
Test Files  5 passed (5)
     Tests  230 passed (230)
```

Observed result after fix: the regression coverage verifies that aborting a pending run clears both local busy-state fields, pending user prompts survive same-session history reloads when history has not committed them yet, pending prompts reconcile to a single history-backed row once the submitted prompt appears in history, chat/lifecycle registration clears the local draft-restore candidate, and command aborts of a pending run drop the pending row and restore the draft through shared `abortActive()` cleanup.

What was not tested: no live interactive TUI PTY run was executed; coverage is focused unit coverage for the state transitions behind the stale busy lock, early prompt disappearance, and early-abort draft restoration.
