### PR TITLE
feat(webchat): allow safe app-protocol links (obsidian://, things://, etc.)

### DIFF
--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -537,6 +537,13 @@ describe("toSanitizedMarkdownHtml", () => {
       const html = toSanitizedMarkdownHtml("[click](file:///etc/passwd)");
       expect(html).toBe("<p><a>click</a></p>\n");
     });
+
+    it("allows safe app-protocol links", () => {
+      const result = toSanitizedMarkdownHtml(
+        "[Open in Obsidian](obsidian://open?vault=MyVault&file=Note)",
+      );
+      expect(result).toContain('href="obsidian://open?vault=MyVault&amp;file=Note"');
+    });
   });
 
   describe("ReDoS protection", () => {

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -72,10 +72,34 @@ const allowedAttrs = [
   "type",
   "aria-label",
 ];
+// App-protocol schemes that are safe to link — they open registered
+// desktop apps and cannot execute arbitrary script.
+const SAFE_APP_PROTOCOLS = new Set([
+  "obsidian:",
+  "things:",
+  "fantastical:",
+  "shortcuts:",
+  "craftdocs:",
+  "notion:",
+  "bear:",
+  "vscode:",
+]);
+
+// Extend DOMPurify's default URI regexp to also accept our safe app protocols.
+// The default allows http, https, ftp, ftps, mailto, tel, callto, sms, cid, xmpp.
+// We add our desktop-app schemes so DOMPurify doesn't strip them before the
+// afterSanitizeAttributes hook can inspect them.
+const SAFE_APP_PROTOCOL_NAMES = [...SAFE_APP_PROTOCOLS].map((p) => p.replace(/:$/, ""));
+const ALLOWED_URI_REGEXP = new RegExp(
+  `^(?:(?:https?|ftp|ftps|mailto|tel|callto|sms|cid|xmpp|${SAFE_APP_PROTOCOL_NAMES.join("|")}):|\\/|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))`,
+  "i",
+);
+
 const sanitizeOptions = {
   ALLOWED_TAGS: allowedTags,
   ALLOWED_ATTR: allowedAttrs,
   ADD_DATA_URI_TAGS: ["img"],
+  ALLOWED_URI_REGEXP,
 };
 
 let hooksInstalled = false;
@@ -133,7 +157,12 @@ function installHooks() {
     // Block dangerous URL schemes (javascript:, data:, vbscript:, etc.)
     try {
       const url = new URL(href, window.location.href);
-      if (url.protocol !== "http:" && url.protocol !== "https:" && url.protocol !== "mailto:") {
+      if (
+        url.protocol !== "http:" &&
+        url.protocol !== "https:" &&
+        url.protocol !== "mailto:" &&
+        !SAFE_APP_PROTOCOLS.has(url.protocol)
+      ) {
         node.removeAttribute("href");
         return;
       }


### PR DESCRIPTION
## Summary

- Adds an allowlist of safe desktop-app URL schemes (`obsidian:`, `things:`, `fantastical:`, `shortcuts:`, `craftdocs:`, `notion:`, `bear:`, `vscode:`) to the DOMPurify sanitizer in `ui/src/ui/markdown.ts`
- Extends both the `ALLOWED_URI_REGEXP` (so DOMPurify doesn't strip them during sanitization) and the `afterSanitizeAttributes` hook (defense-in-depth protocol check) to accept these schemes
- Markdown links like `[Note](obsidian://open?vault=MyVault&file=Note)` now render as clickable `<a>` tags in WebChat instead of having their `href` silently stripped
- Dangerous schemes (`javascript:`, `data:`, `vbscript:`, `file:`) remain blocked

Closes #86334

## Real behavior proof

- Behavior addressed: WebChat markdown preserves safe desktop-app protocol links such as `obsidian://` while continuing to strip dangerous `javascript:` hrefs.
- Real environment tested: Local OpenClaw PR checkout at `0dd6ebdb779efa6f7b5b7b83bd4d5e08e37a0080`; production Control UI built from this branch and served from `dist/control-ui` over loopback; exercised in local Google Chrome through the `/chat` WebChat route with the repo Gateway WebSocket harness. Browser-level launch was also manually verified in Safari on the same Mac with the exact Obsidian URL.
- Exact steps or command run after this patch:
  1. `pnpm ui:build`
  2. `node --import tsx /private/tmp/openclaw-pr86335-proof.mjs`
  3. Opened a bare local test page in Safari with `<a href="obsidian://open?vault=Personal%20Vault&file=Plans%2FEmily%20Alaska%20PNW%20birthday%20trip%202026">Open vault</a>` and clicked the link.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
PR #86335 WebChat app-protocol proof
served bundle: http://127.0.0.1:52237/chat
built asset root: dist/control-ui
allowed screenshot: .artifacts/pr-86335/webchat-app-protocol-link.png
blocked screenshot: .artifacts/pr-86335/webchat-javascript-link-stripped.png
openVaultRenderedAsAnchor: true
openVaultHref: obsidian://open?vault=Test
evilRenderedAsAnchor: true
evilHref: null
allAnchors: [{"href":"obsidian://open?vault=Test","text":"Open vault"},{"href":null,"text":"evil"}]

Manual Safari click-through:
href: obsidian://open?vault=Personal%20Vault&file=Plans%2FEmily%20Alaska%20PNW%20birthday%20trip%202026
result: clicking Open vault opened the target Obsidian vault/file from Safari
```

- Observed result after fix: The rendered WebChat message showed `Open vault` as an anchor with `href="obsidian://open?vault=Test"`. The `evil` markdown label rendered without a `href`, so `javascript:alert(1)` did not survive sanitization. A Safari click-through using the requested `Personal Vault` Obsidian URL opened the target Obsidian location, confirming the preserved href works in a browser that allows custom protocol handlers.
- What was not tested: The Codex in-app browser did not launch the external `obsidian://` protocol, which appears to be a browser-host restriction rather than a sanitizer issue. The other allowlisted app schemes were covered by the same sanitizer path but not separately launched.

## Test plan

- [x] Added test: `allows safe app-protocol links` — verifies `obsidian://` hrefs are preserved in rendered output
- [x] All 70 existing markdown tests pass (including security tests for dangerous scheme blocking)
- [x] Manual: paste `[Open vault](obsidian://open?vault=Test)` in WebChat and verify the link is clickable
- [x] Manual: verify `[evil](javascript:alert(1))` still has its href stripped
- [x] Manual: verify Safari opens `obsidian://open?vault=Personal%20Vault&file=Plans%2FEmily%20Alaska%20PNW%20birthday%20trip%202026`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
