### PR TITLE
fix(agents): release embedded-attempt session lock on every exit path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 - Gateway: avoid sending duplicate tool-event frames to Control UI connections that are subscribed by both run and session.
 - Discord/OpenAI voice: accept leading fuzzy wake-name transcripts such as "Monty" or "Moti" for a Molty agent while keeping ambient speech gated.
 - Media understanding: convert HEIC and HEIF images to JPEG before image description providers run so iPhone photos work in direct and configured image-description flows. (#86037)
+- Agents: release embedded-attempt session locks from outer teardown so post-prompt exceptions cannot wedge later requests behind `SessionWriteLockTimeoutError`. Fixes #86014. Thanks @openperf.
 - Discord/OpenAI voice: rotate Realtime sessions at provider max duration without logging the expected session-expiry event as an error.
 - Agents/media: derive bundled plugin local-media trust from plugin tool metadata instead of importing the full plugin registry on subscription paths. (#84409) Thanks @samzong.
 - Memory/local embeddings: run local GGUF embeddings in an isolated worker sidecar and degrade to configured fallback or keyword search on worker failure so native embedding crashes do not take down the Gateway. (#85348) Thanks @osolmaz.

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
@@ -68,6 +68,45 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(releases).toEqual(["prep", "cleanup"]);
   });
 
+  it("releases the eagerly-held attempt lock on dispose when cleanup is skipped (#86014)", async () => {
+    const releases: string[] = [];
+    const acquireSessionWriteLock = vi
+      .fn()
+      .mockResolvedValueOnce({ release: vi.fn(async () => releases.push("held")) });
+
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions,
+    });
+
+    // An exception on the post-prompt path skips acquireForCleanup; the run's outer finally
+    // must still release the eagerly-held lock or it leaks to the live process.
+    await controller.dispose();
+    await controller.dispose(); // idempotent
+
+    expect(acquireSessionWriteLock).toHaveBeenCalledTimes(1);
+    expect(releases).toEqual(["held"]);
+  });
+
+  it("dispose does not double-release a lock already handed to cleanup", async () => {
+    const releases: string[] = [];
+    const acquireSessionWriteLock = vi
+      .fn()
+      .mockResolvedValueOnce({ release: vi.fn(async () => releases.push("held")) });
+
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions,
+    });
+
+    const cleanupLock = await controller.acquireForCleanup();
+    await cleanupLock.release();
+    await controller.dispose();
+
+    expect(acquireSessionWriteLock).toHaveBeenCalledTimes(1);
+    expect(releases).toEqual(["held"]);
+  });
+
   it("runs post-prompt transcript writes under a short reacquired lock", async () => {
     const events: string[] = [];
     const acquireSessionWriteLock = vi

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
@@ -630,6 +630,13 @@ export type EmbeddedAttemptSessionLockController = {
   ): Promise<T>;
   acquireForCleanup(params?: { session?: unknown }): Promise<SessionLock>;
   hasSessionTakeover(): boolean;
+  /**
+   * Force-release the eagerly-held session lock if it is still retained. Idempotent and safe
+   * to call from a run's outer `finally`: the happy path hands the lock to `acquireForCleanup`
+   * (so this is a no-op), but an exception on the post-prompt path can skip cleanup entirely,
+   * which would otherwise leak the lock to the live process until the watchdog reclaims it.
+   */
+  dispose(): Promise<void>;
 };
 
 export async function createEmbeddedAttemptSessionLockController(params: {
@@ -871,6 +878,14 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     },
     hasSessionTakeover(): boolean {
       return takeoverDetected;
+    },
+    async dispose(): Promise<void> {
+      if (!heldLock) {
+        return;
+      }
+      const lock = heldLock;
+      heldLock = undefined;
+      await lock.release();
     },
   };
 }

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
@@ -630,12 +630,6 @@ export type EmbeddedAttemptSessionLockController = {
   ): Promise<T>;
   acquireForCleanup(params?: { session?: unknown }): Promise<SessionLock>;
   hasSessionTakeover(): boolean;
-  /**
-   * Force-release the eagerly-held session lock if it is still retained. Idempotent and safe
-   * to call from a run's outer `finally`: the happy path hands the lock to `acquireForCleanup`
-   * (so this is a no-op), but an exception on the post-prompt path can skip cleanup entirely,
-   * which would otherwise leak the lock to the live process until the watchdog reclaims it.
-   */
   dispose(): Promise<void>;
 };
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1302,10 +1302,7 @@ export async function runEmbeddedAttempt(
     | undefined;
   let beforeAgentRunBlocked = false;
   let beforeAgentRunBlockedBy: string | undefined;
-  // Set once the session lock controller exists, so the outer finally can always release the
-  // eagerly-held session lock even when an exception on the post-prompt path skips the cleanup
-  // block below (#86014). The cleanup block hands the lock off on normal/aborted paths, so this
-  // is a no-op then.
+  // Releases the eager session lock if post-prompt code exits before cleanup.
   let releaseRetainedSessionLock: (() => Promise<void>) | undefined;
   try {
     const skillsSnapshotForRun =
@@ -5076,10 +5073,6 @@ export async function runEmbeddedAttempt(
       }
     }
   } finally {
-    // Guarantee the eagerly-held session write lock is released on every exit path. The cleanup
-    // block above hands it to acquireForCleanup on normal/aborted/timed-out runs (so this is a
-    // no-op then), but an exception thrown in post-prompt processing skips that block and would
-    // otherwise leak the lock to the live gateway process until the watchdog reclaims it (#86014).
     try {
       await releaseRetainedSessionLock?.();
     } catch (releaseErr) {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1302,6 +1302,11 @@ export async function runEmbeddedAttempt(
     | undefined;
   let beforeAgentRunBlocked = false;
   let beforeAgentRunBlockedBy: string | undefined;
+  // Set once the session lock controller exists, so the outer finally can always release the
+  // eagerly-held session lock even when an exception on the post-prompt path skips the cleanup
+  // block below (#86014). The cleanup block hands the lock off on normal/aborted paths, so this
+  // is a no-op then.
+  let releaseRetainedSessionLock: (() => Promise<void>) | undefined;
   try {
     const skillsSnapshotForRun =
       sandbox?.enabled && sandbox.workspaceAccess !== "rw" ? undefined : params.skillsSnapshot;
@@ -2140,6 +2145,7 @@ export async function runEmbeddedAttempt(
         ...sessionWriteLockOptions,
       },
     });
+    releaseRetainedSessionLock = () => sessionLockController.dispose();
 
     let sessionManager: ReturnType<typeof guardSessionManager> | undefined;
     let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | undefined;
@@ -5070,6 +5076,17 @@ export async function runEmbeddedAttempt(
       }
     }
   } finally {
+    // Guarantee the eagerly-held session write lock is released on every exit path. The cleanup
+    // block above hands it to acquireForCleanup on normal/aborted/timed-out runs (so this is a
+    // no-op then), but an exception thrown in post-prompt processing skips that block and would
+    // otherwise leak the lock to the live gateway process until the watchdog reclaims it (#86014).
+    try {
+      await releaseRetainedSessionLock?.();
+    } catch (releaseErr) {
+      log.error(
+        `failed to release retained session lock on attempt teardown: runId=${params.runId} ${String(releaseErr)}`,
+      );
+    }
     emitDiagnosticRunCompleted?.(
       aborted ? "aborted" : "error",
       promptError ?? new Error("run exited before diagnostic completion"),


### PR DESCRIPTION
### Summary

- **Problem**: During an embedded agent run the gateway holds a write lock on the session `.jsonl` file. If the run times out or a tool errors, the lock can be left held by the live gateway process — subsequent requests to that session block for the acquire timeout and then fail with `SessionWriteLockTimeoutError` (`OPENCLAW_SESSION_WRITE_LOCK_TIMEOUT`), and the retained session graph leaks memory. (#86014)
- **Root Cause**: `createEmbeddedAttemptSessionLockController` acquires its coarse session lock (`heldLock`) **eagerly at creation** and the run releases it only inside the post-run cleanup block (`acquireForCleanup` → `cleanupEmbeddedAttemptResources`, which itself releases in a `finally`). That cleanup block is ordinary try-body code. The run's outer `finally` did **not** release the lock — it only emitted diagnostics and restored skill env. Normal timeout/abort/error paths funnel into `aborted`/`timedOut`/`promptError` flags and *do* reach the cleanup block, but an exception thrown in the ~post-prompt processing between the prompt teardown and the cleanup block (e.g. a tool/result step or the trajectory flush erroring) escapes straight to the outer `finally`, skipping the release. The lock then stays held by the live process (its PID is alive, so it is not stale) until the long compaction-scaled watchdog window elapses or a retry re-acquires it — effectively wedging the session. (The reporter's "`maxHoldMs` grows unboundedly" is a fixed value: the embedded-attempt lock's `maxHoldMs` is the compaction window + grace = `1020000`ms, matching the reported lock file; the observed `createdAt` refresh is the lock being re-acquired by retries.)
- **Regression provenance**: this surfaced with #82891 ("Release embedded session write lock before model I/O", `8a060b2904d4`), which replaced the single per-run `sessionLock` with this eagerly-acquired controller (release-before-I/O + reacquire) and added the post-prompt processing that can throw; the controller releases the lock only through the post-run cleanup hand-off, so an exception on the post-prompt path leaves it held.
- **Fix**: Give the lock controller an idempotent `dispose()` that releases `heldLock` if it is still retained, and call it from the run's outer `finally` so the lock is released on **every** exit path. On normal/aborted/timed-out runs the cleanup block still hands the lock to `acquireForCleanup` first, so `dispose()` is a no-op then (no double release); only the exception-skips-cleanup path now actually releases via `dispose()`.
- **What changed**:
  - `src/agents/pi-embedded-runner/run/attempt.session-lock.ts`: add `dispose(): Promise<void>` to `EmbeddedAttemptSessionLockController` (releases the retained `heldLock`, idempotent).
  - `src/agents/pi-embedded-runner/run/attempt.ts`: capture a `releaseRetainedSessionLock` closure once the controller exists and invoke it in the run's outer `finally` (guarded so a release error is logged rather than masking the run's original error).
  - `src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts`: regression coverage.
- **What did NOT change (scope boundary)**:
  - The happy-path lock handoff (`acquireForCleanup` → `cleanupEmbeddedAttemptResources`) and its flush behavior are unchanged; `dispose()` is a safety net.
  - The session write-lock primitive, its watchdog/stale logic, and `maxHoldMs` derivation are unchanged. The separate "an operation inside `withSessionWriteLock` never returns" variant (its own `finally` cannot run) remains covered only by the watchdog and is out of scope.
  - No config keys, protocol, or message-delivery behavior changed.

### Reproduction

1. An embedded attempt creates the session lock controller (eagerly acquiring the session write lock).
2. Post-prompt processing throws (e.g. a tool/result step or trajectory flush errors) before the cleanup block runs `acquireForCleanup`.
- Before: the exception escapes to the outer `finally`, which does not release the lock; the lock file persists held by the live process and the next request to that session fails with `SessionWriteLockTimeoutError`.
- After: the outer `finally` calls the controller's `dispose()`, releasing the retained lock; the next request succeeds.

### Real behavior proof

- **Behavior addressed**: when an embedded attempt throws after eagerly acquiring the session lock but before the cleanup block, the run must still release the session write lock so later requests to the same session do not fail with `SessionWriteLockTimeoutError`.
- **Real environment tested (Linux, Node 22)**: a standalone harness drives the **real** `acquireSessionWriteLock` and the **real** `createEmbeddedAttemptSessionLockController` against a temp session file, with the embedded-attempt `maxHoldMs` (1020000) the gateway uses. It runs an attempt that acquires the lock then throws during post-prompt processing, then issues a second `acquireSessionWriteLock` for the same session from the same live process — once without the fix (no `dispose()` in the finally) and once with it.
- **Exact steps or command run after this patch**: `tsx /tmp/qmd86014/repro.mts`.
- **Evidence after fix (verbatim harness output)**:

```text
--- BEFORE (pre-fix: outer finally does not release) (dispose in finally = false) ---
  attempt threw: post-processing failure (e.g., trajectory flush)
  lock file persists: true
  subsequent acquire on same session: FAILED SessionWriteLockTimeoutError (isSessionWriteLockTimeoutError=true)

--- AFTER (fix: outer finally calls controller.dispose()) (dispose in finally = true) ---
  attempt threw: post-processing failure (e.g., trajectory flush)
  lock file persists: false
  subsequent acquire on same session: SUCCEEDED

RESULT: PASS — BEFORE leaks the lock and the next request hits SessionWriteLockTimeoutError;
         AFTER (controller.dispose() in the outer finally) releases it and the next request succeeds.
```

- **Observed result after fix**: the leaked lock is released on the exception path; the next request to the same session succeeds instead of failing with `SessionWriteLockTimeoutError` — the reporter's error (`session file locked (timeout 60000ms): pid=7 …/<session>.jsonl.lock`) is reproduced verbatim (same shape, differing only in timeout/pid) and removed by the fix.
- **Regression tests**: `pnpm test src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts` (68 passed) including two new cases — `dispose()` releases the eagerly-held lock when cleanup is skipped (and is idempotent), and `dispose()` does not double-release a lock already handed to `acquireForCleanup`.
- **What was not tested**: a full multi-process live gateway run with real cron `agentTurn` retries over time was not executed; the harness exercises the real lock primitive + real controller end to end and the unit tests cover the `dispose()` contract. The "stalled operation inside `withSessionWriteLock` never returns" variant is not addressed here (covered by the watchdog).

### Risk / Mitigation

- **Risk**: releasing in the outer `finally` could double-release a lock the cleanup block already released, or a release error could mask the run's original error.
- **Mitigation**: `dispose()` is idempotent — the happy/aborted/timed-out paths transfer the lock out via `acquireForCleanup` (so the controller no longer retains it and `dispose()` is a no-op), proven by a no-double-release test. The outer-`finally` call is wrapped so a release failure is logged rather than thrown, mirroring the existing teardown logging. No behavior change on paths that already released the lock.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Sessions / storage

### Linked Issue/PR

Fixes #86014
