### PR TITLE
fix(codex): share native hook relay state

### DIFF
--- a/extensions/codex/src/app-server/approval-bridge.test.ts
+++ b/extensions/codex/src/app-server/approval-bridge.test.ts
@@ -254,6 +254,7 @@ describe("Codex app-server approval bridge", () => {
       turnId: "turn-1",
       nativeHookRelay: {
         relayId: "relay-1",
+        generation: "generation-1",
         allowedEvents: ["pre_tool_use"],
       },
     });
@@ -264,6 +265,7 @@ describe("Codex app-server approval bridge", () => {
     expect(mockInvokeNativeHookRelay).toHaveBeenCalledWith({
       provider: "codex",
       relayId: "relay-1",
+      generation: "generation-1",
       event: "pre_tool_use",
       rawPayload: {
         hook_event_name: "PreToolUse",
@@ -285,6 +287,7 @@ describe("Codex app-server approval bridge", () => {
           cmd: "cat /tmp/private_key",
         },
       },
+      requireGeneration: true,
     });
     findApprovalEvent(params, {
       status: "denied",
@@ -317,6 +320,7 @@ describe("Codex app-server approval bridge", () => {
       turnId: "turn-1",
       nativeHookRelay: {
         relayId: "relay-1",
+        generation: "generation-1",
         allowedEvents: ["pre_tool_use"],
       },
     });
@@ -359,6 +363,7 @@ describe("Codex app-server approval bridge", () => {
       turnId: "turn-1",
       nativeHookRelay: {
         relayId: "relay-1",
+        generation: "generation-1",
         allowedEvents: ["pre_tool_use"],
       },
     });
@@ -398,6 +403,7 @@ describe("Codex app-server approval bridge", () => {
       turnId: "turn-1",
       nativeHookRelay: {
         relayId: "relay-1",
+        generation: "generation-1",
         allowedEvents: ["pre_tool_use"],
       },
     });
@@ -441,6 +447,7 @@ describe("Codex app-server approval bridge", () => {
       turnId: "turn-1",
       nativeHookRelay: {
         relayId: "relay-1",
+        generation: "generation-1",
         allowedEvents: ["pre_tool_use"],
       },
     });
@@ -477,6 +484,7 @@ describe("Codex app-server approval bridge", () => {
       turnId: "turn-1",
       nativeHookRelay: {
         relayId: "relay-1",
+        generation: "generation-1",
         allowedEvents: ["pre_tool_use"],
       },
     });
@@ -508,6 +516,7 @@ describe("Codex app-server approval bridge", () => {
       turnId: "turn-1",
       nativeHookRelay: {
         relayId: "relay-missing",
+        generation: "generation-1",
         allowedEvents: ["pre_tool_use"],
       },
     });
@@ -532,6 +541,7 @@ describe("Codex app-server approval bridge", () => {
       .mockResolvedValueOnce({ id: "plugin:permission-approval", decision: "deny" });
     const nativeHookRelay = {
       relayId: "relay-1",
+      generation: "generation-1",
       allowedEvents: ["pre_tool_use" as const],
     };
 

--- a/extensions/codex/src/app-server/approval-bridge.ts
+++ b/extensions/codex/src/app-server/approval-bridge.ts
@@ -58,7 +58,10 @@ export async function handleCodexAppServerApprovalRequest(params: {
   paramsForRun: EmbeddedRunAttemptParams;
   threadId: string;
   turnId: string;
-  nativeHookRelay?: Pick<NativeHookRelayRegistrationHandle, "allowedEvents" | "relayId">;
+  nativeHookRelay?: Pick<
+    NativeHookRelayRegistrationHandle,
+    "allowedEvents" | "generation" | "relayId"
+  >;
   signal?: AbortSignal;
 }): Promise<JsonValue | undefined> {
   const requestParams = isJsonObject(params.requestParams) ? params.requestParams : undefined;
@@ -302,7 +305,10 @@ async function runOpenClawToolPolicyForApprovalRequest(params: {
   requestParams: JsonObject | undefined;
   paramsForRun: EmbeddedRunAttemptParams;
   context: ApprovalContext;
-  nativeHookRelay?: Pick<NativeHookRelayRegistrationHandle, "allowedEvents" | "relayId">;
+  nativeHookRelay?: Pick<
+    NativeHookRelayRegistrationHandle,
+    "allowedEvents" | "generation" | "relayId"
+  >;
   signal?: AbortSignal;
 }): Promise<ApprovalPolicyOutcome | undefined> {
   const policyRequest = buildOpenClawToolPolicyRequest(params.method, params.requestParams);
@@ -365,7 +371,10 @@ async function runNativeRelayToolPolicyForApprovalRequest(params: {
   requestParams: JsonObject | undefined;
   context: ApprovalContext;
   policyRequest: { toolName: string; params: JsonObject };
-  nativeHookRelay?: Pick<NativeHookRelayRegistrationHandle, "allowedEvents" | "relayId">;
+  nativeHookRelay?: Pick<
+    NativeHookRelayRegistrationHandle,
+    "allowedEvents" | "generation" | "relayId"
+  >;
   cwd?: string;
 }): Promise<
   | {
@@ -409,8 +418,10 @@ async function runNativeRelayToolPolicyForApprovalRequest(params: {
     const response = await invokeNativeHookRelay({
       provider: "codex",
       relayId: params.nativeHookRelay.relayId,
+      generation: params.nativeHookRelay.generation,
       event: "pre_tool_use",
       rawPayload: payload,
+      requireGeneration: true,
     });
     const decision = readNativeRelayPreToolUseDecision(response);
     if (decision.blocked) {

--- a/extensions/codex/src/app-server/native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.test.ts
@@ -20,7 +20,7 @@ describe("Codex native hook relay config", () => {
             {
               type: "command",
               command:
-                "openclaw hooks relay --provider codex --relay-id relay-1 --event pre_tool_use",
+                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event pre_tool_use",
               timeout: 7,
               async: false,
               statusMessage: "OpenClaw native hook relay",
@@ -34,7 +34,7 @@ describe("Codex native hook relay config", () => {
             {
               type: "command",
               command:
-                "openclaw hooks relay --provider codex --relay-id relay-1 --event post_tool_use",
+                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event post_tool_use",
               timeout: 7,
               async: false,
               statusMessage: "OpenClaw native hook relay",
@@ -48,7 +48,7 @@ describe("Codex native hook relay config", () => {
             {
               type: "command",
               command:
-                "openclaw hooks relay --provider codex --relay-id relay-1 --event permission_request",
+                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event permission_request",
               timeout: 7,
               async: false,
               statusMessage: "OpenClaw native hook relay",
@@ -62,7 +62,7 @@ describe("Codex native hook relay config", () => {
             {
               type: "command",
               command:
-                "openclaw hooks relay --provider codex --relay-id relay-1 --event before_agent_finalize",
+                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event before_agent_finalize",
               timeout: 7,
               async: false,
               statusMessage: "OpenClaw native hook relay",
@@ -125,7 +125,7 @@ describe("Codex native hook relay config", () => {
             {
               type: "command",
               command:
-                "openclaw hooks relay --provider codex --relay-id relay-1 --event permission_request",
+                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event permission_request",
               timeout: 5,
               async: false,
               statusMessage: "OpenClaw native hook relay",
@@ -160,7 +160,7 @@ describe("Codex native hook relay config", () => {
             {
               type: "command",
               command:
-                "openclaw hooks relay --provider codex --relay-id relay-1 --event pre_tool_use",
+                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event pre_tool_use",
               timeout: 5,
               async: false,
               statusMessage: "OpenClaw native hook relay",
@@ -200,7 +200,7 @@ describe("Codex native hook relay config", () => {
             {
               type: "command",
               command:
-                "openclaw hooks relay --provider codex --relay-id relay-1 --event permission_request",
+                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event permission_request",
               timeout: 5,
               async: false,
               statusMessage: "OpenClaw native hook relay",
@@ -260,6 +260,7 @@ function createRelay(options?: {
   return {
     relayId: "relay-1",
     provider: "codex",
+    generation: "generation-1",
     sessionId: "session-1",
     sessionKey: "agent:main:session-1",
     runId: "run-1",
@@ -267,7 +268,7 @@ function createRelay(options?: {
     expiresAtMs: Date.now() + 1000,
     shouldRelayEvent: (event) => !inactiveEvents.has(event),
     commandForEvent: (event) =>
-      `openclaw hooks relay --provider codex --relay-id relay-1 --event ${event}`,
+      `openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event ${event}`,
     renew: () => undefined,
     unregister: () => undefined,
   };

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -1,6 +1,6 @@
 import { statSync, writeFileSync } from "node:fs";
 import fs from "node:fs/promises";
-import { createServer } from "node:http";
+import { createServer, request as httpRequest } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -80,6 +80,102 @@ async function waitForNativeHookRelayBridgeRecord(
   return record as Record<string, unknown>;
 }
 
+function openDeferredNativeHookRelayBridgeRequest(
+  record: Record<string, unknown>,
+  payload: Record<string, unknown>,
+): {
+  connected: Promise<void>;
+  response: Promise<Record<string, unknown>>;
+  sendBody: () => void;
+} {
+  const body = JSON.stringify(payload);
+  let settled = false;
+  let resolveResponse!: (value: Record<string, unknown>) => void;
+  let rejectResponse!: (error: unknown) => void;
+  const response = new Promise<Record<string, unknown>>((resolve, reject) => {
+    resolveResponse = resolve;
+    rejectResponse = reject;
+  });
+  const req = httpRequest(
+    {
+      hostname: String(record.hostname),
+      method: "POST",
+      path: "/invoke",
+      port: Number(record.port),
+      headers: {
+        authorization: `Bearer ${String(record.token)}`,
+        "content-type": "application/json",
+        "content-length": Buffer.byteLength(body),
+      },
+    },
+    (res) => {
+      let responseText = "";
+      res.setEncoding("utf8");
+      res.on("data", (chunk) => {
+        responseText += typeof chunk === "string" ? chunk : String(chunk);
+      });
+      res.on("error", rejectResponse);
+      res.on("end", () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        resolveResponse(requireRecord(JSON.parse(responseText), "bridge response"));
+      });
+    },
+  );
+  const connected = new Promise<void>((resolve, reject) => {
+    req.on("socket", (socket) => {
+      socket.on("error", reject);
+      if (socket.connecting) {
+        socket.once("connect", resolve);
+        return;
+      }
+      resolve();
+    });
+  });
+  req.on("error", (error) => {
+    if (!settled) {
+      settled = true;
+      rejectResponse(error);
+    }
+  });
+  req.flushHeaders();
+  return {
+    connected,
+    response,
+    sendBody: () => req.end(body),
+  };
+}
+
+type NativeHookRelaySharedStateForTests = {
+  relays: Map<string, unknown>;
+  relayBridges: Map<string, unknown>;
+  invocations: unknown[];
+  pendingPermissionApprovals: Map<string, unknown>;
+  permissionApprovalWindows: Map<string, unknown[]>;
+  permissionAllowAlwaysApprovals: Map<string, unknown>;
+};
+
+function getNativeHookRelaySharedStateForTests(): NativeHookRelaySharedStateForTests {
+  const state = (
+    globalThis as typeof globalThis & {
+      [key: symbol]: NativeHookRelaySharedStateForTests | undefined;
+    }
+  )[Symbol.for("openclaw.nativeHookRelay.state")];
+  if (!state) {
+    throw new Error("Expected native hook relay shared state to be initialized");
+  }
+  return state;
+}
+
+type NativeHookRelayModuleForTests = typeof import("./native-hook-relay.js");
+
+async function importDuplicateNativeHookRelayModuleForTests(): Promise<NativeHookRelayModuleForTests> {
+  vi.resetModules();
+  return import("./native-hook-relay.js");
+}
+
 describe("native hook relay registry", () => {
   it("registers a short-lived relay and builds hidden CLI commands", () => {
     const relay = registerNativeHookRelay({
@@ -111,8 +207,207 @@ describe("native hook relay registry", () => {
     );
     expect(relay.commandForEvent("pre_tool_use")).toBe(
       "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
-        `${relay.relayId} --event pre_tool_use --timeout 1234`,
+        `${relay.relayId} --generation ${relay.generation} --event pre_tool_use --timeout 1234`,
     );
+  });
+
+  it("stores relay registrations, bridges, and invocations in process-global state", async () => {
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "codex-global-state-session",
+      sessionId: "session-1",
+      runId: "run-1",
+      allowedEvents: ["pre_tool_use"],
+    });
+    const state = getNativeHookRelaySharedStateForTests();
+
+    expect(state.relays.get(relay.relayId)).toMatchObject({
+      provider: "codex",
+      sessionId: "session-1",
+      runId: "run-1",
+    });
+    await waitForNativeHookRelayBridgeRecord(relay.relayId);
+    expect(state.relayBridges.get(relay.relayId)).toMatchObject({
+      relayId: relay.relayId,
+    });
+
+    await invokeNativeHookRelay({
+      provider: "codex",
+      relayId: relay.relayId,
+      event: "pre_tool_use",
+      rawPayload: {
+        hook_event_name: "PreToolUse",
+        tool_name: "Bash",
+        tool_input: { command: "pnpm test" },
+      },
+    });
+
+    expect(state.invocations.at(-1)).toMatchObject({
+      relayId: relay.relayId,
+      event: "pre_tool_use",
+    });
+  });
+
+  it("stores permission approval state in process-global state", async () => {
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "codex-global-permission-state",
+      sessionId: "session-1",
+      runId: "run-1",
+    });
+    let resolveDecision: ((decision: "allow-always") => void) | undefined;
+    const pendingDecision = new Promise<"allow-always">((resolve) => {
+      resolveDecision = resolve;
+    });
+    const approvalRequester = vi.fn(() => pendingDecision);
+    testing.setNativeHookRelayPermissionApprovalRequesterForTests(approvalRequester);
+
+    const first = invokeNativeHookRelay({
+      provider: "codex",
+      relayId: relay.relayId,
+      event: "permission_request",
+      rawPayload: {
+        hook_event_name: "PermissionRequest",
+        cwd: "/repo",
+        tool_name: "Bash",
+        tool_use_id: "native-call-1",
+        tool_input: { command: "browserforce tabs" },
+      },
+    });
+    await Promise.resolve();
+
+    const state = getNativeHookRelaySharedStateForTests();
+    expect(state.pendingPermissionApprovals.size).toBe(1);
+    expect(state.permissionApprovalWindows.get(relay.relayId)).toHaveLength(1);
+
+    resolveDecision?.("allow-always");
+    await expect(first).resolves.toMatchObject({ exitCode: 0 });
+    expect(state.pendingPermissionApprovals.size).toBe(0);
+    expect(state.permissionAllowAlwaysApprovals.size).toBe(1);
+
+    await expect(
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId: relay.relayId,
+        event: "permission_request",
+        rawPayload: {
+          hook_event_name: "PermissionRequest",
+          cwd: "/repo",
+          tool_name: "Bash",
+          tool_use_id: "native-call-2",
+          tool_input: { command: "browserforce tabs" },
+        },
+      }),
+    ).resolves.toMatchObject({ exitCode: 0 });
+    expect(approvalRequester).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares relay state across duplicate module instances", async () => {
+    const duplicateModule = await importDuplicateNativeHookRelayModuleForTests();
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "codex-duplicate-module-session",
+      sessionId: "session-1",
+      runId: "run-1",
+      allowedEvents: ["pre_tool_use", "permission_request"],
+    });
+
+    await expect(
+      duplicateModule.invokeNativeHookRelay({
+        provider: "codex",
+        relayId: relay.relayId,
+        event: "pre_tool_use",
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_input: { command: "pnpm test" },
+        },
+      }),
+    ).resolves.toMatchObject({ exitCode: 0 });
+    expect(getOnlyNativeHookRelayInvocation()).toMatchObject({
+      relayId: relay.relayId,
+      event: "pre_tool_use",
+    });
+
+    const duplicateApprovalRequester = vi.fn(async () => "allow-always" as const);
+    duplicateModule.testing.setNativeHookRelayPermissionApprovalRequesterForTests(
+      duplicateApprovalRequester,
+    );
+    const duplicateApproval = await duplicateModule.invokeNativeHookRelay({
+      provider: "codex",
+      relayId: relay.relayId,
+      event: "permission_request",
+      rawPayload: {
+        hook_event_name: "PermissionRequest",
+        cwd: "/repo",
+        tool_name: "Bash",
+        tool_use_id: "native-call-1",
+        tool_input: { command: "browserforce tabs" },
+      },
+    });
+    expect(JSON.parse(duplicateApproval.stdout)).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PermissionRequest",
+        decision: { behavior: "allow" },
+      },
+    });
+
+    const primaryApprovalRequester = vi.fn(async () => "deny" as const);
+    testing.setNativeHookRelayPermissionApprovalRequesterForTests(primaryApprovalRequester);
+    const primaryApproval = await invokeNativeHookRelay({
+      provider: "codex",
+      relayId: relay.relayId,
+      event: "permission_request",
+      rawPayload: {
+        hook_event_name: "PermissionRequest",
+        cwd: "/repo",
+        tool_name: "Bash",
+        tool_use_id: "native-call-2",
+        tool_input: { command: "browserforce tabs" },
+      },
+    });
+    expect(JSON.parse(primaryApproval.stdout)).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PermissionRequest",
+        decision: { behavior: "allow" },
+      },
+    });
+
+    expect(duplicateApprovalRequester).toHaveBeenCalledTimes(1);
+    expect(primaryApprovalRequester).not.toHaveBeenCalled();
+
+    const replacement = duplicateModule.registerNativeHookRelay({
+      provider: "codex",
+      relayId: relay.relayId,
+      sessionId: "session-1",
+      runId: "run-2",
+      allowedEvents: ["post_tool_use"],
+    });
+    expect(testing.getNativeHookRelayRegistrationForTests(relay.relayId)).toMatchObject({
+      runId: "run-2",
+      allowedEvents: ["post_tool_use"],
+    });
+
+    relay.unregister();
+    expect(testing.getNativeHookRelayRegistrationForTests(relay.relayId)).toMatchObject({
+      runId: "run-2",
+      allowedEvents: ["post_tool_use"],
+    });
+    await expect(
+      invokeNativeHookRelayBridge({
+        provider: "codex",
+        relayId: replacement.relayId,
+        generation: replacement.generation,
+        event: "post_tool_use",
+        timeoutMs: 2_000,
+        rawPayload: {
+          hook_event_name: "PostToolUse",
+          tool_name: "Bash",
+          tool_response: { output: "ok" },
+        },
+      }),
+    ).resolves.toEqual({ stdout: "", stderr: "", exitCode: 0 });
+    replacement.unregister();
   });
 
   it("preserves safety relays while marking hook-only events without handlers inactive", () => {
@@ -153,7 +448,7 @@ describe("native hook relay registry", () => {
     expect(relay.shouldRelayEvent("before_agent_finalize")).toBe(false);
     expect(relay.commandForEvent("post_tool_use")).toBe(
       "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
-        `${relay.relayId} --event post_tool_use --timeout 1234`,
+        `${relay.relayId} --generation ${relay.generation} --event post_tool_use --timeout 1234`,
     );
   });
 
@@ -175,7 +470,7 @@ describe("native hook relay registry", () => {
     expect(relay.shouldRelayEvent("before_agent_finalize")).toBe(true);
     expect(relay.commandForEvent("before_agent_finalize")).toBe(
       "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
-        `${relay.relayId} --event before_agent_finalize --timeout 1234`,
+        `${relay.relayId} --generation ${relay.generation} --event before_agent_finalize --timeout 1234`,
     );
   });
 
@@ -235,6 +530,7 @@ describe("native hook relay registry", () => {
       invokeNativeHookRelayBridge({
         provider: "codex",
         relayId: second.relayId,
+        generation: second.generation,
         event: "post_tool_use",
         timeoutMs: 2_000,
         rawPayload: {
@@ -263,6 +559,7 @@ describe("native hook relay registry", () => {
     const response = await invokeNativeHookRelayBridge({
       provider: "codex",
       relayId: relay.relayId,
+      generation: relay.generation,
       event: "pre_tool_use",
       timeoutMs: 2_000,
       rawPayload: {
@@ -277,6 +574,118 @@ describe("native hook relay registry", () => {
       relayId: relay.relayId,
       event: "pre_tool_use",
       runId: "run-1",
+    });
+  });
+
+  it("rejects stale direct bridge requests after stable relay id replacement", async () => {
+    const first = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "codex-stale-bridge-request",
+      sessionId: "session-1",
+      runId: "run-1",
+      allowedEvents: ["pre_tool_use"],
+    });
+    const firstRecord = await waitForNativeHookRelayBridgeRecord(first.relayId);
+    const staleRequest = openDeferredNativeHookRelayBridgeRequest(firstRecord, {
+      provider: "codex",
+      relayId: first.relayId,
+      generation: first.generation,
+      event: "pre_tool_use",
+      rawPayload: {
+        hook_event_name: "PreToolUse",
+        tool_name: "Bash",
+        tool_input: { command: "pnpm test" },
+      },
+    });
+    await staleRequest.connected;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    const second = registerNativeHookRelay({
+      provider: "codex",
+      relayId: first.relayId,
+      sessionId: "session-1",
+      runId: "run-2",
+      allowedEvents: ["pre_tool_use"],
+    });
+    staleRequest.sendBody();
+
+    await expect(staleRequest.response).resolves.toMatchObject({
+      ok: false,
+      error: "native hook relay bridge stale registration",
+    });
+    expect(testing.getNativeHookRelayInvocationsForTests()).toStrictEqual([]);
+
+    await expect(
+      invokeNativeHookRelayBridge({
+        provider: "codex",
+        relayId: second.relayId,
+        generation: second.generation,
+        event: "pre_tool_use",
+        timeoutMs: 2_000,
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_input: { command: "pnpm test" },
+        },
+      }),
+    ).resolves.toEqual({ stdout: "", stderr: "", exitCode: 0 });
+  });
+
+  it("rejects late stale direct bridge commands after stable relay id replacement", async () => {
+    const first = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "codex-late-stale-bridge-command",
+      sessionId: "session-1",
+      runId: "run-1",
+      allowedEvents: ["pre_tool_use"],
+    });
+    const firstCommand = first.commandForEvent("pre_tool_use");
+    expect(firstCommand).toContain("--generation");
+    expect(firstCommand).toContain(first.generation);
+    await waitForNativeHookRelayBridgeRecord(first.relayId);
+
+    const second = registerNativeHookRelay({
+      provider: "codex",
+      relayId: first.relayId,
+      sessionId: "session-1",
+      runId: "run-2",
+      allowedEvents: ["pre_tool_use"],
+    });
+
+    await expect(
+      invokeNativeHookRelayBridge({
+        provider: "codex",
+        relayId: first.relayId,
+        generation: first.generation,
+        event: "pre_tool_use",
+        timeoutMs: 2_000,
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_input: { command: "pnpm test" },
+        },
+      }),
+    ).rejects.toThrow("native hook relay bridge stale registration");
+    expect(testing.getNativeHookRelayInvocationsForTests()).toStrictEqual([]);
+
+    await expect(
+      invokeNativeHookRelayBridge({
+        provider: "codex",
+        relayId: second.relayId,
+        generation: second.generation,
+        event: "pre_tool_use",
+        timeoutMs: 2_000,
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_input: { command: "pnpm test" },
+        },
+      }),
+    ).resolves.toEqual({ stdout: "", stderr: "", exitCode: 0 });
+    expect(getOnlyNativeHookRelayInvocation()).toMatchObject({
+      relayId: second.relayId,
+      runId: "run-2",
+      event: "pre_tool_use",
     });
   });
 
@@ -302,6 +711,7 @@ describe("native hook relay registry", () => {
     const response = await invokeNativeHookRelayBridge({
       provider: "codex",
       relayId: relay.relayId,
+      generation: relay.generation,
       event: "pre_tool_use",
       timeoutMs: 2_000,
       rawPayload: {
@@ -343,6 +753,7 @@ describe("native hook relay registry", () => {
       invokeNativeHookRelayBridge({
         provider: "codex",
         relayId: relay.relayId,
+        generation: relay.generation,
         event: "pre_tool_use",
         registrationTimeoutMs: 1,
         timeoutMs: 50,
@@ -387,6 +798,7 @@ describe("native hook relay registry", () => {
       invokeNativeHookRelayBridge({
         provider: "codex",
         relayId: second.relayId,
+        generation: second.generation,
         event: "pre_tool_use",
         timeoutMs: 500,
         rawPayload: {
@@ -435,6 +847,7 @@ describe("native hook relay registry", () => {
         invokeNativeHookRelayBridge({
           provider: "codex",
           relayId: relay.relayId,
+          generation: relay.generation,
           event: "pre_tool_use",
           timeoutMs: 500,
           rawPayload: {
@@ -2033,6 +2446,74 @@ describe("native hook relay registry", () => {
     ]);
   });
 
+  it("keeps replacement pending PermissionRequest approvals when stale approvals settle", async () => {
+    const relayId = "codex-stale-pending-permission";
+    const firstRelay = registerNativeHookRelay({
+      provider: "codex",
+      relayId,
+      sessionId: "session-1",
+      runId: "run-1",
+    });
+    const resolvers: Array<(decision: "allow") => void> = [];
+    const approvalRequester = vi.fn(
+      () =>
+        new Promise<"allow">((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+    testing.setNativeHookRelayPermissionApprovalRequesterForTests(approvalRequester);
+    const payload = {
+      hook_event_name: "PermissionRequest",
+      tool_name: "Bash",
+      tool_use_id: "native-call-1",
+      tool_input: { command: "git push" },
+    };
+
+    const firstApproval = invokeNativeHookRelay({
+      provider: "codex",
+      relayId,
+      event: "permission_request",
+      rawPayload: payload,
+    });
+    await Promise.resolve();
+    expect(approvalRequester).toHaveBeenCalledTimes(1);
+    expect(getNativeHookRelaySharedStateForTests().pendingPermissionApprovals.size).toBe(1);
+
+    firstRelay.unregister();
+    registerNativeHookRelay({
+      provider: "codex",
+      relayId,
+      sessionId: "session-1",
+      runId: "run-1",
+    });
+    const secondApproval = invokeNativeHookRelay({
+      provider: "codex",
+      relayId,
+      event: "permission_request",
+      rawPayload: payload,
+    });
+    await Promise.resolve();
+    expect(approvalRequester).toHaveBeenCalledTimes(2);
+    expect(getNativeHookRelaySharedStateForTests().pendingPermissionApprovals.size).toBe(1);
+
+    resolvers[0]?.("allow");
+    await expect(firstApproval).resolves.toMatchObject({ exitCode: 0 });
+    expect(getNativeHookRelaySharedStateForTests().pendingPermissionApprovals.size).toBe(1);
+
+    const duplicateSecondApproval = invokeNativeHookRelay({
+      provider: "codex",
+      relayId,
+      event: "permission_request",
+      rawPayload: payload,
+    });
+    await Promise.resolve();
+    expect(approvalRequester).toHaveBeenCalledTimes(2);
+
+    resolvers[1]?.("allow");
+    await expect(Promise.all([secondApproval, duplicateSecondApproval])).resolves.toHaveLength(2);
+    expect(getNativeHookRelaySharedStateForTests().pendingPermissionApprovals.size).toBe(0);
+  });
+
   it("does not reuse pending PermissionRequest approvals when a tool call id is reused with different input", async () => {
     const relay = registerNativeHookRelay({
       provider: "codex",
@@ -2277,11 +2758,12 @@ describe("native hook relay command builder", () => {
       buildNativeHookRelayCommand({
         provider: "codex",
         relayId: "relay-1",
+        generation: "generation-1",
         event: "permission_request",
         executable: "openclaw",
       }),
     ).toBe(
-      "openclaw hooks relay --provider codex --relay-id relay-1 --event permission_request --timeout 5000",
+      "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event permission_request --timeout 5000",
     );
   });
 });

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -85,6 +85,7 @@ export type NativeHookRelayRegistration = {
 };
 
 export type NativeHookRelayRegistrationHandle = NativeHookRelayRegistration & {
+  generation?: string;
   shouldRelayEvent: (event: NativeHookRelayEvent) => boolean;
   commandForEvent: (event: NativeHookRelayEvent) => string;
   renew: (ttlMs?: number) => void;
@@ -115,8 +116,10 @@ export type NativeHookRelayCommandOptions = {
 export type InvokeNativeHookRelayParams = {
   provider: unknown;
   relayId: unknown;
+  generation?: unknown;
   event: unknown;
   rawPayload: unknown;
+  requireGeneration?: boolean;
 };
 
 export type InvokeNativeHookRelayBridgeParams = InvokeNativeHookRelayParams & {
@@ -178,16 +181,9 @@ const MAX_PERMISSION_ALLOW_ALWAYS_ENTRIES = 512;
 const MAX_NATIVE_HOOK_BRIDGE_BODY_BYTES = 5_000_000;
 const MAX_NATIVE_HOOK_BRIDGE_RESPONSE_BYTES = 5_000_000;
 const NATIVE_HOOK_BRIDGE_RETRY_INTERVAL_MS = 25;
+const NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR =
+  "native hook relay bridge stale registration";
 const ANSI_ESCAPE_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`, "g");
-const relays = new Map<string, NativeHookRelayRegistration>();
-const relayBridges = new Map<string, NativeHookRelayBridgeRegistration>();
-const invocations: NativeHookRelayInvocation[] = [];
-const pendingPermissionApprovals = new Map<
-  string,
-  Promise<NativeHookRelayPermissionApprovalResult>
->();
-const permissionApprovalWindows = new Map<string, number[]>();
-const permissionAllowAlwaysApprovals = new Map<string, { expiresAtMs: number }>();
 const log = createSubsystemLogger("agents/harness/native-hook-relay");
 
 type NativeHookRelayPermissionDecision = "allow" | "deny";
@@ -196,6 +192,48 @@ type NativeHookRelayPermissionApprovalResult =
   | NativeHookRelayPermissionDecision
   | "allow-always"
   | "defer";
+
+type NativeHookRelaySharedState = {
+  relays: Map<string, ActiveNativeHookRelayRegistration>;
+  relayBridges: Map<string, NativeHookRelayBridgeRegistration>;
+  invocations: NativeHookRelayInvocation[];
+  pendingPermissionApprovals: Map<string, Promise<NativeHookRelayPermissionApprovalResult>>;
+  permissionApprovalWindows: Map<string, number[]>;
+  permissionAllowAlwaysApprovals: Map<string, { expiresAtMs: number }>;
+};
+
+type ActiveNativeHookRelayRegistration = NativeHookRelayRegistration & {
+  generation: string;
+};
+
+type ActiveNativeHookRelayRegistrationHandle = NativeHookRelayRegistrationHandle & {
+  generation: string;
+};
+
+const NATIVE_HOOK_RELAY_STATE_SYMBOL = Symbol.for("openclaw.nativeHookRelay.state");
+
+function getNativeHookRelaySharedState(): NativeHookRelaySharedState {
+  const globalRecord = globalThis as typeof globalThis & {
+    [key: symbol]: NativeHookRelaySharedState | undefined;
+  };
+  globalRecord[NATIVE_HOOK_RELAY_STATE_SYMBOL] ??= {
+    relays: new Map<string, ActiveNativeHookRelayRegistration>(),
+    relayBridges: new Map<string, NativeHookRelayBridgeRegistration>(),
+    invocations: [],
+    pendingPermissionApprovals: new Map<string, Promise<NativeHookRelayPermissionApprovalResult>>(),
+    permissionApprovalWindows: new Map<string, number[]>(),
+    permissionAllowAlwaysApprovals: new Map<string, { expiresAtMs: number }>(),
+  };
+  return globalRecord[NATIVE_HOOK_RELAY_STATE_SYMBOL];
+}
+
+const nativeHookRelayState = getNativeHookRelaySharedState();
+const relays = nativeHookRelayState.relays;
+const relayBridges = nativeHookRelayState.relayBridges;
+const invocations = nativeHookRelayState.invocations;
+const pendingPermissionApprovals = nativeHookRelayState.pendingPermissionApprovals;
+const permissionApprovalWindows = nativeHookRelayState.permissionApprovalWindows;
+const permissionAllowAlwaysApprovals = nativeHookRelayState.permissionAllowAlwaysApprovals;
 
 type NativeHookRelayPermissionApprovalRequest = {
   provider: NativeHookRelayProvider;
@@ -230,6 +268,14 @@ type NativeHookRelayBridgeRecord = {
   port: number;
   token: string;
   expiresAtMs: number;
+};
+
+type NativeHookRelayBridgeRequestAuth = {
+  provider: NativeHookRelayProvider;
+  relayId: string;
+  token: string;
+  registration: ActiveNativeHookRelayRegistration;
+  bridge: NativeHookRelayBridgeRegistration;
 };
 
 let nativeHookRelayPermissionApprovalRequester: NativeHookRelayPermissionApprovalRequester =
@@ -299,15 +345,16 @@ const nativeHookRelayProviderAdapters: Record<
 
 export function registerNativeHookRelay(
   params: RegisterNativeHookRelayParams,
-): NativeHookRelayRegistrationHandle {
+): ActiveNativeHookRelayRegistrationHandle {
   pruneExpiredNativeHookRelays();
   pruneNativeHookRelayPermissionAllowAlways();
   const relayId = normalizeRelayId(params.relayId) ?? randomUUID();
   const allowedEvents = normalizeAllowedEvents(params.allowedEvents);
   unregisterNativeHookRelay(relayId);
-  const registration: NativeHookRelayRegistration = {
+  const registration: ActiveNativeHookRelayRegistration = {
     relayId,
     provider: params.provider,
+    generation: randomUUID(),
     ...(params.agentId ? { agentId: params.agentId } : {}),
     sessionId: params.sessionId,
     ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
@@ -320,13 +367,14 @@ export function registerNativeHookRelay(
   };
   relays.set(relayId, registration);
   registerNativeHookRelayBridge(registration);
-  const handle: NativeHookRelayRegistrationHandle = {
+  const handle: ActiveNativeHookRelayRegistrationHandle = {
     ...registration,
     shouldRelayEvent: nativeHookRelayEventHasLocalWork,
     commandForEvent: (event) =>
       buildNativeHookRelayCommand({
         provider: params.provider,
         relayId,
+        generation: registration.generation,
         event,
         timeoutMs: params.command?.timeoutMs,
         executable: params.command?.executable,
@@ -352,7 +400,7 @@ export function registerNativeHookRelay(
 
 function unregisterNativeHookRelay(
   relayId: string,
-  expectedRegistration?: NativeHookRelayRegistration,
+  expectedRegistration?: ActiveNativeHookRelayRegistration,
 ): void {
   if (expectedRegistration && relays.get(relayId) !== expectedRegistration) {
     return;
@@ -377,6 +425,7 @@ function normalizeRelayId(value: string | undefined): string | undefined {
 export function buildNativeHookRelayCommand(params: {
   provider: NativeHookRelayProvider;
   relayId: string;
+  generation?: string;
   event: NativeHookRelayEvent;
   timeoutMs?: number;
   executable?: string;
@@ -396,6 +445,7 @@ export function buildNativeHookRelayCommand(params: {
     params.provider,
     "--relay-id",
     params.relayId,
+    ...(params.generation ? ["--generation", params.generation] : []),
     "--event",
     params.event,
     "--timeout",
@@ -433,6 +483,12 @@ export async function invokeNativeHookRelay(
   }
   if (registration.provider !== provider) {
     throw new Error("native hook relay provider mismatch");
+  }
+  if (params.requireGeneration) {
+    const generation = readNonEmptyString(params.generation, "generation");
+    if (generation !== registration.generation) {
+      throw new Error(NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR);
+    }
   }
   if (!registration.allowedEvents.includes(event)) {
     throw new Error("native hook relay event not allowed");
@@ -494,6 +550,7 @@ export async function invokeNativeHookRelayBridge(
           provider,
           relayId,
           event,
+          generation: params.generation,
           rawPayload: params.rawPayload,
         },
       });
@@ -535,6 +592,12 @@ export function renderNativeHookRelayUnavailableResponse(params: {
   return adapter.renderNoopResponse(event);
 }
 
+export function isNativeHookRelayBridgeStaleRegistrationError(error: unknown): boolean {
+  return (
+    error instanceof Error && error.message === NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR
+  );
+}
+
 function recordNativeHookRelayInvocation(invocation: NativeHookRelayInvocation): void {
   invocations.push({
     ...invocation,
@@ -561,25 +624,28 @@ function pruneExpiredNativeHookRelays(now = Date.now()): void {
   }
 }
 
-function registerNativeHookRelayBridge(registration: NativeHookRelayRegistration): void {
+function registerNativeHookRelayBridge(registration: ActiveNativeHookRelayRegistration): void {
   unregisterNativeHookRelayBridge(registration.relayId);
   const token = randomUUID();
   const bridgeDir = ensureNativeHookRelayBridgeDir();
   const bridgeKey = nativeHookRelayBridgeKey(registration.relayId);
   const registryPath = path.join(bridgeDir, `${bridgeKey}.json`);
-  const server = createServer((req, res) => {
-    void handleNativeHookRelayBridgeRequest(req, res, {
-      provider: registration.provider,
-      relayId: registration.relayId,
-      token,
-    });
-  });
+  const server = createServer();
   const bridge: NativeHookRelayBridgeRegistration = {
     relayId: registration.relayId,
     registryPath,
     token,
     server,
   };
+  server.on("request", (req, res) => {
+    void handleNativeHookRelayBridgeRequest(req, res, {
+      provider: registration.provider,
+      relayId: registration.relayId,
+      token,
+      registration,
+      bridge,
+    });
+  });
   relayBridges.set(registration.relayId, bridge);
   server.on("error", (error) => {
     log.debug("native hook relay bridge server error", { error, relayId: registration.relayId });
@@ -597,7 +663,7 @@ function registerNativeHookRelayBridge(registration: NativeHookRelayRegistration
 }
 
 function writeNativeHookRelayBridgeRecordForRegistration(
-  registration: NativeHookRelayRegistration,
+  registration: ActiveNativeHookRelayRegistration,
   bridge: NativeHookRelayBridgeRegistration,
 ): void {
   const address = bridge.server.address();
@@ -635,7 +701,7 @@ function unregisterNativeHookRelayBridge(relayId: string): void {
 async function handleNativeHookRelayBridgeRequest(
   req: IncomingMessage,
   res: ServerResponse,
-  auth: { provider: NativeHookRelayProvider; relayId: string; token: string },
+  auth: NativeHookRelayBridgeRequestAuth,
 ): Promise<void> {
   try {
     if (req.method !== "POST" || req.url !== "/invoke") {
@@ -644,6 +710,13 @@ async function handleNativeHookRelayBridgeRequest(
     }
     if (req.headers.authorization !== `Bearer ${auth.token}`) {
       writeNativeHookRelayBridgeJson(res, 403, { ok: false, error: "forbidden" });
+      return;
+    }
+    if (!isCurrentNativeHookRelayBridgeRequest(auth)) {
+      writeNativeHookRelayBridgeJson(res, 410, {
+        ok: false,
+        error: NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR,
+      });
       return;
     }
     const body = await readNativeHookRelayBridgeBody(req);
@@ -655,14 +728,31 @@ async function handleNativeHookRelayBridgeRequest(
       });
       return;
     }
-    const result = await invokeNativeHookRelay(payload);
+    if (!isCurrentNativeHookRelayBridgeRequest(auth)) {
+      writeNativeHookRelayBridgeJson(res, 410, {
+        ok: false,
+        error: NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR,
+      });
+      return;
+    }
+    const result = await invokeNativeHookRelay({ ...payload, requireGeneration: true });
     writeNativeHookRelayBridgeJson(res, 200, { ok: true, result });
   } catch (error) {
-    writeNativeHookRelayBridgeJson(res, 500, {
-      ok: false,
-      error: error instanceof Error ? error.message : String(error),
-    });
+    writeNativeHookRelayBridgeJson(
+      res,
+      isNativeHookRelayBridgeStaleRegistrationError(error) ? 410 : 500,
+      {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
   }
+}
+
+function isCurrentNativeHookRelayBridgeRequest(auth: NativeHookRelayBridgeRequestAuth): boolean {
+  return (
+    relays.get(auth.relayId) === auth.registration && relayBridges.get(auth.relayId) === auth.bridge
+  );
 }
 
 async function readNativeHookRelayBridgeBody(req: NodeJS.ReadableStream): Promise<string> {
@@ -686,6 +776,7 @@ function readNativeHookRelayBridgePayload(value: unknown): InvokeNativeHookRelay
   return {
     provider: value.provider,
     relayId: value.relayId,
+    generation: readNonEmptyString(value.generation, "generation"),
     event: value.event,
     rawPayload: value.rawPayload,
   };
@@ -1096,8 +1187,11 @@ async function startNativeHookRelayPermissionApprovalWithBudget(params: {
     );
     return "defer";
   }
-  const approval = nativeHookRelayPermissionApprovalRequester(params.request).finally(() => {
-    pendingPermissionApprovals.delete(params.approvalKey);
+  let approval!: Promise<NativeHookRelayPermissionApprovalResult>;
+  approval = nativeHookRelayPermissionApprovalRequester(params.request).finally(() => {
+    if (pendingPermissionApprovals.get(params.approvalKey) === approval) {
+      pendingPermissionApprovals.delete(params.approvalKey);
+    }
   });
   pendingPermissionApprovals.set(params.approvalKey, approval);
   return approval;

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -525,6 +525,7 @@ export function registerHooksCli(program: Command): void {
     .description("Internal native harness hook relay")
     .requiredOption("--provider <provider>", "Native harness provider")
     .requiredOption("--relay-id <id>", "Native hook relay id")
+    .option("--generation <generation>", "Native hook relay registration generation")
     .requiredOption("--event <event>", "Native hook event")
     .option("--timeout <ms>", "Gateway timeout in ms", "5000")
     .action(async (opts: NativeHookRelayCliOptions) =>

--- a/src/cli/native-hook-relay-cli.test.ts
+++ b/src/cli/native-hook-relay-cli.test.ts
@@ -15,6 +15,7 @@ describe("native hook relay CLI", () => {
       {
         provider: "codex",
         relayId: "relay-1",
+        generation: "generation-1",
         event: "pre_tool_use",
         timeout: "1234",
       },
@@ -40,6 +41,7 @@ describe("native hook relay CLI", () => {
       params: {
         provider: "codex",
         relayId: "relay-1",
+        generation: "generation-1",
         event: "pre_tool_use",
         rawPayload: {
           hook_event_name: "PreToolUse",
@@ -58,7 +60,12 @@ describe("native hook relay CLI", () => {
     const stderr = createWritableTextBuffer();
 
     const exitCode = await runNativeHookRelayCli(
-      { provider: "codex", relayId: "relay-1", event: "permission_request" },
+      {
+        provider: "codex",
+        relayId: "relay-1",
+        generation: "generation-1",
+        event: "permission_request",
+      },
       {
         stdin: createReadableTextStream("{}"),
         stdout,
@@ -72,12 +79,116 @@ describe("native hook relay CLI", () => {
     expect(stderr.text()).toBe("err");
   });
 
+  it("renders unavailable output for legacy relay commands without a generation", async () => {
+    const invokeBridge = vi.fn(async () => {
+      throw new Error("generation must be non-empty string");
+    });
+    const callGateway = vi.fn(async () => {
+      throw new Error("generation must be non-empty string");
+    });
+    const stdout = createWritableTextBuffer();
+    const stderr = createWritableTextBuffer();
+
+    const exitCode = await runNativeHookRelayCli(
+      { provider: "codex", relayId: "relay-1", event: "pre_tool_use" },
+      {
+        stdin: createReadableTextStream("{}"),
+        stdout,
+        stderr,
+        invokeBridge: invokeBridge as never,
+        callGateway: callGateway as never,
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout.text())).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Native hook relay unavailable",
+      },
+    });
+    expect(stderr.text()).toContain("native hook relay unavailable");
+    expect(stderr.text()).toContain("generation must be non-empty string");
+    expect(callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "nativeHook.invoke",
+        params: expect.objectContaining({ generation: undefined }),
+      }),
+    );
+  });
+
+  it.each([
+    {
+      event: "pre_tool_use",
+      stdout: {
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "deny",
+          permissionDecisionReason: "Native hook relay unavailable",
+        },
+      },
+    },
+    {
+      event: "permission_request",
+      stdout: {
+        hookSpecificOutput: {
+          hookEventName: "PermissionRequest",
+          decision: {
+            behavior: "deny",
+            message: "Native hook relay unavailable",
+          },
+        },
+      },
+    },
+    {
+      event: "post_tool_use",
+      stdout: null,
+    },
+  ])(
+    "does not fall back to the gateway after a stale direct bridge error for $event",
+    async (testCase) => {
+      const invokeBridge = vi.fn(async () => {
+        throw new Error("native hook relay bridge stale registration");
+      });
+      const callGateway = vi.fn(async () => ({ stdout: "unexpected", stderr: "", exitCode: 0 }));
+      const stdout = createWritableTextBuffer();
+      const stderr = createWritableTextBuffer();
+
+      const exitCode = await runNativeHookRelayCli(
+        {
+          provider: "codex",
+          relayId: "relay-1",
+          generation: "generation-1",
+          event: testCase.event,
+        },
+        {
+          stdin: createReadableTextStream("{}"),
+          stdout,
+          stderr,
+          invokeBridge: invokeBridge as never,
+          callGateway: callGateway as never,
+        },
+      );
+
+      expect(exitCode).toBe(0);
+      if (testCase.stdout) {
+        expect(JSON.parse(stdout.text())).toEqual(testCase.stdout);
+      } else {
+        expect(stdout.text()).toBe("");
+      }
+      expect(stderr.text()).toContain("native hook relay unavailable");
+      expect(stderr.text()).toContain("native hook relay bridge stale registration");
+      expect(callGateway).not.toHaveBeenCalled();
+    },
+  );
+
   it("returns a nonzero code for malformed hook input without touching the gateway", async () => {
     const callGateway = vi.fn();
     const stderr = createWritableTextBuffer();
 
     const exitCode = await runNativeHookRelayCli(
-      { provider: "codex", relayId: "relay-1", event: "pre_tool_use" },
+      { provider: "codex", relayId: "relay-1", generation: "generation-1", event: "pre_tool_use" },
       {
         stdin: createReadableTextStream("{nope"),
         stderr,
@@ -95,7 +206,7 @@ describe("native hook relay CLI", () => {
     const stderr = createWritableTextBuffer();
 
     const exitCode = await runNativeHookRelayCli(
-      { provider: "codex", relayId: "relay-1", event: "post_tool_use" },
+      { provider: "codex", relayId: "relay-1", generation: "generation-1", event: "post_tool_use" },
       {
         stdin: createReadableTextStream("x".repeat(1024 * 1024 + 1)),
         stderr,
@@ -116,7 +227,7 @@ describe("native hook relay CLI", () => {
     const stderr = createWritableTextBuffer();
 
     const exitCode = await runNativeHookRelayCli(
-      { provider: "codex", relayId: "relay-1", event: "pre_tool_use" },
+      { provider: "codex", relayId: "relay-1", generation: "generation-1", event: "pre_tool_use" },
       {
         stdin: createReadableTextStream("{}"),
         stdout,
@@ -144,7 +255,12 @@ describe("native hook relay CLI", () => {
     const stderr = createWritableTextBuffer();
 
     const exitCode = await runNativeHookRelayCli(
-      { provider: "codex", relayId: "relay-1", event: "permission_request" },
+      {
+        provider: "codex",
+        relayId: "relay-1",
+        generation: "generation-1",
+        event: "permission_request",
+      },
       {
         stdin: createReadableTextStream("{}"),
         stdout,
@@ -173,7 +289,7 @@ describe("native hook relay CLI", () => {
     const stderr = createWritableTextBuffer();
 
     const exitCode = await runNativeHookRelayCli(
-      { provider: "codex", relayId: "relay-1", event: "post_tool_use" },
+      { provider: "codex", relayId: "relay-1", generation: "generation-1", event: "post_tool_use" },
       {
         stdin: createReadableTextStream("{}"),
         stdout,
@@ -195,7 +311,12 @@ describe("native hook relay CLI", () => {
     const stderr = createWritableTextBuffer();
 
     const exitCode = await runNativeHookRelayCli(
-      { provider: "codex", relayId: "relay-1", event: "before_agent_finalize" },
+      {
+        provider: "codex",
+        relayId: "relay-1",
+        generation: "generation-1",
+        event: "before_agent_finalize",
+      },
       {
         stdin: createReadableTextStream("{}"),
         stdout,

--- a/src/cli/native-hook-relay-cli.ts
+++ b/src/cli/native-hook-relay-cli.ts
@@ -1,6 +1,7 @@
 import { Readable, Writable } from "node:stream";
 import {
   invokeNativeHookRelayBridge,
+  isNativeHookRelayBridgeStaleRegistrationError,
   renderNativeHookRelayUnavailableResponse,
   type NativeHookRelayProcessResponse,
 } from "../agents/harness/native-hook-relay.js";
@@ -12,6 +13,7 @@ const MAX_NATIVE_HOOK_STDIN_BYTES = 1024 * 1024;
 export type NativeHookRelayCliOptions = {
   provider?: string;
   relayId?: string;
+  generation?: string;
   event?: string;
   timeout?: string;
 };
@@ -20,6 +22,7 @@ type NativeHookRelayCliDeps = {
   stdin?: NodeJS.ReadableStream;
   stdout?: NodeJS.WritableStream;
   stderr?: NodeJS.WritableStream;
+  invokeBridge?: typeof invokeNativeHookRelayBridge;
   callGateway?: typeof callGateway;
 };
 
@@ -30,9 +33,11 @@ export async function runNativeHookRelayCli(
   const stdin = deps.stdin ?? process.stdin;
   const stdout = deps.stdout ?? process.stdout;
   const stderr = deps.stderr ?? process.stderr;
+  const invokeBridge = deps.invokeBridge ?? invokeNativeHookRelayBridge;
   const callGatewayFn = deps.callGateway ?? callGateway;
   const provider = readRequiredOption(opts.provider, "provider");
   const relayId = readRequiredOption(opts.relayId, "relay-id");
+  const generation = opts.generation?.trim() || undefined;
   const event = readRequiredOption(opts.event, "event");
 
   let rawPayload: unknown;
@@ -45,9 +50,10 @@ export async function runNativeHookRelayCli(
   }
 
   try {
-    const response = await invokeNativeHookRelayBridge({
+    const response = await invokeBridge({
       provider,
       relayId,
+      generation,
       event,
       rawPayload,
       registrationTimeoutMs: 100,
@@ -56,7 +62,18 @@ export async function runNativeHookRelayCli(
     writeText(stdout, response.stdout);
     writeText(stderr, response.stderr);
     return response.exitCode;
-  } catch {
+  } catch (error) {
+    if (isNativeHookRelayBridgeStaleRegistrationError(error)) {
+      writeText(stderr, formatRelayCliError("native hook relay unavailable", error));
+      const response = renderNativeHookRelayUnavailableResponse({
+        provider,
+        event,
+        message: "Native hook relay unavailable",
+      });
+      writeText(stdout, response.stdout);
+      writeText(stderr, response.stderr);
+      return response.exitCode;
+    }
     // Fall through to the gateway path for embedded/local gateway cases and
     // older registrations that predate the direct relay bridge.
   }
@@ -64,7 +81,7 @@ export async function runNativeHookRelayCli(
   try {
     const response = await callGatewayFn<NativeHookRelayProcessResponse>({
       method: "nativeHook.invoke",
-      params: { provider, relayId, event, rawPayload },
+      params: { provider, relayId, generation, event, rawPayload },
       timeoutMs: normalizeTimeoutMs(opts.timeout),
       scopes: [ADMIN_SCOPE],
     });

--- a/src/gateway/server-methods/native-hook-relay.test.ts
+++ b/src/gateway/server-methods/native-hook-relay.test.ts
@@ -21,6 +21,7 @@ describe("native hook relay gateway method", () => {
       params: {
         provider: "codex",
         relayId: relay.relayId,
+        generation: relay.generation,
         event: "post_tool_use",
         rawPayload: {
           hook_event_name: "PostToolUse",
@@ -62,6 +63,52 @@ describe("native hook relay gateway method", () => {
     expect(call?.[1]).toBeUndefined();
     expect(call?.[2]?.code).toBe("INVALID_REQUEST");
     expect(call?.[2]?.message).toContain("not found");
+  });
+
+  it("rejects stale relay generations", async () => {
+    const first = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "relay-1",
+      sessionId: "session-1",
+      runId: "run-1",
+      allowedEvents: ["post_tool_use"],
+    });
+    registerNativeHookRelay({
+      provider: "codex",
+      relayId: first.relayId,
+      sessionId: "session-1",
+      runId: "run-2",
+      allowedEvents: ["post_tool_use"],
+    });
+    const respond = viRespond();
+
+    await nativeHookRelayHandlers["nativeHook.invoke"]({
+      req: { type: "req", id: "1", method: "nativeHook.invoke" },
+      params: {
+        provider: "codex",
+        relayId: first.relayId,
+        generation: first.generation,
+        event: "post_tool_use",
+        rawPayload: {
+          hook_event_name: "PostToolUse",
+          tool_name: "Bash",
+          tool_response: { output: "ok" },
+        },
+      },
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+      context: {} as never,
+    });
+
+    const call = respond.mock.calls.at(0) as
+      | [boolean, unknown, { code?: string; message?: string }]
+      | undefined;
+    expect(call?.[0]).toBe(false);
+    expect(call?.[1]).toBeUndefined();
+    expect(call?.[2]?.code).toBe("INVALID_REQUEST");
+    expect(call?.[2]?.message).toContain("native hook relay bridge stale registration");
+    expect(testing.getNativeHookRelayInvocationsForTests()).toStrictEqual([]);
   });
 });
 

--- a/src/gateway/server-methods/native-hook-relay.ts
+++ b/src/gateway/server-methods/native-hook-relay.ts
@@ -11,8 +11,10 @@ export const nativeHookRelayHandlers: GatewayRequestHandlers = {
       const result: NativeHookRelayProcessResponse = await invokeNativeHookRelay({
         provider: params.provider,
         relayId: params.relayId,
+        generation: params.generation,
         event: params.event,
         rawPayload: params.rawPayload,
+        requireGeneration: true,
       });
       respond(true, result);
     } catch (error) {


### PR DESCRIPTION
## Problem

Codex native hook relays can be registered in one module instance and invoked from another module instance in the same process. When those instances each keep their own in-memory relay maps, OpenClaw can install Codex hook commands but later fail to find the active relay for the same run. A separate race also lets a late hook command for an old run reuse the stable relay id after a replacement run has registered.

Fixes #73723 and replaces the abandoned approach in #73950.

## Change and value

This PR moves native hook relay registry state onto a process-global symbol so duplicate module instances share the same relay, bridge, invocation, and permission-approval state. It also adds a per-registration generation token to newly generated hidden hook commands and validates that token through the direct bridge, gateway fallback, and Codex app-server approval bridge.

The result is that current hook commands still reach the active relay, while stale commands fail closed instead of invoking a replacement registration with the same stable relay id.

## Who is affected, and who is not

- Affected: Codex app-server/native hook relay users, especially runs that load duplicate agent-harness runtime instances or overlap old and replacement Codex runs for the same session relay id.
- Not affected: ordinary plugin hooks, non-Codex native relay providers, and public user-facing CLI commands. `hooks relay` remains a hidden internal command.
- Compatibility: `buildNativeHookRelayCommand()` and the hidden CLI still tolerate omitted generations so older already-written commands fail through the normal unavailable path rather than crashing at option parsing.

## Why now

#73723 is still open, and #73950 has gone stale. Recent cleanup work fixed one pending-unregister race, but it did not make duplicate module instances share relay state or prevent late stale commands from crossing into replacement registrations.

## Implementation

- Store relay registrations, bridge records, invocation history, pending permission approvals, rate-limit windows, and allow-always approvals in a process-global `Symbol.for("openclaw.nativeHookRelay.state")` object.
- Add an internal required `generation` to active registrations while keeping the exported handle field optional for SDK/source compatibility.
- Include `--generation` in newly generated hidden hook commands.
- Require matching generations for direct bridge requests, gateway `nativeHook.invoke`, and the Codex app-server approval bridge's in-process relay invocation.
- Return/recognize stale bridge registrations as a fail-closed unavailable relay result instead of falling back to a newer gateway registration.
- Keep replacement pending permission approvals from being deleted by stale approval finalizers.

## Verification

- Local lightweight checks:
  - `git diff --check origin/main...HEAD`
  - `./node_modules/.bin/oxfmt --check --threads=1 extensions/codex/src/app-server/approval-bridge.ts extensions/codex/src/app-server/approval-bridge.test.ts extensions/codex/src/app-server/native-hook-relay.test.ts src/agents/harness/native-hook-relay.ts src/agents/harness/native-hook-relay.test.ts src/cli/hooks-cli.ts src/cli/native-hook-relay-cli.ts src/cli/native-hook-relay-cli.test.ts src/gateway/server-methods/native-hook-relay.ts src/gateway/server-methods/native-hook-relay.test.ts`
- Review gates:
  - Codex review after rebase against `origin/main`: no actionable findings.
  - Read-only adversarial lanes during development found stale-generation and app-server approval-bridge gaps; both were fixed before final validation.
- Final Crabbox/GCP validation:
  - Lease `cbx_9c0044dd81ae`, slug `brisk-hermit`, GCP `us-east1-b`, Spot `e2-standard-8`, no local sync.
  - Fresh GitHub clone of `openclaw/openclaw`, fetched `Kaspre/openclaw` branch `fix/native-hook-relay-shared-state`, checked out exact head `2a37ac2fc5945c7a3020dfa92c47625ea51dbd67`.
  - Live proof command output:

```text
[proof] head=2a37ac2fc5945c7a3020dfa92c47625ea51dbd67
[proof] duplicate-module-invoke=0
[proof] stale-generation-error=native hook relay bridge stale registration
[proof] replacement-generation-invoke=0
```

  - Focused changed-path tests passed: `src/agents/harness/native-hook-relay.test.ts`, `src/cli/native-hook-relay-cli.test.ts`, `src/gateway/server-methods/native-hook-relay.test.ts`, `extensions/codex/src/app-server/native-hook-relay.test.ts`, `extensions/codex/src/app-server/approval-bridge.test.ts` (`118` tests across `4` Vitest shards).
  - `pnpm check:changed` passed on the same exact head.

## Real behavior proof

**Behavior or issue addressed:** Codex native hook relay state remains available across duplicate module instances, and a stale relay command from an old stable relay-id registration cannot invoke the replacement registration.

**Real environment tested:** Crabbox GCP Spot VM (`us-east1-b`, `e2-standard-8`) from a fresh GitHub clone, checking out pushed fork head `2a37ac2fc5945c7a3020dfa92c47625ea51dbd67`.

**Exact steps or command run after this patch:** On the Crabbox VM, cloned `https://github.com/openclaw/openclaw.git`, fetched `https://github.com/Kaspre/openclaw.git fix/native-hook-relay-shared-state`, checked out `FETCH_HEAD`, installed Node `24.15.0` and `pnpm@11.0.8`, then ran a `node --import tsx --input-type=module -e ...` script that imported `src/agents/harness/native-hook-relay.ts` twice, registered a relay in one module instance, invoked it from the duplicate module instance, replaced the same stable relay id, attempted a stale-generation bridge invocation, and then invoked the replacement generation. The same VM then ran the focused Vitest files and `pnpm check:changed`.

**Evidence after fix:** Terminal capture from lease `cbx_9c0044dd81ae`:

```text
[proof] head=2a37ac2fc5945c7a3020dfa92c47625ea51dbd67
[proof] duplicate-module-invoke=0
[proof] stale-generation-error=native hook relay bridge stale registration
[proof] replacement-generation-invoke=0
```

**Observed result after fix:** The duplicate module successfully invoked the current relay (`exitCode=0`), the stale generation was rejected with `native hook relay bridge stale registration`, the replacement generation invoked successfully (`exitCode=0`), focused changed-path tests passed, and `pnpm check:changed` exited `0`.

**What was not tested:** No changed-path behavior gap remains. The full unrelated repository test suite is left to GitHub CI; this PR ran live relay proof, focused changed-path tests, and `check:changed` on the exact pushed head.

## AI Assistance

I used Codex to prepare the patch and verification.