### PR TITLE
fix(gateway): lighten session event row snapshots

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -1943,6 +1943,11 @@ describe("agent event handler", () => {
     expect(requireMockArg(broadcastToConnIds, 0, 3, "sessions changed options")).toEqual({
       dropIfSlow: true,
     });
+    expect(loadGatewaySessionRow).toHaveBeenCalledWith("session-finished", {
+      skipTranscriptUsageFallback: true,
+      lightweightListRow: true,
+      includeChildSessions: false,
+    });
   });
 
   it("keeps tool output for Control UI recipients when verbose is on", () => {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -319,7 +319,11 @@ export function createAgentEventHandler({
   };
 
   const buildSessionEventSnapshot = (sessionKey: string, evt?: AgentEventPayload) => {
-    const row = loadGatewaySessionRowForSnapshot(sessionKey);
+    const row = loadGatewaySessionRowForSnapshot(sessionKey, {
+      skipTranscriptUsageFallback: true,
+      lightweightListRow: true,
+      includeChildSessions: false,
+    });
     const lifecyclePatch = evt
       ? deriveGatewaySessionLifecycleSnapshot({
           session: row

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -129,7 +129,10 @@ async function handleTranscriptUpdateBroadcast(
       : undefined;
   }
   const sessionSnapshot = buildGatewaySessionSnapshot({
-    sessionRow: loadGatewaySessionRow(sessionKey, { transcriptUsageMaxBytes: 64 * 1024 }),
+    sessionRow: loadGatewaySessionRow(sessionKey, {
+      transcriptUsageMaxBytes: 64 * 1024,
+      includeChildSessions: false,
+    }),
     includeSession: true,
   });
   const rawMessage = attachOpenClawTranscriptMeta(update.message, {
@@ -191,7 +194,11 @@ export function createLifecycleEventBroadcastHandler(params: {
         displayName: event.displayName,
         ts: Date.now(),
         ...buildGatewaySessionSnapshot({
-          sessionRow: loadGatewaySessionRow(event.sessionKey),
+          sessionRow: loadGatewaySessionRow(event.sessionKey, {
+            skipTranscriptUsageFallback: true,
+            lightweightListRow: true,
+            includeChildSessions: false,
+          }),
           label: event.label,
           displayName: event.displayName,
           parentSessionKey: event.parentSessionKey,

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -392,6 +392,46 @@ describe("gateway session utils", () => {
     });
   });
 
+  test("lightweight event rows skip child session resolution", () => {
+    const cfg = createModelDefaultsConfig({ primary: "openai/gpt-5.4" });
+    const now = 10_000;
+    const store: Record<string, SessionEntry> = {
+      "agent:main:parent": {
+        sessionId: "parent",
+        updatedAt: now,
+      },
+      "agent:main:subagent:child": {
+        sessionId: "child",
+        parentSessionKey: "agent:main:parent",
+        updatedAt: now,
+        status: "running",
+      },
+    };
+
+    const fullRow = buildGatewaySessionRow({
+      cfg,
+      storePath: "",
+      store,
+      key: "agent:main:parent",
+      entry: store["agent:main:parent"],
+      now,
+    });
+    const eventRow = buildGatewaySessionRow({
+      cfg,
+      storePath: "",
+      store,
+      key: "agent:main:parent",
+      entry: store["agent:main:parent"],
+      now,
+      skipTranscriptUsageFallback: true,
+      lightweightListRow: true,
+      includeChildSessions: false,
+    });
+
+    expect(fullRow.childSessions).toEqual(["agent:main:subagent:child"]);
+    expect(eventRow.childSessions).toBeUndefined();
+  });
+
   test("async session list reuses thinking metadata for lightweight rows", async () => {
     const resolveThinkingProfile = vi.fn(() => ({
       levels: [{ id: "off" as const }, { id: "medium" as const }],

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1656,6 +1656,7 @@ export function buildGatewaySessionRow(params: {
   rowContext?: SessionListRowContext;
   skipTranscriptUsageFallback?: boolean;
   lightweightListRow?: boolean;
+  includeChildSessions?: boolean;
 }): GatewaySessionRow {
   const { cfg, storePath, store, key, entry } = params;
   const lightweight = params.lightweightListRow === true;
@@ -1805,12 +1806,15 @@ export function buildGatewaySessionRow(params: {
     typeof totalTokens === "number" && Number.isFinite(totalTokens) && totalTokens > 0
       ? true
       : transcriptUsage?.totalTokensFresh === true;
-  const childSessions = params.storeChildSessionsByKey
-    ? mergeChildSessionKeys(
-        resolveRuntimeChildSessionKeys(key, now, rowContext?.subagentRuns),
-        params.storeChildSessionsByKey.get(key),
-      )
-    : resolveChildSessionKeys(key, store, now, rowContext?.subagentRuns);
+  const childSessions =
+    params.includeChildSessions === false
+      ? undefined
+      : params.storeChildSessionsByKey
+        ? mergeChildSessionKeys(
+            resolveRuntimeChildSessionKeys(key, now, rowContext?.subagentRuns),
+            params.storeChildSessionsByKey.get(key),
+          )
+        : resolveChildSessionKeys(key, store, now, rowContext?.subagentRuns);
   const compactionCheckpoints = resolveProjectableCompactionCheckpoints(entry);
   const compactionCheckpointCount = Array.isArray(entry?.compactionCheckpoints)
     ? compactionCheckpoints.length
@@ -2049,6 +2053,9 @@ export function loadGatewaySessionRow(
     includeLastMessage?: boolean;
     now?: number;
     transcriptUsageMaxBytes?: number;
+    skipTranscriptUsageFallback?: boolean;
+    lightweightListRow?: boolean;
+    includeChildSessions?: boolean;
   },
 ): GatewaySessionRow | null {
   const { cfg, storePath, store, entry, canonicalKey } = loadSessionEntry(sessionKey);
@@ -2065,6 +2072,9 @@ export function loadGatewaySessionRow(
     includeDerivedTitles: options?.includeDerivedTitles,
     includeLastMessage: options?.includeLastMessage,
     transcriptUsageMaxBytes: options?.transcriptUsageMaxBytes,
+    skipTranscriptUsageFallback: options?.skipTranscriptUsageFallback,
+    lightweightListRow: options?.lightweightListRow,
+    includeChildSessions: options?.includeChildSessions,
   });
 }
 


### PR DESCRIPTION
## Summary

What problem does this PR solve?
- High-frequency session event broadcasts rebuild full gateway session rows, including child-session and transcript-heavy work that event snapshots do not always need.

Why does this matter now?
- Redacted profiler evidence showed this path on gateway hot workloads.

What is the intended outcome?
- Reduce repeated hot-path work while preserving current behavior contracts.

What is intentionally out of scope?
- Broader profiler reruns and unrelated perf stacks are out of scope for this PR.

What does success look like?
- Focused regression tests pass and the changed path avoids the repeated work described in the linked issue.

What should reviewers focus on?
- Whether the cache/lazy path preserves existing contracts and invalidation boundaries.

## Linked context

Which issue does this close?

Closes #86787

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

Local performance bug extraction from redacted profiler evidence.

## Real behavior proof (required for external PRs)

Behavior addressed: High-frequency session event broadcasts rebuild full gateway session rows, including child-session and transcript-heavy work that event snapshots do not always need.

Real environment tested: Local OpenClaw source worktree on Linux with Node v24.15.0; focused Vitest regression tests and diff hygiene were run in the isolated bug branch worktree.

Exact steps or command run after this patch:
```bash
node node_modules/vitest/vitest.mjs run src/gateway/server-chat.agent-events.test.ts -t "keeps live session setting metadata" --reporter=verbose
node node_modules/vitest/vitest.mjs run src/gateway/session-utils.test.ts -t "lightweight event rows skip child session resolution" --reporter=verbose
node node_modules/vitest/vitest.mjs run src/gateway/session-message-events.test.ts -t "includes live usage metadata on session.message transcript events" --reporter=verbose
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
```

Evidence after fix:
```text
node node_modules/vitest/vitest.mjs run src/gateway/server-chat.agent-events.test.ts -t "keeps live session setting metadata" --reporter=verbose

Result: 1 test passed, 72 skipped.

node node_modules/vitest/vitest.mjs run src/gateway/session-utils.test.ts -t "lightweight event rows skip child session resolution" --reporter=verbose

Result: 3 project files passed, 3 tests passed, 279 skipped.

node node_modules/vitest/vitest.mjs run src/gateway/session-message-events.test.ts -t "includes live usage metadata on session.message transcript events" --reporter=verbose

Result: 3 project files passed, 3 tests passed, 39 skipped.

git diff --check

Result: passed.

.agents/skills/autoreview/scripts/autoreview --mode local

Result: clean, no accepted/actionable findings reported.
```

Observed result after fix: Focused regression coverage passed and autoreview reported no accepted/actionable findings.

What was not tested: No live Control UI/browser broadcast replay or long-running profiler rerun was performed after the patch.

Proof limitations or environment constraints: The original evidence is from redacted local profiler artifacts; this PR includes focused seam proof rather than a full live profiler replay.

Before evidence (optional but encouraged):
```text
Profile excerpt showed buildSessionEventSnapshot chains at 1132.18s and 1045.93s inclusive, both flowing through full row construction and child-session resolution.
```

## Tests and validation

Which commands did you run?

```bash
node node_modules/vitest/vitest.mjs run src/gateway/server-chat.agent-events.test.ts -t "keeps live session setting metadata" --reporter=verbose
node node_modules/vitest/vitest.mjs run src/gateway/session-utils.test.ts -t "lightweight event rows skip child session resolution" --reporter=verbose
node node_modules/vitest/vitest.mjs run src/gateway/session-message-events.test.ts -t "includes live usage metadata on session.message transcript events" --reporter=verbose
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
```

What regression coverage was added or updated?

src/gateway/server-chat.ts; src/gateway/server-session-events.ts; src/gateway/session-utils.ts; src/gateway/server-chat.agent-events.test.ts; src/gateway/session-utils.test.ts

What failed before this fix, if known?

The profiler/timeline evidence showed the hot-path behavior described in the linked issue.

If no test was added, why not?

Focused regression coverage was added or updated.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

No

Did config, environment, or migration behavior change? (`Yes/No`)

No

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No

What is the highest-risk area?

Preserving existing hot-path behavior while reducing repeated work.

How is that risk mitigated?

Focused regression tests plus autoreview.

## Current review state

What is the next action?

Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

Full live profiler replay was not run locally.

Which bot or reviewer comments were addressed?

Local autoreview findings were addressed before opening this PR where applicable.
