### PR TITLE
fix(agents): unwrap standalone message tool JSON

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
@@ -153,12 +153,13 @@ function firstMockArg(mock: { mock: { calls: unknown[][] } }, label: string): un
   return firstMockCall(mock, label)[0];
 }
 
-function createMessageToolEnvelope(message: string): string {
+function createMessageToolEnvelope(message: string, args: Record<string, unknown> = {}): string {
   return JSON.stringify({
     name: "message",
     arguments: {
       action: "send",
       message,
+      ...args,
     },
   });
 }
@@ -679,13 +680,15 @@ describe("handleMessageEnd", () => {
     expect(metadata?.registeredTool).toBe(true);
   });
 
-  it("unwraps standalone message-tool JSON only for message-tool-only delivery", () => {
+  it("unwraps only source-routed or message-tool-only standalone message-tool JSON", () => {
     const visibleReply = "No specific tasks planned, but I'll keep watching for updates.";
-    const messageToolEnvelope = createMessageToolEnvelope(visibleReply);
+    const unroutedEnvelope = createMessageToolEnvelope(visibleReply);
+    const routedEnvelope = createMessageToolEnvelope(visibleReply, { target: "user:redacted" });
 
-    for (const [sourceReplyDeliveryMode, expected] of [
-      ["message_tool_only", visibleReply],
-      [undefined, messageToolEnvelope],
+    for (const [text, sourceReplyDeliveryMode, expected] of [
+      [unroutedEnvelope, "message_tool_only", visibleReply],
+      [routedEnvelope, undefined, visibleReply],
+      [unroutedEnvelope, undefined, unroutedEnvelope],
     ] as const) {
       const emitBlockReply = vi.fn();
       const consumeReplyDirectives = vi.fn((text: string) => (text ? { text } : null));
@@ -700,7 +703,7 @@ describe("handleMessageEnd", () => {
         type: "message_end",
         message: {
           role: "assistant",
-          content: [{ type: "text", text: messageToolEnvelope }],
+          content: [{ type: "text", text }],
         },
       } as never);
 

--- a/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
@@ -83,6 +83,7 @@ function createMessageEndContext(
     consumeReplyDirectives?: ReturnType<typeof vi.fn>;
     warn?: ReturnType<typeof vi.fn>;
     builtinToolNames?: ReadonlySet<string>;
+    sourceReplyDeliveryMode?: "automatic" | "message_tool_only";
     state?: Record<string, unknown>;
   } = {},
 ) {
@@ -90,6 +91,9 @@ function createMessageEndContext(
     params: {
       runId: "run-1",
       session: { id: "session-1" },
+      ...(params.sourceReplyDeliveryMode
+        ? { sourceReplyDeliveryMode: params.sourceReplyDeliveryMode }
+        : {}),
       ...(params.onAgentEvent ? { onAgentEvent: params.onAgentEvent } : {}),
       ...(params.onBlockReply ? { onBlockReply: params.onBlockReply } : { onBlockReply: vi.fn() }),
     },
@@ -147,6 +151,16 @@ function firstMockCall(mock: { mock: { calls: unknown[][] } }, label: string): u
 
 function firstMockArg(mock: { mock: { calls: unknown[][] } }, label: string): unknown {
   return firstMockCall(mock, label)[0];
+}
+
+function createMessageToolEnvelope(message: string): string {
+  return JSON.stringify({
+    name: "message",
+    arguments: {
+      action: "send",
+      message,
+    },
+  });
 }
 
 describe("resolveSilentReplyFallbackText", () => {
@@ -663,6 +677,36 @@ describe("handleMessageEnd", () => {
     expect(metadata?.pattern).toBe("json_tool_call");
     expect(metadata?.toolName).toBe("read");
     expect(metadata?.registeredTool).toBe(true);
+  });
+
+  it("unwraps standalone message-tool JSON only for message-tool-only delivery", () => {
+    const visibleReply = "No specific tasks planned, but I'll keep watching for updates.";
+    const messageToolEnvelope = createMessageToolEnvelope(visibleReply);
+
+    for (const [sourceReplyDeliveryMode, expected] of [
+      ["message_tool_only", visibleReply],
+      [undefined, messageToolEnvelope],
+    ] as const) {
+      const emitBlockReply = vi.fn();
+      const consumeReplyDirectives = vi.fn((text: string) => (text ? { text } : null));
+      const ctx = createMessageEndContext({
+        emitBlockReply,
+        consumeReplyDirectives,
+        builtinToolNames: new Set(["message"]),
+        sourceReplyDeliveryMode,
+      });
+
+      void handleMessageEnd(ctx, {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: messageToolEnvelope }],
+        },
+      } as never);
+
+      expect(consumeReplyDirectives).toHaveBeenCalledWith(expected, { final: true });
+      expect(firstMockArg(emitBlockReply, "block reply")).toMatchObject({ text: expected });
+    }
   });
 
   it("does not warn when the assistant emitted a structured tool call", () => {

--- a/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
@@ -685,17 +685,18 @@ describe("handleMessageEnd", () => {
     const unroutedEnvelope = createMessageToolEnvelope(visibleReply);
     const routedEnvelope = createMessageToolEnvelope(visibleReply, { target: "user:redacted" });
 
-    for (const [text, sourceReplyDeliveryMode, expected] of [
-      [unroutedEnvelope, "message_tool_only", visibleReply],
-      [routedEnvelope, undefined, visibleReply],
-      [unroutedEnvelope, undefined, unroutedEnvelope],
+    for (const [text, api, builtinToolNames, sourceReplyDeliveryMode, expected] of [
+      [unroutedEnvelope, undefined, new Set(["message"]), "message_tool_only", visibleReply],
+      [routedEnvelope, "openai-completions", new Set<string>(), undefined, visibleReply],
+      [routedEnvelope, undefined, new Set<string>(), undefined, routedEnvelope],
+      [unroutedEnvelope, undefined, new Set(["message"]), undefined, unroutedEnvelope],
     ] as const) {
       const emitBlockReply = vi.fn();
       const consumeReplyDirectives = vi.fn((text: string) => (text ? { text } : null));
       const ctx = createMessageEndContext({
         emitBlockReply,
         consumeReplyDirectives,
-        builtinToolNames: new Set(["message"]),
+        builtinToolNames,
         sourceReplyDeliveryMode,
       });
 
@@ -703,6 +704,7 @@ describe("handleMessageEnd", () => {
         type: "message_end",
         message: {
           role: "assistant",
+          ...(api ? { api } : {}),
           content: [{ type: "text", text }],
         },
       } as never);

--- a/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
@@ -684,10 +684,12 @@ describe("handleMessageEnd", () => {
     const visibleReply = "No specific tasks planned, but I'll keep watching for updates.";
     const unroutedEnvelope = createMessageToolEnvelope(visibleReply);
     const routedEnvelope = createMessageToolEnvelope(visibleReply, { target: "user:redacted" });
+    const toRoutedEnvelope = createMessageToolEnvelope(visibleReply, { to: "user:redacted" });
 
     for (const [text, api, builtinToolNames, sourceReplyDeliveryMode, expected] of [
       [unroutedEnvelope, undefined, new Set(["message"]), "message_tool_only", visibleReply],
       [routedEnvelope, "openai-completions", new Set<string>(), undefined, visibleReply],
+      [toRoutedEnvelope, "openai-completions", new Set<string>(), undefined, visibleReply],
       [routedEnvelope, undefined, new Set<string>(), undefined, routedEnvelope],
       [unroutedEnvelope, undefined, new Set(["message"]), undefined, unroutedEnvelope],
     ] as const) {

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -59,6 +59,14 @@ function isOpenAiResponsesAssistantMessage(message: AgentMessage | undefined): b
   return api === "openai-responses" || api === "azure-openai-responses";
 }
 
+function isOpenAiCompletionsAssistantMessage(message: AgentMessage | undefined): boolean {
+  if (!message || message.role !== "assistant") {
+    return false;
+  }
+  const api = normalizeOptionalString((message as { api?: unknown }).api) ?? "";
+  return api === "openai-completions" || api === "openclaw-openai-completions-transport";
+}
+
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -67,20 +75,21 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
 
 function extractStandaloneMessageToolText(
   text: string,
-  params: { allowCurrentSourceReply?: boolean } = {},
+  params: { allowCurrentSourceReply?: boolean; allowRoutedReply?: boolean } = {},
 ): string | undefined {
   try {
     const record = asRecord(JSON.parse(text.trim()) as unknown);
     const args = asRecord(record?.arguments);
-    const hasRoute =
+    const hasRoute = Boolean(
       normalizeOptionalString(args?.target) ||
       normalizeOptionalString(args?.channel) ||
       normalizeOptionalString(args?.accountId) ||
-      Array.isArray(args?.targets);
+      Array.isArray(args?.targets),
+    );
     if (
       normalizeOptionalString(record?.name) !== "message" ||
       normalizeOptionalString(args?.action) !== "send" ||
-      (!hasRoute && !params.allowCurrentSourceReply)
+      (hasRoute ? !params.allowRoutedReply : !params.allowCurrentSourceReply)
     ) {
       return undefined;
     }
@@ -715,11 +724,12 @@ export function handleMessageEnd(
   });
   warnIfAssistantEmittedToolText(ctx, assistantMessage);
   const visibleText =
-    ctx.builtinToolNames?.has("message") === true
-      ? (extractStandaloneMessageToolText(rawVisibleText, {
-          allowCurrentSourceReply: ctx.params.sourceReplyDeliveryMode === "message_tool_only",
-        }) ?? rawVisibleText)
-      : rawVisibleText;
+    extractStandaloneMessageToolText(rawVisibleText, {
+      allowRoutedReply: isOpenAiCompletionsAssistantMessage(assistantMessage),
+      allowCurrentSourceReply:
+        ctx.params.sourceReplyDeliveryMode === "message_tool_only" &&
+        ctx.builtinToolNames?.has("message") === true,
+    }) ?? rawVisibleText;
 
   const text = resolveSilentReplyFallbackText({
     text: ctx.stripBlockTags(visibleText, { thinking: false, final: false }, { final: true }),

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -65,14 +65,26 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
     : undefined;
 }
 
-function extractStandaloneMessageToolText(text: string): string | undefined {
+function extractStandaloneMessageToolText(
+  text: string,
+  params: { allowCurrentSourceReply?: boolean } = {},
+): string | undefined {
   try {
     const record = asRecord(JSON.parse(text.trim()) as unknown);
     const args = asRecord(record?.arguments);
-    return normalizeOptionalString(record?.name) === "message" &&
-      normalizeOptionalString(args?.action) === "send"
-      ? normalizeOptionalString(args?.message)
-      : undefined;
+    const hasRoute =
+      normalizeOptionalString(args?.target) ||
+      normalizeOptionalString(args?.channel) ||
+      normalizeOptionalString(args?.accountId) ||
+      Array.isArray(args?.targets);
+    if (
+      normalizeOptionalString(record?.name) !== "message" ||
+      normalizeOptionalString(args?.action) !== "send" ||
+      (!hasRoute && !params.allowCurrentSourceReply)
+    ) {
+      return undefined;
+    }
+    return normalizeOptionalString(args?.message);
   } catch {
     return undefined;
   }
@@ -703,9 +715,10 @@ export function handleMessageEnd(
   });
   warnIfAssistantEmittedToolText(ctx, assistantMessage);
   const visibleText =
-    ctx.params.sourceReplyDeliveryMode === "message_tool_only" &&
     ctx.builtinToolNames?.has("message") === true
-      ? (extractStandaloneMessageToolText(rawVisibleText) ?? rawVisibleText)
+      ? (extractStandaloneMessageToolText(rawVisibleText, {
+          allowCurrentSourceReply: ctx.params.sourceReplyDeliveryMode === "message_tool_only",
+        }) ?? rawVisibleText)
       : rawVisibleText;
 
   const text = resolveSilentReplyFallbackText({

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -59,6 +59,25 @@ function isOpenAiResponsesAssistantMessage(message: AgentMessage | undefined): b
   return api === "openai-responses" || api === "azure-openai-responses";
 }
 
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function extractStandaloneMessageToolText(text: string): string | undefined {
+  try {
+    const record = asRecord(JSON.parse(text.trim()) as unknown);
+    const args = asRecord(record?.arguments);
+    return normalizeOptionalString(record?.name) === "message" &&
+      normalizeOptionalString(args?.action) === "send"
+      ? normalizeOptionalString(args?.message)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function resolveAssistantStreamItemId(params: {
   contentIndex?: unknown;
   message: AgentMessage | undefined;
@@ -683,9 +702,14 @@ export function handleMessageEnd(
     rawThinking: extractAssistantThinking(assistantMessage),
   });
   warnIfAssistantEmittedToolText(ctx, assistantMessage);
+  const visibleText =
+    ctx.params.sourceReplyDeliveryMode === "message_tool_only" &&
+    ctx.builtinToolNames?.has("message") === true
+      ? (extractStandaloneMessageToolText(rawVisibleText) ?? rawVisibleText)
+      : rawVisibleText;
 
   const text = resolveSilentReplyFallbackText({
-    text: ctx.stripBlockTags(rawVisibleText, { thinking: false, final: false }, { final: true }),
+    text: ctx.stripBlockTags(visibleText, { thinking: false, final: false }, { final: true }),
     messagingToolSentTexts: ctx.state.messagingToolSentTexts,
   });
   const rawThinking =

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -82,6 +82,7 @@ function extractStandaloneMessageToolText(
     const args = asRecord(record?.arguments);
     const hasRoute = Boolean(
       normalizeOptionalString(args?.target) ||
+      normalizeOptionalString(args?.to) ||
       normalizeOptionalString(args?.channel) ||
       normalizeOptionalString(args?.accountId) ||
       Array.isArray(args?.targets),


### PR DESCRIPTION
## Summary

- Unwrap standalone downgraded `message` tool JSON during final assistant `message_end` delivery.
- Preserve the existing diagnostic warning path and add a focused regression for the `openai-completions`-style leaked envelope.

## Verification

- `pnpm test src/agents/pi-embedded-subscribe.handlers.messages.test.ts -- --reporter=verbose`
- `node scripts/run-node.mjs qa suite --provider-mode mock-openai --scenario message-tool-json-leak-proof-local --concurrency 1 --output-dir .artifacts/qa-e2e/message-json-proof/run-after-live-stream-fix`

## Real behavior proof

Behavior addressed: Standalone assistant text shaped like `{"name":"message","arguments":{"action":"send","to":"dm:qa-operator","message":"QA-MESSAGE-JSON-UNWRAPPED-OK"}}` is unwrapped before qa-channel delivery; OpenClaw delivers the `arguments.message` text instead of the JSON envelope.

Real environment tested: Local OpenClaw QA gateway child + qa-channel + qa-lab bus + local OpenAI-compatible Chat Completions streaming server on `127.0.0.1:44555`, configured as `api: openai-completions` with `allowPrivateNetwork: true`.

Exact steps or command run after this patch: Started the local proof provider with `node .artifacts/qa-e2e/message-json-proof/openai-completions-json-provider.mjs 44555 .artifacts/qa-e2e/message-json-proof/provider.log`, then ran `node scripts/run-node.mjs qa suite --provider-mode mock-openai --scenario message-tool-json-leak-proof-local --concurrency 1 --output-dir .artifacts/qa-e2e/message-json-proof/run-after-live-stream-fix`.

Evidence after fix: `.artifacts/qa-e2e/message-json-proof/run-after-live-stream-fix/qa-suite-report.md` recorded `Passed: 1`, `Failed: 0`; `.artifacts/qa-e2e/message-json-proof/run-after-live-stream-fix/qa-suite-summary.json` recorded `counts.total=1`, `counts.passed=1`, `counts.failed=0`.

Observed result after fix: The provider returned `providerEnvelope={"name":"message","arguments":{"action":"send","to":"dm:qa-operator","message":"QA-MESSAGE-JSON-UNWRAPPED-OK"}}`; qa-channel delivered `outbound=QA-MESSAGE-JSON-UNWRAPPED-OK`. The outbound text did not include `"name":"message"` or `"arguments"`.

What was not tested: Real external Discord/Telegram/OpenAI accounts. The proof used a local OpenAI-compatible Chat Completions streaming server to exercise the OpenAI-completions transport shape through a real OpenClaw QA gateway child and qa-channel delivery path.
