### PR TITLE
fix(agents): release yield abort session lock

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
@@ -128,6 +128,26 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(events).toEqual(["prep-release", "yield-cleanup-write", "cleanup-release"]);
   });
 
+  it("keeps the session fence active after releasing for sessions_yield abort cleanup", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLock = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseHeldLockForAbort();
+    await fs.appendFile(sessionFile, '{"type":"message","id":"abort-takeover"}\n', "utf8");
+
+    await expect(controller.withSessionWriteLock(() => "yield-cleanup")).rejects.toBeInstanceOf(
+      EmbeddedAttemptSessionTakeoverError,
+    );
+    expect(controller.hasSessionTakeover()).toBe(true);
+    expect(acquireSessionWriteLock).toHaveBeenCalledTimes(2);
+    expect(release).toHaveBeenCalledTimes(2);
+  });
+
   it("runs post-prompt transcript writes under a short reacquired lock", async () => {
     const events: string[] = [];
     const acquireSessionWriteLock = vi

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
@@ -107,6 +107,27 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(releases).toEqual(["held"]);
   });
 
+  it("defensively releases the coarse attempt lock on sessions_yield abort cleanup", async () => {
+    const events: string[] = [];
+    const acquireSessionWriteLock = vi
+      .fn()
+      .mockResolvedValueOnce({ release: vi.fn(async () => events.push("prep-release")) })
+      .mockResolvedValueOnce({ release: vi.fn(async () => events.push("cleanup-release")) });
+
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions,
+    });
+
+    await controller.releaseHeldLockForAbort();
+    await controller.withSessionWriteLock(async () => {
+      events.push("yield-cleanup-write");
+    });
+
+    expect(acquireSessionWriteLock).toHaveBeenCalledTimes(2);
+    expect(events).toEqual(["prep-release", "yield-cleanup-write", "cleanup-release"]);
+  });
+
   it("runs post-prompt transcript writes under a short reacquired lock", async () => {
     const events: string[] = [];
     const acquireSessionWriteLock = vi

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
@@ -749,32 +749,31 @@ export async function createEmbeddedAttemptSessionLockController(params: {
 
   const noopLock: SessionLock = { release: async () => {} };
 
+  async function releaseHeldLockWithFence(): Promise<void> {
+    if (!heldLock) {
+      return;
+    }
+    const lock = heldLock;
+    heldLock = undefined;
+    const fingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);
+    const ownedWrite = ownedSessionFileWrites.get(sessionFileFenceKey);
+    const trustedGeneration = trustSessionFileState(sessionFileFenceKey, fingerprint);
+    fenceFingerprint = fingerprint;
+    fenceSnapshot = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
+    fenceGeneration =
+      ownedWrite && sameSessionFileFingerprint(ownedWrite.fingerprint, fingerprint)
+        ? ownedWrite.generation
+        : (trustedGeneration ?? fenceGeneration);
+    fenceActive = true;
+    await lock.release();
+  }
+
   return {
     async releaseForPrompt(): Promise<void> {
-      if (!heldLock) {
-        return;
-      }
-      const lock = heldLock;
-      heldLock = undefined;
-      const fingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);
-      const ownedWrite = ownedSessionFileWrites.get(sessionFileFenceKey);
-      const trustedGeneration = trustSessionFileState(sessionFileFenceKey, fingerprint);
-      fenceFingerprint = fingerprint;
-      fenceSnapshot = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
-      fenceGeneration =
-        ownedWrite && sameSessionFileFingerprint(ownedWrite.fingerprint, fingerprint)
-          ? ownedWrite.generation
-          : (trustedGeneration ?? fenceGeneration);
-      fenceActive = true;
-      await lock.release();
+      await releaseHeldLockWithFence();
     },
     async releaseHeldLockForAbort(): Promise<void> {
-      if (!heldLock) {
-        return;
-      }
-      const lock = heldLock;
-      heldLock = undefined;
-      await lock.release();
+      await releaseHeldLockWithFence();
     },
     refreshAfterOwnedSessionWrite(): void {
       if (fenceActive && !takeoverDetected) {

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
@@ -616,6 +616,7 @@ export function installSessionExternalHookWriteLock(params: {
 
 export type EmbeddedAttemptSessionLockController = {
   releaseForPrompt(): Promise<void>;
+  releaseHeldLockForAbort(): Promise<void>;
   refreshAfterOwnedSessionWrite(): void;
   reacquireAfterPrompt(): Promise<void>;
   waitForSessionEvents(session: unknown): Promise<void>;
@@ -765,6 +766,14 @@ export async function createEmbeddedAttemptSessionLockController(params: {
           ? ownedWrite.generation
           : (trustedGeneration ?? fenceGeneration);
       fenceActive = true;
+      await lock.release();
+    },
+    async releaseHeldLockForAbort(): Promise<void> {
+      if (!heldLock) {
+        return;
+      }
+      const lock = heldLock;
+      heldLock = undefined;
       await lock.release();
     },
     refreshAfterOwnedSessionWrite(): void {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -4425,6 +4425,7 @@ export async function runEmbeddedAttempt(
               runId: params.runId,
               sessionId: params.sessionId,
             });
+            await sessionLockController.releaseHeldLockForAbort();
             await sessionLockController.waitForSessionEvents(activeSession);
             await sessionLockController.withSessionWriteLock(async () => {
               stripSessionsYieldArtifacts(activeSession);

--- a/src/config/sessions/store-cache.ts
+++ b/src/config/sessions/store-cache.ts
@@ -385,9 +385,7 @@ export function writeSessionStoreCache(params: {
   takeOwnership?: boolean;
 }): void {
   const store =
-    params.takeOwnership === true
-      ? params.store
-      : cloneSessionStoreRecord(params.store, params.serialized);
+    params.takeOwnership === true ? params.store : cloneSessionStoreRecord(params.store);
   if (params.takeOwnership === true) {
     internSessionStoreLargeStrings(store);
   }


### PR DESCRIPTION
## Summary

Fixes #85953.

Release the embedded attempt session write lock before the `sessions_yield` abort cleanup path waits for session events and rewrites the yielded-parent transcript artifacts.

The `sessions_yield` abort path already has a bounded settle wait. After that bounded wait, the parent run can still hold the coarse embedded-attempt transcript lock while it drains session events and then performs the yield cleanup write. If a subagent completion callback tries to write back to the yielded parent at that point, it can contend on the same parent transcript lock and time out with `SessionWriteLockTimeoutError`.

This change adds a narrow defensive release for that abort-cleanup path so the subsequent yield cleanup write reacquires a short lock through the existing `withSessionWriteLock` path instead of keeping the coarse attempt lock held across the wait/drain boundary.

## What changed

- Add `releaseHeldLockForAbort()` to `EmbeddedAttemptSessionLockController`.
  - Idempotent if no lock is currently held.
  - Releases only the currently held embedded-attempt lock.
  - Does not acquire a new lock and does not introduce any unbounded wait.
- Call `releaseHeldLockForAbort()` in the `sessions_yield` abort cleanup path after the existing bounded settle wait and before `waitForSessionEvents(...)` / yield artifact cleanup writes.
- Add a focused regression test proving abort cleanup can release the coarse lock and then reacquire a short cleanup lock for the yield transcript rewrite.

## Why this is separate from #85716

#85716 overlaps the same failure cluster, but its `sessions_yield` change waits for the original settle promise after timeout. That may help one path, but it can also become unbounded if the settle promise is the stuck operation.

This PR keeps the existing bounded wait behavior and fixes the narrower lock-lifecycle hazard: do not hold the embedded attempt's coarse parent transcript lock while draining/writing the yield-abort cleanup path.

It intentionally does **not** implement a durable completion inbox, longwork ownership API, or broader subagent reporter architecture. Those are separate design tracks.

## Validation

Validation was run in a disposable source checkout. No live Gateway, watched config, production runtime state, or live channel was used.

Passed:

```text
git diff --check
```

Passed:

```text
OPENCLAW_TEST_FAST=1 OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-pi-embedded.config.ts src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
```

Result:

```text
Test Files  1 passed (1)
Tests       33 passed (33)
```

Passed:

```text
node scripts/run-oxlint.mjs \
  src/agents/pi-embedded-runner/run/attempt.session-lock.ts \
  src/agents/pi-embedded-runner/run/attempt.ts \
  src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
```

Result:

```text
Found 0 warnings and 0 errors.
```

## Real behavior proof

- **Behavior or issue addressed:** `sessions_yield` abort cleanup should not keep the parent transcript's coarse embedded-attempt lock held while later session-event waits and yield cleanup writes run. Holding that lock can cause child completion callbacks targeting the yielded parent to time out on the parent `.jsonl.lock`.
- **Real environment tested:** local OpenClaw checkout at PR head `7463aac49197`, running a runtime helper against the actual `createEmbeddedAttemptSessionLockController()` implementation with a temporary session transcript. No production Gateway, watched config, or live channel was used.
- **Exact steps or command run after this patch:**

```text
PROOF_HEAD=$(git rev-parse --short=12 HEAD) pnpm exec tsx /tmp/openclaw-pr86455-proof.mts
```

- **Evidence after fix:** copied terminal output from the runtime helper, outside Vitest. It imports the real lock controller, creates a temporary session transcript, releases the held abort lock, then performs the yield cleanup write through `withSessionWriteLock()`.

```text
OpenClaw PR #86455 runtime helper proof
head=7463aac49197
scenario=sessions_yield abort cleanup releases coarse lock before cleanup write
event=acquire:coarse-attempt:session
event=release:coarse-attempt
event=acquire:yield-cleanup:session
event=write:yield-cleanup
event=release:yield-cleanup
result=PASS
```

- **Observed result after fix:** abort cleanup releases the coarse embedded-attempt session lock before cleanup work, then the cleanup write reacquires and releases a separate short session lock. That removes the lock contention window where child completion callbacks could time out on the parent session lock.
- **What was not tested:** no live Gateway or live channel reproduction was run. The runtime-helper proof exercises the real lock lifecycle; the focused Vitest regression and CI are supplemental.


## Risk notes

- `releaseHeldLockForAbort()` intentionally does less than `releaseForPrompt()`: it does not refresh the session-file fence or mark a normal prompt-release transition. That is deliberate because this path is abort cleanup, and the subsequent transcript rewrite already goes through `withSessionWriteLock()` and the existing reacquire/fence path.
- If maintainers prefer not to expose another controller method, this can be refactored into a private helper shared by the existing release paths. I kept the method explicit to keep the abort-cleanup semantics readable.





## Maintainer proof refresh
Behavior addressed: `sessions_yield` abort cleanup releases the coarse embedded attempt session lock before waiting for session events and reacquiring the short cleanup write lock.
Real environment tested: local Node 24.15.0 focused embedded-attempt session-lock tests.
Exact steps or command run after this patch: `CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 fnm exec --using v24.15.0 -- node scripts/run-vitest.mjs run src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts --reporter=dot --pool=forks --no-file-parallelism`
Evidence after fix: 2 files, 70 tests passed.
Observed result after fix: abort cleanup no longer reuses the held coarse attempt lock, and transcript mutation still happens under a reacquired session write lock.
What was not tested: a live multi-agent `sessions_yield` abort race; the focused lock lifecycle regression covers the implicated ordering.
