### PR TITLE
fix: keep bundled OpenClaw plugins image-owned

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -103,7 +103,7 @@ rewriting files.
 
 ```bash
 openclaw plugins search "calendar"                   # search ClawHub plugins
-openclaw plugins install <package>                      # npm by default
+openclaw plugins install <package>                      # source auto-detection
 openclaw plugins install clawhub:<package>              # ClawHub only
 openclaw plugins install npm:<package>                  # npm only
 openclaw plugins install npm-pack:<path.tgz>            # local npm pack through npm install semantics
@@ -123,7 +123,7 @@ sources with guarded environment variables. See
 [Plugin install overrides](/plugins/install-overrides).
 
 <Warning>
-Bare package names install from npm by default during the launch cutover. Use `clawhub:<package>` for ClawHub. Treat plugin installs like running code. Prefer pinned versions.
+Bare package names install from npm by default during the launch cutover, unless they match an official plugin id. Raw `@openclaw/*` package specs that match bundled plugins use the bundled copy that shipped with the current OpenClaw build. Use `npm:<package>` when you deliberately want an external npm package instead. Use `clawhub:<package>` for ClawHub. Treat plugin installs like running code. Prefer pinned versions.
 </Warning>
 
 `plugins search` queries ClawHub for installable plugin packages and prints
@@ -171,7 +171,9 @@ is available, then fall back to `latest`.
 
     Npm specs are **registry-only** (package name + optional **exact version** or **dist-tag**). Git/URL/file specs and semver ranges are rejected. Dependency installs run project-local with `--ignore-scripts` for safety, even when your shell has global npm install settings. Managed plugin npm roots inherit OpenClaw's package-level npm `overrides`, so host security pins apply to hoisted plugin dependencies too.
 
-    Use `npm:<package>` when you want to make npm resolution explicit. Bare package specs also install directly from npm during the launch cutover.
+    Use `npm:<package>` when you want to make npm resolution explicit. Bare package specs also install directly from npm during the launch cutover unless they match an official plugin id.
+
+    Raw `@openclaw/*` package specs that match bundled plugins resolve to the image-owned bundled copy before npm fallback. For example, `openclaw plugins install @openclaw/discord@2026.5.20 --pin` uses the bundled Discord plugin from the current OpenClaw build instead of creating a managed npm override. To force the external npm package, use `openclaw plugins install npm:@openclaw/discord@2026.5.20 --pin`.
 
     Bare specs and `@latest` stay on the stable track. OpenClaw date-stamped correction versions such as `2026.5.3-1` are stable releases for this check. If npm resolves either of those to a prerelease, OpenClaw stops and asks you to opt in explicitly with a prerelease tag such as `@beta`/`@rc` or an exact prerelease version such as `@1.2.3-beta.4`.
 
@@ -207,7 +209,7 @@ openclaw plugins install clawhub:openclaw-codex-app-server
 openclaw plugins install clawhub:openclaw-codex-app-server@1.2.3
 ```
 
-Bare npm-safe plugin specs install from npm by default during the launch cutover:
+Bare npm-safe plugin specs install from npm by default during the launch cutover unless they match an official plugin id:
 
 ```bash
 openclaw plugins install openclaw-codex-app-server
@@ -217,6 +219,7 @@ Use `npm:` to make npm-only resolution explicit:
 
 ```bash
 openclaw plugins install npm:openclaw-codex-app-server
+openclaw plugins install npm:@openclaw/discord@2026.5.20
 openclaw plugins install npm:@scope/plugin-name@1.0.1
 ```
 

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -40,7 +40,9 @@ Before installing a plugin, make sure you have:
     ```
 
     ClawHub is the primary discovery surface for community plugins. During the
-    launch cutover, ordinary bare package specs still install from npm. Use an
+    launch cutover, ordinary bare package specs still install from npm unless
+    they match an official plugin id. Raw `@openclaw/*` package specs that match
+    bundled plugins use the bundled copy from the current OpenClaw build. Use an
     explicit prefix when you need one source.
 
   </Step>
@@ -126,10 +128,13 @@ Before installing a plugin, make sure you have:
 Bare package specs have special compatibility behavior. If the bare name matches
 a bundled plugin id, OpenClaw uses that bundled source. If it matches an
 official external plugin id, OpenClaw uses the official package catalog. Other
-ordinary bare package specs install through npm during the launch cutover. Use
-`clawhub:`, `npm:`, `git:`, or `npm-pack:` when you need deterministic source
-selection. See [`openclaw plugins`](/cli/plugins#install) for the full command
-contract.
+ordinary bare package specs install through npm during the launch cutover. Raw
+`@openclaw/*` package specs that match bundled plugins also resolve to the
+bundled copy before npm fallback. Use `npm:@openclaw/<plugin>@<version>` when
+you deliberately want the external npm package instead of the image-owned
+bundled copy. Use `clawhub:`, `npm:`, `git:`, or `npm-pack:` when you need
+deterministic source selection. See [`openclaw plugins`](/cli/plugins#install)
+for the full command contract.
 
 ### Configure plugin policy
 

--- a/scripts/clawdock/README.md
+++ b/scripts/clawdock/README.md
@@ -202,7 +202,11 @@ This means:
 - `~/.openclaw/.env` is available inside the container at `/home/node/.openclaw/.env` — OpenClaw loads it automatically as the global env fallback
 - `~/.openclaw/openclaw.json` is available at `/home/node/.openclaw/openclaw.json` — the gateway watches it and hot-reloads most changes
 - `~/.openclaw-auth-profile-secrets` is available at `/home/node/.config/openclaw` — OpenClaw stores the auth-profile encryption key there
-- Downloadable plugin packages and install records live under the mounted OpenClaw home
+- Downloadable external plugin packages and install records live under the mounted OpenClaw home
+- Bundled OpenClaw channel plugins, such as Discord when present in the image,
+  should normally load from the image-matched bundled copy. Avoid installing
+  pinned `@openclaw/*` channel packages into the mounted home unless you
+  deliberately want an external npm override.
 - No need to add API keys to `docker-compose.yml` or configure anything inside the container
 - Keys survive `clawdock-update`, `clawdock-rebuild`, and `clawdock-clean` because they live on the host
 

--- a/src/cli/plugin-install-plan.test.ts
+++ b/src/cli/plugin-install-plan.test.ts
@@ -27,14 +27,44 @@ describe("plugin install plan helpers", () => {
     expect(result?.warning).toContain('bare install spec "voice-call"');
   });
 
-  it("skips bundled pre-plan for scoped npm specs", () => {
-    const findBundledSource = vi.fn();
+  it("prefers bundled plugin for scoped npm package specs", () => {
+    const findBundledSource = vi
+      .fn()
+      .mockImplementation(({ kind, value }: { kind: "pluginId" | "npmSpec"; value: string }) => {
+        if (kind === "npmSpec" && value === "@openclaw/voice-call") {
+          return {
+            pluginId: "voice-call",
+            localPath: installedPluginRoot("/tmp", "voice-call"),
+            npmSpec: "@openclaw/voice-call",
+          };
+        }
+        return undefined;
+      });
     const result = resolveBundledInstallPlanBeforeNpm({
-      rawSpec: "@openclaw/voice-call",
+      rawSpec: "@openclaw/voice-call@2026.5.20",
       findBundledSource,
     });
 
-    expect(findBundledSource).not.toHaveBeenCalled();
+    expect(findBundledSource).toHaveBeenCalledWith({
+      kind: "npmSpec",
+      value: "@openclaw/voice-call@2026.5.20",
+    });
+    expect(findBundledSource).toHaveBeenCalledWith({
+      kind: "npmSpec",
+      value: "@openclaw/voice-call",
+    });
+    expect(result?.bundledSource.pluginId).toBe("voice-call");
+    expect(result?.warning).toContain('npm install spec "@openclaw/voice-call@2026.5.20"');
+    expect(result?.warning).toContain("npm:@openclaw/voice-call@2026.5.20");
+  });
+
+  it("skips bundled pre-plan for npm specs that do not match bundled packages", () => {
+    const findBundledSource = vi.fn();
+    const result = resolveBundledInstallPlanBeforeNpm({
+      rawSpec: "@openclaw/not-bundled",
+      findBundledSource,
+    });
+
     expect(result).toBeNull();
   });
 

--- a/src/cli/plugin-install-plan.ts
+++ b/src/cli/plugin-install-plan.ts
@@ -66,19 +66,43 @@ export function resolveBundledInstallPlanBeforeNpm(params: {
   rawSpec: string;
   findBundledSource: BundledLookup;
 }): { bundledSource: BundledPluginSource; warning: string } | null {
-  if (!isBareNpmPackageName(params.rawSpec)) {
+  const rawSpec = params.rawSpec.trim();
+  if (!rawSpec) {
     return null;
   }
-  const bundledSource = params.findBundledSource({
-    kind: "pluginId",
-    value: params.rawSpec,
-  });
+  if (isBareNpmPackageName(rawSpec)) {
+    const bundledSource = params.findBundledSource({
+      kind: "pluginId",
+      value: rawSpec,
+    });
+    if (!bundledSource) {
+      return null;
+    }
+    return {
+      bundledSource,
+      warning: `Using bundled plugin "${bundledSource.pluginId}" from ${shortenHomePath(bundledSource.localPath)} for bare install spec "${rawSpec}". To install an npm package with the same name, use a scoped package name (for example @scope/${rawSpec}).`,
+    };
+  }
+
+  const parsedNpmSpec = parseRegistryNpmSpec(rawSpec);
+  if (!parsedNpmSpec) {
+    return null;
+  }
+  const bundledSource =
+    params.findBundledSource({
+      kind: "npmSpec",
+      value: rawSpec,
+    }) ??
+    params.findBundledSource({
+      kind: "npmSpec",
+      value: parsedNpmSpec.name,
+    });
   if (!bundledSource) {
     return null;
   }
   return {
     bundledSource,
-    warning: `Using bundled plugin "${bundledSource.pluginId}" from ${shortenHomePath(bundledSource.localPath)} for bare install spec "${params.rawSpec}". To install an npm package with the same name, use a scoped package name (for example @scope/${params.rawSpec}).`,
+    warning: `Using bundled plugin "${bundledSource.pluginId}" from ${shortenHomePath(bundledSource.localPath)} for npm install spec "${rawSpec}" because this plugin ships with the current OpenClaw build. To force an external npm override, use npm:${rawSpec}.`,
   };
 }
 

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -1054,6 +1054,7 @@ describe("plugins cli install", () => {
     const enabledCfg = createEnabledPluginConfig("discord");
 
     loadConfig.mockReturnValue(cfg);
+    findBundledPluginSourceMock.mockReturnValue(undefined);
     installPluginFromNpmSpec.mockResolvedValue(createNpmPluginInstallResult("discord"));
     enablePluginInConfig.mockReturnValue({ config: enabledCfg });
     recordPluginInstall.mockReturnValue(enabledCfg);
@@ -1070,11 +1071,60 @@ describe("plugins cli install", () => {
     expect(installPluginFromClawHub).not.toHaveBeenCalled();
   });
 
+  it("uses bundled OpenClaw package specs instead of pinning stale managed npm overrides", async () => {
+    const cfg = createEmptyPluginConfig();
+    const enabledCfg = createEnabledPluginConfig("discord");
+    const bundledPath = "/app/dist/extensions/discord";
+
+    loadConfig.mockReturnValue(cfg);
+    findBundledPluginSourceMock.mockImplementation(
+      ({ lookup }: { lookup: { kind: "pluginId" | "npmSpec"; value: string } }) =>
+        lookup.kind === "npmSpec" && lookup.value === "@openclaw/discord"
+          ? {
+              pluginId: "discord",
+              localPath: bundledPath,
+              npmSpec: "@openclaw/discord",
+              version: "2026.5.24-beta.2",
+            }
+          : undefined,
+    );
+    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
+    recordPluginInstall.mockReturnValue(enabledCfg);
+    applyExclusiveSlotSelection.mockReturnValue({
+      config: enabledCfg,
+      warnings: [],
+    });
+
+    await runPluginsCommand([
+      "plugins",
+      "install",
+      "@openclaw/discord@2026.5.20",
+      "--pin",
+      "--force",
+    ]);
+
+    expect(installPluginFromNpmSpec).not.toHaveBeenCalled();
+    expect(findBundledPluginSourceMock).toHaveBeenCalledWith({
+      lookup: { kind: "npmSpec", value: "@openclaw/discord@2026.5.20" },
+    });
+    expect(findBundledPluginSourceMock).toHaveBeenCalledWith({
+      lookup: { kind: "npmSpec", value: "@openclaw/discord" },
+    });
+    const record = persistedInstallRecord("discord");
+    expect(record.source).toBe("path");
+    expect(record.spec).toBe("@openclaw/discord@2026.5.20");
+    expect(record.sourcePath).toBe(bundledPath);
+    expect(record.installPath).toBe(bundledPath);
+    expect(runtimeLogsContain("ships with the current OpenClaw build")).toBe(true);
+    expect(runtimeLogsContain("npm:@openclaw/discord@2026.5.20")).toBe(true);
+  });
+
   it("marks catalog npm package installs with alternate selectors as trusted", async () => {
     const cfg = createEmptyPluginConfig();
     const enabledCfg = createEnabledPluginConfig("wecom-openclaw-plugin");
 
     loadConfig.mockReturnValue(cfg);
+    findBundledPluginSourceMock.mockReturnValue(undefined);
     installPluginFromNpmSpec.mockResolvedValue(
       createNpmPluginInstallResult("wecom-openclaw-plugin"),
     );

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -1077,17 +1077,19 @@ describe("plugins cli install", () => {
     const bundledPath = "/app/dist/extensions/discord";
 
     loadConfig.mockReturnValue(cfg);
-    findBundledPluginSourceMock.mockImplementation(
-      ({ lookup }: { lookup: { kind: "pluginId" | "npmSpec"; value: string } }) =>
-        lookup.kind === "npmSpec" && lookup.value === "@openclaw/discord"
-          ? {
-              pluginId: "discord",
-              localPath: bundledPath,
-              npmSpec: "@openclaw/discord",
-              version: "2026.5.24-beta.2",
-            }
-          : undefined,
-    );
+    findBundledPluginSourceMock.mockImplementation((params: unknown) => {
+      const { lookup } = params as {
+        lookup: { kind: "pluginId" | "npmSpec"; value: string };
+      };
+      return lookup.kind === "npmSpec" && lookup.value === "@openclaw/discord"
+        ? {
+            pluginId: "discord",
+            localPath: bundledPath,
+            npmSpec: "@openclaw/discord",
+            version: "2026.5.24-beta.2",
+          }
+        : undefined;
+    });
     enablePluginInConfig.mockReturnValue({ config: enabledCfg });
     recordPluginInstall.mockReturnValue(enabledCfg);
     applyExclusiveSlotSelection.mockReturnValue({


### PR DESCRIPTION
## Summary
- Prefer the bundled install plan when a raw npm spec matches an OpenClaw-bundled plugin package, including scoped/versioned specs like `@openclaw/discord@2026.5.20`.
- Preserve explicit external npm overrides through the existing `npm:<spec>` escape hatch.
- Document the Docker persistence boundary: external packages and install records live in mounted state, but bundled OpenClaw channel plugins should normally load from the image-matched copy.

## Anonymized Source Evidence
A Docker-managed setup installed a pinned bundled channel package into mounted OpenClaw state, where it shadowed the bundled plugin from newer images.

- Redacted config-audit output showed setup running `channels add --channel discord --use-env`.
- Redacted config-audit output then showed `plugins install @openclaw/discord@2026.5.20 --pin --force`.
- Redacted install state recorded `installRecords.discord.source = npm`, `spec = @openclaw/discord@2026.5.20`, and `installPath = <state>/npm/node_modules/@openclaw/discord`.
- Redacted active plugin state showed the Discord plugin loading from `<state>/npm/node_modules/@openclaw/discord`, `origin = global`, `packageVersion = 2026.5.20`.
- Redacted mounted npm state still pinned `@openclaw/discord` to `2026.5.20`.
- The runtime image and mounted plugin versions were split, so Docker could update the gateway image while continuing to load old bundled plugin code from persistent npm state.

## Real behavior proof
Behavior addressed: Raw npm specs matching bundled OpenClaw plugin packages now resolve to the bundled image copy before npm fallback, so setup cannot pin a stale managed npm override unless the operator explicitly uses `npm:<spec>`.

Real environment tested: Local OpenClaw CLI from this PR branch, using a clean temporary state directory and a built `dist/` tree.

Exact steps or command run after this patch:

```bash
export STATE_DIR="$(mktemp -d /tmp/openclaw-pr-86754.XXXXXX)"
OPENCLAW_STATE_DIR="$STATE_DIR" \
OPENCLAW_CONFIG_DIR="$STATE_DIR" \
OPENCLAW_CONFIG_PATH="$STATE_DIR/openclaw.json" \
OPENCLAW_WORKSPACE_DIR="$STATE_DIR/workspace" \
OPENCLAW_DISABLE_BONJOUR=1 \
node scripts/run-node.mjs plugins install @openclaw/discord@2026.5.20 --pin --force

node -e 'const fs=require("fs"); const data=JSON.parse(fs.readFileSync(process.env.STATE_DIR+"/plugins/installs.json","utf8")); console.log(JSON.stringify(data.installRecords.discord,null,2));'
```

Evidence after fix: Redacted terminal output from the clean-state CLI smoke:

```text
Using bundled plugin "discord" from <repo>/dist/extensions/discord for npm install spec "@openclaw/discord@2026.5.20" because this plugin ships with the current OpenClaw build. To force an external npm override, use npm:@openclaw/discord@2026.5.20.
Installed plugin: discord
Restart the gateway to load plugins.
{
  "source": "path",
  "spec": "@openclaw/discord@2026.5.20",
  "sourcePath": "<repo>/dist/extensions/discord",
  "installPath": "<repo>/dist/extensions/discord",
  "installedAt": "<timestamp>"
}
```

Observed result after fix: The install completed as `source: path` with `sourcePath` and `installPath` pointing at the bundled Discord plugin under `<repo>/dist/extensions/discord`; it did not create a managed npm override for `@openclaw/discord@2026.5.20`.

What was not tested: Already-persisted stale npm install records were not migrated; this PR only changes future install routing. Existing-state cleanup should be handled separately through doctor/update repair if maintainers want that behavior.

## Tests
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `node scripts/run-vitest.mjs src/cli/plugin-install-plan.test.ts src/cli/plugins-cli.install.test.ts` -> 2 files passed, 100 tests passed
- `pnpm exec oxlint src/cli/plugin-install-plan.ts src/cli/plugin-install-plan.test.ts src/cli/plugins-cli.install.test.ts`
- `pnpm docs:check-mdx`
- `pnpm docs:check-links -- docs/cli/plugins.md docs/tools/plugin.md`
- `git diff --check`
- Clean-state CLI smoke above
