### PR TITLE
fix(plugins): cache installed manifest fingerprints

### DIFF
--- a/src/plugins/manifest-registry-installed.fingerprint.test.ts
+++ b/src/plugins/manifest-registry-installed.fingerprint.test.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { InstalledPluginIndex } from "./installed-plugin-index.js";
+import { resolveInstalledManifestRegistryIndexFingerprint } from "./manifest-registry-installed.js";
+
+describe("installed manifest registry fingerprint cache", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const tempDir of tempDirs.splice(0)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("reuses the fingerprint for the same installed index object without re-statting files", () => {
+    const pluginDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-installed-fingerprint-"));
+    tempDirs.push(pluginDir);
+    const manifestPath = path.join(pluginDir, "plugin.json");
+    const packageJsonPath = path.join(pluginDir, "package.json");
+    fs.writeFileSync(manifestPath, JSON.stringify({ id: "test-plugin" }), "utf-8");
+    fs.writeFileSync(packageJsonPath, JSON.stringify({ name: "test-plugin" }), "utf-8");
+    const index = {
+      version: 1,
+      hostContractVersion: "test-host",
+      compatRegistryVersion: "test-compat",
+      migrationVersion: 1,
+      policyHash: "test-policy",
+      generatedAtMs: 1,
+      installRecords: {},
+      diagnostics: [],
+      plugins: [
+        {
+          pluginId: "test-plugin",
+          manifestPath,
+          manifestHash: "test-manifest-hash",
+          packageJson: {
+            path: "package.json",
+            hash: "test-package-hash",
+          },
+          rootDir: pluginDir,
+          origin: "external",
+          enabled: true,
+          startup: {
+            sidecar: false,
+            memory: false,
+            deferConfiguredChannelFullLoadUntilAfterListen: false,
+            agentHarnesses: [],
+          },
+          compat: [],
+        },
+      ],
+    } as InstalledPluginIndex;
+    const statSpy = vi.spyOn(fs, "statSync");
+
+    const first = resolveInstalledManifestRegistryIndexFingerprint(index);
+    const statCallsAfterFirst = statSpy.mock.calls.length;
+    const second = resolveInstalledManifestRegistryIndexFingerprint(index);
+
+    expect(second).toBe(first);
+    expect(statCallsAfterFirst).toBeGreaterThan(0);
+    expect(statSpy.mock.calls.length).toBe(statCallsAfterFirst);
+  });
+});

--- a/src/plugins/manifest-registry-installed.ts
+++ b/src/plugins/manifest-registry-installed.ts
@@ -113,10 +113,18 @@ function buildInstalledManifestRegistryIndexKey(index: InstalledPluginIndex) {
   };
 }
 
+const installedManifestRegistryIndexFingerprintCache = new WeakMap<InstalledPluginIndex, string>();
+
 export function resolveInstalledManifestRegistryIndexFingerprint(
   index: InstalledPluginIndex,
 ): string {
-  return hashJson(buildInstalledManifestRegistryIndexKey(index));
+  const cached = installedManifestRegistryIndexFingerprintCache.get(index);
+  if (cached) {
+    return cached;
+  }
+  const fingerprint = hashJson(buildInstalledManifestRegistryIndexKey(index));
+  installedManifestRegistryIndexFingerprintCache.set(index, fingerprint);
+  return fingerprint;
 }
 
 function resolveInstalledPluginRootDir(record: InstalledPluginIndexRecord): string {


### PR DESCRIPTION
## Summary

What problem does this PR solve?
- Gateway plugin metadata hot paths repeatedly resolve and stat stable installed manifest/package metadata when fingerprinting the same installed plugin index object.

Why does this matter now?
- Redacted profiler evidence showed this path on gateway hot workloads.

What is the intended outcome?
- Reduce repeated hot-path work while preserving current behavior contracts.

What is intentionally out of scope?
- Broader profiler reruns and unrelated perf stacks are out of scope for this PR.

What does success look like?
- Focused regression tests pass and the changed path avoids the repeated work described in the linked issue.

What should reviewers focus on?
- Whether the cache/lazy path preserves existing contracts and invalidation boundaries.

## Linked context

Which issue does this close?

Closes #86791

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

Local performance bug extraction from redacted profiler evidence.

## Real behavior proof (required for external PRs)

Behavior addressed: Gateway plugin metadata hot paths repeatedly resolve and stat stable installed manifest/package metadata when fingerprinting the same installed plugin index object.

Real environment tested: Local OpenClaw source worktree on Linux with Node v24.15.0; focused Vitest regression tests and diff hygiene were run in the isolated bug branch worktree.

Exact steps or command run after this patch:
```bash
node node_modules/vitest/vitest.mjs run src/plugins/manifest-registry-installed.fingerprint.test.ts --reporter=verbose
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
```

Evidence after fix:
```text
node node_modules/vitest/vitest.mjs run src/plugins/manifest-registry-installed.fingerprint.test.ts --reporter=verbose

Result: 1 file passed, 1 test passed.

git diff --check

Result: passed.

.agents/skills/autoreview/scripts/autoreview --mode local

Result: clean, no accepted/actionable findings reported.
```

Observed result after fix: Focused regression coverage passed and autoreview reported no accepted/actionable findings.

What was not tested: No live long-running profiler rerun was performed after the patch. Other filesystem chains from session, transcript, Telegram spool, and subagent paths remain out of scope for this narrow PR.

Proof limitations or environment constraints: The original evidence is from redacted local profiler artifacts; this PR includes focused seam proof rather than a full live profiler replay.

Before evidence (optional but encouraged):
```text
Profile snippets showed lstat and realpathSync under resolvePackageJsonPath -> buildInstalledManifestRegistryIndexKey -> resolveInstalledManifestRegistryIndexFingerprint -> resolvePluginControlPlaneContext -> getCurrentPluginMetadataSnapshot.
```

## Tests and validation

Which commands did you run?

```bash
node node_modules/vitest/vitest.mjs run src/plugins/manifest-registry-installed.fingerprint.test.ts --reporter=verbose
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
```

What regression coverage was added or updated?

src/plugins/manifest-registry-installed.ts; src/plugins/manifest-registry-installed.fingerprint.test.ts

What failed before this fix, if known?

The profiler/timeline evidence showed the hot-path behavior described in the linked issue.

If no test was added, why not?

Focused regression coverage was added or updated.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

No

Did config, environment, or migration behavior change? (`Yes/No`)

No

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No

What is the highest-risk area?

Preserving existing hot-path behavior while reducing repeated work.

How is that risk mitigated?

Focused regression tests plus autoreview.

## Current review state

What is the next action?

Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

Full live profiler replay was not run locally.

Which bot or reviewer comments were addressed?

Local autoreview findings were addressed before opening this PR where applicable.
