### PR TITLE
feat(zalouser): add groupLink action to fetch a group's invite link

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -7964,6 +7964,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Config
   - H2: CLI
   - H2: Agent tool
+  - H3: groupLink
   - H2: Related
 
 ## plugins/zoom-meetings.md

--- a/docs/plugins/zalouser.md
+++ b/docs/plugins/zalouser.md
@@ -83,7 +83,24 @@ openclaw directory groups members --channel zalouser --group-id <id>
 
 Tool name: `zalouser`
 
-Actions: `send`, `image`, `link`, `friends`, `groups`, `me`, `status`
+Actions: `send`, `image`, `link`, `friends`, `groups`, `groupLink`, `me`, `status`
+
+### `groupLink`
+
+Fetches the invite link of a group the account is a member of (admin rights are
+not required). `threadId` is the group id. Returns the current link state, e.g.
+`{ "enabled": true, "link": "https://zalo.me/g/..." }`, or `{ "enabled": false }`
+when link sharing is turned off for the group.
+
+<Warning>
+Group invite links are shareable join URLs for private groups. Granting the
+`zalouser` tool to an agent includes this read capability - anyone the agent
+relays the link to can join the group while the link stays enabled. Group tool
+policy (`tools.allow` / `tools.deny`) is tool-name scoped, so it cannot
+allow the rest of the tool while blocking `groupLink` alone. If that exposure
+is not acceptable for a deployment, deny the whole `zalouser` tool in the
+affected groups.
+</Warning>
 
 Channel message actions (not the agent tool) also support `react` for message
 reactions.

--- a/extensions/zalouser/src/tool.test.ts
+++ b/extensions/zalouser/src/tool.test.ts
@@ -4,6 +4,7 @@ import { sendImageZalouser, sendLinkZalouser, sendMessageZalouser } from "./send
 import { createZalouserTool } from "./tool.js";
 import {
   checkZaloAuthenticated,
+  getZaloGroupInviteLink,
   getZaloUserInfo,
   listZaloFriendsMatching,
   listZaloGroupsMatching,
@@ -18,6 +19,7 @@ vi.mock("./send.js", () => ({
 
 vi.mock("./zalo-js.js", () => ({
   checkZaloAuthenticated: vi.fn(),
+  getZaloGroupInviteLink: vi.fn(),
   getZaloUserInfo: vi.fn(),
   listZaloFriendsMatching: vi.fn(),
   listZaloGroupsMatching: vi.fn(),
@@ -30,6 +32,7 @@ const mockCheckAuth = vi.mocked(checkZaloAuthenticated);
 const mockGetUserInfo = vi.mocked(getZaloUserInfo);
 const mockListFriends = vi.mocked(listZaloFriendsMatching);
 const mockListGroups = vi.mocked(listZaloGroupsMatching);
+const mockGetGroupLink = vi.mocked(getZaloGroupInviteLink);
 
 function extractDetails(result: { content?: Array<{ type: string; text?: string }> }): unknown {
   const text = result.content?.[0]?.text ?? "{}";
@@ -52,6 +55,31 @@ describe("executeZalouserTool", () => {
     mockGetUserInfo.mockReset();
     mockListFriends.mockReset();
     mockListGroups.mockReset();
+    mockGetGroupLink.mockReset();
+  });
+
+  it("returns the group invite link for groupLink action", async () => {
+    mockGetGroupLink.mockResolvedValueOnce({
+      link: "https://zalo.me/g/abc123",
+      expiresAt: 1799999999,
+    } as never);
+    const result = await executeZalouserTool("tool-1", {
+      action: "groupLink",
+      threadId: "g-1",
+      profile: "work",
+    });
+    expect(mockGetGroupLink).toHaveBeenCalledWith("work", "g-1");
+    expect(extractDetails(result)).toEqual({
+      link: "https://zalo.me/g/abc123",
+      expiresAt: 1799999999,
+    });
+  });
+
+  it("returns error when groupLink action is missing the group id", async () => {
+    const result = await executeZalouserTool("tool-1", { action: "groupLink" });
+    expect(extractDetails(result)).toEqual({
+      error: "threadId (group id) required for groupLink action",
+    });
   });
 
   it("returns error when send action is missing required fields", async () => {

--- a/extensions/zalouser/src/tool.test.ts
+++ b/extensions/zalouser/src/tool.test.ts
@@ -62,6 +62,7 @@ describe("executeZalouserTool", () => {
     mockGetGroupLink.mockResolvedValueOnce({
       link: "https://zalo.me/g/abc123",
       expiresAt: 1799999999,
+      enabled: true,
     } as never);
     const result = await executeZalouserTool("tool-1", {
       action: "groupLink",
@@ -72,7 +73,19 @@ describe("executeZalouserTool", () => {
     expect(extractDetails(result)).toEqual({
       link: "https://zalo.me/g/abc123",
       expiresAt: 1799999999,
+      enabled: true,
     });
+  });
+
+  it("reports disabled state when the group link is not enabled", async () => {
+    mockGetGroupLink.mockResolvedValueOnce({ enabled: false } as never);
+    const result = await executeZalouserTool("tool-1", {
+      action: "groupLink",
+      threadId: "g-1",
+      profile: "work",
+    });
+    expect(mockGetGroupLink).toHaveBeenCalledWith("work", "g-1");
+    expect(extractDetails(result)).toEqual({ enabled: false });
   });
 
   it("returns error when groupLink action is missing the group id", async () => {

--- a/extensions/zalouser/src/tool.ts
+++ b/extensions/zalouser/src/tool.ts
@@ -8,12 +8,22 @@ import { sendImageZalouser, sendLinkZalouser, sendMessageZalouser } from "./send
 import { parseZalouserOutboundTarget } from "./session-route.js";
 import {
   checkZaloAuthenticated,
+  getZaloGroupInviteLink,
   getZaloUserInfo,
   listZaloFriendsMatching,
   listZaloGroupsMatching,
 } from "./zalo-js.js";
 
-const ACTIONS = ["send", "image", "link", "friends", "groups", "me", "status"] as const;
+const ACTIONS = [
+  "send",
+  "image",
+  "link",
+  "friends",
+  "groups",
+  "groupLink",
+  "me",
+  "status",
+] as const;
 
 const ZalouserToolSchema = Type.Object(
   {
@@ -148,6 +158,16 @@ async function executeZalouserTool(
         return json(rows);
       }
 
+      case "groupLink": {
+        const target = resolveZalouserSendTarget(params, context);
+        const groupId = target.threadId;
+        if (!groupId) {
+          throw new Error("threadId (group id) required for groupLink action");
+        }
+        const result = await getZaloGroupInviteLink(params.profile, groupId);
+        return json(result);
+      }
+
       case "me": {
         const info = await getZaloUserInfo(params.profile);
         return json(info ?? { error: "Not authenticated" });
@@ -164,7 +184,7 @@ async function executeZalouserTool(
       default: {
         params.action satisfies never;
         throw new Error(
-          `Unknown action: ${String(params.action)}. Valid actions: send, image, link, friends, groups, me, status`,
+          `Unknown action: ${String(params.action)}. Valid actions: send, image, link, friends, groups, groupLink, me, status`,
         );
       }
     }

--- a/extensions/zalouser/src/tool.ts
+++ b/extensions/zalouser/src/tool.ts
@@ -202,7 +202,8 @@ export function createZalouserTool(context?: ZalouserToolContext): AnyAgentTool 
     description:
       "Send messages and access data via Zalo personal account. " +
       "Actions: send (text message), image (send image URL), link (send link), " +
-      "friends (list/search friends), groups (list groups), me (profile info), status (auth check).",
+      "friends (list/search friends), groups (list groups), " +
+      "groupLink (read a group's invite link), me (profile info), status (auth check).",
     parameters: ZalouserToolSchema,
     execute: async (toolCallId, params, signal, onUpdate) =>
       await executeZalouserTool(toolCallId, params as ToolParams, signal, onUpdate, context),

--- a/extensions/zalouser/src/zalo-js.ts
+++ b/extensions/zalouser/src/zalo-js.ts
@@ -1060,19 +1060,24 @@ export async function listZaloGroupsMatching(
 }
 
 /**
- * Returns a shareable invite link for a group. Zalo only exposes a link once it
- * is enabled, so this enables it (idempotent on Zalo's side) and returns the
- * link plus its expiry. The caller (e.g. a CS hand-off) can share it so staff
- * can reach the customer's group.
+ * Reads the shareable invite link for a group. Any group member can read the
+ * link once a group admin has enabled it in Zalo's group settings - no admin
+ * rights are required for this call. When the link has not been enabled,
+ * `enabled` is false and `link` is undefined. The caller (e.g. a CS hand-off)
+ * can share the link so staff can reach the customer's group.
  */
 export async function getZaloGroupInviteLink(
   profileInput: string | null | undefined,
   groupId: string,
-): Promise<{ link: string; expiresAt?: number }> {
+): Promise<{ link?: string; expiresAt?: number; enabled: boolean }> {
   const profile = normalizeProfile(profileInput);
   return await withZaloApi(profile, async (api) => {
-    const res = await api.enableGroupLink(groupId);
-    return { link: res.link, expiresAt: res.expiration_date || undefined };
+    const res = await api.getGroupLinkDetail(groupId);
+    return {
+      link: res.link || undefined,
+      expiresAt: res.expiration_date || undefined,
+      enabled: res.enabled === 1,
+    };
   });
 }
 

--- a/extensions/zalouser/src/zalo-js.ts
+++ b/extensions/zalouser/src/zalo-js.ts
@@ -1059,6 +1059,23 @@ export async function listZaloGroupsMatching(
   });
 }
 
+/**
+ * Returns a shareable invite link for a group. Zalo only exposes a link once it
+ * is enabled, so this enables it (idempotent on Zalo's side) and returns the
+ * link plus its expiry. The caller (e.g. a CS hand-off) can share it so staff
+ * can reach the customer's group.
+ */
+export async function getZaloGroupInviteLink(
+  profileInput: string | null | undefined,
+  groupId: string,
+): Promise<{ link: string; expiresAt?: number }> {
+  const profile = normalizeProfile(profileInput);
+  return await withZaloApi(profile, async (api) => {
+    const res = await api.enableGroupLink(groupId);
+    return { link: res.link, expiresAt: res.expiration_date || undefined };
+  });
+}
+
 export async function listZaloGroupMembers(
   profileInput: string | null | undefined,
   groupId: string,

--- a/extensions/zalouser/src/zca-client.ts
+++ b/extensions/zalouser/src/zca-client.ts
@@ -158,9 +158,9 @@ export type API = {
       }
     >;
   }>;
-  enableGroupLink(groupId: string): Promise<{
-    link: string;
-    expiration_date: number;
+  getGroupLinkDetail(groupId: string): Promise<{
+    link?: string;
+    expiration_date?: number;
     enabled: number;
   }>;
   sendMessage(

--- a/extensions/zalouser/src/zca-client.ts
+++ b/extensions/zalouser/src/zca-client.ts
@@ -158,6 +158,11 @@ export type API = {
       }
     >;
   }>;
+  enableGroupLink(groupId: string): Promise<{
+    link: string;
+    expiration_date: number;
+    enabled: number;
+  }>;
   sendMessage(
     message: string | Record<string, unknown>,
     threadId: string,


### PR DESCRIPTION
## What
Adds a `groupLink` action to the zalouser tool that returns a group's shareable invite link. The tool can already `groups` (list) and `link` (send a URL as a message), but there was no way to read a group's invite link.

## Changes
- `zca-client.ts`: add `getGroupLinkDetail(groupId)` to the `API` interface.
- `zalo-js.ts`: add `getZaloGroupInviteLink(profile, groupId)` wrapping it via `withZaloApi`, returning `{ link?, expiresAt?, enabled }`.
- `tool.ts`: add the `groupLink` action (resolves the group thread, returns the link detail).
- `tool.test.ts`: success + disabled-link + missing-group-id cases.

## Why getGroupLinkDetail (not enableGroupLink)
`enableGroupLink` toggles the invite-link feature on, which is admin-only — a regular member account gets a permission error. `getGroupLinkDetail` reads the existing link, so it works for any member once a group admin has enabled the link. When the link is not enabled the action returns `{ enabled: false }` and the caller degrades cleanly.

## Use case
Lets an agent (e.g. a customer-service hand-off flow) surface a link so a human can join the relevant group.

## Real behavior proof

Behavior or issue addressed: the groupLink action originally called the admin-only enableGroupLink, so a regular (non-admin) group member hit a Zalo permission error ("Không đủ quyền") and never got a link. After switching to the read-only getGroupLinkDetail, a non-admin member reads an already-enabled invite link.

Real environment tested: a real Zalo personal account signed in as a regular member (not an admin) of the target groups, running inside a live OpenClaw agent container. The bundled @openclaw/zalouser plugin was hot-patched on disk to mirror this branch and the gateway was restarted so the patched module loaded.

Exact steps or command run after this patch: docker exec <agent> openclaw agent --message "Call the zalouser tool with action=groupLink, threadId=<group id> and return the raw JSON result" --json — run against three real groups (two with the invite link enabled, one with it disabled), driving the patched groupLink action end-to-end through tool.ts to zalo-js to zca-js getGroupLinkDetail.

Evidence after fix: live output copied from the running container for an enabled group (invite-link token redacted; it is a real join link to a private group):
```json
{ "link": "https://zalo.me/g/<redacted>", "expiresAt": 1937494664737, "enabled": true }
```
the same openclaw groupLink call against a group whose invite link was disabled returned, with no error:
```json
{ "enabled": false }
```

Observed result after fix: across three real groups the non-admin member account read invite links via getGroupLinkDetail — two enabled groups returned valid https://zalo.me/g/<token> links with an expiry, and the disabled group returned { enabled: false }. With the previous enableGroupLink call every one of those groups returned "Không đủ quyền". The docker exec openclaw run printed the JSON shown above verbatim.

What was not tested: the admin-only enableGroupLink toggle path (out of scope — this PR is read-only); the downstream hand-off message wiring that consumes the link lives in a separate consumer, not this PR.