### PR TITLE
fix(agents): add missing DeepSeek V4 proxy models to reasoning_content replay set

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -7680,6 +7680,32 @@ describe("buildOpenAICompletionsParams sanitizes reasoning replay fields", () =>
     baseUrl: "https://api.kimi.com/coding/v1",
   } satisfies Model<"openai-completions">;
 
+  const customDeepSeekProxyModel = {
+    id: "deepseek-v4-flash-free",
+    name: "DeepSeek V4 Flash Free",
+    api: "openai-completions",
+    provider: "opencode-go-extras",
+    baseUrl: "https://proxy.example.com/v1",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 64_000,
+    maxTokens: 8000,
+  } satisfies Model<"openai-completions">;
+
+  const customBigPickleProxyModel = {
+    id: "big-pickle",
+    name: "Big Pickle",
+    api: "openai-completions",
+    provider: "custom-openai-proxy",
+    baseUrl: "https://another-proxy.example.com/v1",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 16_000,
+  } satisfies Model<"openai-completions">;
+
   function getAssistantMessage(params: { messages: unknown }) {
     expect(Array.isArray(params.messages)).toBe(true);
     const list = params.messages as Array<Record<string, unknown>>;
@@ -7893,6 +7919,28 @@ describe("buildOpenAICompletionsParams sanitizes reasoning replay fields", () =>
   it("preserves reasoning_content replay for Kimi Coding OpenAI-compatible routes", () => {
     const assistant = getAssistantMessage(
       buildReplayParams(kimiCodingProxyModel, "reasoning_content"),
+    );
+
+    expect(assistant.reasoning_content).toBe("Need to answer politely.");
+    expect(assistant).not.toHaveProperty("reasoning_details");
+    expect(assistant).not.toHaveProperty("reasoning");
+    expect(assistant).not.toHaveProperty("reasoning_text");
+  });
+
+  it("preserves reasoning_content replay for DeepSeek V4 Flash Free via proxy", () => {
+    const assistant = getAssistantMessage(
+      buildReplayParams(customDeepSeekProxyModel, "reasoning_content"),
+    );
+
+    expect(assistant.reasoning_content).toBe("Need to answer politely.");
+    expect(assistant).not.toHaveProperty("reasoning_details");
+    expect(assistant).not.toHaveProperty("reasoning");
+    expect(assistant).not.toHaveProperty("reasoning_text");
+  });
+
+  it("preserves reasoning_content replay for Big Pickle via proxy", () => {
+    const assistant = getAssistantMessage(
+      buildReplayParams(customBigPickleProxyModel, "reasoning_content"),
     );
 
     expect(assistant.reasoning_content).toBe("Need to answer politely.");

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -3372,7 +3372,9 @@ function sanitizeReasoningContentReplayFields(record: Record<string, unknown>): 
 
 const REASONING_CONTENT_REPLAY_MODEL_IDS = new Set([
   "deepseek-v4-flash",
+  "deepseek-v4-flash-free",
   "deepseek-v4-pro",
+  "big-pickle",
   "kimi-for-coding",
   "kimi-k2.5",
   "kimi-k2.6",

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -369,6 +369,10 @@ describe("resolveTranscriptPolicy", () => {
     "hf:moonshotai/kimi-k2-thinking",
     "xiaomi/mimo-v2.6-pro",
     "xiaomi/mimo-v2.6-pro:cloud",
+    "deepseek-v4-flash",
+    "deepseek-v4-flash-free",
+    "deepseek-v4-pro",
+    "big-pickle",
   ])(
     "preserves historical reasoning for %s replay-required OpenAI-compatible models",
     (modelId) => {

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -167,6 +167,10 @@ function buildUnownedProviderTransportReplayFallback(params: {
 }
 
 const REASONING_CONTENT_REPLAY_MODEL_IDS = new Set([
+  "deepseek-v4-flash",
+  "deepseek-v4-flash-free",
+  "deepseek-v4-pro",
+  "big-pickle",
   "kimi-for-coding",
   "kimi-k2.5",
   "kimi-k2.6",


### PR DESCRIPTION
## Summary
- proxy providers like OpenCode Zen can expose DeepSeek V4 models through `opencode-native`, so endpoint-class detection alone does not preserve `reasoning_content` replay
- add `deepseek-v4-flash-free` and `big-pickle` to the replay model allowlist in both transport and transcript policy paths
- add regression coverage for both model IDs through the proxy-compatible path

Fixes #86521

## Focused test output
### Windows local run
- PR head: `b23cbd1363c49af98933489fbf94e3c173b78846`
- Command:
  `node scripts/test-projects.mjs src/agents/openai-transport-stream.test.ts src/agents/transcript-policy.test.ts`
- Result:
  - `Test Files  2 passed (2)`
  - `Tests  243 passed (243)`
  - `Duration  3.13s`
  - Harness summary: `[test] passed 1 Vitest shard in 6.58s`

### WSL / Ubuntu 24.04 run
- Environment: WSL2 `Ubuntu-24.04`, Node `v24.16.0`
- Command:
  `node scripts/test-projects.mjs src/agents/openai-transport-stream.test.ts src/agents/transcript-policy.test.ts`
- Result:
  - `Test Files 2 passed (2)`
  - `Tests 243 passed (243)`
  - `Duration 4.80s`
  - Harness summary: `[test] passed 1 Vitest shard in 8.15s`

## Live proof
Pending contributor live proof from the affected proxy surface. Planned proof update will include:
- exact environment used
- real proxy/provider route exercised
- before/after symptom evidence for tool-call continuation
- observed result after the patch
- any remaining proof gaps