### PR TITLE
fix: guard QMD session stem fallback

### DIFF
--- a/src/plugin-sdk/session-transcript-hit.test.ts
+++ b/src/plugin-sdk/session-transcript-hit.test.ts
@@ -217,6 +217,23 @@ describe("resolveTranscriptStemToSessionKeys", () => {
     ).toEqual(["agent:main:s1"]);
   });
 
+  it("ignores store entries without session ids during QMD-slugified fallback", () => {
+    const store: Record<string, SessionEntry> = {
+      "agent:main:non-session": {
+        updatedAt: 1,
+      } as SessionEntry,
+      "agent:main:s1": baseEntry({ sessionId: "foo_bar.v1" }),
+    };
+
+    expect(
+      resolveTranscriptStemToSessionKeys({
+        store,
+        stem: "foo-bar-v1",
+        allowQmdSlugFallback: true,
+      }),
+    ).toEqual(["agent:main:s1"]);
+  });
+
   it("does not use QMD-slugified fallback unless requested", () => {
     const store: Record<string, SessionEntry> = {
       "agent:main:s1": baseEntry({ sessionId: "foo_bar.v1" }),

--- a/src/plugin-sdk/session-transcript-hit.ts
+++ b/src/plugin-sdk/session-transcript-hit.ts
@@ -151,7 +151,8 @@ export function resolveTranscriptStemToSessionKeys(params: {
           continue;
         }
       }
-      if (normalizeQmdSessionStem(entry.sessionId) === normalizedStem) {
+      const entrySessionId = normalizeOptionalString(entry.sessionId);
+      if (entrySessionId && normalizeQmdSessionStem(entrySessionId) === normalizedStem) {
         matches.push(sessionKey);
       }
     }


### PR DESCRIPTION
## Summary
- Guard QMD-slugified session stem fallback against session-store entries that do not have a usable `sessionId`.
- Add regression coverage for mixed session stores where one entry is metadata-only and another entry should still match by QMD slug.
- AI-assisted: yes. I reviewed and understand the code and test change before opening this PR.

## Linked context
No linked issue. This came from a live QMD session-memory investigation where transcript-hit resolution needed to tolerate store entries without `sessionId`.

## Real behavior proof
Behavior or issue addressed: QMD session transcript hit resolution could inspect a mixed session store and call QMD stem normalization with a missing `sessionId`, throwing before the valid slug fallback match could resolve.

Real environment tested: Local OpenClaw source worktree on macOS, Node v26.0.0, pnpm 11.2.2, branch based on `origin/main`.

Exact steps or command run after this patch:
```sh
pnpm install
node --import tsx -e 'import { resolveTranscriptStemToSessionKeys } from "./src/plugin-sdk/session-transcript-hit.ts"; const store = { "agent:main:non-session": { updatedAt: 1 }, "agent:main:s1": { sessionId: "foo_bar.v1", updatedAt: 2 } }; console.log(JSON.stringify(resolveTranscriptStemToSessionKeys({ store, stem: "foo-bar-v1", allowQmdSlugFallback: true })));'
pnpm vitest run src/plugin-sdk/session-transcript-hit.test.ts
pnpm build
pnpm check
git diff --check
codex review --base origin/main
```

Evidence after fix:
Direct resolver probe output after the patch:
```text
$ node --import tsx -e 'import { resolveTranscriptStemToSessionKeys } from "./src/plugin-sdk/session-transcript-hit.ts"; const store = { "agent:main:non-session": { updatedAt: 1 }, "agent:main:s1": { sessionId: "foo_bar.v1", updatedAt: 2 } }; console.log(JSON.stringify(resolveTranscriptStemToSessionKeys({ store, stem: "foo-bar-v1", allowQmdSlugFallback: true })));'
["agent:main:s1"]
```
Additional validation:
- `pnpm vitest run src/plugin-sdk/session-transcript-hit.test.ts`: 1 test file passed, 27 tests passed.
- `pnpm build`: completed successfully for the patched worktree.
- `pnpm check`: completed successfully, including preflight guards, typecheck, lint, and policy guards.
- `git diff --check`: exit 0.
- `codex review --base origin/main`: clean review; no accepted/actionable findings.

Observed result after fix: Store entries without `sessionId` are ignored during QMD-slugified fallback, and a valid entry with `sessionId: "foo_bar.v1"` still resolves from stem `foo-bar-v1`.

What was not tested: Full `pnpm test` was not run. Live gateway/QMD indexing behavior was not exercised in this PR branch; this patch is limited to the resolver crash guard and regression test.

## Tests and validation
- `node --import tsx -e 'import { resolveTranscriptStemToSessionKeys } from "./src/plugin-sdk/session-transcript-hit.ts"; const store = { "agent:main:non-session": { updatedAt: 1 }, "agent:main:s1": { sessionId: "foo_bar.v1", updatedAt: 2 } }; console.log(JSON.stringify(resolveTranscriptStemToSessionKeys({ store, stem: "foo-bar-v1", allowQmdSlugFallback: true })));'`
- `pnpm vitest run src/plugin-sdk/session-transcript-hit.test.ts`
- `pnpm build`
- `pnpm check`
- `git diff --check`
- `codex review --base origin/main`

## Risk checklist
- User-visible behavior: low risk; this only prevents an invalid/missing session id from aborting QMD slug fallback resolution.
- Config/env/security/auth impact: none.
- Public API impact: none intended; behavior stays within the existing resolver contract.
- Rollback: revert the single commit if the resolver should instead fail hard on malformed store entries.

## Current review state
Ready for maintainer review. Local direct resolver proof, focused validation, build, `pnpm check`, whitespace check, and Codex review are green. GitHub CI is pending after PR creation.
