### PR TITLE
fix(tui): stabilize optimistic user messages across history reloads, runId reassignment, and abort

### DIFF
--- a/src/tui/components/chat-log.test.ts
+++ b/src/tui/components/chat-log.test.ts
@@ -173,6 +173,21 @@ describe("ChatLog", () => {
     expect(chatLog.render(120).join("\n")).toContain("queued hello");
   });
 
+  it("re-keys a pending user in place without moving its position", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.addPendingUser("local", "queued hello", 1_000);
+    chatLog.startAssistant("hi there", "r-accepted");
+
+    expect(chatLog.rekeyPendingUser("local", "r-accepted")).toBe(true);
+
+    const rendered = chatLog.render(120).join("\n");
+    expect(rendered.indexOf("queued hello")).toBeLessThan(rendered.indexOf("hi there"));
+    // The row is now addressable by the gateway-assigned runId.
+    expect(chatLog.dropPendingUser("r-accepted")).toBe(true);
+    expect(chatLog.countPendingUsers()).toBe(0);
+  });
+
   it("reconciles pending users against rebuilt history using timestamps", () => {
     const chatLog = new ChatLog(40);
 

--- a/src/tui/components/chat-log.test.ts
+++ b/src/tui/components/chat-log.test.ts
@@ -173,17 +173,6 @@ describe("ChatLog", () => {
     expect(chatLog.render(120).join("\n")).toContain("queued hello");
   });
 
-  it("stops counting a pending user message once the run is committed", () => {
-    const chatLog = new ChatLog(40);
-
-    chatLog.addPendingUser("run-1", "hello");
-    expect(chatLog.countPendingUsers()).toBe(1);
-
-    expect(chatLog.commitPendingUser("run-1")).toBe(true);
-    expect(chatLog.countPendingUsers()).toBe(0);
-    expect(chatLog.render(120).join("\n")).toContain("hello");
-  });
-
   it("reconciles pending users against rebuilt history using timestamps", () => {
     const chatLog = new ChatLog(40);
 

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -194,10 +194,6 @@ export class ChatLog extends Container {
     return component;
   }
 
-  commitPendingUser(runId: string) {
-    return this.pendingUsers.delete(runId);
-  }
-
   dropPendingUser(runId: string) {
     const existing = this.pendingUsers.get(runId);
     if (!existing) {
@@ -206,10 +202,6 @@ export class ChatLog extends Container {
     this.removeChild(existing.component);
     this.pendingUsers.delete(runId);
     return true;
-  }
-
-  hasPendingUser(runId: string) {
-    return this.pendingUsers.has(runId);
   }
 
   reconcilePendingUsers(

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -204,6 +204,22 @@ export class ChatLog extends Container {
     return true;
   }
 
+  // Re-key in place: the gateway can assign its own runId after the optimistic
+  // row is rendered. Swap the map key without re-mounting the component so the
+  // row keeps its transcript position even if a reply already rendered below it.
+  rekeyPendingUser(fromRunId: string, toRunId: string) {
+    if (fromRunId === toRunId) {
+      return false;
+    }
+    const existing = this.pendingUsers.get(fromRunId);
+    if (!existing) {
+      return false;
+    }
+    this.pendingUsers.delete(fromRunId);
+    this.pendingUsers.set(toRunId, existing);
+    return true;
+  }
+
   reconcilePendingUsers(
     historyUsers: Array<{
       text: string;

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -89,6 +89,7 @@ function createHarness(params?: {
   currentSessionKey?: string;
   abortActive?: AbortActiveMock;
   consumeCompletedRunForPendingSend?: ConsumeCompletedRunMock;
+  isRunObserved?: (runId: string) => boolean;
   flushPendingHistoryRefreshIfIdle?: FlushPendingHistoryRefreshMock;
 }) {
   const sendChat = params?.sendChat ?? vi.fn().mockResolvedValue({ runId: "r1" });
@@ -104,6 +105,7 @@ function createHarness(params?: {
   const addUser = vi.fn();
   const addPendingUser = vi.fn();
   const dropPendingUser = vi.fn();
+  const rekeyPendingUser = vi.fn();
   const addSystem = vi.fn();
   const clearTools = vi.fn();
   const reserveAssistantSlot = vi.fn();
@@ -134,6 +136,7 @@ function createHarness(params?: {
     activeChatRunId: params?.activeChatRunId ?? null,
     pendingOptimisticUserMessage: params?.pendingOptimisticUserMessage ?? false,
     pendingChatRunId: params?.pendingChatRunId ?? null,
+    pendingSubmitDraft: null as { runId: string; text: string } | null,
     activityStatus: params?.activityStatus ?? "idle",
     isConnected: params?.isConnected ?? true,
     sessionInfo: {},
@@ -153,6 +156,7 @@ function createHarness(params?: {
       addUser,
       addPendingUser,
       dropPendingUser,
+      rekeyPendingUser,
       addSystem,
       clearTools,
       reserveAssistantSlot,
@@ -178,6 +182,7 @@ function createHarness(params?: {
     forgetLocalRunId,
     forgetLocalBtwRunId: vi.fn(),
     consumeCompletedRunForPendingSend: params?.consumeCompletedRunForPendingSend,
+    isRunObserved: params?.isRunObserved,
     flushPendingHistoryRefreshIfIdle: params?.flushPendingHistoryRefreshIfIdle,
     runAuthFlow,
     requestExit,
@@ -200,6 +205,7 @@ function createHarness(params?: {
     addUser,
     addPendingUser,
     dropPendingUser,
+    rekeyPendingUser,
     addSystem,
     clearTools,
     reserveAssistantSlot,
@@ -274,8 +280,7 @@ describe("tui command handlers", () => {
   });
 
   it("forwards unknown slash commands to the gateway", async () => {
-    const { handleCommand, sendChat, addPendingUser, addSystem, requestRender } =
-      createHarness();
+    const { handleCommand, sendChat, addPendingUser, addSystem, requestRender } = createHarness();
 
     await handleCommand("/unregistered-command");
 
@@ -286,6 +291,49 @@ describe("tui command handlers", () => {
       message: "/unregistered-command",
     });
     expect(requestRender).toHaveBeenCalled();
+  });
+
+  it("re-keys the optimistic pending row to the gateway-accepted runId in place", async () => {
+    const sendChat = vi.fn().mockResolvedValue({ runId: "r-accepted" });
+    const harness = createHarness({ sendChat });
+
+    await harness.handleCommand("hello");
+
+    const localRunId = harness.addPendingUser.mock.calls[0]?.[0];
+    expect(localRunId).toEqual(expect.any(String));
+    expect(localRunId).not.toBe("r-accepted");
+    // Re-key happens in place (no drop/re-add) so the row keeps its position.
+    expect(harness.rekeyPendingUser).toHaveBeenCalledWith(localRunId, "r-accepted");
+    expect(harness.addPendingUser).toHaveBeenCalledTimes(1);
+    expect(harness.dropPendingUser).not.toHaveBeenCalled();
+    expect(harness.state.pendingSubmitDraft).toEqual({ runId: "r-accepted", text: "hello" });
+  });
+
+  it("does not re-arm the submit draft when the accepted run already emitted events", async () => {
+    const sendChat = vi.fn().mockResolvedValue({ runId: "r-accepted" });
+    const isRunObserved = vi.fn((runId: string) => runId === "r-accepted");
+    const harness = createHarness({ sendChat, isRunObserved });
+
+    await harness.handleCommand("hello");
+
+    // The accepted run already registered, so the draft must not be re-armed —
+    // otherwise a later abort would drop a row whose reply already rendered.
+    expect(harness.rekeyPendingUser).toHaveBeenCalledWith(expect.any(String), "r-accepted");
+    expect(harness.state.pendingSubmitDraft).toBeNull();
+  });
+
+  it("clears the submit draft when the accepted run already completed", async () => {
+    const sendChat = vi.fn().mockResolvedValue({ runId: "r-accepted" });
+    const consumeCompletedRunForPendingSend = vi
+      .fn()
+      .mockReturnValue(true) as ConsumeCompletedRunMock;
+    const harness = createHarness({ sendChat, consumeCompletedRunForPendingSend });
+
+    await harness.handleCommand("hello");
+
+    expect(harness.addPendingUser).toHaveBeenCalledTimes(1);
+    expect(harness.dropPendingUser).not.toHaveBeenCalled();
+    expect(harness.state.pendingSubmitDraft).toBeNull();
   });
 
   it("passes the current backing session id when sending to the gateway", async () => {
@@ -620,7 +668,12 @@ describe("tui command handlers", () => {
 
   it("clears the pending runId if sendChat fails", async () => {
     const sendChat = vi.fn().mockRejectedValue(new Error("boom"));
-    const { handleCommand, sendChat: sendChatMock, dropPendingUser, state } = createHarness({
+    const {
+      handleCommand,
+      sendChat: sendChatMock,
+      dropPendingUser,
+      state,
+    } = createHarness({
       sendChat,
     });
 

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -102,6 +102,8 @@ function createHarness(params?: {
   const setEmptySession =
     params?.setEmptySession ?? (vi.fn().mockResolvedValue(undefined) as SetEmptySessionMock);
   const addUser = vi.fn();
+  const addPendingUser = vi.fn();
+  const dropPendingUser = vi.fn();
   const addSystem = vi.fn();
   const clearTools = vi.fn();
   const reserveAssistantSlot = vi.fn();
@@ -147,7 +149,14 @@ function createHarness(params?: {
       resetSession,
       runGoalCommand,
     } as never,
-    chatLog: { addUser, addSystem, clearTools, reserveAssistantSlot } as never,
+    chatLog: {
+      addUser,
+      addPendingUser,
+      dropPendingUser,
+      addSystem,
+      clearTools,
+      reserveAssistantSlot,
+    } as never,
     tui: { requestRender } as never,
     opts: params?.opts ?? {},
     state: state as never,
@@ -189,6 +198,8 @@ function createHarness(params?: {
     setSession,
     setEmptySession,
     addUser,
+    addPendingUser,
+    dropPendingUser,
     addSystem,
     clearTools,
     reserveAssistantSlot,
@@ -263,12 +274,13 @@ describe("tui command handlers", () => {
   });
 
   it("forwards unknown slash commands to the gateway", async () => {
-    const { handleCommand, sendChat, addUser, addSystem, requestRender } = createHarness();
+    const { handleCommand, sendChat, addPendingUser, addSystem, requestRender } =
+      createHarness();
 
     await handleCommand("/unregistered-command");
 
     expect(addSystem).not.toHaveBeenCalled();
-    expect(addUser).toHaveBeenCalledWith("/unregistered-command");
+    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "/unregistered-command");
     expectSendChatFields(sendChat, {
       sessionKey: "agent:main:main",
       message: "/unregistered-command",
@@ -292,10 +304,11 @@ describe("tui command handlers", () => {
 
   it("starts local goals and sends the objective to the model", async () => {
     const runGoalCommand = vi.fn().mockResolvedValue({ text: "Goal started: ship" });
-    const { handleCommand, sendChat, addSystem, refreshSessionInfo, addUser } = createHarness({
-      opts: { local: true },
-      runGoalCommand,
-    });
+    const { handleCommand, sendChat, addSystem, refreshSessionInfo, addPendingUser } =
+      createHarness({
+        opts: { local: true },
+        runGoalCommand,
+      });
 
     await handleCommand("/goal start ship");
 
@@ -308,7 +321,7 @@ describe("tui command handlers", () => {
       sessionKey: "agent:main:main",
       message: "ship",
     });
-    expect(addUser).toHaveBeenCalledWith("ship");
+    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "ship");
     expect(addSystem).toHaveBeenCalledWith("Goal started: ship");
     expect(refreshSessionInfo).toHaveBeenCalled();
   });
@@ -326,7 +339,7 @@ describe("tui command handlers", () => {
       sessionKey: "agent:main:main",
       message: slashPrompt,
     });
-    expect(slashHarness.addUser).toHaveBeenCalledWith(slashPrompt);
+    expect(slashHarness.addPendingUser).toHaveBeenCalledWith(expect.any(String), slashPrompt);
 
     const bangRunGoalCommand = vi.fn().mockResolvedValue({ text: "Goal started" });
     const bangHarness = createHarness({
@@ -340,7 +353,7 @@ describe("tui command handlers", () => {
       sessionKey: "agent:main:main",
       message: bangPrompt,
     });
-    expect(bangHarness.addUser).toHaveBeenCalledWith(bangPrompt);
+    expect(bangHarness.addPendingUser).toHaveBeenCalledWith(expect.any(String), bangPrompt);
   });
 
   it("keeps local goal status as a control command", async () => {
@@ -358,7 +371,7 @@ describe("tui command handlers", () => {
 
   it("wraps command-prefixed local goal resume notes before sending", async () => {
     const runGoalCommand = vi.fn().mockResolvedValue({ text: "Goal resumed: ship" });
-    const { handleCommand, sendChat, addUser } = createHarness({
+    const { handleCommand, sendChat, addPendingUser } = createHarness({
       opts: { local: true },
       runGoalCommand,
     });
@@ -370,7 +383,7 @@ describe("tui command handlers", () => {
       sessionKey: "agent:main:main",
       message: prompt,
     });
-    expect(addUser).toHaveBeenCalledWith(prompt);
+    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), prompt);
   });
 
   it("passes the selected agent for local global goal commands", async () => {
@@ -467,12 +480,12 @@ describe("tui command handlers", () => {
   });
 
   it("forwards /status to the shared gateway command path", async () => {
-    const { handleCommand, sendChat, addUser, addSystem } = createHarness();
+    const { handleCommand, sendChat, addPendingUser, addSystem } = createHarness();
 
     await handleCommand("/status");
 
     expect(addSystem).not.toHaveBeenCalled();
-    expect(addUser).toHaveBeenCalledWith("/status");
+    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "/status");
     expectSendChatFields(sendChat, {
       sessionKey: "agent:main:main",
       message: "/status",
@@ -607,10 +620,14 @@ describe("tui command handlers", () => {
 
   it("clears the pending runId if sendChat fails", async () => {
     const sendChat = vi.fn().mockRejectedValue(new Error("boom"));
-    const { handleCommand, state } = createHarness({ sendChat });
+    const { handleCommand, sendChat: sendChatMock, dropPendingUser, state } = createHarness({
+      sendChat,
+    });
 
     await handleCommand("hello");
 
+    const sentRunId = (firstMockArg(sendChatMock, "sendChat") as { runId: string }).runId;
+    expect(dropPendingUser).toHaveBeenCalledWith(sentRunId);
     expect(state.pendingChatRunId).toBeNull();
     expect(state.pendingOptimisticUserMessage).toBe(false);
   });
@@ -836,7 +853,7 @@ describe("tui command handlers", () => {
     const {
       handleCommand,
       sendChat,
-      addUser,
+      addPendingUser,
       addSystem,
       reserveAssistantSlot,
       requestRender,
@@ -856,9 +873,9 @@ describe("tui command handlers", () => {
     });
     expect(reserveAssistantSlot).toHaveBeenCalledWith("run-active");
     const reserveCallOrder = reserveAssistantSlot.mock.invocationCallOrder[0];
-    const addUserCallOrder = addUser.mock.invocationCallOrder[0];
-    expect(reserveCallOrder).toBeLessThan(addUserCallOrder);
-    expect(addUser).toHaveBeenCalledWith("/context detail");
+    const addPendingUserCallOrder = addPendingUser.mock.invocationCallOrder[0];
+    expect(reserveCallOrder).toBeLessThan(addPendingUserCallOrder);
+    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "/context detail");
     expect(addSystem).not.toHaveBeenCalledWith(
       "agent is busy — press Esc to abort before sending a new message",
     );
@@ -868,7 +885,7 @@ describe("tui command handlers", () => {
   });
 
   it("blocks gateway slash prompts while a run is active", async () => {
-    const { handleCommand, sendChat, addUser, addSystem } = createHarness({
+    const { handleCommand, sendChat, addPendingUser, addSystem } = createHarness({
       activeChatRunId: "run-active",
       activityStatus: "streaming",
     });
@@ -876,7 +893,7 @@ describe("tui command handlers", () => {
     await handleCommand("/context detail");
 
     expect(sendChat).not.toHaveBeenCalled();
-    expect(addUser).not.toHaveBeenCalled();
+    expect(addPendingUser).not.toHaveBeenCalled();
     expect(addSystem).toHaveBeenCalledWith(
       "agent is busy — press Esc to abort before sending a new message",
     );
@@ -899,7 +916,7 @@ describe("tui command handlers", () => {
 
   it("sends slash stop to the backend when there is no tracked run", async () => {
     const abortActive = vi.fn().mockResolvedValue(undefined);
-    const { handleCommand, sendChat, addUser } = createHarness({ abortActive });
+    const { handleCommand, sendChat, addPendingUser } = createHarness({ abortActive });
 
     await handleCommand("/stop");
 
@@ -909,18 +926,18 @@ describe("tui command handlers", () => {
       message: "/stop",
       sessionKey: "agent:main:main",
     });
-    expect(addUser).toHaveBeenCalledWith("/stop");
+    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "/stop");
   });
 
   it("sends broad stop-like text as a normal prompt when idle", async () => {
     const abortActive = vi.fn().mockResolvedValue(undefined);
-    const { handleCommand, sendChat, addUser } = createHarness({ abortActive });
+    const { handleCommand, sendChat, addPendingUser } = createHarness({ abortActive });
 
     await handleCommand("do not do that");
 
     expect(abortActive).not.toHaveBeenCalled();
     expect(sendChat).toHaveBeenCalledTimes(1);
-    expect(addUser).toHaveBeenCalledWith("do not do that");
+    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "do not do that");
   });
 
   it("rejects normal sends while a queued submit is pending registration", async () => {
@@ -940,7 +957,7 @@ describe("tui command handlers", () => {
   });
 
   it("allows local sends to queue while the current run is finishing", async () => {
-    const { handleCommand, sendChat, addUser, addSystem } = createHarness({
+    const { handleCommand, sendChat, addPendingUser, addSystem } = createHarness({
       opts: { local: true },
       activeChatRunId: "run-active",
       activityStatus: "finishing context",
@@ -949,7 +966,7 @@ describe("tui command handlers", () => {
     await handleCommand("/context detail");
 
     expect(sendChat).toHaveBeenCalledTimes(1);
-    expect(addUser).toHaveBeenCalledWith("/context detail");
+    expect(addPendingUser).toHaveBeenCalledWith(expect.any(String), "/context detail");
     expect(addSystem).not.toHaveBeenCalledWith(
       "agent is busy — press Esc to abort before sending a new message",
     );

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -62,6 +62,7 @@ type CommandHandlerContext = {
   forgetLocalRunId?: (runId: string) => void;
   forgetLocalBtwRunId?: (runId: string) => void;
   consumeCompletedRunForPendingSend?: (runId: string) => boolean;
+  isRunObserved?: (runId: string) => boolean;
   flushPendingHistoryRefreshIfIdle?: () => void;
   runAuthFlow?: (params: {
     provider?: string;
@@ -118,6 +119,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     forgetLocalRunId,
     forgetLocalBtwRunId,
     consumeCompletedRunForPendingSend,
+    isRunObserved,
     flushPendingHistoryRefreshIfIdle,
     runAuthFlow,
     requestExit,
@@ -748,6 +750,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           chatLog.reserveAssistantSlot(state.activeChatRunId);
         }
         chatLog.addPendingUser(runId, text);
+        state.pendingSubmitDraft = { runId, text };
         noteLocalRunId?.(runId);
         state.pendingOptimisticUserMessage = true;
         setActivityStatus("sending");
@@ -774,9 +777,21 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           if (!acceptedRunAlreadyCompleted) {
             noteLocalRunId?.(acceptedRunId);
           }
+          if (state.pendingSubmitDraft?.runId === runId) {
+            // If the accepted run already emitted events, it is registered;
+            // re-arming the draft would let a later abort drop a row whose
+            // reply already rendered.
+            state.pendingSubmitDraft = isRunObserved?.(acceptedRunId)
+              ? null
+              : { runId: acceptedRunId, text };
+          }
+          chatLog.rekeyPendingUser(runId, acceptedRunId);
         }
         if (state.pendingOptimisticUserMessage) {
           if (acceptedRunAlreadyCompleted) {
+            if (state.pendingSubmitDraft?.runId === acceptedRunId) {
+              state.pendingSubmitDraft = null;
+            }
             state.pendingOptimisticUserMessage = false;
             state.pendingChatRunId = null;
             setActivityStatus("idle");
@@ -802,6 +817,9 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         state.pendingOptimisticUserMessage = false;
         state.pendingChatRunId = null;
         state.activeChatRunId = null;
+        if (state.pendingSubmitDraft?.runId === runId) {
+          state.pendingSubmitDraft = null;
+        }
         chatLog.dropPendingUser(runId);
       }
       chatLog.addSystem(`${isBtw ? "btw failed" : "send failed"}: ${String(err)}`);

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -747,7 +747,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         ) {
           chatLog.reserveAssistantSlot(state.activeChatRunId);
         }
-        chatLog.addUser(text);
+        chatLog.addPendingUser(runId, text);
         noteLocalRunId?.(runId);
         state.pendingOptimisticUserMessage = true;
         setActivityStatus("sending");
@@ -802,6 +802,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         state.pendingOptimisticUserMessage = false;
         state.pendingChatRunId = null;
         state.activeChatRunId = null;
+        chatLog.dropPendingUser(runId);
       }
       chatLog.addSystem(`${isBtw ? "btw failed" : "send failed"}: ${String(err)}`);
       if (!isBtw) {

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -975,7 +975,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     const chatLog = {
       ...createMockChatLog(),
       countPendingUsers: () => pendingUsers.size,
-      render: () => Array.from(pendingUsers.values()),
+      render: (_width: number) => Array.from(pendingUsers.values()),
     };
     const { state, noteLocalRunId, handleChatEvent } = createHandlersHarness({
       chatLog: chatLog as unknown as HandlerChatLog,

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -970,6 +970,31 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(loadHistory).not.toHaveBeenCalled();
   });
 
+  it("keeps pending user text after run binding until history catches up", () => {
+    const pendingUsers = new Map([["run-gateway", "queued hello"]]);
+    const chatLog = {
+      ...createMockChatLog(),
+      countPendingUsers: () => pendingUsers.size,
+      render: () => Array.from(pendingUsers.values()),
+    };
+    const { state, noteLocalRunId, handleChatEvent } = createHandlersHarness({
+      chatLog: chatLog as unknown as HandlerChatLog,
+      state: { activeChatRunId: null, pendingOptimisticUserMessage: true },
+    });
+    noteLocalRunId("run-gateway");
+
+    handleChatEvent({
+      runId: "run-gateway",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: "working" },
+    });
+
+    expect(state.pendingOptimisticUserMessage).toBe(false);
+    expect(chatLog.countPendingUsers()).toBe(1);
+    expect(chatLog.render(120).join("\n")).toContain("queued hello");
+  });
+
   it("does not bind unknown gateway run ids while an optimistic message is pending", () => {
     const { state, loadHistory, isLocalRunId, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: null, pendingOptimisticUserMessage: true },

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -270,6 +270,12 @@ export function createEventHandlers(context: EventHandlerContext) {
     pruneRunMap(sessionRuns);
   };
 
+  const markSubmittedRunRegistered = (runId: string) => {
+    if (state.pendingSubmitDraft?.runId === runId) {
+      state.pendingSubmitDraft = null;
+    }
+  };
+
   const noteFinalizedRun = (runId: string, opts?: { displayedFinal?: boolean }) => {
     finalizedRuns.set(runId, Date.now());
     completedRuns.set(runId, Date.now());
@@ -572,6 +578,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     clearPendingTerminalLifecycleError(evt.runId);
     chatLog.dismissPendingSystem(evt.runId);
     noteSessionRun(evt.runId);
+    markSubmittedRunRegistered(evt.runId);
     const isPendingChatRun = state.pendingChatRunId === evt.runId;
     const isLocalChatRun = isLocalRunId?.(evt.runId) ?? false;
     const isLocalBtwRun = isLocalBtwRunId?.(evt.runId) ?? false;
@@ -749,6 +756,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     if (evt.stream === "lifecycle") {
       if (isPendingRun) {
         noteSessionRun(evt.runId);
+        markSubmittedRunRegistered(evt.runId);
         state.activeChatRunId = evt.runId;
         state.pendingChatRunId = null;
         if (state.pendingOptimisticUserMessage) {
@@ -855,6 +863,11 @@ export function createEventHandlers(context: EventHandlerContext) {
     return true;
   };
 
+  // True once any event for this runId has been seen, even before sendChat
+  // resolves. Lets the optimistic-submit path know an accepted run already
+  // registered so it does not re-arm a draft the abort path would then drop.
+  const isRunObserved = (runId: string) => sessionRuns.has(runId);
+
   return {
     handleChatEvent,
     handleAgentEvent,
@@ -862,6 +875,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     pauseStreamingWatchdog,
     reconnectStreamingWatchdog,
     consumeCompletedRunForPendingSend,
+    isRunObserved,
     flushPendingHistoryRefreshIfIdle,
     dispose,
   };

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -44,7 +44,7 @@ describe("tui session actions", () => {
         finalizeAssistant: vi.fn(),
         clearPendingUsers: vi.fn(),
         clearAll: vi.fn(),
-        reconcilePendingUsers: vi.fn(),
+        reconcilePendingUsers: vi.fn().mockReturnValue([]),
         restorePendingUsers: vi.fn(),
       } as unknown as import("./components/chat-log.js").ChatLog,
       btw: createBtwPresenter(),
@@ -508,7 +508,7 @@ describe("tui session actions", () => {
       clearPendingUsers: vi.fn(),
       addUser: vi.fn(),
       finalizeAssistant: vi.fn(),
-      reconcilePendingUsers: vi.fn(),
+      reconcilePendingUsers: vi.fn().mockReturnValue([]),
       restorePendingUsers: vi.fn(),
       updateAssistant,
       startTool: vi.fn(),
@@ -543,7 +543,7 @@ describe("tui session actions", () => {
       clearPendingUsers: vi.fn(),
       addUser: vi.fn(),
       finalizeAssistant: vi.fn(),
-      reconcilePendingUsers: vi.fn(),
+      reconcilePendingUsers: vi.fn().mockReturnValue([]),
       restorePendingUsers: vi.fn(),
       updateAssistant,
       startTool: vi.fn(),
@@ -575,7 +575,7 @@ describe("tui session actions", () => {
       clearPendingUsers: vi.fn(),
       addUser: vi.fn(),
       finalizeAssistant: vi.fn(),
-      reconcilePendingUsers: vi.fn(),
+      reconcilePendingUsers: vi.fn().mockReturnValue([]),
       restorePendingUsers: vi.fn(),
       updateAssistant,
       startTool: vi.fn(),
@@ -900,6 +900,58 @@ describe("tui session actions", () => {
     expect(setActivityStatus).toHaveBeenCalledWith("aborted");
   });
 
+  it("drops the optimistic pending row when aborting a not-yet-registered submit", async () => {
+    const abortChat = vi.fn().mockResolvedValue({ ok: true, aborted: true });
+    const dropPendingUser = vi.fn();
+    const state = createBaseState({
+      activeChatRunId: null,
+      pendingChatRunId: "run-1",
+      pendingOptimisticUserMessage: true,
+      pendingSubmitDraft: { runId: "run-1", text: "hello" },
+    });
+
+    const { abortActive } = createTestSessionActions({
+      client: { listSessions: vi.fn(), abortChat } as unknown as TuiBackend,
+      chatLog: {
+        addSystem: vi.fn(),
+        clearAll: vi.fn(),
+        dropPendingUser,
+      } as unknown as import("./components/chat-log.js").ChatLog,
+      state,
+    });
+
+    await abortActive();
+
+    expect(dropPendingUser).toHaveBeenCalledWith("run-1");
+    expect(state.pendingSubmitDraft).toBeNull();
+    expect(state.pendingOptimisticUserMessage).toBe(false);
+  });
+
+  it("keeps the optimistic row when aborting a run that already registered", async () => {
+    const abortChat = vi.fn().mockResolvedValue({ ok: true, aborted: true });
+    const dropPendingUser = vi.fn();
+    const state = createBaseState({
+      activeChatRunId: null,
+      pendingChatRunId: "run-1",
+      pendingOptimisticUserMessage: true,
+      pendingSubmitDraft: null,
+    });
+
+    const { abortActive } = createTestSessionActions({
+      client: { listSessions: vi.fn(), abortChat } as unknown as TuiBackend,
+      chatLog: {
+        addSystem: vi.fn(),
+        clearAll: vi.fn(),
+        dropPendingUser,
+      } as unknown as import("./components/chat-log.js").ChatLog,
+      state,
+    });
+
+    await abortActive();
+
+    expect(dropPendingUser).not.toHaveBeenCalled();
+  });
+
   it("passes the selected agent when aborting selected global runs", async () => {
     const abortChat = vi.fn().mockResolvedValue({ ok: true, aborted: true });
     const state = createBaseState({
@@ -1133,7 +1185,7 @@ describe("tui session actions", () => {
       finalizeAssistant: vi.fn(),
       clearAll: vi.fn(),
       clearPendingUsers: vi.fn(),
-      reconcilePendingUsers: vi.fn(),
+      reconcilePendingUsers: vi.fn().mockReturnValue([]),
       restorePendingUsers: vi.fn(),
     };
 

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -40,7 +40,12 @@ describe("tui session actions", () => {
       client: { listSessions: vi.fn() } as unknown as TuiBackend,
       chatLog: {
         addSystem: vi.fn(),
+        addUser: vi.fn(),
+        finalizeAssistant: vi.fn(),
+        clearPendingUsers: vi.fn(),
         clearAll: vi.fn(),
+        reconcilePendingUsers: vi.fn(),
+        restorePendingUsers: vi.fn(),
       } as unknown as import("./components/chat-log.js").ChatLog,
       btw: createBtwPresenter(),
       tui: { requestRender: vi.fn() } as unknown as import("@earendil-works/pi-tui").TUI,
@@ -500,8 +505,11 @@ describe("tui session actions", () => {
     const chatLog = {
       addSystem: vi.fn(),
       clearAll: vi.fn(),
+      clearPendingUsers: vi.fn(),
       addUser: vi.fn(),
       finalizeAssistant: vi.fn(),
+      reconcilePendingUsers: vi.fn(),
+      restorePendingUsers: vi.fn(),
       updateAssistant,
       startTool: vi.fn(),
     } as unknown as import("./components/chat-log.js").ChatLog;
@@ -532,8 +540,11 @@ describe("tui session actions", () => {
     const chatLog = {
       addSystem: vi.fn(),
       clearAll: vi.fn(),
+      clearPendingUsers: vi.fn(),
       addUser: vi.fn(),
       finalizeAssistant: vi.fn(),
+      reconcilePendingUsers: vi.fn(),
+      restorePendingUsers: vi.fn(),
       updateAssistant,
       startTool: vi.fn(),
     } as unknown as import("./components/chat-log.js").ChatLog;
@@ -561,8 +572,11 @@ describe("tui session actions", () => {
     const chatLog = {
       addSystem: vi.fn(),
       clearAll: vi.fn(),
+      clearPendingUsers: vi.fn(),
       addUser: vi.fn(),
       finalizeAssistant: vi.fn(),
+      reconcilePendingUsers: vi.fn(),
+      restorePendingUsers: vi.fn(),
       updateAssistant,
       startTool: vi.fn(),
     } as unknown as import("./components/chat-log.js").ChatLog;
@@ -1096,6 +1110,48 @@ describe("tui session actions", () => {
 
     expect(state.currentSessionId).toBe("session-main");
     expect(rememberSessionKey).toHaveBeenCalledWith("agent:main:main");
+  });
+
+  it("preserves optimistic user messages across stale history rebuilds", async () => {
+    const listSessions = vi.fn().mockResolvedValue({
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 1,
+      defaults: {},
+      sessions: [{ key: "agent:main:main", sessionId: "session-main" }],
+    });
+    const loadHistory = vi.fn().mockResolvedValue({
+      sessionId: "session-main",
+      messages: [
+        { role: "user", content: "persisted", timestamp: 2_000 },
+        { role: "assistant", content: [{ type: "text", text: "reply" }] },
+      ],
+    });
+    const chatLog = {
+      addSystem: vi.fn(),
+      addUser: vi.fn(),
+      finalizeAssistant: vi.fn(),
+      clearAll: vi.fn(),
+      clearPendingUsers: vi.fn(),
+      reconcilePendingUsers: vi.fn(),
+      restorePendingUsers: vi.fn(),
+    };
+
+    const { loadHistory: runLoadHistory } = createTestSessionActions({
+      client: {
+        listSessions,
+        loadHistory,
+      } as unknown as TuiBackend,
+      chatLog: chatLog as unknown as import("./components/chat-log.js").ChatLog,
+    });
+
+    await runLoadHistory();
+
+    expect(chatLog.clearAll).toHaveBeenCalledWith({ preservePendingUsers: true });
+    expect(chatLog.reconcilePendingUsers).toHaveBeenCalledWith([
+      { text: "persisted", timestamp: 2_000 },
+    ]);
+    expect(chatLog.restorePendingUsers).toHaveBeenCalledTimes(1);
   });
 
   it("hydrates session info from chat history without listing sessions", async () => {

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -1,4 +1,5 @@
 import type { TUI } from "@earendil-works/pi-tui";
+import { asDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { SessionsPatchResult } from "../../packages/gateway-protocol/src/index.js";
 import { resolveSessionInfoModelSelection } from "../agents/model-selection-display.js";
@@ -93,15 +94,8 @@ function sessionInfoUiEquals(left: SessionInfo, right: SessionInfo): boolean {
 }
 
 function extractMessageTimestamp(message: Record<string, unknown>): number | null {
-  const timestamp = message.timestamp;
-  if (typeof timestamp === "number" && Number.isFinite(timestamp)) {
-    return timestamp;
-  }
-  if (typeof timestamp !== "string") {
-    return null;
-  }
-  const parsed = Date.parse(timestamp);
-  return Number.isFinite(parsed) ? parsed : null;
+  const raw = message.timestamp;
+  return asDateTimestampMs(typeof raw === "string" ? Date.parse(raw) : raw) ?? null;
 }
 
 export function createSessionActions(context: SessionActionContext) {

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -517,7 +517,10 @@ export function createSessionActions(context: SessionActionContext) {
           );
         }
       }
-      chatLog.reconcilePendingUsers(historyUsers);
+      const reconciledRunIds = chatLog.reconcilePendingUsers(historyUsers);
+      if (state.pendingSubmitDraft && reconciledRunIds.includes(state.pendingSubmitDraft.runId)) {
+        state.pendingSubmitDraft = null;
+      }
       chatLog.restorePendingUsers();
       // Restore a run still streaming for this session+agent that the gateway
       // reports as in-flight. Its live deltas were delivered to a per-agent key
@@ -552,6 +555,7 @@ export function createSessionActions(context: SessionActionContext) {
     state.activeChatRunId = null;
     state.pendingChatRunId = null;
     state.pendingOptimisticUserMessage = false;
+    state.pendingSubmitDraft = null;
     setActivityStatus("idle");
     state.currentSessionId = null;
     // Session keys can move backwards in updatedAt ordering; drop previous session freshness
@@ -573,6 +577,7 @@ export function createSessionActions(context: SessionActionContext) {
     state.activeChatRunId = null;
     state.pendingChatRunId = null;
     state.pendingOptimisticUserMessage = false;
+    state.pendingSubmitDraft = null;
     setActivityStatus("idle");
     state.currentSessionId = null;
     const defaults = lastSessionDefaults;
@@ -623,6 +628,7 @@ export function createSessionActions(context: SessionActionContext) {
     const abortsPendingRun = Boolean(
       state.pendingChatRunId && runIds.includes(state.pendingChatRunId),
     );
+    const pendingRunId = state.pendingChatRunId;
     try {
       for (const runId of runIds) {
         await client.abortChat({
@@ -634,6 +640,10 @@ export function createSessionActions(context: SessionActionContext) {
       state.pendingChatRunId = null;
       if (abortsPendingRun) {
         state.pendingOptimisticUserMessage = false;
+        if (pendingRunId && state.pendingSubmitDraft?.runId === pendingRunId) {
+          chatLog.dropPendingUser(pendingRunId);
+          state.pendingSubmitDraft = null;
+        }
       }
       setActivityStatus("aborted");
     } catch (err) {

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -92,6 +92,18 @@ function sessionInfoUiEquals(left: SessionInfo, right: SessionInfo): boolean {
   );
 }
 
+function extractMessageTimestamp(message: Record<string, unknown>): number | null {
+  const timestamp = message.timestamp;
+  if (typeof timestamp === "number" && Number.isFinite(timestamp)) {
+    return timestamp;
+  }
+  if (typeof timestamp !== "string") {
+    return null;
+  }
+  const parsed = Date.parse(timestamp);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 export function createSessionActions(context: SessionActionContext) {
   const {
     client,
@@ -448,7 +460,8 @@ export function createSessionActions(context: SessionActionContext) {
         await refreshSessionInfo();
       }
       const showTools = (state.sessionInfo.verboseLevel ?? "off") !== "off";
-      chatLog.clearAll();
+      const historyUsers: Array<{ text: string; timestamp?: number | null }> = [];
+      chatLog.clearAll({ preservePendingUsers: true });
       btw.clear();
       chatLog.addSystem(`session ${state.currentSessionKey}`);
       for (const entry of record.messages ?? []) {
@@ -466,6 +479,10 @@ export function createSessionActions(context: SessionActionContext) {
         if (message.role === "user") {
           const text = extractTextFromMessage(message);
           if (text) {
+            historyUsers.push({
+              text,
+              timestamp: extractMessageTimestamp(message),
+            });
             chatLog.addUser(text);
           }
           continue;
@@ -500,6 +517,8 @@ export function createSessionActions(context: SessionActionContext) {
           );
         }
       }
+      chatLog.reconcilePendingUsers(historyUsers);
+      chatLog.restorePendingUsers();
       // Restore a run still streaming for this session+agent that the gateway
       // reports as in-flight. Its live deltas were delivered to a per-agent key
       // we stopped watching after switching away, so the persisted history above
@@ -539,6 +558,7 @@ export function createSessionActions(context: SessionActionContext) {
     // so refresh data for the newly selected session isn't rejected as stale.
     state.sessionInfo.updatedAt = null;
     state.historyLoaded = false;
+    chatLog.clearPendingUsers();
     clearLocalRunIds?.();
     btw.clear();
     updateHeader();

--- a/src/tui/tui-types.ts
+++ b/src/tui/tui-types.ts
@@ -138,6 +138,7 @@ export type TuiStateAccess = {
   activeChatRunId: string | null;
   pendingOptimisticUserMessage?: boolean;
   pendingChatRunId?: string | null;
+  pendingSubmitDraft?: { runId: string; text: string } | null;
   queuedMessages?: QueuedMessage[];
   historyLoaded: boolean;
   sessionInfo: SessionInfo;

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -504,6 +504,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   let activeChatRunId: string | null = null;
   let pendingOptimisticUserMessage = false;
   let pendingChatRunId: string | null = null;
+  let pendingSubmitDraft: { runId: string; text: string } | null = null;
   let historyLoaded = false;
   let isConnected = false;
   let wasDisconnected = false;
@@ -593,6 +594,12 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     },
     set pendingChatRunId(value) {
       pendingChatRunId = value ?? null;
+    },
+    get pendingSubmitDraft() {
+      return pendingSubmitDraft;
+    },
+    set pendingSubmitDraft(value) {
+      pendingSubmitDraft = value ?? null;
     },
     get historyLoaded() {
       return historyLoaded;
@@ -1260,6 +1267,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     pauseStreamingWatchdog,
     reconnectStreamingWatchdog,
     consumeCompletedRunForPendingSend,
+    isRunObserved,
     flushPendingHistoryRefreshIfIdle,
   } = createEventHandlers({
     chatLog,
@@ -1353,6 +1361,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       forgetLocalRunId,
       forgetLocalBtwRunId,
       consumeCompletedRunForPendingSend,
+      isRunObserved,
       flushPendingHistoryRefreshIfIdle,
       runAuthFlow,
       requestExit,


### PR DESCRIPTION
## What this fixes

The TUI renders an outbound user message optimistically, before the gateway persists it. Three situations could make that optimistic row disappear, jump position, or linger as a ghost. This PR makes it stable across all three by tracking it as a keyed *pending* entry that is reconciled against real history.

1. **A stale history reload wipes the message.** A `chat.history` rebuild (or run-error refresh) landing before the message is persisted used to clear the optimistic render. Pending rows now survive `clearAll`, are restored across rebuilds, and are reconciled (by text + timestamp) once persisted history catches up. *(Original regressions: #54722, #59014.)*

2. **The gateway reassigns the runId.** When `chat.send` returns a different `runId` than the locally generated one, the pending row is re-keyed **in place** via `ChatLog.rekeyPendingUser` (a map-key swap, no re-mount), so it keeps its transcript position even if a reply already rendered below it.

3. **Abort before the run registers.** A new `pendingSubmitDraft` tracks a submit until it is durably registered (proven by `isRunObserved` or completion). `abortActive` drops the optimistic row only while the submit is still unregistered; once registered, the row is left to history. This removes both the ghost row that used to linger after aborting a pending submit and the risk of dropping a row whose reply already showed.

It also removes two unused `ChatLog` helpers (`commitPendingUser`, `hasPendingUser`) that had no caller.

## Why it exists

Outbound TUI messages silently vanishing or mis-rendering is a recurring, high-annoyance class of bug (#54722, #59014). The optimistic-render path had no durable link between the rendered row and the eventual persisted/streamed run, so any reload, runId reassignment, or abort in the wrong window lost or misplaced it.

## Commits

- `fix(tui): preserve optimistic user messages` — pending-row preservation + reconcile across history reloads (case 1).
- `refactor(tui): drop unused pending-user chat-log helpers` — remove dead `commitPendingUser` / `hasPendingUser`.
- `fix(tui): reconcile optimistic user row across runId reassignment and abort` — in-place re-key (case 2) + gated abort cleanup with the `isRunObserved` registration guard (case 3).

## Related issues

- Guards against the closed disappearance regressions #54722 and #59014.
- Folds in the optimistic-row handling from the closed #86200 (Esc abort), minus its editor draft-restore. The stale busy-state half of that issue (#86199) already landed separately via #86722.
- Distinct from #78017 (open), which is long-message scrollback loss in the renderer (`\x1b[3J`), not the optimistic-history path.

## Verification

Maintainer local proof (no live Gateway run):

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.tui.config.ts \
  src/tui/components/chat-log.test.ts src/tui/tui-command-handlers.test.ts \
  src/tui/tui-session-actions.test.ts src/tui/tui-event-handlers.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json   # CI check-test-types lane (covers src/tui)
.agents/skills/autoreview/scripts/autoreview --mode local
```

- TUI unit lanes: **179 passed** (4 files)
- Fake-backend PTY lane: **13 passed**
- Test + prod types: clean · `oxfmt --check`: clean · `git diff --check`: clean
- autoreview: **patch is correct**, no accepted/actionable findings

New regression coverage: in-place re-key preserves transcript order; abort drops a not-yet-registered pending row; abort keeps a registered row; the draft is not re-armed when the accepted run already emitted events.

Not tested: no live Gateway/provider/streaming run; the fake-backend PTY harness does not prove transport, embedded runtime, providers, or session persistence.
