### PR TITLE
fix(cli): cancel deferred maintenance on exit

### DIFF
--- a/src/agents/pi-embedded-runner/context-engine-maintenance.test.ts
+++ b/src/agents/pi-embedded-runner/context-engine-maintenance.test.ts
@@ -37,6 +37,9 @@ let runContextEngineMaintenance: typeof import("./context-engine-maintenance.js"
 // Keep this literal aligned with the production module; tests use dynamic
 // import reloading, so they cannot safely import the constant directly.
 const TURN_MAINTENANCE_TASK_KIND = "context_engine_turn_maintenance";
+const DEFERRED_TURN_MAINTENANCE_CLI_EXIT_HOOK_KEY = Symbol.for(
+  "openclaw.contextEngineTurnMaintenanceCliExitHook",
+);
 
 async function flushAsyncWork(times = 4): Promise<void> {
   for (let index = 0; index < times; index += 1) {
@@ -293,6 +296,14 @@ describe("buildContextEngineMaintenanceRuntimeContext", () => {
 describe("createDeferredTurnMaintenanceAbortSignal", () => {
   beforeEach(async () => {
     await loadFreshContextEngineMaintenanceModuleForTest();
+  });
+
+  it("registers a lightweight CLI-exit cleanup hook when the module is loaded", () => {
+    const hookState = (
+      globalThis as Record<PropertyKey, { cancelForCliExit?: unknown } | undefined>
+    )[DEFERRED_TURN_MAINTENANCE_CLI_EXIT_HOOK_KEY];
+
+    expect(hookState?.cancelForCliExit).toBe(cancelActiveDeferredTurnMaintenanceRunsForCliExit);
   });
 
   it("aborts on termination signals and unregisters listeners", () => {
@@ -716,7 +727,7 @@ describe("runContextEngineMaintenance", () => {
         });
 
         expect(deferredPromises).toHaveLength(1);
-        await cancelActiveDeferredTurnMaintenanceRunsForCliExit({ drainMs: 0 });
+        await cancelActiveDeferredTurnMaintenanceRunsForCliExit();
         await deferredPromises[0];
 
         expect(maintain).not.toHaveBeenCalled();
@@ -725,7 +736,7 @@ describe("runContextEngineMaintenance", () => {
         );
         expect(tasks).toHaveLength(1);
         expect(tasks[0].status).toBe("cancelled");
-        expect(String(tasks[0].terminalSummary)).toContain("CLI command completed");
+        expect(String(tasks[0].terminalSummary)).toContain("cancelled during shutdown");
 
         if (!releaseForeground) {
           throw new Error("Expected foreground turn release callback to be initialized");
@@ -800,7 +811,7 @@ describe("runContextEngineMaintenance", () => {
         await flushAsyncWork();
         expect(maintain).toHaveBeenCalledTimes(1);
 
-        await cancelActiveDeferredTurnMaintenanceRunsForCliExit({ drainMs: 0 });
+        await cancelActiveDeferredTurnMaintenanceRunsForCliExit();
         await deferredPromises[0];
 
         expect(observedAbortSignal?.aborted).toBe(true);
@@ -897,6 +908,112 @@ describe("runContextEngineMaintenance", () => {
     });
   });
 
+  it("blocks deferred transcript rewrites already queued behind the session lane", async () => {
+    await withStateDirEnv("openclaw-turn-maintenance-cli-exit-", async () => {
+      try {
+        resetCommandQueueStateForTest();
+        resetTaskRegistryForTests({ persist: false });
+        resetTaskFlowRegistryForTests({ persist: false });
+        rewriteTranscriptEntriesInSessionFileMock.mockClear();
+
+        const sessionKey = "agent:main:session-cli-exit-queued-rewrite";
+        const sessionLane = resolveSessionLane(sessionKey);
+        let releaseForeground: (() => void) | undefined;
+        let foregroundTurn: Promise<void> | undefined;
+
+        let observedAbortSignal: AbortSignal | undefined;
+        let rewritePromise: Promise<unknown> | undefined;
+        let resolveRewriteQueued!: () => void;
+        const rewriteQueued = new Promise<void>((resolve) => {
+          resolveRewriteQueued = resolve;
+        });
+        const maintain = vi.fn(
+          async (params?: { runtimeContext?: ContextEngineRuntimeContext }) => {
+            observedAbortSignal = params?.runtimeContext?.abortSignal;
+            foregroundTurn = enqueueCommandInLane(sessionLane, async () => {
+              await new Promise<void>((resolve) => {
+                releaseForeground = resolve;
+              });
+            });
+            await flushAsyncWork();
+            rewritePromise = params?.runtimeContext?.rewriteTranscriptEntries?.({
+              replacements: [
+                {
+                  entryId: "entry-queued-before-abort",
+                  message: castAgentMessage({
+                    role: "assistant",
+                    content: [{ type: "text", text: "queued rewrite" }],
+                    timestamp: 4,
+                  }),
+                },
+              ],
+            });
+            resolveRewriteQueued();
+            await expect(rewritePromise).rejects.toThrow(/short-lived CLI command completed/);
+            return {
+              changed: false,
+              bytesFreed: 0,
+              rewrittenEntries: 0,
+            };
+          },
+        );
+        const backgroundEngine = {
+          info: {
+            id: "test",
+            name: "Test Engine",
+            turnMaintenanceMode: "background" as const,
+          },
+          ingest: async () => ({ ingested: true }),
+          assemble: async ({ messages }: { messages: unknown[] }) => ({
+            messages,
+            estimatedTokens: 0,
+          }),
+          compact: async () => ({ ok: true, compacted: false }),
+          maintain,
+        } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+        const deferredPromises: Promise<void>[] = [];
+
+        await runContextEngineMaintenance({
+          contextEngine: backgroundEngine,
+          sessionId: "session-cli-exit-queued-rewrite",
+          sessionKey,
+          sessionFile: "/tmp/session-cli-exit-queued-rewrite.jsonl",
+          reason: "turn",
+          onDeferredMaintenance: (promise) => {
+            deferredPromises.push(promise);
+          },
+        });
+        await flushAsyncWork();
+        expect(maintain).toHaveBeenCalledTimes(1);
+        await Promise.race([
+          rewriteQueued,
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error("timed out waiting for queued rewrite")), 1_000),
+          ),
+        ]);
+        expect(rewritePromise).toBeDefined();
+
+        await cancelActiveDeferredTurnMaintenanceRunsForCliExit({ drainMs: 0 });
+        if (!releaseForeground) {
+          throw new Error("Expected foreground turn release callback to be initialized");
+        }
+        releaseForeground();
+        await foregroundTurn;
+        await deferredPromises[0];
+
+        expect(observedAbortSignal?.aborted).toBe(true);
+        expect(rewriteTranscriptEntriesInSessionFileMock).not.toHaveBeenCalled();
+        const tasks = listTasksForOwnerKey(sessionKey).filter(
+          (task) => task.taskKind === TURN_MAINTENANCE_TASK_KIND,
+        );
+        expect(tasks).toHaveLength(1);
+        expect(tasks[0].status).toBe("cancelled");
+      } finally {
+        resetCommandQueueStateForTest();
+      }
+    });
+  });
+
   it("clears host progress timers when active deferred maintenance ignores shutdown abort", async () => {
     await withStateDirEnv("openclaw-turn-maintenance-cli-exit-", async () => {
       vi.useFakeTimers();
@@ -940,9 +1057,10 @@ describe("runContextEngineMaintenance", () => {
         const timerCountBeforeCancel = vi.getTimerCount();
         expect(timerCountBeforeCancel).toBeGreaterThan(0);
 
-        await cancelActiveDeferredTurnMaintenanceRunsForCliExit({ drainMs: 0 });
+        const cancelPromise = cancelActiveDeferredTurnMaintenanceRunsForCliExit({ drainMs: 100 });
+        await vi.advanceTimersByTimeAsync(100);
+        await cancelPromise;
 
-        expect(vi.getTimerCount()).toBeLessThan(timerCountBeforeCancel);
         await vi.advanceTimersByTimeAsync(11_000);
         expect(peekSystemEvents(sessionKey).join("\n")).not.toContain(
           "Deferred maintenance is still running.",
@@ -951,7 +1069,8 @@ describe("runContextEngineMaintenance", () => {
           (task) => task.taskKind === TURN_MAINTENANCE_TASK_KIND,
         );
         expect(tasks).toHaveLength(1);
-        expect(tasks[0].status).toBe("cancelled");
+        expect(tasks[0].status).toBe("lost");
+        expect(String(tasks[0].error)).toContain("did not stop before CLI exit");
       } finally {
         vi.useRealTimers();
         resetCommandQueueStateForTest();
@@ -1027,7 +1146,7 @@ describe("runContextEngineMaintenance", () => {
           secondDeferredSettled = true;
         });
 
-        await cancelActiveDeferredTurnMaintenanceRunsForCliExit({ drainMs: 0 });
+        await cancelActiveDeferredTurnMaintenanceRunsForCliExit();
         await Promise.all(deferredPromises);
         await secondDeferred;
 

--- a/src/agents/pi-embedded-runner/context-engine-maintenance.test.ts
+++ b/src/agents/pi-embedded-runner/context-engine-maintenance.test.ts
@@ -30,6 +30,7 @@ const rewriteTranscriptEntriesInSessionFileMock = vi.fn(async (_params?: unknown
   rewrittenEntries: 2,
 }));
 let buildContextEngineMaintenanceRuntimeContext: typeof import("./context-engine-maintenance.js").buildContextEngineMaintenanceRuntimeContext;
+let cancelActiveDeferredTurnMaintenanceRunsForCliExit: typeof import("./context-engine-maintenance.js").cancelActiveDeferredTurnMaintenanceRunsForCliExit;
 let createDeferredTurnMaintenanceAbortSignal: typeof import("./context-engine-maintenance.js").createDeferredTurnMaintenanceAbortSignal;
 let resetDeferredTurnMaintenanceStateForTest: typeof import("./context-engine-maintenance.js").resetDeferredTurnMaintenanceStateForTest;
 let runContextEngineMaintenance: typeof import("./context-engine-maintenance.js").runContextEngineMaintenance;
@@ -98,6 +99,7 @@ vi.mock("./transcript-rewrite.js", () => ({
 async function loadFreshContextEngineMaintenanceModuleForTest() {
   ({
     buildContextEngineMaintenanceRuntimeContext,
+    cancelActiveDeferredTurnMaintenanceRunsForCliExit,
     createDeferredTurnMaintenanceAbortSignal,
     resetDeferredTurnMaintenanceStateForTest,
     runContextEngineMaintenance,
@@ -659,6 +661,387 @@ describe("runContextEngineMaintenance", () => {
         await foregroundTurn;
       } finally {
         vi.useRealTimers();
+      }
+    });
+  });
+
+  it("cancels queued deferred turn maintenance during short-lived CLI shutdown", async () => {
+    await withStateDirEnv("openclaw-turn-maintenance-cli-exit-", async () => {
+      vi.useFakeTimers();
+      try {
+        resetCommandQueueStateForTest();
+        resetTaskRegistryForTests({ persist: false });
+        resetTaskFlowRegistryForTests({ persist: false });
+
+        const sessionKey = "agent:main:session-cli-exit-queued";
+        const sessionLane = resolveSessionLane(sessionKey);
+        let releaseForeground: (() => void) | undefined;
+        const foregroundTurn = enqueueCommandInLane(sessionLane, async () => {
+          await new Promise<void>((resolve) => {
+            releaseForeground = resolve;
+          });
+        });
+        await Promise.resolve();
+
+        const maintain = vi.fn(async () => ({
+          changed: false,
+          bytesFreed: 0,
+          rewrittenEntries: 0,
+        }));
+        const backgroundEngine = {
+          info: {
+            id: "test",
+            name: "Test Engine",
+            turnMaintenanceMode: "background" as const,
+          },
+          ingest: async () => ({ ingested: true }),
+          assemble: async ({ messages }: { messages: unknown[] }) => ({
+            messages,
+            estimatedTokens: 0,
+          }),
+          compact: async () => ({ ok: true, compacted: false }),
+          maintain,
+        } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+        const deferredPromises: Promise<void>[] = [];
+
+        await runContextEngineMaintenance({
+          contextEngine: backgroundEngine,
+          sessionId: "session-cli-exit-queued",
+          sessionKey,
+          sessionFile: "/tmp/session-cli-exit-queued.jsonl",
+          reason: "turn",
+          onDeferredMaintenance: (promise) => {
+            deferredPromises.push(promise);
+          },
+        });
+
+        expect(deferredPromises).toHaveLength(1);
+        await cancelActiveDeferredTurnMaintenanceRunsForCliExit({ drainMs: 0 });
+        await deferredPromises[0];
+
+        expect(maintain).not.toHaveBeenCalled();
+        const tasks = listTasksForOwnerKey(sessionKey).filter(
+          (task) => task.taskKind === TURN_MAINTENANCE_TASK_KIND,
+        );
+        expect(tasks).toHaveLength(1);
+        expect(tasks[0].status).toBe("cancelled");
+        expect(String(tasks[0].terminalSummary)).toContain("CLI command completed");
+
+        if (!releaseForeground) {
+          throw new Error("Expected foreground turn release callback to be initialized");
+        }
+        releaseForeground();
+        await foregroundTurn;
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  it("aborts active deferred turn maintenance during short-lived CLI shutdown", async () => {
+    await withStateDirEnv("openclaw-turn-maintenance-cli-exit-", async () => {
+      try {
+        resetCommandQueueStateForTest();
+        resetTaskRegistryForTests({ persist: false });
+        resetTaskFlowRegistryForTests({ persist: false });
+
+        const sessionKey = "agent:main:session-cli-exit-active";
+        let observedAbortSignal: AbortSignal | undefined;
+        const maintain = vi.fn(
+          async (params?: {
+            sessionId?: string;
+            sessionKey?: string;
+            sessionFile?: string;
+            runtimeContext?: ContextEngineRuntimeContext;
+          }) => {
+            expect(Object.keys(params ?? {}).toSorted()).toEqual([
+              "runtimeContext",
+              "sessionFile",
+              "sessionId",
+              "sessionKey",
+            ]);
+            observedAbortSignal = params?.runtimeContext?.abortSignal;
+            await new Promise<void>((resolve) => {
+              observedAbortSignal?.addEventListener("abort", () => resolve(), { once: true });
+            });
+            return {
+              changed: false,
+              bytesFreed: 0,
+              rewrittenEntries: 0,
+            };
+          },
+        );
+        const backgroundEngine = {
+          info: {
+            id: "test",
+            name: "Test Engine",
+            turnMaintenanceMode: "background" as const,
+          },
+          ingest: async () => ({ ingested: true }),
+          assemble: async ({ messages }: { messages: unknown[] }) => ({
+            messages,
+            estimatedTokens: 0,
+          }),
+          compact: async () => ({ ok: true, compacted: false }),
+          maintain,
+        } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+        const deferredPromises: Promise<void>[] = [];
+
+        await runContextEngineMaintenance({
+          contextEngine: backgroundEngine,
+          sessionId: "session-cli-exit-active",
+          sessionKey,
+          sessionFile: "/tmp/session-cli-exit-active.jsonl",
+          reason: "turn",
+          onDeferredMaintenance: (promise) => {
+            deferredPromises.push(promise);
+          },
+        });
+        await flushAsyncWork();
+        expect(maintain).toHaveBeenCalledTimes(1);
+
+        await cancelActiveDeferredTurnMaintenanceRunsForCliExit({ drainMs: 0 });
+        await deferredPromises[0];
+
+        expect(observedAbortSignal?.aborted).toBe(true);
+        const tasks = listTasksForOwnerKey(sessionKey).filter(
+          (task) => task.taskKind === TURN_MAINTENANCE_TASK_KIND,
+        );
+        expect(tasks).toHaveLength(1);
+        expect(tasks[0].status).toBe("cancelled");
+      } finally {
+        resetCommandQueueStateForTest();
+      }
+    });
+  });
+
+  it("blocks deferred transcript rewrites after short-lived CLI shutdown aborts maintenance", async () => {
+    await withStateDirEnv("openclaw-turn-maintenance-cli-exit-", async () => {
+      try {
+        resetCommandQueueStateForTest();
+        resetTaskRegistryForTests({ persist: false });
+        resetTaskFlowRegistryForTests({ persist: false });
+        rewriteTranscriptEntriesInSessionFileMock.mockClear();
+
+        const sessionKey = "agent:main:session-cli-exit-rewrite";
+        let observedAbortSignal: AbortSignal | undefined;
+        const maintain = vi.fn(
+          async (params?: { runtimeContext?: ContextEngineRuntimeContext }) => {
+            observedAbortSignal = params?.runtimeContext?.abortSignal;
+            await new Promise<void>((resolve) => {
+              observedAbortSignal?.addEventListener("abort", () => resolve(), { once: true });
+            });
+            await expect(
+              params?.runtimeContext?.rewriteTranscriptEntries?.({
+                replacements: [
+                  {
+                    entryId: "entry-after-abort",
+                    message: castAgentMessage({
+                      role: "assistant",
+                      content: [{ type: "text", text: "late rewrite" }],
+                      timestamp: 3,
+                    }),
+                  },
+                ],
+              }),
+            ).rejects.toThrow(/short-lived CLI command completed/);
+            return {
+              changed: false,
+              bytesFreed: 0,
+              rewrittenEntries: 0,
+            };
+          },
+        );
+        const backgroundEngine = {
+          info: {
+            id: "test",
+            name: "Test Engine",
+            turnMaintenanceMode: "background" as const,
+          },
+          ingest: async () => ({ ingested: true }),
+          assemble: async ({ messages }: { messages: unknown[] }) => ({
+            messages,
+            estimatedTokens: 0,
+          }),
+          compact: async () => ({ ok: true, compacted: false }),
+          maintain,
+        } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+        const deferredPromises: Promise<void>[] = [];
+
+        await runContextEngineMaintenance({
+          contextEngine: backgroundEngine,
+          sessionId: "session-cli-exit-rewrite",
+          sessionKey,
+          sessionFile: "/tmp/session-cli-exit-rewrite.jsonl",
+          reason: "turn",
+          onDeferredMaintenance: (promise) => {
+            deferredPromises.push(promise);
+          },
+        });
+        await flushAsyncWork();
+        expect(maintain).toHaveBeenCalledTimes(1);
+
+        await cancelActiveDeferredTurnMaintenanceRunsForCliExit({ drainMs: 0 });
+        await deferredPromises[0];
+
+        expect(observedAbortSignal?.aborted).toBe(true);
+        expect(rewriteTranscriptEntriesInSessionFileMock).not.toHaveBeenCalled();
+        const tasks = listTasksForOwnerKey(sessionKey).filter(
+          (task) => task.taskKind === TURN_MAINTENANCE_TASK_KIND,
+        );
+        expect(tasks).toHaveLength(1);
+        expect(tasks[0].status).toBe("cancelled");
+      } finally {
+        resetCommandQueueStateForTest();
+      }
+    });
+  });
+
+  it("clears host progress timers when active deferred maintenance ignores shutdown abort", async () => {
+    await withStateDirEnv("openclaw-turn-maintenance-cli-exit-", async () => {
+      vi.useFakeTimers();
+      try {
+        resetCommandQueueStateForTest();
+        resetTaskRegistryForTests({ persist: false });
+        resetTaskFlowRegistryForTests({ persist: false });
+        resetSystemEventsForTest();
+
+        const sessionKey = "agent:main:session-cli-exit-ignored-abort";
+        const maintain = vi.fn(async () => await new Promise<never>(() => {}));
+        const backgroundEngine = {
+          info: {
+            id: "test",
+            name: "Test Engine",
+            turnMaintenanceMode: "background" as const,
+          },
+          ingest: async () => ({ ingested: true }),
+          assemble: async ({ messages }: { messages: unknown[] }) => ({
+            messages,
+            estimatedTokens: 0,
+          }),
+          compact: async () => ({ ok: true, compacted: false }),
+          maintain,
+        } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+        const deferredPromises: Promise<void>[] = [];
+
+        await runContextEngineMaintenance({
+          contextEngine: backgroundEngine,
+          sessionId: "session-cli-exit-ignored-abort",
+          sessionKey,
+          sessionFile: "/tmp/session-cli-exit-ignored-abort.jsonl",
+          reason: "turn",
+          onDeferredMaintenance: (promise) => {
+            deferredPromises.push(promise);
+          },
+        });
+        await flushAsyncWork();
+        expect(maintain).toHaveBeenCalledTimes(1);
+        expect(deferredPromises).toHaveLength(1);
+        const timerCountBeforeCancel = vi.getTimerCount();
+        expect(timerCountBeforeCancel).toBeGreaterThan(0);
+
+        await cancelActiveDeferredTurnMaintenanceRunsForCliExit({ drainMs: 0 });
+
+        expect(vi.getTimerCount()).toBeLessThan(timerCountBeforeCancel);
+        await vi.advanceTimersByTimeAsync(11_000);
+        expect(peekSystemEvents(sessionKey).join("\n")).not.toContain(
+          "Deferred maintenance is still running.",
+        );
+        const tasks = listTasksForOwnerKey(sessionKey).filter(
+          (task) => task.taskKind === TURN_MAINTENANCE_TASK_KIND,
+        );
+        expect(tasks).toHaveLength(1);
+        expect(tasks[0].status).toBe("cancelled");
+      } finally {
+        vi.useRealTimers();
+        resetCommandQueueStateForTest();
+      }
+    });
+  });
+
+  it("drops requested deferred maintenance reruns during short-lived CLI shutdown", async () => {
+    await withStateDirEnv("openclaw-turn-maintenance-rerun-cli-exit-", async () => {
+      vi.useFakeTimers();
+      try {
+        resetCommandQueueStateForTest();
+        resetTaskRegistryForTests({ persist: false });
+        resetTaskFlowRegistryForTests({ persist: false });
+
+        const sessionKey = "agent:main:session-rerun-cli-exit";
+        let observedAbortSignal: AbortSignal | undefined;
+        const maintain = vi.fn(
+          async (params?: { runtimeContext?: ContextEngineRuntimeContext }) => {
+            observedAbortSignal = params?.runtimeContext?.abortSignal;
+            await new Promise<void>((resolve) => {
+              observedAbortSignal?.addEventListener("abort", () => resolve(), { once: true });
+            });
+            return {
+              changed: false,
+              bytesFreed: 0,
+              rewrittenEntries: 0,
+            };
+          },
+        );
+
+        const backgroundEngine = {
+          info: {
+            id: "test",
+            name: "Test Engine",
+            turnMaintenanceMode: "background" as const,
+          },
+          ingest: async () => ({ ingested: true }),
+          assemble: async ({ messages }: { messages: unknown[] }) => ({
+            messages,
+            estimatedTokens: 0,
+          }),
+          compact: async () => ({ ok: true, compacted: false }),
+          maintain,
+        } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+        const deferredPromises: Promise<void>[] = [];
+
+        await runContextEngineMaintenance({
+          contextEngine: backgroundEngine,
+          sessionId: "session-rerun-cli-exit",
+          sessionKey,
+          sessionFile: "/tmp/session-rerun-cli-exit.jsonl",
+          reason: "turn",
+          onDeferredMaintenance: (promise) => {
+            deferredPromises.push(promise);
+          },
+        });
+        await waitForAssertion(() => expect(maintain).toHaveBeenCalledTimes(1));
+
+        await runContextEngineMaintenance({
+          contextEngine: backgroundEngine,
+          sessionId: "session-rerun-cli-exit",
+          sessionKey,
+          sessionFile: "/tmp/session-rerun-cli-exit.jsonl",
+          reason: "turn",
+          onDeferredMaintenance: (promise) => {
+            deferredPromises.push(promise);
+          },
+        });
+        expect(deferredPromises).toHaveLength(2);
+        let secondDeferredSettled = false;
+        const secondDeferred = deferredPromises[1].then(() => {
+          secondDeferredSettled = true;
+        });
+
+        await cancelActiveDeferredTurnMaintenanceRunsForCliExit({ drainMs: 0 });
+        await Promise.all(deferredPromises);
+        await secondDeferred;
+
+        expect(observedAbortSignal?.aborted).toBe(true);
+        expect(secondDeferredSettled).toBe(true);
+        expect(maintain).toHaveBeenCalledTimes(1);
+        const tasks = listTasksForOwnerKey(sessionKey).filter(
+          (task) => task.taskKind === TURN_MAINTENANCE_TASK_KIND,
+        );
+        expect(tasks).toHaveLength(1);
+        expect(tasks[0].status).toBe("cancelled");
+      } finally {
+        vi.useRealTimers();
+        resetCommandQueueStateForTest();
       }
     });
   });

--- a/src/agents/pi-embedded-runner/context-engine-maintenance.ts
+++ b/src/agents/pi-embedded-runner/context-engine-maintenance.ts
@@ -8,7 +8,12 @@ import type {
 } from "../../context-engine/types.js";
 import { sleepWithAbort } from "../../infra/backoff.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import { enqueueCommandInLane, getQueueSize } from "../../process/command-queue.js";
+import {
+  clearCommandLane,
+  enqueueCommandInLane,
+  getQueueSize,
+  resetCommandLane,
+} from "../../process/command-queue.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import {
   completeTaskRunByRunId,
@@ -38,6 +43,7 @@ const TURN_MAINTENANCE_TASK_TASK = "Deferred context-engine maintenance after tu
 const TURN_MAINTENANCE_LANE_PREFIX = "context-engine-turn-maintenance:";
 const TURN_MAINTENANCE_WAIT_POLL_MS = 100;
 const TURN_MAINTENANCE_LONG_WAIT_MS = 10_000;
+const TURN_MAINTENANCE_CLI_EXIT_DRAIN_MS = 1_000;
 const DEFERRED_TURN_MAINTENANCE_ABORT_STATE_KEY = Symbol.for(
   "openclaw.contextEngineTurnMaintenanceAbortState",
 );
@@ -56,6 +62,8 @@ type DeferredTurnMaintenanceRunState = {
   promise: Promise<void>;
   rerunRequested: boolean;
   latestParams: DeferredTurnMaintenanceScheduleParams;
+  taskId: string;
+  runId: string;
 };
 
 const activeDeferredTurnMaintenanceRuns = new Map<string, DeferredTurnMaintenanceRunState>();
@@ -103,6 +111,23 @@ function unregisterDeferredTurnMaintenanceAbortSignalHandlers(
   state.registered = false;
 }
 
+function abortDeferredTurnMaintenanceControllers(params: {
+  processLike: DeferredTurnMaintenanceProcessLike;
+  reason: Error;
+}): void {
+  const state = params.processLike[DEFERRED_TURN_MAINTENANCE_ABORT_STATE_KEY];
+  if (!state) {
+    return;
+  }
+  for (const activeController of state.controllers) {
+    if (!activeController.signal.aborted) {
+      activeController.abort(params.reason);
+    }
+  }
+  state.controllers.clear();
+  unregisterDeferredTurnMaintenanceAbortSignalHandlers(params.processLike, state);
+}
+
 function normalizeSessionKey(sessionKey?: string): string | undefined {
   return normalizeOptionalString(sessionKey) || undefined;
 }
@@ -128,15 +153,10 @@ export function createDeferredTurnMaintenanceAbortSignal(params?: {
       typeof processLike.listenerCount === "function"
         ? processLike.listenerCount(signalName) === 1
         : false;
-    for (const activeController of state.controllers) {
-      if (!activeController.signal.aborted) {
-        activeController.abort(
-          new Error(`received ${signalName} while waiting for deferred maintenance`),
-        );
-      }
-    }
-    state.controllers.clear();
-    unregisterDeferredTurnMaintenanceAbortSignalHandlers(processLike, state);
+    abortDeferredTurnMaintenanceControllers({
+      processLike,
+      reason: new Error(`received ${signalName} while waiting for deferred maintenance`),
+    });
     if (shouldReraise && typeof processLike.kill === "function") {
       try {
         processLike.kill(processLike.pid ?? process.pid, signalName);
@@ -186,6 +206,68 @@ export function resetDeferredTurnMaintenanceStateForTest(): void {
   state.controllers.clear();
   unregisterDeferredTurnMaintenanceAbortSignalHandlers(processLike, state);
   delete processLike[DEFERRED_TURN_MAINTENANCE_ABORT_STATE_KEY];
+}
+
+function cancelDeferredTurnMaintenanceTask(params: {
+  sessionKey: string;
+  runId: string;
+  terminalSummary: string;
+}): void {
+  const task = findTaskByRunIdForOwner({
+    runId: params.runId,
+    callerOwnerKey: params.sessionKey,
+  });
+  if (!task) {
+    return;
+  }
+  if (["succeeded", "failed", "timed_out", "cancelled", "lost"].includes(task.status)) {
+    return;
+  }
+  cancelTaskByIdForOwner({
+    taskId: task.taskId,
+    callerOwnerKey: params.sessionKey,
+    endedAt: Date.now(),
+    terminalSummary: params.terminalSummary,
+  });
+}
+
+export async function cancelActiveDeferredTurnMaintenanceRunsForCliExit(params?: {
+  drainMs?: number;
+}): Promise<void> {
+  const activeEntries = Array.from(activeDeferredTurnMaintenanceRuns.entries());
+  if (activeEntries.length === 0) {
+    return;
+  }
+
+  abortDeferredTurnMaintenanceControllers({
+    processLike: process as DeferredTurnMaintenanceProcessLike,
+    reason: new Error("short-lived CLI command completed before deferred maintenance"),
+  });
+
+  for (const [activeSessionKey, state] of activeEntries) {
+    state.rerunRequested = false;
+    activeDeferredTurnMaintenanceRuns.delete(activeSessionKey);
+    cancelDeferredTurnMaintenanceTask({
+      sessionKey: activeSessionKey,
+      runId: state.runId,
+      terminalSummary: "Deferred maintenance cancelled because the CLI command completed.",
+    });
+    const lane = resolveDeferredTurnMaintenanceLane(activeSessionKey);
+    clearCommandLane(lane);
+    resetCommandLane(lane);
+  }
+
+  const drainMs = Math.max(0, Math.floor(params?.drainMs ?? TURN_MAINTENANCE_CLI_EXIT_DRAIN_MS));
+  if (drainMs === 0) {
+    return;
+  }
+  await Promise.race([
+    Promise.allSettled(activeEntries.map(([, state]) => state.promise)),
+    new Promise<void>((resolve) => {
+      const timeout = setTimeout(resolve, drainMs);
+      timeout.unref?.();
+    }),
+  ]);
 }
 
 function markDeferredTurnMaintenanceTaskScheduleFailure(params: {
@@ -288,6 +370,20 @@ export function buildContextEngineMaintenanceRuntimeContext(params: {
   purpose?: string;
   contextEnginePluginId?: string;
 }): ContextEngineRuntimeContext {
+  const abortSignal = params.runtimeContext?.abortSignal;
+  const throwIfMaintenanceAborted = () => {
+    if (!abortSignal?.aborted) {
+      return;
+    }
+    const reason = abortSignal.reason;
+    if (reason instanceof Error) {
+      throw reason;
+    }
+    const error = new Error("Deferred maintenance cancelled before transcript rewrite.");
+    error.name = "AbortError";
+    throw error;
+  };
+
   return {
     ...params.runtimeContext,
     ...resolveContextEngineCapabilities({
@@ -299,27 +395,33 @@ export function buildContextEngineMaintenanceRuntimeContext(params: {
     }),
     ...(params.allowDeferredCompactionExecution ? { allowDeferredCompactionExecution: true } : {}),
     rewriteTranscriptEntries: async (request) => {
+      throwIfMaintenanceAborted();
       if (params.sessionManager) {
         const sessionManager = params.sessionManager;
-        const rewriteSessionManagerEntries = () =>
-          rewriteTranscriptEntriesInSessionManager({
+        const rewriteSessionManagerEntries = () => {
+          throwIfMaintenanceAborted();
+          return rewriteTranscriptEntriesInSessionManager({
             sessionManager,
             replacements: request.replacements,
           });
+        };
         return params.withSessionManagerRewriteLock
           ? await params.withSessionManagerRewriteLock(rewriteSessionManagerEntries)
           : rewriteSessionManagerEntries();
       }
-      const rewriteTranscriptEntriesInFile = async () =>
-        await rewriteTranscriptEntriesInSessionFile({
+      const rewriteTranscriptEntriesInFile = async () => {
+        throwIfMaintenanceAborted();
+        return await rewriteTranscriptEntriesInSessionFile({
           sessionFile: params.sessionFile,
           sessionId: params.sessionId,
           sessionKey: params.sessionKey,
           config: params.config,
           request,
         });
+      };
       const rewriteSessionKey = normalizeSessionKey(params.sessionKey ?? params.sessionId);
       if (params.deferTranscriptRewriteToSessionLane && rewriteSessionKey) {
+        throwIfMaintenanceAborted();
         return await enqueueCommandInLane(
           resolveSessionLane(rewriteSessionKey),
           async () => await rewriteTranscriptEntriesInFile(),
@@ -342,6 +444,7 @@ async function executeContextEngineMaintenance(params: {
   agentId?: string;
   executionMode: "foreground" | "background";
   config?: OpenClawConfig;
+  abortSignal?: AbortSignal;
 }): Promise<ContextEngineMaintenanceResult | undefined> {
   if (typeof params.contextEngine.maintain !== "function") {
     return undefined;
@@ -357,7 +460,10 @@ async function executeContextEngineMaintenance(params: {
       sessionManager: params.executionMode === "background" ? undefined : params.sessionManager,
       withSessionManagerRewriteLock:
         params.executionMode === "background" ? undefined : params.withSessionManagerRewriteLock,
-      runtimeContext: params.runtimeContext,
+      runtimeContext: {
+        ...params.runtimeContext,
+        ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
+      },
       agentId: params.agentId,
       allowDeferredCompactionExecution: params.executionMode === "background",
       deferTranscriptRewriteToSessionLane: params.executionMode === "background",
@@ -386,10 +492,28 @@ async function runDeferredTurnMaintenanceWorker(params: {
   agentId?: string;
   runId: string;
   config?: OpenClawConfig;
+  scheduledAbortSignal?: AbortSignal;
 }): Promise<void> {
+  if (params.scheduledAbortSignal?.aborted) {
+    cancelDeferredTurnMaintenanceTask({
+      sessionKey: params.sessionKey,
+      runId: params.runId,
+      terminalSummary: "Deferred maintenance cancelled during shutdown.",
+    });
+    return;
+  }
   let surfacedUserNotice = false;
   let longRunningTimer: ReturnType<typeof setTimeout> | null = null;
   const shutdownAbort = createDeferredTurnMaintenanceAbortSignal();
+  const clearLongRunningTimer = () => {
+    if (!longRunningTimer) {
+      return;
+    }
+    clearTimeout(longRunningTimer);
+    longRunningTimer = null;
+  };
+  shutdownAbort.abortSignal?.addEventListener("abort", clearLongRunningTimer, { once: true });
+  params.scheduledAbortSignal?.addEventListener("abort", clearLongRunningTimer, { once: true });
   const surfaceMaintenanceUpdate = (summary: string, eventSummary: string) => {
     promoteTurnMaintenanceTaskVisibility({
       sessionKey: params.sessionKey,
@@ -428,8 +552,14 @@ async function runDeferredTurnMaintenanceWorker(params: {
           );
         }
         await sleepWithAbort(TURN_MAINTENANCE_WAIT_POLL_MS, shutdownAbort.abortSignal);
+        if (params.scheduledAbortSignal?.aborted) {
+          throw params.scheduledAbortSignal.reason ?? new Error("deferred maintenance cancelled");
+        }
       }
       await Promise.resolve();
+      if (params.scheduledAbortSignal?.aborted) {
+        throw params.scheduledAbortSignal.reason ?? new Error("deferred maintenance cancelled");
+      }
       if (getQueueSize(sessionLane) === 0) {
         break;
       }
@@ -455,6 +585,7 @@ async function runDeferredTurnMaintenanceWorker(params: {
         log.warn(`failed to surface deferred maintenance progress: ${String(error)}`);
       }
     }, TURN_MAINTENANCE_LONG_WAIT_MS);
+    longRunningTimer.unref?.();
 
     const result = await executeContextEngineMaintenance({
       contextEngine: params.contextEngine,
@@ -467,11 +598,18 @@ async function runDeferredTurnMaintenanceWorker(params: {
       agentId: params.agentId,
       config: params.config,
       executionMode: "background",
+      abortSignal: shutdownAbort.abortSignal,
     });
-    if (longRunningTimer) {
-      clearTimeout(longRunningTimer);
-      longRunningTimer = null;
+    if (shutdownAbort.abortSignal?.aborted || params.scheduledAbortSignal?.aborted) {
+      clearLongRunningTimer();
+      cancelDeferredTurnMaintenanceTask({
+        sessionKey: params.sessionKey,
+        runId: params.runId,
+        terminalSummary: "Deferred maintenance cancelled during shutdown.",
+      });
+      return;
     }
+    clearLongRunningTimer();
 
     const endedAt = Date.now();
     completeTaskRunByRunId({
@@ -488,29 +626,16 @@ async function runDeferredTurnMaintenanceWorker(params: {
         : "No transcript changes were needed.",
     });
   } catch (err) {
-    if (shutdownAbort.abortSignal?.aborted) {
-      if (longRunningTimer) {
-        clearTimeout(longRunningTimer);
-        longRunningTimer = null;
-      }
-      const task = findTaskByRunIdForOwner({
+    if (shutdownAbort.abortSignal?.aborted || params.scheduledAbortSignal?.aborted) {
+      clearLongRunningTimer();
+      cancelDeferredTurnMaintenanceTask({
+        sessionKey: params.sessionKey,
         runId: params.runId,
-        callerOwnerKey: params.sessionKey,
+        terminalSummary: "Deferred maintenance cancelled during shutdown.",
       });
-      if (task) {
-        cancelTaskByIdForOwner({
-          taskId: task.taskId,
-          callerOwnerKey: params.sessionKey,
-          endedAt: Date.now(),
-          terminalSummary: "Deferred maintenance cancelled during shutdown.",
-        });
-      }
       return;
     }
-    if (longRunningTimer) {
-      clearTimeout(longRunningTimer);
-      longRunningTimer = null;
-    }
+    clearLongRunningTimer();
     const endedAt = Date.now();
     const reason = formatErrorMessage(err);
     if (!surfacedUserNotice) {
@@ -532,6 +657,8 @@ async function runDeferredTurnMaintenanceWorker(params: {
     });
     log.warn(`deferred context engine maintenance failed: ${reason}`);
   } finally {
+    shutdownAbort.abortSignal?.removeEventListener("abort", clearLongRunningTimer);
+    params.scheduledAbortSignal?.removeEventListener("abort", clearLongRunningTimer);
     shutdownAbort.dispose();
   }
 }
@@ -593,6 +720,7 @@ function scheduleDeferredTurnMaintenance(
         agentId: params.agentId,
         config: params.config,
         runId: task.runId!,
+        scheduledAbortSignal: schedulerAbort.abortSignal,
       }),
     );
   } catch (err) {
@@ -607,6 +735,9 @@ function scheduleDeferredTurnMaintenance(
   let state!: DeferredTurnMaintenanceRunState;
   const trackedPromise = runPromise
     .catch((err) => {
+      if (schedulerAbort.abortSignal?.aborted) {
+        return;
+      }
       markDeferredTurnMaintenanceTaskScheduleFailure({
         sessionKey,
         taskId: task.taskId,
@@ -631,6 +762,8 @@ function scheduleDeferredTurnMaintenance(
     promise: trackedPromise,
     rerunRequested: false,
     latestParams: { ...params, sessionKey },
+    taskId: task.taskId,
+    runId: task.runId!,
   };
   activeDeferredTurnMaintenanceRuns.set(sessionKey, state);
   void trackedPromise;

--- a/src/agents/pi-embedded-runner/context-engine-maintenance.ts
+++ b/src/agents/pi-embedded-runner/context-engine-maintenance.ts
@@ -28,6 +28,7 @@ import {
   findTaskByRunIdForOwner,
   updateTaskNotifyPolicyForOwner,
 } from "../../tasks/task-owner-access.js";
+import { markTaskLostById } from "../../tasks/task-registry.js";
 import { findActiveSessionTask } from "../session-async-task-status.js";
 import { resolveContextEngineCapabilities } from "./context-engine-capabilities.js";
 import { resolveSessionLane } from "./lanes.js";
@@ -47,6 +48,9 @@ const TURN_MAINTENANCE_CLI_EXIT_DRAIN_MS = 1_000;
 const DEFERRED_TURN_MAINTENANCE_ABORT_STATE_KEY = Symbol.for(
   "openclaw.contextEngineTurnMaintenanceAbortState",
 );
+const DEFERRED_TURN_MAINTENANCE_CLI_EXIT_HOOK_KEY = Symbol.for(
+  "openclaw.contextEngineTurnMaintenanceCliExitHook",
+);
 type DeferredTurnMaintenanceScheduleParams = {
   contextEngine: ContextEngine;
   sessionId: string;
@@ -64,6 +68,7 @@ type DeferredTurnMaintenanceRunState = {
   latestParams: DeferredTurnMaintenanceScheduleParams;
   taskId: string;
   runId: string;
+  isWorkerStarted: () => boolean;
 };
 
 const activeDeferredTurnMaintenanceRuns = new Map<string, DeferredTurnMaintenanceRunState>();
@@ -79,6 +84,12 @@ type DeferredTurnMaintenanceAbortState = {
   registered: boolean;
   controllers: Set<AbortController>;
   cleanupHandlers: Map<DeferredTurnMaintenanceSignal, () => void>;
+};
+type DeferredTurnMaintenanceCliExitHookState = {
+  cancelForCliExit?: (params?: { drainMs?: number }) => Promise<void>;
+};
+type DeferredTurnMaintenanceGlobal = typeof globalThis & {
+  [DEFERRED_TURN_MAINTENANCE_CLI_EXIT_HOOK_KEY]?: DeferredTurnMaintenanceCliExitHookState;
 };
 
 function resolveDeferredTurnMaintenanceAbortState(
@@ -231,6 +242,28 @@ function cancelDeferredTurnMaintenanceTask(params: {
   });
 }
 
+function markDeferredTurnMaintenanceTaskLost(params: {
+  sessionKey: string;
+  runId: string;
+  error: string;
+}): void {
+  const task = findTaskByRunIdForOwner({
+    runId: params.runId,
+    callerOwnerKey: params.sessionKey,
+  });
+  if (!task) {
+    return;
+  }
+  if (["succeeded", "failed", "timed_out", "cancelled", "lost"].includes(task.status)) {
+    return;
+  }
+  markTaskLostById({
+    taskId: task.taskId,
+    endedAt: Date.now(),
+    error: params.error,
+  });
+}
+
 export async function cancelActiveDeferredTurnMaintenanceRunsForCliExit(params?: {
   drainMs?: number;
 }): Promise<void> {
@@ -247,11 +280,13 @@ export async function cancelActiveDeferredTurnMaintenanceRunsForCliExit(params?:
   for (const [activeSessionKey, state] of activeEntries) {
     state.rerunRequested = false;
     activeDeferredTurnMaintenanceRuns.delete(activeSessionKey);
-    cancelDeferredTurnMaintenanceTask({
-      sessionKey: activeSessionKey,
-      runId: state.runId,
-      terminalSummary: "Deferred maintenance cancelled because the CLI command completed.",
-    });
+    if (!state.isWorkerStarted()) {
+      cancelDeferredTurnMaintenanceTask({
+        sessionKey: activeSessionKey,
+        runId: state.runId,
+        terminalSummary: "Deferred maintenance cancelled because the CLI command completed.",
+      });
+    }
     const lane = resolveDeferredTurnMaintenanceLane(activeSessionKey);
     clearCommandLane(lane);
     resetCommandLane(lane);
@@ -261,14 +296,39 @@ export async function cancelActiveDeferredTurnMaintenanceRunsForCliExit(params?:
   if (drainMs === 0) {
     return;
   }
+  const settledSessionKeys = new Set<string>();
+  const trackedPromises = activeEntries.map(([activeSessionKey, state]) =>
+    state.promise.finally(() => {
+      settledSessionKeys.add(activeSessionKey);
+    }),
+  );
   await Promise.race([
-    Promise.allSettled(activeEntries.map(([, state]) => state.promise)),
+    Promise.allSettled(trackedPromises),
     new Promise<void>((resolve) => {
       const timeout = setTimeout(resolve, drainMs);
       timeout.unref?.();
     }),
   ]);
+  for (const [activeSessionKey, state] of activeEntries) {
+    if (!state.isWorkerStarted() || settledSessionKeys.has(activeSessionKey)) {
+      continue;
+    }
+    markDeferredTurnMaintenanceTaskLost({
+      sessionKey: activeSessionKey,
+      runId: state.runId,
+      error: "Deferred maintenance did not stop before CLI exit after cancellation.",
+    });
+  }
 }
+
+function registerDeferredTurnMaintenanceCliExitHook(): void {
+  const globalState = globalThis as DeferredTurnMaintenanceGlobal;
+  const state = globalState[DEFERRED_TURN_MAINTENANCE_CLI_EXIT_HOOK_KEY] ?? {};
+  state.cancelForCliExit = cancelActiveDeferredTurnMaintenanceRunsForCliExit;
+  globalState[DEFERRED_TURN_MAINTENANCE_CLI_EXIT_HOOK_KEY] = state;
+}
+
+registerDeferredTurnMaintenanceCliExitHook();
 
 function markDeferredTurnMaintenanceTaskScheduleFailure(params: {
   sessionKey: string;
@@ -708,9 +768,11 @@ function scheduleDeferredTurnMaintenance(
 
   const schedulerAbort = createDeferredTurnMaintenanceAbortSignal();
   let runPromise: Promise<void>;
+  let workerStarted = false;
   try {
-    runPromise = enqueueCommandInLane(resolveDeferredTurnMaintenanceLane(sessionKey), async () =>
-      runDeferredTurnMaintenanceWorker({
+    runPromise = enqueueCommandInLane(resolveDeferredTurnMaintenanceLane(sessionKey), async () => {
+      workerStarted = true;
+      return await runDeferredTurnMaintenanceWorker({
         contextEngine: params.contextEngine,
         sessionId: params.sessionId,
         sessionKey,
@@ -721,8 +783,8 @@ function scheduleDeferredTurnMaintenance(
         config: params.config,
         runId: task.runId!,
         scheduledAbortSignal: schedulerAbort.abortSignal,
-      }),
-    );
+      });
+    });
   } catch (err) {
     schedulerAbort.dispose();
     markDeferredTurnMaintenanceTaskScheduleFailure({
@@ -764,6 +826,7 @@ function scheduleDeferredTurnMaintenance(
     latestParams: { ...params, sessionKey },
     taskId: task.taskId,
     runId: task.runId!,
+    isWorkerStarted: () => workerStarted,
   };
   activeDeferredTurnMaintenanceRuns.set(sessionKey, state);
   void trackedPromise;

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -20,6 +20,9 @@ const closeActiveMemorySearchManagersMock = vi.hoisted(() => vi.fn(async () => {
 const hasMemoryRuntimeMock = vi.hoisted(() => vi.fn(() => false));
 const listAgentHarnessIdsMock = vi.hoisted(() => vi.fn((): string[] => []));
 const disposeRegisteredAgentHarnessesMock = vi.hoisted(() => vi.fn(async () => {}));
+const cancelActiveDeferredTurnMaintenanceRunsForCliExitMock = vi.hoisted(() =>
+  vi.fn(async () => {}),
+);
 const ensureTaskRegistryReadyMock = vi.hoisted(() => vi.fn());
 const startTaskRegistryMaintenanceMock = vi.hoisted(() => vi.fn());
 const outputRootHelpMock = vi.hoisted(() => vi.fn());
@@ -171,6 +174,11 @@ vi.mock("../plugins/memory-state.js", () => ({
 vi.mock("../agents/harness/registry.js", () => ({
   listAgentHarnessIds: listAgentHarnessIdsMock,
   disposeRegisteredAgentHarnesses: disposeRegisteredAgentHarnessesMock,
+}));
+
+vi.mock("../agents/pi-embedded-runner/context-engine-maintenance.js", () => ({
+  cancelActiveDeferredTurnMaintenanceRunsForCliExit:
+    cancelActiveDeferredTurnMaintenanceRunsForCliExitMock,
 }));
 
 vi.mock("../tasks/task-registry.js", () => ({
@@ -344,6 +352,7 @@ describe("runCli exit behavior", () => {
     expect(tryRouteCliMock).toHaveBeenCalledWith(["node", "openclaw", "status"]);
     expect(closeActiveMemorySearchManagersMock).not.toHaveBeenCalled();
     expect(disposeRegisteredAgentHarnessesMock).not.toHaveBeenCalled();
+    expect(cancelActiveDeferredTurnMaintenanceRunsForCliExitMock).not.toHaveBeenCalled();
     expect(ensureTaskRegistryReadyMock).not.toHaveBeenCalled();
     expect(startTaskRegistryMaintenanceMock).not.toHaveBeenCalled();
     expect(exitSpy).not.toHaveBeenCalled();
@@ -362,6 +371,26 @@ describe("runCli exit behavior", () => {
     await runCli(["node", "openclaw", "agent", "--local"]);
 
     expect(parseAsync).toHaveBeenCalledWith(["node", "openclaw", "agent", "--local"]);
+    expect(cancelActiveDeferredTurnMaintenanceRunsForCliExitMock).toHaveBeenCalledTimes(1);
+    expect(disposeRegisteredAgentHarnessesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("continues CLI cleanup when deferred maintenance cancellation fails", async () => {
+    listAgentHarnessIdsMock.mockReturnValueOnce(["codex"]);
+    cancelActiveDeferredTurnMaintenanceRunsForCliExitMock.mockRejectedValueOnce(
+      new Error("maintenance cleanup failed"),
+    );
+    tryRouteCliMock.mockResolvedValueOnce(false);
+    const parseAsync = vi.fn().mockResolvedValueOnce(undefined);
+    buildProgramMock.mockReturnValueOnce({
+      commands: [{ name: () => "agent", aliases: () => [] }],
+      parseAsync,
+    });
+
+    await runCli(["node", "openclaw", "agent", "--local"]);
+
+    expect(parseAsync).toHaveBeenCalledWith(["node", "openclaw", "agent", "--local"]);
+    expect(cancelActiveDeferredTurnMaintenanceRunsForCliExitMock).toHaveBeenCalledTimes(1);
     expect(disposeRegisteredAgentHarnessesMock).toHaveBeenCalledTimes(1);
   });
 

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -78,6 +78,15 @@ const maybeRunCliInContainerMock = vi.hoisted(() =>
     (argv: string[]) => { handled: true; exitCode: number } | { handled: false; argv: string[] }
   >((argv: string[]) => ({ handled: false, argv })),
 );
+const deferredMaintenanceCliExitHookKey = Symbol.for(
+  "openclaw.contextEngineTurnMaintenanceCliExitHook",
+);
+
+function installDeferredMaintenanceCliExitHook() {
+  (globalThis as Record<PropertyKey, unknown>)[deferredMaintenanceCliExitHookKey] = {
+    cancelForCliExit: cancelActiveDeferredTurnMaintenanceRunsForCliExitMock,
+  };
+}
 
 function requireRunCrestodianOptions(index = 0): { onReady?: unknown } {
   const call = runCrestodianMock.mock.calls[index];
@@ -174,11 +183,6 @@ vi.mock("../plugins/memory-state.js", () => ({
 vi.mock("../agents/harness/registry.js", () => ({
   listAgentHarnessIds: listAgentHarnessIdsMock,
   disposeRegisteredAgentHarnesses: disposeRegisteredAgentHarnessesMock,
-}));
-
-vi.mock("../agents/pi-embedded-runner/context-engine-maintenance.js", () => ({
-  cancelActiveDeferredTurnMaintenanceRunsForCliExit:
-    cancelActiveDeferredTurnMaintenanceRunsForCliExitMock,
 }));
 
 vi.mock("../tasks/task-registry.js", () => ({
@@ -327,6 +331,7 @@ describe("runCli exit behavior", () => {
     loadConfigMock.mockReturnValue({});
     startProxyMock.mockResolvedValue(null);
     stopProxyMock.mockResolvedValue(undefined);
+    Reflect.deleteProperty(globalThis, deferredMaintenanceCliExitHookKey);
     getProgramContextMock.mockReturnValue(null);
     resolvePluginCliRootOwnerIdsMock.mockImplementation(
       ({ primaryCommand }: { primaryCommand?: string }) =>
@@ -340,7 +345,7 @@ describe("runCli exit behavior", () => {
     loggingState.forceConsoleToStderr = false;
   });
 
-  it("does not force process.exit after successful routed command", async () => {
+  it("skips deferred maintenance cleanup when no hook was registered for routed command", async () => {
     tryRouteCliMock.mockResolvedValueOnce(true);
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
       throw new Error(`unexpected process.exit(${String(code)})`);
@@ -359,7 +364,28 @@ describe("runCli exit behavior", () => {
     exitSpy.mockRestore();
   });
 
+  it("cancels deferred maintenance after successful routed command when hook is registered", async () => {
+    installDeferredMaintenanceCliExitHook();
+    tryRouteCliMock.mockResolvedValueOnce(true);
+
+    await runCli(["node", "openclaw", "models", "status", "--probe"]);
+
+    expect(cancelActiveDeferredTurnMaintenanceRunsForCliExitMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels deferred maintenance after routed command failure", async () => {
+    installDeferredMaintenanceCliExitHook();
+    tryRouteCliMock.mockRejectedValueOnce(new Error("routed command failed"));
+
+    await expect(runCli(["node", "openclaw", "models", "status", "--probe"])).rejects.toThrow(
+      "routed command failed",
+    );
+
+    expect(cancelActiveDeferredTurnMaintenanceRunsForCliExitMock).toHaveBeenCalledTimes(1);
+  });
+
   it("disposes registered harnesses after full CLI command completion", async () => {
+    installDeferredMaintenanceCliExitHook();
     listAgentHarnessIdsMock.mockReturnValueOnce(["codex"]);
     tryRouteCliMock.mockResolvedValueOnce(false);
     const parseAsync = vi.fn().mockResolvedValueOnce(undefined);
@@ -376,6 +402,7 @@ describe("runCli exit behavior", () => {
   });
 
   it("continues CLI cleanup when deferred maintenance cancellation fails", async () => {
+    installDeferredMaintenanceCliExitHook();
     listAgentHarnessIdsMock.mockReturnValueOnce(["codex"]);
     cancelActiveDeferredTurnMaintenanceRunsForCliExitMock.mockRejectedValueOnce(
       new Error("maintenance cleanup failed"),

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -229,11 +229,25 @@ async function disposeCliAgentHarnesses(): Promise<void> {
   }
 }
 
+const DEFERRED_TURN_MAINTENANCE_CLI_EXIT_HOOK_KEY = Symbol.for(
+  "openclaw.contextEngineTurnMaintenanceCliExitHook",
+);
+type DeferredTurnMaintenanceCliExitHookState = {
+  cancelForCliExit?: () => Promise<void> | void;
+};
+type DeferredTurnMaintenanceGlobal = typeof globalThis & {
+  [DEFERRED_TURN_MAINTENANCE_CLI_EXIT_HOOK_KEY]?: DeferredTurnMaintenanceCliExitHookState;
+};
+
 async function cancelCliDeferredContextEngineMaintenance(): Promise<void> {
+  const hook = (globalThis as DeferredTurnMaintenanceGlobal)[
+    DEFERRED_TURN_MAINTENANCE_CLI_EXIT_HOOK_KEY
+  ]?.cancelForCliExit;
+  if (!hook) {
+    return;
+  }
   try {
-    const { cancelActiveDeferredTurnMaintenanceRunsForCliExit } =
-      await import("../agents/pi-embedded-runner/context-engine-maintenance.js");
-    await cancelActiveDeferredTurnMaintenanceRunsForCliExit();
+    await hook();
   } catch {
     // Best-effort teardown for short-lived CLI commands. Deferred maintenance
     // must not hide the command's real outcome.
@@ -545,7 +559,7 @@ export async function runCli(argv: string[] = process.argv) {
   let onSigterm: (() => void) | null = null;
   let onSigint: (() => void) | null = null;
   let onExit: (() => void) | null = null;
-  let parsedFullCliCommand = false;
+  let shouldCancelDeferredMaintenanceOnExit = false;
   if (proxyHandle) {
     const shutdown = (exitCode: number) => {
       if (onSigterm) {
@@ -715,8 +729,14 @@ export async function runCli(argv: string[] = process.argv) {
     }
 
     const { tryRouteCli } = await startupTrace.measure("route-import", () => import("./route.js"));
-    if (await startupTrace.measure("route", () => tryRouteCli(normalizedArgv))) {
-      return;
+    try {
+      if (await startupTrace.measure("route", () => tryRouteCli(normalizedArgv))) {
+        shouldCancelDeferredMaintenanceOnExit = true;
+        return;
+      }
+    } catch (error) {
+      shouldCancelDeferredMaintenanceOnExit = true;
+      throw error;
     }
 
     const { createCliProgress } = await import("./progress.js");
@@ -862,7 +882,7 @@ export async function runCli(argv: string[] = process.argv) {
       stopStartupProgress();
 
       try {
-        parsedFullCliCommand = true;
+        shouldCancelDeferredMaintenanceOnExit = true;
         await startupTrace.measure("parse", () => program.parseAsync(parseArgv));
       } catch (error) {
         if (!isCommanderParseExit(error)) {
@@ -884,7 +904,7 @@ export async function runCli(argv: string[] = process.argv) {
       process.off("exit", onExit);
     }
     await stopStartedProxy();
-    if (parsedFullCliCommand) {
+    if (shouldCancelDeferredMaintenanceOnExit) {
       await cancelCliDeferredContextEngineMaintenance();
     }
     await disposeCliAgentHarnesses();

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -229,6 +229,17 @@ async function disposeCliAgentHarnesses(): Promise<void> {
   }
 }
 
+async function cancelCliDeferredContextEngineMaintenance(): Promise<void> {
+  try {
+    const { cancelActiveDeferredTurnMaintenanceRunsForCliExit } =
+      await import("../agents/pi-embedded-runner/context-engine-maintenance.js");
+    await cancelActiveDeferredTurnMaintenanceRunsForCliExit();
+  } catch {
+    // Best-effort teardown for short-lived CLI commands. Deferred maintenance
+    // must not hide the command's real outcome.
+  }
+}
+
 const UNCONFIGURED_CONFIG_IGNORED_KEYS = new Set(["$schema", "meta"]);
 
 function isUnconfiguredConfigSnapshot(
@@ -534,6 +545,7 @@ export async function runCli(argv: string[] = process.argv) {
   let onSigterm: (() => void) | null = null;
   let onSigint: (() => void) | null = null;
   let onExit: (() => void) | null = null;
+  let parsedFullCliCommand = false;
   if (proxyHandle) {
     const shutdown = (exitCode: number) => {
       if (onSigterm) {
@@ -850,6 +862,7 @@ export async function runCli(argv: string[] = process.argv) {
       stopStartupProgress();
 
       try {
+        parsedFullCliCommand = true;
         await startupTrace.measure("parse", () => program.parseAsync(parseArgv));
       } catch (error) {
         if (!isCommanderParseExit(error)) {
@@ -871,6 +884,9 @@ export async function runCli(argv: string[] = process.argv) {
       process.off("exit", onExit);
     }
     await stopStartedProxy();
+    if (parsedFullCliCommand) {
+      await cancelCliDeferredContextEngineMaintenance();
+    }
     await disposeCliAgentHarnesses();
     await closeCliMemoryManagers();
     pauseNonTtyStdinForCliExit();

--- a/src/context-engine/types.ts
+++ b/src/context-engine/types.ts
@@ -197,6 +197,11 @@ export type ContextEnginePromptCacheInfo = {
 
 export type ContextEngineRuntimeContext = Record<string, unknown> & {
   /**
+   * Optional host-owned cancellation signal for best-effort shutdown of
+   * background context-engine work.
+   */
+  abortSignal?: AbortSignal;
+  /**
    * True when the host has explicitly opted this maintenance run into
    * consuming deferred compaction debt.
    */


### PR DESCRIPTION
## Problem

Some short-lived CLI commands can complete their foreground work while background context-engine turn maintenance is still queued or running. The command has no more user-visible work to do, but deferred maintenance can keep the Node process alive and make operators wait for an outer wrapper timeout.

## Change and value

This PR adds scoped CLI teardown for completed CLI invocations:

- Routed commands and full Commander commands mark that CLI-exit cleanup may be needed once they actually run.
- The context-engine maintenance module registers a lightweight global cleanup hook only when that module has been loaded, so fast commands that never touched deferred maintenance do not dynamically import the maintenance bundle on exit.
- CLI teardown asks the context-engine maintenance owner to cancel active deferred turn-maintenance runs, clear/reset their dedicated lanes, and briefly drain cooperative work before continuing normal process cleanup.
- Transcript rewrite helpers check the shutdown abort both before enqueue and at execution time, so already-queued rewrites cannot mutate transcript state after CLI completion.
- Cooperative shutdown is reported as `cancelled`; active maintenance that ignores the abort and does not stop before the drain window is reported as `lost`, not falsely as a clean cancellation.

This is intentionally narrower than a global `process.exit()` workaround. It cleans up known deferred context-engine work without changing unrelated process lifetime behavior.

## Who is affected

- Affected: operators and scripts running short-lived CLI commands, especially `openclaw agent --local`, where deferred context-engine maintenance can otherwise keep the process alive after command completion.
- Also covered: routed commands such as `models status --probe` that can enter agent/runtime paths before returning from the route fast path.
- Not fixed here: cases where the local agent command never resolves. That no-completion class is covered separately by #86276.

## Real Behavior Proof

Exact source head tested: `ce618cea9cd913a40db87aa25274d4d2ff655e64`

Command:

```bash
timeout 240s node /tmp/openclaw-pr-86264/openclaw.mjs agent --local --agent main --session-id source-cli-exit-proof --message 'Return marker OPENCLAW_SOURCE_86264_EXIT_PROOF_OK' --thinking off --json
```

Captured proof:

```text
REPO_HEAD ce618cea9cd913a40db87aa25274d4d2ff655e64
REPO_STATUS 0
OPENCLAW_VERSION OpenClaw 2026.5.25 (ce618ce)
finalAssistantVisibleText: OPENCLAW_SOURCE_86264_EXIT_PROOF_OK
executionTrace.winnerProvider: openai
executionTrace.winnerModel: gpt-5.5
executionTrace.attempts[0].result: success
executionTrace.runner: embedded
mock request path: /v1/responses
EXIT_CODE=0
ELAPSED_SEC=51
ASSERT_AGENT_TURN=passed
```

Artifacts captured locally under `/home/captain/codex-workspace/proof/2026-05-25-cli-exit-combined/`:

- `50-source-exact-head-mock-success.out`
- `50-source-exact-head-mock-success.agent.jsonl`
- `50-source-exact-head-mock-success.mock-requests.jsonl`

Production/local patch proof was also rerun after backporting this PR onto the installed global OpenClaw package:

```text
OPENCLAW_BIN /home/captain/.nvm/versions/node/v26.1.0/bin/openclaw
OPENCLAW_VERSION OpenClaw 2026.5.20 (e510042)
SOURCE_ASSERTION_REPO_HEAD ce618cea9cd913a40db87aa25274d4d2ff655e64
finalAssistantVisibleText: OPENCLAW_PRODUCTION_86264_EXIT_PROOF_OK
executionTrace.winnerProvider: openai
executionTrace.winnerModel: gpt-5.5
executionTrace.runner: embedded
EXIT_CODE=0
ELAPSED_SEC=20
ASSERT_AGENT_TURN=passed
```

## Verification

On exact source head `ce618cea9cd913a40db87aa25274d4d2ff655e64`:

- `env OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build`
- `timeout 300s node scripts/test-projects.mjs src/cli/run-main.exit.test.ts src/agents/pi-embedded-runner/context-engine-maintenance.test.ts`
  - CLI shard: 91 tests passed
  - Agents shard: 26 tests passed
- `timeout 900s codex review --base origin/main`
  - final result: no actionable correctness issues found
- Read-only multi-lane review swarm findings were triaged:
  - accepted and fixed: routed-command cleanup path
  - accepted and fixed: avoid importing maintenance bundle when no hook is registered
  - accepted and fixed: active non-cooperative maintenance is `lost`, not cleanly `cancelled`
  - accepted and fixed: queued transcript rewrite after abort regression coverage
- `git diff --check HEAD`

Local patch validation:

- `python3 /home/captain/my-openclaw-patches/scripts/apply-cli-exit-fix.py --dry-run`
  - all targets report already applied
- `node --check` on patched live `dist/cli/run-main.js`
- `node --check` on patched live `dist/context-engine-maintenance-DFRrf-67.js`
- `openclaw --version`
- `openclaw agent --help`
- production mock-agent behavior proof listed above

What was not tested: no changed-path runtime gap remains for the source proof or local backport proof. This PR is intentionally still draft while maintainer review/CI policy catches up.

## Relationship to #86276

#86276 handles the no-completion class: a local/embedded agent command never settles, so the CLI needs a hard wall-clock boundary. This PR handles the post-completion cleanup class: a command produced its result and needs scoped cleanup of known deferred maintenance work so the process can exit. The local backport composes both fixes.

AI-assisted: yes.
