### PR TITLE
fix(commands): deliver /new and /reset acknowledgements despite source reply suppression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: route normal `[telegram][diag]` polling diagnostics through `runtime.log` while keeping non-diag warnings and persistence failures on `runtime.error`, so healthy polling startup no longer looks like an error. Fixes #82957. (#82958) Thanks @galiniliev.
 - Providers/Ollama: strip inline Kimi cloud reasoning prefixes from streamed and final visible replies while keeping ordinary Kimi answers append-only. (#86286) Thanks @jason-allen-oneal.
 
+- Commands: deliver /new and /reset acknowledgement replies (✅ Session reset. / ✅ New session started.) when source reply delivery is suppressed, so users see confirmation on channels with message_tool_only reply mode. (#86664)
 - Gateway: require Talk secret authority before setup-code handoff can include Talk secrets. (#85690) Thanks @ngutman.
 - Agents: keep fallback error reporting scoped to the active model candidate so stale prior-provider quota/auth text is not reported for later fallback attempts. (#86134) thanks @zhangguiping-xydt.
 

--- a/src/auto-reply/reply/commands-reset.ts
+++ b/src/auto-reply/reply/commands-reset.ts
@@ -4,6 +4,7 @@ import { resetConfiguredBindingTargetInPlace } from "../../channels/plugins/bind
 import { updateSessionStoreEntry } from "../../config/sessions/store.js";
 import { logVerbose } from "../../globals.js";
 import { isAcpSessionKey } from "../../routing/session-key.js";
+import { markReplyPayloadForSourceSuppressionDelivery } from "../reply-payload.js";
 import { resolveBoundAcpThreadSessionKey } from "./commands-acp/targets.js";
 import { emitResetCommandHooks, type ResetCommandAction } from "./commands-reset-hooks.js";
 import { parseSoftResetCommand } from "./commands-reset-mode.js";
@@ -172,9 +173,9 @@ export async function maybeHandleResetCommand(
       ...(hookResult.routedReply
         ? {}
         : {
-            reply: {
+            reply: markReplyPayloadForSourceSuppressionDelivery({
               text: commandAction === "reset" ? "✅ Session reset." : "✅ New session started.",
-            },
+            }),
           }),
     };
   }


### PR DESCRIPTION
## Summary

- The `/new` and `/reset` commands produce acknowledgement replies (✅ Session reset. / ✅ New session started.) that were not delivered to users on channels like Mattermost where `visibleReplies` is set to `message_tool`.
- The acknowledgement reply at `commands-reset.ts:176-178` is now wrapped with `markReplyPayloadForSourceSuppressionDelivery()` so it bypasses source reply suppression, following the same pattern used by other internal notices that must bypass source delivery suppression.

## Verification

- All 1918 tests in the auto-reply-reply test suite pass (114 test files).
- The fix uses the existing `markReplyPayloadForSourceSuppressionDelivery` helper already used by other replies that must bypass source suppression (e.g. ACP reset acknowledgment at line 148).

## Real behavior proof

**Behavior addressed:** `/new` and `/reset` commands on Mattermost group channels silently change session state without showing visible acknowledgement.

**Environment tested:** Node 22.x on Linux, pnpm test.

**Steps run after the patch:** Verified the production `markReplyPayloadForSourceSuppressionDelivery` function sets the `deliverDespiteSourceReplySuppression` metadata flag that the dispatch pipeline checks:

```bash
node --import tsx --no-warnings -e "
import { markReplyPayloadForSourceSuppressionDelivery, getReplyPayloadMetadata } from './src/auto-reply/reply-payload.js';

const reply = markReplyPayloadForSourceSuppressionDelivery({
  text: '✅ Session reset.',
});
const meta = getReplyPayloadMetadata(reply);
console.log('Input reply:', JSON.stringify(reply));
console.log('deliverDespiteSourceReplySuppression:', meta?.deliverDespiteSourceReplySuppression);
"
```

Output:

```
Input reply: {"text":"✅ Session reset."}
deliverDespiteSourceReplySuppression: true
```

**Evidence after fix:**

The fix in `commands-reset.ts` now wraps the reply with `markReplyPayloadForSourceSuppressionDelivery()`:

```typescript
reply: markReplyPayloadForSourceSuppressionDelivery({
  text: commandAction === "reset" ? "✅ Session reset." : "✅ New session started.",
}),
```

The dispatch pipeline in `dispatch-from-config.ts` (line 2414) checks `shouldDeliverDespiteSourceReplySuppression(reply)` before suppressing delivery. The function returns `true` when `deliverDespiteSourceReplySuppression === true` and the reply is not already suppressed by send policy, allowing the acknowledgement to reach the user.

**Observed result:** The acknowledgement reply payload carries `deliverDespiteSourceReplySuppression: true` metadata. The dispatch check at `dispatch-from-config.ts:2414` allows delivery despite `message_tool_only` source reply suppression.

**Not tested:** Live Mattermost gateway session with `visibleReplies: message_tool` configuration.

Closes #86664.

🤖 Generated with [Claude Code](https://claude.com/claude-code)