### PR TITLE
fix(discord): restore bare numeric channel sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Docs: https://docs.openclaw.ai
 - xAI/LM Studio: avoid buffering ordinary bracketed or `final` prose until stream completion while watching for plain-text tool-call fallbacks.
 - Doctor: warn and continue when the cron job store exists but cannot be read so later health checks still run. Fixes #86102. (#86384) Thanks @1052326311.
 - Discord: suppress a bot's previous reply body and referenced media from prompt context when a user replies to that bot message, while keeping reply metadata for routing. (#86238) Thanks @fuller-stack-dev.
+- Discord: restore bare numeric channel IDs for outbound message-tool sends while keeping explicit DM targets unambiguous. (#86571) Thanks @joshavant.
 - Docker E2E: avoid rebuilding the Control UI twice while preparing the shared OpenClaw package tarball for package-backed scenario runs.
 - Tests: avoid rebuilding the Control UI twice during the installer Docker smoke now that `pnpm build` includes `ui:build`.
 - Tests: give QA config mutation RPCs enough native Windows budget to finish gateway config writes and restart settle after hot scenario runs.

--- a/extensions/discord/src/outbound-session-route.test.ts
+++ b/extensions/discord/src/outbound-session-route.test.ts
@@ -39,4 +39,21 @@ describe("resolveDiscordOutboundSessionRoute", () => {
     });
     expect(route?.threadId).toBeUndefined();
   });
+
+  it("treats bare numeric outbound targets as channel routes", () => {
+    const route = resolveDiscordOutboundSessionRoute({
+      cfg: {},
+      agentId: "main",
+      target: "123",
+    });
+
+    expect(route).toMatchObject({
+      baseSessionKey: "agent:main:discord:channel:123",
+      chatType: "channel",
+      from: "discord:channel:123",
+      peer: { kind: "channel", id: "123" },
+      sessionKey: "agent:main:discord:channel:123",
+      to: "channel:123",
+    });
+  });
 });

--- a/extensions/discord/src/outbound-session-route.ts
+++ b/extensions/discord/src/outbound-session-route.ts
@@ -68,5 +68,5 @@ function resolveDiscordOutboundTargetKindHint(params: {
   if (/^(user:|discord:|@|<@!?)/i.test(target)) {
     return "user";
   }
-  return undefined;
+  return "channel";
 }

--- a/extensions/discord/src/recipient-resolution.ts
+++ b/extensions/discord/src/recipient-resolution.ts
@@ -37,3 +37,13 @@ export async function parseAndResolveRecipient(
   );
   return { kind: resolved.kind, id: resolved.id };
 }
+
+export async function parseAndResolveChannelRecipient(
+  raw: string,
+  cfg: OpenClawConfig,
+  accountId?: string,
+): Promise<DiscordRecipient> {
+  return await parseAndResolveRecipient(raw, cfg, accountId, {
+    defaultKind: "channel",
+  });
+}

--- a/extensions/discord/src/send.components.test.ts
+++ b/extensions/discord/src/send.components.test.ts
@@ -170,6 +170,34 @@ describe("sendDiscordComponentMessage", () => {
     );
   });
 
+  it("treats bare numeric component edit targets as channels", async () => {
+    const { rest, patchMock, getMock } = makeDiscordRest();
+    getMock.mockResolvedValueOnce({
+      type: ChannelType.GuildText,
+      id: "273512430271856640",
+    });
+    patchMock.mockResolvedValueOnce({ id: "msg1", channel_id: "273512430271856640" });
+
+    await editDiscordComponentMessage(
+      "273512430271856640",
+      "msg1",
+      {
+        text: "Updated picker",
+        blocks: [{ type: "actions", buttons: [{ label: "Tap" }] }],
+      },
+      {
+        cfg: DISCORD_TEST_CFG,
+        rest,
+        token: "t",
+        sessionKey: "agent:main:discord:channel:273512430271856640",
+        agentId: "main",
+      },
+    );
+
+    expect(patchMock).toHaveBeenCalledTimes(1);
+    expect(readMockCall(patchMock, 0)[0]).toContain("/channels/273512430271856640/messages/msg1");
+  });
+
   it("registers a prebuilt component message against an edited message id", () => {
     registerBuiltDiscordComponentMessage({
       messageId: "msg1",
@@ -310,6 +338,36 @@ describe("sendDiscordComponentMessage classic message downgrade", () => {
     expect(modals[0]?.title).toBe("Feedback");
     expect(modals[0]?.fields).toHaveLength(1);
     expect(modals[0]?.fields?.[0]?.label).toBe("Notes");
+  });
+
+  it("treats bare numeric component send targets as channels", async () => {
+    const { rest, postMock, getMock } = makeDiscordRest();
+    getMock.mockResolvedValueOnce({
+      type: ChannelType.GuildText,
+      id: "273512430271856640",
+    });
+    postMock.mockResolvedValueOnce({ id: "msg1", channel_id: "273512430271856640" });
+
+    await sendDiscordComponentMessage(
+      "273512430271856640",
+      {
+        text: "report",
+        modal: {
+          title: "Feedback",
+          fields: [{ type: "text", label: "Notes" }],
+        },
+      },
+      {
+        cfg: DISCORD_TEST_CFG,
+        rest,
+        token: "t",
+        mediaUrl: "https://example.com/report.pdf",
+      },
+    );
+
+    expect(sendMessageDiscordMock).not.toHaveBeenCalled();
+    expect(postMock).toHaveBeenCalledTimes(1);
+    expect(readMockCall(postMock, 0)[0]).toContain("/channels/273512430271856640/messages");
   });
 
   it("keeps spoiler file blocks on the component path", async () => {

--- a/extensions/discord/src/send.components.ts
+++ b/extensions/discord/src/send.components.ts
@@ -21,7 +21,7 @@ import {
   type MessagePayloadObject,
   type RequestClient,
 } from "./internal/discord.js";
-import { parseAndResolveRecipient } from "./recipient-resolution.js";
+import { parseAndResolveChannelRecipient } from "./recipient-resolution.js";
 import { loadOutboundMediaFromUrl } from "./runtime-api.js";
 import { sendMessageDiscord } from "./send.outbound.js";
 import { createDiscordSendResult } from "./send.receipt.js";
@@ -290,7 +290,7 @@ export async function sendDiscordComponentMessage(
   const cfg = requireRuntimeConfig(opts.cfg, "Discord component send");
   const accountInfo = resolveDiscordAccount({ cfg, accountId: opts.accountId });
   const { token, rest, request } = createDiscordClient({ ...opts, cfg });
-  const recipient = await parseAndResolveRecipient(to, cfg, opts.accountId);
+  const recipient = await parseAndResolveChannelRecipient(to, cfg, opts.accountId);
   const { channelId } = await resolveChannelId(rest, recipient, request);
 
   const channelType = await resolveDiscordChannelType(rest, channelId);
@@ -353,7 +353,7 @@ export async function editDiscordComponentMessage(
   const cfg = requireRuntimeConfig(opts.cfg, "Discord component edit");
   const accountInfo = resolveDiscordAccount({ cfg, accountId: opts.accountId });
   const { token, rest, request } = createDiscordClient({ ...opts, cfg });
-  const recipient = await parseAndResolveRecipient(to, cfg, opts.accountId);
+  const recipient = await parseAndResolveChannelRecipient(to, cfg, opts.accountId);
   const { channelId } = await resolveChannelId(rest, recipient, request);
   const { body, buildResult } = await buildDiscordComponentPayload({
     spec,

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -11,7 +11,7 @@ import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
 import { resolveDiscordAccount } from "./accounts.js";
 import { createChannelMessage, createThread, type RequestClient } from "./internal/discord.js";
 import { rewriteDiscordKnownMentions } from "./mentions.js";
-import { parseAndResolveRecipient } from "./recipient-resolution.js";
+import { parseAndResolveChannelRecipient } from "./recipient-resolution.js";
 import { createDiscordSendResult, type DiscordReceiptResultSource } from "./send.receipt.js";
 import {
   buildDiscordMessageRequest,
@@ -140,7 +140,7 @@ async function resolveDiscordSendTarget(
 ): Promise<{ rest: RequestClient; request: DiscordClientRequest; channelId: string }> {
   const cfg = requireRuntimeConfig(opts.cfg, "Discord send target resolution");
   const { rest, request } = createDiscordClient({ ...opts, cfg });
-  const recipient = await parseAndResolveRecipient(to, cfg, opts.accountId);
+  const recipient = await parseAndResolveChannelRecipient(to, cfg, opts.accountId);
   const { channelId } = await resolveChannelId(rest, recipient, request);
   return { rest, request, channelId };
 }
@@ -181,7 +181,7 @@ export async function sendMessageDiscord(
     mentionAliases: accountInfo.config.mentionAliases,
   });
   const { token, rest, request } = createDiscordClient({ ...opts, cfg });
-  const recipient = await parseAndResolveRecipient(to, cfg, opts.accountId);
+  const recipient = await parseAndResolveChannelRecipient(to, cfg, opts.accountId);
   const { channelId } = await resolveChannelId(rest, recipient, request);
 
   // Forum/Media channels reject POST /messages; auto-create a thread post instead.

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -469,29 +469,23 @@ describe("sendMessageDiscord", () => {
     expect(res.channelId).toBe("chan1");
   });
 
-  it("rejects bare numeric IDs as ambiguous", async () => {
-    const { rest } = makeDiscordRest();
-    await expect(
-      sendMessageDiscord("273512430271856640", "hello", {
-        rest,
-        token: "t",
-        cfg: DISCORD_TEST_CFG,
-      }),
-    ).rejects.toThrow(/Ambiguous Discord recipient/);
-    await expect(
-      sendMessageDiscord("273512430271856640", "hello", {
-        rest,
-        token: "t",
-        cfg: DISCORD_TEST_CFG,
-      }),
-    ).rejects.toThrow(/user:273512430271856640/);
-    await expect(
-      sendMessageDiscord("273512430271856640", "hello", {
-        rest,
-        token: "t",
-        cfg: DISCORD_TEST_CFG,
-      }),
-    ).rejects.toThrow(/channel:273512430271856640/);
+  it("treats bare numeric outbound IDs as channels", async () => {
+    const { rest, postMock, getMock } = makeDiscordRest();
+    getMock.mockResolvedValueOnce({ type: ChannelType.GuildText });
+    postMock.mockResolvedValueOnce({
+      id: "msg1",
+      channel_id: "273512430271856640",
+    });
+
+    const result = await sendMessageDiscord("273512430271856640", "hello", {
+      rest,
+      token: "t",
+      cfg: DISCORD_TEST_CFG,
+    });
+
+    expect(result.channelId).toBe("273512430271856640");
+    expectRestRoute(postMock, 0, Routes.channelMessages("273512430271856640"));
+    expect(requireRestBody(postMock).content).toBe("hello");
   });
 
   it("adds missing permission hints on 50013", async () => {

--- a/extensions/discord/src/send.voice.test.ts
+++ b/extensions/discord/src/send.voice.test.ts
@@ -1,0 +1,63 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeDiscordRest } from "./send.test-harness.js";
+
+const loadWebMediaRawMock = vi.hoisted(() => vi.fn());
+vi.mock("openclaw/plugin-sdk/web-media", () => ({
+  loadWebMediaRaw: loadWebMediaRawMock,
+}));
+
+const voiceMocks = vi.hoisted(() => ({
+  ensureOggOpus: vi.fn(),
+  getVoiceMessageMetadata: vi.fn(),
+  sendDiscordVoiceMessage: vi.fn(),
+}));
+vi.mock("./voice-message.js", () => voiceMocks);
+
+const DISCORD_TEST_CFG = {
+  channels: { discord: { token: "t" } },
+};
+
+let sendVoiceMessageDiscord: typeof import("./send.voice.js").sendVoiceMessageDiscord;
+
+describe("sendVoiceMessageDiscord", () => {
+  beforeAll(async () => {
+    ({ sendVoiceMessageDiscord } = await import("./send.voice.js"));
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadWebMediaRawMock.mockResolvedValue({
+      buffer: Buffer.from("voice"),
+      fileName: "voice.ogg",
+      contentType: "audio/ogg",
+      kind: "audio",
+    });
+    voiceMocks.ensureOggOpus.mockImplementation(async (inputPath: string) => ({
+      path: inputPath,
+      cleanup: false,
+    }));
+    voiceMocks.getVoiceMessageMetadata.mockResolvedValue({ duration_secs: 1, waveform: "" });
+    voiceMocks.sendDiscordVoiceMessage.mockResolvedValue({
+      id: "msg1",
+      channel_id: "273512430271856640",
+    });
+  });
+
+  it("treats bare numeric voice targets as channels", async () => {
+    const { rest } = makeDiscordRest();
+
+    const result = await sendVoiceMessageDiscord(
+      "273512430271856640",
+      "https://example.com/voice.ogg",
+      {
+        cfg: DISCORD_TEST_CFG,
+        rest,
+        token: "t",
+      },
+    );
+
+    expect(result.channelId).toBe("273512430271856640");
+    expect(voiceMocks.sendDiscordVoiceMessage).toHaveBeenCalledTimes(1);
+    expect(voiceMocks.sendDiscordVoiceMessage.mock.calls[0]?.[1]).toBe("273512430271856640");
+  });
+});

--- a/extensions/discord/src/send.voice.ts
+++ b/extensions/discord/src/send.voice.ts
@@ -13,7 +13,7 @@ import { tempWorkspace, resolvePreferredOpenClawTmpDir } from "openclaw/plugin-s
 import { loadWebMediaRaw } from "openclaw/plugin-sdk/web-media";
 import { resolveDiscordAccount } from "./accounts.js";
 import type { RequestClient } from "./internal/discord.js";
-import { parseAndResolveRecipient } from "./recipient-resolution.js";
+import { parseAndResolveChannelRecipient } from "./recipient-resolution.js";
 import { createDiscordSendResult } from "./send.receipt.js";
 import { buildDiscordSendError, createDiscordClient, resolveChannelId } from "./send.shared.js";
 import type { DiscordSendResult } from "./send.types.js";
@@ -95,7 +95,7 @@ export async function sendVoiceMessageDiscord(
     token = client.token;
     rest = client.rest;
     const request = client.request;
-    const recipient = await parseAndResolveRecipient(to, cfg, opts.accountId);
+    const recipient = await parseAndResolveChannelRecipient(to, cfg, opts.accountId);
     channelId = (await resolveChannelId(rest, recipient, request)).channelId;
 
     const ogg = await ensureOggOpus(localInputPath);


### PR DESCRIPTION
## Summary

- Restore Discord outbound channel-send target resolution so bare numeric channel IDs resolve as channels in text, structured, component, and voice send paths.
- Keep generic Discord target parsing ambiguous when no default kind is available, preserving explicit DM syntax and allowFrom DM compatibility.
- Add focused regressions for bare numeric text sends, component send/edit, voice sends, and outbound session routing.

Fixes #86001

## Verification

- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings.
- `node scripts/run-vitest.mjs extensions/discord/src/send.sends-basic-channel-messages.test.ts extensions/discord/src/send.components.test.ts extensions/discord/src/send.voice.test.ts extensions/discord/src/outbound-session-route.test.ts extensions/discord/src/targets.test.ts` — 5 files, 75 tests passed.
- `git diff --check` passed.

## Real behavior proof

Behavior addressed: Discord channel outbound sends whose target is a bare numeric channel ID now deliver to that channel instead of failing with `Ambiguous Discord recipient`.

Real environment tested: AWS Crabbox Linux runner with a real Discord Convex pooled credential (`kind: "discord"`, role `ci`) against current branch changes.

Exact steps or command run after this patch: Ran a Crabbox AWS script that leased a real Discord credential, sent a control message to `channel:<id>` through `sendMessageDiscord`, sent a second message through the same production send path using bare numeric `<id>`, and polled Discord REST for both markers.

Evidence after fix: AWS Crabbox provider `aws`, run `run_afc68d8a9f68`, lease `cbx_b3fe48870a99`, exit `0`. The proof reported prefixed channel send delivered `true`, bare numeric send error `null`, bare numeric marker delivered `true`, and ambiguous failure observed `false`.

Observed result after fix: The formerly failing bare numeric Discord channel target delivered successfully in the real send path.

What was not tested: Full Discord QA scenario matrix and Discord voice delivery against a live audio file were not run; the voice path is covered by focused unit regression around target resolution.

## Agent Transcript

<details>
<summary>Redacted Codex session transcript</summary>

```text
source: local Codex session
redaction: local paths, secrets, auth details, raw tool outputs
omitted: raw tool outputs, system/developer prompts, credential contents

[user]
Analyze OpenClaw issue #86001, considering all comments. Do not assign the requester. First establish a live AWS Crabbox E2E reproduction from current main. If credentials are needed, stop and ask. Also check Convex credential kinds; do not lease telegram-user.

[assistant]
Started from clean main, used the OpenClaw issue/PR maintainer workflow, and did not mutate assignment. gitcrawl was stale for the target thread, so live GitHub was used. Fast-forwarded to origin/main at dd375f9fc3.

Read issue #86001 and PR #85160. Confirmed #86001 reports Discord bare numeric channel IDs failing with "Ambiguous Discord recipient". PR #85160 is Codex native compaction/session lifecycle work, not Discord target parsing.

Checked credential availability. Convex credential broker supports kind "discord"; no telegram-user lease was attempted.

[user]
Credential env files have been recreated. Check them again.

[assistant]
Confirmed credential files were present with private permissions and used them without printing secret contents. Probed Convex kind "discord"; lease succeeded with expected metadata and was released.

Established live AWS Crabbox repro on current main:
- provider: aws
- repo SHA: dd375f9fc39e0f694061c2988fde732d14f5aede
- live Discord credential source: Convex kind "discord", role "ci"
- first sent with channel:<id> and confirmed delivery
- then sent through the same production sendMessageDiscord path with bare numeric to:<channelId>
- observed "Ambiguous Discord recipient"
- polled the channel and confirmed the bare numeric marker was not delivered
- released lease and cleaned up the control message

Source finding:
- extensions/discord/src/target-parsing.ts throws on numeric targets unless defaultKind is provided
- extensions/discord/src/recipient-resolution.ts defaulted parse options to {}
- extensions/discord/src/send.outbound.ts, send.components.ts, and send.voice.ts called recipient resolution without defaultKind
- docs/channels/discord.md documents that bare numeric IDs normally resolve as channels when a channel default is active

[assistant]
Concluded the issue is real breakage, not a feature request. The root cause is missing channel-default context at Discord outbound send boundaries, not the parser’s ambiguity check. PR #85160 is unrelated; the repro used a fresh AWS process, fresh Discord lease, and direct current-main Discord send path.

[user]
Is the proposed fix root-cause or symptom? Is it the best fix? Are we confident?

[assistant]
Recommended a targeted fix: outbound Discord channel-send surfaces should pass channel default context explicitly, while the generic parser should remain ambiguous when no default exists. Explicit user:<id> and <@id> DM targets still win, and allowFrom numeric DM compatibility remains preserved in the resolver.

[user]
Create a feature branch, implement the fix. Then run autoreview, then fix proof and regression repro.

[assistant]
Created branch fix/discord-bare-numeric-channel-targets. Implemented parseAndResolveChannelRecipient and updated Discord outbound text, structured, component, voice, and session route paths to preserve channel-default context.

Added/updated regression coverage for:
- bare numeric text sends
- component send/edit
- voice send
- outbound session route
- generic parser ambiguity remains covered by target parser tests

Ran autoreview:
.agents/skills/autoreview/scripts/autoreview --mode local
Result: clean, no accepted/actionable findings.

Ran focused fix proof:
node scripts/run-vitest.mjs extensions/discord/src/send.sends-basic-channel-messages.test.ts extensions/discord/src/send.components.test.ts extensions/discord/src/send.voice.test.ts extensions/discord/src/outbound-session-route.test.ts extensions/discord/src/targets.test.ts
Result: 5 files passed, 75 tests passed.

Ran live AWS Discord regression repro against the branch:
- provider: aws
- dirty branch patch synced
- same real Discord send path
- prefixed channel send delivered: true
- bare numeric send error: null
- bare numeric marker delivered: true
- ambiguous failure observed: false

Ran git diff --check: clean.

[user]
Open a PR without changelog entries first. After creating the PR, add changelog entry with PR number and thanks @joshavant. Watch CI until green except Real behavior proof.

[assistant]
Prepared to commit code-only changes and create the PR first, then add a separate changelog commit with the PR number as requested. Checked for a local agent transcript before PR body insertion and asked whether to include it.
```

</details>
