### PR TITLE
fix(irc): use channel routes for group inbound targets

### DIFF
--- a/extensions/irc/src/inbound.behavior.test.ts
+++ b/extensions/irc/src/inbound.behavior.test.ts
@@ -241,6 +241,7 @@ describe("irc inbound behavior", () => {
     ).toBe(1);
     expect(runtime.log).not.toHaveBeenCalled();
     expect(ctx?.From).toBe("channel:#ops");
+    expect(ctx?.To).toBe("channel:#ops");
     expect(ctx?.OriginatingTo).toBe("channel:#ops");
   });
 });

--- a/extensions/irc/src/inbound.ts
+++ b/extensions/irc/src/inbound.ts
@@ -377,7 +377,7 @@ export async function handleIrcInbound(params: {
     RawBody: rawBody,
     CommandBody: rawBody,
     From: message.isGroup ? `channel:${channelTarget}` : `irc:${senderDisplay}`,
-    To: `irc:${peerId}`,
+    To: message.isGroup ? `channel:${channelTarget}` : `irc:${peerId}`,
     SessionKey: route.sessionKey,
     AccountId: route.accountId,
     ChatType: message.isGroup ? "group" : "direct",


### PR DESCRIPTION
## Summary
- Normalize IRC inbound group To context routes to channel:#room so group messages use the same channel conversation route for From, To, and OriginatingTo.
- Preserve direct-message To routes as irc:nick; this PR intentionally does not change direct-message routing behavior.
- Add regression coverage alongside the existing group From and OriginatingTo assertions.
- Success looks like IRC group inbound turns consistently routing to the channel conversation while existing direct-message behavior remains unchanged.
- Review focus: IRC inbound route normalization and the regression coverage around group versus direct-message targets.

## Linked context
Closes #85897

Related issues, PRs, or discussions: none known beyond the linked issue.

Maintainer or owner request: not a direct maintainer request; this PR addresses the linked IRC route-consistency issue and follow-up review/proof requirements.

## Real behavior proof (required for external PRs)
- Behavior or issue addressed: IRC group inbound messages now route to the channel conversation consistently. For a group PRIVMSG to #ops, the fixed runtime context uses channel:#ops for From, To, and OriginatingTo; direct-message routing remains outside this PR's changed path.
- Real environment tested: Linux source checkout of this PR branch, using the real IRC socket client, monitorIrcProvider, and handleIrcInbound runtime path. The IRC peer was a local loopback TCP IRC server so the proof does not require external IRC credentials or a public network.
- Exact steps or command run after this patch: From the repository root, ran the validation commands listed in ## Tests and validation, then ran this source-checkout proof command:

~~~bash
OPENCLAW_STATE_DIR="$(mktemp -d)" COREPACK_HOME=<writable-cache> pnpm exec tsx - <<'TS'
// Starts a local TCP IRC server, starts monitorIrcProvider against it,
// sends :alice!ident@example.com PRIVMSG #ops :hello from local irc proof,
// captures the assembled OpenClaw inbound turn, prints the socket transcript
// and the finalized IRC context fields.
TS
~~~

- Evidence after fix: copied live terminal output from the source-checkout IRC runtime proof follows.

~~~text
Source-checkout IRC runtime proof (#86721)
localServer=127.0.0.1:35391
socketTranscript:
  client -> NICK OpenClawProof
  client -> USER openclaw 0 * :OpenClaw local proof
  server -> :proof.local 001 OpenClawProof :welcome to local proof IRC
  debug: [default] << :proof.local 001 OpenClawProof :welcome to local proof IRC
  info: [default] connected to 127.0.0.1:35391 as OpenClawProof
  client -> JOIN #ops
  server -> :alice!ident@example.com PRIVMSG #ops :hello from local irc proof
  debug: [default] << :alice!ident@example.com PRIVMSG #ops :hello from local irc proof
activityRecords:
[
  {
    "channel": "irc",
    "accountId": "default",
    "direction": "inbound",
    "at": 1779784845504
  }
]
capturedTurn:
{
  "routeSessionKey": "agent:default:irc:group:#ops",
  "accountId": "default",
  "deliveryTarget": "#ops",
  "ctx": {
    "From": "channel:#ops",
    "To": "channel:#ops",
    "OriginatingTo": "channel:#ops",
    "ChatType": "group",
    "Provider": "irc",
    "Surface": "irc",
    "SenderId": "alice!ident@example.com",
    "ConversationLabel": "#ops",
    "BodyForAgent": "hello from local irc proof"
  }
}
~~~

- Observed result after fix: The real IRC monitor/client path accepted a loopback IRC PRIVMSG for #ops, recorded one inbound IRC activity event, and assembled the OpenClaw inbound turn with From, To, and OriginatingTo all set to channel:#ops.
- What was not tested: A public external IRC network was not used, and no production OpenClaw state or credentials were touched. The proof stops at assembled inbound turn capture rather than invoking a live model reply.
- Proof limitations or environment constraints: The proof uses a local loopback IRC server to exercise the same socket-monitor runtime path without external credentials or public network state.
- Before evidence (optional but encouraged): Not captured in this run; the regression test and runtime proof focus on the after-fix route fields for the linked issue.

## Tests and validation
Commands run:
- CI=true COREPACK_HOME=<writable-cache> node scripts/test-projects.mjs extensions/irc/src/inbound.behavior.test.ts - passed, 1 file / 4 tests
- CI=true COREPACK_HOME=<writable-cache> pnpm run lint:extensions:bundled - passed
- CI=true COREPACK_HOME=<writable-cache> pnpm -s check:test-types - passed
- git diff --check upstream/main...HEAD - passed
- git merge-tree --write-tree HEAD upstream/main - passed, produced tree 18e324ebe93f3131191c3f97227e42296d406f7a

Regression coverage added:
- extensions/irc/src/inbound.behavior.test.ts now covers group inbound To route normalization next to the existing group From and OriginatingTo route assertions.

Failed before this fix:
- The linked issue expected IRC group inbound target routes to resolve to the channel route; before the fix, the group To context did not consistently use channel:#room.

If no test was added, why not?
- Not applicable; regression coverage was added.

## Risk checklist
Did user-visible behavior change? (Yes/No)

Yes. IRC group inbound context now identifies the target as the channel route.

Did config, environment, or migration behavior change? (Yes/No)

No.

Did security, auth, secrets, network, or tool execution behavior change? (Yes/No)

No.

What is the highest-risk area?

Downstream behavior that reads IRC inbound ctx.To for group messages.

How is that risk mitigated?

The change is limited to IRC group inbound route normalization, direct-message routing is preserved, regression coverage checks group and direct-message behavior, and the source-checkout proof exercises the real IRC monitor/client path.

## Current review state
What is the next action?

Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

No known author action remains after this body/template repair. The PR is labeled proof: supplied, proof: sufficient, and status: ready for maintainer look; maintainer review remains the next step.

Which bot or reviewer comments were addressed?

The PR body now preserves every current upstream template heading. Earlier proof feedback is addressed by the source-checkout IRC runtime proof above.
