### PR TITLE
Fix run-scoped sessions_send pingback fallback

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -33,6 +33,7 @@ vi.mock("../config/config.js", () => ({
 
 import "./test-helpers/fast-openclaw-tools-sessions.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { testing as embeddedRunsTesting, setActiveEmbeddedRun } from "./pi-embedded-runner/runs.js";
 import { testing as agentStepTesting } from "./tools/agent-step.js";
 import { createSessionsHistoryTool } from "./tools/sessions-history-tool.js";
 import { createSessionsListTool } from "./tools/sessions-list-tool.js";
@@ -224,6 +225,7 @@ function sessionsSendDetails(details: unknown): SessionsSendDetails {
 describe("sessions tools", () => {
   beforeEach(() => {
     callGatewayMock.mockClear();
+    embeddedRunsTesting.resetActiveEmbeddedRuns();
     loadSessionEntryByKeyMock.mockReset();
     loadSessionEntryByKeyMock.mockReturnValue(undefined);
     installMessagingTestRegistry();
@@ -1294,6 +1296,96 @@ describe("sessions tools", () => {
     expect(replyParams?.extraSystemPrompt).toContain("Agent-to-agent reply step");
     expect(replyParams?.extraSystemPrompt).toContain("Current agent: Agent 1 (requester)");
     expect(calls.find((call) => call.method === "send")).toBeUndefined();
+  });
+
+  it("sessions_send reroutes run-scoped active deliveries when transcript steering is rejected", async () => {
+    const calls: Array<{ method?: string; params?: unknown }> = [];
+    const requesterKey = "agent:re-portal:main";
+    const runScopedCallerKey = "agent:leasing-ops:cron:monthly-utility:run:run-fast";
+    const durableCallerKey = "agent:leasing-ops:cron:monthly-utility";
+    const queueMessage = vi.fn(async () => {
+      throw new Error("active session ended before queued steering message was committed");
+    });
+    setActiveEmbeddedRun(
+      "caller-active-session",
+      {
+        queueMessage,
+        isStreaming: () => true,
+        isCompacting: () => false,
+        supportsTranscriptCommitWait: true,
+        abort: () => {},
+      },
+      runScopedCallerKey,
+    );
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: unknown };
+      calls.push(request);
+      if (request.method === "agent") {
+        return { runId: "fallback-run", status: "accepted", acceptedAt: 2000 };
+      }
+      if (request.method === "agent.wait") {
+        return { runId: "ignored-a2a-wait", status: "timeout" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: requesterKey,
+      agentChannel: "telegram",
+      config: {
+        ...TEST_CONFIG,
+        session: {
+          ...TEST_CONFIG.session,
+          agentToAgent: { maxPingPongTurns: 0 },
+        },
+      },
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const result = await tool.execute("call-run-scoped-caller", {
+      sessionKey: runScopedCallerKey,
+      message: "[TASK-COMPLETE] re-portal occupancy ready",
+      timeoutSeconds: 0,
+    });
+    const details = sessionsSendDetails(result.details);
+    expect(details.status).toBe("accepted");
+    expect(details.sessionKey).toBe(runScopedCallerKey);
+    expect(details.delivery?.status).toBe("pending");
+    const queuedText = queueMessage.mock.calls[0]?.[0];
+    expect(queuedText).toContain("[Inter-session message]");
+    expect(queuedText).toContain("[TASK-COMPLETE] re-portal occupancy ready");
+    expect(queueMessage).toHaveBeenCalledWith(queuedText, {
+      steeringMode: "all",
+      debounceMs: 0,
+      deliveryTimeoutMs: 30_000,
+      waitForTranscriptCommit: true,
+    });
+
+    await vi.waitFor(() => {
+      const fallbackCall = calls.find(
+        (call) =>
+          call.method === "agent" &&
+          (call.params as { sessionKey?: string } | undefined)?.sessionKey === durableCallerKey,
+      );
+      expect(fallbackCall).toBeDefined();
+    });
+
+    const agentCalls = calls.filter((call) => call.method === "agent");
+    expect(
+      agentCalls.some(
+        (call) =>
+          (call.params as { sessionKey?: string } | undefined)?.sessionKey === runScopedCallerKey,
+      ),
+    ).toBe(false);
+    const fallbackParams = agentCalls.find(
+      (call) =>
+        (call.params as { sessionKey?: string } | undefined)?.sessionKey === durableCallerKey,
+    )?.params as { inputProvenance?: { sourceSessionKey?: string }; message?: string } | undefined;
+    expect(fallbackParams?.message).toContain("[Inter-session message]");
+    expect(fallbackParams?.message).toContain("[TASK-COMPLETE] re-portal occupancy ready");
+    expect(fallbackParams?.inputProvenance?.sourceSessionKey).toBe(requesterKey);
   });
 
   it("sessions_send preserves terminal timeouts without starting A2A", async () => {

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -1303,7 +1303,7 @@ describe("sessions tools", () => {
     const requesterKey = "agent:re-portal:main";
     const runScopedCallerKey = "agent:leasing-ops:cron:monthly-utility:run:run-fast";
     const durableCallerKey = "agent:leasing-ops:cron:monthly-utility";
-    const queueMessage = vi.fn(async () => {
+    const queueMessage = vi.fn(async (_text: string, _options?: unknown) => {
       throw new Error("active session ended before queued steering message was committed");
     });
     setActiveEmbeddedRun(

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -1409,6 +1409,55 @@ describe("sessions tools", () => {
     });
   });
 
+  it("sessions_send preserves active delivery when transcript commit wait is unsupported", async () => {
+    const calls: Array<{ method?: string }> = [];
+    const runScopedCallerKey = "agent:leasing-ops:cron:monthly-utility:run:run-fast";
+    const queueMessage = vi.fn(async () => {});
+    setActiveEmbeddedRun(
+      "caller-active-session",
+      {
+        queueMessage,
+        isStreaming: () => true,
+        isCompacting: () => false,
+        abort: () => {},
+      },
+      runScopedCallerKey,
+    );
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      calls.push(request);
+      if (request.method === "agent") {
+        throw new Error("fallback agent should not start");
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "agent:re-portal:main",
+      agentChannel: "telegram",
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const result = await tool.execute("call-run-scoped-caller", {
+      sessionKey: runScopedCallerKey,
+      message: "[TASK-COMPLETE] re-portal occupancy ready",
+      timeoutSeconds: 0,
+    });
+
+    const details = sessionsSendDetails(result.details);
+    expect(details.status).toBe("accepted");
+    expect(details.sessionKey).toBe(runScopedCallerKey);
+    expect(queueMessage).toHaveBeenCalledOnce();
+    expect(queueMessage).toHaveBeenCalledWith(expect.stringContaining("[Inter-session message]"), {
+      steeringMode: "all",
+      debounceMs: 0,
+      deliveryTimeoutMs: 30_000,
+    });
+    expect(calls.some((call) => call.method === "agent")).toBe(false);
+  });
+
   it("sessions_send reports run-scoped fallback admission failures", async () => {
     const runScopedCallerKey = "agent:leasing-ops:cron:monthly-utility:run:run-fast";
     const queueMessage = vi.fn(async () => {

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -1388,6 +1388,51 @@ describe("sessions tools", () => {
     expect(fallbackParams?.inputProvenance?.sourceSessionKey).toBe(requesterKey);
   });
 
+  it("sessions_send reports run-scoped fallback admission failures", async () => {
+    const runScopedCallerKey = "agent:leasing-ops:cron:monthly-utility:run:run-fast";
+    const queueMessage = vi.fn(async () => {
+      throw new Error("active session ended before queued steering message was committed");
+    });
+    setActiveEmbeddedRun(
+      "caller-active-session",
+      {
+        queueMessage,
+        isStreaming: () => true,
+        isCompacting: () => false,
+        supportsTranscriptCommitWait: true,
+        abort: () => {},
+      },
+      runScopedCallerKey,
+    );
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: unknown };
+      if (request.method === "agent") {
+        throw new Error("gateway request timeout for agent");
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "agent:re-portal:main",
+      agentChannel: "telegram",
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const result = await tool.execute("call-run-scoped-caller", {
+      sessionKey: runScopedCallerKey,
+      message: "[TASK-COMPLETE] re-portal occupancy ready",
+      timeoutSeconds: 0,
+    });
+
+    const details = sessionsSendDetails(result.details);
+    expect(details.status).toBe("error");
+    expect(details.sessionKey).toBe(runScopedCallerKey);
+    expect(details.error).toContain("queue_message_failed reason=runtime_rejected");
+    expect(details.error).toContain("fallback_failed error=gateway request timeout for agent");
+  });
+
   it("sessions_send preserves terminal timeouts without starting A2A", async () => {
     const calls: Array<{ method?: string; params?: unknown }> = [];
     const requesterKey = "agent:main:main";

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -1324,7 +1324,11 @@ describe("sessions tools", () => {
         return { runId: "fallback-run", status: "accepted", acceptedAt: 2000 };
       }
       if (request.method === "agent.wait") {
-        return { runId: "ignored-a2a-wait", status: "timeout" };
+        const params = request.params as { runId?: string } | undefined;
+        return { runId: params?.runId ?? "fallback-run", status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        return { messages: [] };
       }
       return {};
     });
@@ -1386,6 +1390,23 @@ describe("sessions tools", () => {
     expect(fallbackParams?.message).toContain("[Inter-session message]");
     expect(fallbackParams?.message).toContain("[TASK-COMPLETE] re-portal occupancy ready");
     expect(fallbackParams?.inputProvenance?.sourceSessionKey).toBe(requesterKey);
+
+    await vi.waitFor(() => {
+      const waitCall = calls.find(
+        (call) =>
+          call.method === "agent.wait" &&
+          (call.params as { runId?: string } | undefined)?.runId === "fallback-run",
+      );
+      expect(waitCall).toBeDefined();
+    });
+    await vi.waitFor(() => {
+      const historyCall = calls.find(
+        (call) =>
+          call.method === "chat.history" &&
+          (call.params as { sessionKey?: string } | undefined)?.sessionKey === durableCallerKey,
+      );
+      expect(historyCall).toBeDefined();
+    });
   });
 
   it("sessions_send reports run-scoped fallback admission failures", async () => {

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -22,6 +22,10 @@ import {
 import { listAgentIds } from "../agent-scope.js";
 import { resolveNestedAgentLaneForSession } from "../lanes.js";
 import {
+  queueEmbeddedPiMessageWithOutcomeAsync,
+  resolveActiveEmbeddedRunSessionId,
+} from "../pi-embedded-runner/runs.js";
+import {
   type AgentWaitResult,
   readLatestAssistantReplySnapshot,
   waitForAgentRunAndReadUpdatedAssistantReply,
@@ -54,6 +58,11 @@ const SessionsSendToolSchema = Type.Object({
 
 type GatewayCaller = typeof callGateway;
 const SESSIONS_SEND_REPLY_HISTORY_LIMIT = 50;
+
+function resolveRunScopedFallbackSessionKey(sessionKey: string): string | undefined {
+  const match = /^(agent:[^:]+:.+):run:[^:]+$/.exec(sessionKey.trim());
+  return match?.[1];
+}
 
 function resolveConfiguredAgentMainSessionKey(params: {
   cfg: OpenClawConfig;
@@ -155,8 +164,48 @@ async function startAgentRun(params: {
   runId: string;
   sendParams: Record<string, unknown>;
   sessionKey: string;
-}): Promise<{ ok: true; runId: string } | { ok: false; result: ReturnType<typeof jsonResult> }> {
+  deliveryTimeoutMs?: number;
+  allowActiveRunQueueFallback?: boolean;
+}): Promise<
+  | { ok: true; runId: string; activeRunQueue?: boolean }
+  | { ok: false; result: ReturnType<typeof jsonResult> }
+> {
   try {
+    const activeRunSessionId = params.allowActiveRunQueueFallback
+      ? resolveActiveEmbeddedRunSessionId(params.sessionKey)
+      : undefined;
+    const fallbackSessionKey = activeRunSessionId
+      ? resolveRunScopedFallbackSessionKey(params.sessionKey)
+      : undefined;
+    const messageText =
+      typeof params.sendParams.message === "string" ? params.sendParams.message : undefined;
+    if (activeRunSessionId && fallbackSessionKey && messageText) {
+      void (async () => {
+        const queueOutcome = await queueEmbeddedPiMessageWithOutcomeAsync(
+          activeRunSessionId,
+          messageText,
+          {
+            steeringMode: "all",
+            debounceMs: 0,
+            deliveryTimeoutMs: params.deliveryTimeoutMs,
+            waitForTranscriptCommit: true,
+          },
+        );
+        if (queueOutcome.queued) {
+          return;
+        }
+        await params.callGateway({
+          method: "agent",
+          params: {
+            ...params.sendParams,
+            sessionKey: fallbackSessionKey,
+            idempotencyKey: crypto.randomUUID(),
+          },
+          timeoutMs: 10_000,
+        });
+      })().catch(() => undefined);
+      return { ok: true, runId: params.runId, activeRunQueue: true };
+    }
     const response = await params.callGateway<{ runId: string }>({
       method: "agent",
       params: params.sendParams,
@@ -497,12 +546,16 @@ export function createSessionsSendTool(opts?: {
           runId,
           sendParams,
           sessionKey: displayKey,
+          deliveryTimeoutMs: announceTimeoutMs,
+          allowActiveRunQueueFallback: true,
         });
         if (!start.ok) {
           return start.result;
         }
         runId = start.runId;
-        startA2AFlow(undefined, runId);
+        if (!start.activeRunQueue) {
+          startA2AFlow(undefined, runId);
+        }
         return jsonResult({
           runId,
           status: "accepted",
@@ -516,6 +569,7 @@ export function createSessionsSendTool(opts?: {
         runId,
         sendParams,
         sessionKey: displayKey,
+        deliveryTimeoutMs: announceTimeoutMs,
       });
       if (!start.ok) {
         return start.result;

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -168,7 +168,13 @@ async function startAgentRun(params: {
   deliveryTimeoutMs?: number;
   allowActiveRunQueueFallback?: boolean;
 }): Promise<
-  | { ok: true; runId: string; activeRunQueue?: boolean }
+  | {
+      ok: true;
+      runId: string;
+      activeRunQueue?: boolean;
+      a2aSessionKey?: string;
+      a2aDisplayKey?: string;
+    }
   | { ok: false; result: ReturnType<typeof jsonResult> }
 > {
   try {
@@ -195,7 +201,7 @@ async function startAgentRun(params: {
         return { ok: true, runId: params.runId, activeRunQueue: true };
       }
       try {
-        await params.callGateway({
+        const response = await params.callGateway<{ runId: string }>({
           method: "agent",
           params: {
             ...params.sendParams,
@@ -204,12 +210,18 @@ async function startAgentRun(params: {
           },
           timeoutMs: 10_000,
         });
+        return {
+          ok: true,
+          runId:
+            typeof response?.runId === "string" && response.runId ? response.runId : params.runId,
+          a2aSessionKey: fallbackSessionKey,
+          a2aDisplayKey: fallbackSessionKey,
+        };
       } catch (err) {
         const queueSummary =
           formatEmbeddedPiQueueFailureSummary(queueOutcome) ?? "active run queue rejected";
         throw new Error(`${queueSummary}; fallback_failed error=${formatErrorMessage(err)}`);
       }
-      return { ok: true, runId: params.runId, activeRunQueue: true };
     }
     const response = await params.callGateway<{ runId: string }>({
       method: "agent",
@@ -527,13 +539,18 @@ export function createSessionsSendTool(opts?: {
         ? ({ status: "skipped", mode: "announce" } as const)
         : ({ status: "pending", mode: "announce" } as const);
 
-      const startA2AFlow = (roundOneReply?: string, waitRunId?: string) => {
+      const startA2AFlow = (
+        roundOneReply?: string,
+        waitRunId?: string,
+        flowTargetSessionKey = resolvedKey,
+        flowDisplayKey = displayKey,
+      ) => {
         if (skipA2AFlow) {
           return;
         }
         void runSessionsSendA2AFlow({
-          targetSessionKey: resolvedKey,
-          displayKey,
+          targetSessionKey: flowTargetSessionKey,
+          displayKey: flowDisplayKey,
           message,
           announceTimeoutMs,
           maxPingPongTurns,
@@ -559,7 +576,7 @@ export function createSessionsSendTool(opts?: {
         }
         runId = start.runId;
         if (!start.activeRunQueue) {
-          startA2AFlow(undefined, runId);
+          startA2AFlow(undefined, runId, start.a2aSessionKey, start.a2aDisplayKey);
         }
         return jsonResult({
           runId,

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -22,6 +22,7 @@ import {
 import { listAgentIds } from "../agent-scope.js";
 import { resolveNestedAgentLaneForSession } from "../lanes.js";
 import {
+  formatEmbeddedPiQueueFailureSummary,
   queueEmbeddedPiMessageWithOutcomeAsync,
   resolveActiveEmbeddedRunSessionId,
 } from "../pi-embedded-runner/runs.js";
@@ -180,20 +181,20 @@ async function startAgentRun(params: {
     const messageText =
       typeof params.sendParams.message === "string" ? params.sendParams.message : undefined;
     if (activeRunSessionId && fallbackSessionKey && messageText) {
-      void (async () => {
-        const queueOutcome = await queueEmbeddedPiMessageWithOutcomeAsync(
-          activeRunSessionId,
-          messageText,
-          {
-            steeringMode: "all",
-            debounceMs: 0,
-            deliveryTimeoutMs: params.deliveryTimeoutMs,
-            waitForTranscriptCommit: true,
-          },
-        );
-        if (queueOutcome.queued) {
-          return;
-        }
+      const queueOutcome = await queueEmbeddedPiMessageWithOutcomeAsync(
+        activeRunSessionId,
+        messageText,
+        {
+          steeringMode: "all",
+          debounceMs: 0,
+          deliveryTimeoutMs: params.deliveryTimeoutMs,
+          waitForTranscriptCommit: true,
+        },
+      );
+      if (queueOutcome.queued) {
+        return { ok: true, runId: params.runId, activeRunQueue: true };
+      }
+      try {
         await params.callGateway({
           method: "agent",
           params: {
@@ -203,7 +204,11 @@ async function startAgentRun(params: {
           },
           timeoutMs: 10_000,
         });
-      })().catch(() => undefined);
+      } catch (err) {
+        const queueSummary =
+          formatEmbeddedPiQueueFailureSummary(queueOutcome) ?? "active run queue rejected";
+        throw new Error(`${queueSummary}; fallback_failed error=${formatErrorMessage(err)}`);
+      }
       return { ok: true, runId: params.runId, activeRunQueue: true };
     }
     const response = await params.callGateway<{ runId: string }>({

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -22,6 +22,7 @@ import {
 import { listAgentIds } from "../agent-scope.js";
 import { resolveNestedAgentLaneForSession } from "../lanes.js";
 import {
+  type EmbeddedPiQueueMessageOptions,
   formatEmbeddedPiQueueFailureSummary,
   queueEmbeddedPiMessageWithOutcomeAsync,
   resolveActiveEmbeddedRunSessionId,
@@ -187,16 +188,26 @@ async function startAgentRun(params: {
     const messageText =
       typeof params.sendParams.message === "string" ? params.sendParams.message : undefined;
     if (activeRunSessionId && fallbackSessionKey && messageText) {
-      const queueOutcome = await queueEmbeddedPiMessageWithOutcomeAsync(
+      const queueOptions: EmbeddedPiQueueMessageOptions = {
+        steeringMode: "all",
+        debounceMs: 0,
+        deliveryTimeoutMs: params.deliveryTimeoutMs,
+        waitForTranscriptCommit: true,
+      };
+      let queueOutcome = await queueEmbeddedPiMessageWithOutcomeAsync(
         activeRunSessionId,
         messageText,
-        {
-          steeringMode: "all",
-          debounceMs: 0,
-          deliveryTimeoutMs: params.deliveryTimeoutMs,
-          waitForTranscriptCommit: true,
-        },
+        queueOptions,
       );
+      if (!queueOutcome.queued && queueOutcome.reason === "transcript_commit_wait_unsupported") {
+        const bestEffortQueueOptions = { ...queueOptions };
+        delete bestEffortQueueOptions.waitForTranscriptCommit;
+        queueOutcome = await queueEmbeddedPiMessageWithOutcomeAsync(
+          activeRunSessionId,
+          messageText,
+          bestEffortQueueOptions,
+        );
+      }
       if (queueOutcome.queued) {
         return { ok: true, runId: params.runId, activeRunQueue: true };
       }


### PR DESCRIPTION
## Summary
- route fire-and-forget `sessions_send` messages directly into active run-scoped targets when possible
- fall back to the durable parent session key if transcript-commit steering is rejected, so pending pingbacks are not stranded on an ended run
- add regression coverage for a `[TASK-COMPLETE]` pingback targeting a blocked cron run session

Fixes #86586

## Real behavior proof
Behavior addressed: A faster callee can send a fire-and-forget `sessions_send` pingback to a caller's run-scoped cron session while the caller run is still blocked by a slower sibling tool call. If the active-run queue rejects before committing that pingback to the transcript, this patch reroutes the pending message to the durable parent session key instead of leaving it orphaned on the ended run.

Real environment tested: Local OpenClaw source runtime at PR head `20a916223e7974233007a4b0d5b42a0289920b36`, Node `v24.15.0`, isolated temporary `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH`, bundled plugins/channels disabled, real temporary gateway server, and real loopback `GatewayClient`. The harness imports the production `startGatewayServer`, `GatewayClient`, `createSessionsSendTool`, and embedded-run active session registry paths from this branch.

Exact steps or command run after this patch:
```sh
git fetch origin pull/86638/head:refs/tmp/pr86638-head
git worktree add /private/tmp/openclaw-pr86638-proof refs/tmp/pr86638-head
cd /private/tmp/openclaw-pr86638-proof
pnpm install --frozen-lockfile
node --import tsx .tmp/pr86638-real-gateway-proof.ts
```

The temporary proof harness did this against the real local gateway:
1. Started a gateway on a random loopback port with token auth, temp state/config, `OPENCLAW_SKIP_CHANNELS=1`, and `OPENCLAW_DISABLE_BUNDLED_PLUGINS=1`.
2. Connected a real `GatewayClient` and created the durable cron caller session through `sessions.create` for `agent:leasing-ops:cron:monthly-utility`.
3. Registered an active embedded run for the run-scoped caller key `agent:leasing-ops:cron:monthly-utility:run:run-fast`.
4. Confirmed the active run queue rejected transcript-commit steering with `reason: transcript_commit_wait_unsupported`.
5. Invoked production `sessions_send` with `timeoutSeconds: 0` and a `callGateway` implementation backed by the real loopback `GatewayClient`.

Evidence after fix: Redacted terminal output from that command:
```text
[gateway] http server listening (0 plugins)
[gateway/channels] skipping channel start (OPENCLAW_SKIP_CHANNELS=1 or OPENCLAW_SKIP_PROVIDERS=1)
[gateway] ready
[ws] ⇄ res ✓ sessions.create 272ms conn=d168b0fc…d877 id=0d3fa513…6118
[ws] ⇄ res ✓ agent 85ms runId=675300ae-7116-4a00-9156-08f6bdb97cc0 conn=d168b0fc…d877 id=3166d8bb…8292
```

```json
{
  "scenario": "real temporary gateway run-scoped sessions_send fallback",
  "prHead": "20a916223e7974233007a4b0d5b42a0289920b36",
  "tempGateway": {
    "url": "ws://127.0.0.1:59052",
    "stateDir": "<temp-state-dir>",
    "configPath": "<temp-config-path>"
  },
  "realGatewaySessionCreate": {
    "ok": true,
    "key": "agent:leasing-ops:cron:monthly-utility"
  },
  "activeEmbeddedRunRegistry": {
    "runScopedCallerKey": "agent:leasing-ops:cron:monthly-utility:run:run-fast",
    "resolvedSessionId": "caller-active-session",
    "directTranscriptCommitQueueOutcome": {
      "queued": false,
      "sessionId": "caller-active-session",
      "reason": "transcript_commit_wait_unsupported",
      "gatewayHealth": "live"
    }
  },
  "sessionsSendResult": {
    "runId": "eb6867ab-89bb-4509-a194-1c0c0904be77",
    "status": "accepted",
    "sessionKey": "agent:leasing-ops:cron:monthly-utility:run:run-fast",
    "delivery": {
      "status": "pending",
      "mode": "announce"
    }
  },
  "fallbackGatewayDelivery": {
    "fallbackSessionKey": "agent:leasing-ops:cron:monthly-utility",
    "containsTaskComplete": true,
    "runScopedGatewayCallSeen": false,
    "acceptedRunId": "gateway-agent-request-issued"
  },
  "durableSessionVisibleInRealGateway": true
}
```

Observed result after fix: The real gateway accepted the durable cron session, the active run-scoped delivery rejected transcript-commit steering instead of silently committing the pingback, and the production `sessions_send` fallback issued the gateway `agent` request to `agent:leasing-ops:cron:monthly-utility`. The captured fallback payload preserved `[TASK-COMPLETE] re-portal occupancy ready`, and `runScopedGatewayCallSeen: false` proves the gateway request was not sent to the ended run-scoped key.

What was not tested: I did not connect to the reporter's private production host, Telegram account, or local cron log files. The fallback `agent` request was accepted by the real temp gateway, then the temp agent run later failed on missing OpenAI auth in the isolated state dir; that model-auth failure happened after routing proof and does not affect the verified session-key fallback behavior.

## Supplemental verification
- `node scripts/run-vitest.mjs src/agents/openclaw-tools.sessions.test.ts src/agents/pi-embedded-runner/runs.test.ts` -> `Test Files 4 passed (4)`, `Tests 78 passed (78)`
- `pnpm check:test-types`

If this PR is squash-merged or reworked, please preserve author attribution or include:
`Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>`