### PR TITLE
test(perf): disable reply dispatcher idle barrier for RTT A/B

### DIFF
--- a/src/auto-reply/reply/dispatch-acp-delivery.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.ts
@@ -14,7 +14,6 @@ import { resolveConfiguredTtsMode, shouldCleanTtsDirectiveText } from "../../tts
 import { isReplyPayloadStatusNotice } from "../reply-payload.js";
 import type { FinalizedMsgContext } from "../templating.js";
 import type { ReplyPayload } from "../types.js";
-import { waitForReplyDispatcherIdle } from "./reply-dispatcher.js";
 import type { ReplyDispatchKind, ReplyDispatcher } from "./reply-dispatcher.types.js";
 import { resolveRoutedDeliveryThreadId } from "./routed-delivery-thread.js";
 
@@ -193,7 +192,6 @@ export function createAcpDispatchDeliveryCoordinator(params: {
   originatingChannel?: string;
   originatingTo?: string;
   onReplyStart?: () => Promise<void> | void;
-  abortSignal?: AbortSignal;
 }): AcpDispatchDeliveryCoordinator {
   const directChannel = normalizeOptionalLowercaseString(params.ctx.Provider ?? params.ctx.Surface);
   const routedChannel = normalizeOptionalLowercaseString(params.originatingChannel);
@@ -460,9 +458,6 @@ export function createAcpDispatchDeliveryCoordinator(params: {
       state.settledDirectVisibleText = false;
     } else if (!delivered && tracksVisibleText) {
       state.failedVisibleTextDelivery = true;
-    }
-    if (kind === "block" && delivered) {
-      await waitForReplyDispatcherIdle(params.dispatcher, params.abortSignal);
     }
     return delivered;
   };

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -387,7 +387,6 @@ export async function tryDispatchAcpReply(params: {
     originatingChannel: params.originatingChannel,
     originatingTo: params.originatingTo,
     onReplyStart: params.onReplyStart,
-    abortSignal: params.abortSignal,
   });
 
   const identityPendingBeforeTurn = isSessionIdentityPending(

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -130,7 +130,6 @@ import { resolveEffectiveReplyRoute } from "./effective-reply-route.js";
 import { withFullRuntimeReplyConfig } from "./get-reply-fast-path.js";
 import { claimInboundDedupe, commitInboundDedupe, releaseInboundDedupe } from "./inbound-dedupe.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
-import { waitForReplyDispatcherIdle } from "./reply-dispatcher.js";
 import type { ReplyDispatcher } from "./reply-dispatcher.types.js";
 import type { ReplyOperation } from "./reply-run-registry.js";
 import { admitReplyTurn, resolveReplyTurnKind } from "./reply-turn-admission.js";
@@ -2325,10 +2324,7 @@ export async function dispatchReplyFromConfig(
                   await sendPayloadAsync(normalizedPayload, context?.abortSignal, false);
                 } else {
                   markInboundDedupeReplayUnsafe();
-                  const delivered = dispatcher.sendBlockReply(normalizedPayload);
-                  if (delivered) {
-                    await waitForReplyDispatcherIdle(dispatcher, context?.abortSignal);
-                  }
+                  dispatcher.sendBlockReply(normalizedPayload);
                 }
               };
               return run();

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -255,30 +255,6 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
   };
 }
 
-export async function waitForReplyDispatcherIdle(
-  dispatcher: Pick<ReplyDispatcher, "waitForIdle">,
-  abortSignal?: AbortSignal,
-): Promise<void> {
-  if (!abortSignal) {
-    await dispatcher.waitForIdle();
-    return;
-  }
-  if (abortSignal.aborted) {
-    return;
-  }
-  let removeAbortListener: (() => void) | undefined;
-  const aborted = new Promise<void>((resolve) => {
-    const onAbort = () => resolve();
-    abortSignal.addEventListener("abort", onAbort, { once: true });
-    removeAbortListener = () => abortSignal.removeEventListener("abort", onAbort);
-  });
-  try {
-    await Promise.race([dispatcher.waitForIdle(), aborted]);
-  } finally {
-    removeAbortListener?.();
-  }
-}
-
 export function createReplyDispatcherWithTyping(
   options: ReplyDispatcherWithTypingOptions,
 ): ReplyDispatcherWithTypingResult {


### PR DESCRIPTION
Summary:
- Temporary RTT A/B measurement branch.
- Disables the runtime reply dispatcher idle barrier added by 0a4de3de576 while keeping current main otherwise.
- Intended for QA-Lab secret-bearing live workflow comparison only.

Verification:
- Pending: Crabbox/Testbox sanity and QA-Lab live A/B.
