### PR TITLE
fix(cron-cli): accept '+duration' form in `--at` as documented (#86230)

### DIFF
--- a/src/cli/cron-cli/schedule-options.ts
+++ b/src/cli/cron-cli/schedule-options.ts
@@ -104,7 +104,9 @@ function resolveDirectSchedule(options: NormalizedScheduleOptions): CronSchedule
   if (options.at) {
     const atIso = parseAt(options.at, options.tz);
     if (!atIso) {
-      throw new Error("Invalid --at. Use an ISO timestamp or a duration like 20m.");
+      throw new Error(
+        'Invalid --at. Use an ISO timestamp or a duration like "20m" (also accepts "+20m").',
+      );
     }
     return { kind: "at", at: atIso };
   }

--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -4,6 +4,7 @@ import type { RuntimeEnv } from "../../runtime.js";
 import {
   coerceCronDeliveryPreviews,
   getCronChannelOptions,
+  parseAt,
   parseCronToolsAllow,
   printCronList,
 } from "./shared.js";
@@ -278,5 +279,31 @@ describe("coerceCronDeliveryPreviews", () => {
         },
       }).size,
     ).toBe(0);
+  });
+});
+
+describe("parseAt", () => {
+  it("accepts bare relative durations (\"30m\")", () => {
+    const before = Date.now();
+    const iso = parseAt("30m");
+    expect(iso).not.toBeNull();
+    const ms = new Date(iso as string).getTime();
+    expect(ms - before).toBeGreaterThanOrEqual(30 * 60_000 - 5);
+    expect(ms - before).toBeLessThan(30 * 60_000 + 5_000);
+  });
+
+  it("accepts leading-plus relative durations (\"+30m\") to match --at help text", () => {
+    const before = Date.now();
+    const iso = parseAt("+30m");
+    expect(iso).not.toBeNull();
+    const ms = new Date(iso as string).getTime();
+    expect(ms - before).toBeGreaterThanOrEqual(30 * 60_000 - 5);
+    expect(ms - before).toBeLessThan(30 * 60_000 + 5_000);
+  });
+
+  it("rejects garbage input", () => {
+    expect(parseAt("not-a-time")).toBeNull();
+    expect(parseAt("+")).toBeNull();
+    expect(parseAt("")).toBeNull();
   });
 });

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -177,7 +177,10 @@ export function parseAt(input: string, tz?: string): string | null {
   if (absolute !== null) {
     return new Date(absolute).toISOString();
   }
-  const dur = parseDurationMs(raw);
+  // Accept both bare ("30m") and leading-plus ("+30m") relative durations.
+  // The leading-plus form mirrors the `--at` help text and `at(1)`-style tools.
+  const durationCandidate = /^\+\d/.test(raw) ? raw.slice(1) : raw;
+  const dur = parseDurationMs(durationCandidate);
   if (dur !== null) {
     return new Date(Date.now() + dur).toISOString();
   }


### PR DESCRIPTION
## Problem

`openclaw cron add --help` documents `--at` as:

```
--at <when>  Run once at time (ISO with offset, or +duration). Use --tz for offset-less datetimes
```

But the validator rejected the documented `+duration` form:

```
$ openclaw cron add --at '+30m' ...
Error: Invalid --at. Use an ISO timestamp or a duration like 20m.
```

Scripts that lifted `+30m` from the help text silently failed to schedule (see #86230 for the downstream skill that hit this).

## Fix

- `parseAt` now accepts both `30m` and `+30m` (strips a single leading `+` before delegating to `parseDurationMs`). Backward compatible.
- Validator error message updated to mention both forms.
- Added unit tests for bare, leading-plus, and rejection cases.

## Test

```
$ node scripts/run-vitest.mjs run src/cli/cron-cli/shared.test.ts
Test Files  1 passed (1)
     Tests  24 passed (24)
```

Closes #86230