### PR TITLE
[codex] Fix memory close sync race

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -32,6 +32,7 @@ let embedBatchInputCalls = 0;
 let providerCloseCalls = 0;
 let providerCloseFailuresRemaining = 0;
 let providerCloseGate: Promise<void> | null = null;
+let providerInitGate: Promise<void> | null = null;
 let providerCalls: Array<{ provider?: string; model?: string; outputDimensionality?: number }> = [];
 let forceNoProvider = false;
 
@@ -67,6 +68,7 @@ vi.mock("./embeddings.js", () => {
         model: options.model,
         outputDimensionality: options.outputDimensionality,
       });
+      await providerInitGate;
       if (forceNoProvider) {
         return {
           provider: null,
@@ -218,6 +220,7 @@ describe("memory index", () => {
     providerCloseCalls = 0;
     providerCloseFailuresRemaining = 0;
     providerCloseGate = null;
+    providerInitGate = null;
     providerCalls = [];
     forceNoProvider = false;
 
@@ -402,7 +405,7 @@ describe("memory index", () => {
     expect(providerCloseCalls).toBe(1);
   });
 
-  it("closes embedding providers before waiting for pending sync to settle", async () => {
+  it("waits for pending sync before closing embedding providers", async () => {
     const cfg = createCfg({
       storePath: indexMainPath,
       hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
@@ -415,18 +418,77 @@ describe("memory index", () => {
     });
 
     const closePromise = manager.close();
-    await vi.waitFor(() => {
-      expect(providerCloseCalls).toBe(1);
-    });
-    let closeSettled = false;
-    void closePromise.then(() => {
-      closeSettled = true;
-    });
-    await Promise.resolve();
+    try {
+      await Promise.resolve();
+      expect(providerCloseCalls).toBe(0);
 
-    expect(closeSettled).toBe(false);
-    resolveSync();
+      let closeSettled = false;
+      void closePromise.then(() => {
+        closeSettled = true;
+      });
+      await Promise.resolve();
+
+      expect(closeSettled).toBe(false);
+    } finally {
+      resolveSync();
+    }
     await closePromise;
+    expect(providerCloseCalls).toBe(1);
+  });
+
+  it("waits for sync that attaches after provider initialization before closing providers", async () => {
+    let releaseProviderInit: () => void = () => {};
+    providerInitGate = new Promise<void>((resolve) => {
+      releaseProviderInit = resolve;
+    });
+    const cfg = createCfg({
+      storePath: indexMainPath,
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const manager = await getFreshManager(cfg);
+    let releaseSync: () => void = () => {};
+    const syncStarted = new Promise<void>((resolve) => {
+      const originalRunSyncWithReadonlyRecovery = (
+        manager as unknown as {
+          runSyncWithReadonlyRecovery: (params?: {
+            reason?: string;
+            force?: boolean;
+            sessionFiles?: string[];
+            progress?: (update: unknown) => void;
+          }) => Promise<void>;
+        }
+      ).runSyncWithReadonlyRecovery.bind(manager);
+      (
+        manager as unknown as {
+          runSyncWithReadonlyRecovery: typeof originalRunSyncWithReadonlyRecovery;
+        }
+      ).runSyncWithReadonlyRecovery = async (params) => {
+        resolve();
+        await new Promise<void>((syncResolve) => {
+          releaseSync = syncResolve;
+        });
+        await originalRunSyncWithReadonlyRecovery(params);
+      };
+    });
+
+    const syncPromise = manager.sync({ reason: "test" });
+    await vi.waitFor(() => {
+      expect(providerCalls).toHaveLength(1);
+    });
+
+    const closePromise = manager.close();
+    try {
+      releaseProviderInit();
+      await syncStarted;
+      await Promise.resolve();
+
+      expect(providerCloseCalls).toBe(0);
+    } finally {
+      releaseSync();
+    }
+    await syncPromise;
+    await closePromise;
+    expect(providerCloseCalls).toBe(1);
   });
 
   it("evicts scoped memory index managers before close settles", async () => {

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -738,14 +738,16 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     if (this.closed) {
       return;
     }
-    await this.ensureProviderInitialized();
     if (this.syncing) {
       if (params?.sessionFiles?.some((sessionFile) => sessionFile.trim().length > 0)) {
         return this.enqueueTargetedSessionSync(params.sessionFiles);
       }
       return this.syncing;
     }
-    this.syncing = this.runSyncWithReadonlyRecovery(params).finally(() => {
+    this.syncing = (async () => {
+      await this.ensureProviderInitialized();
+      await this.runSyncWithReadonlyRecovery(params);
+    })().finally(() => {
       this.syncing = null;
     });
     return this.syncing ?? Promise.resolve();
@@ -1025,7 +1027,6 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       return;
     }
     this.closed = true;
-    const pendingSync = this.syncing;
     const pendingProviderInit = this.providerInitPromise;
     if (this.watchTimer) {
       clearTimeout(this.watchTimer);
@@ -1048,26 +1049,44 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       this.sessionUnsubscribe = null;
     }
     const closeErrors = new Map<EmbeddingProvider, unknown>();
-    const closeCurrentProvider = async () => {
+    // A sync may swap to a fallback provider before close resumes, so retain
+    // every provider reference observed during shutdown and close them after sync settles.
+    const providersToClose = new Set<EmbeddingProvider>();
+    const rememberCurrentProvider = () => {
       const provider = this.provider;
       if (!provider) {
         return;
       }
-      try {
-        await provider.close?.();
-        closeErrors.delete(provider);
-        if (this.provider === provider) {
-          this.provider = null;
+      providersToClose.add(provider);
+    };
+    const closeTrackedProviders = async () => {
+      rememberCurrentProvider();
+      for (const provider of providersToClose) {
+        try {
+          await provider.close?.();
+          closeErrors.delete(provider);
+          providersToClose.delete(provider);
+          if (this.provider === provider) {
+            this.provider = null;
+          }
+        } catch (err) {
+          closeErrors.set(provider, err);
         }
-      } catch (err) {
-        closeErrors.set(provider, err);
       }
     };
-    await awaitPendingManagerWork({ pendingProviderInit });
-    await closeCurrentProvider();
-    try {
+    const awaitCurrentSync = async () => {
+      const pendingSync = this.syncing;
+      if (!pendingSync) {
+        return;
+      }
       await awaitPendingManagerWork({ pendingSync });
-      await closeCurrentProvider();
+    };
+    await awaitPendingManagerWork({ pendingProviderInit });
+    rememberCurrentProvider();
+    try {
+      await awaitCurrentSync();
+      await closeTrackedProviders();
+      await closeTrackedProviders();
     } finally {
       closeMemoryDatabase(this.db);
       if (INDEX_CACHE.get(this.cacheKey) === this) {

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1049,8 +1049,8 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       this.sessionUnsubscribe = null;
     }
     const closeErrors = new Map<EmbeddingProvider, unknown>();
-    // A sync may swap to a fallback provider before close resumes, so retain
-    // every provider reference observed during shutdown and close them after sync settles.
+    // Sync/provider fallback may swap this.provider while close is awaiting.
+    // Keep every observed provider and drain the set after sync has settled.
     const providersToClose = new Set<EmbeddingProvider>();
     const rememberCurrentProvider = () => {
       const provider = this.provider;
@@ -1059,18 +1059,30 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       }
       providersToClose.add(provider);
     };
-    const closeTrackedProviders = async () => {
-      rememberCurrentProvider();
-      for (const provider of providersToClose) {
+    const closeProvider = async (provider: EmbeddingProvider) => {
+      try {
+        await provider.close?.();
+        closeErrors.delete(provider);
+        if (this.provider === provider) {
+          this.provider = null;
+        }
+      } catch (err) {
+        closeErrors.set(provider, err);
+        providersToClose.add(provider);
+      } finally {
+        rememberCurrentProvider();
+      }
+    };
+    const drainTrackedProviders = async () => {
+      for (let attempt = 0; attempt < 2 && providersToClose.size > 0; attempt += 1) {
+        const providers = Array.from(providersToClose);
+        providersToClose.clear();
         try {
-          await provider.close?.();
-          closeErrors.delete(provider);
-          providersToClose.delete(provider);
-          if (this.provider === provider) {
-            this.provider = null;
+          for (const provider of providers) {
+            await closeProvider(provider);
           }
-        } catch (err) {
-          closeErrors.set(provider, err);
+        } finally {
+          rememberCurrentProvider();
         }
       }
     };
@@ -1085,8 +1097,8 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     rememberCurrentProvider();
     try {
       await awaitCurrentSync();
-      await closeTrackedProviders();
-      await closeTrackedProviders();
+      rememberCurrentProvider();
+      await drainTrackedProviders();
     } finally {
       closeMemoryDatabase(this.db);
       if (INDEX_CACHE.get(this.cacheKey) === this) {


### PR DESCRIPTION
Refs #86702

## Summary

- Register `MemoryIndexManager.sync()` as in-flight before awaiting provider initialization so `close()` can see syncs that are blocked inside provider setup.
- Delay provider and SQLite teardown until the current sync has settled, while still tracking provider references seen during shutdown so fallback swaps can be closed safely.
- Update memory-core regression coverage for both existing pending-sync shutdown and the provider-initialization interleaving.

## Root Cause

`close()` captured `this.syncing` before awaiting provider initialization and watcher teardown. A sync that was already started but still awaiting `ensureProviderInitialized()` could attach `this.syncing` after that stale snapshot, letting `close()` proceed to close provider and database resources while the sync continued.

## Real Behavior Proof

Behavior addressed: `MemoryIndexManager.close()` no longer closes embedding providers or the SQLite database before already-started sync work settles, including syncs blocked in provider initialization.

Real environment tested: Local sparse checkout on macOS arm64 with Node v24.13.1 and installed workspace dependencies. The proof runs a standalone Node runtime script against the real `MemoryIndexManager`, real SQLite index, and the public memory embedding provider registry. The script creates a temporary workspace and memory file, starts `sync({ force: true })`, blocks provider creation, calls `close()`, then releases provider init and holds the real `embedBatch()` call before allowing sync to finish.

Exact steps or command run after this patch:

```bash
NODE_NO_WARNINGS=1 node --import tsx /private/tmp/openclaw-86765-proof.mjs
```

Evidence after fix:

```text
openclaw#86765 runtime proof
node: v24.13.1
platform: darwin arm64
workspace: /var/folders/qm/d7_ghh9j1019scbft187ry000000gn/T/openclaw-86765-proof-511y6J
scenario: sync blocked during provider init, close() called, provider init released, sync held inside real embedBatch
during blocked sync:
  close settled: false
  provider close calls: 0
  embedBatch calls: 1
  sqlite SELECT 1: ok
after releasing sync:
  close error: none
  provider close calls: 1
  sqlite after close: database is not open
events: provider:create:entered -> provider:create:resolved -> provider:embedBatch:start:1 -> provider:embedBatch:released -> provider:close:1
PASS: close waited for the in-flight sync before closing provider/database resources
```

Observed result after fix: While sync was blocked inside the real `embedBatch()` path, `close()` had not settled, the embedding provider had not been closed, and SQLite still answered `SELECT 1`. After releasing sync, `close()` completed without error, the provider closed exactly once, and SQLite reported `database is not open`, which shows resource teardown happened after the in-flight sync settled.

What was not tested: The proof uses a local registered provider adapter to make the race deterministic; it does not call external embedding APIs. Full repository lint/check was not run locally. The repo `run-oxlint.mjs` wrapper tries to prepare extension package boundary artifacts for unrelated sparse-checkout extensions, so the PR uses direct touched-file `oxfmt`/`oxlint` plus the relevant memory tests.

## Verification

- `NODE_NO_WARNINGS=1 node --import tsx /private/tmp/openclaw-86765-proof.mjs` - passed, runtime proof above
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-memory.config.ts --configLoader runner extensions/memory-core/src/memory/index.test.ts extensions/memory-core/src/memory/manager.async-search.test.ts extensions/memory-core/src/memory/manager.readonly-recovery.test.ts` - passed, 3 files / 32 tests
- `./node_modules/.bin/oxfmt --check extensions/memory-core/src/memory/manager.ts extensions/memory-core/src/memory/index.test.ts` - passed
- `./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/memory-core/src/memory/manager.ts extensions/memory-core/src/memory/index.test.ts` - passed
- `git diff --check origin/main...HEAD` - passed
