### PR TITLE
fix(cli): show Gemini CLI runtime auth status

### DIFF
--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -28,6 +28,7 @@ import {
   resolveProviderEnvAuthLookupMaps,
 } from "../../agents/model-auth-env-vars.js";
 import { resolveEnvApiKey, resolveUsableCustomProviderApiKey } from "../../agents/model-auth.js";
+import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
 import {
   buildModelAliasIndex,
   isCliProvider,
@@ -361,12 +362,17 @@ export async function modelsStatusCommand(
       })?.ref;
     };
     const providersFromModels = new Set<string>();
-    const providerUses: Array<{ provider: string; allowCodexRuntimeFallback: boolean }> = [];
+    const providerUses: Array<{
+      provider: string;
+      model: string;
+      allowCodexRuntimeFallback: boolean;
+    }> = [];
     const addProviderUse = (raw: string | undefined, allowCodexRuntimeFallback: boolean) => {
       const ref = resolveStatusModelRef(raw);
       if (ref?.provider) {
         providerUses.push({
           provider: normalizeProviderId(ref.provider),
+          model: ref.model,
           allowCodexRuntimeFallback,
         });
       }
@@ -416,6 +422,28 @@ export async function modelsStatusCommand(
       }).map((provider) => normalizeProviderId(provider)),
     );
     const syntheticAuthByProvider = new Map<string, StatusSyntheticAuth>();
+    const cliRuntimeAuthUsages = providerUses
+      .filter((usage) => usage.allowCodexRuntimeFallback)
+      .map((usage) => {
+        const runtimeProvider = resolveCliRuntimeExecutionProvider({
+          provider: usage.provider,
+          modelId: usage.model,
+          cfg,
+          agentId: workspaceAgentId,
+        });
+        const normalizedRuntime = runtimeProvider
+          ? normalizeProviderId(runtimeProvider)
+          : undefined;
+        return normalizedRuntime && normalizedRuntime !== usage.provider
+          ? {
+              provider: usage.provider,
+              model: usage.model,
+              allowCodexRuntimeFallback: usage.allowCodexRuntimeFallback,
+              runtime: normalizedRuntime,
+            }
+          : undefined;
+      })
+      .filter((usage): usage is NonNullable<typeof usage> => Boolean(usage));
 
     const providers = Array.from(
       new Set([
@@ -423,6 +451,7 @@ export async function modelsStatusCommand(
         ...providersFromConfig,
         ...providersFromModels,
         ...providersFromEnv,
+        ...cliRuntimeAuthUsages.map((usage) => usage.runtime),
       ]),
     )
       .map((p) => normalizeOptionalString(p) ?? "")
@@ -696,25 +725,41 @@ export async function modelsStatusCommand(
       }
       return false;
     };
+    const hasUsableDirectProviderAuth = (provider: string): boolean => {
+      const normalized = normalizeProviderId(provider);
+      const hasUsableProfile = listProviderProfileCandidates(normalized).some((profileId) => {
+        const credential = store.profiles[profileId];
+        return credential ? hasUsableAuthProfile(profileId, credential) : false;
+      });
+      return hasUsableProfile || hasUsableNonProfileAuth(normalized);
+    };
     const hasUsableProviderAuth = (
       provider: string,
       options?: { includeLegacyOpenAICodex?: boolean },
     ): boolean => {
       for (const candidate of listRuntimeAuthProviderCandidates(provider, options)) {
-        const hasUsableProfile = listProviderProfileCandidates(candidate).some((profileId) => {
-          const credential = store.profiles[profileId];
-          return credential ? hasUsableAuthProfile(profileId, credential) : false;
-        });
-        if (hasUsableProfile || hasUsableNonProfileAuth(candidate)) {
+        if (hasUsableDirectProviderAuth(candidate)) {
           return true;
         }
       }
       return false;
     };
+    const resolveCliRuntimeAuthProvider = (usage: (typeof providerUses)[number]) =>
+      cliRuntimeAuthUsages.find(
+        (candidate) =>
+          candidate.provider === usage.provider &&
+          candidate.model === usage.model &&
+          candidate.allowCodexRuntimeFallback === usage.allowCodexRuntimeFallback,
+      )?.runtime;
     const hasUsableAuthForProviderInUse = (
-      provider: string,
+      usage: (typeof providerUses)[number],
       options: { allowCodexRuntimeFallback: boolean },
     ): boolean => {
+      const cliRuntimeAuthProvider = resolveCliRuntimeAuthProvider(usage);
+      if (cliRuntimeAuthProvider) {
+        return hasUsableDirectProviderAuth(cliRuntimeAuthProvider);
+      }
+      const { provider } = usage;
       if (hasUsableProviderAuth(provider)) {
         return true;
       }
@@ -727,8 +772,8 @@ export async function modelsStatusCommand(
       );
     };
     const runtimeAuthRoutes = Array.from(
-      new Map(
-        codexRuntimeAuthUsages.map((usage) => {
+      new Map([
+        ...codexRuntimeAuthUsages.map((usage) => {
           const effective = resolveRuntimeAuthRouteEffective(codexProvider);
           return [
             `${usage.provider}:codex:${codexProvider}`,
@@ -745,21 +790,38 @@ export async function modelsStatusCommand(
             },
           ] as const;
         }),
-      ).values(),
+        ...cliRuntimeAuthUsages.map((usage) => {
+          const effective = resolveRuntimeAuthRouteEffective(usage.runtime);
+          return [
+            `${usage.provider}:${usage.runtime}:${usage.runtime}`,
+            {
+              provider: usage.provider,
+              runtime: usage.runtime,
+              authProvider: usage.runtime,
+              status: hasUsableDirectProviderAuth(usage.runtime) ? "usable" : "missing",
+              effective,
+            },
+          ] as const;
+        }),
+      ]).values(),
     ).toSorted((a, b) => a.provider.localeCompare(b.provider));
     const missingProvidersInUse = Array.from(
       new Set(
         providerUses
           .filter(
             (usage) =>
-              !hasUsableAuthForProviderInUse(usage.provider, {
+              !hasUsableAuthForProviderInUse(usage, {
                 allowCodexRuntimeFallback: usage.allowCodexRuntimeFallback,
               }),
           )
-          .map((usage) => usage.provider),
+          .map((usage) => resolveCliRuntimeAuthProvider(usage) ?? usage.provider),
       ),
     )
-      .filter((provider) => !isCliProvider(provider, cfg))
+      .filter(
+        (provider) =>
+          !isCliProvider(provider, cfg) ||
+          cliRuntimeAuthUsages.some((usage) => usage.runtime === provider),
+      )
       .toSorted((a, b) => a.localeCompare(b));
 
     const probeProfileIds = (() => {
@@ -891,6 +953,12 @@ export async function modelsStatusCommand(
     const checkStatus = (() => {
       const providersInUse = new Set<string>();
       for (const usage of providerUses) {
+        const cliRuntimeAuthProvider = resolveCliRuntimeAuthProvider(usage);
+        if (cliRuntimeAuthProvider) {
+          providersInUse.add(cliRuntimeAuthProvider);
+          providersInUse.add(resolveProviderAuthHealthId(cliRuntimeAuthProvider));
+          continue;
+        }
         providersInUse.add(usage.provider);
         providersInUse.add(resolveProviderAuthHealthId(usage.provider));
         if (

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -41,10 +41,15 @@ const mocks = vi.hoisted(() => {
     resolveAgentDir: vi.fn().mockReturnValue("/tmp/openclaw-agent"),
     resolveAgentWorkspaceDir: vi.fn().mockReturnValue("/tmp/openclaw-agent/workspace"),
     resolveDefaultAgentId: vi.fn().mockReturnValue("main"),
+    resolveSessionAgentIds: vi.fn(({ agentId }: { agentId?: string } = {}) => ({
+      defaultAgentId: "main",
+      sessionAgentId: agentId ?? "main",
+    })),
     resolveAgentExplicitModelPrimary: vi.fn().mockReturnValue(undefined),
     resolveAgentEffectiveModelPrimary: vi.fn().mockReturnValue(undefined),
     resolveAgentModelFallbacksOverride: vi.fn().mockReturnValue(undefined),
     listAgentIds: vi.fn().mockReturnValue(["main", "jeremiah"]),
+    listAgentEntries: vi.fn().mockReturnValue([{ id: "main" }, { id: "jeremiah" }]),
     ensureAuthProfileStore: vi.fn().mockReturnValue(store),
     listProfilesForProvider: vi.fn((s: typeof store, provider: string) => {
       return Object.entries(s.profiles)
@@ -156,10 +161,12 @@ vi.mock("../../agents/agent-scope.js", () => ({
   resolveAgentDir: mocks.resolveAgentDir,
   resolveAgentWorkspaceDir: mocks.resolveAgentWorkspaceDir,
   resolveDefaultAgentId: mocks.resolveDefaultAgentId,
+  resolveSessionAgentIds: mocks.resolveSessionAgentIds,
   resolveAgentExplicitModelPrimary: mocks.resolveAgentExplicitModelPrimary,
   resolveAgentEffectiveModelPrimary: mocks.resolveAgentEffectiveModelPrimary,
   resolveAgentModelFallbacksOverride: mocks.resolveAgentModelFallbacksOverride,
   listAgentIds: mocks.listAgentIds,
+  listAgentEntries: mocks.listAgentEntries,
 }));
 vi.mock("../../agents/workspace.js", () => ({
   resolveDefaultAgentWorkspaceDir: vi.fn().mockReturnValue("/tmp/openclaw-agent/workspace"),
@@ -716,6 +723,89 @@ describe("modelsStatusCommand auth overview", () => {
       }
       if (originalHealthImpl) {
         buildAuthHealthSummaryMock.mockImplementation(originalHealthImpl);
+      }
+    }
+  });
+
+  it("reports Gemini CLI OAuth for canonical Google text routed through the CLI runtime", async () => {
+    const localRuntime = createRuntime();
+    const originalLoadConfig = mocks.loadConfig.getMockImplementation();
+    const originalProfiles = { ...mocks.store.profiles };
+    const originalEnvImpl = mocks.resolveEnvApiKey.getMockImplementation();
+    mocks.loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          model: { primary: "google/gemini-3-flash-preview", fallbacks: [] },
+          models: {
+            "google/*": { agentRuntime: { id: "google-gemini-cli" } },
+          },
+          cliBackends: { "google-gemini-cli": {} },
+        },
+      },
+      models: { providers: {} },
+      env: { shellEnv: { enabled: true } },
+    });
+    mocks.store.profiles = {
+      "google-gemini-cli:user@example.test": {
+        type: "oauth",
+        provider: "google-gemini-cli",
+        access: "gemini-cli-access-token",
+        refresh: "gemini-cli-refresh-token",
+        expires: Date.now() + 60_000,
+      },
+    };
+    mocks.resolveEnvApiKey.mockImplementation((provider: string) =>
+      provider === "google"
+        ? {
+            apiKey: "AIzaSyD-google-env-key-0123456789",
+            source: "env: GEMINI_API_KEY",
+          }
+        : null,
+    );
+
+    try {
+      await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+      const payload = parseFirstJsonLog(localRuntime);
+      expect(payload.auth.missingProvidersInUse).toStrictEqual([]);
+      expect(
+        requireRecord(
+          requireProvider(payload.auth.providers, "google").effective,
+          "google effective",
+        ),
+      ).toEqual(expect.objectContaining({ kind: "env" }));
+      expect(
+        requireRecord(
+          requireProvider(payload.auth.providers, "google-gemini-cli").effective,
+          "google-gemini-cli effective",
+        ),
+      ).toEqual({
+        kind: "profiles",
+        detail: "/tmp/openclaw-agent/auth-profiles.json",
+      });
+      expect(payload.auth.runtimeAuthRoutes).toEqual([
+        {
+          provider: "google",
+          runtime: "google-gemini-cli",
+          authProvider: "google-gemini-cli",
+          status: "usable",
+          effective: {
+            kind: "profiles",
+            detail: "/tmp/openclaw-agent/auth-profiles.json",
+          },
+        },
+      ]);
+      expect(localRuntime.exit).not.toHaveBeenCalledWith(1);
+    } finally {
+      mocks.store.profiles = originalProfiles;
+      if (originalLoadConfig) {
+        mocks.loadConfig.mockImplementation(originalLoadConfig);
+      }
+      if (originalEnvImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(originalEnvImpl);
+      } else if (defaultResolveEnvApiKeyImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(defaultResolveEnvApiKeyImpl);
+      } else {
+        mocks.resolveEnvApiKey.mockImplementation(() => null);
       }
     }
   });


### PR DESCRIPTION
Fixes #79585.

## Summary
- Teach `openclaw models status` to detect canonical text models such as `google/*` that are routed through a CLI runtime such as `google-gemini-cli`.
- Show/check a separate runtime auth route for that split, so `GEMINI_API_KEY` can remain the canonical Google env source while the text runtime route reports Gemini CLI OAuth.
- Keep image routes out of the CLI-runtime path by only resolving CLI runtime auth for text/default model uses.

## Scope
- No public config schema/options changes.
- No plugin API or plugin contract changes.
- No new CLI flags, env vars, migrations, or setup surfaces.
- This is intentionally reduced from the previous broader stack to the direct #79585 behavior fix.

## Validation
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/commands/models/list.status.test.ts --reporter=dot` -> 1 file, 33 passed.
- `node_modules/oxfmt/bin/oxfmt --check src/commands/models/list.status-command.ts src/commands/models/list.status.test.ts` -> passed.
- `node_modules/oxlint/bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/commands/models/list.status-command.ts src/commands/models/list.status.test.ts` -> 0 warnings/errors.
- `git diff --check origin/main...HEAD && git diff --check` -> passed.

## Size
- Current diff: 2 files changed, 171 insertions, 13 deletions.
- Previous broader stack was 3 files changed, 622 insertions, 22 deletions.

Signed head: `8785bc36198da0ac079e604ab109555810b755a2` (`gpgsig` present).
