### PR TITLE
fix(memory-wiki): bound compile page reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -571,6 +571,7 @@ Docs: https://docs.openclaw.ai
 - Recheck rebuilt system.run argv [AI]. (#84090) Thanks @pgondhi987.
 - CLI: keep the private QA subcommand out of exported command descriptors unless `OPENCLAW_ENABLE_PRIVATE_QA_CLI=1`, so root help and subcommand markers match runtime registration. (#84519)
 - CLI/cron: bound `openclaw cron show` job lookup pagination so non-advancing or unbounded `cron.list` responses fail instead of hanging the command. Fixes #83856. (#83989)
+- Memory Wiki: bound compile-time page summary reads so large FileProvider-backed vaults do not issue an unbounded `fs.readFile` burst. Fixes #68738.
 - Agents/messages: stop message-tool-only turns after a successful source-channel `message` send while keeping transcript mirrors under the session write lock. (#84289)
 - Agents: filter silent heartbeat response-tool transcript artifacts out of embedded context snapshots so later user turns are not polluted by heartbeat no-op messages. (#83477) Thanks @fuller-stack-dev.
 - Agents/OpenAI: log repeated strict tool-schema downgrade diagnostics once per provider/model/tool signature, reducing duplicate debug noise while preserving `strict=false` fallback behavior. Fixes #82930. (#82933) Thanks @galiniliev.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -571,7 +571,6 @@ Docs: https://docs.openclaw.ai
 - Recheck rebuilt system.run argv [AI]. (#84090) Thanks @pgondhi987.
 - CLI: keep the private QA subcommand out of exported command descriptors unless `OPENCLAW_ENABLE_PRIVATE_QA_CLI=1`, so root help and subcommand markers match runtime registration. (#84519)
 - CLI/cron: bound `openclaw cron show` job lookup pagination so non-advancing or unbounded `cron.list` responses fail instead of hanging the command. Fixes #83856. (#83989)
-- Memory Wiki: bound compile-time page summary reads so large FileProvider-backed vaults do not issue an unbounded `fs.readFile` burst. Fixes #68738.
 - Agents/messages: stop message-tool-only turns after a successful source-channel `message` send while keeping transcript mirrors under the session write lock. (#84289)
 - Agents: filter silent heartbeat response-tool transcript artifacts out of embedded context snapshots so later user turns are not polluted by heartbeat no-op messages. (#83477) Thanks @fuller-stack-dev.
 - Agents/OpenAI: log repeated strict tool-schema downgrade diagnostics once per provider/model/tool signature, reducing duplicate debug noise while preserving `strict=false` fallback behavior. Fixes #82930. (#82933) Thanks @galiniliev.

--- a/extensions/memory-wiki/src/compile.test.ts
+++ b/extensions/memory-wiki/src/compile.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { compileMemoryWikiVault } from "./compile.js";
 import { renderWikiMarkdown } from "./markdown.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
@@ -108,6 +108,61 @@ describe("compileMemoryWikiVault", () => {
     await expect(
       fs.readFile(path.join(rootDir, ".openclaw-wiki", "cache", "claims.jsonl"), "utf8"),
     ).resolves.toContain('"text":"Alpha is the canonical source page."');
+  });
+
+  it("bounds concurrent page reads while compiling", async () => {
+    const { rootDir, config } = await createVault({
+      rootDir: nextCaseRoot(),
+      initialize: true,
+    });
+
+    for (let index = 0; index < 24; index += 1) {
+      await fs.writeFile(
+        path.join(rootDir, "sources", `page-${index}.md`),
+        renderWikiMarkdown({
+          frontmatter: {
+            pageType: "source",
+            id: `source.page-${index}`,
+            title: `Page ${index}`,
+          },
+          body: `# Page ${index}\n`,
+        }),
+        "utf8",
+      );
+    }
+
+    const originalReadFile = fs.readFile.bind(fs);
+    let activePageReads = 0;
+    let maxActivePageReads = 0;
+    const readFileSpy = vi
+      .spyOn(fs, "readFile")
+      .mockImplementation(async (...args: Parameters<typeof fs.readFile>) => {
+        const targetPath = args[0];
+        const isTestPageRead =
+          typeof targetPath === "string" &&
+          targetPath.startsWith(path.join(rootDir, "sources", "page-"));
+        if (!isTestPageRead) {
+          return await originalReadFile(...args);
+        }
+
+        activePageReads += 1;
+        maxActivePageReads = Math.max(maxActivePageReads, activePageReads);
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          return await originalReadFile(...args);
+        } finally {
+          activePageReads -= 1;
+        }
+      });
+
+    try {
+      await compileMemoryWikiVault(config);
+    } finally {
+      readFileSpy.mockRestore();
+    }
+
+    expect(maxActivePageReads).toBeGreaterThan(0);
+    expect(maxActivePageReads).toBeLessThanOrEqual(16);
   });
 
   it("renders obsidian-friendly links when configured", async () => {

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { runTasksWithConcurrency } from "openclaw/plugin-sdk/concurrency-runtime";
 import {
   replaceManagedMarkdownBlock,
   withTrailingNewline,
@@ -50,6 +51,7 @@ const COMPILE_PAGE_GROUPS: Array<{ kind: WikiPageKind; dir: string; heading: str
 ];
 const AGENT_DIGEST_PATH = ".openclaw-wiki/cache/agent-digest.json";
 const CLAIMS_DIGEST_PATH = ".openclaw-wiki/cache/claims.jsonl";
+const READ_PAGE_SUMMARIES_CONCURRENCY = 16;
 const MAX_RELATED_PAGES_PER_SECTION = 12;
 const MAX_SHARED_SOURCE_FANOUT = 24;
 
@@ -355,15 +357,20 @@ async function readPageSummaries(rootDir: string): Promise<WikiPageSummary[]> {
     await Promise.all(COMPILE_PAGE_GROUPS.map((group) => collectMarkdownFiles(rootDir, group.dir)))
   ).flat();
 
-  const pages = await Promise.all(
-    filePaths.map(async (relativePath) => {
+  const readResult = await runTasksWithConcurrency({
+    tasks: filePaths.map((relativePath) => async () => {
       const absolutePath = path.join(rootDir, relativePath);
       const raw = await fs.readFile(absolutePath, "utf8");
       return toWikiPageSummary({ absolutePath, relativePath, raw });
     }),
-  );
+    limit: READ_PAGE_SUMMARIES_CONCURRENCY,
+    errorMode: "stop",
+  });
+  if (readResult.hasError) {
+    throw readResult.firstError;
+  }
 
-  return pages
+  return readResult.results
     .flatMap((page) => (page ? [page] : []))
     .toSorted((left, right) => left.title.localeCompare(right.title));
 }


### PR DESCRIPTION
Summary
- Bound Memory Wiki compile-time page summary reads through the existing concurrency helper.
- Preserve deterministic result ordering before title sort and keep the helper in stop-on-error mode.
- Replaces #84458 because the fork branch does not allow maintainer edits and the contributor changelog entry needed removal.

Behavior addressed: Memory Wiki compile no longer starts one page-summary read per page without a bound.
Real environment tested: Local macOS source checkout, Node/pnpm repo environment.
Exact steps or command run after this patch: pnpm test extensions/memory-wiki/src/compile.test.ts; pnpm exec oxfmt --check --threads=1 extensions/memory-wiki/src/compile.ts extensions/memory-wiki/src/compile.test.ts; .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --no-web-search --prompt "Review PR #84458 after maintainer fixup. Focus on memory-wiki compile page summary read concurrency, runTasksWithConcurrency result/error handling, ordering preservation, and test reliability."
Evidence after fix: compile.test.ts passed 10 tests; oxfmt reported clean; autoreview reported no accepted/actionable findings.
Observed result after fix: Page reads are executed through runTasksWithConcurrency with errorMode stop, successful results are consumed in input-index order, and the existing summary title sort remains deterministic.
What was not tested: Full repository suite.

Co-authored-by: zhengzuo0-ai <zheng.zuo0@gmail.com>
