### PR TITLE
fix(openai): allow RFC 2544 fake-IP range for Realtime session requests

### DIFF
--- a/extensions/openai/realtime-provider-shared.ts
+++ b/extensions/openai/realtime-provider-shared.ts
@@ -6,12 +6,19 @@ import {
   resolveProviderRequestHeaders,
 } from "openclaw/plugin-sdk/provider-http";
 import { captureWsEvent } from "openclaw/plugin-sdk/proxy-capture";
-import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   asFiniteNumber,
   asOptionalRecord as asObjectRecord,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+const OPENAI_REALTIME_API_BASE_URL = "https://api.openai.com/v1";
+const OPENAI_REALTIME_SSRF_POLICY = {
+  allowRfc2544BenchmarkRange: true,
+  allowIpv6UniqueLocalRange: true,
+  hostnameAllowlist: [new URL(OPENAI_REALTIME_API_BASE_URL).hostname],
+} satisfies SsrFPolicy;
 
 export const trimToUndefined = normalizeOptionalString;
 export { asFiniteNumber, asObjectRecord };
@@ -104,6 +111,7 @@ async function createOpenAIRealtimeSecret(
       },
       body: JSON.stringify(params.body),
     },
+    policy: OPENAI_REALTIME_SSRF_POLICY,
     auditContext: params.auditContext,
   });
   const payload = await (async () => {
@@ -140,7 +148,7 @@ export async function createOpenAIRealtimeClientSecret(params: {
   auditContext: string;
   session: Record<string, unknown>;
 }): Promise<OpenAIRealtimeClientSecretResult> {
-  const url = "https://api.openai.com/v1/realtime/client_secrets";
+  const url = `${OPENAI_REALTIME_API_BASE_URL}/realtime/client_secrets`;
   return createOpenAIRealtimeSecret({
     ...params,
     url,
@@ -155,7 +163,7 @@ export async function createOpenAIRealtimeTranscriptionClientSecret(params: {
   auditContext: string;
   session: Record<string, unknown>;
 }): Promise<OpenAIRealtimeClientSecretResult> {
-  const url = "https://api.openai.com/v1/realtime/transcription_sessions";
+  const url = `${OPENAI_REALTIME_API_BASE_URL}/realtime/transcription_sessions`;
   return createOpenAIRealtimeSecret({
     ...params,
     url,

--- a/extensions/openai/realtime-transcription-provider.test.ts
+++ b/extensions/openai/realtime-transcription-provider.test.ts
@@ -240,6 +240,11 @@ describe("buildOpenAIRealtimeTranscriptionProvider", () => {
     const request = mockCallArg(ssrfMocks.fetchWithSsrFGuard);
     expect(request.auditContext).toBe("openai-realtime-transcription-session");
     expect(request.url).toBe("https://api.openai.com/v1/realtime/transcription_sessions");
+    expect(request.policy).toEqual({
+      allowRfc2544BenchmarkRange: true,
+      allowIpv6UniqueLocalRange: true,
+      hostnameAllowlist: ["api.openai.com"],
+    });
     const init = request.init as {
       method?: string;
       headers?: Record<string, string>;

--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -525,6 +525,11 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
 
     expectRecordFields(requireFetchRequest(), "fetch request", {
       url: "https://api.openai.com/v1/realtime/client_secrets",
+      policy: {
+        allowRfc2544BenchmarkRange: true,
+        allowIpv6UniqueLocalRange: true,
+        hostnameAllowlist: ["api.openai.com"],
+      },
     });
     expectRecordFields(requireFetchInit(), "fetch init", { method: "POST" });
     expectRecordFields(requireFetchHeaders(), "fetch headers", {


### PR DESCRIPTION
## What Problem This Solves

OpenAI Realtime session-secret requests fail behind Clash-, Surge-, or sing-box-style TUN/fake-IP DNS when `api.openai.com` resolves into a documented fake-IP range. The generic SSRF guard correctly rejects those private-looking addresses unless the fixed provider hostname explicitly opts in.

Closes the remaining Realtime-specific part of #56535.

## Why This Change Was Made

Both Realtime secret endpoints now share one OpenAI-owned SSRF policy. It permits RFC 2544 benchmark addresses and IPv6 unique-local addresses only for `api.openai.com`; the existing guard still checks redirects and rejects every non-allowlisted hostname and protected address class.

The maintainer rewrite intentionally keeps this policy inside the OpenAI plugin. The original public plugin-SDK export and API-budget changes were removed because there is no second consumer.

## User Impact

Realtime voice and transcription session setup can work through TUN/fake-IP proxy DNS without weakening SSRF checks for arbitrary hosts. Users outside those proxy environments see no behavior change and gain no new configuration surface.

## Evidence

- Blacksmith Testbox `tbx_01kwxddkwq631x975x00zmd94t`: 74 focused tests passed across the shared helper, Realtime voice, and Realtime transcription.
- Same Testbox: changed-surface extension production/test typechecks, lint, import-cycle check, and repository guards passed.
- Fresh autoreview: no actionable findings, 0.96 confidence.
- The contributor's macOS Clash TUN live proof remains valid: `talk.client.create` returned `ok: true`, audio streaming stayed active, and the Realtime response completed. Screenshot: https://github.com/user-attachments/assets/87a884d2-2902-4915-ade1-99993691d5da
- Primary contracts checked: OpenAI's Realtime endpoint documentation, RFC 2544/RFC 3330 benchmark addressing, RFC 4193 unique-local IPv6, and the sing-box/Mihomo fake-IP defaults.

Known gap: no independent authenticated OpenAI Realtime call was available through a second local Clash/Surge profile. Exact policy propagation for both endpoints is regression-tested.
