### PR TITLE
fix(ui): dismiss stale approval prompts

### DIFF
--- a/ui/src/ui/app.exec-approval.test.ts
+++ b/ui/src/ui/app.exec-approval.test.ts
@@ -1,0 +1,100 @@
+/* @vitest-environment jsdom */
+
+import { describe, expect, it, vi } from "vitest";
+
+type TestApproval = {
+  id: string;
+  kind: "exec";
+  title: string;
+  summary: string;
+  createdAtMs: number;
+  expiresAtMs: number;
+};
+
+type ExecApprovalApp = {
+  client: { request: ReturnType<typeof vi.fn> } | null;
+  execApprovalQueue: TestApproval[];
+  execApprovalBusy: boolean;
+  execApprovalError: string | null;
+};
+
+function createApproval(id: string): TestApproval {
+  return {
+    id,
+    kind: "exec",
+    title: "Approve command",
+    summary: "printf test",
+    createdAtMs: Date.now(),
+    expiresAtMs: Date.now() + 60_000,
+  };
+}
+
+async function runDecision(app: ExecApprovalApp, decision: "allow-once" | "allow-always" | "deny") {
+  const { OpenClawApp } = await import("./app.ts");
+  await OpenClawApp.prototype.handleExecApprovalDecision.call(app as never, decision);
+}
+
+describe("OpenClawApp exec approval decisions", () => {
+  it("dismisses stale approvals that the backend has already expired", async () => {
+    const request = vi.fn(async () => {
+      throw Object.assign(new Error("unknown or expired approval id"), {
+        details: { reason: "APPROVAL_NOT_FOUND" },
+      });
+    });
+    const app: ExecApprovalApp = {
+      client: { request },
+      execApprovalQueue: [createApproval("approval-1")],
+      execApprovalBusy: false,
+      execApprovalError: null,
+    };
+
+    await runDecision(app, "deny");
+
+    expect(request).toHaveBeenCalledWith("exec.approval.resolve", {
+      id: "approval-1",
+      decision: "deny",
+    });
+    expect(app.execApprovalQueue).toEqual([]);
+    expect(app.execApprovalError).toBeNull();
+    expect(app.execApprovalBusy).toBe(false);
+  });
+
+  it("dismisses stale approvals that were resolved from another surface", async () => {
+    const request = vi.fn(async () => {
+      throw Object.assign(new Error("approval already resolved"), {
+        details: { reason: "APPROVAL_ALREADY_RESOLVED" },
+      });
+    });
+    const app: ExecApprovalApp = {
+      client: { request },
+      execApprovalQueue: [createApproval("approval-2")],
+      execApprovalBusy: false,
+      execApprovalError: null,
+    };
+
+    await runDecision(app, "allow-once");
+
+    expect(app.execApprovalQueue).toEqual([]);
+    expect(app.execApprovalError).toBeNull();
+    expect(app.execApprovalBusy).toBe(false);
+  });
+
+  it("keeps the approval visible when resolve fails for a non-terminal reason", async () => {
+    const request = vi.fn(async () => {
+      throw new Error("gateway not connected");
+    });
+    const approval = createApproval("approval-3");
+    const app: ExecApprovalApp = {
+      client: { request },
+      execApprovalQueue: [approval],
+      execApprovalBusy: false,
+      execApprovalError: null,
+    };
+
+    await runDecision(app, "deny");
+
+    expect(app.execApprovalQueue).toEqual([approval]);
+    expect(app.execApprovalError).toBe("Approval failed: Error: gateway not connected");
+    expect(app.execApprovalBusy).toBe(false);
+  });
+});

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -146,6 +146,35 @@ declare global {
 const bootAssistantIdentity = normalizeAssistantIdentity({});
 const bootLocalUserIdentity = loadLocalUserIdentity();
 
+const TERMINAL_APPROVAL_RESOLVE_REASONS = new Set([
+  "APPROVAL_ALREADY_RESOLVED",
+  "APPROVAL_NOT_FOUND",
+]);
+
+function readApprovalResolveErrorReason(err: unknown): string | null {
+  if (!err || typeof err !== "object" || Array.isArray(err) || !("details" in err)) {
+    return null;
+  }
+  const details = err.details;
+  if (!details || typeof details !== "object" || Array.isArray(details) || !("reason" in details)) {
+    return null;
+  }
+  const reason = details.reason;
+  return typeof reason === "string" ? reason : null;
+}
+
+function isTerminalApprovalResolveError(err: unknown): boolean {
+  const reason = readApprovalResolveErrorReason(err);
+  if (reason && TERMINAL_APPROVAL_RESOLVE_REASONS.has(reason)) {
+    return true;
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return (
+    message.includes("unknown or expired approval id") ||
+    message.includes("approval already resolved")
+  );
+}
+
 function resolveOnboardingMode(): boolean {
   if (!window.location.search) {
     return false;
@@ -1228,6 +1257,11 @@ export class OpenClawApp extends LitElement {
       });
       this.execApprovalQueue = this.execApprovalQueue.filter((entry) => entry.id !== active.id);
     } catch (err) {
+      if (isTerminalApprovalResolveError(err)) {
+        this.execApprovalQueue = this.execApprovalQueue.filter((entry) => entry.id !== active.id);
+        this.execApprovalError = null;
+        return;
+      }
       this.execApprovalError = `Approval failed: ${String(err)}`;
     } finally {
       this.execApprovalBusy = false;


### PR DESCRIPTION
## Summary

- Dismiss Control UI approval prompts when the Gateway says the approval was already resolved or expired.
- Keep the prompt visible for non-terminal resolve failures, such as a disconnected Gateway.
- Add jsdom coverage for expired, already-resolved, and real failure cases.

## Verification

- `node scripts/run-vitest.mjs ui/src/ui/app.exec-approval.test.ts ui/src/ui/app-gateway.node.test.ts`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json --incremental false`
- `pnpm exec oxfmt --check --threads=1 ui/src/ui/app.ts ui/src/ui/app.exec-approval.test.ts`
- `git diff --check`

## Real behavior proof

Behavior addressed: stale approval prompts in the Control UI after the Gateway reports `APPROVAL_NOT_FOUND` or `APPROVAL_ALREADY_RESOLVED`.

Real environment tested: local OpenClaw UI test environment in a clean worktree.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs ui/src/ui/app.exec-approval.test.ts ui/src/ui/app-gateway.node.test.ts`.

Evidence after fix: the new tests simulate `unknown or expired approval id` and `approval already resolved`, then assert the active approval is removed and no error remains.

Observed result after fix: 2 test files passed, 54 tests passed.

What was not tested: manual browser clicking against a live stale modal; the behavior is covered with direct handler tests and existing gateway queue tests.
