### PR TITLE
[codex] mirror proactive deliveries into session transcripts

### DIFF
--- a/src/cron/delivery.failure-notify.test.ts
+++ b/src/cron/delivery.failure-notify.test.ts
@@ -36,7 +36,8 @@ vi.mock("../logging.js", () => ({
   })),
 }));
 
-const { sendFailureNotificationAnnounce } = await import("./delivery.js");
+const { sendCronAnnouncePayloadStrict, sendFailureNotificationAnnounce } =
+  await import("./delivery.js");
 
 type DeliveryRequest = {
   abortSignal?: unknown;
@@ -46,6 +47,12 @@ type DeliveryRequest = {
   channel?: string;
   deps?: unknown;
   identity?: unknown;
+  mirror?: {
+    agentId?: string;
+    idempotencyKey?: string;
+    sessionKey?: string;
+    text?: string;
+  };
   payloads?: unknown;
   session?: unknown;
   threadId?: number;
@@ -117,6 +124,175 @@ describe("sendFailureNotificationAnnounce", () => {
     expect(deliveryRequest.bestEffort).toBe(false);
     expect(deliveryRequest.deps).toEqual({ kind: "deps" });
     expect(deliveryRequest.abortSignal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("mirrors successful announces into custom delivery session transcripts", async () => {
+    const abortController = new AbortController();
+
+    await sendCronAnnouncePayloadStrict({
+      deps: {} as never,
+      cfg: {} as never,
+      agentId: "main",
+      jobId: "job-1",
+      target: {
+        channel: "telegram",
+        sessionKey: "agent:main:session:daily-digest",
+      },
+      message: "Cron summary",
+      abortSignal: abortController.signal,
+    });
+
+    const [deliveryRequest] = mocks.deliverOutboundPayloads.mock.calls[0] as [
+      {
+        mirror?: {
+          agentId?: string;
+          idempotencyKey?: string;
+          sessionKey?: string;
+          text?: string;
+        };
+      },
+    ];
+    expect(deliveryRequest.mirror).toMatchObject({
+      sessionKey: "agent:main:session:daily-digest",
+      agentId: "main",
+      text: "Cron summary",
+    });
+    expect(deliveryRequest.mirror?.idempotencyKey).toMatch(/^cron-announce-mirror:v1:job-1:/);
+  });
+
+  it.each([
+    {
+      name: "legacy main alias",
+      agentId: "ops",
+      cfg: { session: { mainKey: "work" } },
+      sessionKey: "main",
+      expected: "agent:ops:work",
+    },
+    {
+      name: "canonical main alias",
+      agentId: "ops",
+      cfg: { session: { mainKey: "work" } },
+      sessionKey: "agent:ops:main",
+      expected: "agent:ops:work",
+    },
+    {
+      name: "unscoped custom session alias",
+      agentId: "main",
+      cfg: {},
+      sessionKey: "daily-digest",
+      expected: "agent:main:daily-digest",
+    },
+  ])(
+    "canonicalizes cron mirror session keys for $name",
+    async ({ agentId, cfg, sessionKey, expected }) => {
+      const abortController = new AbortController();
+
+      await sendCronAnnouncePayloadStrict({
+        deps: {} as never,
+        cfg: cfg as never,
+        agentId,
+        jobId: "job-1",
+        target: {
+          channel: "telegram",
+          sessionKey,
+        },
+        message: "Cron summary",
+        abortSignal: abortController.signal,
+      });
+
+      const deliveryRequest = firstDeliveryRequest();
+      expect(deliveryRequest.mirror).toMatchObject({
+        sessionKey: expected,
+        agentId,
+        text: "Cron summary",
+      });
+    },
+  );
+
+  it("canonicalizes failure alert mirror session keys with the configured main alias", async () => {
+    const cfg = { session: { mainKey: "work" } };
+
+    await sendFailureNotificationAnnounce(
+      {} as never,
+      cfg as never,
+      "ops",
+      "job-1",
+      {
+        channel: "telegram",
+        sessionKey: "main",
+      },
+      "Cron failed",
+    );
+
+    const deliveryRequest = firstDeliveryRequest();
+    expect(deliveryRequest.mirror).toMatchObject({
+      sessionKey: "agent:ops:work",
+      agentId: "ops",
+      text: "Cron failed",
+    });
+  });
+
+  it("skips mirrors for routed peer session keys to avoid active chat lock races", async () => {
+    const abortController = new AbortController();
+
+    await sendCronAnnouncePayloadStrict({
+      deps: {} as never,
+      cfg: {} as never,
+      agentId: "main",
+      jobId: "job-1",
+      target: {
+        channel: "telegram",
+        sessionKey: "agent:main:telegram:direct:123:thread:99",
+      },
+      message: "Cron summary",
+      abortSignal: abortController.signal,
+    });
+
+    const deliveryRequest = firstDeliveryRequest();
+    expect(deliveryRequest.mirror).toBeUndefined();
+  });
+
+  it("skips mirrors for legacy dm routed peer session keys", async () => {
+    const abortController = new AbortController();
+
+    await sendCronAnnouncePayloadStrict({
+      deps: {} as never,
+      cfg: {} as never,
+      agentId: "main",
+      jobId: "job-1",
+      target: {
+        channel: "telegram",
+        sessionKey: "agent:main:telegram:dm:123:thread:99",
+      },
+      message: "Cron summary",
+      abortSignal: abortController.signal,
+    });
+
+    const deliveryRequest = firstDeliveryRequest();
+    expect(deliveryRequest.mirror).toBeUndefined();
+  });
+
+  it.each([
+    "agent:main:telegram:group:-100123:topic:77",
+    "agent:main:slack:channel:general:thread:1699999999.0001",
+  ])("skips mirrors for routed group/channel session key %s", async (sessionKey) => {
+    const abortController = new AbortController();
+
+    await sendCronAnnouncePayloadStrict({
+      deps: {} as never,
+      cfg: {} as never,
+      agentId: "main",
+      jobId: "job-1",
+      target: {
+        channel: "telegram",
+        sessionKey,
+      },
+      message: "Cron summary",
+      abortSignal: abortController.signal,
+    });
+
+    const deliveryRequest = firstDeliveryRequest();
+    expect(deliveryRequest.mirror).toBeUndefined();
   });
 
   it("uses sessionKey for delivery-target resolution and outbound context", async () => {

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { sendDurableMessageBatch } from "../channels/message/runtime.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { createOutboundSendDeps } from "../cli/outbound-send-deps.js";
@@ -6,6 +7,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { resolveAgentOutboundIdentity } from "../infra/outbound/identity.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { getChildLogger } from "../logging.js";
+import { deriveSessionChatTypeFromKey } from "../sessions/session-chat-type-shared.js";
 import {
   resolveFailureDestination,
   type CronFailureDeliveryPlan,
@@ -17,6 +19,7 @@ import {
   resolveDeliveryTarget,
   type DeliveryTargetResolution,
 } from "./isolated-agent/delivery-target.js";
+import { resolveCronAgentSessionKey } from "./isolated-agent/session-key.js";
 import { resolveCronNotificationSessionKey } from "./session-target.js";
 import type { CronMessageChannel } from "./types.js";
 
@@ -30,6 +33,7 @@ export {
 
 const FAILURE_NOTIFICATION_TIMEOUT_MS = 30_000;
 const cronDeliveryLogger = getChildLogger({ subsystem: "cron-delivery" });
+const ROUTED_PEER_SESSION_CHAT_TYPES = new Set(["direct", "group", "channel"]);
 
 export type CronAnnounceTarget = {
   channel?: string;
@@ -39,6 +43,52 @@ export type CronAnnounceTarget = {
 };
 
 type SuccessfulDeliveryTarget = Extract<DeliveryTargetResolution, { ok: true }>;
+
+function buildCronAnnounceMirrorIdempotencyKey(params: {
+  jobId: string;
+  target: SuccessfulDeliveryTarget;
+  message: string;
+}): string {
+  const digest = createHash("sha256")
+    .update(
+      JSON.stringify([
+        params.target.channel,
+        params.target.accountId ?? "",
+        params.target.to,
+        params.target.threadId ?? "",
+        params.message,
+      ]),
+    )
+    .digest("hex")
+    .slice(0, 24);
+  return `cron-announce-mirror:v1:${params.jobId}:${digest}`;
+}
+
+function isRoutedPeerSessionKey(sessionKey: string): boolean {
+  return ROUTED_PEER_SESSION_CHAT_TYPES.has(deriveSessionChatTypeFromKey(sessionKey));
+}
+
+function resolveCronAnnounceMirrorSessionKey(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  sessionKey: string | undefined;
+}): string | undefined {
+  const trimmed = params.sessionKey?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  // Routed peer sessions can be active embedded conversations. Mirror only
+  // into custom/main session keys here so cron delivery does not race locks.
+  if (isRoutedPeerSessionKey(trimmed)) {
+    return undefined;
+  }
+  return resolveCronAgentSessionKey({
+    sessionKey: trimmed,
+    agentId: params.agentId,
+    mainKey: params.cfg.session?.mainKey,
+    cfg: params.cfg,
+  });
+}
 
 async function resolveCronAnnounceDelivery(params: {
   cfg: OpenClawConfig;
@@ -51,6 +101,7 @@ async function resolveCronAnnounceDelivery(params: {
       resolvedTarget: SuccessfulDeliveryTarget;
       session: ReturnType<typeof buildOutboundSessionContext>;
       identity: ReturnType<typeof resolveAgentOutboundIdentity>;
+      mirrorSessionKey?: string;
     }
   | { ok: false; error: Error }
 > {
@@ -74,12 +125,18 @@ async function resolveCronAnnounceDelivery(params: {
       sessionKey: params.target.sessionKey,
     }),
   });
+  const mirrorSessionKey = resolveCronAnnounceMirrorSessionKey({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    sessionKey: params.target.sessionKey,
+  });
 
   return {
     ok: true,
     resolvedTarget,
     session,
     identity,
+    ...(mirrorSessionKey ? { mirrorSessionKey } : {}),
   };
 }
 
@@ -90,7 +147,10 @@ async function deliverCronAnnouncePayload(params: {
     resolvedTarget: SuccessfulDeliveryTarget;
     session: ReturnType<typeof buildOutboundSessionContext>;
     identity: ReturnType<typeof resolveAgentOutboundIdentity>;
+    mirrorSessionKey?: string;
   };
+  agentId: string;
+  jobId: string;
   message: string;
   abortSignal: AbortSignal;
 }): Promise<void> {
@@ -106,6 +166,18 @@ async function deliverCronAnnouncePayload(params: {
     bestEffort: false,
     deps: createOutboundSendDeps(params.deps),
     signal: params.abortSignal,
+    mirror: params.delivery.mirrorSessionKey
+      ? {
+          sessionKey: params.delivery.mirrorSessionKey,
+          agentId: params.agentId,
+          text: params.message,
+          idempotencyKey: buildCronAnnounceMirrorIdempotencyKey({
+            jobId: params.jobId,
+            target: params.delivery.resolvedTarget,
+            message: params.message,
+          }),
+        }
+      : undefined,
   });
   if (send.status === "failed" || send.status === "partial_failed") {
     throw send.error;
@@ -129,6 +201,8 @@ export async function sendCronAnnouncePayloadStrict(params: {
     deps: params.deps,
     cfg: params.cfg,
     delivery,
+    agentId: params.agentId,
+    jobId: params.jobId,
     message: params.message,
     abortSignal: params.abortSignal,
   });
@@ -162,6 +236,8 @@ export async function sendFailureNotificationAnnounce(
       deps,
       cfg,
       delivery,
+      agentId,
+      jobId,
       message,
       abortSignal: abortController.signal,
     });

--- a/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
+++ b/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
@@ -1,20 +1,45 @@
 import fs from "node:fs/promises";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { runHeartbeatOnce, type HeartbeatDeps } from "./heartbeat-runner.js";
 import { installHeartbeatRunnerTestRuntime } from "./heartbeat-runner.test-harness.js";
 import {
   type HeartbeatReplySpy,
   seedMainSessionStore,
+  seedSessionStore,
   withTempHeartbeatSandbox,
   withTempTelegramHeartbeatSandbox,
 } from "./heartbeat-runner.test-utils.js";
+
+type TranscriptAppendParams = {
+  agentId?: string;
+  idempotencyKey?: string;
+  sessionKey?: string;
+  text?: string;
+};
+
+const transcriptMocks = vi.hoisted(() => ({
+  appendAssistantMessageToSessionTranscript: vi.fn(async (_params: TranscriptAppendParams) => ({
+    ok: true,
+    sessionFile: "test-session.jsonl",
+    messageId: "message-1",
+  })),
+}));
+
+vi.mock("../config/sessions/transcript.runtime.js", () => ({
+  appendAssistantMessageToSessionTranscript:
+    transcriptMocks.appendAssistantMessageToSessionTranscript,
+}));
 
 installHeartbeatRunnerTestRuntime();
 
 describe("runHeartbeatOnce ack handling", () => {
   const WHATSAPP_GROUP = "120363140186826074@g.us";
   const TELEGRAM_GROUP = "-1001234567890";
+
+  beforeEach(() => {
+    transcriptMocks.appendAssistantMessageToSessionTranscript.mockClear();
+  });
 
   function createHeartbeatConfig(params: {
     tmpDir: string;
@@ -261,6 +286,49 @@ describe("runHeartbeatOnce ack handling", () => {
         text: "HEARTBEAT_OK",
         cfg,
       });
+    });
+  });
+
+  it("mirrors delivered heartbeat notifications into the active chat transcript", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = createWhatsAppHeartbeatConfig({
+        tmpDir,
+        storePath,
+      });
+      const sessionKey = "agent:main:whatsapp:direct:test-user";
+      await seedSessionStore(storePath, sessionKey, {
+        sessionId: "direct-sid",
+        lastChannel: "whatsapp",
+        lastProvider: "whatsapp",
+        lastTo: "test-user",
+      });
+
+      replySpy.mockResolvedValue({ text: "Deepali messaged about Zane." });
+      const sendWhatsApp = createMessageSendSpy();
+
+      await runHeartbeatOnce({
+        cfg,
+        sessionKey,
+        deps: {
+          ...makeWhatsAppDeps({ sendWhatsApp }),
+          getReplyFromConfig: replySpy,
+        },
+      });
+
+      expect(sendWhatsApp).toHaveBeenCalledWith(
+        "test-user",
+        "Deepali messaged about Zane.",
+        expect.any(Object),
+      );
+      expect(transcriptMocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledTimes(1);
+      const appendCall =
+        transcriptMocks.appendAssistantMessageToSessionTranscript.mock.calls[0]?.[0];
+      expect(appendCall).toMatchObject({
+        agentId: "main",
+        sessionKey,
+        text: "Deepali messaged about Zane.",
+      });
+      expect(appendCall?.idempotencyKey).toMatch(/^heartbeat-delivery-mirror:v1:/);
     });
   });
 

--- a/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
+++ b/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
@@ -332,6 +332,53 @@ describe("runHeartbeatOnce ack handling", () => {
     });
   });
 
+  it("preserves heartbeat mirror text when notifications include media URLs", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = createWhatsAppHeartbeatConfig({
+        tmpDir,
+        storePath,
+      });
+      const sessionKey = "agent:main:whatsapp:direct:test-user";
+      await seedSessionStore(storePath, sessionKey, {
+        sessionId: "direct-sid",
+        lastChannel: "whatsapp",
+        lastProvider: "whatsapp",
+        lastTo: "test-user",
+      });
+
+      replySpy.mockResolvedValue({
+        text: "Deepali sent the programme attachment.",
+        mediaUrls: ["file:///tmp/programme.pdf"],
+      });
+      const sendWhatsApp = createMessageSendSpy();
+
+      await runHeartbeatOnce({
+        cfg,
+        sessionKey,
+        deps: {
+          ...makeWhatsAppDeps({ sendWhatsApp }),
+          getReplyFromConfig: replySpy,
+        },
+      });
+
+      expect(sendWhatsApp).toHaveBeenCalledWith(
+        "test-user",
+        "Deepali sent the programme attachment.",
+        expect.any(Object),
+      );
+      expect(transcriptMocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledTimes(1);
+      const appendCall =
+        transcriptMocks.appendAssistantMessageToSessionTranscript.mock.calls[0]?.[0];
+      expect(appendCall).toMatchObject({
+        agentId: "main",
+        sessionKey,
+        text: "Deepali sent the programme attachment.",
+      });
+      expect(appendCall?.text).not.toBe("programme.pdf");
+      expect(appendCall?.idempotencyKey).toMatch(/^heartbeat-delivery-mirror:v1:/);
+    });
+  });
+
   it.each([
     {
       title: "does not deliver HEARTBEAT_OK to telegram when showOk is false",

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -160,6 +160,77 @@ function loadHeartbeatRunnerRuntime() {
   return heartbeatRunnerRuntimePromise;
 }
 
+function normalizeHeartbeatMirrorMediaUrls(payloads: readonly ReplyPayload[]): string[] {
+  return payloads.flatMap((payload) => [
+    ...(typeof payload.mediaUrl === "string" && payload.mediaUrl.trim()
+      ? [payload.mediaUrl.trim()]
+      : []),
+    ...(Array.isArray(payload.mediaUrls)
+      ? payload.mediaUrls
+          .filter((url): url is string => typeof url === "string" && url.trim().length > 0)
+          .map((url) => url.trim())
+      : []),
+  ]);
+}
+
+function resolveHeartbeatMirrorText(payloads: readonly ReplyPayload[]): string | undefined {
+  const text = payloads
+    .map((payload) => (typeof payload.text === "string" ? payload.text.trim() : ""))
+    .filter(Boolean)
+    .join("\n\n")
+    .trim();
+  return text || undefined;
+}
+
+function buildHeartbeatMirrorIdempotencyKey(params: {
+  runSessionKey: string;
+  sessionKey: string;
+  startedAt: number;
+  text?: string;
+  mediaUrls: readonly string[];
+}): string {
+  const digest = createHash("sha256")
+    .update(
+      JSON.stringify([
+        params.runSessionKey,
+        params.sessionKey,
+        params.startedAt,
+        params.text ?? "",
+        params.mediaUrls,
+      ]),
+    )
+    .digest("hex")
+    .slice(0, 24);
+  return `heartbeat-delivery-mirror:v1:${params.runSessionKey}:${params.startedAt}:${digest}`;
+}
+
+function buildHeartbeatDeliveryMirror(params: {
+  agentId: string;
+  sessionKey: string;
+  runSessionKey: string;
+  startedAt: number;
+  payloads: readonly ReplyPayload[];
+}) {
+  const text = resolveHeartbeatMirrorText(params.payloads);
+  const mediaUrls = normalizeHeartbeatMirrorMediaUrls(params.payloads);
+  if (!text && mediaUrls.length === 0) {
+    return undefined;
+  }
+  return {
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
+    ...(text ? { text } : {}),
+    ...(mediaUrls.length > 0 ? { mediaUrls } : {}),
+    idempotencyKey: buildHeartbeatMirrorIdempotencyKey({
+      runSessionKey: params.runSessionKey,
+      sessionKey: params.sessionKey,
+      startedAt: params.startedAt,
+      text,
+      mediaUrls,
+    }),
+  };
+}
+
 const HEARTBEAT_ALWAYS_BUSY_LANES = [CommandLane.Cron, CommandLane.CronNested] as const;
 
 function hasQueuedWorkInLanes(
@@ -1722,14 +1793,22 @@ export async function runHeartbeatOnce(opts: {
         return false;
       }
     }
+    const heartbeatOkPayloads = [{ text: resolveHeartbeatOkText() }];
     const send = await sendDurableMessageBatch({
       cfg,
       channel: delivery.channel,
       to: delivery.to,
       accountId: delivery.accountId,
       threadId: delivery.threadId,
-      payloads: [{ text: resolveHeartbeatOkText() }],
+      payloads: heartbeatOkPayloads,
       session: outboundSession,
+      mirror: buildHeartbeatDeliveryMirror({
+        agentId,
+        sessionKey,
+        runSessionKey,
+        startedAt,
+        payloads: heartbeatOkPayloads,
+      }),
       deps: opts.deps,
     });
     if (send.status === "failed" || send.status === "partial_failed") {
@@ -2002,6 +2081,17 @@ export async function runHeartbeatOnce(opts: {
       }
     }
 
+    const deliveryPayloads = [
+      ...reasoningPayloads,
+      ...(shouldSkipMain
+        ? []
+        : [
+            {
+              text: normalized.text,
+              mediaUrls,
+            },
+          ]),
+    ];
     const send = await sendDurableMessageBatch({
       cfg,
       channel: delivery.channel,
@@ -2009,17 +2099,14 @@ export async function runHeartbeatOnce(opts: {
       accountId: deliveryAccountId,
       session: outboundSession,
       threadId: delivery.threadId,
-      payloads: [
-        ...reasoningPayloads,
-        ...(shouldSkipMain
-          ? []
-          : [
-              {
-                text: normalized.text,
-                mediaUrls,
-              },
-            ]),
-      ],
+      payloads: deliveryPayloads,
+      mirror: buildHeartbeatDeliveryMirror({
+        agentId,
+        sessionKey,
+        runSessionKey,
+        startedAt,
+        payloads: deliveryPayloads,
+      }),
       deps: opts.deps,
     });
     if (send.status === "failed" || send.status === "partial_failed") {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -216,11 +216,12 @@ function buildHeartbeatDeliveryMirror(params: {
   if (!text && mediaUrls.length === 0) {
     return undefined;
   }
+  const mirrorMediaUrls = text ? [] : mediaUrls;
   return {
     sessionKey: params.sessionKey,
     agentId: params.agentId,
     ...(text ? { text } : {}),
-    ...(mediaUrls.length > 0 ? { mediaUrls } : {}),
+    ...(mirrorMediaUrls.length > 0 ? { mediaUrls: mirrorMediaUrls } : {}),
     idempotencyKey: buildHeartbeatMirrorIdempotencyKey({
       runSessionKey: params.runSessionKey,
       sessionKey: params.sessionKey,


### PR DESCRIPTION
## Summary
- Mirror proactive cron announce/failure delivery into custom/main session transcripts with a stable `cron-announce-mirror:v1:*` idempotency key.
- Keep routed direct, legacy dm, group, and channel session transcripts out of cron mirrors, including provider-owned suffixes such as Telegram `:topic:` and Slack thread suffixes.
- Mirror heartbeat/digest delivery into the active/base chat transcript with a stable `heartbeat-delivery-mirror:v1:*` idempotency key so follow-up replies can see the proactive message that was actually sent.
- Add focused regression coverage for both delivery paths.

Supersedes #86140 with the same bug class handled in one PR.

## Verification
- Based on `origin/main` `5f934830d38272dbe5ed12b453430599378dd936`; PR head is `0a806a46410479c718e79884c8cb9148c84645b9`.
- `node scripts/run-vitest.mjs src/cron/delivery.failure-notify.test.ts` (1 file, 13 tests passed)
- `node scripts/run-vitest.mjs src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts` (1 file, 14 tests passed)
- `pnpm exec oxfmt --check --threads=1 src/cron/delivery.ts src/cron/delivery.failure-notify.test.ts src/infra/heartbeat-runner.ts src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts`
- `git diff --check origin/main...HEAD`
- `pnpm changed:lanes --json` (`core`, `coreTests`)
- `pnpm check:changed`
- `node --import tsx --input-type=module -` temp-state cron alias proof (`target_session_key=main`, `canonical_session_key=agent:ops:work`, `alias_mirror_ok=true`)
- Added heartbeat text+mediaUrls regression coverage: transcript mirrors preserve the delivered heartbeat text instead of resolving to the attachment filename.

## Changelog candidate
- Proactive delivery: mirror cron announce/failure notifications and heartbeat/digest sends into the destination transcript so follow-up replies keep the delivered message in context.

Note: the changelog line is intentionally kept out of this PR diff to avoid repeated `CHANGELOG.md` conflicts while `main` is moving quickly. It can be added at landing.

## Real behavior proof

Behavior addressed: Proactive outbound deliveries that are visible to a user now append the delivered assistant text to the transcript that the next turn will read. Cron announce/failure delivery mirrors only into custom/main session keys and skips routed direct/dm/group/channel chat transcripts, including provider-owned suffixes such as Telegram topics. Heartbeat/digest delivery mirrors into the active/base chat session key, so a reply after a WhatsApp-style proactive digest has the sent digest in context.

Real environment tested: Local OpenClaw checkout `/Users/dross/openclaw-cron-transcript-mirror`, branch `codex/proactive-delivery-transcript-mirrors`, head `0a806a46410479c718e79884c8cb9148c84645b9`, based on `origin/main` `5f934830d38272dbe5ed12b453430599378dd936`, with a temporary `OPENCLAW_STATE_DIR`. The proof uses a local in-process outbound plugin named `proofline`, so no private external account, phone number, endpoint, or token is needed. It exercises `sendCronAnnouncePayloadStrict` and `runHeartbeatOnce` through `sendDurableMessageBatch`, outbound delivery, and transcript append.

Exact steps or command run after this patch: Ran `node --import tsx --input-type=module -` from the repo root with an inline harness that registered a local `proofline` outbound adapter, seeded the default session store with a custom cron session key, a Telegram topic-suffixed group session key, and a direct heartbeat session key, delivered cron and heartbeat messages, then read the resulting transcript files from the temporary state directory.

Evidence after fix:

```text
OPENCLAW_RUNTIME_PROOF proactive delivery transcript mirrors
state_dir=/var/folders/69/5f9v9rq9045bwk3w75cht7wm0000gn/T/openclaw-proactive-mirror-proof.VAikaS
store_path=/var/folders/69/5f9v9rq9045bwk3w75cht7wm0000gn/T/openclaw-proactive-mirror-proof.VAikaS/agents/main/sessions/sessions.json
send_results=[{"to":"cron-recipient","text":"proof cron mirror text"},{"to":"topic-recipient","text":"proof topic mirror skip text"},{"to":"heartbeat-user","text":"proof heartbeat mirror text"}]
cron_custom_transcript={"exists":true,"lineCount":2,"lastRole":"assistant","lastText":"proof cron mirror text","lastIdempotencyKey":null}
topic_group_transcript={"exists":false,"lineCount":0,"lastRole":null,"lastText":null,"lastIdempotencyKey":null}
heartbeat_transcript={"exists":true,"lineCount":2,"lastRole":"assistant","lastText":"proof heartbeat mirror text","lastIdempotencyKey":null}
cron_mirror_ok=true
topic_group_mirror_skipped=true
heartbeat_mirror_ok=true
```

Observed result after fix: All three sends reached the local outbound adapter. The custom cron session transcript was created and ended with the mirrored assistant message. The Telegram topic-suffixed group session still delivered but did not create a transcript mirror. The direct heartbeat session transcript was created and ended with the mirrored heartbeat/digest assistant message.

What was not tested: I did not run a real WhatsApp, Telegram, or Slack network send from this branch. The motivating live WhatsApp evidence was captured separately on a private Dross setup: a heartbeat/digest message was visible in WhatsApp, the user replied immediately after it, and the active session transcript did not contain the digest before this patch. That before-fix evidence is privacy-redacted and not attached as a PR image.
