### PR TITLE
fix: seed cron task progress summaries

### DIFF
--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import * as detachedTaskRuntime from "../../tasks/detached-task-runtime.js";
 import { findTaskByRunId, resetTaskRegistryForTests } from "../../tasks/task-registry.js";
+import { formatTaskStatusDetail } from "../../tasks/task-status.js";
 import { setupCronServiceSuite, writeCronStoreSnapshot } from "../service.test-harness.js";
 import { loadCronStore } from "../store.js";
 import type { CronJob } from "../types.js";
@@ -132,11 +133,15 @@ function expectTaskRun(params: {
   runtime: string;
   status: string;
   sourceId: string;
+  progressSummary?: string;
 }) {
   const task = findTaskByRunId(params.runId);
   expect(task?.runtime).toBe(params.runtime);
   expect(task?.status).toBe(params.status);
   expect(task?.sourceId).toBe(params.sourceId);
+  if (params.progressSummary !== undefined) {
+    expect(task?.progressSummary).toBe(params.progressSummary);
+  }
 }
 
 function createMissedIsolatedJob(now: number): CronJob {
@@ -373,6 +378,7 @@ describe("cron service ops seam coverage", () => {
         runtime: "cron",
         status: "succeeded",
         sourceId: "isolated-timeout",
+        progressSummary: "Running cron job.",
       });
       expect(findTaskByRunId(manualRunId)).toBeUndefined();
     } finally {
@@ -546,7 +552,51 @@ describe("cron service ops seam coverage", () => {
         runtime: "cron",
         status: "timed_out",
         sourceId: "startup-timeout",
+        progressSummary: "Running cron job.",
       });
+    } finally {
+      restoreStateDir();
+    }
+  });
+
+  it("seeds active manual cron task progress for status surfaces", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-03-23T12:00:00.000Z");
+    const restoreStateDir = withStateDirForStorePath(storePath);
+
+    try {
+      await writeDueIsolatedJobSnapshot(storePath, now);
+      let resolveRun: ((value: { status: "ok"; summary: string }) => void) | undefined;
+      const state = createCronServiceState({
+        storePath,
+        cronEnabled: true,
+        log: logger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob: vi.fn(
+          () =>
+            new Promise<{ status: "ok"; summary: string }>((resolve) => {
+              resolveRun = resolve;
+            }),
+        ),
+      });
+
+      const manualRun = run(state, "isolated-timeout");
+      await vi.waitFor(() => {
+        expect(state.deps.runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+      });
+
+      const task = findTaskByRunId(`cron:isolated-timeout:${now}`);
+      if (!task) {
+        throw new Error("expected active manual cron task ledger record");
+      }
+      expect(task.status).toBe("running");
+      expect(task.progressSummary).toBe("Running cron job.");
+      expect(formatTaskStatusDetail(task)).toBe("Running cron job.");
+
+      resolveRun?.({ status: "ok", summary: "done" });
+      await manualRun;
     } finally {
       restoreStateDir();
     }

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -36,6 +36,7 @@ import { locked } from "./locked.js";
 import { normalizeOptionalAgentId } from "./normalize.js";
 import type { CronServiceState, CronWakeMode } from "./state.js";
 import { ensureLoaded, persist, warnIfDisabled } from "./store.js";
+import { CRON_TASK_RUNNING_PROGRESS_SUMMARY } from "./task-ledger.js";
 import {
   applyJobResult,
   armTimer,
@@ -582,6 +583,7 @@ function tryCreateManualTaskRun(params: {
       notifyPolicy: "silent",
       startedAt: params.startedAt,
       lastEventAt: params.startedAt,
+      progressSummary: CRON_TASK_RUNNING_PROGRESS_SUMMARY,
     });
     return runId;
   } catch (error) {

--- a/src/cron/service/task-ledger.ts
+++ b/src/cron/service/task-ledger.ts
@@ -1,0 +1,1 @@
+export const CRON_TASK_RUNNING_PROGRESS_SUMMARY = "Running cron job.";

--- a/src/cron/service/timer.test.ts
+++ b/src/cron/service/timer.test.ts
@@ -8,6 +8,7 @@ import { loadCronStore, saveCronStore } from "../../cron/store.js";
 import type { CronJob } from "../../cron/types.js";
 import * as detachedTaskRuntime from "../../tasks/detached-task-runtime.js";
 import { findTaskByRunId, resetTaskRegistryForTests } from "../../tasks/task-registry.js";
+import { formatTaskStatusDetail } from "../../tasks/task-status.js";
 
 const { logger, makeStorePath } = setupCronServiceSuite({
   prefix: "cron-service-timer-seam",
@@ -223,6 +224,51 @@ describe("cron service timer seam coverage", () => {
     expect(task.childSessionKey).toBe("agent:finn:cron:isolated-agent-job");
     expect(task.status).toBe("succeeded");
     expect(task.terminalSummary).toBe("done");
+  });
+
+  it("seeds active scheduled cron task progress for status surfaces", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-03-23T12:00:00.000Z");
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeat = vi.fn();
+    let resolveRun: ((value: { status: "ok"; summary: string }) => void) | undefined;
+    const runIsolatedAgentJob = vi.fn(
+      () =>
+        new Promise<{ status: "ok"; summary: string }>((resolve) => {
+          resolveRun = resolve;
+        }),
+    );
+
+    await writeCronStoreSnapshot({
+      storePath,
+      jobs: [createDueIsolatedAgentJob({ now })],
+    });
+
+    const state = createCronServiceState({
+      storePath,
+      cronEnabled: true,
+      log: logger,
+      nowMs: () => now,
+      enqueueSystemEvent,
+      requestHeartbeat,
+      runIsolatedAgentJob,
+    });
+
+    const timerRun = onTimer(state);
+    await vi.waitFor(() => {
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+    });
+
+    const task = findTaskByRunId(`cron:isolated-agent-job:${now}`);
+    if (!task) {
+      throw new Error("expected active cron task ledger record");
+    }
+    expect(task.status).toBe("running");
+    expect(task.progressSummary).toBe("Running cron job.");
+    expect(formatTaskStatusDetail(task)).toBe("Running cron job.");
+
+    resolveRun?.({ status: "ok", summary: "done" });
+    await timerRun;
   });
 
   it("keeps scheduler progress when task ledger creation fails", async () => {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -61,6 +61,7 @@ import {
 import { locked } from "./locked.js";
 import type { CronEvent, CronServiceState } from "./state.js";
 import { ensureLoaded, persist } from "./store.js";
+import { CRON_TASK_RUNNING_PROGRESS_SUMMARY } from "./task-ledger.js";
 import { resolveCronJobTimeoutMs } from "./timeout-policy.js";
 
 export { DEFAULT_JOB_TIMEOUT_MS } from "./timeout-policy.js";
@@ -512,6 +513,7 @@ function tryCreateCronTaskRun(params: {
       notifyPolicy: "silent",
       startedAt: params.startedAt,
       lastEventAt: params.startedAt,
+      progressSummary: CRON_TASK_RUNNING_PROGRESS_SUMMARY,
     });
     return runId;
   } catch (error) {


### PR DESCRIPTION
## Summary

- Fixes #63758.
- Seed active cron task rows with a shared `Running cron job.` progress summary.
- Apply the same task-ledger metadata to scheduled/startup cron runs and manual `cron run` executions.
- Add focused regression coverage for the raw task record and the status-detail formatter.

## AI assistance disclosure

Prepared with AI assistance from Codex. I inspected the current cron/task implementation, checked related GitHub issue/PR context, ran focused tests, ran changed-surface checks, ran `codex review`, and captured an isolated runtime proof before drafting this PR.

## Root Cause

Cron already creates shared task-registry rows through `createRunningTaskRun`, and the task status formatter already displays `progressSummary` for active tasks. The scheduled/startup helper in `src/cron/service/timer.ts` and the manual helper in `src/cron/service/ops.ts` simply did not populate `progressSummary`, so active cron tasks had no useful status detail until they reached a terminal state.

## Real behavior proof

Behavior addressed: Active cron task rows now expose a progress summary that task/status surfaces can display while the cron job is still running.

Real environment tested: Source runtime on Node 22 with `node --import tsx`, using the real cron service, real persisted cron store, real task registry, and real task status formatter in an isolated `OPENCLAW_STATE_DIR`.

Exact steps or command run after this patch:

```bash
PROOF_ROOT="$(mktemp -d "$PWD/.artifacts/proof/issue-63758-state-XXXXXX")" && HOME="$PROOF_ROOT/home" XDG_CONFIG_HOME="$PROOF_ROOT/xdg-config" OPENCLAW_STATE_DIR="$PROOF_ROOT/state" PATH="$PWD/.artifacts/bin:$PATH" node --import tsx .artifacts/proof/issue-63758-active-cron-progress.ts | tee .artifacts/proof/issue-63758-active-cron-progress.log
```

Evidence after fix:

```text
run_id=cron:issue-63758-proof-cron:1774267200000
active_task_status=running
active_progress_summary=Running cron job.
active_status_detail=Running cron job.
terminal_task_status=succeeded
terminal_summary=proof completed
```

Observed result after fix: The active cron task record has `progressSummary=Running cron job.`, and `formatTaskStatusDetail` returns the same display text before the cron run completes.

What was not tested: A provider-backed long-running model cron job, Docker/package build, and browser/UI rendering. The proof intentionally isolates the source runtime path that creates and formats the task row without using live credentials.

## Regression Test Plan

- `PATH="$PWD/.artifacts/bin:$PATH" OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree corepack pnpm test src/cron/service/timer.test.ts src/cron/service/ops.test.ts src/tasks/task-status.test.ts src/agents/openclaw-tools.session-status.test.ts -- --reporter=verbose`
- Scheduled cron coverage holds the isolated runner open and asserts active task `progressSummary` plus `formatTaskStatusDetail`.
- Manual cron coverage does the same through the `run` command path.
- Existing manual completion and startup timeout assertions now also verify the seeded progress metadata on updated task rows.

## Security Impact

No credential, auth, secret, network, or permission behavior changes. The new task text is static and does not include user input.

## Human Verification

No human-run live proof was required. The runtime proof used an isolated local state directory and no secrets. This PR should be safe for normal maintainer review plus CI.

## Risks

- The progress text is intentionally generic; richer dynamic cron phases would require a broader execution-state change.
- Raw terminal task rows may retain the last running progress summary, but terminal display paths already prefer terminal summaries or errors.
- The branch is based on `upstream/main` because this fork's `origin/main` is stale; changed checks and review used `--base upstream/main` to avoid unrelated fork drift.

## Validation

- `PATH="$PWD/.artifacts/bin:$PATH" corepack pnpm exec oxfmt --check --threads=1 src/cron/service/timer.ts src/cron/service/ops.ts src/cron/service/task-ledger.ts src/cron/service/timer.test.ts src/cron/service/ops.test.ts`
- `PATH="$PWD/.artifacts/bin:$PATH" OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree corepack pnpm test src/cron/service/timer.test.ts src/cron/service/ops.test.ts src/tasks/task-status.test.ts src/agents/openclaw-tools.session-status.test.ts -- --reporter=verbose`
- `PATH="$PWD/.artifacts/bin:$PATH" OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree corepack pnpm check:changed --base upstream/main`
- `codex review --base upstream/main`
- Runtime proof command shown above
