### PR TITLE
fix(agents): memoize per-pid owner-args lookup and yield in cleanStaleLockFiles

### DIFF
--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -742,6 +742,40 @@ describe("acquireSessionWriteLock", () => {
     }
   });
 
+  it("memoizes readOwnerProcessArgs across locks with the same pid in one sweep (#86509)", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
+    const sessionsDir = path.join(root, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const nowMs = Date.now();
+    const lockCount = 5;
+    try {
+      for (let i = 0; i < lockCount; i++) {
+        await fs.writeFile(
+          path.join(sessionsDir, `same-pid-${i}.jsonl.lock`),
+          JSON.stringify({ pid: process.pid, createdAt: new Date(nowMs).toISOString() }),
+          "utf8",
+        );
+      }
+      const readArgsCalls: number[] = [];
+      const readOwnerProcessArgs = (pid: number) => {
+        readArgsCalls.push(pid);
+        return ["node", "/srv/app/dist/index.js"];
+      };
+      const result = await cleanStaleLockFiles({
+        sessionsDir,
+        staleMs: 30_000,
+        nowMs,
+        removeStale: true,
+        readOwnerProcessArgs,
+      });
+      expect(result.cleaned).toHaveLength(lockCount);
+      // Without memo this would be `lockCount`; the per-pid cache collapses it to a single call.
+      expect(readArgsCalls).toEqual([process.pid]);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("keeps fresh live .jsonl lock files with OpenClaw or unknown owners", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
     const sessionsDir = path.join(root, "sessions");

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -776,6 +776,44 @@ describe("acquireSessionWriteLock", () => {
     }
   });
 
+  it("does not poison the per-pid memo when readOwnerProcessArgs throws (#86509)", async () => {
+    // A helper one layer up (`readOwnerProcessArgs`) already catches thrown resolvers and
+    // returns null, so `cleanStaleLockFiles` never propagates the throw — but a naive memo
+    // could still cache that null-equivalent failure and short-circuit later locks for the
+    // same pid. The fix writes the cache only after the resolver returns, so each lock
+    // retries the resolver fresh after a throw.
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
+    const sessionsDir = path.join(root, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const nowMs = Date.now();
+    const lockCount = 3;
+    try {
+      for (let i = 0; i < lockCount; i++) {
+        await fs.writeFile(
+          path.join(sessionsDir, `throwing-${i}.jsonl.lock`),
+          JSON.stringify({ pid: process.pid, createdAt: new Date(nowMs).toISOString() }),
+          "utf8",
+        );
+      }
+      let throwCalls = 0;
+      const result = await cleanStaleLockFiles({
+        sessionsDir,
+        staleMs: 30_000,
+        nowMs,
+        removeStale: true,
+        readOwnerProcessArgs: () => {
+          throwCalls++;
+          throw new Error("transient resolver failure");
+        },
+      });
+      // Resolver is invoked once per lock — the throw is not cached as a no-args entry.
+      expect(throwCalls).toBe(lockCount);
+      expect(result.cleaned).toHaveLength(0);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("keeps fresh live .jsonl lock files with OpenClaw or unknown owners", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
     const sessionsDir = path.join(root, "sessions");

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -657,7 +657,20 @@ export async function cleanStaleLockFiles(params: {
   );
   const removeStale = params.removeStale !== false;
   const nowMs = params.nowMs ?? Date.now();
-  const ownerProcessArgsReader = params.readOwnerProcessArgs ?? readProcessArgsSync;
+  const baseOwnerProcessArgsReader = params.readOwnerProcessArgs ?? readProcessArgsSync;
+  // Memoize per-invocation: many locks in the same sweep often share a pid (gateway, MCP),
+  // and resolving owner argv is the most expensive per-lock syscall (PowerShell on Windows
+  // is ~0.5–1s per pid) — pids do not recycle within a single sweep. (#86509)
+  const ownerArgsByPid = new Map<number, string[] | null>();
+  const ownerProcessArgsReader: SessionLockOwnerProcessArgsReader = (pid) => {
+    const cached = ownerArgsByPid.get(pid);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const args = baseOwnerProcessArgsReader(pid);
+    ownerArgsByPid.set(pid, args);
+    return args;
+  };
 
   let entries: fsSync.Dirent[] = [];
   try {
@@ -677,6 +690,11 @@ export async function cleanStaleLockFiles(params: {
     .toSorted((a, b) => a.name.localeCompare(b.name));
 
   for (const entry of lockEntries) {
+    // Yield to the event loop between locks so concurrent timers/HTTP polling can run
+    // while this sweep does per-lock sync syscalls (isPidAlive, /proc reads, PowerShell). (#86509)
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
     const lockPath = path.join(sessionsDir, entry.name);
     const payload = await readLockPayload(lockPath);
     const inspected = inspectLockPayloadForSession({


### PR DESCRIPTION
### Summary

- **Problem**: On gateway startup, the `sidecars.session-locks` phase blocks the main event loop long enough to starve concurrent timers and HTTP polling. The reporter sees an 87-second stall on Windows after the v5.20 → v5.22 upgrade with two agents (interactive Telegram + cron `model_call`) firing within ~30s of each other: Telegram `getMe` calls time out at 10s despite 31s elapsed wall, the health monitor flaps and cascade-restarts four bots, and the run never recovers. (#86509)
- **Root Cause**: `cleanStaleLockFiles` iterates every `.jsonl.lock` in each agent's sessions dir on a single serial `for ... await` and, for any fresh non-self alive pid, calls `readOwnerProcessArgs(pid)` to decide whether the lock owner is an OpenClaw process. There is **no per-pid memoization**, so when many locks share the same pid (gateway, MCP wrapper, cron run) the resolver is invoked once per lock. On Linux a `/proc/PID/cmdline` read is ~0.1 ms — annoying but tolerable; on Windows the resolver shells out to `powershell -Command "Get-CimInstance Win32_Process -Filter ..." | Select-Object -ExpandProperty CommandLine` synchronously per pid, ~0.5–1 s each. With multiple agents × dozens of fresh locks pointing at a handful of repeat pids that scales to tens of seconds of synchronous main-thread work, exactly matching the reported 87 s phase.
- **Fix**: Two surgical changes in `cleanStaleLockFiles` only.
  - **Per-sweep memo**: wrap the resolver with a `Map<pid, args>` cache populated on first call. Same pid in the same sweep no longer re-spawns PowerShell (or re-reads `/proc/PID/cmdline`); pids do not recycle within a single sweep so per-invocation caching is safe.
  - **Yield to the event loop between locks**: `await new Promise((r) => setImmediate(r))` at the top of each iteration so concurrent timers (Telegram polling watchdog, fetch timeouts, health monitor) get a chance to run between per-lock sync syscalls instead of all of them piling up under a single long stack.
- **What changed**:
  - `src/agents/session-write-lock.ts`: memoize `readOwnerProcessArgs` per invocation; yield via `setImmediate` between lock entries inside the loop.
  - `src/agents/session-write-lock.test.ts`: regression test asserting the resolver is invoked exactly once for multiple lock files sharing one pid in a single sweep.
- **What did NOT change (scope boundary)**:
  - The lock-staleness rules, file removal semantics, `inspectLockPayload`/`inspectLockPayloadForSession`, `markRestartAbortedMainSessionsFromLocks`, and the outer sidecar loop (`for sessionsDir of sessionDirs` in `server-startup-post-attach.ts`) are unchanged. Parallelizing the outer loop is a separate, larger concern.
  - The general `readOwnerProcessArgs` reader signature is unchanged — the memo lives entirely inside `cleanStaleLockFiles`.
  - No config keys, protocol, schema, or default behavior changes.

### Reproduction

1. Six agent sessions dirs, each populated with many `.jsonl.lock` files whose `pid` clusters on a small set of fresh non-self alive pids and whose `createdAt` is recent (so `cleanStaleLockFiles` enters the "non-OpenClaw owner" check path).
2. Run `cleanStaleLockFiles` once per dir (the production sidecar pattern).
3. Count how many times the (mock or real) `readOwnerProcessArgs` resolver is invoked, and measure event-loop max delay.
- Before: 1800 resolver calls for 1800 locks (one per lock).
- After: 18 resolver calls (3 unique pids × 6 sweeps), with the same set of locks cleaned.

### Real behavior proof

- **Behavior addressed (#86509)**: when a sidecar sweep encounters many locks that share a small set of fresh non-self pids, `cleanStaleLockFiles` must not invoke the expensive owner-args resolver once per lock — and must yield to the event loop between locks so the rest of the gateway (Telegram polling, fetch timers, health monitors) can keep running while the sweep proceeds.
- **Real environment tested (Linux, Node 22)**: a harness builds 6 agent dirs × 300 lock files each (1800 total) pointing at 3 long-lived sleep PIDs, drives the **real** `cleanStaleLockFiles` against them with a counting resolver, and measures wall time + `monitorEventLoopDelay` p99/max.
- **Exact steps or command run after this patch**: `tsx /tmp/qmd86509/repro-cluster.mts <worktree-path>` against the pre-fix worktree and the patched worktree.
- **Evidence after fix (verbatim repro output)**:

```text
############ BEFORE (no fix) ############
Wall: 1365ms  loop-max: 28.2ms  loop-p99: 27.1ms
Total locks: 1800  cleaned: 1800  readOwnerProcessArgs calls: 1800

############ AFTER (with fix) ############
Wall: 1491ms  loop-max: 35.1ms  loop-p99: 27.4ms
Total locks: 1800  cleaned: 1800  readOwnerProcessArgs calls: 18
```

- **Observed result after fix**: the resolver is invoked exactly 18 times across the whole sweep (3 unique pids × 6 cleanStaleLockFiles invocations) instead of 1800 — a 100× reduction in the most expensive per-lock operation. On Linux the resolver itself is cheap so wall time is dominated by `setImmediate` overhead from the new yield (small loss on Linux); on Windows where the resolver is a synchronous PowerShell invocation costing ~0.5–1 s each, the same reduction translates to the sidecar dropping from minutes of blocked main-thread work to seconds. The new yield additionally interleaves the per-lock `isPidAlive` / `getProcessStartTime` syscalls with timer execution so the loop never sits idle on a long stack.
- **Regression tests**: `node scripts/run-vitest.mjs src/agents/session-write-lock.test.ts` (full file passes) — including a new case that asserts the resolver is invoked exactly once for multiple lock files sharing one pid in a single sweep; existing per-lock cleanup behavior is unchanged.
- **What was not tested**: I did not run the full reporter scenario on Windows 11 with the 6-agent + Telegram cascade. The Linux harness exercises the real `cleanStaleLockFiles` and the real (mocked-counter) resolver end to end; the Windows magnitude is an extrapolation from the same algorithmic change (`PowerShell Win32_Process` is documented per-invocation overhead, not modified here).

### Risk / Mitigation

- **Risk 1: pid recycling could make memo unsafe.** Mitigation: the memo is scoped to a single `cleanStaleLockFiles` call (the `Map` is created inside the function). A sweep completes well within the OS pid-recycle window — pids are not reissued in milliseconds — so a cached owner-args entry never becomes stale before the sweep finishes.
- **Risk 2: the new yield could slow short sweeps in tests that depend on synchronous-ish behavior.** Mitigation: yield is via `setImmediate`, which adds ~50 µs per lock; for a small sweep (say 5 locks) overhead is ~0.25 ms — invisible. Existing tests continue to pass.
- **Risk 3: behavior change in non-OpenClaw-owner detection.** Mitigation: the memo wraps the SAME resolver and returns the SAME values, just cached. There is no semantic change to which locks are classified stale or removed; the new regression test pins this contract.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway / orchestration

### Linked Issue/PR

Fixes #86509 · Related (closed precursor) #80695
