### PR TITLE
perf: reduce session and auth cache hotpath work

### DIFF
--- a/src/agents/auth-profiles.store.save.test.ts
+++ b/src/agents/auth-profiles.store.save.test.ts
@@ -14,7 +14,9 @@ import {
 } from "./auth-profiles/store.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 
-const listRuntimeExternalAuthProfilesMock = vi.hoisted(() => vi.fn(() => []));
+const listRuntimeExternalAuthProfilesMock = vi.hoisted(() =>
+  vi.fn<(_params: unknown) => unknown[]>(() => []),
+);
 
 vi.mock("./auth-profiles/external-auth.js", () => ({
   listRuntimeExternalAuthProfiles: listRuntimeExternalAuthProfilesMock,

--- a/src/agents/auth-profiles.store.save.test.ts
+++ b/src/agents/auth-profiles.store.save.test.ts
@@ -14,7 +14,10 @@ import {
 } from "./auth-profiles/store.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 
+const listRuntimeExternalAuthProfilesMock = vi.hoisted(() => vi.fn(() => []));
+
 vi.mock("./auth-profiles/external-auth.js", () => ({
+  listRuntimeExternalAuthProfiles: listRuntimeExternalAuthProfilesMock,
   overlayExternalAuthProfiles: <T>(store: T) => store,
   shouldPersistExternalAuthProfile: () => true,
   syncPersistedExternalCliAuthProfiles: <T>(store: T) => store,
@@ -35,6 +38,48 @@ function expectProfileFields(profile: unknown, expected: Record<string, unknown>
 }
 
 describe("saveAuthProfileStore", () => {
+  it("resolves external auth profiles once per save", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-save-once-"));
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "openai-codex:one": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "access-one",
+          refresh: "refresh-one",
+          expires: Date.now() + 60_000,
+        },
+        "openai-codex:two": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "access-two",
+          refresh: "refresh-two",
+          expires: Date.now() + 60_000,
+        },
+        "openai:default": {
+          type: "api_key",
+          provider: "openai",
+          key: "sk-openai",
+        },
+      },
+    };
+
+    try {
+      listRuntimeExternalAuthProfilesMock.mockClear();
+
+      saveAuthProfileStore(store, agentDir);
+
+      expect(listRuntimeExternalAuthProfilesMock).toHaveBeenCalledTimes(1);
+      expect(listRuntimeExternalAuthProfilesMock.mock.calls[0]?.[0]).toMatchObject({
+        store,
+        agentDir,
+      });
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
   it("strips plaintext when keyRef/tokenRef are present", async () => {
     const structuredCloneSpy = vi.spyOn(globalThis, "structuredClone");
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-save-"));

--- a/src/agents/auth-profiles/external-auth.ts
+++ b/src/agents/auth-profiles/external-auth.ts
@@ -89,7 +89,7 @@ function resolveExternalAuthProfileMap(params: {
   return resolved;
 }
 
-function listRuntimeExternalAuthProfiles(params: {
+export function listRuntimeExternalAuthProfiles(params: {
   store: AuthProfileStore;
   agentDir?: string;
   env?: NodeJS.ProcessEnv;

--- a/src/agents/auth-profiles/oauth-external-auth-passthrough.test-support.ts
+++ b/src/agents/auth-profiles/oauth-external-auth-passthrough.test-support.ts
@@ -1,6 +1,7 @@
 import { vi } from "vitest";
 
 vi.mock("./external-auth.js", () => ({
+  listRuntimeExternalAuthProfiles: () => [],
   overlayExternalAuthProfiles: <T>(store: T) => store,
   shouldPersistExternalAuthProfile: () => true,
 }));

--- a/src/agents/auth-profiles/order.test.ts
+++ b/src/agents/auth-profiles/order.test.ts
@@ -23,6 +23,7 @@ vi.mock("../../plugins/manifest-registry.js", () => ({
 }));
 
 vi.mock("./external-auth.js", () => ({
+  listRuntimeExternalAuthProfiles: () => [],
   overlayExternalAuthProfiles: <T>(store: T) => store,
   shouldPersistExternalAuthProfile: () => true,
 }));

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -7,12 +7,16 @@ import { loadJsonFile, saveJsonFile } from "../../infra/json-file.js";
 import { cloneAuthProfileStore } from "./clone.js";
 import { AUTH_STORE_LOCK_OPTIONS, AUTH_STORE_VERSION, log } from "./constants.js";
 import {
+  listRuntimeExternalAuthProfiles,
   overlayExternalAuthProfiles,
-  shouldPersistExternalAuthProfile,
   syncPersistedExternalCliAuthProfiles,
 } from "./external-auth.js";
 import type { ExternalCliAuthDiscovery } from "./external-cli-discovery.js";
-import { isSafeToAdoptMainStoreOAuthIdentity } from "./oauth-shared.js";
+import {
+  isSafeToAdoptMainStoreOAuthIdentity,
+  shouldPersistRuntimeExternalOAuthProfile,
+  type RuntimeExternalOAuthProfile,
+} from "./oauth-shared.js";
 import {
   ensureAuthStoreFile,
   resolveAuthStatePath,
@@ -364,6 +368,7 @@ function shouldKeepProfileInLocalStore(params: {
   credential: AuthProfileStore["profiles"][string];
   agentDir?: string;
   options?: SaveAuthProfileStoreOptions;
+  externalProfiles: () => RuntimeExternalOAuthProfile[];
 }): boolean {
   if (params.credential.type !== "oauth") {
     return true;
@@ -380,11 +385,10 @@ function shouldKeepProfileInLocalStore(params: {
   if (params.options?.filterExternalAuthProfiles === false) {
     return true;
   }
-  return shouldPersistExternalAuthProfile({
-    store: params.store,
+  return shouldPersistRuntimeExternalOAuthProfile({
     profileId: params.profileId,
     credential: params.credential,
-    agentDir: params.agentDir,
+    profiles: params.externalProfiles(),
   });
 }
 
@@ -394,6 +398,12 @@ function buildLocalAuthProfileStoreForSave(params: {
   options?: SaveAuthProfileStoreOptions;
 }): AuthProfileStore {
   const localStore = cloneAuthProfileStore(params.store);
+  let externalProfiles: RuntimeExternalOAuthProfile[] | undefined;
+  const getExternalProfiles = (): RuntimeExternalOAuthProfile[] =>
+    (externalProfiles ??= listRuntimeExternalAuthProfiles({
+      store: params.store,
+      agentDir: params.agentDir,
+    }));
   localStore.profiles = Object.fromEntries(
     Object.entries(localStore.profiles).filter(([profileId, credential]) =>
       shouldKeepProfileInLocalStore({
@@ -402,6 +412,7 @@ function buildLocalAuthProfileStoreForSave(params: {
         credential,
         agentDir: params.agentDir,
         options: params.options,
+        externalProfiles: getExternalProfiles,
       }),
     ),
   );

--- a/src/agents/pi-auth-json.test.ts
+++ b/src/agents/pi-auth-json.test.ts
@@ -6,6 +6,7 @@ import { saveAuthProfileStore } from "./auth-profiles/store.js";
 import { ensurePiAuthJsonFromAuthProfiles } from "./pi-auth-json.js";
 
 vi.mock("./auth-profiles/external-auth.js", () => ({
+  listRuntimeExternalAuthProfiles: () => [],
   overlayExternalAuthProfiles: <T>(store: T) => store,
   shouldPersistExternalAuthProfile: () => true,
   syncPersistedExternalCliAuthProfiles: <T>(store: T) => store,

--- a/src/config/sessions.cache.test.ts
+++ b/src/config/sessions.cache.test.ts
@@ -5,6 +5,7 @@ import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import {
   getSerializedSessionStore,
   getSerializedSessionStoreCacheStatsForTest,
+  getSessionStoreSnapshotCacheStatsForTest,
   getSessionStoreStringInternStatsForTest,
   readSessionStoreCache,
   setSerializedSessionStore,
@@ -552,6 +553,35 @@ describe("Session Store Cache", () => {
     expect(after).not.toBe(before);
     expect(before["session:1"].displayName).toBe("Test Session 1");
     expect(after["session:1"].displayName).toBe("Updated Session");
+  });
+
+  it("builds immutable session snapshots lazily after writes", async () => {
+    await saveSessionStore(storePath, createSingleSessionStore());
+
+    expect(getSessionStoreSnapshotCacheStatsForTest().entries).toBe(0);
+
+    const first = readSessionStoreSnapshot(storePath);
+    const statsAfterRead = getSessionStoreSnapshotCacheStatsForTest();
+    const second = readSessionStoreSnapshot(storePath);
+
+    expect(first).toBe(second);
+    expect(Object.isFrozen(first)).toBe(true);
+    expect(statsAfterRead.entries).toBe(1);
+
+    await updateSessionStore(
+      storePath,
+      (store) => {
+        store["session:1"] = {
+          ...store["session:1"],
+          displayName: "Updated lazily",
+          updatedAt: Date.now() + 1,
+        };
+      },
+      { skipMaintenance: true },
+    );
+
+    expect(getSessionStoreSnapshotCacheStatsForTest().entries).toBe(0);
+    expect(readSessionStoreSnapshot(storePath)["session:1"].displayName).toBe("Updated lazily");
   });
 
   it("should refresh cache when store file changes on disk", async () => {

--- a/src/config/sessions/store-cache.ts
+++ b/src/config/sessions/store-cache.ts
@@ -156,6 +156,14 @@ export function getSerializedSessionStoreCacheStatsForTest(): {
   };
 }
 
+export function getSessionStoreSnapshotCacheStatsForTest(): {
+  entries: number;
+} {
+  return {
+    entries: SESSION_STORE_SNAPSHOT_CACHE.size(),
+  };
+}
+
 function deepFreeze<T>(value: T, seen = new WeakSet<object>()): DeepReadonly<T> {
   if (!value || typeof value !== "object") {
     return value as DeepReadonly<T>;

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -26,7 +26,6 @@ import {
   setSerializedSessionStore,
   takeMutableSessionStoreCache,
   writeSessionStoreCache,
-  writeSessionStoreSnapshotCache,
 } from "./store-cache.js";
 import { normalizeStoreSessionKey, resolveSessionStoreEntry } from "./store-entry.js";
 import {
@@ -214,13 +213,7 @@ function updateSessionStoreWriteCaches(params: {
     sizeBytes: fileStat?.sizeBytes,
     serialized: params.serialized,
   });
-  writeSessionStoreSnapshotCache({
-    storePath: params.storePath,
-    store: params.store,
-    mtimeMs: fileStat?.mtimeMs,
-    sizeBytes: fileStat?.sizeBytes,
-    serialized: params.serialized,
-  });
+  dropSessionStoreSnapshotCache(params.storePath);
 }
 
 function loadMutableSessionStoreForWriter(storePath: string): Record<string, SessionEntry> {


### PR DESCRIPTION
## Summary

- Reduces gateway CPU work seen in the fresh gateway CPU profile by moving immutable session-store snapshot cloning/freezing off the write path.
- Keeps mutable session-store writes hot while rebuilding immutable snapshots lazily on the next snapshot read.
- Reduces auth-profile save hotpath work by resolving runtime external auth profiles once per save instead of once for every OAuth profile.
- Adds focused regression coverage for lazy session snapshots and single external-auth resolution per save.

## Linked context

Maintainer-requested performance follow-up from fresh gateway CPU profile review.

Related #86659
Related #86668

## Real behavior proof

Behavior addressed: Gateway CPU hotpath work during session-store writes and auth-profile saves.
Real environment tested: Local OpenClaw source checkout on macOS, Node/Vitest repo wrappers.
Exact steps or command run after this patch: `pnpm exec oxfmt --check src/config/sessions/store-cache.ts src/config/sessions/store.ts src/config/sessions/store-load.ts src/config/sessions.cache.test.ts src/agents/auth-profiles/external-auth.ts src/agents/auth-profiles/store.ts src/agents/auth-profiles.store.save.test.ts src/agents/pi-auth-json.test.ts src/agents/auth-profiles/order.test.ts src/agents/auth-profiles/oauth-external-auth-passthrough.test-support.ts`; `pnpm tsgo:core`; `node scripts/run-vitest.mjs src/config/sessions.cache.test.ts src/agents/auth-profiles.store.save.test.ts src/agents/auth-profiles/external-oauth.test.ts`; `pnpm check:test-types`; `.agents/skills/autoreview/scripts/autoreview --mode local`.
Evidence after fix: Focused Vitest reported 5 files / 67 tests passed after rebasing on latest `origin/main`; `pnpm tsgo:core` passed; `pnpm check:test-types` passed; oxfmt passed; autoreview reported no accepted/actionable findings.
Observed result after fix: Session snapshot cache is empty immediately after writes, then rebuilds a frozen snapshot lazily and reuses it across reads; auth-profile save resolves external auth profiles once for a store with multiple OAuth profiles.
What was not tested: A live gateway repro on this exact commit, because the available fresh CPU profile was captured from sibling checkout `3a4f2b17fc`; the patch targets the same profiled functions in source.
Proof limitations or environment constraints: CPU profile comparison is inferential for this commit; validation is focused unit/type/format/review proof.
Before evidence: Fresh profile `openclaw-gateway-82844-2026-05-25T23-09-36-684Z.cpuprofile` showed `saveSessionStoreUnlocked` at ~15.4s inclusive, `updateSessionStoreWriteCaches` at ~11.8s inclusive, eager `writeSessionStoreSnapshotCache` / `cloneSessionStoreSnapshot` around ~5.6s inclusive, plus `saveAuthProfileStore` resolving external auth profiles through plugin runtime.

## Tests and validation

- `pnpm exec oxfmt --check src/config/sessions/store-cache.ts src/config/sessions/store.ts src/config/sessions/store-load.ts src/config/sessions.cache.test.ts src/agents/auth-profiles/external-auth.ts src/agents/auth-profiles/store.ts src/agents/auth-profiles.store.save.test.ts src/agents/pi-auth-json.test.ts src/agents/auth-profiles/order.test.ts src/agents/auth-profiles/oauth-external-auth-passthrough.test-support.ts`
- `pnpm tsgo:core`
- `node scripts/run-vitest.mjs src/config/sessions.cache.test.ts src/agents/auth-profiles.store.save.test.ts src/agents/auth-profiles/external-oauth.test.ts`
- `pnpm check:test-types`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Regression coverage added:
- `src/config/sessions.cache.test.ts` verifies immutable session snapshots are built lazily after writes.
- `src/agents/auth-profiles.store.save.test.ts` verifies external auth profiles are resolved once per save.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)
No.

Did config, environment, or migration behavior change? (`Yes/No`)
No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)
No user-visible auth contract change; auth-profile save filtering now reuses one external-auth resolution for the same save.

What is the highest-risk area?
Session/auth cache invalidation correctness.

How is that risk mitigated?
Writes still invalidate immutable snapshots; snapshot reads still clone/freeze before publishing; auth filtering still uses the same persistence predicate with the same resolved profiles.

## Current review state

What is the next action?
Merge after required checks are green.

What is still waiting on author, maintainer, CI, or external proof?
Final CI rerun after rebase.

Which bot or reviewer comments were addressed?
None yet; local autoreview is clean.


