### PR TITLE
fix(control-ui): save generated raw config text

### DIFF
--- a/ui/src/ui/controllers/config.test.ts
+++ b/ui/src/ui/controllers/config.test.ts
@@ -707,6 +707,29 @@ describe("applyConfig", () => {
 });
 
 describe("saveConfig", () => {
+  it("submits generated raw text when raw mode has no snapshot raw text", async () => {
+    const request = createRequestWithConfigGet();
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+    state.configFormMode = "raw";
+    state.configRaw = '{\n  "gateway": {\n    "mode": "local"\n  }\n}\n';
+    state.configSnapshot = {
+      hash: "hash-generated-raw",
+      sourceConfig: { gateway: { mode: "local" } },
+      valid: true,
+      issues: [],
+      raw: null,
+    };
+
+    await saveConfig(state);
+
+    expect(request).toHaveBeenCalledWith("config.set", {
+      raw: '{\n  "gateway": {\n    "mode": "local"\n  }\n}\n',
+      baseHash: "hash-generated-raw",
+    });
+  });
+
   it("submits the original draft base hash after a dirty config refresh", async () => {
     const request = createRequestWithConfigGet();
     const state = createState();

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -161,9 +161,6 @@ function asJsonSchema(value: unknown): JsonSchema | null {
  * gateway's Zod validation always sees correctly typed values.
  */
 function serializeFormForSubmit(state: ConfigState): string {
-  if (state.configFormMode === "raw" && typeof state.configSnapshot?.raw !== "string") {
-    throw new Error("Raw config editing is unavailable for this snapshot. Switch to Form mode.");
-  }
   if (state.configFormMode !== "form" || !state.configForm) {
     return state.configRaw;
   }


### PR DESCRIPTION
## What changed

- Removes the save-time rejection for raw mode when the current snapshot did not include original raw text.
- Adds a controller test proving `saveConfig` submits the already-generated raw config text with the snapshot base hash.

## Why

`applyConfigSnapshot` can populate `configRaw` by serializing editable structured config when `snapshot.raw` is absent. Once that generated raw text exists, the save path should submit it like any other raw draft.

The previous guard checked only whether the snapshot originally contained raw text. That rejected a valid generated raw draft even though `configRaw` already held the text that should be saved.

## Real behavior proof

- **Behavior or issue addressed**: A live Control UI raw draft generated from structured config submits through `config.set` even when the snapshot did not include raw text.
- **Real environment tested**: WSL Ubuntu 24.04 local OpenClaw setup, `OpenClaw 2026.5.25`, token-authenticated Control UI at `http://127.0.0.1:18789/config`, backed by running OpenClaw gateway processes from `/home/icon/CodexOps/OpenClaw/dist/index.js`.
- **Exact steps or command run after this patch**: Loaded the token-authenticated Control UI in headless Chrome, opened Settings -> Advanced -> Raw, confirmed the live snapshot had no raw string, staged a raw-mode draft in the page, clicked Save, and intercepted the browser client request to inspect the outgoing payload without mutating the real config file.
- **Evidence after fix**:

```text
livePageBefore={"mode":"raw","snapshotRawIsString":false,"snapshotRawType":"object","hasSourceConfig":true,"hasConfig":true,"generatedRawLength":25322,"hashPrefix":"78b0f6f64637"}
capturedRequests=[{"method":"config.set","rawLength":25323,"rawPrefix":"{\n  \"meta\": {\n    \"lastTouchedVersion\": ","baseHashMatches":true},{"method":"config.get","rawLength":null,"rawPrefix":null,"baseHashMatches":false}]
```

- **Observed result after fix**: Clicking Save in raw mode produced a `config.set` request containing generated raw text and the live snapshot base hash even though `snapshot.raw` was not a string. The request was intercepted only to avoid modifying the local operator config during proof capture.
- **What was not tested**: No live config file write was allowed during proof capture; the payload and base hash were verified before network mutation.

## Validation

- `pnpm --dir ui test src/ui/controllers/config.test.ts`
