### PR TITLE
docs(telegram): document Android composer lock with nativeToolProgress

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -338,6 +338,10 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     }
     ```
 
+    <Warning>
+      **Android composer lock**: Telegram Android locks the composer while a `sendMessageDraft` preview is active. The send button becomes a loading indicator, blocking user input including interrupt commands like `/steer`. This is Telegram client behavior, not an OpenClaw bug. For interactive workflows requiring mid-turn intervention, set `nativeToolProgress: false` and rely on editable preview streaming instead. See issue #86195.
+    </Warning>
+
     To keep the edited preview for answer text but hide tool-progress lines, set:
 
     ```json


### PR DESCRIPTION
## Summary

Add warning that Telegram Android locks the composer while `sendMessageDraft` preview is active, blocking user input including interrupt commands like `/steer`.

## Changes

- Added warning box in Telegram documentation about Android composer lock behavior
- Recommended `nativeToolProgress: false` for interactive workflows requiring mid-turn intervention
- Linked to issue #86195

## Verification

This is a documentation-only change based on reported Telegram Android client behavior where the send button becomes a loading indicator while bot drafts are active.

---

## Real behavior proof

**Behavior addressed:** Telegram Android users cannot send messages or interrupt commands (`/steer`, etc.) while a bot's `sendMessageDraft` preview is active — the composer shows a loading indicator instead of the send button.

**Real environment tested:** Documentation update based on user-reported behavior from Telegram Android 12.7.3 with OpenClaw 2026.5.20. This change adds a warning to help operators avoid this configuration pitfall.

**Exact steps or command run after the patch:**
- Reviewed Telegram Android behavior reports showing composer lock during `sendMessageDraft`
- Verified existing documentation at `docs/channels/telegram.md` did not include this warning
- Added warning box in the native tool progress configuration section

**Evidence after fix:**
- Updated documentation now includes explicit warning about Android composer lock
- Operators can reference this warning when configuring `nativeToolProgress: false` for interactive workflows

**Observed result after fix:**
- Documentation clearly warns that `nativeToolProgress` uses Telegram `sendMessageDraft`, which locks the composer on Android
- Operators are directed to use `nativeToolProgress: false` for interactive control workflows

**What was not tested:**
- Live Telegram Android device testing (this is a documentation-only change)
- Other Telegram client platforms (iOS, Desktop) may have different draft behavior

---

Fixes #86195