### PR TITLE
fix(agents): keep cron media completions run-scoped

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -6,6 +6,7 @@ import { callGateway } from "../gateway/call.js";
 import { isEmbeddedMode } from "../infra/embedded-mode.js";
 import { getActiveSecretsRuntimeSnapshot } from "../secrets/runtime-state.js";
 import { getActiveRuntimeWebToolsMetadata } from "../secrets/runtime-web-tools-state.js";
+import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import type { GatewayMessageChannel } from "../utils/message-channel.js";
 import { resolveAgentWorkspaceDir, resolveSessionAgentIds } from "./agent-scope.js";
@@ -201,6 +202,11 @@ export function createOpenClawTools(
     toolAllowlist: options?.pluginToolAllowlist,
     toolDenylist: options?.pluginToolDenylist,
   });
+  const trimmedRunSessionKey = options?.runSessionKey?.trim();
+  const mediaGenerationAgentSessionKey =
+    trimmedRunSessionKey && isCronRunSessionKey(trimmedRunSessionKey)
+      ? trimmedRunSessionKey
+      : options?.agentSessionKey;
   const imageToolAgentDir = options?.agentDir;
   const imageTool = resolveImageToolFactoryAvailable({
     config: availabilityConfig ?? resolvedConfig,
@@ -226,7 +232,7 @@ export function createOpenClawTools(
         config: options?.config,
         agentDir: options?.agentDir,
         authProfileStore: options?.authProfileStore,
-        agentSessionKey: options?.agentSessionKey,
+        agentSessionKey: mediaGenerationAgentSessionKey,
         requesterOrigin: deliveryContext ?? undefined,
         workspaceDir,
         sandbox,
@@ -240,7 +246,7 @@ export function createOpenClawTools(
         config: options?.config,
         agentDir: options?.agentDir,
         authProfileStore: options?.authProfileStore,
-        agentSessionKey: options?.agentSessionKey,
+        agentSessionKey: mediaGenerationAgentSessionKey,
         requesterOrigin: deliveryContext ?? undefined,
         workspaceDir,
         sandbox,
@@ -254,7 +260,7 @@ export function createOpenClawTools(
         config: options?.config,
         agentDir: options?.agentDir,
         authProfileStore: options?.authProfileStore,
-        agentSessionKey: options?.agentSessionKey,
+        agentSessionKey: mediaGenerationAgentSessionKey,
         requesterOrigin: deliveryContext ?? undefined,
         workspaceDir,
         sandbox,

--- a/src/agents/openclaw-tools.tts-config.test.ts
+++ b/src/agents/openclaw-tools.tts-config.test.ts
@@ -17,6 +17,9 @@ const mocks = vi.hoisted(() => {
   return {
     stubTool,
     createCronToolOptions: vi.fn(),
+    createImageGenerateToolOptions: vi.fn(),
+    createMusicGenerateToolOptions: vi.fn(),
+    createVideoGenerateToolOptions: vi.fn(),
     textToSpeech: vi.fn(async () => ({
       success: true,
       audioPath: "/tmp/openclaw/tts-config-test.opus",
@@ -50,7 +53,10 @@ vi.mock("./tools/gateway-tool.js", () => ({
 }));
 
 vi.mock("./tools/image-generate-tool.js", () => ({
-  createImageGenerateTool: () => mocks.stubTool("image_generate"),
+  createImageGenerateTool: (options: unknown) => {
+    mocks.createImageGenerateToolOptions(options);
+    return mocks.stubTool("image_generate");
+  },
 }));
 
 vi.mock("./tools/image-tool.js", () => ({
@@ -62,7 +68,10 @@ vi.mock("./tools/message-tool.js", () => ({
 }));
 
 vi.mock("./tools/music-generate-tool.js", () => ({
-  createMusicGenerateTool: () => mocks.stubTool("music_generate"),
+  createMusicGenerateTool: (options: unknown) => {
+    mocks.createMusicGenerateToolOptions(options);
+    return mocks.stubTool("music_generate");
+  },
 }));
 
 vi.mock("./tools/nodes-tool.js", () => ({
@@ -106,7 +115,10 @@ vi.mock("./tools/update-plan-tool.js", () => ({
 }));
 
 vi.mock("./tools/video-generate-tool.js", () => ({
-  createVideoGenerateTool: () => mocks.stubTool("video_generate"),
+  createVideoGenerateTool: (options: unknown) => {
+    mocks.createVideoGenerateToolOptions(options);
+    return mocks.stubTool("video_generate");
+  },
 }));
 
 vi.mock("./tools/web-tools.js", () => ({
@@ -134,6 +146,9 @@ function getTextToSpeechParams() {
 describe("createOpenClawTools TTS config wiring", () => {
   beforeEach(() => {
     mocks.createCronToolOptions.mockClear();
+    mocks.createImageGenerateToolOptions.mockClear();
+    mocks.createMusicGenerateToolOptions.mockClear();
+    mocks.createVideoGenerateToolOptions.mockClear();
     mocks.textToSpeech.mockClear();
   });
 
@@ -263,6 +278,74 @@ describe("createOpenClawTools TTS config wiring", () => {
     } finally {
       testing.setDepsForTest();
     }
+  });
+});
+
+describe("createOpenClawTools media generation session wiring", () => {
+  beforeEach(() => {
+    mocks.createImageGenerateToolOptions.mockClear();
+    mocks.createMusicGenerateToolOptions.mockClear();
+    mocks.createVideoGenerateToolOptions.mockClear();
+  });
+
+  it("uses the isolated cron run key for background media completions", () => {
+    const config = {
+      agents: {
+        defaults: {
+          imageGenerationModel: { primary: "image-owner/model" },
+          videoGenerationModel: { primary: "video-owner/model" },
+          musicGenerationModel: { primary: "music-owner/model" },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    createOpenClawTools({
+      config,
+      agentSessionKey: "agent:main:cron:daily-media",
+      runSessionKey: "agent:main:cron:daily-media:run:run-123",
+      disableMessageTool: true,
+      disablePluginTools: true,
+    });
+
+    expect(mocks.createImageGenerateToolOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentSessionKey: "agent:main:cron:daily-media:run:run-123",
+      }),
+    );
+    expect(mocks.createVideoGenerateToolOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentSessionKey: "agent:main:cron:daily-media:run:run-123",
+      }),
+    );
+    expect(mocks.createMusicGenerateToolOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentSessionKey: "agent:main:cron:daily-media:run:run-123",
+      }),
+    );
+  });
+
+  it("keeps the requester session key for non-cron media completions", () => {
+    const config = {
+      agents: {
+        defaults: {
+          imageGenerationModel: { primary: "image-owner/model" },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    createOpenClawTools({
+      config,
+      agentSessionKey: "agent:main:slack:channel:C123",
+      runSessionKey: "agent:main:slack:channel:C123:run:run-123",
+      disableMessageTool: true,
+      disablePluginTools: true,
+    });
+
+    expect(mocks.createImageGenerateToolOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentSessionKey: "agent:main:slack:channel:C123",
+      }),
+    );
   });
 });
 

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -2385,6 +2385,47 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     );
   });
 
+  it("no-ops stale isolated cron run media completions", async () => {
+    const callGateway = createGatewayMock();
+    const sendMessage = createSendMessageMock();
+    const queueEmbeddedPiMessageWithOutcome = createQueueOutcomeMock(true);
+    const result = await deliverSlackChannelAnnouncement({
+      callGateway,
+      sendMessage,
+      queueEmbeddedPiMessageWithOutcome,
+      sessionId: "stale-cron-run-session",
+      isActive: false,
+      requesterSessionKey: "agent:main:cron:daily-media:run:run-123",
+      expectsCompletionMessage: true,
+      directIdempotencyKey: "announce-stale-cron-media",
+      sourceTool: "image_generate",
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "image_generation",
+          childSessionKey: "image_generate:task-123",
+          childSessionId: "task-123",
+          announceType: "image generation task",
+          taskLabel: "daily media",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "Generated 1 image.\nMEDIA:/tmp/generated-daily.png",
+          mediaUrls: ["/tmp/generated-daily.png"],
+          replyInstruction: "Deliver the generated image through the requester run.",
+        },
+      ],
+    });
+
+    expectRecordFields(result, {
+      delivered: true,
+      path: "none",
+      phases: [{ phase: "direct-primary", delivered: true, path: "none", error: undefined }],
+    });
+    expect(queueEmbeddedPiMessageWithOutcome).not.toHaveBeenCalled();
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it.each([
     {
       name: "legacy Discord channel",

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -2460,6 +2460,55 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("directly delivers stale isolated cron run media failure completions", async () => {
+    const callGateway = createGatewayMock({
+      result: {
+        payloads: [{ text: "Image generation failed. Provider timed out." }],
+      },
+    });
+    const sendMessage = createSendMessageMock();
+    const queueEmbeddedPiMessageWithOutcome = createQueueOutcomeMock(true);
+    const result = await deliverSlackChannelAnnouncement({
+      callGateway,
+      sendMessage,
+      queueEmbeddedPiMessageWithOutcome,
+      sessionId: "stale-cron-run-session",
+      isActive: false,
+      requesterSessionKey: "agent:main:cron:daily-media:run:run-123",
+      expectsCompletionMessage: true,
+      directIdempotencyKey: "announce-stale-cron-media-failure",
+      sourceTool: "image_generate",
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "image_generation",
+          childSessionKey: "image_generate:task-123",
+          childSessionId: "task-123",
+          announceType: "image generation task",
+          taskLabel: "daily media",
+          status: "error",
+          statusLabel: "failed",
+          result: "Provider timed out.",
+          replyInstruction: "Tell the user image generation failed.",
+        },
+      ],
+    });
+
+    expectRecordFields(result, {
+      delivered: true,
+      path: "direct",
+    });
+    expect(queueEmbeddedPiMessageWithOutcome).not.toHaveBeenCalled();
+    expectGatewayAgentParams(callGateway, {
+      deliver: true,
+      channel: "slack",
+      accountId: "acct-1",
+      to: "channel:C123",
+      threadId: undefined,
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it.each([
     {
       name: "legacy Discord channel",

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -2385,7 +2385,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     );
   });
 
-  it("no-ops stale isolated cron run media completions", async () => {
+  it("directly delivers stale isolated cron run media completions", async () => {
     const callGateway = createGatewayMock();
     const sendMessage = createSendMessageMock();
     const queueEmbeddedPiMessageWithOutcome = createQueueOutcomeMock(true);
@@ -2414,6 +2414,40 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
           replyInstruction: "Deliver the generated image through the requester run.",
         },
       ],
+    });
+
+    expectRecordFields(result, {
+      delivered: true,
+      path: "direct",
+    });
+    expect(queueEmbeddedPiMessageWithOutcome).not.toHaveBeenCalled();
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "slack",
+        accountId: "acct-1",
+        to: "channel:C123",
+        content: "The generated image is ready.",
+        mediaUrls: ["/tmp/generated-daily.png"],
+        idempotencyKey: "announce-stale-cron-media:generated-media-direct",
+      }),
+    );
+  });
+
+  it("no-ops stale isolated cron run text completions", async () => {
+    const callGateway = createGatewayMock();
+    const sendMessage = createSendMessageMock();
+    const queueEmbeddedPiMessageWithOutcome = createQueueOutcomeMock(true);
+    const result = await deliverSlackChannelAnnouncement({
+      callGateway,
+      sendMessage,
+      queueEmbeddedPiMessageWithOutcome,
+      sessionId: "stale-cron-run-session",
+      isActive: false,
+      requesterSessionKey: "agent:main:cron:daily-text:run:run-123",
+      expectsCompletionMessage: true,
+      directIdempotencyKey: "announce-stale-cron-text",
+      sourceTool: "subagent_announce",
     });
 
     expectRecordFields(result, {

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -913,6 +913,10 @@ async function sendSubagentAnnounceDirectly(params: {
       isCronRunSessionKey(canonicalRequesterSessionKey) &&
       !resolveRequesterSessionActivity(canonicalRequesterSessionKey).isActive
     ) {
+      const generatedMediaDelivery = await tryGeneratedMediaDirectDelivery();
+      if (generatedMediaDelivery) {
+        return generatedMediaDelivery;
+      }
       return {
         delivered: true,
         path: "none",

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -10,7 +10,7 @@ import {
   isAgentMediatedCompletionSourceTool,
   shouldPreserveUserFacingSessionStateForInputProvenance,
 } from "../sessions/input-provenance.js";
-import { isCronSessionKey } from "../sessions/session-key-utils.js";
+import { isCronRunSessionKey, isCronSessionKey } from "../sessions/session-key-utils.js";
 import { isNonTerminalAgentRunStatus } from "../shared/agent-run-status.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import { mergeDeliveryContext, normalizeDeliveryContext } from "../utils/delivery-context.js";
@@ -907,6 +907,16 @@ async function sendSubagentAnnounceDirectly(params: {
           wakeOutcome,
         )}`,
       );
+    }
+    if (
+      params.expectsCompletionMessage &&
+      isCronRunSessionKey(canonicalRequesterSessionKey) &&
+      !resolveRequesterSessionActivity(canonicalRequesterSessionKey).isActive
+    ) {
+      return {
+        delivered: true,
+        path: "none",
+      };
     }
     if (params.signal?.aborted) {
       return {

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -917,10 +917,12 @@ async function sendSubagentAnnounceDirectly(params: {
       if (generatedMediaDelivery) {
         return generatedMediaDelivery;
       }
-      return {
-        delivered: true,
-        path: "none",
-      };
+      if (!agentMediatedCompletion) {
+        return {
+          delivered: true,
+          path: "none",
+        };
+      }
     }
     if (params.signal?.aborted) {
       return {


### PR DESCRIPTION
## Summary

- Keeps background media completions from isolated cron jobs tied to the run-scoped cron session key when one is available.
- Treats completion delivery for an inactive run-scoped cron session as stale, so it no-ops instead of starting a requester-agent handoff or direct media fallback.
- Preserves non-cron media completion routing and active requester queue delivery.

## Linked context

Closes #86459

Related #86459

Was this requested by a maintainer or owner?

No. This follows the public bug report and the existing issue labels.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: A late `image_generate` completion from a failed isolated cron run should not be delivered into a later run of the same cron job.
- Real environment tested: Local OpenClaw source checkout on Linux with Node 22.22.2.
- Exact steps or command run after this patch: Ran a local `node --import tsx` proof script that invokes `src/agents/subagent-announce-delivery.ts` with a stale run-scoped cron requester session and records whether any outbound handoff path is attempted.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```json
{
  "result": {
    "delivered": true,
    "path": "none",
    "phases": [
      {
        "phase": "direct-primary",
        "delivered": true,
        "path": "none"
      }
    ]
  },
  "announceAgentCalls": 0,
  "queueCalls": 0,
  "directMessageCalls": 0
}
```

- Observed result after fix: The stale cron-run completion was accepted as handled with `path: "none"`, and no requester-agent call, active-run queue wake, or direct message delivery was attempted.
- What was not tested: Full live image provider plus real gateway/channel E2E for a failed cron run.
- Proof limitations or environment constraints: The focused proof exercises the run-scoped delivery branch locally. Regression coverage covers the media tool session-key wiring, stale cron completion no-op, active requester delivery path, isolated cron session identity, and media task lifecycle.
- Before evidence (optional but encouraged): Not captured as a live run before the patch. The source path previously used the broader requester session key for media tools and allowed inactive completion delivery to fall through to the direct requester-agent/media fallback path.

## Tests and validation

Which commands did you run?

```text
pnpm test src/agents/openclaw-tools.tts-config.test.ts src/agents/subagent-announce-delivery.test.ts
```

Result: 2 files passed, 69 tests passed.

```text
pnpm test src/agents/tools/media-generate-background-shared.test.ts src/cron/isolated-agent.session-identity.test.ts src/cron/isolated-agent/run.message-tool-policy.test.ts
```

Result: 2 Vitest shards passed, 3 files passed, 49 tests passed.

```text
pnpm changed:lanes --json --base d6b7fe8615be187f0c924028ba2904a959cf99e6 --head HEAD
```

Result: core and coreTests lanes only.

```text
pnpm check:changed --base d6b7fe8615be187f0c924028ba2904a959cf99e6 --head HEAD
```

Result: passed.

```text
git diff --check
```

Result: passed.

What regression coverage was added or updated?

- Added media tool wiring coverage to prove isolated cron runs pass the run-scoped key into image/video/music generation tools.
- Added completion delivery coverage to prove stale run-scoped cron media completions no-op without queueing, requester-agent handoff, or direct message fallback.

What failed before this fix, if known?

The stale completion path could fall through from an inactive cron run into direct requester-agent/media fallback delivery.

If no test was added, why not?

Tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Stale isolated-cron media completions are suppressed instead of being delivered later.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes. This changes background tool completion routing for run-scoped cron sessions.

What is the highest-risk area?

Suppressing a completion that should still reach an active requester.

How is that risk mitigated?

The no-op is limited to completion delivery for run-scoped cron session keys whose requester run is no longer active. Active requester delivery remains queued, and non-cron media completions keep the requester session key.

## Current review state

What is the next action?

Review the run-scoped cron completion boundary and confirm the proof level is sufficient.

What is still waiting on author, maintainer, CI, or external proof?

CI and maintainer review after the PR is opened.

Which bot or reviewer comments were addressed?

None yet.
