### PR TITLE
fix(control-ui): support raw edits from editable config

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1198,7 +1198,10 @@ export function renderApp(state: AppViewState) {
     gatewayUrl: state.settings.gatewayUrl,
     assistantName: state.assistantName,
     configPath: state.configSnapshot?.path ?? null,
-    rawAvailable: typeof state.configSnapshot?.raw === "string",
+    rawAvailable:
+      typeof state.configSnapshot?.raw === "string" ||
+      !!state.configSnapshot?.config ||
+      !!state.configForm,
   } satisfies Omit<
     ConfigProps,
     | "formMode"

--- a/ui/src/ui/controllers/config.test.ts
+++ b/ui/src/ui/controllers/config.test.ts
@@ -183,7 +183,7 @@ describe("applyConfigSnapshot", () => {
     expect(state.configDraftBaseHash).toBe("hash-remote");
   });
 
-  it("forces form mode when the snapshot does not include raw text", () => {
+  it("keeps raw mode when editable config can be serialized without raw text", () => {
     const state = createState();
     state.configFormMode = "raw";
 
@@ -195,7 +195,7 @@ describe("applyConfigSnapshot", () => {
       raw: null,
     });
 
-    expect(state.configFormMode).toBe("form");
+    expect(state.configFormMode).toBe("raw");
     expect(state.configRaw).toBe('{\n  "gateway": {\n    "mode": "local"\n  }\n}\n');
   });
 });
@@ -707,6 +707,29 @@ describe("applyConfig", () => {
 });
 
 describe("saveConfig", () => {
+  it("submits generated raw text when the snapshot did not include raw text", async () => {
+    const request = createRequestWithConfigGet();
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+    state.configFormMode = "raw";
+    applyConfigSnapshot(state, {
+      hash: "hash-generated-raw",
+      sourceConfig: { gateway: { mode: "local" } },
+      config: { gateway: { mode: "local", runtimeOnly: true } },
+      valid: true,
+      issues: [],
+      raw: null,
+    });
+
+    await saveConfig(state);
+
+    expect(request).toHaveBeenCalledWith("config.set", {
+      raw: '{\n  "gateway": {\n    "mode": "local"\n  }\n}\n',
+      baseHash: "hash-generated-raw",
+    });
+  });
+
   it("submits the original draft base hash after a dirty config refresh", async () => {
     const request = createRequestWithConfigGet();
     const state = createState();

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -113,7 +113,7 @@ export function applyConfigSnapshot(
   const draftBaseHash = state.configDraftBaseHash ?? state.configSnapshot?.hash ?? null;
   state.configSnapshot = snapshot;
   const editableConfig = resolveEditableSnapshotConfig(snapshot);
-  const rawAvailable = typeof snapshot.raw === "string";
+  const rawAvailable = typeof snapshot.raw === "string" || !!editableConfig || !!state.configForm;
   if (!rawAvailable && state.configFormMode === "raw") {
     state.configFormMode = "form";
   }
@@ -161,9 +161,6 @@ function asJsonSchema(value: unknown): JsonSchema | null {
  * gateway's Zod validation always sees correctly typed values.
  */
 function serializeFormForSubmit(state: ConfigState): string {
-  if (state.configFormMode === "raw" && typeof state.configSnapshot?.raw !== "string") {
-    throw new Error("Raw config editing is unavailable for this snapshot. Switch to Form mode.");
-  }
   if (state.configFormMode !== "form" || !state.configForm) {
     return state.configRaw;
   }


### PR DESCRIPTION
## What changed

- Keeps Control UI Raw config mode available when a config snapshot has editable structured config but no raw text payload.
- Allows that generated raw text to be submitted through `config.set` / `config.apply`.
- Adds controller regression coverage for both staying in Raw mode and saving generated raw text from a `raw: null` snapshot.

Supersedes #86640 and #86641. Those split PRs were not independently safe because raw-mode visibility and raw-mode submit eligibility need to change together.

## Why

The gateway can return redacted config snapshots where `raw` is missing or null while editable structured config is still available through `sourceConfig`, `resolved`, or `config`. `applyConfigSnapshot` already serializes that editable config into `configRaw`.

Before this change, the UI could only treat Raw mode as available when the snapshot originally included raw text. If only structured config was available, Raw mode was forced off even though serializable raw text existed. The submit guard had the same mismatch and rejected generated raw drafts.

This keeps availability, rendering, and submit behavior aligned around the same editable-snapshot behavior.

## Real behavior proof

- **Behavior or issue addressed**: The live Control UI keeps Raw config mode available for an editable snapshot without raw text, and the generated raw text can be submitted with the live snapshot base hash.
- **Real environment tested**: WSL Ubuntu 24.04 local OpenClaw setup, `OpenClaw 2026.5.25`, token-authenticated Control UI at `http://127.0.0.1:18789/config`, backed by running OpenClaw gateway processes from `/home/icon/CodexOps/OpenClaw/dist/index.js`.
- **Exact steps or command run after this patch**: Loaded the token-authenticated Control UI in headless Chrome, opened Settings -> Advanced -> Raw, inspected the live `openclaw-app` state, staged a raw-mode draft, clicked Save, and intercepted the browser client request to inspect the outgoing payload without mutating the real config file.
- **Evidence after fix**:

```text
title=OpenClaw Control
url=http://127.0.0.1:18789/config
containsConfig=true
live state: snapshotRawIsString=false, snapshotRawType=object, hasSourceConfig=true, hasConfig=true, generatedRawLength=25322
rendered buttons: Form disabled=false, Raw disabled=false, Save disabled=true, Apply disabled=true

livePageBefore={"mode":"raw","snapshotRawIsString":false,"snapshotRawType":"object","hasSourceConfig":true,"hasConfig":true,"generatedRawLength":25322,"hashPrefix":"78b0f6f64637"}
capturedRequests=[{"method":"config.set","rawLength":25323,"rawPrefix":"{\n  \"meta\": {\n    \"lastTouchedVersion\": ","baseHashMatches":true},{"method":"config.get","rawLength":null,"rawPrefix":null,"baseHashMatches":false}]
```

- **Observed result after fix**: Raw mode was selectable even though the snapshot did not contain raw text. Clicking Save produced a `config.set` request containing generated raw text and the live snapshot base hash. The request was intercepted only to avoid modifying the local operator config during proof capture.
- **What was not tested**: No live config file write was allowed during proof capture; the payload and base hash were verified before network mutation.

## Validation

- `../node_modules/.bin/vitest run --config vitest.config.ts src/ui/controllers/config.test.ts` from `ui/`
