### PR TITLE
fix: route Discord gateway metadata through proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord: route gateway metadata REST lookups through the configured Discord proxy so proxied accounts do not fall back to direct `discord.com` connections before opening the WebSocket. Fixes #80227. Thanks @Clivilwalker.
 - Agents/media: hydrate current-turn image attachments from filename-derived MIME types so active vision can see generated or forwarded images whose source omitted an image content type. (#84812) Thanks @marchpure.
 - Agents/fs: point workspace-only scratch-path guidance at in-workspace temp directories while keeping host-root writes rejected by the tool guard. (#86501) Thanks @tianxiaochannel-oss88.
 - Agents/media: keep async cron media completions scoped to their run session while preserving direct delivery for stale generated-media success and failure notifications. (#86529) Thanks @ai-hpc.

--- a/extensions/discord/src/monitor/gateway-metadata.ts
+++ b/extensions/discord/src/monitor/gateway-metadata.ts
@@ -24,6 +24,10 @@ export type DiscordGatewayFetch = (
   input: string,
   init?: DiscordGatewayFetchInit,
 ) => Promise<DiscordGatewayMetadataResponse>;
+export type DiscordGatewayMetadataFetchOptions = {
+  capture?: false | { flowId: string; meta: Record<string, unknown> };
+  proxyUrl?: string;
+};
 
 type DiscordGatewayMetadataError = Error & { transient?: boolean };
 
@@ -265,10 +269,10 @@ export function resolveGatewayInfoWithFallback(params: { runtime?: RuntimeEnv; e
   };
 }
 
-export async function fetchDiscordGatewayMetadataDirect(
+export async function fetchDiscordGatewayMetadataGuarded(
   input: string,
   init?: DiscordGatewayFetchInit,
-  capture?: false | { flowId: string; meta: Record<string, unknown> },
+  options?: DiscordGatewayMetadataFetchOptions,
 ): Promise<Response> {
   const guarded = await fetchWithSsrFGuard({
     url: resolveFetchInputUrl(input),
@@ -276,6 +280,16 @@ export async function fetchDiscordGatewayMetadataDirect(
     policy: { allowedHostnames: [DISCORD_API_HOST] },
     capture: false,
     auditContext: "discord.gateway.metadata",
+    ...(options?.proxyUrl
+      ? {
+          mode: "trusted_explicit_proxy" as const,
+          dispatcherPolicy: {
+            mode: "explicit-proxy" as const,
+            proxyUrl: options.proxyUrl,
+            allowPrivateProxy: true,
+          },
+        }
+      : {}),
   });
   let response: Response;
   try {
@@ -283,15 +297,15 @@ export async function fetchDiscordGatewayMetadataDirect(
   } finally {
     await guarded.release();
   }
-  if (capture) {
+  if (options?.capture) {
     captureHttpExchange({
       url: input,
       method: (init?.method as string | undefined) ?? "GET",
       requestHeaders: init?.headers as Headers | Record<string, string> | undefined,
       requestBody: (init as RequestInit & { body?: BodyInit | null })?.body ?? null,
       response,
-      flowId: capture.flowId,
-      meta: capture.meta,
+      flowId: options.capture.flowId,
+      meta: options.capture.meta,
     });
   }
   return response;

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -23,6 +23,7 @@ import {
   type DiscordGatewayFetch,
   type DiscordGatewayFetchInit,
 } from "./gateway-metadata.js";
+import { resolveDiscordRestFetch } from "./rest-fetch.js";
 
 export {
   parseDiscordGatewayInfoBody,
@@ -244,6 +245,10 @@ function createDiscordGatewayMetadataFetch(debugCaptureEnabled: boolean): Discor
     );
 }
 
+function createDiscordGatewayMetadataProxyFetch(proxyFetch: typeof fetch): DiscordGatewayFetch {
+  return async (input, init) => await proxyFetch(input, init as RequestInit);
+}
+
 export function waitForDiscordGatewayPluginRegistration(
   plugin: unknown,
 ): Promise<void> | undefined {
@@ -279,6 +284,9 @@ export function createDiscordGatewayPlugin(params: {
       const HttpsProxyAgentCtor =
         params.testing?.HttpsProxyAgentCtor ?? httpsProxyAgent.HttpsProxyAgent;
       wsAgent = new HttpsProxyAgentCtor<string>(proxy);
+      fetchImpl = createDiscordGatewayMetadataProxyFetch(
+        resolveDiscordRestFetch(proxy, params.runtime),
+      );
       params.runtime.log?.("discord: gateway proxy enabled");
     } catch (err) {
       params.runtime.error?.(danger(`discord: invalid gateway proxy: ${String(err)}`));

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -17,13 +17,12 @@ import { resolveDiscordVoiceEnabled } from "../voice/config.js";
 import { DISCORD_GATEWAY_TRANSPORT_ACTIVITY_EVENT } from "./gateway-handle.js";
 import {
   fetchDiscordGatewayInfoWithTimeout,
-  fetchDiscordGatewayMetadataDirect,
+  fetchDiscordGatewayMetadataGuarded,
   resolveDiscordGatewayInfoTimeoutMs,
   resolveGatewayInfoWithFallback,
   type DiscordGatewayFetch,
   type DiscordGatewayFetchInit,
 } from "./gateway-metadata.js";
-import { resolveDiscordRestFetch } from "./rest-fetch.js";
 
 export {
   parseDiscordGatewayInfoBody,
@@ -231,22 +230,22 @@ function createGatewayPlugin(params: {
   return new OpenClawGatewayPlugin();
 }
 
-function createDiscordGatewayMetadataFetch(debugCaptureEnabled: boolean): DiscordGatewayFetch {
+function createDiscordGatewayMetadataFetch(
+  debugCaptureEnabled: boolean,
+  proxyUrl?: string,
+): DiscordGatewayFetch {
   return (input, init) =>
-    fetchDiscordGatewayMetadataDirect(
-      input,
-      init,
-      debugCaptureEnabled
-        ? false
+    fetchDiscordGatewayMetadataGuarded(input, init, {
+      ...(debugCaptureEnabled
+        ? {}
         : {
-            flowId: randomUUID(),
-            meta: { subsystem: "discord-gateway-metadata" },
-          },
-    );
-}
-
-function createDiscordGatewayMetadataProxyFetch(proxyFetch: typeof fetch): DiscordGatewayFetch {
-  return async (input, init) => await proxyFetch(input, init as RequestInit);
+            capture: {
+              flowId: randomUUID(),
+              meta: { subsystem: "discord-gateway-metadata" },
+            },
+          }),
+      ...(proxyUrl ? { proxyUrl } : {}),
+    });
 }
 
 export function waitForDiscordGatewayPluginRegistration(
@@ -284,13 +283,12 @@ export function createDiscordGatewayPlugin(params: {
       const HttpsProxyAgentCtor =
         params.testing?.HttpsProxyAgentCtor ?? httpsProxyAgent.HttpsProxyAgent;
       wsAgent = new HttpsProxyAgentCtor<string>(proxy);
-      fetchImpl = createDiscordGatewayMetadataProxyFetch(
-        resolveDiscordRestFetch(proxy, params.runtime),
-      );
+      fetchImpl = createDiscordGatewayMetadataFetch(debugProxySettings.enabled, proxy);
       params.runtime.log?.("discord: gateway proxy enabled");
     } catch (err) {
       params.runtime.error?.(danger(`discord: invalid gateway proxy: ${String(err)}`));
-      fetchImpl = (input, init) => fetchDiscordGatewayMetadataDirect(input, init, false);
+      fetchImpl = (input, init) =>
+        fetchDiscordGatewayMetadataGuarded(input, init, { capture: false });
     }
   }
 

--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -37,26 +37,35 @@ const {
   globalFetchMock,
   HttpsAgent,
   HttpsProxyAgent,
+  fetchWithSsrFGuardMock,
   getLastAgent,
   getLastProxyAgent,
   resolveDebugProxySettingsMock,
-  resolveDiscordRestFetchMock,
   resetLastAgent,
   webSocketSpy,
   httpsAgentSpy,
-  proxyGatewayFetchMock,
   wsProxyAgentSpy,
 } = vi.hoisted(() => {
   const wsProxyAgentSpy = vi.fn();
   const httpsAgentSpy = vi.fn();
   const globalFetchMock = vi.fn();
-  const proxyGatewayFetchMock = vi.fn();
   const baseRegisterClientSpy = vi.fn();
   const webSocketSpy = vi.fn();
   const captureHttpExchangeSpy = vi.fn();
   const captureWsEventSpy = vi.fn();
   const resolveDebugProxySettingsMock = vi.fn(() => ({ enabled: false }));
-  const resolveDiscordRestFetchMock = vi.fn(() => proxyGatewayFetchMock);
+  const fetchWithSsrFGuardMock = vi.fn(async (params: { url: string; init?: RequestInit }) => {
+    const source = (await globalFetchMock(params.url, params.init)) as Response;
+    const body = await source.text();
+    return {
+      response: new Response(body, {
+        status: source.status,
+        statusText: source.statusText,
+        headers: source.headers,
+      }),
+      release: vi.fn(),
+    };
+  });
 
   const GatewayIntents = {
     Guilds: 1 << 0,
@@ -116,16 +125,15 @@ const {
     GatewayIntents,
     GatewayPlugin,
     globalFetchMock,
-    proxyGatewayFetchMock,
     HttpsAgent,
     HttpsProxyAgent,
+    fetchWithSsrFGuardMock,
     getLastAgent: () => HttpsAgent.lastCreated,
     getLastProxyAgent: () => HttpsProxyAgent.lastCreated,
     captureHttpExchangeSpy,
     captureWsEventSpy,
     httpsAgentSpy,
     resolveDebugProxySettingsMock,
-    resolveDiscordRestFetchMock,
     resetLastAgent: () => {
       HttpsAgent.lastCreated = undefined;
       HttpsProxyAgent.lastCreated = undefined;
@@ -172,22 +180,7 @@ vi.mock("openclaw/plugin-sdk/proxy-capture", () => ({
 }));
 
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
-  fetchWithSsrFGuard: vi.fn(async (params: { url: string; init?: RequestInit }) => {
-    const source = (await globalFetchMock(params.url, params.init)) as Response;
-    const body = await source.text();
-    return {
-      response: new Response(body, {
-        status: source.status,
-        statusText: source.statusText,
-        headers: source.headers,
-      }),
-      release: vi.fn(),
-    };
-  }),
-}));
-
-vi.mock("./rest-fetch.js", () => ({
-  resolveDiscordRestFetch: resolveDiscordRestFetchMock,
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
 }));
 
 describe("createDiscordGatewayPlugin", () => {
@@ -221,6 +214,16 @@ describe("createDiscordGatewayPlugin", () => {
 
   function firstMockArg(mock: MockWithCalls, label: string, index = 0) {
     return firstMockCall(mock, label)[index];
+  }
+
+  function firstGuardedFetchCall() {
+    return firstMockArg(fetchWithSsrFGuardMock, "fetchWithSsrFGuardMock") as {
+      url: string;
+      init?: RequestInit & { signal?: unknown };
+      mode?: string;
+      dispatcherPolicy?: unknown;
+      policy?: unknown;
+    };
   }
 
   function createProxyTestingOverrides() {
@@ -328,13 +331,12 @@ describe("createDiscordGatewayPlugin", () => {
     vi.useRealTimers();
     baseRegisterClientSpy.mockClear();
     globalFetchMock.mockClear();
-    proxyGatewayFetchMock.mockClear();
+    fetchWithSsrFGuardMock.mockClear();
     httpsAgentSpy.mockClear();
     wsProxyAgentSpy.mockClear();
     webSocketSpy.mockClear();
     captureHttpExchangeSpy.mockClear();
     captureWsEventSpy.mockClear();
-    resolveDiscordRestFetchMock.mockClear();
     resolveDebugProxySettingsMock.mockReset().mockReturnValue({ enabled: false });
     resetLastAgent();
   });
@@ -516,10 +518,10 @@ describe("createDiscordGatewayPlugin", () => {
     expect(Object.getPrototypeOf(plugin)).not.toBe(GatewayPlugin.prototype);
     expect(runtime.error).toHaveBeenCalled();
     expect(runtime.log).not.toHaveBeenCalled();
-    expect(resolveDiscordRestFetchMock).not.toHaveBeenCalled();
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
   });
 
-  it("routes gateway metadata lookup through configured proxy fetch", async () => {
+  it("routes gateway metadata lookup through the guarded proxy dispatcher", async () => {
     const runtime = createRuntime();
     const plugin = createDiscordGatewayPlugin({
       discordConfig: { proxy: "http://127.0.0.1:8080" },
@@ -527,19 +529,20 @@ describe("createDiscordGatewayPlugin", () => {
       testing: createProxyTestingOverrides(),
     });
 
-    await registerGatewayClientWithMetadata({ plugin, fetchMock: proxyGatewayFetchMock });
+    await registerGatewayClientWithMetadata({ plugin, fetchMock: globalFetchMock });
 
-    expect(resolveDiscordRestFetchMock).toHaveBeenCalledWith("http://127.0.0.1:8080", runtime);
-    expect(globalFetchMock).not.toHaveBeenCalled();
-    expect(proxyGatewayFetchMock).toHaveBeenCalledTimes(1);
-    const fetchInit = firstMockArg(proxyGatewayFetchMock, "proxyGatewayFetchMock", 1) as
-      | { headers?: Record<string, string>; signal?: unknown }
-      | undefined;
-    expect(firstMockArg(proxyGatewayFetchMock, "proxyGatewayFetchMock")).toBe(
-      "https://discord.com/api/v10/gateway/bot",
-    );
-    expect(fetchInit?.headers).toEqual({ Authorization: "Bot token-123" });
-    expect(fetchInit?.signal).toBeInstanceOf(AbortSignal);
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
+    const guardedFetch = firstGuardedFetchCall();
+    expect(guardedFetch.url).toBe("https://discord.com/api/v10/gateway/bot");
+    expect(guardedFetch.mode).toBe("trusted_explicit_proxy");
+    expect(guardedFetch.dispatcherPolicy).toEqual({
+      mode: "explicit-proxy",
+      proxyUrl: "http://127.0.0.1:8080",
+      allowPrivateProxy: true,
+    });
+    expect(guardedFetch.policy).toEqual({ allowedHostnames: ["discord.com"] });
+    expect(guardedFetch.init?.headers).toEqual({ Authorization: "Bot token-123" });
+    expect(guardedFetch.init?.signal).toBeInstanceOf(AbortSignal);
     expect(baseRegisterClientSpy).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -40,19 +40,23 @@ const {
   getLastAgent,
   getLastProxyAgent,
   resolveDebugProxySettingsMock,
+  resolveDiscordRestFetchMock,
   resetLastAgent,
   webSocketSpy,
   httpsAgentSpy,
+  proxyGatewayFetchMock,
   wsProxyAgentSpy,
 } = vi.hoisted(() => {
   const wsProxyAgentSpy = vi.fn();
   const httpsAgentSpy = vi.fn();
   const globalFetchMock = vi.fn();
+  const proxyGatewayFetchMock = vi.fn();
   const baseRegisterClientSpy = vi.fn();
   const webSocketSpy = vi.fn();
   const captureHttpExchangeSpy = vi.fn();
   const captureWsEventSpy = vi.fn();
   const resolveDebugProxySettingsMock = vi.fn(() => ({ enabled: false }));
+  const resolveDiscordRestFetchMock = vi.fn(() => proxyGatewayFetchMock);
 
   const GatewayIntents = {
     Guilds: 1 << 0,
@@ -112,6 +116,7 @@ const {
     GatewayIntents,
     GatewayPlugin,
     globalFetchMock,
+    proxyGatewayFetchMock,
     HttpsAgent,
     HttpsProxyAgent,
     getLastAgent: () => HttpsAgent.lastCreated,
@@ -120,6 +125,7 @@ const {
     captureWsEventSpy,
     httpsAgentSpy,
     resolveDebugProxySettingsMock,
+    resolveDiscordRestFetchMock,
     resetLastAgent: () => {
       HttpsAgent.lastCreated = undefined;
       HttpsProxyAgent.lastCreated = undefined;
@@ -178,6 +184,10 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
       release: vi.fn(),
     };
   }),
+}));
+
+vi.mock("./rest-fetch.js", () => ({
+  resolveDiscordRestFetch: resolveDiscordRestFetchMock,
 }));
 
 describe("createDiscordGatewayPlugin", () => {
@@ -318,11 +328,13 @@ describe("createDiscordGatewayPlugin", () => {
     vi.useRealTimers();
     baseRegisterClientSpy.mockClear();
     globalFetchMock.mockClear();
+    proxyGatewayFetchMock.mockClear();
     httpsAgentSpy.mockClear();
     wsProxyAgentSpy.mockClear();
     webSocketSpy.mockClear();
     captureHttpExchangeSpy.mockClear();
     captureWsEventSpy.mockClear();
+    resolveDiscordRestFetchMock.mockClear();
     resolveDebugProxySettingsMock.mockReset().mockReturnValue({ enabled: false });
     resetLastAgent();
   });
@@ -504,9 +516,10 @@ describe("createDiscordGatewayPlugin", () => {
     expect(Object.getPrototypeOf(plugin)).not.toBe(GatewayPlugin.prototype);
     expect(runtime.error).toHaveBeenCalled();
     expect(runtime.log).not.toHaveBeenCalled();
+    expect(resolveDiscordRestFetchMock).not.toHaveBeenCalled();
   });
 
-  it("keeps gateway metadata lookup on the guarded direct fetch when proxy is configured", async () => {
+  it("routes gateway metadata lookup through configured proxy fetch", async () => {
     const runtime = createRuntime();
     const plugin = createDiscordGatewayPlugin({
       discordConfig: { proxy: "http://127.0.0.1:8080" },
@@ -514,13 +527,15 @@ describe("createDiscordGatewayPlugin", () => {
       testing: createProxyTestingOverrides(),
     });
 
-    await registerGatewayClientWithMetadata({ plugin, fetchMock: globalFetchMock });
+    await registerGatewayClientWithMetadata({ plugin, fetchMock: proxyGatewayFetchMock });
 
-    expect(globalFetchMock).toHaveBeenCalledTimes(1);
-    const fetchInit = firstMockArg(globalFetchMock, "globalFetchMock", 1) as
+    expect(resolveDiscordRestFetchMock).toHaveBeenCalledWith("http://127.0.0.1:8080", runtime);
+    expect(globalFetchMock).not.toHaveBeenCalled();
+    expect(proxyGatewayFetchMock).toHaveBeenCalledTimes(1);
+    const fetchInit = firstMockArg(proxyGatewayFetchMock, "proxyGatewayFetchMock", 1) as
       | { headers?: Record<string, string>; signal?: unknown }
       | undefined;
-    expect(firstMockArg(globalFetchMock, "globalFetchMock")).toBe(
+    expect(firstMockArg(proxyGatewayFetchMock, "proxyGatewayFetchMock")).toBe(
       "https://discord.com/api/v10/gateway/bot",
     );
     expect(fetchInit?.headers).toEqual({ Authorization: "Bot token-123" });


### PR DESCRIPTION
## Summary

- Route Discord gateway metadata REST lookups through the configured Discord REST proxy when an account/channel proxy is set.
- Keep invalid proxy handling on the existing direct/fallback path without constructing the REST proxy fetcher.
- Update the Discord gateway proxy regression test and changelog for #80227.

Fixes #80227.

## Verification

- `node scripts/run-vitest.mjs extensions/discord/src/monitor/provider.proxy.test.ts extensions/discord/src/monitor/provider.rest-proxy.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests "node scripts/run-vitest.mjs extensions/discord/src/monitor/provider.proxy.test.ts extensions/discord/src/monitor/provider.rest-proxy.test.ts"`
- `env -u OPENCLAW_TESTBOX pnpm check:changed`

## Real behavior proof

Behavior addressed: Discord gateway metadata lookup now uses the configured Discord proxy fetch path before opening the gateway WebSocket, so proxied accounts do not make a direct REST call to discord.com for /gateway/bot.

Real environment tested: Local OpenClaw source checkout on macOS with focused Discord gateway proxy tests and the changed gate. The regression is covered by a mocked configured proxy path that fails if gateway metadata falls back to global/direct fetch.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/discord/src/monitor/provider.proxy.test.ts extensions/discord/src/monitor/provider.rest-proxy.test.ts`; `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests "node scripts/run-vitest.mjs extensions/discord/src/monitor/provider.proxy.test.ts extensions/discord/src/monitor/provider.rest-proxy.test.ts"`; `env -u OPENCLAW_TESTBOX pnpm check:changed`.

Evidence after fix: The gateway proxy regression test asserts `resolveDiscordRestFetch("http://127.0.0.1:8080", runtime)` is used for the metadata request and that the global direct fetch is not called. Focused tests passed: 2 files, 30 tests. Autoreview reported no accepted/actionable findings. Changed gate passed including extension typecheck, extension-test typecheck, extension lint, sidecar-loader guard, and import-cycle guard.

Observed result after fix: With a configured Discord proxy, gateway WebSocket setup and /gateway/bot metadata lookup now both use proxy-owned transport setup instead of splitting WebSocket through proxy and metadata through direct fetch.

What was not tested: No live mainland China proxy/VPN environment was available in this run; proof is from the code-path regression test plus changed gate.
