### PR TITLE
fix(agents): skip auth cooldown gate for CLI providers

### DIFF
--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -932,7 +932,7 @@ describe("runWithModelFallback", () => {
     expect(run.mock.calls[0]).toEqual(["anthropic", "claude-sonnet-4-6"]);
   });
 
-  it("lets configured CLI runtimes reach the run callback", async () => {
+  it("skips auth cooldown gate for canonical providers resolved to CLI runtimes", async () => {
     const cfg = makeCfg({
       agents: {
         defaults: {
@@ -945,12 +945,27 @@ describe("runWithModelFallback", () => {
         },
       },
     });
+    const tempDir = await makeAuthTempDir();
+    setAuthRuntimeStore(tempDir, {
+      version: AUTH_STORE_VERSION,
+      profiles: {
+        "anthropic:default": { type: "api_key", provider: "anthropic", key: "test-key" },
+      },
+      usageStats: {
+        "anthropic:default": {
+          cooldownUntil: Date.now() + 60_000,
+          cooldownReason: "billing",
+          failureCounts: { billing: 1 },
+        },
+      },
+    });
     const run = vi.fn().mockResolvedValueOnce("cli ok");
 
     const result = await runWithModelFallback({
       cfg,
       provider: "anthropic",
       model: "claude-sonnet-4-6",
+      agentDir: tempDir,
       run,
     });
 

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -888,6 +888,50 @@ describe("runWithModelFallback", () => {
     expect(run).not.toHaveBeenCalled();
   });
 
+  it("skips auth cooldown gate for CLI providers with all profiles in cooldown", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-sonnet-4-6",
+            fallbacks: ["openai/gpt-4.1-mini"],
+          },
+          cliBackends: {
+            anthropic: { command: "claude" },
+          },
+        },
+      },
+    });
+    const tempDir = await makeAuthTempDir();
+    setAuthRuntimeStore(tempDir, {
+      version: AUTH_STORE_VERSION,
+      profiles: {
+        "anthropic:default": { type: "api_key", provider: "anthropic", key: "test-key" },
+        "openai:default": { type: "api_key", provider: "openai", key: "test-key" },
+      },
+      usageStats: {
+        "anthropic:default": {
+          cooldownUntil: Date.now() + 60_000,
+          cooldownReason: "billing",
+          failureCounts: { billing: 1 },
+        },
+      },
+    });
+    const run = vi.fn().mockResolvedValueOnce("cli ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      agentDir: tempDir,
+      run,
+    });
+
+    expect(result.result).toBe("cli ok");
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run.mock.calls[0]).toEqual(["anthropic", "claude-sonnet-4-6"]);
+  });
+
   it("lets configured CLI runtimes reach the run callback", async () => {
     const cfg = makeCfg({
       agents: {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -386,19 +386,16 @@ function isCliAgentRuntime(runtime: string | undefined, cfg: OpenClawConfig | un
   return isCliRuntimeAlias(normalized) || isCliProvider(normalized, cfg);
 }
 
-async function assertModelFallbackCandidateHarnessAvailable(
+function resolveModelFallbackCandidateAgentRuntime(
   params: ModelFallbackRuntimeContext & ModelCandidate,
-): Promise<void> {
-  if (!params.cfg) {
-    return;
-  }
-  const agentHarnessRuntimeOverride = params.resolveAgentHarnessRuntimeOverride?.(
-    params.provider,
-    params.model,
+): {
+  agentHarnessRuntimeOverride?: string;
+  agentRuntime: string;
+  agentRuntimeSource?: "model" | "provider" | "implicit";
+} {
+  const agentHarnessRuntimeOverride = normalizeOptionalString(
+    params.resolveAgentHarnessRuntimeOverride?.(params.provider, params.model),
   );
-  if (isCliProvider(params.provider, params.cfg)) {
-    return;
-  }
   const agentRuntimeOverride = normalizeOptionalAgentRuntimeId(agentHarnessRuntimeOverride);
   const harnessPolicy = resolveAgentHarnessPolicy({
     provider: params.provider,
@@ -415,6 +412,32 @@ async function assertModelFallbackCandidateHarnessAvailable(
     agentRuntimeOverride && !isDefaultAgentRuntimeId(agentRuntimeOverride)
       ? "model"
       : harnessPolicy.runtimeSource;
+  return { agentHarnessRuntimeOverride, agentRuntime, agentRuntimeSource };
+}
+
+function isModelFallbackCandidateCliOwned(
+  params: ModelFallbackRuntimeContext & ModelCandidate,
+): boolean {
+  if (isCliProvider(params.provider, params.cfg)) {
+    return true;
+  }
+  return isCliAgentRuntime(
+    resolveModelFallbackCandidateAgentRuntime(params).agentRuntime,
+    params.cfg,
+  );
+}
+
+async function assertModelFallbackCandidateHarnessAvailable(
+  params: ModelFallbackRuntimeContext & ModelCandidate,
+): Promise<void> {
+  if (!params.cfg) {
+    return;
+  }
+  if (isCliProvider(params.provider, params.cfg)) {
+    return;
+  }
+  const { agentHarnessRuntimeOverride, agentRuntime, agentRuntimeSource } =
+    resolveModelFallbackCandidateAgentRuntime(params);
   if (isCliAgentRuntime(agentRuntime, params.cfg)) {
     return;
   }
@@ -1206,7 +1229,17 @@ export async function runWithModelFallback<T>(
     let runOptions: ModelFallbackRunOptions | undefined;
     let attemptedDuringCooldown = false;
     let transientProbeProviderForAttempt: string | null = null;
-    if (authRuntime && authStore && !isCliProvider(candidate.provider, params.cfg)) {
+    if (
+      authRuntime &&
+      authStore &&
+      !isModelFallbackCandidateCliOwned({
+        cfg: params.cfg,
+        agentId: params.agentId,
+        sessionKey: params.sessionKey,
+        resolveAgentHarnessRuntimeOverride: params.resolveAgentHarnessRuntimeOverride,
+        ...candidate,
+      })
+    ) {
       const profileIds = authRuntime.resolveAuthProfileOrder({
         cfg: params.cfg,
         store: authStore,

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -1206,7 +1206,7 @@ export async function runWithModelFallback<T>(
     let runOptions: ModelFallbackRunOptions | undefined;
     let attemptedDuringCooldown = false;
     let transientProbeProviderForAttempt: string | null = null;
-    if (authRuntime && authStore) {
+    if (authRuntime && authStore && !isCliProvider(candidate.provider, params.cfg)) {
       const profileIds = authRuntime.resolveAuthProfileOrder({
         cfg: params.cfg,
         store: authStore,


### PR DESCRIPTION
## Summary

- Problem: `runWithModelFallback` only skipped auth-profile cooldowns when the provider itself was configured as a CLI provider. Canonical provider configs such as `anthropic/claude-*` with `agentRuntime.id: "claude-cli"` still hit the auth cooldown gate and could skip the CLI runtime before the run callback was invoked.
- Solution: Resolve the candidate's agent runtime before the cooldown gate and treat candidates as CLI-owned when either the provider is a CLI provider or the resolved agent runtime is a CLI runtime.
- What changed: `src/agents/model-fallback.ts` now shares the resolved runtime logic between the harness availability check and cooldown gate; `src/agents/model-fallback.test.ts` now covers canonical `anthropic/*` with `agentRuntime.id: "claude-cli"` and a cooldowned `anthropic:default` auth profile.
- What did NOT change: Non-CLI providers still use auth profile cooldown filtering, and the existing CLI-provider bypass remains intact.

Fixes #85105

## Real behavior proof

- **Behavior or issue addressed:** A canonical provider candidate (`provider: "anthropic"`, `model: "claude-sonnet-4-6"`) resolved through `agents.defaults.models["anthropic/*"].agentRuntime.id = "claude-cli"` should be allowed to reach `runWithModelFallback`'s `run` callback even when `auth-profiles.json` marks `anthropic:default` as cooling down.
- **Real environment tested:** Local OpenClaw PR worktree `/media/vdc/code/ai/aispace/openclaw-worktrees/pr-86568` on Node v22.22.0, using a real persisted auth profile store at `/media/vdc/code/ai/aispace/openclaw-pr-86568-evidence/proof-agent/auth-profiles.json`.
- **Exact steps or command run after this patch:**
  ```bash
  cd /media/vdc/code/ai/aispace/openclaw-worktrees/pr-86568
  node --import tsx --input-type=module -e '
  import fs from "node:fs";
  import path from "node:path";
  import { runWithModelFallback } from "./src/agents/model-fallback.ts";
  const agentDir = "/media/vdc/code/ai/aispace/openclaw-pr-86568-evidence/proof-agent";
  fs.mkdirSync(agentDir, { recursive: true });
  fs.rmSync(path.join(agentDir, "auth-profiles.json"), { force: true });
  const cooldownUntil = Date.now() + 600000;
  fs.writeFileSync(path.join(agentDir, "auth-profiles.json"), JSON.stringify({
    version: 1,
    profiles: {
      "anthropic:default": { type: "api_key", provider: "anthropic", key: "redacted-test-key" }
    },
    usageStats: {
      "anthropic:default": {
        cooldownUntil,
        cooldownReason: "billing",
        failureCounts: { billing: 1 }
      }
    }
  }, null, 2));
  const cfg = {
    agents: {
      defaults: {
        models: {
          "anthropic/*": { agentRuntime: { id: "claude-cli" } }
        },
        model: { primary: "anthropic/claude-sonnet-4-6", fallbacks: [] }
      }
    },
    models: {
      providers: {
        anthropic: { baseUrl: "https://anthropic.example.test", models: [{ id: "claude-sonnet-4-6" }] }
      }
    }
  };
  const calls = [];
  const result = await runWithModelFallback({
    cfg,
    provider: "anthropic",
    model: "claude-sonnet-4-6",
    agentDir,
    run: async (provider, model, options) => {
      calls.push({ provider, model, authProfileId: options?.authProfileId ?? null });
      return "callback reached despite cooldown";
    }
  });
  console.log("proof: canonical provider resolved to CLI runtime");
  console.log("agentRuntime:", cfg.agents.defaults.models["anthropic/*"].agentRuntime.id);
  console.log("cooldown profile:", "anthropic:default");
  console.log("cooldownUntil future:", cooldownUntil > Date.now());
  console.log("run callback calls:", calls.length);
  console.log("run callback args:", JSON.stringify(calls));
  console.log("result:", result.result);
  if (calls.length !== 1 || result.result !== "callback reached despite cooldown") process.exit(1);
  '
  ```
- **Evidence after fix:** Terminal capture / console output from the patched local OpenClaw worktree:
  ```text
  proof: canonical provider resolved to CLI runtime
  agentRuntime: claude-cli
  cooldown profile: anthropic:default
  cooldownUntil future: true
  run callback calls: 1
  run callback args: [{"provider":"anthropic","model":"claude-sonnet-4-6","authProfileId":null}]
  result: callback reached despite cooldown
  ```
- **Observed result after fix:** The production `runWithModelFallback` path reached the `run` callback exactly once for the canonical `anthropic` provider resolved to `claude-cli`, despite the persisted `anthropic:default` auth profile being in future cooldown. The callback received no auth profile id, confirming the cooldowned auth profile was not selected or required for this CLI-owned candidate.
- **What was not tested:** I did not start a live `claude-cli` subprocess or call the real Anthropic service; the proof isolates the fallback/cooldown decision path that this PR changes.

## Regression Test Plan

- **Coverage level:** Targeted unit coverage plus changed-file gates.
- **Target test file:** `src/agents/model-fallback.test.ts`
- **Scenario locked in:** `runWithModelFallback` with canonical `anthropic/*` config and `agentRuntime.id: "claude-cli"` reaches the run callback while `anthropic:default` is in cooldown.
- **Why this is the smallest reliable guardrail:** The regression test exercises the same production cooldown gate that previously skipped the candidate, and it fails if the guard only checks `isCliProvider(candidate.provider, cfg)` without considering the resolved agent runtime.
- **Additional validation run:** `pnpm check:changed` passed in the PR worktree, covering changed-file typecheck, lint, and runtime guard checks.

## Root Cause

- **Root cause:** The cooldown gate checked only whether `candidate.provider` was a CLI provider. That missed the canonical runtime-selection path where the provider remains `anthropic` but `resolveAgentHarnessPolicy` resolves the candidate to a CLI runtime such as `claude-cli`.
- **Missing detection / guardrail:** Existing coverage only proved configured CLI providers. It did not cover canonical provider configs that select CLI execution through `agentRuntime.id`.
