### PR TITLE
fix(auto-reply): recover stale Codex preflight bindings

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -699,6 +699,51 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactCall.sandboxSessionKey).toBe("agent:main:telegram:default:direct:12345");
   });
 
+  it("continues inbound dispatch after recoverable native thread binding compaction failures", async () => {
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 1,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 0,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    compactEmbeddedPiSessionMock.mockResolvedValueOnce({
+      ok: false,
+      compacted: false,
+      reason: "thread not found: thread-1",
+      failure: { reason: "stale_thread_binding" },
+    });
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 1_000,
+      totalTokensFresh: false,
+    };
+    const replyOperation = createReplyOperation();
+
+    const entry = await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({
+        sessionId: "session",
+        sessionKey: "agent:main:telegram:group:123",
+      }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100,
+      sessionEntry,
+      sessionStore: { "agent:main:telegram:group:123": sessionEntry },
+      sessionKey: "agent:main:telegram:group:123",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation,
+    });
+
+    expect(entry).toBe(sessionEntry);
+    expect(compactEmbeddedPiSessionMock).toHaveBeenCalledTimes(1);
+    expect(incrementCompactionCountMock).not.toHaveBeenCalled();
+    expect(replyOperation.setPhase).toHaveBeenCalledWith("preflight_compacting");
+  });
+
   it("updates the active preflight run after transcript rotation", async () => {
     const sessionFile = path.join(rootDir, "session.jsonl");
     const successorFile = path.join(rootDir, "session-rotated.jsonl");

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -124,6 +124,16 @@ const memoryDeps = {
   now: () => Date.now(),
 };
 
+function isRecoverableNativeHarnessBindingFailure(
+  result: Awaited<ReturnType<typeof compactEmbeddedPiSessionDefault>> | undefined,
+): boolean {
+  return (
+    result?.ok === false &&
+    (result.failure?.reason === "missing_thread_binding" ||
+      result.failure?.reason === "stale_thread_binding")
+  );
+}
+
 export function setAgentRunnerMemoryTestDeps(overrides?: Partial<typeof memoryDeps>): void {
   Object.assign(memoryDeps, {
     runWithModelFallback,
@@ -802,6 +812,13 @@ export async function runPreflightCompactionIfNeeded(params: {
   if (!result?.ok || !result.compacted) {
     const reason = result?.reason ?? "not_compacted";
     logVerbose(`preflightCompaction failed: sessionKey=${params.sessionKey} reason=${reason}`);
+    if (isRecoverableNativeHarnessBindingFailure(result)) {
+      logVerbose(
+        `preflightCompaction continuing after recoverable native binding failure: ` +
+          `sessionKey=${params.sessionKey} reason=${reason}`,
+      );
+      return entry ?? params.sessionEntry;
+    }
     throw new Error(`Preflight compaction required but failed: ${reason}`);
   }
 


### PR DESCRIPTION
Summary
- Treat missing or stale native Codex thread bindings as recoverable during inbound preflight compaction.
- Keep other preflight compaction failures fail-closed so real compaction errors still abort before dispatch.
- Add regression coverage for the inbound dispatch path.

Verification
- node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-memory.test.ts extensions/codex/src/app-server/compact.test.ts src/agents/command/cli-compaction.test.ts src/cron/isolated-agent.direct-delivery-core-channels.test.ts extensions/discord/src/token.test.ts src/config/runtime-snapshot.test.ts
- git diff --check
- /Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local

Real behavior proof
Behavior addressed: Telegram inbound dispatch no longer aborts when preflight compaction finds a missing or stale native Codex thread binding.
Real environment tested: local source checkout with focused Vitest regression and sibling compaction tests.
Exact steps or command run after this patch: node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-memory.test.ts extensions/codex/src/app-server/compact.test.ts src/agents/command/cli-compaction.test.ts src/cron/isolated-agent.direct-delivery-core-channels.test.ts extensions/discord/src/token.test.ts src/config/runtime-snapshot.test.ts
Evidence after fix: 7 test files passed; 90 tests passed.
Observed result after fix: recoverable native binding failures return the current session entry and dispatch can continue.
What was not tested: live Telegram delivery was not rerun in this local PR pass.

Fixes #86211
