### PR TITLE
Skip excluded Codex dynamic tool builds

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -17,6 +17,7 @@ import {
 } from "./dynamic-tool-build.js";
 import {
   filterCodexDynamicTools,
+  isCodexDynamicToolsWildcardExcluded,
   resolveCodexDynamicToolsLoading,
 } from "./dynamic-tool-profile.js";
 import { createCodexDynamicToolBridge } from "./dynamic-tools.js";
@@ -161,6 +162,17 @@ describe("Codex app-server dynamic tool build", () => {
         codexDynamicToolsExclude: ["custom_tool"],
       }).map((tool) => tool.name),
     ).toEqual(["message"]);
+  });
+
+  it("treats wildcard Codex dynamic tool excludes as exclude-all", () => {
+    const tools = ["read", "exec", "message", "custom_tool"].map((name) => ({ name }));
+
+    expect(
+      filterCodexDynamicTools(tools, {
+        codexDynamicToolsExclude: ["*"],
+      }).map((tool) => tool.name),
+    ).toEqual([]);
+    expect(isCodexDynamicToolsWildcardExcluded({ codexDynamicToolsExclude: [" * "] })).toBe(true);
   });
 
   it("exposes app-server-owned tools directly for forced private QA Codex runtime", () => {
@@ -404,6 +416,73 @@ describe("Codex app-server dynamic tool build", () => {
 
       expect(tools.map((tool) => tool.name)).toEqual(["message"]);
     }
+  });
+
+  it("skips Codex dynamic tool construction when all dynamic tools are excluded", async () => {
+    const createTools = vi.fn(() => [
+      createRuntimeDynamicTool("exec"),
+      createRuntimeDynamicTool("process"),
+      createRuntimeDynamicTool("message"),
+    ]);
+    setOpenClawCodingToolsFactoryForTests(createTools);
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+
+    const tools = await buildDynamicToolsForTest(params, workspaceDir, {
+      pluginConfig: { codexDynamicToolsExclude: ["*"] },
+    });
+
+    expect(tools).toEqual([]);
+    expect(createTools).not.toHaveBeenCalled();
+  });
+
+  it("limits wildcard-excluded forced message turns to the forced message tool", async () => {
+    const createTools = vi.fn(() => [
+      createRuntimeDynamicTool("exec"),
+      createRuntimeDynamicTool("process"),
+      createRuntimeDynamicTool("message"),
+      createRuntimeDynamicTool("heartbeat_respond"),
+    ]);
+    setOpenClawCodingToolsFactoryForTests(createTools);
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    params.disableTools = false;
+    params.sourceReplyDeliveryMode = "message_tool_only";
+    params.runtimePlan = createCodexRuntimePlanFixture();
+
+    const tools = await buildDynamicToolsForTest(params, workspaceDir, {
+      pluginConfig: { codexDynamicToolsExclude: ["*"] },
+    });
+
+    expect(tools.map((tool) => tool.name)).toEqual(["message"]);
+    expect(createTools).toHaveBeenCalledTimes(1);
+  });
+
+  it("limits wildcard-excluded heartbeat turns to the forced heartbeat tool", async () => {
+    const createTools = vi.fn(() => [
+      createRuntimeDynamicTool("exec"),
+      createRuntimeDynamicTool("message"),
+      createRuntimeDynamicTool("heartbeat_respond"),
+    ]);
+    setOpenClawCodingToolsFactoryForTests(createTools);
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    params.disableTools = false;
+    params.trigger = "heartbeat";
+    params.runtimePlan = createCodexRuntimePlanFixture();
+
+    const tools = await buildDynamicToolsForTest(params, workspaceDir, {
+      forceHeartbeatTool: true,
+      pluginConfig: { codexDynamicToolsExclude: ["*"] },
+    });
+
+    expect(tools.map((tool) => tool.name)).toEqual(["heartbeat_respond"]);
+    expect(createTools).toHaveBeenCalledTimes(1);
   });
 
   it("points yielded sandbox_exec follow-up guidance at sandbox_process", async () => {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -15,6 +15,7 @@ import { isToolAllowed } from "openclaw/plugin-sdk/sandbox";
 import { readCodexPluginConfig, type CodexPluginConfig } from "./config.js";
 import {
   filterCodexDynamicTools,
+  isCodexDynamicToolsWildcardExcluded,
   isForcedPrivateQaCodexRuntime,
   normalizeCodexDynamicToolName,
 } from "./dynamic-tool-profile.js";
@@ -170,6 +171,9 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
   if (params.disableTools || !supportsModelTools(params.model)) {
     return [];
   }
+  if (shouldSkipCodexDynamicToolBuild(input)) {
+    return [];
+  }
   // Dynamic tool construction is on the reply hot path, so per-stage
   // Date.now/span bookkeeping runs only when the Codex profiler flag is set.
   const toolBuildStages = createCodexDynamicToolBuildStageTracker({
@@ -264,14 +268,13 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
     },
   });
   toolBuildStages.mark("create-openclaw-coding-tools");
+  const baseCodexFilteredTools = isCodexDynamicToolsWildcardExcluded(input.pluginConfig)
+    ? filterCodexDynamicToolsForAllowlist(allTools, getForcedCodexDynamicToolNames(params, input))
+    : isCodexMemoryFlushRun(params)
+      ? filterCodexMemoryFlushDynamicTools(allTools)
+      : filterCodexDynamicTools(allTools, input.pluginConfig);
   const codexFilteredTools = addNodeShellDynamicToolsIfNeeded(
-    addSandboxShellDynamicToolsIfAvailable(
-      isCodexMemoryFlushRun(params)
-        ? filterCodexMemoryFlushDynamicTools(allTools)
-        : filterCodexDynamicTools(allTools, input.pluginConfig),
-      allTools,
-      input,
-    ),
+    addSandboxShellDynamicToolsIfAvailable(baseCodexFilteredTools, allTools, input),
     allTools,
     input,
   );
@@ -281,7 +284,7 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
     hasInboundImages: (params.images?.length ?? 0) > 0,
   });
   toolBuildStages.mark("vision-filtering");
-  const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, params);
+  const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, params, input);
   const filteredTools = filterCodexDynamicToolsForAllowlist(visionFilteredTools, toolsAllow);
   toolBuildStages.mark("allowlist-filter");
   const normalizedTools = normalizeAgentRuntimeTools({
@@ -321,14 +324,25 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
   return normalizedTools;
 }
 
+function shouldSkipCodexDynamicToolBuild(input: DynamicToolBuildParams): boolean {
+  if (isCodexMemoryFlushRun(input.params)) {
+    return false;
+  }
+  if (getForcedCodexDynamicToolNames(input.params, input).length > 0) {
+    return false;
+  }
+  return isCodexDynamicToolsWildcardExcluded(input.pluginConfig);
+}
+
 export function includeForcedCodexDynamicToolAllow(
   toolsAllow: string[] | undefined,
   params: EmbeddedRunAttemptParams,
+  input: Pick<DynamicToolBuildParams, "forceHeartbeatTool"> = {},
 ): string[] | undefined {
   if (toolsAllow === undefined || hasWildcardCodexToolsAllow(toolsAllow)) {
     return toolsAllow;
   }
-  const forcedToolNames = shouldForceMessageTool(params) ? ["message"] : [];
+  const forcedToolNames = getForcedCodexDynamicToolNames(params, input);
   if (forcedToolNames.length === 0) {
     return toolsAllow;
   }
@@ -340,6 +354,18 @@ export function includeForcedCodexDynamicToolAllow(
     (toolName) => !normalized.has(normalizeCodexDynamicToolName(toolName)),
   );
   return missingToolNames.length === 0 ? toolsAllow : [...toolsAllow, ...missingToolNames];
+}
+
+function getForcedCodexDynamicToolNames(
+  params: EmbeddedRunAttemptParams,
+  input: Pick<DynamicToolBuildParams, "forceHeartbeatTool">,
+): string[] {
+  return [
+    ...(shouldForceMessageTool(params) ? ["message"] : []),
+    ...(params.trigger === "heartbeat" || input.forceHeartbeatTool === true
+      ? ["heartbeat_respond"]
+      : []),
+  ];
 }
 
 export function shouldEnableCodexAppServerNativeToolSurface(

--- a/extensions/codex/src/app-server/dynamic-tool-profile.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-profile.ts
@@ -52,6 +52,9 @@ export function filterCodexDynamicTools<T extends { name: string }>(
   config: Pick<CodexPluginConfig, "codexDynamicToolsExclude">,
   env: CodexDynamicToolProfileEnv = process.env,
 ): T[] {
+  if (isCodexDynamicToolsWildcardExcluded(config)) {
+    return [];
+  }
   const excludes = new Set<string>();
   if (!isForcedPrivateQaCodexRuntime(env)) {
     for (const name of CODEX_APP_SERVER_OWNED_DYNAMIC_TOOL_EXCLUDES) {
@@ -67,4 +70,12 @@ export function filterCodexDynamicTools<T extends { name: string }>(
   return excludes.size === 0
     ? tools
     : tools.filter((tool) => !excludes.has(normalizeCodexDynamicToolName(tool.name)));
+}
+
+export function isCodexDynamicToolsWildcardExcluded(
+  config: Pick<CodexPluginConfig, "codexDynamicToolsExclude">,
+): boolean {
+  return (config.codexDynamicToolsExclude ?? []).some(
+    (name) => normalizeCodexDynamicToolName(name) === "*",
+  );
 }


### PR DESCRIPTION
## Summary

- Skip Codex dynamic tool construction when `codexDynamicToolsExclude` disables every dynamic tool with `"*"`.
- Preserve existing exceptions for memory-flush runs, forced message-tool delivery, and heartbeat tool registration.
- Add coverage proving the OpenClaw coding-tool factory is not invoked in the all-excluded case.

## Verification

Behavior addressed: Codex harness turns configured with no OpenClaw dynamic tools still paid the synchronous cost of building and normalizing the full tool surface before filtering everything out.

Real environment tested: Local OpenClaw runtime performance gateway using the Codex harness showed hot `dynamic_tools.built` at `0ms` with `toolCount: 0` after this behavior was applied.

Exact steps or command run after this patch: `node --no-maglev node_modules/vitest/vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts --run --reporter=verbose`

Evidence after fix: The new test `skips Codex dynamic tool construction when all dynamic tools are excluded` passes and asserts the tool factory is not called.

Observed result after fix: `extensions/codex/src/app-server/run-attempt.test.ts` passed in the vendor worktree, 216 tests passed.

What was not tested: The clean PR worktree did not have its own `node_modules`, so the same test file was run in the dependency-installed vendor worktree before cherry-picking this commit onto the PR branch.
