### PR TITLE
fix(gateway): dampen repeated device-required probes

### DIFF
--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -180,6 +180,31 @@ function expectProbeAuthFields(
   }
 }
 
+let probeUrlSeq = 0;
+
+function nextProbeUrl(label: string): string {
+  probeUrlSeq += 1;
+  return `ws://127.0.0.1:18789/${label}-${probeUrlSeq}`;
+}
+
+function setDeviceRequiredProbeMode(): void {
+  deviceIdentityState.cachedToken = null;
+  gatewayClientState.startMode = "close";
+  gatewayClientState.close = { code: 1008, reason: "device identity required" };
+}
+
+function lastGatewayClientOptions(): Record<string, unknown> | null {
+  return gatewayClientState.options;
+}
+
+async function runLightweightProbe(url: string): Promise<Awaited<ReturnType<typeof probeGateway>>> {
+  return await probeGateway({
+    url,
+    timeoutMs: 1_000,
+    includeDetails: false,
+  });
+}
+
 describe("probeGateway", () => {
   beforeEach(() => {
     deviceIdentityState.throwOnLoad = false;
@@ -535,5 +560,161 @@ describe("probeGateway", () => {
       error: null,
       close: null,
     });
+  });
+
+  it("short-circuits later unpaired probes after repeated device-required closes", async () => {
+    setDeviceRequiredProbeMode();
+    const url = nextProbeUrl("device-required");
+
+    for (let i = 0; i < 3; i += 1) {
+      gatewayClientState.options = null;
+      const result = await runLightweightProbe(url);
+
+      expectProbeResultFields(result, {
+        ok: false,
+        error: "gateway closed (1008): device identity required",
+        close: { code: 1008, reason: "device identity required" },
+      });
+      expect(lastGatewayClientOptions()?.url).toBe(url);
+    }
+
+    const startCalls = gatewayClientState.startCalls;
+    gatewayClientState.options = null;
+
+    const result = await runLightweightProbe(url);
+
+    expectProbeResultFields(result, {
+      ok: false,
+      connectLatencyMs: null,
+      error: "gateway closed (1008): device identity required",
+      close: {
+        code: 1008,
+        reason: "device identity required",
+        hint: "probe short-circuited by recent device-required rejections",
+      },
+      health: null,
+      status: null,
+      presence: null,
+      configSnapshot: null,
+    });
+    expectProbeAuthFields(result, {
+      role: null,
+      scopes: [],
+      capability: "unknown",
+    });
+    expect(gatewayClientState.startCalls).toBe(startCalls);
+    expect(lastGatewayClientOptions()).toBeNull();
+  });
+
+  it("does not cache other policy-close reasons", async () => {
+    deviceIdentityState.cachedToken = null;
+    gatewayClientState.startMode = "close";
+    gatewayClientState.close = { code: 1008, reason: "pairing required" };
+    const url = nextProbeUrl("pairing-required");
+
+    for (let i = 0; i < 4; i += 1) {
+      gatewayClientState.options = null;
+      const result = await runLightweightProbe(url);
+
+      expect(result.close).toEqual({ code: 1008, reason: "pairing required" });
+      expect(lastGatewayClientOptions()?.url).toBe(url);
+    }
+  });
+
+  it("keeps device-required probe cache entries per URL", async () => {
+    setDeviceRequiredProbeMode();
+    const firstUrl = nextProbeUrl("first-device-required");
+    const secondUrl = nextProbeUrl("second-device-required");
+
+    for (let i = 0; i < 3; i += 1) {
+      await runLightweightProbe(firstUrl);
+    }
+
+    gatewayClientState.options = null;
+    const result = await runLightweightProbe(secondUrl);
+
+    expect(result.close).toEqual({ code: 1008, reason: "device identity required" });
+    expect(result.close?.hint).toBeUndefined();
+    expect(lastGatewayClientOptions()?.url).toBe(secondUrl);
+  });
+
+  it("expires device-required probe cache entries after the TTL", async () => {
+    setDeviceRequiredProbeMode();
+    const url = nextProbeUrl("ttl-device-required");
+    let nowMs = 1_000_000;
+    const dateNowSpy = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+    try {
+      for (let i = 0; i < 3; i += 1) {
+        await runLightweightProbe(url);
+      }
+
+      nowMs += 5 * 60_000;
+      gatewayClientState.options = null;
+      const result = await runLightweightProbe(url);
+
+      expect(result.close).toEqual({ code: 1008, reason: "device identity required" });
+      expect(result.close?.hint).toBeUndefined();
+      expect(lastGatewayClientOptions()?.url).toBe(url);
+    } finally {
+      dateNowSpy.mockRestore();
+    }
+  });
+
+  it("lets paired probes clear prior device-required failures", async () => {
+    setDeviceRequiredProbeMode();
+    const url = nextProbeUrl("paired-device-required");
+
+    for (let i = 0; i < 3; i += 1) {
+      await runLightweightProbe(url);
+    }
+
+    deviceIdentityState.cachedToken = {
+      token: "cached-operator-token",
+      role: "operator",
+      scopes: ["operator.read"],
+      updatedAtMs: 1,
+    };
+    gatewayClientState.startMode = "hello";
+    gatewayClientState.options = null;
+
+    const success = await runLightweightProbe(url);
+
+    expect(success.ok).toBe(true);
+    expect(lastGatewayClientOptions()?.url).toBe(url);
+    expect(lastGatewayClientOptions()?.deviceIdentity).toEqual(deviceIdentityState.value);
+
+    setDeviceRequiredProbeMode();
+    gatewayClientState.options = null;
+    const afterSuccess = await runLightweightProbe(url);
+
+    expect(afterSuccess.close).toEqual({ code: 1008, reason: "device identity required" });
+    expect(afterSuccess.close?.hint).toBeUndefined();
+    expect(lastGatewayClientOptions()?.url).toBe(url);
+  });
+
+  it("does not short-circuit explicit-auth probes after unauthenticated failures", async () => {
+    setDeviceRequiredProbeMode();
+    const url = nextProbeUrl("explicit-auth-device-required");
+
+    for (let i = 0; i < 3; i += 1) {
+      await runLightweightProbe(url);
+    }
+
+    gatewayClientState.startMode = "hello";
+    gatewayClientState.helloAuth = {};
+    gatewayClientState.options = null;
+
+    const result = await probeGateway({
+      url,
+      auth: { token: "explicit-token" },
+      timeoutMs: 1_000,
+      includeDetails: false,
+    });
+
+    expect(result.ok).toBe(true);
+    expectProbeAuthFields(result, { capability: "connected_no_operator_scope" });
+    expect(lastGatewayClientOptions()?.url).toBe(url);
+    expect(lastGatewayClientOptions()?.token).toBe("explicit-token");
+    expect(lastGatewayClientOptions()?.deviceIdentity).toBeNull();
   });
 });

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -61,6 +61,17 @@ const PAIRING_REQUIRED_PATTERN = /\bpairing required\b/i;
 const OPERATOR_READ_SCOPE = "operator.read";
 const OPERATOR_WRITE_SCOPE = "operator.write";
 const OPERATOR_ADMIN_SCOPE = "operator.admin";
+const DEVICE_IDENTITY_REQUIRED_CLOSE_CODE = 1008;
+const DEVICE_IDENTITY_REQUIRED_CLOSE_REASON = "device identity required";
+const DEVICE_REQUIRED_PROBE_FAILURE_THRESHOLD = 3;
+const DEVICE_REQUIRED_PROBE_TTL_MS = 5 * 60_000;
+
+type DeviceRequiredProbeCacheEntry = {
+  failures: number;
+  firstFailureAtMs: number;
+};
+
+const deviceRequiredProbeCache = new Map<string, DeviceRequiredProbeCacheEntry>();
 
 export function clampProbeTimeoutMs(timeoutMs: number): number {
   return resolveSafeTimeoutDelayMs(timeoutMs, { minMs: MIN_PROBE_TIMEOUT_MS });
@@ -68,6 +79,50 @@ export function clampProbeTimeoutMs(timeoutMs: number): number {
 
 function formatProbeCloseError(close: GatewayProbeClose): string {
   return `gateway closed (${close.code}): ${close.reason}`;
+}
+
+function resolveDeviceRequiredProbeCacheKey(url: string): string {
+  try {
+    return new URL(url).href;
+  } catch {
+    return url;
+  }
+}
+
+function isDeviceIdentityRequiredClose(close: GatewayProbeClose | null): boolean {
+  return (
+    close?.code === DEVICE_IDENTITY_REQUIRED_CLOSE_CODE &&
+    close.reason.trim().toLowerCase() === DEVICE_IDENTITY_REQUIRED_CLOSE_REASON
+  );
+}
+
+function hasProbeAuth(auth: GatewayProbeAuth | undefined): boolean {
+  return Boolean(auth?.token?.trim() || auth?.password?.trim());
+}
+
+function shouldShortCircuitDeviceRequiredProbe(cacheKey: string, nowMs: number): boolean {
+  const entry = deviceRequiredProbeCache.get(cacheKey);
+  if (!entry) {
+    return false;
+  }
+  if (nowMs - entry.firstFailureAtMs >= DEVICE_REQUIRED_PROBE_TTL_MS) {
+    deviceRequiredProbeCache.delete(cacheKey);
+    return false;
+  }
+  return entry.failures >= DEVICE_REQUIRED_PROBE_FAILURE_THRESHOLD;
+}
+
+function noteDeviceRequiredProbeFailure(cacheKey: string, nowMs: number): void {
+  const existing = deviceRequiredProbeCache.get(cacheKey);
+  if (!existing || nowMs - existing.firstFailureAtMs >= DEVICE_REQUIRED_PROBE_TTL_MS) {
+    deviceRequiredProbeCache.set(cacheKey, { failures: 1, firstFailureAtMs: nowMs });
+    return;
+  }
+  existing.failures += 1;
+}
+
+function clearDeviceRequiredProbeFailures(cacheKey: string): void {
+  deviceRequiredProbeCache.delete(cacheKey);
 }
 
 function emptyProbeAuth(): GatewayProbeAuthSummary {
@@ -82,6 +137,27 @@ function emptyProbeServer(): GatewayProbeServerSummary {
   return {
     version: null,
     connId: null,
+  };
+}
+
+function makeDeviceRequiredShortCircuitResult(url: string): GatewayProbeResult {
+  const close = {
+    code: DEVICE_IDENTITY_REQUIRED_CLOSE_CODE,
+    reason: DEVICE_IDENTITY_REQUIRED_CLOSE_REASON,
+    hint: "probe short-circuited by recent device-required rejections",
+  };
+  return {
+    ok: false,
+    url,
+    connectLatencyMs: null,
+    error: formatProbeCloseError(close),
+    close,
+    auth: emptyProbeAuth(),
+    server: emptyProbeServer(),
+    health: null,
+    status: null,
+    presence: null,
+    configSnapshot: null,
   };
 }
 
@@ -191,6 +267,11 @@ export async function probeGateway(opts: {
       return null;
     }
   })();
+  const cacheKey = resolveDeviceRequiredProbeCacheKey(opts.url);
+  const cacheEligible = deviceIdentity == null && !hasProbeAuth(opts.auth);
+  if (cacheEligible && shouldShortCircuitDeviceRequiredProbe(cacheKey, Date.now())) {
+    return makeDeviceRequiredShortCircuitResult(opts.url);
+  }
   const initialProbeTimeoutMs = clampProbeTimeoutMs(opts.timeoutMs);
 
   return await new Promise<GatewayProbeResult>((resolve) => {
@@ -219,6 +300,11 @@ export async function probeGateway(opts: {
       startAbort.abort();
       clearProbeTimer();
       client.stop();
+      if (result.ok) {
+        clearDeviceRequiredProbeFailures(cacheKey);
+      } else if (cacheEligible && isDeviceIdentityRequiredClose(result.close)) {
+        noteDeviceRequiredProbeFailure(cacheKey, Date.now());
+      }
       const { connectErrorDetails: resultConnectErrorDetails, ...rest } = result;
       resolve({
         url: opts.url,


### PR DESCRIPTION
## Summary
- Add per-URL dampening for repeated unauthenticated/no-device gateway probe closes with `1008: device identity required`.
- Preserve explicit token/password probes and paired probes so recovery paths still reach the gateway.
- Add focused regression coverage for threshold, TTL, URL scoping, paired recovery, and explicit-auth recovery.

Refs #63427.

## AI assistance disclosure
This change was developed with OpenAI Codex assistance. `codex review --base origin/main` found an explicit-auth edge case during development; that finding was fixed and the rerun reported no actionable regressions before the final rebase.

## Real behavior proof
Behavior addressed: Repeated fresh CLI gateway probes no longer keep opening WebSocket connections after repeated `DEVICE_IDENTITY_REQUIRED` rejections.

Real environment tested: Local OpenClaw gateway started from the patched tree with `auth: { mode: "none" }`, then `probeGateway` called four times against the same loopback URL.

Exact steps or command run after this patch: `node --import tsx .artifacts/63427-real-proof.mjs`

Evidence after fix:
```text
proof-url ws://127.0.0.1:45661
{"attempt":1,"ok":false,"error":"device identity required","close":{"code":1008,"reason":"device identity required"},"connectErrorDetails":{"code":"DEVICE_IDENTITY_REQUIRED"},"authCapability":"unknown","server":{"version":null,"connId":null}}
{"attempt":2,"ok":false,"error":"device identity required","close":{"code":1008,"reason":"device identity required"},"connectErrorDetails":{"code":"DEVICE_IDENTITY_REQUIRED"},"authCapability":"unknown","server":{"version":null,"connId":null}}
{"attempt":3,"ok":false,"error":"device identity required","close":{"code":1008,"reason":"device identity required"},"connectErrorDetails":{"code":"DEVICE_IDENTITY_REQUIRED"},"authCapability":"unknown","server":{"version":null,"connId":null}}
{"attempt":4,"ok":false,"error":"gateway closed (1008): device identity required","close":{"code":1008,"reason":"device identity required","hint":"probe short-circuited by recent device-required rejections"},"connectErrorDetails":null,"authCapability":"unknown","server":{"version":null,"connId":null}}
```

Observed result after fix: The first three probes receive real gateway `DEVICE_IDENTITY_REQUIRED` closes. The fourth returns the short-circuit result and does not produce another gateway close.

What was not tested: Cross-process dampening, because this patch intentionally keeps the cache process-local.

## Root Cause
The reconnect pause lived inside each `GatewayClient` instance. CLI/status/restart probe paths create fresh probe clients, so repeated probe calls had no shared memory of the device-required rejection.

## Regression Test Plan
- `PATH="$HOME/.local/bin:$PATH" pnpm test src/gateway/probe.test.ts -- --reporter=verbose`
- `PATH="$HOME/.local/bin:$PATH" OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm check:changed -- --base upstream/main`

## Security Impact
No auth bypass. The cache only suppresses repeated unauthenticated/no-device probe attempts after the exact device-required close. Explicit gateway auth and paired device identity probes still run.

## Human Verification
Marked ready for maintainer review after local validation, real proof, and ClawSweeper readiness review.

## Risks
The cache is process-local and TTL-based. That matches the reported repeated in-process probe loop, but it does not coordinate separate CLI processes.

## Validation
- `PATH="$HOME/.local/bin:$PATH" pnpm install --frozen-lockfile` passed
- `PATH="$HOME/.local/bin:$PATH" pnpm test src/gateway/probe.test.ts -- --reporter=verbose` passed, 26 tests
- `git diff --check upstream/main` passed
- `PATH="$HOME/.local/bin:$PATH" OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm check:changed -- --base upstream/main` passed
- `node --import tsx .artifacts/63427-real-proof.mjs` passed with the real proof above

