### PR TITLE
Fix plugin runtime module resolution diagnostics

### DIFF
--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -149,11 +149,13 @@ import {
   buildPluginLoaderJitiOptions,
   listPluginSdkAliasCandidates,
   listPluginSdkExportedSubpaths,
+  type PluginRuntimeModuleResolution,
   type PluginSdkResolutionPreference,
   resolveExtensionApiAlias,
   resolvePluginSdkAliasCandidateOrder,
   resolvePluginSdkAliasFile,
   resolvePluginRuntimeModulePath,
+  resolvePluginRuntimeModulePathWithDiagnostics,
   resolvePluginSdkScopedAliasMap,
   shouldPreferNativeModuleLoad,
 } from "./sdk-alias.js";
@@ -613,6 +615,22 @@ function resolvePreferredBuiltBundledRuntimeArtifact(params: {
     }
   }
   return { source, rootDir };
+}
+
+function formatPluginRuntimeModuleResolutionError(params: {
+  resolution: PluginRuntimeModuleResolution;
+  pluginSdkResolution?: PluginSdkResolutionPreference;
+}): string {
+  const { resolution } = params;
+  const candidates = resolution.candidates.length > 0 ? resolution.candidates.join(", ") : "<none>";
+  return [
+    "Unable to resolve plugin runtime module",
+    `loader=${resolution.modulePath ?? "<unresolved>"}`,
+    `packageRoot=${resolution.packageRoot ?? "<none>"}`,
+    `pluginSdkResolution=${params.pluginSdkResolution ?? "auto"}`,
+    `candidates=${candidates}`,
+    ...(resolution.error ? [`resolverError=${resolution.error}`] : []),
+  ].join("; ");
 }
 
 export const testing = {
@@ -1630,11 +1648,17 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       if (createPluginRuntimeFactory) {
         return createPluginRuntimeFactory;
       }
-      const runtimeModulePath = resolvePluginRuntimeModulePath({
+      const runtimeModuleResolution = resolvePluginRuntimeModulePathWithDiagnostics({
         pluginSdkResolution: options.pluginSdkResolution,
       });
+      const runtimeModulePath = runtimeModuleResolution.resolvedPath;
       if (!runtimeModulePath) {
-        throw new Error("Unable to resolve plugin runtime module");
+        throw new Error(
+          formatPluginRuntimeModuleResolutionError({
+            resolution: runtimeModuleResolution,
+            pluginSdkResolution: options.pluginSdkResolution,
+          }),
+        );
       }
       const runtimeModule = withProfile(
         { source: runtimeModulePath },

--- a/src/plugins/registry.runtime-config.test.ts
+++ b/src/plugins/registry.runtime-config.test.ts
@@ -20,6 +20,38 @@ function createTestRegistry(runtime: PluginRuntime) {
 }
 
 describe("plugin registry runtime config scope", () => {
+  it("adds plugin context to lazy runtime resolution failures", () => {
+    const runtime = new Proxy({} as PluginRuntime, {
+      get() {
+        throw new Error("Unable to resolve plugin runtime module; loader=/tmp/openclaw-loader.js");
+      },
+    });
+    const pluginRegistry = createTestRegistry(runtime);
+    const record = createPluginRecord({
+      id: "diagnostic-plugin",
+      name: "Diagnostic Plugin",
+      source: "/plugins/diagnostic-plugin/index.js",
+      origin: "global",
+      enabled: true,
+      configSchema: false,
+    });
+    const api = pluginRegistry.createApi(record, { config: {} as OpenClawConfig });
+
+    let thrown: unknown;
+    try {
+      void api.runtime.version;
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    const message = (thrown as Error).message;
+    expect(message).toContain("Unable to resolve plugin runtime module");
+    expect(message).toContain("pluginRuntimeContext=pluginId:diagnostic-plugin");
+    expect(message).toContain("property:version");
+    expect(message).toContain("source:/plugins/diagnostic-plugin/index.js");
+  });
+
   it("runs config helpers with the owning plugin scope", async () => {
     let currentScope = getPluginRuntimeGatewayRequestScope();
     let mutateScope = getPluginRuntimeGatewayRequestScope();

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -2494,6 +2494,32 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
   const pluginRuntimeById = new Map<string, PluginRuntime>();
   const pluginRuntimeRecordById = new Map<string, PluginRecord>();
 
+  const addPluginRuntimeResolutionContext = (params: {
+    error: unknown;
+    pluginId: string;
+    prop: PropertyKey;
+  }): never => {
+    const { error, pluginId, prop } = params;
+    if (
+      error instanceof Error &&
+      error.message.startsWith("Unable to resolve plugin runtime module") &&
+      !error.message.includes("pluginRuntimeContext=")
+    ) {
+      const record =
+        pluginRuntimeRecordById.get(pluginId) ??
+        registry.plugins.find((entry) => entry.id === pluginId);
+      const propName =
+        typeof prop === "symbol" ? (prop.description ?? prop.toString()) : String(prop);
+      error.message = [
+        error.message,
+        `pluginRuntimeContext=pluginId:${pluginId}`,
+        `property:${propName}`,
+        ...(record?.source ? [`source:${record.source}`] : []),
+      ].join("; ");
+    }
+    throw error;
+  };
+
   const resolvePluginRuntime = (pluginId: string): PluginRuntime => {
     const cached = pluginRuntimeById.get(pluginId);
     if (cached) {
@@ -2509,8 +2535,15 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
             ? withPluginRuntimePluginScope({ pluginId, pluginSource: record.source }, run)
             : withPluginRuntimePluginScope({ pluginId }, run);
         };
+        const getRuntimeProperty = () => {
+          try {
+            return Reflect.get(target, prop, receiver);
+          } catch (error) {
+            return addPluginRuntimeResolutionContext({ error, pluginId, prop });
+          }
+        };
         if (prop === "state") {
-          const baseState = Reflect.get(target, prop, receiver);
+          const baseState = getRuntimeProperty();
           return {
             ...baseState,
             openKeyedStore: <T>(options: OpenKeyedStoreOptions): PluginStateKeyedStore<T> => {
@@ -2527,7 +2560,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
           } satisfies PluginRuntime["state"];
         }
         if (prop === "config") {
-          const config: PluginRuntime["config"] = Reflect.get(target, prop, receiver);
+          const config: PluginRuntime["config"] = getRuntimeProperty();
           return {
             ...config,
             current: () => runWithPluginScope(() => config.current()),
@@ -2537,16 +2570,16 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
           } satisfies PluginRuntime["config"];
         }
         if (prop === "llm") {
-          const llm = Reflect.get(target, prop, receiver);
+          const llm = getRuntimeProperty();
           return {
             complete: (params) =>
               withPluginRuntimePluginIdScope(pluginId, () => llm.complete(params)),
           } satisfies PluginRuntime["llm"];
         }
         if (prop !== "subagent") {
-          return Reflect.get(target, prop, receiver);
+          return getRuntimeProperty();
         }
-        const subagent = Reflect.get(target, prop, receiver);
+        const subagent = getRuntimeProperty();
         return {
           run: (params) => withPluginRuntimePluginIdScope(pluginId, () => subagent.run(params)),
           waitForRun: (params) =>

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -1824,6 +1824,31 @@ export const syntheticRuntimeMarker = {
     ).toBe(distFile);
   });
 
+  it("uses the default startup argv hint for runtime fallback when argv1 is omitted", () => {
+    const root = makeTempDir();
+    const distFile = path.join(root, "dist", "plugins", "runtime", "index.js");
+    const loaderCacheRoot = makeTempDir();
+    const loaderCachePath = path.join(loaderCacheRoot, "tsx", "openclaw-loader.js");
+    const originalArgv1 = process.argv[1];
+    mkdirSafeDir(path.dirname(distFile));
+    mkdirSafeDir(path.dirname(loaderCachePath));
+    mkdirSafeDir(path.join(root, "bin"));
+    fs.writeFileSync(distFile, "export const createPluginRuntime = () => ({});\n", "utf-8");
+    fs.writeFileSync(loaderCachePath, "export {};\n", "utf-8");
+
+    process.argv[1] = path.join(root, "bin", "openclaw");
+    try {
+      expect(
+        resolvePluginRuntimeModulePath({
+          modulePath: loaderCachePath,
+          pluginSdkResolution: "dist",
+        }),
+      ).toBe(distFile);
+    } finally {
+      process.argv[1] = originalArgv1;
+    }
+  });
+
   it("reports loader, package root, and candidate paths when runtime resolution fails", () => {
     const root = makeTempDir();
     const modulePath = path.join(root, "dist", "plugins", "loader.js");

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -1872,6 +1872,53 @@ export const syntheticRuntimeMarker = {
     ).toBe(distFile);
   });
 
+  it("resolves runtime fallback through symlinked startup argv", () => {
+    const root = makeTempDir();
+    const distFile = path.join(root, "dist", "plugins", "runtime", "index.js");
+    const binFile = path.join(root, "bin", "openclaw");
+    const shimRoot = makeTempDir();
+    const shimFile = path.join(shimRoot, "bin", "openclaw");
+    const loaderCachePath = path.join(makeTempDir(), "tsx", "openclaw-loader.js");
+    mkdirSafeDir(path.dirname(distFile));
+    mkdirSafeDir(path.dirname(binFile));
+    mkdirSafeDir(path.dirname(shimFile));
+    mkdirSafeDir(path.dirname(loaderCachePath));
+    fs.writeFileSync(distFile, "export const runtime = 'startup';\n", "utf-8");
+    fs.writeFileSync(binFile, "#!/usr/bin/env node\n", "utf-8");
+    fs.symlinkSync(binFile, shimFile);
+    fs.writeFileSync(loaderCachePath, "export {};\n", "utf-8");
+
+    expect(
+      resolvePluginRuntimeModulePath({
+        modulePath: loaderCachePath,
+        argv1: shimFile,
+        pluginSdkResolution: "dist",
+      }),
+    ).toBe(fs.realpathSync(distFile));
+  });
+
+  it("resolves runtime fallback through npm .bin startup argv", () => {
+    const root = makeTempDir();
+    const packageRoot = path.join(root, "node_modules", "openclaw");
+    const distFile = path.join(packageRoot, "dist", "plugins", "runtime", "index.js");
+    const binFile = path.join(root, "node_modules", ".bin", "openclaw");
+    const loaderCachePath = path.join(makeTempDir(), "tsx", "openclaw-loader.js");
+    mkdirSafeDir(path.dirname(distFile));
+    mkdirSafeDir(path.dirname(binFile));
+    mkdirSafeDir(path.dirname(loaderCachePath));
+    fs.writeFileSync(distFile, "export const runtime = 'startup';\n", "utf-8");
+    fs.writeFileSync(binFile, "#!/usr/bin/env node\n", "utf-8");
+    fs.writeFileSync(loaderCachePath, "export {};\n", "utf-8");
+
+    expect(
+      resolvePluginRuntimeModulePath({
+        modulePath: loaderCachePath,
+        argv1: binFile,
+        pluginSdkResolution: "dist",
+      }),
+    ).toBe(distFile);
+  });
+
   it("reports loader, package root, and candidate paths when runtime resolution fails", () => {
     const root = makeTempDir();
     const modulePath = path.join(root, "dist", "plugins", "loader.js");

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -1849,6 +1849,29 @@ export const syntheticRuntimeMarker = {
     }
   });
 
+  it("prefers startup argv runtime candidates over cache ancestor fallbacks", () => {
+    const root = makeTempDir();
+    const distFile = path.join(root, "dist", "plugins", "runtime", "index.js");
+    const loaderCacheRoot = makeTempDir();
+    const cacheDistFile = path.join(loaderCacheRoot, "dist", "plugins", "runtime", "index.js");
+    const loaderCachePath = path.join(loaderCacheRoot, "tsx", "openclaw-loader.js");
+    mkdirSafeDir(path.dirname(distFile));
+    mkdirSafeDir(path.dirname(cacheDistFile));
+    mkdirSafeDir(path.dirname(loaderCachePath));
+    mkdirSafeDir(path.join(root, "bin"));
+    fs.writeFileSync(distFile, "export const runtime = 'startup';\n", "utf-8");
+    fs.writeFileSync(cacheDistFile, "export const runtime = 'cache';\n", "utf-8");
+    fs.writeFileSync(loaderCachePath, "export {};\n", "utf-8");
+
+    expect(
+      resolvePluginRuntimeModulePath({
+        modulePath: loaderCachePath,
+        argv1: path.join(root, "bin", "openclaw"),
+        pluginSdkResolution: "dist",
+      }),
+    ).toBe(distFile);
+  });
+
   it("reports loader, package root, and candidate paths when runtime resolution fails", () => {
     const root = makeTempDir();
     const modulePath = path.join(root, "dist", "plugins", "loader.js");

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -20,6 +20,7 @@ import {
   resolvePluginLoaderTryNative,
   resolveExtensionApiAlias,
   resolvePluginRuntimeModulePath,
+  resolvePluginRuntimeModulePathWithDiagnostics,
   resolvePluginSdkAliasFile,
   shouldPreferNativeModuleLoad,
 } from "./sdk-alias.js";
@@ -1803,6 +1804,51 @@ export const syntheticRuntimeMarker = {
       env,
     });
     expect(resolved).toBe(expected === "dist" ? fixture.distFile : fixture.srcFile);
+  });
+
+  it("falls back to ancestor runtime candidates when package-root markers are unavailable", () => {
+    const root = makeTempDir();
+    const distFile = path.join(root, "dist", "plugins", "runtime", "index.js");
+    const loaderCachePath = path.join(root, ".cache", "tsx", "openclaw-loader.js");
+    mkdirSafeDir(path.dirname(distFile));
+    mkdirSafeDir(path.dirname(loaderCachePath));
+    fs.writeFileSync(distFile, "export const createPluginRuntime = () => ({});\n", "utf-8");
+    fs.writeFileSync(loaderCachePath, "export {};\n", "utf-8");
+
+    expect(
+      resolvePluginRuntimeModulePath({
+        modulePath: loaderCachePath,
+        argv1: path.join(root, "bin", "openclaw"),
+        pluginSdkResolution: "dist",
+      }),
+    ).toBe(distFile);
+  });
+
+  it("reports loader, package root, and candidate paths when runtime resolution fails", () => {
+    const root = makeTempDir();
+    const modulePath = path.join(root, "dist", "plugins", "loader.js");
+    fs.writeFileSync(
+      path.join(root, "package.json"),
+      JSON.stringify({ name: "openclaw", type: "module" }, null, 2),
+      "utf-8",
+    );
+    mkdirSafeDir(path.dirname(modulePath));
+    fs.writeFileSync(modulePath, "export {};\n", "utf-8");
+
+    const resolution = resolvePluginRuntimeModulePathWithDiagnostics({
+      modulePath,
+      pluginSdkResolution: "dist",
+    });
+
+    expect(resolution.resolvedPath).toBeNull();
+    expect(resolution.modulePath).toBe(modulePath);
+    expect(resolution.packageRoot).toBe(root);
+    expect(resolution.candidates).toContain(
+      path.join(root, "dist", "plugins", "runtime", "index.js"),
+    );
+    expect(resolution.candidates).toContain(
+      path.join(root, "src", "plugins", "runtime", "index.ts"),
+    );
   });
 });
 

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -1901,12 +1901,15 @@ export const syntheticRuntimeMarker = {
     const root = makeTempDir();
     const packageRoot = path.join(root, "node_modules", "openclaw");
     const distFile = path.join(packageRoot, "dist", "plugins", "runtime", "index.js");
+    const projectDistFile = path.join(root, "dist", "plugins", "runtime", "index.js");
     const binFile = path.join(root, "node_modules", ".bin", "openclaw");
     const loaderCachePath = path.join(makeTempDir(), "tsx", "openclaw-loader.js");
     mkdirSafeDir(path.dirname(distFile));
+    mkdirSafeDir(path.dirname(projectDistFile));
     mkdirSafeDir(path.dirname(binFile));
     mkdirSafeDir(path.dirname(loaderCachePath));
     fs.writeFileSync(distFile, "export const runtime = 'startup';\n", "utf-8");
+    fs.writeFileSync(projectDistFile, "export const runtime = 'project';\n", "utf-8");
     fs.writeFileSync(binFile, "#!/usr/bin/env node\n", "utf-8");
     fs.writeFileSync(loaderCachePath, "export {};\n", "utf-8");
 

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -226,6 +226,30 @@ function listAncestorPluginRuntimeModuleCandidates(params: {
   return dedupeResolvedPaths(candidates);
 }
 
+function listArgvRuntimeFallbackStartDirs(argv1: string | undefined): string[] {
+  if (!argv1) {
+    return [];
+  }
+  const normalized = path.resolve(argv1);
+  const starts = [path.dirname(normalized)];
+  try {
+    const resolved = fs.realpathSync(normalized);
+    if (resolved !== normalized) {
+      starts.push(path.dirname(resolved));
+    }
+  } catch {
+    // Keep the unresolved argv path; startup shims may not exist in tests.
+  }
+  const parts = normalized.split(path.sep);
+  const binIndex = parts.lastIndexOf(".bin");
+  if (binIndex > 0 && parts[binIndex - 1] === "node_modules") {
+    const binName = path.basename(normalized);
+    const nodeModulesDir = parts.slice(0, binIndex).join(path.sep);
+    starts.push(path.join(nodeModulesDir, binName));
+  }
+  return dedupeResolvedPaths(starts);
+}
+
 function formatResolutionError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -1063,7 +1087,7 @@ export function resolvePluginRuntimeModulePathWithDiagnostics(
       const argv1 = params.argv1 ?? process.argv[1];
       candidates.push(
         ...listAncestorPluginRuntimeModuleCandidates({
-          starts: [argv1 ? path.dirname(argv1) : undefined, params.cwd],
+          starts: [...listArgvRuntimeFallbackStartDirs(argv1), params.cwd],
           orderedKinds,
         }),
       );

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -1046,13 +1046,10 @@ export function resolvePluginRuntimeModulePathWithDiagnostics(
     if (packageRoot) {
       appendPluginRuntimeModuleCandidates(candidates, packageRoot, orderedKinds);
     } else {
+      const argv1 = params.argv1 ?? process.argv[1];
       candidates.push(
         ...listAncestorPluginRuntimeModuleCandidates({
-          starts: [
-            path.dirname(modulePath),
-            params.cwd,
-            params.argv1 ? path.dirname(params.argv1) : undefined,
-          ],
+          starts: [path.dirname(modulePath), params.cwd, argv1 ? path.dirname(argv1) : undefined],
           orderedKinds,
         }),
       );

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -174,6 +174,20 @@ function appendPluginRuntimeModuleCandidates(
   }
 }
 
+function appendSiblingPluginRuntimeModuleCandidates(
+  candidates: string[],
+  runtimeDir: string,
+  orderedKinds: readonly PluginSdkAliasCandidateKind[],
+): void {
+  const candidateMap = {
+    src: path.join(runtimeDir, "index.ts"),
+    dist: path.join(runtimeDir, "index.js"),
+  } as const;
+  for (const kind of orderedKinds) {
+    candidates.push(candidateMap[kind]);
+  }
+}
+
 function dedupeResolvedPaths(paths: readonly string[]): string[] {
   const seen = new Set<string>();
   const deduped: string[] = [];
@@ -1049,9 +1063,14 @@ export function resolvePluginRuntimeModulePathWithDiagnostics(
       const argv1 = params.argv1 ?? process.argv[1];
       candidates.push(
         ...listAncestorPluginRuntimeModuleCandidates({
-          starts: [path.dirname(modulePath), params.cwd, argv1 ? path.dirname(argv1) : undefined],
+          starts: [argv1 ? path.dirname(argv1) : undefined, params.cwd],
           orderedKinds,
         }),
+      );
+      appendSiblingPluginRuntimeModuleCandidates(
+        candidates,
+        path.join(path.dirname(modulePath), "runtime"),
+        orderedKinds,
       );
     }
     const dedupedCandidates = dedupeResolvedPaths(candidates);

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -231,7 +231,14 @@ function listArgvRuntimeFallbackStartDirs(argv1: string | undefined): string[] {
     return [];
   }
   const normalized = path.resolve(argv1);
-  const starts = [path.dirname(normalized)];
+  const starts: string[] = [];
+  const parts = normalized.split(path.sep);
+  const binIndex = parts.lastIndexOf(".bin");
+  if (binIndex > 0 && parts[binIndex - 1] === "node_modules") {
+    const binName = path.basename(normalized);
+    const nodeModulesDir = parts.slice(0, binIndex).join(path.sep);
+    starts.push(path.join(nodeModulesDir, binName));
+  }
   try {
     const resolved = fs.realpathSync(normalized);
     if (resolved !== normalized) {
@@ -240,13 +247,7 @@ function listArgvRuntimeFallbackStartDirs(argv1: string | undefined): string[] {
   } catch {
     // Keep the unresolved argv path; startup shims may not exist in tests.
   }
-  const parts = normalized.split(path.sep);
-  const binIndex = parts.lastIndexOf(".bin");
-  if (binIndex > 0 && parts[binIndex - 1] === "node_modules") {
-    const binName = path.basename(normalized);
-    const nodeModulesDir = parts.slice(0, binIndex).join(path.sep);
-    starts.push(path.join(nodeModulesDir, binName));
-  }
+  starts.push(path.dirname(normalized));
   return dedupeResolvedPaths(starts);
 }
 
@@ -1087,7 +1088,7 @@ export function resolvePluginRuntimeModulePathWithDiagnostics(
       const argv1 = params.argv1 ?? process.argv[1];
       candidates.push(
         ...listAncestorPluginRuntimeModuleCandidates({
-          starts: [...listArgvRuntimeFallbackStartDirs(argv1), params.cwd],
+          starts: listArgvRuntimeFallbackStartDirs(argv1),
           orderedKinds,
         }),
       );

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -17,6 +17,14 @@ export type LoaderModuleResolveParams = {
   pluginSdkResolution?: PluginSdkResolutionPreference;
 };
 
+export type PluginRuntimeModuleResolution = {
+  modulePath?: string;
+  packageRoot: string | null;
+  candidates: string[];
+  resolvedPath: string | null;
+  error?: string;
+};
+
 type PluginSdkPackageJson = {
   exports?: Record<string, unknown>;
   bin?: string | Record<string, unknown>;
@@ -146,6 +154,66 @@ export function resolveLoaderPackageRoot(
     ...(argv1 ? { argv1 } : {}),
     ...(moduleUrl ? { moduleUrl } : {}),
   });
+}
+
+function createPluginRuntimeModuleCandidateMap(packageRoot: string) {
+  return {
+    src: path.join(packageRoot, "src", "plugins", "runtime", "index.ts"),
+    dist: path.join(packageRoot, "dist", "plugins", "runtime", "index.js"),
+  } as const;
+}
+
+function appendPluginRuntimeModuleCandidates(
+  candidates: string[],
+  packageRoot: string,
+  orderedKinds: readonly PluginSdkAliasCandidateKind[],
+): void {
+  const candidateMap = createPluginRuntimeModuleCandidateMap(packageRoot);
+  for (const kind of orderedKinds) {
+    candidates.push(candidateMap[kind]);
+  }
+}
+
+function dedupeResolvedPaths(paths: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+  for (const candidate of paths) {
+    const resolved = path.resolve(candidate);
+    if (seen.has(resolved)) {
+      continue;
+    }
+    seen.add(resolved);
+    deduped.push(resolved);
+  }
+  return deduped;
+}
+
+function listAncestorPluginRuntimeModuleCandidates(params: {
+  starts: readonly (string | undefined)[];
+  orderedKinds: readonly PluginSdkAliasCandidateKind[];
+  maxDepth?: number;
+}): string[] {
+  const candidates: string[] = [];
+  for (const start of params.starts) {
+    if (!start) {
+      continue;
+    }
+    let cursor = path.resolve(start);
+    const maxDepth = params.maxDepth ?? 12;
+    for (let i = 0; i < maxDepth; i += 1) {
+      appendPluginRuntimeModuleCandidates(candidates, cursor, params.orderedKinds);
+      const parent = path.dirname(cursor);
+      if (parent === cursor) {
+        break;
+      }
+      cursor = parent;
+    }
+  }
+  return dedupeResolvedPaths(candidates);
+}
+
+function formatResolutionError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function resolveLoaderPluginSdkPackageRoot(
@@ -958,33 +1026,63 @@ export function buildPluginLoaderAliasMap(
 export function resolvePluginRuntimeModulePath(
   params: LoaderModuleResolveParams = {},
 ): string | null {
+  return resolvePluginRuntimeModulePathWithDiagnostics(params).resolvedPath;
+}
+
+export function resolvePluginRuntimeModulePathWithDiagnostics(
+  params: LoaderModuleResolveParams = {},
+): PluginRuntimeModuleResolution {
+  let modulePath: string | undefined;
+  let packageRoot: string | null = null;
+  const candidates: string[] = [];
   try {
-    const modulePath = resolveLoaderModulePath(params);
+    modulePath = resolveLoaderModulePath(params);
     const orderedKinds = resolvePluginSdkAliasCandidateOrder({
       modulePath,
       isProduction: process.env.NODE_ENV === "production",
       pluginSdkResolution: params.pluginSdkResolution,
     });
-    const packageRoot = resolveLoaderPackageRoot({ ...params, modulePath });
-    const candidates = packageRoot
-      ? orderedKinds.map((kind) =>
-          kind === "src"
-            ? path.join(packageRoot, "src", "plugins", "runtime", "index.ts")
-            : path.join(packageRoot, "dist", "plugins", "runtime", "index.js"),
-        )
-      : [
-          path.join(path.dirname(modulePath), "runtime", "index.ts"),
-          path.join(path.dirname(modulePath), "runtime", "index.js"),
-        ];
-    for (const candidate of candidates) {
+    packageRoot = resolveLoaderPackageRoot({ ...params, modulePath });
+    if (packageRoot) {
+      appendPluginRuntimeModuleCandidates(candidates, packageRoot, orderedKinds);
+    } else {
+      candidates.push(
+        ...listAncestorPluginRuntimeModuleCandidates({
+          starts: [
+            path.dirname(modulePath),
+            params.cwd,
+            params.argv1 ? path.dirname(params.argv1) : undefined,
+          ],
+          orderedKinds,
+        }),
+      );
+    }
+    const dedupedCandidates = dedupeResolvedPaths(candidates);
+    for (const candidate of dedupedCandidates) {
       if (fs.existsSync(candidate)) {
-        return candidate;
+        return {
+          modulePath,
+          packageRoot,
+          candidates: dedupedCandidates,
+          resolvedPath: candidate,
+        };
       }
     }
-  } catch {
-    // ignore
+  } catch (error) {
+    return {
+      modulePath,
+      packageRoot,
+      candidates: dedupeResolvedPaths(candidates),
+      resolvedPath: null,
+      error: formatResolutionError(error),
+    };
   }
-  return null;
+  return {
+    modulePath,
+    packageRoot,
+    candidates: dedupeResolvedPaths(candidates),
+    resolvedPath: null,
+  };
 }
 
 export function buildPluginLoaderJitiOptions(aliasMap: Record<string, string>) {


### PR DESCRIPTION
## Real behavior proof

Behavior addressed:
Packaged plugin runtime resolution no longer fails silently when the package-root marker path is unavailable, and any remaining failure includes loader, package-root, candidate-path, plugin id, runtime property, and plugin source context.

Real environment tested:
Local macOS shell, Node v24.15.0, built and packed OpenClaw from this branch, then installed published `openclaw@2026.5.20` into a fresh temp npm prefix and upgraded that same prefix to the local packed `openclaw@2026.5.25` build.

Exact steps or command run after this patch:
1. `npm install --prefix <temp>/prefix openclaw@2026.5.20`
2. `npm install --prefix <temp>/prefix <repo>/openclaw-2026.5.25.tgz`
3. Loaded a no-secret `proof-channel` plugin from the upgraded package with `loadOpenClawPlugins`; the plugin reads `api.runtime.version` during register and registers a configured channel account.
4. Imported the packed package's generated `server-channels-*` module, created a channel manager, and ran `manager.startChannels()` with startup tracing enabled.

Evidence after fix:
The package-level proof printed:
```json
{
  "baselineVersion": "2026.5.20",
  "patchedVersion": "2026.5.25",
  "loadedPluginStatus": "loaded",
  "loadedChannelIds": ["proof-channel"],
  "registerRuntimeVersion": "2026.5.25",
  "handoff": {
    "accountId": "default",
    "runtimeVersion": "2026.5.25",
    "hasRuntime": true,
    "hasLog": true
  },
  "startupSpans": [
    "channels.proof-channel.start",
    "channels.proof-channel.list-accounts",
    "channels.proof-channel.is-configured",
    "channels.proof-channel.runtime",
    "channels.proof-channel.approval-bootstrap",
    "channels.proof-channel.start-account-handoff"
  ]
}
```

Observed result after fix:
The upgraded packed build resolved the plugin runtime during plugin registration, loaded the no-secret channel, and reached `channels.proof-channel.start-account-handoff` with a runtime object present. The temp install and tarball were cleaned up after the proof.

What was not tested:
I did not use live Discord or Telegram credentials; the proof used an equivalent configured no-secret channel fixture to exercise the same packaged runtime resolution and account-handoff path.

## Summary

- Add structured diagnostics for `resolvePluginRuntimeModulePath`, including loader path, package root, candidates, and resolver errors.
- Add an ancestor candidate fallback so packaged/runtime-cache contexts can still find `dist/plugins/runtime/index.js` even if package-root marker resolution misses.
- Preserve plugin id/property/source context when a plugin triggers lazy runtime resolution and the host runtime module still cannot be found.

## Validation

- `node scripts/run-vitest.mjs src/plugins/sdk-alias.test.ts src/plugins/loader.test.ts src/gateway/server-channels.test.ts`
- `node scripts/run-vitest.mjs src/gateway/server-startup-post-attach.test.ts test/release-check.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/plugins/sdk-alias.ts src/plugins/sdk-alias.test.ts src/plugins/loader.ts src/plugins/registry.ts`
- `pnpm check:changed -- --base upstream/main --head HEAD`
- `pnpm build`
- `node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"` was attempted, but the local Crabbox binary failed its wrapper sanity check: `[crabbox] selected binary failed basic --version/--help sanity checks`.

Closes #86117
