### PR TITLE
fix: prefer source public artifacts in source checkouts

### DIFF
--- a/src/plugins/public-surface-loader.ts
+++ b/src/plugins/public-surface-loader.ts
@@ -63,7 +63,7 @@ function resolvePublicSurfaceLocationUncached(params: {
   const bundledPluginsDir = resolveBundledPluginsDir();
   const modulePath = resolveBundledPluginPublicSurfacePath({
     rootDir: OPENCLAW_PACKAGE_ROOT,
-    ...(bundledPluginsDir ? { bundledPluginsDir } : {}),
+    ...(bundledPluginsDir ? { bundledPluginsDir, bundledPluginsDirMode: "auto" as const } : {}),
     dirName: params.dirName,
     artifactBasename: params.artifactBasename,
   });

--- a/src/plugins/public-surface-runtime.test.ts
+++ b/src/plugins/public-surface-runtime.test.ts
@@ -70,6 +70,45 @@ describe("bundled plugin public surface runtime", () => {
     ).toBe(sourceModulePath);
   });
 
+  it("prefers source public surfaces over stale auto-resolved dist artifacts in source checkouts", () => {
+    const packageRoot = createTempDir();
+    const sourceModulePath = path.join(packageRoot, "extensions", "demo", "api.ts");
+    const staleDistModulePath = path.join(packageRoot, "dist", "extensions", "demo", "api.js");
+    fs.mkdirSync(path.dirname(sourceModulePath), { recursive: true });
+    fs.mkdirSync(path.dirname(staleDistModulePath), { recursive: true });
+    fs.writeFileSync(sourceModulePath, "export const marker = 'source';\n", "utf8");
+    fs.writeFileSync(staleDistModulePath, "export const marker = 'stale-dist';\n", "utf8");
+
+    expect(
+      resolveBundledPluginPublicSurfacePath({
+        rootDir: packageRoot,
+        bundledPluginsDir: path.join(packageRoot, "dist", "extensions"),
+        bundledPluginsDirMode: "auto",
+        dirName: "demo",
+        artifactBasename: "api.js",
+      }),
+    ).toBe(sourceModulePath);
+  });
+
+  it("keeps explicit bundled dist roots ahead of source public surfaces", () => {
+    const packageRoot = createTempDir();
+    const sourceModulePath = path.join(packageRoot, "extensions", "demo", "api.ts");
+    const distModulePath = path.join(packageRoot, "dist", "extensions", "demo", "api.js");
+    fs.mkdirSync(path.dirname(sourceModulePath), { recursive: true });
+    fs.mkdirSync(path.dirname(distModulePath), { recursive: true });
+    fs.writeFileSync(sourceModulePath, "export const marker = 'source';\n", "utf8");
+    fs.writeFileSync(distModulePath, "export const marker = 'dist';\n", "utf8");
+
+    expect(
+      resolveBundledPluginPublicSurfacePath({
+        rootDir: packageRoot,
+        bundledPluginsDir: path.join(packageRoot, "dist", "extensions"),
+        dirName: "demo",
+        artifactBasename: "api.js",
+      }),
+    ).toBe(distModulePath);
+  });
+
   it("falls back from an incomplete package dist-runtime override to packaged dist", () => {
     const packageRoot = createTempDir();
     const distModulePath = path.join(packageRoot, "dist", "extensions", "demo", "api.js");

--- a/src/plugins/public-surface-runtime.ts
+++ b/src/plugins/public-surface-runtime.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
-import { resolveBundledPluginsDir } from "./bundled-dir.js";
+import { resolveUserPath } from "../utils.js";
+import { areBundledPluginsDisabled, resolveBundledPluginsDir } from "./bundled-dir.js";
 
 export const PUBLIC_SURFACE_SOURCE_EXTENSIONS = [
   ".ts",
@@ -101,37 +102,105 @@ function resolvePackageFallbackForBundledDir(params: {
   });
 }
 
+function sameExistingPath(left: string, right: string): boolean {
+  try {
+    return fs.realpathSync.native(left) === fs.realpathSync.native(right);
+  } catch {
+    return false;
+  }
+}
+
+function resolveExplicitEnvBundledPluginsDir(env: NodeJS.ProcessEnv): string | undefined {
+  const envOverride = env.OPENCLAW_BUNDLED_PLUGINS_DIR?.trim();
+  if (!envOverride) {
+    return undefined;
+  }
+  const bundledPluginsDir = resolveBundledPluginsDir(env);
+  if (!bundledPluginsDir) {
+    return undefined;
+  }
+  const requestedDir = resolveUserPath(envOverride, env);
+  return sameExistingPath(requestedDir, bundledPluginsDir) ? bundledPluginsDir : undefined;
+}
+
+function resolvePublicSurfaceFromBundledDir(params: {
+  rootDir: string;
+  bundledPluginsDir: string;
+  dirName: string;
+  artifactBasename: string;
+}): string | null {
+  const pluginDir = path.resolve(params.bundledPluginsDir, params.dirName);
+  const builtCandidate = path.join(pluginDir, params.artifactBasename);
+  if (fs.existsSync(builtCandidate)) {
+    return builtCandidate;
+  }
+  return (
+    resolveBundledPluginSourcePublicSurfacePath({
+      sourceRoot: params.bundledPluginsDir,
+      dirName: params.dirName,
+      artifactBasename: params.artifactBasename,
+    }) ??
+    resolvePackageFallbackForBundledDir({
+      rootDir: params.rootDir,
+      bundledPluginsDir: params.bundledPluginsDir,
+      dirName: params.dirName,
+      artifactBasename: params.artifactBasename,
+    })
+  );
+}
+
 export function resolveBundledPluginPublicSurfacePath(params: {
   rootDir: string;
   dirName: string;
   artifactBasename: string;
   env?: NodeJS.ProcessEnv;
   bundledPluginsDir?: string;
+  bundledPluginsDirMode?: "explicit" | "auto";
 }): string | null {
   const artifactBasename = normalizeBundledPluginArtifactSubpath(params.artifactBasename);
   const dirName = normalizeBundledPluginDirName(params.dirName);
+  const env = params.env ?? process.env;
 
   const explicitBundledPluginsDir =
-    params.bundledPluginsDir ?? resolveBundledPluginsDir(params.env ?? process.env);
+    params.bundledPluginsDirMode === "auto"
+      ? resolveExplicitEnvBundledPluginsDir(env)
+      : (params.bundledPluginsDir ?? resolveExplicitEnvBundledPluginsDir(env));
   if (explicitBundledPluginsDir) {
-    const explicitPluginDir = path.resolve(explicitBundledPluginsDir, dirName);
-    const explicitBuiltCandidate = path.join(explicitPluginDir, artifactBasename);
-    if (fs.existsSync(explicitBuiltCandidate)) {
-      return explicitBuiltCandidate;
+    return resolvePublicSurfaceFromBundledDir({
+      rootDir: params.rootDir,
+      bundledPluginsDir: explicitBundledPluginsDir,
+      dirName,
+      artifactBasename,
+    });
+  }
+
+  if (areBundledPluginsDisabled(env)) {
+    return null;
+  }
+
+  const sourceCandidate = resolveBundledPluginSourcePublicSurfacePath({
+    sourceRoot: path.resolve(params.rootDir, "extensions"),
+    dirName,
+    artifactBasename,
+  });
+  if (sourceCandidate) {
+    return sourceCandidate;
+  }
+
+  const bundledPluginsDir =
+    params.bundledPluginsDirMode === "auto"
+      ? params.bundledPluginsDir
+      : resolveBundledPluginsDir(env);
+  if (bundledPluginsDir) {
+    const bundledCandidate = resolvePublicSurfaceFromBundledDir({
+      rootDir: params.rootDir,
+      bundledPluginsDir,
+      dirName,
+      artifactBasename,
+    });
+    if (bundledCandidate) {
+      return bundledCandidate;
     }
-    return (
-      resolveBundledPluginSourcePublicSurfacePath({
-        sourceRoot: explicitBundledPluginsDir,
-        dirName,
-        artifactBasename,
-      }) ??
-      resolvePackageFallbackForBundledDir({
-        rootDir: params.rootDir,
-        bundledPluginsDir: explicitBundledPluginsDir,
-        dirName,
-        artifactBasename,
-      })
-    );
   }
 
   for (const candidate of [
@@ -142,10 +211,5 @@ export function resolveBundledPluginPublicSurfacePath(params: {
       return candidate;
     }
   }
-
-  return resolveBundledPluginSourcePublicSurfacePath({
-    sourceRoot: path.resolve(params.rootDir, "extensions"),
-    dirName,
-    artifactBasename,
-  });
+  return null;
 }


### PR DESCRIPTION
## Summary
- Prefer source public artifacts over auto-resolved bundled `dist/` artifacts in source checkouts.
- Keep explicit `bundledPluginsDir` / `OPENCLAW_BUNDLED_PLUGINS_DIR` overrides built-artifact-first.
- Add regression coverage for auto-resolved stale dist vs explicit dist ordering.

## Verification
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.plugins.config.ts src/plugins/public-surface-runtime.test.ts src/plugins/public-surface-loader.test.ts --reporter=verbose`
- `pnpm exec oxfmt --write --threads=1 src/plugins/public-surface-runtime.ts src/plugins/public-surface-loader.ts src/plugins/public-surface-runtime.test.ts`
- `git diff --check`
- `pnpm crabbox:run -- --idle-timeout 30m --ttl 90m --timing-json --shell -- "set -euo pipefail; printf 'CRABBOX_PHASE:public-surface-tests\n'; node scripts/run-vitest.mjs run --config test/vitest/vitest.plugins.config.ts src/plugins/public-surface-runtime.test.ts src/plugins/public-surface-loader.test.ts --reporter=verbose"`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local` clean

## Real behavior proof
Behavior addressed: source checkout public artifact resolution no longer lets ignored stale `dist/extensions/*/*.js` shadow current `extensions/*/*.ts` when the bundled dir was auto-resolved.
Real environment tested: local macOS checkout and AWS Crabbox Linux runner.
Exact steps or command run after this patch: focused Vitest command above locally and through Crabbox.
Evidence after fix: Crabbox provider=aws lease=cbx_159fed274b51 run=run_7ed54940362a exit=0; local focused suite 15 passed.
Observed result after fix: auto-resolved bundled dirs use source-first ordering, while explicit bundled dist roots remain built-first.
What was not tested: full repo check; scope is the bundled public surface resolver/loader path.
