### PR TITLE
test(cli): add focused coverage for node CLI daemon and command registry

### DIFF
--- a/src/cli/node-cli/daemon.test.ts
+++ b/src/cli/node-cli/daemon.test.ts
@@ -2,7 +2,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayServiceRuntime } from "../../daemon/service-runtime.js";
 import type { GatewayServiceCommandConfig } from "../../daemon/service-types.js";
-import { runNodeDaemonInstall, runNodeDaemonStatus } from "./daemon.js";
+import {
+  runNodeDaemonInstall,
+  runNodeDaemonRestart,
+  runNodeDaemonStart,
+  runNodeDaemonStatus,
+  runNodeDaemonStop,
+  runNodeDaemonUninstall,
+} from "./daemon.js";
 
 const mocks = vi.hoisted(() => {
   const service = {
@@ -31,7 +38,12 @@ const mocks = vi.hoisted(() => {
       environment: {},
       environmentValueSources: {},
     })),
+    failIfNixDaemonInstallMode: vi.fn(() => false),
     loadNodeHostConfig: vi.fn(),
+    runServiceRestart: vi.fn(),
+    runServiceStart: vi.fn(),
+    runServiceStop: vi.fn(),
+    runServiceUninstall: vi.fn(),
   };
 });
 
@@ -49,6 +61,13 @@ vi.mock("../../commands/node-daemon-install-helpers.js", () => ({
 
 vi.mock("../../node-host/config.js", () => ({
   loadNodeHostConfig: mocks.loadNodeHostConfig,
+}));
+
+vi.mock("../daemon-cli/lifecycle-core.js", () => ({
+  runServiceRestart: mocks.runServiceRestart,
+  runServiceStart: mocks.runServiceStart,
+  runServiceStop: mocks.runServiceStop,
+  runServiceUninstall: mocks.runServiceUninstall,
 }));
 
 vi.mock("../../daemon/runtime-hints.js", () => ({
@@ -85,7 +104,7 @@ vi.mock("../daemon-cli/shared.js", async () => {
     }),
     formatRuntimeStatus: (runtime: GatewayServiceRuntime | undefined) => runtime?.status ?? "",
     resolveRuntimeStatusColor: () => "",
-    failIfNixDaemonInstallMode: () => false,
+    failIfNixDaemonInstallMode: mocks.failIfNixDaemonInstallMode,
   };
 });
 
@@ -95,6 +114,7 @@ describe("runNodeDaemonInstall", () => {
     mocks.runtime.error.mockClear();
     mocks.runtime.writeJson.mockClear();
     mocks.runtime.exit.mockClear();
+    mocks.failIfNixDaemonInstallMode.mockReset().mockReturnValue(false);
     mocks.service.install.mockReset().mockResolvedValue(undefined);
     mocks.service.isLoaded.mockReset().mockResolvedValue(false);
     mocks.buildNodeInstallPlan.mockReset().mockResolvedValue({
@@ -179,6 +199,129 @@ describe("runNodeDaemonInstall", () => {
       expect.stringContaining("--no-tls cannot be combined with --tls-fingerprint"),
     );
   });
+
+  it("rejects an invalid explicit port", async () => {
+    await runNodeDaemonInstall({ port: "abc" });
+
+    expect(mocks.runtime.error).toHaveBeenCalledWith(expect.stringContaining("Invalid --port"));
+    expect(mocks.service.install).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid saved gateway port", async () => {
+    mocks.loadNodeHostConfig.mockResolvedValue({
+      gateway: { host: "127.0.0.1", port: 0 },
+    });
+
+    await runNodeDaemonInstall({});
+
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid node.gateway.port"),
+    );
+    expect(mocks.service.install).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unsupported service runtime", async () => {
+    await runNodeDaemonInstall({ runtime: "deno" });
+
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid --runtime (use "node"'),
+    );
+    expect(mocks.service.install).not.toHaveBeenCalled();
+  });
+
+  it("returns already-installed without replacing a loaded service", async () => {
+    mocks.service.isLoaded.mockResolvedValue(true);
+
+    await runNodeDaemonInstall({ json: true });
+
+    expect(mocks.runtime.writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({ ok: true, result: "already-installed" }),
+    );
+    expect(mocks.buildNodeInstallPlan).not.toHaveBeenCalled();
+    expect(mocks.service.install).not.toHaveBeenCalled();
+  });
+
+  it("replaces a loaded service when force is set", async () => {
+    mocks.service.isLoaded.mockResolvedValue(true);
+
+    await runNodeDaemonInstall({ force: true });
+
+    expect(mocks.buildNodeInstallPlan).toHaveBeenCalledTimes(1);
+    expect(mocks.service.install).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the default gateway endpoint when no saved config exists", async () => {
+    mocks.loadNodeHostConfig.mockResolvedValue(null);
+
+    await runNodeDaemonInstall({ force: true });
+
+    expect(mocks.buildNodeInstallPlan).toHaveBeenCalledWith(
+      expect.objectContaining({ host: "127.0.0.1", port: 18789 }),
+    );
+  });
+
+  it("does not build or install a service in Nix daemon mode", async () => {
+    mocks.failIfNixDaemonInstallMode.mockReturnValue(true);
+
+    await runNodeDaemonInstall({});
+
+    expect(mocks.buildNodeInstallPlan).not.toHaveBeenCalled();
+    expect(mocks.service.install).not.toHaveBeenCalled();
+  });
+});
+
+describe("node daemon lifecycle commands", () => {
+  beforeEach(() => {
+    mocks.runServiceRestart.mockReset();
+    mocks.runServiceStart.mockReset();
+    mocks.runServiceStop.mockReset();
+    mocks.runServiceUninstall.mockReset();
+  });
+
+  it("delegates start with node service hints", async () => {
+    await runNodeDaemonStart({ json: true });
+
+    expect(mocks.runServiceStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceNoun: "Node",
+        renderStartHints: expect.any(Function),
+        opts: { json: true },
+      }),
+    );
+  });
+
+  it("delegates stop to the node service", async () => {
+    await runNodeDaemonStop({ json: true });
+
+    expect(mocks.runServiceStop).toHaveBeenCalledWith(
+      expect.objectContaining({ serviceNoun: "Node", opts: { json: true } }),
+    );
+  });
+
+  it("delegates restart with node service hints", async () => {
+    await runNodeDaemonRestart({ json: true });
+
+    expect(mocks.runServiceRestart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceNoun: "Node",
+        renderStartHints: expect.any(Function),
+        opts: { json: true },
+      }),
+    );
+  });
+
+  it("delegates uninstall without gateway-specific postconditions", async () => {
+    await runNodeDaemonUninstall({ json: true });
+
+    expect(mocks.runServiceUninstall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceNoun: "Node",
+        opts: { json: true },
+        stopBeforeUninstall: false,
+        assertNotLoadedAfterUninstall: false,
+      }),
+    );
+  });
 });
 
 describe("runNodeDaemonStatus", () => {
@@ -211,6 +354,47 @@ describe("runNodeDaemonStatus", () => {
     expect(mocks.runtime.exit).toHaveBeenCalledWith(1);
     expect(stdout()).not.toContain("not loaded");
     expect(stdout()).not.toContain("openclaw node install");
+  });
+
+  it("includes command and runtime details in JSON output", async () => {
+    mocks.service.readCommand.mockResolvedValue({
+      programArguments: ["openclaw", "node", "run"],
+      sourcePath: "/tmp/ai.openclaw.node.plist",
+    });
+    mocks.service.readRuntime.mockResolvedValue({ status: "running" });
+
+    await runNodeDaemonStatus({ json: true });
+
+    expect(mocks.runtime.writeJson).toHaveBeenCalledWith({
+      service: expect.objectContaining({
+        loaded: true,
+        command: expect.objectContaining({
+          programArguments: ["openclaw", "node", "run"],
+          sourcePath: "/tmp/ai.openclaw.node.plist",
+        }),
+        runtime: { status: "running" },
+      }),
+    });
+  });
+
+  it("prints start hints when the service is not loaded", async () => {
+    mocks.service.isLoaded.mockResolvedValue(false);
+
+    await runNodeDaemonStatus();
+
+    expect(stdout()).toContain("openclaw node start");
+  });
+
+  it("reports an unknown runtime when runtime inspection fails", async () => {
+    mocks.service.readRuntime.mockRejectedValue(new Error("permission denied"));
+
+    await runNodeDaemonStatus({ json: true });
+
+    expect(mocks.runtime.writeJson).toHaveBeenCalledWith({
+      service: expect.objectContaining({
+        runtime: { status: "unknown", detail: "Error: permission denied" },
+      }),
+    });
   });
 
   it("reports a failed service check as JSON without inventing node status", async () => {

--- a/src/cli/node-cli/register.test.ts
+++ b/src/cli/node-cli/register.test.ts
@@ -226,4 +226,69 @@ describe("registerNodeCli", () => {
     );
     expect(daemonMocks.defaultRuntime.exit).toHaveBeenCalledWith(1);
   });
+
+  it("forwards install flags (port/host/runtime/force/json) to runNodeDaemonInstall", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(
+      [
+        "node",
+        "install",
+        "--port",
+        "19000",
+        "--host",
+        "10.0.0.10",
+        "--runtime",
+        "bun",
+        "--force",
+        "--json",
+      ],
+      { from: "user" },
+    );
+
+    const installArgs = daemonMocks.runNodeDaemonInstall.mock.calls[0]?.[0];
+    expect(installArgs).toMatchObject({
+      port: "19000",
+      host: "10.0.0.10",
+      runtime: "bun",
+      force: true,
+      json: true,
+    });
+  });
+
+  it("registers node status and forwards --json to runNodeDaemonStatus", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(["node", "status", "--json"], { from: "user" });
+
+    const args = daemonMocks.runNodeDaemonStatus.mock.calls[0]?.[0];
+    expect(args?.json).toBe(true);
+  });
+
+  it("registers node stop and forwards --json to runNodeDaemonStop", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(["node", "stop", "--json"], { from: "user" });
+
+    const args = daemonMocks.runNodeDaemonStop.mock.calls[0]?.[0];
+    expect(args?.json).toBe(true);
+  });
+
+  it("registers node restart and forwards --json to runNodeDaemonRestart", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(["node", "restart", "--json"], { from: "user" });
+
+    const args = daemonMocks.runNodeDaemonRestart.mock.calls[0]?.[0];
+    expect(args?.json).toBe(true);
+  });
+
+  it("registers node uninstall and forwards --json to runNodeDaemonUninstall", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(["node", "uninstall", "--json"], { from: "user" });
+
+    const args = daemonMocks.runNodeDaemonUninstall.mock.calls[0]?.[0];
+    expect(args?.json).toBe(true);
+  });
 });


### PR DESCRIPTION
Closes #83924

## What Problem This Solves

The node daemon entry points and their Commander registration contain branch-heavy install, lifecycle, status, validation, and option-forwarding behavior that was only partially covered. Regressions in these paths could reach users without a focused test failure.

This test-only change adds colocated coverage without changing production source, dependencies, configuration, or release metadata.

## Why This Change Was Made

`src/cli/node-cli/daemon.test.ts` covers install validation, already-installed and force paths, saved gateway/TLS inheritance, Nix rejection, lifecycle delegation, status rendering, runtime failures, recovery hints, and credential redaction.

`src/cli/node-cli/register.test.ts` covers option forwarding for install, status, stop, restart, and uninstall alongside existing node run/start behavior.

## Evidence

- Base: `32c5f0205075b92b2333764a86086a4e56bc248f`
- Head: `6825a8e4baed5e98c7f25634fecdaad677fc0c72`
- Environment: macOS arm64 source checkout, Node.js 24.14.0
- Full source build: `pnpm build` passed

### Real launchd lifecycle

The exact head was built, then exercised against the real per-user macOS launchd service manager. The service did not exist before the proof and was removed afterward.

```text
node openclaw.mjs node status --json
loaded=false, missingUnit=true; ~/Library/LaunchAgents/ai.openclaw.node.plist absent

node openclaw.mjs node install --host 127.0.0.1 --port 19999 \
  --display-name proof-node-86450-6825 --force --json
ok=true, result=installed, loaded=true

node openclaw.mjs node status --json
loaded=true, runtime.status=running, runtime.state=active
programArguments=<built dist/index.js> node run --host 127.0.0.1 --port 19999 --no-tls

node openclaw.mjs node uninstall --json
ok=true, result=uninstalled, loaded=false

node openclaw.mjs node status --json
loaded=false, missingUnit=true; plist absent; launchctl reports no ai.openclaw.node service
```

No external account, gateway, API key, or remote service was used. Sensitive environment values are omitted; the status command itself returned only environment value sources.

### Tests and static checks

```text
node scripts/run-vitest.mjs run \
  src/cli/node-cli/register.test.ts \
  src/cli/node-cli/daemon.test.ts \
  src/commands/node-daemon-install-helpers.test.ts \
  src/cli/daemon-cli/lifecycle-core.test.ts

Test Files  4 passed (4)
Tests       79 passed (79)
```

- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --pretty false` passed.
- Scoped `oxfmt`, `oxlint`, and `git diff --check origin/main...HEAD` passed.
- Local branch autoreview reported no actionable P0-P2 findings (correctness confidence 0.96); TruffleHog was clean.
- The branch changes only the two test files above.
