### PR TITLE
fix: suppress Telegram progress leaks when disabled

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -556,6 +556,61 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.clear).toHaveBeenCalledTimes(1);
   });
 
+  it("forces default progress suppression when Telegram streaming is off", async () => {
+    let capturedReplyOptions:
+      | DispatchReplyWithBufferedBlockDispatcherArgs["replyOptions"]
+      | undefined;
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      capturedReplyOptions = replyOptions;
+      return { queuedFinal: false, counts: { block: 0, final: 0, tool: 0 } };
+    });
+
+    await dispatchWithContext({
+      context: createContext({ ctxPayload: createDirectSessionPayload() }),
+      streamMode: "off",
+      telegramCfg: { streaming: { mode: "off" } },
+    });
+
+    expect(capturedReplyOptions).toEqual(
+      expect.objectContaining({
+        suppressDefaultToolProgressMessages: true,
+        forceSuppressDefaultToolProgressMessages: true,
+      }),
+    );
+    expect(createTelegramDraftStream).not.toHaveBeenCalled();
+  });
+
+  it("forces default progress suppression when Telegram tool progress is disabled", async () => {
+    const draftStream = createDraftStream();
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    let capturedReplyOptions:
+      | DispatchReplyWithBufferedBlockDispatcherArgs["replyOptions"]
+      | undefined;
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      capturedReplyOptions = replyOptions;
+      return { queuedFinal: false, counts: { block: 0, final: 0, tool: 0 } };
+    });
+
+    await dispatchWithContext({
+      context: createContext({ ctxPayload: createDirectSessionPayload() }),
+      streamMode: "partial",
+      telegramCfg: {
+        streaming: {
+          preview: {
+            toolProgress: false,
+          },
+        },
+      },
+    });
+
+    expect(capturedReplyOptions).toEqual(
+      expect.objectContaining({
+        suppressDefaultToolProgressMessages: true,
+        forceSuppressDefaultToolProgressMessages: true,
+      }),
+    );
+  });
+
   it("recovers forum thread context from a topic-scoped session key", async () => {
     const recordInboundSession = vi.fn(async () => undefined);
     const oldHistoryKey = "-1003774691294:topic:1";

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -899,8 +899,8 @@ export const dispatchTelegramMessage = async ({
   };
   const answerLane = lanes.answer;
   const reasoningLane = lanes.reasoning;
-  const streamToolProgressEnabled =
-    Boolean(answerLane.stream) && resolveChannelStreamingPreviewToolProgress(telegramCfg);
+  const configuredToolProgressEnabled = resolveChannelStreamingPreviewToolProgress(telegramCfg);
+  const streamToolProgressEnabled = Boolean(answerLane.stream) && configuredToolProgressEnabled;
   const nativeToolProgressDraft =
     streamToolProgressEnabled &&
     !isRoomEvent &&
@@ -1950,6 +1950,8 @@ export const dispatchTelegramMessage = async ({
                     : undefined,
                   suppressDefaultToolProgressMessages:
                     !streamDeliveryEnabled || Boolean(answerLane.stream),
+                  forceSuppressDefaultToolProgressMessages:
+                    !streamDeliveryEnabled || configuredToolProgressEnabled === false,
                   allowProgressCallbacksWhenSourceDeliverySuppressed:
                     !isRoomEvent && Boolean(answerLane.stream),
                   onToolStart: async (payload) => {

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -88,6 +88,12 @@ export type GetReplyOptions = {
    * channel to surface progress via its own streaming/edit UX.
    */
   suppressDefaultToolProgressMessages?: boolean;
+  /**
+   * If true, dispatch suppresses default text-only tool/progress messages even
+   * when session verbose progress is enabled. Channels use this when explicit
+   * off/tool-progress-disabled config must remain authoritative.
+   */
+  forceSuppressDefaultToolProgressMessages?: boolean;
   onPartialReply?: (payload: PartialReplyPayload) => Promise<void> | void;
   onReasoningStream?: (payload: ReplyPayload) => Promise<void> | void;
   /** Called when a thinking/reasoning block ends. */

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1848,6 +1848,49 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 
+  it("honors forced tool-summary suppression while verbose is enabled during the run", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      verboseLevel: "off",
+    };
+    const cfg = automaticGroupReplyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "group",
+      From: "telegram:group:-100123",
+      SessionKey: "agent:main:telegram:group:-100123",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      const onToolResult = requireToolResultHandler(opts?.onToolResult);
+      sessionStoreMocks.currentEntry = {
+        verboseLevel: "on",
+      };
+      await onToolResult({ text: "🔧 exec: leaked" });
+      return { text: "hi" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        suppressDefaultToolProgressMessages: true,
+        forceSuppressDefaultToolProgressMessages: true,
+      },
+    });
+
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps tool-error fallbacks available when verbose is disabled during the run", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1848,7 +1848,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 
-  it("honors forced tool-summary suppression while verbose is enabled during the run", async () => {
+  it("honors forced progress suppression while verbose is enabled during the run", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {
       verboseLevel: "off",
@@ -1862,17 +1862,24 @@ describe("dispatchReplyFromConfig", () => {
       From: "telegram:group:-100123",
       SessionKey: "agent:main:telegram:group:-100123",
     });
+    const onPlanUpdate = vi.fn();
+    const onApprovalEvent = vi.fn();
+    const onPatchSummary = vi.fn();
+    const onToolResult = vi.fn();
 
     const replyResolver = async (
       _ctx: MsgContext,
       opts?: GetReplyOptions,
       _cfg?: OpenClawConfig,
     ) => {
-      const onToolResult = requireToolResultHandler(opts?.onToolResult);
+      const handleToolResult = requireToolResultHandler(opts?.onToolResult);
       sessionStoreMocks.currentEntry = {
         verboseLevel: "on",
       };
-      await onToolResult({ text: "🔧 exec: leaked" });
+      await opts?.onPlanUpdate?.({ phase: "update", steps: ["Run command"] });
+      await opts?.onApprovalEvent?.({ phase: "requested", command: "pnpm test" });
+      await opts?.onPatchSummary?.({ phase: "end", summary: "1 modified" });
+      await handleToolResult({ text: "🔧 exec: leaked" });
       return { text: "hi" } satisfies ReplyPayload;
     };
 
@@ -1884,9 +1891,17 @@ describe("dispatchReplyFromConfig", () => {
       replyOptions: {
         suppressDefaultToolProgressMessages: true,
         forceSuppressDefaultToolProgressMessages: true,
+        onPlanUpdate,
+        onApprovalEvent,
+        onPatchSummary,
+        onToolResult,
       },
     });
 
+    expect(onPlanUpdate).not.toHaveBeenCalled();
+    expect(onApprovalEvent).not.toHaveBeenCalled();
+    expect(onPatchSummary).not.toHaveBeenCalled();
+    expect(onToolResult).not.toHaveBeenCalled();
     expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1590,7 +1590,10 @@ export async function dispatchReplyFromConfig(
       return finishReplyOperationBusyDispatch();
     }
 
-    const shouldSuppressDefaultToolProgressMessages = () => !shouldEmitVerboseProgress();
+    const forceSuppressDefaultToolProgressMessages =
+      params.replyOptions?.forceSuppressDefaultToolProgressMessages === true;
+    const shouldSuppressDefaultToolProgressMessages = () =>
+      forceSuppressDefaultToolProgressMessages || !shouldEmitVerboseProgress();
     const shouldSendVerboseProgressMessages = () => !shouldSuppressDefaultToolProgressMessages();
     const shouldSendToolSummaries = () => shouldSendVerboseProgressMessages();
     const shouldSendToolStartStatuses = false;


### PR DESCRIPTION
Fixes #79804

## Summary

This PR makes Telegram progress suppression authoritative when Telegram streaming is off or tool progress is disabled.

Changes:

- Adds forceSuppressDefaultToolProgressMessages to reply options.
- Keeps normal verbose progress behavior unchanged unless a channel explicitly sets the force flag.
- Sets the force flag from Telegram when streamMode is off.
- Sets the force flag from Telegram when streaming.preview.toolProgress resolves to false.
- Adds dispatcher regression coverage for verbose mode trying to emit tool, plan, approval, and patch progress while forced suppression is active.
- Adds Telegram wiring coverage for streaming-off and tool-progress-disabled configurations.

## Why

Telegram already passed suppressDefaultToolProgressMessages, but shared dispatch could still allow default tool/status text when verbose progress became enabled.

That meant internal tool/status cards could leak into Telegram as normal user-facing messages even when Telegram config disabled streaming/tool progress.

This is the preferred landing path over #85992 because it keeps the existing TTS/source-reply metadata preservation path intact and makes explicit Telegram off/tool-progress-disabled config authoritative across the shared dispatcher.

## Tests

- git diff --check
- OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/dispatch-from-config.test.ts
- OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/bot-message-dispatch.test.ts

Observed locally on 1d138de64a87b493f0754de66f4295231ee66f7a:

- auto-reply-reply dispatch-from-config.test.ts: 154 tests passed
- extension-telegram bot-message-dispatch.test.ts: 90 tests passed
- git diff --check: clean

## Real behavior proof

Behavior or issue addressed: Telegram stream-off or tool-progress-disabled configuration should suppress default text-only tool/progress/status messages even if verbose progress becomes enabled during the run, while preserving the final assistant reply.

Real environment tested: local OpenClaw source checkout in `/home/rev/projects/openclaw-prs/pr-86321-telegram-progress-suppression` on Linux, Node 22.22.2, pnpm 11.2.2, head SHA `1d138de64a87b493f0754de66f4295231ee66f7a`. I also checked this shell for live Telegram proof credentials and found none.

Exact steps or command run after this patch:

- `git diff --check`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/dispatch-from-config.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/bot-message-dispatch.test.ts`
- Checked for Telegram QA credentials with redacted env/file discovery before attempting live Telegram proof.

Evidence after fix: terminal output from `/tmp/openclaw-pr86321-proof.log` captured on 2026-05-26 UTC:

```text
HEAD: 1d138de64a87b493f0754de66f4295231ee66f7a
Credential/environment check:
- No TELEGRAM/OpenClaw live QA env vars were present in this shell.
- ~/.openclaw search found no Telegram credential file, only GitHub Copilot credentials.
- Live Telegram direct/group/forum transcript or screenshot was not captured.

Command: git diff --check

Command: OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/dispatch-from-config.test.ts
Test Files  1 passed (1)
Tests  154 passed (154)

Command: OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/bot-message-dispatch.test.ts
Test Files  1 passed (1)
Tests  90 passed (90)
```

Observed result after fix: focused local validation at the PR head stayed green: `git diff --check` was clean, the auto-reply dispatch suite passed 154/154, and the Telegram dispatch suite passed 90/90. The new regression coverage exercises verbose progress becoming enabled during dispatch and verifies forced suppression prevents default progress/status delivery while preserving final reply delivery.

What was not tested: live Telegram direct/group/forum transport proof remains untested from this shell because no Telegram QA credentials or live proof lane were available locally. A maintainer or Mantis run still needs to capture a redacted live Telegram transcript/screenshot/recording before treating the Telegram-visible behavior as fully proven.
