### PR TITLE
perf: speed up usage cost lookups

### DIFF
--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../gateway/model-pricing-cache-state.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
+import * as usageFormat from "../utils/usage-format.js";
 import {
   discoverAllSessions,
   loadCostUsageSummary,
@@ -147,6 +148,52 @@ describe("session cost usage", () => {
       expect(summary.totals.totalTokens).toBe(50);
       expect(summary.totals.totalCost).toBeCloseTo(0.03003, 5);
     });
+  });
+
+  it("reuses resolved model costs while scanning repeated session usage entries", async () => {
+    const root = await makeSessionCostRoot("cost-resolver-cache");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-1.jsonl");
+    const now = new Date().toISOString();
+    const entries = Array.from({ length: 12 }, () => ({
+      type: "message",
+      timestamp: now,
+      message: {
+        role: "assistant",
+        provider: "openai",
+        model: "gpt-5.4",
+        usage: { input: 10, output: 20, totalTokens: 30 },
+      },
+    }));
+    await fs.writeFile(sessionFile, entries.map((entry) => JSON.stringify(entry)).join("\n"));
+
+    const config = {
+      models: {
+        providers: {
+          openai: {
+            models: [
+              {
+                id: "gpt-5.4",
+                cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const costSpy = vi.spyOn(usageFormat, "resolveModelCostConfig");
+    try {
+      await withStateDir(root, async () => {
+        const summary = await loadCostUsageSummary({ days: 30, config });
+        expect(summary.totals.totalTokens).toBe(360);
+        expect(summary.totals.totalCost).toBeCloseTo(0.0006, 8);
+      });
+      expect(costSpy.mock.calls.length).toBeLessThanOrEqual(2);
+    } finally {
+      costSpy.mockRestore();
+    }
   });
 
   it("counts token usage for an unpriced (unconfigured all-zero) model as missing, not a confident $0", async () => {

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -1033,6 +1033,24 @@ const isModelPricingKnown = (cost: ReturnType<typeof resolveModelCostConfig>): b
   return cost.input > 0 || cost.output > 0 || cost.cacheRead > 0 || cost.cacheWrite > 0;
 };
 
+type UsageCostResolver = (params: {
+  provider?: string;
+  model?: string;
+}) => ReturnType<typeof resolveModelCostConfig>;
+
+function createUsageCostResolver(config?: OpenClawConfig): UsageCostResolver {
+  const cache = new Map<string, ReturnType<typeof resolveModelCostConfig>>();
+  return ({ provider, model }) => {
+    const key = `${provider ?? ""}\0${model ?? ""}`;
+    if (cache.has(key)) {
+      return cache.get(key);
+    }
+    const cost = resolveModelCostConfig({ provider, model, config });
+    cache.set(key, cost);
+    return cost;
+  };
+}
+
 async function canReadJsonlFromOffset(filePath: string, startOffset: number): Promise<boolean> {
   if (startOffset <= 0) {
     return true;
@@ -1092,10 +1110,12 @@ async function* readJsonlRecords(
 async function scanTranscriptFile(params: {
   filePath: string;
   config?: OpenClawConfig;
+  resolveCost?: UsageCostResolver;
   startOffset?: number;
   endOffset?: number;
   onEntry: (entry: ParsedTranscriptEntry) => void;
 }): Promise<void> {
+  const resolveCost = params.resolveCost ?? createUsageCostResolver(params.config);
   for await (const parsed of readJsonlRecords(
     params.filePath,
     params.startOffset,
@@ -1107,10 +1127,9 @@ async function scanTranscriptFile(params: {
     }
 
     if (entry.usage) {
-      const cost = resolveModelCostConfig({
+      const cost = resolveCost({
         provider: entry.provider,
         model: entry.model,
-        config: params.config,
       });
       if (cost?.tieredPricing && cost.tieredPricing.length > 0) {
         // When tiered pricing is configured, always recompute to override
@@ -1146,6 +1165,7 @@ async function scanTranscriptFile(params: {
 async function scanUsageFile(params: {
   filePath: string;
   config?: OpenClawConfig;
+  resolveCost?: UsageCostResolver;
   startOffset?: number;
   endOffset?: number;
   onEntry: (entry: ParsedUsageEntry) => void;
@@ -1153,6 +1173,7 @@ async function scanUsageFile(params: {
   await scanTranscriptFile({
     filePath: params.filePath,
     config: params.config,
+    resolveCost: params.resolveCost,
     startOffset: params.startOffset,
     endOffset: params.endOffset,
     onEntry: (entry) => {
@@ -1260,6 +1281,7 @@ export async function loadCostUsageSummary(params?: {
 
   const dailyMap = new Map<string, CostUsageTotals>();
   const totals = emptyTotals();
+  const resolveCost = createUsageCostResolver(params?.config);
 
   const sessionsDir = resolveSessionTranscriptsDirForAgent(params?.agentId);
   const entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true }).catch(() => []);
@@ -1286,6 +1308,7 @@ export async function loadCostUsageSummary(params?: {
     await scanUsageFile({
       filePath,
       config: params?.config,
+      resolveCost,
       onEntry: (entry) => {
         const ts = entry.timestamp?.getTime();
         if (!ts || ts < sinceTime || ts > untilTime) {
@@ -1329,6 +1352,7 @@ export async function loadCostUsageSummary(params?: {
 async function scanUsageFileForCache(params: {
   file: UsageCostTranscriptFile;
   config?: OpenClawConfig;
+  resolveCost?: UsageCostResolver;
   previous?: UsageCostCacheFileEntry;
   includeSessionSummary?: boolean;
 }): Promise<UsageCostCacheFileEntry> {
@@ -1364,6 +1388,7 @@ async function scanUsageFileForCache(params: {
   await scanTranscriptFile({
     filePath: params.file.filePath,
     config: params.config,
+    resolveCost: params.resolveCost,
     startOffset,
     endOffset: params.file.size,
     onEntry: (entry) => {
@@ -1519,11 +1544,13 @@ export async function refreshCostUsageCache(params?: {
         return aSession - bSession || a.size - b.size || a.filePath.localeCompare(b.filePath);
       })
       .slice(0, maxFiles);
+    const resolveCost = createUsageCostResolver(params?.config);
 
     for (const file of staleFiles) {
       cache.files[file.filePath] = await scanUsageFileForCache({
         file,
         config: params?.config,
+        resolveCost,
         previous: cache.files[file.filePath],
         includeSessionSummary: sessionSummaryFiles.has(file.filePath),
       });
@@ -1975,10 +2002,12 @@ export async function loadSessionCostSummary(params: {
   const latencyValues: number[] = [];
   let lastUserTimestamp: number | undefined;
   const MAX_LATENCY_MS = 12 * 60 * 60 * 1000;
+  const resolveCost = createUsageCostResolver(params.config);
 
   await scanTranscriptFile({
     filePath: sessionFile,
     config: params.config,
+    resolveCost,
     onEntry: (entry) => {
       const ts = entry.timestamp?.getTime();
 
@@ -2264,10 +2293,12 @@ export async function loadSessionUsageTimeSeries(params: {
   const points: SessionUsageTimePoint[] = [];
   let cumulativeTokens = 0;
   let cumulativeCost = 0;
+  const resolveCost = createUsageCostResolver(params.config);
 
   await scanUsageFile({
     filePath: sessionFile,
     config: params.config,
+    resolveCost,
     onEntry: (entry) => {
       const ts = entry.timestamp?.getTime();
       if (!ts) {
@@ -2374,6 +2405,7 @@ export async function loadSessionLogs(params: {
     }
   }
   const limit = params.limit ?? 50;
+  const resolveCost = createUsageCostResolver(params.config);
 
   for await (const parsed of readJsonlRecords(sessionFile)) {
     try {
@@ -2488,10 +2520,9 @@ export async function loadSessionLogs(params: {
           if (breakdown?.total !== undefined) {
             cost = breakdown.total;
           } else {
-            const costConfig = resolveModelCostConfig({
+            const costConfig = resolveCost({
               provider: message.provider as string | undefined,
               model: message.model as string | undefined,
-              config: params.config,
             });
             cost = estimateUsageCost({ usage, cost: costConfig });
           }

--- a/src/utils/usage-format.test.ts
+++ b/src/utils/usage-format.test.ts
@@ -1,3 +1,4 @@
+import nodeFs from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -14,6 +15,7 @@ import {
   formatTokenCount,
   formatUsd,
   resolveModelCostConfig,
+  resolveModelCostConfigFingerprint,
   type PricingTier,
 } from "./usage-format.js";
 
@@ -359,6 +361,295 @@ describe("usage-format", () => {
     ).toBe(9);
   });
 
+  it("observes structural config pricing changes after a cached lookup", () => {
+    const models = [
+      {
+        id: "demo-model",
+        cost: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4 },
+      },
+    ];
+    const config = {
+      models: {
+        providers: {
+          "demo-structural": { models },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(
+      resolveModelCostConfig({
+        provider: "demo-structural",
+        model: "demo-model",
+        config,
+      })?.input,
+    ).toBe(1);
+
+    models.push({
+      id: "new-model",
+      cost: { input: 5, output: 6, cacheRead: 7, cacheWrite: 8 },
+    });
+    expect(
+      resolveModelCostConfig({
+        provider: "demo-structural",
+        model: "new-model",
+        config,
+      })?.input,
+    ).toBe(5);
+
+    models.splice(0, 1);
+    expect(
+      resolveModelCostConfig({
+        provider: "demo-structural",
+        model: "demo-model",
+        config,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("observes replaced config cost objects after a cached lookup", () => {
+    const model = {
+      id: "demo-model",
+      cost: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4 },
+    };
+    const config = {
+      models: {
+        providers: {
+          "demo-replaced-cost": { models: [model] },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(
+      resolveModelCostConfig({
+        provider: "demo-replaced-cost",
+        model: "demo-model",
+        config,
+      })?.input,
+    ).toBe(1);
+
+    model.cost = { input: 9, output: 8, cacheRead: 7, cacheWrite: 6 };
+
+    expect(
+      resolveModelCostConfig({
+        provider: "demo-replaced-cost",
+        model: "demo-model",
+        config,
+      })?.input,
+    ).toBe(9);
+  });
+
+  it("ignores malformed raw tier ranges while caching config pricing", () => {
+    const config = {
+      models: {
+        providers: {
+          "demo-bad-tier": {
+            models: [
+              {
+                id: "demo-model",
+                cost: {
+                  input: 1,
+                  output: 2,
+                  cacheRead: 3,
+                  cacheWrite: 4,
+                  tieredPricing: [
+                    { input: 5, output: 6, cacheRead: 7, cacheWrite: 8, range: undefined },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(
+      resolveModelCostConfig({
+        provider: "demo-bad-tier",
+        model: "demo-model",
+        config,
+      }),
+    ).toEqual({
+      input: 1,
+      output: 2,
+      cacheRead: 3,
+      cacheWrite: 4,
+    });
+  });
+
+  it("skips metadata-only model rows while caching configured pricing", async () => {
+    const metadataOnlyModel = { id: "metadata-only" } as {
+      id: string;
+      cost?: { input: number; output: number; cacheRead: number; cacheWrite: number };
+    };
+    const config = {
+      models: {
+        providers: {
+          "demo-metadata-row": {
+            models: [
+              metadataOnlyModel,
+              {
+                id: "priced-model",
+                cost: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4 },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(
+      resolveModelCostConfig({
+        provider: "demo-metadata-row",
+        model: "metadata-only",
+        config,
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveModelCostConfig({
+        provider: "demo-metadata-row",
+        model: "priced-model",
+        config,
+      })?.input,
+    ).toBe(1);
+
+    metadataOnlyModel.cost = { input: 9, output: 8, cacheRead: 7, cacheWrite: 6 };
+    expect(
+      resolveModelCostConfig({
+        provider: "demo-metadata-row",
+        model: "metadata-only",
+        config,
+      })?.input,
+    ).toBe(9);
+
+    await fs.writeFile(
+      path.join(agentDir, "models.json"),
+      JSON.stringify({
+        providers: {
+          "demo-metadata-json": {
+            models: [
+              { id: "metadata-only" },
+              {
+                id: "priced-model",
+                cost: { input: 5, output: 6, cacheRead: 7, cacheWrite: 8 },
+              },
+            ],
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    expect(
+      resolveModelCostConfig({
+        provider: "demo-metadata-json",
+        model: "priced-model",
+      })?.input,
+    ).toBe(5);
+  });
+
+  it("updates pricing fingerprints when metadata-only model rows gain pricing", () => {
+    const metadataOnlyModel = { id: "metadata-only" } as {
+      id: string;
+      cost?: { input: number; output: number; cacheRead: number; cacheWrite: number };
+    };
+    const config = {
+      models: {
+        providers: {
+          "demo-metadata-fingerprint": {
+            models: [metadataOnlyModel],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const before = resolveModelCostConfigFingerprint(config);
+    metadataOnlyModel.cost = { input: 9, output: 8, cacheRead: 7, cacheWrite: 6 };
+    const after = resolveModelCostConfigFingerprint(config);
+
+    expect(after).not.toBe(before);
+    expect(
+      resolveModelCostConfig({
+        provider: "demo-metadata-fingerprint",
+        model: "metadata-only",
+        config,
+      })?.input,
+    ).toBe(9);
+  });
+
+  it("retries models.json after an initial missing read", async () => {
+    expect(
+      resolveModelCostConfig({
+        provider: "demo-late",
+        model: "demo-model",
+      }),
+    ).toBeUndefined();
+
+    await fs.writeFile(
+      path.join(agentDir, "models.json"),
+      JSON.stringify({
+        providers: {
+          "demo-late": {
+            models: [
+              {
+                id: "demo-model",
+                cost: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4 },
+              },
+            ],
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    expect(
+      resolveModelCostConfig({
+        provider: "demo-late",
+        model: "demo-model",
+      })?.input,
+    ).toBe(1);
+  });
+
+  it("does not poll models.json stats after the process-local cost index is loaded", async () => {
+    await fs.writeFile(
+      path.join(agentDir, "models.json"),
+      JSON.stringify({
+        providers: {
+          "demo-stat": {
+            models: [
+              {
+                id: "demo-model",
+                cost: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4 },
+              },
+            ],
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    expect(
+      resolveModelCostConfig({
+        provider: "demo-stat",
+        model: "demo-model",
+      })?.input,
+    ).toBe(1);
+
+    const statSpy = vi.spyOn(nodeFs, "statSync");
+    try {
+      for (let i = 0; i < 20; i += 1) {
+        expect(
+          resolveModelCostConfig({
+            provider: "demo-stat",
+            model: "demo-model",
+          })?.input,
+        ).toBe(1);
+      }
+      expect(statSpy).not.toHaveBeenCalled();
+    } finally {
+      statSpy.mockRestore();
+    }
+  });
+
   // -----------------------------------------------------------------------
   // Tiered pricing tests
   // -----------------------------------------------------------------------
@@ -520,6 +811,19 @@ describe("usage-format", () => {
     });
 
     expect(total).toBeCloseTo(0.00075, 8);
+  });
+
+  it("reuses sorted tier order for repeated estimates", () => {
+    const tiers: PricingTier[] = [
+      { input: 1, output: 10, cacheRead: 0, cacheWrite: 0, range: [100, 200] },
+      { input: 2, output: 20, cacheRead: 0, cacheWrite: 0, range: [0, 100] },
+    ];
+    const tierSortSpy = vi.spyOn(tiers, "toSorted");
+    const cost = { input: 1, output: 10, cacheRead: 0, cacheWrite: 0, tieredPricing: tiers };
+
+    expect(estimateUsageCost({ usage: { input: 150, output: 60 }, cost })).toBeCloseTo(0.00075, 8);
+    expect(estimateUsageCost({ usage: { input: 50, output: 60 }, cost })).toBeCloseTo(0.0013, 8);
+    expect(tierSortSpy).toHaveBeenCalledTimes(1);
   });
 
   it("bills malformed tier gaps at a whole-request fallback tier", () => {

--- a/src/utils/usage-format.ts
+++ b/src/utils/usage-format.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import path from "node:path";
 import { resolveDefaultAgentDir } from "../agents/agent-scope-config.js";
 import { modelKey, normalizeModelRef, normalizeProviderId } from "../agents/model-selection.js";
@@ -57,25 +56,43 @@ export type UsageTotals = {
 
 type ModelsJsonCostCache = {
   path: string;
-  mtimeMs: number;
   providers: Record<string, ModelProviderConfig> | undefined;
   normalizedEntries: Map<string, ModelCostConfig> | null;
   rawEntries: Map<string, ModelCostConfig> | null;
 };
 
 type ProviderCostIndexCacheEntry = {
+  normalizedEntries?: ProviderCostIndex;
+  rawEntries?: ProviderCostIndex;
+};
+
+type ProviderCostIndexSource = {
   fingerprint: string;
-  normalizedEntries?: Map<string, ModelCostConfig>;
-  rawEntries?: Map<string, ModelCostConfig>;
+  model: NonNullable<ModelProviderConfig["models"]>[number];
+  providerKey: string;
+  rawCost: RawModelCostConfig;
+};
+
+type ProviderCostIndex = {
+  entries: Map<string, ModelCostConfig>;
+  sources: Map<string, ProviderCostIndexSource>;
+  structureFingerprint: string;
+};
+
+type RawModelCostConfig = Omit<ModelCostConfig, "tieredPricing"> & {
+  tieredPricing?: RawPricingTier[];
 };
 
 const EMPTY_PROVIDER_COST_INDEX = new Map<string, ModelCostConfig>();
+const MODEL_KEY_CACHE_LIMIT = 4096;
 
 let modelsJsonCostCache: ModelsJsonCostCache | null = null;
 let providerCostIndexByConfig = new WeakMap<
   Record<string, ModelProviderConfig>,
   ProviderCostIndexCacheEntry
 >();
+let modelKeyCache = new Map<string, string | null>();
+let sortedPricingTiersByInput = new WeakMap<PricingTier[], PricingTier[]>();
 
 export function formatTokenCount(value?: number): string {
   if (value === undefined || !Number.isFinite(value)) {
@@ -114,25 +131,51 @@ function toResolvedModelKey(params: {
   model?: string;
   allowPluginNormalization?: boolean;
 }): string | null {
+  const cacheKey = [
+    "resolved",
+    params.allowPluginNormalization === false ? "raw" : "default",
+    params.provider ?? "",
+    params.model ?? "",
+  ].join("\0");
+  if (modelKeyCache.has(cacheKey)) {
+    return modelKeyCache.get(cacheKey) ?? null;
+  }
   const provider = normalizeOptionalString(params.provider);
   const model = normalizeOptionalString(params.model);
   if (!provider || !model) {
+    cacheModelKey(cacheKey, null);
     return null;
   }
   const normalized = normalizeModelRef(provider, model, {
     allowManifestNormalization: params.allowPluginNormalization === false ? false : undefined,
     allowPluginNormalization: params.allowPluginNormalization,
   });
-  return modelKey(normalized.provider, normalized.model);
+  const key = modelKey(normalized.provider, normalized.model);
+  cacheModelKey(cacheKey, key);
+  return key;
 }
 
 function toDirectModelKey(params: { provider?: string; model?: string }): string | null {
+  const cacheKey = ["direct", params.provider ?? "", params.model ?? ""].join("\0");
+  if (modelKeyCache.has(cacheKey)) {
+    return modelKeyCache.get(cacheKey) ?? null;
+  }
   const provider = normalizeProviderId(normalizeOptionalString(params.provider) ?? "");
   const model = normalizeOptionalString(params.model);
   if (!provider || !model) {
+    cacheModelKey(cacheKey, null);
     return null;
   }
-  return modelKey(provider, model);
+  const key = modelKey(provider, model);
+  cacheModelKey(cacheKey, key);
+  return key;
+}
+
+function cacheModelKey(cacheKey: string, key: string | null): void {
+  if (modelKeyCache.size >= MODEL_KEY_CACHE_LIMIT) {
+    modelKeyCache.clear();
+  }
+  modelKeyCache.set(cacheKey, key);
 }
 
 function shouldUseNormalizedCostLookup(params: { provider?: string; model?: string }): boolean {
@@ -185,13 +228,47 @@ function normalizeTieredPricing(raw: RawPricingTier[] | undefined): PricingTier[
   return result.length > 0 ? result.toSorted((a, b) => a.range[0] - b.range[0]) : undefined;
 }
 
-function buildProviderCostIndex(
+function normalizeModelCostConfig(cost: RawModelCostConfig): ModelCostConfig {
+  const normalizedTiers = normalizeTieredPricing(cost.tieredPricing);
+  return {
+    input: cost.input,
+    output: cost.output,
+    cacheRead: cost.cacheRead,
+    cacheWrite: cost.cacheWrite,
+    ...(normalizedTiers ? { tieredPricing: normalizedTiers } : {}),
+  };
+}
+
+function isRawModelCostConfig(value: unknown): value is RawModelCostConfig {
+  return value !== null && typeof value === "object";
+}
+
+function buildProviderCostStructureFingerprint(
+  providers: Record<string, ModelProviderConfig> | undefined,
+): string {
+  if (!providers) {
+    return "";
+  }
+  return Object.entries(providers)
+    .toSorted(([a], [b]) => a.localeCompare(b))
+    .flatMap(([providerKey, providerConfig]) =>
+      (providerConfig?.models ?? []).map(
+        (model) =>
+          `${providerKey}\0${model.id}\0${isRawModelCostConfig(model.cost) ? "cost" : "metadata"}`,
+      ),
+    )
+    .join("\0");
+}
+
+function buildProviderCostIndexBundle(
   providers: Record<string, ModelProviderConfig> | undefined,
   options?: { allowManifestNormalization?: boolean; allowPluginNormalization?: boolean },
-): Map<string, ModelCostConfig> {
+): ProviderCostIndex {
   const entries = new Map<string, ModelCostConfig>();
+  const sources = new Map<string, ProviderCostIndexSource>();
+  const structureFingerprint = buildProviderCostStructureFingerprint(providers);
   if (!providers) {
-    return entries;
+    return { entries, sources, structureFingerprint };
   }
   for (const [providerKey, providerConfig] of Object.entries(providers)) {
     const normalizedProvider = normalizeProviderId(providerKey);
@@ -202,19 +279,28 @@ function buildProviderCostIndex(
           (options?.allowPluginNormalization === false ? false : undefined),
         allowPluginNormalization: options?.allowPluginNormalization,
       });
-      const cost = { ...model.cost };
-      const normalizedTiers = normalizeTieredPricing(cost.tieredPricing);
-      const costConfig: ModelCostConfig = {
-        input: cost.input,
-        output: cost.output,
-        cacheRead: cost.cacheRead,
-        cacheWrite: cost.cacheWrite,
-        ...(normalizedTiers ? { tieredPricing: normalizedTiers } : {}),
-      };
-      entries.set(modelKey(normalized.provider, normalized.model), costConfig);
+      const key = modelKey(normalized.provider, normalized.model);
+      if (!isRawModelCostConfig(model.cost)) {
+        continue;
+      }
+      const rawCost = model.cost;
+      entries.set(key, normalizeModelCostConfig(rawCost));
+      sources.set(key, {
+        fingerprint: buildModelCostFingerprint(rawCost),
+        model,
+        providerKey,
+        rawCost,
+      });
     }
   }
-  return entries;
+  return { entries, sources, structureFingerprint };
+}
+
+function buildProviderCostIndex(
+  providers: Record<string, ModelProviderConfig> | undefined,
+  options?: { allowManifestNormalization?: boolean; allowPluginNormalization?: boolean },
+): Map<string, ModelCostConfig> {
+  return buildProviderCostIndexBundle(providers, options).entries;
 }
 
 function getProviderCostIndex(
@@ -235,21 +321,41 @@ function getProviderCostIndex(
     return buildProviderCostIndex(providers, options);
   }
 
-  const fingerprint = stableCostFingerprintValue(providers);
   let cache = providerCostIndexByConfig.get(providers);
-  if (!cache || cache.fingerprint !== fingerprint) {
-    cache = { fingerprint };
+  if (!cache) {
+    cache = {};
     providerCostIndexByConfig.set(providers, cache);
   }
   if (isRawLookup) {
-    cache.rawEntries ??= buildProviderCostIndex(providers, {
+    cache.rawEntries ??= buildProviderCostIndexBundle(providers, {
       allowManifestNormalization: false,
       allowPluginNormalization: false,
     });
-    return cache.rawEntries;
+    const rawOptions = {
+      allowManifestNormalization: false,
+      allowPluginNormalization: false,
+    };
+    if (refreshProviderCostIndexMutations(cache.rawEntries, providers, rawOptions) === "rebuild") {
+      cache.rawEntries = buildProviderCostIndexBundle(providers, rawOptions);
+    }
+    if (
+      cache.rawEntries.structureFingerprint !== buildProviderCostStructureFingerprint(providers)
+    ) {
+      cache.rawEntries = buildProviderCostIndexBundle(providers, rawOptions);
+    }
+    return cache.rawEntries.entries;
   }
-  cache.normalizedEntries ??= buildProviderCostIndex(providers);
-  return cache.normalizedEntries;
+  cache.normalizedEntries ??= buildProviderCostIndexBundle(providers);
+  if (refreshProviderCostIndexMutations(cache.normalizedEntries, providers) === "rebuild") {
+    cache.normalizedEntries = buildProviderCostIndexBundle(providers);
+  }
+  if (
+    cache.normalizedEntries.structureFingerprint !==
+    buildProviderCostStructureFingerprint(providers)
+  ) {
+    cache.normalizedEntries = buildProviderCostIndexBundle(providers);
+  }
+  return cache.normalizedEntries.entries;
 }
 
 function loadModelsJsonCostIndex(options?: {
@@ -258,18 +364,15 @@ function loadModelsJsonCostIndex(options?: {
   const useRawEntries = options?.allowPluginNormalization === false;
   const modelsPath = path.join(resolveDefaultAgentDir({}), "models.json");
   try {
-    const stat = fs.statSync(modelsPath);
-    if (
-      !modelsJsonCostCache ||
-      modelsJsonCostCache.path !== modelsPath ||
-      modelsJsonCostCache.mtimeMs !== stat.mtimeMs
-    ) {
+    if (!modelsJsonCostCache || modelsJsonCostCache.path !== modelsPath) {
       const parsed = tryReadJsonSync<{
         providers?: Record<string, ModelProviderConfig>;
       }>(modelsPath);
+      if (!parsed) {
+        return EMPTY_PROVIDER_COST_INDEX;
+      }
       modelsJsonCostCache = {
         path: modelsPath,
-        mtimeMs: stat.mtimeMs,
         providers: parsed?.providers,
         normalizedEntries: null,
         rawEntries: null,
@@ -286,15 +389,7 @@ function loadModelsJsonCostIndex(options?: {
     modelsJsonCostCache.normalizedEntries ??= getProviderCostIndex(modelsJsonCostCache.providers);
     return modelsJsonCostCache.normalizedEntries;
   } catch {
-    const empty = new Map<string, ModelCostConfig>();
-    modelsJsonCostCache = {
-      path: modelsPath,
-      mtimeMs: -1,
-      providers: undefined,
-      normalizedEntries: empty,
-      rawEntries: empty,
-    };
-    return empty;
+    return EMPTY_PROVIDER_COST_INDEX;
   }
 }
 
@@ -308,9 +403,9 @@ function findConfiguredProviderCost(params: {
   if (!key) {
     return undefined;
   }
-  return getProviderCostIndex(params.config?.models?.providers, {
+  return getProviderCostFromIndex(params.config?.models?.providers, key, {
     allowPluginNormalization: params.allowPluginNormalization,
-  }).get(key);
+  });
 }
 
 function stableCostFingerprintValue(value: unknown): string {
@@ -329,6 +424,160 @@ function stableCostFingerprintValue(value: unknown): string {
     .toSorted()
     .map((key) => `${JSON.stringify(key)}:${stableCostFingerprintValue(record[key])}`)
     .join(",")}}`;
+}
+
+function buildModelCostFingerprint(cost: RawModelCostConfig): string {
+  const tierFingerprint = Array.isArray(cost.tieredPricing)
+    ? cost.tieredPricing.flatMap((tier) => {
+        const range = Array.isArray(tier.range) ? tier.range : [];
+        return [tier.input, tier.output, tier.cacheRead, tier.cacheWrite, ...range];
+      })
+    : [];
+  return [cost.input, cost.output, cost.cacheRead, cost.cacheWrite, ...tierFingerprint].join("|");
+}
+
+function isProviderCostSourceCurrent(
+  providers: Record<string, ModelProviderConfig>,
+  source: ProviderCostIndexSource,
+  key: string,
+  options?: { allowManifestNormalization?: boolean; allowPluginNormalization?: boolean },
+): boolean {
+  const providerConfig = providers[source.providerKey];
+  if (!providerConfig?.models?.includes(source.model)) {
+    return false;
+  }
+  const normalized = normalizeModelRef(normalizeProviderId(source.providerKey), source.model.id, {
+    allowManifestNormalization:
+      options?.allowManifestNormalization ??
+      (options?.allowPluginNormalization === false ? false : undefined),
+    allowPluginNormalization: options?.allowPluginNormalization,
+  });
+  return modelKey(normalized.provider, normalized.model) === key;
+}
+
+function refreshProviderCostIndexEntry(
+  index: ProviderCostIndex,
+  key: string,
+  providers?: Record<string, ModelProviderConfig>,
+  options?: { allowManifestNormalization?: boolean; allowPluginNormalization?: boolean },
+): "current" | "rebuild" {
+  const source = index.sources.get(key);
+  if (!source) {
+    return "current";
+  }
+  if (providers && !isProviderCostSourceCurrent(providers, source, key, options)) {
+    return "rebuild";
+  }
+  if (!isRawModelCostConfig(source.model.cost)) {
+    return "rebuild";
+  }
+  if (source.model.cost !== source.rawCost) {
+    source.rawCost = source.model.cost;
+  }
+  const fingerprint = buildModelCostFingerprint(source.rawCost);
+  if (source.fingerprint === fingerprint) {
+    return "current";
+  }
+  source.fingerprint = fingerprint;
+  index.entries.set(key, normalizeModelCostConfig(source.rawCost));
+  return "current";
+}
+
+function refreshProviderCostIndexMutations(
+  index: ProviderCostIndex,
+  providers?: Record<string, ModelProviderConfig>,
+  options?: { allowManifestNormalization?: boolean; allowPluginNormalization?: boolean },
+): "current" | "rebuild" {
+  for (const key of index.sources.keys()) {
+    if (refreshProviderCostIndexEntry(index, key, providers, options) === "rebuild") {
+      return "rebuild";
+    }
+  }
+  return "current";
+}
+
+function hasProviderCostSourceForKey(
+  providers: Record<string, ModelProviderConfig>,
+  key: string,
+  options?: { allowManifestNormalization?: boolean; allowPluginNormalization?: boolean },
+): boolean {
+  for (const [providerKey, providerConfig] of Object.entries(providers)) {
+    const normalizedProvider = normalizeProviderId(providerKey);
+    for (const model of providerConfig?.models ?? []) {
+      if (!isRawModelCostConfig(model.cost)) {
+        continue;
+      }
+      const normalized = normalizeModelRef(normalizedProvider, model.id, {
+        allowManifestNormalization:
+          options?.allowManifestNormalization ??
+          (options?.allowPluginNormalization === false ? false : undefined),
+        allowPluginNormalization: options?.allowPluginNormalization,
+      });
+      if (modelKey(normalized.provider, normalized.model) === key) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function getProviderCostFromIndex(
+  providers: Record<string, ModelProviderConfig> | undefined,
+  key: string,
+  options?: { allowManifestNormalization?: boolean; allowPluginNormalization?: boolean },
+): ModelCostConfig | undefined {
+  if (!providers) {
+    return undefined;
+  }
+  const isRawLookup =
+    options?.allowPluginNormalization === false &&
+    (options.allowManifestNormalization === false ||
+      options.allowManifestNormalization === undefined);
+  const isDefaultNormalizedLookup =
+    options?.allowPluginNormalization !== false &&
+    options?.allowManifestNormalization === undefined;
+  if (!isRawLookup && !isDefaultNormalizedLookup) {
+    return buildProviderCostIndex(providers, options).get(key);
+  }
+
+  let cache = providerCostIndexByConfig.get(providers);
+  if (!cache) {
+    cache = {};
+    providerCostIndexByConfig.set(providers, cache);
+  }
+  const index = isRawLookup
+    ? (cache.rawEntries ??= buildProviderCostIndexBundle(providers, {
+        allowManifestNormalization: false,
+        allowPluginNormalization: false,
+      }))
+    : (cache.normalizedEntries ??= buildProviderCostIndexBundle(providers));
+  const sourceMissingWithStructuralChange =
+    !index.sources.has(key) &&
+    index.structureFingerprint !== buildProviderCostStructureFingerprint(providers);
+  const sourceMissingWithNewCost =
+    !index.sources.has(key) && hasProviderCostSourceForKey(providers, key, options);
+  if (
+    refreshProviderCostIndexEntry(index, key, providers, options) === "rebuild" ||
+    sourceMissingWithStructuralChange ||
+    sourceMissingWithNewCost
+  ) {
+    const rebuilt = buildProviderCostIndexBundle(
+      providers,
+      isRawLookup
+        ? {
+            allowManifestNormalization: false,
+            allowPluginNormalization: false,
+          }
+        : undefined,
+    );
+    if (isRawLookup) {
+      cache.rawEntries = rebuilt;
+    } else {
+      cache.normalizedEntries = rebuilt;
+    }
+    return rebuilt.entries.get(key);
+  }
+  return index.entries.get(key);
 }
 
 function serializeCostIndex(
@@ -403,7 +652,7 @@ const toNumber = (value: number | undefined): number =>
   typeof value === "number" && Number.isFinite(value) ? value : 0;
 
 function selectPricingTier(tiers: PricingTier[], input: number): PricingTier | undefined {
-  const sortedTiers = tiers.toSorted((a, b) => a.range[0] - b.range[0]);
+  const sortedTiers = getSortedPricingTiers(tiers);
   if (sortedTiers.length === 0) {
     return undefined;
   }
@@ -426,6 +675,16 @@ function selectPricingTier(tiers: PricingTier[], input: number): PricingTier | u
   }
 
   return sortedTiers[0];
+}
+
+function getSortedPricingTiers(tiers: PricingTier[]): PricingTier[] {
+  const cached = sortedPricingTiersByInput.get(tiers);
+  if (cached) {
+    return cached;
+  }
+  const sorted = tiers.toSorted((a, b) => a.range[0] - b.range[0]);
+  sortedPricingTiersByInput.set(tiers, sorted);
+  return sorted;
 }
 
 function computeTieredCost(
@@ -482,4 +741,6 @@ export function estimateUsageCost(params: {
 export function resetUsageFormatCachesForTest(): void {
   modelsJsonCostCache = null;
   providerCostIndexByConfig = new WeakMap();
+  modelKeyCache = new Map();
+  sortedPricingTiersByInput = new WeakMap();
 }


### PR DESCRIPTION
## Summary

- Cache successful `models.json` cost indexes by process/path so repeated cost lookups stop polling filesystem metadata.
- Reuse normalized model keys, per-model provider cost entries, sorted tier arrays, and repeated session-scan cost resolutions.
- Keep pricing cache correctness for config mutations, metadata-only model rows, malformed tiers, and late `models.json` generation.

## Measurement

Same local microbench before vs after this patch:

- `models-json-lookup-100k`: 493.4 ms -> 157.1 ms
- `config-lookup-100k`: 106756.4 ms -> 206.2 ms
- `tier-estimate-500k`: 41.6 ms -> 25.7 ms

## Verification

- `git diff --check`
- `pnpm exec oxfmt --check src/utils/usage-format.ts src/utils/usage-format.test.ts src/infra/session-cost-usage.ts src/infra/session-cost-usage.test.ts`
- `node scripts/run-vitest.mjs src/utils/usage-format.test.ts src/infra/session-cost-usage.test.ts --reporter=verbose` (80 tests passed)
- `pnpm tsgo:core && pnpm tsgo:test:src`
- `pnpm crabbox:run -- --label cost-lookup-hot-path-focused-r5 --idle-timeout 45m --ttl 120m --timing-json --shell -- "set -euo pipefail; printf 'CRABBOX_PHASE:cost-hot-path-tests\n'; node scripts/run-vitest.mjs src/utils/usage-format.test.ts src/infra/session-cost-usage.test.ts --reporter=verbose"`
  - provider: aws
  - lease: cbx_185a4afb19e0
  - run: run_67e562a12a56
  - result: 80 tests passed
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local`
  - result: clean, no accepted/actionable findings

## Real behavior proof

Behavior addressed: repeated usage-cost lookups and session usage scans no longer spend CPU on per-lookup models.json stat polling, whole-provider cost fingerprinting, repeated model-key normalization, repeated tier sorting, or repeated same-model scan cost resolution.

Real environment tested: local macOS checkout and AWS Crabbox Linux runner.

Exact steps or command run after this patch: focused Vitest for usage formatting and session cost usage, core/test TypeScript passes, local microbench, and AWS Crabbox focused Vitest run `run_67e562a12a56` on lease `cbx_185a4afb19e0`.

Evidence after fix: local focused Vitest passed 80 tests; Crabbox focused Vitest passed 80 tests; local microbench improved config lookup from 106756.4 ms to 206.2 ms for 100k lookups.

Observed result after fix: cost lookups reuse process-local indexes and per-scan resolvers while preserving late models.json reads, config mutation handling, metadata-only rows, malformed tier tolerance, and durable pricing fingerprint invalidation.

What was not tested: full release CI locally; PR CI covers the pushed branch.
