### PR TITLE
fix: sanitize block reply previews

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -5615,6 +5615,68 @@ describe("dispatchReplyFromConfig", () => {
     expect(blockReplySettled).toBe(true);
   });
 
+
+  it("sanitizes internal runtime context before queued and dispatched block replies", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "whatsapp" });
+    const queuedTexts: string[] = [];
+    const dispatchedTexts: string[] = [];
+    const internalBlock = [
+      "Visible intro.",
+      "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+      "OpenClaw runtime event.",
+      "This context is runtime-generated, not user-authored. Keep internal details private.",
+      "",
+      "[Internal task completion event]",
+      "source: subagent",
+      "task: LEAK_SENTINEL_STRICT_BOUNDARIES",
+      "## Active Subagents",
+      "task_json=should-not-appear",
+      "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+      "Visible outro.",
+    ].join("\n");
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload | undefined> => {
+      await opts?.onBlockReply?.({ text: internalBlock });
+      return undefined;
+    };
+    (dispatcher.sendBlockReply as ReturnType<typeof vi.fn>).mockImplementation(
+      (payload: ReplyPayload) => {
+        if (payload.text) {
+          dispatchedTexts.push(payload.text);
+        }
+        return true;
+      },
+    );
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        onBlockReplyQueued: (payload) => {
+          if (payload.text) {
+            queuedTexts.push(payload.text);
+          }
+        },
+      },
+    });
+
+    expect(queuedTexts).toEqual(["Visible intro.\n\nVisible outro."]);
+    expect(dispatchedTexts).toEqual(["Visible intro.\n\nVisible outro."]);
+    for (const text of [...queuedTexts, ...dispatchedTexts]) {
+      expect(text).not.toContain("LEAK_SENTINEL_STRICT_BOUNDARIES");
+      expect(text).not.toContain("## Active Subagents");
+      expect(text).not.toContain("task_json=");
+      expect(text).not.toContain("Internal task completion event");
+      expect(text).not.toContain("source: subagent");
+    }
+  });
+
   it("forwards payload metadata into onBlockReplyQueued context", async () => {
     setNoAbort();
     const dispatcher = createDispatcher();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -10,6 +10,7 @@ import {
   resolveSessionAgentId,
 } from "../../agents/agent-scope.js";
 import { selectAgentHarness } from "../../agents/harness/selection.js";
+import { sanitizeUserFacingText } from "../../agents/pi-embedded-helpers/sanitize-user-facing-text.js";
 import {
   buildModelAliasIndex,
   resolveDefaultModelForAgent,
@@ -1154,6 +1155,15 @@ export async function dispatchReplyFromConfig(
     return await normalizeReplyMediaPayloadPaths(payload);
   };
 
+  const sanitizeVisibleBlockPayload = (payload: ReplyPayload): ReplyPayload | null => {
+    if (!payload.text) {
+      return payload;
+    }
+    const text = sanitizeUserFacingText(payload.text, { errorContext: Boolean(payload.isError) });
+    const nextPayload = { ...payload, text: text.trim() ? text : undefined };
+    return hasOutboundReplyContent(nextPayload, { trimText: true }) ? nextPayload : null;
+  };
+
   const routeReplyToOriginating = async (
     payload: ReplyPayload,
     options?: { abortSignal?: AbortSignal; mirror?: boolean },
@@ -2245,30 +2255,34 @@ export async function dispatchReplyFromConfig(
                 if (payload.isReasoning === true) {
                   return;
                 }
+                const sanitizedPayload = sanitizeVisibleBlockPayload(payload);
+                if (!sanitizedPayload) {
+                  return;
+                }
                 // Accumulate block text for TTS generation after streaming.
                 // Exclude status notices — they are informational UI signals
                 // and must not be synthesised into the spoken reply.
-                const isStatusNotice = isReplyPayloadStatusNotice(payload);
-                if (payload.text && !isStatusNotice) {
+                const isStatusNotice = isReplyPayloadStatusNotice(sanitizedPayload);
+                if (sanitizedPayload.text && !isStatusNotice) {
                   const joinsBufferedTtsDirective =
                     cleanBlockTtsDirectiveText?.hasBufferedDirectiveText() === true;
                   if (accumulatedBlockText.length > 0) {
                     accumulatedBlockText += "\n";
                   }
-                  accumulatedBlockText += payload.text;
+                  accumulatedBlockText += sanitizedPayload.text;
                   if (accumulatedBlockTtsText.length > 0 && !joinsBufferedTtsDirective) {
                     accumulatedBlockTtsText += "\n";
                   }
-                  accumulatedBlockTtsText += payload.text;
+                  accumulatedBlockTtsText += sanitizedPayload.text;
                   blockCount++;
                 }
                 const visiblePayload =
-                  payload.text && cleanBlockTtsDirectiveText && !isStatusNotice
+                  sanitizedPayload.text && cleanBlockTtsDirectiveText && !isStatusNotice
                     ? (() => {
-                        const text = cleanBlockTtsDirectiveText.push(payload.text);
-                        return { ...payload, text: text.trim() ? text : undefined };
+                        const text = cleanBlockTtsDirectiveText.push(sanitizedPayload.text);
+                        return { ...sanitizedPayload, text: text.trim() ? text : undefined };
                       })()
-                    : payload;
+                    : sanitizedPayload;
                 if (!hasOutboundReplyContent(visiblePayload, { trimText: true })) {
                   return;
                 }


### PR DESCRIPTION
## Summary

Fixes a visible-output leak where streamed/block reply previews could receive raw internal runtime context before the normal user-facing sanitizer ran.

The final reply path already normalizes text via `sanitizeUserFacingText`, but the generic block reply callback path handed raw block payloads to queued/progress callbacks first. Channels that render live previews from those callbacks could expose internal runtime context.

## Changes

- Sanitize block reply text in `dispatch-from-config` before it reaches:
  - queued/progress callbacks,
  - TTS block accumulation,
  - routed block delivery,
  - dispatcher block delivery.
- Drop block payloads that sanitize down to empty text and have no media.
- Add a regression test proving queued and dispatched block replies strip internal runtime context sentinel text.

## Test plan

```bash
git diff --check
timeout 600s node scripts/run-vitest.mjs run src/auto-reply/reply/dispatch-from-config.test.ts -t "sanitizes internal runtime context before queued and dispatched block replies"
```

Targeted regression passed in a dependency-populated stage checkout (`1 passed`, `106 skipped`, `rc=0`). A fresh disposable clone with symlinked dependencies could not complete the same test because a local package dependency was unavailable in that checkout; CI should exercise the normal workspace dependency graph.

## Real behavior proof

- **Behavior or issue addressed:** Queued block previews and dispatched block replies should strip the internal runtime-context sentinel before visible delivery, while preserving the user-visible intro/outro text.
- **Real environment tested:** Disposable OpenClaw source checkout of this PR branch on Linux with workspace dependencies installed from the locked package graph. The proof exercised the real block-reply dispatch/sanitization seam with the targeted source-level regression test. No production Gateway, live runtime state, live config, or real provider/channel orchestration was used.
- **Exact steps or command run after this patch:**

  ```bash
  git diff --check
  node <corepack-pnpm.mjs> install --frozen-lockfile
  node scripts/run-vitest.mjs run src/auto-reply/reply/dispatch-from-config.test.ts -t "sanitizes internal runtime context before queued and dispatched block replies"
  ```

- **Evidence after fix:** Copied terminal output from the disposable checkout showed that `git diff --check` produced no whitespace errors, and the targeted regression test passed:

  ```text
  Test Files  1 passed (1)
  Tests       1 passed | 106 skipped
  ```

- **Observed result after fix:** The regression test confirms both queued block previews and dispatched block replies remove the internal-context sentinel and keep the surrounding visible text intact.
- **What was not tested:** No live provider/channel orchestration, production Gateway, production runtime state, or production config was exercised. This proof is intentionally limited to the sanitizer/dispatch seam changed by this PR.