### PR TITLE
fix: surface implicit Codex harness selection

### DIFF
--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -2678,6 +2678,8 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
             case "harness.run.error":
               recordHarnessRunError(evt, metadata);
               return;
+            case "harness.selection":
+              return;
             case "context.assembled":
               recordContextAssembled(evt, metadata);
               return;

--- a/extensions/diagnostics-prometheus/src/service.ts
+++ b/extensions/diagnostics-prometheus/src/service.ts
@@ -550,6 +550,8 @@ function recordDiagnosticEvent(
         harnessLabels(evt),
       );
       return;
+    case "harness.selection":
+      return;
     case "message.processed":
       store.counter("openclaw_message_processed_total", "Inbound messages processed by outcome.", {
         channel: lowCardinalityLabel(evt.channel),

--- a/src/agents/harness/policy.ts
+++ b/src/agents/harness/policy.ts
@@ -12,6 +12,7 @@ import {
 export type AgentHarnessPolicy = {
   runtime: EmbeddedAgentRuntime;
   runtimeSource?: "model" | "provider" | "implicit";
+  runtimeReason?: "openai_official_default_codex" | "openai_codex_provider_default";
 };
 
 export function resolveAgentHarnessPolicy(params: {
@@ -39,13 +40,21 @@ export function resolveAgentHarnessPolicy(params: {
     openAIProviderUsesCodexRuntimeByDefault({ provider: params.provider, config: params.config })
   ) {
     if (runtime === "auto") {
-      return { runtime: "codex", runtimeSource };
+      return {
+        runtime: "codex",
+        runtimeSource,
+        runtimeReason: "openai_official_default_codex",
+      };
     }
     return { runtime, runtimeSource };
   }
   if (isOpenAICodexProvider(params.provider)) {
     if (runtime === "auto") {
-      return { runtime: "codex", runtimeSource };
+      return {
+        runtime: "codex",
+        runtimeSource,
+        runtimeReason: "openai_codex_provider_default",
+      };
     }
     return { runtime, runtimeSource };
   }

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -2,6 +2,12 @@ import type { Api, Model } from "@earendil-works/pi-ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { ContextEngine } from "../../context-engine/types.js";
+import {
+  onInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPayload,
+} from "../../infra/diagnostic-events.js";
 import type {
   EmbeddedRunAttemptParams,
   EmbeddedRunAttemptResult,
@@ -38,10 +44,12 @@ vi.mock("./builtin-pi.js", () => ({
 const originalRuntime = process.env.OPENCLAW_AGENT_RUNTIME;
 
 beforeEach(() => {
+  resetDiagnosticEventsForTest();
   clearAgentHarnesses();
 });
 
 afterEach(() => {
+  resetDiagnosticEventsForTest();
   clearAgentHarnesses();
   piRunAttempt.mockClear();
   if (originalRuntime == null) {
@@ -278,6 +286,7 @@ describe("runAgentHarnessAttempt", () => {
     expect(resolveAgentHarnessPolicy({ provider: "openai", modelId: "gpt-5.4" })).toEqual({
       runtime: "codex",
       runtimeSource: "implicit",
+      runtimeReason: "openai_official_default_codex",
     });
 
     const result = await runAgentHarnessAttempt({
@@ -289,14 +298,74 @@ describe("runAgentHarnessAttempt", () => {
     expect(piRunAttempt).not.toHaveBeenCalled();
   });
 
+  it("emits a structured diagnostic warning for implicit official OpenAI Codex selection", async () => {
+    registerSuccessfulCodexHarness();
+    const events: DiagnosticEventPayload[] = [];
+    const stop = onInternalDiagnosticEvent((event) => {
+      events.push(event);
+    });
+
+    await runAgentHarnessAttempt({
+      ...createAttemptParams(),
+      provider: "openai",
+      modelId: "gpt-5.4",
+    });
+    await waitForDiagnosticEventsDrained();
+    stop();
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "harness.selection",
+        runId: "run-1",
+        provider: "openai",
+        model: "gpt-5.4",
+        selectedHarnessId: "codex",
+        selectedReason: "implicit_plugin",
+        runtime: "codex",
+        runtimeSource: "implicit",
+        runtimeReason: "openai_official_default_codex",
+        warning: "openai_official_implicit_codex_harness",
+      }),
+    );
+  });
+
+  it("emits a structured diagnostic warning for explicit Codex runtime mappings", async () => {
+    registerSuccessfulCodexHarness();
+    const events: DiagnosticEventPayload[] = [];
+    const stop = onInternalDiagnosticEvent((event) => {
+      events.push(event);
+    });
+
+    await runAgentHarnessAttempt({
+      ...createAttemptParams(agentModelRuntimeConfig("openai/*", "codex")),
+      provider: "openai",
+      modelId: "gpt-5.4",
+    });
+    await waitForDiagnosticEventsDrained();
+    stop();
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "harness.selection",
+        selectedHarnessId: "codex",
+        selectedReason: "forced_plugin",
+        runtime: "codex",
+        runtimeSource: "model",
+        warning: "explicit_codex_runtime_mapping",
+      }),
+    );
+  });
+
   it("falls back to PI when the implicit OpenAI Codex harness is unavailable", async () => {
     expect(resolveAgentHarnessPolicy({ provider: "openai", modelId: "gpt-5.4" })).toEqual({
       runtime: "codex",
       runtimeSource: "implicit",
+      runtimeReason: "openai_official_default_codex",
     });
     expect(resolveAvailableAgentHarnessPolicy({ provider: "openai", modelId: "gpt-5.4" })).toEqual({
       runtime: "pi",
       runtimeSource: "implicit",
+      runtimeReason: "openai_official_default_codex",
     });
 
     const result = await runAgentHarnessAttempt({

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { emitTrustedDiagnosticEvent } from "../../infra/diagnostic-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { isCliRuntimeAliasForProvider, isCliRuntimeProvider } from "../model-runtime-aliases.js";
@@ -58,6 +59,8 @@ type AgentHarnessSelectionDecision = {
   selectedReason:
     | "forced_pi"
     | "forced_plugin"
+    // Implicit policy selected a registered plugin harness.
+    | "implicit_plugin"
     // Implicit Codex preference found no registered Codex harness, so PI handled the run.
     | "implicit_plugin_unavailable_pi"
     // Explicit provider-owned CLI runtime aliases have no agent harness plugin
@@ -162,7 +165,7 @@ function selectAgentHarnessDecision(params: {
       return buildSelectionDecision({
         harness: forced,
         policy,
-        selectedReason: "forced_plugin",
+        selectedReason: policy.runtimeSource === "implicit" ? "implicit_plugin" : "forced_plugin",
         candidates: listHarnessCandidates(pluginHarnesses),
       });
     }
@@ -246,6 +249,16 @@ export async function runAgentHarnessAttempt(
     modelId: params.modelId,
     sessionKey: params.sessionKey,
     agentId: params.agentId,
+  });
+  emitAgentHarnessSelectionDiagnostic(selection, {
+    runId: params.runId,
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
+    provider: params.provider,
+    modelId: params.modelId,
+    trigger: params.trigger,
+    messageChannel: params.messageChannel,
   });
   const v2Harness = adaptAgentHarnessToV2(harness);
   if (harness.id === "pi") {
@@ -452,8 +465,66 @@ function logAgentHarnessSelection(
     selectedHarnessId: selection.selectedHarnessId,
     selectedReason: selection.selectedReason,
     runtime: selection.policy.runtime,
+    runtimeSource: selection.policy.runtimeSource,
+    runtimeReason: selection.policy.runtimeReason,
+    warning: resolveAgentHarnessSelectionWarning(selection),
     candidates: selection.candidates,
   });
+}
+
+function emitAgentHarnessSelectionDiagnostic(
+  selection: AgentHarnessSelectionDecision,
+  params: {
+    runId: string;
+    sessionId?: string;
+    sessionKey?: string;
+    agentId?: string;
+    provider: string;
+    modelId?: string;
+    trigger?: string;
+    messageChannel?: string;
+  },
+): void {
+  const warning = resolveAgentHarnessSelectionWarning(selection);
+  emitTrustedDiagnosticEvent({
+    type: "harness.selection",
+    runId: params.runId,
+    provider: params.provider,
+    model: params.modelId,
+    selectedHarnessId: selection.selectedHarnessId,
+    selectedReason: selection.selectedReason,
+    runtime: selection.policy.runtime,
+    ...(selection.policy.runtimeSource ? { runtimeSource: selection.policy.runtimeSource } : {}),
+    ...(selection.policy.runtimeReason ? { runtimeReason: selection.policy.runtimeReason } : {}),
+    ...(warning ? { warning } : {}),
+    ...(params.sessionId ? { sessionId: params.sessionId } : {}),
+    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+    ...(params.trigger ? { trigger: params.trigger } : {}),
+    ...(params.messageChannel ? { channel: params.messageChannel } : {}),
+  });
+}
+
+function resolveAgentHarnessSelectionWarning(
+  selection: AgentHarnessSelectionDecision,
+):
+  | "openai_official_implicit_codex_harness"
+  | "openai_codex_provider_harness"
+  | "explicit_codex_runtime_mapping"
+  | undefined {
+  if (selection.selectedHarnessId !== "codex") {
+    return undefined;
+  }
+  if (selection.policy.runtimeReason === "openai_official_default_codex") {
+    return "openai_official_implicit_codex_harness";
+  }
+  if (selection.policy.runtimeReason === "openai_codex_provider_default") {
+    return "openai_codex_provider_harness";
+  }
+  if (selection.policy.runtimeSource === "model" || selection.policy.runtimeSource === "provider") {
+    return "explicit_codex_runtime_mapping";
+  }
+  return undefined;
 }
 
 export async function maybeCompactAgentHarnessSession(

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -788,6 +788,7 @@ const PRIORITY_ASYNC_DIAGNOSTIC_EVENT_TYPES = new Set<DiagnosticEventPayload["ty
   "tool.execution.completed",
   "tool.execution.error",
   "tool.execution.blocked",
+  "harness.selection",
 ]);
 
 function createDiagnosticEventsState(): DiagnosticEventsGlobalState {

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -483,6 +483,34 @@ type DiagnosticHarnessRunBaseEvent = DiagnosticBaseEvent & {
   pluginId?: string;
 };
 
+export type DiagnosticHarnessSelectionEvent = DiagnosticBaseEvent & {
+  type: "harness.selection";
+  runId: string;
+  sessionKey?: string;
+  sessionId?: string;
+  agentId?: string;
+  provider?: string;
+  model?: string;
+  trigger?: string;
+  channel?: string;
+  selectedHarnessId: string;
+  selectedReason:
+    | "forced_pi"
+    | "forced_plugin"
+    | "implicit_plugin"
+    | "implicit_plugin_unavailable_pi"
+    | "cli_runtime_passthrough_pi"
+    | "auto_plugin"
+    | "auto_pi";
+  runtime: string;
+  runtimeSource?: "model" | "provider" | "implicit";
+  runtimeReason?: "openai_official_default_codex" | "openai_codex_provider_default";
+  warning?:
+    | "openai_official_implicit_codex_harness"
+    | "openai_codex_provider_harness"
+    | "explicit_codex_runtime_mapping";
+};
+
 export type DiagnosticHarnessRunStartedEvent = DiagnosticHarnessRunBaseEvent & {
   type: "harness.run.started";
 };
@@ -680,6 +708,7 @@ export type DiagnosticEventPayload =
   | DiagnosticExecProcessCompletedEvent
   | DiagnosticRunStartedEvent
   | DiagnosticRunCompletedEvent
+  | DiagnosticHarnessSelectionEvent
   | DiagnosticHarnessRunStartedEvent
   | DiagnosticHarnessRunCompletedEvent
   | DiagnosticHarnessRunErrorEvent
@@ -748,6 +777,7 @@ const ASYNC_DIAGNOSTIC_EVENT_TYPES = new Set<DiagnosticEventPayload["type"]>([
   "model.call.completed",
   "model.call.error",
   "run.progress",
+  "harness.selection",
   "harness.run.started",
   "harness.run.completed",
   "harness.run.error",

--- a/src/logging/diagnostic-stability.test.ts
+++ b/src/logging/diagnostic-stability.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   emitDiagnosticEvent,
+  emitTrustedDiagnosticEvent,
   resetDiagnosticEventsForTest,
   waitForDiagnosticEventsDrained,
 } from "../infra/diagnostic-events.js";
@@ -253,6 +254,46 @@ describe("diagnostic stability recorder", () => {
     expect(snapshot.events[0]).not.toHaveProperty("sessionId");
     expect(snapshot.events[0]).not.toHaveProperty("promptChars");
     expect(snapshot.events[0]).not.toHaveProperty("systemPromptChars");
+  });
+
+  it("records trusted harness selection diagnostics through the sanitized stability surface", async () => {
+    startDiagnosticStabilityRecorder();
+
+    emitTrustedDiagnosticEvent({
+      type: "harness.selection",
+      runId: "run-secret",
+      sessionId: "session-secret",
+      sessionKey: "agent:main:webchat:direct:u1",
+      agentId: "main",
+      provider: "openai",
+      model: "gpt-5.4",
+      channel: "webchat",
+      selectedHarnessId: "codex",
+      selectedReason: "implicit_plugin",
+      runtime: "codex",
+      runtimeSource: "implicit",
+      runtimeReason: "openai_official_default_codex",
+      warning: "openai_official_implicit_codex_harness",
+    });
+    await waitForDiagnosticEventsDrained();
+
+    const snapshot = getDiagnosticStabilitySnapshot({ limit: 10 });
+
+    expectFields(snapshot.events[0], {
+      type: "harness.selection",
+      source: "codex",
+      provider: "openai",
+      model: "gpt-5.4",
+      channel: "webchat",
+      mode: "codex",
+      outcome: "implicit_plugin",
+      target: "main",
+      reason: "openai_official_default_codex",
+      level: "warning",
+    });
+    expect(snapshot.events[0]).not.toHaveProperty("runId");
+    expect(snapshot.events[0]).not.toHaveProperty("sessionId");
+    expect(snapshot.events[0]).not.toHaveProperty("sessionKey");
   });
 
   it("sanitizes tool and model diagnostic error categories", async () => {

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -440,6 +440,19 @@ function sanitizeDiagnosticEvent(event: DiagnosticEventPayload): DiagnosticStabi
       record.outcome = event.outcome;
       assignReasonCode(record, event.errorCategory);
       break;
+    case "harness.selection":
+      record.source = event.selectedHarnessId;
+      record.provider = event.provider;
+      record.model = event.model;
+      record.channel = event.channel;
+      record.mode = event.runtime;
+      record.outcome = event.selectedReason;
+      record.target = event.agentId;
+      assignReasonCode(record, event.runtimeReason ?? event.warning ?? event.selectedReason);
+      if (event.warning) {
+        record.level = "warning";
+      }
+      break;
     case "harness.run.started":
       record.source = event.harnessId;
       record.pluginId = event.pluginId;

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -1,5 +1,5 @@
 import {
-  onDiagnosticEvent,
+  onInternalDiagnosticEvent,
   type DiagnosticEventPayload,
   type DiagnosticMemoryUsage,
 } from "../infra/diagnostic-events.js";
@@ -717,7 +717,7 @@ export function startDiagnosticStabilityRecorder(): void {
   if (state.unsubscribe) {
     return;
   }
-  state.unsubscribe = onDiagnosticEvent((event) => {
+  state.unsubscribe = onInternalDiagnosticEvent((event) => {
     appendRecord(sanitizeDiagnosticEvent(event));
   });
 }


### PR DESCRIPTION
## Summary

Adds structured diagnostics for agent harness runtime selection so implicit Codex routing is visible and auditable.

This PR intentionally does not change the current documented behavior that official `openai/*` agent turns may use the Codex app-server harness by default. Instead, it makes that selection explicit through a trusted `harness.selection` diagnostic event and tags Codex selection paths with structured warning values.

Addresses part of #84393.

## What changed

- Adds `runtimeReason` to resolved harness policy for official OpenAI implicit Codex default routing and explicit `openai-codex/*` provider routing.
- Emits a trusted `harness.selection` diagnostic event before harness execution.
- Distinguishes implicit plugin selection from explicit forced plugin selection.
- Adds warning classifications for `openai_official_implicit_codex_harness`, `openai_codex_provider_harness`, and `explicit_codex_runtime_mapping`.
- Adds regression tests for implicit OpenAI Codex routing and explicit Codex runtime mappings.

## Scope note

Issue #84393 asks for broader runtime policy changes, including changing when Codex should be used. Current docs and tests intentionally support Codex as the default harness for official OpenAI agent turns, so this PR avoids changing that product contract before maintainer security/product review.

The narrow goal here is to make the active harness and runtime source visible enough for operators and maintainers to identify when a direct-chat operational agent is actually running through Codex.

## Validation

Focused tests after this patch:

```text
$ node scripts/run-vitest.mjs run src/agents/harness/selection.test.ts src/logging/diagnostic-stability.test.ts src/infra/diagnostic-events.test.ts

Test Files  4 passed (4)
Tests       112 passed (112)
Duration    7.85s
```

Bundled extension lint after this patch:

```text
$ pnpm lint:extensions:bundled
$ node scripts/run-bundled-extension-oxlint.mjs
Finished without errors.
```

Whitespace validation:

```text
$ git diff --check
# no output
```


## Real behavior proof

**Behavior or issue addressed:**
Trusted `harness.selection` events are now routed into the sanitized diagnostic stability surface so operator-visible diagnostics can show implicit Codex harness selection without leaking raw session identifiers. This addresses ClawSweeper's latest finding that the previous trusted event could remain internal-only.

**Real environment tested:**
Local OpenClaw PR worktree on Linux.

```text
repo: /home/rev/projects/openclaw-prs/pr-86310-codex-runtime-selection-diagnostics
head: 300e6b7795cf8e7975a2a08e075bbfa62cfe9af9
node: v22.22.2
pnpm: 11.2.2
proof log: /home/rev/projects/openclaw-prs/_logs/pr-86310/harness-selection-stability-proof-dc9247ce.log
```

**Exact steps or command run after this patch:**

1. Started the diagnostic stability recorder from the PR worktree.
2. Emitted a trusted `harness.selection` diagnostic with the same implicit OpenAI-to-Codex warning fields used by the agent harness selection path.
3. Drained async diagnostics.
4. Queried `getDiagnosticStabilitySnapshot({ limit: 5, type: "harness.selection" })`.
5. Confirmed the sanitized stability record contains the operator-safe selection warning fields and omits raw run/session identifiers.

Command:

```bash
node --import tsx - <<'NODE' 2>&1 | tee /home/rev/projects/openclaw-prs/_logs/pr-86310/harness-selection-stability-proof-dc9247ce.log
import { emitTrustedDiagnosticEvent, resetDiagnosticEventsForTest, waitForDiagnosticEventsDrained } from './src/infra/diagnostic-events.ts';
import { getDiagnosticStabilitySnapshot, resetDiagnosticStabilityRecorderForTest, startDiagnosticStabilityRecorder, stopDiagnosticStabilityRecorder } from './src/logging/diagnostic-stability.ts';

resetDiagnosticEventsForTest();
resetDiagnosticStabilityRecorderForTest();
startDiagnosticStabilityRecorder();
emitTrustedDiagnosticEvent({
  type: 'harness.selection',
  runId: 'proof-run-redacted',
  sessionId: 'proof-session-redacted',
  sessionKey: 'agent:main:webchat:direct:redacted',
  agentId: 'main',
  provider: 'openai',
  model: 'gpt-5.4',
  channel: 'webchat',
  selectedHarnessId: 'codex',
  selectedReason: 'implicit_plugin',
  runtime: 'codex',
  runtimeSource: 'implicit',
  runtimeReason: 'openai_official_default_codex',
  warning: 'openai_official_implicit_codex_harness',
});
await waitForDiagnosticEventsDrained();
const snapshot = getDiagnosticStabilitySnapshot({ limit: 5, type: 'harness.selection' });
stopDiagnosticStabilityRecorder();
console.log(JSON.stringify({ eventCount: snapshot.count, summary: snapshot.summary, events: snapshot.events, containsSecrets: JSON.stringify(snapshot).includes('proof-session-redacted') || JSON.stringify(snapshot).includes('agent:main:webchat:direct:redacted') }, null, 2));
NODE
```

**Evidence after fix:**

Terminal output from the real local runtime module path:

```json
{
  "eventCount": 1,
  "summary": {
    "byType": {
      "harness.selection": 1
    }
  },
  "events": [
    {
      "seq": 1,
      "ts": 1779763310898,
      "type": "harness.selection",
      "source": "codex",
      "provider": "openai",
      "model": "gpt-5.4",
      "channel": "webchat",
      "mode": "codex",
      "outcome": "implicit_plugin",
      "target": "main",
      "reason": "openai_official_default_codex",
      "level": "warning"
    }
  ],
  "containsSecrets": false
}
```

**Observed result after fix:**
The trusted `harness.selection` event is present in the sanitized stability snapshot as an operator-safe warning record. The snapshot exposes the selected harness, provider, model, channel, runtime mode, selection reason, agent target, and stable warning reason, while omitting raw `runId`, `sessionId`, and `sessionKey`.

**What was not tested:**
I did not run a full live external provider request. The proof exercises the actual diagnostic event/stability recorder path locally and the focused regression test covers the harness selection emission path.
