### PR TITLE
fix(discord): persist inbound replay recovery

### DIFF
--- a/extensions/discord/src/monitor/inbound-dedupe.ts
+++ b/extensions/discord/src/monitor/inbound-dedupe.ts
@@ -1,15 +1,45 @@
+import path from "node:path";
 import { createClaimableDedupe, type ClaimableDedupe } from "openclaw/plugin-sdk/persistent-dedupe";
 import type { DiscordMessageEvent } from "./listeners.js";
 import { resolveDiscordMessageChannelId } from "./message-utils.js";
 
 const RECENT_DISCORD_MESSAGE_TTL_MS = 5 * 60_000;
 const RECENT_DISCORD_MESSAGE_MAX = 5000;
+const RECENT_DISCORD_MESSAGE_FILE_MAX = 50_000;
 
-export function createDiscordInboundReplayGuard(): ClaimableDedupe {
-  return createClaimableDedupe({
-    ttlMs: RECENT_DISCORD_MESSAGE_TTL_MS,
-    memoryMaxSize: RECENT_DISCORD_MESSAGE_MAX,
-  });
+function sanitizeFileSegment(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "default";
+  }
+  return trimmed.replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
+export function createDiscordInboundReplayGuard(params?: {
+  stateDir?: string;
+  onDiskError?: (error: unknown) => void;
+}): ClaimableDedupe {
+  const stateDir = params?.stateDir?.trim();
+  return createClaimableDedupe(
+    stateDir
+      ? {
+          ttlMs: RECENT_DISCORD_MESSAGE_TTL_MS,
+          memoryMaxSize: RECENT_DISCORD_MESSAGE_MAX,
+          fileMaxEntries: RECENT_DISCORD_MESSAGE_FILE_MAX,
+          resolveFilePath: (namespace) =>
+            path.join(
+              stateDir,
+              "discord",
+              "inbound-replay",
+              `${sanitizeFileSegment(namespace)}.json`,
+            ),
+          onDiskError: params?.onDiskError,
+        }
+      : {
+          ttlMs: RECENT_DISCORD_MESSAGE_TTL_MS,
+          memoryMaxSize: RECENT_DISCORD_MESSAGE_MAX,
+        },
+  );
 }
 
 export class DiscordRetryableInboundError extends Error {
@@ -38,6 +68,7 @@ export function buildDiscordInboundReplayKey(params: {
 }
 
 export async function claimDiscordInboundReplay(params: {
+  accountId: string;
   replayKey?: string | null;
   replayGuard: ClaimableDedupe;
 }): Promise<boolean> {
@@ -45,25 +76,40 @@ export async function claimDiscordInboundReplay(params: {
   if (!replayKey) {
     return true;
   }
-  const claim = await params.replayGuard.claim(replayKey);
+  const claim = await params.replayGuard.claim(replayKey, {
+    namespace: params.accountId,
+  });
   return claim.kind === "claimed";
 }
 
 export async function commitDiscordInboundReplay(params: {
+  accountId: string;
   replayKeys?: readonly (string | null | undefined)[];
   replayGuard: ClaimableDedupe;
 }): Promise<void> {
   const replayKeys = normalizeDiscordInboundReplayKeys(params.replayKeys);
-  await Promise.all(replayKeys.map((replayKey) => params.replayGuard.commit(replayKey)));
+  await Promise.all(
+    replayKeys.map((replayKey) =>
+      params.replayGuard.commit(replayKey, {
+        namespace: params.accountId,
+      }),
+    ),
+  );
 }
 
 export function releaseDiscordInboundReplay(params: {
+  accountId: string;
   replayKeys?: readonly (string | null | undefined)[];
   replayGuard: ClaimableDedupe;
   error?: unknown;
 }): void {
   const replayKeys = normalizeDiscordInboundReplayKeys(params.replayKeys);
-  replayKeys.forEach((replayKey) => params.replayGuard.release(replayKey, { error: params.error }));
+  replayKeys.forEach((replayKey) =>
+    params.replayGuard.release(replayKey, {
+      namespace: params.accountId,
+      error: params.error,
+    }),
+  );
 }
 
 function normalizeDiscordInboundReplayKeys(

--- a/extensions/discord/src/monitor/inbound-dedupe.ts
+++ b/extensions/discord/src/monitor/inbound-dedupe.ts
@@ -76,10 +76,28 @@ export async function claimDiscordInboundReplay(params: {
   if (!replayKey) {
     return true;
   }
-  const claim = await params.replayGuard.claim(replayKey, {
-    namespace: params.accountId,
-  });
-  return claim.kind === "claimed";
+
+  let releaseRetries = 0;
+  while (true) {
+    const claim = await params.replayGuard.claim(replayKey, {
+      namespace: params.accountId,
+    });
+    if (claim.kind === "claimed") {
+      return true;
+    }
+    if (claim.kind === "duplicate") {
+      return false;
+    }
+    try {
+      await claim.pending;
+      return false;
+    } catch {
+      releaseRetries += 1;
+      if (releaseRetries > 1) {
+        return false;
+      }
+    }
+  }
 }
 
 export async function commitDiscordInboundReplay(params: {

--- a/extensions/discord/src/monitor/message-handler.preflight-logging.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight-logging.ts
@@ -34,3 +34,17 @@ export function logDiscordPreflightInboundSummary(params: {
     `discord: inbound id=${params.messageId} guild=${params.guildId ?? "dm"} channel=${params.channelId} mention=${params.wasMentioned ? "yes" : "no"} type=${params.isDirectMessage ? "dm" : params.isGroupDm ? "group-dm" : "guild"} content=${params.hasContent ? "yes" : "no"}`,
   );
 }
+
+export function logDiscordInboundOutcome(params: {
+  accountId: string;
+  channelId: string;
+  messageId: string;
+  outcome: string;
+  isDirectMessage: boolean;
+  isGroupDm: boolean;
+  reason?: string;
+}) {
+  logVerbose(
+    `discord inbound outcome: account=${params.accountId} channel=${params.channelId} message=${params.messageId} type=${params.isDirectMessage ? "dm" : params.isGroupDm ? "group-dm" : "guild"} outcome=${params.outcome}${params.reason ? ` reason=${params.reason}` : ""}`,
+  );
+}

--- a/extensions/discord/src/monitor/message-handler.preflight.acp-bindings.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.acp-bindings.test.ts
@@ -1,4 +1,5 @@
 import * as conversationBindingRuntime from "openclaw/plugin-sdk/conversation-binding-runtime";
+import * as runtimeEnv from "openclaw/plugin-sdk/runtime-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const ensureConfiguredBindingRouteReadyMock = vi.hoisted(() => vi.fn());
@@ -228,6 +229,8 @@ async function runRestHydrationPreflight(params: {
 describe("preflightDiscordMessage configured ACP bindings", () => {
   beforeEach(() => {
     sessionBindingTesting.resetSessionBindingAdaptersForTests();
+    vi.spyOn(runtimeEnv, "logVerbose").mockImplementation(() => undefined);
+    vi.mocked(runtimeEnv.logVerbose).mockClear();
     ensureConfiguredBindingRouteReadyMock.mockReset();
     resolveConfiguredBindingRouteMock.mockReset();
     resolveConfiguredBindingRouteMock.mockReturnValue(createConfiguredDiscordRoute());
@@ -318,7 +321,33 @@ describe("preflightDiscordMessage configured ACP bindings", () => {
     expect(result?.route.agentId).toBe("codex");
   });
 
-  it("hydrates empty guild message payloads from REST before ensuring configured ACP bindings", async () => {
+  it("logs a structured outcome when configured ACP bindings are unavailable", async () => {
+    vi.mocked(runtimeEnv.logVerbose).mockClear();
+    ensureConfiguredBindingRouteReadyMock.mockResolvedValueOnce({
+      ok: false,
+      error: "binding offline",
+    });
+
+    const result = await preflightDiscordMessage(
+      createBasePreflightParams({
+        guildEntries: createAllowedGuildEntries(false),
+      }),
+    );
+
+    expect(result).toBeNull();
+    expect(
+      vi
+        .mocked(runtimeEnv.logVerbose)
+        .mock.calls.some(
+          ([entry]) =>
+            String(entry).includes("discord inbound outcome:") &&
+            String(entry).includes("reason=configured-binding-unavailable") &&
+            String(entry).includes("message=m-1"),
+        ),
+    ).toBe(true);
+  });
+
+  it("hydrates guild messages from REST before ensuring configured ACP bindings", async () => {
     const { result, restGet } = await runRestHydrationPreflight({
       messageId: "m-rest",
       restPayload: {

--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -34,6 +34,7 @@ import {
   testing as sessionBindingTesting,
   registerSessionBindingAdapter,
 } from "openclaw/plugin-sdk/conversation-runtime";
+import * as runtimeEnv from "openclaw/plugin-sdk/runtime-env";
 import {
   createDiscordMessage,
   createDiscordPreflightArgs,
@@ -344,6 +345,8 @@ describe("resolvePreflightMentionRequirement", () => {
 describe("preflightDiscordMessage", () => {
   beforeEach(() => {
     sessionBindingTesting.resetSessionBindingAdaptersForTests();
+    vi.spyOn(runtimeEnv, "logVerbose").mockImplementation(() => undefined);
+    vi.mocked(runtimeEnv.logVerbose).mockClear();
     transcribeFirstAudioMock.mockReset();
     resolveDiscordDmCommandAccessMock.mockReset();
     resolveDiscordDmCommandAccessMock.mockResolvedValue({
@@ -1530,6 +1533,51 @@ describe("preflightDiscordMessage", () => {
     expect(preflight.shouldRequireMention).toBe(false);
   });
 
+  it("logs a structured outcome when guild mention gating skips a message", async () => {
+    vi.mocked(runtimeEnv.logVerbose).mockClear();
+    const channelId = "channel-outcome-no-mention";
+    const guildId = "guild-outcome-no-mention";
+    const message = createDiscordMessage({
+      id: "m-outcome-no-mention",
+      channelId,
+      content: "general update without a mention",
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "Alice",
+      },
+    });
+
+    const result = await runGuildPreflight({
+      channelId,
+      guildId,
+      message,
+      discordConfig: {} as DiscordConfig,
+      guildEntries: {
+        [guildId]: {
+          channels: {
+            [channelId]: {
+              enabled: true,
+              requireMention: true,
+            },
+          },
+        },
+      },
+    });
+
+    expect(result).toBeNull();
+    expect(
+      vi
+        .mocked(runtimeEnv.logVerbose)
+        .mock.calls.some(
+          ([entry]) =>
+            String(entry).includes("discord inbound outcome:") &&
+            String(entry).includes("message=m-outcome-no-mention") &&
+            String(entry).includes("reason=no-mention"),
+        ),
+    ).toBe(true);
+  });
+
   it("drops guild messages that mention another user when ignoreOtherMentions=true", async () => {
     const channelId = "channel-other-mention-1";
     const guildId = "guild-other-mention-1";
@@ -1548,6 +1596,37 @@ describe("preflightDiscordMessage", () => {
     const result = await runIgnoreOtherMentionsPreflight({ channelId, guildId, message });
 
     expect(result).toBeNull();
+  });
+
+  it("logs a structured outcome when ignoreOtherMentions skips a guild message", async () => {
+    vi.mocked(runtimeEnv.logVerbose).mockClear();
+    const channelId = "channel-outcome-other-mention";
+    const guildId = "guild-outcome-other-mention";
+    const message = createDiscordMessage({
+      id: "m-outcome-other-mention",
+      channelId,
+      content: "hello <@999>",
+      mentionedUsers: [{ id: "999" }],
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "Alice",
+      },
+    });
+
+    const result = await runIgnoreOtherMentionsPreflight({ channelId, guildId, message });
+
+    expect(result).toBeNull();
+    expect(
+      vi
+        .mocked(runtimeEnv.logVerbose)
+        .mock.calls.some(
+          ([entry]) =>
+            String(entry).includes("discord inbound outcome:") &&
+            String(entry).includes("message=m-outcome-other-mention") &&
+            String(entry).includes("reason=other-mention"),
+        ),
+    ).toBe(true);
   });
 
   it("records local image media for skipped mention-gated guild history", async () => {

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -44,6 +44,7 @@ import {
 } from "./message-handler.preflight-helpers.js";
 import { buildDiscordPreflightHistoryEntry } from "./message-handler.preflight-history.js";
 import {
+  logDiscordInboundOutcome,
   logDiscordPreflightChannelConfig,
   logDiscordPreflightInboundSummary,
 } from "./message-handler.preflight-logging.js";
@@ -671,6 +672,15 @@ export async function preflightDiscordMessage(
         },
         "discord: skipping guild message",
       );
+      logDiscordInboundOutcome({
+        accountId: params.accountId,
+        channelId: messageChannelId,
+        messageId: message.id,
+        isDirectMessage,
+        isGroupDm,
+        outcome: "skipped",
+        reason: "no-mention",
+      });
       await recordDiscordPendingHistoryEntry({
         preflight: params,
         historyKey: messageChannelId,
@@ -702,6 +712,22 @@ export async function preflightDiscordMessage(
     logVerbose(
       `discord: drop guild message (another user/role mentioned, ignoreOtherMentions=true, botId=${botId})`,
     );
+    logger.info(
+      {
+        channelId: messageChannelId,
+        reason: "other-mention",
+      },
+      "discord: skipping guild message",
+    );
+    logDiscordInboundOutcome({
+      accountId: params.accountId,
+      channelId: messageChannelId,
+      messageId: message.id,
+      isDirectMessage,
+      isGroupDm,
+      outcome: "skipped",
+      reason: "other-mention",
+    });
     await recordDiscordPendingHistoryEntry({
       preflight: params,
       historyKey: messageChannelId,
@@ -742,6 +768,15 @@ export async function preflightDiscordMessage(
       logVerbose(
         `discord: configured ACP binding unavailable for channel ${configuredBinding.record.conversation.conversationId}: ${ensured.error}`,
       );
+      logDiscordInboundOutcome({
+        accountId: params.accountId,
+        channelId: messageChannelId,
+        messageId: message.id,
+        isDirectMessage,
+        isGroupDm,
+        outcome: "skipped",
+        reason: "configured-binding-unavailable",
+      });
       return null;
     }
   }

--- a/extensions/discord/src/monitor/message-handler.queue.test.ts
+++ b/extensions/discord/src/monitor/message-handler.queue.test.ts
@@ -362,6 +362,30 @@ describe("createDiscordMessageHandler queue behavior", () => {
     expect(preflightDiscordMessageMock).toHaveBeenCalledTimes(1);
   });
 
+  it("logs duplicate inbound drops before queueing", async () => {
+    preflightDiscordMessageMock.mockReset();
+    processDiscordMessageMock.mockReset();
+
+    const params = createDiscordHandlerParams();
+    const handler = createDiscordMessageHandler(params);
+    const duplicate = createMessageData("m-dup-log");
+
+    await expect(handler(duplicate as never, {} as never)).resolves.toBeUndefined();
+    await expect(handler(duplicate as never, {} as never)).resolves.toBeUndefined();
+
+    await flushQueueWork();
+
+    const runtimeLog = params.runtime.log as unknown as MockCallSource;
+    expect(
+      mockCalls(runtimeLog).some(
+        ([message]) =>
+          String(message).includes("discord inbound outcome:") &&
+          String(message).includes("outcome=duplicate-before-queue") &&
+          String(message).includes("message=m-dup-log"),
+      ),
+    ).toBe(true);
+  });
+
   it("retries duplicate deliveries after an explicit retryable worker failure", async () => {
     preflightDiscordMessageMock.mockReset();
     processDiscordMessageMock.mockReset();

--- a/extensions/discord/src/monitor/message-handler.queue.test.ts
+++ b/extensions/discord/src/monitor/message-handler.queue.test.ts
@@ -386,6 +386,40 @@ describe("createDiscordMessageHandler queue behavior", () => {
     ).toBe(true);
   });
 
+  it("retries an inflight duplicate after a retryable release", async () => {
+    preflightDiscordMessageMock.mockReset();
+    processDiscordMessageMock.mockReset();
+
+    const firstRun = createDeferred();
+    processDiscordMessageMock.mockImplementationOnce(async () => {
+      await firstRun.promise;
+      throw new DiscordRetryableInboundError("retry me");
+    });
+    processDiscordMessageMock.mockResolvedValueOnce(undefined);
+    const params = createDiscordHandlerParams();
+    const handler = createDiscordMessageHandler(params);
+    installDefaultDiscordPreflight();
+    const duplicate = createMessageData("m-inflight-retry");
+
+    await expect(handler(duplicate as never, {} as never)).resolves.toBeUndefined();
+    await flushQueueWork();
+    expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+    expect(preflightDiscordMessageMock).toHaveBeenCalledTimes(1);
+
+    const duplicateAttempt = handler(duplicate as never, {} as never);
+    await Promise.resolve();
+    expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+    expect(preflightDiscordMessageMock).toHaveBeenCalledTimes(1);
+
+    firstRun.resolve();
+    await firstRun.promise;
+    await expect(duplicateAttempt).resolves.toBeUndefined();
+    await flushQueueWork();
+
+    expect(processDiscordMessageMock).toHaveBeenCalledTimes(2);
+    expect(preflightDiscordMessageMock).toHaveBeenCalledTimes(2);
+  });
+
   it("retries duplicate deliveries after an explicit retryable worker failure", async () => {
     preflightDiscordMessageMock.mockReset();
     processDiscordMessageMock.mockReset();

--- a/extensions/discord/src/monitor/message-handler.ts
+++ b/extensions/discord/src/monitor/message-handler.ts
@@ -40,6 +40,7 @@ type DiscordMessageHandlerParams = Omit<
 > & {
   setStatus?: DiscordMonitorStatusSink;
   abortSignal?: AbortSignal;
+  replayStateDir?: string;
   testing?: DiscordMessageHandlerTestingHooks;
 };
 
@@ -107,7 +108,12 @@ export function createDiscordMessageHandler(
     params.cfg.messages?.ackReactionScope ??
     "group-mentions";
   const preflightDiscordMessageImpl = params.testing?.preflightDiscordMessage;
-  const replayGuard = createDiscordInboundReplayGuard();
+  const replayGuard = createDiscordInboundReplayGuard({
+    stateDir: params.replayStateDir,
+    onDiskError: (error) => {
+      params.runtime.error?.(danger(`discord inbound replay guard store failed: ${String(error)}`));
+    },
+  });
   const messageRunQueue = createDiscordMessageRunQueue({
     runtime: params.runtime,
     setStatus: params.setStatus,
@@ -162,6 +168,7 @@ export function createDiscordMessageHandler(
       const abortSignal = last.abortSignal;
       if (abortSignal?.aborted) {
         releaseDiscordInboundReplay({
+          accountId: params.accountId,
           replayKeys,
           error: abortSignal.reason,
           replayGuard,
@@ -182,7 +189,11 @@ export function createDiscordMessageHandler(
             client: last.client,
           });
           if (!ctx) {
-            await commitDiscordInboundReplay({ replayKeys, replayGuard });
+            await commitDiscordInboundReplay({
+              accountId: params.accountId,
+              replayKeys,
+              replayGuard,
+            });
             return;
           }
           applyImplicitReplyBatchGate(ctx, params.replyToMode, false);
@@ -232,7 +243,11 @@ export function createDiscordMessageHandler(
           client: last.client,
         });
         if (!ctx) {
-          await commitDiscordInboundReplay({ replayKeys, replayGuard });
+          await commitDiscordInboundReplay({
+            accountId: params.accountId,
+            replayKeys,
+            replayGuard,
+          });
           return;
         }
         applyImplicitReplyBatchGate(ctx, params.replyToMode, true);
@@ -253,9 +268,18 @@ export function createDiscordMessageHandler(
         messageRunQueue.enqueue(buildDiscordInboundJob(ctx, { replayKeys }));
       } catch (error) {
         if (error instanceof DiscordRetryableInboundError) {
-          releaseDiscordInboundReplay({ replayKeys, error, replayGuard });
+          releaseDiscordInboundReplay({
+            accountId: params.accountId,
+            replayKeys,
+            error,
+            replayGuard,
+          });
         } else {
-          await commitDiscordInboundReplay({ replayKeys, replayGuard });
+          await commitDiscordInboundReplay({
+            accountId: params.accountId,
+            replayKeys,
+            replayGuard,
+          });
         }
         throw error;
       }
@@ -285,10 +309,14 @@ export function createDiscordMessageHandler(
       });
       if (
         !(await claimDiscordInboundReplay({
+          accountId: params.accountId,
           replayKey,
           replayGuard,
         }))
       ) {
+        params.runtime.log?.(
+          `discord inbound outcome: account=${params.accountId} channel=${data.channel_id ?? "<unknown>"} message=${data.message?.id ?? "<unknown>"} outcome=duplicate-before-queue`,
+        );
         return;
       }
 

--- a/extensions/discord/src/monitor/message-run-queue.ts
+++ b/extensions/discord/src/monitor/message-run-queue.ts
@@ -53,18 +53,21 @@ async function processDiscordQueuedMessage(params: {
   try {
     await processDiscordMessageImpl(materializeDiscordInboundJob(params.job, abortSignal));
     await commitDiscordInboundReplay({
+      accountId: params.job.payload.accountId,
       replayKeys: params.job.replayKeys,
       replayGuard: params.replayGuard,
     });
   } catch (error) {
     if (error instanceof DiscordRetryableInboundError) {
       releaseDiscordInboundReplay({
+        accountId: params.job.payload.accountId,
         replayKeys: params.job.replayKeys,
         error,
         replayGuard: params.replayGuard,
       });
     } else {
       await commitDiscordInboundReplay({
+        accountId: params.job.payload.accountId,
         replayKeys: params.job.replayKeys,
         replayGuard: params.replayGuard,
       });

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "node:events";
 import type { ChannelRuntimeSurface } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { RateLimitError } from "../internal/discord.js";
 import {
@@ -851,7 +852,19 @@ describe("monitorDiscordProvider", () => {
     expect(params?.workerRunTimeoutMs).toBeUndefined();
   });
 
-  it("continues startup when Discord daily slash-command create quota is exhausted", async () => {
+  it("passes the OpenClaw state dir into the Discord message replay guard", async () => {
+    await monitorDiscordProvider({
+      config: baseConfig(),
+      runtime: baseRuntime(),
+    });
+
+    const params = getFirstDiscordMessageHandlerParams<{
+      replayStateDir?: string;
+    }>();
+    expect(params?.replayStateDir).toBe(resolveStateDir(process.env));
+  });
+
+  it("treats Discord native command deploy rate limits as non-fatal warnings", async () => {
     const runtime = baseRuntime();
     const request = new Request("https://discord.com/api/v10/applications/commands", {
       method: "PUT",

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -21,6 +21,7 @@ import {
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "openclaw/plugin-sdk/runtime-group-policy";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
+import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import {
   resolveDiscordAccount,
   resolveDiscordAccountAllowFrom,
@@ -537,6 +538,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       mediaMaxBytes,
       textLimit,
       replyToMode,
+      replayStateDir: resolveStateDir(process.env),
       dmEnabled,
       dmPolicy,
       groupDmEnabled,


### PR DESCRIPTION
## Summary
- persist Discord inbound replay claims per account so retryable worker failures can recover without dropping the inbound event
- wire the Discord provider state dir into the replay guard and keep queue commit/release paths on the same replay namespace
- add structured inbound outcome logging and focused tests for duplicate-before-queue, mention gating, and configured binding unavailability

## Verification
- corepack pnpm --dir \"/root/.openclaw/workspace/projects/openclaw-upstream\" check:changed
- env -C \"/root/.openclaw/workspace/projects/openclaw-upstream\" node scripts/run-vitest.mjs extensions/discord/src/monitor/message-handler.preflight.acp-bindings.test.ts
- env -C \"/root/.openclaw/workspace/projects/openclaw-upstream\" node scripts/run-vitest.mjs extensions/discord/src/monitor/message-handler.preflight.test.ts
- env -C \"/root/.openclaw/workspace/projects/openclaw-upstream\" node scripts/run-vitest.mjs extensions/discord/src/monitor/provider.test.ts
- env -C \"/root/.openclaw/workspace/projects/openclaw-upstream\" node scripts/run-vitest.mjs extensions/discord/src/monitor/message-handler.queue.test.ts
- env -C \"/root/.openclaw/workspace/projects/openclaw-upstream\" node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
- env -C \"/root/.openclaw/workspace/projects/openclaw-upstream\" node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo

## Real behavior proof
- Behavior addressed: Discord inbound retries can lose replay state after retryable worker failures, and skipped/duplicate paths are hard to distinguish in logs.
- Real environment tested: Local source checkout with focused Discord tests and extension typecheck.
- Exact steps or command run after this patch: Re-ran the focused Discord vitest suites plus extension and extension-test tsgo checks listed above.
- Evidence after fix: Replay claims now persist under the OpenClaw state dir per Discord account, duplicate-before-queue drops emit a structured outcome log, and preflight skip/binding-unavailable paths emit structured outcome logs covered by tests.
- Observed result after fix: Focused Discord tests pass, extension typechecks pass, and the branch stays scoped to the Discord inbound replay and diagnostics patch.
- What was not tested: Live Discord round-trip against a real gateway session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)