### PR TITLE
fix: repair local approval resolution

### DIFF
--- a/extensions/discord/src/monitor/exec-approvals.test.ts
+++ b/extensions/discord/src/monitor/exec-approvals.test.ts
@@ -144,7 +144,7 @@ describe("discord exec approval monitor helpers", () => {
     });
   });
 
-  it("keeps already-resolved approval clicks quiet", async () => {
+  it("shows a follow-up for already-resolved approval clicks", async () => {
     const interaction = createInteraction();
     const button = new ExecApprovalButton({
       getApprovers: () => ["123"],
@@ -154,7 +154,11 @@ describe("discord exec approval monitor helpers", () => {
     await button.run(interaction, { id: "abc", action: "allow-once" });
 
     expect(interaction.acknowledge).toHaveBeenCalled();
-    expect(interaction.followUp).not.toHaveBeenCalled();
+    expect(interaction.followUp).toHaveBeenCalledWith({
+      content:
+        "That approval request is no longer pending. It may have expired or already been resolved.",
+      ephemeral: true,
+    });
   });
 
   it("builds button context from config and routes resolution over gateway", async () => {

--- a/extensions/discord/src/monitor/exec-approvals.ts
+++ b/extensions/discord/src/monitor/exec-approvals.ts
@@ -112,10 +112,13 @@ export class ExecApprovalButton extends Button {
     } catch {}
 
     const result = await this.ctx.resolveApproval(parsed.approvalId, parsed.action);
-    if (!result.ok && result.reason !== "not-found") {
+    if (!result.ok) {
       try {
         await interaction.followUp({
-          content: `Failed to submit approval decision for **${decisionLabel}**. The request may have expired or already been resolved.`,
+          content:
+            result.reason === "not-found"
+              ? `That approval request is no longer pending. It may have expired or already been resolved.`
+              : `Failed to submit approval decision for **${decisionLabel}**. The request may have expired or already been resolved.`,
           ephemeral: true,
         });
       } catch {}

--- a/src/gateway/operator-approvals-client.test.ts
+++ b/src/gateway/operator-approvals-client.test.ts
@@ -117,11 +117,26 @@ describe("withOperatorApprovalsGatewayClient", () => {
     expect(clientState.options?.deviceIdentity).toBeUndefined();
   });
 
-  it("omits approval runtime token for explicit gateway URL overrides", async () => {
+  it("keeps approval runtime token for loopback explicit gateway URL overrides", async () => {
     await withOperatorApprovalsGatewayClient(
       {
         config: {} as never,
         gatewayUrl: "ws://127.0.0.1:18789",
+        clientDisplayName: "Matrix approval (@owner:example.org)",
+      },
+      async () => undefined,
+    );
+
+    expect(typeof clientState.options?.approvalRuntimeToken).toBe("string");
+  });
+
+  it("omits approval runtime token for remote explicit gateway URL overrides", async () => {
+    bootstrapState.url = "wss://gateway.example/ws";
+
+    await withOperatorApprovalsGatewayClient(
+      {
+        config: {} as never,
+        gatewayUrl: "wss://gateway.example/ws",
         clientDisplayName: "Matrix approval (@owner:example.org)",
       },
       async () => undefined,

--- a/src/gateway/operator-approvals-client.ts
+++ b/src/gateway/operator-approvals-client.ts
@@ -44,12 +44,15 @@ export async function createOperatorApprovalsGatewayClient(
     gatewayUrl: params.gatewayUrl,
     env: process.env,
   });
+  const shouldSendApprovalRuntimeToken = !params.gatewayUrl || isLoopbackGatewayUrl(bootstrap.url);
 
   return new GatewayClient({
     url: bootstrap.url,
     token: bootstrap.auth.token,
     password: bootstrap.auth.password,
-    ...(params.gatewayUrl ? {} : { approvalRuntimeToken: getOperatorApprovalRuntimeToken() }),
+    ...(shouldSendApprovalRuntimeToken
+      ? { approvalRuntimeToken: getOperatorApprovalRuntimeToken() }
+      : {}),
     preauthHandshakeTimeoutMs: bootstrap.preauthHandshakeTimeoutMs,
     clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
     clientDisplayName: params.clientDisplayName,


### PR DESCRIPTION
## Summary
- Keep approval resolution on `operator.approvals`; do not grant `operator.write` for Discord approval decisions.
- Keep explicit `gatewayUrl` support, but attach `approvalRuntimeToken` when the resolved gateway URL is default/local loopback so local channel-managed approval clients can still get the internal approval-runtime marker.
- Omit `approvalRuntimeToken` for explicit remote gateway URLs.
- Show an ephemeral Discord follow-up when an approval button is clicked after the request is already resolved or expired.

## Scope split
- Kept in this PR: local/loopback approval-runtime token handling for `gatewayUrl` overrides, plus stale Discord approval-button UX.
- Split out: `approval.routeNotice.send` and approval route-notice gateway authorization.
- Split out: shared `exec-approvals.json` socket token support for Docker/CLI/separate-process approval clients sharing `OPENCLAW_HOME`.

## Real behavior proof
Behavior addressed: Local explicit gateway URLs no longer suppress the process-local `approvalRuntimeToken`, while explicit remote gateway URLs still do not receive it. Stale/already-resolved Discord approval button clicks now produce a visible ephemeral follow-up instead of looking dead.

Real environment tested: Crabbox `local-container` provider, lease `cbx_7c29df4df445`, slug `blue-barnacle`, Linux target `node_24-bookworm`, fresh PR checkout of `openclaw/openclaw#86771` at head `33ca1bcbd4`. Also ran focused local validation on Node `v24.14.0`.

Exact steps or command run after this patch: From the repo root, ran this Crabbox smoke command against a fresh PR checkout:

```text
pnpm crabbox:run -- --provider local-container --local-container-image node:24-bookworm --fresh-pr openclaw/openclaw#86771 --idle-timeout 60m --ttl 120m --timing-json --label pr-86771-approval-live-smoke-node24 --script-stdin
```

The smoke script installed with `corepack pnpm install --frozen-lockfile`, started a real loopback gateway with channels/providers disabled, created requester-bound approvals over a gateway client, resolved them through `createOperatorApprovalsGatewayClient`, and directly exercised the stale Discord approval-button follow-up payload.

Evidence after fix:

```text
run context:
  lease=cbx_7c29df4df445 slug=blue-barnacle provider=local-container target=linux type=node_24-bookworm
CRABBOX_PHASE:smoke
[gateway] http server listening (0 plugins)
[gateway] ready
SMOKE loopback_explicit_gateway_runtime_token ok id=smoke-loopback-c467e189-6421-453f-a2b2-70be055dd1bf decision=allow-once
[ws] ⇄ res ✗ exec.approval.get 1ms errorCode=INVALID_REQUEST errorMessage=unknown or expired approval id conn=<redacted> id=<redacted>
SMOKE remote_explicit_gateway_omits_runtime_token ok host=localtest.me reason=APPROVAL_NOT_FOUND
SMOKE discord_stale_button_followup ok payload={"content":"That approval request is no longer pending. It may have expired or already been resolved.","ephemeral":true}
[shutdown] completed cleanly in 20ms
command complete in 40.936s total=2m54.132s
run details provider=local-container lease=cbx_7c29df4df445 slug=blue-barnacle label="pr-86771-approval-live-smoke-node24" type=node_24-bookworm exit=0
```

Focused local validation also passed:

```text
$ PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" node scripts/run-vitest.mjs src/gateway/operator-approvals-client.test.ts extensions/discord/src/monitor/exec-approvals.test.ts --reporter=dot
Test Files  3 passed (3)
Tests  26 passed (26)

$ PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" pnpm exec oxfmt --check --threads=1 src/gateway/operator-approvals-client.ts src/gateway/operator-approvals-client.test.ts extensions/discord/src/monitor/exec-approvals.ts extensions/discord/src/monitor/exec-approvals.test.ts
All matched files use the correct format.

$ git diff --check upstream/main..HEAD
(no output)
```

Observed result after fix: A loopback explicit `gatewayUrl` keeps enough authority to resolve requester-bound approvals through the approval runtime path. A non-loopback explicit `gatewayUrl` omits `approvalRuntimeToken`; the remote client cannot read that requester-bound approval and gets `APPROVAL_NOT_FOUND`. The stale Discord approval-button path sends the ephemeral message `That approval request is no longer pending. It may have expired or already been resolved.`.

What was not tested: No real Discord API/UI click was performed; the Discord handler payload was exercised in the Crabbox smoke process. Direct AWS Crabbox and Blacksmith Testbox were unavailable from this local setup, so the live gateway proof used Crabbox's `local-container` provider. Native approval route notices and separate-process shared socket-token support are intentionally out of scope for follow-up PRs.

## Tests and validation
- `pnpm crabbox:run -- --provider local-container --local-container-image node:24-bookworm --fresh-pr openclaw/openclaw#86771 --idle-timeout 60m --ttl 120m --timing-json --label pr-86771-approval-live-smoke-node24 --script-stdin`
- `PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" node scripts/run-vitest.mjs src/gateway/operator-approvals-client.test.ts extensions/discord/src/monitor/exec-approvals.test.ts --reporter=dot`
- `PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" pnpm exec oxfmt --check --threads=1 src/gateway/operator-approvals-client.ts src/gateway/operator-approvals-client.test.ts extensions/discord/src/monitor/exec-approvals.ts extensions/discord/src/monitor/exec-approvals.test.ts`
- `git diff --check upstream/main..HEAD`

## Risk checklist
Did user-visible behavior change? `Yes`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `Yes`

Highest-risk area: approval-runtime authentication for explicit local gateway URLs.

Mitigation: the token is still process-local; it is only attached for default or loopback-resolved gateway URLs, and explicit remote gateway URLs continue to omit it.

## Current review state
Next action: review the narrowed approval-resolution diff and follow-up PRs for the split-out route-notice and shared-token changes.
