### PR TITLE
fix(agents): drain prompt-emitted session events before fence reacquire (#85913)

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
@@ -833,7 +833,11 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(releaseForPrompt).toHaveBeenCalledTimes(1);
     expect(reacquireAfterPrompt).toHaveBeenCalledTimes(1);
     expect(streamFn).toHaveBeenCalledWith("model", "context");
-    expect(events).toEqual(["drain", "release", "stream", "reacquire"]);
+    // Two drains: one before releaseForPrompt to clear pre-prompt events,
+    // one after streamFn to clear prompt-emitted events before the fence
+    // check inside reacquireAfterPrompt sees them as external mutation.
+    expect(waitForSessionEvents).toHaveBeenCalledTimes(2);
+    expect(events).toEqual(["drain", "release", "stream", "drain", "reacquire"]);
   });
 
   it("rewraps provider stream submission after the stream function is rebuilt", async () => {
@@ -880,19 +884,95 @@ describe("embedded attempt session lock lifecycle", () => {
 
     expect(firstStreamFn).toHaveBeenCalledTimes(1);
     expect(secondStreamFn).toHaveBeenCalledTimes(1);
-    expect(waitForSessionEvents).toHaveBeenCalledTimes(2);
+    // Two prompts × two drains each (pre-release + post-stream) = 4 drains.
+    expect(waitForSessionEvents).toHaveBeenCalledTimes(4);
     expect(releaseForPrompt).toHaveBeenCalledTimes(2);
     expect(reacquireAfterPrompt).toHaveBeenCalledTimes(2);
     expect(events).toEqual([
       "drain",
       "release",
       "first-stream",
+      "drain",
       "reacquire",
       "drain",
       "release",
       "second-stream",
+      "drain",
       "reacquire",
     ]);
+  });
+
+  it("drains prompt-emitted session events before reacquireAfterPrompt's fence check", async () => {
+    // Pins down the call-ordering invariant added by the kesslerio drain
+    // (#85913): the finally block must call waitForSessionEvents before
+    // reacquireAfterPrompt, symmetric with the pre-release drain at the
+    // top of wrappedStreamFn. In vanilla pi the drain is a no-op (the
+    // session manager doesn't populate `_agentEventQueue`); in deployments
+    // that wire the queue, this is where any provider-emitted side
+    // effects settle before the next lock cycle. The synthetic
+    // pendingPromptEvent below models that "side effect awaiting drain"
+    // shape — it is NOT a faithful reproduction of vanilla pi's stream
+    // listener path, just an ordering probe.
+    const events: string[] = [];
+    // Models a prompt-emitted session event that the streamFn enqueues
+    // during the provider response and that must drain before the fence
+    // check. Resolving the callback represents the event "settling" —
+    // i.e. its write to the session file completing.
+    let pendingPromptEvent: (() => void) | null = null;
+    const streamFn = vi.fn(async () => {
+      events.push("stream-start");
+      // Provider response queues a session event (e.g. an assistant
+      // delta, a tool-call result) but does not synchronously flush it.
+      pendingPromptEvent = () => events.push("event-resolved");
+      events.push("stream-end");
+    });
+    const waitForSessionEvents = vi.fn(async () => {
+      // The drain settles any queued event. Each call records "drain"
+      // for ordering assertions plus runs any pending event resolver.
+      if (pendingPromptEvent) {
+        pendingPromptEvent();
+        pendingPromptEvent = null;
+      }
+      events.push("drain");
+    });
+    const releaseForPrompt = vi.fn(async () => {
+      events.push("release");
+    });
+    const reacquireAfterPrompt = vi.fn(async () => {
+      // assertSessionFileFence() runs inside reacquireAfterPrompt in
+      // production. If the queued prompt event hasn't drained yet, the
+      // fence would see the new file fingerprint and trip — modelled
+      // here as an explicit "fence-trip-on-undrained-event" entry.
+      if (pendingPromptEvent) {
+        events.push("fence-trip-on-undrained-event");
+      }
+      events.push("reacquire");
+    });
+    const session = { agent: { streamFn } };
+
+    installPromptSubmissionLockRelease({
+      session,
+      waitForSessionEvents,
+      releaseForPrompt,
+      reacquireAfterPrompt,
+    });
+
+    await session.agent.streamFn();
+
+    // The ordering invariant the drain pins down: any drainable queued
+    // work is settled before reacquireAfterPrompt. Without the
+    // finally-drain, "event-resolved" would not appear before "reacquire",
+    // and "fence-trip-on-undrained-event" would appear instead.
+    expect(events).toEqual([
+      "drain", // pre-release drain (pre-existing — no event pending yet)
+      "release",
+      "stream-start",
+      "stream-end", // streamFn returns; pendingPromptEvent is now set
+      "event-resolved", // resolved by post-stream drain
+      "drain", // post-stream drain marker
+      "reacquire", // fence check sees a settled queue, no trip
+    ]);
+    expect(events).not.toContain("fence-trip-on-undrained-event");
   });
 
   it("treats transcript appends during prompt streaming as owned session writes", async () => {

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
@@ -921,6 +921,15 @@ export function installPromptSubmissionLockRelease(params: {
       }
       return await originalStreamFn(...args);
     } finally {
+      // Symmetric with the pre-release drain at the top of this function.
+      // In vanilla pi this is a no-op (the upstream session manager doesn't
+      // populate `_agentEventQueue`). In deployments that DO wire the queue
+      // — e.g. embedded runners that need to settle provider-emitted side
+      // effects before the next lock cycle — this gives those queued writes
+      // a chance to complete before reacquireAfterPrompt's fence check runs.
+      // Reported by @kesslerio against AlphaClaw production with a working
+      // mitigation on this code path; #85913 issue thread.
+      await params.waitForSessionEvents(params.session);
       await params.reacquireAfterPrompt();
     }
   };


### PR DESCRIPTION
## Summary

Mirror the pre-release `waitForSessionEvents` drain in `installPromptSubmissionLockRelease`'s `finally` block so deployments that populate `_agentEventQueue` settle any queued provider-emitted side effects before `reacquireAfterPrompt`'s fence check runs.

Reported and production-mitigated by @kesslerio against AlphaClaw on OpenClaw 2026.5.19 (#85913).

## Scope and honest framing

**In vanilla openclaw / pi**: this is a **no-op**. The upstream session manager does not populate `_agentEventQueue` (vanilla pi's persistence path uses synchronous `appendFileSync` directly via `_handleAgentEvent`, not the queue). `waitForSessionEvents` returns immediately in that path. The vanilla-openclaw same-lane race that produces `EmbeddedAttemptSessionTakeoverError` is addressed separately in #86584.

**In deployments that wire `_agentEventQueue`** (AlphaClaw is the reported case, but the pattern is supported by any custom embedded runner that needs to settle provider-emitted side effects via the queue): the drain is **load-bearing**. Without it, queued same-process writes can settle between `streamFn` return and `reacquireAfterPrompt`'s fence check, misclassifying the lane's own writes as external mutation.

## Why ship it

- **Symmetric**: the pre-release drain at the top of `wrappedStreamFn` already calls `waitForSessionEvents`. The finally-side drain makes the wrapper round-trip the queue at both boundaries of the prompt window, which is the natural shape.
- **Additive**: one `await` in a `finally`, no behavior change in vanilla pi, no new failure modes (the pre-release drain has the identical error/hang property).
- **Production-validated** by @kesslerio for the AlphaClaw deployment shape.
- **Defensive value for forks**: any future fork wiring the event queue gets the right behavior out of the box without having to discover the gap themselves.

## What this PR does NOT fix

The vanilla-openclaw same-lane race documented in #86572 and addressed in #86584 (refresh-before-lock pattern). That race is caused by pi's `_handleAgentEvent` writes happening outside any drainable queue — the fence-check fix has to happen at the lock-acquisition boundary, not at the queue-drain boundary. The two fixes are complementary: this PR handles deployments that populate the queue; #86584 handles the case where direct `appendFileSync` writes bypass the queue entirely.

## Real behavior proof

- **Behavior addressed:** Closes a same-lane drain race in `installPromptSubmissionLockRelease` for deployments that wire `_agentEventQueue`. Reported and production-mitigated by @kesslerio against AlphaClaw.

- **Real environment tested:** Local OpenClaw source checkout (macOS 15.5, Node 22.19+) at HEAD `79817ab102`. Existing test suite verifies the call-ordering invariant.

- **Exact steps or command run after this patch:**

  ```sh
  pnpm install
  node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
  ```

- **Evidence after fix:**

  **(a) Symmetry harness** — `run-finally-drain-proof.mjs` loads the patched `installPromptSubmissionLockRelease` from source and runs both scenarios. Verbatim stdout:

  ```
  ============================================================
PR #86585 — finally-drain symmetry proof (Issue #85913)
============================================================

openclaw checkout: /Users/umank/code/openclaw
source under test: src/agents/pi-embedded-runner/run/attempt.session-lock.ts
                   installPromptSubmissionLockRelease
                   + new waitForSessionEvents call in finally

-------- Scenario A — Vanilla pi (no _agentEventQueue, drain is no-op) --------
  [   0.01ms] setup       _agentEventQueue UNSET (vanilla pi)
  [   0.04ms] call        invoking session.agent.streamFn() (now wrapped)
  [   0.10ms] call        wrapped streamFn returned cleanly

  event ledger:
    drain-call
    drain-noop
    releaseForPrompt
    stream-start
    stream-end
    drain-call
    drain-noop
    reacquireAfterPrompt

-------- Scenario B — AlphaClaw-shape (_agentEventQueue wired, drain settles queue) --------
  [   0.00ms] setup       _agentEventQueue WIRED
  [   0.01ms] call        invoking session.agent.streamFn() (now wrapped)
  [   0.03ms] call        wrapped streamFn returned cleanly

  event ledger:
    drain-call
    drain-noop
    releaseForPrompt
    stream-start
    stream-end
    drain-call
    provider-side-effect-settled
    drain-completed
    reacquireAfterPrompt

============================================================
Summary
============================================================

  Scenario A: drain is no-op in vanilla pi (no behavior change) = PASS
  Scenario B: queue settles before reacquireAfterPrompt = PASS

  RESULT: PASS
    Vanilla pi:    finally-drain is a no-op; no behavior change.
    AlphaClaw shape: finally-drain settles the provider side effect
                     before reacquireAfterPrompt. Without it, the
                     reacquire would observe an unsettled queue and
                     the fence check would race with the queued write.
============================================================
  ```

  Both invariants pass:
  - Scenario A: drain is genuinely no-op in vanilla pi (event ledger shows `drain-noop` twice, no fence-check race)
  - Scenario B: drain settles the provider side effect BEFORE reacquireAfterPrompt (event ledger shows `provider-side-effect-settled` → `drain-completed` → `reacquireAfterPrompt`)

  The harness is at `/Users/umank/code/openclaw-tickets/proof/run-finally-drain-proof.mjs`.

  **(b) Test suite** — existing tests updated for the new post-stream drain marker; one new test (`drains prompt-emitted session events before reacquireAfterPrompt's fence check`) pins the ordering invariant. All 70 cases pass:

  ```
   Test Files  2 passed (2)
        Tests  70 passed (70)
  ```

- **Observed result after fix:** All 70 test cases pass. The synthetic `pendingPromptEvent` callback in the new test models the AlphaClaw-shaped scenario where a provider-emitted event is queued during the stream and must be drained before the fence check.

- **What was not tested:** A live AlphaClaw repro on the patched build is not in this PR; @kesslerio has been invited to validate against #86584 + this PR on their production deployment (see thread on #85913). The test surface here covers the structural ordering invariant.

- **Before evidence:** Without the finally-drain, queued same-process writes settle between `streamFn` return and `reacquireAfterPrompt`'s fence check. In vanilla pi this is unobservable (queue not populated); in AlphaClaw it causes the cron-failure class @kesslerio reported.

## Related

- #85913 — original `EmbeddedAttemptSessionTakeoverError` issue (kesslerio's report at #issuecomment-…)
- #86067 — file-scoped prompt-window guard (cross-lane race) — sister PR
- #86572 — vanilla-openclaw same-lane race architecture issue
- #86584 — refresh-before-lock fix for vanilla-openclaw same-lane race

---

*This PR is AI-assisted. Code authored with Claude.*

Co-authored-by: @kesslerio (AlphaClaw production mitigation)
