### PR TITLE
fix(telegram): treat targeted bot commands as mentions

### DIFF
--- a/extensions/telegram/src/bot-message-context.body.test.ts
+++ b/extensions/telegram/src/bot-message-context.body.test.ts
@@ -230,6 +230,37 @@ describe("resolveTelegramInboundBody", () => {
     expect(result).toBeNull();
   });
 
+  it("accepts targeted bot commands as explicit mentions in requireMention groups", async () => {
+    const logger = { info: vi.fn() };
+    const text = "/deploy@bot check status";
+
+    const result = await resolveTelegramBody({
+      cfg: { channels: { telegram: {} } } as never,
+      msg: {
+        message_id: 8,
+        date: 1_700_000_008,
+        chat: { id: -1001234567890, type: "supergroup", title: "Test Group" },
+        from: { id: 46, first_name: "Eve" },
+        text,
+        entities: [{ type: "bot_command", offset: 0, length: "/deploy@bot".length }],
+      } as never,
+      isGroup: true,
+      chatId: -1001234567890,
+      senderId: "46",
+      senderUsername: "",
+      groupConfig: { requireMention: true } as never,
+      requireMention: true,
+      logger,
+    });
+
+    expect(logger.info).not.toHaveBeenCalledWith(
+      { chatId: -1001234567890, reason: "no-mention" },
+      "skipping group message",
+    );
+    expect(result?.rawBody).toBe(text);
+    expect(result?.effectiveWasMentioned).toBe(true);
+  });
+
   it("does not transcribe group audio for unauthorized senders", async () => {
     transcribeFirstAudioMock.mockReset();
     const logger = { info: vi.fn() };

--- a/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
@@ -443,6 +443,54 @@ describe("createTelegramBot channel_post media", () => {
     }
   });
 
+  it("treats targeted bot command captions as mentions before media download", async () => {
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          groupPolicy: "open",
+          groups: { "*": { requireMention: true } },
+        },
+      },
+    });
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      throw new Error("MediaFetchError: ECONNRESET");
+    });
+
+    try {
+      createTelegramBot({ token: "tok" });
+      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+      const caption = "/inspect@openclaw_bot";
+
+      await handler({
+        message: {
+          chat: { id: -100456, type: "supergroup", title: "Ops Chat" },
+          message_id: 81184,
+          date: 1736380800,
+          caption,
+          caption_entities: [{ type: "bot_command", offset: 0, length: caption.length }],
+          photo: [{ file_id: "p1" }],
+          from: { id: 55, is_bot: false, first_name: "u" },
+        },
+        me: { id: 999, username: "openclaw_bot" },
+        getFile: async () => ({ file_path: "photos/p1.jpg" }),
+      });
+
+      expect(sendMessageSpy).toHaveBeenCalledWith(
+        -100456,
+        "⚠️ Failed to download media. Please try again.",
+        {
+          reply_parameters: {
+            message_id: 81184,
+            allow_sending_without_reply: true,
+          },
+        },
+      );
+      expect(replySpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
   it("notifies requireMention group replies to the bot when media download fails", async () => {
     loadConfig.mockReturnValue({
       channels: {

--- a/extensions/telegram/src/bot/body-helpers.ts
+++ b/extensions/telegram/src/bot/body-helpers.ts
@@ -139,6 +139,15 @@ function hasStandaloneTelegramMention(text: string, mention: string): boolean {
   return false;
 }
 
+function isBotCommandAddressedToMention(command: string, mention: string): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(command);
+  if (!normalized.startsWith("/") || !normalized.endsWith(mention)) {
+    return false;
+  }
+  const atIndex = normalized.lastIndexOf(mention);
+  return atIndex > 1;
+}
+
 export function hasBotMention(msg: Message, botUsername: string) {
   const { text, entities } = getTelegramTextParts(msg);
   const mention = normalizeLowercaseStringOrEmpty(`@${botUsername}`);
@@ -146,11 +155,11 @@ export function hasBotMention(msg: Message, botUsername: string) {
     return true;
   }
   for (const ent of entities) {
-    if (ent.type !== "mention") {
-      continue;
-    }
     const slice = text.slice(ent.offset, ent.offset + ent.length);
-    if (normalizeLowercaseStringOrEmpty(slice) === mention) {
+    if (ent.type === "mention" && normalizeLowercaseStringOrEmpty(slice) === mention) {
+      return true;
+    }
+    if (ent.type === "bot_command" && isBotCommandAddressedToMention(slice, mention)) {
       return true;
     }
   }

--- a/extensions/telegram/src/bot/helpers.test.ts
+++ b/extensions/telegram/src/bot/helpers.test.ts
@@ -754,6 +754,36 @@ describe("hasBotMention", () => {
     ).toBe(true);
   });
 
+  it("matches bot command entities addressed to this bot", () => {
+    const text = "/deploy@gaian check status";
+
+    expect(
+      hasBotMention(
+        {
+          text,
+          entities: [{ type: "bot_command", offset: 0, length: "/deploy@gaian".length }],
+          chat: { id: 1, type: "supergroup" },
+        } as any,
+        "gaian",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match bot command entities addressed to another bot", () => {
+    const text = "/deploy@other_bot check status";
+
+    expect(
+      hasBotMention(
+        {
+          text,
+          entities: [{ type: "bot_command", offset: 0, length: "/deploy@other_bot".length }],
+          chat: { id: 1, type: "supergroup" },
+        } as any,
+        "gaian",
+      ),
+    ).toBe(false);
+  });
+
   it("matches mention followed by punctuation", () => {
     expect(
       hasBotMention(


### PR DESCRIPTION
Telegram group messages like `/command@TargetBot` can be dropped by the requireMention gate, so explicitly addressed bot-to-bot/group commands may never reach the agent.

Fixes #84462

## Affected surface
- `extensions/telegram/src/bot/body-helpers.ts`
  - `hasBotMention()` now treats Telegram `bot_command` entity slices ending in `@<current bot username>` as explicit mentions.
- `extensions/telegram/src/bot/helpers.test.ts`
- `extensions/telegram/src/bot-message-context.body.test.ts`
- `extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts`

## Scope
This is a narrow Telegram ingress mention-gate fix. It reuses the existing `hasBotMention()` boundary instead of adding a new config/option or changing generic mention policy.

The new check only accepts Telegram `bot_command` entity slices that:
- start with `/`
- have command text before the target suffix
- end with the normalized current bot mention, e.g. `/deploy@openclaw_bot`

It preserves the existing behavior for:
- normal `@bot` mention entities
- plain-text standalone mentions
- `/command@OtherBot`
- bare `/command`
- existing control-command authorization gates

## Real behavior proof

**Behavior or issue addressed**: After Telegram delivers a group text or caption with a `bot_command` entity like `/deploy@gaian`, OpenClaw should treat it as an explicit mention of the current bot for the existing `requireMention` gate. Before this patch, `hasBotMention()` ignored `bot_command` entities, so `/command@TargetBot` could be skipped as `no-mention`.

**Real environment tested**: Local OpenClaw source checkout on Linux, current PR head `4e776c24655035519e4338e6e2b142332585840f`, using Node 22.22.2 and the repository's installed pnpm workspace dependencies plus a real Telegram supergroup with the target bot and a negative-control bot present. The proof captures live Telegram Bot API updates and calls the current PR head's real `hasBotMention()` helper against those update payloads.

**Exact steps or command run after this patch**:
```text
$ pnpm exec tsx -e 'import { hasBotMention } from "./extensions/telegram/src/bot/body-helpers.ts"; const addressed="/deploy@gaian check status"; const other="/deploy@other_bot check status"; const current=hasBotMention({text:addressed,entities:[{type:"bot_command",offset:0,length:"/deploy@gaian".length}],chat:{id:1,type:"supergroup"}} as any,"gaian"); const wrong=hasBotMention({text:other,entities:[{type:"bot_command",offset:0,length:"/deploy@other_bot".length}],chat:{id:1,type:"supergroup"}} as any,"gaian"); if (current !== true || wrong !== false) { console.error(JSON.stringify({current,wrong})); process.exit(1); } console.log(JSON.stringify({current,wrong}));'

$ OPENCLAW_TEST_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=90000 node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/bot/helpers.test.ts extensions/telegram/src/bot-message-context.body.test.ts extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts --reporter=verbose

$ OPENCLAW_TEST_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=90000 node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/bot-message-context.body.test.ts extensions/telegram/src/bot.create-telegram-bot.test.ts extensions/telegram/src/bot-handlers.runtime.test.ts extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts

$ OPENCLAW_TEST_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=90000 node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply.config.ts src/auto-reply/command-control.test.ts

$ pnpm check:changed --base origin/main
```

**Evidence after fix**: Terminal output from the current PR head:

```text
{"current":true,"wrong":false}

Test Files  3 passed (3)
Tests  104 passed (104)

Test Files  4 passed (4)
Tests  126 passed (126)

Test Files  1 passed (1)
Tests  49 passed (49)

[check:changed] lanes=extensions, extensionTests
runtime-sidecar-loaders: local runtime sidecar loaders look OK.
Import cycle check: 0 runtime value cycle(s).

$ git diff --check origin/main..HEAD
(no output)

$ node scripts/check-no-conflict-markers.mjs
(no output)

$ gitleaks protect --staged --redact
no leaks found
```

RED source repro before the fix:

```text
$ pnpm exec tsx -e 'import { hasBotMention } from "./extensions/telegram/src/bot/body-helpers.ts"; const text="/deploy@gaian check status"; const result=hasBotMention({text,entities:[{type:"bot_command",offset:0,length:"/deploy@gaian".length}],chat:{id:1,type:"supergroup"}} as any,"gaian"); if (result !== true) { console.error(`RED confirmed: expected true, got ${result}`); process.exit(1); }'
RED confirmed: expected true, got false
```

Live Telegram proof from the same PR head, using a real Telegram supergroup and the target bot token. Token, chat id, and private account details are redacted; the target and other bot usernames are intentionally shown because they are the behavior under test.

```text
$ set -a; . /code/secrets/projects/openclaw-telegram-pr83478-proof.env; set +a; pnpm exec tsx /tmp/openclaw-pr86553-telegram-proof/proof.mjs
{"phase":"ready","proof_id":"p1779725433074","target_bot":"openclaw12testbot","other_bot":"ceshiwolfbot","chat_id":"<redacted-chat-id>","commands_to_send":["/ocproof_p1779725433074@openclaw12testbot","/ocproof_p1779725433074@ceshiwolfbot"],"last_seen_update_id":0}
{"phase":"observed_update","update_id":"<redacted-update-id-1>","message_id":"<redacted-message-id-1>","chat_id":"<redacted-chat-id>","chat_type":"supergroup","text":"/ocproof_p1779725433074@openclaw12testbot","entities":[{"type":"bot_command","offset":0,"length":41}],"hasBotMention":true}
{"phase":"observed_update","update_id":"<redacted-update-id-2>","message_id":"<redacted-message-id-2>","chat_id":"<redacted-chat-id>","chat_type":"supergroup","text":"/ocproof_p1779725433074@ceshiwolfbot","entities":[{"type":"bot_command","offset":0,"length":36}],"hasBotMention":false}
{"phase":"summary","proof_id":"p1779725433074","target_update_count":1,"other_update_count":1,"targetMentionPass":true,"otherIgnoredPass":true,"result":"PASS"}
```

**Observed result after fix**: The real `hasBotMention()` helper returns `true` for the current bot's targeted `bot_command` entity and `false` for another bot's targeted command. The live Telegram proof captured both `/ocproof_p1779725433074@openclaw12testbot` and `/ocproof_p1779725433074@ceshiwolfbot` as actual Telegram `bot_command` entities in a supergroup; only the current-bot command was treated as a mention. The Telegram body path no longer skips `/deploy@bot` as `no-mention` in a `requireMention` group, and the media pre-download path treats `/inspect@openclaw_bot` captions as mentioned before attempting media download.

**What was not tested**: I did not run a full OpenClaw gateway conversation loop or assert an LLM reply in Telegram. This proof exercises the real Telegram Bot API update payload plus the current PR head's Telegram mention-gate helper; the source regression tests cover the downstream `requireMention` body/media gates.

## Coverage note
Baseline before push: `origin/main` = `89aea9b8433340bf6d40ff460da50b9346fb0af5`.

Open PR searches rerun immediately before push; all returned `[]`:

```text
gh search prs --repo openclaw/openclaw --state open "Fixes #84462"
gh search prs --repo openclaw/openclaw --state open "#84462"
gh search prs --repo openclaw/openclaw --state open "hasBotMention"
gh search prs --repo openclaw/openclaw --state open "bot-message-context.body.ts bot_command"
gh search prs --repo openclaw/openclaw --state open "Telegram bot-to-bot command mention gate"
```

Recent main had Telegram ingress/media churn, but I did not find a merged/shared default that already treats `bot_command` entities addressed to the current bot as explicit mentions. This patch stays inside the existing `hasBotMention()` helper boundary so `resolveTelegramInboundBody()` and the pre-download media skip path share the same mention signal.



## Maintainer proof refresh
Behavior addressed: Telegram group messages addressed as `/command@TargetBot` now satisfy `requireMention` for the current bot before message/media handling.
Real environment tested: local Node 24.15.0 focused Telegram body/helper tests.
Exact steps or command run after this patch: `CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 fnm exec --using v24.15.0 -- node scripts/run-vitest.mjs run extensions/telegram/src/bot/helpers.test.ts extensions/telegram/src/bot-message-context.body.test.ts extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts --reporter=dot --pool=forks --no-file-parallelism`
Evidence after fix: 3 files, 104 tests passed.
Observed result after fix: targeted bot-command text and captions are treated as explicit mentions for this bot, while commands addressed to other bots remain ignored.
What was not tested: a live Telegram group message; existing Mantis Telegram visible proof remains supplied on the PR.
