### PR TITLE
Preserve xAI usage limit errors in local TUI

### DIFF
--- a/extensions/xai/index.test.ts
+++ b/extensions/xai/index.test.ts
@@ -75,22 +75,25 @@ describe("xai provider plugin", () => {
     expect(
       provider.classifyFailoverReason?.({
         errorMessage:
-          '403 {"error":{"code":"SPENDING_LIMIT","message":"Monthly spending limit reached"}}',
+          '403 {"code":"The caller does not have permission to execute the specified operation","error":"Your team team-redacted has either used all available credits or reached its monthly spending limit. To continue making API requests, please purchase more credits or raise your spending limit."}',
       }),
     ).toBe("billing");
     expect(
       provider.classifyFailoverReason?.({
-        errorMessage: "xAI request failed: usage limit reached for this Grok account",
+        errorMessage:
+          '429 {"code":"Some resource has been exhausted","error":"Your team team-redacted has either used all available credits or reached its monthly spending limit. To continue making API requests, please purchase more credits or raise your spending limit."}',
+      }),
+    ).toBe("billing");
+    expect(
+      provider.classifyFailoverReason?.({
+        errorMessage:
+          '429 {"code":"Some resource has been exhausted","error":"Rate limit exceeded"}',
       }),
     ).toBe("rate_limit");
     expect(
       provider.classifyFailoverReason?.({
-        errorMessage: "Provider API error (429): Too many requests [code=rate_limit_reached]",
-      }),
-    ).toBe("rate_limit");
-    expect(
-      provider.classifyFailoverReason?.({
-        errorMessage: "xAI request failed: invalid request format",
+        errorMessage:
+          '400 {"code":"Client specified an invalid argument","error":"Incorrect API key provided: xa***en. You can obtain an API key from https://console.x.ai."}',
       }),
     ).toBeUndefined();
   });

--- a/extensions/xai/index.test.ts
+++ b/extensions/xai/index.test.ts
@@ -69,6 +69,32 @@ describe("xai provider plugin", () => {
     expect(deviceCode?.wizard?.choiceId).toBe("xai-device-code");
   });
 
+  it("classifies Grok usage and spending limit errors", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    expect(
+      provider.classifyFailoverReason?.({
+        errorMessage:
+          '403 {"error":{"code":"SPENDING_LIMIT","message":"Monthly spending limit reached"}}',
+      }),
+    ).toBe("billing");
+    expect(
+      provider.classifyFailoverReason?.({
+        errorMessage: "xAI request failed: usage limit reached for this Grok account",
+      }),
+    ).toBe("rate_limit");
+    expect(
+      provider.classifyFailoverReason?.({
+        errorMessage: "Provider API error (429): Too many requests [code=rate_limit_reached]",
+      }),
+    ).toBe("rate_limit");
+    expect(
+      provider.classifyFailoverReason?.({
+        errorMessage: "xAI request failed: invalid request format",
+      }),
+    ).toBeUndefined();
+  });
+
   it("registers xAI speech providers for batch and streaming STT", async () => {
     const { mediaProviders, realtimeTranscriptionProviders } = await registerProviderPlugin({
       plugin,

--- a/extensions/xai/index.ts
+++ b/extensions/xai/index.ts
@@ -41,6 +41,35 @@ const PROVIDER_ID = "xai";
 type CodeExecutionModule = typeof import("./code-execution.js");
 type XSearchModule = typeof import("./x-search.js");
 
+const XAI_BILLING_LIMIT_CODES = [
+  "BILLING_DISABLED",
+  "BILLING_HARD_LIMIT",
+  "CREDIT_BALANCE_EXHAUSTED",
+  "CREDIT_BALANCE_TOO_LOW",
+  "INSUFFICIENT_BALANCE",
+  "INSUFFICIENT_CREDITS",
+  "INSUFFICIENT_QUOTA",
+  "MONTHLY_SPENDING_LIMIT",
+  "PAYMENT_REQUIRED",
+  "SPEND_LIMIT",
+  "SPENDING_LIMIT",
+  "SPENDING_LIMIT_EXCEEDED",
+  "SPENDING_LIMIT_REACHED",
+] as const;
+
+const XAI_RATE_LIMIT_CODES = [
+  "QUOTA_EXCEEDED",
+  "RATE_LIMIT",
+  "RATE_LIMIT_EXCEEDED",
+  "RATE_LIMIT_REACHED",
+  "RATE_LIMITED",
+  "RESOURCE_EXHAUSTED",
+  "TOO_MANY_REQUESTS",
+  "USAGE_LIMIT",
+  "USAGE_LIMIT_EXCEEDED",
+  "USAGE_LIMIT_REACHED",
+] as const;
+
 let codeExecutionModulePromise: Promise<CodeExecutionModule> | undefined;
 let xSearchModulePromise: Promise<XSearchModule> | undefined;
 
@@ -52,6 +81,31 @@ function loadCodeExecutionModule(): Promise<CodeExecutionModule> {
 function loadXSearchModule(): Promise<XSearchModule> {
   xSearchModulePromise ??= import("./x-search.js");
   return xSearchModulePromise;
+}
+
+function normalizeXaiErrorSignal(raw: string): string {
+  return raw
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, "_");
+}
+
+function hasXaiErrorSignal(raw: string, signals: readonly string[]): boolean {
+  const normalized = normalizeXaiErrorSignal(raw);
+  return signals.some((signal) => {
+    const escaped = signal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return new RegExp(`(?:^|_)${escaped}(?:_|$)`).test(normalized);
+  });
+}
+
+function classifyXaiFailoverReason(errorMessage: string) {
+  if (hasXaiErrorSignal(errorMessage, XAI_BILLING_LIMIT_CODES)) {
+    return "billing" as const;
+  }
+  if (hasXaiErrorSignal(errorMessage, XAI_RATE_LIMIT_CODES)) {
+    return "rate_limit" as const;
+  }
+  return undefined;
 }
 
 function hasResolvableXaiApiKey(config: unknown, auth?: XaiToolAuthContext): boolean {
@@ -219,6 +273,7 @@ export default defineSingleProviderPluginEntry({
     refreshOAuth: refreshXaiOAuthCredential,
     resolveThinkingProfile,
     isModernModelRef: ({ modelId }) => isModernXaiModel(modelId),
+    classifyFailoverReason: ({ errorMessage }) => classifyXaiFailoverReason(errorMessage),
   },
   register(api) {
     api.registerWebSearchProvider(createXaiWebSearchProvider());

--- a/extensions/xai/index.ts
+++ b/extensions/xai/index.ts
@@ -41,34 +41,9 @@ const PROVIDER_ID = "xai";
 type CodeExecutionModule = typeof import("./code-execution.js");
 type XSearchModule = typeof import("./x-search.js");
 
-const XAI_BILLING_LIMIT_CODES = [
-  "BILLING_DISABLED",
-  "BILLING_HARD_LIMIT",
-  "CREDIT_BALANCE_EXHAUSTED",
-  "CREDIT_BALANCE_TOO_LOW",
-  "INSUFFICIENT_BALANCE",
-  "INSUFFICIENT_CREDITS",
-  "INSUFFICIENT_QUOTA",
-  "MONTHLY_SPENDING_LIMIT",
-  "PAYMENT_REQUIRED",
-  "SPEND_LIMIT",
-  "SPENDING_LIMIT",
-  "SPENDING_LIMIT_EXCEEDED",
-  "SPENDING_LIMIT_REACHED",
-] as const;
-
-const XAI_RATE_LIMIT_CODES = [
-  "QUOTA_EXCEEDED",
-  "RATE_LIMIT",
-  "RATE_LIMIT_EXCEEDED",
-  "RATE_LIMIT_REACHED",
-  "RATE_LIMITED",
-  "RESOURCE_EXHAUSTED",
-  "TOO_MANY_REQUESTS",
-  "USAGE_LIMIT",
-  "USAGE_LIMIT_EXCEEDED",
-  "USAGE_LIMIT_REACHED",
-] as const;
+const XAI_CREDIT_OR_SPENDING_LIMIT_RE =
+  /\b(?:used all available credits|monthly spending limit|purchase more credits|raise your spending limit)\b/i;
+const XAI_RATE_LIMIT_RE = /\b(?:rate limit exceeded|too many requests)\b/i;
 
 let codeExecutionModulePromise: Promise<CodeExecutionModule> | undefined;
 let xSearchModulePromise: Promise<XSearchModule> | undefined;
@@ -83,26 +58,11 @@ function loadXSearchModule(): Promise<XSearchModule> {
   return xSearchModulePromise;
 }
 
-function normalizeXaiErrorSignal(raw: string): string {
-  return raw
-    .trim()
-    .toUpperCase()
-    .replace(/[^A-Z0-9]+/g, "_");
-}
-
-function hasXaiErrorSignal(raw: string, signals: readonly string[]): boolean {
-  const normalized = normalizeXaiErrorSignal(raw);
-  return signals.some((signal) => {
-    const escaped = signal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    return new RegExp(`(?:^|_)${escaped}(?:_|$)`).test(normalized);
-  });
-}
-
 function classifyXaiFailoverReason(errorMessage: string) {
-  if (hasXaiErrorSignal(errorMessage, XAI_BILLING_LIMIT_CODES)) {
+  if (XAI_CREDIT_OR_SPENDING_LIMIT_RE.test(errorMessage)) {
     return "billing" as const;
   }
-  if (hasXaiErrorSignal(errorMessage, XAI_RATE_LIMIT_CODES)) {
+  if (XAI_RATE_LIMIT_RE.test(errorMessage)) {
     return "rate_limit" as const;
   }
   return undefined;

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -544,6 +544,49 @@ describe("failover-error", () => {
         message: INSUFFICIENT_QUOTA_PAYLOAD,
       }),
     ).toBe("billing");
+    expect(
+      resolveFailoverReasonFromError({
+        provider: "openai",
+        status: 429,
+        message: INSUFFICIENT_QUOTA_PAYLOAD,
+      }),
+    ).toBe("billing");
+    expect(
+      resolveFailoverReasonFromError({
+        provider: "openai",
+        status: 429,
+        message: '{"error":"insufficient_balance","message":"Your credit balance is too low."}',
+      }),
+    ).toBe("billing");
+    expect(
+      resolveFailoverReasonFromError({
+        provider: "openai",
+        status: 429,
+        message: '{"error":"insufficient_balance","message":"Insufficient account balance"}',
+      }),
+    ).toBe("billing");
+    expect(
+      resolveFailoverReasonFromError({
+        provider: "openai",
+        status: 429,
+        message:
+          'HTTP 429: {"error":"insufficient_balance","message":"Insufficient account balance"}',
+      }),
+    ).toBe("billing");
+    expect(
+      resolveFailoverReasonFromError({
+        provider: "openai",
+        status: 429,
+        message: "This model requires more credits to use",
+      }),
+    ).toBe("billing");
+    expect(
+      resolveFailoverReasonFromError({
+        provider: "openrouter",
+        status: 429,
+        message: "Key limit exceeded",
+      }),
+    ).toBe("billing");
   });
 
   it("lets structured HTTP 400 payloads reuse provider-specific message classification", () => {

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -172,6 +172,62 @@ describe("formatAssistantErrorText", () => {
     });
     expect(result).toBe(formatBillingErrorMessage("xai", "grok-4.3"));
   });
+  it("keeps known Moonshot 429 balance failures on billing copy", () => {
+    const msg = makeAssistantError(
+      '429 {"error":{"message":"Your account has insufficient balance. Please recharge to continue.","type":"rate_limit_reached"}}',
+    );
+    const result = formatAssistantErrorText(msg, {
+      provider: "moonshot",
+      model: "kimi-k2",
+    });
+    expect(result).toBe(formatBillingErrorMessage("moonshot", "kimi-k2"));
+  });
+  it("keeps high-confidence 429 insufficient quota failures on billing copy", () => {
+    const msg = makeAssistantError(
+      '429 {"type":"error","error":{"type":"insufficient_quota","message":"Your account has insufficient quota balance to run this request."}}',
+    );
+    const result = formatAssistantErrorText(msg, {
+      provider: "openai",
+      model: "gpt-5.5",
+    });
+    expect(result).toBe(formatBillingErrorMessage("openai", "gpt-5.5"));
+  });
+  it("keeps high-confidence 429 insufficient balance failures on billing copy", () => {
+    const msg = makeAssistantError(
+      '429 {"error":"insufficient_balance","message":"Your credit balance is too low."}',
+    );
+    const result = formatAssistantErrorText(msg, {
+      provider: "openai-compatible",
+      model: "custom-model",
+    });
+    expect(result).toBe(formatBillingErrorMessage("openai-compatible", "custom-model"));
+  });
+  it("keeps structured 429 insufficient balance codes on billing copy", () => {
+    const msg = makeAssistantError(
+      'HTTP 429: {"error":"insufficient_balance","message":"Insufficient account balance"}',
+    );
+    const result = formatAssistantErrorText(msg, {
+      provider: "openai-compatible",
+      model: "custom-model",
+    });
+    expect(result).toBe(formatBillingErrorMessage("openai-compatible", "custom-model"));
+  });
+  it("keeps 429 more-credits failures on billing copy", () => {
+    const msg = makeAssistantError("429 This model requires more credits to use");
+    const result = formatAssistantErrorText(msg, {
+      provider: "openai-compatible",
+      model: "custom-model",
+    });
+    expect(result).toBe(formatBillingErrorMessage("openai-compatible", "custom-model"));
+  });
+  it("keeps OpenRouter 429 key budget failures on billing copy", () => {
+    const msg = makeAssistantError("429 API key budget limit exceeded");
+    const result = formatAssistantErrorText(msg, {
+      provider: "openrouter",
+      model: "openai/gpt-5.5",
+    });
+    expect(result).toBe(formatBillingErrorMessage("openrouter", "openai/gpt-5.5"));
+  });
   it("returns a friendly message for rate limit errors", () => {
     const msg = makeAssistantError("429 rate limit reached");
     expect(formatAssistantErrorText(msg)).toContain("rate limit reached");

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -162,6 +162,16 @@ describe("formatAssistantErrorText", () => {
     });
     expect(result).toBe(formatBillingErrorMessage("google", "gemini-3.1-pro-preview"));
   });
+  it("returns a billing message for xAI 429 credit exhaustion before rate-limit copy", () => {
+    const msg = makeAssistantError(
+      '429 {"code":"Some resource has been exhausted","error":"Your team team-redacted has either used all available credits or reached its monthly spending limit. To continue making API requests, please purchase more credits or raise your spending limit."}',
+    );
+    const result = formatAssistantErrorText(msg, {
+      provider: "xai",
+      model: "grok-4.3",
+    });
+    expect(result).toBe(formatBillingErrorMessage("xai", "grok-4.3"));
+  });
   it("returns a friendly message for rate limit errors", () => {
     const msg = makeAssistantError("429 rate limit reached");
     expect(formatAssistantErrorText(msg)).toContain("rate limit reached");

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -5,6 +5,7 @@ import {
   extractLeadingHttpStatus,
   formatRawAssistantErrorForUi,
   isGenericProviderInternalError,
+  parseApiErrorInfo,
 } from "../../shared/assistant-error-format.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -675,14 +676,10 @@ function classifyFailoverClassificationFromHttpStatus(
     return toReasonClassification(classify402Message(message));
   }
   if (status === 429) {
-    if (messageReason === "billing") {
+    if (messageReason === "billing" && !isAmbiguousGeneric429BalanceMessage(message ?? "")) {
       return toReasonClassification("billing");
     }
-    if (
-      message &&
-      (isProvider(provider, "moonshot") || isProvider(provider, "kimi")) &&
-      isBillingErrorMessage(message)
-    ) {
+    if (message && isBilling429MessageForProvider(message, provider)) {
       return toReasonClassification("billing");
     }
     return toReasonClassification("rate_limit");
@@ -800,6 +797,39 @@ function isProvider(provider: string | undefined, match: string): boolean {
   return Boolean(normalized && normalized.includes(match));
 }
 
+function hasProviderBilling429Override(provider: string | undefined): boolean {
+  return (
+    isProvider(provider, "xai") || isProvider(provider, "moonshot") || isProvider(provider, "kimi")
+  );
+}
+
+function hasStructuredBilling429Signal(raw: string): boolean {
+  if (hasBillingApiErrorType(raw)) {
+    return true;
+  }
+  const leadingStatus = extractLeadingHttpStatus(raw.trim());
+  return Boolean(leadingStatus?.rest && hasBillingApiErrorType(leadingStatus.rest));
+}
+
+function hasBillingApiErrorType(raw: string): boolean {
+  const type = normalizeOptionalLowercaseString(parseApiErrorInfo(raw)?.type);
+  if (!type) {
+    return false;
+  }
+  return isBillingErrorMessage(type) || isBillingErrorMessage(type.replaceAll("_", " "));
+}
+
+function isAmbiguousGeneric429BalanceMessage(raw: string): boolean {
+  return /\binsufficient\s+account\s+balance\b/i.test(raw) && !hasStructuredBilling429Signal(raw);
+}
+
+function isBilling429MessageForProvider(raw: string, provider: string | undefined): boolean {
+  if (!isBillingErrorMessage(raw)) {
+    return false;
+  }
+  return hasProviderBilling429Override(provider) || !isAmbiguousGeneric429BalanceMessage(raw);
+}
+
 // pi-ai providers throw `Error("An unknown error occurred")` provider-agnostically
 // (anthropic, google, vertex, openai-completions, mistral, bedrock, etc.) when a
 // stream ends with stopReason === "aborted" | "error" without specific info. Treat
@@ -864,10 +894,8 @@ function classifyFailoverClassificationFromMessage(
   ) {
     return toReasonClassification("billing");
   }
-  // Billing runs before broad 429/resource-exhausted checks so providers that
-  // use a rate-limit-ish transport code for credit exhaustion still land in
-  // the actionable billing lane.
-  if (isBillingErrorMessage(raw)) {
+  const leadingStatus = extractLeadingHttpStatus(raw.trim());
+  if (leadingStatus?.code !== 429 && isBillingErrorMessage(raw)) {
     return toReasonClassification("billing");
   }
   if (isPeriodicUsageLimitErrorMessage(raw)) {
@@ -1187,7 +1215,13 @@ export function formatAssistantErrorText(
     return `LLM request rejected: ${invalidRequest[1]}`;
   }
 
-  if (isBillingErrorMessage(raw)) {
+  if (
+    isOpenRouterKeyLimitExceededError(raw, opts?.provider) ||
+    isOpenRouterKeyBudgetLimitExceededError(raw, opts?.provider)
+  ) {
+    return formatBillingErrorMessage(opts?.provider, opts?.model ?? msg.model);
+  }
+  if (isBilling429MessageForProvider(raw, opts?.provider)) {
     return formatBillingErrorMessage(opts?.provider, opts?.model ?? msg.model);
   }
 
@@ -1207,6 +1241,10 @@ export function formatAssistantErrorText(
 
   if (isTimeoutErrorMessage(raw)) {
     return "LLM request timed out.";
+  }
+
+  if (isBillingErrorMessage(raw)) {
+    return formatBillingErrorMessage(opts?.provider, opts?.model ?? msg.model);
   }
 
   if (providerRuntimeFailureKind === "schema") {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -675,6 +675,9 @@ function classifyFailoverClassificationFromHttpStatus(
     return toReasonClassification(classify402Message(message));
   }
   if (status === 429) {
+    if (messageReason === "billing") {
+      return toReasonClassification("billing");
+    }
     if (
       message &&
       (isProvider(provider, "moonshot") || isProvider(provider, "kimi")) &&
@@ -861,6 +864,12 @@ function classifyFailoverClassificationFromMessage(
   ) {
     return toReasonClassification("billing");
   }
+  // Billing runs before broad 429/resource-exhausted checks so providers that
+  // use a rate-limit-ish transport code for credit exhaustion still land in
+  // the actionable billing lane.
+  if (isBillingErrorMessage(raw)) {
+    return toReasonClassification("billing");
+  }
   if (isPeriodicUsageLimitErrorMessage(raw)) {
     return toReasonClassification(isBillingErrorMessage(raw) ? "billing" : "rate_limit");
   }
@@ -888,12 +897,9 @@ function classifyFailoverClassificationFromMessage(
   if (isGenericProviderInternalError(raw)) {
     return toReasonClassification("timeout");
   }
-  // Billing and auth classifiers run before the broad isJsonApiInternalServerError
-  // check so that provider errors like {"type":"api_error","message":"insufficient
-  // balance"} are correctly classified as "billing"/"auth" rather than "timeout".
-  if (isBillingErrorMessage(raw)) {
-    return toReasonClassification("billing");
-  }
+  // Auth classifiers run before the broad isJsonApiInternalServerError check so that
+  // provider errors like {"type":"api_error","message":"invalid api key"} are
+  // correctly classified as "auth" rather than "timeout".
   const oauthRefreshFailure = classifyOAuthRefreshFailure(raw);
   if (oauthRefreshFailure?.reason) {
     return toReasonClassification("auth_permanent");
@@ -1181,6 +1187,10 @@ export function formatAssistantErrorText(
     return `LLM request rejected: ${invalidRequest[1]}`;
   }
 
+  if (isBillingErrorMessage(raw)) {
+    return formatBillingErrorMessage(opts?.provider, opts?.model ?? msg.model);
+  }
+
   const transientCopy = formatRateLimitOrOverloadedErrorCopy(raw);
   if (transientCopy) {
     return transientCopy;
@@ -1197,10 +1207,6 @@ export function formatAssistantErrorText(
 
   if (isTimeoutErrorMessage(raw)) {
     return "LLM request timed out.";
-  }
-
-  if (isBillingErrorMessage(raw)) {
-    return formatBillingErrorMessage(opts?.provider, opts?.model ?? msg.model);
   }
 
   if (providerRuntimeFailureKind === "schema") {

--- a/src/agents/pi-embedded-helpers/provider-error-patterns.test.ts
+++ b/src/agents/pi-embedded-helpers/provider-error-patterns.test.ts
@@ -149,6 +149,15 @@ describe("classifyFailoverReason with provider patterns", () => {
       "model_not_found",
     );
   });
+
+  it("classifies xAI 429 credit exhaustion as billing before resource-exhausted rate limits", () => {
+    expect(
+      classifyFailoverReason(
+        '429 {"code":"Some resource has been exhausted","error":"Your team team-redacted has either used all available credits or reached its monthly spending limit. To continue making API requests, please purchase more credits or raise your spending limit."}',
+        { provider: "xai" },
+      ),
+    ).toBe("billing");
+  });
 });
 
 describe("Cloudflare / CDN HTML error page classification (#67517)", () => {
@@ -211,9 +220,7 @@ describe("Cloudflare / CDN HTML error page classification (#67517)", () => {
   });
 
   it("classifies 403 HTML runtime failures as auth_html", () => {
-    expect(classifyProviderRuntimeFailureKind({ status: 403, message: html403 })).toBe(
-      "auth_html",
-    );
+    expect(classifyProviderRuntimeFailureKind({ status: 403, message: html403 })).toBe("auth_html");
   });
 
   it("classifies 407 HTML runtime failures as proxy", () => {

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -1022,6 +1022,27 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     );
   });
 
+  it("preserves backend billing and usage-limit errors in local mode", () => {
+    const { chatLog, handleChatEvent } = createHandlersHarness({
+      localMode: true,
+      state: {
+        activeChatRunId: null,
+        sessionInfo: { modelProvider: "xai" },
+      },
+    });
+
+    handleChatEvent({
+      runId: "run-xai-spending-limit",
+      sessionKey: "agent:main:main",
+      state: "error",
+      errorMessage: "403 SPENDING_LIMIT: xAI spending limit reached. Add credits in the xAI console.",
+    });
+
+    expect(chatLog.addSystem).toHaveBeenCalledWith(
+      "run error: HTTP 403: SPENDING_LIMIT: xAI spending limit reached. Add credits in the xAI console.",
+    );
+  });
+
   it("drops streaming assistant when chat final has no message", () => {
     const { state, chatLog, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: null },

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -1023,6 +1023,8 @@ describe("tui-event-handlers: handleAgentEvent", () => {
   });
 
   it("preserves backend billing and usage-limit errors in local mode", () => {
+    const backendError =
+      '403 {"code":"The caller does not have permission to execute the specified operation","error":"Your team team-redacted has either used all available credits or reached its monthly spending limit. To continue making API requests, please purchase more credits or raise your spending limit."}';
     const { chatLog, handleChatEvent } = createHandlersHarness({
       localMode: true,
       state: {
@@ -1035,12 +1037,10 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       runId: "run-xai-spending-limit",
       sessionKey: "agent:main:main",
       state: "error",
-      errorMessage: "403 SPENDING_LIMIT: xAI spending limit reached. Add credits in the xAI console.",
+      errorMessage: backendError,
     });
 
-    expect(chatLog.addSystem).toHaveBeenCalledWith(
-      "run error: HTTP 403: SPENDING_LIMIT: xAI spending limit reached. Add credits in the xAI console.",
-    );
+    expect(chatLog.addSystem).toHaveBeenCalledWith(`run error: ${backendError}`);
   });
 
   it("drops streaming assistant when chat final has no message", () => {

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -1,4 +1,4 @@
-import { isAuthErrorMessage } from "../agents/pi-embedded-helpers.js";
+import { classifyFailoverReason, isAuthErrorMessage } from "../agents/pi-embedded-helpers.js";
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 import { formatRawAssistantErrorForUi } from "../shared/assistant-error-format.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
@@ -187,10 +187,17 @@ export function createEventHandlers(context: EventHandlerContext) {
   };
 
   const resolveAuthErrorHint = (errorMessage: string): string | undefined => {
-    if (!localMode || !isAuthErrorMessage(errorMessage)) {
+    if (!localMode) {
       return undefined;
     }
     const provider = state.sessionInfo.modelProvider?.trim();
+    const failoverReason = classifyFailoverReason(errorMessage, { provider });
+    if (failoverReason === "billing" || failoverReason === "rate_limit") {
+      return undefined;
+    }
+    if (!isAuthErrorMessage(errorMessage)) {
+      return undefined;
+    }
     return provider
       ? `auth or provider access failed for ${provider}. Run /auth ${provider} to refresh credentials; if you already re-authed, switch models/providers because this account may still be blocked for inference.`
       : "auth or provider access failed for the current provider. Run /auth to refresh credentials; if you already re-authed, switch models/providers because this account may still be blocked for inference.";

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -240,6 +240,7 @@ async function writeTuiPtyFixtureScript(dir: string) {
 
       const actionLogPath = process.env.OPENCLAW_TUI_PTY_LOG_PATH;
       const gatewayStatus = process.env.OPENCLAW_TUI_PTY_GATEWAY_STATUS ?? "fixture gateway ok";
+      const xaiLimitError = '403 {"code":"The caller does not have permission to execute the specified operation","error":"Your team team-redacted has either used all available credits or reached its monthly spending limit. To continue making API requests, please purchase more credits or raise your spending limit."}';
       let currentModel = "fixture-provider/fixture-model";
       let fastMode = process.env.OPENCLAW_TUI_PTY_FAST_MODE === "true";
 
@@ -311,7 +312,20 @@ async function writeTuiPtyFixtureScript(dir: string) {
           const runId = opts.runId ?? "run-pty-fixture";
           const responseDelayMs = opts.message === "slow prompt" ? 500 : 20;
           const isSourceReplyProof = opts.message === "message tool only source reply proof";
+          const isXaiLimitProof = opts.message === "xai limit proof";
           setTimeout(() => {
+            if (isXaiLimitProof) {
+              this.onEvent?.({
+                event: "chat",
+                payload: {
+                  runId,
+                  sessionKey: opts.sessionKey,
+                  state: "error",
+                  errorMessage: xaiLimitError,
+                },
+              });
+              return;
+            }
             const sourceReplyPayloads = isSourceReplyProof
               ? buildEmbeddedRunPayloads({
                   assistantTexts: [],
@@ -530,6 +544,20 @@ describe.sequential("TUI PTY harness", () => {
         (entry) =>
           entry.method === "sourceReplyMetadata" &&
           objectFieldEquals(entry, "text", "VISIBLE_TUI_SOURCE_REPLY_PROOF"),
+      );
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "preserves xAI account limit errors in terminal output",
+    async () => {
+      await fixture.run.write("xai limit proof\r");
+      await fixture.run.waitForOutput("monthly spending limit");
+      expect(fixture.run.output()).not.toContain("Run /auth");
+      await fixture.waitForLogEntry(
+        (entry) =>
+          entry.method === "sendChat" && objectFieldEquals(entry, "message", "xai limit proof"),
       );
     },
     TEST_TIMEOUT_MS,


### PR DESCRIPTION
## Summary

- keep local TUI error handling from replacing known billing/rate-limit backend errors with the generic auth hint
- replace the guessed xAI symbolic limit-code list with the observed flat xAI `{"code":"...","error":"..."}` envelope text for credit/spending exhaustion and rate limits
- preserve xAI credit exhaustion as `billing` even when xAI returns HTTP 429 / `Some resource has been exhausted`, including assistant-error formatting and terminal TUI output

## Verification

- `node scripts/run-vitest.mjs extensions/xai/index.test.ts src/tui/tui-event-handlers.test.ts src/agents/pi-embedded-helpers/provider-error-patterns.test.ts src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts`
- `OPENCLAW_TUI_PTY_MIRROR_PATH=/tmp/openclaw-pr-86614-tui.log node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-pty-harness.e2e.test.ts`
- `node scripts/run-oxlint.mjs extensions/xai/index.ts extensions/xai/index.test.ts src/agents/pi-embedded-helpers/errors.ts src/agents/pi-embedded-helpers/provider-error-patterns.test.ts src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts src/tui/tui-event-handlers.test.ts src/tui/tui-pty-harness.e2e.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof

Behavior addressed: local TUI runs now preserve backend text for xAI credit/spending-limit failures instead of replacing it with the `/auth` hint, and xAI 403/429 credit exhaustion classifies/formats as `billing` while plain xAI rate-limit text remains `rate_limit`.

Real environment tested: local Codex worktree on this PR branch; live network probe to xAI with a deliberately invalid, redacted token; real TUI PTY terminal loop with mirrored terminal output; targeted Vitest coverage for xAI plugin registration, TUI chat error events, provider classification precedence, and assistant error formatting.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/xai/index.test.ts src/tui/tui-event-handlers.test.ts src/agents/pi-embedded-helpers/provider-error-patterns.test.ts src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts`; `OPENCLAW_TUI_PTY_MIRROR_PATH=/tmp/openclaw-pr-86614-tui.log node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-pty-harness.e2e.test.ts`; live xAI invalid-token `fetch("https://api.x.ai/v1/chat/completions")` probe.

Evidence after fix: unit proof passed with 5 files and 209 tests; PTY proof passed with 1 file and 12 tests; focused oxlint exited cleanly; `git diff --check` exited cleanly; autoreview exited cleanly with `autoreview clean: no accepted/actionable findings reported`. The live xAI probe returned status `400` and a flat JSON body with top-level `code` and `error`, not nested `error.code`: `{"code":"Client specified an invalid argument","error":"Incorrect API key provided: xa***en..."}`.

Observed result after fix: observed xAI-style `403 {"code":"The caller does not have permission to execute the specified operation","error":"...used all available credits or reached its monthly spending limit..."}` classifies as `billing`; observed xAI-style `429 {"code":"Some resource has been exhausted","error":"...used all available credits or reached its monthly spending limit..."}` also classifies and formats as `billing`; `429 {"code":"Some resource has been exhausted","error":"Rate limit exceeded"}` stays `rate_limit`. Redacted terminal mirror excerpt from the PTY proof:

```text
run error: 403 {"code":"The caller does not have permission to execute the specified
operation","error":"Your team team-redacted has either used all available credits or reached its
monthly spending limit. To continue making API requests, please purchase more credits or raise
your spending limit."}
```

What was not tested: live xAI account credit exhaustion was not exercised because no exhausted xAI credential was available; the spending-limit body shape was verified against current xAI docs plus public captured xAI API failures, and the live probe verified xAI's current flat `code`/`error` envelope without printing secrets.
