### PR TITLE
Refactor realtime output activity tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Voice: expose shared realtime turn-context tracking through the realtime voice SDK and reuse it for Discord speaker attribution and wake-name context recovery.
+- Voice: expose shared realtime output activity tracking through the realtime voice SDK and reuse it for Discord playback activity and barge-in decisions.
 - Voice: expose shared realtime consult question matching, speakable-result extraction, and alias-aware forced-consult coordination through the realtime voice SDK, then reuse it in Gateway Talk, Voice Call, and Discord voice paths.
 - Voice: share activation-name matching and consult-transcript screening through the realtime voice SDK so Discord, browser voice, and meeting surfaces can reuse one implementation.
 - Cron: default `cron.maxConcurrentRuns` to 8 so scheduled automations and their isolated agent turns can make progress in parallel without explicit configuration.

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-5f463f907553c514daf7a7c2d09df88bcfcc73383e8ff41ca4bf10978f303b68  plugin-sdk-api-baseline.json
-bc391fa6f4a0bc0cdf157bd165013ca97fce82b057f0a3a7d799b08af10bfc9c  plugin-sdk-api-baseline.jsonl
+8712c831d993980a72d7a628cd235654a5e7dcf74edda0c9f0c9c9c5ba250afc  plugin-sdk-api-baseline.json
+f6bf4178e5429f64943f5404f3085c360a7f390c15d15b5b9c23239c7a134ca6  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -626,7 +626,7 @@ releases.
   | `plugin-sdk/speech` | Speech helpers | Speech provider types plus provider-facing directive, registry, validation helpers, and OpenAI-compatible TTS builder |
   | `plugin-sdk/speech-core` | Shared speech core | Speech provider types, registry, directives, normalization |
   | `plugin-sdk/realtime-transcription` | Realtime transcription helpers | Provider types, registry helpers, and shared WebSocket session helper |
-  | `plugin-sdk/realtime-voice` | Realtime voice helpers | Provider types, registry/resolution helpers, bridge session helpers, shared agent talk-back queues, active-run voice control, transcript/event health, echo suppression, consult question matching, forced-consult coordination, turn-context tracking, and fast context consult helpers |
+  | `plugin-sdk/realtime-voice` | Realtime voice helpers | Provider types, registry/resolution helpers, bridge session helpers, shared agent talk-back queues, active-run voice control, transcript/event health, echo suppression, consult question matching, forced-consult coordination, turn-context tracking, output activity tracking, and fast context consult helpers |
   | `plugin-sdk/image-generation` | Image-generation helpers | Image generation provider types plus image asset/data URL helpers and the OpenAI-compatible image provider builder |
   | `plugin-sdk/image-generation-core` | Shared image-generation core | Image-generation types, failover, auth, and registry helpers |
   | `plugin-sdk/music-generation` | Music-generation helpers | Music-generation provider/request/result types |

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -331,7 +331,7 @@ focused channel/runtime subpaths, `config-contracts`, `string-coerce-runtime`,
     | `plugin-sdk/speech-core` | Shared speech provider types, registry, directive, normalization, and speech helper exports |
     | `plugin-sdk/realtime-transcription` | Realtime transcription provider types, registry helpers, and shared WebSocket session helper |
     | `plugin-sdk/realtime-bootstrap-context` | Realtime profile bootstrap helper for bounded `IDENTITY.md`, `USER.md`, and `SOUL.md` context injection |
-    | `plugin-sdk/realtime-voice` | Realtime voice provider types, registry helpers, and shared realtime voice behavior helpers |
+    | `plugin-sdk/realtime-voice` | Realtime voice provider types, registry helpers, and shared realtime voice behavior helpers, including output activity tracking |
     | `plugin-sdk/image-generation` | Image generation provider types plus image asset/data URL helpers and the OpenAI-compatible image provider builder |
     | `plugin-sdk/image-generation-core` | Shared image-generation types, failover, auth, and registry helpers |
     | `plugin-sdk/music-generation` | Music generation provider/request/result types |

--- a/extensions/discord/src/voice/realtime.ts
+++ b/extensions/discord/src/voice/realtime.ts
@@ -8,6 +8,7 @@ import {
   createRealtimeVoiceAgentTalkbackQueue,
   createRealtimeVoiceBridgeSession,
   createRealtimeVoiceForcedConsultCoordinator,
+  createRealtimeVoiceOutputActivityTracker,
   createRealtimeVoiceTurnContextTracker,
   matchRealtimeVoiceActivationName,
   matchRealtimeVoiceConsultQuestions,
@@ -30,6 +31,7 @@ import {
   type RealtimeVoiceToolCallEvent,
   type RealtimeVoiceForcedConsultCoordinator,
   type RealtimeVoiceForcedConsultHandle,
+  type RealtimeVoiceOutputActivityTracker,
   type RealtimeVoiceTurnContextHandle,
   type RealtimeVoiceTurnContextTracker,
   sortRealtimeVoiceActivationNames,
@@ -376,15 +378,10 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
       ignoredContextTtlMs: DISCORD_REALTIME_IGNORED_WAKE_NAME_CONTEXT_TTL_MS,
     },
   );
-  private outputAudioTimestampMs = 0;
-  private outputAudioDiscordBytes = 0;
-  private outputAudioRealtimeBytes = 0;
-  private outputAudioChunks = 0;
-  private outputAudioStartedAt: number | undefined;
+  private readonly outputActivity: RealtimeVoiceOutputActivityTracker =
+    createRealtimeVoiceOutputActivityTracker();
   private outputPlaybackWatchdog: ReturnType<typeof setTimeout> | undefined;
-  private outputStreamEnding = false;
   private outputPacedBuffer: Buffer = Buffer.alloc(0);
-  private outputPlaybackStarted = false;
   private realtimeProviderId: string | undefined;
   private queuedExactSpeechMessages: string[] = [];
   private exactSpeechResponseActive = false;
@@ -653,7 +650,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
       turn.inputChunks += 1;
       if (turn.inputChunks === 1) {
         logger.info(
-          `discord voice: realtime input audio started guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} user=${turn.context.userId} speaker=${turn.context.speakerLabel} discordBytes=${discordPcm48kStereo.length} realtimeBytes=${realtimePcm.length} outputAudioMs=${Math.floor(this.outputAudioTimestampMs)} outputActive=${this.isOutputAudioActive()}`,
+          `discord voice: realtime input audio started guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} user=${turn.context.userId} speaker=${turn.context.speakerLabel} discordBytes=${discordPcm48kStereo.length} realtimeBytes=${realtimePcm.length} outputAudioMs=${this.outputAudioMs()} outputActive=${this.isOutputAudioActive()}`,
         );
       }
       const outputActive = this.hasInterruptibleOutputAudio();
@@ -663,7 +660,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
           `realtime barge-in from active speaker audio: guild ${this.params.entry.guildId} channel ${this.params.entry.channelId} user ${turn.context.userId}`,
         );
         logger.info(
-          `discord voice: realtime barge-in detected source=active-speaker-audio guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} user=${turn.context.userId} speaker=${turn.context.speakerLabel} outputAudioMs=${Math.floor(this.outputAudioTimestampMs)} outputActive=${this.isOutputAudioActive()} discordBytes=${discordPcm48kStereo.length} realtimeBytes=${realtimePcm.length}`,
+          `discord voice: realtime barge-in detected source=active-speaker-audio guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} user=${turn.context.userId} speaker=${turn.context.speakerLabel} outputAudioMs=${this.outputAudioMs()} outputActive=${this.isOutputAudioActive()} discordBytes=${discordPcm48kStereo.length} realtimeBytes=${realtimePcm.length}`,
         );
         this.handleBargeIn("active-speaker-audio");
       }
@@ -681,12 +678,12 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     const outputActive = this.hasInterruptibleOutputAudio();
     if (!outputActive) {
       logger.info(
-        `discord voice: realtime barge-in ignored reason=${reason} outputActive=false guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} playbackChunks=${this.outputAudioChunks}`,
+        `discord voice: realtime barge-in ignored reason=${reason} outputActive=false guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} playbackChunks=${this.outputAudioChunks()}`,
       );
       return;
     }
     logger.info(
-      `discord voice: realtime barge-in requested reason=${reason} guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} outputAudioMs=${Math.floor(this.outputAudioTimestampMs)} outputActive=${this.isOutputAudioActive()} playbackChunks=${this.outputAudioChunks}`,
+      `discord voice: realtime barge-in requested reason=${reason} guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} outputAudioMs=${this.outputAudioMs()} outputActive=${this.isOutputAudioActive()} playbackChunks=${this.outputAudioChunks()}`,
     );
     this.bridge?.handleBargeIn({ audioPlaybackActive: true });
   }
@@ -704,9 +701,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
 
   private hasInterruptibleOutputAudio(): boolean {
     this.syncOutputAudioTimestamp();
-    return (
-      this.isOutputAudioActive() || this.outputAudioChunks > 0 || this.outputAudioTimestampMs > 0
-    );
+    return this.outputActivity.isInterruptible(this.isOutputStreamActive());
   }
 
   private get realtimeConfig(): DiscordRealtimeVoiceConfig {
@@ -719,7 +714,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
       return;
     }
     this.syncOutputAudioTimestamp();
-    if (this.outputStreamEnding) {
+    if (this.outputActivity.snapshot().streamEnding) {
       logVoiceVerbose(
         `realtime output audio ignored after stream ending: guild ${this.params.entry.guildId} channel ${this.params.entry.channelId}`,
       );
@@ -729,13 +724,14 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     if (this.exactSpeechResponseActive) {
       this.exactSpeechAudioStarted = true;
     }
-    this.outputAudioDiscordBytes += discordPcm.length;
-    this.outputAudioRealtimeBytes += realtimePcm24kMono.length;
-    this.outputAudioChunks += 1;
-    this.outputAudioTimestampMs += pcm16MonoDurationMs(
-      realtimePcm24kMono,
-      REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ.sampleRateHz,
-    );
+    this.outputActivity.markAudio({
+      audioMs: pcm16MonoDurationMs(
+        realtimePcm24kMono,
+        REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ.sampleRateHz,
+      ),
+      sourceAudioBytes: realtimePcm24kMono.length,
+      sinkAudioBytes: discordPcm.length,
+    });
     this.queueOutputAudio(stream, discordPcm);
   }
 
@@ -746,7 +742,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     const stream = new PassThrough({ highWaterMark: DISCORD_RAW_PCM_FRAME_BYTES * 128 });
     this.outputStream = stream;
     this.outputPacedBuffer = Buffer.alloc(0);
-    this.outputPlaybackStarted = false;
+    this.outputActivity.markStreamOpened();
     stream.once("close", () => {
       if (this.outputStream === stream) {
         this.logOutputAudioStopped("stream-close");
@@ -759,7 +755,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
   }
 
   private queueOutputAudio(stream: PassThrough, discordPcm: Buffer): void {
-    if (this.outputPlaybackStarted) {
+    if (this.outputActivity.snapshot().playbackStarted) {
       stream.write(discordPcm);
       return;
     }
@@ -776,7 +772,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
   }
 
   private startOutputPlayback(stream: PassThrough): void {
-    if (this.outputPlaybackStarted || stream.destroyed) {
+    if (this.outputActivity.snapshot().playbackStarted || stream.destroyed) {
       return;
     }
     const voiceSdk = loadDiscordVoiceSdk();
@@ -788,8 +784,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
       inputType: voiceSdk.StreamType.Raw,
     });
     this.params.entry.player.play(resource);
-    this.outputPlaybackStarted = true;
-    this.outputAudioStartedAt = Date.now();
+    this.outputActivity.markPlaybackStarted();
     const realtimeConfig = this.realtimeConfig;
     logger.info(
       `discord voice: realtime audio playback started guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} mode=${this.params.mode} model=${realtimeConfig?.model ?? "provider-default"} voice=${realtimeConfig?.voice ?? "provider-default"}`,
@@ -807,7 +802,6 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     this.logOutputAudioStopped(reason);
     this.outputStream = null;
     this.outputPacedBuffer = Buffer.alloc(0);
-    this.outputPlaybackStarted = false;
     this.resetOutputAudioStats();
     stream?.end();
     stream?.destroy();
@@ -818,12 +812,12 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     { playBuffered = true }: { playBuffered?: boolean } = {},
   ): void {
     const stream = this.outputStream;
-    if (!stream || stream.destroyed || this.outputStreamEnding) {
+    if (!stream || stream.destroyed || this.outputActivity.snapshot().streamEnding) {
       return;
     }
-    this.outputStreamEnding = true;
+    this.outputActivity.markStreamEnding();
     logger.info(
-      `discord voice: realtime audio playback finishing reason=${reason} guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} audioMs=${Math.floor(this.outputAudioTimestampMs)} chunks=${this.outputAudioChunks}`,
+      `discord voice: realtime audio playback finishing reason=${reason} guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} audioMs=${this.outputAudioMs()} chunks=${this.outputAudioChunks()}`,
     );
     if (playBuffered) {
       this.startOutputPlayback(stream);
@@ -839,14 +833,12 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
 
   private scheduleOutputPlaybackWatchdog(reason: string, stream: PassThrough): void {
     this.clearOutputPlaybackWatchdog();
-    if (!this.outputAudioStartedAt || this.outputAudioTimestampMs <= 0) {
+    const timeoutMs = this.outputActivity.playbackWatchdogDelayMs({
+      marginMs: DISCORD_REALTIME_OUTPUT_PLAYBACK_WATCHDOG_MARGIN_MS,
+    });
+    if (timeoutMs === undefined) {
       return;
     }
-    const elapsedMs = Date.now() - this.outputAudioStartedAt;
-    const timeoutMs = Math.max(
-      1_000,
-      this.outputAudioTimestampMs - elapsedMs + DISCORD_REALTIME_OUTPUT_PLAYBACK_WATCHDOG_MARGIN_MS,
-    );
     this.outputPlaybackWatchdog = setTimeout(() => {
       this.outputPlaybackWatchdog = undefined;
       if (this.outputStream && this.outputStream !== stream) {
@@ -857,7 +849,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
         return;
       }
       logger.warn(
-        `discord voice: realtime audio playback watchdog fired reason=${reason} guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} audioMs=${Math.floor(this.outputAudioTimestampMs)} elapsedMs=${this.outputAudioStartedAt ? Date.now() - this.outputAudioStartedAt : 0}`,
+        `discord voice: realtime audio playback watchdog fired reason=${reason} guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} audioMs=${this.outputAudioMs()} elapsedMs=${this.outputActivity.elapsedPlaybackMs()}`,
       );
       this.clearOutputAudio("playback-watchdog");
       this.completeExactSpeechResponse("playback-watchdog");
@@ -879,7 +871,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     if (this.exactSpeechResponseActive || this.hasInterruptibleOutputAudio()) {
       this.queuedExactSpeechMessages.push(text);
       logger.info(
-        `discord voice: realtime exact speech queued guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} queued=${this.queuedExactSpeechMessages.length} outputAudioMs=${Math.floor(this.outputAudioTimestampMs)} outputActive=${this.isOutputAudioActive()}`,
+        `discord voice: realtime exact speech queued guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} queued=${this.queuedExactSpeechMessages.length} outputAudioMs=${this.outputAudioMs()} outputActive=${this.isOutputAudioActive()}`,
       );
       return;
     }
@@ -986,11 +978,12 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
   }
 
   private logOutputAudioStopped(reason: string): void {
-    const audioMs = Math.floor(this.outputAudioTimestampMs);
-    const chunks = this.outputAudioChunks;
-    const discordBytes = this.outputAudioDiscordBytes;
-    const realtimeBytes = this.outputAudioRealtimeBytes;
-    const elapsedMs = this.outputAudioStartedAt ? Date.now() - this.outputAudioStartedAt : 0;
+    const activity = this.outputActivity.snapshot();
+    const audioMs = Math.floor(activity.audioMs);
+    const chunks = activity.chunks;
+    const discordBytes = activity.sinkAudioBytes;
+    const realtimeBytes = activity.sourceAudioBytes;
+    const elapsedMs = this.outputActivity.elapsedPlaybackMs();
     if (this.outputStream || chunks > 0 || audioMs > 0) {
       logger.info(
         `discord voice: realtime audio playback stopped reason=${reason} guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} audioMs=${audioMs} elapsedMs=${elapsedMs} chunks=${chunks} discordBytes=${discordBytes} realtimeBytes=${realtimeBytes}`,
@@ -999,22 +992,28 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
   }
 
   private resetOutputAudioStats(): void {
-    this.outputAudioTimestampMs = 0;
-    this.outputAudioDiscordBytes = 0;
-    this.outputAudioRealtimeBytes = 0;
-    this.outputAudioChunks = 0;
-    this.outputAudioStartedAt = undefined;
-    this.outputStreamEnding = false;
     this.outputPacedBuffer = Buffer.alloc(0);
-    this.outputPlaybackStarted = false;
+    this.outputActivity.reset();
   }
 
   private syncOutputAudioTimestamp(): void {
-    this.bridge?.setMediaTimestamp(Math.floor(this.outputAudioTimestampMs));
+    this.bridge?.setMediaTimestamp(this.outputAudioMs());
+  }
+
+  private outputAudioMs(): number {
+    return Math.floor(this.outputActivity.snapshot().audioMs);
+  }
+
+  private outputAudioChunks(): number {
+    return this.outputActivity.snapshot().chunks;
+  }
+
+  private isOutputStreamActive(): boolean {
+    return Boolean(this.outputStream && !this.outputStream.destroyed);
   }
 
   private isOutputAudioActive(): boolean {
-    return Boolean(this.outputStream && !this.outputStream.destroyed) || this.outputAudioChunks > 0;
+    return this.outputActivity.isActive(this.isOutputStreamActive());
   }
 
   private logSpeakerTurnClosed(turn: PendingSpeakerTurn): void {
@@ -1385,7 +1384,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     );
     if (this.hasInterruptibleOutputAudio()) {
       logger.info(
-        `discord voice: realtime forced agent consult preserving active playback guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} outputAudioMs=${Math.floor(this.outputAudioTimestampMs)} outputActive=${this.isOutputAudioActive()} playbackChunks=${this.outputAudioChunks}`,
+        `discord voice: realtime forced agent consult preserving active playback guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} outputAudioMs=${this.outputAudioMs()} outputActive=${this.isOutputAudioActive()} playbackChunks=${this.outputAudioChunks()}`,
       );
     }
     state.handledByForcedPlayback = true;

--- a/src/plugin-sdk/realtime-voice.ts
+++ b/src/plugin-sdk/realtime-voice.ts
@@ -91,6 +91,13 @@ export {
   type RealtimeVoiceTurnContextTrackerOptions,
 } from "../talk/turn-context-tracker.js";
 export {
+  createRealtimeVoiceOutputActivityTracker,
+  type RealtimeVoiceOutputActivityDelta,
+  type RealtimeVoiceOutputActivitySnapshot,
+  type RealtimeVoiceOutputActivityTracker,
+  type RealtimeVoiceOutputActivityTrackerOptions,
+} from "../talk/output-activity-tracker.js";
+export {
   buildRealtimeVoiceAgentConsultChatMessage,
   buildRealtimeVoiceAgentConsultPolicyInstructions,
   buildRealtimeVoiceAgentConsultPrompt,

--- a/src/talk/output-activity-tracker.test.ts
+++ b/src/talk/output-activity-tracker.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { createRealtimeVoiceOutputActivityTracker } from "./output-activity-tracker.js";
+
+describe("realtime voice output activity tracker", () => {
+  it("tracks output audio counters and active state", () => {
+    const tracker = createRealtimeVoiceOutputActivityTracker();
+
+    expect(tracker.isActive(false)).toBe(false);
+    expect(tracker.isInterruptible(false)).toBe(false);
+
+    tracker.markAudio({ audioMs: 10, sourceAudioBytes: 480, sinkAudioBytes: 1_920 });
+
+    expect(tracker.isActive(false)).toBe(true);
+    expect(tracker.isInterruptible(false)).toBe(true);
+    expect(tracker.snapshot()).toMatchObject({
+      audioMs: 10,
+      chunks: 1,
+      sourceAudioBytes: 480,
+      sinkAudioBytes: 1_920,
+    });
+  });
+
+  it("treats sink activity as active before audio counters exist", () => {
+    const tracker = createRealtimeVoiceOutputActivityTracker();
+
+    expect(tracker.isActive(true)).toBe(true);
+    expect(tracker.isInterruptible(true)).toBe(true);
+  });
+
+  it("tracks stream ending and playback start state", () => {
+    let now = 1_000;
+    const tracker = createRealtimeVoiceOutputActivityTracker({ now: () => now });
+
+    tracker.markStreamOpened();
+    tracker.markAudio({ audioMs: 2_000 });
+    tracker.markPlaybackStarted();
+    now += 250;
+    tracker.markStreamEnding();
+
+    expect(tracker.elapsedPlaybackMs()).toBe(250);
+    expect(tracker.playbackWatchdogDelayMs({ marginMs: 100, minMs: 500 })).toBe(1_850);
+    expect(tracker.snapshot()).toMatchObject({
+      playbackStarted: true,
+      playbackStartedAt: 1_000,
+      streamEnding: true,
+    });
+  });
+
+  it("resets all output state", () => {
+    const tracker = createRealtimeVoiceOutputActivityTracker();
+
+    tracker.markStreamOpened();
+    tracker.markAudio({ audioMs: 10, sourceAudioBytes: 1, sinkAudioBytes: 2 });
+    tracker.markPlaybackStarted();
+    tracker.markStreamEnding();
+    tracker.reset();
+
+    expect(tracker.snapshot()).toEqual({
+      audioMs: 0,
+      chunks: 0,
+      sourceAudioBytes: 0,
+      sinkAudioBytes: 0,
+      playbackStarted: false,
+      streamEnding: false,
+    });
+  });
+});

--- a/src/talk/output-activity-tracker.ts
+++ b/src/talk/output-activity-tracker.ts
@@ -1,0 +1,104 @@
+export type RealtimeVoiceOutputActivityTrackerOptions = {
+  now?: () => number;
+};
+
+export type RealtimeVoiceOutputActivityDelta = {
+  audioMs?: number;
+  sourceAudioBytes?: number;
+  sinkAudioBytes?: number;
+};
+
+export type RealtimeVoiceOutputActivitySnapshot = {
+  audioMs: number;
+  chunks: number;
+  sourceAudioBytes: number;
+  sinkAudioBytes: number;
+  playbackStarted: boolean;
+  streamEnding: boolean;
+  playbackStartedAt?: number;
+};
+
+export type RealtimeVoiceOutputActivityTracker = {
+  markStreamOpened(): void;
+  markStreamEnding(): void;
+  markPlaybackStarted(): void;
+  markAudio(delta: RealtimeVoiceOutputActivityDelta): void;
+  reset(): void;
+  isActive(sinkActive?: boolean): boolean;
+  isInterruptible(sinkActive?: boolean): boolean;
+  elapsedPlaybackMs(): number;
+  playbackWatchdogDelayMs(options: { marginMs: number; minMs?: number }): number | undefined;
+  snapshot(): RealtimeVoiceOutputActivitySnapshot;
+};
+
+export function createRealtimeVoiceOutputActivityTracker(
+  options: RealtimeVoiceOutputActivityTrackerOptions = {},
+): RealtimeVoiceOutputActivityTracker {
+  const now = options.now ?? Date.now;
+  let audioMs = 0;
+  let chunks = 0;
+  let sourceAudioBytes = 0;
+  let sinkAudioBytes = 0;
+  let playbackStarted = false;
+  let streamEnding = false;
+  let playbackStartedAt: number | undefined;
+
+  const snapshot = (): RealtimeVoiceOutputActivitySnapshot => ({
+    audioMs,
+    chunks,
+    sourceAudioBytes,
+    sinkAudioBytes,
+    playbackStarted,
+    streamEnding,
+    ...(playbackStartedAt === undefined ? {} : { playbackStartedAt }),
+  });
+
+  return {
+    markStreamOpened() {
+      streamEnding = false;
+      playbackStarted = false;
+      playbackStartedAt = undefined;
+    },
+    markStreamEnding() {
+      streamEnding = true;
+    },
+    markPlaybackStarted() {
+      if (playbackStarted) {
+        return;
+      }
+      playbackStarted = true;
+      playbackStartedAt = now();
+    },
+    markAudio(delta) {
+      audioMs += Math.max(0, delta.audioMs ?? 0);
+      sourceAudioBytes += Math.max(0, delta.sourceAudioBytes ?? 0);
+      sinkAudioBytes += Math.max(0, delta.sinkAudioBytes ?? 0);
+      chunks += 1;
+    },
+    reset() {
+      audioMs = 0;
+      chunks = 0;
+      sourceAudioBytes = 0;
+      sinkAudioBytes = 0;
+      playbackStarted = false;
+      streamEnding = false;
+      playbackStartedAt = undefined;
+    },
+    isActive(sinkActive = false) {
+      return sinkActive || chunks > 0;
+    },
+    isInterruptible(sinkActive = false) {
+      return sinkActive || chunks > 0 || audioMs > 0;
+    },
+    elapsedPlaybackMs() {
+      return playbackStartedAt === undefined ? 0 : now() - playbackStartedAt;
+    },
+    playbackWatchdogDelayMs({ marginMs, minMs = 1_000 }) {
+      if (playbackStartedAt === undefined || audioMs <= 0) {
+        return undefined;
+      }
+      return Math.max(minMs, audioMs - (now() - playbackStartedAt) + marginMs);
+    },
+    snapshot,
+  };
+}


### PR DESCRIPTION
Summary
- Add a shared realtime voice output activity tracker to the SDK for audio counters, stream-ending/playback state, interruptible-output checks, and playback watchdog timing.
- Migrate Discord realtime voice playback/barge-in bookkeeping onto the shared tracker while leaving transport, audio conversion, stream/player lifecycle, and Discord config local.
- Refresh SDK API baseline plus realtime voice SDK docs and changelog.

Verification
- pnpm exec oxfmt --check --threads=1 src/talk/output-activity-tracker.ts src/talk/output-activity-tracker.test.ts src/plugin-sdk/realtime-voice.ts extensions/discord/src/voice/realtime.ts
- node scripts/run-vitest.mjs src/talk/output-activity-tracker.test.ts
- pnpm test extensions/discord/src/voice/manager.e2e.test.ts -- --reporter=dot -t "allows configured realtime barge-in|interrupts realtime playback when an already-active speaker keeps talking|does not interrupt realtime provider state when local playback is already idle|ignores realtime capture during playback when barge-in is disabled|queues forced agent-proxy answers until current realtime playback idles|does not interrupt active exact speech for a later forced agent-proxy consult|drains queued exact speech after cancelled prebuffered output is discarded"
- pnpm plugin-sdk:api:check
- pnpm build
- env -u OPENCLAW_TESTBOX pnpm check:changed
- /Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local

Behavior addressed: Discord realtime output playback and barge-in decisions now use the same provider/channel-neutral activity tracker that browser and meeting-style realtime surfaces can reuse.
Real environment tested: Local macOS source checkout, Node/pnpm repo toolchain, focused Discord realtime voice adapter tests.
Exact steps or command run after this patch: Focused tracker tests, focused Discord voice manager e2e tests listed above, SDK API check, full build, changed checks, and autoreview.
Evidence after fix: Tracker tests passed, seven Discord realtime voice e2e cases passed, SDK API baseline check passed, build passed, check:changed passed, autoreview reported no accepted/actionable findings.
Observed result after fix: No intended live provider behavior change; Discord kept local playback/audio lifecycle ownership while shared state produced the same barge-in and playback-idle semantics under adapter tests.
What was not tested: Live Discord, browser voice, or Google Meet-style provider sessions; this is a pure helper extraction with unit and adapter proof.
