### PR TITLE
fix(update): exclude prerelease tags from stable git channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Updater: exclude alpha and release-candidate tags from stable git channel resolution so stable installs do not checkout prerelease builds.
+
 ## 2026.5.25
 
 ### Fixes

--- a/src/infra/update-channels.test.ts
+++ b/src/infra/update-channels.test.ts
@@ -17,12 +17,14 @@ describe("update-channels tag detection", () => {
     { tag: "v2026.2.24-beta.1", beta: true },
     { tag: "v2026.2.24.beta.1", beta: true },
     { tag: "v2026.2.24-BETA-1", beta: true },
+    { tag: "v2026.2.24-alpha.1", beta: false, stable: false },
+    { tag: "v2026.2.24-rc.1", beta: false, stable: false },
     { tag: "v2026.2.24-1", beta: false },
     { tag: "v2026.2.24-alphabeta.1", beta: false },
     { tag: "v2026.2.24", beta: false },
-  ])("classifies $tag", ({ tag, beta }) => {
+  ])("classifies $tag", ({ tag, beta, stable = !beta }) => {
     expect(isBetaTag(tag)).toBe(beta);
-    expect(isStableTag(tag)).toBe(!beta);
+    expect(isStableTag(tag)).toBe(stable);
   });
 });
 

--- a/src/infra/update-channels.ts
+++ b/src/infra/update-channels.ts
@@ -37,8 +37,12 @@ export function isBetaTag(tag: string): boolean {
   return /(?:^|[.-])beta(?:[.-]|$)/i.test(tag);
 }
 
+function isPrereleaseTag(tag: string): boolean {
+  return /(?:^|[.-])(?:alpha|beta|rc)(?:[.-]|$)/i.test(tag);
+}
+
 export function isStableTag(tag: string): boolean {
-  return !isBetaTag(tag);
+  return !isPrereleaseTag(tag);
 }
 
 export function resolveRegistryUpdateChannel(params: {


### PR DESCRIPTION
## Summary

- Fix stable git-channel tag classification so `alpha` and `rc` prerelease tags are not treated as stable release tags.
- Add regression coverage for alpha/rc tag classification while preserving beta detection and numbered stable patch tags.
- Add a changelog entry for the updater fix.

Fixes #86218.

## Tests

- `node scripts/run-vitest.mjs src/infra/update-channels.test.ts`
- `node scripts/run-vitest.mjs src/cli/update-cli.test.ts`
- `git diff --check`

## Real behavior proof

Behavior addressed: Stable-channel git update resolution used `isStableTag`, which previously meant only "not beta" and therefore allowed `v2026.5.24-alpha.1` to outrank the latest stable tag. This patch makes stable tag classification reject alpha and rc prerelease tags while leaving beta-channel detection intact.

Real environment tested: Local OpenClaw source checkout on macOS, running the updated updater classification code through the repository's installed TS runtime.

Exact steps or command run after this patch: `node_modules/.bin/tsx -e 'import { isStableTag, isBetaTag } from "./src/infra/update-channels.ts"; const tags = ["v2026.5.24-alpha.1", "v2026.5.22", "v2026.5.22-beta.1"]; for (const tag of tags) console.log(`${tag} stable=${isStableTag(tag)} beta=${isBetaTag(tag)}`);'`

Evidence after fix:

```text
has-tsx
v2026.5.24-alpha.1 stable=false beta=false
v2026.5.22 stable=true beta=false
v2026.5.22-beta.1 stable=false beta=true
```

Observed result after fix: The alpha prerelease tag is no longer stable-eligible, the stable release tag remains stable-eligible, and the beta tag remains beta-only. Supplemental checks also passed: `node scripts/run-vitest.mjs src/infra/update-channels.test.ts`, `node scripts/run-vitest.mjs src/cli/update-cli.test.ts`, and `git diff --check`.

What was not tested: I did not run a live `openclaw update` against a production git install or perform an actual checkout/restart; the live command above exercises the tag-classification boundary used by git update resolution.
