### PR TITLE
fix(cron): accept plus durations for one-shot jobs

### DIFF
--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CronJob } from "../cron/types.js";
 import { registerCronCli } from "./cron-cli.js";
 
@@ -39,6 +39,10 @@ const defaultGatewayMock = async (
 };
 callGatewayFromCli.mockImplementation(defaultGatewayMock);
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 vi.mock("./gateway-rpc.js", async () => {
   const actual = await vi.importActual<typeof import("./gateway-rpc.js")>("./gateway-rpc.js");
   return {
@@ -75,7 +79,7 @@ type CronUpdatePatch = {
 };
 
 type CronAddParams = {
-  schedule?: { kind?: string; staggerMs?: number };
+  schedule?: { kind?: string; at?: string; staggerMs?: number };
   payload?: {
     model?: string;
     thinking?: string;
@@ -316,16 +320,7 @@ describe("cron cli", () => {
         enqueued: true,
         runId: "manual:job-1:123:0",
         runStatus: status,
-        args: [
-          "cron",
-          "run",
-          "job-1",
-          "--wait",
-          "--wait-timeout",
-          "1s",
-          "--poll-interval",
-          "1ms",
-        ],
+        args: ["cron", "run", "job-1", "--wait", "--wait-timeout", "1s", "--poll-interval", "1ms"],
       });
 
       expect(exitSpy).toHaveBeenCalledWith(expectedExitCode);
@@ -455,6 +450,24 @@ describe("cron cli", () => {
     const addCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.add");
     const params = addCall?.[2] as { deleteAfterRun?: boolean };
     expect(params?.deleteAfterRun).toBe(false);
+  });
+
+  it("accepts leading plus relative durations for cron add --at", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-25T00:00:00.000Z"));
+
+    const params = await runCronAddAndGetParams([
+      "--name",
+      "Plus duration",
+      "--at",
+      "+30m",
+      "--session",
+      "main",
+      "--system-event",
+      "hello",
+    ]);
+
+    expect(params?.schedule).toEqual({ kind: "at", at: "2026-05-25T00:30:00.000Z" });
   });
 
   it("includes --account on isolated cron add delivery", async () => {

--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -1,9 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CronJob } from "../../cron/types.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import {
   coerceCronDeliveryPreviews,
   getCronChannelOptions,
+  parseAt,
   parseCronToolsAllow,
   printCronList,
 } from "./shared.js";
@@ -29,6 +30,10 @@ function createRuntimeLogCapture(): { logs: string[]; runtime: RuntimeEnv } {
 function expectLogsToInclude(logs: readonly string[], text: string): void {
   expect(logs.join("\n")).toContain(text);
 }
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 function createBaseJob(overrides: Partial<CronJob>): CronJob {
   const now = Date.now();
@@ -228,6 +233,16 @@ describe("printCronList", () => {
 
     printCronList([job], runtime);
     expectLogsToInclude(logs, "(exact)");
+  });
+});
+
+describe("parseAt", () => {
+  it("accepts leading plus relative durations for cron add --at", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-25T00:00:00.000Z"));
+
+    expect(parseAt("+30m")).toBe("2026-05-25T00:30:00.000Z");
+    expect(parseAt("30m")).toBe("2026-05-25T00:30:00.000Z");
   });
 });
 

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -177,7 +177,8 @@ export function parseAt(input: string, tz?: string): string | null {
   if (absolute !== null) {
     return new Date(absolute).toISOString();
   }
-  const dur = parseDurationMs(raw);
+  const durationInput = raw.startsWith("+") ? raw.slice(1) : raw;
+  const dur = parseDurationMs(durationInput);
   if (dur !== null) {
     return new Date(Date.now() + dur).toISOString();
   }


### PR DESCRIPTION
## Summary

- Accept an optional leading `+` for `cron add --at` relative durations.
- Keep bare duration support unchanged and leave the shared duration parser strict for other options.
- Add regression coverage for the parser and CLI add path.

## Verification

- `node scripts/run-vitest.mjs src/cli/cron-cli.test.ts`
- `node scripts/run-vitest.mjs src/cli/cron-cli/shared.test.ts`
- `git diff --check`

Closes #86230

## Real behavior proof

**Behavior addressed:** `cron add --at +30m` now resolves as a one-shot schedule instead of being rejected despite the help text advertising `+duration`.
**Real environment tested:** Linux, repository test runner, local source checkout after this patch.
**Exact steps or command run after this patch:**

```bash
node scripts/run-vitest.mjs src/cli/cron-cli.test.ts
node scripts/run-vitest.mjs src/cli/cron-cli/shared.test.ts
git diff --check
node --import tsx --no-warnings -e "import { resolveCronCreateSchedule } from './src/cli/cron-cli/schedule-options.js'; import { parseDurationMs } from './src/cli/cron-cli/shared.js'; Date.now = () => Date.parse('2026-05-25T00:00:00.000Z'); console.log(JSON.stringify({ atPlus: resolveCronCreateSchedule({ at: '+30m' }), atBare: resolveCronCreateSchedule({ at: '30m' }), everyPlusStillInvalid: parseDurationMs('+30m') }, null, 2));"
```

**Evidence after fix:**

```text
RUN  v4.1.7 /home/0668001029/openclaw

 Test Files  1 passed (1)
      Tests  72 passed (72)
```

```text
RUN  v4.1.7 /home/0668001029/openclaw

 Test Files  1 passed (1)
      Tests  22 passed (22)
```

```text
{
  "atPlus": {
    "kind": "at",
    "at": "2026-05-25T00:30:00.000Z"
  },
  "atBare": {
    "kind": "at",
    "at": "2026-05-25T00:30:00.000Z"
  },
  "everyPlusStillInvalid": null
}
```

**Observed result after fix:** The actual schedule resolver accepts `+30m` and `30m` for `--at`, while the duration parser still rejects `+30m` for callers such as `--every`.
**What was not tested:** A live Gateway scheduler run was not started; verification covered the CLI RPC parameters, shared parser, and schedule resolver.