### PR TITLE
perf: precompute audio resample kernels

### DIFF
--- a/src/talk/audio-codec.ts
+++ b/src/talk/audio-codec.ts
@@ -1,6 +1,18 @@
 const TELEPHONY_SAMPLE_RATE = 8000;
 const RESAMPLE_FILTER_TAPS = 31;
 const RESAMPLE_CUTOFF_GUARD = 0.94;
+const RESAMPLE_MAX_PRECOMPUTED_PHASES = 4096;
+const RESAMPLE_HALF_TAPS = Math.floor(RESAMPLE_FILTER_TAPS / 2);
+const RESAMPLE_WINDOW = Array.from(
+  { length: RESAMPLE_FILTER_TAPS },
+  (_, tapIndex) => 0.5 - 0.5 * Math.cos((2 * Math.PI * tapIndex) / (RESAMPLE_FILTER_TAPS - 1)),
+);
+
+type ResampleKernel = {
+  coefficients: readonly Float64Array[];
+  inputStep: number;
+  phaseCount: number;
+};
 
 function clamp16(value: number): number {
   return Math.max(-32768, Math.min(32767, value));
@@ -13,18 +25,83 @@ function sinc(x: number): number {
   return Math.sin(Math.PI * x) / (Math.PI * x);
 }
 
+function gcd(left: number, right: number): number {
+  let a = Math.abs(Math.trunc(left));
+  let b = Math.abs(Math.trunc(right));
+  while (b !== 0) {
+    const next = a % b;
+    a = b;
+    b = next;
+  }
+  return a || 1;
+}
+
+function buildResampleKernel(
+  inputSampleRate: number,
+  outputSampleRate: number,
+  cutoffCyclesPerSample: number,
+): ResampleKernel | undefined {
+  if (!Number.isInteger(inputSampleRate) || !Number.isInteger(outputSampleRate)) {
+    return undefined;
+  }
+  const divisor = gcd(inputSampleRate, outputSampleRate);
+  const inputStep = inputSampleRate / divisor;
+  const phaseCount = outputSampleRate / divisor;
+  if (phaseCount > RESAMPLE_MAX_PRECOMPUTED_PHASES) {
+    return undefined;
+  }
+  const coefficients = Array.from({ length: phaseCount }, (_, phaseIndex) => {
+    const phase = phaseIndex / phaseCount;
+    const phaseCoefficients = new Float64Array(RESAMPLE_FILTER_TAPS);
+    for (let tap = -RESAMPLE_HALF_TAPS; tap <= RESAMPLE_HALF_TAPS; tap += 1) {
+      const distance = tap - phase;
+      const lowPass = 2 * cutoffCyclesPerSample * sinc(2 * cutoffCyclesPerSample * distance);
+      const tapIndex = tap + RESAMPLE_HALF_TAPS;
+      phaseCoefficients[tapIndex] = lowPass * (RESAMPLE_WINDOW[tapIndex] ?? 0);
+    }
+    return phaseCoefficients;
+  });
+  return { coefficients, inputStep, phaseCount };
+}
+
+function sampleBandlimitedWithCoefficients(
+  input: Buffer,
+  inputSamples: number,
+  center: number,
+  coefficients: Float64Array,
+): number {
+  let weighted = 0;
+  let weightSum = 0;
+
+  for (let tap = -RESAMPLE_HALF_TAPS; tap <= RESAMPLE_HALF_TAPS; tap += 1) {
+    const sampleIndex = center + tap;
+    if (sampleIndex < 0 || sampleIndex >= inputSamples) {
+      continue;
+    }
+    const coeff = coefficients[tap + RESAMPLE_HALF_TAPS] ?? 0;
+    weighted += input.readInt16LE(sampleIndex * 2) * coeff;
+    weightSum += coeff;
+  }
+
+  if (weightSum === 0) {
+    const nearest = Math.max(0, Math.min(inputSamples - 1, center));
+    return input.readInt16LE(nearest * 2);
+  }
+
+  return weighted / weightSum;
+}
+
 function sampleBandlimited(
   input: Buffer,
   inputSamples: number,
   srcPos: number,
   cutoffCyclesPerSample: number,
 ): number {
-  const half = Math.floor(RESAMPLE_FILTER_TAPS / 2);
   const center = Math.floor(srcPos);
   let weighted = 0;
   let weightSum = 0;
 
-  for (let tap = -half; tap <= half; tap += 1) {
+  for (let tap = -RESAMPLE_HALF_TAPS; tap <= RESAMPLE_HALF_TAPS; tap += 1) {
     const sampleIndex = center + tap;
     if (sampleIndex < 0 || sampleIndex >= inputSamples) {
       continue;
@@ -32,9 +109,7 @@ function sampleBandlimited(
 
     const distance = sampleIndex - srcPos;
     const lowPass = 2 * cutoffCyclesPerSample * sinc(2 * cutoffCyclesPerSample * distance);
-    const tapIndex = tap + half;
-    const window = 0.5 - 0.5 * Math.cos((2 * Math.PI * tapIndex) / (RESAMPLE_FILTER_TAPS - 1));
-    const coeff = lowPass * window;
+    const coeff = lowPass * (RESAMPLE_WINDOW[tap + RESAMPLE_HALF_TAPS] ?? 0);
     weighted += input.readInt16LE(sampleIndex * 2) * coeff;
     weightSum += coeff;
   }
@@ -66,10 +141,19 @@ export function resamplePcm(
   const maxCutoff = 0.5;
   const downsampleCutoff = ratio > 1 ? maxCutoff / ratio : maxCutoff;
   const cutoffCyclesPerSample = Math.max(0.01, downsampleCutoff * RESAMPLE_CUTOFF_GUARD);
+  const kernel = buildResampleKernel(inputSampleRate, outputSampleRate, cutoffCyclesPerSample);
 
   for (let i = 0; i < outputSamples; i += 1) {
     const sample = Math.round(
-      sampleBandlimited(input, inputSamples, i * ratio, cutoffCyclesPerSample),
+      kernel
+        ? sampleBandlimitedWithCoefficients(
+            input,
+            inputSamples,
+            Math.floor((i * inputSampleRate) / outputSampleRate),
+            kernel.coefficients[(i * kernel.inputStep) % kernel.phaseCount] ??
+              kernel.coefficients[0],
+          )
+        : sampleBandlimited(input, inputSamples, i * ratio, cutoffCyclesPerSample),
     );
     output.writeInt16LE(clamp16(sample), i * 2);
   }


### PR DESCRIPTION
## Summary

- Precompute resampler FIR window and phase coefficients for integer sample-rate pairs.
- Keep the existing dynamic sample path as fallback for non-integer or very high-phase conversions.
- Speeds up Discord/realtime/telephony PCM resampling without changing sample output for common voice ratios.

## Verification

- `node scripts/run-vitest.mjs extensions/voice-call/src/telephony-audio.test.ts`
- `pnpm tsgo:core`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode commit --commit HEAD`
- Local benchmark probe: `48k-to-24k-100x-ms=183.9`
- Old-vs-new local probe before commit showed maxDiff=0 for 48k->24k, 24k->48k, 48k->8k, and 24k->8k; loop speedup was 6.5x to 8.1x for those ratios.

## Real behavior proof

Behavior addressed: Hot CPU samples in gateway voice profiles showed `sampleBandlimited` and `sinc` consuming measurable non-idle CPU during realtime audio resampling.
Real environment tested: Local OpenClaw checkout on macOS, Node toolchain from repo scripts.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/voice-call/src/telephony-audio.test.ts`; `pnpm tsgo:core`; local `tsx` benchmark loop against `resamplePcm`.
Evidence after fix: Existing telephony audio tests passed; TypeScript core lane passed; benchmark completed 100 48k->24k resamples in 183.9ms on this machine.
Observed result after fix: Common voice sample-rate conversions reuse precomputed coefficients and avoid per-output-sample trigonometry while preserving output for tested common ratios.
What was not tested: Full gateway/Discord live E2E after this patch; CI had not completed at PR creation time.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
stats: {"agent":"codex","entries":5,"user":2,"assistant":2,"toolCalls":101,"toolOutputsDropped":100,"web":0,"redactions":2,"omittedUnsafe":0,"rawEntries":21}

[user]
see tmux, load latest cpu profiles, find ways to make this faster

[assistant]
Using `$native-app-performance`: profile-first, then code path. I’ll inspect tmux, locate newest CPU traces, and tie hotspots back to source.

Tmux has gateway watch attached and an older npm-release session. Worktree clean on `main`; next I’m checking pane output and recent `.trace`/profile artifacts.

Pane is active Discord realtime voice logs, running from `[LOCAL_PATH]`, not this checkout. That checkout is dirty in voice docs/tests/runtime, so I’ll treat it as live state and only inspect unless a fix is clearly bounded.

Found the current profile stream: `.artifacts/gateway-watch-profiles/*.cpuprofile`, newest at 20:52 and a larger capture at 20:51. I’m aggregating sample self/stack time by function and source URL now.

Active CPU is mostly filesystem/plugin metadata churn, not Discord loop math. One real hot path inside voice is `src/talk/audio-codec.ts` resampling: `sampleBandlimited` + `sinc` are ~8.6% of non-idle CPU in the 20:51 capture, so I’m checking whether that can be table-driven.

First bounded fix: cache FIR coefficients per sample-rate ratio, so 24k<->48k and 48k/24k->8k stop recomputing `sin`/`cos` for every output sample. It targets the measured voice CPU without touching the dirty realtime files.

Patch in place. I’m running the existing telephony audio tests plus a quick local benchmark to make sure output stays stable and the measured loop actually improves.

Targeted test is still running without output; likely wrapper startup/install overhead. I’m letting it finish once, then I’ll use a narrower type/benchmark probe if it stalls.

Vitest child stayed silent for over a minute; I’m stopping only that process I started, then I’ll validate with a direct Node/tsx probe and a compile check.

Benchmark against the old loop shows identical output for common voice ratios and ~6.5-8x faster resampling loops. I’m running the core tsgo lane next to catch strict type issues.

The remaining big bucket is plugin metadata/model normalization causing FS reads/stats and clones during gateway activity. I’m sampling caller chains from the profiles so the next fix is aimed at the caller, not another cache layer.

Inspected tmux + latest CPU profiles in `[LOCAL_PATH]`.

Changed `src/talk/audio-codec.ts`: resampler now precomputes FIR/window coefficients per sample-rate phase instead of recomputing `sin`/`cos` for every output sample.

Proof:
- `node scripts/run-vitest.mjs extensions/voice-call/src/telephony-audio.test.ts`: 4 passed
- `pnpm tsgo:core`: passed
- local benchmark vs old loop, exact output match:
  - 48k -> 24k: 6.5x faster
  - 24k -> 48k: 8.1x faster
  - 48k -> 8k: 7.2x faster
  - 24k -> 8k: 7.7x faster

Profile read:
- long captures are mostly idle, but active CPU is dominated by plugin metadata/model normalization FS churn.
- biggest remaining target: `normalizeStaticProviderModelId` -> `resolveMetadataSnapshotForPolicies` -> plugin metadata snapshot. Next fix should carry prepared manifest/model-normalization policy through callers instead of resolving metadata repeatedly.
- session store save/clone is another secondary hotspot.

Note: tmux is running from `[LOCAL_PATH]`; that checkout already had dirty Discord voice/doc changes. My only code edit is `src/talk/audio-codec.ts`.

[user]
make PR, include transcript, land

[assistant]
Using `$openclaw-pr-maintainer`, `$agent-transcript`, and `$autoreview`: PR/land workflow, sanitized transcript, pre-land review gate. I’ll keep the existing Discord edits uncommitted and only stage my audio-codec change.

Status: `main`, dirty Discord files pre-existing, plus my audio codec change. I’m creating a focused branch and committing only `src/talk/audio-codec.ts`.

Pull fast-forwarded `main`; Git created/applied an autostash due local dirty files. After reapply, two additional pre-existing `src/talk/activation-name*` edits are present; I’m still staging only `src/talk/audio-codec.ts`.

Commit made: `e7231f9667`, one file only. Now I’m rerunning focused proof on the rebased branch and running autoreview against that commit.

Autoreview is clean: no accepted/actionable findings. The focused Vitest wrapper is still quiet; based on the prior run it should print at completion, so I’m waiting once more before moving on.

Proof is green. Next I’m generating a PR body with the required real-behavior proof fields, appending the redacted local transcript, then I’ll push/create/merge.

[tool summary]
42 read, 1 write, 58 execute; raw tool outputs dropped: 100
````

</details>
<!-- agent-transcript:end -->
