### PR TITLE
fix(matrix): reject malformed integer cli values

### DIFF
--- a/extensions/matrix/src/cli.test.ts
+++ b/extensions/matrix/src/cli.test.ts
@@ -386,6 +386,20 @@ describe("matrix CLI verification commands", () => {
     expect(consoleLogMock).toHaveBeenCalledWith("Backup: active and trusted on this device");
   });
 
+  it("rejects malformed Matrix self-verification timeout values", async () => {
+    const program = buildProgram();
+
+    await program.parseAsync(["matrix", "verify", "self", "--timeout-ms", "5000ms"], {
+      from: "user",
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(consoleErrorMock).toHaveBeenCalledWith(
+      "Self-verification failed: --timeout-ms must be an integer",
+    );
+    expect(runMatrixSelfVerificationMock).not.toHaveBeenCalled();
+  });
+
   it("requests Matrix self-verification and prints the follow-up SAS commands", async () => {
     requestMatrixVerificationMock.mockResolvedValue(
       mockMatrixVerificationSummary({

--- a/extensions/matrix/src/cli.ts
+++ b/extensions/matrix/src/cli.ts
@@ -234,6 +234,9 @@ function parseOptionalInt(value: string | undefined, fieldName: string): number 
   if (!trimmed) {
     return undefined;
   }
+  if (!/^-?\d+$/.test(trimmed)) {
+    throw new Error(`${fieldName} must be an integer`);
+  }
   const parsed = Number.parseInt(trimmed, 10);
   if (!Number.isFinite(parsed)) {
     throw new Error(`${fieldName} must be an integer`);


### PR DESCRIPTION
## Summary

- reject malformed Matrix CLI integer options instead of partially parsing them
- prevent `--timeout-ms 5000ms` from reaching the self-verification runner as `5000`
- add focused regression coverage for malformed timeout input

## Verification

Behavior addressed: Matrix CLI integer parsing used `Number.parseInt`, so malformed values such as `5000ms` were silently truncated and accepted.
Real environment tested: local OpenClaw checkout on Node/Vitest runner.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/matrix/src/cli.test.ts`; `git diff --check`; `node ../clawpatch/dist/cli.js --state-dir /tmp/clawpatch-openclaw revalidate --finding fnd_sig-feat-cli-command-fe5fbd806b-_f9ecba4c13 --include-dirty --plain`; `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local --parallel-tests "node scripts/run-vitest.mjs extensions/matrix/src/cli.test.ts"`.
Evidence after fix: focused Matrix CLI Vitest file passed 50 tests; clawpatch revalidation marked the original finding fixed; autoreview reported no accepted/actionable findings.
Observed result after fix: malformed integer strings now report `<field> must be an integer`, set exit code 1, and do not invoke the Matrix self-verification runner.
What was not tested: live Matrix self-verification against a homeserver.

Additional context: clawpatch reviewed 140 slices and produced 115 raw findings; this PR fixes a high-confidence Matrix CLI parsing finding that was small and directly provable.
