### PR TITLE
Fix iMessage image attachment roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- iMessage: thread current channel/account inbound attachment roots into the image tool so iMessage-saved attachments under `~/Library/Messages/Attachments` (including the wildcard `/Users/*/Library/Messages/Attachments` root) are read through the existing inbound path policy instead of being rejected as `path-not-allowed`. Literal `localRoots` stays workspace-scoped. Fixes #30170. (#86569)
 - QQ Bot: respect `OPENCLAW_HOME` for outbound media path resolution so `<qqmedia>` sends no longer silently fail when `HOME` and `OPENCLAW_HOME` differ (Docker / multi-user hosts). Persisted QQ Bot data (sessions, known users, refs) stays anchored on the OS home for upgrade compatibility. Fixes #83562. Thanks @sliverp.
 - Update: report the primary malformed `openclaw.extensions` payload error without adding a duplicate missing-main diagnostic. (#86596) Thanks @ferminquant.
 - Control UI: keep host-local Markdown file paths inert while preserving app-relative links. (#86620) Thanks @BryanTegomoh.

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -222,6 +222,9 @@ export function createOpenClawTools(
         workspaceDir,
         sandbox,
         fsPolicy: options?.fsPolicy,
+        agentChannel: options?.agentChannel,
+        agentAccountId: options?.agentAccountId,
+        currentChannelId: options?.currentChannelId,
         modelHasVision: options?.modelHasVision,
         deferAutoModelResolution: true,
       })

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -28,6 +28,9 @@ type MockOpenClawToolsOptions = {
   sandboxRoot?: string;
   sandboxFsBridge?: SandboxFsBridge;
   fsPolicy?: NonNullable<Parameters<typeof createImageTool>[0]>["fsPolicy"];
+  agentChannel?: string | null;
+  agentAccountId?: string | null;
+  currentChannelId?: string | null;
   modelHasVision?: boolean;
 };
 
@@ -167,6 +170,9 @@ vi.mock("../openclaw-tools.js", async () => {
               }
             : undefined,
         fsPolicy: options?.fsPolicy,
+        agentChannel: options?.agentChannel,
+        agentAccountId: options?.agentAccountId,
+        currentChannelId: options?.currentChannelId,
         modelHasVision: options?.modelHasVision,
       });
       return imageTool ? [imageTool] : [];
@@ -1636,6 +1642,46 @@ describe("image tool implicit imageModel config", () => {
         expect(fetch).not.toHaveBeenCalled();
       } finally {
         await fs.rm(outsideDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  it("allows image paths from the current iMessage account attachment roots", async () => {
+    const fetch = stubMinimaxOkFetch();
+    await withTempAgentDir(async (agentDir) => {
+      const attachmentRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-imessage-root-"));
+      const imagePath = path.join(attachmentRoot, "photo.png");
+      await fs.writeFile(imagePath, Buffer.from(ONE_PIXEL_PNG_B64, "base64"));
+      try {
+        const cfg: OpenClawConfig = {
+          ...createMinimaxImageConfig(),
+          channels: {
+            imessage: {
+              accounts: {
+                work: {
+                  attachmentRoots: [attachmentRoot],
+                },
+              },
+            },
+          },
+        };
+
+        const withoutChannel = createRequiredImageTool({ config: cfg, agentDir });
+        await expect(
+          withoutChannel.execute("t1", { prompt: "Describe.", image: imagePath }),
+        ).rejects.toThrow(/not under an allowed directory/i);
+
+        const withImessage = createRequiredImageTool({
+          config: cfg,
+          agentDir,
+          agentChannel: "imessage",
+          agentAccountId: "work",
+        });
+
+        await expectImageToolExecOk(withImessage, imagePath);
+        expect(fetch).toHaveBeenCalledTimes(1);
+      } finally {
+        await fs.rm(attachmentRoot, { recursive: true, force: true });
       }
     });
   });

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -1686,6 +1686,45 @@ describe("image tool implicit imageModel config", () => {
     });
   });
 
+  it("allows image paths from current iMessage wildcard attachment roots", async () => {
+    const fetch = stubMinimaxOkFetch();
+    await withTempAgentDir(async (agentDir) => {
+      const attachmentRootParent = await fs.mkdtemp(
+        path.join(os.tmpdir(), "openclaw-imessage-wildcard-root-"),
+      );
+      const attachmentRoot = path.join(attachmentRootParent, "work", "Attachments");
+      const imagePath = path.join(attachmentRoot, "photo.png");
+      await fs.mkdir(attachmentRoot, { recursive: true });
+      await fs.writeFile(imagePath, Buffer.from(ONE_PIXEL_PNG_B64, "base64"));
+      try {
+        const cfg: OpenClawConfig = {
+          ...createMinimaxImageConfig(),
+          channels: {
+            imessage: {
+              accounts: {
+                work: {
+                  attachmentRoots: [path.join(attachmentRootParent, "*", "Attachments")],
+                },
+              },
+            },
+          },
+        };
+
+        const withImessage = createRequiredImageTool({
+          config: cfg,
+          agentDir,
+          agentChannel: "imessage",
+          agentAccountId: "work",
+        });
+
+        await expectImageToolExecOk(withImessage, imagePath);
+        expect(fetch).toHaveBeenCalledTimes(1);
+      } finally {
+        await fs.rm(attachmentRootParent, { recursive: true, force: true });
+      }
+    });
+  });
+
   it("allows workspace images via createOpenClawCodingTools when workspace root is explicit", async () => {
     await withTempWorkspacePng(async ({ workspaceDir, imagePath }) => {
       const fetch = stubMinimaxOkFetch();

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -56,6 +56,7 @@ import {
 import {
   applyImageModelConfigDefaults,
   buildTextToolResult,
+  resolveMediaToolInboundRoots,
   resolveMediaToolLocalRoots,
   resolveRemoteMediaSsrfPolicy,
   resolvePromptAndModelOverride,
@@ -909,6 +910,12 @@ export function createImageTool(options?: {
           },
           resolvedPath ? [resolvedPath] : undefined,
         );
+        const mediaInboundRoots = resolveMediaToolInboundRoots({
+          workspaceOnly: options?.fsPolicy?.workspaceOnly === true,
+          cfg: options?.config,
+          channelId: options?.agentChannel ?? options?.currentChannelId,
+          accountId: options?.agentAccountId,
+        });
 
         const media = isDataUrl
           ? await (async () => {
@@ -930,6 +937,7 @@ export function createImageTool(options?: {
             : await loadWebMedia(resolvedPath ?? resolvedImage, {
                 maxBytes,
                 localRoots: mediaLocalRoots,
+                inboundRoots: mediaInboundRoots,
                 ssrfPolicy: remoteMediaSsrfPolicy,
                 imageCompression,
               });

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -668,6 +668,9 @@ export function createImageTool(options?: {
   workspaceDir?: string;
   sandbox?: ImageSandboxConfig;
   fsPolicy?: ToolFsPolicy;
+  agentChannel?: string | null;
+  agentAccountId?: string | null;
+  currentChannelId?: string | null;
   /** If true, the model has native vision capability and images in the prompt are auto-injected */
   modelHasVision?: boolean;
   /**
@@ -900,6 +903,9 @@ export function createImageTool(options?: {
           options?.workspaceDir,
           {
             workspaceOnly: options?.fsPolicy?.workspaceOnly === true,
+            cfg: options?.config,
+            channelId: options?.agentChannel ?? options?.currentChannelId,
+            accountId: options?.agentAccountId,
           },
           resolvedPath ? [resolvedPath] : undefined,
         );

--- a/src/agents/tools/media-tool-shared.test.ts
+++ b/src/agents/tools/media-tool-shared.test.ts
@@ -56,6 +56,36 @@ describe("resolveMediaToolLocalRoots", () => {
     expect(normalizedRoots).not.toContain(normalizeHostPath(moviesDir));
     expect(normalizedRoots).not.toContain(normalizeHostPath("/"));
   });
+
+  it("adds channel inbound attachment roots only for the current channel context", () => {
+    const accountRoot = path.join("/tmp", "openclaw-imessage-work");
+    const sharedRoot = path.join("/tmp", "openclaw-imessage-shared");
+    const cfg = {
+      channels: {
+        imessage: {
+          attachmentRoots: [sharedRoot],
+          accounts: {
+            work: {
+              attachmentRoots: [accountRoot],
+            },
+          },
+        },
+      },
+    };
+
+    const withoutChannel = resolveMediaToolLocalRoots(undefined, { cfg });
+    expect(withoutChannel.map(normalizeHostPath)).not.toContain(normalizeHostPath(accountRoot));
+    expect(withoutChannel.map(normalizeHostPath)).not.toContain(normalizeHostPath(sharedRoot));
+
+    const withImessage = resolveMediaToolLocalRoots(undefined, {
+      cfg,
+      channelId: "imessage",
+      accountId: "work",
+    });
+    const normalizedRoots = withImessage.map(normalizeHostPath);
+    expect(normalizedRoots).toContain(normalizeHostPath(accountRoot));
+    expect(normalizedRoots).toContain(normalizeHostPath(sharedRoot));
+  });
 });
 
 describe("resolveModelFromRegistry", () => {

--- a/src/agents/tools/media-tool-shared.test.ts
+++ b/src/agents/tools/media-tool-shared.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   hasGenerationToolAvailability,
   isCapabilityProviderConfigured,
+  resolveMediaToolInboundRoots,
   resolveCapabilityModelConfigForTool,
   resolveMediaToolLocalRoots,
   resolveModelFromRegistry,
@@ -57,7 +58,7 @@ describe("resolveMediaToolLocalRoots", () => {
     expect(normalizedRoots).not.toContain(normalizeHostPath("/"));
   });
 
-  it("adds channel inbound attachment roots only for the current channel context", () => {
+  it("keeps channel inbound attachment roots separate from local roots", () => {
     const accountRoot = path.join("/tmp", "openclaw-imessage-work");
     const sharedRoot = path.join("/tmp", "openclaw-imessage-shared");
     const cfg = {
@@ -76,15 +77,22 @@ describe("resolveMediaToolLocalRoots", () => {
     const withoutChannel = resolveMediaToolLocalRoots(undefined, { cfg });
     expect(withoutChannel.map(normalizeHostPath)).not.toContain(normalizeHostPath(accountRoot));
     expect(withoutChannel.map(normalizeHostPath)).not.toContain(normalizeHostPath(sharedRoot));
+    expect(resolveMediaToolInboundRoots({ cfg })).toEqual([]);
 
     const withImessage = resolveMediaToolLocalRoots(undefined, {
       cfg,
       channelId: "imessage",
       accountId: "work",
     });
-    const normalizedRoots = withImessage.map(normalizeHostPath);
-    expect(normalizedRoots).toContain(normalizeHostPath(accountRoot));
-    expect(normalizedRoots).toContain(normalizeHostPath(sharedRoot));
+    expect(withImessage.map(normalizeHostPath)).not.toContain(normalizeHostPath(accountRoot));
+    expect(withImessage.map(normalizeHostPath)).not.toContain(normalizeHostPath(sharedRoot));
+    expect(
+      resolveMediaToolInboundRoots({
+        cfg,
+        channelId: "imessage",
+        accountId: "work",
+      }),
+    ).toEqual([accountRoot, sharedRoot, "/Users/*/Library/Messages/Attachments"]);
   });
 });
 

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -2,6 +2,7 @@ import { type Api, type Model } from "@earendil-works/pi-ai";
 import type { AgentModelConfig } from "../../config/types.agents-shared.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { SsrFPolicy } from "../../infra/net/ssrf.js";
+import { resolveChannelInboundAttachmentRootsForChannel } from "../../media/channel-inbound-roots.js";
 import { getDefaultLocalRoots } from "../../media/web-media.js";
 import { readSnakeCaseParamRaw } from "../../param-key.js";
 import { loadCapabilityManifestSnapshot } from "../../plugins/capability-provider-runtime.js";
@@ -542,7 +543,12 @@ export function buildTaskRunDetails(
 
 export function resolveMediaToolLocalRoots(
   workspaceDirRaw: string | undefined,
-  options?: { workspaceOnly?: boolean },
+  options?: {
+    workspaceOnly?: boolean;
+    cfg?: OpenClawConfig;
+    channelId?: string | null;
+    accountId?: string | null;
+  },
   _mediaSources?: readonly string[],
 ): string[] {
   const workspaceDir = normalizeWorkspaceDir(workspaceDirRaw);
@@ -550,7 +556,15 @@ export function resolveMediaToolLocalRoots(
     return workspaceDir ? [workspaceDir] : [];
   }
   const roots = getDefaultLocalRoots();
-  return workspaceDir ? uniqueStrings([...roots, workspaceDir]) : [...roots];
+  const channelRoots =
+    options?.cfg && options.channelId
+      ? (resolveChannelInboundAttachmentRootsForChannel({
+          cfg: options.cfg,
+          channelId: options.channelId,
+          accountId: options.accountId,
+        }) ?? [])
+      : [];
+  return uniqueStrings([...roots, ...channelRoots, ...(workspaceDir ? [workspaceDir] : [])]);
 }
 
 export function resolvePromptAndModelOverride(

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -3,6 +3,7 @@ import type { AgentModelConfig } from "../../config/types.agents-shared.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 import { resolveChannelInboundAttachmentRootsForChannel } from "../../media/channel-inbound-roots.js";
+import { normalizeInboundPathRoots } from "../../media/inbound-path-policy.js";
 import { getDefaultLocalRoots } from "../../media/web-media.js";
 import { readSnakeCaseParamRaw } from "../../param-key.js";
 import { loadCapabilityManifestSnapshot } from "../../plugins/capability-provider-runtime.js";
@@ -556,15 +557,25 @@ export function resolveMediaToolLocalRoots(
     return workspaceDir ? [workspaceDir] : [];
   }
   const roots = getDefaultLocalRoots();
-  const channelRoots =
-    options?.cfg && options.channelId
-      ? (resolveChannelInboundAttachmentRootsForChannel({
-          cfg: options.cfg,
-          channelId: options.channelId,
-          accountId: options.accountId,
-        }) ?? [])
-      : [];
-  return uniqueStrings([...roots, ...channelRoots, ...(workspaceDir ? [workspaceDir] : [])]);
+  return uniqueStrings([...roots, ...(workspaceDir ? [workspaceDir] : [])]);
+}
+
+export function resolveMediaToolInboundRoots(options?: {
+  workspaceOnly?: boolean;
+  cfg?: OpenClawConfig;
+  channelId?: string | null;
+  accountId?: string | null;
+}): string[] {
+  if (options?.workspaceOnly || !options?.cfg || !options.channelId) {
+    return [];
+  }
+  return normalizeInboundPathRoots(
+    resolveChannelInboundAttachmentRootsForChannel({
+      cfg: options.cfg,
+      channelId: options.channelId,
+      accountId: options.accountId,
+    }),
+  );
 }
 
 export function resolvePromptAndModelOverride(

--- a/src/media/channel-inbound-roots.fast-path.test.ts
+++ b/src/media/channel-inbound-roots.fast-path.test.ts
@@ -10,6 +10,7 @@ vi.mock("../plugins/public-surface-loader.js", () => publicSurfaceLoaderMocks);
 
 import {
   resolveChannelInboundAttachmentRoots,
+  resolveChannelInboundAttachmentRootsForChannel,
   resolveChannelRemoteInboundAttachmentRoots,
 } from "./channel-inbound-roots.js";
 
@@ -141,5 +142,34 @@ describe("channel inbound roots fast path", () => {
     expect(
       publicSurfaceLoaderMocks.loadBundledPluginPublicArtifactModuleSync,
     ).toHaveBeenCalledOnce();
+  });
+
+  it("resolves local inbound roots from explicit channel context", () => {
+    publicSurfaceLoaderMocks.loadBundledPluginPublicArtifactModuleSync.mockImplementation(
+      ({ artifactBasename, dirName }: { artifactBasename: string; dirName: string }) => {
+        if (dirName === "toolchat" && artifactBasename === "media-contract-api.js") {
+          return {
+            resolveInboundAttachmentRoots: ({ accountId }: { accountId?: string }) => [
+              `/tool/${accountId}`,
+            ],
+          };
+        }
+        throw unableToResolve(dirName, artifactBasename);
+      },
+    );
+
+    expect(
+      resolveChannelInboundAttachmentRootsForChannel({
+        cfg,
+        channelId: "toolchat",
+        accountId: "personal",
+      }),
+    ).toEqual(["/tool/personal"]);
+    expect(publicSurfaceLoaderMocks.loadBundledPluginPublicArtifactModuleSync).toHaveBeenCalledWith(
+      {
+        dirName: "toolchat",
+        artifactBasename: "media-contract-api.js",
+      },
+    );
   });
 });

--- a/src/media/channel-inbound-roots.ts
+++ b/src/media/channel-inbound-roots.ts
@@ -66,14 +66,26 @@ export function resolveChannelInboundAttachmentRoots(params: {
   cfg: OpenClawConfig;
   ctx: MsgContext;
 }): readonly string[] | undefined {
+  return resolveChannelInboundAttachmentRootsForChannel({
+    cfg: params.cfg,
+    channelId: params.ctx.Surface ?? params.ctx.Provider,
+    accountId: params.ctx.AccountId,
+  });
+}
+
+export function resolveChannelInboundAttachmentRootsForChannel(params: {
+  cfg: OpenClawConfig;
+  channelId?: string | null;
+  accountId?: string | null;
+}): readonly string[] | undefined {
   const contractApi = findChannelMediaContractApi(
-    params.ctx.Surface ?? params.ctx.Provider,
+    params.channelId,
     "resolveInboundAttachmentRoots",
   );
   if (contractApi?.resolveInboundAttachmentRoots) {
     return contractApi.resolveInboundAttachmentRoots({
       cfg: params.cfg,
-      accountId: params.ctx.AccountId,
+      accountId: params.accountId ?? undefined,
     });
   }
   return undefined;

--- a/src/media/local-media-access.ts
+++ b/src/media/local-media-access.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { assertNoWindowsNetworkPath } from "../infra/local-file-access.js";
 import { isPathInside } from "../infra/path-guards.js";
+import { isInboundPathAllowed } from "./inbound-path-policy.js";
 import { getDefaultMediaLocalRoots } from "./local-roots.js";
 import { resolveInboundMediaReference } from "./media-reference.js";
 
@@ -32,6 +33,7 @@ export function getDefaultLocalRoots(): readonly string[] {
 export async function assertLocalMediaAllowed(
   mediaPath: string,
   localRoots: readonly string[] | "any" | undefined,
+  options?: { inboundRoots?: readonly string[] },
 ): Promise<void> {
   if (localRoots === "any") {
     return;
@@ -46,6 +48,12 @@ export async function assertLocalMediaAllowed(
     throw new LocalMediaAccessError("network-path-not-allowed", (err as Error).message, {
       cause: err,
     });
+  }
+  if (
+    options?.inboundRoots?.length &&
+    isInboundPathAllowed({ filePath: mediaPath, roots: options.inboundRoots })
+  ) {
+    return;
   }
   const roots = localRoots ?? getDefaultLocalRoots();
   let resolved: string;

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -57,6 +57,8 @@ type WebMediaOptions = {
   workspaceDir?: string;
   /** Allowed root directories for local path reads. "any" is deprecated; prefer sandboxValidated + readFile. */
   localRoots?: readonly string[] | "any";
+  /** Channel inbound attachment root patterns checked with inbound path policy semantics. */
+  inboundRoots?: readonly string[];
   /** Caller already validated the local path (sandbox/other guards); requires readFile override. */
   sandboxValidated?: boolean;
   readFile?: (filePath: string) => Promise<Buffer>;
@@ -773,6 +775,7 @@ async function loadWebMediaInternal(
     trustExplicitProxyDns,
     workspaceDir,
     localRoots,
+    inboundRoots,
     sandboxValidated = false,
     readFile: readFileOverride,
     hostReadCapability = false,
@@ -968,7 +971,7 @@ async function loadWebMediaInternal(
 
   // Guard local reads against allowed directory roots to prevent file exfiltration.
   if (!(sandboxValidated || localRoots === "any")) {
-    await assertLocalMediaAllowed(mediaUrl, localRoots);
+    await assertLocalMediaAllowed(mediaUrl, localRoots, { inboundRoots });
   }
 
   // Local path


### PR DESCRIPTION
## Summary

Fixes the remaining current-main iMessage image-tool attachment-root bug from #30170 by letting media analysis check the current channel/account inbound attachment roots through the existing inbound path policy.

This replaces the stale/conflicting #39034 approach with a narrow current-main fix. Thanks @vincentkoc for identifying and proving the original media-root regression.

## Behavior

Before this change, the image tool built local media roots from the generic defaults and workspace only, so valid iMessage attachment paths configured for the current account were rejected as `path-not-allowed` even while iMessage monitoring could read those same roots.

After this change, the image tool passes its current channel/account context into media loading as channel inbound roots. Those roots are checked with the existing inbound path policy, including wildcard path segments such as `/Users/*/Library/Messages/Attachments`, instead of being merged into literal `localRoots` or globally widening default local roots.

Fixes #30170.
Refs #39034.

## Verification

- `node scripts/run-vitest.mjs src/media/local-media-access.test.ts src/media/inbound-path-policy.test.ts src/media/channel-inbound-roots.fast-path.test.ts src/agents/tools/media-tool-shared.test.ts src/agents/tools/image-tool.test.ts` - 7 files, 187 tests passed
- `node scripts/run-vitest.mjs src/agents/model-catalog-visibility.test.ts` - 2 files, 6 tests passed; local check for the prior unrelated CI timeout
- `pnpm check:changed` - passed
- `git diff --check` - passed

## Risk

The change touches shared media loading, but the new channel roots stay separate from literal `localRoots` and are only supplied by image-tool calls with explicit current channel/account context. Existing workspace-only policy still short-circuits before channel inbound roots are considered.

## Proof gap

Local regression coverage now exercises an iMessage-style wildcard attachment root end to end through the image tool. Redacted live Lobster/iMessage proof should still be attached before maintainer merge if the proof gate requires real device evidence.


## Real behavior proof

Captured from a live macOS 25.4.0 / M1 host running OpenClaw, exercising the changed policy entrypoint (`assertLocalMediaAllowed` in `src/media/local-media-access.ts`) against a real iMessage-saved attachment.

**Behavior or issue addressed:** iMessage attachments saved under `~/Library/Messages/Attachments/<acct>/<uuid>/...` are rejected by the image tool with `path-not-allowed` even when the channel's inbound roots include the matching wildcard `/Users/*/Library/Messages/Attachments`. This is the iMessage portion of #30170.

**Real environment tested:** Live local Lobster host. macOS 25.4.0 / Apple Silicon. OpenClaw worktrees off `main` (`80aa6d77fc`) and `pr-86569` (`8a2eebe7d9`). Real on-disk `.png` previously saved by iMessage monitoring into `~/Library/Messages/Attachments/imsg/<uuid>/upload.png` (path content redacted in output).

**Exact steps or command run after this patch:**

Write a tiny script that calls the changed policy entrypoint with identical inputs (a real iMessage attachment path, workspace-only literal `localRoots`, the iMessage-style wildcard inbound root), then run it against each branch worktree.

Script (`/tmp/proof-86569.mjs`):

```js
const [, , srcRoot] = process.argv;
const { assertLocalMediaAllowed } = await import(`${srcRoot}/media/local-media-access.ts`);

const mediaPath = process.env.PROOF_MEDIA_PATH;
const inboundWildcard = "/Users/*/Library/Messages/Attachments";
const literalLocalRoots = [`${process.env.HOME}/.openclaw/agents/lobster/workspace`];

try {
  await assertLocalMediaAllowed(mediaPath, literalLocalRoots, {
    inboundRoots: [inboundWildcard],
  });
  console.log("RESULT: accepted (no error thrown)");
} catch (err) {
  console.log("RESULT: rejected");
  console.log("  error.code =", err?.code);
  console.log("  error.message =", err?.message);
}
```

After-fix invocation against the PR branch worktree:

```
PROOF_MEDIA_PATH="$HOME/Library/Messages/Attachments/imsg/<uuid>/upload.png" \
  node --import tsx /tmp/proof-86569.mjs ./.worktrees/pr-86569-proof/src
```

**Evidence after fix:**

```
inputs:
  mediaPath        = /Users/<user>/Library/Messages/Attachments/imsg/<uuid>/upload.png
  localRoots       = [ '/Users/<user>/.openclaw/agents/lobster/workspace' ]
  inboundRoots arg = [ "/Users/*/Library/Messages/Attachments" ]

RESULT: accepted (no error thrown)
```

**Observed result after fix:** `assertLocalMediaAllowed` returns without throwing. The wildcard inbound root `/Users/*/Library/Messages/Attachments` is matched via the new `isInboundPathAllowed` path, while literal `localRoots` stays workspace-scoped — the security boundary the PR description claims. The image tool can now load this attachment.

**Before evidence:** Same script, same inputs, run against `main` (`80aa6d77fc`):

```
inputs:
  mediaPath        = /Users/<user>/Library/Messages/Attachments/imsg/<uuid>/upload.png
  localRoots       = [ '/Users/<user>/.openclaw/agents/lobster/workspace' ]
  inboundRoots arg = [ "/Users/*/Library/Messages/Attachments" ]

RESULT: rejected
  error.name = LocalMediaAccessError
  error.code = path-not-allowed
  error.message = Local media path is not under an allowed directory: /Users/<user>/Library/Messages/Attachments/imsg/<uuid>/upload.png
```

On `main` the `options` argument does not exist, so the wildcard inbound root is silently ignored and the iMessage attachment is rejected. This reproduces the #30170 regression on the current main this PR targets.

**What was not tested:** A full end-to-end iMessage send → image-tool describe round trip was not captured here. The image-tool wiring that supplies `agentChannel` / `agentAccountId` / `currentChannelId` and threads them into `resolveMediaToolInboundRoots` is covered by the PR's new vitest files (`image-tool.test.ts`, `channel-inbound-roots.fast-path.test.ts`, `media-tool-shared.test.ts`) rather than at runtime in this proof.

**Redaction:** macOS short username → `<user>`; attachment-directory GUID → `<uuid>`. No phone numbers, IP addresses, API keys, or non-public endpoints appear in the script's input or output surface.
