### PR TITLE
fix(feishu): route SDK traffic through ambient proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 - **Codex dynamic tool outcomes:** use the shared tool-result failure contract for arbitrary lifecycle metadata, preventing successful Skill Workshop results from being displayed and persisted as failed calls. Fixes #107684. Thanks @shakkernerd.
 - **Nested resource ignores:** honor slash-free patterns and escaped literal exclamation marks in nested ignore files during skill and resource discovery. Thanks @moguangyu5-design.
 - **Proxy bypass precedence:** honor blank lower-case `no_proxy` values shadowing upper-case `NO_PROXY` consistently with Undici, and reuse the canonical matcher for Telegram fallback selection.
+- **Feishu proxy transport:** reuse one ambient proxy agent across REST, bootstrap, and WebSocket traffic, preserve caller agents outside managed mode, and fail closed when the managed proxy agent cannot be created. Thanks @larry-xue.
 - **Tokenjuice exec compaction:** avoid retaining raw command output inside compacted middleware metadata, preventing large successful compactions from failing the middleware details-size guard.
 - **Agent git package identities:** strip refs before hosted-repository parsing and reject traversal segments so GitLab branch refs resolve to the canonical managed install path.
 - **Tlon custom S3 uploads:** pass storage endpoints through the AWS SDK's native parser so custom S3-compatible uploads no longer fail before presigning.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,6 @@ Docs: https://docs.openclaw.ai
 - **Codex dynamic tool outcomes:** use the shared tool-result failure contract for arbitrary lifecycle metadata, preventing successful Skill Workshop results from being displayed and persisted as failed calls. Fixes #107684. Thanks @shakkernerd.
 - **Nested resource ignores:** honor slash-free patterns and escaped literal exclamation marks in nested ignore files during skill and resource discovery. Thanks @moguangyu5-design.
 - **Proxy bypass precedence:** honor blank lower-case `no_proxy` values shadowing upper-case `NO_PROXY` consistently with Undici, and reuse the canonical matcher for Telegram fallback selection.
-- **Feishu proxy transport:** reuse one ambient proxy agent across REST, bootstrap, and WebSocket traffic, preserve caller agents outside managed mode, and fail closed when the managed proxy agent cannot be created. Thanks @larry-xue.
 - **Tokenjuice exec compaction:** avoid retaining raw command output inside compacted middleware metadata, preventing large successful compactions from failing the middleware details-size guard.
 - **Agent git package identities:** strip refs before hosted-repository parsing and reject traversal segments so GitLab branch refs resolve to the canonical managed install path.
 - **Tlon custom S3 uploads:** pass storage endpoints through the AWS SDK's native parser so custom S3-compatible uploads no longer fail before presigning.

--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -443,6 +443,34 @@ describe("createFeishuClient HTTP timeout", () => {
       },
     );
   });
+
+  it("preserves request-level agents while disabling axios ambient proxy handling", async () => {
+    process.env.HTTPS_PROXY = "http://upper-https:8002";
+    const callerHttpAgent = { caller: "http" };
+    const callerHttpsAgent = { caller: "https" };
+
+    createFeishuClient({
+      appId: "app_12",
+      appSecret: "secret_12", // pragma: allowlist secret
+      accountId: "http-proxy-preserve-agent",
+    });
+
+    const httpInstance = readLastClientHttpInstance();
+    await httpInstance.request({
+      url: "https://example.com/api",
+      httpAgent: callerHttpAgent,
+      httpsAgent: callerHttpsAgent,
+    });
+
+    expect(proxyAgentCtorMock).toHaveBeenCalledTimes(1);
+    expect(mockBaseHttpInstance.request).toHaveBeenCalledWith({
+      url: "https://example.com/api",
+      timeout: FEISHU_HTTP_TIMEOUT_MS,
+      httpAgent: callerHttpAgent,
+      httpsAgent: callerHttpsAgent,
+      proxy: false,
+    });
+  });
 });
 
 describe("createFeishuWSClient proxy handling", () => {

--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -141,13 +141,20 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 type HttpInstanceLike = {
+  request: (options?: Record<string, unknown>) => Promise<unknown>;
   get: (url: string, options?: Record<string, unknown>) => Promise<unknown>;
   post: (url: string, body?: unknown, options?: Record<string, unknown>) => Promise<unknown>;
 };
 
 function requireHttpInstance(value: unknown): HttpInstanceLike {
-  if (isRecord(value) && typeof value.get === "function" && typeof value.post === "function") {
+  if (
+    isRecord(value) &&
+    typeof value.request === "function" &&
+    typeof value.get === "function" &&
+    typeof value.post === "function"
+  ) {
     return {
+      request: value.request as HttpInstanceLike["request"],
       get: value.get as HttpInstanceLike["get"],
       post: value.post as HttpInstanceLike["post"],
     };
@@ -170,6 +177,7 @@ function firstWsClientOptions(): {
   onReady?: unknown;
   onReconnected?: unknown;
   onReconnecting?: unknown;
+  httpInstance?: unknown;
 } {
   const options = readCallOptions(wsClientCtorMock, 0);
   return {
@@ -179,6 +187,7 @@ function firstWsClientOptions(): {
     onReady: options.onReady,
     onReconnected: options.onReconnected,
     onReconnecting: options.onReconnecting,
+    httpInstance: options.httpInstance,
   };
 }
 
@@ -409,6 +418,31 @@ describe("createFeishuClient HTTP timeout", () => {
       timeout: 45_000,
     });
   });
+
+  it("uses OpenClaw's ambient proxy agent for Feishu HTTP API requests", async () => {
+    process.env.HTTPS_PROXY = "http://upper-https:8002";
+
+    createFeishuClient({
+      appId: "app_11",
+      appSecret: "secret_11", // pragma: allowlist secret
+      accountId: "http-proxy-agent",
+    });
+
+    const httpInstance = readLastClientHttpInstance();
+    await httpInstance.post("https://example.com/api", { data: 1 });
+
+    expect(proxyAgentCtorMock).toHaveBeenCalledTimes(1);
+    expect(mockBaseHttpInstance.post).toHaveBeenCalledWith(
+      "https://example.com/api",
+      { data: 1 },
+      {
+        timeout: FEISHU_HTTP_TIMEOUT_MS,
+        httpAgent: { proxied: true },
+        httpsAgent: { proxied: true },
+        proxy: false,
+      },
+    );
+  });
 });
 
 describe("createFeishuWSClient proxy handling", () => {
@@ -441,6 +475,26 @@ describe("createFeishuWSClient proxy handling", () => {
     expect(options.onReconnecting).toBe(onReconnecting);
     expect(options.wsConfig).toEqual({
       pingTimeout: 3,
+    });
+  });
+
+  it("passes the proxy-aware HTTP instance to Lark.WSClient bootstrap requests", async () => {
+    process.env.HTTPS_PROXY = "http://upper-https:8002";
+
+    await createFeishuWSClient(baseAccount);
+
+    const options = firstWsClientOptions();
+    const httpInstance = requireHttpInstance(options.httpInstance);
+    await httpInstance.request({ url: "https://open.feishu.cn/open-apis/ws/v1" });
+
+    expect(proxyAgentCtorMock).toHaveBeenCalledTimes(2);
+    expect(options.agent).toEqual({ proxied: true });
+    expect(mockBaseHttpInstance.request).toHaveBeenCalledWith({
+      url: "https://open.feishu.cn/open-apis/ws/v1",
+      timeout: FEISHU_HTTP_TIMEOUT_MS,
+      httpAgent: { proxied: true },
+      httpsAgent: { proxied: true },
+      proxy: false,
     });
   });
 

--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -62,7 +62,13 @@ const mockBaseHttpInstance = vi.hoisted(() => {
     },
   };
 });
-const proxyEnvKeys = ["https_proxy", "HTTPS_PROXY", "http_proxy", "HTTP_PROXY"] as const;
+const proxyEnvKeys = [
+  "https_proxy",
+  "HTTPS_PROXY",
+  "http_proxy",
+  "HTTP_PROXY",
+  "OPENCLAW_PROXY_ACTIVE",
+] as const;
 type ProxyEnvKey = (typeof proxyEnvKeys)[number];
 const registerFeishuDocToolsMock = vi.hoisted(() => vi.fn());
 const registerFeishuChatToolsMock = vi.hoisted(() => vi.fn());
@@ -468,6 +474,35 @@ describe("createFeishuClient HTTP timeout", () => {
       timeout: FEISHU_HTTP_TIMEOUT_MS,
       httpAgent: callerHttpAgent,
       httpsAgent: callerHttpsAgent,
+      proxy: false,
+    });
+  });
+
+  it("overrides request-level agents while managed proxy mode is active", async () => {
+    process.env.HTTPS_PROXY = "http://upper-https:8002";
+    process.env.OPENCLAW_PROXY_ACTIVE = "1";
+    const callerHttpAgent = { caller: "http" };
+    const callerHttpsAgent = { caller: "https" };
+
+    createFeishuClient({
+      appId: "app_13",
+      appSecret: "secret_13", // pragma: allowlist secret
+      accountId: "http-proxy-managed-agent",
+    });
+
+    const httpInstance = readLastClientHttpInstance();
+    await httpInstance.request({
+      url: "https://example.com/api",
+      httpAgent: callerHttpAgent,
+      httpsAgent: callerHttpsAgent,
+    });
+
+    expect(proxyAgentCtorMock).toHaveBeenCalledTimes(1);
+    expect(mockBaseHttpInstance.request).toHaveBeenCalledWith({
+      url: "https://example.com/api",
+      timeout: FEISHU_HTTP_TIMEOUT_MS,
+      httpAgent: { proxied: true },
+      httpsAgent: { proxied: true },
       proxy: false,
     });
   });

--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -10,6 +10,7 @@ const FEISHU_HTTP_TIMEOUT_MAX_MS = 300_000;
 type CreateFeishuClient = typeof import("./client.js").createFeishuClient;
 type CreateFeishuWSClient = typeof import("./client.js").createFeishuWSClient;
 type GetFeishuUserAgent = typeof import("./client.js").getFeishuUserAgent;
+type ResetFeishuProxyAgentForTest = typeof import("./client.js").resetFeishuProxyAgentForTest;
 
 const requestInterceptorState = vi.hoisted(() => {
   let registered: ((req: unknown) => unknown) | undefined;
@@ -32,11 +33,8 @@ const wsClientCtorMock = vi.hoisted(() =>
     return { connected: true };
   }),
 );
-const proxyAgentCtorMock = vi.hoisted(() =>
-  vi.fn(function createAmbientNodeProxyAgent() {
-    return { proxied: true };
-  }),
-);
+const proxyAgentInstance = vi.hoisted(() => ({ proxied: true, destroy: vi.fn() }));
+const proxyAgentCtorMock = vi.hoisted(() => vi.fn(() => proxyAgentInstance));
 const mockBaseHttpInstance = vi.hoisted(() => {
   const requestInterceptors = { use: requestInterceptorState.use };
   Object.defineProperty(requestInterceptors, "handlers", {
@@ -83,6 +81,7 @@ const registerFeishuSubagentHooksMock = vi.hoisted(() => vi.fn());
 let createFeishuClient: CreateFeishuClient;
 let createFeishuWSClient: CreateFeishuWSClient;
 let getFeishuUserAgent: GetFeishuUserAgent;
+let resetFeishuProxyAgentForTest: ResetFeishuProxyAgentForTest;
 
 let priorProxyEnv: Partial<Record<ProxyEnvKey, string | undefined>> = {};
 let priorFeishuTimeoutEnv: string | undefined;
@@ -219,7 +218,8 @@ beforeAll(async () => {
     ),
   }));
 
-  ({ createFeishuClient, createFeishuWSClient, getFeishuUserAgent } = await import("./client.js"));
+  ({ createFeishuClient, createFeishuWSClient, getFeishuUserAgent, resetFeishuProxyAgentForTest } =
+    await import("./client.js"));
 });
 
 beforeEach(() => {
@@ -230,6 +230,7 @@ beforeEach(() => {
     priorProxyEnv[key] = process.env[key];
     setFeishuTestEnvValue(key, undefined);
   }
+  resetFeishuProxyAgentForTest();
   vi.clearAllMocks();
 });
 
@@ -241,6 +242,7 @@ afterEach(() => {
 });
 
 afterAll(() => {
+  resetFeishuProxyAgentForTest();
   vi.doUnmock("./channel.js");
   vi.doUnmock("./docx.js");
   vi.doUnmock("./chat.js");
@@ -436,6 +438,7 @@ describe("createFeishuClient HTTP timeout", () => {
 
     const httpInstance = readLastClientHttpInstance();
     await httpInstance.post("https://example.com/api", { data: 1 });
+    await httpInstance.get("https://example.com/other");
 
     expect(proxyAgentCtorMock).toHaveBeenCalledTimes(1);
     expect(mockBaseHttpInstance.post).toHaveBeenCalledWith(
@@ -443,11 +446,17 @@ describe("createFeishuClient HTTP timeout", () => {
       { data: 1 },
       {
         timeout: FEISHU_HTTP_TIMEOUT_MS,
-        httpAgent: { proxied: true },
-        httpsAgent: { proxied: true },
+        httpAgent: proxyAgentInstance,
+        httpsAgent: proxyAgentInstance,
         proxy: false,
       },
     );
+    expect(mockBaseHttpInstance.get).toHaveBeenCalledWith("https://example.com/other", {
+      timeout: FEISHU_HTTP_TIMEOUT_MS,
+      httpAgent: proxyAgentInstance,
+      httpsAgent: proxyAgentInstance,
+      proxy: false,
+    });
   });
 
   it("preserves request-level agents while disabling axios ambient proxy handling", async () => {
@@ -501,10 +510,49 @@ describe("createFeishuClient HTTP timeout", () => {
     expect(mockBaseHttpInstance.request).toHaveBeenCalledWith({
       url: "https://example.com/api",
       timeout: FEISHU_HTTP_TIMEOUT_MS,
-      httpAgent: { proxied: true },
-      httpsAgent: { proxied: true },
+      httpAgent: proxyAgentInstance,
+      httpsAgent: proxyAgentInstance,
       proxy: false,
     });
+  });
+
+  it("falls back to Axios ambient proxy handling when agent creation fails", async () => {
+    process.env.HTTPS_PROXY = "http://upper-https:8002";
+    proxyAgentCtorMock.mockImplementationOnce(() => {
+      throw new Error("proxy agent failed");
+    });
+
+    createFeishuClient({
+      ...baseAccount,
+      accountId: "http-proxy-fallback",
+    });
+
+    const httpInstance = readLastClientHttpInstance();
+    await httpInstance.request({ url: "https://example.com/api" });
+
+    expect(mockBaseHttpInstance.request).toHaveBeenCalledWith({
+      url: "https://example.com/api",
+      timeout: FEISHU_HTTP_TIMEOUT_MS,
+    });
+  });
+
+  it("fails closed when managed proxy agent creation fails", async () => {
+    process.env.HTTPS_PROXY = "http://upper-https:8002";
+    process.env.OPENCLAW_PROXY_ACTIVE = "1";
+    proxyAgentCtorMock.mockImplementationOnce(() => {
+      throw new Error("proxy agent failed");
+    });
+
+    createFeishuClient({
+      ...baseAccount,
+      accountId: "http-proxy-managed-failure",
+    });
+
+    const httpInstance = readLastClientHttpInstance();
+    await expect(httpInstance.request({ url: "https://example.com/api" })).rejects.toThrow(
+      "Feishu managed proxy is active but no proxy agent could be created",
+    );
+    expect(mockBaseHttpInstance.request).not.toHaveBeenCalled();
   });
 });
 
@@ -550,13 +598,13 @@ describe("createFeishuWSClient proxy handling", () => {
     const httpInstance = requireHttpInstance(options.httpInstance);
     await httpInstance.request({ url: "https://open.feishu.cn/open-apis/ws/v1" });
 
-    expect(proxyAgentCtorMock).toHaveBeenCalledTimes(2);
-    expect(options.agent).toEqual({ proxied: true });
+    expect(proxyAgentCtorMock).toHaveBeenCalledTimes(1);
+    expect(options.agent).toBe(proxyAgentInstance);
     expect(mockBaseHttpInstance.request).toHaveBeenCalledWith({
       url: "https://open.feishu.cn/open-apis/ws/v1",
       timeout: FEISHU_HTTP_TIMEOUT_MS,
-      httpAgent: { proxied: true },
-      httpsAgent: { proxied: true },
+      httpAgent: proxyAgentInstance,
+      httpsAgent: proxyAgentInstance,
       proxy: false,
     });
   });
@@ -576,7 +624,7 @@ describe("createFeishuWSClient proxy handling", () => {
 
     expect(proxyAgentCtorMock).toHaveBeenCalledTimes(1);
     const options = firstWsClientOptions();
-    expect(options.agent).toEqual({ proxied: true });
+    expect(options.agent).toBe(proxyAgentInstance);
   });
 
   it("creates a ws proxy agent when uppercase HTTPS_PROXY is set", async () => {
@@ -586,7 +634,7 @@ describe("createFeishuWSClient proxy handling", () => {
 
     expect(proxyAgentCtorMock).toHaveBeenCalledTimes(1);
     const options = firstWsClientOptions();
-    expect(options.agent).toEqual({ proxied: true });
+    expect(options.agent).toBe(proxyAgentInstance);
   });
 
   it("falls back to HTTP_PROXY for ws proxy agent creation", async () => {
@@ -596,6 +644,6 @@ describe("createFeishuWSClient proxy handling", () => {
 
     expect(proxyAgentCtorMock).toHaveBeenCalledTimes(1);
     const options = firstWsClientOptions();
-    expect(options.agent).toEqual({ proxied: true });
+    expect(options.agent).toBe(proxyAgentInstance);
   });
 });

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -85,12 +85,59 @@ type FeishuHttpInstanceLike = Pick<
   "request" | "get" | "post" | "put" | "patch" | "delete" | "head" | "options"
 >;
 
-async function getWsProxyAgent() {
-  return resolveAmbientNodeProxyAgent<Agent>();
-}
-
 function isManagedProxyActive() {
   return process.env["OPENCLAW_PROXY_ACTIVE"] === "1";
+}
+
+let cachedFeishuProxyAgent: Agent | undefined;
+let pendingFeishuProxyAgent: Promise<Agent | undefined> | undefined;
+let feishuProxyAgentGeneration = 0;
+
+// Ambient proxy configuration is process-stable. Share one dual-protocol agent
+// across REST, bootstrap, and WebSocket traffic so connections stay pooled.
+async function getFeishuProxyAgent(): Promise<Agent | undefined> {
+  if (cachedFeishuProxyAgent) {
+    return cachedFeishuProxyAgent;
+  }
+  if (pendingFeishuProxyAgent) {
+    return pendingFeishuProxyAgent;
+  }
+
+  const generation = feishuProxyAgentGeneration;
+  let resolutionError: unknown;
+  const pending = resolveAmbientNodeProxyAgent<Agent>({
+    onError: (error) => {
+      resolutionError = error;
+    },
+  }).then((agent) => {
+    if (generation !== feishuProxyAgentGeneration) {
+      agent?.destroy();
+      return undefined;
+    }
+    if (!agent && isManagedProxyActive()) {
+      throw new Error("Feishu managed proxy is active but no proxy agent could be created", {
+        cause: resolutionError,
+      });
+    }
+    cachedFeishuProxyAgent = agent;
+    return agent;
+  });
+  pendingFeishuProxyAgent = pending;
+  try {
+    return await pending;
+  } finally {
+    if (pendingFeishuProxyAgent === pending) {
+      pendingFeishuProxyAgent = undefined;
+    }
+  }
+}
+
+/** @internal Resets process-scoped proxy state between tests. */
+export function resetFeishuProxyAgentForTest(): void {
+  feishuProxyAgentGeneration += 1;
+  pendingFeishuProxyAgent = undefined;
+  cachedFeishuProxyAgent?.destroy();
+  cachedFeishuProxyAgent = undefined;
 }
 
 type FeishuProxyAwareHttpRequestOptions<D> = Lark.HttpRequestOptions<D> & {
@@ -131,7 +178,7 @@ function createFeishuHttpInstance(defaultTimeoutMs: number): Lark.HttpInstance {
     opts?: Lark.HttpRequestOptions<D>,
   ): Promise<FeishuProxyAwareHttpRequestOptions<D>> {
     const next: FeishuProxyAwareHttpRequestOptions<D> = { timeout: defaultTimeoutMs, ...opts };
-    const agent = await getWsProxyAgent();
+    const agent = await getFeishuProxyAgent();
     if (agent) {
       if (isManagedProxyActive()) {
         next.httpAgent = agent;
@@ -231,7 +278,7 @@ export async function createFeishuWSClient(
     throw new Error(`Feishu credentials not configured for account "${accountId}"`);
   }
 
-  const agent = await getWsProxyAgent();
+  const agent = await getFeishuProxyAgent();
   const defaultHttpTimeoutMs = resolveConfiguredHttpTimeoutMs(account);
   return new feishuClientSdk.WSClient({
     appId,

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -89,6 +89,12 @@ async function getWsProxyAgent() {
   return resolveAmbientNodeProxyAgent<Agent>();
 }
 
+type FeishuProxyAwareHttpRequestOptions<D> = Lark.HttpRequestOptions<D> & {
+  httpAgent?: Agent;
+  httpsAgent?: Agent;
+  proxy?: false;
+};
+
 // Multi-account client cache
 const clientCache = new Map<
   string,
@@ -111,24 +117,34 @@ function resolveDomain(domain: FeishuDomain | undefined): Lark.Domain | string {
 /**
  * Create an HTTP instance that delegates to the Lark SDK's default instance
  * but injects a default request timeout and User-Agent header to prevent
- * indefinite hangs and set a standardized User-Agent per OAPI best practices.
+ * indefinite hangs, set a standardized User-Agent per OAPI best practices, and
+ * keep axios from taking a separate ambient proxy path for HTTPS requests.
  */
-function createTimeoutHttpInstance(defaultTimeoutMs: number): Lark.HttpInstance {
+function createFeishuHttpInstance(defaultTimeoutMs: number): Lark.HttpInstance {
   const base: FeishuHttpInstanceLike = feishuClientSdk.defaultHttpInstance;
 
-  function injectTimeout<D>(opts?: Lark.HttpRequestOptions<D>): Lark.HttpRequestOptions<D> {
-    return { timeout: defaultTimeoutMs, ...opts } as Lark.HttpRequestOptions<D>;
+  async function injectRequestOptions<D>(
+    opts?: Lark.HttpRequestOptions<D>,
+  ): Promise<FeishuProxyAwareHttpRequestOptions<D>> {
+    const next: FeishuProxyAwareHttpRequestOptions<D> = { timeout: defaultTimeoutMs, ...opts };
+    const agent = await getWsProxyAgent();
+    if (agent) {
+      next.httpAgent = agent;
+      next.httpsAgent = agent;
+      next.proxy = false;
+    }
+    return next;
   }
 
   return {
-    request: (opts) => base.request(injectTimeout(opts)),
-    get: (url, opts) => base.get(url, injectTimeout(opts)),
-    post: (url, data, opts) => base.post(url, data, injectTimeout(opts)),
-    put: (url, data, opts) => base.put(url, data, injectTimeout(opts)),
-    patch: (url, data, opts) => base.patch(url, data, injectTimeout(opts)),
-    delete: (url, opts) => base.delete(url, injectTimeout(opts)),
-    head: (url, opts) => base.head(url, injectTimeout(opts)),
-    options: (url, opts) => base.options(url, injectTimeout(opts)),
+    request: async (opts) => base.request(await injectRequestOptions(opts)),
+    get: async (url, opts) => base.get(url, await injectRequestOptions(opts)),
+    post: async (url, data, opts) => base.post(url, data, await injectRequestOptions(opts)),
+    put: async (url, data, opts) => base.put(url, data, await injectRequestOptions(opts)),
+    patch: async (url, data, opts) => base.patch(url, data, await injectRequestOptions(opts)),
+    delete: async (url, opts) => base.delete(url, await injectRequestOptions(opts)),
+    head: async (url, opts) => base.head(url, await injectRequestOptions(opts)),
+    options: async (url, opts) => base.options(url, await injectRequestOptions(opts)),
   };
 }
 
@@ -175,7 +191,7 @@ export function createFeishuClient(creds: FeishuClientCredentials): Lark.Client 
     appSecret,
     appType: feishuClientSdk.AppType.SelfBuild,
     domain: resolveDomain(domain),
-    httpInstance: createTimeoutHttpInstance(defaultHttpTimeoutMs),
+    httpInstance: createFeishuHttpInstance(defaultHttpTimeoutMs),
   });
 
   // Cache it
@@ -207,10 +223,12 @@ export async function createFeishuWSClient(
   }
 
   const agent = await getWsProxyAgent();
+  const defaultHttpTimeoutMs = resolveConfiguredHttpTimeoutMs(account);
   return new feishuClientSdk.WSClient({
     appId,
     appSecret,
     domain: resolveDomain(domain),
+    httpInstance: createFeishuHttpInstance(defaultHttpTimeoutMs),
     ...callbacks,
     loggerLevel: feishuClientSdk.LoggerLevel.info,
     wsConfig: FEISHU_WS_CONFIG,

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -89,6 +89,10 @@ async function getWsProxyAgent() {
   return resolveAmbientNodeProxyAgent<Agent>();
 }
 
+function isManagedProxyActive() {
+  return process.env["OPENCLAW_PROXY_ACTIVE"] === "1";
+}
+
 type FeishuProxyAwareHttpRequestOptions<D> = Lark.HttpRequestOptions<D> & {
   httpAgent?: Agent;
   httpsAgent?: Agent;
@@ -129,8 +133,13 @@ function createFeishuHttpInstance(defaultTimeoutMs: number): Lark.HttpInstance {
     const next: FeishuProxyAwareHttpRequestOptions<D> = { timeout: defaultTimeoutMs, ...opts };
     const agent = await getWsProxyAgent();
     if (agent) {
-      next.httpAgent ??= agent;
-      next.httpsAgent ??= agent;
+      if (isManagedProxyActive()) {
+        next.httpAgent = agent;
+        next.httpsAgent = agent;
+      } else {
+        next.httpAgent ??= agent;
+        next.httpsAgent ??= agent;
+      }
       next.proxy = false;
     }
     return next;

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -129,8 +129,8 @@ function createFeishuHttpInstance(defaultTimeoutMs: number): Lark.HttpInstance {
     const next: FeishuProxyAwareHttpRequestOptions<D> = { timeout: defaultTimeoutMs, ...opts };
     const agent = await getWsProxyAgent();
     if (agent) {
-      next.httpAgent = agent;
-      next.httpsAgent = agent;
+      next.httpAgent ??= agent;
+      next.httpsAgent ??= agent;
       next.proxy = false;
     }
     return next;


### PR DESCRIPTION
AI-assisted contribution.

## What Problem This Solves

Feishu REST calls, WebSocket endpoint discovery, and the WebSocket connection itself did not share one ambient proxy transport. Proxy-only deployments could therefore fail during token/API calls or WebSocket startup even when `HTTP_PROXY` / `HTTPS_PROXY` was configured.

Fixes #48949.

## Why This Change Was Made

- Resolve one process-scoped `ProxylineNodeProxyAgent` and reuse it across Feishu REST, SDK bootstrap, and WebSocket traffic.
- Preserve caller-provided HTTP agents in ordinary ambient-proxy mode.
- Override caller agents and fail closed when OpenClaw managed-proxy mode is active, preventing direct-network bypass.
- Keep Axios ambient proxy behavior available if ordinary unmanaged agent construction fails.

The Feishu SDK exposes separate `httpInstance` and WebSocket `agent` seams; using the same dual-protocol Proxyline agent at both seams keeps ownership in the Feishu plugin and preserves connection pooling.

## User Impact

Feishu installations behind an HTTP(S) proxy can authenticate, complete WebSocket endpoint discovery, and maintain the WebSocket session through the configured proxy. No new configuration is introduced.

## Evidence

- Blacksmith Testbox: `pnpm test extensions/feishu/src/client.test.ts` — 24/24 passed.
- Blacksmith Testbox: targeted `oxfmt --check` passed for the touched TypeScript files and changelog.
- Live Testbox probe traversed a real local CONNECT proxy to `open.feishu.cn:443`; fake credentials reached Feishu and failed authentication only after the proxy tunnel succeeded.
- Contributor live environment: WSL2 Ubuntu, OpenClaw 2026.5.22, systemd gateway, and `HTTP_PROXY` / `HTTPS_PROXY` / `OPENCLAW_PROXY_URL` configured. After applying the equivalent installed-package fix, `openclaw channels status --channel feishu --deep --probe` reported `enabled, configured, running, works`; logs reported the bot identity resolved and WebSocket client ready without the prior HTTP-to-HTTPS failure.
- Fresh maintainer autoreview: clean, confidence 0.91.
- Exact-head GitHub CI: pending for `af7b69515f1a3df25d0279d3bad6f70e4341e746`.

Testbox run: https://github.com/openclaw/openclaw/actions/runs/29390928814