### PR TITLE
fix(agents): guide workspace-only scratch paths

### DIFF
--- a/src/agents/pi-embedded-runner/system-prompt.test.ts
+++ b/src/agents/pi-embedded-runner/system-prompt.test.ts
@@ -130,6 +130,63 @@ describe("buildEmbeddedSystemPrompt", () => {
     expect(prompt).toContain("Mode: prefer");
   });
 
+  it("adds workspace-only scratch path guidance when fs workspaceOnly is enabled", () => {
+    const prompt = buildEmbeddedSystemPrompt({
+      config: {
+        tools: {
+          fs: {
+            workspaceOnly: true,
+          },
+        },
+      },
+      workspaceDir: "/tmp/openclaw",
+      reasoningTagHint: false,
+      runtimeInfo: {
+        host: "local",
+        os: "darwin",
+        arch: "arm64",
+        node: process.version,
+        model: "gpt-5.4",
+        provider: "openai",
+      },
+      tools: [],
+      modelAliasLines: [],
+      userTimezone: "UTC",
+    });
+
+    expect(prompt).toContain("tools.fs.workspaceOnly is enabled");
+    expect(prompt).toContain("`.openclaw/tmp/`");
+    expect(prompt).toContain("Do not write files to `/tmp/...`");
+  });
+
+  it("omits workspace-only scratch path guidance when fs workspaceOnly is disabled", () => {
+    const prompt = buildEmbeddedSystemPrompt({
+      config: {
+        tools: {
+          fs: {
+            workspaceOnly: false,
+          },
+        },
+      },
+      workspaceDir: "/tmp/openclaw",
+      reasoningTagHint: false,
+      runtimeInfo: {
+        host: "local",
+        os: "darwin",
+        arch: "arm64",
+        node: process.version,
+        model: "gpt-5.4",
+        provider: "openai",
+      },
+      tools: [],
+      modelAliasLines: [],
+      userTimezone: "UTC",
+    });
+
+    expect(prompt).not.toContain("tools.fs.workspaceOnly is enabled");
+    expect(prompt).not.toContain("Do not write files to `/tmp/...`");
+  });
+
   it("forwards the subagent prompt surface to embedded prompt rendering", () => {
     const prompt = buildEmbeddedSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -667,8 +667,18 @@ export function wrapToolMemoryFlushAppendOnlyWrite(
   };
 }
 
-function isSandboxRootEscapeError(error: unknown): boolean {
+function isSandboxRootEscapeError(error: unknown): error is Error {
   return error instanceof Error && /^Path escapes sandbox root \(/i.test(error.message);
+}
+
+function withWorkspaceSafeTempHint(error: unknown): unknown {
+  if (!isSandboxRootEscapeError(error)) {
+    return error;
+  }
+  const message = error.message.includes(".openclaw/tmp/")
+    ? error.message
+    : `${error.message}. Use a relative path under \`.openclaw/tmp/\` inside the workspace for scratch/temp/meta files that file tools need to read or write later.`;
+  return new Error(message, { cause: error });
 }
 
 async function assertSandboxPathWithinAnyRoot(params: {
@@ -752,10 +762,15 @@ export function wrapToolWorkspaceRootGuardWithOptions(
         }
         const additionalRoots =
           guardedRoot === root && !workspaceMapping.matched ? (options?.additionalRoots ?? []) : [];
-        const sandboxResult = await assertSandboxPathWithinAnyRoot({
-          filePath: sandboxPath,
-          roots: [guardedRoot, ...additionalRoots],
-        });
+        let sandboxResult: Awaited<ReturnType<typeof assertSandboxPathWithinAnyRoot>>;
+        try {
+          sandboxResult = await assertSandboxPathWithinAnyRoot({
+            filePath: sandboxPath,
+            roots: [guardedRoot, ...additionalRoots],
+          });
+        } catch (error) {
+          throw withWorkspaceSafeTempHint(error);
+        }
         if (options?.normalizeGuardedPathParams && record) {
           normalizedRecord ??= { ...record };
           normalizedRecord[key] = sandboxResult.resolved;

--- a/src/agents/pi-tools.read.workspace-root-guard.test.ts
+++ b/src/agents/pi-tools.read.workspace-root-guard.test.ts
@@ -173,6 +173,23 @@ describe("wrapToolWorkspaceRootGuardWithOptions", () => {
     });
   });
 
+  it("adds a workspace-safe temp hint when rejecting paths outside the workspace", async () => {
+    const { execute, tool } = createToolHarness();
+    const wrapped = wrapToolWorkspaceRootGuardWithOptions(tool, root, {
+      containerWorkdir: "/workspace",
+    });
+    mocks.assertSandboxPath.mockImplementationOnce(async () => {
+      throw new Error("Path escapes sandbox root (/tmp/root): /tmp/repo_meta.jsonl");
+    });
+
+    await expect(
+      wrapped.execute("tc-outside-temp", { path: "/tmp/repo_meta.jsonl" }),
+    ).rejects.toThrow(
+      /Path escapes sandbox root .* Use a relative path under `.openclaw\/tmp\/` inside the workspace/,
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
   it("maps additional container mounts to their own guarded host roots", async () => {
     const { tool } = createToolHarness();
     const agentRoot = "/tmp/agent-root";

--- a/src/agents/system-prompt-config.ts
+++ b/src/agents/system-prompt-config.ts
@@ -4,6 +4,7 @@ import { resolveAgentConfig } from "./agent-scope.js";
 import { buildModelAliasLines } from "./model-alias-lines.js";
 import { resolveOwnerDisplaySetting } from "./owner-display.js";
 import { buildAgentSystemPrompt } from "./system-prompt.js";
+import { resolveEffectiveToolFsWorkspaceOnly } from "./tool-fs-policy.js";
 
 type AgentSystemPromptRenderParams = Parameters<typeof buildAgentSystemPrompt>[0];
 
@@ -15,6 +16,7 @@ export type ResolvedAgentSystemPromptConfig = Pick<
   | "ttsHint"
   | "modelAliasLines"
   | "memoryCitationsMode"
+  | "fsWorkspaceOnly"
 >;
 
 export type ConfiguredAgentSystemPromptParams = AgentSystemPromptRenderParams & {
@@ -40,6 +42,7 @@ export function resolveAgentSystemPromptConfig(params: {
     ttsHint: config ? buildTtsSystemPromptHint(config, agentId) : undefined,
     modelAliasLines: buildModelAliasLines(config),
     memoryCitationsMode: config?.memory?.citations,
+    fsWorkspaceOnly: resolveEffectiveToolFsWorkspaceOnly({ cfg: config, agentId }),
   };
 }
 

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -723,6 +723,8 @@ export function buildAgentSystemPrompt(params: {
   };
   messageToolHints?: string[];
   sandboxInfo?: EmbeddedSandboxInfo;
+  /** Whether read/write/edit/apply_patch are restricted to the workspace root. */
+  fsWorkspaceOnly?: boolean;
   /** Reaction guidance for the agent (for Telegram minimal/extensive modes). */
   reactionGuidance?: {
     level: "minimal" | "extensive";
@@ -925,6 +927,10 @@ export function buildAgentSystemPrompt(params: {
     params.sandboxInfo?.enabled && sanitizedSandboxContainerWorkspace
       ? `For read/write/edit/apply_patch, file paths resolve against host workspace: ${sanitizedWorkspaceDir}. For bash/exec commands, use sandbox container paths under ${sanitizedSandboxContainerWorkspace} (or relative paths from that workdir), not host paths. Prefer relative paths so both sandboxed exec and file tools work consistently.`
       : "Treat this directory as the single global workspace for file operations unless explicitly instructed otherwise.";
+  const workspaceOnlyGuidance =
+    params.fsWorkspaceOnly === true
+      ? "tools.fs.workspaceOnly is enabled: scratch/temp/meta files that file tools must later read/write/edit must stay inside the workspace, preferably as relative paths under `.openclaw/tmp/`. Do not write files to `/tmp/...` with exec if a later read/write/edit/apply_patch tool needs them; use `.openclaw/tmp/...` instead."
+      : "";
   const safetySection = [
     "## Safety",
     "No independent goals: no self-preservation, replication, resource acquisition, power-seeking, or long-term plans beyond the user's request.",
@@ -998,6 +1004,7 @@ export function buildAgentSystemPrompt(params: {
     sandboxInfo: params.sandboxInfo,
     displayWorkspaceDir,
     workspaceGuidance,
+    workspaceOnlyGuidance,
     workspaceNotes,
     bootstrapMode: params.bootstrapMode,
     bootstrapSystemPromptSections,
@@ -1133,6 +1140,7 @@ export function buildAgentSystemPrompt(params: {
       "## Workspace",
       `Your working directory is: ${displayWorkspaceDir}`,
       workspaceGuidance,
+      workspaceOnlyGuidance,
       ...workspaceNotes,
       "",
       ...docsSection,


### PR DESCRIPTION
## Summary
- Add system-prompt guidance when `tools.fs.workspaceOnly` is enabled so scratch/temp/meta files stay inside the workspace, preferably under `.openclaw/tmp/`.
- Add a recovery hint to workspace-root guard errors without relaxing the guard or silently rewriting paths.
- Include workspace-only guidance in the stable prompt cache key so enabled/disabled configs cannot reuse the wrong cached prefix.

## Root cause
Agents could write scratch metadata with `exec` to `/tmp/...` and then fail when later file tools tried to read the same path under workspace-only guards. The guard was correct, but the prompt and error did not give a workspace-safe recovery path.

## Real behavior proof
- **Behavior or issue addressed:** With `tools.fs.workspaceOnly=true`, agent-visible prompt/error recovery should steer reusable scratch/temp/meta files into `.openclaw/tmp/`, reject `/tmp/repo_meta.jsonl`, and still allow workspace-local scratch files to be written and read back.
- **Real environment tested:** macOS local OpenClaw checkout on this branch, Node v24.15.0, temporary local workspace, real `createOpenClawCodingTools` read/write tools, config `{ tools: { fs: { workspaceOnly: true } } }`. The temp workspace path is redacted.
- **Exact steps or command run after this patch:** Ran a local `node --import tsx --input-type=module` script that built `buildEmbeddedSystemPrompt`, created real OpenClaw read/write tools for the temporary workspace, attempted to read `/tmp/repo_meta.jsonl`, then wrote/read `.openclaw/tmp/repo_meta.jsonl`.
- **Evidence after fix:** Redacted terminal output from the local run:

```text
REAL_BEHAVIOR_PROOF workspace=<redacted-temp-workspace>
prompt_guidance_present=true
outside_tmp_read_rejected=true
recovery_hint_present=true
workspace_scratch_readback=proof-ok
```

- **Observed result after fix:** The workspace-only prompt guidance was present, the outside `/tmp/repo_meta.jsonl` read was rejected, the rejection included the `.openclaw/tmp/` recovery hint, and the workspace-local `.openclaw/tmp/repo_meta.jsonl` file read back successfully as `proof-ok`.
- **What was not tested:** No additional gaps.

## Validation
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
- `node scripts/run-oxlint-shards.mjs --threads=8`
- `OPENCLAW_VITEST_INCLUDE_FILE=<tmp-json> node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts` for the three target files: 3 files / 38 tests passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts` previously ran the full unit-fast suite: 1005 files / 9415 tests passed.

Note: `corepack pnpm test:unit:fast -- src/agents/pi-embedded-runner/system-prompt.test.ts src/agents/pi-tools.workspace-paths.test.ts` exited 0 but did not select files under the current unit-fast runner, so the targeted run used `OPENCLAW_VITEST_INCLUDE_FILE`.