### PR TITLE
fix: narrow UI vitest target routing

### DIFF
--- a/scripts/run-vitest.mjs
+++ b/scripts/run-vitest.mjs
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import { createRequire } from "node:module";
 import path from "node:path";
-import { isUnitUiTestTarget } from "../test/vitest/vitest.ui-paths.mjs";
+import { isUiTestTarget, isUnitUiTestTarget } from "../test/vitest/vitest.ui-paths.mjs";
 import { resolveLocalVitestEnv } from "./lib/vitest-local-scheduling.mjs";
 import { spawnPnpmRunner } from "./pnpm-runner.mjs";
 import {
@@ -14,6 +14,7 @@ const TRUTHY_ENV_VALUES = new Set(["1", "true", "yes", "on"]);
 const ANSI_CSI_PREFIX = `${String.fromCharCode(27)}[`;
 const ANSI_CSI_SUFFIX_RE = /^[0-?]*[ -/]*[@-~]/u;
 const SUPPRESSED_VITEST_STDERR_PATTERNS = ["[PLUGIN_TIMINGS]"];
+const UI_VITEST_CONFIG = "test/vitest/vitest.ui.config.ts";
 const UNIT_UI_VITEST_CONFIG = "test/vitest/vitest.unit-ui.config.ts";
 const require = createRequire(import.meta.url);
 
@@ -103,6 +104,13 @@ function toRepoRelativeArg(arg, cwd) {
   return normalized.replaceAll(path.sep, "/").replace(/^\.\//u, "");
 }
 
+function withImplicitVitestConfig(argv, config) {
+  if (argv[0] === "run") {
+    return ["run", "--config", config, ...argv.slice(1)];
+  }
+  return ["--config", config, ...argv];
+}
+
 export function resolveImplicitVitestArgs(argv, cwd = process.cwd()) {
   if (hasExplicitVitestConfigArg(argv)) {
     return argv;
@@ -111,12 +119,15 @@ export function resolveImplicitVitestArgs(argv, cwd = process.cwd()) {
     .filter((arg) => !arg.startsWith("-") && arg.endsWith(".test.ts"))
     .map((arg) => toRepoRelativeArg(arg, cwd));
   if (testTargets.length === 0 || !testTargets.every(isUnitUiTestTarget)) {
+    if (
+      testTargets.length > 0 &&
+      testTargets.every((target) => isUiTestTarget(target) && !isUnitUiTestTarget(target))
+    ) {
+      return withImplicitVitestConfig(argv, UI_VITEST_CONFIG);
+    }
     return argv;
   }
-  if (argv[0] === "run") {
-    return ["run", "--config", UNIT_UI_VITEST_CONFIG, ...argv.slice(1)];
-  }
-  return ["--config", UNIT_UI_VITEST_CONFIG, ...argv];
+  return withImplicitVitestConfig(argv, UNIT_UI_VITEST_CONFIG);
 }
 
 function spawnVitestProcess({ pnpmArgs, spawnParams }) {

--- a/scripts/run-vitest.mjs
+++ b/scripts/run-vitest.mjs
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { createRequire } from "node:module";
 import path from "node:path";
+import { isUnitUiTestTarget } from "../test/vitest/vitest.ui-paths.mjs";
 import { resolveLocalVitestEnv } from "./lib/vitest-local-scheduling.mjs";
 import { spawnPnpmRunner } from "./pnpm-runner.mjs";
 import {
@@ -13,6 +14,7 @@ const TRUTHY_ENV_VALUES = new Set(["1", "true", "yes", "on"]);
 const ANSI_CSI_PREFIX = `${String.fromCharCode(27)}[`;
 const ANSI_CSI_SUFFIX_RE = /^[0-?]*[ -/]*[@-~]/u;
 const SUPPRESSED_VITEST_STDERR_PATTERNS = ["[PLUGIN_TIMINGS]"];
+const UNIT_UI_VITEST_CONFIG = "test/vitest/vitest.unit-ui.config.ts";
 const require = createRequire(import.meta.url);
 
 function isTruthyEnvValue(value) {
@@ -90,6 +92,31 @@ export function shouldSuppressVitestStderrLine(line) {
 
 export function resolveDirectNodeVitestArgs(pnpmArgs) {
   return pnpmArgs[0] === "exec" && pnpmArgs[1] === "node" ? pnpmArgs.slice(2) : null;
+}
+
+function hasExplicitVitestConfigArg(argv) {
+  return argv.some((arg) => arg === "--config" || arg === "-c" || arg.startsWith("--config="));
+}
+
+function toRepoRelativeArg(arg, cwd) {
+  const normalized = path.isAbsolute(arg) ? path.relative(cwd, arg) : arg;
+  return normalized.replaceAll(path.sep, "/").replace(/^\.\//u, "");
+}
+
+export function resolveImplicitVitestArgs(argv, cwd = process.cwd()) {
+  if (hasExplicitVitestConfigArg(argv)) {
+    return argv;
+  }
+  const testTargets = argv
+    .filter((arg) => !arg.startsWith("-") && arg.endsWith(".test.ts"))
+    .map((arg) => toRepoRelativeArg(arg, cwd));
+  if (testTargets.length === 0 || !testTargets.every(isUnitUiTestTarget)) {
+    return argv;
+  }
+  if (argv[0] === "run") {
+    return ["run", "--config", UNIT_UI_VITEST_CONFIG, ...argv.slice(1)];
+  }
+  return ["--config", UNIT_UI_VITEST_CONFIG, ...argv];
 }
 
 function spawnVitestProcess({ pnpmArgs, spawnParams }) {
@@ -271,11 +298,18 @@ function main(argv = process.argv.slice(2), env = process.env) {
     process.exit(1);
   }
 
+  const vitestArgs = resolveImplicitVitestArgs(argv);
   const { child, teardown } = spawnWatchedVitestProcess({
-    pnpmArgs: ["exec", "node", ...resolveVitestNodeArgs(env), resolveVitestCliEntry(), ...argv],
+    pnpmArgs: [
+      "exec",
+      "node",
+      ...resolveVitestNodeArgs(env),
+      resolveVitestCliEntry(),
+      ...vitestArgs,
+    ],
     spawnParams: resolveVitestSpawnParams(env),
     env,
-    label: argv.join(" "),
+    label: vitestArgs.join(" "),
   });
 
   child.on("exit", (code, signal) => {

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -34,6 +34,7 @@ import {
   resolvePluginSdkLightIncludePattern,
 } from "../test/vitest/vitest.plugin-sdk-paths.mjs";
 import { fullSuiteVitestShards } from "../test/vitest/vitest.test-shards.mjs";
+import { isUnitUiTestTarget } from "../test/vitest/vitest.ui-paths.mjs";
 import { resolveUnitFastTestIncludePattern } from "../test/vitest/vitest.unit-fast-paths.mjs";
 import {
   isBoundaryTestFile,
@@ -1124,23 +1125,6 @@ function resolveVitestConfigTargetKind(relative) {
 
 function isVitestConfigTargetForKind(kind, targetArg, cwd) {
   return resolveVitestConfigTargetKind(toRepoRelativeTarget(targetArg, cwd)) === kind;
-}
-
-function isUnitUiTestTarget(relative) {
-  if (!relative.endsWith(".test.ts")) {
-    return false;
-  }
-  return (
-    relative === "ui/src/ui/app-chat.test.ts" ||
-    relative.startsWith("ui/src/ui/chat/") ||
-    relative === "ui/src/ui/views/agents-utils.test.ts" ||
-    relative === "ui/src/ui/views/channels.test.ts" ||
-    relative === "ui/src/ui/views/chat.test.ts" ||
-    relative === "ui/src/ui/views/dreaming.test.ts" ||
-    relative === "ui/src/ui/views/usage-render-details.test.ts" ||
-    relative === "ui/src/ui/controllers/agents.test.ts" ||
-    relative === "ui/src/ui/controllers/chat.test.ts"
-  );
 }
 
 function isControlUiE2eTarget(relative) {

--- a/test/scripts/run-vitest.test.ts
+++ b/test/scripts/run-vitest.test.ts
@@ -61,6 +61,20 @@ describe("scripts/run-vitest", () => {
     ]);
   });
 
+  it("routes explicit non-e2e ui tests through the ui config", () => {
+    expect(resolveImplicitVitestArgs(["run", "ui/src/ui/app-gateway.node.test.ts"])).toEqual([
+      "run",
+      "--config",
+      "test/vitest/vitest.ui.config.ts",
+      "ui/src/ui/app-gateway.node.test.ts",
+    ]);
+  });
+
+  it("keeps mixed unit ui and broader ui targets on existing routing", () => {
+    const argv = ["ui/src/ui/controllers/chat.test.ts", "ui/src/ui/app-gateway.node.test.ts"];
+    expect(resolveImplicitVitestArgs(argv)).toBe(argv);
+  });
+
   it("allows opting back into Maglev explicitly", () => {
     expect(
       resolveVitestNodeArgs({

--- a/test/scripts/run-vitest.test.ts
+++ b/test/scripts/run-vitest.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   installVitestNoOutputWatchdog,
   resolveDirectNodeVitestArgs,
+  resolveImplicitVitestArgs,
   resolveVitestNodeArgs,
   resolveVitestNoOutputTimeoutMs,
   resolveVitestSpawnParams,
@@ -24,6 +25,40 @@ describe("scripts/run-vitest", () => {
       ]),
     ).toEqual(["--no-maglev", "node_modules/vitest/vitest.mjs"]);
     expect(resolveDirectNodeVitestArgs(["exec", "vitest", "run"])).toBeNull();
+  });
+
+  it("routes explicit unit ui tests through the narrow unit ui config", () => {
+    expect(
+      resolveImplicitVitestArgs([
+        "ui/src/ui/controllers/chat.test.ts",
+        "-t",
+        "keeps optimistic user attachment previews",
+      ]),
+    ).toEqual([
+      "--config",
+      "test/vitest/vitest.unit-ui.config.ts",
+      "ui/src/ui/controllers/chat.test.ts",
+      "-t",
+      "keeps optimistic user attachment previews",
+    ]);
+  });
+
+  it("does not override explicit vitest configs", () => {
+    const argv = [
+      "--config",
+      "test/vitest/vitest.ui.config.ts",
+      "ui/src/ui/controllers/chat.test.ts",
+    ];
+    expect(resolveImplicitVitestArgs(argv)).toBe(argv);
+  });
+
+  it("keeps the run subcommand first when routing unit ui tests", () => {
+    expect(resolveImplicitVitestArgs(["run", "ui/src/ui/controllers/chat.test.ts"])).toEqual([
+      "run",
+      "--config",
+      "test/vitest/vitest.unit-ui.config.ts",
+      "ui/src/ui/controllers/chat.test.ts",
+    ]);
   });
 
   it("allows opting back into Maglev explicitly", () => {

--- a/test/vitest-projects-config.test.ts
+++ b/test/vitest-projects-config.test.ts
@@ -26,7 +26,8 @@ import {
   sharedVitestConfig,
 } from "./vitest/vitest.shared.config.ts";
 import { fullSuiteVitestShards } from "./vitest/vitest.test-shards.mjs";
-import { createUiVitestConfig, unitUiIncludePatterns } from "./vitest/vitest.ui.config.ts";
+import { unitUiIncludePatterns } from "./vitest/vitest.ui-paths.mjs";
+import { createUiVitestConfig } from "./vitest/vitest.ui.config.ts";
 import { createUnitFastVitestConfig } from "./vitest/vitest.unit-fast.config.ts";
 import unitUiConfig from "./vitest/vitest.unit-ui.config.ts";
 import { createUnitVitestConfig } from "./vitest/vitest.unit.config.ts";

--- a/test/vitest/vitest.ui-paths.mjs
+++ b/test/vitest/vitest.ui-paths.mjs
@@ -1,0 +1,28 @@
+export const unitUiIncludePatterns = [
+  "ui/src/ui/app-chat.test.ts",
+  "ui/src/ui/chat/**/*.test.ts",
+  "ui/src/ui/views/agents-utils.test.ts",
+  "ui/src/ui/views/channels.test.ts",
+  "ui/src/ui/views/chat.test.ts",
+  "ui/src/ui/views/dreaming.test.ts",
+  "ui/src/ui/views/usage-render-details.test.ts",
+  "ui/src/ui/controllers/agents.test.ts",
+  "ui/src/ui/controllers/chat.test.ts",
+];
+
+export function isUnitUiTestTarget(relative) {
+  if (!relative.endsWith(".test.ts")) {
+    return false;
+  }
+  return (
+    relative === "ui/src/ui/app-chat.test.ts" ||
+    relative.startsWith("ui/src/ui/chat/") ||
+    relative === "ui/src/ui/views/agents-utils.test.ts" ||
+    relative === "ui/src/ui/views/channels.test.ts" ||
+    relative === "ui/src/ui/views/chat.test.ts" ||
+    relative === "ui/src/ui/views/dreaming.test.ts" ||
+    relative === "ui/src/ui/views/usage-render-details.test.ts" ||
+    relative === "ui/src/ui/controllers/agents.test.ts" ||
+    relative === "ui/src/ui/controllers/chat.test.ts"
+  );
+}

--- a/test/vitest/vitest.ui-paths.mjs
+++ b/test/vitest/vitest.ui-paths.mjs
@@ -26,3 +26,11 @@ export function isUnitUiTestTarget(relative) {
     relative === "ui/src/ui/controllers/chat.test.ts"
   );
 }
+
+export function isUiTestTarget(relative) {
+  return (
+    relative.startsWith("ui/src/") &&
+    relative.endsWith(".test.ts") &&
+    !relative.endsWith(".e2e.test.ts")
+  );
+}

--- a/test/vitest/vitest.ui.config.ts
+++ b/test/vitest/vitest.ui.config.ts
@@ -1,17 +1,6 @@
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 import { jsdomOptimizedDeps } from "./vitest.shared.config.ts";
-
-export const unitUiIncludePatterns = [
-  "ui/src/ui/app-chat.test.ts",
-  "ui/src/ui/chat/**/*.test.ts",
-  "ui/src/ui/views/agents-utils.test.ts",
-  "ui/src/ui/views/channels.test.ts",
-  "ui/src/ui/views/chat.test.ts",
-  "ui/src/ui/views/dreaming.test.ts",
-  "ui/src/ui/views/usage-render-details.test.ts",
-  "ui/src/ui/controllers/agents.test.ts",
-  "ui/src/ui/controllers/chat.test.ts",
-];
+import { unitUiIncludePatterns } from "./vitest.ui-paths.mjs";
 
 export function createUiVitestConfig(
   env?: Record<string, string | undefined>,

--- a/test/vitest/vitest.unit-ui.config.ts
+++ b/test/vitest/vitest.unit-ui.config.ts
@@ -1,4 +1,5 @@
-import { createUiVitestConfig, unitUiIncludePatterns } from "./vitest.ui.config.ts";
+import { unitUiIncludePatterns } from "./vitest.ui-paths.mjs";
+import { createUiVitestConfig } from "./vitest.ui.config.ts";
 
 export default createUiVitestConfig(process.env, {
   includePatterns: unitUiIncludePatterns,


### PR DESCRIPTION
## Summary

- Route explicit unit UI Vitest targets to the lightweight unit UI config instead of the heavier Control UI startup path.
- Share UI path classification between the runner and Vitest configs so routing stays consistent.
- Cover explicit UI config/target routing in `test/scripts/run-vitest.test.ts`.

## Verification

- `git diff --check origin/main...HEAD`
- Testbox-through-Crabbox `tbx_01ksemq3szatvd5m3t1cy7p5bd`: `CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 node scripts/run-vitest.mjs test/scripts/run-vitest.test.ts -- --reporter=verbose`

Behavior addressed: targeted unit UI test invocations should not pay the heavier Control UI Vitest startup path.
Real environment tested: Blacksmith Testbox through Crabbox, `tbx_01ksemq3szatvd5m3t1cy7p5bd`.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs test/scripts/run-vitest.test.ts -- --reporter=verbose` with CI/Testbox env.
Evidence after fix: `test/scripts/run-vitest.test.ts` passed 17 tests.
Observed result after fix: 1 test file passed, 17 tests passed.
What was not tested: full UI suite; this PR only changes targeted runner routing.
