### PR TITLE
fix(agents): force SIGKILL synchronously when MCP stdio child ignores SIGTERM

### DIFF
--- a/src/agents/mcp-stdio-transport.test.ts
+++ b/src/agents/mcp-stdio-transport.test.ts
@@ -6,6 +6,7 @@ import { OpenClawStdioClientTransport } from "./mcp-stdio-transport.js";
 
 const spawnMock = vi.hoisted(() => vi.fn());
 const killProcessTreeMock = vi.hoisted(() => vi.fn());
+const signalProcessTreeMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", async () => ({
   ...(await vi.importActual<typeof import("node:child_process")>("node:child_process")),
@@ -14,6 +15,7 @@ vi.mock("node:child_process", async () => ({
 
 vi.mock("../process/kill-tree.js", () => ({
   killProcessTree: killProcessTreeMock,
+  signalProcessTree: signalProcessTreeMock,
 }));
 
 class MockChildProcess extends EventEmitter {
@@ -29,6 +31,7 @@ describe("OpenClawStdioClientTransport", () => {
     vi.useRealTimers();
     spawnMock.mockReset();
     killProcessTreeMock.mockReset();
+    signalProcessTreeMock.mockReset();
   });
 
   it("starts stdio MCP servers in a disposable process group on POSIX", async () => {
@@ -82,6 +85,30 @@ describe("OpenClawStdioClientTransport", () => {
     const closing = transport.close();
     await vi.advanceTimersByTimeAsync(2000);
     expect(killProcessTreeMock).toHaveBeenCalledWith(4321);
+
+    child.exitCode = 0;
+    child.emit("close", 0);
+    await closing;
+  });
+
+  it("force-SIGKILLs synchronously when killProcessTree's grace expires (#86412)", async () => {
+    vi.useFakeTimers();
+    const child = new MockChildProcess();
+    spawnMock.mockReturnValue(child);
+
+    const transport = new OpenClawStdioClientTransport({ command: "npx" });
+    const started = transport.start();
+    child.emit("spawn");
+    await started;
+
+    const closing = transport.close();
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(killProcessTreeMock).toHaveBeenCalledWith(4321);
+    expect(signalProcessTreeMock).not.toHaveBeenCalled();
+
+    // killProcessTree's SIGKILL is .unref()'d (#86412); close() force-SIGKILLs synchronously instead.
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(signalProcessTreeMock).toHaveBeenCalledWith(4321, "SIGKILL");
 
     child.exitCode = 0;
     child.emit("close", 0);

--- a/src/agents/mcp-stdio-transport.ts
+++ b/src/agents/mcp-stdio-transport.ts
@@ -5,7 +5,7 @@ import { getDefaultEnvironment } from "@modelcontextprotocol/sdk/client/stdio.js
 import { ReadBuffer, serializeMessage } from "@modelcontextprotocol/sdk/shared/stdio.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
-import { killProcessTree } from "../process/kill-tree.js";
+import { killProcessTree, signalProcessTree } from "../process/kill-tree.js";
 import { prepareOomScoreAdjustedSpawn } from "../process/linux-oom-score.js";
 
 export type OpenClawStdioServerParameters = {
@@ -17,6 +17,7 @@ export type OpenClawStdioServerParameters = {
 };
 
 const CLOSE_TIMEOUT_MS = 2000;
+const SIGKILL_REAP_TIMEOUT_MS = 500;
 
 function delay(ms: number) {
   return new Promise<void>((resolve) => {
@@ -125,6 +126,11 @@ export class OpenClawStdioClientTransport implements Transport {
       if (processToClose.exitCode === null && processToClose.pid) {
         killProcessTree(processToClose.pid);
         await Promise.race([closePromise, delay(CLOSE_TIMEOUT_MS)]);
+        if (processToClose.exitCode === null && processToClose.pid) {
+          // SIGKILL synchronously: killProcessTree's setTimeout is .unref()'d and races shutdown (#86412).
+          signalProcessTree(processToClose.pid, "SIGKILL");
+          await Promise.race([closePromise, delay(SIGKILL_REAP_TIMEOUT_MS)]);
+        }
       }
     }
     this.readBuffer.clear();


### PR DESCRIPTION
### Summary

- **Problem**: After a Gateway restart, MCP server child processes spawned by the bundle-mcp runtime can survive: users see a linear pile-up of zombie MCP processes across restarts, SSH connection exhaustion, and Gateway slowdowns. The original report points at `disposeSession()`, but the actual mechanism is one layer deeper — `disposeSession()` already calls `transport.close()`, and `close()` already calls `killProcessTree(pid)`. (#86412)
- **Root Cause**: `killProcessTree(pid)` sends SIGTERM to the process group **synchronously** and schedules the SIGKILL fallback with `setTimeout(..., graceMs).unref()`. The `.unref()` is intentional in the general utility ("don't block event loop exit"), but for a SIGTERM-ignoring child (a wrapped `npx`/`ssh` that does not propagate the signal, or any cooperative-but-slow child) the close() chain returns after a 2s graceful + 2s SIGTERM wait — and during gateway shutdown the runtime tears down right after that, **cancelling the unref'd SIGKILL setTimeout before it ever fires**. The child outlives the gateway; the next restart spawns a new one alongside, and the count grows linearly.
- **Fix**: In `OpenClawStdioClientTransport.close()`, after the SIGTERM grace, if the child is still alive force-send SIGKILL **synchronously** via the existing `signalProcessTree(pid, "SIGKILL")` helper, then briefly wait for the reap, before `close()` returns. The kill is delivered before the gateway exits — no longer dependent on the `.unref()`'d timer winning the race against shutdown.
- **What changed**:
  - `src/agents/mcp-stdio-transport.ts`: synchronous SIGKILL fallback in `close()` (calls existing `signalProcessTree` from `src/process/kill-tree.ts`); add `SIGKILL_REAP_TIMEOUT_MS = 500`.
  - `src/agents/mcp-stdio-transport.test.ts`: regression test (fake timers) covering the new synchronous-SIGKILL path; existing kill/no-kill cases unchanged.
- **What did NOT change (scope boundary)**:
  - `killProcessTree`'s general `.unref()` setTimeout fallback is unchanged (it stays correct for non-shutdown callers).
  - `disposeSession()` / `BundleMcpSession` / the MCP runtime manager are unchanged.
  - SSH-based MCP servers still leak the **remote** Node.js process on the remote host (the local `ssh` client is now reliably killed, but a remote watchdog or `ssh -t` is needed to clean up the remote node). The reporter notes this as a separate concern.
  - No config keys, protocol, or session-store changes.

### Reproduction

1. Spawn an MCP stdio child that ignores SIGTERM: `node -e "process.on('SIGTERM',()=>{});setInterval(()=>{},60_000)"`.
2. Drive the real `OpenClawStdioClientTransport.start()` → `transport.close()` against it.
3. Immediately `process.exit(0)` to mimic the gateway exiting at the end of a shutdown.
- Before: `close()` returns ~4s in (after the SIGTERM grace) and the unref'd SIGKILL setTimeout never fires (the runner exited first); the child outlives the runner.
- After: `close()` sends a synchronous SIGKILL after the SIGTERM grace and reaps; the child is gone by the time the runner exits.

### Real behavior proof

- **Behavior addressed (#86412)**: when an MCP stdio child ignores SIGTERM, `transport.close()` must guarantee the child is dead by the time it returns, so the next gateway shutdown/restart step cannot leave the child orphaned.
- **Real environment tested (Linux, Node 22)**: a standalone harness drives the **real** `OpenClawStdioClientTransport.start()`/`close()` against a real Node child that catches and swallows SIGTERM. The runner records the child pid, awaits `close()`, then `process.exit(0)` — same shape as the gateway exiting immediately after `disposeAllSessionMcpRuntimes`. A bash driver then checks whether the child pid is still alive.
- **Exact steps or command run after this patch**: `bash /tmp/qmd86412/repro.sh AFTER` (and `bash /tmp/qmd86412/repro.sh BEFORE` with the fix temporarily stashed to compare).
- **Evidence after fix (verbatim repro output)**:

```text
=== AFTER ===
runner: child pid=1668117  close() took 4013ms  exiting now
AFTER: child pid=1668117 is GONE — clean

=== BEFORE ===   (fix stashed)
runner: child pid=1668642  close() took 4006ms  exiting now
BEFORE: child pid=1668642 is STILL ALIVE after runner exit  <-- LEAK
```

- **Observed result after fix**: the SIGTERM-ignoring child is reliably reaped before the runner exits. Without the fix, the same scenario leaves the child alive across runner exit (the unref'd SIGKILL timer is cancelled when the runner exits).
- **Regression tests**: `node scripts/run-vitest.mjs src/agents/mcp-stdio-transport.test.ts` — full suite passes including a new fake-timer case that asserts `signalProcessTree(pid, "SIGKILL")` is invoked synchronously after the SIGTERM grace expires; the existing "kills the process tree" and "does not kill" cases still pass unchanged.
- **What was not tested**: a real multi-server gateway restart loop on macOS with the reporter's exact configuration (5 SSH + local MCP servers) was not run; the harness exercises the real transport + real `signalProcessTree`/`killProcessTree` and the unref-race fix end to end. The remote-side SSH-Node leak is out of scope here — the local `ssh` client is reliably killed; the remote process requires a separate remote watchdog or `ssh -t`.

### Risk / Mitigation

- **Risk**: the new synchronous SIGKILL adds up to `SIGKILL_REAP_TIMEOUT_MS` (500 ms) to `close()`'s worst-case duration, and a synchronous SIGKILL is more aggressive than the previous unref'd-delayed SIGKILL.
- **Mitigation**: SIGKILL is only sent if both the stdin-end grace AND the SIGTERM grace expired (i.e. the child has had 4s+ to exit cleanly). The 500ms reap is bounded — `close()` returns either when the child exits OR when the reap wait expires; it never blocks longer. The general `killProcessTree` utility keeps its `.unref()`'d-setTimeout behavior for non-shutdown callers, so no policy change in the broader codebase. Per-platform handling is delegated to the existing `signalProcessTree` helper (`taskkill /F` on Windows, `process.kill(-pid, "SIGKILL")` group-kill on Unix when detached).

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway / orchestration

### Linked Issue/PR

Fixes #86412
