### PR TITLE
Cache hot reply runtime lookups

### DIFF
--- a/src/agents/harness/runtime-plugin.test.ts
+++ b/src/agents/harness/runtime-plugin.test.ts
@@ -20,6 +20,7 @@ vi.mock("../../plugins/providers.js", () => ({
 
 describe("ensureSelectedAgentHarnessPlugin", () => {
   let ensureSelectedAgentHarnessPlugin: typeof import("./runtime-plugin.js").ensureSelectedAgentHarnessPlugin;
+  let runtimePluginTesting: typeof import("./runtime-plugin.js").testing;
 
   beforeEach(async () => {
     mocks.ensurePluginRegistryLoaded.mockReset();
@@ -36,7 +37,9 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
     );
     mocks.resolveActivatableProviderOwnerPluginIds.mockReturnValue([]);
     vi.resetModules();
-    ({ ensureSelectedAgentHarnessPlugin } = await import("./runtime-plugin.js"));
+    ({ ensureSelectedAgentHarnessPlugin, testing: runtimePluginTesting } =
+      await import("./runtime-plugin.js"));
+    runtimePluginTesting.resetSelectedAgentHarnessPluginCache();
   });
 
   it("loads Codex and the provider owner when an explicit runtime override forces the Codex harness", async () => {
@@ -90,6 +93,27 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
         onlyPluginIds: ["codex", "openai"],
       }),
     );
+  });
+
+  it("reuses a completed scoped Codex harness plugin load", async () => {
+    const params = {
+      provider: "openai-codex",
+      modelId: "gpt-5.5-pro",
+      config: {
+        plugins: {
+          allow: ["codex"],
+          entries: {
+            codex: { enabled: true },
+          },
+        },
+      } as OpenClawConfig,
+      workspaceDir: "/tmp/workspace",
+    };
+
+    await ensureSelectedAgentHarnessPlugin(params);
+    await ensureSelectedAgentHarnessPlugin(params);
+
+    expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledTimes(1);
   });
 
   it("widens a scoped harness allowlist with the provider owner for openai-codex models", async () => {

--- a/src/agents/harness/runtime-plugin.test.ts
+++ b/src/agents/harness/runtime-plugin.test.ts
@@ -116,6 +116,41 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
     expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledTimes(1);
   });
 
+  it("does not reuse a scoped Codex harness plugin load after global plugin enablement changes", async () => {
+    const baseParams = {
+      provider: "openai-codex",
+      modelId: "gpt-5.5-pro",
+      workspaceDir: "/tmp/workspace",
+    };
+
+    await ensureSelectedAgentHarnessPlugin({
+      ...baseParams,
+      config: {
+        plugins: {
+          enabled: false,
+          allow: ["codex"],
+          entries: {
+            codex: { enabled: true },
+          },
+        },
+      } as OpenClawConfig,
+    });
+    await ensureSelectedAgentHarnessPlugin({
+      ...baseParams,
+      config: {
+        plugins: {
+          enabled: true,
+          allow: ["codex"],
+          entries: {
+            codex: { enabled: true },
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledTimes(2);
+  });
+
   it("widens a scoped harness allowlist with the provider owner for openai-codex models", async () => {
     await ensureSelectedAgentHarnessPlugin({
       provider: "openai-codex",

--- a/src/agents/harness/runtime-plugin.ts
+++ b/src/agents/harness/runtime-plugin.ts
@@ -7,6 +7,60 @@ import {
 } from "../../plugins/providers.js";
 import { resolveAgentHarnessPolicy } from "./policy.js";
 
+const SELECTED_AGENT_HARNESS_PLUGIN_CACHE = Symbol.for("openclaw.selectedAgentHarnessPluginCache");
+
+type SelectedAgentHarnessPluginCache = {
+  loadedKeys: Set<string>;
+};
+
+function getSelectedAgentHarnessPluginCache(): SelectedAgentHarnessPluginCache {
+  const globalState = globalThis as typeof globalThis & {
+    [SELECTED_AGENT_HARNESS_PLUGIN_CACHE]?: SelectedAgentHarnessPluginCache;
+  };
+  const existing = globalState[SELECTED_AGENT_HARNESS_PLUGIN_CACHE];
+  if (existing?.loadedKeys instanceof Set) {
+    return existing;
+  }
+  const next: SelectedAgentHarnessPluginCache = { loadedKeys: new Set() };
+  globalState[SELECTED_AGENT_HARNESS_PLUGIN_CACHE] = next;
+  return next;
+}
+
+function buildHarnessPluginCacheKey(params: {
+  provider: string;
+  modelId: string;
+  config?: OpenClawConfig;
+  agentId?: string;
+  sessionKey?: string;
+  agentHarnessRuntimeOverride?: string;
+  workspaceDir: string;
+  runtime: string;
+  pluginIds: readonly string[];
+}): string {
+  return JSON.stringify({
+    provider: params.provider,
+    modelId: params.modelId,
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+    runtime: params.runtime,
+    runtimeOverride: params.agentHarnessRuntimeOverride,
+    workspaceDir: params.workspaceDir,
+    pluginIds: params.pluginIds,
+    plugins: {
+      allow: params.config?.plugins?.allow,
+      bundledDiscovery: params.config?.plugins?.bundledDiscovery,
+      deny: params.config?.plugins?.deny,
+      load: params.config?.plugins?.load,
+      entries: Object.fromEntries(
+        Object.entries(params.config?.plugins?.entries ?? {}).map(([id, entry]) => [
+          id,
+          { enabled: entry?.enabled },
+        ]),
+      ),
+    },
+  });
+}
+
 function dedupePluginIds(values: readonly string[]): string[] {
   const seen = new Set<string>();
   const result: string[] = [];
@@ -120,6 +174,15 @@ export async function ensureSelectedAgentHarnessPlugin(params: {
     config: params.config,
     workspaceDir: params.workspaceDir,
   });
+  const cacheKey = buildHarnessPluginCacheKey({
+    ...params,
+    runtime,
+    pluginIds,
+  });
+  const cache = getSelectedAgentHarnessPluginCache();
+  if (cache.loadedKeys.has(cacheKey)) {
+    return;
+  }
   const configWithAllowedRuntimePlugins = withRuntimePluginIdsAllowed({
     config: params.config,
     requiredPluginId: "codex",
@@ -141,4 +204,12 @@ export async function ensureSelectedAgentHarnessPlugin(params: {
     workspaceDir: params.workspaceDir,
     onlyPluginIds: pluginIds,
   });
+  cache.loadedKeys.add(cacheKey);
 }
+
+export const testing = {
+  resetSelectedAgentHarnessPluginCache() {
+    getSelectedAgentHarnessPluginCache().loadedKeys.clear();
+  },
+  buildHarnessPluginCacheKey,
+};

--- a/src/agents/harness/runtime-plugin.ts
+++ b/src/agents/harness/runtime-plugin.ts
@@ -50,6 +50,7 @@ function buildHarnessPluginCacheKey(params: {
       allow: params.config?.plugins?.allow,
       bundledDiscovery: params.config?.plugins?.bundledDiscovery,
       deny: params.config?.plugins?.deny,
+      enabled: params.config?.plugins?.enabled,
       load: params.config?.plugins?.load,
       entries: Object.fromEntries(
         Object.entries(params.config?.plugins?.entries ?? {}).map(([id, entry]) => [

--- a/src/auto-reply/reply/agent-runner-utils.secret-resolution.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.secret-resolution.test.ts
@@ -17,7 +17,7 @@ vi.mock("../../cli/command-secret-targets.js", () => ({
     hoisted.getScopedChannelsCommandSecretTargetsMock(...args),
 }));
 
-const { resolveQueuedReplyExecutionConfig, resolveQueuedReplyRuntimeConfig } =
+const { resolveQueuedReplyExecutionConfig, resolveQueuedReplyRuntimeConfig, testing } =
   await import("./agent-runner-utils.js");
 const { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } =
   await import("../../config/config.js");
@@ -41,6 +41,7 @@ function resolveCommandSecretRefsCall(callIndex = 0): ResolveCommandSecretRefsCa
 
 describe("resolveQueuedReplyExecutionConfig channel scope", () => {
   beforeEach(() => {
+    testing.resetQueuedReplyExecutionConfigCache();
     clearRuntimeConfigSnapshot();
     hoisted.resolveCommandSecretRefsViaGatewayMock
       .mockReset()
@@ -57,6 +58,7 @@ describe("resolveQueuedReplyExecutionConfig channel scope", () => {
   });
 
   afterEach(() => {
+    testing.resetQueuedReplyExecutionConfigCache();
     clearRuntimeConfigSnapshot();
   });
 
@@ -118,6 +120,24 @@ describe("resolveQueuedReplyExecutionConfig channel scope", () => {
       channel: "discord",
       accountId: "ops",
     });
+  });
+
+  it("reuses resolved execution config for the same source config and reply scope", async () => {
+    const sourceConfig = { source: true } as unknown as OpenClawConfig;
+
+    const first = await resolveQueuedReplyExecutionConfig(sourceConfig, {
+      messageProvider: "discord",
+      agentAccountId: "ops",
+    });
+    const second = await resolveQueuedReplyExecutionConfig(sourceConfig, {
+      messageProvider: "discord",
+      agentAccountId: "ops",
+    });
+
+    expect(first).toBe(sourceConfig);
+    expect(second).toBe(sourceConfig);
+    expect(hoisted.resolveCommandSecretRefsViaGatewayMock).toHaveBeenCalledTimes(2);
+    expect(hoisted.getScopedChannelsCommandSecretTargetsMock).toHaveBeenCalledTimes(1);
   });
 
   it("skips scoped channel resolution when no active channel can be resolved", async () => {

--- a/src/auto-reply/reply/agent-runner-utils.secret-resolution.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.secret-resolution.test.ts
@@ -172,6 +172,28 @@ describe("resolveQueuedReplyExecutionConfig channel scope", () => {
     });
   });
 
+  it("does not reuse a cached reply config after the runtime snapshot changes", async () => {
+    const sourceConfig = { source: true } as unknown as OpenClawConfig;
+    const firstRuntimeConfig = { runtime: "first" } as unknown as OpenClawConfig;
+    const secondRuntimeConfig = { runtime: "second" } as unknown as OpenClawConfig;
+    setRuntimeConfigSnapshot(firstRuntimeConfig, sourceConfig);
+    hoisted.getScopedChannelsCommandSecretTargetsMock.mockReturnValue({
+      targetIds: new Set<string>(),
+    });
+
+    const first = await resolveQueuedReplyExecutionConfig(sourceConfig, {
+      messageProvider: "discord",
+    });
+    setRuntimeConfigSnapshot(secondRuntimeConfig, sourceConfig);
+    const second = await resolveQueuedReplyExecutionConfig(sourceConfig, {
+      messageProvider: "discord",
+    });
+
+    expect(first).toBe(firstRuntimeConfig);
+    expect(second).toBe(secondRuntimeConfig);
+    expect(hoisted.resolveCommandSecretRefsViaGatewayMock).toHaveBeenCalledTimes(2);
+  });
+
   it("does not replace an already resolved run config with a stale runtime snapshot", () => {
     const sourceConfig = {
       models: {

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -36,6 +36,77 @@ import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-r
 import type { FollowupRun } from "./queue.js";
 
 const BUN_FETCH_SOCKET_ERROR_RE = /socket connection was closed unexpectedly/i;
+const QUEUED_REPLY_EXECUTION_CONFIG_CACHE = Symbol.for("openclaw.queuedReplyExecutionConfigCache");
+const QUEUED_REPLY_EXECUTION_CONFIG_CACHE_TTL_MS = 60_000;
+
+type QueuedReplyExecutionConfigCache = {
+  weak: WeakMap<OpenClawConfig, Map<string, { createdAt: number; config: OpenClawConfig }>>;
+  primitive: Map<string, { createdAt: number; config: OpenClawConfig }>;
+};
+
+function getQueuedReplyExecutionConfigCache(): QueuedReplyExecutionConfigCache {
+  const globalState = globalThis as typeof globalThis & {
+    [QUEUED_REPLY_EXECUTION_CONFIG_CACHE]?: QueuedReplyExecutionConfigCache;
+  };
+  const existing = globalState[QUEUED_REPLY_EXECUTION_CONFIG_CACHE];
+  if (existing?.weak instanceof WeakMap && existing.primitive instanceof Map) {
+    return existing;
+  }
+  const next: QueuedReplyExecutionConfigCache = {
+    weak: new WeakMap(),
+    primitive: new Map(),
+  };
+  globalState[QUEUED_REPLY_EXECUTION_CONFIG_CACHE] = next;
+  return next;
+}
+
+function buildQueuedReplyExecutionConfigCacheKey(params?: {
+  originatingChannel?: string;
+  messageProvider?: string;
+  originatingAccountId?: string;
+  agentAccountId?: string;
+}): string {
+  return JSON.stringify({
+    originatingChannel: params?.originatingChannel,
+    messageProvider: params?.messageProvider,
+    originatingAccountId: params?.originatingAccountId,
+    agentAccountId: params?.agentAccountId,
+  });
+}
+
+function readQueuedReplyExecutionConfigCache(
+  config: OpenClawConfig,
+  key: string,
+): OpenClawConfig | undefined {
+  const cache = getQueuedReplyExecutionConfigCache();
+  const entry =
+    typeof config === "object" && config !== null
+      ? cache.weak.get(config)?.get(key)
+      : cache.primitive.get(key);
+  if (!entry || Date.now() - entry.createdAt > QUEUED_REPLY_EXECUTION_CONFIG_CACHE_TTL_MS) {
+    return undefined;
+  }
+  return entry.config;
+}
+
+function writeQueuedReplyExecutionConfigCache(
+  config: OpenClawConfig,
+  key: string,
+  resolvedConfig: OpenClawConfig,
+): void {
+  const cache = getQueuedReplyExecutionConfigCache();
+  const entry = { createdAt: Date.now(), config: resolvedConfig };
+  if (typeof config === "object" && config !== null) {
+    const existing = cache.weak.get(config);
+    if (existing) {
+      existing.set(key, entry);
+    } else {
+      cache.weak.set(config, new Map([[key, entry]]));
+    }
+    return;
+  }
+  cache.primitive.set(key, entry);
+}
 
 export function resolveQueuedReplyRuntimeConfig(config: OpenClawConfig): OpenClawConfig {
   const runtimeConfig =
@@ -60,6 +131,11 @@ export async function resolveQueuedReplyExecutionConfig(
     agentAccountId?: string;
   },
 ): Promise<OpenClawConfig> {
+  const cacheKey = buildQueuedReplyExecutionConfigCacheKey(params);
+  const cached = readQueuedReplyExecutionConfigCache(config, cacheKey);
+  if (cached) {
+    return cached;
+  }
   const runtimeConfig = resolveQueuedReplyRuntimeConfig(config);
   const { resolvedConfig } = await resolveCommandSecretRefsViaGateway({
     config: runtimeConfig,
@@ -75,6 +151,7 @@ export async function resolveQueuedReplyExecutionConfig(
     fallbackAccountId: params?.agentAccountId,
   });
   if (!scope.channel) {
+    writeQueuedReplyExecutionConfigCache(config, cacheKey, baseResolvedConfig);
     return baseResolvedConfig;
   }
 
@@ -84,6 +161,7 @@ export async function resolveQueuedReplyExecutionConfig(
     accountId: scope.accountId,
   });
   if (scopedTargets.targetIds.size === 0) {
+    writeQueuedReplyExecutionConfigCache(config, cacheKey, baseResolvedConfig);
     return baseResolvedConfig;
   }
 
@@ -93,7 +171,9 @@ export async function resolveQueuedReplyExecutionConfig(
     targetIds: scopedTargets.targetIds,
     ...(scopedTargets.allowedPaths ? { allowedPaths: scopedTargets.allowedPaths } : {}),
   });
-  return scopedResolved.resolvedConfig ?? baseResolvedConfig;
+  const finalConfig = scopedResolved.resolvedConfig ?? baseResolvedConfig;
+  writeQueuedReplyExecutionConfigCache(config, cacheKey, finalConfig);
+  return finalConfig;
 }
 
 /**
@@ -172,6 +252,21 @@ export const formatBunFetchSocketError = (message: string) => {
     trimmed || "Unknown error",
     "```",
   ].join("\n");
+};
+
+export const testing = {
+  resetQueuedReplyExecutionConfigCache() {
+    const cache = getQueuedReplyExecutionConfigCache();
+    cache.primitive.clear();
+    // WeakMap entries are not iterable; replacing the global cache clears them.
+    const globalState = globalThis as typeof globalThis & {
+      [QUEUED_REPLY_EXECUTION_CONFIG_CACHE]?: QueuedReplyExecutionConfigCache;
+    };
+    globalState[QUEUED_REPLY_EXECUTION_CONFIG_CACHE] = {
+      weak: new WeakMap(),
+      primitive: new Map(),
+    };
+  },
 };
 
 export const resolveEnforceFinalTag = (

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -13,6 +13,7 @@ import { resolveMessageSecretScope } from "../../cli/message-secret-scope.js";
 import {
   getRuntimeConfigSnapshot,
   getRuntimeConfigSourceSnapshot,
+  resolveRuntimeConfigCacheKey,
   selectApplicableRuntimeConfig,
   type OpenClawConfig,
 } from "../../config/config.js";
@@ -61,12 +62,14 @@ function getQueuedReplyExecutionConfigCache(): QueuedReplyExecutionConfigCache {
 }
 
 function buildQueuedReplyExecutionConfigCacheKey(params?: {
+  runtimeConfigKey?: string;
   originatingChannel?: string;
   messageProvider?: string;
   originatingAccountId?: string;
   agentAccountId?: string;
 }): string {
   return JSON.stringify({
+    runtimeConfigKey: params?.runtimeConfigKey,
     originatingChannel: params?.originatingChannel,
     messageProvider: params?.messageProvider,
     originatingAccountId: params?.originatingAccountId,
@@ -131,12 +134,13 @@ export async function resolveQueuedReplyExecutionConfig(
     agentAccountId?: string;
   },
 ): Promise<OpenClawConfig> {
-  const cacheKey = buildQueuedReplyExecutionConfigCacheKey(params);
+  const runtimeConfig = resolveQueuedReplyRuntimeConfig(config);
+  const runtimeConfigKey = resolveRuntimeConfigCacheKey(runtimeConfig);
+  const cacheKey = buildQueuedReplyExecutionConfigCacheKey({ ...params, runtimeConfigKey });
   const cached = readQueuedReplyExecutionConfigCache(config, cacheKey);
   if (cached) {
     return cached;
   }
-  const runtimeConfig = resolveQueuedReplyRuntimeConfig(config);
   const { resolvedConfig } = await resolveCommandSecretRefsViaGateway({
     config: runtimeConfig,
     commandName: "reply",


### PR DESCRIPTION
## Summary

- Cache completed Codex harness plugin registry loads for the same provider/model/config scope.
- Cache queued reply execution config resolution for the same source config and reply scope.
- Add targeted coverage for both cache paths.

## Verification

Behavior addressed: Hot reply turns could repeatedly reload the same Codex harness plugin registry and resolve the same reply command/channel secret config even when the runtime config and reply scope had not changed.

Real environment tested: Local OpenClaw runtime performance gateway using the Codex harness showed hot wrapper overhead around tens of milliseconds after this behavior was applied, with auth/config/harness phases effectively removed from repeated hot turns.

Exact steps or command run after this patch: `node --no-maglev node_modules/vitest/vitest.mjs src/agents/harness/runtime-plugin.test.ts --run --reporter=verbose` and `node --no-maglev node_modules/vitest/vitest.mjs src/auto-reply/reply/agent-runner-utils.secret-resolution.test.ts --run --reporter=verbose`

Evidence after fix: `runtime-plugin.test.ts` passed 18/18 tests; `agent-runner-utils.secret-resolution.test.ts` passed 6/6 tests.

Observed result after fix: Repeated `ensureSelectedAgentHarnessPlugin` calls reuse the completed scoped load, and repeated `resolveQueuedReplyExecutionConfig` calls for the same config/scope avoid additional secret resolution work.

What was not tested: The clean PR worktree did not have its own `node_modules`, so these targeted tests were run in the dependency-installed vendor worktree before cherry-picking this commit onto the PR branch.
