### PR TITLE
fix doctor gateway SecretRef auth check

### DIFF
--- a/changelog/fragments/doctor-gateway-secretref.md
+++ b/changelog/fragments/doctor-gateway-secretref.md
@@ -1,0 +1,1 @@
+- Doctor: resolve SecretRef-backed local Gateway tokens before warning that gateway auth is unavailable.

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -269,6 +269,86 @@ describe("registerCoreHealthChecks", () => {
     );
   });
 
+  it("does not warn when gateway token SecretRef resolves", async () => {
+    const check = getCheck(createCoreHealthChecks(createDeps()), "core/doctor/gateway-auth");
+    const previousToken = process.env.OPENCLAW_TEST_GATEWAY_TOKEN;
+    process.env.OPENCLAW_TEST_GATEWAY_TOKEN = "resolved-token";
+    try {
+      const findings = await check.detect({
+        mode: "doctor",
+        runtime,
+        cfg: {
+          gateway: {
+            mode: "local",
+            auth: {
+              mode: "token",
+              token: {
+                source: "env",
+                provider: "default",
+                id: "OPENCLAW_TEST_GATEWAY_TOKEN",
+              },
+            },
+          },
+          secrets: {
+            providers: {
+              default: { source: "env" },
+            },
+          },
+        },
+      });
+
+      expect(findings).toEqual([]);
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.OPENCLAW_TEST_GATEWAY_TOKEN;
+      } else {
+        process.env.OPENCLAW_TEST_GATEWAY_TOKEN = previousToken;
+      }
+    }
+  });
+
+  it("keeps warning when gateway token SecretRef is unresolved", async () => {
+    const check = getCheck(createCoreHealthChecks(createDeps()), "core/doctor/gateway-auth");
+    const previousToken = process.env.OPENCLAW_TEST_MISSING_GATEWAY_TOKEN;
+    delete process.env.OPENCLAW_TEST_MISSING_GATEWAY_TOKEN;
+    try {
+      const findings = await check.detect({
+        mode: "doctor",
+        runtime,
+        cfg: {
+          gateway: {
+            mode: "local",
+            auth: {
+              mode: "token",
+              token: {
+                source: "env",
+                provider: "default",
+                id: "OPENCLAW_TEST_MISSING_GATEWAY_TOKEN",
+              },
+            },
+          },
+          secrets: {
+            providers: {
+              default: { source: "env" },
+            },
+          },
+        },
+      });
+
+      expect(findings).toContainEqual(
+        expect.objectContaining({
+          checkId: "core/doctor/gateway-auth",
+          severity: "warning",
+          message: "Gateway token is managed via SecretRef and is currently unavailable.",
+        }),
+      );
+    } finally {
+      if (previousToken !== undefined) {
+        process.env.OPENCLAW_TEST_MISSING_GATEWAY_TOKEN = previousToken;
+      }
+    }
+  });
+
   it("converts workspace suggestions into info findings", async () => {
     const check = getCheck(
       createCoreHealthChecks(

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -157,6 +157,12 @@ const gatewayAuthCheck: HealthCheck = {
       return [];
     }
     if (gatewayTokenRef) {
+      const { resolveGatewayAuthTokenForService } =
+        await import("../commands/doctor-gateway-auth-token.js");
+      const resolved = await resolveGatewayAuthTokenForService(ctx.cfg, process.env);
+      if (resolved.token) {
+        return [];
+      }
       return [
         {
           checkId: "core/doctor/gateway-auth",

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -42,13 +42,15 @@ vi.mock("../config/config.js", () => ({
 
 vi.mock("../commands/onboard-helpers.js", () => ({
   applyWizardMetadata: mocks.applyWizardMetadata,
+  randomToken: vi.fn(() => "generated-token"),
 }));
 
 vi.mock("../config/logging.js", () => ({
   logConfigUpdated: mocks.logConfigUpdated,
 }));
 
-vi.mock("../utils.js", () => ({
+vi.mock("../utils.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../utils.js")>()),
   shortenHomePath: mocks.shortenHomePath,
 }));
 
@@ -189,6 +191,43 @@ describe("doctor health contributions", () => {
 
     expect(ids.indexOf("doctor:command-owner")).toBeGreaterThan(-1);
     expect(ids.indexOf("doctor:command-owner")).toBeLessThan(ids.indexOf("doctor:write-config"));
+  });
+
+  it("does not note gateway auth warning when token SecretRef resolves", async () => {
+    const contribution = requireDoctorContribution("doctor:gateway-auth");
+
+    await contribution.run({
+      cfg: {
+        gateway: {
+          mode: "local",
+          auth: {
+            mode: "token",
+            token: {
+              source: "env",
+              provider: "default",
+              id: "OPENCLAW_TEST_GATEWAY_TOKEN",
+            },
+          },
+        },
+        secrets: {
+          providers: {
+            default: { source: "env" },
+          },
+        },
+      },
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(false),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: { nonInteractive: true },
+      env: {
+        OPENCLAW_TEST_GATEWAY_TOKEN: "resolved-token",
+      },
+    } as Parameters<(typeof contribution)["run"]>[0]);
+
+    expect(mocks.note).not.toHaveBeenCalledWith(
+      expect.stringContaining("Gateway token is managed via SecretRef"),
+      "Gateway auth",
+    );
   });
 
   it("checks skill readiness before final config writes", () => {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -190,6 +190,12 @@ async function runGatewayAuthHealth(ctx: DoctorHealthFlowContext): Promise<void>
     return;
   }
   if (gatewayTokenRef) {
+    const { resolveGatewayAuthTokenForService } =
+      await import("../commands/doctor-gateway-auth-token.js");
+    const resolved = await resolveGatewayAuthTokenForService(ctx.cfg, ctx.env ?? process.env);
+    if (resolved.token) {
+      return;
+    }
     note(
       [
         "Gateway token is managed via SecretRef and is currently unavailable.",


### PR DESCRIPTION
## Summary
- Resolve SecretRef-backed local Gateway tokens before doctor reports gateway auth as unavailable.
- Apply the same check to both structured health findings and legacy doctor health notes.
- Add coverage for resolved and unresolved Gateway token SecretRefs.

## Verification
- `OPENCLAW_VITEST_INCLUDE_FILE=/tmp/openclaw-vitest-include.json OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=20000 OPENCLAW_TEST_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts`
- `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=20000 OPENCLAW_TEST_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/flows/doctor-health-contributions.test.ts`
- `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=20000 OPENCLAW_TEST_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.commands-light.config.ts`
- `npx pnpm@11.2.2 exec oxfmt --check src/flows/doctor-core-checks.ts src/flows/doctor-health-contributions.ts src/flows/doctor-core-checks.test.ts src/flows/doctor-health-contributions.test.ts`

