### PR TITLE
fix(telegram): use explicit === false for linkPreview to survive minification

### DIFF
--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -108,8 +108,8 @@ export async function sendTelegramText(
     silent: opts?.silent,
   });
   // Add link_preview_options when link preview is disabled.
-  const linkPreviewEnabled = opts?.linkPreview ?? true;
-  const linkPreviewOptions = linkPreviewEnabled ? undefined : { is_disabled: true };
+  // Use explicit `=== false` to avoid ?? vs ?: precedence collapse after minification (#86630).
+  const linkPreviewOptions = opts?.linkPreview === false ? { is_disabled: true } : undefined;
   const textMode = opts?.textMode ?? "markdown";
   const htmlText = textMode === "html" ? text : markdownToTelegramHtml(text);
   const fallbackText = opts?.plainText ?? text;

--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -107,8 +107,7 @@ export async function sendTelegramText(
     thread: opts?.thread,
     silent: opts?.silent,
   });
-  // Add link_preview_options when link preview is disabled.
-  // Use explicit `=== false` to avoid ?? vs ?: precedence collapse after minification (#86630).
+  // Add link_preview_options when link preview is explicitly disabled (#86630).
   const linkPreviewOptions = opts?.linkPreview === false ? { is_disabled: true } : undefined;
   const textMode = opts?.textMode ?? "markdown";
   const htmlText = textMode === "html" ? text : markdownToTelegramHtml(text);

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -639,8 +639,9 @@ export async function sendMessageTelegram(
   const renderHtmlText = (value: string) => renderTelegramHtmlText(value, { textMode, tableMode });
 
   // Resolve link preview setting from config (default: enabled).
-  const linkPreviewEnabled = account.config.linkPreview ?? true;
-  const linkPreviewOptions = linkPreviewEnabled ? undefined : { is_disabled: true };
+  // Use explicit `=== false` to avoid ?? vs ?: precedence collapse after minification (#86630).
+  const linkPreviewOptions =
+    account.config.linkPreview === false ? { is_disabled: true } : undefined;
 
   type TelegramTextChunk = {
     plainText: string;

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -638,8 +638,7 @@ export async function sendMessageTelegram(
   });
   const renderHtmlText = (value: string) => renderTelegramHtmlText(value, { textMode, tableMode });
 
-  // Resolve link preview setting from config (default: enabled).
-  // Use explicit `=== false` to avoid ?? vs ?: precedence collapse after minification (#86630).
+  // Resolve link preview setting from config (default: enabled, #86630).
   const linkPreviewOptions =
     account.config.linkPreview === false ? { is_disabled: true } : undefined;
 


### PR DESCRIPTION
## Summary

`channels.telegram.linkPreview: false` is silently ignored in production due to a bundler operator-precedence bug.

The source code uses a two-line pattern:
```ts
const linkPreviewEnabled = account.config.linkPreview ?? true;
const linkPreviewOptions = linkPreviewEnabled ? undefined : { is_disabled: true };
```

This is correct in TypeScript, but the bundler inlines both into a single expression:
```js
const linkPreviewOptions = account.config.linkPreview ?? true ? void 0 : { is_disabled: true };
```

Because `??` has lower precedence than `?:`, this evaluates as `config.linkPreview ?? (true ? void 0 : ...)` which always returns `undefined` when `linkPreview` is `false`, silently ignoring the user's setting.

**Fix:** Replace with `config.linkPreview === false ? { is_disabled: true } : undefined` in both `extensions/telegram/src/send.ts` and `extensions/telegram/src/bot/delivery.send.ts`. This single-expression pattern cannot be misoptimized by any bundler.

Two files changed, 4 lines total.

## Real behavior proof
Behavior addressed: Setting `channels.telegram.linkPreview: false` in `openclaw.json` now correctly disables link previews. Before: the config value was silently ignored after minification; Telegram always showed link previews. After: the compiled output uses `=== false` which survives inlining.
Real environment tested: macOS, OpenClaw source tree at upstream/main (5dccba7), Node 24, pnpm build + grep compiled output.
Exact steps or command run after this patch: Built the patched source with `pnpm build`, then inspected compiled dist output for the linkPreview expression; also ran 158 Telegram tests (105 in send.test.ts, 53 in delivery.test.ts).
Evidence after fix: terminal output copied below.

**Compiled output before fix** (from issue report):
```console
$ grep 'linkPreview' dist/send-HzJbRmiM.js
const linkPreviewOptions = account.config.linkPreview ?? true ? void 0 : { is_disabled: true };
```

**Compiled output after fix:**
```console
$ grep 'linkPreview.*false' dist/send-DQNkghZy.js
const linkPreviewOptions = account.config.linkPreview === false ? { is_disabled: true } : void 0;
```

```console
$ grep 'linkPreview.*false' dist/delivery-Di7smjYg.js
const linkPreviewOptions = opts?.linkPreview === false ? { is_disabled: true } : void 0;
```

**Tests (158 pass):**
```console
$ node scripts/run-vitest.mjs extensions/telegram/src/send.test.ts
 ✓ |extension-telegram| ../../extensions/telegram/src/send.test.ts (105 tests) 115ms
 Test Files  1 passed (1)
      Tests  105 passed (105)

$ node scripts/run-vitest.mjs extensions/telegram/src/bot/delivery.test.ts
 ✓ |extension-telegram| ../../extensions/telegram/src/bot/delivery.test.ts (53 tests) 38ms
 Test Files  1 passed (1)
      Tests  53 passed (53)
```

Observed result after fix: The `=== false` comparison compiles to a direct boolean check that no bundler can misoptimize. Both `send.ts` and `delivery.send.ts` paths now correctly produce `{ is_disabled: true }` when `linkPreview` is `false`.
What was not tested: Live Telegram message delivery was not tested (requires a running gateway with Telegram bot credentials). The existing 158 unit tests cover both `linkPreview: false` and `linkPreview: true` paths. The production-compiled output was verified via grep.
