### PR TITLE
fix: exclude active trajectories from session disk budget

### DIFF
--- a/src/config/sessions/disk-budget.test.ts
+++ b/src/config/sessions/disk-budget.test.ts
@@ -244,6 +244,49 @@ describe("enforceSessionDiskBudget", () => {
     });
   });
 
+  it("excludes referenced trajectory sidecars from conversation disk pressure", async () => {
+    await withTempDir({ prefix: "openclaw-disk-budget-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const sessionId = "active-trajectory";
+      const transcriptPath = path.join(dir, `${sessionId}.jsonl`);
+      const referencedRuntime = resolveTrajectoryFilePath({
+        env: {},
+        sessionFile: transcriptPath,
+        sessionId,
+      });
+      const referencedPointer = resolveTrajectoryPointerFilePath(transcriptPath);
+      const store: Record<string, SessionEntry> = {
+        "agent:main:main": {
+          sessionId,
+          updatedAt: Date.now(),
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf-8");
+      await fs.writeFile(transcriptPath, "t".repeat(80), "utf-8");
+      await fs.writeFile(referencedRuntime, "r".repeat(5000), "utf-8");
+      await fs.writeFile(referencedPointer, "p".repeat(5000), "utf-8");
+
+      const result = await enforceSessionDiskBudget({
+        store,
+        storePath,
+        activeSessionKey: "agent:main:main",
+        maintenance: {
+          maxDiskBytes: 1000,
+          highWaterBytes: 800,
+        },
+        warnOnly: false,
+      });
+
+      await expectPathExists(transcriptPath);
+      await expectPathExists(referencedRuntime);
+      await expectPathExists(referencedPointer);
+      expectBudgetResult(result);
+      expect(result.overBudget).toBe(false);
+      expect(result.removedFiles).toBe(0);
+      expect(result.removedEntries).toBe(0);
+    });
+  });
+
   it("does not evict protected thread session entries under store pressure", async () => {
     await withTempDir({ prefix: "openclaw-disk-budget-" }, async (dir) => {
       const storePath = path.join(dir, "sessions.json");

--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -238,6 +238,16 @@ function isDiskBudgetRemovableSessionFile(
   );
 }
 
+function isDiskBudgetCountedSessionFile(
+  file: Pick<SessionsDirFileStat, "canonicalPath" | "name">,
+  referencedPaths: ReadonlySet<string>,
+): boolean {
+  if (isTrajectorySessionArtifactName(file.name) && referencedPaths.has(file.canonicalPath)) {
+    return false;
+  }
+  return true;
+}
+
 async function removeFileIfExists(filePath: string): Promise<number> {
   const stat = await fs.promises.stat(filePath).catch(() => null);
   if (!stat?.isFile()) {
@@ -349,12 +359,26 @@ export async function enforceSessionDiskBudget(params: {
   const sessionsDir = path.dirname(params.storePath);
   const files = await readSessionsDirFiles(sessionsDir);
   const fileSizesByPath = new Map(files.map((file) => [file.canonicalPath, file.size]));
+  const referencedPaths = resolveReferencedSessionArtifactPaths({
+    sessionsDir,
+    store: params.store,
+  });
+  const budgetCountedFileSizesByPath = new Map(
+    files
+      .filter((file) => isDiskBudgetCountedSessionFile(file, referencedPaths))
+      .map((file) => [file.canonicalPath, file.size]),
+  );
   const simulatedRemovedPaths = new Set<string>();
   const resolvedStorePath = canonicalizePathForComparison(params.storePath);
   const storeFile = files.find((file) => file.canonicalPath === resolvedStorePath);
   let projectedStoreBytes = measureStoreBytes(params.store);
   let total =
-    files.reduce((sum, file) => sum + file.size, 0) - (storeFile?.size ?? 0) + projectedStoreBytes;
+    files.reduce(
+      (sum, file) => sum + (budgetCountedFileSizesByPath.get(file.canonicalPath) ?? 0),
+      0,
+    ) -
+    (budgetCountedFileSizesByPath.get(storeFile?.canonicalPath ?? "") ?? 0) +
+    projectedStoreBytes;
   const totalBefore = total;
   if (total <= maxBytes) {
     return {
@@ -392,10 +416,6 @@ export async function enforceSessionDiskBudget(params: {
   let removedEntries = 0;
   let freedBytes = 0;
 
-  const referencedPaths = resolveReferencedSessionArtifactPaths({
-    sessionsDir,
-    store: params.store,
-  });
   const removableFileQueue = files
     .filter((file) => isDiskBudgetRemovableSessionFile(file, referencedPaths))
     .toSorted((a, b) => a.mtimeMs - b.mtimeMs);
@@ -414,7 +434,7 @@ export async function enforceSessionDiskBudget(params: {
     if (deletedBytes <= 0) {
       continue;
     }
-    total -= deletedBytes;
+    total -= budgetCountedFileSizesByPath.get(file.canonicalPath) ?? 0;
     freedBytes += deletedBytes;
     removedFiles += 1;
   }
@@ -466,8 +486,10 @@ export async function enforceSessionDiskBudget(params: {
       }
       sessionIdRefCounts.delete(sessionId);
       for (const artifactPath of resolveSessionArtifactPathsForEntry({ sessionsDir, entry })) {
+        const canonicalArtifactPath = canonicalizePathForComparison(artifactPath);
         const deletedBytes = await removeFileForBudget({
           filePath: artifactPath,
+          canonicalPath: canonicalArtifactPath,
           dryRun,
           fileSizesByPath,
           simulatedRemovedPaths,
@@ -476,7 +498,7 @@ export async function enforceSessionDiskBudget(params: {
         if (deletedBytes <= 0) {
           continue;
         }
-        total -= deletedBytes;
+        total -= budgetCountedFileSizesByPath.get(canonicalArtifactPath) ?? 0;
         freedBytes += deletedBytes;
         removedFiles += 1;
       }


### PR DESCRIPTION
Summary
- Exclude referenced trajectory runtime/pointer sidecars from the conversation session disk budget so active reasoning telemetry does not make protected live sessions look over-budget.
- Keep unreferenced trajectory sidecars removable under disk pressure, preserving the existing orphan cleanup behaviour.
- Add regression coverage for active same-day trajectory files pushing physical session-dir size above the configured max.

## Real Behavior Proof

- Behavior addressed: Active same-day trajectory sidecars should not make a protected live conversation session exceed the conversation session disk budget.
- Real environment tested: macOS Darwin arm64 on the local OpenClaw checkout, Node v22.22.3.
- Exact steps or command run after this patch: Ran a live OpenClaw disk-budget invocation with a temporary session store containing an active transcript plus referenced trajectory runtime and pointer files. The physical session directory was 6,950 bytes while maxDiskBytes was 1,000 and highWaterBytes was 800.
- Evidence after fix: Terminal output from the patched OpenClaw source:

```text
OpenClaw real behavior proof on darwin/arm64, Node v22.22.3
physical_session_dir_bytes_before=6950
budget_max_bytes=1000 high_water_bytes=800
files_before=live-active-trajectory-proof.jsonl,live-active-trajectory-proof.trajectory-path.json,live-active-trajectory-proof.trajectory.jsonl,sessions.json
disk_budget_result={"totalBytesBefore":123,"totalBytesAfter":123,"removedFiles":0,"removedEntries":0,"freedBytes":0,"maxBytes":1000,"highWaterBytes":800,"overBudget":false}
files_after=live-active-trajectory-proof.jsonl,live-active-trajectory-proof.trajectory-path.json,live-active-trajectory-proof.trajectory.jsonl,sessions.json
```

- Observed result after fix: The active referenced trajectory runtime and pointer files remained present, no session entries or files were removed, and the disk-budget result reported overBudget=false because referenced trajectory telemetry was excluded from the conversation-session budget.
- What was not tested: A full installed gateway restart was not run for this PR because the change is scoped to session disk-budget accounting, not channel startup or provider auth.

Verification
- node scripts/run-vitest.mjs src/config/sessions/disk-budget.test.ts src/config/sessions/store.pruning.integration.test.ts
- corepack pnpm exec oxfmt --check --threads=1 src/config/sessions/disk-budget.ts src/config/sessions/disk-budget.test.ts
- corepack pnpm exec oxlint src/config/sessions/disk-budget.ts src/config/sessions/disk-budget.test.ts
- git diff --check

Refs
- Addresses the trajectory-specific budget pressure reported in #85025.