### PR TITLE
fix(cron): accept plus durations for --at

### DIFF
--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -1335,6 +1335,22 @@ describe("cron cli", () => {
     });
   });
 
+  it("accepts documented +duration values for cron edit --at", async () => {
+    const now = Date.UTC(2026, 0, 1, 0, 0, 0);
+    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+    let patch: CronUpdatePatch;
+    try {
+      patch = await runCronEditAndGetPatch(["--at", "+30m"]);
+    } finally {
+      dateNowSpy.mockRestore();
+    }
+
+    expect(patch?.patch?.schedule).toEqual({
+      kind: "at",
+      at: "2026-01-01T00:30:00.000Z",
+    });
+  });
+
   it("rejects --tz with --every on cron edit", async () => {
     await expectCronCommandExit(["cron", "edit", "job-1", "--every", "10m", "--tz", "UTC"]);
   });

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -316,16 +316,7 @@ describe("cron cli", () => {
         enqueued: true,
         runId: "manual:job-1:123:0",
         runStatus: status,
-        args: [
-          "cron",
-          "run",
-          "job-1",
-          "--wait",
-          "--wait-timeout",
-          "1s",
-          "--poll-interval",
-          "1ms",
-        ],
+        args: ["cron", "run", "job-1", "--wait", "--wait-timeout", "1s", "--poll-interval", "1ms"],
       });
 
       expect(exitSpy).toHaveBeenCalledWith(expectedExitCode);
@@ -455,6 +446,50 @@ describe("cron cli", () => {
     const addCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.add");
     const params = addCall?.[2] as { deleteAfterRun?: boolean };
     expect(params?.deleteAfterRun).toBe(false);
+  });
+
+  it("accepts documented +duration values for cron add --at", async () => {
+    const now = Date.UTC(2026, 0, 1, 0, 0, 0);
+    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+    try {
+      await runCronCommand([
+        "cron",
+        "add",
+        "--name",
+        "Plus duration",
+        "--at",
+        "+30m",
+        "--session",
+        "isolated",
+        "--message",
+        "hello",
+      ]);
+    } finally {
+      dateNowSpy.mockRestore();
+    }
+
+    const params = getGatewayCallParams<{ schedule: { kind?: string; at?: string } }>("cron.add");
+    expect(params.schedule).toEqual({
+      kind: "at",
+      at: "2026-01-01T00:30:00.000Z",
+    });
+  });
+
+  it("keeps leading plus durations invalid for cron add --every", async () => {
+    await expectCronCommandExit([
+      "cron",
+      "add",
+      "--name",
+      "Invalid plus every",
+      "--every",
+      "+30m",
+      "--session",
+      "isolated",
+      "--message",
+      "hello",
+    ]);
+
+    expectRuntimeErrorContaining("Invalid --every");
   });
 
   it("includes --account on isolated cron add delivery", async () => {

--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -4,6 +4,7 @@ import type { RuntimeEnv } from "../../runtime.js";
 import {
   coerceCronDeliveryPreviews,
   getCronChannelOptions,
+  parseAt,
   parseCronToolsAllow,
   printCronList,
 } from "./shared.js";
@@ -256,6 +257,19 @@ describe("parseCronToolsAllow", () => {
 
   it("returns undefined for empty input", () => {
     expect(parseCronToolsAllow(" ,  ")).toBeUndefined();
+  });
+});
+
+describe("parseAt", () => {
+  it("accepts a leading plus on relative durations", () => {
+    const now = Date.UTC(2026, 0, 1, 0, 0, 0);
+    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+    try {
+      expect(parseAt("+30m")).toBe("2026-01-01T00:30:00.000Z");
+      expect(parseAt("30m")).toBe("2026-01-01T00:30:00.000Z");
+    } finally {
+      dateNowSpy.mockRestore();
+    }
   });
 });
 

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -177,7 +177,8 @@ export function parseAt(input: string, tz?: string): string | null {
   if (absolute !== null) {
     return new Date(absolute).toISOString();
   }
-  const dur = parseDurationMs(raw);
+  const durationRaw = raw.startsWith("+") ? raw.slice(1) : raw;
+  const dur = parseDurationMs(durationRaw);
   if (dur !== null) {
     return new Date(Date.now() + dur).toISOString();
   }


### PR DESCRIPTION
Fixes #86230

## Summary
- Accept an optional leading `+` for one-shot `cron add --at` / `cron edit --at` relative durations.
- Keep the shared duration parser strict so interval-style options such as `--every +30m` remain invalid.
- Add parser, `cron add`, and `cron edit` regressions for the documented `--at +30m` form and the unchanged `--every` behavior.

## Problem Statement
`openclaw cron add --help` documents `--at` as accepting `+duration`, but the one-shot schedule parser delegated the raw value to the shared duration parser, which only accepts digit-starting values like `30m`. Scripts following the shipped help text would fail validation before creating the cron job.

## Root Cause
`parseAt` tried absolute time parsing first, then called `parseDurationMs(raw)` directly. `parseDurationMs` is intentionally shared by other flags and rejects a leading `+`, so the documented one-shot form never reached a valid relative duration path.

## Implementation Summary
The fix normalizes only the `parseAt` duration candidate by stripping one leading `+` before calling `parseDurationMs`. That keeps the change scoped to one-shot `--at` parsing and avoids expanding `--every`, `--stagger`, or other duration-based flags. Tests cover the parser helper plus both `cron add --at +30m` and `cron edit --at +30m` command paths.

## Why This Matches Project Conventions
This follows the existing `gather -> parse -> RPC params` cron CLI flow, reuses the existing duration parser, and avoids adding a new abstraction for a single CLI syntax alias. The regression tests are colocated with the existing cron CLI and shared-helper tests.

## Real behavior proof
Behavior addressed: `openclaw cron add --at +30m` and `openclaw cron edit <id> --at +30m` now produce `at` schedules instead of failing validation, while `--every +30m` remains rejected.
Real environment tested: Local OpenClaw checkout on Windows using the bundled Node 24.14.0 runtime; full build and changed tests were also run from a no-space detached worktree at the amended branch head.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/cli/cron-cli.test.ts src/cli/cron-cli/shared.test.ts src/cli/cron-cli/register.cron-edit.test.ts src/cli/cron-cli/register.cron-simple.test.ts`; `node scripts/test-projects.mjs --changed origin/main`; `node scripts/run-vitest.mjs src/agents/model-catalog-visibility.test.ts`; `pnpm exec oxfmt --check --threads=1 src/cli/cron-cli/shared.ts src/cli/cron-cli/shared.test.ts src/cli/cron-cli.test.ts`; `git diff --check`; `node_modules/.bin/oxlint.CMD --tsconfig config/tsconfig/oxlint.core.json src/cli/cron-cli/shared.ts src/cli/cron-cli/shared.test.ts src/cli/cron-cli.test.ts`; `node_modules/.bin/tsgo.CMD -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`; `node_modules/.bin/tsgo.CMD -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`; `node scripts/check-changed.mjs`; no-space worktree `node scripts/test-projects.mjs --changed origin/main`; no-space worktree `pnpm build`; `AUTOREVIEW_AUTO_TESTS=0 python .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`.
Evidence after fix: The expanded focused cron CLI suite passed with 4 files and 102 tests. The smart changed test gate passed in both the source checkout and the no-space worktree with 2 files and 96 tests. Static checks, core/core-test type checks, changed checks, full build, and branch-mode autoreview all completed successfully. The unrelated CI-timeout file `src/agents/model-catalog-visibility.test.ts` also passed locally with 2 files and 6 tests.
Observed result after fix: The new CLI regressions record `schedule: { kind: "at", at: "2026-01-01T00:30:00.000Z" }` for both add/edit `--at +30m`, and the paired `--every +30m` regression still exits through `Invalid --every`.
What was not tested: No live gateway cron job was created; the existing CLI tests use the repository's mocked gateway RPC path, which is the same local convention used by nearby cron CLI tests. Remote Testbox-through-Crabbox proof was attempted but blocked before allocation because the local Crabbox wrapper reported `selected binary failed basic --version/--help sanity checks`.

## Verification
- `node scripts/run-vitest.mjs src/cli/cron-cli.test.ts src/cli/cron-cli/shared.test.ts src/cli/cron-cli/register.cron-edit.test.ts src/cli/cron-cli/register.cron-simple.test.ts`
- `node scripts/test-projects.mjs --changed origin/main`
- `node scripts/run-vitest.mjs src/agents/model-catalog-visibility.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/cli/cron-cli/shared.ts src/cli/cron-cli/shared.test.ts src/cli/cron-cli.test.ts`
- `git diff --check`
- `node_modules/.bin/oxlint.CMD --tsconfig config/tsconfig/oxlint.core.json src/cli/cron-cli/shared.ts src/cli/cron-cli/shared.test.ts src/cli/cron-cli.test.ts`
- `node_modules/.bin/tsgo.CMD -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node_modules/.bin/tsgo.CMD -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `node scripts/check-changed.mjs`
- no-space worktree: `node scripts/test-projects.mjs --changed origin/main`
- no-space worktree: `pnpm build`
- `AUTOREVIEW_AUTO_TESTS=0 python .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`