### PR TITLE
fix: relay Claude CLI assistant partial messages as streaming deltas

### DIFF
--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -4309,7 +4309,6 @@ describe("createCliJsonlStreamingParser", () => {
     );
   });
 
-
   it("deduplicates when both stream_event deltas and assistant partials arrive", () => {
     const deltas: Array<{ text: string; delta: string }> = [];
     const parser = createCliJsonlStreamingParser({

--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -4187,6 +4187,182 @@ describe("createCliJsonlStreamingParser", () => {
     ]);
   });
 
+  it("streams deltas from Claude assistant partial messages", () => {
+    const deltas: Array<{ text: string; delta: string }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: { command: "claude", output: "jsonl" },
+      providerId: "claude-cli",
+      onAssistantDelta: (d) => deltas.push({ text: d.text, delta: d.delta }),
+    });
+
+    parser.push(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Hello" }],
+          stop_reason: null,
+        },
+        session_id: "s1",
+      }) + "\n",
+    );
+    parser.push(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Hello world" }],
+          stop_reason: null,
+        },
+        session_id: "s1",
+      }) + "\n",
+    );
+    parser.finish();
+
+    expect(deltas).toEqual([
+      { text: "Hello", delta: "Hello" },
+      { text: "Hello world", delta: " world" },
+    ]);
+  });
+
+  it("streams later assistant partials after tool use without commentary (per-message baseline)", () => {
+    const deltas: Array<{ text: string; delta: string }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "claude",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      // No onCommentaryText: no-commentary path that previously dropped post-tool partials.
+      onAssistantDelta: (d) => deltas.push({ text: d.text, delta: d.delta }),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({ type: "init", session_id: "session-tool-later" }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            id: "msg-pre-tool",
+            role: "assistant",
+            content: [{ type: "text", text: "I will inspect the repository first." }],
+            stop_reason: null,
+          },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            id: "msg-pre-tool",
+            role: "assistant",
+            content: [
+              { type: "text", text: "I will inspect the repository first." },
+              { type: "tool_use", id: "toolu_1", name: "Bash", input: {} },
+            ],
+            stop_reason: null,
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            index: 1,
+            content_block: { type: "tool_use", id: "toolu_1", name: "Bash", input: {} },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "message_start", message: { id: "msg-post-tool" } },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            id: "msg-post-tool",
+            role: "assistant",
+            content: [{ type: "text", text: "Done." }],
+            stop_reason: null,
+          },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            id: "msg-post-tool",
+            role: "assistant",
+            content: [{ type: "text", text: "Done. Found it." }],
+            stop_reason: null,
+          },
+        }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    // Post-tool message is shorter than the pre-tool snapshot; turn-wide baseline
+    // would drop it. Per-message baseline must still emit Done. / Found it.
+    const joined = deltas.map((d) => d.delta).join("");
+    expect(joined).toContain("I will inspect the repository first.");
+    expect(joined).toContain("Done.");
+    expect(joined).toContain("Found it.");
+    expect(deltas.some((d) => d.delta.includes("Done."))).toBe(true);
+    expect(deltas.some((d) => d.delta.includes("Found it.") || d.text.includes("Found it."))).toBe(
+      true,
+    );
+  });
+
+
+  it("deduplicates when both stream_event deltas and assistant partials arrive", () => {
+    const deltas: Array<{ text: string; delta: string }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: { command: "claude", output: "jsonl" },
+      providerId: "claude-cli",
+      onAssistantDelta: (d) => deltas.push({ text: d.text, delta: d.delta }),
+    });
+
+    parser.push(
+      JSON.stringify({
+        type: "stream_event",
+        event: { type: "content_block_delta", delta: { type: "text_delta", text: "Hi" } },
+      }) + "\n",
+    );
+    parser.push(
+      JSON.stringify({
+        type: "assistant",
+        message: { role: "assistant", content: [{ type: "text", text: "Hi" }] },
+      }) + "\n",
+    );
+    parser.push(
+      JSON.stringify({
+        type: "stream_event",
+        event: { type: "content_block_delta", delta: { type: "text_delta", text: " there" } },
+      }) + "\n",
+    );
+    parser.finish();
+
+    expect(deltas).toEqual([
+      { text: "Hi", delta: "Hi" },
+      { text: "Hi there", delta: " there" },
+    ]);
+  });
+
+  it("ignores assistant partial messages for non-Claude backends", () => {
+    const deltas: Array<{ text: string; delta: string }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: { command: "other-cli", output: "jsonl" },
+      providerId: "other-provider",
+      onAssistantDelta: (d) => deltas.push({ text: d.text, delta: d.delta }),
+    });
+
+    parser.push(
+      JSON.stringify({
+        type: "assistant",
+        message: { role: "assistant", content: [{ type: "text", text: "Hello" }] },
+      }) + "\n",
+    );
+    parser.finish();
+
+    expect(deltas).toEqual([]);
+  });
+
   it("does not fire onCommentaryText when no text precedes tool_use", () => {
     const commentaryTexts: string[] = [];
     const parser = createCliJsonlStreamingParser({
@@ -4318,6 +4494,156 @@ describe("createCliJsonlStreamingParser", () => {
     parser.finish();
 
     expect(commentaryTexts).toEqual(["Reading the file now.", "Now searching."]);
+  });
+
+  it("skips assistant partials with only tool_use content", () => {
+    const deltas: Array<{ text: string; delta: string }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: { command: "claude", output: "jsonl" },
+      providerId: "claude-cli",
+      onAssistantDelta: (d) => deltas.push({ text: d.text, delta: d.delta }),
+    });
+
+    parser.push(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "t1", name: "Read", input: {} }],
+          stop_reason: null,
+        },
+      }) + "\n",
+    );
+    parser.finish();
+
+    expect(deltas).toEqual([]);
+  });
+
+  it("extracts text from assistant partial with mixed text and tool_use content", () => {
+    const deltas: Array<{ text: string; delta: string }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: { command: "claude", output: "jsonl" },
+      providerId: "claude-cli",
+      onAssistantDelta: (d) => deltas.push({ text: d.text, delta: d.delta }),
+    });
+
+    parser.push(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Let me read that file." },
+            { type: "tool_use", id: "t1", name: "Read", input: { path: "README.md" } },
+          ],
+          stop_reason: null,
+        },
+      }) + "\n",
+    );
+    parser.finish();
+
+    expect(deltas).toEqual([{ text: "Let me read that file.", delta: "Let me read that file." }]);
+  });
+
+  it("routes assistant partial pre-tool text to commentary when classification is active", () => {
+    const deltas: Array<{ text: string; delta: string }> = [];
+    const commentaryTexts: string[] = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "claude",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: (d) => deltas.push({ text: d.text, delta: d.delta }),
+      onCommentaryText: (text) => commentaryTexts.push(text),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({ type: "init", session_id: "session-partial-commentary" }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "Let me check that." }],
+            stop_reason: null,
+          },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "text", text: "Let me check that." },
+              { type: "tool_use", id: "toolu_1", name: "Bash", input: {} },
+            ],
+            stop_reason: null,
+          },
+        }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(commentaryTexts).toEqual(["Let me check that."]);
+    expect(deltas).toEqual([]);
+  });
+
+  it("skips assistant records without stop_reason field", () => {
+    const deltas: Array<{ text: string; delta: string }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: { command: "claude", output: "jsonl" },
+      providerId: "claude-cli",
+      onAssistantDelta: (d) => deltas.push({ text: d.text, delta: d.delta }),
+    });
+
+    // Assistant record without stop_reason -- not a confirmed partial
+    parser.push(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Hello" }],
+        },
+      }) + "\n",
+    );
+    parser.finish();
+
+    expect(deltas).toEqual([]);
+  });
+
+  it("skips complete assistant message with stop_reason set", () => {
+    const deltas: Array<{ text: string; delta: string }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: { command: "claude", output: "jsonl" },
+      providerId: "claude-cli",
+      onAssistantDelta: (d) => deltas.push({ text: d.text, delta: d.delta }),
+    });
+
+    parser.push(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Hello" }],
+          stop_reason: null,
+        },
+      }) + "\n",
+    );
+    parser.push(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Hello world" }],
+          stop_reason: "end_turn",
+        },
+      }) + "\n",
+    );
+    parser.finish();
+
+    expect(deltas).toEqual([{ text: "Hello", delta: "Hello" }]);
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -4317,6 +4317,9 @@ describe("createCliJsonlStreamingParser", () => {
       onAssistantDelta: (d) => deltas.push({ text: d.text, delta: d.delta }),
     });
 
+    // Claude often emits stream_event text_delta and a cumulative assistant
+    // snapshot with stop_reason: null for the same prefix. The snapshot must
+    // not re-emit text already delivered via stream_event.
     parser.push(
       JSON.stringify({
         type: "stream_event",
@@ -4326,13 +4329,27 @@ describe("createCliJsonlStreamingParser", () => {
     parser.push(
       JSON.stringify({
         type: "assistant",
-        message: { role: "assistant", content: [{ type: "text", text: "Hi" }] },
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Hi" }],
+          stop_reason: null,
+        },
       }) + "\n",
     );
     parser.push(
       JSON.stringify({
         type: "stream_event",
         event: { type: "content_block_delta", delta: { type: "text_delta", text: " there" } },
+      }) + "\n",
+    );
+    parser.push(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Hi there" }],
+          stop_reason: null,
+        },
       }) + "\n",
     );
     parser.finish();

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -1464,6 +1464,9 @@ export function createCliJsonlStreamingParser(params: {
   let pendingClaudeText = "";
   let lastClaudePartialMessageId: string | undefined;
   let claudePartialTextSoFar = "";
+  // Per-message text already delivered via stream_event (or buffered as commentary).
+  // Do not use turn-wide assistantText for snapshot dedupe (Claw P1).
+  let claudeStreamDeliveredForPartial = "";
   let pendingMessageSeparator = false;
   let currentMessageStart = 0;
   let segmentStart = 0;
@@ -1524,6 +1527,8 @@ export function createCliJsonlStreamingParser(params: {
     if (!delta) {
       return;
     }
+    // Message-local delivered baseline for partial assistant snapshots.
+    claudeStreamDeliveredForPartial = `${claudeStreamDeliveredForPartial}${delta}`;
     if (classifyClaudeCommentary) {
       pendingClaudeText = `${pendingClaudeText}${delta}`;
       return;
@@ -1966,6 +1971,7 @@ export function createCliJsonlStreamingParser(params: {
       if (messageId !== lastClaudePartialMessageId) {
         lastClaudePartialMessageId = messageId;
         claudePartialTextSoFar = "";
+        claudeStreamDeliveredForPartial = "";
       } else {
         const nextText = collectCliText(parsed.message);
         if (claudePartialTextSoFar && nextText && !nextText.startsWith(claudePartialTextSoFar)) {
@@ -1973,22 +1979,15 @@ export function createCliJsonlStreamingParser(params: {
         }
       }
     }
-    // Stream-event text deltas advance `assistantText`. Partial assistant
-    // snapshots are cumulative and must not re-emit that prefix when Claude
-    // also sends stream_event text (mixed delivery). Prefer the longer of the
-    // message-local partial baseline and the already-streamed assistant text
-    // only when the snapshot still starts with that stream text.
+    // Stream-event text is tracked per message in claudeStreamDeliveredForPartial
+    // (including commentary-buffered text). Do not use turn-wide assistantText:
+    // it omits pending commentary and prior message boundaries (duplicate risk).
     let partialTextSoFar = claudePartialTextSoFar;
-    if (parsed.type === "assistant" && isRecord(parsed.message)) {
-      const snapshotText = collectCliText(parsed.message);
-      if (
-        snapshotText &&
-        assistantText &&
-        snapshotText.startsWith(assistantText) &&
-        assistantText.length > partialTextSoFar.length
-      ) {
-        partialTextSoFar = assistantText;
-      }
+    if (
+      claudeStreamDeliveredForPartial.length > partialTextSoFar.length &&
+      (!partialTextSoFar || claudeStreamDeliveredForPartial.startsWith(partialTextSoFar))
+    ) {
+      partialTextSoFar = claudeStreamDeliveredForPartial;
     }
     const partialDelta = parseClaudeCliPartialAssistantDelta({
       backend: params.backend,
@@ -2002,8 +2001,11 @@ export function createCliJsonlStreamingParser(params: {
       claudePartialTextSoFar = partialDelta.text;
       if (classifyClaudeCommentary) {
         pendingClaudeText = `${pendingClaudeText}${partialDelta.delta}`;
+        claudeStreamDeliveredForPartial = partialDelta.text;
       } else {
         emitClaudeVisibleText(partialDelta.delta);
+        // emitClaudeVisibleText appends delta; snap baseline to full cumulative text
+        claudeStreamDeliveredForPartial = partialDelta.text;
       }
     }
 

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -828,6 +828,48 @@ function parseClaudeCliStreamingDelta(params: {
   };
 }
 
+function parseClaudeCliPartialAssistantDelta(params: {
+  backend: CliBackendConfig;
+  providerId: string;
+  parsed: Record<string, unknown>;
+  textSoFar: string;
+  sessionId?: string;
+  usage?: CliUsage;
+}): CliStreamingDelta | null {
+  if (!supportsCliJsonlToolEvents(params)) {
+    return null;
+  }
+  if (params.parsed.type !== "assistant" || !isRecord(params.parsed.message)) {
+    return null;
+  }
+  // Claude CLI --include-partial-messages emits assistant records with
+  // stop_reason: null while streaming and a non-null stop_reason (e.g.
+  // "end_turn") for the final complete message.  Only relay true partials
+  // that have an explicit stop_reason: null (the documented partial signal).
+  // Records without stop_reason at all are not confirmed partials and could
+  // be complete messages from custom claude-stream-json backends.
+  const message = params.parsed.message;
+  if (!isRecord(message) || !("stop_reason" in message) || message.stop_reason !== null) {
+    return null;
+  }
+  const partialText = collectCliText(params.parsed.message);
+  if (!partialText || partialText.length <= params.textSoFar.length) {
+    return null;
+  }
+  const delta = partialText.startsWith(params.textSoFar)
+    ? partialText.slice(params.textSoFar.length)
+    : partialText;
+  if (!delta) {
+    return null;
+  }
+  return {
+    text: partialText,
+    delta,
+    sessionId: params.sessionId,
+    usage: params.usage,
+  };
+}
+
 type PendingToolUse = {
   toolCallId: string;
   name: string;
@@ -1420,6 +1462,8 @@ export function createCliJsonlStreamingParser(params: {
   let assistantText = "";
   let customThinkingText = "";
   let pendingClaudeText = "";
+  let lastClaudePartialMessageId: string | undefined;
+  let claudePartialTextSoFar = "";
   let pendingMessageSeparator = false;
   let currentMessageStart = 0;
   let segmentStart = 0;
@@ -1901,41 +1945,94 @@ export function createCliJsonlStreamingParser(params: {
       sessionId,
       usage,
     });
-    if (!delta) {
-      if (
-        isGeminiStreamJsonDialect(params) &&
-        parsed.type === "message" &&
-        parsed.role === "assistant" &&
-        typeof parsed.content === "string"
-      ) {
-        const deltaText = parsed.content;
-        if (deltaText) {
-          assistantText = `${assistantText}${deltaText}`;
-          params.onAssistantDelta({
-            text: assistantText,
-            delta: deltaText,
-            sessionId,
-            usage,
-          });
+    if (delta) {
+      if (claudeStreamJson) {
+        routeTaggedReasoningDeltas(taggedReasoningRouter.push(delta.delta));
+        return;
+      }
+      emitClaudeVisibleText(delta.delta);
+      return;
+    }
+
+    // Claude CLI --include-partial-messages emits assistant records with
+    // stop_reason: null. Relay them when stream_event text deltas are absent.
+    // Baseline is per assistant message so a later post-tool message that is
+    // shorter than prior turn text still streams (message-local snapshots).
+    if (parsed.type === "assistant" && isRecord(parsed.message)) {
+      const messageId =
+        typeof parsed.message.id === "string" && parsed.message.id.trim()
+          ? parsed.message.id
+          : undefined;
+      if (messageId !== lastClaudePartialMessageId) {
+        lastClaudePartialMessageId = messageId;
+        claudePartialTextSoFar = "";
+      } else {
+        const nextText = collectCliText(parsed.message);
+        if (
+          claudePartialTextSoFar &&
+          nextText &&
+          !nextText.startsWith(claudePartialTextSoFar)
+        ) {
+          claudePartialTextSoFar = "";
         }
-      } else if (
-        isGeminiStreamJsonDialect(params) &&
-        parsed.type === "result" &&
-        parsed.status === "success"
-      ) {
-        output = {
-          text: assistantText.trim(),
+      }
+    }
+    const partialDelta = parseClaudeCliPartialAssistantDelta({
+      backend: params.backend,
+      providerId: params.providerId,
+      parsed,
+      textSoFar: claudePartialTextSoFar,
+      sessionId,
+      usage,
+    });
+    if (partialDelta) {
+      claudePartialTextSoFar = partialDelta.text;
+      if (classifyClaudeCommentary) {
+        pendingClaudeText = `${pendingClaudeText}${partialDelta.delta}`;
+      } else {
+        emitClaudeVisibleText(partialDelta.delta);
+      }
+    }
+
+    // Assistant partials may add tool_use without growing text. Flush pending
+    // narration to commentary then.
+    if (classifyClaudeCommentary && parsed.type === "assistant" && isRecord(parsed.message)) {
+      const content = Array.isArray(parsed.message.content) ? parsed.message.content : [];
+      const hasToolUse = content.some(
+        (block) => isRecord(block) && isClaudeToolUseBlockType(block.type),
+      );
+      if (hasToolUse) {
+        flushPendingClaudeCommentaryText();
+      }
+    }
+
+    if (
+      isGeminiStreamJsonDialect(params) &&
+      parsed.type === "message" &&
+      parsed.role === "assistant" &&
+      typeof parsed.content === "string"
+    ) {
+      const deltaText = parsed.content;
+      if (deltaText) {
+        assistantText = `${assistantText}${deltaText}`;
+        params.onAssistantDelta({
+          text: assistantText,
+          delta: deltaText,
           sessionId,
           usage,
-        };
+        });
       }
-      return;
+    } else if (
+      isGeminiStreamJsonDialect(params) &&
+      parsed.type === "result" &&
+      parsed.status === "success"
+    ) {
+      output = {
+        text: assistantText.trim(),
+        sessionId,
+        usage,
+      };
     }
-    if (claudeStreamJson) {
-      routeTaggedReasoningDeltas(taggedReasoningRouter.push(delta.delta));
-      return;
-    }
-    emitClaudeVisibleText(delta.delta);
   };
 
   const handleJsonlLine = (rawLine: string) => {

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -1973,11 +1973,28 @@ export function createCliJsonlStreamingParser(params: {
         }
       }
     }
+    // Stream-event text deltas advance `assistantText`. Partial assistant
+    // snapshots are cumulative and must not re-emit that prefix when Claude
+    // also sends stream_event text (mixed delivery). Prefer the longer of the
+    // message-local partial baseline and the already-streamed assistant text
+    // only when the snapshot still starts with that stream text.
+    let partialTextSoFar = claudePartialTextSoFar;
+    if (parsed.type === "assistant" && isRecord(parsed.message)) {
+      const snapshotText = collectCliText(parsed.message);
+      if (
+        snapshotText &&
+        assistantText &&
+        snapshotText.startsWith(assistantText) &&
+        assistantText.length > partialTextSoFar.length
+      ) {
+        partialTextSoFar = assistantText;
+      }
+    }
     const partialDelta = parseClaudeCliPartialAssistantDelta({
       backend: params.backend,
       providerId: params.providerId,
       parsed,
-      textSoFar: claudePartialTextSoFar,
+      textSoFar: partialTextSoFar,
       sessionId,
       usage,
     });

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -1968,11 +1968,7 @@ export function createCliJsonlStreamingParser(params: {
         claudePartialTextSoFar = "";
       } else {
         const nextText = collectCliText(parsed.message);
-        if (
-          claudePartialTextSoFar &&
-          nextText &&
-          !nextText.startsWith(claudePartialTextSoFar)
-        ) {
+        if (claudePartialTextSoFar && nextText && !nextText.startsWith(claudePartialTextSoFar)) {
           claudePartialTextSoFar = "";
         }
       }


### PR DESCRIPTION
## What Problem This Solves

Claude CLI JSONL assistant records with the documented partial marker (`stop_reason: null`) were not relayed as streaming deltas, so WebChat/TUI waited for the full response instead of showing progressive text.

Fixes #86050

## Summary

Relay Claude CLI assistant records as streaming deltas so progressive output appears instead of waiting for the full response.

**Fix 1**: Parse `assistant` records from the Claude CLI JSONL stream and forward their text content as streaming deltas.

**Fix 2**: Gate on `stop_reason` using a positive partial signal: only forward records where `stop_reason` is explicitly present and `null` (the documented Claude CLI partial marker). Complete messages with `stop_reason: "end_turn"` are skipped to avoid duplicating the final message. Records without `stop_reason` at all are ignored as ambiguous.

**Fix 3**: When commentary classification is active, assistant-record partials buffer into `pendingClaudeText` like stream_event text so pre-tool narration does not land on final assistant deltas.

Changed files:

- `src/agents/cli-output.ts` - `parseClaudeCliPartialAssistantDelta` with positive `stop_reason: null` guard; commentary routing for assistant partials
- `src/agents/cli-output.test.ts` - partial forwarding, complete-message skip, absent-stop_reason rejection, commentary classification regression

## Evidence

Live Claude CLI `stream-json` session (via local Anthropic-compatible proxy to xAI Grok on 127.0.0.1:3010) produced a real `assistant` record with `stop_reason: null`. Production `createCliJsonlStreamingParser` on head `47e96f1f0e82` relayed that record as exactly one streaming delta. Full capture under Real behavior proof.

## Real behavior proof

Behavior addressed: Claude CLI assistant records with explicit stop_reason null must relay as streaming deltas; complete end_turn terminal records must not create false deltas.
Real environment tested: macOS, OpenClaw branch fix/gateway-stream-relay at /tmp/proof-86649 commit 47e96f1f0e82. Live `claude -p --output-format stream-json` through local Anthropic-compatible proxy on 127.0.0.1:3010 (xAI Grok translation). Production createCliJsonlStreamingParser via pnpm exec tsx on this exact head. No real Anthropic credentials; dummy ANTHROPIC_API_KEY for CLI only.
Exact steps or command run after this patch:
Step 1. Started local Anthropic-to-xAI proxy on port 3010 and ran a short non-interactive Claude CLI stream-json call on head 47e96f1f0e82.
```bash
export ANTHROPIC_BASE_URL=http://127.0.0.1:3010
export ANTHROPIC_API_KEY=sk-ant-api03-demo
claude -p "Reply with exactly: Hello stream proof" --output-format stream-json --verbose --model grok-4
```
Step 2. Fed the redacted live capture through production createCliJsonlStreamingParser on this branch head (47e96f1f0e82).
```bash
pnpm exec tsx proof-parser-live.mjs
```
Evidence after fix: redacted live assistant partial from Claude CLI stream-json on head 47e96f1f0e82, then production parser relay.

Live Claude CLI assistant partial (session ids redacted):
```json
{
  "type": "assistant",
  "message": {
    "id": "REDACTED",
    "type": "message",
    "role": "assistant",
    "model": "grok-4",
    "content": [
      {
        "type": "text",
        "text": "Hello stream proof"
      }
    ],
    "stop_reason": null,
    "stop_sequence": null
  }
}
```

Production parser on that live capture (head 47e96f1f0e82):
```console
$ pnpm exec tsx proof-parser-live.mjs
DELTA: "Hello stream proof" text_len= 18
assistant_partials_in_capture: 1
end_turn_in_capture: 0
deltas_relayed: 1
PARSER_LIVE_PROOF_OK
```

Observed result after fix: Live Claude stream-json on head 47e96f1f0e82 emits assistant records with stop_reason null. The production parser relays those as exactly one streaming delta (deltas_relayed equals assistant_partials_in_capture).
What was not tested: Full Gateway/WebChat or TUI end-to-end session UI attachment (parser path is the product relay used by those surfaces; UI chrome not exercised in this capture). Real Anthropic network credentials (proxy translates to xAI Grok).
