### PR TITLE
fix(android): preserve TLS setting when creating GatewayEndpoint from setup code

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayEndpoint.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayEndpoint.kt
@@ -16,13 +16,14 @@ data class GatewayEndpoint(
     fun manual(
       host: String,
       port: Int,
+      tlsEnabled: Boolean = false,
     ): GatewayEndpoint =
       GatewayEndpoint(
         stableId = "manual|${host.lowercase()}|$port",
         name = "$host:$port",
         host = host,
         port = port,
-        tlsEnabled = false,
+        tlsEnabled = tlsEnabled,
         tlsFingerprintSha256 = null,
       )
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt
@@ -305,7 +305,7 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
           }
           viewModel.setGatewayPassword(config.password)
           viewModel.connect(
-            GatewayEndpoint.manual(host = config.host, port = config.port),
+            GatewayEndpoint.manual(host = config.host, port = config.port, tlsEnabled = config.tls),
             token = config.token.ifEmpty { null },
             bootstrapToken = config.bootstrapToken.ifEmpty { null },
             password = config.password.ifEmpty { null },

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -282,7 +282,7 @@ fun OnboardingFlow(
             viewModel.setGatewayToken(config.token)
             viewModel.setGatewayPassword(config.password)
             viewModel.connect(
-              GatewayEndpoint.manual(host = config.host, port = config.port),
+              GatewayEndpoint.manual(host = config.host, port = config.port, tlsEnabled = config.tls),
               token = config.token.ifEmpty { null },
               bootstrapToken = config.bootstrapToken.ifEmpty { null },
               password = config.password.ifEmpty { null },
@@ -314,7 +314,7 @@ fun OnboardingFlow(
                 password = password,
               ) ?: return@GatewayRecoveryScreen
             viewModel.connect(
-              GatewayEndpoint.manual(host = config.host, port = config.port),
+              GatewayEndpoint.manual(host = config.host, port = config.port, tlsEnabled = config.tls),
               token = config.token.ifEmpty { null },
               bootstrapToken = config.bootstrapToken.ifEmpty { null },
               password = config.password.ifEmpty { null },

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -754,7 +754,7 @@ private fun GatewaySettingsScreen(
             viewModel.setGatewayToken(token)
             viewModel.setGatewayPassword(password)
             viewModel.connect(
-              GatewayEndpoint.manual(host = endpointConfig.host, port = endpointConfig.port),
+              GatewayEndpoint.manual(host = endpointConfig.host, port = endpointConfig.port, tlsEnabled = endpointConfig.tls),
               token = token.ifEmpty { null },
               bootstrapToken = bootstrapToken.ifEmpty { null },
               password = password.ifEmpty { null },

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -476,5 +476,16 @@ class GatewayConfigResolverTest {
     assertEquals(true, resolved?.tls)
   }
 
+  @Test
+  fun gatewayEndpointManualPreservesTlsSetting() {
+    val tlsEndpoint = GatewayEndpoint.manual(host = "gateway.example", port = 443, tlsEnabled = true)
+    val nonTlsEndpoint = GatewayEndpoint.manual(host = "gateway.example", port = 18789, tlsEnabled = false)
+    val defaultEndpoint = GatewayEndpoint.manual(host = "gateway.example", port = 18789)
+
+    assertEquals(true, tlsEndpoint.tlsEnabled)
+    assertEquals(false, nonTlsEndpoint.tlsEnabled)
+    assertEquals(false, defaultEndpoint.tlsEnabled)
+  }
+
   private fun encodeSetupCode(payloadJson: String): String = Base64.getUrlEncoder().withoutPadding().encodeToString(payloadJson.toByteArray(Charsets.UTF_8))
 }


### PR DESCRIPTION
## Summary

Fix Android setup-code import that was discarding the TLS setting from `wss://` Gateway URLs, causing protocol mismatch errors when connecting to Tailscale Serve endpoints.

## Problem

When users generated a setup code with:
```bash
openclaw qr --remote --setup-code-only
```

The decoded payload contained the correct WebSocket URL:
```json
{"url": "wss://as-mac-mini.dzo-bee.ts.net", "hasBootstrapToken": true}
```

However, the Android app would fail to connect because it created a `GatewayEndpoint` with `tlsEnabled=false`, even though the setup code specified `wss://`. This caused the connection layer to use `ws://` instead of `wss://`, resulting in a protocol mismatch.

## Root Cause

The `GatewayEndpoint.manual()` function always created endpoints with `tlsEnabled = false`, ignoring the TLS setting parsed from the setup code URL. While the code correctly parsed `wss://` URLs as `tls=true` in `GatewayEndpointConfig`, this setting was lost when creating the actual `GatewayEndpoint` for connection.

## Solution

1. Added `tlsEnabled` parameter to `GatewayEndpoint.manual()` with default value `false` for backward compatibility
2. Updated all call sites to pass `config.tls` when creating endpoints from setup codes or manual configuration
3. Added test to verify the `tlsEnabled` parameter is preserved

## Changes

- `apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayEndpoint.kt`: Add `tlsEnabled` parameter to `manual()` function
- `apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt`: Pass `config.tls` to `GatewayEndpoint.manual()`
- `apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt`: Pass `config.tls` to `GatewayEndpoint.manual()`
- `apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt`: Pass `endpointConfig.tls` to `GatewayEndpoint.manual()`
- `apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt`: Add test for `tlsEnabled` parameter

## Verification

- Existing tests remain compatible (default parameter preserves existing behavior)
- New test verifies `tlsEnabled` parameter is correctly preserved
- Fix allows Android app to correctly connect to Tailscale Serve endpoints using `wss://` URLs

## Related

Fixes #86364

🤖 AI-generated code
