### PR TITLE
fix(update): avoid duplicate plugin smoke failures

### DIFF
--- a/src/cli/update-cli/plugin-payload-validation.test.ts
+++ b/src/cli/update-cli/plugin-payload-validation.test.ts
@@ -155,6 +155,7 @@ describe("runPluginPayloadSmokeCheck", () => {
     await writePackage(dir, {
       name: "@openclaw/brave-plugin",
       openclaw: { extensions: ["./index.js", " "] },
+      main: "main.js",
     });
     await fs.writeFile(path.join(dir, "index.js"), "export default {};\n", "utf8");
     const result = await runPluginPayloadSmokeCheck({
@@ -168,6 +169,50 @@ describe("runPluginPayloadSmokeCheck", () => {
         reason: "missing-extension-entry",
         detail:
           "Plugin extension entry validation failed: package.json openclaw.extensions[1] must be a non-empty string",
+      },
+    ]);
+  });
+
+  it("reports only extension-entry failure for an empty extensions list even if main is missing", async () => {
+    const dir = path.join(tmpRoot, "brave-empty");
+    await writePackage(dir, {
+      name: "@openclaw/brave-plugin",
+      openclaw: { extensions: [] },
+      main: "dist/index.js",
+    });
+    const result = await runPluginPayloadSmokeCheck({
+      records: { brave: { source: "npm", installPath: dir } },
+      env: {},
+    });
+    expect(result.failures).toStrictEqual([
+      {
+        pluginId: "brave",
+        installPath: dir,
+        reason: "missing-extension-entry",
+        detail:
+          "Plugin extension entry validation failed: package.json openclaw.extensions is empty",
+      },
+    ]);
+  });
+
+  it("reports missing main entry when extension entries are valid", async () => {
+    const dir = path.join(tmpRoot, "brave");
+    await writePackage(dir, {
+      name: "@openclaw/brave-plugin",
+      openclaw: { extensions: ["./index.js"] },
+      main: "dist/index.js",
+    });
+    await fs.writeFile(path.join(dir, "index.js"), "export default {};\n", "utf8");
+    const result = await runPluginPayloadSmokeCheck({
+      records: { brave: { source: "npm", installPath: dir } },
+      env: {},
+    });
+    expect(result.failures).toStrictEqual([
+      {
+        pluginId: "brave",
+        installPath: dir,
+        reason: "missing-main-entry",
+        detail: `Plugin main entry "dist/index.js" not found at ${path.join(dir, "dist/index.js")}`,
       },
     ]);
   });

--- a/src/cli/update-cli/plugin-payload-validation.ts
+++ b/src/cli/update-cli/plugin-payload-validation.ts
@@ -129,6 +129,7 @@ export async function runPluginPayloadSmokeCheck(params: {
             : "package.json openclaw.extensions is empty"
         }`,
       });
+      continue;
     } else if (extensionResolution.status === "ok") {
       const extensionValidation = await validatePackageExtensionEntriesForInstall({
         packageDir: installPath,


### PR DESCRIPTION
## Summary

- Fixes duplicate post-core plugin payload smoke-check failures for malformed `openclaw.extensions` manifests that also declare a missing `main` file.
- Adds the same terminal behavior for `empty`/`invalid` extension-entry failures that already exists for missing package dirs, missing package manifests, and invalid package JSON.
- Keeps the valid-extension path unchanged: when extension entries resolve and validate, the explicit `main` check still runs.
- Intentionally out of scope: changing plugin manifest semantics, changing post-core convergence warning formatting, or editing `CHANGELOG.md` as a contributor.

## AI assistance

This PR was implemented with Codex assistance. I reviewed the change and understand the affected update CLI plugin payload smoke-check path.

## Linked context

Closes #83891.

Related: #84284 was a prior closed PR with the same basic fix shape; it was closed as stale rather than rejected. This PR keeps the narrow fix and tightens regression coverage around the actual manifest contract (`openclaw.extensions: []` is `empty`; malformed arrays are `invalid`).

## Real behavior proof

Behavior addressed: A plugin install record whose package has empty or invalid `openclaw.extensions` plus a declared missing `main` now emits exactly one smoke-check failure for `missing-extension-entry`, instead of also appending `missing-main-entry`.

Real environment tested: Local OpenClaw source checkout on Node 22.22.0, calling the actual exported `runPluginPayloadSmokeCheck` function against real temporary on-disk plugin package fixtures.

Exact steps or command run after this patch:

```bash
node --import tsx - <<'EOF'
const fs = await import("node:fs/promises");
const os = await import("node:os");
const path = await import("node:path");
const { runPluginPayloadSmokeCheck } = await import("./src/cli/update-cli/plugin-payload-validation.ts");

const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-83891-proof-"));
async function writeFixture(name, manifest, files = {}) {
  const dir = path.join(tmp, name);
  await fs.mkdir(dir, { recursive: true });
  await fs.writeFile(path.join(dir, "package.json"), JSON.stringify(manifest), "utf8");
  for (const [relativePath, content] of Object.entries(files)) {
    const target = path.join(dir, relativePath);
    await fs.mkdir(path.dirname(target), { recursive: true });
    await fs.writeFile(target, content, "utf8");
  }
  return dir;
}
const scenarios = [
  {
    name: "empty extensions plus missing main",
    dirName: "empty",
    manifest: { name: "pkg-empty", openclaw: { extensions: [] }, main: "dist/index.js" },
    files: {},
    expected: ["missing-extension-entry"],
  },
  {
    name: "invalid extension entry plus missing main",
    dirName: "invalid",
    manifest: { name: "pkg-invalid", openclaw: { extensions: ["./index.js", " "] }, main: "dist/index.js" },
    files: { "index.js": "export default {};\n" },
    expected: ["missing-extension-entry"],
  },
  {
    name: "valid extension entry plus missing main",
    dirName: "valid",
    manifest: { name: "pkg-valid", openclaw: { extensions: ["./index.js"] }, main: "dist/index.js" },
    files: { "index.js": "export default {};\n" },
    expected: ["missing-main-entry"],
  },
];
try {
  console.log("PROOF_START issue=83891 surface=runPluginPayloadSmokeCheck");
  for (const scenario of scenarios) {
    const dir = await writeFixture(scenario.dirName, scenario.manifest, scenario.files);
    const result = await runPluginPayloadSmokeCheck({ records: { pkg: { source: "npm", installPath: dir } }, env: {} });
    const actual = result.failures.map((failure) => failure.reason);
    const ok = JSON.stringify(actual) === JSON.stringify(scenario.expected);
    console.log(`scenario=${JSON.stringify(scenario.name)} checked=${result.checked.join(",")} failureCount=${result.failures.length} reasons=${actual.join(",")} expected=${scenario.expected.join(",")} status=${ok ? "pass" : "fail"}`);
    if (!ok) throw new Error(`Unexpected failure reasons for ${scenario.name}: ${actual.join(",")}`);
  }
  console.log("PROOF_STATUS=pass");
} finally {
  await fs.rm(tmp, { recursive: true, force: true });
}
EOF
```

Evidence after fix:

```text
PROOF_START issue=83891 surface=runPluginPayloadSmokeCheck
scenario="empty extensions plus missing main" checked=pkg failureCount=1 reasons=missing-extension-entry expected=missing-extension-entry status=pass
scenario="invalid extension entry plus missing main" checked=pkg failureCount=1 reasons=missing-extension-entry expected=missing-extension-entry status=pass
scenario="valid extension entry plus missing main" checked=pkg failureCount=1 reasons=missing-main-entry expected=missing-main-entry status=pass
PROOF_STATUS=pass
```

Observed result after fix: Empty and invalid extension-entry fixtures each return one `missing-extension-entry` failure. The valid-extension fixture still runs the main-entry check and returns one `missing-main-entry` failure.

What was not tested: A full package-update command or gateway restart flow. The changed behavior is isolated to the static smoke-check function, and `runPostCorePluginConvergence` already maps each smoke failure one-for-one into warnings.

Proof limitations or environment constraints: This proof uses a local source checkout and temporary package fixtures rather than a published package update flow.

Before evidence: A pre-patch probe against the same function and an `openclaw.extensions: []` fixture returned `failureReasons: ["missing-extension-entry", "missing-main-entry"]` and `failureCount: 2`.

## Root Cause

`runPluginPayloadSmokeCheck` pushed a `missing-extension-entry` failure for `extensionResolution.status === "invalid" || "empty"`, but then continued executing the same record and reached the declared-`main` check. If that `main` file was also absent, the same plugin produced a second `missing-main-entry` failure.

## Dependency contract

This depends on OpenClaw's internal manifest helper contract in `src/plugins/manifest.ts`: `resolvePackageExtensionEntries` returns `missing` for absent `openclaw` / absent `openclaw.extensions`, `empty` for `openclaw.extensions: []`, `invalid` for non-array or malformed entries, and `ok` for normalized non-empty entries. The patch only short-circuits `empty` and `invalid`; `missing` remains permissive and `ok` still falls through to the `main` check.

## Regression Test Plan

- Added coverage for `openclaw.extensions: []` plus missing `main`, expecting exactly one `missing-extension-entry`.
- Updated invalid extension-entry coverage so it also declares a missing `main`, proving that path does not double-count either.
- Added coverage that a valid extension entry plus missing `main` still reports `missing-main-entry`.

## Security Impact

No security, auth, secrets, network, sandbox, or tool-execution behavior changes. This only changes local static validation control flow and colocated tests.

## Human Verification

I reviewed the code path, the manifest helper contract, the prior closed PR, the issue's bot review, the focused tests, `check:changed`, Codex review, and the runtime proof output.

## CODEOWNERS / owner review

No explicit CODEOWNERS entry matches `src/cli/update-cli/plugin-payload-validation.ts` or its colocated test. Normal CLI/update reviewer judgment applies; likely context owners are maintainers familiar with plugin update convergence.

## Changelog

No `CHANGELOG.md` edit as a contributor.

## Review conversations

No review conversations exist on this PR yet. Local `codex review --base origin/main` reported no actionable regressions.

## Risks

The main risk is hiding a useful `missing-main-entry` diagnostic. This is mitigated by only continuing after terminal `empty`/`invalid` extension-entry failures, plus a regression test that proves valid extension entries still run the `main` check.

## Behavior tradeoffs

Malformed extension metadata is now treated as the primary smoke-check failure for that plugin record, so a simultaneously missing `main` file is not also reported in the same pass. This favors one canonical actionable diagnostic over duplicate per-plugin warnings.

## Scope boundaries

The patch does not change absent-extension behavior, valid-extension behavior, post-core convergence warning mapping, plugin installation validation, plugin discovery, or manifest parsing.

## Validation

- `node scripts/run-vitest.mjs src/cli/update-cli/plugin-payload-validation.test.ts` - passed, 21 tests.
- `pnpm changed:lanes --json` - lanes `core`, `coreTests`.
- `git diff --check` - passed.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm check:changed` - passed.
- `codex review --base origin/main` - no actionable regressions; review also reran the focused Vitest file.
- Runtime proof above - passed.
