### PR TITLE
fix(agents): cap MiniMax /btw side-question tokens

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -356,6 +356,27 @@ describe("anthropic transport stream", () => {
     expect(latestAnthropicRequest().payload.stream).toBe(true);
   });
 
+  it("caps default max_tokens for large-output Anthropic-compatible models", async () => {
+    await runTransportStream(
+      makeAnthropicTransportModel({
+        provider: "minimax-portal",
+        id: "MiniMax-M2.7",
+        baseUrl: "https://api.minimax.io/anthropic",
+        maxTokens: 196_608,
+      }),
+      {
+        messages: [{ role: "user", content: "hello" }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-minimax-redacted",
+      } as AnthropicStreamOptions,
+    );
+
+    expect(latestAnthropicRequest().payload.model).toBe("MiniMax-M2.7");
+    expect(latestAnthropicRequest().payload.max_tokens).toBe(32_000);
+    expect(latestAnthropicRequest().payload.stream).toBe(true);
+  });
+
   it("fails locally when Anthropic maxTokens is non-positive after resolution", async () => {
     const model = attachModelProviderRequestTransport(
       {

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -20,6 +20,7 @@ const resolveAgentWorkspaceDirMock = vi.fn();
 const listAgentEntriesMock = vi.fn();
 const prepareProviderRuntimeAuthMock = vi.fn();
 const registerProviderStreamForModelMock = vi.fn();
+const resolveEmbeddedAgentStreamFnMock = vi.fn();
 const diagDebugMock = vi.fn();
 
 vi.mock("@earendil-works/pi-ai", async () => {
@@ -81,6 +82,10 @@ vi.mock("../plugins/provider-runtime.js", () => ({
 vi.mock("./provider-stream.js", () => ({
   registerProviderStreamForModel: (...args: unknown[]) =>
     registerProviderStreamForModelMock(...args),
+}));
+
+vi.mock("./pi-embedded-runner/stream-resolution.js", () => ({
+  resolveEmbeddedAgentStreamFn: (...args: unknown[]) => resolveEmbeddedAgentStreamFnMock(...args),
 }));
 
 vi.mock("./auth-profiles/session-override.js", () => ({
@@ -370,6 +375,7 @@ describe("runBtwSideQuestion", () => {
     listAgentEntriesMock.mockReset();
     prepareProviderRuntimeAuthMock.mockReset();
     registerProviderStreamForModelMock.mockReset();
+    resolveEmbeddedAgentStreamFnMock.mockReset();
     diagDebugMock.mockReset();
     clearAgentHarnesses();
 
@@ -407,6 +413,11 @@ describe("runBtwSideQuestion", () => {
     listAgentEntriesMock.mockReturnValue([]);
     prepareProviderRuntimeAuthMock.mockResolvedValue(undefined);
     registerProviderStreamForModelMock.mockReturnValue(undefined);
+    resolveEmbeddedAgentStreamFnMock.mockImplementation(
+      (params: { currentStreamFn: unknown; providerStreamFn?: unknown }) => {
+        return params.providerStreamFn ?? params.currentStreamFn;
+      },
+    );
   });
 
   it("streams blocks without persisting BTW data to disk", async () => {
@@ -661,13 +672,58 @@ describe("runBtwSideQuestion", () => {
     expect(streamSimpleMock).not.toHaveBeenCalled();
   });
 
-  it("falls back to streamSimple when no provider stream fn is registered", async () => {
+  it("routes MiniMax Anthropic fallback streams through the embedded resolver", async () => {
+    resolveModelWithRegistryMock.mockReturnValue({
+      provider: "minimax-portal",
+      id: "MiniMax-M2.7",
+      api: "anthropic-messages",
+      baseUrl: "https://api.minimax.io/anthropic",
+      maxTokens: 196_608,
+    });
+    registerProviderStreamForModelMock.mockReturnValue(undefined);
+    const resolvedStreamFn = vi
+      .fn()
+      .mockReturnValue(makeAsyncEvents([createDoneEvent("MiniMax answer.")]));
+    resolveEmbeddedAgentStreamFnMock.mockReturnValueOnce(resolvedStreamFn);
+
+    const result = await runSideQuestion({
+      provider: "minimax-portal",
+      model: "MiniMax-M2.7",
+    });
+
+    expect(result).toEqual({ text: "MiniMax answer." });
+    const resolverParams = expectRecordFields(mockArg(resolveEmbeddedAgentStreamFnMock, 0, 0), {
+      sessionId: "session-1",
+      resolvedApiKey: "secret",
+      authProfileId: "profile-1",
+    });
+    expect(resolverParams.providerStreamFn).toBeUndefined();
+    expectRecordFields(resolverParams.model, {
+      provider: "minimax-portal",
+      id: "MiniMax-M2.7",
+      api: "anthropic-messages",
+      maxTokens: 196_608,
+    });
+    expect(resolvedStreamFn).toHaveBeenCalledTimes(1);
+    expect(streamSimpleMock).not.toHaveBeenCalled();
+  });
+
+  it("uses the embedded resolver fallback when no provider stream fn is registered", async () => {
     registerProviderStreamForModelMock.mockReturnValue(undefined);
     mockDoneAnswer("Fallback answer.");
 
     const result = await runSideQuestion();
 
     expect(result).toEqual({ text: "Fallback answer." });
+    expect(resolveEmbeddedAgentStreamFnMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currentStreamFn: expect.any(Function),
+        providerStreamFn: undefined,
+        sessionId: "session-1",
+        resolvedApiKey: "secret",
+        authProfileId: "profile-1",
+      }),
+    );
     expect(streamSimpleMock).toHaveBeenCalledTimes(1);
   });
 

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -29,6 +29,7 @@ import { EmbeddedBlockChunker, type BlockReplyChunking } from "./pi-embedded-blo
 import { resolveModelWithRegistry } from "./pi-embedded-runner/model.js";
 import { getActiveEmbeddedRunSnapshot } from "./pi-embedded-runner/runs.js";
 import { streamWithPayloadPatch } from "./pi-embedded-runner/stream-payload-utils.js";
+import { resolveEmbeddedAgentStreamFn } from "./pi-embedded-runner/stream-resolution.js";
 import { discoverAuthStorage, discoverModels } from "./pi-model-discovery.js";
 import { registerProviderStreamForModel } from "./provider-stream.js";
 import { stripToolResultDetails } from "./session-transcript-repair.js";
@@ -447,6 +448,15 @@ export async function runBtwSideQuestion(
     workspaceDir,
     env: process.env,
   });
+  const streamFn = resolveEmbeddedAgentStreamFn({
+    currentStreamFn: streamSimple,
+    providerStreamFn,
+    sessionId,
+    signal: params.opts?.abortSignal,
+    model: runtimeModel,
+    resolvedApiKey: apiKey,
+    authProfileId,
+  });
 
   const chunker =
     params.opts?.onBlockReply && params.blockReplyChunking
@@ -475,7 +485,7 @@ export async function runBtwSideQuestion(
   };
 
   const stream = await streamWithPayloadPatch(
-    providerStreamFn ?? streamSimple,
+    streamFn,
     runtimeModel,
     {
       systemPrompt: buildBtwSystemPrompt(),


### PR DESCRIPTION
## Summary

This fixes #86116 by routing `/btw` side-question streams through the same embedded stream resolver used by normal chat.

- Root cause: `/btw` asked `registerProviderStreamForModel` for a provider-owned stream and fell back directly to `streamSimple` when none was registered. MiniMax uses Anthropic-compatible runtime hooks but does not provide a provider-owned `createStreamFn`, so `/btw` could bypass OpenClaw's Anthropic transport and send `model.maxTokens` as `max_tokens`.
- The fix preserves provider-owned stream behavior for providers such as Ollama, while sending fallback streams through `resolveEmbeddedAgentStreamFn` so Anthropic-compatible models get OpenClaw's existing request shaping and token cap.
- Added regression coverage for MiniMax-M2.7 `/btw` routing and for the Anthropic-compatible transport cap when model metadata advertises a very large output token limit.
- Security/runtime controls unchanged: this does not change auth resolution, provider runtime auth, tool availability, transcript shaping, or prompt-only policy. `/btw` remains tool-less and still strips empty tool arrays at payload patch time.

Intentionally out of scope:

- Changing MiniMax catalog values or provider defaults.
- Changing the 32k default Anthropic-compatible transport cap.
- Adding new channel-specific `/btw` behavior.
- Changing normal chat stream resolution.

Success looks like `/btw` and normal chat using the same fallback transport semantics for MiniMax Anthropic-compatible models, with no regression to provider-owned stream functions.

Reviewers should focus on the resolver handoff in `src/agents/btw.ts` and the MiniMax/max_tokens assertions in the focused tests.

## Linked context

Closes #86116

Related issue: https://github.com/openclaw/openclaw/issues/86116

## Real behavior proof (required for external PRs)

Machine-readable maintainer proof:
Behavior or issue addressed: `/btw` side questions for MiniMax Anthropic-compatible models now use the same embedded stream resolver as normal chat, so they do not bypass OpenClaw's Anthropic transport and send an oversized uncapped `max_tokens` value.
Real environment tested: macOS local source checkout, Node v24.8.0, pnpm 11.2.2, OpenClaw checkout ca70015a7c before this branch commit, plus maintainer refresh on local Node 24.15.0 focused `/btw` and Anthropic-compatible transport tests.
Exact steps or command run after this patch: `openclaw update --dry-run --json`, checked local `openclaw --version`, ran `node scripts/run-vitest.mjs src/agents/btw.test.ts src/agents/anthropic-transport-stream.test.ts`, and maintainer-ran `CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 fnm exec --using v24.15.0 -- node scripts/run-vitest.mjs run src/agents/btw.test.ts src/agents/anthropic-transport-stream.test.ts --reporter=dot --pool=forks --no-file-parallelism`.
Evidence after fix: The real command output below shows the patched checkout/version, `openclaw update --dry-run --json` runtime output, focused verbose behavior tests, full focused file tests, and maintainer refresh passing 4 files / 134 tests.
Observed result after fix: MiniMax-M2.7 `/btw` resolves through the embedded stream path rather than direct `streamSimple`, and the Anthropic-compatible transport emits `max_tokens: 32000` instead of the advertised `196608`.
What was not tested: a live MiniMax provider request through Telegram/webchat; no MiniMax or channel credentials were available in the proof shell, and no secrets were printed.

- Behavior or issue addressed: `/btw` side questions for MiniMax Anthropic-compatible models now use the same embedded stream resolver as normal chat. This prevents `/btw` from bypassing OpenClaw's Anthropic transport and sending an oversized uncapped `max_tokens` value.

- Real environment tested: macOS local source checkout, Node v24.8.0, pnpm 11.2.2, OpenClaw checkout ca70015a7c before this branch commit. Local `openclaw` command was pointed at this patched checkout and reported `OpenClaw 2026.5.25 (ca70015)`.

- Exact steps or command run after this patch:

```bash
pnpm build
printf 'node=' && node --version
printf 'pnpm=' && pnpm --version
printf 'openclaw=' && openclaw --version
printf 'git=' && git rev-parse --short HEAD
openclaw update --dry-run --json
node -e "const keys=['MINIMAX_API_KEY','MINIMAX_OAUTH_TOKEN','TELEGRAM_BOT_TOKEN','DISCORD_TOKEN','SLACK_BOT_TOKEN']; const present=keys.filter(k=>Boolean(process.env[k])); console.log('liveCredentialKeysPresent='+(present.length?present.join(','):'none'));"
node scripts/run-vitest.mjs src/agents/btw.test.ts src/agents/anthropic-transport-stream.test.ts -t "routes MiniMax Anthropic fallback streams through the embedded resolver|caps default max_tokens for large-output Anthropic-compatible models" --reporter=verbose
node scripts/run-vitest.mjs src/agents/btw.test.ts src/agents/anthropic-transport-stream.test.ts
git diff --check
pnpm check:changed
```

- Evidence after fix:

Build proof:

```text
$ pnpm build
[build-all] plugins:assets:build
[build-all] tsdown
[build-all] check-cli-bootstrap-imports
CLI bootstrap import guard passed.
[build-all] runtime-postbuild
runtime-postbuild: plugin SDK root alias completed
runtime-postbuild: bundled plugin metadata completed
runtime-postbuild: official channel catalog completed
runtime-postbuild: bundled plugin runtime overlay completed
runtime-postbuild: static extension assets completed
runtime-postbuild: stable root runtime imports completed
runtime-postbuild: stable root runtime aliases completed
[build-all] build:plugin-sdk:dts
[build-all] check-plugin-sdk-exports
OK: All 4 required plugin-sdk exports verified.
[build-all] write-cli-compat
```

Environment/update proof:

```text
node=v24.8.0
pnpm=11.2.2
openclaw=OpenClaw 2026.5.25 (ca70015)
git=ca70015a7c
{
  "dryRun": true,
  "root": "/Users/neeravmakwana/Desktop/github_repos/openclaw_1",
  "installKind": "git",
  "mode": "git",
  "updateInstallKind": "git",
  "switchToGit": false,
  "switchToPackage": false,
  "restart": true,
  "requestedChannel": null,
  "storedChannel": "beta",
  "effectiveChannel": "beta",
  "tag": "beta",
  "currentVersion": null,
  "targetVersion": null,
  "downgradeRisk": false,
  "actions": [
    "Run git update flow on channel beta (fetch/rebase/build/doctor)",
    "Run plugin update sync after core update",
    "Refresh shell completion cache (if needed)",
    "Restart gateway service and run doctor checks"
  ],
  "notes": []
}
liveCredentialKeysPresent=none
```

Focused verbose behavior proof:

```text
$ node scripts/run-vitest.mjs src/agents/btw.test.ts src/agents/anthropic-transport-stream.test.ts -t "routes MiniMax Anthropic fallback streams through the embedded resolver|caps default max_tokens for large-output Anthropic-compatible models" --reporter=verbose

RUN  v4.1.7 /Users/neeravmakwana/Desktop/github_repos/openclaw_1

✓ src/agents/anthropic-transport-stream.test.ts > anthropic transport stream > caps default max_tokens for large-output Anthropic-compatible models
✓ src/agents/btw.test.ts > runBtwSideQuestion > routes MiniMax Anthropic fallback streams through the embedded resolver

Test Files  4 passed (4)
Tests  4 passed | 130 skipped (134)
Duration  4.60s
```

Full focused file proof:

```text
$ node scripts/run-vitest.mjs src/agents/btw.test.ts src/agents/anthropic-transport-stream.test.ts

RUN  v4.1.7 /Users/neeravmakwana/Desktop/github_repos/openclaw_1

Test Files  4 passed (4)
Tests  134 passed (134)
Duration  5.33s
```

Changed-code gate proof:

```text
$ git diff --check
(no output)

$ pnpm check:changed
[check:changed] lanes=core, coreTests
[check:changed] src/agents/anthropic-transport-stream.test.ts: core test
[check:changed] src/agents/btw.test.ts: core test
[check:changed] src/agents/btw.ts: core production
[check:changed] conflict markers
[check:changed] changelog attributions
[check:changed] guarded extension wildcard re-exports
No guarded extension wildcard re-exports found.
[check:changed] plugin-sdk wildcard re-exports
No plugin-sdk wildcard re-exports found in extension API barrels.
[check:changed] duplicate scan target coverage
[dup:check] target coverage ok
[check:changed] dependency pin guard
PASS direct dependency pin guard: checked 435 directly declared dependency specs across 132 tracked package manifests; 0 violations.
[check:changed] package patch guard
PASS package patch guard: no new pnpm patches; 3 legacy patches allowlisted.
[check:changed] typecheck core
[check:changed] typecheck core tests
[check:changed] lint core
[check:changed] media download helper guard
[check:changed] runtime sidecar loader guard
runtime-sidecar-loaders: local runtime sidecar loaders look OK.
[check:changed] runtime import cycles
Import cycle check: 0 runtime value cycle(s).
[check:changed] webhook body guard
[check:changed] pairing store guard
[check:changed] pairing account guard
```

- Observed result after fix: The `/btw` MiniMax-M2.7 fallback path now calls `resolveEmbeddedAgentStreamFn` instead of directly using `streamSimple`. The regression test covers a MiniMax Anthropic-compatible model with `maxTokens: 196608` and proves `/btw` uses the resolved stream function, not direct `streamSimple`. The transport test proves that the Anthropic-compatible request for `MiniMax-M2.7` emits `max_tokens: 32000`, not `196608`.

- What was not tested: A live MiniMax request through Telegram/webchat was not run from this shell.

- Proof limitations or environment constraints: The local environment did not expose `MINIMAX_API_KEY`, `MINIMAX_OAUTH_TOKEN`, `TELEGRAM_BOT_TOKEN`, `DISCORD_TOKEN`, or `SLACK_BOT_TOKEN`, so the real-message channel screenshot path was unavailable. No credential values were printed.

- Before evidence: Before this patch, the existing focused `/btw` test asserted the no-provider-stream path fell directly back to `streamSimple`:

```text
$ node scripts/run-vitest.mjs src/agents/btw.test.ts -t "falls back to streamSimple when no provider stream fn is registered"

RUN  v4.1.7 /Users/neeravmakwana/Desktop/github_repos/openclaw_1

Test Files  2 passed (2)
Tests  2 passed | 54 skipped (56)
Duration  5.13s
```

## Tests and validation

Commands run:

```bash
pnpm build
node scripts/run-vitest.mjs src/agents/btw.test.ts src/agents/anthropic-transport-stream.test.ts -t "routes MiniMax Anthropic fallback streams through the embedded resolver|caps default max_tokens for large-output Anthropic-compatible models" --reporter=verbose
node scripts/run-vitest.mjs src/agents/btw.test.ts src/agents/anthropic-transport-stream.test.ts
git diff --check
pnpm check:changed
```

Regression coverage added:

- `/btw` MiniMax-M2.7 fallback stream routing now asserts `resolveEmbeddedAgentStreamFn` is used and `streamSimple` is not called directly.
- Generic `/btw` fallback test now asserts the embedded resolver is invoked.
- Anthropic-compatible transport test asserts a large `model.maxTokens` value is capped to `max_tokens: 32000` by default.

What failed before this fix: Source inspection and the pre-patch focused test showed `/btw` used direct `streamSimple` fallback when no provider-owned stream function was registered. That is the path that can send `model.maxTokens` directly for Anthropic-compatible MiniMax models.

## Risk checklist

Did user-visible behavior change? Yes. `/btw` side questions should now match normal chat's fallback transport behavior for Anthropic-compatible MiniMax models.

Did config, environment, or migration behavior change? No.

Did security, auth, secrets, network, or tool execution behavior change? No. Existing auth resolution and provider runtime auth are still used; this only reuses the existing embedded stream resolver for fallback stream selection. `/btw` remains tool-less and this PR does not loosen tool execution or rely on prompt text for runtime enforcement.

Highest-risk area: Provider stream selection for `/btw` fallback paths.

How that risk is mitigated: Provider-owned stream functions still take precedence, preserving the Ollama Cloud fix path, and focused tests cover both MiniMax fallback routing and the transport-level token cap.

Why the fix is safe:

- It reuses the same resolver normal embedded chat already uses rather than adding provider-specific MiniMax branching.
- Existing runtime auth and auth profile values are passed through to the resolver.
- Provider-owned stream functions remain preferred, so provider-specific URL construction continues to work.
- The cap behavior is covered at the transport layer rather than relying on prompt text or provider error handling.

## Current review state

Next action: maintainer review and CI.

Waiting on: CI and any maintainer-requested live MiniMax/channel proof with credentials.

Bot/reviewer comments addressed: none yet.

Made with [Cursor](https://cursor.com)


## Maintainer proof refresh
Behavior addressed: `/btw` side-question fallback streams now use the embedded stream resolver so Anthropic-compatible MiniMax models get OpenClaw request shaping and token caps.
Real environment tested: local Node 24.15.0 focused `/btw` and Anthropic-compatible transport tests.
Exact steps or command run after this patch: `CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 fnm exec --using v24.15.0 -- node scripts/run-vitest.mjs run src/agents/btw.test.ts src/agents/anthropic-transport-stream.test.ts --reporter=dot --pool=forks --no-file-parallelism`
Evidence after fix: 4 files, 134 tests passed.
Observed result after fix: MiniMax-M2.7 `/btw` resolves through the embedded stream path and the Anthropic-compatible transport caps large default `max_tokens` to 32,000.
What was not tested: live MiniMax credentials; the focused tests cover routing and request payload shaping without sending provider traffic.
