### PR TITLE
fix(reply): coalesce buffered text into media payload to avoid split Discord messages

### DIFF
--- a/src/auto-reply/reply/block-reply-coalescer.test.ts
+++ b/src/auto-reply/reply/block-reply-coalescer.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import { createBlockReplyCoalescer } from "./block-reply-coalescer.js";
+
+describe("createBlockReplyCoalescer", () => {
+  it("merges buffered text into a media payload as a single message", async () => {
+    const flushed: Array<{ text?: string; mediaUrl?: string }> = [];
+    const coalescer = createBlockReplyCoalescer({
+      config: { minChars: 10, maxChars: 200, idleMs: 0 },
+      shouldAbort: () => false,
+      onFlush: async (payload) => {
+        flushed.push({ text: payload.text, mediaUrl: payload.mediaUrl });
+      },
+    });
+
+    coalescer.enqueue({ text: "Here is the image:" });
+    coalescer.enqueue({ text: "photo.jpg", mediaUrl: "file:///photo.jpg" });
+    await coalescer.flush({ force: true });
+
+    expect(flushed).toHaveLength(1);
+    expect(flushed[0].text).toBe("Here is the image:\nphoto.jpg");
+    expect(flushed[0].mediaUrl).toBe("file:///photo.jpg");
+  });
+
+  it("sends media payload alone when buffer is empty", async () => {
+    const flushed: Array<{ text?: string; mediaUrl?: string }> = [];
+    const coalescer = createBlockReplyCoalescer({
+      config: { minChars: 10, maxChars: 200, idleMs: 0 },
+      shouldAbort: () => false,
+      onFlush: async (payload) => {
+        flushed.push({ text: payload.text, mediaUrl: payload.mediaUrl });
+      },
+    });
+
+    coalescer.enqueue({ text: "photo.jpg", mediaUrl: "file:///photo.jpg" });
+    await coalescer.flush({ force: true });
+
+    expect(flushed).toHaveLength(1);
+    expect(flushed[0].text).toBe("photo.jpg");
+    expect(flushed[0].mediaUrl).toBe("file:///photo.jpg");
+  });
+
+  it("flushes buffered text separately when replyToId conflicts with media payload", async () => {
+    const flushed: Array<{ text?: string; mediaUrl?: string; replyToId?: string }> = [];
+    const coalescer = createBlockReplyCoalescer({
+      config: { minChars: 10, maxChars: 200, idleMs: 0 },
+      shouldAbort: () => false,
+      onFlush: async (payload) => {
+        flushed.push({
+          text: payload.text,
+          mediaUrl: payload.mediaUrl,
+          replyToId: payload.replyToId,
+        });
+      },
+    });
+
+    coalescer.enqueue({ text: "Reply to thread A", replyToId: "thread-a" });
+    coalescer.enqueue({ text: "photo.jpg", mediaUrl: "file:///photo.jpg", replyToId: "thread-b" });
+    await coalescer.flush({ force: true });
+
+    expect(flushed).toHaveLength(2);
+    expect(flushed[0].text).toBe("Reply to thread A");
+    expect(flushed[0].replyToId).toBe("thread-a");
+    expect(flushed[1].text).toBe("photo.jpg");
+    expect(flushed[1].mediaUrl).toBe("file:///photo.jpg");
+    expect(flushed[1].replyToId).toBe("thread-b");
+  });
+
+  it("uses buffered text as caption when media payload has no text", async () => {
+    const flushed: Array<{ text?: string; mediaUrl?: string }> = [];
+    const coalescer = createBlockReplyCoalescer({
+      config: { minChars: 10, maxChars: 200, idleMs: 0 },
+      shouldAbort: () => false,
+      onFlush: async (payload) => {
+        flushed.push({ text: payload.text, mediaUrl: payload.mediaUrl });
+      },
+    });
+
+    coalescer.enqueue({ text: "Look at this:" });
+    coalescer.enqueue({ mediaUrl: "file:///photo.jpg" });
+    await coalescer.flush({ force: true });
+
+    expect(flushed).toHaveLength(1);
+    expect(flushed[0].text).toBe("Look at this:");
+    expect(flushed[0].mediaUrl).toBe("file:///photo.jpg");
+  });
+});

--- a/src/auto-reply/reply/block-reply-coalescer.ts
+++ b/src/auto-reply/reply/block-reply-coalescer.ts
@@ -94,7 +94,25 @@ export function createBlockReplyCoalescer(params: {
     const text = reply.text;
     const hasText = reply.hasText;
     if (hasMedia) {
-      void flush({ force: true });
+      clearIdleTimer();
+      const replyToConflict = Boolean(
+        bufferText &&
+        payload.replyToId &&
+        (!bufferReplyToId || bufferReplyToId !== payload.replyToId),
+      );
+      if (bufferText && !replyToConflict) {
+        const mergedPayload: ReplyPayload = {
+          ...payload,
+          text: text ? `${bufferText}\n${text}` : bufferText,
+        };
+        resetBuffer();
+        void onFlush(mergedPayload);
+        return;
+      }
+      if (bufferText) {
+        void flush({ force: true });
+      }
+      resetBuffer();
       void onFlush(payload);
       return;
     }


### PR DESCRIPTION
## Summary

Fixes Discord sending text and media attachments as two separate messages when they belong to the same assistant turn. The `createBlockReplyCoalescer` function previously flushed any buffered text as a standalone message before sending the media payload, causing a confusing \"doubled\" appearance.

## Changes

- `src/auto-reply/reply/block-reply-coalescer.ts`:
  - When a media payload arrives and the coalescer has buffered text, merge the buffered text into the media payload's `text` field instead of flushing it separately.
  - Preserve existing `replyToConflict` behavior: if the buffered text and media payload target different `replyToId`s, fall back to the old separate-flush behavior.
  - Added `clearIdleTimer()` before media handling to prevent stale timers from firing after the merged payload is sent.
- `src/auto-reply/reply/block-reply-coalescer.test.ts`:
  - Added regression tests verifying that buffered text is merged into a media payload.
  - Added tests for media-only payloads and `replyToConflict` fallback.

## Verification

Behavior addressed: Text + MEDIA in the same assistant turn now arrives as a single Discord message.
Real environment tested: Local source checkout, Linux, Node 22.
Exact steps or command run after this patch:
  - `pnpm test src/auto-reply/reply/block-reply-coalescer.test.ts`
  - `pnpm test src/auto-reply/reply/block-reply-pipeline.test.ts`
  - `pnpm format:check src/auto-reply/reply/block-reply-coalescer.ts`
Evidence after fix: 24 tests pass, 0 failures; formatting check passes.
Observed result after fix: Buffered text is coalesced into the media payload as a single outbound message.
What was not tested: Live Discord webhook with actual file attachment.

Fixes #86446