### PR TITLE
fix(gateway): allow macOS canvas node commands

### DIFF
--- a/extensions/canvas/index.test.ts
+++ b/extensions/canvas/index.test.ts
@@ -49,6 +49,8 @@ function registerCanvas() {
   const services: Array<Parameters<OpenClawPluginApi["registerService"]>[0]> = [];
   const resolvers: Array<Parameters<OpenClawPluginApi["registerHostedMediaResolver"]>[0]> = [];
   const tools: Array<Parameters<OpenClawPluginApi["registerTool"]>[0]> = [];
+  const nodeInvokePolicies: Array<Parameters<OpenClawPluginApi["registerNodeInvokePolicy"]>[0]> =
+    [];
   const cliFeatures: Array<{
     registrar: Parameters<OpenClawPluginApi["registerNodeCliFeature"]>[0];
     opts: Parameters<OpenClawPluginApi["registerNodeCliFeature"]>[1];
@@ -63,10 +65,10 @@ function registerCanvas() {
       registerHostedMediaResolver: (resolver) => resolvers.push(resolver),
       registerTool: (tool) => tools.push(tool),
       registerNodeCliFeature: (registrar, opts) => cliFeatures.push({ registrar, opts }),
-      registerNodeInvokePolicy: vi.fn(),
+      registerNodeInvokePolicy: (policy) => nodeInvokePolicies.push(policy),
     }),
   );
-  return { routes, services, resolvers, tools, cliFeatures };
+  return { routes, services, resolvers, tools, nodeInvokePolicies, cliFeatures };
 }
 
 describe("Canvas plugin entry", () => {
@@ -133,5 +135,42 @@ describe("Canvas plugin entry", () => {
       workspaceDir: "/tmp/workspace",
     });
     expect(mocks.toolExecute).toHaveBeenCalledWith("tool-call", { action: "hide" });
+  });
+
+  it("registers safe Canvas node commands as defaults and eval as opt-in", async () => {
+    const { nodeInvokePolicies } = registerCanvas();
+
+    expect(nodeInvokePolicies).toHaveLength(2);
+    expect(nodeInvokePolicies[0]).toMatchObject({
+      commands: [
+        "canvas.present",
+        "canvas.hide",
+        "canvas.navigate",
+        "canvas.snapshot",
+        "canvas.a2ui.push",
+        "canvas.a2ui.pushJSONL",
+        "canvas.a2ui.reset",
+      ],
+      defaultPlatforms: ["ios", "android", "macos", "windows", "unknown"],
+      foregroundRestrictedOnIos: true,
+    });
+    expect(nodeInvokePolicies[0]?.dangerous).toBeUndefined();
+    expect(nodeInvokePolicies[1]).toMatchObject({
+      commands: ["canvas.eval"],
+      dangerous: true,
+      foregroundRestrictedOnIos: true,
+    });
+    expect(nodeInvokePolicies[1]?.defaultPlatforms).toBeUndefined();
+
+    await expect(
+      nodeInvokePolicies[0]?.handle({
+        invokeNode: async () => ({ ok: true, payload: "safe" }),
+      } as never),
+    ).resolves.toEqual({ ok: true, payload: "safe" });
+    await expect(
+      nodeInvokePolicies[1]?.handle({
+        invokeNode: async () => ({ ok: true, payload: "eval" }),
+      } as never),
+    ).resolves.toEqual({ ok: true, payload: "eval" });
   });
 });

--- a/extensions/canvas/index.ts
+++ b/extensions/canvas/index.ts
@@ -6,16 +6,16 @@ import { canvasConfigSchema, isCanvasHostEnabled } from "./src/config.js";
 import { A2UI_PATH, CANVAS_HOST_PATH, CANVAS_WS_PATH } from "./src/host/a2ui-shared.js";
 import { CanvasToolSchema } from "./src/tool-schema.js";
 
-const CANVAS_NODE_COMMANDS = [
+const CANVAS_SAFE_NODE_COMMANDS = [
   "canvas.present",
   "canvas.hide",
   "canvas.navigate",
-  "canvas.eval",
   "canvas.snapshot",
   "canvas.a2ui.push",
   "canvas.a2ui.pushJSONL",
   "canvas.a2ui.reset",
 ];
+const CANVAS_EVAL_NODE_COMMAND = "canvas.eval";
 
 function createLazyCanvasTool(params: {
   config?: OpenClawConfig;
@@ -120,8 +120,14 @@ export default definePluginEntry({
       });
     }
     api.registerNodeInvokePolicy({
-      commands: CANVAS_NODE_COMMANDS,
+      commands: CANVAS_SAFE_NODE_COMMANDS,
       defaultPlatforms: ["ios", "android", "macos", "windows", "unknown"],
+      foregroundRestrictedOnIos: true,
+      handle: (ctx) => ctx.invokeNode(),
+    });
+    api.registerNodeInvokePolicy({
+      commands: [CANVAS_EVAL_NODE_COMMAND],
+      dangerous: true,
       foregroundRestrictedOnIos: true,
       handle: (ctx) => ctx.invokeNode(),
     });

--- a/src/gateway/node-command-policy.test.ts
+++ b/src/gateway/node-command-policy.test.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import {
+  DEFAULT_DANGEROUS_NODE_COMMANDS,
   isForegroundRestrictedPluginNodeCommand,
   isNodeCommandAllowed,
   normalizeDeclaredNodeCommands,
@@ -101,6 +102,67 @@ describe("gateway/node-command-policy", () => {
 
     expect(allowlist.has("canvas.snapshot")).toBe(true);
     expect(allowlist.has("canvas.present")).toBe(true);
+  });
+
+  it("allows declared macOS canvas UI commands from platform defaults", () => {
+    const allowlist = resolveNodeCommandAllowlist({} as OpenClawConfig, {
+      platform: "macOS 26.5.0",
+      deviceFamily: "Mac",
+      commands: [
+        "canvas.present",
+        "canvas.hide",
+        "canvas.navigate",
+        "canvas.snapshot",
+        "canvas.a2ui.push",
+        "canvas.a2ui.pushJSONL",
+        "canvas.a2ui.reset",
+      ],
+    });
+
+    for (const command of [
+      "canvas.present",
+      "canvas.hide",
+      "canvas.navigate",
+      "canvas.snapshot",
+      "canvas.a2ui.push",
+      "canvas.a2ui.pushJSONL",
+      "canvas.a2ui.reset",
+    ]) {
+      expect(allowlist.has(command)).toBe(true);
+      expect(
+        isNodeCommandAllowed({
+          command,
+          declaredCommands: [command],
+          allowlist,
+        }),
+      ).toEqual({ ok: true });
+    }
+  });
+
+  it("keeps macOS canvas eval opt-in as a dangerous command", () => {
+    const defaultAllowlist = resolveNodeCommandAllowlist({} as OpenClawConfig, {
+      platform: "macOS 26.5.0",
+      deviceFamily: "Mac",
+      commands: ["canvas.eval"],
+    });
+    expect(defaultAllowlist.has("canvas.eval")).toBe(false);
+    expect(DEFAULT_DANGEROUS_NODE_COMMANDS).toContain("canvas.eval");
+
+    const configuredAllowlist = resolveNodeCommandAllowlist(
+      {
+        gateway: {
+          nodes: {
+            allowCommands: ["canvas.eval"],
+          },
+        },
+      } as OpenClawConfig,
+      {
+        platform: "macOS 26.5.0",
+        deviceFamily: "Mac",
+        commands: ["canvas.eval"],
+      },
+    );
+    expect(configuredAllowlist.has("canvas.eval")).toBe(true);
   });
 
   it("does not grant host command defaults for platform prefix aliases", () => {

--- a/src/gateway/node-command-policy.test.ts
+++ b/src/gateway/node-command-policy.test.ts
@@ -3,7 +3,6 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import {
-  DEFAULT_DANGEROUS_NODE_COMMANDS,
   isForegroundRestrictedPluginNodeCommand,
   isNodeCommandAllowed,
   normalizeDeclaredNodeCommands,
@@ -25,8 +24,29 @@ describe("gateway/node-command-policy", () => {
       rootDir: "/extensions/canvas",
       pluginConfig: {},
       policy: {
-        commands: ["canvas.snapshot", "canvas.present"],
+        commands: [
+          "canvas.present",
+          "canvas.hide",
+          "canvas.navigate",
+          "canvas.snapshot",
+          "canvas.a2ui.push",
+          "canvas.a2ui.pushJSONL",
+          "canvas.a2ui.reset",
+        ],
         defaultPlatforms: ["ios", "android", "macos", "windows", "unknown"],
+        foregroundRestrictedOnIos: true,
+        handle: (ctx) => ctx.invokeNode(),
+      },
+    });
+    (registry.nodeInvokePolicies ??= []).push({
+      pluginId: "canvas",
+      pluginName: "Canvas",
+      source: "/extensions/canvas/index.ts",
+      rootDir: "/extensions/canvas",
+      pluginConfig: {},
+      policy: {
+        commands: ["canvas.eval"],
+        dangerous: true,
         foregroundRestrictedOnIos: true,
         handle: (ctx) => ctx.invokeNode(),
       },
@@ -85,8 +105,8 @@ describe("gateway/node-command-policy", () => {
 
   it("keeps canvas commands out of core defaults when the canvas plugin is not active", () => {
     const allowlist = resolveNodeCommandAllowlist({} as OpenClawConfig, {
-      platform: "windows",
-      deviceFamily: "Windows",
+      platform: "macOS 26.5.0",
+      deviceFamily: "Mac",
     });
 
     expect(allowlist.has("canvas.snapshot")).toBe(false);
@@ -104,7 +124,9 @@ describe("gateway/node-command-policy", () => {
     expect(allowlist.has("canvas.present")).toBe(true);
   });
 
-  it("allows declared macOS canvas UI commands from platform defaults", () => {
+  it("allows declared macOS canvas UI commands from active canvas plugin defaults", () => {
+    installCanvasPluginDefaults();
+
     const allowlist = resolveNodeCommandAllowlist({} as OpenClawConfig, {
       platform: "macOS 26.5.0",
       deviceFamily: "Mac",
@@ -140,13 +162,14 @@ describe("gateway/node-command-policy", () => {
   });
 
   it("keeps macOS canvas eval opt-in as a dangerous command", () => {
+    installCanvasPluginDefaults();
+
     const defaultAllowlist = resolveNodeCommandAllowlist({} as OpenClawConfig, {
       platform: "macOS 26.5.0",
       deviceFamily: "Mac",
       commands: ["canvas.eval"],
     });
     expect(defaultAllowlist.has("canvas.eval")).toBe(false);
-    expect(DEFAULT_DANGEROUS_NODE_COMMANDS).toContain("canvas.eval");
 
     const configuredAllowlist = resolveNodeCommandAllowlist(
       {
@@ -305,6 +328,7 @@ describe("gateway/node-command-policy", () => {
     installCanvasPluginDefaults();
 
     expect(isForegroundRestrictedPluginNodeCommand("canvas.snapshot")).toBe(true);
+    expect(isForegroundRestrictedPluginNodeCommand("canvas.eval")).toBe(true);
     expect(isForegroundRestrictedPluginNodeCommand("system.run")).toBe(false);
   });
 });

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -16,6 +16,17 @@ const CAMERA_DANGEROUS_COMMANDS = ["camera.snap", "camera.clip"];
 const SCREEN_COMMANDS = ["screen.snapshot"];
 const SCREEN_DANGEROUS_COMMANDS = ["screen.record"];
 
+const CANVAS_COMMANDS = [
+  "canvas.present",
+  "canvas.hide",
+  "canvas.navigate",
+  "canvas.snapshot",
+  "canvas.a2ui.push",
+  "canvas.a2ui.pushJSONL",
+  "canvas.a2ui.reset",
+];
+const CANVAS_DANGEROUS_COMMANDS = ["canvas.eval"];
+
 const LOCATION_COMMANDS = ["location.get"];
 const NOTIFICATION_COMMANDS = ["notifications.list"];
 const ANDROID_NOTIFICATION_COMMANDS = [...NOTIFICATION_COMMANDS, "notifications.actions"];
@@ -66,6 +77,7 @@ const UNKNOWN_PLATFORM_COMMANDS = [
 export const DEFAULT_DANGEROUS_NODE_COMMANDS = [
   ...CAMERA_DANGEROUS_COMMANDS,
   ...SCREEN_DANGEROUS_COMMANDS,
+  ...CANVAS_DANGEROUS_COMMANDS,
   ...CONTACTS_DANGEROUS_COMMANDS,
   ...CALENDAR_DANGEROUS_COMMANDS,
   ...REMINDERS_DANGEROUS_COMMANDS,
@@ -108,6 +120,7 @@ const PLATFORM_DEFAULTS: Record<string, string[]> = {
     ...MOTION_COMMANDS,
     ...SYSTEM_COMMANDS,
     ...SCREEN_COMMANDS,
+    ...CANVAS_COMMANDS,
   ],
   linux: [...SYSTEM_COMMANDS],
   windows: [

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -16,17 +16,6 @@ const CAMERA_DANGEROUS_COMMANDS = ["camera.snap", "camera.clip"];
 const SCREEN_COMMANDS = ["screen.snapshot"];
 const SCREEN_DANGEROUS_COMMANDS = ["screen.record"];
 
-const CANVAS_COMMANDS = [
-  "canvas.present",
-  "canvas.hide",
-  "canvas.navigate",
-  "canvas.snapshot",
-  "canvas.a2ui.push",
-  "canvas.a2ui.pushJSONL",
-  "canvas.a2ui.reset",
-];
-const CANVAS_DANGEROUS_COMMANDS = ["canvas.eval"];
-
 const LOCATION_COMMANDS = ["location.get"];
 const NOTIFICATION_COMMANDS = ["notifications.list"];
 const ANDROID_NOTIFICATION_COMMANDS = [...NOTIFICATION_COMMANDS, "notifications.actions"];
@@ -77,7 +66,6 @@ const UNKNOWN_PLATFORM_COMMANDS = [
 export const DEFAULT_DANGEROUS_NODE_COMMANDS = [
   ...CAMERA_DANGEROUS_COMMANDS,
   ...SCREEN_DANGEROUS_COMMANDS,
-  ...CANVAS_DANGEROUS_COMMANDS,
   ...CONTACTS_DANGEROUS_COMMANDS,
   ...CALENDAR_DANGEROUS_COMMANDS,
   ...REMINDERS_DANGEROUS_COMMANDS,
@@ -120,7 +108,6 @@ const PLATFORM_DEFAULTS: Record<string, string[]> = {
     ...MOTION_COMMANDS,
     ...SYSTEM_COMMANDS,
     ...SCREEN_COMMANDS,
-    ...CANVAS_COMMANDS,
   ],
   linux: [...SYSTEM_COMMANDS],
   windows: [


### PR DESCRIPTION
## Summary

- Adds macOS Canvas node policy coverage through the Canvas plugin-owned command declarations instead of hardcoded gateway defaults.
- Keeps canvas.eval outside the safe default allowlist and classifies it as a dangerous opt-in command.
- Covers the declared macOS Canvas commands from native platform labels with gateway/plugin policy tests.
- Intended outcome: paired macOS Canvas nodes can use normal Canvas UI/control commands while evaluation remains separately gated.
- Out of scope: live proof on a paired macOS Canvas node, because this worker only has Linux execution capacity available.

Reviewers should focus on the command policy boundary: safe Canvas commands should come from the plugin defaults, and canvas.eval should stay explicit and dangerous.

## Linked context

Closes #86707

Related context: ClawSweeper review feedback asked for the Canvas command policy boundary to stay plugin-owned and for real macOS Canvas node proof.

Requested by a maintainer or owner: tracked from the upstream issue and reviewer automation feedback.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: macOS Canvas node commands need a default allowlist path for normal Canvas UI/control actions, while canvas.eval must remain an explicit dangerous opt-in command.
- Real environment tested: source checkout validation on the Linux worker host. A paired macOS Canvas node is not available in the current worker environment.
- Validation commands run on this head:
  - CI=true COREPACK_HOME=/home/node/.openclaw/workspace/agents/pr-machine/workspace/.corepack node scripts/test-projects.mjs src/gateway/node-command-policy.test.ts extensions/canvas/index.test.ts
  - CI=true COREPACK_HOME=/home/node/.openclaw/workspace/agents/pr-machine/workspace/.corepack pnpm -s check:test-types
  - git diff --check upstream/main...HEAD
  - git merge-tree --write-tree HEAD upstream/main
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): focused policy tests, test typecheck, diff check, and merge-tree validation passed on head f0b838041894afa00e6ae5e39c4805a88986fa6a.
- Observed result after fix: policy coverage confirms safe Canvas plugin commands are allowed from plugin defaults and canvas.eval remains outside the safe default path.
- What was not tested: a live paired macOS Canvas node invoking Canvas commands through a running OpenClaw gateway.
- Proof limitations or environment constraints: this worker has Linux execution only; no paired macOS node is available for the required runtime proof.
- Before evidence (optional but encouraged): prior implementation placed Canvas command policy in the gateway boundary and lacked the current plugin-owned policy test coverage.

## Tests and validation

Commands run:

- CI=true COREPACK_HOME=/home/node/.openclaw/workspace/agents/pr-machine/workspace/.corepack node scripts/test-projects.mjs src/gateway/node-command-policy.test.ts extensions/canvas/index.test.ts
- CI=true COREPACK_HOME=/home/node/.openclaw/workspace/agents/pr-machine/workspace/.corepack pnpm -s check:test-types
- git diff --check upstream/main...HEAD
- git merge-tree --write-tree HEAD upstream/main

Regression coverage added or updated:

- Gateway node command policy coverage for plugin-provided Canvas defaults.
- Canvas plugin policy coverage that keeps canvas.eval dangerous and opt-in.

What failed before this fix, if known:

- Review feedback flagged the policy boundary because Canvas command defaults were handled too broadly in gateway code.

Test coverage note:

- Tests were added/updated in the policy surface covered by this change.

## Risk checklist

Did user-visible behavior change? (Yes/No)

Yes. Paired macOS Canvas nodes should be able to use normal Canvas UI/control commands through the plugin-owned allowlist.

Did config, environment, or migration behavior change? (Yes/No)

Yes. Default node-command policy behavior changes for Canvas plugin commands; no migration is required.

Did security, auth, secrets, network, or tool execution behavior change? (Yes/No)

Yes. This touches node command execution policy.

Highest-risk area:

Accidentally allowing a dangerous Canvas command by default.

Risk mitigation:

The safe defaults are declared by the Canvas plugin, canvas.eval remains a dangerous opt-in command, and focused tests cover both the allowed and denied paths.

## Current review state

Next action:

The remaining next action is obtaining real behavior proof from a paired macOS Canvas node, or maintainer guidance on an acceptable substitute.

Waiting on author, maintainer, CI, or external proof:

External proof is still waiting on access to a paired macOS Canvas node. No branch code change was made for this body-only update.

Bot or reviewer comments addressed:

The earlier Canvas policy-boundary code feedback was addressed on head f0b838041894afa00e6ae5e39c4805a88986fa6a. This update addresses the PR body template gap; the macOS runtime proof gap remains open.
