### PR TITLE
fix(mcp): reuse compact runtime and report omitted servers

### DIFF
--- a/src/agents/pi-bundle-mcp-materialize.ts
+++ b/src/agents/pi-bundle-mcp-materialize.ts
@@ -1,7 +1,5 @@
-import crypto from "node:crypto";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { logWarn } from "../logger.js";
 import { setPluginToolMeta } from "../plugins/tools.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
@@ -10,9 +8,47 @@ import {
   normalizeReservedToolNames,
   TOOL_NAME_SEPARATOR,
 } from "./pi-bundle-mcp-names.js";
-import type { BundleMcpToolRuntime, SessionMcpRuntime } from "./pi-bundle-mcp-types.js";
+import type {
+  BundleMcpToolRuntime,
+  OmittedMcpServer,
+  SessionMcpRuntime,
+} from "./pi-bundle-mcp-types.js";
 import { normalizeToolParameterSchema } from "./pi-tools-parameter-schema.js";
 import type { AnyAgentTool } from "./tools/common.js";
+
+const omittedServerWarningsByRuntime = new WeakMap<SessionMcpRuntime, Set<string>>();
+
+function formatOmittedServerWarning(server: OmittedMcpServer): string {
+  const launch = server.launchSummary ? ` (${server.launchSummary})` : "";
+  const safeName =
+    server.safeServerName && server.safeServerName !== server.serverName
+      ? ` as "${server.safeServerName}"`
+      : "";
+  return (
+    `bundle-mcp: omitted server "${server.serverName}"${safeName}${launch}: ` +
+    `${server.reason}: ${server.errorMessage}`
+  );
+}
+
+function warnForOmittedServers(runtime: SessionMcpRuntime) {
+  const omittedServers = runtime.getOmittedServers();
+  if (omittedServers.length === 0) {
+    return;
+  }
+  let warnedKeys = omittedServerWarningsByRuntime.get(runtime);
+  if (!warnedKeys) {
+    warnedKeys = new Set();
+    omittedServerWarningsByRuntime.set(runtime, warnedKeys);
+  }
+  for (const server of omittedServers) {
+    const key = `${server.serverName}\u0000${server.reason}`;
+    if (warnedKeys.has(key)) {
+      continue;
+    }
+    warnedKeys.add(key);
+    logWarn(formatOmittedServerWarning(server));
+  }
+}
 
 function toAgentToolResult(params: {
   serverName: string;
@@ -65,7 +101,6 @@ function toAgentToolResult(params: {
 export async function materializeBundleMcpToolsForRun(params: {
   runtime: SessionMcpRuntime;
   reservedToolNames?: Iterable<string>;
-  disposeRuntime?: () => Promise<void>;
 }): Promise<BundleMcpToolRuntime> {
   let disposed = false;
   const releaseLease = params.runtime.acquireLease?.();
@@ -73,6 +108,7 @@ export async function materializeBundleMcpToolsForRun(params: {
   let catalog;
   try {
     catalog = await params.runtime.getCatalog();
+    warnForOmittedServers(params.runtime);
   } catch (error) {
     releaseLease?.();
     throw error;
@@ -142,34 +178,6 @@ export async function materializeBundleMcpToolsForRun(params: {
       }
       disposed = true;
       releaseLease?.();
-      await params.disposeRuntime?.();
     },
   };
-}
-
-export async function createBundleMcpToolRuntime(params: {
-  workspaceDir: string;
-  cfg?: OpenClawConfig;
-  reservedToolNames?: Iterable<string>;
-  createRuntime?: (params: {
-    sessionId: string;
-    workspaceDir: string;
-    cfg?: OpenClawConfig;
-  }) => SessionMcpRuntime;
-}): Promise<BundleMcpToolRuntime> {
-  const createRuntime =
-    params.createRuntime ?? (await import("./pi-bundle-mcp-runtime.js")).createSessionMcpRuntime;
-  const runtime = createRuntime({
-    sessionId: `bundle-mcp:${crypto.randomUUID()}`,
-    workspaceDir: params.workspaceDir,
-    cfg: params.cfg,
-  });
-  const materialized = await materializeBundleMcpToolsForRun({
-    runtime,
-    reservedToolNames: params.reservedToolNames,
-    disposeRuntime: async () => {
-      await runtime.dispose();
-    },
-  });
-  return materialized;
 }

--- a/src/agents/pi-bundle-mcp-runtime.test.ts
+++ b/src/agents/pi-bundle-mcp-runtime.test.ts
@@ -149,6 +149,144 @@ async function waitForFileText(
   );
 }
 
+async function writeInitializeHangMcpServer(params: {
+  filePath: string;
+  logPath: string;
+}): Promise<void> {
+  await writeExecutable(
+    params.filePath,
+    `#!/usr/bin/env node
+import fs from "node:fs/promises";
+
+const logPath = ${JSON.stringify(params.logPath)};
+let buffer = "";
+let keepAlive = setInterval(() => {}, 1000);
+function log(line) {
+  void fs.appendFile(logPath, line + "\\n", "utf8").catch(() => {});
+}
+function handle(message) {
+  if (!message || typeof message !== "object") {
+    return;
+  }
+  log("recv " + String(message.method ?? "unknown"));
+}
+function shutdown() {
+  clearInterval(keepAlive);
+  process.exit(0);
+}
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  while (true) {
+    const newline = buffer.indexOf("\\n");
+    if (newline < 0) {
+      return;
+    }
+    const line = buffer.slice(0, newline).replace(/\\r$/, "");
+    buffer = buffer.slice(newline + 1);
+    if (line.trim()) {
+      handle(JSON.parse(line));
+    }
+  }
+});
+process.stdin.on("end", shutdown);
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);`,
+  );
+}
+
+async function writeFailingListToolsMcpServer(params: {
+  filePath: string;
+  logPath: string;
+  errorMessage: string;
+  failSecondPage?: boolean;
+}): Promise<void> {
+  await writeExecutable(
+    params.filePath,
+    `#!/usr/bin/env node
+import fs from "node:fs/promises";
+
+const logPath = ${JSON.stringify(params.logPath)};
+const errorMessage = ${JSON.stringify(params.errorMessage)};
+const failSecondPage = ${params.failSecondPage === true};
+let buffer = "";
+function log(line) {
+  void fs.appendFile(logPath, line + "\\n", "utf8").catch(() => {});
+}
+function send(message) {
+  process.stdout.write(JSON.stringify(message) + "\\n");
+}
+function handle(message) {
+  if (!message || typeof message !== "object") {
+    return;
+  }
+  log("recv " + String(message.method ?? "unknown"));
+  if (message.method === "initialize") {
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        protocolVersion: message.params?.protocolVersion ?? "2025-03-26",
+        capabilities: { tools: {} },
+        serverInfo: { name: "test-failing-list", version: "1.0.0" },
+      },
+    });
+    return;
+  }
+  if (message.method === "notifications/initialized") {
+    return;
+  }
+  if (message.method === "tools/list") {
+    const cursor = message.params?.cursor;
+    log("list cursor " + String(cursor ?? "<none>"));
+    if (failSecondPage && !cursor) {
+      send({
+        jsonrpc: "2.0",
+        id: message.id,
+        result: {
+          tools: [
+            {
+              name: "page_one_tool",
+              description: "Must not leak when page two fails.",
+              inputSchema: { type: "object", properties: {} },
+            },
+          ],
+          nextCursor: "page-2",
+        },
+      });
+      return;
+    }
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      error: { code: -32603, message: errorMessage },
+    });
+  }
+}
+function shutdown() {
+  process.exit(0);
+}
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  while (true) {
+    const newline = buffer.indexOf("\\n");
+    if (newline < 0) {
+      return;
+    }
+    const line = buffer.slice(0, newline).replace(/\\r$/, "");
+    buffer = buffer.slice(newline + 1);
+    if (line.trim()) {
+      handle(JSON.parse(line));
+    }
+  }
+});
+process.stdin.on("end", shutdown);
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);`,
+  );
+}
+
 function makeRuntime(
   tools: Array<{ toolName: string; description: string }>,
   serverName = "bundleProbe",
@@ -166,6 +304,7 @@ function makeRuntime(
     markUsed: () => {
       lastUsedAt = Date.now();
     },
+    getOmittedServers: () => [],
     getCatalog: async () => ({
       version: 1,
       generatedAt: 0,
@@ -308,6 +447,156 @@ describe("session MCP runtime", () => {
     expect(activeLeases).toBe(0);
   });
 
+  it("records omitted diagnostics for unsupported transports and connect failures/timeouts", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-omitted-connect-"));
+    const serverPath = path.join(tempDir, "hang-initialize.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    await writeInitializeHangMcpServer({ filePath: serverPath, logPath });
+
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-omitted-connect",
+      sessionKey: "agent:test:session-omitted-connect",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            unsupportedTransport: {
+              // Deliberately invalid at runtime to exercise omitted diagnostics for unsupported transports.
+              transport: "websocket" as never,
+              url: "https://example.com/mcp",
+            },
+            hangingConnect: {
+              command: process.execPath,
+              args: [serverPath],
+              connectionTimeoutMs: 50,
+            },
+            exitingConnect: {
+              command: process.execPath,
+              args: ["-e", "process.exit(7)"],
+              connectionTimeoutMs: 500,
+            },
+          },
+        },
+      },
+    });
+
+    try {
+      const catalog = await runtime.getCatalog();
+      expect(catalog.tools).toEqual([]);
+      const omittedByServer = Object.fromEntries(
+        runtime.getOmittedServers().map((server) => [server.serverName, server]),
+      );
+      expect(omittedByServer.unsupportedTransport).toMatchObject({
+        reason: "transport-unsupported",
+      });
+      expect(omittedByServer.hangingConnect).toMatchObject({
+        safeServerName: "hangingConnect",
+        reason: "connect-timeout",
+      });
+      expect(omittedByServer.hangingConnect?.errorMessage).toContain("timed out");
+      expect(typeof omittedByServer.hangingConnect?.failedAt).toBe("number");
+      expect(omittedByServer.exitingConnect).toMatchObject({
+        safeServerName: "exitingConnect",
+        reason: "connect-failed",
+      });
+      expect(typeof omittedByServer.exitingConnect?.failedAt).toBe("number");
+    } finally {
+      await runtime.dispose();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("redacts URL secrets from list failure omitted diagnostics", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-omitted-redact-"));
+    const serverPath = path.join(tempDir, "failing-list.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    await writeFailingListToolsMcpServer({
+      filePath: serverPath,
+      logPath,
+      errorMessage: "failed https://user:pass@example.com/mcp?token=secret-token&ok=1",
+    });
+
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-omitted-redact",
+      sessionKey: "agent:test:session-omitted-redact",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            failingList: { command: process.execPath, args: [serverPath] },
+          },
+        },
+      },
+    });
+
+    try {
+      await runtime.getCatalog();
+      const omitted = runtime.getOmittedServers();
+      expect(omitted).toHaveLength(1);
+      expect(omitted[0]).toMatchObject({
+        serverName: "failingList",
+        reason: "list-tools-failed",
+      });
+      expect(omitted[0].errorMessage).not.toContain("user:pass");
+      expect(omitted[0].errorMessage).not.toContain("secret-token");
+      expect(omitted[0].errorMessage).toContain("https://***:***@example.com/mcp");
+      expect(omitted[0].errorMessage).toContain("token=***");
+    } finally {
+      await runtime.dispose();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("omits a whole paginated server when a later tools/list page fails", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-omitted-page-"));
+    const serverPath = path.join(tempDir, "failing-page.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    await writeFailingListToolsMcpServer({
+      filePath: serverPath,
+      logPath,
+      errorMessage: "page two failed",
+      failSecondPage: true,
+    });
+
+    async function runCatalog(sessionId: string) {
+      const runtime = await getOrCreateSessionMcpRuntime({
+        sessionId,
+        sessionKey: `agent:test:${sessionId}`,
+        workspaceDir: "/workspace",
+        cfg: {
+          mcp: {
+            servers: {
+              paginatedFailure: { command: process.execPath, args: [serverPath] },
+            },
+          },
+        },
+      });
+      const catalog = await runtime.getCatalog();
+      const omitted = runtime.getOmittedServers();
+      await runtime.dispose();
+      return { catalog, omitted };
+    }
+
+    try {
+      const first = await runCatalog("session-omitted-page-a");
+      expect(first.catalog.tools).toEqual([]);
+      expect(first.catalog.servers).toEqual({});
+      expect(first.omitted).toHaveLength(1);
+      expect(first.omitted[0]).toMatchObject({
+        serverName: "paginatedFailure",
+        reason: "list-tools-failed",
+      });
+
+      const second = await runCatalog("session-omitted-page-b");
+      expect(second.catalog.tools).toEqual([]);
+      const logText = await fs.readFile(logPath, "utf8");
+      expect(logText.match(/list cursor <none>/g)).toHaveLength(2);
+      expect(logText).toContain("list cursor page-2");
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("keeps MCP tools/list responses that exceed the connection timeout but finish within the internal catalog timeout", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-slow-listtools-"));
     const serverPath = path.join(tempDir, "slow-list-tools.mjs");
@@ -389,6 +678,15 @@ describe("session MCP runtime", () => {
       if (result.status === "resolved") {
         expect(result.catalog.tools).toEqual([]);
         expect(result.catalog.servers).toEqual({});
+        const omitted = runtime.getOmittedServers();
+        expect(omitted).toHaveLength(1);
+        expect(omitted[0]).toMatchObject({
+          serverName: "hangingListTools",
+          safeServerName: "hangingListTools",
+          reason: "list-tools-timeout",
+        });
+        omitted[0].reason = "list-tools-failed";
+        expect(runtime.getOmittedServers()[0]?.reason).toBe("list-tools-timeout");
       }
     } finally {
       await runtime.dispose();
@@ -452,18 +750,69 @@ describe("session MCP runtime", () => {
     expect(runtimeC).not.toBe(runtimeA);
     expect(created).toHaveLength(2);
 
-    const materializedC = await materializeBundleMcpToolsForRun({
-      runtime: runtimeC,
-      disposeRuntime: async () => {
-        await manager.disposeSession("session-a");
-      },
-    });
+    const materializedC = await materializeBundleMcpToolsForRun({ runtime: runtimeC });
     expect(materializedC.tools.map((tool) => tool.name)).toEqual(["bundleProbe__bundle_probe"]);
 
     await materializedC.dispose();
 
-    expect(disposed).toEqual(["session-a", "session-a"]);
-    expect(manager.listSessionIds()).not.toContain("session-a");
+    expect(disposed).toEqual(["session-a"]);
+    expect(manager.listSessionIds()).toContain("session-a");
+  });
+
+  it("fails clearly instead of disposing a leased runtime when MCP config changes", async () => {
+    const disposed: string[] = [];
+    let activeLeases = 0;
+    const createRuntime: RuntimeFactory = (params) => ({
+      ...makeRuntime([{ toolName: "bundle_probe", description: "Bundle MCP probe" }]),
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      workspaceDir: params.workspaceDir,
+      configFingerprint: params.configFingerprint ?? "fingerprint",
+      get activeLeases() {
+        return activeLeases;
+      },
+      acquireLease: () => {
+        activeLeases += 1;
+        let released = false;
+        return () => {
+          if (released) {
+            return;
+          }
+          released = true;
+          activeLeases -= 1;
+        };
+      },
+      dispose: async () => {
+        disposed.push(params.sessionId);
+      },
+    });
+    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+
+    const runtimeA = await manager.getOrCreate({
+      sessionId: "session-busy",
+      sessionKey: "agent:test:session-busy",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: { servers: { configuredProbe: { command: "node", args: ["server-a.mjs"] } } },
+      },
+    });
+    const release = runtimeA.acquireLease?.();
+
+    await expect(
+      manager.getOrCreate({
+        sessionId: "session-busy",
+        sessionKey: "agent:test:session-busy",
+        workspaceDir: "/workspace",
+        cfg: {
+          mcp: { servers: { configuredProbe: { command: "node", args: ["server-b.mjs"] } } },
+        },
+      }),
+    ).rejects.toThrow("bundle-mcp runtime busy");
+
+    expect(disposed).toEqual([]);
+    expect(manager.listSessionIds()).toEqual(["session-busy"]);
+    release?.();
+    await manager.disposeAll();
   });
 
   it("recreates the session runtime when MCP config changes", async () => {

--- a/src/agents/pi-bundle-mcp-runtime.ts
+++ b/src/agents/pi-bundle-mcp-runtime.ts
@@ -3,7 +3,7 @@ import { createRequire } from "node:module";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { ErrorCode, type CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv-provider.js";
 import type {
   JsonSchemaType,
@@ -24,6 +24,8 @@ import type {
   McpCatalogTool,
   McpServerCatalog,
   McpToolCatalog,
+  OmittedMcpServer,
+  OmittedMcpServerReason,
   SessionMcpRuntime,
   SessionMcpRuntimeManager,
 } from "./pi-bundle-mcp-types.js";
@@ -48,6 +50,16 @@ const DRAFT_2020_12_SCHEMA = "https://json-schema.org/draft/2020-12/schema";
 const DEFAULT_SESSION_MCP_RUNTIME_IDLE_TTL_MS = 10 * 60 * 1000;
 const SESSION_MCP_RUNTIME_SWEEP_INTERVAL_MS = 60 * 1000;
 const BUNDLE_MCP_CATALOG_LIST_TIMEOUT_MS = 1_500;
+
+class BundleMcpConnectTimeoutError extends Error {
+  readonly timeoutMs: number;
+
+  constructor(timeoutMs: number) {
+    super(`MCP server connection timed out after ${timeoutMs}ms`);
+    this.name = "BundleMcpConnectTimeoutError";
+    this.timeoutMs = timeoutMs;
+  }
+}
 
 type Ajv2020Like = {
   compile: (schema: JsonSchemaType) => ValidateFunction;
@@ -100,7 +112,7 @@ function connectWithTimeout(
 ): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     const timer = setTimeout(
-      () => reject(new Error(`MCP server connection timed out after ${timeoutMs}ms`)),
+      () => reject(new BundleMcpConnectTimeoutError(timeoutMs)),
       timeoutMs,
     );
     client.connect(transport).then(
@@ -118,6 +130,41 @@ function connectWithTimeout(
 
 function redactErrorUrls(error: unknown): string {
   return redactSensitiveUrlLikeString(String(error));
+}
+
+function hasErrorCode(error: unknown, code: number, seen = new Set<unknown>()): boolean {
+  if (!error || typeof error !== "object" || seen.has(error)) {
+    return false;
+  }
+  seen.add(error);
+  const record = error as { code?: unknown; cause?: unknown; errors?: unknown };
+  if (record.code === code) {
+    return true;
+  }
+  if (hasErrorCode(record.cause, code, seen)) {
+    return true;
+  }
+  if (Array.isArray(record.errors)) {
+    return record.errors.some((item) => hasErrorCode(item, code, seen));
+  }
+  return false;
+}
+
+function isMcpRequestTimeoutError(error: unknown): boolean {
+  return (
+    hasErrorCode(error, ErrorCode.RequestTimeout) ||
+    String(error).includes("MCP error -32001: Request timed out")
+  );
+}
+
+function classifyConnectFailure(error: unknown): OmittedMcpServerReason {
+  return error instanceof BundleMcpConnectTimeoutError || isMcpRequestTimeoutError(error)
+    ? "connect-timeout"
+    : "connect-failed";
+}
+
+function classifyListToolsFailure(error: unknown): OmittedMcpServerReason {
+  return isMcpRequestTimeoutError(error) ? "list-tools-timeout" : "list-tools-failed";
 }
 
 async function listAllTools(client: Client, timeoutMs: number) {
@@ -198,10 +245,28 @@ export function createSessionMcpRuntime(params: {
   let catalog: McpToolCatalog | null = null;
   let catalogInFlight: Promise<McpToolCatalog> | undefined;
   const sessions = new Map<string, BundleMcpSession>();
+  const omittedServers = new Map<string, OmittedMcpServer>();
   const failIfDisposed = () => {
     if (disposed) {
       throw createDisposedError(params.sessionId);
     }
+  };
+
+  const rememberOmittedServer = (params: {
+    serverName: string;
+    safeServerName?: string;
+    launchSummary?: string;
+    reason: OmittedMcpServerReason;
+    error: unknown;
+  }) => {
+    omittedServers.set(params.serverName, {
+      serverName: params.serverName,
+      ...(params.safeServerName ? { safeServerName: params.safeServerName } : {}),
+      ...(params.launchSummary ? { launchSummary: params.launchSummary } : {}),
+      reason: params.reason,
+      errorMessage: redactErrorUrls(params.error),
+      failedAt: Date.now(),
+    });
   };
 
   const getCatalog = async (): Promise<McpToolCatalog> => {
@@ -231,6 +296,11 @@ export function createSessionMcpRuntime(params: {
           failIfDisposed();
           const resolved = resolveMcpTransport(serverName, rawServer);
           if (!resolved) {
+            rememberOmittedServer({
+              serverName,
+              reason: "transport-unsupported",
+              error: "unsupported or invalid MCP transport",
+            });
             continue;
           }
           const safeServerName = sanitizeServerName(serverName, usedServerNames);
@@ -261,38 +331,62 @@ export function createSessionMcpRuntime(params: {
           try {
             failIfDisposed();
             await connectWithTimeout(client, resolved.transport, resolved.connectionTimeoutMs);
-            failIfDisposed();
-            const listedTools = await listAllTools(client, BUNDLE_MCP_CATALOG_LIST_TIMEOUT_MS);
-            failIfDisposed();
-            servers[serverName] = {
-              serverName,
-              launchSummary: resolved.description,
-              toolCount: listedTools.length,
-            };
-            for (const tool of listedTools) {
-              const toolName = tool.name.trim();
-              if (!toolName) {
-                continue;
-              }
-              tools.push({
-                serverName,
-                safeServerName,
-                toolName,
-                title: tool.title,
-                description: normalizeOptionalString(tool.description),
-                inputSchema: tool.inputSchema,
-                fallbackDescription: `Provided by bundle MCP server "${serverName}" (${resolved.description}).`,
-              });
-            }
           } catch (error) {
             if (!disposed) {
-              logWarn(
-                `bundle-mcp: failed to start server "${serverName}" (${resolved.description}): ${redactErrorUrls(error)}`,
-              );
+              rememberOmittedServer({
+                serverName,
+                safeServerName,
+                launchSummary: resolved.description,
+                reason: classifyConnectFailure(error),
+                error,
+              });
             }
             await disposeSession(session);
             sessions.delete(serverName);
             failIfDisposed();
+            continue;
+          }
+
+          let listedTools: ListedTool[];
+          try {
+            failIfDisposed();
+            listedTools = await listAllTools(client, BUNDLE_MCP_CATALOG_LIST_TIMEOUT_MS);
+            failIfDisposed();
+          } catch (error) {
+            if (!disposed) {
+              rememberOmittedServer({
+                serverName,
+                safeServerName,
+                launchSummary: resolved.description,
+                reason: classifyListToolsFailure(error),
+                error,
+              });
+            }
+            await disposeSession(session);
+            sessions.delete(serverName);
+            failIfDisposed();
+            continue;
+          }
+
+          servers[serverName] = {
+            serverName,
+            launchSummary: resolved.description,
+            toolCount: listedTools.length,
+          };
+          for (const tool of listedTools) {
+            const toolName = tool.name.trim();
+            if (!toolName) {
+              continue;
+            }
+            tools.push({
+              serverName,
+              safeServerName,
+              toolName,
+              title: tool.title,
+              description: normalizeOptionalString(tool.description),
+              inputSchema: tool.inputSchema,
+              fallbackDescription: `Provided by bundle MCP server "${serverName}" (${resolved.description}).`,
+            });
           }
         }
 
@@ -334,6 +428,9 @@ export function createSessionMcpRuntime(params: {
     get activeLeases() {
       return activeLeases;
     },
+    getOmittedServers() {
+      return Array.from(omittedServers.values(), (server) => ({ ...server }));
+    },
     acquireLease() {
       activeLeases += 1;
       let released = false;
@@ -369,6 +466,7 @@ export function createSessionMcpRuntime(params: {
       disposed = true;
       catalog = null;
       catalogInFlight = undefined;
+      omittedServers.clear();
       const sessionsToClose = Array.from(sessions.values());
       sessions.clear();
       await Promise.allSettled(sessionsToClose.map((session) => disposeSession(session)));
@@ -484,6 +582,11 @@ function createSessionMcpRuntimeManager(
           existing.workspaceDir !== params.workspaceDir ||
           existing.configFingerprint !== nextFingerprint
         ) {
+          if ((existing.activeLeases ?? 0) > 0) {
+            throw new Error(
+              "bundle-mcp runtime busy; cannot rebind workspace/config while active",
+            );
+          }
           runtimesBySessionId.delete(params.sessionId);
           await existing.dispose();
         } else {

--- a/src/agents/pi-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/pi-bundle-mcp-tools.materialize.test.ts
@@ -1,10 +1,10 @@
 import { validateToolArguments } from "@earendil-works/pi-ai";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { logWarn } from "../logger.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
-import {
-  createBundleMcpToolRuntime,
-  materializeBundleMcpToolsForRun,
-} from "./pi-bundle-mcp-materialize.js";
+
+vi.mock("../logger.js", () => ({ logWarn: vi.fn() }));
+import { materializeBundleMcpToolsForRun } from "./pi-bundle-mcp-materialize.js";
 import type { McpCatalogTool } from "./pi-bundle-mcp-types.js";
 import type { SessionMcpRuntime } from "./pi-bundle-mcp-types.js";
 
@@ -39,6 +39,7 @@ function makeToolRuntime(
     createdAt: 0,
     lastUsedAt: 0,
     markUsed: () => {},
+    getOmittedServers: () => [],
     getCatalog: async () => ({
       version: 1,
       generatedAt: 0,
@@ -59,7 +60,7 @@ function makeToolRuntime(
   };
 }
 
-describe("createBundleMcpToolRuntime", () => {
+describe("materializeBundleMcpToolsForRun", () => {
   it("materializes bundle MCP tools and executes them", async () => {
     const runtime = await materializeBundleMcpToolsForRun({
       runtime: makeToolRuntime(),
@@ -84,52 +85,28 @@ describe("createBundleMcpToolRuntime", () => {
     expect(runtime.tools.map((tool) => tool.name)).toEqual(["bundleProbe__bundle_probe-2"]);
   });
 
-  it("materializes configured MCP tools through the session runtime boundary", async () => {
-    const created: Parameters<
-      NonNullable<Parameters<typeof createBundleMcpToolRuntime>[0]["createRuntime"]>
-    >[0][] = [];
-    const runtime = await createBundleMcpToolRuntime({
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            configuredProbe: {
-              command: "node",
-              args: ["configured-probe.mjs"],
-              env: {
-                BUNDLE_PROBE_TEXT: "FROM-CONFIG",
-              },
-            },
-          },
+  it("warns once per omitted server reason for a shared runtime", async () => {
+    vi.mocked(logWarn).mockClear();
+    const runtime = {
+      ...makeToolRuntime(),
+      getOmittedServers: () => [
+        {
+          serverName: "secretServer",
+          safeServerName: "secretServer",
+          launchSummary: "stdio: secret",
+          reason: "list-tools-failed" as const,
+          errorMessage: "failed https://example.com/path?token=[REDACTED]",
+          failedAt: 123,
         },
-      },
-      createRuntime: (params) => {
-        created.push(params);
-        return makeToolRuntime({
-          serverName: "configuredProbe",
-          resultText: "FROM-CONFIG",
-        });
-      },
-    });
+      ],
+    };
 
-    expect(created).toHaveLength(1);
-    expect(created[0].sessionId).toMatch(/^bundle-mcp:/);
-    expect(created[0].workspaceDir).toBe("/workspace");
-    expect(created[0].cfg?.mcp?.servers?.configuredProbe?.command).toBe("node");
-    expect(created[0].cfg?.mcp?.servers?.configuredProbe?.args).toEqual(["configured-probe.mjs"]);
+    await (await materializeBundleMcpToolsForRun({ runtime })).dispose();
+    await (await materializeBundleMcpToolsForRun({ runtime })).dispose();
 
-    expect(runtime.tools.map((tool) => tool.name)).toEqual(["configuredProbe__bundle_probe"]);
-    const result = await runtime.tools[0].execute(
-      "call-configured-probe",
-      {},
-      undefined,
-      undefined,
-    );
-    expectTextContentBlock(result.content[0], "FROM-CONFIG");
-    expect(result.details).toEqual({
-      mcpServer: "configuredProbe",
-      mcpTool: "bundle_probe",
-    });
+    expect(logWarn).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(logWarn).mock.calls[0]?.[0]).toContain("list-tools-failed");
+    expect(vi.mocked(logWarn).mock.calls[0]?.[0]).toContain("[REDACTED]");
   });
 
   it("returns tools sorted alphabetically for stable prompt-cache keys", async () => {

--- a/src/agents/pi-bundle-mcp-tools.request-boundary.test.ts
+++ b/src/agents/pi-bundle-mcp-tools.request-boundary.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  createBundleMcpToolRuntime,
-  materializeBundleMcpToolsForRun,
-} from "./pi-bundle-mcp-materialize.js";
+import { materializeBundleMcpToolsForRun } from "./pi-bundle-mcp-materialize.js";
 import type { McpCatalogTool, SessionMcpRuntime } from "./pi-bundle-mcp-types.js";
 import { applyFinalEffectiveToolPolicy } from "./pi-embedded-runner/effective-tool-policy.js";
 import { splitSdkTools } from "./pi-embedded-runner/tool-split.js";
@@ -43,6 +40,7 @@ function makeConfiguredRuntime(
     createdAt: 0,
     lastUsedAt: 0,
     markUsed: () => {},
+    getOmittedServers: () => [],
     getCatalog: async () => ({
       version: 1,
       generatedAt: 0,
@@ -66,10 +64,8 @@ function makeConfiguredRuntime(
 async function buildConfiguredMcpToolNamesAtRequestBoundary(params: {
   cfg: OpenClawConfig;
 }): Promise<string[]> {
-  const runtime = await createBundleMcpToolRuntime({
-    workspaceDir: "/workspace",
-    cfg: params.cfg,
-    createRuntime: () => makeConfiguredRuntime(),
+  const runtime = await materializeBundleMcpToolsForRun({
+    runtime: makeConfiguredRuntime(),
   });
   const filtered = applyFinalEffectiveToolPolicy({
     bundledTools: runtime.tools,

--- a/src/agents/pi-bundle-mcp-tools.ts
+++ b/src/agents/pi-bundle-mcp-tools.ts
@@ -17,7 +17,4 @@ export {
   retireSessionMcpRuntime,
   retireSessionMcpRuntimeForSessionKey,
 } from "./pi-bundle-mcp-runtime.js";
-export {
-  createBundleMcpToolRuntime,
-  materializeBundleMcpToolsForRun,
-} from "./pi-bundle-mcp-materialize.js";
+export { materializeBundleMcpToolsForRun } from "./pi-bundle-mcp-materialize.js";

--- a/src/agents/pi-bundle-mcp-types.ts
+++ b/src/agents/pi-bundle-mcp-types.ts
@@ -31,6 +31,22 @@ export type McpToolCatalog = {
   tools: McpCatalogTool[];
 };
 
+export type OmittedMcpServerReason =
+  | "transport-unsupported"
+  | "connect-timeout"
+  | "connect-failed"
+  | "list-tools-timeout"
+  | "list-tools-failed";
+
+export type OmittedMcpServer = {
+  serverName: string;
+  safeServerName?: string;
+  launchSummary?: string;
+  reason: OmittedMcpServerReason;
+  errorMessage: string;
+  failedAt: number;
+};
+
 export type SessionMcpRuntime = {
   sessionId: string;
   sessionKey?: string;
@@ -40,6 +56,7 @@ export type SessionMcpRuntime = {
   lastUsedAt: number;
   activeLeases?: number;
   acquireLease?: () => () => void;
+  getOmittedServers: () => OmittedMcpServer[];
   getCatalog: () => Promise<McpToolCatalog>;
   markUsed: () => void;
   callTool: (serverName: string, toolName: string, input: unknown) => Promise<CallToolResult>;

--- a/src/agents/pi-embedded-runner/compact.hooks.harness.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.harness.ts
@@ -548,7 +548,20 @@ export async function loadCompactHooksHarness(): Promise<{
 
   vi.doMock("../pi-bundle-mcp-tools.js", () => ({
     retireSessionMcpRuntime: vi.fn(async () => true),
-    createBundleMcpToolRuntime: vi.fn(async () => ({
+    getOrCreateSessionMcpRuntime: vi.fn(async () => ({
+      sessionId: "session-1",
+      sessionKey: "test-session-key",
+      workspaceDir: "/tmp/workspace",
+      configFingerprint: "test-config-fingerprint",
+      activeLeases: 0,
+      markUsed: vi.fn(),
+      acquireLease: vi.fn(() => vi.fn()),
+      getCatalog: vi.fn(async () => ({ version: 1, generatedAt: 0, servers: {}, tools: [] })),
+      getOmittedServers: vi.fn(() => []),
+      callTool: vi.fn(),
+      dispose: vi.fn(async () => {}),
+    })),
+    materializeBundleMcpToolsForRun: vi.fn(async () => ({
       tools: [],
       dispose: vi.fn(async () => {}),
     })),

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -262,6 +262,30 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
     });
   });
 
+  it("releases materialized bundle MCP tools when later compact setup fails", async () => {
+    const mcpTools = await import("../pi-bundle-mcp-tools.js");
+    const lspRuntime = await import("../pi-bundle-lsp-runtime.js");
+    const mcpDispose = vi.fn(async () => {});
+    vi.mocked(mcpTools.materializeBundleMcpToolsForRun).mockResolvedValueOnce({
+      tools: [],
+      dispose: mcpDispose,
+    });
+    vi.mocked(lspRuntime.createBundleLspToolRuntime).mockRejectedValueOnce(
+      new Error("lsp setup failed"),
+    );
+
+    const result = await compactEmbeddedPiSessionDirect({
+      sessionId: "session-1",
+      sessionKey: TEST_SESSION_KEY,
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("lsp setup failed");
+    expect(mcpDispose).toHaveBeenCalledOnce();
+  });
+
   it("uses subagent prompt surface and guidance for compacted subagent prompt rebuilds", async () => {
     await compactEmbeddedPiSessionDirect({
       sessionId: "session-1",

--- a/src/agents/pi-embedded-runner/compact.queued.ts
+++ b/src/agents/pi-embedded-runner/compact.queued.ts
@@ -393,6 +393,7 @@ function buildCompactionContextEngineRuntimeContext(params: {
     ...params.params,
     ...buildEmbeddedCompactionRuntimeContext({
       sessionKey: params.params.sessionKey,
+      sandboxSessionKey: params.params.sandboxSessionKey,
       messageChannel: params.params.messageChannel,
       messageProvider: params.params.messageProvider,
       agentAccountId: params.params.agentAccountId,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -74,7 +74,10 @@ import { supportsModelTools } from "../model-tool-support.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
 import { resolveContextConfigProviderForRuntime } from "../openai-codex-routing.js";
 import { createBundleLspToolRuntime } from "../pi-bundle-lsp-runtime.js";
-import { createBundleMcpToolRuntime } from "../pi-bundle-mcp-tools.js";
+import {
+  getOrCreateSessionMcpRuntime,
+  materializeBundleMcpToolsForRun,
+} from "../pi-bundle-mcp-tools.js";
 import { ensureSessionHeader } from "../pi-embedded-helpers.js";
 import { pickFallbackThinkingLevel } from "../pi-embedded-helpers.js";
 import {
@@ -768,230 +771,245 @@ async function compactEmbeddedPiSessionDirectOnce(
       toolsEnabled ? toolsRaw : [],
       runtimePlanModelContext,
     );
-    const bundleMcpRuntime = toolsEnabled
-      ? await createBundleMcpToolRuntime({
-          workspaceDir: effectiveWorkspace,
-          cfg: params.config,
-          reservedToolNames: tools.map((tool) => tool.name),
-        })
-      : undefined;
-    const bundleLspRuntime = toolsEnabled
-      ? await createBundleLspToolRuntime({
-          workspaceDir: effectiveWorkspace,
-          cfg: params.config,
-          reservedToolNames: [
-            ...tools.map((tool) => tool.name),
-            ...(bundleMcpRuntime?.tools.map((tool) => tool.name) ?? []),
-          ],
-        })
-      : undefined;
-    const filteredBundledTools = applyFinalEffectiveToolPolicy({
-      bundledTools: [...(bundleMcpRuntime?.tools ?? []), ...(bundleLspRuntime?.tools ?? [])],
-      config: params.config,
-      sandboxToolPolicy: sandbox?.tools,
-      sessionKey: sandboxSessionKey,
-      // Intentionally omit explicit agentId: the core tools just built with
-      // createOpenClawCodingTools(...) also omit it, so both paths resolve
-      // agentId the same way via resolveAgentIdFromSessionKey(sessionKey).
-      // Passing effectiveSkillAgentId here would diverge from the core-tool
-      // policy for legacy/non-agent session keys where the two sources fall
-      // back to different ids.
-      modelProvider: model.provider,
-      modelId,
-      messageProvider: resolvedMessageProvider,
-      agentAccountId: params.agentAccountId,
-      groupId: params.groupId,
-      groupChannel: params.groupChannel,
-      groupSpace: params.groupSpace,
-      spawnedBy: params.spawnedBy,
-      senderId: params.senderId,
-      senderName: params.senderName,
-      senderUsername: params.senderUsername,
-      senderE164: params.senderE164,
-      warn: (message) => log.warn(message),
-    });
-    const normalizedBundledTools =
-      filteredBundledTools.length > 0
-        ? runtimePlan.tools.normalize(filteredBundledTools, runtimePlanModelContext)
-        : filteredBundledTools;
-    const effectiveTools = [...tools, ...normalizedBundledTools];
-    const allowedToolNames = collectAllowedToolNames({ tools: effectiveTools });
-    runtimePlan.tools.logDiagnostics(effectiveTools, runtimePlanModelContext);
-    const machineName = await getMachineDisplayName();
-    const runtimeChannel = normalizeMessageChannel(params.messageChannel ?? params.messageProvider);
-    const runtimeCapabilities = collectRuntimeChannelCapabilities({
-      cfg: params.config,
-      channel: runtimeChannel,
-      accountId: params.agentAccountId,
-    });
-    const reactionGuidance =
-      runtimeChannel && params.config
-        ? resolveChannelReactionGuidance({
+    let bundleMcpRuntime: Awaited<ReturnType<typeof materializeBundleMcpToolsForRun>> | undefined;
+    let bundleLspRuntime: Awaited<ReturnType<typeof createBundleLspToolRuntime>> | undefined;
+    let sessionLock: Awaited<ReturnType<typeof acquireSessionWriteLock>> | undefined;
+    try {
+      const bundleMcpSessionRuntime = toolsEnabled
+        ? await getOrCreateSessionMcpRuntime({
+            sessionId: params.sessionId,
+            sessionKey: sandboxSessionKey,
+            workspaceDir: effectiveWorkspace,
+            cfg: params.config,
+          })
+        : undefined;
+      bundleMcpRuntime = bundleMcpSessionRuntime
+        ? await materializeBundleMcpToolsForRun({
+            runtime: bundleMcpSessionRuntime,
+            reservedToolNames: tools.map((tool) => tool.name),
+          })
+        : undefined;
+      // Compact reuses the session-scoped bundle MCP runtime. Standalone /compact
+      // releases its materialization lease here but may leave the shared runtime
+      // alive until the manager idle TTL closes it.
+      bundleLspRuntime = toolsEnabled
+        ? await createBundleLspToolRuntime({
+            workspaceDir: effectiveWorkspace,
+            cfg: params.config,
+            reservedToolNames: [
+              ...tools.map((tool) => tool.name),
+              ...(bundleMcpRuntime?.tools.map((tool) => tool.name) ?? []),
+            ],
+          })
+        : undefined;
+      const filteredBundledTools = applyFinalEffectiveToolPolicy({
+        bundledTools: [...(bundleMcpRuntime?.tools ?? []), ...(bundleLspRuntime?.tools ?? [])],
+        config: params.config,
+        sandboxToolPolicy: sandbox?.tools,
+        sessionKey: sandboxSessionKey,
+        // Intentionally omit explicit agentId: the core tools just built with
+        // createOpenClawCodingTools(...) also omit it, so both paths resolve
+        // agentId the same way via resolveAgentIdFromSessionKey(sessionKey).
+        // Passing effectiveSkillAgentId here would diverge from the core-tool
+        // policy for legacy/non-agent session keys where the two sources fall
+        // back to different ids.
+        modelProvider: model.provider,
+        modelId,
+        messageProvider: resolvedMessageProvider,
+        agentAccountId: params.agentAccountId,
+        groupId: params.groupId,
+        groupChannel: params.groupChannel,
+        groupSpace: params.groupSpace,
+        spawnedBy: params.spawnedBy,
+        senderId: params.senderId,
+        senderName: params.senderName,
+        senderUsername: params.senderUsername,
+        senderE164: params.senderE164,
+        warn: (message) => log.warn(message),
+      });
+      const normalizedBundledTools =
+        filteredBundledTools.length > 0
+          ? runtimePlan.tools.normalize(filteredBundledTools, runtimePlanModelContext)
+          : filteredBundledTools;
+      const effectiveTools = [...tools, ...normalizedBundledTools];
+      const allowedToolNames = collectAllowedToolNames({ tools: effectiveTools });
+      runtimePlan.tools.logDiagnostics(effectiveTools, runtimePlanModelContext);
+      const machineName = await getMachineDisplayName();
+      const runtimeChannel = normalizeMessageChannel(
+        params.messageChannel ?? params.messageProvider,
+      );
+      const runtimeCapabilities = collectRuntimeChannelCapabilities({
+        cfg: params.config,
+        channel: runtimeChannel,
+        accountId: params.agentAccountId,
+      });
+      const reactionGuidance =
+        runtimeChannel && params.config
+          ? resolveChannelReactionGuidance({
+              cfg: params.config,
+              channel: runtimeChannel,
+              accountId: params.agentAccountId,
+            })
+          : undefined;
+      const { defaultAgentId, sessionAgentId } = resolveSessionAgentIds({
+        sessionKey: params.sessionKey,
+        config: params.config,
+      });
+      // Resolve channel-specific message actions for system prompt
+      const channelActions = runtimeChannel
+        ? listChannelSupportedActions(
+            buildEmbeddedMessageActionDiscoveryInput({
+              cfg: params.config,
+              channel: runtimeChannel,
+              currentChannelId: params.currentChannelId,
+              currentThreadTs: params.currentThreadTs,
+              currentMessageId: params.currentMessageId,
+              accountId: params.agentAccountId,
+              sessionKey: params.sessionKey,
+              sessionId: params.sessionId,
+              agentId: sessionAgentId,
+              senderId: params.senderId,
+            }),
+          )
+        : undefined;
+      const messageToolHints = runtimeChannel
+        ? resolveChannelMessageToolHints({
             cfg: params.config,
             channel: runtimeChannel,
             accountId: params.agentAccountId,
           })
         : undefined;
-    const { defaultAgentId, sessionAgentId } = resolveSessionAgentIds({
-      sessionKey: params.sessionKey,
-      config: params.config,
-    });
-    // Resolve channel-specific message actions for system prompt
-    const channelActions = runtimeChannel
-      ? listChannelSupportedActions(
-          buildEmbeddedMessageActionDiscoveryInput({
-            cfg: params.config,
-            channel: runtimeChannel,
-            currentChannelId: params.currentChannelId,
-            currentThreadTs: params.currentThreadTs,
-            currentMessageId: params.currentMessageId,
-            accountId: params.agentAccountId,
-            sessionKey: params.sessionKey,
-            sessionId: params.sessionId,
-            agentId: sessionAgentId,
-            senderId: params.senderId,
-          }),
-        )
-      : undefined;
-    const messageToolHints = runtimeChannel
-      ? resolveChannelMessageToolHints({
-          cfg: params.config,
-          channel: runtimeChannel,
-          accountId: params.agentAccountId,
-        })
-      : undefined;
 
-    const runtimeInfo = {
-      host: machineName,
-      os: `${os.type()} ${os.release()}`,
-      arch: os.arch(),
-      node: process.version,
-      model: `${provider}/${modelId}`,
-      shell: detectRuntimeShell(),
-      channel: runtimeChannel,
-      capabilities: runtimeCapabilities,
-      channelActions,
-      activeProcessSessions: listActiveProcessSessionReferences({
-        scopeKey: resolveProcessToolScopeKey({
-          sessionKey: sandboxSessionKey,
-          agentId: sessionAgentId,
+      const runtimeInfo = {
+        host: machineName,
+        os: `${os.type()} ${os.release()}`,
+        arch: os.arch(),
+        node: process.version,
+        model: `${provider}/${modelId}`,
+        shell: detectRuntimeShell(),
+        channel: runtimeChannel,
+        capabilities: runtimeCapabilities,
+        channelActions,
+        activeProcessSessions: listActiveProcessSessionReferences({
+          scopeKey: resolveProcessToolScopeKey({
+            sessionKey: sandboxSessionKey,
+            agentId: sessionAgentId,
+          }),
         }),
-      }),
-    };
-    const sandboxInfo = buildEmbeddedSandboxInfo(sandbox, params.bashElevated);
-    const reasoningTagHint = isReasoningTagProvider(provider, {
-      config: params.config,
-      workspaceDir: effectiveWorkspace,
-      env: process.env,
-      modelId,
-      modelApi: model.api,
-      model,
-    });
-    const userTimezone = resolveUserTimezone(params.config?.agents?.defaults?.userTimezone);
-    const userTimeFormat = resolveUserTimeFormat(params.config?.agents?.defaults?.timeFormat);
-    const userTime = formatUserTime(new Date(), userTimezone, userTimeFormat);
-    const promptSurface = resolveAgentPromptSurfaceForSessionKey(params.sessionKey);
-    const promptMode =
-      isSubagentSessionKey(params.sessionKey) || isCronSessionKey(params.sessionKey)
-        ? "minimal"
-        : "full";
-    const nativeCommandGuidanceLines = listRegisteredPluginAgentPromptGuidance({
-      surface: promptSurface,
-    });
-    const openClawReferences = await resolveOpenClawReferencePaths({
-      workspaceDir: effectiveWorkspace,
-      argv1: process.argv[1],
-      cwd: effectiveWorkspace,
-      moduleUrl: import.meta.url,
-    });
-    const promptContributionContext: Parameters<
-      AgentRuntimePlan["prompt"]["resolveSystemPromptContribution"]
-    >[0] = {
-      config: params.config,
-      agentDir,
-      workspaceDir: effectiveWorkspace,
-      provider,
-      modelId,
-      promptMode,
-      runtimeChannel,
-      runtimeCapabilities,
-      agentId: sessionAgentId,
-    };
-    const promptContribution =
-      runtimePlan.prompt.resolveSystemPromptContribution(promptContributionContext);
-    const buildSystemPromptOverride = (defaultThinkLevel: ThinkLevel) => {
-      const builtSystemPrompt =
-        resolveSystemPromptOverride({
-          config: params.config,
-          agentId: sessionAgentId,
-        }) ??
-        buildEmbeddedSystemPrompt({
-          config: params.config,
-          agentId: sessionAgentId,
-          workspaceDir: effectiveWorkspace,
-          defaultThinkLevel,
-          reasoningLevel: params.reasoningLevel ?? "off",
-          extraSystemPrompt: params.extraSystemPrompt,
-          ownerNumbers: params.ownerNumbers,
-          reasoningTagHint,
-          heartbeatPrompt: resolveHeartbeatPromptForSystemPrompt({
+      };
+      const sandboxInfo = buildEmbeddedSandboxInfo(sandbox, params.bashElevated);
+      const reasoningTagHint = isReasoningTagProvider(provider, {
+        config: params.config,
+        workspaceDir: effectiveWorkspace,
+        env: process.env,
+        modelId,
+        modelApi: model.api,
+        model,
+      });
+      const userTimezone = resolveUserTimezone(params.config?.agents?.defaults?.userTimezone);
+      const userTimeFormat = resolveUserTimeFormat(params.config?.agents?.defaults?.timeFormat);
+      const userTime = formatUserTime(new Date(), userTimezone, userTimeFormat);
+      const promptSurface = resolveAgentPromptSurfaceForSessionKey(params.sessionKey);
+      const promptMode =
+        isSubagentSessionKey(params.sessionKey) || isCronSessionKey(params.sessionKey)
+          ? "minimal"
+          : "full";
+      const nativeCommandGuidanceLines = listRegisteredPluginAgentPromptGuidance({
+        surface: promptSurface,
+      });
+      const openClawReferences = await resolveOpenClawReferencePaths({
+        workspaceDir: effectiveWorkspace,
+        argv1: process.argv[1],
+        cwd: effectiveWorkspace,
+        moduleUrl: import.meta.url,
+      });
+      const promptContributionContext: Parameters<
+        AgentRuntimePlan["prompt"]["resolveSystemPromptContribution"]
+      >[0] = {
+        config: params.config,
+        agentDir,
+        workspaceDir: effectiveWorkspace,
+        provider,
+        modelId,
+        promptMode,
+        runtimeChannel,
+        runtimeCapabilities,
+        agentId: sessionAgentId,
+      };
+      const promptContribution =
+        runtimePlan.prompt.resolveSystemPromptContribution(promptContributionContext);
+      const buildSystemPromptOverride = (defaultThinkLevel: ThinkLevel) => {
+        const builtSystemPrompt =
+          resolveSystemPromptOverride({
             config: params.config,
             agentId: sessionAgentId,
-            defaultAgentId,
-          }),
-          skillsPrompt,
-          docsPath: openClawReferences.docsPath ?? undefined,
-          sourcePath: openClawReferences.sourcePath ?? undefined,
-          promptMode,
-          promptSurface,
-          sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-          acpEnabled: isAcpRuntimeSpawnAvailable({
+          }) ??
+          buildEmbeddedSystemPrompt({
             config: params.config,
-            sandboxed: sandboxInfo?.enabled === true,
-          }),
-          runtimeInfo,
-          reactionGuidance,
-          messageToolHints,
-          sandboxInfo,
-          tools: effectiveTools,
-          userTimezone,
-          userTime,
-          userTimeFormat,
-          contextFiles,
-          promptContribution,
-          nativeCommandGuidanceLines,
-        });
-      return createSystemPromptOverride(
-        transformProviderSystemPrompt({
-          provider,
-          config: params.config,
-          workspaceDir: effectiveWorkspace,
-          context: {
-            config: params.config,
-            agentDir,
+            agentId: sessionAgentId,
             workspaceDir: effectiveWorkspace,
-            provider,
-            modelId,
+            defaultThinkLevel,
+            reasoningLevel: params.reasoningLevel ?? "off",
+            extraSystemPrompt: params.extraSystemPrompt,
+            ownerNumbers: params.ownerNumbers,
+            reasoningTagHint,
+            heartbeatPrompt: resolveHeartbeatPromptForSystemPrompt({
+              config: params.config,
+              agentId: sessionAgentId,
+              defaultAgentId,
+            }),
+            skillsPrompt,
+            docsPath: openClawReferences.docsPath ?? undefined,
+            sourcePath: openClawReferences.sourcePath ?? undefined,
             promptMode,
-            runtimeChannel,
-            runtimeCapabilities,
-            agentId: sessionAgentId,
-            systemPrompt: builtSystemPrompt,
-          },
-        }),
-      );
-    };
+            promptSurface,
+            sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+            acpEnabled: isAcpRuntimeSpawnAvailable({
+              config: params.config,
+              sandboxed: sandboxInfo?.enabled === true,
+            }),
+            runtimeInfo,
+            reactionGuidance,
+            messageToolHints,
+            sandboxInfo,
+            tools: effectiveTools,
+            userTimezone,
+            userTime,
+            userTimeFormat,
+            contextFiles,
+            promptContribution,
+            nativeCommandGuidanceLines,
+          });
+        return createSystemPromptOverride(
+          transformProviderSystemPrompt({
+            provider,
+            config: params.config,
+            workspaceDir: effectiveWorkspace,
+            context: {
+              config: params.config,
+              agentDir,
+              workspaceDir: effectiveWorkspace,
+              provider,
+              modelId,
+              promptMode,
+              runtimeChannel,
+              runtimeCapabilities,
+              agentId: sessionAgentId,
+              systemPrompt: builtSystemPrompt,
+            },
+          }),
+        );
+      };
 
-    const compactionTimeoutMs = resolveCompactionTimeoutMs(params.config);
-    const sessionLock = await acquireSessionWriteLock({
-      sessionFile: params.sessionFile,
-      ...resolveSessionWriteLockOptions(params.config, {
-        maxHoldMsFallback: resolveSessionLockMaxHoldFromTimeout({
-          timeoutMs: compactionTimeoutMs,
+      const compactionTimeoutMs = resolveCompactionTimeoutMs(params.config);
+      sessionLock = await acquireSessionWriteLock({
+        sessionFile: params.sessionFile,
+        ...resolveSessionWriteLockOptions(params.config, {
+          maxHoldMsFallback: resolveSessionLockMaxHoldFromTimeout({
+            timeoutMs: compactionTimeoutMs,
+          }),
         }),
-      }),
-    });
-    try {
+      });
       await repairSessionFileIfNeeded({
         sessionFile: params.sessionFile,
         debug: (message) => log.debug(message),
@@ -1447,7 +1465,9 @@ async function compactEmbeddedPiSessionDirectOnce(
       } catch {
         /* best-effort */
       }
-      await sessionLock.release();
+      if (sessionLock) {
+        await sessionLock.release();
+      }
     }
   } catch (err) {
     const reason = resolveCompactionFailureReason({

--- a/src/agents/pi-embedded-runner/compaction-runtime-context.test.ts
+++ b/src/agents/pi-embedded-runner/compaction-runtime-context.test.ts
@@ -79,6 +79,18 @@ describe("buildEmbeddedCompactionRuntimeContext", () => {
     expect(result.model).toBeUndefined();
   });
 
+  it("omits empty sandbox session keys from compaction routing", () => {
+    const result = buildEmbeddedCompactionRuntimeContext({
+      sessionKey: "agent:main:thread:1",
+      sandboxSessionKey: "",
+      workspaceDir: "/tmp/workspace",
+      agentDir: "/tmp/agent",
+      config: {} as OpenClawConfig,
+    });
+
+    expect(result).not.toHaveProperty("sandboxSessionKey");
+  });
+
   it("applies compaction.model override with provider/model format", () => {
     const result = buildEmbeddedCompactionRuntimeContext({
       workspaceDir: "/tmp/workspace",
@@ -172,6 +184,35 @@ describe("buildEmbeddedCompactionRuntimeContext", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("uses sandbox session key when defaulting active process references", () => {
+    const sandboxScoped = createProcessSessionFixture({
+      id: "sess-sandbox",
+      command: "sleep 600",
+      backgrounded: true,
+    });
+    sandboxScoped.scopeKey = "agent:main:telegram:default:direct:12345";
+    const runScoped = createProcessSessionFixture({
+      id: "sess-run",
+      command: "sleep 600",
+      backgrounded: true,
+    });
+    runScoped.scopeKey = "agent:main:main";
+    addSession(sandboxScoped);
+    addSession(runScoped);
+
+    const result = buildEmbeddedCompactionRuntimeContext({
+      sessionKey: "agent:main:main",
+      sandboxSessionKey: "agent:main:telegram:default:direct:12345",
+      workspaceDir: "/tmp/workspace",
+      agentDir: "/tmp/agent",
+      config: {} as OpenClawConfig,
+    });
+
+    expect(result.activeProcessSessions?.map((session) => session.sessionId)).toEqual([
+      "sess-sandbox",
+    ]);
   });
 
   it("omits active process session references when no safe scope is available", () => {

--- a/src/agents/pi-embedded-runner/compaction-runtime-context.ts
+++ b/src/agents/pi-embedded-runner/compaction-runtime-context.ts
@@ -10,6 +10,7 @@ import type { SkillSnapshot } from "../skills.js";
 
 export type EmbeddedCompactionRuntimeContext = {
   sessionKey?: string;
+  sandboxSessionKey?: string;
   messageChannel?: string;
   messageProvider?: string;
   agentAccountId?: string;
@@ -78,6 +79,7 @@ export function resolveEmbeddedCompactionTarget(params: {
 
 export function buildEmbeddedCompactionRuntimeContext(params: {
   sessionKey?: string | null;
+  sandboxSessionKey?: string | null;
   messageChannel?: string | null;
   messageProvider?: string | null;
   agentAccountId?: string | null;
@@ -108,7 +110,7 @@ export function buildEmbeddedCompactionRuntimeContext(params: {
     modelId: params.modelId,
     authProfileId: params.authProfileId,
   });
-  const processScopeKey = params.sessionKey?.trim();
+  const processScopeKey = params.sandboxSessionKey?.trim() || params.sessionKey?.trim();
   const activeProcessSessions =
     params.activeProcessSessions ??
     listActiveProcessSessionReferences({
@@ -116,6 +118,9 @@ export function buildEmbeddedCompactionRuntimeContext(params: {
     });
   return {
     sessionKey: params.sessionKey ?? undefined,
+    // Non-compact callers may omit the sandbox key; avoid emitting a present
+    // empty/undefined value that could shadow queued compact params.
+    ...(params.sandboxSessionKey?.trim() ? { sandboxSessionKey: params.sandboxSessionKey } : {}),
     messageChannel: params.messageChannel ?? undefined,
     messageProvider: params.messageProvider ?? undefined,
     agentAccountId: params.agentAccountId ?? undefined,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1757,6 +1757,7 @@ export async function runEmbeddedPiAgent(
                 const timeoutCompactionRuntimeContext = {
                   ...buildEmbeddedCompactionRuntimeContext({
                     sessionKey: params.sessionKey,
+                    sandboxSessionKey: params.sandboxSessionKey,
                     messageChannel: params.messageChannel,
                     messageProvider: params.messageProvider,
                     agentAccountId: params.agentAccountId,
@@ -1947,6 +1948,7 @@ export async function runEmbeddedPiAgent(
                 const overflowCompactionRuntimeContext = {
                   ...buildEmbeddedCompactionRuntimeContext({
                     sessionKey: params.sessionKey,
+                    sandboxSessionKey: params.sandboxSessionKey,
                     messageChannel: params.messageChannel,
                     messageProvider: params.messageProvider,
                     agentAccountId: params.agentAccountId,

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -565,7 +565,6 @@ vi.mock("../../pi-tools.js", () => ({
 }));
 
 vi.mock("../../pi-bundle-mcp-tools.js", () => ({
-  createBundleMcpToolRuntime: async () => undefined,
   getOrCreateSessionMcpRuntime: async () => undefined,
   materializeBundleMcpToolsForRun: async () => undefined,
   retireSessionMcpRuntime: async () => true,

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -1,4 +1,5 @@
 import { resolveAgentDir, resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { resolveIngressWorkspaceOverrideForSpawnedRun } from "../../agents/spawned-context.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { resolveAgentHarnessPolicy } from "../../agents/harness/selection.js";
 import {
@@ -16,6 +17,7 @@ import {
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
 import type { CommandHandler } from "./commands-types.js";
+import { resolveRuntimePolicySessionKey } from "./runtime-policy-session-key.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
 
 const compactRuntimeLoader = createLazyImportLoader(() => import("./commands-compact.runtime.js"));
@@ -239,9 +241,20 @@ export const handleCompactCommand: CommandHandler = async (params) => {
     liveContextTokens: params.contextTokens,
     persistedContextTokens: targetSessionEntry.contextTokens,
   });
+  const sandboxSessionKey = resolveRuntimePolicySessionKey({
+    cfg: params.cfg,
+    ctx: params.ctx,
+    sessionKey: params.sessionKey,
+  });
+  const workspaceDir =
+    resolveIngressWorkspaceOverrideForSpawnedRun({
+      spawnedBy: targetSessionEntry.spawnedBy,
+      workspaceDir: targetSessionEntry.spawnedWorkspaceDir,
+    }) ?? params.workspaceDir;
   const result = await runtime.compactEmbeddedPiSession({
     sessionId,
     sessionKey: params.sessionKey,
+    ...(sandboxSessionKey ? { sandboxSessionKey } : {}),
     allowGatewaySubagentBinding: true,
     messageChannel: params.command.channel,
     groupId: targetSessionEntry.groupId,
@@ -260,7 +273,7 @@ export const handleCompactCommand: CommandHandler = async (params) => {
         storePath: params.storePath,
       }),
     ),
-    workspaceDir: params.workspaceDir,
+    workspaceDir,
     agentDir: sessionAgentDir,
     config: params.cfg,
     skillsSnapshot: targetSessionEntry.skillsSnapshot,

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -1,7 +1,5 @@
 import { resolveModelAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
-import { resolveRuntimePolicySessionKey } from "../auto-reply/reply/runtime-policy-session-key.js";
-import { normalizeChatType } from "../channels/chat-type.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { loadSessionStore, resolveSessionTotalTokens } from "../config/sessions.js";
 import type { SessionEntry } from "../config/sessions/types.js";
@@ -12,12 +10,10 @@ import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { classifySessionKind, type SessionKind } from "../sessions/classify-session-kind.js";
 import { isAcpSessionKey } from "../sessions/session-key-utils.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
-import {
-  normalizeOptionalLowercaseString,
-  normalizeOptionalString,
-} from "../shared/string-coerce.js";
+import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import { resolveAgentRuntimeLabel } from "../status/agent-runtime-label.js";
 import { isRich, theme } from "../terminal/theme.js";
+import { resolveDisplayRuntimePolicySessionKey } from "../sessions/runtime-policy-session-key-display.js";
 import { resolveSessionStoreTargetsOrExit } from "./session-store-targets.js";
 import {
   resolveSessionDisplayModelRef,
@@ -223,76 +219,6 @@ function toJsonSessionRow(row: SessionRow): Omit<SessionRow, "runtimeLabel"> {
   const { runtimeLabel, ...jsonRow } = row;
   void runtimeLabel;
   return jsonRow;
-}
-
-function stripChannelRecipientPrefix(
-  value: string | undefined,
-  channel: string | undefined,
-): string | undefined {
-  const raw = normalizeOptionalString(value);
-  const normalizedChannel = normalizeOptionalLowercaseString(channel);
-  if (!raw || !normalizedChannel) {
-    return raw;
-  }
-  const prefix = `${normalizedChannel}:`;
-  if (!raw.toLowerCase().startsWith(prefix)) {
-    return raw;
-  }
-  const stripped = raw.slice(prefix.length);
-  const topicMarkerIndex = stripped.toLowerCase().indexOf(":topic:");
-  return topicMarkerIndex >= 0 ? stripped.slice(0, topicMarkerIndex) : stripped;
-}
-
-function resolveDisplayRuntimePolicySessionKey(params: {
-  cfg: OpenClawConfig;
-  key: string;
-  entry: SessionEntry;
-}): string | undefined {
-  const { cfg, entry, key } = params;
-  const origin = entry.origin;
-  const deliveryContext = entry.deliveryContext;
-  const chatType = normalizeChatType(origin?.chatType ?? entry.chatType);
-  if (chatType !== "direct") {
-    return undefined;
-  }
-
-  const channel = normalizeOptionalString(
-    origin?.provider ??
-      deliveryContext?.channel ??
-      entry.lastChannel ??
-      entry.channel ??
-      origin?.surface,
-  );
-  const to = normalizeOptionalString(origin?.to ?? deliveryContext?.to ?? entry.lastTo);
-  const from = normalizeOptionalString(origin?.from);
-  const nativeDirectUserId = normalizeOptionalString(origin?.nativeDirectUserId);
-  const peerId =
-    nativeDirectUserId ??
-    stripChannelRecipientPrefix(to, channel) ??
-    stripChannelRecipientPrefix(from, channel);
-
-  const runtimePolicySessionKey = resolveRuntimePolicySessionKey({
-    cfg,
-    sessionKey: key,
-    ctx: {
-      SessionKey: key,
-      Provider: channel,
-      Surface: normalizeOptionalString(origin?.surface),
-      AccountId: normalizeOptionalString(
-        origin?.accountId ?? deliveryContext?.accountId ?? entry.lastAccountId,
-      ),
-      ChatType: chatType,
-      NativeDirectUserId: nativeDirectUserId,
-      SenderId: peerId,
-      OriginatingTo: to,
-      From: from,
-      To: to,
-    },
-  });
-
-  return runtimePolicySessionKey && runtimePolicySessionKey !== key
-    ? runtimePolicySessionKey
-    : undefined;
 }
 
 export async function sessionsCommand(

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { CURRENT_SESSION_VERSION } from "@earendil-works/pi-coding-agent";
 import { resolveModelAgentRuntimeMetadata } from "../../agents/agent-runtime-metadata.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { resolveIngressWorkspaceOverrideForSpawnedRun } from "../../agents/spawned-context.js";
 import {
   abortEmbeddedPiRun,
   isEmbeddedPiRunActive,
@@ -74,6 +75,7 @@ import {
   validateSessionsResolveParams,
   validateSessionsSendParams,
 } from "../protocol/index.js";
+import { resolveDisplayRuntimePolicySessionKey } from "../../sessions/runtime-policy-session-key-display.js";
 import { resolveSessionKeyForRun } from "../server-session-key.js";
 import {
   forkCompactionCheckpointTranscriptAsync,
@@ -2278,8 +2280,15 @@ export const sessionsHandlers: GatewayRequestHandlers = {
 
       const resolvedModel = resolveSessionModelRef(cfg, entry, target.agentId);
       const workspaceDir =
-        normalizeOptionalString(entry?.spawnedWorkspaceDir) ||
-        resolveAgentWorkspaceDir(cfg, target.agentId);
+        resolveIngressWorkspaceOverrideForSpawnedRun({
+          spawnedBy: entry?.spawnedBy,
+          workspaceDir: entry?.spawnedWorkspaceDir,
+        }) ?? resolveAgentWorkspaceDir(cfg, target.agentId);
+      const sandboxSessionKey = resolveDisplayRuntimePolicySessionKey({
+        cfg,
+        key: target.canonicalKey,
+        entry,
+      });
       const operationId = randomUUID();
       emitSessionOperation(context, {
         operationId,
@@ -2292,6 +2301,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         result = await compactEmbeddedPiSession({
           sessionId,
           sessionKey: target.canonicalKey,
+          ...(sandboxSessionKey ? { sandboxSessionKey } : {}),
           allowGatewaySubagentBinding: true,
           sessionFile: filePath,
           workspaceDir,

--- a/src/sessions/runtime-policy-session-key-display.ts
+++ b/src/sessions/runtime-policy-session-key-display.ts
@@ -1,0 +1,81 @@
+import { resolveRuntimePolicySessionKey } from "../auto-reply/reply/runtime-policy-session-key.js";
+import { normalizeChatType } from "../channels/chat-type.js";
+import type { SessionEntry } from "../config/sessions/types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  normalizeOptionalLowercaseString,
+  normalizeOptionalString,
+} from "../shared/string-coerce.js";
+
+export function stripChannelRecipientPrefix(
+  value: string | undefined,
+  channel: string | undefined,
+): string | undefined {
+  const raw = normalizeOptionalString(value);
+  const normalizedChannel = normalizeOptionalLowercaseString(channel);
+  if (!raw || !normalizedChannel) {
+    return raw;
+  }
+  const prefix = `${normalizedChannel}:`;
+  if (!raw.toLowerCase().startsWith(prefix)) {
+    return raw;
+  }
+  const stripped = raw.slice(prefix.length);
+  const topicMarkerIndex = stripped.toLowerCase().indexOf(":topic:");
+  return topicMarkerIndex >= 0 ? stripped.slice(0, topicMarkerIndex) : stripped;
+}
+
+export function resolveDisplayRuntimePolicySessionKey(params: {
+  cfg: OpenClawConfig;
+  key: string;
+  entry?: SessionEntry | null;
+}): string | undefined {
+  const { cfg, entry, key } = params;
+  if (!entry) {
+    return undefined;
+  }
+  const origin = entry.origin;
+  const deliveryContext = entry.deliveryContext;
+  const chatType = normalizeChatType(origin?.chatType ?? entry.chatType);
+  if (chatType !== "direct") {
+    return undefined;
+  }
+
+  const channel = normalizeOptionalString(
+    origin?.provider ??
+      deliveryContext?.channel ??
+      entry.lastChannel ??
+      entry.channel ??
+      origin?.surface,
+  );
+  const to = normalizeOptionalString(origin?.to ?? deliveryContext?.to ?? entry.lastTo);
+  const from = normalizeOptionalString(origin?.from);
+  const nativeDirectUserId = normalizeOptionalString(origin?.nativeDirectUserId);
+  const peerId =
+    nativeDirectUserId ??
+    stripChannelRecipientPrefix(to, channel) ??
+    stripChannelRecipientPrefix(from, channel);
+
+  const runtimePolicySessionKey = resolveRuntimePolicySessionKey({
+    cfg,
+    sessionKey: key,
+    ctx: {
+      SessionKey: key,
+      Provider: channel,
+      Surface: normalizeOptionalString(origin?.surface),
+      AccountId: normalizeOptionalString(
+        origin?.accountId ?? deliveryContext?.accountId ?? entry.lastAccountId,
+      ),
+      ChatType: chatType,
+      NativeDirectUserId: nativeDirectUserId,
+      SenderId: peerId,
+      OriginatingTo: to,
+      From: from,
+      To: to,
+    },
+  });
+
+  return runtimePolicySessionKey && runtimePolicySessionKey !== key
+    ? runtimePolicySessionKey
+    : undefined;
+}

--- a/src/shared/net/redact-sensitive-url.test.ts
+++ b/src/shared/net/redact-sensitive-url.test.ts
@@ -43,6 +43,24 @@ describe("redactSensitiveUrlLikeString", () => {
     ).toBe("fatal https://***:***@github.com/one.git and https://***:***@github.com/two.git");
   });
 
+  it("redacts embedded valid URLs that mix userinfo and sensitive query params", () => {
+    expect(
+      redactSensitiveUrlLikeString(
+        "failed https://user:pass@example.com/mcp?token=secret-token&ok=1",
+      ),
+    ).toBe("failed https://***:***@example.com/mcp?token=***&ok=1");
+  });
+
+  it("redacts embedded URL userinfo without lowercasing arbitrary error prefixes", () => {
+    expect(
+      redactSensitiveUrlLikeString(
+        "McpError: MCP error -32603: failed https://user:pass@example.com/mcp?token=secret-token&ok=1",
+      ),
+    ).toBe(
+      "McpError: MCP error -32603: failed https://***:***@example.com/mcp?token=***&ok=1",
+    );
+  });
+
   it("redacts protocol URLs that are too malformed to parse", () => {
     expect(
       redactSensitiveUrlLikeString(

--- a/src/shared/net/redact-sensitive-url.ts
+++ b/src/shared/net/redact-sensitive-url.ts
@@ -65,11 +65,10 @@ export function redactSensitiveUrl(value: string): string {
 }
 
 export function redactSensitiveUrlLikeString(value: string): string {
-  const redactedUrl = redactSensitiveUrl(value);
-  if (redactedUrl !== value) {
-    return redactedUrl;
-  }
-  return value
+  const redactedUrl = /^[a-z][a-z\d+.-]*:\/\//i.test(value)
+    ? redactSensitiveUrl(value)
+    : value;
+  return redactedUrl
     .replace(/\/\/([^@/?#\s]+)@/g, "//***:***@")
     .replace(/([?&])([^=&]+)=([^&]*)/g, (match, prefix: string, key: string) =>
       isSensitiveUrlQueryParamName(key) ? `${prefix}${key}=***` : match,


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Reuses the managed bundle MCP runtime during compact setup instead of creating a one-off runtime that bypasses the session runtime cache.
- Refuses workspace/config rebinds while a bundle MCP runtime has an active materialization lease, so compact setup cannot dispose a runtime that is still in use.
- Reports bundle MCP servers omitted during connect or `tools/list` with sanitized diagnostics instead of silently hiding partial MCP availability.

Why does this matter now?

- #85063 bounded `tools/list` during catalog discovery. Compact setup still had its own runtime path and could lose visibility into partially available bundle MCP servers.

What is the intended outcome?

- `/compact` uses the same managed runtime lifecycle as normal session MCP setup.
- Healthy bundle MCP servers remain available when another server fails during connect or `tools/list`.
- Omitted servers are visible through a warning with a stable reason and redacted error text.

What is intentionally out of scope?

- No retry/backoff/background recovery for failed MCP servers.
- No change to MCP tool-call approval or execution behavior.
- No new config surface or user setting.

What does success look like?

- Compact materialization releases its lease on success and setup failure.
- Active leases block runtime rebinds instead of disposing the leased runtime.
- Failed bundle MCP servers are omitted with sanitized diagnostics while healthy servers are retained.

What should reviewers focus on?

- `src/agents/pi-bundle-mcp-runtime.ts` lease/rebind and omitted-server diagnostics.
- Compact setup cleanup in `src/agents/pi-embedded-runner/compact.ts`.
- `sandboxSessionKey` propagation through compact entrypoints.
- URL redaction for embedded URLs in arbitrary MCP error text.

## Linked context

Which issue does this close?

None.

Which issues, PRs, or discussions are related?

Related #85063.

Was this requested by a maintainer or owner?

No explicit maintainer request; this is a focused follow-up to the merged bounded `tools/list` discovery fix.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed:

Compact now reuses the managed bundle MCP runtime, protects active leases from rebind disposal, releases materialized runtimes after setup failure, and reports omitted bundle MCP servers with redacted diagnostics.

- Real environment tested:

Local OpenClaw worktree on Linux after rebasing onto current `upstream/main`; generated stdio MCP servers created at runtime; one local compact smoke also connected through a loopback proxy to a live OAuth-protected streamable-http MCP server and only allowed discovery/listing.

- Exact steps or command run after this patch:

```
git diff --check upstream/main..HEAD
node scripts/run-vitest.mjs \
  src/shared/net/redact-sensitive-url.test.ts \
  src/agents/pi-bundle-mcp-runtime.test.ts \
  src/agents/pi-bundle-mcp-tools.materialize.test.ts \
  src/agents/pi-bundle-mcp-tools.request-boundary.test.ts \
  src/auto-reply/reply/commands-compact.test.ts \
  src/gateway/server.sessions.compaction.test.ts \
  src/commands/sessions.test.ts \
  src/agents/pi-embedded-runner/compaction-runtime-context.test.ts \
  src/agents/pi-embedded-runner/compact.hooks.test.ts \
  src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts \
  src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts \
  src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
CI=true pnpm check:test-types
pnpm exec tsx /tmp/pr85063-di-omitted-proof.mts
pnpm exec tsx /tmp/pr85063-di-managed-runtime-lifecycle-proof.mts
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

Terminal capture from this branch, copied live output:

```
Test Files  19 passed (19)
Tests       388 passed (388)
```

```
CI=true pnpm check:test-types
...
Done in 7.6s using pnpm v11.2.2
```

```
{
  "proof": "ok",
  "catalogTools": [
    { "serverName": "healthy", "toolName": "healthy_tool" }
  ],
  "catalogServers": ["healthy"],
  "omitted": [
    {
      "serverName": "failingList",
      "reason": "list-tools-failed",
      "errorMessage": "McpError: MCP error -32603: failed https://***:***@example.com/mcp?token=***&ok=1"
    }
  ]
}
```

```
{
  "proof": "ok",
  "initial": {
    "materializedTools": ["healthy__healthy_tool"],
    "activeLeasesWhileMaterialized": 1,
    "busyRebindRejected": true
  },
  "afterCleanup": {
    "activeLeases": 0,
    "rebindAfterCleanupSucceeded": true,
    "reboundServers": ["healthyChangedConfig"]
  }
}
```

Additional local live-transport compact smoke passed: compact listed tools from a live OAuth-protected streamable-http MCP server through a local proxy, omitted a generated local failing server as `list-tools-failed`, observed only `initialize`, `notifications/initialized`, and `tools/list`, observed no `tools/call`, and disposed the runtime cache after the run.

- Observed result after fix:

Healthy bundle MCP tools remain materialized when another server fails during `tools/list`; the failed server is reported as omitted with a stable reason and redacted diagnostic text. Compact setup holds and releases the managed runtime lease correctly, rejects active rebinds, and cleans up after setup failure.

- What was not tested:

No production user session was mutated. The live-transport compact smoke intentionally did not call remote MCP tools. I did not test retry/backoff/background recovery because this PR does not implement it.

- Proof limitations or environment constraints:

The full live-transport compact smoke used a local direct compact invocation with a synthetic session and a loopback proxy, not a hosted production user session. Private server identity and credentials are intentionally omitted from this public proof.

- Before evidence (optional but encouraged):

A pre-change local repro showed a leased bundle MCP runtime could be rebound/disposed when workspace/config changed while a materialization lease was active.

## Tests and validation

Which commands did you run?

- `git diff --check upstream/main..HEAD`
- Targeted `node scripts/run-vitest.mjs ...` suite above: 19 files / 388 tests passed.
- `CI=true pnpm check:test-types`
- Local omitted-server proof script with generated stdio MCP servers.
- Local managed-runtime lifecycle proof script with generated stdio MCP servers.
- Local live-transport compact smoke with discovery/listing only and no tool calls.

What regression coverage was added or updated?

- Managed runtime reuse during compact setup and cleanup.
- Active-lease rebind guard.
- Omitted-server diagnostics for unsupported transport, connect timeout/failure, and `tools/list` timeout/failure.
- Redaction of embedded URL userinfo/query secrets in arbitrary error text.
- `sandboxSessionKey` propagation through command, gateway, queued, timeout, and overflow compact paths.

What failed before this fix, if known?

- A pre-change local repro showed active materialization did not block runtime rebind/disposal.
- Bundle MCP list failures could leave healthy servers available internally but omit diagnostics from materialized tools.

If no test was added, why not?

N/A. Tests were added and updated.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Compact can now surface omitted-server warnings and can fail safely with an active-lease rebind error instead of disposing a leased runtime.

Did config, environment, or migration behavior change? (`Yes/No`)

No. No new config key, environment variable, migration, or persisted-state shape.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes, diagnostics can include upstream MCP error text, so this patch applies shared URL redaction to embedded URLs. No credential source, permission model, or tool execution approval path changes.

What is the highest-risk area?

Runtime lifecycle around compact setup failure and partial MCP discovery failures.

How is that risk mitigated?

The lease guard, setup-failure cleanup, partial omission behavior, redaction behavior, and compact entrypoints are covered by targeted tests plus local production-path proof scripts.

## Current review state

What is the next action?

Ready for maintainer review after PR creation.

What is still waiting on author, maintainer, CI, or external proof?

Hosted PR CI has not run yet because the PR has not been opened.

Which bot or reviewer comments were addressed?

N/A for this new PR.
