### PR TITLE
test(node-cli): cover daemon install and lifecycle paths

### DIFF
--- a/src/cli/node-cli/daemon.test.ts
+++ b/src/cli/node-cli/daemon.test.ts
@@ -155,6 +155,7 @@ describe("runNodeDaemonStatus", () => {
   it("fails install when the saved node gateway port is invalid", async () => {
     mocks.loadNodeHostConfig.mockResolvedValue({
       version: 1,
+      nodeId: "node-invalid-port",
       gateway: { port: 70_000 },
     });
 

--- a/src/cli/node-cli/daemon.test.ts
+++ b/src/cli/node-cli/daemon.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayServiceRuntime } from "../../daemon/service-runtime.js";
+import type { GatewayServiceCommand } from "../../daemon/service.ts";
+import type { NodeHostConfig } from "../../node-host/config.ts";
 import { runNodeDaemonInstall, runNodeDaemonStatus } from "./daemon.js";
 
 const actionState = vi.hoisted(() => ({
@@ -19,7 +21,7 @@ const mocks = vi.hoisted(() => {
     stop: vi.fn(),
     restart: vi.fn(),
     isLoaded: vi.fn(async () => true),
-    readCommand: vi.fn(async () => null),
+    readCommand: vi.fn<() => Promise<GatewayServiceCommand | null>>(async () => null),
     readRuntime: vi.fn<() => Promise<GatewayServiceRuntime>>(async () => ({ status: "running" })),
   };
   return {
@@ -30,7 +32,7 @@ const mocks = vi.hoisted(() => {
       environmentValueSources: {},
       description: "OpenClaw node host",
     })),
-    loadNodeHostConfig: vi.fn(async () => null),
+    loadNodeHostConfig: vi.fn<() => Promise<NodeHostConfig | null>>(async () => null),
     installDaemonServiceAndEmit: vi.fn(async (_params?: unknown) => {}),
     runtime: {
       log: vi.fn<(line: string) => void>(),

--- a/src/cli/node-cli/daemon.test.ts
+++ b/src/cli/node-cli/daemon.test.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayServiceRuntime } from "../../daemon/service-runtime.js";
-import { runNodeDaemonStatus } from "./daemon.js";
+import { runNodeDaemonInstall, runNodeDaemonStatus } from "./daemon.js";
+
+const actionState = vi.hoisted(() => ({
+  warnings: [] as string[],
+  emitted: [] as unknown[],
+  failed: [] as Array<{ message: string; hints?: string[] }>,
+}));
 
 const mocks = vi.hoisted(() => {
   const service = {
@@ -17,6 +23,15 @@ const mocks = vi.hoisted(() => {
     readRuntime: vi.fn<() => Promise<GatewayServiceRuntime>>(async () => ({ status: "running" })),
   };
   return {
+    buildNodeInstallPlan: vi.fn(async () => ({
+      programArguments: ["openclaw", "node", "run"],
+      workingDirectory: "/tmp/openclaw-node",
+      environment: {},
+      environmentValueSources: {},
+      description: "OpenClaw node host",
+    })),
+    loadNodeHostConfig: vi.fn(async () => null),
+    installDaemonServiceAndEmit: vi.fn(async (_params?: unknown) => {}),
     runtime: {
       log: vi.fn<(line: string) => void>(),
       error: vi.fn<(line: string) => void>(),
@@ -33,6 +48,14 @@ vi.mock("../../runtime.js", () => ({
 
 vi.mock("../../daemon/node-service.js", () => ({
   resolveNodeService: () => mocks.service,
+}));
+
+vi.mock("../../commands/node-daemon-install-helpers.js", () => ({
+  buildNodeInstallPlan: mocks.buildNodeInstallPlan,
+}));
+
+vi.mock("../../node-host/config.js", () => ({
+  loadNodeHostConfig: mocks.loadNodeHostConfig,
 }));
 
 vi.mock("../../daemon/runtime-hints.js", () => ({
@@ -57,6 +80,23 @@ vi.mock("../daemon-cli/shared.js", async () => {
     await vi.importActual<typeof import("../daemon-cli/shared.js")>("../daemon-cli/shared.js");
   return {
     ...actual,
+    createDaemonInstallActionContext: (jsonFlag: unknown) => {
+      const json = Boolean(jsonFlag);
+      return {
+        json,
+        stdout: process.stdout,
+        warnings: actionState.warnings,
+        emit: (payload: unknown) => {
+          if (json) {
+            actionState.emitted.push(payload);
+          }
+        },
+        fail: (message: string, hints?: string[]) => {
+          actionState.failed.push({ message, hints });
+          mocks.runtime.exit(1);
+        },
+      };
+    },
     createCliStatusTextStyles: () => ({
       rich: false,
       label: (text: string) => text,
@@ -66,8 +106,19 @@ vi.mock("../daemon-cli/shared.js", async () => {
       warnText: (text: string) => text,
       errorText: (text: string) => text,
     }),
+    failIfNixDaemonInstallMode: () => false,
     formatRuntimeStatus: (runtime: GatewayServiceRuntime | undefined) => runtime?.status ?? "",
     resolveRuntimeStatusColor: () => "",
+  };
+});
+
+vi.mock("../daemon-cli/response.js", async () => {
+  const actual = await vi.importActual<typeof import("../daemon-cli/response.js")>(
+    "../daemon-cli/response.js",
+  );
+  return {
+    ...actual,
+    installDaemonServiceAndEmit: mocks.installDaemonServiceAndEmit,
   };
 });
 
@@ -85,9 +136,82 @@ describe("runNodeDaemonStatus", () => {
     mocks.runtime.error.mockClear();
     mocks.runtime.writeJson.mockClear();
     mocks.runtime.exit.mockClear();
+    mocks.buildNodeInstallPlan.mockClear();
+    mocks.loadNodeHostConfig.mockReset().mockResolvedValue(null);
+    mocks.installDaemonServiceAndEmit.mockReset().mockResolvedValue(undefined);
     mocks.service.isLoaded.mockReset().mockResolvedValue(true);
     mocks.service.readCommand.mockReset().mockResolvedValue(null);
     mocks.service.readRuntime.mockReset().mockResolvedValue({ status: "running" });
+    actionState.warnings.length = 0;
+    actionState.emitted.length = 0;
+    actionState.failed.length = 0;
+  });
+
+  it("fails install when the saved node gateway port is invalid", async () => {
+    mocks.loadNodeHostConfig.mockResolvedValue({
+      version: 1,
+      gateway: { port: 70_000 },
+    });
+
+    await runNodeDaemonInstall({ json: true });
+
+    expect(actionState.failed[0]?.message).toContain("node.gateway.port");
+    expect(mocks.runtime.exit).toHaveBeenCalledWith(1);
+    expect(mocks.service.isLoaded).not.toHaveBeenCalled();
+    expect(mocks.buildNodeInstallPlan).not.toHaveBeenCalled();
+    expect(mocks.installDaemonServiceAndEmit).not.toHaveBeenCalled();
+  });
+
+  it("short-circuits install when the node service is already loaded", async () => {
+    mocks.service.isLoaded.mockResolvedValue(true);
+
+    await runNodeDaemonInstall({});
+
+    expect(stdout()).toContain("Node service already loaded.");
+    expect(stdout()).toContain("openclaw node install --force");
+    expect(actionState.failed).toStrictEqual([]);
+    expect(mocks.buildNodeInstallPlan).not.toHaveBeenCalled();
+    expect(mocks.installDaemonServiceAndEmit).not.toHaveBeenCalled();
+  });
+
+  it("writes node service status as json when requested", async () => {
+    mocks.service.readCommand.mockResolvedValue({
+      programArguments: ["openclaw", "node", "run"],
+      sourcePath: "/tmp/openclaw-node.service",
+      workingDirectory: "/tmp/openclaw-node",
+      environment: { OPENCLAW_PROFILE: "node-test" },
+    });
+
+    await runNodeDaemonStatus({ json: true });
+
+    expect(mocks.runtime.writeJson).toHaveBeenCalledWith({
+      service: {
+        label: "Node service",
+        loaded: true,
+        loadedText: "loaded",
+        notLoadedText: "not loaded",
+        command: {
+          programArguments: ["openclaw", "node", "run"],
+          sourcePath: "/tmp/openclaw-node.service",
+          workingDirectory: "/tmp/openclaw-node",
+          environment: { OPENCLAW_PROFILE: "node-test" },
+        },
+        runtime: { status: "running" },
+      },
+    });
+    expect(stdout()).toBe("");
+    expect(stderr()).toBe("");
+  });
+
+  it("prints node service start hints when the service is not installed", async () => {
+    mocks.service.isLoaded.mockResolvedValue(false);
+    mocks.service.readRuntime.mockResolvedValue({ status: "unknown" });
+
+    await runNodeDaemonStatus();
+
+    expect(stdout()).toContain("Start with: openclaw node install");
+    expect(stdout()).toContain("Start with: openclaw node start");
+    expect(stderr()).toBe("");
   });
 
   it("keeps missing service-unit status on stderr and prints recovery hints on stdout", async () => {

--- a/src/cli/node-cli/daemon.test.ts
+++ b/src/cli/node-cli/daemon.test.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayServiceRuntime } from "../../daemon/service-runtime.js";
-import type { GatewayServiceCommand } from "../../daemon/service.ts";
-import type { NodeHostConfig } from "../../node-host/config.ts";
+import type { GatewayServiceCommandConfig } from "../../daemon/service-types.js";
 import { runNodeDaemonInstall, runNodeDaemonStatus } from "./daemon.js";
+
+type LoadNodeHostConfig = typeof import("../../node-host/config.js").loadNodeHostConfig;
 
 const actionState = vi.hoisted(() => ({
   warnings: [] as string[],
@@ -21,7 +22,9 @@ const mocks = vi.hoisted(() => {
     stop: vi.fn(),
     restart: vi.fn(),
     isLoaded: vi.fn(async () => true),
-    readCommand: vi.fn<() => Promise<GatewayServiceCommand | null>>(async () => null),
+    readCommand: vi.fn<(env: NodeJS.ProcessEnv) => Promise<GatewayServiceCommandConfig | null>>(
+      async () => null,
+    ),
     readRuntime: vi.fn<() => Promise<GatewayServiceRuntime>>(async () => ({ status: "running" })),
   };
   return {
@@ -32,7 +35,7 @@ const mocks = vi.hoisted(() => {
       environmentValueSources: {},
       description: "OpenClaw node host",
     })),
-    loadNodeHostConfig: vi.fn<() => Promise<NodeHostConfig | null>>(async () => null),
+    loadNodeHostConfig: vi.fn<LoadNodeHostConfig>(async () => null),
     installDaemonServiceAndEmit: vi.fn(async (_params?: unknown) => {}),
     runtime: {
       log: vi.fn<(line: string) => void>(),

--- a/src/cli/node-cli/register.test.ts
+++ b/src/cli/node-cli/register.test.ts
@@ -67,6 +67,59 @@ describe("registerNodeCli", () => {
     expect(daemonMocks.runNodeDaemonStart.mock.calls[0]?.[0]?.json).toBe(true);
   });
 
+  it("registers node status/stop/restart/uninstall subcommands", async () => {
+    await createProgram().parseAsync(["node", "status", "--json"], { from: "user" });
+    expect(daemonMocks.runNodeDaemonStatus).toHaveBeenLastCalledWith({ json: true });
+
+    await createProgram().parseAsync(["node", "stop", "--json"], { from: "user" });
+    expect(daemonMocks.runNodeDaemonStop).toHaveBeenLastCalledWith({ json: true });
+
+    await createProgram().parseAsync(["node", "restart", "--json"], { from: "user" });
+    expect(daemonMocks.runNodeDaemonRestart).toHaveBeenLastCalledWith({ json: true });
+
+    await createProgram().parseAsync(["node", "uninstall", "--json"], { from: "user" });
+    expect(daemonMocks.runNodeDaemonUninstall).toHaveBeenLastCalledWith({ json: true });
+  });
+
+  it("passes install flags through to the node daemon installer", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(
+      [
+        "node",
+        "install",
+        "--host",
+        "10.0.0.3",
+        "--port",
+        "19002",
+        "--tls",
+        "--tls-fingerprint",
+        "abc123",
+        "--node-id",
+        "node-1",
+        "--display-name",
+        "Node One",
+        "--runtime",
+        "bun",
+        "--force",
+        "--json",
+      ],
+      { from: "user" },
+    );
+
+    expect(daemonMocks.runNodeDaemonInstall).toHaveBeenCalledWith({
+      host: "10.0.0.3",
+      port: "19002",
+      tls: true,
+      tlsFingerprint: "abc123",
+      nodeId: "node-1",
+      displayName: "Node One",
+      runtime: "bun",
+      force: true,
+      json: true,
+    });
+  });
+
   it("rejects an explicit invalid node run port", async () => {
     const program = createProgram();
 


### PR DESCRIPTION
## Summary
- add focused `node-cli` daemon tests for invalid saved ports, already-installed short-circuit, json status payload, and not-installed start hints
- expand `registerNodeCli` coverage for status/stop/restart/uninstall forwarding and install option passthrough
- keep the change test-only; no production behavior changes

## Verification
- `git diff --check`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/node-cli/daemon.test.ts src/cli/node-cli/register.test.ts --pool forks --maxWorkers=1 --reporter=tap`

## Real behavior proof
Behavior addressed: `openclaw node` still had untested install/status/lifecycle branches on current main even after the original issue report aged; this patch proves those branches now execute under focused CLI tests.
Real environment tested: local source checkout on Linux in a fresh worktree, against current `main`-based code.
Exact steps or command run after this patch: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/node-cli/daemon.test.ts src/cli/node-cli/register.test.ts --pool forks --maxWorkers=1 --reporter=tap`
Evidence after fix: `ok 1 - fails install when the saved node gateway port is invalid`; `ok 2 - short-circuits install when the node service is already loaded`; `ok 3 - writes node service status as json when requested`; `ok 4 - prints node service start hints when the service is not installed`; `ok 2 - registers node status/stop/restart/uninstall subcommands`; `ok 3 - passes install flags through to the node daemon installer`
Observed result after fix: both `src/cli/node-cli/daemon.test.ts` and `src/cli/node-cli/register.test.ts` passed with the newly covered install/status/lifecycle branches executing successfully.
What was not tested: no live launchd/systemd/schtasks install was performed because this PR only adds unit-style CLI coverage and does not change runtime behavior.
