### PR TITLE
fix(exec): hide unavailable durable approval actions

### DIFF
--- a/apps/macos/Sources/OpenClaw/ExecApprovals.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovals.swift
@@ -84,7 +84,7 @@ enum ExecAsk: String, CaseIterable, Codable, Identifiable {
     }
 }
 
-enum ExecApprovalDecision: String, Codable {
+enum ExecApprovalDecision: String, Codable, Equatable {
     case allowOnce = "allow-once"
     case allowAlways = "allow-always"
     case deny

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsGatewayPrompter.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsGatewayPrompter.swift
@@ -70,7 +70,9 @@ final class ExecApprovalsGatewayPrompter {
                     timeoutMs: 10000)
                 return
             }
-            let decision = ExecApprovalsPromptPresenter.prompt(request.request)
+            guard let decision = ExecApprovalsPromptPresenter.prompt(request.request) else {
+                return
+            }
             try await GatewayConnection.shared.requestVoid(
                 method: .execApprovalResolve,
                 params: [

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -60,9 +60,9 @@ struct ExecApprovalPromptRequest: Codable {
         self.agentId = try container.decodeIfPresent(String.self, forKey: .agentId)
         self.resolvedPath = try container.decodeIfPresent(String.self, forKey: .resolvedPath)
         self.sessionKey = try container.decodeIfPresent(String.self, forKey: .sessionKey)
-        let decodedDecisions = try container.decodeIfPresent(
+        let decodedDecisions = (try? container.decodeIfPresent(
             [DecodedExecApprovalDecision].self,
-            forKey: .allowedDecisions) ?? []
+            forKey: .allowedDecisions)) ?? []
         self.allowedDecisions = decodedDecisions.compactMap(\.decision)
     }
 
@@ -297,7 +297,7 @@ final class ExecApprovalsPromptServer {
 
 enum ExecApprovalsPromptPresenter {
     @MainActor
-    static func prompt(_ request: ExecApprovalPromptRequest) -> ExecApprovalDecision {
+    static func prompt(_ request: ExecApprovalPromptRequest) -> ExecApprovalDecision? {
         NSApp.activate(ignoringOtherApps: true)
         let alert = NSAlert()
         alert.alertStyle = .warning
@@ -316,11 +316,19 @@ enum ExecApprovalsPromptPresenter {
             alert.buttons[denyIndex].hasDestructiveAction = true
         }
 
-        let selectedIndex = alert.runModal().rawValue
+        return self.decision(forModalResponse: alert.runModal(), decisions: decisions)
+    }
+
+    static func decision(
+        forModalResponse response: NSApplication.ModalResponse,
+        decisions: [ExecApprovalDecision]) -> ExecApprovalDecision?
+    {
+        let selectedIndex = response.rawValue
             - NSApplication.ModalResponse.alertFirstButtonReturn.rawValue
-        return decisions.indices.contains(selectedIndex)
-            ? decisions[selectedIndex]
-            : .deny
+        if decisions.indices.contains(selectedIndex) {
+            return decisions[selectedIndex]
+        }
+        return decisions.contains(.deny) ? .deny : nil
     }
 
     static func allowedPromptDecisions(_ request: ExecApprovalPromptRequest) -> [ExecApprovalDecision] {
@@ -481,7 +489,7 @@ private enum ExecHostExecutor {
         case .allow:
             break
         case .requiresPrompt:
-            let decision = ExecApprovalsPromptPresenter.prompt(
+            guard let decision = ExecApprovalsPromptPresenter.prompt(
                 ExecApprovalPromptRequest(
                     command: context.displayCommand,
                     cwd: request.cwd,
@@ -493,6 +501,12 @@ private enum ExecHostExecutor {
                     sessionKey: request.sessionKey,
                     allowedDecisions: ExecApprovalPromptRequest.allowedDecisions(
                         forAsk: context.ask.rawValue)))
+            else {
+                return self.errorResponse(
+                    code: "UNAVAILABLE",
+                    message: "SYSTEM_RUN_DENIED: approval prompt closed without decision",
+                    reason: "approval-cancelled")
+            }
 
             let followupDecision: ExecApprovalDecision
             switch decision {
@@ -748,7 +762,7 @@ private final class ExecApprovalsSocketServer: @unchecked Sendable {
     private let logger = Logger(subsystem: "ai.openclaw", category: "exec-approvals.socket")
     private let socketPath: String
     private let token: String
-    private let onPrompt: @Sendable (ExecApprovalPromptRequest) async -> ExecApprovalDecision
+    private let onPrompt: @Sendable (ExecApprovalPromptRequest) async -> ExecApprovalDecision?
     private let onExec: @Sendable (ExecHostRequest) async -> ExecHostResponse
     private var socketFD: Int32 = -1
     private var acceptTask: Task<Void, Never>?
@@ -757,7 +771,7 @@ private final class ExecApprovalsSocketServer: @unchecked Sendable {
     init(
         socketPath: String,
         token: String,
-        onPrompt: @escaping @Sendable (ExecApprovalPromptRequest) async -> ExecApprovalDecision,
+        onPrompt: @escaping @Sendable (ExecApprovalPromptRequest) async -> ExecApprovalDecision?,
         onExec: @escaping @Sendable (ExecHostRequest) async -> ExecHostResponse)
     {
         self.socketPath = socketPath
@@ -899,7 +913,7 @@ private final class ExecApprovalsSocketServer: @unchecked Sendable {
                     try self.sendApprovalResponse(handle: handle, id: request.id, decision: .deny)
                     return
                 }
-                let decision = await self.onPrompt(request.request)
+                guard let decision = await self.onPrompt(request.request) else { return }
                 try self.sendApprovalResponse(handle: handle, id: request.id, decision: decision)
                 return
             }

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -67,6 +67,9 @@ struct ExecApprovalPromptRequest: Codable {
     }
 
     static func allowedDecisions(forAsk ask: String?) -> [ExecApprovalDecision] {
+        // Older payloads did not carry ask/allowedDecisions. Preserve their durable
+        // approval option; explicit ask=always and allowedDecisions payloads are the
+        // policy-carrying shapes that remove it.
         ask == ExecAsk.always.rawValue
             ? [.allowOnce, .deny]
             : [.allowOnce, .allowAlways, .deny]

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -14,6 +14,76 @@ struct ExecApprovalPromptRequest: Codable {
     var agentId: String?
     var resolvedPath: String?
     var sessionKey: String?
+    var allowedDecisions: [ExecApprovalDecision]?
+
+    init(
+        command: String,
+        cwd: String? = nil,
+        host: String? = nil,
+        security: String? = nil,
+        ask: String? = nil,
+        agentId: String? = nil,
+        resolvedPath: String? = nil,
+        sessionKey: String? = nil,
+        allowedDecisions: [ExecApprovalDecision]? = nil)
+    {
+        self.command = command
+        self.cwd = cwd
+        self.host = host
+        self.security = security
+        self.ask = ask
+        self.agentId = agentId
+        self.resolvedPath = resolvedPath
+        self.sessionKey = sessionKey
+        self.allowedDecisions = allowedDecisions
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case command
+        case cwd
+        case host
+        case security
+        case ask
+        case agentId
+        case resolvedPath
+        case sessionKey
+        case allowedDecisions
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.command = try container.decode(String.self, forKey: .command)
+        self.cwd = try container.decodeIfPresent(String.self, forKey: .cwd)
+        self.host = try container.decodeIfPresent(String.self, forKey: .host)
+        self.security = try container.decodeIfPresent(String.self, forKey: .security)
+        self.ask = try container.decodeIfPresent(String.self, forKey: .ask)
+        self.agentId = try container.decodeIfPresent(String.self, forKey: .agentId)
+        self.resolvedPath = try container.decodeIfPresent(String.self, forKey: .resolvedPath)
+        self.sessionKey = try container.decodeIfPresent(String.self, forKey: .sessionKey)
+        let decodedDecisions = try container.decodeIfPresent(
+            [DecodedExecApprovalDecision].self,
+            forKey: .allowedDecisions) ?? []
+        self.allowedDecisions = decodedDecisions.compactMap(\.decision)
+    }
+
+    static func allowedDecisions(forAsk ask: String?) -> [ExecApprovalDecision] {
+        ask == ExecAsk.always.rawValue
+            ? [.allowOnce, .deny]
+            : [.allowOnce, .allowAlways, .deny]
+    }
+}
+
+private struct DecodedExecApprovalDecision: Decodable {
+    var decision: ExecApprovalDecision?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        guard let raw = try? container.decode(String.self) else {
+            self.decision = nil
+            return
+        }
+        self.decision = ExecApprovalDecision(rawValue: raw)
+    }
 }
 
 private struct ExecApprovalSocketRequest: Codable {
@@ -235,20 +305,39 @@ enum ExecApprovalsPromptPresenter {
         alert.informativeText = "Review the command details before allowing."
         alert.accessoryView = self.buildAccessoryView(request)
 
-        alert.addButton(withTitle: "Allow Once")
-        alert.addButton(withTitle: "Always Allow")
-        alert.addButton(withTitle: "Don't Allow")
-        if #available(macOS 11.0, *), alert.buttons.indices.contains(2) {
-            alert.buttons[2].hasDestructiveAction = true
+        let decisions = self.allowedPromptDecisions(request)
+        for decision in decisions {
+            alert.addButton(withTitle: self.buttonTitle(for: decision))
+        }
+        if #available(macOS 11.0, *),
+           let denyIndex = decisions.firstIndex(of: .deny),
+           alert.buttons.indices.contains(denyIndex)
+        {
+            alert.buttons[denyIndex].hasDestructiveAction = true
         }
 
-        switch alert.runModal() {
-        case .alertFirstButtonReturn:
-            return .allowOnce
-        case .alertSecondButtonReturn:
-            return .allowAlways
-        default:
-            return .deny
+        let selectedIndex = alert.runModal().rawValue
+            - NSApplication.ModalResponse.alertFirstButtonReturn.rawValue
+        return decisions.indices.contains(selectedIndex)
+            ? decisions[selectedIndex]
+            : .deny
+    }
+
+    static func allowedPromptDecisions(_ request: ExecApprovalPromptRequest) -> [ExecApprovalDecision] {
+        if let allowedDecisions = request.allowedDecisions, !allowedDecisions.isEmpty {
+            return allowedDecisions
+        }
+        return ExecApprovalPromptRequest.allowedDecisions(forAsk: request.ask)
+    }
+
+    private static func buttonTitle(for decision: ExecApprovalDecision) -> String {
+        switch decision {
+        case .allowOnce:
+            "Allow Once"
+        case .allowAlways:
+            "Always Allow"
+        case .deny:
+            "Don't Allow"
         }
     }
 
@@ -401,7 +490,9 @@ private enum ExecHostExecutor {
                     ask: context.ask.rawValue,
                     agentId: context.agentId,
                     resolvedPath: context.resolution?.resolvedPath,
-                    sessionKey: request.sessionKey))
+                    sessionKey: request.sessionKey,
+                    allowedDecisions: ExecApprovalPromptRequest.allowedDecisions(
+                        forAsk: context.ask.rawValue)))
 
             let followupDecision: ExecApprovalDecision
             switch decision {

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -764,7 +764,9 @@ actor MacNodeRuntime {
                         ask: context.ask.rawValue,
                         agentId: context.agentId,
                         resolvedPath: context.resolution?.resolvedPath,
-                        sessionKey: context.sessionKey))
+                        sessionKey: context.sessionKey,
+                        allowedDecisions: ExecApprovalPromptRequest.allowedDecisions(
+                            forAsk: context.ask.rawValue)))
             }
             switch decision {
             case .deny:

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -754,7 +754,7 @@ actor MacNodeRuntime {
         }
 
         if requiresAsk, !approvedByAsk {
-            let decision = await MainActor.run {
+            let promptDecision = await MainActor.run {
                 ExecApprovalsPromptPresenter.prompt(
                     ExecApprovalPromptRequest(
                         command: context.displayCommand,
@@ -767,6 +767,23 @@ actor MacNodeRuntime {
                         sessionKey: context.sessionKey,
                         allowedDecisions: ExecApprovalPromptRequest.allowedDecisions(
                             forAsk: context.ask.rawValue)))
+            }
+            guard let decision = promptDecision else {
+                await self.emitExecEvent(
+                    "exec.denied",
+                    payload: ExecEventPayload(
+                        sessionKey: context.sessionKey,
+                        runId: context.runId,
+                        host: "node",
+                        command: context.displayCommand,
+                        reason: "approval-cancelled"))
+                return ExecApprovalOutcome(
+                    approvedByAsk: approvedByAsk,
+                    persistAllowlist: persistAllowlist,
+                    response: Self.errorResponse(
+                        req,
+                        code: .unavailable,
+                        message: "SYSTEM_RUN_DENIED: approval prompt closed without decision"))
             }
             switch decision {
             case .deny:

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalPromptLayoutTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalPromptLayoutTests.swift
@@ -5,6 +5,66 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct ExecApprovalPromptLayoutTests {
+    @Test func `allowed decisions omit durable approval even when ask allows it`() {
+        let decisions = ExecApprovalsPromptPresenter.allowedPromptDecisions(
+            ExecApprovalPromptRequest(
+                command: "/bin/sh -lc pwd",
+                cwd: "/Users/example/projects/openclaw",
+                host: "node",
+                security: "full",
+                ask: "on-miss",
+                agentId: "main",
+                resolvedPath: "/bin/sh",
+                sessionKey: "session-1",
+                allowedDecisions: [.allowOnce, .deny]))
+
+        #expect(decisions == [.allowOnce, .deny])
+    }
+
+    @Test func `ask always prompts omit durable approval when decisions are omitted`() {
+        let decisions = ExecApprovalsPromptPresenter.allowedPromptDecisions(
+            ExecApprovalPromptRequest(
+                command: "/bin/sh -lc pwd",
+                cwd: "/Users/example/projects/openclaw",
+                host: "node",
+                security: "full",
+                ask: "always",
+                agentId: "main",
+                resolvedPath: "/bin/sh",
+                sessionKey: "session-1"))
+
+        #expect(decisions == [.allowOnce, .deny])
+    }
+
+    @Test func `ask on miss prompts keep durable approval when decisions are omitted`() {
+        let decisions = ExecApprovalsPromptPresenter.allowedPromptDecisions(
+            ExecApprovalPromptRequest(
+                command: "/bin/sh -lc pwd",
+                cwd: "/Users/example/projects/openclaw",
+                host: "node",
+                security: "full",
+                ask: "on-miss",
+                agentId: "main",
+                resolvedPath: "/bin/sh",
+                sessionKey: "session-1"))
+
+        #expect(decisions == [.allowOnce, .allowAlways, .deny])
+    }
+
+    @Test func `approval request decodes valid allowed decisions only`() throws {
+        let data = """
+            {
+              "command": "/bin/sh -lc pwd",
+              "ask": "on-miss",
+              "allowedDecisions": ["allow-once", "bad", "deny", 3]
+            }
+            """.data(using: .utf8)!
+
+        let request = try JSONDecoder().decode(ExecApprovalPromptRequest.self, from: data)
+
+        #expect(request.allowedDecisions == [.allowOnce, .deny])
+    }
+
     @Test func `accessory view reserves nonzero alert layout space`() {
         let accessory = ExecApprovalsPromptPresenter.buildAccessoryView(
             ExecApprovalPromptRequest(

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalPromptLayoutTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalPromptLayoutTests.swift
@@ -65,6 +65,34 @@ struct ExecApprovalPromptLayoutTests {
         #expect(request.allowedDecisions == [.allowOnce, .deny])
     }
 
+    @Test func `approval request falls back when allowed decisions has wrong shape`() throws {
+        let data = """
+            {
+              "command": "/bin/sh -lc pwd",
+              "ask": "always",
+              "allowedDecisions": "allow-once"
+            }
+            """.data(using: .utf8)!
+
+        let request = try JSONDecoder().decode(ExecApprovalPromptRequest.self, from: data)
+
+        #expect(ExecApprovalsPromptPresenter.allowedPromptDecisions(request) == [.allowOnce, .deny])
+    }
+
+    @Test func `modal close does not synthesize deny when deny is unavailable`() {
+        let closeResponse = NSApplication.ModalResponse(rawValue: 0)
+
+        let withoutDeny = ExecApprovalsPromptPresenter.decision(
+            forModalResponse: closeResponse,
+            decisions: [.allowOnce])
+        let withDeny = ExecApprovalsPromptPresenter.decision(
+            forModalResponse: closeResponse,
+            decisions: [.allowOnce, .deny])
+
+        #expect(withoutDeny == nil)
+        #expect(withDeny == .deny)
+    }
+
     @Test func `accessory view reserves nonzero alert layout space`() {
         let accessory = ExecApprovalsPromptPresenter.buildAccessoryView(
             ExecApprovalPromptRequest(

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalPromptLayoutTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalPromptLayoutTests.swift
@@ -51,6 +51,35 @@ struct ExecApprovalPromptLayoutTests {
         #expect(decisions == [.allowOnce, .allowAlways, .deny])
     }
 
+    @Test func `legacy prompts keep durable approval when policy fields are omitted`() {
+        let decisions = ExecApprovalsPromptPresenter.allowedPromptDecisions(
+            ExecApprovalPromptRequest(
+                command: "/bin/sh -lc pwd",
+                cwd: "/Users/example/projects/openclaw",
+                host: "node",
+                security: "full",
+                agentId: "main",
+                resolvedPath: "/bin/sh",
+                sessionKey: "session-1"))
+
+        #expect(decisions == [.allowOnce, .allowAlways, .deny])
+    }
+
+    @Test func `unknown ask prompts keep legacy durable approval when decisions are omitted`() {
+        let decisions = ExecApprovalsPromptPresenter.allowedPromptDecisions(
+            ExecApprovalPromptRequest(
+                command: "/bin/sh -lc pwd",
+                cwd: "/Users/example/projects/openclaw",
+                host: "node",
+                security: "full",
+                ask: "unexpected",
+                agentId: "main",
+                resolvedPath: "/bin/sh",
+                sessionKey: "session-1"))
+
+        #expect(decisions == [.allowOnce, .allowAlways, .deny])
+    }
+
     @Test func `approval request decodes valid allowed decisions only`() throws {
         let data = """
             {

--- a/src/infra/jsonl-socket.test.ts
+++ b/src/infra/jsonl-socket.test.ts
@@ -125,4 +125,34 @@ describe.runIf(process.platform !== "win32")("requestJsonlSocket", () => {
       ).resolves.toBeNull();
     });
   });
+
+  it("returns null when the socket closes without an accepted response", async () => {
+    await withTempDir({ prefix: "openclaw-jsonl-socket-" }, async (dir) => {
+      const socketPath = path.join(dir, "socket.sock");
+      const server = net.createServer((socket) => {
+        socket.on("data", () => {
+          socket.destroy();
+        });
+      });
+      const listening = await listenOnSocket(server, socketPath);
+      if (!listening) {
+        return;
+      }
+
+      try {
+        const startMs = Date.now();
+        const result = await requestJsonlSocket({
+          socketPath,
+          requestLine: "{}",
+          timeoutMs: 250,
+          accept: () => undefined,
+        });
+
+        expect(result).toBeNull();
+        expect(Date.now() - startMs).toBeLessThan(100);
+      } finally {
+        server.close();
+      }
+    });
+  });
 });

--- a/src/infra/jsonl-socket.ts
+++ b/src/infra/jsonl-socket.ts
@@ -21,6 +21,7 @@ export async function requestJsonlSocket<T>(params: {
         return;
       }
       settled = true;
+      clearNodeTimeout(timer);
       try {
         client.destroy();
       } catch {
@@ -32,6 +33,8 @@ export async function requestJsonlSocket<T>(params: {
     const timer = setNodeTimeout(() => finish(null), timeoutMs);
 
     client.on("error", () => finish(null));
+    client.on("end", () => finish(null));
+    client.on("close", () => finish(null));
     client.connect(socketPath, () => {
       client.end(`${requestLine}\n`);
     });
@@ -51,7 +54,6 @@ export async function requestJsonlSocket<T>(params: {
           if (result === undefined) {
             continue;
           }
-          clearNodeTimeout(timer);
           finish(result);
           return;
         } catch {

--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -22,15 +22,16 @@
     "activity.title",
     "activity.toolCallId",
     "activity.visibleCount",
+    "execApproval.allowAlwaysUnavailable",
     "subtitles.activity",
     "tabs.activity"
   ],
-  "generatedAt": "2026-05-25T03:52:18.827Z",
+  "generatedAt": "2026-05-27T02:52:46.711Z",
   "locale": "ar",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e760668abcba0b56572e1f4772f221e2716a7f39bc7f91669fd3c3db0210f593",
-  "totalKeys": 1154,
+  "sourceHash": "24e6aff2cfb534faf3b6a9c96ccafee1470519c2f4498c07841072435a0565ea",
+  "totalKeys": 1155,
   "translatedKeys": 1130,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -22,15 +22,16 @@
     "activity.title",
     "activity.toolCallId",
     "activity.visibleCount",
+    "execApproval.allowAlwaysUnavailable",
     "subtitles.activity",
     "tabs.activity"
   ],
-  "generatedAt": "2026-05-25T03:52:17.364Z",
+  "generatedAt": "2026-05-27T02:52:45.045Z",
   "locale": "de",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e760668abcba0b56572e1f4772f221e2716a7f39bc7f91669fd3c3db0210f593",
-  "totalKeys": 1154,
+  "sourceHash": "24e6aff2cfb534faf3b6a9c96ccafee1470519c2f4498c07841072435a0565ea",
+  "totalKeys": 1155,
   "translatedKeys": 1130,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -23,15 +23,16 @@
     "activity.title",
     "activity.toolCallId",
     "activity.visibleCount",
+    "execApproval.allowAlwaysUnavailable",
     "subtitles.activity",
     "tabs.activity"
   ],
-  "generatedAt": "2026-05-25T03:52:17.650Z",
+  "generatedAt": "2026-05-27T02:52:45.377Z",
   "locale": "es",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e760668abcba0b56572e1f4772f221e2716a7f39bc7f91669fd3c3db0210f593",
-  "totalKeys": 1154,
+  "sourceHash": "24e6aff2cfb534faf3b6a9c96ccafee1470519c2f4498c07841072435a0565ea",
+  "totalKeys": 1155,
   "translatedKeys": 1129,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -22,15 +22,16 @@
     "activity.title",
     "activity.toolCallId",
     "activity.visibleCount",
+    "execApproval.allowAlwaysUnavailable",
     "subtitles.activity",
     "tabs.activity"
   ],
-  "generatedAt": "2026-05-25T03:52:21.461Z",
+  "generatedAt": "2026-05-27T02:52:49.716Z",
   "locale": "fa",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e760668abcba0b56572e1f4772f221e2716a7f39bc7f91669fd3c3db0210f593",
-  "totalKeys": 1154,
+  "sourceHash": "24e6aff2cfb534faf3b6a9c96ccafee1470519c2f4498c07841072435a0565ea",
+  "totalKeys": 1155,
   "translatedKeys": 1130,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -22,15 +22,16 @@
     "activity.title",
     "activity.toolCallId",
     "activity.visibleCount",
+    "execApproval.allowAlwaysUnavailable",
     "subtitles.activity",
     "tabs.activity"
   ],
-  "generatedAt": "2026-05-25T03:52:18.527Z",
+  "generatedAt": "2026-05-27T02:52:46.368Z",
   "locale": "fr",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e760668abcba0b56572e1f4772f221e2716a7f39bc7f91669fd3c3db0210f593",
-  "totalKeys": 1154,
+  "sourceHash": "24e6aff2cfb534faf3b6a9c96ccafee1470519c2f4498c07841072435a0565ea",
+  "totalKeys": 1155,
   "translatedKeys": 1130,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -22,15 +22,16 @@
     "activity.title",
     "activity.toolCallId",
     "activity.visibleCount",
+    "execApproval.allowAlwaysUnavailable",
     "subtitles.activity",
     "tabs.activity"
   ],
-  "generatedAt": "2026-05-25T03:52:20.016Z",
+  "generatedAt": "2026-05-27T02:52:48.039Z",
   "locale": "id",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e760668abcba0b56572e1f4772f221e2716a7f39bc7f91669fd3c3db0210f593",
-  "totalKeys": 1154,
+  "sourceHash": "24e6aff2cfb534faf3b6a9c96ccafee1470519c2f4498c07841072435a0565ea",
+  "totalKeys": 1155,
   "translatedKeys": 1130,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -22,15 +22,16 @@
     "activity.title",
     "activity.toolCallId",
     "activity.visibleCount",
+    "execApproval.allowAlwaysUnavailable",
     "subtitles.activity",
     "tabs.activity"
   ],
-  "generatedAt": "2026-05-25T03:52:19.127Z",
+  "generatedAt": "2026-05-27T02:52:47.052Z",
   "locale": "it",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e760668abcba0b56572e1f4772f221e2716a7f39bc7f91669fd3c3db0210f593",
-  "totalKeys": 1154,
+  "sourceHash": "24e6aff2cfb534faf3b6a9c96ccafee1470519c2f4498c07841072435a0565ea",
+  "totalKeys": 1155,
   "translatedKeys": 1130,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -22,15 +22,16 @@
     "activity.title",
     "activity.toolCallId",
     "activity.visibleCount",
+    "execApproval.allowAlwaysUnavailable",
     "subtitles.activity",
     "tabs.activity"
   ],
-  "generatedAt": "2026-05-25T03:52:17.937Z",
+  "generatedAt": "2026-05-27T02:52:45.696Z",
   "locale": "ja-JP",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e760668abcba0b56572e1f4772f221e2716a7f39bc7f91669fd3c3db0210f593",
-  "totalKeys": 1154,
+  "sourceHash": "24e6aff2cfb534faf3b6a9c96ccafee1470519c2f4498c07841072435a0565ea",
+  "totalKeys": 1155,
   "translatedKeys": 1130,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -22,15 +22,16 @@
     "activity.title",
     "activity.toolCallId",
     "activity.visibleCount",
+    "execApproval.allowAlwaysUnavailable",
     "subtitles.activity",
     "tabs.activity"
   ],
-  "generatedAt": "2026-05-25T03:52:18.232Z",
+  "generatedAt": "2026-05-27T02:52:46.039Z",
   "locale": "ko",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e760668abcba0b56572e1f4772f221e2716a7f39bc7f91669fd3c3db0210f593",
-  "totalKeys": 1154,
+  "sourceHash": "24e6aff2cfb534faf3b6a9c96ccafee1470519c2f4498c07841072435a0565ea",
+  "totalKeys": 1155,
   "translatedKeys": 1130,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -22,15 +22,16 @@
     "activity.title",
     "activity.toolCallId",
     "activity.visibleCount",
+    "execApproval.allowAlwaysUnavailable",
     "subtitles.activity",
     "tabs.activity"
   ],
-  "generatedAt": "2026-05-25T03:52:21.149Z",
+  "generatedAt": "2026-05-27T02:52:49.375Z",
   "locale": "nl",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e760668abcba0b56572e1f4772f221e2716a7f39bc7f91669fd3c3db0210f593",
-  "totalKeys": 1154,
+  "sourceHash": "24e6aff2cfb534faf3b6a9c96ccafee1470519c2f4498c07841072435a0565ea",
+  "totalKeys": 1155,
   "translatedKeys": 1130,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -22,15 +22,16 @@
     "activity.title",
     "activity.toolCallId",
     "activity.visibleCount",
+    "execApproval.allowAlwaysUnavailable",
     "subtitles.activity",
     "tabs.activity"
   ],
-  "generatedAt": "2026-05-25T03:52:20.307Z",
+  "generatedAt": "2026-05-27T02:52:48.381Z",
   "locale": "pl",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e760668abcba0b56572e1f4772f221e2716a7f39bc7f91669fd3c3db0210f593",
-  "totalKeys": 1154,
+  "sourceHash": "24e6aff2cfb534faf3b6a9c96ccafee1470519c2f4498c07841072435a0565ea",
+  "totalKeys": 1155,
   "translatedKeys": 1130,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -23,15 +23,16 @@
     "activity.title",
     "activity.toolCallId",
     "activity.visibleCount",
+    "execApproval.allowAlwaysUnavailable",
     "subtitles.activity",
     "tabs.activity"
   ],
-  "generatedAt": "2026-05-25T03:52:17.073Z",
+  "generatedAt": "2026-05-27T02:52:44.710Z",
   "locale": "pt-BR",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e760668abcba0b56572e1f4772f221e2716a7f39bc7f91669fd3c3db0210f593",
-  "totalKeys": 1154,
+  "sourceHash": "24e6aff2cfb534faf3b6a9c96ccafee1470519c2f4498c07841072435a0565ea",
+  "totalKeys": 1155,
   "translatedKeys": 1129,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -22,15 +22,16 @@
     "activity.title",
     "activity.toolCallId",
     "activity.visibleCount",
+    "execApproval.allowAlwaysUnavailable",
     "subtitles.activity",
     "tabs.activity"
   ],
-  "generatedAt": "2026-05-25T03:52:20.585Z",
+  "generatedAt": "2026-05-27T02:52:48.711Z",
   "locale": "th",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e760668abcba0b56572e1f4772f221e2716a7f39bc7f91669fd3c3db0210f593",
-  "totalKeys": 1154,
+  "sourceHash": "24e6aff2cfb534faf3b6a9c96ccafee1470519c2f4498c07841072435a0565ea",
+  "totalKeys": 1155,
   "translatedKeys": 1130,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -22,15 +22,16 @@
     "activity.title",
     "activity.toolCallId",
     "activity.visibleCount",
+    "execApproval.allowAlwaysUnavailable",
     "subtitles.activity",
     "tabs.activity"
   ],
-  "generatedAt": "2026-05-25T03:52:19.431Z",
+  "generatedAt": "2026-05-27T02:52:47.383Z",
   "locale": "tr",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e760668abcba0b56572e1f4772f221e2716a7f39bc7f91669fd3c3db0210f593",
-  "totalKeys": 1154,
+  "sourceHash": "24e6aff2cfb534faf3b6a9c96ccafee1470519c2f4498c07841072435a0565ea",
+  "totalKeys": 1155,
   "translatedKeys": 1130,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -22,15 +22,16 @@
     "activity.title",
     "activity.toolCallId",
     "activity.visibleCount",
+    "execApproval.allowAlwaysUnavailable",
     "subtitles.activity",
     "tabs.activity"
   ],
-  "generatedAt": "2026-05-25T03:52:19.720Z",
+  "generatedAt": "2026-05-27T02:52:47.714Z",
   "locale": "uk",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e760668abcba0b56572e1f4772f221e2716a7f39bc7f91669fd3c3db0210f593",
-  "totalKeys": 1154,
+  "sourceHash": "24e6aff2cfb534faf3b6a9c96ccafee1470519c2f4498c07841072435a0565ea",
+  "totalKeys": 1155,
   "translatedKeys": 1130,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -22,15 +22,16 @@
     "activity.title",
     "activity.toolCallId",
     "activity.visibleCount",
+    "execApproval.allowAlwaysUnavailable",
     "subtitles.activity",
     "tabs.activity"
   ],
-  "generatedAt": "2026-05-25T03:52:20.870Z",
+  "generatedAt": "2026-05-27T02:52:49.048Z",
   "locale": "vi",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e760668abcba0b56572e1f4772f221e2716a7f39bc7f91669fd3c3db0210f593",
-  "totalKeys": 1154,
+  "sourceHash": "24e6aff2cfb534faf3b6a9c96ccafee1470519c2f4498c07841072435a0565ea",
+  "totalKeys": 1155,
   "translatedKeys": 1130,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -25,15 +25,16 @@
     "activity.title",
     "activity.toolCallId",
     "activity.visibleCount",
+    "execApproval.allowAlwaysUnavailable",
     "subtitles.activity",
     "tabs.activity"
   ],
-  "generatedAt": "2026-05-25T03:52:16.379Z",
+  "generatedAt": "2026-05-27T02:52:44.017Z",
   "locale": "zh-CN",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e760668abcba0b56572e1f4772f221e2716a7f39bc7f91669fd3c3db0210f593",
-  "totalKeys": 1154,
+  "sourceHash": "24e6aff2cfb534faf3b6a9c96ccafee1470519c2f4498c07841072435a0565ea",
+  "totalKeys": 1155,
   "translatedKeys": 1127,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -23,15 +23,16 @@
     "activity.title",
     "activity.toolCallId",
     "activity.visibleCount",
+    "execApproval.allowAlwaysUnavailable",
     "subtitles.activity",
     "tabs.activity"
   ],
-  "generatedAt": "2026-05-25T03:52:16.776Z",
+  "generatedAt": "2026-05-27T02:52:44.379Z",
   "locale": "zh-TW",
   "model": "claude-opus-4-7",
   "provider": "anthropic",
-  "sourceHash": "e760668abcba0b56572e1f4772f221e2716a7f39bc7f91669fd3c3db0210f593",
-  "totalKeys": 1154,
+  "sourceHash": "24e6aff2cfb534faf3b6a9c96ccafee1470519c2f4498c07841072435a0565ea",
+  "totalKeys": 1155,
   "translatedKeys": 1129,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -361,6 +361,8 @@ export const ar: TranslationMap = {
     pending: "{count} قيد الانتظار",
     allowOnce: "السماح مرة واحدة",
     alwaysAllow: "السماح دائمًا",
+    allowAlwaysUnavailable:
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
     deny: "رفض",
     labels: {
       host: "المضيف",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -365,6 +365,8 @@ export const de: TranslationMap = {
     pending: "{count} pending",
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
+    allowAlwaysUnavailable:
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -360,6 +360,8 @@ export const en: TranslationMap = {
     pending: "{count} pending",
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
+    allowAlwaysUnavailable:
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -362,6 +362,8 @@ export const es: TranslationMap = {
     pending: "{count} pending",
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
+    allowAlwaysUnavailable:
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -363,6 +363,8 @@ export const fa: TranslationMap = {
     pending: "{count} در انتظار",
     allowOnce: "یک‌بار مجاز کن",
     alwaysAllow: "همیشه مجاز کن",
+    allowAlwaysUnavailable:
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
     deny: "رد کردن",
     labels: {
       host: "میزبان",

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -364,6 +364,8 @@ export const fr: TranslationMap = {
     pending: "{count} pending",
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
+    allowAlwaysUnavailable:
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -362,6 +362,8 @@ export const id: TranslationMap = {
     pending: "{count} pending",
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
+    allowAlwaysUnavailable:
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -364,6 +364,8 @@ export const it: TranslationMap = {
     pending: "{count} in sospeso",
     allowOnce: "Consenti una volta",
     alwaysAllow: "Consenti sempre",
+    allowAlwaysUnavailable:
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
     deny: "Nega",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -365,6 +365,8 @@ export const ja_JP: TranslationMap = {
     pending: "{count} pending",
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
+    allowAlwaysUnavailable:
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -361,6 +361,8 @@ export const ko: TranslationMap = {
     pending: "{count} pending",
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
+    allowAlwaysUnavailable:
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -364,6 +364,8 @@ export const nl: TranslationMap = {
     pending: "{count} in behandeling",
     allowOnce: "Eenmalig toestaan",
     alwaysAllow: "Altijd toestaan",
+    allowAlwaysUnavailable:
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
     deny: "Weigeren",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -363,6 +363,8 @@ export const pl: TranslationMap = {
     pending: "{count} pending",
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
+    allowAlwaysUnavailable:
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -362,6 +362,8 @@ export const pt_BR: TranslationMap = {
     pending: "{count} pending",
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
+    allowAlwaysUnavailable:
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -360,6 +360,8 @@ export const th: TranslationMap = {
     pending: "{count} pending",
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
+    allowAlwaysUnavailable:
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -364,6 +364,8 @@ export const tr: TranslationMap = {
     pending: "{count} pending",
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
+    allowAlwaysUnavailable:
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -363,6 +363,8 @@ export const uk: TranslationMap = {
     pending: "{count} pending",
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
+    allowAlwaysUnavailable:
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -362,6 +362,8 @@ export const vi: TranslationMap = {
     pending: "{count} đang chờ",
     allowOnce: "Cho phép một lần",
     alwaysAllow: "Luôn cho phép",
+    allowAlwaysUnavailable:
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
     deny: "Từ chối",
     labels: {
       host: "Máy chủ",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -360,6 +360,8 @@ export const zh_CN: TranslationMap = {
     pending: "{count} 个待处理",
     allowOnce: "允许一次",
     alwaysAllow: "始终允许",
+    allowAlwaysUnavailable:
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
     deny: "拒绝",
     labels: {
       host: "主机",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -360,6 +360,8 @@ export const zh_TW: TranslationMap = {
     pending: "{count} pending",
     allowOnce: "Allow once",
     alwaysAllow: "Always allow",
+    allowAlwaysUnavailable:
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
     deny: "Deny",
     labels: {
       host: "Host",

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -4441,6 +4441,12 @@ td.data-table-key-col {
   color: var(--danger);
 }
 
+.exec-approval-warning {
+  margin-top: 10px;
+  font-size: 13px;
+  color: var(--warning, #b7791f);
+}
+
 .exec-approval-actions {
   margin-top: 16px;
   display: flex;

--- a/ui/src/ui/controllers/exec-approval.test.ts
+++ b/ui/src/ui/controllers/exec-approval.test.ts
@@ -59,6 +59,20 @@ describe("parseExecApprovalRequested", () => {
     expect(result?.kind).toBe("exec");
     expect(result?.request.command).toBe("rm -rf /");
   });
+
+  it("preserves allowed approval decisions", () => {
+    const result = parseExecApprovalRequested({
+      id: "exec-1",
+      request: {
+        command: "pwd",
+        allowedDecisions: ["allow-once", "bad", "deny", "allow-always"],
+      },
+      createdAtMs: 1000,
+      expiresAtMs: 2000,
+    });
+
+    expect(result?.request.allowedDecisions).toEqual(["allow-once", "deny", "allow-always"]);
+  });
 });
 
 describe("parsePluginApprovalRequested", () => {

--- a/ui/src/ui/controllers/exec-approval.ts
+++ b/ui/src/ui/controllers/exec-approval.ts
@@ -13,7 +13,10 @@ export type ExecApprovalRequestPayload = {
     startIndex: number;
     endIndex: number;
   }[];
+  allowedDecisions?: readonly ExecApprovalDecision[];
 };
+
+export type ExecApprovalDecision = "allow-once" | "allow-always" | "deny";
 
 export type ExecApprovalRequest = {
   id: string;
@@ -88,6 +91,17 @@ function parseCommandSpans(
   return spans.length > 0 ? spans : undefined;
 }
 
+function parseAllowedDecisions(value: unknown): ExecApprovalDecision[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const decisions = value.filter(
+    (decision): decision is ExecApprovalDecision =>
+      decision === "allow-once" || decision === "allow-always" || decision === "deny",
+  );
+  return decisions.length > 0 ? decisions : undefined;
+}
+
 export function parseExecApprovalRequested(payload: unknown): ExecApprovalRequest | null {
   if (!isRecord(payload)) {
     return null;
@@ -119,6 +133,7 @@ export function parseExecApprovalRequested(payload: unknown): ExecApprovalReques
       resolvedPath: typeof request.resolvedPath === "string" ? request.resolvedPath : null,
       sessionKey: typeof request.sessionKey === "string" ? request.sessionKey : null,
       commandSpans: parseCommandSpans(request.commandSpans, command.length),
+      allowedDecisions: parseAllowedDecisions(request.allowedDecisions),
     },
     createdAtMs,
     expiresAtMs,
@@ -171,6 +186,7 @@ export function parsePluginApprovalRequested(payload: unknown): ExecApprovalRequ
       command: title,
       agentId: typeof request.agentId === "string" ? request.agentId : null,
       sessionKey: typeof request.sessionKey === "string" ? request.sessionKey : null,
+      allowedDecisions: parseAllowedDecisions(request.allowedDecisions),
     },
     pluginTitle: title,
     pluginDescription: description,

--- a/ui/src/ui/views/exec-approval.test.ts
+++ b/ui/src/ui/views/exec-approval.test.ts
@@ -139,7 +139,54 @@ describe("approval and confirmation modals", () => {
     ).toEqual(["Allow once", "Always allow", "Deny"]);
   });
 
-  it("denies exec approval on Escape", async () => {
+  it("hides unavailable exec approval decisions", async () => {
+    const request = createExecRequest();
+    request.request.ask = "always";
+    request.request.allowedDecisions = ["allow-once", "deny"];
+
+    render(renderExecApprovalPrompt(createExecState({ execApprovalQueue: [request] })), container);
+
+    await getRenderedDialog();
+
+    expect(
+      Array.from(container.querySelectorAll(".exec-approval-actions button")).map((button) =>
+        button.textContent?.trim(),
+      ),
+    ).toEqual(["Allow once", "Deny"]);
+  });
+
+  it("falls back to ask when exec approval decisions are omitted", async () => {
+    const request = createExecRequest();
+    request.request.ask = "always";
+    request.request.allowedDecisions = undefined;
+
+    render(renderExecApprovalPrompt(createExecState({ execApprovalQueue: [request] })), container);
+
+    await getRenderedDialog();
+
+    expect(
+      Array.from(container.querySelectorAll(".exec-approval-actions button")).map((button) =>
+        button.textContent?.trim(),
+      ),
+    ).toEqual(["Allow once", "Deny"]);
+  });
+
+  it("keeps durable exec approval when the request allows it", async () => {
+    const request = createExecRequest();
+    request.request.allowedDecisions = ["allow-once", "allow-always", "deny"];
+
+    render(renderExecApprovalPrompt(createExecState({ execApprovalQueue: [request] })), container);
+
+    await getRenderedDialog();
+
+    expect(
+      Array.from(container.querySelectorAll(".exec-approval-actions button")).map((button) =>
+        button.textContent?.trim(),
+      ),
+    ).toEqual(["Allow once", "Always allow", "Deny"]);
+  });
+
+  it("maps Escape to exec denial when approval is idle", async () => {
     const handleExecApprovalDecision = vi.fn(async () => undefined);
     render(renderExecApprovalPrompt(createExecState({ handleExecApprovalDecision })), container);
 
@@ -148,6 +195,38 @@ describe("approval and confirmation modals", () => {
     dispatchEscape(dialog);
 
     expect(handleExecApprovalDecision).toHaveBeenCalledWith("deny");
+  });
+
+  it("does not dispatch an extra exec decision from Escape while busy", async () => {
+    const handleExecApprovalDecision = vi.fn(async () => undefined);
+    render(
+      renderExecApprovalPrompt(
+        createExecState({ execApprovalBusy: true, handleExecApprovalDecision }),
+      ),
+      container,
+    );
+
+    const { dialog } = await getRenderedDialog();
+    dispatchEscape(dialog);
+
+    expect(handleExecApprovalDecision).not.toHaveBeenCalled();
+  });
+
+  it("does not dispatch denied from Escape when denial is unavailable", async () => {
+    const request = createExecRequest();
+    request.request.allowedDecisions = ["allow-once"];
+    const handleExecApprovalDecision = vi.fn(async () => undefined);
+    render(
+      renderExecApprovalPrompt(
+        createExecState({ execApprovalQueue: [request], handleExecApprovalDecision }),
+      ),
+      container,
+    );
+
+    const { dialog } = await getRenderedDialog();
+    dispatchEscape(dialog);
+
+    expect(handleExecApprovalDecision).not.toHaveBeenCalled();
   });
 
   it("renders exec approval chrome from the active locale", async () => {

--- a/ui/src/ui/views/exec-approval.test.ts
+++ b/ui/src/ui/views/exec-approval.test.ts
@@ -153,6 +153,9 @@ describe("approval and confirmation modals", () => {
         button.textContent?.trim(),
       ),
     ).toEqual(["Allow once", "Deny"]);
+    expect(container.querySelector(".exec-approval-warning")?.textContent?.trim()).toBe(
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
+    );
   });
 
   it("falls back to ask when exec approval decisions are omitted", async () => {
@@ -184,6 +187,32 @@ describe("approval and confirmation modals", () => {
         button.textContent?.trim(),
       ),
     ).toEqual(["Allow once", "Always allow", "Deny"]);
+    expect(container.querySelector(".exec-approval-warning")).toBeNull();
+  });
+
+  it("does not show exec policy warning for restricted plugin approvals", async () => {
+    const request: ExecApprovalRequest = {
+      id: "plugin-approval-1",
+      kind: "plugin",
+      request: {
+        command: "Plugin approval",
+        allowedDecisions: ["allow-once", "deny"],
+      },
+      pluginTitle: "Plugin approval",
+      createdAtMs: Date.now() - 1_000,
+      expiresAtMs: Date.now() + 60_000,
+    };
+
+    render(renderExecApprovalPrompt(createExecState({ execApprovalQueue: [request] })), container);
+
+    await getRenderedDialog();
+
+    expect(
+      Array.from(container.querySelectorAll(".exec-approval-actions button")).map((button) =>
+        button.textContent?.trim(),
+      ),
+    ).toEqual(["Allow once", "Deny"]);
+    expect(container.querySelector(".exec-approval-warning")).toBeNull();
   });
 
   it("maps Escape to exec denial when approval is idle", async () => {

--- a/ui/src/ui/views/exec-approval.ts
+++ b/ui/src/ui/views/exec-approval.ts
@@ -4,9 +4,16 @@ import { t } from "../../i18n/index.ts";
 import type { AppViewState } from "../app-view-state.ts";
 import "../components/modal-dialog.ts";
 import type {
+  ExecApprovalDecision,
   ExecApprovalRequest,
   ExecApprovalRequestPayload,
 } from "../controllers/exec-approval.ts";
+
+const DEFAULT_EXEC_APPROVAL_DECISIONS = [
+  "allow-once",
+  "allow-always",
+  "deny",
+] as const satisfies readonly ExecApprovalDecision[];
 
 function formatRemaining(ms: number): string {
   const remaining = Math.max(0, ms);
@@ -107,6 +114,38 @@ ${active.pluginDescription}</pre
   `;
 }
 
+function approvalDecisionLabel(decision: ExecApprovalDecision): string {
+  switch (decision) {
+    case "allow-once":
+      return t("execApproval.allowOnce");
+    case "allow-always":
+      return t("execApproval.alwaysAllow");
+    case "deny":
+      return t("execApproval.deny");
+  }
+}
+
+function approvalDecisionClass(decision: ExecApprovalDecision): string {
+  switch (decision) {
+    case "allow-once":
+      return "btn primary";
+    case "allow-always":
+      return "btn";
+    case "deny":
+      return "btn danger";
+  }
+}
+
+function resolveApprovalDecisions(active: ExecApprovalRequest): readonly ExecApprovalDecision[] {
+  if (active.request.allowedDecisions?.length) {
+    return active.request.allowedDecisions;
+  }
+  if (active.kind === "exec" && active.request.ask === "always") {
+    return ["allow-once", "deny"];
+  }
+  return DEFAULT_EXEC_APPROVAL_DECISIONS;
+}
+
 export function renderExecApprovalPrompt(state: AppViewState) {
   const active = state.execApprovalQueue[0];
   if (!active) {
@@ -125,8 +164,9 @@ export function renderExecApprovalPrompt(state: AppViewState) {
     : t("execApproval.execApprovalNeeded");
   const titleId = "exec-approval-title";
   const descriptionId = "exec-approval-description";
+  const decisions = resolveApprovalDecisions(active);
   const handleCancel = () => {
-    if (!state.execApprovalBusy) {
+    if (!state.execApprovalBusy && decisions.includes("deny")) {
       void state.handleExecApprovalDecision("deny");
     }
   };
@@ -149,27 +189,17 @@ export function renderExecApprovalPrompt(state: AppViewState) {
           ? html`<div class="exec-approval-error">${state.execApprovalError}</div>`
           : nothing}
         <div class="exec-approval-actions">
-          <button
-            class="btn primary"
-            ?disabled=${state.execApprovalBusy}
-            @click=${() => state.handleExecApprovalDecision("allow-once")}
-          >
-            ${t("execApproval.allowOnce")}
-          </button>
-          <button
-            class="btn"
-            ?disabled=${state.execApprovalBusy}
-            @click=${() => state.handleExecApprovalDecision("allow-always")}
-          >
-            ${t("execApproval.alwaysAllow")}
-          </button>
-          <button
-            class="btn danger"
-            ?disabled=${state.execApprovalBusy}
-            @click=${() => state.handleExecApprovalDecision("deny")}
-          >
-            ${t("execApproval.deny")}
-          </button>
+          ${decisions.map(
+            (decision) => html`
+              <button
+                class=${approvalDecisionClass(decision)}
+                ?disabled=${state.execApprovalBusy}
+                @click=${() => state.handleExecApprovalDecision(decision)}
+              >
+                ${approvalDecisionLabel(decision)}
+              </button>
+            `,
+          )}
         </div>
       </div>
     </openclaw-modal-dialog>

--- a/ui/src/ui/views/exec-approval.ts
+++ b/ui/src/ui/views/exec-approval.ts
@@ -123,6 +123,7 @@ function approvalDecisionLabel(decision: ExecApprovalDecision): string {
     case "deny":
       return t("execApproval.deny");
   }
+  return t("execApproval.deny");
 }
 
 function approvalDecisionClass(decision: ExecApprovalDecision): string {
@@ -134,6 +135,7 @@ function approvalDecisionClass(decision: ExecApprovalDecision): string {
     case "deny":
       return "btn danger";
   }
+  return "btn danger";
 }
 
 function resolveApprovalDecisions(active: ExecApprovalRequest): readonly ExecApprovalDecision[] {

--- a/ui/src/ui/views/exec-approval.ts
+++ b/ui/src/ui/views/exec-approval.ts
@@ -148,6 +148,15 @@ function resolveApprovalDecisions(active: ExecApprovalRequest): readonly ExecApp
   return DEFAULT_EXEC_APPROVAL_DECISIONS;
 }
 
+function renderUnavailableDecisionWarning(
+  active: ExecApprovalRequest,
+  decisions: readonly ExecApprovalDecision[],
+) {
+  return active.kind !== "exec" || decisions.includes("allow-always")
+    ? nothing
+    : html`<div class="exec-approval-warning">${t("execApproval.allowAlwaysUnavailable")}</div>`;
+}
+
 export function renderExecApprovalPrompt(state: AppViewState) {
   const active = state.execApprovalQueue[0];
   if (!active) {
@@ -187,6 +196,7 @@ export function renderExecApprovalPrompt(state: AppViewState) {
             : nothing}
         </div>
         ${isPlugin ? renderPluginBody(active) : renderExecBody(request)}
+        ${renderUnavailableDecisionWarning(active, decisions)}
         ${state.execApprovalError
           ? html`<div class="exec-approval-error">${state.execApprovalError}</div>`
           : nothing}


### PR DESCRIPTION
## Summary
- teach the macOS native exec approval prompt to consume `allowedDecisions` directly, with `ask` only as a legacy fallback
- pass `allowedDecisions` through the Control UI approval parser and render only allowed dashboard actions
- keep durable approvals available for `on-miss` approvals and legacy payloads that do not include an allowed decision list
- fall back safely when native `allowedDecisions` is malformed instead of dropping the prompt
- keep modal cancel from sending `deny` when denial is not an allowed decision

## Verification
- `node scripts/run-vitest.mjs ui/src/ui/controllers/exec-approval.test.ts ui/src/ui/views/exec-approval.test.ts ui/src/ui/views/exec-approval.browser.test.ts`
- `swift test --package-path apps/macos --filter ExecApprovalPromptLayoutTests`
- `swift test --package-path apps/macos --filter ExecApprovalsSocketAuthTests --filter ExecApprovalsGatewayPrompterTests`
- `git diff --check 4beadbf9519ef45d2b9cf74dbb60c4b75af3a48e..HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD` clean: no accepted/actionable findings
- Rebuilt BAD and GOOD mac apps from current `origin/main` base `4beadbf951` with real signing identity `jessesCert`

## Real behavior proof
Behavior addressed: `Ask mode: always` approvals no longer offer durable `Always Allow` in the native macOS prompt or the Control UI approval modal.
Real environment tested: local macOS A/B apps, signed with `jessesCert`; BAD from current `main`, GOOD from this PR.
Exact steps or command run after this patch: triggered `system.run` for `/bin/sh -lc pwd` through the local Gateway/native app approval path.
Evidence after fix: BAD showed `Allow Once`, `Always Allow`, and `Don't Allow`; GOOD showed only `Don't Allow` and `Allow Once` in the native prompt. Focused Control UI tests prove `allowedDecisions: ["allow-once", "deny"]` renders only `Allow once` and `Deny`. Focused Swift tests prove malformed native `allowedDecisions` falls back and native modal close does not synthesize `deny` when it was not rendered.
Observed result after fix: GOOD no longer exposes durable approval for `ask: always`.
What was not tested: broad full-suite CI; GitHub checks had not reported yet after the latest push.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted local agent transcript</summary>

```text
Scope:
- PR #86359: fix unavailable durable exec approval actions.
- Branch: jm/fix-macos-ask-always-approval.
- Primary surfaces:
  - macOS native exec approval prompt.
  - Control UI exec/plugin approval prompt.
  - Gateway approval-decision contract.
  - JSONL socket close handling for native prompt cancellation.
  - Control UI warning text and i18n fallback files.

Redaction note:
- This transcript is a curated local work log, not a raw chat export.
- Personal/casual wording, local machine details, auth/session details, raw tool output, prompts, secrets, browser state, and unrelated turns were omitted.
- User input is summarized as maintainer direction and verification feedback.
- Multiple related local sessions were reviewed. Duplicate subagent reviews and unrelated branch-review turns were not included directly; only the parts that explain how this PR was discovered, scoped, tested, and fixed are summarized.

Origin context before this PR:
- Before PR #86359 existed, a separate heavy review session investigated PR #84172, the broader command-authorization rewrite.
- The maintainer asked that review to look hard at old exec-approval behavior, especially approval fallbacks, durable "allow always" persistence, native macOS parity, and behavior that had grown from earlier security patching.
- That review found several real approval-contract issues in the broader branch. Two were especially relevant to this PR:
  - request-specific approval choices were being modeled as `allowedDecisions`;
  - native/macOS approval paths still had to prove they respected the same approval-decision contract as the gateway.
- One origin sub-review explicitly checked exec approvals, allow-always persistence, approval fallback behavior, node-host/gateway/system.run/native macOS parity, UI/native `allowedDecisions`, and `requiresInteractiveApproval`.
- That sub-review found a native macOS gap: caller-supplied `approved` or `approvalDecision` fields could bypass an interactive-only approval path even when the prompt hid `allow-always`.
- The same origin review showed the intended server contract:
  - `ask=always` resolves to `["allow-once", "deny"]`;
  - other approval modes can include `["allow-once", "allow-always", "deny"]`;
  - the gateway rejects unavailable decisions such as `allow-always` when the effective policy requires approval every time.
- This was the context that led to carving out PR #86359 as a narrow shipped-behavior fix: make the approval UIs show only the choices the request/server contract allows, instead of waiting for the much larger PR #84172.

Initial goal:
- Review PR #86359 and explain what it changed.
- Find related issues and PRs that had raised similar approval-policy problems.
- Fix review findings.
- Build and test bad/good local macOS app variants for A/B behavior checks.
- Use the dashboard/manual test flow so the maintainer could personally verify behavior.

How the issue was found:
- The earlier discovery work started in the PR #84172 review, where the maintainer was searching for approval behavior that should be removed or tightened.
- That review showed `allowedDecisions` was the approval UI contract, not just a helper for one client.
- PR #86359 was then created to fix the smaller shipped mismatch exposed by that work.
- The later PR #86359 review compared the PR description against current shipped behavior and the gateway approval contract.
- Current-main and PR source showed a mismatch:
  - the gateway already computed `allowedDecisions`;
  - the gateway already rejected decisions outside that list;
  - approval consumers could still render choices such as `Always allow` without using that list.
- The earlier PR #84172 work showed the intended shape more clearly:
  - approval requests carry `allowedDecisions`;
  - UI clients should render from the allowed list;
  - server-side resolution remains the final enforcement point.
- This is what turned the review from "macOS hides one button based on ask" into "all approval clients should respect the request's allowed-decision contract."
- The maintainer then pushed on whether this was only macOS or also the dashboard, which led to explicitly including the Control UI in the fix.

Related session candidates reviewed:
- Origin heavy review session for PR #84172:
  - predates PR #86359 and contains the broader approval-policy investigation that led to carving this fix out.
  - covered command authorization, exact-command durable fallback removal, `allow-always` persistence, fallback behavior, native macOS parity, UI/native `allowedDecisions`, and `requiresInteractiveApproval`.
- Origin sub-review for PR #84172:
  - focused on the native macOS approval boundary and confirmed the request-specific decision list was the contract approval clients should respect.
  - reported that native macOS could still bypass interactive-only approval through caller-supplied approval flags, showing that native parity was still an open approval-boundary concern.
- Earlier fallback review around the same branch:
  - found that "Allow Always unavailable" and "interactive approval required" should not be conflated.
  - helped separate the durable-button visibility question from timeout/fallback denial behavior.
- Main PR review and implementation session:
  - contained the initial PR review, related-issue search, local A/B testing, fixes, review loops, and final push.
- Broader command-authorization review sessions:
  - showed where the `allowedDecisions` contract was being introduced and how sibling approval clients were expected to use it.
- Related PR/issue discovery sessions:
  - identified the broader normalized command authorization PR as overlapping context, but not a reason to close this standalone shipped bugfix.
- Local testing sessions:
  - captured the bad/good app setup, dashboard testing, repeated rebuilds from latest main, and manual prompt behavior checks.
- Cold-review sessions:
  - independently checked the final approval/socket behavior, but were mostly excluded from the transcript body because they duplicated the same findings and validation targets.

Initial PR understanding:
- The PR aimed to hide the durable "Always allow" action when the effective exec approval policy requires approval every time.
- The expected `ask=always` choices were:
  - `Allow once`
  - `Deny`
- The expected durable-approval-capable choices remained:
  - `Allow once`
  - `Always allow`
  - `Deny`
- The gateway already computed and enforced allowed approval decisions. The bug was that one or more UI consumers could still show choices the gateway would reject.

Related-work review:
- The broader command authorization work was inspected as related context.
- That work had the same core concept: approval requests carry an `allowedDecisions` list, and UIs should render from that list.
- That context made it clear that `allowedDecisions` was not just a web UI helper. It was the protocol shape approval consumers should use when deciding which actions to show.
- The standalone PR remained justified because this was a shipped approval UI mismatch that could be fixed narrowly without waiting for the broader branch.
- The maintainer asked specifically whether anything already fixed the bug on latest main. Main still needed this fix for the shipped behavior.

Maintainer-driven manual testing:
- The maintainer requested a true A/B setup with separate bad and good macOS apps.
- Both apps were rebuilt from a current main base with a real signing identity so native permission prompts would behave realistically.
- The maintainer tested simple commands such as `pwd` from the local UI/dashboard flow.
- During A/B testing, the maintainer reported that prompts did not always appear as expected, the bad app behavior was confusing, and one flow appeared to flash an approval request and then disappear.
- The test setup was refreshed by pulling latest main and rebuilding both variants to confirm the bug was not just stale local state.
- The maintainer confirmed the dashboard path should be part of the real validation, not only the native app path.

Behavior clarified during review:
- This was not a command-specific rule. The same command can show different actions depending on the approval policy and request metadata.
- For `ask=always`, even a harmless command like `pwd` should not offer durable approval.
- For `ask=on-miss`, a command that misses the allowlist may legitimately offer durable approval.
- Plugin approval requests can also restrict decisions, but their reasons are not necessarily exec-policy reasons.
- The server remains the source of truth and rejects unavailable decisions even if a client tries to send them.

Main implementation work:
- macOS native prompt:
  - Decoded `allowedDecisions` from the approval request.
  - Filtered malformed decision values.
  - Rendered buttons from the explicit allowed-decision list when present.
  - Preserved fallback behavior for older/malformed payloads:
    - `ask=always` falls back to `Allow once` and `Deny`.
    - other/missing ask values preserve previous durable-approval behavior.
  - Mapped AppKit modal button indexes back through the same ordered decision list.
  - Avoided returning a hidden decision when a prompt closes and `deny` is not available.

- macOS native callers:
  - Passed ask-derived allowed decisions into local native prompt paths.
  - Treated prompt close without a decision as denial/unavailable, so commands do not run after an unresolved close.

- Control UI:
  - Parsed `allowedDecisions` from exec approval events.
  - Parsed `allowedDecisions` from plugin approval events.
  - Rendered only allowed buttons.
  - Preserved explicit decision order.
  - Fell back from missing/malformed data using the same ask-aware behavior.
  - Prevented Escape/cancel from sending `deny` when `deny` is not an available decision.

- JSONL socket handling:
  - Review found that native prompt close without a response could leave Node socket clients waiting for the full timeout.
  - The socket client was changed to settle on peer `end`/`close`.
  - Timeout cleanup was moved into the shared finish path so all outcomes clear the timer.
  - A focused regression test was added for close-without-accepted-response.

Maintainer-policy discussion:
- Review called out a policy choice around legacy/malformed payload fallback.
- Current behavior preserves compatibility:
  - missing/malformed `allowedDecisions` plus `ask=always` omits durable approval.
  - missing/malformed `allowedDecisions` plus missing/unknown/non-always ask preserves old durable-approval behavior.
- The maintainer asked for plain-English clarification of whether fallback exists and what it means.
- The conclusion was that this is an intentional compatibility fallback unless maintainers choose a stricter fail-closed policy.

GitHub review follow-up:
- A maintainer comment asked the Control UI to mirror channel-message behavior by explaining why "Allow Always" is unavailable.
- The existing channel copy was:
  "The effective approval policy requires approval every time, so Allow Always is unavailable."
- The Control UI was updated to show that warning for exec approvals when `allow-always` is absent.
- The warning was scoped away from plugin approvals because plugin restrictions can be request-scoped and unrelated to exec policy.
- Tests were added for:
  - restricted exec approval shows the warning.
  - unrestricted exec approval does not show the warning.
  - restricted plugin approval does not show the exec-policy warning.
- Adding the English i18n key triggered a review finding about generated locale drift.
- `ui:i18n:sync` was run and generated locale fallback/meta updates were committed.
- `ui:i18n:check` then passed.

Review findings fixed:
- Swift formatting issue on the original PR head.
- Native prompt initially deriving decisions from raw `ask` instead of the gateway decision contract.
- Native prompt close/cancel behavior producing or attempting hidden decisions.
- Control UI lint/return-shape issue in approval action rendering.
- JSONL socket timeout behavior after native close without a response.
- Control UI warning initially applying too broadly to plugin approvals.
- i18n generated file drift after adding the warning string.

Focused validation run after fixes:
- Vitest:
  - `src/infra/jsonl-socket.test.ts`
  - `src/infra/exec-host.test.ts`
  - `src/infra/exec-approvals-store.test.ts`
  - `ui/src/ui/controllers/exec-approval.test.ts`
  - `ui/src/ui/views/exec-approval.test.ts`
  - `ui/src/ui/views/exec-approval.browser.test.ts`
- Result:
  - 6 files passed.
  - 57 tests passed.

- Swift:
  - `ExecApprovalPromptLayoutTests`
  - Result: 7 tests passed.
  - Covered allowed decision lists, ask fallback, malformed allowed decisions, modal close behavior, and prompt layout.

- Swift:
  - `ExecApprovalsSocketAuthTests`
  - `ExecApprovalsGatewayPrompterTests`
  - Result: 12 tests passed.

- Control UI follow-up tests:
  - `ui/src/ui/controllers/exec-approval.test.ts`
  - `ui/src/ui/views/exec-approval.test.ts`
  - `ui/src/ui/views/exec-approval.browser.test.ts`
  - Result after warning work: 3 files passed, 27 tests passed.

- i18n:
  - `pnpm ui:i18n:check`
  - Result: clean for all configured locales with fallback entries updated.

- Lint/format:
  - `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ...`
  - Result: passed for touched UI files.
  - `git diff --check`
  - Result: passed.

Review process:
- Repeated review passes were run after each accepted fix.
- Independent cold review passes were run on the final approval/socket fix.
- A follow-up autoreview found the i18n sync gap; it was fixed.
- A follow-up autoreview found the plugin-warning scope bug; it was fixed.
- Final autoreview on the warning follow-up reported no accepted/actionable findings.

Pushed commits:
- `fix(macos): align ask always approval actions`
- `fix(macos): harden approval prompt decisions`
- `fix(ui): satisfy approval action lint`
- `fix(infra): settle jsonl sockets on close`
- `fix(ui): explain unavailable durable approvals`

Outcome:
- The PR branch was pushed to the live PR.
- The final pushed head included the macOS native fix, Control UI fix, JSONL socket close fix, dashboard warning, i18n generated updates, and focused tests.
- CI restarted on the final pushed head; no failures were reported at the time of handoff.
```

</details>
<!-- agent-transcript:end -->
