### PR TITLE
fix(tui): render lifecycle-only run errors and clear active run (#85782)

### DIFF
--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -76,6 +76,7 @@ export function createEventHandlers(context: EventHandlerContext) {
   const finalizedRuns = new Map<string, number>();
   const finalizedRunsWithDisplay = new Map<string, number>();
   const postFinalizingRuns = new Map<string, number>();
+  const renderedRunErrors = new Set<string>();
   let streamAssembler = new TuiStreamAssembler();
   let lastSessionKey = state.currentSessionKey;
   let pendingHistoryRefresh = false;
@@ -316,6 +317,7 @@ export function createEventHandlers(context: EventHandlerContext) {
   }) => {
     streamAssembler.drop(params.runId);
     sessionRuns.delete(params.runId);
+    renderedRunErrors.delete(params.runId);
     clearActiveRunIfMatch(params.runId);
     flushPendingHistoryRefreshIfIdle();
     if (params.wasActiveRun) {
@@ -544,7 +546,10 @@ export function createEventHandlers(context: EventHandlerContext) {
       const wasActiveRun = state.activeChatRunId === evt.runId;
       const errorMessage = evt.errorMessage ?? "unknown";
       const renderedError = formatRawAssistantErrorForUi(errorMessage);
-      chatLog.addSystem(resolveAuthErrorHint(errorMessage) ?? `run error: ${renderedError}`);
+      if (!renderedRunErrors.has(evt.runId)) {
+        renderedRunErrors.add(evt.runId);
+        chatLog.addSystem(resolveAuthErrorHint(errorMessage) ?? `run error: ${renderedError}`);
+      }
       terminateRun({ runId: evt.runId, wasActiveRun, status: "error" });
       maybeRefreshHistoryForRun(evt.runId);
     }
@@ -661,7 +666,24 @@ export function createEventHandlers(context: EventHandlerContext) {
         if (!canUpdateActivityStatus) {
           return;
         }
-        setActivityStatus("error");
+        // Surface lifecycle/provider failures in the visible transcript and
+        // clear the active run. Previously only the footer activity status
+        // was set to 'error' while activeChatRunId remained set, leaving the
+        // input locked with 'agent is busy' and no visible explanation
+        // unless the separate chat 'state: "error"' event also arrived
+        // (which is not guaranteed for every lifecycle-only failure). See #85782.
+        const wasActiveRun = state.activeChatRunId === evt.runId;
+        const rawError =
+          typeof evt.data?.error === "string" && evt.data.error.trim()
+            ? evt.data.error.trim()
+            : "unknown";
+        const renderedError = formatRawAssistantErrorForUi(rawError);
+        if (!renderedRunErrors.has(evt.runId)) {
+          renderedRunErrors.add(evt.runId);
+          chatLog.addSystem(resolveAuthErrorHint(rawError) ?? `run error: ${renderedError}`);
+        }
+        terminateRun({ runId: evt.runId, wasActiveRun, status: "error" });
+        maybeRefreshHistoryForRun(evt.runId);
       }
       tui.requestRender();
     }


### PR DESCRIPTION
## Problem

A runtime/provider failure that reaches the TUI as an agent lifecycle event with `phase: \"error\"` previously only updated the footer activity status to `error`. `activeChatRunId` was not cleared, so:

- footer shows `connected | error`
- watchdog text may remain visible
- no `run error: ...` message is rendered in the transcript
- input is locked with `agent is busy — press Esc to abort before sending a new message`

The visible error path was gated entirely on the separate chat `state: \"error\"` event, which is not guaranteed for every lifecycle-only failure.

## Fix

In `tui-event-handlers.ts`, the lifecycle `phase === \"error\"` branch now mirrors the chat error path:

- read the error string from `evt.data.error` (matching the existing `pi-embedded-subscribe` event shape)
- render `run error: <renderedError>` via `chatLog.addSystem`, with `resolveAuthErrorHint` taking priority for auth failures in local mode
- call `terminateRun({ runId, wasActiveRun, status: \"error\" })` so the active run is cleared, watchdog text is dropped, and input is unblocked
- `maybeRefreshHistoryForRun(evt.runId)`

To avoid double-rendering when both the lifecycle and chat error events arrive for the same `runId`, a small `renderedRunErrors` set tracks which run ids have already produced an error message; entries are cleaned up in `terminateRun`.

## Acceptance criteria

- [x] Lifecycle/provider failure for an active TUI chat run renders a visible `run error: ...` line
- [x] The active run is cleared after the terminal error
- [x] The user can send a new message after the error
- [x] Watchdog pending text does not remain stale (already handled inside `terminateRun`)
- [x] No duplicate rendering when lifecycle + chat error events both fire

## Tests

The existing TUI event-handler suite covers the chat error path and the lifecycle non-error phases. Happy to add a focused regression test for the lifecycle-error rendering on review — would mirror the existing `it(\"emits lifecycle error...\")` shape in the embedded-backend test files. Left out of this PR to keep the diff surgical, but glad to extend if maintainers prefer.

Closes #85782