### PR TITLE
fix(tui): clear pendingOptimisticUserMessage on Esc abort + session switch (#86199)

### DIFF
--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -381,6 +381,7 @@ export function createSessionActions(context: SessionActionContext) {
     state.currentSessionKey = nextKey;
     state.activeChatRunId = null;
     state.pendingChatRunId = null;
+    state.pendingOptimisticUserMessage = false;
     setActivityStatus("idle");
     state.currentSessionId = null;
     // Session keys can move backwards in updatedAt ordering; drop previous session freshness
@@ -419,6 +420,11 @@ export function createSessionActions(context: SessionActionContext) {
         runId,
       });
       state.pendingChatRunId = null;
+      // Also clear stale optimistic submit state — otherwise tui-command-handlers
+      // continues to treat the TUI as busy and blocks the next normal prompt
+      // with 'agent is busy — press Esc to abort before sending a new message',
+      // while a second Esc reports 'no active run'. See #86199.
+      state.pendingOptimisticUserMessage = false;
       setActivityStatus("aborted");
     } catch (err) {
       chatLog.addSystem(`abort failed: ${String(err)}`);


### PR DESCRIPTION
## Problem

After a successful Esc abort, the TUI can remain stuck in a contradictory local state:

- no `activeChatRunId`
- no `pendingChatRunId`
- `pendingOptimisticUserMessage` still true
- next prompt is blocked: `agent is busy — press Esc to abort before sending a new message`
- a second Esc reports: `no active run`

Same omission exists in `setSession()` — switching sessions does not clear stale optimistic state.

## Fix

Two small one-line additions:

1. `abortActive()` clears `state.pendingOptimisticUserMessage = false` alongside the existing `pendingChatRunId = null` after the abort RPC succeeds.
2. `setSession()` clears it alongside the other run-state fields.

This matches the acceptance criteria in #86199:

- A successful Esc abort clears stale optimistic submit state ✅
- Switching sessions also clears stale optimistic submit state ✅

## Why no separate regression test in this PR

The submit-guard path already has integration coverage in the TUI command-handler tests; the bug is a missed assignment, not a missing branch. Happy to add a focused unit test if maintainers prefer — it would just assert that `pendingOptimisticUserMessage` is `false` after `abortActive()` resolves.

Closes #86199