### PR TITLE
fix(launcher): detect Bun's module-not-found errors in `openclaw.mjs` (#86198)

### DIFF
--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -247,8 +247,20 @@ if (
   }
 }
 
-const isModuleNotFoundError = (err) =>
-  err && typeof err === "object" && "code" in err && err.code === "ERR_MODULE_NOT_FOUND";
+const isModuleNotFoundError = (err) => {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  // Node sets code === "ERR_MODULE_NOT_FOUND". Bun (as of v1.3.x) does not set
+  // this code on its module-resolution errors, so we also accept the textual
+  // signature when code is absent or different.
+  if ("code" in err && err.code === "ERR_MODULE_NOT_FOUND") {
+    return true;
+  }
+  const message =
+    "message" in err && typeof err.message === "string" ? err.message : "";
+  return /Cannot find module/.test(message);
+};
 
 const isDirectModuleNotFoundError = (err, specifier) => {
   if (!isModuleNotFoundError(err)) {
@@ -264,7 +276,11 @@ const isDirectModuleNotFoundError = (err, specifier) => {
   const expectedPath = fileURLToPath(expectedUrl);
   return (
     message.includes(`Cannot find module '${expectedPath}'`) ||
-    message.includes(`Cannot find module "${expectedPath}"`)
+    message.includes(`Cannot find module "${expectedPath}"`) ||
+    // Bun reports the raw specifier (relative form) in its error message,
+    // not the resolved absolute path that Node uses.
+    message.includes(`Cannot find module '${specifier}'`) ||
+    message.includes(`Cannot find module "${specifier}"`)
   );
 };
 


### PR DESCRIPTION
## Problem

`openclaw` fails to start under Bun with:

```
error: Cannot find module './dist/warning-filter.js' from '.../openclaw.mjs'
```

The launcher in `openclaw.mjs` intentionally treats the optional `./dist/warning-filter.{js,mjs}` import as best-effort and silently continues if absent. The guard `isDirectModuleNotFoundError` checks `err.code === 'ERR_MODULE_NOT_FOUND'`, but Bun (v1.3.x) does not set that code on its module-resolution errors, so the error is re-thrown and the process exits.

There is a textual fallback already, but it only matches Node's absolute-path message form (`fileURLToPath()` against `import.meta.url`). Bun's error message contains the raw relative specifier instead.

## Fix

1. `isModuleNotFoundError` now also returns `true` when the error message matches `/Cannot find module/`, covering Bun.
2. `isDirectModuleNotFoundError` now additionally matches Bun's message form, which embeds the original specifier (e.g. `'./dist/warning-filter.js'`) rather than the resolved absolute path.

Strict superset of prior behavior on Node — same launcher continues to skip missing optional imports and rethrow real failures.

## Verification

Simulated Bun-style error against the relaxed message check:

```
$ node -e '...' # uses raw Bun-format error string
bun-msg matches: true
```

Closes #86198