### PR TITLE
fix(ui): make local markdown file links inert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI: make Markdown Preview render host-local absolute file links as inert text links instead of misleading same-origin Gateway routes. (#84467)
 - Scripts: use `git grep` to prefilter tracked conflict-marker scans so changed checks avoid reading every repository file on clean runs.
 - Installer: install Node.js through `apk` on Alpine Linux instead of falling through to the NodeSource package-manager path.
 - Installer: detect musl Linux shells such as Alpine as Linux instead of rejecting them before npm install.

--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -537,6 +537,20 @@ describe("toSanitizedMarkdownHtml", () => {
       const html = toSanitizedMarkdownHtml("[click](file:///etc/passwd)");
       expect(html).toBe("<p><a>click</a></p>\n");
     });
+
+    it("strips href from host-local absolute file paths", () => {
+      const html = toSanitizedMarkdownHtml(
+        "[example.docx](/Users/alice/.openclaw/data/plugin/output/example.docx)",
+      );
+      expect(html).toBe("<p><a>example.docx</a></p>\n");
+    });
+
+    it("keeps regular root-relative app links clickable", () => {
+      const html = toSanitizedMarkdownHtml("[session](/chat?session=agent%3Amain)");
+      expect(html).toBe(
+        '<p><a href="/chat?session=agent%3Amain" rel="noreferrer noopener" target="_blank">session</a></p>\n',
+      );
+    });
   });
 
   describe("ReDoS protection", () => {

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -94,6 +94,20 @@ const TAIL_LINK_BLUR_CLASS = "chat-link-tail-blur";
 const CJK_RE =
   /[\u2E80-\u2FFF\u3000-\u303F\u3040-\u309F\u30A0-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uAC00-\uD7AF\uF900-\uFAFF\uFF01-\uFF60]/;
 
+const HOST_LOCAL_FILESYSTEM_HREF_PREFIXES = [
+  "/Users/",
+  "/home/",
+  "/private/",
+  "/tmp/",
+  "/Volumes/",
+  "/var/folders/",
+];
+
+function isHostLocalFilesystemHref(href: string): boolean {
+  const normalized = href.trim();
+  return HOST_LOCAL_FILESYSTEM_HREF_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+}
+
 function getCachedMarkdown(key: string): string | null {
   const cached = markdownCache.get(key);
   if (cached === undefined) {
@@ -127,6 +141,11 @@ function installHooks() {
     }
     const href = node.getAttribute("href");
     if (!href) {
+      return;
+    }
+
+    if (isHostLocalFilesystemHref(href)) {
+      node.removeAttribute("href");
       return;
     }
 


### PR DESCRIPTION
## Summary

- Fixes #84467.
- Makes obvious host-local absolute Markdown hrefs inert before they can be treated as same-origin Gateway routes.
- Keeps normal root-relative Control UI links clickable and covered by regression tests.

## Tests

- `node scripts/run-vitest.mjs ui/src/ui/markdown.test.ts`
- `node scripts/run-vitest.mjs ui/src/ui/chat/grouped-render.test.ts`
- `git diff --check`
- `node --import tsx - <<'EOF' ... EOF`

## Real behavior proof

Behavior addressed: Control UI Markdown rendering no longer turns host-local absolute file paths such as `/Users/alice/.openclaw/data/plugin/output/example.docx` into clickable same-origin Gateway routes, while normal root-relative app links remain clickable.

Real environment tested: Local source checkout on macOS with the repository UI markdown renderer imported through Node/tsx and a JSDOM browser-like `https://127.0.0.1:18789/chat` origin.

Exact steps or command run after this patch: `node --import tsx - <<'EOF'` with JSDOM globals, import `./ui/src/ui/markdown.ts`, render `[example.docx](/Users/alice/.openclaw/data/plugin/output/example.docx)`, and render `[session](/chat?session=agent%3Amain)`.

Evidence after fix: copied terminal console output from the after-fix renderer run:

```text
<p><a>example.docx</a></p>
<p><a href="/chat?session=agent%3Amain" rel="noreferrer noopener" target="_blank">session</a></p>
```

Observed result after fix: The `/Users/...` link text remains visible but has no `href`, so clicking it cannot navigate to a misleading Gateway route; `/chat?session=...` retains its href.

What was not tested: I did not run a live browser click against a running Gateway; the renderer behavior was verified directly in the same sanitizer code path used by Markdown Preview.
