### PR TITLE
fix(coalescer): merge buffered text into media payload instead of splitting

### DIFF
--- a/src/auto-reply/reply/block-reply-coalescer.ts
+++ b/src/auto-reply/reply/block-reply-coalescer.ts
@@ -6,6 +6,7 @@ import type { BlockStreamingCoalescing } from "./block-streaming.js";
 export type BlockReplyCoalescer = {
   enqueue: (payload: ReplyPayload) => void;
   flush: (options?: { force?: boolean }) => Promise<void>;
+  drainBufferedText: () => string;
   hasBuffered: () => boolean;
   stop: () => void;
 };
@@ -94,8 +95,17 @@ export function createBlockReplyCoalescer(params: {
     const text = reply.text;
     const hasText = reply.hasText;
     if (hasMedia) {
-      void flush({ force: true });
-      void onFlush(payload);
+      if (bufferText) {
+        // Merge buffered text into the media payload so the channel sends one
+        // combined message (text caption + attachment) instead of two.
+        const mergedText = hasText ? `${bufferText}${joiner}${text}` : bufferText;
+        const replyToId = payload.replyToId ?? bufferReplyToId;
+        clearIdleTimer();
+        resetBuffer();
+        void onFlush({ ...payload, text: mergedText, replyToId });
+      } else {
+        void onFlush(payload);
+      }
       return;
     }
     if (!hasText) {
@@ -180,9 +190,17 @@ export function createBlockReplyCoalescer(params: {
     scheduleIdleFlush();
   };
 
+  const drainBufferedText = (): string => {
+    clearIdleTimer();
+    const text = bufferText;
+    resetBuffer();
+    return text;
+  };
+
   return {
     enqueue,
     flush,
+    drainBufferedText,
     hasBuffered: () => Boolean(bufferText),
     stop: () => clearIdleTimer(),
   };

--- a/src/auto-reply/reply/block-reply-pipeline.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.test.ts
@@ -317,6 +317,53 @@ describe("createBlockReplyPipeline content coverage dedup", () => {
     );
   });
 
+  it("merges coalesced text into media payload as a single delivery", async () => {
+    const sent: Array<{ text?: string; mediaUrl?: string; mediaUrls?: string[] }> = [];
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async (payload) => {
+        sent.push({ text: payload.text, mediaUrl: payload.mediaUrl, mediaUrls: payload.mediaUrls });
+      },
+      timeoutMs: 5000,
+      coalescing: {
+        minChars: 1,
+        maxChars: 200,
+        idleMs: 0,
+        joiner: "\n\n",
+      },
+    });
+
+    pipeline.enqueue({ text: "Here is the image:" });
+    pipeline.enqueue({ mediaUrl: "file:///photo.jpg" });
+    await pipeline.flush({ force: true });
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0].text).toBe("Here is the image:");
+    expect(sent[0].mediaUrl).toBe("file:///photo.jpg");
+  });
+
+  it("sends media-only payload without merging when no text is buffered", async () => {
+    const sent: Array<{ text?: string; mediaUrl?: string }> = [];
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async (payload) => {
+        sent.push({ text: payload.text, mediaUrl: payload.mediaUrl });
+      },
+      timeoutMs: 5000,
+      coalescing: {
+        minChars: 1,
+        maxChars: 200,
+        idleMs: 0,
+        joiner: "\n\n",
+      },
+    });
+
+    pipeline.enqueue({ mediaUrl: "file:///photo.jpg" });
+    await pipeline.flush({ force: true });
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0].text).toBeUndefined();
+    expect(sent[0].mediaUrl).toBe("file:///photo.jpg");
+  });
+
   it("does not suppress unrelated shorter text that appears inside streamed content", async () => {
     const pipeline = createBlockReplyPipeline({
       onBlockReply: async () => {},

--- a/src/auto-reply/reply/block-reply-pipeline.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.test.ts
@@ -205,6 +205,29 @@ describe("createBlockReplyPipeline dedup with threading", () => {
     expect(pipeline.getSentMediaUrls()).toStrictEqual([]);
   });
 
+  it("flushes across undefined assistantMessageIndex gaps", async () => {
+    const sent: string[] = [];
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async (payload) => {
+        sent.push(payload.text ?? "");
+      },
+      timeoutMs: 5000,
+      coalescing: {
+        minChars: 100,
+        maxChars: 200,
+        idleMs: 1000,
+        joiner: "\n\n",
+      },
+    });
+
+    pipeline.enqueue(setReplyPayloadMetadata({ text: "Alpha" }, { assistantMessageIndex: 0 }));
+    pipeline.enqueue({ text: "Gap" });
+    pipeline.enqueue(setReplyPayloadMetadata({ text: "Beta" }, { assistantMessageIndex: 1 }));
+    await pipeline.flush({ force: true });
+
+    expect(sent).toEqual(["Alpha", "Gap", "Beta"]);
+  });
+
   it("does not coalesce logical assistant blocks across assistantMessageIndex boundaries", async () => {
     const sent: string[] = [];
     const pipeline = createBlockReplyPipeline({
@@ -315,6 +338,30 @@ describe("createBlockReplyPipeline content coverage dedup", () => {
     expect(pipeline.hasSentPayload({ text: "Description", mediaUrl: "file:///photo.jpg" })).toBe(
       false,
     );
+  });
+
+  it("uses configured joiner when merging buffered text into a media payload with text", async () => {
+    const sent: Array<{ text?: string; mediaUrl?: string }> = [];
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async (payload) => {
+        sent.push({ text: payload.text, mediaUrl: payload.mediaUrl });
+      },
+      timeoutMs: 5000,
+      coalescing: {
+        minChars: 1,
+        maxChars: 200,
+        idleMs: 0,
+        joiner: "\n\n",
+      },
+    });
+
+    pipeline.enqueue({ text: "Caption:" });
+    pipeline.enqueue({ text: "Check this image", mediaUrl: "file:///photo.jpg" });
+    await pipeline.flush({ force: true });
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.text).toBe("Caption:\n\nCheck this image");
+    expect(sent[0]?.mediaUrl).toBe("file:///photo.jpg");
   });
 
   it("merges coalesced text into media payload as a single delivery", async () => {

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -254,7 +254,8 @@ export function createBlockReplyPipeline(params: {
       if (bufferedText) {
         bufferedAssistantMessageIndex = undefined;
         bufferedKeys.clear();
-        const mergedText = reply.hasText ? `${bufferedText}${payload.text}` : bufferedText;
+        const joiner = coalescing?.joiner ?? "";
+        const mergedText = reply.hasText ? `${bufferedText}${joiner}${payload.text}` : bufferedText;
         sendPayload({ ...payload, text: mergedText }, /* bypassSeenCheck */ false);
       } else {
         sendPayload(payload, /* bypassSeenCheck */ false);
@@ -263,12 +264,7 @@ export function createBlockReplyPipeline(params: {
     }
     if (coalescer) {
       const assistantMessageIndex = getReplyPayloadMetadata(payload)?.assistantMessageIndex;
-      if (
-        assistantMessageIndex !== undefined &&
-        bufferedAssistantMessageIndex !== undefined &&
-        assistantMessageIndex !== bufferedAssistantMessageIndex &&
-        coalescer.hasBuffered()
-      ) {
+      if (assistantMessageIndex !== bufferedAssistantMessageIndex && coalescer.hasBuffered()) {
         // Logical assistant blocks must not be merged together by the generic
         // coalescer. Force-flush the previous buffered block before starting a
         // new assistant-message block.

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -248,8 +248,17 @@ export function createBlockReplyPipeline(params: {
       { trimText: true },
     );
     if (reply.hasMedia || hasNonTextContent) {
-      void coalescer?.flush({ force: true });
-      sendPayload(payload, /* bypassSeenCheck */ false);
+      // Merge any buffered text into the media payload so the channel sends
+      // one combined message (text + attachment) instead of two separate ones.
+      const bufferedText = coalescer?.hasBuffered() ? coalescer.drainBufferedText() : "";
+      if (bufferedText) {
+        bufferedAssistantMessageIndex = undefined;
+        bufferedKeys.clear();
+        const mergedText = reply.hasText ? `${bufferedText}${payload.text}` : bufferedText;
+        sendPayload({ ...payload, text: mergedText }, /* bypassSeenCheck */ false);
+      } else {
+        sendPayload(payload, /* bypassSeenCheck */ false);
+      }
       return;
     }
     if (coalescer) {

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -967,7 +967,7 @@ describe("block reply coalescer", () => {
     }
   });
 
-  it("flushes buffered text before media payloads", () => {
+  it("merges buffered text into media payload as caption", () => {
     const flushes: Array<{ text?: string; mediaUrls?: string[] }> = [];
     const coalescer = createBlockReplyCoalescer({
       config: { minChars: 1, maxChars: 200, idleMs: 0, joiner: " " },
@@ -985,8 +985,31 @@ describe("block reply coalescer", () => {
     coalescer.enqueue({ mediaUrls: ["https://example.com/a.png"] });
     void coalescer.flush({ force: true });
 
+    expect(flushes).toHaveLength(1);
     expect(flushes[0].text).toBe("Hello world");
-    expect(flushes[1].mediaUrls).toEqual(["https://example.com/a.png"]);
+    expect(flushes[0].mediaUrls).toEqual(["https://example.com/a.png"]);
+    coalescer.stop();
+  });
+
+  it("passes media-only payload through without merging", () => {
+    const flushes: Array<{ text?: string; mediaUrls?: string[] }> = [];
+    const coalescer = createBlockReplyCoalescer({
+      config: { minChars: 1, maxChars: 200, idleMs: 0, joiner: " " },
+      shouldAbort: () => false,
+      onFlush: (payload) => {
+        flushes.push({
+          text: payload.text,
+          mediaUrls: payload.mediaUrls,
+        });
+      },
+    });
+
+    coalescer.enqueue({ mediaUrls: ["https://example.com/a.png"] });
+    void coalescer.flush({ force: true });
+
+    expect(flushes).toHaveLength(1);
+    expect(flushes[0].text).toBeUndefined();
+    expect(flushes[0].mediaUrls).toEqual(["https://example.com/a.png"]);
     coalescer.stop();
   });
 });


### PR DESCRIPTION
When an assistant response contains both text and a media attachment, the block reply pipeline flushes them as two separate Discord messages: text first, media second. Discord's API supports sending text + file in a single message, so the pipeline should merge them.

Fixes #86446

## Summary

The production path is `createBlockReplyPipeline.enqueue`, which bypasses the coalescer for media payloads and force-flushes buffered text as a separate message. The fix adds `drainBufferedText()` to the coalescer so the pipeline can extract buffered text without triggering a flush, then merges it into the media payload's `text` field before sending a single combined delivery.

Changes:
- `block-reply-pipeline.ts`: pipeline `enqueue` now drains coalescer text and merges into media payloads
- `block-reply-coalescer.ts`: added `drainBufferedText()` method; coalescer `enqueue` also merges as defense-in-depth
- `block-reply-pipeline.test.ts`: 2 new pipeline-level tests proving single delivery for text+media
- `reply-utils.test.ts`: 2 new coalescer-level tests for the defense-in-depth merge

## Real behavior proof

Behavior addressed: text + media assistant replies send as two Discord messages instead of one
Real environment tested: macOS 15.5, Node 24.2.0, local OpenClaw dev checkout
Exact steps or command run after this patch: node scripts/run-vitest.mjs src/auto-reply/reply/block-reply-pipeline.test.ts && node scripts/run-vitest.mjs src/auto-reply/reply/reply-utils.test.ts && pnpm check:changed
Evidence after fix: terminal output from the production-path pipeline test and coalescer test:
```
$ node scripts/run-vitest.mjs src/auto-reply/reply/block-reply-pipeline.test.ts
 ✓ |unit-fast| block-reply-pipeline.test.ts (22 tests) 7ms
 Test Files  1 passed (1)
      Tests  22 passed (22)

$ node scripts/run-vitest.mjs src/auto-reply/reply/reply-utils.test.ts
 ✓ |auto-reply| reply-utils.test.ts (69 tests) 49ms
 Test Files  1 passed (1)
      Tests  69 passed (69)

$ pnpm check:changed
Found 0 warnings and 0 errors.
Import cycle check: 0 runtime value cycle(s).
```
The pipeline-level test `merges coalesced text into media payload as a single delivery` proves the production path: text is enqueued, media follows, and exactly one combined delivery is sent with both text and mediaUrl.

Observed result after fix: pipeline produces one outbound message containing both text and media attachment instead of two separate messages
What was not tested: live Discord channel send (requires bot token and active server)
