### PR TITLE
fix(docs): stop redirect from shadowing MCP search endpoint

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -69,10 +69,6 @@
       "destination": "/help/gpt55-codex-agentic-parity-maintainers"
     },
     {
-      "source": "/mcp",
-      "destination": "/cli/mcp"
-    },
-    {
       "source": "/providers/modelstudio",
       "destination": "/providers/qwen"
     },

--- a/src/commands/docs.test.ts
+++ b/src/commands/docs.test.ts
@@ -1,6 +1,12 @@
+import fs from "node:fs/promises";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeEnv } from "../runtime.js";
 
+type DocsConfig = {
+  redirects?: Array<{ source?: string }>;
+};
+
+const LEGACY_DOCS_MCP_SERVER_PATH = "/mcp";
 const fetchMock = vi.fn<typeof fetch>();
 
 vi.mock("../terminal/theme.js", () => ({
@@ -56,6 +62,14 @@ describe("docsSearchCommand", () => {
     expect(url).toBeInstanceOf(URL);
     expect(url.href).toBe("https://docs.openclaw.ai/api/search?q=plugin+allowlist");
     expect(init).toMatchObject({ headers: { Accept: "application/json" } });
+  });
+
+  it("does not redirect the legacy docs MCP server path", async () => {
+    const docsConfig = JSON.parse(
+      await fs.readFile(new URL("../../docs/docs.json", import.meta.url), "utf8"),
+    ) as DocsConfig;
+    const redirectSources = (docsConfig.redirects ?? []).map(({ source }) => source);
+    expect(redirectSources).not.toContain(LEGACY_DOCS_MCP_SERVER_PATH);
   });
 
   it("fails loudly when the Cloudflare docs search API fails", async () => {


### PR DESCRIPTION
## Summary

- Remove the `/mcp` docs redirect so it no longer shadows the docs MCP search server path used by `openclaw docs`.
- Add a regression check that keeps the CLI docs search selector aligned with `docs/docs.json` redirects.

Fixes #86223.

## Verification

- `node scripts/run-vitest.mjs src/commands/docs.test.ts`
- `node scripts/check-docs-mdx.mjs docs docs/docs.json`
- `node scripts/docs-link-audit.mjs`
- `pnpm format:check src/commands/docs.test.ts docs/docs.json`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `node scripts/docs-sync-publish.mjs --target /private/tmp/openclaw-docs-proof --source-repo openclaw/openclaw --source-sha 8324fc590d20a5c1219407a5612e7f3e96ac8215 --clawhub-repo /private/tmp/clawhub`
- `npm run docs:build:r2` in the synced `openclaw/docs` deploy-candidate checkout
- `npm run docs:smoke` in the synced `openclaw/docs` deploy-candidate checkout
- `npx wrangler@4.88.0 deploy --dry-run --config wrangler.toml` on the companion docs-router branch
- `NODE_TLS_REJECT_UNAUTHORIZED=0 pnpm dlx mcporter call https://127.0.0.1:8787/mcp.search_open_claw --args '{"query":"heartbeat"}' --output text` against the companion local Wrangler Worker

## Real behavior proof

Behavior addressed: `openclaw docs` calls `https://docs.openclaw.ai/mcp.search_open_claw`, which resolves the MCP server URL to `/mcp`; the docs redirect for `/mcp` made that path return HTML instead of the expected MCP endpoint.

Real environment tested: Local OpenClaw checkout on this issue branch, synced into a local `openclaw/docs` R2 deploy-candidate build, plus a local Wrangler deploy candidate for the companion docs-router branch.

Exact steps or command run after this patch: Synced this PR SHA into `/private/tmp/openclaw-docs-proof`, built the R2 artifact with `npm run docs:build:r2`, verified the manifest, ran `npm run docs:smoke`, then ran the companion docs-router Worker locally with `npx wrangler@4.88.0 dev --local --local-protocol=https --ip 127.0.0.1 --port 8787 --config wrangler.toml` and called it through `mcporter`.

Evidence after fix: The R2 deploy manifest from this PR has no `mcp`, `mcp.md`, or `mcp.html` object and still has `cli/mcp` plus `cli/mcp.md` for the human docs page:

```json
{
  "source": "openclaw/openclaw@8324fc590d20a5c1219407a5612e7f3e96ac8215",
  "objectCount": 50164,
  "hasMcpObject": false,
  "mcpObject": null,
  "hasMcpMd": false,
  "hasMcpHtml": false,
  "cliMcp": {
    "key": "cli/mcp",
    "sourceKey": "cli/mcp/index.html",
    "contentType": "text/html; charset=utf-8"
  },
  "cliMcpMd": {
    "key": "cli/mcp.md",
    "contentType": "text/markdown; charset=utf-8"
  }
}
```

Observed result after fix: The companion local Wrangler Worker proxied `/mcp` to the live Mintlify MCP endpoint and `mcporter call https://127.0.0.1:8787/mcp.search_open_claw --args '{"query":"heartbeat"}' --output text` returned docs search results including `Heartbeat`, `HEARTBEAT.md template`, and `agents.defaults.heartbeat`. The Worker log for that call included `POST /mcp 200 OK`, `POST /mcp 202 Accepted`, and `POST /mcp 200 OK`, with `X-OpenClaw-Docs-Origin: mintlify-mcp` on the proxied `/mcp` response.

What was not tested: Production `https://docs.openclaw.ai/mcp` after deploying the companion docs-router branch. Live production still returns `content-type: text/html; charset=utf-8` from `x-openclaw-docs-origin: cloudflare-r2` until the route change is deployed.
