### PR TITLE
fix: stop repeated heartbeat response loops

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2477,6 +2477,7 @@ export async function runEmbeddedAttempt(
         }
         return Promise.allSettled(promises).then(() => undefined);
       };
+      let heartbeatResponseTerminated = false;
       abortSessionForYield = () => {
         yieldAbortSettled = abortActiveSession();
       };
@@ -3279,6 +3280,16 @@ export async function runEmbeddedAttempt(
           onAssistantMessageStart: params.onAssistantMessageStart,
           onExecutionPhase: params.onExecutionPhase,
           onAgentEvent: params.onAgentEvent,
+          onHeartbeatToolResponse:
+            params.trigger === "heartbeat"
+              ? () => {
+                  if (heartbeatResponseTerminated) {
+                    return;
+                  }
+                  heartbeatResponseTerminated = true;
+                  void abortActiveSession();
+                }
+              : undefined,
           terminalLifecyclePhase: params.deferTerminalLifecycleEnd ? "finishing" : "end",
           onBeforeLifecycleTerminal: () => {
             // Clear embedded-run activity before emitting terminal lifecycle events so
@@ -4242,6 +4253,9 @@ export async function runEmbeddedAttempt(
                 await persistSessionsYieldContextMessage(activeSession, yieldMessage);
               }
             });
+          } else if (heartbeatResponseTerminated && isRunnerAbortError(err)) {
+            aborted = false;
+            await sessionLockController.waitForSessionEvents(activeSession);
           } else if (isMidTurnPrecheckSignal(err)) {
             await sessionLockController.waitForSessionEvents(activeSession);
             await sessionLockController.withSessionWriteLock(() => {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -1143,7 +1143,11 @@ export async function handleToolExecutionEnd(
   if (!isToolError && toolName === HEARTBEAT_RESPONSE_TOOL_NAME) {
     const response = normalizeHeartbeatToolResponse(result?.details);
     if (response) {
+      const isFirstHeartbeatResponse = ctx.state.heartbeatToolResponse === undefined;
       ctx.state.heartbeatToolResponse = response;
+      if (isFirstHeartbeatResponse) {
+        void ctx.params.onHeartbeatToolResponse?.(response);
+      }
     }
   }
 

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -198,6 +198,7 @@ type ToolHandlerParams = Pick<
   | "onBlockReplyFlush"
   | "onAgentEvent"
   | "onExecutionPhase"
+  | "onHeartbeatToolResponse"
   | "onToolResult"
   | "sessionKey"
   | "sessionId"

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
+import { HEARTBEAT_RESPONSE_TOOL_NAME } from "../auto-reply/heartbeat-tool-response.js";
 import * as agentEvents from "../infra/agent-events.js";
 import {
   THINKING_TAG_CASES,
@@ -1216,6 +1217,63 @@ describe("subscribeEmbeddedPiSession", () => {
       phase: "end",
       livenessState: "working",
       replayInvalid: true,
+    });
+  });
+
+  it("notifies the runner once when a heartbeat response tool result is recorded", async () => {
+    const { session, emit } = createStubSessionHarness();
+    const onHeartbeatToolResponse = vi.fn();
+    const subscription = subscribeEmbeddedPiSession({
+      session,
+      runId: "run-heartbeat-terminal",
+      sessionKey: "agent:main:main",
+      onHeartbeatToolResponse,
+    });
+
+    const result = {
+      details: {
+        status: "recorded",
+        outcome: "no_change",
+        notify: false,
+        summary: "Nothing needs attention.",
+      },
+    };
+    emitToolRun({
+      emit,
+      toolName: HEARTBEAT_RESPONSE_TOOL_NAME,
+      toolCallId: "heartbeat-1",
+      args: {
+        outcome: "no_change",
+        notify: false,
+        summary: "Nothing needs attention.",
+      },
+      isError: false,
+      result,
+    });
+    emitToolRun({
+      emit,
+      toolName: HEARTBEAT_RESPONSE_TOOL_NAME,
+      toolCallId: "heartbeat-2",
+      args: {
+        outcome: "no_change",
+        notify: false,
+        summary: "Nothing needs attention.",
+      },
+      isError: false,
+      result,
+    });
+    await flushBlockReplyCallbacks();
+
+    expect(subscription.getHeartbeatToolResponse()).toEqual({
+      outcome: "no_change",
+      notify: false,
+      summary: "Nothing needs attention.",
+    });
+    expect(onHeartbeatToolResponse).toHaveBeenCalledTimes(1);
+    expect(onHeartbeatToolResponse).toHaveBeenCalledWith({
+      outcome: "no_change",
+      notify: false,
+      summary: "Nothing needs attention.",
     });
   });
 });

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -3,6 +3,7 @@ import type {
   PartialReplyPayload,
   SourceReplyDeliveryMode,
 } from "../auto-reply/get-reply-options.types.js";
+import type { HeartbeatToolResponse } from "../auto-reply/heartbeat-tool-response.js";
 import type { ReplyPayload } from "../auto-reply/reply-payload.js";
 import type { ReasoningLevel, ThinkLevel, VerboseLevel } from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -56,6 +57,7 @@ export type SubscribeEmbeddedPiSessionParams = {
     data: Record<string, unknown>;
     sessionKey?: string;
   }) => void | Promise<void>;
+  onHeartbeatToolResponse?: (response: HeartbeatToolResponse) => void | Promise<void>;
   terminalLifecyclePhase?: "end" | "finishing";
   /** Best-effort hook invoked immediately before the terminal lifecycle event is emitted. */
   onBeforeLifecycleTerminal?: () => void | Promise<void>;

--- a/src/agents/tools/heartbeat-response-tool.test.ts
+++ b/src/agents/tools/heartbeat-response-tool.test.ts
@@ -53,6 +53,24 @@ describe("createHeartbeatResponseTool", () => {
     expect(details.summary).toBe("Nothing needs attention.");
   });
 
+  it("rejects repeated heartbeat responses from the same tool instance", async () => {
+    const tool = createHeartbeatResponseTool();
+
+    await tool.execute("call-1", {
+      outcome: "no_change",
+      notify: false,
+      summary: "Nothing needs attention.",
+    });
+
+    await expect(
+      tool.execute("call-2", {
+        outcome: "no_change",
+        notify: false,
+        summary: "Nothing needs attention.",
+      }),
+    ).rejects.toThrow("heartbeat_respond already recorded");
+  });
+
   it("accepts notification text and optional scheduling metadata", async () => {
     const tool = createHeartbeatResponseTool();
 

--- a/src/agents/tools/heartbeat-response-tool.ts
+++ b/src/agents/tools/heartbeat-response-tool.ts
@@ -36,6 +36,7 @@ function readRequiredBoolean(params: Record<string, unknown>, key: string): bool
 }
 
 export function createHeartbeatResponseTool(): AnyAgentTool {
+  let recorded = false;
   return {
     label: "Heartbeat",
     name: HEARTBEAT_RESPONSE_TOOL_NAME,
@@ -54,6 +55,10 @@ export function createHeartbeatResponseTool(): AnyAgentTool {
           "Invalid heartbeat response. Provide outcome, notify, and non-empty summary.",
         );
       }
+      if (recorded) {
+        throw new ToolInputError("heartbeat_respond already recorded for this turn");
+      }
+      recorded = true;
       return jsonResult({
         status: "recorded",
         ...response,


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Prevents a heartbeat turn from continuing to issue repeated `heartbeat_respond` calls after a valid response has already been recorded.

Why does this matter now?

- Issue #86324 reports a main-session heartbeat turn that repeated `heartbeat_respond` 810 times and burned very large token/cache-read volume without useful user-visible work.

What is the intended outcome?

- A valid `heartbeat_respond` records the heartbeat outcome once and terminates the heartbeat-triggered model turn.
- A second call to the same heartbeat response tool instance is rejected as already recorded.

What is intentionally out of scope?

- Changing default heartbeat session routing or moving heartbeat work out of the main session.
- Adding new heartbeat configuration knobs.

What does success look like?

- Silent `notify=false` and visible `notify=true` heartbeat responses still resolve normally, while repeated response-tool loops stop after the first valid response.

What should reviewers focus on?

- Whether aborting the active session after a heartbeat response is recorded preserves the structured heartbeat payload and avoids reporting the turn as interrupted.

## Linked context

Which issue does this close?

Closes #86324

Which issues, PRs, or discussions are related?

Related #86324

Was this requested by a maintainer or owner?

Autonomous OpenClaw P1 repair work approved by Uday for `openclaw/openclaw` P1 issues.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: repeated `heartbeat_respond` loop inside a heartbeat turn.
- Real environment tested: local macOS checkout from `openclaw/openclaw`, branch `fix/86324-heartbeat-respond-loop`, Node v25.9.0, pnpm v11.2.2.
- Exact steps or command run after this patch:

```bash
node --import tsx -e 'import { createHeartbeatResponseTool } from "./src/agents/tools/heartbeat-response-tool.ts"; const tool = createHeartbeatResponseTool(); const first = await tool.execute("heartbeat-1", { outcome: "no_change", notify: false, summary: "Heartbeat check complete: git clean, daily memory exists, no async tasks pending." }); console.log("first heartbeat_respond status=" + first.details.status + " outcome=" + first.details.outcome + " notify=" + first.details.notify); try { await tool.execute("heartbeat-2", { outcome: "no_change", notify: false, summary: "Heartbeat check complete: git clean, daily memory exists, no async tasks pending." }); console.log("second heartbeat_respond unexpectedly recorded"); process.exitCode = 1; } catch (err) { console.log("second heartbeat_respond rejected=" + String(err instanceof Error ? err.message : err)); }'
```

- Evidence after fix: copied terminal output from the local OpenClaw code-path probe:

```text
first heartbeat_respond status=recorded outcome=no_change notify=false
second heartbeat_respond rejected=heartbeat_respond already recorded for this turn
```

- Observed result after fix: the first heartbeat response records the structured no-change result, and the immediate repeated response is rejected with the per-turn guard instead of recording another response.
- What was not tested: a live provider/model reproduction of the original 810-call incident was not available.
- Proof limitations or environment constraints: this console probe exercises the OpenClaw heartbeat response tool path directly; it does not reproduce the unavailable production transcript loop with the original provider/model. Default Clawpatch provider review also failed locally with OpenAI Codex `401 Unauthorized`, so mock-provider Clawpatch review/report was used as a deterministic fallback and found 0 findings.
- Before evidence: before the implementation, the same second `heartbeat_respond` call recorded another response instead of being rejected.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/agents/tools/heartbeat-response-tool.test.ts`
- `node scripts/run-vitest.mjs src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts`
- `node scripts/run-vitest.mjs src/infra/heartbeat-runner.tool-response.test.ts`
- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt-trajectory-status.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/heartbeat-filter.test.ts`
- `node scripts/run-vitest.mjs src/agents/tools/heartbeat-response-tool.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts src/infra/heartbeat-runner.tool-response.test.ts src/agents/pi-embedded-runner/run/attempt-trajectory-status.test.ts src/auto-reply/heartbeat-filter.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:test:src`
- `git diff --check`
- `/Users/miya/.openclaw/bin/clawpatch doctor --root /Users/miya/Desktop/openclaw-issue-86324`
- `/Users/miya/.openclaw/bin/clawpatch map --root /Users/miya/Desktop/openclaw-issue-86324`
- `/Users/miya/.openclaw/bin/clawpatch review --root /Users/miya/Desktop/openclaw-issue-86324 --limit 3 --jobs 1`
- `/Users/miya/.openclaw/bin/clawpatch review --root /Users/miya/Desktop/openclaw-issue-86324 --limit 3 --jobs 1 --provider mock`
- `/Users/miya/.openclaw/bin/clawpatch report --root /Users/miya/Desktop/openclaw-issue-86324`

What regression coverage was added or updated?

- Added coverage that a heartbeat response tool instance rejects a second `heartbeat_respond` call in the same turn.
- Added coverage that the embedded subscriber records the heartbeat payload and invokes the terminal response callback only once.

What failed before this fix, if known?

- The repeated-response test failed because the second call resolved as another recorded response.
- The subscriber callback test failed because no terminal callback was invoked.

If no test was added, why not?

- Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes, for heartbeat turns that call `heartbeat_respond`: the response is now terminal for that heartbeat turn.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes, tool execution behavior changes narrowly for the heartbeat response tool.

What is the highest-risk area?

- Aborting the active session after the heartbeat response could accidentally classify the heartbeat turn as interrupted or lose the structured heartbeat payload.

How is that risk mitigated?

- The runner only enables terminal abort behavior for `trigger === "heartbeat"`.
- The prompt catch path clears the abort state for this terminal heartbeat-response abort.
- Existing heartbeat runner/tool-response tests and trajectory-status tests still pass.

## Current review state

What is the next action?

- CI and maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

- CI results.
- Optional maintainer follow-up for the default Clawpatch provider auth failure in this local environment.

Which bot or reviewer comments were addressed?

- No PR bot/reviewer comments yet.

AI-assisted: yes, implemented by Codex/Vector.