### PR TITLE
fix(doctor): skip restart prompt when gateway is healthy after recent restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 - Tests: clean successful plugin gateway gauntlet isolated temp roots while keeping an explicit preservation switch for failed/debug runs.
 - Plugins/perf: reuse derived plugin metadata snapshots for the lifetime of the process so reply-time skill setup no longer rescans plugin metadata on every turn.
 - Discord/OpenAI voice: keep wake-name master consults using the current speaker context after ignored ambient transcripts and shorten the default capture silence grace.
+- Doctor: skip redundant Gateway restart prompts when a recent supervisor restart leaves the Gateway healthy. Fixes #86518. (#86533) Thanks @liaoyl830.
 - Gateway: keep session-only Control UI tool-start mirrors flowing during diagnostic queue pressure instead of silently dropping non-terminal tool updates.
 - Agents/memory: return optional not-found context for missing date-only daily memory reads instead of logging benign first-run `ENOENT` failures. Fixes #82928. Thanks @galiniliev.
 - Discord: merge streamed text captions into following media block replies so captions and attachments send as one message. (#86487) Thanks @neeravmakwana.

--- a/src/commands/doctor-gateway-daemon-flow.test.ts
+++ b/src/commands/doctor-gateway-daemon-flow.test.ts
@@ -312,7 +312,7 @@ describe("maybeRepairGatewayDaemon", () => {
       healthOk: false,
     });
 
-    expect(readGatewayRestartHandoffSync).toHaveBeenCalledOnce();
+    expect(readGatewayRestartHandoffSync).toHaveBeenCalledTimes(2);
     const [handoffEnv] = readGatewayRestartHandoffSync.mock.calls[0] as unknown as [
       { OPENCLAW_STATE_DIR?: string; OPENCLAW_CONFIG_PATH?: string },
     ];
@@ -550,5 +550,75 @@ describe("maybeRepairGatewayDaemon", () => {
     expect(launchd.repairLaunchAgentBootstrap).not.toHaveBeenCalled();
     expect(service.install).not.toHaveBeenCalled();
     expect(note).toHaveBeenCalledWith(EXTERNAL_SERVICE_REPAIR_NOTE, "Gateway LaunchAgent");
+  });
+
+  it("skips restart prompt when gateway is healthy after recent restart handoff", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(40_000);
+    setPlatform("linux");
+    const handoff = {
+      kind: "gateway-supervisor-restart-handoff",
+      version: 1,
+      intentId: "intent-healthy",
+      pid: 99_999,
+      createdAt: 35_000,
+      expiresAt: 95_000,
+      reason: "update.run",
+      source: "gateway-update",
+      restartKind: "update-process",
+      supervisorMode: "systemd",
+    };
+    readGatewayRestartHandoffSync.mockReturnValue(handoff);
+
+    await maybeRepairGatewayDaemon({
+      cfg: { gateway: {} },
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      prompter: createPrompter(() => true),
+      options: { deep: true },
+      gatewayDetailsMessage: "details",
+      healthOk: false,
+    });
+
+    expect(readGatewayRestartHandoffSync).toHaveBeenCalled();
+    expect(healthCommand).toHaveBeenCalledOnce();
+    expect(service.restart).not.toHaveBeenCalled();
+    expect(note).toHaveBeenCalledWith(
+      "Gateway is healthy after recent restart; skipping restart prompt.",
+      "Gateway",
+    );
+  });
+
+  it("prompts for restart when health probe fails despite recent restart handoff", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(40_000);
+    setPlatform("linux");
+    const handoff = {
+      kind: "gateway-supervisor-restart-handoff",
+      version: 1,
+      intentId: "intent-unhealthy",
+      pid: 88_888,
+      createdAt: 35_000,
+      expiresAt: 95_000,
+      reason: "gateway.restart",
+      source: "operator-restart",
+      restartKind: "full-process",
+      supervisorMode: "systemd",
+    };
+    readGatewayRestartHandoffSync.mockReturnValue(handoff);
+    healthCommand.mockRejectedValueOnce(new Error("gateway closed"));
+
+    await maybeRepairGatewayDaemon({
+      cfg: { gateway: {} },
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      prompter: createPrompter(() => false),
+      options: { deep: true },
+      gatewayDetailsMessage: "details",
+      healthOk: false,
+    });
+
+    expect(readGatewayRestartHandoffSync).toHaveBeenCalled();
+    expect(healthCommand).toHaveBeenCalledOnce();
+    expect(service.restart).not.toHaveBeenCalled();
+    // The restart prompt was shown but user declined (createPrompter returned false for it).
   });
 });

--- a/src/commands/doctor-gateway-daemon-flow.test.ts
+++ b/src/commands/doctor-gateway-daemon-flow.test.ts
@@ -552,7 +552,7 @@ describe("maybeRepairGatewayDaemon", () => {
     expect(note).toHaveBeenCalledWith(EXTERNAL_SERVICE_REPAIR_NOTE, "Gateway LaunchAgent");
   });
 
-  it("skips restart prompt when gateway is healthy after recent restart handoff", async () => {
+  it("skips restart prompt when gateway is healthy after recent restart handoff in normal doctor flow", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(40_000);
     setPlatform("linux");
@@ -574,7 +574,7 @@ describe("maybeRepairGatewayDaemon", () => {
       cfg: { gateway: {} },
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       prompter: createPrompter(() => true),
-      options: { deep: true },
+      options: { deep: false },
       gatewayDetailsMessage: "details",
       healthOk: false,
     });
@@ -588,7 +588,7 @@ describe("maybeRepairGatewayDaemon", () => {
     );
   });
 
-  it("prompts for restart when health probe fails despite recent restart handoff", async () => {
+  it("prompts for restart when health probe fails despite recent restart handoff in normal doctor flow", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(40_000);
     setPlatform("linux");
@@ -611,7 +611,7 @@ describe("maybeRepairGatewayDaemon", () => {
       cfg: { gateway: {} },
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       prompter: createPrompter(() => false),
-      options: { deep: true },
+      options: { deep: false },
       gatewayDetailsMessage: "details",
       healthOk: false,
     });

--- a/src/commands/doctor-gateway-daemon-flow.test.ts
+++ b/src/commands/doctor-gateway-daemon-flow.test.ts
@@ -557,17 +557,17 @@ describe("maybeRepairGatewayDaemon", () => {
     vi.setSystemTime(40_000);
     setPlatform("linux");
     const handoff = {
-      kind: "gateway-supervisor-restart-handoff",
-      version: 1,
+      kind: "gateway-supervisor-restart-handoff" as const,
+      version: 1 as const,
       intentId: "intent-healthy",
       pid: 99_999,
       createdAt: 35_000,
       expiresAt: 95_000,
       reason: "update.run",
-      source: "gateway-update",
-      restartKind: "update-process",
-      supervisorMode: "systemd",
-    };
+      source: "gateway-update" as const,
+      restartKind: "update-process" as const,
+      supervisorMode: "systemd" as const,
+    } satisfies GatewayRestartHandoff;
     readGatewayRestartHandoffSync.mockReturnValue(handoff);
 
     await maybeRepairGatewayDaemon({
@@ -593,17 +593,17 @@ describe("maybeRepairGatewayDaemon", () => {
     vi.setSystemTime(40_000);
     setPlatform("linux");
     const handoff = {
-      kind: "gateway-supervisor-restart-handoff",
-      version: 1,
+      kind: "gateway-supervisor-restart-handoff" as const,
+      version: 1 as const,
       intentId: "intent-unhealthy",
       pid: 88_888,
       createdAt: 35_000,
       expiresAt: 95_000,
       reason: "gateway.restart",
-      source: "operator-restart",
-      restartKind: "full-process",
-      supervisorMode: "systemd",
-    };
+      source: "operator-restart" as const,
+      restartKind: "full-process" as const,
+      supervisorMode: "systemd" as const,
+    } satisfies GatewayRestartHandoff;
     readGatewayRestartHandoffSync.mockReturnValue(handoff);
     healthCommand.mockRejectedValueOnce(new Error("gateway closed"));
 

--- a/src/commands/doctor-gateway-daemon-flow.test.ts
+++ b/src/commands/doctor-gateway-daemon-flow.test.ts
@@ -324,12 +324,12 @@ describe("maybeRepairGatewayDaemon", () => {
     );
   });
 
-  it("does not read restart handoffs during normal doctor", async () => {
+  it("does not inspect port connections during normal doctor", async () => {
     setPlatform("linux");
 
     await runNonInteractiveRepair();
 
-    expect(readGatewayRestartHandoffSync).not.toHaveBeenCalled();
+    expect(readGatewayRestartHandoffSync).toHaveBeenCalled();
     expect(inspectPortConnections).not.toHaveBeenCalled();
   });
 

--- a/src/commands/doctor-gateway-daemon-flow.ts
+++ b/src/commands/doctor-gateway-daemon-flow.ts
@@ -392,7 +392,7 @@ export async function maybeRepairGatewayDaemon(params: {
     // Check if the gateway was recently restarted (e.g., via SIGUSR1 after an update).
     // If a restart handoff exists and the gateway reports healthy, skip the restart prompt
     // to avoid racing with the system supervisor and causing a restart loop.
-    const recentRestart = params.options.deep ? readGatewayRestartHandoffSync(serviceEnv) : null;
+    const recentRestart = readGatewayRestartHandoffSync(serviceEnv);
     if (recentRestart) {
       try {
         await healthCommand({ json: false, timeoutMs: 10_000 }, params.runtime);

--- a/src/commands/doctor-gateway-daemon-flow.ts
+++ b/src/commands/doctor-gateway-daemon-flow.ts
@@ -388,11 +388,26 @@ export async function maybeRepairGatewayDaemon(params: {
       note(EXTERNAL_SERVICE_REPAIR_NOTE, "Gateway");
       return;
     }
+
+    // Check if the gateway was recently restarted (e.g., via SIGUSR1 after an update).
+    // If a restart handoff exists and the gateway reports healthy, skip the restart prompt
+    // to avoid racing with the system supervisor and causing a restart loop.
+    const recentRestart = params.options.deep ? readGatewayRestartHandoffSync(serviceEnv) : null;
+    if (recentRestart) {
+      try {
+        await healthCommand({ json: false, timeoutMs: 10_000 }, params.runtime);
+        note("Gateway is healthy after recent restart; skipping restart prompt.", "Gateway");
+        return;
+      } catch {
+        // Health probe failed — fall through to the restart prompt below.
+      }
+    }
+
     const restart = await confirmDoctorServiceRepair(
       params.prompter,
       {
         message: "Restart gateway service now?",
-        initialValue: true,
+        initialValue: false,
       },
       serviceRepairPolicy,
     );


### PR DESCRIPTION
## Summary
- `openclaw doctor` unconditionally prompted "Restart gateway service now?" with default=Yes whenever the gateway was running, even if it had just restarted via SIGUSR1 after an update
- This caused restart loops on macOS where the prompt raced with `launchctl KeepAlive`
- Added a health probe before the restart prompt when a restart handoff exists (`--deep` mode). If the gateway is healthy, skip the prompt entirely
- Changed `initialValue` from `true` to `false` as a safety net so users don't accidentally confirm a restart by pressing Enter
- Added 2 new tests + updated an existing test assertion

Fixes #86518

## Test plan
- `npx vitest run src/commands/doctor-gateway-daemon-flow.test.ts` — 18/18 passing
- Test: skips restart prompt when gateway is healthy after recent restart handoff
- Test: prompts for restart when health probe fails despite recent restart handoff

## Real behavior proof
Behavior addressed: `openclaw doctor` should not offer or default into a redundant running-service restart when a recent supervisor restart handoff exists and the Gateway is already healthy.

Real environment tested: Brokered AWS Crabbox Linux VM with a real `systemd --user` Gateway service.

Exact steps or command run after this patch: Installed and started a temporary `openclaw-gateway.service` from this PR checkout, verified Gateway RPC health, wrote a fresh `gateway-supervisor-restart-handoff.json`, then invoked the doctor gateway daemon repair path with `healthOk: false` and a prompter that would have accepted restart if prompted.

Evidence after fix: Provider `aws`, lease `cbx_0de0268d5b1e`, run `run_b9adc53ad889`. Copied live terminal output:

```text
Gateway is healthy after recent restart; skipping restart prompt.
proof.prompts=[]
REAL_SYSTEMD_PROOF passed port=21573 active_before=active active_after=active pid=3854 restarts_before=0 restarts_after=0
```

Observed result after fix: `Gateway is healthy after recent restart; skipping restart prompt.` The proof script reported `proof.prompts=[]` and `REAL_SYSTEMD_PROOF passed port=21573 active_before=active active_after=active pid=3854 restarts_before=0 restarts_after=0`.

What was not tested: macOS LaunchAgent timing was not tested in this run.
