### PR TITLE
fix(voice-call): avoid duplicate OpenAI initial greetings

### DIFF
--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -1060,6 +1060,37 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     );
   });
 
+  it("applies provider-configured realtime auto-response opt-out when creating bridges", async () => {
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: {
+        apiKey: "sk-test", // pragma: allowlist secret
+        autoRespondToAudio: false,
+      },
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+    const connecting = bridge.connect();
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) {
+      throw new Error("expected bridge to create a websocket");
+    }
+
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    expectRecordFields(
+      requireNestedRecord(requireSession(socket), ["audio", "input", "turn_detection"]),
+      "turn detection",
+      {
+        create_response: false,
+        interrupt_response: false,
+      },
+    );
+  });
+
   it("can disable realtime response interruption while keeping audio responses enabled", async () => {
     const provider = buildOpenAIRealtimeVoiceProvider();
     const bridge = provider.createBridge({

--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -246,6 +246,17 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     });
   });
 
+  it("preserves explicit realtime auto-response opt-out during config resolution", () => {
+    const provider = buildOpenAIRealtimeVoiceProvider();
+
+    expect(
+      provider.resolveConfig?.({
+        cfg: {} as never,
+        rawConfig: { autoRespondToAudio: false },
+      }).autoRespondToAudio,
+    ).toBe(false);
+  });
+
   it("advertises continuing realtime tool results", () => {
     const provider = buildOpenAIRealtimeVoiceProvider();
     const bridge = provider.createBridge({

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -60,6 +60,7 @@ type OpenAIRealtimeVoiceProviderConfig = {
   vadThreshold?: number;
   silenceDurationMs?: number;
   prefixPaddingMs?: number;
+  autoRespondToAudio?: boolean;
   interruptResponseOnInputAudio?: boolean;
   minBargeInAudioEndMs?: number;
   reasoningEffort?: string;
@@ -215,6 +216,8 @@ function normalizeProviderConfig(
     vadThreshold: asUnitInterval(raw?.vadThreshold),
     silenceDurationMs: asNonNegativeInteger(raw?.silenceDurationMs),
     prefixPaddingMs: asNonNegativeInteger(raw?.prefixPaddingMs),
+    autoRespondToAudio:
+      typeof raw?.autoRespondToAudio === "boolean" ? raw.autoRespondToAudio : undefined,
     interruptResponseOnInputAudio:
       typeof raw?.interruptResponseOnInputAudio === "boolean"
         ? raw.interruptResponseOnInputAudio

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -1475,6 +1475,7 @@ export function buildOpenAIRealtimeVoiceProvider(): RealtimeVoiceProviderPlugin 
         vadThreshold: config.vadThreshold,
         silenceDurationMs: config.silenceDurationMs,
         prefixPaddingMs: config.prefixPaddingMs,
+        autoRespondToAudio: req.autoRespondToAudio ?? config.autoRespondToAudio,
         interruptResponseOnInputAudio:
           req.interruptResponseOnInputAudio ?? config.interruptResponseOnInputAudio,
         minBargeInAudioEndMs: config.minBargeInAudioEndMs,

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -526,10 +526,12 @@ describe("RealtimeCallHandler path routing", () => {
           onReady?: () => void;
         }
       | undefined;
+    let createRequest: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0] | undefined;
     const triggerGreeting = vi.fn();
     const createBridge = vi.fn(
       (request: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0]) => {
         callbacks = request;
+        createRequest = request;
         return makeBridge({ triggerGreeting });
       },
     );
@@ -574,6 +576,7 @@ describe("RealtimeCallHandler path routing", () => {
 
         callbacks?.onReady?.();
 
+        expect(createRequest?.autoRespondToAudio).toBe(false);
         expect(triggerGreeting).toHaveBeenCalledWith(expect.stringContaining("Hi, this is Milly."));
       } finally {
         if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -41,10 +41,11 @@ function makeBridge(overrides: Partial<RealtimeVoiceBridge> = {}): RealtimeVoice
 
 function makeRealtimeProvider(
   createBridge: RealtimeVoiceProviderPlugin["createBridge"],
+  id: RealtimeVoiceProviderPlugin["id"] = "openai",
 ): RealtimeVoiceProviderPlugin {
   return {
-    id: "openai",
-    label: "OpenAI",
+    id,
+    label: id === "openai" ? "OpenAI" : id,
     isConfigured: () => true,
     createBridge,
   };
@@ -82,6 +83,7 @@ function makeHandler(
     providers: overrides?.providers ?? {},
     ...(overrides?.provider ? { provider: overrides.provider } : {}),
   };
+  const realtimeProvider = deps?.realtimeProvider ?? makeRealtimeProvider(() => makeBridge());
   return new RealtimeCallHandler(
     config,
     {
@@ -102,8 +104,8 @@ function makeHandler(
       getCallStatus: vi.fn(),
       ...deps?.provider,
     } as unknown as VoiceCallProvider,
-    deps?.realtimeProvider ?? makeRealtimeProvider(() => makeBridge()),
-    { apiKey: "test-key" },
+    realtimeProvider,
+    config.providers[realtimeProvider.id] ?? { apiKey: "test-key" },
     "/voice/webhook",
   );
 }
@@ -443,6 +445,136 @@ describe("RealtimeCallHandler path routing", () => {
         callbacks?.onReady?.();
 
         expect(triggerGreeting).not.toHaveBeenCalled();
+      } finally {
+        if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+          ws.close();
+        }
+      }
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("lets OpenAI server VAD speak the initial outbound greeting once", async () => {
+    let callbacks:
+      | {
+          onReady?: () => void;
+        }
+      | undefined;
+    let createRequest: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0] | undefined;
+    const triggerGreeting = vi.fn();
+    const createBridge = vi.fn(
+      (request: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0]) => {
+        callbacks = request;
+        createRequest = request;
+        return makeBridge({ triggerGreeting });
+      },
+    );
+    const getCallByProviderCallId = vi.fn(
+      (): CallRecord => ({
+        callId: "call-1",
+        providerCallId: "CA-greeting",
+        provider: "twilio",
+        direction: "outbound",
+        state: "ringing",
+        from: "+15550001234",
+        to: "+15550009999",
+        startedAt: Date.now(),
+        transcript: [],
+        processedEventIds: [],
+        metadata: { initialMessage: "Hi, this is Milly." },
+      }),
+    );
+    const handler = makeHandler(undefined, {
+      manager: {
+        getCallByProviderCallId,
+      },
+      realtimeProvider: makeRealtimeProvider(createBridge),
+    });
+    const server = await startRealtimeServer(handler);
+
+    try {
+      const ws = await connectWs(server.url);
+      try {
+        ws.send(
+          JSON.stringify({
+            event: "start",
+            start: { streamSid: "MZ-greeting", callSid: "CA-greeting" },
+          }),
+        );
+        await waitForRealtimeTest(() => {
+          expect(createBridge).toHaveBeenCalled();
+        });
+
+        callbacks?.onReady?.();
+
+        expect(triggerGreeting).not.toHaveBeenCalled();
+        expect(createRequest?.instructions).toContain("Hi, this is Milly.");
+      } finally {
+        if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+          ws.close();
+        }
+      }
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("keeps explicit greetings when OpenAI auto response is disabled", async () => {
+    let callbacks:
+      | {
+          onReady?: () => void;
+        }
+      | undefined;
+    const triggerGreeting = vi.fn();
+    const createBridge = vi.fn(
+      (request: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0]) => {
+        callbacks = request;
+        return makeBridge({ triggerGreeting });
+      },
+    );
+    const getCallByProviderCallId = vi.fn(
+      (): CallRecord => ({
+        callId: "call-1",
+        providerCallId: "CA-manual-greeting",
+        provider: "twilio",
+        direction: "outbound",
+        state: "ringing",
+        from: "+15550001234",
+        to: "+15550009999",
+        startedAt: Date.now(),
+        transcript: [],
+        processedEventIds: [],
+        metadata: { initialMessage: "Hi, this is Milly." },
+      }),
+    );
+    const handler = makeHandler(
+      { providers: { openai: { autoRespondToAudio: false } } },
+      {
+        manager: {
+          getCallByProviderCallId,
+        },
+        realtimeProvider: makeRealtimeProvider(createBridge),
+      },
+    );
+    const server = await startRealtimeServer(handler);
+
+    try {
+      const ws = await connectWs(server.url);
+      try {
+        ws.send(
+          JSON.stringify({
+            event: "start",
+            start: { streamSid: "MZ-manual-greeting", callSid: "CA-manual-greeting" },
+          }),
+        );
+        await waitForRealtimeTest(() => {
+          expect(createBridge).toHaveBeenCalled();
+        });
+
+        callbacks?.onReady?.();
+
+        expect(triggerGreeting).toHaveBeenCalledWith(expect.stringContaining("Hi, this is Milly."));
       } finally {
         if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
           ws.close();

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -86,6 +86,16 @@ function buildGreetingInstructions(
     : `${intro} "${trimmedGreeting}"`;
 }
 
+function shouldUseOpenAIAutoGreeting(
+  provider: RealtimeVoiceProviderPlugin,
+  providerConfig: RealtimeVoiceProviderConfig,
+): boolean {
+  if (provider.id !== "openai") {
+    return false;
+  }
+  return providerConfig.autoRespondToAudio !== false;
+}
+
 function readConsultArgText(args: unknown, key: string): string | undefined {
   if (!args || typeof args !== "object" || Array.isArray(args)) {
     return undefined;
@@ -641,14 +651,20 @@ export class RealtimeCallHandler {
     const speechDetector = new RealtimeMulawSpeechStartDetector({
       requiredLoudChunks: BARGE_IN_REQUIRED_LOUD_CHUNKS,
     });
+    const useProviderAutoGreeting =
+      Boolean(initialGreetingInstructions) &&
+      shouldUseOpenAIAutoGreeting(this.realtimeProvider, this.providerConfig);
+    const sessionInstructions = useProviderAutoGreeting
+      ? initialGreetingInstructions
+      : this.config.instructions;
     const session = createRealtimeVoiceBridgeSession({
       provider: this.realtimeProvider,
       cfg: this.coreConfig,
       providerConfig: this.providerConfig,
-      instructions: this.config.instructions,
+      instructions: sessionInstructions,
       tools: this.config.tools,
       initialGreetingInstructions,
-      triggerGreetingOnReady: Boolean(initialGreetingInstructions),
+      triggerGreetingOnReady: Boolean(initialGreetingInstructions) && !useProviderAutoGreeting,
       audioSink: {
         isOpen: () => ws.readyState === WebSocket.OPEN,
         sendAudio: (muLaw) => {

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -662,6 +662,7 @@ export class RealtimeCallHandler {
       cfg: this.coreConfig,
       providerConfig: this.providerConfig,
       instructions: sessionInstructions,
+      autoRespondToAudio: this.providerConfig.autoRespondToAudio === false ? false : undefined,
       tools: this.config.tools,
       initialGreetingInstructions,
       triggerGreetingOnReady: Boolean(initialGreetingInstructions) && !useProviderAutoGreeting,


### PR DESCRIPTION
## Summary

- Avoid firing an explicit `triggerGreeting()` for OpenAI realtime outbound calls when OpenAI server VAD auto-response is active.
- Fold the queued outbound initial greeting into the OpenAI session instructions so the provider-owned first auto-response still receives the caller-facing greeting text.
- Preserve the explicit greeting path when `autoRespondToAudio: false` is configured, and now pass that opt-out through to the OpenAI bridge so server VAD `create_response` is disabled for that path.

Fixes #85846

## Test Plan

- RED: `node scripts/run-vitest.mjs extensions/voice-call/src/webhook/realtime-handler.test.ts --testNamePattern 'keeps explicit greetings when OpenAI auto response is disabled'` failed before the source fix with `expected undefined to be false` for `createRequest?.autoRespondToAudio`.
- RED: `node scripts/run-vitest.mjs extensions/openai/realtime-voice-provider.test.ts --testNamePattern "preserves explicit realtime auto-response opt-out during config resolution"` failed before the provider-resolution fix with `expected undefined to be false` for `resolveConfig(...).autoRespondToAudio`.
- GREEN: `node scripts/run-vitest.mjs extensions/openai/realtime-voice-provider.test.ts --testNamePattern "preserves explicit realtime auto-response opt-out during config resolution"` passed after the provider-resolution fix.
- RED: `node scripts/run-vitest.mjs extensions/openai/realtime-voice-provider.test.ts --testNamePattern "applies provider-configured realtime auto-response opt-out when creating bridges"` failed before the bridge-creation fix with `turn detection.create_response: expected true to deeply equal false`.
- GREEN: `node scripts/run-vitest.mjs extensions/openai/realtime-voice-provider.test.ts --testNamePattern "applies provider-configured realtime auto-response opt-out when creating bridges"` passed after the bridge-creation fix (`1 passed | 50 skipped`).
- `node scripts/run-vitest.mjs extensions/voice-call/src/webhook/realtime-handler.test.ts`
- `node scripts/run-vitest.mjs extensions/openai/realtime-voice-provider.test.ts extensions/voice-call/src/webhook/realtime-handler.test.ts`
- `pnpm check:changed --staged`
- Earlier on this branch: `pnpm openclaw voicecall --help` (runtime CLI/build smoke; exits because `voice-call` is disabled by default in this checkout).

## Real behavior proof

Behavior addressed: OpenAI realtime outbound calls with a queued initial greeting no longer create two independent greetings when server VAD auto-response is active; the initial greeting is provided through session instructions and `triggerGreeting()` is suppressed for that OpenAI auto-response path. When `autoRespondToAudio: false` is configured, the voice-call handler keeps the explicit `triggerGreeting()` path and passes `autoRespondToAudio: false` into the OpenAI bridge so the provider session disables server VAD `create_response`.

Real environment tested: Local OpenClaw checkout on macOS with the voice-call realtime WebSocket handler exercised through the repository runtime/test harness, the OpenAI realtime provider bridge tests, and OpenClaw CLI runtime smoke from this branch.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/voice-call/src/webhook/realtime-handler.test.ts --testNamePattern 'keeps explicit greetings when OpenAI auto response is disabled'` before the source fix; `node scripts/run-vitest.mjs extensions/openai/realtime-voice-provider.test.ts --testNamePattern "preserves explicit realtime auto-response opt-out during config resolution"` before and after the provider-resolution fix; `node scripts/run-vitest.mjs extensions/voice-call/src/webhook/realtime-handler.test.ts`; `node scripts/run-vitest.mjs extensions/openai/realtime-voice-provider.test.ts extensions/voice-call/src/webhook/realtime-handler.test.ts`; `pnpm check:changed --staged`; earlier `pnpm openclaw voicecall --help`.

Evidence after fix: The new provider-resolution RED assertion failed before the fix with `expected undefined to be false`, proving OpenAI `resolveConfig` dropped the configured `autoRespondToAudio: false` before the voice-call handler could read it. After the fix, that focused resolver test passed (`1 passed | 49 skipped`), and the combined OpenAI provider plus voice-call handler run passed (`2 files, 71 tests passed`). The changed gate reported lanes `extensions, extensionTests`, then completed typecheck extensions, typecheck extension tests, lint extensions, media helper guard, runtime sidecar loader guard, and runtime import-cycle checks successfully. The earlier CLI runtime smoke built OpenClaw and bundled plugin assets, then exited with the expected message that `openclaw voicecall` is provided by the disabled-by-default `voice-call` plugin. A follow-up bridge-creation RED assertion failed before this update with `turn detection.create_response: expected true to deeply equal false`; after the bridge fix, the focused createBridge test passed (`1 passed | 50 skipped`), and the combined OpenAI provider plus voice-call handler run passed (`2 files, 71 tests passed`).

Observed result after fix: OpenAI's default auto-response path receives the initial greeting in session instructions and the voice-call plugin no longer sends a second explicit greeting request. The disabled-auto-response path now sends exactly one explicit greeting request while carrying `autoRespondToAudio: false` to the OpenAI bridge so OpenAI server VAD does not auto-create a second response. Provider-level `autoRespondToAudio: false` now also reaches bridge creation when no per-request override is present.

What was not tested: A live Twilio/OpenAI phone call was not placed from this environment because external telephony/provider credentials are not available to this cron job; the after-fix proof uses local realtime WebSocket handler/provider bridge execution and CLI/build smoke rather than external telephony credentials.

## Risk/Notes

- Message-delivery behavior is intentionally changed only for OpenAI realtime outbound initial greetings.
- Live carrier/provider proof still requires redacted Twilio/OpenAI runtime logs or a call artifact from an environment with those credentials.

