### PR TITLE
fix(diagnostics): expose missing telemetry signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ Docs: https://docs.openclaw.ai
 - Checks: keep intentional Knip unused-file findings optional so full CI and sparse proof workspaces stay aligned.
 - Docker: restore writable `~/.config` in runtime images. Fixes #85968. Thanks @hkoessler and @Bartok9.
 - Plugin SDK: keep legacy root diagnostic subscriptions connected when built plugin SDK aliases resolve diagnostic helpers through a separate module graph.
+- Diagnostics: export alertable OTel and Prometheus signals for blocked tools, model failover, stale sessions, liveness warnings, oversized payloads, and webhook ingress while fixing shared OTLP endpoints with query strings.
 - Tests: normalize macOS canonical temp paths in exec allowlists, fs-safe trash assertions, installed plugin matching, Telegram topic-name stores, and built ACPX MCP server expectations so native macOS proof runners cover the intended behavior.
 - Codex/app-server: preserve message-tool-only source reply delivery mode on active runs so sub-agent completion wakeups can steer the active Codex turn instead of being rejected. (#86287) Thanks @ferminquant.
 - Tests: sample the Windows kitchen-sink RPC gateway directly and serialize RSS probes so native runs keep the memory guard active.

--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -70,14 +70,15 @@ openclaw plugins enable diagnostics-otel
 
 ## Signals exported
 
-| Signal      | What goes in it                                                                                                                                                                      |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Metrics** | Counters and histograms for token usage, cost, run duration, skill usage, message flow, Talk events, queue lanes, session state/recovery, tool execution, exec, and memory pressure. |
-| **Traces**  | Spans for model usage, model calls, harness lifecycle, skill usage, tool execution, exec, webhook/message processing, context assembly, and tool loops.                              |
-| **Logs**    | Structured `logging.file` records exported over OTLP when `diagnostics.otel.logs` is enabled; log bodies are withheld unless content capture is explicitly enabled.                  |
+| Signal      | What goes in it                                                                                                                                                                                                    |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Metrics** | Counters and histograms for token usage, cost, run duration, failover, skill usage, message flow, Talk events, queue lanes, session state/recovery, tool execution, oversized payloads, exec, and memory pressure. |
+| **Traces**  | Spans for model usage, model calls, harness lifecycle, skill usage, tool execution, exec, webhook/message processing, context assembly, and tool loops.                                                            |
+| **Logs**    | Structured `logging.file` records exported over OTLP when `diagnostics.otel.logs` is enabled; log bodies are withheld unless content capture is explicitly enabled.                                                |
 
-Toggle `traces`, `metrics`, and `logs` independently. All three default to on
-when `diagnostics.otel.enabled` is true.
+Toggle `traces`, `metrics`, and `logs` independently. Traces and metrics
+default to on when `diagnostics.otel.enabled` is true. Logs default to off and
+are exported only when `diagnostics.otel.logs` is explicitly `true`.
 
 ## Configuration reference
 
@@ -189,6 +190,7 @@ message bodies are also approved for export.
 - `openclaw.model_call.request_bytes` (histogram, UTF-8 byte size of the final model request payload; no raw payload content)
 - `openclaw.model_call.response_bytes` (histogram, UTF-8 byte size of streamed model response events; no raw response content)
 - `openclaw.model_call.time_to_first_byte_ms` (histogram, elapsed time before the first streamed response event)
+- `openclaw.model.failover` (counter, attrs: `openclaw.provider`, `openclaw.model`, `openclaw.failover.to_provider`, `openclaw.failover.to_model`, `openclaw.failover.reason`, `openclaw.failover.suspended`, `openclaw.lane`)
 - `openclaw.skill.used` (counter, attrs: `openclaw.skill.name`, `openclaw.skill.source`, `openclaw.skill.activation`, optional `openclaw.agent`, optional `openclaw.toolName`)
 
 ### Message flow
@@ -260,9 +262,22 @@ unchanged, so dashboards should alert on sustained increases rather than every
 heartbeat tick. For the config knob and defaults, see
 [Configuration reference](/gateway/configuration-reference#diagnostics).
 
+Liveness warnings also emit:
+
+- `openclaw.liveness.warning` (counter, attrs: `openclaw.liveness.reason`)
+- `openclaw.liveness.event_loop_delay_p99_ms` (histogram, attrs: `openclaw.liveness.reason`)
+- `openclaw.liveness.event_loop_delay_max_ms` (histogram, attrs: `openclaw.liveness.reason`)
+- `openclaw.liveness.event_loop_utilization` (histogram, attrs: `openclaw.liveness.reason`)
+- `openclaw.liveness.cpu_core_ratio` (histogram, attrs: `openclaw.liveness.reason`)
+
 ### Harness lifecycle
 
 - `openclaw.harness.duration_ms` (histogram, attrs: `openclaw.harness.id`, `openclaw.harness.plugin`, `openclaw.outcome`, `openclaw.harness.phase` on errors)
+
+### Tool execution
+
+- `openclaw.tool.execution.duration_ms` (histogram, attrs: `gen_ai.tool.name`, `openclaw.toolName`, `openclaw.tool.source`, `openclaw.tool.owner`, `openclaw.tool.params.kind`, plus `openclaw.errorCategory` on errors)
+- `openclaw.tool.execution.blocked` (counter, attrs: `gen_ai.tool.name`, `openclaw.toolName`, `openclaw.tool.source`, `openclaw.tool.owner`, `openclaw.tool.params.kind`, `openclaw.deniedReason`)
 
 ### Exec
 
@@ -270,6 +285,8 @@ heartbeat tick. For the config knob and defaults, see
 
 ### Diagnostics internals (memory and tool loop)
 
+- `openclaw.payload.large` (counter, attrs: `openclaw.payload.surface`, `openclaw.payload.action`, `openclaw.channel`, `openclaw.plugin`, `openclaw.reason`)
+- `openclaw.payload.large_bytes` (histogram, attrs: same as `openclaw.payload.large`)
 - `openclaw.memory.heap_used_bytes` (histogram, attrs: `openclaw.memory.kind`)
 - `openclaw.memory.rss_bytes` (histogram)
 - `openclaw.memory.pressure` (counter, attrs: `openclaw.memory.level`)

--- a/docs/gateway/prometheus.md
+++ b/docs/gateway/prometheus.md
@@ -8,7 +8,7 @@ read_when:
   - You want metrics without running an OpenTelemetry collector
 ---
 
-OpenClaw can expose diagnostics metrics through the official `diagnostics-prometheus` plugin. It listens to trusted internal diagnostics and renders a Prometheus text endpoint at:
+OpenClaw can expose diagnostics metrics through the official `diagnostics-prometheus` plugin. It listens to trusted diagnostics plus core-emitted gateway stability events, then renders a Prometheus text endpoint at:
 
 ```text
 GET /api/diagnostics/prometheus
@@ -87,44 +87,59 @@ For traces, logs, OTLP push, and OpenTelemetry GenAI semantic attributes, see [O
 
 ## Metrics exported
 
-| Metric                                        | Type      | Labels                                                                                    |
-| --------------------------------------------- | --------- | ----------------------------------------------------------------------------------------- |
-| `openclaw_run_completed_total`                | counter   | `channel`, `model`, `outcome`, `provider`, `trigger`                                      |
-| `openclaw_run_duration_seconds`               | histogram | `channel`, `model`, `outcome`, `provider`, `trigger`                                      |
-| `openclaw_model_call_total`                   | counter   | `api`, `error_category`, `model`, `outcome`, `provider`, `transport`                      |
-| `openclaw_model_call_duration_seconds`        | histogram | `api`, `error_category`, `model`, `outcome`, `provider`, `transport`                      |
-| `openclaw_model_tokens_total`                 | counter   | `agent`, `channel`, `model`, `provider`, `token_type`                                     |
-| `openclaw_gen_ai_client_token_usage`          | histogram | `model`, `provider`, `token_type`                                                         |
-| `openclaw_model_cost_usd_total`               | counter   | `agent`, `channel`, `model`, `provider`                                                   |
-| `openclaw_skill_used_total`                   | counter   | `activation`, `agent`, `skill`, `source`                                                  |
-| `openclaw_tool_execution_total`               | counter   | `error_category`, `outcome`, `params_kind`, `tool`, `tool_owner`, `tool_source`           |
-| `openclaw_tool_execution_duration_seconds`    | histogram | `error_category`, `outcome`, `params_kind`, `tool`, `tool_owner`, `tool_source`           |
-| `openclaw_harness_run_total`                  | counter   | `channel`, `error_category`, `harness`, `model`, `outcome`, `phase`, `plugin`, `provider` |
-| `openclaw_harness_run_duration_seconds`       | histogram | `channel`, `error_category`, `harness`, `model`, `outcome`, `phase`, `plugin`, `provider` |
-| `openclaw_message_received_total`             | counter   | `channel`, `source`                                                                       |
-| `openclaw_message_dispatch_started_total`     | counter   | `channel`, `source`                                                                       |
-| `openclaw_message_dispatch_completed_total`   | counter   | `channel`, `outcome`, `reason`, `source`                                                  |
-| `openclaw_message_dispatch_duration_seconds`  | histogram | `channel`, `outcome`, `reason`, `source`                                                  |
-| `openclaw_message_processed_total`            | counter   | `channel`, `outcome`, `reason`                                                            |
-| `openclaw_message_processed_duration_seconds` | histogram | `channel`, `outcome`, `reason`                                                            |
-| `openclaw_message_delivery_started_total`     | counter   | `channel`, `delivery_kind`                                                                |
-| `openclaw_message_delivery_total`             | counter   | `channel`, `delivery_kind`, `error_category`, `outcome`                                   |
-| `openclaw_message_delivery_duration_seconds`  | histogram | `channel`, `delivery_kind`, `error_category`, `outcome`                                   |
-| `openclaw_talk_event_total`                   | counter   | `brain`, `event_type`, `mode`, `provider`, `transport`                                    |
-| `openclaw_talk_event_duration_seconds`        | histogram | `brain`, `event_type`, `mode`, `provider`, `transport`                                    |
-| `openclaw_talk_audio_bytes`                   | histogram | `brain`, `event_type`, `mode`, `provider`, `transport`                                    |
-| `openclaw_queue_lane_size`                    | gauge     | `lane`                                                                                    |
-| `openclaw_queue_lane_wait_seconds`            | histogram | `lane`                                                                                    |
-| `openclaw_session_state_total`                | counter   | `reason`, `state`                                                                         |
-| `openclaw_session_queue_depth`                | gauge     | `state`                                                                                   |
-| `openclaw_session_turn_created_total`         | counter   | `agent`, `channel`, `trigger`                                                             |
-| `openclaw_session_recovery_total`             | counter   | `action`, `active_work_kind`, `state`, `status`                                           |
-| `openclaw_session_recovery_age_seconds`       | histogram | `action`, `active_work_kind`, `state`, `status`                                           |
-| `openclaw_memory_bytes`                       | gauge     | `kind`                                                                                    |
-| `openclaw_memory_rss_bytes`                   | histogram | none                                                                                      |
-| `openclaw_memory_pressure_total`              | counter   | `level`, `reason`                                                                         |
-| `openclaw_telemetry_exporter_total`           | counter   | `exporter`, `reason`, `signal`, `status`                                                  |
-| `openclaw_prometheus_series_dropped_total`    | counter   | none                                                                                      |
+| Metric                                           | Type      | Labels                                                                                    |
+| ------------------------------------------------ | --------- | ----------------------------------------------------------------------------------------- |
+| `openclaw_run_completed_total`                   | counter   | `channel`, `model`, `outcome`, `provider`, `trigger`                                      |
+| `openclaw_run_duration_seconds`                  | histogram | `channel`, `model`, `outcome`, `provider`, `trigger`                                      |
+| `openclaw_model_call_total`                      | counter   | `api`, `error_category`, `model`, `outcome`, `provider`, `transport`                      |
+| `openclaw_model_call_duration_seconds`           | histogram | `api`, `error_category`, `model`, `outcome`, `provider`, `transport`                      |
+| `openclaw_model_failover_total`                  | counter   | `from_model`, `from_provider`, `lane`, `reason`, `suspended`, `to_model`, `to_provider`   |
+| `openclaw_model_tokens_total`                    | counter   | `agent`, `channel`, `model`, `provider`, `token_type`                                     |
+| `openclaw_gen_ai_client_token_usage`             | histogram | `model`, `provider`, `token_type`                                                         |
+| `openclaw_model_cost_usd_total`                  | counter   | `agent`, `channel`, `model`, `provider`                                                   |
+| `openclaw_skill_used_total`                      | counter   | `activation`, `agent`, `skill`, `source`                                                  |
+| `openclaw_tool_execution_total`                  | counter   | `error_category`, `outcome`, `params_kind`, `tool`, `tool_owner`, `tool_source`           |
+| `openclaw_tool_execution_duration_seconds`       | histogram | `error_category`, `outcome`, `params_kind`, `tool`, `tool_owner`, `tool_source`           |
+| `openclaw_tool_execution_blocked_total`          | counter   | `denied_reason`, `params_kind`, `tool`, `tool_owner`, `tool_source`                       |
+| `openclaw_harness_run_total`                     | counter   | `channel`, `error_category`, `harness`, `model`, `outcome`, `phase`, `plugin`, `provider` |
+| `openclaw_harness_run_duration_seconds`          | histogram | `channel`, `error_category`, `harness`, `model`, `outcome`, `phase`, `plugin`, `provider` |
+| `openclaw_webhook_received_total`                | counter   | `channel`, `webhook`                                                                      |
+| `openclaw_webhook_error_total`                   | counter   | `channel`, `webhook`                                                                      |
+| `openclaw_webhook_duration_seconds`              | histogram | `channel`, `webhook`                                                                      |
+| `openclaw_message_received_total`                | counter   | `channel`, `source`                                                                       |
+| `openclaw_message_dispatch_started_total`        | counter   | `channel`, `source`                                                                       |
+| `openclaw_message_dispatch_completed_total`      | counter   | `channel`, `outcome`, `reason`, `source`                                                  |
+| `openclaw_message_dispatch_duration_seconds`     | histogram | `channel`, `outcome`, `reason`, `source`                                                  |
+| `openclaw_message_processed_total`               | counter   | `channel`, `outcome`, `reason`                                                            |
+| `openclaw_message_processed_duration_seconds`    | histogram | `channel`, `outcome`, `reason`                                                            |
+| `openclaw_message_delivery_started_total`        | counter   | `channel`, `delivery_kind`                                                                |
+| `openclaw_message_delivery_total`                | counter   | `channel`, `delivery_kind`, `error_category`, `outcome`                                   |
+| `openclaw_message_delivery_duration_seconds`     | histogram | `channel`, `delivery_kind`, `error_category`, `outcome`                                   |
+| `openclaw_talk_event_total`                      | counter   | `brain`, `event_type`, `mode`, `provider`, `transport`                                    |
+| `openclaw_talk_event_duration_seconds`           | histogram | `brain`, `event_type`, `mode`, `provider`, `transport`                                    |
+| `openclaw_talk_audio_bytes`                      | histogram | `brain`, `event_type`, `mode`, `provider`, `transport`                                    |
+| `openclaw_queue_lane_size`                       | gauge     | `lane`                                                                                    |
+| `openclaw_queue_lane_wait_seconds`               | histogram | `lane`                                                                                    |
+| `openclaw_session_state_total`                   | counter   | `reason`, `state`                                                                         |
+| `openclaw_session_queue_depth`                   | gauge     | `state`                                                                                   |
+| `openclaw_session_turn_created_total`            | counter   | `agent`, `channel`, `trigger`                                                             |
+| `openclaw_session_stuck_total`                   | counter   | `reason`, `state`                                                                         |
+| `openclaw_session_stuck_age_seconds`             | histogram | `reason`, `state`                                                                         |
+| `openclaw_session_recovery_total`                | counter   | `action`, `active_work_kind`, `state`, `status`                                           |
+| `openclaw_session_recovery_age_seconds`          | histogram | `action`, `active_work_kind`, `state`, `status`                                           |
+| `openclaw_liveness_warning_total`                | counter   | `reason`                                                                                  |
+| `openclaw_liveness_sessions`                     | gauge     | `state`                                                                                   |
+| `openclaw_liveness_event_loop_delay_p99_seconds` | histogram | `reason`                                                                                  |
+| `openclaw_liveness_event_loop_delay_max_seconds` | histogram | `reason`                                                                                  |
+| `openclaw_liveness_event_loop_utilization_ratio` | histogram | `reason`                                                                                  |
+| `openclaw_liveness_cpu_core_ratio`               | histogram | `reason`                                                                                  |
+| `openclaw_payload_large_total`                   | counter   | `action`, `channel`, `plugin`, `reason`, `surface`                                        |
+| `openclaw_payload_large_bytes`                   | histogram | `action`, `channel`, `plugin`, `reason`, `surface`                                        |
+| `openclaw_memory_bytes`                          | gauge     | `kind`                                                                                    |
+| `openclaw_memory_rss_bytes`                      | histogram | none                                                                                      |
+| `openclaw_memory_pressure_total`                 | counter   | `level`, `reason`                                                                         |
+| `openclaw_telemetry_exporter_total`              | counter   | `exporter`, `reason`, `signal`, `status`                                                  |
+| `openclaw_prometheus_series_dropped_total`       | counter   | none                                                                                      |
 
 ## Label policy
 

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -894,6 +894,43 @@ describe("diagnostics-otel service", () => {
     await service.stop?.(ctx);
   });
 
+  test("records oversized payload metrics without raw identifiers", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { metrics: true, traces: false });
+
+    await service.start(ctx);
+    emitTrustedDiagnosticEvent({
+      type: "payload.large",
+      surface: "gateway.frame",
+      action: "rejected",
+      bytes: 2048,
+      limitBytes: 1024,
+      channel: "web",
+      pluginId: "agent:qa:otel-trace-smoke",
+      reason: "body-too-large",
+    });
+    await flushDiagnosticEvents();
+
+    expect(telemetryState.counters.get("openclaw.payload.large")?.add).toHaveBeenCalledWith(1, {
+      "openclaw.payload.action": "rejected",
+      "openclaw.payload.surface": "gateway.frame",
+      "openclaw.channel": "web",
+      "openclaw.plugin": "none",
+      "openclaw.reason": "body-too-large",
+    });
+    expect(
+      telemetryState.histograms.get("openclaw.payload.large_bytes")?.record,
+    ).toHaveBeenCalledWith(2048, {
+      "openclaw.payload.action": "rejected",
+      "openclaw.payload.surface": "gateway.frame",
+      "openclaw.channel": "web",
+      "openclaw.plugin": "none",
+      "openclaw.reason": "body-too-large",
+    });
+
+    await service.stop?.(ctx);
+  });
+
   test("reports log exporter emit failures without exporting raw error text", async () => {
     const events: Array<Parameters<Parameters<typeof onInternalDiagnosticEvent>[0]>[0]> = [];
     const unsubscribe = onInternalDiagnosticEvent((event) => {
@@ -1062,6 +1099,26 @@ describe("diagnostics-otel service", () => {
 
     const options = firstExporterOptions(traceExporterCtor);
     expect(options.url).toBe("https://collector.example.com/v1/traces?timeout=30s");
+    await service.stop?.(ctx);
+  });
+
+  test("inserts signal path before shared endpoint query params", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createTraceOnlyContext("https://collector.example.com/otlp?timeout=30s");
+    await service.start(ctx);
+
+    const options = firstExporterOptions(traceExporterCtor);
+    expect(options.url).toBe("https://collector.example.com/otlp/v1/traces?timeout=30s");
+    await service.stop?.(ctx);
+  });
+
+  test("inserts signal path before shared endpoint fragments", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createTraceOnlyContext("https://collector.example.com/otlp#tenant-a");
+    await service.start(ctx);
+
+    const options = firstExporterOptions(traceExporterCtor);
+    expect(options.url).toBe("https://collector.example.com/otlp/v1/traces#tenant-a");
     await service.stop?.(ctx);
   });
 
@@ -1874,6 +1931,55 @@ describe("diagnostics-otel service", () => {
     expect(Object.hasOwn(failoverOptions?.attributes ?? {}, "openclaw.sessionKey")).toBe(false);
     expect(failoverOptions?.startTime).toBeTypeOf("number");
     expect(firstSpanEndTime("openclaw.model.failover")).toBeTypeOf("number");
+    expect(firstCounterAddCall("openclaw.model.failover")).toStrictEqual([
+      1,
+      {
+        "openclaw.failover.reason": "overloaded",
+        "openclaw.failover.suspended": "true",
+        "openclaw.lane": "main",
+        "openclaw.model": "claude-opus-4-6",
+        "openclaw.provider": "anthropic",
+        "openclaw.failover.to_model": "gpt-5.4",
+        "openclaw.failover.to_provider": "openai",
+      },
+    ]);
+    await service.stop?.(ctx);
+  });
+
+  test("records blocked tool metrics even when traces are disabled", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { metrics: true, traces: false });
+    await service.start(ctx);
+
+    emitTrustedDiagnosticEvent({
+      type: "tool.execution.blocked",
+      runId: "run-should-not-export",
+      toolName: "browser",
+      toolSource: "mcp",
+      toolOwner: "browser-tools",
+      deniedReason: "tools.deny",
+      reason: "matched browser",
+      paramsSummary: { kind: "object" },
+    });
+    await flushDiagnosticEvents();
+
+    expect(firstCounterAddCall("openclaw.tool.execution.blocked")).toStrictEqual([
+      1,
+      {
+        "openclaw.toolName": "browser",
+        "openclaw.tool.source": "mcp",
+        "gen_ai.tool.name": "browser",
+        "openclaw.tool.owner": "browser-tools",
+        "openclaw.tool.params.kind": "object",
+        "openclaw.deniedReason": "tools.deny",
+      },
+    ]);
+    expect(telemetryState.tracer.startSpan).not.toHaveBeenCalledWith(
+      "openclaw.tool.execution",
+      expect.anything(),
+      expect.anything(),
+    );
+
     await service.stop?.(ctx);
   });
 

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -132,6 +132,16 @@ function resolveOtelUrl(endpoint: string | undefined, path: string): string | un
   if (/\/v1\/(?:traces|metrics|logs)$/i.test(endpointWithoutQueryOrFragment)) {
     return endpoint;
   }
+  if (/[?#]/u.test(endpoint)) {
+    try {
+      const url = new URL(endpoint);
+      const basePath = url.pathname.replace(/\/+$/u, "");
+      url.pathname = `${basePath}/${path}`;
+      return url.toString();
+    } catch {
+      // Fall back to the historical concatenation path for non-URL test doubles.
+    }
+  }
   return `${endpoint}/${path}`;
 }
 
@@ -1037,11 +1047,22 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           description: "Elapsed time before the first streamed model response event",
         },
       );
+      const modelFailoverCounter = meter.createCounter("openclaw.model.failover", {
+        unit: "1",
+        description: "Model failovers by source, destination, lane, and reason",
+      });
       const toolExecutionDurationHistogram = meter.createHistogram(
         "openclaw.tool.execution.duration_ms",
         {
           unit: "ms",
           description: "Tool execution duration",
+        },
+      );
+      const toolExecutionBlockedCounter = meter.createCounter(
+        "openclaw.tool.execution.blocked",
+        {
+          unit: "1",
+          description: "Tool executions blocked by policy or sandbox diagnostics",
         },
       );
       const execProcessDurationHistogram = meter.createHistogram("openclaw.exec.duration_ms", {
@@ -1082,6 +1103,14 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           description: "Async diagnostic queue drops by dropped event class",
         },
       );
+      const payloadLargeCounter = meter.createCounter("openclaw.payload.large", {
+        unit: "1",
+        description: "Oversized payload diagnostics by surface and action",
+      });
+      const payloadLargeBytesHistogram = meter.createHistogram("openclaw.payload.large_bytes", {
+        unit: "By",
+        description: "Oversized payload byte sizes by surface and action",
+      });
       const livenessWarningCounter = meter.createCounter("openclaw.liveness.warning", {
         unit: "1",
         description: "Diagnostic liveness warning events",
@@ -2069,6 +2098,17 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         evt: ModelFailoverDiagnosticEvent,
         metadata: DiagnosticEventMetadata,
       ) => {
+        const metricAttrs: Record<string, string> = {
+          "openclaw.failover.reason": lowCardinalityAttr(evt.reason, "unknown"),
+          "openclaw.failover.suspended":
+            evt.suspended === undefined ? "unknown" : String(evt.suspended),
+          "openclaw.lane": lowCardinalityQueueLaneAttr(evt.lane, "unknown"),
+          "openclaw.model": lowCardinalityAttr(evt.fromModel),
+          "openclaw.provider": lowCardinalityAttr(evt.fromProvider),
+          "openclaw.failover.to_model": lowCardinalityAttr(evt.toModel),
+          "openclaw.failover.to_provider": lowCardinalityAttr(evt.toProvider),
+        };
+        modelFailoverCounter.add(1, metricAttrs);
         if (!tracesEnabled) {
           return;
         }
@@ -2403,6 +2443,10 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         evt: Extract<DiagnosticEventPayload, { type: "tool.execution.blocked" }>,
         metadata: DiagnosticEventMetadata,
       ) => {
+        toolExecutionBlockedCounter.add(1, {
+          ...toolExecutionBaseAttrs(evt),
+          "openclaw.deniedReason": lowCardinalityAttr(evt.deniedReason, "other"),
+        });
         if (!tracesEnabled) {
           return;
         }
@@ -2418,6 +2462,23 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         });
         setSpanAttrs(span, spanAttrs);
         span.end(evt.ts);
+      };
+
+      const recordPayloadLarge = (
+        evt: Extract<DiagnosticEventPayload, { type: "payload.large" }>,
+      ) => {
+        const attrs = {
+          "openclaw.payload.action": evt.action,
+          "openclaw.payload.surface": lowCardinalityAttr(evt.surface, "unknown"),
+          "openclaw.channel": lowCardinalityAttr(evt.channel, "none"),
+          "openclaw.plugin": lowCardinalityAttr(evt.pluginId, "none"),
+          "openclaw.reason": lowCardinalityAttr(evt.reason, "none"),
+        };
+        payloadLargeCounter.add(1, attrs);
+        const bytes = positiveFiniteNumber(evt.bytes);
+        if (bytes !== undefined) {
+          payloadLargeBytesHistogram.record(bytes, attrs);
+        }
       };
 
       const recordExecProcessCompleted = (
@@ -2727,6 +2788,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
               recordTelemetryExporter(evt, metadata);
               return;
             case "payload.large":
+              recordPayloadLarge(evt);
               return;
             case "model.failover":
               recordModelFailover(evt, metadata);

--- a/extensions/diagnostics-prometheus/api.ts
+++ b/extensions/diagnostics-prometheus/api.ts
@@ -2,6 +2,7 @@ export type {
   DiagnosticEventMetadata,
   DiagnosticEventPayload,
 } from "openclaw/plugin-sdk/diagnostic-runtime";
+export { isInternalDiagnosticEventMetadata } from "openclaw/plugin-sdk/diagnostic-runtime";
 export {
   emptyPluginConfigSchema,
   type OpenClawPluginApi,

--- a/extensions/diagnostics-prometheus/src/service.test.ts
+++ b/extensions/diagnostics-prometheus/src/service.test.ts
@@ -94,7 +94,38 @@ describe("diagnostics-prometheus service", () => {
     expect(testApi.renderPrometheusMetrics(store)).toBe("");
   });
 
-  it("records trusted async diagnostic queue drop summaries", () => {
+  it("drops untrusted plugin-emitted diagnostic events that spoof gateway stability signals", () => {
+    const store = testApi.createPrometheusMetricStore();
+
+    for (const event of [
+      {
+        ...baseEvent(),
+        type: "webhook.received",
+        channel: "telegram",
+        updateType: "message",
+      },
+      {
+        ...baseEvent(),
+        type: "payload.large",
+        surface: "gateway.frame",
+        action: "rejected",
+        bytes: 2048,
+      },
+      {
+        ...baseEvent(),
+        type: "session.stuck",
+        state: "processing",
+        ageMs: 12_000,
+        classification: "stale_session_state",
+      },
+    ] satisfies DiagnosticEventPayload[]) {
+      testApi.recordDiagnosticEvent(store, event, untrusted);
+    }
+
+    expect(testApi.renderPrometheusMetrics(store)).toBe("");
+  });
+
+  it("records sanitized async diagnostic queue drop summaries from core diagnostics", () => {
     const store = testApi.createPrometheusMetricStore();
 
     testApi.recordDiagnosticEvent(
@@ -147,6 +178,166 @@ describe("diagnostics-prometheus service", () => {
       'openclaw_tool_execution_total{error_category="other",outcome="error",params_kind="unknown",tool="tool",tool_owner="none",tool_source="core"} 1',
     );
     expect(rendered).not.toContain("Bearer");
+    expect(rendered).not.toContain("sk-secret");
+  });
+
+  it("records operator-critical diagnostic signals missing from generic run metrics", () => {
+    const store = testApi.createPrometheusMetricStore();
+
+    for (const event of [
+      {
+        ...baseEvent(),
+        type: "tool.execution.blocked",
+        toolName: "browser",
+        toolSource: "mcp",
+        toolOwner: "browser-tools",
+        deniedReason: "tools.deny",
+        reason: "matched browser",
+        paramsSummary: { kind: "object" },
+      },
+      {
+        ...baseEvent(),
+        type: "model.failover",
+        lane: "session:Agent:qa:otel-trace-smoke",
+        fromProvider: "anthropic",
+        fromModel: "claude-opus-4-6",
+        toProvider: "openai",
+        toModel: "gpt-5.4",
+        reason: "overloaded",
+        suspended: true,
+      },
+    ] satisfies DiagnosticEventPayload[]) {
+      testApi.recordDiagnosticEvent(store, event, trusted);
+    }
+    for (const event of [
+      {
+        ...baseEvent(),
+        type: "session.stuck",
+        sessionId: "session-should-not-export",
+        sessionKey: "key-should-not-export",
+        state: "processing",
+        ageMs: 12_000,
+        classification: "stale_session_state",
+        reason: "startup-sweep",
+      },
+      {
+        ...baseEvent(),
+        type: "payload.large",
+        surface: "gateway.frame",
+        action: "rejected",
+        bytes: 2048,
+        limitBytes: 1024,
+        channel: "web",
+        pluginId: "agent:qa:otel-trace-smoke",
+        reason: "body-too-large",
+      },
+    ] satisfies DiagnosticEventPayload[]) {
+      testApi.recordDiagnosticEvent(store, event, trusted);
+    }
+
+    const rendered = testApi.renderPrometheusMetrics(store);
+
+    expect(rendered).toContain(
+      'openclaw_tool_execution_blocked_total{denied_reason="tools.deny",params_kind="object",tool="browser",tool_owner="browser-tools",tool_source="mcp"} 1',
+    );
+    expect(rendered).toContain(
+      'openclaw_model_failover_total{from_model="claude-opus-4-6",from_provider="anthropic",lane="session",reason="overloaded",suspended="true",to_model="gpt-5.4",to_provider="openai"} 1',
+    );
+    expect(rendered).toContain(
+      'openclaw_session_stuck_total{reason="startup-sweep",state="processing"} 1',
+    );
+    expect(rendered).toContain(
+      'openclaw_session_stuck_age_seconds_sum{reason="startup-sweep",state="processing"} 12',
+    );
+    expect(rendered).toContain(
+      'openclaw_payload_large_total{action="rejected",channel="web",plugin="none",reason="body-too-large",surface="gateway.frame"} 1',
+    );
+    expect(rendered).toContain(
+      'openclaw_payload_large_bytes_sum{action="rejected",channel="web",plugin="none",reason="body-too-large",surface="gateway.frame"} 2048',
+    );
+    expect(rendered).not.toContain("session-should-not-export");
+    expect(rendered).not.toContain("key-should-not-export");
+    expect(rendered).not.toContain("Agent:qa:otel-trace-smoke");
+  });
+
+  it("records webhook ingress and liveness warning metrics", () => {
+    const store = testApi.createPrometheusMetricStore();
+
+    testApi.recordDiagnosticEvent(
+      store,
+      {
+        ...baseEvent(),
+        type: "webhook.received",
+        channel: "telegram",
+        updateType: "message",
+        chatId: "chat-should-not-export",
+      },
+      trusted,
+    );
+    testApi.recordDiagnosticEvent(
+      store,
+      {
+        ...baseEvent(),
+        type: "webhook.processed",
+        channel: "telegram",
+        updateType: "message",
+        chatId: "chat-should-not-export",
+        durationMs: 250,
+      },
+      trusted,
+    );
+    testApi.recordDiagnosticEvent(
+      store,
+      {
+        ...baseEvent(),
+        type: "webhook.error",
+        channel: "telegram",
+        updateType: "message",
+        chatId: "chat-should-not-export",
+        error: "Bearer sk-secret",
+      },
+      trusted,
+    );
+    testApi.recordDiagnosticEvent(
+      store,
+      {
+        ...baseEvent(),
+        type: "diagnostic.liveness.warning",
+        reasons: ["event_loop_delay", "cpu"],
+        intervalMs: 30_000,
+        eventLoopDelayP99Ms: 250,
+        eventLoopDelayMaxMs: 900,
+        eventLoopUtilization: 0.95,
+        cpuCoreRatio: 1.4,
+        active: 2,
+        waiting: 1,
+        queued: 4,
+      },
+      trusted,
+    );
+
+    const rendered = testApi.renderPrometheusMetrics(store);
+
+    expect(rendered).toContain(
+      'openclaw_webhook_received_total{channel="telegram",webhook="message"} 1',
+    );
+    expect(rendered).toContain(
+      'openclaw_webhook_error_total{channel="telegram",webhook="message"} 1',
+    );
+    expect(rendered).toContain(
+      'openclaw_webhook_duration_seconds_sum{channel="telegram",webhook="message"} 0.25',
+    );
+    expect(rendered).toContain(
+      'openclaw_liveness_warning_total{reason="event_loop_delay:cpu"} 1',
+    );
+    expect(rendered).toContain('openclaw_liveness_sessions{state="active"} 2');
+    expect(rendered).toContain(
+      'openclaw_liveness_event_loop_delay_p99_seconds_sum{reason="event_loop_delay:cpu"} 0.25',
+    );
+    expect(rendered).toContain(
+      'openclaw_liveness_cpu_core_ratio_sum{reason="event_loop_delay:cpu"} 1.4',
+    );
+    expect(rendered).not.toContain("chat-should-not-export");
     expect(rendered).not.toContain("sk-secret");
   });
 

--- a/extensions/diagnostics-prometheus/src/service.ts
+++ b/extensions/diagnostics-prometheus/src/service.ts
@@ -5,7 +5,7 @@ import type {
   OpenClawPluginHttpRouteHandler,
   OpenClawPluginService,
 } from "../api.js";
-import { redactSensitiveText } from "../api.js";
+import { isInternalDiagnosticEventMetadata, redactSensitiveText } from "../api.js";
 
 type LabelSet = Record<string, string>;
 
@@ -46,10 +46,10 @@ const BYTE_BUCKETS = [
   1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824,
   4294967296, 17179869184,
 ];
+const RATIO_BUCKETS = [0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 1, 2, 4, 8, 16];
 const LOW_CARDINALITY_VALUE_RE = /^[A-Za-z0-9_.:-]{1,120}$/u;
 const MAX_PROMETHEUS_SERIES = 2048;
 const DROPPED_SERIES_COUNTER_NAME = "openclaw_prometheus_series_dropped_total";
-
 function lowCardinalityLabel(value: string | undefined, fallback = "unknown"): string {
   if (!value) {
     return fallback;
@@ -233,6 +233,10 @@ function safeErrorMessage(err: unknown): string {
     .slice(0, 500);
 }
 
+function shouldRecordDiagnosticEvent(metadata: DiagnosticEventMetadata): boolean {
+  return metadata.trusted || isInternalDiagnosticEventMetadata(metadata);
+}
+
 function renderPrometheusMetrics(store: PrometheusMetricStore): string {
   const snapshot = store.snapshot();
   const lines: string[] = [];
@@ -330,6 +334,18 @@ function modelCallLabels(evt: {
   };
 }
 
+function modelFailoverLabels(evt: Extract<DiagnosticEventPayload, { type: "model.failover" }>): LabelSet {
+  return {
+    from_model: lowCardinalityLabel(evt.fromModel),
+    from_provider: lowCardinalityLabel(evt.fromProvider),
+    lane: lowCardinalityQueueLaneLabel(evt.lane),
+    reason: lowCardinalityLabel(evt.reason, "other"),
+    suspended: evt.suspended === undefined ? "unknown" : String(evt.suspended),
+    to_model: lowCardinalityLabel(evt.toModel),
+    to_provider: lowCardinalityLabel(evt.toProvider),
+  };
+}
+
 function toolExecutionLabels(evt: {
   errorCategory?: string;
   paramsSummary?: { kind: string };
@@ -344,6 +360,18 @@ function toolExecutionLabels(evt: {
         ? lowCardinalityLabel(evt.errorCategory, "other")
         : "none",
     outcome: evt.type === "tool.execution.error" ? "error" : "completed",
+    params_kind: lowCardinalityLabel(evt.paramsSummary?.kind),
+    tool: lowCardinalityLabel(evt.toolName, "tool"),
+    tool_owner: lowCardinalityLabel(evt.toolOwner, "none"),
+    tool_source: lowCardinalityLabel(evt.toolSource, "core"),
+  };
+}
+
+function toolExecutionBlockedLabels(
+  evt: Extract<DiagnosticEventPayload, { type: "tool.execution.blocked" }>,
+): LabelSet {
+  return {
+    denied_reason: lowCardinalityLabel(evt.deniedReason, "other"),
     params_kind: lowCardinalityLabel(evt.paramsSummary?.kind),
     tool: lowCardinalityLabel(evt.toolName, "tool"),
     tool_owner: lowCardinalityLabel(evt.toolOwner, "none"),
@@ -389,6 +417,25 @@ function harnessLabels(evt: {
   };
 }
 
+function webhookLabels(
+  evt: Extract<
+    DiagnosticEventPayload,
+    { type: "webhook.received" | "webhook.processed" | "webhook.error" }
+  >,
+): LabelSet {
+  return {
+    channel: lowCardinalityLabel(evt.channel),
+    webhook: lowCardinalityLabel(evt.updateType),
+  };
+}
+
+function sessionStuckLabels(evt: Extract<DiagnosticEventPayload, { type: "session.stuck" }>): LabelSet {
+  return {
+    reason: lowCardinalityLabel(evt.reason, "none"),
+    state: evt.state,
+  };
+}
+
 function sessionRecoveryLabels(
   evt: Extract<
     DiagnosticEventPayload,
@@ -405,6 +452,24 @@ function sessionRecoveryLabels(
     active_work_kind: lowCardinalityLabel(evt.activeWorkKind, "none"),
     state: evt.state,
     status: evt.type === "session.recovery.completed" ? evt.status : "requested",
+  };
+}
+
+function livenessLabels(
+  evt: Extract<DiagnosticEventPayload, { type: "diagnostic.liveness.warning" }>,
+): LabelSet {
+  return {
+    reason: lowCardinalityLabel(evt.reasons.join(":"), "unknown"),
+  };
+}
+
+function payloadLargeLabels(evt: Extract<DiagnosticEventPayload, { type: "payload.large" }>): LabelSet {
+  return {
+    action: evt.action,
+    channel: lowCardinalityLabel(evt.channel, "none"),
+    plugin: lowCardinalityLabel(evt.pluginId, "none"),
+    reason: lowCardinalityLabel(evt.reason, "none"),
+    surface: lowCardinalityLabel(evt.surface, "unknown"),
   };
 }
 
@@ -484,7 +549,7 @@ function recordDiagnosticEvent(
   evt: DiagnosticEventPayload,
   metadata: DiagnosticEventMetadata,
 ): void {
-  if (!metadata.trusted) {
+  if (!shouldRecordDiagnosticEvent(metadata)) {
     return;
   }
 
@@ -519,6 +584,13 @@ function recordDiagnosticEvent(
         modelCallLabels(evt),
       );
       return;
+    case "model.failover":
+      store.counter(
+        "openclaw_model_failover_total",
+        "Model failovers by source, destination, lane, and reason.",
+        modelFailoverLabels(evt),
+      );
+      return;
     case "tool.execution.completed":
     case "tool.execution.error":
       store.histogram(
@@ -531,6 +603,13 @@ function recordDiagnosticEvent(
         "openclaw_tool_execution_total",
         "Tool executions completed by outcome.",
         toolExecutionLabels(evt),
+      );
+      return;
+    case "tool.execution.blocked":
+      store.counter(
+        "openclaw_tool_execution_blocked_total",
+        "Tool executions blocked by policy or sandbox diagnostics.",
+        toolExecutionBlockedLabels(evt),
       );
       return;
     case "skill.used":
@@ -565,6 +644,28 @@ function recordDiagnosticEvent(
           reason: lowCardinalityLabel(evt.reason, "none"),
         },
         seconds(evt.durationMs),
+      );
+      return;
+    case "webhook.received":
+      store.counter(
+        "openclaw_webhook_received_total",
+        "Webhook requests received by channel and update type.",
+        webhookLabels(evt),
+      );
+      return;
+    case "webhook.processed":
+      store.histogram(
+        "openclaw_webhook_duration_seconds",
+        "Webhook processing duration in seconds.",
+        webhookLabels(evt),
+        seconds(evt.durationMs),
+      );
+      return;
+    case "webhook.error":
+      store.counter(
+        "openclaw_webhook_error_total",
+        "Webhook processing errors by channel and update type.",
+        webhookLabels(evt),
       );
       return;
     case "message.delivery.started":
@@ -711,6 +812,19 @@ function recordDiagnosticEvent(
         );
       }
       return;
+    case "session.stuck":
+      store.counter(
+        "openclaw_session_stuck_total",
+        "Stale session bookkeeping observations with no active work.",
+        sessionStuckLabels(evt),
+      );
+      store.histogram(
+        "openclaw_session_stuck_age_seconds",
+        "Age of stale session bookkeeping observations in seconds.",
+        sessionStuckLabels(evt),
+        seconds(evt.ageMs),
+      );
+      return;
     case "session.turn.created":
       store.counter("openclaw_session_turn_created_total", "Agent session turns created.", {
         agent: lowCardinalityLabel(evt.agentId),
@@ -755,6 +869,57 @@ function recordDiagnosticEvent(
         },
       );
       return;
+    case "diagnostic.liveness.warning":
+      store.counter(
+        "openclaw_liveness_warning_total",
+        "Diagnostic liveness warning events.",
+        livenessLabels(evt),
+      );
+      store.gauge(
+        "openclaw_liveness_sessions",
+        "Latest session counts reported with diagnostic liveness warnings.",
+        { state: "active" },
+        numericValue(evt.active),
+      );
+      store.gauge(
+        "openclaw_liveness_sessions",
+        "Latest session counts reported with diagnostic liveness warnings.",
+        { state: "waiting" },
+        numericValue(evt.waiting),
+      );
+      store.gauge(
+        "openclaw_liveness_sessions",
+        "Latest session counts reported with diagnostic liveness warnings.",
+        { state: "queued" },
+        numericValue(evt.queued),
+      );
+      store.histogram(
+        "openclaw_liveness_event_loop_delay_p99_seconds",
+        "P99 event-loop delay reported by diagnostic liveness warnings in seconds.",
+        livenessLabels(evt),
+        seconds(evt.eventLoopDelayP99Ms),
+      );
+      store.histogram(
+        "openclaw_liveness_event_loop_delay_max_seconds",
+        "Maximum event-loop delay reported by diagnostic liveness warnings in seconds.",
+        livenessLabels(evt),
+        seconds(evt.eventLoopDelayMaxMs),
+      );
+      store.histogram(
+        "openclaw_liveness_event_loop_utilization_ratio",
+        "Event-loop utilization reported by diagnostic liveness warnings.",
+        livenessLabels(evt),
+        numericValue(evt.eventLoopUtilization),
+        RATIO_BUCKETS,
+      );
+      store.histogram(
+        "openclaw_liveness_cpu_core_ratio",
+        "CPU core ratio reported by diagnostic liveness warnings.",
+        livenessLabels(evt),
+        numericValue(evt.cpuCoreRatio),
+        RATIO_BUCKETS,
+      );
+      return;
     case "diagnostic.async_queue.dropped":
       store.counter(
         "openclaw_diagnostic_async_queue_dropped_total",
@@ -794,7 +959,6 @@ function recordDiagnosticEvent(
       );
       return;
     case "diagnostic.heartbeat":
-    case "diagnostic.liveness.warning":
       return;
     case "telemetry.exporter":
       store.counter("openclaw_telemetry_exporter_total", "Telemetry exporter lifecycle events.", {
@@ -803,6 +967,20 @@ function recordDiagnosticEvent(
         signal: evt.signal,
         status: evt.status,
       });
+      return;
+    case "payload.large":
+      store.counter(
+        "openclaw_payload_large_total",
+        "Oversized payload diagnostics by surface and action.",
+        payloadLargeLabels(evt),
+      );
+      store.histogram(
+        "openclaw_payload_large_bytes",
+        "Oversized payload byte sizes by surface and action.",
+        payloadLargeLabels(evt),
+        numericValue(evt.bytes),
+        BYTE_BUCKETS,
+      );
       return;
     default:
       return;

--- a/src/infra/diagnostic-events.test.ts
+++ b/src/infra/diagnostic-events.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   emitDiagnosticEvent,
+  emitInternalDiagnosticEvent,
   emitTrustedDiagnosticEvent,
   formatDiagnosticTraceparentForPropagation,
   hasPendingInternalDiagnosticEvent,
+  isInternalDiagnosticEventMetadata,
   isDiagnosticsEnabled,
   onInternalDiagnosticEvent,
   onDiagnosticEvent,
@@ -170,13 +172,15 @@ describe("diagnostic-events", () => {
     ]);
   });
 
-  it("marks only internal trusted diagnostic emissions as trusted", async () => {
+  it("marks dispatcher provenance separately from trust", async () => {
     const events: Array<{
+      internal: boolean;
       metadataTrusted: boolean;
       type: string;
     }> = [];
     onInternalDiagnosticEvent((event, metadata) => {
       events.push({
+        internal: isInternalDiagnosticEventMetadata(metadata),
         metadataTrusted: metadata.trusted,
         type: event.type,
       });
@@ -185,6 +189,10 @@ describe("diagnostic-events", () => {
     emitDiagnosticEvent({
       type: "message.queued",
       source: "plugin",
+    });
+    emitInternalDiagnosticEvent({
+      type: "webhook.received",
+      channel: "telegram",
     });
     emitTrustedDiagnosticEvent({
       type: "model.call.started",
@@ -196,9 +204,11 @@ describe("diagnostic-events", () => {
 
     await new Promise<void>((resolve) => setImmediate(resolve));
     expect(events).toEqual([
-      { metadataTrusted: false, type: "message.queued" },
-      { metadataTrusted: true, type: "model.call.started" },
+      { internal: false, metadataTrusted: false, type: "message.queued" },
+      { internal: true, metadataTrusted: false, type: "webhook.received" },
+      { internal: false, metadataTrusted: true, type: "model.call.started" },
     ]);
+    expect(isInternalDiagnosticEventMetadata({ trusted: false })).toBe(false);
   });
 
   it("formats traceparent for propagation only from dispatcher-trusted metadata", () => {

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -702,6 +702,7 @@ export type DiagnosticEventInput = DiagnosticEventPayload extends infer Event
   : never;
 
 export type DiagnosticEventMetadata = Readonly<{
+  internal?: boolean;
   trusted: boolean;
 }>;
 
@@ -968,7 +969,7 @@ function dispatchAsyncDiagnosticDropSummary(state: DiagnosticEventsGlobalState):
     maxQueueLength: MAX_ASYNC_DIAGNOSTIC_EVENTS,
     drainBatchSize: MAX_ASYNC_DIAGNOSTIC_EVENTS_PER_TURN,
   });
-  dispatchDiagnosticEvent(state, event, { trusted: false });
+  dispatchDiagnosticEvent(state, event, createInternalDiagnosticMetadata(false));
 }
 
 export async function waitForDiagnosticEventsDrained(): Promise<void> {
@@ -996,14 +997,22 @@ function enrichDiagnosticEvent(
   return enriched;
 }
 
-function emitDiagnosticEventWithTrust(event: DiagnosticEventInput, trusted: boolean) {
+function createInternalDiagnosticMetadata(trusted: boolean): DiagnosticEventMetadata {
+  return { internal: true, trusted };
+}
+
+function emitDiagnosticEventWithTrust(
+  event: DiagnosticEventInput,
+  trusted: boolean,
+  internal = false,
+) {
   const state = getDiagnosticEventsState();
   if (!state.enabled) {
     return;
   }
 
   const enriched = enrichDiagnosticEvent(state, event);
-  const metadata: DiagnosticEventMetadata = { trusted };
+  const metadata = internal ? createInternalDiagnosticMetadata(trusted) : { trusted };
 
   if (ASYNC_DIAGNOSTIC_EVENT_TYPES.has(enriched.type)) {
     if (state.asyncQueue.length >= MAX_ASYNC_DIAGNOSTIC_EVENTS) {
@@ -1026,6 +1035,10 @@ function emitDiagnosticEventWithTrust(event: DiagnosticEventInput, trusted: bool
 
 export function emitDiagnosticEvent(event: DiagnosticEventInput) {
   emitDiagnosticEventWithTrust(event, false);
+}
+
+export function emitInternalDiagnosticEvent(event: DiagnosticEventInput) {
+  emitDiagnosticEventWithTrust(event, false, true);
 }
 
 export function emitTrustedDiagnosticEvent(event: DiagnosticEventInput) {
@@ -1058,7 +1071,7 @@ export function hasPendingInternalDiagnosticEvent(
     } catch {
       continue;
     }
-    if (predicate(event, Object.freeze({ ...entry.metadata }))) {
+    if (predicate(event, createDiagnosticMetadataForListener(entry.metadata))) {
       return true;
     }
   }
@@ -1082,6 +1095,10 @@ export function formatDiagnosticTraceparentForPropagation(
     return undefined;
   }
   return formatDiagnosticTraceparent(event.trace);
+}
+
+export function isInternalDiagnosticEventMetadata(metadata: DiagnosticEventMetadata): boolean {
+  return metadata.internal === true;
 }
 
 export function resetDiagnosticEventsForTest(): void {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -39,7 +39,10 @@ import type { OutboundMediaAccess } from "../../media/load-options.js";
 import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { diagnosticErrorCategory } from "../diagnostic-error-metadata.js";
-import { emitDiagnosticEvent, type DiagnosticMessageDeliveryKind } from "../diagnostic-events.js";
+import {
+  emitInternalDiagnosticEvent as emitDiagnosticEvent,
+  type DiagnosticMessageDeliveryKind,
+} from "../diagnostic-events.js";
 import { formatErrorMessage } from "../errors.js";
 import { throwIfAborted } from "./abort.js";
 import { resolveOutboundChannelMessageAdapter } from "./channel-resolution.js";

--- a/src/logging/diagnostic-memory.ts
+++ b/src/logging/diagnostic-memory.ts
@@ -1,5 +1,5 @@
 import {
-  emitDiagnosticEvent,
+  emitInternalDiagnosticEvent as emitDiagnosticEvent,
   type DiagnosticMemoryPressureEvent,
   type DiagnosticMemoryUsage,
 } from "../infra/diagnostic-events.js";

--- a/src/logging/diagnostic-payload.ts
+++ b/src/logging/diagnostic-payload.ts
@@ -1,4 +1,4 @@
-import { emitDiagnosticEvent } from "../infra/diagnostic-events.js";
+import { emitInternalDiagnosticEvent as emitDiagnosticEvent } from "../infra/diagnostic-events.js";
 
 type LargePayloadBase = {
   surface: string;

--- a/src/logging/diagnostic-runtime.ts
+++ b/src/logging/diagnostic-runtime.ts
@@ -1,6 +1,6 @@
 import {
   areDiagnosticsEnabledForProcess,
-  emitDiagnosticEvent,
+  emitInternalDiagnosticEvent as emitDiagnosticEvent,
 } from "../infra/diagnostic-events.js";
 import { createSubsystemLogger } from "./subsystem.js";
 

--- a/src/logging/diagnostic-session-recovery-coordinator.ts
+++ b/src/logging/diagnostic-session-recovery-coordinator.ts
@@ -1,4 +1,4 @@
-import { emitDiagnosticEvent } from "../infra/diagnostic-events.js";
+import { emitInternalDiagnosticEvent as emitDiagnosticEvent } from "../infra/diagnostic-events.js";
 import { markDiagnosticActivity as markActivity } from "./diagnostic-runtime.js";
 import type { SessionAttentionClassification } from "./diagnostic-session-attention.js";
 import {

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -4,7 +4,7 @@ import { resolveAllAgentSessionStoreTargetsSync } from "../config/sessions/targe
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   areDiagnosticsEnabledForProcess,
-  emitDiagnosticEvent,
+  emitInternalDiagnosticEvent as emitDiagnosticEvent,
   isDiagnosticsEnabled,
   type DiagnosticPhaseSnapshot,
   type DiagnosticLivenessWarningReason,

--- a/src/plugin-sdk/diagnostic-runtime.ts
+++ b/src/plugin-sdk/diagnostic-runtime.ts
@@ -9,6 +9,7 @@ export {
   emitDiagnosticEvent,
   emitTrustedDiagnosticEvent,
   hasPendingInternalDiagnosticEvent,
+  isInternalDiagnosticEventMetadata,
   isDiagnosticsEnabled,
   onInternalDiagnosticEvent,
   onDiagnosticEvent,


### PR DESCRIPTION
## Summary

- Fix shared OTLP endpoint resolution so `/v1/traces`, `/v1/metrics`, and `/v1/logs` are inserted before query strings or fragments.
- Export alertable OTel and Prometheus signals for model failover, blocked tool executions, oversized payloads, webhook ingress/errors, stale sessions, and liveness warnings.
- Carry core diagnostic provenance on dispatcher metadata so Prometheus records core gateway stability events while dropping plugin-emitted spoof events, then document the updated OTel/Prometheus behavior and changelog entry.

## Verification

- Autoreview: `AUTOREVIEW_AUTO_TESTS=0 AUTOREVIEW_OPENCLAW_MAINTAINER_VALIDATION=1 .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> clean, no accepted/actionable findings.
- AWS Crabbox `run_cf9cee226993`, lease `cbx_e9567e71c6b2`, provider AWS c7a.8xlarge: `pnpm test:serial src/infra/diagnostic-events.test.ts extensions/diagnostics-otel/src/service.test.ts extensions/diagnostics-prometheus/src/service.test.ts && pnpm check:changed && pnpm qa:observability:smoke && pnpm qa:observability:collector-smoke`.
- Focused tests passed: infra diagnostic events 26 tests, diagnostics-otel 65 tests, diagnostics-prometheus 17 tests.
- `pnpm check:changed` passed core, coreTests, extensions, extensionTests, and docs lanes.
- In-process observability smoke passed: OTel spans=18 metrics=37 logs=14 traces=2 metricRequests=7 logRequests=6; Prometheus smoke passed.
- Collector-backed observability smoke passed against `otel/opentelemetry-collector:0.104.0`: OTel spans=18 metrics=28 logs=14 traces=2 metricRequests=6 logRequests=5; Prometheus smoke passed.

## Real behavior proof

Behavior addressed: Operators now get correct OTLP signal URLs when a shared endpoint has query strings/fragments, explicit OTel metrics for blocked tools/model failover/large payloads, and Prometheus metrics for gateway stability signals without accepting plugin-spoofed untrusted diagnostics.

Real environment tested: AWS Crabbox Linux runner, provider `aws`, lease `cbx_e9567e71c6b2`, run `run_cf9cee226993`, including in-process OTLP/Prometheus QA and a Docker OpenTelemetry Collector path.

Exact steps or command run after this patch: `pnpm test:serial src/infra/diagnostic-events.test.ts extensions/diagnostics-otel/src/service.test.ts extensions/diagnostics-prometheus/src/service.test.ts && pnpm check:changed && pnpm qa:observability:smoke && pnpm qa:observability:collector-smoke`.

Evidence after fix: Focused regression tests covered endpoint query/fragment handling, new OTel instruments, Prometheus stability metrics, and plugin-spoofed untrusted diagnostic drops. QA smoke exported OTLP/Prometheus data successfully both directly and through `otel/opentelemetry-collector:0.104.0`.

Observed result after fix: The remote command exited 0. In-process OTel smoke observed spans=18, metrics=37, logs=14, traces=2, metricRequests=7, logRequests=6. Collector smoke observed spans=18, metrics=28, logs=14, traces=2, metricRequests=6, logRequests=5. Prometheus smoke passed in both lanes.

What was not tested: Live third-party Prometheus/Grafana scraping and live external provider traffic were not exercised; the proof used repository QA scenarios and a real OpenTelemetry Collector container.
