### PR TITLE
fix(codex): avoid native compaction on budget triggers

### DIFF
--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -65,6 +65,7 @@ function startSandboxedCompaction(sessionFile: string) {
     sessionKey: "agent:main:session-1",
     sessionFile,
     workspaceDir: tempDir,
+    trigger: "manual",
     config: { agents: { defaults: { sandbox: { mode: "all" } } } },
   });
 }
@@ -75,6 +76,7 @@ function startNodeExecCompaction(sessionFile: string) {
     sessionKey: "agent:main:session-1",
     sessionFile,
     workspaceDir: tempDir,
+    trigger: "manual",
     config: { tools: { exec: { host: "node", node: "worker-1" } } },
   });
 }
@@ -150,6 +152,34 @@ describe("maybeCompactCodexAppServerSession", () => {
       skipped: true,
       reason: "non_manual_trigger",
       trigger: "budget",
+    });
+  });
+
+  it("skips native app-server compaction when trigger is omitted", async () => {
+    const fake = createFakeCodexClient();
+    setCodexAppServerClientFactoryForTest(async () => fake.client);
+    const sessionFile = await writeTestBinding();
+
+    const result = requireCompactResult(
+      await maybeCompactCodexAppServerSession({
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+        sessionFile,
+        workspaceDir: tempDir,
+        currentTokenCount: 789,
+      }),
+    );
+
+    expect(fake.request).not.toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe("codex app-server owns automatic compaction");
+    expect(result.result?.tokensBefore).toBe(789);
+    expect(compactDetails(result)).toMatchObject({
+      backend: "codex-app-server",
+      skipped: true,
+      reason: "non_manual_trigger",
+      trigger: "unknown",
     });
   });
 
@@ -308,6 +338,7 @@ describe("maybeCompactCodexAppServerSession", () => {
       sessionKey: "agent:main:session-1",
       sessionFile,
       workspaceDir: tempDir,
+      trigger: "manual",
       config: {
         agents: {
           defaults: {
@@ -343,6 +374,7 @@ describe("maybeCompactCodexAppServerSession", () => {
       sessionKey: "agent:sara:session-1",
       sessionFile,
       workspaceDir: tempDir,
+      trigger: "manual",
       config: {
         agents: {
           list: [
@@ -384,6 +416,7 @@ describe("maybeCompactCodexAppServerSession", () => {
       sessionKey: "agent:nik:session-1",
       sessionFile,
       workspaceDir: tempDir,
+      trigger: "manual",
       config: {
         agents: {
           defaults: {
@@ -432,6 +465,7 @@ describe("maybeCompactCodexAppServerSession", () => {
       sessionKey: "agent:lossless:session-1",
       sessionFile,
       workspaceDir: tempDir,
+      trigger: "manual",
       contextEngine,
       config: {
         plugins: {
@@ -485,6 +519,7 @@ describe("maybeCompactCodexAppServerSession", () => {
       sessionKey: "agent:lossless-child:session-1",
       sessionFile,
       workspaceDir: tempDir,
+      trigger: "manual",
       contextEngine,
       config: {
         plugins: {
@@ -541,6 +576,7 @@ describe("maybeCompactCodexAppServerSession", () => {
       sessionKey: "agent:main:session-1",
       sessionFile,
       workspaceDir: tempDir,
+      trigger: "manual",
       authProfileId: "openai-codex:runtime",
     });
 

--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -54,6 +54,7 @@ function startCompaction(sessionFile: string, options: { currentTokenCount?: num
     sessionKey: "agent:main:session-1",
     sessionFile,
     workspaceDir: tempDir,
+    trigger: "manual",
     ...options,
   });
 }
@@ -121,6 +122,35 @@ describe("maybeCompactCodexAppServerSession", () => {
     expect(details.threadId).toBe("thread-1");
     expect(details.signal).toBe("thread/compact/start");
     expect(details.pending).toBe(true);
+  });
+
+  it("skips native app-server compaction for automatic budget triggers", async () => {
+    const fake = createFakeCodexClient();
+    setCodexAppServerClientFactoryForTest(async () => fake.client);
+    const sessionFile = await writeTestBinding();
+
+    const result = requireCompactResult(
+      await maybeCompactCodexAppServerSession({
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+        sessionFile,
+        workspaceDir: tempDir,
+        trigger: "budget",
+        currentTokenCount: 456,
+      }),
+    );
+
+    expect(fake.request).not.toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe("codex app-server owns automatic compaction");
+    expect(result.result?.tokensBefore).toBe(456);
+    expect(compactDetails(result)).toMatchObject({
+      backend: "codex-app-server",
+      skipped: true,
+      reason: "non_manual_trigger",
+      trigger: "budget",
+    });
   });
 
   it("blocks native app-server compaction when the current OpenClaw session is sandboxed", async () => {

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -122,6 +122,29 @@ async function compactCodexNativeThread(
   params: CompactEmbeddedPiSessionParams,
   options: { pluginConfig?: unknown; clientFactory?: CodexAppServerClientFactory } = {},
 ): Promise<EmbeddedPiCompactResult | undefined> {
+  if (params.trigger && params.trigger !== "manual") {
+    embeddedAgentLog.info("skipping codex app-server compaction for non-manual trigger", {
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      trigger: params.trigger,
+    });
+    return {
+      ok: true,
+      compacted: false,
+      reason: "codex app-server owns automatic compaction",
+      result: {
+        summary: "",
+        firstKeptEntryId: "",
+        tokensBefore: params.currentTokenCount ?? 0,
+        details: {
+          backend: "codex-app-server",
+          skipped: true,
+          reason: "non_manual_trigger",
+          trigger: params.trigger ?? "unknown",
+        },
+      },
+    };
+  }
   const nativeExecutionBlock = resolveCodexNativeExecutionBlock({
     config: params.config,
     sessionKey: params.sandboxSessionKey ?? params.sessionKey,

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -122,7 +122,7 @@ async function compactCodexNativeThread(
   params: CompactEmbeddedPiSessionParams,
   options: { pluginConfig?: unknown; clientFactory?: CodexAppServerClientFactory } = {},
 ): Promise<EmbeddedPiCompactResult | undefined> {
-  if (params.trigger && params.trigger !== "manual") {
+  if (params.trigger !== "manual") {
     embeddedAgentLog.info("skipping codex app-server compaction for non-manual trigger", {
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,


### PR DESCRIPTION
## Scope

Fixes a Codex app-server reliability path where OpenClaw automatic/budget compaction could forward into `thread/compact/start`, leaving a user turn queued behind native Codex compaction. If the bound Codex thread was stale or compaction timed out, the inbound message could be accepted/queued but never become a normal visible reply turn.

## Change

- Only explicit/manual Codex compaction forwards to native `thread/compact/start`.
- Non-manual triggers such as budget/preflight return a successful no-op because Codex app-server owns automatic server-side compaction.
- Adds regression coverage that budget compaction does not call the Codex app-server compact endpoint.

## Non-goals

- Does not change manual `/compact` behavior.
- Does not add a separate operator notification path for already-stuck queued turns.

## Risk / rollback

Risk is low and scoped to Codex app-server compaction dispatch. Rollback is reverting this commit; manual compaction keeps the existing behavior either way.

## Verification

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/app-server/compact.test.ts` -> 1 file / 17 tests passed
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo` -> passed
- `node_modules/.bin/oxfmt --check extensions/codex/src/app-server/compact.ts extensions/codex/src/app-server/compact.test.ts` -> passed
- `node_modules/.bin/oxlint extensions/codex/src/app-server/compact.ts extensions/codex/src/app-server/compact.test.ts` -> passed

Note: I started the broader `pnpm test:extension codex ...` lane, but it expanded to 63 Codex extension files and stayed CPU-active without output for several minutes, so I stopped it and used the direct focused regression command above.


## Real behavior proof

Behavior addressed: Codex app-server automatic/budget compaction should not call native `thread/compact/start`; explicit manual compaction should still call the native Codex app-server compact path.

Real environment tested: Local OpenClaw source checkout on branch `fix/codex-compaction-drop-notice` at commit `307a1409c3`, running Node with `tsx` against the real `extensions/codex/src/app-server/compact.ts` implementation outside Vitest.

Exact steps or command run after this patch: Created a temporary Codex session JSONL, wrote a real Codex app-server thread binding with `writeCodexAppServerBinding`, invoked `maybeCompactCodexAppServerSession` with `trigger: "budget"`, then invoked the same function with `trigger: "manual"`, and counted app-server requests sent through the client boundary.

Evidence after fix:

```text
[agent/embedded] skipping codex app-server compaction for non-manual trigger
[agent/embedded] started codex app-server compaction
{
  "budget": {
    "ok": true,
    "compacted": false,
    "reason": "codex app-server owns automatic compaction",
    "details": {
      "backend": "codex-app-server",
      "skipped": true,
      "reason": "non_manual_trigger",
      "trigger": "budget"
    },
    "appServerRequestsAfterBudget": 0
  },
  "manual": {
    "ok": true,
    "compacted": false,
    "details": {
      "backend": "codex-app-server",
      "threadId": "thread-real-proof",
      "signal": "thread/compact/start",
      "pending": true
    },
    "appServerRequestsTotal": 1,
    "lastRequest": {
      "method": "thread/compact/start",
      "params": {
        "threadId": "thread-real-proof"
      }
    }
  }
}
```

Observed result after fix: Budget/preflight-style compaction returned a successful Codex-owned no-op and made zero app-server compact requests. Manual compaction still emitted exactly one `thread/compact/start` request for the bound Codex thread. This directly prevents a normal user turn from being queued behind OpenClaw-started native Codex compaction during automatic context-pressure checks.

What was not tested: I did not replay the original live Discord message because that would require forcing the production channel into the same stale thread/compaction timeout state. I also did not run the full 63-file Codex extension lane to completion; it stayed CPU-active without output for several minutes, so I used the focused source-level proof plus targeted regression, type, format, and lint checks.
