### PR TITLE
test: improve test profiling helpers

### DIFF
--- a/scripts/run-vitest-profile.mjs
+++ b/scripts/run-vitest-profile.mjs
@@ -10,10 +10,19 @@ export function parseArgs(argv) {
   const args = {
     mode: "",
     outputDir: process.env.OPENCLAW_VITEST_PROFILE_DIR?.trim() || "",
+    vitestArgs: [],
   };
 
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
+    if (arg === "--") {
+      const rest = argv.slice(i + 1);
+      if (rest[0] === "--output-dir") {
+        continue;
+      }
+      args.vitestArgs = rest;
+      break;
+    }
     if (arg === "--output-dir") {
       args.outputDir = argv[i + 1] ?? "";
       i += 1;
@@ -44,6 +53,10 @@ export function resolveVitestProfileDir({ mode, outputDir }) {
 }
 
 export function buildVitestProfileCommand({ mode, outputDir }) {
+  return buildVitestProfileCommandWithArgs({ mode, outputDir, vitestArgs: [] });
+}
+
+export function buildVitestProfileCommandWithArgs({ mode, outputDir, vitestArgs }) {
   if (mode === "main") {
     return {
       command: process.execPath,
@@ -55,6 +68,7 @@ export function buildVitestProfileCommand({ mode, outputDir }) {
         "--config",
         "test/vitest/vitest.unit.config.ts",
         "--no-file-parallelism",
+        ...vitestArgs,
       ],
     };
   }
@@ -71,6 +85,7 @@ export function buildVitestProfileCommand({ mode, outputDir }) {
       `--execArgv=--cpu-prof-dir=${outputDir}`,
       "--execArgv=--heap-prof",
       `--execArgv=--heap-prof-dir=${outputDir}`,
+      ...vitestArgs,
     ],
   };
 }
@@ -99,9 +114,10 @@ function main() {
   const outputDir = resolveVitestProfileDir(parsed);
   fs.mkdirSync(outputDir, { recursive: true });
 
-  const plan = buildVitestProfileCommand({
+  const plan = buildVitestProfileCommandWithArgs({
     mode: parsed.mode,
     outputDir,
+    vitestArgs: parsed.vitestArgs,
   });
 
   console.log(`[run-vitest-profile] writing ${parsed.mode} profiles to ${outputDir}`);

--- a/scripts/test-group-report.mjs
+++ b/scripts/test-group-report.mjs
@@ -269,13 +269,27 @@ function withUniqueLabels(plans) {
   });
 }
 
+function buildFullSuiteLeafRunPlans() {
+  const previousLeafShards = process.env.OPENCLAW_TEST_PROJECTS_LEAF_SHARDS;
+  process.env.OPENCLAW_TEST_PROJECTS_LEAF_SHARDS = "1";
+  try {
+    return buildFullSuiteVitestRunPlans([], process.cwd());
+  } finally {
+    if (previousLeafShards === undefined) {
+      delete process.env.OPENCLAW_TEST_PROJECTS_LEAF_SHARDS;
+    } else {
+      process.env.OPENCLAW_TEST_PROJECTS_LEAF_SHARDS = previousLeafShards;
+    }
+  }
+}
+
 export function resolveRunPlans(args) {
   if (args.reports.length > 0) {
     return [];
   }
   if (args.fullSuite) {
     return withUniqueLabels(
-      buildFullSuiteVitestRunPlans([], process.cwd()).map((plan) => ({
+      buildFullSuiteLeafRunPlans().map((plan) => ({
         config: plan.config,
         forwardedArgs: plan.forwardedArgs ?? [],
         label: normalizeConfigLabel(plan.config),

--- a/test/scripts/run-vitest-profile.test.ts
+++ b/test/scripts/run-vitest-profile.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildVitestProfileSpawnSpec,
   buildVitestProfileCommand,
+  buildVitestProfileCommandWithArgs,
   parseArgs,
   resolveVitestProfileDir,
 } from "../../scripts/run-vitest-profile.mjs";
@@ -83,6 +84,30 @@ describe("scripts/run-vitest-profile", () => {
     expect(parseArgs(["runner", "--output-dir", "/tmp/out"])).toEqual({
       mode: "runner",
       outputDir: "/tmp/out",
+      vitestArgs: [],
+    });
+  });
+
+  it("passes vitest args after a separator", () => {
+    expect(parseArgs(["main", "--output-dir", "/tmp/out", "--", "--config", "custom.ts"])).toEqual({
+      mode: "main",
+      outputDir: "/tmp/out",
+      vitestArgs: ["--config", "custom.ts"],
+    });
+    expect(
+      buildVitestProfileCommandWithArgs({
+        mode: "runner",
+        outputDir: "/tmp/profile-runner",
+        vitestArgs: ["src/example.test.ts"],
+      }).args,
+    ).toContain("src/example.test.ts");
+  });
+
+  it("allows a package-script separator before script flags", () => {
+    expect(parseArgs(["main", "--", "--output-dir", "/tmp/out"])).toEqual({
+      mode: "main",
+      outputDir: "/tmp/out",
+      vitestArgs: [],
     });
   });
 });

--- a/test/scripts/test-group-report.test.ts
+++ b/test/scripts/test-group-report.test.ts
@@ -274,6 +274,34 @@ describe("scripts/test-group-report arg parsing", () => {
 });
 
 describe("scripts/test-group-report run plans", () => {
+  it("uses leaf configs for full-suite profiling without requiring parallel env", () => {
+    const previousParallel = process.env.OPENCLAW_TEST_PROJECTS_PARALLEL;
+    const previousLeaf = process.env.OPENCLAW_TEST_PROJECTS_LEAF_SHARDS;
+    delete process.env.OPENCLAW_TEST_PROJECTS_PARALLEL;
+    delete process.env.OPENCLAW_TEST_PROJECTS_LEAF_SHARDS;
+    try {
+      const plans = resolveRunPlans(parseTestGroupReportArgs(["--full-suite"]));
+
+      expect(plans.map((plan) => plan.config)).not.toContain(
+        "test/vitest/vitest.full-agentic.config.ts",
+      );
+      expect(plans.map((plan) => plan.config)).toContain(
+        "test/vitest/vitest.agents-tools.config.ts",
+      );
+    } finally {
+      if (previousParallel === undefined) {
+        delete process.env.OPENCLAW_TEST_PROJECTS_PARALLEL;
+      } else {
+        process.env.OPENCLAW_TEST_PROJECTS_PARALLEL = previousParallel;
+      }
+      if (previousLeaf === undefined) {
+        delete process.env.OPENCLAW_TEST_PROJECTS_LEAF_SHARDS;
+      } else {
+        process.env.OPENCLAW_TEST_PROJECTS_LEAF_SHARDS = previousLeaf;
+      }
+    }
+  });
+
   it("preserves full-suite shard file args and unique report labels", () => {
     const previousParallel = process.env.OPENCLAW_TEST_PROJECTS_PARALLEL;
     process.env.OPENCLAW_TEST_PROJECTS_PARALLEL = "6";


### PR DESCRIPTION
## Summary

- Make `test:perf:groups --full-suite` expand leaf Vitest configs even when the parallel-shard env is not set, so profiling reports avoid quiet composite shards.
- Let `run-vitest-profile` accept Vitest passthrough args after `--`, including the package-script separator form.
- Add regression coverage for both profiling helpers.

## Verification

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/test-group-report.test.ts test/scripts/run-vitest-profile.test.ts --reporter=verbose`
- `git diff --check`
- Autoreview: `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings.
- AWS Crabbox `run_b264544c5d7e`, lease `cbx_a15fb97d8e67`, `c7a.8xlarge`: tooling 18 passed, media 59 passed, image quality 1 passed, image auth 5 passed.

## Real behavior proof

Behavior addressed: profiling full-suite test timings and CPU-profile helper argument forwarding.
Real environment tested: local macOS checkout and AWS Crabbox Linux `c7a.8xlarge`.
Exact steps or command run after this patch: `pnpm crabbox:run -- --idle-timeout 45m --ttl 120m --timing-json --shell -- 'set -euo pipefail ... focused Vitest commands ...'`.
Evidence after fix: Crabbox `run_b264544c5d7e` completed with exit 0; command phases `test-tooling`, `test-media`, `test-image-quality`, and `test-image-auth` all passed.
Observed result after fix: `--full-suite` profiling plans use leaf configs, and `run-vitest-profile` preserves explicit profiling output while forwarding Vitest args.
What was not tested: full release CI; proof is focused on the changed profiling scripts and media/image tests used while validating the profiling investigation.
