### PR TITLE
fix(browser): reject invalid wait load states

### DIFF
--- a/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts
@@ -64,6 +64,18 @@ describe("browser action input wait command", () => {
       | undefined;
     expect(options?.timeoutMs).toBeGreaterThan(21000);
   });
+
+  it("rejects unsupported load states before sending the wait request", async () => {
+    const program = createActionInputProgram();
+
+    await expect(
+      program.parseAsync(["browser", "wait", "--load", "complete"], { from: "user" }),
+    ).rejects.toThrow("__exit__:1");
+
+    const capture = getBrowserCliRuntimeCapture();
+    expect(capture.runtimeErrors.join("\n")).toContain("Invalid --load value: complete");
+    expect(mocks.callBrowserRequest).not.toHaveBeenCalled();
+  });
 });
 
 describe("browser action input evaluate command", () => {

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.ts
@@ -10,6 +10,21 @@ import {
 } from "./shared.js";
 
 const DEFAULT_WAIT_CONDITION_TIMEOUT_MS = 20000;
+type BrowserWaitLoadState = "load" | "domcontentloaded" | "networkidle";
+
+function parseBrowserWaitLoadState(value: unknown): BrowserWaitLoadState | undefined {
+  const load = normalizeOptionalString(value);
+  switch (load) {
+    case undefined:
+      return undefined;
+    case "load":
+    case "domcontentloaded":
+    case "networkidle":
+      return load;
+    default:
+      throw new Error(`Invalid --load value: ${load}`);
+  }
+}
 
 export function registerBrowserFormWaitEvalCommands(
   browser: Command,
@@ -64,10 +79,7 @@ export function registerBrowserFormWaitEvalCommands(
       const { parent, profile } = resolveBrowserActionContext(cmd, parentOpts);
       try {
         const sel = normalizeOptionalString(selector);
-        const load =
-          opts.load === "load" || opts.load === "domcontentloaded" || opts.load === "networkidle"
-            ? (opts.load as "load" | "domcontentloaded" | "networkidle")
-            : undefined;
+        const load = parseBrowserWaitLoadState(opts.load);
         const timeoutMs = Number.isFinite(opts.timeoutMs) ? opts.timeoutMs : undefined;
         const timeMs = Number.isFinite(opts.time) ? opts.time : undefined;
         const text = normalizeOptionalString(opts.text);


### PR DESCRIPTION
## Summary

- reject unsupported `browser wait --load` values before sending a browser action request
- keep valid load states narrowed to the action contract
- add focused regression coverage for invalid load-state input

## Verification

Behavior addressed: `browser wait --load complete` previously omitted `loadState` and still sent the wait request, so invalid user input was silently ignored.
Real environment tested: local OpenClaw checkout on Node/Vitest runner.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts`; `git diff --check`; `node ../clawpatch/dist/cli.js --state-dir /tmp/clawpatch-openclaw revalidate --finding fnd_sig-feat-cli-command-0029f9d57b-_8c82c9c9b5 --include-dirty --plain`; `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local --parallel-tests "node scripts/run-vitest.mjs extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts"`.
Evidence after fix: focused Vitest file passed 4 tests; clawpatch revalidation marked the original finding fixed; autoreview reported no accepted/actionable findings.
Observed result after fix: unsupported `--load` values now emit `Invalid --load value: <value>`, exit 1, and do not call the browser runtime.
What was not tested: full browser extension suite and live browser gateway interaction.

Additional context: clawpatch reviewed 140 slices and produced 115 raw findings; this PR fixes the high-confidence Browser CLI finding that was small and directly provable.
