### PR TITLE
fix(ui): pass agentId filter to session picker RPC call

### DIFF
--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -249,6 +249,10 @@ function createChatSessionPickerRequestParams(
   if (search) {
     params.search = search;
   }
+  const agentId = resolveChatAgentFilterId(state, state.sessionKey)?.trim();
+  if (agentId) {
+    params.agentId = agentId;
+  }
   return params;
 }
 


### PR DESCRIPTION
## Summary

The Control UI chat session picker fetches sessions from all agents instead of filtering by the currently selected agent. This is because `createChatSessionPickerRequestParams` never passes `agentId` to the `sessions.list` RPC call.

## Changes

- Add `agentId` parameter to the session picker request in `createChatSessionPickerRequestParams`
- Uses the existing `resolveChatAgentFilterId` helper (already in the same file) to resolve the active agent
- Mirrors the pattern already used in `ui/src/ui/controllers/sessions.ts:551-554`

## Testing

- Verified `resolveChatAgentFilterId` is already used in the same file (lines 706, 1081, 1120, 1142) and is defined at line 1066
- The change follows the exact same gated pattern used by the sessions controller
- Relying on CI for full test suite execution

Closes #86183