### PR TITLE
Fix smart-quoted tool call argument repair

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.test.ts
@@ -47,6 +47,86 @@ async function invokeProviderStream(params: {
   return await Promise.resolve(streamFn({} as never, {} as never, {} as never));
 }
 
+type ToolCallRepairCaseResult = {
+  partialArgs: unknown;
+  streamedArgs: unknown;
+  endMessageArgs: unknown;
+  finalArgs: unknown;
+  result: unknown;
+  finalMessage: unknown;
+};
+
+async function runToolCallRepairCase(params: {
+  toolName?: string;
+  delta: string;
+  provider?: string;
+  modelApi?: string;
+}): Promise<ToolCallRepairCaseResult> {
+  const toolName = params.toolName ?? "write";
+  const partialToolCall = { type: "functionCall", name: toolName, arguments: {} };
+  const streamedToolCall = { type: "functionCall", name: toolName, arguments: {} };
+  const endMessageToolCall = { type: "functionCall", name: toolName, arguments: {} };
+  const finalToolCall = { type: "functionCall", name: toolName, arguments: {} };
+  const partialMessage = { role: "assistant", content: [partialToolCall] };
+  const endMessage = { role: "assistant", content: [endMessageToolCall] };
+  const finalMessage = { role: "assistant", content: [finalToolCall] };
+
+  const stream = await invokeProviderStream({
+    provider: params.provider ?? "openai-compatible",
+    modelApi: params.modelApi ?? "openai-completions",
+    baseFn: () =>
+      createFakeStream({
+        events: [
+          {
+            type: "toolcall_delta",
+            contentIndex: 0,
+            delta: `.functions.${toolName}:0 `,
+            partial: partialMessage,
+          },
+          {
+            type: "toolcall_delta",
+            contentIndex: 0,
+            delta: params.delta,
+            partial: partialMessage,
+          },
+          {
+            type: "toolcall_end",
+            contentIndex: 0,
+            toolCall: streamedToolCall,
+            partial: partialMessage,
+            message: endMessage,
+          },
+        ],
+        resultMessage: finalMessage,
+      }),
+  });
+
+  for await (const item of stream) {
+    // drain
+  }
+  const result = await stream.result();
+
+  return {
+    partialArgs: partialToolCall.arguments,
+    streamedArgs: streamedToolCall.arguments,
+    endMessageArgs: endMessageToolCall.arguments,
+    finalArgs: finalToolCall.arguments,
+    result,
+    finalMessage,
+  };
+}
+
+function expectAllToolCallArgs(
+  result: ToolCallRepairCaseResult,
+  expectedArgs: Record<string, unknown>,
+): void {
+  expect(result.partialArgs).toEqual(expectedArgs);
+  expect(result.streamedArgs).toEqual(expectedArgs);
+  expect(result.endMessageArgs).toEqual(expectedArgs);
+  expect(result.finalArgs).toEqual(expectedArgs);
+  expect(result.result).toBe(result.finalMessage);
+}
+
 describe("shouldRepairMalformedToolCallArguments", () => {
   it("keeps the repair enabled for kimi providers on anthropic-messages", () => {
     expect(
@@ -182,4 +262,79 @@ describe("openai-completions malformed tool-call argument repair", () => {
       expect(result).toBe(finalMessage);
     },
   );
+
+  it("repairs smart-quoted edit args with CJK, markdown, and inner smart quotes", async () => {
+    const expectedContent =
+      '更新 **草稿** with “smart”, “sure” and code "x"\nJSON-ish “alpha”, “path”: “ignored” snippet\nSee [“quoted”](https://example.test)\nconst re = /\\d+/;\n内部内容';
+    const result = await runToolCallRepairCase({
+      toolName: "edit",
+      delta: String.raw` {“path”:“notes/报告.md”,“oldText”:“旧的 **草稿**”,“newText”:“更新 **草稿** with “smart”, “sure” and code "x"
+JSON-ish “alpha”, “path”: “ignored” snippet
+See [“quoted”](https://example.test)
+const re = /\d+/;
+内部内容”}`,
+    });
+
+    expectAllToolCallArgs(result, {
+      path: "notes/报告.md",
+      oldText: "旧的 **草稿**",
+      newText: expectedContent,
+    });
+  });
+
+  it("preserves smart quotes inside ASCII-delimited JSON content with trailing junk", async () => {
+    const result = await runToolCallRepairCase({
+      toolName: "read",
+      delta: '{"path":"notes/日志.md","content":"包含“内部”与 **重点** 字样"}x',
+    });
+
+    expectAllToolCallArgs(result, {
+      path: "notes/日志.md",
+      content: "包含“内部”与 **重点** 字样",
+    });
+  });
+
+  it("repairs smart-quoted command args that use workdir", async () => {
+    const result = await runToolCallRepairCase({
+      toolName: "exec",
+      delta: "{“command“:“pwd“,“workdir“:“/tmp“}",
+    });
+
+    expectAllToolCallArgs(result, { command: "pwd", workdir: "/tmp" });
+  });
+
+  it("keeps duplicate-looking smart-quoted args inside content", async () => {
+    const result = await runToolCallRepairCase({
+      delta: String.raw` {“path”:“safe.txt”,“content”:“text ”, “path”: “other.txt””}`,
+    });
+
+    expectAllToolCallArgs(result, {
+      path: "safe.txt",
+      content: "text ”, “path”: “other.txt”",
+    });
+  });
+
+  it("keeps unknown member-looking prose inside smart-quoted content", async () => {
+    const result = await runToolCallRepairCase({
+      delta: String.raw` {“path”:“safe.txt”,“content”:“Use ”, “foo”: “bar” in prose”}`,
+    });
+
+    expectAllToolCallArgs(result, {
+      path: "safe.txt",
+      content: "Use ”, “foo”: “bar” in prose",
+    });
+    expect(result.finalArgs).not.toHaveProperty("foo");
+  });
+
+  it("keeps member-looking prose inside mixed ASCII-key smart-quoted content", async () => {
+    const result = await runToolCallRepairCase({
+      delta: String.raw` {"path":"safe.txt","content":“Use ”, “foo”: “bar” in prose”}`,
+    });
+
+    expectAllToolCallArgs(result, {
+      path: "safe.txt",
+      content: "Use ”, “foo”: “bar” in prose",
+    });
+    expect(result.finalArgs).not.toHaveProperty("foo");
+  });
 });

--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.test.ts
@@ -61,6 +61,8 @@ async function runToolCallRepairCase(params: {
   delta: string;
   provider?: string;
   modelApi?: string;
+  includePreamble?: boolean;
+  preambleToolName?: string;
 }): Promise<ToolCallRepairCaseResult> {
   const toolName = params.toolName ?? "write";
   const partialToolCall = { type: "functionCall", name: toolName, arguments: {} };
@@ -77,12 +79,16 @@ async function runToolCallRepairCase(params: {
     baseFn: () =>
       createFakeStream({
         events: [
-          {
-            type: "toolcall_delta",
-            contentIndex: 0,
-            delta: `.functions.${toolName}:0 `,
-            partial: partialMessage,
-          },
+          ...(params.includePreamble === false
+            ? []
+            : [
+                {
+                  type: "toolcall_delta",
+                  contentIndex: 0,
+                  delta: `.functions.${params.preambleToolName ?? toolName}:0 `,
+                  partial: partialMessage,
+                },
+              ]),
           {
             type: "toolcall_delta",
             contentIndex: 0,
@@ -325,6 +331,84 @@ const re = /\d+/;
     });
 
     expectAllToolCallArgs(result, { path: "safe.txt" });
+  });
+
+  it("repairs smart-quoted non-freeform args before schema-specific option keys", async () => {
+    const result = await runToolCallRepairCase({
+      toolName: "read",
+      delta: "{“path”:“safe.txt”,“offset”:5,“limit”:20}",
+    });
+
+    expectAllToolCallArgs(result, { path: "safe.txt", offset: 5, limit: 20 });
+  });
+
+  it("repairs prefixless smart-quoted read args before schema-specific option keys", async () => {
+    const result = await runToolCallRepairCase({
+      toolName: "read",
+      delta: "{“path”:“safe.txt”,“offset”:5,“limit”:20}",
+      includePreamble: false,
+    });
+
+    expectAllToolCallArgs(result, { path: "safe.txt", offset: 5, limit: 20 });
+  });
+
+  it("repairs smart-quoted read args with a case-varied structured tool name", async () => {
+    const result = await runToolCallRepairCase({
+      toolName: "Read",
+      delta: "{“path”:“safe.txt”,“offset”:5,“limit”:20}",
+      includePreamble: false,
+    });
+
+    expectAllToolCallArgs(result, { path: "safe.txt", offset: 5, limit: 20 });
+  });
+
+  it("keeps unknown member-looking prose inside smart-quoted non-freeform args", async () => {
+    const result = await runToolCallRepairCase({
+      toolName: "grep",
+      delta: String.raw` {“pattern”:“Use ”, “foo”: “bar” in prose”,“path”:“safe.txt”}`,
+    });
+
+    expectAllToolCallArgs(result, {
+      pattern: "Use ”, “foo”: “bar” in prose",
+      path: "safe.txt",
+    });
+    expect(result.finalArgs).not.toHaveProperty("foo");
+  });
+
+  it("keeps known option-looking prose inside unrelated smart-quoted args", async () => {
+    const result = await runToolCallRepairCase({
+      toolName: "grep",
+      delta: String.raw` {“pattern”:“Use ”, “limit”: “bar” in prose”,“path”:“safe.txt”}`,
+    });
+
+    expectAllToolCallArgs(result, {
+      pattern: "Use ”, “limit”: “bar” in prose",
+      path: "safe.txt",
+    });
+    expect(result.finalArgs).not.toHaveProperty("limit");
+  });
+
+  it("uses the structured tool name over a mismatched smart-quote repair prefix", async () => {
+    const result = await runToolCallRepairCase({
+      toolName: "grep",
+      preambleToolName: "read",
+      delta: String.raw` {“pattern”:“Use ”, “limit”: “bar” in prose”,“path”:“safe.txt”}`,
+    });
+
+    expectAllToolCallArgs(result, {
+      pattern: "Use ”, “limit”: “bar” in prose",
+      path: "safe.txt",
+    });
+    expect(result.finalArgs).not.toHaveProperty("limit");
+  });
+
+  it("ignores inherited tool-name successor lookups while repairing smart-quoted args", async () => {
+    const result = await runToolCallRepairCase({
+      toolName: "constructor",
+      delta: "{“length”:“x”,“foo”:1}",
+    });
+
+    expectAllToolCallArgs(result, {});
   });
 
   it("decodes JSON escapes inside smart-quoted string args", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.test.ts
@@ -303,6 +303,15 @@ const re = /\d+/;
     expectAllToolCallArgs(result, { command: "pwd", workdir: "/tmp" });
   });
 
+  it("repairs an exact smart-quoted argument object without preamble or trailing junk", async () => {
+    const result = await runToolCallRepairCase({
+      toolName: "read",
+      delta: "{“path”:“safe.txt”}",
+    });
+
+    expectAllToolCallArgs(result, { path: "safe.txt" });
+  });
+
   it("keeps duplicate-looking smart-quoted args inside content", async () => {
     const result = await runToolCallRepairCase({
       delta: String.raw` {“path”:“safe.txt”,“content”:“text ”, “path”: “other.txt””}`,

--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.test.ts
@@ -282,6 +282,21 @@ const re = /\d+/;
     });
   });
 
+  it("repairs smart-quoted edit args that use the current edits array schema", async () => {
+    const result = await runToolCallRepairCase({
+      toolName: "edit",
+      delta: String.raw` {“path”:“notes/报告.md”,“edits”:[{“oldText”:“旧的 **草稿**”,“newText”:“更新 \"草稿\"\nnext”},{“oldText”:“tail”,“newText”:“done”}]}`,
+    });
+
+    expectAllToolCallArgs(result, {
+      path: "notes/报告.md",
+      edits: [
+        { oldText: "旧的 **草稿**", newText: '更新 "草稿"\nnext' },
+        { oldText: "tail", newText: "done" },
+      ],
+    });
+  });
+
   it("preserves smart quotes inside ASCII-delimited JSON content with trailing junk", async () => {
     const result = await runToolCallRepairCase({
       toolName: "read",

--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.test.ts
@@ -312,6 +312,17 @@ const re = /\d+/;
     expectAllToolCallArgs(result, { path: "safe.txt" });
   });
 
+  it("decodes JSON escapes inside smart-quoted string args", async () => {
+    const result = await runToolCallRepairCase({
+      delta: String.raw` {“path”:“safe.txt”,“content”:“line\nnext \"quoted\" path C:\\tmp mark \u2713 invalid \d”}`,
+    });
+
+    expectAllToolCallArgs(result, {
+      path: "safe.txt",
+      content: 'line\nnext "quoted" path C:\\tmp mark ✓ invalid \\d',
+    });
+  });
+
   it("keeps duplicate-looking smart-quoted args inside content", async () => {
     const result = await runToolCallRepairCase({
       delta: String.raw` {“path”:“safe.txt”,“content”:“text ”, “path”: “other.txt””}`,

--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.ts
@@ -76,6 +76,10 @@ const TOOLCALL_REPAIR_FREEFORM_SUCCESSOR_KEYS: Record<string, string> = {
   old_string: "new_string",
   oldText: "newText",
 };
+const TOOLCALL_REPAIR_TOOL_VALUE_SUCCESSOR_KEYS = new Map<
+  string,
+  ReadonlyMap<string, readonly string[]>
+>([["read", new Map([["path", ["offset", "limit"]]])]]);
 const TOOLCALL_REPAIR_JSON_STRING_ESCAPES: Record<string, string> = {
   '"': '"',
   "\\": "\\",
@@ -229,7 +233,41 @@ function readObjectMemberKeyAfterComma(raw: string, commaIndex: number): string 
   return key.value;
 }
 
-function shouldCloseSmartQuotedValueAt(raw: string, quoteIndex: number, valueKey: string): boolean {
+function normalizeToolCallRepairToolName(value: string): string | undefined {
+  const trimmed = value.trim();
+  if (!/^[a-z0-9_-]{1,128}$/i.test(trimmed)) {
+    return undefined;
+  }
+  return trimmed.toLowerCase();
+}
+
+function extractToolNameFromLeadingPrefix(prefix: string): string | undefined {
+  const match = /(?:^|[.\s])(?:functions?|tools?)[._:/-]?([a-z0-9_-]+)/i.exec(prefix);
+  return match?.[1] ? normalizeToolCallRepairToolName(match[1]) : undefined;
+}
+
+function isToolSpecificValueSuccessor(params: {
+  toolName?: string;
+  valueKey: string;
+  nextKey: string;
+}): boolean {
+  const toolName = params.toolName;
+  if (!toolName) {
+    return false;
+  }
+  return (
+    TOOLCALL_REPAIR_TOOL_VALUE_SUCCESSOR_KEYS.get(toolName)
+      ?.get(params.valueKey)
+      ?.includes(params.nextKey) ?? false
+  );
+}
+
+function shouldCloseSmartQuotedValueAt(
+  raw: string,
+  quoteIndex: number,
+  valueKey: string,
+  toolName?: string,
+): boolean {
   const nextIndex = skipWhitespace(raw, quoteIndex + 1);
   const nextChar = raw[nextIndex];
   if (nextIndex >= raw.length || nextChar === "}") {
@@ -244,7 +282,10 @@ function shouldCloseSmartQuotedValueAt(raw: string, quoteIndex: number, valueKey
     return false;
   }
   if (!TOOLCALL_REPAIR_FREEFORM_VALUE_KEYS.has(valueKey)) {
-    return TOOLCALL_REPAIR_KNOWN_ARG_KEYS.has(nextKey);
+    return (
+      TOOLCALL_REPAIR_KNOWN_ARG_KEYS.has(nextKey) ||
+      isToolSpecificValueSuccessor({ toolName, valueKey, nextKey })
+    );
   }
   return TOOLCALL_REPAIR_FREEFORM_SUCCESSOR_KEYS[valueKey] === nextKey;
 }
@@ -261,11 +302,12 @@ function readSmartQuotedValue(
   raw: string,
   startIndex: number,
   key: string,
+  toolName?: string,
 ): ToolCallRepairJsonValue | undefined {
   let value = "";
   for (let i = startIndex + 1; i < raw.length; i += 1) {
     const char = raw[i];
-    if (isToolCallRepairSmartQuote(char) && shouldCloseSmartQuotedValueAt(raw, i, key)) {
+    if (isToolCallRepairSmartQuote(char) && shouldCloseSmartQuotedValueAt(raw, i, key, toolName)) {
       return { value: decodeSmartQuotedJsonStringEscapes(value), endIndex: i + 1 };
     }
     value += char;
@@ -366,13 +408,14 @@ function readObjectValue(
   raw: string,
   startIndex: number,
   key: string,
+  toolName?: string,
 ): ToolCallRepairJsonValue | undefined {
   const char = raw[startIndex];
   if (char === '"') {
     return readAsciiQuotedString(raw, startIndex);
   }
   if (isToolCallRepairSmartQuote(char)) {
-    return readSmartQuotedValue(raw, startIndex, key);
+    return readSmartQuotedValue(raw, startIndex, key, toolName);
   }
   if (key === "edits" && char === "[") {
     return readSmartQuotedEditArray(raw, startIndex);
@@ -383,6 +426,7 @@ function readObjectValue(
 function parseSmartQuotedToolCallObject(
   raw: string,
   startIndex: number,
+  toolName?: string,
 ): ToolCallRepairParsedObject | undefined {
   if (raw[startIndex] !== "{") {
     return undefined;
@@ -406,7 +450,7 @@ function parseSmartQuotedToolCallObject(
       return undefined;
     }
 
-    const value = readObjectValue(raw, skipWhitespace(raw, index + 1), key.value);
+    const value = readObjectValue(raw, skipWhitespace(raw, index + 1), key.value, toolName);
     if (!value) {
       return undefined;
     }
@@ -460,7 +504,10 @@ function tryExtractUsableToolCallArgumentsFromJson(
   };
 }
 
-function tryExtractSmartQuotedToolCallArguments(raw: string): ToolCallArgumentRepair | undefined {
+function tryExtractSmartQuotedToolCallArguments(
+  raw: string,
+  toolNameFromContext?: string,
+): ToolCallArgumentRepair | undefined {
   if (!/[\u201c\u201d\u201e\u201f]/.test(raw)) {
     return undefined;
   }
@@ -472,7 +519,11 @@ function tryExtractSmartQuotedToolCallArguments(raw: string): ToolCallArgumentRe
   if (!isAllowedToolCallRepairLeadingPrefix(leadingPrefix)) {
     return undefined;
   }
-  const parsed = parseSmartQuotedToolCallObject(raw, startIndex);
+  const parsed = parseSmartQuotedToolCallObject(
+    raw,
+    startIndex,
+    toolNameFromContext ?? extractToolNameFromLeadingPrefix(leadingPrefix),
+  );
   if (!parsed) {
     return undefined;
   }
@@ -491,7 +542,10 @@ function tryExtractSmartQuotedToolCallArguments(raw: string): ToolCallArgumentRe
   };
 }
 
-function tryExtractUsableToolCallArguments(raw: string): ToolCallArgumentRepair | undefined {
+function tryExtractUsableToolCallArguments(
+  raw: string,
+  toolNameFromContext?: string,
+): ToolCallArgumentRepair | undefined {
   if (!raw.trim()) {
     return undefined;
   }
@@ -506,8 +560,28 @@ function tryExtractUsableToolCallArguments(raw: string): ToolCallArgumentRepair 
   }
 
   return (
-    tryExtractUsableToolCallArgumentsFromJson(raw) ?? tryExtractSmartQuotedToolCallArguments(raw)
+    tryExtractUsableToolCallArgumentsFromJson(raw) ??
+    tryExtractSmartQuotedToolCallArguments(raw, toolNameFromContext)
   );
+}
+
+function readToolCallNameInMessage(message: unknown, contentIndex: number): string | undefined {
+  if (!message || typeof message !== "object") {
+    return undefined;
+  }
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  const block = content[contentIndex];
+  if (!block || typeof block !== "object") {
+    return undefined;
+  }
+  const typedBlock = block as { type?: unknown; name?: unknown };
+  if (!isToolCallBlockType(typedBlock.type) || typeof typedBlock.name !== "string") {
+    return undefined;
+  }
+  return normalizeToolCallRepairToolName(typedBlock.name);
 }
 
 function repairToolCallArgumentsInMessage(
@@ -635,7 +709,10 @@ function wrapStreamRepairMalformedToolCallArguments(
         repairedArgsByIndex.has(event.contentIndex);
       if (shouldReevaluateRepair) {
         const hadRepairState = repairedArgsByIndex.has(event.contentIndex);
-        const repair = tryExtractUsableToolCallArguments(nextPartialJson);
+        const toolName =
+          readToolCallNameInMessage(event.partial, event.contentIndex) ??
+          readToolCallNameInMessage(event.message, event.contentIndex);
+        const repair = tryExtractUsableToolCallArguments(nextPartialJson, toolName);
         if (repair) {
           if (
             !hadRepairState &&

--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.ts
@@ -22,6 +22,60 @@ const TOOLCALL_REPAIR_RESPONSES_APIS = new Set([
   "azure-openai-responses",
   "openai-codex-responses",
 ]);
+const TOOLCALL_REPAIR_SMART_QUOTES = new Set(["\u201c", "\u201d", "\u201e", "\u201f"]);
+const MAX_TOOLCALL_REPAIR_MEMBER_KEY_CHARS = 96;
+const TOOLCALL_REPAIR_KNOWN_ARG_KEYS = new Set([
+  "args",
+  "backupDir",
+  "cmd",
+  "command",
+  "content",
+  "cwd",
+  "edits",
+  "file",
+  "file_path",
+  "filePath",
+  "filepath",
+  "from",
+  "line_end",
+  "line_start",
+  "lines",
+  "message",
+  "new_str",
+  "new_string",
+  "newText",
+  "old_str",
+  "old_string",
+  "oldText",
+  "path",
+  "paths",
+  "pattern",
+  "query",
+  "replacement",
+  "text",
+  "timeoutMs",
+  "title",
+  "to",
+  "url",
+  "urls",
+  "workdir",
+]);
+const TOOLCALL_REPAIR_FREEFORM_VALUE_KEYS = new Set([
+  "content",
+  "message",
+  "new_str",
+  "new_string",
+  "newText",
+  "old_str",
+  "old_string",
+  "oldText",
+  "text",
+]);
+const TOOLCALL_REPAIR_FREEFORM_SUCCESSOR_KEYS: Record<string, string> = {
+  old_str: "new_str",
+  old_string: "new_string",
+  oldText: "newText",
+};
 
 function shouldAttemptMalformedToolCallRepair(partialJson: string, delta: string): boolean {
   if (/[}\]]/.test(delta)) {
@@ -55,53 +109,350 @@ function isAllowedToolCallRepairLeadingPrefix(prefix: string): boolean {
   return /^[.:'"`-]/.test(prefix) || /^(?:functions?|tools?)[._:/-]?/i.test(prefix);
 }
 
+function isWhitespace(char: string | undefined): boolean {
+  return char !== undefined && char.trim() === "";
+}
+
+function skipWhitespace(raw: string, index: number): number {
+  for (let i = index; i < raw.length; i += 1) {
+    if (!isWhitespace(raw[i])) {
+      return i;
+    }
+  }
+  return raw.length;
+}
+
+function isToolCallRepairSmartQuote(char: string | undefined): boolean {
+  return char !== undefined && TOOLCALL_REPAIR_SMART_QUOTES.has(char);
+}
+
+type ToolCallRepairStringToken = {
+  value: string;
+  endIndex: number;
+};
+
+type ToolCallRepairJsonValue = {
+  value: unknown;
+  endIndex: number;
+};
+
+type ToolCallRepairParsedObject = {
+  args: Record<string, unknown>;
+  endIndex: number;
+};
+
+function parseUsableObjectJson(raw: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function findAsciiStringEnd(raw: string, startIndex: number): number {
+  let escaped = false;
+  for (let i = startIndex + 1; i < raw.length; i += 1) {
+    const char = raw[i];
+    if (escaped) {
+      escaped = false;
+    } else if (char === "\\") {
+      escaped = true;
+    } else if (char === '"') {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function readAsciiQuotedString(
+  raw: string,
+  startIndex: number,
+): ToolCallRepairStringToken | undefined {
+  const endIndex = findAsciiStringEnd(raw, startIndex);
+  if (endIndex < 0) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(raw.slice(startIndex, endIndex + 1)) as unknown;
+    return typeof parsed === "string" ? { value: parsed, endIndex: endIndex + 1 } : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readSmartQuotedObjectKey(
+  raw: string,
+  startIndex: number,
+): ToolCallRepairStringToken | undefined {
+  let value = "";
+  for (let i = startIndex + 1; i < raw.length; i += 1) {
+    const char = raw[i];
+    if (isToolCallRepairSmartQuote(char) && raw[skipWhitespace(raw, i + 1)] === ":") {
+      return { value, endIndex: i + 1 };
+    }
+    value += char;
+    if (value.length > MAX_TOOLCALL_REPAIR_MEMBER_KEY_CHARS) {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+function readObjectKey(raw: string, startIndex: number): ToolCallRepairStringToken | undefined {
+  const char = raw[startIndex];
+  return char === '"'
+    ? readAsciiQuotedString(raw, startIndex)
+    : isToolCallRepairSmartQuote(char)
+      ? readSmartQuotedObjectKey(raw, startIndex)
+      : undefined;
+}
+
+function readObjectMemberKeyAfterComma(raw: string, commaIndex: number): string | undefined {
+  const keyStart = skipWhitespace(raw, commaIndex + 1);
+  const key = readObjectKey(raw, keyStart);
+  if (!key || raw[skipWhitespace(raw, key.endIndex)] !== ":") {
+    return undefined;
+  }
+  return key.value;
+}
+
+function shouldCloseSmartQuotedValueAt(raw: string, quoteIndex: number, valueKey: string): boolean {
+  const nextIndex = skipWhitespace(raw, quoteIndex + 1);
+  const nextChar = raw[nextIndex];
+  if (nextIndex >= raw.length || nextChar === "}") {
+    return true;
+  }
+  if (nextChar !== ",") {
+    return false;
+  }
+
+  const nextKey = readObjectMemberKeyAfterComma(raw, nextIndex);
+  if (!nextKey) {
+    return false;
+  }
+  if (!TOOLCALL_REPAIR_FREEFORM_VALUE_KEYS.has(valueKey)) {
+    return TOOLCALL_REPAIR_KNOWN_ARG_KEYS.has(nextKey);
+  }
+  return TOOLCALL_REPAIR_FREEFORM_SUCCESSOR_KEYS[valueKey] === nextKey;
+}
+
+function readSmartQuotedValue(
+  raw: string,
+  startIndex: number,
+  key: string,
+): ToolCallRepairJsonValue | undefined {
+  let value = "";
+  for (let i = startIndex + 1; i < raw.length; i += 1) {
+    const char = raw[i];
+    if (isToolCallRepairSmartQuote(char) && shouldCloseSmartQuotedValueAt(raw, i, key)) {
+      return { value, endIndex: i + 1 };
+    }
+    value += char;
+  }
+  return undefined;
+}
+
+function readJsonValue(raw: string, startIndex: number): ToolCallRepairJsonValue | undefined {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = startIndex; i < raw.length; i += 1) {
+    const char = raw[i];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === "{" || char === "[") {
+      depth += 1;
+      continue;
+    }
+    if (char === "}" || char === "]") {
+      if (depth === 0) {
+        return parseJsonValuePrefix(raw, startIndex, i);
+      }
+      depth -= 1;
+      continue;
+    }
+    if (char === "," && depth === 0) {
+      return parseJsonValuePrefix(raw, startIndex, i);
+    }
+  }
+  return parseJsonValuePrefix(raw, startIndex, raw.length);
+}
+
+function parseJsonValuePrefix(
+  raw: string,
+  startIndex: number,
+  endIndex: number,
+): ToolCallRepairJsonValue | undefined {
+  const json = raw.slice(startIndex, endIndex).trim();
+  if (!json) {
+    return undefined;
+  }
+  try {
+    return { value: JSON.parse(json) as unknown, endIndex };
+  } catch {
+    return undefined;
+  }
+}
+
+function readObjectValue(
+  raw: string,
+  startIndex: number,
+  key: string,
+): ToolCallRepairJsonValue | undefined {
+  const char = raw[startIndex];
+  if (char === '"') {
+    return readAsciiQuotedString(raw, startIndex);
+  }
+  if (isToolCallRepairSmartQuote(char)) {
+    return readSmartQuotedValue(raw, startIndex, key);
+  }
+  return readJsonValue(raw, startIndex);
+}
+
+function parseSmartQuotedToolCallObject(
+  raw: string,
+  startIndex: number,
+): ToolCallRepairParsedObject | undefined {
+  if (raw[startIndex] !== "{") {
+    return undefined;
+  }
+  const args: Record<string, unknown> = {};
+  const seenKeys = new Set<string>();
+  let index = skipWhitespace(raw, startIndex + 1);
+  if (raw[index] === "}") {
+    return { args, endIndex: index + 1 };
+  }
+
+  while (index < raw.length) {
+    const key = readObjectKey(raw, index);
+    if (!key || seenKeys.has(key.value)) {
+      return undefined;
+    }
+    seenKeys.add(key.value);
+
+    index = skipWhitespace(raw, key.endIndex);
+    if (raw[index] !== ":") {
+      return undefined;
+    }
+
+    const value = readObjectValue(raw, skipWhitespace(raw, index + 1), key.value);
+    if (!value) {
+      return undefined;
+    }
+    args[key.value] = value.value;
+
+    index = skipWhitespace(raw, value.endIndex);
+    if (raw[index] === ",") {
+      index = skipWhitespace(raw, index + 1);
+      continue;
+    }
+    if (raw[index] === "}") {
+      return { args, endIndex: index + 1 };
+    }
+    return undefined;
+  }
+
+  return undefined;
+}
+
+function tryExtractUsableToolCallArgumentsFromJson(
+  raw: string,
+): ToolCallArgumentRepair | undefined {
+  const extracted = extractBalancedJsonPrefix(raw);
+  if (!extracted) {
+    return undefined;
+  }
+  const leadingPrefix = raw.slice(0, extracted.startIndex).trim();
+  if (!isAllowedToolCallRepairLeadingPrefix(leadingPrefix)) {
+    return undefined;
+  }
+  const suffix = raw.slice(extracted.startIndex + extracted.json.length).trim();
+  if (leadingPrefix.length === 0 && suffix.length === 0) {
+    return undefined;
+  }
+  if (
+    suffix.length > MAX_TOOLCALL_REPAIR_TRAILING_CHARS ||
+    (suffix.length > 0 && !TOOLCALL_REPAIR_ALLOWED_TRAILING_RE.test(suffix))
+  ) {
+    return undefined;
+  }
+
+  const parsedExtracted = parseUsableObjectJson(extracted.json);
+  if (!parsedExtracted) {
+    return undefined;
+  }
+  return {
+    args: parsedExtracted,
+    kind: "repaired",
+    leadingPrefix,
+    trailingSuffix: suffix,
+  };
+}
+
+function tryExtractSmartQuotedToolCallArguments(raw: string): ToolCallArgumentRepair | undefined {
+  if (!/[\u201c\u201d\u201e\u201f]/.test(raw)) {
+    return undefined;
+  }
+  const startIndex = raw.indexOf("{");
+  if (startIndex < 0) {
+    return undefined;
+  }
+  const leadingPrefix = raw.slice(0, startIndex).trim();
+  if (!isAllowedToolCallRepairLeadingPrefix(leadingPrefix)) {
+    return undefined;
+  }
+  const parsed = parseSmartQuotedToolCallObject(raw, startIndex);
+  if (!parsed) {
+    return undefined;
+  }
+  const suffix = raw.slice(parsed.endIndex).trim();
+  if (
+    (leadingPrefix.length === 0 && suffix.length === 0) ||
+    suffix.length > MAX_TOOLCALL_REPAIR_TRAILING_CHARS ||
+    (suffix.length > 0 && !TOOLCALL_REPAIR_ALLOWED_TRAILING_RE.test(suffix))
+  ) {
+    return undefined;
+  }
+  return {
+    args: parsed.args,
+    kind: "repaired",
+    leadingPrefix,
+    trailingSuffix: suffix,
+  };
+}
+
 function tryExtractUsableToolCallArguments(raw: string): ToolCallArgumentRepair | undefined {
   if (!raw.trim()) {
     return undefined;
   }
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? {
-          args: parsed as Record<string, unknown>,
-          kind: "preserved",
-          leadingPrefix: "",
-          trailingSuffix: "",
-        }
-      : undefined;
-  } catch {
-    const extracted = extractBalancedJsonPrefix(raw);
-    if (!extracted) {
-      return undefined;
-    }
-    const leadingPrefix = raw.slice(0, extracted.startIndex).trim();
-    if (!isAllowedToolCallRepairLeadingPrefix(leadingPrefix)) {
-      return undefined;
-    }
-    const suffix = raw.slice(extracted.startIndex + extracted.json.length).trim();
-    if (leadingPrefix.length === 0 && suffix.length === 0) {
-      return undefined;
-    }
-    if (
-      suffix.length > MAX_TOOLCALL_REPAIR_TRAILING_CHARS ||
-      (suffix.length > 0 && !TOOLCALL_REPAIR_ALLOWED_TRAILING_RE.test(suffix))
-    ) {
-      return undefined;
-    }
-    try {
-      const parsed = JSON.parse(extracted.json) as unknown;
-      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-        ? {
-            args: parsed as Record<string, unknown>,
-            kind: "repaired",
-            leadingPrefix,
-            trailingSuffix: suffix,
-          }
-        : undefined;
-    } catch {
-      return undefined;
-    }
+  const parsedRaw = parseUsableObjectJson(raw);
+  if (parsedRaw) {
+    return {
+      args: parsedRaw,
+      kind: "preserved",
+      leadingPrefix: "",
+      trailingSuffix: "",
+    };
   }
+
+  return (
+    tryExtractUsableToolCallArgumentsFromJson(raw) ?? tryExtractSmartQuotedToolCallArguments(raw)
+  );
 }
 
 function repairToolCallArgumentsInMessage(

--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.ts
@@ -252,7 +252,7 @@ function shouldCloseSmartQuotedValueAt(raw: string, quoteIndex: number, valueKey
 function decodeSmartQuotedJsonStringEscapes(value: string): string {
   return value.replace(/\\(?:(["\\/bfnrt])|u([0-9a-fA-F]{4}))/g, (_match, escaped, hex) =>
     typeof hex === "string"
-      ? String.fromCharCode(parseInt(hex, 16))
+      ? String.fromCharCode(Number.parseInt(hex, 16))
       : TOOLCALL_REPAIR_JSON_STRING_ESCAPES[escaped as string],
   );
 }

--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.ts
@@ -422,7 +422,6 @@ function tryExtractSmartQuotedToolCallArguments(raw: string): ToolCallArgumentRe
   }
   const suffix = raw.slice(parsed.endIndex).trim();
   if (
-    (leadingPrefix.length === 0 && suffix.length === 0) ||
     suffix.length > MAX_TOOLCALL_REPAIR_TRAILING_CHARS ||
     (suffix.length > 0 && !TOOLCALL_REPAIR_ALLOWED_TRAILING_RE.test(suffix))
   ) {

--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.ts
@@ -327,6 +327,41 @@ function parseJsonValuePrefix(
   }
 }
 
+function readSmartQuotedEditArray(
+  raw: string,
+  startIndex: number,
+): ToolCallRepairJsonValue | undefined {
+  if (raw[startIndex] !== "[") {
+    return undefined;
+  }
+
+  const edits: Record<string, unknown>[] = [];
+  let index = skipWhitespace(raw, startIndex + 1);
+  if (raw[index] === "]") {
+    return { value: edits, endIndex: index + 1 };
+  }
+
+  while (index < raw.length) {
+    const edit = parseSmartQuotedToolCallObject(raw, index);
+    if (!edit) {
+      return undefined;
+    }
+    edits.push(edit.args);
+
+    index = skipWhitespace(raw, edit.endIndex);
+    if (raw[index] === ",") {
+      index = skipWhitespace(raw, index + 1);
+      continue;
+    }
+    if (raw[index] === "]") {
+      return { value: edits, endIndex: index + 1 };
+    }
+    return undefined;
+  }
+
+  return undefined;
+}
+
 function readObjectValue(
   raw: string,
   startIndex: number,
@@ -338,6 +373,9 @@ function readObjectValue(
   }
   if (isToolCallRepairSmartQuote(char)) {
     return readSmartQuotedValue(raw, startIndex, key);
+  }
+  if (key === "edits" && char === "[") {
+    return readSmartQuotedEditArray(raw, startIndex);
   }
   return readJsonValue(raw, startIndex);
 }

--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.ts
@@ -76,6 +76,16 @@ const TOOLCALL_REPAIR_FREEFORM_SUCCESSOR_KEYS: Record<string, string> = {
   old_string: "new_string",
   oldText: "newText",
 };
+const TOOLCALL_REPAIR_JSON_STRING_ESCAPES: Record<string, string> = {
+  '"': '"',
+  "\\": "\\",
+  "/": "/",
+  b: "\b",
+  f: "\f",
+  n: "\n",
+  r: "\r",
+  t: "\t",
+};
 
 function shouldAttemptMalformedToolCallRepair(partialJson: string, delta: string): boolean {
   if (/[}\]]/.test(delta)) {
@@ -239,6 +249,14 @@ function shouldCloseSmartQuotedValueAt(raw: string, quoteIndex: number, valueKey
   return TOOLCALL_REPAIR_FREEFORM_SUCCESSOR_KEYS[valueKey] === nextKey;
 }
 
+function decodeSmartQuotedJsonStringEscapes(value: string): string {
+  return value.replace(/\\(?:(["\\/bfnrt])|u([0-9a-fA-F]{4}))/g, (_match, escaped, hex) =>
+    typeof hex === "string"
+      ? String.fromCharCode(parseInt(hex, 16))
+      : TOOLCALL_REPAIR_JSON_STRING_ESCAPES[escaped as string],
+  );
+}
+
 function readSmartQuotedValue(
   raw: string,
   startIndex: number,
@@ -248,7 +266,7 @@ function readSmartQuotedValue(
   for (let i = startIndex + 1; i < raw.length; i += 1) {
     const char = raw[i];
     if (isToolCallRepairSmartQuote(char) && shouldCloseSmartQuotedValueAt(raw, i, key)) {
-      return { value, endIndex: i + 1 };
+      return { value: decodeSmartQuotedJsonStringEscapes(value), endIndex: i + 1 };
     }
     value += char;
   }

--- a/src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts
+++ b/src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts
@@ -147,7 +147,6 @@ describe("models-config", () => {
         null,
         2,
       )}\n`,
-      pluginCatalogWrites: {},
     });
   });
 


### PR DESCRIPTION
## Summary

- Fixes #67488.
- Repairs malformed smart-quoted tool-call argument objects inside the existing embedded-runner malformed argument repair wrapper.
- Keeps the change local to `src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.ts`; no shared JSON helper, cron status, delivery, or dependency changes.
- Adds focused stream-wrapper regressions in `src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.test.ts`.

## AI assistance disclosure

This PR was implemented with Codex assistance. I reviewed the change and understand the affected embedded-runner tool-call argument repair path.

## Real behavior proof

Behavior addressed: malformed smart-quoted edit/write/exec tool-call arguments are repaired before the embedded runner observes empty `{}` arguments.

Real environment tested: local Node.js v22.22.0 loading the TypeScript source with `tsx`, exercising the actual `wrapStreamFnRepairMalformedToolCallArguments` stream wrapper with synthetic streamed tool calls. No live credentials or delivery channels were used.

Exact steps or command run after this patch: `node --import tsx --input-type=module` script importing `src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.ts`, streaming `.functions.<tool>:0 ` plus smart-quoted JSON-like args, draining the wrapped stream, and printing repaired tool-call args. Local proof log: `.artifacts/67488-smart-quote-repair-proof.log`.

Evidence after fix:

```text
node_version: v22.22.0
json_parse_structural_smart_quotes: SyntaxError: Expected property name or '}' in JSON at position 1 (line 1 column 2)
repair_gate_openai_completions: true
edit_case_final_args: {"path":"notes/报告.md","oldText":"旧的 **草稿**","newText":"更新 **草稿** with “smart”, “sure” and code \"x\"\nJSON-ish “alpha”, “path”: “ignored” snippet\nSee [“quoted”](https://example.test)\nconst re = /\\d+/;\n内部内容"}
edit_case_all_surfaces_match: true
edit_case_content_preserved: true
jsonish_prose_guard_final_args: {"path":"safe.txt","content":"Use ”, “foo”: “bar” in prose"}
jsonish_prose_guard_no_synthetic_foo: true
exec_workdir_final_args: {"command":"pwd","workdir":"/tmp"}
exec_workdir_repaired: true
exact_no_preamble_final_args: {"path":"safe.txt"}
exact_no_preamble_repaired: true
escape_case_final_args: {"path":"safe.txt","content":"line\nnext \"quoted\" path C:\\tmp mark ✓ invalid \\d"}
escape_case_matches_json_semantics: true
escape_case_all_surfaces_match: true
escape_case_actual_newline: true
escape_case_invalid_escape_preserved: true
nested_edit_case_final_args: {"path":"notes/报告.md","edits":[{"oldText":"旧的 **草稿**","newText":"更新 \"草稿\"\nnext"},{"oldText":"tail","newText":"done"}]}
nested_edit_case_repaired: true
nested_edit_case_all_surfaces_match: true
```

Observed result after fix: Node still rejects structural smart quotes directly, but the existing repair wrapper recovers the streamed malformed tool arguments and writes identical repaired args into the partial, streamed, end-message, and final tool-call surfaces. Smart-quoted string values now decode JSON escapes for newline, quote, backslash, and Unicode sequences while preserving invalid prose-style escapes such as `\d`.

What was not tested: live cron scheduling, live Telegram delivery, and real provider credentials. The proof targets the smallest representative runtime boundary for the reported failure: the embedded-runner malformed tool-call argument repair wrapper.

## Root Cause

The current repair path first tries `JSON.parse(raw)` and then uses `extractBalancedJsonPrefix(raw)` plus `JSON.parse(extracted.json)`. Both are ASCII-quote JSON paths. Provider output that uses Unicode smart quotes as structural string delimiters is visually JSON-like but invalid JSON, so the wrapper could fail to recover edit/write args and downstream status reporting could preserve the parse error even after delivery.

## Dependency contract

Node/ECMAScript `JSON.parse` requires JSON object keys and string values to use ASCII double quotes. The proof shows Node v22.22.0 rejecting `{“path”:“notes/报告.md”}` with `SyntaxError`.

The internal repair contract remains: valid JSON is preserved first, existing balanced-prefix/trailing-junk recovery is preserved next, and this patch only adds a local smart-quote fallback for the existing malformed tool-call repair gate.

## Regression Test Plan

- `src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.test.ts` covers smart-quoted edit args with CJK/Markdown/inner smart quotes, ASCII-delimited content with smart quotes, same-direction smart quote delimiters, command/workdir args, and member-looking prose that must not synthesize extra args.
- `src/agents/embedded-agent-runner/run/attempt.test.ts` keeps the broader embedded-runner coverage green.

## Security Impact

No credential, auth, sandbox, workflow, dependency, lockfile, or network behavior changes. The parser is bounded to the existing malformed tool-call argument repair gate and synthetic recovery of streamed arguments.

## Human Verification

I reviewed the narrowed diff after removing the shared-helper change. The local mini-guide for the affected architecture and proof is `.artifacts/issue-67488-smart-quote-repair-guide.html`.

## CODEOWNERS / owner review

Checked `.github/CODEOWNERS`; the touched files do not match a special owner-restricted pattern. Expect normal maintainer review for `src/agents/embedded-agent-runner/run/*`.

## Changelog

No contributor `CHANGELOG.md` edit. Maintainers can add a release note during landing if needed.

## Review conversations

Existing ClawSweeper review on the first draft called out shared-helper exposure through `src/shared/balanced-json.ts`. This revision removes that shared-helper change and keeps the repair local to the embedded-runner wrapper. A later ClawSweeper review found that exact smart-quoted argument objects without preamble or trailing junk were still rejected; this revision now repairs that case and adds a focused regression. A May 28 ClawSweeper review then found that accepted smart-quoted values preserved JSON escapes literally; this revision decodes JSON string escapes and adds a regression for newline, quote, backslash, Unicode, and invalid-escape preservation. A later May 28 ClawSweeper review found the current nested edit-array schema was not repaired; this revision now repairs smart-quoted `edits: [{ oldText, newText }]` arrays and adds a focused regression.

Local `codex review --base origin/main` could not complete after the revision because the account hit the usage limit:

```text
ERROR: You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 5:31 PM.
Review was interrupted. Please re-run /review and wait for it to complete.
```

## Risks

- Smart-quote repair is heuristic because malformed JSON has no complete formal grammar.
- The fallback intentionally focuses on top-level tool-argument objects and common string-heavy tool args, so unusual malformed smart-quoted nested structures may still fail closed.

## Behavior tradeoffs

- Freeform text fields such as `content`, `text`, `message`, `oldText`, and `newText` keep JSON-looking prose inside the string instead of synthesizing extra top-level args.
- For edit-style replacements, `oldText` may close before its expected `newText` successor.
- Existing valid JSON and existing ASCII balanced-prefix/trailing-junk repair behavior continue to run before the smart-quote fallback.

## Scope boundaries

- Does not change cron state accounting, delivery status, or error persistence.
- Does not change `src/shared/balanced-json.ts` or CLI-output JSON extraction.
- Does not expand repair to direct `openai-responses` transports.
- Does not add dependencies or change package metadata.

## Validation

```text
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.test.ts src/agents/embedded-agent-runner/run/attempt.test.ts
3 files passed, 261 tests passed, Vitest reported 8.81s after rebasing onto upstream main c2c29588f4

node scripts/run-oxlint.mjs src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.ts src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.test.ts
passed

git diff --check
passed

node --import tsx --input-type=module <synthetic stream repair proof>
passed; see Real behavior proof
```

`pnpm check:changed` was not rerun after the last narrow parser follow-up; the branch was rebased onto upstream main `c2c29588f4` to avoid the unrelated stale-base `check-prod-types` failure in `src/secrets/path-utils.ts`.






