### PR TITLE
fix(models): apply provider policy defaults to inline models

### DIFF
--- a/src/agents/pi-embedded-runner/model.inline-provider.test.ts
+++ b/src/agents/pi-embedded-runner/model.inline-provider.test.ts
@@ -86,6 +86,49 @@ describe("buildInlineProviderModels", () => {
     expect(result[0].id).toBe("gemini-2.5-pro");
   });
 
+  it("applies provider policy api defaults to inline models without clobbering model baseUrl", () => {
+    const providers: Parameters<typeof buildInlineProviderModels>[0] = {
+      anthropic: {
+        baseUrl: "https://anthropic-proxy.example.com/v1",
+        models: [
+          makeModel("claude-sonnet-4-6"),
+          {
+            ...makeModel("claude-opus-4.5"),
+            baseUrl: "https://anthropic-opus-proxy.example.com/v1",
+          },
+        ],
+      },
+      custom: {
+        models: [makeModel("custom-model")],
+      },
+    };
+
+    const result = buildInlineProviderModels(providers);
+
+    expect(
+      result.map(({ provider, id, api, baseUrl }) => ({ provider, id, api, baseUrl })),
+    ).toEqual([
+      {
+        provider: "anthropic",
+        id: "claude-sonnet-4-6",
+        api: "anthropic-messages",
+        baseUrl: "https://anthropic-proxy.example.com/v1",
+      },
+      {
+        provider: "anthropic",
+        id: "claude-opus-4.5",
+        api: "anthropic-messages",
+        baseUrl: "https://anthropic-opus-proxy.example.com/v1",
+      },
+      {
+        provider: "custom",
+        id: "custom-model",
+        api: undefined,
+        baseUrl: undefined,
+      },
+    ]);
+  });
+
   it("model-level api takes precedence over provider-level api", () => {
     const providers: Parameters<typeof buildInlineProviderModels>[0] = {
       custom: {

--- a/src/agents/pi-embedded-runner/model.inline-provider.ts
+++ b/src/agents/pi-embedded-runner/model.inline-provider.ts
@@ -1,4 +1,5 @@
 import type { Api } from "@earendil-works/pi-ai";
+import { normalizeProviderConfigForConfigDefaults } from "../../config/provider-policy.js";
 import type { ModelDefinitionConfig, ModelProviderConfig } from "../../config/types.js";
 import { normalizeGoogleApiBaseUrl } from "../../infra/google-api-base-url.js";
 import { normalizeOptionalLowercaseString } from "../../shared/string-coerce.js";
@@ -135,16 +136,21 @@ export function buildInlineProviderModels(
     if (!trimmed) {
       return [];
     }
-    const providerHeaders = sanitizeModelHeaders(entry?.headers, {
+    const normalizedEntry = normalizeProviderConfigForConfigDefaults({
+      provider: trimmed,
+      providerConfig: entry as ModelProviderConfig,
+    }) as InlineProviderConfig;
+    const providerHeaders = sanitizeModelHeaders(normalizedEntry?.headers, {
       stripSecretRefMarkers: true,
     });
-    const providerRequest = sanitizeConfiguredModelProviderRequest(entry?.request);
-    return (entry?.models ?? []).map((model) => {
+    const providerRequest = sanitizeConfiguredModelProviderRequest(normalizedEntry?.request);
+    return (normalizedEntry?.models ?? []).map((model) => {
+      const inlineModel = model as InlineModelEntry;
       const transport = resolveInlineProviderTransport({
-        api: model.api ?? entry?.api,
-        baseUrl: (model as InlineModelEntry).baseUrl ?? entry?.baseUrl,
+        api: model.api ?? normalizedEntry?.api,
+        baseUrl: inlineModel.baseUrl ?? normalizedEntry?.baseUrl,
       });
-      const modelHeaders = sanitizeModelHeaders((model as InlineModelEntry).headers, {
+      const modelHeaders = sanitizeModelHeaders(inlineModel.headers, {
         stripSecretRefMarkers: true,
       });
       const requestConfig = resolveProviderRequestConfig({
@@ -153,7 +159,7 @@ export function buildInlineProviderModels(
         baseUrl: transport.baseUrl,
         providerHeaders,
         modelHeaders,
-        authHeader: entry?.authHeader,
+        authHeader: normalizedEntry?.authHeader,
         request: providerRequest,
         capability: "llm",
         transport: "stream",
@@ -162,9 +168,9 @@ export function buildInlineProviderModels(
         attachModelProviderRequestTransport(
           {
             ...model,
-            contextWindow: model.contextWindow ?? entry?.contextWindow,
-            contextTokens: model.contextTokens ?? entry?.contextTokens,
-            maxTokens: model.maxTokens ?? entry?.maxTokens,
+            contextWindow: model.contextWindow ?? normalizedEntry?.contextWindow,
+            contextTokens: model.contextTokens ?? normalizedEntry?.contextTokens,
+            maxTokens: model.maxTokens ?? normalizedEntry?.maxTokens,
             input: resolveProviderModelInput({
               provider: trimmed,
               modelId: model.id,
@@ -178,7 +184,7 @@ export function buildInlineProviderModels(
           },
           providerRequest,
         ),
-        entry?.localService,
+        normalizedEntry?.localService,
       );
     });
   });

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -594,6 +594,37 @@ describe("resolveModel", () => {
     });
   });
 
+  it("resolves Anthropic inline entries that rely on provider policy api defaults", () => {
+    const cfg = {
+      models: {
+        providers: {
+          anthropic: {
+            baseUrl: "https://anthropic-proxy.example.com/v1",
+            models: [
+              {
+                id: "claude-sonnet-4-6",
+                name: "Claude Sonnet 4.6",
+                contextWindow: 200_000,
+                maxTokens: 64_000,
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("anthropic", "claude-sonnet-4-6", "/tmp/agent", cfg);
+
+    expectRecordFields(expectResolvedModel(result), {
+      provider: "anthropic",
+      id: "claude-sonnet-4-6",
+      api: "anthropic-messages",
+      baseUrl: "https://anthropic-proxy.example.com",
+      contextWindow: 200_000,
+      maxTokens: 64_000,
+    });
+  });
+
   it("merges configured media input with discovered model metadata", () => {
     mockDiscoveredModel(discoverModels, {
       provider: "custom",


### PR DESCRIPTION
## Summary
- apply provider policy config defaults when building inline provider models
- ensure Anthropic inline provider entries inherit the default `anthropic-messages` API
- preserve model-level `api`/`baseUrl` precedence over provider-level defaults

## Real behavior proof
- **Behavior or issue addressed**: Anthropic inline provider config entries that omit `api` now inherit OpenClaw provider policy defaults, so the runtime model definition resolves with `api: "anthropic-messages"` while preserving the configured provider base URL and model token limits.
- **Real environment tested**: Local OpenClaw checkout on macOS from PR branch `fix/inline-provider-api-inheritance-reimpl`, using an isolated temporary OpenClaw config at `/tmp/openclaw-real-proof.nG7NWK/openclaw.json` with no real credentials or secrets.
- **Exact steps or command run after this patch**: Created an isolated config containing `models.providers.anthropic.baseUrl = "https://anthropic-proxy.example.com/v1"` and a single inline `claude-sonnet-4-6` entry without an explicit `api`, then ran this real local runtime command:
  ```sh
  OPENCLAW_CONFIG_PATH=/tmp/openclaw-real-proof.nG7NWK/openclaw.json OPENCLAW_STATE_DIR=/tmp/openclaw-real-proof.nG7NWK node --import tsx --input-type=module -e 'import { readFileSync } from "node:fs"; import { buildInlineProviderModels } from "./src/agents/pi-embedded-runner/model.inline-provider.ts"; const configPath = process.env.OPENCLAW_CONFIG_PATH; const cfg = JSON.parse(readFileSync(configPath, "utf8")); const models = buildInlineProviderModels(cfg.models.providers).map((m) => ({provider:m.provider,id:m.id,api:m.api,baseUrl:m.baseUrl,contextWindow:m.contextWindow,maxTokens:m.maxTokens})); console.log(JSON.stringify({configPath, models}, null, 2));'
  ```
  Also ran the OpenClaw CLI against the same isolated config:
  ```sh
  OPENCLAW_CONFIG_PATH=/tmp/openclaw-real-proof.nG7NWK/openclaw.json OPENCLAW_STATE_DIR=/tmp/openclaw-real-proof.nG7NWK pnpm openclaw models list --provider anthropic --plain
  ```
- **Evidence after fix**: Terminal output from the runtime model-builder command showed the inline Anthropic model resolved with the inherited API and configured values:
  ```json
  {
    "configPath": "/tmp/openclaw-real-proof.nG7NWK/openclaw.json",
    "models": [
      {
        "provider": "anthropic",
        "id": "claude-sonnet-4-6",
        "api": "anthropic-messages",
        "baseUrl": "https://anthropic-proxy.example.com/v1",
        "contextWindow": 200000,
        "maxTokens": 64000
      }
    ]
  }
  ```
  OpenClaw CLI output from the same isolated config included the configured inline model:
  ```text
  anthropic/claude-opus-4-6
  anthropic/claude-opus-4-7
  anthropic/claude-sonnet-4-6
  ```
- **Observed result after fix**: The real local OpenClaw runtime path now exposes the inline Anthropic provider entry with `api: "anthropic-messages"`, confirming provider policy defaults are applied to inline models after the patch.
- **What was not tested**: No live Anthropic network request was sent; this change only affects local model resolution/config normalization and was verified without credentials.

## Verification
- `pnpm test src/agents/pi-embedded-runner/model.inline-provider.test.ts src/agents/pi-embedded-runner/model.test.ts extensions/anthropic/provider-policy-api.test.ts src/config/model-alias-defaults.test.ts`
- `pnpm exec oxfmt --check src/agents/pi-embedded-runner/model.inline-provider.ts src/agents/pi-embedded-runner/model.inline-provider.test.ts src/agents/pi-embedded-runner/model.test.ts`
- `pnpm check:changed`
- `pnpm build`
