### PR TITLE
fix(googlechat): validate appPrincipal is required when audienceType is app-url

### DIFF
--- a/docs/channels/googlechat.md
+++ b/docs/channels/googlechat.md
@@ -183,6 +183,7 @@ Use these identifiers for delivery and allowlists:
       // or serviceAccountRef: { source: "file", provider: "filemain", id: "/channels/googlechat/serviceAccount" }
       audienceType: "app-url",
       audience: "https://gateway.example.com/googlechat",
+      appPrincipal: "123456789012345678901", // required when audienceType is "app-url"
       webhookPath: "/googlechat",
       botUser: "users/1234567890", // optional; helps mention detection
       allowBots: false,
@@ -211,6 +212,7 @@ Notes:
 
 - Service account credentials can also be passed inline with `serviceAccount` (JSON string).
 - `serviceAccountRef` is also supported (env/file SecretRef), including per-account refs under `channels.googlechat.accounts.<id>.serviceAccountRef`.
+- `appPrincipal` is required when `audienceType` is `"app-url"` (set it to the numeric OAuth 2.0 client ID, not an email address). It is not needed for `project-number` audience.
 - Default webhook path is `/googlechat` if `webhookPath` isn't set.
 - `dangerouslyAllowNameMatching` re-enables mutable email principal matching for allowlists (break-glass compatibility mode).
 - Reactions are available via the `reactions` tool and `channels action` when `actions.reactions` is enabled.

--- a/src/config/config.googlechat-appprincipal.test.ts
+++ b/src/config/config.googlechat-appprincipal.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { GoogleChatConfigSchema } from "./zod-schema.providers-googlechat.js";
+
+describe('GoogleChat appPrincipal required when audienceType is "app-url"', () => {
+  it("accepts app-url with appPrincipal", () => {
+    const result = GoogleChatConfigSchema.safeParse({
+      audienceType: "app-url",
+      appPrincipal: "123456789012345678901",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects app-url without appPrincipal", () => {
+    const result = GoogleChatConfigSchema.safeParse({
+      audienceType: "app-url",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((issue) => issue.path.includes("appPrincipal"))).toBe(true);
+    }
+  });
+
+  it("rejects app-url with empty appPrincipal", () => {
+    const result = GoogleChatConfigSchema.safeParse({
+      audienceType: "app-url",
+      appPrincipal: "   ",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((issue) => issue.path.includes("appPrincipal"))).toBe(true);
+    }
+  });
+
+  it("accepts project-number without appPrincipal", () => {
+    const result = GoogleChatConfigSchema.safeParse({
+      audienceType: "project-number",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects account app-url without appPrincipal when parent has no audienceType", () => {
+    const result = GoogleChatConfigSchema.safeParse({
+      accounts: {
+        work: {
+          audienceType: "app-url",
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some(
+          (issue) => issue.path.includes("accounts") && issue.path.includes("appPrincipal"),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("accepts account app-url with appPrincipal", () => {
+    const result = GoogleChatConfigSchema.safeParse({
+      accounts: {
+        work: {
+          audienceType: "app-url",
+          appPrincipal: "123456789012345678901",
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts account project-number without appPrincipal", () => {
+    const result = GoogleChatConfigSchema.safeParse({
+      accounts: {
+        work: {
+          audienceType: "project-number",
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("inherits parent audienceType for account validation", () => {
+    const result = GoogleChatConfigSchema.safeParse({
+      audienceType: "app-url",
+      appPrincipal: "123456789012345678901",
+      accounts: {
+        work: {},
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some(
+          (issue) => issue.path.includes("accounts") && issue.path.includes("appPrincipal"),
+        ),
+      ).toBe(true);
+    }
+  });
+});

--- a/src/config/types.googlechat.ts
+++ b/src/config/types.googlechat.ts
@@ -78,7 +78,10 @@ export type GoogleChatAccountConfig = {
   audienceType?: "app-url" | "project-number";
   /** Audience value (app URL or project number). */
   audience?: string;
-  /** Exact add-on principal to accept when app-url delivery uses add-on tokens. */
+  /**
+   * Exact add-on principal to accept when app-url delivery uses add-on tokens.
+   * Required when audienceType is "app-url".
+   */
   appPrincipal?: string;
   /** Google Chat webhook path (default: /googlechat). */
   webhookPath?: string;

--- a/src/config/zod-schema.providers-googlechat.ts
+++ b/src/config/zod-schema.providers-googlechat.ts
@@ -100,4 +100,34 @@ export const GoogleChatAccountSchema = z
 export const GoogleChatConfigSchema = GoogleChatAccountSchema.extend({
   accounts: z.record(z.string(), GoogleChatAccountSchema.optional()).optional(),
   defaultAccount: z.string().optional(),
+}).superRefine((value, ctx) => {
+  const audienceType = value.audienceType;
+  const appPrincipal = value.appPrincipal?.trim();
+  if (audienceType === "app-url" && !appPrincipal) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["appPrincipal"],
+      message:
+        'channels.googlechat.audienceType="app-url" requires channels.googlechat.appPrincipal',
+    });
+  }
+
+  if (!value.accounts) {
+    return;
+  }
+  for (const [accountId, account] of Object.entries(value.accounts)) {
+    if (!account) {
+      continue;
+    }
+    const accountAudienceType = account.audienceType ?? audienceType;
+    const accountAppPrincipal = account.appPrincipal?.trim();
+    if (accountAudienceType === "app-url" && !accountAppPrincipal) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["accounts", accountId, "appPrincipal"],
+        message:
+          'channels.googlechat.accounts.*.audienceType="app-url" requires channels.googlechat.accounts.*.appPrincipal',
+      });
+    }
+  }
 });


### PR DESCRIPTION
## Summary

When `audienceType` is `"app-url"`, the `appPrincipal` field (OAuth 2.0 client ID) is required for Google Chat add-on token validation. Previously, omitting `appPrincipal` in this mode would silently pass schema validation, leading to a confusing runtime failure.

This complements the runtime warning added in #71145 by enforcing the requirement at the config schema level.

## Changes

- Add `superRefine` validation to `GoogleChatConfigSchema` that rejects `app-url` configurations without `appPrincipal`
- Propagate the same validation to per-account overrides (`accounts.*`)
- Inherit parent `audienceType` for account-level validation when not explicitly overridden
- Update JSDoc comments on `appPrincipal` to document the requirement
- Update `docs/channels/googlechat.md` example and notes
- Add regression tests covering:
  - `app-url` with/without `appPrincipal`
  - Empty/whitespace `appPrincipal`
  - `project-number` without `appPrincipal` (still allowed)
  - Account-level overrides with inherited parent `audienceType`

## Validation

- `pnpm test src/config/config.googlechat-appprincipal.test.ts` — 8/8 passed
- `pnpm test src/plugins/contracts/config-footprint-guardrails.test.ts` — 11/11 passed
- `pnpm exec oxlint` — 0 warnings, 0 errors

## Compatibility

- No breaking change for existing valid configs
- `project-number` audience type is unaffected
