### PR TITLE
Fix plugin packaging recovery hints

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -273,6 +273,7 @@ function setExternalFeishuSchema() {
 
 function makeInvalidSnapshot(params: {
   issues: ConfigFileSnapshot["issues"];
+  warnings?: ConfigFileSnapshot["warnings"];
   path?: string;
 }): ConfigFileSnapshot {
   return {
@@ -286,7 +287,7 @@ function makeInvalidSnapshot(params: {
     runtimeConfig: {},
     config: {},
     issues: params.issues,
-    warnings: [],
+    warnings: params.warnings ?? [],
     legacyIssues: [],
   };
 }
@@ -1063,6 +1064,36 @@ describe("config cli", () => {
 
       expectErrorIncludes("config is invalid");
       expectErrorIncludes("agents.defaults.suppressToolErrorWarnings");
+      expect(mockLog).not.toHaveBeenCalled();
+    });
+
+    it("replaces doctor advice for plugin packaging compiled-output failures", async () => {
+      setSnapshotOnce(
+        makeInvalidSnapshot({
+          issues: [
+            {
+              path: "plugins.slots.memory",
+              message: "plugin not found: source-only-pack",
+            },
+          ],
+          warnings: [
+            {
+              path: "plugins",
+              message:
+                "plugin source-only-pack: installed plugin package requires compiled runtime output for TypeScript entry index.ts: expected ./dist/index.js. This is a plugin packaging issue, not a local config problem.",
+            },
+          ],
+        }),
+      );
+
+      await expect(runConfigCommand(["config", "validate"])).rejects.toThrow("__exit__:1");
+
+      expectErrorIncludes("plugin not found: source-only-pack");
+      expectErrorIncludes("This is a plugin packaging issue, not a local config problem.");
+      expectErrorIncludes("disable/uninstall the plugin");
+      expect(mockError.mock.calls.map((call) => String(call[0])).join("\n")).not.toContain(
+        "openclaw doctor --fix",
+      );
       expect(mockLog).not.toHaveBeenCalled();
     });
 

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -2,7 +2,11 @@ import fs from "node:fs";
 import type { Command } from "commander";
 import JSON5 from "json5";
 import { normalizeConfiguredProviderCatalogModelId } from "../agents/model-ref-shared.js";
-import { readConfigFileSnapshot, replaceConfigFile } from "../config/config.js";
+import {
+  type ConfigFileSnapshot,
+  readConfigFileSnapshot,
+  replaceConfigFile,
+} from "../config/config.js";
 import { AUTO_MANAGED_CONFIG_META_PATHS } from "../config/io.meta.js";
 import { formatConfigIssueLines, normalizeConfigIssues } from "../config/issue-format.js";
 import {
@@ -11,6 +15,7 @@ import {
 } from "../config/model-input.js";
 import { CONFIG_PATH } from "../config/paths.js";
 import { isBlockedObjectKey } from "../config/prototype-keys.js";
+import { isPluginPackagingRuntimeOutputInvalidConfigSnapshot } from "../config/recovery-policy.js";
 import { redactConfigObject } from "../config/redact-snapshot.js";
 import { readBestEffortRuntimeConfigSchema } from "../config/runtime-schema.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -50,6 +55,7 @@ import { formatDocsLink } from "../terminal/links.js";
 import { theme } from "../terminal/theme.js";
 import { shortenHomePath } from "../utils.js";
 import { formatCliCommand } from "./command-format.js";
+import { formatPluginPackagingRuntimeOutputRecoveryHint } from "./config-recovery-hints.js";
 import type {
   ConfigSetDryRunError,
   ConfigSetDryRunInputMode,
@@ -410,6 +416,15 @@ function hasOwnPathKey(value: Record<string, unknown>, key: string): boolean {
 
 function formatDoctorHint(message: string): string {
   return `Run \`${formatCliCommand("openclaw doctor --fix")}\` ${message}`;
+}
+
+function formatInvalidConfigRepairHint(
+  snapshot: Pick<ConfigFileSnapshot, "valid" | "issues" | "warnings" | "legacyIssues">,
+  doctorMessage: string,
+): string {
+  return isPluginPackagingRuntimeOutputInvalidConfigSnapshot(snapshot)
+    ? formatPluginPackagingRuntimeOutputRecoveryHint()
+    : formatDoctorHint(doctorMessage);
 }
 
 function formatUnsupportedSecretRefPolicyFailureMessage(issues: string[]): string {
@@ -868,7 +883,7 @@ async function loadValidConfig(runtime: RuntimeEnv = defaultRuntime) {
   for (const line of formatConfigIssueLines(snapshot.issues, "-", { normalizeRoot: true })) {
     runtime.error(line);
   }
-  runtime.error(formatDoctorHint("to repair, then retry."));
+  runtime.error(formatInvalidConfigRepairHint(snapshot, "to repair, then retry."));
   runtime.exit(1);
   return snapshot;
 }
@@ -2343,7 +2358,9 @@ export async function runConfigValidate(opts: { json?: boolean; runtime?: Runtim
           runtime.error(`  ${line}`);
         }
         runtime.error("");
-        runtime.error(formatDoctorHint("to repair, or fix the keys above manually."));
+        runtime.error(
+          formatInvalidConfigRepairHint(snapshot, "to repair, or fix the keys above manually."),
+        );
         runtime.error(`Inspect with ${formatCliCommand("openclaw config validate")}.`);
       }
       runtime.exit(1);

--- a/src/cli/config-recovery-hints.ts
+++ b/src/cli/config-recovery-hints.ts
@@ -6,3 +6,10 @@ export function formatInvalidConfigRecoveryHint(): string {
     "If startup is still blocked, inspect the adjacent .bak backup before restoring it manually.",
   ].join("\n");
 }
+
+export function formatPluginPackagingRuntimeOutputRecoveryHint(): string {
+  return [
+    "This is a plugin packaging issue, not a local config problem.",
+    "Update or reinstall the plugin after the publisher ships compiled JavaScript, or disable/uninstall the plugin until then.",
+  ].join("\n");
+}

--- a/src/cli/daemon-cli/lifecycle-core.config-guard.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.config-guard.test.ts
@@ -19,6 +19,14 @@ const invalidConfigRecoveryHint = [
   'Run "openclaw doctor --fix" to repair, then retry.',
   "If startup is still blocked, inspect the adjacent .bak backup before restoring it manually.",
 ].join("\n");
+const pluginPackagingRecoveryHints = [
+  "This is a plugin packaging issue, not a local config problem.",
+  "Update or reinstall the plugin after the publisher ships compiled JavaScript, or disable/uninstall the plugin until then.",
+];
+const pluginPackagingHintItems = pluginPackagingRecoveryHints.map((text) => ({
+  kind: "generic",
+  text,
+}));
 
 function expectLatestRuntimeJson(payload: unknown) {
   const calls = defaultRuntime.writeJson.mock.calls;
@@ -47,6 +55,8 @@ function setConfigSnapshot(params: {
   exists: boolean;
   valid: boolean;
   issues?: Array<{ path: string; message: string }>;
+  warnings?: Array<{ path: string; message: string }>;
+  legacyIssues?: Array<{ path: string; message: string }>;
   lastTouchedVersion?: string;
 }) {
   const config = params.lastTouchedVersion
@@ -58,6 +68,28 @@ function setConfigSnapshot(params: {
     config,
     sourceConfig: config,
     issues: params.issues ?? [],
+    warnings: params.warnings ?? [],
+    legacyIssues: params.legacyIssues ?? [],
+  });
+}
+
+function setPluginPackagingInvalidSnapshot() {
+  setConfigSnapshot({
+    exists: true,
+    valid: false,
+    issues: [
+      {
+        path: "plugins.slots.memory",
+        message: "plugin not found: source-only-pack",
+      },
+    ],
+    warnings: [
+      {
+        path: "plugins",
+        message:
+          "plugin source-only-pack: installed plugin package requires compiled runtime output for TypeScript entry index.ts: expected ./dist/index.js. This is a plugin packaging issue, not a local config problem.",
+      },
+    ],
   });
 }
 
@@ -103,6 +135,22 @@ describe("runServiceRestart config pre-flight (#35862)", () => {
       error: `Gateway aborted: config is invalid.\nagents.defaults.pdfModel: Unrecognized key\n${invalidConfigRecoveryHint}`,
       hints: undefined,
       hintItems: undefined,
+      warnings: undefined,
+    });
+  });
+
+  it("points restart at plugin packaging recovery for packaging-only invalid config", async () => {
+    setPluginPackagingInvalidSnapshot();
+
+    await expect(runServiceRestart(createServiceRunArgs())).rejects.toThrow("__exit__:1");
+
+    expect(service.restart).not.toHaveBeenCalled();
+    expectLatestRuntimeJson({
+      action: "restart",
+      ok: false,
+      error: "Gateway restart blocked: plugins.slots.memory: plugin not found: source-only-pack",
+      hints: pluginPackagingRecoveryHints,
+      hintItems: pluginPackagingHintItems,
       warnings: undefined,
     });
   });
@@ -181,6 +229,22 @@ describe("runServiceStart config pre-flight (#35862)", () => {
       error: `Gateway aborted: config is invalid.\nagents.defaults.pdfModel: Unrecognized key\n${invalidConfigRecoveryHint}`,
       hints: undefined,
       hintItems: undefined,
+      warnings: undefined,
+    });
+  });
+
+  it("points start at plugin packaging recovery for packaging-only invalid config", async () => {
+    setPluginPackagingInvalidSnapshot();
+
+    await expect(runServiceStart(createServiceRunArgs())).rejects.toThrow("__exit__:1");
+
+    expect(service.restart).not.toHaveBeenCalled();
+    expectLatestRuntimeJson({
+      action: "start",
+      ok: false,
+      error: "Gateway start blocked: plugins.slots.memory: plugin not found: source-only-pack",
+      hints: pluginPackagingRecoveryHints,
+      hintItems: pluginPackagingHintItems,
       warnings: undefined,
     });
   });

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -3,6 +3,7 @@ import { readBestEffortConfig, readConfigFileSnapshot } from "../../config/confi
 import { resolveFutureConfigActionBlock } from "../../config/future-version-guard.js";
 import { formatConfigIssueLines } from "../../config/issue-format.js";
 import { resolveIsNixMode } from "../../config/paths.js";
+import { isPluginPackagingRuntimeOutputInvalidConfigSnapshot } from "../../config/recovery-policy.js";
 import { checkTokenDrift } from "../../daemon/service-audit.js";
 import type { GatewayServiceRestartResult } from "../../daemon/service-types.js";
 import type { GatewayServiceStartRepairIssue, GatewayServiceState } from "../../daemon/service.js";
@@ -19,7 +20,10 @@ import {
 import { isWSL } from "../../infra/wsl.js";
 import { defaultRuntime } from "../../runtime.js";
 import { formatCliCommand } from "../command-format.js";
-import { formatInvalidConfigRecoveryHint } from "../config-recovery-hints.js";
+import {
+  formatInvalidConfigRecoveryHint,
+  formatPluginPackagingRuntimeOutputRecoveryHint,
+} from "../config-recovery-hints.js";
 import { resolveGatewayTokenForDriftCheck } from "./gateway-token-drift.js";
 import {
   buildDaemonServiceSnapshot,
@@ -139,6 +143,10 @@ type ConfigActionPreflightFailure = {
   hints?: string[];
 };
 
+function formatPluginPackagingRuntimeOutputRecoveryHints(): string[] {
+  return formatPluginPackagingRuntimeOutputRecoveryHint().split("\n");
+}
+
 async function getConfigActionPreflightFailure(
   action: string,
 ): Promise<ConfigActionPreflightFailure | null> {
@@ -146,11 +154,15 @@ async function getConfigActionPreflightFailure(
   try {
     snapshot = await readConfigFileSnapshot();
     if (snapshot.exists && !snapshot.valid) {
+      const message =
+        snapshot.issues.length > 0
+          ? formatConfigIssueLines(snapshot.issues, "", { normalizeRoot: true }).join("\n")
+          : "Unknown validation issue.";
       return {
-        message:
-          snapshot.issues.length > 0
-            ? formatConfigIssueLines(snapshot.issues, "", { normalizeRoot: true }).join("\n")
-            : "Unknown validation issue.",
+        message,
+        ...(isPluginPackagingRuntimeOutputInvalidConfigSnapshot(snapshot)
+          ? { hints: formatPluginPackagingRuntimeOutputRecoveryHints() }
+          : {}),
       };
     }
   } catch {

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -3,6 +3,11 @@ import { note } from "../../terminal/note.js";
 import { formatCliCommand } from "../command-format.js";
 import { ensureConfigReady, testApi } from "./config-guard.js";
 
+const pluginPackagingRecoveryHint = [
+  "This is a plugin packaging issue, not a local config problem.",
+  "Update or reinstall the plugin after the publisher ships compiled JavaScript, or disable/uninstall the plugin until then.",
+].join("\n");
+
 const loadAndMaybeMigrateDoctorConfigMock = vi.hoisted(() => vi.fn());
 const readConfigFileSnapshotMock = vi.hoisted(() => vi.fn());
 const setRuntimeConfigSnapshotMock = vi.hoisted(() => vi.fn());
@@ -23,6 +28,7 @@ function makeSnapshot() {
     exists: false,
     valid: true,
     issues: [] as ConfigIssue[],
+    warnings: [] as ConfigIssue[],
     legacyIssues: [] as ConfigIssue[],
     path: "/tmp/openclaw.json",
   };
@@ -42,20 +48,16 @@ function plainErrorCalls(runtime: ReturnType<typeof makeRuntime>): string[] {
 
 async function withCapturedStdout(run: () => Promise<void>): Promise<string> {
   const writes: string[] = [];
-  const writeSpy = vi
-    .spyOn(process.stdout, "write")
-    .mockImplementation(
-      ((
-        chunk: unknown,
-        encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
-        callback?: (error?: Error | null) => void,
-      ) => {
-        writes.push(String(chunk));
-        const done = typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
-        done?.();
-        return true;
-      }) as typeof process.stdout.write,
-    );
+  const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(((
+    chunk: unknown,
+    encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+    callback?: (error?: Error | null) => void,
+  ) => {
+    writes.push(String(chunk));
+    const done = typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
+    done?.();
+    return true;
+  }) as typeof process.stdout.write);
   try {
     await run();
     return writes.join("");
@@ -182,6 +184,30 @@ describe("ensureConfigReady", () => {
       `Inspect: ${formatCliCommand("openclaw config validate")}`,
       "Status, health, logs, and doctor commands still run with invalid config.",
     ]);
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("replaces doctor fix advice for plugin packaging-only invalid config", async () => {
+    setInvalidSnapshot({
+      issues: [
+        {
+          path: "plugins.slots.memory",
+          message: "plugin not found: source-only-pack",
+        },
+      ],
+      warnings: [
+        {
+          path: "plugins",
+          message:
+            "plugin source-only-pack: installed plugin package requires compiled runtime output for TypeScript entry index.ts: expected ./dist/index.js. This is a plugin packaging issue, not a local config problem.",
+        },
+      ],
+    });
+    const runtime = await runEnsureConfigReady(["message"]);
+    const calls = plainErrorCalls(runtime);
+
+    expect(calls).toContain(`Fix: ${pluginPackagingRecoveryHint}`);
+    expect(calls).not.toContain(`Fix: ${formatCliCommand("openclaw doctor --fix")}`);
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -96,12 +96,19 @@ export async function ensureConfigReady(params: {
     return;
   }
 
-  const [{ colorize, isRich, theme }, { shortenHomePath }, { formatCliCommand }] =
-    await Promise.all([
-      import("../../terminal/theme.js"),
-      import("../../utils.js"),
-      import("../command-format.js"),
-    ]);
+  const [
+    { colorize, isRich, theme },
+    { shortenHomePath },
+    { formatCliCommand },
+    { isPluginPackagingRuntimeOutputInvalidConfigSnapshot },
+    { formatPluginPackagingRuntimeOutputRecoveryHint },
+  ] = await Promise.all([
+    import("../../terminal/theme.js"),
+    import("../../utils.js"),
+    import("../command-format.js"),
+    import("../../config/recovery-policy.js"),
+    import("../config-recovery-hints.js"),
+  ]);
   const rich = isRich();
   const muted = (value: string) => colorize(rich, theme.muted, value);
   const error = (value: string) => colorize(rich, theme.error, value);
@@ -119,9 +126,10 @@ export async function ensureConfigReady(params: {
     params.runtime.error(legacyIssues.map((issue) => `  ${error(issue)}`).join("\n"));
   }
   params.runtime.error("");
-  params.runtime.error(
-    `${muted("Fix:")} ${commandText(formatCliCommand("openclaw doctor --fix"))}`,
-  );
+  const fixHint = isPluginPackagingRuntimeOutputInvalidConfigSnapshot(snapshot)
+    ? formatPluginPackagingRuntimeOutputRecoveryHint()
+    : commandText(formatCliCommand("openclaw doctor --fix"));
+  params.runtime.error(`${muted("Fix:")} ${fixHint}`);
   params.runtime.error(
     `${muted("Inspect:")} ${commandText(formatCliCommand("openclaw config validate"))}`,
   );

--- a/src/commands/config-validation.test.ts
+++ b/src/commands/config-validation.test.ts
@@ -108,4 +108,54 @@ describe("requireValidConfigSnapshot", () => {
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(runtime.log).not.toHaveBeenCalled();
   });
+
+  it("replaces doctor fix advice for plugin packaging compiled-output failures", async () => {
+    readConfigFileSnapshot.mockResolvedValue({
+      exists: true,
+      valid: false,
+      config: {},
+      issues: [
+        {
+          path: "plugins.slots.memory",
+          message: "plugin not found: source-only-pack",
+        },
+      ],
+      warnings: [
+        {
+          path: "plugins",
+          message:
+            "plugin source-only-pack: installed plugin package requires compiled runtime output for TypeScript entry index.ts: expected ./dist/index.js. This is a plugin packaging issue, not a local config problem.",
+        },
+      ],
+      legacyIssues: [],
+    });
+    const runtime = createRuntime();
+
+    const config = await requireValidConfigSnapshot(runtime);
+
+    expect(config).toBeNull();
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("plugin not found"));
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Fix: This is a plugin packaging issue, not a local config problem.\nUpdate or reinstall the plugin after the publisher ships compiled JavaScript, or disable/uninstall the plugin until then.",
+    );
+    expect(runtime.error).not.toHaveBeenCalledWith("Fix: openclaw doctor --fix");
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("keeps doctor fix advice for normal invalid config failures", async () => {
+    readConfigFileSnapshot.mockResolvedValue({
+      exists: true,
+      valid: false,
+      config: {},
+      issues: [{ path: "gateway.mode", message: "Expected 'local' or 'remote'" }],
+      legacyIssues: [],
+    });
+    const runtime = createRuntime();
+
+    const config = await requireValidConfigSnapshot(runtime);
+
+    expect(config).toBeNull();
+    expect(runtime.error).toHaveBeenCalledWith("Fix: openclaw doctor --fix");
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
 });

--- a/src/commands/config-validation.ts
+++ b/src/commands/config-validation.ts
@@ -1,10 +1,12 @@
 import { formatCliCommand } from "../cli/command-format.js";
+import { formatPluginPackagingRuntimeOutputRecoveryHint } from "../cli/config-recovery-hints.js";
 import {
   type ConfigFileSnapshot,
   type OpenClawConfig,
   readConfigFileSnapshot,
 } from "../config/config.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
+import { isPluginPackagingRuntimeOutputInvalidConfigSnapshot } from "../config/recovery-policy.js";
 import {
   buildPluginCompatibilitySnapshotNotices,
   formatPluginCompatibilityNotice,
@@ -22,7 +24,11 @@ export async function requireValidConfigFileSnapshot(
         ? formatConfigIssueLines(snapshot.issues, "-").join("\n")
         : "Unknown validation issue.";
     runtime.error(`OpenClaw config is invalid: ${snapshot.path}\n${issues}`);
-    runtime.error(`Fix: ${formatCliCommand("openclaw doctor --fix")}`);
+    runtime.error(
+      isPluginPackagingRuntimeOutputInvalidConfigSnapshot(snapshot)
+        ? `Fix: ${formatPluginPackagingRuntimeOutputRecoveryHint()}`
+        : `Fix: ${formatCliCommand("openclaw doctor --fix")}`,
+    );
     runtime.error(`Inspect: ${formatCliCommand("openclaw config validate")}`);
     runtime.exit(1);
     return null;

--- a/src/config/recovery-policy.test.ts
+++ b/src/config/recovery-policy.test.ts
@@ -1,16 +1,18 @@
 import { describe, expect, it } from "vitest";
 import {
+  isPluginPackagingRuntimeOutputInvalidConfigSnapshot,
   isPluginLocalInvalidConfigSnapshot,
   shouldAttemptLastKnownGoodRecovery,
 } from "./recovery-policy.js";
 import type { ConfigFileSnapshot } from "./types.openclaw.js";
 
-type PolicySnapshot = Pick<ConfigFileSnapshot, "valid" | "issues" | "legacyIssues">;
+type PolicySnapshot = Pick<ConfigFileSnapshot, "valid" | "issues" | "warnings" | "legacyIssues">;
 
 function snapshot(params: Partial<PolicySnapshot>): PolicySnapshot {
   return {
     valid: false,
     issues: [],
+    warnings: [],
     legacyIssues: [],
     ...params,
   };
@@ -83,5 +85,69 @@ describe("config recovery policy", () => {
 
     expect(isPluginLocalInvalidConfigSnapshot(current)).toBe(false);
     expect(shouldAttemptLastKnownGoodRecovery(current)).toBe(true);
+  });
+
+  it("classifies plugin packaging compiled-output failures with plugin-not-found fallout", () => {
+    const current = snapshot({
+      issues: [
+        {
+          path: "plugins.slots.memory",
+          message: "plugin not found: source-only-pack",
+        },
+      ],
+      warnings: [
+        {
+          path: "plugins",
+          message:
+            "plugin source-only-pack: installed plugin package requires compiled runtime output for TypeScript entry index.ts: expected ./dist/index.js. This is a plugin packaging issue, not a local config problem.",
+        },
+      ],
+    });
+
+    expect(isPluginPackagingRuntimeOutputInvalidConfigSnapshot(current)).toBe(true);
+  });
+
+  it("does not classify mixed core invalidity as a plugin packaging-only failure", () => {
+    const current = snapshot({
+      issues: [
+        {
+          path: "plugins.slots.memory",
+          message: "plugin not found: source-only-pack",
+        },
+        {
+          path: "gateway.mode",
+          message: "Expected 'local' or 'remote'",
+        },
+      ],
+      warnings: [
+        {
+          path: "plugins",
+          message:
+            "plugin source-only-pack: installed plugin package requires compiled runtime output for TypeScript entry index.ts: expected ./dist/index.js.",
+        },
+      ],
+    });
+
+    expect(isPluginPackagingRuntimeOutputInvalidConfigSnapshot(current)).toBe(false);
+  });
+
+  it("does not classify unrelated missing plugins as packaging fallout", () => {
+    const current = snapshot({
+      issues: [
+        {
+          path: "plugins.slots.memory",
+          message: "plugin not found: missing-memory",
+        },
+      ],
+      warnings: [
+        {
+          path: "plugins",
+          message:
+            "plugin source-only-pack: installed plugin package requires compiled runtime output for TypeScript entry index.ts: expected ./dist/index.js.",
+        },
+      ],
+    });
+
+    expect(isPluginPackagingRuntimeOutputInvalidConfigSnapshot(current)).toBe(false);
   });
 });

--- a/src/config/recovery-policy.ts
+++ b/src/config/recovery-policy.ts
@@ -2,6 +2,13 @@ import type { ConfigFileSnapshot, ConfigValidationIssue } from "./types.openclaw
 
 const PLUGIN_ENTRY_PATH_PREFIX = "plugins.entries.";
 const PLUGIN_POLICY_PATHS = new Set(["plugins.allow", "plugins.deny"]);
+const COMPILED_RUNTIME_OUTPUT_DIAGNOSTIC = "compiled runtime output";
+const PLUGIN_DIAGNOSTIC_PREFIX_PATTERN = /^plugin\s+([^:\s]+):\s/u;
+const PLUGIN_NOT_FOUND_PATTERN = /^plugin not found:\s*([^\s(]+)/u;
+
+function isPluginsPath(path: string): boolean {
+  return path === "plugins" || path.startsWith("plugins.");
+}
 
 function isPluginEntryIssue(issue: ConfigValidationIssue): boolean {
   const path = issue.path.trim();
@@ -15,6 +22,68 @@ function isPluginPolicyIssue(issue: ConfigValidationIssue): boolean {
   return (
     PLUGIN_POLICY_PATHS.has(issue.path.trim()) &&
     issue.message.trim().startsWith("plugin not found:")
+  );
+}
+
+export function isPluginPackagingRuntimeOutputIssue(issue: ConfigValidationIssue): boolean {
+  const path = issue.path.trim();
+  const message = issue.message.trim().toLowerCase();
+  return isPluginsPath(path) && message.includes(COMPILED_RUNTIME_OUTPUT_DIAGNOSTIC);
+}
+
+function isPluginPackagingFalloutIssue(issue: ConfigValidationIssue): boolean {
+  const path = issue.path.trim();
+  const message = issue.message.trim();
+  return isPluginsPath(path) && message.startsWith("plugin not found:");
+}
+
+function normalizePluginIssueId(value: string | undefined): string | null {
+  const normalized = value?.trim().toLowerCase();
+  return normalized ? normalized : null;
+}
+
+function extractPluginPackagingRuntimeOutputPluginId(issue: ConfigValidationIssue): string | null {
+  if (!isPluginPackagingRuntimeOutputIssue(issue)) {
+    return null;
+  }
+  return normalizePluginIssueId(PLUGIN_DIAGNOSTIC_PREFIX_PATTERN.exec(issue.message.trim())?.[1]);
+}
+
+function extractPluginNotFoundIssuePluginId(issue: ConfigValidationIssue): string | null {
+  if (!isPluginPackagingFalloutIssue(issue)) {
+    return null;
+  }
+  return normalizePluginIssueId(PLUGIN_NOT_FOUND_PATTERN.exec(issue.message.trim())?.[1]);
+}
+
+/**
+ * Returns true when an invalid config snapshot is blocked by an installed plugin
+ * package that shipped TypeScript source without compiled JavaScript output.
+ */
+export function isPluginPackagingRuntimeOutputInvalidConfigSnapshot(
+  snapshot: Pick<ConfigFileSnapshot, "valid" | "issues" | "legacyIssues"> &
+    Partial<Pick<ConfigFileSnapshot, "warnings">>,
+): boolean {
+  if (snapshot.valid || (snapshot.legacyIssues?.length ?? 0) > 0 || snapshot.issues.length === 0) {
+    return false;
+  }
+  const packagingIssues = [...snapshot.issues, ...(snapshot.warnings ?? [])].filter(
+    isPluginPackagingRuntimeOutputIssue,
+  );
+  const packagingPluginIds = new Set(
+    packagingIssues
+      .map((issue) => extractPluginPackagingRuntimeOutputPluginId(issue))
+      .filter((pluginId): pluginId is string => pluginId !== null),
+  );
+  return (
+    packagingIssues.length > 0 &&
+    snapshot.issues.every((issue) => {
+      if (isPluginPackagingRuntimeOutputIssue(issue)) {
+        return true;
+      }
+      const pluginId = extractPluginNotFoundIssuePluginId(issue);
+      return pluginId !== null && packagingPluginIds.has(pluginId);
+    })
   );
 }
 

--- a/src/gateway/server-startup-config.recovery.test.ts
+++ b/src/gateway/server-startup-config.recovery.test.ts
@@ -14,50 +14,48 @@ const configMocks = vi.hoisted(() => ({
   isNixMode: { value: false },
 }));
 const pluginManifestRegistry = vi.hoisted(() => ({ plugins: [], diagnostics: [] }));
-const pluginMetadataSnapshot = vi.hoisted(
-  (): PluginMetadataSnapshot => {
-    const emptyOwners = {
-      channels: new Map(),
-      channelConfigs: new Map(),
-      providers: new Map(),
-      modelCatalogProviders: new Map(),
-      cliBackends: new Map(),
-      setupProviders: new Map(),
-      commandAliases: new Map(),
-      contracts: new Map(),
-    };
-    const zeroMetrics = {
-      registrySnapshotMs: 0,
-      manifestRegistryMs: 0,
-      ownerMapsMs: 0,
-      totalMs: 0,
-      indexPluginCount: 0,
-      manifestPluginCount: 0,
-    };
-    return {
+const pluginMetadataSnapshot = vi.hoisted((): PluginMetadataSnapshot => {
+  const emptyOwners = {
+    channels: new Map(),
+    channelConfigs: new Map(),
+    providers: new Map(),
+    modelCatalogProviders: new Map(),
+    cliBackends: new Map(),
+    setupProviders: new Map(),
+    commandAliases: new Map(),
+    contracts: new Map(),
+  };
+  const zeroMetrics = {
+    registrySnapshotMs: 0,
+    manifestRegistryMs: 0,
+    ownerMapsMs: 0,
+    totalMs: 0,
+    indexPluginCount: 0,
+    manifestPluginCount: 0,
+  };
+  return {
+    policyHash: "policy",
+    index: {
+      version: 1,
+      hostContractVersion: "test",
+      compatRegistryVersion: "test",
+      migrationVersion: 1,
       policyHash: "policy",
-      index: {
-        version: 1,
-        hostContractVersion: "test",
-        compatRegistryVersion: "test",
-        migrationVersion: 1,
-        policyHash: "policy",
-        generatedAtMs: 0,
-        installRecords: {},
-        plugins: [],
-        diagnostics: [],
-      },
-      registryDiagnostics: [],
-      manifestRegistry: pluginManifestRegistry,
+      generatedAtMs: 0,
+      installRecords: {},
       plugins: [],
       diagnostics: [],
-      byPluginId: new Map(),
-      normalizePluginId: (pluginId) => pluginId,
-      owners: emptyOwners,
-      metrics: zeroMetrics,
-    };
-  },
-);
+    },
+    registryDiagnostics: [],
+    manifestRegistry: pluginManifestRegistry,
+    plugins: [],
+    diagnostics: [],
+    byPluginId: new Map(),
+    normalizePluginId: (pluginId) => pluginId,
+    owners: emptyOwners,
+    metrics: zeroMetrics,
+  };
+});
 vi.mock("../config/io.js", () => ({
   readConfigFileSnapshot: vi.fn(),
   readConfigFileSnapshotWithPluginMetadata: vi.fn(),
@@ -459,6 +457,98 @@ describe("gateway startup config validation", () => {
     ).rejects.toThrow(
       `Invalid config at ${configPath}.\ngateway.mode: Expected 'local' or 'remote'\nRun "openclaw doctor --fix" to repair, then retry.\nIf startup is still blocked, inspect the adjacent .bak backup before restoring it manually.`,
     );
+  });
+
+  it("does not suggest doctor repair for plugin packaging compiled-output failures", async () => {
+    const invalidSnapshot = buildTestConfigSnapshot({
+      path: configPath,
+      exists: true,
+      raw: `${JSON.stringify({
+        gateway: { mode: "local" },
+        plugins: { slots: { memory: "source-only-pack" } },
+      })}\n`,
+      parsed: {
+        gateway: { mode: "local" },
+        plugins: { slots: { memory: "source-only-pack" } },
+      },
+      valid: false,
+      config: {
+        gateway: { mode: "local" },
+        plugins: { slots: { memory: "source-only-pack" } },
+      } as OpenClawConfig,
+      issues: [
+        {
+          path: "plugins.slots.memory",
+          message: "plugin not found: source-only-pack",
+        },
+      ],
+      warnings: [
+        {
+          path: "plugins",
+          message:
+            "plugin source-only-pack: installed plugin package requires compiled runtime output for TypeScript entry index.ts: expected ./dist/index.js. This is a plugin packaging issue, not a local config problem.",
+        },
+      ],
+      legacyIssues: [],
+    });
+    vi.mocked(configIo.readConfigFileSnapshot).mockResolvedValueOnce(invalidSnapshot);
+
+    const start = loadGatewayStartupConfigSnapshot({
+      minimalTestGateway: true,
+      log: { info: vi.fn(), warn: vi.fn() },
+    });
+    await expect(start).rejects.toThrow(
+      `Invalid config at ${configPath}.\nplugins.slots.memory: plugin not found: source-only-pack\nThis is a plugin packaging issue, not a local config problem.\nUpdate or reinstall the plugin after the publisher ships compiled JavaScript, or disable/uninstall the plugin until then.`,
+    );
+    await start.catch((error: unknown) => {
+      expect(String(error)).not.toContain("openclaw doctor --fix");
+    });
+  });
+
+  it("keeps doctor repair guidance for mixed plugin packaging and core invalidity", async () => {
+    const invalidSnapshot = buildTestConfigSnapshot({
+      path: configPath,
+      exists: true,
+      raw: `${JSON.stringify({
+        gateway: { mode: "invalid" },
+        plugins: { slots: { memory: "source-only-pack" } },
+      })}\n`,
+      parsed: {
+        gateway: { mode: "invalid" },
+        plugins: { slots: { memory: "source-only-pack" } },
+      },
+      valid: false,
+      config: {
+        gateway: { mode: "invalid" },
+        plugins: { slots: { memory: "source-only-pack" } },
+      } as unknown as OpenClawConfig,
+      issues: [
+        {
+          path: "plugins.slots.memory",
+          message: "plugin not found: source-only-pack",
+        },
+        {
+          path: "gateway.mode",
+          message: "Expected 'local' or 'remote'",
+        },
+      ],
+      warnings: [
+        {
+          path: "plugins",
+          message:
+            "plugin source-only-pack: installed plugin package requires compiled runtime output for TypeScript entry index.ts: expected ./dist/index.js.",
+        },
+      ],
+      legacyIssues: [],
+    });
+    vi.mocked(configIo.readConfigFileSnapshot).mockResolvedValueOnce(invalidSnapshot);
+
+    await expect(
+      loadGatewayStartupConfigSnapshot({
+        minimalTestGateway: true,
+        log: { info: vi.fn(), warn: vi.fn() },
+      }),
+    ).rejects.toThrow('Run "openclaw doctor --fix" to repair, then retry.');
   });
 
   it("rejects legacy config entries in Nix mode", async () => {

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -1,5 +1,8 @@
 import { isDeepStrictEqual } from "node:util";
-import { formatInvalidConfigRecoveryHint } from "../cli/config-recovery-hints.js";
+import {
+  formatInvalidConfigRecoveryHint,
+  formatPluginPackagingRuntimeOutputRecoveryHint,
+} from "../cli/config-recovery-hints.js";
 import {
   type ReadConfigFileSnapshotWithPluginMetadataResult,
   readConfigFileSnapshotWithPluginMetadata,
@@ -7,6 +10,7 @@ import {
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import { isNixMode } from "../config/paths.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
+import { isPluginPackagingRuntimeOutputInvalidConfigSnapshot } from "../config/recovery-policy.js";
 import { applyConfigOverrides } from "../config/runtime-overrides.js";
 import type { GatewayAuthConfig, GatewayTailscaleConfig } from "../config/types.gateway.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
@@ -387,8 +391,13 @@ export function assertValidGatewayStartupConfigSnapshot(
     snapshot.issues.length > 0
       ? formatConfigIssueLines(snapshot.issues, "", { normalizeRoot: true }).join("\n")
       : "Unknown validation issue.";
-  const doctorHint = options.includeDoctorHint ? `\n${formatInvalidConfigRecoveryHint()}` : "";
-  throw new Error(`Invalid config at ${snapshot.path}.\n${issues}${doctorHint}`);
+  const recoveryHint =
+    options.includeDoctorHint && isPluginPackagingRuntimeOutputInvalidConfigSnapshot(snapshot)
+      ? `\n${formatPluginPackagingRuntimeOutputRecoveryHint()}`
+      : options.includeDoctorHint
+        ? `\n${formatInvalidConfigRecoveryHint()}`
+        : "";
+  throw new Error(`Invalid config at ${snapshot.path}.\n${issues}${recoveryHint}`);
 }
 
 export async function prepareGatewayStartupConfig(params: {

--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -950,6 +950,12 @@ describe("discoverOpenClawPlugins", () => {
           entry.message.includes("disable/uninstall the plugin"),
       ),
     ).toBe(true);
+    expect(
+      result.diagnostics.some(
+        (entry) =>
+          entry.pluginId === "source-only-pack" && entry.message.includes("openclaw doctor --fix"),
+      ),
+    ).toBe(false);
     expect(result.diagnostics).toHaveLength(1);
   });
 


### PR DESCRIPTION
## Summary

What problem does this PR solve?
- Fixes the remaining #80490 misdirection where plugin packaging failures could still lead startup/config validation users toward the generic `openclaw doctor --fix` recovery hint.

Why does this matter now?
- ClawSweeper found that installed source-only TypeScript plugin packages should remain blocked unless publishers ship compiled JavaScript, but the recovery hint still implied a local doctor repair.

What is the intended outcome?
- Plugin packaging / compiled-runtime-output failures keep the packaging diagnostic and show update/reinstall-after-publisher-fix or disable/uninstall guidance instead of `openclaw doctor --fix`.
- Normal invalid config failures still show the doctor recovery hint.

What is intentionally out of scope?
- No doctor auto-build path for arbitrary third-party plugin source.
- No plugin build-system changes and no changelog edits.

What does success look like?
- Users with a source-only installed plugin package see packaging-specific remediation in config validation and gateway startup, without losing doctor guidance for unrelated invalid config cases.

What should reviewers focus on?
- The classifier in `src/config/recovery-policy.ts`, especially that it only suppresses doctor guidance for compiled-runtime-output packaging diagnostics and same-plugin `plugin not found` fallout.

<details>
<summary>Summary guidance</summary>

This PR description is the contributor's durable explanation of the change. Write it for human maintainers first; ClawSweeper and Barnacle use the same text to understand intent, proof, risk, and current review state.

Describe the intent and outcome in 2-5 bullets. Avoid restating the diff; reviewers and bots can read the changed files.

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

</details>

## Linked context

Which issue does this close?

Closes #80490

Which issues, PRs, or discussions are related?

Related: ClawSweeper guidance in https://github.com/openclaw/openclaw/issues/80490#issuecomment-4416918935

Was this requested by a maintainer or owner?

ClawSweeper guidance requested a focused repair that corrects startup/config guidance without auto-building third-party plugin source.

<details>
<summary>Linked context guidance</summary>

Link the issue, PR, discussion, maintainer request, or owner request that explains why this PR should exist. Maintainer context helps reviewers and automation distinguish intended work from drive-by churn.

</details>

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: source-only installed plugin package referenced from config should fail with plugin packaging guidance, not `openclaw doctor --fix`.
- Real environment tested: Crabbox local-container Linux proof, disposable Docker image `openclaw-issue-80490-proof:local`, provider `local-container`, lease `cbx_0b5f611fb5a6`, slug `silver-shrimp`.
- Exact steps or command run after this patch: created a temporary Linux state dir with an installed `@openclaw/source-only-pack` package whose manifest points at `./index.ts` and no compiled JS, wrote config with `plugins.slots.memory="source-only-pack"`, then ran `pnpm openclaw config validate` and `timeout 30s pnpm openclaw gateway run`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
CONFIG_STATUS=1
OpenClaw config is invalid: /tmp/openclaw-issue-80490-state/openclaw.json
  × plugins.slots.memory: plugin not found: source-only-pack

This is a plugin packaging issue, not a local config problem.
Update or reinstall the plugin after the publisher ships compiled JavaScript, or disable/uninstall the plugin until then.
Inspect with openclaw config validate.

GATEWAY_STATUS=1
Gateway failed to start: Invalid config at /tmp/openclaw-issue-80490-state/openclaw.json.
plugins.slots.memory: plugin not found: source-only-pack
This is a plugin packaging issue, not a local config problem.
Update or reinstall the plugin after the publisher ships compiled JavaScript, or disable/uninstall the plugin until then.. Run openclaw gateway status --deep for diagnostics.
REAL_PROOF_OK issue-80490 plugin packaging startup/config validation hints
```

- Observed result after fix: both real CLI entrypoints failed for the source-only installed plugin package with packaging-specific remediation; grep checks confirmed `openclaw doctor --fix` was absent from both outputs.
- What was not tested: live VPS, live channels, provider accounts, or real third-party plugin registry state.
- Proof limitations or environment constraints: the normal Crabbox local-container sync path failed on this Windows host because rsync was unavailable in the sync shell, and AWS Crabbox was blocked by missing AWS credentials. I used Crabbox local-container with `--no-sync` and a disposable Docker image containing the patched checkout to keep the proof in a real Linux/container lane without touching live runtime state.
- Before evidence (optional but encouraged): ClawSweeper source-level repro in #80490 showed gateway startup still appended `formatInvalidConfigRecoveryHint()` for this failure shape before the patch.

<details>
<summary>Real behavior proof guidance</summary>

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only.

Screenshots are encouraged even for CLI, console, text, or log changes. Terminal screenshots, copied live output, redacted runtime logs, recordings, and linked artifacts count.

If your environment cannot produce the ideal proof, explain that under `Proof limitations or environment constraints` so reviewers and ClawSweeper can direct the next step properly.

Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

</details>

## Tests and validation

Which commands did you run?

```text
node scripts/run-vitest.mjs src/gateway/server-startup-config.recovery.test.ts src/commands/config-validation.test.ts src/cli/config-cli.test.ts src/plugins/discovery.test.ts src/config/recovery-policy.test.ts
pnpm exec oxfmt --check --threads=1 src/cli/config-cli.ts src/cli/config-cli.test.ts src/cli/config-recovery-hints.ts src/commands/config-validation.ts src/commands/config-validation.test.ts src/config/recovery-policy.ts src/config/recovery-policy.test.ts src/gateway/server-startup-config.ts src/gateway/server-startup-config.recovery.test.ts src/plugins/discovery.test.ts
git diff --check
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/cli/config-cli.ts src/cli/config-cli.test.ts src/cli/config-recovery-hints.ts src/commands/config-validation.ts src/commands/config-validation.test.ts src/config/recovery-policy.ts src/config/recovery-policy.test.ts src/gateway/server-startup-config.ts src/gateway/server-startup-config.recovery.test.ts src/plugins/discovery.test.ts
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.issue-80490.rebased.tsbuildinfo
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.issue-80490.rebased.tsbuildinfo
codex review --uncommitted
```

What regression coverage was added or updated?
- Added recovery-policy coverage for plugin packaging snapshots, mixed core invalidity, and unrelated missing-plugin cases.
- Added/updated config validation, config CLI, gateway startup recovery, and plugin discovery tests proving packaging guidance remains while `openclaw doctor --fix` is absent for source-only installed plugin packaging failures.
- Kept normal invalid config coverage proving the doctor hint remains for ordinary invalid configs.

What failed before this fix, if known?
- Gateway startup and config validation recovery paths could still append or print `openclaw doctor --fix` for this packaging failure shape.

If no test was added, why not?
- Tests were added and updated.

<details>
<summary>Testing guidance</summary>

List focused commands, not every incidental check. CI is useful support, but external PRs still need real behavior proof above when behavior changes.

</details>

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No config schema or migration behavior changed; only recovery guidance selection changed.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Over-suppressing the generic doctor hint for mixed or unrelated invalid configs.

How is that risk mitigated?

The classifier requires a compiled-runtime-output plugin packaging diagnostic and only permits same-plugin `plugin not found` fallout; tests cover mixed core invalidity and unrelated missing plugins retaining doctor guidance.

<details>
<summary>Risk guidance</summary>

Use this for author judgment that is not obvious from the diff. ClawSweeper can see touched files, but it cannot know which behavior you think is risky, why the risk is acceptable, or what mitigation reviewers should verify.

</details>

## Current review state

What is the next action?

Review and CI.

What is still waiting on author, maintainer, CI, or external proof?

CI is pending after PR creation; external proof is included above.

Which bot or reviewer comments were addressed?

Addresses ClawSweeper guidance on #80490 by correcting diagnostics/recovery hints rather than auto-building third-party plugin source.

<details>
<summary>Review state guidance</summary>

Keep this as the durable state for review progress. If useful information appears in comments, fold the current next action or blocker back here so maintainers and ClawSweeper do not need to reconstruct state from comment history.

</details>