### PR TITLE
fix(cron): honor isolated sessionTarget and fail missing cron.remove id

### DIFF
--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -630,6 +630,25 @@ describe("cron tool", () => {
     expect(sessionKey).toBe("agent:main:telegram:group:-100123:topic:99");
   });
 
+  it("does not stamp caller sessionKey when add targets isolated session", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const tool = createTestCronTool({ agentSessionKey: "agent:main:webchat:dm:dashboard" });
+    await tool.execute("call-isolated-no-stamp", {
+      action: "add",
+      job: {
+        name: "isolated run",
+        schedule: { at: new Date(123).toISOString() },
+        sessionTarget: "isolated",
+        payload: { kind: "agentTurn", message: "hello" },
+      },
+    });
+    const call = readGatewayCall();
+    const payload = call.params as { sessionKey?: string; sessionTarget?: string } | undefined;
+    expect(payload?.sessionTarget).toBe("isolated");
+    expect(payload).not.toHaveProperty("sessionKey");
+  });
+
   it("adds recent context for systemEvent reminders when contextMessages > 0", async () => {
     callGatewayMock
       .mockResolvedValueOnce({

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -670,7 +670,10 @@ Use jobId canonical; id accepted compat. contextMessages (0-10) adds previous me
                 (job as { agentId?: string }).agentId = agentId;
               }
             }
-            if (!("sessionKey" in job) && resolvedSessionKey) {
+            const sessionTarget = normalizeLowercaseStringOrEmpty(
+              (job as { sessionTarget?: unknown }).sessionTarget,
+            );
+            if (!("sessionKey" in job) && resolvedSessionKey && sessionTarget !== "isolated") {
               (job as { sessionKey?: string }).sessionKey = resolvedSessionKey;
             }
           }

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -477,9 +477,15 @@ export const cronHandlers: GatewayRequestHandlers = {
       return;
     }
     const result = await context.cron.remove(jobId);
-    if (result.removed) {
-      context.logGateway.info("cron: job removed", { jobId });
+    if (!result.removed) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "invalid cron.remove params: id not found"),
+      );
+      return;
     }
+    context.logGateway.info("cron: job removed", { jobId });
     respond(true, result, undefined);
   },
   "cron.run": async ({ params, respond, context }) => {

--- a/src/gateway/server-methods/cron.validation.test.ts
+++ b/src/gateway/server-methods/cron.validation.test.ts
@@ -75,6 +75,7 @@ function createCronContext(currentJob?: CronJob) {
     cron: {
       add: vi.fn(async () => ({ id: "cron-1" })),
       update: vi.fn(async () => ({ id: "cron-1" })),
+      remove: vi.fn(async () => ({ ok: true, removed: true })),
       getDefaultAgentId: vi.fn(() => "main"),
       getJob: vi.fn(() => currentJob),
       wake: vi.fn(() => ({ ok: true }) as const),
@@ -119,6 +120,26 @@ async function invokeCronUpdate(params: Record<string, unknown>, currentJob: Cro
   const context = createCronContext(currentJob);
   const respond = vi.fn();
   await cronHandlers["cron.update"]({
+    req: {} as never,
+    params: params as never,
+    respond: respond as never,
+    context: context as never,
+    client: null,
+    isWebchatConnect: () => false,
+  });
+  return { context, respond };
+}
+
+async function invokeCronRemove(
+  params: Record<string, unknown>,
+  options?: { removeResult?: { ok: boolean; removed: boolean } },
+) {
+  const context = createCronContext();
+  if (options?.removeResult) {
+    context.cron.remove.mockResolvedValueOnce(options.removeResult);
+  }
+  const respond = vi.fn();
+  await cronHandlers["cron.remove"]({
     req: {} as never,
     params: params as never,
     respond: respond as never,
@@ -244,6 +265,17 @@ describe("cron method validation", () => {
       threadId: 123,
     });
     expect(respond).toHaveBeenCalledWith(true, { id: "cron-1" }, undefined);
+  });
+
+  it("returns invalid-request error when cron.remove target id is missing", async () => {
+    const { respond } = await invokeCronRemove(
+      { id: "missing-id" },
+      { removeResult: { ok: true, removed: false } },
+    );
+    expectResponseError(respond, {
+      code: "INVALID_REQUEST",
+      messageIncludes: "invalid cron.remove params: id not found",
+    });
   });
 
   it("returns a single cron job for cron.get", async () => {


### PR DESCRIPTION
## Summary
- prevent cron tool auto-injection of caller session key when a cron job explicitly targets `sessionTarget: "isolated"`
- make `cron.remove` return an invalid-request error when the target job id is not found, instead of `ok: true, removed: false`

Fixes #86202

## Verification
- `node scripts/run-vitest.mjs src/agents/tools/cron-tool.test.ts src/gateway/server-methods/cron.validation.test.ts`
- autoreview clean after rebase on `origin/main`

## Real behavior proof
Behavior addressed: isolated cron jobs should not inherit the caller/dashboard session key, and removing a missing cron id should be surfaced as an invalid request instead of a successful no-op.

Real environment tested: local OpenClaw source checkout on Node 24-compatible tooling, loading the real cron tool and gateway cron handler modules through the repo test harness.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/tools/cron-tool.test.ts src/gateway/server-methods/cron.validation.test.ts`

Evidence after fix: `Test Files 4 passed (4)` and `Tests 204 passed (204)`. The new cron-tool assertion observed an isolated add payload with `sessionTarget: "isolated"` and no `sessionKey`; the gateway validation assertion observed `INVALID_REQUEST` for a missing `cron.remove` id.

Observed result after fix: isolated cron add requests remain isolated, and missing cron removals now return a clear invalid-request error.

What was not tested: a full long-running gateway cron scheduler process with wall-clock job execution; the changed request construction and gateway handler branches were tested directly.
