### PR TITLE
fix(qqbot): persist group inbound delivery route

### DIFF
--- a/extensions/qqbot/src/channel.ts
+++ b/extensions/qqbot/src/channel.ts
@@ -196,6 +196,7 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
   setupWizard: qqbotSetupWizard,
   meta: {
     ...qqbotMeta,
+    preferSessionLookupForAnnounceTarget: true,
   },
   capabilities: {
     chatTypes: ["direct", "group"],

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
@@ -313,7 +313,7 @@ describe("dispatchOutbound", () => {
 
     await dispatchOutbound(inbound, { runtime, cfg: {}, account });
 
-    const turnRun = runtime.channel.turn.run as unknown as { mock: { calls: unknown[][] } };
+    const turnRun = runtime.channel.inbound.run as unknown as { mock: { calls: unknown[][] } };
     const runParams = turnRun.mock.calls[0]?.[0] as
       | {
           adapter: {
@@ -346,7 +346,7 @@ describe("dispatchOutbound", () => {
 
     await dispatchOutbound(inbound, { runtime, cfg: {}, account });
 
-    const turnRun = runtime.channel.turn.run as unknown as { mock: { calls: unknown[][] } };
+    const turnRun = runtime.channel.inbound.run as unknown as { mock: { calls: unknown[][] } };
     const runParams = turnRun.mock.calls[0]?.[0] as
       | {
           adapter: {

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
@@ -332,4 +332,32 @@ describe("dispatchOutbound", () => {
       accountId: "qq-main",
     });
   });
+
+  it("does not persist a direct C2C target as the main session last route", async () => {
+    const runtime = makeRuntime({});
+    const inbound = makeInbound({
+      route: {
+        sessionKey: "agent:main:main",
+        accountId: "qq-main",
+      },
+      qualifiedTarget: "qqbot:c2c:user-openid",
+      fromAddress: "qqbot:c2c:user-openid",
+    });
+
+    await dispatchOutbound(inbound, { runtime, cfg: {}, account });
+
+    const turnRun = runtime.channel.turn.run as unknown as { mock: { calls: unknown[][] } };
+    const runParams = turnRun.mock.calls[0]?.[0] as
+      | {
+          adapter: {
+            resolveTurn: () => {
+              record?: { updateLastRoute?: unknown };
+            };
+          };
+        }
+      | undefined;
+    const turn = runParams?.adapter.resolveTurn();
+
+    expect(turn?.record?.updateLastRoute).toBeUndefined();
+  });
 });

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
@@ -287,4 +287,49 @@ describe("dispatchOutbound", () => {
     expect(finalized?.Surface).toBe("qqbot");
     expect(finalized?.ChatType).toBe("direct");
   });
+
+  it("persists the QQ group target as the inbound last route", async () => {
+    const runtime = makeRuntime({});
+    const inbound = makeInbound({
+      event: {
+        type: "group",
+        senderId: "user-openid",
+        messageId: "msg-group",
+        content: "hello group",
+        timestamp: "2026-04-25T00:00:00.000Z",
+        groupOpenid: "CAAC3E9D0D1C21018767EF4E6ED45CCA",
+      },
+      route: {
+        sessionKey: "agent:main:qqbot:group:caac3e9d0d1c21018767ef4e6ed45cca",
+        accountId: "qq-main",
+      },
+      isGroupChat: true,
+      peerId: "CAAC3E9D0D1C21018767EF4E6ED45CCA",
+      qualifiedTarget: "qqbot:group:CAAC3E9D0D1C21018767EF4E6ED45CCA",
+      fromAddress: "qqbot:group:CAAC3E9D0D1C21018767EF4E6ED45CCA",
+      agentBody: "hello group",
+      body: "hello group",
+    });
+
+    await dispatchOutbound(inbound, { runtime, cfg: {}, account });
+
+    const turnRun = runtime.channel.turn.run as unknown as { mock: { calls: unknown[][] } };
+    const runParams = turnRun.mock.calls[0]?.[0] as
+      | {
+          adapter: {
+            resolveTurn: () => {
+              record?: { updateLastRoute?: unknown };
+            };
+          };
+        }
+      | undefined;
+    const turn = runParams?.adapter.resolveTurn();
+
+    expect(turn?.record?.updateLastRoute).toEqual({
+      sessionKey: "agent:main:qqbot:group:caac3e9d0d1c21018767ef4e6ed45cca",
+      channel: "qqbot",
+      to: "qqbot:group:CAAC3E9D0D1C21018767EF4E6ED45CCA",
+      accountId: "qq-main",
+    });
+  });
 });

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
@@ -256,12 +256,16 @@ export async function dispatchOutbound(
         ctxPayload,
         recordInboundSession: runtime.channel.session.recordInboundSession,
         record: {
-          updateLastRoute: {
-            sessionKey: inbound.route.sessionKey,
-            channel: "qqbot",
-            to: qualifiedTarget,
-            accountId: inbound.route.accountId,
-          },
+          ...(inbound.isGroupChat
+            ? {
+                updateLastRoute: {
+                  sessionKey: inbound.route.sessionKey,
+                  channel: "qqbot" as const,
+                  to: qualifiedTarget,
+                  accountId: inbound.route.accountId,
+                },
+              }
+            : {}),
           onRecordError: (err: unknown) => {
             log?.error(
               `Session metadata update failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
@@ -256,6 +256,12 @@ export async function dispatchOutbound(
         ctxPayload,
         recordInboundSession: runtime.channel.session.recordInboundSession,
         record: {
+          updateLastRoute: {
+            sessionKey: inbound.route.sessionKey,
+            channel: "qqbot",
+            to: qualifiedTarget,
+            accountId: inbound.route.accountId,
+          },
           onRecordError: (err: unknown) => {
             log?.error(
               `Session metadata update failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -127,6 +127,34 @@ function installMessagingTestRegistry() {
           },
         },
       },
+      {
+        pluginId: "qqbot",
+        source: "test",
+        plugin: {
+          id: "qqbot",
+          meta: {
+            id: "qqbot",
+            label: "QQ Bot",
+            selectionLabel: "QQ Bot",
+            docsPath: "/channels/qqbot",
+            blurb: "QQ Bot test stub.",
+            preferSessionLookupForAnnounceTarget: true,
+          },
+          capabilities: { chatTypes: ["direct", "group", "channel"] },
+          messaging: {
+            normalizeTarget: (raw: string) =>
+              raw.startsWith("qqbot:")
+                ? raw
+                : raw.startsWith("group:") || raw.startsWith("channel:") || raw.startsWith("c2c:")
+                  ? `qqbot:${raw}`
+                  : undefined,
+          },
+          config: {
+            listAccountIds: () => ["default"],
+            resolveAccount: () => ({}),
+          },
+        },
+      },
     ]),
   );
 }
@@ -1738,6 +1766,13 @@ describe("sessions tools", () => {
           ],
         };
       }
+      if (request.method === "sessions.resolve") {
+        const params = request.params as { key?: string; sessionId?: string } | undefined;
+        if (params?.key === targetKey || params?.sessionId === targetKey) {
+          return { key: targetKey };
+        }
+        return {};
+      }
       if (request.method === "sessions.list") {
         return {
           sessions: [
@@ -1810,5 +1845,140 @@ describe("sessions tools", () => {
     expect(sendParams.accountId).toBe("work");
     expect(sendParams.message).toBe("announce now");
     expect(sendParams.threadId).toBe("99");
+  });
+
+  it("sessions_send announces QQ Bot groups through stored delivery context", async () => {
+    const calls: Array<{ method?: string; params?: unknown }> = [];
+    let agentCallCount = 0;
+    let lastWaitedRunId: string | undefined;
+    const replyByRunId = new Map<string, string>();
+    const requesterKey = "discord:group:req";
+    const targetKey = "agent:main:qqbot:group:caac3e9d0d1c21018767ef4e6ed45cca";
+    let sendParams: {
+      to?: string;
+      channel?: string;
+      accountId?: string;
+      message?: string;
+    } = {};
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: unknown };
+      calls.push(request);
+      if (request.method === "agent") {
+        agentCallCount += 1;
+        const runId = `run-${agentCallCount}`;
+        const params = request.params as
+          | {
+              sessionKey?: string;
+              extraSystemPrompt?: string;
+            }
+          | undefined;
+        let reply = "initial";
+        if (params?.extraSystemPrompt?.includes("Agent-to-agent reply step")) {
+          reply = params.sessionKey === requesterKey ? "pong-1" : "pong-2";
+        }
+        if (params?.extraSystemPrompt?.includes("Agent-to-agent announce step")) {
+          reply = "announce now";
+        }
+        replyByRunId.set(runId, reply);
+        return {
+          runId,
+          status: "accepted",
+          acceptedAt: 4000 + agentCallCount,
+        };
+      }
+      if (request.method === "agent.wait") {
+        const params = request.params as { runId?: string } | undefined;
+        lastWaitedRunId = params?.runId;
+        return { runId: params?.runId ?? "run-1", status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        const text = (lastWaitedRunId && replyByRunId.get(lastWaitedRunId)) ?? "";
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text }],
+              timestamp: 20,
+            },
+          ],
+        };
+      }
+      if (request.method === "sessions.resolve") {
+        const params = request.params as { key?: string; sessionId?: string } | undefined;
+        if (params?.key === targetKey || params?.sessionId === targetKey) {
+          return { key: targetKey };
+        }
+        return {};
+      }
+      if (request.method === "sessions.list") {
+        return {
+          sessions: [
+            {
+              key: targetKey,
+              deliveryContext: {
+                channel: "qqbot",
+                to: "qqbot:group:CAAC3E9D0D1C21018767EF4E6ED45CCA",
+                accountId: "qq-main",
+              },
+            },
+          ],
+        };
+      }
+      if (request.method === "send") {
+        const params = request.params as
+          | {
+              to?: string;
+              channel?: string;
+              accountId?: string;
+              message?: string;
+            }
+          | undefined;
+        sendParams = {
+          to: params?.to,
+          channel: params?.channel,
+          accountId: params?.accountId,
+          message: params?.message,
+        };
+        return { messageId: "m-qqbot-announce" };
+      }
+      return {};
+    });
+    agentStepTesting.setDepsForTest({
+      agentCommandFromIngress: async () => ({
+        payloads: [{ text: "announce now", mediaUrl: null }],
+        meta: { durationMs: 1 },
+      }),
+      callGateway: (opts: unknown) => callGatewayMock(opts),
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: requesterKey,
+      agentChannel: "discord",
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const waited = await tool.execute("call-qqbot-announce", {
+      sessionKey: targetKey,
+      message: "ping",
+      timeoutSeconds: 1,
+    });
+    const waitedDetails = sessionsSendDetails(waited.details);
+    expect(waitedDetails.status).toBe("ok");
+    expect(waitedDetails.reply).toBe("initial");
+    await vi.waitFor(
+      () => {
+        expect(countMatching(calls, (call) => call.method === "send")).toBe(1);
+      },
+      { timeout: 2_000, interval: 5 },
+    );
+
+    expect(calls.some((call) => call.method === "sessions.list")).toBe(true);
+    expect(sendParams.to).toBe("qqbot:group:CAAC3E9D0D1C21018767EF4E6ED45CCA");
+    expect(sendParams.channel).toBe("qqbot");
+    expect(sendParams.accountId).toBe("qq-main");
+    expect(sendParams.message).toBe("announce now");
   });
 });

--- a/src/agents/test-helpers/fast-openclaw-tools-sessions.ts
+++ b/src/agents/test-helpers/fast-openclaw-tools-sessions.ts
@@ -45,7 +45,24 @@ vi.mock("../tools/update-plan-tool.js", () => ({
 }));
 
 vi.mock("../../channels/plugins/index.js", () => ({
-  getChannelPlugin: () => null,
+  getChannelPlugin: (channel?: string | null) => {
+    const normalized = normalizeOptionalLowercaseString(channel);
+    if (normalized !== "qqbot") {
+      return null;
+    }
+    return {
+      id: "qqbot",
+      meta: { preferSessionLookupForAnnounceTarget: true },
+      messaging: {
+        normalizeTarget: (raw: string) =>
+          raw.startsWith("qqbot:")
+            ? raw
+            : raw.startsWith("group:") || raw.startsWith("channel:") || raw.startsWith("c2c:")
+              ? `qqbot:${raw}`
+              : undefined,
+      },
+    };
+  },
   normalizeChannelId: (channel?: string) => normalizeOptionalLowercaseString(channel),
   listChannelPlugins: () => [],
 }));

--- a/src/agents/tools/sessions-announce-target.ts
+++ b/src/agents/tools/sessions-announce-target.ts
@@ -25,9 +25,9 @@ export async function resolveAnnounceTarget(params: {
     parseThreadSessionSuffix(params.displayKey).threadId;
 
   if (fallback) {
-    const normalized = normalizeChannelId(fallback.channel);
-    const plugin = normalized ? getChannelPlugin(normalized) : null;
-    if (!plugin?.meta?.preferSessionLookupForAnnounceTarget) {
+    const channelId = normalizeChannelId(fallback.channel) ?? fallback.channel;
+    const plugin = getChannelPlugin(channelId);
+    if (plugin?.meta?.preferSessionLookupForAnnounceTarget !== true) {
       return fallback;
     }
   }

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -30,7 +30,7 @@ export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget
   const normalizedChannel =
     normalizeAnyChannelId(parsed.channel) ?? normalizeChatChannelId(parsed.channel);
   const channel = normalizedChannel ?? parsed.channel;
-  const plugin = normalizedChannel ? getChannelPlugin(normalizedChannel) : null;
+  const plugin = getChannelPlugin(channel);
   const genericTarget = parsed.kind === "channel" ? `channel:${parsed.id}` : `group:${parsed.id}`;
   const normalized =
     plugin?.messaging?.resolveSessionTarget?.({
@@ -40,7 +40,7 @@ export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget
     }) ?? plugin?.messaging?.normalizeTarget?.(genericTarget);
   return {
     channel,
-    to: normalized ?? (normalizedChannel ? genericTarget : parsed.id),
+    to: normalized ?? (normalizedChannel || plugin ? genericTarget : parsed.id),
     threadId: parsed.threadId,
   };
 }

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -184,6 +184,34 @@ const installRegistry = async () => {
           },
         },
       },
+      {
+        pluginId: "qqbot",
+        source: "test",
+        plugin: {
+          id: "qqbot",
+          meta: {
+            id: "qqbot",
+            label: "QQ Bot",
+            selectionLabel: "QQ Bot",
+            docsPath: "/channels/qqbot",
+            blurb: "QQ Bot test stub.",
+            preferSessionLookupForAnnounceTarget: true,
+          },
+          capabilities: { chatTypes: ["direct", "group", "channel"] },
+          messaging: {
+            normalizeTarget: (raw: string) =>
+              raw.startsWith("qqbot:")
+                ? raw
+                : raw.startsWith("group:") || raw.startsWith("channel:") || raw.startsWith("c2c:")
+                  ? `qqbot:${raw}`
+                  : undefined,
+          },
+          config: {
+            listAccountIds: () => ["default"],
+            resolveAccount: () => ({}),
+          },
+        },
+      },
     ]),
   );
 };
@@ -468,6 +496,77 @@ describe("resolveAnnounceTarget", () => {
       accountId: "work",
       threadId: "thread-77",
     });
+  });
+
+  it("uses stored QQ Bot delivery context instead of key-derived announce fallback", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [
+        {
+          key: "agent:main:qqbot:group:caac3e9d0d1c21018767ef4e6ed45cca",
+          deliveryContext: {
+            channel: "qqbot",
+            to: "qqbot:group:CAAC3E9D0D1C21018767EF4E6ED45CCA",
+            accountId: "qq-main",
+          },
+        },
+      ],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "agent:main:qqbot:group:caac3e9d0d1c21018767ef4e6ed45cca",
+      displayKey: "agent:main:qqbot:group:caac3e9d0d1c21018767ef4e6ed45cca",
+    });
+    expect(target).toEqual({
+      channel: "qqbot",
+      to: "qqbot:group:CAAC3E9D0D1C21018767EF4E6ED45CCA",
+      accountId: "qq-main",
+    });
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not special-case QQ Bot session lookup without plugin metadata opt-in", async () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "qqbot",
+          source: "test",
+          plugin: {
+            id: "qqbot",
+            meta: {
+              id: "qqbot",
+              label: "QQ Bot",
+              selectionLabel: "QQ Bot",
+              docsPath: "/channels/qqbot",
+              blurb: "QQ Bot test stub.",
+            },
+            capabilities: { chatTypes: ["direct", "group", "channel"] },
+            messaging: {
+              normalizeTarget: (raw: string) =>
+                raw.startsWith("qqbot:")
+                  ? raw
+                  : raw.startsWith("group:") || raw.startsWith("channel:") || raw.startsWith("c2c:")
+                    ? `qqbot:${raw}`
+                    : undefined,
+            },
+            config: {
+              listAccountIds: () => ["default"],
+              resolveAccount: () => ({}),
+            },
+          },
+        },
+      ]),
+    );
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "agent:main:qqbot:group:caac3e9d0d1c21018767ef4e6ed45cca",
+      displayKey: "agent:main:qqbot:group:caac3e9d0d1c21018767ef4e6ed45cca",
+    });
+
+    expect(target).toEqual({
+      channel: "qqbot",
+      to: "qqbot:group:caac3e9d0d1c21018767ef4e6ed45cca",
+    });
+    expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
   it("preserves threaded Slack session keys when sessions.list lacks stored thread metadata", async () => {


### PR DESCRIPTION
## Summary

- Persist QQ Bot group/guild inbound delivery metadata through the channel turn record contract so later session delivery can use the exact inbound route.
- Preserve the exact QQ group target from the inbound event for announce/session delivery instead of relying only on session-key fallback parsing.
- Keep direct C2C/DM messages from overwriting the main session delivery route.
- Add regression coverage around group route persistence and announce delivery behavior.
- Out of scope: adding or changing live QQ Bot credentials, production bot configuration, or unrelated channel routing behavior.

Reviewers should focus on QQ Bot route persistence, sessions_send announce target resolution, and whether the fallback path still behaves correctly for non-QQ channels.

## Linked context

Closes #86387

Related current review finding: https://github.com/openclaw/openclaw/pull/86723#issuecomment-4539178842

No maintainer-specific request beyond the linked issue and current ClawSweeper feedback is known.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: QQ Bot group/guild inbound route persistence and later outbound reply or sessions_send announce delivery back to the same group target, including the stored exact group route and accountId.
- Real environment tested: Source checkout validation on Linux worker for commit 871ca99c1b on fix/qqbot-group-route-persistence. A live QQ Bot group runtime was not available in this worker environment.
- Exact steps or command run after this patch: CI=true COREPACK_HOME=/home/node/.openclaw/workspace/agents/pr-machine/workspace/.corepack node scripts/test-projects.mjs extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts src/agents/tools/sessions.test.ts src/agents/openclaw-tools.sessions.test.ts; CI=true COREPACK_HOME=/home/node/.openclaw/workspace/agents/pr-machine/workspace/.corepack pnpm run lint:extensions:bundled; CI=true COREPACK_HOME=/home/node/.openclaw/workspace/agents/pr-machine/workspace/.corepack pnpm -s check:test-types; git diff --check upstream/main...HEAD; git merge-tree --write-tree HEAD upstream/main.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Focused validation on 871ca99c1b reported Test Files 2 passed (2), Tests 49 passed (49) for the agents shard, Test Files 1 passed (1), Tests 6 passed (6) for the QQ Bot extension shard, and [test] passed 2 Vitest shards in 12.54s. Bundled extension lint exited 0. Test typecheck ran tsgo:core:test and tsgo:extensions:test and exited 0. git diff --check upstream/main...HEAD exited 0. git merge-tree --write-tree HEAD upstream/main exited 0 with tree 4222e937fdb1db310e56f8c0bf363a28a300ead9.
- Observed result after fix: QQ Bot announce target resolution now opts into stored session lookup, and the sessions_send regression sends the announce payload to qqbot:group:CAAC3E9D0D1C21018767EF4E6ED45CCA with accountId qq-main instead of the key-derived group:caac3e9d0d1c21018767ef4e6ed45cca fallback.
- What was not tested: Live QQ Bot group message processing against the external QQ service.
- Proof limitations or environment constraints: This worker has no QQ Bot credential variables or live QQ service target, so it cannot safely produce the redacted live group proof requested by ClawSweeper.
- Before evidence (optional but encouraged): ClawSweeper reported that sessions_send announce resolution still derived QQ Bot delivery from the session key before reading stored session deliveryContext.

## Tests and validation

Completed on 871ca99c1b:

- CI=true COREPACK_HOME=/home/node/.openclaw/workspace/agents/pr-machine/workspace/.corepack node scripts/test-projects.mjs extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts src/agents/tools/sessions.test.ts src/agents/openclaw-tools.sessions.test.ts — passed (49 agent tests and 6 QQ Bot extension tests).
- CI=true COREPACK_HOME=/home/node/.openclaw/workspace/agents/pr-machine/workspace/.corepack pnpm run lint:extensions:bundled — passed.
- CI=true COREPACK_HOME=/home/node/.openclaw/workspace/agents/pr-machine/workspace/.corepack pnpm -s check:test-types — passed.
- git diff --check upstream/main...HEAD — passed.
- git merge-tree --write-tree HEAD upstream/main — passed (4222e937fdb1db310e56f8c0bf363a28a300ead9).

Regression coverage added/updated: QQ Bot outbound dispatch route persistence, announce-target lookup from stored QQ Bot deliveryContext, and sessions_send announce delivery using the persisted exact QQ Bot group route/account.

Known current gap: live QQ Bot runtime proof is still unavailable from this worker.

## Risk checklist

Did user-visible behavior change? `Yes`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

Highest-risk area: routing outbound QQ Bot replies or sessions_send announcements to the wrong target.

Risk mitigation: keep route persistence limited to group/guild inbound targets, preserve direct-message guard behavior, and cover announce delivery with focused regression tests.

## Current review state

Next action: ClawSweeper re-review requested for 871ca99c1b after fixing the P1 announce-route finding.

Current status: code fix and focused validation are complete on the current head. The PR still documents the live QQ Bot proof limitation because this worker does not have external QQ Bot credentials or a safe live group target.

