### PR TITLE
fix(security): audit Claude permission overrides under YOLO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Docs: https://docs.openclaw.ai
 - Tests: sample the Windows kitchen-sink RPC gateway directly and serialize RSS probes so native runs keep the memory guard active.
 - Tests: normalize bundled plugin lifecycle probe paths and state-root lookup so native Windows release sweeps accept valid packaged plugin installs.
 - Agents/Claude CLI: route live native Bash permission requests through OpenClaw exec policy so Claude turns no longer stall on `control_request`, and document that OpenClaw exec policy is authoritative. Fixes #80819. (#86330, from #81971) Thanks @guthirry and @sallyom.
+- Security audit: warn when YOLO OpenClaw exec policy overrides a restrictive raw Claude `--permission-mode` for managed live sessions. (#86557) Thanks @sallyom.
 - Config: keep benign legacy metadata write anomalies out of default doctor and config command output while preserving explicit anomaly logging for diagnostics.
 - Codex: log when implicit app-server `never` approvals are promoted for OpenClaw tool policy, including whether the trigger was a `before_tool_call` hook or trusted tool policy.
 - Codex harness: make subscription usage-limit errors without reset times explain that OpenClaw cannot determine the reset and point users to wait until Codex is available, use another Codex account, or switch to another configured model/provider. Thanks @amknight.

--- a/src/security/audit-exec-surface.test.ts
+++ b/src/security/audit-exec-surface.test.ts
@@ -12,7 +12,8 @@ function hasFinding(
     | "tools.exec.allowlist_interpreter_without_strict_inline_eval"
     | "security.exposure.open_channels_with_exec"
     | "tools.exec.security_full_configured"
-    | "tools.exec.fs_tools_disabled_but_exec_enabled",
+    | "tools.exec.fs_tools_disabled_but_exec_enabled"
+    | "agents.claude_cli.permission_mode_overridden_by_yolo",
   severity: "warn" | "critical",
   findings: ReturnType<typeof collectExecRuntimeFindings>,
 ) {
@@ -97,6 +98,138 @@ describe("security audit exec surface findings", () => {
     expect(
       hasFinding("tools.exec.auto_allow_skills_enabled", "warn", collectExecRuntimeFindings({})),
     ).toBe(true);
+  });
+
+  it("warns when YOLO exec overrides restrictive Claude permission mode", () => {
+    const findings = collectExecRuntimeFindings({
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": {
+              command: "claude",
+              args: ["-p", "--permission-mode", "default"],
+              resumeArgs: ["-p", "--permission-mode=acceptEdits", "--resume", "{sessionId}"],
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig);
+
+    const finding = findings.find(
+      (entry) => entry.checkId === "agents.claude_cli.permission_mode_overridden_by_yolo",
+    );
+    expect(finding).toEqual(
+      expect.objectContaining({
+        severity: "warn",
+        detail: expect.stringContaining("args=default"),
+        remediation: expect.stringContaining("tools.exec.security"),
+      }),
+    );
+    expect(finding?.detail).toContain("resumeArgs=acceptEdits");
+    expect(finding?.detail).toContain("OpenClaw exec is YOLO");
+  });
+
+  it("warns for normalized Claude backend keys", () => {
+    const findings = collectExecRuntimeFindings({
+      agents: {
+        defaults: {
+          cliBackends: {
+            "Anthropic-CLI": {
+              command: "claude",
+              args: ["-p", "--permission-mode", "default"],
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig);
+
+    expect(
+      hasFinding("agents.claude_cli.permission_mode_overridden_by_yolo", "warn", findings),
+    ).toBe(true);
+  });
+
+  it("prefers exact Claude backend config over duplicate normalized aliases", () => {
+    const findings = collectExecRuntimeFindings({
+      agents: {
+        defaults: {
+          cliBackends: {
+            "Anthropic-CLI": {
+              command: "claude",
+              args: ["-p", "--permission-mode", "default"],
+            },
+            "claude-cli": {
+              command: "claude",
+              args: ["-p"],
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig);
+
+    expect(
+      hasFinding("agents.claude_cli.permission_mode_overridden_by_yolo", "warn", findings),
+    ).toBe(false);
+  });
+
+  it("does not warn for restrictive Claude permission mode when OpenClaw exec is restrictive", () => {
+    const findings = collectExecRuntimeFindings({
+      tools: { exec: { security: "allowlist", ask: "on-miss" } },
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": {
+              command: "claude",
+              args: ["-p", "--permission-mode", "default"],
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig);
+
+    expect(
+      hasFinding("agents.claude_cli.permission_mode_overridden_by_yolo", "warn", findings),
+    ).toBe(false);
+  });
+
+  it("does not warn when sandbox host defaults make exec restrictive", () => {
+    const findings = collectExecRuntimeFindings({
+      tools: { exec: { host: "sandbox" } },
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": {
+              command: "claude",
+              args: ["-p", "--permission-mode", "default"],
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig);
+
+    expect(
+      hasFinding("agents.claude_cli.permission_mode_overridden_by_yolo", "warn", findings),
+    ).toBe(false);
+  });
+
+  it("does not warn for restrictive Claude permission mode on non-live backend configs", () => {
+    const findings = collectExecRuntimeFindings({
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": {
+              command: "claude",
+              output: "json",
+              input: "arg",
+              args: ["--permission-mode", "default"],
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig);
+
+    expect(
+      hasFinding("agents.claude_cli.permission_mode_overridden_by_yolo", "warn", findings),
+    ).toBe(false);
   });
 
   it("warns when interpreter allowlists are present without strictInlineEval", () => {

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -616,7 +616,9 @@ function collectRestrictiveClaudePermissionModeHits(
   return hits;
 }
 
-function isManagedClaudeLiveBackendConfig(backend: CliBackendConfig | undefined): boolean {
+function isManagedClaudeLiveBackendConfig(
+  backend: CliBackendConfig | undefined,
+): backend is CliBackendConfig {
   if (!backend) {
     return false;
   }

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -1,13 +1,22 @@
 import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { resolveExecDefaults } from "../agents/exec-defaults.js";
+import { normalizeProviderId } from "../agents/provider-id.js";
 import { resolveSandboxConfigForAgent } from "../agents/sandbox/config.js";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/config.js";
 import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
+import type { CliBackendConfig } from "../config/types.agent-defaults.js";
 import type { GatewayAuthConfig } from "../config/types.gateway.js";
 import type { SecurityAuditSuppression } from "../config/types.openclaw.js";
 import { isInterpreterLikeAllowlistPattern } from "../infra/command-analysis/inline-eval.js";
-import { type ExecApprovalsFile, loadExecApprovals } from "../infra/exec-approvals.js";
+import {
+  type ExecApprovalsFile,
+  loadExecApprovals,
+  maxAsk,
+  minSecurity,
+  resolveExecApprovalsFromFile,
+} from "../infra/exec-approvals.js";
 import {
   listInterpreterLikeSafeBins,
   resolveMergedSafeBinProfileFixtures,
@@ -42,6 +51,10 @@ type SecurityAuditExplicitGatewayAuth = {
   password?: string;
 };
 type SecurityAuditGatewayAuthOverride = Pick<GatewayAuthConfig, "mode" | "token" | "password">;
+type ClaudePermissionModeHit = {
+  argSet: "args" | "resumeArgs";
+  mode: string;
+};
 
 export type {
   SecurityAuditFinding,
@@ -559,6 +572,113 @@ export function collectElevatedFindings(cfg: OpenClawConfig): SecurityAuditFindi
   return findings;
 }
 
+const CLAUDE_PERMISSION_MODE_FLAG = "--permission-mode";
+const CLAUDE_BYPASS_PERMISSION_MODE = "bypassPermissions";
+
+function extractClaudePermissionMode(args: readonly string[] | undefined): string | undefined {
+  if (!Array.isArray(args)) {
+    return undefined;
+  }
+  for (let i = args.length - 1; i >= 0; i -= 1) {
+    const arg = args[i] ?? "";
+    if (arg === CLAUDE_PERMISSION_MODE_FLAG) {
+      const value = args[i + 1];
+      if (typeof value === "string" && value.trim().length > 0 && !value.startsWith("-")) {
+        return value.trim();
+      }
+      continue;
+    }
+    if (arg.startsWith(`${CLAUDE_PERMISSION_MODE_FLAG}=`)) {
+      const value = arg.slice(`${CLAUDE_PERMISSION_MODE_FLAG}=`.length).trim();
+      if (value.length > 0 && !value.startsWith("-")) {
+        return value;
+      }
+    }
+  }
+  return undefined;
+}
+
+function collectRestrictiveClaudePermissionModeHits(
+  backend: CliBackendConfig | undefined,
+): ClaudePermissionModeHit[] {
+  if (!isManagedClaudeLiveBackendConfig(backend)) {
+    return [];
+  }
+  const hits: ClaudePermissionModeHit[] = [];
+  const argsMode = extractClaudePermissionMode(backend.args);
+  if (argsMode && argsMode !== CLAUDE_BYPASS_PERMISSION_MODE) {
+    hits.push({ argSet: "args", mode: argsMode });
+  }
+  const resumeArgsMode = extractClaudePermissionMode(backend.resumeArgs);
+  if (resumeArgsMode && resumeArgsMode !== CLAUDE_BYPASS_PERMISSION_MODE) {
+    hits.push({ argSet: "resumeArgs", mode: resumeArgsMode });
+  }
+  return hits;
+}
+
+function isManagedClaudeLiveBackendConfig(backend: CliBackendConfig | undefined): boolean {
+  if (!backend) {
+    return false;
+  }
+  const output = backend.output ?? "jsonl";
+  const input = backend.input ?? "stdin";
+  const liveSession =
+    backend.liveSession ?? (output === "jsonl" && input === "stdin" ? "claude-stdio" : undefined);
+  return liveSession === "claude-stdio" && output === "jsonl" && input === "stdin";
+}
+
+function findClaudeCliBackendConfig(
+  backends: Record<string, CliBackendConfig> | undefined,
+): CliBackendConfig | undefined {
+  if (!backends) {
+    return undefined;
+  }
+  const directKey = Object.keys(backends).find(
+    (key) => normalizeOptionalLowercaseString(key) === "claude-cli",
+  );
+  if (directKey) {
+    return backends[directKey];
+  }
+  for (const [key, backend] of Object.entries(backends)) {
+    if (normalizeProviderId(key) === "claude-cli") {
+      return backend;
+    }
+  }
+  return undefined;
+}
+
+function collectYoloExecScopeIds(cfg: OpenClawConfig, approvals: ExecApprovalsFile): string[] {
+  const agents = Array.isArray(cfg.agents?.list) ? cfg.agents.list : [];
+  return [
+    { id: DEFAULT_AGENT_ID },
+    ...agents
+      .filter(
+        (entry): entry is NonNullable<(typeof agents)[number]> =>
+          Boolean(entry) && typeof entry === "object" && typeof entry.id === "string",
+      )
+      .map((entry) => ({ id: entry.id })),
+  ]
+    .filter((entry) => {
+      const execDefaults = resolveExecDefaults({
+        cfg,
+        agentId: entry.id === DEFAULT_AGENT_ID ? undefined : entry.id,
+      });
+      const resolvedApprovals = resolveExecApprovalsFromFile({
+        file: approvals,
+        agentId: entry.id === DEFAULT_AGENT_ID ? undefined : entry.id,
+        overrides: {
+          security: execDefaults.security,
+          ask: execDefaults.ask,
+        },
+      });
+      return (
+        minSecurity(execDefaults.security, resolvedApprovals.agent.security) === "full" &&
+        maxAsk(execDefaults.ask, resolvedApprovals.agent.ask) === "off"
+      );
+    })
+    .map((entry) => entry.id);
+}
+
 export function collectExecRuntimeFindings(cfg: OpenClawConfig): SecurityAuditFinding[] {
   const findings: SecurityAuditFinding[] = [];
   const globalExecHost = cfg.tools?.exec?.host;
@@ -566,6 +686,11 @@ export function collectExecRuntimeFindings(cfg: OpenClawConfig): SecurityAuditFi
   const defaultSandboxMode = resolveSandboxConfigForAgent(cfg).mode;
   const defaultHostIsExplicitSandbox = globalExecHost === "sandbox";
   const approvals = loadExecApprovals();
+  const claudePermissionModeHits = collectRestrictiveClaudePermissionModeHits(
+    findClaudeCliBackendConfig(cfg.agents?.defaults?.cliBackends),
+  );
+  const yoloExecScopeIds =
+    claudePermissionModeHits.length > 0 ? collectYoloExecScopeIds(cfg, approvals) : [];
 
   if (defaultHostIsExplicitSandbox && defaultSandboxMode === "off") {
     findings.push({
@@ -643,6 +768,17 @@ export function collectExecRuntimeFindings(cfg: OpenClawConfig): SecurityAuditFi
           : ""),
       remediation:
         'Prefer tools.exec.security="allowlist" with ask prompts, and reserve "full" for tightly scoped break-glass agents only.',
+    });
+  }
+
+  if (claudePermissionModeHits.length > 0 && yoloExecScopeIds.length > 0) {
+    findings.push({
+      checkId: "agents.claude_cli.permission_mode_overridden_by_yolo",
+      severity: "warn",
+      title: "Claude permission mode is ignored under YOLO exec",
+      detail: `claude-cli sets ${claudePermissionModeHits.map((hit) => `${hit.argSet}=${hit.mode}`).join(", ")}, but OpenClaw exec is YOLO for: ${yoloExecScopeIds.join(", ")}. Managed Claude live sessions use --permission-mode bypassPermissions.`,
+      remediation:
+        "Restrict OpenClaw tools.exec.security/tools.exec.ask, or remove the Claude --permission-mode override.",
     });
   }
 


### PR DESCRIPTION
## Summary

- add an `openclaw security audit` warning for OpenClaw YOLO exec plus restrictive raw Claude `--permission-mode`
- keep the check scoped to OpenClaw-managed Claude live-session compatibility from #86330
- add regression coverage for the audit finding and non-YOLO suppression

## Real Behavior Proof

Using isolated `OPENCLAW_HOME` and `OPENCLAW_CONFIG_PATH` temp dirs:

- `openclaw security audit --json` with Claude `--permission-mode default` / `acceptEdits` and default OpenClaw exec emitted `agents.claude_cli.permission_mode_overridden_by_yolo`.
- The emitted detail was: `claude-cli sets args=default, resumeArgs=acceptEdits, but OpenClaw exec is YOLO for: main. Managed Claude live sessions use --permission-mode bypassPermissions.`
- The emitted remediation was: `Restrict OpenClaw tools.exec.security/tools.exec.ask, or remove the Claude --permission-mode override.`
- Re-running `openclaw security audit --json` with the same Claude permission mode but OpenClaw `tools.exec.security="allowlist"` and `tools.exec.ask="on-miss"` did not emit that finding.

## Tests

- `node scripts/run-vitest.mjs src/security/audit-exec-surface.test.ts src/agents/cli-runner.spawn.test.ts`
- `pnpm check:changelog-attributions`
- `pnpm check`
