### PR TITLE
perf: cache model cost indexes

### DIFF
--- a/src/utils/usage-format.test.ts
+++ b/src/utils/usage-format.test.ts
@@ -1,12 +1,13 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   resetGatewayModelPricingCacheForTest,
   setGatewayModelPricingForTest,
 } from "../gateway/model-pricing-cache-state.js";
+import * as manifestModelIdNormalization from "../plugins/manifest-model-id-normalization.js";
 import {
   resetUsageFormatCachesForTest,
   estimateUsageCost,
@@ -286,6 +287,76 @@ describe("usage-format", () => {
       cacheRead: 0.7,
       cacheWrite: 0.8,
     });
+  });
+
+  it("skips manifest model normalization for raw cost lookup", () => {
+    const manifestSpy = vi.spyOn(
+      manifestModelIdNormalization,
+      "normalizeProviderModelIdWithManifest",
+    );
+    const config = {
+      models: {
+        providers: {
+          "demo-raw": {
+            models: [
+              {
+                id: "demo-model",
+                cost: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4 },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(
+      resolveModelCostConfig({
+        provider: "demo-raw",
+        model: "demo-model",
+        config,
+        allowPluginNormalization: false,
+      }),
+    ).toEqual({
+      input: 1,
+      output: 2,
+      cacheRead: 3,
+      cacheWrite: 4,
+    });
+    expect(manifestSpy).not.toHaveBeenCalled();
+  });
+
+  it("observes in-place config pricing changes after a cached lookup", () => {
+    const model = {
+      id: "demo-model",
+      cost: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4 },
+    };
+    const config = {
+      models: {
+        providers: {
+          "demo-mutated": {
+            models: [model],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(
+      resolveModelCostConfig({
+        provider: "demo-mutated",
+        model: "demo-model",
+        config,
+      })?.input,
+    ).toBe(1);
+
+    model.cost.input = 9;
+
+    expect(
+      resolveModelCostConfig({
+        provider: "demo-mutated",
+        model: "demo-model",
+        config,
+      })?.input,
+    ).toBe(9);
   });
 
   // -----------------------------------------------------------------------

--- a/src/utils/usage-format.ts
+++ b/src/utils/usage-format.ts
@@ -63,7 +63,19 @@ type ModelsJsonCostCache = {
   rawEntries: Map<string, ModelCostConfig> | null;
 };
 
+type ProviderCostIndexCacheEntry = {
+  fingerprint: string;
+  normalizedEntries?: Map<string, ModelCostConfig>;
+  rawEntries?: Map<string, ModelCostConfig>;
+};
+
+const EMPTY_PROVIDER_COST_INDEX = new Map<string, ModelCostConfig>();
+
 let modelsJsonCostCache: ModelsJsonCostCache | null = null;
+let providerCostIndexByConfig = new WeakMap<
+  Record<string, ModelProviderConfig>,
+  ProviderCostIndexCacheEntry
+>();
 
 export function formatTokenCount(value?: number): string {
   if (value === undefined || !Number.isFinite(value)) {
@@ -108,6 +120,7 @@ function toResolvedModelKey(params: {
     return null;
   }
   const normalized = normalizeModelRef(provider, model, {
+    allowManifestNormalization: params.allowPluginNormalization === false ? false : undefined,
     allowPluginNormalization: params.allowPluginNormalization,
   });
   return modelKey(normalized.provider, normalized.model);
@@ -174,7 +187,7 @@ function normalizeTieredPricing(raw: RawPricingTier[] | undefined): PricingTier[
 
 function buildProviderCostIndex(
   providers: Record<string, ModelProviderConfig> | undefined,
-  options?: { allowPluginNormalization?: boolean },
+  options?: { allowManifestNormalization?: boolean; allowPluginNormalization?: boolean },
 ): Map<string, ModelCostConfig> {
   const entries = new Map<string, ModelCostConfig>();
   if (!providers) {
@@ -184,6 +197,9 @@ function buildProviderCostIndex(
     const normalizedProvider = normalizeProviderId(providerKey);
     for (const model of providerConfig?.models ?? []) {
       const normalized = normalizeModelRef(normalizedProvider, model.id, {
+        allowManifestNormalization:
+          options?.allowManifestNormalization ??
+          (options?.allowPluginNormalization === false ? false : undefined),
         allowPluginNormalization: options?.allowPluginNormalization,
       });
       const cost = { ...model.cost };
@@ -199,6 +215,41 @@ function buildProviderCostIndex(
     }
   }
   return entries;
+}
+
+function getProviderCostIndex(
+  providers: Record<string, ModelProviderConfig> | undefined,
+  options?: { allowManifestNormalization?: boolean; allowPluginNormalization?: boolean },
+): Map<string, ModelCostConfig> {
+  if (!providers) {
+    return EMPTY_PROVIDER_COST_INDEX;
+  }
+  const isRawLookup =
+    options?.allowPluginNormalization === false &&
+    (options.allowManifestNormalization === false ||
+      options.allowManifestNormalization === undefined);
+  const isDefaultNormalizedLookup =
+    options?.allowPluginNormalization !== false &&
+    options?.allowManifestNormalization === undefined;
+  if (!isRawLookup && !isDefaultNormalizedLookup) {
+    return buildProviderCostIndex(providers, options);
+  }
+
+  const fingerprint = stableCostFingerprintValue(providers);
+  let cache = providerCostIndexByConfig.get(providers);
+  if (!cache || cache.fingerprint !== fingerprint) {
+    cache = { fingerprint };
+    providerCostIndexByConfig.set(providers, cache);
+  }
+  if (isRawLookup) {
+    cache.rawEntries ??= buildProviderCostIndex(providers, {
+      allowManifestNormalization: false,
+      allowPluginNormalization: false,
+    });
+    return cache.rawEntries;
+  }
+  cache.normalizedEntries ??= buildProviderCostIndex(providers);
+  return cache.normalizedEntries;
 }
 
 function loadModelsJsonCostIndex(options?: {
@@ -226,13 +277,13 @@ function loadModelsJsonCostIndex(options?: {
     }
 
     if (useRawEntries) {
-      modelsJsonCostCache.rawEntries ??= buildProviderCostIndex(modelsJsonCostCache.providers, {
+      modelsJsonCostCache.rawEntries ??= getProviderCostIndex(modelsJsonCostCache.providers, {
         allowPluginNormalization: false,
       });
       return modelsJsonCostCache.rawEntries;
     }
 
-    modelsJsonCostCache.normalizedEntries ??= buildProviderCostIndex(modelsJsonCostCache.providers);
+    modelsJsonCostCache.normalizedEntries ??= getProviderCostIndex(modelsJsonCostCache.providers);
     return modelsJsonCostCache.normalizedEntries;
   } catch {
     const empty = new Map<string, ModelCostConfig>();
@@ -257,7 +308,7 @@ function findConfiguredProviderCost(params: {
   if (!key) {
     return undefined;
   }
-  return buildProviderCostIndex(params.config?.models?.providers, {
+  return getProviderCostIndex(params.config?.models?.providers, {
     allowPluginNormalization: params.allowPluginNormalization,
   }).get(key);
 }
@@ -289,9 +340,9 @@ function serializeCostIndex(
 export function resolveModelCostConfigFingerprint(config?: OpenClawConfig): string {
   return stableCostFingerprintValue({
     configuredRaw: serializeCostIndex(
-      buildProviderCostIndex(config?.models?.providers, { allowPluginNormalization: false }),
+      getProviderCostIndex(config?.models?.providers, { allowPluginNormalization: false }),
     ),
-    configuredNormalized: serializeCostIndex(buildProviderCostIndex(config?.models?.providers)),
+    configuredNormalized: serializeCostIndex(getProviderCostIndex(config?.models?.providers)),
     modelsJsonRaw: serializeCostIndex(loadModelsJsonCostIndex({ allowPluginNormalization: false })),
     modelsJsonNormalized: serializeCostIndex(loadModelsJsonCostIndex()),
     gatewayPricing: getGatewayModelPricingCacheFingerprint(),
@@ -430,4 +481,5 @@ export function estimateUsageCost(params: {
 
 export function resetUsageFormatCachesForTest(): void {
   modelsJsonCostCache = null;
+  providerCostIndexByConfig = new WeakMap();
 }


### PR DESCRIPTION
## Summary

- Cache configured model cost indexes per providers object, invalidated by a stable value fingerprint so in-place config changes still update pricing.
- Make raw cost lookups skip manifest model-id normalization as well as runtime/plugin normalization, keeping direct pricing lookups off plugin metadata hot paths.
- Add regressions for raw lookup avoiding manifest normalization and mutable config pricing updates after cache population.

## Verification

- `node scripts/run-vitest.mjs src/utils/usage-format.test.ts`
- `pnpm exec oxfmt --check src/utils/usage-format.ts src/utils/usage-format.test.ts`
- `pnpm lint --threads=8`
- `pnpm tsgo:core`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof

Behavior addressed: CPU profile hotspots from repeated model cost index rebuilds and manifest/plugin metadata normalization during session usage cost lookup.
Real environment tested: local OpenClaw checkout on macOS with gateway CPU profiles from `/Users/steipete/clawdbot/.artifacts/gateway-watch-profiles`.
Exact steps or command run after this patch: focused usage-format Vitest, oxfmt check, oxlint shard lint, core tsgo, and autoreview.
Evidence after fix: focused usage-format tests passed 24 tests; lint, format, and core type gates passed; autoreview reported no accepted/actionable findings.
Observed result after fix: raw cost lookup returns configured pricing without calling manifest model normalization, and cached provider cost indexes observe in-place config pricing changes via value-fingerprint invalidation.
What was not tested: live gateway CPU profile comparison after this exact patch.
