### PR TITLE
fix(doctor): warn and continue when cron job store is unreadable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 - Cron: accept leading-plus relative durations such as `+5m` for one-shot `--at` schedules. (#86341) Thanks @mushuiyu886.
 - Agents/media: preserve async-started media tool metadata so background generation starts no longer surface generic incomplete-turn warnings while replay stays unsafe. (#85933) Thanks @fuller-stack-dev.
 - xAI/LM Studio: avoid buffering ordinary bracketed or `final` prose until stream completion while watching for plain-text tool-call fallbacks.
+- Doctor: warn and continue when the cron job store exists but cannot be read (e.g. owned by another user with `0600` mode inside Docker) so later health checks still run. (#86102)
 - Discord: suppress a bot's previous reply body and referenced media from prompt context when a user replies to that bot message, while keeping reply metadata for routing. (#86238) Thanks @fuller-stack-dev.
 - Docker E2E: avoid rebuilding the Control UI twice while preparing the shared OpenClaw package tarball for package-backed scenario runs.
 - Tests: avoid rebuilding the Control UI twice during the installer Docker smoke now that `pnpm build` includes `ui:build`.

--- a/src/commands/doctor-cron.test.ts
+++ b/src/commands/doctor-cron.test.ts
@@ -566,6 +566,29 @@ describe("maybeRepairLegacyCronStore", () => {
     expectNoteContaining("managed dreaming job", "Cron");
     expectNoteContaining("Rewrote 1 managed dreaming job", "Doctor changes");
   });
+
+  it("warns and continues when the cron job store cannot be read", async () => {
+    const storePath = await makeTempStorePath();
+    // Force loadCronStore to throw a non-ENOENT read error by placing a
+    // directory where the cron job store file would be. This mirrors the
+    // Docker-on-root permission failure reported in #86102 without depending
+    // on the test runner's effective uid (root bypasses chmod gates).
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.mkdir(storePath);
+    const prompter = makePrompter(true);
+
+    await expect(
+      maybeRepairLegacyCronStore({
+        cfg: { cron: { store: storePath } },
+        options: {},
+        prompter,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(prompter.confirm).not.toHaveBeenCalled();
+    expectNoteContaining("Unable to read cron job store at", "Cron");
+    expectNoteContaining("later health checks will continue", "Cron");
+  });
 });
 
 describe("legacy WhatsApp crontab health check", () => {

--- a/src/commands/doctor-cron.ts
+++ b/src/commands/doctor-cron.ts
@@ -335,7 +335,21 @@ export async function maybeRepairLegacyCronStore(params: {
   prompter: Pick<DoctorPrompter, "confirm">;
 }) {
   const storePath = resolveCronStorePath(params.cfg.cron?.store);
-  const store = await loadCronStore(storePath);
+  let store: Awaited<ReturnType<typeof loadCronStore>>;
+  try {
+    store = await loadCronStore(storePath);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    note(
+      [
+        `Unable to read cron job store at ${shortenHomePath(storePath)}.`,
+        `- ${reason}`,
+        `Fix the file's permissions or contents and re-run ${formatCliCommand("openclaw doctor")}; later health checks will continue.`,
+      ].join("\n"),
+      "Cron",
+    );
+    return;
+  }
   const rawJobs = (store.jobs ?? []) as unknown as Array<Record<string, unknown>>;
   if (rawJobs.length === 0) {
     return;


### PR DESCRIPTION
## Summary

`openclaw doctor` aborts mid-run when the legacy cron job store exists but is unreadable by the runtime user (the Docker repro in #86102 leaves `~/.openclaw/cron/jobs.json` as `root:root 0600`). `loadCronStore` only treats `ENOENT` as recoverable; every other read or parse failure rethrows, the legacy cron contribution awaits without a per-contribution catch (`src/flows/doctor-health-contributions.ts`), and later health checks never run.

This PR keeps runtime cron loading strict and only softens the doctor contribution: it catches the load failure inside `maybeRepairLegacyCronStore`, emits a `Cron` warning naming the store path with the underlying reason, and returns so subsequent health checks continue.

Closes #86102.

## Change Type

- [x] Bug fix
- [x] Test

## Scope

- [x] CLI / Doctor

## Linked Issue

- Closes #86102

## Real behavior proof

**Behavior or issue addressed**: When `~/.openclaw/cron/jobs.json` exists but is unreadable to the OpenClaw process (Docker root-owned 0600 file in #86102), `loadCronStore` throws a non-`ENOENT` error that propagates through `maybeRepairLegacyCronStore` and the doctor contribution loop, so `openclaw doctor` cannot complete the rest of the health checks.

**Real environment tested**: macOS Darwin 25.4.0 arm64, Node v22.22.0, openclaw branch `fix/doctor-cron-unreadable-store` rebased on upstream main commit `538fd32954267635cf2fef90c0f3c3ce77a91ece`.

**Exact steps or command run after this patch**:

1. Created a temp cron store file and removed all permissions (`chmod 0000`) to reproduce the EACCES read failure from #86102 without Docker.
2. Ran the patched `maybeRepairLegacyCronStore` via `node --import tsx` pointing at the unreadable store to simulate the doctor cron contribution.
3. Confirmed the function returns cleanly, emits a `Cron` warning with the store path and EACCES reason, and prints "later health checks will continue".
4. Ran focused regression test: `node scripts/run-vitest.mjs run src/commands/doctor-cron.test.ts` (16/16 pass).
5. Drift proof: reverted src patch, re-ran tests — new test fails on EISDIR rethrow; restored — 16/16 pass.
6. Format, lint, typecheck all clean.

**Evidence after fix**:

Real CLI reproduction against an unreadable cron store (EACCES):

```
$ node --import tsx -e "
import { maybeRepairLegacyCronStore } from './src/commands/doctor-cron.ts';
await maybeRepairLegacyCronStore({
  cfg: { cron: { store: '/tmp/doctor-cron-86102/cron/jobs.json' } },
  options: {},
  prompter: { confirm: async () => true },
});
"

 Cron ───────────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  Unable to read cron job store at                                            │
│  /tmp/doctor-cron-86102/cron/jobs.json.                                      │
│  - EACCES: permission denied, open                                           │
│    '/tmp/doctor-cron-86102/cron/jobs.json'                                   │
│  Fix the file's permissions or contents and re-run openclaw doctor;          │
│  later health checks will continue.                                          │
│                                                                              │
├──────────────────────────────────────────────────────────────────────────────╯

=== After fix: doctor continues to next health check ===
```

Focused regression test (16/16 pass):

```
$ node scripts/run-vitest.mjs run src/commands/doctor-cron.test.ts

 ✓  commands  ../../src/commands/doctor-cron.test.ts (16 tests) 59ms

 Test Files  1 passed (1)
      Tests  16 passed (16)
```

Drift proof (patch reverted — new test must fail):

```
$ git stash push -- src/commands/doctor-cron.ts

$ node scripts/run-vitest.mjs run src/commands/doctor-cron.test.ts

 ×  warns and continues when the cron job store cannot be read
   Caused by: Error: EISDIR: illegal operation on a directory, read
       at loadCronStore ../../src/cron/store.ts:218:17
       at Module.maybeRepairLegacyCronStore ../../src/commands/doctor-cron.ts:338:17

 Test Files  1 failed (1)
      Tests  1 failed | 15 passed (16)

$ git stash pop
```

Format, lint, typecheck:

```
$ pnpm exec oxfmt --check src/commands/doctor-cron.ts src/commands/doctor-cron.test.ts CHANGELOG.md
All matched files use the correct format.

$ pnpm exec oxlint src/commands/doctor-cron.ts src/commands/doctor-cron.test.ts
Found 0 warnings and 0 errors.

$ node scripts/run-tsgo.mjs -p tsconfig.json
(no diagnostics, exit 0)
```

**Observed result after fix**: `maybeRepairLegacyCronStore` returns cleanly after emitting a single `Cron` warning ("Unable to read cron job store at ... EACCES: permission denied ... later health checks will continue"). The prompter is never asked. The doctor contribution loop continues to subsequent contributions. On current main the same call throws and aborts the doctor run.

**What was not tested**: A live Docker reproduction with root-owned 0600 inside a container was not executed; the real CLI proof uses a local `chmod 0000` file on macOS which triggers the same `EACCES` path that the reporter observed inside Docker.

## Root Cause

`loadCronStore` (`src/cron/store.ts`) only catches `ENOENT`; any other read or parse failure rethrows. `maybeRepairLegacyCronStore` (`src/commands/doctor-cron.ts:338`) awaits it directly, and the legacy cron contribution in the doctor flow (`src/flows/doctor-health-contributions.ts:413`) awaits each contribution without a per-contribution catch, so an unreadable cron store aborts the whole `openclaw doctor` run.

## Regression Test Plan

Added `warns and continues when the cron job store cannot be read` to `src/commands/doctor-cron.test.ts`. The test substitutes a directory at the cron store path (a non-`ENOENT` read failure that mirrors the reporter's permission case without depending on the test runner's effective uid) and asserts (1) `maybeRepairLegacyCronStore` resolves, (2) the prompter is never invoked, and (3) a `Cron`-titled note containing both the store path and "later health checks will continue" is emitted. With the patch reverted the new test fails on the rethrown `EISDIR`, confirming the test guards the regression.

## User-visible / Behavior Changes

- `openclaw doctor` no longer aborts when the cron job store is unreadable; it now emits a single `Cron` warning naming the store path plus the underlying error reason and points the user at `openclaw doctor` to retry, then continues with the remaining health checks.
- No change to scheduler runtime behavior: `loadCronStore` still rethrows non-`ENOENT` errors so cron execution fails closed.

## Scope boundary

- Only `maybeRepairLegacyCronStore` in `src/commands/doctor-cron.ts` is softened; `loadCronStore` and `loadCronStoreSync` keep their existing throw-on-read-failure contract for the scheduler.
- No changes to the cron file format, doctor prompter contract, or other doctor health contributions.

## Prior art

No prior PR found targeting #86102 at the time of this submission. The closest adjacent work is the existing `maybeRepairLegacyCronStore` contribution introduced via the recent doctor cron migrations on `src/commands/doctor-cron.ts`; this PR only adds a defensive catch around `loadCronStore` and an accompanying focused test.
