### PR TITLE
fix(agents): reuse cached subagent registry reads

### DIFF
--- a/src/agents/subagent-registry-state.ts
+++ b/src/agents/subagent-registry-state.ts
@@ -1,7 +1,4 @@
-import {
-  loadSubagentRegistryFromDisk,
-  saveSubagentRegistryToDisk,
-} from "./subagent-registry.store.js";
+import { loadSubagentRegistryFromDisk, saveSubagentRegistryToDisk } from "./subagent-registry.store.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 export function persistSubagentRunsToDisk(runs: Map<string, SubagentRunRecord>) {
@@ -48,7 +45,7 @@ export function getSubagentRunsSnapshotForRead(
   if (shouldReadDisk) {
     try {
       // Persisted state lets other worker processes observe active runs.
-      for (const [runId, entry] of loadSubagentRegistryFromDisk().entries()) {
+      for (const [runId, entry] of loadSubagentRegistryFromDisk({ clone: false }).entries()) {
         merged.set(runId, entry);
       }
     } catch {

--- a/src/agents/subagent-registry.persistence.test.ts
+++ b/src/agents/subagent-registry.persistence.test.ts
@@ -33,6 +33,7 @@ import {
   loadSubagentRegistryFromDisk,
   resolveSubagentRegistryPath,
 } from "./subagent-registry.store.js";
+import { getSubagentRunsSnapshotForRead } from "./subagent-registry-state.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 const { announceSpy } = vi.hoisted(() => ({
@@ -404,6 +405,45 @@ describe("subagent registry persistence", () => {
     );
 
     expect(loadSubagentRegistryFromDisk().has("run-updated")).toBe(true);
+  });
+
+  it("reuses the persisted registry cache on hot internal read snapshots", async () => {
+    await writePersistedRegistry(
+      {
+        version: 2,
+        runs: {
+          "run-cached-read": {
+            runId: "run-cached-read",
+            childSessionKey: "agent:main:subagent:cached-read",
+            requesterSessionKey: "agent:main:main",
+            requesterDisplayKey: "main",
+            task: "cached persisted run",
+            cleanup: "keep",
+            createdAt: 1,
+            startedAt: 1,
+          },
+        },
+      },
+      { seedChildSessions: false },
+    );
+    const previousFlag = process.env.OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_DISK;
+    let cloneSpy: ReturnType<typeof vi.spyOn> | undefined;
+    try {
+      process.env.OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_DISK = "1";
+      getSubagentRunsSnapshotForRead(new Map());
+      cloneSpy = vi.spyOn(globalThis, "structuredClone");
+      const snapshot = getSubagentRunsSnapshotForRead(new Map());
+
+      expect(snapshot.has("run-cached-read")).toBe(true);
+      expect(cloneSpy).not.toHaveBeenCalled();
+    } finally {
+      cloneSpy?.mockRestore();
+      if (previousFlag === undefined) {
+        delete process.env.OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_DISK;
+      } else {
+        process.env.OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_DISK = previousFlag;
+      }
+    }
   });
 
   it("returns empty maps for unchanged invalid persisted registry snapshots", async () => {

--- a/src/agents/subagent-registry.persistence.test.ts
+++ b/src/agents/subagent-registry.persistence.test.ts
@@ -12,6 +12,7 @@ import { callGateway } from "../gateway/call.js";
 import { onAgentEvent } from "../infra/agent-events.js";
 import { captureEnv, withEnv } from "../test-utils/env.js";
 import { persistSubagentSessionTiming } from "./subagent-registry-helpers.js";
+import { getSubagentRunsSnapshotForRead } from "./subagent-registry-state.js";
 import {
   testing,
   addSubagentRunForTests,
@@ -33,7 +34,6 @@ import {
   loadSubagentRegistryFromDisk,
   resolveSubagentRegistryPath,
 } from "./subagent-registry.store.js";
-import { getSubagentRunsSnapshotForRead } from "./subagent-registry-state.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 const { announceSpy } = vi.hoisted(() => ({
@@ -427,7 +427,7 @@ describe("subagent registry persistence", () => {
       { seedChildSessions: false },
     );
     const previousFlag = process.env.OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_DISK;
-    let cloneSpy: ReturnType<typeof vi.spyOn> | undefined;
+    let cloneSpy: { mockRestore(): void } | undefined;
     try {
       process.env.OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_DISK = "1";
       getSubagentRunsSnapshotForRead(new Map());

--- a/src/agents/subagent-registry.store.ts
+++ b/src/agents/subagent-registry.store.ts
@@ -43,7 +43,9 @@ function cloneSubagentRunRecord(entry: SubagentRunRecord): SubagentRunRecord {
   return structuredClone(entry);
 }
 
-function cloneSubagentRunMap(runs: Map<string, SubagentRunRecord>): Map<string, SubagentRunRecord> {
+function cloneSubagentRunMap(
+  runs: ReadonlyMap<string, SubagentRunRecord>,
+): Map<string, SubagentRunRecord> {
   return new Map([...runs].map(([runId, entry]) => [runId, cloneSubagentRunRecord(entry)]));
 }
 
@@ -78,7 +80,18 @@ export function resolveSubagentRegistryPath(): string {
   return path.join(resolveSubagentStateDir(process.env), "subagents", "runs.json");
 }
 
-export function loadSubagentRegistryFromDisk(): Map<string, SubagentRunRecord> {
+export function loadSubagentRegistryFromDisk(): Map<string, SubagentRunRecord>;
+export function loadSubagentRegistryFromDisk(options: {
+  clone: false;
+}): ReadonlyMap<string, SubagentRunRecord>;
+export function loadSubagentRegistryFromDisk(options?: {
+  clone?: boolean;
+}): Map<string, SubagentRunRecord> | ReadonlyMap<string, SubagentRunRecord> {
+  const snapshot = loadSubagentRegistrySnapshotForRead();
+  return options?.clone === false ? snapshot : cloneSubagentRunMap(snapshot);
+}
+
+function loadSubagentRegistrySnapshotForRead(): ReadonlyMap<string, SubagentRunRecord> {
   const pathname = resolveSubagentRegistryPath();
   const signature = statRegistryFileSignature(pathname);
   if (signature === null) {
@@ -89,7 +102,7 @@ export function loadSubagentRegistryFromDisk(): Map<string, SubagentRunRecord> {
   if (cached?.signature === signature) {
     registryReadCache.delete(pathname);
     registryReadCache.set(pathname, cached);
-    return cloneSubagentRunMap(cached.runs);
+    return cached.runs;
   }
   const raw = loadJsonFile(pathname);
   if (!raw || typeof raw !== "object") {

--- a/src/agents/subagent-registry.store.ts
+++ b/src/agents/subagent-registry.store.ts
@@ -24,6 +24,7 @@ const REGISTRY_VERSION = 2 as const;
 const MAX_SUBAGENT_REGISTRY_READ_CACHE_ENTRIES = 32;
 
 type PersistedSubagentRunRecord = SubagentRunRecord;
+type ReadonlySubagentRunRecord = Readonly<SubagentRunRecord>;
 
 type RegistryCacheEntry = {
   signature: string;
@@ -83,15 +84,15 @@ export function resolveSubagentRegistryPath(): string {
 export function loadSubagentRegistryFromDisk(): Map<string, SubagentRunRecord>;
 export function loadSubagentRegistryFromDisk(options: {
   clone: false;
-}): ReadonlyMap<string, SubagentRunRecord>;
+}): ReadonlyMap<string, ReadonlySubagentRunRecord>;
 export function loadSubagentRegistryFromDisk(options?: {
   clone?: boolean;
-}): Map<string, SubagentRunRecord> | ReadonlyMap<string, SubagentRunRecord> {
+}): Map<string, SubagentRunRecord> | ReadonlyMap<string, ReadonlySubagentRunRecord> {
   const snapshot = loadSubagentRegistrySnapshotForRead();
   return options?.clone === false ? snapshot : cloneSubagentRunMap(snapshot);
 }
 
-function loadSubagentRegistrySnapshotForRead(): ReadonlyMap<string, SubagentRunRecord> {
+function loadSubagentRegistrySnapshotForRead(): ReadonlyMap<string, ReadonlySubagentRunRecord> {
   const pathname = resolveSubagentRegistryPath();
   const signature = statRegistryFileSignature(pathname);
   if (signature === null) {
@@ -102,6 +103,8 @@ function loadSubagentRegistrySnapshotForRead(): ReadonlyMap<string, SubagentRunR
   if (cached?.signature === signature) {
     registryReadCache.delete(pathname);
     registryReadCache.set(pathname, cached);
+    // No-clone reads share cached records; only read snapshot callers may use
+    // this path. Mutation/restore callers must keep the default cloned load.
     return cached.runs;
   }
   const raw = loadJsonFile(pathname);


### PR DESCRIPTION
## Summary

What problem does this PR solve?
- Subagent registry hot reads clone the full persisted run map on cache hits, adding CPU and GC pressure to gateway hot paths.

Why does this matter now?
- Redacted profiler evidence showed this path on gateway hot workloads.

What is the intended outcome?
- Reduce repeated hot-path work while preserving current behavior contracts.

What is intentionally out of scope?
- Broader profiler reruns and unrelated perf stacks are out of scope for this PR.

What does success look like?
- Focused regression tests pass and the changed path avoids the repeated work described in the linked issue.

What should reviewers focus on?
- Whether the cache/lazy path preserves existing contracts and invalidation boundaries.

## Linked context

Which issue does this close?

Closes #86786

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

Local performance bug extraction from redacted profiler evidence.

## Real behavior proof (required for external PRs)

Behavior addressed: Subagent registry hot reads clone the full persisted run map on cache hits, adding CPU and GC pressure to gateway hot paths.

Real environment tested: Local OpenClaw source worktree on Linux with Node v24.15.0; focused Vitest regression tests and diff hygiene were run in the isolated bug branch worktree.

Exact steps or command run after this patch:
```bash
node node_modules/vitest/vitest.mjs run src/agents/subagent-registry.persistence.test.ts --reporter=verbose
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
```

Evidence after fix:
```text
node node_modules/vitest/vitest.mjs run src/agents/subagent-registry.persistence.test.ts --reporter=verbose

Result: 2 project files passed, 36 tests passed.

git diff --check

Result: passed.

.agents/skills/autoreview/scripts/autoreview --mode local

Result: clean, no accepted/actionable findings reported.
```

Observed result after fix: Focused regression coverage passed and autoreview reported no accepted/actionable findings.

What was not tested: No live long-running profiler rerun was performed after the patch.

Proof limitations or environment constraints: The original evidence is from redacted local profiler artifacts; this PR includes focused seam proof rather than a full live profiler replay.

Before evidence (optional but encouraged):
```text
Representative profile chain: structuredClone -> cloneSubagentRunRecord -> cloneSubagentRunMap -> loadSubagentRegistryFromDisk -> getSubagentRunsSnapshotForRead. Current source evidence pointed at src/agents/subagent-registry-state.ts and src/agents/subagent-registry.store.ts read paths.
```

## Tests and validation

Which commands did you run?

```bash
node node_modules/vitest/vitest.mjs run src/agents/subagent-registry.persistence.test.ts --reporter=verbose
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
```

What regression coverage was added or updated?

src/agents/subagent-registry.store.ts; src/agents/subagent-registry-state.ts; src/agents/subagent-registry.persistence.test.ts

What failed before this fix, if known?

The profiler/timeline evidence showed the hot-path behavior described in the linked issue.

If no test was added, why not?

Focused regression coverage was added or updated.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

No

Did config, environment, or migration behavior change? (`Yes/No`)

No

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No

What is the highest-risk area?

Preserving existing hot-path behavior while reducing repeated work.

How is that risk mitigated?

Focused regression tests plus autoreview.

## Current review state

What is the next action?

Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

Full live profiler replay was not run locally.

Which bot or reviewer comments were addressed?

Local autoreview findings were addressed before opening this PR where applicable.
