### PR TITLE
perf(agents): memoize per-message token pressure on precheck path

### DIFF
--- a/scripts/perf/preemptive-precheck-replay.ts
+++ b/scripts/perf/preemptive-precheck-replay.ts
@@ -1,21 +1,27 @@
 /**
  * Embedded-runner pre-prompt precheck replay harness.
  *
- * Exercises `shouldPreemptivelyCompactBeforePrompt` — the same exported helper
- * invoked from `src/agents/pi-embedded-runner/run/attempt.ts` on every prompt
- * submission — on a synthetic activeSession.messages-shaped transcript.
+ * Mirrors the call shape used in `src/agents/embedded-agent-runner/run/attempt.ts`
+ * at the precheck site: precompute the boundary estimate with the internal
+ * append-only cached estimator, then pass it to `shouldPreemptivelyCompactBeforePrompt`
+ * via `llmBoundaryTokenPressure`. The public helper itself stays fresh; the
+ * WeakMap-backed cache is confined to the embedded-runner's append-only path.
  *
- * Use this to reproduce the per-message identity cache behavior locally
- * without a provider call or a captured session log. Produces stdout suitable
- * for inclusion in a PR body Evidence section.
+ * Use this to reproduce the cached-vs-fresh wall time locally without a
+ * provider call or a captured session log. Produces stdout suitable for
+ * inclusion in a PR body Evidence section.
  *
  * Run:
  *   pnpm exec tsx scripts/perf/preemptive-precheck-replay.ts
  */
 
 import { performance } from "node:perf_hooks";
-import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import { shouldPreemptivelyCompactBeforePrompt } from "../../src/agents/pi-embedded-runner/run/preemptive-compaction.js";
+import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
+import {
+  estimateAppendOnlyLlmBoundaryTokenPressure,
+  estimateLlmBoundaryTokenPressure,
+  shouldPreemptivelyCompactBeforePrompt,
+} from "../../src/agents/embedded-agent-runner/run/preemptive-compaction.js";
 
 const CONTEXT_TOKEN_BUDGET = 200_000;
 const RESERVE_TOKENS = 16_000;
@@ -85,13 +91,46 @@ function buildToolHeavyTranscript(turns: number): AgentMessage[] {
   return out;
 }
 
-function precheck(messages: AgentMessage[]) {
+function cachedPrecheck(messages: AgentMessage[]) {
+  // Mirrors the embedded-runner attempt.ts precheck site: feed the
+  // append-only cached estimator into shouldPreemptivelyCompactBeforePrompt.
+  const estimatedPromptTokens = estimateAppendOnlyLlmBoundaryTokenPressure({
+    messages,
+    systemPrompt: SYSTEM_PROMPT,
+    prompt: PROMPT,
+  });
   return shouldPreemptivelyCompactBeforePrompt({
     messages,
     systemPrompt: SYSTEM_PROMPT,
     prompt: PROMPT,
     contextTokenBudget: CONTEXT_TOKEN_BUDGET,
     reserveTokens: RESERVE_TOKENS,
+    llmBoundaryTokenPressure: {
+      estimatedPromptTokens,
+      source: "transcript_estimate",
+    },
+  });
+}
+
+function freshPrecheck(messages: AgentMessage[]) {
+  // Baseline: same caller shape, but using the public fresh estimator.
+  // This is the path SDK consumers exercise when they do not opt into the
+  // internal append-only cache.
+  const estimatedPromptTokens = estimateLlmBoundaryTokenPressure({
+    messages,
+    systemPrompt: SYSTEM_PROMPT,
+    prompt: PROMPT,
+  });
+  return shouldPreemptivelyCompactBeforePrompt({
+    messages,
+    systemPrompt: SYSTEM_PROMPT,
+    prompt: PROMPT,
+    contextTokenBudget: CONTEXT_TOKEN_BUDGET,
+    reserveTokens: RESERVE_TOKENS,
+    llmBoundaryTokenPressure: {
+      estimatedPromptTokens,
+      source: "transcript_estimate",
+    },
   });
 }
 
@@ -109,27 +148,54 @@ function main(): void {
   const baseTurns = 250;
   const messages = buildToolHeavyTranscript(baseTurns);
 
-  const cold = timed(() => precheck(messages));
+  // Cold + warm runs against the cached embedded-runner-equivalent path.
+  const cold = timed(() => cachedPrecheck(messages));
 
   const warmRuns: number[] = [];
   for (let i = 0; i < 20; i++) {
-    warmRuns.push(timed(() => precheck(messages)).ms);
+    warmRuns.push(timed(() => cachedPrecheck(messages)).ms);
   }
   const warmMean = warmRuns.reduce((s, x) => s + x, 0) / warmRuns.length;
+
+  // Fresh (uncached) baseline: same caller shape but using the public helper.
+  // Builds a parallel transcript so the cached WeakMap from the warm runs
+  // does not bleed into the fresh measurement.
+  const freshMessages = buildToolHeavyTranscript(baseTurns);
+  // Warm up so JIT/inline caches stabilize before the measurement.
+  freshPrecheck(freshMessages);
+  const freshRuns: number[] = [];
+  for (let i = 0; i < 20; i++) {
+    freshRuns.push(timed(() => freshPrecheck(freshMessages)).ms);
+  }
+  const freshMean = freshRuns.reduce((s, x) => s + x, 0) / freshRuns.length;
 
   const appendMs: number[] = [];
   const appendRoutes: string[] = [];
   const appendEstimates: number[] = [];
   for (let turn = 0; turn < 10; turn++) {
     messages.push(makeUserMessage(8));
-    const r = timed(() => precheck(messages));
+    const r = timed(() => cachedPrecheck(messages));
     appendMs.push(r.ms);
     appendRoutes.push(r.value.route);
     appendEstimates.push(r.value.estimatedPromptTokens);
   }
   const appendMean = appendMs.reduce((s, x) => s + x, 0) / appendMs.length;
 
-  const finalDecision = precheck(messages);
+  const finalDecision = cachedPrecheck(messages);
+
+  // Sanity: the cached and fresh estimators must return the same number
+  // when called on identical inputs without intervening mutation.
+  const parityMessages = buildToolHeavyTranscript(32);
+  const cachedEstimate = estimateAppendOnlyLlmBoundaryTokenPressure({
+    messages: parityMessages,
+    systemPrompt: SYSTEM_PROMPT,
+    prompt: PROMPT,
+  });
+  const freshEstimate = estimateLlmBoundaryTokenPressure({
+    messages: parityMessages,
+    systemPrompt: SYSTEM_PROMPT,
+    prompt: PROMPT,
+  });
 
   console.log("openclaw preemptive-precheck-replay (embedded-runner path)");
   console.log(`commit                      ${process.env.PROBE_HEAD ?? "(set $PROBE_HEAD)"}`);
@@ -137,15 +203,22 @@ function main(): void {
   console.log(`budget_tokens               ${CONTEXT_TOKEN_BUDGET}`);
   console.log(`reserve                     ${RESERVE_TOKENS}`);
   console.log("");
-  console.log(`cold_precheck_ms            ${cold.ms.toFixed(3)}`);
+  console.log(`cold_precheck_ms            ${cold.ms.toFixed(3)} (append-only cached path)`);
   console.log(
-    `warm_precheck_ms_mean       ${warmMean.toFixed(3)} (20 repeats over the same transcript)`,
+    `warm_precheck_ms_mean       ${warmMean.toFixed(3)} (20 repeats, append-only cached path)`,
   );
   console.log(
-    `append_step_ms_mean         ${appendMean.toFixed(3)} (10 turns, one new user msg each)`,
+    `fresh_precheck_ms_mean      ${freshMean.toFixed(3)} (20 repeats, public fresh helper, parallel transcript)`,
+  );
+  console.log(
+    `append_step_ms_mean         ${appendMean.toFixed(3)} (10 turns, one new user msg each, cached path)`,
   );
   console.log("");
-  console.log("per-append measurements:");
+  console.log(`estimator_parity_cached     ${cachedEstimate}`);
+  console.log(`estimator_parity_fresh      ${freshEstimate}`);
+  console.log(`estimator_parity_match      ${cachedEstimate === freshEstimate}`);
+  console.log("");
+  console.log("per-append measurements (cached path):");
   for (let i = 0; i < appendMs.length; i++) {
     const turn = pad(String(i + 1).padStart(2), 2);
     const ms = appendMs[i].toFixed(3).padStart(8);

--- a/scripts/perf/preemptive-precheck-replay.ts
+++ b/scripts/perf/preemptive-precheck-replay.ts
@@ -1,0 +1,163 @@
+/**
+ * Embedded-runner pre-prompt precheck replay harness.
+ *
+ * Exercises `shouldPreemptivelyCompactBeforePrompt` — the same exported helper
+ * invoked from `src/agents/pi-embedded-runner/run/attempt.ts` on every prompt
+ * submission — on a synthetic activeSession.messages-shaped transcript.
+ *
+ * Use this to reproduce the per-message identity cache behavior locally
+ * without a provider call or a captured session log. Produces stdout suitable
+ * for inclusion in a PR body Evidence section.
+ *
+ * Run:
+ *   pnpm exec tsx scripts/perf/preemptive-precheck-replay.ts
+ */
+
+import { performance } from "node:perf_hooks";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { shouldPreemptivelyCompactBeforePrompt } from "../../src/agents/pi-embedded-runner/run/preemptive-compaction.js";
+
+const CONTEXT_TOKEN_BUDGET = 200_000;
+const RESERVE_TOKENS = 16_000;
+const SYSTEM_PROMPT = "You are a helpful assistant. ".repeat(60);
+const PROMPT = "ping";
+
+let timestamp = 1;
+
+function makeUserMessage(words: number): AgentMessage {
+  return {
+    role: "user",
+    content: "lorem ipsum dolor sit amet ".repeat(words),
+    timestamp: timestamp++,
+  } as unknown as AgentMessage;
+}
+
+function makeAssistantText(words: number): AgentMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text: "alpha beta gamma delta ".repeat(words) }],
+    timestamp: timestamp++,
+  } as unknown as AgentMessage;
+}
+
+function makeAssistantToolCall(argChars: number): AgentMessage {
+  return {
+    role: "assistant",
+    content: [
+      {
+        type: "toolCall",
+        id: `call_${timestamp}`,
+        name: "Read",
+        arguments: {
+          file_path: "/tmp/example/file.ts",
+          payload: "x".repeat(Math.max(1, argChars - 60)),
+        },
+      },
+    ],
+    timestamp: timestamp++,
+  } as unknown as AgentMessage;
+}
+
+function makeToolResult(textChars: number): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId: `call_${timestamp}`,
+    toolName: "Read",
+    content: [
+      {
+        type: "text",
+        text: "fake line of output\n".repeat(Math.max(1, Math.ceil(textChars / 20))),
+      },
+    ],
+    isError: false,
+    timestamp: timestamp++,
+  } as unknown as AgentMessage;
+}
+
+function buildToolHeavyTranscript(turns: number): AgentMessage[] {
+  const out: AgentMessage[] = [];
+  for (let i = 0; i < turns; i++) {
+    out.push(makeUserMessage(8));
+    out.push(makeAssistantToolCall(2_500));
+    out.push(makeToolResult(8_000));
+    out.push(makeAssistantText(40));
+  }
+  return out;
+}
+
+function precheck(messages: AgentMessage[]) {
+  return shouldPreemptivelyCompactBeforePrompt({
+    messages,
+    systemPrompt: SYSTEM_PROMPT,
+    prompt: PROMPT,
+    contextTokenBudget: CONTEXT_TOKEN_BUDGET,
+    reserveTokens: RESERVE_TOKENS,
+  });
+}
+
+function timed<T>(fn: () => T): { ms: number; value: T } {
+  const t0 = performance.now();
+  const value = fn();
+  return { ms: performance.now() - t0, value };
+}
+
+function pad(value: string | number, width: number): string {
+  return String(value).padEnd(width);
+}
+
+function main(): void {
+  const baseTurns = 250;
+  const messages = buildToolHeavyTranscript(baseTurns);
+
+  const cold = timed(() => precheck(messages));
+
+  const warmRuns: number[] = [];
+  for (let i = 0; i < 20; i++) {
+    warmRuns.push(timed(() => precheck(messages)).ms);
+  }
+  const warmMean = warmRuns.reduce((s, x) => s + x, 0) / warmRuns.length;
+
+  const appendMs: number[] = [];
+  const appendRoutes: string[] = [];
+  const appendEstimates: number[] = [];
+  for (let turn = 0; turn < 10; turn++) {
+    messages.push(makeUserMessage(8));
+    const r = timed(() => precheck(messages));
+    appendMs.push(r.ms);
+    appendRoutes.push(r.value.route);
+    appendEstimates.push(r.value.estimatedPromptTokens);
+  }
+  const appendMean = appendMs.reduce((s, x) => s + x, 0) / appendMs.length;
+
+  const finalDecision = precheck(messages);
+
+  console.log("openclaw preemptive-precheck-replay (embedded-runner path)");
+  console.log(`commit                      ${process.env.PROBE_HEAD ?? "(set $PROBE_HEAD)"}`);
+  console.log(`messages_in                 ${messages.length}`);
+  console.log(`budget_tokens               ${CONTEXT_TOKEN_BUDGET}`);
+  console.log(`reserve                     ${RESERVE_TOKENS}`);
+  console.log("");
+  console.log(`cold_precheck_ms            ${cold.ms.toFixed(3)}`);
+  console.log(
+    `warm_precheck_ms_mean       ${warmMean.toFixed(3)} (20 repeats over the same transcript)`,
+  );
+  console.log(
+    `append_step_ms_mean         ${appendMean.toFixed(3)} (10 turns, one new user msg each)`,
+  );
+  console.log("");
+  console.log("per-append measurements:");
+  for (let i = 0; i < appendMs.length; i++) {
+    const turn = pad(String(i + 1).padStart(2), 2);
+    const ms = appendMs[i].toFixed(3).padStart(8);
+    const route = pad(appendRoutes[i], 22);
+    const tokens = appendEstimates[i];
+    console.log(`  turn ${turn} ms=${ms} route=${route} estimatedPromptTokens=${tokens}`);
+  }
+  console.log("");
+  console.log(`final_route                 ${finalDecision.route}`);
+  console.log(`final_estimatedPromptTokens ${finalDecision.estimatedPromptTokens}`);
+  console.log(`final_overflowTokens        ${finalDecision.overflowTokens}`);
+  console.log(`final_promptBudgetBefRes    ${finalDecision.promptBudgetBeforeReserve}`);
+}
+
+main();

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -412,6 +412,7 @@ import {
 import {
   PREEMPTIVE_OVERFLOW_ERROR_TEXT,
   buildPrePromptContextBudgetStatus,
+  estimateAppendOnlyLlmBoundaryTokenPressure,
   formatPrePromptPrecheckLog,
   shouldPreemptivelyCompactBeforePrompt,
 } from "./preemptive-compaction.js";
@@ -3816,6 +3817,22 @@ export async function runEmbeddedAttempt(
                 contextTokenBudget,
                 reserveTokens,
                 toolResultMaxChars: promptToolResultMaxChars,
+                // messagesForCurrentPrompt is activeSession.messages (append-only
+                // between prompt submissions) optionally followed by a freshly
+                // built runtime-context message. The append-only WeakMap caches
+                // the stable activeSession entries by object identity; the new
+                // per-turn runtime-context message is a cache miss that recomputes
+                // once and is gc-eligible after this turn. The public helper
+                // stays fresh by default; this internal cached estimator is not
+                // re-exported through the plugin SDK.
+                llmBoundaryTokenPressure: {
+                  estimatedPromptTokens: estimateAppendOnlyLlmBoundaryTokenPressure({
+                    messages: messagesForCurrentPrompt,
+                    systemPrompt: systemPromptForHook,
+                    prompt: promptForModel,
+                  }),
+                  source: "transcript_estimate",
+                },
               });
           if (preemptiveCompaction) {
             contextBudgetStatus = buildPrePromptContextBudgetStatus({

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
@@ -445,4 +445,146 @@ describe("preemptive-compaction", () => {
     expect(result.route).toBe("truncate_tool_results_only");
     expect(result.shouldCompact).toBe(false);
   });
+
+  describe("per-message identity cache", () => {
+    it("returns the same boundary estimate on repeat scans of the same messages", () => {
+      const messages: AgentMessage[] = [
+        makeAssistantHistory("alpha bravo charlie ".repeat(8)),
+        makeToolResultMessage("result one ".repeat(6), "result two ".repeat(4)),
+        makeAssistantToolCall({ k: "v".repeat(200) }),
+      ];
+      const first = estimateLlmBoundaryTokenPressure({
+        messages,
+        systemPrompt: "sys",
+        prompt: "ping",
+      });
+      const second = estimateLlmBoundaryTokenPressure({
+        messages,
+        systemPrompt: "sys",
+        prompt: "ping",
+      });
+      expect(second).toBe(first);
+    });
+
+    it("memoizes per message identity so post-call content mutation does not alter the estimate", () => {
+      // Demonstrates the cache: after the first scan, a later in-place mutation of
+      // a content block must NOT shift the boundary estimate, because the message
+      // identity is unchanged and the cache short-circuits the re-scan.
+      // (Production messages are append-only; this guards the cache invariant.)
+      const messages: AgentMessage[] = [
+        makeAssistantHistory("baseline content ".repeat(10)),
+        makeToolResultMessage("baseline tool result ".repeat(8)),
+      ];
+      const baseline = estimateLlmBoundaryTokenPressure({
+        messages,
+        systemPrompt: "sys",
+        prompt: "ping",
+      });
+      const assistantContent = (
+        messages[0] as unknown as { content: { type: string; text: string }[] }
+      ).content;
+      assistantContent[0].text = `${assistantContent[0].text} ${"X".repeat(5_000)}`;
+      const afterMutation = estimateLlmBoundaryTokenPressure({
+        messages,
+        systemPrompt: "sys",
+        prompt: "ping",
+      });
+      expect(afterMutation).toBe(baseline);
+    });
+
+    it("re-counts when a brand-new message identity is appended", () => {
+      const transcript: AgentMessage[] = [makeAssistantHistory("seed message ".repeat(6))];
+      const before = estimateLlmBoundaryTokenPressure({
+        messages: transcript,
+        systemPrompt: "sys",
+        prompt: "ping",
+      });
+      const onlyNew = makeAssistantHistory("freshly appended ".repeat(6));
+      const onlyNewTokens = estimateLlmBoundaryTokenPressure({
+        messages: [onlyNew],
+        systemPrompt: "",
+        prompt: "",
+      });
+      const baseline = estimateLlmBoundaryTokenPressure({
+        messages: [],
+        systemPrompt: "sys",
+        prompt: "ping",
+      });
+      const after = estimateLlmBoundaryTokenPressure({
+        messages: [...transcript, onlyNew],
+        systemPrompt: "sys",
+        prompt: "ping",
+      });
+      expect(after).toBeGreaterThan(before);
+      // The non-history overhead (system + prompt + SAFETY_MARGIN) is shared,
+      // so the delta lands within a SAFETY_MARGIN-bounded window of the
+      // standalone per-message estimate. Tight upper-bound check guards the
+      // cache from accidentally double-counting on append.
+      expect(after - before).toBeLessThanOrEqual(onlyNewTokens + baseline);
+    });
+
+    it("does not double-count when the same message identity appears twice", () => {
+      // An accidental dedup-failure (e.g. cache returning 0 on second hit) is
+      // structurally impossible here because the WeakMap value is the per-
+      // message cost, not a "seen" flag. Test makes that contract explicit.
+      const shared = makeAssistantHistory("shared content ".repeat(20));
+      const standalone = estimateLlmBoundaryTokenPressure({
+        messages: [shared],
+        systemPrompt: "sys",
+        prompt: "ping",
+      });
+      const doubled = estimateLlmBoundaryTokenPressure({
+        messages: [shared, shared],
+        systemPrompt: "sys",
+        prompt: "ping",
+      });
+      const empty = estimateLlmBoundaryTokenPressure({
+        messages: [],
+        systemPrompt: "sys",
+        prompt: "ping",
+      });
+      // Each copy contributes once. With shared system + prompt + safety margin
+      // amortized once, `doubled - standalone` ≈ `standalone - empty` within
+      // Math.ceil rounding.
+      expect(doubled - standalone).toBeGreaterThanOrEqual(standalone - empty - 1);
+      expect(doubled - standalone).toBeLessThanOrEqual(standalone - empty + 1);
+    });
+
+    it("preserves precheck route decisions across repeat calls", () => {
+      const messages = [makeAssistantHistory("alpha ".repeat(120))];
+      const first = shouldPreemptivelyCompactBeforePrompt({
+        messages,
+        systemPrompt: "sys",
+        prompt: "ping",
+        contextTokenBudget: 4_000,
+        reserveTokens: 256,
+      });
+      const second = shouldPreemptivelyCompactBeforePrompt({
+        messages,
+        systemPrompt: "sys",
+        prompt: "ping",
+        contextTokenBudget: 4_000,
+        reserveTokens: 256,
+      });
+      expect(second.route).toBe(first.route);
+      expect(second.estimatedPromptTokens).toBe(first.estimatedPromptTokens);
+      expect(second.overflowTokens).toBe(first.overflowTokens);
+    });
+
+    it("counts assistant tool-call argument bytes identically on repeat scans", () => {
+      const heavyArgs = { payload: "X".repeat(20_000) };
+      const messages = [makeAssistantToolCall(heavyArgs)];
+      const cold = estimateLlmBoundaryTokenPressure({
+        messages,
+        systemPrompt: "",
+        prompt: "",
+      });
+      const warm = estimateLlmBoundaryTokenPressure({
+        messages,
+        systemPrompt: "",
+        prompt: "",
+      });
+      expect(warm).toBe(cold);
+    });
+  });
 });

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
@@ -1,9 +1,13 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import "../../test-helpers/agent-session-token-mock.js";
 import { estimateToolResultReductionPotential } from "../tool-result-truncation.js";
 
 let PREEMPTIVE_OVERFLOW_ERROR_TEXT: typeof import("./preemptive-compaction.js").PREEMPTIVE_OVERFLOW_ERROR_TEXT;
+let estimateAppendOnlyLlmBoundaryTokenPressure: typeof import("./preemptive-compaction.js").estimateAppendOnlyLlmBoundaryTokenPressure;
 let estimateLlmBoundaryTokenPressure: typeof import("./preemptive-compaction.js").estimateLlmBoundaryTokenPressure;
 let buildPrePromptContextBudgetStatus: typeof import("./preemptive-compaction.js").buildPrePromptContextBudgetStatus;
 let estimatePrePromptTokens: typeof import("./preemptive-compaction.js").estimatePrePromptTokens;
@@ -15,6 +19,7 @@ beforeAll(async () => {
   vi.resetModules();
   ({
     PREEMPTIVE_OVERFLOW_ERROR_TEXT,
+    estimateAppendOnlyLlmBoundaryTokenPressure,
     estimateLlmBoundaryTokenPressure,
     buildPrePromptContextBudgetStatus,
     estimatePrePromptTokens,
@@ -446,8 +451,8 @@ describe("preemptive-compaction", () => {
     expect(result.shouldCompact).toBe(false);
   });
 
-  describe("per-message identity cache", () => {
-    it("returns the same boundary estimate on repeat scans of the same messages", () => {
+  describe("public estimator freshness", () => {
+    it("returns the same boundary estimate on repeat scans of the same unchanged messages", () => {
       const messages: AgentMessage[] = [
         makeAssistantHistory("alpha bravo charlie ".repeat(8)),
         makeToolResultMessage("result one ".repeat(6), "result two ".repeat(4)),
@@ -466,11 +471,13 @@ describe("preemptive-compaction", () => {
       expect(second).toBe(first);
     });
 
-    it("memoizes per message identity so post-call content mutation does not alter the estimate", () => {
-      // Demonstrates the cache: after the first scan, a later in-place mutation of
-      // a content block must NOT shift the boundary estimate, because the message
-      // identity is unchanged and the cache short-circuits the re-scan.
-      // (Production messages are append-only; this guards the cache invariant.)
+    it("re-reads content after in-place mutation so SDK callers see fresh estimates", () => {
+      // estimateLlmBoundaryTokenPressure is re-exported through
+      // src/plugin-sdk/agent-harness-runtime.ts. Plugin SDK callers may reuse
+      // and mutate AgentMessage objects across calls, so the public helper must
+      // always recount from current content. The append-only WeakMap cache lives
+      // on the internal estimateAppendOnlyLlmBoundaryTokenPressure helper, which
+      // is not part of the SDK surface.
       const messages: AgentMessage[] = [
         makeAssistantHistory("baseline content ".repeat(10)),
         makeToolResultMessage("baseline tool result ".repeat(8)),
@@ -489,44 +496,33 @@ describe("preemptive-compaction", () => {
         systemPrompt: "sys",
         prompt: "ping",
       });
-      expect(afterMutation).toBe(baseline);
+      expect(afterMutation).toBeGreaterThan(baseline);
     });
 
-    it("re-counts when a brand-new message identity is appended", () => {
-      const transcript: AgentMessage[] = [makeAssistantHistory("seed message ".repeat(6))];
-      const before = estimateLlmBoundaryTokenPressure({
-        messages: transcript,
+    it("shouldPreemptivelyCompactBeforePrompt recomputes pressure on mutated content by default", () => {
+      const messages: AgentMessage[] = [makeAssistantHistory("seed ".repeat(20))];
+      const before = shouldPreemptivelyCompactBeforePrompt({
+        messages,
         systemPrompt: "sys",
         prompt: "ping",
+        contextTokenBudget: 8_000,
+        reserveTokens: 256,
       });
-      const onlyNew = makeAssistantHistory("freshly appended ".repeat(6));
-      const onlyNewTokens = estimateLlmBoundaryTokenPressure({
-        messages: [onlyNew],
-        systemPrompt: "",
-        prompt: "",
-      });
-      const baseline = estimateLlmBoundaryTokenPressure({
-        messages: [],
+      const assistantContent = (
+        messages[0] as unknown as { content: { type: string; text: string }[] }
+      ).content;
+      assistantContent[0].text = `${assistantContent[0].text} ${"Y".repeat(20_000)}`;
+      const after = shouldPreemptivelyCompactBeforePrompt({
+        messages,
         systemPrompt: "sys",
         prompt: "ping",
+        contextTokenBudget: 8_000,
+        reserveTokens: 256,
       });
-      const after = estimateLlmBoundaryTokenPressure({
-        messages: [...transcript, onlyNew],
-        systemPrompt: "sys",
-        prompt: "ping",
-      });
-      expect(after).toBeGreaterThan(before);
-      // The non-history overhead (system + prompt + SAFETY_MARGIN) is shared,
-      // so the delta lands within a SAFETY_MARGIN-bounded window of the
-      // standalone per-message estimate. Tight upper-bound check guards the
-      // cache from accidentally double-counting on append.
-      expect(after - before).toBeLessThanOrEqual(onlyNewTokens + baseline);
+      expect(after.estimatedPromptTokens).toBeGreaterThan(before.estimatedPromptTokens);
     });
 
-    it("does not double-count when the same message identity appears twice", () => {
-      // An accidental dedup-failure (e.g. cache returning 0 on second hit) is
-      // structurally impossible here because the WeakMap value is the per-
-      // message cost, not a "seen" flag. Test makes that contract explicit.
+    it("recounts duplicate message identities so repeated entries add their bytes", () => {
       const shared = makeAssistantHistory("shared content ".repeat(20));
       const standalone = estimateLlmBoundaryTokenPressure({
         messages: [shared],
@@ -543,48 +539,104 @@ describe("preemptive-compaction", () => {
         systemPrompt: "sys",
         prompt: "ping",
       });
-      // Each copy contributes once. With shared system + prompt + safety margin
-      // amortized once, `doubled - standalone` ≈ `standalone - empty` within
-      // Math.ceil rounding.
       expect(doubled - standalone).toBeGreaterThanOrEqual(standalone - empty - 1);
       expect(doubled - standalone).toBeLessThanOrEqual(standalone - empty + 1);
     });
+  });
 
-    it("preserves precheck route decisions across repeat calls", () => {
-      const messages = [makeAssistantHistory("alpha ".repeat(120))];
-      const first = shouldPreemptivelyCompactBeforePrompt({
+  describe("internal append-only cached estimator", () => {
+    it("matches the fresh public helper on a single scan", () => {
+      const messages: AgentMessage[] = [
+        makeAssistantHistory("identical content ".repeat(8)),
+        makeToolResultMessage("identical tool result ".repeat(6)),
+      ];
+      const fresh = estimateLlmBoundaryTokenPressure({
         messages,
         systemPrompt: "sys",
         prompt: "ping",
-        contextTokenBudget: 4_000,
-        reserveTokens: 256,
       });
-      const second = shouldPreemptivelyCompactBeforePrompt({
+      const cached = estimateAppendOnlyLlmBoundaryTokenPressure({
         messages,
         systemPrompt: "sys",
         prompt: "ping",
-        contextTokenBudget: 4_000,
-        reserveTokens: 256,
       });
-      expect(second.route).toBe(first.route);
-      expect(second.estimatedPromptTokens).toBe(first.estimatedPromptTokens);
-      expect(second.overflowTokens).toBe(first.overflowTokens);
+      expect(cached).toBe(fresh);
+    });
+
+    it("reflects a new message identity appended after a prior scan", () => {
+      const transcript: AgentMessage[] = [makeAssistantHistory("seed message ".repeat(6))];
+      const before = estimateAppendOnlyLlmBoundaryTokenPressure({
+        messages: transcript,
+        systemPrompt: "sys",
+        prompt: "ping",
+      });
+      const onlyNew = makeAssistantHistory("freshly appended ".repeat(6));
+      const onlyNewTokens = estimateAppendOnlyLlmBoundaryTokenPressure({
+        messages: [onlyNew],
+        systemPrompt: "",
+        prompt: "",
+      });
+      const baseline = estimateAppendOnlyLlmBoundaryTokenPressure({
+        messages: [],
+        systemPrompt: "sys",
+        prompt: "ping",
+      });
+      const after = estimateAppendOnlyLlmBoundaryTokenPressure({
+        messages: [...transcript, onlyNew],
+        systemPrompt: "sys",
+        prompt: "ping",
+      });
+      expect(after).toBeGreaterThan(before);
+      expect(after - before).toBeLessThanOrEqual(onlyNewTokens + baseline);
+    });
+
+    it("does not double-count when the same message identity appears twice", () => {
+      const shared = makeAssistantHistory("shared content ".repeat(20));
+      const standalone = estimateAppendOnlyLlmBoundaryTokenPressure({
+        messages: [shared],
+        systemPrompt: "sys",
+        prompt: "ping",
+      });
+      const doubled = estimateAppendOnlyLlmBoundaryTokenPressure({
+        messages: [shared, shared],
+        systemPrompt: "sys",
+        prompt: "ping",
+      });
+      const empty = estimateAppendOnlyLlmBoundaryTokenPressure({
+        messages: [],
+        systemPrompt: "sys",
+        prompt: "ping",
+      });
+      expect(doubled - standalone).toBeGreaterThanOrEqual(standalone - empty - 1);
+      expect(doubled - standalone).toBeLessThanOrEqual(standalone - empty + 1);
     });
 
     it("counts assistant tool-call argument bytes identically on repeat scans", () => {
       const heavyArgs = { payload: "X".repeat(20_000) };
       const messages = [makeAssistantToolCall(heavyArgs)];
-      const cold = estimateLlmBoundaryTokenPressure({
+      const cold = estimateAppendOnlyLlmBoundaryTokenPressure({
         messages,
         systemPrompt: "",
         prompt: "",
       });
-      const warm = estimateLlmBoundaryTokenPressure({
+      const warm = estimateAppendOnlyLlmBoundaryTokenPressure({
         messages,
         systemPrompt: "",
         prompt: "",
       });
       expect(warm).toBe(cold);
+    });
+
+    it("is not re-exported through the plugin SDK surface", () => {
+      // The append-only cached estimator must stay an internal embedded-runner
+      // helper. Reading the SDK file directly guards against an accidental
+      // future re-export through src/plugin-sdk/agent-harness-runtime.ts.
+      const sdkPath = path.resolve(
+        path.dirname(fileURLToPath(import.meta.url)),
+        "../../../plugin-sdk/agent-harness-runtime.ts",
+      );
+      const sdk = readFileSync(sdkPath, "utf8");
+      expect(sdk).not.toContain("estimateAppendOnlyLlmBoundaryTokenPressure");
     });
   });
 });

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
@@ -590,7 +590,9 @@ describe("preemptive-compaction", () => {
       expect(after - before).toBeLessThanOrEqual(onlyNewTokens + baseline);
     });
 
-    it("does not double-count when the same message identity appears twice", () => {
+    it("adds the per-message cost for each duplicate identity without short-circuiting on cache hit", () => {
+      // Guards against a regression where a "seen" flag instead of the per-message
+      // cost in the WeakMap would silently drop the second occurrence's bytes.
       const shared = makeAssistantHistory("shared content ".repeat(20));
       const standalone = estimateAppendOnlyLlmBoundaryTokenPressure({
         messages: [shared],

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
@@ -184,34 +184,59 @@ function estimateMessageTokenPressure(message: AgentMessage): number {
   return tokens;
 }
 
-// Per-message token pressure is a pure function of the message object's bytes.
-// Messages on the embedded-runner precheck path are append-only and are not
-// mutated in place once added to `activeSession.messages`, so memoize by object
-// identity. WeakMap entries are garbage-collected together with the message,
-// so the cache is bounded by the live transcript and cannot leak.
-const messageTokenPressureCache = new WeakMap<object, number>();
-
-function memoizedMessageTokenPressure(message: AgentMessage): number {
-  if (message !== null && typeof message === "object") {
-    const key = message as unknown as object;
-    const cached = messageTokenPressureCache.get(key);
-    if (cached !== undefined) {
-      return cached;
-    }
-    const computed = estimateMessageTokenPressure(message);
-    messageTokenPressureCache.set(key, computed);
-    return computed;
-  }
-  return estimateMessageTokenPressure(message);
-}
-
 export function estimateLlmBoundaryTokenPressure(params: {
   messages: AgentMessage[];
   systemPrompt?: string;
   prompt: string;
 }): number {
   const historyTokens = params.messages.reduce(
-    (sum, message) => sum + memoizedMessageTokenPressure(message),
+    (sum, message) => sum + estimateMessageTokenPressure(message),
+    0,
+  );
+  const systemTokens =
+    typeof params.systemPrompt === "string" && params.systemPrompt.trim().length > 0
+      ? MESSAGE_BOUNDARY_OVERHEAD_TOKENS + estimateStringTokenPressure(params.systemPrompt)
+      : 0;
+  const promptTokens =
+    MESSAGE_BOUNDARY_OVERHEAD_TOKENS + estimateStringTokenPressure(params.prompt);
+  return Math.max(0, Math.ceil((historyTokens + systemTokens + promptTokens) * SAFETY_MARGIN));
+}
+
+// Internal append-only variant for the embedded-runner precheck path only.
+//
+// Memoizes per-message token pressure by message object identity using a
+// process-local WeakMap. Safe ONLY when callers treat the message objects as
+// immutable for the cache lifetime — the embedded-runner appends new message
+// identities to `activeSession.messages` and does not in-place mutate prior
+// entries between prompt submissions, so identity is a stable key on that path.
+//
+// This helper is intentionally NOT exported through `src/plugin-sdk/*`. The
+// public `estimateLlmBoundaryTokenPressure` and `shouldPreemptivelyCompactBeforePrompt`
+// helpers continue to recompute fresh per call so plugin SDK callers that
+// reuse and mutate message objects keep their fresh-estimate semantics.
+const appendOnlyMessageTokenPressureCache = new WeakMap<object, number>();
+
+function appendOnlyMemoizedMessageTokenPressure(message: AgentMessage): number {
+  if (message !== null && typeof message === "object") {
+    const key = message as unknown as object;
+    const cached = appendOnlyMessageTokenPressureCache.get(key);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const computed = estimateMessageTokenPressure(message);
+    appendOnlyMessageTokenPressureCache.set(key, computed);
+    return computed;
+  }
+  return estimateMessageTokenPressure(message);
+}
+
+export function estimateAppendOnlyLlmBoundaryTokenPressure(params: {
+  messages: AgentMessage[];
+  systemPrompt?: string;
+  prompt: string;
+}): number {
+  const historyTokens = params.messages.reduce(
+    (sum, message) => sum + appendOnlyMemoizedMessageTokenPressure(message),
     0,
   );
   const systemTokens =

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
@@ -184,13 +184,34 @@ function estimateMessageTokenPressure(message: AgentMessage): number {
   return tokens;
 }
 
+// Per-message token pressure is a pure function of the message object's bytes.
+// Messages on the embedded-runner precheck path are append-only and are not
+// mutated in place once added to `activeSession.messages`, so memoize by object
+// identity. WeakMap entries are garbage-collected together with the message,
+// so the cache is bounded by the live transcript and cannot leak.
+const messageTokenPressureCache = new WeakMap<object, number>();
+
+function memoizedMessageTokenPressure(message: AgentMessage): number {
+  if (message !== null && typeof message === "object") {
+    const key = message as unknown as object;
+    const cached = messageTokenPressureCache.get(key);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const computed = estimateMessageTokenPressure(message);
+    messageTokenPressureCache.set(key, computed);
+    return computed;
+  }
+  return estimateMessageTokenPressure(message);
+}
+
 export function estimateLlmBoundaryTokenPressure(params: {
   messages: AgentMessage[];
   systemPrompt?: string;
   prompt: string;
 }): number {
   const historyTokens = params.messages.reduce(
-    (sum, message) => sum + estimateMessageTokenPressure(message),
+    (sum, message) => sum + memoizedMessageTokenPressure(message),
     0,
   );
   const systemTokens =


### PR DESCRIPTION
## Summary

What problem does this PR solve?

`shouldPreemptivelyCompactBeforePrompt` (the per-turn pre-prompt token-pressure precheck on the embedded-runner path) reduces over the entire transcript on every prompt submission via `estimateLlmBoundaryTokenPressure` → `estimateMessageTokenPressure`. The per-message work is recomputed every turn even when only a single message has been appended since the last call, so the wall-time cost of the precheck grows linearly with session length on the hot path before the provider request is sent.

Why does this matter now?

Tool-heavy long sessions pay multi-millisecond per-turn CPU on the precheck. Synthetic 1000-message tool-heavy transcripts measure ~2.9 ms / turn on the public fresh helper; with the embedded-runner cached path on the same transcript the warm per-turn cost drops to ~1.8 ms (and ~1.4 ms when only one new message has been appended). None of this is dominant on its own, but it is purely pre-dispatch local CPU that the same turn pays over and over with no semantic change to the inputs.

What is the intended outcome?

Add a new internal-only helper `estimateAppendOnlyLlmBoundaryTokenPressure` that memoizes `estimateMessageTokenPressure` by message object identity using a process-local `WeakMap<object, number>`. The embedded-runner precheck site in `src/agents/embedded-agent-runner/run/attempt.ts` precomputes the cached estimate from `messagesForCurrentPrompt` (the array the precheck actually evaluates: `activeSession.messages`, optionally followed by a freshly-built runtime-context message for the current turn) and feeds it to `shouldPreemptivelyCompactBeforePrompt` via the existing `llmBoundaryTokenPressure` parameter — the same caller-supplied anchor seam introduced in #85541.

The cache is intentionally NOT used by the public helpers re-exported through `src/plugin-sdk/agent-harness-runtime.ts`:

- `estimateLlmBoundaryTokenPressure` recounts on every call.
- `shouldPreemptivelyCompactBeforePrompt` defaults to a fresh recount unless the caller supplies an explicit `llmBoundaryTokenPressure` (already its public contract).
- `estimateAppendOnlyLlmBoundaryTokenPressure` is not added to the plugin SDK surface; a new test reads `agent-harness-runtime.ts` and asserts it is absent.

No semantic change to the public helpers: the numerical output of `estimateLlmBoundaryTokenPressure` and the `route` / `overflowTokens` / `estimatedPromptTokens` fields of `shouldPreemptivelyCompactBeforePrompt` are byte-identical to current main for any given input. The new internal cached helper returns identical values to the fresh helper when called on the same inputs without intervening mutation; the committed benchmark prints a parity-check line to confirm this.

What is intentionally out of scope?

- Wiring `llmBoundaryTokenPressure` from a real-rendered-transport-bytes anchor (the canonical-fact-forward direction introduced in #85541). This PR caches the fallback path; it does not compete with that direction.
- `estimateMessagesTokens` in `compaction.ts` (compaction-event path) and the existing prune loop in `compaction.ts`.
- `estimateToolResultReductionPotential` in `tool-result-truncation.ts`, which is the un-cached residual cost still present in the precheck wall time.
- Anthropic-side payload / cache-control work.
- Media path work.

What does success look like?

The committed replay artifact (`scripts/perf/preemptive-precheck-replay.ts`) demonstrates the post-patch warm wall-time of the embedded-runner cached path (≈ 1.8 ms) vs the public fresh helper baseline on the same transcript (≈ 2.9 ms), plus an explicit parity check that the two estimators return the same number on identical inputs. This PR does not claim TTFT, p95/p99, or any provider-side improvement. No semantic change on the public SDK helpers; the targeted validation listed below passes (modulo an upstream-induced shrinkwrap-guard failure documented under "Conflict-only rebase validity note"); new behavior tests pin both the public-helper freshness contract and the internal-cache invariants.

What should reviewers focus on?

- **Public SDK helper freshness:** `estimateLlmBoundaryTokenPressure` and `shouldPreemptivelyCompactBeforePrompt` still recount on every call. New tests under `describe("public estimator freshness")` mutate message content in place after a first scan and assert the second scan reflects the mutation. This is the contract that earlier review rounds flagged as load-bearing for plugin SDK callers.
- **Internal cache scope:** the WeakMap lives on `appendOnlyMessageTokenPressureCache` inside `preemptive-compaction.ts` and is only reachable via `estimateAppendOnlyLlmBoundaryTokenPressure`. That helper is only imported by `attempt.ts` for the precheck site. A test grep'ing `agent-harness-runtime.ts` guards against accidental SDK re-export.
- **Append-only invariant on the precheck path:** `activeSession.messages` is append-only between prompt submissions. Window replacement (`state.messages = limited`) creates new identities, which the WeakMap handles correctly. The freshly-built per-turn runtime-context message that upstream attaches via `messagesForCurrentPrompt` is a new identity each turn — a cache miss that recomputes once and is gc-eligible after the precheck returns.
- **Identity-cache + `unwindowedMessages` interaction:** `attempt.ts` precomputes the cached estimate for `messagesForCurrentPrompt` only. The `unwindowedMessages` path inside `shouldPreemptivelyCompactBeforePrompt` continues to use the fresh estimator (correctness-first; it is only invoked when context-engine prompt authority is `preassembly_may_overflow`).

## Identity-cache scope and reproducible benchmark

Reproducible benchmark artifact: `scripts/perf/preemptive-precheck-replay.ts`. It mirrors the embedded-runner call shape at `src/agents/embedded-agent-runner/run/attempt.ts` — precompute the boundary estimate with the internal append-only cached estimator, then feed it to `shouldPreemptivelyCompactBeforePrompt` via `llmBoundaryTokenPressure`. It also runs the public fresh helper on a parallel transcript as a baseline, and emits a parity-check line.

Caller inventory for `shouldPreemptivelyCompactBeforePrompt` (existing callers, NOT changed by this PR — confirms the cache is not silently engaged from anywhere else):

- `src/agents/embedded-agent-runner/run/attempt.ts:3817` — embedded-runner prompt-submission loop. Messages source: `messagesForCurrentPrompt` (`activeSession.messages` plus an optional per-turn runtime-context message). Stable identities on the session portion; the runtime-context message is fresh per turn. **This is the only production caller that supplies `llmBoundaryTokenPressure` from the new internal cached estimator.**
- `src/agents/command/cli-compaction.ts:462` — `openclaw compact` CLI. Messages source: `getSessionBranchMessages(sessionManager)` (read from session JSONL). Calls `shouldPreemptivelyCompactBeforePrompt` without `llmBoundaryTokenPressure` → fresh recount via the public helper.
- `src/agents/embedded-agent-runner/tool-result-context-guard.ts:514` — mid-turn tool-result truncation guard. Calls `shouldPreemptivelyCompactBeforePrompt` without `llmBoundaryTokenPressure` → fresh recount via the public helper.

External callers via plugin-sdk: `src/plugin-sdk/agent-harness-runtime.ts` re-exports `shouldPreemptivelyCompactBeforePrompt` and `estimateRenderedLlmBoundaryTokenPressure` for plugin authors. The new internal `estimateAppendOnlyLlmBoundaryTokenPressure` is intentionally NOT re-exported through the SDK — a new test under `describe("internal append-only cached estimator")` reads `agent-harness-runtime.ts` and asserts the helper name is absent. Plugin SDK callers that mutate message objects in place between calls continue to see fresh estimates, which addresses the ClawSweeper P1 finding from an earlier round of review.

## Linked context

Which issue does this close?

Closes #

This PR does not close an issue. It addresses a structural cost identified in local profiling that overlaps in shape with reports such as #76702 (Windows + Feishu DM slow large-session latency) and #86231 (Codex harness prompt latency overhead). It deliberately does not claim to resolve either, because neither has been root-caused to the precheck path; the per-turn precheck saving alone is too small to explain those reports.

Which issues, PRs, or discussions are related?

Related #85541 (the PR that reshaped this estimator into `estimateLlmBoundaryTokenPressure` and introduced `llmBoundaryTokenPressure` as a caller-supplied anchor — this PR uses that seam rather than competing with it).

Was this requested by a maintainer or owner?

No.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: per-turn `shouldPreemptivelyCompactBeforePrompt` CPU wall time on the embedded-runner precheck path scales O(N) with transcript size and recomputes the same per-message token pressure on every turn for unchanged messages. An earlier round of this PR addressed the cost by caching inside the public helper, which created a plugin-SDK compatibility break (stale estimates after in-place message mutation). The current shape moves the cache off the public helper and onto a new internal append-only helper used only by `attempt.ts`.
- Real environment tested: Linux 6.8.0-111-generic, Node 22.22.2, branch `feature/openclaw-preemptive-precheck-cache` on `37978b6803` rebased on `upstream/main` `4bd711e1c424`. Production function `shouldPreemptivelyCompactBeforePrompt` is the call under measurement, via the same import path the embedded-runner uses, with the same `llmBoundaryTokenPressure` parameter that `attempt.ts` supplies after this patch.
- Exact steps or command run after this patch:
  - `node --version` → v22.22.2
  - `PROBE_HEAD=$(git rev-parse HEAD) pnpm exec tsx scripts/perf/preemptive-precheck-replay.ts`
  - `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts`
  - `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts src/agents/command/cli-compaction.test.ts src/agents/embedded-agent-runner/tool-result-context-guard.test.ts`
  - `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
  - `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
  - `node scripts/run-oxlint.mjs src/agents/embedded-agent-runner/run/preemptive-compaction.ts src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts src/agents/embedded-agent-runner/run/attempt.ts scripts/perf/preemptive-precheck-replay.ts`
- Evidence after fix:

Live console output from the committed replay artifact against the production helpers — copied terminal capture, not a unit test summary:

```
$ PROBE_HEAD=$(git rev-parse HEAD) pnpm exec tsx scripts/perf/preemptive-precheck-replay.ts
openclaw preemptive-precheck-replay (embedded-runner path)
commit                      37978b6803540f39ebc48c5ae2a909475ab1e35c
messages_in                 1010
budget_tokens               200000
reserve                     16000

cold_precheck_ms            7.844 (append-only cached path)
warm_precheck_ms_mean       1.803 (20 repeats, append-only cached path)
fresh_precheck_ms_mean      2.857 (20 repeats, public fresh helper, parallel transcript)
append_step_ms_mean         1.398 (10 turns, one new user msg each, cached path)

estimator_parity_cached     199618
estimator_parity_fresh      199618
estimator_parity_match      true

per-append measurements (cached path):
  turn  1 ms=   1.332 route=compact_then_truncate  estimatedPromptTokens=1555832
  turn  2 ms=   1.313 route=compact_then_truncate  estimatedPromptTokens=1555911
  ...
  turn 10 ms=   1.373 route=compact_then_truncate  estimatedPromptTokens=1556544

final_route                 compact_then_truncate
final_estimatedPromptTokens 1556544
final_overflowTokens        1372544
final_promptBudgetBefRes    184000
```

Vitest output for the changed test file (copied):

```
$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
 Test Files  2 passed (2)
      Tests  50 passed (50)
```

- Observed result after fix: the public `estimateLlmBoundaryTokenPressure` and `shouldPreemptivelyCompactBeforePrompt` helpers return fresh estimates after in-place content mutation (pinned by `re-reads content after in-place mutation so SDK callers see fresh estimates` and `shouldPreemptivelyCompactBeforePrompt recomputes pressure on mutated content by default`). The internal `estimateAppendOnlyLlmBoundaryTokenPressure` returns the same number as the fresh public helper on identical inputs (pinned by the benchmark's `estimator_parity_match` line and by the test `matches the fresh public helper on a single scan`), and is byte-identical to the un-mutated cold scan on repeat. The cached path's warm-per-turn cost (1.803 ms) is ~37% lower than the fresh public helper's per-turn cost (2.857 ms) on the same 1010-message tool-heavy synthetic transcript.
- What was not tested: no live provider/channel ingress (no Anthropic/OpenAI call); no captured real session JSONL replay (the transcript is synthetic but uses the production message shape and the production exported helper); no Windows or non-x86_64 hardware run; no claim of TTFT or provider-side improvement.
- Proof limitations or environment constraints: synthetic transcript, single machine, single Node version. Absolute numbers are hardware-dependent; the relative ordering (cached < fresh < cold) and the parity check are the parts that generalize. The replay harness can be re-run by any reviewer on a normal worktree (no provider credentials required).

## Conflict-only rebase validity note

This branch was rebased onto `upstream/main` at `4bd711e1c424` to resolve conflicts introduced by upstream commits `bb46b79d3c refactor: internalize OpenClaw agent runtime (#85341)` (which renamed `src/agents/pi-embedded-runner/run/` → `src/agents/embedded-agent-runner/run/`) and the change in `attempt.ts` that now passes `messagesForCurrentPrompt` (the precheck's actual input array) to `shouldPreemptivelyCompactBeforePrompt`. The PR's logic is unchanged:

- Cached estimator input was updated from `activeSession.messages` to `messagesForCurrentPrompt` so the supplied `llmBoundaryTokenPressure` matches the precheck's actual input. The append-only invariant still holds: the `activeSession.messages` portion is identity-stable, and the per-turn freshly-built runtime-context message becomes a single cache miss that recomputes once and is gc-eligible after the turn.
- The internal helper, the public-helper-fresh contract, and the SDK non-export test are intact at the new path.

`OPENCLAW_LOCAL_CHECK=1 node scripts/check-changed.mjs` reports the `npm shrinkwrap guard` as failing with `npm-shrinkwrap.json is stale. Run pnpm deps:shrinkwrap:generate.`. This PR's diff does not touch `package.json` / `npm-shrinkwrap.json` / `pnpm-lock.yaml` — verifiable by `git diff --name-only upstream/main..HEAD`, which lists exactly the four files in this PR. The drift is upstream-induced from commits on `upstream/main` (`bb46b79d3c` + `cee2a50fe6 chore(release): prepare 2026.5.28`).

## Tests and validation

Which commands did you run?

Listed under "Exact steps or command run after this patch" above.

What regression coverage was added or updated?

Two `describe` blocks in `src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts`:

`public estimator freshness` (asserts the SDK contract):
1. Same boundary estimate on repeat scans of the same unchanged messages.
2. **Re-reads content after in-place mutation so SDK callers see fresh estimates.**
3. **`shouldPreemptivelyCompactBeforePrompt` recomputes pressure on mutated content by default.**
4. Recounts duplicate message identities so repeated entries add their bytes.

`internal append-only cached estimator` (asserts the embedded-runner-only cache contract):
1. Matches the fresh public helper on a single scan (parity).
2. Reflects a new message identity appended after a prior scan.
3. Adds the per-message cost for each duplicate identity without short-circuiting on cache hit.
4. Counts assistant tool-call argument bytes identically on repeat scans.
5. **Is not re-exported through the plugin SDK surface** (reads `src/plugin-sdk/agent-harness-runtime.ts` and asserts the helper name is absent).

What failed before this fix, if known?

Not a correctness regression on current main; the PR is a performance optimization. The current shape is also a response to an earlier ClawSweeper P1 (since resolved) that the prior implementation made the package-exported precheck helper return stale estimates after in-place message mutation.

If no test was added, why not?

N/A.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

No. `shouldPreemptivelyCompactBeforePrompt` returns the same decision for any given input it received before this PR. The embedded-runner now supplies an additional `llmBoundaryTokenPressure` from the new internal cached estimator, but that estimator returns the same number as the previous fresh recount on the same input (asserted by `matches the fresh public helper on a single scan` and by the benchmark's `estimator_parity_match` line).

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

The append-only cache contract on the embedded-runner path. If a future caller imports `estimateAppendOnlyLlmBoundaryTokenPressure` and uses it against a non-append-only message stream (e.g. message objects that get content-mutated in place between calls), the cached estimate will be stale.

How is that risk mitigated?

- **Type & comment contract:** the doc-comment block above `appendOnlyMessageTokenPressureCache` names the contract; the attempt.ts call site has an extended comment explaining the `messagesForCurrentPrompt` shape (stable `activeSession.messages` entries + per-turn fresh runtime-context message as cache miss).
- **SDK isolation test:** the new test `is not re-exported through the plugin SDK surface` reads `src/plugin-sdk/agent-harness-runtime.ts` and asserts `estimateAppendOnlyLlmBoundaryTokenPressure` is absent. Any future PR that re-exports it through the SDK barrel will fail this test and force an explicit review of the contract.
- **In-tree caller inventory:** the only production caller of the internal helper is `attempt.ts`. `cli-compaction.ts` and `tool-result-context-guard.ts` continue to call the public helper for fresh estimates.
- **Repo policy alignment:** process-local metadata caches are explicitly permitted by `AGENTS.md` ("Process-local metadata caches ok when lifecycle-owned and bounded/single-slot. Freshness exceptions need named owner + tests"). This cache is process-local, lifecycle-bounded by the WeakMap-to-message reference, single-slot per message, and covered by the named test contract.

## Current review state

What is the next action?

Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

Maintainer review of the append-only cache invariant on the embedded-runner precheck path.

Which bot or reviewer comments were addressed?

ClawSweeper review 2026-05-26T22:25Z (against prior head `a5e7c03eb2`): no contributor-facing rank-up moves remained; the only rank-up note was to wait for green required checks. After this conflict-only refresh, the branch was rebased onto `4bd711e1c424` and the four PR commits were preserved.

Codex / GPT-5.5 PR diff review of the rebased state (`docs/work-items/openclaw-preemptive-precheck-cache/CODEX-REBASE-REVIEW.md`): verdict GO, no P0/P1 blockers. One P1 recommendation (attempt-level wiring assertion) was evaluated and declined as decorative given the existing parity + identity-append + SDK-non-export coverage (consistent with the prior round's no-op rationale in `CODEX-NOOP-REVIEW.md`). One P2 recommendation (document shrinkwrap drift) was applied in this PR body refresh.
