### PR TITLE
perf(secrets): propagate snapshots and eliminate esm side-effects in auth env vars

### DIFF
--- a/src/acp/client.test.ts
+++ b/src/acp/client.test.ts
@@ -6,6 +6,11 @@ import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
 
 vi.mock("../secrets/provider-env-vars.js", () => ({
   listKnownProviderAuthEnvVarNames: () => ["OPENAI_API_KEY", "GITHUB_TOKEN", "HF_TOKEN"],
+  resolveProviderAuthLookupMaps: () => ({
+    aliasMap: {},
+    envCandidateMap: {},
+    authEvidenceMap: {},
+  }),
   omitEnvKeysCaseInsensitive: (
     baseEnv: NodeJS.ProcessEnv,
     keys: Iterable<string>,

--- a/src/agents/model-auth-env-vars.ts
+++ b/src/agents/model-auth-env-vars.ts
@@ -36,8 +36,6 @@ export function resolveProviderEnvAuthLookupKeys(params?: ProviderEnvVarLookupPa
   });
 }
 
-export const PROVIDER_ENV_API_KEY_CANDIDATES = resolveProviderEnvApiKeyCandidates();
-
 export function listKnownProviderEnvApiKeyNames(): string[] {
   return listKnownProviderAuthEnvVarNames();
 }

--- a/src/agents/model-auth-env-vars.ts
+++ b/src/agents/model-auth-env-vars.ts
@@ -2,9 +2,11 @@ import {
   listKnownProviderAuthEnvVarNames,
   resolveProviderAuthEvidence,
   resolveProviderAuthEnvVarCandidates,
+  resolveProviderAuthLookupMaps,
 } from "../secrets/provider-env-vars.js";
 import type {
   ProviderAuthEvidence,
+  ProviderAuthLookupMaps,
   ProviderEnvVarLookupParams,
 } from "../secrets/provider-env-vars.js";
 
@@ -20,6 +22,12 @@ export function resolveProviderEnvAuthEvidence(
   return resolveProviderAuthEvidence(params);
 }
 
+export function resolveProviderEnvAuthLookupMaps(
+  params?: ProviderEnvVarLookupParams,
+): ProviderAuthLookupMaps {
+  return resolveProviderAuthLookupMaps(params);
+}
+
 export function listProviderEnvAuthLookupKeys(params: {
   envCandidateMap: Readonly<Record<string, readonly string[]>>;
   authEvidenceMap: Readonly<Record<string, readonly ProviderAuthEvidence[]>>;
@@ -30,9 +38,10 @@ export function listProviderEnvAuthLookupKeys(params: {
 }
 
 export function resolveProviderEnvAuthLookupKeys(params?: ProviderEnvVarLookupParams): string[] {
+  const lookupMaps = resolveProviderEnvAuthLookupMaps(params);
   return listProviderEnvAuthLookupKeys({
-    envCandidateMap: resolveProviderEnvApiKeyCandidates(params),
-    authEvidenceMap: resolveProviderEnvAuthEvidence(params),
+    envCandidateMap: lookupMaps.envCandidateMap,
+    authEvidenceMap: lookupMaps.authEvidenceMap,
   });
 }
 

--- a/src/agents/model-auth-env.ts
+++ b/src/agents/model-auth-env.ts
@@ -6,12 +6,8 @@ import { resolvePluginSetupProvider } from "../plugins/setup-registry.js";
 import type { ProviderAuthEvidence } from "../secrets/provider-env-vars.js";
 import { normalizeOptionalString as normalizeOptionalPathInput } from "../shared/string-coerce.js";
 import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
-import {
-  resolveProviderEnvApiKeyCandidates,
-  resolveProviderEnvAuthEvidence,
-} from "./model-auth-env-vars.js";
+import { resolveProviderEnvAuthLookupMaps } from "./model-auth-env-vars.js";
 import { GCP_VERTEX_CREDENTIALS_MARKER } from "./model-auth-markers.js";
-import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
 import { normalizeProviderIdForAuth } from "./provider-id.js";
 
 export type EnvApiKeyResult = {
@@ -101,11 +97,14 @@ export function resolveEnvApiKey(
     workspaceDir: options.workspaceDir,
     env,
   };
-  const normalized = options.aliasMap
-    ? (options.aliasMap[normalizedProvider] ?? normalizedProvider)
-    : resolveProviderIdForAuth(provider, lookupParams);
-  const candidateMap = options.candidateMap ?? resolveProviderEnvApiKeyCandidates(lookupParams);
-  const authEvidenceMap = options.authEvidenceMap ?? resolveProviderEnvAuthEvidence(lookupParams);
+  const lookupMaps =
+    !options.aliasMap || !options.candidateMap || !options.authEvidenceMap
+      ? resolveProviderEnvAuthLookupMaps(lookupParams)
+      : undefined;
+  const aliasMap = options.aliasMap ?? lookupMaps?.aliasMap ?? {};
+  const normalized = aliasMap[normalizedProvider] ?? normalizedProvider;
+  const candidateMap = options.candidateMap ?? lookupMaps?.envCandidateMap ?? {};
+  const authEvidenceMap = options.authEvidenceMap ?? lookupMaps?.authEvidenceMap ?? {};
   const applied = new Set(getShellEnvAppliedKeys());
   const pick = (envVar: string): EnvApiKeyResult | null => {
     const value = normalizeOptionalSecretInput(env[envVar]);

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -137,7 +137,6 @@ vi.mock("./model-auth-env-vars.js", () => {
     zai: ["ZAI_API_KEY", "Z_AI_API_KEY"],
   } as const;
   return {
-    PROVIDER_ENV_API_KEY_CANDIDATES: candidates,
     listKnownProviderEnvApiKeyNames: () => [...new Set(Object.values(candidates).flat())],
     resolveProviderEnvApiKeyCandidates: () => candidates,
     resolveProviderEnvAuthEvidence: (params?: { config?: OpenClawConfig }) => {

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -136,41 +136,56 @@ vi.mock("./model-auth-env-vars.js", () => {
     voyage: ["VOYAGE_API_KEY"],
     zai: ["ZAI_API_KEY", "Z_AI_API_KEY"],
   } as const;
+  const aliasMap = {
+    modelstudio: "qwen",
+    qwencloud: "qwen",
+    "z.ai": "zai",
+    "z-ai": "zai",
+    "opencode-go-auth": "opencode-go",
+    bedrock: "amazon-bedrock",
+    "aws-bedrock": "amazon-bedrock",
+  };
+  const resolveProviderEnvAuthEvidence = (params?: { config?: OpenClawConfig }) => {
+    const evidence = {
+      "google-vertex": [
+        {
+          type: "local-file-with-env",
+          fileEnvVar: "GOOGLE_APPLICATION_CREDENTIALS",
+          fallbackPaths: [
+            "${HOME}/.config/gcloud/application_default_credentials.json",
+            "${APPDATA}/gcloud/application_default_credentials.json",
+          ],
+          requiresAnyEnv: ["GOOGLE_CLOUD_PROJECT", "GCLOUD_PROJECT"],
+          requiresAllEnv: ["GOOGLE_CLOUD_LOCATION"],
+          credentialMarker: "gcp-vertex-credentials",
+          source: "gcloud adc",
+        },
+      ],
+    } satisfies Record<string, readonly unknown[]>;
+    if (!hasAllowedPlugin(params?.config, "workspace-cloud")) {
+      return evidence;
+    }
+    return {
+      ...evidence,
+      "workspace-cloud": [
+        {
+          type: "local-file-with-env",
+          fileEnvVar: "WORKSPACE_CLOUD_CREDENTIALS",
+          credentialMarker: "workspace-cloud-local-credentials",
+          source: "workspace cloud credentials",
+        },
+      ],
+    };
+  };
   return {
     listKnownProviderEnvApiKeyNames: () => [...new Set(Object.values(candidates).flat())],
     resolveProviderEnvApiKeyCandidates: () => candidates,
-    resolveProviderEnvAuthEvidence: (params?: { config?: OpenClawConfig }) => {
-      const evidence = {
-        "google-vertex": [
-          {
-            type: "local-file-with-env",
-            fileEnvVar: "GOOGLE_APPLICATION_CREDENTIALS",
-            fallbackPaths: [
-              "${HOME}/.config/gcloud/application_default_credentials.json",
-              "${APPDATA}/gcloud/application_default_credentials.json",
-            ],
-            requiresAnyEnv: ["GOOGLE_CLOUD_PROJECT", "GCLOUD_PROJECT"],
-            requiresAllEnv: ["GOOGLE_CLOUD_LOCATION"],
-            credentialMarker: "gcp-vertex-credentials",
-            source: "gcloud adc",
-          },
-        ],
-      } satisfies Record<string, readonly unknown[]>;
-      if (!hasAllowedPlugin(params?.config, "workspace-cloud")) {
-        return evidence;
-      }
-      return {
-        ...evidence,
-        "workspace-cloud": [
-          {
-            type: "local-file-with-env",
-            fileEnvVar: "WORKSPACE_CLOUD_CREDENTIALS",
-            credentialMarker: "workspace-cloud-local-credentials",
-            source: "workspace cloud credentials",
-          },
-        ],
-      };
-    },
+    resolveProviderEnvAuthEvidence,
+    resolveProviderEnvAuthLookupMaps: (params?: { config?: OpenClawConfig }) => ({
+      aliasMap,
+      envCandidateMap: candidates,
+      authEvidenceMap: resolveProviderEnvAuthEvidence(params),
+    }),
   };
 });
 

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -34,10 +34,7 @@ import {
   resolveAuthStorePathForDisplay,
 } from "./auth-profiles.js";
 import * as cliCredentials from "./cli-credentials.js";
-import {
-  resolveProviderEnvApiKeyCandidates,
-  resolveProviderEnvAuthEvidence,
-} from "./model-auth-env-vars.js";
+import { resolveProviderEnvAuthLookupMaps } from "./model-auth-env-vars.js";
 import {
   resolveEnvApiKey,
   type EnvApiKeyLookupOptions,
@@ -51,7 +48,6 @@ import {
 } from "./model-auth-markers.js";
 import { type ResolvedProviderAuth } from "./model-auth-runtime-shared.js";
 import { normalizeProviderId } from "./model-selection.js";
-import { resolveProviderAuthAliasMap } from "./provider-auth-aliases.js";
 
 export {
   ensureAuthProfileStore,
@@ -119,11 +115,12 @@ export function createRuntimeProviderAuthLookup(params: {
     params.includePluginSyntheticAuth === false
       ? undefined
       : resolveRuntimeSyntheticAuthProviderRefState(lookupParams);
+  const authLookupMaps = resolveProviderEnvAuthLookupMaps(lookupParams);
   return {
     envApiKey: {
-      aliasMap: resolveProviderAuthAliasMap(lookupParams),
-      candidateMap: resolveProviderEnvApiKeyCandidates(lookupParams),
-      authEvidenceMap: resolveProviderEnvAuthEvidence(lookupParams),
+      aliasMap: authLookupMaps.aliasMap,
+      candidateMap: authLookupMaps.envCandidateMap,
+      authEvidenceMap: authLookupMaps.authEvidenceMap,
     },
     syntheticAuthProviderRefs: syntheticAuthProviderRefs?.complete
       ? syntheticAuthProviderRefs.refs

--- a/src/agents/models-config.providers.moonshot.test.ts
+++ b/src/agents/models-config.providers.moonshot.test.ts
@@ -21,7 +21,6 @@ vi.mock("./model-auth-env-vars.js", () => {
     moonshot: ["MOONSHOT_API_KEY"],
   } as const;
   return {
-    PROVIDER_ENV_API_KEY_CANDIDATES: candidates,
     listKnownProviderEnvApiKeyNames: () => [...new Set(Object.values(candidates).flat())],
     resolveProviderEnvApiKeyCandidates: () => candidates,
     resolveProviderEnvAuthEvidence: () => ({}),

--- a/src/agents/models-config.providers.moonshot.test.ts
+++ b/src/agents/models-config.providers.moonshot.test.ts
@@ -24,6 +24,11 @@ vi.mock("./model-auth-env-vars.js", () => {
     listKnownProviderEnvApiKeyNames: () => [...new Set(Object.values(candidates).flat())],
     resolveProviderEnvApiKeyCandidates: () => candidates,
     resolveProviderEnvAuthEvidence: () => ({}),
+    resolveProviderEnvAuthLookupMaps: () => ({
+      aliasMap: {},
+      envCandidateMap: candidates,
+      authEvidenceMap: {},
+    }),
   };
 });
 

--- a/src/agents/models-config.providers.nvidia.test.ts
+++ b/src/agents/models-config.providers.nvidia.test.ts
@@ -30,6 +30,11 @@ vi.mock("./model-auth-env-vars.js", () => {
     listKnownProviderEnvApiKeyNames: () => [...new Set(Object.values(candidates).flat())],
     resolveProviderEnvApiKeyCandidates: () => candidates,
     resolveProviderEnvAuthEvidence: () => ({}),
+    resolveProviderEnvAuthLookupMaps: () => ({
+      aliasMap: {},
+      envCandidateMap: candidates,
+      authEvidenceMap: {},
+    }),
   };
 });
 

--- a/src/agents/models-config.providers.nvidia.test.ts
+++ b/src/agents/models-config.providers.nvidia.test.ts
@@ -27,7 +27,6 @@ vi.mock("./model-auth-env-vars.js", () => {
     vllm: ["VLLM_API_KEY"],
   } as const;
   return {
-    PROVIDER_ENV_API_KEY_CANDIDATES: candidates,
     listKnownProviderEnvApiKeyNames: () => [...new Set(Object.values(candidates).flat())],
     resolveProviderEnvApiKeyCandidates: () => candidates,
     resolveProviderEnvAuthEvidence: () => ({}),

--- a/src/agents/models-config.providers.secrets.ts
+++ b/src/agents/models-config.providers.secrets.ts
@@ -3,10 +3,7 @@ import { resolveSecretInputRef } from "../config/types.secrets.js";
 import { resolveProviderSyntheticAuthWithPlugin } from "../plugins/provider-runtime.js";
 import type { ProviderAuthEvidence } from "../secrets/provider-env-vars.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
-import {
-  resolveProviderEnvApiKeyCandidates,
-  resolveProviderEnvAuthEvidence,
-} from "./model-auth-env-vars.js";
+import { resolveProviderEnvAuthLookupMaps } from "./model-auth-env-vars.js";
 import {
   isKnownEnvApiKeyMarker,
   isNonSecretApiKeyMarker,
@@ -22,7 +19,7 @@ import {
   type ProviderApiKeyResolver,
   type ProviderAuthResolver,
 } from "./models-config.providers.secret-helpers.js";
-import { resolveProviderAuthAliasMap, resolveProviderIdForAuth } from "./provider-auth-aliases.js";
+import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
 import { normalizeProviderId } from "./provider-id.js";
 
 export type {
@@ -63,12 +60,17 @@ function createProviderAuthLookupCaches(
   config?: OpenClawConfig,
 ): () => ProviderAuthLookupCaches {
   let caches: ProviderAuthLookupCaches | undefined;
-  return () =>
-    (caches ??= {
-      aliasMap: resolveProviderAuthAliasMap({ config, env }),
-      candidateMap: resolveProviderEnvApiKeyCandidates({ config, env }),
-      authEvidenceMap: resolveProviderEnvAuthEvidence({ config, env }),
-    });
+  return () => {
+    if (!caches) {
+      const lookupMaps = resolveProviderEnvAuthLookupMaps({ config, env });
+      caches = {
+        aliasMap: lookupMaps.aliasMap,
+        candidateMap: lookupMaps.envCandidateMap,
+        authEvidenceMap: lookupMaps.authEvidenceMap,
+      };
+    }
+    return caches;
+  };
 }
 
 function resolveProviderIdForAuthFromCaches(

--- a/src/agents/models-config.runtime-source-snapshot.test.ts
+++ b/src/agents/models-config.runtime-source-snapshot.test.ts
@@ -18,6 +18,11 @@ vi.mock("./model-auth-env-vars.js", () => ({
   listKnownProviderEnvApiKeyNames: () => ["OPENAI_API_KEY"],
   resolveProviderEnvApiKeyCandidates: () => ({ openai: ["OPENAI_API_KEY"] }),
   resolveProviderEnvAuthEvidence: () => ({}),
+  resolveProviderEnvAuthLookupMaps: () => ({
+    aliasMap: {},
+    envCandidateMap: { openai: ["OPENAI_API_KEY"] },
+    authEvidenceMap: {},
+  }),
 }));
 
 vi.mock("../plugins/provider-runtime.js", () => ({

--- a/src/agents/models-config.runtime-source-snapshot.test.ts
+++ b/src/agents/models-config.runtime-source-snapshot.test.ts
@@ -16,7 +16,6 @@ vi.mock("../plugins/manifest-registry.js", () => ({
 
 vi.mock("./model-auth-env-vars.js", () => ({
   listKnownProviderEnvApiKeyNames: () => ["OPENAI_API_KEY"],
-  PROVIDER_ENV_API_KEY_CANDIDATES: { openai: ["OPENAI_API_KEY"] },
   resolveProviderEnvApiKeyCandidates: () => ({ openai: ["OPENAI_API_KEY"] }),
   resolveProviderEnvAuthEvidence: () => ({}),
 }));

--- a/src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts
+++ b/src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts
@@ -17,7 +17,6 @@ vi.mock("./provider-auth-aliases.js", () => ({
 }));
 
 vi.mock("./model-auth-env-vars.js", () => ({
-  PROVIDER_ENV_API_KEY_CANDIDATES: {},
   listKnownProviderEnvApiKeyNames: () => [],
   resolveProviderEnvApiKeyCandidates: () => ({}),
   resolveProviderEnvAuthEvidence: () => ({}),

--- a/src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts
+++ b/src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts
@@ -20,6 +20,11 @@ vi.mock("./model-auth-env-vars.js", () => ({
   listKnownProviderEnvApiKeyNames: () => [],
   resolveProviderEnvApiKeyCandidates: () => ({}),
   resolveProviderEnvAuthEvidence: () => ({}),
+  resolveProviderEnvAuthLookupMaps: () => ({
+    aliasMap: {},
+    envCandidateMap: {},
+    authEvidenceMap: {},
+  }),
 }));
 
 vi.mock("../plugins/provider-runtime.js", () => ({

--- a/src/agents/pi-auth-discovery-core.ts
+++ b/src/agents/pi-auth-discovery-core.ts
@@ -5,8 +5,7 @@ import { replaceFileAtomicSync } from "../infra/replace-file.js";
 import { isRecord } from "../utils.js";
 import {
   listProviderEnvAuthLookupKeys,
-  resolveProviderEnvApiKeyCandidates,
-  resolveProviderEnvAuthEvidence,
+  resolveProviderEnvAuthLookupMaps,
 } from "./model-auth-env-vars.js";
 import { resolveEnvApiKey } from "./model-auth-env.js";
 import type { PiCredentialMap } from "./pi-auth-credentials.js";
@@ -27,8 +26,8 @@ export function addEnvBackedPiCredentials(
     workspaceDir: options.workspaceDir,
     env,
   };
-  const candidateMap = resolveProviderEnvApiKeyCandidates(lookupParams);
-  const authEvidenceMap = resolveProviderEnvAuthEvidence(lookupParams);
+  const lookupMaps = resolveProviderEnvAuthLookupMaps(lookupParams);
+  const { aliasMap, envCandidateMap: candidateMap, authEvidenceMap } = lookupMaps;
   const next = { ...credentials };
   // pi-coding-agent hides providers from its registry when auth storage lacks
   // a matching credential entry. Mirror env-backed provider auth here so
@@ -43,6 +42,7 @@ export function addEnvBackedPiCredentials(
     const resolved = resolveEnvApiKey(provider, env, {
       config: options.config,
       workspaceDir: options.workspaceDir,
+      aliasMap,
       candidateMap,
       authEvidenceMap,
     });

--- a/src/agents/pi-model-discovery.auth.test.ts
+++ b/src/agents/pi-model-discovery.auth.test.ts
@@ -24,6 +24,21 @@ vi.mock("./model-auth-env-vars.js", () => ({
       },
     ],
   }),
+  resolveProviderEnvAuthLookupMaps: () => ({
+    aliasMap: {},
+    envCandidateMap: {
+      mistral: ["MISTRAL_API_KEY"],
+    },
+    authEvidenceMap: {
+      "workspace-cloud": [
+        {
+          type: "local-file-with-env",
+          credentialMarker: "workspace-cloud-local-credentials",
+          source: "workspace cloud credentials",
+        },
+      ],
+    },
+  }),
 }));
 
 vi.mock("./model-auth-env.js", () => ({

--- a/src/agents/provider-auth-aliases.ts
+++ b/src/agents/provider-auth-aliases.ts
@@ -112,7 +112,7 @@ export function resolveProviderAuthAliasMap(
   params?: ProviderAuthAliasLookupParams,
 ): Record<string, string> {
   const env = params?.env ?? process.env;
-  const config = params?.config ?? {};
+  const config = params?.config;
   let cacheKey: string | undefined;
   let envCache: Map<string, Record<string, string>> | undefined;
   if (!params?.metadataSnapshot) {
@@ -129,14 +129,21 @@ export function resolveProviderAuthAliasMap(
   }
   const snapshot =
     params?.metadataSnapshot ??
-    getCurrentPluginMetadataSnapshot({
-      config,
-      ...(params?.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
-      env,
-      allowWorkspaceScopedSnapshot: true,
-    }) ??
+    (config
+      ? getCurrentPluginMetadataSnapshot({
+          config,
+          ...(params?.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
+          env,
+          allowWorkspaceScopedSnapshot: true,
+        })
+      : getCurrentPluginMetadataSnapshot({
+          ...(params?.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
+          env,
+          allowWorkspaceScopedSnapshot: true,
+          requireDefaultDiscoveryContext: true,
+        })) ??
     (() => {
-      if (normalizePluginsConfig(config.plugins).loadPaths.length !== 0) {
+      if (!config || normalizePluginsConfig(config.plugins).loadPaths.length !== 0) {
         return undefined;
       }
       const currentSnapshot = getCurrentPluginMetadataSnapshot({
@@ -148,7 +155,7 @@ export function resolveProviderAuthAliasMap(
       return currentSnapshot;
     })() ??
     loadPluginMetadataSnapshot({
-      config,
+      config: config ?? {},
       ...(params?.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
       env,
     });

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -192,6 +192,11 @@ vi.mock("../runtime.js", () => ({
 
 vi.mock("../secrets/provider-env-vars.js", () => ({
   getProviderEnvVars: mocks.getProviderEnvVars,
+  resolveProviderAuthLookupMaps: () => ({
+    aliasMap: {},
+    envCandidateMap: {},
+    authEvidenceMap: {},
+  }),
 }));
 
 vi.mock("../config/config.js", () => ({

--- a/src/commands/models/list.auth-index.test.ts
+++ b/src/commands/models/list.auth-index.test.ts
@@ -26,6 +26,7 @@ const pluginRegistryMocks = vi.hoisted(() => ({
 
 const envCandidateMocks = vi.hoisted(() => ({
   resolveProviderEnvApiKeyCandidates: vi.fn(),
+  resolveProviderEnvAuthLookupMaps: vi.fn(),
 }));
 
 vi.mock("../../agents/model-auth-env-vars.js", async (importOriginal) => {
@@ -33,9 +34,13 @@ vi.mock("../../agents/model-auth-env-vars.js", async (importOriginal) => {
   envCandidateMocks.resolveProviderEnvApiKeyCandidates.mockImplementation(
     actual.resolveProviderEnvApiKeyCandidates,
   );
+  envCandidateMocks.resolveProviderEnvAuthLookupMaps.mockImplementation(
+    actual.resolveProviderEnvAuthLookupMaps,
+  );
   return {
     ...actual,
     resolveProviderEnvApiKeyCandidates: envCandidateMocks.resolveProviderEnvApiKeyCandidates,
+    resolveProviderEnvAuthLookupMaps: envCandidateMocks.resolveProviderEnvAuthLookupMaps,
   };
 });
 
@@ -97,6 +102,7 @@ async function writeWorkspaceAuthEvidencePlugin(workspaceDir: string) {
 describe("createModelListAuthIndex", () => {
   beforeEach(() => {
     envCandidateMocks.resolveProviderEnvApiKeyCandidates.mockClear();
+    envCandidateMocks.resolveProviderEnvAuthLookupMaps.mockClear();
     pluginRegistryMocks.loadPluginRegistrySnapshotWithMetadata.mockClear();
   });
 
@@ -134,7 +140,11 @@ describe("createModelListAuthIndex", () => {
   });
 
   it("checks resolver-only env auth on demand", () => {
-    envCandidateMocks.resolveProviderEnvApiKeyCandidates.mockReturnValueOnce({});
+    envCandidateMocks.resolveProviderEnvAuthLookupMaps.mockReturnValueOnce({
+      aliasMap: {},
+      envCandidateMap: {},
+      authEvidenceMap: {},
+    });
     const index = createModelListAuthIndex({
       cfg: {},
       authStore: emptyStore,
@@ -147,7 +157,11 @@ describe("createModelListAuthIndex", () => {
   });
 
   it("does not rediscover resolver-only env auth when a command metadata snapshot is supplied", () => {
-    envCandidateMocks.resolveProviderEnvApiKeyCandidates.mockReturnValueOnce({});
+    envCandidateMocks.resolveProviderEnvAuthLookupMaps.mockReturnValueOnce({
+      aliasMap: {},
+      envCandidateMap: {},
+      authEvidenceMap: {},
+    });
     const metadataSnapshot = {
       index: { plugins: [] },
       plugins: [],

--- a/src/commands/models/list.auth-index.ts
+++ b/src/commands/models/list.auth-index.ts
@@ -1,8 +1,7 @@
 import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
 import {
   listProviderEnvAuthLookupKeys,
-  resolveProviderEnvAuthEvidence,
-  resolveProviderEnvApiKeyCandidates,
+  resolveProviderEnvAuthLookupMaps,
 } from "../../agents/model-auth-env-vars.js";
 import { resolveEnvApiKey } from "../../agents/model-auth-env.js";
 import { resolveAwsSdkEnvVarName } from "../../agents/model-auth-runtime-shared.js";
@@ -14,7 +13,6 @@ import {
   OPENAI_CODEX_PROVIDER_ID,
   openAIProviderUsesCodexRuntimeByDefault,
 } from "../../agents/openai-codex-routing.js";
-import { resolveProviderAuthAliasMap } from "../../agents/provider-auth-aliases.js";
 import { normalizeProviderIdForAuth } from "../../agents/provider-id.js";
 import { resolveAgentModelPrimaryValue } from "../../config/model-input.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -76,9 +74,8 @@ export function createModelListAuthIndex(
     env,
     metadataSnapshot: params.metadataSnapshot,
   };
-  const aliasMap = resolveProviderAuthAliasMap(lookupParams);
-  const envCandidateMap = resolveProviderEnvApiKeyCandidates(lookupParams);
-  const authEvidenceMap = resolveProviderEnvAuthEvidence(lookupParams);
+  const { aliasMap, envCandidateMap, authEvidenceMap } =
+    resolveProviderEnvAuthLookupMaps(lookupParams);
   const skipSetupProviderFallback = params.metadataSnapshot !== undefined;
   const authenticatedProviders = new Set<string>();
   const syntheticAuthProviders = new Set<string>();

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -18,8 +18,7 @@ import type { AuthProfileCredential } from "../../agents/auth-profiles/types.js"
 import { resolveProfileUnusableUntilForDisplay } from "../../agents/auth-profiles/usage.js";
 import {
   listProviderEnvAuthLookupKeys,
-  resolveProviderEnvApiKeyCandidates,
-  resolveProviderEnvAuthEvidence,
+  resolveProviderEnvAuthLookupMaps,
 } from "../../agents/model-auth-env-vars.js";
 import { resolveEnvApiKey, resolveUsableCustomProviderApiKey } from "../../agents/model-auth.js";
 import {
@@ -34,10 +33,7 @@ import {
   OPENAI_CODEX_PROVIDER_ID,
   openAIProviderUsesCodexRuntimeByDefault,
 } from "../../agents/openai-codex-routing.js";
-import {
-  resolveProviderAuthAliasMap,
-  resolveProviderIdForAuth,
-} from "../../agents/provider-auth-aliases.js";
+import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { createConfigIO } from "../../config/config.js";
 import {
@@ -364,9 +360,8 @@ export async function modelsStatusCommand(
       env: process.env,
       metadataSnapshot,
     };
-    const aliasMap = resolveProviderAuthAliasMap(envLookupParams);
-    const envCandidateMap = resolveProviderEnvApiKeyCandidates(envLookupParams);
-    const authEvidenceMap = resolveProviderEnvAuthEvidence(envLookupParams);
+    const { aliasMap, envCandidateMap, authEvidenceMap } =
+      resolveProviderEnvAuthLookupMaps(envLookupParams);
     for (const provider of listProviderEnvAuthLookupKeys({ envCandidateMap, authEvidenceMap })) {
       if (
         resolveEnvApiKey(provider, process.env, {

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -92,6 +92,19 @@ const mocks = vi.hoisted(() => {
       fal: ["FAL_KEY"],
     }),
     resolveProviderEnvAuthEvidence: vi.fn().mockReturnValue({}),
+    resolveProviderEnvAuthLookupMaps: vi.fn().mockReturnValue({
+      aliasMap: { "codex-cli": "openai-codex" },
+      envCandidateMap: {
+        anthropic: ["ANTHROPIC_API_KEY"],
+        google: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+        minimax: ["MINIMAX_API_KEY"],
+        "minimax-portal": ["MINIMAX_OAUTH_TOKEN", "MINIMAX_API_KEY"],
+        openai: ["OPENAI_API_KEY"],
+        "openai-codex": ["OPENAI_OAUTH_TOKEN"],
+        fal: ["FAL_KEY"],
+      },
+      authEvidenceMap: {},
+    }),
     listProviderEnvAuthLookupKeys: vi
       .fn()
       .mockImplementation(() => [
@@ -206,6 +219,7 @@ vi.mock("../../agents/model-auth-env-vars.js", () => ({
   listProviderEnvAuthLookupKeys: mocks.listProviderEnvAuthLookupKeys,
   resolveProviderEnvApiKeyCandidates: mocks.resolveProviderEnvApiKeyCandidates,
   resolveProviderEnvAuthEvidence: mocks.resolveProviderEnvAuthEvidence,
+  resolveProviderEnvAuthLookupMaps: mocks.resolveProviderEnvAuthLookupMaps,
   listKnownProviderEnvApiKeyNames: mocks.listKnownProviderEnvApiKeyNames,
 }));
 vi.mock("../../agents/provider-auth-aliases.js", () => ({

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -88,6 +88,11 @@ vi.mock("../agents/provider-auth-aliases.js", () => ({
 
 vi.mock("../secrets/provider-env-vars.js", () => ({
   getProviderEnvVars: vi.fn((provider: string) => providerEnvVarsById[provider] ?? []),
+  resolveProviderAuthLookupMaps: () => ({
+    aliasMap: {},
+    envCandidateMap: {},
+    authEvidenceMap: {},
+  }),
 }));
 
 function requireRecord(value: unknown, label: string): Record<string, unknown> {

--- a/src/config/io.shell-env-expected-keys.test.ts
+++ b/src/config/io.shell-env-expected-keys.test.ts
@@ -9,6 +9,11 @@ vi.mock("../secrets/channel-env-vars.js", () => ({
 
 vi.mock("../secrets/provider-env-vars.js", () => ({
   listKnownProviderAuthEnvVarNames,
+  resolveProviderAuthLookupMaps: () => ({
+    aliasMap: {},
+    envCandidateMap: {},
+    authEvidenceMap: {},
+  }),
 }));
 
 describe("config io shell env expected keys", () => {

--- a/src/infra/provider-usage.auth.plugin.test.ts
+++ b/src/infra/provider-usage.auth.plugin.test.ts
@@ -54,6 +54,14 @@ vi.mock("../secrets/provider-env-vars.js", () => ({
     anthropic: ["ANTHROPIC_API_KEY"],
     minimax: ["MINIMAX_CODE_PLAN_KEY"],
   }),
+  resolveProviderAuthLookupMaps: () => ({
+    aliasMap: {},
+    envCandidateMap: {
+      anthropic: ["ANTHROPIC_API_KEY"],
+      minimax: ["MINIMAX_CODE_PLAN_KEY"],
+    },
+    authEvidenceMap: {},
+  }),
 }));
 
 let resolveProviderAuths: typeof import("./provider-usage.auth.js").resolveProviderAuths;

--- a/src/plugins/provider-auth-env-trust.test.ts
+++ b/src/plugins/provider-auth-env-trust.test.ts
@@ -4,6 +4,11 @@ const getProviderEnvVars = vi.hoisted(() => vi.fn(() => ["WHISPERX_API_KEY"]));
 
 vi.mock("../secrets/provider-env-vars.js", () => ({
   getProviderEnvVars,
+  resolveProviderAuthLookupMaps: () => ({
+    aliasMap: {},
+    envCandidateMap: {},
+    authEvidenceMap: {},
+  }),
 }));
 
 describe("provider auth env trust", () => {

--- a/src/secrets/provider-env-vars.dynamic.test.ts
+++ b/src/secrets/provider-env-vars.dynamic.test.ts
@@ -8,6 +8,7 @@ import {
   PROVIDER_ENV_VARS,
   resolveProviderAuthEnvVarCandidates,
   resolveProviderAuthEvidence,
+  resolveProviderAuthLookupMaps,
 } from "./provider-env-vars.js";
 
 type MockManifestRegistry = {
@@ -621,6 +622,51 @@ describe("provider env vars dynamic manifest metadata", () => {
     resolveProviderAuthEnvVarCandidates({ config: {} });
 
     // Verify it was only called once, proving alias resolution reused the snapshot and did not perform a second cold load!
+    expect(pluginRegistryMocks.loadPluginMetadataSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves alias, env, and evidence lookup maps from one metadata snapshot", () => {
+    pluginRegistryMocks.loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
+      plugins: [
+        {
+          id: "external-fireworks",
+          origin: "global",
+          providerAuthEnvVars: {
+            fireworks: ["FIREWORKS_ALT_API_KEY"],
+          },
+          providerAuthAliases: {
+            "fireworks-plan": "fireworks",
+          },
+          setup: {
+            providers: [
+              {
+                id: "fireworks",
+                authEvidence: [
+                  {
+                    type: "local-file-with-env",
+                    fileEnvVar: "FIREWORKS_CREDENTIALS",
+                    credentialMarker: "fireworks-local-credentials",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    const lookupMaps = resolveProviderAuthLookupMaps({ config: {} });
+
+    expect(lookupMaps.aliasMap["fireworks-plan"]).toBe("fireworks");
+    expect(lookupMaps.envCandidateMap["fireworks-plan"]).toEqual(["FIREWORKS_ALT_API_KEY"]);
+    expect(lookupMaps.authEvidenceMap["fireworks-plan"]).toEqual([
+      {
+        type: "local-file-with-env",
+        fileEnvVar: "FIREWORKS_CREDENTIALS",
+        credentialMarker: "fireworks-local-credentials",
+      },
+    ]);
     expect(pluginRegistryMocks.loadPluginMetadataSnapshot).toHaveBeenCalledTimes(1);
   });
 

--- a/src/secrets/provider-env-vars.dynamic.test.ts
+++ b/src/secrets/provider-env-vars.dynamic.test.ts
@@ -598,4 +598,69 @@ describe("provider env vars dynamic manifest metadata", () => {
       }),
     ).toEqual(["WHISPERX_API_KEY"]);
   });
+
+  it("only loads plugin metadata snapshot once when resolving env var candidates, avoiding duplicate snapshot loads", () => {
+    pluginRegistryMocks.loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
+      plugins: [
+        {
+          id: "external-fireworks",
+          origin: "global",
+          providerAuthEnvVars: {
+            fireworks: ["FIREWORKS_ALT_API_KEY"],
+          },
+          providerAuthAliases: {
+            "fireworks-plan": "fireworks",
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    pluginRegistryMocks.loadPluginMetadataSnapshot.mockClear();
+
+    resolveProviderAuthEnvVarCandidates({ config: {} });
+
+    // Verify it was only called once, proving alias resolution reused the snapshot and did not perform a second cold load!
+    expect(pluginRegistryMocks.loadPluginMetadataSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reuse a load-path current snapshot for default provider env lookups without parameters", () => {
+    const staleSnapshot = {
+      index: {
+        plugins: [
+          {
+            pluginId: "load-path-provider",
+            origin: "global",
+            enabled: true,
+            enabledByDefault: true,
+          },
+        ],
+      },
+      plugins: [
+        {
+          id: "load-path-provider",
+          origin: "global",
+          providerAuthEnvVars: {
+            "load-path-provider": ["LOAD_PATH_PROVIDER_API_KEY"],
+          },
+        },
+      ],
+    };
+    pluginRegistryMocks.getCurrentPluginMetadataSnapshot.mockImplementation(
+      (params: { config?: unknown; requireDefaultDiscoveryContext?: boolean }) => {
+        if (params.config || params.requireDefaultDiscoveryContext) {
+          return undefined;
+        }
+        return staleSnapshot;
+      },
+    );
+
+    expect(resolveProviderAuthEnvVarCandidates()["load-path-provider"]).toBeUndefined();
+    expect(pluginRegistryMocks.getCurrentPluginMetadataSnapshot).toHaveBeenCalledWith({
+      env: process.env,
+      allowWorkspaceScopedSnapshot: true,
+      requireDefaultDiscoveryContext: true,
+    });
+    expect(pluginRegistryMocks.loadPluginMetadataSnapshot).toHaveBeenCalled();
+  });
 });

--- a/src/secrets/provider-env-vars.ts
+++ b/src/secrets/provider-env-vars.ts
@@ -129,18 +129,28 @@ function resolveProviderMetadataSnapshot(
   if (params?.metadataSnapshot) {
     return params.metadataSnapshot;
   }
-  const config = params?.config ?? {};
+  const config = params?.config;
   const env = params?.env ?? process.env;
-  const current = getCurrentPluginMetadataSnapshot({
-    config,
-    env,
-    ...(params?.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
-    allowWorkspaceScopedSnapshot: true,
-  });
+  let current: PluginMetadataSnapshot | undefined;
+  if (config) {
+    current = getCurrentPluginMetadataSnapshot({
+      config,
+      env,
+      ...(params?.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
+      allowWorkspaceScopedSnapshot: true,
+    });
+  } else {
+    current = getCurrentPluginMetadataSnapshot({
+      env,
+      ...(params?.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
+      allowWorkspaceScopedSnapshot: true,
+      requireDefaultDiscoveryContext: true,
+    });
+  }
   if (current) {
     return current;
   }
-  if (normalizePluginsConfig(config.plugins).loadPaths.length === 0) {
+  if (config && normalizePluginsConfig(config.plugins).loadPaths.length === 0) {
     const unscopedCurrent = getCurrentPluginMetadataSnapshot({
       env,
       ...(params?.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
@@ -152,7 +162,7 @@ function resolveProviderMetadataSnapshot(
     }
   }
   return loadPluginMetadataSnapshot({
-    config,
+    config: config ?? {},
     workspaceDir: params?.workspaceDir,
     env,
     preferPersisted: false,
@@ -179,7 +189,10 @@ function resolveManifestProviderAuthEnvVarCandidates(
       appendUniqueEnvVarCandidates(candidates, provider.id, provider.envVars ?? []);
     }
   }
-  const aliases = resolveProviderAuthAliasMap(params);
+  const aliases = resolveProviderAuthAliasMap({
+    ...params,
+    metadataSnapshot: snapshot,
+  });
   for (const [alias, target] of Object.entries(aliases).toSorted(([left], [right]) =>
     left.localeCompare(right),
   )) {
@@ -210,7 +223,10 @@ function resolveManifestProviderAuthEvidence(
       appendUniqueAuthEvidence(evidenceByProvider, provider.id, provider.authEvidence ?? []);
     }
   }
-  const aliases = resolveProviderAuthAliasMap(params);
+  const aliases = resolveProviderAuthAliasMap({
+    ...params,
+    metadataSnapshot: snapshot,
+  });
   for (const [alias, target] of Object.entries(aliases).toSorted(([left], [right]) =>
     left.localeCompare(right),
   )) {

--- a/src/secrets/provider-env-vars.ts
+++ b/src/secrets/provider-env-vars.ts
@@ -48,6 +48,12 @@ export type ProviderAuthEvidence = {
   source?: string;
 };
 
+export type ProviderAuthLookupMaps = {
+  aliasMap: Readonly<Record<string, string>>;
+  envCandidateMap: Readonly<Record<string, readonly string[]>>;
+  authEvidenceMap: Readonly<Record<string, readonly ProviderAuthEvidence[]>>;
+};
+
 function isWorkspacePluginTrustedForProviderEnvVars(
   plugin: PluginManifestRecord,
   config: OpenClawConfig | undefined,
@@ -173,6 +179,18 @@ function resolveManifestProviderAuthEnvVarCandidates(
   params?: ProviderEnvVarLookupParams,
 ): Record<string, string[]> {
   const snapshot = resolveProviderMetadataSnapshot(params);
+  const aliases = resolveProviderAuthAliasMap({
+    ...params,
+    metadataSnapshot: snapshot,
+  });
+  return resolveManifestProviderAuthEnvVarCandidatesFromSnapshot(params, snapshot, aliases);
+}
+
+function resolveManifestProviderAuthEnvVarCandidatesFromSnapshot(
+  params: ProviderEnvVarLookupParams | undefined,
+  snapshot: PluginMetadataSnapshot,
+  aliases: Readonly<Record<string, string>>,
+): Record<string, string[]> {
   const candidates: Record<string, string[]> = {};
   for (const plugin of snapshot.plugins) {
     if (!shouldUsePluginProviderEnvVars(plugin, params)) {
@@ -189,10 +207,6 @@ function resolveManifestProviderAuthEnvVarCandidates(
       appendUniqueEnvVarCandidates(candidates, provider.id, provider.envVars ?? []);
     }
   }
-  const aliases = resolveProviderAuthAliasMap({
-    ...params,
-    metadataSnapshot: snapshot,
-  });
   for (const [alias, target] of Object.entries(aliases).toSorted(([left], [right]) =>
     left.localeCompare(right),
   )) {
@@ -208,6 +222,18 @@ function resolveManifestProviderAuthEvidence(
   params?: ProviderEnvVarLookupParams,
 ): Record<string, ProviderAuthEvidence[]> {
   const snapshot = resolveProviderMetadataSnapshot(params);
+  const aliases = resolveProviderAuthAliasMap({
+    ...params,
+    metadataSnapshot: snapshot,
+  });
+  return resolveManifestProviderAuthEvidenceFromSnapshot(params, snapshot, aliases);
+}
+
+function resolveManifestProviderAuthEvidenceFromSnapshot(
+  params: ProviderEnvVarLookupParams | undefined,
+  snapshot: PluginMetadataSnapshot,
+  aliases: Readonly<Record<string, string>>,
+): Record<string, ProviderAuthEvidence[]> {
   const evidenceByProvider: Record<string, ProviderAuthEvidence[]> = {};
   for (const plugin of snapshot.plugins) {
     if (
@@ -223,10 +249,6 @@ function resolveManifestProviderAuthEvidence(
       appendUniqueAuthEvidence(evidenceByProvider, provider.id, provider.authEvidence ?? []);
     }
   }
-  const aliases = resolveProviderAuthAliasMap({
-    ...params,
-    metadataSnapshot: snapshot,
-  });
   for (const [alias, target] of Object.entries(aliases).toSorted(([left], [right]) =>
     left.localeCompare(right),
   )) {
@@ -251,6 +273,25 @@ export function resolveProviderAuthEvidence(
   params?: ProviderEnvVarLookupParams,
 ): Record<string, readonly ProviderAuthEvidence[]> {
   return resolveManifestProviderAuthEvidence(params);
+}
+
+export function resolveProviderAuthLookupMaps(
+  params?: ProviderEnvVarLookupParams,
+): ProviderAuthLookupMaps {
+  const snapshot = resolveProviderMetadataSnapshot(params);
+  const lookupParams = {
+    ...params,
+    metadataSnapshot: snapshot,
+  };
+  const aliasMap = resolveProviderAuthAliasMap(lookupParams);
+  return {
+    aliasMap,
+    envCandidateMap: {
+      ...resolveManifestProviderAuthEnvVarCandidatesFromSnapshot(params, snapshot, aliasMap),
+      ...CORE_PROVIDER_AUTH_ENV_VAR_CANDIDATES,
+    },
+    authEvidenceMap: resolveManifestProviderAuthEvidenceFromSnapshot(params, snapshot, aliasMap),
+  };
 }
 
 export function resolveProviderEnvVars(

--- a/test/helpers/media-generation/runtime-module-mocks.ts
+++ b/test/helpers/media-generation/runtime-module-mocks.ts
@@ -68,6 +68,11 @@ const mediaRuntimeMocks = vi.hoisted(() => {
         : undefined;
     }),
     resolveProviderAuthEnvVarCandidates: vi.fn(() => ({})),
+    resolveProviderAuthLookupMaps: vi.fn(() => ({
+      aliasMap: {},
+      envCandidateMap: {},
+      authEvidenceMap: {},
+    })),
     debug,
     warn,
   };
@@ -98,6 +103,7 @@ vi.mock("../../../src/logging/subsystem.js", () => ({
 vi.mock("../../../src/secrets/provider-env-vars.js", () => ({
   getProviderEnvVars: mediaRuntimeMocks.getProviderEnvVars,
   resolveProviderAuthEnvVarCandidates: mediaRuntimeMocks.resolveProviderAuthEnvVarCandidates,
+  resolveProviderAuthLookupMaps: mediaRuntimeMocks.resolveProviderAuthLookupMaps,
 }));
 
 vi.mock("../../../src/image-generation/model-ref.js", () => ({

--- a/test/helpers/media-generation/runtime-test-mocks.ts
+++ b/test/helpers/media-generation/runtime-test-mocks.ts
@@ -16,6 +16,7 @@ export type GenerationRuntimeMocks = {
   getProvider: ResettableReturnMock;
   getProviderEnvVars: ResettableReturnMock;
   resolveProviderAuthEnvVarCandidates: ResettableReturnMock;
+  resolveProviderAuthLookupMaps: ResettableReturnMock;
   isFailoverError: ResettableReturnMock;
   listProviders: ResettableReturnMock;
   parseModelRef: ClearableMock;
@@ -33,6 +34,12 @@ export function resetGenerationRuntimeMocks(mocks: GenerationRuntimeMocks): void
   mocks.getProviderEnvVars.mockReturnValue([]);
   mocks.resolveProviderAuthEnvVarCandidates.mockReset();
   mocks.resolveProviderAuthEnvVarCandidates.mockReturnValue({});
+  mocks.resolveProviderAuthLookupMaps.mockReset();
+  mocks.resolveProviderAuthLookupMaps.mockReturnValue({
+    aliasMap: {},
+    envCandidateMap: {},
+    authEvidenceMap: {},
+  });
   mocks.isFailoverError.mockReset();
   mocks.isFailoverError.mockReturnValue(false);
   mocks.listProviders.mockReset();


### PR DESCRIPTION
## Summary

What problem does this PR solve?
- This PR resolves a performance bottleneck where the multi-channel AI gateway unnecessarily scans the disk for plugin manifests, causing higher latency during startup, model-auth, and environment loading paths.
- It eliminates a top-level ESM side-effect in `model-auth-env-vars.ts` which executed a full candidate resolution on import.
- It eliminates config object degradation (collapsing `config` to `{}` on default fallback) which caused cache fingerprint mismatches and cache bypass.
- It propagates metadata snapshots to alias map resolutions to prevent duplicate cold load operations.

Why does this matter now?
- Cold startup and tool selection are critical hot paths in the OpenClaw gateway; avoiding redundant file system operations directly translates to better scalability and zero unnecessary disk overhead during Gateway startup and client connection.

What is the intended outcome?
- Fast, pure memory-based resolutions when snapshots are available.
- Zero ESM import side-effects.
- Complete type-safety and robust test assertions.

What is intentionally out of scope?
- Optimization of the actual disk-scan algorithm or other parts of the plugins loaders (PR 1 and PR 2 address other cache aspects).

What does success look like?
- All tests pass, tsgo compilation succeeds with no type errors, and resolving credentials requires only 1 snapshot load instead of 2.

What should reviewers focus on?
- Verification of snapshot passing into `resolveProviderAuthAliasMap` inside `src/secrets/provider-env-vars.ts`.
- Absence of `PROVIDER_ENV_API_KEY_CANDIDATES` in non-test production code.

- [x] Mark as AI-assisted in the PR description

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

Yes, requested as part of the performance part 2 proposal.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Eliminate ESM top-level autostart and propagate metadata snapshots to resolveProviderAuthAliasMap within provider-env-vars.ts, avoiding duplicate snapshot loading and preventing snapshot fingerprint mismatch.
- Real environment tested: Win32 10.0.26200, PowerShell / Bash, Node 22.19.0
- Exact steps or command run after this patch: Run following code
```js
import { performance } from "node:perf_hooks";
import { setCurrentPluginMetadataSnapshot } from "../src/plugins/current-plugin-metadata-snapshot.js";
import type { PluginMetadataSnapshot } from "../src/plugins/plugin-metadata-snapshot.types.js";

const dummySnapshot = {
  policyHash: "dummy-policy-hash",
  index: { plugins: [] },
  registryDiagnostics: [],
  manifestRegistry: { plugins: [] },
  plugins: [
    {
      id: "plugin-a",
      origin: "global",
      providerAuthEnvVars: {
        provider1: ["PROVIDER_1_API_KEY"],
      },
      providerAuthAliases: {
        "alias-1": "provider1",
      },
    },
  ],
  diagnostics: [],
  byPluginId: new Map(),
  normalizePluginId: (id: string) => id,
  owners: {
    channels: new Map(),
    channelConfigs: new Map(),
    providers: new Map(),
    modelCatalogProviders: new Map(),
    cliBackends: new Map(),
    setupProviders: new Map(),
    commandAliases: new Map(),
    contracts: new Map(),
  },
  metrics: {
    registrySnapshotMs: 0,
    manifestRegistryMs: 0,
    ownerMapsMs: 0,
    totalMs: 0,
    indexPluginCount: 1,
    manifestPluginCount: 1,
  },
} as unknown as PluginMetadataSnapshot;

async function run() {
  console.log("=== OpenClaw Performance Benchmark (Auth Env & Secrets) ===");

  setCurrentPluginMetadataSnapshot(dummySnapshot, {
    config: {},
  });

  const module = await import("../src/agents/model-auth-env-vars.js");

  for (let i = 0; i < 1000; i++) {
    module.resolveProviderEnvApiKeyCandidates();
  }

  const start = performance.now();
  for (let i = 0; i < 10000; i++) {
    module.resolveProviderEnvApiKeyCandidates();
  }
  const elapsed = performance.now() - start;

  console.log(`10,000 iterations of resolveProviderEnvApiKeyCandidates() took: ${elapsed.toFixed(3)} ms`);
  console.log(`Average latency per resolution: ${(elapsed / 10000).toFixed(6)} ms`);
  console.log("========================================================\n");
}

run().catch(console.error);
```  
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): We ran a performance micro-benchmark measuring snapshot resolution times before and after this patch using an active dummy snapshot to evaluate in-memory propagation.
  - Before the Patch (With snapshot cache bypass / duplicate load)
  ```
  === OpenClaw Performance Benchmark (Auth Env & Secrets) ===
  10,000 iterations of resolveProviderEnvApiKeyCandidates() took: 9037.665 ms
  Average latency per resolution: 0.903767 ms
  ========================================================
  ```

  - After the Patch (With warm snapshot propagation)
  ```
  === OpenClaw Performance Benchmark (Auth Env & Secrets) ===
  10,000 iterations of resolveProviderEnvApiKeyCandidates() took: 4508.109 ms
  Average latency per resolution: 0.450811 ms
  ========================================================
  ```

- Observed result after fix: 
  - Resolving env-var candidates on a warm snapshot is **exactly twice as fast** (latency cut by 50% from 0.90ms to 0.45ms), completely bypassing the duplicate snapshot lookup in provider alias mapping.
  - The newly introduced test verifying default snapshot isolation passes perfectly. All 17 tests in `provider-env-vars.dynamic.test.ts` are green.
- What was not tested: Integration of actual cloud providers on a live staging server (which is out of scope for pure static metadata snapshot propagation checks).
- Proof limitations or environment constraints: Tested locally on Windows host.

## Tests and validation

Which commands did you run?
- `pnpm exec vitest run --config test/vitest/vitest.secrets.config.ts src/secrets/provider-env-vars.dynamic.test.ts`
- `pnpm exec vitest run --config test/vitest/vitest.agents.config.ts src/agents/model-auth.profiles.test.ts`
- `pnpm check:test-types`

What regression coverage was added or updated?
- Added `only loads plugin metadata snapshot once when resolving env var candidates, avoiding duplicate snapshot loads` in `provider-env-vars.dynamic.test.ts`.
- Added `does not reuse a load-path current snapshot for default provider env lookups without parameters` in `provider-env-vars.dynamic.test.ts` to enforce default snapshot isolation and prevent fingerprint mismatches.

What failed before this fix, if known?
- Not a functional failure, but a performance bottleneck where loading provider credentials would cause a redundant duplicate scan of plugin metadata on disk due to missing snapshot propagation in auth alias resolution, and loading `model-auth-env-vars` module always triggered an early disk scan.

## Risk checklist

Did user-visible behavior change? (`No`)

Did config, environment, or migration behavior change? (`No`)

Did security, auth, secrets, network, or tool execution behavior change? (`Yes`)
- Yes, credential resolution became faster by reusing already resolved in-memory snapshot contexts instead of cold loading them again.

What is the highest-risk area?
- Type soundness of optional config references and optional chain usages.

How is that risk mitigated?
- Fully checked by `tsgo` compiler across all core and extension packages, and fully covered by extensive existing auth unit tests.

## Current review state

What is the next action?
- Waiting for maintainer review.

What is still waiting on author, maintainer, CI, or external proof?
- None.

Which bot or reviewer comments were addressed?
- None.
