### PR TITLE
Keep Codex turn timeouts inside Codex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,7 +196,6 @@ Docs: https://docs.openclaw.ai
 - Auth/Codex: emit a one-shot actionable `log.warn` from the embedded legacy Codex OAuth sidecar loader when the only available seed lives in the macOS Keychain, naming `openclaw doctor --fix` and macOS Keychain instead of letting the credential silently fall through to a downstream `No API key found for provider "openai-codex"`. Thanks @romneyda.
 - Agents: fail closed when provider-less session models match multiple provider-prefixed runtime policies so CLI runtime routing no longer depends on config order. (#85970) Thanks @potterdigital.
 - Control UI/agents: keep collapsed tool rows readable without early ellipses, preserve raw expanded tool details, and make post-compaction AGENTS.md reinjection opt-in to avoid duplicated project context. Fixes #45649 and #45488. Thanks @BunsDev.
-- Codex: keep harness-owned turn timeouts inside the Codex runtime boundary instead of rotating auth profiles, falling back to public OpenAI, or retiring the shared app-server.
 
 ## 2026.5.24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,7 @@ Docs: https://docs.openclaw.ai
 - Auth/Codex: emit a one-shot actionable `log.warn` from the embedded legacy Codex OAuth sidecar loader when the only available seed lives in the macOS Keychain, naming `openclaw doctor --fix` and macOS Keychain instead of letting the credential silently fall through to a downstream `No API key found for provider "openai-codex"`. Thanks @romneyda.
 - Agents: fail closed when provider-less session models match multiple provider-prefixed runtime policies so CLI runtime routing no longer depends on config order. (#85970) Thanks @potterdigital.
 - Control UI/agents: keep collapsed tool rows readable without early ellipses, preserve raw expanded tool details, and make post-compaction AGENTS.md reinjection opt-in to avoid duplicated project context. Fixes #45649 and #45488. Thanks @BunsDev.
+- Codex: keep harness-owned turn timeouts inside the Codex runtime boundary instead of rotating auth profiles, falling back to public OpenAI, or retiring the shared app-server.
 
 ## 2026.5.24
 

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -4149,7 +4149,7 @@ describe("runCodexAppServerAttempt", () => {
     });
   });
 
-  it("closes the app-server client when the active turn goes idle past the attempt timeout", async () => {
+  it("interrupts but keeps the app-server client alive when a turn timeout fires", async () => {
     const close = vi.fn();
     const request = vi.fn(async (method: string) => {
       if (method === "thread/start") {
@@ -4193,7 +4193,7 @@ describe("runCodexAppServerAttempt", () => {
       },
       { timeoutMs: 5_000 },
     );
-    expect(close).toHaveBeenCalledTimes(1);
+    expect(close).not.toHaveBeenCalled();
     expect(queueActiveRunMessageForTest("session-1", "after timeout")).toBe(false);
   });
 
@@ -5508,6 +5508,7 @@ describe("runCodexAppServerAttempt", () => {
   });
 
   it("does not treat global rate-limit notifications as turn progress", async () => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
     const harness = createStartedThreadHarness();
     const params = createParams(
       path.join(tempDir, "session.jsonl"),
@@ -5549,6 +5550,10 @@ describe("runCodexAppServerAttempt", () => {
           { timeoutMs: 5_000 },
         ),
       { interval: 1 },
+    );
+    expect(warn).not.toHaveBeenCalledWith(
+      "codex app-server client retired after timed-out turn",
+      expect.anything(),
     );
   });
 

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -3164,19 +3164,11 @@ export async function runCodexAppServerAttempt(
   touchTurnCompletionActivity("turn:start", { attemptProgress: true });
 
   const abortListener = () => {
-    const shouldRetireClient = timedOut;
     interruptCodexTurnBestEffort(client, {
       threadId: thread.threadId,
       turnId: activeTurnId,
-      timeoutMs: shouldRetireClient ? CODEX_APP_SERVER_INTERRUPT_TIMEOUT_MS : undefined,
+      timeoutMs: timedOut ? CODEX_APP_SERVER_INTERRUPT_TIMEOUT_MS : undefined,
     });
-    if (shouldRetireClient) {
-      retireCodexAppServerClientAfterTimedOutTurn(client, {
-        threadId: thread.threadId,
-        turnId: activeTurnId,
-        reason: String(runAbortController.signal.reason ?? "timeout"),
-      });
-    }
     resolveCompletion?.();
   };
   runAbortController.signal.addEventListener("abort", abortListener, { once: true });
@@ -3987,29 +3979,6 @@ async function unsubscribeCodexThreadBestEffort(
       error,
     });
   }
-}
-
-function retireCodexAppServerClientAfterTimedOutTurn(
-  client: CodexAppServerClient,
-  params: {
-    threadId: string;
-    turnId: string;
-    reason: string;
-  },
-): void {
-  const clearedSharedClient = clearSharedCodexAppServerClientIfCurrent(client);
-  if (!clearedSharedClient) {
-    const close = (client as { close?: () => void }).close;
-    if (typeof close === "function") {
-      close.call(client);
-    }
-  }
-  embeddedAgentLog.warn("codex app-server client retired after timed-out turn", {
-    threadId: params.threadId,
-    turnId: params.turnId,
-    reason: params.reason,
-    clearedSharedClient,
-  });
 }
 
 type DynamicToolBuildParams = {

--- a/src/agents/pi-embedded-runner/run.codex-app-server-recovery.test.ts
+++ b/src/agents/pi-embedded-runner/run.codex-app-server-recovery.test.ts
@@ -5,6 +5,7 @@ import {
   loadRunOverflowCompactionHarness,
   MockedFailoverError,
   mockedClassifyFailoverReason,
+  mockedMarkAuthProfileFailure,
   mockedRunEmbeddedAttempt,
   overflowBaseRunParams,
   resetRunOverflowCompactionHarnessMocks,
@@ -203,6 +204,7 @@ describe("runEmbeddedPiAgent Codex app-server recovery", () => {
       "codex app-server turn idle timed out waiting for turn/completed",
     );
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(mockedMarkAuthProfileFailure).not.toHaveBeenCalled();
   });
 
   it("does not retry after visible assistant output", async () => {

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
@@ -221,6 +221,7 @@ export const mockedGetApiKeyForModel = vi.fn(
     mode: "api-key" as const,
   }),
 );
+export const mockedMarkAuthProfileFailure = vi.fn(async () => {});
 export const mockedEnsureAuthProfileStore = vi.fn(() => ({}));
 export const mockedEnsureAuthProfileStoreWithoutExternalProfiles = vi.fn(
   (_agentDir?: string, _options?: { allowKeychainPrompt?: boolean }) => ({}),
@@ -408,6 +409,8 @@ export function resetRunOverflowCompactionHarnessMocks(): void {
       mode: "api-key",
     }),
   );
+  mockedMarkAuthProfileFailure.mockReset();
+  mockedMarkAuthProfileFailure.mockResolvedValue(undefined);
   mockedEnsureAuthProfileStore.mockReset();
   mockedEnsureAuthProfileStore.mockReturnValue({});
   mockedEnsureAuthProfileStoreWithoutExternalProfiles.mockReset();
@@ -463,7 +466,7 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
 
   vi.doMock("../auth-profiles.js", () => ({
     isProfileInCooldown: vi.fn(() => false),
-    markAuthProfileFailure: vi.fn(async () => {}),
+    markAuthProfileFailure: mockedMarkAuthProfileFailure,
     markAuthProfileSuccess: mockedMarkAuthProfileSuccess,
     resolveProfilesUnavailableReason: vi.fn(() => undefined),
   }));

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1153,6 +1153,11 @@ export async function runEmbeddedPiAgent(
         if (!profileId || !reason) {
           return;
         }
+        if (pluginHarnessOwnsTransport && reason === "timeout") {
+          // Harness-owned transport timeouts are lifecycle failures, not
+          // credential evidence. Do not poison OpenClaw auth cooldowns.
+          return;
+        }
         await markAuthProfileFailure({
           store: profileFailureStore,
           profileId,
@@ -2393,6 +2398,7 @@ export async function runEmbeddedPiAgent(
               fallbackConfigured,
               failoverFailure: promptFailoverFailure,
               failoverReason: promptFailoverReason,
+              harnessOwnsTransport: pluginHarnessOwnsTransport,
               profileRotated: false,
             });
             if (
@@ -2431,6 +2437,7 @@ export async function runEmbeddedPiAgent(
                 fallbackConfigured,
                 failoverFailure: promptFailoverFailure,
                 failoverReason: promptFailoverReason,
+                harnessOwnsTransport: pluginHarnessOwnsTransport,
                 profileRotated: true,
               });
             }
@@ -2597,6 +2604,7 @@ export async function runEmbeddedPiAgent(
             idleTimedOut,
             timedOutDuringCompaction,
             timedOutDuringToolExecution,
+            harnessOwnsTransport: pluginHarnessOwnsTransport,
             profileRotated: false,
           });
           const assistantFailoverOutcome = await handleAssistantFailover({

--- a/src/agents/pi-embedded-runner/run/failover-policy.test.ts
+++ b/src/agents/pi-embedded-runner/run/failover-policy.test.ts
@@ -319,6 +319,50 @@ describe("resolveRunFailoverDecision", () => {
     });
   });
 
+  it("rotates concrete assistant failover failures that accompany harness-owned timeouts", () => {
+    expect(
+      resolveRunFailoverDecision({
+        stage: "assistant",
+        aborted: false,
+        externalAbort: false,
+        fallbackConfigured: true,
+        failoverFailure: true,
+        failoverReason: "rate_limit",
+        timedOut: true,
+        idleTimedOut: false,
+        timedOutDuringCompaction: false,
+        timedOutDuringToolExecution: false,
+        harnessOwnsTransport: true,
+        profileRotated: false,
+      }),
+    ).toEqual({
+      action: "rotate_profile",
+      reason: "rate_limit",
+    });
+  });
+
+  it("falls back with the concrete assistant failover reason after harness-owned timeout rotation is exhausted", () => {
+    expect(
+      resolveRunFailoverDecision({
+        stage: "assistant",
+        aborted: false,
+        externalAbort: false,
+        fallbackConfigured: true,
+        failoverFailure: true,
+        failoverReason: "billing",
+        timedOut: true,
+        idleTimedOut: false,
+        timedOutDuringCompaction: false,
+        timedOutDuringToolExecution: false,
+        harnessOwnsTransport: true,
+        profileRotated: true,
+      }),
+    ).toEqual({
+      action: "fallback_model",
+      reason: "billing",
+    });
+  });
+
   it("treats idle watchdog timeouts during tool execution as model silence", () => {
     expect(
       resolveRunFailoverDecision({

--- a/src/agents/pi-embedded-runner/run/failover-policy.test.ts
+++ b/src/agents/pi-embedded-runner/run/failover-policy.test.ts
@@ -298,6 +298,27 @@ describe("resolveRunFailoverDecision", () => {
     });
   });
 
+  it("does not rotate harness-owned assistant timeouts", () => {
+    expect(
+      resolveRunFailoverDecision({
+        stage: "assistant",
+        aborted: true,
+        externalAbort: false,
+        fallbackConfigured: true,
+        failoverFailure: false,
+        failoverReason: null,
+        timedOut: true,
+        idleTimedOut: false,
+        timedOutDuringCompaction: false,
+        timedOutDuringToolExecution: false,
+        harnessOwnsTransport: true,
+        profileRotated: false,
+      }),
+    ).toEqual({
+      action: "continue_normal",
+    });
+  });
+
   it("treats idle watchdog timeouts during tool execution as model silence", () => {
     expect(
       resolveRunFailoverDecision({
@@ -399,6 +420,45 @@ describe("resolveRunFailoverDecision", () => {
       }),
     ).toEqual({
       action: "fallback_model",
+      reason: "timeout",
+    });
+  });
+
+  it("does not fallback harness-owned LLM idle timeouts after profile rotation is exhausted", () => {
+    expect(
+      resolveRunFailoverDecision({
+        stage: "assistant",
+        aborted: false,
+        externalAbort: false,
+        fallbackConfigured: true,
+        failoverFailure: false,
+        failoverReason: null,
+        timedOut: false,
+        idleTimedOut: true,
+        timedOutDuringCompaction: false,
+        timedOutDuringToolExecution: false,
+        harnessOwnsTransport: true,
+        profileRotated: true,
+      }),
+    ).toEqual({
+      action: "continue_normal",
+    });
+  });
+
+  it("surfaces harness-owned prompt timeouts instead of falling back", () => {
+    expect(
+      resolveRunFailoverDecision({
+        stage: "prompt",
+        aborted: false,
+        externalAbort: false,
+        fallbackConfigured: true,
+        failoverFailure: true,
+        failoverReason: "timeout",
+        harnessOwnsTransport: true,
+        profileRotated: true,
+      }),
+    ).toEqual({
+      action: "surface_error",
       reason: "timeout",
     });
   });

--- a/src/agents/pi-embedded-runner/run/failover-policy.ts
+++ b/src/agents/pi-embedded-runner/run/failover-policy.ts
@@ -45,6 +45,7 @@ type PromptDecisionParams = {
   fallbackConfigured: boolean;
   failoverFailure: boolean;
   failoverReason: FailoverReason | null;
+  harnessOwnsTransport?: boolean;
   profileRotated: boolean;
 };
 
@@ -60,6 +61,7 @@ type AssistantDecisionParams = {
   idleTimedOut: boolean;
   timedOutDuringCompaction: boolean;
   timedOutDuringToolExecution: boolean;
+  harnessOwnsTransport?: boolean;
   profileRotated: boolean;
 };
 
@@ -107,7 +109,11 @@ function shouldRotateAssistant(params: AssistantDecisionParams): boolean {
   if (isTerminalFormatFailure(params)) {
     return false;
   }
-  return (!params.aborted && params.failoverFailure) || isAssistantTimeoutFailure(params);
+  const timeoutFailure = isAssistantTimeoutFailure(params);
+  if (timeoutFailure && params.harnessOwnsTransport) {
+    return false;
+  }
+  return (!params.aborted && params.failoverFailure) || timeoutFailure;
 }
 
 export function mergeRetryFailoverReason(params: {
@@ -141,6 +147,12 @@ export function resolveRunFailoverDecision(params: RunFailoverDecisionParams): R
 
   if (params.stage === "prompt") {
     if (params.externalAbort) {
+      return {
+        action: "surface_error",
+        reason: params.failoverReason,
+      };
+    }
+    if (params.harnessOwnsTransport && params.failoverReason === "timeout") {
       return {
         action: "surface_error",
         reason: params.failoverReason,

--- a/src/agents/pi-embedded-runner/run/failover-policy.ts
+++ b/src/agents/pi-embedded-runner/run/failover-policy.ts
@@ -127,10 +127,11 @@ function shouldRotateAssistant(params: AssistantDecisionParams): boolean {
 }
 
 function assistantFallbackReason(params: AssistantDecisionParams): FailoverReason {
-  if (isConcreteNonTimeoutAssistantFailure(params)) {
-    return params.failoverReason;
+  const failoverReason = params.failoverReason;
+  if (params.failoverFailure && failoverReason && failoverReason !== "timeout") {
+    return failoverReason;
   }
-  return isAssistantTimeoutFailure(params) ? "timeout" : (params.failoverReason ?? "unknown");
+  return isAssistantTimeoutFailure(params) ? "timeout" : (failoverReason ?? "unknown");
 }
 
 export function mergeRetryFailoverReason(params: {

--- a/src/agents/pi-embedded-runner/run/failover-policy.ts
+++ b/src/agents/pi-embedded-runner/run/failover-policy.ts
@@ -105,15 +105,32 @@ function isAssistantTimeoutFailure(params: AssistantDecisionParams): boolean {
   );
 }
 
+function isConcreteNonTimeoutAssistantFailure(params: AssistantDecisionParams): boolean {
+  return (
+    params.failoverFailure && Boolean(params.failoverReason) && params.failoverReason !== "timeout"
+  );
+}
+
 function shouldRotateAssistant(params: AssistantDecisionParams): boolean {
   if (isTerminalFormatFailure(params)) {
     return false;
   }
   const timeoutFailure = isAssistantTimeoutFailure(params);
-  if (timeoutFailure && params.harnessOwnsTransport) {
+  if (
+    timeoutFailure &&
+    params.harnessOwnsTransport &&
+    !isConcreteNonTimeoutAssistantFailure(params)
+  ) {
     return false;
   }
   return (!params.aborted && params.failoverFailure) || timeoutFailure;
+}
+
+function assistantFallbackReason(params: AssistantDecisionParams): FailoverReason {
+  if (isConcreteNonTimeoutAssistantFailure(params)) {
+    return params.failoverReason;
+  }
+  return isAssistantTimeoutFailure(params) ? "timeout" : (params.failoverReason ?? "unknown");
 }
 
 export function mergeRetryFailoverReason(params: {
@@ -198,7 +215,7 @@ export function resolveRunFailoverDecision(params: RunFailoverDecisionParams): R
   if (assistantShouldRotate && params.fallbackConfigured) {
     return {
       action: "fallback_model",
-      reason: isAssistantTimeoutFailure(params) ? "timeout" : (params.failoverReason ?? "unknown"),
+      reason: assistantFallbackReason(params),
     };
   }
   if (!assistantShouldRotate) {


### PR DESCRIPTION
## Summary

#85958 moved Codex compaction back to the Codex boundary. The follow-up timeout incident showed one remaining leak in the same area: when the app-server turn-completion watchdog fired, OpenClaw still treated that timeout like provider or credential evidence. It could retire the shared Codex app-server client, mark the auth profile as failed, and walk toward generic model failover.

This keeps harness-owned turn timeouts inside the harness boundary. A timed-out Codex turn still gets an interrupt for that turn, but OpenClaw no longer kills the shared app-server as a retry strategy. Harness-owned timeout failures also stop rotating auth profiles or falling through to public OpenAI/provider fallback paths.

The tests now lock that policy down for prompt-stage timeouts, assistant idle timeouts, auth-profile cooldowns, and the Codex app-server timeout path so future changes do not reintroduce the slop.

## Real behavior proof

Behavior addressed: Codex-runtime turn timeouts remain Codex runtime failures instead of becoming OpenClaw auth-profile failure, provider rotation, public OpenAI fallback, or shared app-server retirement.
Real environment tested: Local OpenClaw source checkout on macOS, rebased onto latest `origin/main` after #85958 landed as a squash merge.
Exact steps or command run after this patch: `pnpm test src/agents/pi-embedded-runner/run/failover-policy.test.ts src/agents/pi-embedded-runner/run.codex-app-server-recovery.test.ts extensions/codex/src/app-server/run-attempt.test.ts -- --reporter=dot`; `pnpm exec oxfmt --check --threads=1 extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts src/agents/pi-embedded-runner/run.ts src/agents/pi-embedded-runner/run/failover-policy.ts src/agents/pi-embedded-runner/run/failover-policy.test.ts src/agents/pi-embedded-runner/run.codex-app-server-recovery.test.ts src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts CHANGELOG.md`; `git diff --check origin/main...HEAD`; `pnpm check:changed`; `pnpm build`.
Evidence after fix: The app-server timeout test now asserts the timed-out turn is interrupted while the app-server client stays open; the embedded-runner recovery test asserts timeout no longer marks the auth profile failed; failover-policy tests assert harness-owned prompt and assistant timeouts do not rotate or fall back.
Observed result after fix: All targeted tests, changed checks, formatting, diff whitespace checks, and build passed on the clean follow-up branch.
What was not tested: I did not force a destructive live sleep/heartbeat timeout on Pash's running dev agent after this patch.
