### PR TITLE
Fix voice-call trusted proxy matching for IPv4-mapped webhooks

### DIFF
--- a/extensions/voice-call/src/proxy-ip.ts
+++ b/extensions/voice-call/src/proxy-ip.ts
@@ -1,0 +1,18 @@
+// Voice Call plugin module normalizes proxy IP representations.
+export function normalizeProxyIp(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const unwrapped =
+    trimmed.startsWith("[") && trimmed.endsWith("]") ? trimmed.slice(1, -1) : trimmed;
+  const normalized = unwrapped.toLowerCase();
+  const mappedIpv4Prefix = "::ffff:";
+  if (normalized.startsWith(mappedIpv4Prefix)) {
+    const mappedIpv4 = normalized.slice(mappedIpv4Prefix.length);
+    if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(mappedIpv4)) {
+      return mappedIpv4;
+    }
+  }
+  return normalized;
+}

--- a/extensions/voice-call/src/webhook-security.test.ts
+++ b/extensions/voice-call/src/webhook-security.test.ts
@@ -388,6 +388,42 @@ describe("verifyPlivoWebhook", () => {
     expectAcceptedWebhookVersion(result, "v3");
   });
 
+  it("matches trusted proxies for Plivo when Node reports an IPv4-mapped remote address", () => {
+    const authToken = "test-auth-token";
+    const nonce = "nonce-ipv4-mapped-plivo";
+    const postBody = "CallUUID=uuid&CallStatus=in-progress&From=%2B15550000000";
+    const webhookUrl = "https://proxy.example.com/voice/webhook?flow=answer&callId=abc";
+
+    const signature = plivoV3Signature({
+      authToken,
+      urlWithQuery: webhookUrl,
+      postBody,
+      nonce,
+    });
+
+    const result = verifyPlivoWebhook(
+      {
+        headers: {
+          host: "localhost:3000",
+          "x-forwarded-proto": "https",
+          "x-forwarded-host": "proxy.example.com",
+          "x-plivo-signature-v3": signature,
+          "x-plivo-signature-v3-nonce": nonce,
+        },
+        rawBody: postBody,
+        url: "http://localhost:3000/voice/webhook?flow=answer&callId=abc",
+        method: "POST",
+        query: { flow: "answer", callId: "abc" },
+        remoteAddress: "::ffff:127.0.0.1",
+      },
+      authToken,
+      { trustForwardingHeaders: true, trustedProxyIPs: ["127.0.0.1"] },
+    );
+
+    expectAcceptedWebhookVersion(result, "v3");
+    expect(result.verificationUrl).toBe(webhookUrl);
+  });
+
   it("rejects missing signatures", () => {
     const result = verifyPlivoWebhook(
       {
@@ -784,6 +820,34 @@ describe("verifyTwilioWebhook", () => {
       },
       authToken,
       { trustForwardingHeaders: true, trustedProxyIPs: ["203.0.113.10"] },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.verificationUrl).toBe(webhookUrl);
+  });
+
+  it("matches trusted proxies when Node reports an IPv4-mapped remote address", () => {
+    const authToken = "test-auth-token";
+    const postBody = "CallSid=CS123&CallStatus=completed&From=%2B15550000000";
+    const webhookUrl = "https://proxy.example.com/voice/webhook";
+
+    const signature = twilioSignature({ authToken, url: webhookUrl, postBody });
+
+    const result = verifyTwilioWebhook(
+      {
+        headers: {
+          host: "localhost:3000",
+          "x-forwarded-proto": "https",
+          "x-forwarded-host": "proxy.example.com",
+          "x-twilio-signature": signature,
+        },
+        rawBody: postBody,
+        url: "http://localhost:3000/voice/webhook",
+        method: "POST",
+        remoteAddress: "::ffff:127.0.0.1",
+      },
+      authToken,
+      { trustForwardingHeaders: true, trustedProxyIPs: ["127.0.0.1"] },
     );
 
     expect(result.ok).toBe(true);

--- a/extensions/voice-call/src/webhook-security.ts
+++ b/extensions/voice-call/src/webhook-security.ts
@@ -222,6 +222,24 @@ function extractHostnameFromHeader(headerValue: string): string | null {
   return extractHostname(first);
 }
 
+function normalizeProxyIp(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const unwrapped =
+    trimmed.startsWith("[") && trimmed.endsWith("]") ? trimmed.slice(1, -1) : trimmed;
+  const normalized = unwrapped.toLowerCase();
+  const mappedIpv4Prefix = "::ffff:";
+  if (normalized.startsWith(mappedIpv4Prefix)) {
+    const mappedIpv4 = normalized.slice(mappedIpv4Prefix.length);
+    if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(mappedIpv4)) {
+      return mappedIpv4;
+    }
+  }
+  return normalized;
+}
+
 function normalizeAllowedHosts(allowedHosts?: string[]): Set<string> | null {
   if (!allowedHosts || allowedHosts.length === 0) {
     return null;
@@ -267,8 +285,13 @@ export function reconstructWebhookUrl(ctx: WebhookContext, options?: WebhookUrlO
   const trustedProxyIPs = options?.trustedProxyIPs?.filter(Boolean) ?? [];
   const hasTrustedProxyIPs = trustedProxyIPs.length > 0;
   const remoteIP = options?.remoteIP ?? ctx.remoteAddress;
+  const normalizedTrustedProxyIps = new Set(
+    trustedProxyIPs.map((ip) => normalizeProxyIp(ip)).filter((ip): ip is string => Boolean(ip)),
+  );
+  const normalizedRemoteIp = normalizeProxyIp(remoteIP);
   const fromTrustedProxy =
-    !hasTrustedProxyIPs || (remoteIP ? trustedProxyIPs.includes(remoteIP) : false);
+    !hasTrustedProxyIPs ||
+    (normalizedRemoteIp ? normalizedTrustedProxyIps.has(normalizedRemoteIp) : false);
 
   // Only trust forwarding headers if: (has whitelist OR explicitly trusted) AND from trusted proxy
   const shouldTrustForwardingHeaders = (hasAllowedHosts || explicitlyTrusted) && fromTrustedProxy;

--- a/extensions/voice-call/src/webhook-security.ts
+++ b/extensions/voice-call/src/webhook-security.ts
@@ -12,6 +12,7 @@ import {
   normalizeStringEntries,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { getHeader } from "./http-headers.js";
+import { normalizeProxyIp } from "./proxy-ip.js";
 import type { WebhookContext } from "./types.js";
 
 const REPLAY_WINDOW_MS = 10 * 60 * 1000;
@@ -220,24 +221,6 @@ function extractHostnameFromHeader(headerValue: string): string | null {
     return null;
   }
   return extractHostname(first);
-}
-
-function normalizeProxyIp(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  const unwrapped =
-    trimmed.startsWith("[") && trimmed.endsWith("]") ? trimmed.slice(1, -1) : trimmed;
-  const normalized = unwrapped.toLowerCase();
-  const mappedIpv4Prefix = "::ffff:";
-  if (normalized.startsWith(mappedIpv4Prefix)) {
-    const mappedIpv4 = normalized.slice(mappedIpv4Prefix.length);
-    if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(mappedIpv4)) {
-      return mappedIpv4;
-    }
-  }
-  return normalized;
 }
 
 function normalizeAllowedHosts(allowedHosts?: string[]): Set<string> | null {

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -38,6 +38,7 @@ import { MediaStreamHandler } from "./media-stream.js";
 import type { VoiceCallProvider } from "./providers/base.js";
 import { isProviderStatusTerminal } from "./providers/shared/call-status.js";
 import type { TwilioProvider } from "./providers/twilio.js";
+import { normalizeProxyIp } from "./proxy-ip.js";
 import type { CallRecord, NormalizedEvent, WebhookContext } from "./types.js";
 import type { WebhookResponsePayload } from "./webhook.types.js";
 import type { RealtimeCallHandler } from "./webhook/realtime-handler.js";
@@ -105,24 +106,6 @@ function appendRecentTalkEventMetadata(call: CallRecord, event: TalkEvent): void
 
 function buildRequestUrl(requestUrl: string | undefined): URL {
   return new URL(requestUrl ?? "/", "http://localhost");
-}
-
-function normalizeProxyIp(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  const unwrapped =
-    trimmed.startsWith("[") && trimmed.endsWith("]") ? trimmed.slice(1, -1) : trimmed;
-  const normalized = unwrapped.toLowerCase();
-  const mappedIpv4Prefix = "::ffff:";
-  if (normalized.startsWith(mappedIpv4Prefix)) {
-    const mappedIpv4 = normalized.slice(mappedIpv4Prefix.length);
-    if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(mappedIpv4)) {
-      return mappedIpv4;
-    }
-  }
-  return normalized;
 }
 
 function resolveForwardedClientIp(


### PR DESCRIPTION
## Summary

Fixes #86525.

Normalizes voice-call trusted proxy IP comparisons before webhook URL reconstruction decides whether forwarded host/proto headers are trusted. This aligns Twilio/Plivo webhook signature verification with the existing media-stream client-IP path when Node reports a trusted IPv4 proxy as an IPv4-mapped IPv6 address.

## Motivation / root cause

`reconstructWebhookUrl` compared `trustedProxyIPs` to the socket remote address with a literal string match. A config value of `127.0.0.1` therefore did not match `::ffff:127.0.0.1`, so valid Twilio/Plivo callbacks behind a loopback proxy ignored `X-Forwarded-Host` and reconstructed `https://localhost/...` instead of the provider-signed public URL.

## User-visible behavior

Voice-call webhooks behind local or loopback reverse proxies continue to verify provider signatures when Node reports the proxy peer in IPv4-mapped form. Forwarded headers are still ignored unless `allowedHosts` is configured or `trustForwardingHeaders` is explicitly enabled, and the request still has to come from a trusted proxy when `trustedProxyIPs` is set.

## Real behavior proof

Behavior addressed: valid Twilio/Plivo webhook signatures were rejected when the request remote address was `::ffff:127.0.0.1` but `trustedProxyIPs` contained `127.0.0.1`.

Real environment tested: local OpenClaw checkout on Node v24.10.0 with pnpm 11.2.2.

Exact steps or command run after this patch: `node --import tsx --input-type=module` script calling `verifyTwilioWebhook` with `remoteAddress: "::ffff:127.0.0.1"`, `trustedProxyIPs: ["127.0.0.1"]`, `x-forwarded-host: proxy.example.com`, and a valid Twilio signature for `https://proxy.example.com/voice/webhook`.

Evidence after fix:

```json
{
  "ok": true,
  "verificationUrl": "https://proxy.example.com/voice/webhook",
  "isReplay": false,
  "verifiedRequestKey": "twilio:req:56cf1e50f664e1464033f16c08ad96ce0a96b29597f4be9126eb8f1d0029412a"
}
```

Observed result after fix: the verifier trusts the forwarded public URL only for the normalized trusted proxy and accepts the valid signature.

What was not tested: no live Twilio, Plivo, or reverse-proxy E2E was run; this is local runtime proof plus focused verifier tests.

## Regression tests

Added focused tests covering both provider signature paths:

- Twilio signed webhook with `remoteAddress: "::ffff:127.0.0.1"` and `trustedProxyIPs: ["127.0.0.1"]`.
- Plivo V3 signed webhook with the same trusted proxy normalization shape.

## Verification

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-voice-call.config.ts extensions/voice-call/src/webhook-security.test.ts` - 26 tests passed.
- `pnpm changed:lanes --json` - lanes: `extensions`, `extensionTests`.
- `pnpm check:changed` - passed.
- `git diff --check -- extensions/voice-call/src/webhook-security.ts extensions/voice-call/src/webhook-security.test.ts` - passed.
- Claude Review for Codex, model `opus 4.7` - approved; no material findings.
- Codex code review - no blocking issues.
- Codex Security diff review - no actionable security findings.

## Compatibility and risks

Compatibility: this keeps existing exact trusted proxy config working and only canonicalizes equivalent IPv4-mapped/plain IPv4 peer representations. It does not add CIDR support or change the documented forwarding-header opt-in requirements.

Risk: low. The changed condition is security-sensitive, but forwarded headers are still gated by the same `allowedHosts` / `trustForwardingHeaders` requirement and the normalized socket peer match.
