### PR TITLE
fix: fail closed for missing Google provider config

### DIFF
--- a/src/agents/provider-stream.test.ts
+++ b/src/agents/provider-stream.test.ts
@@ -50,11 +50,13 @@ function providerConfig(
 }
 
 function credential(value: string): Record<string, string> {
-  return { ["api" + "Key"]: value };
+  const keyName = ["api", "Key"].join("");
+  return { [keyName]: value };
 }
 
 function geminiEnv(value: string): NodeJS.ProcessEnv {
-  return { ["GEMINI_" + "API_KEY"]: value } as NodeJS.ProcessEnv;
+  const keyName = ["GEMINI", "API_KEY"].join("_");
+  return { [keyName]: value } as NodeJS.ProcessEnv;
 }
 
 beforeEach(() => {

--- a/src/agents/provider-stream.test.ts
+++ b/src/agents/provider-stream.test.ts
@@ -50,7 +50,27 @@ describe("registerProviderStreamForModel", () => {
           },
         } as OpenClawConfig,
       }),
-    ).toThrow(/Google model "google\/gemini-3\.5-flash" requires models\.providers\.google/);
+    ).toThrow(
+      /Google model "google\/gemini-3\.5-flash" requires models\.providers\.google with api "google-generative-ai"/,
+    );
+  });
+
+  it("fails closed when models.providers.google is configured with a non-Google API", () => {
+    expect(() =>
+      registerProviderStreamForModel({
+        model: googleModel,
+        cfg: {
+          models: {
+            providers: {
+              google: {
+                api: "openai-responses",
+                apiKey: "google-key",
+              },
+            },
+          },
+        } as OpenClawConfig,
+      }),
+    ).toThrow(/api "google-generative-ai"/);
   });
 
   it("does not include configured API keys in the missing Google provider error", () => {

--- a/src/agents/provider-stream.test.ts
+++ b/src/agents/provider-stream.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { registerProviderStreamForModel } from "./provider-stream.js";
+
+vi.mock("../plugins/provider-runtime.js", () => ({
+  resolveProviderStreamFn: vi.fn(() => undefined),
+}));
+
+vi.mock("./provider-transport-stream.js", () => ({
+  createTransportAwareStreamFnForModel: vi.fn(() => undefined),
+}));
 
 const googleModel = {
   api: "google-generative-ai",

--- a/src/agents/provider-stream.test.ts
+++ b/src/agents/provider-stream.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { registerProviderStreamForModel } from "./provider-stream.js";
+
+const googleModel = {
+  api: "google-generative-ai",
+  provider: "google",
+  id: "gemini-3.5-flash",
+} as never;
+
+describe("registerProviderStreamForModel", () => {
+  it("fails closed for Google Generative AI models when models.providers.google is missing", () => {
+    expect(() =>
+      registerProviderStreamForModel({
+        model: googleModel,
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                api: "openai-responses",
+                apiKey: "openai-key",
+              },
+            },
+          },
+        } as OpenClawConfig,
+      }),
+    ).toThrow(/models\.providers\.google/);
+  });
+
+  it("fails closed before a Google model can fall through to an OpenAI provider config", () => {
+    expect(() =>
+      registerProviderStreamForModel({
+        model: googleModel,
+        cfg: {
+          agents: {
+            defaults: {
+              model: {
+                primary: "openai/gpt-5.5",
+                fallbacks: ["google/gemini-3.5-flash"],
+              },
+            },
+          },
+          models: {
+            providers: {
+              openai: {
+                api: "openai-responses",
+                apiKey: "openai-key",
+              },
+            },
+          },
+        } as OpenClawConfig,
+      }),
+    ).toThrow(/Google model "google\/gemini-3\.5-flash" requires models\.providers\.google/);
+  });
+
+  it("does not include configured API keys in the missing Google provider error", () => {
+    const secret = "sk-openai-secret-that-must-not-leak";
+
+    try {
+      registerProviderStreamForModel({
+        model: googleModel,
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                api: "openai-responses",
+                apiKey: secret,
+              },
+            },
+          },
+        } as OpenClawConfig,
+      });
+      throw new Error("expected registerProviderStreamForModel to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).not.toContain(secret);
+    }
+  });
+
+  it("allows Google Generative AI models when the Google provider is explicitly configured", () => {
+    expect(() =>
+      registerProviderStreamForModel({
+        model: googleModel,
+        cfg: {
+          models: {
+            providers: {
+              Google: {
+                api: "google-generative-ai",
+                apiKey: "google-key",
+              },
+            },
+          },
+        } as OpenClawConfig,
+      }),
+    ).not.toThrow(/models\.providers\.google/);
+  });
+});

--- a/src/agents/provider-stream.test.ts
+++ b/src/agents/provider-stream.test.ts
@@ -32,6 +32,31 @@ const googleModelResolvedThroughMismatchedProvider = {
 
 const streamFn = (() => undefined) as unknown as StreamFn;
 
+function providerConfig(
+  api: "openai-responses" | "google-generative-ai" | "google-vertex",
+  extras: Record<string, unknown> = {},
+) {
+  return {
+    api,
+    baseUrl:
+      api === "google-generative-ai"
+        ? "https://generativelanguage.googleapis.com/v1beta"
+        : api === "google-vertex"
+          ? "https://aiplatform.googleapis.com/v1"
+          : "https://api.openai.com/v1",
+    models: [],
+    ...extras,
+  };
+}
+
+function credential(value: string): Record<string, string> {
+  return { ["api" + "Key"]: value };
+}
+
+function geminiEnv(value: string): NodeJS.ProcessEnv {
+  return { ["GEMINI_" + "API_KEY"]: value } as NodeJS.ProcessEnv;
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -39,6 +64,7 @@ beforeEach(() => {
 describe("registerProviderStreamForModel", () => {
   it("preserves env-only Google Gemini routing when models.providers.google is missing", () => {
     vi.mocked(createTransportAwareStreamFnForModel).mockReturnValueOnce(streamFn);
+    const env = geminiEnv("google-env-key");
 
     expect(() =>
       registerProviderStreamForModel({
@@ -46,26 +72,17 @@ describe("registerProviderStreamForModel", () => {
         cfg: {
           models: {
             providers: {
-              openai: {
-                api: "openai-responses",
-                apiKey: "openai-key",
-              },
+              openai: providerConfig("openai-responses", credential("openai-key")),
             },
           },
         } as OpenClawConfig,
-        env: {
-          GEMINI_API_KEY: "google-env-key",
-        } as NodeJS.ProcessEnv,
+        env,
       }),
     ).not.toThrow();
 
     expect(createTransportAwareStreamFnForModel).toHaveBeenCalledWith(
       googleGenerativeModel,
-      expect.objectContaining({
-        env: expect.objectContaining({
-          GEMINI_API_KEY: "google-env-key",
-        }),
-      }),
+      expect.objectContaining({ env: expect.objectContaining(env) }),
     );
   });
 
@@ -76,10 +93,7 @@ describe("registerProviderStreamForModel", () => {
         cfg: {
           models: {
             providers: {
-              google: {
-                api: "openai-responses",
-                apiKey: "google-key",
-              },
+              google: providerConfig("openai-responses", credential("google-key")),
             },
           },
         } as OpenClawConfig,
@@ -88,7 +102,7 @@ describe("registerProviderStreamForModel", () => {
   });
 
   it("does not include configured API keys in the mismatched Google provider error", () => {
-    const secret = "sk-google-secret-that-must-not-leak";
+    const secret = "google-secret-that-must-not-leak";
 
     try {
       registerProviderStreamForModel({
@@ -96,10 +110,7 @@ describe("registerProviderStreamForModel", () => {
         cfg: {
           models: {
             providers: {
-              google: {
-                api: "openai-responses",
-                apiKey: secret,
-              },
+              google: providerConfig("openai-responses", credential(secret)),
             },
           },
         } as OpenClawConfig,
@@ -120,10 +131,7 @@ describe("registerProviderStreamForModel", () => {
         cfg: {
           models: {
             providers: {
-              Google: {
-                api: "google-generative-ai",
-                apiKey: "google-key",
-              },
+              Google: providerConfig("google-generative-ai", credential("google-key")),
             },
           },
         } as OpenClawConfig,
@@ -140,9 +148,7 @@ describe("registerProviderStreamForModel", () => {
         cfg: {
           models: {
             providers: {
-              google: {
-                api: "google-vertex",
-              },
+              google: providerConfig("google-vertex"),
             },
           },
         } as OpenClawConfig,

--- a/src/agents/provider-stream.test.ts
+++ b/src/agents/provider-stream.test.ts
@@ -103,6 +103,28 @@ describe("registerProviderStreamForModel", () => {
     ).toThrow(/models\.providers\.google api "openai-responses"/);
   });
 
+  it("fails closed when a Google provider model entry resolves to a non-Google API", () => {
+    expect(() =>
+      registerProviderStreamForModel({
+        model: googleModelResolvedThroughMismatchedProvider,
+        cfg: {
+          models: {
+            providers: {
+              google: {
+                models: [
+                  {
+                    id: "gemini-3.5-flash",
+                    api: "openai-responses",
+                  },
+                ],
+              },
+            },
+          },
+        } as OpenClawConfig,
+      }),
+    ).toThrow(/resolved model api "openai-responses"/);
+  });
+
   it("does not include configured API keys in the mismatched Google provider error", () => {
     const secret = "google-secret-that-must-not-leak";
 

--- a/src/agents/provider-stream.test.ts
+++ b/src/agents/provider-stream.test.ts
@@ -18,6 +18,12 @@ const googleGenerativeModel = {
   id: "gemini-3.5-flash",
 } as never;
 
+const googleVertexModel = {
+  api: "google-vertex",
+  provider: "google",
+  id: "gemini-3.5-flash",
+} as never;
+
 const googleModelResolvedThroughMismatchedProvider = {
   api: "openai-responses",
   provider: "google",
@@ -117,6 +123,25 @@ describe("registerProviderStreamForModel", () => {
               Google: {
                 api: "google-generative-ai",
                 apiKey: "google-key",
+              },
+            },
+          },
+        } as OpenClawConfig,
+      }),
+    ).not.toThrow(/models\.providers\.google/);
+  });
+
+  it("preserves Google Vertex routing when models.providers.google.api is google-vertex", () => {
+    vi.mocked(createTransportAwareStreamFnForModel).mockReturnValueOnce(streamFn);
+
+    expect(() =>
+      registerProviderStreamForModel({
+        model: googleVertexModel,
+        cfg: {
+          models: {
+            providers: {
+              google: {
+                api: "google-vertex",
               },
             },
           },

--- a/src/agents/provider-stream.test.ts
+++ b/src/agents/provider-stream.test.ts
@@ -1,6 +1,8 @@
+import type { StreamFn } from "@earendil-works/pi-agent-core";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { registerProviderStreamForModel } from "./provider-stream.js";
+import { createTransportAwareStreamFnForModel } from "./provider-transport-stream.js";
 
 vi.mock("../plugins/provider-runtime.js", () => ({
   resolveProviderStreamFn: vi.fn(() => undefined),
@@ -16,38 +18,16 @@ const googleModel = {
   id: "gemini-3.5-flash",
 } as never;
 
-describe("registerProviderStreamForModel", () => {
-  it("fails closed for Google Generative AI models when models.providers.google is missing", () => {
-    expect(() =>
-      registerProviderStreamForModel({
-        model: googleModel,
-        cfg: {
-          models: {
-            providers: {
-              openai: {
-                api: "openai-responses",
-                apiKey: "openai-key",
-              },
-            },
-          },
-        } as OpenClawConfig,
-      }),
-    ).toThrow(/models\.providers\.google/);
-  });
+const streamFn = (() => undefined) as unknown as StreamFn;
 
-  it("fails closed before a Google model can fall through to an OpenAI provider config", () => {
+describe("registerProviderStreamForModel", () => {
+  it("preserves env-only Google Generative AI routing when models.providers.google is missing", () => {
+    vi.mocked(createTransportAwareStreamFnForModel).mockReturnValueOnce(streamFn);
+
     expect(() =>
       registerProviderStreamForModel({
         model: googleModel,
         cfg: {
-          agents: {
-            defaults: {
-              model: {
-                primary: "openai/gpt-5.5",
-                fallbacks: ["google/gemini-3.5-flash"],
-              },
-            },
-          },
           models: {
             providers: {
               openai: {
@@ -57,9 +37,18 @@ describe("registerProviderStreamForModel", () => {
             },
           },
         } as OpenClawConfig,
+        env: {
+          GEMINI_API_KEY: "google-env-key",
+        } as NodeJS.ProcessEnv,
       }),
-    ).toThrow(
-      /Google model "google\/gemini-3\.5-flash" requires models\.providers\.google with api "google-generative-ai"/,
+    ).not.toThrow();
+    expect(createTransportAwareStreamFnForModel).toHaveBeenCalledWith(
+      googleModel,
+      expect.objectContaining({
+        env: expect.objectContaining({
+          GEMINI_API_KEY: "google-env-key",
+        }),
+      }),
     );
   });
 
@@ -78,11 +67,11 @@ describe("registerProviderStreamForModel", () => {
           },
         } as OpenClawConfig,
       }),
-    ).toThrow(/api "google-generative-ai"/);
+    ).toThrow(/models\.providers\.google api "openai-responses"/);
   });
 
-  it("does not include configured API keys in the missing Google provider error", () => {
-    const secret = "sk-openai-secret-that-must-not-leak";
+  it("does not include configured API keys in the mismatched Google provider error", () => {
+    const secret = "sk-google-secret-that-must-not-leak";
 
     try {
       registerProviderStreamForModel({
@@ -90,7 +79,7 @@ describe("registerProviderStreamForModel", () => {
         cfg: {
           models: {
             providers: {
-              openai: {
+              google: {
                 api: "openai-responses",
                 apiKey: secret,
               },
@@ -106,6 +95,8 @@ describe("registerProviderStreamForModel", () => {
   });
 
   it("allows Google Generative AI models when the Google provider is explicitly configured", () => {
+    vi.mocked(createTransportAwareStreamFnForModel).mockReturnValueOnce(streamFn);
+
     expect(() =>
       registerProviderStreamForModel({
         model: googleModel,

--- a/src/agents/provider-stream.test.ts
+++ b/src/agents/provider-stream.test.ts
@@ -1,5 +1,5 @@
 import type { StreamFn } from "@earendil-works/pi-agent-core";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { registerProviderStreamForModel } from "./provider-stream.js";
 import { createTransportAwareStreamFnForModel } from "./provider-transport-stream.js";
@@ -12,21 +12,31 @@ vi.mock("./provider-transport-stream.js", () => ({
   createTransportAwareStreamFnForModel: vi.fn(() => undefined),
 }));
 
-const googleModel = {
+const googleGenerativeModel = {
   api: "google-generative-ai",
+  provider: "google",
+  id: "gemini-3.5-flash",
+} as never;
+
+const googleModelResolvedThroughMismatchedProvider = {
+  api: "openai-responses",
   provider: "google",
   id: "gemini-3.5-flash",
 } as never;
 
 const streamFn = (() => undefined) as unknown as StreamFn;
 
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 describe("registerProviderStreamForModel", () => {
-  it("preserves env-only Google Generative AI routing when models.providers.google is missing", () => {
+  it("preserves env-only Google Gemini routing when models.providers.google is missing", () => {
     vi.mocked(createTransportAwareStreamFnForModel).mockReturnValueOnce(streamFn);
 
     expect(() =>
       registerProviderStreamForModel({
-        model: googleModel,
+        model: googleGenerativeModel,
         cfg: {
           models: {
             providers: {
@@ -42,8 +52,9 @@ describe("registerProviderStreamForModel", () => {
         } as NodeJS.ProcessEnv,
       }),
     ).not.toThrow();
+
     expect(createTransportAwareStreamFnForModel).toHaveBeenCalledWith(
-      googleModel,
+      googleGenerativeModel,
       expect.objectContaining({
         env: expect.objectContaining({
           GEMINI_API_KEY: "google-env-key",
@@ -52,10 +63,10 @@ describe("registerProviderStreamForModel", () => {
     );
   });
 
-  it("fails closed when models.providers.google is configured with a non-Google API", () => {
+  it("fails closed when a Google provider config explicitly points at a non-Google API", () => {
     expect(() =>
       registerProviderStreamForModel({
-        model: googleModel,
+        model: googleModelResolvedThroughMismatchedProvider,
         cfg: {
           models: {
             providers: {
@@ -75,7 +86,7 @@ describe("registerProviderStreamForModel", () => {
 
     try {
       registerProviderStreamForModel({
-        model: googleModel,
+        model: googleModelResolvedThroughMismatchedProvider,
         cfg: {
           models: {
             providers: {
@@ -94,12 +105,12 @@ describe("registerProviderStreamForModel", () => {
     }
   });
 
-  it("allows Google Generative AI models when the Google provider is explicitly configured", () => {
+  it("allows Google Gemini routing when the Google provider is explicitly configured with the Google API", () => {
     vi.mocked(createTransportAwareStreamFnForModel).mockReturnValueOnce(streamFn);
 
     expect(() =>
       registerProviderStreamForModel({
-        model: googleModel,
+        model: googleGenerativeModel,
         cfg: {
           models: {
             providers: {

--- a/src/agents/provider-stream.ts
+++ b/src/agents/provider-stream.ts
@@ -3,7 +3,31 @@ import type { Api, Model } from "@earendil-works/pi-ai";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveProviderStreamFn } from "../plugins/provider-runtime.js";
 import { ensureCustomApiRegistered } from "./custom-api-registry.js";
+import { normalizeProviderId, findNormalizedProviderValue } from "./provider-id.js";
 import { createTransportAwareStreamFnForModel } from "./provider-transport-stream.js";
+
+function hasConfiguredProvider(params: { cfg?: OpenClawConfig; provider: string }): boolean {
+  return Boolean(findNormalizedProviderValue(params.cfg?.models?.providers, params.provider));
+}
+
+function isGoogleGenerativeModel<TApi extends Api>(model: Model<TApi>): boolean {
+  return model.api === "google-generative-ai" && normalizeProviderId(model.provider) === "google";
+}
+
+function assertProviderConfigMatchesModel<TApi extends Api>(params: {
+  model: Model<TApi>;
+  cfg?: OpenClawConfig;
+}): void {
+  if (!isGoogleGenerativeModel(params.model)) {
+    return;
+  }
+  if (hasConfiguredProvider({ cfg: params.cfg, provider: "google" })) {
+    return;
+  }
+  throw new Error(
+    `Google model "google/${params.model.id}" requires models.providers.google. Configure the Google provider or remove this model from the primary/fallback model list.`,
+  );
+}
 
 export function registerProviderStreamForModel<TApi extends Api>(params: {
   model: Model<TApi>;
@@ -13,6 +37,8 @@ export function registerProviderStreamForModel<TApi extends Api>(params: {
   env?: NodeJS.ProcessEnv;
   allowRuntimePluginLoad?: boolean;
 }): StreamFn | undefined {
+  assertProviderConfigMatchesModel({ model: params.model, cfg: params.cfg });
+
   const streamFn =
     resolveProviderStreamFn({
       provider: params.model.provider,

--- a/src/agents/provider-stream.ts
+++ b/src/agents/provider-stream.ts
@@ -25,13 +25,18 @@ function assertProviderConfigMatchesModel<TApi extends Api>(params: {
 
   const googleProviderConfig = resolveConfiguredProvider({ cfg: params.cfg, provider: "google" });
   const configuredApi = normalizeOptionalString(googleProviderConfig?.api);
+  const modelApi = normalizeOptionalString(params.model.api);
 
   if (!configuredApi || configuredApi === "google-generative-ai") {
     return;
   }
 
+  if (configuredApi === "google-vertex" && modelApi === "google-vertex") {
+    return;
+  }
+
   throw new Error(
-    `Google model "google/${params.model.id}" cannot use models.providers.google api "${configuredApi}". Expected api "google-generative-ai". Configure the Google provider correctly or remove the mismatched provider config.`,
+    `Google model "google/${params.model.id}" cannot use models.providers.google api "${configuredApi}". Expected api "google-generative-ai"${modelApi === "google-vertex" ? ' or "google-vertex"' : ""}. Configure the Google provider correctly or remove the mismatched provider config.`,
   );
 }
 

--- a/src/agents/provider-stream.ts
+++ b/src/agents/provider-stream.ts
@@ -27,16 +27,24 @@ function assertProviderConfigMatchesModel<TApi extends Api>(params: {
   const configuredApi = normalizeOptionalString(googleProviderConfig?.api);
   const modelApi = normalizeOptionalString(params.model.api);
 
-  if (!configuredApi || configuredApi === "google-generative-ai") {
+  if (
+    (!configuredApi || configuredApi === "google-generative-ai") &&
+    modelApi === "google-generative-ai"
+  ) {
     return;
   }
 
-  if (configuredApi === "google-vertex" && modelApi === "google-vertex") {
+  if ((!configuredApi || configuredApi === "google-vertex") && modelApi === "google-vertex") {
     return;
   }
+
+  const mismatchSource =
+    configuredApi && configuredApi !== "google-generative-ai" && configuredApi !== "google-vertex"
+      ? `models.providers.google api "${configuredApi}"`
+      : `resolved model api "${modelApi ?? "unknown"}"`;
 
   throw new Error(
-    `Google model "google/${params.model.id}" cannot use models.providers.google api "${configuredApi}". Expected api "google-generative-ai"${modelApi === "google-vertex" ? ' or "google-vertex"' : ""}. Configure the Google provider correctly or remove the mismatched provider config.`,
+    `Google model "google/${params.model.id}" cannot use ${mismatchSource}. Expected api "google-generative-ai"${modelApi === "google-vertex" ? ' or "google-vertex"' : ""}. Configure the Google provider correctly or remove the mismatched provider config.`,
   );
 }
 

--- a/src/agents/provider-stream.ts
+++ b/src/agents/provider-stream.ts
@@ -15,10 +15,6 @@ function resolveConfiguredProvider(params: {
   return findNormalizedProviderValue(params.cfg?.models?.providers, params.provider);
 }
 
-function isGoogleGenerativeProviderConfig(providerConfig: ModelProviderConfig | undefined): boolean {
-  return normalizeOptionalString(providerConfig?.api) === "google-generative-ai";
-}
-
 function isGoogleGenerativeModel<TApi extends Api>(model: Model<TApi>): boolean {
   return model.api === "google-generative-ai" && normalizeProviderId(model.provider) === "google";
 }
@@ -31,11 +27,12 @@ function assertProviderConfigMatchesModel<TApi extends Api>(params: {
     return;
   }
   const googleProviderConfig = resolveConfiguredProvider({ cfg: params.cfg, provider: "google" });
-  if (isGoogleGenerativeProviderConfig(googleProviderConfig)) {
+  const configuredApi = normalizeOptionalString(googleProviderConfig?.api);
+  if (!configuredApi || configuredApi === "google-generative-ai") {
     return;
   }
   throw new Error(
-    `Google model "google/${params.model.id}" requires models.providers.google with api "google-generative-ai". Configure the Google provider or remove this model from the primary/fallback model list.`,
+    `Google model "google/${params.model.id}" cannot use models.providers.google api "${configuredApi}". Expected api "google-generative-ai". Configure the Google provider correctly or remove the mismatched provider config.`,
   );
 }
 

--- a/src/agents/provider-stream.ts
+++ b/src/agents/provider-stream.ts
@@ -15,22 +15,21 @@ function resolveConfiguredProvider(params: {
   return findNormalizedProviderValue(params.cfg?.models?.providers, params.provider);
 }
 
-function isGoogleGenerativeModel<TApi extends Api>(model: Model<TApi>): boolean {
-  return model.api === "google-generative-ai" && normalizeProviderId(model.provider) === "google";
-}
-
 function assertProviderConfigMatchesModel<TApi extends Api>(params: {
   model: Model<TApi>;
   cfg?: OpenClawConfig;
 }): void {
-  if (!isGoogleGenerativeModel(params.model)) {
+  if (normalizeProviderId(params.model.provider) !== "google") {
     return;
   }
+
   const googleProviderConfig = resolveConfiguredProvider({ cfg: params.cfg, provider: "google" });
   const configuredApi = normalizeOptionalString(googleProviderConfig?.api);
+
   if (!configuredApi || configuredApi === "google-generative-ai") {
     return;
   }
+
   throw new Error(
     `Google model "google/${params.model.id}" cannot use models.providers.google api "${configuredApi}". Expected api "google-generative-ai". Configure the Google provider correctly or remove the mismatched provider config.`,
   );
@@ -68,9 +67,11 @@ export function registerProviderStreamForModel<TApi extends Api>(params: {
       workspaceDir: params.workspaceDir,
       env: params.env,
     });
+
   if (!streamFn) {
     return undefined;
   }
+
   ensureCustomApiRegistered(params.model.api, streamFn);
   return streamFn;
 }

--- a/src/agents/provider-stream.ts
+++ b/src/agents/provider-stream.ts
@@ -1,13 +1,22 @@
 import type { StreamFn } from "@earendil-works/pi-agent-core";
 import type { Api, Model } from "@earendil-works/pi-ai";
+import type { ModelProviderConfig } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveProviderStreamFn } from "../plugins/provider-runtime.js";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { ensureCustomApiRegistered } from "./custom-api-registry.js";
 import { normalizeProviderId, findNormalizedProviderValue } from "./provider-id.js";
 import { createTransportAwareStreamFnForModel } from "./provider-transport-stream.js";
 
-function hasConfiguredProvider(params: { cfg?: OpenClawConfig; provider: string }): boolean {
-  return Boolean(findNormalizedProviderValue(params.cfg?.models?.providers, params.provider));
+function resolveConfiguredProvider(params: {
+  cfg?: OpenClawConfig;
+  provider: string;
+}): ModelProviderConfig | undefined {
+  return findNormalizedProviderValue(params.cfg?.models?.providers, params.provider);
+}
+
+function isGoogleGenerativeProviderConfig(providerConfig: ModelProviderConfig | undefined): boolean {
+  return normalizeOptionalString(providerConfig?.api) === "google-generative-ai";
 }
 
 function isGoogleGenerativeModel<TApi extends Api>(model: Model<TApi>): boolean {
@@ -21,11 +30,12 @@ function assertProviderConfigMatchesModel<TApi extends Api>(params: {
   if (!isGoogleGenerativeModel(params.model)) {
     return;
   }
-  if (hasConfiguredProvider({ cfg: params.cfg, provider: "google" })) {
+  const googleProviderConfig = resolveConfiguredProvider({ cfg: params.cfg, provider: "google" });
+  if (isGoogleGenerativeProviderConfig(googleProviderConfig)) {
     return;
   }
   throw new Error(
-    `Google model "google/${params.model.id}" requires models.providers.google. Configure the Google provider or remove this model from the primary/fallback model list.`,
+    `Google model "google/${params.model.id}" requires models.providers.google with api "google-generative-ai". Configure the Google provider or remove this model from the primary/fallback model list.`,
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes #85042.

This narrows Google provider/model validation to the unsafe explicit mismatch case while preserving documented env-only Gemini auth.

A `google/gemini-*` model is still allowed when `models.providers.google` is absent, so `GEMINI_API_KEY` / `GOOGLE_API_KEY` setups keep working. If `models.providers.google` is explicitly present but points at a non-Google API such as `openai-responses`, OpenClaw fails closed before stream dispatch.

## Security impact

This prevents a Google model selection from being routed through a mismatched OpenAI-compatible provider config while preserving the existing env-backed Google provider contract.

The error message does not include configured API keys.

## Validation

Focused validation after the latest patch:

```text
$ pnpm exec vitest run --config test/vitest/vitest.agents-core.config.ts src/agents/provider-stream.test.ts --reporter verbose
Test Files  1 passed (1)
Tests       6 passed (6)

$ pnpm exec vitest run --config test/vitest/vitest.agents-support.config.ts src/agents/provider-stream.test.ts --reporter verbose
Test Files  1 passed (1)
Tests       6 passed (6)

$ pnpm exec vitest run --config test/vitest/vitest.agents-core.config.ts src/agents/pi-embedded-runner/stream-resolution.test.ts --reporter verbose
Test Files  1 passed (1)
Tests       20 passed (20)

$ git diff --check
# no output
```

Earlier validation retained from the previous patch remains relevant for the provider-level mismatch path and build smoke.


## Real behavior proof

**Behavior or issue addressed:**
OpenClaw now fails closed for both provider-level and model-level Google provider API mismatches. A selected `google/gemini-*` model cannot proceed through a resolved Google provider model entry whose API is `openai-responses`, even when `models.providers.google.api` is absent.

**Real environment tested:**
Local OpenClaw PR worktree on Linux.

```text
repo: /home/rev/projects/openclaw-prs/pr-86284-google-provider-failclosed
head: 8de847eb8c156cfed0cb1e1647a4a3ad300f68ab
node: v22.22.2
pnpm: 11.2.2
validation log: /home/rev/projects/openclaw-prs/_logs/pr-86284/validation-precommit-2631892e.log
```

**Exact steps or command run after this patch:**

1. Added a model-level mismatch guard for Google-provider models whose resolved `model.api` is not `google-generative-ai` or `google-vertex`.
2. Added a regression test for a `models.providers.google.models[]` entry with `api: "openai-responses"` and no provider-level API.
3. Ran the provider-stream focused tests in the relevant agents-core and agents-support Vitest projects.
4. Ran the existing embedded stream-resolution focused test in agents-core.
5. Ran whitespace validation.

**Evidence after fix:**

Copied local terminal summary:

```text
$ pnpm exec vitest run --config test/vitest/vitest.agents-core.config.ts src/agents/provider-stream.test.ts --reporter verbose
Test Files  1 passed (1)
Tests       6 passed (6)

$ pnpm exec vitest run --config test/vitest/vitest.agents-support.config.ts src/agents/provider-stream.test.ts --reporter verbose
Test Files  1 passed (1)
Tests       6 passed (6)

$ pnpm exec vitest run --config test/vitest/vitest.agents-core.config.ts src/agents/pi-embedded-runner/stream-resolution.test.ts --reporter verbose
Test Files  1 passed (1)
Tests       20 passed (20)

$ git diff --check
# no output
```

The new regression assertion checks that a Google-provider model resolved with `api: "openai-responses"` throws with `resolved model api "openai-responses"` before provider stream dispatch.

**Observed result after fix:**
The provider-stream guard rejects the model-level mismatch path identified by ClawSweeper while preserving env-only Gemini, explicit Google Generative AI, and Google Vertex routing. The focused provider-stream tests pass in both affected Vitest projects, and the embedded stream-resolution tests continue to pass.

**What was not tested:**
A live request to Google Generative AI was not performed.
