### PR TITLE
Fix deadcode unused-file allowlist

### DIFF
--- a/scripts/deadcode-unused-files.allowlist.mjs
+++ b/scripts/deadcode-unused-files.allowlist.mjs
@@ -1,7 +1,38 @@
 // Intentional Knip unused-file findings. These are dynamic entrypoints,
 // generated/build inputs, manifest-discovered plugin surfaces, live-test
 // helpers, or package bridge files that static production scanning cannot see.
-export const KNIP_UNUSED_FILE_ALLOWLIST = [];
+export const KNIP_UNUSED_FILE_ALLOWLIST = [
+  "extensions/acpx/src/runtime-internals/error-format.mjs",
+  "extensions/acpx/src/runtime-internals/mcp-command-line.mjs",
+  "extensions/acpx/src/runtime-internals/mcp-proxy.mjs",
+  "extensions/canvas/src/host/a2ui-app/bootstrap.js",
+  "extensions/canvas/src/host/a2ui-app/rolldown.config.mjs",
+  "extensions/diffs/src/viewer-client.ts",
+  "extensions/diffs/src/viewer-payload.ts",
+  "extensions/matrix/src/plugin-entry.runtime.js",
+  "extensions/memory-core/src/memory-tool-manager-mock.ts",
+  "src/agents/subagent-registry.runtime.ts",
+  "src/auto-reply/inbound.group-require-mention-test-plugins.ts",
+  "src/auto-reply/reply/get-reply.test-loader.ts",
+  "src/cli/daemon-cli-compat.ts",
+  "src/commands/doctor/shared/deprecation-compat.ts",
+  "src/config/doc-baseline.runtime.ts",
+  "src/config/doc-baseline.ts",
+  "src/gateway/gateway-cli-backend.live-helpers.ts",
+  "src/gateway/gateway-cli-backend.live-probe-helpers.ts",
+  "src/gateway/gateway-codex-harness.live-helpers.ts",
+  "src/infra/changelog-unreleased.ts",
+  "src/mcp/openclaw-tools-serve.ts",
+  "src/mcp/plugin-tools-handlers.ts",
+  "src/mcp/plugin-tools-serve.ts",
+  "src/mcp/tools-stdio-server.ts",
+  "src/plugins/build-smoke-entry.ts",
+  "src/plugins/contracts/host-hook-fixture.ts",
+  "src/plugins/contracts/rootdir-boundary-canary.ts",
+  "src/plugins/contracts/tts-contract-suites.ts",
+  "src/plugins/runtime-sidecar-paths-baseline.ts",
+  "src/tasks/task-registry-control.runtime.ts",
+];
 
 // Knip can disagree across supported local/CI platforms for files that are
 // only reachable through test-only import graphs. Ignore these when reported,


### PR DESCRIPTION
## Summary

- Restore the current Knip unused-file allowlist that was removed while CI still reports those dynamic entrypoints as intentional unused files.

## Verification

- `git diff --check`
- `node --input-type=module -e 'import { KNIP_UNUSED_FILE_ALLOWLIST } from "./scripts/deadcode-unused-files.allowlist.mjs"; const sorted = [...KNIP_UNUSED_FILE_ALLOWLIST].sort((a,b)=>a.localeCompare(b)); if (JSON.stringify(sorted)!==JSON.stringify(KNIP_UNUSED_FILE_ALLOWLIST)) throw new Error("allowlist not sorted"); if (new Set(KNIP_UNUSED_FILE_ALLOWLIST).size !== KNIP_UNUSED_FILE_ALLOWLIST.length) throw new Error("allowlist duplicates"); console.log(`allowlist entries: ${KNIP_UNUSED_FILE_ALLOWLIST.length}`);'`
- Testbox-through-Crabbox: `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 45m --ttl 90m --timing-json -- CI=1 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm deadcode:unused-files`
  - provider: blacksmith-testbox
  - id: tbx_01kseekdfmejqvaw82p1gd5r54
  - result: `[deadcode] Knip unused-file allowlist matched 30 intentional entries.`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean: no accepted/actionable findings.

## Real behavior proof

Behavior addressed: the `check-dependencies` CI shard failed in `pnpm deadcode:unused-files` on current-main Knip unused-file findings after the allowlist was removed.
Real environment tested: Blacksmith Testbox through Crabbox using the repo CI Testbox workflow.
Exact steps or command run after this patch: `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 45m --ttl 90m --timing-json -- CI=1 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm deadcode:unused-files`
Evidence after fix: Testbox `tbx_01kseekdfmejqvaw82p1gd5r54` exited 0 and printed `[deadcode] Knip unused-file allowlist matched 30 intentional entries.`
Observed result after fix: the exact unused-file guard accepts the restored 30 intentional entries instead of failing the dependency shard.
What was not tested: broader CI beyond the targeted unused-file dependency guard before opening this PR.
