### PR TITLE
fix(agents): avoid eager alias normalization for default models

### DIFF
--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -97,12 +97,17 @@ const manifestNormalizationSnapshot = vi.hoisted(() => ({
   ],
 }));
 
+const providerModelNormalizationMock = vi.hoisted(() => ({
+  normalizeProviderModelIdWithRuntime: vi.fn(() => undefined),
+}));
+
 vi.mock("../plugins/current-plugin-metadata-snapshot.js", () => ({
   getCurrentPluginMetadataSnapshot: () => manifestNormalizationSnapshot,
 }));
 
 vi.mock("./provider-model-normalization.runtime.js", () => ({
-  normalizeProviderModelIdWithRuntime: () => undefined,
+  normalizeProviderModelIdWithRuntime:
+    providerModelNormalizationMock.normalizeProviderModelIdWithRuntime,
 }));
 
 vi.mock("./model-selection-cli.js", () => ({
@@ -849,6 +854,36 @@ describe("model-selection", () => {
       });
       expect(index.byAlias.get("smart")?.ref).toEqual({ provider: "openai", model: "gpt-4o" });
       expect(index.byKey.get(modelKey("anthropic", "claude-3-5-sonnet"))).toEqual(["fast"]);
+    });
+
+    it("does not normalize configured model keys that have no alias", () => {
+      providerModelNormalizationMock.normalizeProviderModelIdWithRuntime.mockClear();
+      const models = Object.fromEntries(
+        Array.from({ length: 25 }, (_, index) => [`openai/gpt-5.5-aliasless-${index}`, {}]),
+      );
+      const cfg: Partial<OpenClawConfig> = {
+        agents: {
+          defaults: {
+            models: {
+              ...models,
+              "openai/gpt-5.5-mini": { alias: "mini" },
+            },
+          },
+        },
+      };
+
+      const index = buildModelAliasIndex({
+        cfg: cfg as OpenClawConfig,
+        defaultProvider: "openai",
+      });
+
+      expect(index.byAlias.get("mini")?.ref).toEqual({
+        provider: "openai",
+        model: "gpt-5.5-mini",
+      });
+      expect(
+        providerModelNormalizationMock.normalizeProviderModelIdWithRuntime,
+      ).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -1768,6 +1803,32 @@ describe("model-selection", () => {
       });
 
       expect(result).toEqual({ provider: "openai", model: "gpt-5.5" });
+    });
+
+    it("resolves provider-qualified defaults without normalizing every aliasless configured model", () => {
+      providerModelNormalizationMock.normalizeProviderModelIdWithRuntime.mockClear();
+      const models = Object.fromEntries(
+        Array.from({ length: 25 }, (_, index) => [`anthropic/claude-extra-${index}`, {}]),
+      );
+      const cfg = {
+        agents: {
+          defaults: {
+            model: { primary: "openai/gpt-5.5" },
+            models,
+          },
+        },
+      } as OpenClawConfig;
+
+      const result = resolveConfiguredModelRef({
+        cfg,
+        defaultProvider: "anthropic",
+        defaultModel: "claude-sonnet-4-6",
+      });
+
+      expect(result).toEqual({ provider: "openai", model: "gpt-5.5" });
+      expect(
+        providerModelNormalizationMock.normalizeProviderModelIdWithRuntime,
+      ).toHaveBeenCalledTimes(1);
     });
 
     it("should use default provider/model if config is empty", () => {


### PR DESCRIPTION
## Summary
- avoid building a full model alias index when resolving a configured default model
- skip model key parsing for configured model entries that do not define an alias
- keep slash-form configured aliases working while making provider-qualified defaults resolve through the direct parse path

## Real behavior proof
Behavior addressed: provider-qualified default model resolution no longer walks and normalizes every configured model just to resolve `openai/gpt-5.5` on the inbound reply hot path.
Real environment tested: local OpenClaw source checkout on macOS at current PR head `c8506316c7c05748c3389b5a4c4c47344579519b`, using Node v24.15.0 with `tsx` to execute the production model-selection source directly.
Exact steps or command run after this patch: `node --import tsx - <<'EOF'` executed `resolveConfiguredModelRef` and `buildModelAliasIndex` from `./src/agents/model-selection.ts` against a synthetic config with 97 aliasless configured models plus two configured aliases, then asserted that the provider-qualified default resolved to `openai/gpt-5.5`, the alias index contained only the two real aliases, and the slash-form alias preserved the routed model path. The proof data uses synthetic model names only.
Evidence after fix: Copied console output from the real command:
```terminal
{
  "head": "c8506316c7c05748c3389b5a4c4c47344579519b",
  "scenario": "provider-qualified default model with many aliasless configured models",
  "configuredModelCount": 99,
  "resolved": {
    "provider": "openai",
    "model": "gpt-5.5"
  },
  "aliasCount": 2,
  "miniAlias": {
    "provider": "openai",
    "model": "gpt-5.5-mini"
  },
  "slashAlias": {
    "provider": "openrouter",
    "model": "xiaomi/mimo-v2-pro-mit"
  },
  "elapsedMs": 92.697
}
PASS current-head provider-qualified default resolved without indexing aliasless configured models
```
Observed result after fix: `resolveConfiguredModelRef` resolved the provider-qualified default directly to `openai/gpt-5.5`; `buildModelAliasIndex` ignored the 97 aliasless configured model entries and returned only the two configured aliases; the routed slash-form alias still resolved to `openrouter/xiaomi/mimo-v2-pro-mit`.
What was not tested: a live WhatsApp/gateway workload with the reporter's exact provider plugin normalization latency; the local proof exercises the production source hot path and regression shape from #86635 without private user data.

## Verification
- `node --import tsx - <<'EOF'` current-head production model-selection proof above
- `node scripts/run-vitest.mjs src/agents/model-selection.test.ts`
- `node scripts/run-vitest.mjs src/agents/tools/message-tool.test.ts --testNamePattern 'uses a non-webchat session key'`
- `pnpm exec oxfmt --check --threads=1 src/agents/model-selection.test.ts`
- `git log --format='%h %an <%ae> %s' upstream/main..HEAD`

Fixes #86635

Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>