### PR TITLE
fix: recover Codex binding after stale preflight compaction

### DIFF
--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -36,7 +36,9 @@ function maybeCompactCodexAppServerSession(
   );
 }
 
-async function writeTestBinding(options: { authProfileId?: string } = {}): Promise<string> {
+async function writeTestBinding(
+  options: Partial<Parameters<typeof writeCodexAppServerBinding>[1]> = {},
+): Promise<string> {
   const sessionFile = path.join(tempDir, "session.jsonl");
   await writeCodexAppServerBinding(sessionFile, {
     threadId: "thread-1",
@@ -336,18 +338,30 @@ describe("maybeCompactCodexAppServerSession", () => {
     expect(result.result).toBeUndefined();
   });
 
-  it("clears stale thread bindings and reports failed native compaction", async () => {
+  it("preserves stale thread binding metadata for recovery and reports failed native compaction", async () => {
     const fake = createFakeCodexClient();
     fake.request.mockRejectedValueOnce(new Error("thread not found: thread-1"));
     setCodexAppServerClientFactoryForTest(async () => fake.client);
-    const sessionFile = await writeTestBinding();
+    const sessionFile = await writeTestBinding({
+      authProfileId: "openai-codex:work",
+      model: "gpt-5.4-mini",
+      approvalPolicy: "on-request",
+      sandbox: "workspace-write",
+      serviceTier: "priority",
+    });
 
     const result = requireCompactResult(
       await startCompaction(sessionFile, { currentTokenCount: 456 }),
     );
 
     expect(fake.request).toHaveBeenCalledWith("thread/compact/start", { threadId: "thread-1" });
-    expect(await readCodexAppServerBinding(sessionFile)).toBeUndefined();
+    const preservedBinding = await readCodexAppServerBinding(sessionFile);
+    expect(preservedBinding?.threadId).toBe("thread-1");
+    expect(preservedBinding?.authProfileId).toBe("openai-codex:work");
+    expect(preservedBinding?.model).toBe("gpt-5.4-mini");
+    expect(preservedBinding?.approvalPolicy).toBe("on-request");
+    expect(preservedBinding?.sandbox).toBe("workspace-write");
+    expect(preservedBinding?.serviceTier).toBe("priority");
     expect(result.ok).toBe(false);
     expect(result.compacted).toBe(false);
     expect(result.reason).toBe("thread not found: thread-1");

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -386,7 +386,6 @@ async function compactCodexNativeThread(
     } catch (error) {
       waiter.cancel();
       if (isCodexThreadNotFoundError(error)) {
-        await clearCodexAppServerBinding(params.sessionFile, { config: params.config });
         return failedCodexThreadBindingCompactionResult(params, {
           threadId: binding.threadId,
           reason: formatCompactionError(error),

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -589,6 +589,84 @@ describe("codex conversation binding", () => {
     expect(savedBinding).not.toHaveProperty("modelProvider");
   });
 
+  it("creates a fresh thread when recovery finds the binding already cleared", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    const notificationHandlers: Array<(notification: Record<string, unknown>) => void> = [];
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
+        requests.push({ method, params: requestParams });
+        if (method === "thread/start") {
+          return {
+            thread: { id: "thread-new", sessionId: "session-1", cwd: tempDir },
+            model: "gpt-5.4-mini",
+          };
+        }
+        if (method === "turn/start" && requestParams.threadId === "thread-new") {
+          setImmediate(() => {
+            for (const handler of notificationHandlers) {
+              handler({
+                method: "turn/completed",
+                params: {
+                  threadId: "thread-new",
+                  turn: {
+                    id: "turn-new",
+                    status: "completed",
+                    items: [{ id: "assistant-1", type: "agentMessage", text: "Recovered fresh" }],
+                  },
+                },
+              });
+            }
+          });
+          return { turn: { id: "turn-new" } };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      }),
+      addNotificationHandler: vi.fn((handler) => {
+        notificationHandlers.push(handler);
+        return () => undefined;
+      }),
+      addRequestHandler: vi.fn(() => () => undefined),
+    });
+
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "hi again",
+        bodyForAgent: "hi again",
+        channel: "telegram",
+        isGroup: true,
+        commandAuthorized: true,
+      },
+      {
+        channelId: "telegram",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "redacted-group",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile,
+            workspaceDir: tempDir,
+          },
+        },
+      },
+      { timeoutMs: 500 },
+    );
+
+    expect(result).toEqual({ handled: true, reply: { text: "Recovered fresh" } });
+    expect(requests.map((request) => request.method)).toEqual(["thread/start", "turn/start"]);
+    expect(requests[1]?.params.threadId).toBe("thread-new");
+    const savedBinding = JSON.parse(
+      await fs.readFile(`${sessionFile}.codex-app-server.json`, "utf8"),
+    );
+    expect(savedBinding.threadId).toBe("thread-new");
+  });
+
   it("returns a clean failure reply when app-server turn start rejects", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const agentDir = path.join(tempDir, "agents", "bot-b", "agent");

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -529,7 +529,8 @@ async function runBoundTurnWithMissingThreadRecovery(params: {
 }
 
 function isCodexThreadNotFoundError(error: unknown): boolean {
-  return /\bthread not found:/iu.test(formatErrorMessage(error));
+  const message = formatErrorMessage(error);
+  return /\bthread not found:/iu.test(message) || /\bno thread binding\b/iu.test(message);
 }
 
 function enqueueBoundTurn<T>(key: string, run: () => Promise<T>): Promise<T> {

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -699,6 +699,59 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactCall.sandboxSessionKey).toBe("agent:main:telegram:default:direct:12345");
   });
 
+  it("continues after recoverable native harness binding failure during preflight compaction", async () => {
+    const sessionFile = path.join(rootDir, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
+      "utf8",
+    );
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 1,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 0,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    compactEmbeddedPiSessionMock.mockResolvedValueOnce({
+      ok: false,
+      compacted: false,
+      reason: "thread not found: <codex-thread-id>",
+      failure: { reason: "stale_thread_binding" },
+    });
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokensFresh: false,
+    };
+    const sessionStore = { "agent:main:telegram:group:redacted": sessionEntry };
+
+    const entry = await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({
+        sessionId: "session",
+        sessionFile,
+        sessionKey: "agent:main:telegram:group:redacted",
+        provider: "openai-codex",
+        model: "gpt-5.5",
+      }),
+      defaultModel: "gpt-5.5",
+      agentCfgContextTokens: 100,
+      sessionEntry,
+      sessionStore,
+      sessionKey: "agent:main:telegram:group:redacted",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(entry).toBe(sessionEntry);
+    expect(compactEmbeddedPiSessionMock).toHaveBeenCalledTimes(1);
+    expect(incrementCompactionCountMock).not.toHaveBeenCalled();
+  });
+
   it("updates the active preflight run after transcript rotation", async () => {
     const sessionFile = path.join(rootDir, "session.jsonl");
     const successorFile = path.join(rootDir, "session-rotated.jsonl");

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -699,7 +699,66 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactCall.sandboxSessionKey).toBe("agent:main:telegram:default:direct:12345");
   });
 
-  it("continues after recoverable native harness binding failure during preflight compaction", async () => {
+  it.each([
+    ["stale_thread_binding", "thread not found: <codex-thread-id>"],
+    ["missing_thread_binding", "no thread binding for session"],
+  ])(
+    "continues after recoverable native harness %s failure during preflight compaction",
+    async (failureReason, reason) => {
+      const sessionFile = path.join(rootDir, "session.jsonl");
+      await fs.writeFile(
+        sessionFile,
+        `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
+        "utf8",
+      );
+      registerMemoryFlushPlanResolverForTest(() => ({
+        softThresholdTokens: 1,
+        forceFlushTranscriptBytes: 1_000_000_000,
+        reserveTokensFloor: 0,
+        prompt: "Pre-compaction memory flush.\nNO_REPLY",
+        systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+        relativePath: "memory/2023-11-14.md",
+      }));
+      compactEmbeddedPiSessionMock.mockResolvedValueOnce({
+        ok: false,
+        compacted: false,
+        reason,
+        failure: { reason: failureReason },
+      });
+      const sessionEntry: SessionEntry = {
+        sessionId: "session",
+        sessionFile,
+        updatedAt: Date.now(),
+        totalTokensFresh: false,
+      };
+      const sessionStore = { "agent:main:telegram:group:redacted": sessionEntry };
+
+      const entry = await runPreflightCompactionIfNeeded({
+        cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+        followupRun: createTestFollowupRun({
+          sessionId: "session",
+          sessionFile,
+          sessionKey: "agent:main:telegram:group:redacted",
+          provider: "openai-codex",
+          model: "gpt-5.5",
+        }),
+        defaultModel: "gpt-5.5",
+        agentCfgContextTokens: 100,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:telegram:group:redacted",
+        storePath: path.join(rootDir, "sessions.json"),
+        isHeartbeat: false,
+        replyOperation: createReplyOperation(),
+      });
+
+      expect(entry).toBe(sessionEntry);
+      expect(compactEmbeddedPiSessionMock).toHaveBeenCalledTimes(1);
+      expect(incrementCompactionCountMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("still fails preflight compaction for non-binding native harness failures", async () => {
     const sessionFile = path.join(rootDir, "session.jsonl");
     await fs.writeFile(
       sessionFile,
@@ -717,8 +776,8 @@ describe("runMemoryFlushIfNeeded", () => {
     compactEmbeddedPiSessionMock.mockResolvedValueOnce({
       ok: false,
       compacted: false,
-      reason: "thread not found: <codex-thread-id>",
-      failure: { reason: "stale_thread_binding" },
+      reason: "auth profile mismatch",
+      failure: { reason: "auth_profile_mismatch" },
     });
     const sessionEntry: SessionEntry = {
       sessionId: "session",
@@ -728,26 +787,27 @@ describe("runMemoryFlushIfNeeded", () => {
     };
     const sessionStore = { "agent:main:telegram:group:redacted": sessionEntry };
 
-    const entry = await runPreflightCompactionIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
-      followupRun: createTestFollowupRun({
-        sessionId: "session",
-        sessionFile,
+    await expect(
+      runPreflightCompactionIfNeeded({
+        cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+        followupRun: createTestFollowupRun({
+          sessionId: "session",
+          sessionFile,
+          sessionKey: "agent:main:telegram:group:redacted",
+          provider: "openai-codex",
+          model: "gpt-5.5",
+        }),
+        defaultModel: "gpt-5.5",
+        agentCfgContextTokens: 100,
+        sessionEntry,
+        sessionStore,
         sessionKey: "agent:main:telegram:group:redacted",
-        provider: "openai-codex",
-        model: "gpt-5.5",
+        storePath: path.join(rootDir, "sessions.json"),
+        isHeartbeat: false,
+        replyOperation: createReplyOperation(),
       }),
-      defaultModel: "gpt-5.5",
-      agentCfgContextTokens: 100,
-      sessionEntry,
-      sessionStore,
-      sessionKey: "agent:main:telegram:group:redacted",
-      storePath: path.join(rootDir, "sessions.json"),
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
-    });
+    ).rejects.toThrow("Preflight compaction required but failed: auth profile mismatch");
 
-    expect(entry).toBe(sessionEntry);
     expect(compactEmbeddedPiSessionMock).toHaveBeenCalledTimes(1);
     expect(incrementCompactionCountMock).not.toHaveBeenCalled();
   });

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -124,6 +124,15 @@ const memoryDeps = {
   now: () => Date.now(),
 };
 
+function isRecoverableNativeHarnessCompactionFailure(result: unknown): boolean {
+  if (!result || typeof result !== "object") {
+    return false;
+  }
+  const failure = (result as { failure?: { reason?: unknown } }).failure;
+  const reason = typeof failure?.reason === "string" ? failure.reason : "";
+  return reason === "missing_thread_binding" || reason === "stale_thread_binding";
+}
+
 export function setAgentRunnerMemoryTestDeps(overrides?: Partial<typeof memoryDeps>): void {
   Object.assign(memoryDeps, {
     runWithModelFallback,
@@ -768,6 +777,12 @@ export async function runPreflightCompactionIfNeeded(params: {
   if (!result?.ok || !result.compacted) {
     const reason = result?.reason ?? "not_compacted";
     logVerbose(`preflightCompaction failed: sessionKey=${params.sessionKey} reason=${reason}`);
+    if (isRecoverableNativeHarnessCompactionFailure(result)) {
+      logVerbose(
+        `preflightCompaction continuing after recoverable native harness binding failure: sessionKey=${params.sessionKey} reason=${reason}`,
+      );
+      return entry ?? params.sessionEntry;
+    }
     throw new Error(`Preflight compaction required but failed: ${reason}`);
   }
 


### PR DESCRIPTION
## Summary

Fixes #86211.

This PR makes the Telegram/Codex preflight compaction path recover from stale native harness thread bindings instead of aborting inbound dispatch before an assistant run can start.

Changes:
- treats structured stale_thread_binding / missing_thread_binding native harness compaction failures as recoverable during preflight compaction
- keeps non-binding compaction failures fail-closed and visible
- lets Codex binding recovery create a fresh app-server thread when the old binding has already been cleared
- adds focused regression coverage for both the preflight dispatch path and the cleared-binding Codex recovery path

<!-- plaintext-proof-summary-start -->
## Plaintext Proof Summary

Updated: `2026-05-25T03:44:30Z`

This PR now includes the code repair ClawSweeper requested for the current head `a9ad8a918eba2b33d2766a8fda90a59fa0c30110`.

Code repair made after ClawSweeper review:
- Native Codex compaction no longer deletes a stale app-server binding before inbound recovery can reuse it.
- The stale binding remains available long enough for recovery to preserve `authProfileId`, `model`, `approvalPolicy`, `sandbox`, and `serviceTier` when creating the replacement thread.
- The replacement thread still overwrites the stale binding after successful recovery, so stale state is not kept after recovery succeeds.
- The compact regression now proves stale binding metadata is preserved when native compaction reports `thread not found`.

Validation passed after rebasing on current `origin/main`:
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/app-server/compact.test.ts extensions/codex/src/conversation-binding.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/agent-runner-memory.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-support.config.ts src/agents/command/cli-compaction.test.ts`
- `npx oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/codex/src/app-server/compact.ts extensions/codex/src/app-server/compact.test.ts extensions/codex/src/conversation-binding.ts extensions/codex/src/conversation-binding.test.ts`
- `npx oxlint --tsconfig config/tsconfig/oxlint.core.json src/auto-reply/reply/agent-runner-memory.ts src/auto-reply/reply/agent-runner-memory.test.ts`

OpenClaw proof evidence on this repaired head:
- Head: `a9ad8a918eba2b33d2766a8fda90a59fa0c30110`
- Passing `Real behavior proof` workflow: https://github.com/openclaw/openclaw/actions/runs/26381456712
- Second passing refresh: https://github.com/openclaw/openclaw/actions/runs/26381466564
- Workflow log result: `External PR includes after-fix real behavior proof.`

Known limitation:
- Maintainer-run live Telegram/Mantis proof is still blocked for this contributor account by repository authorization. The current branch now addresses the auth/model/sandbox metadata correctness blocker and includes plaintext validation evidence in this PR summary.
<!-- plaintext-proof-summary-end -->

## Real behavior proof

Behavior or issue addressed: Inbound Telegram/Codex dispatch no longer aborts when preflight compaction sees a stale or missing Codex app-server thread binding. The recoverable stale-thread or missing-thread result now returns the current session entry so dispatch can continue, and the binding layer creates a fresh app-server thread if the binding file has already been cleared.

Real environment tested: Local OpenClaw checkout at /root/.openclaw/workspace/openclaw-upstream on Linux with Node 22.22.2, branch fix-86211-missing-thread-preflight, commit a9ad8a918eba2b33d2766a8fda90a59fa0c30110, rebased on current origin/main.

Exact steps or command run after this patch: Ran targeted OpenClaw runtime checks in the local checkout: node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/agent-runner-memory.test.ts; node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/conversation-binding.test.ts; node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/app-server/compact.test.ts; node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-support.config.ts src/agents/command/cli-compaction.test.ts; focused npx oxlint on the changed core and extension files.

Evidence after fix: Local terminal output showed agent-runner-memory.test.ts passed with 27 tests, conversation-binding.test.ts passed with 13 tests, compact.test.ts passed with 26 tests, cli-compaction.test.ts passed with 11 tests, and focused oxlint exited 0 for the changed core and extension files. The command output was captured after rebasing on origin/main; PR text uses only redacted placeholders such as <codex-thread-id> and no chat IDs.

Observed result after fix: The stale-binding and missing-binding preflight regressions no longer throw "Preflight compaction required but failed: thread not found: <codex-thread-id>" or the equivalent missing-binding failure for structured stale_thread_binding or missing_thread_binding results. Non-binding failures still throw. The cleared-binding Codex conversation regression creates a fresh thread/start, runs turn/start on that new thread, returns a reply, and saves the new binding.

What was not tested: Live Telegram group delivery against a production gateway running this PR build was not tested. The proof uses the local OpenClaw checkout and targeted runtime paths with sanitized evidence. I requested the repository Mantis Telegram proof path in PR comment https://github.com/openclaw/openclaw/pull/86216#issuecomment-4530350483, but direct workflow dispatch requires maintainer/admin rights.

## Validation

Passed locally:
- node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/agent-runner-memory.test.ts
- node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/conversation-binding.test.ts
- node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/app-server/compact.test.ts
- node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-support.config.ts src/agents/command/cli-compaction.test.ts
- npx oxlint --tsconfig config/tsconfig/oxlint.core.json src/auto-reply/reply/agent-runner-memory.ts src/auto-reply/reply/agent-runner-memory.test.ts
- npx oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/codex/src/conversation-binding.ts extensions/codex/src/conversation-binding.test.ts

Also ran node scripts/check-changed.mjs. Its typecheck/core lint/guard steps passed; the broad extension lint subprocess was killed locally after several minutes, so I followed with focused extension oxlint on the changed files, which passed.

## OpenClaw proof gate and live proof status

The repository OpenClaw `Real behavior proof` workflow has re-evaluated the current PR head and passed its parser gate.

- Head: `a9ad8a918eba2b33d2766a8fda90a59fa0c30110`
- Run: https://github.com/openclaw/openclaw/actions/runs/26381456712
- Second refresh: https://github.com/openclaw/openclaw/actions/runs/26381466564
- Job log result: `External PR includes after-fix real behavior proof.`

ClawSweeper still requires live or redacted runtime evidence showing recovered Telegram/Codex inbound dispatch and visible Telegram reply after this fix. I posted the requested Mantis command in the format ClawSweeper asked for:

- Mantis request: https://github.com/openclaw/openclaw/pull/86216#issuecomment-4530736605
- Triggered Mantis Desktop Proof run: https://github.com/openclaw/openclaw/actions/runs/26377627915
- Triggered Mantis Telegram Live run: https://github.com/openclaw/openclaw/actions/runs/26377627889

Both Mantis runs stopped at the repository authorization gate because the commenter account has `read` permission, while Mantis requires `write`, `maintain`, or `admin` for issue-comment requests. A maintainer can unblock by re-posting the same `@openclaw-mantis telegram live proof ...` request from an authorized account, or by re-applying the existing `mantis: telegram-visible-proof` label from maintainer context.

Until that maintainer-side Mantis run publishes artifacts, the remaining merge blocker is live transport proof, not another code/test change.

<!-- latest-openclaw-proof-start -->
### Latest OpenClaw proof refresh

Updated: `2026-05-25T03:44:30Z`

- OpenClaw `Real behavior proof`: https://github.com/openclaw/openclaw/actions/runs/26381456712
- Second refresh: https://github.com/openclaw/openclaw/actions/runs/26381466564
- Head: `a9ad8a918eba2b33d2766a8fda90a59fa0c30110`
- Job log result: `External PR includes after-fix real behavior proof.`
<!-- latest-openclaw-proof-end -->

## Privacy

All issue and PR evidence is sanitized. Production chat IDs, message IDs, and Codex thread IDs are redacted or replaced with placeholders.






<!-- openclaw-proof-ping: 2026-05-25T01:31:29Z -->





