### PR TITLE
docs: add existing-solutions preflight guardrail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ Skills own workflows; root owns hard policy and routing.
 - Repo: `https://github.com/openclaw/openclaw`
 - Replies: repo-root refs only: `extensions/telegram/src/index.ts:80`. No absolute paths, no `~/`.
 - Docs/user-visible work: `pnpm docs:list`, then read relevant docs only.
+- Existing-solutions preflight: before proposing or building a custom system, feature, workflow, tool, integration, or automation, do a lightweight check for open-source projects, maintained libraries, existing OpenClaw plugins, or free platforms that already solve it well enough. Prefer those when adequate. Build custom only when existing options are unsuitable, too expensive, unmaintained, unsafe, non-compliant, or the user explicitly asks for custom. Avoid paid-service recommendations unless the user explicitly approves spend. Keep this to a brief preflight gate, not a broad research assignment.
 - Fix/triage answers need source, tests, current/shipped behavior, and dependency contract proof.
 - Reviews/answers: high confidence required. Default to exhaustive relevant codebase search/read, including owners, callers, siblings, tests, docs, and upstream/dependency contracts before verdict. Diff-only review is insufficient.
 - Review default: read the whole changed function/module plus callers, callees, sibling implementations, adjacent tests, scoped docs, and dependency/Codex contracts before saying `good`, `bad`, `best fix`, `proof sufficient`, or posting a comment. If challenged, keep reading first; do not defend the earlier verdict until the missing path is checked.

--- a/docs/reference/AGENTS.default.md
+++ b/docs/reference/AGENTS.default.md
@@ -45,6 +45,10 @@ cp docs/reference/AGENTS.default.md ~/.openclaw/workspace/AGENTS.md
 - Before changing config or schedulers (for example crontab, systemd units, nginx configs, or shell rc files), inspect existing state first and preserve/merge by default.
 - Don't send partial/streaming replies to external messaging surfaces (only final replies).
 
+## Existing solutions preflight
+
+Before proposing or building a custom system, feature, workflow, tool, integration, or automation, do a brief check for open-source projects, maintained libraries, existing OpenClaw plugins, or free platforms that already solve it well enough. Prefer those when adequate. Build custom only when existing options are unsuitable, too expensive, unmaintained, unsafe, non-compliant, or the user explicitly asks for custom. Avoid paid-service recommendations unless the user explicitly approves spend. Keep this lightweight: a preflight gate, not a broad research assignment.
+
 ## Session start (required)
 
 - Read `SOUL.md`, `USER.md`, and today+yesterday in `memory/`.

--- a/docs/reference/templates/AGENTS.dev.md
+++ b/docs/reference/templates/AGENTS.dev.md
@@ -33,6 +33,10 @@ git commit -m "Add agent workspace"
 - Don't run destructive commands unless explicitly asked.
 - Be concise in chat; write longer output to files in this workspace.
 
+## Existing solutions preflight
+
+Before proposing or building a custom system, feature, workflow, tool, integration, or automation, do a brief check for open-source projects, maintained libraries, existing OpenClaw plugins, or free platforms that already solve it well enough. Prefer those when adequate. Build custom only when existing options are unsuitable, too expensive, unmaintained, unsafe, non-compliant, or the user explicitly asks for custom. Avoid paid-service recommendations unless the user explicitly approves spend. Keep this lightweight: a preflight gate, not a broad research assignment.
+
 ## Daily memory (recommended)
 
 - Keep a short daily log at memory/YYYY-MM-DD.md (create memory/ if needed).

--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -66,6 +66,10 @@ Capture what matters. Decisions, context, things to remember. Skip the secrets u
 - `trash` > `rm` (recoverable beats gone forever)
 - When in doubt, ask.
 
+## Existing Solutions Preflight
+
+Before proposing or building a custom system, feature, workflow, tool, integration, or automation, do a brief check for open-source projects, maintained libraries, existing OpenClaw plugins, or free platforms that already solve it well enough. Prefer those when adequate. Build custom only when existing options are unsuitable, too expensive, unmaintained, unsafe, non-compliant, or the user explicitly asks for custom. Avoid paid-service recommendations unless the user explicitly approves spend. Keep this lightweight: a preflight gate, not a broad research assignment.
+
 ## External vs Internal
 
 **Safe to do freely:**

--- a/scripts/k8s/manifests/configmap.yaml
+++ b/scripts/k8s/manifests/configmap.yaml
@@ -36,3 +36,5 @@ data:
     # OpenClaw Assistant
 
     You are a helpful AI assistant running in Kubernetes.
+
+    Before proposing or building a custom system, feature, workflow, tool, integration, or automation, do a brief check for open-source projects, maintained libraries, existing OpenClaw plugins, or free platforms that already solve it well enough. Prefer those when adequate. Build custom only when existing options are unsuitable, too expensive, unmaintained, unsafe, non-compliant, or the user explicitly asks for custom. Avoid paid-service recommendations unless the user explicitly approves spend. Keep this lightweight: a preflight gate, not a broad research assignment.


### PR DESCRIPTION
## Summary
- add a repo-root AGENTS.md rule requiring a lightweight existing-solutions check before custom builds
- add the same reusable guardrail to default workspace AGENTS templates and the Kubernetes starter AGENTS config
- keep wording scoped to open-source projects, maintained libraries, existing OpenClaw plugins, or free platforms; custom builds remain allowed when existing options are unsuitable, too expensive, unmaintained, unsafe, non-compliant, or explicitly requested

## Real behavior proof

Behavior or issue addressed: Agent instruction surfaces now include a lightweight existing-solutions preflight before custom build proposals. The rule says to prefer open-source projects, maintained libraries, existing OpenClaw plugins, or free platforms when adequate; custom builds are allowed only when existing options are unsuitable, too expensive, unmaintained, unsafe, non-compliant, or explicitly requested; paid-service recommendations require explicit spend approval.

Real environment tested: Local OpenClaw repository workspace on branch `nox-4929-existing-solutions-preflight`, commit `dfaa251df4`, using the checked-in docs/templates/scripts that seed or instruct real OpenClaw agents.

Exact steps or command run after this patch: Ran `pnpm docs:list`, inspected checked-in agent workspace template and Kubernetes starter AGENTS paths, patched the selected files, then searched those exact files for the guardrail text and ran focused formatting/docs checks.

Evidence after fix:

```text
$ rg -n "Existing solutions preflight|Existing Solutions Preflight|Before proposing or building a custom system" AGENTS.md docs/reference/templates/AGENTS.md docs/reference/templates/AGENTS.dev.md docs/reference/AGENTS.default.md scripts/k8s/manifests/configmap.yaml
scripts/k8s/manifests/configmap.yaml:40:    Before proposing or building a custom system, feature, workflow, tool, integration, or automation, do a brief check for open-source projects, maintained libraries, existing OpenClaw plugins, or free platforms that already solve it well enough. Prefer those when adequate. Build custom only when existing options are unsuitable, too expensive, unmaintained, unsafe, non-compliant, or the user explicitly asks for custom. Avoid paid-service recommendations unless the user explicitly approves spend. Keep this lightweight: a preflight gate, not a broad research assignment.
docs/reference/AGENTS.default.md:49:## Existing solutions preflight
docs/reference/AGENTS.default.md:51:Before proposing or building a custom system, feature, workflow, tool, integration, or automation, do a brief check for open-source projects, maintained libraries, existing OpenClaw plugins, or free platforms that already solve it well enough. Prefer those when adequate. Build custom only when existing options are unsuitable, too expensive, unmaintained, unsafe, non-compliant, or the user explicitly asks for custom. Avoid paid-service recommendations unless the user explicitly approves spend. Keep this lightweight: a preflight gate, not a broad research assignment.
docs/reference/templates/AGENTS.dev.md:36:## Existing solutions preflight
docs/reference/templates/AGENTS.dev.md:38:Before proposing or building a custom system, feature, workflow, tool, integration, or automation, do a brief check for open-source projects, maintained libraries, existing OpenClaw plugins, or free platforms that already solve it well enough. Prefer those when adequate. Build custom only when existing options are unsuitable, too expensive, unmaintained, unsafe, non-compliant, or the user explicitly asks for custom. Avoid paid-service recommendations unless the user explicitly approves spend. Keep this lightweight: a preflight gate, not a broad research assignment.
docs/reference/templates/AGENTS.md:67:## Existing Solutions Preflight
docs/reference/templates/AGENTS.md:69:Before proposing or building a custom system, feature, workflow, tool, integration, or automation, do a brief check for open-source projects, maintained libraries, existing OpenClaw plugins, or free platforms that already solve it well enough. Prefer those when adequate. Build custom only when existing options are unsuitable, too expensive, unmaintained, unsafe, non-compliant, or the user explicitly asks for custom. Avoid paid-service recommendations unless the user explicitly approves spend. Keep this lightweight: a preflight gate, not a broad research assignment.

$ node -e 'const fs=require("fs"); const path="scripts/k8s/manifests/configmap.yaml"; const text=fs.readFileSync(path,"utf8"); if (!text.includes("existing OpenClaw plugins") || !text.includes("paid-service recommendations")) process.exit(1); console.log("ConfigMap guardrail text present")'
ConfigMap guardrail text present
```

Observed result after fix: The guardrail is present in repo-root instructions, default workspace instructions, manual/dev workspace templates, and the Kubernetes starter AGENTS config. `pnpm format:check ...`, `node scripts/check-docs-mdx.mjs ...`, and `git diff --check ...` passed for the touched files.

What was not tested: No full `pnpm check`, `pnpm test`, or `pnpm build`; this is instruction/docs/YAML text only. Direct `pnpm exec prettier --check ...` was not available because `prettier` is not installed; the repo formatter command `pnpm format:check ...` passed.

## Verification
- `pnpm docs:list`
- `rg -n "Existing solutions preflight|Existing Solutions Preflight|Before proposing or building a custom system" AGENTS.md docs/reference/templates/AGENTS.md docs/reference/templates/AGENTS.dev.md docs/reference/AGENTS.default.md scripts/k8s/manifests/configmap.yaml`
- `pnpm format:check AGENTS.md docs/reference/templates/AGENTS.md docs/reference/templates/AGENTS.dev.md docs/reference/AGENTS.default.md scripts/k8s/manifests/configmap.yaml`
- `node scripts/check-docs-mdx.mjs docs/reference/templates/AGENTS.md docs/reference/templates/AGENTS.dev.md docs/reference/AGENTS.default.md`
- `git diff --check -- AGENTS.md docs/reference/templates/AGENTS.md docs/reference/templates/AGENTS.dev.md docs/reference/AGENTS.default.md scripts/k8s/manifests/configmap.yaml`

## Notes
- Direct push to `openclaw/openclaw` was denied for `cablackmon`, so this PR is opened from the `cablackmon/openclaw` fork.
