### PR TITLE
perf: reduce runtime metadata hotpath churn

### DIFF
--- a/extensions/discord/src/voice/realtime.ts
+++ b/extensions/discord/src/voice/realtime.ts
@@ -374,6 +374,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     {
       limit: DISCORD_REALTIME_PENDING_SPEAKER_CONTEXT_LIMIT,
       ignoredContextTtlMs: DISCORD_REALTIME_IGNORED_WAKE_NAME_CONTEXT_TTL_MS,
+      deferUntilAudio: true,
     },
   );
   private outputAudioTimestampMs = 0;
@@ -627,9 +628,6 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
         interruptedPlayback: false,
       },
     );
-    logger.info(
-      `discord voice: realtime speaker turn opened guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} user=${userId} speaker=${context.speakerLabel} owner=${context.senderIsOwner} pendingTurns=${this.speakerTurns.size()}`,
-    );
     return {
       sendInputAudio: (discordPcm48kStereo) =>
         this.sendInputAudioForTurn(turn, discordPcm48kStereo),
@@ -645,9 +643,9 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     if (!this.bridge || this.stopped) {
       return;
     }
-    this.speakerTurns.markAudio(turn);
     const realtimePcm = convertDiscordPcm48kStereoToRealtimePcm24kMono(discordPcm48kStereo);
     if (realtimePcm.length > 0) {
+      this.registerSpeakerTurnAudioStarted(turn);
       turn.inputDiscordBytes += discordPcm48kStereo.length;
       turn.inputRealtimeBytes += realtimePcm.length;
       turn.inputChunks += 1;
@@ -669,6 +667,16 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
       }
       this.bridge.sendAudio(realtimePcm);
     }
+  }
+
+  private registerSpeakerTurnAudioStarted(turn: PendingSpeakerTurn): void {
+    if (turn.hasAudio) {
+      return;
+    }
+    this.speakerTurns.markAudio(turn);
+    logger.info(
+      `discord voice: realtime speaker turn opened guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} user=${turn.context.userId} speaker=${turn.context.speakerLabel} owner=${turn.context.senderIsOwner} pendingTurns=${this.speakerTurns.size()}`,
+    );
   }
 
   handleBargeIn(reason = "barge-in"): void {
@@ -1018,7 +1026,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
   }
 
   private logSpeakerTurnClosed(turn: PendingSpeakerTurn): void {
-    if (turn.closed) {
+    if (turn.closed || !turn.hasAudio) {
       return;
     }
     const elapsedMs = Date.now() - turn.startedAt;

--- a/src/plugins/installed-plugin-index-record-builder.ts
+++ b/src/plugins/installed-plugin-index-record-builder.ts
@@ -79,7 +79,9 @@ function resolvePackageJsonPath(
     safeRealpathSync(candidate.packageDir, realpathCache) ?? path.resolve(candidate.packageDir);
   const packageJsonPath = path.join(packageDir, "package.json");
   const rootDir =
-    safeRealpathSync(candidate.rootDir, realpathCache) ?? path.resolve(candidate.rootDir);
+    candidate.rootDir === candidate.packageDir
+      ? packageDir
+      : (safeRealpathSync(candidate.rootDir, realpathCache) ?? path.resolve(candidate.rootDir));
   const packageJsonRealPath = safeRealpathSync(packageJsonPath, realpathCache);
   return packageJsonRealPath && isPathInside(rootDir, packageJsonRealPath)
     ? packageJsonPath
@@ -91,7 +93,10 @@ function resolvePackageJsonRelativePath(
   packageJsonPath: string,
   realpathCache: Map<string, string>,
 ): string {
-  const resolvedRootDir = safeRealpathSync(rootDir, realpathCache) ?? path.resolve(rootDir);
+  const resolvedRootDir =
+    rootDir === path.dirname(packageJsonPath)
+      ? path.dirname(packageJsonPath)
+      : (safeRealpathSync(rootDir, realpathCache) ?? path.resolve(rootDir));
   const relativePath = path.relative(resolvedRootDir, packageJsonPath) || "package.json";
   return relativePath.split(path.sep).join("/");
 }

--- a/src/plugins/manifest-registry-installed.ts
+++ b/src/plugins/manifest-registry-installed.ts
@@ -78,7 +78,9 @@ function buildInstalledManifestRegistryIndexKey(index: InstalledPluginIndex) {
     installRecords: index.installRecords,
     diagnostics: index.diagnostics,
     plugins: index.plugins.map((record) => {
-      const packageJsonPath = resolvePackageJsonPath(record, realpathCache);
+      const packageJsonFile =
+        record.packageJson?.fileSignature ??
+        safeFileSignature(resolvePackageJsonPath(record, realpathCache));
       return {
         pluginId: record.pluginId,
         packageName: record.packageName,
@@ -95,7 +97,7 @@ function buildInstalledManifestRegistryIndexKey(index: InstalledPluginIndex) {
         source: record.source,
         setupSource: record.setupSource,
         packageJson: record.packageJson,
-        packageJsonFile: safeFileSignature(packageJsonPath),
+        packageJsonFile,
         rootDir: record.rootDir,
         origin: record.origin,
         enabled: record.enabled,

--- a/src/plugins/plugin-metadata-snapshot.memo.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.memo.test.ts
@@ -199,26 +199,6 @@ function makeManifestRegistry(pluginId = "demo"): PluginManifestRegistry {
   return { plugins: [plugin], diagnostics: [] };
 }
 
-function firstPlugin(
-  snapshot: ReturnType<typeof loadPluginMetadataSnapshot>,
-): PluginManifestRecord {
-  const plugin = snapshot.plugins[0];
-  if (!plugin) {
-    throw new Error("expected memo test fixture plugin");
-  }
-  return plugin;
-}
-
-function firstCommandAlias(
-  plugin: PluginManifestRecord,
-): NonNullable<PluginManifestRecord["commandAliases"]>[number] {
-  const commandAlias = plugin.commandAliases?.[0];
-  if (!commandAlias) {
-    throw new Error("expected memo test fixture command alias");
-  }
-  return commandAlias;
-}
-
 describe("loadPluginMetadataSnapshot process memo", () => {
   beforeEach(() => {
     clearLoadPluginMetadataSnapshotMemo();
@@ -245,17 +225,19 @@ describe("loadPluginMetadataSnapshot process memo", () => {
     });
 
     const first = loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
-    const firstRecord = firstPlugin(first);
-    firstRecord.providers.push("first-mutated");
-    firstCommandAlias(firstRecord).name = "first-command-mutated";
     const second = loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
-    const secondRecord = firstPlugin(second);
-    secondRecord.providers.push("second-mutated");
-    firstCommandAlias(secondRecord).name = "second-command-mutated";
     const third = loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
 
     expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledOnce();
     expect(loadPluginManifestRegistryForInstalledIndex).toHaveBeenCalledOnce();
+    expect(second).toBe(first);
+    expect(third).toBe(first);
+    expect(() => third.plugins[0]?.providers.push("mutated")).toThrow();
+    expect(() => {
+      if (third.plugins[0]?.commandAliases?.[0]) {
+        third.plugins[0].commandAliases[0].name = "mutated";
+      }
+    }).toThrow();
     expect(third.plugins[0]?.providers).toEqual(["demo"]);
     expect(third.plugins[0]?.commandAliases?.[0]?.name).toBe("demo-command");
     expect(second.manifestRegistry.plugins[0]).toBe(second.plugins[0]);
@@ -402,6 +384,28 @@ describe("loadPluginMetadataSnapshot process memo", () => {
     expect(loadPluginManifestRegistryForInstalledIndex).toHaveBeenCalledOnce();
     expect(statSpy).not.toHaveBeenCalled();
     expect(readSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not freeze caller-owned provided index records", () => {
+    const stateDir = tempStateDir();
+    const index = makeIndex();
+    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+      source: "provided",
+      snapshot: index,
+      diagnostics: [],
+    });
+
+    const snapshot = loadPluginMetadataSnapshot({ config: {}, env: {}, index, stateDir });
+
+    expect(() => {
+      index.plugins[0]!.pluginId = "caller-mutated";
+      index.plugins[0]!.startup.agentHarnesses = ["caller-mutated"];
+    }).not.toThrow();
+    expect(snapshot.index.plugins[0]?.pluginId).toBe("demo");
+    expect(snapshot.index.plugins[0]?.startup.agentHarnesses).toEqual([]);
+    expect(() => {
+      snapshot.index.plugins[0]!.pluginId = "snapshot-mutated";
+    }).toThrow();
   });
 
   it("memoizes policy-stale derived snapshots within the process", () => {

--- a/src/plugins/plugin-metadata-snapshot.memo.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.memo.test.ts
@@ -396,15 +396,20 @@ describe("loadPluginMetadataSnapshot process memo", () => {
     });
 
     const snapshot = loadPluginMetadataSnapshot({ config: {}, env: {}, index, stateDir });
+    const callerRecord = index.plugins[0];
+    const snapshotRecord = snapshot.index.plugins[0];
+    if (!callerRecord || !snapshotRecord) {
+      throw new Error("expected metadata records");
+    }
 
     expect(() => {
-      index.plugins[0]!.pluginId = "caller-mutated";
-      index.plugins[0]!.startup.agentHarnesses = ["caller-mutated"];
+      callerRecord.pluginId = "caller-mutated";
+      callerRecord.startup.agentHarnesses = ["caller-mutated"];
     }).not.toThrow();
     expect(snapshot.index.plugins[0]?.pluginId).toBe("demo");
     expect(snapshot.index.plugins[0]?.startup.agentHarnesses).toEqual([]);
     expect(() => {
-      snapshot.index.plugins[0]!.pluginId = "snapshot-mutated";
+      snapshotRecord.pluginId = "snapshot-mutated";
     }).toThrow();
   });
 

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -124,56 +124,49 @@ function pickMemoRelevantEnv(env: NodeJS.ProcessEnv): Record<string, string> {
   );
 }
 
-function cloneOwnerMaps(owners: PluginMetadataSnapshotOwnerMaps): PluginMetadataSnapshotOwnerMaps {
-  return {
-    channels: new Map(owners.channels),
-    channelConfigs: new Map(owners.channelConfigs),
-    providers: new Map(owners.providers),
-    modelCatalogProviders: new Map(owners.modelCatalogProviders),
-    cliBackends: new Map(owners.cliBackends),
-    setupProviders: new Map(owners.setupProviders),
-    commandAliases: new Map(owners.commandAliases),
-    contracts: new Map(owners.contracts),
-  };
+function throwReadonlyPluginMetadataMutation(): never {
+  throw new TypeError("Plugin metadata snapshots are immutable");
 }
 
-function cloneSnapshotValue<T>(value: T): T {
-  return value && typeof value === "object" ? structuredClone(value) : value;
+function freezeSnapshotValue<T>(value: T, seen = new WeakSet<object>()): T {
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  if (seen.has(value)) {
+    return value;
+  }
+  seen.add(value);
+  if (value instanceof Map) {
+    for (const [key, entry] of value) {
+      freezeSnapshotValue(key, seen);
+      freezeSnapshotValue(entry, seen);
+    }
+    Object.defineProperties(value, {
+      clear: { value: throwReadonlyPluginMetadataMutation },
+      delete: { value: throwReadonlyPluginMetadataMutation },
+      set: { value: throwReadonlyPluginMetadataMutation },
+    });
+    return Object.freeze(value);
+  }
+  if (value instanceof Set) {
+    for (const entry of value) {
+      freezeSnapshotValue(entry, seen);
+    }
+    Object.defineProperties(value, {
+      add: { value: throwReadonlyPluginMetadataMutation },
+      clear: { value: throwReadonlyPluginMetadataMutation },
+      delete: { value: throwReadonlyPluginMetadataMutation },
+    });
+    return Object.freeze(value);
+  }
+  for (const entry of Object.values(value)) {
+    freezeSnapshotValue(entry, seen);
+  }
+  return Object.freeze(value);
 }
 
-function clonePluginManifestRecord(plugin: PluginManifestRecord): PluginManifestRecord {
-  return cloneSnapshotValue(plugin);
-}
-
-function clonePluginMetadataSnapshot(snapshot: PluginMetadataSnapshot): PluginMetadataSnapshot {
-  const plugins = snapshot.plugins.map(clonePluginManifestRecord);
-  const pluginsById = new Map(plugins.map((plugin) => [plugin.id, plugin]));
-  const diagnostics = snapshot.diagnostics.map(cloneSnapshotValue);
-  return {
-    ...snapshot,
-    index: {
-      ...snapshot.index,
-      installRecords: cloneSnapshotValue(snapshot.index.installRecords ?? {}),
-      plugins: snapshot.index.plugins.map(cloneSnapshotValue),
-      diagnostics: snapshot.index.diagnostics.map(cloneSnapshotValue),
-    },
-    registryDiagnostics: snapshot.registryDiagnostics.map(cloneSnapshotValue),
-    manifestRegistry: {
-      ...snapshot.manifestRegistry,
-      plugins,
-      diagnostics,
-    },
-    plugins,
-    diagnostics,
-    byPluginId: new Map(
-      [...snapshot.byPluginId.entries()].map(([pluginId, plugin]) => [
-        pluginId,
-        pluginsById.get(plugin.id) ?? clonePluginManifestRecord(plugin),
-      ]),
-    ),
-    owners: cloneOwnerMaps(snapshot.owners),
-    metrics: { ...snapshot.metrics },
-  };
+function freezePluginMetadataSnapshot(snapshot: PluginMetadataSnapshot): PluginMetadataSnapshot {
+  return freezeSnapshotValue(snapshot);
 }
 
 function resolvePersistedRegistryFastMemoFingerprint(params: {
@@ -366,6 +359,10 @@ function indexesMatch(
   );
 }
 
+function cloneSnapshotInput<T>(value: T): T {
+  return value && typeof value === "object" ? structuredClone(value) : value;
+}
+
 function normalizeInstalledPluginIndex(index: InstalledPluginIndex): InstalledPluginIndex {
   return {
     version: index.version ?? 1,
@@ -374,9 +371,9 @@ function normalizeInstalledPluginIndex(index: InstalledPluginIndex): InstalledPl
     migrationVersion: index.migrationVersion ?? 1,
     policyHash: index.policyHash ?? "",
     generatedAtMs: index.generatedAtMs ?? 0,
-    installRecords: index.installRecords ?? {},
-    plugins: index.plugins ?? [],
-    diagnostics: index.diagnostics ?? [],
+    installRecords: cloneSnapshotInput(index.installRecords ?? {}),
+    plugins: (index.plugins ?? []).map(cloneSnapshotInput),
+    diagnostics: (index.diagnostics ?? []).map(cloneSnapshotInput),
     ...(index.warning ? { warning: index.warning } : {}),
     ...(index.refreshReason ? { refreshReason: index.refreshReason } : {}),
   } as InstalledPluginIndex;
@@ -511,20 +508,16 @@ export function loadPluginMetadataSnapshot(
   const memoKey = computePluginMetadataSnapshotMemoKey({ params, registryState });
   const memo = findPluginMetadataSnapshotMemo(memoKey);
   if (memo?.key === memoKey) {
-    return measureDiagnosticsTimelineSpanSync(
-      "plugins.metadata.scan",
-      () => clonePluginMetadataSnapshot(memo.snapshot),
-      {
-        phase: activeTimelineSpan?.phase ?? "startup",
-        config: params.config,
-        env: params.env,
-        attributes: {
-          cacheHit: true,
-          hasWorkspaceDir: params.workspaceDir !== undefined,
-          hasInstalledIndex: params.index !== undefined,
-        },
+    return measureDiagnosticsTimelineSpanSync("plugins.metadata.scan", () => memo.snapshot, {
+      phase: activeTimelineSpan?.phase ?? "startup",
+      config: params.config,
+      env: params.env,
+      attributes: {
+        cacheHit: true,
+        hasWorkspaceDir: params.workspaceDir !== undefined,
+        hasInstalledIndex: params.index !== undefined,
       },
-    );
+    });
   }
 
   const result = measureDiagnosticsTimelineSpanSync(
@@ -540,12 +533,13 @@ export function loadPluginMetadataSnapshot(
       },
     },
   );
+  const snapshot = freezePluginMetadataSnapshot(result.snapshot);
   if (canMemoizePluginMetadataSnapshotResult(result)) {
     const cachedRegistryState =
       result.registrySource === "derived"
         ? resolvePersistedRegistryMemoState({
             env,
-            index: result.snapshot.index,
+            index: snapshot.index,
             ...(params.stateDir ? { stateDir: resolveUserPath(params.stateDir, env) } : {}),
             ...(params.preferPersisted !== undefined
               ? { preferPersisted: params.preferPersisted }
@@ -555,10 +549,10 @@ export function loadPluginMetadataSnapshot(
     rememberPluginMetadataSnapshotMemo({
       key: computePluginMetadataSnapshotMemoKey({ params, registryState: cachedRegistryState }),
       registryState: cachedRegistryState,
-      snapshot: clonePluginMetadataSnapshot(result.snapshot),
+      snapshot,
     });
   }
-  return result.snapshot;
+  return snapshot;
 }
 
 function canMemoizePluginMetadataSnapshotResult(result: {

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -793,6 +793,7 @@ const aliasMapCache = new PluginLruCache<Record<string, string>>(
 const normalizedJitiAliasMapCache = new PluginLruCache<Record<string, string>>(
   MAX_PLUGIN_LOADER_ALIAS_CACHE_ENTRIES,
 );
+const normalizedJitiAliasMapByInput = new WeakMap<Record<string, string>, Record<string, string>>();
 const pluginLoaderModuleConfigCache = new PluginLruCache<{
   tryNative: boolean;
   aliasMap: Record<string, string>;
@@ -815,9 +816,14 @@ function normalizePluginLoaderAliasMapForJiti(
   if (hasJitiNormalizedAliasMarker(aliasMap)) {
     return aliasMap;
   }
+  const cachedByInput = normalizedJitiAliasMapByInput.get(aliasMap);
+  if (cachedByInput) {
+    return cachedByInput;
+  }
   const cacheKey = createJitiAliasContentCacheKey(aliasMap);
   const cached = normalizedJitiAliasMapCache.get(cacheKey);
   if (cached) {
+    normalizedJitiAliasMapByInput.set(aliasMap, cached);
     return cached;
   }
   const normalizedAliasMap = Object.fromEntries(
@@ -844,6 +850,7 @@ function normalizePluginLoaderAliasMapForJiti(
     enumerable: false,
   });
   normalizedJitiAliasMapCache.set(cacheKey, normalizedAliasMap);
+  normalizedJitiAliasMapByInput.set(aliasMap, normalizedAliasMap);
   return normalizedAliasMap;
 }
 

--- a/src/talk/turn-context-tracker.test.ts
+++ b/src/talk/turn-context-tracker.test.ts
@@ -26,6 +26,22 @@ describe("realtime voice turn context tracker", () => {
     expect(turn.closed).toBe(true);
   });
 
+  it("can defer retaining silent turns until audio starts", () => {
+    const tracker = createRealtimeVoiceTurnContextTracker<{ id: string }>({
+      deferUntilAudio: true,
+    });
+    const silent = tracker.open({ id: "silent" });
+    const spoken = tracker.open({ id: "spoken" });
+
+    expect(tracker.size()).toBe(0);
+    tracker.close(silent);
+    tracker.markAudio(spoken);
+
+    expect(tracker.size()).toBe(1);
+    expect(tracker.consumeAudioContext()).toEqual({ id: "spoken" });
+    expect(tracker.consumeAudioContext()).toBeUndefined();
+  });
+
   it("ignores handles from another tracker", () => {
     const first = createRealtimeVoiceTurnContextTracker<{ id: string }>();
     const second = createRealtimeVoiceTurnContextTracker<{ id: string }>();

--- a/src/talk/turn-context-tracker.ts
+++ b/src/talk/turn-context-tracker.ts
@@ -5,6 +5,7 @@ export type RealtimeVoiceTurnContextTrackerOptions = {
   limit?: number;
   ignoredContextTtlMs?: number;
   now?: () => number;
+  deferUntilAudio?: boolean;
 };
 
 export type RealtimeVoiceTurnContextHandle<
@@ -73,6 +74,7 @@ export function createRealtimeVoiceTurnContextTracker<
     options.ignoredContextTtlMs,
     DEFAULT_REALTIME_VOICE_IGNORED_CONTEXT_TTL_MS,
   );
+  const deferUntilAudio = options.deferUntilAudio === true;
 
   const prune = () => {
     for (let index = turns.length - 1; index >= 0; index -= 1) {
@@ -126,8 +128,10 @@ export function createRealtimeVoiceTurnContextTracker<
         closed: false,
         startedAt,
       };
-      turns.push(handle);
-      prune();
+      if (!deferUntilAudio) {
+        turns.push(handle);
+        prune();
+      }
       return handle;
     },
     markAudio(handle) {
@@ -137,6 +141,8 @@ export function createRealtimeVoiceTurnContextTracker<
       handle.hasAudio = true;
       handle.lastAudioAt = now();
       if (!turns.includes(handle)) {
+        turns.push(handle);
+        prune();
         return;
       }
     },


### PR DESCRIPTION
## Summary

- Make loaded plugin metadata snapshots immutable and return the same frozen snapshot from the process memo instead of cloning on cache hits.
- Reduce installed plugin package path churn by reusing persisted package file signatures where available while preserving realpath containment for package metadata hydration.
- Add an identity cache for normalized Jiti alias maps and delay Discord realtime speaker-turn queue/log work until the first audio frame using deferred turn-context retention.

## Verification

- `node scripts/run-vitest.mjs src/talk/turn-context-tracker.test.ts src/plugins/plugin-metadata-snapshot.memo.test.ts src/plugins/manifest-registry-installed.test.ts src/plugins/sdk-alias.test.ts src/plugins/installed-plugin-index-records.test.ts`
- `node scripts/run-vitest.mjs src/plugins/plugin-metadata-snapshot.memo.test.ts`
- `pnpm test extensions/discord/src/voice/manager.e2e.test.ts --testNamePattern "keeps realtime playback alive|interrupts realtime playback|does not interrupt realtime provider state"`
- `pnpm lint --threads=8`
- `pnpm exec oxfmt --check src/plugins/plugin-metadata-snapshot.ts src/plugins/plugin-metadata-snapshot.memo.test.ts src/plugins/manifest-registry-installed.ts src/plugins/installed-plugin-index-record-builder.ts src/plugins/sdk-alias.ts extensions/discord/src/voice/realtime.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:extensions`
- `pnpm build`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode commit --commit HEAD`

## Real behavior proof

Behavior addressed: CPU profile hotspots from repeated metadata snapshot cloning, repeated plugin path/signature work, Jiti alias normalization, and empty Discord realtime speaker turn churn.
Real environment tested: local OpenClaw checkout on macOS, Node/pnpm repo toolchain.
Exact steps or command run after this patch: focused Vitest plugin/talk tests, focused Discord realtime e2e tests, lint, oxfmt check, core and extension tsgo, full `pnpm build`, and autoreview.
Evidence after fix: focused plugin/talk tests passed 117 tests across 5 files plus metadata snapshot retest passed 27 tests; focused Discord realtime e2e passed 3 selected tests; lint, build, and type gates passed; autoreview reported no accepted/actionable findings.
Observed result after fix: metadata memo returns the same immutable snapshot without clone-on-hit, provided index inputs remain mutable for callers, symlink package metadata escape remains blocked, deferred turn tracking preserves audio-backed turns, and Discord realtime no-audio turns no longer enter the pending queue/log path.
What was not tested: live Discord voice traffic and a fresh CPU profile comparison after this exact patch.
