### PR TITLE
[codex] Document Codex report-mode plugin approvals

### DIFF
--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -173,7 +173,10 @@ Quick `/acp` flow from chat:
     For Codex-native tool events, OpenClaw injects a per-turn native
     hook relay so plugin hooks can block `before_tool_call`, observe
     `after_tool_call`, and route Codex `PermissionRequest` events
-    through OpenClaw approvals. Codex `Stop` hooks are relayed to
+    through OpenClaw approvals. Hook-level plugin `requireApproval`
+    results are reported back to Codex app-server `PreToolUse` as a
+    deny/block reason in report mode; they do not open an OpenClaw
+    plugin approval prompt. Codex `Stop` hooks are relayed to
     OpenClaw `before_agent_finalize`, where plugins can request one more
     model pass before Codex finalizes its answer. The relay remains
     deliberately conservative: it does not mutate Codex-native tool


### PR DESCRIPTION
## Summary

- Clarifies the native Codex routing docs for plugin hook-level `requireApproval` during app-server `PreToolUse` report mode.
- Documents that hook-level plugin `requireApproval` is reported back to Codex as a deny/block reason in report mode, rather than opening an OpenClaw plugin approval prompt.
- Keeps Codex `PermissionRequest` approval routing distinct from plugin `before_tool_call` `requireApproval` behavior.

Refs #86777.

## Why

The current behavior is safe, but surprising for plugin authors. A local plugin symptom was: a `before_tool_call` hook returning `requireApproval` during Codex app-server `PreToolUse` report mode blocked safely, but no approval card appeared. From a plugin/user perspective this can look like approval routing is broken unless the report-mode behavior is documented.

## Validation

- `git diff --check`