### PR TITLE
fix(agents): persist CLI user turns before attempts

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1611,6 +1611,7 @@ async function agentCommandInternal(
             sessionCwd: workspaceDir,
             config: cfg,
             embeddedAssistantGapFill,
+            skipUserMessage: attemptLifecycleState.currentTurnUserMessagePersisted,
           });
           if (suppressVisibleSessionEffects) {
             sessionEntry = prepared.sessionEntry;

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -222,6 +222,16 @@ function expectTextMessage(value: unknown, fields: { role: string; content: stri
   expect(message.timestamp).toBeTypeOf("number");
 }
 
+function readTranscriptMessages(sessionFile: string): Array<Record<string, unknown>> {
+  return fs
+    .readFileSync(sessionFile, "utf-8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as { type?: string; message?: unknown })
+    .filter((entry) => entry.type === "message")
+    .map((entry) => requireRecord(entry.message, "transcript message"));
+}
+
 describe("runCliAgent reliability", () => {
   afterEach(() => {
     replyRunTesting.resetReplyRunRegistry();
@@ -413,6 +423,54 @@ describe("runCliAgent reliability", () => {
       expectTextMessage(messages[0], { role: "user", content: "earlier context" });
       expectTextMessage(messages[1], { role: "user", content: "hi" });
       expect(callArg(hookRunner.runAgentEnd, 0, 1, "agent_end context")).toBeTypeOf("object");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("persists the CLI user turn before backend failures can drop it", async () => {
+    supervisorSpawnMock.mockClear();
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 1,
+        exitSignal: null,
+        durationMs: 150,
+        stdout: "",
+        stderr: "rate limit exceeded",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+    const { dir, sessionFile } = createSessionFile();
+    const onUserMessagePersisted = vi.fn();
+
+    try {
+      await expect(
+        runPreparedCliAgent({
+          ...buildPreparedContext({
+            sessionKey: "agent:main:main",
+            runId: "run-cli-user-before-failure",
+          }),
+          params: {
+            ...buildPreparedContext({
+              sessionKey: "agent:main:main",
+              runId: "run-cli-user-before-failure",
+            }).params,
+            agentId: "main",
+            sessionFile,
+            workspaceDir: dir,
+            transcriptPrompt: "transcript-safe prompt",
+            onUserMessagePersisted,
+          },
+        }),
+      ).rejects.toThrow("rate limit exceeded");
+
+      expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
+      expect(onUserMessagePersisted).toHaveBeenCalledTimes(1);
+      const messages = readTranscriptMessages(sessionFile);
+      expect(messages).toHaveLength(1);
+      expectTextMessage(messages[0], { role: "user", content: "transcript-safe prompt" });
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -2,6 +2,7 @@ import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 import type { ReplyPayload } from "../auto-reply/reply-payload.js";
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import { appendSessionTranscriptMessage } from "../config/sessions/transcript-append.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { buildAgentHookContextChannelFields } from "../plugins/hook-agent-context.js";
@@ -107,6 +108,35 @@ function buildCliContextEngineAssistantMessage(params: {
   };
 }): AgentMessage {
   return buildCliHookAssistantMessage(params) as AgentMessage;
+}
+
+async function persistCliCurrentUserMessage(params: RunCliAgentParams): Promise<boolean> {
+  if (params.suppressNextUserMessagePersistence === true) {
+    return false;
+  }
+  const prompt = params.transcriptPrompt ?? params.prompt;
+  if (!prompt.trim()) {
+    return false;
+  }
+
+  try {
+    const { message } = await appendSessionTranscriptMessage({
+      transcriptPath: params.sessionFile,
+      sessionId: params.sessionId,
+      cwd: params.workspaceDir,
+      config: params.config,
+      message: {
+        role: "user",
+        content: prompt,
+        timestamp: Date.now(),
+      },
+    });
+    params.onUserMessagePersisted?.(message as Extract<AgentMessage, { role: "user" }>);
+    return true;
+  } catch (err) {
+    log.warn(`CLI run: failed to persist user transcript message: ${formatErrorMessage(err)}`);
+    return false;
+  }
 }
 
 type CliAgentEndHookParams = Parameters<typeof runAgentHarnessAgentEndHook>[0];
@@ -368,6 +398,14 @@ export async function runPreparedCliAgent(
     },
   });
 
+  let currentUserMessagePersisted = false;
+  const persistCurrentUserMessage = async (): Promise<void> => {
+    if (currentUserMessagePersisted) {
+      return;
+    }
+    currentUserMessagePersisted = await persistCliCurrentUserMessage(params);
+  };
+
   const persistBlockedBeforeAgentRun = async (block: {
     message: string;
     pluginId: string;
@@ -620,6 +658,7 @@ export async function runPreparedCliAgent(
       }
     }
 
+    await persistCurrentUserMessage();
     runAgentHarnessLlmInputHook({
       event: llmInputEvent,
       ctx: hookContext,
@@ -658,6 +697,7 @@ export async function runPreparedCliAgent(
 
           // For now, retry without the session ID to create a new session
           try {
+            await persistCurrentUserMessage();
             const { output, lastAssistant } = await executeCliAttempt(undefined);
             const assistantText = output.text.trim();
             const effectiveCliSessionId = output.sessionId;
@@ -743,6 +783,8 @@ export function buildRunClaudeCliAgentParams(params: RunClaudeCliAgentParams): R
     images: params.images,
     messageChannel: params.messageChannel,
     messageProvider: params.messageProvider,
+    suppressNextUserMessagePersistence: params.suppressNextUserMessagePersistence,
+    onUserMessagePersisted: params.onUserMessagePersisted,
   };
 }
 

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -1,3 +1,4 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { ImageContent } from "@earendil-works/pi-ai";
 import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options.types.js";
 import type { ReplyOperation } from "../../auto-reply/reply/reply-run-registry.js";
@@ -77,6 +78,8 @@ export type RunCliAgentParams = {
     source?: string;
     firstModelCallStarted?: boolean;
   }) => void;
+  suppressNextUserMessagePersistence?: boolean;
+  onUserMessagePersisted?: (message: Extract<AgentMessage, { role: "user" }>) => void;
   replyOperation?: ReplyOperation;
   /**
    * Close any long-lived CLI live session created for this run after the run

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -562,6 +562,39 @@ describe("CLI attempt execution", () => {
     });
   });
 
+  it("can append only the CLI assistant when the user turn is already persisted", async () => {
+    const sessionKey = "agent:main:subagent:cli-transcript-assistant-only";
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-cli-transcript-assistant-only",
+      updatedAt: Date.now(),
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+
+    const updatedEntry = await persistCliTurnTranscript({
+      body: "already durable",
+      result: makeCliResult("assistant only"),
+      sessionId: sessionEntry.sessionId,
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      storePath,
+      sessionAgentId: "main",
+      sessionCwd: tmpDir,
+      config: {},
+      skipUserMessage: true,
+    });
+
+    const messages = await readSessionMessages(updatedEntry?.sessionFile ?? "");
+    expect(messages).toHaveLength(1);
+    expectRecordFields(requireRecord(messages[0], "assistant message"), {
+      role: "assistant",
+      provider: "claude-cli",
+      model: "opus",
+      content: [{ type: "text", text: "assistant only" }],
+    });
+  });
+
   it("embedded assistant gap-fill skips user mirror and dedupes identical assistant tails", async () => {
     const sessionKey = "agent:main:subagent:embedded-gap-fill";
     const sessionEntry: SessionEntry = {

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -111,6 +111,7 @@ type PersistTextTurnTranscriptParams = {
     model: string;
     usage?: TranscriptUsage;
   };
+  skipUserMessage?: boolean;
 };
 
 type HarnessAuthProfileSelection = {
@@ -229,7 +230,7 @@ async function persistTextTurnTranscript(
     allowReentrant: true,
   });
   try {
-    if (promptText) {
+    if (promptText && !params.skipUserMessage) {
       await appendSessionTranscriptMessage({
         transcriptPath: sessionFile,
         sessionId: params.sessionId,
@@ -335,6 +336,7 @@ export async function persistCliTurnTranscript(params: {
   sessionCwd: string;
   config: OpenClawConfig;
   embeddedAssistantGapFill?: boolean;
+  skipUserMessage?: boolean;
 }): Promise<SessionEntry | undefined> {
   const replyText = resolveCliTranscriptReplyText(params.result);
   const provider = params.result.meta.agentMeta?.provider?.trim() ?? "cli";
@@ -355,6 +357,7 @@ export async function persistCliTurnTranscript(params: {
     sessionCwd: params.sessionCwd,
     config: params.config,
     embeddedAssistantGapFill: gapFill,
+    skipUserMessage: gapFill || params.skipUserMessage === true,
     assistant: {
       api: "cli",
       provider,
@@ -549,6 +552,8 @@ export function runAgentAttempt(params: {
         agentAccountId: params.runContext.accountId,
         senderIsOwner: params.opts.senderIsOwner,
         toolsAllow: params.opts.toolsAllow,
+        suppressNextUserMessagePersistence: params.suppressPromptPersistenceOnRetry === true,
+        onUserMessagePersisted: params.onUserMessagePersisted,
         cleanupBundleMcpOnRunEnd: params.opts.cleanupBundleMcpOnRunEnd,
         cleanupCliLiveSessionOnRunEnd: params.opts.cleanupCliLiveSessionOnRunEnd,
       });

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -5445,7 +5445,12 @@ describe("runAgentTurnWithFallback", () => {
         attempts: [],
       };
     });
-    state.runCliAgentMock.mockRejectedValueOnce(new Error("cli failed"));
+    state.runCliAgentMock.mockImplementationOnce(
+      async (args: { onUserMessagePersisted?: (m: { role: "user"; content: string }) => void }) => {
+        args.onUserMessagePersisted?.({ role: "user", content: "queued" });
+        throw new Error("cli failed");
+      },
+    );
     state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
       payloads: [{ text: "ok" }],
       meta: {},
@@ -5457,6 +5462,7 @@ describe("runAgentTurnWithFallback", () => {
     expect(state.runCliAgentMock).toHaveBeenCalledOnce();
     expect(state.runEmbeddedPiAgentMock).toHaveBeenCalledOnce();
     expectMockCallArgFields(state.runEmbeddedPiAgentMock, 0, "embedded fallback candidate", {
+      suppressNextUserMessagePersistence: true,
       suppressAssistantErrorPersistence: false,
     });
   });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1802,6 +1802,10 @@ export async function runAgentTurnWithFallback(params: {
                 disableTools: params.opts?.disableTools,
                 abortSignal: params.replyOperation?.abortSignal ?? params.opts?.abortSignal,
                 replyOperation: params.replyOperation,
+                suppressNextUserMessagePersistence: suppressQueuedUserPersistenceForCandidate,
+                onUserMessagePersisted: () => {
+                  queuedUserMessagePersistedAcrossFallback = true;
+                },
               },
               transformResult: (rawResult) =>
                 isRoomEventCliRun && rawResult.meta.agentMeta

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -853,7 +853,14 @@ describe("createFollowupRunner runtime config", () => {
         };
       },
     );
-    runCliAgentMock.mockRejectedValueOnce(new Error("cli failed"));
+    runCliAgentMock.mockImplementationOnce(
+      async (args: {
+        onUserMessagePersisted?: (message: { role: "user"; content: string }) => void;
+      }) => {
+        args.onUserMessagePersisted?.({ role: "user", content: "queued" });
+        throw new Error("cli failed");
+      },
+    );
     runEmbeddedPiAgentMock.mockImplementationOnce(async (params: { runId: string }) => {
       realAgentEvents.emitAgentEvent({
         runId: params.runId,
@@ -898,6 +905,7 @@ describe("createFollowupRunner runtime config", () => {
     expect(runCliAgentMock).toHaveBeenCalledTimes(1);
     expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
     const embeddedCall = requireLastMockCallArg(runEmbeddedPiAgentMock, "run embedded pi agent");
+    expect(embeddedCall.suppressNextUserMessagePersistence).toBe(true);
     expect(embeddedCall.suppressAssistantErrorPersistence).toBe(false);
     expect(lifecyclePhases).toEqual(["start", "start", "end"]);
   });

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -757,6 +757,10 @@ export function createFollowupRunner(params: {
                     agentAccountId: run.agentAccountId,
                     disableTools: opts?.disableTools,
                     abortSignal: queued.abortSignal,
+                    suppressNextUserMessagePersistence: suppressQueuedUserPersistenceForCandidate,
+                    onUserMessagePersisted: () => {
+                      queuedUserMessagePersistedAcrossFallback = true;
+                    },
                   },
                   transformResult: (rawResult) =>
                     isRoomEventCliRun && rawResult.meta.agentMeta

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -527,6 +527,44 @@ describe("agentCommand", () => {
     });
   });
 
+  it("does not mirror the CLI user turn twice after the runner persisted it", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store);
+      vi.mocked(attemptExecutionRuntime.runAgentAttempt).mockImplementationOnce(
+        async (params: {
+          onUserMessagePersisted?: (message: {
+            role: "user";
+            content: string;
+            timestamp: number;
+          }) => void;
+        }) => {
+          params.onUserMessagePersisted?.({
+            role: "user",
+            content: "hello from user",
+            timestamp: Date.now(),
+          });
+          const base = createDefaultAgentResult({ payloads: [{ text: "assistant-visible" }] });
+          return {
+            ...base,
+            meta: {
+              ...base.meta,
+              executionTrace: { runner: "cli" },
+            },
+          };
+        },
+      );
+
+      await agentCommand({ message: "hello from user", agentId: "main" }, runtime);
+
+      expect(vi.mocked(attemptExecutionRuntime.persistCliTurnTranscript)).toHaveBeenCalledTimes(1);
+      const persistArgs = vi.mocked(attemptExecutionRuntime.persistCliTurnTranscript).mock
+        .calls[0]?.[0];
+      expect(persistArgs?.embeddedAssistantGapFill).toBe(false);
+      expect(persistArgs?.skipUserMessage).toBe(true);
+    });
+  });
+
   it("gap-fills Telegram-visible embedded replies without a runner trace", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");


### PR DESCRIPTION
## Summary
- Persist accepted CLI user turns to the session transcript after `before_agent_run` hooks pass and before the backend attempt or nonblocking `llm_input` notification can fail.
- Carry the persisted-user signal through post-run transcript mirroring so successful CLI turns append only the assistant and do not duplicate the same user message.
- Thread the same signal through direct and queued fallback dispatch so a later fallback candidate does not persist the same inbound twice.

Fixes #86592

## Verification
- `pnpm test src/agents/cli-runner.reliability.test.ts src/agents/command/attempt-execution.cli.test.ts src/commands/agent.test.ts src/auto-reply/reply/agent-runner-execution.test.ts src/auto-reply/reply/followup-runner.test.ts -- --reporter=verbose`
- `pnpm format:check src/agents/agent-command.ts src/agents/cli-runner.reliability.test.ts src/agents/cli-runner.ts src/agents/cli-runner/types.ts src/agents/command/attempt-execution.cli.test.ts src/agents/command/attempt-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/followup-runner.test.ts src/auto-reply/reply/followup-runner.ts src/commands/agent.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/agent-command.ts src/agents/cli-runner.reliability.test.ts src/agents/cli-runner.ts src/agents/cli-runner/types.ts src/agents/command/attempt-execution.cli.test.ts src/agents/command/attempt-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/followup-runner.test.ts src/auto-reply/reply/followup-runner.ts src/commands/agent.test.ts`
- `git diff --check`

## Real behavior proof
Behavior addressed: accepted Telegram topic user turns are persisted before the agent attempt, so a follow-up in the same topic/session can read the prior user turn instead of losing it when the first candidate owns persistence.

Real environment tested: local OpenClaw source checkout at `052bde7ac426524808a04ccf97a2aebf6a0cf2e1`; gateway running locally; Telegram bot channel in polling mode; Telegram supergroup topic; default model route resolved to `openai/gpt-5.5`.

Exact steps or command run after this patch:
1. Configured Telegram group allowlist and restarted the gateway.
2. Sent `@Tfungbot Reply exactly: group topic route works` in a Telegram topic.
3. Sent `@Tfungbot Reply exactly: topic first turn persisted` in the same topic.
4. Without clearing session/history, sent `@Tfungbot What did I ask you to reply exactly?` in the same topic.
5. Ran `pnpm openclaw models status`.
6. Ran `pnpm openclaw channels status --channel telegram --probe --json`.
7. Ran `pnpm openclaw logs --limit 160 --plain`.

Evidence after fix:
- Telegram Desktop screenshot captured from the live topic shows:
  ```text
  User: @Tfungbot Reply exactly: group topic route works
  Bot:  group topic route works
  User: @Tfungbot Reply exactly: topic first turn persisted
  Bot:  topic first turn persisted
  User: @Tfungbot What did I ask you to reply exactly?
  Bot:  topic first turn persisted
  ```
- `pnpm openclaw models status` resolved the default model route to `openai/gpt-5.5` with no missing provider in use.
- `pnpm openclaw channels status --channel telegram --probe --json` reported Telegram configured, running, connected, polling mode, and `probe.ok: true`.
- Redacted runtime log excerpt from `pnpm openclaw logs --limit 160 --plain`:
  ```text
  2026-05-25T23:21:44.346Z info gateway agent model: openai/gpt-5.5
  2026-05-25T23:21:47.247Z info channels/telegram [default] starting provider (@Tfungbot)
  2026-05-25T23:21:50.413Z info gateway gateway ready
  2026-05-25T23:33:01.395Z info gateway/channels/telegram/inbound Inbound message telegram:group:<redacted>:topic:1 -> @Tfungbot (group, 41 chars)
  2026-05-25T23:33:15.367Z info gateway/ws res ok message.action channel=telegram
  2026-05-25T23:34:16.778Z info gateway/channels/telegram/inbound Inbound message telegram:group:<redacted>:topic:1 -> @Tfungbot (group, 63 chars)
  2026-05-25T23:34:55.240Z info gateway/ws res ok message.action channel=telegram
  2026-05-25T23:38:04.436Z info gateway/channels/telegram/inbound Inbound message telegram:group:<redacted>:topic:1 -> @Tfungbot (group, 27 chars)
  2026-05-25T23:38:17.677Z info gateway/ws res ok message.action channel=telegram
  2026-05-25T23:39:05.353Z info gateway/ws res ok channels.status
  ```

Observed result after fix: the bot replied inside the same Telegram topic, and the follow-up answer returned `topic first turn persisted`, proving the previous accepted user turn was available in the live topic session.

What was not tested: cross-account Telegram routing and non-Telegram channels were not re-run locally. The focused live proof covers the Telegram topic/session path touched by this fix; regression tests cover CLI/direct agent, queued follow-up, fallback suppression, and session JSONL persistence.
