### PR TITLE
fix(tui): queue prompts submitted while busy

### DIFF
--- a/src/tui/components/chat-log.test.ts
+++ b/src/tui/components/chat-log.test.ts
@@ -74,6 +74,16 @@ describe("ChatLog", () => {
     expect(chatLog.children.length).toBe(1);
   });
 
+  it("reserves assistant position without clearing existing streamed text", () => {
+    const chatLog = new ChatLog(40);
+    chatLog.startAssistant("partial", "run-active");
+    chatLog.reserveAssistantSlot("run-active");
+
+    const rendered = chatLog.render(120).join("\n");
+    expect(rendered).toContain("partial");
+    expect(chatLog.children.length).toBe(1);
+  });
+
   it("drops stale tool references when old components are pruned", () => {
     const chatLog = new ChatLog(20);
     chatLog.startTool("tool-1", "read_file", { path: "a.txt" });

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -263,6 +263,15 @@ export class ChatLog extends Container {
     return component;
   }
 
+  reserveAssistantSlot(runId?: string) {
+    const effectiveRunId = this.resolveRunId(runId);
+    const existing = this.streamingRuns.get(effectiveRunId);
+    if (existing) {
+      return existing;
+    }
+    return this.startAssistant("", runId);
+  }
+
   updateAssistant(text: string, runId?: string) {
     const effectiveRunId = this.resolveRunId(runId);
     const existing = this.streamingRuns.get(effectiveRunId);

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -708,19 +708,13 @@ describe("EmbeddedTuiBackend", () => {
       payloads: Array<{ text: string }>;
       meta: Record<string, unknown>;
     }>();
-    const second = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
     const firstAbortListener = vi.fn(() => {
       first.resolve({ payloads: [{ text: "first aborted" }], meta: {} });
     });
-    agentCommandFromIngressMock
-      .mockImplementationOnce((opts: { abortSignal?: AbortSignal }) => {
-        opts.abortSignal?.addEventListener("abort", firstAbortListener);
-        return first.promise;
-      })
-      .mockReturnValueOnce(second.promise);
+    agentCommandFromIngressMock.mockImplementationOnce((opts: { abortSignal?: AbortSignal }) => {
+      opts.abortSignal?.addEventListener("abort", firstAbortListener);
+      return first.promise;
+    });
 
     const backend = new EmbeddedTuiBackend();
     backend.start();
@@ -743,9 +737,7 @@ describe("EmbeddedTuiBackend", () => {
     });
 
     expect(firstAbortListener).toHaveBeenCalledTimes(1);
-    expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(2);
-
-    second.resolve({ payloads: [{ text: "stopped" }], meta: {} });
+    expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
     await flushMicrotasks();
   });
 

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -640,6 +640,56 @@ describe("EmbeddedTuiBackend", () => {
     await flushMicrotasks();
   });
 
+  it("queues same-session sends behind active local runs", async () => {
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const first = deferred<{
+      payloads: Array<{ text: string }>;
+      meta: Record<string, unknown>;
+    }>();
+    const second = deferred<{
+      payloads: Array<{ text: string }>;
+      meta: Record<string, unknown>;
+    }>();
+    const firstAbortListener = vi.fn();
+    agentCommandFromIngressMock
+      .mockImplementationOnce((opts: { abortSignal?: AbortSignal }) => {
+        opts.abortSignal?.addEventListener("abort", firstAbortListener);
+        return first.promise;
+      })
+      .mockReturnValueOnce(second.promise);
+
+    const backend = new EmbeddedTuiBackend();
+    backend.start();
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "first",
+      runId: "run-local-first",
+    });
+
+    registeredListener?.({
+      runId: "run-local-first",
+      stream: "assistant",
+      data: { text: "first response", delta: "first response" },
+    });
+
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "second",
+      runId: "run-local-second",
+    });
+
+    expect(firstAbortListener).not.toHaveBeenCalled();
+    expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
+
+    first.resolve({ payloads: [{ text: "first done" }], meta: {} });
+    await vi.waitFor(() => {
+      expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(2);
+    });
+
+    second.resolve({ payloads: [{ text: "second done" }], meta: {} });
+    await flushMicrotasks();
+  });
+
   it("queues same-session sends behind terminal local runs until maintenance settles", async () => {
     const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const first = deferred<{

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -741,6 +741,28 @@ describe("EmbeddedTuiBackend", () => {
     await flushMicrotasks();
   });
 
+  it("sends broad stop-like text as a normal prompt when idle", async () => {
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const pending = deferred<{
+      payloads: Array<{ text: string }>;
+      meta: Record<string, unknown>;
+    }>();
+    agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
+
+    const backend = new EmbeddedTuiBackend();
+    backend.start();
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "do not do that",
+      runId: "run-local-normal-stop-like-text",
+    });
+
+    expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
+
+    pending.resolve({ payloads: [{ text: "normal prompt" }], meta: {} });
+    await flushMicrotasks();
+  });
+
   it("queues same-session sends behind terminal local runs until maintenance settles", async () => {
     const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const first = deferred<{

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -818,6 +818,46 @@ describe("EmbeddedTuiBackend", () => {
     await flushMicrotasks();
   });
 
+  it("sends idle slash stop as a normal prompt so the TUI receives a terminal event", async () => {
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const pending = deferred<{
+      payloads: Array<{ text: string }>;
+      meta: Record<string, unknown>;
+    }>();
+    agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
+
+    const backend = new EmbeddedTuiBackend();
+    const events: Array<{ event: string; payload: unknown }> = [];
+    backend.onEvent = (evt) => {
+      events.push({ event: evt.event, payload: evt.payload });
+    };
+    backend.start();
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "/stop",
+      runId: "run-local-idle-stop",
+    });
+
+    expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
+
+    pending.resolve({ payloads: [{ text: "idle stop prompt" }], meta: {} });
+    await flushMicrotasks();
+
+    expect(events).toContainEqual({
+      event: "chat",
+      payload: {
+        runId: "run-local-idle-stop",
+        sessionKey: "agent:main:main",
+        state: "final",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "idle stop prompt" }],
+          timestamp: embeddedEventTimestamp,
+        },
+      },
+    });
+  });
+
   it("queues same-session sends behind terminal local runs until maintenance settles", async () => {
     const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const first = deferred<{

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -702,6 +702,53 @@ describe("EmbeddedTuiBackend", () => {
     }
   });
 
+  it("does not queue stop commands behind active local runs", async () => {
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const first = deferred<{
+      payloads: Array<{ text: string }>;
+      meta: Record<string, unknown>;
+    }>();
+    const second = deferred<{
+      payloads: Array<{ text: string }>;
+      meta: Record<string, unknown>;
+    }>();
+    const firstAbortListener = vi.fn(() => {
+      first.resolve({ payloads: [{ text: "first aborted" }], meta: {} });
+    });
+    agentCommandFromIngressMock
+      .mockImplementationOnce((opts: { abortSignal?: AbortSignal }) => {
+        opts.abortSignal?.addEventListener("abort", firstAbortListener);
+        return first.promise;
+      })
+      .mockReturnValueOnce(second.promise);
+
+    const backend = new EmbeddedTuiBackend();
+    backend.start();
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "first",
+      runId: "run-local-first",
+    });
+
+    registeredListener?.({
+      runId: "run-local-first",
+      stream: "assistant",
+      data: { text: "first response", delta: "first response" },
+    });
+
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "/stop",
+      runId: "run-local-stop",
+    });
+
+    expect(firstAbortListener).toHaveBeenCalledTimes(1);
+    expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(2);
+
+    second.resolve({ payloads: [{ text: "stopped" }], meta: {} });
+    await flushMicrotasks();
+  });
+
   it("queues same-session sends behind terminal local runs until maintenance settles", async () => {
     const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const first = deferred<{

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -741,6 +741,45 @@ describe("EmbeddedTuiBackend", () => {
     await flushMicrotasks();
   });
 
+  it("stops terminal local runs while post-turn maintenance is pending", async () => {
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const first = deferred<{
+      payloads: Array<{ text: string }>;
+      meta: Record<string, unknown>;
+    }>();
+    const firstAbortListener = vi.fn(() => {
+      first.resolve({ payloads: [{ text: "first aborted" }], meta: {} });
+    });
+    agentCommandFromIngressMock.mockImplementationOnce((opts: { abortSignal?: AbortSignal }) => {
+      opts.abortSignal?.addEventListener("abort", firstAbortListener);
+      return first.promise;
+    });
+
+    const backend = new EmbeddedTuiBackend();
+    backend.start();
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "first",
+      runId: "run-local-first-terminal",
+    });
+
+    registeredListener?.({
+      runId: "run-local-first-terminal",
+      stream: "lifecycle",
+      data: { phase: "end", stopReason: "stop" },
+    });
+
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "/stop",
+      runId: "run-local-stop-terminal",
+    });
+
+    expect(firstAbortListener).toHaveBeenCalledTimes(1);
+    expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
+    await flushMicrotasks();
+  });
+
   it("sends broad stop-like text as a normal prompt when idle", async () => {
     const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const pending = deferred<{

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -641,53 +641,65 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("queues same-session sends behind active local runs", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const first = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
-    const second = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
-    const firstAbortListener = vi.fn();
-    agentCommandFromIngressMock
-      .mockImplementationOnce((opts: { abortSignal?: AbortSignal }) => {
-        opts.abortSignal?.addEventListener("abort", firstAbortListener);
-        return first.promise;
-      })
-      .mockReturnValueOnce(second.promise);
+    const previous = process.env.OPENCLAW_TUI_LOCAL_RUN_SHUTDOWN_GRACE_MS;
+    process.env.OPENCLAW_TUI_LOCAL_RUN_SHUTDOWN_GRACE_MS = "5";
+    try {
+      const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+      const first = deferred<{
+        payloads: Array<{ text: string }>;
+        meta: Record<string, unknown>;
+      }>();
+      const second = deferred<{
+        payloads: Array<{ text: string }>;
+        meta: Record<string, unknown>;
+      }>();
+      const firstAbortListener = vi.fn();
+      agentCommandFromIngressMock
+        .mockImplementationOnce((opts: { abortSignal?: AbortSignal }) => {
+          opts.abortSignal?.addEventListener("abort", firstAbortListener);
+          return first.promise;
+        })
+        .mockReturnValueOnce(second.promise);
 
-    const backend = new EmbeddedTuiBackend();
-    backend.start();
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "first",
-      runId: "run-local-first",
-    });
+      const backend = new EmbeddedTuiBackend();
+      backend.start();
+      await backend.sendChat({
+        sessionKey: "agent:main:main",
+        message: "first",
+        runId: "run-local-first",
+      });
 
-    registeredListener?.({
-      runId: "run-local-first",
-      stream: "assistant",
-      data: { text: "first response", delta: "first response" },
-    });
+      registeredListener?.({
+        runId: "run-local-first",
+        stream: "assistant",
+        data: { text: "first response", delta: "first response" },
+      });
 
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "second",
-      runId: "run-local-second",
-    });
+      await backend.sendChat({
+        sessionKey: "agent:main:main",
+        message: "second",
+        runId: "run-local-second",
+      });
+      await vi.advanceTimersByTimeAsync(5);
+      await flushMicrotasks();
 
-    expect(firstAbortListener).not.toHaveBeenCalled();
-    expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
+      expect(firstAbortListener).not.toHaveBeenCalled();
+      expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
 
-    first.resolve({ payloads: [{ text: "first done" }], meta: {} });
-    await vi.waitFor(() => {
-      expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(2);
-    });
+      first.resolve({ payloads: [{ text: "first done" }], meta: {} });
+      await vi.waitFor(() => {
+        expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(2);
+      });
 
-    second.resolve({ payloads: [{ text: "second done" }], meta: {} });
-    await flushMicrotasks();
+      second.resolve({ payloads: [{ text: "second done" }], meta: {} });
+      await flushMicrotasks();
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENCLAW_TUI_LOCAL_RUN_SHUTDOWN_GRACE_MS;
+      } else {
+        process.env.OPENCLAW_TUI_LOCAL_RUN_SHUTDOWN_GRACE_MS = previous;
+      }
+    }
   });
 
   it("queues same-session sends behind terminal local runs until maintenance settles", async () => {

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -498,6 +498,10 @@ describe("EmbeddedTuiBackend", () => {
     });
 
     const backend = new EmbeddedTuiBackend();
+    const events: Array<{ event: string; payload: unknown }> = [];
+    backend.onEvent = (evt) => {
+      events.push({ event: evt.event, payload: evt.payload });
+    };
     backend.start();
     await backend.sendChat({
       sessionKey: "agent:main:main",
@@ -756,6 +760,10 @@ describe("EmbeddedTuiBackend", () => {
     });
 
     const backend = new EmbeddedTuiBackend();
+    const events: Array<{ event: string; payload: unknown }> = [];
+    backend.onEvent = (evt) => {
+      events.push({ event: evt.event, payload: evt.payload });
+    };
     backend.start();
     await backend.sendChat({
       sessionKey: "agent:main:main",
@@ -778,6 +786,14 @@ describe("EmbeddedTuiBackend", () => {
     expect(firstAbortListener).toHaveBeenCalledTimes(1);
     expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
     await flushMicrotasks();
+    expect(events).toContainEqual({
+      event: "chat",
+      payload: {
+        runId: "run-local-first-terminal",
+        sessionKey: "agent:main:main",
+        state: "aborted",
+      },
+    });
   });
 
   it("sends broad stop-like text as a normal prompt when idle", async () => {

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -861,6 +861,10 @@ export class EmbeddedTuiBackend implements TuiBackend {
       if (!run) {
         return;
       }
+      if (params.controller.signal.aborted || result?.meta?.aborted === true) {
+        this.emitChatAborted(params.runId, run);
+        return;
+      }
 
       if (run.isBtw) {
         const text = payloadText(result?.payloads);

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -135,11 +135,6 @@ function resolveBtwQuestion(message: string): string | undefined {
   return question ? question : undefined;
 }
 
-function isSlashStopCommand(text: string): boolean {
-  const trimmed = text.trim();
-  return trimmed.startsWith("/") && isChatStopCommandText(trimmed);
-}
-
 function payloadText(parts: unknown): string {
   if (!Array.isArray(parts)) {
     return "";
@@ -331,9 +326,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
     const runId = opts.runId ?? randomUUID();
     const question = resolveBtwQuestion(opts.message);
     const abortableSessionRun = this.hasAbortableSessionRun(opts.sessionKey);
-    const stopCommand =
-      isChatStopCommandText(opts.message) &&
-      (isSlashStopCommand(opts.message) || abortableSessionRun);
+    const stopCommand = abortableSessionRun && isChatStopCommandText(opts.message);
     const queuedAfter =
       question || stopCommand ? undefined : this.findQueuedSessionRunPromise(opts.sessionKey);
     if (stopCommand) {

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -135,6 +135,11 @@ function resolveBtwQuestion(message: string): string | undefined {
   return question ? question : undefined;
 }
 
+function isSlashStopCommand(text: string): boolean {
+  const trimmed = text.trim();
+  return trimmed.startsWith("/") && isChatStopCommandText(trimmed);
+}
+
 function payloadText(parts: unknown): string {
   if (!Array.isArray(parts)) {
     return "";
@@ -325,7 +330,10 @@ export class EmbeddedTuiBackend implements TuiBackend {
   async sendChat(opts: ChatSendOptions): Promise<{ runId: string }> {
     const runId = opts.runId ?? randomUUID();
     const question = resolveBtwQuestion(opts.message);
-    const stopCommand = isChatStopCommandText(opts.message);
+    const abortableSessionRun = this.hasAbortableSessionRun(opts.sessionKey);
+    const stopCommand =
+      isChatStopCommandText(opts.message) &&
+      (isSlashStopCommand(opts.message) || abortableSessionRun);
     const queuedAfter =
       question || stopCommand ? undefined : this.findQueuedSessionRunPromise(opts.sessionKey);
     if (stopCommand) {
@@ -543,6 +551,15 @@ export class EmbeddedTuiBackend implements TuiBackend {
         run.controller.abort();
       }
     }
+  }
+
+  private hasAbortableSessionRun(sessionKey: string): boolean {
+    for (const run of this.runs.values()) {
+      if (run.sessionKey === sessionKey && !run.isBtw && !run.lifecycleEnded) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private nextSeq() {

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -12,6 +12,7 @@ import { createDefaultDeps } from "../cli/deps.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { updateSessionStore } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isChatStopCommandText } from "../gateway/chat-abort.js";
 import {
   projectRecentChatDisplayMessages,
   resolveEffectiveChatHistoryMaxChars,
@@ -323,7 +324,12 @@ export class EmbeddedTuiBackend implements TuiBackend {
   async sendChat(opts: ChatSendOptions): Promise<{ runId: string }> {
     const runId = opts.runId ?? randomUUID();
     const question = resolveBtwQuestion(opts.message);
-    const queuedAfter = question ? undefined : this.findQueuedSessionRunPromise(opts.sessionKey);
+    const stopCommand = isChatStopCommandText(opts.message);
+    const queuedAfter =
+      question || stopCommand ? undefined : this.findQueuedSessionRunPromise(opts.sessionKey);
+    if (stopCommand) {
+      this.abortSessionRuns(opts.sessionKey);
+    }
     const controller = new AbortController();
     const queuedRunReadiness = createQueuedRunReadiness();
     this.runs.set(runId, {
@@ -527,6 +533,14 @@ export class EmbeddedTuiBackend implements TuiBackend {
       }
     }
     return queuedAfter;
+  }
+
+  private abortSessionRuns(sessionKey: string) {
+    for (const run of this.runs.values()) {
+      if (run.sessionKey === sessionKey && !run.isBtw && !run.lifecycleEnded) {
+        run.controller.abort();
+      }
+    }
   }
 
   private nextSeq() {

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -290,12 +290,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
   async sendChat(opts: ChatSendOptions): Promise<{ runId: string }> {
     const runId = opts.runId ?? randomUUID();
     const question = resolveBtwQuestion(opts.message);
-    const queuedAfter = question ? undefined : this.findPendingSessionRunPromise(opts.sessionKey);
-    if (!question) {
-      if (!queuedAfter) {
-        this.abortSessionRuns(opts.sessionKey);
-      }
-    }
+    const queuedAfter = question ? undefined : this.findQueuedSessionRunPromise(opts.sessionKey);
     const controller = new AbortController();
     this.runs.set(runId, {
       sessionKey: opts.sessionKey,
@@ -485,21 +480,14 @@ export class EmbeddedTuiBackend implements TuiBackend {
     }));
   }
 
-  private abortSessionRuns(sessionKey: string) {
-    for (const run of this.runs.values()) {
-      if (run.sessionKey === sessionKey && !run.isBtw && !run.lifecycleEnded && !run.finishing) {
-        run.controller.abort();
-      }
-    }
-  }
-
-  private findPendingSessionRunPromise(sessionKey: string): Promise<void> | undefined {
+  private findQueuedSessionRunPromise(sessionKey: string): Promise<void> | undefined {
+    let queuedAfter: Promise<void> | undefined;
     for (const [runId, run] of this.runs) {
-      if (run.sessionKey === sessionKey && !run.isBtw && (run.finishing || run.lifecycleEnded)) {
-        return this.runPromises.get(runId);
+      if (run.sessionKey === sessionKey && !run.isBtw) {
+        queuedAfter = this.runPromises.get(runId) ?? queuedAfter;
       }
     }
-    return undefined;
+    return queuedAfter;
   }
 
   private nextSeq() {

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -177,6 +177,7 @@ function createQueuedRunReadiness() {
   if (!resolve) {
     throw new Error("Expected queue readiness resolver to be initialized");
   }
+  const resolveReady = resolve;
   let settled = false;
   return {
     promise,
@@ -185,7 +186,7 @@ function createQueuedRunReadiness() {
         return;
       }
       settled = true;
-      resolve();
+      resolveReady();
     },
   };
 }

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -379,7 +379,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
     if (!run || run.sessionKey !== opts.sessionKey) {
       return { ok: true, aborted: false };
     }
-    if (run.lifecycleEnded) {
+    if (!this.isAbortableRun(opts.runId, run)) {
       return { ok: true, aborted: false };
     }
     run.controller.abort();
@@ -546,20 +546,24 @@ export class EmbeddedTuiBackend implements TuiBackend {
   }
 
   private abortSessionRuns(sessionKey: string) {
-    for (const run of this.runs.values()) {
-      if (run.sessionKey === sessionKey && !run.isBtw && !run.lifecycleEnded) {
+    for (const [runId, run] of this.runs) {
+      if (run.sessionKey === sessionKey && !run.isBtw && this.isAbortableRun(runId, run)) {
         run.controller.abort();
       }
     }
   }
 
   private hasAbortableSessionRun(sessionKey: string): boolean {
-    for (const run of this.runs.values()) {
-      if (run.sessionKey === sessionKey && !run.isBtw && !run.lifecycleEnded) {
+    for (const [runId, run] of this.runs) {
+      if (run.sessionKey === sessionKey && !run.isBtw && this.isAbortableRun(runId, run)) {
         return true;
       }
     }
     return false;
+  }
+
+  private isAbortableRun(runId: string, run: LocalRunState): boolean {
+    return !run.lifecycleEnded || this.runPromises.has(runId);
   }
 
   private nextSeq() {

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -75,6 +75,13 @@ type LocalRunState = {
   lifecycleStopReason?: string;
   finalSent: boolean;
   registered: boolean;
+  queuedRunReady: Promise<void>;
+  markQueuedRunReady: () => void;
+};
+
+type QueuedSessionRun = {
+  run: LocalRunState;
+  promise: Promise<void>;
 };
 
 const LIFECYCLE_ERROR_RETRY_GRACE_MS = 15_000;
@@ -161,6 +168,27 @@ function resolveDeltaPayload(text: string, previousText: string | undefined) {
   return { deltaText: text.slice(previousText.length) };
 }
 
+function createQueuedRunReadiness() {
+  let resolve: (() => void) | undefined;
+  const promise = new Promise<void>((ready) => {
+    resolve = ready;
+  });
+  if (!resolve) {
+    throw new Error("Expected queue readiness resolver to be initialized");
+  }
+  let settled = false;
+  return {
+    promise,
+    markReady: () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve();
+    },
+  };
+}
+
 async function waitForLocalRunShutdown(promises: Promise<void>[]): Promise<boolean> {
   if (promises.length === 0) {
     return true;
@@ -186,7 +214,12 @@ async function waitForLocalRunShutdown(promises: Promise<void>[]): Promise<boole
   return completed;
 }
 
-async function waitForQueuedLocalRun(previousRun: Promise<void>, runId: string): Promise<void> {
+async function waitForQueuedLocalRun(previousRun: QueuedSessionRun, runId: string): Promise<void> {
+  await previousRun.run.queuedRunReady;
+  if (!previousRun.run.finishing && !previousRun.run.lifecycleEnded) {
+    await previousRun.promise;
+    return;
+  }
   const timeoutMs = resolveLocalRunShutdownGraceMs();
   if (timeoutMs <= 0) {
     throw new Error(
@@ -196,7 +229,7 @@ async function waitForQueuedLocalRun(previousRun: Promise<void>, runId: string):
   let timeout: ReturnType<typeof setTimeout> | undefined;
   try {
     await Promise.race([
-      previousRun,
+      previousRun.promise,
       new Promise<void>((_, reject) => {
         timeout = setTimeout(() => {
           reject(
@@ -292,6 +325,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
     const question = resolveBtwQuestion(opts.message);
     const queuedAfter = question ? undefined : this.findQueuedSessionRunPromise(opts.sessionKey);
     const controller = new AbortController();
+    const queuedRunReadiness = createQueuedRunReadiness();
     this.runs.set(runId, {
       sessionKey: opts.sessionKey,
       controller,
@@ -302,6 +336,8 @@ export class EmbeddedTuiBackend implements TuiBackend {
       lifecycleEnded: false,
       finalSent: false,
       registered: false,
+      queuedRunReady: queuedRunReadiness.promise,
+      markQueuedRunReady: queuedRunReadiness.markReady,
     });
 
     const runPromise = this.runTurn({
@@ -480,11 +516,14 @@ export class EmbeddedTuiBackend implements TuiBackend {
     }));
   }
 
-  private findQueuedSessionRunPromise(sessionKey: string): Promise<void> | undefined {
-    let queuedAfter: Promise<void> | undefined;
+  private findQueuedSessionRunPromise(sessionKey: string): QueuedSessionRun | undefined {
+    let queuedAfter: QueuedSessionRun | undefined;
     for (const [runId, run] of this.runs) {
       if (run.sessionKey === sessionKey && !run.isBtw) {
-        queuedAfter = this.runPromises.get(runId) ?? queuedAfter;
+        const promise = this.runPromises.get(runId);
+        if (promise) {
+          queuedAfter = { run, promise };
+        }
       }
     }
     return queuedAfter;
@@ -558,6 +597,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
 
   private emitChatFinal(runId: string, run: LocalRunState, stopReason?: string) {
     this.clearPendingLifecycleError(runId);
+    run.markQueuedRunReady();
     const alreadyFinal = run.finalSent;
     run.finishing = false;
     run.lifecycleEnded = true;
@@ -591,6 +631,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
 
   private emitChatAborted(runId: string, run: LocalRunState) {
     this.clearPendingLifecycleError(runId);
+    run.markQueuedRunReady();
     const alreadyFinal = run.finalSent;
     run.finishing = false;
     run.lifecycleEnded = true;
@@ -609,6 +650,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
 
   private emitChatError(runId: string, run: LocalRunState, errorMessage?: string) {
     this.clearPendingLifecycleError(runId);
+    run.markQueuedRunReady();
     const alreadyFinal = run.finalSent;
     run.finishing = false;
     run.lifecycleEnded = true;
@@ -694,6 +736,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
     const aborted = evt.data?.aborted === true || run.controller.signal.aborted;
     if (phase === "finishing") {
       run.finishing = true;
+      run.markQueuedRunReady();
       run.lifecycleStopReason =
         typeof evt.data?.stopReason === "string" ? evt.data.stopReason : undefined;
       return;
@@ -705,6 +748,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
         return;
       }
       run.lifecycleEnded = true;
+      run.markQueuedRunReady();
       run.lifecycleStopReason =
         typeof evt.data?.stopReason === "string" ? evt.data.stopReason : undefined;
       return;
@@ -730,7 +774,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
     deliver?: boolean;
     timeoutMs?: number;
     controller: AbortController;
-    queuedAfter?: Promise<void>;
+    queuedAfter?: QueuedSessionRun;
   }) {
     try {
       if (params.queuedAfter) {
@@ -818,6 +862,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       const errorMessage = error instanceof Error ? error.message : String(error);
       this.emitChatError(params.runId, run, errorMessage);
     } finally {
+      this.runs.get(params.runId)?.markQueuedRunReady();
       this.runs.delete(params.runId);
     }
   }

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -330,6 +330,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       question || stopCommand ? undefined : this.findQueuedSessionRunPromise(opts.sessionKey);
     if (stopCommand) {
       this.abortSessionRuns(opts.sessionKey);
+      return { runId };
     }
     const controller = new AbortController();
     const queuedRunReadiness = createQueuedRunReadiness();

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -500,8 +500,9 @@ describe("tui command handlers", () => {
     expect(setActivityStatus).toHaveBeenLastCalledWith("disconnected");
   });
 
-  it("sends normal prompts while a run is active so queue policy can handle them", async () => {
+  it("sends local prompts while a run is active so queue policy can handle them", async () => {
     const { handleCommand, sendChat, addUser, addSystem, requestRender, state } = createHarness({
+      opts: { local: true },
       activeChatRunId: "run-active",
       activityStatus: "streaming",
     });
@@ -520,6 +521,21 @@ describe("tui command handlers", () => {
     expect(requestRender).toHaveBeenCalled();
     expect(state.activeChatRunId).toBe("run-active");
     expect(state.pendingChatRunId).toEqual(expect.any(String));
+  });
+
+  it("blocks gateway slash prompts while a run is active", async () => {
+    const { handleCommand, sendChat, addUser, addSystem } = createHarness({
+      activeChatRunId: "run-active",
+      activityStatus: "streaming",
+    });
+
+    await handleCommand("/context detail");
+
+    expect(sendChat).not.toHaveBeenCalled();
+    expect(addUser).not.toHaveBeenCalled();
+    expect(addSystem).toHaveBeenCalledWith(
+      "agent is busy — press Esc to abort before sending a new message",
+    );
   });
 
   it("routes slash stop to the abort path instead of queueing a chat send", async () => {
@@ -580,7 +596,7 @@ describe("tui command handlers", () => {
     );
   });
 
-  it("allows gateway sends while the current run is finishing", async () => {
+  it("blocks gateway sends while the current run is finishing", async () => {
     const { handleCommand, sendChat, addUser, addSystem } = createHarness({
       activeChatRunId: "run-active",
       activityStatus: "finishing context",
@@ -588,9 +604,9 @@ describe("tui command handlers", () => {
 
     await handleCommand("/context detail");
 
-    expect(sendChat).toHaveBeenCalledTimes(1);
-    expect(addUser).toHaveBeenCalledWith("/context detail");
-    expect(addSystem).not.toHaveBeenCalledWith(
+    expect(sendChat).not.toHaveBeenCalled();
+    expect(addUser).not.toHaveBeenCalled();
+    expect(addSystem).toHaveBeenCalledWith(
       "agent is busy — press Esc to abort before sending a new message",
     );
   });

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -67,6 +67,7 @@ function createHarness(params?: {
   activityStatus?: string;
   opts?: { local?: boolean };
   currentSessionId?: string | null;
+  abortActive?: ReturnType<typeof vi.fn>;
 }) {
   const sendChat = params?.sendChat ?? vi.fn().mockResolvedValue({ runId: "r1" });
   const getGatewayStatus = params?.getGatewayStatus ?? vi.fn().mockResolvedValue({});
@@ -88,6 +89,7 @@ function createHarness(params?: {
   const openOverlay = vi.fn();
   const closeOverlay = vi.fn();
   const requestExit = vi.fn();
+  const abortActive = params?.abortActive ?? vi.fn();
   const runAuthFlow: RunAuthFlow | undefined =
     params?.runAuthFlow ??
     (params?.opts?.local
@@ -125,7 +127,7 @@ function createHarness(params?: {
     loadHistory,
     setSession,
     refreshAgents: vi.fn(),
-    abortActive: vi.fn(),
+    abortActive,
     setActivityStatus,
     formatSessionKey: vi.fn(),
     applySessionInfoFromPatch: applySessionInfoFromPatch as never,
@@ -160,6 +162,7 @@ function createHarness(params?: {
     noteLocalRunId,
     noteLocalBtwRunId,
     requestExit,
+    abortActive,
     state,
   };
 }
@@ -514,6 +517,21 @@ describe("tui command handlers", () => {
     expect(requestRender).toHaveBeenCalled();
     expect(state.activeChatRunId).toBe("run-active");
     expect(state.pendingChatRunId).toEqual(expect.any(String));
+  });
+
+  it("routes slash stop to the abort path instead of queueing a chat send", async () => {
+    const abortActive = vi.fn().mockResolvedValue(undefined);
+    const { handleCommand, sendChat, addUser } = createHarness({
+      activeChatRunId: "run-active",
+      activityStatus: "streaming",
+      abortActive,
+    });
+
+    await handleCommand("/stop");
+
+    expect(abortActive).toHaveBeenCalledOnce();
+    expect(sendChat).not.toHaveBeenCalled();
+    expect(addUser).not.toHaveBeenCalled();
   });
 
   it("rejects normal sends while a queued submit is pending registration", async () => {

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -7,6 +7,8 @@ import {
 
 type LoadHistoryMock = ReturnType<typeof vi.fn> & (() => Promise<void>);
 type RunAuthFlow = NonNullable<Parameters<typeof createCommandHandlers>[0]["runAuthFlow"]>;
+type AbortActiveMock = ReturnType<typeof vi.fn> &
+  ((params?: { preferActive?: boolean }) => Promise<void>);
 type SelectableOverlay = {
   items?: Array<{ value: string; label?: string; description?: string }>;
   onSelect?: (item: { value: string; label?: string; description?: string }) => void;
@@ -67,7 +69,7 @@ function createHarness(params?: {
   activityStatus?: string;
   opts?: { local?: boolean };
   currentSessionId?: string | null;
-  abortActive?: ReturnType<typeof vi.fn>;
+  abortActive?: AbortActiveMock;
 }) {
   const sendChat = params?.sendChat ?? vi.fn().mockResolvedValue({ runId: "r1" });
   const getGatewayStatus = params?.getGatewayStatus ?? vi.fn().mockResolvedValue({});
@@ -89,7 +91,8 @@ function createHarness(params?: {
   const openOverlay = vi.fn();
   const closeOverlay = vi.fn();
   const requestExit = vi.fn();
-  const abortActive = params?.abortActive ?? vi.fn();
+  const abortActive =
+    params?.abortActive ?? (vi.fn().mockResolvedValue(undefined) as AbortActiveMock);
   const runAuthFlow: RunAuthFlow | undefined =
     params?.runAuthFlow ??
     (params?.opts?.local
@@ -529,9 +532,20 @@ describe("tui command handlers", () => {
 
     await handleCommand("/stop");
 
-    expect(abortActive).toHaveBeenCalledOnce();
+    expect(abortActive).toHaveBeenCalledWith({ preferActive: true });
     expect(sendChat).not.toHaveBeenCalled();
     expect(addUser).not.toHaveBeenCalled();
+  });
+
+  it("sends broad stop-like text as a normal prompt when idle", async () => {
+    const abortActive = vi.fn().mockResolvedValue(undefined);
+    const { handleCommand, sendChat, addUser } = createHarness({ abortActive });
+
+    await handleCommand("do not do that");
+
+    expect(abortActive).not.toHaveBeenCalled();
+    expect(sendChat).toHaveBeenCalledTimes(1);
+    expect(addUser).toHaveBeenCalledWith("do not do that");
   });
 
   it("rejects normal sends while a queued submit is pending registration", async () => {

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -63,6 +63,7 @@ function createHarness(params?: {
   isConnected?: boolean;
   activeChatRunId?: string | null;
   pendingOptimisticUserMessage?: boolean;
+  pendingChatRunId?: string | null;
   activityStatus?: string;
   opts?: { local?: boolean };
   currentSessionId?: string | null;
@@ -98,7 +99,7 @@ function createHarness(params?: {
     currentSessionId: params?.currentSessionId ?? null,
     activeChatRunId: params?.activeChatRunId ?? null,
     pendingOptimisticUserMessage: params?.pendingOptimisticUserMessage ?? false,
-    pendingChatRunId: null as string | null,
+    pendingChatRunId: params?.pendingChatRunId ?? null,
     activityStatus: params?.activityStatus ?? "idle",
     isConnected: params?.isConnected ?? true,
     sessionInfo: {},
@@ -493,9 +494,33 @@ describe("tui command handlers", () => {
     expect(setActivityStatus).toHaveBeenLastCalledWith("disconnected");
   });
 
-  it("rejects normal sends while a run is active", async () => {
+  it("sends normal prompts while a run is active so queue policy can handle them", async () => {
     const { handleCommand, sendChat, addUser, addSystem, requestRender, state } = createHarness({
       activeChatRunId: "run-active",
+      activityStatus: "streaming",
+    });
+
+    await handleCommand("/context detail");
+
+    expect(sendChat).toHaveBeenCalledTimes(1);
+    expectSendChatFields(sendChat, {
+      message: "/context detail",
+      sessionKey: "agent:main:main",
+    });
+    expect(addUser).toHaveBeenCalledWith("/context detail");
+    expect(addSystem).not.toHaveBeenCalledWith(
+      "agent is busy — press Esc to abort before sending a new message",
+    );
+    expect(requestRender).toHaveBeenCalled();
+    expect(state.activeChatRunId).toBe("run-active");
+    expect(state.pendingChatRunId).toEqual(expect.any(String));
+  });
+
+  it("rejects normal sends while a queued submit is pending registration", async () => {
+    const { handleCommand, sendChat, addUser, addSystem } = createHarness({
+      activeChatRunId: "run-active",
+      pendingChatRunId: "run-queued",
+      activityStatus: "waiting",
     });
 
     await handleCommand("/context detail");
@@ -505,8 +530,6 @@ describe("tui command handlers", () => {
     expect(addSystem).toHaveBeenCalledWith(
       "agent is busy — press Esc to abort before sending a new message",
     );
-    expect(requestRender).toHaveBeenCalled();
-    expect(state.activeChatRunId).toBe("run-active");
   });
 
   it("allows local sends to queue while the current run is finishing", async () => {
@@ -525,7 +548,7 @@ describe("tui command handlers", () => {
     );
   });
 
-  it("rejects gateway sends while the current run is finishing", async () => {
+  it("allows gateway sends while the current run is finishing", async () => {
     const { handleCommand, sendChat, addUser, addSystem } = createHarness({
       activeChatRunId: "run-active",
       activityStatus: "finishing context",
@@ -533,9 +556,9 @@ describe("tui command handlers", () => {
 
     await handleCommand("/context detail");
 
-    expect(sendChat).not.toHaveBeenCalled();
-    expect(addUser).not.toHaveBeenCalled();
-    expect(addSystem).toHaveBeenCalledWith(
+    expect(sendChat).toHaveBeenCalledTimes(1);
+    expect(addUser).toHaveBeenCalledWith("/context detail");
+    expect(addSystem).not.toHaveBeenCalledWith(
       "agent is busy — press Esc to abort before sending a new message",
     );
   });

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -80,6 +80,7 @@ function createHarness(params?: {
   const setSession = params?.setSession ?? (vi.fn().mockResolvedValue(undefined) as SetSessionMock);
   const addUser = vi.fn();
   const addSystem = vi.fn();
+  const reserveAssistantSlot = vi.fn();
   const requestRender = vi.fn();
   const noteLocalRunId = vi.fn();
   const noteLocalBtwRunId = vi.fn();
@@ -119,7 +120,7 @@ function createHarness(params?: {
       patchSession,
       resetSession,
     } as never,
-    chatLog: { addUser, addSystem } as never,
+    chatLog: { addUser, addSystem, reserveAssistantSlot } as never,
     tui: { requestRender } as never,
     opts: params?.opts ?? {},
     state: state as never,
@@ -156,6 +157,7 @@ function createHarness(params?: {
     setSession,
     addUser,
     addSystem,
+    reserveAssistantSlot,
     requestRender,
     loadHistory,
     refreshSessionInfo,
@@ -501,7 +503,15 @@ describe("tui command handlers", () => {
   });
 
   it("sends local prompts while a run is active so queue policy can handle them", async () => {
-    const { handleCommand, sendChat, addUser, addSystem, requestRender, state } = createHarness({
+    const {
+      handleCommand,
+      sendChat,
+      addUser,
+      addSystem,
+      reserveAssistantSlot,
+      requestRender,
+      state,
+    } = createHarness({
       opts: { local: true },
       activeChatRunId: "run-active",
       activityStatus: "streaming",
@@ -514,6 +524,10 @@ describe("tui command handlers", () => {
       message: "/context detail",
       sessionKey: "agent:main:main",
     });
+    expect(reserveAssistantSlot).toHaveBeenCalledWith("run-active");
+    const reserveCallOrder = reserveAssistantSlot.mock.invocationCallOrder[0];
+    const addUserCallOrder = addUser.mock.invocationCallOrder[0];
+    expect(reserveCallOrder).toBeLessThan(addUserCallOrder);
     expect(addUser).toHaveBeenCalledWith("/context detail");
     expect(addSystem).not.toHaveBeenCalledWith(
       "agent is busy — press Esc to abort before sending a new message",
@@ -551,6 +565,21 @@ describe("tui command handlers", () => {
     expect(abortActive).toHaveBeenCalledWith({ preferActive: true });
     expect(sendChat).not.toHaveBeenCalled();
     expect(addUser).not.toHaveBeenCalled();
+  });
+
+  it("sends slash stop to the backend when there is no tracked run", async () => {
+    const abortActive = vi.fn().mockResolvedValue(undefined);
+    const { handleCommand, sendChat, addUser } = createHarness({ abortActive });
+
+    await handleCommand("/stop");
+
+    expect(abortActive).not.toHaveBeenCalled();
+    expect(sendChat).toHaveBeenCalledTimes(1);
+    expectSendChatFields(sendChat, {
+      message: "/stop",
+      sessionKey: "agent:main:main",
+    });
+    expect(addUser).toHaveBeenCalledWith("/stop");
   });
 
   it("sends broad stop-like text as a normal prompt when idle", async () => {

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -46,7 +46,7 @@ type CommandHandlerContext = {
   loadHistory: () => Promise<void>;
   setSession: (key: string) => Promise<void>;
   refreshAgents: () => Promise<void>;
-  abortActive: () => Promise<void>;
+  abortActive: (params?: { preferActive?: boolean }) => Promise<void>;
   setActivityStatus: (text: string) => void;
   formatSessionKey: (key: string) => string;
   applySessionInfoFromPatch: (result: SessionsPatchResult) => void;
@@ -62,6 +62,11 @@ type CommandHandlerContext = {
 
 function isBtwCommand(text: string): boolean {
   return /^\/(?:btw|side)(?::|\s|$)/i.test(text.trim());
+}
+
+function isSlashStopCommand(text: string): boolean {
+  const trimmed = text.trim();
+  return trimmed.startsWith("/") && isChatStopCommandText(trimmed);
 }
 
 export function createCommandHandlers(context: CommandHandlerContext) {
@@ -607,6 +612,9 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       case "abort":
         await abortActive();
         break;
+      case "stop":
+        await abortActive({ preferActive: true });
+        break;
       case "settings":
         openSettings();
         break;
@@ -633,8 +641,11 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       return;
     }
     const isBtw = isBtwCommand(text);
-    if (isChatStopCommandText(text)) {
-      await abortActive();
+    const busy = Boolean(
+      state.activeChatRunId || state.pendingChatRunId || state.pendingOptimisticUserMessage,
+    );
+    if (isSlashStopCommand(text) || (busy && isChatStopCommandText(text))) {
+      await abortActive({ preferActive: true });
       return;
     }
     if (!isBtw && (state.pendingChatRunId || state.pendingOptimisticUserMessage)) {

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -105,6 +105,9 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     tui.requestRender();
   };
 
+  const hasTrackedAbortTarget = () =>
+    Boolean(state.activeChatRunId || state.pendingChatRunId || state.pendingOptimisticUserMessage);
+
   const openSelector = (
     selector: {
       onSelect?: (item: SelectItem) => void;
@@ -613,7 +616,11 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         await abortActive();
         break;
       case "stop":
-        await abortActive({ preferActive: true });
+        if (hasTrackedAbortTarget()) {
+          await abortActive({ preferActive: true });
+          break;
+        }
+        await sendMessage(raw);
         break;
       case "settings":
         openSettings();
@@ -644,7 +651,10 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     const busy = Boolean(
       state.activeChatRunId || state.pendingChatRunId || state.pendingOptimisticUserMessage,
     );
-    if (isSlashStopCommand(text) || (busy && isChatStopCommandText(text))) {
+    if (
+      hasTrackedAbortTarget() &&
+      (isSlashStopCommand(text) || (busy && isChatStopCommandText(text)))
+    ) {
       await abortActive({ preferActive: true });
       return;
     }
@@ -661,6 +671,14 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     const runId = randomUUID();
     try {
       if (!isBtw) {
+        if (
+          opts.local === true &&
+          state.activeChatRunId &&
+          !state.pendingChatRunId &&
+          !state.pendingOptimisticUserMessage
+        ) {
+          chatLog.reserveAssistantSlot(state.activeChatRunId);
+        }
         chatLog.addUser(text);
         state.pendingOptimisticUserMessage = true;
         setActivityStatus("sending");

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -7,6 +7,7 @@ import {
   normalizeUsageDisplay,
   resolveResponseUsageMode,
 } from "../auto-reply/thinking.js";
+import { isChatStopCommandText } from "../gateway/chat-abort.js";
 import type { SessionsPatchResult } from "../gateway/protocol/index.js";
 import { formatRelativeTimestamp } from "../infra/format-time/format-relative.ts";
 import { normalizeAgentId } from "../routing/session-key.js";
@@ -632,6 +633,10 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       return;
     }
     const isBtw = isBtwCommand(text);
+    if (isChatStopCommandText(text)) {
+      await abortActive();
+      return;
+    }
     if (!isBtw && (state.pendingChatRunId || state.pendingOptimisticUserMessage)) {
       chatLog.addSystem("agent is busy — press Esc to abort before sending a new message");
       tui.requestRender();

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -648,7 +648,12 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       await abortActive({ preferActive: true });
       return;
     }
-    if (!isBtw && (state.pendingChatRunId || state.pendingOptimisticUserMessage)) {
+    if (
+      !isBtw &&
+      (state.pendingChatRunId ||
+        state.pendingOptimisticUserMessage ||
+        (opts.local !== true && state.activeChatRunId))
+    ) {
       chatLog.addSystem("agent is busy — press Esc to abort before sending a new message");
       tui.requestRender();
       return;

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -632,15 +632,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       return;
     }
     const isBtw = isBtwCommand(text);
-    const canQueueBehindLocalFinishingTurn =
-      opts.local === true && state.activityStatus === "finishing context";
-    if (
-      !isBtw &&
-      (!canQueueBehindLocalFinishingTurn ||
-        state.pendingChatRunId ||
-        state.pendingOptimisticUserMessage) &&
-      (state.activeChatRunId || state.pendingChatRunId || state.pendingOptimisticUserMessage)
-    ) {
+    if (!isBtw && (state.pendingChatRunId || state.pendingOptimisticUserMessage)) {
       chatLog.addSystem("agent is busy — press Esc to abort before sending a new message");
       tui.requestRender();
       return;

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -310,7 +310,25 @@ async function writeTuiPtyFixtureScript(dir: string) {
             thinking: opts.thinking,
           });
           const runId = opts.runId ?? "run-pty-fixture";
-          const responseDelayMs = opts.message === "slow prompt" ? 500 : 20;
+          const responseDelayMs =
+            opts.message === "slow prompt" || opts.message === "streaming prompt" ? 500 : 20;
+          if (opts.message === "streaming prompt") {
+            setTimeout(() => {
+              this.onEvent?.({
+                event: "chat",
+                payload: {
+                  runId,
+                  sessionKey: opts.sessionKey,
+                  state: "delta",
+                  message: {
+                    role: "assistant",
+                    content: [{ type: "text", text: "PTY_STREAMING: streaming prompt" }],
+                    timestamp: Date.now(),
+                  },
+                },
+              });
+            }, 5);
+          }
           const isSourceReplyProof = opts.message === "message tool only source reply proof";
           const isXaiLimitProof = opts.message === "xai limit proof";
           setTimeout(() => {
@@ -580,6 +598,23 @@ describe.sequential("TUI PTY harness", () => {
       expect(slowPromptCalls).toHaveLength(1);
       expect(slowPromptCalls[0]?.payload).toMatchObject({ message: "slow prompt" });
       await fixture.run.write("\x15", { delay: false });
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "submits a follow-up prompt while a run is streaming",
+    async () => {
+      await fixture.run.write("\x15", { delay: false });
+      await fixture.run.write("streaming prompt\r");
+      await fixture.run.waitForOutput("PTY_STREAMING: streaming prompt");
+      await fixture.run.write("queued while streaming\r");
+      await fixture.waitForLogEntry(
+        (entry) =>
+          entry.method === "sendChat" &&
+          objectFieldEquals(entry, "message", "queued while streaming"),
+      );
+      await fixture.run.waitForOutput("PTY_RESPONSE: streaming prompt");
     },
     TEST_TIMEOUT_MS,
   );

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -437,6 +437,31 @@ describe("tui session actions", () => {
     expect(state.activeChatRunId).toBe("run-finishing");
   });
 
+  it("aborts local post-turn maintenance for explicit stop", async () => {
+    const abortChat = vi.fn().mockResolvedValue({ ok: true, aborted: true });
+    const setActivityStatus = vi.fn();
+    const state = createBaseState({
+      activeChatRunId: "run-finishing",
+      pendingChatRunId: null,
+      activityStatus: "finishing context",
+    });
+
+    const { abortActive } = createTestSessionActions({
+      client: { listSessions: vi.fn(), abortChat } as unknown as TuiBackend,
+      opts: { local: true },
+      state,
+      setActivityStatus,
+    });
+
+    await abortActive({ preferActive: true });
+
+    expect(abortChat).toHaveBeenCalledWith({
+      sessionKey: "agent:main:main",
+      runId: "run-finishing",
+    });
+    expect(setActivityStatus).toHaveBeenCalledWith("aborted");
+  });
+
   it("aborts the queued pending run after a local finishing turn accepts the next send", async () => {
     const abortChat = vi.fn().mockResolvedValue({ ok: true, aborted: true });
     const setActivityStatus = vi.fn();

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -507,7 +507,11 @@ describe("tui session actions", () => {
 
     await abortActive({ preferActive: true });
 
-    expect(abortChat).toHaveBeenCalledWith({
+    expect(abortChat).toHaveBeenNthCalledWith(1, {
+      sessionKey: "agent:main:main",
+      runId: "run-queued",
+    });
+    expect(abortChat).toHaveBeenNthCalledWith(2, {
       sessionKey: "agent:main:main",
       runId: "run-active",
     });

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -489,6 +489,32 @@ describe("tui session actions", () => {
     expect(setActivityStatus).toHaveBeenCalledWith("aborted");
   });
 
+  it("aborts the active run when requested while a queued run is pending", async () => {
+    const abortChat = vi.fn().mockResolvedValue({ ok: true, aborted: true });
+    const setActivityStatus = vi.fn();
+    const state = createBaseState({
+      activeChatRunId: "run-active",
+      pendingChatRunId: "run-queued",
+      activityStatus: "waiting",
+    });
+
+    const { abortActive } = createTestSessionActions({
+      client: { listSessions: vi.fn(), abortChat } as unknown as TuiBackend,
+      opts: { local: true },
+      state,
+      setActivityStatus,
+    });
+
+    await abortActive({ preferActive: true });
+
+    expect(abortChat).toHaveBeenCalledWith({
+      sessionKey: "agent:main:main",
+      runId: "run-active",
+    });
+    expect(state.pendingChatRunId).toBeNull();
+    expect(setActivityStatus).toHaveBeenCalledWith("aborted");
+  });
+
   it("remembers the selected session after history loads", async () => {
     const listSessions = vi.fn().mockResolvedValue({
       ts: Date.now(),

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -463,6 +463,32 @@ describe("tui session actions", () => {
     expect(setActivityStatus).toHaveBeenCalledWith("aborted");
   });
 
+  it("aborts the queued pending run after a gateway active turn accepts the next send", async () => {
+    const abortChat = vi.fn().mockResolvedValue({ ok: true, aborted: true });
+    const setActivityStatus = vi.fn();
+    const state = createBaseState({
+      activeChatRunId: "run-active",
+      pendingChatRunId: "run-queued",
+      activityStatus: "waiting",
+    });
+
+    const { abortActive } = createTestSessionActions({
+      client: { listSessions: vi.fn(), abortChat } as unknown as TuiBackend,
+      opts: { local: false },
+      state,
+      setActivityStatus,
+    });
+
+    await abortActive();
+
+    expect(abortChat).toHaveBeenCalledWith({
+      sessionKey: "agent:main:main",
+      runId: "run-queued",
+    });
+    expect(state.pendingChatRunId).toBeNull();
+    expect(setActivityStatus).toHaveBeenCalledWith("aborted");
+  });
+
   it("remembers the selected session after history loads", async () => {
     const listSessions = vi.fn().mockResolvedValue({
       ts: Date.now(),

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -443,6 +443,7 @@ describe("tui session actions", () => {
     const state = createBaseState({
       activeChatRunId: "run-finishing",
       pendingChatRunId: "run-queued",
+      pendingOptimisticUserMessage: true,
       activityStatus: "waiting",
     });
 
@@ -460,6 +461,7 @@ describe("tui session actions", () => {
       runId: "run-queued",
     });
     expect(state.pendingChatRunId).toBeNull();
+    expect(state.pendingOptimisticUserMessage).toBe(false);
     expect(setActivityStatus).toHaveBeenCalledWith("aborted");
   });
 

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -417,6 +417,9 @@ export function createSessionActions(context: SessionActionContext) {
       tui.requestRender();
       return;
     }
+    const abortsPendingRun = Boolean(
+      state.pendingChatRunId && runIds.includes(state.pendingChatRunId),
+    );
     try {
       for (const runId of runIds) {
         await client.abortChat({
@@ -425,6 +428,9 @@ export function createSessionActions(context: SessionActionContext) {
         });
       }
       state.pendingChatRunId = null;
+      if (abortsPendingRun) {
+        state.pendingOptimisticUserMessage = false;
+      }
       setActivityStatus("aborted");
     } catch (err) {
       chatLog.addSystem(`abort failed: ${String(err)}`);

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -404,20 +404,26 @@ export function createSessionActions(context: SessionActionContext) {
       tui.requestRender();
       return;
     }
-    const runId =
-      !params?.preferActive && state.activeChatRunId && state.pendingChatRunId
-        ? state.pendingChatRunId
-        : (state.activeChatRunId ?? state.pendingChatRunId ?? null);
-    if (!runId) {
+    const runIds =
+      params?.preferActive && state.activeChatRunId && state.pendingChatRunId
+        ? [state.pendingChatRunId, state.activeChatRunId]
+        : [
+            !params?.preferActive && state.activeChatRunId && state.pendingChatRunId
+              ? state.pendingChatRunId
+              : (state.activeChatRunId ?? state.pendingChatRunId ?? null),
+          ].filter((runId) => runId !== null);
+    if (runIds.length === 0) {
       chatLog.addSystem("no active run", { coalesceConsecutive: true });
       tui.requestRender();
       return;
     }
     try {
-      await client.abortChat({
-        sessionKey: state.currentSessionKey,
-        runId,
-      });
+      for (const runId of runIds) {
+        await client.abortChat({
+          sessionKey: state.currentSessionKey,
+          runId,
+        });
+      }
       state.pendingChatRunId = null;
       setActivityStatus("aborted");
     } catch (err) {

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -398,6 +398,7 @@ export function createSessionActions(context: SessionActionContext) {
     if (
       opts.local === true &&
       state.activityStatus === "finishing context" &&
+      !params?.preferActive &&
       !state.pendingChatRunId
     ) {
       chatLog.addSystem("agent is finishing context; wait for it to finish before aborting");

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -394,7 +394,7 @@ export function createSessionActions(context: SessionActionContext) {
     await loadHistory();
   };
 
-  const abortActive = async () => {
+  const abortActive = async (params?: { preferActive?: boolean }) => {
     if (
       opts.local === true &&
       state.activityStatus === "finishing context" &&
@@ -405,7 +405,7 @@ export function createSessionActions(context: SessionActionContext) {
       return;
     }
     const runId =
-      state.activeChatRunId && state.pendingChatRunId
+      !params?.preferActive && state.activeChatRunId && state.pendingChatRunId
         ? state.pendingChatRunId
         : (state.activeChatRunId ?? state.pendingChatRunId ?? null);
     if (!runId) {

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -405,7 +405,7 @@ export function createSessionActions(context: SessionActionContext) {
       return;
     }
     const runId =
-      opts.local === true && state.activeChatRunId && state.pendingChatRunId
+      state.activeChatRunId && state.pendingChatRunId
         ? state.pendingChatRunId
         : (state.activeChatRunId ?? state.pendingChatRunId ?? null);
     if (!runId) {

--- a/src/tui/tui-submit-test-helpers.ts
+++ b/src/tui/tui-submit-test-helpers.ts
@@ -16,7 +16,9 @@ type SubmitHarness = {
   onSubmit: (text: string) => void;
 };
 
-export function createSubmitHarness(params?: { canSubmitMessage?: () => boolean }): SubmitHarness {
+export function createSubmitHarness(params?: {
+  canSubmitMessage?: (value: string) => boolean;
+}): SubmitHarness {
   const editor = {
     setText: vi.fn(),
     addToHistory: vi.fn(),

--- a/src/tui/tui-submit.ts
+++ b/src/tui/tui-submit.ts
@@ -8,7 +8,7 @@ export function createEditorSubmitHandler(params: {
   handleCommand: (value: string) => Promise<void> | void;
   sendMessage: (value: string) => Promise<void> | void;
   handleBangLine: (value: string) => Promise<void> | void;
-  canSubmitMessage?: () => boolean;
+  canSubmitMessage?: (value: string) => boolean;
   onBlockedMessageSubmit?: (value: string) => void;
 }) {
   return (text: string) => {
@@ -39,7 +39,7 @@ export function createEditorSubmitHandler(params: {
       return;
     }
 
-    if (params.canSubmitMessage && !params.canSubmitMessage()) {
+    if (params.canSubmitMessage && !params.canSubmitMessage(value)) {
       params.editor.setText(value);
       params.onBlockedMessageSubmit?.(value);
       return;

--- a/src/tui/tui.submit-handler.test.ts
+++ b/src/tui/tui.submit-handler.test.ts
@@ -66,6 +66,16 @@ describe("createEditorSubmitHandler", () => {
     expect(onBlockedMessageSubmit).toHaveBeenCalledWith("wait, use c++ instead");
   });
 
+  it("passes the submitted text to the busy gate", () => {
+    const canSubmitMessage = vi.fn((value: string) => value === "please stop");
+    const { sendMessage, onSubmit } = createSubmitHarness({ canSubmitMessage });
+
+    onSubmit("please stop");
+
+    expect(canSubmitMessage).toHaveBeenCalledWith("please stop");
+    expect(sendMessage).toHaveBeenCalledWith("please stop");
+  });
+
   it("restores the real editor value after pi-tui clears a busy submit", () => {
     const tui = { requestRender: vi.fn() } as unknown as TUI;
     const editor = new CustomEditor(tui, editorTheme);

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -120,6 +120,17 @@ describe("canSubmitTuiChatMessage", () => {
     ).toBe(true);
   });
 
+  it("allows local stop text while a queued run is pending", () => {
+    expect(
+      canSubmitTuiChatMessage({
+        local: true,
+        activeChatRunId: "run-active",
+        pendingChatRunId: "run-queued",
+        message: "please stop",
+      }),
+    ).toBe(true);
+  });
+
   it("blocks submits with pending optimistic state", () => {
     expect(
       canSubmitTuiChatMessage({

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -92,6 +92,24 @@ describe("canSubmitTuiChatMessage", () => {
     expect(canSubmitTuiChatMessage({})).toBe(true);
   });
 
+  it("allows local submit while a run is active", () => {
+    expect(
+      canSubmitTuiChatMessage({
+        local: true,
+        activeChatRunId: "run-active",
+      }),
+    ).toBe(true);
+  });
+
+  it("blocks gateway submit while a run is active", () => {
+    expect(
+      canSubmitTuiChatMessage({
+        local: false,
+        activeChatRunId: "run-active",
+      }),
+    ).toBe(false);
+  });
+
   it("blocks submits with pending optimistic state", () => {
     expect(
       canSubmitTuiChatMessage({

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -98,14 +98,14 @@ describe("canSubmitTuiChatMessage", () => {
     ).toBe(true);
   });
 
-  it("does not allow gateway submit while a run is finishing", () => {
+  it("allows gateway submit while a run is active", () => {
     expect(
       canSubmitTuiChatMessage({
         local: false,
-        activityStatus: "finishing context",
+        activityStatus: "streaming",
         activeChatRunId: "run-active",
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("blocks submits with pending optimistic state", () => {

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -88,33 +88,22 @@ describe("tui slash commands", () => {
 });
 
 describe("canSubmitTuiChatMessage", () => {
-  it("allows local queued submit while a run is finishing", () => {
-    expect(
-      canSubmitTuiChatMessage({
-        local: true,
-        activityStatus: "finishing context",
-        activeChatRunId: "run-active",
-      }),
-    ).toBe(true);
-  });
-
-  it("allows gateway submit while a run is active", () => {
-    expect(
-      canSubmitTuiChatMessage({
-        local: false,
-        activityStatus: "streaming",
-        activeChatRunId: "run-active",
-      }),
-    ).toBe(true);
+  it("allows submit when no run registration is pending", () => {
+    expect(canSubmitTuiChatMessage({})).toBe(true);
   });
 
   it("blocks submits with pending optimistic state", () => {
     expect(
       canSubmitTuiChatMessage({
-        local: true,
-        activityStatus: "finishing context",
-        activeChatRunId: "run-active",
         pendingOptimisticUserMessage: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("blocks submits with a pending chat run id", () => {
+    expect(
+      canSubmitTuiChatMessage({
+        pendingChatRunId: "run-pending",
       }),
     ).toBe(false);
   });

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -110,6 +110,16 @@ describe("canSubmitTuiChatMessage", () => {
     ).toBe(false);
   });
 
+  it("allows gateway stop text while a run is active", () => {
+    expect(
+      canSubmitTuiChatMessage({
+        local: false,
+        activeChatRunId: "run-active",
+        message: "please stop",
+      }),
+    ).toBe(true);
+  });
+
   it("blocks submits with pending optimistic state", () => {
     expect(
       canSubmitTuiChatMessage({

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -374,9 +374,6 @@ export function canSubmitTuiChatMessage(params: {
   pendingOptimisticUserMessage?: boolean;
 }): boolean {
   const pending = Boolean(params.pendingChatRunId) || params.pendingOptimisticUserMessage === true;
-  if (params.activeChatRunId) {
-    return params.local === true && params.activityStatus === "finishing context" && !pending;
-  }
   return !pending;
 }
 

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -367,10 +367,15 @@ export async function drainAndStopTuiSafely(tui: DrainableTui): Promise<void> {
 }
 
 export function canSubmitTuiChatMessage(params: {
+  local?: boolean;
+  activeChatRunId?: string | null;
   pendingChatRunId?: string | null;
   pendingOptimisticUserMessage?: boolean;
 }): boolean {
   const pending = Boolean(params.pendingChatRunId) || params.pendingOptimisticUserMessage === true;
+  if (!params.local && params.activeChatRunId) {
+    return false;
+  }
   return !pending;
 }
 
@@ -1315,6 +1320,8 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   updateAutocompleteProvider();
   const canSubmitChatMessage = () =>
     canSubmitTuiChatMessage({
+      local: opts.local,
+      activeChatRunId: state.activeChatRunId,
       pendingChatRunId: state.pendingChatRunId,
       pendingOptimisticUserMessage: state.pendingOptimisticUserMessage,
     });

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -374,11 +374,12 @@ export function canSubmitTuiChatMessage(params: {
   pendingOptimisticUserMessage?: boolean;
   message?: string;
 }): boolean {
+  const stopText = params.message ? isChatStopCommandText(params.message) : false;
+  if (stopText && (params.activeChatRunId || params.pendingChatRunId)) {
+    return true;
+  }
   const pending = Boolean(params.pendingChatRunId) || params.pendingOptimisticUserMessage === true;
   if (!params.local && params.activeChatRunId) {
-    if (params.message && isChatStopCommandText(params.message)) {
-      return true;
-    }
     return false;
   }
   return !pending;

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -367,9 +367,6 @@ export async function drainAndStopTuiSafely(tui: DrainableTui): Promise<void> {
 }
 
 export function canSubmitTuiChatMessage(params: {
-  local?: boolean;
-  activityStatus: string;
-  activeChatRunId?: string | null;
   pendingChatRunId?: string | null;
   pendingOptimisticUserMessage?: boolean;
 }): boolean {
@@ -1318,9 +1315,6 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   updateAutocompleteProvider();
   const canSubmitChatMessage = () =>
     canSubmitTuiChatMessage({
-      local: opts.local,
-      activityStatus: state.activityStatus,
-      activeChatRunId: state.activeChatRunId,
       pendingChatRunId: state.pendingChatRunId,
       pendingOptimisticUserMessage: state.pendingOptimisticUserMessage,
     });

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -1290,7 +1290,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       client,
       chatLog,
       tui,
-      opts,
+      opts: { ...opts, local: isLocalMode },
       state,
       deliverDefault,
       openOverlay,
@@ -1320,7 +1320,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   updateAutocompleteProvider();
   const canSubmitChatMessage = () =>
     canSubmitTuiChatMessage({
-      local: opts.local,
+      local: isLocalMode,
       activeChatRunId: state.activeChatRunId,
       pendingChatRunId: state.pendingChatRunId,
       pendingOptimisticUserMessage: state.pendingOptimisticUserMessage,

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -14,6 +14,7 @@ import {
 } from "@earendil-works/pi-tui";
 import { resolveAgentIdByWorkspacePath, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { getRuntimeConfig, type OpenClawConfig } from "../config/config.js";
+import { isChatStopCommandText } from "../gateway/chat-abort.js";
 import type { CommandEntry } from "../gateway/protocol/index.js";
 import { registerUncaughtExceptionHandler } from "../infra/unhandled-rejections.js";
 import { setConsoleSubsystemFilter } from "../logging/console.js";
@@ -371,9 +372,13 @@ export function canSubmitTuiChatMessage(params: {
   activeChatRunId?: string | null;
   pendingChatRunId?: string | null;
   pendingOptimisticUserMessage?: boolean;
+  message?: string;
 }): boolean {
   const pending = Boolean(params.pendingChatRunId) || params.pendingOptimisticUserMessage === true;
   if (!params.local && params.activeChatRunId) {
+    if (params.message && isChatStopCommandText(params.message)) {
+      return true;
+    }
     return false;
   }
   return !pending;
@@ -1318,12 +1323,13 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     closeOverlay,
   });
   updateAutocompleteProvider();
-  const canSubmitChatMessage = () =>
+  const canSubmitChatMessage = (message: string) =>
     canSubmitTuiChatMessage({
       local: isLocalMode,
       activeChatRunId: state.activeChatRunId,
       pendingChatRunId: state.pendingChatRunId,
       pendingOptimisticUserMessage: state.pendingOptimisticUserMessage,
+      message,
     });
   const notifyBlockedChatSubmit = () => {
     chatLog.addSystem("agent is busy — press Esc to abort before sending a new message");


### PR DESCRIPTION
## Summary

- Lets normal OpenClaw TUI prompts submitted during an active run reach `sendChat` so existing queue policy can decide whether to steer, follow up, collect, or interrupt.
- Keeps the existing single pending-submit UI guard: once a queued submit is waiting for registration, additional normal submits still show the busy message instead of creating overlapping local pending state.
- Adds unit coverage for the active-run submit path and PTY coverage that types into the real TUI loop while a run is streaming.
- Intentionally out of scope: changing queue policy semantics, Telegram behavior, gateway protocol, Esc abort selection, or allowing multiple locally pending TUI submits at once.

## Linked context

Closes #86673

Root cause: the TUI had two pre-ingress guards. `canSubmitTuiChatMessage` rejected normal editor submits whenever `activeChatRunId` was set, and `sendMessage` returned with `agent is busy — press Esc to abort before sending a new message` before calling `client.sendChat`. Queue modes only apply after a message reaches the backend, so TUI follow-ups could not enter the existing queue machinery.

## Real behavior proof (required for external PRs)
<img width="680" height="331" alt="Screenshot 2026-05-25 at 10 23 33 PM" src="https://github.com/user-attachments/assets/e2fdb54b-15e9-4eaa-b817-ac9a8472e8f7" />

- Behavior or issue addressed: TUI normal prompts typed during an active run now enter the backend `sendChat` path instead of being blocked before queue handling.
- Real environment tested: local source checkout on macOS, built with `pnpm build`; TUI PTY harness exercising the real `runTui()` terminal loop with a fake `TuiBackend`; live Telegram comparison from the local Telegram bot setup, with participant details intended to be redacted in the screenshot the author will attach manually.
- Exact steps or command run after this patch:
  - `pnpm build`
  - `git diff --check origin/main...HEAD`
  - `node scripts/run-vitest.mjs src/tui/tui.test.ts src/tui/tui-command-handlers.test.ts src/tui/tui.submit-handler.test.ts`
  - `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts -- -t "submits a follow-up prompt while a run is streaming"`
  - `pnpm check:changed`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

Redacted after-patch PTY behavior log:

```text
User typed: streaming prompt
TUI displayed: PTY_STREAMING: streaming prompt
User typed during active stream: queued while streaming
Fixture backend log, redacted:
  { "method": "sendChat", "payload": { "sessionKey": "agent:main:main", "message": "streaming prompt", "deliver": false } }
  { "method": "sendChat", "payload": { "sessionKey": "agent:main:main", "message": "queued while streaming", "deliver": false } }
TUI later displayed: PTY_RESPONSE: streaming prompt
```

After-patch command output:

```text
$ node scripts/run-vitest.mjs src/tui/tui.test.ts src/tui/tui-command-handlers.test.ts src/tui/tui.submit-handler.test.ts
Test Files  3 passed (3)
Tests       98 passed (98)

$ node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts -- -t "submits a follow-up prompt while a run is streaming"
Test Files  1 passed (1)
Tests       12 passed (12)

$ pnpm check:changed
[check:changed] lanes=core, coreTests
[check:changed] typecheck core
[check:changed] typecheck core tests
[check:changed] lint core
Import cycle check: 0 runtime value cycle(s).
```

Live Telegram comparison, copied from the manual run with user identity details omitted:

```text
User: Please start a long-running proof task. Wait about 60 seconds before your final answer. While waiting, if you receive another message, handle it according to the queue behavior and mention that queued follow-up explicitly in your final answer.
User: Queued follow-up proof: please include the exact phrase TELEGRAM_QUEUE_PROOF_OK in your final answer.
Telegram bot: I've started a long-running proof task for you. It will complete and deliver "PROOF-C-85314 DONE" in about 60 seconds. If I receive any other messages while waiting, I will handle them as queued follow-ups and explicitly mention them in my final answer.
Telegram bot: I've received your queued follow-up, and I will ensure that the phrase "TELEGRAM_QUEUE_PROOF_OK" is included in my final answer, which will be delivered once the long-running proof task completes in about 60 seconds.
Telegram bot: Okay, I see that "PROOF-C-85314 DONE" from cron job long_running_proof_task has completed.
```

Before evidence:

```text
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts -- -t "blocks overlapping normal messages while a run is busy"
Test Files  1 passed (1)
Tests       11 passed (11)

Pre-patch PTY scenario:
User typed: slow prompt
User typed while busy: second prompt
TUI displayed: agent is busy — press Esc to abort before sending a new message
Fixture backend log, redacted:
  { "method": "sendChat", "payload": { "sessionKey": "agent:main:main", "message": "slow prompt", "deliver": false } }
No `sendChat` entry was recorded for `second prompt`.
```

- Observed result after fix: the busy-time follow-up reaches queue ingress via `sendChat`; the visible busy message is reserved for the narrower case where a previous queued submit is still pending registration.
- Proof limitations or environment constraints: the PTY harness proves the TUI terminal loop and backend ingress, not real Gateway transport. The Telegram sequence is comparison evidence for asynchronous channel behavior and will be augmented by a manually attached screenshot.

## Tests and validation

Commands run:

- `pnpm build`
- `git diff --check origin/main...HEAD`
- `node scripts/run-vitest.mjs src/tui/tui.test.ts src/tui/tui-command-handlers.test.ts src/tui/tui.submit-handler.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts -- -t "submits a follow-up prompt while a run is streaming"`
- `pnpm check:changed`

Regression coverage updated:

- `canSubmitTuiChatMessage` now asserts gateway submits are allowed during active runs unless a pending optimistic send already exists.
- Command-handler tests assert the primary behavior (`sendChat` called while active), observable UI side effects (`addUser`, no busy message), and preserved guard behavior for an already pending queued submit.
- PTY coverage asserts a follow-up typed while the TUI is visibly streaming reaches backend ingress.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. The TUI now accepts one normal follow-up prompt during an active run instead of preserving it in the editor with a busy warning.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No. This only removes the TUI pre-ingress active-run submit block; it does not change queue policy, channel auth, allowlists, prompt trust, tool execution policy, gateway protocol, or provider/runtime security controls. The behavior relies on existing runtime-enforced queue handling after `sendChat`, not on prompt text.

What is the highest-risk area?

TUI local pending-state bookkeeping while a current run is active and a follow-up has been submitted.

How is that risk mitigated?

The patch keeps the existing pending optimistic guard for a queued submit that has not registered yet, and tests assert both the newly allowed active-run submit and the still-blocked already-pending submit.

## Current review state

Next action: maintainer review, CI, and author attachment of the Telegram screenshot to augment the copied live proof.

Waiting on: GitHub CI and manual screenshot attachment.

Bot/reviewer comments addressed: none yet.

Made with [Cursor](https://cursor.com)

## Real behavior proof

Behavior addressed: Local TUI follow-up prompts typed during an active response reach backend ingress and queue behind the active run instead of aborting it; stop commands/text still abort active and queued work; gateway-backed TUI keeps its active-run busy guard for normal prompts.

Real environment tested: Local macOS source checkout running the OpenClaw TUI PTY harness, including the embedded local backend lane, plus Blacksmith Testbox changed-gate proof.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui.config.ts --configLoader runner src/tui/tui.test.ts src/tui/tui.submit-handler.test.ts src/tui/tui-command-handlers.test.ts src/tui/embedded-backend.test.ts src/tui/tui-session-actions.test.ts`; `OPENCLAW_TUI_PTY_MIRROR_PATH=/tmp/pty-mirror.log node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts --configLoader runner`; `OPENCLAW_TUI_PTY_MIRROR_PATH=/tmp/pty-local-mirror.log OPENCLAW_TUI_PTY_INCLUDE_LOCAL=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts --configLoader runner`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`; `pnpm check:changed` on Blacksmith Testbox.

Evidence after fix: Terminal capture from the PTY harness showed the user prompt `streaming prompt`, the visible streamed output `PTY_STREAMING: streaming prompt`, then a second typed prompt `queued while streaming`; the fixture backend log recorded a later `sendChat` entry for `queued while streaming` while the original run was still active. Embedded local PTY also completed with `Test Files 2 passed (2), Tests 14 passed (14)`. Blacksmith Testbox `tbx_01kskeyh1t81z15bxcjvrs3w17` and `tbx_01kskemnxec9t6bs20hh4pk3n3` both exited 0 for changed-gate proof.

Observed result after fix: The queued local prompt reached `sendChat`; stop text and `/stop` route to abort handling; `/stop` cancels both active and queued run ids; idle stop-like text is sent as a normal prompt; gateway active slash prompts are blocked with the busy message.

What was not tested: Live external provider/model execution was not run; the real terminal and embedded backend paths were exercised with mocked/fake provider responses.