### PR TITLE
fix(plugin-sdk): preserve string-const unions as flat enum for deepseek tool schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Plugin SDK: preserve string-const `anyOf`/`oneOf` unions as a flat string `enum` when normalizing tool schemas for the DeepSeek family so Typebox `Type.Union([Type.Literal(...)])` parameters keep every allowed literal instead of collapsing to the first const. (#86468)
 - Update: report the primary malformed `openclaw.extensions` payload error without adding a duplicate missing-main diagnostic. (#86596) Thanks @ferminquant.
 - Control UI: keep host-local Markdown file paths inert while preserving app-relative links. (#86620) Thanks @BryanTegomoh.
 - Gateway: dampen repeated unauthenticated device-required probes per URL while preserving explicit-auth and paired recovery paths. (#86575) Thanks @ferminquant.

--- a/src/plugin-sdk/provider-tools.test.ts
+++ b/src/plugin-sdk/provider-tools.test.ts
@@ -119,6 +119,90 @@ describe("buildProviderToolCompatFamilyHooks", () => {
     ).toStrictEqual([]);
   });
 
+  it("preserves string-const unions as a flat enum for the deepseek family", () => {
+    // Regression for https://github.com/openclaw/openclaw/issues/86468 —
+    // Typebox `Type.Union([Type.Literal(...)])` collapses to anyOf of consts;
+    // the previous normalizer kept only the first const, hiding every other
+    // literal from the model.
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const tools = [
+      {
+        name: "feishu_update_doc",
+        description: "",
+        parameters: {
+          type: "object",
+          properties: {
+            mode: {
+              description: "更新模式（必填）",
+              anyOf: [
+                { const: "overwrite", type: "string" },
+                { const: "append", type: "string" },
+                { const: "replace_range", type: "string" },
+              ],
+            },
+            optional_mode: {
+              anyOf: [
+                { const: "a", type: "string" },
+                { const: "b", type: "string" },
+                { type: "null" },
+              ],
+            },
+            single_const: {
+              anyOf: [{ const: "only", type: "string" }],
+            },
+          },
+          required: ["mode"],
+        },
+      },
+    ] as never;
+
+    const normalized = hooks.normalizeToolSchemas({
+      provider: "deepseek",
+      modelId: "deepseek-v4-pro",
+      modelApi: "openai-completions",
+      model: {
+        provider: "deepseek",
+        api: "openai-completions",
+        id: "deepseek-v4-pro",
+      } as never,
+      tools,
+    });
+
+    expect(normalized[0]?.parameters).toEqual({
+      type: "object",
+      properties: {
+        mode: {
+          description: "更新模式（必填）",
+          type: "string",
+          enum: ["overwrite", "append", "replace_range"],
+        },
+        optional_mode: {
+          type: "string",
+          enum: ["a", "b"],
+          nullable: true,
+        },
+        single_const: {
+          const: "only",
+          type: "string",
+        },
+      },
+      required: ["mode"],
+    });
+    expect(
+      hooks.inspectToolSchemas({
+        provider: "deepseek",
+        modelId: "deepseek-v4-pro",
+        modelApi: "openai-completions",
+        model: {
+          provider: "deepseek",
+          api: "openai-completions",
+          id: "deepseek-v4-pro",
+        } as never,
+        tools: normalized,
+      }),
+    ).toStrictEqual([]);
+  });
+
   it("normalizes parameter-free and typed-object schemas for the openai family", () => {
     const hooks = buildProviderToolCompatFamilyHooks("openai");
     const tools = [

--- a/src/plugin-sdk/provider-tools.ts
+++ b/src/plugin-sdk/provider-tools.ts
@@ -455,6 +455,25 @@ function normalizeDeepSeekSchema(schema: unknown): unknown {
   const variants = record[unionKey] as unknown[];
   const normalizedVariants = variants.map((entry) => normalizeDeepSeekSchema(entry));
   const nonNullVariants = normalizedVariants.filter((entry) => !isNullSchemaVariant(entry));
+  const hasNullVariant = nonNullVariants.length < normalizedVariants.length;
+
+  // Preserve string-const unions as a flat string enum so DeepSeek tool
+  // callers still see every allowed literal. Without this, a Typebox
+  // `Type.Union([Type.Literal("a"), Type.Literal("b"), ...])` collapses to
+  // only the first const and the model can never pick any other value.
+  if (nonNullVariants.length > 1 && nonNullVariants.every((entry) => isStringConstVariant(entry))) {
+    const enumValues = nonNullVariants.map((entry) => (entry as { const: string }).const);
+    const merged: Record<string, unknown> = {
+      ...normalized,
+      type: "string",
+      enum: enumValues,
+    };
+    if (hasNullVariant) {
+      merged.nullable = true;
+    }
+    return merged;
+  }
+
   const selected = nonNullVariants[0] ?? normalizedVariants[0];
   if (!selected || typeof selected !== "object" || Array.isArray(selected)) {
     return normalized;
@@ -464,10 +483,18 @@ function normalizeDeepSeekSchema(schema: unknown): unknown {
     ...(selected as Record<string, unknown>),
     ...normalized,
   };
-  if (nonNullVariants.length < normalizedVariants.length) {
+  if (hasNullVariant) {
     merged.nullable = true;
   }
   return merged;
+}
+
+function isStringConstVariant(entry: unknown): entry is { const: string } {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    return false;
+  }
+  const record = entry as Record<string, unknown>;
+  return typeof record.const === "string";
 }
 
 export function normalizeDeepSeekToolSchemas(


### PR DESCRIPTION
## Summary

Fixes #86468.

`normalizeDeepSeekSchema` in `src/plugin-sdk/provider-tools.ts` collapsed every `anyOf`/`oneOf` union to its first non-null variant. For Typebox-style `Type.Union([Type.Literal("a"), Type.Literal("b"), …])` tool parameters this silently dropped every literal but the first, so DeepSeek-family models could only ever pick the first enum value and any other choice failed validation with `must be equal to constant`.

Detect string-const unions before the existing single-variant fallback and rewrite them as a flat `{ type: "string", enum: [...] }` schema, preserving `nullable: true` when a null variant was part of the union. Single-variant const unions still flow through the original "merge first variant" path so existing nullable-collapse behavior is unchanged.

Closes #86468.

## Change Type

- [x] Bug fix
- [x] Test

## Scope

- [x] Plugin SDK / Provider tool schemas

## Linked Issue

- Closes #86468

## Real behavior proof

**Behavior or issue addressed**: `normalizeDeepSeekSchema` collapsed `anyOf: [{const:"overwrite",type:"string"}, {const:"append",type:"string"}, ...]` (Typebox `Type.Union([Type.Literal(...)])`) down to just `{const:"overwrite",type:"string"}` before sending the tool schema to DeepSeek models, so any model attempting to pick a non-first literal failed with `Validation failed: must be equal to constant`.

**Real environment tested**: macOS Darwin 25.4.0 arm64, Node v22.22.0, openclaw branch `fix/deepseek-const-union-enum` rebased on upstream main commit `c9364f0`. Live invocation of the patched `normalizeDeepSeekToolSchemas` via `node --import tsx` against the exact `feishu_update_doc` tool schema reproduction from #86468.

**Exact steps or command run after this patch**:

1. Built the bug-shaped tool definition from issue #86468 (`mode: anyOf: [{const:"overwrite",type:"string"}, …, {const:"delete_range",type:"string"}]`) plus a nullable variant case.
2. Ran the patched normalizer live in a Node tsx one-liner against the DeepSeek hook to observe the actual schema handed to the model.
3. Confirmed every literal survives as a flat `enum`, and that a union containing `{type:"null"}` adds `nullable: true` while still listing every const.
4. Ran focused regression tests: `node scripts/run-vitest.mjs src/plugin-sdk/provider-tools.test.ts extensions/deepseek/index.test.ts` (20/20 pass).
5. Drift proof: stashed the source patch, kept the new test — new assertion fails because the unfixed code still emits `{const:"a"}` instead of `enum:["a","b"]`; restored the patch and 9/9 pass again.
6. Format, lint, typecheck all clean.

**Evidence after fix**:

Live reproduction of the #86468 input through the patched DeepSeek hook (real terminal output):

```
$ node --import tsx -e "
import { buildProviderToolCompatFamilyHooks } from './src/plugin-sdk/provider-tools.ts';
const hooks = buildProviderToolCompatFamilyHooks('deepseek');
const out = hooks.normalizeToolSchemas({
  provider:'deepseek', modelId:'deepseek-v4-pro', modelApi:'openai-completions',
  model:{provider:'deepseek',api:'openai-completions',id:'deepseek-v4-pro'},
  tools:[{name:'feishu_update_doc',description:'',parameters:{type:'object',properties:{
    mode:{description:'更新模式（必填）',anyOf:[
      {const:'overwrite',type:'string'},{const:'append',type:'string'},
      {const:'replace_range',type:'string'},{const:'replace_all',type:'string'},
      {const:'insert_before',type:'string'},{const:'insert_after',type:'string'},
      {const:'delete_range',type:'string'}]},
    nullable_mode:{anyOf:[{const:'a',type:'string'},{const:'b',type:'string'},{type:'null'}]}
  },required:['mode']}}],
});
console.log(JSON.stringify(out[0].parameters, null, 2));
"

{
  "type": "object",
  "properties": {
    "mode": {
      "description": "更新模式（必填）",
      "type": "string",
      "enum": [
        "overwrite", "append", "replace_range", "replace_all",
        "insert_before", "insert_after", "delete_range"
      ]
    },
    "nullable_mode": {
      "type": "string",
      "enum": ["a", "b"],
      "nullable": true
    }
  },
  "required": ["mode"]
}
```

All 7 modes are now visible to the model. Without this patch the same invocation returned `{"mode":{"description":"更新模式（必填）","const":"overwrite","type":"string"}}` and the other 6 literals were unreachable.

Focused regression tests (20/20 pass) — runtime log from the openclaw repo workspace:

```
$ node scripts/run-vitest.mjs src/plugin-sdk/provider-tools.test.ts extensions/deepseek/index.test.ts

 ✓  unit-fast            ../../src/plugin-sdk/provider-tools.test.ts (9 tests) 4ms
 ✓  extension-providers  ../../extensions/deepseek/index.test.ts (11 tests) 90ms

 Test Files  2 passed (2)
      Tests  20 passed (20)
```

Drift proof — production change reverted, regression test must fail with the pre-patch collapse:

```
$ git stash push -- src/plugin-sdk/provider-tools.ts
Saved working directory and index state WIP on fix/deepseek-const-union-enum

$ node scripts/run-vitest.mjs src/plugin-sdk/provider-tools.test.ts

 ×  preserves string-const unions as a flat enum for the deepseek family
   - "enum": ["a", "b"],
   + "const": "a",
   ...

 Test Files  1 failed (1)
      Tests  1 failed | 8 passed (9)

$ git stash pop
```

Format, lint, typecheck (runtime stdout from the repo):

```
$ pnpm exec oxfmt --check CHANGELOG.md src/plugin-sdk/provider-tools.ts src/plugin-sdk/provider-tools.test.ts
All matched files use the correct format.

$ pnpm exec oxlint src/plugin-sdk/provider-tools.ts src/plugin-sdk/provider-tools.test.ts
Found 0 warnings and 0 errors.

$ node scripts/run-tsgo.mjs -p tsconfig.json && echo OK
OK

$ node scripts/run-tsgo.mjs -p tsconfig.core.json && echo OK
OK
```

**Observed result after fix**: DeepSeek-family tool schemas now expose every string-const literal as a flat `enum`, so models can pick any of the 7 `feishu_update_doc.mode` values (or any other Typebox `Union[Literal]` parameter) without hitting the spurious `must be equal to constant` validation error. Nullable const unions keep `nullable: true` plus the full enum list. Single-variant const unions, plain typed unions, and existing nullable `{type:"string"}|{type:"null"}` collapses are unchanged.

**What was not tested**: live DeepSeek API call — the bug is in local schema normalization that runs before any provider request, and the live one-liner above shows the exact schema now handed to the model. The pre-existing extensions/deepseek provider tests cover the provider integration path.

## Acceptance criteria (from ClawSweeper review)

- [x] `node scripts/run-vitest.mjs src/plugin-sdk/provider-tools.test.ts` — 9/9 pass
- [x] `node scripts/run-vitest.mjs extensions/deepseek/index.test.ts` — 11/11 pass
- [x] `git diff --check` — clean

## Real-behavior-proof policy

```
STATUS: passed
```
