### PR TITLE
fix(gateway): dedupe session tool fanout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway: avoid sending duplicate tool-event frames to Control UI connections that are subscribed by both run and session.
 - Discord/OpenAI voice: accept leading fuzzy wake-name transcripts such as "Monty" or "Moti" for a Molty agent while keeping ambient speech gated.
 - Discord/OpenAI voice: rotate Realtime sessions at provider max duration without logging the expected session-expiry event as an error.
 - Memory/local embeddings: run local GGUF embeddings in an isolated worker sidecar and degrade to configured fallback or keyword search on worker failure so native embedding crashes do not take down the Gateway. (#85348) Thanks @osolmaz.

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -107,8 +107,7 @@ describe("agent event handler", () => {
       loadGatewaySessionRowForSnapshot: loadGatewaySessionRow,
       lifecycleErrorRetryGraceMs: params?.lifecycleErrorRetryGraceMs,
       isChatSendRunActive: params?.isChatSendRunActive,
-      shouldBackoffLowPrioritySessionToolEvents:
-        params?.shouldBackoffLowPrioritySessionToolEvents,
+      shouldBackoffLowPrioritySessionToolEvents: params?.shouldBackoffLowPrioritySessionToolEvents,
     });
 
     return {
@@ -1524,6 +1523,45 @@ describe("agent event handler", () => {
       dropIfSlow: true,
     });
     resetAgentRunContextForTest();
+  });
+
+  it("does not duplicate tool events to clients subscribed by run and session", () => {
+    const { broadcastToConnIds, sessionEventSubscribers, toolEventRecipients, handler } =
+      createHarness({
+        resolveSessionKeyForRun: () => "session-dedupe",
+      });
+
+    registerAgentRunContext("run-session-dedupe-tool", {
+      sessionKey: "session-dedupe",
+      verboseLevel: "off",
+    });
+    toolEventRecipients.add("run-session-dedupe-tool", "conn-overlap");
+    toolEventRecipients.add("run-session-dedupe-tool", "conn-run-only");
+    sessionEventSubscribers.subscribe("conn-overlap");
+    sessionEventSubscribers.subscribe("conn-session-only");
+
+    handler({
+      runId: "run-session-dedupe-tool",
+      seq: 1,
+      stream: "tool",
+      ts: 1_234,
+      data: {
+        phase: "start",
+        name: "exec",
+        toolCallId: "tool-session-dedupe-1",
+        args: { command: "echo hi" },
+      },
+    });
+
+    expect(broadcastToConnIds).toHaveBeenCalledTimes(2);
+    expect(requireMockArg(broadcastToConnIds, 0, 0, "run tool event")).toBe("agent");
+    expect(requireMockArg(broadcastToConnIds, 0, 2, "run tool recipients")).toEqual(
+      new Set(["conn-overlap", "conn-run-only"]),
+    );
+    expect(requireMockArg(broadcastToConnIds, 1, 0, "session tool event")).toBe("session.tool");
+    expect(requireMockArg(broadcastToConnIds, 1, 2, "session tool recipients")).toEqual(
+      new Set(["conn-session-only"]),
+    );
   });
 
   it("backs off session-scoped tool mirrors during queued gateway pressure", () => {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -183,6 +183,22 @@ function isTerminalToolEventPhase(phase: string): boolean {
   return TERMINAL_TOOL_EVENT_PHASES.has(phase);
 }
 
+function excludeConnIds(
+  connIds: ReadonlySet<string>,
+  excludedConnIds: ReadonlySet<string> | undefined,
+): ReadonlySet<string> {
+  if (!excludedConnIds || excludedConnIds.size === 0 || connIds.size === 0) {
+    return connIds;
+  }
+  const filtered = new Set<string>();
+  for (const connId of connIds) {
+    if (!excludedConnIds.has(connId)) {
+      filtered.add(connId);
+    }
+  }
+  return filtered;
+}
+
 type BroadcastDelta = { deltaText: string; replace?: true };
 
 function resolveBroadcastDelta(params: {
@@ -957,12 +973,17 @@ export function createAgentEventHandler({
       // tool-events capability, regardless of verboseLevel. The verbose
       // setting only controls whether tool details are sent as channel
       // messages to messaging surfaces (Telegram, Discord, etc.).
-      const recipients = toolEventRecipients.get(evt.runId);
-      if (isControlUiVisible && !suppressHeartbeatToolEvents && recipients && recipients.size > 0) {
+      const runToolRecipients = toolEventRecipients.get(evt.runId);
+      if (
+        isControlUiVisible &&
+        !suppressHeartbeatToolEvents &&
+        runToolRecipients &&
+        runToolRecipients.size > 0
+      ) {
         broadcastToConnIds(
           "agent",
           sessionKey ? { ...agentPayload, ...buildSessionEventSnapshot(sessionKey) } : agentPayload,
-          recipients,
+          runToolRecipients,
         );
       }
       if (!isControlUiVisible && sessionKey && !suppressHeartbeatToolEvents) {
@@ -985,7 +1006,10 @@ export function createAgentEventHandler({
         !suppressHeartbeatToolEvents &&
         shouldMirrorSessionToolEvent
       ) {
-        const sessionSubscribers = sessionEventSubscribers.getAll();
+        const sessionSubscribers = excludeConnIds(
+          sessionEventSubscribers.getAll(),
+          runToolRecipients,
+        );
         if (sessionSubscribers.size > 0) {
           broadcastToConnIds(
             "session.tool",


### PR DESCRIPTION
## Summary

- Dedupe gateway tool-event fanout when the same websocket is subscribed by both run and session.
- Keep the compatibility `session.tool` mirror for session-only subscribers, but prefer the canonical `agent` event for run-scoped recipients.
- Add regression coverage for the overlap case and keep the existing queue-pressure backoff behavior intact.

## Verification

- `node scripts/run-vitest.mjs src/gateway/server-chat.agent-events.test.ts`
- `git diff --check`
- `env -u OPENCLAW_TESTBOX pnpm check:changed`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof

Behavior addressed: Control UI connections that subscribe to both run-scoped tool events and session-scoped session tool events should not receive the same semantic tool event twice.

Real environment tested: Local OpenClaw source checkout on Node 26 via the repo Vitest wrapper and changed-check lane.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/gateway/server-chat.agent-events.test.ts`; `git diff --check`; `env -u OPENCLAW_TESTBOX pnpm check:changed`; `.agents/skills/autoreview/scripts/autoreview --mode local`.

Evidence after fix: The targeted gateway test file passed with 75 tests. `git diff --check` passed. `check:changed` passed core/coreTests/docs changed lanes after unsetting a stale local `OPENCLAW_TESTBOX` flag. Autoreview reported no accepted/actionable findings.

Observed result after fix: Run-scoped recipients still receive `agent` tool events, session-only subscribers still receive `session.tool`, and overlapping websocket connections are removed from the session mirror recipient set so they receive one frame.

What was not tested: No live browser websocket capture; the behavior is covered at the gateway fanout seam that owns recipient selection.
