### PR TITLE
Clarify secrets runtime plugin source test hook

### DIFF
--- a/src/secrets/runtime.ts
+++ b/src/secrets/runtime.ts
@@ -94,7 +94,7 @@ export async function prepareSecretsRuntimeSnapshot(params: {
   agentDirs?: string[];
   includeAuthStoreRefs?: boolean;
   loadAuthStore?: (agentDir?: string) => AuthProfileStore;
-  /** Test override for discovered loadable plugins and their origins. */
+  // Test hook for discovered loadable plugin source metadata.
   loadablePluginOrigins?: ReadonlyMap<string, PluginOrigin>;
 }): Promise<PreparedSecretsRuntimeSnapshot> {
   const runtimeEnv = mergeSecretsRuntimeEnv(params.env);


### PR DESCRIPTION
## Summary

Clarifies a secrets runtime test-hook comment to avoid implying runtime origin allowlist behavior.

## Scope

Comment-only advisory cleanup in `src/secrets/runtime.ts`.

No runtime behavior, secret resolution behavior, auth store loading, plugin metadata loading, gateway request handling, or config defaults changed.

## Validation

SafeOps target: reduce the advisory wording hit for `src/secrets/runtime.ts`.

Recommended local check:

```bash
make audit-openclaw
jq -r '
  .findings[]
  | select(.file=="src/secrets/runtime.ts")
  | [.id, .file, (.evidence.line // "n/a"), (.evidence.excerpt // "")]
  | @tsv
' reports/v3/openclaw-audit/openclaw-audit.json
```