### PR TITLE
fix(doctor): warn for untrusted external Discord plugin

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -14,6 +14,7 @@ type TerminalNote = (message: string, title?: string) => void;
 const terminalNoteMock = vi.hoisted(() => vi.fn<TerminalNote>());
 const callGatewayMock = vi.hoisted(() => vi.fn());
 const runDoctorRepairSequenceMock = vi.hoisted(() => vi.fn());
+const collectDoctorPreviewNotesParamsMock = vi.hoisted(() => vi.fn());
 const collectImplicitFallbackClobberWarningsMock = vi.hoisted(() =>
   vi.fn<(cfg: unknown) => string[]>(() => []),
 );
@@ -1233,10 +1234,13 @@ vi.mock("./doctor/shared/preview-warnings.js", () => {
   }
 
   return {
-    collectDoctorPreviewNotes: vi.fn(async (params) => ({
-      infoNotes: [],
-      warningNotes: await collectWarnings(params),
-    })),
+    collectDoctorPreviewNotes: vi.fn(async (params) => {
+      collectDoctorPreviewNotesParamsMock(params);
+      return {
+        infoNotes: [],
+        warningNotes: await collectWarnings(params),
+      };
+    }),
     collectDoctorPreviewWarnings: vi.fn(collectWarnings),
   };
 });
@@ -1505,6 +1509,7 @@ describe("doctor config flow", () => {
     callGatewayMock.mockReset();
     callGatewayMock.mockResolvedValue({});
     runDoctorRepairSequenceMock.mockReset();
+    collectDoctorPreviewNotesParamsMock.mockClear();
     collectImplicitFallbackClobberWarningsMock.mockClear();
     collectImplicitFallbackClobberWarningsMock.mockReturnValue([]);
     noteImplicitFallbackClobberWarningsMock.mockClear();
@@ -1522,6 +1527,35 @@ describe("doctor config flow", () => {
     expect((result.cfg as Record<string, unknown>).gateway).toEqual({
       auth: { mode: "token", token: 123 },
     });
+  });
+
+  it("collects plugin blocker previews from the pre-auto-enable config", async () => {
+    await runDoctorConfigWithInput({
+      config: {
+        plugins: {
+          allow: ["existing-plugin"],
+        },
+        tools: {
+          alsoAllow: ["browser"],
+        },
+      },
+      run: loadAndMaybeMigrateDoctorConfig,
+    });
+
+    expect(collectDoctorPreviewNotesParamsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg: expect.objectContaining({
+          plugins: expect.objectContaining({
+            allow: ["existing-plugin", "browser"],
+          }),
+        }),
+        activationSourceConfig: expect.objectContaining({
+          plugins: expect.objectContaining({
+            allow: ["existing-plugin"],
+          }),
+        }),
+      }),
+    );
   });
 
   it("reloads gateway secrets and refreshes auth status after auth profile repairs", async () => {
@@ -1721,7 +1755,9 @@ describe("doctor config flow", () => {
 
     const warning = doctorWarnings.join("\n");
     expect(warning).toContain("hooks.internal.entries.custom-hook:");
-    expect(warning).toContain("unsupported loader keys handler, extraDirs will not load hook modules");
+    expect(warning).toContain(
+      "unsupported loader keys handler, extraDirs will not load hook modules",
+    );
     expect(warning).toContain("bootstrap-extra-files for session bootstrap content");
     expect(warning).toContain("Doctor cannot rewrite this automatically");
     expect(warning).not.toContain("hooks.internal.entries.valid-hook");

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -231,6 +231,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     }));
   }
 
+  const pluginActivationSourceConfig = candidate;
   const { applyPluginAutoEnable } = await import("../config/plugin-auto-enable.js");
   const autoEnable = applyPluginAutoEnable({ config: candidate, env: process.env });
   if (autoEnable.changes.length > 0) {
@@ -329,6 +330,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     const { collectDoctorPreviewNotes } = await import("./doctor/shared/preview-warnings.js");
     const previewNotes = await collectDoctorPreviewNotes({
       cfg: candidate,
+      activationSourceConfig: pluginActivationSourceConfig,
       doctorFixCommand,
       env: process.env,
       allowExec: params.options.allowExec === true,

--- a/src/commands/doctor/shared/channel-plugin-blockers.test.ts
+++ b/src/commands/doctor/shared/channel-plugin-blockers.test.ts
@@ -1,5 +1,6 @@
 // Channel plugin blocker tests cover doctor diagnostics for blocked channel plugin setup.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import * as manifestRegistry from "../../../plugins/manifest-registry.js";
 import {
   collectConfiguredChannelPluginBlockerWarnings,
@@ -11,8 +12,11 @@ describe("channel plugin blockers", () => {
     vi.restoreAllMocks();
   });
 
-  it("skips plugin registry work when config has no configured channel surfaces", () => {
-    const registrySpy = vi.spyOn(manifestRegistry, "loadPluginManifestRegistry");
+  it("returns no blockers when config and manifest env have no channel surfaces", () => {
+    const registrySpy = vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [],
+      diagnostics: [],
+    });
 
     const hits = scanConfiguredChannelPluginBlockers({
       channels: {
@@ -23,7 +27,7 @@ describe("channel plugin blockers", () => {
     });
 
     expect(hits).toStrictEqual([]);
-    expect(registrySpy).not.toHaveBeenCalled();
+    expect(registrySpy).toHaveBeenCalled();
   });
 
   it("reports external channel plugins that are installed but not explicitly enabled", () => {
@@ -57,6 +61,69 @@ describe("channel plugin blockers", () => {
     ]);
     expect(collectConfiguredChannelPluginBlockerWarnings(hits)).toEqual([
       '- channels.discord: channel is configured, but external plugin "discord" is installed without explicit trust. Add plugins.entries.discord.enabled=true. Fix plugin enablement before relying on setup guidance for this channel.',
+    ]);
+  });
+
+  it("reports blockers for enabled-only channel intent", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "discord",
+          origin: "global",
+          channels: ["discord"],
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const hits = scanConfiguredChannelPluginBlockers({
+      plugins: {
+        enabled: false,
+      },
+      channels: {
+        discord: {
+          enabled: true,
+        },
+      },
+    });
+
+    expect(hits).toEqual([
+      {
+        channelId: "discord",
+        pluginId: "discord",
+        reason: "plugins disabled",
+      },
+    ]);
+  });
+
+  it("normalizes explicit channel ids before matching plugin owners", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "discord",
+          origin: "global",
+          channels: ["discord"],
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const hits = scanConfiguredChannelPluginBlockers({
+      channels: {
+        Discord: {
+          enabled: true,
+        },
+      },
+    } as OpenClawConfig);
+
+    expect(hits).toEqual([
+      {
+        channelId: "discord",
+        pluginId: "discord",
+        reason: "missing explicit enablement",
+      },
     ]);
   });
 
@@ -182,6 +249,362 @@ describe("channel plugin blockers", () => {
     ]);
   });
 
+  it("diagnoses an env-only channel whose preferred external owner lacks trust", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "telegram",
+          origin: "bundled",
+          channels: ["telegram"],
+          enabledByDefault: true,
+        },
+        {
+          id: "modern-telegram",
+          origin: "config",
+          channels: ["telegram"],
+          enabledByDefault: false,
+          channelConfigs: {
+            telegram: {
+              schema: { type: "object" },
+              preferOver: ["telegram"],
+            },
+          },
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const hits = scanConfiguredChannelPluginBlockers(
+      {
+        plugins: {
+          entries: {
+            telegram: { enabled: false },
+            "modern-telegram": { enabled: true },
+          },
+        },
+      },
+      {
+        TELEGRAM_BOT_TOKEN: "configured",
+      } as NodeJS.ProcessEnv,
+      {},
+    );
+
+    expect(hits).toEqual([
+      {
+        channelId: "telegram",
+        pluginId: "modern-telegram",
+        reason: "missing explicit enablement",
+      },
+    ]);
+  });
+
+  it("diagnoses an external-only manifest env channel that lacks source trust", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "discord",
+          origin: "global",
+          channels: ["discord"],
+          channelEnvVars: {
+            discord: ["DISCORD_BOT_TOKEN"],
+          },
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const hits = scanConfiguredChannelPluginBlockers(
+      {
+        plugins: {
+          entries: {
+            discord: { enabled: true },
+          },
+        },
+      },
+      {
+        DISCORD_BOT_TOKEN: "configured",
+      } as NodeJS.ProcessEnv,
+      {},
+    );
+
+    expect(hits).toEqual([
+      {
+        channelId: "discord",
+        pluginId: "discord",
+        reason: "missing explicit enablement",
+      },
+    ]);
+  });
+
+  it("keeps manifest env trust diagnostics scoped to the declaring owner", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "bundled-chat",
+          origin: "bundled",
+          channels: ["shared-chat"],
+          enabledByDefault: true,
+        },
+        {
+          id: "external-chat",
+          origin: "config",
+          channels: ["shared-chat"],
+          channelEnvVars: {
+            "shared-chat": ["EXTERNAL_CHAT_TOKEN"],
+          },
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const hits = scanConfiguredChannelPluginBlockers(
+      {
+        plugins: {
+          entries: {
+            "external-chat": { enabled: true },
+          },
+        },
+      },
+      {
+        EXTERNAL_CHAT_TOKEN: "configured",
+      } as NodeJS.ProcessEnv,
+      {},
+    );
+
+    expect(hits).toEqual([
+      {
+        channelId: "shared-chat",
+        pluginId: "external-chat",
+        reason: "missing explicit enablement",
+      },
+    ]);
+  });
+
+  it("does not report unrelated blocked owners for a manifest env trigger", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "triggered-chat",
+          origin: "config",
+          channels: ["shared-chat"],
+          channelEnvVars: {
+            "shared-chat": ["TRIGGERED_CHAT_TOKEN"],
+          },
+          enabledByDefault: false,
+        },
+        {
+          id: "unrelated-chat",
+          origin: "config",
+          channels: ["shared-chat"],
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const hits = scanConfiguredChannelPluginBlockers({}, {
+      TRIGGERED_CHAT_TOKEN: "configured",
+    } as NodeJS.ProcessEnv);
+
+    expect(hits).toEqual([
+      {
+        channelId: "shared-chat",
+        pluginId: "triggered-chat",
+        reason: "missing explicit enablement",
+      },
+    ]);
+  });
+
+  it("ignores manifest env mappings for channels the plugin does not own", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "external-chat",
+          origin: "config",
+          channels: ["external-chat"],
+          channelEnvVars: {
+            discord: ["EXTERNAL_CHAT_TOKEN"],
+          },
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const hits = scanConfiguredChannelPluginBlockers({}, {
+      EXTERNAL_CHAT_TOKEN: "configured",
+    } as NodeJS.ProcessEnv);
+
+    expect(hits).toStrictEqual([]);
+  });
+
+  it("diagnoses a manifest env channel whose bundled owner is opt-in", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "twitch",
+          origin: "bundled",
+          channels: ["twitch"],
+          channelEnvVars: {
+            twitch: ["OPENCLAW_TWITCH_ACCESS_TOKEN"],
+          },
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const hits = scanConfiguredChannelPluginBlockers({}, {
+      OPENCLAW_TWITCH_ACCESS_TOKEN: "configured",
+    } as NodeJS.ProcessEnv);
+
+    expect(hits).toEqual([
+      {
+        channelId: "twitch",
+        pluginId: "twitch",
+        reason: "not enabled",
+      },
+    ]);
+    expect(collectConfiguredChannelPluginBlockerWarnings(hits)).toEqual([
+      '- channels.twitch: channel is configured, but plugin "twitch" is installed but not enabled. Add plugins.entries.twitch.enabled=true. Fix plugin enablement before relying on setup guidance for this channel.',
+    ]);
+  });
+
+  it("includes both actions for a bundled opt-in owner under a restrictive allowlist", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "twitch",
+          origin: "bundled",
+          channels: ["twitch"],
+          channelEnvVars: {
+            twitch: ["OPENCLAW_TWITCH_ACCESS_TOKEN"],
+          },
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const hits = scanConfiguredChannelPluginBlockers(
+      {
+        plugins: {
+          allow: ["browser"],
+        },
+      },
+      {
+        OPENCLAW_TWITCH_ACCESS_TOKEN: "configured",
+      } as NodeJS.ProcessEnv,
+    );
+
+    expect(hits).toEqual([
+      {
+        channelId: "twitch",
+        pluginId: "twitch",
+        reason: "not enabled and not in allowlist",
+      },
+    ]);
+    expect(collectConfiguredChannelPluginBlockerWarnings(hits)).toEqual([
+      '- channels.twitch: channel is configured, but plugin "twitch" is not enabled and is omitted from plugins.allow. Add plugins.entries.twitch.enabled=true and include "twitch" in plugins.allow. Fix plugin enablement before relying on setup guidance for this channel.',
+    ]);
+  });
+
+  it("keeps manifest env blockers when another channel is explicitly configured", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "discord",
+          origin: "global",
+          channels: ["discord"],
+          channelEnvVars: {
+            discord: ["DISCORD_BOT_TOKEN"],
+          },
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const hits = scanConfiguredChannelPluginBlockers(
+      {
+        channels: {
+          telegram: {
+            enabled: true,
+          },
+        },
+        plugins: {
+          entries: {
+            discord: { enabled: true },
+          },
+        },
+      },
+      {
+        DISCORD_BOT_TOKEN: "configured",
+      } as NodeJS.ProcessEnv,
+      {
+        channels: {
+          telegram: {
+            enabled: true,
+          },
+        },
+      },
+    );
+
+    expect(hits).toEqual([
+      {
+        channelId: "discord",
+        pluginId: "discord",
+        reason: "missing explicit enablement",
+      },
+    ]);
+  });
+
+  it("honors explicit channel disablement over manifest env triggers", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "discord",
+          origin: "global",
+          channels: ["discord"],
+          channelEnvVars: {
+            discord: ["DISCORD_BOT_TOKEN"],
+          },
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const hits = scanConfiguredChannelPluginBlockers(
+      {
+        channels: {
+          discord: {
+            enabled: false,
+          },
+        },
+        plugins: {
+          entries: {
+            discord: { enabled: true },
+          },
+        },
+      },
+      {
+        DISCORD_BOT_TOKEN: "configured",
+      } as NodeJS.ProcessEnv,
+      {
+        channels: {
+          discord: {
+            enabled: false,
+          },
+        },
+      },
+    );
+
+    expect(hits).toStrictEqual([]);
+  });
+
   it("accepts an auto-enabled bundled owner under a restrictive source allowlist", () => {
     vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
       plugins: [
@@ -296,7 +719,7 @@ describe("channel plugin blockers", () => {
       },
     ]);
     expect(collectConfiguredChannelPluginBlockerWarnings(hits)).toEqual([
-      '- channels.discord: channel is configured, but external plugin "discord" is installed but omitted from plugins.allow. Include "discord" in plugins.allow. Fix plugin enablement before relying on setup guidance for this channel.',
+      '- channels.discord: channel is configured, but plugin "discord" is installed but omitted from plugins.allow. Include "discord" in plugins.allow. Fix plugin enablement before relying on setup guidance for this channel.',
     ]);
   });
 

--- a/src/commands/doctor/shared/channel-plugin-blockers.test.ts
+++ b/src/commands/doctor/shared/channel-plugin-blockers.test.ts
@@ -382,6 +382,84 @@ describe("channel plugin blockers", () => {
     ]);
   });
 
+  it("accepts an available co-owner for the same manifest env trigger", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "bundled-chat",
+          origin: "bundled",
+          channels: ["shared-chat"],
+          channelEnvVars: {
+            "shared-chat": ["SHARED_CHAT_TOKEN"],
+          },
+          enabledByDefault: true,
+        },
+        {
+          id: "external-chat",
+          origin: "config",
+          channels: ["shared-chat"],
+          channelEnvVars: {
+            "shared-chat": ["SHARED_CHAT_TOKEN"],
+          },
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const hits = scanConfiguredChannelPluginBlockers({}, {
+      SHARED_CHAT_TOKEN: "configured",
+    } as NodeJS.ProcessEnv);
+
+    expect(hits).toStrictEqual([]);
+  });
+
+  it("deduplicates global plugin disablement across manifest env triggers", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "first-chat",
+          origin: "config",
+          channels: ["shared-chat"],
+          channelEnvVars: {
+            "shared-chat": ["FIRST_CHAT_TOKEN"],
+          },
+          enabledByDefault: false,
+        },
+        {
+          id: "second-chat",
+          origin: "config",
+          channels: ["shared-chat"],
+          channelEnvVars: {
+            "shared-chat": ["SECOND_CHAT_TOKEN"],
+          },
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const hits = scanConfiguredChannelPluginBlockers(
+      {
+        plugins: {
+          enabled: false,
+        },
+      },
+      {
+        FIRST_CHAT_TOKEN: "configured",
+        SECOND_CHAT_TOKEN: "configured",
+      } as NodeJS.ProcessEnv,
+    );
+
+    expect(hits).toEqual([
+      {
+        channelId: "shared-chat",
+        pluginId: "first-chat",
+        reason: "plugins disabled",
+      },
+    ]);
+  });
+
   it("does not report unrelated blocked owners for a manifest env trigger", () => {
     vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
       plugins: [
@@ -651,6 +729,88 @@ describe("channel plugin blockers", () => {
     expect(hits).toStrictEqual([]);
   });
 
+  it("preserves explicit external trust across an auto-materialized allowlist", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "discord",
+          origin: "global",
+          channels: ["discord"],
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const sourceConfig: OpenClawConfig = {
+      channels: {
+        discord: {
+          enabled: true,
+        },
+      },
+      plugins: {
+        allow: ["browser"],
+        entries: {
+          discord: { enabled: true },
+        },
+      },
+    };
+    const hits = scanConfiguredChannelPluginBlockers(
+      {
+        ...sourceConfig,
+        plugins: {
+          ...sourceConfig.plugins,
+          allow: ["browser", "discord"],
+        },
+      },
+      process.env,
+      sourceConfig,
+    );
+
+    expect(hits).toStrictEqual([]);
+  });
+
+  it("preserves explicit workspace trust across an auto-materialized allowlist", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "workspace-chat",
+          origin: "workspace",
+          channels: ["workspace-chat"],
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const sourceConfig: OpenClawConfig = {
+      channels: {
+        "workspace-chat": {
+          enabled: true,
+        },
+      },
+      plugins: {
+        allow: ["browser"],
+        entries: {
+          "workspace-chat": { enabled: true },
+        },
+      },
+    };
+    const hits = scanConfiguredChannelPluginBlockers(
+      {
+        ...sourceConfig,
+        plugins: {
+          ...sourceConfig.plugins,
+          allow: ["browser", "workspace-chat"],
+        },
+      },
+      process.env,
+      sourceConfig,
+    );
+
+    expect(hits).toStrictEqual([]);
+  });
+
   it("accepts an env-auto-enabled bundled owner absent from the source config", () => {
     vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
       plugins: [
@@ -756,9 +916,50 @@ describe("channel plugin blockers", () => {
     expect(hits).toEqual([
       {
         channelId: "shared-chat",
+        pluginId: "denied-chat",
+        reason: "blocked by denylist",
+      },
+      {
+        channelId: "shared-chat",
         pluginId: "untrusted-chat",
         reason: "missing explicit enablement",
       },
+    ]);
+  });
+
+  it("reports a single channel owner blocked by plugins.deny", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "discord",
+          origin: "global",
+          channels: ["discord"],
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const hits = scanConfiguredChannelPluginBlockers({
+      plugins: {
+        deny: ["discord"],
+      },
+      channels: {
+        discord: {
+          enabled: true,
+        },
+      },
+    });
+
+    expect(hits).toEqual([
+      {
+        channelId: "discord",
+        pluginId: "discord",
+        reason: "blocked by denylist",
+      },
+    ]);
+    expect(collectConfiguredChannelPluginBlockerWarnings(hits)).toEqual([
+      '- channels.discord: channel is configured, but plugin "discord" is blocked by plugins.deny. Remove "discord" from plugins.deny. Fix plugin enablement before relying on setup guidance for this channel.',
     ]);
   });
 

--- a/src/commands/doctor/shared/channel-plugin-blockers.test.ts
+++ b/src/commands/doctor/shared/channel-plugin-blockers.test.ts
@@ -88,6 +88,47 @@ describe("channel plugin blockers", () => {
     expect(hits).toStrictEqual([]);
   });
 
+  it("diagnoses trust from the pre-auto-enable config", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "discord",
+          origin: "global",
+          channels: ["discord"],
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const channels = {
+      discord: {
+        enabled: true,
+        token: "configured",
+      },
+    };
+    const hits = scanConfiguredChannelPluginBlockers(
+      {
+        channels,
+        plugins: {
+          entries: {
+            discord: { enabled: true },
+          },
+        },
+      },
+      process.env,
+      { channels },
+    );
+
+    expect(hits).toEqual([
+      {
+        channelId: "discord",
+        pluginId: "discord",
+        reason: "missing explicit enablement",
+      },
+    ]);
+  });
+
   it("reports external channel plugins omitted from a restrictive allowlist", () => {
     vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
       plugins: [

--- a/src/commands/doctor/shared/channel-plugin-blockers.test.ts
+++ b/src/commands/doctor/shared/channel-plugin-blockers.test.ts
@@ -129,6 +129,140 @@ describe("channel plugin blockers", () => {
     ]);
   });
 
+  it("uses effective config for preferOver fallback disablement", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "legacy-chat",
+          origin: "bundled",
+          channels: ["legacy-chat"],
+          enabledByDefault: true,
+        },
+        {
+          id: "modern-chat",
+          origin: "config",
+          channels: ["legacy-chat"],
+          enabledByDefault: false,
+          channelConfigs: {
+            "legacy-chat": {
+              schema: { type: "object" },
+              preferOver: ["legacy-chat"],
+            },
+          },
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const channels = {
+      "legacy-chat": {
+        token: "configured",
+      },
+    };
+    const hits = scanConfiguredChannelPluginBlockers(
+      {
+        channels,
+        plugins: {
+          entries: {
+            "legacy-chat": { enabled: false },
+            "modern-chat": { enabled: true },
+          },
+        },
+      },
+      process.env,
+      { channels },
+    );
+
+    expect(hits).toEqual([
+      {
+        channelId: "legacy-chat",
+        pluginId: "modern-chat",
+        reason: "missing explicit enablement",
+      },
+    ]);
+  });
+
+  it("accepts an auto-enabled bundled owner under a restrictive source allowlist", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "telegram-plugin",
+          origin: "bundled",
+          channels: ["telegram"],
+          enabledByDefault: false,
+        },
+        {
+          id: "untrusted-telegram",
+          origin: "config",
+          channels: ["telegram"],
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const channels = {
+      telegram: {
+        botToken: "configured",
+      },
+    };
+    const hits = scanConfiguredChannelPluginBlockers(
+      {
+        channels,
+        plugins: {
+          allow: ["browser", "telegram-plugin"],
+          entries: {
+            "telegram-plugin": { enabled: true },
+          },
+        },
+      },
+      process.env,
+      {
+        channels,
+        plugins: {
+          allow: ["browser"],
+        },
+      },
+    );
+
+    expect(hits).toStrictEqual([]);
+  });
+
+  it("accepts an env-auto-enabled bundled owner absent from the source config", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "telegram",
+          origin: "bundled",
+          channels: ["telegram"],
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const hits = scanConfiguredChannelPluginBlockers(
+      {
+        channels: {
+          telegram: {
+            enabled: true,
+          },
+        },
+        plugins: {
+          allow: ["browser", "telegram"],
+        },
+      },
+      process.env,
+      {
+        plugins: {
+          allow: ["browser"],
+        },
+      },
+    );
+
+    expect(hits).toStrictEqual([]);
+  });
+
   it("reports external channel plugins omitted from a restrictive allowlist", () => {
     vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
       plugins: [
@@ -164,6 +298,75 @@ describe("channel plugin blockers", () => {
     expect(collectConfiguredChannelPluginBlockerWarnings(hits)).toEqual([
       '- channels.discord: channel is configured, but external plugin "discord" is installed but omitted from plugins.allow. Include "discord" in plugins.allow. Fix plugin enablement before relying on setup guidance for this channel.',
     ]);
+  });
+
+  it("keeps blocker reasons scoped to each external owner", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "denied-chat",
+          origin: "config",
+          channels: ["shared-chat"],
+          enabledByDefault: false,
+        },
+        {
+          id: "untrusted-chat",
+          origin: "config",
+          channels: ["shared-chat"],
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const hits = scanConfiguredChannelPluginBlockers({
+      plugins: {
+        deny: ["denied-chat"],
+      },
+      channels: {
+        "shared-chat": {
+          token: "configured",
+        },
+      },
+    });
+
+    expect(hits).toEqual([
+      {
+        channelId: "shared-chat",
+        pluginId: "untrusted-chat",
+        reason: "missing explicit enablement",
+      },
+    ]);
+  });
+
+  it("accepts workspace channel owners activated through a plugin slot", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "workspace-chat",
+          origin: "workspace",
+          channels: ["workspace-chat"],
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const hits = scanConfiguredChannelPluginBlockers({
+      plugins: {
+        allow: ["browser"],
+        slots: {
+          contextEngine: "workspace-chat",
+        },
+      },
+      channels: {
+        "workspace-chat": {
+          token: "configured",
+        },
+      },
+    });
+
+    expect(hits).toStrictEqual([]);
   });
 
   it("still evaluates configured channels when plugins are disabled globally", () => {
@@ -296,7 +499,7 @@ describe("channel plugin blockers", () => {
     expect(hits).toStrictEqual([]);
   });
 
-  it("still reports the disabled bundled owner when an external channel owner is not trusted", () => {
+  it("reports each blocked owner when no channel owner is active", () => {
     vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
       plugins: [
         {
@@ -344,6 +547,11 @@ describe("channel plugin blockers", () => {
         channelId: "feishu",
         pluginId: "feishu",
         reason: "disabled in config",
+      },
+      {
+        channelId: "feishu",
+        pluginId: "openclaw-lark",
+        reason: "missing explicit enablement",
       },
     ]);
   });

--- a/src/commands/doctor/shared/channel-plugin-blockers.test.ts
+++ b/src/commands/doctor/shared/channel-plugin-blockers.test.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import * as manifestRegistry from "../../../plugins/manifest-registry.js";
 import {
   collectConfiguredChannelPluginBlockerWarnings,
+  isWarningBlockedByChannelPlugin,
   scanConfiguredChannelPluginBlockers,
 } from "./channel-plugin-blockers.js";
 
@@ -378,8 +379,31 @@ describe("channel plugin blockers", () => {
         channelId: "shared-chat",
         pluginId: "external-chat",
         reason: "missing explicit enablement",
+        channelAvailable: true,
       },
     ]);
+  });
+
+  it("preserves channel-wide warnings when only a co-owner is blocked", () => {
+    expect(
+      isWarningBlockedByChannelPlugin("channels.shared-chat.groupPolicy: warning", [
+        {
+          channelId: "shared-chat",
+          pluginId: "external-chat",
+          reason: "missing explicit enablement",
+          channelAvailable: true,
+        },
+      ]),
+    ).toBe(false);
+    expect(
+      isWarningBlockedByChannelPlugin("channels.shared-chat.groupPolicy: warning", [
+        {
+          channelId: "shared-chat",
+          pluginId: "external-chat",
+          reason: "missing explicit enablement",
+        },
+      ]),
+    ).toBe(true);
   });
 
   it("accepts an available co-owner for the same manifest env trigger", () => {

--- a/src/commands/doctor/shared/channel-plugin-blockers.test.ts
+++ b/src/commands/doctor/shared/channel-plugin-blockers.test.ts
@@ -1,30 +1,128 @@
 // Channel plugin blocker tests cover doctor diagnostics for blocked channel plugin setup.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as manifestRegistry from "../../../plugins/manifest-registry.js";
-import { scanConfiguredChannelPluginBlockers } from "./channel-plugin-blockers.js";
+import {
+  collectConfiguredChannelPluginBlockerWarnings,
+  scanConfiguredChannelPluginBlockers,
+} from "./channel-plugin-blockers.js";
 
 describe("channel plugin blockers", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("skips plugin registry work when config has no plugin blocker surfaces", () => {
+  it("skips plugin registry work when config has no configured channel surfaces", () => {
     const registrySpy = vi.spyOn(manifestRegistry, "loadPluginManifestRegistry");
 
     const hits = scanConfiguredChannelPluginBlockers({
       channels: {
-        slack: {
-          accounts: {
-            work: {
-              allowFrom: ["alice"],
-            },
-          },
+        defaults: {
+          groupPolicy: "disabled",
         },
       },
     });
 
     expect(hits).toStrictEqual([]);
     expect(registrySpy).not.toHaveBeenCalled();
+  });
+
+  it("reports external channel plugins that are installed but not explicitly enabled", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "discord",
+          origin: "global",
+          channels: ["discord"],
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const hits = scanConfiguredChannelPluginBlockers({
+      channels: {
+        discord: {
+          enabled: true,
+          token: "configured",
+        },
+      },
+    });
+
+    expect(hits).toEqual([
+      {
+        channelId: "discord",
+        pluginId: "discord",
+        reason: "missing explicit enablement",
+      },
+    ]);
+    expect(collectConfiguredChannelPluginBlockerWarnings(hits)).toEqual([
+      '- channels.discord: channel is configured, but external plugin "discord" is installed without explicit trust. Add plugins.entries.discord.enabled=true. Fix plugin enablement before relying on setup guidance for this channel.',
+    ]);
+  });
+
+  it("accepts plugins.allow as explicit trust for external channel plugins", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "discord",
+          origin: "global",
+          channels: ["discord"],
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const hits = scanConfiguredChannelPluginBlockers({
+      plugins: {
+        allow: ["discord"],
+      },
+      channels: {
+        discord: {
+          enabled: true,
+          token: "configured",
+        },
+      },
+    });
+
+    expect(hits).toStrictEqual([]);
+  });
+
+  it("reports external channel plugins omitted from a restrictive allowlist", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "discord",
+          origin: "global",
+          channels: ["discord"],
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const hits = scanConfiguredChannelPluginBlockers({
+      plugins: {
+        allow: ["brave"],
+      },
+      channels: {
+        discord: {
+          enabled: true,
+          token: "configured",
+        },
+      },
+    });
+
+    expect(hits).toEqual([
+      {
+        channelId: "discord",
+        pluginId: "discord",
+        reason: "not in allowlist",
+      },
+    ]);
+    expect(collectConfiguredChannelPluginBlockerWarnings(hits)).toEqual([
+      '- channels.discord: channel is configured, but external plugin "discord" is installed but omitted from plugins.allow. Include "discord" in plugins.allow or remove the restrictive allowlist. Fix plugin enablement before relying on setup guidance for this channel.',
+    ]);
   });
 
   it("still evaluates configured channels when plugins are disabled globally", () => {

--- a/src/commands/doctor/shared/channel-plugin-blockers.test.ts
+++ b/src/commands/doctor/shared/channel-plugin-blockers.test.ts
@@ -121,7 +121,7 @@ describe("channel plugin blockers", () => {
       },
     ]);
     expect(collectConfiguredChannelPluginBlockerWarnings(hits)).toEqual([
-      '- channels.discord: channel is configured, but external plugin "discord" is installed but omitted from plugins.allow. Include "discord" in plugins.allow or remove the restrictive allowlist. Fix plugin enablement before relying on setup guidance for this channel.',
+      '- channels.discord: channel is configured, but external plugin "discord" is installed but omitted from plugins.allow. Include "discord" in plugins.allow. Fix plugin enablement before relying on setup guidance for this channel.',
     ]);
   });
 

--- a/src/commands/doctor/shared/channel-plugin-blockers.ts
+++ b/src/commands/doctor/shared/channel-plugin-blockers.ts
@@ -25,6 +25,8 @@ export type ChannelPluginBlockerHit = {
   channelId: string;
   /** Plugin id that would provide the configured channel. */
   pluginId: string;
+  /** Another owner can still serve this channel despite this owner-specific blocker. */
+  channelAvailable?: boolean;
   /** Effective activation reason preventing the plugin from loading. */
   reason:
     | "disabled in config"
@@ -84,7 +86,11 @@ export function scanConfiguredChannelPluginBlockers(
   const hits: ChannelPluginBlockerHit[] = [];
   const hitKeys = new Set<string>();
   const globalDisableChannelIds = new Set<string>();
-  const addHits = (channelId: string, ownerStates: ChannelOwnerState[]) => {
+  const addHits = (
+    channelId: string,
+    ownerStates: ChannelOwnerState[],
+    channelAvailable = false,
+  ) => {
     for (const state of ownerStates) {
       if (!state.reason) {
         continue;
@@ -100,11 +106,15 @@ export function scanConfiguredChannelPluginBlockers(
         continue;
       }
       hitKeys.add(key);
-      hits.push({
+      const hit: ChannelPluginBlockerHit = {
         channelId,
         pluginId: state.pluginId,
         reason: state.reason,
-      });
+      };
+      if (channelAvailable) {
+        hit.channelAvailable = true;
+      }
+      hits.push(hit);
     }
   };
 
@@ -131,9 +141,13 @@ export function scanConfiguredChannelPluginBlockers(
   }
 
   for (const [channelId, triggers] of manifestEnvTriggers) {
-    for (const pluginIds of triggers.values()) {
-      const owners = registry.plugins.filter((plugin) => pluginIds.has(plugin.id));
-      const ownerStates = owners.map((plugin) =>
+    const channelOwnerStates = registry.plugins
+      .filter((plugin) =>
+        plugin.channels.some(
+          (rawChannelId) => normalizeOptionalLowercaseString(rawChannelId) === channelId,
+        ),
+      )
+      .map((plugin) =>
         resolveConfiguredChannelOwnerState({
           plugin,
           channelId,
@@ -143,10 +157,13 @@ export function scanConfiguredChannelPluginBlockers(
           effectivePluginsConfig,
         }),
       );
+    const channelAvailable = channelOwnerStates.some((state) => state.available);
+    for (const pluginIds of triggers.values()) {
+      const ownerStates = channelOwnerStates.filter((state) => pluginIds.has(state.pluginId));
       if (ownerStates.some((state) => state.available)) {
         continue;
       }
-      addHits(channelId, ownerStates);
+      addHits(channelId, ownerStates, channelAvailable);
     }
   }
 
@@ -348,6 +365,9 @@ export function isWarningBlockedByChannelPlugin(
   hits: ChannelPluginBlockerHit[],
 ): boolean {
   return hits.some((hit) => {
+    if (hit.channelAvailable) {
+      return false;
+    }
     const prefix = `channels.${sanitizeForLog(hit.channelId)}`;
     return warning.includes(`${prefix}:`) || warning.includes(`${prefix}.`);
   });

--- a/src/commands/doctor/shared/channel-plugin-blockers.ts
+++ b/src/commands/doctor/shared/channel-plugin-blockers.ts
@@ -1,12 +1,15 @@
 // Doctor warnings for configured channels blocked by disabled channel plugins.
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog } from "../../../../packages/terminal-core/src/ansi.js";
+import { listExplicitlyDisabledChannelIdsForConfig } from "../../../channels/config-presence.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import {
   hasExplicitChannelConfig,
   listExplicitConfiguredChannelIdsForConfig,
+  resolveConfiguredChannelPresencePolicy,
 } from "../../../plugins/channel-plugin-ids.js";
 import { normalizePluginsConfig } from "../../../plugins/config-state.js";
+import { isPluginEnabledByDefaultForPlatform } from "../../../plugins/default-enablement.js";
 import {
   hasExplicitManifestOwnerTrust,
   isActivatedManifestOwner,
@@ -15,6 +18,7 @@ import {
 } from "../../../plugins/manifest-owner-policy.js";
 import type { PluginManifestRecord } from "../../../plugins/manifest-registry.js";
 import { loadPluginManifestRegistryForPluginRegistry } from "../../../plugins/plugin-registry.js";
+import { isSafeChannelEnvVarTriggerName } from "../../../secrets/channel-env-var-names.js";
 
 export type ChannelPluginBlockerHit = {
   /** Normalized configured channel id whose backing plugin is unavailable. */
@@ -26,6 +30,8 @@ export type ChannelPluginBlockerHit = {
     | "disabled in config"
     | "plugins disabled"
     | "missing explicit enablement"
+    | "not enabled"
+    | "not enabled and not in allowlist"
     | "not in allowlist";
 };
 
@@ -35,15 +41,9 @@ export function scanConfiguredChannelPluginBlockers(
   env: NodeJS.ProcessEnv = process.env,
   activationSourceConfig: OpenClawConfig = cfg,
 ): ChannelPluginBlockerHit[] {
-  const configuredChannelIds = new Set(
-    listExplicitConfiguredChannelIdsForConfig(cfg)
-      .map((channelId) => normalizeOptionalLowercaseString(channelId))
-      .filter((channelId): channelId is string => Boolean(channelId)),
-  );
-  if (configuredChannelIds.size === 0) {
-    return [];
-  }
-
+  const explicitChannelIds = listExplicitConfiguredChannelIdsForConfig(cfg)
+    .map((channelId) => normalizeOptionalLowercaseString(channelId))
+    .filter((channelId): channelId is string => Boolean(channelId));
   const sourcePluginsConfig = normalizePluginsConfig(activationSourceConfig.plugins);
   const effectivePluginsConfig = normalizePluginsConfig(cfg.plugins);
   const registry = loadPluginManifestRegistryForPluginRegistry({
@@ -51,9 +51,63 @@ export function scanConfiguredChannelPluginBlockers(
     env,
     includeDisabled: true,
   });
+  const manifestEnvOwners = listManifestEnvConfiguredChannelOwners(registry.plugins, env);
+  const policyEntries = resolveConfiguredChannelPresencePolicy({
+    config: cfg,
+    activationSourceConfig,
+    env,
+    includePersistedAuthState: false,
+    manifestRecords: registry.plugins,
+  });
+  // A manifest env match identifies one owner. Do not widen the same ambient env signal to
+  // sibling owners that cannot consume that credential.
+  const policyChannelIds = policyEntries
+    .filter(
+      (entry) =>
+        !manifestEnvOwners.has(entry.channelId) ||
+        entry.sources.some((source) => source !== "env" && source !== "manifest-env"),
+    )
+    .map((entry) => entry.channelId);
+  const genericChannelIds = new Set([
+    ...explicitChannelIds,
+    ...(explicitChannelIds.length === 0 ? policyChannelIds : []),
+  ]);
+  for (const channelId of listExplicitlyDisabledChannelIdsForConfig(cfg)) {
+    const normalizedChannelId = normalizeOptionalLowercaseString(channelId) ?? channelId;
+    genericChannelIds.delete(normalizedChannelId);
+    manifestEnvOwners.delete(normalizedChannelId);
+  }
+  if (genericChannelIds.size === 0 && manifestEnvOwners.size === 0) {
+    return [];
+  }
   const hits: ChannelPluginBlockerHit[] = [];
+  const hitKeys = new Set<string>();
+  const addHits = (channelId: string, ownerStates: ChannelOwnerState[]) => {
+    let reportedGlobalDisable = false;
+    for (const state of ownerStates) {
+      if (!state.reason) {
+        continue;
+      }
+      if (state.reason === "plugins disabled") {
+        if (reportedGlobalDisable) {
+          continue;
+        }
+        reportedGlobalDisable = true;
+      }
+      const key = `${channelId}\0${state.pluginId}\0${state.reason}`;
+      if (hitKeys.has(key)) {
+        continue;
+      }
+      hitKeys.add(key);
+      hits.push({
+        channelId,
+        pluginId: state.pluginId,
+        reason: state.reason,
+      });
+    }
+  };
 
-  for (const channelId of configuredChannelIds) {
+  for (const channelId of genericChannelIds) {
     const owners = registry.plugins.filter((plugin) =>
       plugin.channels.some(
         (rawChannelId) => normalizeOptionalLowercaseString(rawChannelId) === channelId,
@@ -72,26 +126,65 @@ export function scanConfiguredChannelPluginBlockers(
     if (ownerStates.some((state) => state.available)) {
       continue;
     }
-    let reportedGlobalDisable = false;
-    for (const state of ownerStates) {
-      if (!state.reason) {
-        continue;
-      }
-      if (state.reason === "plugins disabled") {
-        if (reportedGlobalDisable) {
-          continue;
-        }
-        reportedGlobalDisable = true;
-      }
-      hits.push({
+    addHits(channelId, ownerStates);
+  }
+
+  for (const [channelId, pluginIds] of manifestEnvOwners) {
+    const owners = registry.plugins.filter((plugin) => pluginIds.has(plugin.id));
+    const ownerStates = owners.map((plugin) =>
+      resolveConfiguredChannelOwnerState({
+        plugin,
         channelId,
-        pluginId: state.pluginId,
-        reason: state.reason,
-      });
-    }
+        sourceConfig: activationSourceConfig,
+        sourcePluginsConfig,
+        effectiveConfig: cfg,
+        effectivePluginsConfig,
+      }),
+    );
+    addHits(
+      channelId,
+      ownerStates.filter((state) => !state.available),
+    );
   }
 
   return hits;
+}
+
+function listManifestEnvConfiguredChannelOwners(
+  plugins: readonly PluginManifestRecord[],
+  env: NodeJS.ProcessEnv,
+): Map<string, Set<string>> {
+  const ownersByChannelId = new Map<string, Set<string>>();
+  for (const plugin of plugins) {
+    const ownedChannelIds = new Set(
+      plugin.channels
+        .map((channelId) => normalizeOptionalLowercaseString(channelId))
+        .filter((channelId): channelId is string => Boolean(channelId)),
+    );
+    for (const [rawChannelId, envVars] of Object.entries(plugin.channelEnvVars ?? {})) {
+      const channelId = normalizeOptionalLowercaseString(rawChannelId);
+      if (!channelId || !ownedChannelIds.has(channelId)) {
+        continue;
+      }
+      const configured = envVars.some((envVar) => {
+        if (!isSafeChannelEnvVarTriggerName(envVar)) {
+          return false;
+        }
+        const value = env[envVar] ?? env[envVar.toUpperCase()];
+        return typeof value === "string" && value.trim().length > 0;
+      });
+      if (!configured) {
+        continue;
+      }
+      let ownerIds = ownersByChannelId.get(channelId);
+      if (!ownerIds) {
+        ownerIds = new Set();
+        ownersByChannelId.set(channelId, ownerIds);
+      }
+      ownerIds.add(plugin.id);
+    }
+  }
+  return ownersByChannelId;
 }
 
 type ChannelOwnerState = {
@@ -136,6 +229,18 @@ function resolveConfiguredChannelOwnerState(params: {
             plugin: params.plugin,
             normalizedConfig: params.sourcePluginsConfig,
           })));
+  const sourceBundledActivated =
+    params.plugin.origin === "bundled" &&
+    (bundledChannelConfigured ||
+      isActivatedManifestOwner({
+        plugin: params.plugin,
+        normalizedConfig: params.sourcePluginsConfig,
+        rootConfig: params.sourceConfig,
+      }));
+  const sourceBundledNeedsExplicitEnablement =
+    params.plugin.origin === "bundled" &&
+    !isPluginEnabledByDefaultForPlatform(params.plugin) &&
+    params.sourcePluginsConfig.entries[params.plugin.id]?.enabled !== true;
 
   const effectiveBundledChannelConfigured =
     params.plugin.origin === "bundled" &&
@@ -166,10 +271,18 @@ function resolveConfiguredChannelOwnerState(params: {
     available,
     reason: available
       ? undefined
-      : (mapManifestOwnerBlockerReason(sourceBaseBlock) ??
-        (!sourceExternalTrusted && sourceBaseBlock === null
-          ? "missing explicit enablement"
-          : undefined)),
+      : params.plugin.origin === "bundled" &&
+          sourceBaseBlock === "not-in-allowlist" &&
+          sourceBundledNeedsExplicitEnablement
+        ? "not enabled and not in allowlist"
+        : (mapManifestOwnerBlockerReason(sourceBaseBlock) ??
+          (!sourceExternalTrusted && sourceBaseBlock === null
+            ? "missing explicit enablement"
+            : params.plugin.origin === "bundled" &&
+                sourceBaseBlock === null &&
+                !sourceBundledActivated
+              ? "not enabled"
+              : undefined)),
   };
 }
 
@@ -198,8 +311,14 @@ function formatReason(hit: ChannelPluginBlockerHit): string {
   if (hit.reason === "missing explicit enablement") {
     return `external plugin "${sanitizeForLog(hit.pluginId)}" is installed without explicit trust. Add plugins.entries.${sanitizeForLog(hit.pluginId)}.enabled=true.`;
   }
+  if (hit.reason === "not enabled") {
+    return `plugin "${sanitizeForLog(hit.pluginId)}" is installed but not enabled. Add plugins.entries.${sanitizeForLog(hit.pluginId)}.enabled=true.`;
+  }
+  if (hit.reason === "not enabled and not in allowlist") {
+    return `plugin "${sanitizeForLog(hit.pluginId)}" is not enabled and is omitted from plugins.allow. Add plugins.entries.${sanitizeForLog(hit.pluginId)}.enabled=true and include "${sanitizeForLog(hit.pluginId)}" in plugins.allow.`;
+  }
   if (hit.reason === "not in allowlist") {
-    return `external plugin "${sanitizeForLog(hit.pluginId)}" is installed but omitted from plugins.allow. Include "${sanitizeForLog(hit.pluginId)}" in plugins.allow.`;
+    return `plugin "${sanitizeForLog(hit.pluginId)}" is installed but omitted from plugins.allow. Include "${sanitizeForLog(hit.pluginId)}" in plugins.allow.`;
   }
   return `plugin "${sanitizeForLog(hit.pluginId)}" is not loadable (${sanitizeForLog(hit.reason)}).`;
 }

--- a/src/commands/doctor/shared/channel-plugin-blockers.ts
+++ b/src/commands/doctor/shared/channel-plugin-blockers.ts
@@ -3,13 +3,17 @@ import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/s
 import { sanitizeForLog } from "../../../../packages/terminal-core/src/ansi.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import {
+  hasExplicitChannelConfig,
   listExplicitConfiguredChannelIdsForConfig,
-  resolveConfiguredChannelPresencePolicy,
 } from "../../../plugins/channel-plugin-ids.js";
+import { normalizePluginsConfig } from "../../../plugins/config-state.js";
 import {
-  normalizePluginsConfig,
-  resolveEffectivePluginActivationState,
-} from "../../../plugins/config-state.js";
+  hasExplicitManifestOwnerTrust,
+  isActivatedManifestOwner,
+  resolveManifestOwnerBasePolicyBlock,
+  type ManifestOwnerBasePolicyBlockReason,
+} from "../../../plugins/manifest-owner-policy.js";
+import type { PluginManifestRecord } from "../../../plugins/manifest-registry.js";
 import { loadPluginManifestRegistryForPluginRegistry } from "../../../plugins/plugin-registry.js";
 
 export type ChannelPluginBlockerHit = {
@@ -40,108 +44,148 @@ export function scanConfiguredChannelPluginBlockers(
     return [];
   }
 
-  const pluginsConfig = normalizePluginsConfig(activationSourceConfig.plugins);
+  const sourcePluginsConfig = normalizePluginsConfig(activationSourceConfig.plugins);
+  const effectivePluginsConfig = normalizePluginsConfig(cfg.plugins);
   const registry = loadPluginManifestRegistryForPluginRegistry({
     config: cfg,
     env,
     includeDisabled: true,
   });
-  const presencePolicy = resolveConfiguredChannelPresencePolicy({
-    config: cfg,
-    activationSourceConfig,
-    env,
-    includePersistedAuthState: false,
-    manifestRecords: registry.plugins,
-  });
-  const activeConfiguredChannelIds = new Set(
-    presencePolicy.filter((entry) => entry.effective).map((entry) => entry.channelId),
-  );
-  const blockedReasonsByChannelId = new Map(
-    presencePolicy
-      .filter((entry) => !entry.effective)
-      .map((entry) => [entry.channelId, new Set(entry.blockedReasons)] as const),
-  );
   const hits: ChannelPluginBlockerHit[] = [];
 
-  for (const plugin of registry.plugins) {
-    if (plugin.channels.length === 0) {
+  for (const channelId of configuredChannelIds) {
+    const owners = registry.plugins.filter((plugin) =>
+      plugin.channels.some(
+        (rawChannelId) => normalizeOptionalLowercaseString(rawChannelId) === channelId,
+      ),
+    );
+    const ownerStates = owners.map((plugin) =>
+      resolveConfiguredChannelOwnerState({
+        plugin,
+        channelId,
+        sourceConfig: activationSourceConfig,
+        sourcePluginsConfig,
+        effectiveConfig: cfg,
+        effectivePluginsConfig,
+      }),
+    );
+    if (ownerStates.some((state) => state.available)) {
       continue;
     }
-
-    const activationState = resolveEffectivePluginActivationState({
-      id: plugin.id,
-      origin: plugin.origin,
-      config: pluginsConfig,
-      rootConfig: activationSourceConfig,
-      enabledByDefault: plugin.enabledByDefault,
-    });
-    if (
-      activationState.activated ||
-      !activationState.reason ||
-      (activationState.reason !== "disabled in config" &&
-        activationState.reason !== "plugins disabled")
-    ) {
-      continue;
-    }
-
-    for (const rawChannelId of plugin.channels) {
-      const channelId = normalizeOptionalLowercaseString(rawChannelId);
-      if (!channelId) {
+    let reportedGlobalDisable = false;
+    for (const state of ownerStates) {
+      if (!state.reason) {
         continue;
       }
-      if (!configuredChannelIds.has(channelId)) {
-        continue;
-      }
-      if (activeConfiguredChannelIds.has(channelId)) {
-        continue;
+      if (state.reason === "plugins disabled") {
+        if (reportedGlobalDisable) {
+          continue;
+        }
+        reportedGlobalDisable = true;
       }
       hits.push({
         channelId,
-        pluginId: plugin.id,
-        reason: activationState.reason,
-      });
-    }
-  }
-
-  const channelsWithExplicitBlockerHits = new Set(hits.map((hit) => hit.channelId));
-
-  for (const plugin of registry.plugins) {
-    if (plugin.origin === "bundled" || plugin.channels.length === 0) {
-      continue;
-    }
-
-    for (const rawChannelId of plugin.channels) {
-      const channelId = normalizeOptionalLowercaseString(rawChannelId);
-      if (!channelId) {
-        continue;
-      }
-      if (!configuredChannelIds.has(channelId)) {
-        continue;
-      }
-      if (channelsWithExplicitBlockerHits.has(channelId)) {
-        continue;
-      }
-      if (activeConfiguredChannelIds.has(channelId)) {
-        continue;
-      }
-      const blockedReasons = blockedReasonsByChannelId.get(channelId);
-      const reason = blockedReasons?.has("untrusted-plugin")
-        ? "missing explicit enablement"
-        : blockedReasons?.has("not-in-allowlist")
-          ? "not in allowlist"
-          : undefined;
-      if (!reason) {
-        continue;
-      }
-      hits.push({
-        channelId,
-        pluginId: plugin.id,
-        reason,
+        pluginId: state.pluginId,
+        reason: state.reason,
       });
     }
   }
 
   return hits;
+}
+
+type ChannelOwnerState = {
+  pluginId: string;
+  available: boolean;
+  reason?: ChannelPluginBlockerHit["reason"];
+};
+
+function resolveConfiguredChannelOwnerState(params: {
+  plugin: PluginManifestRecord;
+  channelId: string;
+  sourceConfig: OpenClawConfig;
+  sourcePluginsConfig: ReturnType<typeof normalizePluginsConfig>;
+  effectiveConfig: OpenClawConfig;
+  effectivePluginsConfig: ReturnType<typeof normalizePluginsConfig>;
+}): ChannelOwnerState {
+  const bundledChannelConfigured =
+    params.plugin.origin === "bundled" &&
+    hasExplicitChannelConfig({
+      config: params.sourceConfig,
+      channelId: params.channelId,
+    });
+  const sourceAllowlistBypass =
+    bundledChannelConfigured ||
+    (params.plugin.origin === "workspace" &&
+      params.sourcePluginsConfig.slots.contextEngine === params.plugin.id);
+  const sourceBaseBlock = resolveManifestOwnerBasePolicyBlock({
+    plugin: params.plugin,
+    normalizedConfig: params.sourcePluginsConfig,
+    allowRestrictiveAllowlistBypass: sourceAllowlistBypass,
+  });
+  const sourceExternalTrusted =
+    params.plugin.origin === "bundled" ||
+    (sourceBaseBlock === null &&
+      (params.plugin.origin === "workspace"
+        ? isActivatedManifestOwner({
+            plugin: params.plugin,
+            normalizedConfig: params.sourcePluginsConfig,
+            rootConfig: params.sourceConfig,
+          })
+        : hasExplicitManifestOwnerTrust({
+            plugin: params.plugin,
+            normalizedConfig: params.sourcePluginsConfig,
+          })));
+
+  const effectiveBundledChannelConfigured =
+    params.plugin.origin === "bundled" &&
+    hasExplicitChannelConfig({
+      config: params.effectiveConfig,
+      channelId: params.channelId,
+    });
+  const effectiveAllowlistBypass =
+    effectiveBundledChannelConfigured ||
+    (params.plugin.origin === "workspace" &&
+      params.effectivePluginsConfig.slots.contextEngine === params.plugin.id);
+  const effectiveBaseBlock = resolveManifestOwnerBasePolicyBlock({
+    plugin: params.plugin,
+    normalizedConfig: params.effectivePluginsConfig,
+    allowRestrictiveAllowlistBypass: effectiveAllowlistBypass,
+  });
+  const available =
+    effectiveBaseBlock === null &&
+    sourceExternalTrusted &&
+    (effectiveBundledChannelConfigured ||
+      isActivatedManifestOwner({
+        plugin: params.plugin,
+        normalizedConfig: params.effectivePluginsConfig,
+        rootConfig: params.effectiveConfig,
+      }));
+  return {
+    pluginId: params.plugin.id,
+    available,
+    reason: available
+      ? undefined
+      : (mapManifestOwnerBlockerReason(sourceBaseBlock) ??
+        (!sourceExternalTrusted && sourceBaseBlock === null
+          ? "missing explicit enablement"
+          : undefined)),
+  };
+}
+
+function mapManifestOwnerBlockerReason(
+  reason: ManifestOwnerBasePolicyBlockReason | null,
+): ChannelPluginBlockerHit["reason"] | undefined {
+  if (reason === "plugins-disabled") {
+    return "plugins disabled";
+  }
+  if (reason === "plugin-disabled") {
+    return "disabled in config";
+  }
+  if (reason === "not-in-allowlist") {
+    return "not in allowlist";
+  }
+  return undefined;
 }
 
 function formatReason(hit: ChannelPluginBlockerHit): string {

--- a/src/commands/doctor/shared/channel-plugin-blockers.ts
+++ b/src/commands/doctor/shared/channel-plugin-blockers.ts
@@ -28,6 +28,7 @@ export type ChannelPluginBlockerHit = {
   /** Effective activation reason preventing the plugin from loading. */
   reason:
     | "disabled in config"
+    | "blocked by denylist"
     | "plugins disabled"
     | "missing explicit enablement"
     | "not enabled"
@@ -51,7 +52,7 @@ export function scanConfiguredChannelPluginBlockers(
     env,
     includeDisabled: true,
   });
-  const manifestEnvOwners = listManifestEnvConfiguredChannelOwners(registry.plugins, env);
+  const manifestEnvTriggers = listManifestEnvConfiguredChannelTriggers(registry.plugins, env);
   const policyEntries = resolveConfiguredChannelPresencePolicy({
     config: cfg,
     activationSourceConfig,
@@ -64,7 +65,7 @@ export function scanConfiguredChannelPluginBlockers(
   const policyChannelIds = policyEntries
     .filter(
       (entry) =>
-        !manifestEnvOwners.has(entry.channelId) ||
+        !manifestEnvTriggers.has(entry.channelId) ||
         entry.sources.some((source) => source !== "env" && source !== "manifest-env"),
     )
     .map((entry) => entry.channelId);
@@ -75,24 +76,24 @@ export function scanConfiguredChannelPluginBlockers(
   for (const channelId of listExplicitlyDisabledChannelIdsForConfig(cfg)) {
     const normalizedChannelId = normalizeOptionalLowercaseString(channelId) ?? channelId;
     genericChannelIds.delete(normalizedChannelId);
-    manifestEnvOwners.delete(normalizedChannelId);
+    manifestEnvTriggers.delete(normalizedChannelId);
   }
-  if (genericChannelIds.size === 0 && manifestEnvOwners.size === 0) {
+  if (genericChannelIds.size === 0 && manifestEnvTriggers.size === 0) {
     return [];
   }
   const hits: ChannelPluginBlockerHit[] = [];
   const hitKeys = new Set<string>();
+  const globalDisableChannelIds = new Set<string>();
   const addHits = (channelId: string, ownerStates: ChannelOwnerState[]) => {
-    let reportedGlobalDisable = false;
     for (const state of ownerStates) {
       if (!state.reason) {
         continue;
       }
       if (state.reason === "plugins disabled") {
-        if (reportedGlobalDisable) {
+        if (globalDisableChannelIds.has(channelId)) {
           continue;
         }
-        reportedGlobalDisable = true;
+        globalDisableChannelIds.add(channelId);
       }
       const key = `${channelId}\0${state.pluginId}\0${state.reason}`;
       if (hitKeys.has(key)) {
@@ -129,32 +130,34 @@ export function scanConfiguredChannelPluginBlockers(
     addHits(channelId, ownerStates);
   }
 
-  for (const [channelId, pluginIds] of manifestEnvOwners) {
-    const owners = registry.plugins.filter((plugin) => pluginIds.has(plugin.id));
-    const ownerStates = owners.map((plugin) =>
-      resolveConfiguredChannelOwnerState({
-        plugin,
-        channelId,
-        sourceConfig: activationSourceConfig,
-        sourcePluginsConfig,
-        effectiveConfig: cfg,
-        effectivePluginsConfig,
-      }),
-    );
-    addHits(
-      channelId,
-      ownerStates.filter((state) => !state.available),
-    );
+  for (const [channelId, triggers] of manifestEnvTriggers) {
+    for (const pluginIds of triggers.values()) {
+      const owners = registry.plugins.filter((plugin) => pluginIds.has(plugin.id));
+      const ownerStates = owners.map((plugin) =>
+        resolveConfiguredChannelOwnerState({
+          plugin,
+          channelId,
+          sourceConfig: activationSourceConfig,
+          sourcePluginsConfig,
+          effectiveConfig: cfg,
+          effectivePluginsConfig,
+        }),
+      );
+      if (ownerStates.some((state) => state.available)) {
+        continue;
+      }
+      addHits(channelId, ownerStates);
+    }
   }
 
   return hits;
 }
 
-function listManifestEnvConfiguredChannelOwners(
+function listManifestEnvConfiguredChannelTriggers(
   plugins: readonly PluginManifestRecord[],
   env: NodeJS.ProcessEnv,
-): Map<string, Set<string>> {
-  const ownersByChannelId = new Map<string, Set<string>>();
+): Map<string, Map<string, Set<string>>> {
+  const triggersByChannelId = new Map<string, Map<string, Set<string>>>();
   for (const plugin of plugins) {
     const ownedChannelIds = new Set(
       plugin.channels
@@ -166,25 +169,30 @@ function listManifestEnvConfiguredChannelOwners(
       if (!channelId || !ownedChannelIds.has(channelId)) {
         continue;
       }
-      const configured = envVars.some((envVar) => {
+      for (const envVar of envVars) {
         if (!isSafeChannelEnvVarTriggerName(envVar)) {
-          return false;
+          continue;
         }
         const value = env[envVar] ?? env[envVar.toUpperCase()];
-        return typeof value === "string" && value.trim().length > 0;
-      });
-      if (!configured) {
-        continue;
+        if (typeof value !== "string" || value.trim().length === 0) {
+          continue;
+        }
+        let triggers = triggersByChannelId.get(channelId);
+        if (!triggers) {
+          triggers = new Map();
+          triggersByChannelId.set(channelId, triggers);
+        }
+        const trigger = envVar.trim().toUpperCase();
+        let ownerIds = triggers.get(trigger);
+        if (!ownerIds) {
+          ownerIds = new Set();
+          triggers.set(trigger, ownerIds);
+        }
+        ownerIds.add(plugin.id);
       }
-      let ownerIds = ownersByChannelId.get(channelId);
-      if (!ownerIds) {
-        ownerIds = new Set();
-        ownersByChannelId.set(channelId, ownerIds);
-      }
-      ownerIds.add(plugin.id);
     }
   }
-  return ownersByChannelId;
+  return triggersByChannelId;
 }
 
 type ChannelOwnerState = {
@@ -218,17 +226,12 @@ function resolveConfiguredChannelOwnerState(params: {
   });
   const sourceExternalTrusted =
     params.plugin.origin === "bundled" ||
-    (sourceBaseBlock === null &&
-      (params.plugin.origin === "workspace"
-        ? isActivatedManifestOwner({
-            plugin: params.plugin,
-            normalizedConfig: params.sourcePluginsConfig,
-            rootConfig: params.sourceConfig,
-          })
-        : hasExplicitManifestOwnerTrust({
-            plugin: params.plugin,
-            normalizedConfig: params.sourcePluginsConfig,
-          })));
+    hasExplicitManifestOwnerTrust({
+      plugin: params.plugin,
+      normalizedConfig: params.sourcePluginsConfig,
+    }) ||
+    (params.plugin.origin === "workspace" &&
+      params.sourcePluginsConfig.slots.contextEngine === params.plugin.id);
   const sourceBundledActivated =
     params.plugin.origin === "bundled" &&
     (bundledChannelConfigured ||
@@ -295,6 +298,9 @@ function mapManifestOwnerBlockerReason(
   if (reason === "plugin-disabled") {
     return "disabled in config";
   }
+  if (reason === "blocked-by-denylist") {
+    return "blocked by denylist";
+  }
   if (reason === "not-in-allowlist") {
     return "not in allowlist";
   }
@@ -304,6 +310,9 @@ function mapManifestOwnerBlockerReason(
 function formatReason(hit: ChannelPluginBlockerHit): string {
   if (hit.reason === "disabled in config") {
     return `plugin "${sanitizeForLog(hit.pluginId)}" is disabled by plugins.entries.${sanitizeForLog(hit.pluginId)}.enabled=false.`;
+  }
+  if (hit.reason === "blocked by denylist") {
+    return `plugin "${sanitizeForLog(hit.pluginId)}" is blocked by plugins.deny. Remove "${sanitizeForLog(hit.pluginId)}" from plugins.deny.`;
   }
   if (hit.reason === "plugins disabled") {
     return `plugins.enabled=false blocks channel plugins globally.`;

--- a/src/commands/doctor/shared/channel-plugin-blockers.ts
+++ b/src/commands/doctor/shared/channel-plugin-blockers.ts
@@ -29,6 +29,7 @@ export type ChannelPluginBlockerHit = {
 export function scanConfiguredChannelPluginBlockers(
   cfg: OpenClawConfig,
   env: NodeJS.ProcessEnv = process.env,
+  activationSourceConfig: OpenClawConfig = cfg,
 ): ChannelPluginBlockerHit[] {
   const configuredChannelIds = new Set(
     listExplicitConfiguredChannelIdsForConfig(cfg)
@@ -39,7 +40,7 @@ export function scanConfiguredChannelPluginBlockers(
     return [];
   }
 
-  const pluginsConfig = normalizePluginsConfig(cfg.plugins);
+  const pluginsConfig = normalizePluginsConfig(activationSourceConfig.plugins);
   const registry = loadPluginManifestRegistryForPluginRegistry({
     config: cfg,
     env,
@@ -47,6 +48,7 @@ export function scanConfiguredChannelPluginBlockers(
   });
   const presencePolicy = resolveConfiguredChannelPresencePolicy({
     config: cfg,
+    activationSourceConfig,
     env,
     includePersistedAuthState: false,
     manifestRecords: registry.plugins,
@@ -70,7 +72,7 @@ export function scanConfiguredChannelPluginBlockers(
       id: plugin.id,
       origin: plugin.origin,
       config: pluginsConfig,
-      rootConfig: cfg,
+      rootConfig: activationSourceConfig,
       enabledByDefault: plugin.enabledByDefault,
     });
     if (

--- a/src/commands/doctor/shared/channel-plugin-blockers.ts
+++ b/src/commands/doctor/shared/channel-plugin-blockers.ts
@@ -153,7 +153,7 @@ function formatReason(hit: ChannelPluginBlockerHit): string {
     return `external plugin "${sanitizeForLog(hit.pluginId)}" is installed without explicit trust. Add plugins.entries.${sanitizeForLog(hit.pluginId)}.enabled=true.`;
   }
   if (hit.reason === "not in allowlist") {
-    return `external plugin "${sanitizeForLog(hit.pluginId)}" is installed but omitted from plugins.allow. Include "${sanitizeForLog(hit.pluginId)}" in plugins.allow or remove the restrictive allowlist.`;
+    return `external plugin "${sanitizeForLog(hit.pluginId)}" is installed but omitted from plugins.allow. Include "${sanitizeForLog(hit.pluginId)}" in plugins.allow.`;
   }
   return `plugin "${sanitizeForLog(hit.pluginId)}" is not loadable (${sanitizeForLog(hit.reason)}).`;
 }

--- a/src/commands/doctor/shared/channel-plugin-blockers.ts
+++ b/src/commands/doctor/shared/channel-plugin-blockers.ts
@@ -18,36 +18,18 @@ export type ChannelPluginBlockerHit = {
   /** Plugin id that would provide the configured channel. */
   pluginId: string;
   /** Effective activation reason preventing the plugin from loading. */
-  reason: "disabled in config" | "plugins disabled";
+  reason:
+    | "disabled in config"
+    | "plugins disabled"
+    | "missing explicit enablement"
+    | "not in allowlist";
 };
 
-function hasExplicitChannelPluginBlockerConfig(cfg: OpenClawConfig): boolean {
-  if (cfg.plugins?.enabled === false) {
-    return true;
-  }
-  const entries = cfg.plugins?.entries;
-  if (!entries || typeof entries !== "object") {
-    return false;
-  }
-  return Object.values(entries).some((entry) => {
-    return (
-      entry &&
-      typeof entry === "object" &&
-      !Array.isArray(entry) &&
-      "enabled" in entry &&
-      (entry as { enabled?: unknown }).enabled === false
-    );
-  });
-}
-
-/** Find configured channel ids whose backing plugins are explicitly disabled. */
+/** Find configured channel ids whose backing plugins cannot activate. */
 export function scanConfiguredChannelPluginBlockers(
   cfg: OpenClawConfig,
   env: NodeJS.ProcessEnv = process.env,
 ): ChannelPluginBlockerHit[] {
-  if (!hasExplicitChannelPluginBlockerConfig(cfg)) {
-    return [];
-  }
   const configuredChannelIds = new Set(
     listExplicitConfiguredChannelIdsForConfig(cfg)
       .map((channelId) => normalizeOptionalLowercaseString(channelId))
@@ -63,15 +45,19 @@ export function scanConfiguredChannelPluginBlockers(
     env,
     includeDisabled: true,
   });
+  const presencePolicy = resolveConfiguredChannelPresencePolicy({
+    config: cfg,
+    env,
+    includePersistedAuthState: false,
+    manifestRecords: registry.plugins,
+  });
   const activeConfiguredChannelIds = new Set(
-    resolveConfiguredChannelPresencePolicy({
-      config: cfg,
-      env,
-      includePersistedAuthState: false,
-      manifestRecords: registry.plugins,
-    })
-      .filter((entry) => entry.effective)
-      .map((entry) => entry.channelId),
+    presencePolicy.filter((entry) => entry.effective).map((entry) => entry.channelId),
+  );
+  const blockedReasonsByChannelId = new Map(
+    presencePolicy
+      .filter((entry) => !entry.effective)
+      .map((entry) => [entry.channelId, new Set(entry.blockedReasons)] as const),
   );
   const hits: ChannelPluginBlockerHit[] = [];
 
@@ -115,6 +101,44 @@ export function scanConfiguredChannelPluginBlockers(
     }
   }
 
+  const channelsWithExplicitBlockerHits = new Set(hits.map((hit) => hit.channelId));
+
+  for (const plugin of registry.plugins) {
+    if (plugin.origin === "bundled" || plugin.channels.length === 0) {
+      continue;
+    }
+
+    for (const rawChannelId of plugin.channels) {
+      const channelId = normalizeOptionalLowercaseString(rawChannelId);
+      if (!channelId) {
+        continue;
+      }
+      if (!configuredChannelIds.has(channelId)) {
+        continue;
+      }
+      if (channelsWithExplicitBlockerHits.has(channelId)) {
+        continue;
+      }
+      if (activeConfiguredChannelIds.has(channelId)) {
+        continue;
+      }
+      const blockedReasons = blockedReasonsByChannelId.get(channelId);
+      const reason = blockedReasons?.has("untrusted-plugin")
+        ? "missing explicit enablement"
+        : blockedReasons?.has("not-in-allowlist")
+          ? "not in allowlist"
+          : undefined;
+      if (!reason) {
+        continue;
+      }
+      hits.push({
+        channelId,
+        pluginId: plugin.id,
+        reason,
+      });
+    }
+  }
+
   return hits;
 }
 
@@ -124,6 +148,12 @@ function formatReason(hit: ChannelPluginBlockerHit): string {
   }
   if (hit.reason === "plugins disabled") {
     return `plugins.enabled=false blocks channel plugins globally.`;
+  }
+  if (hit.reason === "missing explicit enablement") {
+    return `external plugin "${sanitizeForLog(hit.pluginId)}" is installed without explicit trust. Add plugins.entries.${sanitizeForLog(hit.pluginId)}.enabled=true.`;
+  }
+  if (hit.reason === "not in allowlist") {
+    return `external plugin "${sanitizeForLog(hit.pluginId)}" is installed but omitted from plugins.allow. Include "${sanitizeForLog(hit.pluginId)}" in plugins.allow or remove the restrictive allowlist.`;
   }
   return `plugin "${sanitizeForLog(hit.pluginId)}" is not loadable (${sanitizeForLog(hit.reason)}).`;
 }

--- a/src/commands/doctor/shared/preview-warnings.test.ts
+++ b/src/commands/doctor/shared/preview-warnings.test.ts
@@ -117,7 +117,7 @@ vi.mock("./channel-plugin-blockers.js", () => ({
     if (Object.keys(env).some((key) => key.startsWith("DISCORD_"))) {
       configuredChannels.add("discord");
     }
-    return manifestState.plugins.flatMap((plugin) => {
+    const hits = manifestState.plugins.flatMap((plugin) => {
       const sourcePlugins = activationSourceConfig.plugins;
       const disabledByEntry = sourcePlugins?.entries?.[plugin.id]?.enabled === false;
       const pluginsDisabled = sourcePlugins?.enabled === false;
@@ -147,6 +147,17 @@ vi.mock("./channel-plugin-blockers.js", () => ({
                 : "missing explicit enablement",
         }));
     });
+    const blockedPluginIds = new Set(hits.map((hit) => hit.pluginId));
+    const availableChannelIds = new Set(
+      manifestState.plugins
+        .filter((plugin) => !blockedPluginIds.has(plugin.id))
+        .flatMap((plugin) =>
+          plugin.channels.filter((channelId) => configuredChannels.has(channelId)),
+        ),
+    );
+    return hits.map((hit) =>
+      availableChannelIds.has(hit.channelId) ? { ...hit, channelAvailable: true } : hit,
+    );
   },
   collectConfiguredChannelPluginBlockerWarnings: (
     hits: Array<{ channelId: string; pluginId: string; reason: string }>,
@@ -162,11 +173,15 @@ vi.mock("./channel-plugin-blockers.js", () => ({
               : `external plugin "${hit.pluginId}" is installed without explicit trust. Add plugins.entries.${hit.pluginId}.enabled=true.`;
       return `- channels.${hit.channelId}: channel is configured, but ${reason}`;
     }),
-  isWarningBlockedByChannelPlugin: (warning: string, hits: Array<{ channelId: string }>) =>
+  isWarningBlockedByChannelPlugin: (
+    warning: string,
+    hits: Array<{ channelId: string; channelAvailable?: boolean }>,
+  ) =>
     hits.some(
       (hit) =>
-        warning.includes(`channels.${hit.channelId}:`) ||
-        warning.includes(`channels.${hit.channelId}.`),
+        !hit.channelAvailable &&
+        (warning.includes(`channels.${hit.channelId}:`) ||
+          warning.includes(`channels.${hit.channelId}.`)),
     ),
 }));
 
@@ -643,6 +658,29 @@ describe("doctor preview warnings", () => {
     expect(warning).toContain("plugins.entries.discord.enabled=true");
     expect(warning).not.toContain("plugins.allow");
     expect(warning).not.toContain("first-time setup mode");
+  });
+
+  it("preserves empty-allowlist warnings when a blocked plugin has an active co-owner", async () => {
+    manifestState.plugins = [
+      channelManifest("bundled-chat", "shared-chat"),
+      externalChannelManifest("external-chat", "shared-chat"),
+    ];
+
+    const warnings = await collectDoctorPreviewWarnings({
+      cfg: {
+        channels: {
+          "shared-chat": {
+            groupPolicy: "allowlist",
+          },
+        },
+      },
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    expect(warnings.join("\n")).toContain(
+      'channels.shared-chat: channel is configured, but external plugin "external-chat" is installed without explicit trust.',
+    );
+    expect(warnings.join("\n")).toContain("channels.shared-chat.groupPolicy");
   });
 
   it("warns for an external-only manifest env channel whose effective owner lacks source trust", async () => {

--- a/src/commands/doctor/shared/preview-warnings.test.ts
+++ b/src/commands/doctor/shared/preview-warnings.test.ts
@@ -98,27 +98,38 @@ vi.mock("./channel-doctor.js", () => ({
 }));
 
 vi.mock("./channel-plugin-blockers.js", () => ({
-  scanConfiguredChannelPluginBlockers: (cfg: {
-    channels?: Record<string, unknown>;
-    plugins?: {
-      allow?: string[];
-      enabled?: boolean;
-      entries?: Record<string, { enabled?: boolean }>;
-    };
-  }) => {
+  scanConfiguredChannelPluginBlockers: (
+    cfg: {
+      channels?: Record<string, unknown>;
+      plugins?: {
+        allow?: string[];
+        enabled?: boolean;
+        entries?: Record<string, { enabled?: boolean }>;
+      };
+    },
+    env: NodeJS.ProcessEnv = process.env,
+    activationSourceConfig = cfg,
+  ) => {
     const configuredChannels = new Set(Object.keys(cfg.channels ?? {}));
+    if (Object.keys(env).some((key) => key.startsWith("TELEGRAM_"))) {
+      configuredChannels.add("telegram");
+    }
+    if (Object.keys(env).some((key) => key.startsWith("DISCORD_"))) {
+      configuredChannels.add("discord");
+    }
     return manifestState.plugins.flatMap((plugin) => {
-      const disabledByEntry = cfg.plugins?.entries?.[plugin.id]?.enabled === false;
-      const pluginsDisabled = cfg.plugins?.enabled === false;
+      const sourcePlugins = activationSourceConfig.plugins;
+      const disabledByEntry = sourcePlugins?.entries?.[plugin.id]?.enabled === false;
+      const pluginsDisabled = sourcePlugins?.enabled === false;
       const isExternal = plugin.origin === "global";
       const omittedFromAllowlist =
         isExternal &&
-        (cfg.plugins?.allow ?? []).length > 0 &&
-        !(cfg.plugins?.allow ?? []).includes(plugin.id);
+        (sourcePlugins?.allow ?? []).length > 0 &&
+        !(sourcePlugins?.allow ?? []).includes(plugin.id);
       const missingExplicitTrust =
         isExternal &&
-        cfg.plugins?.entries?.[plugin.id]?.enabled !== true &&
-        !(cfg.plugins?.allow ?? []).includes(plugin.id);
+        sourcePlugins?.entries?.[plugin.id]?.enabled !== true &&
+        !(sourcePlugins?.allow ?? []).includes(plugin.id);
       if (!disabledByEntry && !pluginsDisabled && !omittedFromAllowlist && !missingExplicitTrust) {
         return [];
       }
@@ -632,6 +643,33 @@ describe("doctor preview warnings", () => {
     expect(warning).toContain("plugins.entries.discord.enabled=true");
     expect(warning).not.toContain("plugins.allow");
     expect(warning).not.toContain("first-time setup mode");
+  });
+
+  it("warns for an external-only manifest env channel whose effective owner lacks source trust", async () => {
+    manifestState.plugins = [externalChannelManifest("discord", "discord")];
+
+    const notes = await collectDoctorPreviewNotes({
+      cfg: {
+        plugins: {
+          entries: {
+            discord: {
+              enabled: true,
+            },
+          },
+        },
+      },
+      activationSourceConfig: {},
+      doctorFixCommand: "openclaw doctor --fix",
+      env: {
+        DISCORD_BOT_TOKEN: "configured",
+      } as NodeJS.ProcessEnv,
+    });
+
+    const warning = expectSingleWarningContaining(
+      notes.warningNotes,
+      'channels.discord: channel is configured, but external plugin "discord" is installed without explicit trust.',
+    );
+    expect(warning).toContain("plugins.entries.discord.enabled=true");
   });
 
   it("warns when a configured external channel plugin is omitted from plugins.allow", async () => {

--- a/src/commands/doctor/shared/preview-warnings.test.ts
+++ b/src/commands/doctor/shared/preview-warnings.test.ts
@@ -147,7 +147,7 @@ vi.mock("./channel-plugin-blockers.js", () => ({
           : hit.reason === "plugins disabled"
             ? "plugins.enabled=false blocks channel plugins globally."
             : hit.reason === "not in allowlist"
-              ? `external plugin "${hit.pluginId}" is installed but omitted from plugins.allow. Include "${hit.pluginId}" in plugins.allow or remove the restrictive allowlist.`
+              ? `external plugin "${hit.pluginId}" is installed but omitted from plugins.allow. Include "${hit.pluginId}" in plugins.allow.`
               : `external plugin "${hit.pluginId}" is installed without explicit trust. Add plugins.entries.${hit.pluginId}.enabled=true.`;
       return `- channels.${hit.channelId}: channel is configured, but ${reason}`;
     }),

--- a/src/commands/doctor/shared/preview-warnings.test.ts
+++ b/src/commands/doctor/shared/preview-warnings.test.ts
@@ -117,7 +117,12 @@ vi.mock("./channel-plugin-blockers.js", () => ({
     if (Object.keys(env).some((key) => key.startsWith("DISCORD_"))) {
       configuredChannels.add("discord");
     }
-    const hits = manifestState.plugins.flatMap((plugin) => {
+    const hits: Array<{
+      channelId: string;
+      pluginId: string;
+      reason: string;
+      channelAvailable?: boolean;
+    }> = manifestState.plugins.flatMap((plugin) => {
       const sourcePlugins = activationSourceConfig.plugins;
       const disabledByEntry = sourcePlugins?.entries?.[plugin.id]?.enabled === false;
       const pluginsDisabled = sourcePlugins?.enabled === false;
@@ -155,9 +160,12 @@ vi.mock("./channel-plugin-blockers.js", () => ({
           plugin.channels.filter((channelId) => configuredChannels.has(channelId)),
         ),
     );
-    return hits.map((hit) =>
-      availableChannelIds.has(hit.channelId) ? { ...hit, channelAvailable: true } : hit,
-    );
+    for (const hit of hits) {
+      if (availableChannelIds.has(hit.channelId)) {
+        hit.channelAvailable = true;
+      }
+    }
+    return hits;
   },
   collectConfiguredChannelPluginBlockerWarnings: (
     hits: Array<{ channelId: string; pluginId: string; reason: string }>,

--- a/src/commands/doctor/shared/preview-warnings.test.ts
+++ b/src/commands/doctor/shared/preview-warnings.test.ts
@@ -15,6 +15,7 @@ import {
 type TestManifestRecord = {
   id: string;
   channels: string[];
+  origin?: "bundled" | "global";
 };
 
 const manifestState = vi.hoisted(
@@ -99,13 +100,26 @@ vi.mock("./channel-doctor.js", () => ({
 vi.mock("./channel-plugin-blockers.js", () => ({
   scanConfiguredChannelPluginBlockers: (cfg: {
     channels?: Record<string, unknown>;
-    plugins?: { enabled?: boolean; entries?: Record<string, { enabled?: boolean }> };
+    plugins?: {
+      allow?: string[];
+      enabled?: boolean;
+      entries?: Record<string, { enabled?: boolean }>;
+    };
   }) => {
     const configuredChannels = new Set(Object.keys(cfg.channels ?? {}));
     return manifestState.plugins.flatMap((plugin) => {
       const disabledByEntry = cfg.plugins?.entries?.[plugin.id]?.enabled === false;
       const pluginsDisabled = cfg.plugins?.enabled === false;
-      if (!disabledByEntry && !pluginsDisabled) {
+      const isExternal = plugin.origin === "global";
+      const omittedFromAllowlist =
+        isExternal &&
+        (cfg.plugins?.allow ?? []).length > 0 &&
+        !(cfg.plugins?.allow ?? []).includes(plugin.id);
+      const missingExplicitTrust =
+        isExternal &&
+        cfg.plugins?.entries?.[plugin.id]?.enabled !== true &&
+        !(cfg.plugins?.allow ?? []).includes(plugin.id);
+      if (!disabledByEntry && !pluginsDisabled && !omittedFromAllowlist && !missingExplicitTrust) {
         return [];
       }
       return plugin.channels
@@ -113,7 +127,13 @@ vi.mock("./channel-plugin-blockers.js", () => ({
         .map((channelId) => ({
           channelId,
           pluginId: plugin.id,
-          reason: disabledByEntry ? "disabled in config" : "plugins disabled",
+          reason: disabledByEntry
+            ? "disabled in config"
+            : pluginsDisabled
+              ? "plugins disabled"
+              : omittedFromAllowlist
+                ? "not in allowlist"
+                : "missing explicit enablement",
         }));
     });
   },
@@ -124,7 +144,11 @@ vi.mock("./channel-plugin-blockers.js", () => ({
       const reason =
         hit.reason === "disabled in config"
           ? `plugin "${hit.pluginId}" is disabled by plugins.entries.${hit.pluginId}.enabled=false.`
-          : "plugins.enabled=false blocks channel plugins globally.";
+          : hit.reason === "plugins disabled"
+            ? "plugins.enabled=false blocks channel plugins globally."
+            : hit.reason === "not in allowlist"
+              ? `external plugin "${hit.pluginId}" is installed but omitted from plugins.allow. Include "${hit.pluginId}" in plugins.allow or remove the restrictive allowlist.`
+              : `external plugin "${hit.pluginId}" is installed without explicit trust. Add plugins.entries.${hit.pluginId}.enabled=true.`;
       return `- channels.${hit.channelId}: channel is configured, but ${reason}`;
     }),
   isWarningBlockedByChannelPlugin: (warning: string, hits: Array<{ channelId: string }>) =>
@@ -213,6 +237,13 @@ function channelManifest(id: string, channelId: string): TestManifestRecord {
   return {
     ...manifest(id),
     channels: [channelId],
+  };
+}
+
+function externalChannelManifest(id: string, channelId: string): TestManifestRecord {
+  return {
+    ...channelManifest(id, channelId),
+    origin: "global",
   };
 }
 
@@ -572,6 +603,67 @@ describe("doctor preview warnings", () => {
       warnings,
       'channels.telegram: channel is configured, but plugin "telegram" is disabled by plugins.entries.telegram.enabled=false.',
     );
+    expect(warning).not.toContain("first-time setup mode");
+  });
+
+  it("warns when a configured external channel plugin lacks explicit trust", async () => {
+    manifestState.plugins = [externalChannelManifest("discord", "discord")];
+
+    const warnings = await collectDoctorPreviewWarnings({
+      cfg: {
+        channels: {
+          discord: {
+            enabled: true,
+            token: {
+              source: "env",
+              provider: "default",
+              id: "DISCORD_BOT_TOKEN",
+            },
+          },
+        },
+      },
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    const warning = expectSingleWarningContaining(
+      warnings,
+      'channels.discord: channel is configured, but external plugin "discord" is installed without explicit trust.',
+    );
+    expect(warning).toContain("plugins.entries.discord.enabled=true");
+    expect(warning).not.toContain("plugins.allow");
+    expect(warning).not.toContain("first-time setup mode");
+  });
+
+  it("warns when a configured external channel plugin is omitted from plugins.allow", async () => {
+    manifestState.plugins = [
+      externalChannelManifest("discord", "discord"),
+      channelManifest("brave", "brave"),
+    ];
+
+    const warnings = await collectDoctorPreviewWarnings({
+      cfg: {
+        plugins: {
+          allow: ["brave"],
+        },
+        channels: {
+          discord: {
+            enabled: true,
+            token: {
+              source: "env",
+              provider: "default",
+              id: "DISCORD_BOT_TOKEN",
+            },
+          },
+        },
+      },
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    const warning = expectSingleWarningContaining(
+      warnings,
+      'channels.discord: channel is configured, but external plugin "discord" is installed but omitted from plugins.allow.',
+    );
+    expect(warning).toContain('Include "discord" in plugins.allow');
     expect(warning).not.toContain("first-time setup mode");
   });
 

--- a/src/commands/doctor/shared/preview-warnings.ts
+++ b/src/commands/doctor/shared/preview-warnings.ts
@@ -801,16 +801,13 @@ export async function collectDoctorPreviewNotes(params: {
     await import("./active-tool-schema-warnings.js");
   warnings.push(...collectActiveToolSchemaProjectionWarnings({ cfg: params.cfg, env }));
 
-  const channelPluginRuntime = hasChannelConfig
-    ? await import("./channel-plugin-blockers.js")
-    : undefined;
-  const channelPluginBlockerHits =
-    channelPluginRuntime?.scanConfiguredChannelPluginBlockers(
-      params.cfg,
-      env,
-      params.activationSourceConfig,
-    ) ?? [];
-  if (channelPluginRuntime && channelPluginBlockerHits.length > 0) {
+  const channelPluginRuntime = await import("./channel-plugin-blockers.js");
+  const channelPluginBlockerHits = channelPluginRuntime.scanConfiguredChannelPluginBlockers(
+    params.cfg,
+    env,
+    params.activationSourceConfig,
+  );
+  if (channelPluginBlockerHits.length > 0) {
     warnings.push(
       channelPluginRuntime
         .collectConfiguredChannelPluginBlockerWarnings(channelPluginBlockerHits)
@@ -924,12 +921,7 @@ export async function collectDoctorPreviewNotes(params: {
         emptyAllowlistHooks.shouldSkipDefaultEmptyGroupAllowlistWarning,
     }).filter(
       (warning) =>
-        !(
-          channelPluginRuntime?.isWarningBlockedByChannelPlugin(
-            warning,
-            channelPluginBlockerHits,
-          ) ?? false
-        ),
+        !channelPluginRuntime.isWarningBlockedByChannelPlugin(warning, channelPluginBlockerHits),
     );
     if (emptyAllowlistWarnings.length > 0) {
       const { sanitizeForLog } = await import("../../../../packages/terminal-core/src/ansi.js");

--- a/src/commands/doctor/shared/preview-warnings.ts
+++ b/src/commands/doctor/shared/preview-warnings.ts
@@ -779,6 +779,7 @@ async function resolveDoctorChannelPreviewConfig(params: {
 /** Collect info and warning notes for doctor preview mode. */
 export async function collectDoctorPreviewNotes(params: {
   cfg: OpenClawConfig;
+  activationSourceConfig?: OpenClawConfig;
   doctorFixCommand: string;
   env?: NodeJS.ProcessEnv;
   allowExec?: boolean;
@@ -804,7 +805,11 @@ export async function collectDoctorPreviewNotes(params: {
     ? await import("./channel-plugin-blockers.js")
     : undefined;
   const channelPluginBlockerHits =
-    channelPluginRuntime?.scanConfiguredChannelPluginBlockers(params.cfg, env) ?? [];
+    channelPluginRuntime?.scanConfiguredChannelPluginBlockers(
+      params.cfg,
+      env,
+      params.activationSourceConfig,
+    ) ?? [];
   if (channelPluginRuntime && channelPluginBlockerHits.length > 0) {
     warnings.push(
       channelPluginRuntime

--- a/src/commands/doctor/shared/preview-warnings.ts
+++ b/src/commands/doctor/shared/preview-warnings.ts
@@ -58,19 +58,6 @@ function hasSubagentAllowlistConfig(cfg: OpenClawConfig): boolean {
   });
 }
 
-function hasExplicitChannelPluginBlockerConfig(cfg: OpenClawConfig): boolean {
-  if (cfg.plugins?.enabled === false) {
-    return true;
-  }
-  const entries = cfg.plugins?.entries;
-  if (!hasRecord(entries)) {
-    return false;
-  }
-  return Object.values(entries).some(
-    (entry) => hasRecord(entry) && "enabled" in entry && entry.enabled === false,
-  );
-}
-
 function hasToolsBySenderKey(value: unknown): boolean {
   if (Array.isArray(value)) {
     return value.some(hasToolsBySenderKey);
@@ -813,10 +800,9 @@ export async function collectDoctorPreviewNotes(params: {
     await import("./active-tool-schema-warnings.js");
   warnings.push(...collectActiveToolSchemaProjectionWarnings({ cfg: params.cfg, env }));
 
-  const channelPluginRuntime =
-    hasChannelConfig && hasExplicitChannelPluginBlockerConfig(params.cfg)
-      ? await import("./channel-plugin-blockers.js")
-      : undefined;
+  const channelPluginRuntime = hasChannelConfig
+    ? await import("./channel-plugin-blockers.js")
+    : undefined;
   const channelPluginBlockerHits =
     channelPluginRuntime?.scanConfiguredChannelPluginBlockers(params.cfg, env) ?? [];
   if (channelPluginRuntime && channelPluginBlockerHits.length > 0) {


### PR DESCRIPTION
## Summary

- Diagnose configured channel plugins blocked by missing explicit trust, restrictive allowlists, denylist entries, global plugin disablement, or missing bundled opt-in enablement.
- Preserve source-authored trust across doctor auto-enable materialization and keep multi-owner fallback semantics aligned with runtime activation.
- Scope manifest environment triggers to their declaring owners while preserving channel-wide safety warnings when another owner remains active.

Closes #83212

## Real behavior proof

Behavior addressed: `openclaw doctor` now gives actionable plugin trust/policy remediation instead of misleading first-time setup guidance when an installed external Discord owner cannot activate.
Real environment tested: Local OpenClaw checkout on Node 24 with an isolated state/config directory and an external Discord plugin copy loaded through `plugins.load.paths`.
Exact steps or command run after this patch: Run `pnpm openclaw doctor` twice with isolated configs: one configured Discord plugin missing explicit trust, and one omitted from a restrictive `plugins.allow`; assert the expected warning/remediation text and absence of first-time setup guidance.
Evidence after fix: Missing-trust output contained `installed without explicit trust` and `plugins.entries.discord.enabled=true`; restrictive-allowlist output contained `omitted from plugins.allow` and the add-to-allowlist instruction, with no allowlist-removal advice.

```text
◇ Doctor warnings
- channels.discord: channel is configured, but external plugin
  "discord" is installed without explicit trust. Add
  plugins.entries.discord.enabled=true.

MISSING_TRUST_ASSERTIONS=warning,entry_hint,no_first_time_setup

◇ Doctor warnings
- channels.discord: channel is configured, but plugin "discord" is
  installed but omitted from plugins.allow. Include "discord" in
  plugins.allow.

ALLOWLIST_ASSERTIONS=warning,allow_hint,no_allowlist_removal,no_first_time_setup
```

Observed result after fix: Both isolated doctor runs exited successfully and emitted the narrow remediation for the actual activation blocker.
What was not tested: A live Discord network connection or token-authenticated gateway startup; this PR changes doctor diagnostics and activation-policy interpretation only.

## Verification

- `pnpm test src/commands/doctor-config-flow.test.ts src/commands/doctor/shared/channel-plugin-blockers.test.ts src/commands/doctor/shared/preview-warnings.test.ts src/plugins/channel-plugin-ids.test.ts src/plugins/manifest-owner-policy.test.ts` (261 tests across 4 shards)
- `pnpm exec oxlint --config .oxlintrc.json src/commands/doctor/shared/preview-warnings.test.ts`
- `git diff --check`
- Autoreview rerun after each accepted finding; final review clean.
- Crabbox/Testbox changed gate: `run_69ba64d2f7ab` (passed) — https://crabbox.openclaw.ai/portal/runs/run_69ba64d2f7ab

## Risk

The change does not auto-trust or auto-enable external plugins. It only explains activation blockers and suppresses secondary setup warnings when the channel truly has no available owner.
