### PR TITLE
fix(agents): honor effective exec policy for Claude live Bash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Docs: https://docs.openclaw.ai
 - Codex/app-server: preserve message-tool-only source reply delivery mode on active runs so sub-agent completion wakeups can steer the active Codex turn instead of being rejected. (#86287) Thanks @ferminquant.
 - Tests: sample the Windows kitchen-sink RPC gateway directly and serialize RSS probes so native runs keep the memory guard active.
 - Tests: normalize bundled plugin lifecycle probe paths and state-root lookup so native Windows release sweeps accept valid packaged plugin installs.
+- Agents/Claude CLI: route live native Bash permission requests through OpenClaw exec policy so Claude turns no longer stall on `control_request`, and document that OpenClaw exec policy is authoritative. Fixes #80819. (#86330, from #81971) Thanks @guthirry and @sallyom.
 - Config: keep benign legacy metadata write anomalies out of default doctor and config command output while preserving explicit anomaly logging for diagnostics.
 - Codex: log when implicit app-server `never` approvals are promoted for OpenClaw tool policy, including whether the trigger was a `before_tool_call` hook or trusted tool policy.
 - Codex harness: make subscription usage-limit errors without reset times explain that OpenClaw cannot determine the reset and point users to wait until Codex is available, use another Codex account, or switch to another configured model/provider. Thanks @amknight.

--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -170,13 +170,15 @@ the prompt. Skill env/API key overrides are still applied by OpenClaw to the
 child process environment for the run.
 
 Claude CLI also has its own noninteractive permission mode. OpenClaw maps that
-to the existing exec policy instead of adding Claude-specific config: when the
-effective requested exec policy is YOLO (`tools.exec.security: "full"` and
-`tools.exec.ask: "off"`), OpenClaw adds `--permission-mode bypassPermissions`.
-Per-agent `agents.list[].tools.exec` settings override global `tools.exec` for
-that agent. To force a different Claude mode, set explicit raw backend args
-such as `--permission-mode default` or `--permission-mode acceptEdits` under
-`agents.defaults.cliBackends.claude-cli.args` and matching `resumeArgs`.
+to the existing exec policy instead of adding Claude-specific policy config.
+For OpenClaw-managed Claude live sessions, the effective OpenClaw exec policy is
+authoritative: YOLO (`tools.exec.security: "full"` and
+`tools.exec.ask: "off"`) launches Claude with
+`--permission-mode bypassPermissions`, while restrictive effective exec policy
+launches Claude with `--permission-mode default`. Per-agent
+`agents.list[].tools.exec` settings override global `tools.exec` for that
+agent. Raw Claude backend args may still include `--permission-mode`, but live
+Claude launches normalize that flag to match the effective OpenClaw exec policy.
 
 The bundled Anthropic `claude-cli` backend also maps OpenClaw `/think` levels
 to Claude Code's native `--effort` flag for non-off levels. `minimal` and

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -207,13 +207,15 @@ YOLO is the default host behavior unless you tighten it explicitly:
 
 CLI-backed providers that expose their own noninteractive permission mode
 can follow this policy. Claude CLI adds
-`--permission-mode bypassPermissions` when OpenClaw's requested exec
-policy is YOLO. Override that backend behavior with explicit Claude args
-under `agents.defaults.cliBackends.claude-cli.args` / `resumeArgs` -
-for example `--permission-mode default`, `acceptEdits`, or
-`bypassPermissions`.
+`--permission-mode bypassPermissions` when OpenClaw's effective exec
+policy is YOLO. For OpenClaw-managed Claude live sessions, OpenClaw's
+effective exec policy is authoritative over Claude's native permission mode:
+YOLO normalizes live launches to `--permission-mode bypassPermissions`, and
+restrictive effective exec policy normalizes live launches to
+`--permission-mode default`, even if raw Claude backend args specify another
+mode.
 
-If you want a more conservative setup, tighten either layer back to
+If you want a more conservative setup, tighten OpenClaw exec policy back to
 `allowlist` / `on-miss` or `deny`.
 
 ### Persistent gateway-host "never prompt" setup

--- a/src/agents/cli-backends.test.ts
+++ b/src/agents/cli-backends.test.ts
@@ -585,7 +585,7 @@ describe("resolveCliBackendConfig claude-cli defaults", () => {
     expect(builder?.config.resumeArgs).toContain("bypassPermissions");
   });
 
-  it("uses existing exec policy and raw Claude args as permission overrides", () => {
+  it("preserves raw Claude permission args during backend normalization", () => {
     const safe = resolveCliBackendConfig("claude-cli", {
       tools: { exec: { security: "full", ask: "off" } },
       agents: {

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -1632,6 +1632,164 @@ ${JSON.stringify({
     expect(parsed.response.response.message).toContain("security=allowlist");
   });
 
+  it("answers Claude live control_request can_use_tool with allow when no exec policy is configured (default deployment)", async () => {
+    let stdoutListener: ((chunk: string) => void) | undefined;
+    const writes: string[] = [];
+    const stdin = {
+      write: vi.fn((data: string, cb?: (err?: Error | null) => void) => {
+        writes.push(data);
+        if (writes.length === 1) {
+          stdoutListener?.(
+            `${JSON.stringify({
+              type: "control_request",
+              request_id: "req-default-allow",
+              request: {
+                subtype: "can_use_tool",
+                tool_name: "Bash",
+                tool_use_id: "tool-default-allow-1",
+                input: { command: "echo hi" },
+              },
+            })}
+${JSON.stringify({
+  type: "system",
+  subtype: "init",
+  session_id: "live-control-default-allow",
+})}
+${JSON.stringify({
+  type: "result",
+  session_id: "live-control-default-allow",
+  result: "ok",
+})}
+`,
+          );
+        }
+        cb?.();
+      }),
+      end: vi.fn(),
+    };
+    supervisorSpawnMock.mockImplementation(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+      stdoutListener = input.onStdout;
+      return {
+        runId: "live-run-default-allow",
+        pid: 3003,
+        startedAtMs: Date.now(),
+        stdin,
+        wait: vi.fn(() => new Promise(() => {})),
+        cancel: vi.fn(),
+      };
+    });
+
+    // No tools.exec configured at all — represents the default deployment
+    // that extensions/anthropic/cli-shared.ts already launches with
+    // --permission-mode bypassPermissions via normalizeClaudePermissionArgs.
+    const result = await executePreparedCliRun(
+      buildPreparedCliRunContext({
+        provider: "claude-cli",
+        model: "sonnet",
+        runId: "run-control-default-allow",
+        prompt: "hello",
+        backend: { liveSession: "claude-stdio" },
+      }),
+    );
+    expect(result.text).toBe("ok");
+    const controlResponse = writes.find((entry) => entry.includes('"control_response"'));
+    expect(controlResponse, "control_response written to stdin").toBeDefined();
+    const parsed = JSON.parse((controlResponse ?? "").trim()) as {
+      type: string;
+      response: {
+        subtype: string;
+        request_id: string;
+        response: { behavior: string; toolUseID?: string };
+      };
+    };
+    expect(parsed.response.response.behavior).toBe("allow");
+    expect(parsed.response.response.toolUseID).toBe("tool-default-allow-1");
+  });
+
+  it("answers Claude live control_request can_use_tool with deny when raw --permission-mode override is not bypass", async () => {
+    let stdoutListener: ((chunk: string) => void) | undefined;
+    const writes: string[] = [];
+    const stdin = {
+      write: vi.fn((data: string, cb?: (err?: Error | null) => void) => {
+        writes.push(data);
+        if (writes.length === 1) {
+          stdoutListener?.(
+            `${JSON.stringify({
+              type: "control_request",
+              request_id: "req-permmode-deny",
+              request: {
+                subtype: "can_use_tool",
+                tool_name: "Bash",
+                tool_use_id: "tool-permmode-deny-1",
+                input: { command: "ls" },
+              },
+            })}
+${JSON.stringify({
+  type: "system",
+  subtype: "init",
+  session_id: "live-control-permmode-deny",
+})}
+${JSON.stringify({
+  type: "result",
+  session_id: "live-control-permmode-deny",
+  result: "ok",
+})}
+`,
+          );
+        }
+        cb?.();
+      }),
+      end: vi.fn(),
+    };
+    supervisorSpawnMock.mockImplementation(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+      stdoutListener = input.onStdout;
+      return {
+        runId: "live-run-permmode-deny",
+        pid: 3004,
+        startedAtMs: Date.now(),
+        stdin,
+        wait: vi.fn(() => new Promise(() => {})),
+        cancel: vi.fn(),
+      };
+    });
+
+    // tools.exec resolves to full/off (would normally allow native Bash),
+    // but the operator explicitly forced --permission-mode default in raw
+    // backend args. That override must be honored: deny native Bash even
+    // though the exec policy alone would permit it.
+    const result = await executePreparedCliRun(
+      buildPreparedCliRunContext({
+        provider: "claude-cli",
+        model: "sonnet",
+        runId: "run-control-permmode-deny",
+        prompt: "hello",
+        backend: {
+          liveSession: "claude-stdio",
+          args: ["-p", "--output-format", "stream-json", "--permission-mode", "default"],
+        },
+        config: {
+          tools: { exec: { security: "full", ask: "off" } },
+        } as PreparedCliRunContext["params"]["config"],
+      }),
+    );
+    expect(result.text).toBe("ok");
+    const controlResponse = writes.find((entry) => entry.includes('"control_response"'));
+    expect(controlResponse, "control_response written to stdin").toBeDefined();
+    const parsed = JSON.parse((controlResponse ?? "").trim()) as {
+      type: string;
+      response: {
+        subtype: string;
+        request_id: string;
+        response: { behavior: string; message: string; decisionClassification: string };
+      };
+    };
+    expect(parsed.response.response.behavior).toBe("deny");
+    expect(parsed.response.response.decisionClassification).toBe("user_reject");
+    expect(parsed.response.response.message).toContain("permission-mode=default");
+  });
+
   it("restarts Claude live sessions for env changes and fresh retries", async () => {
     const cancels: Array<ReturnType<typeof vi.fn>> = [];
     const turnResults = ["first-ok", "resume-ok", "env-ok", "fresh-ok"];

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -1478,6 +1478,160 @@ describe("runCliAgent spawn path", () => {
     expect(requireArgAfter(args, "--permission-prompt-tool")).toBe("stdio");
   });
 
+  it("answers Claude live control_request can_use_tool with allow when exec policy is full/no-ask", async () => {
+    let stdoutListener: ((chunk: string) => void) | undefined;
+    const writes: string[] = [];
+    const stdin = {
+      write: vi.fn((data: string, cb?: (err?: Error | null) => void) => {
+        writes.push(data);
+        if (writes.length === 1) {
+          stdoutListener?.(
+            `${JSON.stringify({
+              type: "control_request",
+              request_id: "req-allow",
+              request: {
+                subtype: "can_use_tool",
+                tool_name: "Bash",
+                tool_use_id: "tool-allow-1",
+                input: { command: "ls" },
+              },
+            })}
+${JSON.stringify({
+  type: "system",
+  subtype: "init",
+  session_id: "live-control-allow",
+})}
+${JSON.stringify({
+  type: "result",
+  session_id: "live-control-allow",
+  result: "ok",
+})}
+`,
+          );
+        }
+        cb?.();
+      }),
+      end: vi.fn(),
+    };
+    supervisorSpawnMock.mockImplementation(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+      stdoutListener = input.onStdout;
+      return {
+        runId: "live-run-allow",
+        pid: 3001,
+        startedAtMs: Date.now(),
+        stdin,
+        wait: vi.fn(() => new Promise(() => {})),
+        cancel: vi.fn(),
+      };
+    });
+
+    const result = await executePreparedCliRun(
+      buildPreparedCliRunContext({
+        provider: "claude-cli",
+        model: "sonnet",
+        runId: "run-control-allow",
+        prompt: "hello",
+        backend: { liveSession: "claude-stdio" },
+        config: {
+          tools: { exec: { security: "full", ask: "off" } },
+        } as PreparedCliRunContext["params"]["config"],
+      }),
+    );
+    expect(result.text).toBe("ok");
+    const controlResponse = writes.find((entry) => entry.includes('"control_response"'));
+    expect(controlResponse, "control_response written to stdin").toBeDefined();
+    const parsed = JSON.parse((controlResponse ?? "").trim()) as {
+      type: string;
+      response: {
+        subtype: string;
+        request_id: string;
+        response: { behavior: string; toolUseID?: string };
+      };
+    };
+    expect(parsed.type).toBe("control_response");
+    expect(parsed.response.subtype).toBe("success");
+    expect(parsed.response.request_id).toBe("req-allow");
+    expect(parsed.response.response.behavior).toBe("allow");
+    expect(parsed.response.response.toolUseID).toBe("tool-allow-1");
+  });
+
+  it("answers Claude live control_request can_use_tool with deny when exec policy is restrictive", async () => {
+    let stdoutListener: ((chunk: string) => void) | undefined;
+    const writes: string[] = [];
+    const stdin = {
+      write: vi.fn((data: string, cb?: (err?: Error | null) => void) => {
+        writes.push(data);
+        if (writes.length === 1) {
+          stdoutListener?.(
+            `${JSON.stringify({
+              type: "control_request",
+              request_id: "req-deny",
+              request: {
+                subtype: "can_use_tool",
+                tool_name: "Bash",
+                tool_use_id: "tool-deny-1",
+                input: { command: "rm -rf /" },
+              },
+            })}
+${JSON.stringify({
+  type: "system",
+  subtype: "init",
+  session_id: "live-control-deny",
+})}
+${JSON.stringify({
+  type: "result",
+  session_id: "live-control-deny",
+  result: "ok",
+})}
+`,
+          );
+        }
+        cb?.();
+      }),
+      end: vi.fn(),
+    };
+    supervisorSpawnMock.mockImplementation(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+      stdoutListener = input.onStdout;
+      return {
+        runId: "live-run-deny",
+        pid: 3002,
+        startedAtMs: Date.now(),
+        stdin,
+        wait: vi.fn(() => new Promise(() => {})),
+        cancel: vi.fn(),
+      };
+    });
+
+    const result = await executePreparedCliRun(
+      buildPreparedCliRunContext({
+        provider: "claude-cli",
+        model: "sonnet",
+        runId: "run-control-deny",
+        prompt: "hello",
+        backend: { liveSession: "claude-stdio" },
+        config: {
+          tools: { exec: { security: "allowlist", ask: "on-miss" } },
+        } as PreparedCliRunContext["params"]["config"],
+      }),
+    );
+    expect(result.text).toBe("ok");
+    const controlResponse = writes.find((entry) => entry.includes('"control_response"'));
+    expect(controlResponse, "control_response written to stdin").toBeDefined();
+    const parsed = JSON.parse((controlResponse ?? "").trim()) as {
+      type: string;
+      response: {
+        subtype: string;
+        request_id: string;
+        response: { behavior: string; message: string; decisionClassification: string };
+      };
+    };
+    expect(parsed.response.response.behavior).toBe("deny");
+    expect(parsed.response.response.decisionClassification).toBe("user_reject");
+    expect(parsed.response.response.message).toContain("security=allowlist");
+  });
+
   it("restarts Claude live sessions for env changes and fresh retries", async () => {
     const cancels: Array<ReturnType<typeof vi.fn>> = [];
     const turnResults = ["first-ok", "resume-ok", "env-ok", "fresh-ok"];

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -52,6 +52,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
   resetClaudeLiveSessionsForTest();
   replyRunTesting.resetReplyRunRegistry();
 });
@@ -63,6 +64,8 @@ function buildPreparedCliRunContext(params: {
   prompt?: string;
   sessionId?: string;
   sessionKey?: string;
+  sessionEntry?: PreparedCliRunContext["params"]["sessionEntry"];
+  agentId?: string;
   backend?: Partial<PreparedCliRunContext["preparedBackend"]["backend"]>;
   resolveExecutionArgs?: PreparedCliRunContext["backendResolved"]["resolveExecutionArgs"];
   config?: PreparedCliRunContext["params"]["config"];
@@ -104,6 +107,8 @@ function buildPreparedCliRunContext(params: {
     params: {
       sessionId: params.sessionId ?? "s1",
       sessionKey: params.sessionKey,
+      sessionEntry: params.sessionEntry,
+      agentId: params.agentId,
       sessionFile: "/tmp/session.jsonl",
       workspaceDir,
       config: params.config,
@@ -200,6 +205,47 @@ async function expectPathMissing(targetPath: string): Promise<void> {
     return;
   }
   throw new Error(`expected ${targetPath} to be missing`);
+}
+
+async function withTempExecApprovalsFile(
+  file: Record<string, unknown>,
+  run: () => Promise<void>,
+): Promise<void> {
+  const originalHome = process.env.HOME;
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-exec-approvals-"));
+  await fs.mkdir(path.join(home, ".openclaw"), { recursive: true });
+  await fs.writeFile(
+    path.join(home, ".openclaw", "exec-approvals.json"),
+    `${JSON.stringify(file)}\n`,
+    "utf-8",
+  );
+  process.env.HOME = home;
+  try {
+    await run();
+  } finally {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    await fs.rm(home, { recursive: true, force: true });
+  }
+}
+
+async function withTempOpenClawHome(run: (home: string) => Promise<void>): Promise<void> {
+  const originalOpenClawHome = process.env.OPENCLAW_HOME;
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-home-"));
+  process.env.OPENCLAW_HOME = home;
+  try {
+    await run(home);
+  } finally {
+    if (originalOpenClawHome === undefined) {
+      delete process.env.OPENCLAW_HOME;
+    } else {
+      process.env.OPENCLAW_HOME = originalOpenClawHome;
+    }
+    await fs.rm(home, { recursive: true, force: true });
+  }
 }
 
 describe("runCliAgent spawn path", () => {
@@ -1630,6 +1676,64 @@ ${JSON.stringify({
     expect(parsed.response.response.behavior).toBe("deny");
     expect(parsed.response.response.decisionClassification).toBe("user_reject");
     expect(parsed.response.response.message).toContain("security=allowlist");
+    const spawnArg = supervisorSpawnMock.mock.calls.at(-1)?.[0] as { argv?: string[] };
+    expect(requireArgAfter(spawnArg.argv, "--permission-mode")).toBe("default");
+  });
+
+  it("does not create exec approvals file while resolving Claude live policy", async () => {
+    await withTempOpenClawHome(async (home) => {
+      const approvalsPath = path.join(home, ".openclaw", "exec-approvals.json");
+      let stdoutListener: ((chunk: string) => void) | undefined;
+      const stdin = {
+        write: vi.fn((_data: string, cb?: (err?: Error | null) => void) => {
+          stdoutListener?.(
+            `${JSON.stringify({
+              type: "system",
+              subtype: "init",
+              session_id: "live-no-approvals-file",
+            })}
+${JSON.stringify({
+  type: "result",
+  session_id: "live-no-approvals-file",
+  result: "ok",
+})}
+`,
+          );
+          cb?.();
+        }),
+        end: vi.fn(),
+      };
+      supervisorSpawnMock.mockImplementation(async (...args: unknown[]) => {
+        const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+        stdoutListener = input.onStdout;
+        return {
+          runId: "live-run-no-approvals-file",
+          pid: 3009,
+          startedAtMs: Date.now(),
+          stdin,
+          wait: vi.fn(() => new Promise(() => {})),
+          cancel: vi.fn(),
+        };
+      });
+
+      const result = await executePreparedCliRun(
+        buildPreparedCliRunContext({
+          provider: "claude-cli",
+          model: "sonnet",
+          runId: "run-no-approvals-file",
+          prompt: "hello",
+          backend: { liveSession: "claude-stdio" },
+          config: {
+            tools: { exec: { security: "allowlist", ask: "on-miss" } },
+          } as PreparedCliRunContext["params"]["config"],
+        }),
+      );
+
+      expect(result.text).toBe("ok");
+      const spawnArg = supervisorSpawnMock.mock.calls.at(-1)?.[0] as { argv?: string[] };
+      expect(requireArgAfter(spawnArg.argv, "--permission-mode")).toBe("default");
+      await expectPathMissing(approvalsPath);
+    });
   });
 
   it("answers Claude live control_request can_use_tool with allow when no exec policy is configured (default deployment)", async () => {
@@ -1707,7 +1811,97 @@ ${JSON.stringify({
     expect(parsed.response.response.toolUseID).toBe("tool-default-allow-1");
   });
 
-  it("answers Claude live control_request can_use_tool with deny when raw --permission-mode override is not bypass", async () => {
+  it("answers Claude live control_request can_use_tool with deny when approval defaults are restrictive", async () => {
+    await withTempExecApprovalsFile(
+      {
+        version: 1,
+        defaults: { security: "allowlist", ask: "on-miss" },
+        agents: {},
+      },
+      async () => {
+        let stdoutListener: ((chunk: string) => void) | undefined;
+        const writes: string[] = [];
+        const stdin = {
+          write: vi.fn((data: string, cb?: (err?: Error | null) => void) => {
+            writes.push(data);
+            if (writes.length === 1) {
+              stdoutListener?.(
+                `${JSON.stringify({
+                  type: "control_request",
+                  request_id: "req-approval-default-deny",
+                  request: {
+                    subtype: "can_use_tool",
+                    tool_name: "Bash",
+                    tool_use_id: "tool-approval-default-deny-1",
+                    input: { command: "ls" },
+                  },
+                })}
+${JSON.stringify({
+  type: "system",
+  subtype: "init",
+  session_id: "live-control-approval-default-deny",
+})}
+${JSON.stringify({
+  type: "result",
+  session_id: "live-control-approval-default-deny",
+  result: "ok",
+})}
+`,
+              );
+            }
+            cb?.();
+          }),
+          end: vi.fn(),
+        };
+        supervisorSpawnMock.mockImplementation(async (...args: unknown[]) => {
+          const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+          stdoutListener = input.onStdout;
+          return {
+            runId: "live-run-approval-default-deny",
+            pid: 3005,
+            startedAtMs: Date.now(),
+            stdin,
+            wait: vi.fn(() => new Promise(() => {})),
+            cancel: vi.fn(),
+          };
+        });
+
+        const result = await executePreparedCliRun(
+          buildPreparedCliRunContext({
+            provider: "claude-cli",
+            model: "sonnet",
+            runId: "run-control-approval-default-deny",
+            prompt: "hello",
+            backend: {
+              liveSession: "claude-stdio",
+              args: [
+                "-p",
+                "--output-format",
+                "stream-json",
+                "--permission-mode",
+                "bypassPermissions",
+              ],
+            },
+          }),
+        );
+        expect(result.text).toBe("ok");
+        const controlResponse = writes.find((entry) => entry.includes('"control_response"'));
+        expect(controlResponse, "control_response written to stdin").toBeDefined();
+        const parsed = JSON.parse((controlResponse ?? "").trim()) as {
+          response: {
+            response: { behavior: string; message: string; decisionClassification: string };
+          };
+        };
+        expect(parsed.response.response.behavior).toBe("deny");
+        expect(parsed.response.response.decisionClassification).toBe("user_reject");
+        expect(parsed.response.response.message).toContain("security=allowlist");
+        const spawnArg = supervisorSpawnMock.mock.calls.at(-1)?.[0] as { argv?: string[] };
+        expect(requireArgAfter(spawnArg.argv, "--permission-mode")).toBe("default");
+      },
+    );
+  });
+
+  it("answers Claude live control_request can_use_tool with deny when session exec ask is restrictive", async () => {
     let stdoutListener: ((chunk: string) => void) | undefined;
     const writes: string[] = [];
     const stdin = {
@@ -1717,22 +1911,22 @@ ${JSON.stringify({
           stdoutListener?.(
             `${JSON.stringify({
               type: "control_request",
-              request_id: "req-permmode-deny",
+              request_id: "req-session-ask-deny",
               request: {
                 subtype: "can_use_tool",
                 tool_name: "Bash",
-                tool_use_id: "tool-permmode-deny-1",
+                tool_use_id: "tool-session-ask-deny-1",
                 input: { command: "ls" },
               },
             })}
 ${JSON.stringify({
   type: "system",
   subtype: "init",
-  session_id: "live-control-permmode-deny",
+  session_id: "live-control-session-ask-deny",
 })}
 ${JSON.stringify({
   type: "result",
-  session_id: "live-control-permmode-deny",
+  session_id: "live-control-session-ask-deny",
   result: "ok",
 })}
 `,
@@ -1746,7 +1940,272 @@ ${JSON.stringify({
       const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
       stdoutListener = input.onStdout;
       return {
-        runId: "live-run-permmode-deny",
+        runId: "live-run-session-ask-deny",
+        pid: 3006,
+        startedAtMs: Date.now(),
+        stdin,
+        wait: vi.fn(() => new Promise(() => {})),
+        cancel: vi.fn(),
+      };
+    });
+
+    const result = await executePreparedCliRun(
+      buildPreparedCliRunContext({
+        provider: "claude-cli",
+        model: "sonnet",
+        runId: "run-control-session-ask-deny",
+        prompt: "hello",
+        backend: {
+          liveSession: "claude-stdio",
+          args: ["-p", "--output-format", "stream-json", "--permission-mode", "bypassPermissions"],
+        },
+        sessionEntry: { execAsk: "always" } as PreparedCliRunContext["params"]["sessionEntry"],
+        config: {
+          tools: { exec: { security: "full", ask: "off" } },
+        } as PreparedCliRunContext["params"]["config"],
+      }),
+    );
+    expect(result.text).toBe("ok");
+    const controlResponse = writes.find((entry) => entry.includes('"control_response"'));
+    expect(controlResponse, "control_response written to stdin").toBeDefined();
+    const parsed = JSON.parse((controlResponse ?? "").trim()) as {
+      response: {
+        response: { behavior: string; message: string; decisionClassification: string };
+      };
+    };
+    expect(parsed.response.response.behavior).toBe("deny");
+    expect(parsed.response.response.decisionClassification).toBe("user_reject");
+    expect(parsed.response.response.message).toContain("ask=always");
+    const spawnArg = supervisorSpawnMock.mock.calls.at(-1)?.[0] as { argv?: string[] };
+    expect(requireArgAfter(spawnArg.argv, "--permission-mode")).toBe("default");
+  });
+
+  it("answers Claude live control_request can_use_tool with deny when agent approvals are restrictive", async () => {
+    await withTempExecApprovalsFile(
+      {
+        version: 1,
+        agents: { reviewer: { security: "deny" } },
+      },
+      async () => {
+        let stdoutListener: ((chunk: string) => void) | undefined;
+        const writes: string[] = [];
+        const stdin = {
+          write: vi.fn((data: string, cb?: (err?: Error | null) => void) => {
+            writes.push(data);
+            if (writes.length === 1) {
+              stdoutListener?.(
+                `${JSON.stringify({
+                  type: "control_request",
+                  request_id: "req-agent-approval-deny",
+                  request: {
+                    subtype: "can_use_tool",
+                    tool_name: "Bash",
+                    tool_use_id: "tool-agent-approval-deny-1",
+                    input: { command: "ls" },
+                  },
+                })}
+${JSON.stringify({
+  type: "system",
+  subtype: "init",
+  session_id: "live-control-agent-approval-deny",
+})}
+${JSON.stringify({
+  type: "result",
+  session_id: "live-control-agent-approval-deny",
+  result: "ok",
+})}
+`,
+              );
+            }
+            cb?.();
+          }),
+          end: vi.fn(),
+        };
+        supervisorSpawnMock.mockImplementation(async (...args: unknown[]) => {
+          const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+          stdoutListener = input.onStdout;
+          return {
+            runId: "live-run-agent-approval-deny",
+            pid: 3007,
+            startedAtMs: Date.now(),
+            stdin,
+            wait: vi.fn(() => new Promise(() => {})),
+            cancel: vi.fn(),
+          };
+        });
+
+        const result = await executePreparedCliRun(
+          buildPreparedCliRunContext({
+            provider: "claude-cli",
+            model: "sonnet",
+            runId: "run-control-agent-approval-deny",
+            prompt: "hello",
+            backend: {
+              liveSession: "claude-stdio",
+              args: [
+                "-p",
+                "--output-format",
+                "stream-json",
+                "--permission-mode",
+                "bypassPermissions",
+              ],
+            },
+            agentId: "reviewer",
+            config: {
+              tools: { exec: { security: "full", ask: "off" } },
+            } as PreparedCliRunContext["params"]["config"],
+          }),
+        );
+        expect(result.text).toBe("ok");
+        const controlResponse = writes.find((entry) => entry.includes('"control_response"'));
+        expect(controlResponse, "control_response written to stdin").toBeDefined();
+        const parsed = JSON.parse((controlResponse ?? "").trim()) as {
+          response: {
+            response: { behavior: string; message: string; decisionClassification: string };
+          };
+        };
+        expect(parsed.response.response.behavior).toBe("deny");
+        expect(parsed.response.response.decisionClassification).toBe("user_reject");
+        expect(parsed.response.response.message).toContain("security=deny");
+        const spawnArg = supervisorSpawnMock.mock.calls.at(-1)?.[0] as { argv?: string[] };
+        expect(requireArgAfter(spawnArg.argv, "--permission-mode")).toBe("default");
+      },
+    );
+  });
+
+  it("answers Claude live control_request can_use_tool with deny when session-key agent approvals are restrictive", async () => {
+    await withTempExecApprovalsFile(
+      {
+        version: 1,
+        agents: { reviewer: { security: "deny" } },
+      },
+      async () => {
+        let stdoutListener: ((chunk: string) => void) | undefined;
+        const writes: string[] = [];
+        const stdin = {
+          write: vi.fn((data: string, cb?: (err?: Error | null) => void) => {
+            writes.push(data);
+            if (writes.length === 1) {
+              stdoutListener?.(
+                `${JSON.stringify({
+                  type: "control_request",
+                  request_id: "req-session-key-approval-deny",
+                  request: {
+                    subtype: "can_use_tool",
+                    tool_name: "Bash",
+                    tool_use_id: "tool-session-key-approval-deny-1",
+                    input: { command: "ls" },
+                  },
+                })}
+${JSON.stringify({
+  type: "system",
+  subtype: "init",
+  session_id: "live-control-session-key-approval-deny",
+})}
+${JSON.stringify({
+  type: "result",
+  session_id: "live-control-session-key-approval-deny",
+  result: "ok",
+})}
+`,
+              );
+            }
+            cb?.();
+          }),
+          end: vi.fn(),
+        };
+        supervisorSpawnMock.mockImplementation(async (...args: unknown[]) => {
+          const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+          stdoutListener = input.onStdout;
+          return {
+            runId: "live-run-session-key-approval-deny",
+            pid: 3008,
+            startedAtMs: Date.now(),
+            stdin,
+            wait: vi.fn(() => new Promise(() => {})),
+            cancel: vi.fn(),
+          };
+        });
+
+        const result = await executePreparedCliRun(
+          buildPreparedCliRunContext({
+            provider: "claude-cli",
+            model: "sonnet",
+            runId: "run-control-session-key-approval-deny",
+            prompt: "hello",
+            backend: {
+              liveSession: "claude-stdio",
+              args: [
+                "-p",
+                "--output-format",
+                "stream-json",
+                "--permission-mode",
+                "bypassPermissions",
+              ],
+            },
+            sessionKey: "agent:reviewer:main",
+            config: {
+              tools: { exec: { security: "full", ask: "off" } },
+            } as PreparedCliRunContext["params"]["config"],
+          }),
+        );
+        expect(result.text).toBe("ok");
+        const controlResponse = writes.find((entry) => entry.includes('"control_response"'));
+        expect(controlResponse, "control_response written to stdin").toBeDefined();
+        const parsed = JSON.parse((controlResponse ?? "").trim()) as {
+          response: {
+            response: { behavior: string; message: string; decisionClassification: string };
+          };
+        };
+        expect(parsed.response.response.behavior).toBe("deny");
+        expect(parsed.response.response.decisionClassification).toBe("user_reject");
+        expect(parsed.response.response.message).toContain("security=deny");
+        const spawnArg = supervisorSpawnMock.mock.calls.at(-1)?.[0] as { argv?: string[] };
+        expect(requireArgAfter(spawnArg.argv, "--permission-mode")).toBe("default");
+      },
+    );
+  });
+
+  it("answers Claude live control_request can_use_tool with allow when OpenClaw exec is YOLO despite raw --permission-mode default", async () => {
+    let stdoutListener: ((chunk: string) => void) | undefined;
+    const writes: string[] = [];
+    const stdin = {
+      write: vi.fn((data: string, cb?: (err?: Error | null) => void) => {
+        writes.push(data);
+        if (writes.length === 1) {
+          stdoutListener?.(
+            `${JSON.stringify({
+              type: "control_request",
+              request_id: "req-permmode-allow",
+              request: {
+                subtype: "can_use_tool",
+                tool_name: "Bash",
+                tool_use_id: "tool-permmode-allow-1",
+                input: { command: "ls" },
+              },
+            })}
+${JSON.stringify({
+  type: "system",
+  subtype: "init",
+  session_id: "live-control-permmode-allow",
+})}
+${JSON.stringify({
+  type: "result",
+  session_id: "live-control-permmode-allow",
+  result: "ok",
+})}
+`,
+          );
+        }
+        cb?.();
+      }),
+      end: vi.fn(),
+    };
+    supervisorSpawnMock.mockImplementation(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+      stdoutListener = input.onStdout;
+      return {
+        runId: "live-run-permmode-allow",
         pid: 3004,
         startedAtMs: Date.now(),
         stdin,
@@ -1756,14 +2215,13 @@ ${JSON.stringify({
     });
 
     // tools.exec resolves to full/off (would normally allow native Bash),
-    // but the operator explicitly forced --permission-mode default in raw
-    // backend args. That override must be honored: deny native Bash even
-    // though the exec policy alone would permit it.
+    // and OpenClaw policy is authoritative over raw Claude permission-mode
+    // args. The live launch is normalized back to bypassPermissions.
     const result = await executePreparedCliRun(
       buildPreparedCliRunContext({
         provider: "claude-cli",
         model: "sonnet",
-        runId: "run-control-permmode-deny",
+        runId: "run-control-permmode-allow",
         prompt: "hello",
         backend: {
           liveSession: "claude-stdio",
@@ -1782,12 +2240,13 @@ ${JSON.stringify({
       response: {
         subtype: string;
         request_id: string;
-        response: { behavior: string; message: string; decisionClassification: string };
+        response: { behavior: string; toolUseID?: string };
       };
     };
-    expect(parsed.response.response.behavior).toBe("deny");
-    expect(parsed.response.response.decisionClassification).toBe("user_reject");
-    expect(parsed.response.response.message).toContain("permission-mode=default");
+    expect(parsed.response.response.behavior).toBe("allow");
+    expect(parsed.response.response.toolUseID).toBe("tool-permmode-allow-1");
+    const spawnArg = supervisorSpawnMock.mock.calls.at(-1)?.[0] as { argv?: string[] };
+    expect(requireArgAfter(spawnArg.argv, "--permission-mode")).toBe("bypassPermissions");
   });
 
   it("restarts Claude live sessions for env changes and fresh retries", async () => {

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -718,6 +718,7 @@ export function buildRunClaudeCliAgentParams(params: RunClaudeCliAgentParams): R
   return {
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
+    sessionEntry: params.sessionEntry,
     agentId: params.agentId,
     trigger: params.trigger,
     sessionFile: params.sessionFile,

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -1,6 +1,8 @@
 import crypto from "node:crypto";
 import type { ReplyBackendHandle } from "../../auto-reply/reply/reply-run-registry.js";
 import type { CliBackendConfig } from "../../config/types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { ExecToolConfig } from "../../config/types.tools.js";
 import {
   createCliJsonlStreamingParser,
   extractCliErrorMessage,
@@ -46,6 +48,12 @@ type ClaudeLiveSession = {
   cleanup: () => Promise<void>;
   cleanupDone: boolean;
   closing: boolean;
+  controlRequestPolicy: ClaudeLiveControlRequestPolicy;
+};
+type ClaudeLiveControlRequestPolicy = {
+  allowNativeBash: boolean;
+  security: "deny" | "allowlist" | "full";
+  ask: "off" | "on-miss" | "always";
 };
 type ClaudeLiveRunResult = {
   output: CliOutput;
@@ -286,6 +294,7 @@ function buildClaudeLiveFingerprint(params: {
     env: Object.keys(params.env)
       .toSorted()
       .map((key) => [key, params.env[key] ? sha256(params.env[key]) : ""]),
+    controlRequestPolicy: resolveClaudeLiveControlRequestPolicy(params.context),
   });
 }
 
@@ -449,6 +458,124 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
+function resolveExecPolicyForClaudeLiveSession(
+  context: PreparedCliRunContext,
+): ExecToolConfig | undefined {
+  const config: OpenClawConfig | undefined = context.params.config;
+  const agentId = context.params.agentId;
+  if (config && agentId) {
+    const agentEntry = config.agents?.list?.find((entry) => entry?.id === agentId);
+    const agentExec = agentEntry?.tools?.exec;
+    if (agentExec) {
+      return agentExec;
+    }
+  }
+  return config?.tools?.exec;
+}
+
+function resolveClaudeLiveControlRequestPolicy(
+  context: PreparedCliRunContext,
+): ClaudeLiveControlRequestPolicy {
+  const exec = resolveExecPolicyForClaudeLiveSession(context);
+  // Mirror the runtime fallbacks used by the node-host exec runner so the
+  // bridge's view of "what the user actually granted" matches what real
+  // Bash invocations would see.
+  const security: ClaudeLiveControlRequestPolicy["security"] =
+    exec?.security === "deny" || exec?.security === "allowlist" || exec?.security === "full"
+      ? exec.security
+      : "allowlist";
+  const ask: ClaudeLiveControlRequestPolicy["ask"] =
+    exec?.ask === "off" || exec?.ask === "on-miss" || exec?.ask === "always" ? exec.ask : "on-miss";
+  return {
+    allowNativeBash: security === "full" && ask === "off",
+    security,
+    ask,
+  };
+}
+
+function writeClaudeLiveControlResponse(
+  session: ClaudeLiveSession,
+  response: Record<string, unknown>,
+): void {
+  const stdin = session.managedRun.stdin;
+  if (!stdin) {
+    closeLiveSession(
+      session,
+      "abort",
+      new Error("Claude CLI live session stdin is unavailable for control response"),
+    );
+    return;
+  }
+  stdin.write(`${JSON.stringify(response)}\n`, (error) => {
+    if (error) {
+      closeLiveSession(session, "abort", error);
+    }
+  });
+}
+
+function buildClaudeLivePermissionResult(
+  session: ClaudeLiveSession,
+  request: Record<string, unknown>,
+): Record<string, unknown> {
+  const toolName = typeof request.tool_name === "string" ? request.tool_name : "";
+  const toolUseID = typeof request.tool_use_id === "string" ? request.tool_use_id : undefined;
+  if (toolName === "Bash" && session.controlRequestPolicy.allowNativeBash) {
+    return {
+      behavior: "allow",
+      updatedInput: isRecord(request.input) ? request.input : {},
+      ...(toolUseID ? { toolUseID } : {}),
+    };
+  }
+  const message =
+    toolName === "Bash"
+      ? `OpenClaw denied Claude native Bash because the effective exec policy is security=${session.controlRequestPolicy.security}, ask=${session.controlRequestPolicy.ask}; this bridge only auto-allows Bash when OpenClaw exec is full/no-ask.`
+      : `OpenClaw denied Claude native ${toolName || "tool"}; this bridge only maps Claude native Bash permission prompts to OpenClaw exec policy. Use OpenClaw MCP tools instead.`;
+  return {
+    behavior: "deny",
+    message,
+    ...(toolUseID ? { toolUseID } : {}),
+    decisionClassification: "user_reject",
+  };
+}
+
+function handleClaudeLiveControlRequest(
+  session: ClaudeLiveSession,
+  parsed: Record<string, unknown>,
+): void {
+  const requestId = typeof parsed.request_id === "string" ? parsed.request_id : "";
+  const request = isRecord(parsed.request) ? parsed.request : null;
+  if (!requestId || !request) {
+    cliBackendLog.warn("claude live control_request ignored: malformed request");
+    return;
+  }
+  if (request.subtype === "can_use_tool") {
+    const permissionResult = buildClaudeLivePermissionResult(session, request);
+    const toolName = typeof request.tool_name === "string" ? request.tool_name : "unknown";
+    cliBackendLog.info(
+      `claude live control_request: subtype=can_use_tool tool=${toolName} decision=${permissionResult.behavior as string}`,
+    );
+    writeClaudeLiveControlResponse(session, {
+      type: "control_response",
+      response: {
+        subtype: "success",
+        request_id: requestId,
+        response: permissionResult,
+      },
+    });
+    return;
+  }
+  const subtype = typeof request.subtype === "string" ? request.subtype : "unknown";
+  cliBackendLog.warn(`claude live control_request denied: unsupported subtype=${subtype}`);
+  writeClaudeLiveControlResponse(session, {
+    type: "control_response",
+    response: {
+      subtype: "error",
+      request_id: requestId,
+      error: `OpenClaw Claude live bridge does not support control request subtype '${subtype}'.`,
+    },
+  });
+}
+
 function normalizePositiveInt(
   value: number | undefined,
   fallback: number,
@@ -528,6 +655,13 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
   }
   const parsed = parseClaudeLiveJsonLine(session, trimmed);
   if (!parsed) {
+    return;
+  }
+  if (parsed.type === "control_request") {
+    handleClaudeLiveControlRequest(session, parsed);
+    return;
+  }
+  if (parsed.type === "control_response") {
     return;
   }
   if (session.drainingAbortedTurn) {
@@ -739,6 +873,7 @@ async function createClaudeLiveSession(params: {
     cleanup: params.cleanup,
     cleanupDone: false,
     closing: false,
+    controlRequestPolicy: resolveClaudeLiveControlRequestPolicy(params.context),
   };
   void managedRun.wait().then(
     (exit) => handleClaudeExit(session, exit.exitCode),

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -1,8 +1,13 @@
 import crypto from "node:crypto";
 import type { ReplyBackendHandle } from "../../auto-reply/reply/reply-run-registry.js";
 import type { CliBackendConfig } from "../../config/types.js";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type { ExecToolConfig } from "../../config/types.tools.js";
+import {
+  loadExecApprovals,
+  maxAsk,
+  minSecurity,
+  resolveExecApprovalsFromFile,
+} from "../../infra/exec-approvals.js";
+import { resolveSessionAgentIds } from "../agent-scope.js";
 import {
   createCliJsonlStreamingParser,
   extractCliErrorMessage,
@@ -10,6 +15,7 @@ import {
   type CliOutput,
   type CliStreamingDelta,
 } from "../cli-output.js";
+import { resolveExecDefaults } from "../exec-defaults.js";
 import { FailoverError, resolveFailoverStatus } from "../failover-error.js";
 import { classifyFailoverReason } from "../pi-embedded-helpers.js";
 import { cliBackendLog } from "./log.js";
@@ -57,10 +63,11 @@ type ClaudeLiveControlRequestPolicy = {
   effectivePermissionMode?: string;
 };
 
-// Claude's bypass permission mode disables its native permission prompts entirely;
-// the live bridge must only auto-allow native Bash when the launched Claude is
-// actually in that mode AND the OpenClaw exec policy resolves to full/no-ask.
+// OpenClaw exec policy is authoritative for Claude live native Bash. Keep
+// Claude's launch mode aligned with the effective OpenClaw policy instead of
+// letting raw Claude permission args silently relax or tighten it.
 const CLAUDE_BYPASS_PERMISSION_MODE = "bypassPermissions";
+const CLAUDE_DEFAULT_PERMISSION_MODE = "default";
 const CLAUDE_PERMISSION_MODE_FLAG = "--permission-mode";
 type ClaudeLiveRunResult = {
   output: CliOutput;
@@ -465,21 +472,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
-function resolveExecPolicyForClaudeLiveSession(
-  context: PreparedCliRunContext,
-): ExecToolConfig | undefined {
-  const config: OpenClawConfig | undefined = context.params.config;
-  const agentId = context.params.agentId;
-  if (config && agentId) {
-    const agentEntry = config.agents?.list?.find((entry) => entry?.id === agentId);
-    const agentExec = agentEntry?.tools?.exec;
-    if (agentExec) {
-      return agentExec;
-    }
-  }
-  return config?.tools?.exec;
-}
-
 function extractClaudeEffectivePermissionMode(argv: readonly string[]): string | undefined {
   // Scan from the end so the last-set --permission-mode wins, matching how
   // CLI arg precedence works in practice and how
@@ -508,43 +500,58 @@ function resolveClaudeLiveControlRequestPolicy(
   context: PreparedCliRunContext,
   argv?: readonly string[],
 ): ClaudeLiveControlRequestPolicy {
-  const exec = resolveExecPolicyForClaudeLiveSession(context);
-  // Use the same defaults as extensions/anthropic/cli-shared.ts
-  // isOpenClawRequestedYolo (security ?? "full", ask ?? "off") and
-  // src/agents/exec-defaults.ts resolveExecDefaults, so the bridge's view of
-  // "what the user actually granted" matches both the launched Claude
-  // permission mode and the real Bash exec runner.
-  const security: ClaudeLiveControlRequestPolicy["security"] =
-    exec?.security === "deny" || exec?.security === "allowlist" || exec?.security === "full"
-      ? exec.security
-      : "full";
-  const ask: ClaudeLiveControlRequestPolicy["ask"] =
-    exec?.ask === "off" || exec?.ask === "on-miss" || exec?.ask === "always" ? exec.ask : "off";
-  // Effective permission mode: prefer an explicit --permission-mode in argv
-  // (which is how operators override OpenClaw's automatic bypass), and fall
-  // back to what extensions/anthropic/cli-shared.ts:normalizeClaudePermissionArgs
-  // would have inserted for an un-overridden launch. This keeps the bridge's
-  // view of the launched Claude mode in sync with what the backend actually
-  // passes on argv even in callers that constructed argv before normalization.
+  const execDefaults = resolveExecDefaults({
+    cfg: context.params.config,
+    sessionEntry: context.params.sessionEntry,
+    agentId: context.params.agentId,
+    sessionKey: context.params.sessionKey,
+  });
+  const effectiveAgentId = resolveSessionAgentIds({
+    sessionKey: context.params.sessionKey,
+    config: context.params.config,
+    agentId: context.params.agentId,
+  }).sessionAgentId;
+  const approvals = resolveExecApprovalsFromFile({
+    file: loadExecApprovals(),
+    agentId: effectiveAgentId,
+    overrides: {
+      security: execDefaults.security,
+      ask: execDefaults.ask,
+    },
+  });
+  const security: ClaudeLiveControlRequestPolicy["security"] = minSecurity(
+    execDefaults.security,
+    approvals.agent.security,
+  );
+  const ask: ClaudeLiveControlRequestPolicy["ask"] = maxAsk(execDefaults.ask, approvals.agent.ask);
+  // Effective permission mode starts from argv so we can detect when the live
+  // launch needs to be normalized back to OpenClaw's effective exec policy.
   const argvMode = argv ? extractClaudeEffectivePermissionMode(argv) : undefined;
   const synthesizedMode =
     security === "full" && ask === "off" ? CLAUDE_BYPASS_PERMISSION_MODE : undefined;
   const effectivePermissionMode = argvMode ?? synthesizedMode;
-  // Auto-allow native Bash only when the launched Claude is actually in the
-  // bypass-permissions path (no native prompt) AND the OpenClaw exec policy
-  // resolves to full/no-ask. Explicit raw-arg overrides like
-  // --permission-mode default or acceptEdits broaden Claude's native prompting
-  // intentionally; honor that operator intent by routing through deny here.
-  const allowNativeBash =
-    security === "full" &&
-    ask === "off" &&
-    effectivePermissionMode === CLAUDE_BYPASS_PERMISSION_MODE;
+  const allowNativeBash = security === "full" && ask === "off";
   return {
     allowNativeBash,
     security,
     ask,
     ...(effectivePermissionMode ? { effectivePermissionMode } : {}),
   };
+}
+
+function shouldForceClaudeLivePermissionPrompt(policy: ClaudeLiveControlRequestPolicy): boolean {
+  return (
+    (policy.security !== "full" || policy.ask !== "off") &&
+    policy.effectivePermissionMode !== CLAUDE_DEFAULT_PERMISSION_MODE
+  );
+}
+
+function shouldForceClaudeLiveBypass(policy: ClaudeLiveControlRequestPolicy): boolean {
+  return (
+    policy.security === "full" &&
+    policy.ask === "off" &&
+    policy.effectivePermissionMode !== CLAUDE_BYPASS_PERMISSION_MODE
+  );
 }
 
 function writeClaudeLiveControlResponse(
@@ -585,7 +592,7 @@ function buildClaudeLivePermissionResult(
     : "";
   const message =
     toolName === "Bash"
-      ? `OpenClaw denied Claude native Bash because the effective exec policy is security=${session.controlRequestPolicy.security}, ask=${session.controlRequestPolicy.ask}${permissionModeNote}; this bridge only auto-allows Bash when OpenClaw exec is full/no-ask and Claude is in bypassPermissions mode.`
+      ? `OpenClaw denied Claude native Bash because the effective exec policy is security=${session.controlRequestPolicy.security}, ask=${session.controlRequestPolicy.ask}${permissionModeNote}; this bridge only auto-allows Bash when OpenClaw exec is full/no-ask.`
       : `OpenClaw denied Claude native ${toolName || "tool"}; this bridge only maps Claude native Bash permission prompts to OpenClaw exec policy. Use OpenClaw MCP tools instead.`;
   return {
     behavior: "deny",
@@ -1036,15 +1043,25 @@ export async function runClaudeLiveSessionTurn(params: {
 }): Promise<ClaudeLiveRunResult> {
   const key = buildClaudeLiveKey(params.context);
   const resumeCapable = Boolean(params.context.preparedBackend.backend.resumeArgs?.length);
-  const argv = [
-    params.context.preparedBackend.backend.command,
-    ...buildClaudeLiveArgs({
-      args: params.args,
-      backend: params.context.preparedBackend.backend,
-      systemPrompt: params.context.systemPrompt,
-      useResume: params.useResume,
-    }),
-  ];
+  let liveArgs = buildClaudeLiveArgs({
+    args: params.args,
+    backend: params.context.preparedBackend.backend,
+    systemPrompt: params.context.systemPrompt,
+    useResume: params.useResume,
+  });
+  let argv = [params.context.preparedBackend.backend.command, ...liveArgs];
+  const launchPolicy = resolveClaudeLiveControlRequestPolicy(params.context, argv);
+  if (shouldForceClaudeLivePermissionPrompt(launchPolicy)) {
+    liveArgs = upsertArgValue(
+      liveArgs,
+      CLAUDE_PERMISSION_MODE_FLAG,
+      CLAUDE_DEFAULT_PERMISSION_MODE,
+    );
+    argv = [params.context.preparedBackend.backend.command, ...liveArgs];
+  } else if (shouldForceClaudeLiveBypass(launchPolicy)) {
+    liveArgs = upsertArgValue(liveArgs, CLAUDE_PERMISSION_MODE_FLAG, CLAUDE_BYPASS_PERMISSION_MODE);
+    argv = [params.context.preparedBackend.backend.command, ...liveArgs];
+  }
   const fingerprint = buildClaudeLiveFingerprint({
     context: params.context,
     argv,

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -54,7 +54,14 @@ type ClaudeLiveControlRequestPolicy = {
   allowNativeBash: boolean;
   security: "deny" | "allowlist" | "full";
   ask: "off" | "on-miss" | "always";
+  effectivePermissionMode?: string;
 };
+
+// Claude's bypass permission mode disables its native permission prompts entirely;
+// the live bridge must only auto-allow native Bash when the launched Claude is
+// actually in that mode AND the OpenClaw exec policy resolves to full/no-ask.
+const CLAUDE_BYPASS_PERMISSION_MODE = "bypassPermissions";
+const CLAUDE_PERMISSION_MODE_FLAG = "--permission-mode";
 type ClaudeLiveRunResult = {
   output: CliOutput;
 };
@@ -294,7 +301,7 @@ function buildClaudeLiveFingerprint(params: {
     env: Object.keys(params.env)
       .toSorted()
       .map((key) => [key, params.env[key] ? sha256(params.env[key]) : ""]),
-    controlRequestPolicy: resolveClaudeLiveControlRequestPolicy(params.context),
+    controlRequestPolicy: resolveClaudeLiveControlRequestPolicy(params.context, params.argv),
   });
 }
 
@@ -473,23 +480,70 @@ function resolveExecPolicyForClaudeLiveSession(
   return config?.tools?.exec;
 }
 
+function extractClaudeEffectivePermissionMode(argv: readonly string[]): string | undefined {
+  // Scan from the end so the last-set --permission-mode wins, matching how
+  // CLI arg precedence works in practice and how
+  // extensions/anthropic/cli-shared.ts:normalizeClaudePermissionArgs treats
+  // operator-provided overrides.
+  for (let i = argv.length - 1; i >= 0; i -= 1) {
+    const arg = argv[i] ?? "";
+    if (arg === CLAUDE_PERMISSION_MODE_FLAG) {
+      const value = argv[i + 1];
+      if (typeof value === "string" && value.trim().length > 0 && !value.startsWith("-")) {
+        return value.trim();
+      }
+      continue;
+    }
+    if (arg.startsWith(`${CLAUDE_PERMISSION_MODE_FLAG}=`)) {
+      const value = arg.slice(`${CLAUDE_PERMISSION_MODE_FLAG}=`.length).trim();
+      if (value.length > 0 && !value.startsWith("-")) {
+        return value;
+      }
+    }
+  }
+  return undefined;
+}
+
 function resolveClaudeLiveControlRequestPolicy(
   context: PreparedCliRunContext,
+  argv?: readonly string[],
 ): ClaudeLiveControlRequestPolicy {
   const exec = resolveExecPolicyForClaudeLiveSession(context);
-  // Mirror the runtime fallbacks used by the node-host exec runner so the
-  // bridge's view of "what the user actually granted" matches what real
-  // Bash invocations would see.
+  // Use the same defaults as extensions/anthropic/cli-shared.ts
+  // isOpenClawRequestedYolo (security ?? "full", ask ?? "off") and
+  // src/agents/exec-defaults.ts resolveExecDefaults, so the bridge's view of
+  // "what the user actually granted" matches both the launched Claude
+  // permission mode and the real Bash exec runner.
   const security: ClaudeLiveControlRequestPolicy["security"] =
     exec?.security === "deny" || exec?.security === "allowlist" || exec?.security === "full"
       ? exec.security
-      : "allowlist";
+      : "full";
   const ask: ClaudeLiveControlRequestPolicy["ask"] =
-    exec?.ask === "off" || exec?.ask === "on-miss" || exec?.ask === "always" ? exec.ask : "on-miss";
+    exec?.ask === "off" || exec?.ask === "on-miss" || exec?.ask === "always" ? exec.ask : "off";
+  // Effective permission mode: prefer an explicit --permission-mode in argv
+  // (which is how operators override OpenClaw's automatic bypass), and fall
+  // back to what extensions/anthropic/cli-shared.ts:normalizeClaudePermissionArgs
+  // would have inserted for an un-overridden launch. This keeps the bridge's
+  // view of the launched Claude mode in sync with what the backend actually
+  // passes on argv even in callers that constructed argv before normalization.
+  const argvMode = argv ? extractClaudeEffectivePermissionMode(argv) : undefined;
+  const synthesizedMode =
+    security === "full" && ask === "off" ? CLAUDE_BYPASS_PERMISSION_MODE : undefined;
+  const effectivePermissionMode = argvMode ?? synthesizedMode;
+  // Auto-allow native Bash only when the launched Claude is actually in the
+  // bypass-permissions path (no native prompt) AND the OpenClaw exec policy
+  // resolves to full/no-ask. Explicit raw-arg overrides like
+  // --permission-mode default or acceptEdits broaden Claude's native prompting
+  // intentionally; honor that operator intent by routing through deny here.
+  const allowNativeBash =
+    security === "full" &&
+    ask === "off" &&
+    effectivePermissionMode === CLAUDE_BYPASS_PERMISSION_MODE;
   return {
-    allowNativeBash: security === "full" && ask === "off",
+    allowNativeBash,
     security,
     ask,
+    ...(effectivePermissionMode ? { effectivePermissionMode } : {}),
   };
 }
 
@@ -526,9 +580,12 @@ function buildClaudeLivePermissionResult(
       ...(toolUseID ? { toolUseID } : {}),
     };
   }
+  const permissionModeNote = session.controlRequestPolicy.effectivePermissionMode
+    ? `, permission-mode=${session.controlRequestPolicy.effectivePermissionMode}`
+    : "";
   const message =
     toolName === "Bash"
-      ? `OpenClaw denied Claude native Bash because the effective exec policy is security=${session.controlRequestPolicy.security}, ask=${session.controlRequestPolicy.ask}; this bridge only auto-allows Bash when OpenClaw exec is full/no-ask.`
+      ? `OpenClaw denied Claude native Bash because the effective exec policy is security=${session.controlRequestPolicy.security}, ask=${session.controlRequestPolicy.ask}${permissionModeNote}; this bridge only auto-allows Bash when OpenClaw exec is full/no-ask and Claude is in bypassPermissions mode.`
       : `OpenClaw denied Claude native ${toolName || "tool"}; this bridge only maps Claude native Bash permission prompts to OpenClaw exec policy. Use OpenClaw MCP tools instead.`;
   return {
     behavior: "deny",
@@ -873,7 +930,7 @@ async function createClaudeLiveSession(params: {
     cleanup: params.cleanup,
     cleanupDone: false,
     closing: false,
-    controlRequestPolicy: resolveClaudeLiveControlRequestPolicy(params.context),
+    controlRequestPolicy: resolveClaudeLiveControlRequestPolicy(params.context, params.argv),
   };
   void managedRun.wait().then(
     (exit) => handleClaudeExit(session, exit.exitCode),

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -3,7 +3,7 @@ import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options
 import type { ReplyOperation } from "../../auto-reply/reply/reply-run-registry.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { InboundEventKind } from "../../channels/inbound-event/kind.js";
-import type { CliSessionBinding } from "../../config/sessions.js";
+import type { CliSessionBinding, SessionEntry } from "../../config/sessions.js";
 import type { SessionSystemPromptReport } from "../../config/sessions/types.js";
 import type { CliBackendConfig } from "../../config/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -24,6 +24,7 @@ import type { SilentReplyPromptMode } from "../system-prompt.types.js";
 export type RunCliAgentParams = {
   sessionId: string;
   sessionKey?: string;
+  sessionEntry?: SessionEntry;
   agentId?: string;
   trigger?: EmbeddedRunTrigger;
   sessionFile: string;

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -518,6 +518,7 @@ export function runAgentAttempt(params: {
       runCliAgent({
         sessionId: params.sessionId,
         sessionKey: params.sessionKey,
+        sessionEntry: params.sessionEntry,
         agentId: params.sessionAgentId,
         trigger: "user",
         sessionFile: params.sessionFile,

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -190,6 +190,7 @@ export function createCronPromptExecutor(params: {
           const result = await runCliAgent({
             sessionId: params.cronSession.sessionEntry.sessionId,
             sessionKey: params.runSessionKey,
+            sessionEntry: params.cronSession.sessionEntry,
             agentId: params.agentId,
             trigger: "cron",
             jobId: params.job.id,


### PR DESCRIPTION
## Summary

Follow-up to #81971. The original live Claude `control_request` handling fixed the stdio response path, but the Bash allow/deny decision still needed to match OpenClaw's effective exec policy.

This patch:

- resolves Claude live Bash policy through the effective exec defaults and approval-file tightening path
- treats OpenClaw's effective exec policy as authoritative over Claude's native permission mode, matching the Codex path
- updates the public Claude CLI permission-mode docs so raw Claude args are no longer documented as an OpenClaw policy override for managed live sessions
- normalizes Claude live launches in both directions:
    - effective OpenClaw `security=full`, `ask=off` launches Claude with `--permission-mode bypassPermissions`, even if raw Claude args requested a non-bypass mode
    - restrictive effective OpenClaw policy launches Claude with `--permission-mode default`, even if raw Claude args requested `bypassPermissions` or omitted `--permission-mode`
- honors session exec overrides, approval defaults, per-agent approvals from explicit `agentId` or `sessionKey`, and sandbox-derived defaults
- forwards `sessionEntry` through user and cron CLI paths
- adds regression coverage for restrictive approval defaults, session overrides, explicit-agent approvals, session-key-derived approvals, launch-mode downgrading, omitted Claude permission mode under restrictive OpenClaw policy, and OpenClaw YOLO overriding raw Claude non-bypass mode

Fixes #80819.

Related review context: #81971 and ClawSweeper comment https://github.com/openclaw/openclaw/pull/81971#issuecomment-4455925341.

## Real Behavior Proof

Ran a local real Claude CLI/API-backed proof against this branch with OpenClaw state isolated in a temporary `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, and config path. The proof exercised OpenClaw's Claude live stdio bridge through `executePreparedCliRun`, not a mocked Claude process.

Observed behavior:

- permissive openclaw effective policy (`security=full`, `ask=off`) launched Claude with `--permission-mode bypassPermissions`
    - permissive case successfully executed a harmless Bash side effect
- restrictive openclaw effective policy (`security=allowlist`, `ask=on-miss`) launched Claude with `--permission-mode default`
    - restrictive case produced a real Claude native Bash `control_request`
    - OpenClaw replied with a deny `control_response`
    - the denied Bash side effect did not happen

Redacted proof summary:

```json
{
  "realClaudeCli": true,
  "tempOpenClawHome": true,
  "allow": {
    "permissionMode": "bypassPermissions",
    "sideEffectObserved": true
  },
  "deny": {
    "permissionMode": "default",
    "bashControlRequests": 1,
    "denyResponses": 1,
    "sideEffectBlocked": true
  }
}
```

## Testing

- `node scripts/run-vitest.mjs src/agents/cli-runner.spawn.test.ts`
- `node scripts/run-vitest.mjs src/agents/cli-backends.test.ts src/agents/cli-runner.spawn.test.ts src/cron/isolated-agent/run.session-key-isolation.test.ts src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts`
- `pnpm check`
- `pnpm check:changelog-attributions`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt 'Review PR #86330 after fixing the restrictive no-permission-mode path. OpenClaw effective exec policy is authoritative over Claude native permission mode, matching Codex: effective OpenClaw full/off must normalize Claude live to --permission-mode bypassPermissions and allow native Bash even if raw Claude args requested default/acceptEdits; any restrictive effective OpenClaw policy must normalize Claude live to --permission-mode default, including when Claude args omitted --permission-mode, and deny/route native Bash control_request through OpenClaw policy. Check for regressions, compatibility issues, missing tests, and stale PR/comment wording.' --parallel-tests 'node scripts/run-vitest.mjs src/agents/cli-runner.spawn.test.ts src/cron/isolated-agent/run.session-key-isolation.test.ts src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts'`

Final autoreview result: `autoreview clean: no accepted/actionable findings reported`.
