### PR TITLE
fix(status): prefer active OAuth for runtime aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - Gateway: emit plugin `session_end`/`session_start` hooks when `agent.send` rotates or replaces a session id, keeping hook lifecycle state aligned with `sessions.changed` notifications. Fixes #83507. (#85875) Thanks @brokemac79.
 - OpenShell/SSH: reject malformed generated exec commands before sandbox/session setup so unresolved workflow placeholders fail fast instead of reaching the remote shell. Fixes #72373. Thanks @brokemac79.
 - Installer: make Alpine apk installs cover Git, verify the Node runtime floor, try `nodejs-current`, and report Alpine version guidance when repositories only provide older Node packages.
+- Agents/status: prefer the active Claude CLI OAuth auth label over an unused Anthropic env API-key label for equivalent runtime aliases. Fixes #80184. (#86570) Thanks @brokemac79.
 - Agents/media: send direct fallback for generated media still missing after an active requester wake fails. (#85489) Thanks @fuller-stack-dev.
 - Agents: derive overflow compaction budgets from provider-reported and synthetic over-budget token counts so confirmed context overflows compact before retrying. (#70473) Thanks @fuller-stack-dev.
 - Agents/Codex: recover Codex context-window prompt errors through overflow compaction and surface reset guidance when recovery is exhausted. (#85542) Thanks @fuller-stack-dev.

--- a/src/agents/model-runtime-aliases.ts
+++ b/src/agents/model-runtime-aliases.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import { normalizeStaticProviderModelId } from "./model-ref-shared.js";
 import { resolveModelRuntimePolicy } from "./model-runtime-policy.js";
 import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
@@ -179,6 +180,26 @@ function normalizeRuntimeModelRefForComparison(raw: string): string {
 export function areRuntimeModelRefsEquivalent(left: string, right: string): boolean {
   return (
     normalizeRuntimeModelRefForComparison(left) === normalizeRuntimeModelRefForComparison(right)
+  );
+}
+
+export function shouldPreferActiveRuntimeAliasAuthLabel(params: {
+  runtimeAliasModelEquivalent: boolean;
+  selectedAuthLabel?: string;
+  activeAuthLabel?: string;
+}): boolean {
+  if (!params.runtimeAliasModelEquivalent) {
+    return false;
+  }
+  const selectedAuth = normalizeOptionalLowercaseString(params.selectedAuthLabel);
+  const activeAuth = normalizeOptionalLowercaseString(params.activeAuthLabel);
+  if (!activeAuth || activeAuth === "unknown") {
+    return false;
+  }
+  return (
+    selectedAuth === "unknown" ||
+    (Boolean(selectedAuth?.startsWith("api-key")) &&
+      (activeAuth.startsWith("oauth") || activeAuth.startsWith("token")))
   );
 }
 

--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -856,6 +856,52 @@ describe("buildStatusReply subagent summary", () => {
     );
   });
 
+  it("prefers active Claude CLI OAuth over selected env API-key labels for runtime aliases", async () => {
+    const text = await buildStatusText({
+      cfg: {
+        ...baseCfg,
+        agents: {
+          defaults: {
+            agentRuntime: { id: "claude-cli" },
+          },
+        },
+      },
+      sessionEntry: {
+        sessionId: "sess-status-claude-cli-env-key-shadow",
+        updatedAt: 0,
+        providerOverride: "anthropic",
+        modelOverride: "claude-opus-4-7",
+        modelProvider: "claude-cli",
+        model: "claude-opus-4-7",
+        fallbackNoticeSelectedModel: "anthropic/claude-opus-4-7",
+        fallbackNoticeActiveModel: "claude-cli/claude-opus-4-7",
+        fallbackNoticeReason: "selected model unavailable",
+      },
+      sessionKey: "agent:main:main",
+      parentSessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      statusChannel: "mobilechat",
+      provider: "anthropic",
+      model: "claude-opus-4-7",
+      contextTokens: 32_000,
+      resolvedHarness: "claude-cli",
+      resolvedFastMode: false,
+      resolvedVerboseLevel: "off",
+      resolvedReasoningLevel: "off",
+      resolveDefaultThinkingLevel: async () => undefined,
+      isGroup: false,
+      defaultGroupActivation: () => "mention",
+      modelAuthOverride: "api-key (env: ANTHROPIC_API_KEY)",
+      activeModelAuthOverride: "oauth (claude-cli)",
+    });
+
+    const normalized = normalizeTestText(text);
+    expect(normalized).toContain("Session selected: anthropic/claude-opus-4-7");
+    expect(normalized).toContain("oauth (claude-cli)");
+    expect(normalized).not.toContain("api-key (env: ANTHROPIC_API_KEY)");
+    expect(normalized).not.toContain("Usage:");
+  });
+
   it("uses Codex OAuth context overrides for openai models running on the Codex harness", async () => {
     registerStatusCodexHarness();
 

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -995,6 +995,53 @@ describe("buildStatusMessage", () => {
     expect(normalized).toContain("Context: 36k/1.0m (4%)");
   });
 
+  it("prefers active CLI OAuth over selected env API-key labels for runtime aliases", () => {
+    const text = buildStatusMessage({
+      config: {
+        models: {
+          providers: {
+            anthropic: {
+              models: [
+                {
+                  id: "claude-opus-4-7",
+                  cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+                },
+              ],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      agent: {
+        model: "anthropic/claude-opus-4-7",
+      },
+      sessionEntry: {
+        sessionId: "claude-cli-runtime-alias-env-key",
+        updatedAt: 0,
+        providerOverride: "anthropic",
+        modelOverride: "claude-opus-4-7",
+        modelProvider: "claude-cli",
+        model: "claude-opus-4-7",
+        fallbackNoticeSelectedModel: "anthropic/claude-opus-4-7",
+        fallbackNoticeActiveModel: "claude-cli/claude-opus-4-7",
+        fallbackNoticeReason: "selected model unavailable",
+        inputTokens: 29,
+        outputTokens: 19_000,
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "api-key (env: ANTHROPIC_API_KEY)",
+      activeModelAuth: "oauth (anthropic:claude-cli)",
+    });
+
+    const normalized = normalizeTestText(text);
+    expect(normalized).toContain("Model: anthropic/claude-opus-4-7");
+    expect(normalized).toContain("oauth (anthropic:claude-cli)");
+    expect(normalized).not.toContain("api-key (env: ANTHROPIC_API_KEY)");
+    expect(normalized).not.toContain("Fallback: claude-cli/claude-opus-4-7");
+    expect(normalized).not.toContain("Cost:");
+  });
+
   it("keeps an explicit runtime context limit when fallback status already computed one", () => {
     const text = buildStatusMessage({
       config: {

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -2,7 +2,10 @@ import fs from "node:fs";
 import { resolveContextTokensForModel } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveModelAuthMode } from "../agents/model-auth.js";
-import { areRuntimeModelRefsEquivalent } from "../agents/model-runtime-aliases.js";
+import {
+  areRuntimeModelRefsEquivalent,
+  shouldPreferActiveRuntimeAliasAuthLabel,
+} from "../agents/model-runtime-aliases.js";
 import {
   buildModelAliasIndex,
   resolveConfiguredModelRef,
@@ -925,8 +928,15 @@ export function buildStatusMessage(args: StatusArgs): string {
     activeAuthMode && activeAuthMode !== "unknown"
       ? (args.activeModelAuth ?? activeAuthMode)
       : undefined;
-  const selectedAuthLabelValue =
-    rawSelectedAuthLabelValue ?? (runtimeAliasModelEquivalent ? activeAuthLabelValue : undefined);
+  const preferActiveAuthLabel = shouldPreferActiveRuntimeAliasAuthLabel({
+    runtimeAliasModelEquivalent,
+    selectedAuthLabel: rawSelectedAuthLabelValue,
+    activeAuthLabel: activeAuthLabelValue,
+  });
+  const selectedAuthLabelValue = preferActiveAuthLabel
+    ? activeAuthLabelValue
+    : (rawSelectedAuthLabelValue ??
+      (runtimeAliasModelEquivalent ? activeAuthLabelValue : undefined));
   const fallbackState = resolveActiveFallbackState({
     selectedModelRef: selectedModelLabel,
     activeModelRef: activeModelLabel,

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -10,7 +10,10 @@ import {
 import { resolveContextTokensForModel } from "../agents/context.js";
 import { resolveFastModeState } from "../agents/fast-mode.js";
 import { resolveModelAuthLabel } from "../agents/model-auth-label.js";
-import { areRuntimeModelRefsEquivalent } from "../agents/model-runtime-aliases.js";
+import {
+  areRuntimeModelRefsEquivalent,
+  shouldPreferActiveRuntimeAliasAuthLabel,
+} from "../agents/model-runtime-aliases.js";
 import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../agents/openai-codex-routing.js";
 import {
@@ -280,10 +283,11 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
     modelRefs.active.label,
   );
   if (
-    runtimeAliasModelEquivalent &&
-    normalizeOptionalLowercaseString(selectedModelAuth) === "unknown" &&
-    activeModelAuth &&
-    normalizeOptionalLowercaseString(activeModelAuth) !== "unknown"
+    shouldPreferActiveRuntimeAliasAuthLabel({
+      runtimeAliasModelEquivalent,
+      selectedAuthLabel: selectedModelAuth,
+      activeAuthLabel: activeModelAuth,
+    })
   ) {
     selectedModelAuth = activeModelAuth;
   }


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Fixes /status rendering for equivalent runtime aliases where the selected config resolves to an env API-key label but the active runtime auth is OAuth.

Why does this matter now?

- Issue #80184 documents a misleading status label for claude-cli OAuth users who also have ANTHROPIC_API_KEY present for a separate provider path.

What is the intended outcome?

- Equivalent runtime aliases such as anthropic/<model> running through claude-cli/<model> display the active OAuth label instead of the unused selected env API-key label.
- The status output does not show unused API-key cost/usage information for that alias case.

What is intentionally out of scope?

- Provider routing, auth resolution, runtime selection, and live credential state are unchanged.
- No changelog entry; this is a focused contributor fix for a display-only issue.

What does success look like?

- /status reports OAuth for the active runtime alias path and keeps existing direct API-key behavior intact.

What should reviewers focus on?

- The renderer-only predicate in src/agents/model-runtime-aliases.ts and its use from both status renderers.
- The regression coverage in src/auto-reply/status.test.ts and src/auto-reply/reply/commands-status.test.ts.

## Linked context

Which issue does this close?

Closes #80184

Which issues, PRs, or discussions are related?

Related #79082, #80260, #80417

Was this requested by a maintainer or owner?

- This follows ClawSweeper's status-rendering guidance on #80184: prefer the active OAuth label and suppress unused API-key cost display only for equivalent runtime aliases.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: /status could show `api-key (env: ANTHROPIC_API_KEY)` for an anthropic selected model even when the active equivalent runtime alias was authenticated through claude-cli OAuth.
- Real environment tested: Contributor source checkout on Windows with focused renderer tests, plus maintainer macOS source checkout on this branch using real Claude Code Max OAuth (`claude auth status` reported logged in via `claude.ai`, subscription `max`) and a throwaway OpenClaw state/config. The maintainer ran `openclaw models auth login --provider anthropic --method cli --set-default` against that throwaway state, which created `anthropic:claude-cli (claude-cli/oauth)`, then rendered `/status` with a dummy `ANTHROPIC_API_KEY` label and the active OAuth profile label. No live channel account state or user state was mutated.
- Exact steps or command run after this patch:
  - `pnpm install` (needed because this worktree initially lacked vitest)
  - `node scripts/run-vitest.mjs src/auto-reply/status.test.ts -- -t "prefers active CLI OAuth"`
  - `node scripts/run-vitest.mjs src/auto-reply/reply/commands-status.test.ts -- -t "prefers active Claude CLI OAuth"`
  - `pnpm exec oxfmt --check src/agents/model-runtime-aliases.ts src/status/status-text.ts src/status/status-message.ts src/auto-reply/status.test.ts src/auto-reply/reply/commands-status.test.ts`
  - `git diff --check origin/main...HEAD`
  - `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-80184.tsbuildinfo`
  - `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test-80184.tsbuildinfo`
  - `codex review --uncommitted`
  - Maintainer: `claude auth status`
  - Maintainer: `OPENCLAW_STATE_DIR=<tmp> OPENCLAW_CONFIG_PATH=<tmp>/openclaw.json pnpm openclaw models auth login --provider anthropic --method cli --set-default`
  - Maintainer: `ANTHROPIC_API_KEY=<dummy> OPENCLAW_STATE_DIR=<tmp> OPENCLAW_CONFIG_PATH=<tmp>/openclaw.json node --import tsx <status-renderer-proof>`
  - Maintainer: `node scripts/run-vitest.mjs src/auto-reply/status.test.ts src/auto-reply/reply/commands-status.test.ts -- -t "prefers active" --reporter=verbose`
  - Maintainer: `git diff --check origin/main...HEAD`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): focused Vitest passed for both status files after the final rebase; oxfmt and diff whitespace checks passed; core and core-test tsgo passed; Codex review reported no regression in the modified paths. Maintainer live proof rendered `Model: anthropic/claude-opus-4-7 · oauth (anthropic:claude-cli)` while the selected label input was `api-key (env: ANTHROPIC_API_KEY)`; the rendered status did not contain `api-key (env: ANTHROPIC_API_KEY)`, did not contain `Usage:`, and the active label came from the throwaway OpenClaw `anthropic:claude-cli` OAuth profile.
- Observed result after fix: The new regressions assert that equivalent runtime aliases render `oauth (anthropic:claude-cli)` / `oauth (claude-cli)`, do not render `api-key (env: ANTHROPIC_API_KEY)`, do not show the runtime alias as a fallback, and suppress unused cost/usage lines in the covered status paths.
- What was not tested: A live chat-channel `/status` message was not sent. The maintainer exercised the real Claude CLI OAuth detection/setup path and the production `/status` renderer locally against throwaway OpenClaw state.
- Proof limitations or environment constraints: The requested scope explicitly avoided touching the user's live VPS/OpenClaw runtime or channel/account state. Maintainer proof used local real Claude CLI OAuth credentials with isolated OpenClaw state and a dummy env key, so it verifies the auth-label rendering path without mutating production channel/gateway state.
- Before evidence (optional but encouraged): ClawSweeper's review on #80184 shows the pre-fix source-level reproduction: selected auth `api-key` plus active auth `oauth` for equivalent `anthropic/*` and `claude-cli/*` refs kept the selected env API-key label.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/auto-reply/status.test.ts -- -t "prefers active CLI OAuth"`
- `node scripts/run-vitest.mjs src/auto-reply/reply/commands-status.test.ts -- -t "prefers active Claude CLI OAuth"`
- `pnpm exec oxfmt --check src/agents/model-runtime-aliases.ts src/status/status-text.ts src/status/status-message.ts src/auto-reply/status.test.ts src/auto-reply/reply/commands-status.test.ts`
- `git diff --check origin/main...HEAD`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-80184.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test-80184.tsbuildinfo`
- `codex review --uncommitted`

What regression coverage was added or updated?

- Added status-message coverage for selected env API-key auth plus active claude-cli OAuth on equivalent runtime aliases.
- Added /status text coverage for the same label-shadowing case.

What failed before this fix, if known?

- Current main preferred the selected env API-key label before considering the active OAuth runtime alias label when selected auth was concrete `api-key` rather than `unknown`.

If no test was added, why not?

- N/A.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. /status text changes for the narrow equivalent-runtime-alias API-key-over-OAuth display case.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No. This is status rendering only; auth resolution and routing are unchanged.

What is the highest-risk area?

- Mislabeling other runtime-alias auth states.

How is that risk mitigated?

- The predicate is limited to equivalent runtime model refs and either the existing unknown-auth fallback or selected API-key labels with active OAuth/token labels.
- Existing direct API-key labels remain preferred outside that runtime-alias OAuth case.

## Current review state

What is the next action?

- Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

- CI is green except the earlier stale proof checks from before maintainer proof was added; maintainer supplied live Claude CLI OAuth renderer proof with isolated OpenClaw state.

Which bot or reviewer comments were addressed?

- No PR comments yet. This implements the ClawSweeper guidance already recorded on #80184.

