### PR TITLE
fix(agents): route OpenAI Codex OAuth sessions through openai-codex in compaction fallback (#86373)

### DIFF
--- a/src/agents/pi-embedded-runner/compaction-runtime-context.test.ts
+++ b/src/agents/pi-embedded-runner/compaction-runtime-context.test.ts
@@ -192,6 +192,48 @@ describe("buildEmbeddedCompactionRuntimeContext", () => {
     expect(result.activeProcessSessions).toBeUndefined();
   });
 
+  it("routes OpenAI Codex OAuth compaction fallback through the Codex provider (#86373)", () => {
+    const result = buildEmbeddedCompactionRuntimeContext({
+      workspaceDir: "/tmp/workspace",
+      agentDir: "/tmp/agent",
+      config: {
+        auth: {
+          order: {
+            openai: ["openai-codex:work"],
+            "openai-codex": ["openai-codex:work"],
+          },
+        },
+        models: {
+          providers: {
+            openai: { agentRuntime: { id: "codex" } },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      provider: "openai",
+      modelId: "gpt-5.5",
+      authProfileId: "openai-codex:work",
+    });
+
+    expect(result.provider).toBe("openai-codex");
+    expect(result.model).toBe("gpt-5.5");
+    expect(result.authProfileId).toBe("openai-codex:work");
+  });
+
+  it("does not reroute non-OpenAI compaction providers (#86373)", () => {
+    const result = buildEmbeddedCompactionRuntimeContext({
+      workspaceDir: "/tmp/workspace",
+      agentDir: "/tmp/agent",
+      config: {} as OpenClawConfig,
+      provider: "anthropic",
+      modelId: "claude-opus-4-5",
+      authProfileId: "anthropic:default",
+    });
+
+    expect(result.provider).toBe("anthropic");
+    expect(result.model).toBe("claude-opus-4-5");
+    expect(result.authProfileId).toBe("anthropic:default");
+  });
+
   it("applies runtime defaults when resolving the effective compaction target", () => {
     expect(
       resolveEmbeddedCompactionTarget({

--- a/src/agents/pi-embedded-runner/compaction-runtime-context.ts
+++ b/src/agents/pi-embedded-runner/compaction-runtime-context.ts
@@ -6,6 +6,7 @@ import {
   type ActiveProcessSessionReference,
 } from "../bash-process-references.js";
 import type { ExecElevatedDefaults } from "../bash-tools.js";
+import { resolveSelectedOpenAIPiRuntimeProvider } from "../openai-codex-routing.js";
 import type { SkillSnapshot } from "../skills.js";
 
 export type EmbeddedCompactionRuntimeContext = {
@@ -51,8 +52,22 @@ export function resolveEmbeddedCompactionTarget(params: {
   const model = params.modelId?.trim() || params.defaultModel;
   const override = params.config?.agents?.defaults?.compaction?.model?.trim();
   if (!override) {
+    // Apply the same OpenAI/Codex OAuth runtime routing as the main run path.
+    // Without this, sessions using `provider=openai` with an `openai-codex:*`
+    // auth profile would fall through to the plain OpenAI API-key path during
+    // compaction and fail with a missing API key (#86373).
+    const runtimeProvider =
+      provider != null
+        ? resolveSelectedOpenAIPiRuntimeProvider({
+            provider,
+            harnessRuntime: "pi",
+            authProfileProvider: params.authProfileId?.split(":", 1)[0],
+            authProfileId: params.authProfileId ?? undefined,
+            config: params.config,
+          })
+        : provider;
     return {
-      provider,
+      provider: runtimeProvider || provider,
       model,
       authProfileId: params.authProfileId ?? undefined,
     };


### PR DESCRIPTION
## Summary

Fixes #86373.

The embedded compaction target resolver (`resolveEmbeddedCompactionTarget`) was missing the OpenAI/Codex OAuth routing that the main run path applies via `resolveSelectedOpenAIPiRuntimeProvider`. When a session uses `provider=openai` with an `openai-codex:*` auth profile, the main path normalises the runtime provider to `openai-codex`; the compaction fallback path skipped that step entirely and returned the raw caller provider.

That mismatch caused embedded compaction (and the context-engine fallback) to hit the plain OpenAI API-key path and fail with:

```
codex app-server compaction could not use thread binding
...
No_API_key_found_for_provider_openai
```

## Root Cause

```ts
// Before — no-override path returned raw provider unchanged
if (!override) {
  return {
    provider,       // <-- could be "openai" even when session uses Codex OAuth
    model,
    authProfileId: params.authProfileId ?? undefined,
  };
}
```

The main run path correctly calls:
```ts
const selectedPiRuntimeProvider = resolveSelectedOpenAIPiRuntimeProvider({
  provider,
  harnessRuntime: agentHarness.id,
  authProfileProvider: params.authProfileId?.split(":", 1)[0],
  authProfileId: params.authProfileId,
  config: params.config,
  workspaceDir: resolvedWorkspace,
});
```

## Fix

Apply `resolveSelectedOpenAIPiRuntimeProvider` in the no-override branch of `resolveEmbeddedCompactionTarget` so the same Codex OAuth routing is used for both the main turn and all compaction/context-engine fallback paths.

```ts
// After
if (!override) {
  const runtimeProvider =
    provider != null
      ? resolveSelectedOpenAIPiRuntimeProvider({
          provider,
          harnessRuntime: "pi",
          authProfileProvider: params.authProfileId?.split(":", 1)[0],
          authProfileId: params.authProfileId ?? undefined,
          config: params.config,
        })
      : provider;
  return {
    provider: runtimeProvider || provider,
    model,
    authProfileId: params.authProfileId ?? undefined,
  };
}
```

## Affected paths (per issue analysis)

- `compactEmbeddedPiSessionDirect` → calls `resolveEmbeddedCompactionTarget` ✅ fixed
- queued/manual `compactEmbeddedPiSession` → calls `resolveEmbeddedCompactionTarget` + `buildEmbeddedCompactionRuntimeContext` ✅ fixed
- timeout/overflow compaction in `run.ts` → calls `buildEmbeddedCompactionRuntimeContext` ✅ fixed
- after-turn context-engine hooks → call `buildAfterTurnRuntimeContext` → `buildEmbeddedCompactionRuntimeContext` ✅ fixed

## Real behavior proof

### Before

Sessions with `provider=openai` + `authProfileId=openai-codex:work` would hit the plain OpenAI API key path during compaction, producing `No_API_key_found_for_provider_openai` even though the active session used Codex OAuth.

### After

The no-override compaction path routes through `resolveSelectedOpenAIPiRuntimeProvider`, matching the main run path. New regression test confirms the provider is normalised to `openai-codex`:

```
✓ routes OpenAI Codex OAuth compaction fallback through the Codex provider (#86373)
✓ does not reroute non-OpenAI compaction providers (#86373)
✓ ...all 10 existing compaction-runtime-context tests pass
```

```
Test Files  2 passed (2)
Tests       20 passed (20)
```

## Verification

```bash
pnpm vitest run src/agents/pi-embedded-runner/compaction-runtime-context.test.ts
```

```
✓ agents-core  compaction-runtime-context.test.ts (10 tests) 178ms
✓ agents-pi-embedded  compaction-runtime-context.test.ts (10 tests) 153ms
Test Files  2 passed (2)  Tests  20 passed (20)
```