### PR TITLE
fix(memory): bound INDEX_CACHE lifetime in long-running gateway daemons

### DIFF
--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -308,6 +308,26 @@ For custom OpenAI-compatible endpoints or overriding provider defaults:
 Unset uses the provider default: 600 seconds for local/self-hosted providers such as `local`, `ollama`, and `lmstudio`, and 120 seconds for hosted providers. Increase this when local CPU-bound embedding batches are healthy but slow.
 </ParamField>
 
+### Idle eviction for cached memory managers
+
+Long-running gateway daemons cache one `MemoryIndexManager` per workspace inside a process-wide `INDEX_CACHE`. Each cached manager owns a chokidar `FSWatcher` and (with `sync.watch=true`, the default) a read file descriptor per watched `memory/*.md` file. Without eviction these resources grow for the daemon's entire lifetime; a periodic sweep closes managers that have been idle for a while so the watchers and fds are released.
+
+Both knobs below are **gateway-wide** — they are read from `agents.defaults.memorySearch.sync.*`. The cache itself is process-wide, so there is no coherent per-agent answer when two agents share the same workspace and disagree on the threshold. Per-agent values under `agents.list[].memorySearch.sync.*` are currently accepted by the config schema (it is shared with `agents.defaults`) but are silently ignored by the sweep. Set the field on `agents.defaults` instead.
+
+<ParamField path="sync.idleEvictMs" type="number" default="900000">
+  Idle TTL in milliseconds. A cached `MemoryIndexManager` that has not served a request for this long is closed on the next sweep, releasing its chokidar `FSWatcher` and any read fds held by `awaitWriteFinish`.
+
+Default: `900000` (15 minutes). Set to `0` to disable eviction entirely (the cache then grows for the daemon lifetime, the pre-`#86293` behavior).
+</ParamField>
+
+<ParamField path="sync.idleEvictScanMs" type="number" default="300000">
+  How often the gateway runs the idle-eviction sweep, in milliseconds. Lower for tighter resource caps at the cost of more sweep work; raise to reduce sweep overhead at the cost of higher peak fd / RSS between sweeps.
+
+Default: `300000` (5 minutes). Set to `0` to disable the periodic sweep entirely (independent of `idleEvictMs`).
+</ParamField>
+
+An in-flight protection layer prevents the sweep from closing a manager that is currently running `sync()`, `search()`, or `ensureProviderInitialized()`; busy managers are deferred to the next sweep, so the only cost of an aggressive `idleEvictMs` is wall-clock latency on the next request that re-opens the manager.
+
 ---
 
 ## Hybrid search config

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -170,6 +170,17 @@ const memoryRuntime: MemoryPluginRuntime = {
     const { memoryRuntime: runtime } = await loadRuntimeProviderModule();
     await runtime.closeMemorySearchManager?.(params);
   },
+  async closeIdleMemorySearchManagers(opts) {
+    const { memoryRuntime: runtime } = await loadRuntimeProviderModule();
+    return (
+      (await runtime.closeIdleMemorySearchManagers?.(opts)) ?? {
+        evicted: 0,
+        skippedBusy: 0,
+        skippedRevalidated: 0,
+        remaining: 0,
+      }
+    );
+  },
 };
 export default definePluginEntry({
   id: "memory-core",

--- a/extensions/memory-core/manager-runtime.ts
+++ b/extensions/memory-core/manager-runtime.ts
@@ -1,5 +1,6 @@
 export {
   closeAllMemoryIndexManagers,
+  closeIdleMemoryIndexManagers,
   closeMemoryIndexManagersForAgent,
   MemoryIndexManager,
 } from "./src/memory/manager-runtime.js";

--- a/extensions/memory-core/src/memory/index.ts
+++ b/extensions/memory-core/src/memory/index.ts
@@ -6,6 +6,7 @@ export type {
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 export {
   closeAllMemorySearchManagers,
+  closeIdleMemorySearchManagers,
   closeMemorySearchManager,
   getMemorySearchManager,
   type MemorySearchManagerPurpose,

--- a/extensions/memory-core/src/memory/manager-cache.test.ts
+++ b/extensions/memory-core/src/memory/manager-cache.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  acquireManagedCacheKey,
+  closeIdleManagedCacheEntries,
   closeManagedCacheEntries,
   getOrCreateManagedCacheEntry,
+  isManagedCacheKeyBusy,
   resolveSingletonManagedCache,
   type ManagedCache,
 } from "./manager-cache.js";
@@ -132,6 +135,483 @@ describe("manager cache", () => {
     expect(resolvedFirst).toBe(first);
     expect(resolvedSecond).toBe(second);
     expect(resolvedSecond).not.toBe(resolvedFirst);
+  });
+
+  it("records lastAccessAt when forwarded to getOrCreateManagedCacheEntry", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const before = Date.now();
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "k",
+      create: async () => createEntry("e"),
+    });
+    const recorded = cache.lastAccessAt.get("k");
+    expect(recorded).toBeTypeOf("number");
+    expect(recorded!).toBeGreaterThanOrEqual(before);
+  });
+
+  it("refreshes lastAccessAt on cache hit", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "k",
+      create: async () => createEntry("e"),
+    });
+    const firstAccess = cache.lastAccessAt.get("k")!;
+    // Advance time deterministically so the second access has a later
+    // timestamp without depending on wall-clock granularity.
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(firstAccess + 5_000);
+    try {
+      await getOrCreateManagedCacheEntry({
+        cache: cache.cache,
+        pending: cache.pending,
+        lastAccessAt: cache.lastAccessAt,
+        key: "k",
+        create: async () => createEntry("never-called"),
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
+    expect(cache.lastAccessAt.get("k")).toBe(firstAccess + 5_000);
+  });
+
+  it("closeIdleManagedCacheEntries evicts entries past the idle threshold", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const entry = createEntry("idle");
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "k",
+      create: async () => entry,
+    });
+    // Make the entry look ancient.
+    cache.lastAccessAt.set("k", Date.now() - 10_000);
+    const evictedKeys: string[] = [];
+    const result = await closeIdleManagedCacheEntries({
+      cache,
+      idleMs: 5_000,
+      onEvictKey: (key) => evictedKeys.push(key),
+    });
+    expect(result.evicted).toBe(1);
+    expect(result.remaining).toBe(0);
+    expect(entry.close).toHaveBeenCalledTimes(1);
+    expect(cache.cache.has("k")).toBe(false);
+    expect(cache.lastAccessAt.has("k")).toBe(false);
+    expect(evictedKeys).toEqual(["k"]);
+  });
+
+  it("closeIdleManagedCacheEntries leaves recently accessed entries alone", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const fresh = createEntry("fresh");
+    const stale = createEntry("stale");
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "fresh",
+      create: async () => fresh,
+    });
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "stale",
+      create: async () => stale,
+    });
+    cache.lastAccessAt.set("stale", Date.now() - 10_000);
+    const result = await closeIdleManagedCacheEntries({ cache, idleMs: 5_000 });
+    expect(result.evicted).toBe(1);
+    expect(result.remaining).toBe(1);
+    expect(fresh.close).not.toHaveBeenCalled();
+    expect(stale.close).toHaveBeenCalledTimes(1);
+    expect(cache.cache.has("fresh")).toBe(true);
+    expect(cache.cache.has("stale")).toBe(false);
+  });
+
+  it("closeIdleManagedCacheEntries isolates close() errors and still evicts the rest", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const failing: TestEntry = {
+      id: "failing",
+      close: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    };
+    const ok = createEntry("ok");
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "failing",
+      create: async () => failing,
+    });
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "ok",
+      create: async () => ok,
+    });
+    cache.lastAccessAt.set("failing", Date.now() - 10_000);
+    cache.lastAccessAt.set("ok", Date.now() - 10_000);
+    const errors: unknown[] = [];
+    const result = await closeIdleManagedCacheEntries({
+      cache,
+      idleMs: 5_000,
+      onCloseError: (err) => errors.push(err),
+    });
+    expect(result.evicted).toBe(2);
+    expect(failing.close).toHaveBeenCalledTimes(1);
+    expect(ok.close).toHaveBeenCalledTimes(1);
+    expect(errors).toHaveLength(1);
+    expect(cache.cache.size).toBe(0);
+  });
+
+  it("acquireManagedCacheKey marks the key busy until release fires", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const entry = createEntry("busy");
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "k",
+      create: async () => entry,
+    });
+    expect(isManagedCacheKeyBusy(cache, "k")).toBe(false);
+    const release = acquireManagedCacheKey(cache, "k");
+    expect(isManagedCacheKeyBusy(cache, "k")).toBe(true);
+    release();
+    expect(isManagedCacheKeyBusy(cache, "k")).toBe(false);
+  });
+
+  it("acquireManagedCacheKey refcounts nested acquires", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const release1 = acquireManagedCacheKey(cache, "k");
+    const release2 = acquireManagedCacheKey(cache, "k");
+    expect(cache.inflightCount.get("k")).toBe(2);
+    release1();
+    expect(cache.inflightCount.get("k")).toBe(1);
+    expect(isManagedCacheKeyBusy(cache, "k")).toBe(true);
+    release2();
+    expect(cache.inflightCount.has("k")).toBe(false);
+    expect(isManagedCacheKeyBusy(cache, "k")).toBe(false);
+  });
+
+  it("release is idempotent and never produces negative counts", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const release = acquireManagedCacheKey(cache, "k");
+    release();
+    release();
+    release();
+    expect(cache.inflightCount.has("k")).toBe(false);
+  });
+
+  it("acquire and release both refresh lastAccessAt", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const t0 = 1_700_000_000_000;
+    const spy = vi.spyOn(Date, "now");
+    try {
+      spy.mockReturnValue(t0);
+      const release = acquireManagedCacheKey(cache, "k");
+      expect(cache.lastAccessAt.get("k")).toBe(t0);
+      spy.mockReturnValue(t0 + 7_000);
+      release();
+      expect(cache.lastAccessAt.get("k")).toBe(t0 + 7_000);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("closeIdleManagedCacheEntries defers busy entries past idleMs", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const entry = createEntry("busy-stale");
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "k",
+      create: async () => entry,
+    });
+    // Simulate a long-running operation acquiring the key while the cache
+    // entry ages past idleMs without further refresh.
+    const release = acquireManagedCacheKey(cache, "k");
+    cache.lastAccessAt.set("k", Date.now() - 30_000);
+    const skippedKeys: string[] = [];
+    const first = await closeIdleManagedCacheEntries({
+      cache,
+      idleMs: 5_000,
+      onSkipBusy: (key) => skippedKeys.push(key),
+    });
+    expect(first.evicted).toBe(0);
+    expect(first.skippedBusy).toBe(1);
+    expect(first.remaining).toBe(1);
+    expect(entry.close).not.toHaveBeenCalled();
+    expect(cache.cache.has("k")).toBe(true);
+    expect(skippedKeys).toEqual(["k"]);
+
+    // Release the in-flight operation. release() refreshes lastAccessAt, so
+    // the next sweep is a no-op; we must age the entry again before it can
+    // be evicted.
+    release();
+    expect(isManagedCacheKeyBusy(cache, "k")).toBe(false);
+    const second = await closeIdleManagedCacheEntries({ cache, idleMs: 5_000 });
+    expect(second.evicted).toBe(0);
+    expect(entry.close).not.toHaveBeenCalled();
+
+    cache.lastAccessAt.set("k", Date.now() - 30_000);
+    const third = await closeIdleManagedCacheEntries({ cache, idleMs: 5_000 });
+    expect(third.evicted).toBe(1);
+    expect(third.skippedBusy).toBe(0);
+    expect(entry.close).toHaveBeenCalledTimes(1);
+    expect(cache.cache.has("k")).toBe(false);
+  });
+
+  it("closeIdleManagedCacheEntries evicts non-busy stale entries alongside busy deferrals", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const idle = createEntry("idle");
+    const busy = createEntry("busy");
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "idle",
+      create: async () => idle,
+    });
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "busy",
+      create: async () => busy,
+    });
+    const release = acquireManagedCacheKey(cache, "busy");
+    cache.lastAccessAt.set("idle", Date.now() - 30_000);
+    cache.lastAccessAt.set("busy", Date.now() - 30_000);
+    const result = await closeIdleManagedCacheEntries({ cache, idleMs: 5_000 });
+    expect(result.evicted).toBe(1);
+    expect(result.skippedBusy).toBe(1);
+    expect(result.remaining).toBe(1);
+    expect(idle.close).toHaveBeenCalledTimes(1);
+    expect(busy.close).not.toHaveBeenCalled();
+    release();
+  });
+
+  it("closeIdleManagedCacheEntries clears inflightCount on eviction", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const entry = createEntry("e");
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "k",
+      create: async () => entry,
+    });
+    // No in-flight refs; eviction should clean up an empty count entry too.
+    cache.inflightCount.set("k", 0);
+    cache.lastAccessAt.set("k", Date.now() - 30_000);
+    await closeIdleManagedCacheEntries({ cache, idleMs: 5_000 });
+    expect(cache.cache.has("k")).toBe(false);
+    expect(cache.inflightCount.has("k")).toBe(false);
+  });
+
+  it("closeIdleManagedCacheEntries is idempotent when entry.close removes its own cache slot", async () => {
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const entry: TestEntry = {
+      id: "self-evict",
+      close: vi.fn(async () => {
+        // Simulate MemoryIndexManager.close() removing its own cache entry.
+        cache.cache.delete("k");
+        cache.lastAccessAt.delete("k");
+      }),
+    };
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "k",
+      create: async () => entry,
+    });
+    cache.lastAccessAt.set("k", Date.now() - 10_000);
+    const result = await closeIdleManagedCacheEntries({ cache, idleMs: 5_000 });
+    expect(result.evicted).toBe(1);
+    expect(entry.close).toHaveBeenCalledTimes(1);
+    expect(cache.cache.size).toBe(0);
+  });
+
+  it("closeIdleManagedCacheEntries revalidates lastAccessAt before closing (race: cache hit during scan-to-close gap)", async () => {
+    // Regression for PR #85972 ClawSweeper review:
+    //   t0: scan collects toEvict[] based on stale lastAccessAt
+    //   t1: a concurrent caller does INDEX_CACHE.get(K), refreshing
+    //       lastAccessAt without acquiring busy refcount
+    //   t2: close loop must NOT close K — the next .search() would hit a
+    //       closed manager.
+    // We use the deterministic testHookBeforeCloseLoop hook to model
+    // the gap between survey and close.
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const entry = createEntry("refreshed-during-gap");
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "k",
+      create: async () => entry,
+    });
+    const now = Date.now();
+    cache.lastAccessAt.set("k", now - 30_000); // stale by survey time
+    const skippedRevalidatedKeys: string[] = [];
+    const result = await closeIdleManagedCacheEntries({
+      cache,
+      idleMs: 5_000,
+      now: () => now,
+      onSkipRevalidated: (key) => skippedRevalidatedKeys.push(key),
+      testHookBeforeCloseLoop: () => {
+        // Simulate a cache hit during the scan-to-close gap. The hit
+        // path (getOrCreateManagedCacheEntry) bumps lastAccessAt to
+        // `Date.now()` which is necessarily > our captured `now - idleMs`.
+        cache.lastAccessAt.set("k", now);
+      },
+    });
+    expect(result.evicted).toBe(0);
+    expect(result.skippedRevalidated).toBe(1);
+    expect(result.skippedBusy).toBe(0);
+    expect(result.remaining).toBe(1);
+    expect(entry.close).not.toHaveBeenCalled();
+    expect(cache.cache.has("k")).toBe(true);
+    expect(cache.lastAccessAt.get("k")).toBe(now);
+    expect(skippedRevalidatedKeys).toEqual(["k"]);
+  });
+
+  it("closeIdleManagedCacheEntries respects busy state acquired during scan-to-close gap", async () => {
+    // Companion test: same race window, but the gap action is
+    // acquireManagedCacheKey() rather than a cache hit. Counts under
+    // skippedBusy (consistent with the survey-loop busy skip).
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const entry = createEntry("acquired-during-gap");
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "k",
+      create: async () => entry,
+    });
+    const now = Date.now();
+    cache.lastAccessAt.set("k", now - 30_000);
+    let release: (() => void) | undefined;
+    const skippedBusyKeys: string[] = [];
+    const result = await closeIdleManagedCacheEntries({
+      cache,
+      idleMs: 5_000,
+      now: () => now,
+      onSkipBusy: (key) => skippedBusyKeys.push(key),
+      testHookBeforeCloseLoop: () => {
+        // Acquire AFTER the survey loop already added the key to stale[].
+        // acquireManagedCacheKey also refreshes lastAccessAt, so we reset
+        // it to keep the busy branch (not the freshness branch) firing.
+        release = acquireManagedCacheKey(cache, "k");
+        cache.lastAccessAt.set("k", now - 30_000);
+      },
+    });
+    try {
+      expect(result.evicted).toBe(0);
+      expect(result.skippedBusy).toBe(1);
+      expect(result.skippedRevalidated).toBe(0);
+      expect(result.remaining).toBe(1);
+      expect(entry.close).not.toHaveBeenCalled();
+      expect(cache.cache.has("k")).toBe(true);
+      expect(skippedBusyKeys).toEqual(["k"]);
+    } finally {
+      release?.();
+    }
+  });
+
+  it("closeIdleManagedCacheEntries treats cache identity replacement as revalidation skip", async () => {
+    // If cache.set(key, newEntry) lands in the scan-to-close gap, the
+    // captured entry no longer matches the cache slot. We must NOT
+    // close either entry: the new one has its own fresh state and the
+    // old one was already replaced by the swap caller.
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const original = createEntry("original");
+    const replacement = createEntry("replacement");
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "k",
+      create: async () => original,
+    });
+    const now = Date.now();
+    cache.lastAccessAt.set("k", now - 30_000);
+    const result = await closeIdleManagedCacheEntries({
+      cache,
+      idleMs: 5_000,
+      now: () => now,
+      testHookBeforeCloseLoop: () => {
+        // Swap in a new instance and keep lastAccessAt stale so the
+        // revalidation branch we hit is specifically the identity
+        // mismatch one (not the freshness or busy ones).
+        cache.cache.set("k", replacement);
+      },
+    });
+    expect(result.evicted).toBe(0);
+    expect(result.skippedRevalidated).toBe(1);
+    expect(result.skippedBusy).toBe(0);
+    expect(original.close).not.toHaveBeenCalled();
+    expect(replacement.close).not.toHaveBeenCalled();
+    expect(cache.cache.get("k")).toBe(replacement);
+  });
+
+  it("closeIdleManagedCacheEntries handles disappearance of cache slot during gap", async () => {
+    // Another caller fully tore down the entry during the scan-to-close
+    // gap (e.g. a competing closeMemoryIndexManagersForAgent path). The
+    // sweep should treat that as a revalidation skip — not crash, not
+    // double-close.
+    const cache = createTestCache();
+    cachesForCleanup.push(cache);
+    const entry = createEntry("torn-down");
+    await getOrCreateManagedCacheEntry({
+      cache: cache.cache,
+      pending: cache.pending,
+      lastAccessAt: cache.lastAccessAt,
+      key: "k",
+      create: async () => entry,
+    });
+    const now = Date.now();
+    cache.lastAccessAt.set("k", now - 30_000);
+    const result = await closeIdleManagedCacheEntries({
+      cache,
+      idleMs: 5_000,
+      now: () => now,
+      testHookBeforeCloseLoop: () => {
+        cache.cache.delete("k");
+        // lastAccessAt intentionally not deleted yet — exercise the
+        // currentEntry === undefined branch which also cleans it up.
+      },
+    });
+    expect(result.evicted).toBe(0);
+    expect(result.skippedRevalidated).toBe(1);
+    expect(entry.close).not.toHaveBeenCalled();
+    expect(cache.cache.has("k")).toBe(false);
+    expect(cache.lastAccessAt.has("k")).toBe(false);
   });
 
   it("bypasses identity caching for status-only callers", async () => {

--- a/extensions/memory-core/src/memory/manager-cache.ts
+++ b/extensions/memory-core/src/memory/manager-cache.ts
@@ -7,27 +7,55 @@ type Closable = {
 export type ManagedCache<T> = {
   cache: Map<string, T>;
   pending: Map<string, Promise<T>>;
+  // Tracks last access time per cache key for idle-TTL eviction in
+  // long-running daemons. Refreshed on cache hit and on initial set.
+  lastAccessAt: Map<string, number>;
+  // Tracks the number of in-flight operations currently using each cache
+  // entry. Idle eviction must NOT close an entry whose count is > 0 even
+  // if its lastAccessAt has aged past the idle threshold (e.g. a long
+  // batch reindex that started before idleMs elapsed and is still
+  // running). See acquireManagedCacheKey / isManagedCacheKeyBusy.
+  inflightCount: Map<string, number>;
 };
+
+function isManagedCacheShape<T>(value: unknown): value is ManagedCache<T> {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const candidate = value as Partial<ManagedCache<T>>;
+  return (
+    candidate.cache instanceof Map &&
+    candidate.pending instanceof Map &&
+    candidate.lastAccessAt instanceof Map &&
+    candidate.inflightCount instanceof Map
+  );
+}
 
 export function resolveSingletonManagedCache<T>(cacheKey: symbol): ManagedCache<T> {
   const resolved = resolveGlobalSingleton<unknown>(cacheKey, () => ({
     cache: new Map<string, T>(),
     pending: new Map<string, Promise<T>>(),
+    lastAccessAt: new Map<string, number>(),
+    inflightCount: new Map<string, number>(),
   }));
-  if (
-    typeof resolved === "object" &&
-    resolved !== null &&
-    (resolved as Partial<ManagedCache<T>>).cache instanceof Map &&
-    (resolved as Partial<ManagedCache<T>>).pending instanceof Map
-  ) {
-    return resolved as ManagedCache<T>;
+  if (isManagedCacheShape<T>(resolved)) {
+    return resolved;
   }
+  // Older daemons may have placed an incompatible shape (e.g. missing
+  // lastAccessAt or inflightCount) at this key. Re-seed a fresh cache so
+  // callers get a consistent structure.
   const repaired: ManagedCache<T> = {
     cache: new Map<string, T>(),
     pending: new Map<string, Promise<T>>(),
+    lastAccessAt: new Map<string, number>(),
+    inflightCount: new Map<string, number>(),
   };
   (globalThis as Record<PropertyKey, unknown>)[cacheKey] = repaired;
   return repaired;
+}
+
+function recordLastAccess(lastAccessAt: Map<string, number> | undefined, key: string): void {
+  lastAccessAt?.set(key, Date.now());
 }
 
 export async function getOrCreateManagedCacheEntry<T>(params: {
@@ -36,12 +64,17 @@ export async function getOrCreateManagedCacheEntry<T>(params: {
   key: string;
   bypassCache?: boolean;
   create: () => Promise<T> | T;
+  // Optional last-access tracker. Callers that pass a ManagedCache should
+  // forward its lastAccessAt map so idle-TTL eviction sees a fresh
+  // timestamp on every cache hit.
+  lastAccessAt?: Map<string, number>;
 }): Promise<T> {
   if (params.bypassCache) {
     return await params.create();
   }
   const existing = params.cache.get(params.key);
   if (existing) {
+    recordLastAccess(params.lastAccessAt, params.key);
     return existing;
   }
   const pending = params.pending.get(params.key);
@@ -51,10 +84,12 @@ export async function getOrCreateManagedCacheEntry<T>(params: {
   const createPromise = (async () => {
     const refreshed = params.cache.get(params.key);
     if (refreshed) {
+      recordLastAccess(params.lastAccessAt, params.key);
       return refreshed;
     }
     const entry = await params.create();
     params.cache.set(params.key, entry);
+    recordLastAccess(params.lastAccessAt, params.key);
     return entry;
   })();
   params.pending.set(params.key, createPromise);
@@ -70,6 +105,8 @@ export async function getOrCreateManagedCacheEntry<T>(params: {
 export async function closeManagedCacheEntries<T extends Closable>(params: {
   cache: Map<string, T>;
   pending: Map<string, Promise<T>>;
+  lastAccessAt?: Map<string, number>;
+  inflightCount?: Map<string, number>;
   onCloseError?: (err: unknown) => void;
 }): Promise<void> {
   const pending = Array.from(params.pending.values());
@@ -78,6 +115,12 @@ export async function closeManagedCacheEntries<T extends Closable>(params: {
   }
   const entries = Array.from(params.cache.values());
   params.cache.clear();
+  params.lastAccessAt?.clear();
+  // Full teardown is unconditional: by the time callers reach
+  // closeManagedCacheEntries (process shutdown / agent close), they have
+  // already decided to terminate work and any lingering refcounts are
+  // stale. Drop them so subsequent test runs start clean.
+  params.inflightCount?.clear();
   for (const entry of entries) {
     if (typeof entry.close !== "function") {
       continue;
@@ -88,4 +131,185 @@ export async function closeManagedCacheEntries<T extends Closable>(params: {
       params.onCloseError?.(err);
     }
   }
+}
+
+// Mark a cache key as in-flight. Returns a release function the caller
+// must invoke (typically in a try/finally) when the operation completes.
+// While inflightCount[key] > 0, closeIdleManagedCacheEntries will skip
+// the entry even if its lastAccessAt has aged past the idle threshold.
+//
+// The release function is idempotent. Both acquire() and release() also
+// touch lastAccessAt so that a manager which was busy for the whole idle
+// window gets a fresh idle countdown once it goes idle (avoiding an
+// immediate eviction on the very next scan).
+export function acquireManagedCacheKey<T>(cache: ManagedCache<T>, key: string): () => void {
+  const current = cache.inflightCount.get(key) ?? 0;
+  cache.inflightCount.set(key, current + 1);
+  cache.lastAccessAt.set(key, Date.now());
+  let released = false;
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    const c = cache.inflightCount.get(key) ?? 0;
+    if (c <= 1) {
+      cache.inflightCount.delete(key);
+    } else {
+      cache.inflightCount.set(key, c - 1);
+    }
+    cache.lastAccessAt.set(key, Date.now());
+  };
+}
+
+export function isManagedCacheKeyBusy<T>(cache: ManagedCache<T>, key: string): boolean {
+  return (cache.inflightCount.get(key) ?? 0) > 0;
+}
+
+// Idle-TTL eviction for long-running daemons. Walks the lastAccessAt map and
+// closes any entry whose last access happened more than `idleMs` ago. Each
+// entry's close() is awaited sequentially so errors are isolated; a thrown
+// error from one entry does not prevent later entries from being evicted.
+//
+// Active-use protection: entries with inflightCount[key] > 0 are skipped
+// regardless of how stale lastAccessAt looks. This is the safety net for
+// long-running operations (batch reindex, async search-time sync, ...)
+// whose runtime can exceed idleMs while only refreshing lastAccessAt at
+// the start and end. They are surfaced through the optional onSkipBusy
+// callback for observability, and reported back to callers via the
+// `skippedBusy` count so periodic sidecars can log them.
+//
+// Scan-to-close race protection: between the survey loop and the close
+// loop, a concurrent caller can refresh lastAccessAt (cache hit) or
+// acquire the busy refcount on a key we already added to the eviction
+// list. Before closing each entry we re-validate `lastAccessAt`
+// freshness against the same cutoff, `isBusy`, and cache identity. An
+// entry that no longer satisfies the original idle predicate is
+// reported back via the new `skippedRevalidated` counter and left in
+// the cache for the next scan to reconsider.
+//
+// Entries can themselves remove their own cacheKey from cache.delete() during
+// close() (e.g. MemoryIndexManager does this); this is intentional and
+// idempotent because we capture the eviction list up-front and re-check the
+// cache before deleting.
+export async function closeIdleManagedCacheEntries<T extends Closable>(params: {
+  cache: ManagedCache<T>;
+  idleMs: number;
+  now?: () => number;
+  onCloseError?: (err: unknown) => void;
+  onEvictKey?: (key: string) => void;
+  onSkipBusy?: (key: string) => void;
+  onSkipRevalidated?: (key: string) => void;
+  // Test hook: invoked after the survey loop but before the close loop.
+  // Allows regression tests to deterministically inject a cache hit or
+  // busy acquire into the scan-to-close gap.
+  testHookBeforeCloseLoop?: () => Promise<void> | void;
+}): Promise<{
+  evicted: number;
+  skippedBusy: number;
+  skippedRevalidated: number;
+  remaining: number;
+}> {
+  const now = (params.now ?? Date.now)();
+  const cutoff = now - params.idleMs;
+  const stale: Array<{ key: string; entry: T }> = [];
+  let skippedBusy = 0;
+  let skippedRevalidated = 0;
+  for (const [key, lastAccess] of params.cache.lastAccessAt) {
+    if (lastAccess > cutoff) {
+      continue;
+    }
+    const entry = params.cache.cache.get(key);
+    if (!entry) {
+      // lastAccessAt drifted out of sync with cache; clean it up.
+      params.cache.lastAccessAt.delete(key);
+      continue;
+    }
+    if (isManagedCacheKeyBusy(params.cache, key)) {
+      // Active-use protection: a long-running operation currently holds
+      // a reference to this entry. Defer eviction until the next scan
+      // after release() fires (which will also refresh lastAccessAt).
+      skippedBusy += 1;
+      params.onSkipBusy?.(key);
+      continue;
+    }
+    stale.push({ key, entry });
+  }
+  // Test hook: lets regression tests simulate the scan-to-close gap by
+  // injecting a cache hit or busy acquire between survey and close.
+  if (params.testHookBeforeCloseLoop) {
+    await params.testHookBeforeCloseLoop();
+  }
+  let evicted = 0;
+  for (const { key, entry } of stale) {
+    // Re-validate state immediately before close to close the race
+    // identified in PR #85972 review: between the survey loop and this
+    // point a concurrent caller may have either refreshed lastAccessAt
+    // (cache hit), acquired the busy refcount, or replaced the cache
+    // entry with a new instance. Closing in any of those cases would
+    // hand out a stale closed reference.
+    const currentTs = params.cache.lastAccessAt.get(key);
+    if (currentTs === undefined) {
+      // Another path already evicted this key (e.g. close() racing with
+      // a competing teardown). Nothing to do.
+      skippedRevalidated += 1;
+      params.onSkipRevalidated?.(key);
+      continue;
+    }
+    if (currentTs > cutoff) {
+      // Refreshed during the scan-to-close gap. Leave the entry in the
+      // cache and let the next scan reconsider it against a fresher
+      // cutoff. This is the merge-blocker case from the review.
+      skippedRevalidated += 1;
+      params.onSkipRevalidated?.(key);
+      continue;
+    }
+    if (isManagedCacheKeyBusy(params.cache, key)) {
+      // Busy was acquired during the gap; treat the same as the survey
+      // loop skip so sidecar metrics stay consistent.
+      skippedBusy += 1;
+      params.onSkipBusy?.(key);
+      continue;
+    }
+    const currentEntry = params.cache.cache.get(key);
+    if (!currentEntry) {
+      // Cache slot disappeared during the gap. Cleanup any orphan
+      // lastAccessAt entry and move on.
+      params.cache.lastAccessAt.delete(key);
+      skippedRevalidated += 1;
+      params.onSkipRevalidated?.(key);
+      continue;
+    }
+    if (currentEntry !== entry) {
+      // Cache identity changed (cache.set(key, newEntry) happened in the
+      // gap). The new entry has its own fresh lastAccessAt and may be
+      // in-flight; leave it for the next scan instead of closing it.
+      skippedRevalidated += 1;
+      params.onSkipRevalidated?.(key);
+      continue;
+    }
+    // Drop the cache slot first so concurrent readers do not pick up a
+    // closing entry. close() may itself attempt the same delete; that is
+    // safe because Map.delete on a missing key is a no-op.
+    if (params.cache.cache.get(key) === entry) {
+      params.cache.cache.delete(key);
+    }
+    params.cache.lastAccessAt.delete(key);
+    params.cache.inflightCount.delete(key);
+    params.onEvictKey?.(key);
+    if (typeof entry.close === "function") {
+      try {
+        await entry.close();
+      } catch (err) {
+        params.onCloseError?.(err);
+      }
+    }
+    evicted += 1;
+  }
+  return {
+    evicted,
+    skippedBusy,
+    skippedRevalidated,
+    remaining: params.cache.cache.size,
+  };
 }

--- a/extensions/memory-core/src/memory/manager-runtime.ts
+++ b/extensions/memory-core/src/memory/manager-runtime.ts
@@ -1,5 +1,6 @@
 export {
   closeAllMemoryIndexManagers,
+  closeIdleMemoryIndexManagers,
   closeMemoryIndexManagersForAgent,
   MemoryIndexManager,
 } from "./manager.js";

--- a/extensions/memory-core/src/memory/manager.idle-gc.test.ts
+++ b/extensions/memory-core/src/memory/manager.idle-gc.test.ts
@@ -1,0 +1,390 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  acquireManagedCacheKey,
+  isManagedCacheKeyBusy,
+  type ManagedCache,
+} from "./manager-cache.js";
+import { closeIdleMemoryIndexManagers, EMBEDDING_PROBE_CACHE_TTL_MS } from "./manager.js";
+
+const MEMORY_INDEX_MANAGER_CACHE_KEY = Symbol.for("openclaw.memoryIndexManagerCache");
+
+type FakeManager = {
+  cacheKey: string;
+  close: () => Promise<void>;
+};
+
+function resolveLiveCache(): ManagedCache<FakeManager> {
+  const cache = (globalThis as Record<PropertyKey, unknown>)[MEMORY_INDEX_MANAGER_CACHE_KEY];
+  if (
+    !cache ||
+    typeof cache !== "object" ||
+    !(cache as ManagedCache<FakeManager>).cache ||
+    !(cache as ManagedCache<FakeManager>).lastAccessAt
+  ) {
+    throw new Error("MemoryIndexManager singleton cache not initialized");
+  }
+  return cache as ManagedCache<FakeManager>;
+}
+
+function makeFakeManager(cacheKey: string): FakeManager {
+  return {
+    cacheKey,
+    close: vi.fn(async () => {}),
+  };
+}
+
+describe("closeIdleMemoryIndexManagers", () => {
+  let cache: ManagedCache<FakeManager>;
+  const seededKeys: string[] = [];
+
+  beforeEach(() => {
+    cache = resolveLiveCache();
+  });
+
+  afterEach(() => {
+    for (const key of seededKeys.splice(0)) {
+      cache.cache.delete(key);
+      cache.lastAccessAt.delete(key);
+    }
+  });
+
+  function seed(key: string, lastAccessAt: number): FakeManager {
+    const manager = makeFakeManager(key);
+    cache.cache.set(key, manager);
+    cache.lastAccessAt.set(key, lastAccessAt);
+    seededKeys.push(key);
+    return manager;
+  }
+
+  it("evicts cached managers idle past the threshold and calls close()", async () => {
+    const stale = seed("idle:stale", Date.now() - 10_000);
+    const fresh = seed("idle:fresh", Date.now());
+
+    const result = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+
+    expect(result.evicted).toBe(1);
+    expect(stale.close).toHaveBeenCalledTimes(1);
+    expect(fresh.close).not.toHaveBeenCalled();
+    expect(cache.cache.has("idle:stale")).toBe(false);
+    expect(cache.cache.has("idle:fresh")).toBe(true);
+    expect(cache.lastAccessAt.has("idle:stale")).toBe(false);
+  });
+
+  it("idleMs=0 evicts every cached manager (used in tests/teardown)", async () => {
+    const a = seed("idle:a", Date.now());
+    const b = seed("idle:b", Date.now());
+
+    const result = await closeIdleMemoryIndexManagers({ idleMs: 0 });
+
+    expect(result.evicted).toBeGreaterThanOrEqual(2);
+    expect(a.close).toHaveBeenCalledTimes(1);
+    expect(b.close).toHaveBeenCalledTimes(1);
+    expect(cache.cache.has("idle:a")).toBe(false);
+    expect(cache.cache.has("idle:b")).toBe(false);
+  });
+
+  it("clears the embedding probe cache entry alongside the evicted manager", async () => {
+    // Pull in the embedding probe cache by importing the manager module
+    // surface. We populate the probe cache indirectly by seeding the
+    // private map through the same module load: simulate by going through
+    // a helper that the production code uses.
+    const stale = seed("idle:probe", Date.now() - 10_000);
+
+    // Round-trip probe TTL constant to ensure the module is wired.
+    expect(EMBEDDING_PROBE_CACHE_TTL_MS).toBeGreaterThan(0);
+
+    const result = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+
+    expect(result.evicted).toBe(1);
+    expect(stale.close).toHaveBeenCalledTimes(1);
+    // After eviction the cache entry is gone; the probe cache deletion
+    // path is exercised through the onEvictKey hook in the production
+    // implementation (the symbol-keyed cache is internal so we cannot
+    // peek at it directly here, but exercising the path proves the hook
+    // fired without throwing).
+    expect(cache.cache.has("idle:probe")).toBe(false);
+  });
+
+  it("isolates close() errors from one manager so others still get evicted", async () => {
+    const failing: FakeManager = {
+      cacheKey: "idle:bad",
+      close: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    };
+    cache.cache.set("idle:bad", failing);
+    cache.lastAccessAt.set("idle:bad", Date.now() - 10_000);
+    seededKeys.push("idle:bad");
+
+    const ok = seed("idle:ok", Date.now() - 10_000);
+
+    const result = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+
+    expect(result.evicted).toBe(2);
+    expect(failing.close).toHaveBeenCalledTimes(1);
+    expect(ok.close).toHaveBeenCalledTimes(1);
+    expect(cache.cache.has("idle:bad")).toBe(false);
+    expect(cache.cache.has("idle:ok")).toBe(false);
+  });
+
+  it("returns zero when there is nothing to evict", async () => {
+    const result = await closeIdleMemoryIndexManagers({ idleMs: 60_000 });
+    expect(result.evicted).toBe(0);
+    expect(result.skippedBusy).toBe(0);
+  });
+
+  it("defers a manager held in-flight via acquireManagedCacheKey", async () => {
+    const stale = seed("idle:in-flight", Date.now() - 30_000);
+    // Simulate a long-running batch reindex that started before the idle
+    // window opened and is still executing.
+    const release = acquireManagedCacheKey(cache, "idle:in-flight");
+    // Override the lastAccessAt that acquire just refreshed so the scan
+    // sees a stale timestamp; the busy guard is what must keep us alive.
+    cache.lastAccessAt.set("idle:in-flight", Date.now() - 30_000);
+
+    const first = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+    expect(first.evicted).toBe(0);
+    expect(first.skippedBusy).toBe(1);
+    expect(stale.close).not.toHaveBeenCalled();
+    expect(cache.cache.has("idle:in-flight")).toBe(true);
+
+    // Once the in-flight operation completes, release() refreshes
+    // lastAccessAt; we age the entry again before the next scan to confirm
+    // it then evicts cleanly.
+    release();
+    cache.lastAccessAt.set("idle:in-flight", Date.now() - 30_000);
+    const second = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+    expect(second.evicted).toBe(1);
+    expect(second.skippedBusy).toBe(0);
+    expect(stale.close).toHaveBeenCalledTimes(1);
+    expect(cache.cache.has("idle:in-flight")).toBe(false);
+  });
+
+  it("protects manager whose sync is waiting on provider initialization", async () => {
+    // Regression for the provider-init race identified in PR #85972 review:
+    // before the fix, MemoryIndexManager.sync() awaited
+    // ensureProviderInitialized() outside the withBusy() scope, so the idle
+    // sweeper could observe busy=0 while a caller was blocked on a slow
+    // provider boot (seconds to minutes for some embedding APIs) and evict
+    // the manager before its work even started.
+    //
+    // This test simulates production's `withBusy(async () => { await
+    // ensureProviderInitialized(); ... })` ordering and verifies that the
+    // busy refcount is already held during the provider-init wait, so the
+    // sweeper reports skippedBusy === 1 and evicted === 0.
+    const stale = seed("idle:provider-init-sync", Date.now() - 30_000);
+
+    let resolveProviderInit!: () => void;
+    const providerInitPromise = new Promise<void>((resolve) => {
+      resolveProviderInit = resolve;
+    });
+
+    // Production sync(): withBusy wraps the entire body including the
+    // ensureProviderInitialized() await. Reproduce that ordering exactly.
+    const syncRun = (async () => {
+      const release = acquireManagedCacheKey(cache, stale.cacheKey);
+      try {
+        // Step out of the way of the scan below by aging lastAccessAt
+        // (acquire just refreshed it). The busy ref must be the thing
+        // keeping us alive.
+        cache.lastAccessAt.set(stale.cacheKey, Date.now() - 30_000);
+        await providerInitPromise;
+        // Provider init complete; in production this is where embedding /
+        // vector / FTS work would actually run. For the test, completing
+        // the await is enough to prove the busy ref covered the wait.
+      } finally {
+        release();
+      }
+    })();
+
+    // Let acquireManagedCacheKey fire before we run the scan.
+    await Promise.resolve();
+
+    const firstScan = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+    expect(firstScan.skippedBusy).toBe(1);
+    expect(firstScan.evicted).toBe(0);
+    expect(stale.close).not.toHaveBeenCalled();
+    expect(cache.cache.has(stale.cacheKey)).toBe(true);
+
+    // Unblock provider init and let the simulated sync drain.
+    resolveProviderInit();
+    await syncRun;
+
+    // After release the manager is evict-eligible again. Re-age lastAccessAt
+    // because release() refreshed it.
+    cache.lastAccessAt.set(stale.cacheKey, Date.now() - 30_000);
+    const secondScan = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+    expect(secondScan.skippedBusy).toBe(0);
+    expect(secondScan.evicted).toBe(1);
+    expect(stale.close).toHaveBeenCalledTimes(1);
+    expect(cache.cache.has(stale.cacheKey)).toBe(false);
+  });
+
+  it("protects manager whose search is waiting on provider initialization", async () => {
+    // Same race surface as sync(), but exercised via the search() entry
+    // point. Production search() wraps the entire searchInternal flow in
+    // withBusy, so a provider-init await deep inside searchInternal is
+    // still protected.
+    const stale = seed("idle:provider-init-search", Date.now() - 30_000);
+
+    let resolveProviderInit!: () => void;
+    const providerInitPromise = new Promise<void>((resolve) => {
+      resolveProviderInit = resolve;
+    });
+
+    const searchRun = (async () => {
+      const release = acquireManagedCacheKey(cache, stale.cacheKey);
+      try {
+        cache.lastAccessAt.set(stale.cacheKey, Date.now() - 30_000);
+        // In production this happens inside searchInternal, after the
+        // outer search() has already entered withBusy.
+        await providerInitPromise;
+      } finally {
+        release();
+      }
+    })();
+
+    await Promise.resolve();
+
+    const firstScan = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+    expect(firstScan.skippedBusy).toBe(1);
+    expect(firstScan.evicted).toBe(0);
+    expect(stale.close).not.toHaveBeenCalled();
+
+    resolveProviderInit();
+    await searchRun;
+
+    cache.lastAccessAt.set(stale.cacheKey, Date.now() - 30_000);
+    const secondScan = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+    expect(secondScan.evicted).toBe(1);
+    expect(stale.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the busy ref when provider initialization throws", async () => {
+    // If ensureProviderInitialized() rejects, the withBusy() finally block
+    // must still release the busy ref so the entry becomes evict-eligible
+    // rather than leaking inflightCount > 0 forever.
+    const stale = seed("idle:provider-init-throws", Date.now() - 30_000);
+
+    let rejectProviderInit!: (err: unknown) => void;
+    const providerInitPromise = new Promise<void>((_resolve, reject) => {
+      rejectProviderInit = reject;
+    });
+
+    const syncRun = (async () => {
+      const release = acquireManagedCacheKey(cache, stale.cacheKey);
+      try {
+        cache.lastAccessAt.set(stale.cacheKey, Date.now() - 30_000);
+        await providerInitPromise;
+      } finally {
+        release();
+      }
+    })();
+
+    await Promise.resolve();
+
+    const duringScan = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+    expect(duringScan.skippedBusy).toBe(1);
+    expect(duringScan.evicted).toBe(0);
+
+    rejectProviderInit(new Error("provider boot failed"));
+    await expect(syncRun).rejects.toThrow(/provider boot failed/);
+
+    cache.lastAccessAt.set(stale.cacheKey, Date.now() - 30_000);
+    const afterScan = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+    expect(afterScan.evicted).toBe(1);
+    expect(stale.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("defers multiple busy entries together in a single scan", async () => {
+    const a = seed("idle:busy-a", Date.now() - 30_000);
+    const b = seed("idle:busy-b", Date.now() - 30_000);
+    const c = seed("idle:fresh", Date.now() - 30_000);
+    const releaseA = acquireManagedCacheKey(cache, "idle:busy-a");
+    const releaseB = acquireManagedCacheKey(cache, "idle:busy-b");
+    cache.lastAccessAt.set("idle:busy-a", Date.now() - 30_000);
+    cache.lastAccessAt.set("idle:busy-b", Date.now() - 30_000);
+
+    const result = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+    expect(result.evicted).toBe(1);
+    expect(result.skippedBusy).toBe(2);
+    expect(a.close).not.toHaveBeenCalled();
+    expect(b.close).not.toHaveBeenCalled();
+    expect(c.close).toHaveBeenCalledTimes(1);
+    expect(cache.cache.has("idle:fresh")).toBe(false);
+
+    releaseA();
+    releaseB();
+  });
+
+  // These tests exercise the identity-guarded teardown contract enforced
+  // by MemoryIndexManager.close()'s finally block (and the matching
+  // guard in closeMemoryIndexManagersForAgent). The race they cover:
+  //
+  //   T0  sweep / closeMemoryIndexManagersForAgent picks M_old for close
+  //   T1  M_old.close() starts; awaits provider/db teardown
+  //   T2  another caller getOrCreate(key) sees closed=true, installs M_new
+  //   T3  M_old.close() finally block runs
+  //
+  // Without an identity guard, T3 would delete cache[key] = M_new,
+  // lastAccessAt[key] (recorded by T2), and inflightCount[key] (used by
+  // T2's caller), making M_new invisible to every future idle sweep.
+  //
+  // The unit tests below model that finally block directly against the
+  // shared ManagedCache instance so they catch any regression where the
+  // identity guard is dropped or applied to only some of the three maps.
+  function runIdentityGuardedFinally(closingManager: FakeManager) {
+    // Equivalent of the post-fix MemoryIndexManager.close() finally:
+    if (cache.cache.get(closingManager.cacheKey) === closingManager) {
+      cache.cache.delete(closingManager.cacheKey);
+      cache.lastAccessAt.delete(closingManager.cacheKey);
+      cache.inflightCount.delete(closingManager.cacheKey);
+    }
+  }
+
+  it("identity guard: keeps replacement manager metadata when M_old.close() finally races getOrCreate(M_new)", async () => {
+    // Seed M_old into the cache the way getOrCreate would have left it.
+    const mOld = seed("race:key", Date.now() - 30_000);
+    // T2 happens: a caller replaces M_old with M_new in the same slot,
+    // records a fresh lastAccessAt, and acquires the busy refcount via
+    // its first sync()/search() call.
+    const mNew = makeFakeManager("race:key");
+    cache.cache.set("race:key", mNew);
+    seededKeys.push("race:key"); // already pushed by seed(), idempotent in afterEach
+    cache.lastAccessAt.set("race:key", Date.now());
+    const releaseNew = acquireManagedCacheKey(cache, "race:key");
+
+    // T3 happens: M_old.close()'s finally block fires. With the identity
+    // guard it must observe that the cache slot is no longer M_old and
+    // leave M_new's metadata alone.
+    runIdentityGuardedFinally(mOld);
+
+    expect(cache.cache.get("race:key")).toBe(mNew);
+    // The critical post-fix invariants — without these the next idle
+    // sweep would not be able to find or guard M_new.
+    expect(cache.lastAccessAt.has("race:key")).toBe(true);
+    expect(isManagedCacheKeyBusy(cache, "race:key")).toBe(true);
+
+    // M_new should still participate in the next idle sweep once it
+    // becomes idle: drop its busy refcount, age its lastAccessAt past
+    // the threshold, and verify the sweep picks it up.
+    releaseNew();
+    cache.lastAccessAt.set("race:key", Date.now() - 30_000);
+    const result = await closeIdleMemoryIndexManagers({ idleMs: 5_000 });
+    expect(result.evicted).toBe(1);
+    expect(mNew.close).toHaveBeenCalledTimes(1);
+    expect(cache.cache.has("race:key")).toBe(false);
+  });
+
+  it("identity guard: clears metadata when M_old is still the cache occupant (no race occurred)", async () => {
+    // No racing replacement. Sanity check that the identity guard does
+    // not regress the normal teardown path.
+    const mOld = seed("noop:key", Date.now() - 30_000);
+
+    runIdentityGuardedFinally(mOld);
+
+    expect(cache.cache.has("noop:key")).toBe(false);
+    expect(cache.lastAccessAt.has("noop:key")).toBe(false);
+    expect(isManagedCacheKeyBusy(cache, "noop:key")).toBe(false);
+  });
+});

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -33,6 +33,8 @@ import { bm25RankToScore, buildFtsQuery, mergeHybridResults } from "./hybrid.js"
 import { awaitPendingManagerWork, startAsyncSearchSync } from "./manager-async-state.js";
 import { MEMORY_BATCH_FAILURE_LIMIT } from "./manager-batch-state.js";
 import {
+  acquireManagedCacheKey,
+  closeIdleManagedCacheEntries,
   closeManagedCacheEntries,
   getOrCreateManagedCacheEntry,
   resolveSingletonManagedCache,
@@ -69,8 +71,11 @@ export const EMBEDDING_PROBE_CACHE_TTL_MS = 30_000;
 const log = createSubsystemLogger("memory");
 type MemoryIndexManagerPurpose = "default" | "status" | "cli";
 
-const { cache: INDEX_CACHE, pending: INDEX_CACHE_PENDING } =
-  resolveSingletonManagedCache<MemoryIndexManager>(MEMORY_INDEX_MANAGER_CACHE_KEY);
+const INDEX_MANAGER_CACHE = resolveSingletonManagedCache<MemoryIndexManager>(
+  MEMORY_INDEX_MANAGER_CACHE_KEY,
+);
+const INDEX_CACHE = INDEX_MANAGER_CACHE.cache;
+const INDEX_CACHE_PENDING = INDEX_MANAGER_CACHE.pending;
 
 type EmbeddingProbeCacheEntry = {
   result: MemoryEmbeddingProbeResult;
@@ -85,8 +90,46 @@ export async function closeAllMemoryIndexManagers(): Promise<void> {
   await closeManagedCacheEntries({
     cache: INDEX_CACHE,
     pending: INDEX_CACHE_PENDING,
+    lastAccessAt: INDEX_MANAGER_CACHE.lastAccessAt,
+    inflightCount: INDEX_MANAGER_CACHE.inflightCount,
     onCloseError: (err) => {
       log.warn(`failed to close memory index manager: ${String(err)}`);
+    },
+  });
+}
+
+// Idle-TTL eviction for cached MemoryIndexManager instances in long-running
+// gateway daemons. Each manager owns a chokidar FSWatcher that accumulates
+// native handles and file descriptors over time; CLI-exit-only cleanup
+// (see closeAllMemoryIndexManagers) is not enough for daemon processes.
+//
+// This is intended to run on a slow periodic tick (every few minutes). The
+// idle threshold should be larger than the typical gap between memory
+// searches to avoid churning the cache.
+//
+// Managers currently running a long-lived operation (full reindex, batch
+// reindex, async sync-on-search) wrap themselves in MemoryIndexManager.
+// withBusy(), which bumps an inflightCount refcount on the singleton
+// cache. closeIdleManagedCacheEntries honors that refcount and skips
+// busy entries; busyDeferred is the count of such skipped keys for this
+// scan and is logged when non-zero.
+export async function closeIdleMemoryIndexManagers(opts: { idleMs: number }): Promise<{
+  evicted: number;
+  skippedBusy: number;
+  skippedRevalidated: number;
+  remaining: number;
+}> {
+  return await closeIdleManagedCacheEntries({
+    cache: INDEX_MANAGER_CACHE,
+    idleMs: opts.idleMs,
+    onCloseError: (err) => {
+      log.warn(`failed to close idle memory index manager: ${String(err)}`);
+    },
+    onEvictKey: (key) => {
+      // Drop the embedding probe entry so the next request re-probes the
+      // provider rather than serving a stale TTL result tied to the evicted
+      // manager instance.
+      EMBEDDING_PROBE_CACHE.delete(key);
     },
   });
 }
@@ -109,7 +152,17 @@ export async function closeMemoryIndexManagersForAgent(params: {
   if (!manager) {
     return;
   }
-  INDEX_CACHE.delete(key);
+  // Identity-guarded teardown: only clear metadata if we are still the
+  // current cache occupant for this key. A racing getOrCreate(key) that
+  // observes manager.closed === true may install a replacement here
+  // between our snapshot above and these deletes; in that case we must
+  // leave the replacement's metadata alone. See the matching identity
+  // guard in MemoryIndexManager.close() for the full rationale.
+  if (INDEX_CACHE.get(key) === manager) {
+    INDEX_CACHE.delete(key);
+    INDEX_MANAGER_CACHE.lastAccessAt.delete(key);
+    INDEX_MANAGER_CACHE.inflightCount.delete(key);
+  }
   try {
     await manager.close();
   } catch (err) {
@@ -214,6 +267,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     return await getOrCreateManagedCacheEntry({
       cache: INDEX_CACHE,
       pending: INDEX_CACHE_PENDING,
+      lastAccessAt: INDEX_MANAGER_CACHE.lastAccessAt,
       key,
       bypassCache: transient,
       create: async () =>
@@ -386,6 +440,25 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       qmdSearchModeOverride?: "query" | "search" | "vsearch";
       onDebug?: (debug: MemorySearchRuntimeDebug) => void;
       /** When set, only these chunk sources are considered (must be enabled for this manager). */
+      sources?: MemorySource[];
+    },
+  ): Promise<MemorySearchResult[]> {
+    // Mark this manager as in-flight for the full search lifetime so the
+    // idle sweeper cannot close us while embedding/vector/FTS work is in
+    // progress. The inner sync() call below will acquire its own ref
+    // (refcounting is additive), and the search() refcount drops in the
+    // finally below.
+    return await this.withBusy(async () => this.searchInternal(query, opts));
+  }
+
+  private async searchInternal(
+    query: string,
+    opts?: {
+      maxResults?: number;
+      minScore?: number;
+      sessionKey?: string;
+      qmdSearchModeOverride?: "query" | "search" | "vsearch";
+      onDebug?: (debug: MemorySearchRuntimeDebug) => void;
       sources?: MemorySource[];
     },
   ): Promise<MemorySearchResult[]> {
@@ -729,6 +802,23 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }).then((entries) => entries.map((entry) => entry as MemorySearchResult));
   }
 
+  // Runs `fn` with this manager's cache key marked as in-flight so the
+  // idle-eviction sweeper (closeIdleMemoryIndexManagers) will not close
+  // us mid-operation. Safe to nest: each call acquires its own ref.
+  //
+  // Use this on long-running operations whose runtime can exceed the
+  // configured idle threshold (full reindex, batch reindex, search-time
+  // async sync, etc.). Short-lived synchronous reads against the cached
+  // manager do not need wrapping; they refresh lastAccessAt on cache hit.
+  protected async withBusy<T>(fn: () => Promise<T>): Promise<T> {
+    const release = acquireManagedCacheKey(INDEX_MANAGER_CACHE, this.cacheKey);
+    try {
+      return await fn();
+    } finally {
+      release();
+    }
+  }
+
   async sync(params?: {
     reason?: string;
     force?: boolean;
@@ -738,19 +828,31 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     if (this.closed) {
       return;
     }
-    if (this.syncing) {
-      if (params?.sessionFiles?.some((sessionFile) => sessionFile.trim().length > 0)) {
-        return this.enqueueTargetedSessionSync(params.sessionFiles);
-      }
-      return this.syncing;
-    }
-    this.syncing = (async () => {
+    // Hold the busy ref across the entire sync lifetime, including the
+    // provider initialization step below. Without this outer wrapper, the
+    // idle sweeper could observe a stale lastAccessAt and busy=0 while we
+    // are blocked inside ensureProviderInitialized() and evict the manager
+    // before the inner reindex even starts.
+    return await this.withBusy(async () => {
       await this.ensureProviderInitialized();
-      await this.runSyncWithReadonlyRecovery(params);
-    })().finally(() => {
-      this.syncing = null;
+      if (this.syncing) {
+        if (params?.sessionFiles?.some((sessionFile) => sessionFile.trim().length > 0)) {
+          return this.enqueueTargetedSessionSync(params.sessionFiles);
+        }
+        return this.syncing;
+      }
+      // Wrap the underlying recovery loop in a nested busy ref so the
+      // idle sweeper still skips us after the outer withBusy() unwinds
+      // (e.g. when a search() caller awaits us but a longer reindex keeps
+      // running). Nested refcounts are additive; both releases must fire
+      // for the entry to become evict-eligible.
+      const release = acquireManagedCacheKey(INDEX_MANAGER_CACHE, this.cacheKey);
+      this.syncing = this.runSyncWithReadonlyRecovery(params).finally(() => {
+        this.syncing = null;
+        release();
+      });
+      await (this.syncing ?? Promise.resolve());
     });
-    return this.syncing ?? Promise.resolve();
   }
 
   private enqueueTargetedSessionSync(sessionFiles?: string[]): Promise<void> {
@@ -952,15 +1054,19 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       this.vector.semanticAvailable = false;
       return false;
     }
-    await this.ensureProviderInitialized();
-    // FTS-only mode: vector search not available
-    if (!this.provider) {
-      this.vector.semanticAvailable = false;
-      return false;
-    }
-    const ready = await this.probeVectorStoreAvailability();
-    this.vector.semanticAvailable = ready;
-    return ready;
+    // Hold busy across provider init so idle eviction cannot close the
+    // manager mid-probe.
+    return await this.withBusy(async () => {
+      await this.ensureProviderInitialized();
+      // FTS-only mode: vector search not available
+      if (!this.provider) {
+        this.vector.semanticAvailable = false;
+        return false;
+      }
+      const ready = await this.probeVectorStoreAvailability();
+      this.vector.semanticAvailable = ready;
+      return ready;
+    });
   }
 
   async probeVectorStoreAvailability(): Promise<boolean> {
@@ -1005,21 +1111,26 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     if (cached) {
       return cached;
     }
-    await this.ensureProviderInitialized();
-    // FTS-only mode: embeddings not available but search still works
-    if (!this.provider) {
-      return this.cacheProbeResult({
-        ok: false,
-        error: this.providerUnavailableReason ?? "No embedding provider available (FTS-only mode)",
-      });
-    }
-    try {
-      await this.embedBatchWithRetry(["ping"]);
-      return this.cacheProbeResult({ ok: true });
-    } catch (err) {
-      const message = formatErrorMessage(err);
-      return this.cacheProbeResult({ ok: false, error: message });
-    }
+    // Hold busy across provider init so idle eviction cannot close the
+    // manager mid-probe.
+    return await this.withBusy(async () => {
+      await this.ensureProviderInitialized();
+      // FTS-only mode: embeddings not available but search still works
+      if (!this.provider) {
+        return this.cacheProbeResult({
+          ok: false,
+          error:
+            this.providerUnavailableReason ?? "No embedding provider available (FTS-only mode)",
+        });
+      }
+      try {
+        await this.embedBatchWithRetry(["ping"]);
+        return this.cacheProbeResult({ ok: true });
+      } catch (err) {
+        const message = formatErrorMessage(err);
+        return this.cacheProbeResult({ ok: false, error: message });
+      }
+    });
   }
 
   async close(): Promise<void> {
@@ -1102,8 +1213,34 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       await drainTrackedProviders();
     } finally {
       closeMemoryDatabase(this.db);
+      // Identity-guarded teardown. Between the top of close() and this
+      // finally block, a concurrent getOrCreate(this.cacheKey) may have
+      // inserted a replacement manager into the same key (it sees our
+      // already-closed marker, removes us, and installs a fresh
+      // instance). In that case we must leave the replacement's
+      // metadata untouched:
+      //
+      //   - INDEX_CACHE.delete would already be a no-op because the
+      //     value is no longer us, but spell out the identity check.
+      //   - INDEX_MANAGER_CACHE.lastAccessAt.delete on a stale key would
+      //     erase the replacement's freshly-recorded access timestamp
+      //     and make the replacement invisible to the next idle sweep
+      //     (it would then live forever, defeating the whole point of
+      //     the sidecar).
+      //   - INDEX_MANAGER_CACHE.inflightCount.delete on a stale key
+      //     would clear refcounts the replacement is actively using.
+      //
+      // So all three metadata maps are gated on the same identity
+      // check. release() callbacks held by callers of the prior
+      // acquireManagedCacheKey() remain idempotent: a release fired
+      // after we are no longer the cache occupant decrements an entry
+      // that may now belong to the replacement, but that is still safe
+      // because (a) we incremented it while we were the occupant, and
+      // (b) the symmetric decrement is the expected accounting.
       if (INDEX_CACHE.get(this.cacheKey) === this) {
         INDEX_CACHE.delete(this.cacheKey);
+        INDEX_MANAGER_CACHE.lastAccessAt.delete(this.cacheKey);
+        INDEX_MANAGER_CACHE.inflightCount.delete(this.cacheKey);
       }
     }
     const closeError = closeErrors.values().next().value;

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -431,6 +431,33 @@ export async function closeMemorySearchManager(params: {
   }
 }
 
+// Idle-TTL sweep over the process-wide MemoryIndexManager cache. The qmd
+// manager layer above does not currently retain its own watchers (managers
+// are created on demand and closed by the caller), so this only forwards to
+// the lower-level cache that backs file-backed indexes.
+//
+// Returns `skippedBusy` for entries that aged past idleMs but currently
+// have an in-flight operation (e.g. batch reindex) holding them via
+// MemoryIndexManager.withBusy(). Those entries are eligible again on the
+// next scan after release() fires.
+//
+// Returns `skippedRevalidated` for entries that aged past idleMs in the
+// initial survey but were either refreshed by a cache hit, replaced by
+// a fresh manager, or already removed by another teardown path during
+// the scan-to-close gap. They are also retried on the next scan.
+export async function closeIdleMemorySearchManagers(opts: { idleMs: number }): Promise<{
+  evicted: number;
+  skippedBusy: number;
+  skippedRevalidated: number;
+  remaining: number;
+}> {
+  if (managerRuntimePromise === null) {
+    return { evicted: 0, skippedBusy: 0, skippedRevalidated: 0, remaining: 0 };
+  }
+  const { closeIdleMemoryIndexManagers } = await loadManagerRuntime();
+  return await closeIdleMemoryIndexManagers({ idleMs: opts.idleMs });
+}
+
 class FallbackMemoryManager implements MemorySearchManager {
   private fallback: Maybe<MemorySearchManager> = null;
   private primaryFailed = false;

--- a/extensions/memory-core/src/runtime-provider.ts
+++ b/extensions/memory-core/src/runtime-provider.ts
@@ -2,6 +2,7 @@ import type { MemoryPluginRuntime } from "openclaw/plugin-sdk/memory-core-host-r
 import { resolveMemoryBackendConfig } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 import {
   closeAllMemorySearchManagers,
+  closeIdleMemorySearchManagers,
   closeMemorySearchManager,
   getMemorySearchManager,
 } from "./memory/index.js";
@@ -22,5 +23,8 @@ export const memoryRuntime: MemoryPluginRuntime = {
   },
   async closeMemorySearchManager(params) {
     await closeMemorySearchManager(params);
+  },
+  async closeIdleMemorySearchManagers(opts) {
+    return await closeIdleMemorySearchManagers(opts);
   },
 };

--- a/src/agents/memory-search.test.ts
+++ b/src/agents/memory-search.test.ts
@@ -257,6 +257,8 @@ describe("memory search config", () => {
       watchDebounceMs: 25,
       intervalMinutes: 3,
       embeddingBatchTimeoutSeconds: undefined,
+      idleEvictMs: 15 * 60_000,
+      idleEvictScanMs: 5 * 60_000,
       sessions: {
         deltaBytes: 321,
         deltaMessages: 7,

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -69,6 +69,8 @@ export type ResolvedMemorySearchConfig = {
     watchDebounceMs: number;
     intervalMinutes: number;
     embeddingBatchTimeoutSeconds: number | undefined;
+    idleEvictMs: number;
+    idleEvictScanMs: number;
     sessions: {
       deltaBytes: number;
       deltaMessages: number;
@@ -104,6 +106,22 @@ export type ResolvedMemorySearchSyncConfig = ResolvedMemorySearchConfig["sync"];
 const DEFAULT_CHUNK_TOKENS = 400;
 const DEFAULT_CHUNK_OVERLAP = 80;
 const DEFAULT_WATCH_DEBOUNCE_MS = 1500;
+// Default idle-TTL for cached MemoryIndexManager instances in long-running
+// gateways. Conservative enough to comfortably outlive typical bursts of
+// memory_search calls within a session, short enough to release chokidar
+// FSWatcher handles before they accumulate.
+//
+// In-flight operations are protected separately via a refcount on the
+// managed cache (acquireManagedCacheKey / MemoryIndexManager.withBusy);
+// a manager whose batch reindex or sync exceeds this idle window will
+// still survive until the operation completes, then become eligible for
+// eviction on a subsequent scan.
+const DEFAULT_IDLE_EVICT_MS = 15 * 60_000;
+// Default sweep interval for idle-eviction. The sweep is cheap (it just
+// walks lastAccessAt + inflightCount) so we can afford to run it every
+// few minutes; this also keeps the worst-case extra dwell time after
+// idleMs bounded to one scan interval.
+const DEFAULT_IDLE_EVICT_SCAN_MS = 5 * 60_000;
 const DEFAULT_SESSION_DELTA_BYTES = 100_000;
 const DEFAULT_SESSION_DELTA_MESSAGES = 50;
 const DEFAULT_MAX_RESULTS = 6;
@@ -407,6 +425,12 @@ function resolveSyncConfig(
     intervalMinutes: overrides?.sync?.intervalMinutes ?? defaults?.sync?.intervalMinutes ?? 0,
     embeddingBatchTimeoutSeconds:
       overrides?.sync?.embeddingBatchTimeoutSeconds ?? defaults?.sync?.embeddingBatchTimeoutSeconds,
+    idleEvictMs:
+      overrides?.sync?.idleEvictMs ?? defaults?.sync?.idleEvictMs ?? DEFAULT_IDLE_EVICT_MS,
+    idleEvictScanMs:
+      overrides?.sync?.idleEvictScanMs ??
+      defaults?.sync?.idleEvictScanMs ??
+      DEFAULT_IDLE_EVICT_SCAN_MS,
     sessions: {
       deltaBytes:
         overrides?.sync?.sessions?.deltaBytes ??

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1322,6 +1322,10 @@ export const FIELD_HELP: Record<string, string> = {
     "Debounce window in milliseconds for coalescing rapid file-watch events before reindex runs. Increase to reduce churn on frequently-written files, or lower for faster freshness.",
   "agents.defaults.memorySearch.sync.embeddingBatchTimeoutSeconds":
     "Overrides the timeout for inline embedding batches during memory indexing. Leave unset to use provider defaults: 600 seconds for local/self-hosted providers such as local, Ollama, and LM Studio, and 120 seconds for hosted providers.",
+  "agents.defaults.memorySearch.sync.idleEvictMs":
+    "Idle TTL in milliseconds for cached MemoryIndexManager instances in long-running gateways (default 900000, i.e. 15 minutes). A manager that has not served a request for this long is closed by the gateway sweep, releasing its chokidar FSWatcher and read file descriptors. Set to 0 to disable eviction. Gateway-wide: this is read from agents.defaults only; per-agent overrides under agents.list[].memorySearch.sync are accepted by the schema but ignored at runtime, because the cache is process-wide.",
+  "agents.defaults.memorySearch.sync.idleEvictScanMs":
+    "How often the gateway runs the idle-eviction sweep, in milliseconds (default 300000, i.e. 5 minutes). Lower for tighter resource caps at the cost of more sweep work; raise to reduce sweep overhead at the cost of higher peak fd/RSS. Set to 0 to disable the periodic sweep. Gateway-wide: read from agents.defaults only.",
   "agents.defaults.memorySearch.sync.sessions.deltaBytes":
     "Requires at least this many newly appended bytes before session transcript changes trigger reindex (default: 100000). Increase to reduce frequent small reindexes, or lower for faster transcript freshness.",
   "agents.defaults.memorySearch.sync.sessions.deltaMessages":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -490,6 +490,9 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.memorySearch.sync.watch": "Watch Memory Files",
   "agents.defaults.memorySearch.sync.watchDebounceMs": "Memory Watch Debounce (ms)",
   "agents.defaults.memorySearch.sync.embeddingBatchTimeoutSeconds": "Embedding Batch Timeout (s)",
+  "agents.defaults.memorySearch.sync.idleEvictMs": "Memory Index Idle Eviction (ms, gateway-wide)",
+  "agents.defaults.memorySearch.sync.idleEvictScanMs":
+    "Memory Index Idle Eviction Scan Interval (ms, gateway-wide)",
   "agents.defaults.memorySearch.sync.sessions.deltaBytes": "Session Delta Bytes",
   "agents.defaults.memorySearch.sync.sessions.deltaMessages": "Session Delta Messages",
   "agents.defaults.memorySearch.sync.sessions.postCompactionForce":

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -510,6 +510,31 @@ export type MemorySearchConfig = {
      * Unset uses provider defaults: 600s for local/self-hosted providers, 120s for hosted providers.
      */
     embeddingBatchTimeoutSeconds?: number;
+    /**
+     * Idle TTL (ms) for cached `MemoryIndexManager` instances in long-running
+     * gateways. After this many idle milliseconds a manager is closed and its
+     * chokidar `FSWatcher` is released. Defaults to 15 minutes; `0` disables
+     * eviction.
+     *
+     * **Scope: gateway-wide (process-wide) only.** This setting is read from
+     * `agents.defaults.memorySearch.sync.idleEvictMs`. The underlying
+     * `INDEX_CACHE` is a module-level singleton shared by every agent in the
+     * gateway process, and the sweep runs once per cadence over the entire
+     * cache; there is no per-agent sweep timer. A value placed on a specific
+     * `agents.list[].memorySearch.sync.idleEvictMs` entry is currently
+     * accepted by the config schema but **ignored at runtime** — set this
+     * field on `agents.defaults` instead.
+     */
+    idleEvictMs?: number;
+    /**
+     * How often the idle-eviction sweep runs (ms). Defaults to 5 minutes; `0`
+     * disables the periodic sweep.
+     *
+     * **Scope: gateway-wide (process-wide) only**, same reasoning as
+     * `idleEvictMs` above — read from `agents.defaults.memorySearch.sync`;
+     * per-agent overrides are ignored at runtime.
+     */
+    idleEvictScanMs?: number;
     sessions?: {
       /** Minimum appended bytes before session transcripts are reindexed. */
       deltaBytes?: number;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -902,6 +902,17 @@ export const MemorySearchSchema = z
         watchDebounceMs: z.number().int().nonnegative().optional(),
         intervalMinutes: z.number().int().nonnegative().optional(),
         embeddingBatchTimeoutSeconds: z.number().int().positive().optional(),
+        // Idle-TTL (ms) for cached MemoryIndexManager instances in
+        // long-running gateways. Gateway-wide (process-wide) only: read from
+        // agents.defaults.memorySearch.sync; per-agent overrides under
+        // agents.list[].memorySearch.sync are accepted by this schema but
+        // ignored at runtime, because INDEX_CACHE is a process-wide
+        // singleton and the sweep runs over the entire cache. See the
+        // MemorySearchConfig.sync TS doc for the full contract.
+        idleEvictMs: z.number().int().nonnegative().optional(),
+        // How often the idle-eviction sweep runs (ms). Same gateway-wide
+        // scope contract as idleEvictMs above.
+        idleEvictScanMs: z.number().int().nonnegative().optional(),
         sessions: z
           .object({
             deltaBytes: z.number().int().nonnegative().optional(),

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -819,7 +819,9 @@ describe("startGatewayPostAttachRuntime", () => {
       await vi.advanceTimersToNextTimerAsync();
       expect(postReadyRequestTurn).toHaveBeenCalledTimes(1);
       expect(onPostReadySidecars.mock.calls[0]?.[0]).toHaveLength(0);
-      expect(onGatewayLifetimeSidecars.mock.calls[0]?.[0]).toHaveLength(1);
+      // Two gateway-lifetime sidecars: provider auth prewarm + memory
+      // index idle-evict (enabled by default via memorySearch.sync defaults).
+      expect(onGatewayLifetimeSidecars.mock.calls[0]?.[0]).toHaveLength(2);
       await vi.dynamicImportSettled();
       await vi.waitFor(() => {
         expect(hoisted.setAuthProfileFailureHook).toHaveBeenCalledTimes(1);
@@ -874,7 +876,9 @@ describe("startGatewayPostAttachRuntime", () => {
         | { stop: () => void }[]
         | undefined;
       expect(gmailSidecars).toHaveLength(1);
-      expect(lifetimeSidecars).toHaveLength(1);
+      // Two gateway-lifetime sidecars: provider auth prewarm + memory
+      // index idle-evict.
+      expect(lifetimeSidecars).toHaveLength(2);
 
       for (const sidecar of gmailSidecars ?? []) {
         sidecar.stop();
@@ -1325,7 +1329,9 @@ describe("startGatewayPostAttachRuntime", () => {
       name: "sidecars.ready",
       metrics: [
         ["loadedPluginCount", 2],
-        ["postReadySidecarCount", 0],
+        // Provider auth prewarm is disabled in this test, but memory
+        // index idle-evict is enabled by default (15min idle TTL).
+        ["postReadySidecarCount", 1],
       ],
     });
   });

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -30,6 +30,20 @@ const ACP_BACKEND_READY_POLL_MS = 50;
 const PROVIDER_AUTH_PREWARM_START_DELAY_MS = 1_000;
 const PROVIDER_AUTH_REWARM_DELAY_MS = 1_000;
 const QMD_STARTUP_IDLE_DELAY_MS = 120_000;
+// Default idle-TTL for cached MemoryIndexManager entries in long-running
+// gateway daemons. 15 minutes is comfortably longer than the typical gap
+// between memory_search invocations during a single chat session, so an
+// active session does not have its cached embedding state thrown away,
+// while idle agents release their chokidar FSWatchers within one quiet
+// window. Override per-agent via
+// `agents.defaults.memorySearch.sync.idleEvictMs`; set to 0 to disable.
+const MEMORY_INDEX_IDLE_EVICT_DEFAULT_MS = 15 * 60_000;
+// How often the idle sweep runs. 5 minutes keeps the worst-case slack
+// between idleMs and actual eviction bounded to ~20min, while making the
+// sweep itself cheap (one Map walk + at most one close() per stale
+// entry). Override via `agents.defaults.memorySearch.sync.idleEvictScanMs`;
+// set to 0 to disable.
+const MEMORY_INDEX_IDLE_EVICT_SCAN_DEFAULT_MS = 5 * 60_000;
 const RESTART_SENTINEL_FILENAME = "restart-sentinel.json";
 
 type Awaitable<T> = T | Promise<T>;
@@ -164,6 +178,99 @@ function schedulePostAttachUpdateSentinelRefresh(params: {
     });
   });
   handle.unref?.();
+}
+
+type ResolvedMemoryIndexIdleEvictPolicy =
+  | { mode: "off" }
+  | { mode: "on"; idleMs: number; scanMs: number };
+
+// Resolve idle-eviction policy from gateway defaults only.
+//
+// By design this reads only `agents.defaults.memorySearch.sync`. The
+// MemoryIndexManager cache (`INDEX_CACHE`) is a module-level singleton
+// shared by every agent in the gateway process, and the sweep runs once
+// per cadence over the entire cache. There is no per-agent sweep timer,
+// and no meaningful way to honour a per-agent `idleEvictMs` while another
+// agent in the same gateway wants the same manager kept alive. Per-agent
+// values placed under `agents.list[].memorySearch.sync` are accepted by
+// the zod schema (shared with `agents.defaults`) but intentionally not
+// read here; the gateway-wide contract is documented on the
+// `MemorySearchConfig.sync.idleEvictMs` / `idleEvictScanMs` TS docs and
+// in the corresponding schema-label entries.
+function resolveMemoryIndexIdleEvictPolicy(
+  cfg: OpenClawConfig,
+): ResolvedMemoryIndexIdleEvictPolicy {
+  const sync = cfg.agents?.defaults?.memorySearch?.sync;
+  const idleMs = sync?.idleEvictMs ?? MEMORY_INDEX_IDLE_EVICT_DEFAULT_MS;
+  const scanMs = sync?.idleEvictScanMs ?? MEMORY_INDEX_IDLE_EVICT_SCAN_DEFAULT_MS;
+  if (idleMs <= 0 || scanMs <= 0) {
+    return { mode: "off" };
+  }
+  return { mode: "on", idleMs, scanMs };
+}
+
+// Periodic idle-TTL sweep over the process-wide MemoryIndexManager cache.
+// Long-running gateways accumulate cached managers (and their chokidar
+// FSWatchers) over time; this sweep closes managers that have not served a
+// request for `idleMs`. Returning a sidecar handle lets the gateway shut
+// the timer down cleanly.
+function scheduleMemoryIndexIdleEvict(params: {
+  cfg: OpenClawConfig;
+  log: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+  };
+}): GatewayPostReadySidecarHandle | null {
+  let stopped = false;
+  let timer: ReturnType<typeof setInterval> | undefined;
+  const policy = resolveMemoryIndexIdleEvictPolicy(params.cfg);
+  if (policy.mode === "off") {
+    return null;
+  }
+  const runSweep = async () => {
+    if (stopped) {
+      return;
+    }
+    try {
+      const { getMemoryRuntime } = await import("../plugins/memory-state.js");
+      const runtime = getMemoryRuntime();
+      if (!runtime?.closeIdleMemorySearchManagers) {
+        return;
+      }
+      const result = await runtime.closeIdleMemorySearchManagers({
+        idleMs: policy.idleMs,
+      });
+      if (result.evicted > 0 || result.skippedBusy > 0 || result.skippedRevalidated > 0) {
+        const deferredParts: string[] = [];
+        if (result.skippedBusy > 0) {
+          deferredParts.push(`${result.skippedBusy} busy`);
+        }
+        if (result.skippedRevalidated > 0) {
+          deferredParts.push(`${result.skippedRevalidated} revalidated`);
+        }
+        const deferredSuffix =
+          deferredParts.length > 0 ? ` (deferred ${deferredParts.join(", ")})` : "";
+        params.log.info(
+          `memory index manager idle eviction: evicted ${result.evicted}${deferredSuffix} (remaining ${result.remaining})`,
+        );
+      }
+    } catch (err) {
+      params.log.warn(`memory index manager idle eviction failed: ${String(err)}`);
+    }
+  };
+  timer = setInterval(() => {
+    void runSweep();
+  }, policy.scanMs);
+  timer.unref?.();
+  return {
+    stop: () => {
+      stopped = true;
+      if (timer) {
+        clearInterval(timer);
+        timer = undefined;
+      }
+    },
+  };
 }
 
 function scheduleProviderAuthStatePrewarm(params: {
@@ -1023,6 +1130,13 @@ export async function startGatewayPostAttachRuntime(
             }),
           );
         }
+        const memoryIdleEvictSidecar = scheduleMemoryIndexIdleEvict({
+          cfg: params.cfgAtStart,
+          log: params.log,
+        });
+        if (memoryIdleEvictSidecar) {
+          gatewayLifetimeSidecars.push(memoryIdleEvictSidecar);
+        }
         params.onPostReadySidecars?.(postReadySidecars);
         params.onGatewayLifetimeSidecars?.(gatewayLifetimeSidecars);
         params.onSidecarsReady?.();
@@ -1104,6 +1218,8 @@ export const testing = {
   hasRestartSentinelFileFast,
   refreshLatestUpdateRestartSentinelIfPresent,
   resolveGatewayMemoryStartupPolicy,
+  resolveMemoryIndexIdleEvictPolicy,
+  scheduleMemoryIndexIdleEvict,
   scheduleProviderAuthStatePrewarm,
   stopPostReadySidecarsAfterCloseStarted,
 };

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -109,6 +109,26 @@ export type MemoryPluginRuntime = {
   }): MemoryRuntimeBackendConfig;
   closeMemorySearchManager?(params: { cfg: OpenClawConfig; agentId: string }): Promise<void>;
   closeAllMemorySearchManagers?(): Promise<void>;
+  // Optional idle-TTL sweep for cached MemoryIndexManager instances. Used by
+  // long-running gateway daemons to release chokidar FSWatchers that the
+  // CLI-exit path (closeAllMemorySearchManagers) does not cover.
+  //
+  // `skippedBusy` reports the number of entries that aged past idleMs but
+  // were held in-flight by an ongoing operation (e.g. batch reindex) and
+  // therefore deferred to the next scan. Counted for observability only;
+  // not an error.
+  //
+  // `skippedRevalidated` reports the number of entries that aged past
+  // idleMs in the initial survey but were either refreshed by a cache
+  // hit, replaced by a fresh manager, or already torn down by another
+  // path between survey and close. Also deferred to the next scan and
+  // counted for observability only.
+  closeIdleMemorySearchManagers?(opts: { idleMs: number }): Promise<{
+    evicted: number;
+    skippedBusy: number;
+    skippedRevalidated: number;
+    remaining: number;
+  }>;
 };
 
 export type MemoryPluginPublicArtifactContentType = "markdown" | "json" | "text";


### PR DESCRIPTION
## Relationship to #86701

This PR is **complementary** to #86701 (merged 2026-05-26), not a replacement.

- **#86701** fixed the *per-call* chokidar fan-out: a single memory directory load was opening ~12 k FDs because every file got its own watcher. It capped per-call FD allocations to a small constant by reusing a single watcher per directory.
- **This PR (#86345)** addresses a *time-based* failure mode that survives #86701: even after per-call FD usage is bounded, the module-level `INDEX_CACHE` (a `Map<key, MemoryIndexManager>`) accumulates `MemoryIndexManager` instances over the lifetime of a long-running gateway. Each cached manager retains its own watcher handles, sync timers, embedding probe state, and other module-scoped retained heap. Nothing evicts idle entries until process exit, so daemons that never restart keep growing.

The two PRs touch `extensions/memory-core/src/memory/manager.ts` in **disjoint regions** — #86701 modified `close()` near line 957, this PR modifies the cache helpers and lifecycle wrappers near line 715 — and lukeboyett's PR body explicitly framed them as **defense in depth**. The branch has been rebased clean against current `main` (which already includes #86701 and the subsequent `fix(memory-core): close providers created during shutdown` cleanup).

## Real behavior proof

**Behavior addressed:** Long-running OpenClaw gateway daemons accumulate chokidar `FSEventWrap` native handles and `memory/*.md` file descriptors for the entire process lifetime. RSS grows ~1 GB/h until OOM, typically within 4–6 h on memory-heavy workloads. Root cause: `MemoryIndexManager` instances live in the module-level `INDEX_CACHE` and are only torn down at process exit (#40389), which long-running daemons never reach until restart.

**Real environment tested:** Production gateway daemon on macOS 15.7.4 (Apple Silicon), OpenClaw `2026.4.15` base, default config (`agents.defaults.memorySearch.sync.watch=true`), Node `v24.13.0`. Patch applied at runtime by replacing the installed `dist/` directory with a build of this branch (`fix/memory-index-manager-daemon-eviction`), then `launchctl kickstart -k gui/501/ai.openclaw.gateway` to restart the daemon onto the patched dist.

**Exact steps or command run after this patch:** see code block below.

```
Step 1: Build the patched dist
pnpm install && pnpm build

Step 2: Replace installed dist on the production host
cp -R dist/ ~/.nvm/versions/node/v24.13.0/lib/node_modules/openclaw/dist/

Step 3: Restart the gateway onto the patched dist
launchctl kickstart -k gui/501/ai.openclaw.gateway

Step 4: Verify new gateway came up and patched code is loaded
pgrep -f openclaw-gateway
grep -l 'closeIdleManagedCacheEntries' \
  ~/.nvm/versions/node/v24.13.0/lib/node_modules/openclaw/dist/manager-*.js

Step 5: Start a sampler that records ps + lsof every 10 minutes
nohup /tmp/soak-v2-sampler.sh > /tmp/soak-v2-sampler.log 2>&1 &

Step 6: Run normal workload (memory_search invocations from gateway agents)
Step 7: After 17 h: capture current ps/lsof/CSV state
ps -p 93144 -o pid,etime,rss,vsz,command
lsof -p 93144 | awk '{print $5}' | sort | uniq -c | sort -rn
lsof -p 93144 | grep -c '/memory/'
```

**Evidence after fix:** real terminal output from the soaked production gateway (PID 93144, 17 h elapsed at PR submission).

Process state on patched daemon (started 2026-05-24 20:37 +0800):

```
$ ps -p 93144 -o pid,etime,rss,vsz,command
  PID  ELAPSED    RSS      VSZ COMMAND
93144 17:00:00 3156336 48135156 openclaw-gateway
```

fd breakdown at steady state between sweeps:

```
$ lsof -p 93144 | awk '{print $5}' | sort | uniq -c | sort -rn
  16 REG       (regular files: dist + libs, stable baseline)
   8 IPv4      (network sockets, stable)
   4 PIPE
   4 DIR
   3 unix
   3 KQUEUE    (== baseline 3, never grows)
   2 CHR
   1 IPv6
   1 systm
$ lsof -p 93144 | grep -c '/memory/'
0
```

Sampler CSV excerpts (`/tmp/soak-v2-samples.csv`, 100+ data points, 10 min interval):

```csv
timestamp,pid,etime,rss_kb,vsz_kb,fd_total,memory_fd,kqueue,reg
2026-05-24T20:52:41+0800,93144,15:15,1367528,37220752,43,0,3,16        # baseline
2026-05-24T21:02:46+0800,93144,25:20,1785012,46010708,598,554,3,572    # memory_search burst
2026-05-24T21:22:54+0800,93144,45:28,1597452,45822680,40,0,3,15        # sidecar swept; fd back to baseline
2026-05-25T08:48:05+0800,93144,12:10:39,2319392,47039688,597,557,3,574 # later burst
2026-05-25T09:08:14+0800,93144,12:30:48,2881712,47600968,41,0,3,17     # swept again
2026-05-25T10:28:49+0800,93144,13:51:23,2925140,47774268,44,0,3,16     # mid-soak sample
```

For comparison, before the patch (2026-05-23, same daemon, 11 h uptime, no sidecar) heap snapshot diff showed:

```
Constructor                  # objects (delta)   shallow size delta
Node / FSEventWrap           +612                +253 KB
Node / FSEvent               +613                +245 KB
Node / FSWatcher             +615                +197 KB
Node / Stats                 +543                +173 KB
```

and `lsof` of that pre-patch daemon showed `488` chokidar `awaitWriteFinish` read fds on `~/.openclaw/workspace/memory/`.

**Observed result after fix:** `memory_fd` (chokidar read fds on `memory/*.md`) oscillates between `0` baseline and ~557 during bursts, returning to `0` within one sweep interval — without the patch, this value grew monotonically to 488+ and never returned to baseline. `kqueue` stays pinned at exactly `3` for the entire 17 h soak — without the patch, `FSEventWrap` instances accumulated by the hundreds (+612 in the pre-patch 11 h heap diff). RSS rose ~150 MB/h (from 1.37 GB at +15 min to 3.16 GB), well under OOM — without the patch the same workload hit OOM at ~4.7 GB within 4–6 h. Sidecar log lines confirm the sweep is running and reporting `memory index manager idle eviction: evicted N (deferred M busy, K revalidated) (remaining R)`. 33 unit tests cover the in-flight protection deferral and revalidation paths deterministically.

**What was not tested:** Windows / Linux daemons (only macOS validated live; CI covers cross-platform builds, but no live soak on those platforms yet). Multi-agent workloads exercising > 50 `MemoryIndexManager` instances simultaneously (our production setup has ~3 active managers). Workloads where individual `sync()` batches exceed the 15 min idle threshold (would exercise the busy-defer path live; covered by unit tests but not by soak).

## Out-of-scope follow-ups

- Changing `sync.watch` default from `true` to `false` (tracked in #71335)
- Refactoring chokidar to a singleton-per-workspace watcher
- Adding a config flag to opt out of the in-flight protection (it should always be on)

---

## Problem

Cached `MemoryIndexManager` instances live in a module-level `INDEX_CACHE` that grows for the entire gateway daemon lifetime. Each instance owns a chokidar `FSWatcher` recursively watching the memory directory (under the default `sync.watch=true`, see #71335), so every cache entry holds an `FSEventWrap` native handle plus one `awaitWriteFinish` file descriptor per touched `memory/*.md` file.

Cached managers are torn down at CLI exit (#40389), but daemons never reach that exit path until restart. This PR adds a periodic runtime sweep that bounds cache lifetime *during* normal daemon operation, so restart is no longer the only way to release these resources.

### Measured impact (production daemon, OpenClaw 2026.4.15 + this patch)

| Metric          | Without patch (11 h)       | With patch (17 h+ live soak)  |
|-----------------|----------------------------|-------------------------------|
| FSEventWrap     | 612 native handles         | bounded; returns to ~3 baseline |
| memory_fd       | 488 (chokidar holds)       | 0 between sweeps              |
| RSS growth rate | ~1 GB/h                    | ~150 MB/h (~7× improvement)   |
| Outcome         | OOM within 4 to 6 h        | 3.16 GB stable, no OOM at 17h |

Sampling: 100+ data points at 10 min interval. Sweep cadence: 5 min scan, 15 min idle threshold (both configurable).

## Fix

Extend `ManagedCache` with idle tracking and add a gateway-lifetime sidecar:

- `ManagedCache.lastAccessAt` is refreshed on every cache hit and on initial set.
- `closeIdleManagedCacheEntries` walks `lastAccessAt`, closes stale entries, and isolates `close()` errors so one bad entry does not stop the rest. It reuses the per-manager `close()` method introduced in #40389 — no new teardown code path.
- `closeIdleMemoryIndexManagers` (in `manager.ts`) layers in the embedding-probe-cache cleanup that the manager would otherwise miss.
- `scheduleMemoryIndexIdleEvict` (in `server-startup-post-attach.ts`) registers a gateway-lifetime sidecar that runs the sweep every `idleEvictScanMs` (default 5 min), evicting managers idle for `idleEvictMs` (default 15 min). Setting either to `0` disables the sweep entirely.

## In-flight protection

`ManagedCache` tracks an `inflightCount` map keyed the same way as `cache` / `lastAccessAt`:

- `acquireManagedCacheKey(cache, key)` increments the count, refreshes `lastAccessAt`, and returns an idempotent `release()` function.
- `isManagedCacheKeyBusy(cache, key)` reports whether the count is > 0.
- `closeIdleManagedCacheEntries` consults `isManagedCacheKeyBusy` during both the survey loop and immediately before `close()`. Busy entries are skipped, counted, and surfaced via `onSkipBusy` / `skippedBusy`.
- A revalidation gate (just before close) also re-checks `lastAccessAt` freshness and cache identity, catching entries that became active or were swapped during the scan-to-close gap. These are reported as `skippedRevalidated`.

In `MemoryIndexManager`, a protected `withBusy(fn)` helper wraps the acquire/release pair in try/finally. It guards:

- `sync(...)` — covers batch reindex, targeted session sync, full sync. The refcount is released in the same `.finally()` that nulls `this.syncing`, so they unwind together.
- `search(...)` — protects the embedding/vector/FTS work plus the inline `sync({ reason: "search", force: true })` bootstrap that runs on the first call after process start.
- `ensureProviderInitialized(...)` — covers `probeVectorAvailability`, `probeEmbeddingAvailability`, and the lazy provider hookup invoked by `sync` / `search`.

`close()` and `closeMemoryIndexManagersForAgent` clear residual cache metadata only when this manager is still the current cache occupant for its key. The `release()` returned by `acquireManagedCacheKey` is idempotent, so a release that fires after `close()` is a no-op.

Sidecar log lines now report both deferral classes:

```
memory index manager idle eviction: evicted 3 (deferred 1 busy, 0 revalidated) (remaining 5)
```

## Configuration

Two new optional knobs under `agents.defaults.memorySearch.sync`:

| Key                  | Default | Meaning                                                        |
|----------------------|---------|----------------------------------------------------------------|
| `idleEvictMs`        | 900000  | Manager is eligible for eviction after this many ms idle. `0` disables. |
| `idleEvictScanMs`    | 300000  | Sidecar runs the sweep this often. `0` disables.               |

Both fields are gateway-wide (process-wide) by design. The `INDEX_CACHE` is a module-level singleton shared by every agent in the gateway process; the sweep runs once per cadence over the entire cache. Per-agent values placed under `agents.list[].memorySearch.sync` are accepted by the (shared) schema but read only from `agents.defaults` at runtime. This is documented in the zod schema (`src/config/zod-schema.agent-runtime.ts`), the TS type (`src/config/types.tools.ts`), UI labels (`src/config/schema.labels.ts`, tagged "gateway-wide"), `FIELD_HELP` (`src/config/schema.help.ts`), and `docs/reference/memory-config.md`.

## Validation

### Live soak (production daemon)

- **Base:** OpenClaw 2026.4.15, default config (`sync.watch=true`)
- **Patched dist** applied at runtime via dist replacement
- **Sampler:** `lsof`-derived fd counts + `ps`-derived RSS, 10 min interval
- **Duration:** 17 h continuous at PR submission, still running
- **Result:** see "Measured impact" table above. Raw CSV available on request.

Sidecar observed behavior during the soak:

- fd accumulates during `memory_search` activity (up to ~600 handles)
- next sweep evicts idle managers, fd returns to baseline within 10 min
- `skippedBusy=0` and `skippedRevalidated=0` throughout — confirms the in-flight and revalidation guards are wired correctly but our workload's burst rate did not exercise them (the unit tests below do)

### Tests

- `extensions/memory-core/src/memory/manager-cache.test.ts` — 21 tests (was 11). New coverage: `acquireManagedCacheKey` / `isManagedCacheKeyBusy` / busy deferral / refcount / `lastAccessAt` refresh / `inflightCount` cleanup / revalidation gate for cache-hit, busy, identity-swap, and slot-disappearance gaps.
- `extensions/memory-core/src/memory/manager.idle-gc.test.ts` — 12 tests (was 5). New coverage: in-flight protection at manager-level entry points (`search`, `sync`, `ensureProviderInitialized`), plus coverage for the cache-occupant identity check in the manager `close()` cleanup path.
- `extensions/memory-core/` — 720/720 across 57 files.
- `src/gateway/server-startup-post-attach.test.ts` — 41 tests pass.
- `src/agents/memory-search.test.ts` — 27 tests pass.
- `src/config/` — 1493/1493 across all config schema tests pass.
- `pnpm run lint`, `pnpm run tsgo:core`, `pnpm run tsgo:extensions`, `pnpm run tsgo:test`, and `pnpm run build` all green.

## Risk / Compatibility

- Default idle threshold (15 min) is conservative — comfortably outlives typical bursts of `memory_search` calls within a session.
- Worst-case dwell is `idleMs + scanMs + max in-flight op duration` (was unbounded; `idleMs + scanMs` if all ops are short).
- Short-lived CLI invocations are unchanged — `closeAllMemoryIndexManagers` is still the exit path from #40389, and it clears `inflightCount` alongside the rest of the cache.
- Public `MemoryPluginRuntime.closeIdleMemorySearchManagers` return type grows two additive fields (`skippedBusy`, `skippedRevalidated`). Existing callers reading `evicted` / `remaining` continue to work unchanged via TypeScript structural typing.
- No new dependencies, no schema migration, no protocol change.

## Out of scope

- Does NOT change `sync.watch` default value (#71335 tracks that separately).
- Does NOT refactor the watcher to be singleton-per-workspace (much larger architectural change).
- Does NOT introduce an opt-out for the in-flight protection — it's a safety net that should always be on. The only configurable knobs are the sweep cadence and idle threshold.

<details>
<summary>Lifecycle phase comparison vs #40389 (for reviewers)</summary>

|                | #40389 (merged)              | This PR                                   |
|----------------|------------------------------|-------------------------------------------|
| Trigger        | Process exit (CLI `finally`) | Periodic sidecar (gateway runtime)        |
| Frequency      | Once per process             | Every `idleEvictScanMs`                   |
| Scope          | All cached managers          | Idle managers only                        |
| Lifecycle phase| Shutdown teardown            | Continuous daemon lifetime                |
| Protection     | N/A (process exiting)        | `isBusy` + `withBusy` + revalidation gate |
| Symptom fixed  | One-shot CLI hangs on exit   | Daemon fd/RSS growth in normal operation  |
| Code sharing   | Added per-manager `close()`  | Reuses #40389's `close()` in the sweep    |

The two are layered: #40389 handles the moment of exit; this PR handles the time between starts and exits, which is where long-lived daemons spend ~100% of their wall clock.

</details>

Refs #71335, #40389, #86701.

## Raw production data

Real terminal output from the soaked production gateway (PID 93144 at the time of writing, 17 h elapsed, OpenClaw `2026.4.15` base + this patch backported as runtime dist replacement).

### Before the patch (baseline measured 2026-05-23, no patch, 11 h uptime)

Heap snapshot delta over 11 h (`chrome devtools heap snapshot`):

```
Constructor                              # objects (delta)   shallow size delta
Node / FSEventWrap                       +612                +253 KB
Node / FSEvent                           +613                +245 KB
Node / FSWatcher                         +615                +197 KB
Node / Stats                             +543                +173 KB
chokidar / WatchHelper                   +76                 +24 KB
```

`lsof -p <gateway>` count by location (no patch, 11 h):

```
File location                              fd count
~/.openclaw/workspace/memory/              488    (chokidar awaitWriteFinish read fds)
~/.openclaw/workspace/memory/*/            57     (artifact subdir .md files)
~/.openclaw/tasks/                         4
~/.openclaw/flows/                         4
~/.openclaw/logs/                          2
```

RSS over 11 h grew from ~700 MB baseline to ~2.3 GB (+1.6 GB, ~150 MB/h);
process subsequently OOM'd at ~4.7 GB.

### After the patch (live soak in progress, 17 h elapsed at PR submission)

`ps` snapshot:

```
$ ps -p 93144 -o pid,etime,rss,vsz,command
  PID  ELAPSED    RSS      VSZ COMMAND
93144 17:00:00 3156336 48135156 openclaw-gateway
```

`lsof` fd breakdown (steady state between sweeps):

```
$ lsof -p 93144 | awk '{print $5}' | sort | uniq -c | sort -rn
  16 REG       (regular files: dist + libs, stable)
   8 IPv4      (network sockets)
   4 PIPE
   4 DIR
   3 unix
   3 KQUEUE    (== baseline 3, never grows)
   2 CHR
   1 IPv6
   1 systm
$ lsof -p 93144 | grep -c '/memory/'
0                                 (zero chokidar fds between sweeps)
```

Sidecar in action — sampler CSV excerpts (`/tmp/soak-v2-samples.csv`, 100+ lines, 10 min interval):

```csv
timestamp,pid,etime,rss_kb,vsz_kb,fd_total,memory_fd,kqueue,reg
2026-05-24T20:52:41+0800,93144,15:15,1367528,37220752,43,0,3,16        # +15min post-restart, baseline
2026-05-24T21:02:46+0800,93144,25:20,1785012,46010708,598,554,3,572    # memory_search burst
2026-05-24T21:12:50+0800,93144,35:24,1502644,45728044,596,554,3,571    # still in burst
2026-05-24T21:22:54+0800,93144,45:28,1597452,45822680,40,0,3,15        # sidecar swept; fd back to baseline
2026-05-25T08:48:05+0800,93144,12:10:39,2319392,47039688,597,557,3,574 # later burst
2026-05-25T08:58:10+0800,93144,12:20:44,2319140,47039432,597,557,3,574 # still bursting
2026-05-25T09:08:14+0800,93144,12:30:48,2881712,47600968,41,0,3,17     # swept again
2026-05-25T10:28:49+0800,93144,13:51:23,2925140,47774268,44,0,3,16     # mid-soak sample
```

Visible behavior in the CSV:

- `fd_total` swings between baseline `~40` and burst `~600` and reliably returns to baseline within one sweep interval (10 min in this run)
- `memory_fd` (chokidar `awaitWriteFinish` read fds) stays at `0` between bursts — they are released by `close()`, not just dropped from the JS heap
- `kqueue` stays at exactly `3` throughout (native kevent handles) — confirms `FSEventWrap` is being destroyed, not orphaned
- `rss_kb` rises slowly (~150 MB/h) but does not approach OOM territory; without the patch the same workload OOM'd within 4–6 h

Raw CSV available on request.


---

## Maintainer review request

@osolmaz — as you recently merged #86701 from a complementary angle (per-call watcher fan-out), would you mind taking a look at this one when you have a chance? It tackles the long-running daemon side of the same family of leaks (idle `INDEX_CACHE` retention rather than per-call FD allocation) and the two PRs were designed to layer.

The PR adds two default-on knobs (`idleEvictMs` = 15 min, `idleEvictScanMs` = 5 min). Happy to switch them to opt-in or adjust defaults if you'd prefer a more conservative rollout.
