### PR TITLE
fix(telegram): propagate forum topic names into agent context

### DIFF
--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -1,8 +1,17 @@
+import os from "node:os";
+import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { captureEnv } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { handleTelegramAction, telegramActionRuntime } from "./action-runtime.js";
 import { beginTelegramInboundEventDeliveryCorrelation } from "./inbound-event-delivery.js";
+import {
+  getTopicName,
+  resetTopicNameCacheForTest,
+  resolveTopicNameCacheScope,
+  setTelegramTopicNameStoreFactoryForTest,
+} from "./topic-name-cache.js";
 
 const originalTelegramActionRuntime = { ...telegramActionRuntime };
 const reactMessageTelegram = vi.fn(async () => ({ ok: true }));
@@ -42,6 +51,38 @@ const createForumTopicTelegram = vi.fn(async () => ({
   chatId: "123",
 }));
 let envSnapshot: ReturnType<typeof captureEnv>;
+
+type TopicNameEntryForTest = {
+  name: string;
+  iconColor?: number;
+  iconCustomEmojiId?: string;
+  closed?: boolean;
+  updatedAt: number;
+};
+
+const topicNameStoresForTest = new Map<string, Map<string, TopicNameEntryForTest>>();
+
+function installTopicNameStoreForTest() {
+  topicNameStoresForTest.clear();
+  setTelegramTopicNameStoreFactoryForTest((namespace) => {
+    const entries = topicNameStoresForTest.get(namespace) ?? new Map();
+    topicNameStoresForTest.set(namespace, entries);
+    return {
+      async register(key, value) {
+        entries.set(key, value);
+      },
+      async entries() {
+        return Array.from(entries, ([key, value]) => ({ key, value }));
+      },
+      async delete(key) {
+        return entries.delete(key);
+      },
+      async clear() {
+        entries.clear();
+      },
+    };
+  });
+}
 
 type MockCallSource = {
   mock: {
@@ -93,6 +134,10 @@ describe("handleTelegramAction", () => {
     } as OpenClawConfig;
   }
 
+  function topicCacheScopeFor(cfg: OpenClawConfig, accountId: string): string {
+    return resolveTopicNameCacheScope(resolveStorePath(cfg.session?.store, { agentId: accountId }));
+  }
+
   async function sendInlineButtonsMessage(params: {
     to: string;
     buttons: Array<Array<{ text: string; callback_data: string; style?: string }>>;
@@ -131,6 +176,8 @@ describe("handleTelegramAction", () => {
 
   beforeEach(() => {
     envSnapshot = captureEnv(["TELEGRAM_BOT_TOKEN"]);
+    resetTopicNameCacheForTest();
+    installTopicNameStoreForTest();
     Object.assign(telegramActionRuntime, originalTelegramActionRuntime, {
       reactMessageTelegram,
       sendMessageTelegram,
@@ -155,6 +202,9 @@ describe("handleTelegramAction", () => {
   });
 
   afterEach(() => {
+    setTelegramTopicNameStoreFactoryForTest(undefined);
+    resetTopicNameCacheForTest();
+    topicNameStoresForTest.clear();
     envSnapshot.restore();
   });
 
@@ -864,6 +914,53 @@ describe("handleTelegramAction", () => {
       expect(opts.gatewayClientScopes).toEqual(["operator.write"]);
     },
   );
+
+  it("stores created forum topic names in the account-scoped cache", async () => {
+    createForumTopicTelegram.mockResolvedValueOnce({
+      topicId: 99,
+      name: "Topic",
+      chatId: "-100123",
+    });
+    const cfg = {
+      ...telegramConfig({ actions: { createForumTopic: true } }),
+      session: { store: path.join(os.tmpdir(), "openclaw-telegram-action-sessions.json") },
+    } as OpenClawConfig;
+
+    await handleTelegramAction(
+      { action: "createForumTopic", accountId: "work", chatId: "alias-chat", name: "Topic" },
+      cfg,
+    );
+
+    const scope = topicCacheScopeFor(cfg, "work");
+    await expect(getTopicName("-100123", 99, scope)).resolves.toBe("Topic");
+    await expect(getTopicName("alias-chat", 99, scope)).resolves.toBeUndefined();
+  });
+
+  it("stores edited forum topic names in the account-scoped cache", async () => {
+    editForumTopicTelegram.mockResolvedValueOnce({
+      ok: true,
+      chatId: "-100123",
+      messageThreadId: 42,
+      name: "New",
+    });
+    const cfg = {
+      ...telegramConfig({ actions: { editForumTopic: true } }),
+      session: { store: path.join(os.tmpdir(), "openclaw-telegram-action-sessions.json") },
+    } as OpenClawConfig;
+
+    await handleTelegramAction(
+      {
+        action: "editForumTopic",
+        accountId: "work",
+        chatId: "alias-chat",
+        messageThreadId: 42,
+        name: "New",
+      },
+      cfg,
+    );
+
+    await expect(getTopicName("-100123", 42, topicCacheScopeFor(cfg, "work"))).resolves.toBe("New");
+  });
 
   it.each([
     {

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -40,6 +40,7 @@ import {
 import { getCacheStats, searchStickers } from "./sticker-cache.js";
 import { normalizeTelegramOutboundTarget, parseTelegramTarget } from "./targets.js";
 import { resolveTelegramToken } from "./token.js";
+import { updateTopicName } from "./topic-name-cache.js";
 
 export const telegramActionRuntime = {
   createForumTopicTelegram,
@@ -726,6 +727,13 @@ export async function handleTelegramAction(
       iconCustomEmojiId: iconCustomEmojiId ?? undefined,
       gatewayClientScopes: options?.gatewayClientScopes,
     });
+    if (result.topicId != null && chatId) {
+      await updateTopicName(chatId, result.topicId, {
+        name,
+        ...(iconColor != null ? { iconColor } : {}),
+        ...(iconCustomEmojiId ? { iconCustomEmojiId } : {}),
+      }).catch(() => {});
+    }
     return jsonResult({
       ok: true,
       topicId: result.topicId,
@@ -763,6 +771,18 @@ export async function handleTelegramAction(
         gatewayClientScopes: options?.gatewayClientScopes,
       },
     );
+    if (chatId) {
+      const patch: { name?: string; iconCustomEmojiId?: string } = {};
+      if (name) {
+        patch.name = name;
+      }
+      if (iconCustomEmojiId) {
+        patch.iconCustomEmojiId = iconCustomEmojiId;
+      }
+      if (Object.keys(patch).length > 0) {
+        await updateTopicName(chatId, messageThreadId, patch).catch(() => {});
+      }
+    }
     return jsonResult(result);
   }
 

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -16,7 +16,12 @@ import {
   renderMessagePresentationFallbackText,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import type { MessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
-import { createTelegramActionGate, resolveTelegramPollActionGateState } from "./accounts.js";
+import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import {
+  createTelegramActionGate,
+  resolveDefaultTelegramAccountId,
+  resolveTelegramPollActionGateState,
+} from "./accounts.js";
 import { resolveTelegramInlineButtons } from "./button-types.js";
 import { notifyTelegramInboundEventOutboundSuccess } from "./inbound-event-delivery.js";
 import {
@@ -40,7 +45,7 @@ import {
 import { getCacheStats, searchStickers } from "./sticker-cache.js";
 import { normalizeTelegramOutboundTarget, parseTelegramTarget } from "./targets.js";
 import { resolveTelegramToken } from "./token.js";
-import { updateTopicName } from "./topic-name-cache.js";
+import { resolveTopicNameCacheScope, updateTopicName } from "./topic-name-cache.js";
 
 export const telegramActionRuntime = {
   createForumTopicTelegram,
@@ -115,6 +120,13 @@ function readTelegramThreadId(params: Record<string, unknown>) {
     readNumberParam(params, "messageThreadId", { integer: true }) ??
     readNumberParam(params, "threadId", { integer: true })
   );
+}
+
+function resolveActionTopicNameCacheScope(cfg: OpenClawConfig, accountId?: string | null): string {
+  const storePath = resolveStorePath(cfg.session?.store, {
+    agentId: accountId ?? resolveDefaultTelegramAccountId(cfg),
+  });
+  return resolveTopicNameCacheScope(storePath);
 }
 
 function formatTelegramDeliveryTarget(to: string, messageThreadId?: number | null): string {
@@ -727,12 +739,17 @@ export async function handleTelegramAction(
       iconCustomEmojiId: iconCustomEmojiId ?? undefined,
       gatewayClientScopes: options?.gatewayClientScopes,
     });
-    if (result.topicId != null && chatId) {
-      await updateTopicName(chatId, result.topicId, {
-        name,
-        ...(iconColor != null ? { iconColor } : {}),
-        ...(iconCustomEmojiId ? { iconCustomEmojiId } : {}),
-      }).catch(() => {});
+    if (result.topicId != null && result.chatId) {
+      await updateTopicName(
+        result.chatId,
+        result.topicId,
+        {
+          name,
+          ...(iconColor != null ? { iconColor } : {}),
+          ...(iconCustomEmojiId ? { iconCustomEmojiId } : {}),
+        },
+        resolveActionTopicNameCacheScope(cfg, accountId),
+      ).catch(() => {});
     }
     return jsonResult({
       ok: true,
@@ -771,7 +788,7 @@ export async function handleTelegramAction(
         gatewayClientScopes: options?.gatewayClientScopes,
       },
     );
-    if (chatId) {
+    if (result.chatId) {
       const patch: { name?: string; iconCustomEmojiId?: string } = {};
       if (name) {
         patch.name = name;
@@ -780,7 +797,12 @@ export async function handleTelegramAction(
         patch.iconCustomEmojiId = iconCustomEmojiId;
       }
       if (Object.keys(patch).length > 0) {
-        await updateTopicName(chatId, messageThreadId, patch).catch(() => {});
+        await updateTopicName(
+          result.chatId,
+          result.messageThreadId,
+          patch,
+          resolveActionTopicNameCacheScope(cfg, accountId),
+        ).catch(() => {});
       }
     }
     return jsonResult(result);

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -100,6 +100,7 @@ import { resolveTelegramGroupPromptSettings } from "./group-config-helpers.js";
 import { resolveTelegramCommandIngressAuthorization } from "./ingress.js";
 import { buildInlineKeyboard } from "./inline-keyboard.js";
 import { recordSentMessage } from "./sent-message-cache.js";
+import { getTopicName, resolveTopicNameCacheScope } from "./topic-name-cache.js";
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
 const TELEGRAM_NATIVE_COMMAND_CALLBACK_PREFIX = "tgcmd:";
@@ -1161,6 +1162,18 @@ export const registerTelegramNativeCommands = ({
           chunkMode,
           linkPreview: runtimeTelegramCfg.linkPreview,
         });
+        let topicName: string | undefined;
+        if (isForum && resolvedThreadId != null) {
+          try {
+            const storePath = resolveStorePath(executionCfg.session?.store, {
+              agentId: route.agentId,
+            });
+            const scope = resolveTopicNameCacheScope(storePath);
+            topicName = await getTopicName(chatId, resolvedThreadId, scope);
+          } catch {
+            // best-effort: topic name is supplementary metadata
+          }
+        }
         const conversationLabel = isGroup
           ? msg.chat.title
             ? `${msg.chat.title} id:${chatId}`
@@ -1199,6 +1212,7 @@ export const registerTelegramNativeCommands = ({
           CommandTargetSessionKey: commandTargetSessionKey,
           MessageThreadId: threadSpec.id,
           IsForum: isForum,
+          TopicName: isForum && topicName ? topicName : undefined,
           // Originating context for sub-agent announce routing
           OriginatingChannel: "telegram" as const,
           OriginatingTo: originatingTo,

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -1166,7 +1166,7 @@ export const registerTelegramNativeCommands = ({
         if (isForum && resolvedThreadId != null) {
           try {
             const storePath = resolveStorePath(executionCfg.session?.store, {
-              agentId: route.agentId,
+              agentId: route.accountId,
             });
             const scope = resolveTopicNameCacheScope(storePath);
             topicName = await getTopicName(chatId, resolvedThreadId, scope);


### PR DESCRIPTION
## Summary

Forum topic names are tracked in the Telegram topic-name cache from `forum_topic_created` / `forum_topic_edited` service events, but two runtime paths missed that cache.

`bot-native-commands.ts` built agent context with `IsForum: true` without resolving the cached topic name, so agents could not tell which forum topic they were handling. `action-runtime.ts` created and edited forum topics without persisting the resulting topic metadata back into the same account-scoped cache, so newly created or renamed topics stayed unnamed until a later service event.

## Changes

1. `bot-native-commands.ts`: resolve the account-scoped topic cache and include `TopicName` in agent context when available.
2. `action-runtime.ts`: after successful `createForumTopic` / `editForumTopic`, write the returned topic name and metadata into the account-scoped topic cache.
3. Regression tests cover native command context lookup plus create/edit action cache writes.

## Real behavior proof

Behavior addressed: Telegram forum topic names created or edited through OpenClaw are now available to later Telegram context construction through the account-scoped topic cache.

Real environment tested: local OpenClaw checkout on macOS, rebased on current `origin/main`, using the Telegram runtime code path with deterministic Telegram API stubs and the real topic-name cache store wiring.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/telegram/src/action-runtime.test.ts extensions/telegram/src/bot-native-commands.test.ts extensions/telegram/src/topic-name-cache.test.ts extensions/telegram/src/bot-message-context.dm-threads.test.ts`

Evidence after fix: terminal output from the local OpenClaw run:

```text
RUN  v4.1.7 /Users/steipete/Projects/clawdbot3

Test Files  4 passed (4)
Tests  119 passed (119)
```

Observed result after fix: the create/edit action tests read back the created or renamed topic from the account-scoped topic cache, and the native-command context test emits the cached `TopicName` for forum messages.

What was not tested: a live Telegram Bot API create/edit forum-topic call against a real supergroup was not run for this PR.

## Verification

- `node scripts/run-vitest.mjs extensions/telegram/src/action-runtime.test.ts extensions/telegram/src/bot-native-commands.test.ts extensions/telegram/src/topic-name-cache.test.ts extensions/telegram/src/bot-message-context.dm-threads.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "node scripts/run-vitest.mjs extensions/telegram/src/action-runtime.test.ts extensions/telegram/src/bot-native-commands.test.ts extensions/telegram/src/topic-name-cache.test.ts extensions/telegram/src/bot-message-context.dm-threads.test.ts"`

Closes #86024
