### PR TITLE
fix(acp): skip oneshot sessions during startup identity reconcile

### DIFF
--- a/src/acp/control-plane/manager.startup-identity-reconcile.test.ts
+++ b/src/acp/control-plane/manager.startup-identity-reconcile.test.ts
@@ -168,4 +168,41 @@ describe("AcpSessionManager startup identity reconcile", () => {
     expect(runtimeState.getStatus).not.toHaveBeenCalled();
     expect(runtimeState.ensureSession).not.toHaveBeenCalled();
   });
+
+  it("skips pending oneshot identities during startup reconciliation", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    const sessionKey = "agent:codex:acp:oneshot:session-1";
+    const acp: SessionAcpMeta = {
+      ...readySessionMeta(),
+      mode: "oneshot",
+      identity: {
+        state: "pending",
+        source: "ensure",
+        acpxSessionId: "acpx-stale",
+        lastUpdatedAt: Date.now(),
+      },
+    };
+    hoisted.listAcpSessionEntriesMock.mockResolvedValue([
+      {
+        cfg: baseCfg,
+        storePath: "/tmp/sessions-acp.json",
+        sessionKey,
+        storeSessionKey: sessionKey,
+        entry: { sessionId: "session-1", updatedAt: Date.now(), acp },
+        acp,
+      },
+    ]);
+
+    const result = await new AcpSessionManager().reconcilePendingSessionIdentities({
+      cfg: baseCfg,
+    });
+
+    expect(result).toEqual({ checked: 0, resolved: 0, failed: 0 });
+    expect(runtimeState.ensureSession).not.toHaveBeenCalled();
+    expect(runtimeState.getStatus).not.toHaveBeenCalled();
+  });
 });

--- a/src/acp/control-plane/manager.startup-identity-reconcile.ts
+++ b/src/acp/control-plane/manager.startup-identity-reconcile.ts
@@ -42,6 +42,9 @@ export async function runManagerStartupIdentityReconcile(params: {
     if (!session.acp || !session.sessionKey) {
       continue;
     }
+    if (session.acp.mode === "oneshot") {
+      continue;
+    }
     const currentIdentity = resolveSessionIdentityFromMeta(session.acp);
     if (
       !isSessionIdentityPending(currentIdentity) ||


### PR DESCRIPTION
Closes #72013

## What Problem This Solves

Fixes misleading gateway startup warnings caused by terminal one-shot ACP rows whose persisted identity remains pending. Those rows could increment the startup reconciliation failure count even though fresh Codex and Claude ACP sessions were healthy.

## Why This Change Was Made

Startup identity reconciliation now skips `mode: "oneshot"` rows before identity resolution, `checked` increments, or runtime handle creation. Persistent pending identities with stable runtime ids retain the existing reconciliation path. The maintainer rewrite removes the one-off 171-line proof script and keeps the landing patch to the owner function plus its regression test.

## User Impact

Gateway startup no longer reports stale one-shot identities as current ACP routing failures. Persistent ACP sessions still reconcile normally.

## Evidence

- `node scripts/run-vitest.mjs src/acp/control-plane/manager.startup-identity-reconcile.test.ts` — 4 passed.
- `node scripts/run-vitest.mjs src/acp/control-plane/manager.runtime-handles.test.ts` — 12 passed.
- Structured autoreview — clean, confidence 0.98.
- The contributor's production-path proof established that both one-shot and persistent rows are visible through `listAcpSessionEntries`, while only persistent rows should remain reconcile-eligible.

## Credit

Maintainer rewrite of Sebastien Tardif's contribution (@SebTardif), preserved with `Co-authored-by: Sebastien Tardif <sebtardif@ncf.ca>`.
