### PR TITLE
fix: sort tool definitions by name for stable prompt cache hits

### DIFF
--- a/src/agents/agent-tool-definition-adapter.ts
+++ b/src/agents/agent-tool-definition-adapter.ts
@@ -396,7 +396,7 @@ export function toToolDefinitions(
         },
       } satisfies ToolDefinition;
     })
-    .sort((a, b) => a.name.localeCompare(b.name));
+    .toSorted((a, b) => a.name.localeCompare(b.name));
 }
 
 /**

--- a/src/agents/agent-tool-definition-adapter.ts
+++ b/src/agents/agent-tool-definition-adapter.ts
@@ -317,81 +317,86 @@ export function toToolDefinitions(
   tools: AnyAgentTool[],
   hookContext?: HookContext,
 ): ToolDefinition[] {
-  return tools.map((tool) => {
-    const name = tool.name || "tool";
-    const normalizedName = normalizeToolName(name);
-    const beforeHookWrapped = isToolWrappedWithBeforeToolCallHook(tool);
-    return {
-      name,
-      label: tool.label ?? name,
-      description: tool.description ?? "",
-      parameters: tool.parameters,
-      execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
-        const { toolCallId, params, onUpdate, signal } = splitToolExecuteArgs(args);
-        let executeParams = params;
-        try {
-          if (!beforeHookWrapped) {
-            const hookParams = normalizeCodeModeExecBeforeHookParams({ tool, params });
-            const hookMetadata = getCodeModeExecBeforeHookMetadata({ tool, params });
-            const hookOutcome = await runBeforeToolCallHook({
-              toolName: name,
-              params: hookParams,
-              ...hookMetadata,
-              toolCallId,
-              ctx: hookContext,
-            });
-            if (hookOutcome.blocked) {
-              if (hookOutcome.kind === "veto") {
-                return buildBlockedToolResult({
-                  reason: hookOutcome.reason,
-                  deniedReason: hookOutcome.deniedReason,
-                });
+  // Sort tool definitions by name for byte-stable ordering across sessions.
+  // This ensures Anthropic prompt cache hits when tools are registered in
+  // different orders (e.g. plugin tools, MCP tools, dynamic registration).
+  return tools
+    .map((tool) => {
+      const name = tool.name || "tool";
+      const normalizedName = normalizeToolName(name);
+      const beforeHookWrapped = isToolWrappedWithBeforeToolCallHook(tool);
+      return {
+        name,
+        label: tool.label ?? name,
+        description: tool.description ?? "",
+        parameters: tool.parameters,
+        execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
+          const { toolCallId, params, onUpdate, signal } = splitToolExecuteArgs(args);
+          let executeParams = params;
+          try {
+            if (!beforeHookWrapped) {
+              const hookParams = normalizeCodeModeExecBeforeHookParams({ tool, params });
+              const hookMetadata = getCodeModeExecBeforeHookMetadata({ tool, params });
+              const hookOutcome = await runBeforeToolCallHook({
+                toolName: name,
+                params: hookParams,
+                ...hookMetadata,
+                toolCallId,
+                ctx: hookContext,
+              });
+              if (hookOutcome.blocked) {
+                if (hookOutcome.kind === "veto") {
+                  return buildBlockedToolResult({
+                    reason: hookOutcome.reason,
+                    deniedReason: hookOutcome.deniedReason,
+                  });
+                }
+                throw new Error(hookOutcome.reason);
               }
-              throw new Error(hookOutcome.reason);
+              executeParams = reconcileCodeModeExecBeforeHookParams({
+                tool,
+                originalParams: params,
+                hookParams,
+                adjustedParams: hookOutcome.params,
+              });
+              recordAdjustedParamsForToolCall(toolCallId, executeParams, hookContext?.runId);
             }
-            executeParams = reconcileCodeModeExecBeforeHookParams({
-              tool,
-              originalParams: params,
-              hookParams,
-              adjustedParams: hookOutcome.params,
+            const rawResult = await tool.execute(toolCallId, executeParams, signal, onUpdate);
+            const result = normalizeToolExecutionResult({
+              toolName: normalizedName,
+              result: rawResult,
             });
-            recordAdjustedParamsForToolCall(toolCallId, executeParams, hookContext?.runId);
-          }
-          const rawResult = await tool.execute(toolCallId, executeParams, signal, onUpdate);
-          const result = normalizeToolExecutionResult({
-            toolName: normalizedName,
-            result: rawResult,
-          });
-          return result;
-        } catch (err) {
-          if (signal?.aborted) {
-            throw err;
-          }
-          if (isBeforeToolCallBlockedError(err)) {
-            logDebug(`tools: ${normalizedName} blocked by before_tool_call: ${err.reason}`);
-            return buildBlockedToolResult({
-              reason: err.reason,
+            return result;
+          } catch (err) {
+            if (signal?.aborted) {
+              throw err;
+            }
+            if (isBeforeToolCallBlockedError(err)) {
+              logDebug(`tools: ${normalizedName} blocked by before_tool_call: ${err.reason}`);
+              return buildBlockedToolResult({
+                reason: err.reason,
+              });
+            }
+            const described = describeToolExecutionError(err);
+            if (described.stack && described.stack !== described.message) {
+              logDebug(`tools: ${normalizedName} failed stack:\n${described.stack}`);
+            }
+            const inputPreview = describeToolFailureInputs({
+              toolName: normalizedName,
+              rawParams: params,
+              effectiveParams: executeParams,
             });
-          }
-          const described = describeToolExecutionError(err);
-          if (described.stack && described.stack !== described.message) {
-            logDebug(`tools: ${normalizedName} failed stack:\n${described.stack}`);
-          }
-          const inputPreview = describeToolFailureInputs({
-            toolName: normalizedName,
-            rawParams: params,
-            effectiveParams: executeParams,
-          });
-          logError(`[tools] ${normalizedName} failed: ${described.message} ${inputPreview}`);
+            logError(`[tools] ${normalizedName} failed: ${described.message} ${inputPreview}`);
 
-          return buildToolExecutionErrorResult({
-            toolName: normalizedName,
-            message: described.message,
-          });
-        }
-      },
-    } satisfies ToolDefinition;
-  });
+            return buildToolExecutionErrorResult({
+              toolName: normalizedName,
+              message: described.message,
+            });
+          }
+        },
+      } satisfies ToolDefinition;
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
 }
 
 /**

--- a/src/agents/embedded-agent-runner.splitsdktools.test.ts
+++ b/src/agents/embedded-agent-runner.splitsdktools.test.ts
@@ -21,11 +21,11 @@ describe("splitSdkTools", () => {
       sandboxEnabled: true,
     });
     expect(customTools.map((tool) => tool.name)).toEqual([
-      "read",
-      "exec",
-      "edit",
-      "write",
       "browser",
+      "edit",
+      "exec",
+      "read",
+      "write",
     ]);
   });
 
@@ -35,11 +35,11 @@ describe("splitSdkTools", () => {
       sandboxEnabled: false,
     });
     expect(customTools.map((tool) => tool.name)).toEqual([
-      "read",
-      "exec",
-      "edit",
-      "write",
       "browser",
+      "edit",
+      "exec",
+      "read",
+      "write",
     ]);
   });
 


### PR DESCRIPTION
## Problem

`toToolDefinitions()` maps tools to API-ready definitions but preserves whatever order they were registered in. When plugin tools or MCP tools are loaded in different orders across sessions (e.g., due to plugin discovery timing, config changes, or MCP server startup order), the tool array sent to the Anthropic API has different byte ordering. This causes prompt cache misses, since Anthropic's cache key includes the full tool definitions in order.

## Fix

Sort tool definitions alphabetically by name at the end of `toToolDefinitions()` — the last transform before tools reach the API. This is a one-line change:

```ts
}).sort((a, b) => a.name.localeCompare(b.name));
```

This guarantees byte-stable tool ordering regardless of registration order, maximizing Anthropic prompt cache hit rates.

## Prior Art

Inspired by [elephant-agent PR#39](https://github.com/agentic-in/elephant-agent/pull/39), which demonstrated that a single `sorted()` call on tool registry output guarantees cache stability. Their three-pronged approach:
1. **Tool ordering** (this PR) — sorted by tool ID
2. **Frozen prefix cache** — SHA-256 hash comparison to skip reconstruction
3. **Explicit `cache_control` breakpoints** — Anthropic-specific cache hints

This PR implements prong 1 (tool ordering). Prongs 2 and 3 could be follow-up work.

## Testing

- Updated `splitSdkTools` test expectations to match sorted order
- The change is a pure sort on the output array — no behavioral changes to individual tools
- Note: full test suite couldn't be run locally (OOM on this machine), but the change is mechanically trivial