### PR TITLE
fix(whatsapp): support pluginHooks.messageReceived in channel/account config schema

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -104,11 +104,20 @@ function shouldEmitWhatsAppMessageReceivedHooks(params: {
     params.accountId && channelConfig?.accounts
       ? channelConfig.accounts[params.accountId]
       : undefined;
-  return (
+  
+  // Try channel/account config first (documented path)
+  const channelOptIn =
     readWhatsAppMessageReceivedHookOptIn(accountConfig) ??
-    readWhatsAppMessageReceivedHookOptIn(channelConfig) ??
-    false
-  );
+    readWhatsAppMessageReceivedHookOptIn(channelConfig);
+  if (channelOptIn !== undefined) {
+    return channelOptIn;
+  }
+  
+  // Fallback to plugin config path for compatibility
+  const pluginConfig = params.cfg.plugins?.entries?.whatsapp?.config as
+    | WhatsAppMessageReceivedHookConfig
+    | undefined;
+  return readWhatsAppMessageReceivedHookOptIn(pluginConfig) ?? false;
 }
 
 function emitWhatsAppMessageReceivedHooks(params: {

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -93,7 +93,7 @@ function readWhatsAppMessageReceivedHookOptIn(value: unknown): boolean | undefin
   if (pluginHooks?.messageReceived === undefined) {
     return undefined;
   }
-  return pluginHooks?.messageReceived === true;
+  return pluginHooks.messageReceived;
 }
 
 function shouldEmitWhatsAppMessageReceivedHooks(params: {
@@ -108,19 +108,11 @@ function shouldEmitWhatsAppMessageReceivedHooks(params: {
       ? channelConfig.accounts[params.accountId]
       : undefined;
 
-  // Try channel/account config first (documented path)
-  const channelOptIn =
+  return (
     readWhatsAppMessageReceivedHookOptIn(accountConfig) ??
-    readWhatsAppMessageReceivedHookOptIn(channelConfig);
-  if (channelOptIn !== undefined) {
-    return channelOptIn;
-  }
-
-  // Fallback to plugin config path for compatibility
-  const pluginConfig = params.cfg.plugins?.entries?.whatsapp?.config as
-    | WhatsAppMessageReceivedHookConfig
-    | undefined;
-  return readWhatsAppMessageReceivedHookOptIn(pluginConfig) ?? false;
+    readWhatsAppMessageReceivedHookOptIn(channelConfig) ??
+    false
+  );
 }
 
 function emitWhatsAppMessageReceivedHooks(params: {

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -80,7 +80,7 @@ const WHATSAPP_MESSAGE_RECEIVED_HOOK_LIMITS = {
 
 type WhatsAppMessageReceivedHookConfig = {
   pluginHooks?: {
-    messageReceived?: unknown;
+    messageReceived?: boolean;
   };
   accounts?: Record<string, unknown>;
 };
@@ -90,7 +90,10 @@ function readWhatsAppMessageReceivedHookOptIn(value: unknown): boolean | undefin
     return undefined;
   }
   const pluginHooks = (value as WhatsAppMessageReceivedHookConfig).pluginHooks;
-  return pluginHooks?.messageReceived === true ? true : undefined;
+  if (pluginHooks?.messageReceived === undefined) {
+    return undefined;
+  }
+  return pluginHooks?.messageReceived === true;
 }
 
 function shouldEmitWhatsAppMessageReceivedHooks(params: {
@@ -104,7 +107,7 @@ function shouldEmitWhatsAppMessageReceivedHooks(params: {
     params.accountId && channelConfig?.accounts
       ? channelConfig.accounts[params.accountId]
       : undefined;
-  
+
   // Try channel/account config first (documented path)
   const channelOptIn =
     readWhatsAppMessageReceivedHookOptIn(accountConfig) ??
@@ -112,7 +115,7 @@ function shouldEmitWhatsAppMessageReceivedHooks(params: {
   if (channelOptIn !== undefined) {
     return channelOptIn;
   }
-  
+
   // Fallback to plugin config path for compatibility
   const pluginConfig = params.cfg.plugins?.entries?.whatsapp?.config as
     | WhatsAppMessageReceivedHookConfig

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -134,6 +134,11 @@ export type WhatsAppConfig = WhatsAppConfigCore &
     defaultAccount?: string;
     /** Per-action tool gating (default: true for all). */
     actions?: WhatsAppActionConfig;
+    /** Plugin hook opt-in configuration for privacy-sensitive inbound events. */
+    pluginHooks?: {
+      /** Enable message_received hooks to broadcast inbound WhatsApp messages to plugins. */
+      messageReceived?: boolean;
+    };
   };
 
 export type WhatsAppAccountConfig = WhatsAppConfigCore &
@@ -144,4 +149,9 @@ export type WhatsAppAccountConfig = WhatsAppConfigCore &
     enabled?: boolean;
     /** Override auth directory (Baileys multi-file auth state). */
     authDir?: string;
+    /** Plugin hook opt-in configuration for privacy-sensitive inbound events. */
+    pluginHooks?: {
+      /** Enable message_received hooks to broadcast inbound WhatsApp messages to plugins. */
+      messageReceived?: boolean;
+    };
   };

--- a/src/config/zod-schema.providers-whatsapp.test.ts
+++ b/src/config/zod-schema.providers-whatsapp.test.ts
@@ -136,4 +136,48 @@ describe("WhatsApp prompt config Zod validation", () => {
       undefined,
     );
   });
+
+  it("accepts channel-level pluginHooks.messageReceived", () => {
+    const config = {
+      pluginHooks: {
+        messageReceived: true,
+      },
+    };
+
+    const result = WhatsAppConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.pluginHooks?.messageReceived).toBe(true);
+    }
+  });
+
+  it("accepts account-level pluginHooks.messageReceived", () => {
+    const config = {
+      accounts: {
+        work: {
+          pluginHooks: {
+            messageReceived: true,
+          },
+        },
+      },
+    };
+
+    const result = WhatsAppConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.accounts?.work?.pluginHooks?.messageReceived).toBe(true);
+    }
+  });
+
+  it("rejects extra properties in pluginHooks", () => {
+    const config = {
+      pluginHooks: {
+        messageReceived: true,
+        otherProp: "invalid",
+      },
+    };
+
+    const result = WhatsAppConfigSchema.safeParse(config);
+    expect(result.success).toBe(false);
+  });
 });

--- a/src/config/zod-schema.providers-whatsapp.test.ts
+++ b/src/config/zod-schema.providers-whatsapp.test.ts
@@ -180,4 +180,36 @@ describe("WhatsApp prompt config Zod validation", () => {
     const result = WhatsAppConfigSchema.safeParse(config);
     expect(result.success).toBe(false);
   });
+
+  it("accepts channel-level pluginHooks.messageReceived: false", () => {
+    const config = {
+      pluginHooks: {
+        messageReceived: false,
+      },
+    };
+
+    const result = WhatsAppConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.pluginHooks?.messageReceived).toBe(false);
+    }
+  });
+
+  it("accepts account-level pluginHooks.messageReceived: false", () => {
+    const config = {
+      accounts: {
+        work: {
+          pluginHooks: {
+            messageReceived: false,
+          },
+        },
+      },
+    };
+
+    const result = WhatsAppConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.accounts?.work?.pluginHooks?.messageReceived).toBe(false);
+    }
+  });
 });

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -48,6 +48,13 @@ const WhatsAppAckReactionSchema = z
   .strict()
   .optional();
 
+const WhatsAppPluginHooksSchema = z
+  .object({
+    messageReceived: z.boolean().optional(),
+  })
+  .strict()
+  .optional();
+
 function stripDeprecatedWhatsAppNoopKeys(value: unknown): unknown {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return value;
@@ -97,6 +104,7 @@ function buildWhatsAppCommonShape(params: { useDefaults: boolean }) {
     replyToMode: ReplyToModeSchema.optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
     healthMonitor: ChannelHealthMonitorSchema,
+    pluginHooks: WhatsAppPluginHooksSchema,
   };
 }
 
@@ -150,12 +158,6 @@ const WhatsAppAccountObjectSchema = z
     /** Override auth directory for this WhatsApp account (Baileys multi-file auth state). */
     authDir: z.string().optional(),
     mediaMaxMb: z.number().int().positive().optional(),
-    pluginHooks: z
-      .object({
-        messageReceived: z.boolean().optional(),
-      })
-      .strict()
-      .optional(),
   })
   .strict();
 
@@ -175,12 +177,6 @@ const WhatsAppConfigObjectSchema = z
         reactions: z.boolean().optional(),
         sendMessage: z.boolean().optional(),
         polls: z.boolean().optional(),
-      })
-      .strict()
-      .optional(),
-    pluginHooks: z
-      .object({
-        messageReceived: z.boolean().optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -150,6 +150,12 @@ const WhatsAppAccountObjectSchema = z
     /** Override auth directory for this WhatsApp account (Baileys multi-file auth state). */
     authDir: z.string().optional(),
     mediaMaxMb: z.number().int().positive().optional(),
+    pluginHooks: z
+      .object({
+        messageReceived: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict();
 
@@ -169,6 +175,12 @@ const WhatsAppConfigObjectSchema = z
         reactions: z.boolean().optional(),
         sendMessage: z.boolean().optional(),
         polls: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
+    pluginHooks: z
+      .object({
+        messageReceived: z.boolean().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

Fixes the WhatsApp `messageReceived` hook opt-in configuration mismatch between docs, schema, and runtime.

## Changes

1. **Schema**: Added `pluginHooks.messageReceived` to both `WhatsAppConfigSchema` (channel-level) and `WhatsAppAccountSchema` (account-level)
2. **Runtime**: Updated `shouldEmitWhatsAppMessageReceivedHooks()` with proper precedence:
   - Account config → Channel config
   - **Honors explicit `false` opt-out**
3. **Types**: Added `pluginHooks.messageReceived` to exported `WhatsAppConfig` and `WhatsAppAccountConfig` types
4. **Tests**: Added regression tests for:
   - Channel-level and account-level `pluginHooks` validation
   - Explicit `messageReceived: false` opt-out at both levels
   - Rejection of extra properties in `pluginHooks`

## Behavior

### Before this fix
- Docs documented `channels.whatsapp.pluginHooks.messageReceived` but schema rejected it
- Exported TypeScript types were out of sync with schema

### After this fix
- ✅ Channel-level config: `channels.whatsapp.pluginHooks.messageReceived: true/false`
- ✅ Account-level config: `channels.whatsapp.accounts.<id>.pluginHooks.messageReceived: true/false`
- ✅ **Explicit `false` is honored**
- ✅ All config paths are schema-validated, type-safe, and runtime-honored

## Verification

### Schema Validation Tests
```bash
pnpm test src/config/zod-schema.providers-whatsapp.test.ts
```

New test coverage:
- ✅ accepts channel-level pluginHooks.messageReceived: true
- ✅ accepts account-level pluginHooks.messageReceived: true
- ✅ accepts channel-level pluginHooks.messageReceived: false
- ✅ accepts account-level pluginHooks.messageReceived: false
- ✅ rejects extra properties in pluginHooks

### Real behavior proof
**Exact steps or command run after this patch:**

1. Created test config file with channel-level pluginHooks:
```json5
{
  "channels": {
    "whatsapp": {
      "pluginHooks": {
        messageReceived: true
      }
    }
  }
}
```

2. Validated against WhatsAppConfigSchema - passes validation ✅

3. Created test config file with explicit false opt-out:
```json5
{
  "channels": {
    "whatsapp": {
      "pluginHooks": {
        messageReceived: false  // Explicit opt-out honored
      }
    }
  }
}
```

4. Validated against WhatsAppConfigSchema - passes validation ✅

5. Verified runtime precedence logic:
   - File: `extensions/whatsapp/src/auto-reply/monitor/process-message.ts:86-118`
   - Logic: Account config → Channel config
   - **Critical fix**: `readWhatsAppMessageReceivedHookOptIn()` now returns `false` for explicit false values

**Evidence after fix:**
- All 5 new test cases pass (see `src/config/zod-schema.providers-whatsapp.test.ts:140-217`)
- Schema accepts documented config paths from `docs/channels/whatsapp.md:210-240`
- Runtime respects privacy opt-outs
- Exported types in `src/config/types.whatsapp.ts` now match schema contract

**What was not tested:**
- Live WhatsApp message delivery (requires physical device/QR pairing)
- End-to-end hook firing in production gateway

## Related

Fixes #86390

## Changelog entry (for maintainer)

```markdown
- **WhatsApp plugin hooks**: Fixed `messageReceived` hook opt-in to accept channel-level and account-level `pluginHooks.messageReceived` config, aligning docs, schema, and runtime. Explicit `false` opt-outs are now honored.
```
