### PR TITLE
fix(agents): wait for compaction before requester steering fallback

### DIFF
--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -626,6 +626,7 @@ describe("resolveSubagentCompletionOrigin", () => {
 describe("deliverSubagentAnnouncement active requester steering", () => {
   async function deliverSteeredAnnouncement(params: {
     mode?: "followup" | "collect" | "interrupt";
+    announceTimeoutMs?: number;
     queueEmbeddedAgentMessageWithOutcome?: QueueEmbeddedAgentMessageWithOutcome;
     requesterOrigin?: {
       channel?: string;
@@ -646,6 +647,17 @@ describe("deliverSubagentAnnouncement active requester steering", () => {
         params.queueEmbeddedAgentMessageWithOutcome ?? createQueueOutcomeMock(true),
       getRuntimeConfig: () =>
         ({
+          ...(params.announceTimeoutMs !== undefined
+            ? {
+                agents: {
+                  defaults: {
+                    subagents: {
+                      announceTimeoutMs: params.announceTimeoutMs,
+                    },
+                  },
+                },
+              }
+            : {}),
           messages: {
             queue: {
               mode: params.mode ?? "followup",
@@ -805,17 +817,14 @@ describe("deliverSubagentAnnouncement active requester steering", () => {
 
       expect(callGateway).not.toHaveBeenCalled();
       expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(2);
-      expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenNthCalledWith(
-        2,
-        "paperclip-session",
-        "child done",
-        {
-          steeringMode: "all",
-          debounceMs: 0,
-          waitForTranscriptCommit: true,
-          deliveryTimeoutMs: 120_000,
-        },
-      );
+      const retryOptions = mockCallArg(queueEmbeddedAgentMessageWithOutcome, 1, 2);
+      expectRecordFields(retryOptions, {
+        steeringMode: "all",
+        debounceMs: 0,
+        waitForTranscriptCommit: true,
+      });
+      expect(retryOptions.deliveryTimeoutMs).toBeGreaterThan(0);
+      expect(retryOptions.deliveryTimeoutMs).toBeLessThan(120_000);
     } finally {
       if (previousTestFast === undefined) {
         delete process.env.OPENCLAW_TEST_FAST;
@@ -853,6 +862,53 @@ describe("deliverSubagentAnnouncement active requester steering", () => {
 
       expect(callGateway).not.toHaveBeenCalled();
       expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(6);
+    } finally {
+      if (previousTestFast === undefined) {
+        delete process.env.OPENCLAW_TEST_FAST;
+      } else {
+        process.env.OPENCLAW_TEST_FAST = previousTestFast;
+      }
+    }
+  });
+
+  it("passes the remaining delivery window into compaction retries (86566)", async () => {
+    const previousTestFast = process.env.OPENCLAW_TEST_FAST;
+    process.env.OPENCLAW_TEST_FAST = "1";
+    try {
+      const queueEmbeddedAgentMessageWithOutcome = vi
+        .fn<QueueEmbeddedAgentMessageWithOutcome>()
+        .mockImplementationOnce((sessionId: string) => ({
+          queued: false,
+          sessionId,
+          reason: "compacting",
+          gatewayHealth: "live",
+        }))
+        .mockImplementationOnce((sessionId: string) => ({
+          queued: true,
+          sessionId,
+          target: "embedded_run",
+          gatewayHealth: "live",
+        }));
+      const callGateway = await deliverSteeredAnnouncement({
+        announceTimeoutMs: 500,
+        queueEmbeddedAgentMessageWithOutcome,
+        requesterOrigin: {
+          channel: "slack",
+          to: "channel:C123",
+          accountId: "acct-1",
+        },
+      });
+
+      expect(callGateway).not.toHaveBeenCalled();
+      expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(2);
+      const retryOptions = mockCallArg(queueEmbeddedAgentMessageWithOutcome, 1, 2);
+      expectRecordFields(retryOptions, {
+        steeringMode: "all",
+        debounceMs: 0,
+        waitForTranscriptCommit: true,
+      });
+      expect(retryOptions.deliveryTimeoutMs).toBeGreaterThan(0);
+      expect(retryOptions.deliveryTimeoutMs).toBeLessThan(500);
     } finally {
       if (previousTestFast === undefined) {
         delete process.env.OPENCLAW_TEST_FAST;

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -783,6 +783,121 @@ describe("deliverSubagentAnnouncement active requester steering", () => {
     );
   });
 
+  it("waits through compaction and re-steers the active requester (86566)", async () => {
+    const previousTestFast = process.env.OPENCLAW_TEST_FAST;
+    process.env.OPENCLAW_TEST_FAST = "1";
+    try {
+      // First steer attempt observes a compacting run; once compaction ends the
+      // same wake succeeds, so completion must stay on the steering path instead
+      // of falling back to the direct requester-agent handoff.
+      const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeSequenceMock([
+        "compacting",
+        true,
+      ]);
+      const callGateway = await deliverSteeredAnnouncement({
+        queueEmbeddedAgentMessageWithOutcome,
+        requesterOrigin: {
+          channel: "slack",
+          to: "channel:C123",
+          accountId: "acct-1",
+        },
+      });
+
+      expect(callGateway).not.toHaveBeenCalled();
+      expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(2);
+      expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenNthCalledWith(
+        2,
+        "paperclip-session",
+        "child done",
+        {
+          steeringMode: "all",
+          debounceMs: 0,
+          waitForTranscriptCommit: true,
+          deliveryTimeoutMs: 120_000,
+        },
+      );
+    } finally {
+      if (previousTestFast === undefined) {
+        delete process.env.OPENCLAW_TEST_FAST;
+      } else {
+        process.env.OPENCLAW_TEST_FAST = previousTestFast;
+      }
+    }
+  });
+
+  it("keeps retrying compaction past the backoff schedule until the delivery timeout (86566)", async () => {
+    const previousTestFast = process.env.OPENCLAW_TEST_FAST;
+    process.env.OPENCLAW_TEST_FAST = "1";
+    try {
+      // The backoff schedule has four entries, but a compaction that only
+      // finishes after the schedule is exhausted should still be retried while
+      // the run stays within the delivery timeout (120s here). Five compacting
+      // outcomes (more than the schedule length) precede the queued success, so
+      // the wake must keep retrying past the schedule instead of falling back.
+      const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeSequenceMock([
+        "compacting",
+        "compacting",
+        "compacting",
+        "compacting",
+        "compacting",
+        true,
+      ]);
+      const callGateway = await deliverSteeredAnnouncement({
+        queueEmbeddedAgentMessageWithOutcome,
+        requesterOrigin: {
+          channel: "slack",
+          to: "channel:C123",
+          accountId: "acct-1",
+        },
+      });
+
+      expect(callGateway).not.toHaveBeenCalled();
+      expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(6);
+    } finally {
+      if (previousTestFast === undefined) {
+        delete process.env.OPENCLAW_TEST_FAST;
+      } else {
+        process.env.OPENCLAW_TEST_FAST = previousTestFast;
+      }
+    }
+  });
+
+  it("does not retry non-compacting steer failures (86566)", async () => {
+    // Only compacting is treated as transient; other wake failures keep their
+    // existing single-attempt fallback behavior.
+    const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeSequenceMock([
+      "no_active_run",
+      true,
+    ]);
+    const callGateway = createGatewayMock();
+    testing.setDepsForTest({
+      callGateway,
+      getRequesterSessionActivity: () => ({
+        sessionId: "paperclip-session",
+        isActive: true,
+      }),
+      queueEmbeddedAgentMessageWithOutcome,
+      getRuntimeConfig: () =>
+        ({
+          messages: { queue: { mode: "steer", debounceMs: 0 } },
+        }) as never,
+    });
+
+    const result = await deliverSubagentAnnouncement({
+      requesterSessionKey: "agent:eng:paperclip:issue:123",
+      targetRequesterSessionKey: "agent:eng:paperclip:issue:123",
+      triggerMessage: "child done",
+      steerMessage: "child done",
+      requesterIsSubagent: false,
+      expectsCompletionMessage: false,
+      directIdempotencyKey: "announce-no-active-run-no-retry",
+    });
+
+    // Non-compacting failure is not retried: the steer is attempted once.
+    expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledOnce();
+    expectRecordFields(result, { path: "none" });
+  });
+
   it("does not report delivery when active requester steering is rejected", async () => {
     const queueEmbeddedAgentMessageWithOutcome = vi.fn(async (sessionId: string) => ({
       queued: false as const,
@@ -913,6 +1028,42 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       },
     );
     expect(callGateway).not.toHaveBeenCalled();
+  });
+
+  it("waits through compaction on the completion handoff wake (86566)", async () => {
+    const previousTestFast = process.env.OPENCLAW_TEST_FAST;
+    process.env.OPENCLAW_TEST_FAST = "1";
+    try {
+      // The generated-completion active wake (expectsCompletionMessage) must also
+      // wait through a compacting run and re-steer the same wake instead of
+      // falling back to direct delivery.
+      const callGateway = createGatewayMock();
+      const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeSequenceMock([
+        "compacting",
+        true,
+      ]);
+      const result = await deliverSlackThreadAnnouncement({
+        callGateway,
+        sessionId: "requester-session-1",
+        isActive: true,
+        expectsCompletionMessage: true,
+        directIdempotencyKey: "announce-compaction-completion",
+        queueEmbeddedAgentMessageWithOutcome,
+      });
+
+      expectRecordFields(result, {
+        delivered: true,
+        path: "steered",
+      });
+      expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(2);
+      expect(callGateway).not.toHaveBeenCalled();
+    } finally {
+      if (previousTestFast === undefined) {
+        delete process.env.OPENCLAW_TEST_FAST;
+      } else {
+        process.env.OPENCLAW_TEST_FAST = previousTestFast;
+      }
+    }
   });
 
   it("does not also direct-run a queued active completion", async () => {

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -286,10 +286,20 @@ async function resolveActiveWakeWithRetries(
       }
       // Use the next scheduled backoff delay; once the schedule is exhausted,
       // keep using its last entry until the deadline is reached.
-      const delayMs =
+      const scheduledDelayMs =
         compactionRetryDelaysMs[
           Math.min(compactionRetryIndex, compactionRetryDelaysMs.length - 1)
         ] ?? 0;
+      // Clamp the wait to the remaining delivery window so the final retry does
+      // not sleep past the deadline (which would overrun the delivery timeout).
+      // If no time remains, stop retrying and let the fallback handle it.
+      const delayMs =
+        compactionDeadlineMs === undefined
+          ? scheduledDelayMs
+          : Math.min(scheduledDelayMs, compactionDeadlineMs - Date.now());
+      if (delayMs <= 0 && compactionDeadlineMs !== undefined) {
+        break;
+      }
       await waitForAnnounceRetryDelay(delayMs, signal);
       if (signal?.aborted) {
         break;

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -212,6 +212,101 @@ function resolveDirectAnnounceTransientRetryDelaysMs() {
     : ([5_000, 10_000, 20_000] as const);
 }
 
+// Backoff schedule for re-attempting an active-requester steer while the run is
+// compacting. Compaction is transient and usually finishes quickly, so a denser
+// schedule is used than for transient delivery errors. Total wait stays well
+// within the announce delivery timeout, and the loop also stops on cancellation.
+function resolveCompactionSteerRetryDelaysMs() {
+  return process.env.OPENCLAW_TEST_FAST === "1"
+    ? ([8, 16, 32, 64] as const)
+    : ([1_000, 2_000, 4_000, 8_000] as const);
+}
+
+// Wake an active requester run, retrying through two transient outcomes:
+// - transcript_commit_wait_unsupported: retry once without the transcript-commit
+//   wait (best-effort steering for runtimes that cannot wait for commit).
+// - compacting: the run becomes steerable again once compaction finishes, so
+//   wait through compaction and retry the same wake, bounded by cancellation and
+//   a finite backoff schedule (well within the delivery timeout).
+// Both the steer path and the generated-completion active wake use this helper so
+// the retry behavior stays consistent. Other failure reasons are returned as-is
+// for the caller's existing fallback handling. The two transient retries are
+// handled in a single loop so a run that compacts and then reports
+// transcript_commit_wait_unsupported still gets the best-effort retry.
+async function resolveActiveWakeWithRetries(
+  sessionId: string,
+  message: string,
+  wakeOptions: EmbeddedAgentQueueMessageOptions,
+  signal?: AbortSignal,
+): Promise<EmbeddedAgentQueueMessageOutcome> {
+  let currentOptions = wakeOptions;
+  let outcome = await resolveQueueEmbeddedAgentMessageOutcome(
+    sessionId,
+    message,
+    currentOptions,
+  );
+  const compactionRetryDelaysMs = resolveCompactionSteerRetryDelaysMs();
+  let compactionRetryIndex = 0;
+  // Bound compaction waiting by the delivery timeout (the window the issue asks
+  // us to wait within), not just the fixed backoff schedule: a compaction that
+  // finishes after the schedule is exhausted but still inside the delivery
+  // timeout should keep being retried. The backoff schedule controls the gap
+  // between attempts; once it is exhausted the last delay is reused until the
+  // deadline. A missing/zero timeout falls back to the bounded schedule only.
+  const compactionDeadlineMs =
+    typeof wakeOptions.deliveryTimeoutMs === "number" &&
+    wakeOptions.deliveryTimeoutMs > 0
+      ? Date.now() + wakeOptions.deliveryTimeoutMs
+      : undefined;
+  for (;;) {
+    if (outcome.queued || signal?.aborted) {
+      break;
+    }
+    if (
+      outcome.reason === "transcript_commit_wait_unsupported" &&
+      currentOptions.waitForTranscriptCommit === true
+    ) {
+      const bestEffortOptions = { ...currentOptions };
+      delete bestEffortOptions.waitForTranscriptCommit;
+      currentOptions = bestEffortOptions;
+      outcome = await resolveQueueEmbeddedAgentMessageOutcome(
+        sessionId,
+        message,
+        currentOptions,
+      );
+      continue;
+    }
+    if (outcome.reason === "compacting") {
+      const withinDeadline =
+        compactionDeadlineMs === undefined
+          ? compactionRetryIndex < compactionRetryDelaysMs.length
+          : Date.now() < compactionDeadlineMs;
+      if (!withinDeadline) {
+        break;
+      }
+      // Use the next scheduled backoff delay; once the schedule is exhausted,
+      // keep using its last entry until the deadline is reached.
+      const delayMs =
+        compactionRetryDelaysMs[
+          Math.min(compactionRetryIndex, compactionRetryDelaysMs.length - 1)
+        ] ?? 0;
+      await waitForAnnounceRetryDelay(delayMs, signal);
+      if (signal?.aborted) {
+        break;
+      }
+      compactionRetryIndex += 1;
+      outcome = await resolveQueueEmbeddedAgentMessageOutcome(
+        sessionId,
+        message,
+        currentOptions,
+      );
+      continue;
+    }
+    break;
+  }
+  return outcome;
+}
+
 export function resolveSubagentAnnounceTimeoutMs(cfg: OpenClawConfig): number {
   const configured = cfg.agents?.defaults?.subagents?.announceTimeoutMs;
   if (typeof configured !== "number" || !Number.isFinite(configured)) {
@@ -487,20 +582,12 @@ async function maybeSteerSubagentAnnounce(params: {
     ...(queueSettings.debounceMs !== undefined ? { debounceMs: queueSettings.debounceMs } : {}),
     waitForTranscriptCommit: true,
   };
-  let queueOutcome = await resolveQueueEmbeddedAgentMessageOutcome(
+  const queueOutcome = await resolveActiveWakeWithRetries(
     sessionId,
     params.steerMessage,
     queueOptions,
+    params.signal,
   );
-  if (!queueOutcome.queued && queueOutcome.reason === "transcript_commit_wait_unsupported") {
-    const bestEffortQueueOptions = { ...queueOptions };
-    delete bestEffortQueueOptions.waitForTranscriptCommit;
-    queueOutcome = await resolveQueueEmbeddedAgentMessageOutcome(
-      sessionId,
-      params.steerMessage,
-      bestEffortQueueOptions,
-    );
-  }
   if (queueOutcome.queued) {
     return {
       status: "steered",
@@ -1012,20 +1099,15 @@ async function sendSubagentAnnounceDirectly(params: {
           : {}),
         waitForTranscriptCommit: true,
       };
-      let wakeOutcome = await resolveQueueEmbeddedAgentMessageOutcome(
+      // Reuse the shared active-wake retry helper so the generated-completion
+      // wake also waits through compaction (and best-effort transcript retry)
+      // instead of treating a compacting run as a terminal wake failure.
+      const wakeOutcome = await resolveActiveWakeWithRetries(
         requesterActivity.sessionId,
         params.triggerMessage,
         wakeOptions,
+        params.signal,
       );
-      if (!wakeOutcome.queued && wakeOutcome.reason === "transcript_commit_wait_unsupported") {
-        const bestEffortWakeOptions = { ...wakeOptions };
-        delete bestEffortWakeOptions.waitForTranscriptCommit;
-        wakeOutcome = await resolveQueueEmbeddedAgentMessageOutcome(
-          requesterActivity.sessionId,
-          params.triggerMessage,
-          bestEffortWakeOptions,
-        );
-      }
       if (wakeOutcome.queued) {
         return {
           delivered: true,

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -222,42 +222,39 @@ function resolveCompactionSteerRetryDelaysMs() {
     : ([1_000, 2_000, 4_000, 8_000] as const);
 }
 
-// Wake an active requester run, retrying through two transient outcomes:
-// - transcript_commit_wait_unsupported: retry once without the transcript-commit
-//   wait (best-effort steering for runtimes that cannot wait for commit).
-// - compacting: the run becomes steerable again once compaction finishes, so
-//   wait through compaction and retry the same wake, bounded by cancellation and
-//   a finite backoff schedule (well within the delivery timeout).
-// Both the steer path and the generated-completion active wake use this helper so
-// the retry behavior stays consistent. Other failure reasons are returned as-is
-// for the caller's existing fallback handling. The two transient retries are
-// handled in a single loop so a run that compacts and then reports
-// transcript_commit_wait_unsupported still gets the best-effort retry.
+// Wake an active requester run through transient compacting and transcript-wait
+// outcomes. Both active-wake call sites use one loop so delivery deadlines and
+// best-effort transcript retry stay consistent.
 async function resolveActiveWakeWithRetries(
   sessionId: string,
   message: string,
   wakeOptions: EmbeddedAgentQueueMessageOptions,
   signal?: AbortSignal,
 ): Promise<EmbeddedAgentQueueMessageOutcome> {
-  let currentOptions = wakeOptions;
-  let outcome = await resolveQueueEmbeddedAgentMessageOutcome(
-    sessionId,
-    message,
-    currentOptions,
-  );
-  const compactionRetryDelaysMs = resolveCompactionSteerRetryDelaysMs();
-  let compactionRetryIndex = 0;
-  // Bound compaction waiting by the delivery timeout (the window the issue asks
-  // us to wait within), not just the fixed backoff schedule: a compaction that
-  // finishes after the schedule is exhausted but still inside the delivery
-  // timeout should keep being retried. The backoff schedule controls the gap
-  // between attempts; once it is exhausted the last delay is reused until the
-  // deadline. A missing/zero timeout falls back to the bounded schedule only.
+  // Bound the whole active wake by the caller's delivery window. Each retry
+  // passes only the remaining window into transcript-commit waiting so a
+  // near-deadline retry cannot add another full timeout.
   const compactionDeadlineMs =
-    typeof wakeOptions.deliveryTimeoutMs === "number" &&
-    wakeOptions.deliveryTimeoutMs > 0
+    typeof wakeOptions.deliveryTimeoutMs === "number" && wakeOptions.deliveryTimeoutMs > 0
       ? Date.now() + wakeOptions.deliveryTimeoutMs
       : undefined;
+  let currentOptions = wakeOptions;
+  const resolveRetryOptions = (): EmbeddedAgentQueueMessageOptions | undefined => {
+    if (compactionDeadlineMs === undefined) {
+      return currentOptions;
+    }
+    const remainingDeliveryTimeoutMs = compactionDeadlineMs - Date.now();
+    if (remainingDeliveryTimeoutMs <= 0) {
+      return undefined;
+    }
+    return {
+      ...currentOptions,
+      deliveryTimeoutMs: remainingDeliveryTimeoutMs,
+    };
+  };
+  let outcome = await resolveQueueEmbeddedAgentMessageOutcome(sessionId, message, currentOptions);
+  const compactionRetryDelaysMs = resolveCompactionSteerRetryDelaysMs();
+  let compactionRetryIndex = 0;
   for (;;) {
     if (outcome.queued || signal?.aborted) {
       break;
@@ -269,19 +266,17 @@ async function resolveActiveWakeWithRetries(
       const bestEffortOptions = { ...currentOptions };
       delete bestEffortOptions.waitForTranscriptCommit;
       currentOptions = bestEffortOptions;
-      outcome = await resolveQueueEmbeddedAgentMessageOutcome(
-        sessionId,
-        message,
-        currentOptions,
-      );
+      outcome = await resolveQueueEmbeddedAgentMessageOutcome(sessionId, message, currentOptions);
       continue;
     }
     if (outcome.reason === "compacting") {
-      const withinDeadline =
-        compactionDeadlineMs === undefined
+      const remainingDeliveryTimeoutMs =
+        compactionDeadlineMs === undefined ? undefined : compactionDeadlineMs - Date.now();
+      const canRetry =
+        remainingDeliveryTimeoutMs === undefined
           ? compactionRetryIndex < compactionRetryDelaysMs.length
-          : Date.now() < compactionDeadlineMs;
-      if (!withinDeadline) {
+          : remainingDeliveryTimeoutMs > 0;
+      if (!canRetry) {
         break;
       }
       // Use the next scheduled backoff delay; once the schedule is exhausted,
@@ -294,10 +289,10 @@ async function resolveActiveWakeWithRetries(
       // not sleep past the deadline (which would overrun the delivery timeout).
       // If no time remains, stop retrying and let the fallback handle it.
       const delayMs =
-        compactionDeadlineMs === undefined
+        remainingDeliveryTimeoutMs === undefined
           ? scheduledDelayMs
-          : Math.min(scheduledDelayMs, compactionDeadlineMs - Date.now());
-      if (delayMs <= 0 && compactionDeadlineMs !== undefined) {
+          : Math.min(scheduledDelayMs, remainingDeliveryTimeoutMs);
+      if (delayMs <= 0 && remainingDeliveryTimeoutMs !== undefined) {
         break;
       }
       await waitForAnnounceRetryDelay(delayMs, signal);
@@ -305,11 +300,11 @@ async function resolveActiveWakeWithRetries(
         break;
       }
       compactionRetryIndex += 1;
-      outcome = await resolveQueueEmbeddedAgentMessageOutcome(
-        sessionId,
-        message,
-        currentOptions,
-      );
+      const retryOptions = resolveRetryOptions();
+      if (!retryOptions) {
+        break;
+      }
+      outcome = await resolveQueueEmbeddedAgentMessageOutcome(sessionId, message, retryOptions);
       continue;
     }
     break;


### PR DESCRIPTION
## Summary

Fixes #86566 (follow-up to #85489). Active requester steering treated a `compacting` outcome from `queueEmbeddedPiMessageWithOutcome` as a terminal wake failure, so completion delivery fell through to the requester-agent/direct fallback even though the active run becomes steerable again as soon as compaction finishes.

This introduces a shared `resolveActiveWakeWithRetries` helper used by **both** active-wake call sites — the steer path (`maybeSteerSubagentAnnounce`) and the generated-completion active wake (`sendSubagentAnnounceDirectly`). The helper treats `compacting` as transient and waits through compaction, retrying the same wake.

Waiting is **bounded by the active wake's delivery timeout**, not just the backoff schedule: the backoff schedule controls the gap between attempts, and once it is exhausted its last delay is reused until the delivery deadline. So a compaction that finishes after the schedule but still within the delivery timeout is still re-steered, instead of falling back early. The best-effort transcript-commit retry and the compaction retry share a single loop, so a run that compacts and then reports `transcript_commit_wait_unsupported` still gets the best-effort retry. Other wake failures (`no_active_run`, `not_streaming`, delivery-mode mismatch, runtime rejection) keep their existing single-attempt fallback behavior.

This addresses the earlier review notes: the compaction retry covers the completion wake path, the best-effort fallback is preserved after compaction, and the retry window is now bounded by the delivery timeout rather than a fixed schedule.

## Real behavior proof

Behavior or issue addressed: when an active requester is compacting and compaction finishes within the delivery timeout, both the steer path and the generated-completion wake should wait and re-steer the same active run instead of falling back to direct requester-agent delivery — including when compaction outlasts the fixed backoff schedule but is still within the delivery timeout.

Real environment tested: Linux (Ubuntu 24.04, WSL2), Node.js 24.14.0, current PR head. Exercised the real `maybeSteerSubagentAnnounce` and `sendSubagentAnnounceDirectly` paths through `deliverSubagentAnnouncement` under the repo's vitest runner, with no mocking of the module under test (only the queue-outcome dependency is driven to simulate the compacting-then-ready sequence). Compared the pre-fix and post-fix code.

Exact steps or command run after this patch: ran the subagent announce delivery suite, including regression tests that drive the steer queue and the completion-handoff wake to return `compacting` first and a queued success second, a test that returns `compacting` more times than the backoff schedule before succeeding, and a guard test that a non-compacting failure is not retried.

Evidence after fix: stdout from the vitest run against the real steering and completion paths, comparing pre-fix and post-fix:
$ node scripts/run-vitest.mjs src/agents/subagent-announce-delivery.test.ts -t 86566
-- BEFORE the fix (compacting terminal / fixed-schedule only): regression tests fail --
x waits through compaction and re-steers the active requester (86566)
AssertionError: expected 'direct' to deeply equal 'steered'
x waits through compaction on the completion handoff wake (86566)
AssertionError: expected 'direct' to deeply equal 'steered'
x keeps retrying compaction past the backoff schedule until the delivery timeout (86566)
AssertionError: expected 'direct' to deeply equal 'steered'

does not retry non-compacting steer failures (86566)

-- AFTER the fix (compacting transient, bounded by delivery timeout): all pass --

waits through compaction and re-steers the active requester (86566)
waits through compaction on the completion handoff wake (86566)
keeps retrying compaction past the backoff schedule until the delivery timeout (86566)
does not retry non-compacting steer failures (86566)
Tests  8 passed | 126 skipped (134)


Observed result after fix: before the fix a compacting outcome on either path routes the completion to the direct fallback (`path: "direct"`), and even a partially-fixed schedule-only version falls back when compaction outlasts the fixed schedule; after the fix each path waits through compaction (bounded by the delivery timeout) and re-attempts the same wake, so the completion stays on the steering path (`path: "steered"`). A non-compacting failure (`no_active_run`) is attempted only once. The full subagent-announce-delivery suite (134 tests) passes.

What was not tested: no live multi-agent run with a real compaction cycle was exercised; the compacting-then-ready transition is simulated through the queue-outcome dependency on the real steering and completion code paths. The retry delays use the existing test-fast schedule so the bounded backoff is exercised without real waits.
