### PR TITLE
test: derive deprecated SDK usage guard

### DIFF
--- a/scripts/check-deprecated-api-usage.mjs
+++ b/scripts/check-deprecated-api-usage.mjs
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { collectDeprecatedInternalConfigApiViolations } from "./lib/deprecated-config-api-guard.mjs";
+import { buildDeprecatedPluginSdkModuleSpecifiers } from "./lib/deprecated-plugin-sdk-usage.mjs";
 
 const repoRoot = process.cwd();
 
@@ -11,6 +12,13 @@ const skippedFilePatterns = [
   /\.test\.[cm]?[jt]sx?$/u,
   /\.spec\.[cm]?[jt]sx?$/u,
   /\.e2e\.[cm]?[jt]sx?$/u,
+  /\.test-(?:harness|loader|support)\.[cm]?[jt]sx?$/u,
+  /\.contract-test-support\.[cm]?[jt]sx?$/u,
+  /(?:^|\/)test-(?:helpers|support)\.[cm]?[jt]sx?$/u,
+  /(?:^|\/)(?:test-helpers|test-support)\//u,
+  /^extensions\/test-support\//u,
+  /^src\/channels\/plugins\/contracts\/test-helpers\//u,
+  /^src\/plugins\/contracts\/tts-contract-suites\.ts$/u,
   /\.d\.ts$/u,
 ];
 
@@ -131,21 +139,7 @@ const rules = [
   {
     id: "plugin-sdk-compat-subpaths",
     roots: ["src", "extensions", "packages"],
-    moduleSpecifiers: [
-      "openclaw/plugin-sdk/agent-dir-compat",
-      "openclaw/plugin-sdk/channel-config-schema-legacy",
-      "openclaw/plugin-sdk/channel-reply-pipeline",
-      "openclaw/plugin-sdk/channel-runtime",
-      "openclaw/plugin-sdk/compat",
-      "openclaw/plugin-sdk/discord",
-      "openclaw/plugin-sdk/infra-runtime",
-      "openclaw/plugin-sdk/mattermost",
-      "openclaw/plugin-sdk/matrix",
-      "openclaw/plugin-sdk/telegram-account",
-      "openclaw/plugin-sdk/testing",
-      "openclaw/plugin-sdk/test-utils",
-      "openclaw/plugin-sdk/zalouser",
-    ],
+    moduleSpecifiers: buildDeprecatedPluginSdkModuleSpecifiers(),
     message: "use focused non-deprecated plugin SDK subpaths",
   },
   {

--- a/scripts/lib/deprecated-plugin-sdk-usage.mjs
+++ b/scripts/lib/deprecated-plugin-sdk-usage.mjs
@@ -1,0 +1,18 @@
+import deprecatedPublicPluginSdkSubpaths from "./plugin-sdk-deprecated-public-subpaths.json" with { type: "json" };
+
+const DEPRECATED_PLUGIN_SDK_EXTRA_SPECIFIERS = [
+  "openclaw/plugin-sdk",
+  "openclaw/plugin-sdk/agent-dir-compat",
+  "openclaw/plugin-sdk/test-utils",
+];
+
+export function buildDeprecatedPluginSdkModuleSpecifiers(
+  deprecatedSubpaths = deprecatedPublicPluginSdkSubpaths,
+) {
+  return [
+    ...new Set([
+      ...DEPRECATED_PLUGIN_SDK_EXTRA_SPECIFIERS,
+      ...deprecatedSubpaths.map((subpath) => `openclaw/plugin-sdk/${subpath}`),
+    ]),
+  ].toSorted();
+}

--- a/test/scripts/check-deprecated-api-usage.test.ts
+++ b/test/scripts/check-deprecated-api-usage.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { buildDeprecatedPluginSdkModuleSpecifiers } from "../../scripts/lib/deprecated-plugin-sdk-usage.mjs";
+import deprecatedPublicPluginSdkSubpaths from "../../scripts/lib/plugin-sdk-deprecated-public-subpaths.json" with { type: "json" };
+
+describe("scripts/check-deprecated-api-usage", () => {
+  it("bans every curated deprecated public plugin SDK subpath", () => {
+    const specifiers = new Set(buildDeprecatedPluginSdkModuleSpecifiers());
+
+    for (const subpath of deprecatedPublicPluginSdkSubpaths) {
+      expect(specifiers.has(`openclaw/plugin-sdk/${subpath}`), subpath).toBe(true);
+    }
+  });
+
+  it("keeps root and private compatibility aliases explicit", () => {
+    expect(buildDeprecatedPluginSdkModuleSpecifiers()).toEqual(
+      expect.arrayContaining([
+        "openclaw/plugin-sdk",
+        "openclaw/plugin-sdk/agent-dir-compat",
+        "openclaw/plugin-sdk/test-utils",
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
Summary
- derive deprecated plugin SDK import guardrails from the curated deprecated public subpath inventory
- keep root/private compatibility aliases explicit
- skip test-support helper files so the guard continues to enforce production SDK usage

Verification
- node scripts/check-deprecated-api-usage.mjs
- node scripts/run-vitest.mjs test/scripts/check-deprecated-api-usage.test.ts
- git diff --check
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
