### PR TITLE
fix(slack): keep downloaded files out of reply media

### DIFF
--- a/extensions/slack/src/action-runtime.test.ts
+++ b/extensions/slack/src/action-runtime.test.ts
@@ -448,6 +448,7 @@ describe("handleSlackAction", () => {
     });
     expect(details.media).toEqual({
       mediaUrl: "/tmp/openclaw-media/report.pdf",
+      outbound: false,
       contentType: "application/pdf",
     });
   });

--- a/extensions/slack/src/action-runtime.ts
+++ b/extensions/slack/src/action-runtime.ts
@@ -492,6 +492,7 @@ export async function handleSlackAction(
             placeholder: downloaded.placeholder,
             media: {
               mediaUrl: downloaded.path,
+              outbound: false,
               ...(downloaded.contentType ? { contentType: downloaded.contentType } : {}),
             },
           });
@@ -504,6 +505,7 @@ export async function handleSlackAction(
             fileId,
             path: downloaded.path,
             ...(downloaded.contentType ? { contentType: downloaded.contentType } : {}),
+            media: { outbound: false },
           },
         });
       }

--- a/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
@@ -664,6 +664,61 @@ describe("handleToolExecutionEnd media emission", () => {
     expect(ctx.state.pendingToolTrustedLocalMedia).toBe(true);
   });
 
+  it("does NOT queue structured media marked as non-outbound", async () => {
+    const ctx = createMockContext({
+      shouldEmitToolOutput: false,
+      onToolResult: vi.fn(),
+      builtinToolNames: new Set(["message"]),
+    });
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "message",
+      toolCallId: "tc-1",
+      isError: false,
+      result: {
+        content: [{ type: "text", text: "Downloaded Slack file to /tmp/report.pdf" }],
+        details: {
+          media: {
+            mediaUrl: "/tmp/report.pdf",
+            outbound: false,
+          },
+        },
+      },
+    });
+
+    expect(ctx.state.pendingToolMediaUrls).toStrictEqual([]);
+  });
+
+  it("does NOT queue image fallback paths when media is marked as non-outbound", async () => {
+    const ctx = createMockContext({
+      shouldEmitToolOutput: false,
+      onToolResult: vi.fn(),
+      builtinToolNames: new Set(["message"]),
+    });
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "message",
+      toolCallId: "tc-1",
+      isError: false,
+      result: {
+        content: [
+          { type: "text", text: "Downloaded Slack image" },
+          { type: "image", data: "base64", mimeType: "image/png" },
+        ],
+        details: {
+          path: "/tmp/slack-image.png",
+          media: {
+            outbound: false,
+          },
+        },
+      },
+    });
+
+    expect(ctx.state.pendingToolMediaUrls).toStrictEqual([]);
+  });
+
   it("queues trusted TTS local media when the exact built-in name is absent", async () => {
     const ctx = createMockContext({
       shouldEmitToolOutput: false,

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -463,6 +463,10 @@ function collectStructuredMediaUrls(media: Record<string, unknown>): string[] {
   return Array.from(new Set(urls));
 }
 
+function isNonOutboundToolResultMedia(media: Record<string, unknown>): boolean {
+  return media.outbound === false;
+}
+
 function extractTextContentMediaArtifact(content: unknown[]): {
   mediaUrls: string[];
   audioAsVoice?: boolean;
@@ -510,6 +514,9 @@ export function extractToolResultMediaArtifact(
   const record = result as Record<string, unknown>;
   const detailsMedia = readToolResultDetailsMedia(record);
   if (detailsMedia) {
+    if (isNonOutboundToolResultMedia(detailsMedia)) {
+      return undefined;
+    }
     const mediaUrls = collectStructuredMediaUrls(detailsMedia);
     if (mediaUrls.length > 0) {
       return {


### PR DESCRIPTION
## Summary
- Fixes #86300 by marking Slack `download-file` media as read-only/non-outbound while preserving the downloaded path and metadata for agent analysis.
- Teaches the shared tool-media extractor to skip structured media with `outbound: false`, including Slack image downloads that would otherwise fall back through `details.path`.
- Adds focused regressions for non-outbound structured media and image fallback suppression.

## Root Cause
Slack `download-file` is a read/intake action, but its tool result was shaped like outbound media: `details.media.mediaUrl` pointed at the downloaded local file. The shared tool-media path trusts the built-in `message` tool for local media, so it extracted that local downloaded file and merged it into the final visible reply payload. That could re-upload an inbound private Slack attachment even when the agent only downloaded it for analysis.

## Why This Fix Is Safe
The fix preserves the agent-readable file metadata (`path`, `contentType`, placeholder text, and `details.media.mediaUrl`) but adds an explicit runtime marker: `outbound: false`. The delivery pipeline now treats that marker as authoritative and refuses to queue it for auto-reply media. Explicit outbound flows remain unchanged: `MEDIA:` directives, generated media tools, TTS trusted media, and Slack send/upload actions still use the existing delivery paths.

Security/runtime controls unchanged: Slack read-target authorization, token selection, channel allowlist checks, max download size, local-media trust for explicit trusted tools, MCP/external local-media blocking, and outbound media loading policy are unchanged. This patch adds a runtime-enforced boundary; it does not rely on prompt text or model behavior.

## Verification
- `pnpm test extensions/slack/src/action-runtime.test.ts src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts src/agents/pi-embedded-runner/run/tool-media-payloads.test.ts`
  - Passed: 3 Vitest shards, 91 tests.
- `git diff --check`
  - Passed.
- `pnpm check:changed`
  - Passed: changed core/extension typecheck and lint lanes completed cleanly.

## Real behavior proof
- Behavior addressed: Slack `message.download-file` results remain readable by the agent but no longer become auto-reply outbound media for a plain final answer.
- Real environment tested: Local macOS source checkout at `9db04a27eb20` plus this patch, Node `v24.8.0`, Slack channel `C0B5897MA0M`, Slack bot token loaded from `.env` as `SLACK_BOT_TOKEN_1`. Token values, team/user/bot ids, and file ids are redacted below.
- Exact steps or command run after this patch:
  1. Ran the local live Slack proof script from the patched checkout: `OPENCLAW_BEHAVIOR_HEAD="$(git rev-parse --short=12 HEAD)" node --import tsx .artifacts/behavior-86300/slack-download-current-head-proof.mjs`.
  2. The probe posted seed message `OpenClaw #86300 live proof seed 86300-20260525T035423Z` to Slack channel `C0B5897MA0M`.
  3. The probe uploaded harmless file `86300-20260525T035423Z-seed.txt` in that Slack thread.
  4. The probe re-read the Slack thread and file metadata using the Slack Web API.
  5. The probe called OpenClaw Slack `downloadFile` for the real Slack file id, then ran the resulting tool result through `extractToolResultMediaArtifact`, `filterToolResultMediaUrls("message", ...)`, and `mergeAttemptToolMediaPayloads` with a plain final text reply.
- Evidence after fix: Redacted local proof artifacts recorded the following after-fix values:

```json
{
  "runId": "86300-20260525T035423Z",
  "env": {
    "tokenSourceKey": "SLACK_BOT_TOKEN_1",
    "channelId": "C0B5897MA0M",
    "node": "v24.8.0",
    "platform": "darwin"
  },
  "slack": {
    "auth": {
      "ok": true,
      "teamId": "T0B6...53NU",
      "userId": "U0B5...Q75Z",
      "botId": "B0B5...7LEB"
    },
    "seedMessageTs": "1779681264.262699",
    "uploadedFileId": "F0B5...SGM9"
  },
  "openclawDownloadFileResult": {
    "ok": true,
    "contentTypes": ["text"],
    "hasDetailsPath": true,
    "hasDetailsMedia": true,
    "detailsMedia": {
      "mediaUrl": "/Users/<redacted>/.openclaw/media/inbound/dbf0d310-464b-4beb-a41b-65fb8bb3ce14",
      "outbound": false,
      "contentType": "application/force-download"
    },
    "contentType": "application/force-download",
    "placeholder": "[Slack file: 86300-20260525T035423Z-seed.txt (fileId: F0B5...SGM9)]"
  },
  "toolMediaPipelineCurrentHead": {
    "extractedMediaUrls": [],
    "filteredMessageToolMediaUrls": [],
    "mergedPayloads": [
      {
        "text": "Plain final answer for 86300-20260525T035423Z"
      }
    ],
    "wouldAttachDownloadedFileToPlainFinalReply": false
  }
}
```

Follow-up Slack readback for the same run:

```json
{
  "channel": "C0B5897MA0M",
  "seedMessageTs": "1779681264.262699",
  "fileId": "F0B5...SGM9",
  "repliesCount": 2,
  "repliesSawFile": true,
  "historyCount": 1,
  "historySawSeed": true,
  "historySawFile": false,
  "fileInfoOk": true,
  "fileName": "86300-20260525T035423Z-seed.txt",
  "fileMimetype": "text/plain",
  "fileSharesKeys": ["public"]
}
```

- Observed result after fix: Slack contained the real seed message and uploaded thread attachment, `downloadFile` succeeded and still returned agent-readable downloaded-file metadata, but `outbound: false` caused the shared media extractor to return no media URLs and the final plain reply payload stayed text-only (`wouldAttachDownloadedFileToPlainFinalReply: false`).
- What was not tested: No cross-workspace Slack scenario, private-channel invite flow, or full end-to-end model-generated assistant turn was run. The proof uses the real Slack Web API plus the exact OpenClaw Slack `downloadFile` and shared tool-media pipeline implicated by the issue.
- Proof limitations or environment constraints: Screenshots are intentionally not included in this PR body; the Slack-side screenshot will be uploaded manually. Redacted local artifact paths are not committed.

## Out of scope
- Changing Slack upload/send semantics.
- Reworking same-text final-answer dedupe across unrelated delivery routes.
- Changing trusted local-media behavior for explicit generated media, TTS, or `MEDIA:` directives.
- Adding new Slack scopes or changing channel setup/onboarding behavior.

Made with [Cursor](https://cursor.com)