### PR TITLE
fix(agents): gate owned-write publish on pre-append fingerprint (#86572)

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -767,8 +767,13 @@ describe("embedded attempt session lock lifecycle", () => {
 
     await controller.releaseForPrompt();
     await controller.reacquireAfterPrompt();
+    // Post-reacquire owned write: an owned append landing after the prompt
+    // stream's lock reacquisition still publishes through the trust gate (the
+    // fence stays active), so cleanup must not flag it as a takeover. Distinct
+    // from the in-prompt publish path the trust-gate suite below covers.
+    const beforeWrite = readSessionFileFingerprintSync(sessionFile);
     await fs.appendFile(sessionFile, '{"type":"message","id":"provider-error"}\n', "utf8");
-    controller.refreshAfterOwnedSessionWrite();
+    controller.publishOwnedPostMessageWrite(beforeWrite);
 
     const cleanupLock = await controller.acquireForCleanup();
     await cleanupLock.release();
@@ -852,23 +857,6 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(controller.hasSessionTakeover()).toBe(false);
     expect(acquireSessionWriteLockLocal4).toHaveBeenCalledTimes(3);
     expect(release).toHaveBeenCalledTimes(3);
-  });
-
-  it("refreshes the prompt fence after an owned session manager append", async () => {
-    const sessionFile = await createTempSessionFile();
-    const release = vi.fn(async () => {});
-    const acquireSessionWriteLockLocal3 = vi.fn(async () => ({ release }));
-    const controller = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock: acquireSessionWriteLockLocal3,
-      lockOptions: { ...lockOptions, sessionFile },
-    });
-
-    await controller.releaseForPrompt();
-    await fs.appendFile(sessionFile, '{"type":"message","id":"owned-session-manager"}\n', "utf8");
-    controller.refreshAfterOwnedSessionWrite();
-
-    await expect(controller.withSessionWriteLock(() => "finalize")).resolves.toBe("finalize");
-    expect(controller.hasSessionTakeover()).toBe(false);
   });
 
   it("allows post-prompt writes after the prompt context publishes an owned transcript write", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -21,6 +21,7 @@ import {
   createEmbeddedAttemptSessionLockController,
   EmbeddedAttemptSessionTakeoverError,
   installPromptSubmissionLockRelease,
+  readSessionFileFingerprintSync,
   resetEmbeddedAttemptSessionFileOwnersForTest,
 } from "./attempt.session-lock.js";
 
@@ -1478,5 +1479,76 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(transcript).toContain("session-locked hook write");
     expect(transcript).toContain("prompt-stream write");
     expect(controller.hasSessionTakeover()).toBe(false);
+  });
+});
+
+describe("publishOwnedPostMessageWrite trust gate (#86572)", () => {
+  // Pre-append trust gate for same-lane session-manager writes (PR #86584).
+  // After releaseForPrompt() the fence is F0 (trusted); pi's own append to F1
+  // happens before the next hook-lock acquisition. The lane's write may only be
+  // recorded as owned when its pre-append fingerprint was trusted, otherwise the
+  // takeover fence must stay closed. The pure-external advance case is already
+  // covered by "rejects post-prompt writes when another owner advances the
+  // session file"; these cases exercise the publish path itself.
+
+  it("trips the fence on a same-lane write that skips publishOwnedPostMessageWrite", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLockLocal29 = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocal29,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    // pi appends F0 -> F1 but never publishes the owned write: fail closed.
+    await fs.appendFile(sessionFile, '{"type":"message","id":"pi-stream-write"}\n', "utf8");
+
+    await expect(controller.withSessionWriteLock(() => "hook")).rejects.toBeInstanceOf(
+      EmbeddedAttemptSessionTakeoverError,
+    );
+    expect(controller.hasSessionTakeover()).toBe(true);
+  });
+
+  it("accepts a same-lane write published with a trusted pre-append fingerprint", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLockLocal30 = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocal30,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    // F0 was trusted at releaseForPrompt; capture it before pi's own append.
+    const beforeWrite = readSessionFileFingerprintSync(sessionFile);
+    await fs.appendFile(sessionFile, '{"type":"message","id":"pi-stream-write"}\n', "utf8");
+    controller.publishOwnedPostMessageWrite(beforeWrite);
+
+    await expect(controller.withSessionWriteLock(() => "hook")).resolves.toBe("hook");
+    expect(controller.hasSessionTakeover()).toBe(false);
+  });
+
+  it("still trips when an external write poisons the published baseline (mixed interleave)", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLockLocal31 = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocal31,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    // External actor advances F0 -> F1 first, so the baseline pi captures (F1)
+    // was never trusted. publish must refuse to launder the combined F2 state.
+    await fs.appendFile(sessionFile, '{"type":"message","id":"external-first"}\n', "utf8");
+    const beforeWrite = readSessionFileFingerprintSync(sessionFile);
+    await fs.appendFile(sessionFile, '{"type":"message","id":"pi-after-external"}\n', "utf8");
+    controller.publishOwnedPostMessageWrite(beforeWrite);
+
+    await expect(controller.withSessionWriteLock(() => "hook")).rejects.toBeInstanceOf(
+      EmbeddedAttemptSessionTakeoverError,
+    );
+    expect(controller.hasSessionTakeover()).toBe(true);
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -624,7 +624,6 @@ export class EmbeddedAttemptSessionTakeoverError extends Error {
 export type EmbeddedAttemptSessionLockController = {
   releaseForPrompt(): Promise<void>;
   releaseHeldLockForAbort(): Promise<void>;
-  refreshAfterOwnedSessionWrite(): void;
   publishOwnedPostMessageWrite(beforeWrite: SessionFileFingerprint | undefined): void;
   reacquireAfterPrompt(): Promise<void>;
   waitForSessionEvents(session: unknown): Promise<void>;
@@ -951,12 +950,6 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     },
     async releaseHeldLockForAbort(): Promise<void> {
       await releaseHeldLockWithFence();
-    },
-    refreshAfterOwnedSessionWrite(): void {
-      if (fenceActive && !takeoverDetected) {
-        fenceFingerprint = readSessionFileFingerprintSync(params.lockOptions.sessionFile);
-        fenceSnapshot = { fingerprint: fenceFingerprint };
-      }
     },
     publishOwnedPostMessageWrite(beforeWrite: SessionFileFingerprint | undefined): void {
       // Called synchronously after pi's `sessionManager.appendMessage` →

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
-import { statSync } from "node:fs";
+import { closeSync, openSync, readSync, statSync } from "node:fs";
 import fs from "node:fs/promises";
 import { isDeepStrictEqual } from "node:util";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
@@ -36,7 +36,7 @@ type PromptReleaseStreamFn = ((...args: unknown[]) => unknown) & {
   __openclawSessionLockPromptReleaseInstalled?: boolean;
 };
 
-type SessionFileFingerprint =
+export type SessionFileFingerprint =
   | { exists: false }
   | {
       exists: true;
@@ -209,6 +209,35 @@ async function readAppendedSessionFileText(params: {
   return buffer.toString("utf8");
 }
 
+function readAppendedSessionFileTextSync(params: {
+  sessionFile: string;
+  previous: Extract<SessionFileFingerprint, { exists: true }>;
+  current: Extract<SessionFileFingerprint, { exists: true }>;
+}): string | undefined {
+  if (params.current.size <= params.previous.size || params.previous.size > MAX_SAFE_FILE_OFFSET) {
+    return undefined;
+  }
+  const appendedBytes = params.current.size - params.previous.size;
+  if (
+    appendedBytes > BigInt(MAX_BENIGN_SESSION_FENCE_ADVANCE_BYTES) ||
+    appendedBytes > MAX_SAFE_FILE_OFFSET
+  ) {
+    return undefined;
+  }
+  const length = Number(appendedBytes);
+  const buffer = Buffer.alloc(length);
+  const file = openSync(params.sessionFile, "r");
+  try {
+    const bytesRead = readSync(file, buffer, 0, length, Number(params.previous.size));
+    if (bytesRead !== length) {
+      return undefined;
+    }
+  } finally {
+    closeSync(file);
+  }
+  return buffer.toString("utf8");
+}
+
 async function readSessionFileFenceSnapshot(
   sessionFile: string,
 ): Promise<SessionFileFenceSnapshot> {
@@ -243,6 +272,30 @@ async function sessionFenceAdvanceIsBenign(params: {
     return false;
   }
   const text = await readAppendedSessionFileText({
+    sessionFile: params.sessionFile,
+    previous: params.previous.fingerprint,
+    current: params.current,
+  });
+  if (!text?.endsWith("\n")) {
+    return false;
+  }
+  const lines = normalizeStringEntries(text.split("\n"));
+  return lines.length > 0 && lines.every(isTranscriptOnlyOpenClawAssistantLine);
+}
+
+function sessionFenceAdvanceIsBenignSync(params: {
+  sessionFile: string;
+  previous: SessionFileFenceSnapshot | undefined;
+  current: SessionFileFingerprint;
+}): boolean {
+  if (
+    !params.previous?.fingerprint.exists ||
+    !params.current.exists ||
+    !sameSessionFileIdentity(params.previous.fingerprint, params.current)
+  ) {
+    return false;
+  }
+  const text = readAppendedSessionFileTextSync({
     sessionFile: params.sessionFile,
     previous: params.previous.fingerprint,
     current: params.current,
@@ -540,7 +593,7 @@ async function readSessionFileFingerprint(sessionFile: string): Promise<SessionF
   }
 }
 
-function readSessionFileFingerprintSync(sessionFile: string): SessionFileFingerprint {
+export function readSessionFileFingerprintSync(sessionFile: string): SessionFileFingerprint {
   try {
     const stat = statSync(sessionFile, { bigint: true });
     return {
@@ -572,6 +625,7 @@ export type EmbeddedAttemptSessionLockController = {
   releaseForPrompt(): Promise<void>;
   releaseHeldLockForAbort(): Promise<void>;
   refreshAfterOwnedSessionWrite(): void;
+  publishOwnedPostMessageWrite(beforeWrite: SessionFileFingerprint | undefined): void;
   reacquireAfterPrompt(): Promise<void>;
   waitForSessionEvents(session: unknown): Promise<void>;
   withSessionWriteLock<T>(
@@ -902,6 +956,57 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       if (fenceActive && !takeoverDetected) {
         fenceFingerprint = readSessionFileFingerprintSync(params.lockOptions.sessionFile);
         fenceSnapshot = { fingerprint: fenceFingerprint };
+      }
+    },
+    publishOwnedPostMessageWrite(beforeWrite: SessionFileFingerprint | undefined): void {
+      // Called synchronously after pi's `sessionManager.appendMessage` →
+      // `_persist` → `appendFileSync` from the `onMessagePersisted` callback.
+      // `beforeWrite` is the file fingerprint captured immediately BEFORE the
+      // session-manager append (passed through `beforeMessagePersist` in
+      // `installSessionPersistenceGuard`). Records the post-write fingerprint
+      // as an OWNED write in `ownedSessionFileWrites` so subsequent
+      // `assertSessionFileFence` calls inside `withSessionWriteLock` accept
+      // the lane's own writes via the owned-write match path.
+      //
+      // Fail-closed gate: the trust check runs on `beforeWrite`, not on the
+      // current fence fingerprint. If an external mutation lands between
+      // `releaseForPrompt` (which marks F0 trusted) and pi's append, then
+      // `beforeWrite` = F1 ≠ F0 and `isTrustedSessionFileState` returns
+      // false — publish is skipped and the external + pi combined state
+      // (F2) is NOT recorded as owned. The subsequent hook-lock
+      // `assertSessionFileFence` still sees current = F2 ≠ fence = F0 and
+      // trips the takeover correctly.
+      if (takeoverDetected) {
+        return;
+      }
+      if (!beforeWrite) {
+        return;
+      }
+      const beforeWriteMatchesActiveFence =
+        fenceActive && sameSessionFileFingerprint(fenceFingerprint, beforeWrite);
+      const beforeWriteIsBenignAdvance =
+        fenceActive &&
+        sessionFenceAdvanceIsBenignSync({
+          sessionFile: params.lockOptions.sessionFile,
+          previous: fenceSnapshot,
+          current: beforeWrite,
+        });
+      if (
+        !beforeWriteMatchesActiveFence &&
+        !beforeWriteIsBenignAdvance &&
+        !isTrustedSessionFileState(sessionFileFenceKey, beforeWrite)
+      ) {
+        return;
+      }
+      const current = readSessionFileFingerprintSync(params.lockOptions.sessionFile);
+      if (sameSessionFileFingerprint(beforeWrite, current)) {
+        return;
+      }
+      const generation = recordOwnedSessionFileWrite(sessionFileFenceKey, current);
+      if (fenceActive) {
+        fenceFingerprint = current;
+        fenceSnapshot = { fingerprint: current };
+        fenceGeneration = generation;
       }
     },
     async reacquireAfterPrompt(): Promise<void> {

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -373,6 +373,8 @@ import {
   type EmbeddedAttemptSessionFileOwner,
   createEmbeddedAttemptSessionLockController,
   installPromptSubmissionLockRelease,
+  readSessionFileFingerprintSync,
+  type SessionFileFingerprint,
 } from "./attempt.session-lock.js";
 import {
   createYieldAbortedResponse,
@@ -1977,8 +1979,20 @@ export async function runEmbeddedAttempt(
         suppressTranscriptOnlyAssistantPersistence:
           params.suppressTranscriptOnlyAssistantPersistence,
         suppressAssistantErrorPersistence: params.suppressAssistantErrorPersistence,
-        onMessagePersisted: () => {
-          sessionLockController.refreshAfterOwnedSessionWrite();
+        beforeMessagePersist: () => readSessionFileFingerprintSync(params.sessionFile),
+        onMessagePersisted: (_message, { beforeWriteSnapshot }) => {
+          // Publish pi's appendFileSync write to the controller's owned-write
+          // map so subsequent assertSessionFileFence calls accept the lane's
+          // own writes via the owned-write match path. The trust check inside
+          // publishOwnedPostMessageWrite runs on beforeWriteSnapshot (the
+          // fingerprint captured immediately BEFORE pi's appendFileSync), so
+          // if an external mutation slipped in between releaseForPrompt and
+          // this append, the publish is skipped and the combined post-write
+          // state stays unowned — preserving fail-closed takeover detection.
+          // See #86572.
+          sessionLockController.publishOwnedPostMessageWrite(
+            beforeWriteSnapshot as SessionFileFingerprint | undefined,
+          );
         },
         onUserMessagePersisted: (message) => {
           params.onUserMessagePersisted?.(message);

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -43,7 +43,11 @@ export function guardSessionManager(
     onUserMessagePersisted?: (
       message: Extract<AgentMessage, { role: "user" }>,
     ) => void | Promise<void>;
-    onMessagePersisted?: (message: AgentMessage) => void | Promise<void>;
+    onMessagePersisted?: (
+      message: AgentMessage,
+      context: { beforeWriteSnapshot?: unknown },
+    ) => void | Promise<void>;
+    beforeMessagePersist?: () => unknown;
     onAssistantErrorMessagePersisted?: (
       message: Extract<AgentMessage, { role: "assistant" }>,
     ) => void | Promise<void>;
@@ -135,6 +139,7 @@ export function guardSessionManager(
     suppressTranscriptOnlyAssistantPersistence: opts?.suppressTranscriptOnlyAssistantPersistence,
     suppressAssistantErrorPersistence: opts?.suppressAssistantErrorPersistence,
     onMessagePersisted: opts?.onMessagePersisted,
+    beforeMessagePersist: opts?.beforeMessagePersist,
     onUserMessagePersisted: opts?.onUserMessagePersisted,
     onAssistantErrorMessagePersisted: opts?.onAssistantErrorMessagePersisted,
   });

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -562,7 +562,15 @@ export function installSessionToolResultGuard(
     onUserMessagePersisted?: (
       message: Extract<AgentMessage, { role: "user" }>,
     ) => void | Promise<void>;
-    onMessagePersisted?: (message: AgentMessage) => void | Promise<void>;
+    onMessagePersisted?: (
+      message: AgentMessage,
+      context: { beforeWriteSnapshot?: unknown },
+    ) => void | Promise<void>;
+    // Captured immediately before the session-manager append. Callers can use
+    // the returned snapshot to detect external writes that landed between
+    // earlier lifecycle checkpoints and the current append (see #86572 for
+    // the session-takeover fence trust gate that consumes it).
+    beforeMessagePersist?: () => unknown;
     onAssistantErrorMessagePersisted?: (
       message: Extract<AgentMessage, { role: "assistant" }>,
     ) => void | Promise<void>;
@@ -603,8 +611,9 @@ export function installSessionToolResultGuard(
     message: AgentMessage,
   ): { entryId: string; messageSeq?: number; sessionFile?: string | null } => {
     const parentEntryId = sessionManager.getLeafId();
+    const beforeWriteSnapshot = opts?.beforeMessagePersist?.();
     const entryId = originalAppend(message as never);
-    void opts?.onMessagePersisted?.(message);
+    void opts?.onMessagePersisted?.(message, { beforeWriteSnapshot });
     const sessionFile = getSessionFile();
     if (!sessionFile) {
       return { entryId, sessionFile };


### PR DESCRIPTION
## Summary

Converts the embedded session-takeover fence's post-write handling from a **fail-open** unconditional fence refresh into a **fail-closed**, trust-gated owned-write publish.

On current `main`, after a lane's own message persists, `onMessagePersisted → refreshAfterOwnedSessionWrite()` unconditionally re-reads the session file and trusts whatever is on disk as the new fence baseline. If an external mutation interleaves between `releaseForPrompt` (fence = F0) and the lane's own append (F1 → F2), that external mutation is silently **laundered** into the fence and the takeover detector never trips.

This PR captures the file fingerprint immediately **before** the lane's append (`beforeMessagePersist`) and records the post-write state as owned **only when that pre-append fingerprint was trusted** (matches the active fence, is a benign transcript-only advance, or is a previously-trusted state). Otherwise it refuses to record — so an interleaved external mutation can no longer be laundered, and the fence still trips.

Closes #86572. Complementary to #87159: that PR closes the **cross-lane** file-ownership race; this PR closes the **same-lane** publish boundary. The two enforce orthogonal invariants.

## Fix shape (vs. #86572's proposal)

#86572 proposed hoisting the `withOwnedSessionTranscriptWrites` ALS scope to span `agent.prompt()`. This PR instead gates at the **publish boundary** (`onMessagePersisted`): pi's session writes already funnel through the guarded `sessionManager.appendMessage` seam, so the trust decision belongs in the controller that owns the fence, not in the ALS scope. This keeps the trust decision at the ownership boundary and avoids classifying unrelated listener writes as owned.

## Rebase note (force-pushed, head `43baac80c5`)

Rebased onto current `upstream/main`, picking up:
- [#87159](https://github.com/openclaw/openclaw/pull/87159) — canonical session-file ownership indexing
- [#87409](https://github.com/openclaw/openclaw/pull/87409) — removed `installSessionExternalHookWriteLock` / `installSessionEventWriteLock`, moved hook locking into the controller

## Production context — corrected

> **Correction (see [@htuyer121's comment](https://github.com/openclaw/openclaw/pull/86584#issuecomment-4602536906)):** an earlier revision of this PR cited @htuyer121's `EmbeddedAttemptSessionTakeoverError` corpus as evidence the class *"continues firing after #87159."* That framing was **inaccurate** and the reporter has corrected it.

- All 30 of their events were on the **pre-#87159** build (2026.5.26). #87159 reached their install via v2026.5.27 on 2026-05-29.
- Since deploying #87159: **zero events over ~6 days**; former hot-spot jobs now run clean through to delivery.
- Once #87159 closes the cross-lane boundary, their production window **cannot isolate a same-lane-only race**.

So there is **no current production signal** for the specific same-lane path this PR hardens. Per the reporter's own recommendation, this PR should be weighed on its **source-level proof**, not on that corpus. This is defense-in-depth hardening of the publish boundary — not a fix for an actively-firing production class.

## Real behavior proof

- **Behavior addressed:** Converts the post-owned-write fence update from fail-open (unconditional refresh that can launder an interleaved external mutation into the fence) to fail-closed (record-as-owned only when the pre-append fingerprint was trusted). The behavioral delta versus current `main` is the **mixed-interleave case (Scenario D)**: `main` launders the external mutation into the fence; this PR refuses to, so the takeover still trips. Clean same-lane writes (Scenario B) behave identically to `main`.

- **Real environment tested:** Source-level runtime harness on rebased branch `43baac80c5`: macOS 26.5, Node 26.0.0, branched off current `upstream/main` (post-#87159 + #87409); loads the patched `EmbeddedAttemptSessionLockController` from source via dynamic import and drives four runtime scenarios against real temp session JSONL files via `fs.appendFile` and `controller.withSessionWriteLock`.

- **Exact steps or command run after this patch:** `git fetch origin && git checkout fix/session-takeover-refresh-before-hook-lock` (confirm at `43baac80c5`), then `node --import tsx /Users/umank/code/openclaw-tickets/proof/run-refresh-before-hook-lock-proof.mjs /Users/umank/code/openclaw`. Checked-in regression: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts`.

- **Evidence after fix:** terminal capture from the rebased branch follows. Note: in the harness, Scenario A's *"pre-fix"* label means the controller is simply **not informed of the write** (neither `main`'s `refreshAfterOwnedSessionWrite` nor this PR's `publishOwnedPostMessageWrite` is called) — it demonstrates the controller mechanics, not a literal `main` reproduction. The behavioral delta over `main` is **Scenario D**.

```
============================================================
PR #86584 — publish-on-onMessagePersisted proof (Issue #86572)
============================================================
source under test: src/agents/embedded-agent-runner/run/attempt.session-lock.ts
                   publishOwnedPostMessageWrite(beforeWrite)
                   gated on isTrustedSessionFileState(key, beforeWrite)

-------- Scenario A — pre-fix: pi-style write WITHOUT publish (trips takeover) --------
  [   0.13ms] setup      mode=pre-fix
  [   0.15ms] lifecycle  releaseForPrompt() — capture fence F0 + mark trusted
  [   0.47ms] pi-write   pi appendFileSync (F0 → F1) — no publish call
  [   0.60ms] hook       controller.withSessionWriteLock(beforeToolCallBody)
  [   1.62ms] hook       RESULT: TAKEOVER (EmbeddedAttemptSessionTakeoverError: session file changed while embedded prompt lock was released: /var/folders/hw/b1qn975s06qg...)
  [   1.64ms] state      hasSessionTakeover() = true

-------- Scenario B — post-fix: pi-style write WITH publish (hook fires cleanly) --------
  [   0.05ms] lifecycle  releaseForPrompt() — capture fence F0 + mark trusted
  [   0.18ms] pi-write   pi appendFileSync (F0 → F1) with pre-write captured
  [   0.27ms] publish    publishOwnedPostMessageWrite(F0) — F0 is trusted, record F1 as owned
  [   0.34ms] hook       controller.withSessionWriteLock(beforeToolCallBody)
  [   0.46ms] hook       RESULT: hook fired successfully (hookOutcome.fired=true)
  [   0.47ms] state      hasSessionTakeover() = false

-------- Scenario C — negative: external write bypasses publish (still trips) --------
  [   0.12ms] pi-write   EXTERNAL appendFileSync (F0 → F1) — no publish
  [   0.34ms] hook       RESULT: TAKEOVER (EmbeddedAttemptSessionTakeoverError)
  [   0.35ms] state      hasSessionTakeover() = true

-------- Scenario D — mixed interleave: external THEN pi write + publish (still trips) --------
  [   0.12ms] external   EXTERNAL appendFileSync first (F0 → F1)
  [   0.20ms] pi-write   pi appendFileSync second (F1 → F2) — pre-write captured = F1
  [   0.28ms] publish    publishOwnedPostMessageWrite(F1) — F1 NOT trusted, skip (fail closed)
  [   0.50ms] hook       RESULT: TAKEOVER (EmbeddedAttemptSessionTakeoverError)
  [   0.51ms] state      hasSessionTakeover() = true

============================================================
Summary
============================================================
  Scenario A (no fix):       hook fired=false, threw=TAKEOVER
  Scenario B (with fix):     hook fired=true, threw=no
  Scenario C (negative):     hook fired=false, threw=TAKEOVER
  Scenario D (mixed):        hook fired=false, threw=TAKEOVER

RESULT: PASS — all four scenarios behaved as expected.
```

- **Observed result after fix:** Scenarios A/B/C demonstrate the gate mechanics; **Scenario D is the behavioral improvement over `main`** — `main`'s unconditional refresh would record the combined F2 (external + pi) state as the trusted fence and silently absorb the external mutation, whereas the trust gate sees the untrusted pre-append baseline (F1) and refuses to record, so the takeover fence still fires. The checked-in regression covers the publish / skip / mixed-interleave cases directly.

- **What was not tested:**
  1. A live runtime reproduction against @htuyer121's corpus on the rebased branch — that corpus is **pre-#87159** (see corrected timeline above), so it cannot corroborate the post-#87159 same-lane path.
  2. **Known limitation:** the trust gate captures the pre-append fingerprint immediately before `appendFileSync`. A concurrent external writer appending benign-looking transcript JSONL inside that narrow window could still be absorbed. Preventing concurrent writers to the same session file is the responsibility of #87159's file-ownership boundary, not this publish-boundary gate.

## Compatibility / Risk

- `publishOwnedPostMessageWrite(beforeWrite)` is an additive method on `EmbeddedAttemptSessionLockController`.
- `beforeMessagePersist` is an additive optional opt on the session guard. Backward compatible.
- The trust gate is fail-closed: any baseline mismatch refuses to record. Cannot launder external mutations.

## Related

- Issue #86572 — root cause and acceptance criteria (this PR takes the publish-boundary fix shape, not the proposed ALS-scope hoist)
- #87159 — joshavant's session-file ownership (complementary, landed)
- #87409 — moved hook locking into the controller (this PR rebased on top)
- #86845 — @htuyer121's corpus (pre-#87159; see corrected timeline above)

---

*This PR is AI-assisted. Code authored with Claude.*
