### PR TITLE
fix(gateway): skip transcript resolution for missing files

### DIFF
--- a/src/gateway/server-session-events.test.ts
+++ b/src/gateway/server-session-events.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+
+const resolveSessionKeyForTranscriptFileMock = vi.hoisted(() => vi.fn());
+const projectChatDisplayMessageMock = vi.hoisted(() => vi.fn((message: unknown) => message));
+const attachOpenClawTranscriptMetaMock = vi.hoisted(() => vi.fn((message: unknown) => message));
+const loadGatewaySessionRowMock = vi.hoisted(() => vi.fn());
+const loadSessionEntryMock = vi.hoisted(() => vi.fn());
+const readSessionMessageCountAsyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./session-transcript-key.js", () => ({
+  resolveSessionKeyForTranscriptFile: resolveSessionKeyForTranscriptFileMock,
+}));
+
+vi.mock("./chat-display-projection.js", () => ({
+  projectChatDisplayMessage: projectChatDisplayMessageMock,
+}));
+
+vi.mock("./session-utils.js", () => ({
+  attachOpenClawTranscriptMeta: attachOpenClawTranscriptMetaMock,
+  loadGatewaySessionRow: loadGatewaySessionRowMock,
+  loadSessionEntry: loadSessionEntryMock,
+  readSessionMessageCountAsync: readSessionMessageCountAsyncMock,
+}));
+
+import { createTranscriptUpdateBroadcastHandler } from "./server-session-events.js";
+
+describe("createTranscriptUpdateBroadcastHandler", () => {
+  it("does not resolve a missing transcript path without an explicit session key", async () => {
+    const broadcastToConnIds = vi.fn();
+    const sessionEventSubscribers = {
+      getAll: vi.fn(() => new Set<string>(["operator-events"])),
+    };
+    const sessionMessageSubscribers = {
+      get: vi.fn(() => new Set<string>(["operator-message"])),
+    };
+    const handler = createTranscriptUpdateBroadcastHandler({
+      broadcastToConnIds,
+      sessionEventSubscribers,
+      sessionMessageSubscribers,
+    });
+
+    handler({
+      sessionFile: `/tmp/openclaw-missing-${Date.now()}.jsonl`,
+      message: { role: "assistant", content: [{ type: "text", text: "hello" }] },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(resolveSessionKeyForTranscriptFileMock).not.toHaveBeenCalled();
+    expect(sessionEventSubscribers.getAll).not.toHaveBeenCalled();
+    expect(sessionMessageSubscribers.get).not.toHaveBeenCalled();
+    expect(loadSessionEntryMock).not.toHaveBeenCalled();
+    expect(readSessionMessageCountAsyncMock).not.toHaveBeenCalled();
+    expect(projectChatDisplayMessageMock).not.toHaveBeenCalled();
+    expect(broadcastToConnIds).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import type { SessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import type { SessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import { asPositiveSafeInteger } from "../shared/number-coercion.js";
@@ -105,7 +106,7 @@ async function handleTranscriptUpdateBroadcast(
   },
   update: SessionTranscriptUpdate,
 ): Promise<void> {
-  const sessionKey = update.sessionKey ?? resolveSessionKeyForTranscriptFile(update.sessionFile);
+  const sessionKey = update.sessionKey ?? (fs.existsSync(update.sessionFile) ? resolveSessionKeyForTranscriptFile(update.sessionFile) : undefined);
   if (!sessionKey || update.message === undefined) {
     return;
   }


### PR DESCRIPTION
What does this PR do?
- Avoids resolving a session key from a transcript path when the transcript file no longer exists.
- Adds a regression test that verifies a missing transcript path does not reach the broadcast path.

Root cause
- The transcript broadcast path still attempted to resolve a session key from stale transcript metadata even when the underlying transcript file was already gone.

Fix
- Guard transcript-key resolution with `fs.existsSync(...)` before looking up the session key.
- Add a test that calls the broadcast handler with a missing transcript file and asserts no resolution or broadcast happens.

Why this shape
- Preserves explicit `sessionKey` updates.
- Only changes the fallback path that can resurrect stale transient sessions.

Tests
- `/opt/homebrew/bin/node ./node_modules/vitest/vitest.mjs run src/gateway/server-session-events.test.ts`

Related PRs / issues
- Fixes #86505