### PR TITLE
fix(cron): use original config for isolated delivery secretRef resolution

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -745,6 +745,9 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       synthesizedText: "Custom main session briefing complete.",
       runStartedAt: 1_000,
     });
+    params.cfg = {
+      session: { mainKey: "work" },
+    } as never;
     params.cfgWithAgentDefaults = {
       session: { mainKey: "work" },
     } as never;
@@ -787,6 +790,9 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       synthesizedText: "Threaded custom main session briefing complete.",
       runStartedAt: 1_000,
     });
+    params.cfg = {
+      session: { mainKey: "work" },
+    } as never;
     params.cfgWithAgentDefaults = {
       session: { mainKey: "work" },
     } as never;

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -753,12 +753,12 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(state.result).toBeUndefined();
     expect(state.delivered).toBe(true);
     expect(buildOutboundSessionContext).toHaveBeenCalledWith({
-      cfg: params.cfgWithAgentDefaults,
+      cfg: params.cfg,
       agentId: "main",
       sessionKey: "agent:main:work",
     });
     expect(ensureOutboundSessionEntry).toHaveBeenCalledWith({
-      cfg: params.cfgWithAgentDefaults,
+      cfg: params.cfg,
       channel: "telegram",
       accountId: undefined,
       route: expect.objectContaining({
@@ -795,12 +795,12 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(state.result).toBeUndefined();
     expect(state.delivered).toBe(true);
     expect(buildOutboundSessionContext).toHaveBeenCalledWith({
-      cfg: params.cfgWithAgentDefaults,
+      cfg: params.cfg,
       agentId: "main",
       sessionKey: "agent:main:work:thread:42",
     });
     expect(ensureOutboundSessionEntry).toHaveBeenCalledWith({
-      cfg: params.cfgWithAgentDefaults,
+      cfg: params.cfg,
       channel: "telegram",
       accountId: undefined,
       route: expect.objectContaining({
@@ -1363,7 +1363,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(state.result).toBeUndefined();
     expect(state.delivered).toBe(true);
     expect(buildOutboundSessionContext).toHaveBeenCalledWith({
-      cfg: params.cfgWithAgentDefaults,
+      cfg: params.cfg,
       agentId: "main",
       sessionKey: "agent:main:telegram:123456",
     });
@@ -1392,7 +1392,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(state.result).toBeUndefined();
     expect(state.delivered).toBe(true);
     expect(resolveOutboundSessionRoute).toHaveBeenCalledWith({
-      cfg: params.cfgWithAgentDefaults,
+      cfg: params.cfg,
       channel: "whatsapp",
       agentId: "main",
       accountId: undefined,
@@ -1401,7 +1401,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       threadId: undefined,
     });
     expect(ensureOutboundSessionEntry).toHaveBeenCalledWith({
-      cfg: params.cfgWithAgentDefaults,
+      cfg: params.cfg,
       channel: "whatsapp",
       accountId: undefined,
       route: expect.objectContaining({
@@ -1409,7 +1409,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       }),
     });
     expect(buildOutboundSessionContext).toHaveBeenCalledWith({
-      cfg: params.cfgWithAgentDefaults,
+      cfg: params.cfg,
       agentId: "main",
       sessionKey: "agent:main:whatsapp:direct:+15551234567",
     });
@@ -1474,7 +1474,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(state.delivered).toBe(true);
     expect(resolveOutboundSessionRoute).not.toHaveBeenCalled();
     expect(buildOutboundSessionContext).toHaveBeenCalledWith({
-      cfg: params.cfgWithAgentDefaults,
+      cfg: params.cfg,
       agentId: "main",
       sessionKey: "agent:main:session:daily-report",
     });

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -909,14 +909,14 @@ export async function dispatchCronDelivery(
         return null;
       }
       const deliverySessionKey = await resolveDirectCronDeliverySessionKey({
-        cfg: params.cfgWithAgentDefaults,
+        cfg: params.cfg,
         job: params.job,
         agentId: params.agentId,
         agentSessionKey: params.agentSessionKey,
         delivery,
       });
       const deliverySession = buildOutboundSessionContext({
-        cfg: params.cfgWithAgentDefaults,
+        cfg: params.cfg,
         agentId: params.agentId,
         sessionKey: deliverySessionKey,
       });
@@ -947,7 +947,7 @@ export async function dispatchCronDelivery(
       const runDelivery = async () => {
         attemptedPayloadsForMirror.length = 0;
         const send = await sendDurableMessageBatch({
-          cfg: params.cfgWithAgentDefaults,
+          cfg: params.cfg,
           channel: delivery.channel,
           to: delivery.to,
           accountId: delivery.accountId,


### PR DESCRIPTION
## Summary

Fix cron isolated-agent delivery dispatch to use the original config (carrying runtime-resolved secretRefs) for credential-sensitive channel operations, instead of the agent-defaults config that strips them.

Closes #86545

## Problem

When a cron job runs in isolated mode, `dispatchCronDelivery` receives two config objects:

- `params.cfg`: the original config with runtime-resolved `secretRefs` needed for channel authentication
- `params.cfgWithAgentDefaults`: a spread copy with agent defaults applied, but without the runtime-resolved secret references

Three credential-sensitive calls used `params.cfgWithAgentDefaults`:

1. `resolveDirectCronDeliverySessionKey` (line 912): resolves the delivery session key
2. `buildOutboundSessionContext` (line 918): builds the outbound session context for channel delivery
3. `sendDurableMessageBatch` (line 950): sends the actual message batch to the channel

All three fail to resolve channel credentials because the spread config does not carry the runtime-resolved `secretRef` bindings.

## Change

`src/cron/isolated-agent/delivery-dispatch.ts`: changed 3 lines from `params.cfgWithAgentDefaults` to `params.cfg` for the three credential-sensitive calls.

## Verification

- **Behavior addressed**: cron isolated jobs fail Discord (and other channel) delivery because secretRefs are not resolved when the delivery dispatch uses the agent-defaults config instead of the original config (#86545)
- **Real environment tested**: macOS arm64, Node 22, vitest
- **Exact steps or command run after this patch**:
  ```
  node scripts/run-vitest.mjs src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
  ```
- **Evidence after fix**:
  ```
  ✓ |cron| ../../src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts (62 tests) 172ms

  Test Files  1 passed (1)
       Tests  62 passed (62)
  ```
  The test suite covers the delivery dispatch flow including session key resolution, outbound context building, and message batch sending. The 3-line config routing change ensures credential-sensitive calls receive `params.cfg` (with secretRef bindings) instead of `params.cfgWithAgentDefaults` (without).

  Config split by concern:
  ```
  // Credential-sensitive (now use params.cfg):
  resolveDirectCronDeliverySessionKey({ cfg: params.cfg, ... })
  buildOutboundSessionContext({ cfg: params.cfg, ... })
  sendDurableMessageBatch({ cfg: params.cfg, ... })

  // Agent-settings (unchanged, use cfgWithAgentDefaults):
  identity, TTS, awareness, transcript mirror, store path
  ```
- **Observed result after fix**: the three delivery calls now receive the config object that carries runtime-resolved secret references, consistent with how non-isolated delivery paths handle channel authentication
- **What was not tested**: live Discord delivery with a real cron isolated job (requires configured channel credentials and a running gateway with scheduled cron jobs)
