### PR TITLE
fix(sessions): defer maintenance preserve scans

### DIFF
--- a/src/config/sessions/store.pruning.integration.test.ts
+++ b/src/config/sessions/store.pruning.integration.test.ts
@@ -914,6 +914,62 @@ describe("Integration: saveSessionStore with pruning", () => {
     expect(loaded).toHaveProperty("session-50");
   });
 
+  it("saveSessionStore skips preserve providers below the entry maintenance high-water mark", async () => {
+    const now = Date.now();
+    const preserveProvider = vi.fn(() => ["protected-session"]);
+    const unregister = registerSessionMaintenancePreserveKeysProvider(preserveProvider);
+    mockLoadConfig.mockReturnValue({
+      session: {
+        maintenance: {
+          mode: "enforce",
+          pruneAfter: "365d",
+          maxEntries: 500,
+        },
+      },
+    });
+
+    try {
+      await saveSessionStore(storePath, {
+        "session-1": makeEntry(now),
+        "session-2": makeEntry(now - 1),
+      });
+
+      expect(preserveProvider).not.toHaveBeenCalled();
+      const loaded = loadSessionStore(storePath, { skipCache: true });
+      expect(Object.keys(loaded)).toHaveLength(2);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("saveSessionStore calls preserve providers when entry maintenance runs", async () => {
+    const now = Date.now();
+    const preserveProvider = vi.fn(() => ["session-0"]);
+    const unregister = registerSessionMaintenancePreserveKeysProvider(preserveProvider);
+    mockLoadConfig.mockReturnValue({
+      session: {
+        maintenance: {
+          mode: "enforce",
+          pruneAfter: "365d",
+          maxEntries: 1,
+        },
+      },
+    });
+
+    try {
+      await saveSessionStore(storePath, {
+        "session-0": makeEntry(now),
+        "session-1": makeEntry(now - 1),
+      });
+
+      expect(preserveProvider).toHaveBeenCalledTimes(1);
+      const loaded = loadSessionStore(storePath, { skipCache: true });
+      expect(loaded).toHaveProperty("session-0");
+    } finally {
+      unregister();
+    }
+  });
+
   it("loadSessionStore honors configured maxEntries without an explicit override", async () => {
     mockLoadConfig.mockReturnValue({
       session: {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -289,6 +289,16 @@ function preserveExistingAcpMetadata(params: {
   }
 }
 
+function hasStaleSessionEntry(
+  store: Record<string, SessionEntry>,
+  maxAgeMs: number,
+): boolean {
+  const cutoffMs = Date.now() - maxAgeMs;
+  return Object.values(store).some(
+    (entry) => entry?.updatedAt != null && entry.updatedAt < cutoffMs,
+  );
+}
+
 async function saveSessionStoreUnlocked(
   storePath: string,
   store: Record<string, SessionEntry>,
@@ -347,15 +357,25 @@ async function saveSessionStoreUnlocked(
         diskBudget,
       });
     } else {
-      const preserveSessionKeys = collectSessionMaintenancePreserveKeys([opts?.activeSessionKey]);
+      let preserveSessionKeys: Set<string> | undefined;
+      const getPreserveSessionKeys = () => {
+        preserveSessionKeys ??= collectSessionMaintenancePreserveKeys([opts?.activeSessionKey]);
+        return preserveSessionKeys;
+      };
       // Prune stale entries and cap total count before serializing.
       const removedSessionFiles = new Map<string, string | undefined>();
-      const pruned = pruneStaleEntries(store, maintenance.pruneAfterMs, {
-        onPruned: ({ entry }) => {
-          rememberRemovedSessionFile(removedSessionFiles, entry);
-        },
-        preserveKeys: preserveSessionKeys,
-      });
+      const shouldRunPruneMaintenance =
+        forceMaintenance ||
+        shouldRunEntryMaintenance ||
+        hasStaleSessionEntry(store, maintenance.pruneAfterMs);
+      const pruned = shouldRunPruneMaintenance
+        ? pruneStaleEntries(store, maintenance.pruneAfterMs, {
+            onPruned: ({ entry }) => {
+              rememberRemovedSessionFile(removedSessionFiles, entry);
+            },
+            preserveKeys: getPreserveSessionKeys(),
+          })
+        : 0;
       const countAfterPrune = Object.keys(store).length;
       const shouldRunCapMaintenance =
         forceMaintenance ||
@@ -368,7 +388,7 @@ async function saveSessionStoreUnlocked(
             onCapped: ({ entry }) => {
               rememberRemovedSessionFile(removedSessionFiles, entry);
             },
-            preserveKeys: preserveSessionKeys,
+            preserveKeys: getPreserveSessionKeys(),
           })
         : 0;
       const archivedDirs = new Set<string>();
@@ -418,7 +438,7 @@ async function saveSessionStoreUnlocked(
         store,
         storePath,
         activeSessionKey: opts?.activeSessionKey,
-        preserveKeys: preserveSessionKeys,
+        preserveKeys: maintenance.maxDiskBytes != null ? getPreserveSessionKeys() : undefined,
         maintenance,
         warnOnly: false,
         log,


### PR DESCRIPTION
## Summary

What problem does this PR solve?
- Session store saves call maintenance preserve providers even when entry maintenance does not need provider state, triggering expensive subagent registry reads on ordinary writes.

Why does this matter now?
- Redacted profiler evidence showed this path on gateway hot workloads.

What is the intended outcome?
- Reduce repeated hot-path work while preserving current behavior contracts.

What is intentionally out of scope?
- Broader profiler reruns and unrelated perf stacks are out of scope for this PR.

What does success look like?
- Focused regression tests pass and the changed path avoids the repeated work described in the linked issue.

What should reviewers focus on?
- Whether the cache/lazy path preserves existing contracts and invalidation boundaries.

## Linked context

Which issue does this close?

Closes #86789

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

Local performance bug extraction from redacted profiler evidence.

## Real behavior proof (required for external PRs)

Behavior addressed: Session store saves call maintenance preserve providers even when entry maintenance does not need provider state, triggering expensive subagent registry reads on ordinary writes.

Real environment tested: Local OpenClaw source worktree on Linux with Node v24.15.0; focused Vitest regression tests and diff hygiene were run in the isolated bug branch worktree.

Exact steps or command run after this patch:
```bash
node node_modules/vitest/vitest.mjs run src/config/sessions/store.pruning.integration.test.ts -t "saveSessionStore prunes stale entries on write|saveSessionStore skips preserve providers|saveSessionStore calls preserve providers" --reporter=verbose
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
```

Evidence after fix:
```text
node node_modules/vitest/vitest.mjs run src/config/sessions/store.pruning.integration.test.ts -t "saveSessionStore prunes stale entries on write|saveSessionStore skips preserve providers|saveSessionStore calls preserve providers" --reporter=verbose

Result: 1 file passed, 3 tests passed, 29 skipped.

git diff --check

Result: passed.

.agents/skills/autoreview/scripts/autoreview --mode local

Result: clean, no accepted/actionable findings reported.
```

Observed result after fix: Focused regression coverage passed and autoreview reported no accepted/actionable findings.

What was not tested: No live long-running profiler rerun was performed after the patch. Snapshot-cache freezing/cloning remains out of scope for this PR.

Proof limitations or environment constraints: The original evidence is from redacted local profiler artifacts; this PR includes focused seam proof rather than a full live profiler replay.

Before evidence (optional but encouraged):
```text
Profile excerpt showed saveSessionStoreUnlocked at 1571.64s inclusive and collectSessionMaintenancePreserveKeys at 1423.20s inclusive, flowing into subagent registry snapshot cloning.
```

## Tests and validation

Which commands did you run?

```bash
node node_modules/vitest/vitest.mjs run src/config/sessions/store.pruning.integration.test.ts -t "saveSessionStore prunes stale entries on write|saveSessionStore skips preserve providers|saveSessionStore calls preserve providers" --reporter=verbose
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
```

What regression coverage was added or updated?

src/config/sessions/store.ts; src/config/sessions/store.pruning.integration.test.ts

What failed before this fix, if known?

The profiler/timeline evidence showed the hot-path behavior described in the linked issue.

If no test was added, why not?

Focused regression coverage was added or updated.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

No

Did config, environment, or migration behavior change? (`Yes/No`)

No

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No

What is the highest-risk area?

Preserving existing hot-path behavior while reducing repeated work.

How is that risk mitigated?

Focused regression tests plus autoreview.

## Current review state

What is the next action?

Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

Full live profiler replay was not run locally.

Which bot or reviewer comments were addressed?

Local autoreview findings were addressed before opening this PR where applicable.
