### PR TITLE
fix(discord): merge media captions into one message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 - Gateway: keep session-only Control UI tool-start mirrors flowing during diagnostic queue pressure instead of silently dropping non-terminal tool updates.
 - Agents/memory: return optional not-found context for missing date-only daily memory reads instead of logging benign first-run `ENOENT` failures. Fixes #82928. Thanks @galiniliev.
+- Discord: merge streamed text captions into following media block replies so captions and attachments send as one message. (#86487) Thanks @neeravmakwana.
 - Gateway: avoid sending duplicate tool-event frames to Control UI connections that are subscribed by both run and session.
 - Discord/OpenAI voice: accept longer leading wake-name mistranscripts such as "Open Club" for OpenClaw.
 - Agents/OpenAI-compatible: stop ModelStudio-compatible chat requests before sending system/tool-only payloads that have no usable user or assistant turn. (#86177) Thanks @TurboTheTurtle.

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -7,6 +7,7 @@ import {
   setReplyPayloadMetadata,
 } from "../reply-payload.js";
 import { buildReplyPayloads } from "./agent-runner-payloads.js";
+import { createBlockReplyPipeline } from "./block-reply-pipeline.js";
 
 const baseParams = {
   isHeartbeat: false,
@@ -557,6 +558,32 @@ describe("buildReplyPayloads media filter integration", () => {
       blockStreamingEnabled: true,
       blockReplyPipeline: pipeline,
       payloads: [{ text: "response", mediaUrl: "/tmp/generated.png" }],
+    });
+
+    expect(replyPayloads).toHaveLength(0);
+  });
+
+  it("drops final caption and media already sent as one coalesced block payload", async () => {
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async () => {},
+      timeoutMs: 5000,
+      coalescing: {
+        minChars: 1,
+        maxChars: 200,
+        idleMs: 0,
+        joiner: " ",
+      },
+    });
+    pipeline.enqueue({ text: "Preview" });
+    pipeline.enqueue({ text: "below" });
+    pipeline.enqueue({ mediaUrls: ["file:///photo.png"] });
+    await pipeline.flush({ force: true });
+
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      blockStreamingEnabled: true,
+      blockReplyPipeline: pipeline,
+      payloads: [{ text: "Preview below", mediaUrls: ["file:///photo.png"] }],
     });
 
     expect(replyPayloads).toHaveLength(0);

--- a/src/auto-reply/reply/block-reply-coalescer.ts
+++ b/src/auto-reply/reply/block-reply-coalescer.ts
@@ -85,6 +85,32 @@ export function createBlockReplyCoalescer(params: {
     await onFlush(payload);
   };
 
+  const canMergeBufferedTextWithMedia = (payload: ReplyPayload) =>
+    Boolean(bufferText) &&
+    !flushOnEnqueue &&
+    !bufferAudioAsVoice &&
+    !payload.audioAsVoice &&
+    !payload.isReasoning &&
+    !isReplyPayloadStatusNotice(payload) &&
+    !bufferIsReasoning &&
+    !isReplyPayloadStatusNotice({
+      isCompactionNotice: bufferIsCompactionNotice,
+      isFallbackNotice: bufferIsFallbackNotice,
+      isStatusNotice: bufferIsStatusNotice,
+    }) &&
+    (!payload.replyToId || bufferReplyToId === payload.replyToId);
+
+  const mergeBufferedTextWithMedia = (payload: ReplyPayload, text: string): ReplyPayload => {
+    const mergedText = text ? `${bufferText}${joiner}${text}` : bufferText;
+    const mergedPayload: ReplyPayload = {
+      ...payload,
+      text: mergedText,
+      replyToId: payload.replyToId ?? bufferReplyToId,
+    };
+    resetBuffer();
+    return mergedPayload;
+  };
+
   const enqueue = (payload: ReplyPayload) => {
     if (shouldAbort()) {
       return;
@@ -94,6 +120,10 @@ export function createBlockReplyCoalescer(params: {
     const text = reply.text;
     const hasText = reply.hasText;
     if (hasMedia) {
+      if (canMergeBufferedTextWithMedia(payload)) {
+        void onFlush(mergeBufferedTextWithMedia(payload, text));
+        return;
+      }
       void flush({ force: true });
       void onFlush(payload);
       return;

--- a/src/auto-reply/reply/block-reply-pipeline.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.test.ts
@@ -214,6 +214,7 @@ describe("createBlockReplyPipeline dedup with threading", () => {
 
     expect(sent).toEqual([{ text: "Preview below", mediaUrls: ["file:///photo.png"] }]);
     expect(pipeline.getSentMediaUrls()).toEqual(["file:///photo.png"]);
+    expect(pipeline.hasSentPayload({ text: "Preview below" })).toBe(true);
   });
 
   it("keeps media separate across assistant message boundaries", async () => {

--- a/src/auto-reply/reply/block-reply-pipeline.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.test.ts
@@ -192,6 +192,59 @@ describe("createBlockReplyPipeline dedup with threading", () => {
     expect(sent).toEqual([{ presentation }]);
   });
 
+  it("merges coalesced text into a following media payload", async () => {
+    const sent: Array<{ text?: string; mediaUrls?: string[] }> = [];
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async (payload) => {
+        sent.push({ text: payload.text, mediaUrls: payload.mediaUrls });
+      },
+      timeoutMs: 5000,
+      coalescing: {
+        minChars: 1,
+        maxChars: 200,
+        idleMs: 0,
+        joiner: " ",
+      },
+    });
+
+    pipeline.enqueue({ text: "Preview" });
+    pipeline.enqueue({ text: "below" });
+    pipeline.enqueue({ mediaUrls: ["file:///photo.png"] });
+    await pipeline.flush({ force: true });
+
+    expect(sent).toEqual([{ text: "Preview below", mediaUrls: ["file:///photo.png"] }]);
+    expect(pipeline.getSentMediaUrls()).toEqual(["file:///photo.png"]);
+  });
+
+  it("keeps media separate across assistant message boundaries", async () => {
+    const sent: Array<{ text?: string; mediaUrls?: string[] }> = [];
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async (payload) => {
+        sent.push({ text: payload.text, mediaUrls: payload.mediaUrls });
+      },
+      timeoutMs: 5000,
+      coalescing: {
+        minChars: 1,
+        maxChars: 200,
+        idleMs: 0,
+        joiner: " ",
+      },
+    });
+
+    pipeline.enqueue(
+      setReplyPayloadMetadata({ text: "First block" }, { assistantMessageIndex: 0 }),
+    );
+    pipeline.enqueue(
+      setReplyPayloadMetadata({ mediaUrls: ["file:///photo.png"] }, { assistantMessageIndex: 1 }),
+    );
+    await pipeline.flush({ force: true });
+
+    expect(sent).toEqual([
+      { text: "First block", mediaUrls: undefined },
+      { text: undefined, mediaUrls: ["file:///photo.png"] },
+    ]);
+  });
+
   it("does not track media when text-only blocks are delivered", async () => {
     const pipeline = createBlockReplyPipeline({
       onBlockReply: async () => {},

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -244,9 +244,29 @@ export function createBlockReplyPipeline(params: {
     }
     const reply = resolveSendableOutboundReplyParts(payload);
     const hasNonTextContent = hasOutboundReplyContent(
-      { ...payload, text: undefined },
+      { ...payload, text: undefined, mediaUrl: undefined, mediaUrls: undefined },
       { trimText: true },
     );
+    if (reply.hasMedia && coalescer && !hasNonTextContent) {
+      const assistantMessageIndex = getReplyPayloadMetadata(payload)?.assistantMessageIndex;
+      if (
+        assistantMessageIndex !== undefined &&
+        bufferedAssistantMessageIndex !== undefined &&
+        assistantMessageIndex !== bufferedAssistantMessageIndex &&
+        coalescer.hasBuffered()
+      ) {
+        flushBufferedAssistantBlock();
+      }
+      const payloadKey = createBlockReplyPayloadKey(payload);
+      if (hasSeenOrQueuedPayloadKey(payloadKey) || bufferedKeys.has(payloadKey)) {
+        return;
+      }
+      seenKeys.add(payloadKey);
+      bufferedKeys.add(payloadKey);
+      bufferedAssistantMessageIndex = assistantMessageIndex;
+      coalescer.enqueue(payload);
+      return;
+    }
     if (reply.hasMedia || hasNonTextContent) {
       void coalescer?.flush({ force: true });
       sendPayload(payload, /* bypassSeenCheck */ false);

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -170,7 +170,7 @@ export function createBlockReplyPipeline(params: {
         for (const mediaUrl of reply.mediaUrls) {
           sentMediaUrls.add(mediaUrl);
         }
-        if (!isStatusNotice && !reply.hasMedia && reply.trimmedText) {
+        if (!isStatusNotice && reply.trimmedText) {
           streamedTextFragments.push(reply.trimmedText);
         }
         if (!isStatusNotice) {

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -980,7 +980,7 @@ describe("block reply coalescer", () => {
     }
   });
 
-  it("merges compatible buffered text into following media payloads", () => {
+  it("merges compatible buffered text into following media payloads", async () => {
     const { flushes, coalescer } = createPayloadCoalescerHarness<{
       text?: string;
       mediaUrls?: string[];
@@ -994,7 +994,7 @@ describe("block reply coalescer", () => {
     coalescer.enqueue({ text: "Hello", replyToId: "thread-1" });
     coalescer.enqueue({ text: "world" });
     coalescer.enqueue({ mediaUrls: ["https://example.com/a.png"] });
-    void coalescer.flush({ force: true });
+    await coalescer.flush({ force: true });
 
     expect(flushes).toEqual([
       {
@@ -1006,7 +1006,7 @@ describe("block reply coalescer", () => {
     coalescer.stop();
   });
 
-  it("keeps reasoning text separate from media payloads", () => {
+  it("keeps reasoning text separate from media payloads", async () => {
     const { flushes, coalescer } = createPayloadCoalescerHarness<{
       text?: string;
       mediaUrls?: string[];
@@ -1019,7 +1019,7 @@ describe("block reply coalescer", () => {
 
     coalescer.enqueue({ text: "hidden", isReasoning: true });
     coalescer.enqueue({ mediaUrls: ["https://example.com/a.png"] });
-    void coalescer.flush({ force: true });
+    await coalescer.flush({ force: true });
 
     expect(flushes).toEqual([
       { text: "hidden", mediaUrls: undefined, isReasoning: true },
@@ -1032,7 +1032,7 @@ describe("block reply coalescer", () => {
     coalescer.stop();
   });
 
-  it("keeps buffered text separate when media changes reply target", () => {
+  it("keeps buffered text separate when media changes reply target", async () => {
     const { flushes, coalescer } = createPayloadCoalescerHarness<{
       text?: string;
       mediaUrls?: string[];
@@ -1045,7 +1045,7 @@ describe("block reply coalescer", () => {
 
     coalescer.enqueue({ text: "Unthreaded caption" });
     coalescer.enqueue({ mediaUrls: ["https://example.com/a.png"], replyToId: "thread-2" });
-    void coalescer.flush({ force: true });
+    await coalescer.flush({ force: true });
 
     expect(flushes).toEqual([
       { text: "Unthreaded caption", mediaUrls: undefined, replyToId: undefined },
@@ -1058,7 +1058,7 @@ describe("block reply coalescer", () => {
     coalescer.stop();
   });
 
-  it("keeps text separate from voice media payloads", () => {
+  it("keeps text separate from voice media payloads", async () => {
     const { flushes, coalescer } = createPayloadCoalescerHarness<{
       text?: string;
       mediaUrls?: string[];
@@ -1071,7 +1071,7 @@ describe("block reply coalescer", () => {
 
     coalescer.enqueue({ text: "Listen to this" });
     coalescer.enqueue({ mediaUrls: ["https://example.com/a.ogg"], audioAsVoice: true });
-    void coalescer.flush({ force: true });
+    await coalescer.flush({ force: true });
 
     expect(flushes).toEqual([
       { text: "Listen to this", mediaUrls: undefined, audioAsVoice: undefined },

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -795,6 +795,19 @@ describe("block reply coalescer", () => {
     return { flushes, coalescer };
   }
 
+  type FlushedPayload = Parameters<Parameters<typeof createBlockReplyCoalescer>[0]["onFlush"]>[0];
+  function createPayloadCoalescerHarness<T>(pick: (payload: FlushedPayload) => T) {
+    const flushes: T[] = [];
+    const coalescer = createBlockReplyCoalescer({
+      config: { minChars: 1, maxChars: 200, idleMs: 0, joiner: " " },
+      shouldAbort: () => false,
+      onFlush: (payload) => {
+        flushes.push(pick(payload));
+      },
+    });
+    return { flushes, coalescer };
+  }
+
   it("coalesces chunks within the idle window", async () => {
     vi.useFakeTimers();
     const { flushes, coalescer } = createBlockCoalescerHarness({
@@ -967,26 +980,107 @@ describe("block reply coalescer", () => {
     }
   });
 
-  it("flushes buffered text before media payloads", () => {
-    const flushes: Array<{ text?: string; mediaUrls?: string[] }> = [];
-    const coalescer = createBlockReplyCoalescer({
-      config: { minChars: 1, maxChars: 200, idleMs: 0, joiner: " " },
-      shouldAbort: () => false,
-      onFlush: (payload) => {
-        flushes.push({
-          text: payload.text,
-          mediaUrls: payload.mediaUrls,
-        });
-      },
-    });
+  it("merges compatible buffered text into following media payloads", () => {
+    const { flushes, coalescer } = createPayloadCoalescerHarness<{
+      text?: string;
+      mediaUrls?: string[];
+      replyToId?: string;
+    }>((payload) => ({
+      text: payload.text,
+      mediaUrls: payload.mediaUrls,
+      replyToId: payload.replyToId,
+    }));
 
-    coalescer.enqueue({ text: "Hello" });
+    coalescer.enqueue({ text: "Hello", replyToId: "thread-1" });
     coalescer.enqueue({ text: "world" });
     coalescer.enqueue({ mediaUrls: ["https://example.com/a.png"] });
     void coalescer.flush({ force: true });
 
-    expect(flushes[0].text).toBe("Hello world");
-    expect(flushes[1].mediaUrls).toEqual(["https://example.com/a.png"]);
+    expect(flushes).toEqual([
+      {
+        text: "Hello world",
+        mediaUrls: ["https://example.com/a.png"],
+        replyToId: "thread-1",
+      },
+    ]);
+    coalescer.stop();
+  });
+
+  it("keeps reasoning text separate from media payloads", () => {
+    const { flushes, coalescer } = createPayloadCoalescerHarness<{
+      text?: string;
+      mediaUrls?: string[];
+      isReasoning?: boolean;
+    }>((payload) => ({
+      text: payload.text,
+      mediaUrls: payload.mediaUrls,
+      isReasoning: payload.isReasoning,
+    }));
+
+    coalescer.enqueue({ text: "hidden", isReasoning: true });
+    coalescer.enqueue({ mediaUrls: ["https://example.com/a.png"] });
+    void coalescer.flush({ force: true });
+
+    expect(flushes).toEqual([
+      { text: "hidden", mediaUrls: undefined, isReasoning: true },
+      {
+        text: undefined,
+        mediaUrls: ["https://example.com/a.png"],
+        isReasoning: undefined,
+      },
+    ]);
+    coalescer.stop();
+  });
+
+  it("keeps buffered text separate when media changes reply target", () => {
+    const { flushes, coalescer } = createPayloadCoalescerHarness<{
+      text?: string;
+      mediaUrls?: string[];
+      replyToId?: string;
+    }>((payload) => ({
+      text: payload.text,
+      mediaUrls: payload.mediaUrls,
+      replyToId: payload.replyToId,
+    }));
+
+    coalescer.enqueue({ text: "Unthreaded caption" });
+    coalescer.enqueue({ mediaUrls: ["https://example.com/a.png"], replyToId: "thread-2" });
+    void coalescer.flush({ force: true });
+
+    expect(flushes).toEqual([
+      { text: "Unthreaded caption", mediaUrls: undefined, replyToId: undefined },
+      {
+        text: undefined,
+        mediaUrls: ["https://example.com/a.png"],
+        replyToId: "thread-2",
+      },
+    ]);
+    coalescer.stop();
+  });
+
+  it("keeps text separate from voice media payloads", () => {
+    const { flushes, coalescer } = createPayloadCoalescerHarness<{
+      text?: string;
+      mediaUrls?: string[];
+      audioAsVoice?: boolean;
+    }>((payload) => ({
+      text: payload.text,
+      mediaUrls: payload.mediaUrls,
+      audioAsVoice: payload.audioAsVoice,
+    }));
+
+    coalescer.enqueue({ text: "Listen to this" });
+    coalescer.enqueue({ mediaUrls: ["https://example.com/a.ogg"], audioAsVoice: true });
+    void coalescer.flush({ force: true });
+
+    expect(flushes).toEqual([
+      { text: "Listen to this", mediaUrls: undefined, audioAsVoice: undefined },
+      {
+        text: undefined,
+        mediaUrls: ["https://example.com/a.ogg"],
+        audioAsVoice: true,
+      },
+    ]);
     coalescer.stop();
   });
 });


### PR DESCRIPTION
## Summary
- Fixes #86446 by folding compatible buffered visible reply text into the following media payload.
- Keeps reasoning/status notices, reply-target changes, and voice media on separate payloads so existing runtime boundaries remain intact.
- Adds focused regression coverage for the merge path and the preserved split paths.

## Root Cause
`createBlockReplyCoalescer` flushed any buffered text as soon as a media payload arrived, then emitted the media payload separately. Discord's sender already supports sending `content` and `files` in one request, but the shared coalescer split the turn before Discord received it.

## Why This Is Safe
The merge is limited to compatible buffered visible text followed by media. It is disabled when `flushOnEnqueue` is active, for reasoning/status notice boundaries, for voice media, and when the media payload introduces a different reply target. The media sender still owns Discord API behavior, media loading, chunking, and attachment delivery.

## Security And Runtime Controls
No prompt-only policy is introduced. Existing runtime-enforced checks for Discord credentials, target resolution, media loading, file access, permissions, voice handling, and message delivery are unchanged. This patch only changes how already-sendable reply payloads are coalesced before delivery.

## Real Behavior Proof
<img width="837" height="216" alt="discord_proof" src="https://github.com/user-attachments/assets/8fd3f17f-7c86-445b-ab9b-7374c8041dbc" />

Behavior addressed: text plus media in one assistant turn should arrive as one Discord message with the text as caption and the file attached.

Real environment tested: macOS source checkout, OpenClaw `2026.5.25`, managed LaunchAgent gateway on loopback `127.0.0.1:18789`. Secrets, channel ids, and platform message ids were redacted from logs.

Before patch source-level log:

```json
{
  "proof": "before",
  "flushCount": 2,
  "flushes": [
    {
      "index": 1,
      "hasText": true,
      "textPreview": "Caption before attachmen...",
      "mediaCount": 0,
      "mediaSchemes": [],
      "isReasoning": false,
      "isStatusNotice": false
    },
    {
      "index": 2,
      "hasText": false,
      "textPreview": "",
      "mediaCount": 1,
      "mediaSchemes": ["https"],
      "isReasoning": false,
      "isStatusNotice": false
    }
  ]
}
```

After patch source-level log:

```json
{
  "proof": "after-gateway-restart-source-checkout",
  "flushCount": 1,
  "flushes": [
    {
      "index": 1,
      "hasText": true,
      "textPreview": "Caption before attachmen...",
      "mediaCount": 1,
      "mediaSchemes": ["https"],
      "isReasoning": false,
      "isStatusNotice": false
    }
  ]
}
```

Gateway restart proof after rebuilding local OpenClaw:

```json
{
  "cliVersion": "2026.5.25",
  "gatewayVersion": "2026.5.25",
  "gatewayBind": "127.0.0.1:18789",
  "rpcOk": true,
  "runtimeStatus": "running"
}
```

Redacted gateway log tail after restart included `starting channels and sidecars...`, `gateway ready`, heartbeat start, and provider auth pre-warm completion. Token values and personal/channel identifiers were not included.

Live Discord verification sent marker `OC-86446-live-20260525124156`. The patched coalescer emitted one text+media payload, and Discord returned one platform message receipt:

```json
{
  "marker": "OC-86446-live-20260525124156",
  "coalescedFlushCount": 1,
  "coalescedPayload": {
    "hasText": true,
    "textContainsMarker": true,
    "mediaCount": 1,
    "mediaScheme": "https"
  },
  "discordResult": {
    "messageIdPresent": true,
    "platformMessageCount": 1,
    "firstReceiptPartKind": "media",
    "receiptPartCount": 1
  }
}
```

## Verification
- `git diff --check`
- `node scripts/run-vitest.mjs src/auto-reply/reply/reply-utils.test.ts extensions/discord/src/send.sends-basic-channel-messages.test.ts -t "block reply coalescer|preserves whitespace in media captions|sends media with empty text"`
- `pnpm check:changed`
- `pnpm build`
- `pnpm openclaw gateway restart`
- Live Discord send with marker `OC-86446-live-20260525124156`

## Out-Of-Scope Follow-Ups
- No Discord sender API changes; it already supports text plus media in one request.
- No changes to voice-message behavior, reasoning/status notices, reply target policy, or channel credentials.
- No persistent local channel config changes were made for the live proof.

Made with [Cursor](https://cursor.com)