### PR TITLE
fix: normalizeDeepSeekSchema collapses const unions to first variant

### DIFF
--- a/src/plugin-sdk/provider-tools.ts
+++ b/src/plugin-sdk/provider-tools.ts
@@ -1,0 +1,555 @@
+import type { TSchema } from "typebox";
+import {
+  cleanSchemaForGemini,
+  GEMINI_UNSUPPORTED_SCHEMA_KEYWORDS,
+} from "../agents/schema/clean-for-gemini.js";
+import type {
+  AnyAgentTool,
+  ProviderNormalizeToolSchemasContext,
+  ProviderToolSchemaDiagnostic,
+} from "./plugin-entry.js";
+
+// Shared provider-tool helpers for plugin-owned schema compatibility rewrites.
+export { cleanSchemaForGemini, GEMINI_UNSUPPORTED_SCHEMA_KEYWORDS };
+
+export function stripUnsupportedSchemaKeywords(
+  schema: unknown,
+  unsupportedKeywords: ReadonlySet<string>,
+): unknown {
+  if (!schema || typeof schema !== "object") {
+    return schema;
+  }
+  if (Array.isArray(schema)) {
+    return schema.map((entry) => stripUnsupportedSchemaKeywords(entry, unsupportedKeywords));
+  }
+  const obj = schema as Record<string, unknown>;
+  const cleaned: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (unsupportedKeywords.has(key)) {
+      continue;
+    }
+    if (key === "properties" && value && typeof value === "object" && !Array.isArray(value)) {
+      cleaned[key] = Object.fromEntries(
+        Object.entries(value as Record<string, unknown>).map(([childKey, childValue]) => [
+          childKey,
+          stripUnsupportedSchemaKeywords(childValue, unsupportedKeywords),
+        ]),
+      );
+      continue;
+    }
+    if (key === "items" && value && typeof value === "object") {
+      cleaned[key] = Array.isArray(value)
+        ? value.map((entry) => stripUnsupportedSchemaKeywords(entry, unsupportedKeywords))
+        : stripUnsupportedSchemaKeywords(value, unsupportedKeywords);
+      continue;
+    }
+    if ((key === "anyOf" || key === "oneOf" || key === "allOf") && Array.isArray(value)) {
+      cleaned[key] = value.map((entry) =>
+        stripUnsupportedSchemaKeywords(entry, unsupportedKeywords),
+      );
+      continue;
+    }
+    cleaned[key] = value;
+  }
+  return cleaned;
+}
+
+export function findUnsupportedSchemaKeywords(
+  schema: unknown,
+  path: string,
+  unsupportedKeywords: ReadonlySet<string>,
+): string[] {
+  if (!schema || typeof schema !== "object") {
+    return [];
+  }
+  if (Array.isArray(schema)) {
+    return schema.flatMap((item, index) =>
+      findUnsupportedSchemaKeywords(item, `${path}[${index}]`, unsupportedKeywords),
+    );
+  }
+  const record = schema as Record<string, unknown>;
+  const violations: string[] = [];
+  const properties =
+    record.properties && typeof record.properties === "object" && !Array.isArray(record.properties)
+      ? (record.properties as Record<string, unknown>)
+      : undefined;
+  if (properties) {
+    for (const [key, value] of Object.entries(properties)) {
+      violations.push(
+        ...findUnsupportedSchemaKeywords(value, `${path}.properties.${key}`, unsupportedKeywords),
+      );
+    }
+  }
+  for (const [key, value] of Object.entries(record)) {
+    if (key === "properties") {
+      continue;
+    }
+    if (unsupportedKeywords.has(key)) {
+      violations.push(`${path}.${key}`);
+    }
+    if (value && typeof value === "object") {
+      violations.push(
+        ...findUnsupportedSchemaKeywords(value, `${path}.${key}`, unsupportedKeywords),
+      );
+    }
+  }
+  return violations;
+}
+
+export function normalizeGeminiToolSchemas(
+  ctx: ProviderNormalizeToolSchemasContext,
+): AnyAgentTool[] {
+  return ctx.tools.map((tool) => {
+    if (!tool.parameters || typeof tool.parameters !== "object") {
+      return tool;
+    }
+    return {
+      ...tool,
+      parameters: cleanSchemaForGemini(tool.parameters),
+    };
+  });
+}
+
+export function inspectGeminiToolSchemas(
+  ctx: ProviderNormalizeToolSchemasContext,
+): ProviderToolSchemaDiagnostic[] {
+  return ctx.tools.flatMap((tool, toolIndex) => {
+    const violations = findUnsupportedSchemaKeywords(
+      tool.parameters,
+      `${tool.name}.parameters`,
+      GEMINI_UNSUPPORTED_SCHEMA_KEYWORDS,
+    );
+    if (violations.length === 0) {
+      return [];
+    }
+    return [{ toolName: tool.name, toolIndex, violations }];
+  });
+}
+
+export function normalizeOpenAIToolSchemas(
+  ctx: ProviderNormalizeToolSchemasContext,
+): AnyAgentTool[] {
+  if (!shouldApplyOpenAIToolCompat(ctx)) {
+    return ctx.tools;
+  }
+  return ctx.tools.map((tool) => {
+    if (tool.parameters == null) {
+      return {
+        ...tool,
+        parameters: normalizeOpenAIStrictCompatSchema({}),
+      };
+    }
+    if (typeof tool.parameters !== "object") {
+      return tool;
+    }
+    return {
+      ...tool,
+      parameters: normalizeOpenAIStrictCompatSchema(tool.parameters),
+    };
+  });
+}
+
+function normalizeOpenAIStrictCompatSchema(schema: unknown): TSchema {
+  return normalizeOpenAIStrictCompatSchemaRecursive(schema, {
+    promoteEmptyObject: true,
+  }) as TSchema;
+}
+
+function shouldApplyOpenAIToolCompat(ctx: ProviderNormalizeToolSchemasContext): boolean {
+  const provider = (ctx.model?.provider ?? ctx.provider ?? "").trim().toLowerCase();
+  const api = (ctx.model?.api ?? ctx.modelApi ?? "").trim().toLowerCase();
+  const baseUrl = (ctx.model?.baseUrl ?? "").trim().toLowerCase();
+
+  if (provider === "openai") {
+    return api === "openai-responses" && (!baseUrl || isOpenAIResponsesBaseUrl(baseUrl));
+  }
+  if (provider === "openai-codex") {
+    return (
+      api === "openai-codex-responses" &&
+      (!baseUrl || isOpenAIResponsesBaseUrl(baseUrl) || isOpenAICodexBaseUrl(baseUrl))
+    );
+  }
+  return false;
+}
+
+function isOpenAIResponsesBaseUrl(baseUrl: string): boolean {
+  return /^https:\/\/api\.openai\.com(?:\/v1)?(?:\/|$)/i.test(baseUrl);
+}
+
+function isOpenAICodexBaseUrl(baseUrl: string): boolean {
+  return /^https:\/\/chatgpt\.com\/backend-api(?:\/|$)/i.test(baseUrl);
+}
+
+type NormalizeOpenAIStrictCompatOptions = {
+  promoteEmptyObject: boolean;
+};
+
+const OPENAI_STRICT_COMPAT_SCHEMA_MAP_KEYS = new Set([
+  "$defs",
+  "definitions",
+  "dependentSchemas",
+  "patternProperties",
+  "properties",
+]);
+
+const OPENAI_STRICT_COMPAT_SCHEMA_NESTED_KEYS = new Set([
+  "additionalProperties",
+  "allOf",
+  "anyOf",
+  "contains",
+  "else",
+  "if",
+  "items",
+  "not",
+  "oneOf",
+  "prefixItems",
+  "propertyNames",
+  "then",
+  "unevaluatedItems",
+  "unevaluatedProperties",
+]);
+
+function normalizeOpenAIStrictCompatSchemaMap(schema: unknown): unknown {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+    return schema;
+  }
+
+  let changed = false;
+  const normalized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(schema as Record<string, unknown>)) {
+    const next = normalizeOpenAIStrictCompatSchemaRecursive(value, {
+      promoteEmptyObject: false,
+    });
+    normalized[key] = next;
+    changed ||= next !== value;
+  }
+  return changed ? normalized : schema;
+}
+
+function normalizeOpenAIStrictCompatSchemaRecursive(
+  schema: unknown,
+  options: NormalizeOpenAIStrictCompatOptions,
+): unknown {
+  if (Array.isArray(schema)) {
+    let changed = false;
+    const normalized = schema.map((entry) => {
+      const next = normalizeOpenAIStrictCompatSchemaRecursive(entry, {
+        promoteEmptyObject: false,
+      });
+      changed ||= next !== entry;
+      return next;
+    });
+    return changed ? normalized : schema;
+  }
+  if (!schema || typeof schema !== "object") {
+    return schema;
+  }
+
+  const record = schema as Record<string, unknown>;
+  let changed = false;
+  const normalized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    const next = OPENAI_STRICT_COMPAT_SCHEMA_MAP_KEYS.has(key)
+      ? normalizeOpenAIStrictCompatSchemaMap(value)
+      : OPENAI_STRICT_COMPAT_SCHEMA_NESTED_KEYS.has(key)
+        ? normalizeOpenAIStrictCompatSchemaRecursive(value, {
+            promoteEmptyObject: false,
+          })
+        : value;
+    normalized[key] = next;
+    changed ||= next !== value;
+  }
+
+  if (Object.keys(normalized).length === 0) {
+    if (!options.promoteEmptyObject) {
+      return schema;
+    }
+    return {
+      type: "object",
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    };
+  }
+
+  const hasObjectShapeHints =
+    !("type" in normalized) &&
+    ((normalized.properties &&
+      typeof normalized.properties === "object" &&
+      !Array.isArray(normalized.properties)) ||
+      Array.isArray(normalized.required));
+  if (hasObjectShapeHints) {
+    normalized.type = "object";
+    changed = true;
+  }
+  if (normalized.type === "object" && !("properties" in normalized)) {
+    normalized.properties = {};
+    changed = true;
+  }
+
+  const hasEmptyProperties =
+    normalized.properties &&
+    typeof normalized.properties === "object" &&
+    !Array.isArray(normalized.properties) &&
+    Object.keys(normalized.properties as Record<string, unknown>).length === 0;
+
+  if (normalized.type === "object" && !Array.isArray(normalized.required) && hasEmptyProperties) {
+    normalized.required = [];
+    changed = true;
+  }
+
+  if (
+    normalized.type === "object" &&
+    hasEmptyProperties &&
+    !("additionalProperties" in normalized)
+  ) {
+    normalized.additionalProperties = false;
+    changed = true;
+  }
+
+  return changed ? normalized : schema;
+}
+
+export function findOpenAIStrictSchemaViolations(
+  schema: unknown,
+  path: string,
+  options?: { requireObjectRoot?: boolean },
+): string[] {
+  if (Array.isArray(schema)) {
+    if (options?.requireObjectRoot) {
+      return [`${path}.type`];
+    }
+    return schema.flatMap((item, index) =>
+      findOpenAIStrictSchemaViolations(item, `${path}[${index}]`),
+    );
+  }
+  if (!schema || typeof schema !== "object") {
+    if (options?.requireObjectRoot) {
+      return [`${path}.type`];
+    }
+    return [];
+  }
+
+  const record = schema as Record<string, unknown>;
+  const violations: string[] = [];
+  for (const key of ["anyOf", "oneOf", "allOf"] as const) {
+    if (Array.isArray(record[key])) {
+      violations.push(`${path}.${key}`);
+    }
+  }
+  if (Array.isArray(record.type)) {
+    violations.push(`${path}.type`);
+  }
+
+  const properties =
+    record.properties && typeof record.properties === "object" && !Array.isArray(record.properties)
+      ? (record.properties as Record<string, unknown>)
+      : undefined;
+
+  if (record.type === "object") {
+    if (record.additionalProperties !== false) {
+      violations.push(`${path}.additionalProperties`);
+    }
+    const required = Array.isArray(record.required)
+      ? record.required.filter((entry): entry is string => typeof entry === "string")
+      : undefined;
+    if (!required) {
+      violations.push(`${path}.required`);
+    } else if (properties) {
+      const requiredSet = new Set(required);
+      for (const key of Object.keys(properties)) {
+        if (!requiredSet.has(key)) {
+          violations.push(`${path}.required.${key}`);
+        }
+      }
+    }
+  }
+
+  if (properties) {
+    for (const [key, value] of Object.entries(properties)) {
+      violations.push(...findOpenAIStrictSchemaViolations(value, `${path}.properties.${key}`));
+    }
+  }
+
+  for (const [key, value] of Object.entries(record)) {
+    if (key === "properties") {
+      continue;
+    }
+    if (value && typeof value === "object") {
+      violations.push(...findOpenAIStrictSchemaViolations(value, `${path}.${key}`));
+    }
+  }
+
+  return violations;
+}
+
+export function inspectOpenAIToolSchemas(
+  ctx: ProviderNormalizeToolSchemasContext,
+): ProviderToolSchemaDiagnostic[] {
+  if (!shouldApplyOpenAIToolCompat(ctx)) {
+    return [];
+  }
+  // Native OpenAI transports fall back to `strict: false` when any tool schema is not
+  // strict-compatible, so these findings are expected for optional-heavy tool schemas.
+  return [];
+}
+
+export const DEEPSEEK_UNSUPPORTED_SCHEMA_KEYWORDS = new Set(["anyOf", "oneOf"]);
+
+function isNullSchemaVariant(schema: unknown): boolean {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+    return false;
+  }
+  const record = schema as Record<string, unknown>;
+  if (record.type === "null") {
+    return true;
+  }
+  if (Array.isArray(record.type) && record.type.length === 1 && record.type[0] === "null") {
+    return true;
+  }
+  if ("const" in record && record.const === null) {
+    return true;
+  }
+  return Array.isArray(record.enum) && record.enum.length === 1 && record.enum[0] === null;
+}
+
+function normalizeDeepSeekSchema(schema: unknown): unknown {
+  if (Array.isArray(schema)) {
+    let changed = false;
+    const normalized = schema.map((entry) => {
+      const next = normalizeDeepSeekSchema(entry);
+      changed ||= next !== entry;
+      return next;
+    });
+    return changed ? normalized : schema;
+  }
+  if (!schema || typeof schema !== "object") {
+    return schema;
+  }
+
+  const record = schema as Record<string, unknown>;
+  const unionKey = Array.isArray(record.anyOf)
+    ? "anyOf"
+    : Array.isArray(record.oneOf)
+      ? "oneOf"
+      : undefined;
+
+  let changed = false;
+  const normalized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (key === "anyOf" || key === "oneOf") {
+      if (key === unionKey) {
+        changed = true;
+        continue;
+      }
+    }
+    const next = normalizeDeepSeekSchema(value);
+    normalized[key] = next;
+    changed ||= next !== value;
+  }
+
+  if (!unionKey) {
+    return changed ? normalized : schema;
+  }
+
+  const variants = record[unionKey] as unknown[];
+  const normalizedVariants = variants.map((entry) => normalizeDeepSeekSchema(entry));
+  const nonNullVariants = normalizedVariants.filter((entry) => !isNullSchemaVariant(entry));
+
+  // When all non-null variants are const string literals, merge them into an enum
+  // array instead of picking just the first. This preserves the full set of
+  // allowed values for DeepSeek models (which strip anyOf/oneOf).
+  if (
+    nonNullVariants.length > 1 &&
+    nonNullVariants.every(
+      (v): v is Record<string, unknown> =>
+        typeof v === "object" &&
+        v !== null &&
+        !Array.isArray(v) &&
+        "const" in v &&
+        typeof v.const === "string"
+    )
+  ) {
+    const enumValues = nonNullVariants.map(
+      (v) => (v as Record<string, unknown>).const as string
+    );
+    return {
+      type: "string",
+      enum: enumValues,
+      ...normalized,
+    };
+  }
+
+  const selected = nonNullVariants[0] ?? normalizedVariants[0];
+  if (!selected || typeof selected !== "object" || Array.isArray(selected)) {
+    return normalized;
+  }
+
+  const merged = {
+    ...(selected as Record<string, unknown>),
+    ...normalized,
+  };
+  if (nonNullVariants.length < normalizedVariants.length) {
+    merged.nullable = true;
+  }
+  return merged;
+}
+
+export function normalizeDeepSeekToolSchemas(
+  ctx: ProviderNormalizeToolSchemasContext,
+): AnyAgentTool[] {
+  return ctx.tools.map((tool) => {
+    if (!tool.parameters || typeof tool.parameters !== "object") {
+      return tool;
+    }
+    const parameters = normalizeDeepSeekSchema(tool.parameters);
+    return parameters === tool.parameters
+      ? tool
+      : {
+          ...tool,
+          parameters: parameters as TSchema,
+        };
+  });
+}
+
+export function inspectDeepSeekToolSchemas(
+  ctx: ProviderNormalizeToolSchemasContext,
+): ProviderToolSchemaDiagnostic[] {
+  return ctx.tools.flatMap((tool, toolIndex) => {
+    const violations = findUnsupportedSchemaKeywords(
+      tool.parameters,
+      `${tool.name}.parameters`,
+      DEEPSEEK_UNSUPPORTED_SCHEMA_KEYWORDS,
+    );
+    if (violations.length === 0) {
+      return [];
+    }
+    return [{ toolName: tool.name, toolIndex, violations }];
+  });
+}
+
+export type ProviderToolCompatFamily = "deepseek" | "gemini" | "openai";
+
+export function buildProviderToolCompatFamilyHooks(family: ProviderToolCompatFamily): {
+  normalizeToolSchemas: (ctx: ProviderNormalizeToolSchemasContext) => AnyAgentTool[];
+  inspectToolSchemas: (ctx: ProviderNormalizeToolSchemasContext) => ProviderToolSchemaDiagnostic[];
+} {
+  switch (family) {
+    case "deepseek":
+      return {
+        normalizeToolSchemas: normalizeDeepSeekToolSchemas,
+        inspectToolSchemas: inspectDeepSeekToolSchemas,
+      };
+    case "gemini":
+      return {
+        normalizeToolSchemas: normalizeGeminiToolSchemas,
+        inspectToolSchemas: inspectGeminiToolSchemas,
+      };
+    case "openai":
+      return {
+        normalizeToolSchemas: normalizeOpenAIToolSchemas,
+        inspectToolSchemas: inspectOpenAIToolSchemas,
+      };
+  }
+  throw new Error("Unsupported provider tool compatibility family");
+}


### PR DESCRIPTION
## Summary

Fixes `normalizeDeepSeekSchema` in `src/plugin-sdk/provider-tools.ts` which collapses `anyOf` unions of `const` string literals to only the first variant, making multi-option tool parameters invisible to the LLM.

## Root Cause

When a property has `anyOf: [{const:"A"}, {const:"B"}, ..., {const:"G"}]` (7 const literals from Typebox `Union[Literal]`), `normalizeDeepSeekSchema`:
1. Skips copying the `anyOf` key
2. Takes only `nonNullVariants[0]` — the first const value
3. Merges it with remaining properties

Result: The LLM sees `{const: "A", type: "string"}` instead of all 7 allowed values.

The function was designed to handle nullable unions (e.g. `{anyOf: [{type:"string"}, {type:"null"}]}` → `{type:"string", nullable:true}`), but incorrectly applies the same "pick first" logic to unions of string literal consts.

## Fix

When all non-null variants are const string literals, merge them into an `enum` array instead of picking the first one. This preserves the full set of allowed values while staying compatible with DeepSeek's schema requirements.

## Testing

After this fix, the `feishu_update_doc` tool's `mode` parameter correctly exposes all 7 modes to DeepSeek models via `enum: ["overwrite", "append", "replace_range", "replace_all", "insert_before", "insert_after", "delete_range"]`.

Fixes #86468