### PR TITLE
fix(ollama): strip inline kimi cloud reasoning leak

### DIFF
--- a/extensions/ollama/src/model-behavior.ts
+++ b/extensions/ollama/src/model-behavior.ts
@@ -1,0 +1,5 @@
+import { isOllamaCloudKimiModelRef } from "./sanitizers/kimi-inline-reasoning.js";
+
+export function shouldWrapOllamaCompatMoonshotThinking(modelId: string): boolean {
+  return isOllamaCloudKimiModelRef(modelId);
+}

--- a/extensions/ollama/src/sanitizers/kimi-inline-reasoning.ts
+++ b/extensions/ollama/src/sanitizers/kimi-inline-reasoning.ts
@@ -38,7 +38,7 @@ function resolveInlineReasoningVisibleText(params: {
   const boundaryEndIndex = match.index + match[0].length;
   const prefix = params.text.slice(0, boundaryStartIndex).trim();
   const answer = params.text.slice(boundaryEndIndex).trim();
-  if (prefix.length >= INLINE_REASONING_MIN_PREFIX_CHARS && answer) {
+  if (prefix.length >= INLINE_REASONING_MIN_PREFIX_CHARS) {
     return { kind: "visible", text: answer };
   }
 

--- a/extensions/ollama/src/sanitizers/kimi-inline-reasoning.ts
+++ b/extensions/ollama/src/sanitizers/kimi-inline-reasoning.ts
@@ -2,7 +2,7 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import type {
   OllamaVisibleContentSanitizer,
   OllamaVisibleContentStreamResolution,
-} from "./visible-content.js";
+} from "./visible-content-contract.js";
 
 const INLINE_REASONING_MIN_PREFIX_CHARS = 80;
 const INLINE_REASONING_MAX_PENDING_CHARS = 512;

--- a/extensions/ollama/src/sanitizers/kimi-inline-reasoning.ts
+++ b/extensions/ollama/src/sanitizers/kimi-inline-reasoning.ts
@@ -14,7 +14,10 @@ type InlineReasoningVisibleTextResolution =
 
 export function isOllamaCloudKimiModelRef(modelId: string): boolean {
   const normalizedModelId = normalizeLowercaseStringOrEmpty(modelId);
-  return normalizedModelId.startsWith("kimi-k") && normalizedModelId.includes(":cloud");
+  const slashIndex = normalizedModelId.indexOf("/");
+  const normalizedWireModelId =
+    slashIndex === -1 ? normalizedModelId : normalizedModelId.slice(slashIndex + 1);
+  return normalizedWireModelId.startsWith("kimi-k") && normalizedWireModelId.includes(":cloud");
 }
 
 function resolveInlineReasoningVisibleText(params: {

--- a/extensions/ollama/src/sanitizers/kimi-inline-reasoning.ts
+++ b/extensions/ollama/src/sanitizers/kimi-inline-reasoning.ts
@@ -1,0 +1,74 @@
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type {
+  OllamaVisibleContentSanitizer,
+  OllamaVisibleContentStreamResolution,
+} from "./visible-content.js";
+
+const INLINE_REASONING_MIN_PREFIX_CHARS = 80;
+const INLINE_REASONING_MAX_PENDING_CHARS = 512;
+const INLINE_REASONING_BOUNDARY_RE = /(^|\s)\uFE0F\s*/u;
+
+type InlineReasoningVisibleTextResolution =
+  | { kind: "visible"; text: string; bypassInlineReasoning?: boolean }
+  | { kind: "pending" };
+
+export function isOllamaCloudKimiModelRef(modelId: string): boolean {
+  const normalizedModelId = normalizeLowercaseStringOrEmpty(modelId);
+  return normalizedModelId.startsWith("kimi-k") && normalizedModelId.includes(":cloud");
+}
+
+function resolveInlineReasoningVisibleText(params: {
+  text: string;
+  final: boolean;
+}): InlineReasoningVisibleTextResolution {
+  const match = INLINE_REASONING_BOUNDARY_RE.exec(params.text);
+  if (!match) {
+    if (!params.final && params.text.length <= INLINE_REASONING_MAX_PENDING_CHARS) {
+      return { kind: "pending" };
+    }
+    return {
+      kind: "visible",
+      text: params.text,
+      bypassInlineReasoning:
+        !params.final && params.text.length > INLINE_REASONING_MAX_PENDING_CHARS,
+    };
+  }
+
+  const boundaryStartIndex = match.index + match[1].length;
+  const boundaryEndIndex = match.index + match[0].length;
+  const prefix = params.text.slice(0, boundaryStartIndex).trim();
+  const answer = params.text.slice(boundaryEndIndex).trim();
+  if (prefix.length >= INLINE_REASONING_MIN_PREFIX_CHARS && answer) {
+    return { kind: "visible", text: answer };
+  }
+
+  return params.final ? { kind: "visible", text: params.text } : { kind: "pending" };
+}
+
+export function createKimiInlineReasoningSanitizer(): OllamaVisibleContentSanitizer {
+  let bypassInlineReasoning = false;
+
+  return {
+    resolveStreamText(params): OllamaVisibleContentStreamResolution {
+      if (bypassInlineReasoning) {
+        return { kind: "visible", text: params.text };
+      }
+
+      const resolution = resolveInlineReasoningVisibleText(params);
+      if (resolution.kind === "pending") {
+        return resolution;
+      }
+      if (resolution.bypassInlineReasoning) {
+        bypassInlineReasoning = true;
+      }
+      return { kind: "visible", text: resolution.text };
+    },
+    sanitizeFinalText(text) {
+      const resolution = resolveInlineReasoningVisibleText({ text, final: true });
+      return resolution.kind === "visible" ? resolution.text : text;
+    },
+    shouldSanitizeFinalMessage() {
+      return !bypassInlineReasoning;
+    },
+  };
+}

--- a/extensions/ollama/src/sanitizers/kimi-inline-reasoning.ts
+++ b/extensions/ollama/src/sanitizers/kimi-inline-reasoning.ts
@@ -70,8 +70,5 @@ export function createKimiInlineReasoningSanitizer(): OllamaVisibleContentSaniti
       const resolution = resolveInlineReasoningVisibleText({ text, final: true });
       return resolution.kind === "visible" ? resolution.text : text;
     },
-    shouldSanitizeFinalMessage() {
-      return !bypassInlineReasoning;
-    },
   };
 }

--- a/extensions/ollama/src/sanitizers/visible-content-contract.ts
+++ b/extensions/ollama/src/sanitizers/visible-content-contract.ts
@@ -1,0 +1,9 @@
+export type OllamaVisibleContentStreamResolution =
+  | { kind: "visible"; text: string }
+  | { kind: "pending" };
+
+export type OllamaVisibleContentSanitizer = {
+  resolveStreamText(params: { text: string; final: boolean }): OllamaVisibleContentStreamResolution;
+  sanitizeFinalText(text: string): string;
+  shouldSanitizeFinalMessage(): boolean;
+};

--- a/extensions/ollama/src/sanitizers/visible-content-contract.ts
+++ b/extensions/ollama/src/sanitizers/visible-content-contract.ts
@@ -5,5 +5,4 @@ export type OllamaVisibleContentStreamResolution =
 export type OllamaVisibleContentSanitizer = {
   resolveStreamText(params: { text: string; final: boolean }): OllamaVisibleContentStreamResolution;
   sanitizeFinalText(text: string): string;
-  shouldSanitizeFinalMessage(): boolean;
 };

--- a/extensions/ollama/src/sanitizers/visible-content.ts
+++ b/extensions/ollama/src/sanitizers/visible-content.ts
@@ -11,9 +11,6 @@ const noopVisibleContentSanitizer: OllamaVisibleContentSanitizer = {
   sanitizeFinalText(text) {
     return text;
   },
-  shouldSanitizeFinalMessage() {
-    return true;
-  },
 };
 
 export function createOllamaVisibleContentSanitizer(

--- a/extensions/ollama/src/sanitizers/visible-content.ts
+++ b/extensions/ollama/src/sanitizers/visible-content.ts
@@ -1,0 +1,42 @@
+import {
+  createKimiInlineReasoningSanitizer,
+  isOllamaCloudKimiModelRef,
+} from "./kimi-inline-reasoning.js";
+
+export type OllamaVisibleContentStreamResolution =
+  | { kind: "visible"; text: string }
+  | { kind: "pending" };
+
+export type OllamaVisibleContentSanitizer = {
+  resolveStreamText(params: { text: string; final: boolean }): OllamaVisibleContentStreamResolution;
+  sanitizeFinalText(text: string): string;
+  shouldSanitizeFinalMessage(): boolean;
+};
+
+const noopVisibleContentSanitizer: OllamaVisibleContentSanitizer = {
+  resolveStreamText(params) {
+    return { kind: "visible", text: params.text };
+  },
+  sanitizeFinalText(text) {
+    return text;
+  },
+  shouldSanitizeFinalMessage() {
+    return true;
+  },
+};
+
+export function createOllamaVisibleContentSanitizer(
+  modelId: string,
+): OllamaVisibleContentSanitizer {
+  if (isOllamaCloudKimiModelRef(modelId)) {
+    return createKimiInlineReasoningSanitizer();
+  }
+  return noopVisibleContentSanitizer;
+}
+
+export function sanitizeOllamaFinalVisibleContent(params: {
+  modelId: string;
+  text: string;
+}): string {
+  return createOllamaVisibleContentSanitizer(params.modelId).sanitizeFinalText(params.text);
+}

--- a/extensions/ollama/src/sanitizers/visible-content.ts
+++ b/extensions/ollama/src/sanitizers/visible-content.ts
@@ -2,16 +2,7 @@ import {
   createKimiInlineReasoningSanitizer,
   isOllamaCloudKimiModelRef,
 } from "./kimi-inline-reasoning.js";
-
-export type OllamaVisibleContentStreamResolution =
-  | { kind: "visible"; text: string }
-  | { kind: "pending" };
-
-export type OllamaVisibleContentSanitizer = {
-  resolveStreamText(params: { text: string; final: boolean }): OllamaVisibleContentStreamResolution;
-  sanitizeFinalText(text: string): string;
-  shouldSanitizeFinalMessage(): boolean;
-};
+import type { OllamaVisibleContentSanitizer } from "./visible-content-contract.js";
 
 const noopVisibleContentSanitizer: OllamaVisibleContentSanitizer = {
   resolveStreamText(params) {

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -979,6 +979,30 @@ describe("buildAssistantMessage", () => {
     expect(result.content).toEqual([{ type: "text", text: "intro ️keep this intact" }]);
   });
 
+  it("does not treat emoji variation selectors as Kimi inline-reasoning boundaries", () => {
+    const response = {
+      model: "kimi-k2.6:cloud",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content:
+          "This is a normal Kimi cloud answer with enough length to cross the prefix threshold and no hidden reasoning leak. ☀️sunshine should remain visible to the user.",
+      },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, {
+      api: "ollama",
+      provider: "ollama",
+      id: "kimi-k2.6:cloud",
+    });
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: "This is a normal Kimi cloud answer with enough length to cross the prefix threshold and no hidden reasoning leak. ☀️sunshine should remain visible to the user.",
+      },
+    ]);
+  });
+
   it("estimates usage when Ollama omits eval counters", () => {
     const response = {
       model: "qwen3:32b",
@@ -1785,6 +1809,63 @@ describe("createOllamaStreamFn streaming events", () => {
 
         const delta = events.find((e) => e.type === "text_delta");
         expect(delta?.delta).toBe("one shot");
+      },
+    );
+  });
+
+  it("sanitizes Kimi inline reasoning in text_delta, text_end, partial, and done output", async () => {
+    await withMockNdjsonFetch(
+      [
+        JSON.stringify({
+          model: "kimi-k2.6:cloud",
+          created_at: "t",
+          message: {
+            role: "assistant",
+            content:
+              "I should think privately and not leak this planning text in the answer. I need to keep deciding what to say next. ️Final answer",
+          },
+          done: false,
+        }),
+        JSON.stringify({
+          model: "kimi-k2.6:cloud",
+          created_at: "t",
+          message: { role: "assistant", content: " only." },
+          done: false,
+        }),
+        '{"model":"kimi-k2.6:cloud","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":3,"eval_count":4}',
+      ],
+      async () => {
+        const stream = await createOllamaTestStream({
+          baseUrl: "http://ollama-host:11434",
+          model: { id: "kimi-k2.6:cloud", provider: "ollama" },
+        });
+        const events = await collectStreamEvents(stream);
+        const types = events.map((e) => e.type);
+        expect(types).toEqual([
+          "start",
+          "text_start",
+          "text_delta",
+          "text_delta",
+          "text_end",
+          "done",
+        ]);
+
+        const deltas = events.filter((e) => e.type === "text_delta");
+        expect(deltas).toHaveLength(2);
+        expect(deltas[0]?.delta).toBe("Final answer");
+        expect(deltas[1]?.delta).toBe(" only.");
+        expect(deltas[0]?.partial.content).toEqual([{ type: "text", text: "Final answer" }]);
+        expect(deltas[1]?.partial.content).toEqual([{ type: "text", text: "Final answer only." }]);
+
+        const textEnd = events.find((e) => e.type === "text_end");
+        expect(textEnd?.content).toBe("Final answer only.");
+        expect(textEnd?.partial.content).toEqual([{ type: "text", text: "Final answer only." }]);
+
+        const doneEvent = events.at(-1);
+        expect(doneEvent?.type).toBe("done");
+        if (doneEvent?.type === "done") {
+          expect(doneEvent.message.content).toEqual([{ type: "text", text: "Final answer only." }]);
+        }
       },
     );
   });

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1003,6 +1003,25 @@ describe("buildAssistantMessage", () => {
     expect(result.content).toEqual([{ type: "text", text: "OK." }]);
   });
 
+  it("strips inline reasoning when the Kimi boundary has no visible answer", () => {
+    const response = {
+      model: "kimi-k2.6:cloud",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content:
+          "I should think privately and not leak this planning text in the answer. I need to keep deciding what to say next. ️ ",
+      },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, {
+      api: "ollama",
+      provider: "ollama",
+      id: "kimi-k2.6:cloud",
+    });
+    expect(result.content).toEqual([]);
+  });
+
   it("does not strip inline boundary marker on non-kimi models", () => {
     const response = {
       model: "qwen3:32b",
@@ -2096,6 +2115,55 @@ describe("createOllamaStreamFn streaming events", () => {
         expect(doneEvent?.type).toBe("done");
         if (doneEvent?.type === "done") {
           expect(doneEvent.message.content).toEqual([{ type: "text", text: "Final answer only." }]);
+        }
+      },
+    );
+  });
+
+  it("does not leak Kimi inline reasoning when a boundary is followed by tool calls only", async () => {
+    const hiddenPrefix =
+      "I should think privately and not leak this planning text in the answer. " +
+      "I need to keep deciding what tool to call before showing any visible text.";
+    await withMockNdjsonFetch(
+      [
+        JSON.stringify({
+          model: "kimi-k2.6:cloud",
+          created_at: "t",
+          message: { role: "assistant", content: `${hiddenPrefix} ️ ` },
+          done: false,
+        }),
+        JSON.stringify({
+          model: "kimi-k2.6:cloud",
+          created_at: "t",
+          message: {
+            role: "assistant",
+            content: "",
+            tool_calls: [{ function: { name: "bash", arguments: { command: "ls" } } }],
+          },
+          done: false,
+        }),
+        '{"model":"kimi-k2.6:cloud","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":20,"eval_count":40}',
+      ],
+      async () => {
+        const stream = await createOllamaTestStream({
+          baseUrl: "http://ollama-host:11434",
+          model: { id: "kimi-k2.6:cloud", provider: "ollama" },
+        });
+        const events = await collectStreamEvents(stream);
+
+        expect(events.map((e) => e.type)).toEqual(["done"]);
+        const doneEvent = events.at(-1);
+        expect(doneEvent?.type).toBe("done");
+        if (doneEvent?.type === "done") {
+          expect(doneEvent.message.content).toEqual([
+            {
+              type: "toolCall",
+              id: expect.any(String),
+              name: "bash",
+              arguments: { command: "ls" },
+            },
+          ]);
+          expect(JSON.stringify(doneEvent)).not.toContain("I should think privately");
         }
       },
     );

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1755,7 +1755,7 @@ describe("createOllamaStreamFn streaming events", () => {
         const events = await collectStreamEvents(stream);
 
         const types = events.map((e) => e.type);
-        expect(types).toEqual(["start", "text_start", "text_delta", "error"]);
+        expect(types).toEqual(["error"]);
         const errorEvent = events.at(-1);
         expect(errorEvent?.type).toBe("error");
         if (errorEvent?.type === "error") {
@@ -1763,6 +1763,95 @@ describe("createOllamaStreamFn streaming events", () => {
         }
       },
     );
+  });
+
+  it("buffers Kimi inline reasoning until the streaming boundary is safe", async () => {
+    const controlledFetch = createControlledNdjsonFetch();
+    fetchWithSsrFGuardMock.mockImplementation(controlledFetch.fetchImpl);
+
+    try {
+      const stream = await createOllamaTestStream({
+        baseUrl: "http://ollama-host:11434",
+        model: { id: "kimi-k2.6:cloud", provider: "ollama" },
+      });
+      const iterator = stream[Symbol.asyncIterator]();
+
+      controlledFetch.pushLine(
+        JSON.stringify({
+          model: "kimi-k2.6:cloud",
+          created_at: "t",
+          message: {
+            role: "assistant",
+            content:
+              "The user is asking for a short answer. I should reason privately before answering. I need to avoid showing this planning text to the user.",
+          },
+          done: false,
+        }),
+      );
+
+      const pendingStartEvent = iterator.next();
+      expect(
+        await Promise.race([
+          pendingStartEvent.then(() => "event" as const),
+          new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 100)),
+        ]),
+      ).toBe("timeout");
+
+      controlledFetch.pushLine(
+        JSON.stringify({
+          model: "kimi-k2.6:cloud",
+          created_at: "t",
+          message: { role: "assistant", content: " ️Final answer only." },
+          done: false,
+        }),
+      );
+
+      const startEvent = await pendingStartEvent;
+      expectIteratorEvent(startEvent, { type: "start", done: false });
+
+      const textStartEvent = await nextEventWithin(iterator);
+      expect(textStartEvent).not.toBe("timeout");
+      expectIteratorEvent(textStartEvent, { type: "text_start", done: false });
+
+      const textDeltaEvent = await nextEventWithin(iterator);
+      expect(textDeltaEvent).not.toBe("timeout");
+      expectIteratorEvent(textDeltaEvent, {
+        type: "text_delta",
+        delta: "Final answer only.",
+        done: false,
+      });
+      if (textDeltaEvent !== "timeout" && textDeltaEvent.done === false) {
+        const value = requireRecord(textDeltaEvent.value, "text_delta value");
+        expect(JSON.stringify(value)).not.toContain("The user is asking");
+      }
+
+      controlledFetch.pushLine(
+        '{"model":"kimi-k2.6:cloud","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":20,"eval_count":40}',
+      );
+      controlledFetch.close();
+
+      const textEndEvent = await nextEventWithin(iterator);
+      expect(textEndEvent).not.toBe("timeout");
+      expectIteratorEvent(textEndEvent, {
+        type: "text_end",
+        content: "Final answer only.",
+        done: false,
+      });
+
+      const doneEvent = await nextEventWithin(iterator);
+      expect(doneEvent).not.toBe("timeout");
+      expectIteratorEvent(doneEvent, { type: "done", done: false });
+      if (doneEvent !== "timeout" && doneEvent.done === false) {
+        const value = requireRecord(doneEvent.value, "done value");
+        expect(JSON.stringify(value)).not.toContain("The user is asking");
+      }
+
+      const streamEnd = await nextEventWithin(iterator);
+      expect(streamEnd).not.toBe("timeout");
+      expectIteratorEvent(streamEnd, { done: true });
+    } finally {
+      fetchWithSsrFGuardMock.mockReset();
+    }
   });
 
   it("does not reject punctuation-heavy text from unrelated Ollama models", async () => {

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -946,6 +946,39 @@ describe("buildAssistantMessage", () => {
     expect(result.content).toEqual([{ type: "thinking", thinking: "Reasoning output" }]);
   });
 
+  it("strips inline reasoning prefix from kimi cloud visible text", () => {
+    const response = {
+      model: "kimi-k2.6:cloud",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content:
+          "I should think privately and not leak this planning text in the answer. I need to keep deciding what to say next. ️Final answer only.",
+      },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, {
+      api: "ollama",
+      provider: "ollama",
+      id: "kimi-k2.6:cloud",
+    });
+    expect(result.content).toEqual([{ type: "text", text: "Final answer only." }]);
+  });
+
+  it("does not strip inline boundary marker on non-kimi models", () => {
+    const response = {
+      model: "qwen3:32b",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content: "intro ️keep this intact",
+      },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, modelInfo);
+    expect(result.content).toEqual([{ type: "text", text: "intro ️keep this intact" }]);
+  });
+
   it("estimates usage when Ollama omits eval counters", () => {
     const response = {
       model: "qwen3:32b",

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1892,6 +1892,70 @@ describe("createOllamaStreamFn streaming events", () => {
     }
   });
 
+  it("streams marker-less Kimi answers after the bounded sanitizer window", async () => {
+    const controlledFetch = createControlledNdjsonFetch();
+    fetchWithSsrFGuardMock.mockImplementation(controlledFetch.fetchImpl);
+
+    try {
+      const stream = await createOllamaTestStream({
+        baseUrl: "http://ollama-host:11434",
+        model: { id: "kimi-k2.6:cloud", provider: "ollama" },
+      });
+      const iterator = stream[Symbol.asyncIterator]();
+      const visibleAnswer = "This is a normal Kimi cloud answer without hidden reasoning. ".repeat(
+        12,
+      );
+
+      controlledFetch.pushLine(
+        JSON.stringify({
+          model: "kimi-k2.6:cloud",
+          created_at: "t",
+          message: { role: "assistant", content: visibleAnswer },
+          done: false,
+        }),
+      );
+
+      const startEvent = await nextEventWithin(iterator);
+      expect(startEvent).not.toBe("timeout");
+      expectIteratorEvent(startEvent, { type: "start", done: false });
+
+      const textStartEvent = await nextEventWithin(iterator);
+      expect(textStartEvent).not.toBe("timeout");
+      expectIteratorEvent(textStartEvent, { type: "text_start", done: false });
+
+      const textDeltaEvent = await nextEventWithin(iterator);
+      expect(textDeltaEvent).not.toBe("timeout");
+      expectIteratorEvent(textDeltaEvent, {
+        type: "text_delta",
+        delta: visibleAnswer,
+        done: false,
+      });
+
+      controlledFetch.pushLine(
+        '{"model":"kimi-k2.6:cloud","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":20,"eval_count":40}',
+      );
+      controlledFetch.close();
+
+      const textEndEvent = await nextEventWithin(iterator);
+      expect(textEndEvent).not.toBe("timeout");
+      expectIteratorEvent(textEndEvent, {
+        type: "text_end",
+        content: visibleAnswer,
+        done: false,
+      });
+
+      const doneEvent = await nextEventWithin(iterator);
+      expect(doneEvent).not.toBe("timeout");
+      expectIteratorEvent(doneEvent, { type: "done", done: false });
+
+      const streamEnd = await nextEventWithin(iterator);
+      expect(streamEnd).not.toBe("timeout");
+      expectIteratorEvent(streamEnd, { done: true });
+    } finally {
+      fetchWithSsrFGuardMock.mockReset();
+    }
+  });
+
   it("does not reject punctuation-heavy text from unrelated Ollama models", async () => {
     const punctuationHeavy =
       '$$"##"%#"##"####""$""""##""$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$' +

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -965,6 +965,25 @@ describe("buildAssistantMessage", () => {
     expect(result.content).toEqual([{ type: "text", text: "Final answer only." }]);
   });
 
+  it("strips inline reasoning for provider-qualified Kimi cloud refs", () => {
+    const response = {
+      model: "kimi-k2.6:cloud",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content:
+          "I should think privately and not leak this planning text in the answer. I need to keep deciding what to say next. ️Final answer only.",
+      },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, {
+      api: "ollama",
+      provider: "ollama",
+      id: "ollama/kimi-k2.6:cloud",
+    });
+    expect(result.content).toEqual([{ type: "text", text: "Final answer only." }]);
+  });
+
   it("strips inline reasoning when the Kimi boundary is followed by whitespace", () => {
     const response = {
       model: "kimi-k2.6:cloud",

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1934,6 +1934,8 @@ describe("createOllamaStreamFn streaming events", () => {
         const types = events.map((e) => e.type);
         expect(types).toEqual(["start", "text_start", "text_delta", "text_end", "done"]);
 
+        const textStart = events.find((e) => e.type === "text_start");
+        expect(textStart?.partial.content).toEqual([]);
         const delta = events.find((e) => e.type === "text_delta");
         expect(delta?.delta).toBe("one shot");
       },
@@ -1977,6 +1979,8 @@ describe("createOllamaStreamFn streaming events", () => {
           "done",
         ]);
 
+        const textStart = events.find((e) => e.type === "text_start");
+        expect(textStart?.partial.content).toEqual([]);
         const deltas = events.filter((e) => e.type === "text_delta");
         expect(deltas).toHaveLength(2);
         expect(deltas[0]?.delta).toBe("Final answer");

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -965,6 +965,44 @@ describe("buildAssistantMessage", () => {
     expect(result.content).toEqual([{ type: "text", text: "Final answer only." }]);
   });
 
+  it("strips inline reasoning when the Kimi boundary is followed by whitespace", () => {
+    const response = {
+      model: "kimi-k2.6:cloud",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content:
+          "I should think privately and not leak this planning text in the answer. I need to keep deciding what to say next. ️ Final answer only.",
+      },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, {
+      api: "ollama",
+      provider: "ollama",
+      id: "kimi-k2.6:cloud",
+    });
+    expect(result.content).toEqual([{ type: "text", text: "Final answer only." }]);
+  });
+
+  it("strips inline reasoning before short Kimi cloud answers", () => {
+    const response = {
+      model: "kimi-k2.6:cloud",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content:
+          "I should think privately and not leak this planning text in the answer. I need to keep deciding what to say next. ️ OK.",
+      },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, {
+      api: "ollama",
+      provider: "ollama",
+      id: "kimi-k2.6:cloud",
+    });
+    expect(result.content).toEqual([{ type: "text", text: "OK." }]);
+  });
+
   it("does not strip inline boundary marker on non-kimi models", () => {
     const response = {
       model: "qwen3:32b",
@@ -1801,7 +1839,7 @@ describe("createOllamaStreamFn streaming events", () => {
         JSON.stringify({
           model: "kimi-k2.6:cloud",
           created_at: "t",
-          message: { role: "assistant", content: " ️Final answer only." },
+          message: { role: "assistant", content: " ️ OK." },
           done: false,
         }),
       );
@@ -1817,7 +1855,7 @@ describe("createOllamaStreamFn streaming events", () => {
       expect(textDeltaEvent).not.toBe("timeout");
       expectIteratorEvent(textDeltaEvent, {
         type: "text_delta",
-        delta: "Final answer only.",
+        delta: "OK.",
         done: false,
       });
       if (textDeltaEvent !== "timeout" && textDeltaEvent.done === false) {
@@ -1834,7 +1872,7 @@ describe("createOllamaStreamFn streaming events", () => {
       expect(textEndEvent).not.toBe("timeout");
       expectIteratorEvent(textEndEvent, {
         type: "text_end",
-        content: "Final answer only.",
+        content: "OK.",
         done: false,
       });
 

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1956,6 +1956,42 @@ describe("createOllamaStreamFn streaming events", () => {
     }
   });
 
+  it("keeps Kimi deltas append-only after the bounded sanitizer window is bypassed", async () => {
+    const longPrefix = "This Kimi cloud output has streamed past the sanitizer window. ".repeat(10);
+    await withMockNdjsonFetch(
+      [
+        JSON.stringify({
+          model: "kimi-k2.6:cloud",
+          created_at: "t",
+          message: { role: "assistant", content: longPrefix },
+          done: false,
+        }),
+        JSON.stringify({
+          model: "kimi-k2.6:cloud",
+          created_at: "t",
+          message: { role: "assistant", content: " ️ OK." },
+          done: false,
+        }),
+        '{"model":"kimi-k2.6:cloud","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":20,"eval_count":40}',
+      ],
+      async () => {
+        const stream = await createOllamaTestStream({
+          baseUrl: "http://ollama-host:11434",
+          model: { id: "kimi-k2.6:cloud", provider: "ollama" },
+        });
+        const events = await collectStreamEvents(stream);
+        const deltas = events.filter((event) => event.type === "text_delta");
+        expect(deltas.map((event) => event.delta)).toEqual([longPrefix, " ️ OK."]);
+
+        const rawText = `${longPrefix} ️ OK.`;
+        const textEnd = events.find((event) => event.type === "text_end");
+        expect(textEnd?.content).toBe(rawText);
+        const doneEvent = events.find((event) => event.type === "done");
+        expect(doneEvent?.message.content).toEqual([{ type: "text", text: rawText }]);
+      },
+    );
+  });
+
   it("does not reject punctuation-heavy text from unrelated Ollama models", async () => {
     const punctuationHeavy =
       '$$"##"%#"##"####""$""""##""$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$' +

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -2139,6 +2139,47 @@ describe("createOllamaStreamFn streaming events", () => {
     );
   });
 
+  it("does not re-sanitize visible Kimi stream output before done", async () => {
+    const visibleAnswer =
+      "This visible answer is intentionally long enough to look like a reasoning prefix if it is sanitized a second time. ️ keep this marker visible.";
+    await withMockNdjsonFetch(
+      [
+        JSON.stringify({
+          model: "kimi-k2.6:cloud",
+          created_at: "t",
+          message: {
+            role: "assistant",
+            content:
+              "I should think privately and not leak this planning text in the answer. I need to keep deciding what to say next. ️",
+          },
+          done: false,
+        }),
+        JSON.stringify({
+          model: "kimi-k2.6:cloud",
+          created_at: "t",
+          message: { role: "assistant", content: visibleAnswer },
+          done: false,
+        }),
+        '{"model":"kimi-k2.6:cloud","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":3,"eval_count":4}',
+      ],
+      async () => {
+        const stream = await createOllamaTestStream({
+          baseUrl: "http://ollama-host:11434",
+          model: { id: "kimi-k2.6:cloud", provider: "ollama" },
+        });
+        const events = await collectStreamEvents(stream);
+        const textEnd = events.find((event) => event.type === "text_end");
+        const doneEvent = events.at(-1);
+
+        expect(textEnd?.content).toBe(visibleAnswer);
+        expect(doneEvent?.type).toBe("done");
+        if (doneEvent?.type === "done") {
+          expect(doneEvent.message.content).toEqual([{ type: "text", text: visibleAnswer }]);
+        }
+      },
+    );
+  });
+
   it("does not leak Kimi inline reasoning when a boundary is followed by tool calls only", async () => {
     const hiddenPrefix =
       "I should think privately and not leak this planning text in the answer. " +

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -364,6 +364,15 @@ function isOllamaCloudKimiModelRef(modelId: string): boolean {
 const KIMI_INLINE_REASONING_BOUNDARY = "️";
 const KIMI_INLINE_REASONING_MIN_PREFIX_CHARS = 80;
 const KIMI_INLINE_REASONING_MIN_ANSWER_CHARS = 8;
+const KIMI_INLINE_REASONING_BOUNDARY_RE = /(^|\s)\uFE0F(?=\S)/u;
+
+function findKimiInlineReasoningBoundaryIndex(text: string): number {
+  const match = KIMI_INLINE_REASONING_BOUNDARY_RE.exec(text);
+  if (!match) {
+    return -1;
+  }
+  return match.index + match[1].length;
+}
 
 function stripKimiInlineReasoningFromVisibleText(params: {
   modelId: string;
@@ -372,7 +381,7 @@ function stripKimiInlineReasoningFromVisibleText(params: {
   if (!isOllamaCloudKimiModelRef(params.modelId)) {
     return params.text;
   }
-  const boundaryIndex = params.text.indexOf(KIMI_INLINE_REASONING_BOUNDARY);
+  const boundaryIndex = findKimiInlineReasoningBoundaryIndex(params.text);
   if (boundaryIndex < 0) {
     return params.text;
   }
@@ -388,6 +397,21 @@ function stripKimiInlineReasoningFromVisibleText(params: {
     return params.text;
   }
   return answer;
+}
+
+function resolveStreamingTextDelta(previousText: string, nextText: string): string {
+  if (!nextText) {
+    return "";
+  }
+  if (!previousText) {
+    return nextText;
+  }
+  if (nextText.startsWith(previousText)) {
+    return nextText.slice(previousText.length);
+  }
+  // Sanitizers may rewrite previously accumulated content. Fall back to
+  // re-emitting the latest complete text so downstream partial state converges.
+  return nextText;
 }
 
 export function createConfiguredOllamaCompatStreamWrapper(
@@ -1153,7 +1177,8 @@ export function createOllamaStreamFn(
           }
 
           const reader = response.body.getReader();
-          let accumulatedContent = "";
+          let accumulatedRawContent = "";
+          let accumulatedVisibleContent = "";
           let accumulatedThinking = "";
           const accumulatedToolCalls: OllamaToolCall[] = [];
           let finalResponse: OllamaChatResponse | undefined;
@@ -1173,8 +1198,8 @@ export function createOllamaStreamFn(
                 thinking: accumulatedThinking,
               });
             }
-            if (accumulatedContent) {
-              parts.push({ type: "text", text: accumulatedContent });
+            if (accumulatedVisibleContent) {
+              parts.push({ type: "text", text: accumulatedVisibleContent });
             }
             return parts;
           };
@@ -1212,7 +1237,7 @@ export function createOllamaStreamFn(
             stream.push({
               type: "text_end",
               contentIndex: textContentIndex(),
-              content: accumulatedContent,
+              content: accumulatedVisibleContent,
               partial,
             });
           };
@@ -1256,7 +1281,22 @@ export function createOllamaStreamFn(
             }
 
             if (chunk.message?.content) {
-              const delta = chunk.message.content;
+              const rawDelta = chunk.message.content;
+              const previousVisibleContent = accumulatedVisibleContent;
+              accumulatedRawContent += rawDelta;
+              const nextVisibleContent = stripKimiInlineReasoningFromVisibleText({
+                modelId: model.id,
+                text: accumulatedRawContent,
+              });
+              const delta = resolveStreamingTextDelta(previousVisibleContent, nextVisibleContent);
+              if (!delta) {
+                accumulatedVisibleContent = nextVisibleContent;
+                if (chunk.done) {
+                  finalResponse = chunk;
+                  break;
+                }
+                continue;
+              }
               if (thinkingStarted && !thinkingEnded) {
                 closeThinkingBlock();
               }
@@ -1282,7 +1322,7 @@ export function createOllamaStreamFn(
                 stream.push({ type: "text_start", contentIndex: textContentIndex(), partial });
               }
 
-              accumulatedContent += delta;
+              accumulatedVisibleContent = nextVisibleContent;
               const partial = buildStreamAssistantMessage({
                 model: modelInfo,
                 content: buildCurrentContent(),
@@ -1311,13 +1351,13 @@ export function createOllamaStreamFn(
             throw new Error("Ollama API stream ended without a final response");
           }
 
-          if (isLikelyGarbledVisibleText({ text: accumulatedContent, modelId: model.id })) {
+          if (isLikelyGarbledVisibleText({ text: accumulatedVisibleContent, modelId: model.id })) {
             throw new Error(
               `Ollama returned non-linguistic garbled visible text for ${model.id}; retry or switch models`,
             );
           }
 
-          finalResponse.message.content = accumulatedContent;
+          finalResponse.message.content = accumulatedVisibleContent;
           if (accumulatedThinking) {
             finalResponse.message.thinking = accumulatedThinking;
           }

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -1367,7 +1367,7 @@ export function createOllamaStreamFn(
           };
           const assistantMessage = buildAssistantMessage(finalResponse, modelInfo, usageFallback, {
             ...toolCallNameOptions,
-            sanitizeVisibleContent: visibleContentSanitizer.shouldSanitizeFinalMessage(),
+            sanitizeVisibleContent: false,
           });
           closeThinkingBlock();
           closeTextBlock();

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -33,12 +33,17 @@ import {
   readStringValue,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { OLLAMA_DEFAULT_BASE_URL } from "./defaults.js";
+import { shouldWrapOllamaCompatMoonshotThinking } from "./model-behavior.js";
 import { normalizeOllamaWireModelId } from "./model-id.js";
 import {
   parseJsonObjectPreservingUnsafeIntegers,
   parseJsonPreservingUnsafeIntegers,
 } from "./ollama-json.js";
 import { buildOllamaBaseUrlSsrFPolicy } from "./provider-models.js";
+import {
+  createOllamaVisibleContentSanitizer,
+  sanitizeOllamaFinalVisibleContent,
+} from "./sanitizers/visible-content.js";
 
 const log = createSubsystemLogger("ollama-stream");
 
@@ -356,68 +361,6 @@ function resolveOllamaTopLevelParams(
   return Object.keys(requestParams).length > 0 ? requestParams : undefined;
 }
 
-function isOllamaCloudKimiModelRef(modelId: string): boolean {
-  const normalizedModelId = normalizeLowercaseStringOrEmpty(modelId);
-  return normalizedModelId.startsWith("kimi-k") && normalizedModelId.includes(":cloud");
-}
-
-const KIMI_INLINE_REASONING_MIN_PREFIX_CHARS = 80;
-const KIMI_INLINE_REASONING_MAX_PENDING_CHARS = 512;
-const KIMI_INLINE_REASONING_BOUNDARY_RE = /(^|\s)\uFE0F\s*/u;
-
-type KimiInlineReasoningVisibleTextResolution =
-  | { kind: "visible"; text: string; bypassInlineReasoning?: boolean }
-  | { kind: "pending" };
-
-function resolveKimiInlineReasoningVisibleText(params: {
-  modelId: string;
-  text: string;
-  final: boolean;
-}): KimiInlineReasoningVisibleTextResolution {
-  if (!isOllamaCloudKimiModelRef(params.modelId)) {
-    return { kind: "visible", text: params.text };
-  }
-
-  const match = KIMI_INLINE_REASONING_BOUNDARY_RE.exec(params.text);
-  if (!match) {
-    if (!params.final && params.text.length <= KIMI_INLINE_REASONING_MAX_PENDING_CHARS) {
-      return { kind: "pending" };
-    }
-    return {
-      kind: "visible",
-      text: params.text,
-      bypassInlineReasoning:
-        !params.final && params.text.length > KIMI_INLINE_REASONING_MAX_PENDING_CHARS,
-    };
-  }
-
-  const boundaryStartIndex = match.index + match[1].length;
-  const boundaryEndIndex = match.index + match[0].length;
-  const prefix = params.text.slice(0, boundaryStartIndex).trim();
-  const answer = params.text.slice(boundaryEndIndex).trim();
-  if (prefix.length >= KIMI_INLINE_REASONING_MIN_PREFIX_CHARS && answer) {
-    return { kind: "visible", text: answer };
-  }
-
-  return params.final ? { kind: "visible", text: params.text } : { kind: "pending" };
-}
-
-function stripKimiInlineReasoningFromVisibleText(params: {
-  modelId: string;
-  text: string;
-}): string {
-  const resolution = resolveKimiInlineReasoningVisibleText({ ...params, final: true });
-  return resolution.kind === "visible" ? resolution.text : params.text;
-}
-
-function resolveStreamingVisibleText(params: {
-  modelId: string;
-  text: string;
-  final: boolean;
-}): KimiInlineReasoningVisibleTextResolution {
-  return resolveKimiInlineReasoningVisibleText(params);
-}
-
 function resolveStreamingTextDelta(previousText: string, nextText: string): string {
   if (!nextText) {
     return "";
@@ -475,7 +418,10 @@ export function createConfiguredOllamaCompatStreamWrapper(
     streamFn = createOllamaThinkingWrapper(streamFn, ollamaThinkValue);
   }
 
-  if (normalizeProviderId(ctx.provider) === "ollama" && isOllamaCloudKimiModelRef(ctx.modelId)) {
+  if (
+    normalizeProviderId(ctx.provider) === "ollama" &&
+    shouldWrapOllamaCompatMoonshotThinking(ctx.modelId)
+  ) {
     const thinkingType = resolveMoonshotThinkingType({
       configuredThinking: ctx.extraParams?.thinking,
       thinkingLevel: ctx.thinkingLevel,
@@ -863,7 +809,7 @@ type OllamaToolCallNameOptions = {
 };
 
 type OllamaAssistantMessageBuildOptions = OllamaToolCallNameOptions & {
-  sanitizeKimiInlineReasoning?: boolean;
+  sanitizeVisibleContent?: boolean;
 };
 
 function readOllamaToolCallId(value: unknown): string | undefined {
@@ -1029,9 +975,9 @@ export function buildAssistantMessage(
   }
   const rawText = response.message.content || "";
   const text =
-    options.sanitizeKimiInlineReasoning === false
+    options.sanitizeVisibleContent === false
       ? rawText
-      : stripKimiInlineReasoningFromVisibleText({
+      : sanitizeOllamaFinalVisibleContent({
           modelId: modelInfo.id,
           text: rawText,
         });
@@ -1211,7 +1157,7 @@ export function createOllamaStreamFn(
           let finalResponse: OllamaChatResponse | undefined;
           let pendingFinalVisibleContent: string | undefined;
           const modelInfo = { api: model.api, provider: model.provider, id: model.id };
-          let bypassKimiInlineReasoningSanitizer = false;
+          const visibleContentSanitizer = createOllamaVisibleContentSanitizer(model.id);
           let streamStarted = false;
           let thinkingStarted = false;
           let thinkingEnded = false;
@@ -1321,19 +1267,12 @@ export function createOllamaStreamFn(
           };
 
           const resolveVisibleContent = (final: boolean): string | undefined => {
-            if (bypassKimiInlineReasoningSanitizer) {
-              return accumulatedRawContent;
-            }
-            const resolution = resolveStreamingVisibleText({
-              modelId: model.id,
+            const resolution = visibleContentSanitizer.resolveStreamText({
               text: accumulatedRawContent,
               final,
             });
             if (resolution.kind === "pending") {
               return undefined;
-            }
-            if (resolution.bypassInlineReasoning) {
-              bypassKimiInlineReasoningSanitizer = true;
             }
             return resolution.text;
           };
@@ -1428,7 +1367,7 @@ export function createOllamaStreamFn(
           };
           const assistantMessage = buildAssistantMessage(finalResponse, modelInfo, usageFallback, {
             ...toolCallNameOptions,
-            sanitizeKimiInlineReasoning: !bypassKimiInlineReasoningSanitizer,
+            sanitizeVisibleContent: visibleContentSanitizer.shouldSanitizeFinalMessage(),
           });
           closeThinkingBlock();
           closeTextBlock();

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -399,6 +399,34 @@ function stripKimiInlineReasoningFromVisibleText(params: {
   return answer;
 }
 
+function resolveStreamingVisibleText(params: {
+  modelId: string;
+  text: string;
+  final: boolean;
+}): string | undefined {
+  if (!isOllamaCloudKimiModelRef(params.modelId)) {
+    return params.text;
+  }
+
+  const boundaryIndex = findKimiInlineReasoningBoundaryIndex(params.text);
+  if (boundaryIndex < 0) {
+    return params.final ? params.text : undefined;
+  }
+
+  const prefix = params.text.slice(0, boundaryIndex).trim();
+  const answer = params.text.slice(boundaryIndex + KIMI_INLINE_REASONING_BOUNDARY.length).trim();
+  if (
+    prefix &&
+    answer &&
+    prefix.length >= KIMI_INLINE_REASONING_MIN_PREFIX_CHARS &&
+    answer.length >= KIMI_INLINE_REASONING_MIN_ANSWER_CHARS
+  ) {
+    return answer;
+  }
+
+  return params.final ? params.text : undefined;
+}
+
 function resolveStreamingTextDelta(previousText: string, nextText: string): string {
   if (!nextText) {
     return "";
@@ -1182,6 +1210,7 @@ export function createOllamaStreamFn(
           let accumulatedThinking = "";
           const accumulatedToolCalls: OllamaToolCall[] = [];
           let finalResponse: OllamaChatResponse | undefined;
+          let pendingFinalVisibleContent: string | undefined;
           const modelInfo = { api: model.api, provider: model.provider, id: model.id };
           let streamStarted = false;
           let thinkingStarted = false;
@@ -1242,6 +1271,55 @@ export function createOllamaStreamFn(
             });
           };
 
+          const flushVisibleText = (nextVisibleContent: string | undefined) => {
+            if (nextVisibleContent === undefined) {
+              return;
+            }
+            const previousVisibleContent = accumulatedVisibleContent;
+            const delta = resolveStreamingTextDelta(previousVisibleContent, nextVisibleContent);
+            accumulatedVisibleContent = nextVisibleContent;
+            if (!delta) {
+              return;
+            }
+            if (thinkingStarted && !thinkingEnded) {
+              closeThinkingBlock();
+            }
+
+            if (!streamStarted) {
+              streamStarted = true;
+              const emptyPartial = buildStreamAssistantMessage({
+                model: modelInfo,
+                content: [],
+                stopReason: "stop",
+                usage: buildUsageWithNoCost({}),
+              });
+              stream.push({ type: "start", partial: emptyPartial });
+            }
+            if (!textBlockStarted) {
+              textBlockStarted = true;
+              const partial = buildStreamAssistantMessage({
+                model: modelInfo,
+                content: buildCurrentContent(),
+                stopReason: "stop",
+                usage: buildUsageWithNoCost({}),
+              });
+              stream.push({ type: "text_start", contentIndex: textContentIndex(), partial });
+            }
+
+            const partial = buildStreamAssistantMessage({
+              model: modelInfo,
+              content: buildCurrentContent(),
+              stopReason: "stop",
+              usage: buildUsageWithNoCost({}),
+            });
+            stream.push({
+              type: "text_delta",
+              contentIndex: textContentIndex(),
+              delta,
+              partial,
+            });
+          };
+
           for await (const chunk of parseNdjsonStream(reader)) {
             const thinkingDelta = chunk.message?.thinking ?? chunk.message?.reasoning;
             if (thinkingDelta) {
@@ -1282,59 +1360,13 @@ export function createOllamaStreamFn(
 
             if (chunk.message?.content) {
               const rawDelta = chunk.message.content;
-              const previousVisibleContent = accumulatedVisibleContent;
               accumulatedRawContent += rawDelta;
-              const nextVisibleContent = stripKimiInlineReasoningFromVisibleText({
+              const nextVisibleContent = resolveStreamingVisibleText({
                 modelId: model.id,
                 text: accumulatedRawContent,
+                final: false,
               });
-              const delta = resolveStreamingTextDelta(previousVisibleContent, nextVisibleContent);
-              if (!delta) {
-                accumulatedVisibleContent = nextVisibleContent;
-                if (chunk.done) {
-                  finalResponse = chunk;
-                  break;
-                }
-                continue;
-              }
-              if (thinkingStarted && !thinkingEnded) {
-                closeThinkingBlock();
-              }
-
-              if (!streamStarted) {
-                streamStarted = true;
-                const emptyPartial = buildStreamAssistantMessage({
-                  model: modelInfo,
-                  content: [],
-                  stopReason: "stop",
-                  usage: buildUsageWithNoCost({}),
-                });
-                stream.push({ type: "start", partial: emptyPartial });
-              }
-              if (!textBlockStarted) {
-                textBlockStarted = true;
-                const partial = buildStreamAssistantMessage({
-                  model: modelInfo,
-                  content: buildCurrentContent(),
-                  stopReason: "stop",
-                  usage: buildUsageWithNoCost({}),
-                });
-                stream.push({ type: "text_start", contentIndex: textContentIndex(), partial });
-              }
-
-              accumulatedVisibleContent = nextVisibleContent;
-              const partial = buildStreamAssistantMessage({
-                model: modelInfo,
-                content: buildCurrentContent(),
-                stopReason: "stop",
-                usage: buildUsageWithNoCost({}),
-              });
-              stream.push({
-                type: "text_delta",
-                contentIndex: textContentIndex(),
-                delta,
-                partial,
-              });
+              flushVisibleText(nextVisibleContent);
             }
             if (chunk.message?.tool_calls) {
               closeThinkingBlock();
@@ -1342,6 +1374,11 @@ export function createOllamaStreamFn(
               accumulatedToolCalls.push(...chunk.message.tool_calls);
             }
             if (chunk.done) {
+              pendingFinalVisibleContent = resolveStreamingVisibleText({
+                modelId: model.id,
+                text: accumulatedRawContent,
+                final: true,
+              });
               finalResponse = chunk;
               break;
             }
@@ -1350,6 +1387,17 @@ export function createOllamaStreamFn(
           if (!finalResponse) {
             throw new Error("Ollama API stream ended without a final response");
           }
+
+          if (
+            pendingFinalVisibleContent !== undefined &&
+            isLikelyGarbledVisibleText({ text: pendingFinalVisibleContent, modelId: model.id })
+          ) {
+            throw new Error(
+              `Ollama returned non-linguistic garbled visible text for ${model.id}; retry or switch models`,
+            );
+          }
+
+          flushVisibleText(pendingFinalVisibleContent);
 
           if (isLikelyGarbledVisibleText({ text: accumulatedVisibleContent, modelId: model.id })) {
             throw new Error(

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -362,6 +362,7 @@ function isOllamaCloudKimiModelRef(modelId: string): boolean {
 }
 
 const KIMI_INLINE_REASONING_MIN_PREFIX_CHARS = 80;
+const KIMI_INLINE_REASONING_MAX_PENDING_CHARS = 512;
 const KIMI_INLINE_REASONING_BOUNDARY_RE = /(^|\s)\uFE0F\s*/u;
 
 type KimiInlineReasoningVisibleTextResolution =
@@ -379,7 +380,10 @@ function resolveKimiInlineReasoningVisibleText(params: {
 
   const match = KIMI_INLINE_REASONING_BOUNDARY_RE.exec(params.text);
   if (!match) {
-    return params.final ? { kind: "visible", text: params.text } : { kind: "pending" };
+    if (!params.final && params.text.length <= KIMI_INLINE_REASONING_MAX_PENDING_CHARS) {
+      return { kind: "pending" };
+    }
+    return { kind: "visible", text: params.text };
   }
 
   const boundaryStartIndex = match.index + match[1].length;

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -1260,7 +1260,6 @@ export function createOllamaStreamFn(
             }
             const previousVisibleContent = accumulatedVisibleContent;
             const delta = resolveStreamingTextDelta(previousVisibleContent, nextVisibleContent);
-            accumulatedVisibleContent = nextVisibleContent;
             if (!delta) {
               return;
             }
@@ -1289,6 +1288,7 @@ export function createOllamaStreamFn(
               stream.push({ type: "text_start", contentIndex: textContentIndex(), partial });
             }
 
+            accumulatedVisibleContent = nextVisibleContent;
             const partial = buildStreamAssistantMessage({
               model: modelInfo,
               content: buildCurrentContent(),

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -361,6 +361,35 @@ function isOllamaCloudKimiModelRef(modelId: string): boolean {
   return normalizedModelId.startsWith("kimi-k") && normalizedModelId.includes(":cloud");
 }
 
+const KIMI_INLINE_REASONING_BOUNDARY = "️";
+const KIMI_INLINE_REASONING_MIN_PREFIX_CHARS = 80;
+const KIMI_INLINE_REASONING_MIN_ANSWER_CHARS = 8;
+
+function stripKimiInlineReasoningFromVisibleText(params: {
+  modelId: string;
+  text: string;
+}): string {
+  if (!isOllamaCloudKimiModelRef(params.modelId)) {
+    return params.text;
+  }
+  const boundaryIndex = params.text.indexOf(KIMI_INLINE_REASONING_BOUNDARY);
+  if (boundaryIndex < 0) {
+    return params.text;
+  }
+  const prefix = params.text.slice(0, boundaryIndex).trim();
+  const answer = params.text.slice(boundaryIndex + KIMI_INLINE_REASONING_BOUNDARY.length).trim();
+  if (!prefix || !answer) {
+    return params.text;
+  }
+  if (prefix.length < KIMI_INLINE_REASONING_MIN_PREFIX_CHARS) {
+    return params.text;
+  }
+  if (answer.length < KIMI_INLINE_REASONING_MIN_ANSWER_CHARS) {
+    return params.text;
+  }
+  return answer;
+}
+
 export function createConfiguredOllamaCompatStreamWrapper(
   ctx: ProviderWrapStreamFnContext,
 ): StreamFn | undefined {
@@ -951,7 +980,10 @@ export function buildAssistantMessage(
   if (thinking) {
     content.push({ type: "thinking", thinking });
   }
-  const text = response.message.content || "";
+  const text = stripKimiInlineReasoningFromVisibleText({
+    modelId: modelInfo.id,
+    text: response.message.content || "",
+  });
   if (text) {
     content.push({ type: "text", text });
   }

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -366,7 +366,7 @@ const KIMI_INLINE_REASONING_MAX_PENDING_CHARS = 512;
 const KIMI_INLINE_REASONING_BOUNDARY_RE = /(^|\s)\uFE0F\s*/u;
 
 type KimiInlineReasoningVisibleTextResolution =
-  | { kind: "visible"; text: string }
+  | { kind: "visible"; text: string; bypassInlineReasoning?: boolean }
   | { kind: "pending" };
 
 function resolveKimiInlineReasoningVisibleText(params: {
@@ -383,7 +383,12 @@ function resolveKimiInlineReasoningVisibleText(params: {
     if (!params.final && params.text.length <= KIMI_INLINE_REASONING_MAX_PENDING_CHARS) {
       return { kind: "pending" };
     }
-    return { kind: "visible", text: params.text };
+    return {
+      kind: "visible",
+      text: params.text,
+      bypassInlineReasoning:
+        !params.final && params.text.length > KIMI_INLINE_REASONING_MAX_PENDING_CHARS,
+    };
   }
 
   const boundaryStartIndex = match.index + match[1].length;
@@ -409,9 +414,8 @@ function resolveStreamingVisibleText(params: {
   modelId: string;
   text: string;
   final: boolean;
-}): string | undefined {
-  const resolution = resolveKimiInlineReasoningVisibleText(params);
-  return resolution.kind === "visible" ? resolution.text : undefined;
+}): KimiInlineReasoningVisibleTextResolution {
+  return resolveKimiInlineReasoningVisibleText(params);
 }
 
 function resolveStreamingTextDelta(previousText: string, nextText: string): string {
@@ -858,6 +862,10 @@ type OllamaToolCallNameOptions = {
   availableToolNames?: ReadonlySet<string>;
 };
 
+type OllamaAssistantMessageBuildOptions = OllamaToolCallNameOptions & {
+  sanitizeKimiInlineReasoning?: boolean;
+};
+
 function readOllamaToolCallId(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
 }
@@ -1012,17 +1020,21 @@ export function buildAssistantMessage(
   response: OllamaChatResponse,
   modelInfo: StreamModelDescriptor,
   usageFallback?: OllamaUsageFallback,
-  options: OllamaToolCallNameOptions = {},
+  options: OllamaAssistantMessageBuildOptions = {},
 ): AssistantMessage {
   const content: (TextContent | ThinkingContent | ToolCall)[] = [];
   const thinking = response.message.thinking ?? response.message.reasoning ?? "";
   if (thinking) {
     content.push({ type: "thinking", thinking });
   }
-  const text = stripKimiInlineReasoningFromVisibleText({
-    modelId: modelInfo.id,
-    text: response.message.content || "",
-  });
+  const rawText = response.message.content || "";
+  const text =
+    options.sanitizeKimiInlineReasoning === false
+      ? rawText
+      : stripKimiInlineReasoningFromVisibleText({
+          modelId: modelInfo.id,
+          text: rawText,
+        });
   if (text) {
     content.push({ type: "text", text });
   }
@@ -1199,6 +1211,7 @@ export function createOllamaStreamFn(
           let finalResponse: OllamaChatResponse | undefined;
           let pendingFinalVisibleContent: string | undefined;
           const modelInfo = { api: model.api, provider: model.provider, id: model.id };
+          let bypassKimiInlineReasoningSanitizer = false;
           let streamStarted = false;
           let thinkingStarted = false;
           let thinkingEnded = false;
@@ -1307,6 +1320,24 @@ export function createOllamaStreamFn(
             });
           };
 
+          const resolveVisibleContent = (final: boolean): string | undefined => {
+            if (bypassKimiInlineReasoningSanitizer) {
+              return accumulatedRawContent;
+            }
+            const resolution = resolveStreamingVisibleText({
+              modelId: model.id,
+              text: accumulatedRawContent,
+              final,
+            });
+            if (resolution.kind === "pending") {
+              return undefined;
+            }
+            if (resolution.bypassInlineReasoning) {
+              bypassKimiInlineReasoningSanitizer = true;
+            }
+            return resolution.text;
+          };
+
           for await (const chunk of parseNdjsonStream(reader)) {
             const thinkingDelta = chunk.message?.thinking ?? chunk.message?.reasoning;
             if (thinkingDelta) {
@@ -1348,12 +1379,7 @@ export function createOllamaStreamFn(
             if (chunk.message?.content) {
               const rawDelta = chunk.message.content;
               accumulatedRawContent += rawDelta;
-              const nextVisibleContent = resolveStreamingVisibleText({
-                modelId: model.id,
-                text: accumulatedRawContent,
-                final: false,
-              });
-              flushVisibleText(nextVisibleContent);
+              flushVisibleText(resolveVisibleContent(false));
             }
             if (chunk.message?.tool_calls) {
               closeThinkingBlock();
@@ -1361,11 +1387,7 @@ export function createOllamaStreamFn(
               accumulatedToolCalls.push(...chunk.message.tool_calls);
             }
             if (chunk.done) {
-              pendingFinalVisibleContent = resolveStreamingVisibleText({
-                modelId: model.id,
-                text: accumulatedRawContent,
-                final: true,
-              });
+              pendingFinalVisibleContent = resolveVisibleContent(true);
               finalResponse = chunk;
               break;
             }
@@ -1404,12 +1426,10 @@ export function createOllamaStreamFn(
             input: estimateOllamaPromptTokens({ messages: ollamaMessages, tools: ollamaTools }),
             output: estimateOllamaCompletionTokens(finalResponse),
           };
-          const assistantMessage = buildAssistantMessage(
-            finalResponse,
-            modelInfo,
-            usageFallback,
-            toolCallNameOptions,
-          );
+          const assistantMessage = buildAssistantMessage(finalResponse, modelInfo, usageFallback, {
+            ...toolCallNameOptions,
+            sanitizeKimiInlineReasoning: !bypassKimiInlineReasoningSanitizer,
+          });
           closeThinkingBlock();
           closeTextBlock();
 

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -361,42 +361,44 @@ function isOllamaCloudKimiModelRef(modelId: string): boolean {
   return normalizedModelId.startsWith("kimi-k") && normalizedModelId.includes(":cloud");
 }
 
-const KIMI_INLINE_REASONING_BOUNDARY = "️";
 const KIMI_INLINE_REASONING_MIN_PREFIX_CHARS = 80;
-const KIMI_INLINE_REASONING_MIN_ANSWER_CHARS = 8;
-const KIMI_INLINE_REASONING_BOUNDARY_RE = /(^|\s)\uFE0F(?=\S)/u;
+const KIMI_INLINE_REASONING_BOUNDARY_RE = /(^|\s)\uFE0F\s*/u;
 
-function findKimiInlineReasoningBoundaryIndex(text: string): number {
-  const match = KIMI_INLINE_REASONING_BOUNDARY_RE.exec(text);
-  if (!match) {
-    return -1;
+type KimiInlineReasoningVisibleTextResolution =
+  | { kind: "visible"; text: string }
+  | { kind: "pending" };
+
+function resolveKimiInlineReasoningVisibleText(params: {
+  modelId: string;
+  text: string;
+  final: boolean;
+}): KimiInlineReasoningVisibleTextResolution {
+  if (!isOllamaCloudKimiModelRef(params.modelId)) {
+    return { kind: "visible", text: params.text };
   }
-  return match.index + match[1].length;
+
+  const match = KIMI_INLINE_REASONING_BOUNDARY_RE.exec(params.text);
+  if (!match) {
+    return params.final ? { kind: "visible", text: params.text } : { kind: "pending" };
+  }
+
+  const boundaryStartIndex = match.index + match[1].length;
+  const boundaryEndIndex = match.index + match[0].length;
+  const prefix = params.text.slice(0, boundaryStartIndex).trim();
+  const answer = params.text.slice(boundaryEndIndex).trim();
+  if (prefix.length >= KIMI_INLINE_REASONING_MIN_PREFIX_CHARS && answer) {
+    return { kind: "visible", text: answer };
+  }
+
+  return params.final ? { kind: "visible", text: params.text } : { kind: "pending" };
 }
 
 function stripKimiInlineReasoningFromVisibleText(params: {
   modelId: string;
   text: string;
 }): string {
-  if (!isOllamaCloudKimiModelRef(params.modelId)) {
-    return params.text;
-  }
-  const boundaryIndex = findKimiInlineReasoningBoundaryIndex(params.text);
-  if (boundaryIndex < 0) {
-    return params.text;
-  }
-  const prefix = params.text.slice(0, boundaryIndex).trim();
-  const answer = params.text.slice(boundaryIndex + KIMI_INLINE_REASONING_BOUNDARY.length).trim();
-  if (!prefix || !answer) {
-    return params.text;
-  }
-  if (prefix.length < KIMI_INLINE_REASONING_MIN_PREFIX_CHARS) {
-    return params.text;
-  }
-  if (answer.length < KIMI_INLINE_REASONING_MIN_ANSWER_CHARS) {
-    return params.text;
-  }
-  return answer;
+  const resolution = resolveKimiInlineReasoningVisibleText({ ...params, final: true });
+  return resolution.kind === "visible" ? resolution.text : params.text;
 }
 
 function resolveStreamingVisibleText(params: {
@@ -404,27 +406,8 @@ function resolveStreamingVisibleText(params: {
   text: string;
   final: boolean;
 }): string | undefined {
-  if (!isOllamaCloudKimiModelRef(params.modelId)) {
-    return params.text;
-  }
-
-  const boundaryIndex = findKimiInlineReasoningBoundaryIndex(params.text);
-  if (boundaryIndex < 0) {
-    return params.final ? params.text : undefined;
-  }
-
-  const prefix = params.text.slice(0, boundaryIndex).trim();
-  const answer = params.text.slice(boundaryIndex + KIMI_INLINE_REASONING_BOUNDARY.length).trim();
-  if (
-    prefix &&
-    answer &&
-    prefix.length >= KIMI_INLINE_REASONING_MIN_PREFIX_CHARS &&
-    answer.length >= KIMI_INLINE_REASONING_MIN_ANSWER_CHARS
-  ) {
-    return answer;
-  }
-
-  return params.final ? params.text : undefined;
+  const resolution = resolveKimiInlineReasoningVisibleText(params);
+  return resolution.kind === "visible" ? resolution.text : undefined;
 }
 
 function resolveStreamingTextDelta(previousText: string, nextText: string): string {


### PR DESCRIPTION
## Summary
- add Ollama Kimi-cloud response sanitizer for leaked inline reasoning prefixes in visible assistant text
- scope sanitizer to `kimi-k*:cloud` and boundary-delimited payloads only, with conservative guards to avoid clipping normal output
- add regression coverage in Ollama stream runtime tests
- buffer Kimi-cloud streaming output until the inline reasoning boundary is safe, so raw reasoning prefixes are not emitted while the response is live

## Changes
- `extensions/ollama/src/stream.ts`
  - added `stripKimiInlineReasoningFromVisibleText(...)`
  - invoke sanitizer from `buildAssistantMessage(...)` before publishing visible `text` blocks
  - route streaming visible text through the same Kimi-cloud boundary decision before `text_delta`, `text_end`, partials, and final `done`
- `extensions/ollama/src/stream-runtime.test.ts`
  - new test: strips inline reasoning prefix for `kimi-k2.6:cloud`
  - new test: does not strip boundary marker for non-Kimi models
  - new test: buffers split Kimi inline reasoning until the answer boundary is safe

## Real behavior proof
Behavior addressed: Ollama Kimi cloud responses can include private reasoning in the visible content stream before the final answer boundary. OpenClaw must not emit that prefix in live streaming events or in the saved final assistant message.

Real environment tested: `bob@isengard`, `/tmp/openclaw-86286-pr` at PR head `aaddcf0a3e56bd3eb1afceea4546d93efc1bff24`, running OpenClaw's real `createOllamaStreamFn` against a local Ollama-compatible HTTP NDJSON server. This exercised the actual OpenClaw Ollama stream parser and event builder rather than the final message constructor alone.

Exact steps or command run after this patch: `/home/bob/.nvm/versions/node/v22.22.0/bin/node --import tsx /tmp/openclaw-86286-real-proof.mjs`

Evidence after fix: Terminal output from that command included only the cleaned answer in the emitted OpenClaw stream events:

```text
[
  {
    "type": "text_delta",
    "delta": "Final answer only.",
    "partial": { "content": [{ "type": "text", "text": "Final answer only." }] }
  },
  {
    "type": "text_end",
    "content": "Final answer only.",
    "partial": { "content": [{ "type": "text", "text": "Final answer only." }] }
  },
  {
    "type": "done",
    "message": { "content": [{ "type": "text", "text": "Final answer only." }] }
  }
]
RESULT: OpenClaw streamed only the cleaned answer; hidden prefix was not emitted.
```

Observed result after fix: The injected hidden prefix text (`The user is asking for a short answer...`) did not appear in `text_delta`, `text_end`, partial content, or the final `done` message. The stream emitted only `Final answer only.`.

What was not tested: A live vendor response that naturally reproduces the delimiter leak was not captured; direct calls to the available Ollama Kimi cloud key did not reproduce the delimiter leak during investigation, so the proof used a local Ollama-compatible stream with the observed leaked wire shape.

## Validation
- `/home/bob/.nvm/versions/node/v22.22.0/bin/node --import tsx /tmp/openclaw-86286-real-proof.mjs`
- `node scripts/run-vitest.mjs extensions/ollama/src/stream-runtime.test.ts`
- `node scripts/run-vitest.mjs src/agents/model-catalog-visibility.test.ts`

Fixes #86129
