### PR TITLE
Allow SubRip subtitle media uploads

### DIFF
--- a/src/media/mime.ts
+++ b/src/media/mime.ts
@@ -52,6 +52,7 @@ const EXT_BY_MIME: Record<string, string> = {
   "text/csv": ".csv",
   "text/plain": ".txt",
   "text/markdown": ".md",
+  "application/x-subrip": ".srt",
   "text/html": ".html",
   "text/xml": ".xml",
   "text/css": ".css",

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -758,6 +758,19 @@ describe("loadWebMedia", () => {
     expect(result.contentType).toBe("text/markdown");
   });
 
+  it("allows host-read SubRip subtitle files", async () => {
+    const srtFile = path.join(fixtureRoot, "captions.srt");
+    await fs.writeFile(srtFile, "1\n00:00:00,000 --> 00:00:01,500\nHello from captions.\n", "utf8");
+    const result = await loadWebMedia(srtFile, {
+      maxBytes: 1024 * 1024,
+      localRoots: "any",
+      readFile: async (filePath) => await fs.readFile(filePath),
+      hostReadCapability: true,
+    });
+    expect(result.kind).toBe("document");
+    expect(result.contentType).toBe("application/x-subrip");
+  });
+
   it.each([
     {
       label: "ZIP",
@@ -819,6 +832,7 @@ describe("loadWebMedia", () => {
   it.each([
     { label: "CSV", fileName: "opaque.csv" },
     { label: "Markdown", fileName: "opaque.md" },
+    { label: "SubRip", fileName: "opaque.srt" },
   ])("rejects opaque non-NUL binary data disguised as %s", async ({ fileName }) => {
     const fakeTextFile = path.join(fixtureRoot, fileName);
     const opaqueBinary = Buffer.alloc(9000);
@@ -840,6 +854,7 @@ describe("loadWebMedia", () => {
   it.each([
     { label: "CSV", fileName: "prefix-tail.csv" },
     { label: "Markdown", fileName: "prefix-tail.md" },
+    { label: "SubRip", fileName: "prefix-tail.srt" },
   ])(
     "rejects %s files with a text prefix and binary tail after the old sample window",
     async ({ fileName }) => {
@@ -873,6 +888,12 @@ describe("loadWebMedia", () => {
       contentType: "text/markdown",
       body: "---\n***\n> > >\n",
     },
+    {
+      label: "SubRip",
+      fileName: "punctuation.srt",
+      contentType: "application/x-subrip",
+      body: "1\n00:00:00,000 --> 00:00:01,000\n---\n",
+    },
   ])(
     "loads valid punctuation-heavy %s files when host-read capability is enabled",
     async ({ fileName, contentType, body }) => {
@@ -895,6 +916,12 @@ describe("loadWebMedia", () => {
       contentType: "text/markdown",
       body: Buffer.from("R\xe9sum\xe9\nni\xf1o\n", "latin1"),
     },
+    {
+      label: "SubRip",
+      fileName: "legacy.srt",
+      contentType: "application/x-subrip",
+      body: Buffer.from("1\n00:00:00,000 --> 00:00:01,000\ncaf\xe9\n", "latin1"),
+    },
   ])(
     "loads valid single-byte encoded %s files when host-read capability is enabled",
     async ({ fileName, contentType, body }) => {
@@ -907,6 +934,7 @@ describe("loadWebMedia", () => {
   it.each([
     { label: "CSV", fileName: "nul-padded.csv" },
     { label: "Markdown", fileName: "nul-padded.md" },
+    { label: "SubRip", fileName: "nul-padded.srt" },
   ])("rejects NUL-padded binary data disguised as %s", async ({ fileName }) => {
     const fakeTextFile = path.join(fixtureRoot, fileName);
     // Alternating 0x00/0xFF — UTF-8 decode fails (0xFF is invalid UTF-8), then
@@ -930,6 +958,7 @@ describe("loadWebMedia", () => {
   it.each([
     { label: "CSV", fileName: "bom-binary.csv" },
     { label: "Markdown", fileName: "bom-binary.md" },
+    { label: "SubRip", fileName: "bom-binary.srt" },
   ])("rejects UTF-16 BOM-prefixed binary data disguised as %s", async ({ fileName }) => {
     const fakeTextFile = path.join(fixtureRoot, fileName);
     // UTF-16LE BOM + repeating 0xFF bytes: if UTF-16 decoding were attempted,

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -138,6 +138,7 @@ const WINDOWS_DRIVE_RE = /^[A-Za-z]:[\\/]/;
 const HOST_READ_ALLOWED_DOCUMENT_MIMES = new Set([
   "application/msword",
   "application/pdf",
+  "application/x-subrip",
   "application/vnd.ms-excel",
   "application/vnd.ms-powerpoint",
   "application/vnd.openxmlformats-officedocument.presentationml.presentation",
@@ -150,9 +151,10 @@ const HOST_READ_ALLOWED_DOCUMENT_MIMES = new Set([
   "text/csv",
   "text/markdown",
 ]);
-// file-type returns undefined (no magic bytes) for plain-text formats like CSV and
-// Markdown, so host-read needs an explicit "this really decodes as text" fallback.
-const HOST_READ_TEXT_PLAIN_ALIASES = new Set(["text/csv", "text/markdown"]);
+// file-type returns undefined (no magic bytes) for plain-text formats like CSV,
+// Markdown, and SubRip captions, so host-read needs an explicit "this really
+// decodes as text" fallback.
+const HOST_READ_TEXT_PLAIN_ALIASES = new Set(["application/x-subrip", "text/csv", "text/markdown"]);
 const MB = 1024 * 1024;
 
 function getTextStats(text: string): { printableRatio: number } {
@@ -277,7 +279,7 @@ function assertHostReadMediaAllowed(params: {
     }
     throw new LocalMediaAccessError(
       "path-not-allowed",
-      "hostReadCapability permits only validated plain-text CSV/Markdown documents for local reads",
+      "hostReadCapability permits only validated plain-text CSV/Markdown/SubRip documents for local reads",
     );
   }
   const sniffedKind = kindFromMime(params.sniffedContentType);
@@ -298,10 +300,10 @@ function assertHostReadMediaAllowed(params: {
   ) {
     return;
   }
-  // CSV / Markdown exception: file-type v22 returns undefined (not "text/plain") for
-  // plain-text buffers that have no binary magic bytes. Allow these formats when:
+  // CSV / Markdown / SubRip exception: file-type v22 returns undefined (not "text/plain")
+  // for plain-text buffers that have no binary magic bytes. Allow these formats when:
   // - sniffedMime is undefined (no binary signature detected by file-type)
-  // - The extension-derived MIME is text/csv or text/markdown (operator intent)
+  // - The extension-derived MIME is an allowed plain-text document (operator intent)
   // - The buffer decodes as actual text instead of opaque binary bytes
   if (
     !sniffedMime &&
@@ -324,7 +326,7 @@ function assertHostReadMediaAllowed(params: {
   }
   throw new LocalMediaAccessError(
     "path-not-allowed",
-    `Host-local media sends only allow buffer-verified images, audio, video, PDF, Office documents, archives, CSV, and Markdown (got ${sniffedMime ?? normalizedMime ?? "unknown"}).`,
+    `Host-local media sends only allow buffer-verified images, audio, video, PDF, Office documents, archives, CSV, Markdown, and SubRip captions (got ${sniffedMime ?? normalizedMime ?? "unknown"}).`,
   );
 }
 


### PR DESCRIPTION
## Summary
- map .srt files to application/x-subrip
- allow validated SubRip caption files through host-read media sends
- add coverage for valid and binary-disguised .srt files

## Tests
- npx vitest run src/media/web-media.test.ts