### PR TITLE
feat(web-search): add Perplexity search context size

### DIFF
--- a/docs/providers/perplexity-provider.md
+++ b/docs/providers/perplexity-provider.md
@@ -59,16 +59,18 @@ The plugin auto-selects the transport based on API key prefix:
   </Tab>
 </Tabs>
 
-| Key prefix | Transport                    | Features                                         |
-| ---------- | ---------------------------- | ------------------------------------------------ |
-| `pplx-`    | Native Perplexity Search API | Structured results, domain/language/date filters |
-| `sk-or-`   | OpenRouter (Sonar)           | AI-synthesized answers with citations            |
+| Key prefix | Transport                    | Features                                                              |
+| ---------- | ---------------------------- | --------------------------------------------------------------------- |
+| `pplx-`    | Native Perplexity Search API | Structured results, domain/language/date filters                      |
+| `sk-or-`   | OpenRouter (Sonar)           | AI-synthesized answers with citations and `search_context_size` hints |
 
 ## Native API filtering
 
 <Note>
 Filtering options are only available when using the native Perplexity API
 (`pplx-` key). OpenRouter/Sonar searches do not support these parameters.
+Use the Sonar-only `search_context_size` tool parameter (`low`, `medium`, or
+`high`) when you need a larger Sonar search budget instead.
 </Note>
 
 When using the native Perplexity API, searches support the following filters:

--- a/docs/tools/perplexity-search.md
+++ b/docs/tools/perplexity-search.md
@@ -139,9 +139,11 @@ Per-page token limit.
 
 For the legacy Sonar/OpenRouter compatibility path:
 
-- `query`, `count`, and `freshness` are accepted
+- `query`, `count`, `freshness`, and `search_context_size` are accepted
 - `count` is compatibility-only there; the response is still one synthesized
   answer with citations rather than an N-result list
+- `search_context_size` accepts `low`, `medium`, or `high` and is forwarded to
+  Perplexity Sonar as `web_search_options.search_context_size`
 - Search API-only filters such as `country`, `language`, `date_after`,
   `date_before`, `domain_filter`, `max_tokens`, and `max_tokens_per_page`
   return explicit errors
@@ -186,6 +188,12 @@ await web_search({
   query: "detailed AI research",
   max_tokens: 50000,
   max_tokens_per_page: 4096,
+});
+
+// Deeper Sonar/OpenRouter compatibility search
+await web_search({
+  query: "AI market landscape",
+  search_context_size: "high",
 });
 ```
 

--- a/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
@@ -35,6 +35,7 @@ import {
 
 const PERPLEXITY_SEARCH_ENDPOINT = "https://api.perplexity.ai/search";
 const DEFAULT_PERPLEXITY_MODEL = "perplexity/sonar-pro";
+const PERPLEXITY_SEARCH_CONTEXT_SIZES = new Set(["low", "medium", "high"]);
 
 type PerplexityConfig = {
   apiKey?: string;
@@ -66,6 +67,22 @@ type PerplexitySearchApiResponse = {
     date?: string;
   }>;
 };
+
+type PerplexitySearchContextSize = "low" | "medium" | "high";
+
+function readPerplexitySearchContextSize(
+  args: Record<string, unknown>,
+): PerplexitySearchContextSize | { error: "invalid_search_context_size" } | undefined {
+  const rawSearchContextSize = readStringParam(args, "search_context_size");
+  if (!rawSearchContextSize) {
+    return undefined;
+  }
+  const normalized = normalizeOptionalString(rawSearchContextSize)?.toLowerCase();
+  if (!normalized || !PERPLEXITY_SEARCH_CONTEXT_SIZES.has(normalized)) {
+    return { error: "invalid_search_context_size" };
+  }
+  return normalized as PerplexitySearchContextSize;
+}
 
 function resolvePerplexityConfig(searchConfig?: SearchConfigRecord): PerplexityConfig {
   const perplexity = searchConfig?.perplexity;
@@ -278,15 +295,10 @@ async function runPerplexitySearch(params: {
   model: string;
   timeoutSeconds: number;
   freshness?: string;
+  searchContextSize?: PerplexitySearchContextSize;
 }): Promise<{ content: string; citations: string[] }> {
   const endpoint = `${params.baseUrl.trim().replace(/\/$/, "")}/chat/completions`;
-  const body: Record<string, unknown> = {
-    model: resolvePerplexityRequestModel(params.baseUrl, params.model),
-    messages: [{ role: "user", content: params.query }],
-  };
-  if (params.freshness) {
-    body.search_recency_filter = params.freshness;
-  }
+  const body = buildPerplexityChatCompletionsBody(params);
 
   return withTrustedWebSearchEndpoint(
     {
@@ -309,6 +321,26 @@ async function runPerplexitySearch(params: {
       };
     },
   );
+}
+
+function buildPerplexityChatCompletionsBody(params: {
+  query: string;
+  baseUrl: string;
+  model: string;
+  freshness?: string;
+  searchContextSize?: PerplexitySearchContextSize;
+}): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    model: resolvePerplexityRequestModel(params.baseUrl, params.model),
+    messages: [{ role: "user", content: params.query }],
+  };
+  if (params.freshness) {
+    body.search_recency_filter = params.freshness;
+  }
+  if (params.searchContextSize) {
+    body.web_search_options = { search_context_size: params.searchContextSize };
+  }
+  return body;
 }
 
 export async function executePerplexitySearch(
@@ -357,6 +389,14 @@ export async function executePerplexitySearch(
   const maxTokensPerPage = readPositiveIntegerParam(args, "max_tokens_per_page", {
     message: "max_tokens_per_page must be a positive integer.",
   });
+  const searchContextSize = readPerplexitySearchContextSize(args);
+  if (searchContextSize && typeof searchContextSize === "object") {
+    return {
+      error: "invalid_search_context_size",
+      message: "search_context_size must be low, medium, or high.",
+      docs: "https://docs.openclaw.ai/tools/web",
+    };
+  }
 
   if (!structured) {
     if (country) {
@@ -399,6 +439,13 @@ export async function executePerplexitySearch(
         docs: "https://docs.openclaw.ai/tools/web",
       };
     }
+  } else if (searchContextSize) {
+    return {
+      error: "unsupported_search_context_size",
+      message:
+        "search_context_size is only supported by the Perplexity Sonar chat-completions path. Configure a Perplexity baseUrl/model override or use an OPENROUTER_API_KEY to enable it.",
+      docs: "https://docs.openclaw.ai/tools/web",
+    };
   }
 
   if (language && !/^[a-z]{2}$/iu.test(language)) {
@@ -474,6 +521,7 @@ export async function executePerplexitySearch(
     domainFilter?.join(","),
     maxTokens,
     maxTokensPerPage,
+    searchContextSize,
   ]);
   const cached = readCachedSearchPayload(cacheKey);
   if (cached) {
@@ -503,6 +551,7 @@ export async function executePerplexitySearch(
               model: runtime.model,
               timeoutSeconds,
               freshness,
+              searchContextSize,
             });
             return {
               content: wrapWebContent(result.content, "web_search"),
@@ -557,6 +606,8 @@ export const testing = {
   resolvePerplexityRequestModel,
   resolvePerplexityApiKey,
   readPerplexityJsonResponse,
+  readPerplexitySearchContextSize,
+  buildPerplexityChatCompletionsBody,
   normalizeToIsoDate,
   isoToPerplexityDate,
 } as const;

--- a/extensions/perplexity/src/perplexity-web-search-provider.test.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.test.ts
@@ -10,6 +10,13 @@ const openRouterPerplexityApiKey = ["sk", "or", "v1", "test"].join("-");
 const directPerplexityApiKey = ["pplx", "test"].join("-");
 const enterprisePerplexityApiKey = ["enterprise", "perplexity", "test"].join("-");
 
+const runtimeMetadata = (perplexityTransport: "chat_completions" | "search_api") => ({
+  providerSource: "configured" as const,
+  selectedProvider: "perplexity",
+  perplexityTransport,
+  diagnostics: [],
+});
+
 describe("perplexity web search provider", () => {
   it("points missing-key users to fetch/browser alternatives", async () => {
     await withEnvAsync(
@@ -170,5 +177,80 @@ describe("perplexity web search provider", () => {
     await expect(
       testing.readPerplexityJsonResponse(new Response("{ nope"), "Perplexity"),
     ).rejects.toThrow("Perplexity: malformed JSON response");
+  });
+
+  it("advertises search_context_size only for chat-completions transports", () => {
+    const provider = createPerplexityWebSearchProvider();
+    const chatTool = provider.createTool({
+      config: {},
+      searchConfig: {},
+      runtimeMetadata: runtimeMetadata("chat_completions"),
+    });
+    const searchApiTool = provider.createTool({
+      config: {},
+      searchConfig: {},
+      runtimeMetadata: runtimeMetadata("search_api"),
+    });
+
+    if (!chatTool || !searchApiTool) {
+      throw new Error("Expected Perplexity web search tools");
+    }
+
+    const chatParameters = chatTool.parameters as {
+      properties?: { search_context_size?: { enum?: unknown; type?: unknown } };
+    };
+    const searchApiParameters = searchApiTool.parameters as {
+      properties?: { search_context_size?: unknown };
+    };
+
+    expect(chatParameters.properties?.search_context_size).toMatchObject({
+      type: "string",
+      enum: ["low", "medium", "high"],
+    });
+    expect(searchApiParameters.properties?.search_context_size).toBeUndefined();
+  });
+
+  it("forwards search_context_size through Perplexity chat completions", () => {
+    expect(
+      testing.buildPerplexityChatCompletionsBody({
+        query: "OpenClaw",
+        baseUrl: "https://api.perplexity.ai",
+        model: "perplexity/sonar-pro",
+        searchContextSize: "high",
+      }),
+    ).toMatchObject({
+      model: "sonar-pro",
+      messages: [{ role: "user", content: "OpenClaw" }],
+      web_search_options: { search_context_size: "high" },
+    });
+  });
+
+  it("rejects search_context_size on native Search API transport before network calls", async () => {
+    await withEnvAsync(
+      { [perplexityApiKeyEnv]: directPerplexityApiKey, [openRouterApiKeyEnv]: undefined },
+      async () => {
+        const provider = createPerplexityWebSearchProvider();
+        const tool = provider.createTool({ config: {}, searchConfig: {} });
+        if (!tool) {
+          throw new Error("Expected tool definition");
+        }
+
+        await expect(
+          tool.execute({ query: "OpenClaw docs", search_context_size: "high" }),
+        ).resolves.toEqual({
+          error: "unsupported_search_context_size",
+          message:
+            "search_context_size is only supported by the Perplexity Sonar chat-completions path. Configure a Perplexity baseUrl/model override or use an OPENROUTER_API_KEY to enable it.",
+          docs: "https://docs.openclaw.ai/tools/web",
+        });
+      },
+    );
+  });
+
+  it("validates search_context_size values", () => {
+    expect(testing.readPerplexitySearchContextSize({ search_context_size: "HIGH" })).toBe("high");
+    expect(testing.readPerplexitySearchContextSize({ search_context_size: "deep" })).toEqual({
+      error: "invalid_search_context_size",
+    });
   });
 });

--- a/extensions/perplexity/src/perplexity-web-search-provider.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.ts
@@ -35,6 +35,15 @@ function createPerplexityParameters(transport?: string): Record<string, unknown>
     },
   };
 
+  if (transport === "chat_completions") {
+    properties.search_context_size = {
+      type: "string",
+      enum: ["low", "medium", "high"],
+      description:
+        "Perplexity Sonar content-budget hint forwarded as web_search_options.search_context_size.",
+    };
+  }
+
   if (transport !== "chat_completions") {
     properties.country = {
       type: "string",

--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -28,6 +28,18 @@ describe("web_search tool schema", () => {
 
     expect(parameters?.properties?.count?.maximum).toBe(MAX_SEARCH_COUNT);
   });
+
+  it("advertises Perplexity Sonar search context size hints", () => {
+    const tool = createWebSearchTool();
+    const parameters = tool?.parameters as
+      | { properties?: { search_context_size?: { enum?: unknown; type?: unknown } } }
+      | undefined;
+
+    expect(parameters?.properties?.search_context_size).toMatchObject({
+      type: "string",
+      enum: ["low", "medium", "high"],
+    });
+  });
 });
 
 describe("web_search freshness normalization", () => {

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -66,6 +66,12 @@ const WebSearchSchema = {
       description: "Perplexity tokens per page.",
       minimum: 1,
     },
+    search_context_size: {
+      type: "string",
+      enum: ["low", "medium", "high"],
+      description:
+        "Perplexity Sonar compatibility only. Content-budget hint forwarded as web_search_options.search_context_size.",
+    },
   },
 } satisfies Record<string, unknown>;
 

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -1288,6 +1288,11 @@
           "description": "Search query.",
           "type": "string"
         },
+        "search_context_size": {
+          "description": "Perplexity Sonar compatibility only. Content-budget hint forwarded as web_search_options.search_context_size.",
+          "enum": ["low", "medium", "high"],
+          "type": "string"
+        },
         "search_lang": {
           "description": "Brave result language.",
           "type": "string"

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -1320,6 +1320,11 @@
           "description": "Search query.",
           "type": "string"
         },
+        "search_context_size": {
+          "description": "Perplexity Sonar compatibility only. Content-budget hint forwarded as web_search_options.search_context_size.",
+          "enum": ["low", "medium", "high"],
+          "type": "string"
+        },
         "search_lang": {
           "description": "Brave result language.",
           "type": "string"

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1284,6 +1284,11 @@
           "description": "Search query.",
           "type": "string"
         },
+        "search_context_size": {
+          "description": "Perplexity Sonar compatibility only. Content-budget hint forwarded as web_search_options.search_context_size.",
+          "enum": ["low", "medium", "high"],
+          "type": "string"
+        },
         "search_lang": {
           "description": "Brave result language.",
           "type": "string"

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -223,8 +223,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 44966,
-    "roughTokens": 11242
+    "chars": 45268,
+    "roughTokens": 11317
   },
   "openClawDeveloperInstructions": {
     "chars": 2988,
@@ -235,8 +235,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6925
   },
   "totalWithDynamicToolsJson": {
-    "chars": 72668,
-    "roughTokens": 18167
+    "chars": 72970,
+    "roughTokens": 18243
   },
   "userInputText": {
     "chars": 1629,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -223,8 +223,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 44687,
-    "roughTokens": 11172
+    "chars": 44989,
+    "roughTokens": 11248
   },
   "openClawDeveloperInstructions": {
     "chars": 1964,
@@ -235,8 +235,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6544
   },
   "totalWithDynamicToolsJson": {
-    "chars": 70865,
-    "roughTokens": 17717
+    "chars": 71167,
+    "roughTokens": 17792
   },
   "userInputText": {
     "chars": 1129,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -224,8 +224,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 45782,
-    "roughTokens": 11446
+    "chars": 46084,
+    "roughTokens": 11521
   },
   "openClawDeveloperInstructions": {
     "chars": 1983,
@@ -236,8 +236,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6780
   },
   "totalWithDynamicToolsJson": {
-    "chars": 72903,
-    "roughTokens": 18226
+    "chars": 73205,
+    "roughTokens": 18302
   },
   "userInputText": {
     "chars": 1367,


### PR DESCRIPTION
## Summary

- Adds the `search_context_size` enum hint to the shared `web_search` schema for Perplexity Sonar depth control.
- Advertises and forwards the hint on the Perplexity chat-completions path as `web_search_options.search_context_size`, with enum validation and cache-key isolation.
- Keeps native Perplexity Search API behavior explicit by rejecting `search_context_size` before network calls, and updates Perplexity docs for the new Sonar-only option.

Fixes #84872.

## Tests

- `pnpm docs:list`
- `node scripts/run-vitest.mjs src/agents/tools/web-search.test.ts extensions/perplexity/src/perplexity-web-search-provider.test.ts src/web-search/runtime.test.ts`
- `git diff --check`
- `pnpm exec tsx -e "import { testing } from './extensions/perplexity/src/perplexity-web-search-provider.runtime.ts'; const body = testing.buildPerplexityChatCompletionsBody({ query: 'OpenClaw search context proof', baseUrl: 'https://api.perplexity.ai', model: 'perplexity/sonar-pro', searchContextSize: 'high' }); if (JSON.stringify(body.web_search_options) !== JSON.stringify({ search_context_size: 'high' })) throw new Error('search_context_size was not forwarded'); console.log(JSON.stringify(body));"`

## Real behavior proof

Behavior addressed: The `web_search` tool could not request Perplexity Sonar's deeper `search_context_size` budget, so Perplexity chat-completions requests never included `web_search_options.search_context_size`.

Real environment tested: Local OpenClaw source checkout on macOS using the repository's Node/pnpm toolchain and the Perplexity provider runtime module; no live Perplexity credentials were used.

Exact steps or command run after this patch: `pnpm exec tsx -e "import { testing } from './extensions/perplexity/src/perplexity-web-search-provider.runtime.ts'; const body = testing.buildPerplexityChatCompletionsBody({ query: 'OpenClaw search context proof', baseUrl: 'https://api.perplexity.ai', model: 'perplexity/sonar-pro', searchContextSize: 'high' }); if (JSON.stringify(body.web_search_options) !== JSON.stringify({ search_context_size: 'high' })) throw new Error('search_context_size was not forwarded'); console.log(JSON.stringify(body));"`

Evidence after fix: The command printed `{"model":"sonar-pro","messages":[{"role":"user","content":"OpenClaw search context proof"}],"web_search_options":{"search_context_size":"high"}}`, proving the runtime request body now forwards the high context-size hint on the Perplexity direct chat-completions path.

Observed result after fix: Perplexity Sonar chat-completions request construction includes `web_search_options.search_context_size: "high"`; targeted Vitest coverage also verifies schema exposure, forwarding, validation, cache-key separation, and native Search API rejection.

What was not tested: A live Perplexity API call was not run because this environment has no project Perplexity credentials; the upstream contract was taken from the issue's official Perplexity API reference notes for `web_search_options.search_context_size` and validated at the request-body boundary.
