### PR TITLE
fix(ui): keep local file markdown links inert

### DIFF
--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -569,6 +569,20 @@ PY
       const html = toSanitizedMarkdownHtml("[click](file:///etc/passwd)");
       expect(html).toBe("<p><a>click</a></p>\n");
     });
+
+    it("strips href from host-local absolute file paths", () => {
+      const html = toSanitizedMarkdownHtml(
+        "[report.docx](/Users/test/.openclaw/data/skills/output/report.docx)",
+      );
+      expect(html).toBe("<p><a>report.docx</a></p>\n");
+    });
+
+    it("keeps app-relative links navigable", () => {
+      const html = toSanitizedMarkdownHtml("[usage](/usage)");
+      expect(html).toBe(
+        '<p><a href="/usage" rel="noreferrer noopener" target="_blank">usage</a></p>\n',
+      );
+    });
   });
 
   describe("ReDoS protection", () => {

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -84,6 +84,8 @@ const MARKDOWN_PARSE_LIMIT = 40_000;
 const MARKDOWN_CACHE_LIMIT = 200;
 const MARKDOWN_CACHE_MAX_CHARS = 50_000;
 const INLINE_DATA_IMAGE_RE = /^data:image\/[a-z0-9.+-]+;base64,/i;
+const HOST_LOCAL_FILE_HREF_RE =
+  /^(?:~\/|\/(?:Users|home|tmp|private\/tmp|var\/folders|private\/var\/folders)\/|\/[A-Za-z]:\/|[A-Za-z]:[\\/])/;
 const markdownCache = new Map<string, string>();
 const TAIL_LINK_BLUR_CLASS = "chat-link-tail-blur";
 
@@ -135,6 +137,10 @@ function shouldRenderCodeBlockCopy(env: unknown): boolean {
   return (env as Partial<MarkdownRenderEnv> | undefined)?.codeBlockChrome !== "none";
 }
 
+function isHostLocalFileHref(href: string): boolean {
+  return HOST_LOCAL_FILE_HREF_RE.test(href.trim());
+}
+
 function installHooks() {
   if (hooksInstalled) {
     return;
@@ -147,6 +153,11 @@ function installHooks() {
     }
     const href = node.getAttribute("href");
     if (!href) {
+      return;
+    }
+
+    if (isHostLocalFileHref(href)) {
+      node.removeAttribute("href");
       return;
     }
 


### PR DESCRIPTION
## Summary

Markdown rendering now treats obvious host-local file paths as inert text links instead of clickable same-origin Gateway routes.

- Strip `href` from Markdown links that point at host-local paths such as `/Users/...`.
- Keep normal app-relative links, such as `/usage`, navigable.
- Keep the fix limited to Control UI Markdown sanitization. This does not add local file serving or expand assistant-media access.

## Linked context

Closes #84467

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Markdown links pointing at host-local paths no longer render with an `href` that navigates inside the Gateway origin.
- Real environment tested: Local OpenClaw source checkout on macOS, targeted Control UI renderer path.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs ui/src/ui/markdown.test.ts ui/src/ui/chat/grouped-render.test.ts`
- Evidence after fix: The renderer test `strips href from host-local absolute file paths` verifies `[report.docx](/Users/test/.openclaw/data/skills/output/report.docx)` renders as `<a>report.docx</a>`, while `keeps app-relative links navigable` verifies `/usage` remains clickable.
- Observed result after fix: 116 tests passed across `ui/src/ui/markdown.test.ts` and `ui/src/ui/chat/grouped-render.test.ts`.
- What was not tested: A live Control UI browser click against a running Gateway. `pnpm check:changed` did not complete locally because `pnpm` stalled while fetching optional platform tarballs from npm.
- Proof limitations or environment constraints: Validation used the shared Markdown renderer path and grouped chat render coverage, not a full browser manual session.
- Before evidence: The issue documents the pre-fix `/Users/...` link navigating as a same-origin Gateway route.

## Tests and validation

- `pnpm changed:lanes --json`
- `node scripts/run-vitest.mjs ui/src/ui/markdown.test.ts ui/src/ui/chat/grouped-render.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ui/src/ui/markdown.ts ui/src/ui/markdown.test.ts`
- `pnpm format:check -- ui/src/ui/markdown.ts ui/src/ui/markdown.test.ts`
- `git diff --check`

Regression coverage added:

- Host-local `/Users/...` Markdown links lose `href`.
- App-relative `/usage` links remain clickable.

## Risk checklist

Did user-visible behavior change? `Yes`
Did config, environment, or migration behavior change? `No`
Did security, auth, secrets, network, or tool execution behavior change? `No`

Highest-risk area: Link sanitization in Control UI Markdown rendering.
Mitigation: The change only strips hrefs from obvious host-local filesystem paths and adds a regression that normal app-relative links remain navigable.

## Current review state

Next action: Maintainer review.
Waiting on: CI and any maintainer request for live browser proof.
Bot or reviewer comments addressed: None yet.