### PR TITLE
fix(agents): cap DSML recovery buffer to prevent unbounded memory growth

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2948,6 +2948,127 @@ describe("openai transport stream", () => {
     expect(output.content).toEqual([]);
   });
 
+  it("discards oversized DeepSeek DSML recovery buffer as text", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+    const events: CapturedStreamEvent[] = [];
+
+    // Build an oversized DSML body that exceeds 256KB
+    const hugeBody =
+      '<｜DSML｜invoke name="session_status"><｜DSML｜parameter name="key" string="true">' +
+      "x".repeat(300_000) +
+      "</｜DSML｜parameter></｜DSML｜invoke>";
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-dsml-oversized",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: "<｜DSML｜tool_calls>" + hugeBody,
+              },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: "chatcmpl-deepseek-dsml-oversized",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: "</｜DSML｜tool_calls>",
+              },
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      {
+        push(event: unknown) {
+          events.push(event as CapturedStreamEvent);
+        },
+      },
+    );
+
+    // The oversized DSML block should be discarded; no tool calls recovered
+    expect(output.content.filter((b) => b.type === "toolCall")).toEqual([]);
+  });
+
+  it("discards oversized DeepSeek DSML recovery buffer with multibyte UTF-8 text", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+    const events: CapturedStreamEvent[] = [];
+
+    // 200,000 "é" chars: .length = 200,000 (under 256KB string-length cap)
+    // but UTF-8 byte size = 400,000 (over 256KB byte cap).
+    // This test only passes when the cap uses byte accounting.
+    const multibyteBody =
+      '<｜DSML｜invoke name="session_status"><｜DSML｜parameter name="key" string="true">' +
+      "\u00E9".repeat(200_000) +
+      "</｜DSML｜parameter></｜DSML｜invoke>";
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-deepseek-dsml-multibyte",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: "<｜DSML｜tool_calls>" + multibyteBody,
+              },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: "chatcmpl-deepseek-dsml-multibyte",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: "</｜DSML｜tool_calls>",
+              },
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      {
+        push(event: unknown) {
+          events.push(event as CapturedStreamEvent);
+        },
+      },
+    );
+
+    // Multibyte text exceeds 256KB in bytes despite being under 256K in
+    // string length; the buffer cap should still discard it.
+    expect(output.content.filter((b) => b.type === "toolCall")).toEqual([]);
+  });
+
   it("keeps OpenRouter thinking format for declared OpenRouter providers on custom proxy URLs", () => {
     const params = buildOpenAICompletionsParams(
       attachModelProviderRequestTransport(

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -3290,8 +3290,21 @@ const DEEPSEEK_DSML_TOOL_MAX_OPEN_TOKEN_LEN = Math.max(
   ...DEEPSEEK_DSML_TOOL_OPEN_TOKENS.map((token) => token.length),
 );
 
+const MAX_DSML_RECOVERY_BUFFER_BYTES = 256_000;
+
 function createDeepSeekDsmlToolCallRecoverer() {
   let buffer = "";
+  let bufferBytes = 0;
+
+  const emitAndSlice = (text: string): void => {
+    buffer = buffer.slice(text.length);
+    bufferBytes -= Buffer.byteLength(text, "utf8");
+  };
+
+  const clearBuffer = (): void => {
+    buffer = "";
+    bufferBytes = 0;
+  };
 
   const consume = (final: boolean): DeepSeekDsmlRecoveredPart[] => {
     const output: DeepSeekDsmlRecoveredPart[] = [];
@@ -3300,42 +3313,44 @@ function createDeepSeekDsmlToolCallRecoverer() {
       if (!open) {
         if (final) {
           output.push({ kind: "text", text: buffer });
-          buffer = "";
+          clearBuffer();
           return output;
         }
         const keep = longestDeepSeekDsmlToolOpenPrefixSuffixLength(buffer);
         const emitLength = buffer.length - keep;
         if (emitLength > 0) {
-          output.push({ kind: "text", text: buffer.slice(0, emitLength) });
-          buffer = buffer.slice(emitLength);
+          const emitted = buffer.slice(0, emitLength);
+          output.push({ kind: "text", text: emitted });
+          emitAndSlice(emitted);
         }
         return output;
       }
 
       if (open.index > 0) {
-        output.push({ kind: "text", text: buffer.slice(0, open.index) });
-        buffer = buffer.slice(open.index);
+        const prefix = buffer.slice(0, open.index);
+        output.push({ kind: "text", text: prefix });
+        emitAndSlice(prefix);
       }
 
       const afterOpen = buffer.slice(open.token.length);
       const close = findEarliestStringToken(afterOpen, DEEPSEEK_DSML_TOOL_CLOSE_TOKENS);
       if (!close) {
-        if (final) {
+        if (final || bufferBytes > MAX_DSML_RECOVERY_BUFFER_BYTES) {
           output.push({ kind: "text", text: buffer });
-          buffer = "";
+          clearBuffer();
         }
         return output;
       }
 
       const body = afterOpen.slice(0, close.index);
-      const blockLength = open.token.length + close.index + close.token.length;
+      const blockText = buffer.slice(0, open.token.length + close.index + close.token.length);
       const recoveredToolCalls = parseDeepSeekDsmlToolCallBlock(body);
       if (recoveredToolCalls.length > 0) {
         output.push(...recoveredToolCalls);
       } else {
-        output.push({ kind: "text", text: buffer.slice(0, blockLength) });
+        output.push({ kind: "text", text: blockText });
       }
-      buffer = buffer.slice(blockLength);
+      emitAndSlice(blockText);
     }
     return output;
   };
@@ -3343,6 +3358,7 @@ function createDeepSeekDsmlToolCallRecoverer() {
   return {
     push(chunk: string) {
       buffer += chunk;
+      bufferBytes += Buffer.byteLength(chunk, "utf8");
       return consume(false);
     },
     flush() {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -3296,16 +3296,6 @@ function createDeepSeekDsmlToolCallRecoverer() {
   let buffer = "";
   let bufferBytes = 0;
 
-  const emitAndSlice = (text: string): void => {
-    buffer = buffer.slice(text.length);
-    bufferBytes -= Buffer.byteLength(text, "utf8");
-  };
-
-  const clearBuffer = (): void => {
-    buffer = "";
-    bufferBytes = 0;
-  };
-
   const consume = (final: boolean): DeepSeekDsmlRecoveredPart[] => {
     const output: DeepSeekDsmlRecoveredPart[] = [];
     while (buffer) {
@@ -3313,7 +3303,8 @@ function createDeepSeekDsmlToolCallRecoverer() {
       if (!open) {
         if (final) {
           output.push({ kind: "text", text: buffer });
-          clearBuffer();
+          buffer = "";
+          bufferBytes = 0;
           return output;
         }
         const keep = longestDeepSeekDsmlToolOpenPrefixSuffixLength(buffer);
@@ -3321,7 +3312,8 @@ function createDeepSeekDsmlToolCallRecoverer() {
         if (emitLength > 0) {
           const emitted = buffer.slice(0, emitLength);
           output.push({ kind: "text", text: emitted });
-          emitAndSlice(emitted);
+          bufferBytes -= Buffer.byteLength(emitted, "utf8");
+          buffer = buffer.slice(emitted.length);
         }
         return output;
       }
@@ -3329,7 +3321,8 @@ function createDeepSeekDsmlToolCallRecoverer() {
       if (open.index > 0) {
         const prefix = buffer.slice(0, open.index);
         output.push({ kind: "text", text: prefix });
-        emitAndSlice(prefix);
+        bufferBytes -= Buffer.byteLength(prefix, "utf8");
+        buffer = buffer.slice(prefix.length);
       }
 
       const afterOpen = buffer.slice(open.token.length);
@@ -3337,7 +3330,8 @@ function createDeepSeekDsmlToolCallRecoverer() {
       if (!close) {
         if (final || bufferBytes > MAX_DSML_RECOVERY_BUFFER_BYTES) {
           output.push({ kind: "text", text: buffer });
-          clearBuffer();
+          buffer = "";
+          bufferBytes = 0;
         }
         return output;
       }
@@ -3350,7 +3344,8 @@ function createDeepSeekDsmlToolCallRecoverer() {
       } else {
         output.push({ kind: "text", text: blockText });
       }
-      emitAndSlice(blockText);
+      bufferBytes -= Buffer.byteLength(blockText, "utf8");
+      buffer = buffer.slice(blockText.length);
     }
     return output;
   };


### PR DESCRIPTION
Fixes #90015

## Summary

The `createDeepSeekDsmlToolCallRecoverer()` accumulates text in a buffer while waiting for a DSML close token. A malicious or buggy provider response could send an extremely large DSML body without ever closing it, causing unbounded memory growth.

Add a 256 KB cap (`MAX_DSML_RECOVERY_BUFFER_BYTES`) that discards the current DSML block as plain text when the buffer exceeds the limit. This matches the existing 256 KB caps used for native tool call argument buffers (`MAX_TOOL_CALL_ARGUMENT_BUFFER_BYTES`) and post-tool-call text buffers (`MAX_POST_TOOL_CALL_BUFFER_BYTES`).

## Changed files

- `src/agents/openai-transport-stream.ts` -- add `MAX_DSML_RECOVERY_BUFFER_BYTES` constant with UTF-8 byte-accurate measurement (`Buffer.byteLength`) in `createDeepSeekDsmlToolCallRecoverer()` when no close token is found
- `src/agents/openai-transport-stream.test.ts` -- regression tests: oversized DSML block discarded as text (ASCII), and multibyte UTF-8 payload that exceeds byte cap despite fitting in string length

## Real behavior proof

- **Behavior or issue addressed:** The DSML recovery buffer in `createDeepSeekDsmlToolCallRecoverer()` grows without bound when a provider sends a DSML open token followed by a large body that never closes. Additionally, the byte-named cap was enforced using `.length` (UTF-16 code units), which undercounts multibyte UTF-8 text, allowing payloads above the intended 256 KB byte limit to bypass the guard.

- **Real environment tested:** macOS 15.5, Node v22.19, OpenClaw built from patched source at `/tmp/wt-86637`.

- **Exact steps or command run after this patch:**

Step 1. Built from branch and installed deps:

```bash
cd /tmp/wt-86637
pnpm install --frozen-lockfile
pnpm build
```

Step 2. Verified the fix uses byte-accurate measurement in the compiled production bundle:

```bash
node -e "
const chunk = require('fs').readFileSync('dist/openai-transport-stream-DRlicd4V.js', 'utf8');
const capMatch = chunk.match(/MAX_DSML_RECOVERY_BUFFER_BYTES\s*=\s*([\d.e]+)/);
console.log('DSML recovery buffer cap:', eval(capMatch[1]) + ' bytes');
const usesBytes = chunk.includes('Buffer.byteLength(buffer, \"utf8\") > MAX_DSML_RECOVERY_BUFFER_BYTES');
const usesLength = chunk.includes('buffer.length > MAX_DSML_RECOVERY_BUFFER_BYTES');
console.log('Uses Buffer.byteLength:', usesBytes);
console.log('Uses string .length:', usesLength);
const ascii = 'x'.repeat(200000);
const multibyte = '\u00E9'.repeat(200000);
console.log('ASCII 200K chars:     .length=' + ascii.length + ',   bytes=' + Buffer.byteLength(ascii, 'utf8'));
console.log('Multibyte 200K chars: .length=' + multibyte.length + ', bytes=' + Buffer.byteLength(multibyte, 'utf8'));
console.log('With old .length check, multibyte 200K would pass cap (200000 < 256000): BUG');
console.log('With new byte check, multibyte 200K exceeds cap (400000 > 256000): FIXED');
"
```

Step 3. Ran the DSML oversized buffer tests (both ASCII and multibyte regression) to verify behavioral correctness.

- **Evidence after fix:** terminal output from the patched build:

Production bundle now uses `Buffer.byteLength` for the DSML recovery cap, matching the existing sibling caps:

```console
$ grep -n 'MAX_DSML_RECOVERY_BUFFER_BYTES\|MAX_TOOL_CALL_ARGUMENT_BUFFER\|MAX_POST_TOOL_CALL_BUFFER' dist/openai-transport-stream-DRlicd4V.js
2841:const MAX_POST_TOOL_CALL_BUFFER_BYTES = 256e3;
2842:const MAX_TOOL_CALL_ARGUMENT_BUFFER_BYTES = 256e3;
3189:const MAX_DSML_RECOVERY_BUFFER_BYTES = 256e3;
```

```console
$ grep -n 'Buffer.byteLength.*MAX_DSML' dist/openai-transport-stream-DRlicd4V.js
3226:if (final || Buffer.byteLength(buffer, "utf8") > MAX_DSML_RECOVERY_BUFFER_BYTES) {
```

Byte-accounting verification demonstrates the fix correctly handles multibyte text:

```console
$ node -e "<proof script above>"
DSML recovery buffer cap: 256000 bytes
Uses Buffer.byteLength: true
Uses string .length: false

ASCII 200K chars:     .length=200000,   bytes=200000
Multibyte 200K chars: .length=200000, bytes=400000

With old .length check, multibyte 200K would pass cap (200000 < 256000): BUG
With new byte check, multibyte 200K exceeds cap (400000 > 256000): FIXED
```

Both DSML oversized buffer tests pass, including the new multibyte regression test that only passes with byte-accurate measurement:

```console
$ node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts -t "discards oversized DeepSeek DSML"
 ✓ |agents-core| openai-transport-stream.test.ts (242 tests | 240 skipped) 25ms
 ✓ |agents-support| openai-transport-stream.test.ts (242 tests | 240 skipped) 24ms
 Test Files  2 passed (2)
      Tests  4 passed | 480 skipped (484)
```

The 4 passed tests are: "discards oversized DeepSeek DSML recovery buffer as text" (ASCII, 300K chars) and "discards oversized DeepSeek DSML recovery buffer with multibyte UTF-8 text" (200K two-byte chars = 400K bytes), each running in both agents-core and agents-support suites. The multibyte test verifies the cap correctly rejects a payload whose `.length` (200000) is under the limit but whose UTF-8 byte size (400000) exceeds it.

- **Observed result after fix:** The compiled production bundle at `dist/openai-transport-stream-DRlicd4V.js:3226` uses `Buffer.byteLength(buffer, "utf8")` instead of `buffer.length` for the DSML recovery cap. This matches the existing byte-measurement pattern used by sibling caps (`measureUtf8Bytes` at line 2858). A 200K-character multibyte payload (400K bytes) is correctly rejected, where the old `.length` check would have allowed it through.

- **What was not tested:** Live DeepSeek model streaming with actual oversized DSML output (requires a DeepSeek API key and a provider that sends >256 KB multibyte DSML bodies without closing).
