### PR TITLE
fix(gateway): disable provider auth prewarm by default

### DIFF
--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -942,6 +942,59 @@ describe("startGatewayPostAttachRuntime", () => {
     }
   });
 
+  it("keeps provider auth failure rewarm without default startup prewarm", async () => {
+    vi.useFakeTimers();
+    const onGatewayLifetimeSidecars = vi.fn();
+    const startupCfg = { marker: "startup" } as never;
+    const afterFailureCfg = { marker: "after-failure" } as never;
+    let currentCfg = startupCfg;
+    const log = { info: vi.fn(), warn: vi.fn() };
+
+    try {
+      await startGatewayPostAttachRuntime({
+        ...createPostAttachParams(),
+        log,
+        deferSidecars: true,
+        providerAuthPrewarm: {
+          delayMs: 1_000,
+          getConfig: () => currentCfg,
+        },
+        onGatewayLifetimeSidecars,
+      });
+
+      await vi.advanceTimersToNextTimerAsync();
+      await vi.waitFor(() => {
+        expect(onGatewayLifetimeSidecars).toHaveBeenCalledTimes(1);
+      });
+      expect(onGatewayLifetimeSidecars.mock.calls[0]?.[0]).toHaveLength(1);
+      await vi.dynamicImportSettled();
+      await vi.waitFor(() => {
+        expect(hoisted.setAuthProfileFailureHook).toHaveBeenCalledTimes(1);
+      });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(hoisted.warmCurrentProviderAuthStateOffMainThread).not.toHaveBeenCalled();
+
+      const hook = hoisted.setAuthProfileFailureHook.mock.calls[0]?.[0] as (() => void) | undefined;
+      if (!hook) {
+        throw new Error("Expected provider auth failure hook to be registered");
+      }
+      currentCfg = afterFailureCfg;
+      hook();
+      expect(hoisted.clearCurrentProviderAuthState).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.waitFor(() => {
+        expect(hoisted.warmCurrentProviderAuthStateOffMainThread).toHaveBeenCalledTimes(1);
+      });
+      expect(hoisted.warmCurrentProviderAuthStateOffMainThread.mock.calls[0]?.[0]).toBe(
+        afterFailureCfg,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps provider auth prewarm alive when Gmail post-ready sidecars stop", async () => {
     vi.useFakeTimers();
     const onPostReadySidecars = vi.fn();

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -220,6 +220,7 @@ function scheduleProviderAuthStatePrewarm(params: {
     warn: (msg: string) => void;
   };
   delayMs?: number;
+  startupWarmEnabled?: boolean;
 }): GatewayPostReadySidecarHandle {
   let stopped = false;
   let startupTimer: ReturnType<typeof setTimeout> | undefined;
@@ -285,29 +286,31 @@ function scheduleProviderAuthStatePrewarm(params: {
       clearCurrentProviderAuthState();
       scheduleAuthMapRewarm("auth-profile-failure");
     });
-    startupTimer = setTimeout(
-      () => {
-        void (async () => {
-          if (isStopped()) {
-            return;
-          }
-          const cfg = params.getConfig();
-          const metrics = await measureProviderAuthWarm(() =>
-            warmCurrentProviderAuthStateOffMainThread(cfg, { isCancelled: isStopped }),
-          );
-          if (isStopped()) {
-            return;
-          }
-          params.log.info(
-            `provider auth state pre-warmed ${formatProviderAuthWarmMetrics(metrics)}`,
-          );
-        })().catch((err) => {
-          params.log.warn(`provider auth state pre-warm failed: ${String(err)}`);
-        });
-      },
-      Math.max(0, delayMs),
-    );
-    startupTimer.unref?.();
+    if (params.startupWarmEnabled !== false) {
+      startupTimer = setTimeout(
+        () => {
+          void (async () => {
+            if (isStopped()) {
+              return;
+            }
+            const cfg = params.getConfig();
+            const metrics = await measureProviderAuthWarm(() =>
+              warmCurrentProviderAuthStateOffMainThread(cfg, { isCancelled: isStopped }),
+            );
+            if (isStopped()) {
+              return;
+            }
+            params.log.info(
+              `provider auth state pre-warmed ${formatProviderAuthWarmMetrics(metrics)}`,
+            );
+          })().catch((err) => {
+            params.log.warn(`provider auth state pre-warm failed: ${String(err)}`);
+          });
+        },
+        Math.max(0, delayMs),
+      );
+      startupTimer.unref?.();
+    }
   })().catch((err) => {
     params.log.warn(`provider auth state pre-warm setup failed: ${String(err)}`);
   });
@@ -1255,12 +1258,13 @@ export async function startGatewayPostAttachRuntime(
         }
         const postReadySidecars = [...result.postReadySidecars];
         const gatewayLifetimeSidecars: GatewayPostReadySidecarHandle[] = [];
-        if (params.providerAuthPrewarm?.enabled !== false) {
+        if (params.providerAuthPrewarm && params.providerAuthPrewarm.enabled !== false) {
           gatewayLifetimeSidecars.push(
             scheduleProviderAuthStatePrewarm({
               getConfig: params.providerAuthPrewarm?.getConfig ?? (() => params.cfgAtStart),
               log: params.log,
               delayMs: params.providerAuthPrewarm?.delayMs,
+              startupWarmEnabled: params.providerAuthPrewarm.enabled === true,
             }),
           );
         }


### PR DESCRIPTION
## Summary

- Skip the provider-auth startup warm on the normal gateway path unless `providerAuthPrewarm.enabled === true`.
- Keep the gateway lifetime provider-auth sidecar installed when the runtime supplies `providerAuthPrewarm`, so auth-profile failures still clear stale prepared state and schedule a delayed rewarm.
- Add a regression test for the default hook-only path.

## Root Cause

The post-attach startup flow treated `providerAuthPrewarm` as enabled unless callers explicitly set `enabled: false`. The normal gateway caller supplies `providerAuthPrewarm` for live config access, so startup still scheduled provider-auth warm work by default. The previous PR version fixed the startup warm by disabling the entire sidecar, which also removed auth-profile failure invalidation.

## Fix

- Keep `enabled: true` as the explicit startup-warm opt-in.
- Treat omitted `enabled` as hook-only: register the auth failure hook and rewarm sidecar, but do not schedule startup warm.
- Keep `enabled: false` as the test/minimal disable path.

## Real behavior proof

Behavior addressed: gateway startup no longer kicks off provider-auth warm by default, while auth-profile failures still clear and rewarm prepared provider-auth state.

Real environment tested: AWS Crabbox Linux runner, lease `cbx_7966d6c753d7`, run `run_5d2dd60d1672`.

Exact steps or command run after this patch: `node scripts/crabbox-wrapper.mjs run --provider aws --label wsl-event-loop-86752-check-changed --idle-timeout 45m --ttl 90m --timing-json --stop-after always --shell -- 'pnpm check:changed'`.

Evidence after fix: `pnpm check:changed` exited 0. The changed gate selected `core` and `coreTests`, then ran conflict-marker guard, dependency guards, core typecheck, core test typecheck, changed-file lint, runtime sidecar loader guard, import-cycle check, webhook body guard, and pairing guards.

Observed result after fix: the focused regression path keeps the provider-auth failure hook active without calling `warmCurrentProviderAuthStateOffMainThread` on startup; triggering the auth failure hook clears current provider-auth state and performs the delayed rewarm.

What was not tested: native Windows and WSL2 project tests did not run. AWS native Windows had no `node` runtime in PATH (`run_a044f871e2b3`), the tooling probe also found no `node`, `choco`, `winget`, or `pwsh` (`run_498feccc91fb`), AWS WSL2 hydration exited before its marker (`run_9230eb79e292`), and Azure WSL2 allocation did not produce a lease after more than 10 minutes (`run_6a3979ab4680`).

## Verification

- `node scripts/run-vitest.mjs src/gateway/server-startup-post-attach.test.ts` at `187cf1f85e4`: 46 passed
- `git diff --check origin/main...HEAD`
- `node scripts/run-oxlint.mjs src/gateway/server-startup-post-attach.ts src/gateway/server-startup-post-attach.test.ts`
- `autoreview --mode local`: clean, no accepted/actionable findings
- Crabbox AWS changed gate: `run_5d2dd60d1672`, lease `cbx_7966d6c753d7`, `pnpm check:changed`, exit 0

## Related PRs / issues

Fixes https://github.com/openclaw/openclaw/issues/86512
Refs https://github.com/openclaw/openclaw/issues/86752
