### PR TITLE
[AI-assisted] fix(cron): preserve unsupported payload rows on writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Docs: https://docs.openclaw.ai
 - Gateway: clear the runtime config snapshot before `SIGUSR1` in-process restarts so config changes survive the next gateway loop. (#86388) Thanks @XuZehan-iCenter.
 - Models: show OAuth delegation markers as configured `models.json` auth while keeping runtime route usability checks strict. (#86378) Thanks @rohitjavvadi.
 - Cron: seed active scheduled and manual cron task rows with a progress summary so status surfaces do not look blank while jobs run. (#86313) Thanks @ferminquant.
+- Cron: preserve unsupported persisted cron payload rows during routine store writes while keeping those rows non-runnable. Fixes #84922. (#86415) Thanks @IWhatsskill.
 - Updater: exclude prerelease git tags from stable channel resolution so source updates do not check out newer alpha/rc/preview/canary tags. (#86260) Thanks @stevenepalmer.
 - Security/Audit: flag webhook `hooks.token` reuse of active Gateway password auth in `openclaw security audit` while keeping password-mode startup compatibility. (#84338) Thanks @coygeek.
 - QQBot: derive the outbound reply watchdog from configured agent and provider timeouts so slow local model replies are not cut off at five minutes. Fixes #85267. (#85271) Thanks @SymbolStar.

--- a/src/commands/doctor-cron-store-migration.test.ts
+++ b/src/commands/doctor-cron-store-migration.test.ts
@@ -170,6 +170,29 @@ describe("normalizeStoredCronJobs", () => {
     expect(result.jobs.map((job) => job.id)).toEqual(["valid"]);
   });
 
+  it("does not normalize unsupported payload kinds into runnable cron jobs", () => {
+    const jobs = [
+      makeLegacyJob({
+        id: "legacy-command-kind",
+        schedule: { kind: "every", everyMs: 60_000, anchorMs: 1 },
+        payload: { kind: "command", command: "echo daily" },
+      }),
+      makeLegacyJob({
+        id: "legacy-agentmessage-kind",
+        schedule: { kind: "cron", expr: "0 9 * * *", tz: "UTC" },
+        sessionTarget: "isolated",
+        payload: { kind: "agentmessage", message: "summarize" },
+      }),
+    ];
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.mutated).toBe(true);
+    expect(result.issues.invalidPayload).toBe(2);
+    expect(jobs).toEqual([]);
+    expect(result.jobs).toEqual([]);
+  });
+
   it("normalizes whitespace-padded and non-canonical payload kinds", () => {
     const jobs = [
       {

--- a/src/cron/service.test-harness.ts
+++ b/src/cron/service.test-harness.ts
@@ -247,6 +247,7 @@ export function createMockCronStateForJobs(params: {
     warnedDisabled: false,
     warnedMissingSessionTargetJobIds: new Set<string>(),
     warnedInvalidPersistedJobKeys: new Set<string>(),
+    preservedInvalidPersistedJobs: [],
     deps: {
       storePath: "/mock/path",
       cronEnabled: true,

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -1,6 +1,7 @@
 import type { CronConfig } from "../../config/types.cron.js";
 import type { HeartbeatRunResult, HeartbeatWakeRequest } from "../../infra/heartbeat-wake.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
+import type { PreservedCronConfigJob } from "../store.js";
 import type {
   CronAgentExecutionPhaseUpdate,
   CronAgentExecutionStarted,
@@ -168,6 +169,11 @@ export type CronServiceState = {
    * until doctor/fix or an explicit config write repairs the store.
    */
   warnedInvalidPersistedJobKeys: Set<string>;
+  /**
+   * Raw persisted config rows that are skipped for runtime safety but must not
+   * be deleted by routine cron-store writes.
+   */
+  preservedInvalidPersistedJobs: PreservedCronConfigJob[];
   storeLoadedAtMs: number | null;
   storeFileMtimeMs: number | null;
 };
@@ -182,6 +188,7 @@ export function createCronServiceState(deps: CronServiceDeps): CronServiceState 
     warnedDisabled: false,
     warnedMissingSessionTargetJobIds: new Set<string>(),
     warnedInvalidPersistedJobKeys: new Set<string>(),
+    preservedInvalidPersistedJobs: [],
     storeLoadedAtMs: null,
     storeFileMtimeMs: null,
   };

--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -223,6 +223,82 @@ describe("cron service store seam coverage", () => {
     ]);
   });
 
+  it("skips preserved unsupported rows that collide with supported jobs by canonical id", async () => {
+    const { storePath } = await makeStorePath();
+
+    await writeJobStore(storePath, [
+      {
+        id: "trimmed-collision",
+        name: "supported trimmed collision",
+        enabled: true,
+        createdAtMs: STORE_TEST_NOW - 60_000,
+        updatedAtMs: STORE_TEST_NOW - 60_000,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "main",
+        wakeMode: "now",
+        payload: { kind: "systemEvent", text: "tick" },
+        state: {},
+      },
+      {
+        id: "  trimmed-collision  ",
+        name: "stale unsupported padded id",
+        enabled: true,
+        createdAtMs: STORE_TEST_NOW - 60_000,
+        schedule: { kind: "cron", expr: "0 8 * * *", tz: "UTC" },
+        sessionTarget: "main",
+        wakeMode: "now",
+        payload: { kind: "command", command: "echo stale" },
+      },
+      {
+        id: "legacy-jobid-collision",
+        name: "supported legacy jobId collision",
+        enabled: true,
+        createdAtMs: STORE_TEST_NOW - 60_000,
+        updatedAtMs: STORE_TEST_NOW - 60_000,
+        schedule: { kind: "every", everyMs: 120_000 },
+        sessionTarget: "main",
+        wakeMode: "now",
+        payload: { kind: "systemEvent", text: "tick legacy" },
+        state: {},
+      },
+      {
+        jobId: "  legacy-jobid-collision  ",
+        name: "stale unsupported legacy jobId",
+        enabled: true,
+        createdAtMs: STORE_TEST_NOW - 60_000,
+        schedule: { kind: "cron", expr: "0 9 * * *", tz: "UTC" },
+        sessionTarget: "main",
+        wakeMode: "now",
+        payload: { kind: "agentmessage", message: "summarize stale" },
+      },
+    ]);
+
+    const state = createStoreTestState(storePath);
+    await ensureLoaded(state, { skipRecompute: true });
+
+    expect(state.store?.jobs.map((job) => job.id)).toEqual([
+      "trimmed-collision",
+      "legacy-jobid-collision",
+    ]);
+
+    await persist(state);
+
+    const config = JSON.parse(await fs.readFile(storePath, "utf8")) as {
+      jobs: Array<Record<string, unknown>>;
+    };
+    expect(config.jobs.map((job) => job.id)).toEqual([
+      "trimmed-collision",
+      "legacy-jobid-collision",
+    ]);
+    expect(config.jobs.map((job) => job.name)).toEqual([
+      "supported trimmed collision",
+      "supported legacy jobId collision",
+    ]);
+    expect(config.jobs.some((job) => job.jobId === "  legacy-jobid-collision  ")).toBe(false);
+    expect(config.jobs.some((job) => job.name === "stale unsupported padded id")).toBe(false);
+    expect(config.jobs.some((job) => job.name === "stale unsupported legacy jobId")).toBe(false);
+  });
+
   it("normalizes jobId-only jobs in memory so scheduler lookups resolve by stable id", async () => {
     const { storePath } = await makeStorePath();
 

--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -15,13 +15,17 @@ const { logger, makeStorePath } = setupCronServiceSuite({
 const STORE_TEST_NOW = Date.parse("2026-03-23T12:00:00.000Z");
 
 async function writeSingleJobStore(storePath: string, job: Record<string, unknown>) {
+  await writeJobStore(storePath, [job]);
+}
+
+async function writeJobStore(storePath: string, jobs: Array<Record<string, unknown>>) {
   await fs.mkdir(path.dirname(storePath), { recursive: true });
   await fs.writeFile(
     storePath,
     JSON.stringify(
       {
         version: 1,
-        jobs: [job],
+        jobs,
       },
       null,
       2,
@@ -128,6 +132,95 @@ describe("cron service store seam coverage", () => {
     await persist(state);
     expect(typeof state.storeFileMtimeMs).toBe("number");
     expect((state.storeFileMtimeMs ?? 0) >= (firstMtime ?? 0)).toBe(true);
+  });
+
+  it("preserves unsupported payload-kind rows across full persistence without loading them", async () => {
+    const { storePath } = await makeStorePath();
+
+    await writeJobStore(storePath, [
+      {
+        id: "valid-job",
+        name: "valid job",
+        enabled: true,
+        createdAtMs: STORE_TEST_NOW - 60_000,
+        updatedAtMs: STORE_TEST_NOW - 60_000,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "main",
+        wakeMode: "now",
+        payload: { kind: "systemEvent", text: "tick" },
+        state: {},
+      },
+      {
+        id: "legacy-command",
+        name: "legacy command",
+        enabled: true,
+        createdAtMs: STORE_TEST_NOW - 60_000,
+        updatedAtMs: STORE_TEST_NOW - 60_000,
+        schedule: { kind: "cron", expr: "0 8 * * *", tz: "UTC" },
+        sessionTarget: "main",
+        wakeMode: "now",
+        payload: { kind: "command", command: "echo daily" },
+        state: { lastRunAtMs: STORE_TEST_NOW - 3_600_000 },
+      },
+      {
+        id: "legacy-agentmessage",
+        name: "legacy agentmessage",
+        enabled: true,
+        createdAtMs: STORE_TEST_NOW - 60_000,
+        schedule: { kind: "cron", expr: "0 9 * * *", tz: "UTC" },
+        sessionTarget: "isolated",
+        wakeMode: "now",
+        payload: { kind: "agentmessage", message: "summarize" },
+        metadata: { preserve: { nested: true } },
+      },
+    ]);
+
+    const state = createStoreTestState(storePath);
+    await ensureLoaded(state, { skipRecompute: true });
+
+    expect(state.store?.jobs.map((job) => job.id)).toEqual(["valid-job"]);
+    expect(() => findJobOrThrow(state, "legacy-command")).toThrow(/unknown cron job id/);
+    expect(() => findJobOrThrow(state, "legacy-agentmessage")).toThrow(/unknown cron job id/);
+
+    const valid = findJobOrThrow(state, "valid-job");
+    valid.name = "valid job renamed";
+    await persist(state);
+
+    const config = JSON.parse(await fs.readFile(storePath, "utf8")) as {
+      jobs: Array<Record<string, unknown>>;
+    };
+    expect(config.jobs.map((job) => job.id)).toEqual([
+      "valid-job",
+      "legacy-command",
+      "legacy-agentmessage",
+    ]);
+    expect(config.jobs[0]?.name).toBe("valid job renamed");
+    expect(config.jobs[1]).toMatchObject({
+      id: "legacy-command",
+      payload: { kind: "command", command: "echo daily" },
+      state: { lastRunAtMs: STORE_TEST_NOW - 3_600_000 },
+    });
+    expect(config.jobs[2]).toMatchObject({
+      id: "legacy-agentmessage",
+      payload: { kind: "agentmessage", message: "summarize" },
+      metadata: { preserve: { nested: true } },
+    });
+    expect(config.jobs[2]).not.toHaveProperty("state");
+    expect(config.jobs[2]).not.toHaveProperty("updatedAtMs");
+
+    const stateFile = JSON.parse(
+      await fs.readFile(storePath.replace(/\.json$/, "-state.json"), "utf8"),
+    ) as { jobs: Record<string, unknown> };
+    expect(Object.keys(stateFile.jobs)).toEqual(["valid-job"]);
+
+    const invalidPayloadWarns = logger.warn.mock.calls.filter((call) => {
+      const msg = typeof call[1] === "string" ? call[1] : "";
+      return msg.includes("skipped invalid persisted job");
+    });
+    expect(invalidPayloadWarns.map((call) => (call[0] as { jobId?: string }).jobId)).toEqual([
+      "legacy-command",
+      "legacy-agentmessage",
+    ]);
   });
 
   it("normalizes jobId-only jobs in memory so scheduler lookups resolve by stable id", async () => {

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -4,7 +4,11 @@ import { normalizeCronJobInput } from "../normalize.js";
 import { getInvalidPersistedCronJobReason } from "../persisted-shape.js";
 import { cronSchedulingInputsEqual } from "../schedule-identity.js";
 import { isInvalidCronSessionTargetIdError } from "../session-target.js";
-import { loadCronStore, saveCronStore } from "../store.js";
+import {
+  loadCronStoreWithConfigJobs,
+  saveCronStore,
+  type PreservedCronConfigJob,
+} from "../store.js";
 import type { CronJob } from "../types.js";
 import { recomputeNextRuns } from "./jobs.js";
 import type { CronServiceState } from "./state.js";
@@ -44,6 +48,21 @@ function warnInvalidPersistedCronJob(params: {
   );
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasUnsupportedStringPayloadKind(candidate: Record<string, unknown>): boolean {
+  const payload = candidate.payload;
+  if (!isRecord(payload)) {
+    return false;
+  }
+  const kind = payload.kind;
+  return (
+    typeof kind === "string" && kind.trim() !== "" && kind !== "systemEvent" && kind !== "agentTurn"
+  );
+}
+
 async function getFileMtimeMs(path: string): Promise<number | null> {
   try {
     const stats = await fs.promises.stat(path);
@@ -75,11 +94,13 @@ export async function ensureLoaded(
   // edits on filesystems with coarse mtime resolution.
 
   const fileMtimeMs = await getFileMtimeMs(state.deps.storePath);
-  const loaded = await loadCronStore(state.deps.storePath);
-  const loadedJobs = (loaded.jobs ?? []) as unknown as CronJob[];
+  const loaded = await loadCronStoreWithConfigJobs(state.deps.storePath);
+  const loadedJobs = (loaded.store.jobs ?? []) as unknown as CronJob[];
   const jobs: CronJob[] = [];
+  const preservedInvalidPersistedJobs: PreservedCronConfigJob[] = [];
   for (const [index, job] of loadedJobs.entries()) {
     const raw = job as unknown as Record<string, unknown>;
+    const rawConfigJob = loaded.configJobs[index] ?? structuredClone(raw);
     const { legacyJobIdIssue } = normalizeCronJobIdentityFields(raw);
     let normalized: Record<string, unknown> | null;
     try {
@@ -100,6 +121,9 @@ export async function ensureLoaded(
       hydrated as unknown as Record<string, unknown>,
     );
     if (invalidReason) {
+      if (invalidReason === "invalid-payload" && hasUnsupportedStringPayloadKind(rawConfigJob)) {
+        preservedInvalidPersistedJobs.push({ index, job: rawConfigJob });
+      }
       warnInvalidPersistedCronJob({ state, raw, index, reason: invalidReason });
       continue;
     }
@@ -159,6 +183,7 @@ export async function ensureLoaded(
     version: 1,
     jobs,
   };
+  state.preservedInvalidPersistedJobs = preservedInvalidPersistedJobs;
   state.storeLoadedAtMs = state.deps.nowMs();
   state.storeFileMtimeMs = fileMtimeMs;
 
@@ -188,7 +213,10 @@ export async function persist(
   if (!state.store) {
     return;
   }
-  await saveCronStore(state.deps.storePath, state.store, opts);
+  await saveCronStore(state.deps.storePath, state.store, {
+    ...opts,
+    preservedConfigJobs: state.preservedInvalidPersistedJobs,
+  });
   // Update file mtime after save to prevent immediate reload
   state.storeFileMtimeMs = await getFileMtimeMs(state.deps.storePath);
 }

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -1013,6 +1013,7 @@ describe("cron service timer regressions", () => {
         now += params.job.id === first.id ? 50 : 20;
         return { status: "ok" as const, summary: "ok" };
       }),
+      cronConfig: { maxConcurrentRuns: 1 },
     });
 
     await onTimer(state);

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -13,6 +13,16 @@ type SerializedStoreCacheEntry = {
   needsSplitMigration: boolean;
 };
 
+export type PreservedCronConfigJob = {
+  index: number;
+  job: Record<string, unknown>;
+};
+
+export type LoadedCronStore = {
+  store: CronStoreFile;
+  configJobs: Array<Record<string, unknown>>;
+};
+
 const serializedStoreCache = new Map<string, SerializedStoreCacheEntry>();
 
 function getSerializedStoreCache(storePath: string): SerializedStoreCacheEntry {
@@ -66,13 +76,71 @@ function normalizeCronStoreFile(parsed: unknown): CronStoreFile {
   };
 }
 
-function stripRuntimeOnlyCronFields(store: CronStoreFile): unknown {
+function cloneConfigJobs(jobs: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+  return jobs.map((job) => structuredClone(job));
+}
+
+function stripJobRuntimeFields(job: CronStoreFile["jobs"][number]): Record<string, unknown> {
+  const { state: _state, updatedAtMs: _updatedAtMs, ...rest } = job;
+  return { ...rest, state: {} };
+}
+
+function persistedJobId(job: Record<string, unknown>): string | null {
+  const id = job.id;
+  return typeof id === "string" && id.trim() ? id : null;
+}
+
+function mergePreservedConfigJobs(
+  jobs: Array<Record<string, unknown>>,
+  preservedConfigJobs: PreservedCronConfigJob[] | undefined,
+): Array<Record<string, unknown>> {
+  if (!preservedConfigJobs?.length) {
+    return jobs;
+  }
+
+  const occupiedIds = new Set<string>();
+  for (const job of jobs) {
+    const id = persistedJobId(job);
+    if (id) {
+      occupiedIds.add(id);
+    }
+  }
+
+  const seenPreservedIds = new Set<string>();
+  const preserved = preservedConfigJobs
+    .filter((entry) => {
+      const id = persistedJobId(entry.job);
+      if (!id) {
+        return true;
+      }
+      if (occupiedIds.has(id) || seenPreservedIds.has(id)) {
+        return false;
+      }
+      seenPreservedIds.add(id);
+      return true;
+    })
+    .toSorted((a, b) => a.index - b.index);
+
+  if (preserved.length === 0) {
+    return jobs;
+  }
+
+  const merged = jobs.slice();
+  for (const entry of preserved) {
+    const index = Math.max(0, Math.min(entry.index, merged.length));
+    merged.splice(index, 0, { ...entry.job });
+  }
+  return merged;
+}
+
+function stripRuntimeOnlyCronFields(
+  store: CronStoreFile,
+  preservedConfigJobs?: PreservedCronConfigJob[],
+): unknown {
+  const jobs = store.jobs.map(stripJobRuntimeFields);
   return {
     version: store.version,
-    jobs: store.jobs.map((job) => {
-      const { state: _state, updatedAtMs: _updatedAtMs, ...rest } = job;
-      return { ...rest, state: {} };
-    }),
+    jobs: mergePreservedConfigJobs(jobs, preservedConfigJobs),
   };
 }
 
@@ -213,7 +281,7 @@ function mergeStateFileEntry(job: CronStoreFile["jobs"][number], entry: unknown)
   }
 }
 
-export async function loadCronStore(storePath: string): Promise<CronStoreFile> {
+export async function loadCronStoreWithConfigJobs(storePath: string): Promise<LoadedCronStore> {
   try {
     const raw = await fs.promises.readFile(storePath, "utf-8");
     let parsed: unknown;
@@ -226,6 +294,7 @@ export async function loadCronStore(storePath: string): Promise<CronStoreFile> {
     }
     const store = normalizeCronStoreFile(parsed);
     const jobs = store.jobs as unknown as Array<Record<string, unknown>>;
+    const configJobs = cloneConfigJobs(jobs);
 
     // Load state file and merge.
     const statePath = resolveStatePath(storePath);
@@ -263,14 +332,18 @@ export async function loadCronStore(storePath: string): Promise<CronStoreFile> {
       needsSplitMigration: hasLegacyInlineState,
     });
 
-    return store;
+    return { store, configJobs };
   } catch (err) {
     if ((err as { code?: unknown })?.code === "ENOENT") {
       serializedStoreCache.delete(storePath);
-      return { version: 1, jobs: [] };
+      return { store: { version: 1, jobs: [] }, configJobs: [] };
     }
     throw err;
   }
+}
+
+export async function loadCronStore(storePath: string): Promise<CronStoreFile> {
+  return (await loadCronStoreWithConfigJobs(storePath)).store;
 }
 
 export function loadCronStoreSync(storePath: string): CronStoreFile {
@@ -321,6 +394,7 @@ export function loadCronStoreSync(storePath: string): CronStoreFile {
 type SaveCronStoreOptions = {
   skipBackup?: boolean;
   stateOnly?: boolean;
+  preservedConfigJobs?: PreservedCronConfigJob[];
 };
 
 async function setSecureFileMode(filePath: string): Promise<void> {
@@ -364,7 +438,11 @@ export async function saveCronStore(
   opts?: SaveCronStoreOptions,
 ) {
   const stateOnly = opts?.stateOnly === true;
-  const configJson = JSON.stringify(stripRuntimeOnlyCronFields(store), null, 2);
+  const configJson = JSON.stringify(
+    stripRuntimeOnlyCronFields(store, opts?.preservedConfigJobs),
+    null,
+    2,
+  );
   const stateFile = extractStateFile(store);
   const stateJson = JSON.stringify(stateFile, null, 2);
 

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { expandHomePrefix } from "../infra/home-dir.js";
 import { replaceFileAtomic } from "../infra/replace-file.js";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { resolveConfigDir } from "../utils.js";
 import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
 import { tryCronScheduleIdentity } from "./schedule-identity.js";
@@ -86,8 +87,7 @@ function stripJobRuntimeFields(job: CronStoreFile["jobs"][number]): Record<strin
 }
 
 function persistedJobId(job: Record<string, unknown>): string | null {
-  const id = job.id;
-  return typeof id === "string" && id.trim() ? id : null;
+  return normalizeOptionalString(job.id) ?? normalizeOptionalString(job.jobId) ?? null;
 }
 
 function mergePreservedConfigJobs(


### PR DESCRIPTION
## Summary

What problem does this PR solve?

Persisted cron jobs with unsupported string `payload.kind` values, such as `command` or `agentmessage`, are skipped during runtime load and can then be permanently deleted when the cron service performs a full `jobs.json` write from the filtered runtime store.

Why does this matter now?

#84922 reports durable cron job configuration loss: three production cron jobs were lost after unsupported persisted rows were filtered out and the next routine store write rewrote `jobs.json` without them.

What is the intended outcome?

Routine cron-store writes preserve unsupported persisted rows on disk, while runtime execution remains limited to documented `systemEvent` and `agentTurn` payloads.

What is intentionally out of scope?

This PR does not add execution support for `command`, `agentmessage`, or arbitrary payload kinds. It does not relax persisted payload validation and does not change doctor migration policy for converting legacy rows into runnable canonical jobs.

What does success look like?

A load plus full persist keeps unsupported rows in `jobs.json`, loads only supported jobs into `state.store.jobs`, and writes split runtime state only for supported runtime jobs.

What should reviewers focus on?

Please focus on the boundary between lossless config preservation and runtime execution: skipped unsupported rows should remain raw on disk, should not become runnable, and should not duplicate or replace a supported runtime job with the same id.

## Linked context

Which issue does this close?

Closes #84922

Which issues, PRs, or discussions are related?

Related #84971

Was this requested by a maintainer or owner?

ClawSweeper's issue review for #84922 called for lossless routine cron-store writes for unsupported persisted rows while keeping runtime execution limited to documented payload kinds.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: persisted cron rows with unsupported string `payload.kind` values were deleted from `jobs.json` after load plus full persist.
- Real environment tested: isolated Linux VPS, Node 22.19.0, clean OpenClaw clone at the PR merge base (`b1b28415c2`) compared with this patched checkout.
- Exact steps or command run after this patch:

```text
node --import tsx cron-lossless-proof.mjs <clean-main-repo> before-main
node --import tsx cron-lossless-proof.mjs <patched-repo> after-patch
```

- Evidence after fix:

```json
{
  "label": "after-patch",
  "loadedRuntimeJobIds": ["valid-job"],
  "persistedJobIdsAfterFullPersist": [
    "valid-job",
    "legacy-command",
    "legacy-agentmessage"
  ],
  "legacyCommandPayload": {
    "kind": "command",
    "command": "echo daily"
  },
  "legacyAgentmessagePayload": {
    "kind": "agentmessage",
    "message": "summarize"
  },
  "legacyAgentmessageMetadata": {
    "preserve": {
      "nested": true
    }
  },
  "legacyAgentmessageHasState": false,
  "legacyAgentmessageHasUpdatedAtMs": false,
  "splitStateJobIds": ["valid-job"],
  "warnings": [
    {
      "msg": "cron: skipped invalid persisted job; run openclaw doctor --fix to repair",
      "jobId": "legacy-command",
      "reason": "invalid-payload"
    },
    {
      "msg": "cron: skipped invalid persisted job; run openclaw doctor --fix to repair",
      "jobId": "legacy-agentmessage",
      "reason": "invalid-payload"
    }
  ]
}
```

- Observed result after fix: both unsupported rows stayed in `jobs.json` after a full persist, nested metadata stayed intact, no runtime-only `state` or `updatedAtMs` fields were added to the unsupported `agentmessage` row, and only `valid-job` loaded into runtime jobs and received split runtime state.
- What was not tested: actual execution or migration of `command` or `agentmessage` payloads, because this PR intentionally does not make those kinds runnable.
- Proof limitations or environment constraints: `pnpm check:changed` required a temporary swapfile on the VPS because `tsgolint` exceeded the server's RAM without swap; the swapfile was removed after the run.
- Before evidence:

```json
{
  "label": "before-main",
  "loadedRuntimeJobIds": ["valid-job"],
  "persistedJobIdsAfterFullPersist": ["valid-job"],
  "legacyCommandPayload": null,
  "legacyAgentmessagePayload": null,
  "legacyAgentmessageMetadata": null,
  "legacyAgentmessageHasState": false,
  "legacyAgentmessageHasUpdatedAtMs": false,
  "splitStateJobIds": ["valid-job"],
  "warnings": [
    {
      "msg": "cron: skipped invalid persisted job; run openclaw doctor --fix to repair",
      "jobId": "legacy-command",
      "reason": "invalid-payload"
    },
    {
      "msg": "cron: skipped invalid persisted job; run openclaw doctor --fix to repair",
      "jobId": "legacy-agentmessage",
      "reason": "invalid-payload"
    }
  ]
}
```

## Tests and validation

Which commands did you run?

```text
node scripts/run-vitest.mjs src/cron/service/store.test.ts src/cron/service/store.load-missing-session-target.test.ts src/cron/store.test.ts src/commands/doctor-cron-store-migration.test.ts
pnpm exec oxfmt --check --threads=1 src/commands/doctor-cron-store-migration.test.ts src/cron/service.test-harness.ts src/cron/service/state.ts src/cron/service/store.test.ts src/cron/service/store.ts src/cron/store.ts
pnpm exec oxfmt --check --threads=1 src/cron/store.ts src/cron/service/store.test.ts
git diff --check
pnpm check:changed
```

What regression coverage was added or updated?

Added cron service store coverage proving unsupported `command` and `agentmessage` rows are not loaded into runtime jobs but survive a config-changing full persist. The same test proves the unsupported `agentmessage` row keeps nested metadata and does not gain runtime-only `state` or `updatedAtMs`. Added canonical duplicate-suppression coverage proving unsupported preserved rows are not written back when they collide with supported runtime jobs through a whitespace-padded `id` or a legacy `jobId`. Added doctor migration coverage proving unsupported payload kinds are not normalized into runnable canonical jobs.

What failed before this fix, if known?

The before-main proof loaded only `valid-job` and rewrote `jobs.json` with only `valid-job`, deleting `legacy-command` and `legacy-agentmessage`.

If no test was added, why not?

N/A. Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Routine cron writes preserve unsupported persisted rows instead of deleting them.

Did config, environment, or migration behavior change? (`Yes/No`)

Yes. Cron config persistence now merges skipped unsupported raw rows back into `jobs.json`; doctor migration behavior is unchanged.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

The highest-risk area is accidentally preserving a stale unsupported row after a supported runtime job with the same id exists, or accidentally broadening unsupported payload kinds into runnable jobs.

How is that risk mitigated?

Preserved rows are collected only from skipped `invalid-payload` rows with unsupported string `payload.kind` values. They stay out of `state.store.jobs`, split runtime state is written only for supported runtime jobs, and config save skips a preserved row when a supported runtime job with the same canonical id already exists. The duplicate check now trims `id` and falls back to trimmed legacy `jobId`, matching cron load identity normalization.

## Current review state

What is the next action?

Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

No known author-side code or proof action is pending after addressing the ClawSweeper duplicate-suppression finding. The PR is still draft; Ready-for-review, CI reruns, bot commands, or automerge need explicit maintainer or author action.

Which bot or reviewer comments were addressed?

Addressed ClawSweeper's P2 comment from #4533108072: preserved-row duplicate detection now uses canonical persisted IDs by trimming `id` and falling back to trimmed legacy `jobId`, with regression coverage for both collision shapes.