### PR TITLE
fix(auth): point Keychain-only legacy Codex OAuth users at doctor instead of auto-prompting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Docs: https://docs.openclaw.ai
 - Crabbox: install Corepack shims into the writable hydration `PNPM_HOME` so local AWS runner hydration no longer tries to overwrite `/usr/local/bin/pnpm`.
 - Live tests: fail Gateway live model sweeps when selected coverage is lost to timeouts or stale high-signal filters instead of reporting false missing-profile coverage, and pin Docker OpenAI gateway coverage to the current `gpt-5.5` lane.
 - Tests: fail Docker resource-ceiling checks when stats samples or configured limits are invalid instead of silently reporting zero peaks.
+- Auth/Codex: emit a one-shot actionable `log.warn` from the embedded legacy Codex OAuth sidecar loader when the only available seed lives in the macOS Keychain, naming `openclaw doctor --fix` and macOS Keychain instead of letting the credential silently fall through to a downstream `No API key found for provider "openai-codex"`. Thanks @romneyda.
 - Agents: fail closed when provider-less session models match multiple provider-prefixed runtime policies so CLI runtime routing no longer depends on config order. (#85970) Thanks @potterdigital.
 
 ## 2026.5.24

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -413,7 +413,7 @@ That stages grounded durable candidates into the short-term dreaming store while
     - short cooldowns (rate limits/timeouts/auth failures)
     - longer disables (billing/credit failures)
 
-    Legacy Codex OAuth profiles whose tokens live in macOS Keychain (older onboarding before the file-based sidecar layout) are not picked up by the embedded runtime path — that path runs with `allowKeychainPrompt: false` and cannot trigger a Keychain prompt. Run `openclaw doctor --fix` once to migrate Keychain-backed legacy tokens inline into `auth-profiles.json`; after that, embedded turns (Telegram, cron, sub-agent dispatch) resolve them like any other inline OAuth profile.
+    Legacy Codex OAuth profiles whose tokens live in macOS Keychain (older onboarding before the file-based sidecar layout) are not picked up by the embedded runtime path — that path runs with `allowKeychainPrompt: false` and cannot trigger a Keychain prompt. Affected users will see a one-shot `log.warn` from the legacy sidecar loader naming `openclaw doctor --fix` and macOS Keychain (instead of the credential silently falling through to a downstream `No API key found for provider "openai-codex"`). Run `openclaw doctor --fix` once from an interactive terminal to migrate Keychain-backed legacy tokens inline into `auth-profiles.json`; after that, embedded turns (Telegram, cron, sub-agent dispatch) resolve them like any other inline OAuth profile.
 
   </Accordion>
   <Accordion title="6. Hooks model validation">

--- a/src/agents/auth-profiles/legacy-oauth-sidecar.test.ts
+++ b/src/agents/auth-profiles/legacy-oauth-sidecar.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetLogger, setLoggerOverride } from "../../logging/logger.js";
+import { loggingState } from "../../logging/state.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import {
+  legacyOAuthSidecarInternalTestUtils,
+  legacyOAuthSidecarTestUtils,
+  loadLegacyOAuthSidecarMaterial,
+} from "./legacy-oauth-sidecar.js";
+
+const states: OpenClawTestState[] = [];
+
+function setPlatform(value: NodeJS.Platform): () => void {
+  const descriptor = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { value, configurable: true });
+  return () => {
+    if (descriptor) {
+      Object.defineProperty(process, "platform", descriptor);
+    }
+  };
+}
+
+async function writeLegacySidecarThatNeedsKeychain(): Promise<{
+  state: OpenClawTestState;
+  ref: { source: "openclaw-credentials"; provider: "openai-codex"; id: string };
+  profileId: string;
+}> {
+  const state = await createOpenClawTestState({
+    layout: "state-only",
+    prefix: "openclaw-legacy-oauth-keychain-warn-",
+    env: {
+      OPENCLAW_AGENT_DIR: undefined,
+      OPENCLAW_AUTH_PROFILE_SECRET_KEY: undefined,
+    },
+  });
+  states.push(state);
+  const profileId = "openai-codex:default";
+  const ref = {
+    source: "openclaw-credentials" as const,
+    provider: "openai-codex" as const,
+    id: "0123456789abcdef0123456789abcdef",
+  };
+  await state.writeJson(`credentials/auth-profiles/${ref.id}.json`, {
+    version: 1,
+    profileId,
+    provider: "openai-codex",
+    encrypted: legacyOAuthSidecarTestUtils.encryptLegacyOAuthMaterial({
+      ref,
+      profileId,
+      provider: "openai-codex",
+      seed: "only-in-keychain",
+      material: { access: "a", refresh: "b", idToken: "c" },
+    }),
+  });
+  return { state, ref, profileId };
+}
+
+afterEach(async () => {
+  for (const state of states.splice(0)) {
+    await state.cleanup();
+  }
+  legacyOAuthSidecarInternalTestUtils.resetKeychainOnlyMigrationHint();
+});
+
+describe("loadLegacyOAuthSidecarMaterial keychain-only headless warning", () => {
+  let restorePlatform: () => void;
+  let warnSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    restorePlatform = setPlatform("darwin");
+    setLoggerOverride({ level: "warn", consoleLevel: "warn" });
+    warnSpy = vi.fn();
+    loggingState.rawConsole = {
+      log: vi.fn(),
+      info: vi.fn(),
+      warn: warnSpy as unknown as typeof console.warn,
+      error: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    restorePlatform();
+    loggingState.rawConsole = null;
+    setLoggerOverride(null);
+    resetLogger();
+  });
+
+  function envWithoutVitestSignals(state: OpenClawTestState): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = { ...state.env };
+    delete env.VITEST;
+    delete env.VITEST_WORKER_ID;
+    return env;
+  }
+
+  it("emits a single doctor-pointer warning when only Keychain can decrypt and prompts are disabled", async () => {
+    const { state, ref, profileId } = await writeLegacySidecarThatNeedsKeychain();
+    const env = envWithoutVitestSignals(state);
+
+    const firstAttempt = loadLegacyOAuthSidecarMaterial({
+      ref,
+      profileId,
+      provider: "openai-codex",
+      allowKeychainPrompt: false,
+      env,
+    });
+    expect(firstAttempt).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [firstMessage] = warnSpy.mock.calls[0] as [unknown];
+    expect(String(firstMessage)).toContain("openclaw doctor --fix");
+    expect(String(firstMessage)).toContain("macOS Keychain");
+
+    const secondAttempt = loadLegacyOAuthSidecarMaterial({
+      ref,
+      profileId,
+      provider: "openai-codex",
+      allowKeychainPrompt: false,
+      env,
+    });
+    expect(secondAttempt).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not emit the doctor-pointer warning on non-darwin platforms", async () => {
+    restorePlatform();
+    restorePlatform = setPlatform("linux");
+    const { state, ref, profileId } = await writeLegacySidecarThatNeedsKeychain();
+    const env = envWithoutVitestSignals(state);
+
+    const attempt = loadLegacyOAuthSidecarMaterial({
+      ref,
+      profileId,
+      provider: "openai-codex",
+      allowKeychainPrompt: false,
+      env,
+    });
+    expect(attempt).toBeNull();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/auth-profiles/legacy-oauth-sidecar.ts
+++ b/src/agents/auth-profiles/legacy-oauth-sidecar.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { resolveOAuthDir, resolveStateDir } from "../../config/paths.js";
 import { loadJsonFile } from "../../infra/json-file.js";
+import { log } from "./constants.js";
 
 const LEGACY_OAUTH_REF_SOURCE = "openclaw-credentials";
 const LEGACY_OAUTH_REF_PROVIDER = "openai-codex";
@@ -333,8 +334,37 @@ function decryptLegacyOAuthSecretMaterial(params: {
   if (keychainSeed && !seeds.includes(keychainSeed)) {
     return decryptLegacyOAuthSecretMaterialWithSeed(params, keychainSeed);
   }
+  if (
+    process.platform === "darwin" &&
+    params.allowKeychainPrompt === false &&
+    params.env.VITEST !== "true" &&
+    params.env.VITEST_WORKER_ID === undefined
+  ) {
+    emitKeychainOnlyMigrationHintOnce(params.profileId);
+  }
   return null;
 }
+
+let keychainOnlyMigrationHintEmitted = false;
+
+function emitKeychainOnlyMigrationHintOnce(profileId: string): void {
+  if (keychainOnlyMigrationHintEmitted) {
+    return;
+  }
+  keychainOnlyMigrationHintEmitted = true;
+  log.warn(
+    "Legacy Codex OAuth credentials are stored only in macOS Keychain on this host. " +
+      "Headless paths cannot prompt for Keychain access; run `openclaw doctor --fix` " +
+      "from an interactive terminal to migrate them back to inline auth-profiles.json credentials.",
+    { profileId },
+  );
+}
+
+export const legacyOAuthSidecarInternalTestUtils = {
+  resetKeychainOnlyMigrationHint(): void {
+    keychainOnlyMigrationHintEmitted = false;
+  },
+};
 
 export function loadLegacyOAuthSidecarMaterial(params: {
   ref: LegacyOAuthRef;

--- a/src/commands/doctor-auth-oauth-sidecar.test.ts
+++ b/src/commands/doctor-auth-oauth-sidecar.test.ts
@@ -139,7 +139,7 @@ describe("maybeRepairLegacyOAuthSidecarProfiles", () => {
     expect(result.detected).toEqual([authPath]);
     expect(result.warnings).toStrictEqual([]);
     expect(result.changes).toStrictEqual([
-      `Migrated 1 sidecar-backed Codex OAuth profile in ${authPath} to inline credentials (backup: ${authPath}.oauth-ref.123.bak).`,
+      `Migrated 1 legacy Codex OAuth profile in ${authPath} to inline credentials (backup: ${authPath}.oauth-ref.123.bak).`,
     ]);
     expect(fs.existsSync(sidecarPath)).toBe(false);
     expect(JSON.parse(fs.readFileSync(`${authPath}.oauth-ref.123.bak`, "utf8"))).toEqual(auth);
@@ -390,7 +390,7 @@ describe("maybeRepairLegacyOAuthSidecarProfiles", () => {
       expect(result.detected).toEqual([authPath]);
       expect(result.warnings).toStrictEqual([]);
       expect(result.changes).toStrictEqual([
-        `Migrated 1 sidecar-backed Codex OAuth profile in ${authPath} to inline credentials (backup: ${authPath}.oauth-ref.789.bak).`,
+        `Migrated 1 legacy Codex OAuth profile in ${authPath} to inline credentials (backup: ${authPath}.oauth-ref.789.bak).`,
       ]);
       expect(JSON.parse(fs.readFileSync(authPath, "utf8"))).toEqual({
         version: 1,
@@ -462,8 +462,8 @@ describe("maybeRepairLegacyOAuthSidecarProfiles", () => {
     expect(result.detected).toEqual([mainAuthPath, workerAuthPath]);
     expect(result.warnings).toStrictEqual([]);
     expect(result.changes).toEqual([
-      `Migrated 1 sidecar-backed Codex OAuth profile in ${mainAuthPath} to inline credentials (backup: ${mainAuthPath}.oauth-ref.456.bak).`,
-      `Migrated 1 sidecar-backed Codex OAuth profile in ${workerAuthPath} to inline credentials (backup: ${workerAuthPath}.oauth-ref.456.bak).`,
+      `Migrated 1 legacy Codex OAuth profile in ${mainAuthPath} to inline credentials (backup: ${mainAuthPath}.oauth-ref.456.bak).`,
+      `Migrated 1 legacy Codex OAuth profile in ${workerAuthPath} to inline credentials (backup: ${workerAuthPath}.oauth-ref.456.bak).`,
     ]);
     for (const authPath of [mainAuthPath, workerAuthPath]) {
       expect(JSON.parse(fs.readFileSync(authPath, "utf8"))).toEqual({

--- a/src/commands/doctor-auth-oauth-sidecar.ts
+++ b/src/commands/doctor-auth-oauth-sidecar.ts
@@ -222,7 +222,7 @@ export async function maybeRepairLegacyOAuthSidecarProfiles(params: {
       [
         ...stores.map(
           (entry) =>
-            `- ${shortenHomePath(entry.authPath)} has legacy sidecar-backed Codex OAuth profiles.`,
+            `- ${shortenHomePath(entry.authPath)} has legacy Codex OAuth profiles to migrate.`,
         ),
         ...(unreferencedSidecars.length > 0
           ? [
@@ -237,7 +237,7 @@ export async function maybeRepairLegacyOAuthSidecarProfiles(params: {
   }
 
   const shouldRepair = await params.prompter.confirmAutoFix({
-    message: "Migrate legacy sidecar-backed Codex OAuth credentials now?",
+    message: "Migrate legacy Codex OAuth credentials now?",
     initialValue: true,
   });
   if (!shouldRepair) {
@@ -283,7 +283,7 @@ export async function maybeRepairLegacyOAuthSidecarProfiles(params: {
         migratedSidecarsByRefId.set(refId, sidecarPath);
       }
       result.changes.push(
-        `Migrated ${migratedCount} sidecar-backed Codex OAuth profile${migratedCount === 1 ? "" : "s"} in ${shortenHomePath(store.authPath)} to inline credentials (backup: ${shortenHomePath(backupPath)}).`,
+        `Migrated ${migratedCount} legacy Codex OAuth profile${migratedCount === 1 ? "" : "s"} in ${shortenHomePath(store.authPath)} to inline credentials (backup: ${shortenHomePath(backupPath)}).`,
       );
     } catch (err) {
       for (const refId of storeMigratedSidecarsByRefId.keys()) {

--- a/src/commands/doctor/repair-sequencing.test.ts
+++ b/src/commands/doctor/repair-sequencing.test.ts
@@ -359,7 +359,7 @@ describe("doctor repair sequencing", () => {
       events.push("sidecar-oauth");
       return {
         detected: ["auth-profiles.json"],
-        changes: ["Migrated 1 sidecar-backed Codex OAuth profile."],
+        changes: ["Migrated 1 legacy Codex OAuth profile."],
         warnings: ["Sidecar warning"],
       };
     });
@@ -389,7 +389,7 @@ describe("doctor repair sequencing", () => {
       env: process.env,
     });
     expect(result.changeNotes).toEqual([
-      "Migrated 1 sidecar-backed Codex OAuth profile.",
+      "Migrated 1 legacy Codex OAuth profile.",
       "Removed stale OAuth auth profile shadow openai-codex.",
     ]);
     expect(result.warningNotes).toEqual(["Sidecar warning"]);


### PR DESCRIPTION
## Summary

Alternative to #85163 closing the same bucket from #85083 (macOS users whose legacy `oauthRef` sidecar seed lives only in the Keychain), but without an auto-prompt startup hook.

#85163 reuses the existing `maybeRepairLegacyOAuthSidecarProfiles` doctor flow as a pre-command hook in `runCli`, so every non-skipped interactive `openclaw` invocation on darwin can fire a Keychain migration prompt. That works, but trades a wide and growing skip surface (five ClawSweeper rounds, `--non-interactive`/`--yes`/`--no-input`/`--force`/`--json`/`channels remove --delete` and counting) for the auto-heal property — and it violates the AGENTS.md rule:

> Legacy config repair belongs in `openclaw doctor --fix`, not startup/load-time core migrations.

This PR takes the inverse design: keep doctor as the only place that migrates, and make sure affected headless users see a single, actionable error pointing at it instead of a silent fall-through to `No API key found for provider "openai-codex"`.

## Approach

Three concrete pieces, ~40 lines net:

1. **One-shot headless warn in `src/agents/auth-profiles/legacy-oauth-sidecar.ts`** — when `loadLegacyOAuthSidecarMaterial` returns null on darwin with `allowKeychainPrompt: false` (i.e., env/file seeds were tried and Keychain was blocked), emit a single `log.warn` per process naming `openclaw doctor --fix` and macOS Keychain. Rate-limited so embedded turns log it once per gateway lifetime, not per attempt. Guarded by the same VITEST env signals as the keychain read so unrelated test runs don't surface it.
2. **Wording cleanup in `src/commands/doctor-auth-oauth-sidecar.ts`** — drop the user-confusing `sidecar-backed` phrasing from the doctor prompt, notes, and changes (users don't know what a sidecar is); internal identifier names are left intact.
3. **Docs/changelog** — update `docs/gateway/doctor.md` accordion 5 to mention the new headless warning alongside the existing doctor-driven migration; add a single CHANGELOG bullet.

## What this deliberately doesn't do

- **No `runCli` pre-command hook.** No new file in `src/cli/`.
- **No interactive prompt outside `openclaw doctor --fix`.** Users who upgrade into the Keychain-only state see one warning telling them what to run; doctor remains the single place that prompts.
- **No decline marker, no env opt-out (`OPENCLAW_AUTO_MIGRATE_LEGACY_OAUTH_SIDECAR`), no skip ladder.** Nothing to bypass because nothing prompts.
- **No change to `maybeRepairLegacyOAuthSidecarProfiles` semantics.** Doctor still migrates exactly the same way it has since #83312.

## Trade vs. #85163

| | #85163 (auto-prompt hook) | This PR (fail-fast pointer) |
|---|---|---|
| User has to know about `openclaw doctor --fix` | No — prompt fires on next interactive command | Yes — one log line tells them |
| Surface where prompts can appear | Any non-skipped CLI command on darwin | None (only `openclaw doctor --fix`) |
| Skip-rule maintenance | Growing list (`channels remove --delete` was the latest) | None |
| `openclaw status` can surprise-prompt the user | Yes | No |
| Violates `AGENTS.md` "Legacy config repair belongs in doctor" | Yes (intentionally) | No |
| LOC added | +860 / -10 / 10 files | +183 / -10 / 7 files |

The cost of this design is honesty: we tell affected users they have one command to run instead of trying to auto-heal them silently. That cost is bounded — the headless warn is loud, actionable, and survives across restarts; `openclaw doctor --fix` is the one-line remediation. The benefit is the entire ClawSweeper skip-rule treadmill plus the AGENTS.md tension go away.

## Regression tests

- `src/agents/auth-profiles/legacy-oauth-sidecar.test.ts` (new) — exercises the headless warn path: emit once when blocked on darwin with no env/file seeds; never emit on non-darwin; rate-limited per process.

## Verification

- `node scripts/run-vitest.mjs src/agents/auth-profiles/legacy-oauth-sidecar.test.ts src/commands/doctor-auth-oauth-sidecar.test.ts src/commands/doctor/repair-sequencing.test.ts` — 21/21 green (4 files; one is a co-resident sibling).
- `node scripts/run-oxlint.mjs` clean on all touched files; `oxfmt --check` clean.

## Related

- Alternative to #85163
- Closes #85083 (same bucket, different shape)
- Companion to #85074 (file/env-seed bucket) and #85028 (fail-fast on missing refresh token)
- Original surface: #84893 / #84752 / #83312
