### PR TITLE
fix(elevenlabs): accept voice and model as aliases for voiceId and modelId (#86180)

### DIFF
--- a/extensions/elevenlabs/speech-provider.test.ts
+++ b/extensions/elevenlabs/speech-provider.test.ts
@@ -73,6 +73,49 @@ describe("elevenlabs speech provider", () => {
     }
   });
 
+  it("accepts voice and model as aliases for voiceId and modelId in config", () => {
+    const provider = buildElevenLabsSpeechProvider();
+
+    const config = provider.resolveConfig?.({
+      cfg: {} as never,
+      timeoutMs: 30_000,
+      rawConfig: {
+        providers: {
+          elevenlabs: {
+            apiKey: "sk-test",
+            voice: "N2lVS1w4EtoT3dr4eOWO",
+            model: "eleven_v3",
+          },
+        },
+      },
+    });
+
+    expect(config?.voiceId).toBe("N2lVS1w4EtoT3dr4eOWO");
+    expect(config?.modelId).toBe("eleven_v3");
+  });
+
+  it("prefers voiceId over voice and modelId over model when both are present", () => {
+    const provider = buildElevenLabsSpeechProvider();
+
+    const config = provider.resolveConfig?.({
+      cfg: {} as never,
+      timeoutMs: 30_000,
+      rawConfig: {
+        providers: {
+          elevenlabs: {
+            voiceId: "preferred-voice",
+            voice: "fallback-voice",
+            modelId: "preferred-model",
+            model: "fallback-model",
+          },
+        },
+      },
+    });
+
+    expect(config?.voiceId).toBe("preferred-voice");
+    expect(config?.modelId).toBe("preferred-model");
+  });
+
   it("applies provider overrides to telephony synthesis", async () => {
     const provider = buildElevenLabsSpeechProvider();
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {

--- a/extensions/elevenlabs/speech-provider.ts
+++ b/extensions/elevenlabs/speech-provider.ts
@@ -90,8 +90,8 @@ function normalizeElevenLabsProviderConfig(
       path: "messages.tts.providers.elevenlabs.apiKey",
     }),
     baseUrl: normalizeElevenLabsBaseUrl(trimToUndefined(raw?.baseUrl)),
-    voiceId: trimToUndefined(raw?.voiceId) ?? DEFAULT_ELEVENLABS_VOICE_ID,
-    modelId: trimToUndefined(raw?.modelId) ?? DEFAULT_ELEVENLABS_MODEL_ID,
+    voiceId: trimToUndefined(raw?.voiceId ?? raw?.voice) ?? DEFAULT_ELEVENLABS_VOICE_ID,
+    modelId: trimToUndefined(raw?.modelId ?? raw?.model) ?? DEFAULT_ELEVENLABS_MODEL_ID,
     seed: asFiniteNumber(raw?.seed),
     applyTextNormalization: trimToUndefined(raw?.applyTextNormalization) as
       | "auto"
@@ -120,8 +120,8 @@ function readElevenLabsProviderConfig(config: SpeechProviderConfig): ElevenLabsP
   return {
     apiKey: trimToUndefined(config.apiKey) ?? defaults.apiKey,
     baseUrl: normalizeElevenLabsBaseUrl(trimToUndefined(config.baseUrl) ?? defaults.baseUrl),
-    voiceId: trimToUndefined(config.voiceId) ?? defaults.voiceId,
-    modelId: trimToUndefined(config.modelId) ?? defaults.modelId,
+    voiceId: trimToUndefined(config.voiceId ?? config.voice) ?? defaults.voiceId,
+    modelId: trimToUndefined(config.modelId ?? config.model) ?? defaults.modelId,
     seed: asFiniteNumber(config.seed) ?? defaults.seed,
     applyTextNormalization:
       (trimToUndefined(config.applyTextNormalization) as "auto" | "on" | "off" | undefined) ??
@@ -383,12 +383,16 @@ export function buildElevenLabsSpeechProvider(): SpeechProviderPlugin {
         ...(trimToUndefined(talkProviderConfig.baseUrl) == null
           ? {}
           : { baseUrl: normalizeElevenLabsBaseUrl(trimToUndefined(talkProviderConfig.baseUrl)) }),
-        ...(trimToUndefined(talkProviderConfig.voiceId) == null
+        ...(trimToUndefined(talkProviderConfig.voiceId ?? talkProviderConfig.voice) == null
           ? {}
-          : { voiceId: trimToUndefined(talkProviderConfig.voiceId) }),
-        ...(trimToUndefined(talkProviderConfig.modelId) == null
+          : {
+              voiceId: trimToUndefined(talkProviderConfig.voiceId ?? talkProviderConfig.voice),
+            }),
+        ...(trimToUndefined(talkProviderConfig.modelId ?? talkProviderConfig.model) == null
           ? {}
-          : { modelId: trimToUndefined(talkProviderConfig.modelId) }),
+          : {
+              modelId: trimToUndefined(talkProviderConfig.modelId ?? talkProviderConfig.model),
+            }),
         ...(asFiniteNumber(talkProviderConfig.seed) == null
           ? {}
           : { seed: asFiniteNumber(talkProviderConfig.seed) }),


### PR DESCRIPTION
## Summary

Fixes the ElevenLabs TTS provider ignoring `voice` and `model` config keys. The generic OpenAI-compatible speech provider accepts both `voice`/`voiceId` and `model`/`modelId`, but the ElevenLabs-specific provider only checked `voiceId` and `modelId`. Users who configured `talk.providers.elevenlabs.voice` (per the generic pattern or docs convention) silently got the default voice instead of their chosen one.

## Changes

- `extensions/elevenlabs/speech-provider.ts`:
  - `normalizeElevenLabsProviderConfig`: read `voice` as fallback for `voiceId`, and `model` as fallback for `modelId`
  - `readElevenLabsProviderConfig`: same alias support when reading resolved `SpeechProviderConfig`
  - `resolveTalkConfig`: same alias support when resolving talk-level provider overrides
- `extensions/elevenlabs/speech-provider.test.ts`: add two regression tests verifying `voice`/`model` aliases work and that explicit `voiceId`/`modelId` still wins when both are present

## Verification

Behavior addressed: ElevenLabs TTS `voice` and `model` config keys are now respected
Real environment tested: Local source checkout, Linux, Node 22
Exact steps or command run after this patch:
  - pnpm test extensions/elevenlabs/speech-provider.test.ts
  - pnpm format:check extensions/elevenlabs/speech-provider.ts extensions/elevenlabs/speech-provider.test.ts
Evidence after fix: 5 tests pass, 0 failures; formatting check passes
Observed result after fix: Config with `voice` and `model` keys resolves to the correct `voiceId` and `modelId`
What was not tested: Live ElevenLabs API call with custom voice

Fixes #86180