### PR TITLE
fix(tavily): pass api_key in request body instead of Authorization header

### DIFF
--- a/extensions/tavily/src/tavily-client.ts
+++ b/extensions/tavily/src/tavily-client.ts
@@ -78,7 +78,7 @@ async function postTavilyJson(params: {
       url: resolveEndpoint(params.baseUrl, params.pathname),
       timeoutSeconds: params.timeoutSeconds,
       apiKey: params.apiKey,
-      body: params.body,
+      body: { ...params.body, api_key: params.apiKey },
       errorLabel: params.errorLabel,
       extraHeaders: { "X-Client-Source": "openclaw" },
     },


### PR DESCRIPTION
## Problem

When Tavily is configured as the web search provider (`tools.web.search.provider: "tavily"`) with a valid API key, all `web_search` calls return **0 results** with no error message. This affects all agents including family bots, security research, and any workflow using web search.

### Root Cause

OpenClaw sends the Tavily API key via `Authorization: Bearer <key>` header. Tavily's API **silently ignores** this header — it expects `api_key` in the request body. Since no error is returned, the search "succeeds" with `count: 0`.

The `postTrustedWebToolsJson` helper always puts the key in an `Authorization` header, which works for Brave/Perplexity but not Tavily.

### Fix

In `postTavilyJson`, spread `api_key` into the request body before forwarding:

```diff
- body: params.body,
+ body: { ...params.body, api_key: params.apiKey },
```

This ensures the API key reaches Tavily in the format it expects.

### Verification

- **Before:** `web_search("Metformin side effects")` → `count: 0` (no error)
- **After:** `web_search("Metformin side effects")` → `count: 3` (NHS, GoodRx, etc.) in 64ms

Direct API test confirms Tavily works with `api_key` in body but returns empty when only Bearer auth is used.