### PR TITLE
fix(build): pin synthetic auth runtime dist entry

### DIFF
--- a/src/infra/tsdown-config.test.ts
+++ b/src/infra/tsdown-config.test.ts
@@ -105,6 +105,7 @@ describe("tsdown config", () => {
       "plugins/provider-discovery.runtime",
       "plugins/provider-runtime.runtime",
       "plugins/runtime/index",
+      "plugins/synthetic-auth.runtime",
       "web-fetch/runtime",
       "plugin-sdk/compat",
       "plugin-sdk/index",
@@ -146,6 +147,14 @@ describe("tsdown config", () => {
 
     expect(entrySources(distGraph)["plugins/hook-runner-global"]).toBe(
       "src/plugins/hook-runner-global.ts",
+    );
+  });
+
+  it("keeps synthetic auth refs behind one stable runtime dist entry", () => {
+    const distGraph = requireUnifiedDistGraph();
+
+    expect(entrySources(distGraph)["plugins/synthetic-auth.runtime"]).toBe(
+      "src/plugins/synthetic-auth.runtime.ts",
     );
   });
 

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -239,6 +239,7 @@ function buildCoreDistEntries(): Record<string, string> {
     "server-close.runtime": "src/gateway/server-close.runtime.ts",
     "plugins/hook-runner-global": "src/plugins/hook-runner-global.ts",
     "plugins/memory-state": "src/plugins/memory-state.ts",
+    "plugins/synthetic-auth.runtime": "src/plugins/synthetic-auth.runtime.ts",
     "subagent-registry.runtime": "src/agents/subagent-registry.runtime.ts",
     "task-registry-control.runtime": "src/tasks/task-registry-control.runtime.ts",
     "agents/pi-model-discovery-runtime": "src/agents/pi-model-discovery-runtime.ts",


### PR DESCRIPTION
## Summary
- add `src/plugins/synthetic-auth.runtime.ts` as an explicit stable tsdown dist entry
- cover the entry in `src/infra/tsdown-config.test.ts`
- keep isolated cron/model-discovery package imports from depending on an unstable shared chunk export shape

## Real behavior proof
Behavior addressed: packaged isolated cron/model discovery paths can import synthetic-auth runtime refs without `SyntaxError: The requested module "./synthetic-auth.runtime.js" does not provide an export named "r"`.
Real environment tested: local OpenClaw source checkout on macOS at PR head `8d4952a7cbff40f6166aa9a49e0c6c8e9cb6b6e3`, Node v24.15.0, using freshly emitted production `dist/` files from `pnpm build`.
Exact steps or command run after this patch: ran `pnpm build`, then ran `node --input-type=module` to import `./dist/plugins/synthetic-auth.runtime.js`, `./dist/agents/pi-model-discovery-runtime.js`, `./dist/synthetic-auth.runtime.js`, and an emitted `./dist/model-*.js` chunk. The script asserted the stable plugin runtime exports were present, the root runtime alias export `r` was present, and the model chunk import completed.
Evidence after fix: Copied terminal output from the real emitted-dist smoke command:
```terminal
{
  "node": "v24.15.0",
  "pluginRuntimeFileBytes": 334,
  "rootRuntimeFileBytes": 54,
  "pluginRuntimeExports": [
    "resolveRuntimeExternalAuthProviderRefs",
    "resolveRuntimeSyntheticAuthProviderRefState",
    "resolveRuntimeSyntheticAuthProviderRefs"
  ],
  "rootRuntimeExports": [
    "n",
    "r",
    "t"
  ],
  "piRuntimeImported": true,
  "importedModelChunk": "model-ByxdMfk2.js",
  "importedModelChunkExportCount": 4
}
PASS emitted dist imports resolve synthetic auth runtime exports
```
Observed result after fix: the freshly emitted package files imported successfully, `dist/plugins/synthetic-auth.runtime.js` exposed the named synthetic-auth runtime helpers, the root synthetic-auth runtime exposed the chunk alias export `r`, and the emitted model chunk loaded without the missing-export exception.
What was not tested: a live scheduled cron job against a packaged npm install; the proof covers the production package build output and emitted import path that previously failed.

## Verification
- `node scripts/run-vitest.mjs src/infra/tsdown-config.test.ts src/plugins/synthetic-auth.runtime.test.ts src/agents/pi-embedded-runner/model.test.ts`
- `pnpm exec oxfmt --check --threads=1 tsdown.config.ts src/infra/tsdown-config.test.ts`
- `pnpm build`
- emitted package smoke: imported `./dist/plugins/synthetic-auth.runtime.js`, `./dist/agents/pi-model-discovery-runtime.js`, and the generated `./dist/model-ByxdMfk2.js` chunk
- `git log --format='%h %an <%ae> %s' upstream/main..HEAD`

Fixes #86143

Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>
