### PR TITLE
docs(telegram): note native progress draft control tradeoff

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -323,7 +323,11 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     Tool-progress preview updates are the short status lines shown while tools run, for example command execution, file reads, planning updates, patch summaries, or Codex preamble/commentary text in Codex app-server mode. Telegram keeps these enabled by default to match released OpenClaw behavior from `v2026.4.22` and later.
 
-    Direct chats can use native Telegram drafts for these tool-progress lines without persisting tool chatter into chat history. Native drafts stop before answer text starts; final answers stay on the normal persistent delivery path. This lane is off by default and should be gated to trusted DM IDs first:
+    Direct chats can use native Telegram drafts for these tool-progress lines without persisting tool chatter into chat history. Native drafts stop before answer text starts; final answers stay on the normal persistent delivery path. This lane is off by default and should be gated to trusted DM IDs first.
+
+    <Warning>
+      Native tool-progress drafts use Telegram's `sendMessageDraft` action. Some Telegram clients, including Telegram Android, can treat an active bot draft as a passive-viewing state and replace the normal send control while the draft is active. Keep `nativeToolProgress` disabled when users need to send `/steer`, `/stop`, corrections, or other mid-run follow-ups from the same chat. Use the regular edited preview lane (`toolProgress: true`, `nativeToolProgress: false`) for interactive control workflows.
+    </Warning>
 
     ```json
     {


### PR DESCRIPTION
## Summary

- Document that Telegram native tool-progress drafts use `sendMessageDraft` and can leave some clients, including Telegram Android, in a passive-viewing state while active.
- Recommend keeping `nativeToolProgress` disabled for workflows that need `/steer`, `/stop`, corrections, or mid-run follow-ups from the same chat.
- Point interactive users at the existing edited preview lane with `toolProgress: true` and `nativeToolProgress: false`.

Fixes #86195

## Tests

- `pnpm docs:list`
- `git diff --check`
- `pnpm docs:check-mdx`
- `pnpm docs:check-links`

## Real behavior proof

Behavior addressed: Telegram docs now explain the native `sendMessageDraft` tool-progress tradeoff and the safer interactive-control configuration for users who need to steer or stop active runs from the same chat.

Real environment tested: Local OpenClaw docs checkout on macOS using the repository docs validation scripts against this patch.

Exact steps or command run after this patch: `pnpm docs:list`; `git diff --check`; `pnpm docs:check-mdx`; `pnpm docs:check-links`.

Evidence after fix: After-fix terminal capture from the local docs checkout:

```text
$ pnpm docs:list
$ node scripts/docs-list.js
Listing all markdown files in docs folder:
...
channels/telegram.md - Telegram bot support status, capabilities, and configuration
  Read when: Working on Telegram features or webhooks
...
Reminder: keep docs up to date as behavior changes.

$ git diff --check

$ pnpm docs:check-mdx
$ node scripts/check-docs-mdx.mjs docs README.md
Docs MDX check passed (655 files, 5357ms).

$ pnpm docs:check-links
$ node scripts/docs-link-audit.mjs
checked_internal_links=4457
broken_links=0
```

Observed result after fix: The Telegram channel docs render as valid MDX and have no broken internal links after adding the warning about native tool-progress drafts and interactive control.

What was not tested: A live Telegram Android composer-lock reproduction was not run for this docs-only change; the documented behavior is based on the issue report and the existing opt-in OpenClaw `sendMessageDraft` behavior.