### PR TITLE
fix(reply): don't wedge preflight compaction on benign skip reasons

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -912,6 +912,73 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactCall.currentTokenCount).toBe(347_000);
   });
 
+  it.each([
+    "no real conversation messages",
+    "Already compacted",
+    "nothing to compact",
+    "below threshold",
+  ])(
+    "Layer 2: benign compaction skip %j does not wedge a claude-cli-runtime session (provider=anthropic)",
+    async (reason) => {
+      registerMemoryFlushPlanResolverForTest(() => ({
+        softThresholdTokens: 4_000,
+        forceFlushTranscriptBytes: 1_000_000_000,
+        reserveTokensFloor: 20_000,
+        prompt: "Pre-compaction memory flush.\nNO_REPLY",
+        systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+        relativePath: "memory/2023-11-14.md",
+      }));
+      // claude-cli session: OpenClaw transcript is empty -> compaction returns a skip reason.
+      compactEmbeddedPiSessionMock.mockReset().mockResolvedValue({
+        ok: false,
+        compacted: false,
+        reason,
+      });
+      const sessionEntry: SessionEntry = {
+        sessionId: "session",
+        updatedAt: Date.now(),
+        totalTokens: 1_207_416, // inflated cache-read sum, over the 1M window
+        totalTokensFresh: true,
+      };
+
+      const run = runPreflightCompactionIfNeeded({
+        cfg: {
+          models: {
+            providers: {
+              anthropic: { models: [{ id: "claude-opus-4-7", contextWindow: 1_048_576 }] },
+            },
+          },
+          agents: {
+            defaults: {
+              // user's setup: claude-cli backend + per-MODEL runtime pin (provider stays "anthropic")
+              cliBackends: { "claude-cli": { command: "/usr/bin/claude" } },
+              models: { "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } } },
+              compaction: { memoryFlush: {} },
+            },
+          },
+        } as never,
+        followupRun: createTestFollowupRun({
+          provider: "anthropic",
+          model: "claude-opus-4-7",
+          sessionId: "session",
+          sessionKey: "main",
+        }),
+        defaultModel: "anthropic/claude-opus-4-7",
+        sessionEntry,
+        sessionStore: { main: sessionEntry },
+        sessionKey: "main",
+        storePath: path.join(rootDir, "sessions.json"),
+        isHeartbeat: false,
+        replyOperation: createReplyOperation(),
+      });
+
+      // The over-threshold session must NOT wedge: a benign skip returns the entry so the
+      // turn proceeds. (Pre-fix this threw "Preflight compaction required but failed: <reason>".)
+      await expect(run).resolves.toBeDefined();
+      expect(compactEmbeddedPiSessionMock).toHaveBeenCalled();
+    },
+  );
+
   it("keeps the OpenAI API context window for persisted PI runtime overrides", async () => {
     registerMemoryFlushPlanResolverForTest(() => ({
       softThresholdTokens: 4_000,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -45,6 +45,7 @@ import {
   buildEmbeddedRunExecutionParams,
   resolveModelFallbackOptions,
 } from "./agent-runner-utils.js";
+import { isCompactionSkipReason } from "./commands-compact.js";
 import {
   hasAlreadyFlushedForCurrentCompaction,
   resolveMaxActiveTranscriptBytes,
@@ -768,6 +769,14 @@ export async function runPreflightCompactionIfNeeded(params: {
   if (!result?.ok || !result.compacted) {
     const reason = result?.reason ?? "not_compacted";
     logVerbose(`preflightCompaction failed: sessionKey=${params.sessionKey} reason=${reason}`);
+    // A benign compaction *skip* (nothing to compact / below threshold / already
+    // compacted / no real conversation messages) is not a failure — it routinely
+    // happens for provider-owned CLI-runtime sessions, whose OpenClaw-side transcript
+    // is empty. Throwing here wedges every subsequent dispatch on the session. Defer
+    // to the same classifier used by the manual /compact path and proceed.
+    if (isCompactionSkipReason(reason)) {
+      return entry ?? params.sessionEntry;
+    }
     throw new Error(`Preflight compaction required but failed: ${reason}`);
   }
 

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -51,7 +51,7 @@ function extractCompactInstructions(params: {
   return rest.length ? rest : undefined;
 }
 
-function isCompactionSkipReason(reason?: string): boolean {
+export function isCompactionSkipReason(reason?: string): boolean {
   const text = normalizeOptionalLowercaseString(reason) ?? "";
   return (
     text.includes("nothing to compact") ||


### PR DESCRIPTION
## Summary

`runPreflightCompactionIfNeeded` throws unconditionally on any non-ok/non-compacted embedded compaction result. For per-model `claude-cli` runtime sessions (the model's provider stays `anthropic` via a per-model `agentRuntime.id` pin), the embedded compaction legitimately returns a benign *skip* — e.g. `no real conversation messages` (the CLI session's OpenClaw-side transcript is empty) or `Already compacted` — and the throw then fails *every* subsequent dispatch on that session until it is reset. The user-visible symptom is a "context limit"-style error even though real resident context is small.

Same class as #84878 (which skipped the harness compaction preflight for CLI runtimes), but on the still-unguarded preflight gate in `runPreflightCompactionIfNeeded`.

Fix: reuse the existing `isCompactionSkipReason` classifier (already used on the manual `/compact` path) at the throw site, returning the session entry for benign skips (`nothing to compact | below threshold | already compacted | no real conversation messages`) instead of throwing.

- `src/auto-reply/reply/commands-compact.ts` — export `isCompactionSkipReason`
- `src/auto-reply/reply/agent-runner-memory.ts` — graceful skip before the throw
- `src/auto-reply/reply/agent-runner-memory.test.ts` — parametrized regression test

## Real behavior proof

Behavior addressed: per-model `claude-cli` runtime sessions no longer wedge in preflight compaction when it returns a benign skip reason.

Real environment tested: built from this branch (2026.5.25, Node 24, macOS) and running as the gateway; agent default `anthropic/claude-opus-4-7` with a per-model `agentRuntime.id=claude-cli` pin (provider resolves to `anthropic`).

Exact steps or command run after this patch: `node scripts/run-vitest.mjs run src/auto-reply/reply/agent-runner-memory.test.ts`

Evidence after fix: `Test Files 1 passed (1)` / `Tests 28 passed (28)`, including a parametrized case over `no real conversation messages`, `Already compacted`, `nothing to compact`, and `below threshold`. The gateway built from this branch logs no `Preflight compaction required but failed: …` occurrences.

Observed result after fix: benign compaction skips return the existing session entry and the turn proceeds.

What was not tested: did not also add a runtime-aware guard at the `isCliProvider` check (`agent-runner-memory.ts:612`) — the more complete complementary fix, left as follow-up; full CI suite not run locally (narrow unit + live behavior only).
