### PR TITLE
fix(agents): skip wildcard catalog metadata refs

### DIFF
--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -553,6 +553,9 @@ function buildModelCatalogMetadata(
   const aliasByKey = new Map<string, string>();
   const configuredModels = params.cfg.agents?.defaults?.models ?? {};
   for (const [rawKey, entryRaw] of Object.entries(configuredModels)) {
+    if (rawKey.trim().endsWith("/*")) {
+      continue;
+    }
     const alias = ((entryRaw as { alias?: string } | undefined)?.alias ?? "").trim();
     if (!alias) {
       continue;

--- a/src/commands/models/list.configured.test.ts
+++ b/src/commands/models/list.configured.test.ts
@@ -73,4 +73,23 @@ describe("resolveConfiguredEntries", () => {
     expect(entries[0]?.aliases).toEqual(["Kilo Gemini"]);
     expect(entries[0]?.tags).toEqual(new Set(["default", "configured"]));
   });
+
+  it("treats provider wildcard defaults as selectors, not configured model rows", () => {
+    const { entries } = resolveConfiguredEntries({
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.5",
+          models: {
+            "openai-codex/*": {},
+            "openai/gpt-5.5": { alias: "Primary" },
+          },
+        },
+      },
+      models: { providers: {} },
+    });
+
+    expect(entries.map((entry) => entry.key)).toEqual(["openai/gpt-5.5"]);
+    expect(entries[0]?.aliases).toEqual(["Primary"]);
+    expect(entries[0]?.tags).toEqual(new Set(["default", "configured"]));
+  });
 });

--- a/src/commands/models/list.configured.ts
+++ b/src/commands/models/list.configured.ts
@@ -73,6 +73,9 @@ export function resolveConfiguredEntries(cfg: OpenClawConfig) {
   });
 
   for (const key of Object.keys(cfg.agents?.defaults?.models ?? {})) {
+    if (key.trim().endsWith("/*")) {
+      continue;
+    }
     const resolved = resolveModelRefFromString({
       cfg,
       raw: key,


### PR DESCRIPTION
## Summary

Skips wildcard default model allowlist entries while building concrete model catalog metadata and configured `models list` rows.

Entries such as `openai-codex/*` are valid allowlist selectors, but they are not concrete model ids and do not have per-model alias metadata to resolve or display as configured rows. The catalog metadata builder and configured list resolver now ignore those wildcard keys instead of sending them through concrete model normalization.

Split out from #85817 so the policy-scoping PR remains policy-only.

## Verification

- `node scripts/run-vitest.mjs src/commands/models/list.configured.test.ts src/agents/model-catalog-visibility.test.ts --reporter=dot` -> 3 files, 9 tests passed
- `./node_modules/.bin/oxfmt --check src/commands/models/list.configured.ts src/commands/models/list.configured.test.ts src/agents/model-selection-shared.ts src/agents/model-catalog-visibility.test.ts`
- `./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/commands/models/list.configured.ts src/commands/models/list.configured.test.ts src/agents/model-selection-shared.ts src/agents/model-catalog-visibility.test.ts`
- `git diff --check refs/remotes/upstream-safe/main...HEAD`
- `git diff --check`

Signed head: `01fbfe3ae08446dec418d14af119872a2cea1a23`.

## Real behavior proof

Behavior addressed: wildcard default model allowlist entries are treated as selectors, not concrete catalog model ids or configured model rows.

Real environment tested: WSL Ubuntu 24.04 checkout under `/root/src/openclaw-86524`, with a temp OpenClaw home at `/tmp/openclaw-86524-proof`.

Exact steps or command run after this patch: `OPENCLAW_HOME=/tmp/openclaw-86524-proof OPENCLAW_DISABLE_AUTO_UPDATE=1 OPENCLAW_DISABLE_BUNDLED_PLUGINS=1 OPENCLAW_TEST_FAST=1 node --import tsx src/entry.ts models list --json`

Evidence after fix: the temp config set `agents.defaults.model` to `openai/gpt-5.5` and included both `agents.defaults.models["openai-codex/*"] = {}` and `agents.defaults.models["openai/gpt-5.5"].alias = "Primary"`.

Observed result after fix: the redacted JSON summary was `{ "modelCount": 1, "keys": ["openai/gpt-5.5"], "wildcardRows": [], "configuredRows": [{ "key": "openai/gpt-5.5", "tags": ["default", "configured", "alias:Primary"], "aliases": [] }] }`.

What was not tested: live provider catalog discovery with external provider credentials.