### PR TITLE
feat: add message to DEFAULT_TOOL_ALLOW in sandbox policy

### DIFF
--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -25,6 +25,7 @@ export const DEFAULT_TOOL_ALLOW = [
   "sessions_yield",
   "subagents",
   "session_status",
+  "message",
 ] as const;
 
 // Provider docking: keep sandbox policy aligned with provider tool names.

--- a/src/agents/sandbox/tool-policy.test.ts
+++ b/src/agents/sandbox/tool-policy.test.ts
@@ -329,4 +329,18 @@ describe("sandbox/tool-policy", () => {
     expect(message).toContain("openclaw sandbox explain --agent main");
     expect(message).not.toContain("--session");
   });
+
+  it("includes message in the default sandbox allowlist without explicit alsoAllow", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: { mode: "all", scope: "agent" },
+        },
+        list: [{ id: "test-agent" }],
+      },
+    };
+
+    const resolved = resolveSandboxToolPolicyForAgent(cfg, "test-agent");
+    expect(resolved.allow).toContain("message");
+  });
 });


### PR DESCRIPTION
## Summary

- Add `"message"` to `DEFAULT_TOOL_ALLOW` in `src/agents/sandbox/constants.ts`
- Add test coverage proving the default sandbox allowlist permits `message` without explicit `alsoAllow` config

## Context

The sandbox default allowlist omitted `message`, which prevented agents in `workspace-write` sandbox mode from sending visible replies through Discord (and potentially other channels) without an explicit `tools.sandbox.tools.alsoAllow: ["message"]` override in `openclaw.json`.

This was the root cause of the Discord channel message tool injection failure, diagnosed through Cycle 2 debug logging.

## Verification

- `pnpm test src/agents/sandbox/tool-policy.test.ts` — 11 tests passed (1 new)
- `pnpm build` — clean

## After merge

The runtime workaround (`tools.sandbox.tools.alsoAllow: ["message"]` in `openclaw.json`) can be safely withdrawn.