### PR TITLE
fix(control-ui): keep raw mode for editable config snapshots

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1198,7 +1198,10 @@ export function renderApp(state: AppViewState) {
     gatewayUrl: state.settings.gatewayUrl,
     assistantName: state.assistantName,
     configPath: state.configSnapshot?.path ?? null,
-    rawAvailable: typeof state.configSnapshot?.raw === "string",
+    rawAvailable:
+      typeof state.configSnapshot?.raw === "string" ||
+      !!state.configSnapshot?.config ||
+      !!state.configForm,
   } satisfies Omit<
     ConfigProps,
     | "formMode"

--- a/ui/src/ui/controllers/config.test.ts
+++ b/ui/src/ui/controllers/config.test.ts
@@ -183,7 +183,7 @@ describe("applyConfigSnapshot", () => {
     expect(state.configDraftBaseHash).toBe("hash-remote");
   });
 
-  it("forces form mode when the snapshot does not include raw text", () => {
+  it("keeps raw mode when editable config can be serialized without raw text", () => {
     const state = createState();
     state.configFormMode = "raw";
 
@@ -195,7 +195,7 @@ describe("applyConfigSnapshot", () => {
       raw: null,
     });
 
-    expect(state.configFormMode).toBe("form");
+    expect(state.configFormMode).toBe("raw");
     expect(state.configRaw).toBe('{\n  "gateway": {\n    "mode": "local"\n  }\n}\n');
   });
 });

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -113,7 +113,7 @@ export function applyConfigSnapshot(
   const draftBaseHash = state.configDraftBaseHash ?? state.configSnapshot?.hash ?? null;
   state.configSnapshot = snapshot;
   const editableConfig = resolveEditableSnapshotConfig(snapshot);
-  const rawAvailable = typeof snapshot.raw === "string";
+  const rawAvailable = typeof snapshot.raw === "string" || !!editableConfig || !!state.configForm;
   if (!rawAvailable && state.configFormMode === "raw") {
     state.configFormMode = "form";
   }


### PR DESCRIPTION
## What changed

- Keeps the Control UI raw config mode available when a config snapshot has editable structured config but no raw text payload.
- Uses the same raw availability rule in both the renderer props and config controller state transition.
- Updates the config controller test so snapshots with serializable config stay in raw mode instead of being forced back to form mode.

## Why

The gateway can return snapshots where `raw` is missing or null while structured config is still available through `sourceConfig`, `resolved`, or `config`. The controller already serializes that editable config into `configRaw`, so treating raw mode as unavailable solely because `snapshot.raw` is absent hides a mode that can still be rendered from structured config.

This fixes the UI/control-state mismatch without changing behavior for snapshots that truly have neither raw text nor editable structured config.

## Real behavior proof

- **Behavior or issue addressed**: The live Control UI keeps Raw config mode available when the gateway snapshot has editable structured config but no raw string.
- **Real environment tested**: WSL Ubuntu 24.04 local OpenClaw setup, `OpenClaw 2026.5.25`, token-authenticated Control UI at `http://127.0.0.1:18789/config`, backed by running OpenClaw gateway processes from `/home/icon/CodexOps/OpenClaw/dist/index.js`.
- **Exact steps or command run after this patch**: Loaded the token-authenticated Control UI in headless Chrome, opened Settings -> Advanced, selected Raw, and inspected the live `openclaw-app` state plus the rendered tab buttons.
- **Evidence after fix**:

```text
title=OpenClaw Control
url=http://127.0.0.1:18789/config
containsConfig=true
live state: snapshotRawIsString=false, snapshotRawType=object, hasSourceConfig=true, hasConfig=true, generatedRawLength=25322
rendered buttons: Form disabled=false, Raw disabled=false, Save disabled=true, Apply disabled=true
```

- **Observed result after fix**: Raw mode was selectable on the live Settings page even though the snapshot did not contain raw text; the UI used generated raw text from the editable config instead of forcing the user back to Form mode.
- **What was not tested**: The generated-raw Save submit path is covered separately in #86641.

## Validation

- `pnpm --dir ui test src/ui/controllers/config.test.ts`
