### PR TITLE
fix(agents): remap /btw transcript after compaction

### DIFF
--- a/src/agents/btw-transcript.test.ts
+++ b/src/agents/btw-transcript.test.ts
@@ -1,0 +1,87 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { SessionEntry } from "../config/sessions.js";
+import { resolveBtwSessionTranscriptPath } from "./btw-transcript.js";
+
+function createCompactionCheckpointEntry(params: {
+  sessionId?: string;
+  sessionFile: string;
+  postSessionFile: string;
+}): SessionEntry {
+  const sessionId = params.sessionId ?? "session-1";
+  return {
+    sessionId,
+    sessionFile: params.sessionFile,
+    updatedAt: 1,
+    compactionCheckpoints: [
+      {
+        checkpointId: "98904e8a-a402-4d92-8795-4a2d7bba2276",
+        sessionKey: "agent:main:telegram:direct:user",
+        sessionId,
+        createdAt: 1,
+        reason: "manual",
+        preCompaction: {
+          sessionId,
+          sessionFile: params.sessionFile,
+          leafId: "pre-leaf",
+        },
+        postCompaction: {
+          sessionId,
+          sessionFile: params.postSessionFile,
+          leafId: "post-leaf",
+        },
+      },
+    ],
+  };
+}
+
+describe("resolveBtwSessionTranscriptPath", () => {
+  it("uses the active post-compaction transcript when the stored session file points at a checkpoint", () => {
+    const storePath = "/tmp/openclaw-btw-session/sessions.json";
+    const checkpointFile = path.join(
+      path.dirname(storePath),
+      "session-1.checkpoint.98904e8a-a402-4d92-8795-4a2d7bba2276.jsonl",
+    );
+    const postCompactionFile = path.join(path.dirname(storePath), "session-1.jsonl");
+    const sessionEntry = createCompactionCheckpointEntry({
+      sessionFile: checkpointFile,
+      postSessionFile: postCompactionFile,
+    });
+
+    expect(
+      resolveBtwSessionTranscriptPath({
+        sessionId: "session-1",
+        sessionEntry,
+        sessionKey: "agent:main:telegram:direct:user",
+        storePath,
+      }),
+    ).toBe(postCompactionFile);
+  });
+
+  it("leaves active transcript paths unchanged when no checkpoint remap is needed", () => {
+    const storePath = "/tmp/openclaw-btw-session/sessions.json";
+    const checkpointFile = path.join(
+      path.dirname(storePath),
+      "session-1.checkpoint.98904e8a-a402-4d92-8795-4a2d7bba2276.jsonl",
+    );
+    const postCompactionFile = path.join(path.dirname(storePath), "session-1.jsonl");
+    const sessionEntry = createCompactionCheckpointEntry({
+      sessionFile: postCompactionFile,
+      postSessionFile: postCompactionFile,
+    });
+    const [checkpoint] = sessionEntry.compactionCheckpoints ?? [];
+    if (!checkpoint) {
+      throw new Error("Expected compaction checkpoint");
+    }
+    checkpoint.preCompaction.sessionFile = checkpointFile;
+
+    expect(
+      resolveBtwSessionTranscriptPath({
+        sessionId: "session-1",
+        sessionEntry,
+        sessionKey: "agent:main:telegram:direct:user",
+        storePath,
+      }),
+    ).toBe(postCompactionFile);
+  });
+});

--- a/src/agents/btw-transcript.ts
+++ b/src/agents/btw-transcript.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { readFile } from "node:fs/promises";
 import {
   buildSessionContext,
@@ -8,6 +9,7 @@ import {
 import {
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
+  type SessionFilePathOptions,
   type SessionEntry as StoredSessionEntry,
 } from "../config/sessions.js";
 import { diagnosticLogger as diag } from "../logging/diagnostic.js";
@@ -24,13 +26,63 @@ export function resolveBtwSessionTranscriptPath(params: {
       agentId,
       storePath: params.storePath,
     });
-    return resolveSessionFilePath(params.sessionId, params.sessionEntry, pathOpts);
+    const sessionFile = resolveSessionFilePath(params.sessionId, params.sessionEntry, pathOpts);
+    return (
+      resolvePostCompactionSessionTranscriptPath({
+        sessionFile,
+        sessionEntry: params.sessionEntry,
+        pathOpts,
+      }) ?? sessionFile
+    );
   } catch (error) {
     diag.debug(
       `resolveSessionTranscriptPath failed: sessionId=${params.sessionId} err=${String(error)}`,
     );
     return undefined;
   }
+}
+
+function resolvePostCompactionSessionTranscriptPath(params: {
+  sessionFile: string;
+  sessionEntry?: StoredSessionEntry;
+  pathOpts?: SessionFilePathOptions;
+}): string | undefined {
+  const checkpoints = params.sessionEntry?.compactionCheckpoints;
+  if (!Array.isArray(checkpoints) || checkpoints.length === 0) {
+    return undefined;
+  }
+
+  const resolvedSessionFile = path.resolve(params.sessionFile);
+  for (let index = checkpoints.length - 1; index >= 0; index -= 1) {
+    const checkpoint = checkpoints[index];
+    const preSessionId = checkpoint.preCompaction.sessionId?.trim();
+    if (!preSessionId) {
+      continue;
+    }
+    const preSessionFile = resolveSessionFilePath(
+      preSessionId,
+      { sessionFile: checkpoint.preCompaction.sessionFile },
+      params.pathOpts,
+    );
+    if (path.resolve(preSessionFile) !== resolvedSessionFile) {
+      continue;
+    }
+
+    const postSessionId =
+      checkpoint.postCompaction.sessionId?.trim() ||
+      checkpoint.sessionId?.trim() ||
+      params.sessionEntry?.sessionId?.trim();
+    if (!postSessionId) {
+      continue;
+    }
+    return resolveSessionFilePath(
+      postSessionId,
+      { sessionFile: checkpoint.postCompaction.sessionFile },
+      params.pathOpts,
+    );
+  }
+
+  return undefined;
 }
 
 function readSessionEntryId(entry: PiSessionEntry): string | undefined {

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -549,6 +549,61 @@ describe("runBtwSideQuestion", () => {
     expect(registerProviderStreamForModelMock).not.toHaveBeenCalled();
   });
 
+  it("uses the active post-compaction transcript for Codex BTW questions", async () => {
+    const codexSideQuestionMock = vi.fn().mockResolvedValue({ text: "Codex side answer." });
+    registerAgentHarness({
+      id: "codex",
+      label: "Codex test harness",
+      supports: () => ({ supported: true, priority: 100 }),
+      runAttempt: vi.fn(),
+      runSideQuestion: codexSideQuestionMock,
+    });
+    resolveModelWithRegistryMock.mockReturnValue({
+      provider: "openai",
+      id: "gpt-5.5",
+      api: "openai-responses",
+    });
+    resolveSessionAuthProfileOverrideMock.mockResolvedValue("openai-codex:work");
+    const checkpointFile = "/tmp/session-1.checkpoint.98904e8a-a402-4d92-8795-4a2d7bba2276.jsonl";
+    const postCompactionFile = "/tmp/session-1.jsonl";
+
+    await runSideQuestion({
+      provider: "openai",
+      model: "gpt-5.5",
+      sessionKey: DEFAULT_SESSION_KEY,
+      sessionEntry: createSessionEntry({
+        sessionFile: checkpointFile,
+        compactionCheckpoints: [
+          {
+            checkpointId: "98904e8a-a402-4d92-8795-4a2d7bba2276",
+            sessionKey: DEFAULT_SESSION_KEY,
+            sessionId: "session-1",
+            createdAt: 1,
+            reason: "manual",
+            preCompaction: {
+              sessionId: "session-1",
+              sessionFile: checkpointFile,
+              leafId: "pre-leaf",
+            },
+            postCompaction: {
+              sessionId: "session-1",
+              sessionFile: postCompactionFile,
+              leafId: "post-leaf",
+            },
+          },
+        ],
+      }),
+    });
+
+    expect(codexSideQuestionMock).toHaveBeenCalledTimes(1);
+    expect(
+      (mockArg(codexSideQuestionMock, 0, 0) as { sessionFile?: string }).sessionFile,
+    ).toContain("session-1.jsonl");
+    expect(
+      (mockArg(codexSideQuestionMock, 0, 0) as { sessionFile?: string }).sessionFile,
+    ).not.toContain(".checkpoint.");
+  });
+
   it("does not fall back to the direct provider call when Codex lacks BTW support", async () => {
     registerAgentHarness({
       id: "codex",


### PR DESCRIPTION
## Summary
- remap `/btw` session transcript resolution from a matched pre-compaction checkpoint transcript back to the active post-compaction transcript
- keep Codex side-question binding lookup pointed at the active transcript sidecar instead of a checkpoint path with no binding
- add focused regression coverage for both the resolver and the Codex harness `/btw` path

Closes #86393.

## Verification
- `git diff --check`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.agents-core.config.ts src/agents/btw-transcript.test.ts src/agents/btw.test.ts --pool forks --maxWorkers=1 --reporter=tap`

## Real behavior proof
- Behavior or issue addressed: Codex `/btw` side questions should resolve back to the active post-compaction transcript when the stored session entry still points at a pre-compaction checkpoint transcript.
- Real environment tested: local OpenClaw source checkout running the production `resolveBtwSessionTranscriptPath()` implementation through `node --import tsx`.
- Exact steps or command run after this patch: `node --import tsx --eval "import { resolveBtwSessionTranscriptPath } from './src/agents/btw-transcript.ts'; const storePath='/tmp/openclaw-btw-session/sessions.json'; const checkpointFile='/tmp/openclaw-btw-session/session-1.checkpoint.98904e8a-a402-4d92-8795-4a2d7bba2276.jsonl'; const postCompactionFile='/tmp/openclaw-btw-session/session-1.jsonl'; const sessionEntry={ sessionId:'session-1', sessionFile:checkpointFile, updatedAt:1, compactionCheckpoints:[{ checkpointId:'98904e8a-a402-4d92-8795-4a2d7bba2276', sessionKey:'agent:main:telegram:direct:user', sessionId:'session-1', createdAt:1, reason:'manual', preCompaction:{ sessionId:'session-1', sessionFile:checkpointFile, leafId:'pre-leaf' }, postCompaction:{ sessionId:'session-1', sessionFile:postCompactionFile, leafId:'post-leaf' } }] }; console.log(resolveBtwSessionTranscriptPath({ sessionId:'session-1', sessionEntry, sessionKey:'agent:main:telegram:direct:user', storePath }));"`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): terminal output from the command above:
```text
$ node --import tsx --eval "import { resolveBtwSessionTranscriptPath } from './src/agents/btw-transcript.ts'; ..."
/tmp/openclaw-btw-session/session-1.jsonl
```
- Observed result after fix: with a stored checkpoint transcript as input, the production resolver returns the active `session-1.jsonl` transcript path instead of keeping `/btw` on the `.checkpoint...jsonl` path.
- What was not tested: no live end-to-end Codex app-server `/btw` run against a real persisted `.codex-app-server.json` sidecar.
- Proof limitations or environment constraints: this proof exercises the real runtime resolver directly in a local checkout, but it does not include a GUI or networked Codex session.

## Tests and validation
Which commands did you run?
- `git diff --check`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.agents-core.config.ts src/agents/btw-transcript.test.ts src/agents/btw.test.ts --pool forks --maxWorkers=1 --reporter=tap`

What regression coverage was added or updated?
- added `src/agents/btw-transcript.test.ts` for checkpoint-to-post-compaction remapping
- added a Codex `/btw` compaction regression to `src/agents/btw.test.ts`

What failed before this fix, if known?
- `/btw` could keep the checkpoint transcript path, so Codex side-question binding lookup missed the active transcript sidecar and treated the thread as inactive

If no test was added, why not?
- tests were added

## Risk checklist
Did user-visible behavior change? (`Yes/No`)
- Yes

Did config, environment, or migration behavior change? (`Yes/No`)
- No

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)
- No

What is the highest-risk area?
- transcript-path remapping when compaction checkpoint metadata is present

How is that risk mitigated?
- the remap only applies when the current resolved transcript exactly matches a stored pre-compaction checkpoint transcript, and focused regression coverage exercises both the resolver and the Codex `/btw` harness path
