### PR TITLE
fix(launcher): recognize Bun module-not-found errors without ERR_MODULE_NOT_FOUND code

### DIFF
--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -247,8 +247,17 @@ if (
   }
 }
 
-const isModuleNotFoundError = (err) =>
-  err && typeof err === "object" && "code" in err && err.code === "ERR_MODULE_NOT_FOUND";
+const isModuleNotFoundError = (err) => {
+  if (err && typeof err === "object" && "code" in err && err.code === "ERR_MODULE_NOT_FOUND") {
+    return true;
+  }
+  // Bun uses ResolveMessage without the Node-specific error code.
+  const message =
+    err && typeof err === "object" && "message" in err && typeof err.message === "string"
+      ? err.message
+      : "";
+  return message.includes("Cannot find module") || message.includes("Cannot find package");
+};
 
 const isDirectModuleNotFoundError = (err, specifier) => {
   if (!isModuleNotFoundError(err)) {


### PR DESCRIPTION
## Summary

Bun's `ResolveMessage` errors carry `"Cannot find module"` in the message but do not set the Node-specific `code: "ERR_MODULE_NOT_FOUND"`. The launcher's `isModuleNotFoundError` predicate gated entirely on that code, so under Bun the `catch` blocks in `installProcessWarningFilter` and `tryImport` re-threw instead of continuing, causing a crash loop when `dist/warning-filter.js` was missing.

This widens the predicate to also match `"Cannot find module"` and `"Cannot find package"` in the error message, matching the pattern already used by the browser extension (`extensions/browser/src/browser/pw-ai-module.ts:10-23`). The inner `isDirectModuleNotFoundError` caller already narrows to exact-specifier matching, so transitive dependency errors are still surfaced correctly.

Closes #86198

## Changes

| File | Change |
|------|--------|
| `openclaw.mjs:250-260` | Widen `isModuleNotFoundError` to accept Bun-style errors via message matching |

## Real behavior proof

Behavior addressed: Bun launcher crash loop when `dist/warning-filter.js` is missing and Bun throws without `ERR_MODULE_NOT_FOUND` code

Real environment tested: macOS 15.5, Node 24, full launcher e2e suite

Exact steps or command run after this patch:
```
pnpm test test/openclaw-launcher.e2e.test.ts
```

Evidence after fix:
```
$ pnpm test test/openclaw-launcher.e2e.test.ts

 ✓ test/openclaw-launcher.e2e.test.ts (22 tests) 3438ms
   ✓ surfaces transitive entry import failures instead of masking them as missing dist
   ✓ keeps the friendly launcher error for a truly missing entry build output

 Test Files  1 passed (1)
 Tests  22 passed (22)
```
The transitive-error-surfacing test (line 174) confirms that widening the outer gate does not mask transitive failures. The missing-entry test (line 193) confirms direct module misses still produce the friendly error. Both critical safety tests pass unchanged.

The predicate change is also validated by code inspection: `isDirectModuleNotFoundError` (lines 253-269) already does exact-specifier matching via URL comparison and path-in-message checks, so the outer gate only determines "is this a module resolution error at all?" while the inner function determines "is it for THIS specific specifier?"

Observed result after fix: `isModuleNotFoundError({ message: "Cannot find module './dist/warning-filter.js'" })` returns `true` even without `code: "ERR_MODULE_NOT_FOUND"`, allowing the launcher to fall through gracefully under Bun.

What was not tested: live Bun runtime (Bun is not installed in the test environment; the error format difference was verified by reading Bun source and issue reports)
