### PR TITLE
fix(agents): route PI compaction through Codex auth

### DIFF
--- a/src/agents/pi-embedded-runner/compaction-runtime-context.test.ts
+++ b/src/agents/pi-embedded-runner/compaction-runtime-context.test.ts
@@ -127,6 +127,20 @@ describe("buildEmbeddedCompactionRuntimeContext", () => {
     expect(result.authProfileId).toBe("ollama:default");
   });
 
+  it("routes OpenAI PI compaction through Codex auth provider when auth profile is openai-codex", () => {
+    const result = buildEmbeddedCompactionRuntimeContext({
+      workspaceDir: "/tmp/workspace",
+      agentDir: "/tmp/agent",
+      config: {} as OpenClawConfig,
+      provider: "openai",
+      modelId: "gpt-5.5",
+      authProfileId: "openai-codex:work",
+    });
+    expect(result.provider).toBe("openai-codex");
+    expect(result.model).toBe("gpt-5.5");
+    expect(result.authProfileId).toBe("openai-codex:work");
+  });
+
   it("preserves scoped active process session references for compaction", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-02T03:04:05.000Z"));

--- a/src/agents/pi-embedded-runner/compaction-runtime-context.ts
+++ b/src/agents/pi-embedded-runner/compaction-runtime-context.ts
@@ -1,6 +1,7 @@
 import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options.types.js";
 import type { ReasoningLevel, ThinkLevel } from "../../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveOpenAIRuntimeProviderForPi } from "../openai-codex-routing.js";
 import {
   listActiveProcessSessionReferences,
   type ActiveProcessSessionReference,
@@ -51,10 +52,20 @@ export function resolveEmbeddedCompactionTarget(params: {
   const model = params.modelId?.trim() || params.defaultModel;
   const override = params.config?.agents?.defaults?.compaction?.model?.trim();
   if (!override) {
+    const authProfileId = params.authProfileId ?? undefined;
     return {
-      provider,
+      provider:
+        provider === undefined
+          ? undefined
+          : resolveOpenAIRuntimeProviderForPi({
+              provider,
+              harnessRuntime: "pi",
+              authProfileProvider: authProfileId?.split(":", 1)[0],
+              authProfileId,
+              config: params.config,
+            }),
       model,
-      authProfileId: params.authProfileId ?? undefined,
+      authProfileId,
     };
   }
   const slashIdx = override.indexOf("/");


### PR DESCRIPTION
## Summary
- reuse the existing OpenAI Codex PI runtime-provider routing helper in embedded compaction when no compaction override is configured
- preserve the existing override behavior and auth-profile retention rules
- add a focused regression test for `provider=openai` plus `authProfileId=openai-codex:*`

Closes #86373.

## Testing
- `CI=1 OPENCLAW_VITEST_MAX_WORKERS=1 node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.agents-pi-embedded.config.ts src/agents/pi-embedded-runner/compaction-runtime-context.test.ts --pool forks --maxWorkers=1 --reporter=tap`
- `CI=1 OPENCLAW_VITEST_MAX_WORKERS=1 node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.agents-pi-embedded.config.ts src/agents/pi-embedded-runner/compact.hooks.test.ts --pool forks --maxWorkers=1 --reporter=tap`
- `CI=1 OPENCLAW_VITEST_MAX_WORKERS=1 node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.unit.config.ts src/agents/command/cli-compaction.test.ts --pool forks --maxWorkers=1 --reporter=tap`

## Real behavior proof
Behavior or issue addressed:
OpenAI PI embedded compaction was preserving `provider=openai` when the active auth profile was `openai-codex:*`, so fallback/context compaction paths could miss the Codex OAuth transport that the normal embedded run path already uses.

Real environment tested:
Local OpenClaw source checkout with the patched `resolveEmbeddedCompactionTarget` implementation, exercised through the real TypeScript runtime entrypoint instead of mocks.

Exact steps or command run after this patch:
```bash
node --import tsx --eval "import { resolveEmbeddedCompactionTarget } from './src/agents/pi-embedded-runner/compaction-runtime-context.ts'; const result = resolveEmbeddedCompactionTarget({ provider: 'openai', modelId: 'gpt-5.5', authProfileId: 'openai-codex:work', config: {}, defaultProvider: 'openai', defaultModel: 'gpt-5.5' }); console.log(JSON.stringify(result)); if (result.provider !== 'openai-codex' || result.authProfileId !== 'openai-codex:work' || result.model !== 'gpt-5.5') process.exit(1);"
```

Evidence after fix:
```text
{"provider":"openai-codex","model":"gpt-5.5","authProfileId":"openai-codex:work"}
```

Observed result after fix:
The no-override embedded compaction target now resolves to `provider=openai-codex` while preserving the original `openai-codex:*` auth profile and selected model, aligning the compaction path with the normal PI runtime-provider routing rule.

What was not tested:
I did not run a full live remote provider compaction session with an actual OpenAI Codex OAuth account in this environment.
