### PR TITLE
fix(auto-reply): stage sandboxed workspace media

### DIFF
--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.ts
@@ -560,7 +560,7 @@ async function runWhatsAppScenario(params: {
   sutAuthDir: string;
   sutPhoneE164: string;
   groupJid?: string;
-}) {
+}): Promise<WhatsAppQaScenarioResult> {
   const scenarioRun = params.scenario.buildRun();
   if (scenarioRun.target === "group" && !params.groupJid) {
     throw new Error(`WhatsApp scenario ${params.scenario.id} requires groupJid.`);

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -257,7 +257,7 @@ describe("createReplyMediaPathNormalizer", () => {
       workspaceDir: "/tmp/sandboxes/session-1",
       containerWorkdir: "/workspace",
     });
-    const absolutePath = "/Users/peter/.openclaw/workspace/reports/report.html";
+    const absolutePath = "/Users/peter/.openclaw/workspace/reports/screenshot.png";
     const normalize = createReplyMediaPathNormalizer({
       cfg: {},
       sessionKey: "session-key",
@@ -268,7 +268,9 @@ describe("createReplyMediaPathNormalizer", () => {
       mediaUrls: [absolutePath],
     });
 
-    expectMedia(result, "/tmp/outbound-media/report.html", ["/tmp/outbound-media/report.html"]);
+    expectMedia(result, "/tmp/outbound-media/screenshot.png", [
+      "/tmp/outbound-media/screenshot.png",
+    ]);
     expectOutboundAttachmentCall(0, absolutePath, 5 * 1024 * 1024);
   });
 

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -252,6 +252,26 @@ describe("createReplyMediaPathNormalizer", () => {
     expect(resolveOutboundAttachmentFromUrl).not.toHaveBeenCalled();
   });
 
+  it("stages absolute workspace media paths before sandbox mapping", async () => {
+    ensureSandboxWorkspaceForSession.mockResolvedValue({
+      workspaceDir: "/tmp/sandboxes/session-1",
+      containerWorkdir: "/workspace",
+    });
+    const absolutePath = "/Users/peter/.openclaw/workspace/reports/report.html";
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/Users/peter/.openclaw/workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: [absolutePath],
+    });
+
+    expectMedia(result, "/tmp/outbound-media/report.html", ["/tmp/outbound-media/report.html"]);
+    expectOutboundAttachmentCall(0, absolutePath, 5 * 1024 * 1024);
+  });
+
   it("stages absolute workspace media paths so the PR scenario now works", async () => {
     const absolutePath = "/Users/peter/.openclaw/workspace/exports/images/chart.png";
     const normalize = createReplyMediaPathNormalizer({

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -144,6 +144,17 @@ export function createReplyMediaPathNormalizer(params: {
     return resolvePathFromInput(relativeWorkspacePath, params.workspaceDir);
   };
 
+  const resolveAbsoluteWorkspaceMedia = (media: string): string | undefined => {
+    if (FILE_URL_RE.test(media) || (!path.isAbsolute(media) && !WINDOWS_DRIVE_RE.test(media))) {
+      return undefined;
+    }
+    try {
+      return resolveWorkspaceRelativeMedia(media);
+    } catch {
+      return undefined;
+    }
+  };
+
   const normalizeMediaSource = async (raw: string): Promise<string> => {
     const media = raw.trim();
     if (!media) {
@@ -152,6 +163,10 @@ export function createReplyMediaPathNormalizer(params: {
     assertMediaNotDataUrl(media);
     if (isPassThroughRemoteMediaSource(media)) {
       return media;
+    }
+    const absoluteWorkspaceMedia = resolveAbsoluteWorkspaceMedia(media);
+    if (absoluteWorkspaceMedia) {
+      return await persistLocalReplyMedia(absoluteWorkspaceMedia);
     }
     const isRelativeLocalMedia =
       isLikelyLocalMediaSource(media) &&

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -759,6 +759,19 @@ describe("loadWebMedia", () => {
     expect(result.contentType).toBe("text/markdown");
   });
 
+  it("allows host-read HTML files when the buffer validates as text", async () => {
+    const htmlFile = path.join(fixtureRoot, "report.html");
+    await fs.writeFile(htmlFile, "<!doctype html><title>Report</title><h1>Report</h1>\n", "utf8");
+    const result = await loadWebMedia(htmlFile, {
+      maxBytes: 1024 * 1024,
+      localRoots: "any",
+      readFile: async (filePath) => await fs.readFile(filePath),
+      hostReadCapability: true,
+    });
+    expect(result.kind).toBe("document");
+    expect(result.contentType).toBe("text/html");
+  });
+
   it.each([
     {
       label: "ZIP",
@@ -819,6 +832,7 @@ describe("loadWebMedia", () => {
 
   it.each([
     { label: "CSV", fileName: "opaque.csv" },
+    { label: "HTML", fileName: "opaque.html" },
     { label: "Markdown", fileName: "opaque.md" },
   ])("rejects opaque non-NUL binary data disguised as %s", async ({ fileName }) => {
     const fakeTextFile = path.join(fixtureRoot, fileName);
@@ -840,6 +854,7 @@ describe("loadWebMedia", () => {
 
   it.each([
     { label: "CSV", fileName: "prefix-tail.csv" },
+    { label: "HTML", fileName: "prefix-tail.html" },
     { label: "Markdown", fileName: "prefix-tail.md" },
   ])(
     "rejects %s files with a text prefix and binary tail after the old sample window",
@@ -869,6 +884,12 @@ describe("loadWebMedia", () => {
       body: ",,,,,,,,,,\n",
     },
     {
+      label: "HTML",
+      fileName: "punctuation.html",
+      contentType: "text/html",
+      body: "<!doctype html><hr><br>\n",
+    },
+    {
       label: "Markdown",
       fileName: "punctuation.md",
       contentType: "text/markdown",
@@ -891,6 +912,12 @@ describe("loadWebMedia", () => {
       body: Buffer.from("caf\xe9,ni\xf1o\n", "latin1"),
     },
     {
+      label: "HTML",
+      fileName: "legacy.html",
+      contentType: "text/html",
+      body: Buffer.from("<p>caf\xe9</p>\n", "latin1"),
+    },
+    {
       label: "Markdown",
       fileName: "legacy.md",
       contentType: "text/markdown",
@@ -907,6 +934,7 @@ describe("loadWebMedia", () => {
 
   it.each([
     { label: "CSV", fileName: "nul-padded.csv" },
+    { label: "HTML", fileName: "nul-padded.html" },
     { label: "Markdown", fileName: "nul-padded.md" },
   ])("rejects NUL-padded binary data disguised as %s", async ({ fileName }) => {
     const fakeTextFile = path.join(fixtureRoot, fileName);
@@ -930,6 +958,7 @@ describe("loadWebMedia", () => {
 
   it.each([
     { label: "CSV", fileName: "bom-binary.csv" },
+    { label: "HTML", fileName: "bom-binary.html" },
     { label: "Markdown", fileName: "bom-binary.md" },
   ])("rejects UTF-16 BOM-prefixed binary data disguised as %s", async ({ fileName }) => {
     const fakeTextFile = path.join(fixtureRoot, fileName);
@@ -953,6 +982,7 @@ describe("loadWebMedia", () => {
 
   it.each([
     { label: "CSV", fileName: "alternating-high.csv" },
+    { label: "HTML", fileName: "alternating-high.html" },
     { label: "Markdown", fileName: "alternating-high.md" },
   ])("rejects alternating ASCII/high-byte data disguised as %s", async ({ fileName }) => {
     const fakeTextFile = path.join(fixtureRoot, fileName);
@@ -977,6 +1007,7 @@ describe("loadWebMedia", () => {
 
   it.each([
     { label: "CSV", fileName: "high-bytes.csv" },
+    { label: "HTML", fileName: "high-bytes.html" },
     { label: "Markdown", fileName: "high-bytes.md" },
   ])("rejects high-byte opaque data disguised as %s", async ({ fileName }) => {
     const fakeTextFile = path.join(fixtureRoot, fileName);

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -759,17 +759,18 @@ describe("loadWebMedia", () => {
     expect(result.contentType).toBe("text/markdown");
   });
 
-  it("allows host-read HTML files when the buffer validates as text", async () => {
+  it("rejects host-read HTML files without a separate security-boundary approval", async () => {
     const htmlFile = path.join(fixtureRoot, "report.html");
     await fs.writeFile(htmlFile, "<!doctype html><title>Report</title><h1>Report</h1>\n", "utf8");
-    const result = await loadWebMedia(htmlFile, {
-      maxBytes: 1024 * 1024,
-      localRoots: "any",
-      readFile: async (filePath) => await fs.readFile(filePath),
-      hostReadCapability: true,
-    });
-    expect(result.kind).toBe("document");
-    expect(result.contentType).toBe("text/html");
+    await expectLoadWebMediaErrorCode(
+      loadWebMedia(htmlFile, {
+        maxBytes: 1024 * 1024,
+        localRoots: "any",
+        readFile: async (filePath) => await fs.readFile(filePath),
+        hostReadCapability: true,
+      }),
+      "path-not-allowed",
+    );
   });
 
   it.each([
@@ -884,12 +885,6 @@ describe("loadWebMedia", () => {
       body: ",,,,,,,,,,\n",
     },
     {
-      label: "HTML",
-      fileName: "punctuation.html",
-      contentType: "text/html",
-      body: "<!doctype html><hr><br>\n",
-    },
-    {
       label: "Markdown",
       fileName: "punctuation.md",
       contentType: "text/markdown",
@@ -910,12 +905,6 @@ describe("loadWebMedia", () => {
       fileName: "legacy.csv",
       contentType: "text/csv",
       body: Buffer.from("caf\xe9,ni\xf1o\n", "latin1"),
-    },
-    {
-      label: "HTML",
-      fileName: "legacy.html",
-      contentType: "text/html",
-      body: Buffer.from("<p>caf\xe9</p>\n", "latin1"),
     },
     {
       label: "Markdown",

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -148,12 +148,15 @@ const HOST_READ_ALLOWED_DOCUMENT_MIMES = new Set([
   "application/x-tar",
   "application/zip",
   "text/csv",
-  "text/html",
   "text/markdown",
 ]);
-// file-type returns undefined (no magic bytes) for plain-text formats like CSV,
-// HTML, and Markdown, so host-read needs an explicit text validation fallback.
-const HOST_READ_TEXT_PLAIN_ALIASES = new Set(["text/csv", "text/html", "text/markdown"]);
+// file-type returns undefined (no magic bytes) for plain-text formats like CSV
+// and Markdown, so host-read needs an explicit text validation fallback.
+const HOST_READ_TEXT_PLAIN_ALIASES = new Set(["text/csv", "text/markdown"]);
+// HTML remains deliberately outside the host-read allowlist pending a separate
+// security-boundary review, but extension-declared .html files still need to
+// fail closed instead of falling through to binary/media sniffing.
+const HOST_READ_DECLARED_TEXT_MIMES = new Set([...HOST_READ_TEXT_PLAIN_ALIASES, "text/html"]);
 const MB = 1024 * 1024;
 
 function getTextStats(text: string): { printableRatio: number } {
@@ -272,13 +275,18 @@ function assertHostReadMediaAllowed(params: {
   // text validator path. Some opaque blobs can still produce bogus binary MIME
   // hits (for example BOM-prefixed 0xFF data sniffing as audio/mpeg), and
   // host-read should reject those instead of returning early on the sniff.
-  if (declaredMime && HOST_READ_TEXT_PLAIN_ALIASES.has(declaredMime)) {
-    if (!params.sniffedContentType && params.buffer && isValidatedHostReadText(params.buffer)) {
+  if (declaredMime && HOST_READ_DECLARED_TEXT_MIMES.has(declaredMime)) {
+    if (
+      HOST_READ_TEXT_PLAIN_ALIASES.has(declaredMime) &&
+      !params.sniffedContentType &&
+      params.buffer &&
+      isValidatedHostReadText(params.buffer)
+    ) {
       return;
     }
     throw new LocalMediaAccessError(
       "path-not-allowed",
-      "hostReadCapability permits only validated plain-text CSV/HTML/Markdown documents for local reads",
+      "hostReadCapability permits only validated plain-text CSV/Markdown documents for local reads",
     );
   }
   const sniffedKind = kindFromMime(params.sniffedContentType);
@@ -299,10 +307,10 @@ function assertHostReadMediaAllowed(params: {
   ) {
     return;
   }
-  // CSV / HTML / Markdown exception: file-type v22 returns undefined (not "text/plain") for
+  // CSV / Markdown exception: file-type v22 returns undefined (not "text/plain") for
   // plain-text buffers that have no binary magic bytes. Allow these formats when:
   // - sniffedMime is undefined (no binary signature detected by file-type)
-  // - The extension-derived MIME is text/csv, text/html, or text/markdown (operator intent)
+  // - The extension-derived MIME is text/csv or text/markdown (operator intent)
   // - The buffer decodes as actual text instead of opaque binary bytes
   if (
     !sniffedMime &&
@@ -325,7 +333,7 @@ function assertHostReadMediaAllowed(params: {
   }
   throw new LocalMediaAccessError(
     "path-not-allowed",
-    `Host-local media sends only allow buffer-verified images, audio, video, PDF, Office documents, archives, CSV, HTML, and Markdown (got ${sniffedMime ?? normalizedMime ?? "unknown"}).`,
+    `Host-local media sends only allow buffer-verified images, audio, video, PDF, Office documents, archives, CSV, and Markdown (got ${sniffedMime ?? normalizedMime ?? "unknown"}).`,
   );
 }
 

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -148,11 +148,12 @@ const HOST_READ_ALLOWED_DOCUMENT_MIMES = new Set([
   "application/x-tar",
   "application/zip",
   "text/csv",
+  "text/html",
   "text/markdown",
 ]);
-// file-type returns undefined (no magic bytes) for plain-text formats like CSV and
-// Markdown, so host-read needs an explicit "this really decodes as text" fallback.
-const HOST_READ_TEXT_PLAIN_ALIASES = new Set(["text/csv", "text/markdown"]);
+// file-type returns undefined (no magic bytes) for plain-text formats like CSV,
+// HTML, and Markdown, so host-read needs an explicit text validation fallback.
+const HOST_READ_TEXT_PLAIN_ALIASES = new Set(["text/csv", "text/html", "text/markdown"]);
 const MB = 1024 * 1024;
 
 function getTextStats(text: string): { printableRatio: number } {
@@ -267,7 +268,7 @@ function assertHostReadMediaAllowed(params: {
 }): void {
   const declaredMime = normalizeMimeType(mimeTypeFromFilePath(params.filePath));
   const normalizedMime = normalizeMimeType(params.contentType);
-  // For extension-declared plain-text aliases such as .csv/.md, trust only the
+  // For extension-declared plain-text aliases such as .csv/.html/.md, trust only the
   // text validator path. Some opaque blobs can still produce bogus binary MIME
   // hits (for example BOM-prefixed 0xFF data sniffing as audio/mpeg), and
   // host-read should reject those instead of returning early on the sniff.
@@ -277,7 +278,7 @@ function assertHostReadMediaAllowed(params: {
     }
     throw new LocalMediaAccessError(
       "path-not-allowed",
-      "hostReadCapability permits only validated plain-text CSV/Markdown documents for local reads",
+      "hostReadCapability permits only validated plain-text CSV/HTML/Markdown documents for local reads",
     );
   }
   const sniffedKind = kindFromMime(params.sniffedContentType);
@@ -298,10 +299,10 @@ function assertHostReadMediaAllowed(params: {
   ) {
     return;
   }
-  // CSV / Markdown exception: file-type v22 returns undefined (not "text/plain") for
+  // CSV / HTML / Markdown exception: file-type v22 returns undefined (not "text/plain") for
   // plain-text buffers that have no binary magic bytes. Allow these formats when:
   // - sniffedMime is undefined (no binary signature detected by file-type)
-  // - The extension-derived MIME is text/csv or text/markdown (operator intent)
+  // - The extension-derived MIME is text/csv, text/html, or text/markdown (operator intent)
   // - The buffer decodes as actual text instead of opaque binary bytes
   if (
     !sniffedMime &&
@@ -324,7 +325,7 @@ function assertHostReadMediaAllowed(params: {
   }
   throw new LocalMediaAccessError(
     "path-not-allowed",
-    `Host-local media sends only allow buffer-verified images, audio, video, PDF, Office documents, archives, CSV, and Markdown (got ${sniffedMime ?? normalizedMime ?? "unknown"}).`,
+    `Host-local media sends only allow buffer-verified images, audio, video, PDF, Office documents, archives, CSV, HTML, and Markdown (got ${sniffedMime ?? normalizedMime ?? "unknown"}).`,
   );
 }
 


### PR DESCRIPTION
Fixes #74061.

## Summary

- Stages absolute media paths that are already inside the agent workspace before trying sandbox path translation.
- Keeps absolute host-local paths outside the workspace blocked when sandbox mapping fails.
- Keeps host-read HTML out of this PR: `.html` remains denied under `hostReadCapability` pending a separate security-boundary review, and extension-declared `.html` files fail closed instead of falling through to binary/media sniffing.
- Adds an explicit WhatsApp QA scenario return type so the existing RTT proof object keeps its literal `request-to-observed-message` source type and production typecheck stays green on current `main`.

## Real behavior proof

- Behavior or issue addressed: Telegram/local final-reply `MEDIA:` paths that point to files inside the agent workspace can be dropped when a sandbox workspace exists because sandbox path translation runs before the normal local staging path. The reported repro includes `/home/openclaw/.openclaw/workspace/.../screenshot.png` and other local workspace files receiving only `Media failed`.

- Real environment tested: Current OpenClaw PR worktree for `codex/74061-workspace-media-staging` on Ubuntu 24.04 with repository dependencies already installed.

- Exact steps or command run after this patch:

```text
pnpm exec vitest run --config test/vitest/vitest.media.config.ts src/auto-reply/reply/reply-media-paths.test.ts src/media/web-media.test.ts
node scripts/test-projects.mjs src/auto-reply/reply/reply-media-paths.test.ts src/media/web-media.test.ts
pnpm tsgo:prod
pnpm check:test-types
git diff --check
pnpm run test:extensions:package-boundary:compile
pnpm run test:extensions:package-boundary:canary
```

- Evidence after fix:

```text
RUN  v4.1.7 /tmp/openclaw-74061.LyunfH
Test Files  1 passed (1)
Tests  66 passed (66)
```

```text
[test] starting test/vitest/vitest.media.config.ts
[test] starting test/vitest/vitest.auto-reply.config.ts
[test] passed 2 Vitest shards in 10.22s
```

```text
extension package boundary check passed
mode: compile
compiled plugins: 108
canary plugins: 0
```

```text
extension package boundary check passed
mode: canary
compiled plugins: 0
canary plugins: 2
```

- Observed result after fix: The reply media normalizer now stages `/Users/peter/.openclaw/workspace/reports/screenshot.png` to `/tmp/outbound-media/screenshot.png` even when `ensureSandboxWorkspaceForSession()` returns a sandbox workspace, instead of dropping the path before delivery. The outside-workspace host path case remains blocked.

- Security-boundary result after narrowing: `text/html` was removed from the host-read document allowlist. Valid local `.html` files now reject with `path-not-allowed`, and binary-disguised `.html` files are explicitly blocked before media sniffing can treat them as another allowed media type. HTML host-read support should be reviewed separately if maintainers want it.

- What was not tested: I did not send a live Telegram Bot API message from the reporter's environment because those channel credentials are not available in this checkout. The proof exercises the production normalizer and host-read boundary code paths in the repository test harness.
