### PR TITLE
fix(openai): add Responses message type discriminators

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2022,6 +2022,48 @@ describe("openai transport stream", () => {
     expect(params.input?.[0]?.role).toBe("developer");
   });
 
+  it("adds message type discriminators for Foundry-compatible Responses system and user input items", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.4-codex",
+        name: "GPT-5.4 Codex",
+        api: "openai-responses",
+        provider: "microsoft-foundry",
+        baseUrl: "https://example.services.ai.azure.com/api/projects/proj/openai/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-responses">,
+      {
+        systemPrompt: "You are concise.",
+        messages: [{ role: "user", content: "hello", timestamp: 1 }],
+        tools: [],
+      } as never,
+      undefined,
+    ) as {
+      input?: Array<{
+        type?: string;
+        role?: string;
+        content?: Array<{ type?: string; text?: string }>;
+      }>;
+    };
+
+    expect(params.input).toEqual([
+      {
+        type: "message",
+        role: "system",
+        content: [{ type: "input_text", text: "You are concise." }],
+      },
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "hello" }],
+      },
+    ]);
+  });
+
   it("uses model maxTokens for Responses params when runtime maxTokens is omitted", () => {
     const params = buildOpenAIResponsesParams(
       {
@@ -2982,6 +3024,7 @@ describe("openai transport stream", () => {
     expect(params.instructions).toBe("Stable prefix\nDynamic suffix");
     expect(params.input).toEqual([
       {
+        type: "message",
         role: "user",
         content: [{ type: "input_text", text: " " }],
       },
@@ -3353,9 +3396,11 @@ describe("openai transport stream", () => {
         tools: [],
       } as never,
       undefined,
-    ) as { input?: Array<{ content?: string }> };
+    ) as { input?: Array<{ content?: Array<{ type?: string; text?: string }> }> };
 
-    expect(params.input?.[0]?.content).toBe("Stable prefix\nDynamic suffix");
+    expect(params.input?.[0]?.content).toEqual([
+      { type: "input_text", text: "Stable prefix\nDynamic suffix" },
+    ]);
   });
 
   it("defaults responses tool schemas to strict on native OpenAI routes", () => {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -997,6 +997,17 @@ function parseTextSignature(
   return { id: signature };
 }
 
+function buildResponsesInputTextContent(text: string): ResponseInputMessageContentList {
+  return [{ type: "input_text", text }] as ResponseInputMessageContentList;
+}
+
+function buildResponsesMessageInputItem(
+  role: "system" | "developer" | "user",
+  content: ResponseInputMessageContentList,
+): ResponseInputItem {
+  return { type: "message", role, content } as ResponseInputItem;
+}
+
 function convertResponsesMessages(
   model: Model<Api>,
   context: Context,
@@ -1065,19 +1076,25 @@ function convertResponsesMessages(
   );
   const includeSystemPrompt = options?.includeSystemPrompt ?? true;
   if (includeSystemPrompt && context.systemPrompt) {
-    messages.push({
-      role: model.reasoning && options?.supportsDeveloperRole !== false ? "developer" : "system",
-      content: sanitizeTransportPayloadText(stripSystemPromptCacheBoundary(context.systemPrompt)),
-    });
+    messages.push(
+      buildResponsesMessageInputItem(
+        model.reasoning && options?.supportsDeveloperRole !== false ? "developer" : "system",
+        buildResponsesInputTextContent(
+          sanitizeTransportPayloadText(stripSystemPromptCacheBoundary(context.systemPrompt)),
+        ),
+      ),
+    );
   }
   let msgIndex = 0;
   for (const msg of transformedMessages) {
     if (msg.role === "user") {
       if (typeof msg.content === "string") {
-        messages.push({
-          role: "user",
-          content: [{ type: "input_text", text: sanitizeTransportPayloadText(msg.content) }],
-        });
+        messages.push(
+          buildResponsesMessageInputItem(
+            "user",
+            buildResponsesInputTextContent(sanitizeTransportPayloadText(msg.content)),
+          ),
+        );
       } else {
         const content = (
           msg.content.map((item) =>
@@ -1091,7 +1108,7 @@ function convertResponsesMessages(
           ) as ResponseInputMessageContentList
         ).filter((item) => model.input.includes("image") || item.type !== "input_image");
         if (content.length > 0) {
-          messages.push({ role: "user", content });
+          messages.push(buildResponsesMessageInputItem("user", content));
         }
       }
     } else if (msg.role === "assistant") {
@@ -1990,6 +2007,7 @@ function ensureOpenAICodexResponsesInput(messages: ResponseInput, context: Conte
     );
   }
   messages.push({
+    type: "message",
     role: "user",
     content: [{ type: "input_text", text: OPENAI_CODEX_RESPONSES_EMPTY_INPUT_TEXT }],
   });


### PR DESCRIPTION
Azure AI Foundry Responses endpoints reject OpenClaw turns because user/system input items miss the explicit `type: "message"` discriminator that Foundry requires.

Fixes #84109.

## Affected surface

- `src/agents/openai-transport-stream.ts`
  - `convertResponsesMessages()`
  - `ensureOpenAICodexResponsesInput()`
- `src/agents/openai-transport-stream.test.ts`

## Scope

- Adds the existing OpenAI Responses message discriminator to shared system/developer/user input message items.
- Keeps assistant replay items, reasoning replay items, function calls, and function-call outputs unchanged.
- Does not add a config flag, provider-specific workaround, or Azure SDK transport change.

## Real behavior proof

RED, current main failed the focused regression:

```text
pnpm test src/agents/openai-transport-stream.test.ts -t "adds message type discriminators"

FAIL  src/agents/openai-transport-stream.test.ts > openai transport stream > adds message type discriminators for Foundry-compatible Responses input items
AssertionError: expected ... type: "message" ...

Received system/user input items only had role/content; the user item lacked type and the system prompt used string content.
```

GREEN, current head:

```text
pnpm test src/agents/openai-transport-stream.test.ts -t "adds message type discriminators"
Test Files  1 passed (1)
Tests  1 passed | 192 skipped (193)

pnpm test src/agents/openai-transport-stream.test.ts
Test Files  1 passed (1)
Tests  193 passed (193)

pnpm test src/agents/openai-transport-stream.test.ts src/agents/pi-embedded-runner-extraparams.test.ts extensions/microsoft-foundry/index.test.ts
Test Files  2 passed (agents shard)
Tests  320 passed
Test Files  1 passed (extension-providers shard)
Tests  29 passed

pnpm check:changed --base origin/main
passed

git diff --check origin/main
passed

node scripts/check-no-conflict-markers.mjs
passed

gitleaks protect --staged --redact
no leaks found
```

## Coverage note

Push-before-PR searches were rerun from latest `origin/main`:

```text
gh search prs --repo openclaw/openclaw --state open "Fixes #84109"
no results

gh search prs --repo openclaw/openclaw --state open "#84109"
#74163 WORKING: All Microsoft Issues and PRs (refresh) - draft tracker only, not an implementation PR

gh search prs --repo openclaw/openclaw --state open "convertResponsesMessages"
Responses replay / training-export adjacent PRs only; none add Foundry message discriminators

gh search prs --repo openclaw/openclaw --state open "openai-transport-stream type message"
no results

gh search prs --repo openclaw/openclaw --state open "Azure Foundry Responses type message"
no results
```

## What was not tested

- No live Azure AI Foundry request was run from this executor.
- No change was made to the `azure-openai-responses` SDK transport or `api-version` behavior; this PR fixes the shared `openai-responses` request shape that the Microsoft Foundry provider already uses.
