### PR TITLE
fix(gateway): cache single session row child indexes

### DIFF
--- a/src/config/sessions/store-cache.ts
+++ b/src/config/sessions/store-cache.ts
@@ -51,6 +51,7 @@ const SESSION_STORE_SNAPSHOT_CACHE = createExpiringMapCache<string, SessionStore
     ttlMs: getSessionStoreTtl,
   },
 );
+const SESSION_STORE_CACHE_VERSION = new Map<string, number>();
 const SESSION_STORE_SERIALIZED_CACHE = new Map<string, SerializedSessionStoreCacheEntry>();
 const SESSION_STORE_STRING_INTERN_POOL = new Map<string, string>();
 const SESSION_STORE_STRING_INTERN_STATS = {
@@ -258,9 +259,18 @@ export function isSessionStoreCacheEnabled(): boolean {
   return isCacheEnabled(getSessionStoreTtl());
 }
 
+function bumpSessionStoreCacheVersion(storePath: string): void {
+  SESSION_STORE_CACHE_VERSION.set(storePath, (SESSION_STORE_CACHE_VERSION.get(storePath) ?? 0) + 1);
+}
+
+export function getSessionStoreCacheVersion(storePath: string): number {
+  return SESSION_STORE_CACHE_VERSION.get(storePath) ?? 0;
+}
+
 export function clearSessionStoreCaches(): void {
   SESSION_STORE_CACHE.clear();
   SESSION_STORE_SNAPSHOT_CACHE.clear();
+  SESSION_STORE_CACHE_VERSION.clear();
   SESSION_STORE_SERIALIZED_CACHE.clear();
   sessionStoreSerializedCacheBytes = 0;
   SESSION_STORE_STRING_INTERN_POOL.clear();
@@ -269,6 +279,7 @@ export function clearSessionStoreCaches(): void {
 }
 
 export function invalidateSessionStoreCache(storePath: string): void {
+  bumpSessionStoreCacheVersion(storePath);
   SESSION_STORE_CACHE.delete(storePath);
   SESSION_STORE_SNAPSHOT_CACHE.delete(storePath);
   deleteSerializedSessionStore(storePath);
@@ -328,6 +339,7 @@ export function setSerializedSessionStore(
 }
 
 export function dropSessionStoreObjectCache(storePath: string): void {
+  bumpSessionStoreCacheVersion(storePath);
   SESSION_STORE_CACHE.delete(storePath);
 }
 
@@ -413,6 +425,7 @@ export function writeSessionStoreCache(params: {
   cloneSerialized?: string;
   takeOwnership?: boolean;
 }): void {
+  bumpSessionStoreCacheVersion(params.storePath);
   const store =
     params.takeOwnership === true ? params.store : cloneSessionStoreRecord(params.store);
   if (params.takeOwnership === true) {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -27,6 +27,7 @@ import {
   dropSessionStoreObjectCache,
   dropSessionStoreSnapshotCache,
   getSerializedSessionStore,
+  getSessionStoreCacheVersion,
   invalidateSessionStoreCache,
   isSessionStoreCacheEnabled,
   setSerializedSessionStore,
@@ -136,6 +137,7 @@ export type SessionMaintenanceApplyReport = {
 export {
   capEntryCount,
   getActiveSessionMaintenanceWarning,
+  getSessionStoreCacheVersion,
   pruneStaleEntries,
   resolveMaintenanceConfig,
 };

--- a/src/gateway/session-utils.single-row-cache.test.ts
+++ b/src/gateway/session-utils.single-row-cache.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveStorePath, saveSessionStore, type SessionEntry } from "../config/sessions.js";
+import { resetPluginRuntimeStateForTest } from "../plugins/runtime.js";
+import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
+
+const subagentRegistryReadMock = vi.hoisted(() => {
+  let runsByChildSessionKey = new Map<string, Record<string, unknown>>();
+  const buildSubagentRunReadIndex = vi.fn(() => {
+    const runsByControllerSessionKey = new Map<string, Record<string, unknown>[]>();
+    for (const entry of runsByChildSessionKey.values()) {
+      const controllerSessionKey =
+        typeof entry.controllerSessionKey === "string"
+          ? entry.controllerSessionKey
+          : typeof entry.requesterSessionKey === "string"
+            ? entry.requesterSessionKey
+            : undefined;
+      if (!controllerSessionKey) {
+        continue;
+      }
+      const runs = runsByControllerSessionKey.get(controllerSessionKey) ?? [];
+      runs.push(entry);
+      runsByControllerSessionKey.set(controllerSessionKey, runs);
+    }
+    return {
+      runsByControllerSessionKey,
+      getDisplaySubagentRun: vi.fn(
+        (childSessionKey: string) => runsByChildSessionKey.get(childSessionKey) ?? null,
+      ),
+      countActiveDescendantRuns: vi.fn(() => 0),
+    };
+  });
+  return {
+    buildSubagentRunReadIndex,
+    countActiveDescendantRuns: vi.fn(() => 0),
+    getSessionDisplaySubagentRunByChildSessionKey: vi.fn(
+      (childSessionKey: string) => runsByChildSessionKey.get(childSessionKey) ?? null,
+    ),
+    getSubagentSessionRuntimeMs: vi.fn(() => undefined),
+    getSubagentSessionStartedAt: vi.fn(() => undefined),
+    isSubagentRunLive: vi.fn(() => false),
+    listSubagentRunsForController: vi.fn((controllerSessionKey: string) =>
+      [...runsByChildSessionKey.values()].filter((entry) => {
+        const controller =
+          typeof entry.controllerSessionKey === "string"
+            ? entry.controllerSessionKey
+            : typeof entry.requesterSessionKey === "string"
+              ? entry.requesterSessionKey
+              : undefined;
+        return controller === controllerSessionKey;
+      }),
+    ),
+    resolveSubagentSessionStatus: vi.fn(() => undefined),
+    setSubagentRunsForTest: (runs: Record<string, unknown>[]) => {
+      runsByChildSessionKey = new Map(
+        runs
+          .filter((entry) => typeof entry.childSessionKey === "string")
+          .map((entry) => [entry.childSessionKey as string, entry]),
+      );
+    },
+  };
+});
+
+vi.mock("../agents/subagent-registry-read.js", () => subagentRegistryReadMock);
+
+import { loadGatewaySessionRow } from "./session-utils.js";
+
+describe("single gateway session row child-session cache", () => {
+  afterEach(() => {
+    resetConfigRuntimeState();
+    resetPluginRuntimeStateForTest();
+    subagentRegistryReadMock.setSubagentRunsForTest([]);
+    vi.clearAllMocks();
+  });
+
+  test("shares the child-session index across repeated single-row loads for the same store", async () => {
+    await withStateDirEnv("openclaw-single-row-cache-", async () => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          list: [
+            {
+              id: "main",
+              default: true,
+              workspace: "/tmp/openclaw-single-row-cache",
+            },
+          ],
+          defaults: { model: { primary: "openai/gpt-5.4" } },
+        },
+      } as OpenClawConfig;
+      setRuntimeConfigSnapshot(cfg, cfg);
+      const now = Math.floor(Date.now() / 1_000) * 1_000 + 100;
+      const store: Record<string, SessionEntry> = {
+        "agent:main:subagent:parent-a": {
+          sessionId: "parent-a",
+          updatedAt: now,
+        },
+        "agent:main:subagent:child-a": {
+          sessionId: "child-a",
+          parentSessionKey: "agent:main:subagent:parent-a",
+          updatedAt: now,
+          status: "running",
+        },
+        "agent:main:subagent:parent-b": {
+          sessionId: "parent-b",
+          updatedAt: now,
+        },
+        "agent:main:subagent:child-b": {
+          sessionId: "child-b",
+          parentSessionKey: "agent:main:subagent:parent-b",
+          updatedAt: now,
+          status: "running",
+        },
+      };
+      await saveSessionStore(resolveStorePath(cfg.session?.store, { agentId: "main" }), store);
+
+      const rowA = loadGatewaySessionRow("agent:main:subagent:parent-a", { now });
+      const rowB = loadGatewaySessionRow("agent:main:subagent:parent-b", { now: now + 50 });
+      const rowAAfterWindow = loadGatewaySessionRow("agent:main:subagent:parent-a", {
+        now: now + 1_500,
+      });
+
+      expect(rowA?.childSessions).toEqual(["agent:main:subagent:child-a"]);
+      expect(rowB?.childSessions).toEqual(["agent:main:subagent:child-b"]);
+      expect(rowAAfterWindow?.childSessions).toEqual(["agent:main:subagent:child-a"]);
+      expect(subagentRegistryReadMock.buildSubagentRunReadIndex).not.toHaveBeenCalled();
+    });
+  });
+
+  test("refreshes subagent registry state while reusing store child candidates", async () => {
+    await withStateDirEnv("openclaw-single-row-cache-fresh-registry-", async () => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          list: [
+            {
+              id: "main",
+              default: true,
+              workspace: "/tmp/openclaw-single-row-cache-fresh-registry",
+            },
+          ],
+          defaults: { model: { primary: "openai/gpt-5.4" } },
+        },
+      } as OpenClawConfig;
+      setRuntimeConfigSnapshot(cfg, cfg);
+      const now = Math.floor(Date.now() / 1_000) * 1_000 + 100;
+      const oldParent = "agent:main:subagent:parent-old";
+      const newParent = "agent:main:subagent:parent-new";
+      const child = "agent:main:subagent:child";
+      const store: Record<string, SessionEntry> = {
+        [oldParent]: {
+          sessionId: "parent-old",
+          updatedAt: now,
+        },
+        [newParent]: {
+          sessionId: "parent-new",
+          updatedAt: now,
+        },
+        [child]: {
+          sessionId: "child",
+          parentSessionKey: oldParent,
+          updatedAt: now,
+          status: "running",
+        },
+      };
+      await saveSessionStore(resolveStorePath(cfg.session?.store, { agentId: "main" }), store);
+
+      subagentRegistryReadMock.setSubagentRunsForTest([
+        {
+          childSessionKey: child,
+          controllerSessionKey: oldParent,
+          requesterSessionKey: oldParent,
+          createdAt: now,
+        },
+      ]);
+      expect(loadGatewaySessionRow(oldParent, { now })?.childSessions).toEqual([child]);
+
+      subagentRegistryReadMock.setSubagentRunsForTest([
+        {
+          childSessionKey: child,
+          controllerSessionKey: newParent,
+          requesterSessionKey: newParent,
+          createdAt: now + 25,
+        },
+      ]);
+      expect(loadGatewaySessionRow(oldParent, { now: now + 50 })?.childSessions).toBeUndefined();
+      expect(loadGatewaySessionRow(newParent, { now: now + 50 })?.childSessions).toEqual([child]);
+      expect(subagentRegistryReadMock.buildSubagentRunReadIndex).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/gateway/session-utils.single-row-cache.test.ts
+++ b/src/gateway/session-utils.single-row-cache.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { resolveStorePath, saveSessionStore, type SessionEntry } from "../config/sessions.js";
+import {
+  resolveStorePath,
+  saveSessionStore,
+  updateSessionStore,
+  type SessionEntry,
+} from "../config/sessions.js";
 import { resetPluginRuntimeStateForTest } from "../plugins/runtime.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 
@@ -182,6 +187,63 @@ describe("single gateway session row child-session cache", () => {
           createdAt: now + 25,
         },
       ]);
+      expect(loadGatewaySessionRow(oldParent, { now: now + 50 })?.childSessions).toBeUndefined();
+      expect(loadGatewaySessionRow(newParent, { now: now + 50 })?.childSessions).toEqual([child]);
+      expect(subagentRegistryReadMock.buildSubagentRunReadIndex).not.toHaveBeenCalled();
+    });
+  });
+
+  test("rebuilds store child candidates after same-object session store writes", async () => {
+    await withStateDirEnv("openclaw-single-row-cache-write-version-", async () => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          list: [
+            {
+              id: "main",
+              default: true,
+              workspace: "/tmp/openclaw-single-row-cache-write-version",
+            },
+          ],
+          defaults: { model: { primary: "openai/gpt-5.4" } },
+        },
+      } as OpenClawConfig;
+      setRuntimeConfigSnapshot(cfg, cfg);
+      const now = Math.floor(Date.now() / 1_000) * 1_000 + 100;
+      const oldParent = "agent:main:subagent:parent-old";
+      const newParent = "agent:main:subagent:parent-new";
+      const child = "agent:main:subagent:child";
+      const storePath = resolveStorePath(cfg.session?.store, { agentId: "main" });
+      const store: Record<string, SessionEntry> = {
+        [oldParent]: {
+          sessionId: "parent-old",
+          updatedAt: now,
+        },
+        [newParent]: {
+          sessionId: "parent-new",
+          updatedAt: now,
+        },
+        [child]: {
+          sessionId: "child",
+          parentSessionKey: oldParent,
+          updatedAt: now,
+          status: "running",
+        },
+      };
+      await saveSessionStore(storePath, store);
+
+      expect(loadGatewaySessionRow(oldParent, { now })?.childSessions).toEqual([child]);
+      await updateSessionStore(
+        storePath,
+        (cachedStore) => {
+          const childEntry = cachedStore[child];
+          if (childEntry) {
+            childEntry.parentSessionKey = newParent;
+            childEntry.updatedAt = now + 25;
+          }
+        },
+        { skipMaintenance: true, takeCacheOwnership: true },
+      );
+
       expect(loadGatewaySessionRow(oldParent, { now: now + 50 })?.childSessions).toBeUndefined();
       expect(loadGatewaySessionRow(newParent, { now: now + 50 })?.childSessions).toEqual([child]);
       expect(subagentRegistryReadMock.buildSubagentRunReadIndex).not.toHaveBeenCalled();

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -397,6 +397,7 @@ function resolveEstimatedSessionCostUsd(params: {
 }
 
 const STALE_STORE_ONLY_CHILD_LINK_MS = 60 * 60 * 1_000;
+const SINGLE_ROW_CONTEXT_CACHE_MAX_ENTRIES = 64;
 
 function isFinitePositiveTimestamp(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
@@ -440,6 +441,68 @@ type SessionListRowContext = {
   displayModelIdentityByKey: Map<string, { provider?: string; model?: string }>;
   modelCostConfigByModelRef: Map<string, ModelCostConfig | undefined>;
 };
+
+type SingleRowChildSessionCandidateCacheEntry = {
+  store: Record<string, SessionEntry>;
+  childSessionCandidatesByParentKey: Map<string, string[]>;
+};
+
+const singleRowChildSessionCandidateCache = new Map<
+  string,
+  SingleRowChildSessionCandidateCacheEntry
+>();
+
+function rememberSingleRowChildSessionCandidateCacheEntry(
+  storePath: string,
+  entry: SingleRowChildSessionCandidateCacheEntry,
+) {
+  if (singleRowChildSessionCandidateCache.has(storePath)) {
+    singleRowChildSessionCandidateCache.delete(storePath);
+  }
+  singleRowChildSessionCandidateCache.set(storePath, entry);
+  if (singleRowChildSessionCandidateCache.size <= SINGLE_ROW_CONTEXT_CACHE_MAX_ENTRIES) {
+    return;
+  }
+  const oldestKey = singleRowChildSessionCandidateCache.keys().next().value;
+  if (oldestKey) {
+    singleRowChildSessionCandidateCache.delete(oldestKey);
+  }
+}
+
+function buildStoreChildSessionCandidateIndex(
+  store: Record<string, SessionEntry>,
+): Map<string, string[]> {
+  const childSessionsByKey = new Map<string, string[]>();
+  for (const [key, entry] of Object.entries(store)) {
+    if (!entry) {
+      continue;
+    }
+    const parentKeys = [
+      normalizeOptionalString(entry.spawnedBy),
+      normalizeOptionalString(entry.parentSessionKey),
+    ].filter((value): value is string => Boolean(value) && value !== key);
+    for (const parentKey of parentKeys) {
+      addChildSessionKey(childSessionsByKey, parentKey, key);
+    }
+  }
+  return childSessionsByKey;
+}
+
+function getSingleRowChildSessionCandidates(params: {
+  storePath: string;
+  store: Record<string, SessionEntry>;
+}): Map<string, string[]> {
+  const cached = singleRowChildSessionCandidateCache.get(params.storePath);
+  if (cached && cached.store === params.store) {
+    return cached.childSessionCandidatesByParentKey;
+  }
+  const childSessionCandidatesByParentKey = buildStoreChildSessionCandidateIndex(params.store);
+  rememberSingleRowChildSessionCandidateCacheEntry(params.storePath, {
+    store: params.store,
+    childSessionCandidatesByParentKey,
+  });
+  return childSessionCandidatesByParentKey;
+}
 
 function resolveRuntimeChildSessionKeys(
   controllerSessionKey: string,
@@ -547,6 +610,45 @@ function buildStoreChildSessionIndex(
   return childSessionsByKey;
 }
 
+function resolveStoreChildSessionKeysFromCandidates(params: {
+  store: Record<string, SessionEntry>;
+  key: string;
+  now: number;
+  candidates: ReadonlyMap<string, readonly string[]>;
+}): string[] | undefined {
+  const childSessionKeys: string[] = [];
+  for (const childKey of params.candidates.get(params.key) ?? []) {
+    const entry = params.store[childKey];
+    if (!entry) {
+      continue;
+    }
+    const latest = getSessionDisplaySubagentRunByChildSessionKey(childKey);
+    if (latest) {
+      const latestControllerSessionKey =
+        normalizeOptionalString(latest.controllerSessionKey) ||
+        normalizeOptionalString(latest.requesterSessionKey);
+      if (latestControllerSessionKey !== params.key) {
+        continue;
+      }
+      if (
+        !shouldKeepSubagentRunChildLink(latest, {
+          activeDescendants: countActiveDescendantRuns(childKey),
+          now: params.now,
+        })
+      ) {
+        continue;
+      }
+      childSessionKeys.push(childKey);
+      continue;
+    }
+    if (!shouldKeepStoreOnlyChildLink(entry, params.now)) {
+      continue;
+    }
+    childSessionKeys.push(childKey);
+  }
+  return childSessionKeys.length > 0 ? childSessionKeys : undefined;
+}
+
 function buildSessionListRowContext(params: {
   store: Record<string, SessionEntry>;
   now: number;
@@ -560,6 +662,24 @@ function buildSessionListRowContext(params: {
     displayModelIdentityByKey: new Map(),
     modelCostConfigByModelRef: new Map(),
   };
+}
+
+function buildSingleRowStoreChildSessionsByKey(params: {
+  store: Record<string, SessionEntry>;
+  storePath: string;
+  key: string;
+  now: number;
+}): Map<string, string[]> {
+  const storeChildSessions = resolveStoreChildSessionKeysFromCandidates({
+    store: params.store,
+    key: params.key,
+    now: params.now,
+    candidates: getSingleRowChildSessionCandidates({
+      storePath: params.storePath,
+      store: params.store,
+    }),
+  });
+  return storeChildSessions ? new Map([[params.key, storeChildSessions]]) : new Map();
 }
 
 function createSessionRowModelCacheKey(provider: string | undefined, model: string | undefined) {
@@ -2061,20 +2181,30 @@ export function loadGatewaySessionRow(
     transcriptUsageMaxBytes?: number;
   },
 ): GatewaySessionRow | null {
-  const { cfg, storePath, store, entry, canonicalKey } = loadSessionEntry(sessionKey);
+  const now = options?.now ?? Date.now();
+  const { cfg, storePath, store, entry, canonicalKey } = loadSessionEntry(sessionKey, {
+    clone: false,
+  });
   if (!entry) {
     return null;
   }
+  const storeChildSessionsByKey = buildSingleRowStoreChildSessionsByKey({
+    storePath,
+    store,
+    key: canonicalKey,
+    now,
+  });
   return buildGatewaySessionRow({
     cfg,
     storePath,
     store,
     key: canonicalKey,
     entry,
-    now: options?.now,
+    now,
     includeDerivedTitles: options?.includeDerivedTitles,
     includeLastMessage: options?.includeLastMessage,
     transcriptUsageMaxBytes: options?.transcriptUsageMaxBytes,
+    storeChildSessionsByKey,
   });
 }
 

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -47,6 +47,7 @@ import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import { resolveStateDir } from "../config/paths.js";
 import {
   buildGroupDisplayName,
+  getSessionStoreCacheVersion,
   loadSessionStore,
   resolveAllAgentSessionStoreTargetsSync,
   resolveAgentMainSessionKey,
@@ -444,6 +445,7 @@ type SessionListRowContext = {
 
 type SingleRowChildSessionCandidateCacheEntry = {
   store: Record<string, SessionEntry>;
+  storeVersion: number;
   childSessionCandidatesByParentKey: Map<string, string[]>;
 };
 
@@ -492,13 +494,15 @@ function getSingleRowChildSessionCandidates(params: {
   storePath: string;
   store: Record<string, SessionEntry>;
 }): Map<string, string[]> {
+  const storeVersion = getSessionStoreCacheVersion(params.storePath);
   const cached = singleRowChildSessionCandidateCache.get(params.storePath);
-  if (cached && cached.store === params.store) {
+  if (cached && cached.store === params.store && cached.storeVersion === storeVersion) {
     return cached.childSessionCandidatesByParentKey;
   }
   const childSessionCandidatesByParentKey = buildStoreChildSessionCandidateIndex(params.store);
   rememberSingleRowChildSessionCandidateCacheEntry(params.storePath, {
     store: params.store,
+    storeVersion,
     childSessionCandidatesByParentKey,
   });
   return childSessionCandidatesByParentKey;


### PR DESCRIPTION
## Summary

What problem does this PR solve?
- Single-row gateway session loads rebuild the whole store child-session index, turning O(1)-looking event row loads into store-wide scans.

Why does this matter now?
- Redacted profiler evidence showed this path on gateway hot workloads.

What is the intended outcome?
- Reduce repeated hot-path work while preserving current behavior contracts.

What is intentionally out of scope?
- Broader profiler reruns and unrelated perf stacks are out of scope for this PR.

What does success look like?
- Focused regression tests pass and the changed path avoids the repeated work described in the linked issue.

What should reviewers focus on?
- Whether the cache/lazy path preserves existing contracts and invalidation boundaries.

## Linked context

Which issue does this close?

Closes #86788

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

Local performance bug extraction from redacted profiler evidence.

## Real behavior proof (required for external PRs)

Behavior addressed: Single-row gateway session loads rebuild the whole store child-session index, turning O(1)-looking event row loads into store-wide scans.

Real environment tested: Local OpenClaw source worktree on Linux with Node v24.15.0; focused Vitest regression tests and diff hygiene were run in the isolated bug branch worktree.

Exact steps or command run after this patch:
```bash
node node_modules/vitest/vitest.mjs run src/gateway/session-utils.single-row-cache.test.ts --reporter=verbose
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
```

Evidence after fix:
```text
node node_modules/vitest/vitest.mjs run src/gateway/session-utils.single-row-cache.test.ts --reporter=verbose

Result: 3 project files passed, 3 tests passed.

git diff --check

Result: passed.

.agents/skills/autoreview/scripts/autoreview --mode local

Result: clean, no accepted/actionable findings reported.
```

Observed result after fix: Focused regression coverage passed and autoreview reported no accepted/actionable findings.

What was not tested: No live long-running profiler rerun was performed after the patch.

Proof limitations or environment constraints: The original evidence is from redacted local profiler artifacts; this PR includes focused seam proof rather than a full live profiler replay.

Before evidence (optional but encouraged):
```text
Profile excerpt showed resolveChildSessionKeys at 3.57% and 3.30% inclusive cost, with buildStoreChildSessionIndex at 903.39s inclusive under single-row session loading.
```

## Tests and validation

Which commands did you run?

```bash
node node_modules/vitest/vitest.mjs run src/gateway/session-utils.single-row-cache.test.ts --reporter=verbose
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
```

What regression coverage was added or updated?

src/gateway/session-utils.ts; src/gateway/session-utils.single-row-cache.test.ts

What failed before this fix, if known?

The profiler/timeline evidence showed the hot-path behavior described in the linked issue.

If no test was added, why not?

Focused regression coverage was added or updated.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

No

Did config, environment, or migration behavior change? (`Yes/No`)

No

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No

What is the highest-risk area?

Preserving existing hot-path behavior while reducing repeated work.

How is that risk mitigated?

Focused regression tests plus autoreview.

## Current review state

What is the next action?

Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

Full live profiler replay was not run locally.

Which bot or reviewer comments were addressed?

Local autoreview findings were addressed before opening this PR where applicable.
