### PR TITLE
fix: use context-aware reserveTokensFloor in overflow recovery hint

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -9,6 +9,7 @@ import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
   buildContextOverflowRecoveryText,
+  computeContextAwareReserveTokensFloor,
   MAX_LIVE_SWITCH_RETRIES,
   resolveRunAfterAutoFallbackPrimaryProbeRecheck,
 } from "./agent-runner-execution.js";
@@ -405,6 +406,44 @@ function createMinimalRunAgentTurnParams(overrides?: {
   };
 }
 
+describe("computeContextAwareReserveTokensFloor", () => {
+  it("returns 100000 for 1M context windows", () => {
+    expect(computeContextAwareReserveTokensFloor(1_000_000)).toBe(100_000);
+  });
+
+  it("returns 50000 for 200k context windows", () => {
+    expect(computeContextAwareReserveTokensFloor(200_000)).toBe(50_000);
+  });
+
+  it("returns 35000 for 100k context windows", () => {
+    expect(computeContextAwareReserveTokensFloor(100_000)).toBe(35_000);
+  });
+
+  it("returns 20000 for context windows below 100k", () => {
+    expect(computeContextAwareReserveTokensFloor(99_999)).toBe(20_000);
+    expect(computeContextAwareReserveTokensFloor(32_768)).toBe(20_000);
+    expect(computeContextAwareReserveTokensFloor(50_000)).toBe(20_000);
+  });
+
+  it("returns 20000 for undefined context window", () => {
+    expect(computeContextAwareReserveTokensFloor(undefined)).toBe(20_000);
+  });
+
+  it("returns 20000 for non-positive context window", () => {
+    expect(computeContextAwareReserveTokensFloor(0)).toBe(20_000);
+    expect(computeContextAwareReserveTokensFloor(-1)).toBe(20_000);
+  });
+
+  it("returns correct tiers at exact boundaries", () => {
+    expect(computeContextAwareReserveTokensFloor(100_000)).toBe(35_000);
+    expect(computeContextAwareReserveTokensFloor(200_000)).toBe(50_000);
+    expect(computeContextAwareReserveTokensFloor(1_000_000)).toBe(100_000);
+    expect(computeContextAwareReserveTokensFloor(99_999)).toBe(20_000);
+    expect(computeContextAwareReserveTokensFloor(199_999)).toBe(35_000);
+    expect(computeContextAwareReserveTokensFloor(999_999)).toBe(50_000);
+  });
+});
+
 describe("buildContextOverflowRecoveryText", () => {
   it("keeps the generic compaction-buffer hint without heartbeat model evidence", () => {
     const text = buildContextOverflowRecoveryText({
@@ -414,6 +453,138 @@ describe("buildContextOverflowRecoveryText", () => {
     });
 
     expect(text).toContain("reserveTokensFloor");
+    expect(text).toContain("20000");
+    expect(text).not.toContain("heartbeat model bleed");
+  });
+
+  it("suggests 100000 reserveTokensFloor for 1M context models", () => {
+    const text = buildContextOverflowRecoveryText({
+      cfg: {
+        models: {
+          providers: {
+            openrouter: {
+              baseUrl: "https://openrouter.test",
+              models: [makeTestModel("qwen3.6-plus", 1_000_000)],
+            },
+          },
+        },
+      },
+      primaryProvider: "openrouter",
+      primaryModel: "qwen3.6-plus",
+    });
+
+    expect(text).toContain("reserveTokensFloor");
+    expect(text).toContain("100000");
+    expect(text).not.toContain("heartbeat model bleed");
+  });
+
+  it("suggests 50000 reserveTokensFloor for 200k context models", () => {
+    const text = buildContextOverflowRecoveryText({
+      cfg: {
+        models: {
+          providers: {
+            openrouter: {
+              baseUrl: "https://openrouter.test",
+              models: [makeTestModel("gpt-5.5-200k", 200_000)],
+            },
+          },
+        },
+      },
+      primaryProvider: "openrouter",
+      primaryModel: "gpt-5.5-200k",
+    });
+
+    expect(text).toContain("reserveTokensFloor");
+    expect(text).toContain("50000");
+    expect(text).not.toContain("heartbeat model bleed");
+  });
+
+  it("suggests 35000 reserveTokensFloor for 100k context models", () => {
+    const text = buildContextOverflowRecoveryText({
+      cfg: {
+        models: {
+          providers: {
+            openrouter: {
+              baseUrl: "https://openrouter.test",
+              models: [makeTestModel("gpt-5.5", 100_000)],
+            },
+          },
+        },
+      },
+      primaryProvider: "openrouter",
+      primaryModel: "gpt-5.5",
+    });
+
+    expect(text).toContain("reserveTokensFloor");
+    expect(text).toContain("35000");
+    expect(text).not.toContain("heartbeat model bleed");
+  });
+
+  it("suggests 20000 reserveTokensFloor for small context windows", () => {
+    const text = buildContextOverflowRecoveryText({
+      cfg: {
+        models: {
+          providers: {
+            ollama: {
+              baseUrl: "http://ollama.test",
+              models: [makeTestModel("qwen3.5-9b-32k:latest", 32_768)],
+            },
+          },
+        },
+      },
+      primaryProvider: "ollama",
+      primaryModel: "qwen3.5-9b-32k:latest",
+    });
+
+    expect(text).toContain("reserveTokensFloor");
+    expect(text).toContain("20000");
+    expect(text).not.toContain("heartbeat model bleed");
+  });
+
+  it("uses session contextTokens as fallback when model metadata is unavailable", () => {
+    const text = buildContextOverflowRecoveryText({
+      cfg: {},
+      primaryProvider: "openrouter",
+      primaryModel: "unknown-model",
+      activeSessionEntry: {
+        sessionId: "session",
+        updatedAt: 1,
+        modelProvider: "openrouter",
+        model: "unknown-model",
+        contextTokens: 200_000,
+      },
+    });
+
+    expect(text).toContain("reserveTokensFloor");
+    expect(text).toContain("50000");
+    expect(text).not.toContain("heartbeat model bleed");
+  });
+
+  it("prefers model metadata over session contextTokens", () => {
+    const text = buildContextOverflowRecoveryText({
+      cfg: {
+        models: {
+          providers: {
+            openrouter: {
+              baseUrl: "https://openrouter.test",
+              models: [makeTestModel("qwen3.6-plus", 1_000_000)],
+            },
+          },
+        },
+      },
+      primaryProvider: "openrouter",
+      primaryModel: "qwen3.6-plus",
+      activeSessionEntry: {
+        sessionId: "session",
+        updatedAt: 1,
+        modelProvider: "openrouter",
+        model: "qwen3.6-plus",
+        contextTokens: 32_768,
+      },
+    });
+
+    expect(text).toContain("reserveTokensFloor");
+    expect(text).toContain("100000");
     expect(text).not.toContain("heartbeat model bleed");
   });
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -714,9 +714,55 @@ export function buildKnownAgentRunFailureReplyPayload(params: {
   });
 }
 
-const CONTEXT_OVERFLOW_RESET_HINT =
-  "\n\nTo prevent this, increase your compaction buffer by setting " +
-  "`agents.defaults.compaction.reserveTokensFloor` to 20000 or higher in your config.";
+const DEFAULT_RESERVE_TOKENS_FLOOR = 20_000;
+
+export function computeContextAwareReserveTokensFloor(contextWindow: number | undefined): number {
+  if (typeof contextWindow !== "number" || contextWindow <= 0) {
+    return DEFAULT_RESERVE_TOKENS_FLOOR;
+  }
+  if (contextWindow >= 1_000_000) {
+    return 100_000;
+  }
+  if (contextWindow >= 200_000) {
+    return 50_000;
+  }
+  if (contextWindow >= 100_000) {
+    return 35_000;
+  }
+  return DEFAULT_RESERVE_TOKENS_FLOOR;
+}
+
+function resolveContextWindowForCompactionHint(params: {
+  cfg: FollowupRun["run"]["config"];
+  primaryProvider?: string;
+  primaryModel?: string;
+  activeSessionEntry?: SessionEntry;
+}): number | undefined {
+  if (params.primaryProvider && params.primaryModel) {
+    const modelWindow = resolveContextTokensForModel({
+      cfg: params.cfg,
+      provider: params.primaryProvider,
+      model: params.primaryModel,
+      allowAsyncLoad: false,
+    });
+    if (typeof modelWindow === "number" && modelWindow > 0) {
+      return modelWindow;
+    }
+  }
+  const sessionTokens = params.activeSessionEntry?.contextTokens;
+  if (typeof sessionTokens === "number" && Number.isFinite(sessionTokens) && sessionTokens > 0) {
+    return Math.floor(sessionTokens);
+  }
+  return undefined;
+}
+
+function buildContextOverflowResetHint(contextWindowTokens: number | undefined): string {
+  const reserveFloor = computeContextAwareReserveTokensFloor(contextWindowTokens);
+  return (
+    "\n\nTo prevent this, increase your compaction buffer by setting " +
+    `\`agents.defaults.compaction.reserveTokensFloor\` to ${reserveFloor} or higher in your config.`
+  );
+}
 
 type ModelRefLike = {
   provider: string;
@@ -907,6 +953,12 @@ export function buildContextOverflowRecoveryText(params: {
     : params.duringCompaction
       ? "⚠️ Context limit exceeded during compaction. I've reset our conversation to start fresh - please try again."
       : "⚠️ Context limit exceeded. I've reset our conversation to start fresh - please try again.";
+  const primaryContextWindow = resolveContextWindowForCompactionHint({
+    cfg: params.cfg,
+    primaryProvider: params.primaryProvider,
+    primaryModel: params.primaryModel,
+    activeSessionEntry: params.activeSessionEntry,
+  });
   return (
     prefix +
     (resolveHeartbeatBleedHint({
@@ -915,7 +967,7 @@ export function buildContextOverflowRecoveryText(params: {
       primaryProvider: params.primaryProvider,
       primaryModel: params.primaryModel,
       activeSessionEntry: params.activeSessionEntry,
-    }) ?? CONTEXT_OVERFLOW_RESET_HINT)
+    }) ?? buildContextOverflowResetHint(primaryContextWindow))
   );
 }
 


### PR DESCRIPTION
## Summary

The overflow recovery hint always suggests setting `reserveTokensFloor` to 20000, regardless of the model's context window size. For models with larger context (e.g., 200K+), this suggestion is too conservative and leads to repeated overflow resets.

This PR makes the hint context-aware by computing a proportional reserve token floor based on the model's actual context window:

| Context window | Suggested reserveTokensFloor |
|---|---|
| >= 1,000,000 | 100,000 |
| >= 200,000 | 50,000 |
| >= 100,000 | 35,000 |
| < 100,000 or unknown | 20,000 (default) |

## Change Type

- [x] Bug fix (better UX for overflow recovery)

## Real behavior proof (required for external PRs)

Behavior addressed: Overflow recovery hint now reflects the model's actual context window instead of hardcoding 20000.

Real environment tested: Linux (x86_64), Node 22.22, local OpenClaw checkout.

Exact steps or command run after this patch:

```bash
node --import tsx -e "import { computeContextAwareReserveTokensFloor } from './src/auto-reply/reply/agent-runner-execution.js'; console.log('1M+:', computeContextAwareReserveTokensFloor(1_000_000)); console.log('200K+:', computeContextAwareReserveTokensFloor(200_000)); console.log('100K+:', computeContextAwareReserveTokensFloor(100_000)); console.log('65K:', computeContextAwareReserveTokensFloor(65_000)); console.log('undefined:', computeContextAwareReserveTokensFloor(undefined));"
```

Evidence after fix (terminal output):

```
$ node --import tsx -e "import { computeContextAwareReserveTokensFloor } from './src/auto-reply/reply/agent-runner-execution.js'; ...
1M+: 100000
200K+: 50000
100K+: 35000
65K: 20000
undefined: 20000
```

Observed result after fix: The function returns proportional values matching the context window size thresholds.

What was not tested: Live overflow scenario (requires real context limit hit). Unit tests in the same file cover the integration.

## Security Impact

None. Only error message text is changed.
