### PR TITLE
fix(discord): gate native built-ins before success UI

### DIFF
--- a/extensions/discord/src/monitor/native-command-arg-ui.ts
+++ b/extensions/discord/src/monitor/native-command-arg-ui.ts
@@ -109,7 +109,7 @@ export async function handleDiscordCommandArgInteraction(params: {
     await clearWithMessage("Sorry, that command is no longer available.");
     return;
   }
-  const argUpdateResult = await clearWithMessage(`✅ Selected ${parsed.value}.`);
+  const argUpdateResult = await clearWithMessage(`⏳ Applying ${parsed.value}...`);
   if (argUpdateResult === null) {
     return;
   }

--- a/extensions/discord/src/monitor/native-command-auth.ts
+++ b/extensions/discord/src/monitor/native-command-auth.ts
@@ -63,6 +63,36 @@ export function resolveDiscordNativeCommandAllowlistAccess(params: {
   return { configured: true, allowed: match.allowed } as const;
 }
 
+export function resolveDiscordCommandOwnerAllowFrom(cfg: OpenClawConfig): string[] | undefined {
+  const raw = cfg.commands?.ownerAllowFrom;
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return undefined;
+  }
+  const entries: string[] = [];
+  for (const entry of raw) {
+    const trimmed = normalizeOptionalString(String(entry ?? "")) ?? "";
+    if (!trimmed) {
+      continue;
+    }
+    const separatorIndex = trimmed.indexOf(":");
+    if (separatorIndex > 0) {
+      const prefix = trimmed.slice(0, separatorIndex).toLowerCase();
+      if (prefix === "discord") {
+        const remainder = normalizeOptionalString(trimmed.slice(separatorIndex + 1)) ?? "";
+        if (remainder) {
+          entries.push(remainder);
+        }
+        continue;
+      }
+      if (prefix !== "user" && prefix !== "pk") {
+        continue;
+      }
+    }
+    entries.push(trimmed);
+  }
+  return entries.length > 0 ? entries : undefined;
+}
+
 export async function resolveDiscordGuildNativeCommandAuthorized(params: {
   cfg: OpenClawConfig;
   accountId: string;
@@ -157,6 +187,7 @@ export async function resolveDiscordNativeAutocompleteAuthorized(params: {
   cfg: OpenClawConfig;
   discordConfig: DiscordConfig;
   accountId: string;
+  skipCommandOwnerAllowFrom?: boolean;
 }): Promise<boolean> {
   const { interaction, cfg, discordConfig, accountId } = params;
   const user = interaction.user;
@@ -288,6 +319,23 @@ export async function resolveDiscordNativeAutocompleteAuthorized(params: {
   });
   if (!groupDmAccess.allowed) {
     return false;
+  }
+  if (params.skipCommandOwnerAllowFrom !== true) {
+    const commandOwnerAllowFrom = resolveDiscordCommandOwnerAllowFrom(cfg);
+    const { ownerAllowed: commandOwnerOk } = resolveDiscordOwnerAccess({
+      allowFrom: commandOwnerAllowFrom,
+      sender: {
+        id: sender.id,
+        name: sender.name,
+        tag: sender.tag,
+      },
+      allowNameMatching,
+    });
+    const commandOwnerAllowAll = commandOwnerAllowFrom?.includes("*") === true;
+    const senderIsCommandOwner = commandOwnerOk || commandOwnerAllowAll;
+    if (commandOwnerAllowFrom && !senderIsCommandOwner && !commandsAllowFromAccess.allowed) {
+      return false;
+    }
   }
   if (!isDirectMessage) {
     return resolveDiscordGuildNativeCommandAuthorized({

--- a/extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts
+++ b/extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts
@@ -142,6 +142,22 @@ describe("Discord native slash commands with commands.allowFrom", () => {
     expectNotUnauthorizedReply(interaction);
   });
 
+  it("authorizes command allowlist users even when commands.ownerAllowFrom is also configured", async () => {
+    const { dispatchSpy, interaction } = await runGuildSlashCommand({
+      userId: "999999999999999999",
+      mutateConfig: (cfg) => {
+        cfg.commands = {
+          ownerAllowFrom: ["user:123456789012345678"],
+          allowFrom: {
+            discord: ["user:999999999999999999"],
+          },
+        };
+      },
+    });
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    expectNotUnauthorizedReply(interaction);
+  });
+
   it("authorizes guild slash commands from the global commands.allowFrom list when provider-specific allowFrom is missing", async () => {
     const { dispatchSpy, interaction } = await runGuildSlashCommand({
       mutateConfig: (cfg) => {
@@ -319,6 +335,19 @@ describe("Discord native slash commands with commands.allowFrom", () => {
             ...cfg.channels?.discord,
             allowFrom: ["user:123456789012345678"],
           },
+        };
+      },
+    });
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    expectUnauthorizedReply(interaction);
+  });
+
+  it("rejects guild slash commands when commands.ownerAllowFrom fails even if the channel-level native gate allowed the command", async () => {
+    const { dispatchSpy, interaction } = await runGuildSlashCommand({
+      userId: "999999999999999999",
+      mutateConfig: (cfg) => {
+        cfg.commands = {
+          ownerAllowFrom: ["user:123456789012345678"],
         };
       },
     });

--- a/extensions/discord/src/monitor/native-command.options.test.ts
+++ b/extensions/discord/src/monitor/native-command.options.test.ts
@@ -32,6 +32,8 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", () => ({
 
 let listNativeCommandSpecs: typeof import("openclaw/plugin-sdk/command-auth").listNativeCommandSpecs;
 let createDiscordNativeCommand: typeof import("./native-command.js").createDiscordNativeCommand;
+let nativeCommandTesting: typeof import("./native-command.js").testing;
+let resolveDiscordNativeAutocompleteAuthorized: typeof import("./native-command-auth.js").resolveDiscordNativeAutocompleteAuthorized;
 let createNoopThreadBindingManager: typeof import("./thread-bindings.js").createNoopThreadBindingManager;
 
 function createNativeCommand(
@@ -116,6 +118,29 @@ function requireAutocomplete(option: CommandOption, errorMessage: string) {
   return autocomplete as (interaction: unknown) => Promise<unknown>;
 }
 
+function createAllowedGuildAutocompleteConfig(
+  commands: NonNullable<OpenClawConfig["commands"]>,
+): OpenClawConfig {
+  return {
+    commands,
+    channels: {
+      discord: {
+        groupPolicy: "allowlist",
+        guilds: {
+          "guild-1": {
+            channels: {
+              "channel-1": {
+                enabled: true,
+                requireMention: false,
+              },
+            },
+          },
+        },
+      },
+    },
+  } as OpenClawConfig;
+}
+
 async function runAutocomplete(
   autocomplete: (interaction: unknown) => Promise<unknown>,
   params: {
@@ -156,10 +181,43 @@ async function runAutocomplete(
   return respond;
 }
 
+async function resolveAutocompleteAuthorized(params: {
+  cfg: OpenClawConfig;
+  userId: string;
+  username?: string;
+  globalName?: string;
+}) {
+  return await resolveDiscordNativeAutocompleteAuthorized({
+    cfg: params.cfg,
+    discordConfig: params.cfg.channels?.discord ?? {},
+    accountId: "default",
+    interaction: {
+      user: {
+        id: params.userId,
+        username: params.username ?? params.userId,
+        globalName: params.globalName ?? params.userId,
+      },
+      channel: {
+        type: ChannelType.GuildText,
+        id: "channel-1",
+        name: "general",
+      },
+      guild: { id: "guild-1" },
+      rawData: {
+        member: { roles: [] },
+      },
+      client: {},
+    } as never,
+  });
+}
+
 describe("createDiscordNativeCommand option wiring", () => {
   beforeAll(async () => {
     ({ listNativeCommandSpecs } = await import("openclaw/plugin-sdk/command-auth"));
-    ({ createDiscordNativeCommand } = await import("./native-command.js"));
+    ({ createDiscordNativeCommand, testing: nativeCommandTesting } = await import(
+      "./native-command.js"
+    ));
+    ({ resolveDiscordNativeAutocompleteAuthorized } = await import("./native-command-auth.js"));
     ({ createNoopThreadBindingManager } = await import("./thread-bindings.js"));
   });
 
@@ -228,6 +286,114 @@ describe("createDiscordNativeCommand option wiring", () => {
     });
 
     expect(respond).toHaveBeenCalledWith([]);
+  });
+
+  it("rejects autocomplete when commands.ownerAllowFrom rejects the sender", async () => {
+    await expect(
+      resolveAutocompleteAuthorized({
+        cfg: createAllowedGuildAutocompleteConfig({
+          ownerAllowFrom: ["user:owner-user"],
+        }),
+        userId: "blocked-user",
+        username: "blocked",
+        globalName: "Blocked",
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("authorizes autocomplete for commands.allowFrom users when commands.ownerAllowFrom is configured", async () => {
+    await expect(
+      resolveAutocompleteAuthorized({
+        cfg: createAllowedGuildAutocompleteConfig({
+          ownerAllowFrom: ["user:owner-user"],
+          allowFrom: {
+            discord: ["user:allowed-user"],
+          },
+        }),
+        userId: "blocked-user",
+        username: "blocked",
+        globalName: "Blocked",
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      resolveAutocompleteAuthorized({
+        cfg: createAllowedGuildAutocompleteConfig({
+          ownerAllowFrom: ["user:owner-user"],
+          allowFrom: {
+            discord: ["user:allowed-user"],
+          },
+        }),
+        userId: "allowed-user",
+        username: "allowed",
+        globalName: "Allowed",
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("keeps plugin command autocomplete aligned with dispatch owner checks", async () => {
+    const restoreMatchPluginCommand = nativeCommandTesting.setMatchPluginCommand((prompt) =>
+      prompt === "/pair" ? ({ command: { name: "pair" }, args: "" } as never) : null,
+    );
+    try {
+      const command = createDiscordNativeCommand({
+        command: {
+          name: "pair",
+          description: "Pair",
+          acceptsArgs: true,
+          args: [
+            {
+              name: "mode",
+              description: "Pairing mode",
+              type: "string",
+              preferAutocomplete: true,
+              choices: () => [
+                { label: "fast", value: "fast" },
+                { label: "secure", value: "secure" },
+              ],
+            },
+          ],
+        },
+        cfg: createAllowedGuildAutocompleteConfig({
+          ownerAllowFrom: ["user:owner-user"],
+        }),
+        discordConfig: {
+          groupPolicy: "allowlist",
+          guilds: {
+            "guild-1": {
+              channels: {
+                "channel-1": {
+                  enabled: true,
+                  requireMention: false,
+                },
+              },
+            },
+          },
+        },
+        accountId: "default",
+        sessionPrefix: "discord:slash",
+        ephemeralDefault: true,
+        threadBindings: createNoopThreadBindingManager("default"),
+      });
+      const mode = requireOption(command, "mode");
+      const autocomplete = requireAutocomplete(mode, "plugin mode option did not wire autocomplete");
+      const respond = await runAutocomplete(autocomplete, {
+        userId: "blocked-user",
+        username: "blocked",
+        globalName: "Blocked",
+        channelType: ChannelType.GuildText,
+        channelId: "channel-1",
+        channelName: "general",
+        guildId: "guild-1",
+        focusedValue: "",
+      });
+
+      expect(respond).toHaveBeenCalledWith([
+        { name: "fast", value: "fast" },
+        { name: "secure", value: "secure" },
+      ]);
+    } finally {
+      nativeCommandTesting.setMatchPluginCommand(restoreMatchPluginCommand);
+    }
   });
 
   it("returns no autocomplete choices outside the Discord allowlist when commands.useAccessGroups is false and commands.allowFrom is not configured", async () => {

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -16,7 +16,6 @@ import {
 import { resolveChunkMode, resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
 import { createSubsystemLogger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
-import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   resolveDiscordAccountAllowFrom,
   resolveDiscordAccountDmPolicy,
@@ -42,6 +41,7 @@ import { resolveDiscordDmCommandAccess } from "./dm-command-auth.js";
 import { handleDiscordDmCommandDecision } from "./dm-command-decision.js";
 import { dispatchDiscordNativeAgentReply } from "./native-command-agent-reply.js";
 import {
+  resolveDiscordCommandOwnerAllowFrom,
   resolveDiscordGuildNativeCommandAuthorized,
   resolveDiscordNativeAutocompleteAuthorized,
   resolveDiscordNativeCommandAllowlistAccess,
@@ -86,36 +86,6 @@ import type { ThreadBindingManager } from "./thread-bindings.js";
 const log = createSubsystemLogger("discord/native-command");
 export { testing, testing as __testing } from "./native-command.runtime.js";
 
-function resolveDiscordCommandOwnerAllowFrom(cfg: OpenClawConfig): string[] | undefined {
-  const raw = cfg.commands?.ownerAllowFrom;
-  if (!Array.isArray(raw) || raw.length === 0) {
-    return undefined;
-  }
-  const entries: string[] = [];
-  for (const entry of raw) {
-    const trimmed = normalizeOptionalString(String(entry ?? "")) ?? "";
-    if (!trimmed) {
-      continue;
-    }
-    const separatorIndex = trimmed.indexOf(":");
-    if (separatorIndex > 0) {
-      const prefix = trimmed.slice(0, separatorIndex).toLowerCase();
-      if (prefix === "discord") {
-        const remainder = normalizeOptionalString(trimmed.slice(separatorIndex + 1)) ?? "";
-        if (remainder) {
-          entries.push(remainder);
-        }
-        continue;
-      }
-      if (prefix !== "user" && prefix !== "pk") {
-        continue;
-      }
-    }
-    entries.push(trimmed);
-  }
-  return entries.length > 0 ? entries : undefined;
-}
-
 export function createDiscordNativeCommand(params: {
   command: NativeCommandSpec;
   cfg: OpenClawConfig;
@@ -135,8 +105,9 @@ export function createDiscordNativeCommand(params: {
     threadBindings,
   } = params;
   const fallbackCommandDefinition = createNativeCommandDefinition(command);
+  const pluginCommandMatch = nativeCommandRuntime.matchPluginCommand(`/${command.name}`);
   const commandDefinition =
-    nativeCommandRuntime.matchPluginCommand(`/${command.name}`) !== null
+    pluginCommandMatch !== null
       ? fallbackCommandDefinition
       : (findCommandByNativeName(command.name, "discord", {
           includeBundledChannelFallback: false,
@@ -151,6 +122,7 @@ export function createDiscordNativeCommand(params: {
         cfg,
         discordConfig,
         accountId,
+        skipCommandOwnerAllowFrom: pluginCommandMatch !== null,
       }),
     resolveChoiceContext: async (interaction) =>
       resolveDiscordNativeChoiceContext({
@@ -502,6 +474,20 @@ async function dispatchDiscordCommandInteraction(params: {
     }
   }
 
+  const pluginMatch = nativeCommandRuntime.matchPluginCommand(prompt);
+  if (
+    commandOwnerAllowFrom &&
+    !senderIsCommandOwner &&
+    !commandsAllowFromAccess.allowed &&
+    commandName !== "status" &&
+    !pluginMatch
+  ) {
+    await respond("You are not authorized to use this command.", { ephemeral: true });
+    return { accepted: false };
+  }
+
+  const isGuild = Boolean(interaction.guild);
+  const channelId = rawChannelId || "unknown";
   const menuNeedsModelContext =
     !(commandArgs?.raw && !commandArgs.values) &&
     command.args?.some(
@@ -557,12 +543,10 @@ async function dispatchDiscordCommandInteraction(params: {
     return { accepted: true };
   }
 
-  const pluginMatch = nativeCommandRuntime.matchPluginCommand(prompt);
   if (pluginMatch && commandName !== "status") {
     if (suppressReplies) {
       return { accepted: true };
     }
-    const channelId = rawChannelId || "unknown";
     const messageThreadId = !isDirectMessage && isThreadChannel ? channelId : undefined;
     const pluginThreadParentId = !isDirectMessage && isThreadChannel ? threadParentId : undefined;
     const { effectiveRoute } = await getNativeRouteState();
@@ -623,8 +607,6 @@ async function dispatchDiscordCommandInteraction(params: {
     return { accepted: true };
   }
 
-  const isGuild = Boolean(interaction.guild);
-  const channelId = rawChannelId || "unknown";
   const interactionId = interaction.rawData.id;
   const routeState = await getNativeRouteState();
   if (routeState.bindingReadiness && !routeState.bindingReadiness.ok) {
@@ -647,32 +629,6 @@ async function dispatchDiscordCommandInteraction(params: {
     boundSessionKey,
   });
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, effectiveRoute.agentId);
-  const directStatusResult = await maybeDeliverDiscordDirectStatus({
-    commandName,
-    suppressReplies,
-    resolveDirectStatusReplyForSession: nativeCommandRuntime.resolveDirectStatusReplyForSession,
-    cfg,
-    discordConfig,
-    accountId,
-    sessionKey,
-    commandTargetSessionKey,
-    channel: "discord",
-    senderId: sender.id,
-    senderIsOwner: senderIsCommandOwner,
-    isAuthorizedSender: commandAuthorized,
-    isGroup: isGuild || isGroupDm,
-    defaultGroupActivation: () =>
-      !isGuild ? "always" : channelConfig?.requireMention === false ? "always" : "mention",
-    interaction,
-    mediaLocalRoots,
-    preferFollowUp,
-    responseEphemeral,
-    effectiveRoute,
-    respond,
-  });
-  if (directStatusResult) {
-    return directStatusResult;
-  }
   const ctxPayload = buildDiscordNativeCommandContext({
     prompt,
     commandArgs: commandArgs ?? {},
@@ -701,6 +657,33 @@ async function dispatchDiscordCommandInteraction(params: {
     },
     sender: { id: sender.id, name: sender.name, tag: sender.tag },
   });
+
+  const directStatusResult = await maybeDeliverDiscordDirectStatus({
+    commandName,
+    suppressReplies,
+    resolveDirectStatusReplyForSession: nativeCommandRuntime.resolveDirectStatusReplyForSession,
+    cfg,
+    discordConfig,
+    accountId,
+    sessionKey,
+    commandTargetSessionKey,
+    channel: "discord",
+    senderId: sender.id,
+    senderIsOwner: senderIsCommandOwner,
+    isAuthorizedSender: commandAuthorized,
+    isGroup: isGuild || isGroupDm,
+    defaultGroupActivation: () =>
+      !isGuild ? "always" : channelConfig?.requireMention === false ? "always" : "mention",
+    interaction,
+    mediaLocalRoots,
+    preferFollowUp,
+    responseEphemeral,
+    effectiveRoute,
+    respond,
+  });
+  if (directStatusResult) {
+    return directStatusResult;
+  }
 
   await dispatchDiscordNativeAgentReply({
     cfg,


### PR DESCRIPTION
Closes #86654

## Summary
- gate Discord native built-in slash commands through the stricter command owner allowlist before menu/success UI or dispatch
- change command-arg component copy from optimistic `Selected ...` to `Applying ...`
- keep direct plugin commands and `/status` on their existing path while covering built-in owner rejection and autocomplete authorization

## Verification
- `node scripts/run-vitest.mjs extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts extensions/discord/src/monitor/native-command.options.test.ts extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts extensions/discord/src/monitor/native-command.think-autocomplete.test.ts extensions/discord/src/monitor/native-command.command-arg.test.ts -- --reporter=dot` - 5 files, 54 tests passed before the final rebase
- `git diff --check` - passed
- `AUTOREVIEW_OPENCLAW_MAINTAINER_VALIDATION=1 AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local` - clean, no accepted/actionable findings
- AWS Crabbox changed gate: provider `aws`, lease `cbx_b729c8b1d0ce`, slug `blue-prawn`, run `run_c301e5f6c801`, command `env CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 pnpm check:changed`, exit 0

## Proof gap
Live Discord client proof has not been captured yet. The PR is narrowed and validated with focused regression coverage plus the changed gate; the Real behavior proof check will remain red until a live Discord artifact or maintainer proof override is supplied.

## Rollback
Revert this PR to restore the previous native built-in command flow and picker copy.
