### PR TITLE
fix(update): exclude prerelease tags from stable git channel

### DIFF
--- a/src/infra/update-channels.test.ts
+++ b/src/infra/update-channels.test.ts
@@ -3,6 +3,7 @@ import {
   channelToNpmTag,
   formatUpdateChannelLabel,
   isBetaTag,
+  isPrereleaseTag,
   isStableTag,
   normalizeUpdateChannel,
   resolveEffectiveUpdateChannel,
@@ -17,12 +18,24 @@ describe("update-channels tag detection", () => {
     { tag: "v2026.2.24-beta.1", beta: true },
     { tag: "v2026.2.24.beta.1", beta: true },
     { tag: "v2026.2.24-BETA-1", beta: true },
+    { tag: "v2026.2.24-alpha.1", beta: false },
     { tag: "v2026.2.24-1", beta: false },
     { tag: "v2026.2.24-alphabeta.1", beta: false },
     { tag: "v2026.2.24", beta: false },
   ])("classifies $tag", ({ tag, beta }) => {
     expect(isBetaTag(tag)).toBe(beta);
-    expect(isStableTag(tag)).toBe(!beta);
+  });
+
+  it.each([
+    { tag: "v2026.2.24-alpha.1", prerelease: true, stable: false },
+    { tag: "v2026.2.24-beta.1", prerelease: true, stable: false },
+    { tag: "v2026.2.24-rc.1", prerelease: true, stable: false },
+    { tag: "v2026.2.24-preview.1", prerelease: true, stable: false },
+    { tag: "v2026.2.24-1", prerelease: false, stable: true },
+    { tag: "v2026.2.24", prerelease: false, stable: true },
+  ])("stable/prerelease classification for $tag", ({ tag, prerelease, stable }) => {
+    expect(isPrereleaseTag(tag)).toBe(prerelease);
+    expect(isStableTag(tag)).toBe(stable);
   });
 });
 

--- a/src/infra/update-channels.ts
+++ b/src/infra/update-channels.ts
@@ -37,8 +37,12 @@ export function isBetaTag(tag: string): boolean {
   return /(?:^|[.-])beta(?:[.-]|$)/i.test(tag);
 }
 
+export function isPrereleaseTag(tag: string): boolean {
+  return /(?:^|[.-])(alpha|beta|rc|pre|preview|canary|dev)(?:[.-]|$)/i.test(tag);
+}
+
 export function isStableTag(tag: string): boolean {
-  return !isBetaTag(tag);
+  return !isPrereleaseTag(tag);
 }
 
 export function resolveRegistryUpdateChannel(params: {

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -742,6 +742,30 @@ describe("runGatewayUpdate", () => {
     expect(calls).not.toContain(`git -C ${tempDir} checkout --detach ${betaTag}`);
   });
 
+  it("uses stable tag for stable channel even when a newer alpha tag sorts first", async () => {
+    await setupGitCheckout({ packageManager: "pnpm@8.0.0" });
+    await setupUiIndex();
+    const stableTag = "v2026.5.22";
+    const alphaTag = "v2026.5.24-alpha.1";
+    const doctorNodePath = await resolveStableNodePath(process.execPath);
+    const { runner, calls } = createRunner({
+      ...buildStableTagResponses(alphaTag, { additionalTags: [stableTag] }),
+      [`git -C ${tempDir} checkout --detach ${stableTag}`]: { stdout: "" },
+      "pnpm install": { stdout: "" },
+      "pnpm build": { stdout: "" },
+      "pnpm ui:build": { stdout: "" },
+      [`${doctorNodePath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`]: {
+        stdout: "",
+      },
+    });
+
+    const result = await runWithRunner(runner, { channel: "stable" });
+
+    expect(result.status).toBe("ok");
+    expect(calls).toContain(`git -C ${tempDir} checkout --detach ${stableTag}`);
+    expect(calls).not.toContain(`git -C ${tempDir} checkout --detach ${alphaTag}`);
+  });
+
   it("bootstraps pnpm via npm when pnpm and corepack are unavailable", async () => {
     await setupGitPackageManagerFixture();
     const stableTag = "v1.0.1-1";


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Stable git updates treated any non-beta tag as stable, so prerelease tags such as alpha, rc, preview, canary, and dev could be selected by the stable channel.
- This allowed a newer alpha tag to win when git tags were sorted by version.

Why does this matter now?

- Closes #86218, where a stable-channel git update checked out an alpha tag instead of the latest stable tag.

What is the intended outcome?

- Stable git updates choose the newest stable release tag and skip prerelease tags.
- Beta git updates still prefer beta tags when appropriate, while retaining the existing stable fallback behavior.

What is intentionally out of scope?

- NPM/package update channel resolution.
- Release tagging policy.
- Update UI copy or install flow changes outside tag classification/selection.

What does success look like?

- Given v2026.5.24-alpha.1 and v2026.5.22, the stable git channel checks out v2026.5.22.
- Existing beta-channel fallback behavior remains covered.

What should reviewers focus on?

- The prerelease tag matcher in src/infra/update-channels.ts.
- The stable-channel tag-selection regression in src/infra/update-runner.test.ts.

## Linked context

Which issue does this close?

Closes #86218

Which issues, PRs, or discussions are related?

Related #86218

Was this requested by a maintainer or owner?

No direct maintainer request beyond the tracked issue and triage labels.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: stable-channel git updates could select prerelease tags because isStableTag() only excluded beta tags.
- Real environment tested: local Linux OpenClaw source checkout on this branch, rebased onto current upstream/main, using the real repository git tags.
- Exact steps or command run after this patch:
  - Ran a Node runtime probe with node --import tsx. The probe imported src/infra/update-channels.ts from this branch, ran git tag --list v* --sort=-v:refname against the checkout, then applied the patched isStableTag/isPrereleaseTag logic to the real tag list.
  - Ran the focused updater/classifier regression commands listed under Tests and validation.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  - Copied live console output from the runtime probe:

        top git tags:
          v2026.5.24-beta.2
          v2026.5.24-beta.1
          v2026.5.24-alpha.1
          v2026.5.23-alpha.1
          v2026.5.22-beta.1
          v2026.5.22
        stable channel selected: v2026.5.22
        prerelease tags skipped before stable: v2026.5.24-beta.2, v2026.5.24-beta.1, v2026.5.24-alpha.1, v2026.5.23-alpha.1, v2026.5.22-beta.1

  - update-channels.test.ts: Test Files 1 passed (1), Tests 43 passed (43).
  - update-runner.test.ts: Test Files 1 passed (1), Tests 48 passed (48).
  - The new runner regression feeds git tag output where v2026.5.24-alpha.1 sorts before v2026.5.22 and asserts the checkout command uses v2026.5.22, not the alpha tag.
- Observed result after fix: stable tag classification excludes common prerelease markers, and the stable selector chooses v2026.5.22 from the real tag list while skipping newer alpha/beta prerelease tags.
- What was not tested: a live openclaw update against an installed production/self-updating OpenClaw instance.
- Proof limitations or environment constraints: running the live self-update command would mutate the active installation, so the real behavior proof uses a source-checkout runtime probe against the real git tags plus focused regression coverage rather than a full live install mutation.
- Before evidence (optional but encouraged): on current main before this patch, isStableTag(tag) returned !isBetaTag(tag), which meant v2026.5.24-alpha.1 counted as stable.

## Tests and validation

Which commands did you run?

- CI=true COREPACK_HOME=/tmp/openclaw-corepack-pr86260 node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/infra/update-channels.test.ts
- CI=true COREPACK_HOME=/tmp/openclaw-corepack-pr86260 node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/update-runner.test.ts

What regression coverage was added or updated?

- Added prerelease classification coverage for alpha, beta, rc, preview, numeric suffix tags, and plain stable tags.
- Added a stable-channel updater regression proving that a newer alpha tag does not win over the latest stable tag.

What failed before this fix, if known?

- The new stable-channel updater regression would have checked out the alpha tag on the previous implementation because alpha was treated as stable.

If no test was added, why not?

- Tests were added.

## Risk checklist

Did user-visible behavior change? (Yes/No)

Yes. Stable-channel git updates now ignore prerelease tags instead of treating non-beta prerelease tags as stable.

Did config, environment, or migration behavior change? (Yes/No)

No.

Did security, auth, secrets, network, or tool execution behavior change? (Yes/No)

No.

What is the highest-risk area?

- A release tag containing one of the prerelease marker words could now be excluded from stable-channel selection.

How is that risk mitigated?

- The matcher requires the marker to appear as a dot/dash-delimited token, and regression coverage keeps numeric stable suffixes such as v2026.2.24-1 classified as stable.

## Current review state

What is the next action?

- Wait for CI and maintainer/ClawSweeper review.

What is still waiting on author, maintainer, CI, or external proof?

- CI is running on the new PR.
- Maintainer review is needed for the prerelease marker set and the proof limitation around not mutating a live install.

Which bot or reviewer comments were addressed?

- Updated the PR body with copied live runtime-probe output after the initial Real behavior proof check reported that unit tests alone were not enough.
