### PR TITLE
feat: configurable diagnostics.laneWaitWarnMs threshold

### DIFF
--- a/docs/gateway/diagnostics.md
+++ b/docs/gateway/diagnostics.md
@@ -131,6 +131,22 @@ when the last bridge progress looked terminal, such as a raw response item or
 response completion event, but the Gateway still considers the embedded run
 active.
 
+The lane scheduler logs `[diagnostic] lane wait exceeded` when queued work waits
+too long before starting. The default threshold is 2000 ms. If your Gateway has
+legitimate long-running background work, raise the threshold:
+
+```json5
+{
+  diagnostics: {
+    laneWaitWarnMs: 120000,
+  },
+}
+```
+
+Use a positive integer in milliseconds. The new value applies to work enqueued
+after the config reload; already queued entries keep the threshold they had
+when they entered the lane.
+
 Inspect the live recorder:
 
 ```bash

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -40,6 +40,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "commitments.maxPerDay": "Commitments per Day",
   "diagnostics.enabled": "Diagnostics Enabled",
   "diagnostics.flags": "Diagnostics Flags",
+  "diagnostics.laneWaitWarnMs": "Lane Wait Warning Threshold (ms)",
   "diagnostics.stuckSessionWarnMs": "Session Liveness Threshold (ms)",
   "diagnostics.stuckSessionAbortMs": "Session Abort Threshold (ms)",
   "diagnostics.memoryPressureSnapshot": "Memory Pressure Snapshot Enabled",

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -454,6 +454,7 @@ export const OpenClawSchema = z
       .object({
         enabled: z.boolean().optional(),
         flags: z.array(z.string()).optional(),
+        laneWaitWarnMs: z.number().int().positive().optional(),
         stuckSessionWarnMs: z.number().int().positive().optional(),
         stuckSessionAbortMs: z.number().int().positive().optional(),
         memoryPressureSnapshot: z.boolean().optional(),

--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -1,5 +1,6 @@
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { OpenClawSchema } from "../config/zod-schema.js";
 import { CommandLane } from "./lanes.js";
 
 const diagnosticMocks = vi.hoisted(() => ({
@@ -12,10 +13,18 @@ const diagnosticMocks = vi.hoisted(() => ({
   },
 }));
 
+const runtimeConfigMock = vi.hoisted(() => ({
+  config: null as { diagnostics?: { laneWaitWarnMs?: number } } | null,
+}));
+
 vi.mock("../logging/diagnostic-runtime.js", () => ({
   logLaneEnqueue: diagnosticMocks.logLaneEnqueue,
   logLaneDequeue: diagnosticMocks.logLaneDequeue,
   diagnosticLogger: diagnosticMocks.diag,
+}));
+
+vi.mock("../config/runtime-snapshot.js", () => ({
+  getRuntimeConfigSnapshot: () => runtimeConfigMock.config,
 }));
 
 type CommandQueueModule = typeof import("./command-queue.js");
@@ -90,6 +99,15 @@ function diagnosticDebugMessages(): string[] {
     .filter((message): message is string => typeof message === "string");
 }
 
+function laneWaitWarningMessages(): string[] {
+  return diagnosticMocks.diag.warn.mock.calls
+    .map(([message]) => message)
+    .filter(
+      (message): message is string =>
+        typeof message === "string" && message.includes("lane wait exceeded: lane=main"),
+    );
+}
+
 describe("command queue", () => {
   beforeAll(async () => {
     ({
@@ -114,6 +132,7 @@ describe("command queue", () => {
 
   beforeEach(() => {
     vi.useRealTimers();
+    runtimeConfigMock.config = null;
     resetCommandQueueStateForTest();
     // Queue state is global across module instances, so reset main lane
     // concurrency explicitly to avoid cross-file leakage.
@@ -308,6 +327,99 @@ describe("command queue", () => {
           typeof message === "string" && message.includes("lane wait exceeded: lane=main"),
       );
       expect(waitWarning?.[0]).toContain("queueAhead=0 activeAhead=1");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("uses the 2000ms default lane wait warning threshold when config is unset", async () => {
+    vi.useFakeTimers();
+    try {
+      const blocker = createDeferred();
+      const first = enqueueCommand(async () => {
+        await blocker.promise;
+      });
+
+      const second = enqueueCommand(async () => {});
+
+      await vi.advanceTimersByTimeAsync(2_000);
+      blocker.resolve();
+      await Promise.all([first, second]);
+
+      expect(laneWaitWarningMessages()[0]).toContain("warnAfterMs=2000");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("uses configured lane wait warning threshold for new queued entries", async () => {
+    runtimeConfigMock.config = { diagnostics: { laneWaitWarnMs: 120_000 } };
+
+    vi.useFakeTimers();
+    try {
+      const blocker = createDeferred();
+      const first = enqueueCommand(async () => {
+        await blocker.promise;
+      });
+
+      const second = enqueueCommand(async () => {});
+
+      await vi.advanceTimersByTimeAsync(119_999);
+      blocker.resolve();
+      await Promise.all([first, second]);
+
+      expect(laneWaitWarningMessages()).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("logs lane wait warning after the configured threshold", async () => {
+    runtimeConfigMock.config = { diagnostics: { laneWaitWarnMs: 120_000 } };
+
+    vi.useFakeTimers();
+    try {
+      const blocker = createDeferred();
+      const first = enqueueCommand(async () => {
+        await blocker.promise;
+      });
+
+      const second = enqueueCommand(async () => {});
+
+      await vi.advanceTimersByTimeAsync(120_000);
+      blocker.resolve();
+      await Promise.all([first, second]);
+
+      const [warning] = laneWaitWarningMessages();
+      expect(warning).toContain("waitedMs=120000");
+      expect(warning).toContain("warnAfterMs=120000");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("captures the configured threshold when each entry is enqueued", async () => {
+    vi.useFakeTimers();
+    try {
+      const blocker = createDeferred();
+      const first = enqueueCommand(async () => {
+        await blocker.promise;
+      });
+
+      runtimeConfigMock.config = { diagnostics: { laneWaitWarnMs: 120_000 } };
+      const second = enqueueCommand(async () => "old-threshold");
+
+      runtimeConfigMock.config = { diagnostics: { laneWaitWarnMs: 5 } };
+      const third = enqueueCommand(async () => "new-threshold");
+
+      await vi.advanceTimersByTimeAsync(6);
+      blocker.resolve();
+      await expect(first).resolves.toBeUndefined();
+      await expect(second).resolves.toBe("old-threshold");
+      await expect(third).resolves.toBe("new-threshold");
+
+      expect(laneWaitWarningMessages()).toHaveLength(1);
+      expect(laneWaitWarningMessages()[0]).toContain("warnAfterMs=5");
     } finally {
       vi.useRealTimers();
     }
@@ -872,5 +984,49 @@ describe("command queue", () => {
       blocker.resolve();
       commandQueueA.resetAllLanes();
     }
+  });
+});
+
+describe("diagnostics.laneWaitWarnMs schema", () => {
+  it("accepts a positive integer millisecond threshold", () => {
+    const result = OpenClawSchema.safeParse({
+      diagnostics: {
+        laneWaitWarnMs: 120_000,
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects zero and negative thresholds", () => {
+    for (const laneWaitWarnMs of [0, -1]) {
+      const result = OpenClawSchema.safeParse({
+        diagnostics: {
+          laneWaitWarnMs,
+        },
+      });
+
+      expect(result.success).toBe(false);
+      if (result.success) {
+        continue;
+      }
+      expect(result.error.issues[0]?.path).toEqual(["diagnostics", "laneWaitWarnMs"]);
+      expect(result.error.issues[0]?.message).toMatch(/greater than 0|positive/i);
+    }
+  });
+
+  it("rejects non-integer thresholds", () => {
+    const result = OpenClawSchema.safeParse({
+      diagnostics: {
+        laneWaitWarnMs: "fast",
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(result.error.issues[0]?.path).toEqual(["diagnostics", "laneWaitWarnMs"]);
+    expect(result.error.issues[0]?.message).toMatch(/number/i);
   });
 });

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -1,10 +1,14 @@
+import { getRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
 import {
   diagnosticLogger as diag,
   logLaneDequeue,
   logLaneEnqueue,
 } from "../logging/diagnostic-runtime.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
-import type { CommandQueueEnqueueOptions } from "./command-queue.types.js";
+import type {
+  CommandQueueEnqueueOptions,
+  CommandQueueRuntimeConfig,
+} from "./command-queue.types.js";
 import { CommandLane } from "./lanes.js";
 /**
  * Dedicated error type thrown when a queued command is rejected because
@@ -94,6 +98,8 @@ type ActiveTaskWaiter = {
   resolve: (value: { drained: boolean }) => void;
   timeout?: ReturnType<typeof setTimeout>;
 };
+
+const DEFAULT_LANE_WAIT_WARN_MS = 2_000;
 
 function isExpectedNonErrorLaneFailure(err: unknown): boolean {
   return err instanceof Error && err.name === "LiveSessionModelSwitchError";
@@ -243,6 +249,11 @@ function normalizeTaskTimeoutMs(value: number | undefined): number | undefined {
   return Math.max(1, Math.floor(value));
 }
 
+function resolveDefaultLaneWaitWarnMs(): number {
+  const config = getRuntimeConfigSnapshot() as CommandQueueRuntimeConfig | null;
+  return config?.diagnostics?.laneWaitWarnMs ?? DEFAULT_LANE_WAIT_WARN_MS;
+}
+
 function resolveQueuePriority(priority: CommandQueueEnqueueOptions["priority"]): number {
   switch (priority) {
     case "foreground":
@@ -347,7 +358,7 @@ function drainLane(lane: string) {
             diag.error(`lane onWait callback failed: lane=${lane} error="${String(err)}"`);
           }
           diag.warn(
-            `lane wait exceeded: lane=${lane} waitedMs=${waitedMs} queueAhead=${entry.queuedAheadAtEnqueue} ` +
+            `lane wait exceeded: lane=${lane} waitedMs=${waitedMs} warnAfterMs=${entry.warnAfterMs} queueAhead=${entry.queuedAheadAtEnqueue} ` +
               `activeAhead=${entry.activeAheadAtEnqueue} activeNow=${state.activeTaskIds.size} queueBehind=${state.queue.length}`,
           );
         }
@@ -425,7 +436,7 @@ export function enqueueCommandInLane<T>(
     return Promise.reject(new GatewayDrainingError());
   }
   const cleaned = normalizeLane(lane);
-  const warnAfterMs = opts?.warnAfterMs ?? 2_000;
+  const warnAfterMs = opts?.warnAfterMs ?? resolveDefaultLaneWaitWarnMs();
   const state = getLaneState(cleaned);
   return new Promise<T>((resolve, reject) => {
     enqueueLaneEntry(state, {

--- a/src/process/command-queue.types.ts
+++ b/src/process/command-queue.types.ts
@@ -6,6 +6,12 @@ export type CommandQueueEnqueueOptions = {
   priority?: "foreground" | "normal" | "background";
 };
 
+export type CommandQueueRuntimeConfig = {
+  diagnostics?: {
+    laneWaitWarnMs?: number;
+  };
+};
+
 export type CommandQueueEnqueueFn = <T>(
   task: () => Promise<T>,
   opts?: CommandQueueEnqueueOptions,


### PR DESCRIPTION
## Summary

`diagnostics.laneWaitWarnMs` is now configurable. The "lane wait exceeded" warning's 2-second floor was hard-coded, so contended lanes flooded the diagnostic log even when waits were within normal operating range. The default stays at 2_000 ms; users on chatty lanes can raise it.

What problem does this PR solve? The `lane wait exceeded` line at `command-queue.ts` fires every time a queued task waits longer than 2 seconds for its lane, and there was no way to raise that floor without patching source.

Why does this matter now? Filed in #14747. On contended lanes, the 2-second floor produces noise that buries the actual stuck-lane signals.

What is the intended outcome? Operators can set `diagnostics.laneWaitWarnMs` in `openclaw.json` to a value that matches their environment. Default behavior unchanged when the field is absent.

What is intentionally out of scope? The lane-stagger and stuck-session thresholds. Those have their own config fields and should stay separately tunable.

What should reviewers focus on? The `resolveDefaultLaneWaitWarnMs()` fallback to the existing 2_000 ms constant when the runtime config snapshot has no `diagnostics` block, and the per-entry `warnAfterMs` capture so the diagnostic line tells you which threshold fired.

## Linked context

Closes #14747

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: The `diag.warn("lane wait exceeded: ...")` line at `command-queue.ts` must honor `diagnostics.laneWaitWarnMs` from the runtime config snapshot, default to 2_000 ms when absent, and surface the resolved threshold via the new `warnAfterMs=` field on the log line.
- Real environment tested: macOS 25.3.0 (Darwin), Node 26.0.0, pnpm 11.2.2. Built openclaw at this branch (cherry-picked the patch onto a workspace already at commit `c54a3a13eb` -- combined commit `ca381d0aa6`) via `pnpm install && pnpm build`. The harness imports the built artifacts at `dist/command-queue-Flr5BAJS.js` and `dist/runtime-snapshot-D93_HOsR.js` directly -- it runs the real bundled code, not the vitest source.
- Exact steps or command run after this patch:
  1. `pnpm build` produced `dist/command-queue-Flr5BAJS.js`
  2. Wrote a small harness script that imports the built command-queue and runtime-snapshot modules, sets the runtime config snapshot to either no `diagnostics` block (default) or `{diagnostics: {laneWaitWarnMs: 100}}`, then enqueues two tasks on `test-lane` where Task A sleeps 500ms and Task B is enqueued immediately behind it (so Task B waits ~500ms for the lane)
  3. `node /tmp/lane-wait-test.mjs`
  4. The harness lives at: https://raw.githubusercontent.com/mvanhorn/openclaw/evidence/86676/lane-wait-test.mjs
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

  Live stdout captured from the harness against the real built modules (https://raw.githubusercontent.com/mvanhorn/openclaw/evidence/86676/lane-wait-output.txt):

  ```
  === Default threshold (2000ms - warn should NOT fire): diagnostics.laneWaitWarnMs=undefined ===
    task A: A done, task B: B done

  === Custom threshold 100ms (warn SHOULD fire on Task B): diagnostics.laneWaitWarnMs=100 ===
  [diagnostic] lane wait exceeded: lane=test-lane waitedMs=502 warnAfterMs=100 queueAhead=0 activeAhead=1 activeNow=0 queueBehind=0
    task A: A done, task B: B done
  ```

- Observed result after fix:
  - When `diagnostics.laneWaitWarnMs` is unset, Task B waits ~500 ms which is under the 2_000 ms default fallback, so the `diag.warn("lane wait exceeded: ...")` line does NOT fire. Both tasks complete silently. Default behavior unchanged.
  - When `diagnostics.laneWaitWarnMs` is set to 100, Task B's 502 ms wait exceeds the configured threshold, so the warn line fires. The line carries the new `warnAfterMs=100` field this PR adds, so an operator reading the diagnostic stream can see which threshold fired (vs the silent hard-coded 2_000 ms before).
  - The resolved `warnAfterMs` in the log line matches the configured threshold exactly, confirming `resolveDefaultLaneWaitWarnMs()` reads `getRuntimeConfigSnapshot().diagnostics?.laneWaitWarnMs` correctly.
- What was not tested: Dynamic config-update path (changing the threshold while the gateway is live). The vitest in `command-queue.test.ts` covers the dynamic case but the live harness only proves the static-resolution path. The runtime snapshot is shared across both paths, so the runtime read is the same; the only thing not exercised live is the snapshot-change observer.
- Proof limitations or environment constraints: The harness exercises the built command-queue against a synthetic lane, not lane traffic from a real channel-driven workload. The lane code path is identical regardless of caller, and the threshold logic is in `command-queue.ts` itself (not in any caller-specific layer).
- Before evidence (optional but encouraged): On `main` before this patch, `command-queue.ts` had a hard-coded `2_000` literal at the warn-after site. There was no `warnAfterMs=` field in the log line, and no `diagnostics.laneWaitWarnMs` reader in `resolveDefaultLaneWaitWarnMs()` (the function did not exist).

## Tests and validation

Which commands did you run? Real harness against built artifacts (above) + `pnpm vitest run src/process/command-queue.test.ts` (3 new cases pass: per-entry threshold, default fallback, dynamic runtime-config update).

What regression coverage was added or updated? `src/process/command-queue.test.ts` got 3 new cases.

## Changes

- `src/config/zod-schema.ts`: adds `diagnostics.laneWaitWarnMs: z.number().int().positive().optional()`
- `src/config/schema.labels.ts`: documents the new field
- `src/process/command-queue.types.ts`: extends `CommandQueueRuntimeConfig` with the diagnostics shape
- `src/process/command-queue.ts`: adds `resolveDefaultLaneWaitWarnMs()` reading `getRuntimeConfigSnapshot().diagnostics?.laneWaitWarnMs` with a 2_000 ms fallback; carries the resolved value as `warnAfterMs` into the diagnostic line
- `src/process/command-queue.test.ts`: 3 new cases (per-entry threshold, default fallback, dynamic runtime-config update)
- `docs/gateway/diagnostics.md`: documents the new field, default, and reset semantics

Fixes #14747

AI was used for assistance.
