### PR TITLE
fix(auto-reply): strip reasoning blocks before NO_REPLY detection (#66701)

### DIFF
--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -40,6 +40,36 @@ describe("isSilentReplyText", () => {
   it("returns false for token embedded in text", () => {
     expect(isSilentReplyText("Please NO_REPLY to this")).toBe(false);
   });
+
+  it("returns true when <think> block precedes token (#66701)", () => {
+    expect(isSilentReplyText("<think>I will stay quiet here.</think>NO_REPLY")).toBe(true);
+  });
+
+  it("returns true when <think> block with whitespace precedes token (#66701)", () => {
+    expect(
+      isSilentReplyText("<think>\nCav is talking to someone else.\n</think>\n\nNO_REPLY"),
+    ).toBe(true);
+  });
+
+  it("returns true for <antthinking> block prefix (#66701)", () => {
+    expect(isSilentReplyText("<antthinking>skip</antthinking>NO_REPLY")).toBe(true);
+  });
+
+  it("returns false when substantive text follows token after reasoning strip (#66701)", () => {
+    expect(isSilentReplyText("<think>reasoning</think>NO_REPLY but also responding")).toBe(false);
+  });
+
+  it("returns true for multiple sequential reasoning blocks before token (#66701)", () => {
+    expect(isSilentReplyText("<think>a</think><think>b</think>NO_REPLY")).toBe(true);
+  });
+
+  it("returns false when token is inside a reasoning block with content after (#66701)", () => {
+    expect(isSilentReplyText("<think>NO_REPLY</think>actual reply")).toBe(false);
+  });
+
+  it("returns false for unclosed reasoning block containing substantive text before token (#66701)", () => {
+    expect(isSilentReplyText("<think>I will stay quiet here.\nNO_REPLY")).toBe(false);
+  });
 });
 
 describe("stripSilentToken", () => {

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -1,4 +1,5 @@
 import { escapeRegExp } from "../shared/regexp.js";
+import { stripReasoningTagsFromText } from "../shared/text/reasoning-tags.js";
 
 export const HEARTBEAT_TOKEN = "HEARTBEAT_OK";
 export const SILENT_REPLY_TOKEN = "NO_REPLY";
@@ -36,9 +37,13 @@ export function isSilentReplyText(
   if (!text) {
     return false;
   }
+  // Strip reasoning blocks (<think>, <thinking>, etc.) before the exact-match
+  // check. Some models prepend chain-of-thought before NO_REPLY (#66701);
+  // without this, the exact regex fails and the raw reasoning text is posted.
+  const stripped = stripReasoningTagsFromText(text);
   // Match only the exact silent token with optional surrounding whitespace.
   // This prevents substantive replies ending with NO_REPLY from being suppressed (#19537).
-  return getSilentExactRegex(token).test(text);
+  return getSilentExactRegex(token).test(stripped);
 }
 
 type SilentReplyActionEnvelope = { action?: unknown };


### PR DESCRIPTION
## Summary

`isSilentReplyText` in `src/auto-reply/tokens.ts` uses an exact-match regex (`^\s*NO_REPLY\s*$`) to suppress agent replies. Some models can prepend reasoning blocks before the token:

```text
<think>
Cav is talking to someone else. I will stay quiet here.
</think>NO_REPLY
```

The regex fails on this input and the raw reasoning text is posted to chat.

This patch calls `stripReasoningTagsFromText` from `src/shared/text/reasoning-tags.ts` before testing the input. That strips supported reasoning tags such as `<think>`, `<thinking>`, and `<antthinking>` before the exact `NO_REPLY` match.

The #19537 behavior is covered by tests: substantive replies that end with `NO_REPLY` are still not suppressed after reasoning-tag stripping.

Closes #66701.

## Changes

- `src/auto-reply/tokens.ts` — import `stripReasoningTagsFromText` and strip reasoning tags before the exact-match check in `isSilentReplyText`
- `src/auto-reply/tokens.test.ts` — 7 new test cases for reasoning-prefix variants, multiple blocks, token-inside-block, and unclosed-block cases

## Real behavior proof

**Behavior addressed:** `isSilentReplyText("<think>I will stay quiet.</think>NO_REPLY")` returned `false`, causing reasoning text to be posted to chat. After this patch it returns `true`.

**Real environment tested:** Node 24, WSL2 — unit test suite only. A live reasoning model is required to reproduce the original symptom end-to-end.

**Exact steps or command run after fix:**
```
pnpm test src/auto-reply/tokens.test.ts --reporter=verbose
```

**Evidence (branch-local run):**
```
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > isSilentReplyText > returns true for exact token 2ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > isSilentReplyText > returns true for token with surrounding whitespace 0ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > isSilentReplyText > returns true for mixed-case token 0ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > isSilentReplyText > returns false for undefined/empty 0ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > isSilentReplyText > returns false for substantive text ending with token (#19537) 0ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > isSilentReplyText > returns false for substantive text starting with token 0ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > isSilentReplyText > returns false for token embedded in text 0ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > isSilentReplyText > returns true when <think> block precedes token (#66701) 1ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > isSilentReplyText > returns true when <think> block with whitespace precedes token (#66701) 0ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > isSilentReplyText > returns true for <antthinking> block prefix (#66701) 0ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > isSilentReplyText > returns false when substantive text follows token after reasoning strip (#66701) 0ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > isSilentReplyText > returns true for multiple sequential reasoning blocks before token (#66701) 0ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > isSilentReplyText > returns false when token is inside a reasoning block with content after (#66701) 0ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > isSilentReplyText > returns false for unclosed reasoning block containing substantive text before token (#66701) 0ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > stripSilentToken > strips token from end of text 0ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > stripSilentToken > does not strip token from start of text 0ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > stripSilentToken > strips token with emoji (#30916) 0ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > stripSilentToken > does not strip embedded token suffix without whitespace delimiter 0ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > stripSilentToken > strips only trailing occurrence 0ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > stripSilentToken > returns empty string when only token remains 0ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > stripSilentToken > strips token preceded by bold markdown formatting 0ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > custom silent tokens > handles custom token for 'exact-token detection' 0ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > custom silent tokens > handles custom token for 'substantive text detection' 0ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > custom silent tokens > handles custom token for 'trailing token stripping' 0ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > stripLeadingSilentToken > strips glued leading token text 0ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > startsWithSilentToken > matches leading glued silent tokens case-insensitively 1ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > startsWithSilentToken > rejects separated substantive prefixes and exact-token-only text 1ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > isSilentReplyPrefixText > matches uppercase token lead fragments 0ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > isSilentReplyPrefixText > rejects ambiguous natural-language prefixes 0ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > isSilentReplyPrefixText > keeps underscore guard for non-NO_REPLY tokens 0ms
 ✓ |unit-fast| src/auto-reply/tokens.test.ts > isSilentReplyPrefixText > rejects non-prefixes and mixed characters 0ms

 Test Files  1 passed (1)
      Tests  31 passed (31)
   Start at  20:25:27
   Duration  274ms (transform 84ms, setup 0ms, import 104ms, tests 10ms, environment 0ms)
```

**Observed result:** All 31 tests pass including the 7 new `#66701` cases that cover `<think>`, `<antthinking>`, multiple blocks, token-inside-block, and unclosed-block variants.

**What was not tested:** Live Telegram, Signal, or Slack delivery with a real Gemini or Haiku model producing a reasoning-prefixed `NO_REPLY`. That path requires a running OpenClaw instance with a reasoning model configured.