### PR TITLE
fix(telegram): use monotonic polling liveness

### DIFF
--- a/extensions/telegram/src/polling-liveness.test.ts
+++ b/extensions/telegram/src/polling-liveness.test.ts
@@ -53,7 +53,10 @@ describe("TelegramPollingLivenessTracker", () => {
 
   it("reports active stuck getUpdates calls", () => {
     let now = 0;
-    const tracker = new TelegramPollingLivenessTracker({ now: () => now });
+    const tracker = new TelegramPollingLivenessTracker({
+      now: () => now,
+      monotonicNow: () => now,
+    });
 
     now = 1;
     tracker.noteGetUpdatesStarted({ offset: 7 });
@@ -69,5 +72,32 @@ describe("TelegramPollingLivenessTracker", () => {
 
     tracker.noteGetUpdatesSuccess([]);
     tracker.noteGetUpdatesFinished();
+  });
+
+  it("does not treat wall-clock sleep as an active getUpdates stall", () => {
+    let now = 1_000;
+    let monotonicNow = 1_000;
+    const tracker = new TelegramPollingLivenessTracker({
+      now: () => now,
+      monotonicNow: () => monotonicNow,
+    });
+
+    tracker.noteGetUpdatesStarted({ offset: 7 });
+
+    now += 10 * 60 * 60 * 1_000;
+    monotonicNow += 10 * 60 * 60 * 1_000;
+
+    expect(
+      tracker.detectStall({
+        thresholdMs: POLL_STALL_THRESHOLD_MS,
+      }),
+    ).toBeNull();
+
+    monotonicNow += POLL_STALL_THRESHOLD_MS + 1;
+    const stall = tracker.detectStall({
+      thresholdMs: POLL_STALL_THRESHOLD_MS,
+    });
+
+    expect(stall?.message).toContain("active getUpdates stuck");
   });
 });

--- a/extensions/telegram/src/polling-liveness.test.ts
+++ b/extensions/telegram/src/polling-liveness.test.ts
@@ -5,12 +5,17 @@ const POLL_STALL_THRESHOLD_MS = 90_000;
 
 describe("TelegramPollingLivenessTracker", () => {
   it("records successful getUpdates calls and publishes poll success time", () => {
-    const nowValues = [0, 10, 25];
-    const now = vi.fn(() => nowValues.shift() ?? 25);
+    let now = 0;
     const onPollSuccess = vi.fn();
-    const tracker = new TelegramPollingLivenessTracker({ now, onPollSuccess });
+    const tracker = new TelegramPollingLivenessTracker({
+      now: () => now,
+      monotonicNow: () => now,
+      onPollSuccess,
+    });
 
+    now = 10;
     tracker.noteGetUpdatesStarted({ offset: 42 });
+    now = 25;
     tracker.noteGetUpdatesSuccess([{ update_id: 1 }, { update_id: 2 }]);
     tracker.noteGetUpdatesFinished();
 
@@ -22,8 +27,10 @@ describe("TelegramPollingLivenessTracker", () => {
 
   it("detects stale polling without considering unrelated API activity", () => {
     let now = 0;
-    const tracker = new TelegramPollingLivenessTracker({ now: () => now });
+    const tracker = new TelegramPollingLivenessTracker({ monotonicNow: () => now });
 
+    now = 45_000;
+    expect(tracker.detectStall({ thresholdMs: POLL_STALL_THRESHOLD_MS })).toBeNull();
     now = 120_001;
     expect(
       tracker.detectStall({
@@ -34,8 +41,10 @@ describe("TelegramPollingLivenessTracker", () => {
 
   it("detects and throttles stale polling diagnostics", () => {
     let now = 0;
-    const tracker = new TelegramPollingLivenessTracker({ now: () => now });
+    const tracker = new TelegramPollingLivenessTracker({ monotonicNow: () => now });
 
+    now = 45_000;
+    expect(tracker.detectStall({ thresholdMs: POLL_STALL_THRESHOLD_MS })).toBeNull();
     now = 120_001;
     const stall = tracker.detectStall({
       thresholdMs: POLL_STALL_THRESHOLD_MS,
@@ -61,6 +70,8 @@ describe("TelegramPollingLivenessTracker", () => {
     now = 1;
     tracker.noteGetUpdatesStarted({ offset: 7 });
 
+    now = 45_000;
+    expect(tracker.detectStall({ thresholdMs: POLL_STALL_THRESHOLD_MS })).toBeNull();
     now = 120_001;
     const stall = tracker.detectStall({
       thresholdMs: POLL_STALL_THRESHOLD_MS,
@@ -74,30 +85,66 @@ describe("TelegramPollingLivenessTracker", () => {
     tracker.noteGetUpdatesFinished();
   });
 
-  it("does not treat wall-clock sleep as an active getUpdates stall", () => {
-    let now = 1_000;
-    let monotonicNow = 1_000;
+  it("does not treat a wall-clock correction as an active getUpdates stall", () => {
+    let wallNow = 1_000;
+    let monotonicNow = 0;
     const tracker = new TelegramPollingLivenessTracker({
-      now: () => now,
+      now: () => wallNow,
       monotonicNow: () => monotonicNow,
     });
 
     tracker.noteGetUpdatesStarted({ offset: 7 });
 
-    now += 10 * 60 * 60 * 1_000;
-    monotonicNow += 10 * 60 * 60 * 1_000;
+    wallNow += 154_000;
+    monotonicNow += 30_000;
 
-    expect(
-      tracker.detectStall({
-        thresholdMs: POLL_STALL_THRESHOLD_MS,
-      }),
-    ).toBeNull();
+    expect(tracker.detectStall({ thresholdMs: POLL_STALL_THRESHOLD_MS })).toBeNull();
 
-    monotonicNow += POLL_STALL_THRESHOLD_MS + 1;
+    monotonicNow += POLL_STALL_THRESHOLD_MS - 30_000 + 1;
     const stall = tracker.detectStall({
       thresholdMs: POLL_STALL_THRESHOLD_MS,
     });
 
     expect(stall?.message).toContain("active getUpdates stuck");
+  });
+
+  it("measures completed polls across backward wall-clock corrections", () => {
+    let wallNow = 200_000;
+    let monotonicNow = 1_000;
+    const tracker = new TelegramPollingLivenessTracker({
+      now: () => wallNow,
+      monotonicNow: () => monotonicNow,
+    });
+
+    tracker.noteGetUpdatesStarted({ offset: 7 });
+    wallNow -= 124_193;
+    monotonicNow += 30_000;
+    tracker.noteGetUpdatesSuccess([]);
+    tracker.noteGetUpdatesFinished();
+
+    expect(tracker.formatDiagnosticFields()).toContain(
+      "startedAt=200000 finishedAt=75807 durationMs=30000",
+    );
+  });
+
+  it("rebases liveness after the watchdog itself was paused", () => {
+    let now = 1_000;
+    const tracker = new TelegramPollingLivenessTracker({
+      now: () => now,
+      monotonicNow: () => now,
+    });
+    tracker.noteGetUpdatesStarted({ offset: 7 });
+
+    now += 10 * 60 * 60 * 1_000;
+    expect(tracker.detectStall({ thresholdMs: POLL_STALL_THRESHOLD_MS })).toBeNull();
+
+    now += 30_000;
+    expect(tracker.detectStall({ thresholdMs: POLL_STALL_THRESHOLD_MS })).toBeNull();
+    now += 30_000;
+    expect(tracker.detectStall({ thresholdMs: POLL_STALL_THRESHOLD_MS })).toBeNull();
+    now += 30_001;
+    expect(tracker.detectStall({ thresholdMs: POLL_STALL_THRESHOLD_MS })?.message).toContain(
+      "active getUpdates stuck",
+    );
   });
 });

--- a/extensions/telegram/src/polling-liveness.ts
+++ b/extensions/telegram/src/polling-liveness.ts
@@ -3,6 +3,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 
 type TelegramPollingLivenessTrackerOptions = {
   now?: () => number;
+  monotonicNow?: () => number;
   onPollSuccess?: (finishedAt: number) => void;
 };
 
@@ -13,7 +14,9 @@ type TelegramPollingStall = {
 export class TelegramPollingLivenessTracker {
   #lastGetUpdatesAt: number;
   #lastGetUpdatesActivityAt: number;
+  #lastGetUpdatesActivityMonotonicAt: number;
   #lastGetUpdatesStartedAt: number | null = null;
+  #lastGetUpdatesStartedMonotonicAt: number | null = null;
   #lastGetUpdatesFinishedAt: number | null = null;
   #lastGetUpdatesDurationMs: number | null = null;
   #lastGetUpdatesOutcome = "not-started";
@@ -21,10 +24,13 @@ export class TelegramPollingLivenessTracker {
   #lastGetUpdatesOffset: number | null = null;
   #inFlightGetUpdates = 0;
   #stallDiagLoggedAt = 0;
+  #lastStallCheckAt: number;
 
   constructor(private readonly options: TelegramPollingLivenessTrackerOptions = {}) {
     this.#lastGetUpdatesAt = this.#now();
     this.#lastGetUpdatesActivityAt = this.#lastGetUpdatesAt;
+    this.#lastGetUpdatesActivityMonotonicAt = this.#monotonicNow();
+    this.#lastStallCheckAt = this.#lastGetUpdatesAt;
   }
 
   get inFlightGetUpdates() {
@@ -34,7 +40,10 @@ export class TelegramPollingLivenessTracker {
   noteGetUpdatesStarted(payload: unknown, at = this.#now()) {
     this.#lastGetUpdatesAt = at;
     this.#lastGetUpdatesActivityAt = at;
+    const startedMonotonicAt = this.#monotonicNow();
+    this.#lastGetUpdatesActivityMonotonicAt = startedMonotonicAt;
     this.#lastGetUpdatesStartedAt = at;
+    this.#lastGetUpdatesStartedMonotonicAt = startedMonotonicAt;
     this.#lastGetUpdatesOffset = resolveGetUpdatesOffset(payload);
     this.#inFlightGetUpdates += 1;
     this.#lastGetUpdatesOutcome = "started";
@@ -43,6 +52,7 @@ export class TelegramPollingLivenessTracker {
 
   noteGetUpdatesSuccess(result: unknown, at = this.#now()) {
     this.#lastGetUpdatesActivityAt = at;
+    this.#lastGetUpdatesActivityMonotonicAt = this.#monotonicNow();
     this.#lastGetUpdatesFinishedAt = at;
     this.#lastGetUpdatesDurationMs =
       this.#lastGetUpdatesStartedAt == null ? null : at - this.#lastGetUpdatesStartedAt;
@@ -52,6 +62,7 @@ export class TelegramPollingLivenessTracker {
 
   noteGetUpdatesSuccessCount(count: number, at = this.#now()) {
     this.#lastGetUpdatesActivityAt = at;
+    this.#lastGetUpdatesActivityMonotonicAt = this.#monotonicNow();
     this.#lastGetUpdatesFinishedAt = at;
     this.#lastGetUpdatesDurationMs =
       this.#lastGetUpdatesStartedAt == null ? null : at - this.#lastGetUpdatesStartedAt;
@@ -62,6 +73,7 @@ export class TelegramPollingLivenessTracker {
 
   noteGetUpdatesError(err: unknown, at = this.#now()) {
     this.#lastGetUpdatesActivityAt = at;
+    this.#lastGetUpdatesActivityMonotonicAt = this.#monotonicNow();
     this.#lastGetUpdatesFinishedAt = at;
     this.#lastGetUpdatesDurationMs =
       this.#lastGetUpdatesStartedAt == null ? null : at - this.#lastGetUpdatesStartedAt;
@@ -75,13 +87,25 @@ export class TelegramPollingLivenessTracker {
 
   noteGetUpdatesActivity(at = this.#now()) {
     this.#lastGetUpdatesActivityAt = at;
+    this.#lastGetUpdatesActivityMonotonicAt = this.#monotonicNow();
   }
 
   detectStall(params: { thresholdMs: number; now?: number }): TelegramPollingStall | null {
     const now = params.now ?? this.#now();
+    const monotonicNow = this.#monotonicNow();
+    const lastStallCheckAt = this.#lastStallCheckAt;
+    this.#lastStallCheckAt = now;
+    if (
+      this.#inFlightGetUpdates > 0 &&
+      now - lastStallCheckAt > params.thresholdMs * 2
+    ) {
+      this.#lastGetUpdatesActivityAt = now;
+      this.#lastGetUpdatesActivityMonotonicAt = monotonicNow;
+      return null;
+    }
     const activeElapsed =
-      this.#inFlightGetUpdates > 0 && this.#lastGetUpdatesStartedAt != null
-        ? now - this.#lastGetUpdatesActivityAt
+      this.#inFlightGetUpdates > 0 && this.#lastGetUpdatesStartedMonotonicAt != null
+        ? monotonicNow - this.#lastGetUpdatesActivityMonotonicAt
         : 0;
     const idleElapsed =
       this.#inFlightGetUpdates > 0
@@ -113,6 +137,10 @@ export class TelegramPollingLivenessTracker {
 
   #now(): number {
     return this.options.now?.() ?? Date.now();
+  }
+
+  #monotonicNow(): number {
+    return this.options.monotonicNow?.() ?? performance.now();
   }
 }
 

--- a/extensions/telegram/src/polling-liveness.ts
+++ b/extensions/telegram/src/polling-liveness.ts
@@ -78,9 +78,9 @@ export class TelegramPollingLivenessTracker {
     const monotonicNow = this.#monotonicNow();
     const checkGap = monotonicNow - this.#lastStallCheckMonotonicAt;
     this.#lastStallCheckMonotonicAt = monotonicNow;
-    // The watchdog cannot distinguish a stalled poll from delayed callbacks when
-    // it did not run for a full threshold. Rebase once, then observe normally.
-    if (checkGap > params.thresholdMs) {
+    // The watchdog cannot distinguish a stalled poll from delayed callbacks after
+    // missing two full detection windows. Rebase once, then observe normally.
+    if (checkGap > params.thresholdMs * 2) {
       this.#lastGetUpdatesActivityMonotonicAt = monotonicNow;
       return null;
     }

--- a/extensions/telegram/src/polling-liveness.ts
+++ b/extensions/telegram/src/polling-liveness.ts
@@ -12,8 +12,6 @@ type TelegramPollingStall = {
 };
 
 export class TelegramPollingLivenessTracker {
-  #lastGetUpdatesAt: number;
-  #lastGetUpdatesActivityAt: number;
   #lastGetUpdatesActivityMonotonicAt: number;
   #lastGetUpdatesStartedAt: number | null = null;
   #lastGetUpdatesStartedMonotonicAt: number | null = null;
@@ -23,14 +21,13 @@ export class TelegramPollingLivenessTracker {
   #lastGetUpdatesError: string | null = null;
   #lastGetUpdatesOffset: number | null = null;
   #inFlightGetUpdates = 0;
-  #stallDiagLoggedAt = 0;
-  #lastStallCheckAt: number;
+  #stallDiagLoggedMonotonicAt = 0;
+  #lastStallCheckMonotonicAt: number;
 
   constructor(private readonly options: TelegramPollingLivenessTrackerOptions = {}) {
-    this.#lastGetUpdatesAt = this.#now();
-    this.#lastGetUpdatesActivityAt = this.#lastGetUpdatesAt;
-    this.#lastGetUpdatesActivityMonotonicAt = this.#monotonicNow();
-    this.#lastStallCheckAt = this.#lastGetUpdatesAt;
+    const monotonicNow = this.#monotonicNow();
+    this.#lastGetUpdatesActivityMonotonicAt = monotonicNow;
+    this.#lastStallCheckMonotonicAt = monotonicNow;
   }
 
   get inFlightGetUpdates() {
@@ -38,12 +35,12 @@ export class TelegramPollingLivenessTracker {
   }
 
   noteGetUpdatesStarted(payload: unknown, at = this.#now()) {
-    this.#lastGetUpdatesAt = at;
-    this.#lastGetUpdatesActivityAt = at;
     const startedMonotonicAt = this.#monotonicNow();
     this.#lastGetUpdatesActivityMonotonicAt = startedMonotonicAt;
     this.#lastGetUpdatesStartedAt = at;
     this.#lastGetUpdatesStartedMonotonicAt = startedMonotonicAt;
+    this.#lastGetUpdatesFinishedAt = null;
+    this.#lastGetUpdatesDurationMs = null;
     this.#lastGetUpdatesOffset = resolveGetUpdatesOffset(payload);
     this.#inFlightGetUpdates += 1;
     this.#lastGetUpdatesOutcome = "started";
@@ -51,32 +48,20 @@ export class TelegramPollingLivenessTracker {
   }
 
   noteGetUpdatesSuccess(result: unknown, at = this.#now()) {
-    this.#lastGetUpdatesActivityAt = at;
-    this.#lastGetUpdatesActivityMonotonicAt = this.#monotonicNow();
-    this.#lastGetUpdatesFinishedAt = at;
-    this.#lastGetUpdatesDurationMs =
-      this.#lastGetUpdatesStartedAt == null ? null : at - this.#lastGetUpdatesStartedAt;
+    this.#noteGetUpdatesCompleted(at);
     this.#lastGetUpdatesOutcome = Array.isArray(result) ? `ok:${result.length}` : "ok";
     this.options.onPollSuccess?.(at);
   }
 
   noteGetUpdatesSuccessCount(count: number, at = this.#now()) {
-    this.#lastGetUpdatesActivityAt = at;
-    this.#lastGetUpdatesActivityMonotonicAt = this.#monotonicNow();
-    this.#lastGetUpdatesFinishedAt = at;
-    this.#lastGetUpdatesDurationMs =
-      this.#lastGetUpdatesStartedAt == null ? null : at - this.#lastGetUpdatesStartedAt;
+    this.#noteGetUpdatesCompleted(at);
     const normalizedCount = Number.isFinite(count) ? Math.max(0, Math.floor(count)) : 0;
     this.#lastGetUpdatesOutcome = `ok:${normalizedCount}`;
     this.options.onPollSuccess?.(at);
   }
 
   noteGetUpdatesError(err: unknown, at = this.#now()) {
-    this.#lastGetUpdatesActivityAt = at;
-    this.#lastGetUpdatesActivityMonotonicAt = this.#monotonicNow();
-    this.#lastGetUpdatesFinishedAt = at;
-    this.#lastGetUpdatesDurationMs =
-      this.#lastGetUpdatesStartedAt == null ? null : at - this.#lastGetUpdatesStartedAt;
+    this.#noteGetUpdatesCompleted(at);
     this.#lastGetUpdatesOutcome = "error";
     this.#lastGetUpdatesError = formatErrorMessage(err);
   }
@@ -85,40 +70,31 @@ export class TelegramPollingLivenessTracker {
     this.#inFlightGetUpdates = Math.max(0, this.#inFlightGetUpdates - 1);
   }
 
-  noteGetUpdatesActivity(at = this.#now()) {
-    this.#lastGetUpdatesActivityAt = at;
+  noteGetUpdatesActivity() {
     this.#lastGetUpdatesActivityMonotonicAt = this.#monotonicNow();
   }
 
-  detectStall(params: { thresholdMs: number; now?: number }): TelegramPollingStall | null {
-    const now = params.now ?? this.#now();
+  detectStall(params: { thresholdMs: number }): TelegramPollingStall | null {
     const monotonicNow = this.#monotonicNow();
-    const lastStallCheckAt = this.#lastStallCheckAt;
-    this.#lastStallCheckAt = now;
-    if (
-      this.#inFlightGetUpdates > 0 &&
-      now - lastStallCheckAt > params.thresholdMs * 2
-    ) {
-      this.#lastGetUpdatesActivityAt = now;
+    const checkGap = monotonicNow - this.#lastStallCheckMonotonicAt;
+    this.#lastStallCheckMonotonicAt = monotonicNow;
+    // The watchdog cannot distinguish a stalled poll from delayed callbacks when
+    // it did not run for a full threshold. Rebase once, then observe normally.
+    if (checkGap > params.thresholdMs) {
       this.#lastGetUpdatesActivityMonotonicAt = monotonicNow;
       return null;
     }
-    const activeElapsed =
-      this.#inFlightGetUpdates > 0 && this.#lastGetUpdatesStartedMonotonicAt != null
-        ? monotonicNow - this.#lastGetUpdatesActivityMonotonicAt
-        : 0;
-    const idleElapsed =
-      this.#inFlightGetUpdates > 0
-        ? 0
-        : now - (this.#lastGetUpdatesFinishedAt ?? this.#lastGetUpdatesAt);
-    const elapsed = this.#inFlightGetUpdates > 0 ? activeElapsed : idleElapsed;
+    const elapsed = monotonicNow - this.#lastGetUpdatesActivityMonotonicAt;
     if (elapsed <= params.thresholdMs) {
       return null;
     }
-    if (this.#stallDiagLoggedAt && now - this.#stallDiagLoggedAt < params.thresholdMs / 2) {
+    if (
+      this.#stallDiagLoggedMonotonicAt &&
+      monotonicNow - this.#stallDiagLoggedMonotonicAt < params.thresholdMs / 2
+    ) {
       return null;
     }
-    this.#stallDiagLoggedAt = now;
+    this.#stallDiagLoggedMonotonicAt = monotonicNow;
 
     const elapsedLabel =
       this.#inFlightGetUpdates > 0
@@ -141,6 +117,16 @@ export class TelegramPollingLivenessTracker {
 
   #monotonicNow(): number {
     return this.options.monotonicNow?.() ?? performance.now();
+  }
+
+  #noteGetUpdatesCompleted(finishedAt: number): void {
+    const finishedMonotonicAt = this.#monotonicNow();
+    this.#lastGetUpdatesActivityMonotonicAt = finishedMonotonicAt;
+    this.#lastGetUpdatesFinishedAt = finishedAt;
+    this.#lastGetUpdatesDurationMs =
+      this.#lastGetUpdatesStartedMonotonicAt == null
+        ? null
+        : finishedMonotonicAt - this.#lastGetUpdatesStartedMonotonicAt;
   }
 }
 

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -156,6 +156,7 @@ function makeBot() {
 }
 
 function installPollingStallWatchdogHarness(dateNowSequence: readonly number[] = [0, 0]) {
+  let monotonicNow = dateNowSequence[0] ?? 0;
   let watchdog: (() => void) | undefined;
   let resolveWatchdog: ((fn: () => void) => void) | undefined;
   const watchdogReady = new Promise<() => void>((resolve) => {
@@ -177,6 +178,7 @@ function installPollingStallWatchdogHarness(dateNowSequence: readonly number[] =
   });
   const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout").mockImplementation(() => {});
   const dateNowSpy = vi.spyOn(Date, "now");
+  const performanceNowSpy = vi.spyOn(performance, "now").mockImplementation(() => monotonicNow);
   for (const value of dateNowSequence) {
     dateNowSpy.mockImplementationOnce(() => value);
   }
@@ -204,6 +206,7 @@ function installPollingStallWatchdogHarness(dateNowSequence: readonly number[] =
       });
     },
     setNow(now: number) {
+      monotonicNow = now;
       dateNowSpy.mockReset();
       dateNowSpy.mockImplementation(() => now);
     },
@@ -213,6 +216,7 @@ function installPollingStallWatchdogHarness(dateNowSequence: readonly number[] =
       setTimeoutSpy.mockRestore();
       clearTimeoutSpy.mockRestore();
       dateNowSpy.mockRestore();
+      performanceNowSpy.mockRestore();
     },
   };
 }

--- a/extensions/telegram/src/telegram-ingress-worker.deadline.test.ts
+++ b/extensions/telegram/src/telegram-ingress-worker.deadline.test.ts
@@ -1,0 +1,82 @@
+// Telegram tests cover the isolated ingress request deadline boundary.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  TelegramIngressWorkerCommand,
+  TelegramIngressWorkerMessage,
+} from "./telegram-ingress-worker.js";
+import { runTelegramIngressWorkerRuntime } from "./telegram-ingress-worker.runtime.js";
+
+type RuntimePort = Parameters<typeof runTelegramIngressWorkerRuntime>[0]["port"];
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("telegram ingress worker request deadline", () => {
+  it("aborts a stalled response body at the getUpdates deadline", async () => {
+    vi.useFakeTimers();
+    const messages: TelegramIngressWorkerMessage[] = [];
+    const listeners = new Set<(message: TelegramIngressWorkerCommand) => void>();
+    let requestSignal: AbortSignal | undefined;
+    const sendCommand = (message: TelegramIngressWorkerCommand) => {
+      for (const listener of listeners) {
+        listener(message);
+      }
+    };
+    const port: RuntimePort = {
+      postMessage(message) {
+        messages.push(message);
+        if (message.type === "poll-error") {
+          sendCommand({ type: "stop" });
+        }
+      },
+      onMessage(listener) {
+        listeners.add(listener);
+      },
+      close() {},
+    };
+    const fetchImpl: typeof fetch = async (_url, init) => {
+      requestSignal = init?.signal ?? undefined;
+      const signal = requestSignal;
+      return new Response(
+        new ReadableStream({
+          start(controller) {
+            signal?.addEventListener("abort", () => controller.error(signal.reason), {
+              once: true,
+            });
+          },
+        }),
+        { status: 200 },
+      );
+    };
+    const done = runTelegramIngressWorkerRuntime({
+      options: {
+        token: "test-auth-token",
+        accountId: "acct",
+        initialUpdateId: null,
+        spoolDir: "/tmp/openclaw-telegram-ingress-worker-deadline-test",
+        apiRoot: "https://api.telegram.test",
+      },
+      port,
+      deps: {
+        fetch: fetchImpl,
+        closeTransport: async () => {},
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(44_999);
+    expect(requestSignal?.aborted).toBe(false);
+    expect(messages.some((message) => message.type === "poll-error")).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await done;
+
+    expect(requestSignal?.aborted).toBe(true);
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        type: "poll-error",
+        message: "Telegram getUpdates timed out",
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Measure Telegram polling liveness and durations with `performance.now()` so wall-clock corrections cannot create false stalls or negative durations.
- Rebase the monotonic activity baseline after a missed watchdog window, preserving suspend/resume recovery without a wall-clock special case.
- Keep wall time only for operator-facing start/finish timestamps.
- Add exact worker coverage proving the 45-second abort still covers a stalled response body.

## Linked context

Closes #86535
Closes #119007

## Root cause and best-fix judgment

The isolated polling worker already bounds `fetch()` and body consumption with one 45-second `AbortSignal`. Issue #119007's negative `durationMs=-124193` proves the system wall clock moved backward; the matching forward correction can make a healthy 30–45 second poll appear older than the 120-second watchdog threshold. The request timeout was not being ignored.

`polling-liveness.ts` owns watchdog elapsed time. One monotonic activity clock is the canonical fix: transport/network code remains unchanged, while operator timestamps remain wall-clock values. This replaces the prior mixed-clock/sleep special case rather than adding a second recovery path.

## Real behavior proof

PR head: `3d05213b47268f51474ea4aabf90562e20cfe0fe`
Exact current-main merge tested: `e0799199b30fda0ee7268c8fed7e195cb6f5251b + 3d05213b47268f51474ea4aabf90562e20cfe0fe` (clean merge)
Environment: Linux, Node 24.18.0

### Exact-current-main parent-pause and continued-stall proof

A real child Node process instantiated the merged tracker, started an in-flight poll, and was externally paused with `SIGSTOP` for 7 seconds. The threshold was 3 seconds, so the parent missed more than two complete detection windows. After `SIGCONT`, the first real timer check stayed healthy; with the same poll still in flight, the next uninterrupted threshold emitted the normal forced-restart verdict.

```json
{"event":"resumed","elapsedMs":7012}
{"event":"first-post-gap-check","elapsedMs":7262,"verdict":"healthy"}
{"event":"continued-stall-detected","elapsedMs":10016,"message":"Polling stall detected (active getUpdates stuck for 3s); forcing restart."}
```

Verdict:

```json
{
  "verdict": "pass",
  "mergeBase": "e0799199b30fda0ee7268c8fed7e195cb6f5251b",
  "prHead": "3d05213b47268f51474ea4aabf90562e20cfe0fe",
  "pauseMechanism": "OS SIGSTOP/SIGCONT",
  "falseRestartAfterGap": false,
  "continuedRealStallRestarted": true
}
```

This directly demonstrates the intentional tradeoff: one post-gap rebase, then ordinary real-stall recovery. The branch was not rebased because it merges cleanly; preserving the reviewed head avoids invalidating exact-head CI. The exact merge result, not the stale branch tree, was built and tested.

### Real Telegram QA-user DM

A dedicated QA user drove the PR merged with main SHA `52c9448cb505bf49df234347f6084eb3b5d3d1fb`:

```shell
TELEGRAM_E2E_SKILL_DIR=/path/to/telegram-e2e-userbot node "$TELEGRAM_E2E_SKILL_DIR/scripts/run-mock-sut-user-e2e.mjs" \
  --dm --timeout-ms 25000 \
  --text 'Please answer with OPENCLAW_E2E_BASIC only.' \
  --record /tmp/telegram-e2e-pr86541-3d05213b/basic-turns/events.ndjson \
  --output /tmp/telegram-e2e-pr86541-3d05213b/basic-turns/summary.json
```

```json
{
  "verdict": "pass",
  "transport": "real Telegram QA user and bot",
  "sentMessageId": 336592896,
  "botApiMessageId": 322,
  "reply": "OPENCLAW_E2E_BASIC",
  "providerRequests": 1,
  "isolatedIngress": ["update received", "spooled", "offset persisted"]
}
```

TDLib recorded typing and the final bot reply after 2.164 seconds. The provider log contains one `POST /v1/responses` request. No Mantis path was used. A second DM attempt on the exact `e0799199` merge was not accepted as proof: another external `getUpdates` consumer acquired the shared QA bot, so the run ended before provider delivery. No unrelated poller was terminated.

### Exact-current-main deterministic proof

```shell
node scripts/run-vitest.mjs \
  extensions/telegram/src/polling-liveness.test.ts \
  extensions/telegram/src/telegram-ingress-worker.deadline.test.ts
# 2 files passed; 8 tests passed

node scripts/run-vitest.mjs extensions/telegram/src/polling-session.test.ts \
  -t 'restarts isolated ingress when worker liveness stalls|keeps isolated ingress alive when spooled messages show worker activity|forces a restart when polling stalls without getUpdates activity'
# 2 tests passed; 78 skipped

pnpm build
# passed on e0799199 + PR head

git diff --check
# passed
```

The worker regression holds a response body open: 44,999 ms does not abort; 45,000 ms aborts and emits `poll-error`. Liveness tests cover backward wall-clock correction, long watchdog gaps, real active stalls, idle stalls, and diagnostic throttling.

## Review metrics

- Production: +48 / -34 lines (`+14` net). Justification: one canonical monotonic ownership boundary replacing mixed-clock liveness policy.
- Tests: +169 / -6 lines.
- Config/default surfaces: 0 added, changed, or removed.

## Risk

Highest risk: suppressing a real active stall after a long event-loop/suspend gap. Mitigation: only the first check after more than two missed detection windows rebases; the next uninterrupted threshold still reports and restarts a true stall. No config, protocol, persistence, dependency, or user setup change.
