### PR TITLE
fix(pi-embedded): route openai+codex auth through openai-codex on compaction fallback (#86373)

### DIFF
--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -484,6 +484,72 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
     }
   });
 
+  it("preserves Codex OAuth across same-provider OpenAI compaction fallbacks", async () => {
+    resolveModelMock.mockImplementation((provider = "openai", modelId = "fake") => ({
+      model: { provider, api: "responses", id: modelId, input: [] },
+      error: null,
+      authStorage: { setRuntimeApiKey: vi.fn() },
+      modelRegistry: {},
+    }));
+    sessionCompactImpl
+      .mockRejectedValueOnce(
+        Object.assign(new Error("primary compaction rate limited"), {
+          status: 429,
+          code: "rate_limit_exceeded",
+        }),
+      )
+      .mockResolvedValueOnce({
+        summary: "oauth fallback summary",
+        firstKeptEntryId: "entry-fallback",
+        tokensBefore: 120,
+        details: { ok: true },
+      });
+
+    const result = await compactEmbeddedPiSessionDirect({
+      sessionId: "session-1",
+      sessionKey: TEST_SESSION_KEY,
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp/workspace",
+      provider: "openai",
+      model: "gpt-primary",
+      authProfileId: "openai-codex:default",
+      trigger: "overflow",
+      modelFallbacksOverride: ["openai/gpt-fallback"],
+      config: {
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai/gpt-primary",
+              fallbacks: [],
+            },
+          },
+        },
+      } as never,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.result?.summary).toBe("oauth fallback summary");
+    findMockCall(resolveAgentHarnessPolicyMock, ([arg]) => {
+      const policyArg = arg as Record<string, unknown>;
+      return policyArg.provider === "openai" && policyArg.modelId === "gpt-primary";
+    });
+    findMockCall(resolveAgentHarnessPolicyMock, ([arg]) => {
+      const policyArg = arg as Record<string, unknown>;
+      return policyArg.provider === "openai" && policyArg.modelId === "gpt-fallback";
+    });
+    findMockCall(
+      resolveModelMock,
+      ([provider, modelId]) => provider === "openai-codex" && modelId === "gpt-primary",
+    );
+    findMockCall(
+      resolveModelMock,
+      ([provider, modelId]) => provider === "openai-codex" && modelId === "gpt-fallback",
+    );
+    expectRecordFields(mockCallArg(resolveEmbeddedAgentStreamFnMock, 1), {
+      authProfileId: "openai-codex:default",
+    });
+  });
+
   it("routes OpenAI compaction through the selected Codex runtime provider before auth", async () => {
     resolveAgentHarnessPolicyMock.mockReturnValue({ runtime: "codex" });
     resolveModelMock.mockImplementation((provider = "openai", modelId = "fake") => ({
@@ -552,7 +618,7 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
     expect(mockCallArg(resolveModelMock, 0, 1)).toBe("gpt-5.5");
   });
 
-  it("uses the persisted Codex runtime for compaction context windows", async () => {
+  it("uses Codex auth for runtime model loading while preserving OpenAI context config", async () => {
     resolveAgentHarnessPolicyMock.mockReturnValue({ runtime: "pi" });
     resolveModelMock.mockImplementation((provider = "openai", modelId = "fake") => ({
       model: { provider, api: "responses", id: modelId, input: [], contextWindow: 1_000_000 },
@@ -568,7 +634,7 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
       workspaceDir: "/tmp/workspace",
       provider: "openai",
       model: "gpt-5.5",
-      agentHarnessId: "codex",
+      authProfileId: "openai-codex:work",
       config: {
         models: {
           providers: {
@@ -588,7 +654,7 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
     expect(result.ok).toBe(true);
     expect(mockCallArg(resolveModelMock)).toBe("openai-codex");
     expectRecordFields(mockCallArg(resolveContextWindowInfoMock), {
-      provider: "openai-codex",
+      provider: "openai",
       modelId: "gpt-5.5",
     });
   });

--- a/src/agents/pi-embedded-runner/compact.queued.ts
+++ b/src/agents/pi-embedded-runner/compact.queued.ts
@@ -185,9 +185,10 @@ export async function compactEmbeddedPiSession(
     defaultModel: DEFAULT_MODEL,
   });
   const ceProvider = resolvedCompactionTarget.provider ?? DEFAULT_PROVIDER;
+  const ceRuntimeProvider = resolvedCompactionTarget.runtimeProvider ?? ceProvider;
   const ceModelId = resolvedCompactionTarget.model ?? DEFAULT_MODEL;
   const { model: ceModel } = await resolveModelAsync(
-    ceProvider,
+    ceRuntimeProvider,
     ceModelId,
     agentDir,
     params.config,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -431,6 +431,7 @@ export async function compactEmbeddedPiSessionDirect(
   });
   const primaryProvider = resolvedCompactionTarget.provider ?? DEFAULT_PROVIDER;
   const primaryModel = resolvedCompactionTarget.model ?? DEFAULT_MODEL;
+  const requestedPrimaryProvider = params.provider?.trim() || DEFAULT_PROVIDER;
   const fallbacksOverride = resolveCompactionFallbacksOverride(params);
   const fallbackAgentId = resolveSessionAgentIds({
     sessionKey: params.sandboxSessionKey ?? params.sessionKey,
@@ -461,7 +462,9 @@ export async function compactEmbeddedPiSessionDirect(
       classifyResult: ({ result, provider, model }) =>
         classifyCompactionFallbackResult(result, provider, model),
       run: async (provider, model) => {
-        const authProfileId = provider === primaryProvider ? params.authProfileId : undefined;
+        const preservesPrimaryAuth =
+          provider === primaryProvider || provider === requestedPrimaryProvider;
+        const authProfileId = preservesPrimaryAuth ? params.authProfileId : undefined;
         return await compactEmbeddedPiSessionDirectOnce({
           ...params,
           provider,
@@ -499,7 +502,7 @@ async function compactEmbeddedPiSessionDirectOnce(
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
   });
-  // Keep the configured provider for context-window policy, while auth/model loading below can
+  // Keep the configured provider for harness policy, while auth/model loading below can
   // route OpenAI compaction through Codex OAuth when that runtime owns the session credentials.
   const modelConfigProvider = resolvedCompactionTarget.provider ?? DEFAULT_PROVIDER;
   const modelId = resolvedCompactionTarget.model ?? DEFAULT_MODEL;

--- a/src/agents/pi-embedded-runner/compaction-runtime-context.test.ts
+++ b/src/agents/pi-embedded-runner/compaction-runtime-context.test.ts
@@ -210,4 +210,79 @@ describe("buildEmbeddedCompactionRuntimeContext", () => {
       authProfileId: undefined,
     });
   });
+
+  it("keeps configured OpenAI provider while routing Codex auth to runtime provider (#86373)", () => {
+    const result = resolveEmbeddedCompactionTarget({
+      provider: "openai",
+      modelId: "gpt-5.4",
+      authProfileId: "openai-codex:default",
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.4",
+    });
+    expect(result.provider).toBe("openai");
+    expect(result.runtimeProvider).toBe("openai-codex");
+    expect(result.model).toBe("gpt-5.4");
+    expect(result.authProfileId).toBe("openai-codex:default");
+  });
+
+  it("routes openai auth order with Codex profile to openai-codex runtime provider", () => {
+    const result = resolveEmbeddedCompactionTarget({
+      config: {
+        auth: { order: { openai: ["openai-codex:default"] } },
+      } as OpenClawConfig,
+      provider: "openai",
+      modelId: "gpt-5.5",
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+    });
+    expect(result.provider).toBe("openai");
+    expect(result.runtimeProvider).toBe("openai-codex");
+    expect(result.model).toBe("gpt-5.5");
+    expect(result.authProfileId).toBeUndefined();
+  });
+
+  it("routes model-only compaction overrides with Codex auth through openai-codex", () => {
+    const result = resolveEmbeddedCompactionTarget({
+      config: {
+        agents: { defaults: { compaction: { model: "gpt-5.4" } } },
+      } as OpenClawConfig,
+      provider: "openai",
+      modelId: "gpt-5.5",
+      authProfileId: "openai-codex:default",
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+    });
+    expect(result.provider).toBe("openai");
+    expect(result.runtimeProvider).toBe("openai-codex");
+    expect(result.model).toBe("gpt-5.4");
+    expect(result.authProfileId).toBe("openai-codex:default");
+  });
+
+  it("routes openai compaction overrides with Codex auth through openai-codex", () => {
+    const result = resolveEmbeddedCompactionTarget({
+      config: {
+        agents: { defaults: { compaction: { model: "openai/gpt-5.4" } } },
+      } as OpenClawConfig,
+      provider: "openai",
+      modelId: "gpt-5.5",
+      authProfileId: "openai-codex:default",
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+    });
+    expect(result.provider).toBe("openai");
+    expect(result.runtimeProvider).toBe("openai-codex");
+    expect(result.model).toBe("gpt-5.4");
+    expect(result.authProfileId).toBe("openai-codex:default");
+  });
+
+  it("leaves non-openai providers unchanged", () => {
+    const result = resolveEmbeddedCompactionTarget({
+      provider: "anthropic",
+      modelId: "claude-opus-4-5",
+      authProfileId: "anthropic:default",
+      defaultProvider: "anthropic",
+      defaultModel: "claude-opus-4-5",
+    });
+    expect(result.provider).toBe("anthropic");
+  });
 });

--- a/src/agents/pi-embedded-runner/compaction-runtime-context.ts
+++ b/src/agents/pi-embedded-runner/compaction-runtime-context.ts
@@ -6,6 +6,7 @@ import {
   type ActiveProcessSessionReference,
 } from "../bash-process-references.js";
 import type { ExecElevatedDefaults } from "../bash-tools.js";
+import { resolveSelectedOpenAIPiRuntimeProvider } from "../openai-codex-routing.js";
 import type { SkillSnapshot } from "../skills.js";
 
 export type EmbeddedCompactionRuntimeContext = {
@@ -24,6 +25,7 @@ export type EmbeddedCompactionRuntimeContext = {
   senderIsOwner?: boolean;
   senderId?: string;
   provider?: string;
+  runtimeProvider?: string;
   model?: string;
   modelFallbacksOverride?: string[];
   thinkLevel?: ThinkLevel;
@@ -46,15 +48,37 @@ export function resolveEmbeddedCompactionTarget(params: {
   authProfileId?: string | null;
   defaultProvider?: string;
   defaultModel?: string;
-}): { provider: string | undefined; model: string | undefined; authProfileId: string | undefined } {
+}): {
+  provider: string | undefined;
+  runtimeProvider?: string;
+  model: string | undefined;
+  authProfileId: string | undefined;
+} {
   const provider = params.provider?.trim() || params.defaultProvider;
   const model = params.modelId?.trim() || params.defaultModel;
   const override = params.config?.agents?.defaults?.compaction?.model?.trim();
+  const resolveRuntimeProvider = (
+    targetProvider: string | undefined,
+    authProfileId: string | undefined,
+  ) => {
+    if (!targetProvider) {
+      return undefined;
+    }
+    const runtimeProvider = resolveSelectedOpenAIPiRuntimeProvider({
+      provider: targetProvider,
+      harnessRuntime: "pi",
+      authProfileId,
+      config: params.config,
+    });
+    return runtimeProvider === targetProvider ? undefined : runtimeProvider;
+  };
   if (!override) {
+    const authProfileId = params.authProfileId ?? undefined;
     return {
       provider,
+      runtimeProvider: resolveRuntimeProvider(provider, authProfileId),
       model,
-      authProfileId: params.authProfileId ?? undefined,
+      authProfileId,
     };
   }
   const slashIdx = override.indexOf("/");
@@ -67,12 +91,19 @@ export function resolveEmbeddedCompactionTarget(params: {
       overrideProvider !== (params.provider ?? "")?.trim()
         ? undefined
         : (params.authProfileId ?? undefined);
-    return { provider: overrideProvider, model: overrideModel, authProfileId };
+    return {
+      provider: overrideProvider,
+      runtimeProvider: resolveRuntimeProvider(overrideProvider, authProfileId),
+      model: overrideModel,
+      authProfileId,
+    };
   }
+  const authProfileId = params.authProfileId ?? undefined;
   return {
     provider,
+    runtimeProvider: resolveRuntimeProvider(provider, authProfileId),
     model: override,
-    authProfileId: params.authProfileId ?? undefined,
+    authProfileId,
   };
 }
 
@@ -130,6 +161,7 @@ export function buildEmbeddedCompactionRuntimeContext(params: {
     senderIsOwner: params.senderIsOwner,
     senderId: params.senderId ?? undefined,
     provider: resolved.provider,
+    runtimeProvider: resolved.runtimeProvider,
     model: resolved.model,
     modelFallbacksOverride: params.modelFallbacksOverride,
     thinkLevel: params.thinkLevel,

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -231,7 +231,9 @@ async function startAgentRun(params: {
       } catch (err) {
         const queueSummary =
           formatEmbeddedPiQueueFailureSummary(queueOutcome) ?? "active run queue rejected";
-        throw new Error(`${queueSummary}; fallback_failed error=${formatErrorMessage(err)}`);
+        throw new Error(`${queueSummary}; fallback_failed error=${formatErrorMessage(err)}`, {
+          cause: err,
+        });
       }
     }
     const response = await params.callGateway<{ runId: string }>({


### PR DESCRIPTION
## Summary

Fixes #86373.

Codex OAuth compaction now keeps the configured/model-policy provider (`openai`) separate from the runtime auth provider (`openai-codex`). That matches the main Pi run path without breaking OpenAI model policy or context-window config lookup.

The fallback runner also preserves the primary Codex OAuth auth profile for same-logical-provider OpenAI fallback attempts, while still dropping it for cross-provider fallbacks.

Also preserves the original cause when `sessions.send` reports A2A fallback failure, fixing the current core lint gate on latest `main`.

## Verification

Behavior addressed: OpenAI sessions authenticated with `openai-codex:*` no longer fall through to the plain OpenAI API-key path during compaction/fallback routing.

Real environment tested: Local source checkout with the repo Vitest wrapper on the rebased PR branch; local core oxlint against latest `origin/main`.

Exact steps or command run after this patch: `./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src ui packages --threads=8`; `node scripts/run-vitest.mjs src/agents/tools/sessions.test.ts src/agents/pi-embedded-runner/compaction-runtime-context.test.ts src/agents/openai-codex-routing.test.ts src/agents/pi-embedded-runner/compact.hooks.test.ts src/agents/command/cli-compaction.test.ts`

Evidence after fix: core oxlint completed with exit 0; 9 test files passed, 221 tests passed.

Observed result after fix: Codex OAuth-backed OpenAI compaction resolves runtime model loading through `openai-codex`, preserves OpenAI provider policy/config lookup, keeps `openai-codex:*` auth on same-provider fallback attempts, and the sessions tool lint rule preserves the caught error as `cause`.

What was not tested: A live OpenAI/Codex OAuth network call was not run in this local proof; the regression is covered at the routing/auth-profile boundary with focused unit tests.
