### PR TITLE
fix(update): mark post-core child as update in progress

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -893,6 +893,7 @@ describe("update-cli", () => {
     expect(call?.[1]).toEqual([entrypoints[0], "update", "--yes", "--timeout", "1800"]);
     expect(call?.[2]?.stdio).toBe("inherit");
     expect(call?.[2]?.env?.NODE_DISABLE_COMPILE_CACHE).toBe("1");
+    expect(call?.[2]?.env?.OPENCLAW_UPDATE_IN_PROGRESS).toBe("1");
     expect(call?.[2]?.env?.OPENCLAW_UPDATE_POST_CORE).toBe("1");
     expect(call?.[2]?.env?.OPENCLAW_UPDATE_POST_CORE_CHANNEL).toBe("dev");
     expect(call?.[2]?.env?.OPENCLAW_COMPATIBILITY_HOST_VERSION).toBe("1.0.0");
@@ -1185,8 +1186,7 @@ describe("update-cli", () => {
         .mocked(readConfigFileSnapshot)
         .mock.calls.some(
           ([options]) =>
-            options?.skipPluginValidation === true &&
-            options.suppressFutureVersionWarning === true,
+            options?.skipPluginValidation === true && options.suppressFutureVersionWarning === true,
         ),
     ).toBe(true);
     expect(defaultRuntime.exit).toHaveBeenCalledWith(0);

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -2750,6 +2750,7 @@ async function continuePostCoreUpdateInFreshProcess(params: {
       stdio: childStdio,
       env: {
         ...stripGatewayServiceMarkerEnv(disableUpdatedPackageCompileCacheEnv(process.env)),
+        OPENCLAW_UPDATE_IN_PROGRESS: "1",
         [POST_CORE_UPDATE_ENV]: "1",
         [POST_CORE_UPDATE_CHANNEL_ENV]: params.channel,
         ...(params.requestedChannel


### PR DESCRIPTION
## Summary
- Mark the post-core update child process with `OPENCLAW_UPDATE_IN_PROGRESS=1` as well as `OPENCLAW_UPDATE_POST_CORE=1`.
- Keeps generic update-phase guards active during the fresh-process handoff after a package update, including future-config warning suppression paths that key off the broader update-in-progress flag.
- Adds regression coverage to the post-core respawn test so the handoff environment carries both update markers.

## Test Plan
- `OPENCLAW_TEST_PROJECTS_SERIAL=1 node scripts/run-vitest.mjs src/cli/update-cli.test.ts -t "respawns into the updated package root before running post-update tasks"`
- `OPENCLAW_TEST_PROJECTS_SERIAL=1 node scripts/run-vitest.mjs src/cli/update-cli.test.ts`
- `git diff --check HEAD^..HEAD`

## Real behavior proof
- Behavior addressed: During a package update, the old OpenClaw parent respawns the updated install for post-core work. The child already got `OPENCLAW_UPDATE_POST_CORE=1`; this patch also gives it the generic `OPENCLAW_UPDATE_IN_PROGRESS=1` marker so update-phase config/version-warning guards stay active during the handoff.
- Real environment tested: Local OpenClaw source checkout on Linux/Kali, Node v22.22.2 for the shell command, with a live OpenClaw install/gateway also present. Temporary proof config was isolated under `/tmp/openclaw-proof-home/.openclaw/openclaw.json` with `meta.lastTouchedVersion=9999.1.1`.
- Exact steps or command run after this patch:
  1. Created the isolated temp config with a deliberately future `meta.lastTouchedVersion`.
  2. Ran `OPENCLAW_HOME=/tmp/openclaw-proof-home pnpm openclaw status --json >/tmp/openclaw-proof-without.stdout 2>/tmp/openclaw-proof-without.stderr`.
  3. Ran `OPENCLAW_HOME=/tmp/openclaw-proof-home OPENCLAW_UPDATE_IN_PROGRESS=1 pnpm openclaw status --json >/tmp/openclaw-proof-with.stdout 2>/tmp/openclaw-proof-with.stderr`.
  4. Checked both stderr files for `Your OpenClaw config was written by version 9999.1.1`.
- Evidence after fix:
  ```text
  without: stderr_contains_future_warning=True
  with: stderr_contains_future_warning=False
  exit_without=0 exit_with=0

  --- without marker index: 737 ---
  ... Your OpenClaw config was written by version 9999.1.1, but this command is running 2026.5.25. | Check: `openclaw --version`, `which openclaw`, and `openclaw gateway status --deep`. | If unexpected, update PATH so `openclaw` points to the version you want, or reinstall the Gateway service from that same OpenClaw install. ...
  --- with marker index: -1 ---
  no future-version warning emitted
  ```
- Observed result after fix: In the real CLI/config path, the generic `OPENCLAW_UPDATE_IN_PROGRESS=1` marker suppresses the false future-version warning for an update-owned config read. The patched post-core respawn now sets that marker, and the focused regression test first failed with `expected undefined to be '1'` before the production change, then passed after the patch.
- What was not tested: I did not publish/install a private package build and perform an actual package-manager self-update; the exact post-core respawn environment is covered by the update CLI regression test, while the live CLI proof above verifies the marker's real config-warning behavior.
