### PR TITLE
feat(mcp): bridge slack channel actions through openclaw-tools MCP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- MCP/openclaw-tools: bridge the Slack channel-plugin actions through the OpenClaw-tools MCP server so Claude Code and other harnesses with `mcp__openclaw__*` allowed tools can react, send/edit/delete messages, read history, manage pins, fetch member info, and upload/download files instead of seeing Slack guidance in `skills/slack/SKILL.md` with no callable surface. Admin operations like channel/app creation remain out of scope. Refs #74757. Thanks @Tiger0710.
+
 ### Fixes
 
 - Codex: log when implicit app-server `never` approvals are promoted for OpenClaw tool policy, including whether the trigger was a `before_tool_call` hook or trusted tool policy.

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -8,6 +8,8 @@ metadata: { "openclaw": { "emoji": "💬", "requires": { "config": ["channels.sl
 
 Use the `slack` tool. Reuse `channelId` and Slack timestamp message IDs from context when present.
 
+Harnesses that only see `mcp__openclaw__*` tools (Claude Code, etc.) reach the same surface as `mcp__openclaw__slack` via the OpenClaw-tools MCP bridge; the tool name stays `slack` and the `action` parameter selects the operation. The bridge routes through the Slack channel plugin and uses the configured bot token; admin operations such as channel creation or app-manifest mutation are out of scope and not exposed here.
+
 ## Inputs
 
 - `channelId`: Slack channel ID.

--- a/src/agents/tools/slack-tool.test.ts
+++ b/src/agents/tools/slack-tool.test.ts
@@ -1,0 +1,324 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { callGatewayTool } from "./gateway.js";
+import { createSlackTool } from "./slack-tool.js";
+
+type GatewayCall = {
+  method: string;
+  opts: unknown;
+  request: {
+    channel: string;
+    action: string;
+    params: Record<string, unknown>;
+    accountId?: string;
+    idempotencyKey: string;
+  };
+};
+
+const callGatewayMock = vi.fn();
+
+const callGatewayStub: typeof callGatewayTool = async (method, opts, request) =>
+  callGatewayMock({ method, opts, request }) as never;
+
+function makeTool(): ReturnType<typeof createSlackTool> {
+  return createSlackTool({
+    callGatewayTool: callGatewayStub,
+    randomId: () => "idem-test",
+  });
+}
+
+function lastCall(): GatewayCall {
+  const call = callGatewayMock.mock.calls.at(-1)?.[0] as GatewayCall | undefined;
+  if (!call) {
+    throw new Error("expected gateway call");
+  }
+  return call;
+}
+
+beforeEach(() => {
+  callGatewayMock.mockReset();
+  callGatewayMock.mockResolvedValue({ ok: true });
+});
+
+describe("slack tool bridge", () => {
+  it("is not owner-only so harnesses can call it", () => {
+    const tool = makeTool();
+    expect(tool.ownerOnly).toBeFalsy();
+    expect(tool.name).toBe("slack");
+  });
+
+  it("dispatches to message.action with the slack channel id", async () => {
+    const tool = makeTool();
+    await tool.execute("call-1", {
+      action: "sendMessage",
+      to: "channel:C123",
+      content: "hi",
+    });
+    const call = lastCall();
+    expect(call.method).toBe("message.action");
+    expect(call.request.channel).toBe("slack");
+    expect(call.request.idempotencyKey).toBe("idem-test");
+  });
+
+  it("forwards accountId only when supplied", async () => {
+    const tool = makeTool();
+    await tool.execute("call-default", {
+      action: "sendMessage",
+      to: "channel:C123",
+      content: "hi",
+    });
+    expect(lastCall().request.accountId).toBeUndefined();
+
+    await tool.execute("call-account", {
+      action: "sendMessage",
+      to: "channel:C123",
+      content: "hi",
+      accountId: "team-a",
+    });
+    expect(lastCall().request.accountId).toBe("team-a");
+  });
+
+  describe("action mapping", () => {
+    it("maps react with optional remove", async () => {
+      const tool = makeTool();
+      await tool.execute("call", {
+        action: "react",
+        channelId: "C1",
+        messageId: "1.0",
+        emoji: "✅",
+      });
+      expect(lastCall().request).toMatchObject({
+        action: "react",
+        params: { channelId: "C1", messageId: "1.0", emoji: "✅" },
+      });
+      expect(lastCall().request.params).not.toHaveProperty("remove");
+
+      await tool.execute("call-remove", {
+        action: "react",
+        channelId: "C1",
+        messageId: "1.0",
+        emoji: "✅",
+        remove: true,
+      });
+      expect(lastCall().request.params).toMatchObject({ remove: true });
+    });
+
+    it("maps reactions list", async () => {
+      const tool = makeTool();
+      await tool.execute("call", {
+        action: "reactions",
+        channelId: "C1",
+        messageId: "1.0",
+        limit: 5,
+      });
+      expect(lastCall().request).toMatchObject({
+        action: "reactions",
+        params: { channelId: "C1", messageId: "1.0", limit: 5 },
+      });
+    });
+
+    it("sendMessage prefers `to` over channelId and threads via threadTs", async () => {
+      const tool = makeTool();
+      await tool.execute("call", {
+        action: "sendMessage",
+        channelId: "C1",
+        to: "user:U9",
+        content: "hi",
+        threadTs: "1.5",
+      });
+      expect(lastCall().request).toMatchObject({
+        action: "send",
+        params: { to: "user:U9", message: "hi", threadId: "1.5" },
+      });
+    });
+
+    it("sendMessage falls back to channelId when `to` is omitted", async () => {
+      const tool = makeTool();
+      await tool.execute("call", {
+        action: "sendMessage",
+        channelId: "C1",
+        content: "hi",
+      });
+      expect(lastCall().request.params).toMatchObject({ to: "C1" });
+    });
+
+    it("editMessage and deleteMessage map to edit/delete", async () => {
+      const tool = makeTool();
+      await tool.execute("c-edit", {
+        action: "editMessage",
+        channelId: "C1",
+        messageId: "1.0",
+        content: "fixed",
+      });
+      expect(lastCall().request).toMatchObject({
+        action: "edit",
+        params: { channelId: "C1", messageId: "1.0", message: "fixed" },
+      });
+
+      await tool.execute("c-del", {
+        action: "deleteMessage",
+        channelId: "C1",
+        messageId: "1.0",
+      });
+      expect(lastCall().request).toMatchObject({
+        action: "delete",
+        params: { channelId: "C1", messageId: "1.0" },
+      });
+    });
+
+    it("readMessages forwards window/threading params", async () => {
+      const tool = makeTool();
+      await tool.execute("call", {
+        action: "readMessages",
+        channelId: "C1",
+        limit: 20,
+        before: "1.9",
+        after: "1.1",
+        threadId: "1.5",
+      });
+      expect(lastCall().request).toMatchObject({
+        action: "read",
+        params: {
+          channelId: "C1",
+          limit: 20,
+          before: "1.9",
+          after: "1.1",
+          threadId: "1.5",
+        },
+      });
+    });
+
+    it("pin / unpin / list-pins", async () => {
+      const tool = makeTool();
+      await tool.execute("c-pin", {
+        action: "pinMessage",
+        channelId: "C1",
+        messageId: "1.0",
+      });
+      expect(lastCall().request).toMatchObject({
+        action: "pin",
+        params: { channelId: "C1", messageId: "1.0" },
+      });
+
+      await tool.execute("c-unpin", {
+        action: "unpinMessage",
+        channelId: "C1",
+        messageId: "1.0",
+      });
+      expect(lastCall().request).toMatchObject({
+        action: "unpin",
+        params: { channelId: "C1", messageId: "1.0" },
+      });
+
+      await tool.execute("c-list", { action: "listPins", channelId: "C1" });
+      expect(lastCall().request).toMatchObject({
+        action: "list-pins",
+        params: { channelId: "C1" },
+      });
+    });
+
+    it("memberInfo + emojiList", async () => {
+      const tool = makeTool();
+      await tool.execute("c-mem", { action: "memberInfo", userId: "U1" });
+      expect(lastCall().request).toMatchObject({
+        action: "member-info",
+        params: { userId: "U1" },
+      });
+
+      await tool.execute("c-emoji", { action: "emojiList", limit: 10 });
+      expect(lastCall().request).toMatchObject({
+        action: "emoji-list",
+        params: { limit: 10 },
+      });
+    });
+
+    it("uploadFile and downloadFile", async () => {
+      const tool = makeTool();
+      await tool.execute("c-up", {
+        action: "uploadFile",
+        to: "channel:C1",
+        filePath: "/tmp/a.png",
+        initialComment: "look",
+        filename: "a.png",
+        title: "A",
+        threadTs: "1.5",
+      });
+      expect(lastCall().request).toMatchObject({
+        action: "upload-file",
+        params: {
+          to: "channel:C1",
+          filePath: "/tmp/a.png",
+          initialComment: "look",
+          filename: "a.png",
+          title: "A",
+          threadId: "1.5",
+        },
+      });
+
+      await tool.execute("c-down", {
+        action: "downloadFile",
+        fileId: "F1",
+        channelId: "C1",
+        threadId: "1.5",
+      });
+      expect(lastCall().request).toMatchObject({
+        action: "download-file",
+        params: { fileId: "F1", channelId: "C1", threadId: "1.5" },
+      });
+    });
+  });
+
+  describe("validation", () => {
+    it("rejects unknown action", async () => {
+      const tool = makeTool();
+      await expect(tool.execute("call", { action: "nope" })).rejects.toThrow(
+        /Unknown slack action/,
+      );
+      expect(callGatewayMock).not.toHaveBeenCalled();
+    });
+
+    it("requires channelId/messageId for react", async () => {
+      const tool = makeTool();
+      await expect(tool.execute("call", { action: "react", emoji: "✅" })).rejects.toThrow(
+        /channelId required/,
+      );
+      await expect(
+        tool.execute("call", { action: "react", channelId: "C1", emoji: "✅" }),
+      ).rejects.toThrow(/messageId required/);
+    });
+
+    it("sendMessage requires `to` or channelId", async () => {
+      const tool = makeTool();
+      await expect(tool.execute("call", { action: "sendMessage", content: "hi" })).rejects.toThrow(
+        /to or channelId required/,
+      );
+    });
+
+    it("uploadFile requires filePath and target", async () => {
+      const tool = makeTool();
+      await expect(
+        tool.execute("call", { action: "uploadFile", to: "channel:C1" }),
+      ).rejects.toThrow(/filePath/);
+      await expect(
+        tool.execute("call", { action: "uploadFile", filePath: "/tmp/a" }),
+      ).rejects.toThrow(/to or channelId required/);
+    });
+
+    it("downloadFile requires fileId", async () => {
+      const tool = makeTool();
+      await expect(tool.execute("call", { action: "downloadFile" })).rejects.toThrow(/fileId/);
+    });
+
+    it("memberInfo requires userId", async () => {
+      const tool = makeTool();
+      await expect(tool.execute("call", { action: "memberInfo" })).rejects.toThrow(/userId/);
+    });
+  });
+
+  describe("description", () => {
+    it("documents the bridge boundary and refuses admin operations", () => {
+      const tool = makeTool();
+      expect(tool.description).toContain("skills/slack/SKILL.md");
+      expect(tool.description).toContain("does not unlock admin-token operations");
+    });
+  });
+});

--- a/src/agents/tools/slack-tool.ts
+++ b/src/agents/tools/slack-tool.ts
@@ -1,0 +1,339 @@
+import { randomUUID } from "node:crypto";
+import { Type } from "typebox";
+import { stringEnum } from "../schema/typebox.js";
+import { type AnyAgentTool, jsonResult, readNumberParam, readStringParam } from "./common.js";
+import { callGatewayTool, readGatewayCallOptions, type GatewayCallOptions } from "./gateway.js";
+
+const SLACK_CHANNEL_ID = "slack";
+
+const SLACK_TOOL_ACTIONS = [
+  "react",
+  "reactions",
+  "sendMessage",
+  "editMessage",
+  "deleteMessage",
+  "readMessages",
+  "pinMessage",
+  "unpinMessage",
+  "listPins",
+  "memberInfo",
+  "emojiList",
+  "uploadFile",
+  "downloadFile",
+] as const;
+
+type SlackToolAction = (typeof SLACK_TOOL_ACTIONS)[number];
+
+const SlackToolSchema = Type.Object(
+  {
+    action: stringEnum(SLACK_TOOL_ACTIONS, {
+      description: "Slack action to invoke. Mirrors the verbs documented in skills/slack/SKILL.md.",
+    }),
+    accountId: Type.Optional(
+      Type.String({ description: "Slack account id when multiple accounts are configured." }),
+    ),
+    channelId: Type.Optional(
+      Type.String({ description: "Slack channel id (e.g. C123) for channel-scoped actions." }),
+    ),
+    to: Type.Optional(
+      Type.String({
+        description:
+          'Send target ("channel:<id>", "user:<id>", or a bare channel id) for sendMessage/uploadFile.',
+      }),
+    ),
+    messageId: Type.Optional(
+      Type.String({ description: "Slack message timestamp, e.g. 1712023032.1234." }),
+    ),
+    threadTs: Type.Optional(
+      Type.String({ description: "Thread root timestamp for threaded sends/uploads." }),
+    ),
+    threadId: Type.Optional(
+      Type.String({ description: "Thread id used by readMessages and downloadFile." }),
+    ),
+    content: Type.Optional(
+      Type.String({ description: "Message body for sendMessage/editMessage." }),
+    ),
+    emoji: Type.Optional(
+      Type.String({
+        description: "Reaction emoji name (Unicode or :name:). Required when adding a reaction.",
+      }),
+    ),
+    remove: Type.Optional(
+      Type.Boolean({ description: "Set true to remove a reaction instead of adding it." }),
+    ),
+    userId: Type.Optional(Type.String({ description: "Slack user id for memberInfo." })),
+    fileId: Type.Optional(Type.String({ description: "Slack file id for downloadFile." })),
+    filePath: Type.Optional(
+      Type.String({
+        description: "Local file path to upload (uploadFile only).",
+      }),
+    ),
+    initialComment: Type.Optional(
+      Type.String({ description: "Optional comment to send with an uploaded file." }),
+    ),
+    filename: Type.Optional(Type.String({ description: "Override filename for uploadFile." })),
+    title: Type.Optional(Type.String({ description: "Override title for uploadFile." })),
+    limit: Type.Optional(
+      Type.Number({ description: "Result limit for readMessages/reactions/emojiList." }),
+    ),
+    before: Type.Optional(Type.String({ description: "Read messages before this timestamp." })),
+    after: Type.Optional(Type.String({ description: "Read messages after this timestamp." })),
+    gatewayUrl: Type.Optional(Type.String()),
+    gatewayToken: Type.Optional(Type.String()),
+    timeoutMs: Type.Optional(Type.Number()),
+  },
+  { additionalProperties: true },
+);
+
+type SlackGatewayCall = (params: {
+  channel: string;
+  action: string;
+  params: Record<string, unknown>;
+  accountId?: string;
+  idempotencyKey: string;
+}) => Promise<unknown>;
+
+export type SlackToolDeps = {
+  callGatewayTool?: typeof callGatewayTool;
+  randomId?: () => string;
+};
+
+function pickDefined(value: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (entry !== undefined) {
+      out[key] = entry;
+    }
+  }
+  return out;
+}
+
+function buildSlackActionRequest(
+  action: SlackToolAction,
+  params: Record<string, unknown>,
+): { agnosticAction: string; actionParams: Record<string, unknown> } {
+  const channelId = readStringParam(params, "channelId");
+  const messageId = readStringParam(params, "messageId");
+  const to = readStringParam(params, "to");
+  const threadTs = readStringParam(params, "threadTs");
+  const threadId = readStringParam(params, "threadId");
+
+  switch (action) {
+    case "react": {
+      if (!channelId) {
+        throw new Error("channelId required");
+      }
+      if (!messageId) {
+        throw new Error("messageId required");
+      }
+      const remove = typeof params.remove === "boolean" ? params.remove : undefined;
+      return {
+        agnosticAction: "react",
+        actionParams: pickDefined({
+          channelId,
+          messageId,
+          emoji: readStringParam(params, "emoji", { allowEmpty: true }),
+          ...(remove !== undefined ? { remove } : {}),
+        }),
+      };
+    }
+    case "reactions": {
+      if (!channelId) {
+        throw new Error("channelId required");
+      }
+      if (!messageId) {
+        throw new Error("messageId required");
+      }
+      return {
+        agnosticAction: "reactions",
+        actionParams: pickDefined({
+          channelId,
+          messageId,
+          limit: readNumberParam(params, "limit", { integer: true }),
+        }),
+      };
+    }
+    case "sendMessage": {
+      const target = to ?? channelId;
+      if (!target) {
+        throw new Error("to or channelId required");
+      }
+      const content = readStringParam(params, "content", { allowEmpty: true });
+      return {
+        agnosticAction: "send",
+        actionParams: pickDefined({
+          to: target,
+          message: content,
+          threadId: threadTs ?? threadId,
+        }),
+      };
+    }
+    case "editMessage": {
+      if (!channelId) {
+        throw new Error("channelId required");
+      }
+      if (!messageId) {
+        throw new Error("messageId required");
+      }
+      const content = readStringParam(params, "content", { allowEmpty: true });
+      return {
+        agnosticAction: "edit",
+        actionParams: pickDefined({ channelId, messageId, message: content }),
+      };
+    }
+    case "deleteMessage": {
+      if (!channelId) {
+        throw new Error("channelId required");
+      }
+      if (!messageId) {
+        throw new Error("messageId required");
+      }
+      return {
+        agnosticAction: "delete",
+        actionParams: { channelId, messageId },
+      };
+    }
+    case "readMessages": {
+      if (!channelId) {
+        throw new Error("channelId required");
+      }
+      return {
+        agnosticAction: "read",
+        actionParams: pickDefined({
+          channelId,
+          limit: readNumberParam(params, "limit", { integer: true }),
+          before: readStringParam(params, "before"),
+          after: readStringParam(params, "after"),
+          threadId,
+        }),
+      };
+    }
+    case "pinMessage": {
+      if (!channelId) {
+        throw new Error("channelId required");
+      }
+      if (!messageId) {
+        throw new Error("messageId required");
+      }
+      return {
+        agnosticAction: "pin",
+        actionParams: { channelId, messageId },
+      };
+    }
+    case "unpinMessage": {
+      if (!channelId) {
+        throw new Error("channelId required");
+      }
+      if (!messageId) {
+        throw new Error("messageId required");
+      }
+      return {
+        agnosticAction: "unpin",
+        actionParams: { channelId, messageId },
+      };
+    }
+    case "listPins": {
+      if (!channelId) {
+        throw new Error("channelId required");
+      }
+      return {
+        agnosticAction: "list-pins",
+        actionParams: { channelId },
+      };
+    }
+    case "memberInfo": {
+      const userId = readStringParam(params, "userId", { required: true });
+      return {
+        agnosticAction: "member-info",
+        actionParams: { userId },
+      };
+    }
+    case "emojiList": {
+      return {
+        agnosticAction: "emoji-list",
+        actionParams: pickDefined({
+          limit: readNumberParam(params, "limit", { integer: true }),
+        }),
+      };
+    }
+    case "uploadFile": {
+      const target = to ?? channelId;
+      if (!target) {
+        throw new Error("to or channelId required");
+      }
+      const filePath = readStringParam(params, "filePath", { required: true, trim: false });
+      return {
+        agnosticAction: "upload-file",
+        actionParams: pickDefined({
+          to: target,
+          filePath,
+          initialComment: readStringParam(params, "initialComment", { allowEmpty: true }),
+          filename: readStringParam(params, "filename"),
+          title: readStringParam(params, "title"),
+          threadId: threadTs ?? threadId,
+        }),
+      };
+    }
+    case "downloadFile": {
+      const fileId = readStringParam(params, "fileId", { required: true });
+      return {
+        agnosticAction: "download-file",
+        actionParams: pickDefined({ fileId, channelId, threadId }),
+      };
+    }
+    default: {
+      const exhaustive: never = action;
+      throw new Error(`Unsupported slack action: ${exhaustive as string}`);
+    }
+  }
+}
+
+export const SLACK_TOOL_DISPLAY_SUMMARY = "Bridge to the Slack channel plugin's actions.";
+
+export function createSlackTool(deps?: SlackToolDeps): AnyAgentTool {
+  const callGateway = deps?.callGatewayTool ?? callGatewayTool;
+  const newId = deps?.randomId ?? (() => randomUUID());
+  return {
+    label: "Slack",
+    name: "slack",
+    displaySummary: SLACK_TOOL_DISPLAY_SUMMARY,
+    description: `Invoke Slack channel actions through the Gateway. Action names match skills/slack/SKILL.md.
+
+Routes through the gateway message.action method, which dispatches to the Slack channel plugin and uses the configured Slack account credentials. Requires channels.slack to be configured. The tool only exposes the action surface advertised by skills/slack/SKILL.md and does not unlock admin-token operations such as conversations.create or apps.manifest.create.
+
+Common parameters: channelId (e.g. C123), messageId (Slack message timestamp), to ("channel:<id>" / "user:<id>" / bare id), content (message body), emoji (Unicode or :name:), threadTs (thread root timestamp).
+
+Examples:
+- React: { "action": "react", "channelId": "C123", "messageId": "1712023032.1234", "emoji": "✅" }
+- Send: { "action": "sendMessage", "to": "channel:C123", "content": "Hello" }
+- Read: { "action": "readMessages", "channelId": "C123", "limit": 20 }
+- Pin:  { "action": "pinMessage", "channelId": "C123", "messageId": "1712023032.1234" }`,
+    parameters: SlackToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = (args ?? {}) as Record<string, unknown>;
+      const action = readStringParam(params, "action", { required: true }) as SlackToolAction;
+      if (!SLACK_TOOL_ACTIONS.includes(action)) {
+        throw new Error(`Unknown slack action: ${action}`);
+      }
+      const accountId = readStringParam(params, "accountId");
+      const { agnosticAction, actionParams } = buildSlackActionRequest(action, params);
+      const gatewayOpts: GatewayCallOptions = {
+        ...readGatewayCallOptions(params),
+        timeoutMs:
+          typeof params.timeoutMs === "number" && Number.isFinite(params.timeoutMs)
+            ? params.timeoutMs
+            : 60_000,
+      };
+      const callable: SlackGatewayCall = async (request) =>
+        await callGateway("message.action", gatewayOpts, request);
+      const result = await callable({
+        channel: SLACK_CHANNEL_ID,
+        action: agnosticAction,
+        params: actionParams,
+        ...(accountId ? { accountId } : {}),
+        idempotencyKey: newId(),
+      });
+      return jsonResult(result);
+    },
+  };
+}

--- a/src/mcp/openclaw-tools-serve.test.ts
+++ b/src/mcp/openclaw-tools-serve.test.ts
@@ -9,4 +9,31 @@ describe("OpenClaw tools MCP server", () => {
     const listed = await handlers.listTools();
     expect(listed.tools.map((tool) => tool.name)).toContain("cron");
   });
+
+  it("exposes the slack action bridge so harnesses can call channel actions", async () => {
+    const handlers = createPluginToolsMcpHandlers(resolveOpenClawToolsForMcp());
+    const listed = await handlers.listTools();
+    const slack = listed.tools.find((tool) => tool.name === "slack");
+    expect(slack).toBeDefined();
+
+    const schema = slack?.inputSchema as { properties?: Record<string, unknown> };
+    const action = schema.properties?.action as { enum?: unknown[] } | undefined;
+    expect(action?.enum).toEqual(
+      expect.arrayContaining([
+        "react",
+        "reactions",
+        "sendMessage",
+        "editMessage",
+        "deleteMessage",
+        "readMessages",
+        "pinMessage",
+        "unpinMessage",
+        "listPins",
+        "memberInfo",
+        "emojiList",
+        "uploadFile",
+        "downloadFile",
+      ]),
+    );
+  });
 });

--- a/src/mcp/openclaw-tools-serve.ts
+++ b/src/mcp/openclaw-tools-serve.ts
@@ -8,11 +8,12 @@ import { pathToFileURL } from "node:url";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import { createCronTool } from "../agents/tools/cron-tool.js";
+import { createSlackTool } from "../agents/tools/slack-tool.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { connectToolsMcpServerToStdio, createToolsMcpServer } from "./tools-stdio-server.js";
 
 export function resolveOpenClawToolsForMcp(): AnyAgentTool[] {
-  return [createCronTool()];
+  return [createCronTool(), createSlackTool()];
 }
 
 function createOpenClawToolsMcpServer(


### PR DESCRIPTION
## Summary

Adds a thin MCP bridge so Claude Code (and any other harness restricted to `mcp__openclaw__*` tools) can call the Slack actions that `skills/slack/SKILL.md` already documents.

Today Slack is registered through `defineBundledChannelEntry`, which means it never enters the bundle/MCP tool catalog (`src/plugins/bundle-config-shared.ts` only keeps `record.format === "bundle"`), and Claude Code is launched with `--allowedTools "mcp__openclaw__*"` (`extensions/anthropic/cli-backend.ts`). The skill lists actions like `react`/`sendMessage`/`pinMessage`, but the agent has no callable tool — a footgun the maintainer review explicitly called out in #74757.

This PR re-exposes the existing Slack channel-plugin actions through the OpenClaw-tools MCP server (the same path used by `cron`):

- `react`, `reactions`
- `sendMessage`, `editMessage`, `deleteMessage`, `readMessages`
- `pinMessage`, `unpinMessage`, `listPins`
- `memberInfo`, `emojiList`
- `uploadFile`, `downloadFile`

The tool is a parameter-mapper only: it forwards to the gateway `message.action` method with `channel: "slack"`, so account scoping, credentials, and dispatch logic stay in the channel plugin. The agent surface stays a single tool (`slack`) with a typed `action` enum — same shape Claude Code already expects from `mcp__openclaw__*` entries.

Admin operations like `conversations.create`, `users.lookupByEmail`, and `apps.manifest.create` are intentionally **out of scope** of this PR. Those need new tokens (`userToken`, `appConfigToken`) and an explicit opt-in story; they will land in follow-up PRs (issue #74757 part 2).

This corresponds to direction **(a)** from the issue update (MCP bridge over the existing channel plugin), which the issue thread settled on as the smallest reviewable shape. The complementary skill-loading guard (direction **(b)**) is a separate small PR.

## Changes

- `src/agents/tools/slack-tool.ts`: new agent tool that maps the action enum + parameters to the existing Slack channel plugin contract and dispatches via `callGatewayTool("message.action", …)`. Each action enforces its required parameters; default 60s timeout; idempotency key per call.
- `src/mcp/openclaw-tools-serve.ts`: register `createSlackTool()` next to `createCronTool()` in `resolveOpenClawToolsForMcp()`.
- `src/agents/tools/slack-tool.test.ts`: 19 unit tests covering action-to-channel-action mapping, account scoping, send-target precedence (`to` over `channelId`), validation errors, and that the tool is not `ownerOnly`.
- `src/mcp/openclaw-tools-serve.test.ts`: assert the MCP catalog lists `slack` with the full action enum.
- `skills/slack/SKILL.md`: short note that harnesses on `mcp__openclaw__*` reach the same surface as `mcp__openclaw__slack` through this bridge, and that admin operations stay out of scope.
- `CHANGELOG.md`: Unreleased entry under Changes.

## Tests

```
node scripts/run-vitest.mjs \
  src/agents/tools/slack-tool.test.ts \
  src/mcp/openclaw-tools-serve.test.ts
# 40 passed, 3 files

node scripts/run-vitest.mjs \
  extensions/slack/src/message-tools.test.ts \
  extensions/slack/src/channel.test.ts \
  extensions/slack/src/message-action-dispatch.test.ts \
  extensions/slack/src/action-runtime.test.ts \
  extensions/slack/src/channel-actions-setup-status.contract.test.ts \
  src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
# 155 passed, 6 files (existing Slack channel suite still green)
```

oxlint and oxfmt clean on the touched files.

## Notes for maintainers (@steipete)

Posting this as the answer to the direction question on #74757 — Q1 = (a) MCP bridge, Q2 = admin ops stay default-off and land in a separate PR series, Q3 = starting now rather than waiting; happy to iterate on this and the follow-up PRs.

Refs #74757
