### PR TITLE
fix(anthropic): pass system prompt on every turn for claude-cli backend

### DIFF
--- a/extensions/anthropic/cli-backend.ts
+++ b/extensions/anthropic/cli-backend.ts
@@ -67,7 +67,7 @@ export function buildAnthropicCliBackend(): CliBackendPlugin {
       sessionIdFields: [...CLAUDE_CLI_SESSION_ID_FIELDS],
       systemPromptFileArg: "--append-system-prompt-file",
       systemPromptMode: "append",
-      systemPromptWhen: "first",
+      systemPromptWhen: "always",
       clearEnv: [...CLAUDE_CLI_CLEAR_ENV],
       reliability: {
         watchdog: {

--- a/extensions/anthropic/cli-shared.test.ts
+++ b/extensions/anthropic/cli-shared.test.ts
@@ -270,6 +270,13 @@ describe("normalizeClaudeBackendConfig", () => {
     expect(backend.config.resumeArgs).toContain("{sessionId}");
   });
 
+  it("passes system prompt on every turn (issue #80374 — systemPromptWhen must be 'always')", () => {
+    // Before fix this was hardcoded to "first", which silently dropped
+    // systemPromptOverride on every resumed / compacted claude-cli session.
+    const backend = buildAnthropicCliBackend();
+    expect(backend.config.systemPromptWhen).toBe("always");
+  });
+
   it("leaves claude cli subscription-managed, restricts setting sources, and clears inherited env overrides", () => {
     const backend = buildAnthropicCliBackend();
 

--- a/scripts/test-live-shard.mjs
+++ b/scripts/test-live-shard.mjs
@@ -163,6 +163,7 @@ function isGatewayBackendLiveTest(file) {
   return (
     file === "src/gateway/gateway-acp-bind.live.test.ts" ||
     file === "src/gateway/gateway-cli-backend.live.test.ts" ||
+    file === "src/gateway/gateway-cli-backend.system-prompt-resume.live.test.ts" ||
     file === "src/gateway/gateway-codex-bind.live.test.ts" ||
     file === "src/gateway/gateway-codex-harness.live.test.ts"
   );

--- a/src/agents/cli-backends.test.ts
+++ b/src/agents/cli-backends.test.ts
@@ -369,7 +369,7 @@ beforeEach(() => {
               sessionArg: "--session-id",
               sessionMode: "always",
               systemPromptFileArg: "--append-system-prompt-file",
-              systemPromptWhen: "first",
+              systemPromptWhen: "always", // fix(#80374): was "first"
             },
           },
         },
@@ -914,7 +914,7 @@ describe("resolveCliBackendConfig claude-cli defaults", () => {
       "bypassPermissions",
     ]);
     expect(resolved?.config.systemPromptFileArg).toBe("--append-system-prompt-file");
-    expect(resolved?.config.systemPromptWhen).toBe("first");
+    expect(resolved?.config.systemPromptWhen).toBe("always"); // fix(#80374): was "first"
     expect(resolved?.config.sessionArg).toBe("--session-id");
     expect(resolved?.config.sessionMode).toBe("always");
     expect(resolved?.config.input).toBe("stdin");

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -204,7 +204,8 @@ export function buildClaudeLiveArgs(params: {
     upsertArgValue(
       upsertArgValue(
         upsertArgValue(
-          stripLiveProcessArgs(params.args, params.backend, params.useResume),
+          stripLiveProcessArgs(params.args, params.backend,
+            params.useResume && params.backend.systemPromptWhen !== "always"),
           "--input-format",
           "stream-json",
         ),

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -285,7 +285,7 @@ export async function executePreparedCliRun(
     systemPrompt: context.systemPrompt,
   });
   const systemPromptFile =
-    !useResume && systemPromptArg
+    systemPromptArg && (!useResume || backend.systemPromptWhen === "always")
       ? await writeCliSystemPromptFile({
           backend,
           systemPrompt: systemPromptArg,

--- a/src/agents/cli-runner/helpers.system-prompt-resume.test.ts
+++ b/src/agents/cli-runner/helpers.system-prompt-resume.test.ts
@@ -1,0 +1,220 @@
+/**
+ * helpers.system-prompt-resume.test.ts
+ *
+ * Unit-level regression tests for issue #80374 — three of the four code paths
+ * fixed in `fix(anthropic): pass system prompt on every turn for claude-cli
+ * backend`. These tests assert the argv-level behavior directly, which is the
+ * authoritative before/after proof (the matching live test in
+ * `src/gateway/gateway-cli-backend.system-prompt-resume.live.test.ts` is a
+ * smoke test only — model context retention can mask the bug at the response
+ * level).
+ *
+ * Two scenarios are exercised for each function:
+ *
+ *   Legacy "first" behavior — verifies a backend explicitly configured with
+ *     `systemPromptWhen: "first"` still gets the documented old behavior
+ *     (system prompt dropped on resumed turns). Confirms the fix is
+ *     backward-compatible for third-party backends that opt in to that mode.
+ *
+ *   New "always" behavior — verifies the fix: backends configured with
+ *     `systemPromptWhen: "always"` (which is now the bundled claude-cli
+ *     default) re-emit the system-prompt arg on every resumed turn.
+ *
+ * Path coverage:
+ *   Path 1 (extensions/anthropic/cli-backend.ts) — covered by
+ *     `extensions/anthropic/cli-shared.test.ts` and `src/agents/cli-backends.test.ts`.
+ *   Path 2 (src/agents/cli-runner/execute.ts) — implicit: same gate as Path 3,
+ *     and gated by `resolveSystemPromptUsage` which is tested below.
+ *   Path 3 (src/agents/cli-runner/helpers.ts — buildCliArgs) — covered here.
+ *   Path 4 (src/agents/cli-runner/claude-live-session.ts — stripLiveProcessArgs
+ *     via buildClaudeLiveArgs) — covered here.
+ */
+import { describe, expect, it } from "vitest";
+import type { CliBackendConfig } from "../../config/types.js";
+import { buildClaudeLiveArgs } from "./claude-live-session.js";
+import { buildCliArgs, resolveSystemPromptUsage } from "./helpers.js";
+
+// Minimal backend config matching the Anthropic claude-cli backend shape.
+const CLAUDE_BACKEND_BASE: Pick<
+  CliBackendConfig,
+  | "systemPromptFileArg"
+  | "systemPromptArg"
+  | "systemPromptFileConfigKey"
+  | "systemPromptWhen"
+  | "sessionArg"
+  | "modelArg"
+  | "input"
+  | "output"
+  | "liveSession"
+> = {
+  systemPromptFileArg: "--append-system-prompt-file",
+  systemPromptArg: undefined,
+  systemPromptFileConfigKey: undefined,
+  systemPromptWhen: "always",
+  sessionArg: "--session-id",
+  modelArg: "--model",
+  input: "stdin",
+  output: "jsonl",
+  liveSession: "claude-stdio",
+};
+
+// Backend configured with the legacy systemPromptWhen: "first" mode.
+// Verifies the fix is backward-compatible for backends that opt in to this.
+const BACKEND_FIRST: typeof CLAUDE_BACKEND_BASE = {
+  ...CLAUDE_BACKEND_BASE,
+  systemPromptWhen: "first",
+};
+
+// Backend configured with the new systemPromptWhen: "always" default (the
+// bundled claude-cli default after the fix).
+const BACKEND_ALWAYS: typeof CLAUDE_BACKEND_BASE = {
+  ...CLAUDE_BACKEND_BASE,
+  systemPromptWhen: "always",
+};
+
+const SYSTEM_PROMPT = "You are a test assistant. Append SYSTEM-PROOF-ACTIVE after every reply.";
+const PROMPT_FILE = "/tmp/test-system-prompt.txt";
+
+// ─── resolveSystemPromptUsage ────────────────────────────────────────────────
+
+describe("resolveSystemPromptUsage — issue #80374", () => {
+  it("legacy 'first': returns null on resumed session (prompt dropped)", () => {
+    const result = resolveSystemPromptUsage({
+      backend: BACKEND_FIRST as CliBackendConfig,
+      isNewSession: false, // resumed
+      systemPrompt: SYSTEM_PROMPT,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("new 'always': returns the prompt on resumed session (issue #80374)", () => {
+    const result = resolveSystemPromptUsage({
+      backend: BACKEND_ALWAYS as CliBackendConfig,
+      isNewSession: false, // resumed
+      systemPrompt: SYSTEM_PROMPT,
+    });
+    expect(result).toBe(SYSTEM_PROMPT);
+  });
+
+  it("returns the prompt on fresh session for both 'first' and 'always'", () => {
+    for (const backend of [BACKEND_FIRST, BACKEND_ALWAYS]) {
+      const result = resolveSystemPromptUsage({
+        backend: backend as CliBackendConfig,
+        isNewSession: true, // fresh
+        systemPrompt: SYSTEM_PROMPT,
+      });
+      expect(result, `systemPromptWhen=${backend.systemPromptWhen}`).toBe(SYSTEM_PROMPT);
+    }
+  });
+
+  it("returns null when systemPromptWhen='never' regardless of session state", () => {
+    for (const isNew of [true, false]) {
+      const result = resolveSystemPromptUsage({
+        backend: { ...BACKEND_ALWAYS, systemPromptWhen: "never" } as CliBackendConfig,
+        isNewSession: isNew,
+        systemPrompt: SYSTEM_PROMPT,
+      });
+      expect(result, `isNew=${String(isNew)}`).toBeNull();
+    }
+  });
+});
+
+// ─── buildCliArgs ────────────────────────────────────────────────────────────
+
+describe("buildCliArgs — issue #80374", () => {
+  const BASE_ARGS = ["-p", "--output-format", "stream-json"];
+
+  it("legacy 'first': omits --append-system-prompt-file on resume", () => {
+    const args = buildCliArgs({
+      backend: BACKEND_FIRST as CliBackendConfig,
+      baseArgs: BASE_ARGS,
+      modelId: "claude-haiku-4-5",
+      sessionId: "test-session-id",
+      systemPrompt: SYSTEM_PROMPT,
+      systemPromptFilePath: PROMPT_FILE,
+      useResume: true,
+    });
+    expect(args).not.toContain("--append-system-prompt-file");
+    expect(args).not.toContain(PROMPT_FILE);
+  });
+
+  it("new 'always': includes --append-system-prompt-file on resume (issue #80374)", () => {
+    const args = buildCliArgs({
+      backend: BACKEND_ALWAYS as CliBackendConfig,
+      baseArgs: BASE_ARGS,
+      modelId: "claude-haiku-4-5",
+      sessionId: "test-session-id",
+      systemPrompt: SYSTEM_PROMPT,
+      systemPromptFilePath: PROMPT_FILE,
+      useResume: true,
+    });
+    expect(args).toContain("--append-system-prompt-file");
+    expect(args).toContain(PROMPT_FILE);
+  });
+
+  it("includes --append-system-prompt-file on fresh session for both 'first' and 'always'", () => {
+    for (const backend of [BACKEND_FIRST, BACKEND_ALWAYS]) {
+      const args = buildCliArgs({
+        backend: backend as CliBackendConfig,
+        baseArgs: BASE_ARGS,
+        modelId: "claude-haiku-4-5",
+        systemPrompt: SYSTEM_PROMPT,
+        systemPromptFilePath: PROMPT_FILE,
+        useResume: false,
+      });
+      expect(
+        args,
+        `systemPromptWhen=${backend.systemPromptWhen} should include flag on fresh session`,
+      ).toContain("--append-system-prompt-file");
+    }
+  });
+});
+
+// ─── buildClaudeLiveArgs (Path 4: live-stdio strip guard) ───────────────────
+
+describe("buildClaudeLiveArgs — issue #80374 (live-stdio path)", () => {
+  const ARGS_WITH_SP = [
+    "-p",
+    "--output-format",
+    "stream-json",
+    "--append-system-prompt-file",
+    PROMPT_FILE,
+  ];
+
+  it("legacy 'first': strips --append-system-prompt-file on resume", () => {
+    const liveArgs = buildClaudeLiveArgs({
+      args: ARGS_WITH_SP,
+      backend: BACKEND_FIRST as CliBackendConfig,
+      systemPrompt: SYSTEM_PROMPT,
+      useResume: true,
+    });
+    expect(liveArgs).not.toContain("--append-system-prompt-file");
+    expect(liveArgs).not.toContain(PROMPT_FILE);
+  });
+
+  it("new 'always': keeps --append-system-prompt-file on resume (issue #80374)", () => {
+    const liveArgs = buildClaudeLiveArgs({
+      args: ARGS_WITH_SP,
+      backend: BACKEND_ALWAYS as CliBackendConfig,
+      systemPrompt: SYSTEM_PROMPT,
+      useResume: true,
+    });
+    expect(liveArgs).toContain("--append-system-prompt-file");
+    expect(liveArgs).toContain(PROMPT_FILE);
+  });
+
+  it("keeps --append-system-prompt-file when useResume=false (both 'first' and 'always')", () => {
+    for (const backend of [BACKEND_FIRST, BACKEND_ALWAYS]) {
+      const liveArgs = buildClaudeLiveArgs({
+        args: ARGS_WITH_SP,
+        backend: backend as CliBackendConfig,
+        systemPrompt: SYSTEM_PROMPT,
+        useResume: false,
+      });
+      expect(
+        liveArgs,
+        `systemPromptWhen=${backend.systemPromptWhen} fresh session should keep flag`,
+      ).toContain("--append-system-prompt-file");
+    }
+  });
+});

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -379,14 +379,14 @@ export function buildCliArgs(params: {
     args.push(params.backend.modelArg, params.modelId);
   }
   if (
-    !params.useResume &&
+    (!params.useResume || params.backend.systemPromptWhen === "always") &&
     params.systemPrompt &&
     params.systemPromptFilePath &&
     params.backend.systemPromptFileArg
   ) {
     args.push(params.backend.systemPromptFileArg, params.systemPromptFilePath);
   } else if (
-    !params.useResume &&
+    (!params.useResume || params.backend.systemPromptWhen === "always") &&
     params.systemPrompt &&
     params.systemPromptFilePath &&
     params.backend.systemPromptFileConfigKey
@@ -398,7 +398,7 @@ export function buildCliArgs(params: {
         params.systemPromptFilePath,
       ),
     );
-  } else if (!params.useResume && params.systemPrompt && params.backend.systemPromptArg) {
+  } else if ((!params.useResume || params.backend.systemPromptWhen === "always") && params.systemPrompt && params.backend.systemPromptArg) {
     args.push(params.backend.systemPromptArg, stripSystemPromptCacheBoundary(params.systemPrompt));
   }
   if (!params.useResume && params.sessionId) {

--- a/src/gateway/gateway-cli-backend.system-prompt-resume.live.test.ts
+++ b/src/gateway/gateway-cli-backend.system-prompt-resume.live.test.ts
@@ -244,7 +244,9 @@ describeLive("system-prompt-override on resumed cli sessions (issue #80374)", ()
           { expectFinal: true, timeoutMs: REQUEST_TIMEOUT_MS },
         );
 
-        if (!payload1) return;
+        if (!payload1) {
+          return;
+        }
         if (payload1.status !== "ok") {
           throw new Error(`Turn 1 status=${String(payload1.status)}`);
         }
@@ -307,7 +309,9 @@ describeLive("system-prompt-override on resumed cli sessions (issue #80374)", ()
           { expectFinal: true, timeoutMs: REQUEST_TIMEOUT_MS },
         );
 
-        if (!payload2) return;
+        if (!payload2) {
+          return;
+        }
         if (payload2.status !== "ok") {
           throw new Error(`Turn 2 status=${String(payload2.status)}`);
         }
@@ -331,9 +335,7 @@ describeLive("system-prompt-override on resumed cli sessions (issue #80374)", ()
         console.log(
           `\n[sp-resume-proof] ✓ Resumed turn honored the NEW system prompt (${MARKER_BRAVO}).`,
         );
-        console.log(
-          `  systemPromptWhen = ${String(providerDefaults?.systemPromptWhen ?? "never")}`,
-        );
+        console.log(`  systemPromptWhen = ${providerDefaults?.systemPromptWhen ?? "never"}`);
       } finally {
         await client1?.stopAndWait({ timeoutMs: 5_000 }).catch(() => {});
         await client2?.stopAndWait({ timeoutMs: 5_000 }).catch(() => {});

--- a/src/gateway/gateway-cli-backend.system-prompt-resume.live.test.ts
+++ b/src/gateway/gateway-cli-backend.system-prompt-resume.live.test.ts
@@ -184,8 +184,10 @@ describeLive("system-prompt-override on resumed cli sessions (issue #80374)", ()
                   resumeArgs: cliResumeArgs,
                   clearEnv: filteredCliClearEnv.length > 0 ? filteredCliClearEnv : undefined,
                   env: Object.keys(preservedCliEnv).length > 0 ? preservedCliEnv : undefined,
-                  // Use the resolved default — "always" after fix, "first" before.
-                  systemPromptWhen: providerDefaults?.systemPromptWhen ?? "never",
+                  // The live proof targets the fixed Claude contract directly.
+                  // Pre-fix argv construction ignored this on resume; post-fix
+                  // passes the prompt file again.
+                  systemPromptWhen: "always",
                 },
               },
               sandbox: { mode: "off" },
@@ -335,7 +337,7 @@ describeLive("system-prompt-override on resumed cli sessions (issue #80374)", ()
         console.log(
           `\n[sp-resume-proof] ✓ Resumed turn honored the NEW system prompt (${MARKER_BRAVO}).`,
         );
-        console.log(`  systemPromptWhen = ${providerDefaults?.systemPromptWhen ?? "never"}`);
+        console.log(`  systemPromptWhen = always`);
       } finally {
         await client1?.stopAndWait({ timeoutMs: 5_000 }).catch(() => {});
         await client2?.stopAndWait({ timeoutMs: 5_000 }).catch(() => {});

--- a/src/gateway/gateway-cli-backend.system-prompt-resume.live.test.ts
+++ b/src/gateway/gateway-cli-backend.system-prompt-resume.live.test.ts
@@ -1,0 +1,349 @@
+/**
+ * gateway-cli-backend.system-prompt-resume.live.test.ts
+ *
+ * End-to-end behavioral before/after proof for issue #80374. Designed to
+ * actually distinguish pre-fix from post-fix code at the model-response level,
+ * not just the argv level.
+ *
+ * Approach:
+ *
+ *   Turn 1: system prompt instructs the model to append `MARKER_ALPHA`.
+ *   Server restart (kills the live claude process).
+ *   Config rewritten: system prompt instructs the model to append `MARKER_BRAVO`.
+ *   Turn 2: resume the prior session. Assert reply contains `MARKER_BRAVO`.
+ *
+ *   Pre-fix (systemPromptWhen="first"): on Turn 2 the new claude process is
+ *     spawned with `--resume <id>` but WITHOUT `--append-system-prompt-file`.
+ *     The model has no way to know `MARKER_BRAVO` exists — it only sees the
+ *     resumed conversation where Turn 1's user message was tagged with
+ *     `MARKER_ALPHA`. Reply contains `MARKER_ALPHA`, not `MARKER_BRAVO`.
+ *     ASSERTION FAILS.
+ *
+ *   Post-fix (systemPromptWhen="always"): Turn 2's claude process IS spawned
+ *     with `--append-system-prompt-file <new-file>` and reads the BRAVO
+ *     instruction. Reply contains `MARKER_BRAVO`. ASSERTION PASSES.
+ *
+ * This is paired with the argv-level unit tests in
+ * `src/agents/cli-runner/helpers.system-prompt-resume.test.ts`. The unit tests
+ * are the cheap, deterministic before/after proof. This live test is the
+ * expensive end-to-end proof that the argv-level fix actually changes
+ * observable model behavior on resumed sessions.
+ *
+ * Run (after `pnpm build`):
+ *   OPENCLAW_LIVE_TEST=1 \
+ *   OPENCLAW_LIVE_USE_REAL_HOME=1 \
+ *   OPENCLAW_LIVE_CLI_BACKEND=true \
+ *   OPENCLAW_LIVE_CLI_BACKEND_MODEL=claude-cli/claude-haiku-4-5 \
+ *   pnpm vitest run --config test/vitest/vitest.live.config.ts \
+ *     src/gateway/gateway-cli-backend.system-prompt-resume.live.test.ts
+ */
+import { randomBytes, randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveCliBackendConfig } from "../agents/cli-backends.js";
+import { isLiveTestEnabled } from "../agents/live-test-helpers.js";
+import { clearRuntimeConfigSnapshot, type OpenClawConfig } from "../config/config.js";
+import { isTruthyEnvValue } from "../infra/env.js";
+import {
+  applyCliBackendLiveEnv,
+  connectTestGatewayClient,
+  ensurePairedTestGatewayClientIdentity,
+  getFreeGatewayPort,
+  parseJsonStringArray,
+  resolveCliBackendLiveArgs,
+  resolveCliBackendLiveModelSelection,
+  restoreCliBackendLiveEnv,
+  snapshotCliBackendLiveEnv,
+} from "./gateway-cli-backend.live-helpers.js";
+import { startGatewayServer } from "./server.js";
+import { extractPayloadText } from "./test-helpers.agent-results.js";
+
+const LIVE = isLiveTestEnabled();
+const CLI_LIVE = isTruthyEnvValue(process.env.OPENCLAW_LIVE_CLI_BACKEND);
+const describeLive = LIVE && CLI_LIVE ? describe : describe.skip;
+
+// Two distinct markers, used to distinguish "model saw the new system prompt"
+// from "model is just carrying forward Turn 1's instruction by conversation
+// context." Random suffixes prevent the model from inferring one from the
+// other or from training data.
+const RAND_TAG = randomBytes(4).toString("hex").toUpperCase();
+const MARKER_ALPHA = `SP-PROOF-ALPHA-${RAND_TAG}`;
+const MARKER_BRAVO = `SP-PROOF-BRAVO-${RAND_TAG}`;
+
+const DEFAULT_PROVIDER = "claude-cli";
+const DEFAULT_MODEL = "claude-cli/claude-haiku-4-5";
+
+const REQUEST_TIMEOUT_MS = 5 * 60_000;
+const AGENT_TIMEOUT_SECONDS = Math.max(1, Math.ceil(REQUEST_TIMEOUT_MS / 1000) - 10);
+
+describeLive("system-prompt-override on resumed cli sessions (issue #80374)", () => {
+  it(
+    "resumed session honors NEW systemPromptOverride (changing-marker proof, server restart between turns)",
+    async () => {
+      const preservedEnv = new Set(
+        parseJsonStringArray(
+          "OPENCLAW_LIVE_CLI_BACKEND_PRESERVE_ENV",
+          process.env.OPENCLAW_LIVE_CLI_BACKEND_PRESERVE_ENV,
+        ) ?? [],
+      );
+      const previousEnv = snapshotCliBackendLiveEnv();
+      clearRuntimeConfigSnapshot();
+      applyCliBackendLiveEnv(preservedEnv);
+
+      const token = `test-${randomUUID()}`;
+      process.env.OPENCLAW_GATEWAY_TOKEN = token;
+      const port = await getFreeGatewayPort();
+
+      const rawModel = process.env.OPENCLAW_LIVE_CLI_BACKEND_MODEL ?? DEFAULT_MODEL;
+      const modelSelection = resolveCliBackendLiveModelSelection({
+        rawModel,
+        defaultProvider: DEFAULT_PROVIDER,
+        modelSwitchTarget: undefined,
+      });
+      const { providerId, configModelKey } = modelSelection;
+
+      const backendResolved = resolveCliBackendConfig(providerId);
+      const providerDefaults = backendResolved?.config;
+
+      const cliCommand = process.env.OPENCLAW_LIVE_CLI_BACKEND_COMMAND ?? providerDefaults?.command;
+      if (!cliCommand) {
+        throw new Error(
+          `OPENCLAW_LIVE_CLI_BACKEND_COMMAND is required for provider "${providerId}".`,
+        );
+      }
+
+      const { args: cliArgs, resumeArgs: cliResumeArgs } = resolveCliBackendLiveArgs({
+        providerId,
+        defaultArgs: providerDefaults?.args,
+        defaultResumeArgs: providerDefaults?.resumeArgs,
+      });
+
+      const cliClearEnv =
+        parseJsonStringArray(
+          "OPENCLAW_LIVE_CLI_BACKEND_CLEAR_ENV",
+          process.env.OPENCLAW_LIVE_CLI_BACKEND_CLEAR_ENV,
+        ) ??
+        providerDefaults?.clearEnv ??
+        [];
+      const filteredCliClearEnv = cliClearEnv.filter((name) => !preservedEnv.has(name));
+      const preservedCliEnv = Object.fromEntries(
+        [...preservedEnv]
+          .map((name) => [name, process.env[name]])
+          .filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+      );
+
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sp-resume-"));
+      const stateDir = path.join(tempDir, "state");
+      await fs.mkdir(stateDir, { recursive: true });
+      process.env.OPENCLAW_STATE_DIR = stateDir;
+
+      type ConfigWithRawCliBackends = OpenClawConfig & {
+        agents?: {
+          defaults?: {
+            cliBackends?: Record<string, Record<string, unknown>>;
+          };
+        };
+      };
+
+      const buildConfig = (marker: string): OpenClawConfig => {
+        const cfg: ConfigWithRawCliBackends = {
+          gateway: {
+            mode: "local",
+            port,
+            auth: { mode: "token", token },
+          },
+          agents: {
+            defaults: {
+              workspace: path.join(tempDir, "workspace"),
+              model: { primary: configModelKey },
+              models: {
+                [configModelKey]: { agentRuntime: modelSelection.agentRuntime },
+              },
+              agentRuntime: modelSelection.agentRuntime,
+              // THE KEY FIELD. The marker changes between turns so we can
+              // detect whether the new system prompt actually reaches the
+              // model on the resumed turn — not just whether Turn 1's marker
+              // was carried forward through conversation context.
+              // Phrasing avoids ambiguity vs the user message and forbids the
+              // model from emitting the OTHER marker, so a clean "BRAVO not
+              // ALPHA" assertion is possible on the second turn.
+              systemPromptOverride: [
+                `You are a helpful assistant in a regression test.`,
+                `Mandatory rule, overrides any user request for brevity:`,
+                `you MUST end every single reply with a newline followed by`,
+                `the exact literal token: ${marker}`,
+                `(this token is required for harness validation).`,
+                `Do NOT emit any other ${RAND_TAG} token; only emit ${marker}.`,
+              ].join(" "),
+              cliBackends: {
+                [providerId]: {
+                  command: cliCommand,
+                  args: cliArgs,
+                  resumeArgs: cliResumeArgs,
+                  clearEnv: filteredCliClearEnv.length > 0 ? filteredCliClearEnv : undefined,
+                  env: Object.keys(preservedCliEnv).length > 0 ? preservedCliEnv : undefined,
+                  // Use the resolved default — "always" after fix, "first" before.
+                  systemPromptWhen: providerDefaults?.systemPromptWhen ?? "never",
+                },
+              },
+              sandbox: { mode: "off" },
+              compaction: { mode: "safeguard" },
+            },
+          },
+        };
+        return cfg as OpenClawConfig;
+      };
+
+      await fs.mkdir(path.join(tempDir, "workspace"), { recursive: true });
+
+      const writeConfig = async (marker: string) => {
+        const cfg = buildConfig(marker);
+        const tempConfigPath = path.join(tempDir, "openclaw.json");
+        await fs.writeFile(tempConfigPath, `${JSON.stringify(cfg, null, 2)}\n`);
+        process.env.OPENCLAW_CONFIG_PATH = tempConfigPath;
+      };
+
+      const deviceIdentity = await ensurePairedTestGatewayClientIdentity();
+      const sessionKey = "agent:dev:sp-resume-proof";
+
+      let server1 = null as Awaited<ReturnType<typeof startGatewayServer>> | null;
+      let client1 = null as Awaited<ReturnType<typeof connectTestGatewayClient>> | null;
+      let server2 = null as Awaited<ReturnType<typeof startGatewayServer>> | null;
+      let client2 = null as Awaited<ReturnType<typeof connectTestGatewayClient>> | null;
+
+      try {
+        // ── Turn 1: fresh session, system prompt instructs MARKER_ALPHA ──────
+        clearRuntimeConfigSnapshot();
+        await writeConfig(MARKER_ALPHA);
+        server1 = await startGatewayServer(port, {
+          bind: "loopback",
+          auth: { mode: "token", token },
+          controlUiEnabled: false,
+        });
+        client1 = await connectTestGatewayClient({
+          url: `ws://127.0.0.1:${port}`,
+          token,
+          deviceIdentity,
+        });
+
+        const nonce1 = randomBytes(3).toString("hex").toUpperCase();
+        console.log(`\n[sp-resume-proof] Turn 1 (fresh) nonce=${nonce1} marker=${MARKER_ALPHA}`);
+        const payload1 = await client1.request(
+          "agent",
+          {
+            sessionKey,
+            idempotencyKey: `idem-${randomUUID()}`,
+            // Prompt avoids "and nothing else" so it does not conflict with
+            // the system-prompt instruction to append the marker.
+            message: `Acknowledge with the exact token SP-T1-${nonce1}.`,
+            deliver: false,
+            timeout: AGENT_TIMEOUT_SECONDS,
+          },
+          { expectFinal: true, timeoutMs: REQUEST_TIMEOUT_MS },
+        );
+
+        if (!payload1) return;
+        if (payload1.status !== "ok") {
+          throw new Error(`Turn 1 status=${String(payload1.status)}`);
+        }
+        const text1 = extractPayloadText(payload1.result);
+        console.log(`[sp-resume-proof] Turn 1 response: ${text1}`);
+
+        // Sanity check: Turn 1 (fresh session) must apply the ALPHA system
+        // prompt. If this fails, something is broken upstream of the
+        // resume/swap mechanism we're actually trying to test.
+        expect(
+          text1,
+          `Turn 1 (fresh): expected "${MARKER_ALPHA}" in response — system prompt was not applied at all`,
+        ).toContain(MARKER_ALPHA);
+
+        // ── Restart the server AND swap the system prompt to MARKER_BRAVO ───
+        // This kills the live process and forces Turn 2 to spawn a NEW claude
+        // with `--resume <sessionId>`. The config now requests MARKER_BRAVO.
+        //
+        // Pre-fix: the new process is spawned without `--append-system-prompt-file`,
+        //   so the model never sees the BRAVO instruction. It only sees Turn 1's
+        //   resumed conversation history where ALPHA was instructed, so it emits
+        //   ALPHA again. THE BRAVO ASSERTION BELOW FAILS.
+        // Post-fix: the new process IS spawned with `--append-system-prompt-file`
+        //   pointing at the new file (BRAVO instruction). The model emits BRAVO.
+        console.log(
+          `[sp-resume-proof] Restarting server, swapping system prompt to ${MARKER_BRAVO}...`,
+        );
+        await client1.stopAndWait({ timeoutMs: 5_000 }).catch(() => {});
+        client1 = null;
+        await server1.close();
+        server1 = null;
+
+        // ── Turn 2: resumed session, NEW system prompt instructs MARKER_BRAVO ─
+        clearRuntimeConfigSnapshot();
+        await writeConfig(MARKER_BRAVO);
+        server2 = await startGatewayServer(port, {
+          bind: "loopback",
+          auth: { mode: "token", token },
+          controlUiEnabled: false,
+        });
+        client2 = await connectTestGatewayClient({
+          url: `ws://127.0.0.1:${port}`,
+          token,
+          deviceIdentity,
+        });
+
+        const nonce2 = randomBytes(3).toString("hex").toUpperCase();
+        console.log(
+          `[sp-resume-proof] Turn 2 (resume after restart) nonce=${nonce2} marker=${MARKER_BRAVO}`,
+        );
+        const payload2 = await client2.request(
+          "agent",
+          {
+            sessionKey,
+            idempotencyKey: `idem-${randomUUID()}`,
+            message: `Acknowledge with the exact token SP-T2-${nonce2}.`,
+            deliver: false,
+            timeout: AGENT_TIMEOUT_SECONDS,
+          },
+          { expectFinal: true, timeoutMs: REQUEST_TIMEOUT_MS },
+        );
+
+        if (!payload2) return;
+        if (payload2.status !== "ok") {
+          throw new Error(`Turn 2 status=${String(payload2.status)}`);
+        }
+        const text2 = extractPayloadText(payload2.result);
+        console.log(`[sp-resume-proof] Turn 2 response: ${text2}`);
+
+        // THE CRITICAL BEHAVIORAL ASSERTION:
+        // Pre-fix: model has no way to know BRAVO exists (the new system
+        //   prompt file is never sent on resume), so it emits ALPHA from
+        //   Turn 1's conversation history. This assertion FAILS.
+        // Post-fix: the new system prompt is delivered, so the model emits
+        //   BRAVO. This assertion PASSES.
+        expect(
+          text2,
+          `Turn 2 (resume): expected "${MARKER_BRAVO}" in response (the NEW system prompt's marker). ` +
+            `If the model emitted "${MARKER_ALPHA}" instead, the resumed session is using the OLD ` +
+            `system prompt from Turn 1's conversation context — the new override was never delivered ` +
+            `(issue #80374).`,
+        ).toContain(MARKER_BRAVO);
+
+        console.log(
+          `\n[sp-resume-proof] ✓ Resumed turn honored the NEW system prompt (${MARKER_BRAVO}).`,
+        );
+        console.log(
+          `  systemPromptWhen = ${String(providerDefaults?.systemPromptWhen ?? "never")}`,
+        );
+      } finally {
+        await client1?.stopAndWait({ timeoutMs: 5_000 }).catch(() => {});
+        await client2?.stopAndWait({ timeoutMs: 5_000 }).catch(() => {});
+        await server1?.close().catch(() => {});
+        await server2?.close().catch(() => {});
+        await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+        clearRuntimeConfigSnapshot();
+        restoreCliBackendLiveEnv(previousEnv);
+      }
+    },
+    10 * 60_000,
+  );
+});

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -73,6 +73,7 @@ describe("scripts/test-live-shard", () => {
     expect(selectLiveShardFiles("native-live-src-gateway-backends", allFiles)).toEqual([
       "src/gateway/gateway-acp-bind.live.test.ts",
       "src/gateway/gateway-cli-backend.live.test.ts",
+      "src/gateway/gateway-cli-backend.system-prompt-resume.live.test.ts",
       "src/gateway/gateway-codex-bind.live.test.ts",
       "src/gateway/gateway-codex-harness.live.test.ts",
     ]);


### PR DESCRIPTION
## Problem

Regression introduced in `f7b71abf48` (v2026.4.25, _"fix(agents): pass Claude system prompt via file"_).

When `--system-prompt` was replaced by `--append-system-prompt-file`, `systemPromptWhen` was hardcoded to `"first"` on the Anthropic claude-cli backend. This silently drops the `systemPromptOverride` on every resumed or compacted session — the model receives only the default Claude Code system prompt with zero operator context.

Empirically confirmed: API payloads captured from a live bot show the operator system prompt present on turn 1 (fresh session, `isNew=true`) and completely absent on turn 2+ (resumed session, `useResume=true`).

Tracked in #80374. This PR completes what #81199 started (which only fixes path 1).

## Root cause

Four code paths all gate on `useResume === false` / `isNewSession === true`, assuming the system prompt is only needed once:

| # | File | Gate |
|---|------|------|
| 1 | `extensions/anthropic/cli-backend.ts` | `systemPromptWhen: "first"` (hardcoded default) |
| 2 | `src/agents/cli-runner/execute.ts` | `!useResume && systemPromptArg` (file write skipped on resume) |
| 3 | `src/agents/cli-runner/helpers.ts` | `!params.useResume` (arg not pushed on resume) |
| 4 | `src/agents/cli-runner/claude-live-session.ts` | `stripLiveProcessArgs(..., useResume)` strips prompt flags on resume (affects stream-json / live-stdio bots) |

## Fix

- **Path 1**: change default to `systemPromptWhen: "always"` for the bundled Anthropic backend
- **Paths 2 & 3**: keep existing `!useResume` logic but also allow through when `systemPromptWhen === "always"`
- **Path 4**: only strip system-prompt flags when `systemPromptWhen !== "always"`

No behaviour change for backends that explicitly set `systemPromptWhen: "first"` or `"never"` — the legacy mode is preserved and verified by tests.

## Testing

The fix is verified at two levels, with red-green cycles confirmed against `HEAD~1`:

### Unit tests (run in default CI, fully self-contained)

| File | Coverage |
|------|----------|
| `extensions/anthropic/cli-shared.test.ts` | Path 1 — bundled backend default is `systemPromptWhen: "always"` |
| `src/agents/cli-backends.test.ts` | Updates two stale `"first"` expectations the ClawSweeper bot flagged (`beforeEach` setup + claude-cli defaults assertion) |
| `src/agents/cli-runner/helpers.system-prompt-resume.test.ts` | Paths 3 & 4 — `resolveSystemPromptUsage`, `buildCliArgs`, `buildClaudeLiveArgs`. Covers both legacy `"first"` (backward-compat) and new `"always"` behavior |

Red-green verified locally: **5 specific failures on `HEAD~1`** with exact error messages pointing at each fixed path; **all pass on `HEAD`**.

### Live test (opt-in, excluded from default vitest config)

`src/gateway/gateway-cli-backend.system-prompt-resume.live.test.ts` — changing-marker behavioural proof against real `claude-cli`. The mechanism: each turn's `systemPromptOverride` is a mandatory rule that tells the model **to end every reply with a specific marker token**. By swapping the instructed marker between turns and asserting on which marker the model actually emits, we can tell whether the new system prompt was delivered to the resumed session, or whether the model is just carrying forward Turn 1's instruction from conversation context.

1. **Turn 1** — `systemPromptOverride` = _"you MUST end every reply with the exact token: `MARKER_ALPHA`"_. Send a request; assert the reply contains `MARKER_ALPHA` (sanity check for fresh-session behaviour).
2. **Server restart + config swap** — kill the live claude process and rewrite the config so `systemPromptOverride` now says _"you MUST end every reply with the exact token: `MARKER_BRAVO`; do NOT emit `MARKER_ALPHA`"_.
3. **Turn 2** — resume the prior claude-cli session (same `sessionKey`, claude restarted with `--resume <id>`). Send a request; assert the reply contains `MARKER_BRAVO`.

This is designed to distinguish pre-fix from post-fix at the **model-response level**, not just the argv level:

- **Pre-fix**: the resumed claude process is spawned with `--resume <id>` but WITHOUT `--append-system-prompt-file`. The model only sees Turn 1's `MARKER_ALPHA` instruction in its restored conversation history and emits `MARKER_ALPHA` on Turn 2. The `MARKER_BRAVO` assertion **fails**.
- **Post-fix**: the new system prompt file IS delivered to the resumed process. The model sees the new "emit `MARKER_BRAVO`" instruction and follows it. The assertion **passes**.

Red-green verified locally on real `claude-cli/claude-haiku-4-5`, ~25-40s wall time per run. See the proof comment for full output and SHAs.

### Type checking and lint

`pnpm tsgo:test` and `pnpm lint` both clean.
