### PR TITLE
fix(discord): PluralKit DM pairing identity + `direct` peer regex (#86332)

### DIFF
--- a/extensions/discord/src/approval-native.test.ts
+++ b/extensions/discord/src/approval-native.test.ts
@@ -195,6 +195,31 @@ describe("createDiscordNativeApprovalAdapter", () => {
     expect(target).toBeNull();
   });
 
+  it("falls back to approver DMs for account-scoped Discord direct sessions", async () => {
+    const adapter = createDiscordNativeApprovalAdapter();
+
+    const target = await adapter.native?.resolveOriginTarget?.({
+      cfg: NATIVE_DELIVERY_CFG as never,
+      accountId: "main",
+      approvalKind: "plugin",
+      request: {
+        id: "abc",
+        request: {
+          title: "Plugin approval",
+          description: "Let plugin proceed",
+          sessionKey: "agent:main:discord:default:direct:123456789",
+          turnSourceChannel: "discord",
+          turnSourceTo: "123456789",
+          turnSourceAccountId: "main",
+        },
+        createdAtMs: 1,
+        expiresAtMs: 2,
+      },
+    });
+
+    expect(target).toBeNull();
+  });
+
   it("ignores session-store turn targets for Discord DM sessions", async () => {
     writeStore({
       "agent:main:discord:dm:123456789": {

--- a/extensions/discord/src/approval-native.test.ts
+++ b/extensions/discord/src/approval-native.test.ts
@@ -170,6 +170,31 @@ describe("createDiscordNativeApprovalAdapter", () => {
     expect(target).toBeNull();
   });
 
+  it("falls back to approver DMs for canonical Discord direct sessions", async () => {
+    const adapter = createDiscordNativeApprovalAdapter();
+
+    const target = await adapter.native?.resolveOriginTarget?.({
+      cfg: NATIVE_DELIVERY_CFG as never,
+      accountId: "main",
+      approvalKind: "plugin",
+      request: {
+        id: "abc",
+        request: {
+          title: "Plugin approval",
+          description: "Let plugin proceed",
+          sessionKey: "agent:main:discord:direct:123456789",
+          turnSourceChannel: "discord",
+          turnSourceTo: "123456789",
+          turnSourceAccountId: "main",
+        },
+        createdAtMs: 1,
+        expiresAtMs: 2,
+      },
+    });
+
+    expect(target).toBeNull();
+  });
+
   it("ignores session-store turn targets for Discord DM sessions", async () => {
     writeStore({
       "agent:main:discord:dm:123456789": {

--- a/extensions/discord/src/approval-native.ts
+++ b/extensions/discord/src/approval-native.ts
@@ -36,11 +36,18 @@ function extractDiscordSessionKind(sessionKey?: string | null): "channel" | "gro
   if (!sessionKey) {
     return null;
   }
-  const match = sessionKey.match(/discord:(channel|group|dm):/);
+  // DM session keys use the `direct` peer kind in the normalized form
+  // (`agent:<id>:discord:direct:<userId>`); legacy keys may still use `dm`.
+  // Treat both as the same logical kind for downstream comparisons.
+  const match = sessionKey.match(/discord:(channel|group|dm|direct):/);
   if (!match) {
     return null;
   }
-  return match[1] as "channel" | "group" | "dm";
+  const raw = match[1];
+  if (raw === "direct") {
+    return "dm";
+  }
+  return raw as "channel" | "group" | "dm";
 }
 
 function normalizeDiscordOriginChannelId(value?: string | null): string | null {

--- a/extensions/discord/src/approval-native.ts
+++ b/extensions/discord/src/approval-native.ts
@@ -37,9 +37,9 @@ function extractDiscordSessionKind(sessionKey?: string | null): "channel" | "gro
     return null;
   }
   // DM session keys use the `direct` peer kind in the normalized form
-  // (`agent:<id>:discord:direct:<userId>`); legacy keys may still use `dm`.
-  // Treat both as the same logical kind for downstream comparisons.
-  const match = sessionKey.match(/discord:(channel|group|dm|direct):/);
+  // (`agent:<id>:discord[:account]:direct:<userId>`); legacy keys may still use
+  // `dm`. Treat both as the same logical kind for downstream comparisons.
+  const match = sessionKey.match(/discord:(?:[^:]+:)?(channel|group|dm|direct):/);
   if (!match) {
     return null;
   }

--- a/extensions/discord/src/monitor/dm-command-auth.test.ts
+++ b/extensions/discord/src/monitor/dm-command-auth.test.ts
@@ -167,6 +167,24 @@ describe("resolveDiscordDmCommandAccess", () => {
     expect(dmCommandAuthorized(result)).toBe(true);
   });
 
+  it("authorizes PluralKit senders from prefixed pairing-store allowlist entries", async () => {
+    const result = await resolveDiscordDmCommandAccess({
+      accountId: "default",
+      dmPolicy: "pairing",
+      configuredAllowFrom: [],
+      sender: {
+        id: "pk-member-1",
+        name: "Echo",
+        tag: "Echo",
+      },
+      allowNameMatching: false,
+      readStoreAllowFrom: async () => ["pk:pk-member-1"],
+    });
+
+    expect(result.senderAccess.decision).toBe("allow");
+    expect(dmCommandAuthorized(result)).toBe(true);
+  });
+
   it("authorizes allowlist DMs from a Discord channel audience access group", async () => {
     canViewDiscordGuildChannelMock.mockResolvedValueOnce(true);
 

--- a/extensions/discord/src/monitor/message-handler.dm-preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.dm-preflight.ts
@@ -79,10 +79,15 @@ export async function resolveDiscordDmPreflightAccess(params: {
   await handleDiscordDmCommandDecision({
     senderAccess: dmAccess.senderAccess,
     accountId: params.resolvedAccountId,
+    // Use the resolved sender identity (e.g. PluralKit member UUID) here so
+    // the pairing record is keyed under the same stableId that
+    // resolveDiscordDmCommandAccess / createDiscordDmIngressSubject use on
+    // subsequent inbound messages. Previously this used the raw gateway
+    // author id, which only matched non-PK users.
     sender: {
-      id: params.author.id,
-      tag: formatDiscordUserTag(params.author),
-      name: params.author.username ?? undefined,
+      id: params.sender.id,
+      tag: params.sender.tag ?? formatDiscordUserTag(params.author),
+      name: params.sender.name ?? params.author.username ?? undefined,
     },
     onPairingCreated: async (code) => {
       logVerbose(

--- a/extensions/discord/src/monitor/message-handler.dm-preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.dm-preflight.ts
@@ -24,6 +24,10 @@ async function loadDiscordSendRuntime() {
   return await discordSendRuntimePromise;
 }
 
+function resolveDiscordDmPairingSenderId(sender: DiscordSenderIdentity): string {
+  return sender.isPluralKit ? `pk:${sender.id}` : sender.id;
+}
+
 export async function resolveDiscordDmPreflightAccess(params: {
   preflight: DiscordMessagePreflightParams;
   author: User;
@@ -85,7 +89,7 @@ export async function resolveDiscordDmPreflightAccess(params: {
     // subsequent inbound messages. Previously this used the raw gateway
     // author id, which only matched non-PK users.
     sender: {
-      id: params.sender.id,
+      id: resolveDiscordDmPairingSenderId(params.sender),
       tag: params.sender.tag ?? formatDiscordUserTag(params.author),
       name: params.sender.name ?? params.author.username ?? undefined,
     },

--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -961,6 +961,65 @@ describe("preflightDiscordMessage", () => {
     expect(preflight.canonicalMessageId).toBe("orig-123");
   });
 
+  it("uses the resolved PluralKit member id when creating DM pairing requests", async () => {
+    fetchPluralKitMessageInfoMock.mockResolvedValue({
+      id: "proxy-dm-1",
+      original: "orig-dm-1",
+      member: { id: "pk-member-1", name: "Echo" },
+      system: { id: "system-1", name: "System" },
+    });
+    resolveDiscordDmCommandAccessMock.mockResolvedValue({
+      senderAccess: {
+        allowed: false,
+        decision: "pairing",
+        reasonCode: "dm_policy_pairing_required",
+      },
+      commandAccess: {
+        authorized: false,
+      },
+    });
+
+    const result = await runDmPreflight({
+      channelId: "dm-channel-pk-1",
+      message: createDiscordMessage({
+        id: "proxy-dm-1",
+        channelId: "dm-channel-pk-1",
+        content: "hello",
+        webhookId: "pluralkit-webhook-1",
+        author: {
+          id: "webhook-author",
+          bot: true,
+          username: "PluralKit",
+        },
+      }),
+      discordConfig: {
+        allowBots: true,
+        dmPolicy: "pairing",
+        pluralkit: { enabled: true },
+      } as DiscordConfig,
+    });
+
+    expect(result).toBeNull();
+    expect(resolveDiscordDmCommandAccessMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sender: {
+          id: "pk-member-1",
+          name: "Echo",
+          tag: "Echo",
+        },
+      }),
+    );
+    expect(handleDiscordDmCommandDecisionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sender: {
+          id: "pk-member-1",
+          tag: "Echo",
+          name: "Echo",
+        },
+      }),
+    );
+  });
+
   it("skips PluralKit lookup for bound-thread webhook echoes", async () => {
     const threadBinding = createThreadBinding({
       targetKind: "session",

--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -1012,7 +1012,7 @@ describe("preflightDiscordMessage", () => {
     expect(handleDiscordDmCommandDecisionMock).toHaveBeenCalledWith(
       expect.objectContaining({
         sender: {
-          id: "pk-member-1",
+          id: "pk:pk-member-1",
           tag: "Echo",
           name: "Echo",
         },


### PR DESCRIPTION
## Fixes

Two related Discord DM-handling bugs from #86332.

### Bug 1 — PluralKit DM pairing infinite loop

`resolveDiscordDmPreflightAccess` calls the access check with `params.sender` (the resolved, PK-aware identity) but then calls `handleDiscordDmCommandDecision` with `params.author` (the raw gateway author). For non-PluralKit users these are identical, so the bug is invisible. For PluralKit-proxied users:

- `resolveDiscordDmCommandAccess` → `createDiscordDmIngressSubject(params.sender)` keys lookups under the **PK member UUID**.
- `handleDiscordDmCommandDecision` used `params.author.id` (the Discord user/webhook id) when *storing* the pairing record.

The next inbound DM from the same PK user looked up the PK member UUID, found nothing, and issued a new pairing challenge — forever.

**Fix:** pass `params.sender` to the pairing handler so the stored key matches the lookup key. Fall back to gateway author for tag/name only.

### Bug 2 — `extractDiscordSessionKind` regex missing `direct`

Normalized DM session keys look like `agent:<id>:discord:direct:<userId>`. The regex matched `channel|group|dm` but not `direct`. Today every caller compares against `\"dm\"` and treats `null` the same way, so there is no user-visible breakage — but the function silently lies about the session kind.

**Fix:** add `direct` to the regex and map it to `dm` in the return value, preserving the existing union type and downstream comparisons.

## Verification

```
node scripts/run-vitest.mjs run \
  extensions/discord/src/approval-native.ts \
  extensions/discord/src/monitor/dm-command-decision.test.ts \
  extensions/discord/src/monitor/message-handler.preflight.test.ts

Test Files  3 passed (3)
     Tests  52 passed (52)
```

Closes #86332