### PR TITLE
test: fix mock signatures for tsgo

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -26,7 +26,9 @@ const state = vi.hoisted(() => ({
   resolveAcpExplicitTurnPolicyErrorMock: vi.fn(),
   runWithModelFallbackMock: vi.fn(),
   runAgentAttemptMock: vi.fn(),
-  resolveAgentSkillsFilterMock: vi.fn((): string[] | undefined => undefined),
+  resolveAgentSkillsFilterMock: vi.fn(
+    (_cfg?: unknown, _agentId?: string): string[] | undefined => undefined,
+  ),
   resolveEffectiveModelFallbacksMock: vi.fn().mockReturnValue(undefined),
   emitAgentEventMock: vi.fn(),
   registerAgentRunContextMock: vi.fn(),
@@ -313,7 +315,8 @@ vi.mock("./agent-scope.js", () => ({
   resolveEffectiveModelFallbacks: state.resolveEffectiveModelFallbacksMock,
   resolveSessionAgentIds: () => ({ defaultAgentId: "default", sessionAgentId: "default" }),
   resolveSessionAgentId: () => "default",
-  resolveAgentSkillsFilter: (...args: unknown[]) => state.resolveAgentSkillsFilterMock(...args),
+  resolveAgentSkillsFilter: (cfg: unknown, agentId: string) =>
+    state.resolveAgentSkillsFilterMock(cfg, agentId),
   resolveAgentWorkspaceDir: () => "/tmp/workspace",
 }));
 

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -6,7 +6,9 @@ const agentCommandFromIngressMock = vi.fn();
 const updateSessionStoreMock = vi.fn();
 const applySessionsPatchToStoreMock = vi.fn();
 const getRuntimeConfigMock = vi.fn(() => ({}));
-const loadGatewayModelCatalogMock = vi.fn(() => []);
+const loadGatewayModelCatalogMock = vi.fn(
+  (_params?: unknown): Array<{ id: string; name: string; provider: string }> => [],
+);
 const loadSessionEntryMock = vi.fn((sessionKey: string) => ({
   cfg: {},
   canonicalKey: sessionKey,
@@ -108,7 +110,7 @@ vi.mock("../gateway/session-utils.js", () => ({
 }));
 
 vi.mock("../gateway/server-model-catalog.js", () => ({
-  loadGatewayModelCatalog: (...args: unknown[]) => loadGatewayModelCatalogMock(...args),
+  loadGatewayModelCatalog: (params?: unknown) => loadGatewayModelCatalogMock(params),
 }));
 
 vi.mock("../gateway/session-reset-service.js", () => ({


### PR DESCRIPTION
## Summary

Fixes the current `check:test-types` failure by tightening test mock signatures to match the production call shapes they stand in for.

## Verification

- `rm -f .artifacts/tsgo-cache/core-test.tsbuildinfo .artifacts/tsgo-cache/extensions-test.tsbuildinfo && pnpm check:test-types`
- `CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 fnm exec --using v24.15.0 -- node scripts/run-vitest.mjs run src/agents/agent-command.live-model-switch.test.ts src/tui/embedded-backend.test.ts --reporter=dot --pool=forks --no-file-parallelism`
- autoreview clean on head `0810e95674`

## Real behavior proof

Behavior addressed: `check:test-types` failed on current `origin/main` because two test mocks had zero-arg or untyped rest signatures after the production functions gained concrete parameter shapes.

Real environment tested: Local OpenClaw checkout on Node 24.15.0.

Exact steps or command run after this patch: `rm -f .artifacts/tsgo-cache/core-test.tsbuildinfo .artifacts/tsgo-cache/extensions-test.tsbuildinfo && pnpm check:test-types && CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=120000 fnm exec --using v24.15.0 -- node scripts/run-vitest.mjs run src/agents/agent-command.live-model-switch.test.ts src/tui/embedded-backend.test.ts --reporter=dot --pool=forks --no-file-parallelism`

Evidence after fix: terminal output from the local OpenClaw run:

```text
$ pnpm tsgo:test
$ pnpm tsgo:core:test && pnpm tsgo:extensions:test
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo

RUN  v4.1.7 /Users/steipete/Projects/clawdbot3
.....................................................................
Test Files  3 passed (3)
Tests  69 passed (69)
```

Observed result after fix: `check:test-types` exits 0, and the affected test files still pass.

What was not tested: Full `pnpm check`; GitHub CI covers the full PR matrix.
