### PR TITLE
fix #86423: codex: explicit toolsAllow lists strip native read/write/edit/exec instead of enabling them

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2097,6 +2097,36 @@ describe("runCodexAppServerAttempt", () => {
     expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
   });
 
+  it("enables Codex native tool surfaces when toolsAllow explicitly includes native-owned tools", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+
+    // Single native tool
+    params.toolsAllow = ["read"];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+
+    // Multiple native tools
+    params.toolsAllow = ["write", "edit"];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+
+    // Mix of native and non-native tools
+    params.toolsAllow = ["memory_search", "read", "web_search"];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+
+    // Exec alias should work
+    params.toolsAllow = ["bash"];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+
+    // apply-patch alias should work
+    params.toolsAllow = ["apply-patch"];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+
+    // Non-native only should remain disabled
+    params.toolsAllow = ["memory_search", "message", "web_search"];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+  });
+
   it("disables Codex native tool surfaces when the effective exec target is node", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const sessionParams = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -52,6 +52,7 @@ import {
   emitDynamicToolStartedDiagnostic,
   emitDynamicToolTerminalDiagnostic,
 } from "./dynamic-tool-diagnostics.js";
+import { CODEX_APP_SERVER_OWNED_DYNAMIC_TOOL_EXCLUDES } from "./dynamic-tool-profile.js";
 import {
   CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE,
   createCodexDynamicToolBridge,
@@ -2097,34 +2098,55 @@ describe("runCodexAppServerAttempt", () => {
     expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
   });
 
-  it("enables Codex native tool surfaces when toolsAllow explicitly includes native-owned tools", () => {
+  it("keeps partial native-owned toolsAllow lists from widening to the full native surface", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
     params.disableTools = false;
 
-    // Single native tool
     params.toolsAllow = ["read"];
-    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
 
-    // Multiple native tools
     params.toolsAllow = ["write", "edit"];
-    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
 
-    // Mix of native and non-native tools
     params.toolsAllow = ["memory_search", "read", "web_search"];
-    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
 
-    // Exec alias should work
     params.toolsAllow = ["bash"];
-    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
 
-    // apply-patch alias should work
     params.toolsAllow = ["apply-patch"];
-    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
 
-    // Non-native only should remain disabled
     params.toolsAllow = ["memory_search", "message", "web_search"];
     expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+  });
+
+  it("enables Codex native tool surfaces for wildcard or complete native-owned toolsAllow lists", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+
+    params.toolsAllow = ["*"];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+
+    params.toolsAllow = [...CODEX_APP_SERVER_OWNED_DYNAMIC_TOOL_EXCLUDES];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+
+    params.toolsAllow = [
+      "read",
+      "write",
+      "edit",
+      "apply-patch",
+      "bash",
+      "process",
+      "update_plan",
+      "tool_call",
+      "tool_describe",
+      "tool_search",
+      "tool_search_code",
+    ];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
   });
 
   it("disables Codex native tool surfaces when the effective exec target is node", () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -98,6 +98,7 @@ import {
   emitDynamicToolTerminalDiagnostic,
 } from "./dynamic-tool-diagnostics.js";
 import {
+  CODEX_APP_SERVER_OWNED_DYNAMIC_TOOL_EXCLUDES,
   filterCodexDynamicTools,
   isForcedPrivateQaCodexRuntime,
   normalizeCodexDynamicToolName,
@@ -3979,11 +3980,14 @@ function shouldEnableCodexAppServerNativeToolSurface(
   if (toolsAllow === undefined) {
     return canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox, options);
   }
-  // Codex native code mode exposes its shell/file surface as one app-server
-  // capability, so narrow OpenClaw allowlists must fail closed rather than
-  // widening `message` or `web_search` into shell access.
+  // Enable native surface if toolsAllow has wildcard OR explicitly requests any
+  // native-owned tool (read, write, edit, exec, etc.). This ensures that when
+  // users request native tools in their allowlist, they actually get them.
+  const hasNativeRequest = toolsAllow.some((name) =>
+    CODEX_APP_SERVER_OWNED_DYNAMIC_TOOL_EXCLUDES.includes(normalizeCodexDynamicToolName(name)),
+  );
   return (
-    hasWildcardCodexToolsAllow(toolsAllow) &&
+    (hasWildcardCodexToolsAllow(toolsAllow) || hasNativeRequest) &&
     canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox, options)
   );
 }

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -3980,18 +3980,23 @@ function shouldEnableCodexAppServerNativeToolSurface(
   if (toolsAllow === undefined) {
     return canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox, options);
   }
-  // Enable native surface if toolsAllow has wildcard OR explicitly requests any
-  // native-owned tool (read, write, edit, exec, etc.). This ensures that when
-  // users request native tools in their allowlist, they actually get them.
-  const hasNativeRequest = toolsAllow.some((name) =>
-    (CODEX_APP_SERVER_OWNED_DYNAMIC_TOOL_EXCLUDES as readonly string[]).includes(
-      normalizeCodexDynamicToolName(name),
-    ),
-  );
+  const enablesCompleteNativeSurface =
+    hasWildcardCodexToolsAllow(toolsAllow) ||
+    explicitlyAllowsCompleteCodexNativeToolSurface(toolsAllow);
   return (
-    (hasWildcardCodexToolsAllow(toolsAllow) || hasNativeRequest) &&
-    canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox, options)
+    enablesCompleteNativeSurface && canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox, options)
   );
+}
+
+function explicitlyAllowsCompleteCodexNativeToolSurface(toolsAllow: readonly string[]): boolean {
+  const normalized = new Set<string>();
+  for (const name of toolsAllow) {
+    const toolName = normalizeCodexDynamicToolName(name);
+    if (toolName) {
+      normalized.add(toolName);
+    }
+  }
+  return CODEX_APP_SERVER_OWNED_DYNAMIC_TOOL_EXCLUDES.every((toolName) => normalized.has(toolName));
 }
 
 function isCodexNativeExecutionBlockedByNodeExecHost(

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -3984,7 +3984,9 @@ function shouldEnableCodexAppServerNativeToolSurface(
   // native-owned tool (read, write, edit, exec, etc.). This ensures that when
   // users request native tools in their allowlist, they actually get them.
   const hasNativeRequest = toolsAllow.some((name) =>
-    CODEX_APP_SERVER_OWNED_DYNAMIC_TOOL_EXCLUDES.includes(normalizeCodexDynamicToolName(name)),
+    (CODEX_APP_SERVER_OWNED_DYNAMIC_TOOL_EXCLUDES as readonly string[]).includes(
+      normalizeCodexDynamicToolName(name),
+    ),
   );
   return (
     (hasWildcardCodexToolsAllow(toolsAllow) || hasNativeRequest) &&


### PR DESCRIPTION
## Summary

This updates the previous fix for #86423 so explicit `toolsAllow` lists do not accidentally widen a narrow native tool subset into the full Codex native Code Mode surface.

The original PR enabled native Code Mode when `toolsAllow` contained any native-owned tool such as `read`, `write`, `edit`, `bash`, or `apply-patch`. That made the broken cron allowlist work, but it also meant `toolsAllow: ["read"]` could expose the whole native read/write/edit/exec surface because the downstream Codex runtime receives a single `nativeCodeModeEnabled` boolean, not a per-native-tool allowlist.

This revision keeps the native surface fail-closed for partial native allowlists. Native Code Mode is enabled only when `toolsAllow` is unrestricted via `*`, omitted, or explicitly includes the complete native-owned surface. Partial lists such as `["read"]`, `["write","edit"]`, `["bash"]`, and mixed non-native lists remain disabled instead of being widened.

## Real behavior proof

- **Behavior or issue addressed:** Explicit partial native `toolsAllow` lists no longer widen into the full Codex native Code Mode surface. This preserves narrow allowlist semantics and addresses the security-boundary review concern on PR #86432.

- **Real environment tested:** Local openclaw/openclaw PR worktree `/media/vdc/code/ai/aispace/openclaw-worktrees/pr-86432`, branch `repair/pr-86432`, on Linux with Node 22.22.0 and pnpm. The checks were run after this patch against `extensions/codex/src/app-server/run-attempt.ts` and `extensions/codex/src/app-server/run-attempt.test.ts`.

- **Exact steps or command run after this patch:**
  ```bash
  node --import tsx --input-type=module -e 'import { testing } from "./extensions/codex/src/app-server/run-attempt.ts"; const base={prompt:"hello",sessionId:"session-1",sessionKey:"agent:main:session-1",sessionFile:"/tmp/session.jsonl",workspaceDir:process.cwd(),runId:"run-1",provider:"codex",modelId:"gpt-5.4-codex",model:{},contextTokenBudget:150000,contextWindowInfo:{tokens:150000,referenceTokens:200000,source:"agentContextTokens"},thinkLevel:"medium",disableTools:false,timeoutMs:5000,authStorage:{},authProfileStore:{version:1,profiles:{}},modelRegistry:{}}; const cases=[["read"],["write","edit"],["memory_search","read","web_search"],["bash"],["apply-patch"],["*"],["read","write","edit","apply-patch","bash","process","update_plan","tool_call","tool_describe","tool_search","tool_search_code"]]; for (const toolsAllow of cases) { console.log(JSON.stringify(toolsAllow), testing.shouldEnableCodexAppServerNativeToolSurface({...base, toolsAllow})); }'
  pnpm exec vitest run extensions/codex/src/app-server/run-attempt.test.ts -t "native tool surfaces"
  pnpm tsgo:extensions:test
  git diff --check
  ```

- **Evidence after fix:**
  ```text
  $ node --import tsx --input-type=module -e '...call shouldEnableCodexAppServerNativeToolSurface for reviewed allowlists...'
  ["read"] false
  ["write","edit"] false
  ["memory_search","read","web_search"] false
  ["bash"] false
  ["apply-patch"] false
  ["*"] true
  ["read","write","edit","apply-patch","bash","process","update_plan","tool_call","tool_describe","tool_search","tool_search_code"] true

  $ pnpm exec vitest run extensions/codex/src/app-server/run-attempt.test.ts -t "native tool surfaces"
   Test Files  1 passed (1)
        Tests  5 passed | 219 skipped (224)
     Duration  64.11s

  $ pnpm tsgo:extensions:test
  exit code 0

  $ git diff --check
  exit code 0
  ```

- **Observed result after fix:** `toolsAllow: ["read"]`, `["write","edit"]`, `["memory_search","read","web_search"]`, `["bash"]`, and `["apply-patch"]` all keep the native surface disabled. `toolsAllow: ["*"]` and an explicit complete native-owned tool list enable it. The previous widening behavior is no longer present.

- **What was not tested:** I did not run a full cron job through the live gateway because the changed behavior is the server-side native-surface policy decision function, and the downstream runtime currently accepts only the single `nativeCodeModeEnabled` boolean that this function controls.

## Regression Test Plan

- **Target test file:** `extensions/codex/src/app-server/run-attempt.test.ts`
- **Scenario locked in:** Partial native-owned `toolsAllow` values remain disabled, while wildcard and complete-native allowlists enable the native surface.
- **Why this is the smallest reliable guardrail:** The regression happened in `shouldEnableCodexAppServerNativeToolSurface`, so the test exercises that function directly with the reviewed security-boundary cases and without relying on slower end-to-end runtime setup.

## Root Cause

- **Root cause:** The earlier patch treated any native-owned allowlist entry as permission to enable Codex native Code Mode. Since the downstream app-server thread config only carries `nativeCodeModeEnabled`, enabling it for one native tool widened that narrow allowlist to the complete native surface. The corrected logic requires unrestricted or complete-native intent before setting that boolean.
