### PR TITLE
fix(codex): enable native tool surface when toolsAllow lists native tools

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2097,6 +2097,35 @@ describe("runCodexAppServerAttempt", () => {
     expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
   });
 
+  it("enables Codex native tool surfaces when toolsAllow lists native tools", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+
+    // Explicit native tool names should enable the native surface
+    params.toolsAllow = ["read"];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+
+    params.toolsAllow = ["write"];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+
+    params.toolsAllow = ["edit"];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+
+    params.toolsAllow = ["exec"];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+
+    params.toolsAllow = ["read", "write", "edit"];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+
+    // Non-native tools should NOT enable the native surface
+    params.toolsAllow = ["message"];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+
+    params.toolsAllow = ["web_search"];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+  });
+
   it("disables Codex native tool surfaces when the effective exec target is node", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const sessionParams = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -102,6 +102,7 @@ import {
   isForcedPrivateQaCodexRuntime,
   normalizeCodexDynamicToolName,
   resolveCodexDynamicToolsLoading,
+  CODEX_APP_SERVER_OWNED_DYNAMIC_TOOL_EXCLUDES,
 } from "./dynamic-tool-profile.js";
 import { createCodexDynamicToolBridge, type CodexDynamicToolBridge } from "./dynamic-tools.js";
 import { handleCodexAppServerElicitationRequest } from "./elicitation-bridge.js";
@@ -3982,8 +3983,14 @@ function shouldEnableCodexAppServerNativeToolSurface(
   // Codex native code mode exposes its shell/file surface as one app-server
   // capability, so narrow OpenClaw allowlists must fail closed rather than
   // widening `message` or `web_search` into shell access.
+  // However, if the user explicitly lists native tools (read/write/edit) in
+  // toolsAllow, the native surface must be enabled for those tools to work.
+  const nativeExcludeSet = new Set(CODEX_APP_SERVER_OWNED_DYNAMIC_TOOL_EXCLUDES);
+  const requestsNativeTool = toolsAllow.some(
+    (name) => nativeExcludeSet.has(normalizeCodexDynamicToolName(name)),
+  );
   return (
-    hasWildcardCodexToolsAllow(toolsAllow) &&
+    (hasWildcardCodexToolsAllow(toolsAllow) || requestsNativeTool) &&
     canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox, options)
   );
 }


### PR DESCRIPTION
## Summary

Fixes silent failure when `toolsAllow` explicitly lists native Codex tools (read/write/edit/exec).

## Problem

When `toolsAllow` is set to an explicit list like `["read", "write", "edit"]`, `shouldEnableCodexAppServerNativeToolSurface` returns `false` because:
1. Native tools are excluded from dynamic tools (`CODEX_APP_SERVER_OWNED_DYNAMIC_TOOL_EXCLUDES`)
2. Native tool surface is only enabled for wildcard (`*`) or undefined `toolsAllow`

Result: agent reports "no write tools" but `lastRunStatus: ok` — silent data loss for memory-consolidation crons and other restricted-tool workflows.

## Fix

Check if `toolsAllow` contains any native tool names and enable the native tool surface accordingly.

| File | Changes |
|------|---------|
| `extensions/codex/src/app-server/run-attempt.ts` | +10 | Add native tool detection to `shouldEnableCodexAppServerNativeToolSurface` |
| `extensions/codex/src/app-server/run-attempt.test.ts` | +27 | 8 test cases for native/non-native toolsAllow |

Maintains fail-closed behavior for non-native tools (`message`, `web_search`).

Fixes: #86423