### PR TITLE
fix(discord): allow marked room_event final fallback delivery

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -5804,6 +5804,68 @@ describe("dispatchReplyFromConfig", () => {
     expect(blockReplySettled).toBe(true);
   });
 
+
+  it("sanitizes internal runtime context before queued and dispatched block replies", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "whatsapp" });
+    const queuedTexts: string[] = [];
+    const dispatchedTexts: string[] = [];
+    const internalBlock = [
+      "Visible intro.",
+      "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+      "OpenClaw runtime event.",
+      "This context is runtime-generated, not user-authored. Keep internal details private.",
+      "",
+      "[Internal task completion event]",
+      "source: subagent",
+      "task: LEAK_SENTINEL_STRICT_BOUNDARIES",
+      "## Active Subagents",
+      "task_json=should-not-appear",
+      "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+      "Visible outro.",
+    ].join("\n");
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload | undefined> => {
+      await opts?.onBlockReply?.({ text: internalBlock });
+      return undefined;
+    };
+    (dispatcher.sendBlockReply as ReturnType<typeof vi.fn>).mockImplementation(
+      (payload: ReplyPayload) => {
+        if (payload.text) {
+          dispatchedTexts.push(payload.text);
+        }
+        return true;
+      },
+    );
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        onBlockReplyQueued: (payload) => {
+          if (payload.text) {
+            queuedTexts.push(payload.text);
+          }
+        },
+      },
+    });
+
+    expect(queuedTexts).toEqual(["Visible intro.\n\nVisible outro."]);
+    expect(dispatchedTexts).toEqual(["Visible intro.\n\nVisible outro."]);
+    for (const text of [...queuedTexts, ...dispatchedTexts]) {
+      expect(text).not.toContain("LEAK_SENTINEL_STRICT_BOUNDARIES");
+      expect(text).not.toContain("## Active Subagents");
+      expect(text).not.toContain("task_json=");
+      expect(text).not.toContain("Internal task completion event");
+      expect(text).not.toContain("source: subagent");
+    }
+  });
+
   it("forwards payload metadata into onBlockReplyQueued context", async () => {
     setNoAbort();
     const dispatcher = createDispatcher();

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -6570,7 +6570,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
   });
 
-  it("suppresses marked runtime failure notices for room events", async () => {
+  it("delivers marked room-event runtime fallback notices exactly once", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {
       sessionId: "s1",
@@ -6584,13 +6584,56 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     );
     const replyResolver = vi.fn(async () => failureNotice satisfies ReplyPayload);
     const ctx = buildTestCtx({
-      ChatType: "group",
+      Provider: "discord",
+      Surface: "discord",
+      ChatType: "channel",
       InboundEventKind: "room_event",
-      SessionKey: "test:session",
+      SessionKey: "test:discord:channel:C1",
     });
 
     const result = await dispatchReplyFromConfig({
       ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(result.queuedFinal).toBe(true);
+    expect(result.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(failureNotice);
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+  });
+
+  it("keeps non-Discord marked room-event runtime fallback notices private", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(
+      async () =>
+        setReplyPayloadMetadata(
+          { text: "⚠️ You've reached your usage limit." },
+          { deliverDespiteSourceReplySuppression: true },
+        ) satisfies ReplyPayload,
+    );
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "slack",
+        Surface: "slack",
+        ChatType: "channel",
+        InboundEventKind: "room_event",
+        SessionKey: "test:slack:channel:C1",
+      }),
       cfg: emptyConfig,
       dispatcher,
       replyResolver,
@@ -6718,6 +6761,120 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
     const result = await dispatchReplyFromConfig({
       ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(result.queuedFinal).toBe(false);
+    expect(result.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
+  it("does not deliver marked room-event runtime fallback notices when sendPolicy denies delivery", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "deny",
+    };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(
+      async () =>
+        setReplyPayloadMetadata(
+          { text: "⚠️ You've reached your Codex subscription usage limit." },
+          { deliverDespiteSourceReplySuppression: true },
+        ) satisfies ReplyPayload,
+    );
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "discord",
+        Surface: "discord",
+        ChatType: "channel",
+        InboundEventKind: "room_event",
+        SessionKey: "test:discord:channel:C1",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(result.queuedFinal).toBe(false);
+    expect(result.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
+  it("keeps marked empty room-event fallback payloads private", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(
+      async () =>
+        setReplyPayloadMetadata(
+          { text: "  " },
+          { deliverDespiteSourceReplySuppression: true },
+        ) satisfies ReplyPayload,
+    );
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "discord",
+        Surface: "discord",
+        ChatType: "channel",
+        InboundEventKind: "room_event",
+        SessionKey: "test:discord:channel:C1",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(result.queuedFinal).toBe(false);
+    expect(result.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
+  it("keeps marked NO_REPLY room-event fallback payloads private", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(
+      async () =>
+        setReplyPayloadMetadata(
+          { text: "  NO_REPLY  " },
+          { deliverDespiteSourceReplySuppression: true },
+        ) satisfies ReplyPayload,
+    );
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "discord",
+        Surface: "discord",
+        ChatType: "channel",
+        InboundEventKind: "room_event",
+        SessionKey: "test:discord:channel:C1",
+      }),
       cfg: emptyConfig,
       dispatcher,
       replyResolver,

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -10,6 +10,7 @@ import {
   resolveSessionAgentId,
 } from "../../agents/agent-scope.js";
 import { selectAgentHarness } from "../../agents/harness/selection.js";
+import { sanitizeUserFacingText } from "../../agents/pi-embedded-helpers/sanitize-user-facing-text.js";
 import {
   buildModelAliasIndex,
   resolveDefaultModelForAgent,
@@ -1155,6 +1156,15 @@ export async function dispatchReplyFromConfig(
     return await normalizeReplyMediaPayloadPaths(payload);
   };
 
+  const sanitizeVisibleBlockPayload = (payload: ReplyPayload): ReplyPayload | null => {
+    if (!payload.text) {
+      return payload;
+    }
+    const text = sanitizeUserFacingText(payload.text, { errorContext: Boolean(payload.isError) });
+    const nextPayload = { ...payload, text: text.trim() ? text : undefined };
+    return hasOutboundReplyContent(nextPayload, { trimText: true }) ? nextPayload : null;
+  };
+
   const routeReplyToOriginating = async (
     payload: ReplyPayload,
     options?: { abortSignal?: AbortSignal; mirror?: boolean },
@@ -2246,30 +2256,34 @@ export async function dispatchReplyFromConfig(
                 if (payload.isReasoning === true) {
                   return;
                 }
+                const sanitizedPayload = sanitizeVisibleBlockPayload(payload);
+                if (!sanitizedPayload) {
+                  return;
+                }
                 // Accumulate block text for TTS generation after streaming.
                 // Exclude status notices — they are informational UI signals
                 // and must not be synthesised into the spoken reply.
-                const isStatusNotice = isReplyPayloadStatusNotice(payload);
-                if (payload.text && !isStatusNotice) {
+                const isStatusNotice = isReplyPayloadStatusNotice(sanitizedPayload);
+                if (sanitizedPayload.text && !isStatusNotice) {
                   const joinsBufferedTtsDirective =
                     cleanBlockTtsDirectiveText?.hasBufferedDirectiveText() === true;
                   if (accumulatedBlockText.length > 0) {
                     accumulatedBlockText += "\n";
                   }
-                  accumulatedBlockText += payload.text;
+                  accumulatedBlockText += sanitizedPayload.text;
                   if (accumulatedBlockTtsText.length > 0 && !joinsBufferedTtsDirective) {
                     accumulatedBlockTtsText += "\n";
                   }
-                  accumulatedBlockTtsText += payload.text;
+                  accumulatedBlockTtsText += sanitizedPayload.text;
                   blockCount++;
                 }
                 const visiblePayload =
-                  payload.text && cleanBlockTtsDirectiveText && !isStatusNotice
+                  sanitizedPayload.text && cleanBlockTtsDirectiveText && !isStatusNotice
                     ? (() => {
-                        const text = cleanBlockTtsDirectiveText.push(payload.text);
-                        return { ...payload, text: text.trim() ? text : undefined };
+                        const text = cleanBlockTtsDirectiveText.push(sanitizedPayload.text);
+                        return { ...sanitizedPayload, text: text.trim() ? text : undefined };
                       })()
-                    : payload;
+                    : sanitizedPayload;
                 if (!hasOutboundReplyContent(visiblePayload, { trimText: true })) {
                   return;
                 }

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -33,6 +33,7 @@ import {
   touchConversationBindingRecord,
 } from "../../bindings/records.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
+import { isSilentReplyPayloadText } from "../tokens.js";
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { shouldSuppressLocalExecApprovalPrompt } from "../../channels/plugins/exec-approval-local.js";
 import { applyMergePatch } from "../../config/merge-patch.js";
@@ -2381,8 +2382,10 @@ export async function dispatchReplyFromConfig(
     let finalDeliveryFailed = false;
     const shouldDeliverDespiteSourceReplySuppression = (reply: ReplyPayload) =>
       suppressAutomaticSourceDelivery &&
-      ctx.InboundEventKind !== "room_event" &&
+      (ctx.InboundEventKind !== "room_event" || ctx.Provider === "discord") &&
       !sendPolicyDenied &&
+      hasOutboundReplyContent(reply, { trimText: true }) &&
+      !isSilentReplyPayloadText(reply.text) &&
       getReplyPayloadMetadata(reply)?.deliverDespiteSourceReplySuppression === true;
     for (const reply of replies) {
       throwIfDispatchOperationAborted();


### PR DESCRIPTION
## Summary

Fixes #84022 by allowing Discord `room_event` final-visible fallback/failure payloads to be delivered when runtime code explicitly marks them with `deliverDespiteSourceReplySuppression`.

The change keeps the ambient room-event privacy guard intact:

- unmarked `room_event` final payloads still remain private under source-reply suppression;
- `sendPolicy: deny` still suppresses marked fallback delivery;
- empty/whitespace payloads stay private;
- exact `NO_REPLY` / silent-envelope payloads stay private;
- successful message-tool / side-effect sends are still filtered upstream by the existing payload construction/dedupe path.

## Why

`room_event` dispatch currently has an absolute suppression check, so even runtime-marked final fallback/failure notices cannot reach `sendFinalReply`. That means a user-visible final can be lost on Discord room-event/message-tool-only surfaces when the runtime deliberately prepared a visible fallback.

#84328 is only partial/unmerged for this case because it does not cover the room-event dispatch suppressor.

## Real behavior proof

- **Behavior or issue addressed:** Discord `room_event` final-visible fallback/failure payloads that runtime code explicitly marks with `deliverDespiteSourceReplySuppression` should reach final reply dispatch, while ordinary ambient `room_event` content, `sendPolicy: deny`, empty payloads, exact `NO_REPLY`, and silent envelopes stay suppressed.
- **Real environment tested:** Disposable OpenClaw source checkout using this PR branch on Linux with Node 22. The proof exercised the actual `dispatchReplyFromConfig` delivery gate with a fake dispatcher and synthetic Discord `room_event` inputs. No production Gateway, live runtime state, live config, or real Discord channel was used.
- **Exact steps or command run after this patch:**

  ```bash
  corepack pnpm install --offline --ignore-scripts --frozen-lockfile
  corepack pnpm exec vitest run src/auto-reply/reply/dispatch-from-config.test.ts \
    --testNamePattern "marked runtime fallback|marked room-event runtime fallback|marked empty room-event|marked NO_REPLY room-event|ambient room-event" \
    --reporter=dot --pool=forks --maxWorkers=1
  ./node_modules/.bin/vitest run src/auto-reply/reply/dispatch-from-config.test.ts \
    -t "marked room-event|sendPolicy denies delivery|marked empty room-event|marked NO_REPLY room-event|ambient room-event" \
    --reporter=verbose
  ```

- **Evidence after fix:** Copied terminal output from the disposable checkout showed:

  ```text
  Test Files  1 passed (1)
  Tests       5 passed | 109 skipped (114)

  Targeted non-live dispatch-path validation at 9dec5405a5c6ea5fc2f1811692f26e9e2a3f6eeb:
  Test Files 1 passed (1)
  Tests 6 passed | 150 skipped (156)
  ```

- **Observed result after fix:** The patched dispatch path delivered the explicitly marked Discord `room_event` fallback exactly once when `sendPolicy` allowed it, while unmarked ambient `room_event` finals, empty marked fallbacks, exact `NO_REPLY` marked fallbacks, and `sendPolicy: deny` remained private.
- **What was not tested:** No production Gateway, live runtime state, live config, or real Discord transport was exercised. This is targeted non-live source-level proof for the final-delivery gate changed by this PR; maintainer/Mantis live proof would still be stronger if required for real transport evidence.


## Reviewer / AI review map

This PR now intentionally supersedes #86634 so reviewers only need to evaluate one `dispatch-from-config` branch for this overlapping seam.

- **Combined scope:** two narrow final/block delivery guards in the same dispatcher file:
  1. sanitize streamed/block reply previews before queued/progress, TTS, routed, or dispatcher block delivery;
  2. allow explicitly marked Discord `room_event` fallback/failure finals to bypass source-reply suppression when `sendPolicy` allows it.
- **Shared files:** `src/auto-reply/reply/dispatch-from-config.ts` and `src/auto-reply/reply/dispatch-from-config.test.ts` only.
- **Non-overlap within the combined PR:** the sanitizer path normalizes block reply text before callback/delivery use; the Discord `room_event` change is a later final-delivery suppression exception guarded by provider, marker, non-silent content, and `sendPolicy`.
- **Privacy/silence boundaries preserved:** empty sanitized blocks drop; exact `NO_REPLY` and silent envelopes remain suppressed; `sendPolicy: deny` still wins; unmarked ambient `room_event` finals remain private.
- **Why combine:** #86634 and this PR were the only authored open PRs with direct file overlap. Combining them reduces queue pressure and removes one cross-PR conflict without broadening beyond the existing dispatcher seam.
- **What not to review here:** unrelated Discord queue behavior, native subagent completion ownership, session replay repair, or broader auto-reply refactors.

## Combined validation update

After combining #86634 into this branch in a disposable checkout, targeted non-live validation passed:

```text
openclaw-heavy-run --backend auto -- \
  bash -lc "node <pnpm.mjs> install --offline --ignore-scripts --frozen-lockfile && \
  node <pnpm.mjs> exec vitest run src/auto-reply/reply/dispatch-from-config.test.ts \
    -t 'sanitize|marked room-event|marked runtime fallback|sendPolicy denies delivery|ambient room-event|NO_REPLY room-event' \
    --reporter=dot --pool=forks --maxWorkers=1"

Test Files 1 passed (1)
Tests 7 passed | 154 skipped (161)

git diff --check origin/main...HEAD
# rc=0
```

This validation is intentionally source-level and non-production; no live Gateway, runtime state, live config, or real Discord transport was exercised.

## Risk / notes

- Scope is intentionally narrow: `dispatch-from-config` final delivery gating plus focused unit coverage.
- No old thread missing finals are supplemented by this patch.
- No live runtime or production Discord validation was performed.
- CI should still run the full project matrix.

## Related

- Fixes #84022
- Not the same class as #84864 longwork checkpoint or #84708 replay poison.
