### PR TITLE
fix(message-tool): hydrate attachments[] on reply (and other single-attachment actions)

### DIFF
--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -123,8 +123,15 @@ function readAttachmentFileHint(args: Record<string, unknown>): string | undefin
 // silently dropped: hydration found no hint, no buffer was loaded, and the
 // channel handler shipped text-only. Backward-compatible: only fills slots when
 // they are empty.
-function liftFirstAttachmentToTopLevel(args: Record<string, unknown>): void {
+export function liftFirstAttachmentToTopLevel(args: Record<string, unknown>): void {
   if (!Array.isArray(args.attachments) || args.attachments.length === 0) {
+    return;
+  }
+  if (
+    readAttachmentMediaHint(args) ||
+    readAttachmentFileHint(args) ||
+    readStringParam(args, "buffer", { trim: false })
+  ) {
     return;
   }
   for (const attachment of args.attachments) {
@@ -142,13 +149,7 @@ function liftFirstAttachmentToTopLevel(args: Record<string, unknown>): void {
     if (!source) {
       continue;
     }
-    if (
-      !readAttachmentMediaHint(args) &&
-      !readAttachmentFileHint(args) &&
-      !readStringParam(args, "buffer", { trim: false })
-    ) {
-      args.path = source;
-    }
+    args.path = source;
     const mimeType =
       normalizeOptionalString(record.mimeType) ?? normalizeOptionalString(record.contentType);
     if (mimeType && !readStringParam(args, "mimeType") && !readStringParam(args, "contentType")) {

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -114,6 +114,58 @@ function readAttachmentFileHint(args: Record<string, unknown>): string | undefin
   );
 }
 
+// The message tool exposes a structured `attachments: [{path, mimeType, name}]`
+// shape that already worked for the `send` action (see
+// collectMessageAttachmentMediaHints in message-action-runner). Single-attachment
+// actions (`reply`, `sendAttachment`, `setGroupIcon`, `upload-file`) hydrate via
+// top-level `media|mediaUrl|path|filePath|fileUrl`, so without this lift an
+// agent calling `message(action:"reply", attachments:[{...}])` had its file
+// silently dropped: hydration found no hint, no buffer was loaded, and the
+// channel handler shipped text-only. Backward-compatible: only fills slots when
+// they are empty.
+function liftFirstAttachmentToTopLevel(args: Record<string, unknown>): void {
+  if (!Array.isArray(args.attachments) || args.attachments.length === 0) {
+    return;
+  }
+  for (const attachment of args.attachments) {
+    if (!attachment || typeof attachment !== "object" || Array.isArray(attachment)) {
+      continue;
+    }
+    const record = attachment as Record<string, unknown>;
+    const source =
+      normalizeOptionalString(record.path) ??
+      normalizeOptionalString(record.filePath) ??
+      normalizeOptionalString(record.media) ??
+      normalizeOptionalString(record.mediaUrl) ??
+      normalizeOptionalString(record.fileUrl) ??
+      normalizeOptionalString(record.url);
+    if (!source) {
+      continue;
+    }
+    if (
+      !readAttachmentMediaHint(args) &&
+      !readAttachmentFileHint(args) &&
+      !readStringParam(args, "buffer", { trim: false })
+    ) {
+      args.path = source;
+    }
+    const mimeType =
+      normalizeOptionalString(record.mimeType) ?? normalizeOptionalString(record.contentType);
+    if (mimeType && !readStringParam(args, "mimeType") && !readStringParam(args, "contentType")) {
+      // Write to `contentType` (canonical) — hydration treats it as the
+      // primary content type and falls back to `mimeType`. Downstream channel
+      // handlers read `args.contentType`.
+      args.contentType = mimeType;
+    }
+    const filename =
+      normalizeOptionalString(record.name) ?? normalizeOptionalString(record.filename);
+    if (filename && !readStringParam(args, "filename")) {
+      args.filename = filename;
+    }
+    return;
+  }
+}
+
 function resolveAttachmentMaxBytes(params: {
   cfg: OpenClawConfig;
   channel: ChannelId;
@@ -361,6 +413,7 @@ async function hydrateAttachmentActionPayload(params: {
   mediaPolicy: AttachmentMediaPolicy;
   optimizeImages?: boolean;
 }): Promise<void> {
+  liftFirstAttachmentToTopLevel(params.args);
   const mediaHint = readAttachmentMediaHint(params.args);
   const fileHint = readAttachmentFileHint(params.args);
   const contentTypeParam =

--- a/src/infra/outbound/message-action-runner.media.test.ts
+++ b/src/infra/outbound/message-action-runner.media.test.ts
@@ -774,6 +774,57 @@ describe("runMessageAction media behavior", () => {
       expect(handlerParams.caption).toBeUndefined();
       expect(handlerParams.message).toBe("look at this");
     });
+
+    it("hydrates buffer/filename/contentType from attachments[] on reply", async () => {
+      // Regression: agents calling message(action:"reply", attachments:[{path,mimeType,name}])
+      // previously had the attachment silently dropped because the reply
+      // hydration path only read top-level media/mediaUrl/path/filePath/fileUrl.
+      const result = await runMessageAction({
+        cfg,
+        action: "reply",
+        params: {
+          channel: "replychat",
+          target: "+15551234567",
+          messageId: "parent-id",
+          text: "look at this",
+          attachments: [
+            {
+              path: "https://example.com/pic.png",
+              mimeType: "image/png",
+              name: "mug.png",
+            },
+          ],
+        },
+      });
+
+      expect(result.kind).toBe("action");
+      expect(handleActionMock).toHaveBeenCalledTimes(1);
+      const handlerParams = firstMockArg(handleActionMock, "handleAction");
+      expect(handlerParams.buffer).toBe(Buffer.from("hello").toString("base64"));
+      expect(handlerParams.filename).toBe("mug.png");
+      expect(handlerParams.contentType).toBe("image/png");
+    });
+
+    it("prefers an explicit top-level hint over attachments[] entries", async () => {
+      await runMessageAction({
+        cfg,
+        action: "reply",
+        params: {
+          channel: "replychat",
+          target: "+15551234567",
+          messageId: "parent-id",
+          text: "look at this",
+          media: "https://example.com/explicit.png",
+          attachments: [{ path: "https://example.com/ignored.png" }],
+        },
+      });
+
+      expect(handleActionMock).toHaveBeenCalledTimes(1);
+      const handlerParams = firstMockArg(handleActionMock, "handleAction");
+      // hint resolution preserved the explicit `media` and didn't overwrite
+      // it with the attachments[] entry.
+      expect(handlerParams.buffer).toBe(Buffer.from("hello").toString("base64"));
+    });
   });
 
   describe("plugin-owned media-source discovery routing", () => {

--- a/src/infra/outbound/message-action-runner.media.test.ts
+++ b/src/infra/outbound/message-action-runner.media.test.ts
@@ -805,6 +805,48 @@ describe("runMessageAction media behavior", () => {
       expect(handlerParams.contentType).toBe("image/png");
     });
 
+    it("allows host-local image paths from attachments[] when fs root expansion is enabled", async () => {
+      const actual = await vi.importActual<typeof import("../../media/web-media.js")>(
+        "../../media/web-media.js",
+      );
+      vi.mocked(loadWebMedia).mockImplementation(actual.loadWebMedia);
+
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "msg-reply-attachment-image-"));
+      try {
+        const outsidePath = path.join(tempDir, "photo.png");
+        await fs.writeFile(outsidePath, onePixelPng);
+
+        const result = await runMessageAction({
+          cfg: {
+            ...cfg,
+            tools: { fs: { workspaceOnly: false } },
+          },
+          action: "reply",
+          params: {
+            channel: "replychat",
+            target: "+15551234567",
+            messageId: "parent-id",
+            text: "look at this",
+            attachments: [
+              {
+                path: outsidePath,
+                mimeType: "image/png",
+                name: "photo.png",
+              },
+            ],
+          },
+        });
+
+        expect(result.kind).toBe("action");
+        expect(handleActionMock).toHaveBeenCalledTimes(1);
+        const handlerParams = firstMockArg(handleActionMock, "handleAction");
+        expect(handlerParams.filename).toBe("photo.png");
+        expect(handlerParams.contentType).toBe("image/png");
+      } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
     it("prefers an explicit top-level hint over attachments[] entries", async () => {
       await runMessageAction({
         cfg,
@@ -815,7 +857,13 @@ describe("runMessageAction media behavior", () => {
           messageId: "parent-id",
           text: "look at this",
           media: "https://example.com/explicit.png",
-          attachments: [{ path: "https://example.com/ignored.png" }],
+          attachments: [
+            {
+              path: "https://example.com/ignored.png",
+              mimeType: "image/jpeg",
+              name: "ignored.jpg",
+            },
+          ],
         },
       });
 
@@ -824,6 +872,8 @@ describe("runMessageAction media behavior", () => {
       // hint resolution preserved the explicit `media` and didn't overwrite
       // it with the attachments[] entry.
       expect(handlerParams.buffer).toBe(Buffer.from("hello").toString("base64"));
+      expect(handlerParams.filename).toBe("pic.png");
+      expect(handlerParams.contentType).toBe("image/png");
     });
   });
 

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -59,6 +59,7 @@ import { normalizeMessageActionInput } from "./message-action-normalization.js";
 import {
   collectActionMediaSourceHints,
   hydrateAttachmentParamsForAction,
+  liftFirstAttachmentToTopLevel,
   normalizeSandboxMediaList,
   normalizeSandboxMediaParams,
   parseInteractiveParam,
@@ -1355,6 +1356,7 @@ export async function runMessageAction(
     requesterSenderId: input.requesterSenderId,
     senderIsOwner: input.senderIsOwner,
   });
+  liftFirstAttachmentToTopLevel(params);
 
   await normalizeSandboxMediaParams({
     args: params,


### PR DESCRIPTION
## Summary

Agents that followed the published `message` tool schema and passed `attachments: [{ path, mimeType, name }]` on `action: "reply"` had the file silently dropped — only the text portion shipped. No error was raised. Same gap on `sendAttachment`, `setGroupIcon`, and `upload-file`.

## Root cause

- `src/agents/tools/message-tool.ts:194` declares `attachments[]` as a top-level peer of `media|mediaUrl|path|filePath|buffer` etc., with `path|filePath|media|mediaUrl|fileUrl|url|mimeType|name` per-entry. No action scoping.
- `src/infra/outbound/message-action-runner.ts:506` (`collectMessageAttachmentMediaHints`) reads `attachments[]` — but it's only called from `buildSendPayloadParts`, which is only reached on `action: "send"` and the webchat internal-source-reply sink. Every other action path never sees `attachments[]`.
- `src/infra/outbound/message-action-params.ts:353` (`hydrateAttachmentActionPayload`), used by `reply` / `sendAttachment` / `setGroupIcon` / `upload-file`, reads only top-level `media|mediaUrl|path|filePath|fileUrl` for hints. `args.buffer` never gets populated.
- Each channel's `reply` handler then sees no hydrated buffer and no top-level path. E.g. `extensions/imessage/src/actions.ts:290` `extractReplyAttachment` returns `null` (only throws on the bypass case — a top-level path without a buffer — not on absence), so the reply ships text-only. Silent drop.

Affects every channel that supports `reply` with media — iMessage, Telegram, WhatsApp, Discord, BlueBubbles, etc. — because they all share the same hydration step.

## Fix

Lift the first usable `attachments[]` entry into the top-level hint slots inside `hydrateAttachmentActionPayload` before reading them:

- `path|filePath|media|mediaUrl|fileUrl|url` → `args.path` (if no top-level hint and no buffer already)
- `mimeType|contentType` → `args.contentType` (canonical; hydration falls back to mimeType too)
- `name|filename` → `args.filename`

Backwards-compatible: only fills empty slots, explicit top-level hints win. The lifted path still flows through `loadWebMedia` with the resolved `mediaPolicy`, so all sandbox / `mediaLocalRoots` / size enforcement is preserved. No security boundary changes.

## How I found it

Real-world repro: I (the lobster gateway, a personal agent on a Mac running `openclaw 2026.5.26`) was asked to "send me an image of a red coffee mug on a blue table." I wrote an SVG via `apply_patch`, then invoked `message(action: "reply", attachments: [{path: ".../tmp-red-mug-blue-table.svg", mimeType: "image/svg+xml", name: "..."}])`. The owner replied "Nothing was sent." I retried with a real PNG path in `attachments[]` — same result. `imsg history --chat-id <dm> --attachments` confirmed the text portion landed both times but no attachment row was attached. Tracing it back from `imessageMessageActions.handleAction` showed the iMessage handler is fine (it gets called with no buffer and no path-bypass keys; `extractReplyAttachment` correctly returns `null`). The hydration step never saw `attachments[]`.

## Test plan

- [x] Added regression tests in `src/infra/outbound/message-action-runner.media.test.ts` for the `reply` action:
  - `hydrates buffer/filename/contentType from attachments[] on reply`
  - `prefers an explicit top-level hint over attachments[] entries`
- [x] All 26 tests in `message-action-runner.media.test.ts` pass (24 pre-existing + 2 new).
- [x] Full `src/infra/outbound` suite: pre-existing failure count drops from 119 → 107 with this patch (no new failures introduced; the lift also clears 12 pre-existing failures where the same shape was tested elsewhere).