### PR TITLE
fix(discord): harden reply delivery accounting

### DIFF
--- a/extensions/discord/src/channel-actions.test.ts
+++ b/extensions/discord/src/channel-actions.test.ts
@@ -353,6 +353,12 @@ describe("discordMessageActions", () => {
   it("extracts send targets for message and thread reply actions", () => {
     expect(
       discordMessageActions.extractToolSend?.({
+        args: { action: "send", to: "channel:123" },
+      }),
+    ).toEqual({ to: "channel:123" });
+
+    expect(
+      discordMessageActions.extractToolSend?.({
         args: { action: "sendMessage", to: "channel:123" },
       }),
     ).toEqual({ to: "channel:123" });

--- a/extensions/discord/src/channel-actions.ts
+++ b/extensions/discord/src/channel-actions.ts
@@ -168,8 +168,8 @@ export const discordMessageActions: ChannelMessageActionAdapter = {
   describeMessageTool: describeDiscordMessageTool,
   extractToolSend: ({ args }) => {
     const action = normalizeOptionalString(args.action) ?? "";
-    if (action === "sendMessage") {
-      return extractToolSend(args, "sendMessage");
+    if (action === "send" || action === "sendMessage") {
+      return extractToolSend(args, action);
     }
     if (action === "threadReply") {
       const channelId = normalizeOptionalString(args.channelId) ?? "";

--- a/extensions/discord/src/monitor/native-command-agent-reply.ts
+++ b/extensions/discord/src/monitor/native-command-agent-reply.ts
@@ -62,7 +62,7 @@ export async function dispatchDiscordNativeAgentReply(params: {
           return;
         }
         try {
-          await deliverDiscordInteractionReply({
+          const delivered = await deliverDiscordInteractionReply({
             interaction: params.interaction,
             payload,
             mediaLocalRoots: params.mediaLocalRoots,
@@ -78,6 +78,9 @@ export async function dispatchDiscordNativeAgentReply(params: {
             responseEphemeral: params.responseEphemeral,
             chunkMode: resolveChunkMode(params.cfg, "discord", params.accountId),
           });
+          if (!delivered) {
+            return;
+          }
         } catch (error) {
           if (isDiscordUnknownInteraction(error)) {
             logVerbose("discord: interaction reply skipped (interaction expired)");

--- a/extensions/discord/src/monitor/native-command-reply.test.ts
+++ b/extensions/discord/src/monitor/native-command-reply.test.ts
@@ -26,7 +26,7 @@ describe("deliverDiscordInteractionReply", () => {
 
     expect(hasRenderableReplyPayload(payload)).toBe(true);
 
-    await deliverDiscordInteractionReply({
+    const delivered = await deliverDiscordInteractionReply({
       interaction: interaction as never,
       payload,
       textLimit: 2000,
@@ -40,13 +40,14 @@ describe("deliverDiscordInteractionReply", () => {
       ephemeral: true,
     });
     expect(interaction.reply).not.toHaveBeenCalled();
+    expect(delivered).toBe(true);
   });
 
   it("sends component-only native command replies through the initial reply when not deferred", async () => {
     const interaction = createInteraction();
     const components = [new Container([new TextDisplay("Choose an action")])];
 
-    await deliverDiscordInteractionReply({
+    const delivered = await deliverDiscordInteractionReply({
       interaction: interaction as never,
       payload: {
         channelData: {
@@ -64,5 +65,25 @@ describe("deliverDiscordInteractionReply", () => {
       components,
     });
     expect(interaction.followUp).not.toHaveBeenCalled();
+    expect(delivered).toBe(true);
+  });
+
+  it("reports no delivery when Discord rejects an expired interaction", async () => {
+    const interaction = createInteraction();
+    interaction.reply.mockRejectedValueOnce({
+      rawBody: { code: 10062, message: "Unknown interaction" },
+    });
+
+    const delivered = await deliverDiscordInteractionReply({
+      interaction: interaction as never,
+      payload: { text: "too late" },
+      textLimit: 2000,
+      preferFollowUp: false,
+      chunkMode: "length",
+    });
+
+    expect(interaction.reply).toHaveBeenCalledTimes(1);
+    expect(interaction.followUp).not.toHaveBeenCalled();
+    expect(delivered).toBe(false);
   });
 });

--- a/extensions/discord/src/monitor/native-command-reply.ts
+++ b/extensions/discord/src/monitor/native-command-reply.ts
@@ -74,7 +74,7 @@ export async function deliverDiscordInteractionReply(params: {
   preferFollowUp: boolean;
   responseEphemeral?: boolean;
   chunkMode: "length" | "newline";
-}) {
+}): Promise<boolean> {
   const { interaction, payload, textLimit, maxLinesPerMessage, preferFollowUp, chunkMode } = params;
   const reply = resolveSendableOutboundReplyParts(payload);
   const discordData = payload.channelData?.discord as
@@ -115,17 +115,19 @@ export async function deliverDiscordInteractionReply(params: {
               ? { ephemeral: params.responseEphemeral }
               : {}),
           };
-    await safeDiscordInteractionCall("interaction send", async () => {
+    const result = await safeDiscordInteractionCall("interaction send", async () => {
       if (!preferFollowUp && !hasReplied) {
         await interaction.reply(payload);
         hasReplied = true;
         firstMessageComponents = undefined;
-        return;
+        return true;
       }
       await interaction.followUp(payload);
       hasReplied = true;
       firstMessageComponents = undefined;
+      return true;
     });
+    return result === true;
   };
 
   if (reply.hasMedia) {
@@ -149,18 +151,18 @@ export async function deliverDiscordInteractionReply(params: {
       }),
     );
     const caption = chunks[0] ?? "";
-    await sendMessage(caption, media, firstMessageComponents);
+    let delivered = await sendMessage(caption, media, firstMessageComponents);
     for (const chunk of chunks.slice(1)) {
       if (!chunk.trim()) {
         continue;
       }
-      await sendMessage(chunk);
+      delivered = (await sendMessage(chunk)) || delivered;
     }
-    return;
+    return delivered;
   }
 
   if (!reply.hasText && !firstMessageComponents) {
-    return;
+    return false;
   }
   let chunks =
     reply.text || firstMessageComponents
@@ -176,10 +178,12 @@ export async function deliverDiscordInteractionReply(params: {
   if (chunks.length === 0 && firstMessageComponents) {
     chunks = [""];
   }
+  let delivered = false;
   for (const chunk of chunks) {
     if (!chunk.trim() && !firstMessageComponents) {
       continue;
     }
-    await sendMessage(chunk, undefined, firstMessageComponents);
+    delivered = (await sendMessage(chunk, undefined, firstMessageComponents)) || delivered;
   }
+  return delivered;
 }

--- a/extensions/discord/src/monitor/reply-delivery.test.ts
+++ b/extensions/discord/src/monitor/reply-delivery.test.ts
@@ -157,6 +157,22 @@ describe("deliverDiscordReply", () => {
     ).rejects.toThrow("discord final reply produced no delivered message for channel:101");
   });
 
+  it("fails when a final reply sanitizes down to no visible Discord payload", async () => {
+    await expect(
+      deliverDiscordReply({
+        replies: [{ text: "analysis: internal only\ncommentary: tool trace only" }],
+        target: "channel:101",
+        token: "token",
+        accountId: "default",
+        runtime,
+        cfg,
+        textLimit: 2000,
+        kind: "final",
+      }),
+    ).rejects.toThrow("discord final reply sanitized to empty for channel:101");
+    expect(sendDurableMessageBatchMock).not.toHaveBeenCalled();
+  });
+
   it("preserves explicit tool progress payloads at the tool delivery boundary", async () => {
     await deliverDiscordReply({
       replies: [{ text: "🛠️ Exec: `echo visible`" }],

--- a/extensions/discord/src/monitor/reply-delivery.ts
+++ b/extensions/discord/src/monitor/reply-delivery.ts
@@ -179,6 +179,9 @@ export async function deliverDiscordReply(params: {
   const delivery = resolveDiscordDeliveryOptions(params);
   const payloads = sanitizeDiscordFrontChannelReplyPayloads(params.replies, { kind: params.kind });
   if (payloads.length === 0) {
+    if (params.kind === "final") {
+      throw new Error(`discord final reply sanitized to empty for ${delivery.to}`);
+    }
     return;
   }
 


### PR DESCRIPTION
## Scope
- Return an explicit delivery result from Discord interaction replies so expired interactions are not counted as delivered.
- Fail final Discord delivery when sanitizer removes all visible/sendable payload content.
- Normalize Discord message send extraction for both `send` and `sendMessage` actions.

## Non-goals
- No changes to Discord transport connection, auth, or gateway startup.
- No changes to deliberate silent `NO_REPLY` handling before final delivery.

## Risk
Low. The change is scoped to Discord reply accounting and message-tool send target extraction. The main behavioral change is surfacing empty final replies as delivery failures instead of silent success.

## Rollback
Revert commit `64f2dc4b2d`.

## Real behavior proof
**Behavior or issue addressed:** Discord final reply delivery after applying the equivalent local runtime hotfix no longer silently completes for normal visible replies; the live channel continued receiving final assistant replies and the Discord transport stayed healthy.

**Real environment tested:** Richard's real OpenClaw gateway using Discord channel `#starlord-infra`, installed OpenClaw `2026.5.22` with the equivalent local Discord delivery-accounting hotfix applied before this PR was ported back to source.

**Exact steps or command run after the patch:**
1. Applied the equivalent hotfix to the installed OpenClaw runtime bundles.
2. Restarted/verified the live gateway loaded the patched runtime.
3. Sent live Discord turns through the active `#starlord-infra` channel.
4. Ran `openclaw channels status --probe && openclaw gateway stability` after the visible Discord replies landed.

**Evidence after fix:**

```text
Checking channel status (probe)...
Gateway reachable.
- Discord default: enabled, configured, running, connected, in:20m ago, out:39m ago, transport:just now, bot:@Starlord, token:config, intents:content=limited, works, audit ok
Gateway Stability
Recent:
  2026-05-26T01:49:44.186Z #3701 diagnostic.heartbeat queued=0
```

**Observed result after fix:** The same real Discord setup delivered visible final replies after the hotfix, while the gateway reported Discord `works` and queue depth `0`. This PR ports that runtime hotfix into source and adds regression coverage for the expired-interaction accounting path, sanitizer-empty final path, and `send`/`sendMessage` extraction mismatch.

**What was not tested:** I did not force a real expired Discord slash-interaction token in production; that path is covered by unit regression because manufacturing an expired live token would be brittle and user-visible.

## Verification
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-discord.config.ts extensions/discord/src/monitor/native-command-reply.test.ts extensions/discord/src/monitor/reply-delivery.test.ts extensions/discord/src/channel-actions.test.ts` -> 3 files / 38 tests passed
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/discord/src/monitor/native-command-reply.ts extensions/discord/src/monitor/native-command-agent-reply.ts extensions/discord/src/monitor/reply-delivery.ts extensions/discord/src/channel-actions.ts extensions/discord/src/monitor/native-command-reply.test.ts extensions/discord/src/monitor/reply-delivery.test.ts extensions/discord/src/channel-actions.test.ts` -> passed
- `corepack pnpm exec oxfmt --check extensions/discord/src/monitor/native-command-reply.ts extensions/discord/src/monitor/native-command-agent-reply.ts extensions/discord/src/monitor/reply-delivery.ts extensions/discord/src/channel-actions.ts extensions/discord/src/monitor/native-command-reply.test.ts extensions/discord/src/monitor/reply-delivery.test.ts extensions/discord/src/channel-actions.test.ts` -> passed
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --noEmit` -> passed