### PR TITLE
fix(openai): route compaction through Codex auth provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 - Agents: derive overflow compaction budgets from provider-reported and synthetic over-budget token counts so confirmed context overflows compact before retrying. (#70473) Thanks @fuller-stack-dev.
 - Agents/Codex: recover Codex context-window prompt errors through overflow compaction and surface reset guidance when recovery is exhausted. (#85542) Thanks @fuller-stack-dev.
 - Agents/Codex: allow Codex app-server runs to bootstrap from `CODEX_API_KEY` or `OPENAI_API_KEY` when no Codex auth profile is configured.
+- Agents/Codex: keep selected Codex runtime routing on OpenAI-Codex while preserving direct OpenAI API-key compaction fallback. (#86408) Thanks @funmerlin and @VACInc.
 - Agent transcript: include OpenClaw agent session logs when finding local transcript candidates.
 - Crabbox: bootstrap raw AWS macOS shell commands wrapped in absolute `time` paths so RSS probes can run Node and pnpm on fresh macOS runners.
 - Crabbox: bootstrap raw AWS macOS shell commands even when setup statements precede Node or pnpm usage.

--- a/src/agents/openai-codex-routing.test.ts
+++ b/src/agents/openai-codex-routing.test.ts
@@ -151,13 +151,66 @@ describe("OpenAI Codex routing policy", () => {
     ).toEqual(["openai-codex"]);
   });
 
-  it("routes openai provider to openai-codex when harness runtime is codex", () => {
+  it("routes OpenAI provider to OpenAI-Codex when Codex auth order is configured", () => {
+    expect(
+      resolveSelectedOpenAIPiRuntimeProvider({
+        provider: "openai",
+        harnessRuntime: "codex",
+        config: {
+          auth: {
+            order: {
+              "openai-codex": ["openai-codex:work"],
+            },
+          },
+        },
+      }),
+    ).toBe("openai-codex");
+  });
+
+  it("routes OpenAI provider to OpenAI-Codex when a Codex auth profile is configured", () => {
+    expect(
+      resolveSelectedOpenAIPiRuntimeProvider({
+        provider: "openai",
+        harnessRuntime: "codex",
+        config: {
+          auth: {
+            profiles: {
+              work: {
+                provider: "openai-codex",
+                mode: "oauth",
+              },
+            },
+          },
+        },
+      }),
+    ).toBe("openai-codex");
+  });
+
+  it("routes OpenAI provider to OpenAI-Codex when OpenAI auth order selects Codex", () => {
+    const config = {
+      auth: {
+        order: {
+          openai: ["openai-codex:work"],
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    expect(
+      resolveSelectedOpenAIPiRuntimeProvider({
+        provider: "openai",
+        harnessRuntime: "codex",
+        config,
+      }),
+    ).toBe("openai-codex");
+  });
+
+  it("keeps OpenAI provider for Codex runtime when only direct API-key auth is implied", () => {
     expect(
       resolveSelectedOpenAIPiRuntimeProvider({
         provider: "openai",
         harnessRuntime: "codex",
       }),
-    ).toBe("openai-codex");
+    ).toBe("openai");
   });
 
   it("does not route non-OpenAI providers when runtime is codex", () => {

--- a/src/agents/openai-codex-routing.test.ts
+++ b/src/agents/openai-codex-routing.test.ts
@@ -4,6 +4,7 @@ import {
   listOpenAIAuthProfileProvidersForAgentRuntime,
   modelSelectionShouldEnsureCodexPlugin,
   openAIProviderUsesCodexRuntimeByDefault,
+  resolveOpenAICompactionRuntimeProvider,
   resolveOpenAIRuntimeProviderForPi,
   resolveSelectedOpenAIPiRuntimeProvider,
 } from "./openai-codex-routing.js";
@@ -151,9 +152,18 @@ describe("OpenAI Codex routing policy", () => {
     ).toEqual(["openai-codex"]);
   });
 
-  it("routes OpenAI provider to OpenAI-Codex when Codex auth order is configured", () => {
+  it("routes selected OpenAI Codex runtime through OpenAI-Codex even before auth is configured", () => {
     expect(
       resolveSelectedOpenAIPiRuntimeProvider({
+        provider: "openai",
+        harnessRuntime: "codex",
+      }),
+    ).toBe("openai-codex");
+  });
+
+  it("routes OpenAI compaction to OpenAI-Codex when Codex auth order is configured", () => {
+    expect(
+      resolveOpenAICompactionRuntimeProvider({
         provider: "openai",
         harnessRuntime: "codex",
         config: {
@@ -167,9 +177,9 @@ describe("OpenAI Codex routing policy", () => {
     ).toBe("openai-codex");
   });
 
-  it("routes OpenAI provider to OpenAI-Codex when a Codex auth profile is configured", () => {
+  it("routes OpenAI compaction to OpenAI-Codex when a Codex auth profile is configured", () => {
     expect(
-      resolveSelectedOpenAIPiRuntimeProvider({
+      resolveOpenAICompactionRuntimeProvider({
         provider: "openai",
         harnessRuntime: "codex",
         config: {
@@ -186,7 +196,7 @@ describe("OpenAI Codex routing policy", () => {
     ).toBe("openai-codex");
   });
 
-  it("routes OpenAI provider to OpenAI-Codex when OpenAI auth order selects Codex", () => {
+  it("routes OpenAI compaction to OpenAI-Codex when OpenAI auth order selects Codex", () => {
     const config = {
       auth: {
         order: {
@@ -196,7 +206,7 @@ describe("OpenAI Codex routing policy", () => {
     } satisfies OpenClawConfig;
 
     expect(
-      resolveSelectedOpenAIPiRuntimeProvider({
+      resolveOpenAICompactionRuntimeProvider({
         provider: "openai",
         harnessRuntime: "codex",
         config,
@@ -204,9 +214,9 @@ describe("OpenAI Codex routing policy", () => {
     ).toBe("openai-codex");
   });
 
-  it("keeps OpenAI provider for Codex runtime when only direct API-key auth is implied", () => {
+  it("keeps OpenAI compaction on OpenAI when only direct API-key auth is implied", () => {
     expect(
-      resolveSelectedOpenAIPiRuntimeProvider({
+      resolveOpenAICompactionRuntimeProvider({
         provider: "openai",
         harnessRuntime: "codex",
       }),

--- a/src/agents/openai-codex-routing.ts
+++ b/src/agents/openai-codex-routing.ts
@@ -92,6 +92,26 @@ function configuredOpenAIAuthOrderStartsWithCodexProfile(config: OpenClawConfig 
   return hasOpenAICodexAuthProfileOverride(firstProfile);
 }
 
+function configuredOpenAICodexAuthProfileExists(config: OpenClawConfig | undefined): boolean {
+  if (!openAIProviderUsesCodexRuntimeByDefault({ provider: OPENAI_PROVIDER_ID, config })) {
+    return false;
+  }
+  const configuredCodexOrder = findNormalizedProviderValue(
+    config?.auth?.order,
+    OPENAI_CODEX_PROVIDER_ID,
+  );
+  if (
+    configuredCodexOrder?.some(
+      (profileId) => typeof profileId === "string" && profileId.trim().length > 0,
+    ) === true
+  ) {
+    return true;
+  }
+  return Object.values(config?.auth?.profiles ?? {}).some(
+    (profile) => normalizeProviderId(profile?.provider ?? "") === OPENAI_CODEX_PROVIDER_ID,
+  );
+}
+
 export function shouldRouteOpenAIPiThroughCodexAuthProvider(params: {
   provider: string;
   harnessRuntime?: string;
@@ -184,7 +204,12 @@ export function resolveSelectedOpenAIPiRuntimeProvider(params: {
   if (!isOpenAIProvider(params.provider)) {
     return params.provider;
   }
-  if (runtime === "codex") {
+  if (
+    runtime === "codex" &&
+    (hasOpenAICodexAuthProfileOverride(params.authProfileId) ||
+      configuredOpenAIAuthOrderStartsWithCodexProfile(params.config) ||
+      configuredOpenAICodexAuthProfileExists(params.config))
+  ) {
     return OPENAI_CODEX_PROVIDER_ID;
   }
   return runtime === "pi" &&

--- a/src/agents/openai-codex-routing.ts
+++ b/src/agents/openai-codex-routing.ts
@@ -204,6 +204,32 @@ export function resolveSelectedOpenAIPiRuntimeProvider(params: {
   if (!isOpenAIProvider(params.provider)) {
     return params.provider;
   }
+  if (runtime === "codex") {
+    return OPENAI_CODEX_PROVIDER_ID;
+  }
+  return runtime === "pi" &&
+    !params.authProfileId?.trim() &&
+    configuredOpenAIAuthOrderStartsWithCodexProfile(params.config)
+    ? OPENAI_CODEX_PROVIDER_ID
+    : params.provider;
+}
+
+export function resolveOpenAICompactionRuntimeProvider(params: {
+  provider: string;
+  harnessRuntime?: string;
+  agentHarnessId?: string;
+  authProfileProvider?: string;
+  authProfileId?: string;
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+}): string {
+  if (shouldRouteOpenAIPiThroughCodexAuthProvider(params)) {
+    return OPENAI_CODEX_PROVIDER_ID;
+  }
+  const runtime = normalizeEmbeddedAgentRuntime(params.agentHarnessId ?? params.harnessRuntime);
+  if (!isOpenAIProvider(params.provider)) {
+    return params.provider;
+  }
   if (
     runtime === "codex" &&
     (hasOpenAICodexAuthProfileOverride(params.authProfileId) ||

--- a/src/agents/pi-embedded-runner/compact.hooks.harness.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.harness.ts
@@ -78,6 +78,8 @@ export const resolveSessionAgentIdsMock = vi.fn(() => ({
   sessionAgentId: "main",
 }));
 export const estimateTokensMock = vi.fn((_message?: unknown) => 10);
+export const resolveAgentHarnessPolicyMock = vi.fn(() => ({ runtime: "pi" }));
+export const resolveContextWindowInfoMock = vi.fn(() => ({ tokens: 128_000 }));
 function createDefaultSessionMessages(): unknown[] {
   return [
     { role: "user", content: "hello", timestamp: 1 },
@@ -313,6 +315,10 @@ export function resetCompactHooksHarnessMocks(): void {
     authStorage: { setRuntimeApiKey: vi.fn() },
     modelRegistry: {},
   });
+  resolveAgentHarnessPolicyMock.mockReset();
+  resolveAgentHarnessPolicyMock.mockReturnValue({ runtime: "pi" });
+  resolveContextWindowInfoMock.mockReset();
+  resolveContextWindowInfoMock.mockReturnValue({ tokens: 128_000 });
 
   sessionCompactImpl.mockReset();
   sessionCompactImpl.mockResolvedValue({
@@ -381,7 +387,7 @@ export async function loadCompactHooksHarness(): Promise<{
 
   vi.doMock("../harness/selection.js", () => ({
     maybeCompactAgentHarnessSession: maybeCompactAgentHarnessSessionMock,
-    resolveAgentHarnessPolicy: vi.fn(() => ({ runtime: "pi" })),
+    resolveAgentHarnessPolicy: resolveAgentHarnessPolicyMock,
   }));
 
   vi.doMock("../../plugins/provider-runtime.js", () => ({
@@ -537,7 +543,7 @@ export async function loadCompactHooksHarness(): Promise<{
   }));
 
   vi.doMock("../context-window-guard.js", () => ({
-    resolveContextWindowInfo: vi.fn(() => ({ tokens: 128_000 })),
+    resolveContextWindowInfo: resolveContextWindowInfoMock,
   }));
 
   vi.doMock("../bootstrap-files.js", () => ({

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -12,7 +12,9 @@ import {
   listRegisteredPluginAgentPromptGuidanceMock,
   loadCompactHooksHarness,
   maybeCompactAgentHarnessSessionMock,
+  resolveAgentHarnessPolicyMock,
   registerProviderStreamForModelMock,
+  resolveContextWindowInfoMock,
   resolveContextEngineMock,
   resolveEmbeddedAgentStreamFnMock,
   resolveMemorySearchConfigMock,
@@ -439,6 +441,115 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
     if (fallbackCall[3] === undefined) {
       throw new Error("Expected fallback resolve-model options");
     }
+  });
+
+  it("routes OpenAI compaction through the selected Codex runtime provider before auth", async () => {
+    resolveAgentHarnessPolicyMock.mockReturnValue({ runtime: "codex" });
+    resolveModelMock.mockImplementation((provider = "openai", modelId = "fake") => ({
+      model: { provider, api: "responses", id: modelId, input: [] },
+      error: null,
+      authStorage: { setRuntimeApiKey: vi.fn() },
+      modelRegistry: {},
+    }));
+
+    const result = await compactEmbeddedPiSessionDirect({
+      sessionId: "session-1",
+      sessionKey: TEST_SESSION_KEY,
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp/workspace",
+      provider: "openai",
+      model: "gpt-5.5",
+      config: {
+        models: {
+          providers: {
+            openai: { models: [{ id: "gpt-5.5", contextWindow: 1_000_000 }] },
+            "openai-codex": { models: [{ id: "gpt-5.5", contextWindow: 350_000 }] },
+          },
+        },
+        auth: {
+          order: {
+            "openai-codex": ["openai-codex:work"],
+          },
+        },
+        agents: { defaults: { embeddedHarness: { runtime: "codex" } } },
+      } as never,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(mockCallArg(resolveModelMock)).toBe("openai-codex");
+    expect(mockCallArg(resolveModelMock, 0, 1)).toBe("gpt-5.5");
+  });
+
+  it("preserves direct OpenAI API-key compaction when no Codex auth is configured", async () => {
+    resolveAgentHarnessPolicyMock.mockReturnValue({ runtime: "codex" });
+    resolveModelMock.mockImplementation((provider = "openai", modelId = "fake") => ({
+      model: { provider, api: "responses", id: modelId, input: [] },
+      error: null,
+      authStorage: { setRuntimeApiKey: vi.fn() },
+      modelRegistry: {},
+    }));
+
+    const result = await compactEmbeddedPiSessionDirect({
+      sessionId: "session-1",
+      sessionKey: TEST_SESSION_KEY,
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp/workspace",
+      provider: "openai",
+      model: "gpt-5.5",
+      config: {
+        models: {
+          providers: {
+            openai: { models: [{ id: "gpt-5.5", contextWindow: 1_000_000 }] },
+          },
+        },
+        agents: { defaults: { embeddedHarness: { runtime: "codex" } } },
+      } as never,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(mockCallArg(resolveModelMock)).toBe("openai");
+    expect(mockCallArg(resolveModelMock, 0, 1)).toBe("gpt-5.5");
+  });
+
+  it("uses the persisted Codex runtime for compaction context windows", async () => {
+    resolveAgentHarnessPolicyMock.mockReturnValue({ runtime: "pi" });
+    resolveModelMock.mockImplementation((provider = "openai", modelId = "fake") => ({
+      model: { provider, api: "responses", id: modelId, input: [], contextWindow: 1_000_000 },
+      error: null,
+      authStorage: { setRuntimeApiKey: vi.fn() },
+      modelRegistry: {},
+    }));
+
+    const result = await compactEmbeddedPiSessionDirect({
+      sessionId: "session-1",
+      sessionKey: TEST_SESSION_KEY,
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp/workspace",
+      provider: "openai",
+      model: "gpt-5.5",
+      agentHarnessId: "codex",
+      config: {
+        models: {
+          providers: {
+            openai: { models: [{ id: "gpt-5.5", contextWindow: 1_000_000 }] },
+            "openai-codex": { models: [{ id: "gpt-5.5", contextWindow: 350_000 }] },
+          },
+        },
+        auth: {
+          order: {
+            "openai-codex": ["openai-codex:work"],
+          },
+        },
+        agents: { defaults: { embeddedHarness: { runtime: "pi" } } },
+      } as never,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(mockCallArg(resolveModelMock)).toBe("openai-codex");
+    expectRecordFields(mockCallArg(resolveContextWindowInfoMock), {
+      provider: "openai-codex",
+      modelId: "gpt-5.5",
+    });
   });
 
   it("keeps compaction fallback selection ephemeral", async () => {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -72,7 +72,10 @@ import {
 import { isFallbackSummaryError, runWithModelFallback } from "../model-fallback.js";
 import { supportsModelTools } from "../model-tool-support.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
-import { resolveContextConfigProviderForRuntime } from "../openai-codex-routing.js";
+import {
+  resolveContextConfigProviderForRuntime,
+  resolveSelectedOpenAIPiRuntimeProvider,
+} from "../openai-codex-routing.js";
 import { createBundleLspToolRuntime } from "../pi-bundle-lsp-runtime.js";
 import { createBundleMcpToolRuntime } from "../pi-bundle-mcp-tools.js";
 import { ensureSessionHeader } from "../pi-embedded-helpers.js";
@@ -496,9 +499,29 @@ async function compactEmbeddedPiSessionDirectOnce(
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
   });
-  const provider = resolvedCompactionTarget.provider ?? DEFAULT_PROVIDER;
+  const modelConfigProvider = resolvedCompactionTarget.provider ?? DEFAULT_PROVIDER;
   const modelId = resolvedCompactionTarget.model ?? DEFAULT_MODEL;
   const authProfileId = resolvedCompactionTarget.authProfileId;
+  const earlyAgentIds = resolveSessionAgentIds({
+    sessionKey: params.sessionKey,
+    config: params.config,
+  });
+  const runtimeHarnessPolicy = resolveAgentHarnessPolicy({
+    provider: modelConfigProvider,
+    modelId,
+    config: params.config,
+    agentId: earlyAgentIds.sessionAgentId,
+    sessionKey: params.sessionKey,
+  });
+  const selectedHarnessRuntime = params.agentHarnessId ?? runtimeHarnessPolicy.runtime;
+  const provider = resolveSelectedOpenAIPiRuntimeProvider({
+    provider: modelConfigProvider,
+    harnessRuntime: runtimeHarnessPolicy.runtime,
+    agentHarnessId: params.agentHarnessId,
+    authProfileId,
+    config: params.config,
+    workspaceDir: resolvedWorkspace,
+  });
   let thinkLevel: ThinkLevel = params.thinkLevel ?? "off";
   const attemptedThinking = new Set<ThinkLevel>();
   const fail = (reason: string, err?: unknown): EmbeddedPiCompactResult => {
@@ -527,10 +550,6 @@ async function compactEmbeddedPiSessionDirectOnce(
         : undefined,
     };
   };
-  const earlyAgentIds = resolveSessionAgentIds({
-    sessionKey: params.sessionKey,
-    config: params.config,
-  });
   const agentDir =
     params.agentDir ?? resolveAgentDir(params.config ?? {}, earlyAgentIds.sessionAgentId);
   await ensureOpenClawModelsJson(params.config, agentDir, {
@@ -615,10 +634,7 @@ async function compactEmbeddedPiSessionDirectOnce(
     sessionId: params.sessionId,
     cwd: effectiveWorkspace,
   });
-  const { sessionAgentId: effectiveSkillAgentId } = resolveSessionAgentIds({
-    sessionKey: params.sessionKey,
-    config: params.config,
-  });
+  const effectiveSkillAgentId = earlyAgentIds.sessionAgentId;
 
   let restoreSkillEnv: (() => void) | undefined;
   let compactionSessionManager: unknown = null;
@@ -670,18 +686,11 @@ async function compactEmbeddedPiSessionDirectOnce(
     // Apply contextTokens cap to model so pi-coding-agent's auto-compaction
     // threshold uses the effective limit, not the native context window.
     const runtimeModelWithContext = runtimeModel as ProviderRuntimeModel;
-    const runtimeHarnessPolicy = resolveAgentHarnessPolicy({
-      provider,
-      modelId,
-      config: params.config,
-      agentId: effectiveSkillAgentId,
-      sessionKey: params.sessionKey,
-    });
     const ctxInfo = resolveContextWindowInfo({
       cfg: params.config,
       provider: resolveContextConfigProviderForRuntime({
-        provider,
-        runtimeId: runtimeHarnessPolicy.runtime,
+        provider: modelConfigProvider,
+        runtimeId: selectedHarnessRuntime,
       }),
       modelId,
       modelContextTokens: readPiModelContextTokens(runtimeModel),

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -74,7 +74,7 @@ import { supportsModelTools } from "../model-tool-support.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
 import {
   resolveContextConfigProviderForRuntime,
-  resolveSelectedOpenAIPiRuntimeProvider,
+  resolveOpenAICompactionRuntimeProvider,
 } from "../openai-codex-routing.js";
 import { createBundleLspToolRuntime } from "../pi-bundle-lsp-runtime.js";
 import { createBundleMcpToolRuntime } from "../pi-bundle-mcp-tools.js";
@@ -514,7 +514,7 @@ async function compactEmbeddedPiSessionDirectOnce(
     sessionKey: params.sessionKey,
   });
   const selectedHarnessRuntime = params.agentHarnessId ?? runtimeHarnessPolicy.runtime;
-  const provider = resolveSelectedOpenAIPiRuntimeProvider({
+  const provider = resolveOpenAICompactionRuntimeProvider({
     provider: modelConfigProvider,
     harnessRuntime: runtimeHarnessPolicy.runtime,
     agentHarnessId: params.agentHarnessId,

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -1136,7 +1136,6 @@ describe("runMemoryFlushIfNeeded", () => {
             models: {
               "openai/gpt-5.5": {
                 params: {
-                  responsesServerCompaction: true,
                   responsesCompactThreshold: 200_000,
                 },
               },
@@ -1216,6 +1215,59 @@ describe("runMemoryFlushIfNeeded", () => {
 
     const compactCall = requireCompactEmbeddedPiSessionCall();
     expect(compactCall.currentTokenCount).toBe(201_000);
+  });
+
+  it("uses the local preflight threshold when OpenAI server compaction is explicitly disabled", async () => {
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 4_000,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 60_000,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 161_077,
+      totalTokensFresh: true,
+      agentRuntimeOverride: "pi",
+    };
+
+    await runPreflightCompactionIfNeeded({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5.5": {
+                params: {
+                  responsesServerCompaction: false,
+                  responsesCompactThreshold: 200_000,
+                },
+              },
+            },
+            compaction: { memoryFlush: {} },
+          },
+        },
+      } as never,
+      followupRun: createTestFollowupRun({
+        provider: "openai",
+        model: "gpt-5.5",
+        sessionId: "session",
+        sessionKey: "main",
+      }),
+      defaultModel: "gpt-5.5",
+      agentCfgContextTokens: 220_000,
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    const compactCall = requireCompactEmbeddedPiSessionCall();
+    expect(compactCall.currentTokenCount).toBe(161_077);
   });
 
   it("uses the active run sessionFile when the session entry has no transcript path", async () => {

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -1112,6 +1112,112 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactEmbeddedPiSessionMock).not.toHaveBeenCalled();
   });
 
+  it("defers OpenAI preflight compaction until the configured server threshold", async () => {
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 4_000,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 60_000,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 161_077,
+      totalTokensFresh: true,
+      agentRuntimeOverride: "pi",
+    };
+
+    const entry = await runPreflightCompactionIfNeeded({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5.5": {
+                params: {
+                  responsesServerCompaction: true,
+                  responsesCompactThreshold: 200_000,
+                },
+              },
+            },
+            compaction: { memoryFlush: {} },
+          },
+        },
+      } as never,
+      followupRun: createTestFollowupRun({
+        provider: "openai",
+        model: "gpt-5.5",
+        sessionId: "session",
+        sessionKey: "main",
+      }),
+      defaultModel: "gpt-5.5",
+      agentCfgContextTokens: 220_000,
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(entry).toBe(sessionEntry);
+    expect(compactEmbeddedPiSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("runs OpenAI preflight compaction at the configured server threshold", async () => {
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 4_000,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 60_000,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 201_000,
+      totalTokensFresh: true,
+      agentRuntimeOverride: "pi",
+    };
+
+    await runPreflightCompactionIfNeeded({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5.5": {
+                params: {
+                  responsesServerCompaction: true,
+                  responsesCompactThreshold: 200_000,
+                },
+              },
+            },
+            compaction: { memoryFlush: {} },
+          },
+        },
+      } as never,
+      followupRun: createTestFollowupRun({
+        provider: "openai",
+        model: "gpt-5.5",
+        sessionId: "session",
+        sessionKey: "main",
+      }),
+      defaultModel: "gpt-5.5",
+      agentCfgContextTokens: 220_000,
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    const compactCall = requireCompactEmbeddedPiSessionCall();
+    expect(compactCall.currentTokenCount).toBe(201_000);
+  });
+
   it("uses the active run sessionFile when the session entry has no transcript path", async () => {
     const sessionFile = path.join(rootDir, "active-run-session.jsonl");
     await fs.writeFile(

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -49,6 +49,7 @@ import {
   hasAlreadyFlushedForCurrentCompaction,
   resolveMaxActiveTranscriptBytes,
   resolveMemoryFlushContextWindowTokens,
+  resolveResponsesServerCompactionThreshold,
   shouldRunMemoryFlush,
   shouldRunPreflightCompaction,
 } from "./memory-flush.js";
@@ -735,11 +736,20 @@ export async function runPreflightCompactionIfNeeded(params: {
       ? projectedTokenCount
       : undefined;
 
-  const threshold = contextWindowTokens - reserveTokensFloor - softThresholdTokens;
+  const serverCompactionThreshold = resolveResponsesServerCompactionThreshold({
+    cfg: params.cfg,
+    provider: params.followupRun.run.provider,
+    modelId: params.followupRun.run.model ?? params.defaultModel,
+  });
+  const threshold = Math.max(
+    contextWindowTokens - reserveTokensFloor - softThresholdTokens,
+    serverCompactionThreshold ?? 0,
+  );
   logVerbose(
     `preflightCompaction check: sessionKey=${params.sessionKey} ` +
       `tokenCount=${tokenCountForCompaction ?? freshPersistedTokens ?? "undefined"} ` +
       `contextWindow=${contextWindowTokens} threshold=${threshold} ` +
+      `serverCompactionThreshold=${serverCompactionThreshold ?? "undefined"} ` +
       `isHeartbeat=${params.isHeartbeat} isCli=${isCli} ` +
       `persistedFresh=${entry?.totalTokensFresh === true} ` +
       `transcriptPromptTokens=${transcriptPromptTokens ?? "undefined"} ` +
@@ -755,6 +765,7 @@ export async function runPreflightCompactionIfNeeded(params: {
     contextWindowTokens,
     reserveTokensFloor,
     softThresholdTokens,
+    minimumThresholdTokens: serverCompactionThreshold,
   });
   const shouldCompact = shouldCompactByTokens || shouldCompactByTranscriptBytes;
   if (!shouldCompact) {

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -88,7 +88,10 @@ export function resolveResponsesServerCompactionThreshold(params: {
     asRecord(params.cfg?.agents?.defaults?.params),
     asRecord(modelConfig?.params),
   ];
-  if (resolveBooleanParam(sources, "responsesServerCompaction") !== true) {
+  const serverCompaction = resolveBooleanParam(sources, "responsesServerCompaction");
+  const serverCompactionEnabled =
+    provider === "openai" ? serverCompaction !== false : serverCompaction === true;
+  if (!serverCompactionEnabled) {
     return undefined;
   }
   return resolvePositiveIntegerParam(sources, "responsesCompactThreshold");

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -1,5 +1,6 @@
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
+import { legacyModelKey, modelKey } from "../../agents/model-selection-normalize.js";
 import { parseNonNegativeByteSize } from "../../config/byte-size.js";
 import { resolveFreshSessionTotalTokens, type SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -36,6 +37,63 @@ function resolvePositiveTokenCount(value: number | undefined): number | undefine
     : undefined;
 }
 
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function resolveBooleanParam(sources: Array<Record<string, unknown> | undefined>, key: string) {
+  for (const source of sources.toReversed()) {
+    const value = source?.[key];
+    if (typeof value === "boolean") {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function resolvePositiveIntegerParam(
+  sources: Array<Record<string, unknown> | undefined>,
+  key: string,
+): number | undefined {
+  for (const source of sources.toReversed()) {
+    const value = source?.[key];
+    if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+      return Math.floor(value);
+    }
+  }
+  return undefined;
+}
+
+export function resolveResponsesServerCompactionThreshold(params: {
+  cfg?: OpenClawConfig;
+  provider?: string;
+  modelId?: string;
+}): number | undefined {
+  const provider = params.provider?.trim();
+  const modelId = params.modelId?.trim();
+  if (!provider || !modelId) {
+    return undefined;
+  }
+  const legacyKey = legacyModelKey(provider, modelId);
+  const providerConfig = params.cfg?.models?.providers?.[provider];
+  const modelConfig =
+    params.cfg?.agents?.defaults?.models?.[modelKey(provider, modelId)] ??
+    (legacyKey ? params.cfg?.agents?.defaults?.models?.[legacyKey] : undefined);
+  const providerModelConfig = providerConfig?.models?.find((entry) => entry.id === modelId);
+  const sources = [
+    asRecord(providerConfig?.params),
+    asRecord(providerModelConfig?.params),
+    asRecord(params.cfg?.agents?.defaults?.params),
+    asRecord(modelConfig?.params),
+  ];
+  if (resolveBooleanParam(sources, "responsesServerCompaction") !== true) {
+    return undefined;
+  }
+  return resolvePositiveIntegerParam(sources, "responsesCompactThreshold");
+}
+
 function resolveMemoryFlushGateState<
   TEntry extends Pick<SessionEntry, "totalTokens" | "totalTokensFresh">,
 >(params: {
@@ -44,6 +102,7 @@ function resolveMemoryFlushGateState<
   contextWindowTokens: number;
   reserveTokensFloor: number;
   softThresholdTokens: number;
+  minimumThresholdTokens?: number;
 }): { entry: TEntry; totalTokens: number; threshold: number } | null {
   if (!params.entry) {
     return null;
@@ -58,7 +117,11 @@ function resolveMemoryFlushGateState<
   const contextWindow = Math.max(1, Math.floor(params.contextWindowTokens));
   const reserveTokens = Math.max(0, Math.floor(params.reserveTokensFloor));
   const softThreshold = Math.max(0, Math.floor(params.softThresholdTokens));
-  const threshold = Math.max(0, contextWindow - reserveTokens - softThreshold);
+  const threshold = Math.max(
+    0,
+    contextWindow - reserveTokens - softThreshold,
+    Math.floor(params.minimumThresholdTokens ?? 0),
+  );
   if (threshold <= 0) {
     return null;
   }
@@ -104,6 +167,7 @@ export function shouldRunPreflightCompaction(params: {
   contextWindowTokens: number;
   reserveTokensFloor: number;
   softThresholdTokens: number;
+  minimumThresholdTokens?: number;
 }): boolean {
   const state = resolveMemoryFlushGateState(params);
   return Boolean(state && state.totalTokens >= state.threshold);


### PR DESCRIPTION
## Summary

- Problem: when an `openai/gpt-5.5` session reaches the embedded/context-engine compaction path after a stale or missing Codex thread binding, compaction can resolve auth against the direct `openai` provider and fail with missing `OPENAI_API_KEY` even though the selected runtime uses Codex OAuth.
- Solution: resolve the selected OpenAI runtime provider before compaction model/auth lookup, so Codex-authenticated OpenAI sessions compact through `openai-codex`.
- What changed: compaction now uses the selected runtime provider for model/auth resolution, preserves direct OpenAI API-key routing when no Codex auth profile is configured, uses the persisted/selected runtime for context-window lookup, and honors configured OpenAI Responses server compaction thresholds during preflight gating.
- What did NOT change (scope boundary): this does not repair stale/missing Codex thread bindings, does not change startup provider auth prewarm defaults, does not touch hook scheduling/status/reset behavior, and does not address unrelated encrypted-reasoning retry/429 behavior.

AI-assisted: yes. This patch was prepared with Codex, with focused local test verification.

## Motivation

- Related prior work: #85413 identified the same core failure mode and was directionally correct: stale/missing Codex thread binding can push compaction into a fallback path that resolves `openai/gpt-5.5` as direct OpenAI API-key auth instead of the selected Codex OAuth runtime.
- Why this PR deviates from #85413: that draft mixed the compaction auth-route fix with broader startup/provider-auth-prewarm defaults, hook scheduling, runtime plugin loading, status/reset behavior, and other review surfaces. Those may be valid changes, but they are not required to fix this incident and make the auth-sensitive review harder.
- This PR keeps the central compaction routing fix, preserves direct OpenAI API-key behavior, adds the missing production threshold logic behind the threshold tests, and leaves unrelated startup/default/runtime behavior unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #85413
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Codex OAuth OpenAI compaction fallback should resolve against `openai-codex`, not direct `openai` API-key auth; OpenAI API-key-only compaction should remain on `openai`; preflight compaction should not run earlier than configured OpenAI Responses server compaction thresholds.
- Real environment tested: local OpenClaw checkout on macOS, built with `pnpm build`, installed into the LaunchAgent-pinned OpenClaw path, restarted gateway, real Discord channel sessions using Merlin/main with `openai/gpt-5.5` via Codex OAuth.
- Exact steps or command run after this patch: `pnpm build`; `npm install -g /Users/merlin/openclaw --prefix /Users/merlin/.nvm/versions/node/v24.13.0`; `openclaw gateway restart`; continued a long-running Discord `#claw-enhance` session until timeout-recovery compaction triggered. Focused tests were also run with `node scripts/run-vitest.mjs src/agents/openai-codex-routing.test.ts src/agents/pi-embedded-runner/compact.hooks.test.ts src/auto-reply/reply/agent-runner-memory.test.ts` plus `git diff --check`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): PR comment with copied redacted live runtime logs: https://github.com/openclaw/openclaw/pull/86408#issuecomment-4536022867. Key after-fix line: `2026-05-25T19:18:05.519+02:00 [timeout-compaction] compaction succeeded for openai-codex/gpt-5.5; retrying prompt`. Session transcript also contains a `type=compaction` record at the same timestamp. Focused Vitest reported `Test Files 4 passed (4)` and `Tests 135 passed (135)`; `git diff --check` exited cleanly.
- Observed result after fix: a real oversized Codex OAuth Discord session compacted successfully through `openai-codex/gpt-5.5`, then retried the prompt and completed with session state `status=done`, `modelProvider=openai-codex`, `compactionCount=6`, and post-compaction memory sync. The prior direct `provider=openai/gpt-5.5` / `No_API_key_found_for_provider_openai` failure did not recur for that channel after the patched build was installed. Unit coverage also confirms Codex-auth-configured OpenAI compaction resolves `openai-codex` before auth lookup, direct OpenAI API-key compaction remains `openai`, persisted Codex runtime context-window lookup uses `openai-codex`, and server-threshold gating defers/runs preflight at the configured threshold.
- What was not tested: full `pnpm check` / full test suite were not run in this local proof pass; the live proof covered timeout-recovery compaction rather than a separate clean budget/preflight success.
- Proof limitations or environment constraints: one timeout-recovery attempt in the same session timed out, but that failure also routed through `provider=openai-codex/gpt-5.5`, not direct `openai/gpt-5.5`, so the auth-provider regression stayed fixed even in the failure case.
- Before evidence (optional but encouraged): the exact same Discord channel/session previously logged stale thread binding followed by context-engine fallback on `provider=openai/gpt-5.5` and `No_API_key_found_for_provider_openai` on 2026-05-24 at 22:40:14 CEST.

## Root Cause (if applicable)

- Root cause: embedded compaction resolved the compaction target's raw model provider before applying the selected/persisted runtime provider. For OpenAI model refs using Codex OAuth, that let fallback compaction ask direct `openai` auth for an API key instead of using `openai-codex`.
- Missing detection / guardrail: there was no regression test asserting that direct compaction resolves the selected Codex runtime provider before auth, no direct-OpenAI preservation test for the same path, and preflight threshold tests were not backed by production threshold logic.
- Contributing context (if known): current `main` already avoids some Codex automatic compaction fallback behavior, but direct embedded/context-engine compaction still needed auth-route consistency.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/openai-codex-routing.test.ts`, `src/agents/pi-embedded-runner/compact.hooks.test.ts`, `src/auto-reply/reply/agent-runner-memory.test.ts`.
- Scenario the test should lock in: Codex-auth OpenAI compaction uses `openai-codex`; direct OpenAI compaction remains `openai`; persisted Codex runtime context sizing uses `openai-codex`; OpenAI Responses server thresholds are honored by production preflight gating.
- Why this is the smallest reliable guardrail: it exercises the model/auth selection seam directly without requiring a live Codex account or a gateway restart.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Codex OAuth users should no longer see fallback compaction ask for a direct OpenAI API key when the selected runtime/auth route is Codex. Direct OpenAI API-key-only setups remain routed through `openai`.

## Diagram (if applicable)

```text
Before:
openai/gpt-5.5 + Codex runtime -> fallback compaction -> openai auth -> missing OPENAI_API_KEY

After:
openai/gpt-5.5 + configured Codex auth -> fallback compaction -> openai-codex auth -> Codex OAuth route
openai/gpt-5.5 + direct OpenAI only -> fallback compaction -> openai auth -> API-key route
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: auth provider selection changes for compaction only. The routing predicate requires an explicit/configured Codex auth profile before mapping `openai` to `openai-codex`, and tests cover both Codex OAuth and direct OpenAI API-key preservation.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local checkout
- Model/provider: `openai/gpt-5.5`, `openai-codex/gpt-5.5`
- Integration/channel (if any): N/A for local tests
- Relevant config (redacted): tests cover `auth.order.openai-codex`, `auth.profiles` with provider `openai-codex`, and direct OpenAI with no Codex auth profile.

### Steps

1. Configure an OpenAI model selection using Codex auth.
2. Force the embedded compaction path to resolve the model before auth.
3. Observe provider passed to model/auth resolution.

### Expected

- Codex-auth OpenAI compaction resolves `openai-codex`.
- Direct OpenAI API-key compaction resolves `openai`.

### Actual

- After this patch, focused tests observe the expected provider selection.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused verification:

```text
Test Files  4 passed (4)
Tests  135 passed (135)
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused Vitest for OpenAI/Codex routing, embedded compaction provider selection, context-window provider selection, and preflight threshold gating.
- Edge cases checked: direct OpenAI API-key preservation when no Codex auth profile is configured; non-OpenAI providers are not rerouted.
- What you did **not** verify: full `pnpm check` / full test suite in this proof pass; a separate clean budget/preflight success distinct from timeout-recovery compaction.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: auth-sensitive provider routing can break Codex OAuth or direct OpenAI setups.
  - Mitigation: routing is narrowed to explicit/configured Codex auth and includes direct OpenAI preservation tests.
- Risk: live proof covered timeout-recovery compaction, while maintainers may still want a separate clean budget/preflight success.
  - Mitigation: the real session shows successful `openai-codex/gpt-5.5` compaction and the same auth route on timeout failure; the exact proof log is linked in the PR comments.
