### PR TITLE
perf: cache plugin package realpaths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - Gateway: avoid sending duplicate tool-event frames to Control UI connections that are subscribed by both run and session.
 - Discord/OpenAI voice: accept longer leading wake-name mistranscripts such as "Open Club" for OpenClaw.
 - Agents/OpenAI-compatible: stop ModelStudio-compatible chat requests before sending system/tool-only payloads that have no usable user or assistant turn. (#86177) Thanks @TurboTheTurtle.
+- Gateway/plugins: reuse plugin package realpath checks while building installed plugin indexes so startup avoids repeated filesystem resolution work.
 - Discord/OpenAI voice: accept leading fuzzy wake-name transcripts such as "Monty" or "Moti" for a Molty agent while keeping ambient speech gated.
 - Media understanding: convert HEIC and HEIF images to JPEG before image description providers run so iPhone photos work in direct and configured image-description flows. (#86037)
 - Agents: release embedded-attempt session locks from outer teardown so post-prompt exceptions cannot wedge later requests behind `SessionWriteLockTimeoutError`. Fixes #86014. Thanks @openperf.

--- a/src/plugins/installed-plugin-index-record-builder.ts
+++ b/src/plugins/installed-plugin-index-record-builder.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/types.js";
 import type { PluginCompatCode } from "./compat/registry.js";
@@ -18,7 +17,7 @@ import type {
 import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
 import type { PluginDiagnostic } from "./manifest-types.js";
 import type { PluginPackageChannel } from "./manifest.js";
-import { isPathInsideWithRealpath, safeRealpathSync } from "./path-safety.js";
+import { isPathInside, safeRealpathSync } from "./path-safety.js";
 import { hasKind } from "./slots.js";
 
 function sortUnique(values: readonly string[] | undefined): readonly string[] {
@@ -77,20 +76,30 @@ export function collectPluginManifestCompatCodes(
   return sortUnique(codes) as readonly PluginCompatCode[];
 }
 
-function resolvePackageJsonPath(candidate: PluginCandidate | undefined): string | undefined {
+function resolvePackageJsonPath(
+  candidate: PluginCandidate | undefined,
+  realpathCache: Map<string, string>,
+): string | undefined {
   if (!candidate?.packageDir) {
     return undefined;
   }
-  const packageDir = safeRealpathSync(candidate.packageDir) ?? path.resolve(candidate.packageDir);
+  const packageDir =
+    safeRealpathSync(candidate.packageDir, realpathCache) ?? path.resolve(candidate.packageDir);
   const packageJsonPath = path.join(packageDir, "package.json");
-  const rootDir = safeRealpathSync(candidate.rootDir) ?? path.resolve(candidate.rootDir);
-  return fs.existsSync(packageJsonPath) && isPathInsideWithRealpath(rootDir, packageJsonPath)
+  const rootDir =
+    safeRealpathSync(candidate.rootDir, realpathCache) ?? path.resolve(candidate.rootDir);
+  const packageJsonRealPath = safeRealpathSync(packageJsonPath, realpathCache);
+  return packageJsonRealPath && isPathInside(rootDir, packageJsonRealPath)
     ? packageJsonPath
     : undefined;
 }
 
-function resolvePackageJsonRelativePath(rootDir: string, packageJsonPath: string): string {
-  const resolvedRootDir = safeRealpathSync(rootDir) ?? path.resolve(rootDir);
+function resolvePackageJsonRelativePath(
+  rootDir: string,
+  packageJsonPath: string,
+  realpathCache: Map<string, string>,
+): string {
+  const resolvedRootDir = safeRealpathSync(rootDir, realpathCache) ?? path.resolve(rootDir);
   const relativePath = path.relative(resolvedRootDir, packageJsonPath) || "package.json";
   return relativePath.split(path.sep).join("/");
 }
@@ -100,6 +109,7 @@ function resolvePackageJsonRecord(params: {
   packageJsonPath: string | undefined;
   diagnostics: PluginDiagnostic[];
   pluginId: string;
+  realpathCache: Map<string, string>;
 }): InstalledPluginIndexRecord["packageJson"] | undefined {
   if (!params.candidate?.packageDir || !params.packageJsonPath) {
     return undefined;
@@ -115,7 +125,11 @@ function resolvePackageJsonRecord(params: {
   }
   const fileSignature = safeFileSignature(params.packageJsonPath);
   return {
-    path: resolvePackageJsonRelativePath(params.candidate.rootDir, params.packageJsonPath),
+    path: resolvePackageJsonRelativePath(
+      params.candidate.rootDir,
+      params.packageJsonPath,
+      params.realpathCache,
+    ),
     hash,
     ...(fileSignature ? { fileSignature } : {}),
   };
@@ -207,9 +221,10 @@ export function buildInstalledPluginIndexRecords(params: {
 }): InstalledPluginIndexRecord[] {
   const candidateByRootDir = buildCandidateLookup(params.candidates);
   const normalizedConfig = normalizePluginsConfig(params.config?.plugins);
+  const realpathCache = new Map<string, string>();
   return params.registry.plugins.map((record): InstalledPluginIndexRecord => {
     const candidate = candidateByRootDir.get(record.rootDir);
-    const packageJsonPath = resolvePackageJsonPath(candidate);
+    const packageJsonPath = resolvePackageJsonPath(candidate, realpathCache);
     const installRecord = params.installRecords[record.id];
     const packageInstall = describePackageInstallSource(candidate);
     const packageChannel = normalizePackageChannel(
@@ -224,6 +239,7 @@ export function buildInstalledPluginIndexRecords(params: {
       packageJsonPath,
       diagnostics: params.diagnostics,
       pluginId: record.id,
+      realpathCache,
     });
     const enabled = resolveEffectiveEnableState({
       id: record.id,

--- a/src/plugins/manifest-registry-installed.ts
+++ b/src/plugins/manifest-registry-installed.ts
@@ -17,7 +17,7 @@ import {
   type PackageManifest,
   type PluginPackageChannel,
 } from "./manifest.js";
-import { isPathInsideWithRealpath, safeRealpathSync } from "./path-safety.js";
+import { isPathInside, safeRealpathSync } from "./path-safety.js";
 import { tracePluginLifecyclePhase } from "./plugin-lifecycle-trace.js";
 import {
   normalizePluginDependencySpecs,
@@ -33,18 +33,22 @@ function isRelativePathInsideOrEqual(relativePath: string): boolean {
   );
 }
 
-function resolvePackageJsonPath(record: InstalledPluginIndexRecord): string | undefined {
+function resolvePackageJsonPath(
+  record: InstalledPluginIndexRecord,
+  realpathCache: Map<string, string>,
+): string | undefined {
   if (!record.packageJson?.path) {
     return undefined;
   }
   const rootDir = resolveInstalledPluginRootDir(record);
-  const realRootDir = safeRealpathSync(rootDir) ?? path.resolve(rootDir);
+  const realRootDir = safeRealpathSync(rootDir, realpathCache) ?? path.resolve(rootDir);
   const packageJsonPath = path.resolve(realRootDir, record.packageJson.path);
   const relative = path.relative(realRootDir, packageJsonPath);
   if (!isRelativePathInsideOrEqual(relative)) {
     return undefined;
   }
-  if (!isPathInsideWithRealpath(realRootDir, packageJsonPath)) {
+  const packageJsonRealPath = safeRealpathSync(packageJsonPath, realpathCache);
+  if (!packageJsonRealPath || !isPathInside(realRootDir, packageJsonRealPath)) {
     return undefined;
   }
   return packageJsonPath;
@@ -63,6 +67,7 @@ function safeFileSignature(filePath: string | undefined): string | undefined {
 }
 
 function buildInstalledManifestRegistryIndexKey(index: InstalledPluginIndex) {
+  const realpathCache = new Map<string, string>();
   return {
     version: index.version,
     hostContractVersion: index.hostContractVersion,
@@ -72,7 +77,7 @@ function buildInstalledManifestRegistryIndexKey(index: InstalledPluginIndex) {
     installRecords: index.installRecords,
     diagnostics: index.diagnostics,
     plugins: index.plugins.map((record) => {
-      const packageJsonPath = resolvePackageJsonPath(record);
+      const packageJsonPath = resolvePackageJsonPath(record, realpathCache);
       return {
         pluginId: record.pluginId,
         packageName: record.packageName,
@@ -359,7 +364,10 @@ function normalizePersistedPackageChannel(value: unknown): PluginPackageChannel 
   return channel;
 }
 
-function resolveInstalledPackageMetadata(record: InstalledPluginIndexRecord): {
+function resolveInstalledPackageMetadata(
+  record: InstalledPluginIndexRecord,
+  realpathCache: Map<string, string>,
+): {
   packageManifest?: OpenClawPackageManifest;
   packageDependencies?: PluginDependencySpecMap;
   packageOptionalDependencies?: PluginDependencySpecMap;
@@ -370,7 +378,9 @@ function resolveInstalledPackageMetadata(record: InstalledPluginIndexRecord): {
         channel: recordPackageChannel,
       }
     : undefined;
-  const packageJsonPath = record.packageJson?.path ? resolvePackageJsonPath(record) : undefined;
+  const packageJsonPath = record.packageJson?.path
+    ? resolvePackageJsonPath(record, realpathCache)
+    : undefined;
   if (!packageJsonPath) {
     return fallbackPackageManifest ? { packageManifest: fallbackPackageManifest } : {};
   }
@@ -409,9 +419,12 @@ function resolveInstalledPackageMetadata(record: InstalledPluginIndexRecord): {
   return fallbackPackageManifest ? { packageManifest: fallbackPackageManifest } : {};
 }
 
-function toPluginCandidate(record: InstalledPluginIndexRecord): PluginCandidate {
+function toPluginCandidate(
+  record: InstalledPluginIndexRecord,
+  realpathCache: Map<string, string>,
+): PluginCandidate {
   const rootDir = resolveInstalledPluginRootDir(record);
-  const packageMetadata = resolveInstalledPackageMetadata(record);
+  const packageMetadata = resolveInstalledPackageMetadata(record, realpathCache);
   return {
     idHint: record.pluginId,
     source: record.source ?? resolveFallbackPluginSource(record),
@@ -452,6 +465,7 @@ export function loadPluginManifestRegistryForInstalledIndex(params: {
       }
       const env = params.env ?? process.env;
       const pluginIdSet = params.pluginIds?.length ? new Set(params.pluginIds) : null;
+      const realpathCache = new Map<string, string>();
       const diagnostics = pluginIdSet
         ? params.index.diagnostics.filter((diagnostic) => {
             const pluginId = diagnostic.pluginId;
@@ -461,7 +475,7 @@ export function loadPluginManifestRegistryForInstalledIndex(params: {
       const candidates = params.index.plugins
         .filter((plugin) => params.includeDisabled || plugin.enabled)
         .filter((plugin) => !pluginIdSet || pluginIdSet.has(plugin.pluginId))
-        .map(toPluginCandidate);
+        .map((plugin) => toPluginCandidate(plugin, realpathCache));
       return loadPluginManifestRegistry({
         config: params.config,
         workspaceDir: params.workspaceDir,


### PR DESCRIPTION
## Summary

- Cache plugin package realpath checks while building installed plugin index records.
- Reuse the same cached package path validation when deriving installed manifest registry fingerprints and candidates.
- Keep package.json symlink escape protection by realpathing the target once and checking it remains inside the canonical plugin root.

## Verification

- `pnpm test src/plugins/installed-plugin-index.test.ts src/plugins/plugin-metadata-snapshot.memo.test.ts src/plugins/setup-registry.runtime.test.ts src/plugins/plugin-lookup-table.test.ts`
- `env -u OPENCLAW_TESTBOX pnpm check:changed`
- `pnpm test:gateway:cpu-scenarios --skip-qa --startup-case default --runs 1 --warmup 0 --output-dir .artifacts/gateway-cpu-scenarios/profile-package-realpath-cache`
- `pnpm tsgo:extensions`
- `pnpm tsgo:extensions:test`
- `pnpm run test:extensions:package-boundary:compile`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof

Behavior addressed: Gateway CPU profiles showed repeated plugin package path realpath/stat/open work while building installed plugin indexes and installed manifest registry data.

Real environment tested: Local source checkout on macOS with existing tracked gateway CPU profiles and the repo gateway startup CPU scenario.

Exact steps or command run after this patch: `pnpm test:gateway:cpu-scenarios --skip-qa --startup-case default --runs 1 --warmup 0 --output-dir .artifacts/gateway-cpu-scenarios/profile-package-realpath-cache`

Evidence after fix: Startup scenario completed successfully with default gateway ready in about 1.59s, `/readyz` in about 2.21s, and no CPU observations.

Observed result after fix: The plugin package metadata paths still reject out-of-root package.json symlinks in regression tests while avoiding duplicate root/target realpath checks within each index build.

What was not tested: Full QA scenario CPU suite; this patch used focused plugin registry/index tests, changed gates, and the default gateway startup CPU scenario.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details, unrelated session turns
scope: PR #86517, branch perf/plugin-index-realpath-cache, plugin package realpath cache perf work

[user]
check the cpu profile we track on gateway and see if we have any obvious spots that we can make faster

[assistant]
Using `$openclaw-debugging` for the gateway/runtime investigation. I’ll find the captured profile first, then inspect hot frames against current source before proposing or patching anything.

Found the tracked gateway profiles under `.artifacts/gateway-watch-profiles`; latest gateway capture is from [REDACTED]. I’m summarizing V8 samples by self time and source location now.

Latest capture is short, but the hot samples are already clustered: JSON5 session-store parsing, plugin alias normalization through Jiti/package resolution, schema validation, and synchronous child process/fs resolution. I’m checking a few adjacent longer captures so we don’t chase a one-off startup slice.

Across longer captures, active CPU is dominated by filesystem/module resolution: `lstat`, `open`, `stat`, `existsSync`, `realpathSync`, path normalization, plus `tryReadJsonSync` and Jiti. That’s the likely obvious win area, not voice/audio. I’m tracing those native frames back to callers.

The clean low-risk target is plugin package path validation. The profile shows repeated realpath/inside checks around `package.json` in installed plugin index construction; current code realpaths the root, then calls a helper that realpaths the root again plus target. I’m checking tests around that path and then I can patch it to reuse one realpath cache.

I’m going to make the bounded optimization in two plugin-index paths: add a per-build realpath cache, validate `package.json` by realpathing the target once, and avoid the duplicate root realpath inside `isPathInsideWithRealpath`. Existing symlink/out-of-root tests cover the security behavior.

Patch is in. Running the installed-plugin-index tests first, since they cover symlinked package roots and package.json escaping outside the plugin root.

Focused plugin index tests pass. I’m running the nearby manifest-registry/plugin metadata tests that exercise the second touched path.

The diff is small and covered by existing tests. I’m adding a changelog note because this is a gateway startup/plugin discovery perf change, then I’ll run the changed check.

Changed check found two straightforward type issues: one now-unused `fs` import, and one remaining helper call that needs the new realpath cache argument. Fixing those.

Type fixes applied. Rerunning the focused tests, then the changed gate.

Changed gate passed. I’m running the lightweight gateway startup CPU scenario for the default case so the perf path gets exercised against built artifacts, not only type/tests.

Startup scenario passed: default gateway ready in ~1.59s, `/readyz` in ~2.21s, no CPU observations. Before closeout I’m running `$autoreview` on the small perf diff per repo policy.

Autoreview clean: no accepted/actionable findings reported.

[assistant]
Found an obvious hotspot in the tracked gateway CPU profiles:

- Latest/adjacent gateway profiles: active CPU mostly `lstat/open/stat/existsSync/realpathSync`.
- Caller stacks point at plugin registry/index rebuild paths, especially package `package.json` validation during installed plugin index + manifest registry loading.
- One long profile had ~48s in `lstat` and ~37s in `open`; most of that traced through plugin discovery/index code.

I patched the low-risk part:
- `src/plugins/installed-plugin-index-record-builder.ts`: reuse a per-index realpath cache and avoid duplicate root realpath checks.
- `src/plugins/manifest-registry-installed.ts`: same cache reuse for installed-index manifest registry conversion.
- `CHANGELOG.md`: perf note.

Safety kept: `package.json` symlink escapes still rejected by realpathing the target once and checking it remains inside the real plugin root.

Proof:
- `pnpm test src/plugins/installed-plugin-index.test.ts src/plugins/plugin-metadata-snapshot.memo.test.ts src/plugins/setup-registry.runtime.test.ts src/plugins/plugin-lookup-table.test.ts`: 68 passed.
- `env -u OPENCLAW_TESTBOX pnpm check:changed`: passed.
- `pnpm test:gateway:cpu-scenarios --skip-qa --startup-case default --runs 1 --warmup 0 ...`: passed, default gateway ready ~1.59s, `/readyz` ~2.21s, no CPU observations.
- `.agents/skills/autoreview/scripts/autoreview --mode local`: clean.

[user]
rebase main, make PR, read agent-transcript skill and preview what we would send

[assistant]
Using `$agent-transcript` because you named it, plus the PR workflow. I’ll first read that skill and check git state, then branch/commit/rebase and draft the outbound transcript text before any send.

`main` is already at `origin/main`; dirty files are only the perf patch and changelog. I’m creating a focused branch, committing those files, then I’ll rebase against fresh `origin/main` before creating the PR.

Rebase completed cleanly onto fresh `origin/main`. Next: find the local session transcript candidate, render a sanitized preview, and create the PR without adding transcript logs unless you approve that section.

Transcript finder is taking a bit against local logs. I’m letting it finish; no network involved per the skill.

The transcript candidate is safe-renderable but broad: it includes earlier voice/CI/landing work from the same local session, not just this perf patch. I created the local HTML preview at `/tmp/plugin-index-realpath-agent-transcript.html`; I’ll make the PR without adding that transcript section unless you approve it.

Branch pushed. I’m writing the PR body through a temp file, inspecting it, then creating the PR. Transcript is not included in the body yet; local preview is available for approval.

Rebased onto fresh `origin/main`, committed, pushed, and opened PR #86517.

Preview finding: sanitized output is safe-renderable, but broad. It includes earlier same-session voice/CI/landing work, not just this perf patch, so I did not add it to the PR body.

[user]
pull agin, check if search is faster, and do new instructions

[assistant]
Pulling/rebasing the PR branch again, then I’ll reread updated local instructions/agent-transcript skill and time the transcript search path that was slow.

Rebase hit a changelog-only conflict from newer `main`. I’m resolving by keeping the new upstream entries plus this perf bullet.

Rebase finished after resolving the changelog conflict. I’m rereading the current repo instructions/agent-transcript skill from the rebased tree, then timing the local transcript search.

New instructions changed: transcript sections must trim unrelated turns before insertion, and `find` now scans newest 400 matching local logs by default with `--max-files` available. That directly addresses the earlier broad transcript issue.

Search is much faster now: `agent-transcript find` completed in 1.75s and returned the same top session. I’m preparing a trimmed transcript section scoped only to this PR, per the updated instruction, then I’ll force-push the rebased branch.
````

</details>
<!-- agent-transcript:end -->
