### PR TITLE
[AI-assisted] fix(agents): resolve CLI runtime in preflight + memory-flush gates

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -2186,6 +2186,116 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
   });
 
+  it("does not skip memory flush when authProfileId pins to a direct-API profile despite CLI in auth order", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 80_000,
+      compactionCount: 1,
+    };
+
+    await runMemoryFlushIfNeeded({
+      cfg: {
+        agents: {
+          defaults: {
+            cliBackends: { "claude-cli": { command: "claude" } },
+            compaction: { memoryFlush: {} },
+          },
+        },
+        auth: {
+          profiles: {
+            "direct-api": { provider: "anthropic" },
+            "cli-profile": { provider: "claude-cli" },
+          },
+          order: {
+            anthropic: ["cli-profile", "direct-api"],
+          },
+        },
+      } as never,
+      followupRun: createTestFollowupRun({
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+        authProfileId: "direct-api",
+      }),
+      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      defaultModel: "anthropic/claude-opus-4-7",
+      agentCfgContextTokens: 100_000,
+      resolvedVerboseLevel: "off",
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    // With authProfileId pointing to direct-api (provider: "anthropic"), the
+    // resolver should NOT treat this as CLI — so memory flush proceeds.
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not skip preflight compaction when authProfileId pins to a direct-API profile despite CLI in auth order", async () => {
+    const sessionFile = path.join(rootDir, "direct-api-preflight.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
+      "utf8",
+    );
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 1,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 0,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokensFresh: false,
+    };
+
+    await runPreflightCompactionIfNeeded({
+      cfg: {
+        agents: {
+          defaults: {
+            cliBackends: { "claude-cli": { command: "claude" } },
+            compaction: { memoryFlush: {} },
+          },
+        },
+        auth: {
+          profiles: {
+            "direct-api": { provider: "anthropic" },
+            "cli-profile": { provider: "claude-cli" },
+          },
+          order: {
+            anthropic: ["cli-profile", "direct-api"],
+          },
+        },
+      } as never,
+      followupRun: createTestFollowupRun({
+        sessionId: "session",
+        sessionFile,
+        sessionKey: "main",
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+        authProfileId: "direct-api",
+      }),
+      defaultModel: "anthropic/claude-opus-4-7",
+      agentCfgContextTokens: 100,
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    // With authProfileId pointing to direct-api (provider: "anthropic"), the
+    // resolver should NOT treat this as CLI — so preflight compaction proceeds.
+    expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
+  });
+
   it("uses configured prompts and stored bootstrap warning signatures", async () => {
     const sessionEntry: SessionEntry = {
       sessionId: "session",

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -2446,6 +2446,99 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
   });
 
+  it("runs memory flush when a stale claude-cli override is incompatible with the active provider", async () => {
+    // claude-cli is registered only for anthropic (see beforeEach). A session
+    // carrying agentRuntimeOverride="claude-cli" on an openai turn is stale:
+    // dispatch resolves it embedded, so the gate must NOT skip the flush.
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 80_000,
+      compactionCount: 1,
+      agentRuntimeOverride: "claude-cli",
+    };
+
+    await runMemoryFlushIfNeeded({
+      cfg: {
+        agents: {
+          defaults: {
+            cliBackends: { "claude-cli": { command: "claude" } },
+            compaction: { memoryFlush: {} },
+          },
+        },
+      } as never,
+      followupRun: createTestFollowupRun({
+        provider: "openai",
+        model: "gpt-5.5",
+      }),
+      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      defaultModel: "openai/gpt-5.5",
+      agentCfgContextTokens: 100_000,
+      resolvedVerboseLevel: "off",
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs preflight compaction when a stale claude-cli override is incompatible with the active provider", async () => {
+    // Mismatched CLI override on an openai turn dispatches embedded, so the
+    // preflight gate must compact instead of trusting the stale CLI pin.
+    const sessionFile = path.join(rootDir, "cli-override-mismatch-preflight.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
+      "utf8",
+    );
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 1,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 0,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokensFresh: false,
+      agentRuntimeOverride: "claude-cli",
+    };
+
+    await runPreflightCompactionIfNeeded({
+      cfg: {
+        agents: {
+          defaults: {
+            cliBackends: { "claude-cli": { command: "claude" } },
+            compaction: { memoryFlush: {} },
+          },
+        },
+      } as never,
+      followupRun: createTestFollowupRun({
+        sessionId: "session",
+        sessionFile,
+        sessionKey: "main",
+        provider: "openai",
+        model: "gpt-5.5",
+      }),
+      defaultModel: "openai/gpt-5.5",
+      agentCfgContextTokens: 100,
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
+  });
+
   it("runs memory flush when agentRuntimeOverride is 'pi' even though auth.order prefers a CLI profile", async () => {
     const sessionEntry: SessionEntry = {
       sessionId: "session",

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -2355,4 +2355,141 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(flushCall.bootstrapPromptWarningSignaturesSeen).toEqual(["sig-a", "sig-b"]);
     expect(flushCall.bootstrapPromptWarningSignature).toBe("sig-b");
   });
+
+  it("skips memory flush when agentRuntimeOverride pins the session to claude-cli", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 80_000,
+      compactionCount: 1,
+      agentRuntimeOverride: "claude-cli",
+    };
+
+    const entry = await runMemoryFlushIfNeeded({
+      cfg: {
+        agents: {
+          defaults: {
+            cliBackends: { "claude-cli": { command: "claude" } },
+            compaction: { memoryFlush: {} },
+          },
+        },
+      } as never,
+      followupRun: createTestFollowupRun({
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+      }),
+      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      defaultModel: "anthropic/claude-opus-4-7",
+      agentCfgContextTokens: 100_000,
+      resolvedVerboseLevel: "off",
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(entry).toBe(sessionEntry);
+    expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("skips preflight compaction when agentRuntimeOverride pins the session to claude-cli", async () => {
+    const sessionFile = path.join(rootDir, "cli-override-preflight.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
+      "utf8",
+    );
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 1,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 0,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokensFresh: false,
+      agentRuntimeOverride: "claude-cli",
+    };
+
+    const entry = await runPreflightCompactionIfNeeded({
+      cfg: {
+        agents: {
+          defaults: {
+            cliBackends: { "claude-cli": { command: "claude" } },
+            compaction: { memoryFlush: {} },
+          },
+        },
+      } as never,
+      followupRun: createTestFollowupRun({
+        sessionId: "session",
+        sessionFile,
+        sessionKey: "main",
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+      }),
+      defaultModel: "anthropic/claude-opus-4-7",
+      agentCfgContextTokens: 100,
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(entry).toBe(sessionEntry);
+    expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("runs memory flush when agentRuntimeOverride is 'pi' even though auth.order prefers a CLI profile", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 80_000,
+      compactionCount: 1,
+      agentRuntimeOverride: "pi",
+    };
+
+    await runMemoryFlushIfNeeded({
+      cfg: {
+        agents: {
+          defaults: {
+            cliBackends: { "claude-cli": { command: "claude" } },
+            compaction: { memoryFlush: {} },
+          },
+        },
+        auth: {
+          profiles: {
+            "direct-api": { provider: "anthropic" },
+            "cli-profile": { provider: "claude-cli" },
+          },
+          order: {
+            anthropic: ["cli-profile", "direct-api"],
+          },
+        },
+      } as never,
+      followupRun: createTestFollowupRun({
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+      }),
+      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      defaultModel: "anthropic/claude-opus-4-7",
+      agentCfgContextTokens: 100_000,
+      resolvedVerboseLevel: "off",
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    // agentRuntimeOverride: "pi" forces canonical-provider routing, so the
+    // CLI gate should NOT fire even when auth.order prefers a CLI profile.
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -2539,7 +2539,7 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
   });
 
-  it("runs memory flush when agentRuntimeOverride is 'pi' even though auth.order prefers a CLI profile", async () => {
+  it("skips memory flush when agentRuntimeOverride is 'pi' and auth.order routes the provider to a CLI profile (matches dispatch)", async () => {
     const sessionEntry: SessionEntry = {
       sessionId: "session",
       updatedAt: Date.now(),
@@ -2581,8 +2581,49 @@ describe("runMemoryFlushIfNeeded", () => {
       replyOperation: createReplyOperation(),
     });
 
-    // agentRuntimeOverride: "pi" forces canonical-provider routing, so the
-    // CLI gate should NOT fire even when auth.order prefers a CLI profile.
+    // The gate mirrors dispatch's config-driven CLI routing: a "pi" override is
+    // not special-cased, so when auth.order routes anthropic to a CLI profile
+    // (claude-cli), dispatch runs CLI and the gate skips embedded flush too.
+    expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("runs memory flush when agentRuntimeOverride is 'pi' but no model/auth policy routes the provider to a CLI runtime", async () => {
+    // Inverse of the CLI-routed case: a "pi" override on a provider with no CLI
+    // route (claude-cli is bound to anthropic, not openai; no auth.order CLI
+    // profile) dispatches embedded, so the gate must run embedded flush too.
+    // Proves the gate and dispatch agree in both directions.
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 80_000,
+      compactionCount: 1,
+      agentRuntimeOverride: "pi",
+    };
+
+    await runMemoryFlushIfNeeded({
+      cfg: {
+        agents: {
+          defaults: {
+            cliBackends: { "claude-cli": { command: "claude" } },
+            compaction: { memoryFlush: {} },
+          },
+        },
+      } as never,
+      followupRun: createTestFollowupRun({
+        provider: "openai",
+        model: "gpt-5.5",
+      }),
+      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      defaultModel: "openai/gpt-5.5",
+      agentCfgContextTokens: 100_000,
+      resolvedVerboseLevel: "off",
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
     expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { testing as cliBackendsTesting } from "../../agents/cli-backends.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { readSessionStoreForTest } from "../../config/sessions/test-helpers.js";
 import {
@@ -157,6 +158,28 @@ describe("runMemoryFlushIfNeeded", () => {
   let rootDir = "";
 
   beforeEach(async () => {
+    // Register claude-cli as a runtime CLI backend bound to anthropic so that
+    // resolveCliRuntimeExecutionProvider can map provider="anthropic" +
+    // runtime="claude-cli" to a CLI execution provider. Without this, the
+    // dynamic backend registry (post bb46b79d3c) is empty in tests and the
+    // CLI-runtime gates can't fire.
+    cliBackendsTesting.setDepsForTest({
+      resolvePluginSetupRegistry: () => ({
+        providers: [],
+        cliBackends: [],
+        configMigrations: [],
+        autoEnableProbes: [],
+        diagnostics: [],
+      }),
+      resolveRuntimeCliBackends: () => [
+        {
+          id: "claude-cli",
+          modelProvider: "anthropic",
+          pluginId: "anthropic",
+          config: { command: "claude" },
+        },
+      ],
+    });
     rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-unit-"));
     registerMemoryFlushPlanResolverForTest(() => ({
       softThresholdTokens: 4_000,
@@ -228,6 +251,7 @@ describe("runMemoryFlushIfNeeded", () => {
   afterEach(async () => {
     setAgentRunnerMemoryTestDeps();
     clearMemoryPluginState();
+    cliBackendsTesting.resetDepsForTest();
     await fs.rm(rootDir, { recursive: true, force: true });
   });
 
@@ -913,6 +937,49 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
   });
 
+  it("skips memory flush when the canonical provider is routed through a CLI runtime", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 80_000,
+      compactionCount: 1,
+    };
+
+    const entry = await runMemoryFlushIfNeeded({
+      cfg: {
+        agents: {
+          defaults: {
+            cliBackends: { "claude-cli": { command: "claude" } },
+            compaction: { memoryFlush: {} },
+          },
+        },
+        models: {
+          providers: {
+            anthropic: {
+              agentRuntime: { id: "claude-cli" },
+            },
+          },
+        },
+      } as never,
+      followupRun: createTestFollowupRun({
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+      }),
+      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      defaultModel: "anthropic/claude-opus-4-7",
+      agentCfgContextTokens: 100_000,
+      resolvedVerboseLevel: "off",
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(entry).toBe(sessionEntry);
+    expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
+  });
+
   it("uses runtime policy session key when checking memory-flush sandbox writability", async () => {
     const sessionEntry: SessionEntry = {
       sessionId: "session",
@@ -1314,6 +1381,66 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactCall.authProfileId).toBe("anthropic:claude@martian.engineering");
     expect(compactCall.contextTokenBudget).toBe(258_000);
   });
+
+  it("skips preflight compaction when the canonical provider is routed through a CLI runtime", async () => {
+    const sessionFile = path.join(rootDir, "cli-runtime-preflight.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
+      "utf8",
+    );
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 1,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 0,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokensFresh: false,
+    };
+
+    const entry = await runPreflightCompactionIfNeeded({
+      cfg: {
+        agents: {
+          defaults: {
+            cliBackends: { "claude-cli": { command: "claude" } },
+            compaction: { memoryFlush: {} },
+          },
+        },
+        models: {
+          providers: {
+            anthropic: {
+              agentRuntime: { id: "claude-cli" },
+            },
+          },
+        },
+      } as never,
+      followupRun: createTestFollowupRun({
+        sessionId: "session",
+        sessionFile,
+        sessionKey: "main",
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+      }),
+      defaultModel: "anthropic/claude-opus-4-7",
+      agentCfgContextTokens: 100,
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(entry).toBe(sessionEntry);
+    expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
+  });
+
   it("updates the active preflight run after transcript rotation", async () => {
     const sessionFile = path.join(rootDir, "session.jsonl");
     const successorFile = path.join(rootDir, "session-rotated.jsonl");

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -44,6 +44,7 @@ import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import type { TemplateContext } from "../templating.js";
 import type { VerboseLevel } from "../thinking.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import { resolveRunAuthProfile } from "./agent-runner-auth-profile.js";
 import {
   buildEmbeddedRunExecutionParams,
   resolveModelFallbackOptions,
@@ -708,12 +709,17 @@ export async function runPreflightCompactionIfNeeded(params: {
     return entry ?? params.sessionEntry;
   }
 
+  const { authProfileId } = resolveRunAuthProfile(
+    params.followupRun.run,
+    params.followupRun.run.provider,
+  );
   const cliExecutionProvider =
     resolveCliRuntimeExecutionProvider({
       provider: params.followupRun.run.provider,
       cfg: params.cfg,
       agentId: params.followupRun.run.agentId,
       modelId: params.followupRun.run.model ?? params.defaultModel,
+      authProfileId,
     }) ?? params.followupRun.run.provider;
   const isCli = isCliProvider(cliExecutionProvider, params.cfg);
   if (params.isHeartbeat || isCli) {
@@ -1002,12 +1008,17 @@ export async function runMemoryFlushIfNeeded(params: {
     return sandboxCfg.workspaceAccess === "rw";
   })();
 
+  const { authProfileId: flushAuthProfileId } = resolveRunAuthProfile(
+    params.followupRun.run,
+    params.followupRun.run.provider,
+  );
   const cliExecutionProvider =
     resolveCliRuntimeExecutionProvider({
       provider: params.followupRun.run.provider,
       cfg: params.cfg,
       agentId: params.followupRun.run.agentId,
       modelId: params.followupRun.run.model ?? params.defaultModel,
+      authProfileId: flushAuthProfileId,
     }) ?? params.followupRun.run.provider;
   const isCli = isCliProvider(cliExecutionProvider, params.cfg);
   const canAttemptFlush = memoryFlushWritable && !params.isHeartbeat && !isCli;

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -12,6 +12,7 @@ import { classifyCompactionReason } from "../../agents/embedded-agent-runner/com
 import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
 import { ensureSelectedAgentHarnessPlugin } from "../../agents/harness/runtime-plugin.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
+import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import { resolveContextConfigProviderForRuntime } from "../../agents/openai-routing.js";
 import type { AgentMessage } from "../../agents/runtime/index.js";
@@ -707,7 +708,14 @@ export async function runPreflightCompactionIfNeeded(params: {
     return entry ?? params.sessionEntry;
   }
 
-  const isCli = isCliProvider(params.followupRun.run.provider, params.cfg);
+  const cliExecutionProvider =
+    resolveCliRuntimeExecutionProvider({
+      provider: params.followupRun.run.provider,
+      cfg: params.cfg,
+      agentId: params.followupRun.run.agentId,
+      modelId: params.followupRun.run.model ?? params.defaultModel,
+    }) ?? params.followupRun.run.provider;
+  const isCli = isCliProvider(cliExecutionProvider, params.cfg);
   if (params.isHeartbeat || isCli) {
     return entry ?? params.sessionEntry;
   }
@@ -994,7 +1002,14 @@ export async function runMemoryFlushIfNeeded(params: {
     return sandboxCfg.workspaceAccess === "rw";
   })();
 
-  const isCli = isCliProvider(params.followupRun.run.provider, params.cfg);
+  const cliExecutionProvider =
+    resolveCliRuntimeExecutionProvider({
+      provider: params.followupRun.run.provider,
+      cfg: params.cfg,
+      agentId: params.followupRun.run.agentId,
+      modelId: params.followupRun.run.model ?? params.defaultModel,
+    }) ?? params.followupRun.run.provider;
+  const isCli = isCliProvider(cliExecutionProvider, params.cfg);
   const canAttemptFlush = memoryFlushWritable && !params.isHeartbeat && !isCli;
   let entry =
     params.sessionEntry ??

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -714,36 +714,36 @@ export async function runPreflightCompactionIfNeeded(params: {
     params.followupRun.run,
     params.followupRun.run.provider,
   );
-  // Three-tier runtime resolution mirroring runReplyAgent's dispatch path
-  // (agent-runner-execution.ts:2056, followup-runner.ts:726):
-  //   1. agentRuntimeOverride === "pi" forces canonical-provider routing,
-  //      so the gate does NOT short-circuit (preflight runs).
-  //   2. resolveSessionRuntimeOverrideForProvider honors a persisted runtime
+  // Resolve the effective CLI runtime exactly as runReplyAgent's dispatch path
+  // does (agent-runner-execution.ts:2056, followup-runner.ts:726), so the gate
+  // skips embedded compaction only when dispatch would route to a CLI runtime:
+  //   1. resolveSessionRuntimeOverrideForProvider honors a persisted runtime
   //      override only when it is provider-compatible (a CLI backend bound to
   //      the active provider, or codex/openclaw). A stale/mismatched CLI
   //      override returns undefined so we fall through, not skip.
-  //   3. Fall through to the auth-profile-aware resolver, which inspects
+  //   2. Fall through to the auth-profile-aware resolver, which inspects
   //      models.providers.<provider>.agentRuntime and auth-order routing.
-  // Honoring a stale CLI override here would skip embedded compaction on a
-  // turn that dispatch actually runs embedded.
+  // A "pi"/openclaw override is not special-cased here because dispatch does not
+  // special-case it either: it falls through to the same config-driven
+  // resolution, which yields an embedded run for canonical configs and a CLI run
+  // for CLI-routed configs. Honoring a stale CLI override here would skip
+  // embedded compaction on a turn that dispatch actually runs embedded.
   const sessionRuntimeOverride = resolveSessionRuntimeOverrideForProvider({
     provider: params.followupRun.run.provider,
     entry,
   });
   const cliExecutionProvider =
-    normalizeLowercaseStringOrEmpty(entry.agentRuntimeOverride) === "pi"
-      ? params.followupRun.run.provider
-      : ((sessionRuntimeOverride && isCliProvider(sessionRuntimeOverride, params.cfg)
-          ? sessionRuntimeOverride
-          : undefined) ??
-        resolveCliRuntimeExecutionProvider({
-          provider: params.followupRun.run.provider,
-          cfg: params.cfg,
-          agentId: params.followupRun.run.agentId,
-          modelId: params.followupRun.run.model ?? params.defaultModel,
-          authProfileId,
-        }) ??
-        params.followupRun.run.provider);
+    (sessionRuntimeOverride && isCliProvider(sessionRuntimeOverride, params.cfg)
+      ? sessionRuntimeOverride
+      : undefined) ??
+    resolveCliRuntimeExecutionProvider({
+      provider: params.followupRun.run.provider,
+      cfg: params.cfg,
+      agentId: params.followupRun.run.agentId,
+      modelId: params.followupRun.run.model ?? params.defaultModel,
+      authProfileId,
+    }) ??
+    params.followupRun.run.provider;
   const isCli = isCliProvider(cliExecutionProvider, params.cfg);
   if (params.isHeartbeat || isCli) {
     return entry ?? params.sessionEntry;
@@ -1038,36 +1038,36 @@ export async function runMemoryFlushIfNeeded(params: {
     params.followupRun.run,
     params.followupRun.run.provider,
   );
-  // Three-tier runtime resolution mirroring runReplyAgent's dispatch path
-  // (agent-runner-execution.ts:2056, followup-runner.ts:726):
-  //   1. agentRuntimeOverride === "pi" forces canonical-provider routing,
-  //      so the gate does NOT short-circuit (memory flush runs).
-  //   2. resolveSessionRuntimeOverrideForProvider honors a persisted runtime
+  // Resolve the effective CLI runtime exactly as runReplyAgent's dispatch path
+  // does (agent-runner-execution.ts:2056, followup-runner.ts:726), so the gate
+  // skips embedded flush only when dispatch would route to a CLI runtime:
+  //   1. resolveSessionRuntimeOverrideForProvider honors a persisted runtime
   //      override only when it is provider-compatible (a CLI backend bound to
   //      the active provider, or codex/openclaw). A stale/mismatched CLI
   //      override returns undefined so we fall through, not skip.
-  //   3. Fall through to the auth-profile-aware resolver, which inspects
+  //   2. Fall through to the auth-profile-aware resolver, which inspects
   //      models.providers.<provider>.agentRuntime and auth-order routing.
-  // Honoring a stale CLI override here would skip embedded flush on a turn
-  // that dispatch actually runs embedded.
+  // A "pi"/openclaw override is not special-cased here because dispatch does not
+  // special-case it either: it falls through to the same config-driven
+  // resolution, which yields an embedded run for canonical configs and a CLI run
+  // for CLI-routed configs. Honoring a stale CLI override here would skip
+  // embedded flush on a turn that dispatch actually runs embedded.
   const sessionRuntimeOverride = resolveSessionRuntimeOverrideForProvider({
     provider: params.followupRun.run.provider,
     entry,
   });
   const cliExecutionProvider =
-    normalizeLowercaseStringOrEmpty(entry?.agentRuntimeOverride) === "pi"
-      ? params.followupRun.run.provider
-      : ((sessionRuntimeOverride && isCliProvider(sessionRuntimeOverride, params.cfg)
-          ? sessionRuntimeOverride
-          : undefined) ??
-        resolveCliRuntimeExecutionProvider({
-          provider: params.followupRun.run.provider,
-          cfg: params.cfg,
-          agentId: params.followupRun.run.agentId,
-          modelId: params.followupRun.run.model ?? params.defaultModel,
-          authProfileId: flushAuthProfileId,
-        }) ??
-        params.followupRun.run.provider);
+    (sessionRuntimeOverride && isCliProvider(sessionRuntimeOverride, params.cfg)
+      ? sessionRuntimeOverride
+      : undefined) ??
+    resolveCliRuntimeExecutionProvider({
+      provider: params.followupRun.run.provider,
+      cfg: params.cfg,
+      agentId: params.followupRun.run.agentId,
+      modelId: params.followupRun.run.model ?? params.defaultModel,
+      authProfileId: flushAuthProfileId,
+    }) ??
+    params.followupRun.run.provider;
   const isCli = isCliProvider(cliExecutionProvider, params.cfg);
   const canAttemptFlush = memoryFlushWritable && !params.isHeartbeat && !isCli;
   const contextWindowTokens = resolveMemoryFlushContextWindowTokens({

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -713,14 +713,28 @@ export async function runPreflightCompactionIfNeeded(params: {
     params.followupRun.run,
     params.followupRun.run.provider,
   );
+  // Three-tier runtime resolution mirroring runReplyAgent's dispatch path:
+  //   1. agentRuntimeOverride === "pi" forces canonical-provider routing,
+  //      so the gate does NOT short-circuit (preflight runs).
+  //   2. agentRuntimeOverride that is itself a CLI provider for the cfg
+  //      pins the session to that CLI runtime — short-circuit applies.
+  //   3. Fall through to the auth-profile-aware resolver, which inspects
+  //      models.providers.<provider>.agentRuntime and auth-order routing.
+  const sessionRuntimeOverride = normalizeLowercaseStringOrEmpty(entry.agentRuntimeOverride);
   const cliExecutionProvider =
-    resolveCliRuntimeExecutionProvider({
-      provider: params.followupRun.run.provider,
-      cfg: params.cfg,
-      agentId: params.followupRun.run.agentId,
-      modelId: params.followupRun.run.model ?? params.defaultModel,
-      authProfileId,
-    }) ?? params.followupRun.run.provider;
+    sessionRuntimeOverride === "pi"
+      ? params.followupRun.run.provider
+      : ((sessionRuntimeOverride && isCliProvider(sessionRuntimeOverride, params.cfg)
+          ? sessionRuntimeOverride
+          : undefined) ??
+        resolveCliRuntimeExecutionProvider({
+          provider: params.followupRun.run.provider,
+          cfg: params.cfg,
+          agentId: params.followupRun.run.agentId,
+          modelId: params.followupRun.run.model ?? params.defaultModel,
+          authProfileId,
+        }) ??
+        params.followupRun.run.provider);
   const isCli = isCliProvider(cliExecutionProvider, params.cfg);
   if (params.isHeartbeat || isCli) {
     return entry ?? params.sessionEntry;
@@ -1008,23 +1022,37 @@ export async function runMemoryFlushIfNeeded(params: {
     return sandboxCfg.workspaceAccess === "rw";
   })();
 
+  let entry =
+    params.sessionEntry ??
+    (params.sessionKey ? params.sessionStore?.[params.sessionKey] : undefined);
   const { authProfileId: flushAuthProfileId } = resolveRunAuthProfile(
     params.followupRun.run,
     params.followupRun.run.provider,
   );
+  // Three-tier runtime resolution mirroring runReplyAgent's dispatch path:
+  //   1. agentRuntimeOverride === "pi" forces canonical-provider routing,
+  //      so the gate does NOT short-circuit (memory flush runs).
+  //   2. agentRuntimeOverride that is itself a CLI provider for the cfg
+  //      pins the session to that CLI runtime — short-circuit applies.
+  //   3. Fall through to the auth-profile-aware resolver, which inspects
+  //      models.providers.<provider>.agentRuntime and auth-order routing.
+  const sessionRuntimeOverride = normalizeLowercaseStringOrEmpty(entry?.agentRuntimeOverride);
   const cliExecutionProvider =
-    resolveCliRuntimeExecutionProvider({
-      provider: params.followupRun.run.provider,
-      cfg: params.cfg,
-      agentId: params.followupRun.run.agentId,
-      modelId: params.followupRun.run.model ?? params.defaultModel,
-      authProfileId: flushAuthProfileId,
-    }) ?? params.followupRun.run.provider;
+    sessionRuntimeOverride === "pi"
+      ? params.followupRun.run.provider
+      : ((sessionRuntimeOverride && isCliProvider(sessionRuntimeOverride, params.cfg)
+          ? sessionRuntimeOverride
+          : undefined) ??
+        resolveCliRuntimeExecutionProvider({
+          provider: params.followupRun.run.provider,
+          cfg: params.cfg,
+          agentId: params.followupRun.run.agentId,
+          modelId: params.followupRun.run.model ?? params.defaultModel,
+          authProfileId: flushAuthProfileId,
+        }) ??
+        params.followupRun.run.provider);
   const isCli = isCliProvider(cliExecutionProvider, params.cfg);
   const canAttemptFlush = memoryFlushWritable && !params.isHeartbeat && !isCli;
-  let entry =
-    params.sessionEntry ??
-    (params.sessionKey ? params.sessionStore?.[params.sessionKey] : undefined);
   const contextWindowTokens = resolveMemoryFlushContextWindowTokens({
     cfg: params.cfg,
     provider: resolveFollowupContextConfigProvider({

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -17,6 +17,7 @@ import { isCliProvider } from "../../agents/model-selection.js";
 import { resolveContextConfigProviderForRuntime } from "../../agents/openai-routing.js";
 import type { AgentMessage } from "../../agents/runtime/index.js";
 import { resolveSandboxConfigForAgent, resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
+import { resolveSessionRuntimeOverrideForProvider } from "../../agents/session-runtime-compat.js";
 import {
   derivePromptTokens,
   hasNonzeroUsage,
@@ -713,16 +714,24 @@ export async function runPreflightCompactionIfNeeded(params: {
     params.followupRun.run,
     params.followupRun.run.provider,
   );
-  // Three-tier runtime resolution mirroring runReplyAgent's dispatch path:
+  // Three-tier runtime resolution mirroring runReplyAgent's dispatch path
+  // (agent-runner-execution.ts:2056, followup-runner.ts:726):
   //   1. agentRuntimeOverride === "pi" forces canonical-provider routing,
   //      so the gate does NOT short-circuit (preflight runs).
-  //   2. agentRuntimeOverride that is itself a CLI provider for the cfg
-  //      pins the session to that CLI runtime — short-circuit applies.
+  //   2. resolveSessionRuntimeOverrideForProvider honors a persisted runtime
+  //      override only when it is provider-compatible (a CLI backend bound to
+  //      the active provider, or codex/openclaw). A stale/mismatched CLI
+  //      override returns undefined so we fall through, not skip.
   //   3. Fall through to the auth-profile-aware resolver, which inspects
   //      models.providers.<provider>.agentRuntime and auth-order routing.
-  const sessionRuntimeOverride = normalizeLowercaseStringOrEmpty(entry.agentRuntimeOverride);
+  // Honoring a stale CLI override here would skip embedded compaction on a
+  // turn that dispatch actually runs embedded.
+  const sessionRuntimeOverride = resolveSessionRuntimeOverrideForProvider({
+    provider: params.followupRun.run.provider,
+    entry,
+  });
   const cliExecutionProvider =
-    sessionRuntimeOverride === "pi"
+    normalizeLowercaseStringOrEmpty(entry.agentRuntimeOverride) === "pi"
       ? params.followupRun.run.provider
       : ((sessionRuntimeOverride && isCliProvider(sessionRuntimeOverride, params.cfg)
           ? sessionRuntimeOverride
@@ -1029,16 +1038,24 @@ export async function runMemoryFlushIfNeeded(params: {
     params.followupRun.run,
     params.followupRun.run.provider,
   );
-  // Three-tier runtime resolution mirroring runReplyAgent's dispatch path:
+  // Three-tier runtime resolution mirroring runReplyAgent's dispatch path
+  // (agent-runner-execution.ts:2056, followup-runner.ts:726):
   //   1. agentRuntimeOverride === "pi" forces canonical-provider routing,
   //      so the gate does NOT short-circuit (memory flush runs).
-  //   2. agentRuntimeOverride that is itself a CLI provider for the cfg
-  //      pins the session to that CLI runtime — short-circuit applies.
+  //   2. resolveSessionRuntimeOverrideForProvider honors a persisted runtime
+  //      override only when it is provider-compatible (a CLI backend bound to
+  //      the active provider, or codex/openclaw). A stale/mismatched CLI
+  //      override returns undefined so we fall through, not skip.
   //   3. Fall through to the auth-profile-aware resolver, which inspects
   //      models.providers.<provider>.agentRuntime and auth-order routing.
-  const sessionRuntimeOverride = normalizeLowercaseStringOrEmpty(entry?.agentRuntimeOverride);
+  // Honoring a stale CLI override here would skip embedded flush on a turn
+  // that dispatch actually runs embedded.
+  const sessionRuntimeOverride = resolveSessionRuntimeOverrideForProvider({
+    provider: params.followupRun.run.provider,
+    entry,
+  });
   const cliExecutionProvider =
-    sessionRuntimeOverride === "pi"
+    normalizeLowercaseStringOrEmpty(entry?.agentRuntimeOverride) === "pi"
       ? params.followupRun.run.provider
       : ((sessionRuntimeOverride && isCliProvider(sessionRuntimeOverride, params.cfg)
           ? sessionRuntimeOverride


### PR DESCRIPTION
## Summary

`runPreflightCompactionIfNeeded` and `runMemoryFlushIfNeeded` in `src/auto-reply/reply/agent-runner-memory.ts` gate on `isCliProvider(params.followupRun.run.provider, params.cfg)`. `isCliProvider` only returns true when the passed provider id is itself a key in `agents.defaults.cliBackends`. For an agent configured with a primary model on a canonical provider (e.g. `anthropic/claude-opus-4-7`) that resolves through a CLI runtime via `models.providers.<provider>.agentRuntime.id` (or per-agent / per-model `agentRuntime` policy), the gate evaluates `isCli=false` and preflight runs as if the agent were embedded — even though the conversation transcript and tokens live in the CLI runtime's own session, not in the OC transcript file.

This PR mirrors the resolution shape already used by the runtime dispatch path: resolve the CLI execution provider via `resolveCliRuntimeExecutionProvider` first, then ask `isCliProvider` about the resolved id. The two preflight/flush gates predate that resolve and were never updated.

## Existing pattern

`src/auto-reply/reply/agent-runner-execution.ts` resolves the CLI execution provider before gating on `isCliProvider`:

```ts
const cliExecutionProvider =
  resolveCliRuntimeExecutionProvider({
    provider,
    cfg: runtimeConfig,
    agentId: params.followupRun.run.agentId,
    modelId: model,
  }) ?? provider;

if (isCliProvider(cliExecutionProvider, runtimeConfig)) {
  // ... CLI dispatch path
}
```

The fix in this PR uses the same shape at both `agent-runner-memory.ts` call sites.

## Reproduction context

A long-lived agent routed through a CLI runtime via `agentRuntime.id` accumulates context inside the CLI's own session. The model reports a large `promptTokens` to OC, which OC stores as `entry.totalTokens`. Once that crosses the preflight threshold (`contextWindow - reserveTokensFloor - softThresholdTokens`), preflight fires and tries to compact the OC-side transcript file. For agents whose real conversation lives outside the OC transcript file (the CLI runtime's own session), OC's transcript file only contains delivery-mirror records, and the compaction safeguard's `containsRealConversationMessages` filter strips those, returning `compacted:false reason:"no real conversation messages"`. Preflight then throws `Preflight compaction required but failed: no real conversation messages`, surfacing as a generic dispatch error.

The runtime dispatch path doesn't hit this because it had already been migrated to `resolveCliRuntimeExecutionProvider`. The preflight + flush gates had not.

## Verification

- `pnpm tsgo:core` and `pnpm tsgo:core:test` green.
- `pnpm exec vitest run src/auto-reply/reply/agent-runner-memory.test.ts`: 26 passed (existing 24 + 2 new). Both new tests fail without the source fix and pass with it.
- `pnpm exec oxfmt --check` clean on both touched files.

The two new tests configure `agents.defaults.cliBackends["claude-cli"]` plus `models.providers.anthropic.agentRuntime.id = "claude-cli"` and assert that a `followupRun` with `provider="anthropic"` short-circuits both `runMemoryFlushIfNeeded` (returns the entry without invoking `runEmbeddedPiAgent`) and `runPreflightCompactionIfNeeded` (returns the entry without invoking `compactEmbeddedPiSession`).

## Real behavior proof

**Behavior addressed:** Telegram dispatch on a long-lived claude-cli-routed Anthropic agent surfaced "Something went wrong while processing your request." The underlying error in the gateway log was `Preflight compaction required but failed: no real conversation messages`. Root cause: `runPreflightCompactionIfNeeded` evaluated `isCliProvider("anthropic", cfg)` (false because cliBackends keys on `claude-cli`, not `anthropic`), so preflight ran on agents whose real conversation lives in claude-cli's session JSONL — not in OC's transcript file (which holds only delivery-mirror records for that surface). The compactor's `containsRealConversationMessages` filter then strips delivery-mirror records and returns `compacted:false`, so preflight throws.

**Real environment tested:** A live OpenClaw stack on macOS 14 with three claude-cli-routed Anthropic agents wired to Telegram. Anthropic configured as primary; routes through `auth.profiles["anthropic:claude-cli"]` so dispatch resolves to the claude-cli runtime. Six historical failures observed today across one of the three agents over ~2h before manual recovery (delete the broken session-store binding + archive the all-delivery-mirror transcript file).

**Exact steps or command run after this patch:**

1. Patched `~/.local/bin/openclaw-cli-runtime-preflight-gate-patch.py` applied to the brew-installed OC dist (mirrors this PR's source change exactly — same anchored swap of `isCliProvider(params.followupRun.run.provider, ...)` for resolve-then-isCli).
2. Restarted the gateway: `openclaw gateway restart --safe`.
3. Enabled debug logging via `OPENCLAW_LOG_LEVEL=debug` so the `preflightCompaction check` / `memoryFlush check` verbose lines emit.
4. Sent one Telegram inbound to a claude-cli-routed agent on the same session-key shape that previously failed.
5. Sent one Telegram inbound to a different claude-cli-routed agent for cross-agent confirmation.
6. Inspected the gateway log for the verbose `isCli=` value at both gates.
7. Reverted `OPENCLAW_LOG_LEVEL=debug` and restarted the gateway.

**Evidence after fix:**

Pre-fix gateway log (six historical failures across ~2h, redacted):

```
[compaction-diag] end runId=<redacted> sessionKey=<redacted-agent-session-key> diagId=cmp-<redacted>
  trigger=budget provider=anthropic/claude-opus-4-7 attempt=1 maxAttempts=1
  outcome=failed reason=unknown detail=No_API_key_found_for_provider_anthropic_._Auth_store:_<path>
  durationMs=7540
[compaction] skipping — no real conversation messages (sessionKey=<redacted>)
message dispatch completed: ... outcome=error duration=17203ms
  error="Error: Preflight compaction required but failed: no real conversation messages"
```

Pre-fix verbose `memoryFlush check` (debug log, before patch was applied; raw `provider="anthropic"` misclassified):

```
memoryFlush check: sessionKey=<redacted> tokenCount=51762 contextWindow=1048576 threshold=1024576
  isHeartbeat=false isCli=false
  persistedFresh=true ...
```

Post-fix verbose `memoryFlush check` (same env, same agent kind, debug log after patch + this PR's source change):

```
memoryFlush check: sessionKey=<redacted> tokenCount=48024 contextWindow=1048576 threshold=1024576
  isHeartbeat=false isCli=true
  ...
```

Post-fix preflight short-circuits at the gate before its own verbose log emits — the early-return at the resolved-runtime-isCli check fires before the `logVerbose` line on the run-preflight branch.

**Observed result after fix:** All three claude-cli-routed agents now resolve `isCli=true` at both `runPreflightCompactionIfNeeded` and `runMemoryFlushIfNeeded`. The Telegram dispatch path no longer hits the OC-transcript compaction path, no `Preflight compaction required but failed` errors, no user-visible "Something went wrong" message. Six previously-failing inbounds no longer reproduce on the affected session-key shape (verified by sending three test messages across two agents post-patch — all returned the agent's reply normally).

**What was not tested:** The auth-profile-pinned-to-direct-API-while-auth-order-prefers-CLI configuration was added in the follow-up commit (per Codex review) and is covered by the new regression tests but was not exercised live — the live test stack uses the simpler `auth.profiles["anthropic:claude-cli"]` mapping rather than a direct-API pin override. No Crabbox / Testbox run; the live verification was on a personal stack with the three claude-cli-routed agents reproducing the exact original failure shape.
