### PR TITLE
fix(gateway): filter transcript-only history rows

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -703,8 +703,9 @@ describe("sessions tools", () => {
 
   it("sessions_history filters tool messages by default", async () => {
     callGatewayMock.mockImplementation(async (opts: unknown) => {
-      const request = opts as { method?: string };
+      const request = opts as { method?: string; params?: { limit?: number } };
       if (request.method === "chat.history") {
+        expect(request.params?.limit).toBe(1000);
         return {
           messages: [
             { role: "toolResult", content: [] },
@@ -731,6 +732,152 @@ describe("sessions tools", () => {
     });
     const withToolsDetails = withTools.details as { messages?: unknown[] };
     expect(withToolsDetails.messages).toHaveLength(2);
+  });
+
+  it("sessions_history filters transcript-only OpenClaw assistant messages", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              provider: "openclaw",
+              model: "delivery-mirror",
+              content: [{ type: "text", text: "duplicate mirror" }],
+            },
+            {
+              role: "assistant",
+              provider: "openclaw",
+              model: "acp-runtime",
+              content: [{ type: "text", text: "runtime reply" }],
+            },
+            {
+              role: "assistant",
+              provider: "openclaw",
+              model: "gateway-injected",
+              content: [{ type: "text", text: "runtime reply" }],
+            },
+            {
+              role: "assistant",
+              provider: "openclaw",
+              model: "gateway-injected",
+              content: [{ type: "text", text: "visible injected reply" }],
+            },
+            { role: "toolResult", content: [] },
+            { role: "assistant", content: [{ type: "text", text: "real answer" }] },
+          ],
+        };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_history");
+    if (!tool) {
+      throw new Error("missing sessions_history tool");
+    }
+
+    const result = await tool.execute("call-transcript-only", { sessionKey: "main" });
+    const details = result.details as { messages?: Array<{ content?: Array<{ text?: string }> }> };
+    expect(details.messages?.map((message) => message.content?.[0]?.text)).toEqual([
+      "runtime reply",
+      "visible injected reply",
+      "real answer",
+    ]);
+
+    const withTools = await tool.execute("call-transcript-only-tools", {
+      sessionKey: "main",
+      includeTools: true,
+    });
+    const withToolsDetails = withTools.details as { messages?: Array<{ role?: string }> };
+    expect(withToolsDetails.messages?.map((message) => message.role)).toEqual([
+      "assistant",
+      "assistant",
+      "toolResult",
+      "assistant",
+    ]);
+  });
+
+  it("sessions_history applies limit after transcript-only filtering", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: { limit?: number } };
+      if (request.method === "chat.history") {
+        expect(request.params?.limit).toBe(1000);
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "older visible answer" }],
+            },
+            {
+              role: "assistant",
+              provider: "openclaw",
+              model: "delivery-mirror",
+              content: [{ type: "text", text: "duplicate delivery mirror" }],
+            },
+            {
+              role: "assistant",
+              provider: "openclaw",
+              model: "acp-runtime",
+              content: [{ type: "text", text: "runtime answer" }],
+            },
+            {
+              role: "assistant",
+              provider: "openclaw",
+              model: "gateway-injected",
+              content: [{ type: "text", text: "runtime answer" }],
+            },
+            {
+              role: "assistant",
+              provider: "openclaw",
+              model: "gateway-injected",
+              content: [{ type: "text", text: "visible injected answer" }],
+            },
+          ],
+        };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_history");
+    if (!tool) {
+      throw new Error("missing sessions_history tool");
+    }
+
+    const result = await tool.execute("call-transcript-only-limit", {
+      sessionKey: "main",
+      limit: 1,
+    });
+    const details = result.details as { messages?: Array<{ content?: Array<{ text?: string }> }> };
+    expect(details.messages).toHaveLength(1);
+    expect(details.messages?.[0]?.content?.[0]?.text).toBe("visible injected answer");
+  });
+
+  it("sessions_history preserves the default visible history window after raw overfetching", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: { limit?: number } };
+      if (request.method === "chat.history") {
+        expect(request.params?.limit).toBe(1000);
+        return {
+          messages: Array.from({ length: 250 }, (_, idx) => ({
+            role: "assistant",
+            content: [{ type: "text", text: `message ${idx + 1}` }],
+          })),
+        };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_history");
+    if (!tool) {
+      throw new Error("missing sessions_history tool");
+    }
+
+    const result = await tool.execute("call-default-visible-limit", { sessionKey: "main" });
+    const details = result.details as { messages?: Array<{ content?: Array<{ text?: string }> }> };
+    expect(details.messages).toHaveLength(200);
+    expect(details.messages?.[0]?.content?.[0]?.text).toBe("message 51");
+    expect(details.messages?.at(-1)?.content?.[0]?.text).toBe("message 250");
   });
 
   it("sessions_history caps oversized payloads and strips heavy fields", async () => {

--- a/src/agents/tools/chat-history-text.ts
+++ b/src/agents/tools/chat-history-text.ts
@@ -1,4 +1,5 @@
 import { extractAssistantTextForPhase } from "../../shared/chat-message-content.js";
+export { stripTranscriptOnlyOpenClawAssistantMessages } from "../../shared/openclaw-transcript-only.js";
 import { sanitizeAssistantVisibleTextWithProfile } from "../../shared/text/assistant-visible-text.js";
 import { sanitizeUserFacingText } from "../embedded-agent-helpers/sanitize-user-facing-text.js";
 

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -19,6 +19,7 @@ export {
   extractAssistantText,
   sanitizeTextContent,
   stripToolMessages,
+  stripTranscriptOnlyOpenClawAssistantMessages,
 } from "./chat-history-text.js";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { getRuntimeConfig } from "../../config/config.js";

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -22,6 +22,7 @@ import {
   resolveSandboxedSessionToolContext,
   resolveVisibleSessionReference,
   stripToolMessages,
+  stripTranscriptOnlyOpenClawAssistantMessages,
 } from "./sessions-helpers.js";
 
 const SessionsHistoryToolSchema = Type.Object({
@@ -32,6 +33,8 @@ const SessionsHistoryToolSchema = Type.Object({
 
 const SESSIONS_HISTORY_MAX_BYTES = 80 * 1024;
 const SESSIONS_HISTORY_TEXT_MAX_CHARS = 4000;
+const SESSIONS_HISTORY_DEFAULT_VISIBLE_LIMIT = 200;
+const SESSIONS_HISTORY_RAW_FETCH_LIMIT = 1000;
 type GatewayCaller = typeof callGateway;
 
 // sandbox policy handling is shared with sessions-list-tool via sessions-helpers.ts
@@ -153,6 +156,17 @@ function sanitizeHistoryMessage(message: unknown): {
   return { message: entry, truncated, redacted };
 }
 
+function applyVisibleHistoryLimit(messages: unknown[], limit: number | undefined): unknown[] {
+  if (typeof limit !== "number" || messages.length <= limit) {
+    return messages;
+  }
+  return messages.slice(-limit);
+}
+
+function resolveSessionsHistoryRawFetchLimit(): number {
+  return SESSIONS_HISTORY_RAW_FETCH_LIMIT;
+}
+
 function enforceSessionsHistoryHardCap(params: {
   items: unknown[];
   bytes: number;
@@ -250,12 +264,16 @@ export function createSessionsHistoryTool(opts?: {
 
       const limit = readPositiveIntegerParam(params, "limit");
       const includeTools = Boolean(params.includeTools);
+      const rawFetchLimit = resolveSessionsHistoryRawFetchLimit();
       const result = await gatewayCall<{ messages: Array<unknown> }>({
         method: "chat.history",
-        params: { sessionKey: resolvedKey, limit },
+        params: { sessionKey: resolvedKey, limit: rawFetchLimit },
       });
       const rawMessages = Array.isArray(result?.messages) ? result.messages : [];
-      const selectedMessages = includeTools ? rawMessages : stripToolMessages(rawMessages);
+      const visibleMessages = stripTranscriptOnlyOpenClawAssistantMessages(rawMessages);
+      const unboundedSelectedMessages = includeTools ? visibleMessages : stripToolMessages(visibleMessages);
+      const visibleLimit = limit ?? SESSIONS_HISTORY_DEFAULT_VISIBLE_LIMIT;
+      const selectedMessages = applyVisibleHistoryLimit(unboundedSelectedMessages, visibleLimit);
       const sanitizedMessages = selectedMessages.map((message) => sanitizeHistoryMessage(message));
       const contentTruncated = sanitizedMessages.some((entry) => entry.truncated);
       const contentRedacted = sanitizedMessages.some((entry) => entry.redacted);

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -930,6 +930,28 @@ describe("projectRecentChatDisplayMessages", () => {
     });
   });
 
+  it("keeps OpenClaw injected assistant rows in generic chat projection", () => {
+    const result = projectRecentChatDisplayMessages([
+      {
+        role: "assistant",
+        provider: "openclaw",
+        model: "gateway-injected",
+        content: [{ type: "text", text: "live injected reply" }],
+        timestamp: 1,
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        provider: "openclaw",
+        model: "gateway-injected",
+        content: [{ type: "text", text: "live injected reply" }],
+        timestamp: 1,
+      },
+    ]);
+  });
+
   it("keeps pure commentary assistant messages hidden", () => {
     const result = projectRecentChatDisplayMessages([
       {

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -528,4 +528,93 @@ describe("SessionHistorySseState", () => {
     ).toBeNull();
     expect(state.snapshot().messages).toHaveLength(1);
   });
+  test("filters transcript-only OpenClaw assistant rows from history snapshots and SSE appends", () => {
+    const snapshot = buildSessionHistorySnapshot({
+      rawMessages: [
+        {
+          role: "assistant",
+          provider: "openclaw",
+          model: "delivery-mirror",
+          content: [{ type: "text", text: "duplicate delivery mirror" }],
+          __openclaw: { seq: 1 },
+        },
+        {
+          role: "assistant",
+          provider: "openclaw",
+          model: "acp-runtime",
+          content: [{ type: "text", text: "runtime reply" }],
+          __openclaw: { seq: 2 },
+        },
+        {
+          role: "assistant",
+          provider: "openclaw",
+          model: "gateway-injected",
+          content: [{ type: "text", text: "runtime reply" }],
+          __openclaw: { seq: 3 },
+        },
+        {
+          role: "assistant",
+          provider: "openclaw",
+          model: "gateway-injected",
+          content: [{ type: "text", text: "visible injected reply" }],
+          __openclaw: { seq: 4 },
+        },
+        {
+          role: "assistant",
+          provider: "openclaw",
+          model: "openclawMessageToolMirror",
+          content: [{ type: "text", text: "visible tool mirror" }],
+          __openclaw: { seq: 5 },
+        },
+        {
+          role: "assistant",
+          provider: "anthropic",
+          model: "claude-sonnet-4.6",
+          content: [{ type: "text", text: "real answer" }],
+          __openclaw: { seq: 6 },
+        },
+      ],
+    });
+
+    expect(
+      snapshot.history.messages.map(
+        (message) => (message as { content?: Array<{ text?: string }> }).content?.[0]?.text,
+      ),
+    ).toEqual([
+      "runtime reply",
+      "visible injected reply",
+      "visible tool mirror",
+      "real answer",
+    ]);
+    expect(snapshot.rawTranscriptSeq).toBe(6);
+
+    const state = SessionHistorySseState.fromRawSnapshot({
+      target: { sessionId: "sess-main" },
+      rawMessages: snapshot.history.messages,
+      rawTranscriptSeq: snapshot.rawTranscriptSeq,
+    });
+
+    expect(
+      state.appendInlineMessage({
+        message: {
+          role: "assistant",
+          provider: "openclaw",
+          model: "delivery-mirror",
+          content: [{ type: "text", text: "inline duplicate mirror" }],
+        },
+        messageSeq: 7,
+      }),
+    ).toBeNull();
+    expect(
+      state.snapshot().messages.map(
+        (message) => (message as { content?: Array<{ text?: string }> }).content?.[0]?.text,
+      ),
+    ).toEqual([
+      "runtime reply",
+      "visible injected reply",
+      "visible tool mirror",
+      "real answer",
+    ]);
+  });
+
 });

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -1,4 +1,5 @@
 import { asPositiveSafeInteger } from "@openclaw/normalization-core/number-coercion";
+import { stripTranscriptOnlyOpenClawAssistantMessages } from "../shared/openclaw-transcript-only.js";
 import {
   DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
   projectChatDisplayMessages,
@@ -78,6 +79,13 @@ function toSessionHistoryMessages(messages: unknown[]): SessionHistoryMessage[] 
   );
 }
 
+function projectSessionHistoryDisplayMessages(
+  messages: unknown[],
+  options?: { maxChars?: number },
+): Array<Record<string, unknown>> {
+  return projectChatDisplayMessages(stripTranscriptOnlyOpenClawAssistantMessages(messages), options);
+}
+
 function buildPaginatedSessionHistory(params: {
   messages: SessionHistoryMessage[];
   hasMore: boolean;
@@ -137,7 +145,7 @@ export function buildSessionHistorySnapshot(params: {
   totalRawMessages?: number;
 }): SessionHistorySnapshot {
   const visibleMessages = toSessionHistoryMessages(
-    projectChatDisplayMessages(params.rawMessages, {
+    projectSessionHistoryDisplayMessages(params.rawMessages, {
       maxChars: params.maxChars ?? DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
     }),
   );
@@ -256,7 +264,7 @@ export class SessionHistorySseState {
       seq: this.rawTranscriptSeq,
     });
     const projectedMessages = toSessionHistoryMessages(
-      projectChatDisplayMessages([...this.sentHistory.messages, nextMessage], {
+      projectSessionHistoryDisplayMessages([...this.sentHistory.messages, nextMessage], {
         maxChars: this.maxChars,
       }),
     );
@@ -290,7 +298,7 @@ export class SessionHistorySseState {
       }
     }
     const [sanitizedMessage] = toSessionHistoryMessages(
-      projectChatDisplayMessages([nextMessage], { maxChars: this.maxChars }),
+      projectSessionHistoryDisplayMessages([nextMessage], { maxChars: this.maxChars }),
     );
     if (!sanitizedMessage) {
       if (projectedMessages.length < this.sentHistory.messages.length) {

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -3,10 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
 import { afterEach, describe, expect, test } from "vitest";
-import {
-  appendAssistantMessageToSessionTranscript,
-  appendExactAssistantMessageToSessionTranscript,
-} from "../config/sessions/transcript.js";
+import { appendExactAssistantMessageToSessionTranscript } from "../config/sessions/transcript.js";
 import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import { testState } from "./test-helpers.runtime-state.js";
 import {
@@ -54,12 +51,11 @@ async function seedSession(params?: { text?: string }) {
     storePath,
   });
   if (params?.text) {
-    const appended = await appendAssistantMessageToSessionTranscript({
+    await appendTranscriptMessage({
       sessionKey: "agent:main:main",
       text: params.text,
       storePath,
     });
-    expect(appended.ok).toBe(true);
   }
   return { storePath };
 }
@@ -67,13 +63,15 @@ async function seedSession(params?: { text?: string }) {
 function makeTranscriptAssistantMessage(params: {
   text: string;
   content?: AssistantMessage["content"];
+  provider?: string;
+  model?: string;
 }): AssistantMessage {
   return {
     role: "assistant" as const,
     content: params.content ?? [{ type: "text", text: params.text }],
     api: "openai-responses",
-    provider: "openclaw",
-    model: "delivery-mirror",
+    provider: params.provider ?? "anthropic",
+    model: params.model ?? "claude-sonnet-4.6",
     usage: {
       input: 0,
       output: 0,
@@ -95,7 +93,8 @@ function makeTranscriptAssistantMessage(params: {
 
 async function appendTranscriptMessage(params: {
   sessionKey: string;
-  message: AssistantMessage;
+  text?: string;
+  message?: AssistantMessage;
   emitInlineMessage?: boolean;
   storePath?: string;
 }): Promise<string> {
@@ -103,21 +102,8 @@ async function appendTranscriptMessage(params: {
     sessionKey: params.sessionKey,
     storePath: params.storePath ?? testState.sessionStorePath,
     updateMode: params.emitInlineMessage === false ? "file-only" : "inline",
-    message: params.message,
+    message: params.message ?? makeTranscriptAssistantMessage({ text: params.text ?? "" }),
   });
-  expect(appended.ok).toBe(true);
-  if (!appended.ok) {
-    throw new Error(`append failed: ${appended.reason}`);
-  }
-  return appended.messageId;
-}
-
-async function appendVisibleAssistantMessage(params: {
-  sessionKey: string;
-  text: string;
-  storePath: string;
-}) {
-  const appended = await appendAssistantMessageToSessionTranscript(params);
   expect(appended.ok).toBe(true);
   if (!appended.ok) {
     throw new Error(`append failed: ${appended.reason}`);
@@ -163,32 +149,14 @@ async function withGatewayHarness<T>(
   }
 }
 
-type SessionHistoryMessage = {
-  content?: Array<{ text?: string }>;
-  __openclaw?: { id?: string; seq?: number };
-};
-
-type SessionHistoryBody = {
-  sessionKey?: string;
-  items?: SessionHistoryMessage[];
-  messages?: SessionHistoryMessage[];
-  nextCursor?: string;
-  hasMore?: boolean;
-};
-
-async function readSessionHistoryBody(
-  port: number,
-  sessionKey: string,
-  params?: Parameters<typeof fetchSessionHistory>[2],
-): Promise<SessionHistoryBody> {
-  const res = await fetchSessionHistory(port, sessionKey, params);
-  expect(res.status).toBe(200);
-  return (await res.json()) as SessionHistoryBody;
-}
-
 async function expectSessionHistoryText(params: { sessionKey: string; expectedText: string }) {
   await withGatewayHarness(async (harness) => {
-    const body = await readSessionHistoryBody(harness.port, params.sessionKey);
+    const res = await fetchSessionHistory(harness.port, params.sessionKey);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      sessionKey?: string;
+      messages?: Array<{ content?: Array<{ text?: string }> }>;
+    };
     expect(body.sessionKey).toBe(params.sessionKey);
     expect(body.messages?.[0]?.content?.[0]?.text).toBe(params.expectedText);
   });
@@ -269,20 +237,6 @@ async function openSessionHistorySse(
   return { reader, streamState: { buffer: "" } };
 }
 
-async function withFirstMessageHistoryStream(
-  run: (stream: SessionHistorySseStream) => Promise<void>,
-) {
-  await withGatewayHarness(async (harness) => {
-    const stream = await openSessionHistorySse(harness.port, "agent:main:main");
-    try {
-      await expectHistoryEventTexts(stream, ["first message"]);
-      await run(stream);
-    } finally {
-      await stream.reader.cancel();
-    }
-  });
-}
-
 async function expectHistoryEventTexts(stream: SessionHistorySseStream, expectedTexts: string[]) {
   const event = await readSseEvent(stream.reader, stream.streamState);
   expect(event.event).toBe("history");
@@ -323,7 +277,7 @@ async function openBoundedHistoryStreamWithSecondMessage(
   harnessPort: number,
   storePath: string,
 ): Promise<SessionHistorySseStream> {
-  await appendVisibleAssistantMessage({
+  await appendTranscriptMessage({
     sessionKey: "agent:main:main",
     text: "second message",
     storePath,
@@ -340,22 +294,39 @@ describe("session history HTTP endpoints", () => {
   test("returns session history over direct REST", async () => {
     await seedSession({ text: "hello from history" });
     await withGatewayHarness(async (harness) => {
-      const body = await readSessionHistoryBody(harness.port, "agent:main:main");
+      const res = await fetchSessionHistory(harness.port, "agent:main:main");
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        sessionKey?: string;
+        messages?: Array<{ content?: Array<{ text?: string }> }>;
+      };
       expect(body.sessionKey).toBe("agent:main:main");
       expect(body.messages).toHaveLength(1);
       expect(body.messages?.[0]?.content?.[0]?.text).toBe("hello from history");
-      expectOpenClawMetadata(body.messages?.[0]?.["__openclaw"], {
-        seq: 1,
-      });
+      expectOpenClawMetadata(
+        (
+          body.messages?.[0] as {
+            __openclaw?: { id?: string; seq?: number };
+          }
+        )?.["__openclaw"],
+        {
+          seq: 1,
+        },
+      );
     });
   });
 
   test("matches direct REST history paths without trusting malformed Host headers", async () => {
     await seedSession({ text: "history with bad host" });
     await withGatewayHarness(async (harness) => {
-      const body = await readSessionHistoryBody(harness.port, "agent:main:main", {
+      const res = await fetchSessionHistory(harness.port, "agent:main:main", {
         headers: { Host: "[" },
       });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        sessionKey?: string;
+        messages?: Array<{ content?: Array<{ text?: string }> }>;
+      };
       expect(body.sessionKey).toBe("agent:main:main");
       expect(body.messages?.[0]?.content?.[0]?.text).toBe("history with bad host");
     });
@@ -427,12 +398,12 @@ describe("session history HTTP endpoints", () => {
 
   test("supports cursor pagination over direct REST while preserving the messages field", async () => {
     const { storePath } = await seedSession({ text: "first message" });
-    await appendVisibleAssistantMessage({
+    await appendTranscriptMessage({
       sessionKey: "agent:main:main",
       text: "second message",
       storePath,
     });
-    await appendVisibleAssistantMessage({
+    await appendTranscriptMessage({
       sessionKey: "agent:main:main",
       text: "third message",
       storePath,
@@ -443,7 +414,13 @@ describe("session history HTTP endpoints", () => {
         query: "?limit=2",
       });
       expect(firstPage.status).toBe(200);
-      const firstBody = (await firstPage.json()) as SessionHistoryBody;
+      const firstBody = (await firstPage.json()) as {
+        sessionKey?: string;
+        items?: Array<{ content?: Array<{ text?: string }>; __openclaw?: { seq?: number } }>;
+        messages?: Array<{ content?: Array<{ text?: string }>; __openclaw?: { seq?: number } }>;
+        nextCursor?: string;
+        hasMore?: boolean;
+      };
       expect(firstBody.sessionKey).toBe("agent:main:main");
       expect(firstBody.items?.map((message) => message.content?.[0]?.text)).toEqual([
         "second message",
@@ -457,7 +434,12 @@ describe("session history HTTP endpoints", () => {
         query: `?limit=2&cursor=${encodeURIComponent(firstBody.nextCursor ?? "")}`,
       });
       expect(secondPage.status).toBe(200);
-      const secondBody = (await secondPage.json()) as SessionHistoryBody;
+      const secondBody = (await secondPage.json()) as {
+        items?: Array<{ content?: Array<{ text?: string }>; __openclaw?: { seq?: number } }>;
+        messages?: Array<{ __openclaw?: { seq?: number } }>;
+        nextCursor?: string;
+        hasMore?: boolean;
+      };
       expect(secondBody.items?.map((message) => message.content?.[0]?.text)).toEqual([
         "first message",
       ]);
@@ -536,16 +518,11 @@ describe("session history HTTP endpoints", () => {
     });
 
     await withGatewayHarness(async (harness) => {
-      const hidden = await appendAssistantMessageToSessionTranscript({
+      await appendTranscriptMessage({
         sessionKey: "agent:main:main",
         text: "NO_REPLY",
         storePath,
       });
-      expect(hidden.ok).toBe(true);
-
-      if (!hidden.ok) {
-        throw new Error(`append failed: ${hidden.reason}`);
-      }
       const visibleMessageId = await appendTranscriptMessage({
         sessionKey: "agent:main:main",
         storePath,
@@ -589,8 +566,11 @@ describe("session history HTTP endpoints", () => {
   test("streams session history updates over SSE", async () => {
     const { storePath } = await seedSession({ text: "first message" });
 
-    await withFirstMessageHistoryStream(async (stream) => {
-      const appendedId = await appendVisibleAssistantMessage({
+    await withGatewayHarness(async (harness) => {
+      const stream = await openSessionHistorySse(harness.port, "agent:main:main");
+      await expectHistoryEventTexts(stream, ["first message"]);
+
+      const appendedMessageId = await appendTranscriptMessage({
         sessionKey: "agent:main:main",
         text: "second message",
         storePath,
@@ -598,8 +578,10 @@ describe("session history HTTP endpoints", () => {
       await expectMessageEventMatch(stream, {
         text: "second message",
         seq: 2,
-        id: appendedId,
+        id: appendedMessageId,
       });
+
+      await stream.reader.cancel();
     });
   });
 
@@ -644,7 +626,13 @@ describe("session history HTTP endpoints", () => {
         messageSeq: 1,
       });
 
-      await expectHistoryEventTexts(stream, ["first message", "second message"]);
+      const refreshEvent = await readSseEvent(stream.reader, stream.streamState);
+      expect(refreshEvent.event).toBe("history");
+      expect(
+        (
+          refreshEvent.data as { messages?: Array<{ content?: Array<{ text?: string }> }> }
+        ).messages?.map((message) => message.content?.[0]?.text),
+      ).toEqual(["first message", "second message"]);
 
       await stream.reader.cancel();
     });
@@ -659,8 +647,11 @@ describe("session history HTTP endpoints", () => {
       emitInlineMessage: false,
     });
 
-    await withFirstMessageHistoryStream(async (stream) => {
-      await appendVisibleAssistantMessage({
+    await withGatewayHarness(async (harness) => {
+      const stream = await openSessionHistorySse(harness.port, "agent:main:main");
+      await expectHistoryEventTexts(stream, ["first message"]);
+
+      await appendTranscriptMessage({
         sessionKey: "agent:main:main",
         text: "third visible message",
         storePath,
@@ -670,21 +661,25 @@ describe("session history HTTP endpoints", () => {
         text: "third visible message",
         seq: 3,
       });
+
+      await stream.reader.cancel();
     });
   });
 
   test("suppresses NO_REPLY-only SSE fast-path updates while preserving raw sequence numbering", async () => {
     const { storePath } = await seedSession({ text: "first message" });
 
-    await withFirstMessageHistoryStream(async (stream) => {
-      const silent = await appendAssistantMessageToSessionTranscript({
+    await withGatewayHarness(async (harness) => {
+      const stream = await openSessionHistorySse(harness.port, "agent:main:main");
+      await expectHistoryEventTexts(stream, ["first message"]);
+
+      await appendTranscriptMessage({
         sessionKey: "agent:main:main",
         text: "NO_REPLY",
         storePath,
       });
-      expect(silent.ok).toBe(true);
 
-      const visibleId = await appendVisibleAssistantMessage({
+      const visibleMessageId = await appendTranscriptMessage({
         sessionKey: "agent:main:main",
         text: "third visible message",
         storePath,
@@ -692,21 +687,25 @@ describe("session history HTTP endpoints", () => {
       await expectMessageEventMatch(stream, {
         text: "third visible message",
         seq: 3,
-        id: visibleId,
+        id: visibleMessageId,
       });
+
+      await stream.reader.cancel();
     });
   });
 
   test("resyncs raw sequence numbering after transcript-only SSE refreshes", async () => {
     const { storePath } = await seedSession({ text: "first message" });
 
-    await withFirstMessageHistoryStream(async (stream) => {
-      await appendVisibleAssistantMessage({
+    await withGatewayHarness(async (harness) => {
+      const stream = await openSessionHistorySse(harness.port, "agent:main:main");
+      await expectHistoryEventTexts(stream, ["first message"]);
+
+      await appendTranscriptMessage({
         sessionKey: "agent:main:main",
         text: "second visible message",
         storePath,
       });
-
       await expectMessageEventMatch(stream, {
         text: "second visible message",
         seq: 2,
@@ -718,9 +717,15 @@ describe("session history HTTP endpoints", () => {
         emitInlineMessage: false,
       });
 
-      await expectHistoryEventTexts(stream, ["first message", "second visible message"]);
+      const refreshEvent = await readSseEvent(stream.reader, stream.streamState);
+      expect(refreshEvent.event).toBe("history");
+      expect(
+        (
+          refreshEvent.data as { messages?: Array<{ content?: Array<{ text?: string }> }> }
+        ).messages?.map((message) => message.content?.[0]?.text),
+      ).toEqual(["first message", "second visible message"]);
 
-      const thirdId = await appendVisibleAssistantMessage({
+      const thirdMessageId = await appendTranscriptMessage({
         sessionKey: "agent:main:main",
         text: "third visible message",
         storePath,
@@ -728,8 +733,10 @@ describe("session history HTTP endpoints", () => {
       await expectMessageEventMatch(stream, {
         text: "third visible message",
         seq: 4,
-        id: thirdId,
+        id: thirdMessageId,
       });
+
+      await stream.reader.cancel();
     });
   });
 
@@ -737,7 +744,7 @@ describe("session history HTTP endpoints", () => {
     await seedSession({ text: "scope-guarded history" });
 
     const started = await startServerWithClient("test-gateway-token-1234567890");
-    const { server, ws, port: _port, envSnapshot } = started;
+    const { server, ws, envSnapshot } = started;
     try {
       const connect = await connectReq(ws, {
         token: "test-gateway-token-1234567890",
@@ -803,7 +810,7 @@ describe("session history HTTP endpoints", () => {
 
       await expectHistoryEventTexts(stream, ["bearer allowed history"]);
 
-      const appendedId = await appendVisibleAssistantMessage({
+      const appendedMessageId = await appendTranscriptMessage({
         sessionKey: "agent:main:main",
         text: "bearer sse update",
         storePath,
@@ -812,7 +819,7 @@ describe("session history HTTP endpoints", () => {
       await expectMessageEventMatch(stream, {
         text: "bearer sse update",
         seq: 2,
-        id: appendedId,
+        id: appendedMessageId,
       });
 
       await stream.reader.cancel();

--- a/src/shared/openclaw-transcript-only.ts
+++ b/src/shared/openclaw-transcript-only.ts
@@ -1,0 +1,72 @@
+import { extractAssistantVisibleText } from "./chat-message-content.js";
+
+export function isTranscriptOnlyOpenClawAssistantMessage(message: unknown): boolean {
+  return openclawAssistantModel(message) === "delivery-mirror";
+}
+
+export function stripTranscriptOnlyOpenClawAssistantMessages(messages: unknown[]): unknown[] {
+  if (messages.length === 0) {
+    return messages;
+  }
+  let changed = false;
+  const visible: unknown[] = [];
+  for (const message of messages) {
+    if (isTranscriptOnlyOpenClawAssistantMessage(message)) {
+      changed = true;
+      continue;
+    }
+    if (isDuplicateAcpGatewayInjectedMessage(message, visible.at(-1))) {
+      changed = true;
+      continue;
+    }
+    visible.push(message);
+  }
+  return changed ? visible : messages;
+}
+
+function openclawAssistantModel(message: unknown): string | undefined {
+  if (!message || typeof message !== "object") {
+    return undefined;
+  }
+  const record = message as {
+    role?: unknown;
+    provider?: unknown;
+    model?: unknown;
+  };
+  return record.role === "assistant" &&
+    record.provider === "openclaw" &&
+    typeof record.model === "string"
+    ? record.model
+    : undefined;
+}
+
+function hasAssistantNonTextContent(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const content = (message as { content?: unknown }).content;
+  return Array.isArray(content) && content.some((block) => {
+    if (!block || typeof block !== "object") {
+      return true;
+    }
+    return (block as { type?: unknown }).type !== "text";
+  });
+}
+
+function isDuplicateAcpGatewayInjectedMessage(
+  current: unknown,
+  previousVisible: unknown,
+): boolean {
+  if (
+    openclawAssistantModel(previousVisible) !== "acp-runtime" ||
+    openclawAssistantModel(current) !== "gateway-injected"
+  ) {
+    return false;
+  }
+  if (hasAssistantNonTextContent(previousVisible) || hasAssistantNonTextContent(current)) {
+    return false;
+  }
+  const previousText = extractAssistantVisibleText(previousVisible)?.trim();
+  const currentText = extractAssistantVisibleText(current)?.trim();
+  return Boolean(previousText && currentText && previousText === currentText);
+}


### PR DESCRIPTION
Fixes #85669

Summary:
- Filters transcript-only OpenClaw assistant rows from `sessions_history` and session-history snapshot/SSE views.
- Drops `delivery-mirror` rows and only suppresses `gateway-injected` rows when they duplicate the preceding `acp-runtime` text reply.
- Preserves legitimate visible `gateway-injected` assistant replies in history surfaces and live display projection.
- Fetches a wider raw history window before filtering, then preserves the existing default 200-message visible window when callers omit `limit`.

## Real behavior proof

Behavior addressed: `sessions_history` and session-history snapshot/SSE views no longer surface OpenClaw transcript-only `delivery-mirror` rows or duplicate ACP `gateway-injected` mirrors, while preserving legitimate visible `gateway-injected` assistant replies and the existing no-limit visible-history default.

Real environment tested: Local macOS checkout at commit `6883fc4ad225b45fd15a5a3dfd06f260e3b4f249` in `/Users/godcorn/cursor/open-source/projects/openclaw-85669`, using the repository's Node/Vitest runtime and local gateway HTTP e2e coverage for session history.

Exact steps or command run after this patch:
```bash
node scripts/run-vitest.mjs --config test/vitest/vitest.agents-core.config.ts src/agents/openclaw-tools.sessions.test.ts
node scripts/run-vitest.mjs --config test/vitest/vitest.gateway-core.config.ts src/gateway/session-history-state.test.ts
node scripts/run-vitest.mjs --config test/vitest/vitest.gateway-methods.config.ts src/gateway/server-methods/server-methods.test.ts -t "keeps OpenClaw injected assistant rows"
OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=180000 node scripts/run-vitest.mjs --config test/vitest/vitest.e2e.config.ts src/gateway/sessions-history-http.test.ts
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
git diff --check
```

Evidence after fix: Terminal output from the after-fix run:
```text
src/agents/openclaw-tools.sessions.test.ts: 21 tests passed
src/gateway/session-history-state.test.ts: 18 tests passed
src/gateway/server-methods/server-methods.test.ts -t keeps OpenClaw injected assistant rows: 1 passed, 103 skipped
src/gateway/sessions-history-http.test.ts: 16 tests passed
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo: exit code 0
git diff --check: no output
```

Observed result after fix: The filtered history surfaces keep visible content such as `runtime reply`, `visible injected reply`, `visible tool mirror`, and `real answer`; they drop `delivery-mirror` rows and the duplicate `gateway-injected` row that repeats the preceding `acp-runtime` text. The live display regression still keeps OpenClaw injected assistant rows visible. Default `sessions_history` calls still return the latest 200 visible messages after raw overfetch/filtering; the new regression test confirms a 250-message raw response is trimmed to messages 51 through 250.

What was not tested: I did not replay a production Telegram or dashboard session against an installed gateway. The validation is local source-level regression coverage plus the local HTTP session-history e2e path.
