### PR TITLE
feat(plugin-sdk): re-export PluginHookHandlerMap and PluginHookName from plugin-entry

### DIFF
--- a/src/plugin-sdk/plugin-entry.ts
+++ b/src/plugin-sdk/plugin-entry.ts
@@ -247,9 +247,11 @@ export type {
   PluginConversationBindingRequestResult,
 } from "../plugins/conversation-binding.types.js";
 export type {
+  PluginHookHandlerMap,
   PluginHookInboundClaimContext,
   PluginHookInboundClaimEvent,
   PluginHookInboundClaimResult,
+  PluginHookName,
 } from "../plugins/hook-types.js";
 export type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 export type {


### PR DESCRIPTION
## Summary

Adds two type re-exports to `plugin-sdk/plugin-entry` so third-party plugins can type their hook handler factories. Strictly-additive change.

```ts
// src/plugin-sdk/plugin-entry.ts
export type {
  PluginHookHandlerMap,
  PluginHookInboundClaimContext,
  PluginHookInboundClaimEvent,
  PluginHookInboundClaimResult,
  PluginHookName,
} from "../plugins/hook-types.js";
```

(Two names added to an existing re-export block; alphabetized.)

## Motivation

`OpenClawPluginApi.on` is generic:

```ts
on: <K extends PluginHookName>(
  hookName: K,
  handler: PluginHookHandlerMap[K],
  opts?: { priority?: number; timeoutMs?: number },
) => void;
```

So `api.on("llm_input", (event, ctx) => {...})` infers `event` and `ctx` at the call site. That works great for inline lambdas.

But third-party plugins that organize their handlers as factories (one per concern, dispatched via a registry) want to type the **factory return values**, not just the registration callsite. Today that requires importing `PluginHookHandlerMap` (or the per-event types like `PluginHookLlmInputEvent`) directly — and none of those are reachable from any publicly-listed import path. The types are present in `src/plugins/hook-types.ts`, ship in the dist tree, and are referenced transitively by `OpenClawPluginApi`, but consumers with `moduleResolution: "Bundler"` (or any resolver that respects the `exports` map in `package.json`) can't import them by name.

The result: the typed contract exists, but no third-party can hold it. Handler factories default to `event: any`, defensive `typeof === "string"` filters proliferate, and upstream renames don't surface at build time.

## Why this shape

Re-exporting `PluginHookHandlerMap` and `PluginHookName` is sufficient. Because `PluginHookHandlerMap[K]` is a concrete (non-generic) function type, downstream consumers can derive every per-event and per-context type via standard `Parameters<>` extraction without needing 30+ individual per-event type re-exports:

```ts
import type {
  PluginHookHandlerMap,
  PluginHookName,
} from "openclaw/plugin-sdk/plugin-entry";

type HookEvent<K extends PluginHookName> = Parameters<PluginHookHandlerMap[K]>[0];
type HookCtx<K extends PluginHookName>   = Parameters<PluginHookHandlerMap[K]>[1];
```

This keeps the public-surface commitment narrow: you promise that `PluginHookHandlerMap` keeps its shape (a record mapping hook names to handler signatures), not that any particular `PluginHookXEvent` type stays exported by name. The per-event types remain internal — but their structure (the field set) becomes a public contract via the handler signature.

## Use case

[weave-openclaw v2](https://github.com/wandb/weave-openclaw/pull/25) — third-party plugin that emits OpenClaw agent diagnostic events to W&B Weave's Agents OTel endpoint. Subscribes to 13 hooks (`session_start`, `model_call_started`, `llm_input`, `llm_output`, `before_tool_call`, `after_tool_call`, etc.) and consumes 12 diagnostic event types.

Diagnostic side: fully typed today via the publicly-exported `DiagnosticEventPayload` discriminated union. `switch (event.type)` narrows each branch automatically. Works great.

Hook side: factory functions across `src/handlers/hooks/*.ts` use `event: any` because the per-hook event types aren't reachable. The boundary at `api.on(...)` is inferred-typed, but inside the factory you've lost the narrowing. A typical handler factory after this PR:

```ts
import type { HookEvent, HookCtx } from "../../types/openclaw-hooks.js";

export function createLlmHookHandlers(deps: HandlerDeps) {
  return {
    model_call_started(event: HookEvent<"model_call_started">, ctx: HookCtx<"model_call_started">) {
      // event.runId, event.callId, event.provider, event.model — typed
      if (event.runId && event.callId) beginModelCall(deps.hookState, event.runId, event.callId);
    },
    llm_input(event: HookEvent<"llm_input">, ctx: HookCtx<"llm_input">) {
      // event.systemPrompt, event.prompt, event.historyMessages — typed
      const capture = {
        systemPrompt: event.systemPrompt,
        prompt: event.prompt,
        historyMessages: event.historyMessages,
      };
      // ...
    },
  };
}
```

Concrete wins for downstream consumers:

1. IDE autocomplete on `event.X` shows the real fields.
2. Misspellings caught at build time.
3. Upstream renames propagate. When a `PluginHookLlmInputEvent` field is renamed in a future OpenClaw release, downstream `tsc` fails at the field access — bisect in seconds, not after noticing missing data in production.
4. Defensive `typeof event.X === "string"` scaffolding deleted where the type guarantees the field.

## Test plan

- [x] `pnpm build:plugin-sdk:strict-smoke` clean on the branch.
- [x] Resulting `dist/plugin-sdk/src/plugin-sdk/plugin-entry.d.ts` includes `PluginHookHandlerMap` and `PluginHookName` in the re-export block.
- [ ] Downstream test from weave-openclaw v2 once a published openclaw version with this change lands: re-type the hook factories using `Parameters<PluginHookHandlerMap[K]>[0]` derivation and confirm `tsc` clean.

## Compatibility / risk

Strictly-additive. No existing import path changes shape; no existing type is renamed or removed; no runtime behavior touched. The only commitment widening is that `PluginHookHandlerMap` (and its index-access shape) is now part of the published surface — meaning a hypothetical future rename of a field on a `PluginHookXEvent` becomes a contract break that needs a major version bump rather than a silent change.

That commitment is arguably right anyway: those fields are already publicly readable through `api.on(...)` and any third party that calls `api.on` can break silently on a rename today. Making the contract explicit is a fix for that, not a new burden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)