### PR TITLE
fix(plugin-sdk): preserve all const literals in anyOf unions for DeepSeek (#86468)

### DIFF
--- a/src/plugin-sdk/provider-tools.test.ts
+++ b/src/plugin-sdk/provider-tools.test.ts
@@ -119,6 +119,91 @@ describe("buildProviderToolCompatFamilyHooks", () => {
     ).toStrictEqual([]);
   });
 
+  it("converts anyOf const string unions to enum for the deepseek family", () => {
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const tools = [
+      {
+        name: "feishu_update_doc",
+        description: "",
+        parameters: {
+          type: "object",
+          properties: {
+            mode: {
+              description: "更新模式（必填）",
+              anyOf: [
+                { const: "overwrite", type: "string" },
+                { const: "append", type: "string" },
+                { const: "replace_range", type: "string" },
+                { const: "replace_all", type: "string" },
+                { const: "insert_before", type: "string" },
+                { const: "insert_after", type: "string" },
+                { const: "delete_range", type: "string" },
+              ],
+            },
+            nullable_mode: {
+              anyOf: [
+                { const: "on", type: "string" },
+                { const: "off", type: "string" },
+                { type: "null" },
+              ],
+            },
+          },
+          required: ["mode"],
+        },
+      },
+    ] as never;
+
+    const normalized = hooks.normalizeToolSchemas({
+      provider: "deepseek",
+      modelId: "deepseek-v4-pro",
+      modelApi: "openai-completions",
+      model: {
+        provider: "deepseek",
+        api: "openai-completions",
+        id: "deepseek-v4-pro",
+      } as never,
+      tools,
+    });
+
+    expect(normalized[0]?.parameters).toEqual({
+      type: "object",
+      properties: {
+        mode: {
+          description: "更新模式（必填）",
+          type: "string",
+          enum: [
+            "overwrite",
+            "append",
+            "replace_range",
+            "replace_all",
+            "insert_before",
+            "insert_after",
+            "delete_range",
+          ],
+        },
+        nullable_mode: {
+          type: "string",
+          enum: ["on", "off"],
+          nullable: true,
+        },
+      },
+      required: ["mode"],
+    });
+    expect(
+      hooks.inspectToolSchemas({
+        provider: "deepseek",
+        modelId: "deepseek-v4-pro",
+        modelApi: "openai-completions",
+        model: {
+          provider: "deepseek",
+          api: "openai-completions",
+          id: "deepseek-v4-pro",
+        } as never,
+        tools: normalized,
+      }),
+    ).toStrictEqual([]);
+  });
+
   it("normalizes parameter-free and typed-object schemas for the openai family", () => {
     const hooks = buildProviderToolCompatFamilyHooks("openai");
     const tools = [

--- a/src/plugin-sdk/provider-tools.ts
+++ b/src/plugin-sdk/provider-tools.ts
@@ -455,6 +455,30 @@ function normalizeDeepSeekSchema(schema: unknown): unknown {
   const variants = record[unionKey] as unknown[];
   const normalizedVariants = variants.map((entry) => normalizeDeepSeekSchema(entry));
   const nonNullVariants = normalizedVariants.filter((entry) => !isNullSchemaVariant(entry));
+
+  const allConstStrings =
+    nonNullVariants.length > 0 &&
+    nonNullVariants.every(
+      (v) =>
+        v &&
+        typeof v === "object" &&
+        !Array.isArray(v) &&
+        "const" in v &&
+        typeof (v as Record<string, unknown>).const === "string",
+    );
+  if (allConstStrings) {
+    const enumValues = nonNullVariants.map((v) => (v as Record<string, unknown>).const as string);
+    const merged: Record<string, unknown> = {
+      type: "string",
+      enum: enumValues,
+      ...normalized,
+    };
+    if (nonNullVariants.length < normalizedVariants.length) {
+      merged.nullable = true;
+    }
+    return merged;
+  }
+
   const selected = nonNullVariants[0] ?? normalizedVariants[0];
   if (!selected || typeof selected !== "object" || Array.isArray(selected)) {
     return normalized;


### PR DESCRIPTION
## Summary

Fixes `normalizeDeepSeekSchema` dropping all but the first `anyOf` variant for unions of `const` string literals. The function was designed to collapse nullable unions (e.g. `anyOf: [{type:\"string\"}, {type:\"null\"}]` → `{type:\"string\", nullable:true}`), but incorrectly applied the same \"pick first\" logic to unions of string literal consts.

When a plugin tool uses `Type.Union([Type.Literal(\"a\"), Type.Literal(\"b\"), ...])` (Typebox) with a DeepSeek model, the LLM previously saw only the first const value, causing validation errors for all other options.

## Changes

- `src/plugin-sdk/provider-tools.ts`:
  - In `normalizeDeepSeekSchema`, detect when all non-null `anyOf`/`oneOf` variants are `const` string literals.
  - Convert such unions to `{type: \"string\", enum: [...values], ...normalized}` instead of picking the first variant.
  - Preserve existing nullable behavior: if the union includes a null variant, add `nullable: true`.
- `src/plugin-sdk/provider-tools.test.ts`:
  - Add regression test verifying `anyOf` const string unions are converted to `enum` arrays.
  - Add test for nullable const unions (`anyOf: [{const:\"on\"}, {const:\"off\"}, {type:\"null\"}]`) to ensure `nullable: true` is preserved.

## Verification

Behavior addressed: anyOf/oneOf const string unions are preserved as enum arrays for DeepSeek models.
Real environment tested: Local source checkout, Linux, Node 22.
Exact steps or command run after this patch:
  - `pnpm test src/plugin-sdk/provider-tools.test.ts`
  - `pnpm format:check src/plugin-sdk/provider-tools.ts src/plugin-sdk/provider-tools.test.ts`
  - `pnpm check:changed` (core typecheck passes; extension typecheck failures are pre-existing unrelated missing-dependency issues)
Evidence after fix: 9 tests pass, 0 failures; formatting check passes; core and core-test typechecks pass.
Observed result after fix: `anyOf: [{const:\"overwrite\"}, {const:\"append\"}, ...]` is normalized to `{type:\"string\", enum:[\"overwrite\",\"append\",...]}`.
What was not tested: Live DeepSeek API call with a tool using const union parameters.


Fixes #86468