### PR TITLE
refactor: share realtime forced consult coordination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Voice: expose shared realtime consult question matching, speakable-result extraction, and forced-consult coordination through the realtime voice SDK, then reuse it in Gateway Talk, Voice Call, and Discord voice paths.
 - Voice: share activation-name matching and consult-transcript screening through the realtime voice SDK so Discord, browser voice, and meeting surfaces can reuse one implementation.
 - Cron: default `cron.maxConcurrentRuns` to 8 so scheduled automations and their isolated agent turns can make progress in parallel without explicit configuration.
 - QA-Lab: add `qa coverage --match <query>` so focused proof selection can discover matching scenarios from existing metadata before running live or remote lanes.

--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -626,7 +626,7 @@ releases.
   | `plugin-sdk/speech` | Speech helpers | Speech provider types plus provider-facing directive, registry, validation helpers, and OpenAI-compatible TTS builder |
   | `plugin-sdk/speech-core` | Shared speech core | Speech provider types, registry, directives, normalization |
   | `plugin-sdk/realtime-transcription` | Realtime transcription helpers | Provider types, registry helpers, and shared WebSocket session helper |
-  | `plugin-sdk/realtime-voice` | Realtime voice helpers | Provider types, registry/resolution helpers, bridge session helpers, shared agent talk-back queues, active-run voice control, transcript/event health, echo suppression, and fast context consult helpers |
+  | `plugin-sdk/realtime-voice` | Realtime voice helpers | Provider types, registry/resolution helpers, bridge session helpers, shared agent talk-back queues, active-run voice control, transcript/event health, echo suppression, consult question matching, forced-consult coordination, and fast context consult helpers |
   | `plugin-sdk/image-generation` | Image-generation helpers | Image generation provider types plus image asset/data URL helpers and the OpenAI-compatible image provider builder |
   | `plugin-sdk/image-generation-core` | Shared image-generation core | Image-generation types, failover, auth, and registry helpers |
   | `plugin-sdk/music-generation` | Music-generation helpers | Music-generation provider/request/result types |

--- a/extensions/discord/src/voice/realtime.ts
+++ b/extensions/discord/src/voice/realtime.ts
@@ -8,6 +8,7 @@ import {
   createRealtimeVoiceAgentTalkbackQueue,
   createRealtimeVoiceBridgeSession,
   matchRealtimeVoiceActivationName,
+  matchRealtimeVoiceConsultQuestions,
   normalizeSupportedRealtimeVoiceActivationName,
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
   REALTIME_VOICE_AGENT_CONTROL_TOOL,
@@ -308,10 +309,6 @@ function extractDiscordExactSpeechConsultText(args: unknown): string | undefined
   );
 }
 
-function normalizeRealtimeConsultMatchText(text: string): string {
-  return text.toLowerCase().replace(/\s+/g, " ").trim();
-}
-
 function normalizeControlSpeechText(text: string): string {
   return text.toLowerCase().replace(/\s+/g, " ").trim();
 }
@@ -354,14 +351,7 @@ function resolveDiscordRealtimeWakeNames(params: {
 }
 
 function matchesPendingAgentProxyQuestion(consultMessage: string, question: string): boolean {
-  const normalizedConsult = normalizeRealtimeConsultMatchText(consultMessage);
-  const normalizedQuestion = normalizeRealtimeConsultMatchText(question);
-  if (!normalizedConsult || !normalizedQuestion) {
-    return false;
-  }
-  return (
-    normalizedConsult.includes(normalizedQuestion) || normalizedQuestion.includes(normalizedConsult)
-  );
+  return matchRealtimeVoiceConsultQuestions(consultMessage, question);
 }
 
 export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -5,10 +5,15 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   buildRealtimeVoiceAgentConsultWorkingResponse,
+  createRealtimeVoiceForcedConsultCoordinator,
   createTalkSessionController,
   createRealtimeVoiceBridgeSession,
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
+  readRealtimeVoiceConsultQuestion,
+  readSpeakableRealtimeVoiceToolResult,
   recordTalkObservabilityEvent,
+  type RealtimeVoiceForcedConsultCoordinator,
+  type RealtimeVoiceForcedConsultHandle,
   type RealtimeVoiceBridgeSession,
   type RealtimeVoiceProviderConfig,
   type RealtimeVoiceProviderPlugin,
@@ -81,21 +86,6 @@ function buildGreetingInstructions(
     : `${intro} "${trimmedGreeting}"`;
 }
 
-function readSpeakableToolResultText(result: unknown): string | undefined {
-  if (typeof result === "string") {
-    return result.trim() || undefined;
-  }
-  if (!result || typeof result !== "object" || Array.isArray(result)) {
-    return undefined;
-  }
-  const text = (result as { text?: unknown }).text;
-  if (typeof text === "string" && text.trim()) {
-    return text.trim();
-  }
-  const output = (result as { output?: unknown }).output;
-  return typeof output === "string" && output.trim() ? output.trim() : undefined;
-}
-
 function readConsultArgText(args: unknown, key: string): string | undefined {
   if (!args || typeof args !== "object" || Array.isArray(args)) {
     return undefined;
@@ -105,12 +95,7 @@ function readConsultArgText(args: unknown, key: string): string | undefined {
 }
 
 function readConsultQuestionText(args: unknown): string | undefined {
-  return (
-    readConsultArgText(args, "question") ??
-    readConsultArgText(args, "prompt") ??
-    readConsultArgText(args, "query") ??
-    readConsultArgText(args, "task")
-  );
+  return readRealtimeVoiceConsultQuestion(args);
 }
 
 function normalizeTranscriptText(text: string): string {
@@ -315,10 +300,11 @@ export class RealtimeCallHandler {
     string,
     ReturnType<typeof setTimeout>
   >();
-  private readonly forcedConsultTimersByCallId = new Map<string, ReturnType<typeof setTimeout>>();
-  private readonly forcedConsultInFlightByCallId = new Set<string>();
+  private readonly forcedConsultCoordinatorsByCallId = new Map<
+    string,
+    RealtimeVoiceForcedConsultCoordinator
+  >();
   private readonly forcedConsultsByCallId = new Map<string, ForcedConsultState>();
-  private readonly lastProviderConsultAtByCallId = new Map<string, number>();
   private readonly nativeConsultsInFlightByCallId = new Map<string, NativeConsultState>();
   private publicOrigin: string | null = null;
   private publicPathPrefix = "";
@@ -1012,14 +998,19 @@ export class RealtimeCallHandler {
   }
 
   private clearForcedConsultState(callId: string): void {
-    const timer = this.forcedConsultTimersByCallId.get(callId);
-    if (timer) {
-      clearTimeout(timer);
-      this.forcedConsultTimersByCallId.delete(callId);
-    }
-    this.forcedConsultInFlightByCallId.delete(callId);
+    this.forcedConsultCoordinatorsByCallId.get(callId)?.clear();
+    this.forcedConsultCoordinatorsByCallId.delete(callId);
     this.forcedConsultsByCallId.delete(callId);
-    this.lastProviderConsultAtByCallId.delete(callId);
+  }
+
+  private forcedConsultCoordinator(callId: string): RealtimeVoiceForcedConsultCoordinator {
+    const existing = this.forcedConsultCoordinatorsByCallId.get(callId);
+    if (existing) {
+      return existing;
+    }
+    const created = createRealtimeVoiceForcedConsultCoordinator();
+    this.forcedConsultCoordinatorsByCallId.set(callId, created);
+    return created;
   }
 
   private closeTelephonyBridge(
@@ -1053,43 +1044,48 @@ export class RealtimeCallHandler {
     if (!handler) {
       return;
     }
-    const existingTimer = this.forcedConsultTimersByCallId.get(params.callId);
-    if (existingTimer) {
-      clearTimeout(existingTimer);
+    const existingForcedConsult = this.forcedConsultsByCallId.get(params.callId);
+    if (existingForcedConsult && !existingForcedConsult.completedAt) {
+      return;
     }
-    const timer = setTimeout(() => {
-      this.forcedConsultTimersByCallId.delete(params.callId);
-      if (this.forcedConsultInFlightByCallId.has(params.callId)) {
-        return;
-      }
-      const lastProviderConsultAt = this.lastProviderConsultAtByCallId.get(params.callId) ?? 0;
-      if (Date.now() - lastProviderConsultAt < 2_000) {
+    const coordinator = this.forcedConsultCoordinator(params.callId);
+    if (coordinator.hasRecentNativeConsult(question, { allowUnknownQuestion: true })) {
+      return;
+    }
+    coordinator.clearPending();
+    const pending = coordinator.prepare(question);
+    if (!pending) {
+      return;
+    }
+    coordinator.schedule(pending, FORCED_CONSULT_FALLBACK_DELAY_MS, (handle) => {
+      const activeForcedConsult = this.forcedConsultsByCallId.get(params.callId);
+      if (activeForcedConsult && !activeForcedConsult.completedAt) {
         return;
       }
       void this.runForcedAgentConsult({
         ...params,
-        question,
+        handle,
         handler,
       });
-    }, FORCED_CONSULT_FALLBACK_DELAY_MS);
-    this.forcedConsultTimersByCallId.set(params.callId, timer);
+    });
   }
 
   private async runForcedAgentConsult(params: {
     session: ActiveRealtimeVoiceBridge;
     callId: string;
     callSid: string;
-    question: string;
+    handle: RealtimeVoiceForcedConsultHandle;
     clearAudio: () => void;
     handler: ToolHandlerFn;
   }): Promise<void> {
-    this.forcedConsultInFlightByCallId.add(params.callId);
+    const coordinator = this.forcedConsultCoordinator(params.callId);
+    coordinator.markStarted(params.handle);
     const startedAt = Date.now();
     logger.debug(
-      `[voice-call] realtime forced agent consult reason=${FORCED_CONSULT_REASON} consultPolicy=always callId=${params.callId} providerCallId=${params.callSid} chars=${params.question.length}`,
+      `[voice-call] realtime forced agent consult reason=${FORCED_CONSULT_REASON} consultPolicy=always callId=${params.callId} providerCallId=${params.callSid} chars=${params.handle.question.length}`,
     );
     console.log(
-      `[voice-call] realtime forced agent consult starting callId=${params.callId} providerCallId=${params.callSid} chars=${params.question.length}`,
+      `[voice-call] realtime forced agent consult starting callId=${params.callId} providerCallId=${params.callSid} chars=${params.handle.question.length}`,
     );
     params.clearAudio();
     const state: ForcedConsultState = {
@@ -1097,7 +1093,7 @@ export class RealtimeCallHandler {
       promise: Promise.resolve().then(() =>
         params.handler(
           {
-            question: params.question,
+            question: params.handle.question,
           },
           params.callId,
           {},
@@ -1108,7 +1104,11 @@ export class RealtimeCallHandler {
     try {
       const result = await state.promise;
       state.completedAt = Date.now();
-      const text = readSpeakableToolResultText(result);
+      coordinator.markDelivered(params.handle);
+      const text = readSpeakableRealtimeVoiceToolResult(result, {
+        keys: ["text", "output"],
+        maxChars: FORCED_CONSULT_RESULT_MAX_CHARS,
+      });
       if (!text) {
         console.warn(
           `[voice-call] realtime forced agent consult returned no speakable text callId=${params.callId} providerCallId=${params.callSid}`,
@@ -1122,16 +1122,16 @@ export class RealtimeCallHandler {
       console.log(
         `[voice-call] realtime forced agent consult completed callId=${params.callId} providerCallId=${params.callSid} elapsedMs=${Date.now() - startedAt}`,
       );
-      this.consumePartialUserTranscript(params.callId, params.question);
+      this.consumePartialUserTranscript(params.callId, params.handle.question);
     } catch (error) {
       console.warn(
         `[voice-call] realtime forced agent consult failed callId=${params.callId} providerCallId=${params.callSid} error=${formatErrorMessage(error)}`,
       );
     } finally {
-      this.forcedConsultInFlightByCallId.delete(params.callId);
       const cleanupTimer = setTimeout(() => {
         if (this.forcedConsultsByCallId.get(params.callId) === state) {
           this.forcedConsultsByCallId.delete(params.callId);
+          coordinator.remove(params.handle);
         }
       }, FORCED_CONSULT_NATIVE_DEDUPE_MS);
       cleanupTimer.unref?.();
@@ -1273,15 +1273,17 @@ export class RealtimeCallHandler {
       }
     };
     if (name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME) {
-      this.lastProviderConsultAtByCallId.set(callId, Date.now());
-      const timer = this.forcedConsultTimersByCallId.get(callId);
-      if (timer) {
-        clearTimeout(timer);
-        this.forcedConsultTimersByCallId.delete(callId);
+      const coordinator = this.forcedConsultCoordinator(callId);
+      const forcedMatch = coordinator.recordNativeConsult(args, bridgeCallId);
+      if (forcedMatch.kind === "none") {
+        const pending = coordinator.consumePending();
+        if (pending) {
+          coordinator.remove(pending);
+        }
       }
       const forcedConsult = this.forcedConsultsByCallId.get(callId);
       if (forcedConsult) {
-        if (forcedConsult.completedAt) {
+        if (forcedConsult.completedAt || forcedMatch.kind === "already_delivered") {
           submitFinalToolResult({
             status: "already_delivered",
             message: "OpenClaw already delivered this consult result internally. Do not repeat it.",

--- a/src/gateway/talk-realtime-relay.ts
+++ b/src/gateway/talk-realtime-relay.ts
@@ -11,6 +11,11 @@ import {
   shouldAutoControlRealtimeVoiceAgentText,
   type RealtimeVoiceAgentControlResult,
 } from "../talk/agent-run-control.js";
+import { readSpeakableRealtimeVoiceToolResult } from "../talk/consult-question.js";
+import {
+  createRealtimeVoiceForcedConsultCoordinator,
+  type RealtimeVoiceForcedConsultCoordinator,
+} from "../talk/forced-consult-coordinator.js";
 import { recordTalkObservabilityEvent } from "../talk/observability.js";
 import {
   REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
@@ -39,34 +44,7 @@ const MAX_RELAY_SESSIONS_PER_CONN = 2;
 const MAX_RELAY_SESSIONS_GLOBAL = 64;
 const RELAY_EVENT = "talk.event";
 const FORCED_CONSULT_FALLBACK_DELAY_MS = 200;
-const FORCED_CONSULT_NATIVE_DEDUPE_MS = 2_000;
 const FORCED_CONSULT_RESULT_MAX_CHARS = 1_800;
-const CONSULT_QUESTION_STOPWORDS = new Set([
-  "a",
-  "an",
-  "and",
-  "are",
-  "can",
-  "check",
-  "could",
-  "for",
-  "in",
-  "is",
-  "it",
-  "look",
-  "me",
-  "of",
-  "on",
-  "or",
-  "please",
-  "see",
-  "that",
-  "the",
-  "this",
-  "to",
-  "would",
-  "you",
-]);
 
 type TalkRealtimeRelayEventPayload =
   | { relaySessionId: string; type: "ready" }
@@ -97,14 +75,6 @@ type TalkRealtimeRelayEventPayload =
 
 type TalkRealtimeRelayEvent = TalkRealtimeRelayEventPayload & { talkEvent?: TalkEvent };
 
-type ForcedConsultState = {
-  question: string;
-  nativeCallIds: Set<string>;
-  cancelled?: boolean;
-  completedAtMs?: number;
-  cleanupTimer?: ReturnType<typeof setTimeout>;
-};
-
 type RelaySession = {
   id: string;
   connId: string;
@@ -117,10 +87,7 @@ type RelaySession = {
   activeAgentRuns: Map<string, string>;
   activeAgentToolCalls: Map<string, string>;
   completedAgentToolCalls: Set<string>;
-  forcedConsultTimer?: ReturnType<typeof setTimeout>;
-  pendingForcedConsultQuestion?: string;
-  lastProviderConsult?: { atMs: number; question?: string };
-  forcedConsultCalls: Map<string, ForcedConsultState>;
+  forcedConsults: RealtimeVoiceForcedConsultCoordinator;
 };
 
 type CreateTalkRealtimeRelaySessionParams = {
@@ -153,29 +120,6 @@ function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function readSpeakableToolResultText(result: unknown): string | undefined {
-  if (!result || typeof result !== "object" || Array.isArray(result)) {
-    return undefined;
-  }
-  const record = result as Record<string, unknown>;
-  const value =
-    typeof record.text === "string"
-      ? record.text
-      : typeof record.result === "string"
-        ? record.result
-        : record.error;
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  return trimmed.length <= FORCED_CONSULT_RESULT_MAX_CHARS
-    ? trimmed
-    : `${trimmed.slice(0, FORCED_CONSULT_RESULT_MAX_CHARS - 16).trimEnd()} [truncated]`;
-}
-
 function isWorkingToolResult(result: unknown): boolean {
   return (
     Boolean(result) &&
@@ -183,70 +127,6 @@ function isWorkingToolResult(result: unknown): boolean {
     !Array.isArray(result) &&
     (result as Record<string, unknown>).status === "working"
   );
-}
-
-function readConsultQuestion(args: unknown): string | undefined {
-  if (!args || typeof args !== "object" || Array.isArray(args)) {
-    return undefined;
-  }
-  const record = args as Record<string, unknown>;
-  for (const key of ["question", "prompt", "query", "task"]) {
-    const value = record[key];
-    if (typeof value === "string" && value.trim()) {
-      return value.trim();
-    }
-  }
-  return undefined;
-}
-
-function normalizeConsultQuestion(value: string | undefined): string | undefined {
-  return (
-    value
-      ?.toLowerCase()
-      .replace(/[^\p{L}\p{N}]+/gu, " ")
-      .replace(/\s+/gu, " ")
-      .trim() || undefined
-  );
-}
-
-function questionTokens(value: string | undefined): Set<string> {
-  const normalized = normalizeConsultQuestion(value);
-  if (!normalized) {
-    return new Set();
-  }
-  return new Set(
-    normalized
-      .split(/[^\p{L}\p{N}]+/gu)
-      .map((token) => token.trim())
-      .filter((token) => token.length >= 2 && !CONSULT_QUESTION_STOPWORDS.has(token)),
-  );
-}
-
-function consultQuestionsMatch(left: string | undefined, right: string | undefined): boolean {
-  const normalizedLeft = normalizeConsultQuestion(left);
-  const normalizedRight = normalizeConsultQuestion(right);
-  if (!normalizedLeft || !normalizedRight) {
-    return false;
-  }
-  if (
-    normalizedLeft === normalizedRight ||
-    normalizedLeft.includes(normalizedRight) ||
-    normalizedRight.includes(normalizedLeft)
-  ) {
-    return true;
-  }
-  const leftTokens = questionTokens(normalizedLeft);
-  const rightTokens = questionTokens(normalizedRight);
-  if (leftTokens.size === 0 || rightTokens.size === 0) {
-    return false;
-  }
-  let overlap = 0;
-  for (const token of leftTokens) {
-    if (rightTokens.has(token)) {
-      overlap += 1;
-    }
-  }
-  return overlap / Math.min(leftTokens.size, rightTokens.size) >= 0.6;
 }
 
 function buildForcedConsultCheckingPrompt(): string {
@@ -272,66 +152,10 @@ function buildAlreadyDeliveredToolResult(): Record<string, string> {
   };
 }
 
-function clearPendingForcedConsult(session: RelaySession): void {
-  if (!session.forcedConsultTimer) {
-    return;
-  }
-  clearTimeout(session.forcedConsultTimer);
-  session.forcedConsultTimer = undefined;
-  session.pendingForcedConsultQuestion = undefined;
-}
-
-function clearForcedConsultStates(session: RelaySession): void {
-  for (const state of session.forcedConsultCalls.values()) {
-    if (state.cleanupTimer) {
-      clearTimeout(state.cleanupTimer);
-    }
-  }
-  session.forcedConsultCalls.clear();
-}
-
 function cancelForcedConsults(session: RelaySession): void {
-  for (const state of session.forcedConsultCalls.values()) {
-    state.cancelled = true;
+  for (const handle of session.forcedConsults.handles()) {
+    session.forcedConsults.markCancelled(handle);
   }
-}
-
-function scheduleForcedConsultCleanup(
-  session: RelaySession,
-  callId: string,
-  state: ForcedConsultState,
-): void {
-  if (state.cleanupTimer) {
-    clearTimeout(state.cleanupTimer);
-  }
-  state.cleanupTimer = setTimeout(() => {
-    if (session.forcedConsultCalls.get(callId) === state) {
-      session.forcedConsultCalls.delete(callId);
-    }
-  }, FORCED_CONSULT_NATIVE_DEDUPE_MS);
-  state.cleanupTimer.unref?.();
-}
-
-function findActiveForcedConsult(
-  session: RelaySession,
-  nativeArgs: unknown,
-): ForcedConsultState | undefined {
-  const nativeQuestion = readConsultQuestion(nativeArgs);
-  if (!nativeQuestion) {
-    return undefined;
-  }
-  const now = Date.now();
-  for (const state of session.forcedConsultCalls.values()) {
-    if (state.cancelled) {
-      continue;
-    }
-    const active =
-      !state.completedAtMs || now - state.completedAtMs < FORCED_CONSULT_NATIVE_DEDUPE_MS;
-    if (active && consultQuestionsMatch(state.question, nativeQuestion)) {
-      return state;
-    }
-  }
-  return undefined;
 }
 
 function broadcastToOwner(
@@ -378,16 +202,14 @@ function submitRelayAgentControlProviderResults(
   }
   const activeCallIds = [...session.activeAgentToolCalls.keys()];
   for (const callId of activeCallIds) {
-    const forcedConsult = session.forcedConsultCalls.get(callId);
+    const forcedConsult = session.forcedConsults.handles().find((handle) => handle.id === callId);
     if (forcedConsult) {
-      forcedConsult.cancelled = true;
-      forcedConsult.completedAtMs = Date.now();
-      for (const nativeCallId of forcedConsult.nativeCallIds) {
+      session.forcedConsults.markCancelled(forcedConsult);
+      for (const nativeCallId of session.forcedConsults.nativeCallIds(forcedConsult)) {
         session.bridge.submitToolResult(nativeCallId, result.providerResult, {
           suppressResponse: true,
         });
       }
-      scheduleForcedConsultCleanup(session, callId, forcedConsult);
     } else {
       session.bridge.submitToolResult(callId, result.providerResult, { suppressResponse: true });
     }
@@ -410,8 +232,7 @@ function submitRelayAgentControlProviderResults(
 }
 
 function closeRelaySession(session: RelaySession, reason: "completed" | "error"): void {
-  clearPendingForcedConsult(session);
-  clearForcedConsultStates(session);
+  session.forcedConsults.clear();
   relaySessions.delete(session.id);
   forgetUnifiedTalkSession(session.id);
   clearTimeout(session.cleanupTimer);
@@ -590,18 +411,12 @@ export function createTalkRealtimeRelaySession(
     onToolCall: (toolCall) => {
       const turnId = relay ? ensureRelayTurn(relay) : undefined;
       if (relay && toolCall.name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME) {
-        const nativeQuestion = readConsultQuestion(toolCall.args);
-        relay.lastProviderConsult = {
-          atMs: Date.now(),
-          question: nativeQuestion,
-        };
-        if (consultQuestionsMatch(relay.pendingForcedConsultQuestion, nativeQuestion)) {
-          clearPendingForcedConsult(relay);
-        }
-        const forcedConsult = findActiveForcedConsult(relay, toolCall.args);
-        if (forcedConsult) {
-          forcedConsult.nativeCallIds.add(toolCall.callId);
-          if (forcedConsult.completedAtMs) {
+        const forcedConsult = relay.forcedConsults.recordNativeConsult(
+          toolCall.args,
+          toolCall.callId,
+        );
+        if (forcedConsult.kind === "in_flight" || forcedConsult.kind === "already_delivered") {
+          if (forcedConsult.kind === "already_delivered") {
             submitAlreadyDeliveredToolResult(relay, toolCall.callId, turnId);
           } else {
             submitRealtimeAgentConsultWorkingResponse(relay, toolCall.callId, turnId);
@@ -640,8 +455,7 @@ export function createTalkRealtimeRelaySession(
       if (!active) {
         return;
       }
-      clearPendingForcedConsult(active);
-      clearForcedConsultStates(active);
+      active.forcedConsults.clear();
       relaySessions.delete(relaySessionId);
       forgetUnifiedTalkSession(relaySessionId);
       clearTimeout(active.cleanupTimer);
@@ -669,7 +483,7 @@ export function createTalkRealtimeRelaySession(
     activeAgentRuns: new Map(),
     activeAgentToolCalls: new Map(),
     completedAgentToolCalls: new Set(),
-    forcedConsultCalls: new Map(),
+    forcedConsults: createRealtimeVoiceForcedConsultCoordinator(),
   };
   relay.cleanupTimer.unref?.();
   relaySessions.set(relaySessionId, relay);
@@ -701,26 +515,22 @@ function scheduleForcedAgentConsult(session: RelaySession | undefined, question:
   if (!session || !question.trim()) {
     return;
   }
-  clearPendingForcedConsult(session);
-  session.pendingForcedConsultQuestion = question;
-  session.forcedConsultTimer = setTimeout(() => {
-    session.forcedConsultTimer = undefined;
-    session.pendingForcedConsultQuestion = undefined;
+  if (session.forcedConsults.hasRecentNativeConsult(question)) {
+    return;
+  }
+  session.forcedConsults.clearPending();
+  const handle = session.forcedConsults.prepare(question);
+  if (!handle) {
+    return;
+  }
+  session.forcedConsults.schedule(handle, FORCED_CONSULT_FALLBACK_DELAY_MS, () => {
     if (!relaySessions.has(session.id)) {
       return;
     }
-    const providerConsult = session.lastProviderConsult;
-    if (
-      providerConsult &&
-      Date.now() - providerConsult.atMs < FORCED_CONSULT_NATIVE_DEDUPE_MS &&
-      consultQuestionsMatch(providerConsult.question, question)
-    ) {
-      return;
-    }
     const turnId = ensureRelayTurn(session);
-    const callId = `forced-consult-${randomUUID()}`;
+    const callId = handle.id;
     const itemId = `forced-consult-item-${randomUUID()}`;
-    session.forcedConsultCalls.set(callId, { question, nativeCallIds: new Set() });
+    session.forcedConsults.markStarted(handle);
     session.bridge.handleBargeIn({ audioPlaybackActive: true, force: true });
     broadcastToOwner(session.context, session.connId, {
       relaySessionId: session.id,
@@ -730,7 +540,7 @@ function scheduleForcedAgentConsult(session: RelaySession | undefined, question:
       name: REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
       forced: true,
       args: {
-        question,
+        question: handle.question,
         context:
           "The realtime provider produced a final user transcript without invoking openclaw_agent_consult, so OpenClaw is forcing the consult for realtime Talk.",
         responseStyle: "Reply in a concise spoken tone.",
@@ -742,13 +552,12 @@ function scheduleForcedAgentConsult(session: RelaySession | undefined, question:
         turnId,
         payload: {
           name: REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
-          args: { question },
+          args: { question: handle.question },
           forced: true,
         },
       }),
     });
-  }, FORCED_CONSULT_FALLBACK_DELAY_MS);
-  session.forcedConsultTimer.unref?.();
+  });
 }
 
 function submitAlreadyDeliveredToolResult(
@@ -859,27 +668,33 @@ export function submitTalkRealtimeRelayToolResult(params: {
   if (session.completedAgentToolCalls.has(params.callId)) {
     return;
   }
-  const forcedConsult = session.forcedConsultCalls.get(params.callId);
+  const forcedConsult = session.forcedConsults
+    .handles()
+    .find((handle) => handle.id === params.callId);
   if (forcedConsult) {
     const turnId = ensureRelayTurn(session);
-    if (forcedConsult.cancelled) {
-      forcedConsult.completedAtMs = Date.now();
+    const cancelled = session.forcedConsults.isCancelled(forcedConsult);
+    if (cancelled) {
+      if (params.options?.willContinue !== true) {
+        session.forcedConsults.markCancelled(forcedConsult);
+      }
     } else if (isWorkingToolResult(params.result)) {
       session.bridge.sendUserMessage(buildForcedConsultCheckingPrompt());
     } else {
-      forcedConsult.completedAtMs = Date.now();
-      const text = readSpeakableToolResultText(params.result);
-      for (const nativeCallId of forcedConsult.nativeCallIds) {
+      session.forcedConsults.markDelivered(forcedConsult);
+      const text = readSpeakableRealtimeVoiceToolResult(params.result, {
+        maxChars: FORCED_CONSULT_RESULT_MAX_CHARS,
+      });
+      for (const nativeCallId of session.forcedConsults.nativeCallIds(forcedConsult)) {
         submitAlreadyDeliveredToolResult(session, nativeCallId, turnId);
       }
       if (text) {
         session.bridge.sendUserMessage(buildForcedConsultSpeechPrompt(text));
       }
-      scheduleForcedConsultCleanup(session, params.callId, forcedConsult);
     }
     const final = params.options?.willContinue !== true;
-    if (forcedConsult.cancelled && final) {
-      scheduleForcedConsultCleanup(session, params.callId, forcedConsult);
+    if (final && !cancelled && !isWorkingToolResult(params.result)) {
+      session.forcedConsults.markDelivered(forcedConsult);
     }
     broadcastToOwner(session.context, session.connId, {
       relaySessionId: session.id,
@@ -986,7 +801,6 @@ export function cancelTalkRealtimeRelayTurn(params: {
   const session = getRelaySession(params.relaySessionId, params.connId);
   const turnId = ensureRelayTurn(session);
   const reason = params.reason ?? "client-cancelled";
-  clearPendingForcedConsult(session);
   cancelForcedConsults(session);
   session.bridge.handleBargeIn({ audioPlaybackActive: true });
   abortRelayAgentRuns(session, reason);
@@ -1011,8 +825,7 @@ export function stopTalkRealtimeRelaySession(params: {
 
 export function clearTalkRealtimeRelaySessionsForTest(): void {
   for (const session of relaySessions.values()) {
-    clearPendingForcedConsult(session);
-    clearForcedConsultStates(session);
+    session.forcedConsults.clear();
     clearTimeout(session.cleanupTimer);
     forgetUnifiedTalkSession(session.id);
     session.bridge.close();

--- a/src/plugin-sdk/realtime-voice.ts
+++ b/src/plugin-sdk/realtime-voice.ts
@@ -68,6 +68,23 @@ export {
   type SkippableRealtimeVoiceConsultTranscriptReason,
 } from "../talk/consult-transcript.js";
 export {
+  matchRealtimeVoiceConsultQuestions,
+  normalizeRealtimeVoiceConsultQuestion,
+  readRealtimeVoiceConsultQuestion,
+  readSpeakableRealtimeVoiceToolResult,
+  type RealtimeVoiceConsultQuestionMatchOptions,
+  type RealtimeVoiceSpeakableToolResultOptions,
+} from "../talk/consult-question.js";
+export {
+  createRealtimeVoiceForcedConsultCoordinator,
+  type RealtimeVoiceForcedConsultCoordinator,
+  type RealtimeVoiceForcedConsultCoordinatorOptions,
+  type RealtimeVoiceForcedConsultHandle,
+  type RealtimeVoiceForcedConsultNativeMatch,
+  type RealtimeVoiceForcedConsultNativeRecentOptions,
+  type RealtimeVoiceForcedConsultTimer,
+} from "../talk/forced-consult-coordinator.js";
+export {
   buildRealtimeVoiceAgentConsultChatMessage,
   buildRealtimeVoiceAgentConsultPolicyInstructions,
   buildRealtimeVoiceAgentConsultPrompt,

--- a/src/talk/consult-question.test.ts
+++ b/src/talk/consult-question.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  matchRealtimeVoiceConsultQuestions,
+  readRealtimeVoiceConsultQuestion,
+  readSpeakableRealtimeVoiceToolResult,
+} from "./consult-question.js";
+
+describe("realtime voice consult question helpers", () => {
+  it("reads common provider question fields", () => {
+    expect(readRealtimeVoiceConsultQuestion({ question: " check status " })).toBe("check status");
+    expect(readRealtimeVoiceConsultQuestion({ prompt: "look up docs" })).toBe("look up docs");
+    expect(readRealtimeVoiceConsultQuestion({ query: "find logs" })).toBe("find logs");
+    expect(readRealtimeVoiceConsultQuestion({ task: "summarize" })).toBe("summarize");
+    expect(readRealtimeVoiceConsultQuestion({ question: "   " })).toBeUndefined();
+  });
+
+  it("matches exact, contained, and token-overlap questions conservatively", () => {
+    expect(matchRealtimeVoiceConsultQuestions("Can you check this?", "check this")).toBe(true);
+    expect(
+      matchRealtimeVoiceConsultQuestions(
+        "Send me a Discord message after checking the branch",
+        "check branch and send Discord message",
+      ),
+    ).toBe(true);
+    expect(matchRealtimeVoiceConsultQuestions("check this branch", "restart the server")).toBe(
+      false,
+    );
+    expect(matchRealtimeVoiceConsultQuestions("restart server", "check server")).toBe(false);
+  });
+
+  it("extracts bounded speakable text from tool results", () => {
+    expect(readSpeakableRealtimeVoiceToolResult({ text: " Answer " })).toBe("Answer");
+    expect(readSpeakableRealtimeVoiceToolResult({ result: "Result" })).toBe("Result");
+    expect(readSpeakableRealtimeVoiceToolResult("Direct")).toBe("Direct");
+    expect(
+      readSpeakableRealtimeVoiceToolResult(
+        { text: "abcdefghijklmnopqrstuvwxyz" },
+        { maxChars: 24 },
+      ),
+    ).toBe("abcdefgh [truncated]");
+  });
+});

--- a/src/talk/consult-question.ts
+++ b/src/talk/consult-question.ts
@@ -1,0 +1,158 @@
+const REALTIME_VOICE_CONSULT_QUESTION_STOPWORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "can",
+  "check",
+  "could",
+  "for",
+  "in",
+  "is",
+  "it",
+  "look",
+  "me",
+  "of",
+  "on",
+  "or",
+  "please",
+  "see",
+  "that",
+  "the",
+  "this",
+  "to",
+  "would",
+  "you",
+]);
+
+const DEFAULT_REALTIME_VOICE_CONSULT_QUESTION_KEYS = ["question", "prompt", "query", "task"];
+const DEFAULT_REALTIME_VOICE_SPEAKABLE_RESULT_KEYS = ["text", "result", "output", "error"];
+const DEFAULT_REALTIME_VOICE_SPEAKABLE_RESULT_MAX_CHARS = 1_800;
+
+export type RealtimeVoiceConsultQuestionMatchOptions = {
+  minTokenOverlapRatio?: number;
+  minTokenOverlapCount?: number;
+};
+
+export type RealtimeVoiceSpeakableToolResultOptions = {
+  keys?: readonly string[];
+  maxChars?: number;
+  stringResult?: boolean;
+};
+
+export function readRealtimeVoiceConsultQuestion(
+  args: unknown,
+  keys: readonly string[] = DEFAULT_REALTIME_VOICE_CONSULT_QUESTION_KEYS,
+): string | undefined {
+  if (typeof args === "string") {
+    return args.trim() || undefined;
+  }
+  if (!args || typeof args !== "object" || Array.isArray(args)) {
+    return undefined;
+  }
+  const record = args as Record<string, unknown>;
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+export function normalizeRealtimeVoiceConsultQuestion(
+  value: string | undefined,
+): string | undefined {
+  return (
+    value
+      ?.toLowerCase()
+      .replace(/[^\p{L}\p{N}]+/gu, " ")
+      .replace(/\s+/gu, " ")
+      .trim() || undefined
+  );
+}
+
+export function matchRealtimeVoiceConsultQuestions(
+  left: string | undefined,
+  right: string | undefined,
+  options: RealtimeVoiceConsultQuestionMatchOptions = {},
+): boolean {
+  const normalizedLeft = normalizeRealtimeVoiceConsultQuestion(left);
+  const normalizedRight = normalizeRealtimeVoiceConsultQuestion(right);
+  if (!normalizedLeft || !normalizedRight) {
+    return false;
+  }
+  if (
+    normalizedLeft === normalizedRight ||
+    normalizedLeft.includes(normalizedRight) ||
+    normalizedRight.includes(normalizedLeft)
+  ) {
+    return true;
+  }
+  const leftTokens = realtimeVoiceConsultQuestionTokens(normalizedLeft);
+  const rightTokens = realtimeVoiceConsultQuestionTokens(normalizedRight);
+  if (leftTokens.size === 0 || rightTokens.size === 0) {
+    return false;
+  }
+  let overlap = 0;
+  for (const token of leftTokens) {
+    if (rightTokens.has(token)) {
+      overlap += 1;
+    }
+  }
+  const minTokenOverlapCount = options.minTokenOverlapCount ?? 2;
+  if (overlap < minTokenOverlapCount) {
+    return false;
+  }
+  const minTokenOverlapRatio = options.minTokenOverlapRatio ?? 0.6;
+  return overlap / Math.min(leftTokens.size, rightTokens.size) >= minTokenOverlapRatio;
+}
+
+export function readSpeakableRealtimeVoiceToolResult(
+  result: unknown,
+  options: RealtimeVoiceSpeakableToolResultOptions = {},
+): string | undefined {
+  const stringResult = options.stringResult ?? true;
+  if (typeof result === "string") {
+    return stringResult
+      ? limitSpeakableRealtimeVoiceToolResult(result, options.maxChars)
+      : undefined;
+  }
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return undefined;
+  }
+  const record = result as Record<string, unknown>;
+  const keys = options.keys ?? DEFAULT_REALTIME_VOICE_SPEAKABLE_RESULT_KEYS;
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return limitSpeakableRealtimeVoiceToolResult(value, options.maxChars);
+    }
+  }
+  return undefined;
+}
+
+function realtimeVoiceConsultQuestionTokens(value: string): Set<string> {
+  return new Set(
+    value
+      .split(/[^\p{L}\p{N}]+/gu)
+      .map((token) => token.trim())
+      .filter(
+        (token) => token.length >= 2 && !REALTIME_VOICE_CONSULT_QUESTION_STOPWORDS.has(token),
+      ),
+  );
+}
+
+function limitSpeakableRealtimeVoiceToolResult(
+  value: string,
+  maxChars = DEFAULT_REALTIME_VOICE_SPEAKABLE_RESULT_MAX_CHARS,
+): string | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (trimmed.length <= maxChars) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, Math.max(0, maxChars - 16)).trimEnd()} [truncated]`;
+}

--- a/src/talk/forced-consult-coordinator.test.ts
+++ b/src/talk/forced-consult-coordinator.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from "vitest";
+import { createRealtimeVoiceForcedConsultCoordinator } from "./forced-consult-coordinator.js";
+
+describe("realtime voice forced consult coordinator", () => {
+  it("runs a delayed pending consult unless a native consult arrives first", () => {
+    vi.useFakeTimers();
+    try {
+      const coordinator = createRealtimeVoiceForcedConsultCoordinator();
+      const run = vi.fn();
+      const pending = coordinator.prepare("Can you check this?", { id: "forced-1" });
+      expect(pending).toBeDefined();
+      coordinator.schedule(pending!, 200, run);
+
+      expect(
+        coordinator.recordNativeConsult({ question: "Can you check this?" }, "native-call"),
+      ).toMatchObject({ kind: "pending", handle: { id: "forced-1" } });
+      vi.advanceTimersByTime(250);
+
+      expect(run).not.toHaveBeenCalled();
+      expect(coordinator.hasRecent("Can you check this?")).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("marks late native consults already delivered after a forced result", () => {
+    vi.useFakeTimers();
+    try {
+      const coordinator = createRealtimeVoiceForcedConsultCoordinator();
+      const pending = coordinator.prepare("Can you check this?", { id: "forced-1" });
+      coordinator.markStarted(pending!);
+      coordinator.markDelivered(pending!);
+
+      expect(
+        coordinator.recordNativeConsult({ question: "Can you check this?" }, "native-call"),
+      ).toMatchObject({ kind: "already_delivered", handle: { id: "forced-1" } });
+      expect(coordinator.nativeCallIds(pending!)).toEqual(["native-call"]);
+
+      vi.advanceTimersByTime(2_001);
+      expect(coordinator.hasRecent("Can you check this?")).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("tracks native-first consults during the dedupe window", () => {
+    vi.useFakeTimers();
+    try {
+      const coordinator = createRealtimeVoiceForcedConsultCoordinator();
+
+      expect(coordinator.recordNativeConsult({ question: "check server" })).toMatchObject({
+        kind: "none",
+        question: "check server",
+      });
+      expect(coordinator.hasRecentNativeConsult("check server")).toBe(true);
+      expect(coordinator.hasRecentNativeConsult("restart server")).toBe(false);
+
+      vi.advanceTimersByTime(2_001);
+      expect(coordinator.hasRecentNativeConsult("check server")).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("can treat native consults without a readable question as recent", () => {
+    const coordinator = createRealtimeVoiceForcedConsultCoordinator();
+
+    coordinator.recordNativeConsult({ prompt: "   " });
+
+    expect(coordinator.hasRecentNativeConsult("check status")).toBe(false);
+    expect(coordinator.hasRecentNativeConsult("check status", { allowUnknownQuestion: true })).toBe(
+      true,
+    );
+  });
+
+  it("clears pending, active, and cleanup timers", () => {
+    vi.useFakeTimers();
+    try {
+      const coordinator = createRealtimeVoiceForcedConsultCoordinator();
+      const run = vi.fn();
+      const pending = coordinator.prepare("check status", { id: "forced-1" });
+      coordinator.schedule(pending!, 200, run);
+      coordinator.clear();
+      vi.advanceTimersByTime(250);
+      expect(run).not.toHaveBeenCalled();
+      expect(coordinator.hasRecent("check status")).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears only pending handles", () => {
+    vi.useFakeTimers();
+    try {
+      const coordinator = createRealtimeVoiceForcedConsultCoordinator();
+      const pendingRun = vi.fn();
+      const active = coordinator.prepare("active question", { id: "active" });
+      const pending = coordinator.prepare("pending question", { id: "pending" });
+      coordinator.markStarted(active!);
+      coordinator.schedule(pending!, 200, pendingRun);
+
+      coordinator.clearPending();
+      vi.advanceTimersByTime(250);
+
+      expect(pendingRun).not.toHaveBeenCalled();
+      expect(coordinator.hasRecent("pending question")).toBe(false);
+      expect(coordinator.hasRecent("active question")).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("consumes the only pending handle while delivered handles are retained", () => {
+    vi.useFakeTimers();
+    try {
+      const coordinator = createRealtimeVoiceForcedConsultCoordinator();
+      const delivered = coordinator.prepare("delivered question", { id: "delivered" });
+      coordinator.markStarted(delivered!);
+      coordinator.markDelivered(delivered!);
+      const pending = coordinator.prepare("pending question", { id: "pending" });
+
+      expect(coordinator.consumePending()).toEqual(pending);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears an existing timer when an explicit handle id is reused", () => {
+    vi.useFakeTimers();
+    try {
+      const coordinator = createRealtimeVoiceForcedConsultCoordinator();
+      const staleRun = vi.fn();
+      const currentRun = vi.fn();
+      const stale = coordinator.prepare("first question", { id: "call-1" });
+      coordinator.schedule(stale!, 200, staleRun);
+
+      const current = coordinator.prepare("second question", { id: "call-1" });
+      coordinator.schedule(current!, 200, currentRun);
+      vi.advanceTimersByTime(250);
+
+      expect(staleRun).not.toHaveBeenCalled();
+      expect(currentRun).toHaveBeenCalledWith(current);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reports cancelled handles until the dedupe window expires", () => {
+    vi.useFakeTimers();
+    try {
+      const coordinator = createRealtimeVoiceForcedConsultCoordinator();
+      const pending = coordinator.prepare("check status", { id: "forced-1" });
+      coordinator.markStarted(pending!);
+      coordinator.markCancelled(pending!);
+
+      expect(coordinator.isCancelled(pending!)).toBe(true);
+      vi.advanceTimersByTime(2_001);
+      expect(coordinator.isCancelled(pending!)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/talk/forced-consult-coordinator.ts
+++ b/src/talk/forced-consult-coordinator.ts
@@ -1,0 +1,340 @@
+import {
+  matchRealtimeVoiceConsultQuestions,
+  readRealtimeVoiceConsultQuestion,
+} from "./consult-question.js";
+
+const DEFAULT_REALTIME_VOICE_FORCED_CONSULT_NATIVE_DEDUPE_MS = 2_000;
+const DEFAULT_REALTIME_VOICE_FORCED_CONSULT_LIMIT = 12;
+
+export type RealtimeVoiceForcedConsultTimer = {
+  clear(): void;
+};
+
+export type RealtimeVoiceForcedConsultCoordinatorOptions = {
+  limit?: number;
+  nativeDedupeMs?: number;
+  now?: () => number;
+  setTimer?: (fn: () => void, ms: number) => RealtimeVoiceForcedConsultTimer;
+  questionsMatch?: (left: string | undefined, right: string | undefined) => boolean;
+};
+
+export type RealtimeVoiceForcedConsultHandle<TContext = unknown> = {
+  id: string;
+  question: string;
+  context?: TContext;
+};
+
+export type RealtimeVoiceForcedConsultNativeMatch<TContext = unknown> =
+  | { kind: "none"; question?: string }
+  | { kind: "pending"; question?: string; handle: RealtimeVoiceForcedConsultHandle<TContext> }
+  | { kind: "in_flight"; question?: string; handle: RealtimeVoiceForcedConsultHandle<TContext> }
+  | {
+      kind: "already_delivered";
+      question?: string;
+      handle: RealtimeVoiceForcedConsultHandle<TContext>;
+    };
+
+export type RealtimeVoiceForcedConsultNativeRecentOptions = {
+  allowUnknownQuestion?: boolean;
+};
+
+export type RealtimeVoiceForcedConsultCoordinator<TContext = unknown> = {
+  prepare(
+    question: string,
+    options?: { context?: TContext; id?: string },
+  ): RealtimeVoiceForcedConsultHandle<TContext> | undefined;
+  schedule(
+    handle: RealtimeVoiceForcedConsultHandle<TContext>,
+    delayMs: number,
+    run: (handle: RealtimeVoiceForcedConsultHandle<TContext>) => void,
+  ): void;
+  clearPending(): void;
+  consumePending(question?: string): RealtimeVoiceForcedConsultHandle<TContext> | undefined;
+  cancelPending(handle: RealtimeVoiceForcedConsultHandle<TContext>): void;
+  recordNativeConsult(
+    args: unknown,
+    nativeCallId?: string,
+  ): RealtimeVoiceForcedConsultNativeMatch<TContext>;
+  markStarted(handle: RealtimeVoiceForcedConsultHandle<TContext>): void;
+  markDelivered(handle: RealtimeVoiceForcedConsultHandle<TContext>): void;
+  markCancelled(handle: RealtimeVoiceForcedConsultHandle<TContext>): void;
+  isCancelled(handle: RealtimeVoiceForcedConsultHandle<TContext>): boolean;
+  nativeCallIds(handle: RealtimeVoiceForcedConsultHandle<TContext>): readonly string[];
+  handles(): readonly RealtimeVoiceForcedConsultHandle<TContext>[];
+  hasRecent(question: string): boolean;
+  hasRecentNativeConsult(
+    question: string,
+    options?: RealtimeVoiceForcedConsultNativeRecentOptions,
+  ): boolean;
+  remove(handle: RealtimeVoiceForcedConsultHandle<TContext>): void;
+  clear(): void;
+};
+
+type StoredForcedConsult<TContext> = {
+  handle: RealtimeVoiceForcedConsultHandle<TContext>;
+  createdAt: number;
+  nativeCallIds: Set<string>;
+  pending: boolean;
+  started: boolean;
+  delivered: boolean;
+  cancelled: boolean;
+  timer?: RealtimeVoiceForcedConsultTimer;
+  cleanupTimer?: RealtimeVoiceForcedConsultTimer;
+};
+
+type RecentNativeConsult = {
+  question?: string;
+  at: number;
+};
+
+export function createRealtimeVoiceForcedConsultCoordinator<TContext = unknown>(
+  options: RealtimeVoiceForcedConsultCoordinatorOptions = {},
+): RealtimeVoiceForcedConsultCoordinator<TContext> {
+  const state = new Map<string, StoredForcedConsult<TContext>>();
+  const recentNativeConsults: RecentNativeConsult[] = [];
+  let nextId = 0;
+  const now = options.now ?? Date.now;
+  const limit = options.limit ?? DEFAULT_REALTIME_VOICE_FORCED_CONSULT_LIMIT;
+  const nativeDedupeMs =
+    options.nativeDedupeMs ?? DEFAULT_REALTIME_VOICE_FORCED_CONSULT_NATIVE_DEDUPE_MS;
+  const setTimer =
+    options.setTimer ??
+    ((fn: () => void, ms: number) => {
+      const timer = setTimeout(fn, ms);
+      timer.unref?.();
+      return { clear: () => clearTimeout(timer) };
+    });
+  const questionsMatch = options.questionsMatch ?? matchRealtimeVoiceConsultQuestions;
+
+  const clearTimer = (stored: StoredForcedConsult<TContext>) => {
+    stored.timer?.clear();
+    stored.timer = undefined;
+  };
+
+  const scheduleCleanup = (stored: StoredForcedConsult<TContext>) => {
+    stored.cleanupTimer?.clear();
+    stored.cleanupTimer = setTimer(() => {
+      if (state.get(stored.handle.id) === stored) {
+        state.delete(stored.handle.id);
+      }
+    }, nativeDedupeMs);
+  };
+
+  const prune = () => {
+    const earliestRecentNative = now() - nativeDedupeMs;
+    for (let index = recentNativeConsults.length - 1; index >= 0; index -= 1) {
+      const recent = recentNativeConsults[index];
+      if (recent && recent.at < earliestRecentNative) {
+        recentNativeConsults.splice(index, 1);
+      }
+    }
+    while (recentNativeConsults.length > limit) {
+      recentNativeConsults.shift();
+    }
+    while (state.size > limit) {
+      const first = state.values().next().value;
+      if (!first) {
+        return;
+      }
+      first.timer?.clear();
+      first.cleanupTimer?.clear();
+      state.delete(first.handle.id);
+    }
+  };
+
+  const findMatching = (question: string | undefined) => {
+    if (!question) {
+      return undefined;
+    }
+    const stored = [...state.values()]
+      .toReversed()
+      .find((candidate) => questionsMatch(candidate.handle.question, question));
+    return stored;
+  };
+
+  const recordRecentNativeConsult = (question: string | undefined) => {
+    recentNativeConsults.push({ question, at: now() });
+    prune();
+  };
+
+  const hasRecentNativeConsult = (
+    question: string,
+    recentOptions: RealtimeVoiceForcedConsultNativeRecentOptions = {},
+  ) => {
+    prune();
+    return recentNativeConsults
+      .toReversed()
+      .some((recent) =>
+        recent.question
+          ? questionsMatch(recent.question, question)
+          : recentOptions.allowUnknownQuestion === true,
+      );
+  };
+
+  const getStored = (handle: RealtimeVoiceForcedConsultHandle<TContext>) => state.get(handle.id);
+
+  return {
+    prepare(question, prepareOptions) {
+      const trimmed = question.trim();
+      if (!trimmed) {
+        return undefined;
+      }
+      const id = prepareOptions?.id ?? `forced-consult:${now()}:${++nextId}`;
+      const existing = state.get(id);
+      if (existing) {
+        existing.timer?.clear();
+        existing.cleanupTimer?.clear();
+      }
+      const handle: RealtimeVoiceForcedConsultHandle<TContext> = {
+        id,
+        question: trimmed,
+        ...(prepareOptions && "context" in prepareOptions
+          ? { context: prepareOptions.context }
+          : {}),
+      };
+      state.set(handle.id, {
+        handle,
+        createdAt: now(),
+        nativeCallIds: new Set(),
+        pending: true,
+        started: false,
+        delivered: false,
+        cancelled: false,
+      });
+      prune();
+      return handle;
+    },
+    schedule(handle, delayMs, run) {
+      const stored = getStored(handle);
+      if (!stored || !stored.pending || stored.timer) {
+        return;
+      }
+      stored.timer = setTimer(() => {
+        stored.timer = undefined;
+        if (state.get(handle.id) === stored && stored.pending && !stored.cancelled) {
+          run(handle);
+        }
+      }, delayMs);
+    },
+    clearPending() {
+      for (const stored of state.values()) {
+        if (stored.pending) {
+          clearTimer(stored);
+          state.delete(stored.handle.id);
+        }
+      }
+    },
+    consumePending(question) {
+      const pendingCandidates = [...state.values()].filter((candidate) => candidate.pending);
+      const stored =
+        !question && pendingCandidates.length === 1
+          ? pendingCandidates[0]
+          : pendingCandidates
+              .toReversed()
+              .find((candidate) => questionsMatch(candidate.handle.question, question));
+      if (!stored?.pending) {
+        return undefined;
+      }
+      clearTimer(stored);
+      stored.pending = false;
+      return stored.handle;
+    },
+    cancelPending(handle) {
+      const stored = getStored(handle);
+      if (!stored?.pending) {
+        return;
+      }
+      clearTimer(stored);
+      stored.pending = false;
+      state.delete(handle.id);
+    },
+    recordNativeConsult(args, nativeCallId) {
+      const question = readRealtimeVoiceConsultQuestion(args);
+      recordRecentNativeConsult(question);
+      const pending = [...state.values()]
+        .toReversed()
+        .find(
+          (candidate) => candidate.pending && questionsMatch(candidate.handle.question, question),
+        );
+      if (pending) {
+        clearTimer(pending);
+        if (nativeCallId) {
+          pending.nativeCallIds.add(nativeCallId);
+        }
+        state.delete(pending.handle.id);
+        return { kind: "pending", question, handle: pending.handle };
+      }
+      const stored = findMatching(question);
+      if (!stored || stored.cancelled) {
+        return { kind: "none", question };
+      }
+      if (nativeCallId) {
+        stored.nativeCallIds.add(nativeCallId);
+      }
+      if (stored.delivered) {
+        return { kind: "already_delivered", question, handle: stored.handle };
+      }
+      if (stored.started) {
+        return { kind: "in_flight", question, handle: stored.handle };
+      }
+      return { kind: "none", question };
+    },
+    markStarted(handle) {
+      const stored = getStored(handle);
+      if (!stored) {
+        return;
+      }
+      clearTimer(stored);
+      stored.pending = false;
+      stored.started = true;
+    },
+    markDelivered(handle) {
+      const stored = getStored(handle);
+      if (!stored) {
+        return;
+      }
+      clearTimer(stored);
+      stored.pending = false;
+      stored.started = true;
+      stored.delivered = true;
+      scheduleCleanup(stored);
+    },
+    markCancelled(handle) {
+      const stored = getStored(handle);
+      if (!stored) {
+        return;
+      }
+      clearTimer(stored);
+      stored.pending = false;
+      stored.cancelled = true;
+      scheduleCleanup(stored);
+    },
+    isCancelled(handle) {
+      return getStored(handle)?.cancelled === true;
+    },
+    nativeCallIds(handle) {
+      return [...(getStored(handle)?.nativeCallIds ?? [])];
+    },
+    handles() {
+      return [...state.values()].map((stored) => stored.handle);
+    },
+    hasRecent(question) {
+      return Boolean(findMatching(question));
+    },
+    hasRecentNativeConsult,
+    remove(handle) {
+      const stored = getStored(handle);
+      stored?.timer?.clear();
+      stored?.cleanupTimer?.clear();
+      state.delete(handle.id);
+    },
+    clear() {
+      for (const stored of state.values()) {
+        stored.timer?.clear();
+        stored.cleanupTimer?.clear();
+      }
+      state.clear();
+      recentNativeConsults.length = 0;
+    },
+  };
+}


### PR DESCRIPTION
Summary
- Add shared realtime voice consult-question helpers and a forced-consult coordinator to `plugin-sdk/realtime-voice`.
- Migrate Gateway Talk and Voice Call forced-consult dedupe/fallback state to the shared coordinator, and move Discord consult-question matching to the shared helper.
- Update SDK API baseline, SDK migration docs, changelog, and focused helper tests.

Verification
- `node scripts/run-vitest.mjs src/talk/consult-question.test.ts src/talk/forced-consult-coordinator.test.ts src/gateway/talk-realtime-relay.test.ts extensions/voice-call/src/webhook/realtime-handler.test.ts extensions/discord/src/voice/manager.e2e.test.ts -t "forced|consult tool|recent agent-proxy|duplicate consult|partial transcript|final user transcript|barge-in"`
- `pnpm plugin-sdk:api:check`
- `env -u OPENCLAW_TESTBOX pnpm check:changed`
- `pnpm build`
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local`

Behavior addressed: Shared provider/channel-neutral realtime voice consult matching, speakable result extraction, and forced-consult coordination across Gateway Talk, Voice Call, and Discord consult-question matching.
Real environment tested: Local OpenClaw source checkout on macOS, Node/pnpm repo toolchain.
Exact steps or command run after this patch: Focused Vitest command above, plugin SDK API check, changed gate with `OPENCLAW_TESTBOX` unset, full build, and structured autoreview.
Evidence after fix: Focused tests passed 22 tests across 5 files with 1 skipped file; SDK API baseline check passed; changed gate passed; build passed through plugin SDK d.ts/export checks and Control UI build; autoreview returned clean.
Observed result after fix: Forced fallback replacement, native-first suppression, late native already-delivered suppression, cancelled forced result suppression, and conservative consult-question matching remain covered by unit/adapter proof.
What was not tested: Live Discord, browser Talk, Voice Call telephony, or Google Meet sessions; this is helper extraction/adapter proof with no intended provider transport or audio behavior change.
