### PR TITLE
fix(updater): exclude prerelease tags from stable git channel

### DIFF
--- a/docs/install/development-channels.md
+++ b/docs/install/development-channels.md
@@ -124,8 +124,10 @@ source (config, git tag, git branch, or default).
 ## Tagging best practices
 
 - Tag releases you want git checkouts to land on (`vYYYY.M.D` for stable,
-  `vYYYY.M.D-beta.N` for beta; semver prerelease suffixes are not stable
-  targets).
+  `vYYYY.M.D-beta.N` for beta; named semver prerelease suffixes such as
+  `-alpha.N`, `-rc.N`, and `-next.N` are not stable targets).
+- Legacy numeric stable tags such as `vYYYY.M.D-1` and `v1.0.1-1` are still
+  recognized as stable git tags for compatibility.
 - `vYYYY.M.D.beta.N` is also recognized for compatibility, but prefer `-beta.N`.
 - Keep tags immutable: never move or reuse a tag.
 - npm dist-tags remain the source of truth for npm installs:

--- a/docs/install/development-channels.md
+++ b/docs/install/development-channels.md
@@ -37,7 +37,10 @@ install method:
 - **`stable`** (package installs): updates via npm dist-tag `latest`.
 - **`beta`** (package installs): prefers npm dist-tag `beta`, but falls back to
   `latest` when `beta` is missing or older than the current stable tag.
-- **`stable`** (git installs): checks out the latest stable git tag.
+- **`stable`** (git installs): checks out the latest stable git tag, excluding
+  semver prerelease tags such as `-alpha.N`, `-beta.N`, `-rc.N`, `-dev.N`,
+  `-next.N`, `-preview.N`, `-canary.N`, `-nightly.N`, and other prerelease
+  suffixes.
 - **`beta`** (git installs): prefers the latest beta git tag, but falls back to
   the latest stable git tag when beta is missing or older.
 - **`dev`**: ensures a git checkout (default `~/openclaw`, or
@@ -121,9 +124,9 @@ source (config, git tag, git branch, or default).
 ## Tagging best practices
 
 - Tag releases you want git checkouts to land on (`vYYYY.M.D` for stable,
-  `vYYYY.M.D-beta.N` for beta).
+  `vYYYY.M.D-beta.N` for beta; semver prerelease suffixes are not stable
+  targets).
 - `vYYYY.M.D.beta.N` is also recognized for compatibility, but prefer `-beta.N`.
-- Legacy `vYYYY.M.D-<patch>` tags are still recognized as stable (non-beta).
 - Keep tags immutable: never move or reuse a tag.
 - npm dist-tags remain the source of truth for npm installs:
   - `latest` -> stable

--- a/src/infra/update-channels.test.ts
+++ b/src/infra/update-channels.test.ts
@@ -38,7 +38,8 @@ describe("update-channels tag detection", () => {
     { tag: "v2026.2.24-nightly.1", prerelease: true, stable: false },
     { tag: "v2026.2.24-experimental.1", prerelease: true, stable: false },
     { tag: "v2026.2.24-custom.1", prerelease: true, stable: false },
-    { tag: "v2026.2.24-1", prerelease: true, stable: false },
+    { tag: "v2026.2.24-1", prerelease: false, stable: true },
+    { tag: "v1.0.1-1", prerelease: false, stable: true },
     { tag: "v2026.2.24-alphabeta.1", prerelease: true, stable: false },
     { tag: "v2026.2.24", prerelease: false, stable: true },
   ])("stable/prerelease classification for $tag", ({ tag, prerelease, stable }) => {
@@ -120,6 +121,14 @@ describe("resolveEffectiveUpdateChannel", () => {
         git: { tag: "v2026.5.25-alpha.1" },
       },
       expected: { channel: "dev", source: "git-tag" },
+    },
+    {
+      name: "preserves legacy numeric stable git tags",
+      params: {
+        installKind: "git" as const,
+        git: { tag: "v1.0.1-1" },
+      },
+      expected: { channel: "stable", source: "git-tag" },
     },
     {
       name: "uses non-HEAD git branch as dev",

--- a/src/infra/update-channels.test.ts
+++ b/src/infra/update-channels.test.ts
@@ -19,6 +19,7 @@ describe("update-channels tag detection", () => {
     { tag: "v2026.2.24.beta.1", beta: true },
     { tag: "v2026.2.24-BETA-1", beta: true },
     { tag: "v2026.2.24-alpha.1", beta: false },
+    { tag: "v2026.2.24-next.1", beta: false },
     { tag: "v2026.2.24-1", beta: false },
     { tag: "v2026.2.24-alphabeta.1", beta: false },
     { tag: "v2026.2.24", beta: false },
@@ -31,7 +32,14 @@ describe("update-channels tag detection", () => {
     { tag: "v2026.2.24-beta.1", prerelease: true, stable: false },
     { tag: "v2026.2.24-rc.1", prerelease: true, stable: false },
     { tag: "v2026.2.24-preview.1", prerelease: true, stable: false },
-    { tag: "v2026.2.24-1", prerelease: false, stable: true },
+    { tag: "v2026.2.24-dev.1", prerelease: true, stable: false },
+    { tag: "v2026.2.24-next.1", prerelease: true, stable: false },
+    { tag: "v2026.2.24-canary.1", prerelease: true, stable: false },
+    { tag: "v2026.2.24-nightly.1", prerelease: true, stable: false },
+    { tag: "v2026.2.24-experimental.1", prerelease: true, stable: false },
+    { tag: "v2026.2.24-custom.1", prerelease: true, stable: false },
+    { tag: "v2026.2.24-1", prerelease: true, stable: false },
+    { tag: "v2026.2.24-alphabeta.1", prerelease: true, stable: false },
     { tag: "v2026.2.24", prerelease: false, stable: true },
   ])("stable/prerelease classification for $tag", ({ tag, prerelease, stable }) => {
     expect(isPrereleaseTag(tag)).toBe(prerelease);
@@ -101,9 +109,17 @@ describe("resolveEffectiveUpdateChannel", () => {
       name: "treats non-beta git tag as stable",
       params: {
         installKind: "git" as const,
-        git: { tag: "v2026.2.24-1" },
+        git: { tag: "v2026.2.24" },
       },
       expected: { channel: "stable", source: "git-tag" },
+    },
+    {
+      name: "treats non-beta prerelease git tag as dev",
+      params: {
+        installKind: "git" as const,
+        git: { tag: "v2026.5.25-alpha.1" },
+      },
+      expected: { channel: "dev", source: "git-tag" },
     },
     {
       name: "uses non-HEAD git branch as dev",

--- a/src/infra/update-channels.ts
+++ b/src/infra/update-channels.ts
@@ -41,7 +41,7 @@ export function isBetaTag(tag: string): boolean {
 export function isPrereleaseTag(tag: string): boolean {
   const parsed = parseComparableSemver(tag, { normalizeLegacyDotBeta: true });
   if (parsed) {
-    return Boolean(parsed.prerelease?.length);
+    return Boolean(parsed.prerelease?.some((part) => !/^[0-9]+$/.test(part)));
   }
   return /(?:^|[.-])(alpha|beta|rc|pre|preview|canary|dev|next|nightly|experimental)(?:[.-]|$)/i.test(
     tag,

--- a/src/infra/update-channels.ts
+++ b/src/infra/update-channels.ts
@@ -1,4 +1,5 @@
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
+import { parseComparableSemver } from "./semver-compare.js";
 
 export type UpdateChannel = "stable" | "beta" | "dev";
 export type UpdateChannelSource =
@@ -38,7 +39,13 @@ export function isBetaTag(tag: string): boolean {
 }
 
 export function isPrereleaseTag(tag: string): boolean {
-  return /(?:^|[.-])(alpha|beta|rc|pre|preview|canary|dev)(?:[.-]|$)/i.test(tag);
+  const parsed = parseComparableSemver(tag, { normalizeLegacyDotBeta: true });
+  if (parsed) {
+    return Boolean(parsed.prerelease?.length);
+  }
+  return /(?:^|[.-])(alpha|beta|rc|pre|preview|canary|dev|next|nightly|experimental)(?:[.-]|$)/i.test(
+    tag,
+  );
 }
 
 export function isStableTag(tag: string): boolean {
@@ -82,7 +89,10 @@ export function resolveEffectiveUpdateChannel(params: {
   if (params.installKind === "git") {
     const tag = params.git?.tag;
     if (tag) {
-      return { channel: isBetaTag(tag) ? "beta" : "stable", source: "git-tag" };
+      return {
+        channel: isBetaTag(tag) ? "beta" : isStableTag(tag) ? "stable" : "dev",
+        source: "git-tag",
+      };
     }
     const branch = params.git?.branch;
     if (branch && branch !== "HEAD") {


### PR DESCRIPTION
## Summary

- classify named semver prerelease git tags as non-stable when deriving the effective update channel
- keep beta git tags on the beta channel and keep legacy numeric stable git tags like `vYYYY.M.D-1` / `v1.0.1-1` stable for compatibility
- update release-channel docs and focused tests for named prerelease vs legacy numeric stable tag handling

## Verification

- `node --import tsx --input-type=module <<'EOF' ... EOF` direct update-channel probe passed: `update-channel legacy numeric stable probe passed (8 tags, 24 assertions)`
- `node --import tsx --input-type=module <<'EOF' ... EOF` real git update/status probe passed; output copied below in Real behavior proof
- `git diff --check` passed
- `pnpm docs:list` passed
- `.agents/skills/autoreview/scripts/autoreview --mode local` passed: `autoreview clean: no accepted/actionable findings reported`
- `timeout 120s node scripts/run-vitest.mjs src/infra/update-channels.test.ts --reporter=verbose` timed out locally with no Vitest output in this Codex worktree; the same no-output local runner hang was seen before this repair, so the pushed CI infra shard is the CI-equivalent Vitest proof for `src/infra/update-runner.test.ts`

## Real behavior proof

Behavior addressed: Git update/status channel resolution now preserves legacy numeric stable tags such as `v1.0.1-1` and `vYYYY.M.D-1` as stable, while named prerelease tags such as `-alpha`, `-rc`, `-next`, and non-beta prerelease tags are excluded from stable. Beta channel handling still allows beta tags and falls back to a compatible stable tag when beta is older.

Real environment tested: Local Codex worktree on Linux using real temporary git repositories and the real `runGatewayUpdate` path. The probe used actual `git init`, `git tag`, `git status --porcelain -- :!dist/control-ui/`, and `git checkout --detach` commands. Install/build/doctor commands were stubbed to avoid mutating live dist or restarting the gateway.

Exact steps or command run after this patch: `node --import tsx --input-type=module <<'EOF' ... EOF` importing `src/infra/update-runner.ts`, creating temporary git repositories with stable, beta, and named prerelease tags, and running `runGatewayUpdate({ channel: "stable" | "beta" })`.

Evidence after fix:

```text
legacy-numeric-stable: status=ok
legacy-numeric-stable: git -C /tmp/openclaw-update-proof-legacy-numeric-stable-5LqxHq status --porcelain -- :!dist/control-ui/
legacy-numeric-stable: git -C /tmp/openclaw-update-proof-legacy-numeric-stable-5LqxHq checkout --detach v1.0.1-1
named-prerelease-only: status=error reason=no-release-tag
named-prerelease-only: git -C /tmp/openclaw-update-proof-named-prerelease-only-TfN0kf status --porcelain -- :!dist/control-ui/
named-prerelease-only: <none>
beta-falls-back-to-legacy-stable: status=ok
beta-falls-back-to-legacy-stable: git -C /tmp/openclaw-update-proof-beta-falls-back-to-legacy-stable-e962Gh status --porcelain -- :!dist/control-ui/
beta-falls-back-to-legacy-stable: git -C /tmp/openclaw-update-proof-beta-falls-back-to-legacy-stable-e962Gh checkout --detach v1.0.1-1
git update/status channel proof passed
```

Observed result after fix: Stable git updates checked status, ignored the newer named prerelease tag, and checked out the legacy numeric stable tag `v1.0.1-1`. A repository containing only a named alpha prerelease returned `no-release-tag` for stable and performed no checkout. Beta-channel update fell back to the legacy numeric stable tag when the beta tag was older.

What was not tested: The local Vitest wrapper timed out without output in this Codex worktree, so focused Vitest proof is left to the pushed GitHub Actions `checks-node-core-runtime-infra-state` rerun on Linux/Node 24.
