### PR TITLE
fix(elevenlabs): accept `voice` as alias for `voiceId` (#86180)

### DIFF
--- a/extensions/elevenlabs/speech-provider.ts
+++ b/extensions/elevenlabs/speech-provider.ts
@@ -90,7 +90,11 @@ function normalizeElevenLabsProviderConfig(
       path: "messages.tts.providers.elevenlabs.apiKey",
     }),
     baseUrl: normalizeElevenLabsBaseUrl(trimToUndefined(raw?.baseUrl)),
-    voiceId: trimToUndefined(raw?.voiceId) ?? DEFAULT_ELEVENLABS_VOICE_ID,
+    // Accept `voice` as an alias for `voiceId` (matches the realtime-config
+    // field name and reduces silent fallback to DEFAULT_ELEVENLABS_VOICE_ID
+    // when users follow the more natural `voice: "<id>"` shape). See #86180.
+    voiceId:
+      trimToUndefined(raw?.voiceId) ?? trimToUndefined(raw?.voice) ?? DEFAULT_ELEVENLABS_VOICE_ID,
     modelId: trimToUndefined(raw?.modelId) ?? DEFAULT_ELEVENLABS_MODEL_ID,
     seed: asFiniteNumber(raw?.seed),
     applyTextNormalization: trimToUndefined(raw?.applyTextNormalization) as
@@ -120,7 +124,10 @@ function readElevenLabsProviderConfig(config: SpeechProviderConfig): ElevenLabsP
   return {
     apiKey: trimToUndefined(config.apiKey) ?? defaults.apiKey,
     baseUrl: normalizeElevenLabsBaseUrl(trimToUndefined(config.baseUrl) ?? defaults.baseUrl),
-    voiceId: trimToUndefined(config.voiceId) ?? defaults.voiceId,
+    voiceId:
+      trimToUndefined(config.voiceId) ??
+      trimToUndefined((config as Record<string, unknown>).voice) ??
+      defaults.voiceId,
     modelId: trimToUndefined(config.modelId) ?? defaults.modelId,
     seed: asFiniteNumber(config.seed) ?? defaults.seed,
     applyTextNormalization:


### PR DESCRIPTION
## Problem

`talk.providers.elevenlabs.voice` is accepted silently by the gateway config loader (no schema error) but is **never read** by the ElevenLabs speech provider. The provider only looks at `voiceId`, so users who follow the more natural `voice: <id>` shape (which also matches the existing `talk.realtime.voice` field name) silently fall back to `DEFAULT_ELEVENLABS_VOICE_ID` with no warning.

The reporter set `talk.providers.elevenlabs.voice = \"N2lVS1w4EtoT3dr4eOWO\"` (Callum) and got the default voice instead.

## Fix

Accept `voice` as an alias for `voiceId` in:

- `normalizeElevenLabsProviderConfig` (reads from raw `config.providers.elevenlabs`)
- `readElevenLabsProviderConfig` (reads from the already-resolved `SpeechProviderConfig`)

`voiceId` still wins when both are set, so existing configs are unaffected. This brings the per-provider config in line with the realtime config (`talk.realtime.voice`), which is what people expect.

## Test plan

The change is mechanical (one extra nullish fallback per call site). Existing unit tests for `normalizeElevenLabsProviderConfig` continue to pass because `voice` is only consulted when `voiceId` is absent.

Closes #86180