### PR TITLE
fix: preserve message and media fields in webchat tool result details

### DIFF
--- a/src/infra/outbound/message-action-runner.send-validation.test.ts
+++ b/src/infra/outbound/message-action-runner.send-validation.test.ts
@@ -132,9 +132,10 @@ describe("runMessageAction send validation", () => {
       target: "current-run",
       sourceReplyDeliveryMode: "message_tool_only",
       sourceReplySink: "internal-ui",
+      message: "hello from codex",
       dryRun: false,
     });
-    expect(JSON.stringify(result.toolResult)).not.toContain("hello from codex");
+    expect(result.toolResult?.details?.message).toBe("hello from codex");
   });
 
   it("strips unsupported citation control markers from internal UI source replies", async () => {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -745,6 +745,10 @@ function buildInternalSourceReplyToolResult(payload: {
   target: string;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   sourceReplySink?: "internal-ui";
+  sourceReply?: unknown;
+  message?: string;
+  mediaUrl?: string;
+  mediaUrls?: string[];
   dryRun: boolean;
 }): AgentToolResult<{
   status: string;
@@ -753,6 +757,10 @@ function buildInternalSourceReplyToolResult(payload: {
   target: string;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   sourceReplySink?: "internal-ui";
+  sourceReply?: unknown;
+  message?: string;
+  mediaUrl?: string;
+  mediaUrls?: string[];
   dryRun: boolean;
 }> {
   const action = payload.dryRun ? "Prepared" : "Sent";
@@ -773,6 +781,10 @@ function buildInternalSourceReplyToolResult(payload: {
         ? { sourceReplyDeliveryMode: payload.sourceReplyDeliveryMode }
         : {}),
       ...(payload.sourceReplySink ? { sourceReplySink: payload.sourceReplySink } : {}),
+      ...(payload.sourceReply !== undefined ? { sourceReply: payload.sourceReply } : {}),
+      ...(payload.message !== undefined ? { message: payload.message } : {}),
+      ...(payload.mediaUrl !== undefined ? { mediaUrl: payload.mediaUrl } : {}),
+      ...(payload.mediaUrls !== undefined ? { mediaUrls: payload.mediaUrls } : {}),
       dryRun: payload.dryRun,
     },
   };


### PR DESCRIPTION
## Summary

修复 WebChat message tool 回复无法渲染的问题。`buildInternalSourceReplyToolResult` 函数之前丢弃了 `sourceReply`、`message`、`mediaUrl` 和 `mediaUrls` 字段，导致 chat mirror 路径无法获取结构化数据来渲染助手回复。

## Changes

- **src/infra/outbound/message-action-runner.ts**: 更新 `buildInternalSourceReplyToolResult` 函数的类型定义和实现，保留所有 payload 字段到 `toolResult.details`
- **src/infra/outbound/message-action-runner.send-validation.test.ts**: 更新测试以验证 `message` 字段被正确保留

## Verification

修改了 `src/infra/outbound/message-action-runner.send-validation.test.ts` 中的测试用例，现在验证 `toolResult.details.message` 包含实际的回复内容。

## References

Fixes #86347

🤖 AI-generated code
