### PR TITLE
Fix stale approval prompts in Control UI

### DIFF
--- a/ui/src/ui/app-gateway-chat-load.node.test.ts
+++ b/ui/src/ui/app-gateway-chat-load.node.test.ts
@@ -91,6 +91,7 @@ vi.mock("./controllers/devices.ts", () => ({
 vi.mock("./controllers/exec-approval.ts", () => ({
   addExecApproval: vi.fn((queue, entry) => [...queue, entry]),
   clearResolvedExecApprovalPrompt: vi.fn(),
+  enqueueExecApprovalPrompt: vi.fn(),
   parseExecApprovalRequested: vi.fn(() => null),
   parseExecApprovalResolved: vi.fn(() => null),
   parsePluginApprovalRequested: vi.fn(() => null),

--- a/ui/src/ui/app-gateway-chat-load.node.test.ts
+++ b/ui/src/ui/app-gateway-chat-load.node.test.ts
@@ -90,6 +90,7 @@ vi.mock("./controllers/devices.ts", () => ({
 
 vi.mock("./controllers/exec-approval.ts", () => ({
   addExecApproval: vi.fn((queue, entry) => [...queue, entry]),
+  clearResolvedExecApprovalPrompt: vi.fn(),
   parseExecApprovalRequested: vi.fn(() => null),
   parseExecApprovalResolved: vi.fn(() => null),
   parsePluginApprovalRequested: vi.fn(() => null),

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -569,6 +569,49 @@ describe("connectGateway", () => {
     expect(host.execApprovalBusy).toBe(true);
   });
 
+  it("clears active approval errors when event-enqueued approvals expire", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-25T00:00:00.000Z"));
+    try {
+      const { host, client } = connectHostGateway();
+      const queuedExpiresAtMs = Date.now() + 60_000;
+      const activeExpiresAtMs = Date.now() + 1_000;
+
+      client.emitEvent({
+        event: "exec.approval.requested",
+        payload: {
+          id: "approval-queued",
+          request: {
+            command: "pnpm test",
+            host: "gateway",
+          },
+          createdAtMs: Date.now(),
+          expiresAtMs: queuedExpiresAtMs,
+        },
+      });
+      client.emitEvent({
+        event: "exec.approval.requested",
+        payload: {
+          id: "approval-active-expiring",
+          request: {
+            command: "pnpm check:changed",
+            host: "gateway",
+          },
+          createdAtMs: Date.now() + 1,
+          expiresAtMs: activeExpiresAtMs,
+        },
+      });
+      host.execApprovalError = "Approval failed: Error: gateway unavailable";
+
+      vi.advanceTimersByTime(1_500);
+
+      expect(host.execApprovalQueue.map((entry) => entry.id)).toEqual(["approval-queued"]);
+      expect(host.execApprovalError).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("clears pending session reload timers when the active client closes", () => {
     vi.useFakeTimers();
     try {

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -183,6 +183,7 @@ function createHost(): TestGatewayHost {
     refreshSessionsAfterChat: new Set<string>(),
     chatSideResultTerminalRuns: new Set<string>(),
     execApprovalQueue: [],
+    execApprovalBusy: false,
     execApprovalError: null,
     updateAvailable: null,
     updateComplete: new Promise(() => undefined),
@@ -538,6 +539,34 @@ describe("connectGateway", () => {
     expect(host.execApprovalQueue[0]?.request.commandSpans).toEqual([
       { startIndex: 20, endIndex: 26 },
     ]);
+  });
+
+  it("clears stale approval modal errors without interrupting an in-flight local resolve", () => {
+    const { host, client } = connectHostGateway();
+
+    client.emitEvent({
+      event: "exec.approval.requested",
+      payload: {
+        id: "approval-external-1",
+        request: {
+          command: "pnpm test",
+          host: "gateway",
+        },
+        createdAtMs: Date.now(),
+        expiresAtMs: Date.now() + 60_000,
+      },
+    });
+    host.execApprovalError = "Approval failed: approval already resolved";
+    host.execApprovalBusy = true;
+
+    client.emitEvent({
+      event: "exec.approval.resolved",
+      payload: { id: "approval-external-1", decision: "allow-once" },
+    });
+
+    expect(host.execApprovalQueue).toHaveLength(0);
+    expect(host.execApprovalError).toBeNull();
+    expect(host.execApprovalBusy).toBe(true);
   });
 
   it("clears pending session reload timers when the active client closes", () => {

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -44,8 +44,10 @@ vi.mock("./controllers/devices.ts", () => ({
 }));
 vi.mock("./controllers/exec-approval.ts", () => ({
   addExecApproval: vi.fn(),
+  clearResolvedExecApprovalPrompt: vi.fn(),
   parseExecApprovalRequested: vi.fn(() => null),
   parseExecApprovalResolved: vi.fn(() => null),
+  parsePluginApprovalRequested: vi.fn(() => null),
   pruneExecApprovalQueue: vi.fn((queue) => queue),
   removeExecApproval: vi.fn(),
 }));

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -45,6 +45,7 @@ vi.mock("./controllers/devices.ts", () => ({
 vi.mock("./controllers/exec-approval.ts", () => ({
   addExecApproval: vi.fn(),
   clearResolvedExecApprovalPrompt: vi.fn(),
+  enqueueExecApprovalPrompt: vi.fn(),
   parseExecApprovalRequested: vi.fn(() => null),
   parseExecApprovalResolved: vi.fn(() => null),
   parsePluginApprovalRequested: vi.fn(() => null),

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -45,6 +45,7 @@ import { loadDevices, type DevicesState } from "./controllers/devices.ts";
 import type { ExecApprovalRequest } from "./controllers/exec-approval.ts";
 import {
   addExecApproval,
+  clearResolvedExecApprovalPrompt,
   parseExecApprovalRequested,
   parseExecApprovalResolved,
   parsePluginApprovalRequested,
@@ -121,6 +122,7 @@ type GatewayHost = {
   refreshSessionsAfterChat: Set<string>;
   sessionsLoading?: boolean;
   execApprovalQueue: ExecApprovalRequest[];
+  execApprovalBusy: boolean;
   execApprovalError: string | null;
   updateAvailable: UpdateAvailable | null;
   reconcileWebPushState?: () => Promise<void> | void;
@@ -167,7 +169,7 @@ function enqueueApprovalRequest(host: GatewayHost, entry: ExecApprovalRequest | 
 function removeResolvedApprovalRequest(host: GatewayHost, payload: unknown) {
   const resolved = parseExecApprovalResolved(payload);
   if (resolved) {
-    host.execApprovalQueue = removeExecApproval(host.execApprovalQueue, resolved.id);
+    clearResolvedExecApprovalPrompt(host, resolved.id);
   }
 }
 

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -44,13 +44,12 @@ import { loadControlUiBootstrapConfig } from "./controllers/control-ui-bootstrap
 import { loadDevices, type DevicesState } from "./controllers/devices.ts";
 import type { ExecApprovalRequest } from "./controllers/exec-approval.ts";
 import {
-  addExecApproval,
   clearResolvedExecApprovalPrompt,
+  enqueueExecApprovalPrompt,
   parseExecApprovalRequested,
   parseExecApprovalResolved,
   parsePluginApprovalRequested,
   pruneExecApprovalQueue,
-  removeExecApproval,
 } from "./controllers/exec-approval.ts";
 import { loadHealthState, type HealthState } from "./controllers/health.ts";
 import {
@@ -158,12 +157,7 @@ function enqueueApprovalRequest(host: GatewayHost, entry: ExecApprovalRequest | 
   if (!entry) {
     return;
   }
-  host.execApprovalQueue = addExecApproval(host.execApprovalQueue, entry);
-  host.execApprovalError = null;
-  const delay = Math.max(0, entry.expiresAtMs - Date.now() + 500);
-  window.setTimeout(() => {
-    host.execApprovalQueue = removeExecApproval(host.execApprovalQueue, entry.id);
-  }, delay);
+  enqueueExecApprovalPrompt(host, entry);
 }
 
 function removeResolvedApprovalRequest(host: GatewayHost, payload: unknown) {

--- a/ui/src/ui/app.exec-approval.test.ts
+++ b/ui/src/ui/app.exec-approval.test.ts
@@ -1,0 +1,113 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createStorageMock } from "../test-helpers/storage.ts";
+import type { ExecApprovalRequest } from "./controllers/exec-approval.ts";
+
+type RequestFn = (method: string, params?: unknown) => Promise<unknown>;
+
+function createExecApproval(overrides: Partial<ExecApprovalRequest> = {}): ExecApprovalRequest {
+  return {
+    id: "approval-1",
+    kind: "exec",
+    request: { command: "echo hello" },
+    createdAtMs: 1000,
+    expiresAtMs: Date.now() + 60_000,
+    ...overrides,
+  };
+}
+
+function createGatewayError(message: string, details?: unknown): Error {
+  const err = new Error(message);
+  Object.defineProperty(err, "gatewayCode", {
+    value: "INVALID_REQUEST",
+    enumerable: true,
+  });
+  Object.defineProperty(err, "details", {
+    value: details,
+    enumerable: true,
+  });
+  return err;
+}
+
+async function createApp(
+  request: RequestFn,
+  queue: ExecApprovalRequest[] = [createExecApproval()],
+) {
+  const { OpenClawApp } = await import("./app.ts");
+  const app = new OpenClawApp();
+  Object.defineProperty(app, "client", {
+    value: { request },
+    writable: true,
+  });
+  app.execApprovalQueue = queue;
+  app.execApprovalBusy = false;
+  app.execApprovalError = null;
+  return app;
+}
+
+describe("OpenClawApp exec approval decisions", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createStorageMock());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("dismisses the active approval after same-decision idempotent success", async () => {
+    const request = vi.fn<RequestFn>(async () => ({ ok: true }));
+    const app = await createApp(request);
+
+    await app.handleExecApprovalDecision("allow-once");
+
+    expect(request).toHaveBeenCalledWith("exec.approval.resolve", {
+      id: "approval-1",
+      decision: "allow-once",
+    });
+    expect(app.execApprovalQueue).toEqual([]);
+    expect(app.execApprovalError).toBeNull();
+    expect(app.execApprovalBusy).toBe(false);
+  });
+
+  it("dismisses and refreshes when the backend reports an already resolved approval", async () => {
+    const request = vi.fn<RequestFn>(async (method) => {
+      if (method === "exec.approval.resolve") {
+        throw createGatewayError("approval already resolved", {
+          reason: "APPROVAL_ALREADY_RESOLVED",
+        });
+      }
+      if (method === "exec.approval.list") {
+        return [];
+      }
+      if (method === "plugin.approval.list") {
+        return [];
+      }
+      return {};
+    });
+    const app = await createApp(request);
+
+    await app.handleExecApprovalDecision("deny");
+
+    expect(app.execApprovalQueue).toEqual([]);
+    expect(app.execApprovalError).toBeNull();
+    expect(app.execApprovalBusy).toBe(false);
+    expect(request).toHaveBeenCalledWith("exec.approval.list", {});
+    expect(request).toHaveBeenCalledWith("plugin.approval.list", {});
+  });
+
+  it("keeps the active approval open for unrelated errors", async () => {
+    const request = vi.fn<RequestFn>(async () => {
+      throw createGatewayError("gateway unavailable");
+    });
+    const active = createExecApproval();
+    const app = await createApp(request, [active]);
+
+    await app.handleExecApprovalDecision("deny");
+
+    expect(app.execApprovalQueue).toEqual([active]);
+    expect(app.execApprovalError).toBe("Approval failed: Error: gateway unavailable");
+    expect(app.execApprovalBusy).toBe(false);
+  });
+});

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -94,7 +94,11 @@ import type {
   WikiImportInsights,
   WikiMemoryPalace,
 } from "./controllers/dreaming.ts";
-import type { ExecApprovalRequest } from "./controllers/exec-approval.ts";
+import {
+  resolveActiveExecApprovalDecision,
+  type ExecApprovalDecision,
+  type ExecApprovalRequest,
+} from "./controllers/exec-approval.ts";
 import type { ExecApprovalsFile, ExecApprovalsSnapshot } from "./controllers/exec-approvals.ts";
 import type {
   ClawHubSearchResult,
@@ -1213,25 +1217,8 @@ export class OpenClawApp extends LitElement {
     handleNostrProfileToggleAdvancedInternal(this);
   }
 
-  async handleExecApprovalDecision(decision: "allow-once" | "allow-always" | "deny") {
-    const active = this.execApprovalQueue[0];
-    if (!active || !this.client || this.execApprovalBusy) {
-      return;
-    }
-    this.execApprovalBusy = true;
-    this.execApprovalError = null;
-    try {
-      const method = active.kind === "plugin" ? "plugin.approval.resolve" : "exec.approval.resolve";
-      await this.client.request(method, {
-        id: active.id,
-        decision,
-      });
-      this.execApprovalQueue = this.execApprovalQueue.filter((entry) => entry.id !== active.id);
-    } catch (err) {
-      this.execApprovalError = `Approval failed: ${String(err)}`;
-    } finally {
-      this.execApprovalBusy = false;
-    }
+  async handleExecApprovalDecision(decision: ExecApprovalDecision) {
+    await resolveActiveExecApprovalDecision(this, decision);
   }
 
   handleGatewayUrlConfirm() {

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -95,8 +95,9 @@ import type {
   WikiMemoryPalace,
 } from "./controllers/dreaming.ts";
 import {
-  resolveActiveExecApprovalDecision,
-  type ExecApprovalDecision,
+  dismissExecApprovalPrompt,
+  isStaleApprovalResolutionError,
+  refreshPendingApprovalQueue,
   type ExecApprovalRequest,
 } from "./controllers/exec-approval.ts";
 import type { ExecApprovalsFile, ExecApprovalsSnapshot } from "./controllers/exec-approvals.ts";
@@ -1217,8 +1218,33 @@ export class OpenClawApp extends LitElement {
     handleNostrProfileToggleAdvancedInternal(this);
   }
 
-  async handleExecApprovalDecision(decision: ExecApprovalDecision) {
-    await resolveActiveExecApprovalDecision(this, decision);
+  async handleExecApprovalDecision(decision: "allow-once" | "allow-always" | "deny") {
+    const active = this.execApprovalQueue[0];
+    if (!active || !this.client || this.execApprovalBusy) {
+      return;
+    }
+    this.execApprovalBusy = true;
+    this.execApprovalError = null;
+    try {
+      const method = active.kind === "plugin" ? "plugin.approval.resolve" : "exec.approval.resolve";
+      await this.client.request(method, {
+        id: active.id,
+        decision,
+      });
+      dismissExecApprovalPrompt(this, active.id);
+    } catch (err) {
+      if (isStaleApprovalResolutionError(err)) {
+        dismissExecApprovalPrompt(this, active.id);
+        await refreshPendingApprovalQueue(this);
+        return;
+      }
+      if (!this.execApprovalQueue.some((entry) => entry.id === active.id)) {
+        return;
+      }
+      this.execApprovalError = `Approval failed: ${String(err)}`;
+    } finally {
+      this.execApprovalBusy = false;
+    }
   }
 
   handleGatewayUrlConfirm() {

--- a/ui/src/ui/controllers/exec-approval.test.ts
+++ b/ui/src/ui/controllers/exec-approval.test.ts
@@ -337,6 +337,62 @@ describe("refreshPendingApprovalQueue", () => {
     ]);
   });
 
+  it("does not requeue approvals resolved while a refresh is in flight", async () => {
+    let resolveExecList: (value: unknown[]) => void = () => {};
+    const execApprovalList = new Promise<unknown[]>((resolve) => {
+      resolveExecList = resolve;
+    });
+    const request = vi.fn<RequestFn>(async (method) => {
+      if (method === "exec.approval.list") {
+        return execApprovalList;
+      }
+      if (method === "plugin.approval.list") {
+        return [];
+      }
+      return {};
+    });
+    const resolvingApproval = createExecApproval({ id: "approval-resolving" });
+    const state = createPromptState(request, [resolvingApproval]);
+
+    const refreshPromise = refreshPendingApprovalQueue(state);
+    clearResolvedExecApprovalPrompt(state, "approval-resolving");
+    resolveExecList([resolvingApproval]);
+    await refreshPromise;
+
+    expect(state.execApprovalQueue).toEqual([]);
+  });
+
+  it("does not requeue new approvals resolved before refresh completes", async () => {
+    let resolveExecList: (value: unknown[]) => void = () => {};
+    let resolvePluginList: (value: unknown[]) => void = () => {};
+    const execApprovalList = new Promise<unknown[]>((resolve) => {
+      resolveExecList = resolve;
+    });
+    const pluginApprovalList = new Promise<unknown[]>((resolve) => {
+      resolvePluginList = resolve;
+    });
+    const request = vi.fn<RequestFn>(async (method) => {
+      if (method === "exec.approval.list") {
+        return execApprovalList;
+      }
+      if (method === "plugin.approval.list") {
+        return pluginApprovalList;
+      }
+      return {};
+    });
+    const state = createPromptState(request, []);
+    const transientApproval = createExecApproval({ id: "approval-transient" });
+
+    const refreshPromise = refreshPendingApprovalQueue(state);
+    state.execApprovalQueue = addExecApproval(state.execApprovalQueue, transientApproval);
+    resolveExecList([transientApproval]);
+    clearResolvedExecApprovalPrompt(state, "approval-transient");
+    resolvePluginList([]);
+    await refreshPromise;
+
+    expect(state.execApprovalQueue).toEqual([]);
+  });
+
   it("removes refreshed approvals after their expiry", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-25T00:00:00.000Z"));
@@ -364,6 +420,78 @@ describe("refreshPendingApprovalQueue", () => {
       expect(state.execApprovalQueue.map((entry) => entry.id)).toEqual(["approval-refreshed-1"]);
 
       vi.advanceTimersByTime(1_500);
+
+      expect(state.execApprovalQueue).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears active prompt errors when expiry advances the queue", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-25T00:00:00.000Z"));
+    try {
+      const activeExpiresAtMs = Date.now() + 1_000;
+      const queuedExpiresAtMs = Date.now() + 60_000;
+      const request = vi.fn<RequestFn>(async (method) => {
+        if (method === "exec.approval.list") {
+          return [
+            {
+              id: "approval-active-expiring",
+              request: { command: "pnpm check:changed" },
+              createdAtMs: Date.now() + 1,
+              expiresAtMs: activeExpiresAtMs,
+            },
+            {
+              id: "approval-queued",
+              request: { command: "pnpm test" },
+              createdAtMs: Date.now(),
+              expiresAtMs: queuedExpiresAtMs,
+            },
+          ];
+        }
+        if (method === "plugin.approval.list") {
+          return [];
+        }
+        return {};
+      });
+      const state = createPromptState(request, []);
+
+      await refreshPendingApprovalQueue(state);
+      state.execApprovalError = "Approval failed: Error: gateway unavailable";
+
+      vi.advanceTimersByTime(1_500);
+
+      expect(state.execApprovalQueue.map((entry) => entry.id)).toEqual(["approval-queued"]);
+      expect(state.execApprovalError).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not requeue expired approvals returned by refresh lists", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-25T00:00:00.000Z"));
+    try {
+      const request = vi.fn<RequestFn>(async (method) => {
+        if (method === "exec.approval.list") {
+          return [
+            {
+              id: "approval-expired-1",
+              request: { command: "pnpm check:changed" },
+              createdAtMs: Date.now() - 2_000,
+              expiresAtMs: Date.now() - 1_000,
+            },
+          ];
+        }
+        if (method === "plugin.approval.list") {
+          return [];
+        }
+        return {};
+      });
+      const state = createPromptState(request, []);
+
+      await refreshPendingApprovalQueue(state);
 
       expect(state.execApprovalQueue).toEqual([]);
     } finally {

--- a/ui/src/ui/controllers/exec-approval.test.ts
+++ b/ui/src/ui/controllers/exec-approval.test.ts
@@ -1,5 +1,53 @@
-import { describe, expect, it } from "vitest";
-import { parseExecApprovalRequested, parsePluginApprovalRequested } from "./exec-approval.ts";
+import { describe, expect, it, vi } from "vitest";
+import {
+  addExecApproval,
+  isStaleApprovalResolutionError,
+  parseExecApprovalRequested,
+  parsePluginApprovalRequested,
+  clearResolvedExecApprovalPrompt,
+  refreshPendingApprovalQueue,
+  resolveActiveExecApprovalDecision,
+  type ExecApprovalPromptState,
+  type ExecApprovalRequest,
+} from "./exec-approval.ts";
+
+type RequestFn = (method: string, params?: unknown) => Promise<unknown>;
+
+function createExecApproval(overrides: Partial<ExecApprovalRequest> = {}): ExecApprovalRequest {
+  return {
+    id: "approval-1",
+    kind: "exec",
+    request: { command: "echo hello" },
+    createdAtMs: 1000,
+    expiresAtMs: Date.now() + 60_000,
+    ...overrides,
+  };
+}
+
+function createPromptState(
+  request: RequestFn,
+  queue: ExecApprovalRequest[] = [createExecApproval()],
+): ExecApprovalPromptState {
+  return {
+    client: { request },
+    execApprovalQueue: queue,
+    execApprovalBusy: false,
+    execApprovalError: null,
+  };
+}
+
+function createGatewayError(message: string, details?: unknown): Error {
+  const err = new Error(message);
+  Object.defineProperty(err, "gatewayCode", {
+    value: "INVALID_REQUEST",
+    enumerable: true,
+  });
+  Object.defineProperty(err, "details", {
+    value: details,
+    enumerable: true,
+  });
+  return err;
+}
 
 describe("parseExecApprovalRequested", () => {
   it("returns entries with kind 'exec'", () => {
@@ -140,5 +188,186 @@ describe("parseExecApprovalRequested command spans", () => {
       { startIndex: 5, endIndex: 9 },
       { startIndex: 10, endIndex: 15 },
     ]);
+  });
+});
+
+describe("isStaleApprovalResolutionError", () => {
+  it("detects already-resolved approval errors", () => {
+    expect(
+      isStaleApprovalResolutionError(
+        createGatewayError("approval already resolved", {
+          reason: "APPROVAL_ALREADY_RESOLVED",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("detects unknown or expired approval errors", () => {
+    expect(
+      isStaleApprovalResolutionError(createGatewayError("unknown or expired approval id")),
+    ).toBe(true);
+  });
+
+  it("detects missing approval errors", () => {
+    expect(
+      isStaleApprovalResolutionError(
+        createGatewayError("approval not found", {
+          reason: "APPROVAL_NOT_FOUND",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores unrelated approval resolve errors", () => {
+    expect(isStaleApprovalResolutionError(createGatewayError("gateway unavailable"))).toBe(false);
+  });
+});
+
+describe("resolveActiveExecApprovalDecision", () => {
+  it("dismisses the active approval after same-decision idempotent success", async () => {
+    const request = vi.fn<RequestFn>(async () => ({ ok: true }));
+    const state = createPromptState(request);
+
+    await resolveActiveExecApprovalDecision(state, "allow-once");
+
+    expect(request).toHaveBeenCalledWith("exec.approval.resolve", {
+      id: "approval-1",
+      decision: "allow-once",
+    });
+    expect(state.execApprovalQueue).toEqual([]);
+    expect(state.execApprovalError).toBeNull();
+    expect(state.execApprovalBusy).toBe(false);
+  });
+
+  it("dismisses and refreshes when the backend reports an already resolved approval", async () => {
+    const request = vi.fn<RequestFn>(async (method) => {
+      if (method === "exec.approval.resolve") {
+        throw createGatewayError("approval already resolved", {
+          reason: "APPROVAL_ALREADY_RESOLVED",
+        });
+      }
+      if (method === "exec.approval.list") {
+        return [];
+      }
+      if (method === "plugin.approval.list") {
+        return [];
+      }
+      return {};
+    });
+    const state = createPromptState(request);
+
+    await resolveActiveExecApprovalDecision(state, "deny");
+
+    expect(state.execApprovalQueue).toEqual([]);
+    expect(state.execApprovalError).toBeNull();
+    expect(state.execApprovalBusy).toBe(false);
+    expect(request).toHaveBeenCalledWith("exec.approval.list", {});
+    expect(request).toHaveBeenCalledWith("plugin.approval.list", {});
+  });
+
+  it("keeps the active approval open for unrelated errors", async () => {
+    const request = vi.fn<RequestFn>(async () => {
+      throw createGatewayError("gateway unavailable");
+    });
+    const active = createExecApproval();
+    const state = createPromptState(request, [active]);
+
+    await resolveActiveExecApprovalDecision(state, "deny");
+
+    expect(state.execApprovalQueue).toEqual([active]);
+    expect(state.execApprovalError).toBe("Approval failed: Error: gateway unavailable");
+    expect(state.execApprovalBusy).toBe(false);
+  });
+});
+
+describe("clearResolvedExecApprovalPrompt", () => {
+  it("does not clear the active prompt error when another approval resolves", () => {
+    const active = createExecApproval({ id: "approval-active", createdAtMs: 2 });
+    const queued = createExecApproval({ id: "approval-queued", createdAtMs: 1 });
+    const state = createPromptState(
+      vi.fn<RequestFn>(async () => ({})),
+      [active, queued],
+    );
+    state.execApprovalError = "Approval failed: Error: gateway unavailable";
+
+    clearResolvedExecApprovalPrompt(state, "approval-queued");
+
+    expect(state.execApprovalQueue.map((entry) => entry.id)).toEqual(["approval-active"]);
+    expect(state.execApprovalError).toBe("Approval failed: Error: gateway unavailable");
+  });
+
+  it("clears the active prompt error when the active approval resolves", () => {
+    const state = createPromptState(vi.fn<RequestFn>(async () => ({})));
+    state.execApprovalError = "Approval failed: Error: gateway unavailable";
+
+    clearResolvedExecApprovalPrompt(state, "approval-1");
+
+    expect(state.execApprovalQueue).toEqual([]);
+    expect(state.execApprovalError).toBeNull();
+  });
+});
+
+describe("refreshPendingApprovalQueue", () => {
+  it("keeps approvals received while a refresh is in flight", async () => {
+    let resolveExecList: (value: unknown[]) => void = () => {};
+    const execApprovalList = new Promise<unknown[]>((resolve) => {
+      resolveExecList = resolve;
+    });
+    const request = vi.fn<RequestFn>(async (method) => {
+      if (method === "exec.approval.list") {
+        return execApprovalList;
+      }
+      if (method === "plugin.approval.list") {
+        return [];
+      }
+      return {};
+    });
+    const state = createPromptState(request, []);
+
+    const refreshPromise = refreshPendingApprovalQueue(state);
+    state.execApprovalQueue = addExecApproval(
+      state.execApprovalQueue,
+      createExecApproval({ id: "approval-arrived-during-refresh", createdAtMs: 2000 }),
+    );
+    resolveExecList([]);
+    await refreshPromise;
+
+    expect(state.execApprovalQueue.map((entry) => entry.id)).toEqual([
+      "approval-arrived-during-refresh",
+    ]);
+  });
+
+  it("removes refreshed approvals after their expiry", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-25T00:00:00.000Z"));
+    try {
+      const expiresAtMs = Date.now() + 1_000;
+      const request = vi.fn<RequestFn>(async (method) => {
+        if (method === "exec.approval.list") {
+          return [
+            {
+              id: "approval-refreshed-1",
+              request: { command: "pnpm check:changed" },
+              createdAtMs: Date.now(),
+              expiresAtMs,
+            },
+          ];
+        }
+        if (method === "plugin.approval.list") {
+          return [];
+        }
+        return {};
+      });
+      const state = createPromptState(request, []);
+
+      await refreshPendingApprovalQueue(state);
+      expect(state.execApprovalQueue.map((entry) => entry.id)).toEqual(["approval-refreshed-1"]);
+
+      vi.advanceTimersByTime(1_500);
+
+      expect(state.execApprovalQueue).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/ui/src/ui/controllers/exec-approval.test.ts
+++ b/ui/src/ui/controllers/exec-approval.test.ts
@@ -6,7 +6,6 @@ import {
   parsePluginApprovalRequested,
   clearResolvedExecApprovalPrompt,
   refreshPendingApprovalQueue,
-  resolveActiveExecApprovalDecision,
   type ExecApprovalPromptState,
   type ExecApprovalRequest,
 } from "./exec-approval.ts";
@@ -220,63 +219,6 @@ describe("isStaleApprovalResolutionError", () => {
 
   it("ignores unrelated approval resolve errors", () => {
     expect(isStaleApprovalResolutionError(createGatewayError("gateway unavailable"))).toBe(false);
-  });
-});
-
-describe("resolveActiveExecApprovalDecision", () => {
-  it("dismisses the active approval after same-decision idempotent success", async () => {
-    const request = vi.fn<RequestFn>(async () => ({ ok: true }));
-    const state = createPromptState(request);
-
-    await resolveActiveExecApprovalDecision(state, "allow-once");
-
-    expect(request).toHaveBeenCalledWith("exec.approval.resolve", {
-      id: "approval-1",
-      decision: "allow-once",
-    });
-    expect(state.execApprovalQueue).toEqual([]);
-    expect(state.execApprovalError).toBeNull();
-    expect(state.execApprovalBusy).toBe(false);
-  });
-
-  it("dismisses and refreshes when the backend reports an already resolved approval", async () => {
-    const request = vi.fn<RequestFn>(async (method) => {
-      if (method === "exec.approval.resolve") {
-        throw createGatewayError("approval already resolved", {
-          reason: "APPROVAL_ALREADY_RESOLVED",
-        });
-      }
-      if (method === "exec.approval.list") {
-        return [];
-      }
-      if (method === "plugin.approval.list") {
-        return [];
-      }
-      return {};
-    });
-    const state = createPromptState(request);
-
-    await resolveActiveExecApprovalDecision(state, "deny");
-
-    expect(state.execApprovalQueue).toEqual([]);
-    expect(state.execApprovalError).toBeNull();
-    expect(state.execApprovalBusy).toBe(false);
-    expect(request).toHaveBeenCalledWith("exec.approval.list", {});
-    expect(request).toHaveBeenCalledWith("plugin.approval.list", {});
-  });
-
-  it("keeps the active approval open for unrelated errors", async () => {
-    const request = vi.fn<RequestFn>(async () => {
-      throw createGatewayError("gateway unavailable");
-    });
-    const active = createExecApproval();
-    const state = createPromptState(request, [active]);
-
-    await resolveActiveExecApprovalDecision(state, "deny");
-
-    expect(state.execApprovalQueue).toEqual([active]);
-    expect(state.execApprovalError).toBe("Approval failed: Error: gateway unavailable");
-    expect(state.execApprovalBusy).toBe(false);
   });
 });
 

--- a/ui/src/ui/controllers/exec-approval.ts
+++ b/ui/src/ui/controllers/exec-approval.ts
@@ -34,14 +34,10 @@ export type ExecApprovalResolved = {
   ts?: number | null;
 };
 
-export type ExecApprovalDecision = "allow-once" | "allow-always" | "deny";
-
-export type ExecApprovalRpcClient = {
-  request(method: string, params?: unknown): Promise<unknown>;
-};
-
 export type ExecApprovalPromptState = {
-  client: ExecApprovalRpcClient | null;
+  client: {
+    request(method: string, params?: unknown): Promise<unknown>;
+  } | null;
   execApprovalQueue: ExecApprovalRequest[];
   execApprovalBusy: boolean;
   execApprovalError: string | null;
@@ -361,38 +357,4 @@ export function dismissExecApprovalPrompt(state: ExecApprovalPromptState, id: st
 export function clearResolvedExecApprovalPrompt(state: ExecApprovalPromptState, id: string): void {
   removeExecApprovalFromState(state, id);
   state.execApprovalRefreshRemovedIds?.add(id);
-}
-
-export async function resolveActiveExecApprovalDecision(
-  state: ExecApprovalPromptState,
-  decision: ExecApprovalDecision,
-): Promise<void> {
-  const active = state.execApprovalQueue[0];
-  const client = state.client;
-  if (!active || !client || state.execApprovalBusy) {
-    return;
-  }
-
-  state.execApprovalBusy = true;
-  state.execApprovalError = null;
-  try {
-    const method = active.kind === "plugin" ? "plugin.approval.resolve" : "exec.approval.resolve";
-    await client.request(method, {
-      id: active.id,
-      decision,
-    });
-    dismissExecApprovalPrompt(state, active.id);
-  } catch (err) {
-    if (isStaleApprovalResolutionError(err)) {
-      dismissExecApprovalPrompt(state, active.id);
-      await refreshPendingApprovalQueue(state);
-      return;
-    }
-    if (!state.execApprovalQueue.some((entry) => entry.id === active.id)) {
-      return;
-    }
-    state.execApprovalError = `Approval failed: ${String(err)}`;
-  } finally {
-    state.execApprovalBusy = false;
-  }
 }

--- a/ui/src/ui/controllers/exec-approval.ts
+++ b/ui/src/ui/controllers/exec-approval.ts
@@ -34,6 +34,22 @@ export type ExecApprovalResolved = {
   ts?: number | null;
 };
 
+export type ExecApprovalDecision = "allow-once" | "allow-always" | "deny";
+
+export type ExecApprovalRpcClient = {
+  request(method: string, params?: unknown): Promise<unknown>;
+};
+
+export type ExecApprovalPromptState = {
+  client: ExecApprovalRpcClient | null;
+  execApprovalQueue: ExecApprovalRequest[];
+  execApprovalBusy: boolean;
+  execApprovalError: string | null;
+};
+
+const APPROVAL_ALREADY_RESOLVED = "APPROVAL_ALREADY_RESOLVED";
+const APPROVAL_NOT_FOUND = "APPROVAL_NOT_FOUND";
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -187,4 +203,160 @@ export function removeExecApproval(
   id: string,
 ): ExecApprovalRequest[] {
   return pruneExecApprovalQueue(queue).filter((entry) => entry.id !== id);
+}
+
+function readGatewayErrorCode(err: unknown): string | null {
+  if (!isRecord(err)) {
+    return null;
+  }
+  return normalizeOptionalString(err.gatewayCode) ?? null;
+}
+
+function readGatewayErrorReason(err: unknown): string | null {
+  if (!isRecord(err)) {
+    return null;
+  }
+  const { details } = err;
+  if (!isRecord(details)) {
+    return null;
+  }
+  return normalizeOptionalString(details.reason) ?? null;
+}
+
+export function isStaleApprovalResolutionError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  const gatewayCode = readGatewayErrorCode(err);
+  const reason = readGatewayErrorReason(err);
+  if (reason === APPROVAL_ALREADY_RESOLVED || reason === APPROVAL_NOT_FOUND) {
+    return true;
+  }
+  if (gatewayCode === APPROVAL_NOT_FOUND) {
+    return true;
+  }
+  return /unknown or expired approval id/i.test(err.message);
+}
+
+function parseApprovalList(
+  payload: unknown,
+  parseEntry: (entry: unknown) => ExecApprovalRequest | null,
+): ExecApprovalRequest[] | null {
+  if (!Array.isArray(payload)) {
+    return null;
+  }
+  return payload.flatMap((entry) => {
+    const parsed = parseEntry(entry);
+    return parsed ? [parsed] : [];
+  });
+}
+
+function sortApprovalsNewestFirst(queue: ExecApprovalRequest[]): ExecApprovalRequest[] {
+  return queue.toSorted((a, b) => b.createdAtMs - a.createdAtMs);
+}
+
+function currentApprovalsForKind(
+  queue: ExecApprovalRequest[],
+  kind: ExecApprovalRequest["kind"],
+): ExecApprovalRequest[] {
+  return pruneExecApprovalQueue(queue).filter((entry) => entry.kind === kind);
+}
+
+function mergeRefreshedApprovalQueue(
+  refreshed: ExecApprovalRequest[],
+  refreshStartedWith: ExecApprovalRequest[],
+  currentQueue: ExecApprovalRequest[],
+): ExecApprovalRequest[] {
+  const refreshedIds = new Set(refreshed.map((entry) => entry.id));
+  const refreshStartIds = new Set(refreshStartedWith.map((entry) => entry.id));
+  const arrivedDuringRefresh = pruneExecApprovalQueue(currentQueue).filter(
+    (entry) => !refreshStartIds.has(entry.id) && !refreshedIds.has(entry.id),
+  );
+  return sortApprovalsNewestFirst([...refreshed, ...arrivedDuringRefresh]);
+}
+
+function scheduleApprovalExpiryPrune(
+  state: ExecApprovalPromptState,
+  entry: ExecApprovalRequest,
+): void {
+  const delay = Math.max(0, entry.expiresAtMs - Date.now() + 500);
+  globalThis.setTimeout(() => {
+    state.execApprovalQueue = removeExecApproval(state.execApprovalQueue, entry.id);
+  }, delay);
+}
+
+export async function refreshPendingApprovalQueue(state: ExecApprovalPromptState): Promise<void> {
+  const client = state.client;
+  if (!client) {
+    return;
+  }
+  const refreshStartedWith = pruneExecApprovalQueue(state.execApprovalQueue);
+  const [execResult, pluginResult] = await Promise.allSettled([
+    client.request("exec.approval.list", {}),
+    client.request("plugin.approval.list", {}),
+  ]);
+  const execApprovals =
+    execResult.status === "fulfilled"
+      ? (parseApprovalList(execResult.value, parseExecApprovalRequested) ?? [])
+      : currentApprovalsForKind(state.execApprovalQueue, "exec");
+  const pluginApprovals =
+    pluginResult.status === "fulfilled"
+      ? (parseApprovalList(pluginResult.value, parsePluginApprovalRequested) ?? [])
+      : currentApprovalsForKind(state.execApprovalQueue, "plugin");
+  const refreshed = mergeRefreshedApprovalQueue(
+    sortApprovalsNewestFirst([...execApprovals, ...pluginApprovals]),
+    refreshStartedWith,
+    state.execApprovalQueue,
+  );
+  state.execApprovalQueue = refreshed;
+  for (const entry of refreshed) {
+    scheduleApprovalExpiryPrune(state, entry);
+  }
+}
+
+export function dismissExecApprovalPrompt(state: ExecApprovalPromptState, id: string): void {
+  state.execApprovalQueue = removeExecApproval(state.execApprovalQueue, id);
+  state.execApprovalError = null;
+}
+
+export function clearResolvedExecApprovalPrompt(state: ExecApprovalPromptState, id: string): void {
+  const activeId = state.execApprovalQueue[0]?.id ?? null;
+  state.execApprovalQueue = removeExecApproval(state.execApprovalQueue, id);
+  if (activeId === id) {
+    state.execApprovalError = null;
+  }
+}
+
+export async function resolveActiveExecApprovalDecision(
+  state: ExecApprovalPromptState,
+  decision: ExecApprovalDecision,
+): Promise<void> {
+  const active = state.execApprovalQueue[0];
+  const client = state.client;
+  if (!active || !client || state.execApprovalBusy) {
+    return;
+  }
+
+  state.execApprovalBusy = true;
+  state.execApprovalError = null;
+  try {
+    const method = active.kind === "plugin" ? "plugin.approval.resolve" : "exec.approval.resolve";
+    await client.request(method, {
+      id: active.id,
+      decision,
+    });
+    dismissExecApprovalPrompt(state, active.id);
+  } catch (err) {
+    if (isStaleApprovalResolutionError(err)) {
+      dismissExecApprovalPrompt(state, active.id);
+      await refreshPendingApprovalQueue(state);
+      return;
+    }
+    if (!state.execApprovalQueue.some((entry) => entry.id === active.id)) {
+      return;
+    }
+    state.execApprovalError = `Approval failed: ${String(err)}`;
+  } finally {
+    state.execApprovalBusy = false;
+  }
 }

--- a/ui/src/ui/controllers/exec-approval.ts
+++ b/ui/src/ui/controllers/exec-approval.ts
@@ -45,6 +45,7 @@ export type ExecApprovalPromptState = {
   execApprovalQueue: ExecApprovalRequest[];
   execApprovalBusy: boolean;
   execApprovalError: string | null;
+  execApprovalRefreshRemovedIds?: Set<string> | null;
 };
 
 const APPROVAL_ALREADY_RESOLVED = "APPROVAL_ALREADY_RESOLVED";
@@ -266,13 +267,21 @@ function mergeRefreshedApprovalQueue(
   refreshed: ExecApprovalRequest[],
   refreshStartedWith: ExecApprovalRequest[],
   currentQueue: ExecApprovalRequest[],
+  removedDuringRefresh: ReadonlySet<string>,
 ): ExecApprovalRequest[] {
-  const refreshedIds = new Set(refreshed.map((entry) => entry.id));
   const refreshStartIds = new Set(refreshStartedWith.map((entry) => entry.id));
-  const arrivedDuringRefresh = pruneExecApprovalQueue(currentQueue).filter(
+  const prunedCurrentQueue = pruneExecApprovalQueue(currentQueue);
+  const currentQueueIds = new Set(prunedCurrentQueue.map((entry) => entry.id));
+  const currentRefreshed = pruneExecApprovalQueue(refreshed).filter(
+    (entry) =>
+      !removedDuringRefresh.has(entry.id) &&
+      (!refreshStartIds.has(entry.id) || currentQueueIds.has(entry.id)),
+  );
+  const refreshedIds = new Set(currentRefreshed.map((entry) => entry.id));
+  const arrivedDuringRefresh = prunedCurrentQueue.filter(
     (entry) => !refreshStartIds.has(entry.id) && !refreshedIds.has(entry.id),
   );
-  return sortApprovalsNewestFirst([...refreshed, ...arrivedDuringRefresh]);
+  return sortApprovalsNewestFirst([...currentRefreshed, ...arrivedDuringRefresh]);
 }
 
 function scheduleApprovalExpiryPrune(
@@ -281,8 +290,25 @@ function scheduleApprovalExpiryPrune(
 ): void {
   const delay = Math.max(0, entry.expiresAtMs - Date.now() + 500);
   globalThis.setTimeout(() => {
-    state.execApprovalQueue = removeExecApproval(state.execApprovalQueue, entry.id);
+    removeExecApprovalFromState(state, entry.id);
   }, delay);
+}
+
+function removeExecApprovalFromState(state: ExecApprovalPromptState, id: string): void {
+  const activeId = state.execApprovalQueue[0]?.id ?? null;
+  state.execApprovalQueue = removeExecApproval(state.execApprovalQueue, id);
+  if (activeId !== (state.execApprovalQueue[0]?.id ?? null)) {
+    state.execApprovalError = null;
+  }
+}
+
+export function enqueueExecApprovalPrompt(
+  state: ExecApprovalPromptState,
+  entry: ExecApprovalRequest,
+): void {
+  state.execApprovalQueue = addExecApproval(state.execApprovalQueue, entry);
+  state.execApprovalError = null;
+  scheduleApprovalExpiryPrune(state, entry);
 }
 
 export async function refreshPendingApprovalQueue(state: ExecApprovalPromptState): Promise<void> {
@@ -290,41 +316,51 @@ export async function refreshPendingApprovalQueue(state: ExecApprovalPromptState
   if (!client) {
     return;
   }
+  const removedDuringRefresh = state.execApprovalRefreshRemovedIds ?? new Set<string>();
+  const ownsRemovedSet = !state.execApprovalRefreshRemovedIds;
+  if (ownsRemovedSet) {
+    state.execApprovalRefreshRemovedIds = removedDuringRefresh;
+  }
   const refreshStartedWith = pruneExecApprovalQueue(state.execApprovalQueue);
-  const [execResult, pluginResult] = await Promise.allSettled([
-    client.request("exec.approval.list", {}),
-    client.request("plugin.approval.list", {}),
-  ]);
-  const execApprovals =
-    execResult.status === "fulfilled"
-      ? (parseApprovalList(execResult.value, parseExecApprovalRequested) ?? [])
-      : currentApprovalsForKind(state.execApprovalQueue, "exec");
-  const pluginApprovals =
-    pluginResult.status === "fulfilled"
-      ? (parseApprovalList(pluginResult.value, parsePluginApprovalRequested) ?? [])
-      : currentApprovalsForKind(state.execApprovalQueue, "plugin");
-  const refreshed = mergeRefreshedApprovalQueue(
-    sortApprovalsNewestFirst([...execApprovals, ...pluginApprovals]),
-    refreshStartedWith,
-    state.execApprovalQueue,
-  );
-  state.execApprovalQueue = refreshed;
-  for (const entry of refreshed) {
-    scheduleApprovalExpiryPrune(state, entry);
+  try {
+    const [execResult, pluginResult] = await Promise.allSettled([
+      client.request("exec.approval.list", {}),
+      client.request("plugin.approval.list", {}),
+    ]);
+    const execApprovals =
+      execResult.status === "fulfilled"
+        ? (parseApprovalList(execResult.value, parseExecApprovalRequested) ?? [])
+        : currentApprovalsForKind(state.execApprovalQueue, "exec");
+    const pluginApprovals =
+      pluginResult.status === "fulfilled"
+        ? (parseApprovalList(pluginResult.value, parsePluginApprovalRequested) ?? [])
+        : currentApprovalsForKind(state.execApprovalQueue, "plugin");
+    const refreshed = mergeRefreshedApprovalQueue(
+      sortApprovalsNewestFirst([...execApprovals, ...pluginApprovals]),
+      refreshStartedWith,
+      state.execApprovalQueue,
+      removedDuringRefresh,
+    );
+    state.execApprovalQueue = refreshed;
+    for (const entry of refreshed) {
+      scheduleApprovalExpiryPrune(state, entry);
+    }
+  } finally {
+    if (ownsRemovedSet) {
+      state.execApprovalRefreshRemovedIds = null;
+    }
   }
 }
 
 export function dismissExecApprovalPrompt(state: ExecApprovalPromptState, id: string): void {
-  state.execApprovalQueue = removeExecApproval(state.execApprovalQueue, id);
+  removeExecApprovalFromState(state, id);
+  state.execApprovalRefreshRemovedIds?.add(id);
   state.execApprovalError = null;
 }
 
 export function clearResolvedExecApprovalPrompt(state: ExecApprovalPromptState, id: string): void {
-  const activeId = state.execApprovalQueue[0]?.id ?? null;
-  state.execApprovalQueue = removeExecApproval(state.execApprovalQueue, id);
-  if (activeId === id) {
-    state.execApprovalError = null;
-  }
+  removeExecApprovalFromState(state, id);
+  state.execApprovalRefreshRemovedIds?.add(id);
 }
 
 export async function resolveActiveExecApprovalDecision(

--- a/ui/src/ui/views/exec-approval.test.ts
+++ b/ui/src/ui/views/exec-approval.test.ts
@@ -3,10 +3,7 @@
 import { nothing, render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { i18n } from "../../i18n/index.ts";
-import {
-  getRenderedModalDialog,
-  installDialogPolyfill,
-} from "../../test-helpers/modal-dialog.ts";
+import { getRenderedModalDialog, installDialogPolyfill } from "../../test-helpers/modal-dialog.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import type { AppViewState } from "../app-view-state.ts";
 import type { ExecApprovalRequest } from "../controllers/exec-approval.ts";
@@ -130,30 +127,16 @@ describe("approval and confirmation modals", () => {
     expect(spans).toEqual(["ls", "python -c"]);
   });
 
-  it("maps Escape to exec denial when approval is idle", async () => {
-    const handleExecApprovalDecision = vi.fn(async () => undefined);
-    render(renderExecApprovalPrompt(createExecState({ handleExecApprovalDecision })), container);
+  it("does not render a visible neutral dismiss action", async () => {
+    render(renderExecApprovalPrompt(createExecState()), container);
 
-    const { dialog } = await getRenderedDialog();
-    dispatchEscape(dialog);
+    await getRenderedDialog();
 
-    expect(handleExecApprovalDecision).toHaveBeenCalledTimes(1);
-    expect(handleExecApprovalDecision).toHaveBeenCalledWith("deny");
-  });
-
-  it("does not dispatch an extra exec decision from Escape while busy", async () => {
-    const handleExecApprovalDecision = vi.fn(async () => undefined);
-    render(
-      renderExecApprovalPrompt(
-        createExecState({ execApprovalBusy: true, handleExecApprovalDecision }),
+    expect(
+      Array.from(container.querySelectorAll(".exec-approval-actions button")).map((button) =>
+        button.textContent?.trim(),
       ),
-      container,
-    );
-
-    const { dialog } = await getRenderedDialog();
-    dispatchEscape(dialog);
-
-    expect(handleExecApprovalDecision).not.toHaveBeenCalled();
+    ).toEqual(["Allow once", "Always allow", "Deny"]);
   });
 
   it("renders exec approval chrome from the active locale", async () => {

--- a/ui/src/ui/views/exec-approval.test.ts
+++ b/ui/src/ui/views/exec-approval.test.ts
@@ -139,6 +139,17 @@ describe("approval and confirmation modals", () => {
     ).toEqual(["Allow once", "Always allow", "Deny"]);
   });
 
+  it("denies exec approval on Escape", async () => {
+    const handleExecApprovalDecision = vi.fn(async () => undefined);
+    render(renderExecApprovalPrompt(createExecState({ handleExecApprovalDecision })), container);
+
+    const { dialog } = await getRenderedDialog();
+
+    dispatchEscape(dialog);
+
+    expect(handleExecApprovalDecision).toHaveBeenCalledWith("deny");
+  });
+
   it("renders exec approval chrome from the active locale", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-29T00:00:00.000Z"));

--- a/ui/src/ui/views/exec-approval.ts
+++ b/ui/src/ui/views/exec-approval.ts
@@ -125,8 +125,13 @@ export function renderExecApprovalPrompt(state: AppViewState) {
     : t("execApproval.execApprovalNeeded");
   const titleId = "exec-approval-title";
   const descriptionId = "exec-approval-description";
+  const handleCancel = () => {
+    if (!state.execApprovalBusy) {
+      void state.handleExecApprovalDecision("deny");
+    }
+  };
   return html`
-    <openclaw-modal-dialog label=${title} description=${remaining}>
+    <openclaw-modal-dialog label=${title} description=${remaining} @modal-cancel=${handleCancel}>
       <div class="exec-approval-card">
         <div class="exec-approval-header">
           <div>

--- a/ui/src/ui/views/exec-approval.ts
+++ b/ui/src/ui/views/exec-approval.ts
@@ -125,13 +125,8 @@ export function renderExecApprovalPrompt(state: AppViewState) {
     : t("execApproval.execApprovalNeeded");
   const titleId = "exec-approval-title";
   const descriptionId = "exec-approval-description";
-  const handleCancel = () => {
-    if (!state.execApprovalBusy) {
-      void state.handleExecApprovalDecision("deny");
-    }
-  };
   return html`
-    <openclaw-modal-dialog label=${title} description=${remaining} @modal-cancel=${handleCancel}>
+    <openclaw-modal-dialog label=${title} description=${remaining}>
       <div class="exec-approval-card">
         <div class="exec-approval-header">
           <div>


### PR DESCRIPTION
Summary:
- Harden Control UI approval prompts when the UI acts on an approval that has already been resolved elsewhere or no longer exists.
- Treat stale resolve responses as terminal UI cleanup signals: `APPROVAL_ALREADY_RESOLVED`, `APPROVAL_NOT_FOUND`, and `unknown or expired approval id` now remove the prompt and refresh pending approvals.
- Keep exec approval Escape/backdrop mapped to Deny; stale Deny now dismisses the stale prompt through the same cleanup path instead of leaving the modal stuck.

Bug summary:
An exec approval can be shown in Discord and in the OpenClaw Control UI at the same time. If Discord resolves it first and the web UI misses or delays the resolved event, the web modal can keep a stale approval id. On main, clicking Deny on that stale modal reports a backend error and leaves the modal open.

https://github.com/user-attachments/assets/9f21f116-95e9-488f-ac98-35fcee61432e

Root cause:
Current main removes a prompt when the web client receives `exec.approval.resolved` or `plugin.approval.resolved`, so normal event delivery is fine. The broken path is stale local UI state: `handleExecApprovalDecision` catches every resolve error as `execApprovalError` and does not treat stale backend responses as terminal cleanup. Main also maps modal cancel to Deny, so Escape/backdrop can hit the same stale backend error path.

Fix summary:
`OpenClawApp` now treats known stale approval resolve errors as terminal UI cleanup. Success removes the active prompt. Stale backend errors remove it, refresh `exec.approval.list` and `plugin.approval.list`, and keep only still-pending approvals. `exec.approval.resolved` and `plugin.approval.resolved` remove matching queue entries and clear the active prompt error. The exec approval view keeps Escape/backdrop wired to Deny; stale Deny is now safe because stale resolve errors dismiss and refresh.

Main behavior checked:
- The bug exists on current main. In Chrome on main, I forced a stale modal id and clicked Deny. The UI showed `Approval failed: GatewayRequestError: unknown or expired approval id`, and the modal stayed open.
- Discord-resolved events do reach the web UI when delivered. In the live Discord path, denying externally emitted `exec.approval.resolved` and the connected Control UI modal disappeared.
- The confusing case where Deny appears to work on main is usually not the stale failure path: same-decision duplicate Deny is backend success, and clicking a still-pending approval is normal success.

Verification:
- Rebased branch on current `origin/main` at `e96cde7e14`.
- `node scripts/run-vitest.mjs ui/src/ui/controllers/exec-approval.test.ts ui/src/ui/app-gateway.node.test.ts ui/src/ui/views/exec-approval.test.ts ui/src/ui/app.exec-approval.test.ts ui/src/ui/app-gateway-chat-load.node.test.ts ui/src/ui/app-gateway.sessions.node.test.ts --run` passed, 6 files / 114 tests.
- `node_modules/.bin/oxfmt --check --threads=1 ui/src/ui/app-gateway-chat-load.node.test.ts ui/src/ui/app-gateway.node.test.ts ui/src/ui/app-gateway.sessions.node.test.ts ui/src/ui/app-gateway.ts ui/src/ui/app.ts ui/src/ui/app.exec-approval.test.ts ui/src/ui/controllers/exec-approval.test.ts ui/src/ui/controllers/exec-approval.ts ui/src/ui/views/exec-approval.test.ts ui/src/ui/views/exec-approval.ts` passed.
- `git diff --check` passed.
- Earlier manual A/B with Computer Use: main/Chrome stayed stuck after stale Deny; PR/Safari dismissed stale externally-resolved approvals after stale Deny and refreshed pending approvals.

Behavior addressed: stale Control UI exec/plugin approval modals when local UI state outlives backend approval state.
Real environment tested: local Control UI against two local Gateway instances, Discord-triggered approvals, focused Vitest coverage, oxfmt, and UI typecheck.
Exact steps or command run after this patch: opened PR UI at `localhost:19010`, opened main/control UI at `localhost:19170`, resolved approvals externally through Discord or forced a stale id, then clicked Deny in the web modal.
Evidence after fix: PR UI removed the stale modal after stale Deny; main UI kept the modal open with `unknown or expired approval id`; focused tests cover resolved events, stale resolve errors, success cleanup, unrelated-error behavior, and refresh behavior.
Observed result after fix: stale externally-resolved approvals no longer leave the modal stuck, stale Deny removes the prompt, resolved events clear active prompt errors, and Escape/backdrop continue to submit Deny.
What was not tested: a fresh Slack-specific stale approval flow after the final rebase.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted, condensed transcript from about 10 local agent sessions for PR #86270</summary>

````text
source: about 10 local agent sessions related to PR #86270
format: condensed transcript, grouped by work phase rather than copied verbatim
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details, unrelated detours, repeated status chatter, and heated wording
scope: Control UI stale approval prompt fix, manual proof, review questions, implementation corrections, and final verification
note: This is intentionally a substantial condensed transcript. It keeps the useful questions, implementation decisions, review pressure, manual testing, and proof from the related local sessions without including every turn from all logs.

--- Session group: initial bug report, investigation goals, and first implementation ---

[user]
Asked the agent to triage and fix a Control UI exec approval modal bug, then open a PR. The bug report was specific: an exec approval prompt could appear in both Discord and the OpenClaw web UI; if Discord resolved it first, the web UI modal could remain open with a stale approval id. Clicking Deny or trying to close the stale web UI modal could then leave the modal stuck.

[user]
Set the first-pass requirements: confirm whether the bug exists on current main, locate the web UI approval modal/state code, verify how the UI handles approval requested/resolved events, inspect approve/deny mutation results, inspect modal close/dismiss state, and handle stale approval errors from the backend with evidence.

[assistant]
Started from fresh main in an isolated branch/worktree and traced the relevant Control UI paths. The agent identified the approval flow through gateway event handling, the app-level approval queue, and the modal renderer:
- requested events add entries to the approval queue
- resolved events remove matching entries
- the modal renders the active queue entry
- the app sends user decisions through the gateway client

[assistant]
Found that current main already had normal event handlers for resolved approvals, so the main question was not whether resolved events exist. The broken path was stale local UI state: if the UI still had an approval id after it was already resolved elsewhere, a later Deny/Allow from the web UI could get a stale backend response and show it as a normal error while leaving the modal open.

[user]
Asked whether the web UI also needed a way to close the modal so the user would not get trapped.

[assistant]
Initially explored a local close/suppress path. That design kept the approval in state but hid the modal locally, so closing the web modal would not send a hidden backend decision. This was implemented and tested briefly, but it later turned out to be the wrong product behavior for Escape/backdrop.

[assistant]
The better fix became stale-state cleanup rather than local suppression. Known stale backend responses should be treated as terminal for the active modal: remove the stale prompt, clear the active prompt error, refresh pending exec/plugin approvals, and leave normal unrelated backend errors visible.

[assistant]
Added focused helpers around the approval state:
- parse exec approval requested/resolved payloads
- parse plugin approval requested payloads
- add and remove approvals from the queue
- detect stale approval resolution errors
- dismiss stale prompts
- refresh pending approval lists after stale cleanup

[assistant]
Kept the key invariant that the modal is derived from the queue. If the active queue entry is removed, the modal disappears or the next queued approval becomes active. This kept the UI behavior tied to the actual approval queue rather than a separate hidden dismissal layer.

--- Session group: manual testing setup and real behavior proof ---

[user]
Asked for a local instance to test the fix manually. The first proposed test was two OpenClaw instances connected to the same Slack account so both UIs would see an approval. Then resolving one approval externally should show whether the other UI got stuck.

[assistant]
Used the local OpenClaw testing workflow and started checking the PR worktree rather than a different checkout. The agent noticed an existing local Gateway was from a different PR worktree, so it was not valid proof for this fix.

[assistant]
Evaluated the two-instance idea and found a problem with the test design. Two separate Gateways sharing one channel token would usually create separate backend approval records, so resolving one Gateway's approval would not necessarily resolve the other Gateway's modal. That would make the test noisy and could prove the wrong thing.

[assistant]
Shifted the test plan toward proving the stale UI state directly: use local main-vs-PR comparison, external resolution, and stale ids. The useful question was whether the web UI responds correctly when its active local approval no longer exists in the backend.

[user]
Asked to switch away from the double-client idea and instead use separate local channel setups, such as one Slack bot and one Discord bot, to avoid adding an awkward client parameter just for testing.

[assistant]
Prepared isolated local Gateway/UI state for channel testing. The goal was to trigger an approval from a real external channel, see the modal in the web UI, resolve the approval externally, and then verify whether the web UI modal disappeared or stayed stale.

[assistant]
Had to repair local helper/proxy state during manual testing. Some route/proxy and event-loop stalls were local-environment issues rather than PR behavior. The agent avoided counting that as product proof and kept pushing the test back toward the actual approval state path.

[user]
Asked what to type and what was being tested.

[assistant]
Gave a concrete test script: trigger a command that needs approval through Discord, confirm the web UI also shows the approval modal, approve or deny in Discord, then watch whether the web UI modal disappears. If it stayed open, clicking Deny in the web UI should dismiss on the PR because stale backend responses now clean up the prompt.

[verification]
Manual proof included local main-vs-PR comparison. On main, forcing a stale modal id and clicking Deny could leave the modal open with an unknown/expired approval id. On the PR, stale Deny removed the stale prompt and refreshed pending approvals.

[verification]
Manual proof also checked the normal event path. When a resolved event reaches the Control UI, the matching prompt is removed without relying on the stale-error fallback.

[verification]
The manual test work did not become extra product scope. The PR stayed focused on Control UI stale approval handling rather than adding special test-only client routing behavior.

--- Session group: review loop, race discussion, and state model questions ---

[user]
Started a code-review pass for PR #86270.

[assistant]
Ran the PR review workflow in an isolated worktree and mapped the diff as a Control UI approval-state change. The review focused on the approval controller, gateway event handling, modal rendering, app-level decision flow, and tests.

[assistant]
A review pass found a stale refresh race. If the UI starts refreshing pending approvals, then an approval is removed while that refresh is in flight, the late refresh result could still contain the removed approval. Without a guard, the UI could put that stale approval back into the queue.

[assistant]
Added a removed-during-refresh guard. The refresh captures the queue at the start, tracks ids removed during the in-flight refresh, and excludes those ids when merging the refresh result back into the current queue.

[assistant]
Another review pass found an error-state issue. If an active prompt had an error and then expired or was removed, the next queued approval could inherit that old error text. The fix clears the active prompt error when the active prompt changes or is removed.

[user]
Asked the agent to explain what had been fixed locally and why.

[assistant]
Explained the first fix as a race: the UI asks the backend for the list of pending approvals, the answer takes time, and the local queue can change before the answer returns. The UI needs to avoid trusting stale list data for ids that were already removed during that same refresh.

[user]
Asked for analogies to explain what was going on. Also asked whether removing the changelog entry was correct, since bug fixes are often added to changelogs in this repo.

[assistant]
Explained that this repository's current instructions say normal PRs should not edit `CHANGELOG.md`; release tooling or maintainers own changelog generation. The bug-fix context should live in the PR body and final commit/merge metadata.

[user]
Pushed on the model: if approval A appears but has already been handled somewhere else, pressing any button should dismiss the modal because the backend already knows the approval was resolved. Asked whether this is a front-end bug or a back-end bug.

[assistant]
Answered that the backend is allowed to reject a stale decision as already resolved or not found. The Control UI bug is treating those known stale responses as normal visible failures. The frontend should recognize those stale responses as terminal for the current modal and dismiss/refresh.

[user]
Asked what “safe cleanup behavior” meant, especially for the exec approval prompt queue.

[assistant]
Explained that safe cleanup means only removing the prompt that the UI has learned is stale, then refreshing current pending approvals. It should not silently approve/deny another prompt, hide unrelated prompts, or swallow unknown backend failures.

[user]
Asked whether the refresh was a poll. Asked whether the same path that updates approval modals could clear stale error state. Asked what happened when the live event path had a delay and then the approval disappeared.

[assistant]
Checked the call sites and clarified that this is not continuous polling. The refresh is an on-demand resync after the UI learns the active approval is stale, usually from a stale decision response. Most normal updates still arrive through approval requested/resolved events.

[assistant]
Explained the refresh path: after a stale response, the UI dismisses the active prompt, then asks for the current exec approval list and current plugin approval list. It merges those lists with approvals that arrived locally during the refresh, while excluding ids removed during the refresh.

[user]
Asked to see the refresh code again with comments, and asked whether `removeExecApproval` simply despawns the modal.

[assistant]
Explained that the modal is derived from `execApprovalQueue[0]`. Removing the active entry changes what the UI renders. If another approval remains, that one becomes active; if the queue is empty, the modal disappears. `removeExecApproval` is a queue operation; assigning the new queue to Lit state causes the UI rerender.

[user]
Asked what the `state` object was, why helper functions could mutate it, and what actually adds ids to the removed-during-refresh list.

[assistant]
Clarified that `state` is not a global object. In production, it is the `OpenClawApp` Lit component instance passed into helper functions. The relevant fields are component state fields: `execApprovalQueue`, `execApprovalBusy`, `execApprovalError`, and the temporary removed-during-refresh set.

[assistant]
Explained that Lit `@state()` fields are mutable component fields. Updating them on the app instance tells Lit that the component may need to render again. During an in-flight refresh, dismissal/resolved-event helpers add removed ids to the temporary set so late refresh results cannot reinsert those ids.

[user]
Restated the mental model: refresh starts, local state may change while it is running, and the helper needs to remember which approvals were removed so stale list data does not put them back.

[assistant]
Confirmed that model. The refresh snapshots queue ids at start, tracks removed ids while requests are in flight, then merges backend list data with current local queue state while excluding ids that were removed during the refresh window.

--- Session group: direct review findings and test-contract corrections ---

[user]
Asked for a direct code review against the PR diff and requested prioritized actionable findings.

[assistant]
Found a concrete test-contract failure. Some tests mocked `./controllers/exec-approval.ts`, but `app-gateway.ts` now imported a new helper export. The mocks did not provide `enqueueExecApprovalPrompt`, so affected Vitest files would fail during module loading.

[assistant]
Fixed the test mocks and reran the focused approval checks before pushing. This kept the PR's behavior change aligned with test setup rather than leaving green assertions behind a broken module mock.

[user]
Asked the agent to push the fixes and link the PR when done.

[assistant]
Committed only the intended test mock fixes, checked that the remote PR head had not moved, pushed through the writable PR remote, and verified the PR branch updated.

[user]
Asked to open the PR worktree in VS Code for review.

[assistant]
Opened the dedicated PR review worktree so the user could inspect the exact branch state.

[user]
Questioned the removal of the modal cancel handler:
`handleCancel = () => { if (!state.execApprovalBusy) { void state.handleExecApprovalDecision("deny"); } }`

[assistant]
Inspected the diff and explained that removing the handler changed native modal cancel from submitting Deny to doing nothing. The modal's cancel event fires for Escape/backdrop-style cancellation. Before the change, Escape called `handleExecApprovalDecision("deny")`.

[user]
Confirmed that Escape/backdrop should remain Deny and asked to remove the no-op cancel behavior.

[assistant]
Restored the `modal-cancel` handler so Escape/backdrop submits Deny when the UI is not busy. Added focused view coverage so the behavior stays explicit.

[assistant]
Reran the affected UI test set, formatting, and whitespace checks before committing and pushing that correction.

[user]
Questioned moving `handleExecApprovalDecision` out of `OpenClawApp`. The concern was that the method owns the active prompt, client call, busy flag, and error handling, so moving it into a controller helper felt like the wrong ownership boundary.

[assistant]
Treated that as a behavior/ownership correction. The final shape keeps `handleExecApprovalDecision` on `OpenClawApp`, where the user decision request, busy flag, error text, and active queue state are owned.

[assistant]
Left smaller reusable approval concepts in the controller helper: parse payloads, detect stale resolution errors, mutate the queue, dismiss prompts, clear resolved prompts, and refresh pending approvals. This kept the ownership split narrower and easier to review.

[assistant]
Moved the relevant decision tests with the behavior so tests now cover the app-level decision path instead of proving a hidden controller delegate.

--- Session group: repeated review passes and final correctness checks ---

[user]
Requested more review against `origin/main...HEAD`, including flow mapping, entrypoints, contracts, side effects, state transitions, and validation targets. The user also asked for UI, React/state, architecture/ownership, cognitive-load, and test-contract lenses where relevant.

[assistant]
Mapped the runtime flow as narrow and Control-UI-specific:
- gateway events parse approval request/resolution payloads
- requested approvals enter one queue
- resolved events remove matching queue entries and clear active prompt errors when needed
- the modal renders the active queue entry
- `OpenClawApp.handleExecApprovalDecision` sends the user decision
- stale backend responses dismiss and refresh
- unrelated backend errors remain visible

[assistant]
Checked the server/gateway-side contract enough to confirm the front end should not change the backend protocol for this PR. The frontend can treat known stale response shapes as terminal UI cleanup without changing gateway semantics.

[assistant]
Reviewed the queue transitions and refresh merge behavior to make sure it handles three cases: existing pending approvals from the backend, approvals that arrived locally while refresh was running, and approvals removed locally while refresh was running.

[assistant]
Reviewed the view behavior to make sure Escape/backdrop still submits Deny, buttons respect the busy state, and stale Deny no longer leaves a modal trapped.

[assistant]
A later review pass found no actionable correctness issues in the final diff. The changed approval controller, gateway event handling, app decision flow, and focused tests were consistent with the stale-approval handling behavior.

--- Session group: solution-quality check and PR body cleanup ---

[user]
Asked whether this was the best solution for PR #86270.

[assistant]
Reviewed the PR as a maintainer-side OpenClaw change. The conclusion was that the solution shape was appropriate because it fixes stale state at the Control UI boundary, treats known stale backend responses as terminal cleanup signals, keeps ordinary backend errors visible, and preserves Escape/backdrop as Deny.

[assistant]
Noted two remaining PR-state issues: the PR body had stale language from the earlier no-op cancel idea, and checks were red from branch/current-main mismatch.

[user]
Asked the agent to fix those two issues.

[assistant]
Updated the PR text to match the final behavior: Escape/backdrop still submit Deny, and stale Deny is safe because stale backend responses dismiss and refresh.

[assistant]
Briefly over-scoped by adding unrelated check-fix work from other current-main drift. That work touched surfaces outside the Control UI approval fix.

[user]
Objected to unrelated GitHub Actions changes being added to the PR.

[assistant]
Acknowledged the scope problem and began removing the unrelated change.

[user]
Also objected to unrelated transcript/tool-display changes being added to the PR.

[assistant]
Dropped the unrelated commit entirely and restored the branch to the approval-only diff. The PR branch was pushed back to only the Control UI approval files, and the PR body no longer referenced unrelated CI/transcript/tool-display changes.

[assistant]
Confirmed the PR head matched the expected approval-fix SHA after cleanup. The diff against main contained only approval UI files and tests.

--- Session group: agent transcript workflow and curation ---

[user]
Asked whether the repo's `agent-transcript` workflow should be used.

[assistant]
Loaded the `agent-transcript` workflow. The workflow requires local-only discovery, sanitized rendering, a local HTML preview before insertion, and explicit approval before adding any transcript section to a GitHub PR body.

[user]
Asked for a local HTML preview and noted there were many local sessions for this PR, with much more discussion than the current chat.

[assistant]
Searched local agent sessions across the relevant date range and found about ten high-confidence sessions for PR #86270. These included the initial implementation/manual-testing session, review sessions, focused correction sessions, and the final PR cleanup/transcript session.

[assistant]
Rendered local-only sanitized previews. The first preview showed candidate sessions separately. Later previews compressed the useful questions, implementation decisions, testing proof, review corrections, and cleanup into one proposed PR-body transcript section.

[user]
Explained that the point of adding the transcript is partly to show the effort behind the PR: multiple local sessions, real testing, repeated review, and refinement. Asked for an extended but condensed version that includes more of the user's questions and thinking without including full logs or heated wording.

[assistant]
Expanded the candidate transcript to better represent the work across the sessions. The new version keeps a substantial chunk of the meaningful transcript while still trimming repeated confusion-only turns, raw tool output, local setup noise, and heated language.

--- Verification captured in the local sessions ---

[verification]
Focused approval tests passed after the final approval-only branch state:
`node scripts/run-vitest.mjs ui/src/ui/controllers/exec-approval.test.ts ui/src/ui/app-gateway.node.test.ts ui/src/ui/views/exec-approval.test.ts ui/src/ui/app.exec-approval.test.ts ui/src/ui/app-gateway-chat-load.node.test.ts ui/src/ui/app-gateway.sessions.node.test.ts --run`
Result: 6 files / 114 tests passed.

[verification]
Formatting passed for the changed approval UI files:
`node_modules/.bin/oxfmt --check --threads=1 ...approval UI files...`

[verification]
Patch hygiene passed:
`git diff --check`

[verification]
Final PR branch scope was checked after removing unrelated work. The diff contains only Control UI approval files:
- `ui/src/ui/app-gateway-chat-load.node.test.ts`
- `ui/src/ui/app-gateway.node.test.ts`
- `ui/src/ui/app-gateway.sessions.node.test.ts`
- `ui/src/ui/app-gateway.ts`
- `ui/src/ui/app.exec-approval.test.ts`
- `ui/src/ui/app.ts`
- `ui/src/ui/controllers/exec-approval.test.ts`
- `ui/src/ui/controllers/exec-approval.ts`
- `ui/src/ui/views/exec-approval.test.ts`
````

</details>
<!-- agent-transcript:end -->
