### PR TITLE
fix(doctor): warn and continue when cron store is unreadable

### DIFF
--- a/src/commands/doctor-cron.test.ts
+++ b/src/commands/doctor-cron.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import * as cronStore from "../cron/store.js";
 import {
   collectLegacyWhatsAppCrontabHealthWarning,
   maybeRepairLegacyCronStore,
@@ -25,6 +26,7 @@ async function makeTempStorePath() {
 }
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   noteMock.mockClear();
   if (tempRoot) {
     await fs.rm(tempRoot, { recursive: true, force: true });
@@ -124,6 +126,45 @@ function expectNoNoteContaining(message: string, title: string): void {
 }
 
 describe("maybeRepairLegacyCronStore", () => {
+  it("warns and continues when the cron store is unreadable", async () => {
+    const storePath = await makeTempStorePath();
+    const err = new Error("permission denied") as NodeJS.ErrnoException;
+    err.code = "EACCES";
+    const loadCronStoreSpy = vi.spyOn(cronStore, "loadCronStore").mockRejectedValueOnce(err);
+
+    await expect(
+      maybeRepairLegacyCronStore({
+        cfg: createCronConfig(storePath),
+        options: {},
+        prompter: makePrompter(true),
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(loadCronStoreSpy).toHaveBeenCalledWith(storePath);
+    expectNoteContaining(`Cron store at ${storePath} could not be read.`, "Doctor warnings");
+    expectNoteContaining(
+      "Doctor skipped legacy cron store checks and will continue with later health checks.",
+      "Doctor warnings",
+    );
+    expectNoteContaining("Read error: permission denied", "Doctor warnings");
+  });
+
+  it("rethrows non-permission cron store errors", async () => {
+    const storePath = await makeTempStorePath();
+    const err = new Error("Failed to parse cron store");
+    vi.spyOn(cronStore, "loadCronStore").mockRejectedValueOnce(err);
+
+    await expect(
+      maybeRepairLegacyCronStore({
+        cfg: createCronConfig(storePath),
+        options: {},
+        prompter: makePrompter(true),
+      }),
+    ).rejects.toThrow("Failed to parse cron store");
+
+    expectNoNoteContaining("could not be read", "Doctor warnings");
+  });
+
   it("surfaces cron payload model overrides without rewriting current jobs", async () => {
     const storePath = await makeTempStorePath();
     await writeCronStore(storePath, [

--- a/src/commands/doctor-cron.ts
+++ b/src/commands/doctor-cron.ts
@@ -34,6 +34,15 @@ function pluralize(count: number, noun: string) {
   return `${count} ${noun}${count === 1 ? "" : "s"}`;
 }
 
+function isUnreadableCronStoreError(err: unknown): boolean {
+  const code = (err as { code?: unknown })?.code;
+  if (code === "EACCES" || code === "EPERM") {
+    return true;
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return /permission denied|operation not permitted/i.test(message);
+}
+
 function formatLegacyIssuePreview(issues: Partial<Record<string, number>>): string[] {
   const lines: string[] = [];
   if (issues.jobId) {
@@ -335,7 +344,23 @@ export async function maybeRepairLegacyCronStore(params: {
   prompter: Pick<DoctorPrompter, "confirm">;
 }) {
   const storePath = resolveCronStorePath(params.cfg.cron?.store);
-  const store = await loadCronStore(storePath);
+  let store: Awaited<ReturnType<typeof loadCronStore>>;
+  try {
+    store = await loadCronStore(storePath);
+  } catch (err) {
+    if (!isUnreadableCronStoreError(err)) {
+      throw err;
+    }
+    note(
+      [
+        `Cron store at ${shortenHomePath(storePath)} could not be read.`,
+        `Doctor skipped legacy cron store checks and will continue with later health checks.`,
+        `Read error: ${err instanceof Error ? err.message : String(err)}`,
+      ].join("\n"),
+      "Doctor warnings",
+    );
+    return;
+  }
   const rawJobs = (store.jobs ?? []) as unknown as Array<Record<string, unknown>>;
   if (rawJobs.length === 0) {
     return;


### PR DESCRIPTION
## Summary
- warn and continue in `maybeRepairLegacyCronStore` when the cron store exists but cannot be read because of permission/access errors
- keep non-permission cron store failures strict so malformed JSON and other corruption still surface
- add focused regression tests for both paths

## Real behavior proof
Behavior or issue addressed: `openclaw doctor` should not stop early when the legacy cron store exists but is unreadable because of permission errors; malformed cron store content should still remain a hard failure.

Real environment tested: local OpenClaw checkout on Linux with a real temporary `cron/jobs.json` file, real filesystem permission changes (`chmod 000`), and direct execution of the patched doctor cron path via `node --import tsx`.

Exact steps or command run after this patch:
- Create a temporary cron store file containing one persisted job, change the file mode to `000`, and run `maybeRepairLegacyCronStore` through `node --import tsx`.
- Create a separate temporary cron store file containing malformed JSON and run the same path again.

Evidence after fix:
```text
Doctor warnings
Cron store at /media/vdc/0668001470/tmp/openclaw-doctor-cron-ZT95Ot/cron/jobs.json could not be read.
Doctor skipped legacy cron store checks and will continue with later health checks.
Read error: EACCES: permission denied, open '/media/vdc/0668001470/tmp/openclaw-doctor-cron-ZT95Ot/cron/jobs.json'
UNREADABLE_OK
PARSE_THROW_OK
```

Observed result after fix: the unreadable cron store path emitted a `Doctor warnings` note and returned without throwing, which preserves later doctor health checks; the malformed cron store path still threw the parse failure and the verification script reported `PARSE_THROW_OK`.

What was not tested: full `openclaw doctor` end-to-end execution across every later health contribution, and non-Linux permission behavior such as Windows or macOS ACL differences.

## Testing
- `git diff --check`
- `node --import tsx --eval 'import fs from "node:fs/promises"; import os from "node:os"; import path from "node:path"; import { maybeRepairLegacyCronStore } from "./src/commands/doctor-cron.ts"; const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-doctor-cron-")); const storePath = path.join(root, "cron", "jobs.json"); await fs.mkdir(path.dirname(storePath), { recursive: true }); await fs.writeFile(storePath, JSON.stringify({ version: 1, jobs: [{ id: "job-1", name: "Job 1", enabled: true, createdAtMs: Date.now(), updatedAtMs: Date.now(), schedule: { kind: "every", everyMs: 60000 }, payload: { kind: "systemEvent", text: "hi" }, state: {} }] }, null, 2), "utf8"); await fs.chmod(storePath, 0o000); try { await maybeRepairLegacyCronStore({ cfg: { cron: { store: storePath, webhook: "https://example.invalid/cron" } }, options: {}, prompter: { confirm: async () => true } }); console.log("UNREADABLE_OK"); } finally { await fs.chmod(storePath, 0o600).catch(() => undefined); await fs.rm(root, { recursive: true, force: true }); }'`
- `node --import tsx --eval 'import fs from "node:fs/promises"; import os from "node:os"; import path from "node:path"; import { maybeRepairLegacyCronStore } from "./src/commands/doctor-cron.ts"; const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-doctor-cron-parse-")); const storePath = path.join(root, "cron", "jobs.json"); await fs.mkdir(path.dirname(storePath), { recursive: true }); await fs.writeFile(storePath, "{ not json", "utf8"); let threw = false; try { await maybeRepairLegacyCronStore({ cfg: { cron: { store: storePath, webhook: "https://example.invalid/cron" } }, options: {}, prompter: { confirm: async () => true } }); } catch (err) { threw = String(err).includes("Failed to parse cron store"); if (threw) { console.log("PARSE_THROW_OK"); } else { console.error(String(err)); process.exitCode = 1; } } finally { await fs.rm(root, { recursive: true, force: true }); } if (!threw) { console.error("PARSE_THROW_FAIL"); process.exitCode = 1; }'`

Closes #86102.
