### PR TITLE
fix(canvas): reject invalid snapshot formats

### DIFF
--- a/extensions/canvas/src/cli.test.ts
+++ b/extensions/canvas/src/cli.test.ts
@@ -113,4 +113,21 @@ describe("canvas CLI", () => {
     ).rejects.toThrow(/invalid canvas\.snapshot payload/i);
     expect(writtenFiles).toHaveLength(0);
   });
+
+  it("rejects unsupported snapshot formats before invoking the node", async () => {
+    const program = new Command();
+    program.exitOverride();
+    const nodes = program.command("nodes");
+    const { deps, writtenFiles } = createCanvasCliDeps();
+
+    registerNodesCanvasCommands(nodes, deps);
+
+    await expect(
+      program.parseAsync(["nodes", "canvas", "snapshot", "--node", "ios-node", "--format", "gif"], {
+        from: "user",
+      }),
+    ).rejects.toThrow(/invalid format: gif/i);
+    expect(deps.callGatewayCli).not.toHaveBeenCalled();
+    expect(writtenFiles).toHaveLength(0);
+  });
 });

--- a/extensions/canvas/src/cli.ts
+++ b/extensions/canvas/src/cli.ts
@@ -68,6 +68,20 @@ export type CanvasCliDependencies = {
 };
 
 type CanvasNodeCandidate = NodeMatchCandidate;
+type CanvasSnapshotRequestFormat = "png" | "jpeg";
+
+function parseCanvasSnapshotRequestFormat(raw: unknown): CanvasSnapshotRequestFormat {
+  const format = normalizeLowercaseStringOrEmpty(normalizeOptionalString(raw) ?? "jpg");
+  switch (format) {
+    case "png":
+      return "png";
+    case "jpg":
+    case "jpeg":
+      return "jpeg";
+    default:
+      throw new Error(`invalid format: ${String(raw)} (expected png|jpg|jpeg)`);
+  }
+}
 
 function parseTimeoutMs(raw: unknown): number | undefined {
   if (raw === undefined || raw === null) {
@@ -234,19 +248,11 @@ export function registerNodesCanvasCommands(nodes: Command, deps: CanvasCliDepen
       .option("--invoke-timeout <ms>", "Node invoke timeout in ms (default 20000)", "20000")
       .action(async (opts: CanvasNodesRpcOpts) => {
         await deps.runNodesCommand("canvas snapshot", async () => {
-          const formatOpt = normalizeLowercaseStringOrEmpty(
-            normalizeOptionalString(opts.format) ?? "jpg",
-          );
-          const formatForParams =
-            formatOpt === "jpg" ? "jpeg" : formatOpt === "jpeg" ? "jpeg" : "png";
-          if (formatForParams !== "png" && formatForParams !== "jpeg") {
-            throw new Error(`invalid format: ${String(opts.format)} (expected png|jpg|jpeg)`);
-          }
-
+          const format = parseCanvasSnapshotRequestFormat(opts.format);
           const maxWidth = opts.maxWidth ? Number.parseInt(opts.maxWidth, 10) : undefined;
           const quality = opts.quality ? Number.parseFloat(opts.quality) : undefined;
           const raw = await invokeCanvas(deps, opts, "canvas.snapshot", {
-            format: formatForParams,
+            format,
             maxWidth: Number.isFinite(maxWidth) ? maxWidth : undefined,
             quality: Number.isFinite(quality) ? quality : undefined,
           });


### PR DESCRIPTION
## Summary

- reject unsupported `nodes canvas snapshot --format` values before invoking the node
- keep `jpg`/`jpeg` normalized to the `jpeg` request contract and `png` as-is
- add focused regression coverage for invalid snapshot format input

## Verification

Behavior addressed: `nodes canvas snapshot --format gif` previously normalized to `png`, so invalid user input silently changed the requested snapshot format and still invoked the node.
Real environment tested: local OpenClaw checkout on Node/Vitest runner.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/canvas/src/cli.test.ts`; `git diff --check`; `node ../clawpatch/dist/cli.js --state-dir /tmp/clawpatch-openclaw revalidate --finding fnd_sig-feat-cli-command-f0d473e0a9-_bdc589d008 --include-dirty --plain`; `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local --parallel-tests "node scripts/run-vitest.mjs extensions/canvas/src/cli.test.ts"`.
Evidence after fix: focused Vitest file passed 3 tests; clawpatch revalidation marked the original finding fixed; autoreview reported no accepted/actionable findings.
Observed result after fix: unsupported `--format` values now throw `invalid format: <value> (expected png|jpg|jpeg)` before `node.invoke` and before writing snapshot output.
What was not tested: full Canvas plugin suite and live paired-node snapshot capture.

Additional context: clawpatch reviewed 140 slices and produced 115 raw findings; this PR fixes a high-confidence Canvas CLI finding that was small and directly provable.
