### PR TITLE
test(agents): preserve provider hook mock exports

### DIFF
--- a/src/agents/pi-embedded-runner.openai-tool-id-preservation.test.ts
+++ b/src/agents/pi-embedded-runner.openai-tool-id-preservation.test.ts
@@ -17,23 +17,25 @@ vi.mock(
   "../plugins/provider-runtime.js",
   async () => await createSanitizeSessionHistoryProviderRuntimeMock(),
 );
-vi.mock("../plugins/provider-hook-runtime.js", () =>
-  createSanitizeSessionHistoryProviderHookRuntimeMock({
-    resolveProviderRuntimePlugin: vi.fn(({ provider }: { provider?: string }) =>
-      provider === "openai"
-        ? {
-            buildReplayPolicy: (context?: { modelApi?: string }) => ({
-              sanitizeMode: "images-only",
-              sanitizeToolCallIds: context?.modelApi === "openai-completions",
-              ...(context?.modelApi === "openai-completions" ? { toolCallIdMode: "strict" } : {}),
-              applyAssistantFirstOrderingFix: false,
-              validateGeminiTurns: false,
-              validateAnthropicTurns: false,
-            }),
-          }
-        : undefined,
-    ),
-  }),
+vi.mock(
+  "../plugins/provider-hook-runtime.js",
+  async () =>
+    await createSanitizeSessionHistoryProviderHookRuntimeMock({
+      resolveProviderRuntimePlugin: vi.fn(({ provider }: { provider?: string }) =>
+        provider === "openai"
+          ? {
+              buildReplayPolicy: (context?: { modelApi?: string }) => ({
+                sanitizeMode: "images-only",
+                sanitizeToolCallIds: context?.modelApi === "openai-completions",
+                ...(context?.modelApi === "openai-completions" ? { toolCallIdMode: "strict" } : {}),
+                applyAssistantFirstOrderingFix: false,
+                validateGeminiTurns: false,
+                validateAnthropicTurns: false,
+              }),
+            }
+          : undefined,
+      ),
+    }),
 );
 
 describe("sanitizeSessionHistory openai tool id preservation", () => {

--- a/src/agents/pi-embedded-runner.sanitize-session-history.policy.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.policy.test.ts
@@ -21,8 +21,9 @@ vi.mock(
   "../plugins/provider-runtime.js",
   async () => await createSanitizeSessionHistoryProviderRuntimeMock(),
 );
-vi.mock("../plugins/provider-hook-runtime.js", () =>
-  createSanitizeSessionHistoryProviderHookRuntimeMock(),
+vi.mock(
+  "../plugins/provider-hook-runtime.js",
+  async () => await createSanitizeSessionHistoryProviderHookRuntimeMock(),
 );
 
 let sanitizeSessionHistory: SanitizeSessionHistoryHarness["sanitizeSessionHistory"];

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test-harness.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test-harness.ts
@@ -84,11 +84,15 @@ export async function createSanitizeSessionHistoryProviderRuntimeMock(
   };
 }
 
-export function createSanitizeSessionHistoryProviderHookRuntimeMock(
+export async function createSanitizeSessionHistoryProviderHookRuntimeMock(
   extra: Record<string, unknown> = {},
 ) {
   const clearProviderRuntimePluginCacheForTest = vi.fn();
+  const actual = await vi.importActual<typeof import("../plugins/provider-hook-runtime.js")>(
+    "../plugins/provider-hook-runtime.js",
+  );
   return {
+    ...actual,
     clearProviderRuntimePluginCacheForTest,
     resolveProviderRuntimePlugin: vi.fn(() => undefined),
     resolveProviderHookPlugin: vi.fn(() => undefined),


### PR DESCRIPTION
## Summary

Keeps the pi-embedded sanitize-session-history provider hook runtime mock aligned with the real module contract.

The test harness now imports the real `provider-hook-runtime` module and overrides only the hook functions the tests need. This preserves unrelated exports for agent tests while keeping provider hook behavior isolated.

Split out from #85817 so the policy-scoping PR remains policy-only.

## Verification

- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-pi-provider-hook-mock node scripts/run-vitest.mjs src/agents/pi-embedded-runner.sanitize-session-history.policy.test.ts src/agents/pi-embedded-runner.openai-tool-id-preservation.test.ts -- --reporter=dot --testTimeout=30000` -> 4 files, 12 tests passed
- `/root/src/openclaw-policy-agent-scoped-design/node_modules/.bin/oxlint src/agents/pi-embedded-runner.sanitize-session-history.test-harness.ts src/agents/pi-embedded-runner.sanitize-session-history.policy.test.ts src/agents/pi-embedded-runner.openai-tool-id-preservation.test.ts`
- `git diff --check`

## Real behavior proof

Behavior addressed: pi-embedded sanitize-session-history tests can mock provider hook behavior without dropping real exports from `provider-hook-runtime`.

Real environment tested: WSL Ubuntu 24.04 checkout under `/root/src/openclaw-pi-provider-hook-mock`.

Exact steps or command run after this patch: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-pi-provider-hook-mock node scripts/run-vitest.mjs src/agents/pi-embedded-runner.sanitize-session-history.policy.test.ts src/agents/pi-embedded-runner.openai-tool-id-preservation.test.ts -- --reporter=dot --testTimeout=30000`

Evidence after fix: the affected pi-embedded sanitize-session-history tests passed in both agent shards.

Observed result after fix: 4 files and 12 tests passed; oxlint and `git diff --check` passed.

What was not tested: broader agent runtime suites or live provider execution.
