### PR TITLE
[codex] Fix memory-core REM light handoff

### DIFF
--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -18,7 +18,9 @@ import {
 } from "./dreaming-phases.js";
 import { previewRemHarness } from "./rem-harness.js";
 import {
+  applyShortTermPromotions,
   rankShortTermPromotionCandidates,
+  readShortTermRecallEntries,
   recordShortTermRecalls,
   resolveShortTermPhaseSignalStorePath,
   type ShortTermRecallEntry,
@@ -2534,6 +2536,349 @@ describe("memory-core dreaming phases", () => {
     const baselineSignals = phaseSignalStore.entries[baseline[0].key];
     expect(baselineSignals?.lightHits).toBe(1);
     expect(baselineSignals?.remHits).toBe(1);
+  });
+
+  it("keeps full-sweep REM candidate truths on the light-staged handoff", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    const sweepNowMs = Date.parse("2026-04-05T10:00:00.000Z");
+    await fs.writeFile(
+      path.join(workspaceDir, "memory", "2026-04-01.md"),
+      "Legacy runbook says always restart the gateway before checking credentials.\n",
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(workspaceDir, "memory", "2026-04-05.md"),
+      "Fresh customer handoff says verify the S3 Glacier restore window first.\n",
+      "utf-8",
+    );
+
+    for (const [index, day] of ["2026-04-01", "2026-04-02"].entries()) {
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: `legacy gateway recall ${index}`,
+        dayBucket: day,
+        nowMs: Date.parse(`${day}T09:00:00.000Z`),
+        results: [
+          {
+            path: "memory/2026-04-01.md",
+            startLine: 1,
+            endLine: 1,
+            score: 0.99,
+            snippet: "Legacy runbook says always restart the gateway before checking credentials.",
+            source: "memory",
+          },
+        ],
+      });
+    }
+    await recordShortTermRecalls({
+      workspaceDir,
+      query: "fresh glacier handoff",
+      dayBucket: "2026-04-05",
+      nowMs: Date.parse("2026-04-05T09:55:00.000Z"),
+      results: [
+        {
+          path: "memory/2026-04-05.md",
+          startLine: 1,
+          endLine: 1,
+          score: 0.9,
+          snippet: "Fresh customer handoff says verify the S3 Glacier restore window first.",
+          source: "memory",
+        },
+      ],
+    });
+
+    const candidates = await rankShortTermPromotionCandidates({
+      workspaceDir,
+      minScore: 0,
+      minRecallCount: 0,
+      minUniqueQueries: 0,
+      nowMs: sweepNowMs,
+    });
+    const legacyKey = requireCandidateKeyByPath(
+      candidates,
+      (candidatePath) => candidatePath === "memory/2026-04-01.md",
+      "legacy high-recall note",
+    );
+    const freshKey = requireCandidateKeyByPath(
+      candidates,
+      (candidatePath) => candidatePath === "memory/2026-04-05.md",
+      "fresh light-staged note",
+    );
+    const unfilteredRemPreview = testing.previewRemDreaming({
+      entries: filterRecallEntriesWithinLookback({
+        entries: await readShortTermRecallEntries({ workspaceDir, nowMs: sweepNowMs }),
+        nowMs: sweepNowMs,
+        lookbackDays: 7,
+      }),
+      limit: 1,
+      minPatternStrength: 0,
+    });
+    expect(unfilteredRemPreview.candidateKeys).toEqual([legacyKey]);
+
+    const testConfig: OpenClawConfig = {
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: true,
+                timezone: "UTC",
+                storage: { mode: "inline", separateReports: false },
+                phases: {
+                  light: {
+                    enabled: true,
+                    limit: 1,
+                    lookbackDays: 2,
+                  },
+                  rem: {
+                    enabled: true,
+                    limit: 1,
+                    lookbackDays: 7,
+                    minPatternStrength: 0,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    await runDreamingSweepPhases({
+      workspaceDir,
+      cfg: testConfig,
+      pluginConfig: resolveMemoryCorePluginConfig(testConfig),
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      nowMs: sweepNowMs,
+    });
+
+    const phaseSignalStore = JSON.parse(
+      await fs.readFile(resolveShortTermPhaseSignalStorePath(workspaceDir), "utf-8"),
+    ) as {
+      entries: Record<string, { lightHits?: number; remHits?: number }>;
+    };
+    expect(phaseSignalStore.entries[freshKey]?.lightHits).toBe(1);
+    expect(phaseSignalStore.entries[freshKey]?.remHits).toBe(1);
+    expect(phaseSignalStore.entries[legacyKey]?.remHits).toBeUndefined();
+
+    const dailyOutput = await fs.readFile(
+      path.join(workspaceDir, "memory", `${DREAMING_TEST_DAY}.md`),
+      "utf-8",
+    );
+    expect(dailyOutput).toContain("Fresh customer handoff says verify the S3 Glacier");
+    expect(dailyOutput).not.toContain("Legacy runbook says always restart the gateway");
+  });
+
+  it("falls back to REM lookback when the full-sweep light handoff is empty", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    const sweepNowMs = Date.parse("2026-04-05T10:00:00.000Z");
+    await fs.writeFile(
+      path.join(workspaceDir, "memory", "2026-04-01.md"),
+      "Dormant incident note says rotate webhook secrets after closure.\n",
+      "utf-8",
+    );
+    await recordShortTermRecalls({
+      workspaceDir,
+      query: "dormant incident recall",
+      dayBucket: "2026-04-01",
+      nowMs: Date.parse("2026-04-01T09:00:00.000Z"),
+      results: [
+        {
+          path: "memory/2026-04-01.md",
+          startLine: 1,
+          endLine: 1,
+          score: 0.95,
+          snippet: "Dormant incident note says rotate webhook secrets after closure.",
+          source: "memory",
+        },
+      ],
+    });
+
+    const candidates = await rankShortTermPromotionCandidates({
+      workspaceDir,
+      minScore: 0,
+      minRecallCount: 0,
+      minUniqueQueries: 0,
+      nowMs: sweepNowMs,
+    });
+    const dormantKey = requireCandidateKeyByPath(
+      candidates,
+      (candidatePath) => candidatePath === "memory/2026-04-01.md",
+      "REM-lookback note outside light handoff",
+    );
+
+    const testConfig: OpenClawConfig = {
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: true,
+                timezone: "UTC",
+                storage: { mode: "inline", separateReports: false },
+                phases: {
+                  light: {
+                    enabled: true,
+                    limit: 1,
+                    lookbackDays: 2,
+                  },
+                  rem: {
+                    enabled: true,
+                    limit: 1,
+                    lookbackDays: 7,
+                    minPatternStrength: 0,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    await runDreamingSweepPhases({
+      workspaceDir,
+      cfg: testConfig,
+      pluginConfig: resolveMemoryCorePluginConfig(testConfig),
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      nowMs: sweepNowMs,
+    });
+
+    const phaseSignalStore = JSON.parse(
+      await fs.readFile(resolveShortTermPhaseSignalStorePath(workspaceDir), "utf-8"),
+    ) as {
+      entries: Record<string, { lightHits?: number; remHits?: number }>;
+    };
+    expect(phaseSignalStore.entries[dormantKey]?.lightHits ?? 0).toBe(0);
+    expect(phaseSignalStore.entries[dormantKey]?.remHits).toBe(1);
+
+    const dailyOutput = await fs.readFile(
+      path.join(workspaceDir, "memory", `${DREAMING_TEST_DAY}.md`),
+      "utf-8",
+    );
+    expect(dailyOutput).toContain("Dormant incident note says rotate webhook secrets");
+  });
+
+  it("falls back to REM lookback when light-staged keys are not REM-eligible", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    const sweepNowMs = Date.parse("2026-04-05T10:00:00.000Z");
+    await fs.writeFile(
+      path.join(workspaceDir, "memory", "2026-04-01.md"),
+      "Older unpromoted runbook says page storage before restarting workers.\n",
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(workspaceDir, "memory", "2026-04-05.md"),
+      "Recently promoted handoff says record the billing export checksum.\n",
+      "utf-8",
+    );
+    await recordShortTermRecalls({
+      workspaceDir,
+      query: "older storage recall",
+      dayBucket: "2026-04-01",
+      nowMs: Date.parse("2026-04-01T09:00:00.000Z"),
+      results: [
+        {
+          path: "memory/2026-04-01.md",
+          startLine: 1,
+          endLine: 1,
+          score: 0.95,
+          snippet: "Older unpromoted runbook says page storage before restarting workers.",
+          source: "memory",
+        },
+      ],
+    });
+    await recordShortTermRecalls({
+      workspaceDir,
+      query: "fresh billing checksum",
+      dayBucket: "2026-04-05",
+      nowMs: Date.parse("2026-04-05T09:55:00.000Z"),
+      results: [
+        {
+          path: "memory/2026-04-05.md",
+          startLine: 1,
+          endLine: 1,
+          score: 0.99,
+          snippet: "Recently promoted handoff says record the billing export checksum.",
+          source: "memory",
+        },
+      ],
+    });
+
+    const candidates = await rankShortTermPromotionCandidates({
+      workspaceDir,
+      minScore: 0,
+      minRecallCount: 0,
+      minUniqueQueries: 0,
+      nowMs: sweepNowMs,
+    });
+    const olderKey = requireCandidateKeyByPath(
+      candidates,
+      (candidatePath) => candidatePath === "memory/2026-04-01.md",
+      "older REM candidate",
+    );
+    const promotedKey = requireCandidateKeyByPath(
+      candidates,
+      (candidatePath) => candidatePath === "memory/2026-04-05.md",
+      "fresh promoted handoff",
+    );
+    await applyShortTermPromotions({
+      workspaceDir,
+      candidates: [requireCandidateByKey(candidates, promotedKey)],
+      minScore: 0,
+      minRecallCount: 0,
+      minUniqueQueries: 0,
+      nowMs: Date.parse("2026-04-05T09:56:00.000Z"),
+    });
+
+    const testConfig: OpenClawConfig = {
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: true,
+                timezone: "UTC",
+                storage: { mode: "inline", separateReports: false },
+                phases: {
+                  light: {
+                    enabled: true,
+                    limit: 1,
+                    lookbackDays: 2,
+                  },
+                  rem: {
+                    enabled: true,
+                    limit: 1,
+                    lookbackDays: 7,
+                    minPatternStrength: 0,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    await runDreamingSweepPhases({
+      workspaceDir,
+      cfg: testConfig,
+      pluginConfig: resolveMemoryCorePluginConfig(testConfig),
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      nowMs: sweepNowMs,
+    });
+
+    const phaseSignalStore = JSON.parse(
+      await fs.readFile(resolveShortTermPhaseSignalStorePath(workspaceDir), "utf-8"),
+    ) as {
+      entries: Record<string, { lightHits?: number; remHits?: number }>;
+    };
+    expect(phaseSignalStore.entries[promotedKey]?.lightHits).toBe(1);
+    expect(phaseSignalStore.entries[promotedKey]?.remHits ?? 0).toBe(0);
+    expect(phaseSignalStore.entries[olderKey]?.remHits).toBe(1);
+
+    const dailyOutput = await fs.readFile(
+      path.join(workspaceDir, "memory", `${DREAMING_TEST_DAY}.md`),
+      "utf-8",
+    );
+    expect(dailyOutput).toContain("Older unpromoted runbook says page storage");
   });
 
   it("skips REM short-term candidates whose source file disappeared", async () => {

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -1607,7 +1607,7 @@ async function runLightDreaming(params: {
   subagent?: Parameters<typeof generateAndAppendDreamNarrative>[0]["subagent"];
   detachNarratives?: boolean;
   nowMs?: number;
-}): Promise<void> {
+}): Promise<string[]> {
   const nowMs = Number.isFinite(params.nowMs) ? (params.nowMs as number) : Date.now();
   await ingestDailyMemorySignals({
     workspaceDir: params.workspaceDir,
@@ -1645,6 +1645,7 @@ async function runLightDreaming(params: {
     params.config.dedupeSimilarity,
   );
   const capped = entries.slice(0, params.config.limit);
+  const stagedKeys = capped.map((entry) => entry.key);
   const bodyLines = buildLightDreamingBody(capped);
   await writeDailyDreamingPhaseBlock({
     workspaceDir: params.workspaceDir,
@@ -1657,7 +1658,7 @@ async function runLightDreaming(params: {
   await recordDreamingPhaseSignals({
     workspaceDir: params.workspaceDir,
     phase: "light",
-    keys: capped.map((entry) => entry.key),
+    keys: stagedKeys,
     nowMs,
   });
   if (params.config.enabled && entries.length > 0 && params.config.storage.mode !== "separate") {
@@ -1695,6 +1696,7 @@ async function runLightDreaming(params: {
       });
     }
   }
+  return stagedKeys;
 }
 
 async function runRemDreaming(params: {
@@ -1703,6 +1705,7 @@ async function runRemDreaming(params: {
   primaryWorkspaceDir?: string;
   config: RemDreamingConfig;
   logger: Logger;
+  stagedCandidateKeys?: readonly string[];
   subagent?: Parameters<typeof generateAndAppendDreamNarrative>[0]["subagent"];
   detachNarratives?: boolean;
   nowMs?: number;
@@ -1723,7 +1726,7 @@ async function runRemDreaming(params: {
     nowMs,
     timezone: params.config.timezone,
   });
-  const entries = await filterLiveShortTermRecallEntries({
+  const allEntries = await filterLiveShortTermRecallEntries({
     workspaceDir: params.workspaceDir,
     entries: filterRecallEntriesWithinLookback({
       entries: await readShortTermRecallEntries({ workspaceDir: params.workspaceDir, nowMs }),
@@ -1731,11 +1734,29 @@ async function runRemDreaming(params: {
       lookbackDays: params.config.lookbackDays,
     }),
   });
-  const preview = previewRemDreaming({
+  const stagedCandidateKeys = params.stagedCandidateKeys?.map((key) => key.trim()).filter(Boolean);
+  const stagedCandidateKeySet =
+    stagedCandidateKeys === undefined || stagedCandidateKeys.length === 0
+      ? undefined
+      : new Set(stagedCandidateKeys);
+  // Use light handoff when it yields REM truths; otherwise keep REM's wider lookback.
+  let entries =
+    stagedCandidateKeySet === undefined
+      ? allEntries
+      : allEntries.filter((entry) => stagedCandidateKeySet.has(entry.key));
+  let preview = previewRemDreaming({
     entries,
     limit: params.config.limit,
     minPatternStrength: params.config.minPatternStrength,
   });
+  if (stagedCandidateKeySet !== undefined && preview.candidateKeys.length === 0) {
+    entries = allEntries;
+    preview = previewRemDreaming({
+      entries,
+      limit: params.config.limit,
+      minPatternStrength: params.config.minPatternStrength,
+    });
+  }
   await writeDailyDreamingPhaseBlock({
     workspaceDir: params.workspaceDir,
     phase: "rem",
@@ -1812,8 +1833,9 @@ export async function runDreamingSweepPhases(params: {
     pluginConfig: params.pluginConfig,
     cfg: params.cfg as Parameters<typeof resolveMemoryLightDreamingConfig>[0]["cfg"],
   });
+  let lightStagedKeys: string[] | undefined;
   if (light.enabled && light.limit > 0) {
-    await runLightDreaming({
+    lightStagedKeys = await runLightDreaming({
       workspaceDir: params.workspaceDir,
       cfg: params.cfg,
       config: light,
@@ -1834,6 +1856,7 @@ export async function runDreamingSweepPhases(params: {
       cfg: params.cfg,
       config: rem,
       logger: params.logger,
+      stagedCandidateKeys: lightStagedKeys,
       subagent: params.subagent,
       nowMs: sweepNowMs,
       detachNarratives: params.detachNarratives,


### PR DESCRIPTION
## Summary
- Carry full-sweep light dreaming staged candidate keys into REM candidate-truth selection.
- Preserve direct/standalone REM lookback behavior.
- Fall back to REM's normal lookback when the light handoff is empty or cannot yield REM candidate truth keys.

Fixes #86249.

## AI assistance disclosure
This PR was prepared with AI assistance.

## Real behavior proof
Behavior addressed: Full light -> REM dreaming sweeps now let REM candidate truths follow the same-sweep light-staged handoff when that handoff yields REM candidate truth keys.

Real environment tested: Local source checkout, Node v22.22.0, temporary memory workspace, actual `runDreamingSweepPhases` implementation.

Exact steps or command run after this patch: Ran `node --import tsx --input-type=module` with an inline script that created a temporary memory workspace, wrote old and fresh daily memory files, recorded short-term recalls, confirmed unfiltered REM would choose the old key, then ran the actual `runDreamingSweepPhases` path and checked the resulting phase signals plus managed daily output.

Evidence after fix: Copied terminal output from the after-fix real behavior proof command:

```text
issue=86249
environment=local source checkout, Node v22.22.0, temp memory workspace
actual_path=runDreamingSweepPhases -> runLightDreaming -> runRemDreaming
unfiltered_rem_would_choose=memory:memory/2026-04-01.md:1:1
light_staged_key=memory:memory/2026-04-05.md:1:1
fresh_light_hits=1
fresh_rem_hits=1
legacy_rem_hits=0
daily_output_has_fresh_candidate_truth=true
daily_output_has_legacy_candidate_truth=false
status=ok
```

Observed result after fix: The real source path showed that unfiltered REM would have selected the older legacy key, but the full sweep selected the fresh light-staged key and recorded matching light/REM phase signals while keeping the legacy key at `legacy_rem_hits=0`.

What was not tested: Broad CI, cross-OS proof, and live user memory integrations.

## Root Cause
`runDreamingSweepPhases` already runs light before REM, but `runLightDreaming` did not return the keys it staged. `runRemDreaming` then re-read and ranked the full REM lookback independently, so older high-recall entries could dominate REM candidate truth selection and fail to pair with the fresh light-staged entries.

## Regression Test Plan
Added behavior coverage in `extensions/memory-core/src/dreaming-phases.test.ts` for:
- REM using the full-sweep light handoff when unfiltered REM would choose an older high-recall key.
- REM falling back to its normal lookback when the light handoff is empty.
- REM falling back to its normal lookback when light-staged keys are already promoted and therefore cannot produce REM candidate truth keys.

## Security Impact
No new secret handling, auth, network, or permission surface. Test/proof data is synthetic and local.

## Human Verification
Please review the narrow handoff/fallback policy in `extensions/memory-core/src/dreaming-phases.ts`, especially the fallback after a staged handoff produces no REM candidate truth keys.

## Risks
The main risk is over-constraining REM. The fallback avoids that by narrowing only when the light handoff yields actual REM candidate truth keys; otherwise REM keeps the prior wider-lookback behavior. Direct REM triggers and `previewRemHarness` do not pass a handoff and remain on the standalone path.

## Validation
- `PATH=$PWD/.artifacts/bin:$PATH OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm test extensions/memory-core/src/dreaming-phases.test.ts -- --reporter=verbose` - 44 passed.
- `PATH=$PWD/.artifacts/bin:$PATH OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm check:changed --base upstream/main` - passed.
- `PATH=$PWD/.artifacts/bin:$PATH codex review --base upstream/main` - final review found no actionable correctness issues.
