### PR TITLE
fix(codex): recover stale preflight bindings

### DIFF
--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -36,7 +36,9 @@ function maybeCompactCodexAppServerSession(
   );
 }
 
-async function writeTestBinding(options: { authProfileId?: string } = {}): Promise<string> {
+async function writeTestBinding(
+  options: Partial<Parameters<typeof writeCodexAppServerBinding>[1]> = {},
+): Promise<string> {
   const sessionFile = path.join(tempDir, "session.jsonl");
   await writeCodexAppServerBinding(sessionFile, {
     threadId: "thread-1",
@@ -211,18 +213,30 @@ describe("maybeCompactCodexAppServerSession", () => {
     expect(result.result).toBeUndefined();
   });
 
-  it("clears stale thread bindings and reports failed native compaction", async () => {
+  it("preserves stale thread binding metadata for recovery and reports failed native compaction", async () => {
     const fake = createFakeCodexClient();
     fake.request.mockRejectedValueOnce(new Error("thread not found: thread-1"));
     setCodexAppServerClientFactoryForTest(async () => fake.client);
-    const sessionFile = await writeTestBinding();
+    const sessionFile = await writeTestBinding({
+      authProfileId: "openai-codex:work",
+      model: "gpt-5.5-mini",
+      approvalPolicy: "on-request",
+      sandbox: "workspace-write",
+      serviceTier: "priority",
+    });
 
     const result = requireCompactResult(
       await startCompaction(sessionFile, { currentTokenCount: 456 }),
     );
 
     expect(fake.request).toHaveBeenCalledWith("thread/compact/start", { threadId: "thread-1" });
-    expect(await readCodexAppServerBinding(sessionFile)).toBeUndefined();
+    const preservedBinding = await readCodexAppServerBinding(sessionFile);
+    expect(preservedBinding?.threadId).toBe("thread-1");
+    expect(preservedBinding?.authProfileId).toBe("openai-codex:work");
+    expect(preservedBinding?.model).toBe("gpt-5.5-mini");
+    expect(preservedBinding?.approvalPolicy).toBe("on-request");
+    expect(preservedBinding?.sandbox).toBe("workspace-write");
+    expect(preservedBinding?.serviceTier).toBe("priority");
     expect(result.ok).toBe(false);
     expect(result.compacted).toBe(false);
     expect(result.reason).toBe("thread not found: thread-1");

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -10,7 +10,7 @@ import {
 import { resolveCodexAppServerRuntimeOptions } from "./config.js";
 import type { JsonObject } from "./protocol.js";
 import { resolveCodexNativeExecutionBlock } from "./sandbox-guard.js";
-import { clearCodexAppServerBinding, readCodexAppServerBinding } from "./session-binding.js";
+import { readCodexAppServerBinding } from "./session-binding.js";
 
 const warnedIgnoredCompactionOverrides = new Set<string>();
 
@@ -170,7 +170,6 @@ async function compactCodexNativeThread(
     });
   } catch (error) {
     if (isCodexThreadNotFoundError(error)) {
-      await clearCodexAppServerBinding(params.sessionFile, { config: params.config });
       return failedCodexThreadBindingCompactionResult(params, {
         threadId: binding.threadId,
         reason: formatCompactionError(error),

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -589,6 +589,84 @@ describe("codex conversation binding", () => {
     expect(savedBinding).not.toHaveProperty("modelProvider");
   });
 
+  it("creates a fresh thread when recovery finds the binding already cleared", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    const notificationHandlers: Array<(notification: Record<string, unknown>) => void> = [];
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
+        requests.push({ method, params: requestParams });
+        if (method === "thread/start") {
+          return {
+            thread: { id: "thread-new", sessionId: "session-1", cwd: tempDir },
+            model: "gpt-5.5-mini",
+          };
+        }
+        if (method === "turn/start" && requestParams.threadId === "thread-new") {
+          setImmediate(() => {
+            for (const handler of notificationHandlers) {
+              handler({
+                method: "turn/completed",
+                params: {
+                  threadId: "thread-new",
+                  turn: {
+                    id: "turn-new",
+                    status: "completed",
+                    items: [{ id: "assistant-1", type: "agentMessage", text: "Recovered fresh" }],
+                  },
+                },
+              });
+            }
+          });
+          return { turn: { id: "turn-new" } };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      }),
+      addNotificationHandler: vi.fn((handler) => {
+        notificationHandlers.push(handler);
+        return () => undefined;
+      }),
+      addRequestHandler: vi.fn(() => () => undefined),
+    });
+
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "hi again",
+        bodyForAgent: "hi again",
+        channel: "telegram",
+        isGroup: true,
+        commandAuthorized: true,
+      },
+      {
+        channelId: "telegram",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "redacted-group",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile,
+            workspaceDir: tempDir,
+          },
+        },
+      },
+      { timeoutMs: 500 },
+    );
+
+    expect(result).toEqual({ handled: true, reply: { text: "Recovered fresh" } });
+    expect(requests.map((request) => request.method)).toEqual(["thread/start", "turn/start"]);
+    expect(requests[1]?.params.threadId).toBe("thread-new");
+    const savedBinding = JSON.parse(
+      await fs.readFile(`${sessionFile}.codex-app-server.json`, "utf8"),
+    );
+    expect(savedBinding.threadId).toBe("thread-new");
+  });
+
   it("returns a clean failure reply when app-server turn start rejects", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const agentDir = path.join(tempDir, "agents", "bot-b", "agent");

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -529,7 +529,11 @@ async function runBoundTurnWithMissingThreadRecovery(params: {
 }
 
 function isCodexThreadNotFoundError(error: unknown): boolean {
-  return /\bthread not found:/iu.test(formatErrorMessage(error));
+  const message = formatErrorMessage(error);
+  return (
+    /\bthread not found:/iu.test(message) ||
+    /\bbound Codex conversation has no thread binding\b/u.test(message)
+  );
 }
 
 function enqueueBoundTurn<T>(key: string, run: () => Promise<T>): Promise<T> {

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -699,6 +699,115 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactCall.sandboxSessionKey).toBe("agent:main:telegram:default:direct:12345");
   });
 
+  it.each([
+    ["stale_thread_binding", "thread not found: <codex-thread-id>"],
+    ["missing_thread_binding", "no thread binding for session"],
+  ])(
+    "continues after recoverable native harness %s failure during preflight compaction",
+    async (failureReason, reason) => {
+      const sessionFile = path.join(rootDir, "session.jsonl");
+      await fs.writeFile(
+        sessionFile,
+        `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
+        "utf8",
+      );
+      registerMemoryFlushPlanResolverForTest(() => ({
+        softThresholdTokens: 1,
+        forceFlushTranscriptBytes: 1_000_000_000,
+        reserveTokensFloor: 0,
+        prompt: "Pre-compaction memory flush.\nNO_REPLY",
+        systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+        relativePath: "memory/2023-11-14.md",
+      }));
+      compactEmbeddedPiSessionMock.mockResolvedValueOnce({
+        ok: false,
+        compacted: false,
+        reason,
+        failure: { reason: failureReason },
+      });
+      const sessionEntry: SessionEntry = {
+        sessionId: "session",
+        sessionFile,
+        updatedAt: Date.now(),
+        totalTokensFresh: false,
+      };
+      const sessionStore = { "agent:main:telegram:group:redacted": sessionEntry };
+
+      const entry = await runPreflightCompactionIfNeeded({
+        cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+        followupRun: createTestFollowupRun({
+          sessionId: "session",
+          sessionFile,
+          sessionKey: "agent:main:telegram:group:redacted",
+        }),
+        defaultModel: "anthropic/claude-opus-4-6",
+        agentCfgContextTokens: 100,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:telegram:group:redacted",
+        storePath: path.join(rootDir, "sessions.json"),
+        isHeartbeat: false,
+        replyOperation: createReplyOperation(),
+      });
+
+      expect(entry).toBe(sessionEntry);
+      expect(compactEmbeddedPiSessionMock).toHaveBeenCalledTimes(1);
+      expect(incrementCompactionCountMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("still fails preflight compaction for non-binding native harness failures", async () => {
+    const sessionFile = path.join(rootDir, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
+      "utf8",
+    );
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 1,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 0,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    compactEmbeddedPiSessionMock.mockResolvedValueOnce({
+      ok: false,
+      compacted: false,
+      reason: "auth profile mismatch",
+      failure: { reason: "auth_profile_mismatch" },
+    });
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokensFresh: false,
+    };
+    const sessionStore = { "agent:main:telegram:group:redacted": sessionEntry };
+
+    await expect(
+      runPreflightCompactionIfNeeded({
+        cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+        followupRun: createTestFollowupRun({
+          sessionId: "session",
+          sessionFile,
+          sessionKey: "agent:main:telegram:group:redacted",
+        }),
+        defaultModel: "anthropic/claude-opus-4-6",
+        agentCfgContextTokens: 100,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:telegram:group:redacted",
+        storePath: path.join(rootDir, "sessions.json"),
+        isHeartbeat: false,
+        replyOperation: createReplyOperation(),
+      }),
+    ).rejects.toThrow("Preflight compaction required but failed: auth profile mismatch");
+
+    expect(compactEmbeddedPiSessionMock).toHaveBeenCalledTimes(1);
+    expect(incrementCompactionCountMock).not.toHaveBeenCalled();
+  });
+
   it("updates the active preflight run after transcript rotation", async () => {
     const sessionFile = path.join(rootDir, "session.jsonl");
     const successorFile = path.join(rootDir, "session-rotated.jsonl");

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -124,6 +124,14 @@ const memoryDeps = {
   now: () => Date.now(),
 };
 
+function isRecoverableNativeHarnessBindingFailure(result: unknown): boolean {
+  if (!result || typeof result !== "object") {
+    return false;
+  }
+  const failure = (result as { failure?: { reason?: unknown } }).failure;
+  return failure?.reason === "missing_thread_binding" || failure?.reason === "stale_thread_binding";
+}
+
 export function setAgentRunnerMemoryTestDeps(overrides?: Partial<typeof memoryDeps>): void {
   Object.assign(memoryDeps, {
     runWithModelFallback,
@@ -802,6 +810,12 @@ export async function runPreflightCompactionIfNeeded(params: {
   if (!result?.ok || !result.compacted) {
     const reason = result?.reason ?? "not_compacted";
     logVerbose(`preflightCompaction failed: sessionKey=${params.sessionKey} reason=${reason}`);
+    if (isRecoverableNativeHarnessBindingFailure(result)) {
+      logVerbose(
+        `preflightCompaction continuing after recoverable native harness binding failure: sessionKey=${params.sessionKey} reason=${reason}`,
+      );
+      return entry ?? params.sessionEntry;
+    }
     throw new Error(`Preflight compaction required but failed: ${reason}`);
   }
 


### PR DESCRIPTION
## Summary

Fixes #86211.

This is the maintainer-owned replacement for the closed contributor PR #86216, with Paul Frederiksen preserved as co-author in the commit.

Changes:
- keeps stale Codex app-server thread bindings long enough for recovery to preserve auth/model/sandbox metadata
- lets auto-reply preflight continue only for structured missing or stale native harness binding failures
- lets Codex conversation binding recover from an already-cleared binding by creating a fresh thread
- keeps non-binding compaction failures fail-closed and visible

## Verification

- node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-memory.test.ts extensions/codex/src/app-server/compact.test.ts extensions/codex/src/conversation-binding.test.ts
- env -u OPENCLAW_TESTBOX -u OPENCLAW_TESTBOX_REMOTE_RUN pnpm check:changed
- git diff --check
- /Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local

## Real behavior proof

Behavior addressed: Telegram/Codex inbound dispatch no longer aborts solely because preflight compaction encounters a structured stale_thread_binding or missing_thread_binding result from the Codex native harness path.

Real environment tested: Local OpenClaw checkout on macOS, Node/Vitest through repository wrappers, branch fix/86211-codex-preflight-binding-recovery, commit b3c451ab9ccedc8aa7c88a0e9d6d5ebd2c8c7291.

Exact steps or command run after this patch: Ran targeted runtime regressions with node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-memory.test.ts extensions/codex/src/app-server/compact.test.ts extensions/codex/src/conversation-binding.test.ts; ran env -u OPENCLAW_TESTBOX -u OPENCLAW_TESTBOX_REMOTE_RUN pnpm check:changed; ran git diff --check; ran autoreview local with the Codex engine.

Evidence after fix: The targeted Vitest run passed 57 tests across 3 files. check:changed completed guards, core and extension typechecks, core and extension lint, import-cycle checks, and pairing/webhook guards. Autoreview reported no accepted/actionable findings.

Observed result after fix: Structured missing_thread_binding and stale_thread_binding preflight compaction results return the current session entry instead of throwing. Non-binding failures such as auth profile mismatch still throw. Codex app-server compaction preserves stale binding metadata, and conversation binding can create a fresh thread when recovery finds the binding already cleared.

What was not tested: Live Telegram group delivery against a production gateway was not run in this local maintainer patch. The change is covered by focused runtime tests for the auto-reply preflight and Codex app-server binding paths.
