### PR TITLE
fix(agents): attribute embedded tool logs to channels

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -2006,6 +2006,23 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(params.sessionKey).toBe(sessionKey);
   });
 
+  it("forwards the normalized message channel to the embedded subscription", async () => {
+    await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey,
+      tempPaths,
+      attemptOverrides: {
+        messageChannel: "TELEGRAM",
+      },
+    });
+
+    const subscriptionParams = requireRecord(
+      hoisted.subscribeEmbeddedAgentSessionMock.mock.calls[0]?.[0],
+      "subscription params",
+    );
+    expect(subscriptionParams.messageChannel).toBe("telegram");
+  });
+
   it("skips maintenance when afterTurn fails", async () => {
     const { bootstrap, assemble } = createContextEngineBootstrapAndAssemble();
     const afterTurn = vi.fn(async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2957,6 +2957,7 @@ export async function runEmbeddedAttempt(
         buildEmbeddedSubscriptionParams({
           session: activeSession,
           runId: params.runId,
+          messageChannel: runtimeChannel,
           initialReplayState: params.initialReplayState,
           hookRunner: getGlobalHookRunner() ?? undefined,
           verboseLevel: params.verboseLevel,

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -1,7 +1,12 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it, vi } from "vitest";
 import { HEARTBEAT_RESPONSE_TOOL_NAME } from "../auto-reply/heartbeat-tool-response.js";
 import * as agentEvents from "../infra/agent-events.js";
+import { resetLogger, setLoggerOverride } from "../logging/logger.js";
+import { parseLogLine } from "../logging/parse-log-line.js";
 import {
   THINKING_TAG_CASES,
   createSubscribedSessionHarness,
@@ -114,6 +119,45 @@ describe("subscribeEmbeddedAgentSession", () => {
     });
   }
 
+  async function captureToolLifecycleLogSubsystems(messageChannel?: string): Promise<string[]> {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-tool-log-attribution-"));
+    const logFile = path.join(tempDir, "openclaw.log");
+    try {
+      setLoggerOverride({
+        level: "debug",
+        consoleLevel: "silent",
+        file: logFile,
+      });
+      const { emit } = createSubscribedHarness({
+        runId: "run-log-attribution",
+        messageChannel,
+      });
+
+      emitToolRun({
+        emit,
+        toolName: "exec",
+        toolCallId: "tool-log-attribution",
+        args: { command: "echo ok" },
+        isError: false,
+        result: { ok: true },
+      });
+
+      const logText = await fs.readFile(logFile, "utf8");
+      const subsystems: string[] = [];
+      for (const line of logText.trim().split(/\n+/)) {
+        const parsed = parseLogLine(line);
+        if (parsed?.message.includes("embedded run tool")) {
+          subsystems.push(parsed.subsystem ?? "");
+        }
+      }
+      return subsystems;
+    } finally {
+      resetLogger();
+      setLoggerOverride(null);
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  }
+
   function findBlockReplyPayload(
     onBlockReply: { mock: { calls: unknown[][] } },
     text: string,
@@ -194,6 +238,21 @@ describe("subscribeEmbeddedAgentSession", () => {
       total: 30_868,
     });
   });
+
+  it.each([
+    ["telegram", "gateway/channels/telegram"],
+    [undefined, "agent/embedded"],
+    ["openclaw", "agent/embedded"],
+    ["not a channel", "agent/embedded"],
+  ] as const)(
+    "attributes tool lifecycle logs for channel=%s",
+    async (messageChannel, subsystem) => {
+      await expect(captureToolLifecycleLogSubsystems(messageChannel)).resolves.toEqual([
+        subsystem,
+        subsystem,
+      ]);
+    },
+  );
 
   it("does not double-count usage when done and message_end carry the same snapshot", () => {
     const { emit, subscription } = createSubscribedSessionHarness({ runId: "run" });

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -10,6 +10,7 @@ import { buildCodeSpanIndex, createInlineCodeState } from "../markdown/code-span
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { findFinalTagMatches } from "../shared/text/final-tags.js";
 import { hasOrphanReasoningCloseBoundary } from "../shared/text/reasoning-tags.js";
+import { isDeliverableMessageChannel, normalizeMessageChannel } from "../utils/message-channel.js";
 import { EmbeddedBlockChunker } from "./embedded-agent-block-chunker.js";
 import {
   isMessagingToolDuplicateNormalized,
@@ -59,7 +60,15 @@ const STREAM_STRIPPED_BLOCK_TAG_NAMES = [
   "antml:thinking",
   "antml:thought",
 ] as const;
-const log = createSubsystemLogger("agent/embedded");
+const embeddedLog = createSubsystemLogger("agent/embedded");
+
+function resolveEmbeddedAgentSessionLogger(messageChannel?: string) {
+  const normalizedChannel = normalizeMessageChannel(messageChannel);
+  if (normalizedChannel && isDeliverableMessageChannel(normalizedChannel)) {
+    return createSubsystemLogger(`gateway/channels/${normalizedChannel}`);
+  }
+  return embeddedLog;
+}
 
 function isPotentialTrailingBlockTagFragment(fragment: string): boolean {
   if (!fragment.startsWith("<") || fragment.includes(">")) {
@@ -124,6 +133,7 @@ function collectPendingMediaFromInternalEvents(
 export type { SubscribeEmbeddedAgentSessionParams } from "./embedded-agent-subscribe.types.js";
 
 export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSessionParams) {
+  const log = resolveEmbeddedAgentSessionLogger(params.messageChannel);
   const reasoningMode = params.reasoningMode ?? "off";
   const canShowReasoning = params.thinkingLevel !== "off";
   const toolResultFormat = params.toolResultFormat ?? "markdown";

--- a/src/agents/embedded-agent-subscribe.types.ts
+++ b/src/agents/embedded-agent-subscribe.types.ts
@@ -25,6 +25,8 @@ export type {
 export type SubscribeEmbeddedAgentSessionParams = {
   session: AgentSession;
   runId: string;
+  /** Originating message channel used for subsystem log attribution. */
+  messageChannel?: string;
   initialReplayState?: EmbeddedRunReplayState;
   hookRunner?: HookRunner;
   verboseLevel?: VerboseLevel;


### PR DESCRIPTION
## Summary

- Attribute embedded subscription/tool lifecycle logs to `gateway/channels/<channel>` for valid channel-originated runs.
- Preserve `agent/embedded` for channel-less, internal, or invalid channel values.
- Add focused regression coverage for subscriber log attribution and runner channel handoff.

Fixes #50565.

## AI assistance

This PR was implemented with Codex assistance. I reviewed the change and understand the affected embedded subscription/tool lifecycle logging path.

## Real behavior proof

Behavior addressed: embedded tool lifecycle logs from Telegram-originated runs now use `gateway/channels/telegram` instead of `agent/embedded`.

Real environment tested: local OpenClaw source runtime with actual `subscribeEmbeddedPiSession`, logging, channel normalization, and log parsing code.

Exact steps or command run after this patch: `node --import tsx --input-type=module` proof script saved at `.artifacts/issue-50565/real-behavior-proof.log`.

Evidence after fix:

```text
telegram_subsystems=gateway/channels/telegram,gateway/channels/telegram
fallback_subsystems=agent/embedded,agent/embedded
proof_status=ok
```

Observed result after fix: channel-originated embedded tool start/end logs carry the Telegram gateway subsystem; fallback still uses `agent/embedded`.

What was not tested: no live Telegram credentials, gateway process, or external channel delivery.

## Root Cause

`subscribeEmbeddedPiSession` created a static `agent/embedded` logger and did not receive the runner's normalized channel origin.

## Dependency contract

No external dependency contract changed. Internal contracts checked: `createSubsystemLogger` writes subsystem labels to structured logs; `normalizeMessageChannel` canonicalizes channel ids; `isDeliverableMessageChannel` excludes internal/non-delivery channels.

## Regression Test Plan

Focused subscriber test asserts Telegram and fallback subsystem labels. Runner test asserts `TELEGRAM` is normalized to `telegram` before subscription.

## Security Impact

No secrets, credentials, auth policy, or message payload exposure changes.

## Human Verification

Reviewed issue #50565, related searches, implementation diff, tests, proof output, and local guide.

## CODEOWNERS / owner review

No CODEOWNERS-specific owner match for touched paths. Agent/gateway maintainer review expected.

## Changelog

None; contributor PR, narrow internal bug fix.

## Review conversations

Issue #50565 comments reviewed. Exact open/closed PR searches for `50565` found no existing PR. Related #55846 is a broader observability discussion, not a duplicate fix.

## Risks

No live gateway/channel process proof.

## Behavior tradeoffs

Valid channel-originated subscription logs now group under the channel subsystem. Invalid/internal/channel-less values keep old fallback behavior.

## Scope boundaries

No log text, level, tool execution, reply delivery, channel policy, docs, or dependency changes.

## Validation

- `codex review --base origin/main`
- `pnpm test src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts -- --reporter=verbose`
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm check:changed`
- `git diff --check origin/main...HEAD`
