### PR TITLE
fix: rotate realtime voice sessions on max duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord/OpenAI voice: rotate Realtime sessions at provider max duration without logging the expected session-expiry event as an error.
 - Memory/local embeddings: run local GGUF embeddings in an isolated worker sidecar and degrade to configured fallback or keyword search on worker failure so native embedding crashes do not take down the Gateway. (#85348) Thanks @osolmaz.
 - Gateway: clear the runtime config snapshot before `SIGUSR1` in-process restarts so config changes survive the next gateway loop. (#86388) Thanks @XuZehan-iCenter.
 - Models: show OAuth delegation markers as configured `models.json` auth while keeping runtime route usability checks strict. (#86378) Thanks @rohitjavvadi.

--- a/extensions/discord/src/voice/realtime.ts
+++ b/extensions/discord/src/voice/realtime.ts
@@ -177,6 +177,14 @@ function formatRealtimeInterruptionLog(event: RealtimeVoiceBridgeEvent): string 
   return undefined;
 }
 
+function formatRealtimeLifecycleLog(event: RealtimeVoiceBridgeEvent): string | undefined {
+  if (!event.type.startsWith("session.")) {
+    return undefined;
+  }
+  const detail = event.detail ? ` ${event.detail}` : "";
+  return `discord voice: realtime lifecycle ${event.direction}:${event.type}${detail}`;
+}
+
 function isRealtimeResponseCancelled(event: RealtimeVoiceBridgeEvent): boolean {
   return (
     event.direction === "server" &&
@@ -590,6 +598,10 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
         const interruptionLog = formatRealtimeInterruptionLog(event);
         if (interruptionLog) {
           logger.info(interruptionLog);
+        }
+        const lifecycleLog = formatRealtimeLifecycleLog(event);
+        if (lifecycleLog) {
+          logger.info(lifecycleLog);
         }
       },
       onError: (error) => this.logRealtimeError(formatErrorMessage(error)),

--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -778,6 +778,81 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     expect(bridge.isConnected()).toBe(true);
   });
 
+  it("rotates realtime bridges on provider max-duration events without reporting an error", async () => {
+    vi.useFakeTimers();
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    const onError = vi.fn();
+    const onEvent = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onError,
+      onEvent,
+    });
+    const connecting = bridge.connect();
+    const firstSocket = FakeWebSocket.instances[0];
+    if (!firstSocket) {
+      throw new Error("expected bridge to create a websocket");
+    }
+
+    firstSocket.readyState = FakeWebSocket.OPEN;
+    firstSocket.emit("open");
+    firstSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    firstSocket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "error",
+          error: { message: "Your session hit the maximum duration of 60 minutes." },
+        }),
+      ),
+    );
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(firstSocket.closed).toBe(true);
+    expect(onEvent).toHaveBeenCalledWith({
+      direction: "server",
+      type: "session.rotation",
+      detail: "reason=max-duration",
+    });
+    expect(onEvent).toHaveBeenCalledWith({
+      direction: "client",
+      type: "session.reconnect.scheduled",
+      detail: "reason=max-duration attempt=1 delayMs=1000",
+    });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(2));
+    const secondSocket = FakeWebSocket.instances[1];
+    if (!secondSocket) {
+      throw new Error("expected bridge to reconnect");
+    }
+    secondSocket.readyState = FakeWebSocket.OPEN;
+    secondSocket.emit("open");
+    secondSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+
+    await vi.waitFor(() =>
+      expect(onEvent).toHaveBeenCalledWith({
+        direction: "server",
+        type: "session.rotation.ready",
+        detail: "reason=max-duration",
+      }),
+    );
+    await vi.waitFor(() =>
+      expect(onEvent).toHaveBeenCalledWith({
+        direction: "client",
+        type: "session.reconnect.ready",
+        detail: "reason=max-duration attempt=1",
+      }),
+    );
+    expect(bridge.isConnected()).toBe(true);
+
+    bridge.close();
+  });
+
   it("keeps Azure deployment bridges on deployment-compatible session payloads", async () => {
     const provider = buildOpenAIRealtimeVoiceProvider();
     const bridge = provider.createBridge({

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -90,6 +90,7 @@ const OPENAI_REALTIME_ACTIVE_RESPONSE_ERROR_PREFIX =
   "Conversation already has an active response in progress:";
 const OPENAI_REALTIME_NO_ACTIVE_RESPONSE_CANCEL_ERROR =
   "Cancellation failed: no active response found";
+const OPENAI_REALTIME_MAX_SESSION_DURATION_FRAGMENT = "maximum duration";
 const OPENAI_REALTIME_DEFAULT_MIN_BARGE_IN_AUDIO_END_MS = 250;
 const OPENAI_REALTIME_VOICES = [
   "alloy",
@@ -330,6 +331,14 @@ function prefersCodexOAuthForRealtimeModel(model: string | undefined): boolean {
   return (model ?? OPENAI_REALTIME_DEFAULT_MODEL).trim().toLowerCase().startsWith("gpt-");
 }
 
+function isOpenAIRealtimeMaxSessionDurationError(detail: string): boolean {
+  const normalized = detail.toLowerCase();
+  return (
+    normalized.includes("session") &&
+    normalized.includes(OPENAI_REALTIME_MAX_SESSION_DURATION_FRAGMENT)
+  );
+}
+
 async function resolveOpenAIRealtimeDefaultAuth(params: {
   configuredApiKey: string | undefined;
   cfg: RealtimeVoiceBrowserSessionCreateRequest["cfg"] | undefined;
@@ -426,6 +435,8 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   private deliveredToolCallKeys = new Set<string>();
   private readonly flowId = randomUUID();
   private sessionReadyFired = false;
+  private reconnectReason: string | undefined;
+  private activeConnectionReason: string | undefined;
   private readonly audioFormat: RealtimeVoiceAudioFormat;
 
   constructor(private readonly config: OpenAIRealtimeVoiceBridgeConfig) {
@@ -658,7 +669,9 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
             settleReject(new Error("OpenAI realtime connection closed before ready"));
             return;
           }
-          void this.attemptReconnect();
+          const reason = this.reconnectReason ?? "websocket-close";
+          this.reconnectReason = undefined;
+          void this.attemptReconnect(reason);
         });
       };
 
@@ -833,26 +846,41 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
     };
   }
 
-  private async attemptReconnect(): Promise<void> {
+  private async attemptReconnect(reason: string): Promise<void> {
     if (this.intentionallyClosed) {
       return;
     }
     if (this.reconnectAttempts >= OpenAIRealtimeVoiceBridge.MAX_RECONNECT_ATTEMPTS) {
+      this.config.onEvent?.({
+        direction: "client",
+        type: "session.reconnect.exhausted",
+        detail: `reason=${reason} attempts=${this.reconnectAttempts}`,
+      });
       this.config.onClose?.("error");
       return;
     }
     this.reconnectAttempts += 1;
-    const delay =
-      OpenAIRealtimeVoiceBridge.BASE_RECONNECT_DELAY_MS * 2 ** (this.reconnectAttempts - 1);
+    const attempt = this.reconnectAttempts;
+    const delay = OpenAIRealtimeVoiceBridge.BASE_RECONNECT_DELAY_MS * 2 ** (attempt - 1);
+    this.config.onEvent?.({
+      direction: "client",
+      type: "session.reconnect.scheduled",
+      detail: `reason=${reason} attempt=${attempt} delayMs=${delay}`,
+    });
     await new Promise((resolve) => setTimeout(resolve, delay));
     if (this.intentionallyClosed) {
       return;
     }
     try {
       await this.doConnect();
+      this.config.onEvent?.({
+        direction: "client",
+        type: "session.reconnect.ready",
+        detail: `reason=${reason} attempt=${attempt}`,
+      });
     } catch (error) {
       this.config.onError?.(error instanceof Error ? error : new Error(String(error)));
-      await this.attemptReconnect();
+      await this.attemptReconnect(reason);
     }
   }
 
@@ -951,11 +979,27 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   }
 
   private handleEvent(event: RealtimeEvent): void {
-    this.config.onEvent?.({
-      direction: "server",
-      type: event.type,
-      detail: this.describeServerEvent(event),
-    });
+    const emitServerEvent = () =>
+      this.config.onEvent?.({
+        direction: "server",
+        type: event.type,
+        detail: this.describeServerEvent(event),
+      });
+    if (
+      event.type === "error" &&
+      isOpenAIRealtimeMaxSessionDurationError(readRealtimeErrorDetail(event.error))
+    ) {
+      this.reconnectReason = "max-duration";
+      this.activeConnectionReason = "max-duration";
+      this.config.onEvent?.({
+        direction: "server",
+        type: "session.rotation",
+        detail: "reason=max-duration",
+      });
+      this.ws?.close(1000, "max-duration rotation");
+      return;
+    }
+    emitServerEvent();
     switch (event.type) {
       case "session.created":
         return;
@@ -964,6 +1008,14 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         this.sessionConfigured = true;
         for (const chunk of this.pendingAudio.splice(0)) {
           this.sendAudio(chunk);
+        }
+        if (this.activeConnectionReason) {
+          this.config.onEvent?.({
+            direction: "server",
+            type: "session.rotation.ready",
+            detail: `reason=${this.activeConnectionReason}`,
+          });
+          this.activeConnectionReason = undefined;
         }
         if (!this.sessionReadyFired) {
           this.sessionReadyFired = true;

--- a/scripts/deadcode-unused-files.allowlist.mjs
+++ b/scripts/deadcode-unused-files.allowlist.mjs
@@ -42,4 +42,5 @@ export const KNIP_OPTIONAL_UNUSED_FILE_ALLOWLIST = [
   "extensions/qa-lab/src/auth-profile.fixture.ts",
   "extensions/qa-lab/src/codex-plugin.fixture.ts",
   "src/gateway/test/server-sessions-helpers.ts",
+  "ui/src/ui/control-ui-chunking.ts",
 ];


### PR DESCRIPTION
## Summary

- Treat OpenAI Realtime max-session-duration errors as expected rotation lifecycle events instead of surfaced voice errors.
- Reconnect expired Realtime voice bridges through the existing websocket reconnect path and log session lifecycle visibility in Discord voice.
- Add a regression test covering provider max-duration rotation without `onError`.
- Allowlist the existing Control UI build chunking helper in the optional Knip unused-file set so the dependency shard stays green on the current base.

## Verification

- `node scripts/run-vitest.mjs extensions/openai/realtime-voice-provider.test.ts extensions/discord/src/voice/manager.e2e.test.ts -- --reporter=verbose`
- `pnpm test extensions/discord/src/voice/manager.e2e.test.ts -- --reporter=verbose`
- `git diff --check`
- `pnpm changed:lanes --json`
- `env -u OPENCLAW_TESTBOX pnpm check:changed`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local`
- `pnpm deadcode:unused-files`
- `pnpm deadcode:dependencies`
- `pnpm deadcode:report:ci:ts-unused`

## Real behavior proof

Behavior addressed: OpenAI Realtime provider max-duration events no longer appear as Discord voice errors, and the expired Realtime session is rotated through reconnect.
Real environment tested: Local source checkout with focused OpenAI provider and Discord voice test coverage; live tmux logs were inspected before the patch and showed hourly max-duration Realtime errors.
Exact steps or command run after this patch: `env -u OPENCLAW_TESTBOX pnpm check:changed`; focused Vitest and dependency-shard commands listed above.
Evidence after fix: Regression test proves the provider max-duration error closes the stale websocket, schedules a reconnect, reaches `session.rotation.ready`, and never calls `onError`.
Observed result after fix: Changed gate, dependency shard commands, and autoreview pass locally; focused provider and Discord voice tests pass.
What was not tested: A live one-hour Discord/OpenAI Realtime call after patch was not run locally; CI will cover repository gates for this branch.
