### PR TITLE
fix(codex): retire MCP app-server helpers

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -211,6 +211,7 @@ import {
   writeCodexAppServerBinding,
   type CodexAppServerThreadBinding,
 } from "./session-binding.js";
+import { retireSharedCodexAppServerClientIfCurrent } from "./shared-client.js";
 import { rotateOversizedCodexAppServerStartupBinding } from "./startup-binding.js";
 import {
   buildDeveloperInstructions,
@@ -2508,6 +2509,9 @@ export async function runCodexAppServerAttempt(
     notificationCleanup();
     requestCleanup();
     closeCleanup?.();
+    if (shouldRetireCodexAppServerClientAfterTurn(thread, appServer)) {
+      retireSharedCodexAppServerClientIfCurrent(client);
+    }
     releaseSharedClientLeaseOnce();
     if (nativeHookRelay) {
       if (shouldDelayNativeHookRelayUnregister) {
@@ -2528,6 +2532,13 @@ export async function runCodexAppServerAttempt(
     steeringQueueRef.current?.cancel();
     clearActiveEmbeddedRun(params.sessionId, handle, params.sessionKey);
   }
+}
+
+function shouldRetireCodexAppServerClientAfterTurn(
+  thread: CodexAppServerThreadLifecycleBinding,
+  appServer: CodexAppServerRuntimeOptions,
+): boolean {
+  return appServer.start.transport === "stdio" && thread.userMcpServersFingerprint !== undefined;
 }
 
 function readDynamicToolCallParams(


### PR DESCRIPTION
## Summary
- Rebase onto current `origin/main` after the shared Codex app-server lease API landed upstream.
- Retire stdio shared app-server clients after a completed turn that projected user MCP servers, using the existing `retireSharedCodexAppServerClientIfCurrent` lifecycle path.
- Preserve active shared-client leases until normal cleanup releases them, so concurrent runs are not interrupted while idle MCP-backed helpers stop being retained for reuse.

## Verification
- `pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/shared-client.test.ts extensions/codex/src/app-server/attempt-client-cleanup.test.ts`
- `node scripts/run-oxlint.mjs extensions/codex/src/app-server/run-attempt.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/codex/src/app-server/run-attempt.ts`
- `git diff --check origin/main...HEAD`
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo && node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`

Additional note: `node scripts/run-vitest.mjs extensions/codex/src/app-server/shared-client.test.ts extensions/codex/src/app-server/attempt-client-cleanup.test.ts extensions/codex/src/app-server/run-attempt.test.ts` currently fails one `run-attempt.test.ts` assertion in `passes session plugin app policy context to elicitation handling` (`pluginName` is `undefined` instead of `google-calendar`). That assertion happens before this PR's new cleanup line can run, so it is tracked as unrelated current-main drift rather than this patch's behavior.

CI is rerunning for refreshed head `89c98534847ed17257ffc2d3f15f81415f2c22c9`.

## Real Behavior Proof
Behavior addressed: Completed Codex app-server turns that start projected user MCP stdio servers no longer leave MCP-backed shared app-server clients eligible for indefinite reuse after the turn finishes.

Real environment tested: Ash macOS OpenClaw workspace with the live Codex app-server/Linear MCP setup from TRR-25, plus the refreshed PR branch rebased onto current `origin/main`.

Exact steps or command run after this patch: Rebased the PR onto current `origin/main`, resolved the stale shared-client API conflicts onto the existing lease/retire API, then ran the Verification commands listed above. I also made a read-only live stdio MCP call with `mcporter call linear-stdio.get_user query=me --output json` from the same OpenClaw workspace.

Evidence after fix: Terminal capture from the refreshed PR branch and local OpenClaw MCP setup:

```text
$ git rev-parse --short HEAD && git status --short --branch
89c9853484
## ash/trr-25-fix-codex-linear-mcp-helper-lifecycle-leaks...fork/ash/trr-25-fix-codex-linear-mcp-helper-lifecycle-leaks

$ node scripts/run-vitest.mjs extensions/codex/src/app-server/shared-client.test.ts extensions/codex/src/app-server/attempt-client-cleanup.test.ts
[test] starting test/vitest/vitest.extension-codex.config.ts

 RUN  v4.1.7 /Users/ash/.openclaw/workspace/repos/openclaw

 Test Files  2 passed (2)
      Tests  22 passed (22)
   Start at  09:00:46
   Duration  5.09s (transform 1.38s, setup 80ms, import 2.06s, tests 2.89s, environment 0ms)

[test] passed 1 Vitest shard in 7.78s

$ mcporter call linear-stdio.get_user query=me --output json
{
  "id": "fa3157a6-7c0a-43d9-9af1-8b45a09e799d",
  "name": "ash",
  "email": "emergentash@gmail.com",
  "displayName": "ash",
  "isAdmin": true,
  "isGuest": false,
  "isActive": true,
  "teams": ["the ready room", "fontjot", "lodestone", "byword"]
}
```

Observed result after fix: The branch now exercises the cleanup path that retires MCP-backed stdio shared app-server clients after a completed turn, while the passing cleanup shard verifies retired clients stay alive while leases are active and close once leases release. The live Linear MCP stdio call still succeeds in Ash's OpenClaw workspace after the branch refresh.

What was not tested: I did not restart a production installed OpenClaw runtime from this refreshed branch under concurrent real user traffic. The old bridge helper proof command path from the earlier investigation is no longer present in this checkout, and the broad `run-attempt.test.ts` shard has the unrelated Google Calendar plugin-policy assertion described above.

Linear: https://linear.app/picardandelaine/issue/TRR-25/fix-codex-linear-mcp-helper-lifecycle-leaks
