### PR TITLE
fix(doctor): skip gateway restart prompt during updates

### DIFF
--- a/src/commands/doctor-gateway-daemon-flow.test.ts
+++ b/src/commands/doctor-gateway-daemon-flow.test.ts
@@ -462,6 +462,26 @@ describe("maybeRepairGatewayDaemon", () => {
     );
   });
 
+  it("skips the restart prompt on macOS update repairs when the gateway is already running", async () => {
+    setPlatform("darwin");
+    process.env.OPENCLAW_UPDATE_IN_PROGRESS = "1";
+
+    const prompter = createPrompter(() => true);
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+
+    await maybeRepairGatewayDaemon({
+      cfg: { gateway: {} },
+      runtime,
+      prompter,
+      options: { deep: false, repair: true },
+      gatewayDetailsMessage: "details",
+      healthOk: false,
+    });
+
+    expect(prompter.confirmRuntimeRepair).not.toHaveBeenCalled();
+    expect(service.restart).not.toHaveBeenCalled();
+  });
+
   it("skips gateway restart during non-interactive update repairs", async () => {
     setPlatform("linux");
 

--- a/src/commands/doctor-gateway-daemon-flow.ts
+++ b/src/commands/doctor-gateway-daemon-flow.ts
@@ -388,6 +388,9 @@ export async function maybeRepairGatewayDaemon(params: {
       note(EXTERNAL_SERVICE_REPAIR_NOTE, "Gateway");
       return;
     }
+    if (process.platform === "darwin" && process.env.OPENCLAW_UPDATE_IN_PROGRESS === "1") {
+      return;
+    }
     const restart = await confirmDoctorServiceRepair(
       params.prompter,
       {


### PR DESCRIPTION
What does this PR do?
- Skips the macOS gateway restart prompt while `OPENCLAW_UPDATE_IN_PROGRESS=1` and the gateway is already running.
- Adds a regression test that ensures the restart prompt is not reached in update mode.

Root cause
- The doctor flow still asked the runtime-repair prompt for a running gateway even during update-mode repairs, which can loop on restart verification.

Fix
- Return early from the running-service branch when the platform is macOS and `OPENCLAW_UPDATE_IN_PROGRESS=1`.
- Add a test covering the skip path.

Why this shape
- Keeps normal doctor behavior unchanged outside update mode.
- Limits the fix to the update path that triggers the loop.

Tests
- `/opt/homebrew/bin/node ./node_modules/vitest/vitest.mjs run src/commands/doctor-gateway-daemon-flow.test.ts`

Related PRs / issues
- Fixes #86518