### PR TITLE
fix(cli): handle Bun optional import misses

### DIFF
--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -262,16 +262,19 @@ const isDirectModuleNotFoundError = (err, specifier) => {
     message.includes(`Cannot find module "${specifier}"`);
 
   const expectedUrl = new URL(specifier, import.meta.url);
-  if (err && typeof err === "object" && "url" in err && err.url === expectedUrl.href) {
-    return true;
-  }
-
   const expectedPath = fileURLToPath(expectedUrl);
   const nodePathMiss =
     message.includes(`Cannot find module '${expectedPath}'`) ||
     message.includes(`Cannot find module "${expectedPath}"`);
 
-  return isModuleNotFoundError(err) ? nodePathMiss : bunSpecifierMiss;
+  if (isModuleNotFoundError(err)) {
+    if (err && typeof err === "object" && "url" in err && err.url === expectedUrl.href) {
+      return true;
+    }
+    return nodePathMiss;
+  }
+
+  return bunSpecifierMiss;
 };
 
 const installProcessWarningFilter = async () => {

--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -271,7 +271,7 @@ const isDirectModuleNotFoundError = (err, specifier) => {
     if (err && typeof err === "object" && "url" in err && err.url === expectedUrl.href) {
       return true;
     }
-    return nodePathMiss;
+    return nodePathMiss || bunSpecifierMiss;
   }
 
   return bunSpecifierMiss;

--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -247,25 +247,31 @@ if (
   }
 }
 
+const getErrorMessage = (err) =>
+  err && typeof err === "object" && "message" in err && typeof err.message === "string"
+    ? err.message
+    : "";
+
 const isModuleNotFoundError = (err) =>
   err && typeof err === "object" && "code" in err && err.code === "ERR_MODULE_NOT_FOUND";
 
 const isDirectModuleNotFoundError = (err, specifier) => {
-  if (!isModuleNotFoundError(err)) {
-    return false;
-  }
+  const message = getErrorMessage(err);
+  const bunSpecifierMiss =
+    message.includes(`Cannot find module '${specifier}'`) ||
+    message.includes(`Cannot find module "${specifier}"`);
 
   const expectedUrl = new URL(specifier, import.meta.url);
-  if ("url" in err && err.url === expectedUrl.href) {
+  if (err && typeof err === "object" && "url" in err && err.url === expectedUrl.href) {
     return true;
   }
 
-  const message = "message" in err && typeof err.message === "string" ? err.message : "";
   const expectedPath = fileURLToPath(expectedUrl);
-  return (
+  const nodePathMiss =
     message.includes(`Cannot find module '${expectedPath}'`) ||
-    message.includes(`Cannot find module "${expectedPath}"`)
-  );
+    message.includes(`Cannot find module "${expectedPath}"`);
+
+  return isModuleNotFoundError(err) ? nodePathMiss : bunSpecifierMiss;
 };
 
 const installProcessWarningFilter = async () => {

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -15,6 +15,26 @@ async function makeLauncherFixture(fixtureRoots: string[]): Promise<string> {
   return fixtureRoot;
 }
 
+async function makeLauncherProbeFixture(
+  fixtureRoots: string[],
+  probeSource: string,
+): Promise<string> {
+  const fixtureRoot = await makeLauncherFixture(fixtureRoots);
+  const launcherPath = path.join(fixtureRoot, "openclaw.mjs");
+  const launcher = await fs.readFile(launcherPath, "utf8");
+  const bootstrapStart = "\nif (!waitingForCompileCacheRespawn) {";
+  const bootstrapIndex = launcher.indexOf(bootstrapStart);
+  if (bootstrapIndex < 0) {
+    throw new Error("openclaw launcher bootstrap block was not found");
+  }
+  await fs.writeFile(
+    launcherPath,
+    `${launcher.slice(0, bootstrapIndex)}\n${probeSource}\n`,
+    "utf8",
+  );
+  return fixtureRoot;
+}
+
 async function addSourceTreeMarker(fixtureRoot: string): Promise<void> {
   await fs.mkdir(path.join(fixtureRoot, "src"), { recursive: true });
   await fs.writeFile(path.join(fixtureRoot, "src", "entry.ts"), "export {};\n", "utf8");
@@ -201,6 +221,34 @@ describe("openclaw launcher", () => {
 
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain("missing dist/entry.(m)js");
+  });
+
+  it("treats Bun direct optional import misses as direct launcher misses", async () => {
+    const fixtureRoot = await makeLauncherProbeFixture(
+      fixtureRoots,
+      [
+        "const result = {",
+        "  direct: isDirectModuleNotFoundError(",
+        "    { message: \"Cannot find module './dist/warning-filter.js' from '/pkg/openclaw/openclaw.mjs'\" },",
+        "    './dist/warning-filter.js',",
+        "  ),",
+        "  transitive: isDirectModuleNotFoundError(",
+        "    { message: \"Cannot find module './nested.js' from '/pkg/openclaw/dist/entry.js'\" },",
+        "    './dist/entry.js',",
+        "  ),",
+        "};",
+        "process.stdout.write(`${JSON.stringify(result)}\\n`);",
+      ].join("\n"),
+    );
+
+    const result = spawnSync(process.execPath, [path.join(fixtureRoot, "openclaw.mjs")], {
+      cwd: fixtureRoot,
+      env: launcherEnv(),
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({ direct: true, transitive: false });
   });
 
   it("uses precomputed root help when plugin config does not invalidate it", async () => {

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -232,6 +232,10 @@ describe("openclaw launcher", () => {
         "    { message: \"Cannot find module './dist/warning-filter.js' from '/pkg/openclaw/openclaw.mjs'\" },",
         "    './dist/warning-filter.js',",
         "  ),",
+        "  directWithCode: isDirectModuleNotFoundError(",
+        "    { code: 'ERR_MODULE_NOT_FOUND', message: \"Cannot find module './dist/warning-filter.js' from '/pkg/openclaw/openclaw.mjs'\" },",
+        "    './dist/warning-filter.js',",
+        "  ),",
         "  transitive: isDirectModuleNotFoundError(",
         "    { message: \"Cannot find module './nested.js' from '/pkg/openclaw/dist/entry.js'\" },",
         "    './dist/entry.js',",
@@ -258,6 +262,7 @@ describe("openclaw launcher", () => {
     expect(result.status).toBe(0);
     expect(JSON.parse(result.stdout)).toEqual({
       direct: true,
+      directWithCode: true,
       nonModulePath: false,
       nonModuleUrl: false,
       transitive: false,

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -236,6 +236,14 @@ describe("openclaw launcher", () => {
         "    { message: \"Cannot find module './nested.js' from '/pkg/openclaw/dist/entry.js'\" },",
         "    './dist/entry.js',",
         "  ),",
+        "  nonModuleUrl: isDirectModuleNotFoundError(",
+        "    { message: 'boom', url: new URL('./dist/warning-filter.js', import.meta.url).href },",
+        "    './dist/warning-filter.js',",
+        "  ),",
+        "  nonModulePath: isDirectModuleNotFoundError(",
+        "    { message: `Cannot find module '${fileURLToPath(new URL('./dist/warning-filter.js', import.meta.url))}'` },",
+        "    './dist/warning-filter.js',",
+        "  ),",
         "};",
         "process.stdout.write(`${JSON.stringify(result)}\\n`);",
       ].join("\n"),
@@ -248,7 +256,12 @@ describe("openclaw launcher", () => {
     });
 
     expect(result.status).toBe(0);
-    expect(JSON.parse(result.stdout)).toEqual({ direct: true, transitive: false });
+    expect(JSON.parse(result.stdout)).toEqual({
+      direct: true,
+      nonModulePath: false,
+      nonModuleUrl: false,
+      transitive: false,
+    });
   });
 
   it("uses precomputed root help when plugin config does not invalidate it", async () => {


### PR DESCRIPTION
Fixes #86198

## Summary
- Recognize Bun-style direct module-miss messages in the launcher optional-import guard.
- Keep Node direct misses supported through `ERR_MODULE_NOT_FOUND`, URL, and absolute-path checks.
- Preserve the transitive-miss behavior so missing dependencies from `dist/entry.js` are still surfaced instead of being treated as missing OpenClaw build output.

## Verification
- `node scripts/run-vitest.mjs --config test/vitest/vitest.e2e.config.ts test/openclaw-launcher.e2e.test.ts --reporter=dot` -> 1 file, 23 tests passed
- `./node_modules/.bin/oxfmt --check openclaw.mjs test/openclaw-launcher.e2e.test.ts`
- `./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.core.json openclaw.mjs test/openclaw-launcher.e2e.test.ts`
- `git diff --check refs/remotes/upstream-safe/main...HEAD`
- `git diff --check`

## Live Bun proof
- Head tested: `459e76e8b7efef8fe3bb5c3ab3cc86040c4e9886`
- Environment: WSL Ubuntu-24.04 under `/root/src/openclaw-86198`, Bun `1.3.14`
- Command shape: built temporary launcher fixtures that execute `openclaw.mjs` under Bun with one fixture where the optional warning-filter/root-help imports are missing and `dist/entry.js` exists, and one fixture where `dist/entry.js` exists but imports a missing transitive dependency.
- Observed output: optional fixture returned `optional_status=0` and printed `entry-reached-after-missing-warning-filter-and-root-help`.
- Preserved failure behavior: transitive fixture returned `transitive_status=1` and printed `Cannot find package 'missing-openclaw-launcher-dep' from '<temp>/transitive/dist/entry.js'`.
- Remaining gap: this proof exercises the affected launcher surface locally under Bun; it does not use a published package artifact.

Note: refreshed commits are SSH-signed locally and verified with `git log --show-signature -1`.