### PR TITLE
fix: repair gateway stop hook runner alias

### DIFF
--- a/scripts/runtime-postbuild.mjs
+++ b/scripts/runtime-postbuild.mjs
@@ -55,6 +55,13 @@ const LEGACY_ROOT_RUNTIME_COMPAT_ALIASES = [
   ["manager-DzRWrKSA.js", "acp/control-plane/manager.js"],
   ["runtime-CeGN4XUC.js", "web-fetch/runtime.js"],
 ];
+const NESTED_STABLE_ROOT_CHUNK_ALIASES = [
+  {
+    aliasFileName: "plugins/hook-runner-global.js",
+    candidateBaseFileName: "hook-runner-global",
+    sourceIncludes: ["runGlobalGatewayStopSafely", "initializeGlobalHookRunner"],
+  },
+];
 const LEGACY_PLUGIN_INSTALL_RUNTIME_MARKERS = [
   "scanPackageInstallSource",
   "scanFileInstallSource",
@@ -267,6 +274,7 @@ export function listCoreRuntimePostBuildOutputs(params = {}) {
     ...listPluginSdkRootAliasOutputs(),
     ...listOfficialChannelCatalogOutputs(),
     ...listStableRootRuntimeAliasOutputs(params),
+    ...listNestedStableRootChunkAliasOutputs(params),
     ...listLegacyRootRuntimeCompatOutputs(params),
     ...listLegacyCliExitCompatOutputs(params),
   ].toSorted((left, right) => left.localeCompare(right));
@@ -396,6 +404,78 @@ function resolveRootRuntimeCandidateByMarkers(params) {
   return candidates.length === 1 ? candidates[0] : null;
 }
 
+function resolveNestedStableRootChunkAliasTarget(params) {
+  if (params.fsImpl.existsSync(path.join(params.distDir, params.aliasFileName))) {
+    return null;
+  }
+  const hashedPattern = new RegExp(
+    `^${escapeRegExp(params.candidateBaseFileName)}-[A-Za-z0-9_-]+\\.js$`,
+    "u",
+  );
+  let entries = [];
+  try {
+    entries = params.fsImpl.readdirSync(params.distDir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  const candidates = [];
+  for (const entry of entries.toSorted((left, right) => left.name.localeCompare(right.name))) {
+    if (!entry.isFile() || !hashedPattern.test(entry.name)) {
+      continue;
+    }
+    const candidatePath = path.join(params.distDir, entry.name);
+    let source;
+    try {
+      source = params.fsImpl.readFileSync(candidatePath, "utf8");
+    } catch {
+      continue;
+    }
+    if (params.sourceIncludes.every((marker) => source.includes(marker))) {
+      candidates.push(entry.name);
+    }
+  }
+  return candidates.length === 1 ? candidates[0] : null;
+}
+
+export function listNestedStableRootChunkAliasOutputs(params = {}) {
+  const rootDir = params.rootDir ?? ROOT;
+  const distDir = path.join(rootDir, "dist");
+  const fsImpl = params.fs ?? fs;
+  return NESTED_STABLE_ROOT_CHUNK_ALIASES.filter((entry) =>
+    resolveNestedStableRootChunkAliasTarget({
+      distDir,
+      fsImpl,
+      ...entry,
+    }),
+  )
+    .map((entry) => `dist/${entry.aliasFileName}`)
+    .toSorted((left, right) => left.localeCompare(right));
+}
+
+export function writeNestedStableRootChunkAliases(params = {}) {
+  const rootDir = params.rootDir ?? ROOT;
+  const distDir = path.join(rootDir, "dist");
+  const fsImpl = params.fs ?? fs;
+  for (const entry of NESTED_STABLE_ROOT_CHUNK_ALIASES) {
+    const targetFileName = resolveNestedStableRootChunkAliasTarget({
+      distDir,
+      fsImpl,
+      ...entry,
+    });
+    if (!targetFileName) {
+      continue;
+    }
+    const relativeTarget = path.posix.relative(
+      path.posix.dirname(entry.aliasFileName),
+      targetFileName,
+    );
+    writeTextFileIfChanged(
+      path.join(distDir, entry.aliasFileName),
+      `export * from "./${relativeTarget}";\n`,
+    );
+  }
+}
+
 function resolveLegacyRootRuntimeCompatTarget(params) {
   if (
     params.aliasFileName &&
@@ -480,6 +560,7 @@ export function runRuntimePostBuild(params = {}) {
   });
   runPhase("stable root runtime imports", () => rewriteRootRuntimeImportsToStableAliases(params));
   runPhase("stable root runtime aliases", () => writeStableRootRuntimeAliases(params));
+  runPhase("nested stable root chunk aliases", () => writeNestedStableRootChunkAliases(params));
   runPhase("legacy root runtime compat aliases", () => writeLegacyRootRuntimeCompatAliases(params));
   runPhase("legacy CLI exit compat chunks", () => writeLegacyCliExitCompatChunks(params));
 }

--- a/test/scripts/runtime-postbuild.test.ts
+++ b/test/scripts/runtime-postbuild.test.ts
@@ -12,6 +12,7 @@ import {
   runRuntimePostBuild,
   writeLegacyCliExitCompatChunks,
   writeLegacyRootRuntimeCompatAliases,
+  writeNestedStableRootChunkAliases,
   writeStableRootRuntimeAliases,
 } from "../../scripts/runtime-postbuild.mjs";
 import { expectNoNodeFsScans } from "../../src/test-utils/fs-scan-assertions.js";
@@ -710,6 +711,27 @@ describe("runtime postbuild static assets", () => {
     );
     expect(await fs.readFile(path.join(distDir, "server-close-DvAvfgr8.js"), "utf8")).toBe(
       'export * from "./server-close.runtime.js";\n',
+    );
+    expect(await fs.readFile(path.join(distDir, "hook-runner-global-B8rMIo8I.js"), "utf8")).toBe(
+      'export * from "./plugins/hook-runner-global.js";\n',
+    );
+  });
+
+  it("repairs the stable gateway shutdown hook runner alias from a hashed root chunk", async () => {
+    const rootDir = createTempDir("openclaw-runtime-postbuild-");
+    const distDir = path.join(rootDir, "dist");
+    await fs.mkdir(path.join(distDir, "plugins"), { recursive: true });
+    await fs.writeFile(
+      path.join(distDir, "hook-runner-global-NewHash.js"),
+      "export const runGlobalGatewayStopSafely = true;\nexport const initializeGlobalHookRunner = true;\n",
+      "utf8",
+    );
+
+    writeNestedStableRootChunkAliases({ rootDir });
+    writeLegacyRootRuntimeCompatAliases({ rootDir });
+
+    expect(await fs.readFile(path.join(distDir, "plugins", "hook-runner-global.js"), "utf8")).toBe(
+      'export * from "./../hook-runner-global-NewHash.js";\n',
     );
     expect(await fs.readFile(path.join(distDir, "hook-runner-global-B8rMIo8I.js"), "utf8")).toBe(
       'export * from "./plugins/hook-runner-global.js";\n',


### PR DESCRIPTION
## Summary

- Repairs runtime postbuild so a missing nested `dist/plugins/hook-runner-global.js` alias is recreated from the hashed root hook-runner chunk when present.
- Runs that nested alias repair before legacy root chunk compatibility aliases, so old shutdown chunks can point at the stable nested path.
- Adds script-level regression coverage for the missing stable alias shape.
- Out of scope: changing the gateway shutdown lazy import boundary.

## Linked context

Which issue does this close?

Closes #86536

Which issues, PRs, or discussions are related?

Related #86536

Was this requested by a maintainer or owner?

Local bug evidence under `/mnt/c/OpenClaw/bugs/BUG-037-gateway-shutdown-imports-missing-hook-runner-global-dist-module`.

## Real behavior proof (required for external PRs)

- Behavior addressed: Runtime postbuild now recreates the stable gateway shutdown hook-runner alias when a built dist tree has only the hashed root hook-runner chunk.
- Real environment tested: Linux WSL2 dev checkout, Node 24.15.0, OpenClaw 2026.5.25 branch `bug-037-gateway-stop-hook-runner`.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs test/scripts/runtime-postbuild.test.ts`; `pnpm build`; `git diff --check`; `.agents/skills/autoreview/scripts/autoreview --mode local`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```shell
RUN  v4.1.7 /home/galini/GitHub/worktrees/bug-037-gateway-stop-hook-runner

Test Files  1 passed (1)
     Tests  26 passed (26)
  Start at  14:54:58
  Duration  1.90s

runtime-postbuild: nested stable root chunk aliases completed in 0ms
[build-all] write-cli-compat

autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.86)
```

- Observed result after fix: The regression creates `dist/hook-runner-global-NewHash.js`, runs the nested alias repair, and observes `dist/plugins/hook-runner-global.js` exporting from the hashed chunk; `pnpm build` completes with the new postbuild phase.
- What was not tested: A live packaged gateway SIGINT run with real plugins was not rerun.
- Proof limitations or environment constraints: Local proof recreates the exact missing-artifact shape from the redacted shutdown log without requiring the private original dist tree.
- Before evidence (optional but encouraged):

```shell
shutdown error: Error [ERR_MODULE_NOT_FOUND]: Cannot find module '[redacted repo path]/dist/plugins/hook-runner-global.js' imported from [redacted repo path]/dist/server.impl-[hash].js
```

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs test/scripts/runtime-postbuild.test.ts`
- `pnpm build`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

What regression coverage was added or updated?

- `test/scripts/runtime-postbuild.test.ts` now covers repairing the stable gateway shutdown hook-runner alias from a hashed root chunk.

What failed before this fix, if known?

- Redacted logs showed shutdown failing to import `dist/plugins/hook-runner-global.js`.

If no test was added, why not?

N/A

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes

Did config, environment, or migration behavior change? (`Yes/No`)

No

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No

What is the highest-risk area?

Runtime postbuild artifact generation.

How is that risk mitigated?

The repair is marker-gated to the hook-runner chunk, only writes the alias when missing, and is covered by the postbuild test plus full build.

## Current review state

What is the next action?

Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

Live packaged shutdown proof was not run.

Which bot or reviewer comments were addressed?

Autoreview reported no accepted/actionable findings.


## Crabbox log proof update - 2026-05-25

Azure Crabbox evidence was collected on lease `cbx_e06ef86ae274` (`silver-prawn`) against head `bff54a87ac7613e92a71ac4ab5fe155fe2188c4f`.

Before proof from logs:

```text
BEFORE_FIX_PROOF=missing_alias_import_failed
chunk=hook-runner-global-CUJPsSCk.js
error=Error [ERR_MODULE_NOT_FOUND]: Cannot find module .../dist/plugins/hook-runner-global.js
```

After proof from logs:

```text
CONTROL_PROOF=alias_file=export * from "./../hook-runner-global-CUJPsSCk.js";
CONTROL_PROOF=legacy_file=export * from "./plugins/hook-runner-global.js";
CONTROL_PROOF=root_exports=a,c,d,i,l,n,o,r,s,t,u
CONTROL_PROOF=nested_exports=a,c,d,i,l,n,o,r,s,t,u
RESULT_PROOF=repaired_alias_imports_but_missing_shutdown_export=true
```

Result: the repair recreates `dist/plugins/hook-runner-global.js` and the legacy compatibility alias, but the repaired import still does not expose the expected named `runGlobalGatewayStopSafely` export from the built root chunk. This means the missing-file symptom is addressed, but the runtime shutdown import is not fully proven fixed by this patch as written.
