### PR TITLE
fix(plugin-sdk): preserve anyOf const unions in normalizeDeepSeekSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Plugin SDK: preserve `anyOf`/`oneOf` unions of `const` literals as JSON Schema `enum` when normalizing tool schemas for DeepSeek-routed models, so multi-option tool parameters built from `Type.Union([Type.Literal(...), ...])` no longer collapse to a single `const`. (#86468)
 - Memory/local embeddings: run local GGUF embeddings in an isolated worker sidecar and degrade to configured fallback or keyword search on worker failure so native embedding crashes do not take down the Gateway. (#85348) Thanks @osolmaz.
 - Gateway: clear the runtime config snapshot before `SIGUSR1` in-process restarts so config changes survive the next gateway loop. (#86388) Thanks @XuZehan-iCenter.
 - Models: show OAuth delegation markers as configured `models.json` auth while keeping runtime route usability checks strict. (#86378) Thanks @rohitjavvadi.

--- a/src/plugin-sdk/provider-tools.test.ts
+++ b/src/plugin-sdk/provider-tools.test.ts
@@ -356,4 +356,279 @@ describe("buildProviderToolCompatFamilyHooks", () => {
 
     expect(diagnostics).toStrictEqual([]);
   });
+
+  it("preserves const-literal anyOf unions as enums for the deepseek family", () => {
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const tools = [
+      {
+        name: "feishu_update_doc",
+        description: "",
+        parameters: {
+          type: "object",
+          properties: {
+            mode: {
+              description: "update mode",
+              anyOf: [
+                { const: "overwrite", type: "string" },
+                { const: "append", type: "string" },
+                { const: "replace_range", type: "string" },
+                { const: "replace_all", type: "string" },
+                { const: "insert_before", type: "string" },
+                { const: "insert_after", type: "string" },
+                { const: "delete_range", type: "string" },
+              ],
+            },
+          },
+          required: ["mode"],
+        },
+      },
+    ] as never;
+
+    const ctx = {
+      provider: "deepseek" as const,
+      modelId: "deepseek-v4-pro",
+      modelApi: "openai-completions" as const,
+      model: {
+        provider: "deepseek",
+        api: "openai-completions",
+        id: "deepseek-v4-pro",
+      } as never,
+      tools,
+    };
+    const normalized = hooks.normalizeToolSchemas(ctx);
+
+    expect(normalized[0]?.parameters).toEqual({
+      type: "object",
+      properties: {
+        mode: {
+          description: "update mode",
+          type: "string",
+          enum: [
+            "overwrite",
+            "append",
+            "replace_range",
+            "replace_all",
+            "insert_before",
+            "insert_after",
+            "delete_range",
+          ],
+        },
+      },
+      required: ["mode"],
+    });
+    expect(hooks.inspectToolSchemas({ ...ctx, tools: normalized })).toStrictEqual([]);
+  });
+
+  it("keeps nullable string union behavior unchanged for the deepseek family", () => {
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const tools = [
+      {
+        name: "with_optional",
+        description: "",
+        parameters: {
+          type: "object",
+          properties: {
+            ticker: {
+              anyOf: [{ type: "string" }, { type: "null" }],
+            },
+          },
+        },
+      },
+    ] as never;
+
+    const normalized = hooks.normalizeToolSchemas({
+      provider: "deepseek",
+      modelId: "deepseek-v4-pro",
+      modelApi: "openai-completions",
+      model: {
+        provider: "deepseek",
+        api: "openai-completions",
+        id: "deepseek-v4-pro",
+      } as never,
+      tools,
+    });
+
+    expect(normalized[0]?.parameters).toEqual({
+      type: "object",
+      properties: {
+        ticker: { type: "string", nullable: true },
+      },
+    });
+  });
+
+  it("combines const variants with a null variant into a nullable enum for the deepseek family", () => {
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const tools = [
+      {
+        name: "with_nullable_const",
+        description: "",
+        parameters: {
+          type: "object",
+          properties: {
+            kind: {
+              anyOf: [
+                { const: "a", type: "string" },
+                { const: "b", type: "string" },
+                { type: "null" },
+              ],
+            },
+          },
+        },
+      },
+    ] as never;
+
+    const normalized = hooks.normalizeToolSchemas({
+      provider: "deepseek",
+      modelId: "deepseek-v4-pro",
+      modelApi: "openai-completions",
+      model: {
+        provider: "deepseek",
+        api: "openai-completions",
+        id: "deepseek-v4-pro",
+      } as never,
+      tools,
+    });
+
+    expect(normalized[0]?.parameters).toEqual({
+      type: "object",
+      properties: {
+        kind: {
+          type: "string",
+          enum: ["a", "b"],
+          nullable: true,
+        },
+      },
+    });
+  });
+
+  it("preserves numeric const unions as enums for the deepseek family", () => {
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const tools = [
+      {
+        name: "with_numeric_union",
+        description: "",
+        parameters: {
+          type: "object",
+          properties: {
+            level: {
+              anyOf: [
+                { const: 1, type: "number" },
+                { const: 2, type: "number" },
+              ],
+            },
+          },
+        },
+      },
+    ] as never;
+
+    const normalized = hooks.normalizeToolSchemas({
+      provider: "deepseek",
+      modelId: "deepseek-v4-pro",
+      modelApi: "openai-completions",
+      model: {
+        provider: "deepseek",
+        api: "openai-completions",
+        id: "deepseek-v4-pro",
+      } as never,
+      tools,
+    });
+
+    expect(normalized[0]?.parameters).toEqual({
+      type: "object",
+      properties: {
+        level: { type: "number", enum: [1, 2] },
+      },
+    });
+  });
+
+  it("handles nested anyOf inside object properties for the deepseek family", () => {
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const tools = [
+      {
+        name: "nested_union",
+        description: "",
+        parameters: {
+          type: "object",
+          properties: {
+            payload: {
+              type: "object",
+              properties: {
+                action: {
+                  anyOf: [
+                    { const: "create", type: "string" },
+                    { const: "delete", type: "string" },
+                  ],
+                },
+              },
+              required: ["action"],
+            },
+          },
+          required: ["payload"],
+        },
+      },
+    ] as never;
+
+    const normalized = hooks.normalizeToolSchemas({
+      provider: "deepseek",
+      modelId: "deepseek-v4-pro",
+      modelApi: "openai-completions",
+      model: {
+        provider: "deepseek",
+        api: "openai-completions",
+        id: "deepseek-v4-pro",
+      } as never,
+      tools,
+    });
+
+    expect(normalized[0]?.parameters).toEqual({
+      type: "object",
+      properties: {
+        payload: {
+          type: "object",
+          properties: {
+            action: { type: "string", enum: ["create", "delete"] },
+          },
+          required: ["action"],
+        },
+      },
+      required: ["payload"],
+    });
+  });
+
+  it("collapses a single-element const anyOf to a const for the deepseek family", () => {
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const tools = [
+      {
+        name: "single_const",
+        description: "",
+        parameters: {
+          type: "object",
+          properties: {
+            kind: {
+              anyOf: [{ const: "only", type: "string" }],
+            },
+          },
+        },
+      },
+    ] as never;
+
+    const normalized = hooks.normalizeToolSchemas({
+      provider: "deepseek",
+      modelId: "deepseek-v4-pro",
+      modelApi: "openai-completions",
+      model: {
+        provider: "deepseek",
+        api: "openai-completions",
+        id: "deepseek-v4-pro",
+      } as never,
+      tools,
+    });
+
+    expect(normalized[0]?.parameters).toEqual({
+      type: "object",
+      properties: {
+        kind: { type: "string", const: "only" },
+      },
+    });
+  });
 });

--- a/src/plugin-sdk/provider-tools.ts
+++ b/src/plugin-sdk/provider-tools.ts
@@ -455,6 +455,25 @@ function normalizeDeepSeekSchema(schema: unknown): unknown {
   const variants = record[unionKey] as unknown[];
   const normalizedVariants = variants.map((entry) => normalizeDeepSeekSchema(entry));
   const nonNullVariants = normalizedVariants.filter((entry) => !isNullSchemaVariant(entry));
+  const hasNullVariant = nonNullVariants.length < normalizedVariants.length;
+
+  const constUnion = extractConstUnion(nonNullVariants);
+  if (constUnion && constUnion.values.length > 0) {
+    const merged: Record<string, unknown> = { ...normalized };
+    if (constUnion.type !== undefined && merged.type === undefined) {
+      merged.type = constUnion.type;
+    }
+    if (constUnion.values.length === 1) {
+      merged.const = constUnion.values[0];
+    } else {
+      merged.enum = constUnion.values;
+    }
+    if (hasNullVariant) {
+      merged.nullable = true;
+    }
+    return merged;
+  }
+
   const selected = nonNullVariants[0] ?? normalizedVariants[0];
   if (!selected || typeof selected !== "object" || Array.isArray(selected)) {
     return normalized;
@@ -464,10 +483,37 @@ function normalizeDeepSeekSchema(schema: unknown): unknown {
     ...(selected as Record<string, unknown>),
     ...normalized,
   };
-  if (nonNullVariants.length < normalizedVariants.length) {
+  if (hasNullVariant) {
     merged.nullable = true;
   }
   return merged;
+}
+
+function extractConstUnion(
+  variants: unknown[],
+): { values: unknown[]; type: string | undefined } | undefined {
+  if (variants.length === 0) {
+    return undefined;
+  }
+  const values: unknown[] = [];
+  const types = new Set<string>();
+  for (const variant of variants) {
+    if (!variant || typeof variant !== "object" || Array.isArray(variant)) {
+      return undefined;
+    }
+    const record = variant as Record<string, unknown>;
+    if (!("const" in record)) {
+      return undefined;
+    }
+    values.push(record.const);
+    if (typeof record.type === "string") {
+      types.add(record.type);
+    }
+  }
+  return {
+    values,
+    type: types.size === 1 ? (types.values().next().value as string) : undefined,
+  };
 }
 
 export function normalizeDeepSeekToolSchemas(


### PR DESCRIPTION
## Summary
Fixes #86468. `normalizeDeepSeekSchema` was designed for nullable unions (`{anyOf: [{type:"string"}, {type:"null"}]}` → `{type:"string", nullable:true}`) but applied the same "pick first variant" collapse to legitimate const-literal unions, breaking multi-option tool parameters for DeepSeek-routed models.

## Root cause
In `src/plugin-sdk/provider-tools.ts`, `normalizeDeepSeekSchema` collapsed every `anyOf` to `nonNullVariants[0]`, regardless of whether the variants were null discriminators or real enum-like alternatives. A tool parameter like:

```ts
mode: Type.Union([
  Type.Literal("overwrite"),
  Type.Literal("append"),
  // … 5 more
])
```

…reached the LLM as a single `{const: "overwrite", type: "string"}`, so any call attempting `"append"` was rejected as a schema mismatch (`Validation failed: mode: must be equal to constant`).

## Fix
DeepSeek does not support `anyOf` / `oneOf` at all — they are listed in `DEEPSEEK_UNSUPPORTED_SCHEMA_KEYWORDS`, which is why the normalizer flattens unions in the first place. Re-emitting the original `anyOf` would just trigger the inspector's diagnostic. The fix instead detects "pure const-union" `anyOf`/`oneOf` arrays (every non-null variant carries a `const`) and rewrites them to a single schema with the equivalent JSON Schema `enum`, preserving the shared `type` when consistent, surrounding metadata (e.g. `description`), and nullability. Nullable unions and mixed-type unions retain existing behavior.

A single-element const union is collapsed to `const` (matching the no-union case rather than an `enum` of length one).

## Before / After

| Input | Before (LLM sees) | After (LLM sees) |
|---|---|---|
| `anyOf: [{const:"a",type:"string"}, {const:"b",type:"string"}, {const:"c",type:"string"}]` | `{const:"a", type:"string"}` ❌ | `{type:"string", enum:["a","b","c"]}` ✅ |
| `anyOf: [{type:"string"}, {type:"null"}]` | `{type:"string", nullable:true}` ✅ | `{type:"string", nullable:true}` ✅ (unchanged) |
| `anyOf: [{const:"x",type:"string"}, {type:"null"}]` | `{const:"x", type:"string"}` ❌ | `{type:"string", const:"x", nullable:true}` ✅ |
| `anyOf: [{const:1,type:"number"}, {const:2,type:"number"}]` | `{const:1, type:"number"}` ❌ | `{type:"number", enum:[1,2]}` ✅ |

## Reproduction (pre-fix)
Any plugin tool with a `Type.Union([Type.Literal(...), ...])` parameter routed through a DeepSeek model. The bug report's concrete repro is `openclaw-lark`'s `feishu_update_doc.mode` parameter (7 string literals); pre-fix the model only ever saw `overwrite`.

```ts
const tools = [{
  name: "feishu_update_doc",
  parameters: {
    type: "object",
    properties: {
      mode: { anyOf: [
        { const: "overwrite", type: "string" },
        { const: "append", type: "string" },
        // ...
      ]},
    },
    required: ["mode"],
  },
}];
normalizeDeepSeekToolSchemas({ /* deepseek ctx */, tools })[0].parameters
// pre-fix:  mode -> { const: "overwrite", type: "string" }
// post-fix: mode -> { type: "string", enum: ["overwrite","append", ...] }
```

## Tests
Six new tests in `src/plugin-sdk/provider-tools.test.ts`:

1. Pure const-string `anyOf` (the `feishu_update_doc` case) → emits the full `enum` and passes the DeepSeek inspector with zero diagnostics.
2. Nullable string `anyOf: [{type:"string"}, {type:"null"}]` → still collapses to `{type:"string", nullable:true}` (regression guard).
3. Const variants + `{type:"null"}` → emits `{type:"string", enum:[...], nullable:true}`.
4. Numeric const union → emits `{type:"number", enum:[1,2]}`.
5. Nested `anyOf` inside an object property → recursion correctly produces an inner `enum`.
6. Single-element const `anyOf` edge case → collapses to a plain `const`.

All previously-passing tests in the file remain green (`pnpm vitest run src/plugin-sdk/provider-tools.test.ts` → 14 passed).

## Verification
- `pnpm tsgo:core` — clean
- `pnpm tsgo:core:test` — clean
- `pnpm vitest run src/plugin-sdk/provider-tools.test.ts` — 14/14 passing
- `oxlint src/plugin-sdk/provider-tools.ts src/plugin-sdk/provider-tools.test.ts` — 0 warnings, 0 errors
- `oxfmt --check` on both touched files — clean

## Architecture affected
Only `normalizeDeepSeekSchema` (plus a small new helper `extractConstUnion`) in `src/plugin-sdk/provider-tools.ts`. The function runs once per tool registration when a DeepSeek-routed provider is selected — no runtime-hot-path impact. Other providers' schemas are untouched (the gemini/openai normalizers and inspectors are not called from this path).

## Changelog
Added entry under `Unreleased / Fixes` crediting #86468.

Fixes #86468
