### PR TITLE
fix(memory-core): filter REM dreaming candidates to light-staged entries

### DIFF
--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -28,6 +28,7 @@ import {
 import { asRecord, formatErrorMessage, normalizeTrimmedString } from "./dreaming-shared.js";
 import {
   filterLiveShortTermRecallEntries,
+  readLightStagedKeys,
   readShortTermRecallEntries,
   recordDreamingPhaseSignals,
   recordShortTermRecalls,
@@ -1723,7 +1724,7 @@ async function runRemDreaming(params: {
     nowMs,
     timezone: params.config.timezone,
   });
-  const entries = await filterLiveShortTermRecallEntries({
+  const allEntries = await filterLiveShortTermRecallEntries({
     workspaceDir: params.workspaceDir,
     entries: filterRecallEntriesWithinLookback({
       entries: await readShortTermRecallEntries({ workspaceDir: params.workspaceDir, nowMs }),
@@ -1731,6 +1732,14 @@ async function runRemDreaming(params: {
       lookbackDays: params.config.lookbackDays,
     }),
   });
+  // Prefer entries staged by light sleep so REM synthesises from the
+  // sequential light→REM pipeline instead of rescanning the full store.
+  const lightKeys = await readLightStagedKeys({
+    workspaceDir: params.workspaceDir,
+    nowMs,
+  });
+  const entries =
+    lightKeys.size > 0 ? allEntries.filter((entry) => lightKeys.has(entry.key)) : allEntries;
   const preview = previewRemDreaming({
     entries,
     limit: params.config.limit,

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -31,6 +31,7 @@ import {
   readLightStagedKeys,
   readShortTermRecallEntries,
   recordDreamingPhaseSignals,
+  recordRemConsideredPhaseSignals,
   recordShortTermRecalls,
   type ShortTermRecallEntry,
 } from "./short-term-promotion.js";
@@ -1738,8 +1739,9 @@ async function runRemDreaming(params: {
     workspaceDir: params.workspaceDir,
     nowMs,
   });
-  const entries =
-    lightKeys.size > 0 ? allEntries.filter((entry) => lightKeys.has(entry.key)) : allEntries;
+  const stagedEntries =
+    lightKeys.size > 0 ? allEntries.filter((entry) => lightKeys.has(entry.key)) : [];
+  const entries = stagedEntries.length > 0 ? stagedEntries : allEntries;
   const preview = previewRemDreaming({
     entries,
     limit: params.config.limit,
@@ -1753,6 +1755,13 @@ async function runRemDreaming(params: {
     timezone: params.config.timezone,
     storage: params.config.storage,
   });
+  if (stagedEntries.length > 0) {
+    await recordRemConsideredPhaseSignals({
+      workspaceDir: params.workspaceDir,
+      keys: stagedEntries.map((entry) => entry.key),
+      nowMs,
+    });
+  }
   await recordDreamingPhaseSignals({
     workspaceDir: params.workspaceDir,
     phase: "rem",

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -14,6 +14,7 @@ import {
   recordGroundedShortTermCandidates,
   rankShortTermPromotionCandidates,
   recordDreamingPhaseSignals,
+  recordRemConsideredPhaseSignals,
   recordShortTermRecalls,
   readLightStagedKeys,
   removeGroundedShortTermCandidates,
@@ -556,6 +557,16 @@ describe("short-term promotion", () => {
 
       await expect(readLightStagedKeys({ workspaceDir, nowMs: nowMs + 120_000 })).resolves.toEqual(
         new Set([pendingKey]),
+      );
+
+      await recordRemConsideredPhaseSignals({
+        workspaceDir,
+        keys: [pendingKey],
+        nowMs: nowMs + 180_000,
+      });
+
+      await expect(readLightStagedKeys({ workspaceDir, nowMs: nowMs + 240_000 })).resolves.toEqual(
+        new Set(),
       );
     });
   });

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -15,6 +15,7 @@ import {
   rankShortTermPromotionCandidates,
   recordDreamingPhaseSignals,
   recordShortTermRecalls,
+  readLightStagedKeys,
   removeGroundedShortTermCandidates,
   repairShortTermPromotionArtifacts,
   resolveShortTermRecallLockPath,
@@ -489,6 +490,73 @@ describe("short-term promotion", () => {
       expect(ranked[0]?.uniqueQueries).toBe(3);
       expect(ranked[0]?.recallDays).toEqual(queryDays);
       expect(ranked[0]?.score).toBeGreaterThanOrEqual(0.75);
+    });
+  });
+
+  it("reads only light-staged keys that have not already gone through REM", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const nowMs = Date.parse("2026-04-05T10:00:00.000Z");
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "phase pipeline",
+        nowMs,
+        results: [
+          {
+            path: "memory/2026-04-01.md",
+            startLine: 1,
+            endLine: 1,
+            score: 0.9,
+            snippet: "Move backups to S3 Glacier.",
+            source: "memory",
+          },
+          {
+            path: "memory/2026-04-02.md",
+            startLine: 1,
+            endLine: 1,
+            score: 0.91,
+            snippet: "Document the Ollama setup.",
+            source: "memory",
+          },
+        ],
+      });
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs,
+      });
+      const staleKey = requireCandidateKey(
+        ranked.find((entry) => entry.path === "memory/2026-04-01.md"),
+        "stale candidate",
+      );
+      const pendingKey = requireCandidateKey(
+        ranked.find((entry) => entry.path === "memory/2026-04-02.md"),
+        "pending candidate",
+      );
+
+      await recordDreamingPhaseSignals({
+        workspaceDir,
+        phase: "light",
+        keys: [staleKey],
+        nowMs: nowMs - 60_000,
+      });
+      await recordDreamingPhaseSignals({
+        workspaceDir,
+        phase: "rem",
+        keys: [staleKey],
+        nowMs,
+      });
+      await recordDreamingPhaseSignals({
+        workspaceDir,
+        phase: "light",
+        keys: [pendingKey],
+        nowMs: nowMs + 60_000,
+      });
+
+      await expect(readLightStagedKeys({ workspaceDir, nowMs: nowMs + 120_000 })).resolves.toEqual(
+        new Set([pendingKey]),
+      );
     });
   });
 

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -1235,7 +1235,15 @@ export async function readLightStagedKeys(params: {
   const store = await readPhaseSignalStore(workspaceDir, nowIso);
   const keys = new Set<string>();
   for (const [key, entry] of Object.entries(store.entries)) {
-    if (entry.lightHits > 0) {
+    if (entry.lightHits <= 0) {
+      continue;
+    }
+    const lastLightMs = Date.parse(entry.lastLightAt ?? "");
+    const lastRemMs = Date.parse(entry.lastRemAt ?? "");
+    const hasPendingLightSignal = Number.isFinite(lastLightMs)
+      ? !Number.isFinite(lastRemMs) || lastLightMs > lastRemMs
+      : !entry.lastRemAt;
+    if (hasPendingLightSignal) {
       keys.add(key);
     }
   }

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -1222,6 +1222,26 @@ export async function recordDreamingPhaseSignals(params: {
   });
 }
 
+export async function readLightStagedKeys(params: {
+  workspaceDir: string;
+  nowMs?: number;
+}): Promise<Set<string>> {
+  const workspaceDir = params.workspaceDir?.trim();
+  if (!workspaceDir) {
+    return new Set();
+  }
+  const nowMs = Number.isFinite(params.nowMs) ? (params.nowMs as number) : Date.now();
+  const nowIso = new Date(nowMs).toISOString();
+  const store = await readPhaseSignalStore(workspaceDir, nowIso);
+  const keys = new Set<string>();
+  for (const [key, entry] of Object.entries(store.entries)) {
+    if (entry.lightHits > 0) {
+      keys.add(key);
+    }
+  }
+  return keys;
+}
+
 export async function rankShortTermPromotionCandidates(
   options: RankShortTermPromotionOptions,
 ): Promise<PromotionCandidate[]> {

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -96,6 +96,7 @@ type ShortTermPhaseSignalEntry = {
   remHits: number;
   lastLightAt?: string;
   lastRemAt?: string;
+  lastRemConsideredAt?: string;
 };
 
 type ShortTermPhaseSignalStore = {
@@ -831,12 +832,17 @@ function normalizePhaseSignalStore(raw: unknown, nowIso: string): ShortTermPhase
       typeof entry.lastRemAt === "string" && entry.lastRemAt.trim().length > 0
         ? entry.lastRemAt
         : undefined;
+    const lastRemConsideredAt =
+      typeof entry.lastRemConsideredAt === "string" && entry.lastRemConsideredAt.trim().length > 0
+        ? entry.lastRemConsideredAt
+        : undefined;
     entries[key] = {
       key,
       lightHits,
       remHits,
       ...(lastLightAt ? { lastLightAt } : {}),
       ...(lastRemAt ? { lastRemAt } : {}),
+      ...(lastRemConsideredAt ? { lastRemConsideredAt } : {}),
     };
   }
   return {
@@ -1222,6 +1228,53 @@ export async function recordDreamingPhaseSignals(params: {
   });
 }
 
+export async function recordRemConsideredPhaseSignals(params: {
+  workspaceDir?: string;
+  keys: string[];
+  nowMs?: number;
+}): Promise<void> {
+  const workspaceDir = params.workspaceDir?.trim();
+  if (!workspaceDir) {
+    return;
+  }
+  const keys = [...new Set(params.keys.map((key) => key.trim()).filter(Boolean))];
+  if (keys.length === 0) {
+    return;
+  }
+  const nowMs = Number.isFinite(params.nowMs) ? (params.nowMs as number) : Date.now();
+  const nowIso = new Date(nowMs).toISOString();
+
+  await withShortTermLock(workspaceDir, async () => {
+    const [store, phaseSignals] = await Promise.all([
+      readStore(workspaceDir, nowIso),
+      readPhaseSignalStore(workspaceDir, nowIso),
+    ]);
+    const knownKeys = new Set(Object.keys(store.entries));
+
+    for (const key of keys) {
+      if (!knownKeys.has(key)) {
+        continue;
+      }
+      const entry = phaseSignals.entries[key] ?? {
+        key,
+        lightHits: 0,
+        remHits: 0,
+      };
+      entry.lastRemConsideredAt = nowIso;
+      phaseSignals.entries[key] = entry;
+    }
+
+    for (const [key, entry] of Object.entries(phaseSignals.entries)) {
+      if (!knownKeys.has(key) || (entry.lightHits <= 0 && entry.remHits <= 0)) {
+        delete phaseSignals.entries[key];
+      }
+    }
+
+    phaseSignals.updatedAt = nowIso;
+    await writePhaseSignalStore(workspaceDir, phaseSignals);
+  });
+}
+
 export async function readLightStagedKeys(params: {
   workspaceDir: string;
   nowMs?: number;
@@ -1240,8 +1293,13 @@ export async function readLightStagedKeys(params: {
     }
     const lastLightMs = Date.parse(entry.lastLightAt ?? "");
     const lastRemMs = Date.parse(entry.lastRemAt ?? "");
+    const lastRemConsideredMs = Date.parse(entry.lastRemConsideredAt ?? "");
+    const lastConsumedMs = Math.max(
+      Number.isFinite(lastRemMs) ? lastRemMs : Number.NEGATIVE_INFINITY,
+      Number.isFinite(lastRemConsideredMs) ? lastRemConsideredMs : Number.NEGATIVE_INFINITY,
+    );
     const hasPendingLightSignal = Number.isFinite(lastLightMs)
-      ? !Number.isFinite(lastRemMs) || lastLightMs > lastRemMs
+      ? lastLightMs > lastConsumedMs
       : !entry.lastRemAt;
     if (hasPendingLightSignal) {
       keys.add(key);


### PR DESCRIPTION
## Summary

REM dreaming re-ingested the full short-term recall store independently, ignoring which entries had actually been staged by light sleep. The confidence formula weights accumulated `averageScore` and `recallStrength`, so older high-recall entries could dominate freshly staged candidates and break the intended light-to-REM-to-deep pipeline.

## Root cause

`runRemDreaming()` read all short-term recall entries in the lookback window and passed them unfiltered to `previewRemDreaming()`. REM candidate selection then ranked by accumulated recall history rather than by the current light-sleep staging signal.

## Fix

1. `short-term-promotion.ts`: add staged-key reading that only returns light-staged keys still pending REM consideration.
2. `dreaming-phases.ts`: prefer live light-staged entries for REM, fall back to the full recent store when staged keys are stale or absent, and mark staged entries as REM-considered without giving every considered entry promotion credit.
3. Regression tests cover pending staged keys, consumed staged keys, and the existing REM/promotion behavior.

## Real behavior proof

Behavior addressed: REM dreaming now synthesizes from the current live light-staged recall entries instead of reselecting unrelated older high-recall entries from the full short-term store.

Real environment tested: local OpenClaw checkout on macOS, rebased on current `origin/main`, using the memory-core dreaming and short-term promotion implementation with real temp-workspace stores.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/memory-core/src/dreaming-phases.test.ts extensions/memory-core/src/short-term-promotion.test.ts`

Evidence after fix: terminal output from the local OpenClaw run:

```text
RUN  v4.1.7 /Users/steipete/Projects/clawdbot3

Test Files  2 passed (2)
Tests  97 passed (97)
```

Observed result after fix: staged light keys are consumed by REM consideration, stale/non-live staged keys no longer block REM from falling back to recent recalls, and the focused memory-core regression suite stays green.

What was not tested: a multi-day live memory-core deployment with production user memory was not replayed for this PR.

## Verification

- `node scripts/run-vitest.mjs extensions/memory-core/src/dreaming-phases.test.ts extensions/memory-core/src/short-term-promotion.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "node scripts/run-vitest.mjs extensions/memory-core/src/dreaming-phases.test.ts extensions/memory-core/src/short-term-promotion.test.ts"`

Closes #86249
