### PR TITLE
refactor(cli): own lazy reparse argv outside commander

### DIFF
--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -565,12 +565,25 @@ describe("argv helpers", () => {
       rawArgs: ["bun", "src/entry.ts", "status"],
       expected: ["bun", "src/entry.ts", "status"],
     },
-  ] as const)("builds parse argv from raw args: $name", ({ rawArgs, expected }) => {
+    {
+      name: "scopes root node argv to nested lazy program",
+      rawArgs: ["node", "openclaw", "browser", "--json", "tabs"],
+      programName: "browser",
+      expected: ["node", "browser", "--json", "tabs"],
+    },
+    {
+      name: "scopes root argv with root options to nested lazy program",
+      rawArgs: ["node", "openclaw", "--profile", "work", "browser", "--json", "tabs"],
+      programName: "browser",
+      expected: ["node", "browser", "--json", "tabs"],
+    },
+  ] as const)("builds parse argv from raw args: $name", (entry) => {
+    const programName = "programName" in entry ? entry.programName : "openclaw";
     const parsed = buildParseArgv({
-      programName: "openclaw",
-      rawArgs: [...rawArgs],
+      programName,
+      rawArgs: [...entry.rawArgs],
     });
-    expect(parsed).toEqual([...expected]);
+    expect(parsed).toEqual([...entry.expected]);
   });
 
   it("builds parse argv from fallback args", () => {

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -432,6 +432,10 @@ export function buildParseArgv(params: {
         ? params.fallbackArgv
         : process.argv;
   const programName = params.programName ?? "";
+  const scopedArgv = scopeRawArgvToProgram(baseArgv, programName);
+  if (scopedArgv) {
+    return scopedArgv;
+  }
   const normalizedArgv =
     programName && baseArgv[0] === programName
       ? baseArgv.slice(1)
@@ -445,6 +449,42 @@ export function buildParseArgv(params: {
     return normalizedArgv;
   }
   return ["node", programName || "openclaw", ...normalizedArgv];
+}
+
+function scopeRawArgvToProgram(baseArgv: readonly string[], programName: string): string[] | null {
+  if (!programName || baseArgv.length === 0 || baseArgv[0] === programName) {
+    return null;
+  }
+  const launcher = baseArgv[0] ?? "node";
+  const launchedByRuntime = isNodeRuntime(launcher) || isBunRuntime(launcher);
+  if (!launchedByRuntime) {
+    return null;
+  }
+  const start = 2;
+  if (start >= baseArgv.length) {
+    return null;
+  }
+  const args = baseArgv.slice(start);
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg || arg === FLAG_TERMINATOR) {
+      break;
+    }
+    const consumed = consumeRootOptionToken(args, index);
+    if (consumed > 0) {
+      index += consumed - 1;
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      continue;
+    }
+    if (arg !== programName) {
+      return null;
+    }
+    const scopedArgs = args.slice(index + 1);
+    return [launcher, programName, ...scopedArgs];
+  }
+  return null;
 }
 
 export function shouldMigrateStateFromPath(path: string[]): boolean {

--- a/src/cli/program/action-reparse.test.ts
+++ b/src/cli/program/action-reparse.test.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { reparseProgramFromActionArgs } from "./action-reparse.js";
+import { setProgramRawArgv } from "./program-context.js";
 
 const buildParseArgvMock = vi.hoisted(() => vi.fn());
 const resolveActionArgsMock = vi.hoisted(() => vi.fn());
@@ -28,10 +29,9 @@ describe("reparseProgramFromActionArgs", () => {
     const parseAsync = vi.spyOn(program, "parseAsync").mockResolvedValue(program);
     const actionCommand = {
       name: () => "status",
-      parent: {
-        rawArgs: ["node", "openclaw", "status", "--json"],
-      },
+      parent: new Command(),
     } as unknown as Command;
+    setProgramRawArgv(actionCommand.parent as Command, ["node", "openclaw", "status", "--json"]);
     resolveActionArgsMock.mockReturnValue(["--json"]);
 
     await reparseProgramFromActionArgs(program, [actionCommand]);
@@ -78,8 +78,30 @@ describe("reparseProgramFromActionArgs", () => {
     expect(resolveCommandOptionArgsMock).toHaveBeenCalledWith(program);
     expect(buildParseArgvMock).toHaveBeenCalledWith({
       programName: "browser",
-      rawArgs: [],
+      rawArgs: undefined,
       fallbackArgv: ["--json", "open", "about:blank"],
+    });
+    expect(parseAsync).toHaveBeenCalledWith(["node", "openclaw", "status"]);
+  });
+
+  it("reuses raw argv stored on an ancestor command", async () => {
+    const program = new Command().name("browser");
+    const parseAsync = vi.spyOn(program, "parseAsync").mockResolvedValue(program);
+    const root = new Command().name("openclaw");
+    const browser = new Command().name("browser");
+    browser.parent = root;
+    setProgramRawArgv(root, ["node", "openclaw", "browser", "--json", "tabs"]);
+    const actionCommand = {
+      name: () => "tabs",
+      parent: browser,
+    } as unknown as Command;
+
+    await reparseProgramFromActionArgs(program, [actionCommand]);
+
+    expect(buildParseArgvMock).toHaveBeenCalledWith({
+      programName: "browser",
+      rawArgs: ["node", "openclaw", "browser", "--json", "tabs"],
+      fallbackArgv: ["tabs"],
     });
     expect(parseAsync).toHaveBeenCalledWith(["node", "openclaw", "status"]);
   });
@@ -93,7 +115,7 @@ describe("reparseProgramFromActionArgs", () => {
     expect(resolveActionArgsMock).toHaveBeenCalledWith(undefined);
     expect(buildParseArgvMock).toHaveBeenCalledWith({
       programName: "openclaw",
-      rawArgs: [],
+      rawArgs: undefined,
       fallbackArgv: [],
     });
     expect(parseAsync).toHaveBeenCalledWith(["node", "openclaw", "status"]);

--- a/src/cli/program/action-reparse.ts
+++ b/src/cli/program/action-reparse.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 import { buildParseArgv } from "../argv.js";
+import { getProgramRawArgv } from "./program-context.js";
 import { resolveActionArgs, resolveCommandOptionArgs } from "./helpers.js";
 
 function buildFallbackArgv(program: Command, actionCommand: Command | undefined): string[] {
@@ -16,8 +17,7 @@ export async function reparseProgramFromActionArgs(
   actionArgs: unknown[],
 ): Promise<void> {
   const actionCommand = actionArgs.at(-1) as Command | undefined;
-  const root = actionCommand?.parent ?? program;
-  const rawArgs = (root as Command & { rawArgs?: string[] }).rawArgs;
+  const rawArgs = getProgramRawArgv(actionCommand?.parent ?? program);
   const fallbackArgv = buildFallbackArgv(program, actionCommand);
   const parseArgv = buildParseArgv({
     programName: program.name(),

--- a/src/cli/program/build-program.test.ts
+++ b/src/cli/program/build-program.test.ts
@@ -9,6 +9,7 @@ const createProgramContextMock = vi.hoisted(() => vi.fn());
 const configureProgramHelpMock = vi.hoisted(() => vi.fn());
 const registerPreActionHooksMock = vi.hoisted(() => vi.fn());
 const setProgramContextMock = vi.hoisted(() => vi.fn());
+const setProgramRawArgvMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./command-registry.js", () => ({
   registerProgramCommands: registerProgramCommandsMock,
@@ -28,6 +29,7 @@ vi.mock("./preaction.js", () => ({
 
 vi.mock("./program-context.js", () => ({
   setProgramContext: setProgramContextMock,
+  setProgramRawArgv: setProgramRawArgvMock,
 }));
 
 describe("buildProgram", () => {
@@ -74,6 +76,7 @@ describe("buildProgram", () => {
 
       expect(program).toBeInstanceOf(Command);
       expect(setProgramContextMock).toHaveBeenCalledWith(program, ctx);
+      expect(setProgramRawArgvMock).toHaveBeenCalledWith(program, argv);
       expect(configureProgramHelpMock).toHaveBeenCalledWith(program, ctx);
       expect(registerPreActionHooksMock).toHaveBeenCalledWith(program, ctx.programVersion);
       expect(registerProgramCommandsMock).toHaveBeenCalledWith(program, ctx, argv);

--- a/src/cli/program/build-program.test.ts
+++ b/src/cli/program/build-program.test.ts
@@ -85,6 +85,21 @@ describe("buildProgram", () => {
     }
   });
 
+  it("refreshes stored raw argv when parseAsync receives user argv later", async () => {
+    const originalArgv = process.argv;
+    process.argv = ["node", "openclaw"];
+    try {
+      const program = buildProgram();
+      program.command("test").argument("[value]").action(() => undefined);
+
+      await program.parseAsync(["test", "value"], { from: "user" });
+
+      expect(setProgramRawArgvMock).toHaveBeenLastCalledWith(program, ["test", "value"]);
+    } finally {
+      process.argv = originalArgv;
+    }
+  });
+
   it("sets exitCode to 1 on argument errors (fixes #60905)", async () => {
     const program = buildProgram();
     program.command("test").description("Test command");

--- a/src/cli/program/build-program.ts
+++ b/src/cli/program/build-program.ts
@@ -4,9 +4,9 @@ import { registerProgramCommands } from "./command-registry.js";
 import { createProgramContext } from "./context.js";
 import { configureProgramHelp } from "./help.js";
 import { registerPreActionHooks } from "./preaction.js";
-import { setProgramContext } from "./program-context.js";
+import { setProgramContext, setProgramRawArgv } from "./program-context.js";
 
-export function buildProgram() {
+export function buildProgram(argv: readonly string[] = process.argv) {
   const program = new Command();
   program.enablePositionalOptions();
   // Preserve Commander-computed exit codes while still aborting parse flow.
@@ -17,9 +17,9 @@ export function buildProgram() {
     throw err;
   });
   const ctx = createProgramContext();
-  const argv = process.argv;
 
   setProgramContext(program, ctx);
+  setProgramRawArgv(program, argv);
   configureProgramHelp(program, ctx);
   registerPreActionHooks(program, ctx.programVersion);
 

--- a/src/cli/program/build-program.ts
+++ b/src/cli/program/build-program.ts
@@ -8,6 +8,7 @@ import { setProgramContext, setProgramRawArgv } from "./program-context.js";
 
 export function buildProgram(argv: readonly string[] = process.argv) {
   const program = new Command();
+  const registrationArgv = [...argv];
   program.enablePositionalOptions();
   // Preserve Commander-computed exit codes while still aborting parse flow.
   // Without this, unknown nested commands can print an error
@@ -23,7 +24,7 @@ export function buildProgram(argv: readonly string[] = process.argv) {
   configureProgramHelp(program, ctx);
   registerPreActionHooks(program, ctx.programVersion);
 
-  registerProgramCommands(program, ctx, argv);
+  registerProgramCommands(program, ctx, registrationArgv);
 
   return program;
 }

--- a/src/cli/program/build-program.ts
+++ b/src/cli/program/build-program.ts
@@ -6,6 +6,25 @@ import { configureProgramHelp } from "./help.js";
 import { registerPreActionHooks } from "./preaction.js";
 import { setProgramContext, setProgramRawArgv } from "./program-context.js";
 
+function installRawArgvTracking(program: Command): void {
+  const originalParse = program.parse.bind(program);
+  const originalParseAsync = program.parseAsync.bind(program);
+
+  program.parse = ((argv, parseOptions) => {
+    if (Array.isArray(argv)) {
+      setProgramRawArgv(program, argv);
+    }
+    return originalParse(argv, parseOptions);
+  }) as typeof program.parse;
+
+  program.parseAsync = (async (argv, parseOptions) => {
+    if (Array.isArray(argv)) {
+      setProgramRawArgv(program, argv);
+    }
+    return await originalParseAsync(argv, parseOptions);
+  }) as typeof program.parseAsync;
+}
+
 export function buildProgram(argv: readonly string[] = process.argv) {
   const program = new Command();
   const registrationArgv = [...argv];
@@ -21,6 +40,7 @@ export function buildProgram(argv: readonly string[] = process.argv) {
 
   setProgramContext(program, ctx);
   setProgramRawArgv(program, argv);
+  installRawArgvTracking(program);
   configureProgramHelp(program, ctx);
   registerPreActionHooks(program, ctx.programVersion);
 

--- a/src/cli/program/program-context.test.ts
+++ b/src/cli/program/program-context.test.ts
@@ -1,7 +1,12 @@
 import { Command } from "commander";
 import { describe, expect, it } from "vitest";
 import type { ProgramContext } from "./context.js";
-import { getProgramContext, setProgramContext } from "./program-context.js";
+import {
+  getProgramContext,
+  getProgramRawArgv,
+  setProgramContext,
+  setProgramRawArgv,
+} from "./program-context.js";
 
 function makeCtx(version: string): ProgramContext {
   return {
@@ -34,5 +39,26 @@ describe("program context storage", () => {
 
     expect(getProgramContext(programA)).toBe(ctxA);
     expect(getProgramContext(programB)).toBe(ctxB);
+  });
+
+  it("resolves context from ancestor commands", () => {
+    const root = new Command();
+    const child = new Command();
+    child.parent = root;
+    const ctx = makeCtx("root");
+
+    setProgramContext(root, ctx);
+
+    expect(getProgramContext(child)).toBe(ctx);
+  });
+
+  it("stores and resolves raw argv across the command tree", () => {
+    const root = new Command();
+    const child = new Command();
+    child.parent = root;
+
+    setProgramRawArgv(root, ["node", "openclaw", "browser", "status"]);
+
+    expect(getProgramRawArgv(child)).toEqual(["node", "openclaw", "browser", "status"]);
   });
 });

--- a/src/cli/program/program-context.ts
+++ b/src/cli/program/program-context.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import type { ProgramContext } from "./context.js";
 
 const PROGRAM_CONTEXT_SYMBOL: unique symbol = Symbol.for("openclaw.cli.programContext");
+const PROGRAM_RAW_ARGV_SYMBOL: unique symbol = Symbol.for("openclaw.cli.programRawArgv");
 
 export function setProgramContext(program: Command, ctx: ProgramContext): void {
   (program as Command & { [PROGRAM_CONTEXT_SYMBOL]?: ProgramContext })[PROGRAM_CONTEXT_SYMBOL] =
@@ -9,7 +10,31 @@ export function setProgramContext(program: Command, ctx: ProgramContext): void {
 }
 
 export function getProgramContext(program: Command): ProgramContext | undefined {
-  return (program as Command & { [PROGRAM_CONTEXT_SYMBOL]?: ProgramContext })[
-    PROGRAM_CONTEXT_SYMBOL
+  for (let current: Command | null | undefined = program; current; current = current.parent) {
+    const ctx = (current as Command & { [PROGRAM_CONTEXT_SYMBOL]?: ProgramContext })[
+      PROGRAM_CONTEXT_SYMBOL
+    ];
+    if (ctx) {
+      return ctx;
+    }
+  }
+  return undefined;
+}
+
+export function setProgramRawArgv(program: Command, rawArgv: readonly string[]): void {
+  (program as Command & { [PROGRAM_RAW_ARGV_SYMBOL]?: string[] })[PROGRAM_RAW_ARGV_SYMBOL] = [
+    ...rawArgv,
   ];
+}
+
+export function getProgramRawArgv(program: Command): string[] | undefined {
+  for (let current: Command | null | undefined = program; current; current = current.parent) {
+    const rawArgv = (current as Command & { [PROGRAM_RAW_ARGV_SYMBOL]?: string[] })[
+      PROGRAM_RAW_ARGV_SYMBOL
+    ];
+    if (Array.isArray(rawArgv)) {
+      return [...rawArgv];
+    }
+  }
+  return undefined;
 }

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -783,7 +783,8 @@ export async function runCli(argv: string[] = process.argv) {
           import("../../packages/terminal-core/src/restore.js"),
         ]),
       );
-      const program = await startupTrace.measure("build-program", () => buildProgram());
+      const parseArgv = normalizeGeneratedHelpCommandArgv(rewriteUpdateFlagArgv(normalizedArgv));
+      const program = await startupTrace.measure("build-program", () => buildProgram(parseArgv));
 
       // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
       // These log the error and exit gracefully instead of crashing without trace.
@@ -814,7 +815,6 @@ export async function runCli(argv: string[] = process.argv) {
         process.exit(1);
       });
 
-      const parseArgv = normalizeGeneratedHelpCommandArgv(rewriteUpdateFlagArgv(normalizedArgv));
       const invocation = resolveCliArgvInvocation(parseArgv);
       // Register the primary command (builtin or subcli) so help and command parsing
       // are correct even with lazy command registration.


### PR DESCRIPTION
## Summary
- store the parse argv on OpenClaw program state instead of reading Commander's private runtime-only `rawArgs` field
- let lazy command reparsing resolve that stored argv from the current command or any ancestor command
- scope full root argv back to the nested lazy program before reparsing, so plugin lazy commands like `browser --json tabs` do not see the root `browser` token as an excess argument
- cover the ownership and nested-program argv path with focused CLI, browser, and plugin regression tests

## Verification
- `git diff --check`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/cli/argv.test.ts --pool forks --maxWorkers=1 --reporter=tap`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/program/action-reparse.test.ts src/cli/program/build-program.test.ts --pool forks --maxWorkers=1 --reporter=tap`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/program/build-program.version-alias.test.ts --pool forks --maxWorkers=1 --reporter=tap`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node /media/vdc/0668001470/workSpace/claw-campaign/openclaw-issue-83893/node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extension-browser.config.ts extensions/browser/src/cli/browser-cli.lazy.test.ts --pool forks --maxWorkers=1 --reporter=tap`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.plugins.config.ts src/plugins/cli.browser-plugin.integration.test.ts src/plugins/cli.test.ts --pool forks --maxWorkers=1 --reporter=tap`
- `pnpm check:test-types`

## Real behavior proof
Behavior addressed: current main still reparses lazy CLI commands by casting `Command` to read Commander's private `rawArgs` runtime field. This patch proves OpenClaw can own that argv itself and scopes full root argv like `node openclaw browser --json tabs` back to the nested lazy `browser` program before reparsing, so the real CLI no longer treats the root command token as an excess browser argument.

Real environment tested: local source checkout on Linux in a fresh worktree, against PR head `18a50929d4`, using a fresh temporary `OPENCLAW_HOME`.

Exact steps or command run after this patch: `OPENCLAW_HOME=$(mktemp -d) OPENCLAW_DISABLE_CLI_STARTUP_HELP_FAST_PATH=1 NO_COLOR=1 node scripts/run-node.mjs browser --json tabs`

Evidence after fix: copied live terminal output from the actual after-patch CLI invocation:

```text
$ OPENCLAW_HOME=$(mktemp -d) OPENCLAW_DISABLE_CLI_STARTUP_HELP_FAST_PATH=1 NO_COLOR=1 node scripts/run-node.mjs browser --json tabs
[openclaw] Building TypeScript (dist is stale: git_head_changed - git head changed).
[openclaw] Building bundled plugin assets.
[canvas] build: node scripts/bundle-a2ui.mjs
A2UI bundle up to date; skipping.
runtime-postbuild: plugin SDK root alias completed in 1ms
runtime-postbuild: bundled plugin metadata completed in 333ms
runtime-postbuild: official channel catalog completed in 6ms
runtime-postbuild: bundled plugin runtime overlay completed in 383ms
runtime-postbuild: static extension assets completed in 79ms
runtime-postbuild: stable root runtime imports completed in 421ms
runtime-postbuild: stable root runtime aliases completed in 76ms
runtime-postbuild: legacy root runtime compat chunks completed in 21ms
runtime-postbuild: legacy CLI exit compat chunks completed in 1ms
gateway connect failed: GatewayClientRequestError: protocol mismatch
GatewayTransportError: gateway closed (1002): protocol mismatch
Gateway target: ws://127.0.0.1:18789
Source: local loopback
Config: /tmp/.../.openclaw/openclaw.json
Bind: loopback
```

Observed result after fix: the actual `openclaw` launcher accepted the lazy plugin command shape `browser --json tabs` and reached the browser Gateway RPC path. Before the final fix, the same command failed at Commander parsing with `Too many arguments for this command. Try: openclaw browser tabs --help`, so it never reached browser command execution. The post-fix failure shown above is an expected local Gateway/runtime mismatch in my environment, not a CLI argv parse failure.

What was not tested: I did not run a fully healthy local Gateway/browser service; the real CLI proof stops at the environment-specific Gateway protocol mismatch after command dispatch. I also did not run the entire repository test matrix locally because the targeted CLI, plugin CLI, argv, and browser lazy-command suites cover the changed behavior and CI covers the full shard set.
