### PR TITLE
perf: reduce runtime cache churn

### DIFF
--- a/src/config/sessions.cache.test.ts
+++ b/src/config/sessions.cache.test.ts
@@ -235,7 +235,7 @@ describe("Session Store Cache", () => {
     structuredCloneSpy.mockRestore();
   });
 
-  it("does not parse serialized stores when writing the cache", () => {
+  it("does not parse serialized stores when writing or reading object-cache hits", () => {
     const testStore = createSingleSessionStore(
       createSessionEntry({
         origin: { provider: "openai" },
@@ -252,9 +252,24 @@ describe("Session Store Cache", () => {
     const cached = readSessionStoreCache({ storePath });
 
     expect(cached?.["session:1"].origin?.provider).toBe("openai");
-    expect(parseSpy).toHaveBeenCalledTimes(1);
+    expect(parseSpy).not.toHaveBeenCalled();
 
     parseSpy.mockRestore();
+  });
+
+  it("clones cached session records without invoking prototype setters", () => {
+    const testStore = JSON.parse(
+      `{"session:1":{"sessionId":"id-1","updatedAt":${Date.now()},"displayName":"Test Session 1","__proto__":{"polluted":true}}}`,
+    ) as Record<string, SessionEntry>;
+
+    writeSessionStoreCache({ storePath, store: testStore });
+    const cached = readSessionStoreCache({ storePath });
+    const entry = cached?.["session:1"] as (SessionEntry & { polluted?: boolean }) | undefined;
+
+    expect(entry).toBeDefined();
+    expect(entry?.polluted).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(entry, "__proto__")).toBe(true);
+    expect(Object.prototype).not.toHaveProperty("polluted");
   });
 
   it("clones disk-loaded stores from the raw serialized JSON", () => {

--- a/src/config/sessions.cache.test.ts
+++ b/src/config/sessions.cache.test.ts
@@ -173,6 +173,16 @@ describe("Session Store Cache", () => {
     parseSpy.mockRestore();
   });
 
+  it("keeps disk-loaded clone:false cache hits by reference", () => {
+    const testStore = createSingleSessionStore();
+    fs.writeFileSync(storePath, JSON.stringify(testStore), "utf8");
+
+    const loaded1 = loadSessionStore(storePath, { clone: false });
+    const loaded2 = loadSessionStore(storePath, { clone: false });
+
+    expect(loaded2["session:1"]).toBe(loaded1["session:1"]);
+  });
+
   it("does not cache pre-migration or pre-normalization disk JSON", () => {
     fs.writeFileSync(
       storePath,

--- a/src/config/sessions/store-cache.ts
+++ b/src/config/sessions/store-cache.ts
@@ -179,7 +179,10 @@ export function cloneSessionStoreRecord(
   store: Record<string, SessionEntry>,
   serialized?: string,
 ): Record<string, SessionEntry> {
-  const cloned = JSON.parse(serialized ?? JSON.stringify(store)) as Record<string, SessionEntry>;
+  const cloned =
+    serialized === undefined
+      ? cloneJsonLikeValue(store)
+      : (JSON.parse(serialized) as Record<string, SessionEntry>);
   internSessionStoreLargeStrings(cloned);
   return cloned;
 }
@@ -193,7 +196,12 @@ function cloneJsonLikeValue<T>(value: T): T {
   }
   const cloned: Record<string, unknown> = {};
   for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
-    cloned[key] = cloneJsonLikeValue(child);
+    Object.defineProperty(cloned, key, {
+      value: cloneJsonLikeValue(child),
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
   }
   return cloned as T;
 }
@@ -342,7 +350,7 @@ export function readSessionStoreCache(params: {
   if (params.clone === false) {
     return cached.store;
   }
-  return cloneSessionStoreRecord(cached.store, cached.serialized);
+  return cloneSessionStoreRecord(cached.store);
 }
 
 export function takeMutableSessionStoreCache(params: {
@@ -369,11 +377,7 @@ export function writeSessionStoreCache(params: {
   sizeBytes?: number;
   serialized?: string;
 }): void {
-  const store =
-    params.serialized === undefined ? cloneSessionStoreRecord(params.store) : params.store;
-  if (params.serialized !== undefined) {
-    internSessionStoreLargeStrings(store);
-  }
+  const store = cloneSessionStoreRecord(params.store);
   SESSION_STORE_CACHE.set(params.storePath, {
     store,
     mtimeMs: params.mtimeMs,

--- a/src/config/sessions/store-cache.ts
+++ b/src/config/sessions/store-cache.ts
@@ -376,8 +376,13 @@ export function writeSessionStoreCache(params: {
   mtimeMs?: number;
   sizeBytes?: number;
   serialized?: string;
+  takeOwnership?: boolean;
 }): void {
-  const store = cloneSessionStoreRecord(params.store);
+  const store =
+    params.takeOwnership === true ? params.store : cloneSessionStoreRecord(params.store);
+  if (params.takeOwnership === true) {
+    internSessionStoreLargeStrings(store);
+  }
   SESSION_STORE_CACHE.set(params.storePath, {
     store,
     mtimeMs: params.mtimeMs,

--- a/src/config/sessions/store-load.ts
+++ b/src/config/sessions/store-load.ts
@@ -448,6 +448,7 @@ export function loadSessionStore(
       mtimeMs,
       sizeBytes: fileStat?.sizeBytes,
       serialized: serializedFromDisk,
+      takeOwnership: serializedFromDisk !== undefined,
     });
   }
 

--- a/src/plugins/manifest-model-id-normalization.test.ts
+++ b/src/plugins/manifest-model-id-normalization.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   clearCurrentPluginMetadataSnapshot,
   resolvePluginMetadataControlPlaneFingerprint,
@@ -11,6 +12,7 @@ import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";
 import { listOpenClawPluginManifestMetadata } from "./manifest-metadata-scan.js";
 import { normalizeProviderModelIdWithManifest } from "./manifest-model-id-normalization.js";
+import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "./runtime.js";
@@ -87,8 +89,10 @@ function createCurrentSnapshot(params: {
   manifestHash: string;
   prefix: string;
   workspaceDir?: string;
+  config?: OpenClawConfig;
 }): PluginMetadataSnapshot {
-  const policyHash = resolveInstalledPluginIndexPolicyHash({});
+  const config = params.config ?? {};
+  const policyHash = resolveInstalledPluginIndexPolicyHash(config);
   const index: InstalledPluginIndex = {
     version: 1,
     hostContractVersion: "test-host",
@@ -119,15 +123,12 @@ function createCurrentSnapshot(params: {
   };
   return {
     policyHash,
-    configFingerprint: resolvePluginMetadataControlPlaneFingerprint(
-      {},
-      {
-        env: process.env,
-        index,
-        policyHash,
-        workspaceDir: params.workspaceDir,
-      },
-    ),
+    configFingerprint: resolvePluginMetadataControlPlaneFingerprint(config, {
+      env: process.env,
+      index,
+      policyHash,
+      workspaceDir: params.workspaceDir,
+    }),
     workspaceDir: params.workspaceDir,
     index,
     registryDiagnostics: [],
@@ -149,6 +150,17 @@ function createCurrentSnapshot(params: {
 function normalizeDemoModel(modelId = "demo-model"): string | undefined {
   return normalizeProviderModelIdWithManifest({
     provider: "demo",
+    context: { provider: "demo", modelId },
+  });
+}
+
+function normalizeDemoModelWithEnv(
+  env: NodeJS.ProcessEnv,
+  modelId = "demo-model",
+): string | undefined {
+  return normalizeProviderModelIdWithManifest({
+    provider: "demo",
+    env,
     context: { provider: "demo", modelId },
   });
 }
@@ -234,6 +246,45 @@ describe("manifest model id normalization", () => {
     expect(normalizeDemoModel()).toBe("alpha/demo-model");
   });
 
+  it("reuses current metadata when callers omit config", () => {
+    const config: OpenClawConfig = { plugins: { allow: ["normalizer"] } };
+    setCurrentPluginMetadataSnapshot(
+      createCurrentSnapshot({
+        manifestHash: "alpha",
+        prefix: "alpha",
+        config,
+      }),
+      { config, env: process.env },
+    );
+
+    expect(normalizeDemoModel()).toBe("alpha/demo-model");
+  });
+
+  it("validates explicit env before reusing current metadata", () => {
+    setCurrentPluginMetadataSnapshot(
+      createCurrentSnapshot({
+        manifestHash: "alpha",
+        prefix: "alpha",
+      }),
+      { config: {}, env: process.env },
+    );
+
+    const stateDir = makeTempDir();
+    const pluginDir = path.join(stateDir, "extensions", "normalizer");
+    writeInstallIndex({ stateDir, pluginDir });
+    writeNormalizerManifest({ pluginDir, prefix: "bravo" });
+
+    const env = {
+      ...process.env,
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_HOME: undefined,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+    };
+
+    expect(normalizeDemoModelWithEnv(env)).toBe("bravo/demo-model");
+  });
+
   it("reflects manifest edits and state-dir changes on the next lookup", () => {
     const stateDirA = makeTempDir();
     const pluginDirA = path.join(stateDirA, "extensions", "normalizer");
@@ -248,6 +299,7 @@ describe("manifest model id normalization", () => {
     expect(normalizeDemoModel()).toBe("alpha/demo-model");
 
     writeNormalizerManifest({ pluginDir: pluginDirA, prefix: "bravo-local" });
+    clearPluginMetadataLifecycleCaches();
     expect(normalizeDemoModel()).toBe("bravo-local/demo-model");
 
     const stateDirB = makeTempDir();
@@ -256,6 +308,7 @@ describe("manifest model id normalization", () => {
     writeNormalizerManifest({ pluginDir: pluginDirB, prefix: "charlie" });
 
     process.env.OPENCLAW_STATE_DIR = stateDirB;
+    clearPluginMetadataLifecycleCaches();
     expect(normalizeDemoModel()).toBe("charlie/demo-model");
   });
 

--- a/src/plugins/manifest-model-id-normalization.ts
+++ b/src/plugins/manifest-model-id-normalization.ts
@@ -1,11 +1,9 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import type { PluginManifestModelIdNormalizationProvider } from "./manifest.js";
-import {
-  resolvePluginMetadataSnapshot,
-  type PluginMetadataSnapshot,
-} from "./plugin-metadata-snapshot.js";
+import { resolvePluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 import { getActivePluginRegistryWorkspaceDirFromState } from "./runtime-state.js";
 
 type ManifestModelIdNormalizationLookupParams = {
@@ -37,19 +35,37 @@ let cachedPolicies: ManifestModelIdNormalizationPolicyCache | undefined;
 function resolveMetadataSnapshotForPolicies(
   params: ManifestModelIdNormalizationLookupParams = {},
 ): {
-  snapshot: PluginMetadataSnapshot;
+  plugins: readonly Pick<PluginManifestRecord, "modelIdNormalization">[];
+  configFingerprint?: string;
   cacheable: boolean;
 } {
   const env = params.env ?? process.env;
   const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDirFromState();
-  return {
-    snapshot: resolvePluginMetadataSnapshot({
-      config: params.config ?? {},
+  if (params.config === undefined) {
+    const currentSnapshot = getCurrentPluginMetadataSnapshot({
       env,
       workspaceDir,
-      allowWorkspaceScopedCurrent: true,
-    }),
-    cacheable: true,
+      allowWorkspaceScopedSnapshot: true,
+      requireDefaultDiscoveryContext: params.env !== undefined,
+    });
+    if (currentSnapshot) {
+      return {
+        plugins: currentSnapshot.plugins,
+        configFingerprint: currentSnapshot.configFingerprint,
+        cacheable: true,
+      };
+    }
+  }
+  const snapshot = resolvePluginMetadataSnapshot({
+    config: params.config ?? {},
+    env,
+    workspaceDir,
+    allowWorkspaceScopedCurrent: true,
+  });
+  return {
+    plugins: snapshot.plugins,
+    configFingerprint: snapshot.configFingerprint,
+    cacheable: false,
   };
 }
 
@@ -59,12 +75,11 @@ function loadManifestModelIdNormalizationPolicies(
   if (params.plugins) {
     return collectManifestModelIdNormalizationPolicies(params.plugins);
   }
-  const { snapshot, cacheable } = resolveMetadataSnapshotForPolicies(params);
-  const configFingerprint = snapshot.configFingerprint;
+  const { plugins, configFingerprint, cacheable } = resolveMetadataSnapshotForPolicies(params);
   if (cacheable && configFingerprint && cachedPolicies?.configFingerprint === configFingerprint) {
     return cachedPolicies.policies;
   }
-  const policies = collectManifestModelIdNormalizationPolicies(snapshot.plugins);
+  const policies = collectManifestModelIdNormalizationPolicies(plugins);
   if (cacheable && configFingerprint) {
     cachedPolicies = { configFingerprint, policies };
   }


### PR DESCRIPTION
## Summary

- Reuse the current plugin metadata snapshot for configless manifest model-id normalization, while validating explicit `env` overrides before taking that fast path.
- Keep cold normalization on the normal snapshot pipeline and update the manifest-edit test to model the plugin metadata lifecycle clear.
- Stop reparsing serialized session stores on object-cache hits by cloning from the cached object, preserving clone isolation, `clone:false` ownership semantics for disk-loaded stores, and `__proto__` data-property behavior.

## Verification

- `pnpm exec oxfmt --check src/plugins/manifest-model-id-normalization.ts src/plugins/manifest-model-id-normalization.test.ts src/config/sessions/store-cache.ts src/config/sessions.cache.test.ts`
- `node scripts/run-vitest.mjs src/plugins/manifest-model-id-normalization.test.ts src/config/sessions.cache.test.ts`
- `node scripts/run-vitest.mjs src/config/sessions.cache.test.ts src/plugins/manifest-model-id-normalization.test.ts src/gateway/session-utils.subagent.test.ts`
- `pnpm tsgo:core`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof

Behavior addressed: CPU-profiled runtime churn in manifest model-id normalization and session-store cache cloning.
Real environment tested: local macOS checkout on branch `perf/runtime-hotpath-cache-churn`; profiles inspected from gateway watch tmux under `.artifacts/gateway-watch-profiles`.
Exact steps or command run after this patch: focused Vitest for manifest normalization/session cache, the CI-failing gateway subagent session regression, core tsgo lane, oxfmt check, and autoreview.
Evidence after fix: focused tests passed 30/30; expanded fixup tests passed 112/112; `pnpm tsgo:core` passed; oxfmt check passed; autoreview reported no accepted/actionable findings.
Observed result after fix: configless normalization can reuse the active metadata snapshot without falling back to filesystem-backed snapshot resolution, explicit `env` stays isolated, session object-cache hits avoid JSON parse, and disk-loaded `clone:false` cache hits preserve reference identity.
What was not tested: full `pnpm check`; relying on focused tests and PR CI for broader lanes.

## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

```text
source: [LOCAL_SESSION]
redaction: local paths, secrets, raw tool outputs, system/developer prompts, auth details
scope: current runtime-cache perf PR only

[user]
what next in perf

[assistant]
Next best perf target from the profiles: model-id normalization causing plugin metadata rescans.
Second target: session store clone/save churn.
Order: add focused proof, reduce repeated metadata resolution, re-profile, then address session store clone/save if still hot.

[user]
do all of that, autoreview, PR, land

[assistant]
Started from fresh main, branched `perf/runtime-hotpath-cache-churn`, inspected tmux gateway profiles, and scoped the PR to metadata lookup plus session-store clone/cache churn.
Implemented current-snapshot reuse for configless manifest model-id normalization, while preserving normal cold snapshot semantics and explicit env isolation.
Changed session-store cache hits to clone from cached objects instead of reparsing cached serialized JSON, then fixed the clone to preserve `__proto__` data-property semantics and disk-loaded `clone:false` ownership.
Ran focused Vitest, the gateway subagent regression after CI exposed it, core typecheck, oxfmt check, and repeated autoreview until no accepted/actionable findings remained.

[tool summary]
Inspected tmux gateway watch and latest CPU profiles; edited source/tests; committed `perf: reduce runtime cache churn` and `fix: preserve clone false session cache ownership`; pushed branch for PR.
```

</details>
