### PR TITLE
fix: tolerate Bun launcher import misses

### DIFF
--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -250,22 +250,35 @@ if (
 const isModuleNotFoundError = (err) =>
   err && typeof err === "object" && "code" in err && err.code === "ERR_MODULE_NOT_FOUND";
 
+const hasDirectModuleNotFoundMessage = (message, specifier, expectedPath) =>
+  message.includes(`Cannot find module '${specifier}'`) ||
+  message.includes(`Cannot find module "${specifier}"`) ||
+  message.includes(`Cannot find module '${expectedPath}'`) ||
+  message.includes(`Cannot find module "${expectedPath}"`);
+
 const isDirectModuleNotFoundError = (err, specifier) => {
-  if (!isModuleNotFoundError(err)) {
+  if (!err || typeof err !== "object") {
     return false;
   }
 
   const expectedUrl = new URL(specifier, import.meta.url);
+  const expectedPath = fileURLToPath(expectedUrl);
+  const message = "message" in err && typeof err.message === "string" ? err.message : "";
+
+  // Bun does not attach Node's ERR_MODULE_NOT_FOUND code to import misses.
+  if (hasDirectModuleNotFoundMessage(message, specifier, expectedPath)) {
+    return true;
+  }
+
+  if (!isModuleNotFoundError(err)) {
+    return false;
+  }
+
   if ("url" in err && err.url === expectedUrl.href) {
     return true;
   }
 
-  const message = "message" in err && typeof err.message === "string" ? err.message : "";
-  const expectedPath = fileURLToPath(expectedUrl);
-  return (
-    message.includes(`Cannot find module '${expectedPath}'`) ||
-    message.includes(`Cannot find module "${expectedPath}"`)
-  );
+  return false;
 };
 
 const installProcessWarningFilter = async () => {

--- a/test/scripts/openclaw-launcher-module-not-found.test.ts
+++ b/test/scripts/openclaw-launcher-module-not-found.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import vm from "node:vm";
+import { describe, expect, it } from "vitest";
+
+const launcherUrl = new URL("../../openclaw.mjs", import.meta.url);
+
+function loadDirectModuleNotFoundMatcher(): (err: unknown, specifier: string) => boolean {
+  const source = readFileSync(launcherUrl, "utf8");
+  const match = source.match(
+    /const isModuleNotFoundError =[\s\S]*?\nconst installProcessWarningFilter =/,
+  );
+  if (!match) {
+    throw new Error("failed to find launcher module-not-found helpers");
+  }
+
+  const helperSource = match[0]
+    .replace(/\nconst installProcessWarningFilter =$/, "")
+    .replaceAll("import.meta.url", "importMetaUrl");
+  const context = {
+    fileURLToPath,
+    importMetaUrl: launcherUrl.href,
+    URL,
+  };
+  vm.runInNewContext(`${helperSource}\nglobalThis.result = isDirectModuleNotFoundError;`, context);
+  return (context as typeof context & { result: (err: unknown, specifier: string) => boolean })
+    .result;
+}
+
+describe("openclaw launcher module-not-found matching", () => {
+  it("accepts Bun direct import misses that omit ERR_MODULE_NOT_FOUND", () => {
+    const isDirectModuleNotFoundError = loadDirectModuleNotFoundMatcher();
+    const err = new Error(
+      `Cannot find module './dist/warning-filter.js' from '${fileURLToPath(launcherUrl)}'`,
+    );
+
+    expect(isDirectModuleNotFoundError(err, "./dist/warning-filter.js")).toBe(true);
+  });
+
+  it("does not treat unrelated Bun import misses as the requested direct miss", () => {
+    const isDirectModuleNotFoundError = loadDirectModuleNotFoundMatcher();
+    const err = new Error(`Cannot find module './missing.js' from '${fileURLToPath(launcherUrl)}'`);
+
+    expect(isDirectModuleNotFoundError(err, "./dist/warning-filter.js")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- match Bun direct module-miss messages for optional launcher imports that omit ERR_MODULE_NOT_FOUND
- keep direct-miss matching scoped to the requested specifier or resolved path
- add regression coverage for Bun-style launcher module-not-found messages

Fixes #86198

## Tests
- `node scripts/run-vitest.mjs test/scripts/openclaw-launcher-module-not-found.test.ts`

## Real behavior proof
- Behavior or issue addressed: Bun packaged launcher startup no longer exits when optional `./dist/warning-filter.js` / `.mjs` imports are absent and Bun reports the direct import miss without `ERR_MODULE_NOT_FOUND`.
- Real environment tested: Local Linux x64 checkout with Bun v1.3.13, using a temp package directory containing this patched `openclaw.mjs`, minimal package metadata, and a dummy packaged `dist/entry.js`.
- Exact steps or command run after this patch: Created a temp package directory, copied the patched launcher, wrote a minimal `package.json`, wrote `dist/entry.js`, intentionally did not create `dist/warning-filter.js` or `dist/warning-filter.mjs`, then launched it with Bun.
- Evidence after fix: Console output from the temp packaged-launcher smoke:

```text
$ tmp=$(mktemp -d) && cp openclaw.mjs "$tmp/openclaw.mjs" && printf '{"version":"test","type":"module"}\n' > "$tmp/package.json" && mkdir -p "$tmp/dist" && printf 'console.log("entry loaded")\n' > "$tmp/dist/entry.js" && (cd "$tmp" && bun ./openclaw.mjs)
entry loaded
```

- Observed result after fix: The launcher skipped the missing optional warning-filter module and loaded `dist/entry.js` successfully, printing `entry loaded`; it did not throw `Cannot find module './dist/warning-filter.js'`.
- What was not tested: Full published package install under Bun; this was a focused packaged-launcher smoke for the reported missing optional warning-filter import path.
