### PR TITLE
fix: install gogcli and add linuxbrew to global PATH

### DIFF
--- a/Dockerfile.sandbox-common
+++ b/Dockerfile.sandbox-common
@@ -42,6 +42,9 @@ RUN if [ "${INSTALL_BREW}" = "1" ]; then \
   if [ ! -e "${BREW_INSTALL_DIR}/Library" ]; then ln -s "${BREW_INSTALL_DIR}/Homebrew/Library" "${BREW_INSTALL_DIR}/Library"; fi; \
   if [ ! -x "${BREW_INSTALL_DIR}/bin/brew" ]; then echo \"brew install failed\"; exit 1; fi; \
   ln -sf "${BREW_INSTALL_DIR}/bin/brew" /usr/local/bin/brew; \
+  su - linuxbrew -c "${BREW_INSTALL_DIR}/bin/brew install gogcli"; \
+  echo "export PATH=\"${BUN_INSTALL_DIR}/bin:${BREW_INSTALL_DIR}/bin:${BREW_INSTALL_DIR}/sbin:\$PATH\"" >> /etc/profile.d/sandbox-path.sh; \
+  echo "PATH=\"${BUN_INSTALL_DIR}/bin:${BREW_INSTALL_DIR}/bin:${BREW_INSTALL_DIR}/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"" >> /etc/environment; \
 fi
 
 # Default is sandbox, but allow BASE_IMAGE overrides to select another final user.


### PR DESCRIPTION
Fixes missing gogcli and PATH issues for sandbox image.