### PR TITLE
fix: respect webchat history max chars config

### DIFF
--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -24,7 +24,6 @@ const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
 const SYNTHETIC_TRANSCRIPT_REPAIR_RESULT =
   "[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.";
 const CHAT_HISTORY_REQUEST_LIMIT = 100;
-const CHAT_HISTORY_REQUEST_MAX_CHARS = 4_000;
 const STARTUP_CHAT_HISTORY_RETRY_TIMEOUT_MS = 60_000;
 const STARTUP_CHAT_HISTORY_DEFAULT_RETRY_MS = 500;
 const STARTUP_CHAT_HISTORY_MAX_RETRY_MS = 5_000;
@@ -325,7 +324,6 @@ export async function loadChatHistory(state: ChatState) {
         }>("chat.history", {
           sessionKey,
           limit: CHAT_HISTORY_REQUEST_LIMIT,
-          maxChars: CHAT_HISTORY_REQUEST_MAX_CHARS,
         });
         break;
       } catch (err) {


### PR DESCRIPTION
Summary
- Stop Control UI from sending a hardcoded `maxChars` value in `chat.history` requests.
- Let the existing gateway resolver apply `gateway.webchat.chatHistoryMaxChars` for WebChat history responses.

Verification
- Not run (per repository instruction not to run tests unless explicitly asked).
- Source inspection: `ui/src/ui/controllers/chat.ts` no longer includes `maxChars`, so `src/gateway/chat-display-projection.ts` keeps using configured/default history limits when no per-request override is supplied.