### PR TITLE
fix(google): keep flash-lite model ids current

### DIFF
--- a/extensions/google/api.test.ts
+++ b/extensions/google/api.test.ts
@@ -106,7 +106,7 @@ describe("google generative ai helpers", () => {
     });
   });
 
-  it("normalizes google-vertex model ids without rewriting the OpenAI-compatible baseUrl", () => {
+  it("keeps current google-vertex flash-lite model ids without rewriting the OpenAI-compatible baseUrl", () => {
     expect(
       normalizeGoogleProviderConfig("google-vertex", {
         api: "openai-completions",
@@ -132,7 +132,7 @@ describe("google generative ai helpers", () => {
         {
           contextWindow: 1,
           cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-          id: "gemini-3.1-flash-lite-preview",
+          id: "gemini-3.1-flash-lite",
           input: ["text"],
           maxTokens: 1,
           name: "Gemini Flash Lite",

--- a/extensions/google/cli-backend.ts
+++ b/extensions/google/cli-backend.ts
@@ -7,7 +7,7 @@ import {
 const GEMINI_MODEL_ALIASES: Record<string, string> = {
   pro: "gemini-3.1-pro-preview",
   flash: "gemini-3.1-flash-preview",
-  "flash-lite": "gemini-3.1-flash-lite-preview",
+  "flash-lite": "gemini-3.1-flash-lite",
 };
 const GEMINI_CLI_DEFAULT_MODEL_REF = "google-gemini-cli/gemini-3-flash-preview";
 

--- a/extensions/google/model-id.test.ts
+++ b/extensions/google/model-id.test.ts
@@ -36,7 +36,10 @@ describe("google model id helpers", () => {
     );
   });
 
-  it("adds the preview suffix for gemini 3.1 flash-lite", () => {
-    expect(normalizeGoogleModelId("gemini-3.1-flash-lite")).toBe("gemini-3.1-flash-lite-preview");
+  it("keeps the bare Gemini 3.1 Flash-Lite API id unchanged", () => {
+    expect(normalizeGoogleModelId("gemini-3.1-flash-lite")).toBe("gemini-3.1-flash-lite");
+    expect(normalizeGoogleModelId("google/gemini-3.1-flash-lite")).toBe(
+      "google/gemini-3.1-flash-lite",
+    );
   });
 });

--- a/extensions/google/model-id.ts
+++ b/extensions/google/model-id.ts
@@ -18,9 +18,6 @@ export function normalizeGoogleModelId(id: string): string {
   if (id === "gemini-3.1-pro") {
     return "gemini-3.1-pro-preview";
   }
-  if (id === "gemini-3.1-flash-lite") {
-    return "gemini-3.1-flash-lite-preview";
-  }
   if (id === "gemini-3.1-flash" || id === "gemini-3.1-flash-preview") {
     return "gemini-3-flash-preview";
   }

--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -14,7 +14,6 @@
           "gemini-3-pro-preview": "gemini-3.1-pro-preview",
           "gemini-3-flash": "gemini-3-flash-preview",
           "gemini-3.1-pro": "gemini-3.1-pro-preview",
-          "gemini-3.1-flash-lite": "gemini-3.1-flash-lite-preview",
           "gemini-3.1-flash": "gemini-3-flash-preview",
           "gemini-3.1-flash-preview": "gemini-3-flash-preview"
         }
@@ -25,7 +24,6 @@
           "gemini-3-pro-preview": "gemini-3.1-pro-preview",
           "gemini-3-flash": "gemini-3-flash-preview",
           "gemini-3.1-pro": "gemini-3.1-pro-preview",
-          "gemini-3.1-flash-lite": "gemini-3.1-flash-lite-preview",
           "gemini-3.1-flash": "gemini-3-flash-preview",
           "gemini-3.1-flash-preview": "gemini-3-flash-preview"
         }
@@ -36,7 +34,6 @@
           "gemini-3-pro-preview": "gemini-3.1-pro-preview",
           "gemini-3-flash": "gemini-3-flash-preview",
           "gemini-3.1-pro": "gemini-3.1-pro-preview",
-          "gemini-3.1-flash-lite": "gemini-3.1-flash-lite-preview",
           "gemini-3.1-flash": "gemini-3-flash-preview",
           "gemini-3.1-flash-preview": "gemini-3-flash-preview"
         }
@@ -133,12 +130,12 @@
       {
         "provider": "google",
         "model": "gemini-2.5-flash-lite-preview-09-25",
-        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google/gemini-3.1-flash-lite-preview."
+        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google/gemini-3.1-flash-lite."
       },
       {
         "provider": "google",
         "model": "gemini-2.5-flash-lite-preview-09-2025",
-        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google/gemini-3.1-flash-lite-preview."
+        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google/gemini-3.1-flash-lite."
       },
       {
         "provider": "google",
@@ -298,12 +295,12 @@
       {
         "provider": "google-gemini-cli",
         "model": "gemini-2.5-flash-lite-preview-09-25",
-        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google-gemini-cli/gemini-3.1-flash-lite-preview."
+        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google-gemini-cli/gemini-3.1-flash-lite."
       },
       {
         "provider": "google-gemini-cli",
         "model": "gemini-2.5-flash-lite-preview-09-2025",
-        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google-gemini-cli/gemini-3.1-flash-lite-preview."
+        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google-gemini-cli/gemini-3.1-flash-lite."
       },
       {
         "provider": "google-gemini-cli",
@@ -463,12 +460,12 @@
       {
         "provider": "google-vertex",
         "model": "gemini-2.5-flash-lite-preview-09-25",
-        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google-vertex/gemini-3.1-flash-lite-preview."
+        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google-vertex/gemini-3.1-flash-lite."
       },
       {
         "provider": "google-vertex",
         "model": "gemini-2.5-flash-lite-preview-09-2025",
-        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google-vertex/gemini-3.1-flash-lite-preview."
+        "reason": "Google shut down this Gemini 2.5 Flash-Lite preview on 2026-03-31. Use google-vertex/gemini-3.1-flash-lite."
       },
       {
         "provider": "google-vertex",

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -48,7 +48,6 @@ const manifestNormalizationSnapshot = vi.hoisted(() => ({
               "gemini-3-pro": "gemini-3.1-pro-preview",
               "gemini-3-flash": "gemini-3-flash-preview",
               "gemini-3.1-pro": "gemini-3.1-pro-preview",
-              "gemini-3.1-flash-lite": "gemini-3.1-flash-lite-preview",
               "gemini-3.1-flash": "gemini-3-flash-preview",
               "gemini-3.1-flash-preview": "gemini-3-flash-preview",
             },
@@ -58,7 +57,6 @@ const manifestNormalizationSnapshot = vi.hoisted(() => ({
               "gemini-3-pro": "gemini-3.1-pro-preview",
               "gemini-3-flash": "gemini-3-flash-preview",
               "gemini-3.1-pro": "gemini-3.1-pro-preview",
-              "gemini-3.1-flash-lite": "gemini-3.1-flash-lite-preview",
               "gemini-3.1-flash": "gemini-3-flash-preview",
               "gemini-3.1-flash-preview": "gemini-3-flash-preview",
             },
@@ -330,10 +328,10 @@ describe("model-selection", () => {
         expected: { provider: "google-gemini-cli", model: "gemini-3.1-pro-preview" },
       },
       {
-        name: "normalizes gemini 3.1 flash-lite ids",
+        name: "keeps gemini 3.1 flash-lite ids unchanged",
         variants: ["google/gemini-3.1-flash-lite", "gemini-3.1-flash-lite"],
         defaultProvider: "google",
-        expected: { provider: "google", model: "gemini-3.1-flash-lite-preview" },
+        expected: { provider: "google", model: "gemini-3.1-flash-lite" },
       },
       {
         name: "normalizes deprecated xai grok 4.20 beta ids",
@@ -405,10 +403,10 @@ describe("model-selection", () => {
         expected: { provider: "openai", model: "gpt-5.4-codex-codex" },
       },
       {
-        name: "normalizes gemini 3.1 flash-lite ids for google-vertex",
+        name: "keeps gemini 3.1 flash-lite ids unchanged for google-vertex",
         variants: ["google-vertex/gemini-3.1-flash-lite", "gemini-3.1-flash-lite"],
         defaultProvider: "google-vertex",
-        expected: { provider: "google-vertex", model: "gemini-3.1-flash-lite-preview" },
+        expected: { provider: "google-vertex", model: "gemini-3.1-flash-lite" },
       },
       {
         name: "normalizes anthropic-cli refs to the Claude CLI provider alias",
@@ -1784,7 +1782,7 @@ describe("model-selection", () => {
 
       expect(result).toEqual({
         provider: "google-vertex",
-        model: "gemini-3.1-flash-lite-preview",
+        model: "gemini-3.1-flash-lite",
       });
     });
 

--- a/src/agents/models-config.providers.google-antigravity.test.ts
+++ b/src/agents/models-config.providers.google-antigravity.test.ts
@@ -7,9 +7,6 @@ vi.mock("../plugins/provider-runtime.js", () => {
     if (provider === "google-antigravity") {
       return /^(gemini-3(?:[.-]1)?-pro)$/.test(modelId) ? `${modelId}-low` : modelId;
     }
-    if (provider === "google-vertex" && modelId === "gemini-3.1-flash-lite") {
-      return "gemini-3.1-flash-lite-preview";
-    }
     return modelId;
   }
 
@@ -113,27 +110,9 @@ describe("google-antigravity provider normalization", () => {
 });
 
 describe("google-vertex provider normalization", () => {
-  it("normalizes gemini flash-lite IDs for google-vertex providers", () => {
+  it("keeps current gemini flash-lite IDs for google-vertex providers", () => {
     const providers = {
       "google-vertex": buildProvider(["gemini-3.1-flash-lite", "gemini-3-flash-preview"], {
-        api: undefined,
-      }),
-      openai: buildProvider(["gpt-5"]),
-    };
-
-    const normalized = normalizeProviderMap(providers);
-
-    expect(normalized).not.toBe(providers);
-    expect(normalized?.["google-vertex"]?.models.map((model) => model.id)).toEqual([
-      "gemini-3.1-flash-lite-preview",
-      "gemini-3-flash-preview",
-    ]);
-    expect(normalized?.openai).toBe(providers.openai);
-  });
-
-  it("returns original providers object when no google-vertex IDs need normalization", () => {
-    const providers = {
-      "google-vertex": buildProvider(["gemini-3.1-flash-lite-preview", "gemini-3-flash-preview"], {
         api: undefined,
       }),
     };

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -33,10 +33,10 @@ const DEFAULT_MODEL_ALIASES: Readonly<Record<string, string>> = {
   "gpt-mini": "openai/gpt-5.4-mini",
   "gpt-nano": "openai/gpt-5.4-nano",
 
-  // Google Gemini (3.x are preview ids in the catalog)
+  // Google Gemini
   gemini: "google/gemini-3.1-pro-preview",
   "gemini-flash": "google/gemini-3-flash-preview",
-  "gemini-flash-lite": "google/gemini-3.1-flash-lite-preview",
+  "gemini-flash-lite": "google/gemini-3.1-flash-lite",
 };
 
 const DEFAULT_MODEL_COST: ModelDefinitionConfig["cost"] = {

--- a/src/config/model-alias-defaults.test.ts
+++ b/src/config/model-alias-defaults.test.ts
@@ -110,7 +110,7 @@ describe("applyModelDefaults", () => {
           models: {
             "google/gemini-3.1-pro-preview": { alias: "" },
             "google/gemini-3-flash-preview": {},
-            "google/gemini-3.1-flash-lite-preview": {},
+            "google/gemini-3.1-flash-lite": {},
           },
         },
       },
@@ -122,7 +122,7 @@ describe("applyModelDefaults", () => {
     expect(next.agents?.defaults?.models?.["google/gemini-3-flash-preview"]?.alias).toBe(
       "gemini-flash",
     );
-    expect(next.agents?.defaults?.models?.["google/gemini-3.1-flash-lite-preview"]?.alias).toBe(
+    expect(next.agents?.defaults?.models?.["google/gemini-3.1-flash-lite"]?.alias).toBe(
       "gemini-flash-lite",
     );
   });

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -113,6 +113,8 @@ vi.mock("../plugins/provider-runtime.js", async () => ({
   ...(await vi.importActual<typeof import("../plugins/provider-runtime.js")>(
     "../plugins/provider-runtime.js",
   )),
+  normalizeProviderModelIdWithPlugin: ({ context }: { context: { modelId: string } }) =>
+    context.modelId,
   prepareProviderDynamicModel: prepareProviderDynamicModelMock,
 }));
 
@@ -1105,13 +1107,13 @@ describe("describeImageWithModel", () => {
     expect(setRuntimeApiKeyMock).toHaveBeenCalledWith("google", "oauth-test");
   });
 
-  it("normalizes gemini 3.1 flash-lite ids before lookup and keeps profile auth selection", async () => {
+  it("keeps gemini 3.1 flash-lite ids before lookup and keeps profile auth selection", async () => {
     const findMock = vi.fn((provider: string, modelId: string) => {
       expect(provider).toBe("google");
-      expect(modelId).toBe("gemini-3.1-flash-lite-preview");
+      expect(modelId).toBe("gemini-3.1-flash-lite");
       return {
         provider: "google",
-        id: "gemini-3.1-flash-lite-preview",
+        id: "gemini-3.1-flash-lite",
         input: ["text", "image"],
         baseUrl: "https://generativelanguage.googleapis.com/v1beta",
       };
@@ -1121,7 +1123,7 @@ describe("describeImageWithModel", () => {
       role: "assistant",
       api: "google-generative-ai",
       provider: "google",
-      model: "gemini-3.1-flash-lite-preview",
+      model: "gemini-3.1-flash-lite",
       stopReason: "stop",
       timestamp: Date.now(),
       content: [{ type: "text", text: "flash lite ok" }],
@@ -1142,7 +1144,7 @@ describe("describeImageWithModel", () => {
 
     expect(result).toEqual({
       text: "flash lite ok",
-      model: "gemini-3.1-flash-lite-preview",
+      model: "gemini-3.1-flash-lite",
     });
     expect(findMock).toHaveBeenCalled();
     const authRequest = getApiKeyForModelCall();

--- a/src/plugin-sdk/provider-model-id-normalize.test.ts
+++ b/src/plugin-sdk/provider-model-id-normalize.test.ts
@@ -18,4 +18,11 @@ describe("provider model id normalization", () => {
     expect(normalizeGooglePreviewModelId("gemini-3.1-pro-preview")).toBe("gemini-3.1-pro-preview");
     expect(normalizeGooglePreviewModelId("gemini-2.5-flash")).toBe("gemini-2.5-flash");
   });
+
+  it("keeps the bare Gemini 3.1 Flash-Lite API id unchanged", () => {
+    expect(normalizeGooglePreviewModelId("gemini-3.1-flash-lite")).toBe("gemini-3.1-flash-lite");
+    expect(normalizeGooglePreviewModelId("google/gemini-3.1-flash-lite")).toBe(
+      "google/gemini-3.1-flash-lite",
+    );
+  });
 });

--- a/src/plugin-sdk/provider-model-id-normalize.ts
+++ b/src/plugin-sdk/provider-model-id-normalize.ts
@@ -16,9 +16,6 @@ export function normalizeGooglePreviewModelId(id: string): string {
   if (id === "gemini-3.1-pro") {
     return "gemini-3.1-pro-preview";
   }
-  if (id === "gemini-3.1-flash-lite") {
-    return "gemini-3.1-flash-lite-preview";
-  }
   if (id === "gemini-3.1-flash" || id === "gemini-3.1-flash-preview") {
     return "gemini-3-flash-preview";
   }


### PR DESCRIPTION
## Summary

- Keep `gemini-3.1-flash-lite` as the current Google Flash-Lite model id instead of rewriting it to `gemini-3.1-flash-lite-preview`.
- Align Google plugin manifest aliases, SDK normalization, default aliases, Gemini CLI shorthand, model selection, and media understanding tests with the current id.

## Verification

- `pnpm build`
- `node scripts/run-vitest.mjs run extensions/google/model-id.test.ts src/plugin-sdk/provider-model-id-normalize.test.ts src/agents/model-selection.test.ts src/config/model-alias-defaults.test.ts extensions/google/api.test.ts src/agents/models-config.providers.google-antigravity.test.ts src/media-understanding/image.test.ts`

## Real behavior proof

**Behavior addressed:** Google Flash-Lite normalization now keeps `gemini-3.1-flash-lite` unchanged for plugin, SDK, and model-ref paths.
**Real environment tested:** Linux, Node via repository build/test commands, local checkout after this patch.
**Exact steps or command run after this patch:**

```bash
node --import tsx --no-warnings -e "import { normalizeModelRef } from './src/agents/model-selection.js'; import { normalizeGoogleModelId } from './extensions/google/model-id.js'; import { normalizeGooglePreviewModelId } from './src/plugin-sdk/provider-model-id-normalize.js'; const rows = { plugin: normalizeGoogleModelId('gemini-3.1-flash-lite'), sdk: normalizeGooglePreviewModelId('gemini-3.1-flash-lite'), google: normalizeModelRef('google', 'gemini-3.1-flash-lite'), vertex: normalizeModelRef('google-vertex', 'gemini-3.1-flash-lite'), cli: normalizeModelRef('google-gemini-cli', 'gemini-3.1-flash-lite') }; console.log(JSON.stringify(rows, null, 2));"
```

**Evidence after fix:**

```text
{
  "plugin": "gemini-3.1-flash-lite",
  "sdk": "gemini-3.1-flash-lite",
  "google": {
    "provider": "google",
    "model": "gemini-3.1-flash-lite"
  },
  "vertex": {
    "provider": "google-vertex",
    "model": "gemini-3.1-flash-lite"
  },
  "cli": {
    "provider": "google-gemini-cli",
    "model": "gemini-3.1-flash-lite"
  }
}
```

**Observed result after fix:** Bare Flash-Lite ids remain bare across the production normalization paths, and targeted tests plus build pass.
**What was not tested:** Live Google API request against `gemini-3.1-flash-lite`.

Closes #86151