### PR TITLE
fix: preserve webchat source reply details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- WebChat: keep message-tool replies visible in the chat while still summarizing internal tool results for the model. Fixes #86347. Thanks @shakkernerd.
 - Agents/commitments: serialize commitment store load-modify-save writes so concurrent heartbeat and CLI updates no longer lose dismissal, sent, or attempt state. (#81153) Thanks @ai-hpc.
 - Gateway/perf: tighten restart and startup benchmark failure handling so long profiling runs, failed probes, and fresh Linux runners no longer produce false passing or `n/a` results.
 - Checks: keep intentional Knip unused-file findings optional so full CI and sparse proof workspaces stay aligned.

--- a/src/infra/outbound/message-action-runner.send-validation.test.ts
+++ b/src/infra/outbound/message-action-runner.send-validation.test.ts
@@ -132,9 +132,13 @@ describe("runMessageAction send validation", () => {
       target: "current-run",
       sourceReplyDeliveryMode: "message_tool_only",
       sourceReplySink: "internal-ui",
+      sourceReply: {
+        text: "hello from codex",
+      },
+      message: "hello from codex",
       dryRun: false,
     });
-    expect(JSON.stringify(result.toolResult)).not.toContain("hello from codex");
+    expect(JSON.stringify(result.toolResult?.content)).not.toContain("hello from codex");
   });
 
   it("strips unsupported citation control markers from internal UI source replies", async () => {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -745,6 +745,10 @@ function buildInternalSourceReplyToolResult(payload: {
   target: string;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   sourceReplySink?: "internal-ui";
+  sourceReply: ReplyPayload;
+  message?: string;
+  mediaUrl?: string;
+  mediaUrls?: string[];
   dryRun: boolean;
 }): AgentToolResult<{
   status: string;
@@ -753,6 +757,10 @@ function buildInternalSourceReplyToolResult(payload: {
   target: string;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   sourceReplySink?: "internal-ui";
+  sourceReply: ReplyPayload;
+  message?: string;
+  mediaUrl?: string;
+  mediaUrls?: string[];
   dryRun: boolean;
 }> {
   const action = payload.dryRun ? "Prepared" : "Sent";
@@ -773,6 +781,10 @@ function buildInternalSourceReplyToolResult(payload: {
         ? { sourceReplyDeliveryMode: payload.sourceReplyDeliveryMode }
         : {}),
       ...(payload.sourceReplySink ? { sourceReplySink: payload.sourceReplySink } : {}),
+      sourceReply: payload.sourceReply,
+      ...(payload.message ? { message: payload.message } : {}),
+      ...(payload.mediaUrl ? { mediaUrl: payload.mediaUrl } : {}),
+      ...(payload.mediaUrls?.length ? { mediaUrls: payload.mediaUrls } : {}),
       dryRun: payload.dryRun,
     },
   };


### PR DESCRIPTION
## Summary

- Preserve structured internal WebChat source-reply details on `message` tool results while keeping the model-facing tool output summarized.
- Restore `sourceReply`, `message`, `mediaUrl`, and `mediaUrls` in `toolResult.details` so chat history/mirroring can render the visible reply exactly once.
- Add regression coverage for the summarized tool output plus retained source-reply details.

Fixes #86347.

## Verification

- `node scripts/run-vitest.mjs src/infra/outbound/message-action-runner.send-validation.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "node scripts/run-vitest.mjs src/infra/outbound/message-action-runner.send-validation.test.ts"`

## Real Behavior Proof

Behavior addressed: WebChat `message` tool replies disappeared because the summarized tool result dropped structured `sourceReply` details.

Real environment tested: `CodexClaw-tui-latest` with the local fix branch in dev/watch mode.

Exact steps or command run after this patch: Sent WebChat prompts that caused Codex to reply via the `message` tool.

Evidence after fix: Transcript showed `message` tool call, summarized tool result, then a `delivery-mirror` assistant message.

Observed result after fix: Assistant replies rendered in WebChat without needing a second prompt or refresh, and no duplicate assistant replies appeared.
