### PR TITLE
fix(codex): preserve source reply mode for active runs

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -7884,6 +7884,44 @@ describe("runCodexAppServerAttempt", () => {
     expect(interrupt?.params).toEqual({ threadId: "thread-1", turnId: "turn-1" });
   });
 
+  it("accepts message-tool-only steering for active Codex app-server source replies", async () => {
+    const { requests, waitForMethod, completeTurn } = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.sourceReplyDeliveryMode = "message_tool_only";
+
+    const run = runCodexAppServerAttempt(params);
+    await waitForMethod("turn/start");
+
+    expect(
+      queueActiveRunMessageForTest("session-1", "subagent complete", {
+        debounceMs: 1,
+        steeringMode: "all",
+        sourceReplyDeliveryMode: "message_tool_only",
+      }),
+    ).toBe(true);
+
+    await vi.waitFor(
+      () =>
+        expect(requests.filter((entry) => entry.method === "turn/steer")).toEqual([
+          {
+            method: "turn/steer",
+            params: {
+              threadId: "thread-1",
+              expectedTurnId: "turn-1",
+              input: [{ type: "text", text: "subagent complete", text_elements: [] }],
+            },
+          },
+        ]),
+      { interval: 1 },
+    );
+
+    await completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+  });
+
   it("batches default queued steering before sending turn/steer", async () => {
     const { requests, waitForMethod, completeTurn } = createStartedThreadHarness();
 

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -3144,6 +3144,7 @@ export async function runCodexAppServerAttempt(
       activeSteeringQueue.queue(text, options),
     isStreaming: () => !completed,
     isCompacting: () => projector?.isCompacting() ?? false,
+    sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
     cancel: () => runAbortController.abort("cancelled"),
     abort: () => runAbortController.abort("aborted"),
   };


### PR DESCRIPTION
## Summary

- Fixes #86232.
- Preserve `sourceReplyDeliveryMode` on the Codex app-server active-run handle so message-tool-only source replies are accepted by the shared active-run queue.
- Add focused regression coverage showing a Codex app-server run with `message_tool_only` accepts queued sub-agent completion steering and sends `turn/steer`.

## AI assistance disclosure

This PR was prepared with AI assistance. I inspected the reported issue, related OpenClaw threads, source paths, queue contract, and validation output before making the change.

## Real behavior proof

Behavior addressed: Codex app-server active runs now carry `message_tool_only` source reply delivery mode into the shared active-run queue, allowing sub-agent completion wakeups to steer the active Codex turn instead of being rejected as `source_reply_delivery_mode_mismatch`.

Real environment tested: Local OpenClaw source runtime in a dedicated worktree, using the production `queueAgentHarnessMessage` active-run guard and the Codex app-server steering queue.

Exact steps or command run after this patch:

```bash
timeout 60s node --import tsx .artifacts/issue-86232-codex-source-reply-proof.mjs
```

Evidence after fix:

```json
{
  "proof": "issue-86232-codex-source-reply-delivery-mode",
  "mismatchedMode": {
    "queued": false,
    "requestMethods": []
  },
  "matchedMode": {
    "sourceReplyDeliveryModeOnHandle": "message_tool_only",
    "queued": true,
    "steerMethod": "turn/steer",
    "steerParams": {
      "threadId": "proof-thread-86232",
      "expectedTurnId": "proof-turn-86232",
      "input": [
        {
          "type": "text",
          "text": "subagent complete",
          "text_elements": []
        }
      ]
    },
    "requestMethods": [
      "turn/steer"
    ]
  },
  "expected": {
    "mismatchedQueued": false,
    "matchedQueued": true,
    "matchedMethod": "turn/steer"
  }
}
```

Observed result after fix: A handle without `sourceReplyDeliveryMode` still rejects a message-tool-only source reply, while a Codex-style active handle with `sourceReplyDeliveryMode: "message_tool_only"` accepts the same reply and emits `turn/steer` with the sub-agent completion text.

What was not tested: No live Discord group chat was used, so this proof does not verify Discord transport credentials, gateway delivery, or final message-tool posting. It proves the source runtime contract that caused the reported silent rejection.

## Root Cause

The shared active-run queue rejects source replies marked `message_tool_only` unless the registered active run handle also advertises `sourceReplyDeliveryMode: "message_tool_only"`. The regular PI embedded runner already passes that field into its active handle, but the Codex app-server runner omitted it when registering its handle with `setActiveEmbeddedRun`. As a result, Codex app-server group sessions that required message-tool-only delivery could reject sub-agent completion wakeups before steering the active turn.

## Regression Test Plan

- The new test starts the Codex app-server attempt harness with `params.sourceReplyDeliveryMode = "message_tool_only"`.
- It queues a source reply with the same delivery mode through `queueAgentHarnessMessage`.
- It asserts the queue accepts the reply and the app-server client receives one `turn/steer` request containing the completion text.

## Security Impact

Low. This preserves an existing run-scoped delivery-mode fact on the active handle. It does not weaken the existing guard: source replies that request `message_tool_only` are still rejected unless the run explicitly carries that same mode.

## Human Verification

Human review should focus on whether this is the intended narrow contract alignment for Codex app-server runs, rather than expanding broader source-reply fallback behavior. Related final-message and requester-wake policy issues are intentionally out of scope.

## Risks

- The change does not address broader cases where the active turn is gone or the final message still needs a message-tool fallback.
- The proof is source-runtime proof, not a live Discord E2E.
- If another Codex app-server caller constructs active handles elsewhere, it would need the same field, but this is the active handle used by `runCodexAppServerAttempt`.

## Validation

```bash
corepack pnpm format:check -- extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts
```

Passed.

```bash
PATH="$PWD/.artifacts/bin:$PATH" corepack pnpm test extensions/codex/src/app-server/run-attempt.test.ts -t "message-tool-only steering"
```

Passed: 1 test passed, 218 skipped.

```bash
node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -t "message-tool-only steering"
```

Passed: 1 test passed, 218 skipped.

```bash
OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree PATH="$PWD/.artifacts/bin:$PATH" corepack pnpm check:changed --base upstream/main
```

Passed.

```bash
codex review --base upstream/main
```

Passed: no actionable correctness issues found.

Validation note: the full `extensions/codex/src/app-server/run-attempt.test.ts` file currently has one unrelated isolated failure in `passes session plugin app policy context to elicitation handling` (`calendarPolicy?.pluginName` was `undefined`). The new focused regression test passes independently.