### PR TITLE
Refactor Google Meet realtime output activity tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Voice: expose shared realtime turn-context tracking through the realtime voice SDK and reuse it for Discord speaker attribution and wake-name context recovery.
+- Voice: reuse shared realtime output activity tracking in Google Meet command and node audio bridges, including recent-output checks for local barge-in detection.
 - Voice: expose shared realtime output activity tracking through the realtime voice SDK and reuse it for Discord playback activity and barge-in decisions.
 - Voice: expose shared realtime consult question matching, speakable-result extraction, and alias-aware forced-consult coordination through the realtime voice SDK, then reuse it in Gateway Talk, Voice Call, and Discord voice paths.
 - Voice: share activation-name matching and consult-transcript screening through the realtime voice SDK so Discord, browser voice, and meeting surfaces can reuse one implementation.

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-8712c831d993980a72d7a628cd235654a5e7dcf74edda0c9f0c9c9c5ba250afc  plugin-sdk-api-baseline.json
-f6bf4178e5429f64943f5404f3085c360a7f390c15d15b5b9c23239c7a134ca6  plugin-sdk-api-baseline.jsonl
+5ea1c7850cd69d5cfb6817148ffff622a52c6e0a2306e0ae71b6f451ad54ac2c  plugin-sdk-api-baseline.json
+df2ca60d91db5c5b0225286938a175c3b56feb3190b613a6524864471efa4588  plugin-sdk-api-baseline.jsonl

--- a/extensions/google-meet/src/realtime-node.ts
+++ b/extensions/google-meet/src/realtime-node.ts
@@ -9,6 +9,7 @@ import {
   createRealtimeVoiceAgentTalkbackQueue,
   createTalkSessionController,
   createRealtimeVoiceBridgeSession,
+  createRealtimeVoiceOutputActivityTracker,
   recordTalkObservabilityEvent,
   type RealtimeVoiceAgentTalkbackQueue,
   type RealtimeVoiceBridgeSession,
@@ -27,7 +28,7 @@ import {
   getGoogleMeetRealtimeTranscriptHealth,
   buildGoogleMeetSpeakExactUserMessage,
   GOOGLE_MEET_AGENT_TRANSCRIPT_DEBOUNCE_MS,
-  extendGoogleMeetOutputEchoSuppression,
+  recordGoogleMeetOutputActivity,
   getGoogleMeetRealtimeEventHealth,
   recordGoogleMeetRealtimeTranscript,
   recordGoogleMeetRealtimeEvent,
@@ -97,7 +98,7 @@ export async function startNodeAgentAudioBridge(params: {
   let lastInputAt: string | undefined;
   let lastOutputAt: string | undefined;
   let lastInputBytes = 0;
-  let lastOutputBytes = 0;
+  const outputActivity = createRealtimeVoiceOutputActivityTracker();
   let suppressedInputBytes = 0;
   let lastSuppressedInputAt: string | undefined;
   let suppressInputUntil = 0;
@@ -148,7 +149,8 @@ export async function startNodeAgentAudioBridge(params: {
   };
 
   const pushOutputAudio = async (audio: Buffer) => {
-    const suppression = extendGoogleMeetOutputEchoSuppression({
+    const suppression = recordGoogleMeetOutputActivity({
+      tracker: outputActivity,
       audio,
       audioFormat: params.config.chrome.audioFormat,
       nowMs: Date.now(),
@@ -158,7 +160,6 @@ export async function startNodeAgentAudioBridge(params: {
     suppressInputUntil = suppression.suppressInputUntilMs;
     lastOutputPlayableUntilMs = suppression.lastOutputPlayableUntilMs;
     lastOutputAt = new Date().toISOString();
-    lastOutputBytes += audio.byteLength;
     await params.runtime.nodes.invoke({
       nodeId: params.nodeId,
       command: "googlemeet.chrome",
@@ -317,12 +318,12 @@ export async function startNodeAgentAudioBridge(params: {
       providerConnected: sttSession?.isConnected() ?? false,
       realtimeReady,
       audioInputActive: lastInputBytes > 0,
-      audioOutputActive: lastOutputBytes > 0,
+      audioOutputActive: outputActivity.isActive(),
       lastInputAt,
       lastOutputAt,
       lastSuppressedInputAt,
       lastInputBytes,
-      lastOutputBytes,
+      lastOutputBytes: outputActivity.snapshot().sinkAudioBytes,
       suppressedInputBytes,
       ...getGoogleMeetRealtimeTranscriptHealth(transcript),
       consecutiveInputErrors,
@@ -351,7 +352,7 @@ export async function startNodeRealtimeAudioBridge(params: {
   let lastOutputAt: string | undefined;
   let lastClearAt: string | undefined;
   let lastInputBytes = 0;
-  let lastOutputBytes = 0;
+  const outputActivity = createRealtimeVoiceOutputActivityTracker();
   let suppressedInputBytes = 0;
   let lastSuppressedInputAt: string | undefined;
   let suppressInputUntil = 0;
@@ -505,7 +506,8 @@ export async function startNodeRealtimeAudioBridge(params: {
           turnId,
           payload: { byteLength: audio.byteLength },
         });
-        const suppression = extendGoogleMeetOutputEchoSuppression({
+        const suppression = recordGoogleMeetOutputActivity({
+          tracker: outputActivity,
           audio,
           audioFormat: params.config.chrome.audioFormat,
           nowMs: Date.now(),
@@ -515,7 +517,6 @@ export async function startNodeRealtimeAudioBridge(params: {
         suppressInputUntil = suppression.suppressInputUntilMs;
         lastOutputPlayableUntilMs = suppression.lastOutputPlayableUntilMs;
         lastOutputAt = new Date().toISOString();
-        lastOutputBytes += audio.byteLength;
         void params.runtime.nodes
           .invoke({
             nodeId: params.nodeId,
@@ -759,13 +760,13 @@ export async function startNodeRealtimeAudioBridge(params: {
       providerConnected: bridge?.bridge.isConnected() ?? false,
       realtimeReady,
       audioInputActive: lastInputBytes > 0,
-      audioOutputActive: lastOutputBytes > 0,
+      audioOutputActive: outputActivity.isActive(),
       lastInputAt,
       lastOutputAt,
       lastSuppressedInputAt,
       lastClearAt,
       lastInputBytes,
-      lastOutputBytes,
+      lastOutputBytes: outputActivity.snapshot().sinkAudioBytes,
       suppressedInputBytes,
       ...getGoogleMeetRealtimeTranscriptHealth(transcript),
       ...getGoogleMeetRealtimeEventHealth(realtimeEvents),

--- a/extensions/google-meet/src/realtime.ts
+++ b/extensions/google-meet/src/realtime.ts
@@ -13,6 +13,7 @@ import {
 import {
   createRealtimeVoiceAgentTalkbackQueue,
   createRealtimeVoiceBridgeSession,
+  createRealtimeVoiceOutputActivityTracker,
   createTalkSessionController,
   convertPcmToMulaw8k,
   extendRealtimeVoiceOutputEchoSuppression,
@@ -30,6 +31,7 @@ import {
   type RealtimeVoiceAgentTalkbackQueue,
   type RealtimeVoiceBridgeEventLogEntry,
   type RealtimeVoiceBridgeSession,
+  type RealtimeVoiceOutputActivityTracker,
   type RealtimeVoiceProviderConfig,
   type RealtimeVoiceProviderPlugin,
   type RealtimeVoiceTranscriptEntry,
@@ -161,6 +163,24 @@ export function extendGoogleMeetOutputEchoSuppression(params: {
     bytesPerMs,
     tailMs: GOOGLE_MEET_OUTPUT_ECHO_SUPPRESSION_TAIL_MS,
   });
+}
+
+export function recordGoogleMeetOutputActivity(params: {
+  tracker: RealtimeVoiceOutputActivityTracker;
+  audio: Buffer;
+  audioFormat: GoogleMeetConfig["chrome"]["audioFormat"];
+  nowMs: number;
+  lastOutputPlayableUntilMs: number;
+  suppressInputUntilMs: number;
+}): { lastOutputPlayableUntilMs: number; suppressInputUntilMs: number; durationMs: number } {
+  const suppression = extendGoogleMeetOutputEchoSuppression(params);
+  params.tracker.markPlaybackStarted();
+  params.tracker.markAudio({
+    audioMs: suppression.durationMs,
+    sourceAudioBytes: params.audio.byteLength,
+    sinkAudioBytes: params.audio.byteLength,
+  });
+  return suppression;
 }
 
 export function resolveGoogleMeetRealtimeAudioFormat(config: GoogleMeetConfig) {
@@ -477,7 +497,7 @@ export async function startCommandAgentAudioBridge(params: {
   let lastInputAt: string | undefined;
   let lastOutputAt: string | undefined;
   let lastInputBytes = 0;
-  let lastOutputBytes = 0;
+  const outputActivity = createRealtimeVoiceOutputActivityTracker();
   let suppressedInputBytes = 0;
   let lastSuppressedInputAt: string | undefined;
   let suppressInputUntil = 0;
@@ -606,7 +626,8 @@ export async function startCommandAgentAudioBridge(params: {
   });
 
   const writeOutputAudio = (audio: Buffer) => {
-    const suppression = extendGoogleMeetOutputEchoSuppression({
+    const suppression = recordGoogleMeetOutputActivity({
+      tracker: outputActivity,
       audio,
       audioFormat: params.config.chrome.audioFormat,
       nowMs: Date.now(),
@@ -616,7 +637,6 @@ export async function startCommandAgentAudioBridge(params: {
     suppressInputUntil = suppression.suppressInputUntilMs;
     lastOutputPlayableUntilMs = suppression.lastOutputPlayableUntilMs;
     lastOutputAt = new Date().toISOString();
-    lastOutputBytes += audio.byteLength;
     emitTalkEvent({
       type: "output.audio.delta",
       turnId: ensureTalkTurn(),
@@ -787,12 +807,12 @@ export async function startCommandAgentAudioBridge(params: {
       providerConnected: sttSession?.isConnected() ?? false,
       realtimeReady,
       audioInputActive: lastInputBytes > 0,
-      audioOutputActive: lastOutputBytes > 0,
+      audioOutputActive: outputActivity.isActive(),
       lastInputAt,
       lastOutputAt,
       lastSuppressedInputAt,
       lastInputBytes,
-      lastOutputBytes,
+      lastOutputBytes: outputActivity.snapshot().sinkAudioBytes,
       suppressedInputBytes,
       ...getGoogleMeetRealtimeTranscriptHealth(transcript),
       recentTalkEvents: summarizeGoogleMeetTalkEvents(recentTalkEvents),
@@ -833,19 +853,19 @@ export async function startCommandRealtimeAudioBridge(params: {
   let lastInputAt: string | undefined;
   let lastOutputAt: string | undefined;
   let lastInputBytes = 0;
-  let lastOutputBytes = 0;
+  const outputActivity = createRealtimeVoiceOutputActivityTracker();
   let lastClearAt: string | undefined;
   let clearCount = 0;
   let suppressedInputBytes = 0;
   let lastSuppressedInputAt: string | undefined;
   let suppressInputUntil = 0;
-  let lastOutputAtMs = 0;
   let lastOutputPlayableUntilMs = 0;
   let bargeInInputProcess: BridgeProcess | undefined;
   let agentTalkback: RealtimeVoiceAgentTalkbackQueue | undefined;
 
   const suppressInputForOutput = (audio: Buffer) => {
-    const suppression = extendGoogleMeetOutputEchoSuppression({
+    const suppression = recordGoogleMeetOutputActivity({
+      tracker: outputActivity,
       audio,
       audioFormat: params.config.chrome.audioFormat,
       nowMs: Date.now(),
@@ -970,12 +990,13 @@ export async function startCommandRealtimeAudioBridge(params: {
       stdio: ["ignore", "pipe", "pipe"],
     });
     bargeInInputProcess.stdout?.on("data", (chunk) => {
-      if (stopped || lastOutputAtMs === 0) {
+      if (stopped || !outputActivity.isInterruptible()) {
         return;
       }
       const now = Date.now();
       const playbackActive = now <= Math.max(lastOutputPlayableUntilMs, suppressInputUntil);
-      if (!playbackActive && now - lastOutputAtMs > 1000) {
+      const lastOutputAudioAt = outputActivity.snapshot().lastAudioAt;
+      if (!playbackActive && (lastOutputAudioAt === undefined || now - lastOutputAudioAt > 1_000)) {
         return;
       }
       if (now - lastBargeInAt < params.config.chrome.bargeInCooldownMs) {
@@ -1141,9 +1162,7 @@ export async function startCommandRealtimeAudioBridge(params: {
           turnId,
           payload: { byteLength: audio.byteLength },
         });
-        lastOutputAtMs = Date.now();
         lastOutputAt = new Date().toISOString();
-        lastOutputBytes += audio.byteLength;
         suppressInputForOutput(audio);
         writeOutputAudio(audio);
       },
@@ -1315,12 +1334,12 @@ export async function startCommandRealtimeAudioBridge(params: {
       providerConnected: bridge?.bridge.isConnected() ?? false,
       realtimeReady,
       audioInputActive: lastInputBytes > 0,
-      audioOutputActive: lastOutputBytes > 0,
+      audioOutputActive: outputActivity.isActive(),
       lastInputAt,
       lastOutputAt,
       lastSuppressedInputAt,
       lastInputBytes,
-      lastOutputBytes,
+      lastOutputBytes: outputActivity.snapshot().sinkAudioBytes,
       suppressedInputBytes,
       ...getGoogleMeetRealtimeTranscriptHealth(transcript),
       ...getGoogleMeetRealtimeEventHealth(realtimeEvents),

--- a/src/talk/output-activity-tracker.test.ts
+++ b/src/talk/output-activity-tracker.test.ts
@@ -7,6 +7,7 @@ describe("realtime voice output activity tracker", () => {
 
     expect(tracker.isActive(false)).toBe(false);
     expect(tracker.isInterruptible(false)).toBe(false);
+    expect(tracker.snapshot().lastAudioAt).toBeUndefined();
 
     tracker.markAudio({ audioMs: 10, sourceAudioBytes: 480, sinkAudioBytes: 1_920 });
 
@@ -17,6 +18,7 @@ describe("realtime voice output activity tracker", () => {
       chunks: 1,
       sourceAudioBytes: 480,
       sinkAudioBytes: 1_920,
+      lastAudioAt: expect.any(Number),
     });
   });
 
@@ -43,6 +45,7 @@ describe("realtime voice output activity tracker", () => {
       playbackStarted: true,
       playbackStartedAt: 1_000,
       streamEnding: true,
+      lastAudioAt: 1_000,
     });
   });
 

--- a/src/talk/output-activity-tracker.ts
+++ b/src/talk/output-activity-tracker.ts
@@ -15,6 +15,7 @@ export type RealtimeVoiceOutputActivitySnapshot = {
   sinkAudioBytes: number;
   playbackStarted: boolean;
   streamEnding: boolean;
+  lastAudioAt?: number;
   playbackStartedAt?: number;
 };
 
@@ -41,6 +42,7 @@ export function createRealtimeVoiceOutputActivityTracker(
   let sinkAudioBytes = 0;
   let playbackStarted = false;
   let streamEnding = false;
+  let lastAudioAt: number | undefined;
   let playbackStartedAt: number | undefined;
 
   const snapshot = (): RealtimeVoiceOutputActivitySnapshot => ({
@@ -50,6 +52,7 @@ export function createRealtimeVoiceOutputActivityTracker(
     sinkAudioBytes,
     playbackStarted,
     streamEnding,
+    ...(lastAudioAt === undefined ? {} : { lastAudioAt }),
     ...(playbackStartedAt === undefined ? {} : { playbackStartedAt }),
   });
 
@@ -58,6 +61,7 @@ export function createRealtimeVoiceOutputActivityTracker(
       streamEnding = false;
       playbackStarted = false;
       playbackStartedAt = undefined;
+      lastAudioAt = undefined;
     },
     markStreamEnding() {
       streamEnding = true;
@@ -74,6 +78,7 @@ export function createRealtimeVoiceOutputActivityTracker(
       sourceAudioBytes += Math.max(0, delta.sourceAudioBytes ?? 0);
       sinkAudioBytes += Math.max(0, delta.sinkAudioBytes ?? 0);
       chunks += 1;
+      lastAudioAt = now();
     },
     reset() {
       audioMs = 0;
@@ -82,6 +87,7 @@ export function createRealtimeVoiceOutputActivityTracker(
       sinkAudioBytes = 0;
       playbackStarted = false;
       streamEnding = false;
+      lastAudioAt = undefined;
       playbackStartedAt = undefined;
     },
     isActive(sinkActive = false) {


### PR DESCRIPTION
Summary
- Add optional `lastAudioAt` metadata to the shared realtime output activity tracker snapshot without adding a required SDK method.
- Reuse the shared tracker in Google Meet Chrome command-pair and paired-node realtime output paths for output byte/active health and recent-output local barge-in gating.
- Keep transport, Chrome/node process lifecycle, audio conversion, echo suppression, and Google Meet config ownership local.

Audit notes
- Gateway Talk already consumes shared forced-consult coordination and speakable tool-result extraction; it does not own browser playback, so no output tracker migration there.
- Google Meet is the useful non-Discord adapter proof because it owns local playback/buffer clearing and local human barge-in detection.
- Duplicate realtime error suppression still appears provider-specific to OpenAI; no second generic consumer found in this pass.
- Speakable-result extraction is already shared where Gateway Talk and Voice Call need it; Google Meet native consult submission does not need a separate extraction.

Verification
- pnpm exec oxfmt --check --threads=1 src/talk/output-activity-tracker.ts src/talk/output-activity-tracker.test.ts extensions/google-meet/src/realtime.ts extensions/google-meet/src/realtime-node.ts
- node scripts/run-vitest.mjs src/talk/output-activity-tracker.test.ts
- pnpm test extensions/google-meet/index.test.ts -- --reporter=dot -t "uses realtime transcription plus regular TTS in Chrome agent mode|pipes Chrome command-pair audio through the realtime provider|uses a local barge-in input command to clear active Chrome playback|pipes paired-node command-pair audio through the realtime provider"
- pnpm plugin-sdk:api:check
- pnpm build
- env -u OPENCLAW_TESTBOX pnpm check:changed
- /Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local

Behavior addressed: Google Meet command and node realtime audio bridges now consume the shared realtime output activity tracker while preserving existing playback ownership and local barge-in timing behavior.
Real environment tested: Local macOS source checkout, Node/pnpm repo toolchain, focused Google Meet realtime adapter tests.
Exact steps or command run after this patch: Tracker unit test, four focused Google Meet realtime adapter tests, SDK API check, full build, changed checks, and two autoreview runs after one accepted SDK-compat finding was fixed.
Evidence after fix: Tracker tests passed, Google Meet adapter tests passed, SDK API baseline check passed, build passed, check:changed passed, final autoreview reported no accepted/actionable findings.
Observed result after fix: Output byte/active health and recent-output barge-in checks are backed by shared tracker state; no live provider behavior change intended.
What was not tested: Live Google Meet, browser voice, or Discord sessions; this is a helper reuse/refactor with unit and adapter proof.
