### PR TITLE
fix(agents): label path-only bootstrap files

### DIFF
--- a/src/agents/bootstrap-budget.test.ts
+++ b/src/agents/bootstrap-budget.test.ts
@@ -47,6 +47,30 @@ describe("buildBootstrapInjectionStats", () => {
     expect(stats[1]?.injectedChars).toBe(20);
     expect(stats[1]?.truncated).toBe(true);
   });
+
+  it("normalizes malformed bootstrap names from paths for budget diagnostics", () => {
+    const bootstrapFiles = [
+      {
+        path: "/tmp/AGENTS.md",
+        content: "a".repeat(100),
+        missing: false,
+      } as unknown as WorkspaceBootstrapFile,
+    ];
+    const stats = buildBootstrapInjectionStats({
+      bootstrapFiles,
+      injectedFiles: [{ path: "/tmp/AGENTS.md", content: "a".repeat(20) }],
+    });
+    const analysis = analyzeBootstrapBudget({
+      files: stats,
+      bootstrapMaxChars: 50,
+      bootstrapTotalMaxChars: 200,
+    });
+
+    expect(stats[0]?.name).toBe("AGENTS.md");
+    expect(formatBootstrapTruncationWarningLines({ analysis })).toContain(
+      "AGENTS.md was truncated; read the full AGENTS.md before relying on scoped policy.",
+    );
+  });
 });
 
 describe("analyzeBootstrapBudget", () => {

--- a/src/agents/bootstrap-budget.ts
+++ b/src/agents/bootstrap-budget.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
+import { isAgentsBootstrapName, normalizeBootstrapFileName } from "./bootstrap-file-name.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
 import type { WorkspaceBootstrapFile } from "./workspace.js";
 
@@ -66,10 +67,6 @@ function normalizePositiveLimit(value: number): number {
 
 function formatWarningCause(cause: BootstrapTruncationCause): string {
   return cause === "per-file-limit" ? "max/file" : "max/total";
-}
-
-function isAgentsBootstrapName(name: string | undefined): boolean {
-  return name?.toLowerCase() === "agents.md";
 }
 
 function normalizeSeenSignatures(signatures?: string[]): string[] {
@@ -148,16 +145,17 @@ export function buildBootstrapInjectionStats(params: {
   }
   return params.bootstrapFiles.map((file) => {
     const pathValue = normalizeOptionalString(file.path) ?? "";
+    const name = normalizeBootstrapFileName(file.name, pathValue);
     const rawChars = file.missing ? 0 : (file.content ?? "").trimEnd().length;
     const injected =
       (pathValue ? injectedByPath.get(pathValue) : undefined) ??
-      injectedByPath.get(file.name) ??
-      injectedByBaseName.get(file.name);
+      injectedByPath.get(name) ??
+      injectedByBaseName.get(name);
     const injectedChars = injected ? injected.length : 0;
     const truncated = !file.missing && injectedChars < rawChars;
     return {
-      name: file.name,
-      path: pathValue || file.name,
+      name,
+      path: pathValue || name,
       missing: file.missing,
       rawChars,
       injectedChars,

--- a/src/agents/bootstrap-file-name.ts
+++ b/src/agents/bootstrap-file-name.ts
@@ -1,0 +1,23 @@
+import path from "node:path";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
+
+export const AGENTS_BOOTSTRAP_FILENAME = "AGENTS.md";
+
+export function normalizeBootstrapFileName(name: unknown, filePath?: unknown): string {
+  const normalizedName = normalizeOptionalString(name);
+  if (normalizedName) {
+    return normalizedName;
+  }
+  const normalizedPath = normalizeOptionalString(filePath);
+  if (normalizedPath) {
+    const baseName = path.basename(normalizedPath.replace(/\\/g, "/"));
+    if (baseName) {
+      return baseName;
+    }
+  }
+  return "bootstrap file";
+}
+
+export function isAgentsBootstrapName(name: unknown): boolean {
+  return normalizeBootstrapFileName(name).toLowerCase() === AGENTS_BOOTSTRAP_FILENAME.toLowerCase();
+}

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -60,6 +60,20 @@ function registerMalformedBootstrapFileHook() {
   });
 }
 
+function registerUndefinedNameBootstrapFileHook() {
+  registerInternalHook("agent:bootstrap", (event) => {
+    const context = event.context as AgentBootstrapHookContext;
+    context.bootstrapFiles = [
+      ...context.bootstrapFiles,
+      {
+        path: path.join(context.workspaceDir, "EXTRA.md"),
+        content: "hook content",
+        missing: false,
+      } as unknown as WorkspaceBootstrapFile,
+    ];
+  });
+}
+
 function registerDuplicateBootstrapFileHook() {
   registerInternalHook("agent:bootstrap", (event) => {
     const context = event.context as AgentBootstrapHookContext;
@@ -163,6 +177,20 @@ describe("resolveBootstrapFilesForRun", () => {
     const agentsContextFiles = context.contextFiles.filter((file) => file.path === agentsPath);
     expect(agentsContextFiles).toHaveLength(1);
     expect(agentsContextFiles[0]?.content).toBe("workspace rules");
+  });
+
+  it("normalizes hook files with undefined names before context injection", async () => {
+    registerUndefinedNameBootstrapFileHook();
+
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    const extraPath = path.join(workspaceDir, "EXTRA.md");
+    const files = await resolveBootstrapFilesForRun({ workspaceDir });
+    const extraFile = files.find((file) => file.path === extraPath);
+
+    expect(extraFile?.name).toBe("EXTRA.md");
+    await expect(resolveBootstrapContextForRun({ workspaceDir })).resolves.toMatchObject({
+      contextFiles: expect.arrayContaining([expect.objectContaining({ path: extraPath })]),
+    });
   });
 
   it("ignores stale workspace BOOTSTRAP.md once setup is completed", async () => {

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -6,6 +6,7 @@ import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveAgentConfig, resolveSessionAgentIds } from "./agent-scope.js";
 import { getOrLoadBootstrapFiles } from "./bootstrap-cache.js";
+import { normalizeBootstrapFileName } from "./bootstrap-file-name.js";
 import { applyBootstrapHookOverrides } from "./bootstrap-hooks.js";
 import { shouldIncludeHeartbeatGuidanceForSystemPrompt } from "./heartbeat-system-prompt.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
@@ -166,9 +167,10 @@ function sanitizeBootstrapFiles(
   const sanitized: WorkspaceBootstrapFile[] = [];
   for (const file of files) {
     const pathValue = normalizeOptionalString(file.path) ?? "";
+    const fileName = normalizeBootstrapFileName(file.name, pathValue);
     if (!pathValue) {
       warn?.(
-        `skipping bootstrap file "${file.name}" — missing or invalid "path" field (hook may have used "filePath" instead)`,
+        `skipping bootstrap file "${fileName}" — missing or invalid "path" field (hook may have used "filePath" instead)`,
       );
       continue;
     }
@@ -182,7 +184,11 @@ function sanitizeBootstrapFiles(
       continue;
     }
     seenPaths.add(dedupeKey);
-    sanitized.push({ ...file, path: resolvedPath });
+    sanitized.push({
+      ...file,
+      name: fileName as WorkspaceBootstrapFile["name"],
+      path: resolvedPath,
+    });
   }
   return sanitized;
 }

--- a/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts
+++ b/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts
@@ -86,6 +86,27 @@ describe("buildBootstrapContextFiles", () => {
     expect(warnings[0]).toContain("TOOLS.md");
     expect(warnings[0]).toContain("limit 200");
   });
+  it("derives a safe display name when malformed bootstrap entries omit name", () => {
+    const file = {
+      path: "/tmp/AGENTS.md",
+      content: [
+        "# Root policy",
+        "- Required scoped instruction: read scoped AGENTS.md before editing subtree work.",
+        "x".repeat(1_000),
+      ].join("\n"),
+      missing: false,
+    } as unknown as WorkspaceBootstrapFile;
+    const warnings: string[] = [];
+
+    const [result] = buildBootstrapContextFiles([file], {
+      maxChars: 300,
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(result?.content).toContain("[Policy digest from AGENTS.md]");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("workspace bootstrap file AGENTS.md");
+  });
   it("fits the rendered truncation marker inside the per-file budget", () => {
     const maxChars = DEFAULT_BOOTSTRAP_MAX_CHARS;
     const files = [

--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -6,6 +6,11 @@ import { sanitizeGoogleAssistantFirstOrdering } from "../../shared/google-turn-o
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import { resolveAgentConfig } from "../agent-scope.js";
+import {
+  AGENTS_BOOTSTRAP_FILENAME,
+  isAgentsBootstrapName,
+  normalizeBootstrapFileName,
+} from "../bootstrap-file-name.js";
 import type { WorkspaceBootstrapFile } from "../workspace.js";
 import type { EmbeddedContextFile } from "./types.js";
 
@@ -96,7 +101,6 @@ const MIN_BOOTSTRAP_FILE_BUDGET_CHARS = 64;
 const BOOTSTRAP_HEAD_RATIO = 0.75;
 const BOOTSTRAP_TAIL_RATIO = 0.25;
 const MIN_BOOTSTRAP_TRIMMED_CONTENT_CHARS = 16;
-const AGENTS_BOOTSTRAP_FILENAME = "AGENTS.md";
 const AGENTS_POLICY_DIGEST_RATIO = 0.35;
 const AGENTS_POLICY_HEAD_RATIO = 0.45;
 const AGENTS_POLICY_TAIL_RATIO = 0.15;
@@ -149,10 +153,6 @@ export function resolveBootstrapPromptTruncationWarningMode(
     return raw;
   }
   return DEFAULT_BOOTSTRAP_PROMPT_TRUNCATION_WARNING_MODE;
-}
-
-function isAgentsBootstrapFile(fileName: string | undefined): boolean {
-  return fileName?.toLowerCase() === AGENTS_BOOTSTRAP_FILENAME.toLowerCase();
 }
 
 function isPolicyDigestCandidate(line: string): boolean {
@@ -279,7 +279,7 @@ function trimBootstrapContent(
       originalLength: trimmed.length,
     };
   }
-  if (isAgentsBootstrapFile(fileName)) {
+  if (isAgentsBootstrapName(fileName)) {
     return trimAgentsBootstrapContent(content, maxChars);
   }
 
@@ -423,9 +423,10 @@ export function buildBootstrapContextFiles(
       break;
     }
     const pathValue = normalizeOptionalString(file.path) ?? "";
+    const fileName = normalizeBootstrapFileName(file.name, pathValue);
     if (!pathValue) {
       opts?.warn?.(
-        `skipping bootstrap file "${file.name}" — missing or invalid "path" field (hook may have used "filePath" instead)`,
+        `skipping bootstrap file "${fileName}" — missing or invalid "path" field (hook may have used "filePath" instead)`,
       );
       continue;
     }
@@ -449,14 +450,14 @@ export function buildBootstrapContextFiles(
       break;
     }
     const fileMaxChars = Math.max(1, Math.min(maxChars, remainingTotalChars));
-    const trimmed = trimBootstrapContent(file.content ?? "", file.name, fileMaxChars);
+    const trimmed = trimBootstrapContent(file.content ?? "", fileName, fileMaxChars);
     const contentWithinBudget = clampToBudget(trimmed.content, remainingTotalChars);
     if (!contentWithinBudget) {
       continue;
     }
     if (trimmed.truncated || contentWithinBudget.length < trimmed.content.length) {
       opts?.warn?.(
-        `workspace bootstrap file ${file.name} is ${trimmed.originalLength} chars (limit ${trimmed.maxChars}); truncating in injected context`,
+        `workspace bootstrap file ${fileName} is ${trimmed.originalLength} chars (limit ${trimmed.maxChars}); truncating in injected context`,
       );
     }
     remainingTotalChars = Math.max(0, remainingTotalChars - contentWithinBudget.length);


### PR DESCRIPTION
## Summary

- Fixes #47941.
- Adds a shared bootstrap file-name normalizer so path-only virtual bootstrap files get a stable display label instead of `undefined`.
- Reuses the normalized label in bootstrap sanitization, injected context trimming warnings, and bootstrap budget stats, with regression coverage for path-only entries.

## Tests

- `node scripts/run-vitest.mjs src/agents/bootstrap-budget.test.ts src/agents/bootstrap-files.test.ts src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts --run`
- `node scripts/run-vitest.mjs src/auto-reply/reply/commands-context-report.test.ts --run`
- `node --import tsx --input-type=module - <<'EOF'
import { buildBootstrapInjectionStats } from './src/agents/bootstrap-budget.ts';
const [stat] = buildBootstrapInjectionStats({
  bootstrapFiles: [{ path: 'SELF_IMPROVEMENT_REMINDER.md', content: 'remember', missing: false }],
  injectedFiles: [{ path: 'SELF_IMPROVEMENT_REMINDER.md', content: 'remember' }],
});
console.log(`${stat.name}: ${stat.injectedChars}/${stat.rawChars}`);
if (stat.name === 'undefined' || stat.name !== 'SELF_IMPROVEMENT_REMINDER.md') {
  throw new Error(`unexpected bootstrap label: ${stat.name}`);
}
EOF`
- `git diff --check`

## Real behavior proof

Behavior addressed: `/context` bootstrap breakdown stats should not display a literal `undefined` label when a bootstrap hook supplies a virtual/path-only file with content.

Real environment tested: Local OpenClaw checkout on macOS with Node/tsx, running the actual `buildBootstrapInjectionStats` runtime helper used by context reporting.

Exact steps or command run after this patch: `node --import tsx --input-type=module - <<'EOF'
import { buildBootstrapInjectionStats } from './src/agents/bootstrap-budget.ts';
const [stat] = buildBootstrapInjectionStats({
  bootstrapFiles: [{ path: 'SELF_IMPROVEMENT_REMINDER.md', content: 'remember', missing: false }],
  injectedFiles: [{ path: 'SELF_IMPROVEMENT_REMINDER.md', content: 'remember' }],
});
console.log(`${stat.name}: ${stat.injectedChars}/${stat.rawChars}`);
if (stat.name === 'undefined' || stat.name !== 'SELF_IMPROVEMENT_REMINDER.md') {
  throw new Error(`unexpected bootstrap label: ${stat.name}`);
}
EOF`

Evidence after fix: Terminal output from the runtime helper command was `SELF_IMPROVEMENT_REMINDER.md: 8/8`.

Observed result after fix: The path-only bootstrap entry is labeled with `SELF_IMPROVEMENT_REMINDER.md`, not `undefined`, while preserving the injected/raw character counts.

What was not tested: I did not run a full interactive `/context` command against a live model session; the covered helper is the source-level stats path that feeds the context report row.
