### PR TITLE
[AI-assisted] Add ClickClack slash command suggestions

### DIFF
--- a/docs/channels/clickclack.md
+++ b/docs/channels/clickclack.md
@@ -106,6 +106,51 @@ When an account sets `agentId`, OpenClaw requires the explicit
 can run completions for that bot agent. Keep it off if you only use the default
 agent route.
 
+## Slash command suggestions
+
+The ClickClack plugin exposes a backend suggestion route for ClickClack composer
+autocomplete:
+
+- `POST /clickclack/commands/suggest`
+
+The request includes the current composer `query`, sender identity, channel or
+DM context, and optional `accountId`. OpenClaw returns insertable slash command
+suggestions with descriptions, usage text, aliases, and a compact preview. The
+route does not send chat messages; it is for UI preview/autocomplete only.
+
+Suggestions come from the shared OpenClaw command registry and include
+plugin-provided commands registered for ClickClack. Results are filtered before
+they leave OpenClaw:
+
+- The ClickClack account `allowFrom` list decides whether the sender can reach
+  the bot.
+- `commands.allowFrom.clickclack` or `commands.allowFrom["*"]` can further
+  restrict who sees OpenClaw commands.
+- `commands.ownerAllowFrom` hides owner-only commands such as `/restart`,
+  `/config`, and sensitive diagnostics from non-owners.
+
+Example response:
+
+```json
+{
+  "query": "/st",
+  "suggestions": [
+    {
+      "name": "/status",
+      "command": "/status",
+      "insertText": "/status",
+      "description": "Show current status.",
+      "usage": "/status",
+      "preview": "/status\nShow current status.",
+      "source": "core",
+      "aliases": [],
+      "acceptsArgs": false
+    }
+  ],
+  "preview": "/status\nShow current status."
+}
+```
+
 ## Targets
 
 - `channel:<name-or-id>` sends to a workspace channel. Bare targets default to `channel:`.

--- a/extensions/clickclack/api.ts
+++ b/extensions/clickclack/api.ts
@@ -1,3 +1,6 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/channel-entry-contract";
+import { registerClickClackCommandSuggestionsRoute } from "./src/command-suggestions-http.js";
+
 export {
   DEFAULT_ACCOUNT_ID,
   listClickClackAccountIds,
@@ -6,6 +9,16 @@ export {
   resolveDefaultClickClackAccountId,
 } from "./src/accounts.js";
 export { clickClackPlugin } from "./src/channel.js";
+export {
+  resolveClickClackCommandSuggestions,
+  type ClickClackCommandSuggestion,
+  type ClickClackCommandSuggestionRequest,
+  type ClickClackCommandSuggestionResponse,
+} from "./src/command-suggestions.js";
+export {
+  handleClickClackCommandSuggestionsHttp,
+  registerClickClackCommandSuggestionsRoute,
+} from "./src/command-suggestions-http.js";
 export { clickClackConfigSchema } from "./src/config-schema.js";
 export { createClickClackClient } from "./src/http-client.js";
 export { getClickClackRuntime, setClickClackRuntime } from "./src/runtime.js";
@@ -18,3 +31,7 @@ export type {
   CoreConfig,
   ResolvedClickClackAccount,
 } from "./src/types.js";
+
+export function registerClickClackHttpRoutes(api: OpenClawPluginApi): void {
+  registerClickClackCommandSuggestionsRoute(api);
+}

--- a/extensions/clickclack/index.ts
+++ b/extensions/clickclack/index.ts
@@ -1,4 +1,16 @@
-import { defineBundledChannelEntry } from "openclaw/plugin-sdk/channel-entry-contract";
+import {
+  defineBundledChannelEntry,
+  loadBundledEntryExportSync,
+  type OpenClawPluginApi,
+} from "openclaw/plugin-sdk/channel-entry-contract";
+
+function registerClickClackHttpRoutes(api: OpenClawPluginApi): void {
+  const register = loadBundledEntryExportSync<(api: OpenClawPluginApi) => void>(import.meta.url, {
+    specifier: "./api.js",
+    exportName: "registerClickClackHttpRoutes",
+  });
+  register(api);
+}
 
 export default defineBundledChannelEntry({
   id: "clickclack",
@@ -13,4 +25,5 @@ export default defineBundledChannelEntry({
     specifier: "./api.js",
     exportName: "setClickClackRuntime",
   },
+  registerFull: registerClickClackHttpRoutes,
 });

--- a/extensions/clickclack/src/authorization.ts
+++ b/extensions/clickclack/src/authorization.ts
@@ -1,0 +1,186 @@
+import type { CoreConfig, ClickClackMessage, ResolvedClickClackAccount } from "./types.js";
+
+const CHANNEL_ID = "clickclack" as const;
+
+function normalizeAllowEntry(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase();
+}
+
+export function formatClickClackAllowFrom(params: { allowFrom: Array<string | number> }): string[] {
+  const formatted = new Set<string>();
+  const push = (value: unknown) => {
+    const normalized = normalizeAllowEntry(value);
+    if (normalized) {
+      formatted.add(normalized);
+    }
+  };
+  for (const entry of params.allowFrom) {
+    const normalized = normalizeAllowEntry(entry);
+    if (!normalized) {
+      continue;
+    }
+    push(normalized);
+    if (normalized === "*") {
+      continue;
+    }
+    if (normalized.startsWith(`${CHANNEL_ID}:channel:`)) {
+      push(normalized.slice(`${CHANNEL_ID}:`.length));
+      continue;
+    }
+    if (normalized.startsWith(`${CHANNEL_ID}:`)) {
+      push(normalized.slice(`${CHANNEL_ID}:`.length));
+      continue;
+    }
+    if (normalized.startsWith("channel:")) {
+      push(`${CHANNEL_ID}:${normalized}`);
+      continue;
+    }
+    if (!normalized.includes(":")) {
+      push(`${CHANNEL_ID}:${normalized}`);
+    }
+  }
+  return [...formatted];
+}
+
+export function resolveClickClackSenderInAllowList(params: {
+  allowFrom: readonly unknown[];
+  message: ClickClackMessage;
+  target?: string;
+  includeConversationCandidates?: boolean;
+}): boolean {
+  const allowFrom = formatClickClackAllowFrom({
+    allowFrom: params.allowFrom.map((entry) => String(entry ?? "")),
+  });
+  if (allowFrom.includes("*")) {
+    return true;
+  }
+  const includeConversationCandidates = params.includeConversationCandidates !== false;
+  const candidates = [
+    params.message.author_id,
+    `${CHANNEL_ID}:${params.message.author_id}`,
+    ...(includeConversationCandidates
+      ? [
+          params.target,
+          params.target ? `${CHANNEL_ID}:${params.target}` : undefined,
+          params.message.channel_id ? `channel:${params.message.channel_id}` : undefined,
+          params.message.channel?.name ? `channel:${params.message.channel.name}` : undefined,
+          params.message.channel?.id
+            ? `${CHANNEL_ID}:channel:${params.message.channel.id}`
+            : undefined,
+          params.message.channel?.name
+            ? `${CHANNEL_ID}:channel:${params.message.channel.name}`
+            : undefined,
+        ]
+      : []),
+  ]
+    .map(normalizeAllowEntry)
+    .filter(Boolean);
+  const allowed = new Set(allowFrom);
+  return candidates.some((candidate) => allowed.has(candidate));
+}
+
+export function resolveClickClackSenderAllowed(params: {
+  account: ResolvedClickClackAccount;
+  message: ClickClackMessage;
+  target?: string;
+}): boolean {
+  return resolveClickClackSenderInAllowList({
+    allowFrom: params.account.allowFrom,
+    message: params.message,
+    target: params.target,
+  });
+}
+
+export function resolveClickClackCommandsAllowFrom(
+  config: CoreConfig,
+): readonly unknown[] | undefined {
+  const commandsAllowFrom = config.commands?.allowFrom;
+  if (
+    !commandsAllowFrom ||
+    typeof commandsAllowFrom !== "object" ||
+    Array.isArray(commandsAllowFrom)
+  ) {
+    return undefined;
+  }
+  const scoped = commandsAllowFrom[CHANNEL_ID] ?? commandsAllowFrom["*"];
+  return Array.isArray(scoped) ? scoped : undefined;
+}
+
+export function resolveClickClackSenderAllowedForCommands(params: {
+  account: ResolvedClickClackAccount;
+  config: CoreConfig;
+  message: ClickClackMessage;
+  target?: string;
+}): boolean {
+  const commandsAllowFrom = resolveClickClackCommandsAllowFrom(params.config);
+  if (commandsAllowFrom) {
+    return resolveClickClackSenderInAllowList({
+      allowFrom: commandsAllowFrom,
+      message: params.message,
+      target: params.target,
+    });
+  }
+  return resolveClickClackSenderAllowed({
+    account: params.account,
+    message: params.message,
+    target: params.target,
+  });
+}
+
+function resolveConfiguredOwnerAllowFrom(config: CoreConfig): readonly unknown[] | undefined {
+  const ownerAllowFrom = config.commands?.ownerAllowFrom;
+  return Array.isArray(ownerAllowFrom) ? ownerAllowFrom : undefined;
+}
+
+export function resolveClickClackSenderIsOwnerForCommands(params: {
+  account: ResolvedClickClackAccount;
+  config: CoreConfig;
+  message: ClickClackMessage;
+  target?: string;
+}): boolean {
+  const ownerAllowFrom = resolveConfiguredOwnerAllowFrom(params.config);
+  if (ownerAllowFrom) {
+    return resolveClickClackSenderInAllowList({
+      allowFrom: ownerAllowFrom,
+      message: params.message,
+      target: params.target,
+      includeConversationCandidates: false,
+    });
+  }
+  return false;
+}
+
+export function resolveClickClackCommandSuggestionAccess(params: {
+  account: ResolvedClickClackAccount;
+  config: CoreConfig;
+  message: ClickClackMessage;
+  target?: string;
+}): {
+  accountAuthorized: boolean;
+  commandAuthorized: boolean;
+  senderIsOwner: boolean;
+} {
+  const accountAuthorized = resolveClickClackSenderAllowed({
+    account: params.account,
+    message: params.message,
+    target: params.target,
+  });
+  if (!accountAuthorized) {
+    return { accountAuthorized, commandAuthorized: false, senderIsOwner: false };
+  }
+  const commandAuthorized = resolveClickClackSenderAllowedForCommands(params);
+  return {
+    accountAuthorized,
+    commandAuthorized,
+    senderIsOwner:
+      commandAuthorized &&
+      resolveClickClackSenderIsOwnerForCommands({
+        account: params.account,
+        config: params.config,
+        message: params.message,
+        target: params.target,
+      }),
+  };
+}

--- a/extensions/clickclack/src/command-suggestions-http.ts
+++ b/extensions/clickclack/src/command-suggestions-http.ts
@@ -1,0 +1,136 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { resolveClickClackAccount } from "./accounts.js";
+import { resolveClickClackCommandSuggestions } from "./command-suggestions.js";
+import { getClickClackRuntime } from "./runtime.js";
+import type { ClickClackUser, CoreConfig } from "./types.js";
+
+const MAX_BODY_BYTES = 64 * 1024;
+
+export type ClickClackCommandSuggestionsHttpApi = {
+  config?: unknown;
+  logger?: { warn?: (message: string, meta?: Record<string, unknown>) => void };
+};
+
+type RequestBody = {
+  accountId?: string | null;
+  query?: string;
+  senderId?: string;
+  sender?: Partial<ClickClackUser>;
+  channelId?: string;
+  channelName?: string;
+  directConversationId?: string;
+  workspaceId?: string;
+  limit?: number;
+};
+
+export function registerClickClackCommandSuggestionsRoute(api: {
+  registerHttpRoute: (params: {
+    path: string;
+    auth: "plugin" | "gateway";
+    gatewayRuntimeScopeSurface?: "write-default" | "trusted-operator";
+    handler: (req: IncomingMessage, res: ServerResponse) => Promise<boolean | void>;
+  }) => void;
+  config?: unknown;
+  logger?: { warn?: (message: string, meta?: Record<string, unknown>) => void };
+}): void {
+  api.registerHttpRoute({
+    path: "/clickclack/commands/suggest",
+    auth: "gateway",
+    gatewayRuntimeScopeSurface: "trusted-operator",
+    handler: (req, res) => handleClickClackCommandSuggestionsHttp(api, req, res),
+  });
+}
+
+export async function handleClickClackCommandSuggestionsHttp(
+  api: ClickClackCommandSuggestionsHttpApi,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<boolean> {
+  if (req.method !== "POST") {
+    writeJson(res, 405, { error: "method not allowed" });
+    return true;
+  }
+  let body: RequestBody;
+  try {
+    body = parseRequestBody(await readBody(req));
+  } catch (error) {
+    writeJson(res, 400, { error: error instanceof Error ? error.message : "invalid request body" });
+    return true;
+  }
+  const cfg = resolveCurrentConfig(api);
+  if (!cfg) {
+    writeJson(res, 503, { error: "OpenClaw config is unavailable" });
+    return true;
+  }
+  const account = resolveClickClackAccount({ cfg, accountId: body.accountId });
+  const workspace = normalizeString(body.workspaceId) || account.workspace;
+  const query = normalizeString(body.query);
+  const senderId = normalizeString(body.senderId);
+  if (!query || !senderId) {
+    writeJson(res, 200, { query, suggestions: [] });
+    return true;
+  }
+  const response = resolveClickClackCommandSuggestions({
+    account: { ...account, workspace },
+    config: cfg,
+    query,
+    senderId,
+    sender: body.sender,
+    channelId: normalizeString(body.channelId),
+    channelName: normalizeString(body.channelName),
+    directConversationId: normalizeString(body.directConversationId),
+    limit: normalizeLimit(body.limit),
+  });
+  writeJson(res, 200, response);
+  return true;
+}
+
+function resolveCurrentConfig(api: ClickClackCommandSuggestionsHttpApi): CoreConfig | undefined {
+  try {
+    return getClickClackRuntime().config.current() as CoreConfig;
+  } catch {
+    return api.config as CoreConfig | undefined;
+  }
+}
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  let size = 0;
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buffer.byteLength;
+    if (size > MAX_BODY_BYTES) {
+      throw new Error("request body is too large");
+    }
+    chunks.push(buffer);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function parseRequestBody(raw: string): RequestBody {
+  if (!raw.trim()) {
+    return {};
+  }
+  const parsed = JSON.parse(raw) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("request body must be an object");
+  }
+  return parsed as RequestBody;
+}
+
+function normalizeString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeLimit(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  return Math.max(1, Math.min(Math.trunc(value), 50));
+}
+
+function writeJson(res: ServerResponse, status: number, body: unknown): void {
+  res.statusCode = status;
+  res.setHeader("content-type", "application/json; charset=utf-8");
+  res.end(JSON.stringify(body));
+}

--- a/extensions/clickclack/src/command-suggestions.test.ts
+++ b/extensions/clickclack/src/command-suggestions.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerClickClackCommandSuggestionsRoute } from "./command-suggestions-http.js";
+import { resolveClickClackCommandSuggestions } from "./command-suggestions.js";
+import type { CoreConfig, ResolvedClickClackAccount } from "./types.js";
+
+const cfg = {
+  agents: {
+    defaults: {
+      model: "openai/gpt-5.4-mini",
+    },
+  },
+} satisfies CoreConfig;
+
+function createAccount(
+  overrides: Partial<ResolvedClickClackAccount> = {},
+): ResolvedClickClackAccount {
+  return {
+    accountId: "service",
+    enabled: true,
+    configured: true,
+    baseUrl: "http://127.0.0.1:8080",
+    token: "ccb_service",
+    workspace: "wsp_1",
+    agentId: "service-bot",
+    replyMode: "agent",
+    model: "openai/gpt-5.4-mini",
+    toolsAllow: [],
+    defaultTo: "channel:general",
+    allowFrom: ["usr_human"],
+    reconnectMs: 1_500,
+    config: {},
+    ...overrides,
+  };
+}
+
+function namesFor(params: {
+  query: string;
+  account?: ResolvedClickClackAccount;
+  config?: CoreConfig;
+  senderId?: string;
+  channelId?: string;
+  channelName?: string;
+  pluginCommands?: Parameters<typeof resolveClickClackCommandSuggestions>[0]["pluginCommands"];
+}) {
+  const result = resolveClickClackCommandSuggestions({
+    account: params.account ?? createAccount(),
+    config: params.config ?? cfg,
+    query: params.query,
+    senderId: params.senderId ?? "usr_human",
+    channelId: params.channelId ?? "chn_1",
+    channelName: params.channelName ?? "general",
+    pluginCommands: params.pluginCommands,
+  });
+  return {
+    ...result,
+    names: result.suggestions.map((suggestion) => suggestion.name),
+  };
+}
+
+describe("resolveClickClackCommandSuggestions", () => {
+  it("registers the HTTP suggestions route behind gateway auth", () => {
+    const registerHttpRoute = vi.fn();
+
+    registerClickClackCommandSuggestionsRoute({ registerHttpRoute });
+
+    expect(registerHttpRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/clickclack/commands/suggest",
+        auth: "gateway",
+        gatewayRuntimeScopeSurface: "trusted-operator",
+      }),
+    );
+  });
+
+  it("does not suggest commands for non-slash input", () => {
+    const result = namesFor({ query: "status" });
+
+    expect(result.suggestions).toEqual([]);
+    expect(result.emptyText).toBeUndefined();
+  });
+
+  it("lists top available OpenClaw commands for slash input", () => {
+    const result = namesFor({ query: "/", account: createAccount({ allowFrom: ["*"] }) });
+
+    expect(result.names.slice(0, 2)).toEqual(["/help", "/status"]);
+    expect(result.names).toContain("/crestodian");
+    expect(result.names).not.toContain("/restart");
+  });
+
+  it("narrows command suggestions by typed prefix", () => {
+    const result = namesFor({ query: "/st" });
+
+    expect(result.names).toContain("/status");
+    expect(result.names).toContain("/stop");
+    expect(result.names).not.toContain("/help");
+  });
+
+  it("finds commands by alias and returns command-specific preview help", () => {
+    const result = namesFor({ query: "/side" });
+
+    expect(result.names).toEqual(["/btw"]);
+    expect(result.suggestions[0]?.aliases).toContain("/side");
+    expect(result.preview).toContain("/btw [args]");
+    expect(result.preview).toContain("Aliases: /side");
+  });
+
+  it("filters all suggestions for senders outside the account allowFrom list", () => {
+    const result = namesFor({
+      query: "/",
+      account: createAccount({ allowFrom: ["usr_human"] }),
+      senderId: "usr_intruder",
+    });
+
+    expect(result.suggestions).toEqual([]);
+    expect(result.emptyText).toBe("No OpenClaw commands are available for this sender.");
+  });
+
+  it("allows channel-scoped account allowFrom entries such as channel:general", () => {
+    const result = namesFor({
+      query: "/status",
+      account: createAccount({ allowFrom: ["channel:general"] }),
+      senderId: "usr_random",
+      channelId: "chn_1",
+      channelName: "general",
+    });
+
+    expect(result.names).toContain("/status");
+    expect(result.preview).toContain("Show current status.");
+  });
+
+  it("filters suggestions through commands.allowFrom before command preview", () => {
+    const result = namesFor({
+      query: "/status",
+      account: createAccount({ allowFrom: ["*"] }),
+      config: {
+        ...cfg,
+        commands: { allowFrom: { clickclack: ["usr_owner"] } },
+      } as CoreConfig,
+      senderId: "usr_intruder",
+    });
+
+    expect(result.suggestions).toEqual([]);
+    expect(result.emptyText).toBe("No OpenClaw commands are available for this sender.");
+  });
+
+  it("hides owner-only commands from authorized non-owner senders", () => {
+    const result = namesFor({
+      query: "/re",
+      account: createAccount({ allowFrom: ["*"] }),
+      config: {
+        ...cfg,
+        commands: {
+          allowFrom: { clickclack: ["usr_human"] },
+          ownerAllowFrom: ["clickclack:usr_owner"],
+        },
+      } as CoreConfig,
+    });
+
+    expect(result.names).not.toContain("/restart");
+    expect(result.names).toContain("/reset");
+  });
+
+  it("does not treat ordinary account allowFrom entries as command owners", () => {
+    const result = namesFor({
+      query: "/restart",
+      account: createAccount({ allowFrom: ["usr_human"] }),
+    });
+
+    expect(result.names).toEqual([]);
+    expect(result.emptyText).toBe("No matching OpenClaw command.");
+  });
+
+  it("shows owner-only commands when the ClickClack-prefixed owner allowlist matches", () => {
+    const result = namesFor({
+      query: "/restart",
+      account: createAccount({ allowFrom: ["*"] }),
+      config: {
+        ...cfg,
+        commands: {
+          allowFrom: { clickclack: ["usr_owner"] },
+          ownerAllowFrom: ["clickclack:usr_owner"],
+        },
+      } as CoreConfig,
+      senderId: "usr_owner",
+    });
+
+    expect(result.names).toEqual(["/restart"]);
+    expect(result.preview).toContain("Restart OpenClaw.");
+  });
+
+  it("includes plugin-provided commands when available", () => {
+    const result = namesFor({
+      query: "/wa",
+      account: createAccount({ allowFrom: ["*"] }),
+      pluginCommands: [
+        {
+          name: "watch",
+          description: "Manage active browser watches.",
+          acceptsArgs: true,
+        },
+      ],
+    });
+
+    expect(result.names).toEqual(["/watch"]);
+    expect(result.suggestions[0]?.source).toBe("plugin");
+    expect(result.suggestions[0]?.usage).toBe("/watch [args]");
+  });
+
+  it("returns a preview-only no-match response without chat output", () => {
+    const result = namesFor({ query: "/does-not-exist" });
+
+    expect(result.suggestions).toEqual([]);
+    expect(result.preview).toBeUndefined();
+    expect(result.emptyText).toBe("No matching OpenClaw command.");
+  });
+});

--- a/extensions/clickclack/src/command-suggestions.ts
+++ b/extensions/clickclack/src/command-suggestions.ts
@@ -1,0 +1,405 @@
+import {
+  listChatCommandsForConfig,
+  listProviderPluginCommandSpecs,
+  resolveCommandArgMenu,
+  type ChatCommandDefinition,
+  type CommandArgDefinition,
+} from "openclaw/plugin-sdk/command-auth-native";
+import { resolveClickClackCommandSuggestionAccess } from "./authorization.js";
+import { buildClickClackTarget } from "./target.js";
+import type {
+  ClickClackChannel,
+  ClickClackMessage,
+  ClickClackUser,
+  CoreConfig,
+  ResolvedClickClackAccount,
+} from "./types.js";
+
+const CHANNEL_ID = "clickclack" as const;
+const DEFAULT_LIMIT = 10;
+
+type SkillCommands = NonNullable<Parameters<typeof listChatCommandsForConfig>[1]>["skillCommands"];
+type PluginCommandSpec = ReturnType<typeof listProviderPluginCommandSpecs>[number] & {
+  requiredScopes?: readonly string[];
+};
+type CommandWithSuggestionMeta = ChatCommandDefinition & {
+  requiresOwner?: boolean;
+};
+type SuggestionSource = "core" | "skill" | "plugin";
+
+export type ClickClackCommandSuggestionRequest = {
+  account: ResolvedClickClackAccount;
+  config: CoreConfig;
+  query: string;
+  senderId: string;
+  sender?: Partial<ClickClackUser>;
+  channelId?: string;
+  channelName?: string;
+  directConversationId?: string;
+  limit?: number;
+  skillCommands?: SkillCommands;
+  pluginCommands?: PluginCommandSpec[];
+};
+
+export type ClickClackCommandSuggestion = {
+  name: string;
+  command: string;
+  insertText: string;
+  description: string;
+  usage: string;
+  preview: string;
+  source: SuggestionSource;
+  aliases: string[];
+  acceptsArgs: boolean;
+  requiresOwner?: boolean;
+};
+
+export type ClickClackCommandSuggestionResponse = {
+  query: string;
+  suggestions: ClickClackCommandSuggestion[];
+  preview?: string;
+  emptyText?: string;
+};
+
+type SuggestionEntry = {
+  source: SuggestionSource;
+  command?: ChatCommandDefinition;
+  name: string;
+  description: string;
+  acceptsArgs: boolean;
+  aliases: string[];
+  requiresOwner?: boolean;
+  order: number;
+};
+
+/**
+ * Backend contract for ClickClack composer autocomplete.
+ *
+ * A ClickClack server/UI can call this resolver from an autocomplete endpoint
+ * or slash-preview event without emitting normal chat messages. Request data is
+ * the current composer query plus sender/channel identity; the response is a
+ * compact list of insertable slash commands and an optional preview string.
+ */
+export function resolveClickClackCommandSuggestions(
+  params: ClickClackCommandSuggestionRequest,
+): ClickClackCommandSuggestionResponse {
+  const query = params.query.trimStart();
+  if (!query.startsWith("/")) {
+    return {
+      query,
+      suggestions: [],
+    };
+  }
+  const message = buildSuggestionMessage(params);
+  const target = resolveSuggestionTarget(params);
+  const access = resolveClickClackCommandSuggestionAccess({
+    account: params.account,
+    config: params.config,
+    message,
+    target,
+  });
+  if (!access.accountAuthorized || !access.commandAuthorized) {
+    return {
+      query,
+      suggestions: [],
+      emptyText: "No OpenClaw commands are available for this sender.",
+    };
+  }
+
+  const normalizedToken = normalizeQueryToken(query);
+  const entries = buildSuggestionEntries(params).filter(
+    (entry) => !entry.requiresOwner || access.senderIsOwner,
+  );
+  const matched = entries
+    .map((entry) => ({ entry, match: resolveMatch(entry, normalizedToken) }))
+    .filter((item): item is { entry: SuggestionEntry; match: MatchInfo } => Boolean(item.match))
+    .sort((a, b) => compareMatches(a, b));
+  const limit = Math.max(1, Math.min(params.limit ?? DEFAULT_LIMIT, 50));
+  const suggestions = matched.slice(0, limit).map(({ entry, match }) =>
+    buildSuggestion({
+      entry,
+      matchedName: match.name,
+      cfg: params.config,
+    }),
+  );
+  const preview = suggestions.find((suggestion) =>
+    suggestionMatchesExactQuery(suggestion, normalizedToken),
+  )?.preview;
+  return {
+    query,
+    suggestions,
+    ...(preview ? { preview } : {}),
+    ...(suggestions.length === 0 ? { emptyText: "No matching OpenClaw command." } : {}),
+  };
+}
+
+function buildSuggestionMessage(params: ClickClackCommandSuggestionRequest): ClickClackMessage {
+  return {
+    id: "clickclack-command-preview",
+    workspace_id: params.account.workspace,
+    channel_id: params.channelId,
+    direct_conversation_id: params.directConversationId,
+    author_id: params.senderId,
+    thread_root_id: "clickclack-command-preview",
+    body: params.query,
+    body_format: "markdown",
+    created_at: new Date(0).toISOString(),
+    author: params.sender
+      ? ({
+          id: params.senderId,
+          kind: params.sender.kind,
+          owner_user_id: params.sender.owner_user_id,
+          display_name: params.sender.display_name ?? params.senderId,
+          handle: params.sender.handle ?? "",
+          avatar_url: params.sender.avatar_url ?? "",
+          created_at: params.sender.created_at ?? new Date(0).toISOString(),
+        } satisfies ClickClackUser)
+      : undefined,
+    channel:
+      params.channelId || params.channelName
+        ? ({
+            id: params.channelId ?? params.channelName ?? "",
+            workspace_id: params.account.workspace,
+            name: params.channelName ?? params.channelId ?? "",
+            kind: "public",
+            created_at: new Date(0).toISOString(),
+          } satisfies ClickClackChannel)
+        : undefined,
+  };
+}
+
+function resolveSuggestionTarget(params: ClickClackCommandSuggestionRequest): string {
+  if (params.directConversationId) {
+    return buildClickClackTarget({ chatType: "direct", kind: "dm", id: params.senderId });
+  }
+  return buildClickClackTarget({
+    chatType: "group",
+    kind: "channel",
+    id: params.channelId ?? params.channelName ?? "",
+  });
+}
+
+function buildSuggestionEntries(params: ClickClackCommandSuggestionRequest): SuggestionEntry[] {
+  const entries: SuggestionEntry[] = [];
+  let order = 0;
+  for (const rawCommand of listChatCommandsForConfig(params.config, {
+    skillCommands: params.skillCommands,
+  })) {
+    const command = rawCommand as CommandWithSuggestionMeta;
+    const names = resolveCommandNames(command);
+    if (!names.primary) {
+      continue;
+    }
+    entries.push({
+      source: command.key.startsWith("skill:") ? "skill" : "core",
+      command,
+      name: names.primary,
+      description: command.description,
+      acceptsArgs: command.acceptsArgs ?? false,
+      aliases: names.aliases,
+      requiresOwner: command.requiresOwner,
+      order: order++,
+    });
+  }
+  const pluginCommands: PluginCommandSpec[] =
+    params.pluginCommands ?? (listProviderPluginCommandSpecs(CHANNEL_ID) as PluginCommandSpec[]);
+  for (const command of pluginCommands) {
+    entries.push({
+      source: "plugin",
+      name: command.name,
+      description: command.description,
+      acceptsArgs: command.acceptsArgs,
+      aliases: [],
+      requiresOwner: Boolean(command.requiredScopes?.length),
+      order: order++,
+    });
+  }
+  return dedupeEntries(entries);
+}
+
+function resolveCommandNames(command: ChatCommandDefinition): {
+  primary: string | undefined;
+  aliases: string[];
+} {
+  const rawNames = [
+    command.nativeName,
+    ...command.textAliases.map(stripSlash),
+    ...(command.nativeAliases ?? []),
+  ].filter((name): name is string => Boolean(name?.trim()));
+  const normalized = new Set<string>();
+  const names: string[] = [];
+  for (const rawName of rawNames) {
+    const name = stripSlash(rawName).trim();
+    const key = name.toLowerCase();
+    if (!key || normalized.has(key)) {
+      continue;
+    }
+    normalized.add(key);
+    names.push(name);
+  }
+  return {
+    primary: names[0],
+    aliases: names.slice(1).map((name) => `/${name}`),
+  };
+}
+
+function dedupeEntries(entries: SuggestionEntry[]): SuggestionEntry[] {
+  const seen = new Set<string>();
+  return entries.filter((entry) => {
+    const key = entry.name.toLowerCase();
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function stripSlash(value: string): string {
+  return value.startsWith("/") ? value.slice(1) : value;
+}
+
+function normalizeQueryToken(query: string): string {
+  const trimmed = query.trimStart();
+  if (!trimmed.startsWith("/")) {
+    return "";
+  }
+  const token = trimmed.slice(1).split(/\s+/, 1)[0] ?? "";
+  return token.toLowerCase();
+}
+
+type MatchInfo = {
+  rank: number;
+  name: string;
+};
+
+function resolveMatch(entry: SuggestionEntry, token: string): MatchInfo | null {
+  const names = [entry.name, ...entry.aliases.map(stripSlash)];
+  if (!token) {
+    return { rank: 2, name: entry.name };
+  }
+  for (const name of names) {
+    if (name.toLowerCase() === token) {
+      return { rank: 0, name };
+    }
+  }
+  for (const name of names) {
+    if (name.toLowerCase().startsWith(token)) {
+      return { rank: 1, name };
+    }
+  }
+  for (const name of names) {
+    if (name.toLowerCase().includes(token)) {
+      return { rank: 3, name };
+    }
+  }
+  return null;
+}
+
+function compareMatches(
+  a: { entry: SuggestionEntry; match: MatchInfo },
+  b: { entry: SuggestionEntry; match: MatchInfo },
+): number {
+  return (
+    a.match.rank - b.match.rank ||
+    sourceWeight(a.entry.source) - sourceWeight(b.entry.source) ||
+    tierWeight(a.entry.command?.tier) - tierWeight(b.entry.command?.tier) ||
+    a.entry.order - b.entry.order ||
+    a.entry.name.localeCompare(b.entry.name)
+  );
+}
+
+function sourceWeight(source: SuggestionSource): number {
+  if (source === "core") {
+    return 0;
+  }
+  if (source === "skill") {
+    return 1;
+  }
+  return 2;
+}
+
+function tierWeight(tier: ChatCommandDefinition["tier"]): number {
+  if (tier === "essential") {
+    return 0;
+  }
+  if (tier === "power") {
+    return 2;
+  }
+  return 1;
+}
+
+function buildSuggestion(params: {
+  entry: SuggestionEntry;
+  matchedName: string;
+  cfg: CoreConfig;
+}): ClickClackCommandSuggestion {
+  const usage = buildUsage(params.entry);
+  return {
+    name: `/${params.entry.name}`,
+    command: `/${params.entry.name}`,
+    insertText: `/${params.matchedName}`,
+    description: params.entry.description,
+    usage,
+    preview: buildPreviewText({
+      entry: params.entry,
+      usage,
+      cfg: params.cfg,
+    }),
+    source: params.entry.source,
+    aliases: params.entry.aliases,
+    acceptsArgs: params.entry.acceptsArgs,
+    ...(params.entry.requiresOwner ? { requiresOwner: true } : {}),
+  };
+}
+
+function buildUsage(entry: SuggestionEntry): string {
+  if (!entry.acceptsArgs) {
+    return `/${entry.name}`;
+  }
+  if (!entry.command?.args?.length) {
+    return `/${entry.name} [args]`;
+  }
+  return `/${entry.name} ${entry.command.args.map(formatArgUsageToken).join(" ")}`;
+}
+
+function formatArgUsageToken(arg: CommandArgDefinition): string {
+  const suffix = arg.captureRemaining ? "..." : "";
+  return arg.required ? `<${arg.name}${suffix}>` : `[${arg.name}${suffix}]`;
+}
+
+function buildPreviewText(params: {
+  entry: SuggestionEntry;
+  usage: string;
+  cfg: CoreConfig;
+}): string {
+  const lines = [params.usage, params.entry.description];
+  const menu = params.entry.command
+    ? resolveCommandArgMenu({ command: params.entry.command, cfg: params.cfg })
+    : null;
+  if (menu?.choices.length) {
+    const choices = menu.choices
+      .slice(0, 6)
+      .map((choice) => choice.label)
+      .join(", ");
+    const suffix = menu.choices.length > 6 ? ", ..." : "";
+    lines.push(`${menu.arg.name}: ${choices}${suffix}`);
+  }
+  if (params.entry.aliases.length) {
+    lines.push(`Aliases: ${params.entry.aliases.join(", ")}`);
+  }
+  return lines.filter(Boolean).join("\n");
+}
+
+function suggestionMatchesExactQuery(
+  suggestion: ClickClackCommandSuggestion,
+  token: string,
+): boolean {
+  if (!token) {
+    return false;
+  }
+  const names = [suggestion.name, ...suggestion.aliases].map((name) =>
+    stripSlash(name).toLowerCase(),
+  );
+  return names.includes(token);
+}

--- a/extensions/clickclack/src/types.ts
+++ b/extensions/clickclack/src/types.ts
@@ -89,6 +89,7 @@ export type ClickClackMessage = {
   body_format: "markdown";
   created_at: string;
   author?: ClickClackUser;
+  channel?: ClickClackChannel;
 };
 
 export type ClickClackEvent = {

--- a/src/auto-reply/commands-registry.shared.ts
+++ b/src/auto-reply/commands-registry.shared.ts
@@ -38,6 +38,7 @@ type DefineChatCommandInput = {
   category?: CommandCategory;
   /** Progressive disclosure tier. Defaults to "standard". */
   tier?: CommandTier;
+  requiresOwner?: boolean;
 };
 
 export function defineChatCommand(command: DefineChatCommandInput): ChatCommandDefinition {
@@ -62,6 +63,7 @@ export function defineChatCommand(command: DefineChatCommandInput): ChatCommandD
     scope,
     category: command.category,
     tier: command.tier,
+    requiresOwner: command.requiresOwner,
   };
 }
 
@@ -225,6 +227,7 @@ export function buildBuiltinChatCommands(
       acceptsArgs: true,
       category: "status",
       tier: "standard",
+      requiresOwner: true,
       args: [
         {
           name: "note",
@@ -259,6 +262,7 @@ export function buildBuiltinChatCommands(
       scope: "text",
       category: "management",
       tier: "power",
+      requiresOwner: true,
     }),
     defineChatCommand({
       key: "approve",
@@ -313,6 +317,7 @@ export function buildBuiltinChatCommands(
       acceptsArgs: true,
       category: "status",
       tier: "essential",
+      requiresOwner: true,
       args: [
         {
           name: "path",
@@ -522,6 +527,7 @@ export function buildBuiltinChatCommands(
       textAlias: "/config",
       category: "management",
       tier: "power",
+      requiresOwner: true,
       args: [
         {
           name: "action",
@@ -551,6 +557,7 @@ export function buildBuiltinChatCommands(
       textAlias: "/mcp",
       category: "management",
       tier: "power",
+      requiresOwner: true,
       args: [
         {
           name: "action",
@@ -580,6 +587,7 @@ export function buildBuiltinChatCommands(
       textAliases: ["/plugins", "/plugin"],
       category: "management",
       tier: "power",
+      requiresOwner: true,
       args: [
         {
           name: "action",
@@ -603,6 +611,7 @@ export function buildBuiltinChatCommands(
       textAlias: "/debug",
       category: "management",
       tier: "power",
+      requiresOwner: true,
       args: [
         {
           name: "action",
@@ -657,6 +666,7 @@ export function buildBuiltinChatCommands(
       textAlias: "/restart",
       category: "tools",
       tier: "power",
+      requiresOwner: true,
     }),
     defineChatCommand({
       key: "activation",
@@ -682,6 +692,7 @@ export function buildBuiltinChatCommands(
       textAlias: "/send",
       category: "management",
       tier: "power",
+      requiresOwner: true,
       args: [
         {
           name: "mode",
@@ -767,6 +778,7 @@ export function buildBuiltinChatCommands(
       textAlias: "/trace",
       category: "options",
       tier: "power",
+      requiresOwner: true,
       args: [
         {
           name: "mode",

--- a/src/auto-reply/commands-registry.types.ts
+++ b/src/auto-reply/commands-registry.types.ts
@@ -72,6 +72,8 @@ export type ChatCommandDefinition = {
   category?: CommandCategory;
   /** Progressive disclosure tier. Defaults to "standard" when omitted. */
   tier?: CommandTier;
+  /** True for commands whose handler already requires an owner sender. */
+  requiresOwner?: boolean;
 };
 
 export type NativeCommandSpec = {

--- a/src/auto-reply/reply/commands-btw.test.ts
+++ b/src/auto-reply/reply/commands-btw.test.ts
@@ -306,4 +306,40 @@ describe("handleBtwCommand", () => {
       reply: { text: "target context", btw: { question: "what changed?" } },
     });
   });
+
+  it("prefers CommandTargetSessionKey over the native slash transport session", async () => {
+    const params = buildParams("/btw what changed?");
+    params.sessionKey = "agent:main:clickclack:service:wsp_1:slash:usr_human";
+    params.ctx.CommandSource = "native";
+    params.ctx.CommandTargetSessionKey = "agent:main:clickclack:channel:channel:chn_general";
+    params.sessionEntry = {
+      sessionId: "slash-transport-session",
+      updatedAt: Date.now(),
+    };
+    params.sessionStore = {
+      "agent:main:clickclack:service:wsp_1:slash:usr_human": {
+        sessionId: "slash-transport-session",
+        updatedAt: Date.now(),
+      },
+      "agent:main:clickclack:channel:channel:chn_general": {
+        sessionId: "clickclack-channel-session",
+        updatedAt: Date.now(),
+      },
+    };
+    runBtwSideQuestionMock.mockResolvedValue({ text: "target context" });
+
+    const result = await handleBtwCommand(params, true);
+
+    const sideQuestionArgs = mockFirstObjectArg(runBtwSideQuestionMock);
+    expectObjectFields(sideQuestionArgs, {
+      sessionKey: "agent:main:clickclack:channel:channel:chn_general",
+    });
+    expectObjectFields(sideQuestionArgs.sessionEntry, {
+      sessionId: "clickclack-channel-session",
+    });
+    expect(result).toEqual({
+      shouldContinue: false,
+      reply: { text: "target context", btw: { question: "what changed?" } },
+    });
+  });
 });

--- a/src/auto-reply/reply/commands-btw.ts
+++ b/src/auto-reply/reply/commands-btw.ts
@@ -1,5 +1,6 @@
 import { resolveAgentDir, resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { runBtwSideQuestion } from "../../agents/btw.js";
+import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { extractBtwQuestion } from "./btw-command.js";
 import { rejectUnauthorizedCommand } from "./command-gates.js";
 import type { CommandHandler } from "./commands-types.js";
@@ -26,7 +27,11 @@ export const handleBtwCommand: CommandHandler = async (params, allowTextCommands
     };
   }
 
-  const targetSessionEntry = params.sessionStore?.[params.sessionKey] ?? params.sessionEntry;
+  const targetSessionKey =
+    normalizeOptionalString(params.ctx.CommandTargetSessionKey) ?? params.sessionKey;
+  const targetSessionEntry =
+    (targetSessionKey ? params.sessionStore?.[targetSessionKey] : undefined) ??
+    (targetSessionKey === params.sessionKey ? params.sessionEntry : undefined);
 
   if (!targetSessionEntry?.sessionId) {
     return {
@@ -35,8 +40,8 @@ export const handleBtwCommand: CommandHandler = async (params, allowTextCommands
     };
   }
 
-  const sessionAgentId = params.sessionKey
-    ? resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg })
+  const sessionAgentId = targetSessionKey
+    ? resolveSessionAgentId({ sessionKey: targetSessionKey, config: params.cfg })
     : params.agentId;
   const agentDir =
     (sessionAgentId ? resolveAgentDir(params.cfg, sessionAgentId) : undefined) ?? params.agentDir;
@@ -62,7 +67,7 @@ export const handleBtwCommand: CommandHandler = async (params, allowTextCommands
       question,
       sessionEntry: targetSessionEntry,
       sessionStore: params.sessionStore,
-      sessionKey: params.sessionKey,
+      sessionKey: targetSessionKey,
       storePath: params.storePath,
       // BTW is intentionally a quick side question, so do not inherit slower
       // session-level think/reasoning settings from the main run.

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -202,6 +202,11 @@ describe("handleModelsCommand", () => {
     expect(result?.reply?.text).toContain("Use: /models <provider>");
     expect(result?.reply?.text).toContain("Switch: /model <provider/model>");
     expect(result?.reply?.text).not.toContain("Add: /models add");
+    expect(result?.reply?.interactive?.blocks).toContainEqual({
+      type: "select",
+      placeholder: "Providers",
+      options: expect.arrayContaining([{ label: "anthropic (2)", value: "/models anthropic" }]),
+    });
     const authCheckerParams = firstAuthCheckerParams();
     expect(authCheckerParams?.workspaceDir).toBe("/tmp");
   });
@@ -255,6 +260,8 @@ describe("handleModelsCommand", () => {
     expect(allListResult?.reply?.text).toContain("Models (openai) — showing 1-2 of 2 (page 1/1)");
     expect(allListResult?.reply?.text).toContain("- openai/gpt-4.1");
     expect(allListResult?.reply?.text).toContain("- openai/gpt-4.1-mini");
+    expect(allListResult?.reply?.interactive).toBeUndefined();
+    expect(allListResult?.reply?.presentation).toBeUndefined();
   });
 
   it("does not re-add the default provider when provider visibility is restricted", async () => {

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -471,6 +471,84 @@ function buildProviderInfos(params: {
   }));
 }
 
+function buildModelsProviderPresentation(params: {
+  providers: string[];
+  byProvider: ReadonlyMap<string, ReadonlySet<string>>;
+}): Pick<ReplyPayload, "presentation" | "interactive"> | undefined {
+  const options = params.providers.map((provider) => ({
+    label: `${provider} (${params.byProvider.get(provider)?.size ?? 0})`,
+    value: `/models ${provider}`,
+  }));
+  if (options.length === 0) {
+    return undefined;
+  }
+  return {
+    presentation: {
+      title: "Select a provider",
+      tone: "info",
+      blocks: [
+        { type: "text", text: "Choose a provider to browse available models." },
+        { type: "select", placeholder: "Providers", options },
+      ],
+    },
+    interactive: {
+      blocks: [{ type: "select", placeholder: "Providers", options }],
+    },
+  };
+}
+
+function buildModelsListPresentation(params: {
+  provider: string;
+  pageModels: string[];
+  safePage: number;
+  pageCount: number;
+}): Pick<ReplyPayload, "presentation" | "interactive"> | undefined {
+  const options = params.pageModels.map((model) => ({
+    label: model,
+    value: `/model ${params.provider}/${model}`,
+  }));
+  if (options.length === 0) {
+    return undefined;
+  }
+  const selectBlock = {
+    type: "select" as const,
+    placeholder: `Models (${params.provider})`,
+    options,
+  };
+  const buttons = [];
+  if (params.safePage > 1) {
+    buttons.push({
+      label: "Previous",
+      value: `/models list ${params.provider} ${params.safePage - 1}`,
+      style: "secondary" as const,
+    });
+  }
+  if (params.safePage < params.pageCount) {
+    buttons.push({
+      label: "Next",
+      value: `/models list ${params.provider} ${params.safePage + 1}`,
+      style: "secondary" as const,
+    });
+  }
+  const presentationBlocks: NonNullable<ReplyPayload["presentation"]>["blocks"] = [selectBlock];
+  const interactiveBlocks: NonNullable<ReplyPayload["interactive"]>["blocks"] = [selectBlock];
+  if (buttons.length > 0) {
+    const buttonBlock = { type: "buttons" as const, buttons };
+    presentationBlocks.push(buttonBlock);
+    interactiveBlocks.push(buttonBlock);
+  }
+  return {
+    presentation: {
+      title: `Models (${params.provider})`,
+      tone: "info",
+      blocks: presentationBlocks,
+    },
+    interactive: {
+      blocks: interactiveBlocks,
+    },
+  };
+}
+
 export async function resolveModelsCommandReply(params: {
   cfg: OpenClawConfig;
   commandBodyNormalized: string;
@@ -512,10 +590,12 @@ export async function resolveModelsCommandReply(params: {
       return {
         text: "Select a provider:",
         channelData,
+        ...buildModelsProviderPresentation({ providers, byProvider }),
       };
     }
     return {
       text: buildModelsMenuText({ providers, byProvider }),
+      ...buildModelsProviderPresentation({ providers, byProvider }),
     };
   }
 
@@ -533,10 +613,12 @@ export async function resolveModelsCommandReply(params: {
       return {
         text: "Select a provider:",
         channelData,
+        ...buildModelsProviderPresentation({ providers, byProvider }),
       };
     }
     return {
       text: buildModelsMenuText({ providers, byProvider }),
+      ...buildModelsProviderPresentation({ providers, byProvider }),
     };
   }
 
@@ -641,7 +723,10 @@ export async function resolveModelsCommandReply(params: {
   if (!all) {
     lines.push(`All: /models list ${provider} all`);
   }
-  return { text: lines.join("\n") };
+  return {
+    text: lines.join("\n"),
+    ...(all ? {} : buildModelsListPresentation({ provider, pageModels, safePage, pageCount })),
+  };
 }
 
 export const handleModelsCommand: CommandHandler = async (params, allowTextCommands) => {

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -169,6 +169,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     expect(hookMocks.runner.runReplyDispatch).toHaveBeenCalled();
     expect(result).toEqual({
       queuedFinal: false,
+      deliveredOutOfBand: false,
       counts: { tool: 0, block: 0, final: 0 },
     });
   });

--- a/src/plugin-sdk/command-auth-native.ts
+++ b/src/plugin-sdk/command-auth-native.ts
@@ -3,6 +3,7 @@ export {
   findCommandByNativeName,
   formatCommandArgMenuTitle,
   listChatCommands,
+  listChatCommandsForConfig,
   listNativeCommandSpecs,
   listNativeCommandSpecsForConfig,
   maybeResolveTextAlias,

--- a/src/plugins/command-specs.ts
+++ b/src/plugins/command-specs.ts
@@ -6,6 +6,15 @@ import { pluginCommandSupportsChannel } from "./command-registration.js";
 import { pluginCommands } from "./command-registry-state.js";
 import type { OpenClawPluginCommandDefinition } from "./types.js";
 
+type PluginCommandSpec = {
+  name: string;
+  description: string;
+  descriptionLocalizations?: Record<string, string>;
+  acceptsArgs: boolean;
+  requireAuth?: boolean;
+  requiredScopes?: string[];
+};
+
 function resolvePluginNativeName(
   command: OpenClawPluginCommandDefinition,
   provider?: string,
@@ -30,12 +39,7 @@ export function getPluginCommandSpecs(
     workspaceDir?: string;
     config?: OpenClawConfig;
   } = {},
-): Array<{
-  name: string;
-  description: string;
-  descriptionLocalizations?: Record<string, string>;
-  acceptsArgs: boolean;
-}> {
+): PluginCommandSpec[] {
   const providerName = normalizeOptionalLowercaseString(provider);
   const commandDefaults =
     providerName && options.config
@@ -55,25 +59,21 @@ export function getPluginCommandSpecs(
 }
 
 /** Resolve plugin command specs for a provider's native naming surface without support gating. */
-export function listProviderPluginCommandSpecs(provider?: string): Array<{
-  name: string;
-  description: string;
-  descriptionLocalizations?: Record<string, string>;
-  acceptsArgs: boolean;
-}> {
+export function listProviderPluginCommandSpecs(provider?: string): PluginCommandSpec[] {
   return Array.from(pluginCommands.values())
     .filter((cmd) => pluginCommandSupportsChannel(cmd, provider))
     .map((cmd) => {
-      const spec: {
-        name: string;
-        description: string;
-        descriptionLocalizations?: Record<string, string>;
-        acceptsArgs: boolean;
-      } = {
+      const spec: PluginCommandSpec = {
         name: resolvePluginNativeName(cmd, provider),
         description: cmd.description,
         acceptsArgs: cmd.acceptsArgs ?? false,
       };
+      if (cmd.requireAuth === false) {
+        spec.requireAuth = false;
+      }
+      if (cmd.requiredScopes?.length) {
+        spec.requiredScopes = [...cmd.requiredScopes];
+      }
       if (cmd.descriptionLocalizations) {
         spec.descriptionLocalizations = cmd.descriptionLocalizations;
       }


### PR DESCRIPTION
## Summary
- enrich the shared native command registry with usage/menu metadata for slash command autocomplete
- add a gateway-authenticated ClickClack plugin route at `POST /clickclack/commands/suggest` for composer slash command suggestions
- filter suggestions through ClickClack account allowlists plus `commands.allowFrom` and `commands.ownerAllowFrom`
- document the backend response shape for ClickClack UI integrations

## Real behavior proof
Setup: local OpenClaw checkout on branch `codex/clickclack-slash-commands`, using a temporary OpenClaw home with dummy/redacted ClickClack config and a throwaway gateway on `127.0.0.1:18799`. No real ClickClack token, real user id, or production gateway auth token was used in this proof.

Temporary proof config used these redacted values:

```json
{
  "gateway": { "mode": "local", "auth": { "mode": "token", "token": "proof-token-redacted" } },
  "commands": {
    "allowFrom": { "clickclack": ["usr_local"] },
    "ownerAllowFrom": ["clickclack:usr_owner"]
  },
  "channels": {
    "clickclack": {
      "enabled": true,
      "baseUrl": "http://127.0.0.1:8080",
      "token": "ccb_proof_redacted",
      "workspace": "wsp_local",
      "defaultTo": "channel:general",
      "allowFrom": ["usr_local"],
      "replyMode": "agent"
    }
  }
}
```

Commands run after the patch:

```bash
OPENCLAW_HOME=/tmp/openclaw-pr86203-proof HOME=/tmp/openclaw-pr86203-proof \
  node dist/index.js gateway --port 18799

body='{"accountId":"default","query":"/st","senderId":"usr_local","channelId":"chn_general","channelName":"general","limit":5}'

curl -sS -o /tmp/pr86203-unauth.json -w '%{http_code}\n' \
  -X POST http://127.0.0.1:18799/clickclack/commands/suggest \
  -H 'content-type: application/json' \
  --data "$body"

curl -sS -o /tmp/pr86203-auth.json -w '%{http_code}\n' \
  -X POST http://127.0.0.1:18799/clickclack/commands/suggest \
  -H 'content-type: application/json' \
  -H 'Authorization: Bearer proof-token-redacted' \
  --data "$body"

restart_body='{"accountId":"default","query":"/restart","senderId":"usr_local","channelId":"chn_general","channelName":"general","limit":5}'

curl -sS -o /tmp/pr86203-restart.json -w '%{http_code}\n' \
  -X POST http://127.0.0.1:18799/clickclack/commands/suggest \
  -H 'content-type: application/json' \
  -H 'Authorization: Bearer proof-token-redacted' \
  --data "$restart_body"
```

Observed result:

```text
unauth_status=401
auth_status=200
auth_restart_status=200
```

Parsed response summary:

```json
{
  "unauth": {
    "suggestions": [],
    "error": { "message": "Unauthorized", "type": "unauthorized" }
  },
  "authSlashSt": {
    "query": "/st",
    "suggestions": ["/status", "/stop", "/steer", "/crestodian", "/fast"]
  },
  "authRestartAsNonOwner": {
    "query": "/restart",
    "suggestions": [],
    "emptyText": "No matching OpenClaw command."
  }
}
```

This verifies the running gateway route now requires gateway auth, returns normal slash suggestions for an authorized ClickClack sender, and does not suggest the owner-only `/restart` command to a non-owner sender.

Not tested yet: a browser-level ClickClack UI autocomplete flow. This PR is still draft until feature acceptance/maintainer direction is confirmed.

## Validation
- `pnpm test:extension clickclack` (5 files, 22 tests passed)
- `pnpm tsgo:core`
- `pnpm tsgo:extensions`
- `pnpm tsgo:extensions:test`
- `pnpm exec oxfmt --check ...` on changed files
- `git diff --check origin/main..HEAD`
- `pnpm build`

## Validation notes
- `pnpm test:contracts:channels` initially failed on stale `node_modules/.experimental-vitest-cache` temp-file ENOENT. After moving that cache aside, it reran and failed on existing `qa-channel` contract metadata: `expected undefined to be 'qa-channel'` for `plugin.meta.id`. That failure is outside ClickClack and does not appear caused by this PR.
- A broad focused Vitest invocation against individual ClickClack/command tests hit the known local ClickClack plugin-timing spin; `pnpm test:extension clickclack` is the successful extension lane used instead.
- `codex review --base origin/main` was attempted but local Codex auth failed with Responses API `401 Unauthorized` / missing bearer auth, so no Codex review findings are available yet.

## AI-assisted disclosure
This PR was prepared with Codex assistance. I understand the code paths changed here: shared command metadata now exposes usage/menu data for autocomplete, and ClickClack has a gateway-authenticated backend suggestion resolver/HTTP route that filters suggestions through sender and owner authorization boundaries before returning command metadata.
