### PR TITLE
fix(gateway): add OPENCLAW_SKIP_PROVIDER_AUTH_PREWARM env var to skip startup prewarm

### DIFF
--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -972,7 +972,10 @@ export async function startGatewayPostAttachRuntime(
         }
         const postReadySidecars = [...result.postReadySidecars];
         const gatewayLifetimeSidecars: GatewayPostReadySidecarHandle[] = [];
-        if (params.providerAuthPrewarm?.enabled !== false) {
+        if (
+          !isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDER_AUTH_PREWARM) &&
+          params.providerAuthPrewarm?.enabled !== false
+        ) {
           gatewayLifetimeSidecars.push(
             scheduleProviderAuthStatePrewarm({
               getConfig: params.providerAuthPrewarm?.getConfig ?? (() => params.cfgAtStart),


### PR DESCRIPTION
## Summary

Adds `OPENCLAW_SKIP_PROVIDER_AUTH_PREWARM=1` env var to let operators skip the provider auth prewarm at gateway startup without needing a config change or rebuild.

## Problem

Provider auth prewarming (`warmCurrentProviderAuthState`) can block the Node.js event loop for 30-79 seconds on constrained hosts during gateway startup. This causes:

- CLI health responses taking 20-27 seconds (HTTP API unaffected at 70-75ms)
- Channel handshake timeouts (Discord, WhatsApp, Telegram)
- Event loop degradation warnings (p99=28s, util=100%)
- `startup model warmup timed out after 5000ms` log spam

Affected platforms: Windows 11 native, WSL2, low-core Linux VMs.

Reported in: #85999, #86201, #84771

## Fix

Adds an env var check before the prewarm push at line 975 of `server-startup-post-attach.ts`:

```typescript
if (
  !isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDER_AUTH_PREWARM) &&
  params.providerAuthPrewarm?.enabled !== false
) {
```

The env var follows the existing pattern used by `OPENCLAW_SKIP_PROVIDERS` and `OPENCLAW_SKIP_CHANNELS` (same file, same helper function). It acts as an additional gate — if the env var is truthy, the prewarm is skipped regardless of config.

## Testing

Verified on Windows 11 Pro (build 26200), OpenClaw 2026.5.22, Node 25.9.0:
- Without env var: health CLI 20-27s, `provider auth state pre-warmed in 78798ms eventLoopMax=25786.6ms`
- With `OPENCLAW_SKIP_PROVIDER_AUTH_PREWARM=1`: no prewarm log, no event loop degradation
- Gateway HTTP API unaffected in both cases (70-75ms baseline)

## Relationship to other PRs

- **#86003** (operator controls): adds `gateway.providerAuthPrewarm.enabled` config key with schema validation, delayMs, and reload/lougout rewarm path support. This PR adds the env var override that operators can use immediately without waiting for config schema changes.
- **#82894** (runtime prewarm): restructures prewarm ordering during sidecar startup. Orthogonal — addresses a different part of the startup path.

## What this PR does NOT do

- Does not add config schema validation (defer to #86003)
- Does not fix the underlying synchronous blocking in `warmCurrentProviderAuthState` (requires deeper refactor in `model-provider-auth.ts`)
- Does not affect the model prewarm path (separate env var `OPENCLAW_SKIP_STARTUP_MODEL_PREWARM`)

## Checklist

- [x] Follows existing code patterns (`isTruthyEnvValue`, existing env var naming convention)
- [x] Does not change default behavior (prewarm still runs without env var)
- [x] No new dependencies
- [x] No config changes
- [x] Single file, minimal diff (+4/-1)

Closes: #85999
Related: #86201, #84771, #86003, #82894