### PR TITLE
feat(webchat): render allowlisted custom protocol links as clickable (#86334)

### DIFF
--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -537,6 +537,25 @@ describe("toSanitizedMarkdownHtml", () => {
       const html = toSanitizedMarkdownHtml("[click](file:///etc/passwd)");
       expect(html).toBe("<p><a>click</a></p>\n");
     });
+
+    it("keeps href for allowlisted custom productivity-app schemes (#86334)", () => {
+      const obsidian = toSanitizedMarkdownHtml(
+        "[note](obsidian://open?vault=Personal%20Vault&file=Plans%2FTest)",
+      );
+      expect(obsidian).toContain('href="obsidian://');
+      expect(obsidian).toContain('rel="noreferrer noopener"');
+
+      const things = toSanitizedMarkdownHtml("[t](things:///add?title=hi)");
+      expect(things).toContain('href="things://');
+
+      const shortcuts = toSanitizedMarkdownHtml("[s](shortcuts://run-shortcut?name=foo)");
+      expect(shortcuts).toContain('href="shortcuts://');
+    });
+
+    it("still strips href for non-allowlisted custom schemes", () => {
+      const html = toSanitizedMarkdownHtml("[x](weirdscheme://payload)");
+      expect(html).toBe("<p><a>x</a></p>\n");
+    });
   });
 
   describe("ReDoS protection", () => {

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -76,6 +76,13 @@ const sanitizeOptions = {
   ALLOWED_TAGS: allowedTags,
   ALLOWED_ATTR: allowedAttrs,
   ADD_DATA_URI_TAGS: ["img"],
+  // Allow the http/https/mailto baseline plus the custom productivity-app
+  // schemes whitelisted in ALLOWED_CUSTOM_LINK_SCHEMES (see #86334). The
+  // afterSanitizeAttributes hook still validates each href against the
+  // explicit allowlist; this regex only prevents DOMPurify from stripping
+  // the href before our hook runs.
+  ALLOWED_URI_REGEXP:
+    /^(?:(?:https?|mailto|obsidian|things|fantastical|shortcuts|craftdocs|notion|bear|ulysses|drafts|hook|x-apple-reminderkit|calshow):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
 };
 
 let hooksInstalled = false;
@@ -86,6 +93,30 @@ const MARKDOWN_CACHE_MAX_CHARS = 50_000;
 const INLINE_DATA_IMAGE_RE = /^data:image\/[a-z0-9.+-]+;base64,/i;
 const markdownCache = new Map<string, string>();
 const TAIL_LINK_BLUR_CLASS = "chat-link-tail-blur";
+
+// Custom URI schemes that are commonly used by note-taking and productivity
+// apps (Obsidian, Things, Fantastical, Shortcuts, etc). These are rendered
+// as clickable anchors when used inside explicit markdown link syntax
+// `[text](scheme://...)`. The OS routes them to the registered app.
+//
+// DOMPurify strips most non-http schemes by default, so we keep the anchor
+// `href` instead of clearing it. Schemes not in this list (or in the
+// http/https/mailto baseline) are stripped — defense in depth against
+// `javascript:`, `data:`, `vbscript:`, etc.
+const ALLOWED_CUSTOM_LINK_SCHEMES = new Set([
+  "obsidian:",
+  "things:",
+  "fantastical:",
+  "shortcuts:",
+  "craftdocs:",
+  "notion:",
+  "bear:",
+  "ulysses:",
+  "drafts:",
+  "hook:",
+  "x-apple-reminderkit:",
+  "calshow:",
+]);
 
 // CJK character ranges for URL boundary detection (RFC 3986: CJK is not valid in raw URLs).
 // CJK Unified Ideographs, CJK Symbols/Punctuation, Fullwidth Forms, Hiragana, Katakana,
@@ -133,7 +164,12 @@ function installHooks() {
     // Block dangerous URL schemes (javascript:, data:, vbscript:, etc.)
     try {
       const url = new URL(href, window.location.href);
-      if (url.protocol !== "http:" && url.protocol !== "https:" && url.protocol !== "mailto:") {
+      const safe =
+        url.protocol === "http:" ||
+        url.protocol === "https:" ||
+        url.protocol === "mailto:" ||
+        ALLOWED_CUSTOM_LINK_SCHEMES.has(url.protocol);
+      if (!safe) {
         node.removeAttribute("href");
         return;
       }


### PR DESCRIPTION
## Problem

Markdown links with custom URI schemes (e.g. `obsidian://`, `things://`, `shortcuts://`) were rendered as plain text in WebChat, even when wrapped in explicit markdown link syntax `[text](scheme://...)`. The OS would happily route these schemes from a browser address bar, but the user could not click them.

Root cause: `toSanitizedMarkdownHtml` only kept `http:`/`https:`/`mailto:` hrefs after sanitization. Other schemes were stripped — both by DOMPurify (which has a conservative default URI regexp) and by our `afterSanitizeAttributes` hook.

## Fix

Add a small allowlist of well-known productivity-app schemes that remain clickable when used inside explicit markdown link syntax. The fix is two-layered:

1. `sanitizeOptions.ALLOWED_URI_REGEXP` accepts the allowlisted schemes (otherwise DOMPurify drops the href before our hook can see it).
2. The `afterSanitizeAttributes` hook also validates the scheme against the explicit allowlist.

Allowlisted schemes (from #86334):

```
obsidian, things, fantastical, shortcuts, craftdocs, notion, bear,
ulysses, drafts, hook, x-apple-reminderkit, calshow
```

Any scheme not in the allowlist (or the `http`/`https`/`mailto` baseline) is still stripped, so the defense against `javascript:`, `data:`, `vbscript:`, `file:`, etc. is unchanged. Bare URLs (linkify autolinks) are unaffected — the allowlist only applies to explicit markdown link syntax that the user wrote.

## Verification

```
node scripts/run-vitest.mjs run ui/src/ui/markdown.test.ts

Test Files  1 passed (1)
     Tests  71 passed (71)
```

New tests cover:
- `obsidian://`, `things://`, `shortcuts://` keep their `href` and get `rel=\"noreferrer noopener\"`
- An unknown custom scheme (`weirdscheme://...`) still has its `href` stripped
- All existing `javascript:` / `data:` / `file:` / `vbscript:` blocks continue to pass

Closes #86334