### PR TITLE
feat(skills): add sally-skills (Health category)

### DIFF
--- a/skills/sally-skills/SKILL.md
+++ b/skills/sally-skills/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: sally-skills
+description: "Connect Sally Skills, a metered MCP server with six clinical-grade health tools (CGM, wearables, lab OCR, TCM), to an OpenClaw agent over HTTPS."
+homepage: https://sally.a1c.io/mcp
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🩺",
+        "category": "Health",
+        "transport": "Streamable HTTP",
+        "auth": "Bearer sk-sally-…",
+        "requires": { "bins": [] },
+      },
+  }
+---
+
+# Sally Skills
+
+[Sally Skills](https://github.com/Sally-A1C/ai-sally-skills) is a metered Model Context Protocol server that exposes the clinical-grade metabolic-health intelligence behind the A1C Insights iOS app to AI agents. One bearer key, six skills, pay-per-call in USD, no subscription.
+
+## Tools the agent gets
+
+| Tool | Cost / call | Returns |
+|---|---|---|
+| `health_sync` | FREE | 64+ daily biomarkers from wearables, CGM, sleep, vitals, activity, environment. |
+| `chat_with_sally` | $0.003 | Preventive-health and Traditional Chinese Medicine Q&A with source citations. |
+| `analyze_lab_result` | $0.008 | Parsed lab panel (lipid, HbA1c, CBC, thyroid, hormone, micronutrient) with risk flags grounded in ADA / ACC / ESC guidelines. |
+| `food_journal` | $0.004 | Meal photo to macros, glucose-spike prediction, Smart vs Trap categorisation. |
+| `health_insights` | $0.003 | Morning, afternoon, or evening readout from the user's last day. |
+| `metabolic_overview` | $0.005 | CGM time-in-range, glycemic variability, dawn phenomenon, postprandial response curves. |
+
+## When to Use
+
+Connect Sally Skills when an OpenClaw conversation needs grounded health context:
+
+- The user wants their CGM, sleep, vitals, or activity in the agent's context.
+- A lab PDF needs OCR plus clinical interpretation.
+- A meal photo needs macro and glucose-spike grading.
+- The user asks for a daily readout.
+- A 30-day metabolic snapshot is useful.
+- A preventive-health or TCM question needs evidence-graded answers.
+
+Do not use Sally Skills for diagnosis or treatment decisions. It returns clinical signals and reference ranges, not medical advice.
+
+## Prerequisites
+
+1. Install **A1C Insights** on iPhone: <https://apps.apple.com/id/app/a1c-insights/id6748399956>
+2. Create an account in the app.
+3. Sign in to the developer console: <https://console.a1c.io>
+4. Open **API Keys**, click **Create new key**, copy the `sk-sally-…` value. It is shown only once.
+5. Top up the wallet at <https://console.a1c.io/billing> for paid skills. `health_sync` is permanently free.
+
+## How to Run
+
+OpenClaw with MCP support reads `mcp.json` (or an equivalent config). Add Sally as a remote MCP server:
+
+```json
+{
+  "mcpServers": {
+    "sally": {
+      "url": "https://sally.a1c.io/mcp",
+      "headers": {
+        "Authorization": "Bearer sk-sally-..."
+      }
+    }
+  }
+}
+```
+
+Restart OpenClaw. The six skills appear as callable tools.
+
+If OpenClaw uses the `mcporter` skill (stdio bridge to remote MCP), you can also connect through that:
+
+```bash
+npx mcporter call sally health_sync --header "Authorization:Bearer sk-sally-..."
+```
+
+## Quick smoke test
+
+After configuring, verify the connection works:
+
+```bash
+curl -sS https://sally.a1c.io/v1/call \
+  -H "Authorization: Bearer sk-sally-..." \
+  -H "Content-Type: application/json" \
+  -d '{"skill":"health_sync","input":{}}' | jq .ok
+# → true
+```
+
+A `true` response confirms the key resolves to an A1C account and `health_sync` is callable.
+
+## Pitfalls
+
+- **Lab PDFs and meal photos are not persisted by Sally.** They flow agent to gateway to AI service to response, with no S3 or GCS upload. The agent's request cache may be the only copy.
+- **`metabolic_overview` requires an active CGM** paired in A1C Insights. Without one it returns `404 not_found` rather than synthesising values.
+- **`402 payment_required`** is the wallet-empty signal. Surface a top-up link to <https://console.a1c.io/billing> instead of retrying.
+- **The bearer key is the identity.** Sally never accepts a `user_uuid` or `email` in the body. One key per agent or device; sharing one key across humans mixes their data.
+
+## Source
+
+- Public docs and protocol guides: <https://github.com/a1c-ai-agent/sally-skills>
+- Gateway source code: <https://github.com/Sally-A1C/ai-sally-skills>
+- Developer console: <https://console.a1c.io>
+- iOS app (identity source): <https://apps.apple.com/id/app/a1c-insights/id6748399956>
+- Contact: ai@sallya1c.com


### PR DESCRIPTION
## Summary

What problem does this PR solve?

OpenClaw has 75+ skills today and exactly zero that give an agent access to a user's own physiology. `skills/healthcheck` exists but it audits host security, not clinical health. This PR adds `skills/sally-skills/SKILL.md`, a connector for [Sally Skills](https://github.com/Sally-A1C/ai-sally-skills), a metered MCP server that turns the user's wearable, CGM, sleep, vitals, lab results, and meal photos into six callable tools.

Why does this matter now?

Agents are excellent at scheduling, writing, browsing, and coding. They are terrible at noticing that the human running them slept 4 hours, has a fasting glucose of 110, and a recent HbA1c of 5.9. The information is right there in Apple Health and the user's CGM, but no OpenClaw skill currently surfaces it. Sally Skills closes that gap with one config block. The agent can now answer "how was my morning?" with structured biomarkers instead of a hallucinated guess, or interpret a lab PDF with current ADA / ACC / ESC guideline context instead of three Google searches.

What is the intended outcome?

A new `🩺 Health` category in the OpenClaw skills catalog, anchored by `sally-skills`. Any OpenClaw agent that loads this skill gains six clinical-grade tools: `health_sync` (free, 64+ daily biomarkers), `chat_with_sally` (preventive-health and TCM Q&A with citations), `analyze_lab_result` (VLM OCR for lipid, HbA1c, CBC, thyroid, hormone, micronutrient panels), `food_journal` (meal-photo grading with glucose-spike prediction), `health_insights` (morning, afternoon, evening readouts), `metabolic_overview` (30-day CGM snapshot with TIR, variability, dawn phenomenon).

What is intentionally out of scope?

- No bundled CLI or local binary. Sally Skills is a remote MCP server. The skill points OpenClaw at `https://sally.a1c.io/mcp` and the existing `mcporter` skill (or any MCP-aware OpenClaw runtime) handles the transport.
- No clinical decision support. Sally returns reference ranges and risk flags. Treatment and diagnosis remain the user's clinician's job. The SKILL.md says so explicitly under Pitfalls.
- No persistence on Sally's side. Lab PDFs and meal photos flow agent to gateway to AI service to response without an S3 or GCS upload.

What does success look like?

An OpenClaw user with the A1C Insights iOS app installed pastes one `sk-sally-...` key, sees six tools light up, and the agent answers questions about their actual physiology instead of generic health platitudes.

What should reviewers focus on?

- Does `skills/sally-skills/SKILL.md` match the openclaw skill schema? It mirrors `skills/mcporter/SKILL.md` for the frontmatter shape (name, description, homepage, metadata.openclaw block) and the standard body sections.
- Is `category: Health` the right placement? `healthcheck` already exists for host audit, so the new `Health` namespace cleanly separates clinical-health from security-health.
- Is the description ≤ schema limits and free of marketing language? Single factual sentence, no superlatives.

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #

## Real behavior proof (required for external PRs)

What did you test, what worked, what did not?

Tested end-to-end against `https://sally.a1c.io/mcp` from five MCP clients: Claude Code, Claude Desktop, Cursor, Codex CLI, and Windsurf. All six tools resolved via `tools/list` and executed via `tools/call`. The same config block works in each.

Verification command anyone can run after pasting a real `sk-sally-…` key:

```bash
curl -sS https://sally.a1c.io/mcp \
  -H "Authorization: Bearer sk-sally-..." \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | jq '.result.tools[] | {name, description}'
```

Expected output: six tools named `health_sync`, `chat_with_sally`, `analyze_lab_result`, `food_journal`, `health_insights`, `metabolic_overview`. The free `health_sync` is callable immediately. Paid skills return `402 payment_required` until the wallet is topped up at <https://console.a1c.io/billing>.

`initialize` and `tools/list` are public (no key required) so OpenClaw's MCP catalog or `mcporter inspect` can scan Sally without an auth step.

## Tests and validation

This PR adds a single Markdown documentation file with frontmatter. No tests run against it directly. If openclaw's skill linter validates frontmatter shape, this passes the same shape as `skills/mcporter/SKILL.md`.

## Risk checklist

- [x] No source code changes (Markdown documentation only).
- [x] No new external dependencies pulled into openclaw.
- [x] No PII or secrets in the skill body.
- [x] No telemetry or callbacks to my infrastructure from openclaw itself. The user explicitly configures their own key.
- [x] License field on the skill source repo is MIT and compatible.

## Current review state

Awaiting maintainer feedback. Happy to:

- Restructure under a different folder if `skills/sally-skills/` is the wrong location.
- Reformat the frontmatter if openclaw expects a different shape than mcporter.
- Move the submission to ClawHub (https://clawhub.ai) if that is the canonical path for community-contributed skills today, and close this PR in favor of the ClawHub entry.

## Links

- Public docs: <https://github.com/a1c-ai-agent/sally-skills>
- Gateway source: <https://github.com/Sally-A1C/ai-sally-skills>
- Per-agent connection guides: <https://console.a1c.io/docs.html#mcp>
- Pricing model: <https://console.a1c.io/docs.html#wallet>
- iOS app: <https://apps.apple.com/id/app/a1c-insights/id6748399956>
- Contact: ai@sallya1c.com