### PR TITLE
fix(agents): add missing DeepSeek V4 proxy models to reasoning_content replay set

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -7680,6 +7680,32 @@ describe("buildOpenAICompletionsParams sanitizes reasoning replay fields", () =>
     baseUrl: "https://api.kimi.com/coding/v1",
   } satisfies Model<"openai-completions">;
 
+  const customDeepSeekProxyModel = {
+    id: "deepseek-v4-flash-free",
+    name: "DeepSeek V4 Flash Free",
+    api: "openai-completions",
+    provider: "opencode-go-extras",
+    baseUrl: "https://proxy.example.com/v1",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 64_000,
+    maxTokens: 8000,
+  } satisfies Model<"openai-completions">;
+
+  const customBigPickleProxyModel = {
+    id: "big-pickle",
+    name: "Big Pickle",
+    api: "openai-completions",
+    provider: "custom-openai-proxy",
+    baseUrl: "https://another-proxy.example.com/v1",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 16_000,
+  } satisfies Model<"openai-completions">;
+
   function getAssistantMessage(params: { messages: unknown }) {
     expect(Array.isArray(params.messages)).toBe(true);
     const list = params.messages as Array<Record<string, unknown>>;
@@ -7893,6 +7919,28 @@ describe("buildOpenAICompletionsParams sanitizes reasoning replay fields", () =>
   it("preserves reasoning_content replay for Kimi Coding OpenAI-compatible routes", () => {
     const assistant = getAssistantMessage(
       buildReplayParams(kimiCodingProxyModel, "reasoning_content"),
+    );
+
+    expect(assistant.reasoning_content).toBe("Need to answer politely.");
+    expect(assistant).not.toHaveProperty("reasoning_details");
+    expect(assistant).not.toHaveProperty("reasoning");
+    expect(assistant).not.toHaveProperty("reasoning_text");
+  });
+
+  it("preserves reasoning_content replay for DeepSeek V4 Flash Free via proxy", () => {
+    const assistant = getAssistantMessage(
+      buildReplayParams(customDeepSeekProxyModel, "reasoning_content"),
+    );
+
+    expect(assistant.reasoning_content).toBe("Need to answer politely.");
+    expect(assistant).not.toHaveProperty("reasoning_details");
+    expect(assistant).not.toHaveProperty("reasoning");
+    expect(assistant).not.toHaveProperty("reasoning_text");
+  });
+
+  it("preserves reasoning_content replay for Big Pickle via proxy", () => {
+    const assistant = getAssistantMessage(
+      buildReplayParams(customBigPickleProxyModel, "reasoning_content"),
     );
 
     expect(assistant.reasoning_content).toBe("Need to answer politely.");

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -3372,7 +3372,9 @@ function sanitizeReasoningContentReplayFields(record: Record<string, unknown>): 
 
 const REASONING_CONTENT_REPLAY_MODEL_IDS = new Set([
   "deepseek-v4-flash",
+  "deepseek-v4-flash-free",
   "deepseek-v4-pro",
+  "big-pickle",
   "kimi-for-coding",
   "kimi-k2.5",
   "kimi-k2.6",

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -369,6 +369,10 @@ describe("resolveTranscriptPolicy", () => {
     "hf:moonshotai/kimi-k2-thinking",
     "xiaomi/mimo-v2.6-pro",
     "xiaomi/mimo-v2.6-pro:cloud",
+    "deepseek-v4-flash",
+    "deepseek-v4-flash-free",
+    "deepseek-v4-pro",
+    "big-pickle",
   ])(
     "preserves historical reasoning for %s replay-required OpenAI-compatible models",
     (modelId) => {

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -167,6 +167,10 @@ function buildUnownedProviderTransportReplayFallback(params: {
 }
 
 const REASONING_CONTENT_REPLAY_MODEL_IDS = new Set([
+  "deepseek-v4-flash",
+  "deepseek-v4-flash-free",
+  "deepseek-v4-pro",
+  "big-pickle",
   "kimi-for-coding",
   "kimi-k2.5",
   "kimi-k2.6",


### PR DESCRIPTION
## Summary
- DeepSeek V4 models (`deepseek-v4-flash-free`, `big-pickle`) accessed through proxy providers (e.g. OpenCode Zen) lose `reasoning_content` in assistant message replay, causing 500 errors from the API
- `isDeepSeek` detection only checks `endpointClass === "deepseek-native"` which doesn't match proxy endpoints (`opencode-native`)
- The model ID fallback set `REASONING_CONTENT_REPLAY_MODEL_IDS` was missing these model variants

Fix:
- Add `deepseek-v4-flash-free` and `big-pickle` to `REASONING_CONTENT_REPLAY_MODEL_IDS` in both `openai-transport-stream.ts` and `transcript-policy.ts`
- Add regression tests for DeepSeek V4 Flash Free and Big Pickle via proxy

Fixes #86521

## Test plan
- `npx vitest run src/agents/openai-transport-stream.test.ts` — 392 passing (includes 2 new tests)
- `npx vitest run src/agents/transcript-policy.test.ts` — 98 passing (includes 4 new model IDs)
- New tests: preserves reasoning_content replay for DeepSeek V4 Flash Free via proxy
- New tests: preserves reasoning_content replay for Big Pickle via proxy

## Real behavior proof
This fix targets the model ID fallback path in `shouldPreserveReasoningContentReplay`. The model ID check already works for proxy endpoints — the issue was simply that `deepseek-v4-flash-free` and `big-pickle` were missing from the set. The new unit tests cover both proxy model configurations. A live reproduction would require an OpenCode Zen (or similar) proxy configured with a DeepSeek V4 model.