### PR TITLE
fix(telegram): warn and skip pairing check on transient store read failure

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -859,7 +859,13 @@ export const registerTelegramHandlers = ({
   };
 
   const loadStoreAllowFrom = async () =>
-    telegramDeps.readChannelAllowFromStore("telegram", process.env, accountId).catch(() => []);
+    telegramDeps.readChannelAllowFromStore("telegram", process.env, accountId).catch((err) => {
+      warn(
+        `pairing-store read failed (${(err as { code?: string }).code ?? "unknown"}), ` +
+          "skipping store-based authorization for this request",
+      );
+      return ["*"];
+    });
 
   const recordMessageForReplyChain = (msg: Message, threadId?: number) =>
     messageCache.record({

--- a/extensions/telegram/src/bot.helpers.test.ts
+++ b/extensions/telegram/src/bot.helpers.test.ts
@@ -1,5 +1,5 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { resolveTelegramGroupAllowFromContext, resolveTelegramStreamMode } from "./bot/helpers.js";
 import { resolveTelegramDraftStreamingChunking } from "./draft-chunking.js";
 
@@ -26,6 +26,37 @@ describe("resolveTelegramStreamMode", () => {
 });
 
 describe("resolveTelegramGroupAllowFromContext", () => {
+  it("returns wildcard storeAllowFrom when store read fails with transient I/O error", async () => {
+    const emfileError = Object.assign(new Error("EMFILE: too many open files"), { code: "EMFILE" });
+    const warnSpy = vi.spyOn(await import("openclaw/plugin-sdk/runtime-env"), "warn");
+
+    const context = await resolveTelegramGroupAllowFromContext({
+      chatId: 123,
+      accountId: "default",
+      readChannelAllowFromStore: async () => {
+        throw emfileError;
+      },
+      resolveTelegramGroupConfig: () => ({}),
+    });
+
+    expect(context.storeAllowFrom).toEqual(["*"]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("pairing-store read failed (EMFILE)"),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("returns actual store entries when store read succeeds", async () => {
+    const context = await resolveTelegramGroupAllowFromContext({
+      chatId: 123,
+      accountId: "default",
+      readChannelAllowFromStore: async () => ["111222333"],
+      resolveTelegramGroupConfig: () => ({}),
+    });
+
+    expect(context.storeAllowFrom).toEqual(["111222333"]);
+  });
+
   it("expands Telegram access groups before normalizing allowFrom entries", async () => {
     const cfg: OpenClawConfig = {
       accessGroups: {

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -14,6 +14,7 @@ import type {
 } from "openclaw/plugin-sdk/config-contracts";
 import { readChannelAllowFromStore } from "openclaw/plugin-sdk/conversation-runtime";
 import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
+import { warn } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { expandTelegramAllowFromWithAccessGroups } from "../access-groups.js";
 import { firstDefined, normalizeAllowFrom, type NormalizedAllowFrom } from "../bot-access.js";
@@ -210,11 +211,20 @@ export async function resolveTelegramGroupAllowFromContext(params: {
   const resolvedThreadId = threadSpec.scope === "forum" ? threadSpec.id : undefined;
   const dmThreadId = threadSpec.scope === "dm" ? threadSpec.id : undefined;
   const threadIdForConfig = resolvedThreadId ?? dmThreadId;
-  const storeAllowFrom = await (params.readChannelAllowFromStore ?? readChannelAllowFromStore)(
-    "telegram",
-    process.env,
-    accountId,
-  ).catch(() => []);
+  let storeAllowFrom: string[];
+  try {
+    storeAllowFrom = await (params.readChannelAllowFromStore ?? readChannelAllowFromStore)(
+      "telegram",
+      process.env,
+      accountId,
+    );
+  } catch (err) {
+    warn(
+      `pairing-store read failed (${(err as { code?: string }).code ?? "unknown"}), ` +
+        "skipping store-based authorization",
+    );
+    storeAllowFrom = ["*"];
+  }
   const { groupConfig, topicConfig } = params.resolveTelegramGroupConfig(
     params.chatId,
     threadIdForConfig,

--- a/extensions/telegram/src/security-audit.ts
+++ b/extensions/telegram/src/security-audit.ts
@@ -1,5 +1,6 @@
 import { readChannelAllowFromStore } from "openclaw/plugin-sdk/conversation-runtime";
 import { resolveNativeSkillsEnabled } from "openclaw/plugin-sdk/native-command-config-runtime";
+import { warn } from "openclaw/plugin-sdk/runtime-env";
 import type { OpenClawConfig } from "../runtime-api.js";
 import type { ResolvedTelegramAccount } from "./accounts.js";
 import { isNumericTelegramSenderUserId, normalizeTelegramAllowFromEntry } from "./allow-from.js";
@@ -93,7 +94,12 @@ export async function collectTelegramSecurityAuditFindings(params: {
   }
 
   const storeAllowFrom = await readChannelAllowFromStore("telegram", process.env, accountId).catch(
-    () => [],
+    (err) => {
+      warn(
+        `pairing-store read failed during audit (${(err as { code?: string }).code ?? "unknown"})`,
+      );
+      return [];
+    },
   );
   const storeHasWildcard = storeAllowFrom.some(
     (value) => (normalizeOptionalString(value) ?? "") === "*",


### PR DESCRIPTION
## Summary

Fixes #85577

Three call sites in the Telegram extension catch transient I/O errors from `readChannelAllowFromStore` with `.catch(() => [])`. Since the underlying `readAllowFromFileWithExists` already handles `ENOENT` (file not found) internally, the `.catch(() => [])` only fires on real I/O failures like `EACCES`, `EMFILE`, or `EBADF`. Returning an empty array tells the authorization logic "nobody is paired," which triggers bogus pairing prompts on already-paired bots.

**Fix:** Replace the silent catch with a `warn()` log and return `["*"]` (wildcard) in the two authorization paths, so the store-based check is skipped on transient failures instead of denying access. The security-audit path returns `[]` with a warning since it reports actual state rather than making access decisions.

**Changed files:**
- `extensions/telegram/src/bot/helpers.ts` -- `resolveTelegramGroupAllowFromContext`
- `extensions/telegram/src/bot-handlers.runtime.ts` -- `loadStoreAllowFrom`
- `extensions/telegram/src/security-audit.ts` -- `collectTelegramSecurityAuditFindings`

## Verification

- 162 tests pass across the Telegram extension (10 helpers + 4 security-audit + 71 bot + 77 handlers)
- 2 new test cases cover the transient I/O error path (EMFILE simulation via mock)

## Real behavior proof

Behavior addressed: Transient pairing-store read failures silently return an empty allowlist, triggering bogus "access not configured" pairing prompts on already-paired Telegram bots (#85577)

Real environment tested: macOS 15.5, Node 22, patched source from branch fix/telegram-pairing-store-transient

Exact steps or command run after this patch: Created a pairing-store JSON file, made it unreadable with chmod 000 to simulate a transient I/O error (EACCES), then ran node to compare the before and after behavior of the catch handler

Evidence after fix:
```
BEFORE fix (silent .catch(() => [])):
  Result: []
  Effect: empty allowFrom -> thinks nobody paired -> bogus pairing prompt

  [warn] pairing-store read failed (EACCES), skipping store-based authorization
AFTER fix (warn + wildcard fallback):
  Result: ["*"]
  Effect: wildcard -> skips store check -> no bogus prompt
```

Observed result after fix: With the patched code, a transient EACCES error on the store file now logs a warning with the error code and returns a wildcard array instead of an empty array. The authorization logic sees the wildcard and skips the store-based check, preventing the bogus pairing prompt. The warning provides an observable diagnostic for operators to investigate the underlying file permission issue.

What was not tested: Full end-to-end Telegram bot pairing flow with a real Telegram bot token and live Bot API; the reproduction uses direct filesystem simulation of the transient error path
