### PR TITLE
fix(agents): handle preflight compaction no-op budgets

### DIFF
--- a/src/agents/pi-embedded-runner/compact.hooks.harness.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.harness.ts
@@ -822,11 +822,15 @@ export async function loadCompactHooksHarness(): Promise<{
     createSystemPromptOverride: vi.fn(() => () => ""),
   }));
 
-  vi.doMock("./utils.js", () => ({
-    describeUnknownError: vi.fn((err: unknown) => String(err)),
-    mapThinkingLevel: vi.fn((level?: string) => level ?? "off"),
-    resolveExecToolDefaults: vi.fn(() => undefined),
-  }));
+  vi.doMock("./utils.js", async () => {
+    const actual = await vi.importActual<typeof import("./utils.js")>("./utils.js");
+    return {
+      ...actual,
+      describeUnknownError: vi.fn((err: unknown) => String(err)),
+      mapThinkingLevel: vi.fn((level?: string) => level ?? "off"),
+      resolveExecToolDefaults: vi.fn(() => undefined),
+    };
+  });
 
   const [compactModule, compactQueuedModule, transcriptEvents] = await Promise.all([
     import("./compact.js"),

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -1475,6 +1475,37 @@ describe("compactEmbeddedPiSession hooks (ownsCompaction engine)", () => {
     });
   });
 
+  it("clamps caller context token budget before queued engine-owned compaction", async () => {
+    resolveContextWindowInfoMock.mockReturnValueOnce({ tokens: 32_000 });
+
+    await compactEmbeddedPiSession(
+      wrappedCompactionArgs({
+        contextTokenBudget: 64_000,
+        config: {
+          agents: {
+            defaults: {
+              compaction: {
+                model: "anthropic/claude-opus-4-6",
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    const harnessArg = mockCallArg(maybeCompactAgentHarnessSessionMock) as Record<string, unknown>;
+    expect(harnessArg.contextTokenBudget).toBe(32_000);
+    const compactArg = mockCallArg(contextEngineCompactMock) as {
+      tokenBudget?: number;
+      runtimeContext?: Record<string, unknown>;
+    };
+    expect(compactArg.tokenBudget).toBe(32_000);
+    expectRecordFields(compactArg.runtimeContext, {
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    });
+  });
+
   it("passes resolved context-engine runtime context to harness compaction", async () => {
     maybeCompactAgentHarnessSessionMock.mockResolvedValueOnce({
       ok: true,

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -381,6 +381,34 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
     });
   });
 
+  it("uses the caller context token budget during runtime compaction", async () => {
+    await compactEmbeddedPiSessionDirect({
+      sessionId: "session-1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp/workspace",
+      contextTokenBudget: 64_000,
+    });
+
+    expectRecordFields(mockCallArg(createOpenClawCodingToolsMock), {
+      modelContextWindowTokens: 64_000,
+    });
+  });
+
+  it("clamps the caller context token budget to the compaction model", async () => {
+    resolveContextWindowInfoMock.mockReturnValueOnce({ tokens: 32_000 });
+
+    await compactEmbeddedPiSessionDirect({
+      sessionId: "session-1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp/workspace",
+      contextTokenBudget: 64_000,
+    });
+
+    expectRecordFields(mockCallArg(createOpenClawCodingToolsMock), {
+      modelContextWindowTokens: 32_000,
+    });
+  });
+
   it("uses the session model fallback chain when overflow compaction fails", async () => {
     resolveModelMock.mockImplementation((provider = "openai", modelId = "fake") => ({
       model: { provider, api: "responses", id: modelId, input: [] },

--- a/src/agents/pi-embedded-runner/compact.queued.ts
+++ b/src/agents/pi-embedded-runner/compact.queued.ts
@@ -47,6 +47,7 @@ import { log } from "./logger.js";
 import { readPiModelContextTokens } from "./model-context-tokens.js";
 import { resolveModelAsync } from "./model.js";
 import type { EmbeddedPiCompactResult } from "./types.js";
+import { normalizeContextTokenBudget } from "./utils.js";
 
 function shouldFallbackAfterHarnessCompaction(
   result: EmbeddedPiCompactResult | undefined,
@@ -87,44 +88,49 @@ export async function compactEmbeddedPiSession(
     agentDir,
     workspaceDir: resolvedWorkspaceDir,
   });
-  let contextTokenBudget = params.contextTokenBudget;
-  if (!contextTokenBudget || !Number.isFinite(contextTokenBudget) || contextTokenBudget <= 0) {
-    const resolvedCompactionTarget = resolveEmbeddedCompactionTarget({
-      config: params.config,
-      provider: params.provider,
-      modelId: params.model,
-      authProfileId: params.authProfileId,
-      defaultProvider: DEFAULT_PROVIDER,
-      defaultModel: DEFAULT_MODEL,
-    });
-    const ceProvider = resolvedCompactionTarget.provider ?? DEFAULT_PROVIDER;
-    const ceModelId = resolvedCompactionTarget.model ?? DEFAULT_MODEL;
-    const { model: ceModel } = await resolveModelAsync(
-      ceProvider,
-      ceModelId,
-      agentDir,
-      params.config,
-    );
-    const ceRuntimeModel = ceModel as ProviderRuntimeModel | undefined;
-    const ceHarnessPolicy = resolveAgentHarnessPolicy({
-      provider: ceProvider,
-      modelId: ceModelId,
-      config: params.config,
-      agentId: agentIds.sessionAgentId,
-      sessionKey: params.sessionKey,
-    });
-    contextTokenBudget = resolveContextWindowInfo({
-      cfg: params.config,
-      provider: resolveContextConfigProviderForRuntime({
-        provider: ceProvider,
-        runtimeId: ceHarnessPolicy.runtime,
-      }),
-      modelId: ceModelId,
-      modelContextTokens: readPiModelContextTokens(ceModel),
-      modelContextWindow: ceRuntimeModel?.contextWindow,
-      defaultTokens: DEFAULT_CONTEXT_TOKENS,
-    }).tokens;
-  }
+  const resolvedCompactionTarget = resolveEmbeddedCompactionTarget({
+    config: params.config,
+    provider: params.provider,
+    modelId: params.model,
+    authProfileId: params.authProfileId,
+    defaultProvider: DEFAULT_PROVIDER,
+    defaultModel: DEFAULT_MODEL,
+  });
+  const ceProvider = resolvedCompactionTarget.provider ?? DEFAULT_PROVIDER;
+  const ceModelId = resolvedCompactionTarget.model ?? DEFAULT_MODEL;
+  const { model: ceModel } = await resolveModelAsync(
+    ceProvider,
+    ceModelId,
+    agentDir,
+    params.config,
+  );
+  const ceRuntimeModel = ceModel as ProviderRuntimeModel | undefined;
+  const ceHarnessPolicy = resolveAgentHarnessPolicy({
+    provider: ceProvider,
+    modelId: ceModelId,
+    config: params.config,
+    agentId: agentIds.sessionAgentId,
+    sessionKey: params.sessionKey,
+  });
+  const resolvedContextTokenBudget =
+    normalizeContextTokenBudget(
+      resolveContextWindowInfo({
+        cfg: params.config,
+        provider: resolveContextConfigProviderForRuntime({
+          provider: ceProvider,
+          runtimeId: ceHarnessPolicy.runtime,
+        }),
+        modelId: ceModelId,
+        modelContextTokens: readPiModelContextTokens(ceModel),
+        modelContextWindow: ceRuntimeModel?.contextWindow,
+        defaultTokens: DEFAULT_CONTEXT_TOKENS,
+      }).tokens,
+    ) ?? DEFAULT_CONTEXT_TOKENS;
+  const requestedContextTokenBudget = normalizeContextTokenBudget(params.contextTokenBudget);
+  const contextTokenBudget = Math.min(
+    requestedContextTokenBudget ?? resolvedContextTokenBudget,
+    resolvedContextTokenBudget,
+  );
   const contextEngineRuntimeContext = buildCompactionContextEngineRuntimeContext({
     params,
     agentDir,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -170,7 +170,7 @@ import {
 import { splitSdkTools } from "./tool-split.js";
 import { readTranscriptFileState } from "./transcript-file-state.js";
 import type { EmbeddedPiCompactResult } from "./types.js";
-import { mapThinkingLevel } from "./utils.js";
+import { mapThinkingLevel, normalizeContextTokenBudget } from "./utils.js";
 import { flushPendingToolResultsAfterIdle } from "./wait-for-idle-before-flush.js";
 export type { CompactEmbeddedPiSessionParams } from "./compact.types.js";
 
@@ -263,12 +263,6 @@ function resolveCompactionProviderStream(params: {
 }
 
 function normalizeObservedTokenCount(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) && value > 0
-    ? Math.floor(value)
-    : undefined;
-}
-
-function normalizeContextTokenBudget(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) && value > 0
     ? Math.floor(value)
     : undefined;

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -268,6 +268,12 @@ function normalizeObservedTokenCount(value: unknown): number | undefined {
     : undefined;
 }
 
+function normalizeContextTokenBudget(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : undefined;
+}
+
 function getMessageTextChars(msg: AgentMessage): number {
   const content = (msg as { content?: unknown }).content;
   if (typeof content === "string") {
@@ -697,10 +703,19 @@ async function compactEmbeddedPiSessionDirectOnce(
       modelContextWindow: runtimeModelWithContext.contextWindow,
       defaultTokens: DEFAULT_CONTEXT_TOKENS,
     });
+    const resolvedContextTokenBudget =
+      normalizeContextTokenBudget(ctxInfo.tokens) ?? DEFAULT_CONTEXT_TOKENS;
+    const requestedContextTokenBudget =
+      normalizeContextTokenBudget(params.contextTokenBudget) ??
+      normalizeContextTokenBudget(params.tokenBudget);
+    const contextTokenBudget = Math.min(
+      requestedContextTokenBudget ?? resolvedContextTokenBudget,
+      resolvedContextTokenBudget,
+    );
     const effectiveModel = applyAuthHeaderOverride(
       applyLocalNoAuthHeaderOverride(
-        ctxInfo.tokens < (runtimeModelWithContext.contextWindow ?? Infinity)
-          ? { ...runtimeModelWithContext, contextWindow: ctxInfo.tokens }
+        contextTokenBudget < (runtimeModelWithContext.contextWindow ?? Infinity)
+          ? { ...runtimeModelWithContext, contextWindow: contextTokenBudget }
           : runtimeModelWithContext,
         apiKeyInfo,
       ),
@@ -761,7 +776,7 @@ async function compactEmbeddedPiSessionDirectOnce(
       modelId,
       modelCompat: extractModelCompat(effectiveModel),
       modelApi: model.api,
-      modelContextWindowTokens: ctxInfo.tokens,
+      modelContextWindowTokens: contextTokenBudget,
       skillsSnapshot: skillsSnapshotForRun,
       modelAuthMode: resolveModelAuthMode(model.provider, params.config, undefined, {
         workspaceDir: effectiveWorkspace,
@@ -1012,7 +1027,7 @@ async function compactEmbeddedPiSessionDirectOnce(
         agentId: sessionAgentId,
         sessionKey: params.sessionKey,
         config: params.config,
-        contextWindowTokens: ctxInfo.tokens,
+        contextWindowTokens: contextTokenBudget,
         allowSyntheticToolResults: transcriptPolicy.allowSyntheticToolResults,
         missingToolResultText:
           model.api === "openai-responses" ||
@@ -1037,7 +1052,7 @@ async function compactEmbeddedPiSessionDirectOnce(
           env: process.env,
           workspaceDir: effectiveWorkspace,
         }),
-        contextTokenBudget: ctxInfo.tokens,
+        contextTokenBudget,
       });
       // Sets compaction/pruning runtime state and returns extension factories
       // that must be passed to the resource loader for the safeguard to be active.
@@ -1064,7 +1079,7 @@ async function compactEmbeddedPiSessionDirectOnce(
       applyPiCompactionSettingsFromConfig({
         settingsManager,
         cfg: params.config,
-        contextTokenBudget: ctxInfo.tokens,
+        contextTokenBudget,
       });
       // contextEngineInfo is intentionally omitted: this guard runs inside the
       // compaction LLM session, which is not the user-facing agent session and

--- a/src/agents/pi-embedded-runner/utils.ts
+++ b/src/agents/pi-embedded-runner/utils.ts
@@ -1,6 +1,12 @@
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { ReasoningLevel, ThinkLevel } from "../../auto-reply/thinking.js";
 
+export function normalizeContextTokenBudget(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : undefined;
+}
+
 export function mapThinkingLevel(level?: ThinkLevel): ThinkingLevel {
   // pi-agent-core supports "xhigh"; OpenClaw enables it for specific models.
   if (!level) {

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -15,6 +15,7 @@ import {
   setAgentRunnerMemoryTestDeps,
 } from "./agent-runner-memory.js";
 import { createTestFollowupRun, writeTestSessionStore } from "./agent-runner.test-fixtures.js";
+import type { ReplyOperation } from "./reply-run-registry.js";
 
 const compactEmbeddedPiSessionMock = vi.fn();
 const runWithModelFallbackMock = vi.fn();
@@ -28,12 +29,31 @@ function registerMemoryFlushPlanResolverForTest(resolver: MemoryFlushPlanResolve
   registerMemoryCapability("memory-core", { flushPlanResolver: resolver });
 }
 
-function createReplyOperation() {
+type TestReplyOperation = ReplyOperation & {
+  setPhase: ReturnType<typeof vi.fn<ReplyOperation["setPhase"]>>;
+  updateSessionId: ReturnType<typeof vi.fn<ReplyOperation["updateSessionId"]>>;
+};
+
+function createReplyOperation(): TestReplyOperation {
   return {
+    key: "test",
+    sessionId: "session",
     abortSignal: new AbortController().signal,
-    setPhase: vi.fn(),
-    updateSessionId: vi.fn(),
-  } as never;
+    resetTriggered: false,
+    phase: "queued",
+    result: null,
+    setPhase: vi.fn<ReplyOperation["setPhase"]>(),
+    updateSessionId: vi.fn<ReplyOperation["updateSessionId"]>(),
+    attachBackend: vi.fn(),
+    detachBackend: vi.fn(),
+    complete: vi.fn(),
+    completeThen: vi.fn((afterClear: () => void) => {
+      afterClear();
+    }),
+    fail: vi.fn(),
+    abortByUser: vi.fn(),
+    abortForRestart: vi.fn(),
+  };
 }
 
 type RefreshQueuedFollowupSessionParams = {
@@ -75,6 +95,7 @@ type CompactEmbeddedPiSessionParams = {
   sessionKey?: string;
   sandboxSessionKey?: string;
   currentTokenCount?: number;
+  contextTokenBudget?: number;
   sessionFile?: string;
   sessionId?: string;
   trigger?: string;
@@ -845,12 +866,7 @@ describe("runMemoryFlushIfNeeded", () => {
       sessionFile,
       sessionKey: "agent:main:main",
     });
-    const updateSessionId = vi.fn();
-    const replyOperation = {
-      abortSignal: new AbortController().signal,
-      setPhase: vi.fn(),
-      updateSessionId,
-    } as never;
+    const replyOperation = createReplyOperation();
 
     const entry = await runPreflightCompactionIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
@@ -869,7 +885,7 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(entry?.sessionFile).toBe(successorFile);
     expect(followupRun.run.sessionId).toBe("session-rotated");
     expect(followupRun.run.sessionFile).toBe(successorFile);
-    expect(updateSessionId).toHaveBeenCalledWith("session-rotated");
+    expect(replyOperation.updateSessionId).toHaveBeenCalledWith("session-rotated");
     expect(refreshQueuedFollowupSessionMock).toHaveBeenCalledWith({
       key: "agent:main:main",
       previousSessionId: "session",
@@ -925,6 +941,48 @@ describe("runMemoryFlushIfNeeded", () => {
 
     const compactCall = requireCompactEmbeddedPiSessionCall();
     expect(compactCall.currentTokenCount).toBeGreaterThanOrEqual(100_000);
+  });
+
+  it("continues when preflight compaction returns a successful no-op", async () => {
+    compactEmbeddedPiSessionMock.mockResolvedValueOnce({
+      ok: true,
+      compacted: false,
+      reason: "already under target",
+    });
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 180_499,
+      totalTokensFresh: true,
+      compactionCount: 0,
+    };
+    const sessionStore = { main: sessionEntry };
+    const replyOperation = createReplyOperation();
+
+    const entry = await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({
+        sessionId: "session",
+        sessionKey: "main",
+      }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 200_000,
+      sessionEntry,
+      sessionStore,
+      sessionKey: "main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation,
+    });
+
+    expect(entry).toBe(sessionEntry);
+    expect(compactEmbeddedPiSessionMock).toHaveBeenCalledTimes(1);
+    const compactCall = requireCompactEmbeddedPiSessionCall();
+    expect(compactCall.contextTokenBudget).toBe(200_000);
+    expect(replyOperation.setPhase).toHaveBeenCalledWith("preflight_compacting");
+    expect(replyOperation.updateSessionId).not.toHaveBeenCalled();
+    expect(incrementCompactionCountMock).not.toHaveBeenCalled();
+    expect(refreshQueuedFollowupSessionMock).not.toHaveBeenCalled();
   });
 
   it("skips OpenClaw preflight compaction for persisted Codex runtime sessions", async () => {
@@ -1574,11 +1632,7 @@ describe("runMemoryFlushIfNeeded", () => {
       compactionCount: 0,
     };
     const sessionStore = { main: sessionEntry };
-    const replyOperation = {
-      abortSignal: new AbortController().signal,
-      setPhase: vi.fn(),
-      updateSessionId: vi.fn(),
-    };
+    const replyOperation = createReplyOperation();
 
     const entry = await runPreflightCompactionIfNeeded({
       cfg: {
@@ -1603,7 +1657,7 @@ describe("runMemoryFlushIfNeeded", () => {
       sessionKey: "main",
       storePath: path.join(rootDir, "sessions.json"),
       isHeartbeat: false,
-      replyOperation: replyOperation as never,
+      replyOperation,
     });
 
     expect(entry?.compactionCount).toBe(1);

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -814,11 +814,12 @@ export async function runPreflightCompactionIfNeeded(params: {
     bashElevated: params.followupRun.run.bashElevated,
     trigger: "budget",
     currentTokenCount: tokenCountForCompaction ?? freshPersistedTokens,
+    contextTokenBudget: contextWindowTokens,
     ownerNumbers: params.followupRun.run.ownerNumbers,
     abortSignal: params.replyOperation.abortSignal,
   });
 
-  if (!result?.ok || !result.compacted) {
+  if (!result?.ok) {
     const reason = result?.reason ?? "not_compacted";
     logVerbose(`preflightCompaction failed: sessionKey=${params.sessionKey} reason=${reason}`);
     if (isRecoverableNativeHarnessBindingFailure(result)) {
@@ -828,6 +829,12 @@ export async function runPreflightCompactionIfNeeded(params: {
       return entry ?? params.sessionEntry;
     }
     throw new Error(`Preflight compaction required but failed: ${reason}`);
+  }
+
+  if (!result.compacted) {
+    const reason = result.reason ?? "not_compacted";
+    logVerbose(`preflightCompaction no-op: sessionKey=${params.sessionKey} reason=${reason}`);
+    return entry ?? params.sessionEntry;
   }
 
   await incrementCompactionCount({


### PR DESCRIPTION
## Summary

- Treat `ok: true, compacted: false` preflight compaction results as successful no-ops instead of failing the reply path.
- Pass the caller-resolved context budget from `src/auto-reply/reply/agent-runner-memory.ts` into runtime compaction so the compactor evaluates the same budget that triggered preflight.
- Clamp caller-provided compaction budgets to the selected compaction model's resolved context window in `src/agents/pi-embedded-runner/compact.ts`, so an active conversation model cannot overstate the capacity of a smaller compaction model.
- Added focused coverage for no-op preflight behavior, budget forwarding, and compaction-model budget clamping.

## Verification

- `git diff --check`
- `pnpm tsgo:core`
- `pnpm check:test-types`

## Real behavior proof

Behavior addressed: preflight compaction no longer fails a successful no-op result, while runtime compaction still receives and clamps the caller budget safely.

Real environment tested: local OpenClaw checkout on branch `fix/preflight-compaction-noop`.

Exact steps or command run after this patch: `git diff --check`; `pnpm tsgo:core`.

Evidence after fix: whitespace check passed; core TypeScript lane passed.

Observed result after fix: branch typechecks with the new budget-forwarding and budget-clamping paths.

What was not tested: focused Vitest completion; local Vitest processes remained CPU-bound with no output and were killed after bounded waits.

