### PR TITLE
fix: accept OpenClaw voice wake confusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway: avoid sending duplicate tool-event frames to Control UI connections that are subscribed by both run and session.
+- Discord/OpenAI voice: accept longer leading wake-name mistranscripts such as "Open Club" for OpenClaw.
 - Discord/OpenAI voice: accept leading fuzzy wake-name transcripts such as "Monty" or "Moti" for a Molty agent while keeping ambient speech gated.
 - Media understanding: convert HEIC and HEIF images to JPEG before image description providers run so iPhone photos work in direct and configured image-description flows. (#86037)
 - Discord/OpenAI voice: rotate Realtime sessions at provider max duration without logging the expected session-expiry event as an error.

--- a/extensions/discord/src/voice/manager.e2e.test.ts
+++ b/extensions/discord/src/voice/manager.e2e.test.ts
@@ -3031,6 +3031,27 @@ describe("DiscordVoiceManager", () => {
 
     expect(agentCommandArgsAt(2).message).toContain("can you still hear me?");
     expect(agentCommandArgsAt(2).message).not.toContain("Open claw");
+
+    const openClubTurn = entry.realtime?.beginSpeakerTurn(
+      { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
+      "u-owner",
+    );
+    openClubTurn?.sendInputAudio(Buffer.alloc(8));
+    bridgeParams?.onTranscript?.("user", "Open Club, can you hear me now?", true);
+    await new Promise((resolve) => setTimeout(resolve, 260));
+
+    expect(agentCommandArgsAt(3).message).toContain("can you hear me now?");
+    expect(agentCommandArgsAt(3).message).not.toContain("Open Club");
+
+    const openChatTurn = entry.realtime?.beginSpeakerTurn(
+      { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
+      "u-owner",
+    );
+    openChatTurn?.sendInputAudio(Buffer.alloc(8));
+    bridgeParams?.onTranscript?.("user", "Open chat, can you hear me now?", true);
+    await new Promise((resolve) => setTimeout(resolve, 260));
+
+    expect(agentCommandMock).toHaveBeenCalledTimes(4);
   });
 
   it("rejects non-wake fuzzy leading phrases before realtime agent-proxy consults", async () => {

--- a/extensions/discord/src/voice/realtime.ts
+++ b/extensions/discord/src/voice/realtime.ts
@@ -70,6 +70,9 @@ const DISCORD_RAW_PCM_FRAME_BYTES = 3_840;
 const DISCORD_REALTIME_OUTPUT_PREROLL_FRAMES = 25;
 const DISCORD_REALTIME_TRAILING_SILENCE_MIN_MS = 700;
 const DISCORD_REALTIME_TRAILING_SILENCE_MAX_MS = 3_000;
+const DISCORD_REALTIME_WAKE_NAME_CONFUSIONS = new Map<string, ReadonlySet<string>>([
+  ["openclaw", new Set(["openclub", "opencloud"])],
+]);
 const DISCORD_REALTIME_FORCED_CONSULT_TRAILING_FRAGMENT_WORDS = new Set([
   "a",
   "about",
@@ -492,7 +495,10 @@ function isFuzzyWakeNameMatch(candidate: LeadingWakeNameCandidate, wakeName: str
   if (distance <= 1) {
     return true;
   }
-  return distance === 2 && wakeCompact.length >= 5 && heardCompact.length !== wakeCompact.length;
+  if (distance === 2 && wakeCompact.length >= 5 && heardCompact.length !== wakeCompact.length) {
+    return true;
+  }
+  return DISCORD_REALTIME_WAKE_NAME_CONFUSIONS.get(wakeCompact)?.has(heardCompact) === true;
 }
 
 function stripLeadingWakeNameCandidate(text: string, candidate: LeadingWakeNameCandidate): string {


### PR DESCRIPTION
## Summary
- Accept known leading OpenClaw wake-name ASR confusions such as `Open Club` and `Open Cloud` without broadening short-name fuzzy wake matching.
- Keep nearby non-wake phrases such as `Open chat` gated.
- Update the changelog for the Discord/OpenAI voice wake fix.

## Verification
- Live logs: `Open Club, can you hear me?` was transcribed and ignored before this patch; `OpenClo, can you hear me?` matched fuzzy and reached agent consult.
- `pnpm test extensions/discord/src/voice/manager.e2e.test.ts`
- `env -u OPENCLAW_TESTBOX pnpm check:changed`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof
Behavior addressed: Discord/OpenAI voice wake-name gating now accepts the observed `Open Club` mistranscript for OpenClaw while preserving ambient-speech gating for nearby non-wake phrases.
Real environment tested: Local live gateway logs from the maintainer-lounge Discord voice session, plus local focused e2e coverage.
Exact steps or command run after this patch: `pnpm test extensions/discord/src/voice/manager.e2e.test.ts`; `env -u OPENCLAW_TESTBOX pnpm check:changed`; `.agents/skills/autoreview/scripts/autoreview --mode local`.
Evidence after fix: Focused e2e now covers `Open Club, can you hear me now?` as accepted and `Open chat, can you hear me now?` as ignored.
Observed result after fix: 113 Discord voice e2e tests passed; changed check passed; autoreview clean.
What was not tested: A fresh live spoken `Open Club` utterance after the patch.
