### PR TITLE
fix: classify read-only shell probes as non-mutating

### DIFF
--- a/src/agents/tool-mutation.test.ts
+++ b/src/agents/tool-mutation.test.ts
@@ -26,8 +26,12 @@ describe("tool mutation helpers", () => {
     );
     expect(writeFingerprint).toBe("tool=write|path=/tmp/demo.txt|id=42");
 
-    const metaOnlyFingerprint = buildToolActionFingerprint("exec", { command: "ls -la" }, "ls -la");
-    expect(metaOnlyFingerprint).toBe("tool=exec|meta=ls -la");
+    const readOnlyExecFingerprint = buildToolActionFingerprint(
+      "exec",
+      { command: "ls -la" },
+      "ls -la",
+    );
+    expect(readOnlyExecFingerprint).toBeUndefined();
 
     const readFingerprint = buildToolActionFingerprint("read", { path: "/tmp/demo.txt" });
     expect(readFingerprint).toBeUndefined();
@@ -61,6 +65,26 @@ describe("tool mutation helpers", () => {
       buildToolMutationState("subagents", { action: "steer", target: "worker-1" }).mutatingAction,
     ).toBe(true);
     expect(buildToolMutationState("subagents", { action: "list" }).mutatingAction).toBe(false);
+  });
+
+  it("treats read-only shell probes as non-mutating", () => {
+    expect(isMutatingToolCall("bash", { command: "ls $HOME/.openclaw/service-env" })).toBe(false);
+    expect(
+      isMutatingToolCall("bash", {
+        command: `/bin/bash -lc "sed -n '1,240p' ~/.openclaw/workspace/skills/discord/SKILL.md"`,
+      }),
+    ).toBe(false);
+    expect(isMutatingToolCall("exec", { command: "git -C /tmp/repo status --short" })).toBe(false);
+    expect(isMutatingToolCall("exec", { command: "timeout 20 openclaw status --json --all" })).toBe(
+      false,
+    );
+  });
+
+  it("keeps mutating shell commands classified as mutating", () => {
+    expect(isMutatingToolCall("bash", { command: "git commit -am fix" })).toBe(true);
+    expect(isMutatingToolCall("bash", { command: "openclaw update --channel beta" })).toBe(true);
+    expect(isMutatingToolCall("exec", { command: "python3 scripts/write-report.py" })).toBe(true);
+    expect(isMutatingToolCall("exec", { command: "ls docs > out.txt" })).toBe(true);
   });
 
   it("matches tool actions by fingerprint and fails closed on asymmetric data", () => {

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -67,6 +67,140 @@ const MESSAGE_MUTATING_ACTIONS = new Set([
   "unpin",
 ]);
 
+const READ_ONLY_SHELL_COMMANDS = new Set([
+  "[",
+  "cat",
+  "cd",
+  "date",
+  "du",
+  "echo",
+  "file",
+  "find",
+  "grep",
+  "head",
+  "jq",
+  "ls",
+  "nl",
+  "printf",
+  "pwd",
+  "rg",
+  "sed",
+  "stat",
+  "tail",
+  "test",
+  "wc",
+  "which",
+]);
+
+const READ_ONLY_GIT_SUBCOMMANDS = new Set([
+  "branch",
+  "describe",
+  "diff",
+  "grep",
+  "log",
+  "ls-files",
+  "ls-tree",
+  "remote",
+  "rev-parse",
+  "show",
+  "status",
+]);
+
+const READ_ONLY_OPENCLAW_SUBCOMMANDS = new Set([
+  "channels status",
+  "config validate",
+  "cron get",
+  "cron list",
+  "cron status",
+  "doctor",
+  "gateway status",
+  "models status",
+  "status",
+  "update status",
+]);
+
+function extractShellCommand(args: unknown): string | undefined {
+  const record = asRecord(args);
+  const command = record?.command;
+  if (typeof command !== "string") {
+    return undefined;
+  }
+  const trimmed = command.trim();
+  const shellWrapped = trimmed.match(/^(?:\/[\w./-]+\/)?(?:bash|sh)\s+-lc\s+(["'])([\s\S]*)\1$/u);
+  return shellWrapped?.[2]?.trim() || trimmed;
+}
+
+function tokenizeShellSegment(segment: string): string[] {
+  return Array.from(segment.matchAll(/"(?:\\.|[^"])*"|'(?:\\.|[^'])*'|\S+/gu)).map((match) =>
+    match[0].replace(/^(["'])([\s\S]*)\1$/u, "$2"),
+  );
+}
+
+function firstNonOptionGitSubcommand(tokens: string[]): string | undefined {
+  for (let i = 1; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (!token) {
+      continue;
+    }
+    if (["-C", "--git-dir", "--work-tree"].includes(token)) {
+      i += 1;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      continue;
+    }
+    return normalizeActionName(token);
+  }
+  return undefined;
+}
+
+function isReadOnlyOpenClawCommand(tokens: string[]): boolean {
+  const subcommand = tokens.slice(1, 3).map(normalizeActionName).filter(Boolean).join(" ");
+  const single = normalizeActionName(tokens[1]);
+  return (
+    READ_ONLY_OPENCLAW_SUBCOMMANDS.has(subcommand) ||
+    Boolean(single && READ_ONLY_OPENCLAW_SUBCOMMANDS.has(single))
+  );
+}
+
+function isReadOnlyShellCommand(args: unknown): boolean {
+  const command = extractShellCommand(args);
+  if (!command) {
+    return false;
+  }
+  const withoutDevNullRedirects = command.replace(/\s+\d?>\s*\/dev\/null\b/gu, "");
+  if (/[<>]/u.test(withoutDevNullRedirects)) {
+    return false;
+  }
+  return command
+    .split(/\s*(?:&&|\|\||;|\||\n)\s*/u)
+    .filter((segment) => segment.trim().length > 0)
+    .every((segment) => {
+      const tokens = tokenizeShellSegment(segment);
+      while (tokens[0] && /^[A-Za-z_][A-Za-z0-9_]*=.*/u.test(tokens[0])) {
+        tokens.shift();
+      }
+      if (tokens[0] === "env" || tokens[0] === "command") {
+        tokens.shift();
+      }
+      if (tokens[0] === "timeout") {
+        tokens.splice(0, tokens[1]?.startsWith("-") ? 3 : 2);
+      }
+      const commandName = normalizeActionName(tokens[0]);
+      if (!commandName) {
+        return true;
+      }
+      if (commandName === "git") {
+        const subcommand = firstNonOptionGitSubcommand(tokens);
+        return Boolean(subcommand && READ_ONLY_GIT_SUBCOMMANDS.has(subcommand));
+      }
+      if (commandName === "openclaw") {
+        return isReadOnlyOpenClawCommand(tokens);
+      }
+      return READ_ONLY_SHELL_COMMANDS.has(commandName);
+    });
+}
+
 // Structured file-target identity for cross-tool same-target recovery.
 // Carried alongside `actionFingerprint` so comparison does not have to
 // re-parse the joined fingerprint string. Re-parsing was unsafe because
@@ -146,10 +280,11 @@ export function isMutatingToolCall(toolName: string, args: unknown): boolean {
     case "write":
     case "edit":
     case "apply_patch":
-    case "exec":
-    case "bash":
     case "sessions_send":
       return true;
+    case "exec":
+    case "bash":
+      return !isReadOnlyShellCommand(args);
     case "process":
       return action != null && PROCESS_MUTATING_ACTIONS.has(action);
     case "message":


### PR DESCRIPTION
## Summary

Fixes #86727.

This keeps failed read-only `bash`/`exec` probes out of the mutating-tool warning path. Before this change, every `bash` and `exec` call was classified as mutating, so failures from harmless probes like `ls`, `sed -n`, `git status`, or `openclaw status` could be delivered to chat users as visible `⚠️ 🛠️ ... failed` warnings.

The new classifier is intentionally conservative:

- simple allow-list for read-only shell commands
- read-only `git` subcommands such as `status`, `diff`, `show`, and `log`
- read-only `openclaw` status/validation commands
- shell redirection to files and unknown commands remain mutating
- script execution, `git commit`, and `openclaw update` remain mutating

## Real behavior proof

Behavior addressed: Failed read-only shell probes were being classified as mutating tool failures and could surface to chat users as visible `⚠️ 🛠️ ... failed` warnings. The observed read-only commands were equivalent to `ls "$HOME/.openclaw/service-env"` and `sed -n '1,240p' ~/.openclaw/workspace/skills/discord/SKILL.md`.

Real environment tested: Real Linux/systemd beta runtime running OpenClaw `2026.5.24-beta.2`, with source-level verification in the matching beta source checkout refreshed from upstream main.

Exact steps or command run after this patch:

1. Checked beta runtime logs and session history for the last seven days.
2. Found the failed `sed -n` read-only skill-file probe in session history; the underlying failure was `No such file or directory` and the command had no side effect.
3. Inspected current source and confirmed `src/agents/tool-mutation.ts` classified `exec` and `bash` as mutating unconditionally.
4. Applied this PR's classifier change in the beta source checkout.
5. Ran direct after-fix mutation-classification checks for read-only and mutating shell commands.

Evidence: After the fix, direct mutation-classification checks in the beta source checkout printed this terminal output:

```text
direct mutation checks passed
```

The asserted after-fix cases included:

```text
bash: ls $HOME/.openclaw/service-env => non-mutating
bash: /bin/bash -lc "sed -n '1,240p' ~/.openclaw/workspace/skills/discord/SKILL.md" => non-mutating
exec: git -C /tmp/repo status --short => non-mutating
exec: timeout 20 openclaw status --json --all => non-mutating
bash: git commit -am fix => mutating
bash: openclaw update --channel beta => mutating
exec: python3 scripts/write-report.py => mutating
exec: ls docs > out.txt => mutating
```

Observed result after fix: Read-only probes no longer qualify for mutating-warning delivery, while unknown or side-effecting shell commands still fail closed as mutating.

What was not tested: I did not run a full live chat smoke on the patched runtime, because this change is isolated to mutation classification and was verified directly against the classifier boundary. I attempted a focused Vitest run on the beta host, but it stalled during Rolldown transform diagnostics before producing a test result. No test failure was observed.

## Testing

On the beta Contabo source checkout:

- `pnpm exec oxfmt --check src/agents/tool-mutation.ts src/agents/tool-mutation.test.ts`
- direct `tsx` assertions for the exact read-only and mutating cases added in this PR
- `git diff --check`

Also verified the pushed PR branch with `git diff --check main..HEAD`.
