### PR TITLE
fix(models): show OAuth delegation marker auth status

### DIFF
--- a/src/commands/models/list.auth-overview.test.ts
+++ b/src/commands/models/list.auth-overview.test.ts
@@ -58,7 +58,7 @@ vi.mock("../../agents/model-auth.js", () => {
         provider: string;
       }) => {
         const apiKey = resolveConfigKey(params.cfg, params.provider);
-        if (!apiKey || apiKey === "secretref-managed") {
+        if (!apiKey || apiKey === "secretref-managed" || apiKey.startsWith("oauth:")) {
           return null;
         }
         if (apiKey === "OPENAI_API_KEY") {
@@ -188,6 +188,18 @@ describe("resolveProviderAuthOverview", () => {
     expect(overview.effective.kind).toBe("missing");
     expect(overview.effective.detail).toBe("missing");
     expect(overview.modelsJson?.value).toContain(`marker(${NON_ENV_SECRETREF_MARKER})`);
+  });
+
+  it("treats OAuth delegation markers as effective models.json auth", () => {
+    const overview = withEnv({ OPENAI_API_KEY: undefined }, () =>
+      resolveOpenAiOverview("oauth:openai-codex"),
+    );
+
+    expect(overview.effective).toEqual({
+      kind: "models.json",
+      detail: "marker(oauth:openai-codex)",
+    });
+    expect(overview.modelsJson?.value).toBe("marker(oauth:openai-codex)");
   });
 
   it("keeps env-var-shaped models.json values masked to avoid accidental plaintext exposure", () => {

--- a/src/commands/models/list.auth-overview.ts
+++ b/src/commands/models/list.auth-overview.ts
@@ -5,7 +5,7 @@ import { loadPersistedAuthProfileStore } from "../../agents/auth-profiles/persis
 import { listProfilesForProvider } from "../../agents/auth-profiles/profiles.js";
 import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
 import { resolveProfileUnusableUntilForDisplay } from "../../agents/auth-profiles/usage.js";
-import { isNonSecretApiKeyMarker } from "../../agents/model-auth-markers.js";
+import { isNonSecretApiKeyMarker, isOAuthApiKeyMarker } from "../../agents/model-auth-markers.js";
 import {
   getCustomProviderApiKey,
   resolveEnvApiKey,
@@ -176,6 +176,9 @@ export function resolveProviderAuthOverview(params: {
     }
     if (params.syntheticAuth) {
       return { kind: "synthetic", detail: params.syntheticAuth.source };
+    }
+    if (customKey && isOAuthApiKeyMarker(customKey)) {
+      return { kind: "models.json", detail: formatMarkerOrSecret(customKey) };
     }
     return { kind: "missing", detail: "missing" };
   })();

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -516,6 +516,84 @@ describe("modelsStatusCommand auth overview", () => {
     }
   });
 
+  it("keeps delegated OAuth marker display separate from runtime route usability", async () => {
+    const localRuntime = createRuntime();
+    const originalLoadConfig = mocks.loadConfig.getMockImplementation();
+    const originalProfiles = { ...mocks.store.profiles };
+    const originalEnvImpl = mocks.resolveEnvApiKey.getMockImplementation();
+    const originalCustomKeyImpl = mocks.getCustomProviderApiKey.getMockImplementation();
+    const originalUsableCustomKeyImpl =
+      mocks.resolveUsableCustomProviderApiKey.getMockImplementation();
+    mocks.loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.5", fallbacks: [] },
+          models: { "openai/gpt-5.5": {} },
+        },
+      },
+      models: {
+        providers: {
+          openai: {
+            apiKey: "oauth:openai-codex",
+          },
+        },
+      },
+      env: { shellEnv: { enabled: false } },
+    });
+    mocks.store.profiles = {};
+    mocks.resolveEnvApiKey.mockImplementation(() => null);
+    mocks.getCustomProviderApiKey.mockImplementation((_cfg: unknown, provider: string) =>
+      provider === "openai" ? "oauth:openai-codex" : undefined,
+    );
+    mocks.resolveUsableCustomProviderApiKey.mockImplementation(() => null);
+
+    try {
+      await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+      const payload = parseFirstJsonLog(localRuntime);
+      const openai = requireProvider(payload.auth.providers, "openai");
+      expect(openai.effective).toEqual({
+        kind: "models.json",
+        detail: "marker(oauth:openai-codex)",
+      });
+      expect(payload.auth.runtimeAuthRoutes).toEqual([
+        {
+          provider: "openai",
+          runtime: "codex",
+          authProvider: "openai-codex",
+          status: "missing",
+          effective: {
+            kind: "missing",
+            detail: "missing",
+          },
+        },
+      ]);
+      expect(payload.auth.missingProvidersInUse).toStrictEqual(["openai"]);
+      expect(localRuntime.exit).toHaveBeenCalledWith(1);
+    } finally {
+      mocks.store.profiles = originalProfiles;
+      if (originalLoadConfig) {
+        mocks.loadConfig.mockImplementation(originalLoadConfig);
+      }
+      if (originalEnvImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(originalEnvImpl);
+      } else if (defaultResolveEnvApiKeyImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(defaultResolveEnvApiKeyImpl);
+      } else {
+        mocks.resolveEnvApiKey.mockImplementation(() => null);
+      }
+      if (originalCustomKeyImpl) {
+        mocks.getCustomProviderApiKey.mockImplementation(originalCustomKeyImpl);
+      } else {
+        mocks.getCustomProviderApiKey.mockReturnValue(undefined);
+      }
+      if (originalUsableCustomKeyImpl) {
+        mocks.resolveUsableCustomProviderApiKey.mockImplementation(originalUsableCustomKeyImpl);
+      } else {
+        mocks.resolveUsableCustomProviderApiKey.mockReturnValue(null);
+      }
+    }
+  });
+
   it("uses Codex synthetic auth for canonical OpenAI text routes", async () => {
     const localRuntime = createRuntime();
     const originalLoadConfig = mocks.loadConfig.getMockImplementation();


### PR DESCRIPTION
## Summary

Fixes #83732.

`openclaw models status` now reports an OAuth delegation marker from `models.json` as configured `models.json` auth instead of `missing`, while leaving runtime route health and `--check` behavior tied to the delegated provider's actual usable auth.

## Motivation / root cause

Runtime auth treats values such as `oauth:openai-codex` as delegation markers, but the status overview asked `resolveUsableCustomProviderApiKey` for a usable key. That helper intentionally filters marker values out because the marker is not itself a credential. The overview then fell through to `effective=missing` even when `models.json` clearly contained the delegation marker and the `openai-codex` route was usable.

## Real behavior proof

Behavior addressed: `models status` no longer shows `openai effective=missing` when `openai.apiKey` is `oauth:openai-codex`.

Real environment tested: local persisted OpenClaw state fixture under `/tmp/openclaw-83732-after-vXrPvD` with `openai.apiKey = "oauth:openai-codex"` and a usable `openai-codex` OAuth profile in `auth-profiles.json`.

Exact steps or command run after this patch: `OPENCLAW_STATE_DIR=/tmp/openclaw-83732-after-vXrPvD/state OPENCLAW_AGENT_DIR=/tmp/openclaw-83732-after-vXrPvD/state/agents/main/agent OPENAI_API_KEY= OPENAI_OAUTH_TOKEN= pnpm --silent openclaw models status --json --check`

Evidence after fix: the command exited 0 and reported:

```json
{
  "missingProvidersInUse": [],
  "openaiEffective": {
    "kind": "models.json",
    "detail": "marker(oauth:openai-codex)"
  },
  "runtimeAuthRoutes": [
    {
      "provider": "openai",
      "runtime": "codex",
      "authProvider": "openai-codex",
      "status": "usable"
    }
  ]
}
```

Observed result after fix: human output includes `openai effective=models.json:marker(oauth:openai-codex)` and the runtime auth section still shows `openai via codex uses openai-codex ... status=usable`.

What was not tested: full suite, cross-OS runs, and live provider network calls. This only exercises persisted local status output and the focused command tests.

## Regression tests

- Adds an auth-overview unit test for `oauth:openai-codex` marker display.
- Adds a status-command regression test proving marker display stays separate from runtime route usability: if the delegated `openai-codex` auth is absent, the marker is still displayed but `runtimeAuthRoutes[].status` is `missing`, `missingProvidersInUse` contains `openai`, and `--check` exits 1.

## Commands run

- `node scripts/run-vitest.mjs src/commands/models/list.auth-overview.test.ts`
- `node scripts/run-vitest.mjs src/commands/models/list.status.test.ts`
- `node scripts/run-vitest.mjs src/commands/models/list.auth-overview.test.ts src/commands/models/list.status.test.ts`
- `git diff --check`
- `pnpm check:changed`
- real fixture command above, plus `pnpm --silent openclaw models status` for human output

## User-visible behavior

Users with delegated OpenAI Codex auth should see the configured marker source in `models status` instead of a misleading `missing` effective auth label.

## Compatibility and risks

The change is display-only for `models status`; it does not make an OAuth marker a usable credential and does not change runtime auth routing. The main risk is status wording around delegation markers, covered by tests for both usable and missing delegated auth.
