### PR TITLE
fix(cli): add Windows stack-size respawn

### DIFF
--- a/src/cli/windows-argv.ts
+++ b/src/cli/windows-argv.ts
@@ -1,12 +1,21 @@
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 
-export function normalizeWindowsArgv(argv: string[]): string[] {
-  if (process.platform !== "win32") {
+export function normalizeWindowsArgv(
+  argv: string[],
+  options: {
+    platform?: NodeJS.Platform;
+    execPath?: string;
+    pathExists?: (path: string) => boolean;
+  } = {},
+): string[] {
+  const platform = options.platform ?? process.platform;
+  if (platform !== "win32") {
     return argv;
   }
   if (argv.length < 2) {
     return argv;
   }
+  const pathExists = options.pathExists ?? (() => false);
 
   const stripControlChars = (value: string): string => {
     let out = "";
@@ -27,7 +36,7 @@ export function normalizeWindowsArgv(argv: string[]): string[] {
     normalizeArg(value).replace(/^\\\\\\?\\/, "");
   const basename = (value: string): string => value.split(/[\\/]/).pop() ?? value;
 
-  const execPath = normalizeCandidate(process.execPath);
+  const execPath = normalizeCandidate(options.execPath ?? process.execPath);
   const execPathLower = normalizeLowercaseStringOrEmpty(execPath);
   const execBase = normalizeLowercaseStringOrEmpty(basename(execPath));
   const isExecPath = (value: string | undefined): boolean => {
@@ -45,7 +54,8 @@ export function normalizeWindowsArgv(argv: string[]): string[] {
       base === execBase ||
       lower.endsWith("\\node.exe") ||
       lower.endsWith("/node.exe") ||
-      base === "node.exe"
+      lower.includes("node.exe") ||
+      (base === "node.exe" && pathExists(normalized))
     );
   };
 

--- a/src/entry.respawn.test.ts
+++ b/src/entry.respawn.test.ts
@@ -139,6 +139,28 @@ describe("buildCliRespawnPlan", () => {
     expect(respawnPlan.env[OPENCLAW_NODE_OPTIONS_READY]).toBeUndefined();
   });
 
+  it("normalizes duplicated Windows node.exe argv before respawning", () => {
+    const scriptPath =
+      "C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules\\openclaw\\openclaw.mjs";
+    const plan = buildCliRespawnPlan({
+      argv: [
+        "C:\\Program Files\\nodejs\\node.exe",
+        "C:\\Program Files\\nodejs\\node.exe",
+        scriptPath,
+        "node.exe",
+        "dashboard",
+        "--no-open",
+      ],
+      env: {},
+      execArgv: [],
+      execPath: "C:\\Program Files\\nodejs\\node.exe",
+      platform: "win32",
+    });
+
+    const respawnPlan = expectCliRespawnPlan(plan);
+    expect(respawnPlan.argv).toEqual(["--stack-size=8192", scriptPath, "dashboard", "--no-open"]);
+  });
+
   it("does not respawn on Windows when stack size is already configured", () => {
     expect(
       buildCliRespawnPlan({

--- a/src/entry.respawn.test.ts
+++ b/src/entry.respawn.test.ts
@@ -45,6 +45,7 @@ describe("buildCliRespawnPlan", () => {
       env: {},
       execArgv: [],
       autoNodeExtraCaCerts: "/etc/ssl/certs/ca-certificates.crt",
+      platform: "linux",
     });
 
     const respawnPlan = expectCliRespawnPlan(plan);
@@ -63,6 +64,7 @@ describe("buildCliRespawnPlan", () => {
         env: {},
         execArgv: [],
         autoNodeExtraCaCerts: "/etc/ssl/certs/ca-certificates.crt",
+        platform: "linux",
       });
 
       const respawnPlan = expectCliRespawnPlan(plan);
@@ -80,6 +82,7 @@ describe("buildCliRespawnPlan", () => {
         env: { [OPENCLAW_NODE_EXTRA_CA_CERTS_READY]: "1" },
         execArgv: [],
         autoNodeExtraCaCerts: undefined,
+        platform: "linux",
       }),
     ).toBeNull();
   });
@@ -90,6 +93,7 @@ describe("buildCliRespawnPlan", () => {
       env: { NODE_EXTRA_CA_CERTS: "/custom/ca.pem" },
       execArgv: [],
       autoNodeExtraCaCerts: "/etc/ssl/certs/ca-certificates.crt",
+      platform: "linux",
     });
 
     const respawnPlan = expectCliRespawnPlan(plan);
@@ -106,20 +110,45 @@ describe("buildCliRespawnPlan", () => {
         },
         execArgv: [EXPERIMENTAL_WARNING_FLAG],
         autoNodeExtraCaCerts: "/etc/ssl/certs/ca-certificates.crt",
+        platform: "linux",
       }),
     ).toBeNull();
   });
 
-  it("does not respawn on Windows", () => {
+  it("adds a larger V8 stack size on Windows", () => {
+    const plan = buildCliRespawnPlan({
+      argv: [
+        "node",
+        "C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules\\openclaw\\openclaw.mjs",
+        "dashboard",
+      ],
+      env: {},
+      execArgv: [],
+      autoNodeExtraCaCerts: "/etc/ssl/certs/ca-certificates.crt",
+      platform: "win32",
+    });
+
+    const respawnPlan = expectCliRespawnPlan(plan);
+    expect(respawnPlan.argv).toEqual([
+      "--stack-size=8192",
+      "C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules\\openclaw\\openclaw.mjs",
+      "dashboard",
+    ]);
+    expect(respawnPlan.env.NODE_EXTRA_CA_CERTS).toBeUndefined();
+    expect(respawnPlan.env[OPENCLAW_NODE_EXTRA_CA_CERTS_READY]).toBeUndefined();
+    expect(respawnPlan.env[OPENCLAW_NODE_OPTIONS_READY]).toBeUndefined();
+  });
+
+  it("does not respawn on Windows when stack size is already configured", () => {
     expect(
       buildCliRespawnPlan({
         argv: [
           "node",
           "C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules\\openclaw\\openclaw.mjs",
-          "onboard",
+          "dashboard",
         ],
         env: {},
-        execArgv: [],
+        execArgv: ["--stack-size=16384"],
         autoNodeExtraCaCerts: "/etc/ssl/certs/ca-certificates.crt",
         platform: "win32",
       }),

--- a/src/entry.respawn.ts
+++ b/src/entry.respawn.ts
@@ -5,6 +5,7 @@ import {
   shouldSkipRespawnForArgv,
   shouldSkipStartupEnvironmentRespawnForArgv,
 } from "./cli/respawn-policy.js";
+import { normalizeWindowsArgv } from "./cli/windows-argv.js";
 import { isTruthyEnvValue } from "./infra/env.js";
 import { attachChildProcessBridge } from "./process/child-process-bridge.js";
 
@@ -78,9 +79,11 @@ export function buildCliRespawnPlan(
   const execArgv = params.execArgv ?? process.execArgv;
   const execPath = params.execPath ?? process.execPath;
   const platform = params.platform ?? process.platform;
+  const normalizedArgv =
+    platform === "win32" ? normalizeWindowsArgv(argv, { platform, execPath }) : argv;
 
   if (
-    shouldSkipStartupEnvironmentRespawnForArgv(argv) ||
+    shouldSkipStartupEnvironmentRespawnForArgv(normalizedArgv) ||
     isTruthyEnvValue(env.OPENCLAW_NO_RESPAWN)
   ) {
     return null;
@@ -102,7 +105,7 @@ export function buildCliRespawnPlan(
 
     return {
       command: resolveCliRespawnCommand({ execPath, platform }),
-      argv: [...childExecArgv, ...argv.slice(1)],
+      argv: [...childExecArgv, ...normalizedArgv.slice(1)],
       env: childEnv,
     };
   }

--- a/src/entry.respawn.ts
+++ b/src/entry.respawn.ts
@@ -11,6 +11,7 @@ import { attachChildProcessBridge } from "./process/child-process-bridge.js";
 export const EXPERIMENTAL_WARNING_FLAG = "--disable-warning=ExperimentalWarning";
 export const OPENCLAW_NODE_OPTIONS_READY = "OPENCLAW_NODE_OPTIONS_READY";
 export const OPENCLAW_NODE_EXTRA_CA_CERTS_READY = "OPENCLAW_NODE_EXTRA_CA_CERTS_READY";
+const WINDOWS_STACK_SIZE_FLAG = "--stack-size=8192";
 const CLI_RESPAWN_SIGNAL_EXIT_GRACE_MS = 1_000;
 const CLI_RESPAWN_SIGNAL_FORCE_KILL_GRACE_MS = 1_000;
 
@@ -58,6 +59,10 @@ function hasExperimentalWarningSuppressed(
   return execArgv.some((arg) => arg === EXPERIMENTAL_WARNING_FLAG || arg === "--no-warnings");
 }
 
+function hasStackSizeConfigured(execArgv: string[]): boolean {
+  return execArgv.some((arg) => arg.startsWith("--stack-size"));
+}
+
 export function buildCliRespawnPlan(
   params: {
     argv?: string[];
@@ -81,13 +86,26 @@ export function buildCliRespawnPlan(
     return null;
   }
 
-  if (platform === "win32") {
-    return null;
-  }
-
   const childEnv: NodeJS.ProcessEnv = { ...env };
   const childExecArgv = [...execArgv];
   let needsRespawn = false;
+
+  if (platform === "win32") {
+    if (!hasStackSizeConfigured(childExecArgv)) {
+      childExecArgv.unshift(WINDOWS_STACK_SIZE_FLAG);
+      needsRespawn = true;
+    }
+
+    if (!needsRespawn) {
+      return null;
+    }
+
+    return {
+      command: resolveCliRespawnCommand({ execPath, platform }),
+      argv: [...childExecArgv, ...argv.slice(1)],
+      env: childEnv,
+    };
+  }
 
   const autoNodeExtraCaCerts =
     params.autoNodeExtraCaCerts ??


### PR DESCRIPTION
## Summary
- add a Windows-only respawn path that launches the CLI with `--stack-size=8192`
- normalize Windows argv before building the respawn child argv so duplicated `node.exe` / wrapper args are not forwarded
- preserve existing Windows behavior for CA cert and warning-suppression respawns
- skip the respawn when the user already provided a `--stack-size` exec arg
- pin non-Windows respawn baseline tests to Linux so Windows test runs exercise the new path deterministically

Fixes #62055.

## Validation
- WSL/Linux: `node scripts/run-vitest.mjs src/entry.respawn.test.ts --reporter=dot` -> 16 tests passed
- WSL/Linux: `./node_modules/.bin/oxfmt --check src/entry.respawn.ts src/entry.respawn.test.ts src/cli/windows-argv.ts`
- WSL/Linux: `./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/entry.respawn.ts src/entry.respawn.test.ts src/cli/windows-argv.ts`
- WSL/Linux: `git diff --check refs/remotes/upstream-safe/main...HEAD`
- WSL/Linux: `git diff --check`
- Windows 11 / Node v22.22.3: `node node_modules\vitest\vitest.mjs src/entry.respawn.test.ts --reporter=dot --run` -> 16 tests passed

Signed head: `21b89af215c6ebeb8d3d5466f1c66e7b0570f8a5`.

## ClawSweeper follow-up
- Addressed P1 `Normalize Windows argv before respawning` by calling `normalizeWindowsArgv()` from `buildCliRespawnPlan()` for `win32` before skip checks and before constructing child args.
- Added regression coverage for duplicated `node.exe` / wrapper args so the respawn child receives `--stack-size=8192`, the OpenClaw script path, and the real command args only.

## Windows packaged runtime proof

Head tested: `b139bf5db3f900ff694ac3e376855c84185091ed`.

Environment: Windows 11, Node `v22.22.3`, npm `10.9.8`, package tarball built from this head with `npm pack` after `node scripts/build-all.mjs`.

Local machine caveat: this Windows environment blocks Node from executing script filenames containing `openclaw` with `Access is denied`, even for a one-line test file. To avoid that local endpoint-policy block while still testing the packed runtime, I extracted the tarball under `C:\src\claws\ocpkg-86307\pkg`, installed production dependencies in that extracted package with `npm install --ignore-scripts --omit=dev --no-bin-links`, and invoked the packed `dist\entry.js` directly. This exercises the PR's Windows `buildCliRespawnPlan()` / `runCliRespawnPlan()` path without manually setting `NODE_OPTIONS`.

Exact proof commands/results:
- `node C:\src\claws\ocpkg-86307\pkg\dist\entry.js plugins list --json` with isolated `OPENCLAW_HOME` -> exit `0`; JSON output included `"plugins": []` and registry source `"derived"`.
- `node C:\src\claws\ocpkg-86307\pkg\dist\entry.js doctor` with isolated `OPENCLAW_HOME` -> exit `0`; emitted normal first-run doctor findings for missing gateway config, auth token, plugin registry, and state directory.
- `echo n | node C:\src\claws\ocpkg-86307\pkg\dist\entry.js dashboard --no-open` with isolated `OPENCLAW_HOME` -> exit `0`; emitted `Gateway is not running.` and suggested gateway status/start/run commands.
- `NODE_DEBUG=child_process node C:\src\claws\ocpkg-86307\pkg\dist\entry.js plugins list --json` -> exit `0`; debug output showed the Windows respawn args included `C:\Program Files\nodejs\node.exe`, `--stack-size=8192`, the packed `dist\entry.js`, and `plugins list --json`.

Remaining proof gap: the exact `openclaw.mjs`/`.cmd` filename could not be smoked on this corporate Windows machine because of the local filename policy described above. The packed runtime entry, dependency set, command behavior, and Windows stack-size respawn were exercised.

Note: commits are SSH-signed locally and verified with `git log --show-signature -1`.